### PR TITLE
[codex] fix provider error classification

### DIFF
--- a/docs/adr/0002-structured-provider-error-classification.md
+++ b/docs/adr/0002-structured-provider-error-classification.md
@@ -1,0 +1,38 @@
+# ADR 0002: Structured Provider Error Classification
+
+## Status
+
+Accepted
+
+## Context
+
+Routed providers can fail in three different shapes: direct non-2xx HTTP responses, inline error
+frames inside a 200 streaming response, and transport/read failures after a stream has started.
+The old bridge collapsed most inline adapter errors to a message-only `502 upstream_error`. The
+classifier then looked for text such as `rate limit` and could produce `rate_limit_exceeded` even
+when the upstream did not return HTTP 429 or a structured rate-limit code.
+
+That was especially risky for compatibility providers such as Umans, where an upstream gateway can
+include rate-limit wording in a generic Anthropic-style error while the user's billing/usage limit is
+not actually exhausted.
+
+## Decision
+
+Adapters now preserve structured upstream error metadata when it exists:
+
+- `status`: HTTP-like status inferred from provider code/type or explicit numeric fields.
+- `code`: provider/OpenAI-style error code such as `rate_limit_exceeded`.
+- `errorType`: provider enum/type such as `rate_limit_error`, `RESOURCE_EXHAUSTED`, or
+  `ThrottlingException`.
+
+The bridge passes that metadata to the shared classifier. The classifier treats rate-limit as
+confirmed only when the actual status is `429` or a structured provider code/type says rate-limit.
+Plain message text alone no longer turns a `502` stream failure into `rate_limit_exceeded`.
+
+## Consequences
+
+- False 429/rate-limit reports from message-only compatibility errors are reduced.
+- Real provider rate limits still surface as Codex-compatible `rate_limit_exceeded` when upstream
+  sends HTTP 429 or structured code/type metadata.
+- Stream truncation and read failures are explicitly marked as upstream stream errors rather than
+  silently completing or being guessed from provider prose.

--- a/src/adapters/anthropic.ts
+++ b/src/adapters/anthropic.ts
@@ -18,6 +18,7 @@ import { ANTHROPIC_OAUTH_BETA, CLAUDE_CODE_SYSTEM_INSTRUCTION, applyClaudeToolPr
 import { parseDataUrl } from "./image";
 import { neutralizeIdentity } from "./identity";
 import { CLAUDE_CODE_HEADERS, claudeCodeSessionId } from "./client-fingerprint";
+import { errorEvent, errorEventFromEnvelope } from "./error-events";
 
 /** Map a user content part to an Anthropic content block (text or image source). */
 function toAnthropicContentPart(p: OcxContentPart): unknown {
@@ -325,7 +326,7 @@ export function createAnthropicAdapter(provider: OcxProviderConfig): ProviderAda
 
     async *parseStream(response: Response): AsyncGenerator<AdapterEvent> {
       if (!response.body) {
-        yield { type: "error", message: "No response body" };
+        yield errorEvent("No response body");
         return;
       }
 
@@ -418,8 +419,7 @@ export function createAnthropicAdapter(provider: OcxProviderConfig): ProviderAda
                 break;
               }
               case "error": {
-                const err = data.error as { message?: string } | undefined;
-                yield { type: "error", message: err?.message ?? "Anthropic error" };
+                yield errorEventFromEnvelope(data.error, "Anthropic error");
                 return;
               }
             }
@@ -427,6 +427,11 @@ export function createAnthropicAdapter(provider: OcxProviderConfig): ProviderAda
           }
         }
         if (pendingUsage && !emittedDone) yield* emitDone();
+      } catch (err) {
+        yield errorEvent(`Anthropic stream read failed: ${err instanceof Error ? err.message : String(err)}`, {
+          status: 502,
+          code: "upstream_stream_error",
+        });
       } finally {
         reader.releaseLock();
       }

