### PR TITLE
Preserve Codex resume history by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,9 +243,11 @@ Local models work too. Point opencodex at any OpenAI-compatible server running o
 
 WebSocket transport is off by default. Set `"websockets": true` only if you want Codex to advertise and use the Responses WebSocket path instead of HTTP/SSE.
 
-opencodex leaves existing Codex resume history untouched by default so Codex App project chats keep
-showing up under their original provider. If you explicitly want old OpenAI-backed threads to be
-remapped to the opencodex provider while the proxy is active, set `"syncResumeHistory": true`.
+opencodex leaves existing Codex resume history untouched by default. This avoids changing Codex's
+local thread index just because the proxy started, but Codex App may hide old OpenAI-backed project
+threads while `opencodex` is the active provider. If you want those existing chats to appear while
+the proxy is active, enable the compatibility remap with `"syncResumeHistory": true`. Restore still
+maps previously remapped `opencodex` rows back to `openai`.
 
 See the **[Configuration reference](https://lidge-jun.github.io/opencodex/reference/configuration/)** for every field.
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ Local models work too. Point opencodex at any OpenAI-compatible server running o
 
 WebSocket transport is off by default. Set `"websockets": true` only if you want Codex to advertise and use the Responses WebSocket path instead of HTTP/SSE.
 
+opencodex leaves existing Codex resume history untouched by default so Codex App project chats keep
+showing up under their original provider. If you explicitly want old OpenAI-backed threads to be
+remapped to the opencodex provider while the proxy is active, set `"syncResumeHistory": true`.
+
 See the **[Configuration reference](https://lidge-jun.github.io/opencodex/reference/configuration/)** for every field.
 
 ## Documentation

--- a/src/codex-inject.ts
+++ b/src/codex-inject.ts
@@ -236,9 +236,9 @@ export async function injectCodexConfig(port: number, config?: OcxConfig, option
   const catalogMessage = catalogPath
     ? `  Codex model catalog: ${catalogPath}\n`
     : `  Codex model catalog not injected because no opencodex catalog file exists yet.\n`;
-  const historyMessage = history.rows > 0
+  const historyMessage = config?.syncResumeHistory === true
     ? `  Codex resume history: ${history.rows} thread(s) mapped to opencodex.\n`
-    : "";
+    : `  Codex resume history: left unchanged. Existing OpenAI project chats may be hidden while opencodex is active; set syncResumeHistory=true to remap them.\n`;
   return {
     success: true,
     message: `Injected opencodex as default provider into Codex config.\n` +

--- a/src/codex-inject.ts
+++ b/src/codex-inject.ts
@@ -229,7 +229,9 @@ export async function injectCodexConfig(port: number, config?: OcxConfig, option
 
   writeFileSync(CODEX_CONFIG_PATH, content, "utf-8");
   writeFileSync(CODEX_PROFILE_PATH, buildProfileFile(port, catalogPath), "utf-8");
-  const history = syncCodexHistoryProvider("opencodex");
+  const history = config?.syncResumeHistory === true
+    ? syncCodexHistoryProvider("opencodex")
+    : { rows: 0, files: 0 };
 
   const catalogMessage = catalogPath
     ? `  Codex model catalog: ${catalogPath}\n`

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,8 +188,9 @@ export interface OcxConfig {
   /** Auto-start/sync the proxy from the Codex shim before launching Codex. Default true. */
   codexAutoStart?: boolean;
   /**
-   * Rewrite existing Codex resume-history threads from openai to opencodex while the proxy is active.
-   * Disabled by default because Codex desktop may hide project chats whose stored provider is not openai.
+   * Compatibility mode: rewrite existing Codex resume-history threads from openai to opencodex
+   * while the proxy is active so Codex App can show old project chats under the active provider.
+   * Disabled by default because it mutates Codex's local thread index.
    */
   syncResumeHistory?: boolean;
   /** Freshness window (ms) for the per-provider live `/models` cache. Defaults to 5 min. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -187,6 +187,11 @@ export interface OcxConfig {
   websockets?: boolean;
   /** Auto-start/sync the proxy from the Codex shim before launching Codex. Default true. */
   codexAutoStart?: boolean;
+  /**
+   * Rewrite existing Codex resume-history threads from openai to opencodex while the proxy is active.
+   * Disabled by default because Codex desktop may hide project chats whose stored provider is not openai.
+   */
+  syncResumeHistory?: boolean;
   /** Freshness window (ms) for the per-provider live `/models` cache. Defaults to 5 min. */
   modelCacheTtlMs?: number;
   /** Web-search sidecar: route web_search for non-OpenAI models through a gpt-mini via ChatGPT passthrough. */


### PR DESCRIPTION
## Summary

Make Codex resume-history remapping an explicit compatibility mode instead of an automatic side effect.

## Why

Codex App appears to scope project/thread visibility by the active provider. That means existing OpenAI-backed project chats can disappear from the sidebar while `model_provider = "opencodex"`, even though the local thread rows still exist.

Users reasonably expect existing chats to remain visible. The practical workaround is to remap old `openai` resume-history rows to `opencodex` while the proxy is active. That behavior is useful, but it mutates Codex's local thread index and should be an explicit compatibility choice rather than something that happens just because the proxy started.

This is related to #11. This PR does not claim to fix every App-side filtering path; it makes the history remap explicit, documented, and still reversible through restore.

## Changes

- Add `syncResumeHistory` as an explicit compatibility-mode config flag.
- Leave existing Codex resume history untouched by default during injection.
- Print a startup note explaining that existing OpenAI project chats may be hidden unless `syncResumeHistory=true` is enabled.
- Keep restore behavior intact so previously remapped `opencodex` rows can still be mapped back to `openai`.
- Document the tradeoff in the README.

## Validation

- `bun install`
- `bun x tsc --noEmit`
- `git diff --check`
- Manual Windows Codex App check: with `syncResumeHistory=true`, existing `zerodi-wd1` project chats became visible again while opencodex was active, and opencodex models appeared in the model picker.