### PR TITLE
Preserve DeepSeek V4 thinking history

### DIFF
--- a/docs/adr/0003-deepseek-v4-thinking-history.md
+++ b/docs/adr/0003-deepseek-v4-thinking-history.md
@@ -1,0 +1,33 @@
+# ADR 0003: DeepSeek V4 thinking history is model-scoped metadata
+
+## Status
+
+Accepted
+
+## Context
+
+DeepSeek V4 thinking mode returns assistant `reasoning_content` and expects that
+field to be passed back in later multi-turn and tool-call requests. If the
+gateway drops that history, DeepSeek can reject the next request with a 400 that
+says the `reasoning_content` from thinking mode must be passed back.
+
+opencodex already has a provider flag for OpenAI-compatible chat models that
+require reasoning history replay: `preserveReasoningContentModels`.
+
+## Decision
+
+DeepSeek V4 thinking models are marked in the provider registry with:
+
+- model-scoped Codex reasoning levels
+- `xhigh` to upstream `max` reasoning effort mapping
+- `preserveReasoningContentModels`
+
+This is not enabled for every OpenAI-compatible provider or for the legacy
+`deepseek-reasoner` preset.
+
+## Consequences
+
+- Existing saved `deepseek` configs receive the new metadata at route time.
+- DeepSeek V4 tool-call/subagent turns keep `reasoning_content` on assistant
+  history messages, including messages that also carry `tool_calls`.
+- The older DeepSeek reasoner behavior remains unchanged.

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -73,6 +73,15 @@ const ZAI_GLM_52_REASONING_MAP: Record<string, string> = {
   xhigh: "max",
   max: "max",
 };
