### PR TITLE
docs: document where to set unsafeAllowNativeLocalExec for Cursor

### DIFF
--- a/docs-site/src/content/docs/guides/providers.md
+++ b/docs-site/src/content/docs/guides/providers.md
@@ -113,12 +113,14 @@ and the dashboard Add Provider picker as an experimental local config entry with
 public model catalog metadata. When a Cursor access token is configured, opencodex uses Cursor's
 live HTTP/2 transport. Cursor server-driven native read/write/delete/ls/grep/shell/fetch execution
 is disabled by default because it bypasses Codex's approval and sandbox path; set
-`unsafeAllowNativeLocalExec: true` only for trusted local experiments. The older
-`allowNativeLocalExec` spelling is accepted as a deprecated transition alias. MCP, screen recording,
-and computer-use are available as executor hooks; without a configured local executor, opencodex
-returns typed no-executor results instead of policy-blocking the request. Cursor OAuth and live
-model discovery are enabled for this experimental adapter; Cursor is still not shown in key-login
-lists.
+`unsafeAllowNativeLocalExec: true` on the `providers.cursor` object in `~/.opencodex/config.json`
+only for trusted local experiments (or via **Providers → Cursor → Edit JSON** in the dashboard).
+The older `allowNativeLocalExec` spelling is accepted as a deprecated transition alias. See the
+[Configuration reference](/opencodex/reference/configuration/#cursor-provider-adapter-cursor) for a
+full example. MCP, screen recording, and computer-use are available as executor hooks; without a
+configured local executor, opencodex returns typed no-executor results instead of policy-blocking
+the request. Cursor OAuth and live model discovery are enabled for this experimental adapter;
+Cursor is still not shown in key-login lists.
 :::
 
 ### Ollama Cloud

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -72,7 +72,7 @@ network. Only do this on trusted networks, and always set a strong `OPENCODEX_AP
 
 | Field | Type | Meaning |
 | --- | --- | --- |
-| `adapter` | `string` | One of `openai-chat`, `openai-responses`, `anthropic`, `google`, `azure-openai`. |
+| `adapter` | `string` | One of `openai-chat`, `openai-responses`, `anthropic`, `google`, `azure-openai`, `cursor`. |
 | `baseUrl` | `string` | Upstream API base URL. |
 | `apiKey?` | `string` | API key, or an `${ENV_VAR}` / `$ENV_VAR` reference resolved at request time. |
 | `defaultModel?` | `string` | Model used when this provider is selected without an explicit model. |
@@ -86,6 +86,47 @@ network. Only do this on trusted networks, and always set a strong `OPENCODEX_AP
 | `noReasoningModels?` | `string[]` | Models that reject a reasoning/thinking param — the adapter drops `reasoning_effort` for them. |
 | `noVisionModels?` | `string[]` | Text-only models — the [vision sidecar](/opencodex/guides/sidecars/) describes images for them. Matching tolerates an Ollama `:size` tag. |
 | `escapeBuiltinToolNames?` | `boolean` | Anthropic-compatible gateways such as Umans can require tool-name escaping on the wire; opencodex strips the prefix before returning tool calls to Codex. |
+| `unsafeAllowNativeLocalExec?` | `boolean` | **Cursor adapter only.** Opt-in escape hatch for Cursor server-driven local `read` / `write` / `delete` / `ls` / `grep` / `shell` / `fetch` execution. Defaults to `false` so remote Cursor messages cannot bypass Codex approval and sandbox enforcement. See [Cursor provider](#cursor-provider-adapter-cursor) below. |
+
+## Cursor provider (`adapter: "cursor"`)
+
+The Cursor bridge is experimental. After `ocx login cursor`, add or edit the `cursor` entry under
+`providers` in `~/.opencodex/config.json` (Windows: `%USERPROFILE%\.opencodex\config.json`).
+
+By default, Cursor's server-driven native local tools stay **disabled**. Codex keeps using its own
+tools (`apply_patch`, `exec_command`, and so on) with approval and sandbox policy. Set
+`unsafeAllowNativeLocalExec` only for trusted local experiments where you accept that Cursor may
+read, write, delete, list, grep, shell, or fetch on your machine **without** Codex's approval path.
+
+```json
+{
+  "providers": {
+    "cursor": {
+      "adapter": "cursor",
+      "baseUrl": "https://api2.cursor.sh",
+      "authMode": "oauth",
+      "defaultModel": "auto",
+      "unsafeAllowNativeLocalExec": true
+    }
+  }
+}
+```
+
+The flag belongs on the **provider object** (`providers.cursor`), not at the top level of
+`config.json`.
+
+You can also set it from the [web dashboard](/opencodex/guides/web-dashboard/): **Providers →
+Cursor → Edit JSON**, add `"unsafeAllowNativeLocalExec": true`, save, then restart the proxy
+(`ocx restart` or `ocx stop` + `ocx start`).
+
+The older `allowNativeLocalExec` spelling is still accepted as a deprecated transition alias.
+MCP, screen recording, and computer-use use separate executor config (`mcpExecutor`,
+`desktopExecutor`) and are not controlled by this flag.
+
+:::caution[Security]
+Leave `unsafeAllowNativeLocalExec` unset or `false` unless you explicitly want Cursor-native local
+execution that bypasses Codex approval and sandbox semantics.
+:::
 
 ## Static model allowlists
 

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -167,7 +167,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     authKind: "oauth",
     featured: false,
     dashboardPreset: true,
-    note: "Experimental Cursor bridge. Live transport and live model discovery are enabled after a standalone PKCE browser login via 'ocx login cursor'; native read/write/delete/shell/fetch execution stays disabled unless provider.unsafeAllowNativeLocalExec is explicitly set for a trusted local experiment.",
+    note: "Experimental Cursor bridge. Live transport and live model discovery are enabled after a standalone PKCE browser login via 'ocx login cursor'; native read/write/delete/shell/fetch execution stays disabled unless you set \"unsafeAllowNativeLocalExec\": true on providers.cursor in ~/.opencodex/config.json (dashboard: Providers → Cursor → Edit JSON) for a trusted local experiment.",
     models: cursorModelIds(CURSOR_STATIC_MODELS),
     liveModels: true,
     defaultModel: "auto",

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -108,7 +108,9 @@ describe("provider registry parity", () => {
     });
     expect(cursor?.note).toContain("Live transport");
     expect(cursor?.note).toContain("live model discovery");
-    expect(cursor?.note).toContain("provider.unsafeAllowNativeLocalExec");
+    expect(cursor?.note).toContain("unsafeAllowNativeLocalExec");
+    expect(cursor?.note).toContain("~/.opencodex/config.json");
+    expect(cursor?.note).toContain("Providers → Cursor → Edit JSON");
     expect(cursor?.models).toContain("auto");
     expect(cursor?.models?.length).toBeGreaterThanOrEqual(40);
     expect(cursor?.models).toContain("claude-sonnet-5");


### PR DESCRIPTION
## Summary
- Add a dedicated **Cursor provider** section to the configuration reference with a `config.json` example
- Clarify that `unsafeAllowNativeLocalExec` belongs on `providers.cursor`, not at the top level
- Mention the dashboard path (Providers → Cursor → Edit JSON)
- Update the Cursor registry note shown in the Add Provider picker with the same guidance

## Test plan
- [x] `bun test tests/provider-registry-parity.test.ts`
- [ ] Docs render correctly on the docs site
- [ ] Anchor link from providers guide resolves