### PR TITLE
[codex] Allow static provider model catalogs

### DIFF
--- a/docs-site/src/content/docs/ko/reference/configuration.md
+++ b/docs-site/src/content/docs/ko/reference/configuration.md
@@ -29,11 +29,31 @@ opencodex는 `~/.opencodex/config.json`으로 설정됩니다. 이 파일은 `oc
 | `baseUrl` | `string` | 업스트림 API 기본 URL. |
 | `apiKey?` | `string` | API 키, 또는 요청 시점에 해석되는 `${ENV_VAR}` / `$ENV_VAR` 참조. |
 | `defaultModel?` | `string` | 명시적인 모델 없이 이 프로바이더가 선택되었을 때 사용하는 모델. |
-| `models?` | `string[]` | 시드/폴백 모델 목록 (실시간 `/models`에 접근 가능하면 그쪽이 우선됨). |
+| `models?` | `string[]` | 시드/폴백 모델 목록. `liveModels`가 `false`이면 Codex 카탈로그에 노출할 정확한 allowlist가 됩니다. |
+| `liveModels?` | `boolean` | 시작/동기화 시 프로바이더의 실시간 `/models` 카탈로그를 가져옵니다(기본 `true`). `false`로 두면 설정된 `models`만 사용합니다. |
 | `headers?` | `Record<string,string>` | 업스트림으로 전송되는 추가 HTTP 헤더. |
 | `authMode?` | `"key" \| "forward" \| "oauth"` | 인증 방식 (기본 `key`). [프로바이더](/opencodex/ko/guides/providers/#auth-modes) 참조. |
 | `noReasoningModels?` | `string[]` | reasoning/thinking 파라미터를 거부하는 모델 — 어댑터가 이들에 대해 `reasoning_effort`를 제거함. |
 | `noVisionModels?` | `string[]` | 텍스트 전용 모델 — [비전 사이드카](/opencodex/ko/guides/sidecars/)가 이들을 위해 이미지를 설명함. 매칭 시 Ollama의 `:size` 태그를 허용함. |
+
+## 정적 모델 allowlist
+
+일부 프로바이더는 실시간 모델 카탈로그가 매우 크거나 느릴 수 있습니다. Codex에 `models`에
+고정한 모델만 노출하려면 `liveModels`를 `false`로 설정하세요.
+
+```json
+{
+  "providers": {
+    "openrouter": {
+      "adapter": "openai-chat",
+      "baseUrl": "https://openrouter.ai/api/v1",
+      "apiKey": "${OPENROUTER_API_KEY}",
+      "liveModels": false,
+      "models": ["deepseek/deepseek-v4-flash", "qwen/qwen3-coder-plus"]
+    }
+  }
+}
+```
 
 ## 사이드카
 

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -29,11 +29,31 @@ default (a single `openai` forward provider).
 | `baseUrl` | `string` | Upstream API base URL. |
 | `apiKey?` | `string` | API key, or an `${ENV_VAR}` / `$ENV_VAR` reference resolved at request time. |
 | `defaultModel?` | `string` | Model used when this provider is selected without an explicit model. |
-| `models?` | `string[]` | Seed/fallback model list (live `/models` is preferred when reachable). |
+| `models?` | `string[]` | Seed/fallback model list. Also becomes the exact catalog allowlist when `liveModels` is `false`. |
+| `liveModels?` | `boolean` | Fetch the provider's live `/models` catalog on start/sync (default `true`). Set `false` to use only configured `models`. |
 | `headers?` | `Record<string,string>` | Extra HTTP headers sent upstream. |
 | `authMode?` | `"key" \| "forward" \| "oauth"` | How to authenticate (default `key`). See [Providers](/opencodex/guides/providers/#auth-modes). |
 | `noReasoningModels?` | `string[]` | Models that reject a reasoning/thinking param — the adapter drops `reasoning_effort` for them. |
 | `noVisionModels?` | `string[]` | Text-only models — the [vision sidecar](/opencodex/guides/sidecars/) describes images for them. Matching tolerates an Ollama `:size` tag. |
+
+## Static model allowlists
+
+Some providers expose very large or slow live model catalogs. Set `liveModels` to `false` when you
+want Codex to see only the models pinned in `models`:
+
+```json
+{
+  "providers": {
+    "openrouter": {
+      "adapter": "openai-chat",
+      "baseUrl": "https://openrouter.ai/api/v1",
+      "apiKey": "${OPENROUTER_API_KEY}",
+      "liveModels": false,
+      "models": ["deepseek/deepseek-v4-flash", "qwen/qwen3-coder-plus"]
+    }
+  }
+}
+```
 
 ## Sidecars
 

--- a/docs-site/src/content/docs/zh-cn/reference/configuration.md
+++ b/docs-site/src/content/docs/zh-cn/reference/configuration.md
@@ -27,11 +27,31 @@ opencodex 通过 `~/.opencodex/config.json` 进行配置。它由 `ocx init` 和
 | `baseUrl` | `string` | 上游 API 的基础 URL。 |
 | `apiKey?` | `string` | API key,或在请求时解析的 `${ENV_VAR}` / `$ENV_VAR` 引用。 |
 | `defaultModel?` | `string` | 当选中该 provider 但未指定明确模型时使用的模型。 |
-| `models?` | `string[]` | 种子/回退模型列表(当实时 `/models` 可达时优先使用它)。 |
+| `models?` | `string[]` | 种子/回退模型列表。当 `liveModels` 为 `false` 时,它也是 Codex 目录中精确暴露的 allowlist。 |
+| `liveModels?` | `boolean` | 启动/同步时获取 provider 的实时 `/models` 目录(默认 `true`)。设为 `false` 时只使用配置的 `models`。 |
 | `headers?` | `Record<string,string>` | 发送到上游的额外 HTTP 头。 |
 | `authMode?` | `"key" \| "forward" \| "oauth"` | 认证方式(默认 `key`)。见 [Providers](/opencodex/zh-cn/guides/providers/#auth-modes)。 |
 | `noReasoningModels?` | `string[]` | 会拒绝 reasoning/thinking 参数的模型 —— adapter 会为它们丢弃 `reasoning_effort`。 |
 | `noVisionModels?` | `string[]` | 纯文本模型 —— [视觉 sidecar](/opencodex/zh-cn/guides/sidecars/) 会为它们描述图像。匹配时可容忍 Ollama 的 `:size` 标签。 |
+
+## 静态模型 allowlist
+
+有些 provider 的实时模型目录非常大或响应较慢。如果只希望 Codex 看到 `models` 中固定的模型,
+可以将 `liveModels` 设为 `false`。
+
+```json
+{
+  "providers": {
+    "openrouter": {
+      "adapter": "openai-chat",
+      "baseUrl": "https://openrouter.ai/api/v1",
+      "apiKey": "${OPENROUTER_API_KEY}",
+      "liveModels": false,
+      "models": ["deepseek/deepseek-v4-flash", "qwen/qwen3-coder-plus"]
+    }
+  }
+}
+```
 
 ## Sidecars
 

--- a/src/codex-catalog.ts
+++ b/src/codex-catalog.ts
@@ -395,13 +395,17 @@ async function fetchProviderModels(name: string, prov: OcxProviderConfig, ttlMs:
   if (prov.authMode === "forward") return []; // ChatGPT backend has no /models
   const apiKey = await resolveModelsAuthToken(name, prov);
   if (prov.authMode === "oauth" && !apiKey) return []; // not logged in → skip
-  const fresh = getFreshCached(name, ttlMs);
-  if (fresh) return applyConfigHintsToCachedModels(name, prov, fresh); // dedups Codex's frequent /v1/models polling within the TTL
   const configured: CatalogModel[] = (prov.models ?? []).map(id => ({
     id,
     provider: name,
     ...catalogHintsFromProviderConfig(name, prov, id),
   }));
+  if (prov.liveModels === false) {
+    setCached(name, configured);
+    return configured;
+  }
+  const fresh = getFreshCached(name, ttlMs);
+  if (fresh) return applyConfigHintsToCachedModels(name, prov, fresh); // dedups Codex's frequent /v1/models polling within the TTL
   const { url, headers } = buildModelsRequest(prov, apiKey);
   try {
     const res = await fetch(url, { headers, signal: AbortSignal.timeout(8000) });

--- a/src/codex-catalog.ts
+++ b/src/codex-catalog.ts
@@ -401,7 +401,6 @@ async function fetchProviderModels(name: string, prov: OcxProviderConfig, ttlMs:
     ...catalogHintsFromProviderConfig(name, prov, id),
   }));
   if (prov.liveModels === false) {
-    setCached(name, configured);
     return configured;
   }
   const fresh = getFreshCached(name, ttlMs);

--- a/src/types.ts
+++ b/src/types.ts
@@ -223,6 +223,12 @@ export interface OcxProviderConfig {
   apiKey?: string;
   defaultModel?: string;
   models?: string[];
+  /**
+   * Fetch the provider's live `/models` endpoint. Defaults to true.
+   * Set false when `models` is an intentional allowlist or a provider's live catalog is too large
+   * or too flaky for startup/catalog sync.
+   */
+  liveModels?: boolean;
   headers?: Record<string, string>;
   /**
    * "key" (default): authenticate upstream with `apiKey`.

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -191,6 +191,60 @@ describe("Codex catalog routed normalization", () => {
     }
   });
 
+  test("liveModels false does not poison the live-model cache when toggled back on", async () => {
+    clearModelCache("static-toggle");
+    const originalFetch = globalThis.fetch;
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls += 1;
+      return new Response(JSON.stringify({
+        data: [{ id: "live-after-toggle", owned_by: "provider" }],
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+    try {
+      const staticModels = await gatherRoutedModels({
+        providers: {
+          "static-toggle": {
+            baseUrl: "https://example.invalid/v1",
+            adapter: "openai-chat",
+            authMode: "key",
+            liveModels: false,
+            models: ["configured-only"],
+          },
+        },
+      });
+
+      expect(staticModels.map(m => `${m.provider}/${m.id}`)).toEqual([
+        "static-toggle/configured-only",
+      ]);
+      expect(fetchCalls).toBe(0);
+
+      const liveModels = await gatherRoutedModels({
+        providers: {
+          "static-toggle": {
+            baseUrl: "https://example.invalid/v1",
+            adapter: "openai-chat",
+            authMode: "key",
+            liveModels: true,
+            models: ["configured-only"],
+          },
+        },
+      });
+
+      expect(fetchCalls).toBe(1);
+      expect(new Set(liveModels.map(m => `${m.provider}/${m.id}`))).toEqual(new Set([
+        "static-toggle/live-after-toggle",
+        "static-toggle/configured-only",
+      ]));
+    } finally {
+      globalThis.fetch = originalFetch;
+      clearModelCache("static-toggle");
+    }
+  });
+
   test("routed entries receive exact jawcode context metadata", () => {
     const entries = buildCatalogEntries(nativeTemplate(), [], [
       { provider: "opencode-go", id: "deepseek-v4-pro" },

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { augmentRoutedModelsWithJawcodeMetadata, buildCatalogEntries, isMediaGenerationModelId, normalizeRoutedCatalogEntry } from "../src/codex-catalog";
+import { augmentRoutedModelsWithJawcodeMetadata, buildCatalogEntries, gatherRoutedModels, isMediaGenerationModelId, normalizeRoutedCatalogEntry } from "../src/codex-catalog";
 import { getJawcodeModelMetadata, resolveJawcodeProvider } from "../src/generated/jawcode-model-metadata";
+import { clearModelCache, setCached } from "../src/model-cache";
 
 function nativeTemplate(): Record<string, unknown> {
   return {
@@ -131,6 +132,63 @@ describe("Codex catalog routed normalization", () => {
 
     expect(routed?.web_search_tool_type).toBe("text_and_image");
     expect(routed?.supports_search_tool).toBe(true);
+  });
+
+  test("liveModels false uses configured provider models without fetching", async () => {
+    clearModelCache("static-provider");
+    const originalFetch = globalThis.fetch;
+    let fetchCalls = 0;
+    globalThis.fetch = (() => {
+      fetchCalls += 1;
+      throw new Error("fetch should not be called");
+    }) as typeof fetch;
+    try {
+      const models = await gatherRoutedModels({
+        providers: {
+          "static-provider": {
+            baseUrl: "https://example.invalid/v1",
+            adapter: "openai-chat",
+            authMode: "key",
+            liveModels: false,
+            models: ["alpha", "beta"],
+          },
+        },
+      });
+
+      expect(fetchCalls).toBe(0);
+      expect(models.map(m => `${m.provider}/${m.id}`)).toEqual([
+        "static-provider/alpha",
+        "static-provider/beta",
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      clearModelCache("static-provider");
+    }
+  });
+
+  test("liveModels false ignores a fresh live-model cache", async () => {
+    setCached("static-cache", [
+      { provider: "static-cache", id: "cached-live-model" },
+    ]);
+    try {
+      const models = await gatherRoutedModels({
+        providers: {
+          "static-cache": {
+            baseUrl: "https://example.invalid/v1",
+            adapter: "openai-chat",
+            authMode: "key",
+            liveModels: false,
+            models: ["configured-only"],
+          },
+        },
+      });
+
+      expect(models.map(m => `${m.provider}/${m.id}`)).toEqual([
+        "static-cache/configured-only",
+      ]);
+    } finally {
+      clearModelCache("static-cache");
+    }
   });
 
   test("routed entries receive exact jawcode context metadata", () => {


### PR DESCRIPTION
## Summary

Add a `liveModels` provider option so operators can pin a static model allowlist instead of fetching a provider's live `/models` catalog during startup/catalog sync.

## Why

Some providers expose very large or slow live model catalogs. For providers such as OpenRouter, users may want deterministic Codex model-picker entries and faster startup by advertising only the explicitly configured models.

This does not attempt to fix any Bun runtime crash. It gives users a stable catalog path that avoids live provider catalog fetches when those fetches are unnecessary or unreliable.

## Changes

- Add `OcxProviderConfig.liveModels?: boolean`.
- When `liveModels` is `false`, use configured `models` directly and skip the provider `/models` fetch.
- Ensure a fresh live-model cache does not override an explicit static allowlist.
- Add catalog tests for the no-fetch path and cache precedence.
- Document static model allowlists in the English, Korean, and Chinese configuration references.

## Validation

- `C:\Users\cherr\.bun-canary\bin\bun.exe run typecheck`
- `C:\Users\cherr\.bun-canary\bin\bun.exe test tests`
- `git diff --check`
