### PR TITLE
fix: support Google Gemini /models lfix: support Google Gemini models listing via x-goog-api-keyisting via x-goog-api-key header

### DIFF
--- a/src/codex-catalog.ts
+++ b/src/codex-catalog.ts
@@ -687,7 +687,14 @@ async function fetchProviderModels(name: string, prov: OcxProviderConfig, ttlMs:
       return stale ? applyConfigHintsToCachedModels(name, prov, stale, contextCap) : configured;
     }
     const json = await res.json() as { data?: ProviderModelsApiItem[] };
-    const live = (json.data ?? []).map(m => applyProviderConfigHints(name, prov, {
+    const jsonData = (json as any).data;
+    const models = name === "google" && prov.adapter === "google" && Array.isArray((json as any).models)
+      ? ((json as any).models as Array<{name?: string; displayName?: string}>).map((m: any) => ({
+          id: (m.name ?? '').replace(/^models\//, ''),
+          owned_by: "google",
+        }))
+      : (jsonData ?? []);
+    const live = models.map(m => applyProviderConfigHints(name, prov, {
       id: m.id,
       provider: name,
       owned_by: m.owned_by,

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -195,6 +195,10 @@ export function buildModelsRequest(prov: OcxProviderConfig, apiKey: string | und
     }
     return { url: `${prov.baseUrl}/v1/models?limit=1000`, headers };
   }
+  if (prov.adapter === "google") {
+    if (apiKey) headers["x-goog-api-key"] = apiKey;
+    return { url: ${prov.baseUrl}/v1/models, headers };
+  }
   if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
   return { url: `${prov.baseUrl}/models`, headers };
 }


### PR DESCRIPTION
Google Generative Language API uses x-goog-api-key header instead of Authorization: Bearer, and its /models response returns { models: [{ name: "models/gemini-..." }] } rather than OpenAI's { data: [{ id: "gemini-..." }] } format.
This fix handles both issues so that the Google provider's models appear in the opencodex dashboard and Codex model picker.