### PR TITLE
[codex] Fix Windows shim test

### DIFF
--- a/tests/codex-shim.test.ts
+++ b/tests/codex-shim.test.ts
@@ -60,6 +60,8 @@ describe("Codex autostart shim", () => {
   });
 
   test("Unix shim skips ocx startup for Codex internal commands", () => {
+    if (process.platform === "win32") return;
+
     const dir = mkdtempSync(join(tmpdir(), "ocx-shim-test-"));
     const logPath = join(dir, "calls.log");
     const bunPath = join(dir, "bun");


### PR DESCRIPTION
Follow-up for PR #8. The Unix shim execution test is meaningful on POSIX only and fails on Windows because the generated shell script is not directly executable there. Windows behavior remains covered by the Windows shim assertions.\n\nValidation:\n- bun test tests/codex-shim.test.ts\n- bun test tests\n- bun run typecheck