### PR TITLE
Guard subcommand help before side effects

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,6 +38,69 @@ Examples:
   ocx sync                    Sync available models to Codex`);
 }
 
+function hasHelpFlag(values: string[]): boolean {
+  return values.some(value => value === "--help" || value === "-h" || value === "help");
+}
+
+function printSubcommandUsage(name: string | undefined): void {
+  switch (name) {
+    case "init":
+      console.log("Usage: ocx init\n\nInteractive setup for providers and Codex config injection.");
+      break;
+    case "start":
+      console.log("Usage: ocx start [--port <port>]\n\nStart the proxy server and sync models to Codex.");
+      break;
+    case "stop":
+      console.log("Usage: ocx stop\n\nStop the proxy and restore native Codex config.");
+      break;
+    case "restore":
+    case "eject":
+      console.log(`Usage: ocx ${name}\n\nRestore native Codex config without stopping the proxy.`);
+      break;
+    case "uninstall":
+    case "remove":
+      console.log(`Usage: ocx ${name}\n\nRemove service/shim/config and restore native Codex.`);
+      break;
+    case "service":
+      console.log("Usage: ocx service <install|start|stop|status|uninstall>");
+      break;
+    case "codex-shim":
+      console.log("Usage: ocx codex-shim <install|status|uninstall>");
+      break;
+    case "ensure":
+      console.log("Usage: ocx ensure\n\nEnsure the proxy is running and Codex config/cache are current.");
+      break;
+    case "sync":
+      console.log("Usage: ocx sync\n\nFetch provider models and inject them into Codex config.");
+      break;
+    case "sync-cache":
+      console.log("Usage: ocx sync-cache\n\nRefresh Codex's model cache from the active catalog.");
+      break;
+    case "status":
+      console.log("Usage: ocx status\n\nCheck proxy server status.");
+      break;
+    case "login":
+      console.log("Usage: ocx login <provider>\n\nOAuth or API-key login for a provider.");
+      break;
+    case "logout":
+      console.log("Usage: ocx logout <provider>\n\nRemove a stored provider login.");
+      break;
+    case "gui":
+      console.log("Usage: ocx gui\n\nOpen the opencodex dashboard.");
+      break;
+    case "update":
+      console.log("Usage: ocx update\n\nUpdate opencodex to the latest published version.");
+      break;
+    default:
+      printUsage();
+  }
+}
+
+if (command !== undefined && command !== "help" && hasHelpFlag(args.slice(1))) {
+  printSubcommandUsage(command);
+  process.exit(0);
+}
+
 async function syncModelsToCodex(port?: number) {
   const config = loadConfig();
   const p = port ?? config.port ?? 10100;

--- a/tests/cli-help.test.ts
+++ b/tests/cli-help.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+const cliPath = join(repoRoot, "src", "cli.ts");
+
+describe("CLI subcommand help", () => {
+  test("restore --help prints usage without mutating Codex config", () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "ocx-help-"));
+    try {
+      const configPath = join(codexHome, "config.toml");
+      const before = [
+        'model_provider = "opencodex"',
+        "",
+        "[model_providers.opencodex]",
+        'base_url = "http://localhost:10100/v1"',
+        'wire_api = "responses"',
+        "",
+      ].join("\n");
+      writeFileSync(configPath, before, "utf8");
+
+      const result = spawnSync(process.execPath, [cliPath, "restore", "--help"], {
+        cwd: repoRoot,
+        env: { ...process.env, CODEX_HOME: codexHome },
+        encoding: "utf8",
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("Usage: ocx restore");
+      expect(result.stdout).not.toContain("Plain `codex` now runs natively");
+      expect(readFileSync(configPath, "utf8")).toBe(before);
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Prevent subcommand help flags from executing side-effecting commands.

## Why
`ocx restore --help` currently enters the `restore` switch case and mutates Codex config instead of showing help. That behavior was noted while triaging #11, and the same command shape can affect other side-effecting subcommands.

## Changes
- Add a shared subcommand help guard for `--help`, `-h`, and `help`.
- Print subcommand-specific usage before the main command switch can run side effects.
- Add a regression test proving `restore --help` leaves `CODEX_HOME/config.toml` unchanged.

## Validation
- `bun install`
- `bun test tests/cli-help.test.ts`
- `bun x tsc --noEmit`
- `git diff --check`