### PR TITLE
[codex] fix passthrough stream idle disconnects

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -199,9 +199,14 @@ async function handleResponses(
         : `Provider unreachable: ${err instanceof Error ? err.message : String(err)}`;
       return formatErrorResponse(502, "upstream_error", msg);
     }
-    return new Response(relayWithAbort(upstreamResponse.body, upstream), {
+    const headers = sanitizePassthroughHeaders(upstreamResponse.headers);
+    const isEventStream = headers.get("content-type")?.toLowerCase().includes("text/event-stream") ?? false;
+    const body = isEventStream
+      ? relaySseWithHeartbeat(upstreamResponse.body, upstream)
+      : relayWithAbort(upstreamResponse.body, upstream);
+    return new Response(body, {
       status: upstreamResponse.status,
-      headers: sanitizePassthroughHeaders(upstreamResponse.headers),
+      headers,
     });
   }
 
@@ -337,6 +342,56 @@ export function relayWithAbort(
     },
     cancel(reason) {
       // Client disconnected: abort the upstream fetch and release the reader so we do not leak it.
+      upstream.abort(reason);
+      reader.cancel(reason).catch(() => {});
+    },
+  });
+}
+
+export function relaySseWithHeartbeat(
+  body: ReadableStream<Uint8Array> | null,
+  upstream: AbortController,
+  heartbeatMs = 15_000,
+): ReadableStream<Uint8Array> | null {
+  if (!body) return null;
+  const reader = body.getReader();
+  const heartbeat = new TextEncoder().encode(": opencodex keepalive\n\n");
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let closed = false;
+
+  const cleanup = () => {
+    closed = true;
+    if (timer) clearInterval(timer);
+    timer = undefined;
+  };
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      timer = setInterval(() => {
+        if (closed) return;
+        try {
+          controller.enqueue(heartbeat);
+        } catch {
+          cleanup();
+        }
+      }, heartbeatMs);
+    },
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          cleanup();
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (err) {
+        cleanup();
+        try { controller.error(err); } catch { /* already torn down */ }
+      }
+    },
+    cancel(reason) {
+      cleanup();
       upstream.abort(reason);
       reader.cancel(reason).catch(() => {});
     },

--- a/src/service.ts
+++ b/src/service.ts
@@ -85,6 +85,12 @@ function systemdEnvironmentAssignment(name: string, value: string | undefined): 
   return `Environment=${systemdQuote(`${name}=${value}`)}`;
 }
 
+function systemdOutputTarget(value: string): string {
+  // StandardOutput/StandardError use output specifiers such as append:/path.
+  // Quoting the full specifier makes systemd reject it as an invalid output target.
+  return value.replace(/%/g, "%%").replace(/\n/g, "\\n");
+}
+
 function sh(cmd: string): string {
   return execSync(cmd, { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }).trim();
 }
@@ -183,8 +189,8 @@ ExecStart=${systemdQuote(bun)} ${systemdQuote(cli)} start
 Restart=on-failure
 RestartSec=5
 ${envLines}
-StandardOutput=${systemdQuote(`append:${log}`)}
-StandardError=${systemdQuote(`append:${log}`)}
+StandardOutput=${systemdOutputTarget(`append:${log}`)}
+StandardError=${systemdOutputTarget(`append:${log}`)}
 
 [Install]
 WantedBy=default.target

--- a/tests/passthrough-abort.test.ts
+++ b/tests/passthrough-abort.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { linkAbortSignal, relayWithAbort } from "../src/server";
+import { linkAbortSignal, relaySseWithHeartbeat, relayWithAbort } from "../src/server";
 
 function streamFromChunks(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
   let i = 0;
@@ -44,6 +44,24 @@ describe("passthrough relayWithAbort (RC2, passthrough path)", () => {
     const ac = new AbortController();
     expect(relayWithAbort(null, ac)).toBeNull();
     expect(ac.signal.aborted).toBe(false);
+  });
+
+  test("SSE passthrough emits heartbeat comments while upstream is silent", async () => {
+    const ac = new AbortController();
+    const body = new ReadableStream<Uint8Array>({ pull() { return new Promise<void>(() => {}); } });
+    const relayed = relaySseWithHeartbeat(body, ac, 5)!;
+    const reader = relayed.getReader();
+    const first = await Promise.race([
+      reader.read(),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("heartbeat timeout")), 200)),
+    ]);
+
+    expect(first.done).toBe(false);
+    expect(new TextDecoder().decode(first.value)).toBe(": opencodex keepalive\n\n");
+
+    await reader.cancel("client gone");
+    expect(ac.signal.aborted).toBe(true);
+    expect(ac.signal.reason).toBe("client gone");
   });
 
   test("turn-level abort signal aborts the upstream fetch before headers arrive", () => {

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { buildUnit } from "../src/service";
+
+describe("systemd service unit", () => {
+  test("uses unquoted append targets for service logs", () => {
+    const unit = buildUnit();
+
+    expect(unit).toContain("StandardOutput=append:");
+    expect(unit).toContain("StandardError=append:");
+    expect(unit).not.toContain('StandardOutput="append:');
+    expect(unit).not.toContain('StandardError="append:');
+  });
+});


### PR DESCRIPTION
## Summary
- add heartbeat comments to OpenAI Responses SSE passthrough streams so long silent reasoning does not trip the proxy/client idle path
- keep non-SSE passthrough responses byte-for-byte unchanged
- fix systemd service log targets by leaving append: output specifiers unquoted

## Root cause
Native GPT requests route through the OpenAI Responses passthrough path. That path relayed upstream SSE bytes verbatim, but it did not emit any keepalive bytes while the upstream was silent. Long reasoning turns could therefore leave the downstream connection idle long enough for the Bun/server-client path to close before a `response.completed` event arrived, which surfaced as `stream disconnected before completion: stream closed before response.completed`.

A separate service-unit issue quoted `StandardOutput=append:...`, which systemd rejected, hiding useful service logs.

## Validation
- `bun test tests/passthrough-abort.test.ts tests/passthrough-headers.test.ts tests/service.test.ts`
- `bun run typecheck`
- `bun test tests`
- restarted `opencodex-proxy.service` locally and verified `/healthz`
