### PR TITLE
fix(logs): finalize native passthrough SSE usage

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -518,14 +518,13 @@ async function handleResponses(
       const turnAc = new AbortController();
       linkAbortSignal(upstream, turnAc.signal);
       registerTurn(turnAc);
-      if (terminalBodyWillRecord && recordTerminalOutcomes) {
-        const recordTerminal = terminalRecorder;
+      if (recordTerminalOutcomes) {
         const reportNativeTerminal = (status: ResponsesTerminalStatus) => {
           if (options.abortSignal?.aborted) {
             options.onNativePassthroughCancel?.();
             return;
           }
-          recordTerminal(status);
+          terminalRecorder?.(status);
           options.onNativePassthroughTerminal?.(status);
         };
         consumeForInspection(inspectBody, reportNativeTerminal, turnAc.signal, () => unregisterTurn(turnAc), logCtx);

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -843,6 +843,87 @@ describe("server local API auth", () => {
     }
   });
 
+  test("native passthrough SSE records completed usage without pool terminal tracking", async () => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+
+    const upstream = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(
+          [
+            "event: response.completed",
+            'data: {"type":"response.completed","response":{"status":"completed","model":"gpt-5.5","usage":{"input_tokens":11,"output_tokens":7,"input_tokens_details":{"cached_tokens":3},"output_tokens_details":{"reasoning_tokens":2}}}}',
+            "",
+            "",
+          ].join("\n"),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      },
+    });
+    saveConfig({
+      port: 0,
+      defaultProvider: "test-openai",
+      providers: {
+        "test-openai": {
+          adapter: "openai-responses",
+          baseUrl: upstream.url.toString(),
+          apiKey: "provider-key",
+          defaultModel: "gpt-5.5",
+        },
+      },
+    } as OcxConfig);
+
+    const server = startServer(0);
+    try {
+      const response = await fetch(new URL("/v1/responses", server.url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "gpt-5.5", input: "hello", stream: true }),
+      });
+
+      expect(response.status).toBe(200);
+      await response.text();
+      const logs = await fetch(new URL("/api/logs?tail=1", server.url)).then(r => r.json()) as Array<{
+        status: number;
+        terminalStatus?: string;
+        closeReason?: string;
+        usageStatus?: string;
+        totalTokens?: number;
+        usage?: { inputTokens: number; outputTokens: number; cachedInputTokens?: number; reasoningOutputTokens?: number };
+      }>;
+      expect(logs.at(-1)).toMatchObject({
+        status: 200,
+        terminalStatus: "completed",
+        closeReason: "terminal",
+        usageStatus: "reported",
+        totalTokens: 18,
+        usage: {
+          inputTokens: 11,
+          outputTokens: 7,
+          cachedInputTokens: 3,
+          reasoningOutputTokens: 2,
+        },
+      });
+
+      const usage = await fetch(new URL("/api/usage?range=all", server.url)).then(r => r.json()) as {
+        summary: { requests: number; reportedRequests: number; totalTokens: number };
+        models: Array<{ provider: string; model: string; reportedRequests: number; totalTokens: number }>;
+      };
+      expect(usage.summary).toMatchObject({ requests: 1, reportedRequests: 1, totalTokens: 18 });
+      expect(usage.models.at(-1)).toMatchObject({
+        provider: "test-openai",
+        model: "gpt-5.5",
+        reportedRequests: 1,
+        totalTokens: 18,
+      });
+    } finally {
+      await server.stop(true);
+      await upstream.stop(true);
+    }
+  });
+
   test("passthrough SSE client cancel aborts the upstream request", async () => {
     if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
     mkdirSync(TEST_DIR, { recursive: true });


### PR DESCRIPTION
## Summary

- finalize request logs for native passthrough SSE even when no Codex pool terminal recorder is active
- preserve the existing native relay path used for the Bun SSE passthrough workaround
- add a regression test that verifies `/api/logs` and `/api/usage` receive reported usage from a completed native passthrough SSE response

Refs #44.

## Why

Native passthrough SSE responses are marked with `markNativePassthroughSseResponse(...)`, so `responseWithDeferredRequestLog(...)` intentionally skips the normal client-facing SSE logging wrapper. Before this change, the background inspection path finalized the request log only when `terminalBodyWillRecord` was true, which requires a Codex forward/pool terminal recorder.

That left key-based native `openai-responses` passthrough streams able to deliver the upstream response while not finalizing the request log entry. The usage dashboard then could miss the completed request, or fail to count reported usage that was present in the terminal SSE payload.

## Changed Behavior

| Case | Before | After |
| --- | --- | --- |
| Native passthrough SSE with no pool terminal recorder | background inspection could read metadata without finalizing `/api/logs` | background inspection finalizes terminal/cancel logging and still records usage metadata |
| Codex forward/pool passthrough SSE | terminal recorder finalized quota/health and request log | unchanged, with the terminal recorder called when present |
| WebSocket/native relay workaround | native SSE response still bypasses the JS client-facing wrapper | unchanged |

## Verification

- `bun test tests/server-auth.test.ts` -> 30 pass
- `bun run typecheck` -> pass
- `bun test tests/request-log.test.ts tests/passthrough-abort.test.ts` -> 22 pass
- `git diff --check` -> pass

## Notes

This only records usage when the upstream terminal SSE payload includes usage. If the native ChatGPT/OpenAI upstream omits usage entirely, the request can still be finalized as unreported; this PR does not synthesize usage from Codex session files.
