### PR TITLE
[codex] Source dashboard badge version from runtime health

### DIFF
--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -24,6 +24,12 @@ const NAV: { id: Page; tkey: TKey; Icon: typeof IconGrid }[] = [
 const THEME_ICON = { light: IconSun, dark: IconMoon, system: IconMonitor } as const;
 const THEME_TKEY: Record<Theme, TKey> = { light: "theme.light", dark: "theme.dark", system: "theme.system" };
 
+function readRuntimeVersion(data: unknown): string | null {
+  if (!data || typeof data !== "object" || !("version" in data)) return null;
+  const version = (data as { version?: unknown }).version;
+  return typeof version === "string" && version.length > 0 ? version : null;
+}
+
 function readStoredTheme(): Theme {
   const t = localStorage.getItem(THEME_KEY);
   return t === "light" || t === "dark" ? t : "system";
@@ -32,6 +38,7 @@ function readStoredTheme(): Theme {
 export default function App() {
   const [page, setPage] = useState<Page>("dashboard");
   const [theme, setTheme] = useState<Theme>(readStoredTheme);
+  const [runtimeVersion, setRuntimeVersion] = useState<string | null>(null);
   const { locale, setLocale } = useI18n();
   const t = useT();
 
@@ -43,8 +50,26 @@ export default function App() {
     else { el.setAttribute("data-theme", theme); localStorage.setItem(THEME_KEY, theme); }
   }, [theme]);
 
+  useEffect(() => {
+    let cancelled = false;
+    const fetchRuntimeVersion = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/healthz`);
+        if (!res.ok) return;
+        const version = readRuntimeVersion(await res.json());
+        if (!cancelled && version) setRuntimeVersion(version);
+      } catch {
+        // Keep the build-time fallback when the proxy is unavailable.
+      }
+    };
+    fetchRuntimeVersion();
+    const interval = setInterval(fetchRuntimeVersion, 30000);
+    return () => { cancelled = true; clearInterval(interval); };
+  }, []);
+
   const cycleTheme = () => setTheme(t => (t === "light" ? "dark" : t === "dark" ? "system" : "light"));
   const ThemeIcon = THEME_ICON[theme];
+  const displayedVersion = runtimeVersion ?? __APP_VERSION__;
 
   const langName = LOCALES.find(l => l.code === locale)?.name ?? "English";
   const cycleLang = () => {
@@ -65,7 +90,7 @@ export default function App() {
         <div className="brand">
           <span className="brand-logo" role="img" aria-label="opencodex logo" />
           <span className="name">opencodex</span>
-          <span className="ver">v{__APP_VERSION__}</span>
+          <span className="ver">v{displayedVersion}</span>
         </div>
         <nav>
           {NAV.map(({ id, tkey, Icon }) => (

--- a/gui/src/vite-env.d.ts
+++ b/gui/src/vite-env.d.ts
@@ -1,4 +1,4 @@
 /// <reference types="vite/client" />
 
-// Injected at build time by vite.config.ts `define` (root package.json version).
+// Injected at build time by vite.config.ts `define` as the UI version fallback.
 declare const __APP_VERSION__: string;

--- a/gui/vite.config.ts
+++ b/gui/vite.config.ts
@@ -2,8 +2,8 @@ import { readFileSync } from 'node:fs'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// Bake the parent package version into the bundle so the brand badge matches the npm release
-// (built together via `build:gui` in prepublishOnly). Single source = the root package.json.
+// Bake the parent package version into the bundle as a fallback for moments when the runtime
+// `/healthz` version is not reachable yet.
 const version = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')).version
 
 // https://vite.dev/config/


### PR DESCRIPTION
## What changed

- Updates the sidebar brand badge to prefer the running proxy version from `/healthz`.
- Keeps the build-time `__APP_VERSION__` value as a fallback while the runtime health endpoint is unavailable.
- Updates the Vite/version declaration comments so they no longer describe the build-time value as the dashboard source of truth.

## Why

The dashboard can show two different versions at once when an older GUI bundle is served with a newer proxy runtime. In the observed case, the sidebar badge showed `v2.1.3` while the main dashboard version card showed `2.1.5` from `/healthz`.

The root cause is that the sidebar badge used a build-time package version, while the main dashboard card used the runtime health response. The runtime proxy version is the better source of truth for what is actually running.

## Validation

- `bun run build:gui`
- Confirmed `/healthz` returned `version: 2.1.5` locally.
- Confirmed the served dashboard bundle no longer contained `2.1.3` and did contain the `/healthz` runtime version lookup.