### PR TITLE
Release v2.1.6

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -112,6 +112,7 @@ codex -m "xai/grok-4"                  "이 PR을 리뷰해 줘"
 |---|---|---|
 | OpenAI (ChatGPT 로그인) | `openai-responses` | forward (키 불필요) |
 | OpenAI (API 키) | `openai-responses` | key |
+| Umans AI Coding Plan | `anthropic` | key |
 | Anthropic Claude | `anthropic` | oauth / key |
 | xAI Grok | `openai-chat` | oauth / key |
 | Kimi (Moonshot) | `openai-chat` | oauth / key |

--- a/README.md
+++ b/README.md
@@ -251,6 +251,16 @@ those chats to appear while the proxy is active, enable the reversible compatibi
 `~/.opencodex/codex-history-backup.json` and `ocx stop` / `ocx restore` restore only those backed-up
 rows.
 
+If you tested an older development build where `syncResumeHistory` already remapped OpenAI history
+before backup support existed, `ocx stop` may report unbacked `opencodex` interactive rows and leave
+them unchanged. That is intentional: after the old mutation, opencodex cannot safely distinguish old
+OpenAI rows from genuinely opencodex-owned interactive rows. If you know those rows came from the old
+remap, recover them explicitly:
+
+```bash
+ocx recover-history --legacy-openai
+```
+
 See the **[Configuration reference](https://lidge-jun.github.io/opencodex/reference/configuration/)** for every field.
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Routed models also appear in the **Codex App** model picker with per-model reaso
 |---|---|---|
 | OpenAI (ChatGPT login) | `openai-responses` | forward (no key) |
 | OpenAI (API key) | `openai-responses` | key |
+| Umans AI Coding Plan | `anthropic` | key |
 | Anthropic Claude | `anthropic` | oauth / key |
 | xAI Grok | `openai-chat` | oauth / key |
 | Kimi (Moonshot) | `openai-chat` | oauth / key |

--- a/README.md
+++ b/README.md
@@ -248,14 +248,12 @@ local thread index just because the proxy started, but Codex App may hide old Op
 threads and opencodex-created `exec` threads while `opencodex` is the active provider. If you want
 those chats to appear while the proxy is active, enable the reversible compatibility remap with
 `"syncResumeHistory": true`. opencodex records the original provider/source metadata in
-`~/.opencodex/codex-history-backup.json` and `ocx stop` / `ocx restore` restore only those backed-up
-rows.
+`~/.opencodex/codex-history-backup.json`. `ocx stop` / `ocx restore` restores backed-up OpenAI rows
+to OpenAI, and ejects any remaining opencodex user threads to OpenAI as well so native Codex does not
+try to resume a thread whose provider no longer exists in `config.toml`.
 
-If you tested an older development build where `syncResumeHistory` already remapped OpenAI history
-before backup support existed, `ocx stop` may report unbacked `opencodex` interactive rows and leave
-them unchanged. That is intentional: after the old mutation, opencodex cannot safely distinguish old
-OpenAI rows from genuinely opencodex-owned interactive rows. If you know those rows came from the old
-remap, recover them explicitly:
+If you tested an older development build where `syncResumeHistory` already remapped history before
+backup support existed, you can also run the explicit recovery command:
 
 ```bash
 ocx recover-history --legacy-openai

--- a/README.md
+++ b/README.md
@@ -243,9 +243,11 @@ Local models work too. Point opencodex at any OpenAI-compatible server running o
 
 WebSocket transport is off by default. Set `"websockets": true` only if you want Codex to advertise and use the Responses WebSocket path instead of HTTP/SSE.
 
-opencodex leaves existing Codex resume history untouched by default so Codex App project chats keep
-showing up under their original provider. If you explicitly want old OpenAI-backed threads to be
-remapped to the opencodex provider while the proxy is active, set `"syncResumeHistory": true`.
+opencodex leaves existing Codex resume history untouched by default. This avoids changing Codex's
+local thread index just because the proxy started, but Codex App may hide old OpenAI-backed project
+threads while `opencodex` is the active provider. If you want those existing chats to appear while
+the proxy is active, enable the compatibility remap with `"syncResumeHistory": true`. Restore still
+maps previously remapped `opencodex` rows back to `openai`.
 
 See the **[Configuration reference](https://lidge-jun.github.io/opencodex/reference/configuration/)** for every field.
 

--- a/README.md
+++ b/README.md
@@ -245,9 +245,11 @@ WebSocket transport is off by default. Set `"websockets": true` only if you want
 
 opencodex leaves existing Codex resume history untouched by default. This avoids changing Codex's
 local thread index just because the proxy started, but Codex App may hide old OpenAI-backed project
-threads while `opencodex` is the active provider. If you want those existing chats to appear while
-the proxy is active, enable the compatibility remap with `"syncResumeHistory": true`. Restore still
-maps previously remapped `opencodex` rows back to `openai`.
+threads and opencodex-created `exec` threads while `opencodex` is the active provider. If you want
+those chats to appear while the proxy is active, enable the reversible compatibility remap with
+`"syncResumeHistory": true`. opencodex records the original provider/source metadata in
+`~/.opencodex/codex-history-backup.json` and `ocx stop` / `ocx restore` restore only those backed-up
+rows.
 
 See the **[Configuration reference](https://lidge-jun.github.io/opencodex/reference/configuration/)** for every field.
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ Local models work too. Point opencodex at any OpenAI-compatible server running o
 
 WebSocket transport is off by default. Set `"websockets": true` only if you want Codex to advertise and use the Responses WebSocket path instead of HTTP/SSE.
 
+opencodex leaves existing Codex resume history untouched by default so Codex App project chats keep
+showing up under their original provider. If you explicitly want old OpenAI-backed threads to be
+remapped to the opencodex provider while the proxy is active, set `"syncResumeHistory": true`.
+
 See the **[Configuration reference](https://lidge-jun.github.io/opencodex/reference/configuration/)** for every field.
 
 ## Documentation

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -106,6 +106,7 @@ codex -m "deepseek/deepseek-r1"        "分析这个性能瓶颈"
 |---|---|---|
 | OpenAI（ChatGPT 登录） | `openai-responses` | 转发（无需 key） |
 | OpenAI（API key） | `openai-responses` | key |
+| Umans AI Coding Plan | `anthropic` | key |
 | Anthropic Claude | `anthropic` | oauth / key |
 | xAI Grok | `openai-chat` | oauth / key |
 | Kimi（Moonshot） | `openai-chat` | oauth / key |

--- a/devlog/220_codex-app-history-visibility/00_plan.md
+++ b/devlog/220_codex-app-history-visibility/00_plan.md
@@ -1,0 +1,115 @@
+# 220 Codex App history visibility
+
+## Goal
+
+Investigate and fix the Codex App project-sidebar history visibility regression around `ocx start` / `ocx stop`, issue #11, and PR #13.
+
+The fix must preserve user data by default, document the exact reproduction, explain the Codex App filtering semantics we can infer from `codex-rs` and local state, and avoid broad irreversible mutation of the user's real `~/.codex/state_5.sqlite`.
+
+## User reproduction
+
+The local `ocx` binary is the development checkout:
+
+- `/Users/jun/.local/bin/ocx`
+- `/Users/jun/Developer/new/700_projects/opencodex/dist/bin/ocx`
+- `/Users/jun/Developer/new/700_projects/opencodex/src/cli.ts`
+
+Observed behavior:
+
+1. `ocx start` makes all Codex App project conversations disappear from the sidebar, including old OpenAI conversations and conversations created while opencodex was active.
+2. `ocx stop` makes old OpenAI-side conversations visible again.
+3. Conversations created while opencodex was active remain invisible after `ocx stop`.
+
+## Current evidence
+
+Local config evidence:
+
+- `/Users/jun/.opencodex/config.json` currently has no `syncResumeHistory` key, so PR #13's default is "do not rewrite resume history".
+- `~/.codex/config.toml` can be in native mode after `ocx stop`, with no root `model_provider = "opencodex"`.
+
+Local Codex state evidence from `~/.codex/state_5.sqlite`:
+
+| Row set | model_provider | source | Count / effect |
+| --- | --- | --- | --- |
+| App/CLI resumable rows | `openai` | `cli`, `vscode` | Visible when native OpenAI provider is active |
+| opencodex-created project rows | `opencodex` | `exec` | Not visible in Codex App project sidebar |
+| opencodex `cli`/`vscode` rows | `opencodex` | `cli`, `vscode` | None found in current local state |
+
+Working hypothesis:
+
+- Codex App visibility is not controlled by provider alone.
+- It likely filters by both `threads.model_provider` and a resumable/source classification.
+- Old OpenAI rows disappear during `ocx start` because the active/root provider becomes `opencodex`.
+- opencodex-created rows stay hidden because they are mostly `source = 'exec'`, not `cli` or `vscode`.
+
+## Current PR #13 behavior
+
+PR #13 is already merged locally on `dev` for testing.
+
+It changes the default from automatic resume-history rewriting to explicit opt-in:
+
+- Default: leave history unchanged.
+- `syncResumeHistory: true`: remap resumable OpenAI rows to opencodex during `ocx start`.
+- `ocx stop`: remap opencodex rows back to OpenAI using the existing restoration path.
+
+Limitation:
+
+- #13 is a safety improvement, not the full #11 fix.
+- It only addresses the provider-label side of the problem.
+- It does not make opencodex-created `source = 'exec'` rows visible in Codex App.
+
+## Plan
+
+### P / A: document and audit
+
+- Create this devlog file as the durable issue record.
+- Correctly notify GitHub issue #11 and PR #13 that investigation is underway with the refined reproduction and current hypothesis.
+- Run a read-only audit worker against the plan and the local code anchors before editing behavior.
+
+### B: investigate and implement
+
+- Inspect local `codex-rs` / Codex App sources or installed artifacts for thread filtering semantics around `model_provider`, `source`, `thread_source`, `cwd`, `archived`, and `has_user_event`.
+- Re-check the local SQLite schema and representative rows without mutating the real DB.
+- Design the smallest opencodex-side compatibility fix that can make old OpenAI rows and opencodex-created rows visible without unsafe broad mutation.
+- Preserve reversibility. If metadata must be changed, record original values before changing them and restore only rows opencodex touched.
+
+### C: verify
+
+- Add unit tests against temporary SQLite fixtures only.
+- Run targeted tests first, then full `bun test tests`.
+- Run `bun run typecheck`.
+- Verify no test or script mutates the real `~/.codex/state_5.sqlite`.
+
+### D: report
+
+- Summarize the root cause in plain Korean.
+- List exact files changed.
+- Include verification commands and results.
+- Note remaining Codex App upstream limitation if any behavior can only be fully fixed in `codex-rs`.
+
+## Likely files
+
+Likely code files:
+
+- `/Users/jun/Developer/new/700_projects/opencodex/src/codex-history-provider.ts`
+- `/Users/jun/Developer/new/700_projects/opencodex/src/codex-inject.ts`
+- `/Users/jun/Developer/new/700_projects/opencodex/src/types.ts`
+
+Likely tests:
+
+- `/Users/jun/Developer/new/700_projects/opencodex/tests/codex-history-provider.test.ts`
+- `/Users/jun/Developer/new/700_projects/opencodex/tests/codex-inject.test.ts`
+
+Likely docs:
+
+- `/Users/jun/Developer/new/700_projects/opencodex/README.md`
+- `/Users/jun/Developer/new/700_projects/opencodex/docs-site/src/content/docs/reference/configuration.md`
+- `/Users/jun/Developer/new/700_projects/opencodex/docs-site/src/content/docs/ko/reference/configuration.md`
+- `/Users/jun/Developer/new/700_projects/opencodex/docs-site/src/content/docs/zh/reference/configuration.md`
+
+## Safety rules
+
+- Do not mutate the user's real Codex DB while testing.
+- Do not broaden `ocx start` default behavior into silent history rewriting without an explicit config or user action.
+- Do not let `ocx stop` broadly rewrite all `opencodex` rows to `openai` if the implementation starts producing genuinely opencodex-owned visible rows.
+- Prefer reversible metadata backup over pattern-based rollback.

--- a/devlog/220_codex-app-history-visibility/01_codex-rs-findings.md
+++ b/devlog/220_codex-app-history-visibility/01_codex-rs-findings.md
@@ -78,3 +78,18 @@ For `syncResumeHistory: true`:
 - on `ocx stop` / `ocx restore`, restore only rows recorded in the backup manifest.
 
 Default remains unchanged: no history mutation unless the user explicitly enables `syncResumeHistory`.
+
+## Legacy PR #13 upgrade edge
+
+There is one unsafe-to-automate edge case:
+
+1. A user enabled `syncResumeHistory: true` on a development build before backup support existed.
+2. That build remapped old `openai` interactive rows to `opencodex`.
+3. The user upgrades while those rows are still remapped.
+4. The new backup manifest does not exist, so `ocx stop` cannot know which `opencodex` interactive rows were originally OpenAI rows.
+
+The fix must not silently rewrite all `opencodex` `cli`/`vscode` rows to `openai`, because future or app-created rows can legitimately be opencodex-owned. Instead:
+
+- normal `ocx stop` detects and reports ambiguous unbacked rows;
+- it leaves them unchanged by default;
+- `ocx recover-history --legacy-openai` is the explicit manual recovery path for users who know those rows came from the old remap.

--- a/devlog/220_codex-app-history-visibility/01_codex-rs-findings.md
+++ b/devlog/220_codex-app-history-visibility/01_codex-rs-findings.md
@@ -93,3 +93,36 @@ The fix must not silently rewrite all `opencodex` `cli`/`vscode` rows to `openai
 - normal `ocx stop` detects and reports ambiguous unbacked rows;
 - it leaves them unchanged by default;
 - `ocx recover-history --legacy-openai` is the explicit manual recovery path for users who know those rows came from the old remap.
+
+## 2026-06-22 correction: native restore cannot leave opencodex providers behind
+
+Live local testing showed that the conservative "leave unbacked opencodex rows unchanged" approach
+breaks Codex App after `ocx stop`:
+
+```text
+Codex can't load config.toml, so this thread can't resume.
+Fix config.toml: Model provider `opencodex` not found.
+```
+
+The root cause is straightforward: `ocx stop` removes `[model_providers.opencodex]` from
+`~/.codex/config.toml`. Any remaining `threads.model_provider = 'opencodex'` row can therefore point
+Codex App at a provider id that no longer exists. This applies not only to legacy `cli`/`vscode` rows,
+but also to opencodex-created `exec` rows and subagent rows if the user resumes them directly.
+
+Revised opencodex invariant:
+
+- while opencodex is active, `syncResumeHistory: true` may remap/promote history so the App sidebar is visible;
+- after native restore (`ocx stop`, `ocx restore`, uninstall), no user thread should be left with
+  `model_provider = 'opencodex'` unless the Codex config still contains that provider;
+- backed-up OpenAI rows restore to OpenAI;
+- opencodex-owned user rows are ejected to `openai`, and `exec` source is promoted to `cli`, so native
+  Codex can list/resume them after the proxy provider has been removed;
+- root `model = "provider/model"` values are also stripped on native restore because provider-prefixed
+  routed model ids are invalid without the opencodex provider/catalog.
+
+Local repair evidence after the correction:
+
+- `ocx recover-history --legacy-openai` recovered 218 user thread rows to `openai`;
+- `ocx stop` left zero user rows with `model_provider = 'opencodex'`;
+- `~/.codex/config.toml` no longer contains `[model_providers.opencodex]`, root
+  `model_provider = "opencodex"`, or root `model = "provider/model"`.

--- a/devlog/220_codex-app-history-visibility/01_codex-rs-findings.md
+++ b/devlog/220_codex-app-history-visibility/01_codex-rs-findings.md
@@ -1,0 +1,80 @@
+# Codex App / codex-rs findings
+
+## Summary
+
+The sidebar disappearance is caused by two independent filters in Codex App / app-server:
+
+1. Provider filter: when `model_providers` is omitted, app-server defaults to the active configured provider.
+2. Source filter: when `source_kinds` is omitted or empty, app-server defaults to `INTERACTIVE_SESSION_SOURCES`.
+
+In the local codex-rs checkout at `/Users/jun/Developer/codex/codex-cli/codex-rs`, `INTERACTIVE_SESSION_SOURCES` is:
+
+```text
+cli
+vscode
+custom atlas
+custom chatgpt
+```
+
+It does not include `exec`.
+
+## Source anchors
+
+codex-rs source anchors:
+
+- `/Users/jun/Developer/codex/codex-cli/codex-rs/rollout/src/lib.rs`
+  - `INTERACTIVE_SESSION_SOURCES` includes `Cli`, `VSCode`, `Custom("atlas")`, `Custom("chatgpt")`.
+- `/Users/jun/Developer/codex/codex-cli/codex-rs/app-server/src/filters.rs`
+  - `compute_source_filters(None)` returns `INTERACTIVE_SESSION_SOURCES`.
+  - `compute_source_filters(Some(Vec::new()))` also returns `INTERACTIVE_SESSION_SOURCES`.
+  - `ThreadSourceKind::Exec` requires an explicit source filter.
+- `/Users/jun/Developer/codex/codex-cli/codex-rs/app-server/src/request_processors/thread_processor.rs`
+  - `model_providers: None` becomes `Some(vec![self.config.model_provider_id.clone()])`.
+  - `source_kinds` flows through `compute_source_filters()`.
+  - Those filters are passed to `thread_store.list_threads()`.
+- `/Users/jun/Developer/codex/codex-cli/codex-rs/state/src/runtime/threads.rs`
+  - SQL filter applies `threads.archived = 0`, `threads.preview <> ''`, optional `threads.source IN (...)`, optional `threads.model_provider IN (...)`, and optional `threads.cwd IN (...)`.
+
+## Local DB evidence
+
+Read-only query against `/Users/jun/.codex/state_5.sqlite` for project cwd `/Users/jun/Developer/new/700_projects/opencodex`:
+
+| model_provider | source | count |
+| --- | --- | ---: |
+| `openai` | `cli` | 7 |
+| `openai` | `exec` | 2 |
+| `opencodex` | `exec` | 43 |
+| `opencodex` | subagent thread-spawn JSON | 2 |
+
+Default Codex App list while opencodex is active:
+
+```sql
+WHERE archived = 0
+  AND preview <> ''
+  AND source IN ('cli', 'vscode', 'atlas', 'chatgpt')
+  AND model_provider = 'opencodex'
+```
+
+That returns zero rows locally because opencodex-created project rows are `source = 'exec'`.
+
+## Upstream patch direction
+
+The cleaner upstream fix would be in Codex App / codex-rs:
+
+- either request `sourceKinds` including `exec` for the project sidebar,
+- or make the project sidebar intentionally provider/source agnostic when the user is browsing project history,
+- or expose a UI affordance for source filtering.
+
+opencodex cannot change Codex App's `thread/list` request payload. The opencodex-side fix therefore must be an explicit compatibility mode that temporarily adjusts local metadata and restores it later.
+
+## opencodex fix direction
+
+For `syncResumeHistory: true`:
+
+- backup original thread metadata into `~/.opencodex/codex-history-backup.json`;
+- remap old OpenAI `cli`/`vscode` rows to `model_provider = 'opencodex'`;
+- promote opencodex-created user `exec` rows to `source = 'cli'`;
+- update the rollout JSONL first `session_meta` line consistently so Codex's rollout scanner does not repair the DB back to the hidden state;
+- on `ocx stop` / `ocx restore`, restore only rows recorded in the backup manifest.
+
+Default remains unchanged: no history mutation unless the user explicitly enables `syncResumeHistory`.

--- a/devlog/230_umans-wire-protocol/00_research.md
+++ b/devlog/230_umans-wire-protocol/00_research.md
@@ -1,0 +1,320 @@
+# 230 Umans wire protocol and custom adapter research
+
+## Goal
+
+Investigate whether issue #18 can be explained by routing Umans models through the wrong wire
+adapter, and decide whether opencodex needs a custom-provider path for Anthropic Messages-style
+providers in addition to the existing OpenAI Chat Completions path.
+
+Issue anchor:
+
+- https://github.com/lidge-jun/opencodex/issues/18
+
+## External evidence
+
+### Umans official docs
+
+Source: https://app.umans.ai/offers/code/docs
+
+Findings:
+
+- Umans Code exposes an Anthropic-compatible endpoint:
+  - `POST https://api.code.umans.ai/v1/messages`
+  - Auth header: `x-api-key`
+  - Requires `anthropic-version: 2023-06-01`
+  - Streamed responses use Anthropic Messages SSE.
+- Umans Code also exposes an OpenAI-compatible endpoint:
+  - `POST https://api.code.umans.ai/v1/chat/completions`
+  - Auth header: `Authorization: Bearer ...`
+  - Streamed responses use Chat Completions-style chunks.
+- Umans recommends `umans-kimi-k2.7` for hard coding tasks. Kimi K2.7-Code always reasons before
+  answering, so reasoning output is expected.
+- Umans documents reasoning output by protocol:
+  - `/v1/messages`: `thinking` content blocks / `thinking_delta` stream events.
+  - `/v1/chat/completions`: `reasoning_content` on messages and streamed deltas.
+- Umans documents Claude Code manual configuration with:
+  - `ANTHROPIC_BASE_URL=https://api.code.umans.ai`
+  - `ANTHROPIC_AUTH_TOKEN=sk-your-umans-api-key`
+
+### models.dev provider metadata
+
+Sources:
+
+- https://models.dev/providers/umans-ai/
+- https://models.dev/providers/umans-ai-coding-plan/
+- https://models.dev/api.json
+
+Findings:
+
+- Both `Umans AI` and `Umans AI Coding Plan` are listed as `@ai-sdk/openai-compatible`.
+- API base is `https://api.code.umans.ai/v1`.
+- `umans-kimi-k2.7`:
+  - family: `kimi-k2`
+  - reasoning: true
+  - reasoning_options: empty array
+  - tool_call: true
+  - structured_output: true
+  - temperature: false
+  - interleaved reasoning field: `reasoning_content`
+  - regular plan output limit: 32,768
+  - coding plan output limit: 262,144
+- `umans-coder` currently routes to Kimi K2.7-Code and has the same Kimi-like constraints.
+- `umans-glm-5.2` supports reasoning effort values `high` and `max`.
+- `umans-flash` / Qwen-like models support `low`, `medium`, `high` efforts.
+
+### Related ecosystem signal
+
+Source: https://newreleases.io/project/github/can1357/oh-my-pi/release/v16.0.1
+
+Findings:
+
+- Another coding-agent stack recently added Umans AI Coding Plan API-key login support.
+- The same release fixed OpenAI-compatible Chat Completions streams whose tool arguments arrive as
+  object-shaped fragments and need deep-merge behavior instead of naive replacement. This is not
+  direct evidence that Umans emits that exact shape, but it is a useful warning that modern
+  OpenAI-compatible coding gateways do not always behave like simple scalar-delta streams.
+
+## opencodex local evidence
+
+### Router
+
+File: `/Users/jun/Developer/new/700_projects/opencodex/src/router.ts`
+
+Routing behavior:
+
+- `umans/umans-kimi-k2.7` will use provider `umans` only if `config.providers.umans` exists.
+- The upstream model id becomes `umans-kimi-k2.7`.
+- The provider's configured `adapter` controls the wire protocol.
+
+Local config check during this investigation:
+
+```json
+{
+  "defaultProvider": "opencode-go",
+  "umans": null
+}
+```
+
+So the reporter's `umans` provider is not present in this local machine's
+`~/.opencodex/config.json`; conclusions about its exact adapter must be verified against the
+reporter's config.
+
+### OpenAI Chat adapter
+
+File: `/Users/jun/Developer/new/700_projects/opencodex/src/adapters/openai-chat.ts`
+
+Behavior:
+
+- Always sends to `${provider.baseUrl}/chat/completions`.
+- Sends `max_tokens` for output cap.
+- Sends `reasoning_effort` if `mapReasoningEffort(...)` returns a value.
+- Sends `temperature`, `top_p`, and penalties unless the provider/model is listed in the relevant
+  no-parameter config arrays.
+- Streams only scalar `choices[0].delta.content` and `choices[0].delta.reasoning_content` as
+  append-only deltas.
+- Tracks one current tool call id/name, not a full index-keyed map of parallel or interleaved tool
+  call chunks.
+
+Issue #18 implication:
+
+- If Umans Chat Completions emits cumulative or overlapping content snapshots rather than strict
+  append-only deltas, opencodex will append them and live output can duplicate partial text.
+- If Umans emits tool-call arguments as object fragments, cumulative snapshots, or id-less indexed
+  chunks, the current parser can lose or corrupt tool-call state. That can explain commentary
+  streaming successfully but the turn stalling before Codex receives a file-change/tool event.
+- If a custom `umans` provider lacks Kimi model constraints, opencodex can send unsupported or
+  poorly matched params (`temperature`, `top_p`, `reasoning_effort`, `tool_choice`) to
+  Kimi-family models.
+
+### Anthropic Messages adapter
+
+File: `/Users/jun/Developer/new/700_projects/opencodex/src/adapters/anthropic.ts`
+
+Behavior:
+
+- Sends to `${baseUrlWithoutV1}/v1/messages`.
+- For API-key providers, uses `x-api-key`.
+- Sets `anthropic-version: 2023-06-01`.
+- Maps Codex reasoning to Anthropic `thinking`.
+- Parses `thinking_delta`, `text_delta`, and `input_json_delta` into opencodex `AdapterEvent`s.
+
+Issue #18 implication:
+
+- Since Umans officially implements `/v1/messages`, opencodex can already target the Messages path
+  by configuring:
+
+```json
+{
+  "providers": {
+    "umans": {
+      "adapter": "anthropic",
+      "baseUrl": "https://api.code.umans.ai",
+      "apiKey": "sk-...",
+      "defaultModel": "umans-coder",
+      "models": ["umans-coder", "umans-kimi-k2.7", "umans-glm-5.2", "umans-flash"]
+    }
+  }
+}
+```
+
+- This route may be safer for Claude/Codex-style tool and thinking semantics than the Chat
+  Completions route, because Umans' own docs present it as Anthropic-compatible and Claude Code
+  setup uses the Anthropic base/auth variables.
+
+### Dashboard / custom provider surface
+
+Files:
+
+- `/Users/jun/Developer/new/700_projects/opencodex/gui/src/components/AddProviderModal.tsx`
+- `/Users/jun/Developer/new/700_projects/opencodex/src/providers/derive.ts`
+- `/Users/jun/Developer/new/700_projects/opencodex/src/server.ts`
+
+Current behavior:
+
+- The custom provider preset defaults to `adapter: "openai-chat"`.
+- The Add Provider modal already lets a user choose:
+  - `openai-responses`
+  - `openai-chat`
+  - `anthropic`
+  - `google`
+  - `azure-openai`
+- `/api/providers` accepts any `provider.adapter` and `provider.baseUrl`; it then calls
+  `enrichProviderFromCatalog(name, prov)`.
+
+Gap:
+
+- The UI does not teach users that providers such as Umans may have two valid protocols, and that
+  the Messages path may be safer for coding-agent/tool-call stability.
+- There is no first-class Umans preset in `PROVIDER_REGISTRY`, so users are likely to add it via
+  Custom and leave the default `openai-chat` adapter.
+
+## Working hypotheses for issue #18
+
+### H1: wrong protocol selection for Umans custom provider
+
+Evidence:
+
+- Custom providers default to `openai-chat`.
+- Umans offers both OpenAI-compatible and Anthropic-compatible endpoints.
+- Claude Code setup in Umans docs uses Anthropic-style base URL and auth token.
+- Issue #18 happens in coding-agent turns where tool/file-change semantics matter.
+
+Risk:
+
+- If the reporter's `umans` provider uses `openai-chat`, opencodex goes through
+  `/v1/chat/completions`.
+- That may still be officially supported, but it may be the less stable path for Codex's
+  Responses-to-tool-call bridge.
+
+Falsification:
+
+- Capture the reporter's `~/.opencodex/config.json` provider entry with secrets redacted.
+- Run the same prompt with:
+  - `adapter: "openai-chat", baseUrl: "https://api.code.umans.ai/v1"`
+  - `adapter: "anthropic", baseUrl: "https://api.code.umans.ai"`
+- If duplication/stall disappears only on `anthropic`, protocol selection is implicated.
+
+### H2: OpenAI-compatible stream is not strict scalar-delta compatible
+
+Evidence:
+
+- Issue #18 live text examples look like append duplication.
+- `openai-chat.ts` assumes every `delta.content` / `delta.reasoning_content` string is append-only.
+- Related ecosystem release notes warn about object-shaped tool argument fragments in
+  OpenAI-compatible streams.
+
+Falsification:
+
+- Record raw upstream SSE for a short Umans stream.
+- Check whether `delta.content`, `delta.reasoning_content`, or `tool_calls[].function.arguments`
+  are append-only strings or cumulative/object fragments.
+
+### H3: missing model capability flags for Kimi-family Umans models
+
+Evidence:
+
+- models.dev marks `umans-kimi-k2.7` and `umans-coder` as `temperature: false` and
+  `reasoning_options: []`.
+- Existing Kimi registry entries in opencodex have explicit no-temperature/no-top-p/no-penalty and
+  auto-tool-choice-only settings.
+- A custom Umans provider will not inherit those Kimi constraints unless catalog enrichment covers
+  this provider id or the user config includes them.
+
+Falsification:
+
+- Inspect `enrichProviderFromCatalog("umans", prov)` behavior for this provider name.
+- Add/verify a first-class `umans` registry entry with model constraints and compare request bodies.
+
+## Patch options
+
+### Option A: first-class Umans provider presets
+
+Add registry entries:
+
+- `umans` or `umans-ai`
+  - label: `Umans AI`
+  - adapter: `anthropic`
+  - baseUrl: `https://api.code.umans.ai`
+  - authKind: `key`
+  - dashboardUrl: `https://app.umans.ai/offers/code/docs`
+  - defaultModel: `umans-coder`
+  - models: `umans-coder`, `umans-kimi-k2.7`, `umans-glm-5.2`, `umans-flash`, possibly
+    `umans-glm-5.1`
+- `umans-openai` optional advanced preset
+  - adapter: `openai-chat`
+  - baseUrl: `https://api.code.umans.ai/v1`
+  - note: OpenAI-compatible route; use only if a tool specifically requires Chat Completions.
+
+Reasoning:
+
+- Make the safer coding-agent path the obvious default.
+- Keep Chat Completions available for users who need it.
+
+### Option B: custom provider protocol helper
+
+Improve the custom provider modal:
+
+- Add an adapter explainer:
+  - `openai-chat`: base URL should end in `/v1`; opencodex calls `/chat/completions`.
+  - `anthropic`: base URL should be provider root or `/v1`; opencodex calls `/v1/messages`.
+- Add a preset-like "Umans Messages" row so users do not accidentally keep `openai-chat`.
+- Optionally warn when a base URL contains `api.code.umans.ai` and adapter is still `openai-chat`:
+  "Umans also supports Messages; use Anthropic adapter for Codex-style tool stability."
+
+### Option C: harden OpenAI Chat streaming parser
+
+Add tests and parser support for:
+
+- id-less tool-call indexed chunks.
+- multiple tool-call indexes even when `parallel_tool_calls=false`.
+- object-shaped or cumulative tool arguments if observed in raw stream.
+- optional duplicate/cumulative text detection only if raw Umans evidence proves it; do not guess.
+
+### Option D: raw stream capture debug mode
+
+Add a temporary or gated debug facility:
+
+- Log upstream SSE frames for a selected provider/model with secrets stripped.
+- Include request adapter, URL path, and model params.
+- Use it to prove whether duplication comes from upstream frames, opencodex bridge, or Codex
+  mobile renderer.
+
+## Recommendation
+
+Do not treat #18 as a generic stall timeout issue. It is likely a wire-protocol / event-contract
+problem.
+
+Immediate next implementation cycle should:
+
+1. Add first-class Umans presets, defaulting to `adapter: "anthropic"` / `/v1/messages`.
+2. Add documentation for when custom providers should use `anthropic` instead of `openai-chat`.
+3. Add an A/B repro plan for Umans `openai-chat` vs `anthropic`.
+4. Add raw-stream capture tests before changing duplicate suppression logic.
+5. Harden `openai-chat` tool-call parsing only from observed raw stream evidence.
+
+## Evidence status
+
+- Umans protocol support: sufficient. Confirmed from official Umans docs and models.dev metadata.
+- Reporter config: insufficient. Local machine does not have `providers.umans`.
+- Root cause of #18: partial. Strong hypotheses exist, but raw upstream SSE capture is required before
+  changing streaming parser behavior.

--- a/devlog/230_umans-wire-protocol/01_oh_my_pi_findings.md
+++ b/devlog/230_umans-wire-protocol/01_oh_my_pi_findings.md
@@ -1,0 +1,307 @@
+# 230.1 Oh My Pi Umans implementation findings
+
+## Goal
+
+Inspect how `can1357/oh-my-pi` implements Umans, specifically whether it treats Umans as an
+OpenAI-compatible Chat Completions provider or as an Anthropic Messages provider.
+
+Repository:
+
+- https://github.com/can1357/oh-my-pi
+
+## Summary
+
+Oh My Pi treats Umans as an **Anthropic Messages** provider.
+
+It does not make Umans' coding-plan login validate against `/v1/chat/completions`. It validates
+the pasted key against:
+
+- `POST https://api.code.umans.ai/v1/messages`
+- `anthropic-version: 2023-06-01`
+- `x-api-key: <umans key>`
+- model: `umans-coder`
+
+Its catalog also maps Umans models to:
+
+- `api: "anthropic-messages"`
+- `provider: "umans"`
+- `baseUrl: "https://api.code.umans.ai"`
+
+This strongly supports making opencodex's first-class Umans preset use the `anthropic` adapter,
+not the `openai-chat` adapter.
+
+## Evidence
+
+### Provider registry
+
+Source:
+
+- https://github.com/can1357/oh-my-pi/blob/main/packages/ai/src/registry/umans.ts
+
+Observed implementation:
+
+```ts
+export const loginUmans = createApiKeyLogin({
+  providerLabel: "Umans AI Coding Plan",
+  authUrl: "https://app.umans.ai/billing",
+  instructions: "Create or copy your Umans API key from Dashboard -> API Keys.",
+  promptMessage: "Paste your Umans API key",
+  placeholder: "sk-...",
+  validation: {
+    kind: "anthropic-messages",
+    provider: "Umans AI Coding Plan",
+    baseUrl: "https://api.code.umans.ai",
+    model: "umans-coder",
+  },
+});
+
+export const umansProvider = {
+  id: "umans",
+  name: "Umans AI Coding Plan",
+  login: (cb: OAuthLoginCallbacks) => loginUmans(cb),
+};
+```
+
+Interpretation:
+
+- The provider id is `umans`.
+- The user-facing login is API-key paste, not OAuth.
+- Validation kind is `anthropic-messages`.
+- Base URL intentionally omits `/v1`; the Anthropic client appends `/v1/messages`.
+
+### API-key validation test
+
+Source:
+
+- https://github.com/can1357/oh-my-pi/blob/main/packages/ai/test/umans-login.test.ts
+
+Observed assertions:
+
+```ts
+expect(url).toBe("https://api.code.umans.ai/v1/messages");
+expect(init?.method).toBe("POST");
+expect(headers.get("content-type")).toBe("application/json");
+expect(headers.get("anthropic-version")).toBe("2023-06-01");
+expect(headers.get("x-api-key")).toBe("sk-umans-valid");
+expect(headers.get("authorization")).toBeNull();
+expect(body.model).toBe("umans-coder");
+expect(body.max_tokens).toBe(1);
+```
+
+Interpretation:
+
+- Oh My Pi explicitly forbids Bearer auth for this validation path.
+- It validates using `x-api-key`.
+- It validates with `umans-coder`, not `umans-kimi-k2.7`.
+
+### Catalog mapping test
+
+Source:
+
+- https://github.com/can1357/oh-my-pi/blob/main/packages/catalog/test/umans-provider.test.ts
+
+Observed assertions:
+
+```ts
+expect(model).toMatchObject({
+  id: "umans-coder",
+  api: "anthropic-messages",
+  provider: "umans",
+  baseUrl: "https://api.code.umans.ai",
+  reasoning: true,
+  input: ["text", "image"],
+  contextWindow: 262_144,
+  maxTokens: 32_768,
+  thinking: { defaultLevel: "medium" },
+  compat: { escapeBuiltinToolNames: true },
+});
+```
+
+For `umans-kimi-k2.7`:
+
+```ts
+expect(mandatoryReasoningModel).toMatchObject({
+  id: "umans-kimi-k2.7",
+  reasoning: true,
+  maxTokens: 32_768,
+  thinking: { defaultLevel: "medium", requiresEffort: true },
+  compat: { escapeBuiltinToolNames: true },
+});
+```
+
+Interpretation:
+
+- Oh My Pi models Umans Kimi as mandatory-reasoning Anthropic Messages.
+- It adds `compat.escapeBuiltinToolNames: true` for Umans.
+- It caps `umans-kimi-k2.7` max output at 32,768 despite some public metadata showing larger plan
+  ceilings.
+
+### Dynamic model discovery
+
+Source:
+
+- https://github.com/can1357/oh-my-pi/blob/main/packages/catalog/src/provider-models/openai-compat.ts
+
+Observed implementation:
+
+- `UMANS_BASE_URL = "https://api.code.umans.ai"`
+- `UMANS_MODELS_INFO_PATH = "/models/info"`
+- `umansModelManagerOptions()` returns `ModelManagerOptions<"anthropic-messages">`
+- dynamic discovery fetches:
+  - `GET https://api.code.umans.ai/v1/models/info`
+  - optional `x-api-key`
+- every mapped Umans model has:
+  - `api: "anthropic-messages"`
+  - `provider: "umans"`
+  - `baseUrl: "https://api.code.umans.ai"`
+  - `compat.escapeBuiltinToolNames: true`
+
+Important comment:
+
+```ts
+// Umans `models/info` reports `supports_vision: true` for natively
+// vision-capable models and a non-empty string sentinel (e.g.
+// `"via-handoff"`) for models that route image inputs through a vision
+// handoff pre-analysis step instead of accepting raw image blocks. Only
+// `true` means the model accepts image content directly; sentinel values
+// MUST map to text-only ...
+```
+
+Interpretation:
+
+- Umans has a custom `/v1/models/info` endpoint with richer capability metadata.
+- `supports_vision: "via-handoff"` must not be treated as native image support.
+- Oh My Pi drops cached/stale GLM rows if static metadata says those rows are text-only.
+
+### Host compatibility
+
+Source:
+
+- https://github.com/can1357/oh-my-pi/blob/main/packages/catalog/src/hosts.ts
+- https://github.com/can1357/oh-my-pi/blob/main/packages/catalog/src/compat/anthropic.ts
+
+Observed implementation:
+
+```ts
+umans: { providers: ["umans"], urlMarkers: ["api.code.umans.ai"] }
+```
+
+Anthropic compat sets:
+
+```ts
+escapeBuiltinToolNames: modelMatchesHost(spec, "umans")
+```
+
+Interpretation:
+
+- Umans is a known host class.
+- Built-in tool names are escaped for Umans on the Anthropic Messages path.
+- This is likely a defensive fix for provider-side reserved/built-in Anthropic tool names.
+
+### Bundled model snapshot
+
+Source:
+
+- https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/catalog/src/models.json
+
+Observed Umans models:
+
+- `umans-coder`
+- `umans-flash`
+- `umans-glm-5.1`
+- `umans-glm-5.2`
+- `umans-kimi-k2.6`
+- `umans-kimi-k2.7`
+- `umans-qwen3.6-35b-a3b`
+
+All are bundled as:
+
+```json
+{
+  "api": "anthropic-messages",
+  "provider": "umans",
+  "baseUrl": "https://api.code.umans.ai",
+  "reasoning": true,
+  "compat": {
+    "escapeBuiltinToolNames": true
+  }
+}
+```
+
+Notable model metadata:
+
+- `umans-coder`: text+image, context 262,144, maxTokens 32,768, thinking requires effort.
+- `umans-kimi-k2.7`: text+image, context 262,144, maxTokens 32,768, thinking requires effort.
+- `umans-glm-5.1` and `umans-glm-5.2`: text-only, because image support is treated as
+  via-handoff, not native image blocks.
+- `umans-glm-5.2`: context 405,504, maxTokens 131,071.
+
+## Implications for opencodex
+
+### 1. Default Umans preset should be `anthropic`
+
+Recommended opencodex provider seed:
+
+```json
+{
+  "adapter": "anthropic",
+  "baseUrl": "https://api.code.umans.ai",
+  "authMode": "key",
+  "defaultModel": "umans-coder",
+  "models": [
+    "umans-coder",
+    "umans-kimi-k2.7",
+    "umans-kimi-k2.6",
+    "umans-flash",
+    "umans-glm-5.2",
+    "umans-glm-5.1",
+    "umans-qwen3.6-35b-a3b"
+  ]
+}
+```
+
+### 2. opencodex may need an Umans-specific Anthropic compat flag
+
+Oh My Pi sets `escapeBuiltinToolNames: true` for Umans. opencodex currently only has generic
+Anthropic tool mapping and does not expose an equivalent provider flag. If issue #18 includes
+tool/file-change instability on Umans, this is a concrete compatibility gap to inspect.
+
+Patch direction:
+
+- Add an optional provider flag such as `escapeBuiltinToolNames?: boolean`, or hard-code for provider
+  id/base URL `umans` / `api.code.umans.ai`.
+- Apply it only inside the Anthropic adapter's tool-name mapping path.
+
+### 3. Umans dynamic model metadata should prefer `/v1/models/info`
+
+Oh My Pi does not rely only on generic `/models`. It uses:
+
+- `GET https://api.code.umans.ai/v1/models/info`
+
+Patch direction:
+
+- For opencodex, a first pass can ship static model metadata in `PROVIDER_REGISTRY`.
+- A second pass can add Umans-specific live metadata enrichment for context/output/vision/thinking
+  flags.
+
+### 4. `openai-chat` should remain an advanced fallback only
+
+Umans does expose Chat Completions, but Oh My Pi's coding-agent path deliberately chooses
+Anthropic Messages. For opencodex/Codex, the safer UX is:
+
+- default: `umans` -> `anthropic`
+- optional advanced: `umans-openai` -> `openai-chat`
+
+## Conclusion
+
+Oh My Pi strongly confirms the previous opencodex research:
+
+- Umans should be treated as an Anthropic Messages provider for coding-agent usage.
+- API-key validation should call `/v1/messages` with `x-api-key`, not `/chat/completions` with
+  Bearer.
+- Umans model metadata should include mandatory reasoning, text-only GLM via-handoff handling, and
+  built-in tool-name escaping.
+
+For opencodex, the next implementation should add a first-class Umans provider preset using the
+`anthropic` adapter and then test issue #18 against that path before attempting duplicate-suppression
+logic in the OpenAI Chat adapter.

--- a/devlog/230_umans-wire-protocol/01_oh_my_pi_findings.md
+++ b/devlog/230_umans-wire-protocol/01_oh_my_pi_findings.md
@@ -9,6 +9,12 @@ Repository:
 
 - https://github.com/can1357/oh-my-pi
 
+Local reference clone:
+
+- `/Users/jun/Developer/new/700_projects/jawcode/devlog/_upstream_omp`
+- Checked at `cc0c67beb chore: bump version to 16.1.13`
+- `git status --short --branch`: `## main...origin/main`
+
 ## Summary
 
 Oh My Pi treats Umans as an **Anthropic Messages** provider.
@@ -37,6 +43,7 @@ not the `openai-chat` adapter.
 Source:
 
 - https://github.com/can1357/oh-my-pi/blob/main/packages/ai/src/registry/umans.ts
+- `/Users/jun/Developer/new/700_projects/jawcode/devlog/_upstream_omp/packages/ai/src/registry/umans.ts`
 
 Observed implementation:
 
@@ -74,6 +81,7 @@ Interpretation:
 Source:
 
 - https://github.com/can1357/oh-my-pi/blob/main/packages/ai/test/umans-login.test.ts
+- `/Users/jun/Developer/new/700_projects/jawcode/devlog/_upstream_omp/packages/ai/test/umans-login.test.ts`
 
 Observed assertions:
 

--- a/devlog/241_umans-provider-cleanup/00_note.md
+++ b/devlog/241_umans-provider-cleanup/00_note.md
@@ -1,0 +1,21 @@
+# Umans provider cleanup note
+
+## Context
+
+During the PR #14/#19 local dev merge stop audit, an unrelated Umans provider WIP appeared in the working tree. The PR #14/#19 commits themselves were already verified, but the dirty tree meant dev was not ready for a later main merge decision.
+
+## Scope
+
+- Add Umans AI Coding Plan as a key-login Anthropic-compatible provider.
+- Preserve provider runtime metadata when saving API-key logins.
+- Validate Anthropic-compatible API keys with the Messages API shape instead of `/models`.
+- Escape builtin tool names on the wire for gateways that require it and strip the prefix before returning tool calls to Codex.
+- Document the new provider/config flag in README and docs-site locale pages.
+
+## Verification
+
+- `bun run typecheck`
+- `bun test tests/umans-provider.test.ts tests/provider-registry-parity.test.ts`
+- `bun test tests`
+- `bun run build:gui`
+

--- a/docs-site/src/content/docs/ko/reference/configuration.md
+++ b/docs-site/src/content/docs/ko/reference/configuration.md
@@ -22,6 +22,12 @@ opencodex는 `~/.opencodex/config.json`으로 설정됩니다. 이 파일은 `oc
 | `webSearchSidecar?` | `OcxWebSearchSidecarConfig` | on | 웹 검색 사이드카 옵션 (아래 참조). |
 | `visionSidecar?` | `OcxVisionSidecarConfig` | on | 비전 사이드카 옵션 (아래 참조). |
 
+백업 지원 이전의 개발 빌드에서 이미 `syncResumeHistory`를 실행했다면, `ocx stop`이 백업 없는
+`opencodex` interactive row를 보고할 수 있습니다. opencodex는 이 row를 자동으로 바꾸지 않습니다.
+이전 mutation 이후에는 old OpenAI row와 진짜 opencodex-owned row를 안전하게 구분할 수 없기
+때문입니다. 해당 row가 예전 remap에서 온 것이 확실하면 `ocx recover-history --legacy-openai`로
+명시 복구하세요.
+
 ## 프로바이더 (`OcxProviderConfig`)
 
 | Field | Type | Meaning |

--- a/docs-site/src/content/docs/ko/reference/configuration.md
+++ b/docs-site/src/content/docs/ko/reference/configuration.md
@@ -17,16 +17,13 @@ opencodex는 `~/.opencodex/config.json`으로 설정됩니다. 이 파일은 `oc
 | `subagentModels?` | `string[]` | — | Codex의 서브에이전트 선택기에서 가장 먼저 노출되는 최대 5개의 `provider/model` id. |
 | `disabledModels?` | `string[]` | — | Codex에서 숨겨지는 라우팅된 `provider/model` id (카탈로그와 `/v1/models`에서 제외됨). |
 | `websockets?` | `boolean` | `false` | Codex가 Responses WebSocket 경로를 사용하도록 `supports_websockets`를 광고합니다. 생략하거나 `false`로 두면 HTTP/SSE를 유지합니다. |
-| `syncResumeHistory?` | `boolean` | `false` | Codex App 히스토리 호환 모드. 켜면 opencodex가 원래 Codex thread metadata를 백업하고, 기존 OpenAI interactive row를 `opencodex`로 remap하며, opencodex가 만든 `exec` row를 App에 보이는 source로 임시 승격합니다. `ocx stop` / `ocx restore`는 백업된 row만 원래 값으로 복원합니다. |
+| `syncResumeHistory?` | `boolean` | `false` | Codex App 히스토리 호환 모드. 켜면 opencodex가 원래 Codex thread metadata를 백업하고, 기존 OpenAI interactive row를 `opencodex`로 remap하며, opencodex가 만든 `exec` row를 App에 보이는 source로 임시 승격합니다. `ocx stop` / `ocx restore`는 백업된 OpenAI row를 복원하고, 남은 opencodex user thread는 OpenAI로 eject해서 `config.toml`에서 프록시 provider가 제거된 뒤에도 native Codex가 resume할 수 있게 합니다. |
 | `modelCacheTtlMs?` | `number` | `300000` | 프로바이더별 `/models` 캐시의 유효 기간 (5분). |
 | `webSearchSidecar?` | `OcxWebSearchSidecarConfig` | on | 웹 검색 사이드카 옵션 (아래 참조). |
 | `visionSidecar?` | `OcxVisionSidecarConfig` | on | 비전 사이드카 옵션 (아래 참조). |
 
-백업 지원 이전의 개발 빌드에서 이미 `syncResumeHistory`를 실행했다면, `ocx stop`이 백업 없는
-`opencodex` interactive row를 보고할 수 있습니다. opencodex는 이 row를 자동으로 바꾸지 않습니다.
-이전 mutation 이후에는 old OpenAI row와 진짜 opencodex-owned row를 안전하게 구분할 수 없기
-때문입니다. 해당 row가 예전 remap에서 온 것이 확실하면 `ocx recover-history --legacy-openai`로
-명시 복구하세요.
+백업 지원 이전의 개발 빌드에서 이미 `syncResumeHistory`를 실행했다면,
+`ocx recover-history --legacy-openai`로 같은 native-provider 복구를 명시 실행할 수도 있습니다.
 
 ## 프로바이더 (`OcxProviderConfig`)
 

--- a/docs-site/src/content/docs/ko/reference/configuration.md
+++ b/docs-site/src/content/docs/ko/reference/configuration.md
@@ -38,6 +38,7 @@ opencodex는 `~/.opencodex/config.json`으로 설정됩니다. 이 파일은 `oc
 | `authMode?` | `"key" \| "forward" \| "oauth"` | 인증 방식 (기본 `key`). [프로바이더](/opencodex/ko/guides/providers/#auth-modes) 참조. |
 | `noReasoningModels?` | `string[]` | reasoning/thinking 파라미터를 거부하는 모델 — 어댑터가 이들에 대해 `reasoning_effort`를 제거함. |
 | `noVisionModels?` | `string[]` | 텍스트 전용 모델 — [비전 사이드카](/opencodex/ko/guides/sidecars/)가 이들을 위해 이미지를 설명함. 매칭 시 Ollama의 `:size` 태그를 허용함. |
+| `escapeBuiltinToolNames?` | `boolean` | Umans 같은 Anthropic 호환 게이트웨이가 wire에서 도구명 escape를 요구할 때 사용합니다. opencodex는 Codex에 tool call을 돌려주기 전에 prefix를 제거합니다. |
 
 ## 사이드카
 

--- a/docs-site/src/content/docs/ko/reference/configuration.md
+++ b/docs-site/src/content/docs/ko/reference/configuration.md
@@ -17,6 +17,7 @@ opencodex는 `~/.opencodex/config.json`으로 설정됩니다. 이 파일은 `oc
 | `subagentModels?` | `string[]` | — | Codex의 서브에이전트 선택기에서 가장 먼저 노출되는 최대 5개의 `provider/model` id. |
 | `disabledModels?` | `string[]` | — | Codex에서 숨겨지는 라우팅된 `provider/model` id (카탈로그와 `/v1/models`에서 제외됨). |
 | `websockets?` | `boolean` | `false` | Codex가 Responses WebSocket 경로를 사용하도록 `supports_websockets`를 광고합니다. 생략하거나 `false`로 두면 HTTP/SSE를 유지합니다. |
+| `syncResumeHistory?` | `boolean` | `false` | Codex App 히스토리 호환 모드. 켜면 opencodex가 원래 Codex thread metadata를 백업하고, 기존 OpenAI interactive row를 `opencodex`로 remap하며, opencodex가 만든 `exec` row를 App에 보이는 source로 임시 승격합니다. `ocx stop` / `ocx restore`는 백업된 row만 원래 값으로 복원합니다. |
 | `modelCacheTtlMs?` | `number` | `300000` | 프로바이더별 `/models` 캐시의 유효 기간 (5분). |
 | `webSearchSidecar?` | `OcxWebSearchSidecarConfig` | on | 웹 검색 사이드카 옵션 (아래 참조). |
 | `visionSidecar?` | `OcxVisionSidecarConfig` | on | 비전 사이드카 옵션 (아래 참조). |

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -22,6 +22,12 @@ default (a single `openai` forward provider).
 | `webSearchSidecar?` | `OcxWebSearchSidecarConfig` | on | Web-search sidecar options (see below). |
 | `visionSidecar?` | `OcxVisionSidecarConfig` | on | Vision sidecar options (see below). |
 
+If an older development build already ran `syncResumeHistory` before backup support existed,
+`ocx stop` may report unbacked `opencodex` interactive rows. opencodex leaves those rows unchanged
+because it cannot safely distinguish old OpenAI rows from genuinely opencodex-owned rows after the
+old mutation. If you know they came from the old remap, recover them explicitly with
+`ocx recover-history --legacy-openai`.
+
 ## Providers (`OcxProviderConfig`)
 
 | Field | Type | Meaning |

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -17,16 +17,13 @@ default (a single `openai` forward provider).
 | `subagentModels?` | `string[]` | — | Up to 5 `provider/model` ids featured first in Codex's subagent picker. |
 | `disabledModels?` | `string[]` | — | Routed `provider/model` ids hidden from Codex (excluded from the catalog and `/v1/models`). |
 | `websockets?` | `boolean` | `false` | Advertise `supports_websockets` so Codex uses the Responses WebSocket path. Omit or set `false` to keep HTTP/SSE. |
-| `syncResumeHistory?` | `boolean` | `false` | Reversible Codex App history compatibility mode. When enabled, opencodex backs up original Codex thread metadata, remaps old OpenAI interactive rows to `opencodex`, and temporarily promotes opencodex-created `exec` rows to an app-visible source. `ocx stop` / `ocx restore` restore only the backed-up rows. |
+| `syncResumeHistory?` | `boolean` | `false` | Reversible Codex App history compatibility mode. When enabled, opencodex backs up original Codex thread metadata, remaps old OpenAI interactive rows to `opencodex`, and temporarily promotes opencodex-created `exec` rows to an app-visible source. `ocx stop` / `ocx restore` restore backed-up OpenAI rows and eject remaining opencodex user threads to OpenAI so native Codex can resume them after the proxy is removed from `config.toml`. |
 | `modelCacheTtlMs?` | `number` | `300000` | Freshness window for the per-provider `/models` cache (5 min). |
 | `webSearchSidecar?` | `OcxWebSearchSidecarConfig` | on | Web-search sidecar options (see below). |
 | `visionSidecar?` | `OcxVisionSidecarConfig` | on | Vision sidecar options (see below). |
 
-If an older development build already ran `syncResumeHistory` before backup support existed,
-`ocx stop` may report unbacked `opencodex` interactive rows. opencodex leaves those rows unchanged
-because it cannot safely distinguish old OpenAI rows from genuinely opencodex-owned rows after the
-old mutation. If you know they came from the old remap, recover them explicitly with
-`ocx recover-history --legacy-openai`.
+If an older development build already ran `syncResumeHistory` before backup support existed, you can
+also force the same native-provider recovery with `ocx recover-history --legacy-openai`.
 
 ## Providers (`OcxProviderConfig`)
 

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -38,6 +38,7 @@ also force the same native-provider recovery with `ocx recover-history --legacy-
 | `authMode?` | `"key" \| "forward" \| "oauth"` | How to authenticate (default `key`). See [Providers](/opencodex/guides/providers/#auth-modes). |
 | `noReasoningModels?` | `string[]` | Models that reject a reasoning/thinking param — the adapter drops `reasoning_effort` for them. |
 | `noVisionModels?` | `string[]` | Text-only models — the [vision sidecar](/opencodex/guides/sidecars/) describes images for them. Matching tolerates an Ollama `:size` tag. |
+| `escapeBuiltinToolNames?` | `boolean` | Anthropic-compatible gateways such as Umans can require tool-name escaping on the wire; opencodex strips the prefix before returning tool calls to Codex. |
 
 ## Sidecars
 

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -17,6 +17,7 @@ default (a single `openai` forward provider).
 | `subagentModels?` | `string[]` | — | Up to 5 `provider/model` ids featured first in Codex's subagent picker. |
 | `disabledModels?` | `string[]` | — | Routed `provider/model` ids hidden from Codex (excluded from the catalog and `/v1/models`). |
 | `websockets?` | `boolean` | `false` | Advertise `supports_websockets` so Codex uses the Responses WebSocket path. Omit or set `false` to keep HTTP/SSE. |
+| `syncResumeHistory?` | `boolean` | `false` | Reversible Codex App history compatibility mode. When enabled, opencodex backs up original Codex thread metadata, remaps old OpenAI interactive rows to `opencodex`, and temporarily promotes opencodex-created `exec` rows to an app-visible source. `ocx stop` / `ocx restore` restore only the backed-up rows. |
 | `modelCacheTtlMs?` | `number` | `300000` | Freshness window for the per-provider `/models` cache (5 min). |
 | `webSearchSidecar?` | `OcxWebSearchSidecarConfig` | on | Web-search sidecar options (see below). |
 | `visionSidecar?` | `OcxVisionSidecarConfig` | on | Vision sidecar options (see below). |

--- a/docs-site/src/content/docs/zh-cn/reference/configuration.md
+++ b/docs-site/src/content/docs/zh-cn/reference/configuration.md
@@ -15,9 +15,15 @@ opencodex 通过 `~/.opencodex/config.json` 进行配置。它由 `ocx init` 和
 | `subagentModels?` | `string[]` | — | 最多 5 个 `provider/model` id,会在 Codex 的 subagent 选择器中优先展示。 |
 | `disabledModels?` | `string[]` | — | 从 Codex 中隐藏的已路由 `provider/model` id(从目录和 `/v1/models` 中排除)。 |
 | `websockets?` | `boolean` | `false` | 广告 `supports_websockets`，让 Codex 使用 Responses WebSocket 路径。省略或设为 `false` 会保持 HTTP/SSE。 |
+| `syncResumeHistory?` | `boolean` | `false` | Codex App 历史兼容模式。启用后,opencodex 会备份原始 Codex thread metadata,把旧的 OpenAI interactive row remap 到 `opencodex`,并临时把 opencodex 创建的 `exec` row 提升为 App 可见的 source。`ocx stop` / `ocx restore` 只恢复备份过的 row。 |
 | `modelCacheTtlMs?` | `number` | `300000` | 每个 provider 的 `/models` 缓存的有效期(5 分钟)。 |
 | `webSearchSidecar?` | `OcxWebSearchSidecarConfig` | 开启 | 网络搜索 sidecar 选项(见下文)。 |
 | `visionSidecar?` | `OcxVisionSidecarConfig` | 开启 | 视觉 sidecar 选项(见下文)。 |
+
+如果旧的开发构建在备份支持出现之前已经运行过 `syncResumeHistory`,`ocx stop` 可能会报告没有备份的
+`opencodex` interactive row。opencodex 会保持这些 row 不变,因为旧 mutation 之后无法安全地区分
+旧 OpenAI row 和真正属于 opencodex 的 row。如果你确认这些 row 来自旧 remap,请显式运行
+`ocx recover-history --legacy-openai` 进行恢复。
 
 ## Providers(`OcxProviderConfig`)
 

--- a/docs-site/src/content/docs/zh-cn/reference/configuration.md
+++ b/docs-site/src/content/docs/zh-cn/reference/configuration.md
@@ -15,15 +15,13 @@ opencodex 通过 `~/.opencodex/config.json` 进行配置。它由 `ocx init` 和
 | `subagentModels?` | `string[]` | — | 最多 5 个 `provider/model` id,会在 Codex 的 subagent 选择器中优先展示。 |
 | `disabledModels?` | `string[]` | — | 从 Codex 中隐藏的已路由 `provider/model` id(从目录和 `/v1/models` 中排除)。 |
 | `websockets?` | `boolean` | `false` | 广告 `supports_websockets`，让 Codex 使用 Responses WebSocket 路径。省略或设为 `false` 会保持 HTTP/SSE。 |
-| `syncResumeHistory?` | `boolean` | `false` | Codex App 历史兼容模式。启用后,opencodex 会备份原始 Codex thread metadata,把旧的 OpenAI interactive row remap 到 `opencodex`,并临时把 opencodex 创建的 `exec` row 提升为 App 可见的 source。`ocx stop` / `ocx restore` 只恢复备份过的 row。 |
+| `syncResumeHistory?` | `boolean` | `false` | Codex App 历史兼容模式。启用后,opencodex 会备份原始 Codex thread metadata,把旧的 OpenAI interactive row remap 到 `opencodex`,并临时把 opencodex 创建的 `exec` row 提升为 App 可见的 source。`ocx stop` / `ocx restore` 会恢复已备份的 OpenAI row,并把剩余的 opencodex user thread eject 到 OpenAI,这样在 `config.toml` 中移除 proxy provider 后 native Codex 仍可 resume。 |
 | `modelCacheTtlMs?` | `number` | `300000` | 每个 provider 的 `/models` 缓存的有效期(5 分钟)。 |
 | `webSearchSidecar?` | `OcxWebSearchSidecarConfig` | 开启 | 网络搜索 sidecar 选项(见下文)。 |
 | `visionSidecar?` | `OcxVisionSidecarConfig` | 开启 | 视觉 sidecar 选项(见下文)。 |
 
-如果旧的开发构建在备份支持出现之前已经运行过 `syncResumeHistory`,`ocx stop` 可能会报告没有备份的
-`opencodex` interactive row。opencodex 会保持这些 row 不变,因为旧 mutation 之后无法安全地区分
-旧 OpenAI row 和真正属于 opencodex 的 row。如果你确认这些 row 来自旧 remap,请显式运行
-`ocx recover-history --legacy-openai` 进行恢复。
+如果旧的开发构建在备份支持出现之前已经运行过 `syncResumeHistory`,也可以显式运行
+`ocx recover-history --legacy-openai` 执行同样的 native-provider 恢复。
 
 ## Providers(`OcxProviderConfig`)
 

--- a/docs-site/src/content/docs/zh-cn/reference/configuration.md
+++ b/docs-site/src/content/docs/zh-cn/reference/configuration.md
@@ -36,6 +36,7 @@ opencodex 通过 `~/.opencodex/config.json` 进行配置。它由 `ocx init` 和
 | `authMode?` | `"key" \| "forward" \| "oauth"` | 认证方式(默认 `key`)。见 [Providers](/opencodex/zh-cn/guides/providers/#auth-modes)。 |
 | `noReasoningModels?` | `string[]` | 会拒绝 reasoning/thinking 参数的模型 —— adapter 会为它们丢弃 `reasoning_effort`。 |
 | `noVisionModels?` | `string[]` | 纯文本模型 —— [视觉 sidecar](/opencodex/zh-cn/guides/sidecars/) 会为它们描述图像。匹配时可容忍 Ollama 的 `:size` 标签。 |
+| `escapeBuiltinToolNames?` | `boolean` | Umans 等 Anthropic 兼容网关可能要求在 wire 上转义工具名；opencodex 会在把 tool call 返回给 Codex 前移除前缀。 |
 
 ## Sidecars
 

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -24,6 +24,12 @@ const NAV: { id: Page; tkey: TKey; Icon: typeof IconGrid }[] = [
 const THEME_ICON = { light: IconSun, dark: IconMoon, system: IconMonitor } as const;
 const THEME_TKEY: Record<Theme, TKey> = { light: "theme.light", dark: "theme.dark", system: "theme.system" };
 
+function readRuntimeVersion(data: unknown): string | null {
+  if (!data || typeof data !== "object" || !("version" in data)) return null;
+  const version = (data as { version?: unknown }).version;
+  return typeof version === "string" && version.length > 0 ? version : null;
+}
+
 function readStoredTheme(): Theme {
   const t = localStorage.getItem(THEME_KEY);
   return t === "light" || t === "dark" ? t : "system";
@@ -32,6 +38,7 @@ function readStoredTheme(): Theme {
 export default function App() {
   const [page, setPage] = useState<Page>("dashboard");
   const [theme, setTheme] = useState<Theme>(readStoredTheme);
+  const [runtimeVersion, setRuntimeVersion] = useState<string | null>(null);
   const { locale, setLocale } = useI18n();
   const t = useT();
 
@@ -43,8 +50,26 @@ export default function App() {
     else { el.setAttribute("data-theme", theme); localStorage.setItem(THEME_KEY, theme); }
   }, [theme]);
 
+  useEffect(() => {
+    let cancelled = false;
+    const fetchRuntimeVersion = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/healthz`);
+        if (!res.ok) return;
+        const version = readRuntimeVersion(await res.json());
+        if (!cancelled && version) setRuntimeVersion(version);
+      } catch {
+        // Keep the build-time fallback when the proxy is unavailable.
+      }
+    };
+    fetchRuntimeVersion();
+    const interval = setInterval(fetchRuntimeVersion, 30000);
+    return () => { cancelled = true; clearInterval(interval); };
+  }, []);
+
   const cycleTheme = () => setTheme(t => (t === "light" ? "dark" : t === "dark" ? "system" : "light"));
   const ThemeIcon = THEME_ICON[theme];
