### PR TITLE
fix(cursor): enable multi-account OAuth by extracting JWT identity

### DIFF
--- a/gui/src/pages/Providers.tsx
+++ b/gui/src/pages/Providers.tsx
@@ -13,7 +13,7 @@ interface Config {
   providers: Record<string, { adapter: string; baseUrl: string; hasApiKey?: boolean; hasHeaders?: boolean; defaultModel?: string; authMode?: string; disabled?: boolean }>;
 }
 
-interface OAuthStatus { loggedIn: boolean; email?: string; error?: string }
+interface OAuthStatus { loggedIn: boolean; email?: string; error?: string; done?: boolean }
 interface ProviderQuotaReport { provider: string; quota: AccountQuota; source: string; updatedAt: number }
 interface OAuthAccount { id: string; email?: string; active: boolean; needsReauth?: boolean; expiresAt?: number }
 interface ApiKeyEntry { id: string; label?: string; masked: string; active: boolean }
@@ -246,7 +246,10 @@ export default function Providers({ apiBase }: { apiBase: string }) {
         const s: (OAuthStatus & { accounts?: OAuthAccount[] }) | null = await fetch(`${apiBase}/api/oauth/status?provider=${provider}`).then(r => r.json()).catch(() => null);
         if (!s) continue;
         // For add-account flows the provider is already "logged in": wait for the account count to grow.
-        const completed = addAccount ? (s.accounts?.length ?? 0) > baselineCount : s.loggedIn;
+        // addAccount: wait for a new slot OR flow completion (same-account re-login won't grow count).
+        const completed = addAccount
+          ? ((s.accounts?.length ?? 0) > baselineCount || (s.done === true && !s.error))
+          : s.loggedIn;
         if (completed) {
           setOauthStatus(prev => ({ ...prev, [provider]: s }));
           notify(t("prov.loginOk", { provider: oauthLabel(provider), cmd: "ocx sync" }), true);

--- a/src/oauth/cursor.ts
+++ b/src/oauth/cursor.ts
@@ -32,6 +32,37 @@ export interface CursorAuthParams {
   loginUrl: string;
 }
 
+interface CursorJwtPayload {
+  sub?: unknown;
+  email?: unknown;
+  exp?: unknown;
+}
+
+function decodeCursorJwtPayload(token: string): CursorJwtPayload | undefined {
+  const parts = token.split(".");
+  const payload = parts[1];
+  if (parts.length !== 3 || !payload) return undefined;
+  try {
+    return JSON.parse(Buffer.from(payload, "base64url").toString("utf-8")) as CursorJwtPayload;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Build OAuthCredentials from Cursor tokens, extracting stable identity from JWT `sub` for multiauth. */
+export function credentialsFromCursorTokens(accessToken: string, refreshToken: string): OAuthCredentials {
+  const payload = decodeCursorJwtPayload(accessToken) ?? decodeCursorJwtPayload(refreshToken);
+  const accountId = typeof payload?.sub === "string" && payload.sub.length > 0 ? payload.sub : undefined;
+  const email = typeof payload?.email === "string" && payload.email.length > 0 ? payload.email.toLowerCase() : undefined;
+  return {
+    access: accessToken,
+    refresh: refreshToken,
+    expires: getTokenExpiry(accessToken),
+    ...(accountId ? { accountId } : {}),
+    ...(email ? { email } : {}),
+  };
+}
+
 /** Generate PKCE params + the cursor.com deep-link login URL (challenge only — never the verifier). */
 export async function generateCursorAuthParams(): Promise<CursorAuthParams> {
   const { verifier, challenge } = await generatePKCE();
@@ -113,7 +144,7 @@ export async function loginCursor(
   ctrl.onAuth?.({ url: loginUrl, instructions: "Approve the Cursor login in your browser, then return here." });
   ctrl.onProgress?.("Waiting for Cursor login approval…");
   const { accessToken, refreshToken } = await pollCursorAuth(uuid, verifier, ctrl.signal, pollBaseDelayMs);
-  return { access: accessToken, refresh: refreshToken, expires: getTokenExpiry(accessToken) };
+  return credentialsFromCursorTokens(accessToken, refreshToken);
 }
 
 function isRetryableRefreshStatus(status: number): boolean {
@@ -160,7 +191,7 @@ export async function refreshCursorToken(refresh: string, signal?: AbortSignal):
     if (response.ok) {
       const data = (await response.json()) as { accessToken?: string; refreshToken?: string };
       if (!data.accessToken) throw new Error("Cursor refresh response missing access token");
-      return { access: data.accessToken, refresh: data.refreshToken || refresh, expires: getTokenExpiry(data.accessToken) };
+      return credentialsFromCursorTokens(data.accessToken, data.refreshToken || refresh);
     }
     if (!isRetryableRefreshStatus(response.status) || attempt === REFRESH_ATTEMPTS - 1) {
       throw new Error(`Cursor token refresh failed: ${response.status}`);
@@ -174,15 +205,7 @@ export async function refreshCursorToken(refresh: string, signal?: AbortSignal):
 
 /** Resolve a token's expiry (epoch ms) from its JWT `exp`, minus a 5-minute skew; ~1h fallback. */
 export function getTokenExpiry(token: string): number {
-  try {
-    const parts = token.split(".");
-    const payload = parts.length === 3 ? parts[1] : undefined;
-    if (payload) {
-      const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf-8")) as { exp?: number };
-      if (typeof decoded.exp === "number") return decoded.exp * 1000 - EXPIRY_SKEW_MS;
-    }
-  } catch {
-    // fall through to the fixed fallback below
-  }
+  const decoded = decodeCursorJwtPayload(token);
+  if (typeof decoded?.exp === "number") return decoded.exp * 1000 - EXPIRY_SKEW_MS;
   return Date.now() + FALLBACK_TTL_MS;
 }

--- a/src/oauth/store.ts
+++ b/src/oauth/store.ts
@@ -10,9 +10,10 @@
  * Exceptions:
  * - `chatgpt` stays single-slot (always replaced): codex-auth-api uses it as a scratch slot
  *   for Codex pool logins, which have their own ledger (codex-accounts.json).
- * - Credentials without identity (no accountId/email — kimi, kiro, cursor) replace the
- *   active slot instead of appending: their refresh tokens rotate, so a derived id would
- *   duplicate the same human on every re-login.
+ * - Credentials without identity (no accountId/email — kimi, kiro) replace the active slot
+ *   instead of appending: their refresh tokens rotate, so a derived id would duplicate the
+ *   same human on every re-login. Cursor login extracts JWT `sub` as accountId so multiauth
+ *   can append distinct accounts.
  */
 import { createHash } from "node:crypto";
 import { copyFileSync, existsSync, mkdirSync, readFileSync, chmodSync } from "node:fs";

--- a/tests/cursor-oauth.test.ts
+++ b/tests/cursor-oauth.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   generateCursorAuthParams,
+  credentialsFromCursorTokens,
   getTokenExpiry,
   loginCursor,
   pollCursorAuth,
@@ -12,9 +13,9 @@ afterEach(() => {
   globalThis.fetch = realFetch;
 });
 
-function jwtWithExp(expSeconds: number): string {
+function jwtWithExp(expSeconds: number, extra: Record<string, unknown> = {}): string {
   const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
-  const payload = Buffer.from(JSON.stringify({ exp: expSeconds })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({ exp: expSeconds, ...extra })).toString("base64url");
   return `${header}.${payload}.sig`;
 }
 
@@ -135,5 +136,23 @@ describe("Cursor OAuth core flow", () => {
     expect(authedUrl).toContain("cursor.com/loginDeepControl");
     expect(creds.access).toBeTruthy();
     expect(creds.refresh).toBe("ref");
+  });
+
+  test("credentialsFromCursorTokens extracts JWT sub as accountId for multiauth", () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    const access = jwtWithExp(exp, { sub: "google-oauth2|user_01ABC", email: "dev@example.com" });
+    const creds = credentialsFromCursorTokens(access, "refresh-token");
+    expect(creds.accountId).toBe("google-oauth2|user_01ABC");
+    expect(creds.email).toBe("dev@example.com");
+    expect(creds.expires).toBe(exp * 1000 - 5 * 60 * 1000);
+  });
+
+  test("refreshCursorToken preserves accountId from the refreshed access token", async () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    const access = jwtWithExp(exp, { sub: "google-oauth2|user_02XYZ" });
+    globalThis.fetch = (async () => new Response(JSON.stringify({ accessToken: access, refreshToken: "newRef" }), { status: 200 })) as typeof fetch;
+    const out = await refreshCursorToken("rt");
+    expect(out.accountId).toBe("google-oauth2|user_02XYZ");
+    expect(out.refresh).toBe("newRef");
   });
 });

--- a/tests/oauth-store-multi.test.ts
+++ b/tests/oauth-store-multi.test.ts
@@ -96,6 +96,13 @@ describe("multi-account auth store", () => {
     expect(getCredential("cursor")?.access).toBe("rotated");
   });
 
+  test("cursor with distinct accountIds appends a second account", () => {
+    saveCredential("cursor", cred({ accountId: "google-oauth2|user_a", access: "access-a" }));
+    saveCredential("cursor", cred({ accountId: "google-oauth2|user_b", access: "access-b" }));
+    expect(listAccounts("cursor").length).toBe(2);
+    expect(getCredential("cursor")?.access).toBe("access-b");
+  });
+
   test("chatgpt stays single-slot even with distinct identities", () => {
     saveCredential("chatgpt", cred({ email: "a@example.com", accountId: "one" }));
     saveCredential("chatgpt", cred({ email: "b@example.com", accountId: "two", access: "b-access" }));


### PR DESCRIPTION
## Summary
- Extract stable Cursor account identity from JWT `sub` (and `email` when present) during login and token refresh, so the multiauth store can append distinct accounts instead of always replacing the active slot.
- Fix the Providers UI add-account polling loop to treat a completed OAuth flow (`done: true`) as success, not only when the account count grows — covers same-account re-login.

## Problem
Adding a second Cursor account showed \"Waiting for browser…\" forever even after Cursor returned \"All set!\". OAuth completed (`done: true`) but `accounts.length` stayed at 1 because Cursor credentials had no persisted identity.

## Test plan
- [x] `bun test tests/cursor-oauth.test.ts tests/oauth-store-multi.test.ts`
- [ ] Add a second Cursor account via Web UI → dialog closes, both accounts listed
- [ ] Switch between Cursor accounts in the provider card dropdown
- [ ] Re-login the same Cursor account via \"Add account\" → completes without hanging