### PR TITLE
[codex] add native Umans provider

### DIFF
--- a/src/codex-catalog.ts
+++ b/src/codex-catalog.ts
@@ -344,8 +344,12 @@ type ProviderModelsApiItem = {
 function catalogHintsFromProviderConfig(name: string, prov: OcxProviderConfig, id: string): Partial<CatalogModel> {
   void name;
   const reasoningEfforts = configuredReasoningEfforts(prov, id);
+  const contextWindow = prov.modelContextWindows?.[id];
+  const inputModalities = prov.modelInputModalities?.[id];
   return {
     ...(reasoningEfforts !== undefined ? { reasoningEfforts } : {}),
+    ...(typeof contextWindow === "number" && contextWindow > 0 ? { contextWindow } : {}),
+    ...(inputModalities && inputModalities.length > 0 ? { inputModalities: [...inputModalities] } : {}),
   };
 }
 

--- a/src/oauth/key-providers.ts
+++ b/src/oauth/key-providers.ts
@@ -24,6 +24,8 @@ export interface KeyLoginProvider {
   modelReasoningEfforts?: Record<string, string[]>;
   reasoningEffortMap?: Record<string, string>;
   modelReasoningEffortMap?: Record<string, Record<string, string>>;
+  modelContextWindows?: Record<string, number>;
+  modelInputModalities?: Record<string, string[]>;
   noVisionModels?: string[];
   noReasoningModels?: string[];
   noTemperatureModels?: string[];
@@ -51,6 +53,8 @@ export function enrichProviderFromCatalog(name: string, prov: OcxProviderConfig)
   if (!prov.modelReasoningEfforts && e.modelReasoningEfforts) prov.modelReasoningEfforts = cloneRecordOfArrays(e.modelReasoningEfforts);
   if (!prov.reasoningEffortMap && e.reasoningEffortMap) prov.reasoningEffortMap = { ...e.reasoningEffortMap };
   if (!prov.modelReasoningEffortMap && e.modelReasoningEffortMap) prov.modelReasoningEffortMap = cloneNestedRecord(e.modelReasoningEffortMap);
+  if (!prov.modelContextWindows && e.modelContextWindows) prov.modelContextWindows = { ...e.modelContextWindows };
+  if (!prov.modelInputModalities && e.modelInputModalities) prov.modelInputModalities = cloneRecordOfArrays(e.modelInputModalities);
   if (!prov.noVisionModels && e.noVisionModels) prov.noVisionModels = [...e.noVisionModels];
   if (!prov.noReasoningModels && e.noReasoningModels) prov.noReasoningModels = [...e.noReasoningModels];
   if (!prov.noTemperatureModels && e.noTemperatureModels) prov.noTemperatureModels = [...e.noTemperatureModels];

--- a/src/oauth/login-cli.ts
+++ b/src/oauth/login-cli.ts
@@ -63,6 +63,8 @@ export function providerConfigFromKeyLoginProvider(def: KeyLoginProvider, key: s
     ...(def.modelReasoningEfforts ? { modelReasoningEfforts: cloneRecordOfArrays(def.modelReasoningEfforts) } : {}),
     ...(def.reasoningEffortMap ? { reasoningEffortMap: { ...def.reasoningEffortMap } } : {}),
     ...(def.modelReasoningEffortMap ? { modelReasoningEffortMap: cloneNestedRecord(def.modelReasoningEffortMap) } : {}),
+    ...(def.modelContextWindows ? { modelContextWindows: { ...def.modelContextWindows } } : {}),
+    ...(def.modelInputModalities ? { modelInputModalities: cloneRecordOfArrays(def.modelInputModalities) } : {}),
     ...(def.noVisionModels ? { noVisionModels: [...def.noVisionModels] } : {}),
     ...(def.noReasoningModels ? { noReasoningModels: [...def.noReasoningModels] } : {}),
     ...(def.noTemperatureModels ? { noTemperatureModels: [...def.noTemperatureModels] } : {}),

--- a/src/providers/derive.ts
+++ b/src/providers/derive.ts
@@ -12,6 +12,8 @@ export interface DerivedKeyLoginProvider {
   modelReasoningEfforts?: Record<string, string[]>;
   reasoningEffortMap?: Record<string, string>;
   modelReasoningEffortMap?: Record<string, Record<string, string>>;
+  modelContextWindows?: Record<string, number>;
+  modelInputModalities?: Record<string, string[]>;
   noVisionModels?: string[];
   noReasoningModels?: string[];
   noTemperatureModels?: string[];
@@ -67,6 +69,8 @@ export function providerConfigSeed(entry: ProviderRegistryEntry): OcxProviderCon
     ...(entry.modelReasoningEfforts ? { modelReasoningEfforts: cloneRecordOfArrays(entry.modelReasoningEfforts) } : {}),
     ...(entry.reasoningEffortMap ? { reasoningEffortMap: { ...entry.reasoningEffortMap } } : {}),
     ...(entry.modelReasoningEffortMap ? { modelReasoningEffortMap: cloneNestedRecord(entry.modelReasoningEffortMap) } : {}),
+    ...(entry.modelContextWindows ? { modelContextWindows: { ...entry.modelContextWindows } } : {}),
+    ...(entry.modelInputModalities ? { modelInputModalities: cloneRecordOfArrays(entry.modelInputModalities) } : {}),
     ...(entry.noVisionModels ? { noVisionModels: [...entry.noVisionModels] } : {}),
     ...(entry.noReasoningModels ? { noReasoningModels: [...entry.noReasoningModels] } : {}),
     ...(entry.noTemperatureModels ? { noTemperatureModels: [...entry.noTemperatureModels] } : {}),
@@ -94,6 +98,8 @@ export function deriveKeyLoginMap(): Record<string, DerivedKeyLoginProvider> {
       ...(entry.modelReasoningEfforts ? { modelReasoningEfforts: cloneRecordOfArrays(entry.modelReasoningEfforts) } : {}),
       ...(entry.reasoningEffortMap ? { reasoningEffortMap: { ...entry.reasoningEffortMap } } : {}),
       ...(entry.modelReasoningEffortMap ? { modelReasoningEffortMap: cloneNestedRecord(entry.modelReasoningEffortMap) } : {}),
+      ...(entry.modelContextWindows ? { modelContextWindows: { ...entry.modelContextWindows } } : {}),
+      ...(entry.modelInputModalities ? { modelInputModalities: cloneRecordOfArrays(entry.modelInputModalities) } : {}),
       ...(entry.noVisionModels ? { noVisionModels: [...entry.noVisionModels] } : {}),
       ...(entry.noReasoningModels ? { noReasoningModels: [...entry.noReasoningModels] } : {}),
       ...(entry.noTemperatureModels ? { noTemperatureModels: [...entry.noTemperatureModels] } : {}),

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -18,6 +18,8 @@ export interface ProviderRegistryEntry {
   modelReasoningEfforts?: Record<string, string[]>;
   reasoningEffortMap?: Record<string, string>;
   modelReasoningEffortMap?: Record<string, Record<string, string>>;
+  modelContextWindows?: Record<string, number>;
+  modelInputModalities?: Record<string, string[]>;
   noVisionModels?: string[];
   noReasoningModels?: string[];
   noTemperatureModels?: string[];
@@ -36,6 +38,7 @@ export type ProviderConfigSeed = Pick<
   OcxProviderConfig,
   "adapter" | "baseUrl" | "authMode" | "defaultModel" | "models"
   | "reasoningEfforts" | "modelReasoningEfforts" | "reasoningEffortMap" | "modelReasoningEffortMap"
+  | "modelContextWindows" | "modelInputModalities"
   | "noVisionModels" | "noReasoningModels" | "noTemperatureModels" | "noTopPModels" | "noPenaltyModels"
   | "autoToolChoiceOnlyModels" | "preserveReasoningContentModels" | "escapeBuiltinToolNames"
 >;
@@ -60,26 +63,43 @@ const NEURALWATT_REASONING_HISTORY_MODELS = [
   "qwen3.5-397b", "qwen3.6-35b",
 ];
 const UMANS_MODELS = [
-  "umans-coder",
-  "umans-kimi-k2.7",
   "umans-kimi-k2.6",
-  "umans-flash",
-  "umans-glm-5.2",
+  "umans-kimi-k2.7",
   "umans-glm-5.1",
+  "umans-glm-5.2",
+  "umans-coder",
+  "umans-flash",
   "umans-qwen3.6-35b-a3b",
 ];
-const UMANS_REASONING_EFFORTS = ["low", "medium", "high", "xhigh"];
-const UMANS_GLM_REASONING_EFFORTS = ["high", "xhigh"];
-const UMANS_GLM_REASONING_MAP: Record<string, string> = {
-  none: "high",
-  minimal: "high",
+const UMANS_VISION_MODELS = Object.fromEntries(UMANS_MODELS.map(id => [id, ["text", "image"]]));
+const UMANS_REASONING_HISTORY_MODELS = UMANS_MODELS;
+const UMANS_GLM_51_REASONING_MAP: Record<string, string> = {
+  none: "none",
+  minimal: "none",
+  low: "medium",
+  medium: "medium",
+  high: "medium",
+  xhigh: "medium",
+  max: "medium",
+};
+const UMANS_GLM_52_REASONING_MAP: Record<string, string> = {
+  none: "none",
+  minimal: "none",
   low: "high",
   medium: "high",
   high: "high",
   xhigh: "max",
   max: "max",
 };
-const UMANS_TEXT_ONLY_MODELS = ["umans-glm-5.2", "umans-glm-5.1"];
+const UMANS_QWEN_REASONING_MAP: Record<string, string> = {
+  none: "none",
+  minimal: "none",
+  low: "low",
+  medium: "medium",
+  high: "high",
+  xhigh: "high",
+  max: "high",
+};
 
 export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
   {
@@ -142,33 +162,6 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
   },
   { id: "openai-apikey", label: "OpenAI (API key)", adapter: "openai-responses", baseUrl: "https://api.openai.com/v1", authKind: "key", featured: true, dashboardUrl: "https://platform.openai.com/api-keys", defaultModel: "gpt-5.5" },
   {
-    id: "umans",
-    label: "Umans AI Coding Plan",
-    adapter: "anthropic",
-    baseUrl: "https://api.code.umans.ai",
-    authKind: "key",
-    featured: true,
-    dashboardUrl: "https://app.umans.ai/billing",
-    defaultModel: "umans-coder",
-    models: UMANS_MODELS,
-    note: "Coding plan via Anthropic Messages",
-    modelReasoningEfforts: {
-      "umans-coder": UMANS_REASONING_EFFORTS,
-      "umans-kimi-k2.7": UMANS_REASONING_EFFORTS,
-      "umans-kimi-k2.6": UMANS_REASONING_EFFORTS,
-      "umans-flash": ["low", "medium", "high"],
-      "umans-glm-5.2": UMANS_GLM_REASONING_EFFORTS,
-      "umans-glm-5.1": UMANS_GLM_REASONING_EFFORTS,
-      "umans-qwen3.6-35b-a3b": ["low", "medium", "high"],
-    },
-    modelReasoningEffortMap: {
-      "umans-glm-5.2": UMANS_GLM_REASONING_MAP,
-      "umans-glm-5.1": UMANS_GLM_REASONING_MAP,
-    },
-    noVisionModels: UMANS_TEXT_ONLY_MODELS,
-    escapeBuiltinToolNames: true,
-  },
-  {
     id: "opencode-go", label: "opencode go", adapter: "openai-chat", baseUrl: "https://opencode.ai/zen/go/v1",
     authKind: "key", featured: true, dashboardUrl: "https://opencode.ai/auth", defaultModel: "kimi-k2.7-code",
     jawcodeBundle: "opencode-go", note: "GLM, DeepSeek, Kimi, Qwen, MiMo…",
@@ -221,6 +214,44 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     noPenaltyModels: ["kimi-k2.7-code"],
     autoToolChoiceOnlyModels: ["kimi-k2.7-code"],
     preserveReasoningContentModels: NEURALWATT_REASONING_HISTORY_MODELS,
+  },
+  {
+    id: "umans",
+    label: "Umans Code",
+    adapter: "openai-chat",
+    baseUrl: "https://api.code.umans.ai/v1",
+    authKind: "key",
+    featured: true,
+    dashboardUrl: "https://app.umans.ai/offers/code",
+    defaultModel: "umans-coder",
+    note: "Kimi K2.7-Code, GLM 5.2, and Qwen Flash via Umans Code",
+    models: UMANS_MODELS,
+    modelContextWindows: {
+      "umans-kimi-k2.6": 262_144,
+      "umans-kimi-k2.7": 262_144,
+      "umans-glm-5.1": 202_752,
+      "umans-glm-5.2": 405_504,
+      "umans-coder": 262_144,
+      "umans-flash": 262_144,
+      "umans-qwen3.6-35b-a3b": 262_144,
+    },
+    modelInputModalities: UMANS_VISION_MODELS,
+    modelReasoningEfforts: {
+      "umans-kimi-k2.6": [],
+      "umans-kimi-k2.7": [],
+      "umans-glm-5.1": ["medium"],
+      "umans-glm-5.2": ["high", "xhigh"],
+      "umans-coder": [],
+      "umans-flash": ["low", "medium", "high"],
+      "umans-qwen3.6-35b-a3b": ["low", "medium", "high"],
+    },
+    modelReasoningEffortMap: {
+      "umans-glm-5.1": UMANS_GLM_51_REASONING_MAP,
+      "umans-glm-5.2": UMANS_GLM_52_REASONING_MAP,
+      "umans-flash": UMANS_QWEN_REASONING_MAP,
+      "umans-qwen3.6-35b-a3b": UMANS_QWEN_REASONING_MAP,
+    },
+    preserveReasoningContentModels: UMANS_REASONING_HISTORY_MODELS,
   },
   { id: "openrouter", label: "OpenRouter", adapter: "openai-chat", baseUrl: "https://openrouter.ai/api/v1", authKind: "key", featured: true, dashboardUrl: "https://openrouter.ai/keys", jawcodeBundle: "openrouter" },
   { id: "groq", label: "Groq", adapter: "openai-chat", baseUrl: "https://api.groq.com/openai/v1", authKind: "key", featured: true, dashboardUrl: "https://console.groq.com/keys" },

--- a/src/types.ts
+++ b/src/types.ts
@@ -250,6 +250,10 @@ export interface OcxProviderConfig {
   reasoningEffortMap?: Record<string, string>;
   /** Model-specific mapping from Codex effort labels to upstream `reasoning_effort` values. */
   modelReasoningEffortMap?: Record<string, Record<string, string>>;
+  /** Model-specific context windows used when a provider's `/models` endpoint is sparse. */
+  modelContextWindows?: Record<string, number>;
+  /** Model-specific input modalities used when a provider's `/models` endpoint is sparse. */
+  modelInputModalities?: Record<string, string[]>;
   /**
    * Model ids that do NOT support a reasoning/thinking parameter. The openai-chat adapter drops
    * reasoning_effort for these even when Codex selects a reasoning level (e.g. xAI grok-build-0.1).

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { augmentRoutedModelsWithJawcodeMetadata, buildCatalogEntries, isMediaGenerationModelId, normalizeRoutedCatalogEntry } from "../src/codex-catalog";
 import { getJawcodeModelMetadata, resolveJawcodeProvider } from "../src/generated/jawcode-model-metadata";
+import { providerConfigSeed } from "../src/providers/derive";
+import { getProviderRegistryEntry } from "../src/providers/registry";
 
 function nativeTemplate(): Record<string, unknown> {
   return {
@@ -201,6 +203,32 @@ describe("Codex catalog routed normalization", () => {
     expect(routed?.max_context_window).toBe(262_144);
     expect(routed?.auto_compact_token_limit).toBe(235_929);
     expect(routed?.input_modalities).toEqual(["text", "image"]);
+  });
+
+  test("Umans native registry metadata advertises docs-matched context, vision, and reasoning levels", () => {
+    const entry = getProviderRegistryEntry("umans");
+    expect(entry).toBeDefined();
+    const provider = providerConfigSeed(entry!);
+    const entries = buildCatalogEntries(nativeTemplate(), [], provider.models!.map(id => ({
+      id,
+      provider: "umans",
+      reasoningEfforts: provider.modelReasoningEfforts?.[id],
+      contextWindow: provider.modelContextWindows?.[id],
+      inputModalities: provider.modelInputModalities?.[id],
+    })));
+
+    const glm52 = entries.find(e => e.slug === "umans/umans-glm-5.2");
+    expect(glm52?.context_window).toBe(405_504);
+    expect(glm52?.max_context_window).toBe(405_504);
+    expect(glm52?.input_modalities).toEqual(["text", "image"]);
+    expect((glm52?.supported_reasoning_levels as { effort: string }[]).map(l => l.effort)).toEqual(["high", "xhigh"]);
+    expect(glm52?.default_reasoning_level).toBe("high");
+
+    const coder = entries.find(e => e.slug === "umans/umans-coder");
+    expect(coder?.context_window).toBe(262_144);
+    expect(coder?.input_modalities).toEqual(["text", "image"]);
+    expect(coder?.supported_reasoning_levels).toEqual([]);
+    expect(coder).not.toHaveProperty("default_reasoning_level");
   });
 
   test("unknown routed entries receive conservative strict catalog defaults", () => {

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -25,7 +25,7 @@ function nativeTemplate(): Record<string, unknown> {
 }
 
 const EXPECTED_KEY_PROVIDER_IDS = [
-  "openai-apikey", "umans", "opencode-go", "neuralwatt", "openrouter", "groq", "google", "azure-openai",
+  "openai-apikey", "opencode-go", "neuralwatt", "umans", "openrouter", "groq", "google", "azure-openai",
   "deepseek", "cerebras", "together", "fireworks", "firepass", "moonshot",
   "huggingface", "nvidia", "venice", "zai", "nanogpt", "synthetic", "qwen-portal",
   "qianfan", "alibaba", "parallel", "zenmux", "litellm", "ollama-cloud", "mistral",
@@ -45,13 +45,13 @@ describe("provider registry parity", () => {
     expect(Object.keys(deriveKeyLoginMap())).toEqual(EXPECTED_KEY_PROVIDER_IDS);
     expect(KEY_LOGIN_PROVIDERS.minimax.defaultModel).toBe("MiniMax-M2.5");
     expect(KEY_LOGIN_PROVIDERS.umans).toMatchObject({
-      label: "Umans AI Coding Plan",
-      adapter: "anthropic",
-      baseUrl: "https://api.code.umans.ai",
+      label: "Umans Code",
+      adapter: "openai-chat",
+      baseUrl: "https://api.code.umans.ai/v1",
       defaultModel: "umans-coder",
-      escapeBuiltinToolNames: true,
     });
-    expect(KEY_LOGIN_PROVIDERS.umans.noVisionModels).toContain("umans-glm-5.2");
+    expect(KEY_LOGIN_PROVIDERS.umans.modelContextWindows?.["umans-glm-5.2"]).toBe(405_504);
+    expect(KEY_LOGIN_PROVIDERS.umans.modelInputModalities?.["umans-glm-5.2"]).toEqual(["text", "image"]);
   });
 
   test("CLI init providers are derived from the registry", () => {
@@ -68,17 +68,19 @@ describe("provider registry parity", () => {
   test("GUI preset projection preserves current featured set plus key catalog and custom", () => {
     const featured = deriveFeaturedProviderIds();
     expect(featured).toEqual([
-      "openai", "xai", "anthropic", "kimi", "openai-apikey", "umans", "opencode-go", "openrouter",
+      "openai", "xai", "anthropic", "kimi", "openai-apikey", "opencode-go", "umans", "openrouter",
       "groq", "google", "azure-openai", "ollama", "vllm", "lm-studio",
     ]);
 
     const presets = deriveProviderPresets();
     expect(presets.at(-1)?.id).toBe("custom");
     expect(presets.find(p => p.id === "kimi")?.baseUrl).toBe("https://api.kimi.com/coding/v1");
+    expect(presets.find(p => p.id === "umans")?.baseUrl).toBe("https://api.code.umans.ai/v1");
+    expect(presets.find(p => p.id === "umans")?.defaultModel).toBe("umans-coder");
     expect(presets.find(p => p.id === "anthropic")?.defaultModel).toBe("claude-sonnet-4-6");
     expect(presets.find(p => p.id === "umans")).toMatchObject({
-      adapter: "anthropic",
-      baseUrl: "https://api.code.umans.ai",
+      adapter: "openai-chat",
+      baseUrl: "https://api.code.umans.ai/v1",
       auth: "key",
       defaultModel: "umans-coder",
     });

--- a/tests/reasoning-effort.test.ts
+++ b/tests/reasoning-effort.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { buildCatalogEntries } from "../src/codex-catalog";
 import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
+import { providerConfigSeed } from "../src/providers/derive";
+import { getProviderRegistryEntry } from "../src/providers/registry";
 import type { OcxParsedRequest, OcxProviderConfig } from "../src/types";
 
 function nativeTemplate(): Record<string, unknown> {
@@ -104,6 +106,18 @@ describe("provider-specific reasoning effort mapping", () => {
 
     expect(body.reasoning_effort).toBe("max");
     expect(body.messages[1].reasoning_content).toBe("prior reasoning");
+  });
+
+  test("Umans maps docs reasoning levels to Codex-safe controls", () => {
+    const entry = getProviderRegistryEntry("umans");
+    expect(entry).toBeDefined();
+    const provider = providerConfigSeed(entry!);
+
+    expect(buildBody(provider, "umans-glm-5.2", { reasoning: "xhigh" }).reasoning_effort).toBe("max");
+    expect(buildBody(provider, "umans-glm-5.2", { reasoning: "medium" }).reasoning_effort).toBe("high");
+    expect(buildBody(provider, "umans-glm-5.1", { reasoning: "high" }).reasoning_effort).toBe("medium");
+    expect(buildBody(provider, "umans-flash", { reasoning: "xhigh" }).reasoning_effort).toBe("high");
+    expect(buildBody(provider, "umans-coder", { reasoning: "high" })).not.toHaveProperty("reasoning_effort");
   });
 
   test("Kimi K2.7 Code does not receive unsupported OpenAI reasoning/sampling controls", () => {

--- a/tests/umans-provider.test.ts
+++ b/tests/umans-provider.test.ts
@@ -1,16 +1,15 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { createAnthropicAdapter } from "../src/adapters/anthropic";
+import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
 import { providerConfigFromKeyLoginProvider } from "../src/oauth/login-cli";
 import { enrichProviderFromCatalog, KEY_LOGIN_PROVIDERS, validateApiKey } from "../src/oauth/key-providers";
 import type { AdapterEvent, OcxParsedRequest, OcxProviderConfig } from "../src/types";
 
 function umansProvider(apiKey = "sk-umans"): OcxProviderConfig {
   return {
-    adapter: "anthropic",
-    baseUrl: "https://api.code.umans.ai",
+    adapter: "openai-chat",
+    baseUrl: "https://api.code.umans.ai/v1",
     apiKey,
     defaultModel: "umans-coder",
-    escapeBuiltinToolNames: true,
   };
 }
 
@@ -43,10 +42,10 @@ describe("Umans provider", () => {
     globalThis.fetch = originalFetch;
   });
 
-  test("catalog enrichment preserves Anthropic Messages runtime metadata", () => {
+  test("catalog enrichment preserves OpenAI-compatible runtime metadata", () => {
     const provider: OcxProviderConfig = {
-      adapter: "anthropic",
-      baseUrl: "https://api.code.umans.ai",
+      adapter: "openai-chat",
+      baseUrl: "https://api.code.umans.ai/v1",
       apiKey: "sk-umans",
     };
 
@@ -54,87 +53,84 @@ describe("Umans provider", () => {
 
     expect(provider.defaultModel).toBe("umans-coder");
     expect(provider.models).toContain("umans-kimi-k2.7");
-    expect(provider.noVisionModels).toContain("umans-glm-5.2");
-    expect(provider.escapeBuiltinToolNames).toBe(true);
+    expect(provider.modelContextWindows?.["umans-glm-5.2"]).toBe(405_504);
+    expect(provider.modelInputModalities?.["umans-glm-5.2"]).toEqual(["text", "image"]);
+    expect(provider.modelReasoningEfforts?.["umans-glm-5.2"]).toEqual(["high", "xhigh"]);
+    expect(provider.escapeBuiltinToolNames).toBeUndefined();
   });
 
   test("CLI key-login save payload preserves Umans runtime metadata", () => {
     const provider = providerConfigFromKeyLoginProvider(KEY_LOGIN_PROVIDERS.umans, "sk-umans");
 
     expect(provider).toMatchObject({
-      adapter: "anthropic",
-      baseUrl: "https://api.code.umans.ai",
+      adapter: "openai-chat",
+      baseUrl: "https://api.code.umans.ai/v1",
       apiKey: "sk-umans",
       defaultModel: "umans-coder",
-      escapeBuiltinToolNames: true,
     });
     expect(provider.models).toContain("umans-kimi-k2.7");
     expect(provider.modelReasoningEfforts?.["umans-glm-5.2"]).toEqual(["high", "xhigh"]);
     expect(provider.modelReasoningEffortMap?.["umans-glm-5.2"]?.xhigh).toBe("max");
-    expect(provider.noVisionModels).toContain("umans-glm-5.1");
+    expect(provider.modelContextWindows?.["umans-glm-5.2"]).toBe(405_504);
+    expect(provider.modelInputModalities?.["umans-glm-5.2"]).toEqual(["text", "image"]);
   });
 
-  test("Anthropic adapter posts Umans requests to /v1/messages with x-api-key", () => {
-    const req = createAnthropicAdapter(umansProvider()).buildRequest(parsedWithWebSearchTool());
+  test("OpenAI chat adapter posts Umans requests to /v1/chat/completions with bearer auth", () => {
+    const req = createOpenAIChatAdapter(umansProvider()).buildRequest(parsedWithWebSearchTool());
     const body = JSON.parse(req.body as string) as {
-      tools: Array<{ name: string }>;
-      tool_choice: { type: string; name: string };
-      system?: unknown;
+      tools: Array<{ function: { name: string } }>;
+      tool_choice: { type: string; function: { name: string } };
     };
 
-    expect(req.url).toBe("https://api.code.umans.ai/v1/messages");
+    expect(req.url).toBe("https://api.code.umans.ai/v1/chat/completions");
     expect(req.method).toBe("POST");
-    expect(req.headers.Authorization).toBeUndefined();
-    expect(req.headers["x-api-key"]).toBe("sk-umans");
-    expect(req.headers["anthropic-version"]).toBe("2023-06-01");
-    expect(req.headers["anthropic-beta"]).toBeUndefined();
-    expect(body.system).toBeUndefined();
-    expect(body.tools[0].name).toBe("ocx_web_search");
-    expect(body.tool_choice).toEqual({ type: "tool", name: "ocx_web_search" });
+    expect(req.headers.Authorization).toBe("Bearer sk-umans");
+    expect(req.headers["x-api-key"]).toBeUndefined();
+    expect(body.tools[0].function.name).toBe("web_search");
+    expect(body.tool_choice).toEqual({ type: "function", function: { name: "web_search" } });
   });
 
-  test("Anthropic adapter strips Umans compatibility prefix from streamed tool calls", async () => {
+  test("OpenAI chat adapter parses streamed Umans tool calls", async () => {
     const stream = new ReadableStream({
       start(controller) {
         controller.enqueue(new TextEncoder().encode(
-          `event: content_block_start\n` +
-          `data: {"type":"content_block_start","content_block":{"type":"tool_use","id":"toolu_1","name":"ocx_web_search"}}\n\n` +
-          `event: content_block_delta\n` +
-          `data: {"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{\\"query\\":\\"umans\\"}"}}\n\n` +
-          `event: content_block_stop\n` +
-          `data: {"type":"content_block_stop"}\n\n`,
+          `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"web_search","arguments":"{\\"query\\":\\"umans\\"}"}}]},"finish_reason":"tool_calls"}]}\n\n` +
+          `data: [DONE]\n\n`,
         ));
         controller.close();
       },
     });
 
-    const events = await collect(createAnthropicAdapter(umansProvider()).parseStream(new Response(stream)));
+    const events = await collect(createOpenAIChatAdapter(umansProvider()).parseStream(new Response(stream)));
 
-    expect(events[0]).toEqual({ type: "tool_call_start", id: "toolu_1", name: "web_search" });
-    expect(events[1]).toEqual({ type: "tool_call_delta", arguments: "{\"query\":\"umans\"}" });
-    expect(events[2]).toEqual({ type: "tool_call_end" });
-  });
-
-  test("Anthropic adapter strips Umans compatibility prefix from non-streaming tool calls", async () => {
-    const response = new Response(JSON.stringify({
-      content: [{
-        type: "tool_use",
-        id: "toolu_1",
-        name: "ocx_web_search",
-        input: { query: "umans" },
-      }],
-      usage: { input_tokens: 10, output_tokens: 3 },
-    }));
-
-    const events = await createAnthropicAdapter(umansProvider()).parseResponse(response);
-
-    expect(events[0]).toEqual({ type: "tool_call_start", id: "toolu_1", name: "web_search" });
+    expect(events[0]).toEqual({ type: "tool_call_start", id: "call_1", name: "web_search" });
     expect(events[1]).toEqual({ type: "tool_call_delta", arguments: "{\"query\":\"umans\"}" });
     expect(events[2]).toEqual({ type: "tool_call_end" });
     expect(events[3].type).toBe("done");
   });
 
-  test("Umans API-key validation uses Anthropic Messages shape", async () => {
+  test("OpenAI chat adapter parses non-streaming Umans tool calls", async () => {
+    const response = new Response(JSON.stringify({
+      choices: [{
+        message: {
+          tool_calls: [{
+            id: "call_1",
+            function: { name: "web_search", arguments: "{\"query\":\"umans\"}" },
+          }],
+        },
+      }],
+      usage: { prompt_tokens: 10, completion_tokens: 3 },
+    }));
+
+    const events = await createOpenAIChatAdapter(umansProvider()).parseResponse(response);
+
+    expect(events[0]).toEqual({ type: "tool_call_start", id: "call_1", name: "web_search" });
+    expect(events[1]).toEqual({ type: "tool_call_delta", arguments: "{\"query\":\"umans\"}" });
+    expect(events[2]).toEqual({ type: "tool_call_end" });
+    expect(events[3].type).toBe("done");
+  });
+
+  test("Umans API-key validation uses OpenAI-compatible models endpoint", async () => {
     let seenUrl = "";
     let seenInit: RequestInit | undefined;
     globalThis.fetch = (async (url, init) => {
@@ -145,15 +141,10 @@ describe("Umans provider", () => {
 
     const valid = await validateApiKey(KEY_LOGIN_PROVIDERS.umans, "sk-umans-valid");
     const headers = new Headers(seenInit?.headers);
-    const body = JSON.parse(String(seenInit?.body)) as Record<string, unknown>;
 
     expect(valid).toBe(true);
-    expect(seenUrl).toBe("https://api.code.umans.ai/v1/messages");
-    expect(seenInit?.method).toBe("POST");
-    expect(headers.get("x-api-key")).toBe("sk-umans-valid");
-    expect(headers.get("authorization")).toBeNull();
-    expect(headers.get("anthropic-version")).toBe("2023-06-01");
-    expect(body.model).toBe("umans-coder");
-    expect(body.max_tokens).toBe(1);
+    expect(seenUrl).toBe("https://api.code.umans.ai/v1/models");
+    expect(headers.get("authorization")).toBe("Bearer sk-umans-valid");
+    expect(headers.get("x-api-key")).toBeNull();
   });
 });


### PR DESCRIPTION
## What changed
- Adds Umans Code as a native key-based provider preset using `https://api.code.umans.ai/v1` and default model `umans-coder`.
- Carries Umans model metadata into routed Codex catalog entries for context windows, image input support, and Codex-safe reasoning controls.
- Adds registry, reasoning mapping, and catalog tests for the Umans provider.

## Why
Manual Umans config can route requests, but the GUI/provider preset list is derived from the native provider registry. Without a registry entry, Umans does not appear as a first-class provider.

## Validation
- `bun test tests/provider-registry-parity.test.ts tests/reasoning-effort.test.ts tests/codex-catalog.test.ts`
- `bun run typecheck`
- `bun test tests`
- Local derivation smoke confirmed `deriveProviderPresets()` includes `umans` and catalog entries expose docs-matched context/vision/reasoning metadata.