### PR TITLE
fix(anthropic): send adaptive thinking for models that reject thinking.type "enabled"

### DIFF
--- a/src/adapters/anthropic.ts
+++ b/src/adapters/anthropic.ts
@@ -257,6 +257,36 @@ function reasoningBudget(effort: string): number {
   }
 }
 
+/**
+ * Claude families that moved to adaptive thinking: they 400 on `thinking.type: "enabled"`
+ * ("Use \"thinking.type.adaptive\" and \"output_config.effort\" to control thinking behavior."),
+ * while older families (Haiku 4.5, Sonnet 4.x, Opus <= 4.6) 400 on `adaptive` — so both wire
+ * shapes must stay. Verified against api.anthropic.com: sonnet-5, fable-5, opus-4-7 and opus-4-8
+ * require adaptive; haiku-4-5 and sonnet-4-5 reject it; opus-4-6/sonnet-4-6 accept both.
+ */
+const ADAPTIVE_THINKING_FAMILY_MINIMUMS: Record<string, readonly [major: number, minor: number]> = {
+  sonnet: [5, 0],
+  opus: [4, 7],
+  fable: [0, 0],
+};
+
+function usesAdaptiveThinking(modelId: string): boolean {
+  // Minor is 1-2 digits with a non-digit lookahead so date-pinned ids ("claude-opus-4-20250514")
+  // parse as minor 0 instead of minor 20250514; suffixed ids ("claude-opus-4-8[1m]") still match.
+  const match = /^claude-([a-z]+)-(\d+)(?:-(\d{1,2}))?(?!\d)/.exec(modelId);
+  if (!match) return false;
+  const minimum = ADAPTIVE_THINKING_FAMILY_MINIMUMS[match[1]];
+  if (!minimum) return false;
+  const major = Number(match[2]);
+  const minor = match[3] === undefined ? 0 : Number(match[3]);
+  return major > minimum[0] || (major === minimum[0] && minor >= minimum[1]);
+}
+
+/** `output_config.effort` accepts low|medium|high|xhigh|max — "minimal" is rejected with a 400. */
+function adaptiveEffort(effort: string): string {
+  return effort === "minimal" ? "low" : effort;
+}
+
 function usageFromAnthropic(usage: Record<string, number> | undefined): OcxUsage | undefined {
   if (!usage) return undefined;
   const hasCache = usage.cache_read_input_tokens !== undefined || usage.cache_creation_input_tokens !== undefined;
@@ -460,16 +490,23 @@ export function createAnthropicAdapter(provider: OcxProviderConfig, cacheRetenti
       // REASONING_EFFORTS). A bare truthy check would treat "none" as truthy and wrongly enable
       // extended thinking (and strip temperature/top_p), so gate on a real, non-disable effort.
       if (typeof parsed.options.reasoning === "string" && parsed.options.reasoning !== "none") {
-        // Anthropic requires max_tokens > thinking.budget_tokens (max_tokens caps thinking +
-        // visible output) and budget_tokens >= 1024. Codex sends the SAME value for both, which
-        // 400s ("max_tokens must be greater than thinking.budget_tokens"). Size them so max_tokens
-        // always exceeds the budget within a model-safe ceiling, reserving room for visible output.
-        const maxOut = parsed.options.maxOutputTokens ?? DEFAULT_MAX_TOKENS;
-        const wantBudget = reasoningBudget(parsed.options.reasoning);
-        const maxTokens = Math.min(REASONING_MAX_TOKENS_CEILING, Math.max(maxOut, wantBudget + OUTPUT_HEADROOM));
-        const budget = Math.max(MIN_THINKING_BUDGET, Math.min(wantBudget, maxTokens - OUTPUT_FLOOR));
-        body.max_tokens = maxTokens;
-        body.thinking = { type: "enabled", budget_tokens: budget };
+        if (usesAdaptiveThinking(parsed.modelId)) {
+          // Adaptive-thinking models replace the token budget with an effort knob and reject
+          // `thinking.type: "enabled"` outright — no budget/max_tokens re-sizing needed.
+          body.thinking = { type: "adaptive" };
+          body.output_config = { effort: adaptiveEffort(parsed.options.reasoning) };
+        } else {
+          // Anthropic requires max_tokens > thinking.budget_tokens (max_tokens caps thinking +
+          // visible output) and budget_tokens >= 1024. Codex sends the SAME value for both, which
+          // 400s ("max_tokens must be greater than thinking.budget_tokens"). Size them so max_tokens
+          // always exceeds the budget within a model-safe ceiling, reserving room for visible output.
+          const maxOut = parsed.options.maxOutputTokens ?? DEFAULT_MAX_TOKENS;
+          const wantBudget = reasoningBudget(parsed.options.reasoning);
+          const maxTokens = Math.min(REASONING_MAX_TOKENS_CEILING, Math.max(maxOut, wantBudget + OUTPUT_HEADROOM));
+          const budget = Math.max(MIN_THINKING_BUDGET, Math.min(wantBudget, maxTokens - OUTPUT_FLOOR));
+          body.max_tokens = maxTokens;
+          body.thinking = { type: "enabled", budget_tokens: budget };
+        }
         // Extended thinking disallows temperature != 1 and top_p — drop both or the API 400s.
         delete body.temperature;
         delete body.top_p;

--- a/tests/anthropic-reasoning.test.ts
+++ b/tests/anthropic-reasoning.test.ts
@@ -5,9 +5,9 @@ import type { OcxParsedRequest, OcxProviderConfig } from "../src/types";
 
 const provider = { adapter: "anthropic", baseUrl: "https://api.anthropic.com", apiKey: "sk-x", authMode: "apiKey" } as unknown as OcxProviderConfig;
 
-function parsed(reasoning?: string, extraOpts: Record<string, unknown> = {}): OcxParsedRequest {
+function parsed(reasoning?: string, extraOpts: Record<string, unknown> = {}, modelId = "anthropic/claude-sonnet-4.5"): OcxParsedRequest {
   return {
-    modelId: "anthropic/claude-sonnet-4.5",
+    modelId,
     stream: false,
     options: { ...(reasoning !== undefined ? { reasoning } : {}), ...extraOpts },
     context: { systemPrompt: ["sys"], messages: [{ role: "user", content: "hi" }] },
@@ -42,6 +42,46 @@ describe("anthropic extended-thinking gate", () => {
     expect(b.max_tokens as number).toBeGreaterThan(thinking!.budget_tokens);
     expect(b.temperature).toBeUndefined();
     expect(b.top_p).toBeUndefined();
+  });
+
+  test.each([
+    "claude-sonnet-5",
+    "claude-fable-5",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-opus-4-8[1m]",
+  ])("adaptive-thinking model %s sends thinking.adaptive + output_config.effort", (modelId) => {
+    const b = bodyOf(parsed("xhigh", { temperature: 0.3, topP: 0.9 }, modelId));
+    expect(b.thinking).toEqual({ type: "adaptive" });
+    expect(b.output_config).toEqual({ effort: "xhigh" });
+    expect(b.temperature).toBeUndefined();
+    expect(b.top_p).toBeUndefined();
+  });
+
+  test("adaptive-thinking model maps unsupported 'minimal' effort to 'low'", () => {
+    const b = bodyOf(parsed("minimal", {}, "claude-fable-5"));
+    expect(b.output_config).toEqual({ effort: "low" });
+  });
+
+  test.each([
+    "claude-haiku-4-5",
+    "claude-sonnet-4-6",
+    "claude-sonnet-4-5",
+    "claude-opus-4-6",
+    "claude-opus-4-20250514",
+  ])("budget-thinking model %s keeps thinking.enabled with budget_tokens", (modelId) => {
+    const b = bodyOf(parsed("high", {}, modelId));
+    const thinking = b.thinking as { type: string; budget_tokens: number } | undefined;
+    expect(thinking?.type).toBe("enabled");
+    expect(typeof thinking?.budget_tokens).toBe("number");
+    expect(b.output_config).toBeUndefined();
+  });
+
+  test("adaptive-thinking model with reasoning 'none' sends no thinking config", () => {
+    const b = bodyOf(parsed("none", { temperature: 0.3 }, "claude-fable-5"));
+    expect(b.thinking).toBeUndefined();
+    expect(b.output_config).toBeUndefined();
+    expect(b.temperature).toBe(0.3);
   });
 
   test("drops reconstructed Responses reasoning signatures when switching into Anthropic", () => {


### PR DESCRIPTION
## Problem

Newer Claude models reject the legacy extended-thinking wire shape with a 400 when routed through the Anthropic adapter (API-key path):

```
Provider error 400: {"type":"error","error":{"type":"invalid_request_error","message":"\"thinking.type.enabled\" is not supported for this model. Use \"thinking.type.adaptive\" and \"output_config.effort\" to control thinking behavior."}}
```

Meanwhile the older families 400 on `adaptive` ("adaptive thinking is not supported on this model"), so both wire shapes have to coexist.

## Verified against api.anthropic.com (API key)

| model | `thinking.type: enabled` | `thinking.type: adaptive` |
|---|---|---|
| claude-sonnet-5 | 400 | 200 |
| claude-fable-5 | 400 | 200 |
| claude-opus-4-8 | 400 | 200 |
| claude-opus-4-7 | 400 | 200 |
| claude-opus-4-6 | 200 | 200 |
| claude-sonnet-4-6 | 200 | 200 |
| claude-sonnet-4-5 | 200 | 400 |
| claude-haiku-4-5 | 200 | 400 |

`output_config.effort` accepts `low|medium|high|xhigh|max` (Codex's `minimal` is rejected with a 400, so it maps to `low`).

## Change

- `usesAdaptiveThinking(modelId)`: family/version gate (Sonnet >= 5, Opus >= 4.7, Fable). Date-pinned ids like `claude-opus-4-20250514` parse as minor 0 and stay on the budget path; suffixed ids like `claude-opus-4-8[1m]` match.
- Adaptive models send `thinking: {type: "adaptive"}` + `output_config: {effort}`; everything else keeps the existing `enabled`/`budget_tokens` sizing. The temperature/top_p stripping is shared by both paths.
- opus-4-6 / sonnet-4-6 accept both shapes and are kept on `enabled` (no behavior change for them).

## Tests

- New cases in `tests/anthropic-reasoning.test.ts` covering both wire shapes, the `minimal -> low` mapping, the `[1m]` suffix, date-pinned ids, and the `none` sentinel.
- `bun test`: 1440 pass / 0 fail. `bun x tsc --noEmit` clean.
- Live smoke through the proxy: fable-5 and opus-4-8 with reasoning xhigh both return 200.