+  const displayedVersion = runtimeVersion ?? __APP_VERSION__;
 
   const langName = LOCALES.find(l => l.code === locale)?.name ?? "English";
   const cycleLang = () => {
@@ -65,7 +90,7 @@ export default function App() {
         <div className="brand">
           <span className="brand-logo" role="img" aria-label="opencodex logo" />
           <span className="name">opencodex</span>
-          <span className="ver">v{__APP_VERSION__}</span>
+          <span className="ver">v{displayedVersion}</span>
         </div>
         <nav>
           {NAV.map(({ id, tkey, Icon }) => (

--- a/gui/src/vite-env.d.ts
+++ b/gui/src/vite-env.d.ts
@@ -1,4 +1,4 @@
 /// <reference types="vite/client" />
 
-// Injected at build time by vite.config.ts `define` (root package.json version).
+// Injected at build time by vite.config.ts `define` as the UI version fallback.
 declare const __APP_VERSION__: string;

--- a/gui/vite.config.ts
+++ b/gui/vite.config.ts
@@ -2,8 +2,8 @@ import { readFileSync } from 'node:fs'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// Bake the parent package version into the bundle so the brand badge matches the npm release
-// (built together via `build:gui` in prepublishOnly). Single source = the root package.json.
+// Bake the parent package version into the bundle as a fallback for moments when the runtime
+// `/healthz` version is not reachable yet.
 const version = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')).version
 
 // https://vite.dev/config/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitkyc08/opencodex",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Universal provider proxy for OpenAI Codex — use any LLM with Codex CLI/App/SDK",
   "type": "module",
   "main": "src/index.ts",

--- a/src/adapters/anthropic.ts
+++ b/src/adapters/anthropic.ts
@@ -37,6 +37,7 @@ const MIN_THINKING_BUDGET = 1024;
 const OUTPUT_HEADROOM = 8192;
 /** Minimum visible-output room kept below `max_tokens` (so `max_tokens > budget_tokens` always holds). */
 const OUTPUT_FLOOR = 4096;
+const COMPAT_TOOL_PREFIX = "ocx_";
 
 /** Map a Responses reasoning effort to an Anthropic extended-thinking budget (tokens, >= 1024). */
 function reasoningBudget(effort: string): number {
@@ -61,7 +62,23 @@ function usageFromAnthropic(usage: Record<string, number> | undefined): OcxUsage
   };
 }
 
-function messagesToAnthropicFormat(parsed: OcxParsedRequest, isOAuth: boolean): { system: string | undefined; messages: unknown[] } {
+function buildToolNameTransforms(provider: OcxProviderConfig): { toWire: (name: string) => string; fromWire: (name: string) => string } {
+  if (provider.authMode === "oauth") {
+    return { toWire: applyClaudeToolPrefix, fromWire: stripClaudeToolPrefix };
+  }
+  if (provider.escapeBuiltinToolNames === true) {
+    return {
+      toWire: (name) => name.startsWith(COMPAT_TOOL_PREFIX) ? name : COMPAT_TOOL_PREFIX + name,
+      fromWire: (name) => name.startsWith(COMPAT_TOOL_PREFIX) ? name.slice(COMPAT_TOOL_PREFIX.length) : name,
+    };
+  }
+  return { toWire: (name) => name, fromWire: (name) => name };
+}
+
+function messagesToAnthropicFormat(
+  parsed: OcxParsedRequest,
+  toolNames: { toWire: (name: string) => string },
+): { system: string | undefined; messages: unknown[] } {
   const system = parsed.context.systemPrompt?.join("\n\n") || undefined;
   const messages: unknown[] = [];
 
@@ -87,7 +104,7 @@ function messagesToAnthropicFormat(parsed: OcxParsedRequest, isOAuth: boolean): 
           } else if (part.type === "toolCall") {
             const tc = part as OcxToolCall;
             const flatName = namespacedToolName(tc.namespace, tc.name);
-            content.push({ type: "tool_use", id: tc.id, name: isOAuth ? applyClaudeToolPrefix(flatName) : flatName, input: tc.arguments });
+            content.push({ type: "tool_use", id: tc.id, name: toolNames.toWire(flatName), input: tc.arguments });
           }
         }
         messages.push({ role: "assistant", content });
@@ -115,10 +132,10 @@ function messagesToAnthropicFormat(parsed: OcxParsedRequest, isOAuth: boolean): 
   return { system, messages };
 }
 
-function toolsToAnthropicFormat(parsed: OcxParsedRequest, isOAuth: boolean): unknown[] | undefined {
+function toolsToAnthropicFormat(parsed: OcxParsedRequest, toolNames: { toWire: (name: string) => string }): unknown[] | undefined {
   if (!parsed.context.tools || parsed.context.tools.length === 0) return undefined;
   return parsed.context.tools.map(t => ({
-    name: isOAuth ? applyClaudeToolPrefix(namespacedToolName(t.namespace, t.name)) : namespacedToolName(t.namespace, t.name),
+    name: toolNames.toWire(namespacedToolName(t.namespace, t.name)),
     description: t.description,
     input_schema: t.parameters,
   }));
@@ -126,12 +143,13 @@ function toolsToAnthropicFormat(parsed: OcxParsedRequest, isOAuth: boolean): unk
 
 export function createAnthropicAdapter(provider: OcxProviderConfig): ProviderAdapter {
   const isOAuth = provider.authMode === "oauth";
+  const toolNames = buildToolNameTransforms(provider);
   return {
     name: "anthropic",
 
     buildRequest(parsed: OcxParsedRequest) {
-      const { system, messages } = messagesToAnthropicFormat(parsed, isOAuth);
-      const tools = toolsToAnthropicFormat(parsed, isOAuth);
+      const { system, messages } = messagesToAnthropicFormat(parsed, toolNames);
+      const tools = toolsToAnthropicFormat(parsed, toolNames);
 
       const body: Record<string, unknown> = {
         model: parsed.modelId,
@@ -174,7 +192,7 @@ export function createAnthropicAdapter(provider: OcxProviderConfig): ProviderAda
         if (tc === "auto") body.tool_choice = { type: "auto" };
         else if (tc === "none") body.tool_choice = { type: "none" };
         else if (tc === "required") body.tool_choice = { type: "any" };
-        else if (typeof tc === "object" && "name" in tc) body.tool_choice = { type: "tool", name: isOAuth ? applyClaudeToolPrefix(tc.name) : tc.name };
+        else if (typeof tc === "object" && "name" in tc) body.tool_choice = { type: "tool", name: toolNames.toWire(tc.name) };
       }
 
       const base = provider.baseUrl.replace(/\/v1\/?$/, "");
@@ -241,7 +259,7 @@ export function createAnthropicAdapter(provider: OcxProviderConfig): ProviderAda
                 currentBlockType = block.type;
                 if (block.type === "tool_use") {
                   currentToolCallId = block.id ?? "";
-                  currentToolCallName = isOAuth ? stripClaudeToolPrefix(block.name ?? "") : (block.name ?? "");
+                  currentToolCallName = toolNames.fromWire(block.name ?? "");
                   yield { type: "tool_call_start", id: currentToolCallId, name: currentToolCallName };
                 }
                 break;
@@ -302,7 +320,7 @@ export function createAnthropicAdapter(provider: OcxProviderConfig): ProviderAda
           if (block.type === "text" && block.text) {
             events.push({ type: "text_delta", text: block.text });
           } else if (block.type === "tool_use") {
-            events.push({ type: "tool_call_start", id: block.id ?? "", name: isOAuth ? stripClaudeToolPrefix(block.name ?? "") : (block.name ?? "") });
+            events.push({ type: "tool_call_start", id: block.id ?? "", name: toolNames.fromWire(block.name ?? "") });
             events.push({ type: "tool_call_delta", arguments: JSON.stringify(block.input ?? {}) });
             events.push({ type: "tool_call_end" });
           }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 import { execFileSync, spawn } from "node:child_process";
 import { rmSync } from "node:fs";
 import { restoreNativeCodex } from "./codex-inject";
+import { restoreLegacyOpenaiHistory } from "./codex-history-provider";
 import { codexAutoStartEnabled, getConfigDir, loadConfig, readPid, removePid, saveConfig, writePid } from "./config";
 import { findAvailablePort } from "./ports";
 import { serviceCommand, stopServiceIfInstalled, uninstallServiceIfInstalled } from "./service";
@@ -19,6 +20,8 @@ Usage:
   ocx start [--port <port>]   Start the proxy server (auto-syncs models to Codex)
   ocx stop                    Stop the proxy AND restore native Codex (plain codex works again)
   ocx restore                 Restore native Codex without stopping (alias: eject)
+  ocx recover-history --legacy-openai
+                               Explicitly recover pre-backup syncResumeHistory rows
   ocx uninstall               Remove service/shim/config and restore native Codex
   ocx service <sub>           Run as a background service (install|start|stop|status|uninstall)
   ocx codex-shim <sub>        Auto-start proxy when \`codex\` launches (install|status|uninstall)
@@ -304,6 +307,16 @@ function handleStatus() {
   }
 }
 
+function handleRecoverHistory() {
+  if (args[1] !== "--legacy-openai") {
+    console.error("Usage: ocx recover-history --legacy-openai");
+    console.error("Only use this if an older syncResumeHistory build already remapped OpenAI Codex App history to opencodex before backup support existed.");
+    process.exit(1);
+  }
+  const r = restoreLegacyOpenaiHistory();
+  console.log(`Recovered ${r.rows} legacy thread(s) to openai (${r.files} rollout file(s) updated).`);
+}
+
 switch (command) {
   case "init": {
     const { runInit } = await import("./init");
@@ -323,6 +336,9 @@ switch (command) {
     console.log("Plain `codex` now runs natively (no proxy).");
     break;
   }
+  case "recover-history":
+    handleRecoverHistory();
+    break;
   case "uninstall":
   case "remove":
     await handleUninstall();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,6 +60,9 @@ function printSubcommandUsage(name: string | undefined): void {
     case "eject":
       console.log(`Usage: ocx ${name}\n\nRestore native Codex config without stopping the proxy.`);
       break;
+    case "recover-history":
+      console.log("Usage: ocx recover-history --legacy-openai\n\nExplicitly recover pre-backup syncResumeHistory rows.");
+      break;
     case "uninstall":
     case "remove":
       console.log(`Usage: ocx ${name}\n\nRemove service/shim/config and restore native Codex.`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,6 +41,69 @@ Examples:
   ocx sync                    Sync available models to Codex`);
 }
 
+function hasHelpFlag(values: string[]): boolean {
+  return values.some(value => value === "--help" || value === "-h" || value === "help");
+}
+
+function printSubcommandUsage(name: string | undefined): void {
+  switch (name) {
+    case "init":
+      console.log("Usage: ocx init\n\nInteractive setup for providers and Codex config injection.");
+      break;
+    case "start":
+      console.log("Usage: ocx start [--port <port>]\n\nStart the proxy server and sync models to Codex.");
+      break;
+    case "stop":
+      console.log("Usage: ocx stop\n\nStop the proxy and restore native Codex config.");
+      break;
+    case "restore":
+    case "eject":
+      console.log(`Usage: ocx ${name}\n\nRestore native Codex config without stopping the proxy.`);
+      break;
+    case "uninstall":
+    case "remove":
+      console.log(`Usage: ocx ${name}\n\nRemove service/shim/config and restore native Codex.`);
+      break;
+    case "service":
+      console.log("Usage: ocx service <install|start|stop|status|uninstall>");
+      break;
+    case "codex-shim":
+      console.log("Usage: ocx codex-shim <install|status|uninstall>");
+      break;
+    case "ensure":
+      console.log("Usage: ocx ensure\n\nEnsure the proxy is running and Codex config/cache are current.");
+      break;
+    case "sync":
+      console.log("Usage: ocx sync\n\nFetch provider models and inject them into Codex config.");
+      break;
+    case "sync-cache":
+      console.log("Usage: ocx sync-cache\n\nRefresh Codex's model cache from the active catalog.");
+      break;
+    case "status":
+      console.log("Usage: ocx status\n\nCheck proxy server status.");
+      break;
+    case "login":
+      console.log("Usage: ocx login <provider>\n\nOAuth or API-key login for a provider.");
+      break;
+    case "logout":
+      console.log("Usage: ocx logout <provider>\n\nRemove a stored provider login.");
+      break;
+    case "gui":
+      console.log("Usage: ocx gui\n\nOpen the opencodex dashboard.");
+      break;
+    case "update":
+      console.log("Usage: ocx update\n\nUpdate opencodex to the latest published version.");
+      break;
+    default:
+      printUsage();
+  }
+}
+
+if (command !== undefined && command !== "help" && hasHelpFlag(args.slice(1))) {
+  printSubcommandUsage(command);
+  process.exit(0);
+}
+
 async function syncModelsToCodex(port?: number) {
   const config = loadConfig();
   const p = port ?? config.port ?? 10100;

--- a/src/codex-history-provider.ts
+++ b/src/codex-history-provider.ts
@@ -10,6 +10,12 @@ const RESUMABLE_SOURCES = ["cli", "vscode"] as const;
 
 type CodexHistoryProvider = "openai" | "opencodex";
 
+export interface CodexHistorySyncResult {
+  rows: number;
+  files: number;
+  legacyRows?: number;
+}
+
 interface ThreadRow {
   id: string;
   rollout_path: string;
@@ -99,7 +105,7 @@ function updateSessionMeta(path: string, patch: { provider?: string; source?: st
   return true;
 }
 
-export function syncCodexHistoryProvider(provider: CodexHistoryProvider, stateDbPath = STATE_DB_PATH, backupPath = HISTORY_BACKUP_PATH): { rows: number; files: number } {
+export function syncCodexHistoryProvider(provider: CodexHistoryProvider, stateDbPath = STATE_DB_PATH, backupPath = HISTORY_BACKUP_PATH): CodexHistorySyncResult {
   if (!existsSync(stateDbPath)) return { rows: 0, files: 0 };
   if (provider === "openai") return restoreCodexHistoryProvider(stateDbPath, backupPath);
 
@@ -174,13 +180,29 @@ export function syncCodexHistoryProvider(provider: CodexHistoryProvider, stateDb
   }
 }
 
-function restoreCodexHistoryProvider(stateDbPath: string, backupPath: string): { rows: number; files: number } {
+function countAmbiguousOpencodexInteractiveRows(db: Database): number {
+  const placeholders = RESUMABLE_SOURCES.map(() => "?").join(",");
+  const row = db.query<{ n: number }, string[]>(`
+    SELECT COUNT(*) AS n
+    FROM threads
+    WHERE model_provider = 'opencodex'
+      AND source IN (${placeholders})
+      AND trim(coalesce(first_user_message, '')) != ''
+  `).get(...RESUMABLE_SOURCES);
+  return Number(row?.n ?? 0);
+}
+
+function restoreCodexHistoryProvider(stateDbPath: string, backupPath: string): CodexHistorySyncResult {
   const manifest = readBackup(backupPath);
   const entries = Object.values(manifest.entries);
-  if (entries.length === 0) return { rows: 0, files: 0 };
 
   const db = new Database(stateDbPath);
   try {
+    if (entries.length === 0) {
+      const legacyRows = countAmbiguousOpencodexInteractiveRows(db);
+      return legacyRows > 0 ? { rows: 0, files: 0, legacyRows } : { rows: 0, files: 0 };
+    }
+
     let files = 0;
     for (const entry of entries) {
       try {
@@ -205,6 +227,43 @@ function restoreCodexHistoryProvider(stateDbPath: string, backupPath: string): {
     restore();
     writeBackup(backupPath, { version: 1, entries: {} });
     return { rows: entries.length, files };
+  } finally {
+    db.close();
+  }
+}
+
+export function restoreLegacyOpenaiHistory(stateDbPath = STATE_DB_PATH): { rows: number; files: number } {
+  if (!existsSync(stateDbPath)) return { rows: 0, files: 0 };
+  const db = new Database(stateDbPath);
+  try {
+    const placeholders = RESUMABLE_SOURCES.map(() => "?").join(",");
+    const rows = db.query<ThreadRow, string[]>(`
+      SELECT id, rollout_path, model_provider, source, has_user_event
+      FROM threads
+      WHERE model_provider = 'opencodex'
+        AND source IN (${placeholders})
+        AND trim(coalesce(first_user_message, '')) != ''
+    `).all(...RESUMABLE_SOURCES);
+
+    let files = 0;
+    for (const row of rows) {
+      try {
+        if (updateSessionMeta(row.rollout_path, { provider: "openai" })) files++;
+      } catch {
+        /* explicit recovery should continue even if an old rollout is missing */
+      }
+    }
+
+    const restore = db.transaction(() => {
+      const update = db.query(`
+        UPDATE threads
+        SET model_provider = 'openai'
+        WHERE id = ?
+      `);
+      for (const row of rows) update.run(row.id);
+    });
+    restore();
+    return { rows: rows.length, files };
   } finally {
     db.close();
   }

--- a/src/codex-history-provider.ts
+++ b/src/codex-history-provider.ts
@@ -13,7 +13,7 @@ type CodexHistoryProvider = "openai" | "opencodex";
 export interface CodexHistorySyncResult {
   rows: number;
   files: number;
-  legacyRows?: number;
+  ejectedRows?: number;
 }
 
 interface ThreadRow {
@@ -35,6 +35,12 @@ interface BackupEntry {
 interface BackupManifest {
   version: 1;
   entries: Record<string, BackupEntry>;
+}
+
+interface NativeRestoreTarget {
+  modelProvider: string;
+  source: string;
+  hasUserEvent: number;
 }
 
 function readBackup(path: string): BackupManifest {
@@ -103,6 +109,57 @@ function updateSessionMeta(path: string, patch: { provider?: string; source?: st
   writeFileSync(path, `${JSON.stringify(record)}${rest}`, "utf8");
   utimesSync(path, stat.atime, stat.mtime);
   return true;
+}
+
+function toNativeRestoreTarget(entry: BackupEntry): NativeRestoreTarget {
+  if (entry.modelProvider !== "opencodex") {
+    return {
+      modelProvider: entry.modelProvider,
+      source: entry.source,
+      hasUserEvent: entry.hasUserEvent,
+    };
+  }
+  return {
+    modelProvider: "openai",
+    source: entry.source === "exec" ? "cli" : entry.source,
+    hasUserEvent: 1,
+  };
+}
+
+function ejectRemainingOpencodexHistory(db: Database): { rows: number; files: number } {
+  const rows = db
+    .query<ThreadRow, []>(`
+      SELECT id, rollout_path, model_provider, source, has_user_event
+      FROM threads
+      WHERE model_provider = 'opencodex'
+        AND trim(coalesce(first_user_message, '')) != ''
+    `)
+    .all();
+
+  let files = 0;
+  for (const row of rows) {
+    try {
+      if (updateSessionMeta(row.rollout_path, {
+        provider: "openai",
+        source: row.source === "exec" ? "cli" : undefined,
+      })) files++;
+    } catch {
+      /* native restore should continue even if an old rollout is missing */
+    }
+  }
+
+  const restore = db.transaction(() => {
+    const update = db.query(`
+      UPDATE threads
+      SET model_provider = 'openai',
+          source = CASE WHEN source = 'exec' THEN 'cli' ELSE source END,
+          has_user_event = 1
+      WHERE id = ?
+    `);
+    for (const row of rows) update.run(row.id);
+  });
+  restore();
+  return { rows: rows.length, files };
 }
 
 export function syncCodexHistoryProvider(provider: CodexHistoryProvider, stateDbPath = STATE_DB_PATH, backupPath = HISTORY_BACKUP_PATH): CodexHistorySyncResult {
@@ -180,18 +237,6 @@ export function syncCodexHistoryProvider(provider: CodexHistoryProvider, stateDb
   }
 }
 
-function countAmbiguousOpencodexInteractiveRows(db: Database): number {
-  const placeholders = RESUMABLE_SOURCES.map(() => "?").join(",");
-  const row = db.query<{ n: number }, string[]>(`
-    SELECT COUNT(*) AS n
-    FROM threads
-    WHERE model_provider = 'opencodex'
-      AND source IN (${placeholders})
-      AND trim(coalesce(first_user_message, '')) != ''
-  `).get(...RESUMABLE_SOURCES);
-  return Number(row?.n ?? 0);
-}
-
 function restoreCodexHistoryProvider(stateDbPath: string, backupPath: string): CodexHistorySyncResult {
   const manifest = readBackup(backupPath);
   const entries = Object.values(manifest.entries);
@@ -199,14 +244,15 @@ function restoreCodexHistoryProvider(stateDbPath: string, backupPath: string): C
   const db = new Database(stateDbPath);
   try {
     if (entries.length === 0) {
-      const legacyRows = countAmbiguousOpencodexInteractiveRows(db);
-      return legacyRows > 0 ? { rows: 0, files: 0, legacyRows } : { rows: 0, files: 0 };
+      const ejected = ejectRemainingOpencodexHistory(db);
+      return ejected.rows > 0 ? { rows: 0, files: ejected.files, ejectedRows: ejected.rows } : { rows: 0, files: 0 };
     }
 
     let files = 0;
     for (const entry of entries) {
+      const target = toNativeRestoreTarget(entry);
       try {
-        if (updateSessionMeta(entry.rolloutPath, { provider: entry.modelProvider, source: entry.source })) files++;
+        if (updateSessionMeta(entry.rolloutPath, { provider: target.modelProvider, source: target.source })) files++;
       } catch {
         /* best-effort; keep DB restore moving even if one rollout disappeared */
       }
@@ -221,12 +267,16 @@ function restoreCodexHistoryProvider(stateDbPath: string, backupPath: string): C
         WHERE id = ?
       `);
       for (const entry of entries) {
-        update.run(entry.modelProvider, entry.source, entry.hasUserEvent, entry.id);
+        const target = toNativeRestoreTarget(entry);
+        update.run(target.modelProvider, target.source, target.hasUserEvent, entry.id);
       }
     });
     restore();
     writeBackup(backupPath, { version: 1, entries: {} });
-    return { rows: entries.length, files };
+    const ejected = ejectRemainingOpencodexHistory(db);
+    return ejected.rows > 0
+      ? { rows: entries.length, files: files + ejected.files, ejectedRows: ejected.rows }
+      : { rows: entries.length, files };
   } finally {
     db.close();
   }
@@ -236,34 +286,7 @@ export function restoreLegacyOpenaiHistory(stateDbPath = STATE_DB_PATH): { rows:
   if (!existsSync(stateDbPath)) return { rows: 0, files: 0 };
   const db = new Database(stateDbPath);
   try {
-    const placeholders = RESUMABLE_SOURCES.map(() => "?").join(",");
-    const rows = db.query<ThreadRow, string[]>(`
-      SELECT id, rollout_path, model_provider, source, has_user_event
-      FROM threads
-      WHERE model_provider = 'opencodex'
-        AND source IN (${placeholders})
-        AND trim(coalesce(first_user_message, '')) != ''
-    `).all(...RESUMABLE_SOURCES);
-
-    let files = 0;
-    for (const row of rows) {
-      try {
-        if (updateSessionMeta(row.rollout_path, { provider: "openai" })) files++;
-      } catch {
-        /* explicit recovery should continue even if an old rollout is missing */
-      }
-    }
-
-    const restore = db.transaction(() => {
-      const update = db.query(`
-        UPDATE threads
-        SET model_provider = 'openai'
-        WHERE id = ?
-      `);
-      for (const row of rows) update.run(row.id);
-    });
-    restore();
-    return { rows: rows.length, files };
+    return ejectRemainingOpencodexHistory(db);
   } finally {
     db.close();
   }

--- a/src/codex-history-provider.ts
+++ b/src/codex-history-provider.ts
@@ -1,9 +1,11 @@
-import { existsSync, readFileSync, statSync, utimesSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync, utimesSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { Database } from "bun:sqlite";
 import { CODEX_HOME } from "./codex-paths";
+import { atomicWriteFile, getConfigDir } from "./config";
 
 const STATE_DB_PATH = join(CODEX_HOME, "state_5.sqlite");
+const HISTORY_BACKUP_PATH = join(getConfigDir(), "codex-history-backup.json");
 const RESUMABLE_SOURCES = ["cli", "vscode"] as const;
 
 type CodexHistoryProvider = "openai" | "opencodex";
@@ -11,9 +13,58 @@ type CodexHistoryProvider = "openai" | "opencodex";
 interface ThreadRow {
   id: string;
   rollout_path: string;
+  model_provider: string;
+  source: string;
+  has_user_event: number;
 }
 
-function updateSessionMetaProvider(path: string, provider: CodexHistoryProvider): boolean {
+interface BackupEntry {
+  id: string;
+  rolloutPath: string;
+  modelProvider: string;
+  source: string;
+  hasUserEvent: number;
+}
+
+interface BackupManifest {
+  version: 1;
+  entries: Record<string, BackupEntry>;
+}
+
+function readBackup(path: string): BackupManifest {
+  if (!existsSync(path)) return { version: 1, entries: {} };
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<BackupManifest>;
+    if (parsed.version !== 1 || !parsed.entries || typeof parsed.entries !== "object") {
+      return { version: 1, entries: {} };
+    }
+    return { version: 1, entries: parsed.entries };
+  } catch {
+    return { version: 1, entries: {} };
+  }
+}
+
+function writeBackup(path: string, manifest: BackupManifest): void {
+  if (Object.keys(manifest.entries).length === 0) {
+    if (existsSync(path)) unlinkSync(path);
+    return;
+  }
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  atomicWriteFile(path, JSON.stringify(manifest, null, 2) + "\n");
+}
+
+function rememberOriginal(manifest: BackupManifest, row: ThreadRow): void {
+  if (manifest.entries[row.id]) return;
+  manifest.entries[row.id] = {
+    id: row.id,
+    rolloutPath: row.rollout_path,
+    modelProvider: row.model_provider,
+    source: row.source,
+    hasUserEvent: Number(row.has_user_event) || 0,
+  };
+}
+
+function updateSessionMeta(path: string, patch: { provider?: string; source?: string }): boolean {
   if (!path || !existsSync(path)) return false;
   const stat = statSync(path);
   const raw = readFileSync(path, "utf8");
@@ -29,57 +80,131 @@ function updateSessionMetaProvider(path: string, provider: CodexHistoryProvider)
   }
 
   if (!parsed || typeof parsed !== "object") return false;
-  const record = parsed as { type?: unknown; payload?: { model_provider?: unknown } };
+  const record = parsed as { type?: unknown; payload?: { model_provider?: unknown; source?: unknown } };
   if (record.type !== "session_meta" || !record.payload || typeof record.payload !== "object") return false;
-  if (record.payload.model_provider === provider) return false;
 
-  record.payload.model_provider = provider;
+  let changed = false;
+  if (patch.provider !== undefined && record.payload.model_provider !== patch.provider) {
+    record.payload.model_provider = patch.provider;
+    changed = true;
+  }
+  if (patch.source !== undefined && record.payload.source !== patch.source) {
+    record.payload.source = patch.source;
+    changed = true;
+  }
+  if (!changed) return false;
+
   writeFileSync(path, `${JSON.stringify(record)}${rest}`, "utf8");
   utimesSync(path, stat.atime, stat.mtime);
   return true;
 }
 
-export function syncCodexHistoryProvider(provider: CodexHistoryProvider, stateDbPath = STATE_DB_PATH): { rows: number; files: number } {
+export function syncCodexHistoryProvider(provider: CodexHistoryProvider, stateDbPath = STATE_DB_PATH, backupPath = HISTORY_BACKUP_PATH): { rows: number; files: number } {
   if (!existsSync(stateDbPath)) return { rows: 0, files: 0 };
-  const from = provider === "opencodex" ? "openai" : "opencodex";
+  if (provider === "openai") return restoreCodexHistoryProvider(stateDbPath, backupPath);
+
   const db = new Database(stateDbPath);
   try {
     const placeholders = RESUMABLE_SOURCES.map(() => "?").join(",");
-    const rows = db
+    const openaiRows = db
       .query<ThreadRow, string[]>(`
-        SELECT id, rollout_path
+        SELECT id, rollout_path, model_provider, source, has_user_event
         FROM threads
-        WHERE model_provider = ?
+        WHERE model_provider = 'openai'
           AND source IN (${placeholders})
       `)
-      .all(from, ...RESUMABLE_SOURCES);
+      .all(...RESUMABLE_SOURCES);
+    const execRows = db
+      .query<ThreadRow, []>(`
+        SELECT id, rollout_path, model_provider, source, has_user_event
+        FROM threads
+        WHERE model_provider = 'opencodex'
+          AND source = 'exec'
+          AND trim(coalesce(first_user_message, '')) != ''
+      `)
+      .all();
+
+    const manifest = readBackup(backupPath);
+    for (const row of [...openaiRows, ...execRows]) rememberOriginal(manifest, row);
+    writeBackup(backupPath, manifest);
 
     let files = 0;
-    for (const row of rows) {
+    for (const row of openaiRows) {
       try {
-        if (updateSessionMetaProvider(row.rollout_path, provider)) files++;
+        if (updateSessionMeta(row.rollout_path, { provider: "opencodex" })) files++;
+      } catch {
+        /* best-effort; keep DB migration moving even if one old rollout is malformed */
+      }
+    }
+    for (const row of execRows) {
+      try {
+        if (updateSessionMeta(row.rollout_path, { source: "cli" })) files++;
       } catch {
         /* best-effort; keep DB migration moving even if one old rollout is malformed */
       }
     }
 
     const update = db.transaction(() => {
-      db.query(`
+      const markUserEvent = db.query(`
         UPDATE threads
         SET has_user_event = 1
-        WHERE source IN (${placeholders})
+        WHERE id = ?
           AND trim(coalesce(first_user_message, '')) != ''
+      `);
+      for (const row of [...openaiRows, ...execRows]) markUserEvent.run(row.id);
+      db.query(`
+        UPDATE threads
+        SET model_provider = 'opencodex'
+        WHERE model_provider = 'openai'
+          AND source IN (${placeholders})
       `).run(...RESUMABLE_SOURCES);
       db.query(`
         UPDATE threads
-        SET model_provider = ?
-        WHERE model_provider = ?
-          AND source IN (${placeholders})
-      `).run(provider, from, ...RESUMABLE_SOURCES);
+        SET source = 'cli'
+        WHERE model_provider = 'opencodex'
+          AND source = 'exec'
+          AND trim(coalesce(first_user_message, '')) != ''
+      `).run();
     });
     update();
 
-    return { rows: rows.length, files };
+    return { rows: openaiRows.length + execRows.length, files };
+  } finally {
+    db.close();
+  }
+}
+
+function restoreCodexHistoryProvider(stateDbPath: string, backupPath: string): { rows: number; files: number } {
+  const manifest = readBackup(backupPath);
+  const entries = Object.values(manifest.entries);
+  if (entries.length === 0) return { rows: 0, files: 0 };
+
+  const db = new Database(stateDbPath);
+  try {
+    let files = 0;
+    for (const entry of entries) {
+      try {
+        if (updateSessionMeta(entry.rolloutPath, { provider: entry.modelProvider, source: entry.source })) files++;
+      } catch {
+        /* best-effort; keep DB restore moving even if one rollout disappeared */
+      }
+    }
+
+    const restore = db.transaction(() => {
+      const update = db.query(`
+        UPDATE threads
+        SET model_provider = ?,
+            source = ?,
+            has_user_event = ?
+        WHERE id = ?
+      `);
+      for (const entry of entries) {
+        update.run(entry.modelProvider, entry.source, entry.hasUserEvent, entry.id);
+      }
+    });
+    restore();
+    writeBackup(backupPath, { version: 1, entries: {} });
+    return { rows: entries.length, files };
   } finally {
     db.close();
   }

--- a/src/codex-inject.ts
+++ b/src/codex-inject.ts
@@ -323,7 +323,11 @@ export function restoreNativeCodex(): { success: boolean; message: string } {
   const msg = cat.removed > 0
     ? `${cfg.message} Catalog restored to ${cat.kept} native model(s) (dropped ${cat.removed} proxy-routed).`
     : cfg.message;
-  const historyMsg = history.rows > 0 ? ` Resume history restored from opencodex backup (${history.rows} thread(s)).` : "";
+  const historyMsg = history.rows > 0
+    ? ` Resume history restored from opencodex backup (${history.rows} thread(s)).`
+    : history.legacyRows
+      ? ` ${history.legacyRows} opencodex interactive thread(s) have no restore backup and were left unchanged; if these came from the old syncResumeHistory remap, run: ocx recover-history --legacy-openai`
+      : "";
   return { success: cfg.success, message: `${msg}${historyMsg}` };
 }
 

--- a/src/codex-inject.ts
+++ b/src/codex-inject.ts
@@ -71,6 +71,21 @@ function stripRootContextWindowOverrides(content: string): string {
     .join("\n");
 }
 
+function stripRootRoutedModel(content: string): string {
+  const lines = content.split("\n");
+  const firstTable = lines.findIndex(l => /^\s*\[/.test(l));
+  return lines
+    .filter((line, i) => {
+      const isRoot = firstTable === -1 || i < firstTable;
+      if (!isRoot) return true;
+      const m = line.match(/^\s*model\s*=\s*("(?:\\.|[^"])*"|'[^']*')\s*$/);
+      if (!m) return true;
+      const model = parseTomlString(m[1]);
+      return !model?.includes("/");
+    })
+    .join("\n");
+}
+
 /**
  * Insert `model_provider = "opencodex"` at the document ROOT — immediately before the first table
  * header (TOML root keys must precede all tables). If there are no tables, append it to the root body.
@@ -285,6 +300,7 @@ export function stripOpencodexConfig(content: string): string {
   // must match the detection regex above, or a detected line could survive un-removed.
   out = out.split("\n").filter(l => !/^\s*model_provider\s*=\s*"opencodex"\s*$/.test(l)).join("\n");
   out = stripRootContextWindowOverrides(out);
+  out = stripRootRoutedModel(out);
   out = stripOpencodexCatalogPath(out);
   return out.replace(/\n{3,}/g, "\n\n").trimEnd() + "\n";
 }
@@ -301,7 +317,7 @@ export function removeCodexConfig(): { success: boolean; message: string } {
   const had = hasOpencodexRouting(content);
   if (had) {
     atomicWriteFile(CODEX_CONFIG_PATH, stripOpencodexConfig(content));
-  } else if (stripRootContextWindowOverrides(content) !== content) {
+  } else if (stripOpencodexConfig(content) !== content) {
     atomicWriteFile(CODEX_CONFIG_PATH, stripOpencodexConfig(content));
   }
   if (existsSync(CODEX_PROFILE_PATH)) unlinkSync(CODEX_PROFILE_PATH);
@@ -325,8 +341,8 @@ export function restoreNativeCodex(): { success: boolean; message: string } {
     : cfg.message;
   const historyMsg = history.rows > 0
     ? ` Resume history restored from opencodex backup (${history.rows} thread(s)).`
-    : history.legacyRows
-      ? ` ${history.legacyRows} opencodex interactive thread(s) have no restore backup and were left unchanged; if these came from the old syncResumeHistory remap, run: ocx recover-history --legacy-openai`
+    : history.ejectedRows
+      ? ` ${history.ejectedRows} opencodex history thread(s) were ejected to openai so native Codex can resume them.`
       : "";
   return { success: cfg.success, message: `${msg}${historyMsg}` };
 }

--- a/src/codex-inject.ts
+++ b/src/codex-inject.ts
@@ -236,9 +236,9 @@ export async function injectCodexConfig(port: number, config?: OcxConfig, option
   const catalogMessage = catalogPath
     ? `  Codex model catalog: ${catalogPath}\n`
     : `  Codex model catalog not injected because no opencodex catalog file exists yet.\n`;
-  const historyMessage = history.rows > 0
+  const historyMessage = config?.syncResumeHistory === true
     ? `  Codex resume history: ${history.rows} thread(s) mapped to opencodex.\n`
-    : "";
+    : `  Codex resume history: left unchanged. Existing OpenAI project chats may be hidden while opencodex is active; set syncResumeHistory=true to remap them.\n`;
   return {
     success: true,
     message: `Injected opencodex as default provider into Codex config.\n` +

--- a/src/codex-inject.ts
+++ b/src/codex-inject.ts
@@ -229,7 +229,9 @@ export async function injectCodexConfig(port: number, config?: OcxConfig, option
 
   writeFileSync(CODEX_CONFIG_PATH, content, "utf-8");
   writeFileSync(CODEX_PROFILE_PATH, buildProfileFile(port, catalogPath), "utf-8");
-  const history = syncCodexHistoryProvider("opencodex");
+  const history = config?.syncResumeHistory === true
+    ? syncCodexHistoryProvider("opencodex")
+    : { rows: 0, files: 0 };
 
   const catalogMessage = catalogPath
     ? `  Codex model catalog: ${catalogPath}\n`

--- a/src/codex-inject.ts
+++ b/src/codex-inject.ts
@@ -237,8 +237,8 @@ export async function injectCodexConfig(port: number, config?: OcxConfig, option
     ? `  Codex model catalog: ${catalogPath}\n`
     : `  Codex model catalog not injected because no opencodex catalog file exists yet.\n`;
   const historyMessage = config?.syncResumeHistory === true
-    ? `  Codex resume history: ${history.rows} thread(s) mapped to opencodex.\n`
-    : `  Codex resume history: left unchanged. Existing OpenAI project chats may be hidden while opencodex is active; set syncResumeHistory=true to remap them.\n`;
+    ? `  Codex resume history: ${history.rows} thread(s) made visible for opencodex; originals backed up for restore.\n`
+    : `  Codex resume history: left unchanged. Existing OpenAI and opencodex exec project chats may be hidden while opencodex is active; set syncResumeHistory=true to enable the reversible compatibility remap.\n`;
   return {
     success: true,
     message: `Injected opencodex as default provider into Codex config.\n` +
@@ -323,7 +323,7 @@ export function restoreNativeCodex(): { success: boolean; message: string } {
   const msg = cat.removed > 0
     ? `${cfg.message} Catalog restored to ${cat.kept} native model(s) (dropped ${cat.removed} proxy-routed).`
     : cfg.message;
-  const historyMsg = history.rows > 0 ? ` Resume history restored to openai (${history.rows} thread(s)).` : "";
+  const historyMsg = history.rows > 0 ? ` Resume history restored from opencodex backup (${history.rows} thread(s)).` : "";
   return { success: cfg.success, message: `${msg}${historyMsg}` };
 }
 

--- a/src/oauth/key-providers.ts
+++ b/src/oauth/key-providers.ts
@@ -31,6 +31,7 @@ export interface KeyLoginProvider {
   noPenaltyModels?: string[];
   autoToolChoiceOnlyModels?: string[];
   preserveReasoningContentModels?: string[];
+  escapeBuiltinToolNames?: boolean;
 }
 
 export const KEY_LOGIN_PROVIDERS: Record<string, KeyLoginProvider> = deriveKeyLoginMap();
@@ -57,6 +58,7 @@ export function enrichProviderFromCatalog(name: string, prov: OcxProviderConfig)
   if (!prov.noPenaltyModels && e.noPenaltyModels) prov.noPenaltyModels = [...e.noPenaltyModels];
   if (!prov.autoToolChoiceOnlyModels && e.autoToolChoiceOnlyModels) prov.autoToolChoiceOnlyModels = [...e.autoToolChoiceOnlyModels];
   if (!prov.preserveReasoningContentModels && e.preserveReasoningContentModels) prov.preserveReasoningContentModels = [...e.preserveReasoningContentModels];
+  if (prov.escapeBuiltinToolNames === undefined && e.escapeBuiltinToolNames !== undefined) prov.escapeBuiltinToolNames = e.escapeBuiltinToolNames;
 }
 
 
@@ -76,10 +78,31 @@ export function listKeyLoginProviders(): Array<{ id: string } & KeyLoginProvider
   return Object.entries(KEY_LOGIN_PROVIDERS).map(([id, p]) => ({ id, ...p }));
 }
 
-/** Best-effort key validation: GET {baseUrl}/models with the key. Returns true/false/unknown. */
-export async function validateApiKey(baseUrl: string, key: string): Promise<boolean | "unknown"> {
+/** Best-effort key validation. Returns true/false/unknown; never persists the key itself. */
+export async function validateApiKey(provider: KeyLoginProvider, key: string): Promise<boolean | "unknown"> {
   try {
-    const res = await fetch(`${baseUrl}/models`, {
+    if (provider.adapter === "anthropic") {
+      const base = provider.baseUrl.replace(/\/v1\/?$/, "");
+      const res = await fetch(`${base}/v1/messages`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "anthropic-version": "2023-06-01",
+          "x-api-key": key,
+        },
+        body: JSON.stringify({
+          model: provider.defaultModel ?? "claude-sonnet-4-6",
+          max_tokens: 1,
+          messages: [{ role: "user", content: "ping" }],
+        }),
+        signal: AbortSignal.timeout(8000),
+      });
+      if (res.ok) return true;
+      if (res.status === 401 || res.status === 403) return false;
+      return "unknown";
+    }
+
+    const res = await fetch(`${provider.baseUrl}/models`, {
       headers: { Authorization: `Bearer ${key}` },
       signal: AbortSignal.timeout(8000),
     });

--- a/src/oauth/login-cli.ts
+++ b/src/oauth/login-cli.ts
@@ -2,7 +2,8 @@ import * as readline from "node:readline";
 import { openUrl } from "../open-url";
 import { loadConfig, readPid, saveConfig } from "../config";
 import { OAUTH_PROVIDERS, runLogin } from "./index";
-import { KEY_LOGIN_PROVIDERS, isKeyLoginProvider, validateApiKey } from "./key-providers";
+import { KEY_LOGIN_PROVIDERS, isKeyLoginProvider, validateApiKey, type KeyLoginProvider } from "./key-providers";
+import type { OcxProviderConfig } from "../types";
 
 /** Push the new provider into a running proxy's live config so it routes without a restart. */
 async function notifyRunningProxy(name: string, provider: unknown): Promise<void> {
@@ -51,6 +52,28 @@ async function handleOAuthLogin(name: string): Promise<void> {
   console.log(`\n✅ Logged in to ${name}. Try: ocx sync`);
 }
 
+export function providerConfigFromKeyLoginProvider(def: KeyLoginProvider, key: string): OcxProviderConfig {
+  return {
+    adapter: def.adapter,
+    baseUrl: def.baseUrl,
+    apiKey: key,
+    ...(def.defaultModel ? { defaultModel: def.defaultModel } : {}),
+    ...(def.models ? { models: [...def.models] } : {}),
+    ...(def.reasoningEfforts ? { reasoningEfforts: [...def.reasoningEfforts] } : {}),
+    ...(def.modelReasoningEfforts ? { modelReasoningEfforts: cloneRecordOfArrays(def.modelReasoningEfforts) } : {}),
+    ...(def.reasoningEffortMap ? { reasoningEffortMap: { ...def.reasoningEffortMap } } : {}),
+    ...(def.modelReasoningEffortMap ? { modelReasoningEffortMap: cloneNestedRecord(def.modelReasoningEffortMap) } : {}),
+    ...(def.noVisionModels ? { noVisionModels: [...def.noVisionModels] } : {}),
+    ...(def.noReasoningModels ? { noReasoningModels: [...def.noReasoningModels] } : {}),
+    ...(def.noTemperatureModels ? { noTemperatureModels: [...def.noTemperatureModels] } : {}),
+    ...(def.noTopPModels ? { noTopPModels: [...def.noTopPModels] } : {}),
+    ...(def.noPenaltyModels ? { noPenaltyModels: [...def.noPenaltyModels] } : {}),
+    ...(def.autoToolChoiceOnlyModels ? { autoToolChoiceOnlyModels: [...def.autoToolChoiceOnlyModels] } : {}),
+    ...(def.preserveReasoningContentModels ? { preserveReasoningContentModels: [...def.preserveReasoningContentModels] } : {}),
+    ...(def.escapeBuiltinToolNames !== undefined ? { escapeBuiltinToolNames: def.escapeBuiltinToolNames } : {}),
+  };
+}
+
 async function handleKeyLogin(name: string): Promise<void> {
   const def = KEY_LOGIN_PROVIDERS[name];
   console.log(`\n🔑 ${def.label} — opening ${def.dashboardUrl} so you can create/copy an API key...`);
@@ -63,22 +86,24 @@ async function handleKeyLogin(name: string): Promise<void> {
     process.exit(1);
   }
   process.stdout.write("   validating… ");
-  const valid = await validateApiKey(def.baseUrl, key);
+  const valid = await validateApiKey(def, key);
   console.log(valid === true ? "valid ✅" : valid === false ? "INVALID ❌" : "couldn't validate (may still work)");
   if (valid === false) {
     console.error("Provider rejected the key. Not saved.");
     process.exit(1);
   }
-  const provider = {
-    adapter: def.adapter,
-    baseUrl: def.baseUrl,
-    apiKey: key,
-    ...(def.defaultModel ? { defaultModel: def.defaultModel } : {}),
-    ...(def.models ? { models: def.models } : {}),
-  };
+  const provider = providerConfigFromKeyLoginProvider(def, key);
   const config = loadConfig();
   config.providers[name] = provider;
   saveConfig(config);
   await notifyRunningProxy(name, provider);
   console.log(`✅ ${def.label} added. Try: ocx sync`);
+}
+
+function cloneRecordOfArrays(input: Record<string, string[]>): Record<string, string[]> {
+  return Object.fromEntries(Object.entries(input).map(([key, value]) => [key, [...value]]));
+}
+
+function cloneNestedRecord(input: Record<string, Record<string, string>>): Record<string, Record<string, string>> {
+  return Object.fromEntries(Object.entries(input).map(([key, value]) => [key, { ...value }]));
 }

--- a/src/providers/derive.ts
+++ b/src/providers/derive.ts
@@ -19,6 +19,7 @@ export interface DerivedKeyLoginProvider {
   noPenaltyModels?: string[];
   autoToolChoiceOnlyModels?: string[];
   preserveReasoningContentModels?: string[];
+  escapeBuiltinToolNames?: boolean;
 }
 
 export interface DerivedInitProvider {
@@ -73,6 +74,7 @@ export function providerConfigSeed(entry: ProviderRegistryEntry): OcxProviderCon
     ...(entry.noPenaltyModels ? { noPenaltyModels: [...entry.noPenaltyModels] } : {}),
     ...(entry.autoToolChoiceOnlyModels ? { autoToolChoiceOnlyModels: [...entry.autoToolChoiceOnlyModels] } : {}),
     ...(entry.preserveReasoningContentModels ? { preserveReasoningContentModels: [...entry.preserveReasoningContentModels] } : {}),
+    ...(entry.escapeBuiltinToolNames !== undefined ? { escapeBuiltinToolNames: entry.escapeBuiltinToolNames } : {}),
   };
 }
 
@@ -99,6 +101,7 @@ export function deriveKeyLoginMap(): Record<string, DerivedKeyLoginProvider> {
       ...(entry.noPenaltyModels ? { noPenaltyModels: [...entry.noPenaltyModels] } : {}),
       ...(entry.autoToolChoiceOnlyModels ? { autoToolChoiceOnlyModels: [...entry.autoToolChoiceOnlyModels] } : {}),
       ...(entry.preserveReasoningContentModels ? { preserveReasoningContentModels: [...entry.preserveReasoningContentModels] } : {}),
+      ...(entry.escapeBuiltinToolNames !== undefined ? { escapeBuiltinToolNames: entry.escapeBuiltinToolNames } : {}),
     };
   }
   return out;

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -25,6 +25,7 @@ export interface ProviderRegistryEntry {
   noPenaltyModels?: string[];
   autoToolChoiceOnlyModels?: string[];
   preserveReasoningContentModels?: string[];
+  escapeBuiltinToolNames?: boolean;
   oauthId?: string;
   jawcodeBundle?: string;
   extraMetadataAliases?: string[];
@@ -36,7 +37,7 @@ export type ProviderConfigSeed = Pick<
   "adapter" | "baseUrl" | "authMode" | "defaultModel" | "models"
   | "reasoningEfforts" | "modelReasoningEfforts" | "reasoningEffortMap" | "modelReasoningEffortMap"
   | "noVisionModels" | "noReasoningModels" | "noTemperatureModels" | "noTopPModels" | "noPenaltyModels"
-  | "autoToolChoiceOnlyModels" | "preserveReasoningContentModels"
+  | "autoToolChoiceOnlyModels" | "preserveReasoningContentModels" | "escapeBuiltinToolNames"
 >;
 
 
@@ -58,6 +59,27 @@ const NEURALWATT_REASONING_HISTORY_MODELS = [
   "moonshotai/Kimi-K2.5", "kimi-k2.6", "kimi-k2.7-code",
   "qwen3.5-397b", "qwen3.6-35b",
 ];
+const UMANS_MODELS = [
+  "umans-coder",
+  "umans-kimi-k2.7",
+  "umans-kimi-k2.6",
+  "umans-flash",
+  "umans-glm-5.2",
+  "umans-glm-5.1",
+  "umans-qwen3.6-35b-a3b",
+];
+const UMANS_REASONING_EFFORTS = ["low", "medium", "high", "xhigh"];
+const UMANS_GLM_REASONING_EFFORTS = ["high", "xhigh"];
+const UMANS_GLM_REASONING_MAP: Record<string, string> = {
+  none: "high",
+  minimal: "high",
+  low: "high",
+  medium: "high",
+  high: "high",
+  xhigh: "max",
+  max: "max",
+};
+const UMANS_TEXT_ONLY_MODELS = ["umans-glm-5.2", "umans-glm-5.1"];
 
 export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
   {
@@ -119,6 +141,33 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     preserveReasoningContentModels: KIMI_THINKING_MODELS,
   },
   { id: "openai-apikey", label: "OpenAI (API key)", adapter: "openai-responses", baseUrl: "https://api.openai.com/v1", authKind: "key", featured: true, dashboardUrl: "https://platform.openai.com/api-keys", defaultModel: "gpt-5.5" },
+  {
+    id: "umans",
+    label: "Umans AI Coding Plan",
+    adapter: "anthropic",
+    baseUrl: "https://api.code.umans.ai",
+    authKind: "key",
+    featured: true,
+    dashboardUrl: "https://app.umans.ai/billing",
+    defaultModel: "umans-coder",
+    models: UMANS_MODELS,
+    note: "Coding plan via Anthropic Messages",
+    modelReasoningEfforts: {
+      "umans-coder": UMANS_REASONING_EFFORTS,
+      "umans-kimi-k2.7": UMANS_REASONING_EFFORTS,
+      "umans-kimi-k2.6": UMANS_REASONING_EFFORTS,
+      "umans-flash": ["low", "medium", "high"],
+      "umans-glm-5.2": UMANS_GLM_REASONING_EFFORTS,
+      "umans-glm-5.1": UMANS_GLM_REASONING_EFFORTS,
+      "umans-qwen3.6-35b-a3b": ["low", "medium", "high"],
+    },
+    modelReasoningEffortMap: {
+      "umans-glm-5.2": UMANS_GLM_REASONING_MAP,
+      "umans-glm-5.1": UMANS_GLM_REASONING_MAP,
+    },
+    noVisionModels: UMANS_TEXT_ONLY_MODELS,
+    escapeBuiltinToolNames: true,
+  },
   {
     id: "opencode-go", label: "opencode go", adapter: "openai-chat", baseUrl: "https://opencode.ai/zen/go/v1",
     authKind: "key", featured: true, dashboardUrl: "https://opencode.ai/auth", defaultModel: "kimi-k2.7-code",

--- a/src/types.ts
+++ b/src/types.ts
@@ -265,6 +265,8 @@ export interface OcxProviderConfig {
   autoToolChoiceOnlyModels?: string[];
   /** Model ids that expect prior assistant `reasoning_content` to be preserved in chat history. */
   preserveReasoningContentModels?: string[];
+  /** Anthropic-compatible gateways that need custom tool names escaped on the wire. */
+  escapeBuiltinToolNames?: boolean;
   /**
    * Model ids that do NOT accept image inputs. The proxy gives them "eyes" via the vision sidecar:
    * attached images are described by a gpt vision model and replaced with text before the call.

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,8 +188,9 @@ export interface OcxConfig {
   /** Auto-start/sync the proxy from the Codex shim before launching Codex. Default true. */
   codexAutoStart?: boolean;
   /**
-   * Rewrite existing Codex resume-history threads from openai to opencodex while the proxy is active.
-   * Disabled by default because Codex desktop may hide project chats whose stored provider is not openai.
+   * Compatibility mode: rewrite existing Codex resume-history threads from openai to opencodex
+   * while the proxy is active so Codex App can show old project chats under the active provider.
+   * Disabled by default because it mutates Codex's local thread index.
    */
   syncResumeHistory?: boolean;
   /** Freshness window (ms) for the per-provider live `/models` cache. Defaults to 5 min. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,9 +188,10 @@ export interface OcxConfig {
   /** Auto-start/sync the proxy from the Codex shim before launching Codex. Default true. */
   codexAutoStart?: boolean;
   /**
-   * Compatibility mode: rewrite existing Codex resume-history threads from openai to opencodex
-   * while the proxy is active so Codex App can show old project chats under the active provider.
-   * Disabled by default because it mutates Codex's local thread index.
+   * Compatibility mode: temporarily rewrite Codex resume-history metadata while the proxy is active
+   * so Codex App can show old OpenAI chats and opencodex-created exec chats under its default
+   * interactive-source/provider filters. Disabled by default because it mutates Codex's local
+   * thread index; originals are backed up and restored by `ocx stop` / `ocx restore`.
    */
   syncResumeHistory?: boolean;
   /** Freshness window (ms) for the per-provider live `/models` cache. Defaults to 5 min. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -187,6 +187,11 @@ export interface OcxConfig {
   websockets?: boolean;
   /** Auto-start/sync the proxy from the Codex shim before launching Codex. Default true. */
   codexAutoStart?: boolean;
+  /**
+   * Rewrite existing Codex resume-history threads from openai to opencodex while the proxy is active.
+   * Disabled by default because Codex desktop may hide project chats whose stored provider is not openai.
+   */
+  syncResumeHistory?: boolean;
   /** Freshness window (ms) for the per-provider live `/models` cache. Defaults to 5 min. */
   modelCacheTtlMs?: number;
   /** Web-search sidecar: route web_search for non-OpenAI models through a gpt-mini via ChatGPT passthrough. */

--- a/tests/cli-help.test.ts
+++ b/tests/cli-help.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+const cliPath = join(repoRoot, "src", "cli.ts");
+
+describe("CLI subcommand help", () => {
+  test("restore --help prints usage without mutating Codex config", () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "ocx-help-"));
+    try {
+      const configPath = join(codexHome, "config.toml");
+      const before = [
+        'model_provider = "opencodex"',
+        "",
+        "[model_providers.opencodex]",
+        'base_url = "http://localhost:10100/v1"',
+        'wire_api = "responses"',
+        "",
+      ].join("\n");
+      writeFileSync(configPath, before, "utf8");
+
+      const result = spawnSync(process.execPath, [cliPath, "restore", "--help"], {
+        cwd: repoRoot,
+        env: { ...process.env, CODEX_HOME: codexHome },
+        encoding: "utf8",
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("Usage: ocx restore");
+      expect(result.stdout).not.toContain("Plain `codex` now runs natively");
+      expect(readFileSync(configPath, "utf8")).toBe(before);
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/cli-help.test.ts
+++ b/tests/cli-help.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -33,6 +33,28 @@ describe("CLI subcommand help", () => {
       expect(result.stdout).toContain("Usage: ocx restore");
       expect(result.stdout).not.toContain("Plain `codex` now runs natively");
       expect(readFileSync(configPath, "utf8")).toBe(before);
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  test("recover-history --help prints usage without opening history database", () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "ocx-help-"));
+    try {
+      const statePath = join(codexHome, "state_5.sqlite");
+
+      const result = spawnSync(process.execPath, [cliPath, "recover-history", "--help"], {
+        cwd: repoRoot,
+        env: { ...process.env, CODEX_HOME: codexHome },
+        encoding: "utf8",
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("Usage: ocx recover-history --legacy-openai");
+      expect(result.stdout).toContain("Explicitly recover pre-backup syncResumeHistory rows.");
+      expect(result.stdout).not.toContain("Recovered");
+      expect(result.stderr).toBe("");
+      expect(existsSync(statePath)).toBe(false);
     } finally {
       rmSync(codexHome, { recursive: true, force: true });
     }

--- a/tests/codex-history-provider.test.ts
+++ b/tests/codex-history-provider.test.ts
@@ -3,9 +3,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
-import { syncCodexHistoryProvider } from "../src/codex-history-provider";
+import { restoreLegacyOpenaiHistory, syncCodexHistoryProvider } from "../src/codex-history-provider";
 
-function makeFixture({ includeExec = false } = {}) {
+function makeFixture({ includeExec = false, includeLegacy = false } = {}) {
   const dir = join(tmpdir(), `ocx-history-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
   mkdirSync(dir, { recursive: true });
   const rollout = join(dir, "rollout.jsonl");
@@ -24,9 +24,18 @@ function makeFixture({ includeExec = false } = {}) {
     }),
     JSON.stringify({ type: "event_msg", timestamp: "2026-01-01T00:00:00.000Z", payload: { message: "y" } }),
   ].join("\n") + "\n");
+  const legacyRollout = join(dir, "legacy-rollout.jsonl");
+  writeFileSync(legacyRollout, [
+    JSON.stringify({
+      type: "session_meta",
+      payload: { id: "thread-3", model_provider: "opencodex", source: "cli", cwd: dir },
+    }),
+    JSON.stringify({ type: "event_msg", timestamp: "2026-01-01T00:00:00.000Z", payload: { message: "z" } }),
+  ].join("\n") + "\n");
   const mtime = new Date("2026-01-02T03:04:05.000Z");
   utimesSync(rollout, mtime, mtime);
   utimesSync(execRollout, mtime, mtime);
+  utimesSync(legacyRollout, mtime, mtime);
 
   const dbPath = join(dir, "state_5.sqlite");
   const backupPath = join(dir, "codex-history-backup.json");
@@ -51,8 +60,14 @@ function makeFixture({ includeExec = false } = {}) {
       VALUES ('thread-2', ?, 'opencodex', 'exec', 'hello from exec', 0)
     `, execRollout);
   }
+  if (includeLegacy) {
+    db.run(`
+      INSERT INTO threads (id, rollout_path, model_provider, source, first_user_message, has_user_event)
+      VALUES ('thread-3', ?, 'opencodex', 'cli', 'legacy remapped row', 1)
+    `, legacyRollout);
+  }
   db.close();
-  return { dbPath, backupPath, rollout, execRollout, mtime };
+  return { dbPath, backupPath, rollout, execRollout, legacyRollout, mtime };
 }
 
 describe("Codex history provider sync", () => {
@@ -115,5 +130,36 @@ describe("Codex history provider sync", () => {
     firstLine = readFileSync(execRollout, "utf8").split("\n")[0];
     expect(JSON.parse(firstLine).payload.source).toBe("exec");
     expect(existsSync(backupPath)).toBe(false);
+  });
+
+  test("leaves ambiguous legacy opencodex interactive rows untouched when no backup exists", () => {
+    const { dbPath, backupPath } = makeFixture({ includeLegacy: true });
+
+    const result = syncCodexHistoryProvider("openai", dbPath, backupPath);
+
+    expect(result).toEqual({ rows: 0, files: 0, legacyRows: 1 });
+    const db = new Database(dbPath);
+    expect(db.query("SELECT model_provider, source FROM threads WHERE id = 'thread-3'").get()).toEqual({
+      model_provider: "opencodex",
+      source: "cli",
+    });
+    db.close();
+    expect(existsSync(backupPath)).toBe(false);
+  });
+
+  test("explicitly recovers legacy opencodex interactive rows to openai", () => {
+    const { dbPath, legacyRollout } = makeFixture({ includeLegacy: true });
+
+    const result = restoreLegacyOpenaiHistory(dbPath);
+
+    expect(result).toEqual({ rows: 1, files: 1 });
+    const db = new Database(dbPath);
+    expect(db.query("SELECT model_provider, source FROM threads WHERE id = 'thread-3'").get()).toEqual({
+      model_provider: "openai",
+      source: "cli",
+    });
+    db.close();
+    const firstLine = readFileSync(legacyRollout, "utf8").split("\n")[0];
+    expect(JSON.parse(firstLine).payload.model_provider).toBe("openai");
   });
 });

--- a/tests/codex-history-provider.test.ts
+++ b/tests/codex-history-provider.test.ts
@@ -122,44 +122,54 @@ describe("Codex history provider sync", () => {
     expect(restore).toEqual({ rows: 2, files: 2 });
     db = new Database(dbPath);
     expect(db.query("SELECT model_provider, source, has_user_event FROM threads WHERE id = 'thread-2'").get()).toEqual({
-      model_provider: "opencodex",
-      source: "exec",
-      has_user_event: 0,
+      model_provider: "openai",
+      source: "cli",
+      has_user_event: 1,
     });
     db.close();
     firstLine = readFileSync(execRollout, "utf8").split("\n")[0];
-    expect(JSON.parse(firstLine).payload.source).toBe("exec");
+    expect(JSON.parse(firstLine).payload.model_provider).toBe("openai");
+    expect(JSON.parse(firstLine).payload.source).toBe("cli");
     expect(existsSync(backupPath)).toBe(false);
   });
 
-  test("leaves ambiguous legacy opencodex interactive rows untouched when no backup exists", () => {
+  test("ejects no-backup opencodex interactive rows to openai during native restore", () => {
     const { dbPath, backupPath } = makeFixture({ includeLegacy: true });
 
     const result = syncCodexHistoryProvider("openai", dbPath, backupPath);
 
-    expect(result).toEqual({ rows: 0, files: 0, legacyRows: 1 });
-    const db = new Database(dbPath);
-    expect(db.query("SELECT model_provider, source FROM threads WHERE id = 'thread-3'").get()).toEqual({
-      model_provider: "opencodex",
-      source: "cli",
-    });
-    db.close();
-    expect(existsSync(backupPath)).toBe(false);
-  });
-
-  test("explicitly recovers legacy opencodex interactive rows to openai", () => {
-    const { dbPath, legacyRollout } = makeFixture({ includeLegacy: true });
-
-    const result = restoreLegacyOpenaiHistory(dbPath);
-
-    expect(result).toEqual({ rows: 1, files: 1 });
+    expect(result).toEqual({ rows: 0, files: 1, ejectedRows: 1 });
     const db = new Database(dbPath);
     expect(db.query("SELECT model_provider, source FROM threads WHERE id = 'thread-3'").get()).toEqual({
       model_provider: "openai",
       source: "cli",
     });
     db.close();
-    const firstLine = readFileSync(legacyRollout, "utf8").split("\n")[0];
+    expect(existsSync(backupPath)).toBe(false);
+  });
+
+  test("explicitly recovers legacy opencodex user rows to openai", () => {
+    const { dbPath, execRollout, legacyRollout } = makeFixture({ includeExec: true, includeLegacy: true });
+
+    const result = restoreLegacyOpenaiHistory(dbPath);
+
+    expect(result).toEqual({ rows: 2, files: 2 });
+    const db = new Database(dbPath);
+    expect(db.query("SELECT model_provider, source FROM threads WHERE id = 'thread-3'").get()).toEqual({
+      model_provider: "openai",
+      source: "cli",
+    });
+    expect(db.query("SELECT model_provider, source, has_user_event FROM threads WHERE id = 'thread-2'").get()).toEqual({
+      model_provider: "openai",
+      source: "cli",
+      has_user_event: 1,
+    });
+    db.close();
+    let firstLine = readFileSync(execRollout, "utf8").split("\n")[0];
+    expect(JSON.parse(firstLine).payload.model_provider).toBe("openai");
+    expect(JSON.parse(firstLine).payload.source).toBe("cli");
+
+    firstLine = readFileSync(legacyRollout, "utf8").split("\n")[0];
     expect(JSON.parse(firstLine).payload.model_provider).toBe("openai");
   });
 });

--- a/tests/codex-history-provider.test.ts
+++ b/tests/codex-history-provider.test.ts
@@ -1,11 +1,11 @@
-import { mkdirSync, readFileSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 import { syncCodexHistoryProvider } from "../src/codex-history-provider";
 
-function makeFixture() {
+function makeFixture({ includeExec = false } = {}) {
   const dir = join(tmpdir(), `ocx-history-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
   mkdirSync(dir, { recursive: true });
   const rollout = join(dir, "rollout.jsonl");
@@ -16,10 +16,20 @@ function makeFixture() {
     }),
     JSON.stringify({ type: "event_msg", timestamp: "2026-01-01T00:00:00.000Z", payload: { message: "x" } }),
   ].join("\n") + "\n");
+  const execRollout = join(dir, "exec-rollout.jsonl");
+  writeFileSync(execRollout, [
+    JSON.stringify({
+      type: "session_meta",
+      payload: { id: "thread-2", model_provider: "opencodex", source: "exec", cwd: dir },
+    }),
+    JSON.stringify({ type: "event_msg", timestamp: "2026-01-01T00:00:00.000Z", payload: { message: "y" } }),
+  ].join("\n") + "\n");
   const mtime = new Date("2026-01-02T03:04:05.000Z");
   utimesSync(rollout, mtime, mtime);
+  utimesSync(execRollout, mtime, mtime);
 
   const dbPath = join(dir, "state_5.sqlite");
+  const backupPath = join(dir, "codex-history-backup.json");
   const db = new Database(dbPath);
   db.run(`
     CREATE TABLE threads (
@@ -35,15 +45,21 @@ function makeFixture() {
     INSERT INTO threads (id, rollout_path, model_provider, source, first_user_message, has_user_event)
     VALUES ('thread-1', ?, 'openai', 'vscode', 'hello', 0)
   `, rollout);
+  if (includeExec) {
+    db.run(`
+      INSERT INTO threads (id, rollout_path, model_provider, source, first_user_message, has_user_event)
+      VALUES ('thread-2', ?, 'opencodex', 'exec', 'hello from exec', 0)
+    `, execRollout);
+  }
   db.close();
-  return { dbPath, rollout, mtime };
+  return { dbPath, backupPath, rollout, execRollout, mtime };
 }
 
 describe("Codex history provider sync", () => {
   test("maps resumable Codex threads to opencodex without touching file mtime", () => {
-    const { dbPath, rollout, mtime } = makeFixture();
+    const { dbPath, backupPath, rollout, mtime } = makeFixture();
 
-    const result = syncCodexHistoryProvider("opencodex", dbPath);
+    const result = syncCodexHistoryProvider("opencodex", dbPath, backupPath);
 
     expect(result).toEqual({ rows: 1, files: 1 });
     const db = new Database(dbPath);
@@ -56,10 +72,10 @@ describe("Codex history provider sync", () => {
   });
 
   test("maps resumable Codex threads back to openai", () => {
-    const { dbPath, rollout } = makeFixture();
-    syncCodexHistoryProvider("opencodex", dbPath);
+    const { dbPath, backupPath, rollout } = makeFixture();
+    syncCodexHistoryProvider("opencodex", dbPath, backupPath);
 
-    const result = syncCodexHistoryProvider("openai", dbPath);
+    const result = syncCodexHistoryProvider("openai", dbPath, backupPath);
 
     expect(result).toEqual({ rows: 1, files: 1 });
     const db = new Database(dbPath);
@@ -67,5 +83,37 @@ describe("Codex history provider sync", () => {
     db.close();
     const firstLine = readFileSync(rollout, "utf8").split("\n")[0];
     expect(JSON.parse(firstLine).payload.model_provider).toBe("openai");
+    expect(existsSync(backupPath)).toBe(false);
+  });
+
+  test("promotes opencodex exec threads to app-visible cli source and restores from backup", () => {
+    const { dbPath, backupPath, execRollout } = makeFixture({ includeExec: true });
+
+    const result = syncCodexHistoryProvider("opencodex", dbPath, backupPath);
+
+    expect(result).toEqual({ rows: 2, files: 2 });
+    let db = new Database(dbPath);
+    expect(db.query("SELECT model_provider, source, has_user_event FROM threads WHERE id = 'thread-2'").get()).toEqual({
+      model_provider: "opencodex",
+      source: "cli",
+      has_user_event: 1,
+    });
+    db.close();
+    let firstLine = readFileSync(execRollout, "utf8").split("\n")[0];
+    expect(JSON.parse(firstLine).payload.source).toBe("cli");
+
+    const restore = syncCodexHistoryProvider("openai", dbPath, backupPath);
+
+    expect(restore).toEqual({ rows: 2, files: 2 });
+    db = new Database(dbPath);
+    expect(db.query("SELECT model_provider, source, has_user_event FROM threads WHERE id = 'thread-2'").get()).toEqual({
+      model_provider: "opencodex",
+      source: "exec",
+      has_user_event: 0,
+    });
+    db.close();
+    firstLine = readFileSync(execRollout, "utf8").split("\n")[0];
+    expect(JSON.parse(firstLine).payload.source).toBe("exec");
+    expect(existsSync(backupPath)).toBe(false);
   });
 });

--- a/tests/codex-inject.test.ts
+++ b/tests/codex-inject.test.ts
@@ -43,6 +43,20 @@ describe("Codex config injection", () => {
     expect(stripped).not.toContain("model_catalog_json");
   });
 
+  test("removes root routed model names when restoring native Codex", () => {
+    const stripped = stripOpencodexConfig([
+      'model = "opencode-go/minimax-m3"',
+      'model_verbosity = "high"',
+      "",
+      "[features]",
+      "fast_mode = true",
+      "",
+    ].join("\n"));
+
+    expect(stripped).not.toContain('model = "opencode-go/minimax-m3"');
+    expect(stripped).toContain('model_verbosity = "high"');
+  });
+
   test("can build fallback profile without a model catalog path", () => {
     const profile = buildProfileFile(10100, null);
 

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -25,7 +25,7 @@ function nativeTemplate(): Record<string, unknown> {
 }
 
 const EXPECTED_KEY_PROVIDER_IDS = [
-  "openai-apikey", "opencode-go", "neuralwatt", "openrouter", "groq", "google", "azure-openai",
+  "openai-apikey", "umans", "opencode-go", "neuralwatt", "openrouter", "groq", "google", "azure-openai",
   "deepseek", "cerebras", "together", "fireworks", "firepass", "moonshot",
   "huggingface", "nvidia", "venice", "zai", "nanogpt", "synthetic", "qwen-portal",
   "qianfan", "alibaba", "parallel", "zenmux", "litellm", "ollama-cloud", "mistral",
@@ -44,6 +44,14 @@ describe("provider registry parity", () => {
     expect(Object.keys(KEY_LOGIN_PROVIDERS)).toEqual(EXPECTED_KEY_PROVIDER_IDS);
     expect(Object.keys(deriveKeyLoginMap())).toEqual(EXPECTED_KEY_PROVIDER_IDS);
     expect(KEY_LOGIN_PROVIDERS.minimax.defaultModel).toBe("MiniMax-M2.5");
+    expect(KEY_LOGIN_PROVIDERS.umans).toMatchObject({
+      label: "Umans AI Coding Plan",
+      adapter: "anthropic",
+      baseUrl: "https://api.code.umans.ai",
+      defaultModel: "umans-coder",
+      escapeBuiltinToolNames: true,
+    });
+    expect(KEY_LOGIN_PROVIDERS.umans.noVisionModels).toContain("umans-glm-5.2");
   });
 
   test("CLI init providers are derived from the registry", () => {
@@ -60,7 +68,7 @@ describe("provider registry parity", () => {
   test("GUI preset projection preserves current featured set plus key catalog and custom", () => {
     const featured = deriveFeaturedProviderIds();
     expect(featured).toEqual([
-      "openai", "xai", "anthropic", "kimi", "openai-apikey", "opencode-go", "openrouter",
+      "openai", "xai", "anthropic", "kimi", "openai-apikey", "umans", "opencode-go", "openrouter",
       "groq", "google", "azure-openai", "ollama", "vllm", "lm-studio",
     ]);
 
@@ -68,6 +76,12 @@ describe("provider registry parity", () => {
     expect(presets.at(-1)?.id).toBe("custom");
     expect(presets.find(p => p.id === "kimi")?.baseUrl).toBe("https://api.kimi.com/coding/v1");
     expect(presets.find(p => p.id === "anthropic")?.defaultModel).toBe("claude-sonnet-4-6");
+    expect(presets.find(p => p.id === "umans")).toMatchObject({
+      adapter: "anthropic",
+      baseUrl: "https://api.code.umans.ai",
+      auth: "key",
+      defaultModel: "umans-coder",
+    });
     expect(presets.find(p => p.id === "azure-openai")?.adapter).toBe("azure-openai");
   });
 

--- a/tests/umans-provider.test.ts
+++ b/tests/umans-provider.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createAnthropicAdapter } from "../src/adapters/anthropic";
+import { providerConfigFromKeyLoginProvider } from "../src/oauth/login-cli";
+import { enrichProviderFromCatalog, KEY_LOGIN_PROVIDERS, validateApiKey } from "../src/oauth/key-providers";
+import type { AdapterEvent, OcxParsedRequest, OcxProviderConfig } from "../src/types";
+
+function umansProvider(apiKey = "sk-umans"): OcxProviderConfig {
+  return {
+    adapter: "anthropic",
+    baseUrl: "https://api.code.umans.ai",
+    apiKey,
+    defaultModel: "umans-coder",
+    escapeBuiltinToolNames: true,
+  };
+}
+
+function parsedWithWebSearchTool(): OcxParsedRequest {
+  return {
+    modelId: "umans-coder",
+    context: {
+      messages: [{ role: "user", content: "search docs", timestamp: 0 }],
+      tools: [{
+        name: "web_search",
+        description: "Search the web",
+        parameters: { type: "object", properties: { query: { type: "string" } }, required: ["query"] },
+      }],
+    },
+    stream: true,
+    options: { toolChoice: { name: "web_search" } },
+  };
+}
+
+async function collect(events: AsyncGenerator<AdapterEvent>): Promise<AdapterEvent[]> {
+  const out: AdapterEvent[] = [];
+  for await (const event of events) out.push(event);
+  return out;
+}
+
+describe("Umans provider", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("catalog enrichment preserves Anthropic Messages runtime metadata", () => {
+    const provider: OcxProviderConfig = {
+      adapter: "anthropic",
+      baseUrl: "https://api.code.umans.ai",
+      apiKey: "sk-umans",
+    };
+
+    enrichProviderFromCatalog("umans", provider);
+
+    expect(provider.defaultModel).toBe("umans-coder");
+    expect(provider.models).toContain("umans-kimi-k2.7");
+    expect(provider.noVisionModels).toContain("umans-glm-5.2");
+    expect(provider.escapeBuiltinToolNames).toBe(true);
+  });
+
+  test("CLI key-login save payload preserves Umans runtime metadata", () => {
+    const provider = providerConfigFromKeyLoginProvider(KEY_LOGIN_PROVIDERS.umans, "sk-umans");
+
+    expect(provider).toMatchObject({
+      adapter: "anthropic",
+      baseUrl: "https://api.code.umans.ai",
+      apiKey: "sk-umans",
+      defaultModel: "umans-coder",
+      escapeBuiltinToolNames: true,
+    });
+    expect(provider.models).toContain("umans-kimi-k2.7");
+    expect(provider.modelReasoningEfforts?.["umans-glm-5.2"]).toEqual(["high", "xhigh"]);
+    expect(provider.modelReasoningEffortMap?.["umans-glm-5.2"]?.xhigh).toBe("max");
+    expect(provider.noVisionModels).toContain("umans-glm-5.1");
+  });
+
+  test("Anthropic adapter posts Umans requests to /v1/messages with x-api-key", () => {
+    const req = createAnthropicAdapter(umansProvider()).buildRequest(parsedWithWebSearchTool());
+    const body = JSON.parse(req.body as string) as {
+      tools: Array<{ name: string }>;
+      tool_choice: { type: string; name: string };
+      system?: unknown;
+    };
+
+    expect(req.url).toBe("https://api.code.umans.ai/v1/messages");
+    expect(req.method).toBe("POST");
+    expect(req.headers.Authorization).toBeUndefined();
+    expect(req.headers["x-api-key"]).toBe("sk-umans");
+    expect(req.headers["anthropic-version"]).toBe("2023-06-01");
+    expect(req.headers["anthropic-beta"]).toBeUndefined();
+    expect(body.system).toBeUndefined();
+    expect(body.tools[0].name).toBe("ocx_web_search");
+    expect(body.tool_choice).toEqual({ type: "tool", name: "ocx_web_search" });
+  });
+
+  test("Anthropic adapter strips Umans compatibility prefix from streamed tool calls", async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(
+          `event: content_block_start\n` +
+          `data: {"type":"content_block_start","content_block":{"type":"tool_use","id":"toolu_1","name":"ocx_web_search"}}\n\n` +
+          `event: content_block_delta\n` +
+          `data: {"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{\\"query\\":\\"umans\\"}"}}\n\n` +
+          `event: content_block_stop\n` +
+          `data: {"type":"content_block_stop"}\n\n`,
+        ));
+        controller.close();
+      },
+    });
+
+    const events = await collect(createAnthropicAdapter(umansProvider()).parseStream(new Response(stream)));
+
+    expect(events[0]).toEqual({ type: "tool_call_start", id: "toolu_1", name: "web_search" });
+    expect(events[1]).toEqual({ type: "tool_call_delta", arguments: "{\"query\":\"umans\"}" });
+    expect(events[2]).toEqual({ type: "tool_call_end" });
+  });
+
+  test("Anthropic adapter strips Umans compatibility prefix from non-streaming tool calls", async () => {
+    const response = new Response(JSON.stringify({
+      content: [{
+        type: "tool_use",
+        id: "toolu_1",
+        name: "ocx_web_search",
+        input: { query: "umans" },
+      }],
+      usage: { input_tokens: 10, output_tokens: 3 },
+    }));
+
+    const events = await createAnthropicAdapter(umansProvider()).parseResponse(response);
+
+    expect(events[0]).toEqual({ type: "tool_call_start", id: "toolu_1", name: "web_search" });
+    expect(events[1]).toEqual({ type: "tool_call_delta", arguments: "{\"query\":\"umans\"}" });
+    expect(events[2]).toEqual({ type: "tool_call_end" });
+    expect(events[3].type).toBe("done");
+  });
+
+  test("Umans API-key validation uses Anthropic Messages shape", async () => {
+    let seenUrl = "";
+    let seenInit: RequestInit | undefined;
+    globalThis.fetch = (async (url, init) => {
+      seenUrl = String(url);
+      seenInit = init;
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const valid = await validateApiKey(KEY_LOGIN_PROVIDERS.umans, "sk-umans-valid");
+    const headers = new Headers(seenInit?.headers);
+    const body = JSON.parse(String(seenInit?.body)) as Record<string, unknown>;
+
+    expect(valid).toBe(true);
+    expect(seenUrl).toBe("https://api.code.umans.ai/v1/messages");
+    expect(seenInit?.method).toBe("POST");
+    expect(headers.get("x-api-key")).toBe("sk-umans-valid");
+    expect(headers.get("authorization")).toBeNull();
+    expect(headers.get("anthropic-version")).toBe("2023-06-01");
+    expect(body.model).toBe("umans-coder");
+    expect(body.max_tokens).toBe(1);
+  });
+});

--- a/tests/uninstall.test.ts
+++ b/tests/uninstall.test.ts
@@ -18,6 +18,14 @@ describe("full uninstall command", () => {
     expect(cli).toContain("rmSync(getConfigDir()");
   });
 
+  test("CLI exposes explicit legacy history recovery command", async () => {
+    const cli = await readText("src/cli.ts");
+
+    expect(cli).toContain("ocx recover-history --legacy-openai");
+    expect(cli).toContain("function handleRecoverHistory()");
+    expect(cli).toContain("restoreLegacyOpenaiHistory");
+  });
+
   test("service cleanup has a quiet best-effort helper", async () => {
     const service = await readText("src/service.ts");
 


### PR DESCRIPTION
## Summary
- Merge local dev history compatibility fixes for Codex App resume history visibility (#13/#11 work)
- Merge PR #14 from @0disoft: guard subcommand help before side effects
- Add dev follow-up for recover-history help guard and side-effect regression coverage
- Merge PR #19 from @0disoft: source dashboard badge version from runtime /healthz
- Add Umans provider preset and Anthropic-compatible wire/tool handling
- Bump package version to 2.1.6 for npm OIDC Trusted Publishing

## Verification
- bun run typecheck
- bun test tests (150 pass, 0 fail)
- bun run build:gui
- Backend stop-audit confirmed dev clean and PR #14/#19 author attribution preserved

## Release
After merge to main, dispatch Release workflow with version 2.1.6, tag latest, dry-run false.