### PR TITLE
feat: add request log metadata filters

### DIFF
--- a/docs-site/src/content/docs/guides/web-dashboard.md
+++ b/docs-site/src/content/docs/guides/web-dashboard.md
@@ -65,6 +65,7 @@ The GUI is a thin client over the proxy's management API. Useful endpoints (all 
 | `PUT /api/codex-auth/auto-switch` | Set the quota threshold for automatic new-session account selection. |
 | `PUT /api/codex-auth/failover` | Set how many transient upstream failures trigger future-session failover. |
 | `POST /api/codex-auth/login` · `GET /api/codex-auth/login-status` | Add a pool account through the browser login flow. |
+| `GET /api/logs?tail=50&provider=…&status=5xx` | Read recent request metadata with optional tail, provider, and status filters. |
 | `GET` / `PUT /api/subagent-models` | Read / set the featured subagent models. |
 | `POST /api/stop` | Gracefully stop the proxy (and the background service if installed), restore native Codex, then exit. |
 

--- a/gui/src/i18n/en.ts
+++ b/gui/src/i18n/en.ts
@@ -115,9 +115,11 @@ export const en = {
   "logs.autoRefresh": "Auto-refresh",
   "logs.noRequests": "No requests yet.",
   "logs.col.time": "Time",
+  "logs.col.request": "Request",
   "logs.col.model": "Model",
   "logs.col.provider": "Provider",
   "logs.col.status": "Status",
+  "logs.col.error": "Error",
   "logs.col.duration": "Duration",
 
   // add-provider modal

--- a/gui/src/i18n/ko.ts
+++ b/gui/src/i18n/ko.ts
@@ -115,9 +115,11 @@ export const ko: Record<TKey, string> = {
   "logs.autoRefresh": "자동 새로고침",
   "logs.noRequests": "아직 요청이 없습니다.",
   "logs.col.time": "시간",
+  "logs.col.request": "요청",
   "logs.col.model": "모델",
   "logs.col.provider": "프로바이더",
   "logs.col.status": "상태",
+  "logs.col.error": "오류",
   "logs.col.duration": "소요 시간",
 
   // add-provider modal

--- a/gui/src/i18n/zh.ts
+++ b/gui/src/i18n/zh.ts
@@ -115,9 +115,11 @@ export const zh: Record<TKey, string> = {
   "logs.autoRefresh": "自动刷新",
   "logs.noRequests": "暂无请求。",
   "logs.col.time": "时间",
+  "logs.col.request": "请求",
   "logs.col.model": "模型",
   "logs.col.provider": "提供方",
   "logs.col.status": "状态",
+  "logs.col.error": "错误",
   "logs.col.duration": "耗时",
 
   // add-provider modal

--- a/gui/src/pages/Logs.tsx
+++ b/gui/src/pages/Logs.tsx
@@ -2,11 +2,13 @@ import { useEffect, useState } from "react";
 import { useI18n, LOCALES } from "../i18n";
 
 interface LogEntry {
+  requestId?: string;
   timestamp: number;
   model: string;
   provider: string;
   status: number;
   durationMs: number;
+  errorCode?: string;
 }
 
 export default function Logs({ apiBase }: { apiBase: string }) {
@@ -49,21 +51,25 @@ export default function Logs({ apiBase }: { apiBase: string }) {
             <thead>
               <tr>
                 <th>{t("logs.col.time")}</th>
+                <th>{t("logs.col.request")}</th>
                 <th>{t("logs.col.model")}</th>
                 <th>{t("logs.col.provider")}</th>
                 <th>{t("logs.col.status")}</th>
+                <th>{t("logs.col.error")}</th>
                 <th className="num">{t("logs.col.duration")}</th>
               </tr>
             </thead>
             <tbody>
               {[...logs].reverse().map((log, i) => (
-                <tr key={i}>
+                <tr key={log.requestId ?? `${log.timestamp}-${i}`}>
                   <td className="muted mono">{new Date(log.timestamp).toLocaleTimeString(localeTag)}</td>
+                  <td className="muted mono">{log.requestId ?? "-"}</td>
                   <td className="mono">{log.model}</td>
                   <td className="muted">{log.provider}</td>
                   <td>
                     <span className="mono" style={{ color: statusColor(log.status), fontWeight: 600 }}>{log.status}</span>
                   </td>
+                  <td className="muted mono">{log.errorCode ?? "-"}</td>
                   <td className="num">{log.durationMs}ms</td>
                 </tr>
               ))}

--- a/src/server.ts
+++ b/src/server.ts
@@ -522,12 +522,56 @@ async function fetchWithHeaderTimeout(
   }
 }
 
-const requestLog: { timestamp: number; model: string; provider: string; status: number; durationMs: number }[] = [];
-const MAX_LOG_SIZE = 200;
+export interface RequestLogEntry {
+  requestId: string;
+  timestamp: number;
+  model: string;
+  provider: string;
+  status: number;
+  durationMs: number;
+  errorCode?: string;
+}
 
-function addRequestLog(entry: typeof requestLog[number]) {
+const requestLog: RequestLogEntry[] = [];
+const MAX_LOG_SIZE = 200;
+let requestLogSeq = 0;
+
+function addRequestLog(entry: RequestLogEntry) {
   requestLog.push(entry);
   if (requestLog.length > MAX_LOG_SIZE) requestLog.shift();
+}
+
+export function nextRequestLogId(timestamp = Date.now()): string {
+  requestLogSeq = (requestLogSeq % 1_000_000) + 1;
+  return `ocx-${timestamp.toString(36)}-${requestLogSeq.toString(36)}`;
+}
+
+export function requestLogErrorCode(status: number): string | undefined {
+  if (status >= 200 && status < 400) return undefined;
+  if (status === 400 || status === 409) return "invalid_request_error";
+  if (status === 401 || status === 403) return "invalid_api_key";
+  if (status === 429) return "rate_limit_exceeded";
+  if (status === 503) return "server_is_overloaded";
+  if (status >= 500) return "upstream_server_error";
+  return `http_${status}`;
+}
+
+export function filterRequestLogs(logs: RequestLogEntry[], params: URLSearchParams): RequestLogEntry[] {
+  let filtered = logs;
+  const provider = params.get("provider")?.trim();
+  if (provider) filtered = filtered.filter(entry => entry.provider === provider);
+  const status = params.get("status")?.trim().toLowerCase();
+  if (status) {
+    filtered = /^[1-5]xx$/.test(status)
+      ? filtered.filter(entry => Math.floor(entry.status / 100) === Number(status[0]))
+      : filtered.filter(entry => String(entry.status) === status);
+  }
+  const tailRaw = params.get("tail")?.trim();
+  if (tailRaw) {
+    const tail = Number.parseInt(tailRaw, 10);
+    if (Number.isFinite(tail) && tail > 0) filtered = filtered.slice(-Math.min(tail, MAX_LOG_SIZE));
+  }
+  return filtered;
 }
 
 /**
@@ -941,7 +985,7 @@ async function handleManagementAPI(req: Request, url: URL, config: OcxConfig): P
   }
 
   if (url.pathname === "/api/logs" && req.method === "GET") {
-    return jsonResponse(requestLog);
+    return jsonResponse(filterRequestLogs(requestLog, url.searchParams));
   }
 
   if (url.pathname === "/api/providers" && req.method === "GET") {
@@ -1228,14 +1272,18 @@ export function startServer(port?: number) {
           return formatErrorResponse(403, "origin_rejected", "cross-origin data-plane request blocked");
         }
         const start = Date.now();
+        const requestId = nextRequestLogId(start);
         const logCtx = { model: "unknown", provider: "unknown" };
         const response = await handleResponses(req, config, logCtx);
+        const errorCode = requestLogErrorCode(response.status);
         addRequestLog({
+          requestId,
           timestamp: start,
           model: logCtx.model,
           provider: logCtx.provider,
           status: response.status,
           durationMs: Date.now() - start,
+          ...(errorCode ? { errorCode } : {}),
         });
         return response;
       }

--- a/tests/request-log.test.ts
+++ b/tests/request-log.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import {
+  filterRequestLogs,
+  nextRequestLogId,
+  requestLogErrorCode,
+  type RequestLogEntry,
+} from "../src/server";
+
+function log(overrides: Partial<RequestLogEntry>): RequestLogEntry {
+  return {
+    requestId: "ocx-test",
+    timestamp: 1,
+    model: "gpt-test",
+    provider: "openai",
+    status: 200,
+    durationMs: 10,
+    ...overrides,
+  };
+}
+
+describe("request log metadata", () => {
+  test("generates compact request ids", () => {
+    expect(nextRequestLogId(1_700_000_000_000)).toMatch(/^ocx-[a-z0-9]+-[a-z0-9]+$/);
+    expect(nextRequestLogId(1_700_000_000_000)).not.toBe(nextRequestLogId(1_700_000_000_000));
+  });
+
+  test("classifies status codes without reading response bodies", () => {
+    expect(requestLogErrorCode(200)).toBeUndefined();
+    expect(requestLogErrorCode(400)).toBe("invalid_request_error");
+    expect(requestLogErrorCode(401)).toBe("invalid_api_key");
+    expect(requestLogErrorCode(429)).toBe("rate_limit_exceeded");
+    expect(requestLogErrorCode(503)).toBe("server_is_overloaded");
+    expect(requestLogErrorCode(502)).toBe("upstream_server_error");
+  });
+
+  test("filters logs by provider, status, and tail", () => {
+    const logs = [
+      log({ requestId: "a", provider: "openai", status: 200 }),
+      log({ requestId: "b", provider: "umans", status: 429 }),
+      log({ requestId: "c", provider: "umans", status: 502 }),
+      log({ requestId: "d", provider: "opencode-go", status: 500 }),
+    ];
+
+    expect(filterRequestLogs(logs, new URLSearchParams("provider=umans")).map(entry => entry.requestId)).toEqual(["b", "c"]);
+    expect(filterRequestLogs(logs, new URLSearchParams("status=5xx")).map(entry => entry.requestId)).toEqual(["c", "d"]);
+    expect(filterRequestLogs(logs, new URLSearchParams("status=429")).map(entry => entry.requestId)).toEqual(["b"]);
+    expect(filterRequestLogs(logs, new URLSearchParams("tail=2")).map(entry => entry.requestId)).toEqual(["c", "d"]);
+  });
+});


### PR DESCRIPTION
## Summary

- add stable request ids and status-derived error codes to `/api/logs` entries
- support metadata-only log filters: `tail`, `provider`, and `status` (`429` or `5xx` style)
- show request id and error code columns in the dashboard logs table
- document the logs endpoint query shape in the dashboard guide

## Notes

This intentionally keeps request logging metadata-only. It does not store raw request bodies, response bodies, headers, tokens, or user content.

## Validation

- `git diff --check`
- `bun test tests/request-log.test.ts`
- `bun run typecheck`
- `cd gui && bun run build`