### PR TITLE
feat(providers): add anthropic-apikey built-in for direct Anthropic API-key billing

### DIFF
--- a/gui/src/provider-icons.ts
+++ b/gui/src/provider-icons.ts
@@ -1,5 +1,6 @@
 const PROVIDER_ICON_ALIASES: Record<string, string> = {
   anthropic: "claude-color.svg",
+  "anthropic-apikey": "claude-color.svg",
   "azure-openai": "openai.svg",
   chatgpt: "openai.svg",
   "cloudflare-ai-gateway": "cloudflare-ai-gateway-color.svg",

--- a/src/generated/jawcode-model-metadata.ts
+++ b/src/generated/jawcode-model-metadata.ts
@@ -14,6 +14,8 @@ export interface JawcodeModelMetadata {
 const PROVIDER_ALIASES: Record<string, string> = {
   "xai": "xai",
   "anthropic": "anthropic",
+  "anthropic-apikey": "anthropic",
+  "anthropic-key": "anthropic",
   "kimi": "moonshot",
   "opencode-go": "opencode-go",
   "openrouter": "openrouter",

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -62,6 +62,11 @@ export type ProviderConfigSeed = Pick<
 
 const OLLAMA_REASONING_MAP: Record<string, string> = { xhigh: "max" };
 
+// Shared between the OAuth (Claude account) and API-key Anthropic entries so both expose the
+// same static model seed.
+const ANTHROPIC_MODELS = ["claude-sonnet-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"];
+const ANTHROPIC_MODEL_CONTEXT_WINDOWS: Record<string, number> = { "claude-sonnet-5": 1_000_000 };
+
 const ZAI_GLM_52_MODELS = ["glm-5.2", "glm-5.2[1m]"];
 const ZAI_GLM_52_REASONING_EFFORTS = ["low", "medium", "high", "xhigh"];
 const ZAI_GLM_52_REASONING_MAP: Record<string, string> = {
@@ -174,8 +179,24 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     oauthId: "anthropic",
     jawcodeBundle: "anthropic",
     note: "Log in with your Claude account",
-    models: ["claude-sonnet-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"],
-    modelContextWindows: { "claude-sonnet-5": 1_000_000 },
+    models: [...ANTHROPIC_MODELS],
+    modelContextWindows: { ...ANTHROPIC_MODEL_CONTEXT_WINDOWS },
+    defaultModel: "claude-sonnet-4-6",
+  },
+  {
+    id: "anthropic-apikey",
+    label: "Anthropic (API key)",
+    adapter: "anthropic",
+    baseUrl: "https://api.anthropic.com",
+    authKind: "key",
+    featured: true,
+    dashboardUrl: "https://console.anthropic.com/settings/keys",
+    jawcodeBundle: "anthropic",
+    extraMetadataAliases: ["anthropic-key"],
+    note: "Direct Anthropic API billing — no Claude subscription",
+    models: [...ANTHROPIC_MODELS],
+    liveModels: true,
+    modelContextWindows: { ...ANTHROPIC_MODEL_CONTEXT_WINDOWS },
     defaultModel: "claude-sonnet-4-6",
   },
   {

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -27,7 +27,7 @@ function nativeTemplate(): Record<string, unknown> {
 }
 
 const EXPECTED_KEY_PROVIDER_IDS = [
-  "openai-apikey", "umans", "opencode-go", "neuralwatt", "openrouter", "groq", "google", "google-vertex", "azure-openai",
+  "anthropic-apikey", "openai-apikey", "umans", "opencode-go", "neuralwatt", "openrouter", "groq", "google", "google-vertex", "azure-openai",
   "deepseek", "cerebras", "together", "fireworks", "firepass", "moonshot",
   "huggingface", "nvidia", "venice", "zai", "nanogpt", "synthetic", "qwen-portal",
   "qianfan", "alibaba", "parallel", "zenmux", "litellm", "ollama-cloud", "mistral",
@@ -64,6 +64,20 @@ describe("provider registry parity", () => {
     expect(KEY_LOGIN_PROVIDERS.deepseek.modelReasoningEfforts?.["deepseek-v4-pro"]).toEqual(["high", "xhigh"]);
     expect(KEY_LOGIN_PROVIDERS.deepseek.modelReasoningEffortMap?.["deepseek-v4-pro"]?.xhigh).toBe("max");
     expect(KEY_LOGIN_PROVIDERS.deepseek.preserveReasoningContentModels).toEqual(["deepseek-v4-pro", "deepseek-v4-flash"]);
+  });
+
+  test("Anthropic API-key provider mirrors the OAuth entry's models on the key flow", () => {
+    const anthropicOauth = PROVIDER_REGISTRY.find(entry => entry.id === "anthropic");
+    expect(KEY_LOGIN_PROVIDERS["anthropic-apikey"]).toMatchObject({
+      label: "Anthropic (API key)",
+      adapter: "anthropic",
+      baseUrl: "https://api.anthropic.com",
+      dashboardUrl: "https://console.anthropic.com/settings/keys",
+      defaultModel: "claude-sonnet-4-6",
+      liveModels: true,
+    });
+    expect(KEY_LOGIN_PROVIDERS["anthropic-apikey"].models).toEqual(anthropicOauth?.models);
+    expect(KEY_LOGIN_PROVIDERS["anthropic-apikey"].modelContextWindows).toEqual(anthropicOauth?.modelContextWindows);
   });
 
   test("CLI init providers are derived from the registry", () => {
@@ -160,7 +174,7 @@ describe("provider registry parity", () => {
   test("GUI preset projection preserves current featured set plus key catalog and custom", () => {
     const featured = deriveFeaturedProviderIds();
     expect(featured).toEqual([
-      "openai", "xai", "anthropic", "kimi", "openai-apikey", "umans", "opencode-go", "openrouter",
+      "openai", "xai", "anthropic", "anthropic-apikey", "kimi", "openai-apikey", "umans", "opencode-go", "openrouter",
       "groq", "google", "azure-openai", "ollama", "vllm", "lm-studio",
     ]);
 
@@ -213,6 +227,8 @@ describe("provider registry parity", () => {
     expect(deriveJawcodeAliases()).toEqual({
       xai: "xai",
       anthropic: "anthropic",
+      "anthropic-apikey": "anthropic",
+      "anthropic-key": "anthropic",
       kimi: "moonshot",
       "opencode-go": "opencode-go",
       openrouter: "openrouter",


### PR DESCRIPTION
## Problem

The built-in `anthropic` provider is `authKind: "oauth"`, and `routedProviderConfig()` canonicalizes any user `authMode` override back to the registry's authKind. So a user who sets an API key on the `anthropic` provider is still routed through the Claude-account OAuth path — requests burn (and 429 on) the subscription quota instead of API billing, which is confusing to debug because the config *looks* like it's on API-key auth.

The only workaround today is a custom provider entry, which loses registry metadata: jawcode context windows, static model seeds, and the GUI icon.

## Change

Add a first-class `anthropic-apikey` registry entry (`authKind: "key"`), mirroring the existing `openai` / `openai-apikey` split:

- Shares the OAuth entry's static model seed + context windows via a hoisted `ANTHROPIC_MODELS` const, with `liveModels: true` since Anthropic's `/v1/models` works with `x-api-key` (`buildModelsRequest` already handles the anthropic adapter branch).
- Reuses the `anthropic` jawcode bundle for model metadata, plus an `anthropic-key` metadata alias for pre-existing custom configs with that name.
- Key-login flow works out of the box: `dashboardUrl` points at console.anthropic.com API keys, and `validateApiKey()` already probes the anthropic adapter with `x-api-key`.
- GUI: claude icon alias; `src/generated/jawcode-model-metadata.ts` PROVIDER_ALIASES updated to match `deriveJawcodeAliases()` (same edit the generator would emit).

This keeps OAuth and API-key routing configurable side by side — e.g. subscription for daily use, API key as fallback when the account is rate-limited.

## Tests

- New parity case asserting `anthropic-apikey` mirrors the OAuth entry's models/context windows and key-login fields.
- Updated `EXPECTED_KEY_PROVIDER_IDS`, featured set, and jawcode alias expectations.
- `bun test`: 1429 pass / 0 fail. `bun x tsc --noEmit` clean.