### PR TITLE
Add configurable context window caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,26 @@ Local models work too. Point opencodex at any OpenAI-compatible server running o
 
 WebSocket transport is off by default. Set `"websockets": true` only if you want Codex to advertise and use the Responses WebSocket path instead of HTTP/SSE.
 
+Some providers report very large context windows from `/models`. To keep Codex from retaining more
+history than you want, cap the Codex-visible context window per provider or per model:
+
+```json
+{
+  "providers": {
+    "openrouter": {
+      "adapter": "openai-chat",
+      "baseUrl": "https://openrouter.ai/api/v1",
+      "apiKey": "${OPENROUTER_API_KEY}",
+      "contextWindow": 262144,
+      "modelContextWindows": {
+        "z-ai/glm-5.2": 262144,
+        "deepseek/deepseek-v4-pro": 262144
+      }
+    }
+  }
+}
+```
+
 See the **[Configuration reference](https://lidge-jun.github.io/opencodex/reference/configuration/)** for every field.
 
 ## Documentation

--- a/src/codex-catalog.ts
+++ b/src/codex-catalog.ts
@@ -341,18 +341,26 @@ type ProviderModelsApiItem = {
   };
 };
 
+function configuredContextWindow(prov: OcxProviderConfig, id: string): number | undefined {
+  const modelContextWindow = prov.modelContextWindows?.[id];
+  if (typeof modelContextWindow === "number" && modelContextWindow > 0) return modelContextWindow;
+  return typeof prov.contextWindow === "number" && prov.contextWindow > 0 ? prov.contextWindow : undefined;
+}
+
 function catalogHintsFromProviderConfig(name: string, prov: OcxProviderConfig, id: string): Partial<CatalogModel> {
   void name;
   const reasoningEfforts = configuredReasoningEfforts(prov, id);
+  const contextWindow = configuredContextWindow(prov, id);
   return {
     ...(reasoningEfforts !== undefined ? { reasoningEfforts } : {}),
+    ...(contextWindow !== undefined ? { contextWindow } : {}),
   };
 }
 
 function applyConfigHintsToCachedModels(name: string, prov: OcxProviderConfig, models: CatalogModel[]): CatalogModel[] {
   return models.map(model => ({
-    ...catalogHintsFromProviderConfig(name, prov, model.id),
     ...model,
+    ...catalogHintsFromProviderConfig(name, prov, model.id),
   }));
 }
 
@@ -414,8 +422,8 @@ async function fetchProviderModels(name: string, prov: OcxProviderConfig, ttlMs:
       id: m.id,
       provider: name,
       owned_by: m.owned_by,
-      ...catalogHintsFromProviderConfig(name, prov, m.id),
       ...catalogHintsFromModelsApiItem(name, m),
+      ...catalogHintsFromProviderConfig(name, prov, m.id),
     }));
     const liveIds = new Set(live.map(m => m.id));
     // Merge explicit config additions (e.g. a model not in the provider's /models, like a new endpoint).

--- a/src/types.ts
+++ b/src/types.ts
@@ -223,6 +223,10 @@ export interface OcxProviderConfig {
   apiKey?: string;
   defaultModel?: string;
   models?: string[];
+  /** Provider-wide Codex-visible context window cap, in tokens. */
+  contextWindow?: number;
+  /** Model-specific Codex-visible context window caps, in tokens. */
+  modelContextWindows?: Record<string, number>;
   headers?: Record<string, string>;
   /**
    * "key" (default): authenticate upstream with `apiKey`.


### PR DESCRIPTION
## Summary

Add optional provider-level and model-level context window caps for the Codex model catalog.

## Why

Some upstream providers report very large context windows from `/models` metadata, such as 1M-token models. Syncing those values directly into Codex can make Codex retain much larger histories than an operator wants, increasing latency, cost, and practical context-management risk.

## Changes

- Add `contextWindow` to cap all models for a provider.
- Add `modelContextWindows` to cap specific provider model ids.
- Apply configured caps after live `/models` metadata and cached metadata so user config wins.
- Document the config fields in the README.

## Validation

- `bun install`
- `bun x tsc --noEmit`
- `git diff --check`
