### PR TITLE
fix anthropic tool result history

### DIFF
--- a/src/adapters/anthropic.ts
+++ b/src/adapters/anthropic.ts
@@ -10,6 +10,7 @@ import type {
   OcxTextContent,
   OcxThinkingContent,
   OcxToolCall,
+  OcxToolResultMessage,
   OcxUsage,
 } from "../types";
 import { namespacedToolName } from "../types";
@@ -75,6 +76,28 @@ function buildToolNameTransforms(provider: OcxProviderConfig): { toWire: (name: 
   return { toWire: (name) => name, fromWire: (name) => name };
 }
 
+function toAnthropicToolResult(msg: OcxToolResultMessage): Record<string, unknown> {
+  // Anthropic tool_result accepts a string OR content blocks — render images natively
+  // (e.g. Codex view_image output) instead of dropping them.
+  const content = typeof msg.content === "string"
+    ? msg.content
+    : (msg.content as OcxContentPart[]).map(toAnthropicContentPart);
+  return {
+    type: "tool_result",
+    tool_use_id: msg.toolCallId,
+    content,
+    ...(msg.isError ? { is_error: true } : {}),
+  };
+}
+
+function orphanToolResultText(msg: OcxToolResultMessage): string {
+  const label = msg.toolName ? `${msg.toolName} (${msg.toolCallId})` : msg.toolCallId;
+  const content = typeof msg.content === "string"
+    ? msg.content
+    : JSON.stringify(msg.content);
+  return `[tool_result without adjacent tool_use: ${label}]\n${content}`;
+}
+
 function messagesToAnthropicFormat(
   parsed: OcxParsedRequest,
   toolNames: { toWire: (name: string) => string },
@@ -82,7 +105,8 @@ function messagesToAnthropicFormat(
   const system = parsed.context.systemPrompt?.join("\n\n") || undefined;
   const messages: unknown[] = [];
 
-  for (const msg of parsed.context.messages) {
+  for (let i = 0; i < parsed.context.messages.length; i++) {
+    const msg = parsed.context.messages[i];
     switch (msg.role) {
       case "user":
       case "developer": {
@@ -95,6 +119,7 @@ function messagesToAnthropicFormat(
       case "assistant": {
         const aMsg = msg as OcxAssistantMessage;
         const content: unknown[] = [];
+        const toolUseIds: string[] = [];
         for (const part of aMsg.content) {
           if (part.type === "text") {
             content.push({ type: "text", text: (part as OcxTextContent).text });
@@ -104,26 +129,46 @@ function messagesToAnthropicFormat(
           } else if (part.type === "toolCall") {
             const tc = part as OcxToolCall;
             const flatName = namespacedToolName(tc.namespace, tc.name);
+            toolUseIds.push(tc.id);
             content.push({ type: "tool_use", id: tc.id, name: toolNames.toWire(flatName), input: tc.arguments });
           }
         }
         messages.push({ role: "assistant", content });
+        if (toolUseIds.length > 0) {
+          const requiredIds = new Set(toolUseIds);
+          const resultBlocks: Record<string, unknown>[] = [];
+          const orphanBlocks: Record<string, unknown>[] = [];
+          const seen = new Set<string>();
+          let j = i + 1;
+          while (j < parsed.context.messages.length && parsed.context.messages[j].role === "toolResult") {
+            const tr = parsed.context.messages[j] as OcxToolResultMessage;
+            if (requiredIds.has(tr.toolCallId) && !seen.has(tr.toolCallId)) {
+              resultBlocks.push(toAnthropicToolResult(tr));
+              seen.add(tr.toolCallId);
+            } else {
+              orphanBlocks.push({ type: "text", text: orphanToolResultText(tr) });
+            }
+            j++;
+          }
+          for (const id of toolUseIds) {
+            if (!seen.has(id)) {
+              resultBlocks.push({
+                type: "tool_result",
+                tool_use_id: id,
+                content: "[opencodex: missing tool_result for this tool_use in Codex history]",
+                is_error: true,
+              });
+            }
+          }
+          messages.push({ role: "user", content: [...resultBlocks, ...orphanBlocks] });
+          i = j - 1;
+        }
         break;
       }
       case "toolResult": {
-        // Anthropic tool_result accepts a string OR content blocks — render images natively
-        // (e.g. Codex view_image output) instead of dropping them.
-        const trContent = typeof msg.content === "string"
-          ? msg.content
-          : (msg.content as OcxContentPart[]).map(toAnthropicContentPart);
-        messages.push({
-          role: "user",
-          content: [{
-            type: "tool_result",
-            tool_use_id: msg.toolCallId,
-            content: trContent,
-          }],
-        });
+        // A standalone Anthropic tool_result is invalid unless it immediately follows an
+        // assistant tool_use. Preserve the information as text instead of sending a 400-prone block.
+        messages.push({ role: "user", content: orphanToolResultText(msg as OcxToolResultMessage) });
         break;
       }
     }

--- a/tests/adapter-usage.test.ts
+++ b/tests/adapter-usage.test.ts
@@ -211,3 +211,92 @@ describe("openai-chat tool history repair", () => {
     expect(body.messages[1]).toMatchObject({ role: "tool", tool_call_id: "call_1" });
   });
 });
+
+describe("anthropic tool result history repair", () => {
+  test("merges adjacent tool results after multiple tool uses into one user message", () => {
+    const adapter = createAnthropicAdapter({ ...provider, adapter: "anthropic" });
+    const request = adapter.buildRequest({
+      modelId: "claude-sonnet",
+      context: {
+        messages: [
+          { role: "user", content: "start", timestamp: 0 },
+          {
+            role: "assistant",
+            content: [
+              { type: "toolCall", id: "call_1", name: "first_tool", arguments: {} },
+              { type: "toolCall", id: "call_2", name: "second_tool", arguments: {} },
+            ],
+            model: "claude-sonnet",
+            timestamp: 0,
+          },
+          { role: "toolResult", toolCallId: "call_1", toolName: "first_tool", content: "one", isError: false, timestamp: 0 },
+          { role: "toolResult", toolCallId: "call_2", toolName: "second_tool", content: "two", isError: false, timestamp: 0 },
+          { role: "user", content: "continue", timestamp: 0 },
+        ],
+      },
+      stream: true,
+      options: {},
+    });
+    const body = JSON.parse(request.body) as { messages: Array<{ role: string; content: any }> };
+
+    expect(body.messages).toHaveLength(4);
+    expect(body.messages[2].role).toBe("user");
+    expect(body.messages[2].content).toEqual([
+      { type: "tool_result", tool_use_id: "call_1", content: "one" },
+      { type: "tool_result", tool_use_id: "call_2", content: "two" },
+    ]);
+  });
+
+  test("adds an error tool result when history is missing a tool result", () => {
+    const adapter = createAnthropicAdapter({ ...provider, adapter: "anthropic" });
+    const request = adapter.buildRequest({
+      modelId: "claude-sonnet",
+      context: {
+        messages: [{
+          role: "assistant",
+          content: [{ type: "toolCall", id: "call_1", name: "read_file", arguments: {} }],
+          model: "claude-sonnet",
+          timestamp: 0,
+        }],
+      },
+      stream: true,
+      options: {},
+    });
+    const body = JSON.parse(request.body) as { messages: Array<{ role: string; content: any }> };
+
+    expect(body.messages[1]).toEqual({
+      role: "user",
+      content: [{
+        type: "tool_result",
+        tool_use_id: "call_1",
+        content: "[opencodex: missing tool_result for this tool_use in Codex history]",
+        is_error: true,
+      }],
+    });
+  });
+
+  test("preserves orphan tool results as text instead of invalid Anthropic tool_result blocks", () => {
+    const adapter = createAnthropicAdapter({ ...provider, adapter: "anthropic" });
+    const request = adapter.buildRequest({
+      modelId: "claude-sonnet",
+      context: {
+        messages: [{
+          role: "toolResult",
+          toolCallId: "orphan_call",
+          toolName: "lost_tool",
+          content: "orphan output",
+          isError: false,
+          timestamp: 0,
+        }],
+      },
+      stream: true,
+      options: {},
+    });
+    const body = JSON.parse(request.body) as { messages: Array<{ role: string; content: string }> };
+
+    expect(body.messages).toEqual([{
+      role: "user",
+      content: "[tool_result without adjacent tool_use: lost_tool (orphan_call)]\norphan output",
+    }]);
+  });
+});


### PR DESCRIPTION
Fixes Anthropic Messages requests that contain assistant tool_use blocks followed by multiple Codex toolResult messages. The adapter now merges matching adjacent tool results into the required immediate user message, synthesizes an error tool_result for missing history entries, and preserves orphan tool results as text so malformed history does not trigger upstream 400s. Tests: bun test tests; bun x tsc --noEmit