--- a/src/adapters/error-events.ts
+++ b/src/adapters/error-events.ts
@@ -1,0 +1,61 @@
+import type { AdapterEvent } from "../types";
+
+type ErrorEnvelope = {
+  message?: unknown;
+  code?: unknown;
+  type?: unknown;
+  status?: unknown;
+  error?: unknown;
+};
+
+function safeString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function numericStatus(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isInteger(value) && value >= 100 && value <= 599) return value;
+  if (typeof value === "string" && /^\d{3}$/.test(value.trim())) return Number(value.trim());
+  return undefined;
+}
+
+function normalized(value: string | undefined): string | undefined {
+  return value?.trim().toLowerCase();
+}
+
+export function statusFromErrorIdentifiers(code?: string | null, errorType?: string | null): number | undefined {
+  const ids = new Set([code, errorType].map(value => normalized(value ?? undefined)).filter((value): value is string => !!value));
+  if (ids.has("rate_limit_error") || ids.has("rate_limit_exceeded") || ids.has("too_many_requests") || ids.has("throttlingexception") || ids.has("resource_exhausted")) return 429;
+  if (ids.has("insufficient_quota") || ids.has("quota_exceeded") || ids.has("billing_hard_limit_reached")) return 402;
+  if (ids.has("authentication_error") || ids.has("invalid_api_key") || ids.has("unauthenticated") || ids.has("unauthenticated_error")) return 401;
+  if (ids.has("permission_denied") || ids.has("access_denied")) return 403;
+  if (ids.has("invalid_request_error") || ids.has("invalid_argument") || ids.has("bad_request")) return 400;
+  if (ids.has("not_found")) return 404;
+  if (ids.has("server_is_overloaded") || ids.has("unavailable")) return 503;
+  return undefined;
+}
+
+/* [Decision Log]
+- 목적: streaming provider 오류가 200 OK 안쪽의 JSON/SSE frame으로 도착해도 실제 provider code/type/status를 잃지 않도록 한다.
+- 대안 분석: (1) 각 adapter에서 message string만 조립하면 기존 구현은 작지만 false 429와 연결 끊김 오분류가 반복된다. (2) provider별 error payload를 bridge까지 그대로 노출하면 타입이 퍼지고 redaction 책임이 흐려진다. (3) 공통 helper가 OpenAI/Anthropic/Google 계열 envelope를 작은 AdapterEvent metadata로 정규화한다.
+- 선택 근거: bridge와 classifier는 하나의 작은 계약만 알면 되고, provider별 parser는 기존 위치에서 안전하게 metadata만 추가하면 된다.
+*/
+export function errorEventFromEnvelope(error: unknown, fallbackMessage = "upstream error"): Extract<AdapterEvent, { type: "error" }> {
+  const envelope = (error && typeof error === "object" ? error : {}) as ErrorEnvelope;
+  const nested = envelope.error && typeof envelope.error === "object" ? envelope.error as ErrorEnvelope : undefined;
+  const source = nested ?? envelope;
+  const message = safeString(source.message) ?? safeString(envelope.message) ?? fallbackMessage;
+  const code = safeString(source.code);
+  const errorType = safeString(source.type) ?? safeString(source.status);
+  const status = numericStatus(source.status) ?? numericStatus(source.code) ?? statusFromErrorIdentifiers(code, errorType);
+  return {
+    type: "error",
+    message,
+    ...(status !== undefined ? { status } : {}),
+    ...(code !== undefined ? { code } : {}),
+    ...(errorType !== undefined ? { errorType } : {}),
+  };
+}
+
+export function errorEvent(message: string, metadata: Omit<Extract<AdapterEvent, { type: "error" }>, "type" | "message"> = {}): Extract<AdapterEvent, { type: "error" }> {
+  return { type: "error", message, ...metadata };
+}

