### PR TITLE
fix(gui): format dashboard uptime for readability

### DIFF
--- a/gui/src/formatUptime.ts
+++ b/gui/src/formatUptime.ts
@@ -1,0 +1,27 @@
+import type { Locale } from "./i18n";
+
+const UPTIME_UNITS: Record<Locale, { day: string; hour: string; minute: string; second: string }> = {
+  en: { day: "d", hour: "h", minute: "m", second: "s" },
+  ko: { day: "일", hour: "시간", minute: "분", second: "초" },
+  zh: { day: "天", hour: "小时", minute: "分钟", second: "秒" },
+};
+
+export function formatUptime(seconds: number, locale: Locale): string {
+  const totalSeconds = Math.max(0, Math.floor(seconds));
+  const units = UPTIME_UNITS[locale] ?? UPTIME_UNITS.en;
+
+  if (totalSeconds < 5 * 60) return `${totalSeconds}${units.second}`;
+
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) return `${totalMinutes}${units.minute}`;
+
+  const totalHours = Math.floor(totalMinutes / 60);
+  if (totalHours < 24) {
+    const minutes = totalMinutes % 60;
+    return minutes > 0 ? `${totalHours}${units.hour} ${minutes}${units.minute}` : `${totalHours}${units.hour}`;
+  }
+
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours % 24;
+  return hours > 0 ? `${days}${units.day} ${hours}${units.hour}` : `${days}${units.day}`;
+}

--- a/gui/src/pages/Dashboard.tsx
+++ b/gui/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
+import { formatUptime } from "../formatUptime";
 import { IconAlert } from "../icons";
-import { useT, Trans } from "../i18n";
+import { useI18n, Trans } from "../i18n";
 
 interface HealthData { status: string; version: string; uptime: number }
 interface ProviderInfo { name: string; adapter: string; baseUrl: string; defaultModel?: string; hasApiKey: boolean }
@@ -19,7 +20,7 @@ const SIDECAR_MODELS = ["gpt-5.4-mini", "gpt-5.4", "gpt-5.5", "gpt-5.3-codex-spa
 const REASONING_LEVELS = ["low", "medium", "high"];
 
 export default function Dashboard({ apiBase }: { apiBase: string }) {
-  const t = useT();
+  const { locale, t } = useI18n();
   const [health, setHealth] = useState<HealthData | null>(null);
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [models, setModels] = useState<ModelInfo[]>([]);
@@ -143,7 +144,7 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
           </div>
         </div>
         <div className="stat"><div className="label">{t("dash.version")}</div><div className="value mono">{health?.version ?? "—"}</div></div>
-        <div className="stat"><div className="label">{t("dash.uptime")}</div><div className="value mono">{health ? `${Math.floor(health.uptime)}s` : "—"}</div></div>
+        <div className="stat"><div className="label">{t("dash.uptime")}</div><div className="value mono">{health ? formatUptime(health.uptime, locale) : "—"}</div></div>
         <div className="stat"><div className="label">{t("dash.providers")}</div><div className="value">{providers.length}</div></div>
         <div className="stat">
           <div className="label">{t("dash.tokens30d")}</div>

--- a/tests/dashboard-uptime.test.ts
+++ b/tests/dashboard-uptime.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { formatUptime } from "../gui/src/formatUptime";
+
+describe("dashboard uptime formatting", () => {
+  test("keeps short uptimes in seconds", () => {
+    expect(formatUptime(0, "ko")).toBe("0초");
+    expect(formatUptime(299.9, "ko")).toBe("299초");
+  });
+
+  test("uses minutes after five minutes", () => {
+    expect(formatUptime(300, "ko")).toBe("5분");
+    expect(formatUptime(3599, "ko")).toBe("59분");
+  });
+
+  test("uses hours and minutes after one hour", () => {
+    expect(formatUptime(3600, "ko")).toBe("1시간");
+    expect(formatUptime(64685, "ko")).toBe("17시간 58분");
+  });
+
+  test("uses days and hours after one day", () => {
+    expect(formatUptime(86400, "ko")).toBe("1일");
+    expect(formatUptime(183600, "ko")).toBe("2일 3시간");
+  });
+
+  test("uses compact localized units", () => {
+    expect(formatUptime(3720, "en")).toBe("1h 2m");
+    expect(formatUptime(93600, "zh")).toBe("1天 2小时");
+  });
+});


### PR DESCRIPTION
## Summary

- format the dashboard uptime tile as human-readable elapsed time instead of raw seconds
- keep sub-5-minute uptimes in seconds, then switch to minutes, hours/minutes, and days/hours
- add focused boundary tests for the formatter across Korean, English, and Chinese unit output

## Verification

- `bun test tests/dashboard-uptime.test.ts` passed: 5 pass, 0 fail
- `cd gui && bun run build` passed
- `bun run typecheck` passed
- `git diff --check` passed with only the existing Windows CRLF/LF warning on `gui/src/pages/Dashboard.tsx`

## Notes

This targets `dev` because the dashboard/tooling branch already includes the latest maintainer-side integration work.