+const DEEPSEEK_THINKING_MODELS = ["deepseek-v4-pro", "deepseek-v4-flash"];
+const DEEPSEEK_THINKING_EFFORTS = ["high", "xhigh"];
+const DEEPSEEK_THINKING_REASONING_MAP: Record<string, string> = {
+  low: "high",
+  medium: "high",
+  high: "high",
+  xhigh: "max",
+  max: "max",
+};
 const KIMI_THINKING_MODELS = ["kimi-k2.7-code", "kimi-k2.7-code-highspeed", "kimi-k2.6", "kimi-k2.5", "kimi-k2-0905-preview"];
 const KIMI_LOCKED_PARAMETER_MODELS = ["kimi-k2.7-code", "kimi-k2.7-code-highspeed", "kimi-k2.6", "kimi-k2.5"];
 const NEURALWATT_REASONING_HISTORY_MODELS = [
@@ -297,7 +306,24 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
   { id: "ollama", label: "Ollama (local)", adapter: "openai-chat", baseUrl: "http://localhost:11434/v1", authKind: "local", featured: true, note: "Local — key usually blank", reasoningEffortMap: OLLAMA_REASONING_MAP },
   { id: "vllm", label: "vLLM (local)", adapter: "openai-chat", baseUrl: "http://localhost:8000/v1", authKind: "local", featured: true, note: "Local — key usually blank" },
   { id: "lm-studio", label: "LM Studio (local)", adapter: "openai-chat", baseUrl: "http://localhost:1234/v1", authKind: "local", featured: true, note: "Local — no key needed" },
-  { id: "deepseek", label: "DeepSeek", baseUrl: "https://api.deepseek.com", adapter: "openai-chat", authKind: "key", dashboardUrl: "https://platform.deepseek.com/api_keys", models: ["deepseek-chat", "deepseek-reasoner"], defaultModel: "deepseek-chat" },
+  {
+    id: "deepseek",
+    label: "DeepSeek",
+    baseUrl: "https://api.deepseek.com",
+    adapter: "openai-chat",
+    authKind: "key",
+    dashboardUrl: "https://platform.deepseek.com/api_keys",
+    models: ["deepseek-chat", "deepseek-reasoner", ...DEEPSEEK_THINKING_MODELS],
+    defaultModel: "deepseek-chat",
+    /* [Decision Log]
+    - 목적: DeepSeek V4 thinking mode multi-turn/tool-call requests must replay prior assistant reasoning_content.
+    - 대안 분석: Globally preserve reasoning_content for all OpenAI-compatible models; preserve it for legacy deepseek-reasoner too; mark only V4 thinking models in registry metadata.
+    - 선택 근거: DeepSeek V4 thinking mode requires history replay, while older DeepSeek reasoner has different compatibility rules. A model-scoped registry flag fixes built-in and stale saved configs without broad provider regressions.
+    */
+    modelReasoningEfforts: Object.fromEntries(DEEPSEEK_THINKING_MODELS.map(id => [id, DEEPSEEK_THINKING_EFFORTS])),
+    modelReasoningEffortMap: Object.fromEntries(DEEPSEEK_THINKING_MODELS.map(id => [id, DEEPSEEK_THINKING_REASONING_MAP])),
+    preserveReasoningContentModels: DEEPSEEK_THINKING_MODELS,
+  },
   { id: "cerebras", label: "Cerebras", baseUrl: "https://api.cerebras.ai/v1", adapter: "openai-chat", authKind: "key", dashboardUrl: "https://cloud.cerebras.ai/platform/apikeys", defaultModel: "llama-3.3-70b" },
   { id: "together", label: "Together", baseUrl: "https://api.together.xyz/v1", adapter: "openai-chat", authKind: "key", dashboardUrl: "https://api.together.xyz/settings/api-keys" },
   { id: "fireworks", label: "Fireworks", baseUrl: "https://api.fireworks.ai/inference/v1", adapter: "openai-chat", authKind: "key", dashboardUrl: "https://fireworks.ai/account/api-keys" },

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -60,6 +60,10 @@ describe("provider registry parity", () => {
     expect(KEY_LOGIN_PROVIDERS.umans.modelInputModalities?.["umans-glm-5.2"]).toEqual(["text"]);
     expect(KEY_LOGIN_PROVIDERS.openrouter.models).toContain("anthropic/claude-sonnet-5");
     expect(KEY_LOGIN_PROVIDERS.openrouter.modelContextWindows?.["anthropic/claude-sonnet-5"]).toBe(1_000_000);
+    expect(KEY_LOGIN_PROVIDERS.deepseek.models).toContain("deepseek-v4-pro");
+    expect(KEY_LOGIN_PROVIDERS.deepseek.modelReasoningEfforts?.["deepseek-v4-pro"]).toEqual(["high", "xhigh"]);
+    expect(KEY_LOGIN_PROVIDERS.deepseek.modelReasoningEffortMap?.["deepseek-v4-pro"]?.xhigh).toBe("max");
+    expect(KEY_LOGIN_PROVIDERS.deepseek.preserveReasoningContentModels).toEqual(["deepseek-v4-pro", "deepseek-v4-flash"]);
   });
 
   test("CLI init providers are derived from the registry", () => {

--- a/tests/reasoning-effort.test.ts
+++ b/tests/reasoning-effort.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { buildCatalogEntries } from "../src/codex-catalog";
 import { createAnthropicAdapter } from "../src/adapters/anthropic";
 import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
-import type { OcxParsedRequest, OcxProviderConfig } from "../src/types";
+import { routeModel } from "../src/router";
+import type { OcxConfig, OcxParsedRequest, OcxProviderConfig } from "../src/types";
 
 function nativeTemplate(): Record<string, unknown> {
   return {
@@ -105,6 +106,94 @@ describe("provider-specific reasoning effort mapping", () => {
 
     expect(body.reasoning_effort).toBe("max");
     expect(body.messages[1].reasoning_content).toBe("prior reasoning");
+  });
+
+  test("DeepSeek V4 thinking models replay reasoning_content beside tool calls", () => {
+    const config: OcxConfig = {
+      port: 10100,
+      defaultProvider: "deepseek",
+      providers: {
+        deepseek: {
+          adapter: "openai-chat",
+          baseUrl: "https://api.deepseek.com",
+          apiKey: "key",
+          models: ["deepseek-v4-pro"],
+        },
+      },
+    };
+    const route = routeModel(config, "deepseek/deepseek-v4-pro");
+
+    const req = createOpenAIChatAdapter(route.provider).buildRequest({
+      modelId: route.modelId,
+      context: {
+        messages: [
+          { role: "user", content: "inspect the repo", timestamp: 0 },
+          { role: "assistant", timestamp: 1, content: [
+            { type: "thinking", thinking: "I need to inspect files before answering." },
+            { type: "toolCall", id: "call_1", name: "read_file", arguments: { path: "README.md" } },
+          ] },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "read_file",
+            content: "contents",
+            isError: false,
+            timestamp: 2,
+          },
+        ],
+      },
+      stream: true,
+      options: { reasoning: "xhigh" },
+    });
+    const body = JSON.parse(req.body as string) as { reasoning_effort?: string; messages: Record<string, unknown>[] };
+
+    expect(body.reasoning_effort).toBe("max");
+    expect(body.messages[1].reasoning_content).toBe("I need to inspect files before answering.");
+    expect(body.messages[1]).toMatchObject({
+      role: "assistant",
+      content: null,
+      tool_calls: [{
+        id: "call_1",
+        type: "function",
+        function: { name: "read_file", arguments: JSON.stringify({ path: "README.md" }) },
+      }],
+    });
+  });
+
+  test("DeepSeek legacy reasoner does not inherit V4 thinking-mode history replay", () => {
+    const config: OcxConfig = {
+      port: 10100,
+      defaultProvider: "deepseek",
+      providers: {
+        deepseek: {
+          adapter: "openai-chat",
+          baseUrl: "https://api.deepseek.com",
+          apiKey: "key",
+          models: ["deepseek-reasoner"],
+        },
+      },
+    };
+    const route = routeModel(config, "deepseek/deepseek-reasoner");
+
+    const req = createOpenAIChatAdapter(route.provider).buildRequest({
+      modelId: route.modelId,
+      context: {
+        messages: [
+          { role: "user", content: "first", timestamp: 0 },
+          { role: "assistant", timestamp: 1, content: [
+            { type: "thinking", thinking: "legacy hidden reasoning" },
+            { type: "text", text: "answer" },
+          ] },
+          { role: "user", content: "continue", timestamp: 2 },
+        ],
+      },
+      stream: false,
+      options: {},
+    });
+    const body = JSON.parse(req.body as string) as { messages: Record<string, unknown>[] };
+
+    expect(route.provider.preserveReasoningContentModels).toEqual(["deepseek-v4-pro", "deepseek-v4-flash"]);
+    expect(body.messages[1].reasoning_content).toBeUndefined();
   });
 
   test("Kimi K2.7 Code does not receive unsupported OpenAI reasoning/sampling controls", () => {


### PR DESCRIPTION
## Summary
- add DeepSeek V4 thinking models to the built-in DeepSeek provider preset
- route `deepseek-v4-pro` / `deepseek-v4-flash` with `preserveReasoningContentModels` so assistant `reasoning_content` is replayed in multi-turn/tool-call history
- map Codex `xhigh` to DeepSeek `max` while clamping lower stale requests to DeepSeek `high`
- document the model-scoped decision in ADR 0003

## Root Cause
DeepSeek V4 thinking mode expects prior assistant `reasoning_content` to be passed back in later requests. The openai-chat adapter already supported model-scoped reasoning history replay, but the built-in DeepSeek preset did not mark the V4 thinking models for that behavior, so tool/subagent continuation turns could drop the field and trigger DeepSeek 400s.

## Notes
This deliberately does not enable reasoning-content replay globally, and it does not apply the V4 rule to the legacy `deepseek-reasoner` preset.

Addresses #58.

References:
- https://api-docs.deepseek.com/guides/thinking_mode
- https://api-docs.deepseek.com/guides/reasoning_model

## Validation
- `bun run typecheck`
- `bun test tests/reasoning-effort.test.ts tests/provider-registry-parity.test.ts tests/router.test.ts`
- `bun test ./tests/`