--- a/src/adapters/google-http.ts
+++ b/src/adapters/google-http.ts
@@ -4,6 +4,7 @@ import { isQuotaExhaustedBody, retryableGoogleStatus, safeGoogleHttpErrorMessage
 const GOOGLE_RETRY_ATTEMPTS = 3;
 const GOOGLE_RETRY_BASE_MS = 250;
 const GOOGLE_RETRY_MAX_MS = 2_000;
+const GOOGLE_RETRY_AFTER_MAX_MS = 60_000;
 
 function retryAfterMs(headers: Headers): number | undefined {
   const raw = headers.get("retry-after")?.trim();
@@ -17,7 +18,7 @@ function retryAfterMs(headers: Headers): number | undefined {
 
 function retryDelayMs(attempt: number, headers?: Headers): number {
   const retryAfter = headers ? retryAfterMs(headers) : undefined;
-  if (retryAfter !== undefined) return Math.min(retryAfter, GOOGLE_RETRY_MAX_MS);
+  if (retryAfter !== undefined) return Math.min(retryAfter, GOOGLE_RETRY_AFTER_MAX_MS);
   const exp = Math.min(GOOGLE_RETRY_BASE_MS * (2 ** attempt), GOOGLE_RETRY_MAX_MS);
   return Math.floor(exp * (0.8 + Math.random() * 0.4));
 }

--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -21,6 +21,7 @@ import { sanitizeGeminiToolParameters } from "./google-tool-schema";
 import { neutralizeIdentity } from "./identity";
 import { antigravityUsesReplayCache, applyAntigravityReplay, clearAntigravityReplay, observeAntigravityReplay } from "./google-antigravity-replay";
 import { resolveAntigravityWireModelId } from "../providers/antigravity-models";
+import { errorEvent, errorEventFromEnvelope } from "./error-events";
 
 // Google-family models (Gemini/Vertex/Antigravity) tend to emit long running commentary between
 // tool calls. This steers them to keep the BETWEEN-STEP text to one line and reason internally
@@ -297,7 +298,7 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
 
     async *parseStream(response: Response): AsyncGenerator<AdapterEvent> {
       if (!response.body) {
-        yield { type: "error", message: "No response body" };
+        yield errorEvent("No response body");
         return;
       }
 
@@ -327,14 +328,13 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
 
             // Inline provider error inside a 200 stream → terminal error (see openai-chat.ts).
             if (chunk.error) {
-              const err = chunk.error as { message?: string } | undefined;
               // Clear-on-invalid: a signature rejection means our replayed thoughtSignatures are stale.
               // Drop the cache entry so the next turn starts clean instead of re-injecting a bad sig.
               if (provider.googleMode === "cloud-code-assist" && antigravityModel && antigravitySession
-                && /signature|invalid_argument|invalid argument/i.test(err?.message ?? "")) {
+                && /signature|invalid_argument|invalid argument/i.test((chunk.error as { message?: string } | undefined)?.message ?? "")) {
                 clearAntigravityReplay(antigravityModel, antigravitySession);
               }
-              yield { type: "error", message: err?.message ?? "upstream error" };
+              yield errorEventFromEnvelope(chunk.error);
               return;
             }
 
@@ -380,10 +380,25 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
         // an error instead of a silently-incomplete done. Mirrors kiro-truncation.
         if ((provider.googleMode === "vertex" || provider.googleMode === "cloud-code-assist")
           && toolCallsStarted > 0 && isVertexTruncationReason(lastFinishReason)) {
-          yield { type: "error", message: vertexTruncationErrorMessage(lastFinishReason) };
+          yield errorEvent(vertexTruncationErrorMessage(lastFinishReason), {
+            status: 502,
+            code: "upstream_stream_truncated",
+          });
+          return;
+        }
+        if (!lastFinishReason && pendingUsage === undefined) {
+          yield errorEvent("Google stream ended without finishReason or usage metadata — possible truncation", {
+            status: 502,
+            code: "upstream_stream_truncated",
+          });
           return;
         }
         yield { type: "done", usage: pendingUsage };
+      } catch (err) {
+        yield errorEvent(`Google stream read failed: ${err instanceof Error ? err.message : String(err)}`, {
+          status: 502,
+          code: "upstream_stream_error",
+        });
       } finally {
         reader.releaseLock();
       }
@@ -420,7 +435,10 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
       // (MAX_TOKENS / MALFORMED_FUNCTION_CALL) surfaces an error instead of a silent done.
       if ((provider.googleMode === "vertex" || provider.googleMode === "cloud-code-assist")
         && toolCallsStarted > 0 && isVertexTruncationReason(candidates?.[0]?.finishReason)) {
-        return [{ type: "error", message: vertexTruncationErrorMessage(candidates?.[0]?.finishReason) }];
+        return [errorEvent(vertexTruncationErrorMessage(candidates?.[0]?.finishReason), {
+          status: 502,
+          code: "upstream_stream_truncated",
+        })];
       }
 
       const usage = json.usageMetadata as Record<string, number> | undefined;

--- a/src/adapters/kiro-errors.ts
+++ b/src/adapters/kiro-errors.ts
@@ -96,6 +96,18 @@ export function safeKiroErrorMessage(headers: Record<string, unknown>, payloadTe
   return normalizedKiroErrorMessage(headers, payloadText);
 }
 
+export function kiroEventErrorMetadata(headers: Record<string, unknown>, payloadText: string): { status?: number; code?: string; errorType?: string } {
+  const headerType = headerValue(headers, ":exception-type") || headerValue(headers, ":error-type");
+  const parts = [headerType, ...payloadDetails(payloadText)].filter((part): part is string => !!part);
+  const classification = classifyKiroText(undefined, parts.join(" "));
+  if (classification === "Kiro rate limit exceeded") return { status: 429, code: "rate_limit_exceeded", ...(headerType ? { errorType: headerType } : {}) };
+  if (classification === "Kiro quota exhausted") return { status: 402, code: "insufficient_quota", ...(headerType ? { errorType: headerType } : {}) };
+  if (classification === "Kiro authentication failed") return { status: 401, code: "invalid_api_key", ...(headerType ? { errorType: headerType } : {}) };
+  if (classification === "Kiro server overloaded") return { status: 503, code: "server_is_overloaded", ...(headerType ? { errorType: headerType } : {}) };
+  if (classification === "Kiro invalid request") return { status: 400, code: "invalid_request_error", ...(headerType ? { errorType: headerType } : {}) };
+  return headerType ? { errorType: headerType } : {};
+}
+
 export function safeKiroHttpErrorMessage(status: number, headers: Headers | Record<string, unknown>, payloadText: string): string {
   return normalizedKiroErrorMessage(headers, payloadText, status);
 }

--- a/src/adapters/kiro-retry.ts
+++ b/src/adapters/kiro-retry.ts
@@ -4,6 +4,7 @@ import { safeKiroHttpErrorMessage } from "./kiro-errors";
 const KIRO_RETRY_ATTEMPTS = 3;
 const KIRO_RETRY_BASE_MS = 250;
 const KIRO_RETRY_MAX_MS = 2_000;
+const KIRO_RETRY_AFTER_MAX_MS = 60_000;
 
 function retryableKiroStatus(status: number): boolean {
   return status === 429 || status === 500 || status === 502 || status === 503 || status === 504;
@@ -21,7 +22,7 @@ function retryAfterMs(headers: Headers): number | undefined {
 
 function retryDelayMs(attempt: number, headers?: Headers): number {
   const retryAfter = headers ? retryAfterMs(headers) : undefined;
-  if (retryAfter !== undefined) return Math.min(retryAfter, KIRO_RETRY_MAX_MS);
+  if (retryAfter !== undefined) return Math.min(retryAfter, KIRO_RETRY_AFTER_MAX_MS);
   const exp = Math.min(KIRO_RETRY_BASE_MS * (2 ** attempt), KIRO_RETRY_MAX_MS);
   return Math.floor(exp * (0.8 + Math.random() * 0.4));
 }

--- a/src/adapters/kiro.ts
+++ b/src/adapters/kiro.ts
@@ -5,11 +5,12 @@ import { resolveKiroApiRegion, resolveKiroProfileArn } from "../oauth/kiro";
 import { KIRO_MODEL_CONTEXT_WINDOWS, normalizeKiroModelId } from "../providers/kiro-models";
 import { modelRecordValue } from "../reasoning-effort";
 import { parseKiroEvent } from "./kiro-events";
-import { safeKiroErrorMessage } from "./kiro-errors";
+import { kiroEventErrorMetadata, safeKiroErrorMessage } from "./kiro-errors";
 import { appendFallbackText, toolCallFallbackText, toolResultFallbackText } from "./kiro-tool-fallback";
 import { KiroThinkingParser } from "./kiro-thinking";
 import { isCompleteKiroToolInput, kiroTruncationErrorMessage } from "./kiro-truncation";
 import { fallbackToolUseId, fingerprint, invocationId, kiroToolName, mapModelId, normalizeToolId, osTag, stableConversationId } from "./kiro-wire";
+import { errorEvent } from "./error-events";
 import { namespacedToolName } from "../types";
 import type {
   AdapterEvent,
@@ -338,7 +339,7 @@ export async function* parseKiroStream(
   nameMap?: Map<string, string>,
 ): AsyncGenerator<AdapterEvent> {
   if (!response.body) {
-    yield { type: "error", message: "Kiro response has no body" };
+    yield errorEvent("Kiro response has no body");
     return;
   }
   let open: { id: string; name: string; chunks: string[] } | null = null;
@@ -367,7 +368,8 @@ export async function* parseKiroStream(
       if (mt === "exception" || mt === "error") {
         // Terminal: surface the upstream error and never emit a trailing success-shaped `done`.
         open = null;
-        yield { type: "error", message: safeKiroErrorMessage(msg.headers, new TextDecoder().decode(msg.payload)) };
+        const payloadText = new TextDecoder().decode(msg.payload);
+        yield errorEvent(safeKiroErrorMessage(msg.headers, payloadText), kiroEventErrorMetadata(msg.headers, payloadText));
         return;
       }
       if (mt && mt !== "event") continue;
@@ -384,7 +386,10 @@ export async function* parseKiroStream(
         case "content":
           if (open) {
             open = null;
-            yield { type: "error", message: kiroTruncationErrorMessage("content arrived before tool stop") };
+            yield errorEvent(kiroTruncationErrorMessage("content arrived before tool stop"), {
+              status: 502,
+              code: "upstream_stream_truncated",
+            });
             return;
           }
           if (ev.data) {
@@ -404,7 +409,10 @@ export async function* parseKiroStream(
           if (open) {
             if (open.id !== id || open.name !== name) {
               open = null;
-              yield { type: "error", message: kiroTruncationErrorMessage("new tool started before previous tool stop") };
+              yield errorEvent(kiroTruncationErrorMessage("new tool started before previous tool stop"), {
+                status: 502,
+                code: "upstream_stream_truncated",
+              });
               return;
             }
           } else {
@@ -434,7 +442,10 @@ export async function* parseKiroStream(
             const input = open.chunks.join("");
             if (!isCompleteKiroToolInput(input)) {
               open = null;
-              yield { type: "error", message: kiroTruncationErrorMessage("incomplete tool input JSON") };
+              yield errorEvent(kiroTruncationErrorMessage("incomplete tool input JSON"), {
+                status: 502,
+                code: "upstream_stream_truncated",
+              });
               return;
             }
             yield* flushTool();
@@ -443,7 +454,10 @@ export async function* parseKiroStream(
         }
         case "truncation":
           open = null;
-          yield { type: "error", message: kiroTruncationErrorMessage(ev.data) };
+          yield errorEvent(kiroTruncationErrorMessage(ev.data), {
+            status: 502,
+            code: "upstream_stream_truncated",
+          });
           return;
       }
     }
@@ -455,7 +469,10 @@ export async function* parseKiroStream(
       const input = open.chunks.join("");
       if (!isCompleteKiroToolInput(input)) {
         open = null;
-        yield { type: "error", message: kiroTruncationErrorMessage("stream ended before tool stop") };
+        yield errorEvent(kiroTruncationErrorMessage("stream ended before tool stop"), {
+          status: 502,
+          code: "upstream_stream_truncated",
+        });
         return;
       }
       yield* flushTool();
@@ -466,7 +483,10 @@ export async function* parseKiroStream(
     if (totalTokens !== undefined) usage.totalTokens = totalTokens;
     yield { type: "done", usage };
   } catch (err) {
-    yield { type: "error", message: safeKiroErrorMessage({}, err instanceof Error ? err.message : String(err)) };
+    yield errorEvent(safeKiroErrorMessage({}, err instanceof Error ? err.message : String(err)), {
+      status: 502,
+      code: "upstream_stream_error",
+    });
   }
 }
 

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -5,6 +5,7 @@ import { isAllowedToolChoice, modelInList, namespacedToolName, resolveToolChoice
 import { mapReasoningEffort } from "../reasoning-effort";
 import { contentPartsToText } from "./image";
 import { neutralizeIdentity } from "./identity";
+import { errorEvent, errorEventFromEnvelope } from "./error-events";
 
 // Z.AI's "glm-5.2[1m]" 1M-context id is a Claude-Code / Anthropic-endpoint-only
 // convention; OpenAI-compatible chat-completions endpoints reject the bracketed
@@ -213,7 +214,7 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
 
     async *parseStream(response: Response): AsyncGenerator<AdapterEvent> {
       if (!response.body) {
-        yield { type: "error", message: "No response body" };
+        yield errorEvent("No response body");
         return;
       }
 
@@ -257,9 +258,8 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
         // instead of a clean [DONE]. Surface it as a terminal error so the bridge emits a
         // classified response.failed (bridge case "error") — never a truncated completion.
         if (chunk.error) {
-          const err = chunk.error as { message?: string } | undefined;
           if (currentToolCallId) yield { type: "tool_call_end" };
-          yield { type: "error", message: err?.message ?? "upstream error" };
+          yield errorEventFromEnvelope(chunk.error);
           return "terminate";
         }
 
@@ -340,11 +340,19 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
         // at end-of-generation). If NONE of those were seen, the stream was cut mid-flight — fail
         // closed so the bridge emits a classified response.failed rather than a silent truncation.
         if (!sawFinish && pendingUsage === undefined) {
-          yield { type: "error", message: "upstream stream ended without a terminal signal ([DONE] or finish_reason) — possible truncation" };
+          yield errorEvent("upstream stream ended without a terminal signal ([DONE] or finish_reason) — possible truncation", {
+            status: 502,
+            code: "upstream_stream_truncated",
+          });
           return;
         }
         // Graceful close that omitted [DONE] but delivered finish_reason and/or final usage.
         yield { type: "done", usage: pendingUsage };
+      } catch (err) {
+        yield errorEvent(`upstream stream read failed: ${err instanceof Error ? err.message : String(err)}`, {
+          status: 502,
+          code: "upstream_stream_error",
+        });
       } finally {
         reader.releaseLock();
       }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1,5 +1,5 @@
 import type { AdapterEvent, OcxUsage } from "./types";
-import { classifyError, type OcxErrorPayload } from "./errors";
+import { classifyError, type OcxErrorHints, type OcxErrorPayload } from "./errors";
 import { usageDisplayTotalTokens, usageInputTokensWithCacheDetail } from "./usage-totals";
 
 function uuid(): string {
@@ -27,8 +27,15 @@ function responsesUsage(usage: OcxUsage | undefined): Record<string, unknown> {
   return out;
 }
 
-function responseError(status: number, type: string, message: string): OcxErrorPayload {
-  return classifyError(status, type, message);
+function responseError(status: number, type: string, message: string, hints?: OcxErrorHints): OcxErrorPayload {
+  return classifyError(status, type, message, hints);
+}
+
+function adapterError(event: Extract<AdapterEvent, { type: "error" }>): OcxErrorPayload {
+  return responseError(event.status ?? 502, "upstream_error", event.message, {
+    code: event.code,
+    errorType: event.errorType,
+  });
 }
 
 /**
@@ -450,11 +457,12 @@ export function bridgeToResponsesSSE(
               if (currentRawReasoning) closeCurrentRawReasoning();
               if (currentToolCall) closeCurrentToolCall();
               if (currentWebSearch) closeCurrentWebSearch("failed", []);
+              const error = adapterError(event);
               emit("response.failed", {
                 response: {
                   ...responseSnapshot("failed", finishedItems),
-                  error: responseError(502, "upstream_error", event.message),
-                  last_error: responseError(502, "upstream_error", event.message),
+                  error,
+                  last_error: error,
                 },
               });
               reportTerminal("failed");
@@ -527,7 +535,7 @@ export function buildResponseJSON(
   const responseId = `resp_${uuid()}`;
   const output: OutputItem[] = [];
   let usage: OcxUsage | undefined;
-  let errorMessage: string | undefined;
+  let errorPayload: OcxErrorPayload | undefined;
 
   let currentText = "";
   let currentSummaryReasoning = "";
@@ -662,7 +670,7 @@ export function buildResponseJSON(
         }
         break;
       case "error":
-        errorMessage = e.message;
+        errorPayload = adapterError(e);
         break;
       case "done":
         usage = e.usage;
@@ -677,15 +685,17 @@ export function buildResponseJSON(
   return {
     id: responseId, object: "response",
     created_at: Math.floor(Date.now() / 1000),
-    status: errorMessage ? "failed" : "completed",
+    status: errorPayload ? "failed" : "completed",
     model: modelId, output,
-    ...(errorMessage ? { error: { message: errorMessage } } : {}),
+    ...(errorPayload ? { error: errorPayload } : {}),
     usage: responsesUsage(usage),
   };
 }
 
-export function formatErrorResponse(status: number, type: string, message: string): Response {
-  return new Response(JSON.stringify({ error: classifyError(status, type, message) }), {
-    status, headers: { "Content-Type": "application/json" },
+export function formatErrorResponse(status: number, type: string, message: string, options?: { hints?: OcxErrorHints; headers?: HeadersInit }): Response {
+  const headers = new Headers(options?.headers);
+  headers.set("Content-Type", "application/json");
+  return new Response(JSON.stringify({ error: classifyError(status, type, message, options?.hints) }), {
+    status, headers,
   });
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -4,9 +4,29 @@ export interface OcxErrorPayload {
   code: string | null;
 }
 
-export function classifyError(status: number, type: string, message: string): OcxErrorPayload {
+export interface OcxErrorHints {
+  code?: string | null;
+  errorType?: string | null;
+}
+
+function normalizedHint(value: string | null | undefined): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim().toLowerCase() : undefined;
+}
+
+function hintSet(type: string, hints?: OcxErrorHints): Set<string> {
+  return new Set([type, hints?.code, hints?.errorType].map(normalizedHint).filter((v): v is string => !!v));
+}
+
+/* [Decision Log]
+- 목적: upstream 오류를 Codex 호환 error code로 변환하되, provider 메시지에 섞인 "rate limit" 문구만으로 가짜 429를 만들지 않기 위함.
+- 대안 분석: (1) 기존처럼 message substring만 사용하면 간단하지만 Umans 같은 compatibility provider에서 false rate-limit이 발생한다. (2) 모든 upstream error를 그대로 passthrough하면 Codex가 context/quota/auth 오류를 제대로 인식하지 못한다. (3) HTTP status와 구조화된 provider code/type을 우선하고, message fallback은 context/auth/overload처럼 덜 모호한 오류에만 남긴다.
+- 선택 근거: adapter가 보존한 status/code/type을 신뢰하면 실제 429와 연결 끊김/일반 upstream 실패를 구분할 수 있고, 기존 Codex 호환 error envelope는 유지된다.
+*/
+export function classifyError(status: number, type: string, message: string, hints?: OcxErrorHints): OcxErrorPayload {
   const text = message.toLowerCase();
+  const ids = hintSet(type, hints);
   if (
+    ids.has("context_length_exceeded") ||
     text.includes("context_length_exceeded") ||
     text.includes("context window") ||
     text.includes("context length") ||
@@ -16,6 +36,8 @@ export function classifyError(status: number, type: string, message: string): Oc
     return { message, type: "invalid_request_error", code: "context_length_exceeded" };
   }
   if (
+    ids.has("insufficient_quota") ||
+    status === 402 ||
     text.includes("insufficient_quota") ||
     text.includes("exceeded your current quota") ||
     text.includes("quota exhausted") ||
@@ -27,10 +49,11 @@ export function classifyError(status: number, type: string, message: string): Oc
   }
   if (
     status === 429 ||
-    text.includes("rate limit") ||
-    text.includes("rate limited") ||
-    text.includes("too many requests") ||
-    text.includes("throttlingexception")
+    ids.has("rate_limit_error") ||
+    ids.has("rate_limit_exceeded") ||
+    ids.has("too_many_requests") ||
+    ids.has("throttlingexception") ||
+    ids.has("resource_exhausted")
   ) {
     return { message, type: "rate_limit_error", code: "rate_limit_exceeded" };
   }
@@ -41,6 +64,11 @@ export function classifyError(status: number, type: string, message: string): Oc
     status === 401 ||
     status === 403 ||
     type === "authentication_error" ||
+    ids.has("authentication_error") ||
+    ids.has("invalid_api_key") ||
+    ids.has("unauthenticated") ||
+    ids.has("unauthenticated_error") ||
+    ids.has("permission_denied") ||
     text.includes("authentication failed") ||
     text.includes("access denied") ||
     text.includes("unauthorizedexception") ||
@@ -53,6 +81,8 @@ export function classifyError(status: number, type: string, message: string): Oc
   }
   if (
     status === 503 ||
+    ids.has("server_is_overloaded") ||
+    ids.has("unavailable") ||
     text.includes("overloaded") ||
     text.includes("server is busy") ||
     text.includes("temporarily unavailable")
@@ -62,6 +92,10 @@ export function classifyError(status: number, type: string, message: string): Oc
     return { message, type: "server_error", code: "server_is_overloaded" };
   }
   if (
+    ids.has("invalid_request_error") ||
+    ids.has("invalid_argument") ||
+    ids.has("bad_request") ||
+    ids.has("not_found") ||
     text.includes("validationexception") ||
     text.includes("invalid request") ||
     text.includes("model unavailable") ||

--- a/src/server.ts
+++ b/src/server.ts
@@ -501,7 +501,12 @@ async function handleResponses(
   if (!upstreamResponse.ok) {
     const errorText = await upstreamResponse.text().catch(() => "unknown error");
     cleanupUpstreamAbort();
-    return formatErrorResponse(upstreamResponse.status, "upstream_error", `Provider error ${upstreamResponse.status}: ${errorText.slice(0, 500)}`);
+    return formatErrorResponse(
+      upstreamResponse.status,
+      "upstream_error",
+      `Provider error ${upstreamResponse.status}: ${errorText.slice(0, 500)}`,
+      { headers: errorResponseHeaders(upstreamResponse.headers) },
+    );
   }
 
   if (parsed.stream) {
@@ -1300,6 +1305,12 @@ export function sanitizePassthroughHeaders(upstream: Headers): Headers {
     if (!DROP.has(key.toLowerCase())) out.set(key, value);
   });
   return out;
+}
+
+function errorResponseHeaders(upstream: Headers): Headers {
+  const headers = sanitizePassthroughHeaders(upstream);
+  headers.delete("content-type");
+  return headers;
 }
 
 let _corsOrigin = "http://localhost:10100";

--- a/src/types.ts
+++ b/src/types.ts
@@ -192,7 +192,13 @@ export type AdapterEvent =
   | { type: "web_search_call_begin"; id: string }
   | { type: "web_search_call_end"; id: string; queries: string[]; status?: "completed" | "failed"; sources?: OcxUrlCitation[] }
   | { type: "done"; usage?: OcxUsage }
-  | { type: "error"; message: string };
+  | {
+    type: "error";
+    message: string;
+    status?: number;
+    code?: string | null;
+    errorType?: string | null;
+  };
 
 /**
  * A web source backing a search answer. Surfaced on the search-end event and rendered by the bridge

--- a/tests/adapter-error-inline.test.ts
+++ b/tests/adapter-error-inline.test.ts
@@ -37,25 +37,41 @@ describe("inline error envelope in a 200 stream (F1)", () => {
       'data: {"error":{"message":"Rate limit reached for model","code":"rate_limit_exceeded"}}\n\n',
     ].join(""));
     const events = await collect(adapter.parseStream(response));
-    expect(events.find(e => e.type === "error")).toMatchObject({ message: "Rate limit reached for model" });
+    expect(events.find(e => e.type === "error")).toMatchObject({
+      message: "Rate limit reached for model",
+      status: 429,
+      code: "rate_limit_exceeded",
+    });
   });
 
   test("google yields a terminal error on an inline error frame", async () => {
     const adapter = createGoogleAdapter({ ...provider, adapter: "google" });
     const response = new Response('data: {"error":{"message":"RESOURCE_EXHAUSTED","code":429}}\n\n');
     const events = await collect(adapter.parseStream(response));
-    expect(events.find(e => e.type === "error")).toMatchObject({ message: "RESOURCE_EXHAUSTED" });
+    expect(events.find(e => e.type === "error")).toMatchObject({ message: "RESOURCE_EXHAUSTED", status: 429 });
   });
 
-  test("bridge converts the adapter error into a classified response.failed (no completed)", async () => {
+  test("bridge converts a structured adapter rate-limit error into a classified response.failed (no completed)", async () => {
     async function* gen(): AsyncGenerator<AdapterEvent> {
       yield { type: "text_delta", text: "par" };
-      yield { type: "error", message: "Rate limit reached for model" };
+      yield { type: "error", message: "Rate limit reached for model", status: 429, code: "rate_limit_exceeded" };
     }
     const frames = await collectSse(bridgeToResponsesSSE(gen(), "routed/model"));
     const failed = frames.find(f => f.event === "response.failed");
     expect(failed).toBeDefined();
     expect((failed!.data.response as Record<string, unknown>).error).toMatchObject({ code: "rate_limit_exceeded" });
     expect(frames.some(f => f.event === "response.completed")).toBe(false);
+  });
+
+  test("bridge does not turn message-only rate-limit text into a false 429", async () => {
+    async function* gen(): AsyncGenerator<AdapterEvent> {
+      yield { type: "error", message: "provider said rate limit, but sent no status or code" };
+    }
+    const frames = await collectSse(bridgeToResponsesSSE(gen(), "umans/umans-coder"));
+    const failed = frames.find(f => f.event === "response.failed");
+    expect((failed!.data.response as Record<string, unknown>).error).toMatchObject({
+      type: "server_error",
+      code: "upstream_server_error",
+    });
   });
 });

--- a/tests/error-fidelity.test.ts
+++ b/tests/error-fidelity.test.ts
@@ -46,7 +46,7 @@ describe("error fidelity", () => {
       type: "invalid_request_error",
       code: "origin_rejected",
     });
-    expect(classifyError(502, "upstream_error", "Kiro rate limit exceeded: ThrottlingException: rate limited")).toMatchObject({
+    expect(classifyError(502, "upstream_error", "Kiro rate limit exceeded: ThrottlingException: rate limited", { errorType: "ThrottlingException" })).toMatchObject({
       type: "rate_limit_error",
       code: "rate_limit_exceeded",
     });
@@ -74,6 +74,22 @@ describe("error fidelity", () => {
         code: "rate_limit_exceeded",
       },
     });
+  });
+
+  test("message-only rate-limit text on a 502 remains an upstream server error", () => {
+    expect(classifyError(502, "upstream_error", "Provider said rate limit without status or code")).toMatchObject({
+      type: "server_error",
+      code: "upstream_server_error",
+    });
+  });
+
+  test("formatErrorResponse preserves safe retry metadata headers", () => {
+    const response = formatErrorResponse(429, "upstream_error", "Rate limit reached", {
+      headers: { "Retry-After": "8", "X-RateLimit-Reset": "later" },
+    });
+    expect(response.headers.get("retry-after")).toBe("8");
+    expect(response.headers.get("x-ratelimit-reset")).toBe("later");
+    expect(response.headers.get("content-type")).toContain("application/json");
   });
 
   test("streaming response.failed includes both error and last_error", async () => {

--- a/tests/google-vertex-stream.test.ts
+++ b/tests/google-vertex-stream.test.ts
@@ -72,6 +72,18 @@ describe("vertex parseStream fail-closed truncation", () => {
     expect(usage?.inputTokens).toBe(7);
     expect(usage?.outputTokens).toBe(3);
   });
+
+  test("EOF without finishReason or usage fails closed as possible truncation", async () => {
+    const events = await collect(vertexProvider, [
+      { candidates: [{ content: { parts: [{ text: "partial" }] } }] },
+    ]);
+    expect(events.at(-1)).toMatchObject({
+      type: "error",
+      status: 502,
+      code: "upstream_stream_truncated",
+    });
+    expect(events.some(e => e.type === "done")).toBe(false);
+  });
 });
 
 describe("vertex parseResponse fail-closed truncation (non-streaming)", () => {

--- a/tests/openai-chat-eof.test.ts
+++ b/tests/openai-chat-eof.test.ts
@@ -44,7 +44,11 @@ describe("openai-chat stream EOF fail-closed", () => {
       'data: {"error":{"message":"Rate limit reached for model","code":"rate_limit_exceeded"}}\n\n',
     ].join(""));
     const events = await collect(createOpenAIChatAdapter(provider).parseStream(response));
-    expect(events.find(e => e.type === "error")).toMatchObject({ message: "Rate limit reached for model" });
+    expect(events.find(e => e.type === "error")).toMatchObject({
+      message: "Rate limit reached for model",
+      status: 429,
+      code: "rate_limit_exceeded",
+    });
   });
 
   test("finish-only chunk with no delta (provider omits [DONE]) is accepted as done", async () => {

--- a/tests/umans-provider.test.ts
+++ b/tests/umans-provider.test.ts
@@ -154,6 +154,43 @@ describe("Umans provider", () => {
     expect(events[2]).toEqual({ type: "tool_call_end" });
   });
 
+  test("Anthropic adapter does not invent Umans rate-limit metadata from message text alone", async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(
+          `event: error\n` +
+          `data: {"type":"error","error":{"message":"rate limit text from compatibility layer"}}\n\n`,
+        ));
+        controller.close();
+      },
+    });
+
+    const events = await collect(createAnthropicAdapter(umansProvider()).parseStream(new Response(stream)));
+
+    expect(events.at(-1)).toEqual({ type: "error", message: "rate limit text from compatibility layer" });
+  });
+
+  test("Anthropic adapter preserves structured Umans rate-limit errors", async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(
+          `event: error\n` +
+          `data: {"type":"error","error":{"type":"rate_limit_error","message":"rate limit reached"}}\n\n`,
+        ));
+        controller.close();
+      },
+    });
+
+    const events = await collect(createAnthropicAdapter(umansProvider()).parseStream(new Response(stream)));
+
+    expect(events.at(-1)).toEqual({
+      type: "error",
+      message: "rate limit reached",
+      status: 429,
+      errorType: "rate_limit_error",
+    });
+  });
+
   test("Anthropic adapter strips Umans compatibility prefix from non-streaming tool calls", async () => {
     const response = new Response(JSON.stringify({
       content: [{


### PR DESCRIPTION
## Summary

- Preserve structured provider error metadata (`status`, `code`, `errorType`) through adapter error events and the Responses bridge.
- Stop classifying message-only `rate limit` text on 502 stream failures as `rate_limit_exceeded`, which reduces false 429 reports for Umans-style compatibility errors.
- Mark stream read failures/truncations as upstream stream errors for OpenAI-compatible, Anthropic/Umans, Google/Vertex, and Kiro paths.
- Preserve safe upstream retry metadata headers on wrapped non-2xx provider errors and honor longer `Retry-After` values in Google/Kiro retry wrappers.
- Add ADR 0002 documenting the structured error-classification decision.

## Root Cause

Inline streaming provider errors were collapsed to message-only adapter events. The shared classifier then inferred rate limits from message substrings, so a provider/gateway message containing `rate limit` could become a Codex `rate_limit_exceeded` error even without HTTP 429 or a structured provider rate-limit code.

## Validation

- `bun run typecheck`
- `bun test tests/adapter-error-inline.test.ts tests/umans-provider.test.ts tests/error-fidelity.test.ts tests/openai-chat-eof.test.ts tests/google-vertex-stream.test.ts tests/kiro-stream.test.ts tests/kiro-retry.test.ts tests/google-vertex-http.test.ts`
- `bun test ./tests/`