### PR TITLE
fix: guard stale proxy pid files

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -191,7 +191,7 @@ async function handleStart(options: { block?: boolean } = {}) {
       console.error(`⚠️  Proxy already running (PID ${existingPid}). Use 'ocx stop' first.`);
       process.exit(1);
     }
-    removePid();
+    removePid(existingPid);
   }
 
   const requestedPort = parsePortOption();
@@ -205,7 +205,7 @@ async function handleStart(options: { block?: boolean } = {}) {
     console.log("\n🛑 Shutting down opencodex proxy...");
     void (async () => {
       await drainAndShutdown(server, config.shutdownTimeoutMs ?? 5000);
-      removePid();
+      removePid(process.pid);
       if (!process.env.OCX_SERVICE) { try { restoreNativeCodex(); } catch { /* best-effort restore */ } }
       process.exit(0);
     })();
@@ -300,7 +300,7 @@ function handleStop() {
     try {
       killProxy(pid);
       console.log(`✅ Proxy (PID ${pid}) stopped.`);
-      removePid();
+      removePid(pid);
     } catch {
       stopFailed = true;
       console.error(`❌ Failed to stop proxy (PID ${pid}).`);
@@ -336,7 +336,7 @@ async function handleUninstall() {
     const pid = readPid();
     if (!pid) return false;
     killProxy(pid);
-    removePid();
+    removePid(pid);
     return true;
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { copyFileSync, existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync, chmodSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -172,7 +173,7 @@ export function writePid(pid: number): void {
   } else {
     hardenConfigDir();
   }
-  writeFileSync(getPidPath(), String(pid), "utf-8");
+  atomicWriteFile(getPidPath(), String(pid));
 }
 
 export function readPid(): number | null {
@@ -180,13 +181,15 @@ export function readPid(): number | null {
   if (!existsSync(pidPath)) return null;
   try {
     const raw = readFileSync(pidPath, "utf-8").trim();
-    const pid = parseInt(raw, 10);
-    if (isNaN(pid)) return null;
+    const pid = parsePidFile(raw);
+    if (pid === null) return null;
     try {
       process.kill(pid, 0);
-      return pid;
+      return isLikelyOcxStartProcess(pid) ? pid : null;
     } catch (e: unknown) {
-      if ((e as NodeJS.ErrnoException).code === "EPERM") return pid;
+      if ((e as NodeJS.ErrnoException).code === "EPERM") {
+        return isLikelyOcxStartProcess(pid) ? pid : null;
+      }
       return null;
     }
   } catch {
@@ -194,7 +197,8 @@ export function readPid(): number | null {
   }
 }
 
-export function removePid(): void {
+export function removePid(expectedPid?: number): void {
+  if (expectedPid !== undefined && readPidFileValue() !== expectedPid) return;
   try {
     unlinkSync(getPidPath());
   } catch { /* ignore */ }
@@ -205,6 +209,56 @@ function warnConfigRepaired(configPath: string, error: z.ZodError): void {
   warnedConfigFallbacks.add(configPath);
   const fields = error.issues.map(i => i.path.join(".") || "config").join(", ");
   console.error(`opencodex config at ${configPath}: repaired missing field(s) [${fields}] with defaults. Your providers and accounts are preserved.`);
+}
+
+function readPidFileValue(): number | null {
+  try {
+    return parsePidFile(readFileSync(getPidPath(), "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+export function parsePidFile(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const pid = Number.parseInt(trimmed, 10);
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : null;
+}
+
+export function isOcxStartCommandLine(commandLine: string): boolean {
+  const normalized = commandLine.toLowerCase().replace(/\\/g, "/");
+  const hasOcxEntrypoint = normalized.includes("src/cli.ts")
+    || normalized.includes("@bitkyc08/opencodex")
+    || /(?:^|[\s/"'])(?:ocx|opencodex)(?:\.cmd)?(?:$|[\s"'])/.test(normalized);
+  return hasOcxEntrypoint && /(?:^|[\s"'])start(?:$|[\s"'])/.test(normalized);
+}
+
+function isLikelyOcxStartProcess(pid: number): boolean {
+  const commandLine = readProcessCommandLine(pid);
+  if (commandLine === undefined) return true;
+  return isOcxStartCommandLine(commandLine);
+}
+
+function readProcessCommandLine(pid: number): string | undefined {
+  try {
+    if (process.platform === "win32") {
+      const output = execFileSync("powershell.exe", [
+        "-NoProfile",
+        "-Command",
+        `(Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}").CommandLine`,
+      ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"], timeout: 3000 });
+      return output.trim() || undefined;
+    }
+    const output = execFileSync("ps", ["-p", String(pid), "-o", "command="], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 1000,
+    });
+    return output.trim() || undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function warnAndBackupInvalidConfig(configPath: string, error: unknown): void {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -2,7 +2,17 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { codexAutoStartEnabled, getConfigPath, getDefaultConfig, loadConfig } from "../src/config";
+import {
+  codexAutoStartEnabled,
+  getConfigPath,
+  getDefaultConfig,
+  getPidPath,
+  isOcxStartCommandLine,
+  loadConfig,
+  parsePidFile,
+  removePid,
+  writePid,
+} from "../src/config";
 
 let testDir = "";
 
@@ -132,5 +142,38 @@ describe("opencodex config defaults", () => {
     } finally {
       errorSpy.mockRestore();
     }
+  });
+
+  test("parses pid files", () => {
+    expect(parsePidFile("12345")).toBe(12345);
+    expect(parsePidFile("0")).toBeNull();
+    expect(parsePidFile("12x")).toBeNull();
+    expect(parsePidFile("not-json")).toBeNull();
+  });
+
+  test("recognizes opencodex start command lines", () => {
+    expect(isOcxStartCommandLine('bun run src/cli.ts start')).toBe(true);
+    expect(isOcxStartCommandLine('"C:/tools/bun/bin/bun.exe" "run" "src/cli.ts" "start"')).toBe(true);
+    expect(isOcxStartCommandLine('bun C:/tools/bun/install/global/node_modules/@bitkyc08/opencodex/src/cli.ts start')).toBe(true);
+    expect(isOcxStartCommandLine("opencodex start")).toBe(true);
+
+    expect(isOcxStartCommandLine("bun run src/cli.ts status")).toBe(false);
+    expect(isOcxStartCommandLine("bun test C:/work/opencodex/tests/config.test.ts")).toBe(false);
+    expect(isOcxStartCommandLine("notepad.exe")).toBe(false);
+  });
+
+  test("writes pid file as a numeric pid", () => {
+    writePid(process.pid);
+
+    expect(readFileSync(getPidPath(), "utf-8")).toBe(String(process.pid));
+  });
+
+  test("removes pid file only when the expected pid still matches", () => {
+    writeFileSync(getPidPath(), "111", "utf-8");
+    removePid(222);
+    expect(existsSync(getPidPath())).toBe(true);
+
+    removePid(111);
+    expect(existsSync(getPidPath())).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- keep `ocx.pid` in the existing numeric PID format, but parse it strictly
- verify that a live PID still looks like an opencodex `start` process before treating it as the proxy
- pass the expected PID when removing pid files so a concurrent/new proxy pid file is not removed accidentally
- add focused config tests for PID parsing, command-line matching, pid writes, and guarded removal

## Why

A PID file that stores only a number can become stale if the original proxy exits and the OS later reuses that PID for an unrelated process. In that case `process.kill(pid, 0)` can report success even though opencodex is not running, which can make `ocx status`, `ocx stop`, or startup checks act on the wrong process.

This keeps backward compatibility with the existing pid file shape while adding a best-effort process command-line check. If the platform command-line lookup is unavailable, the code falls back to the previous alive-PID behavior instead of failing closed and breaking older/locked-down environments.

## Validation

- `git diff --check`
- `bun test tests/config.test.ts`
- `bun run typecheck`