### PR TITLE
feat(diagnostics): warn when project .codex/config.toml bypasses OpenCodex

### DIFF
--- a/gui/src/i18n/en.ts
+++ b/gui/src/i18n/en.ts
@@ -58,6 +58,8 @@ export const en = {
   "dash.syncOk": "Sync complete. {count} model(s) appended.",
   "dash.syncStaleHint": "If Codex App still shows an older list, restart its long-lived app-server process.",
   "dash.syncFailed": "Sync failed: {error}",
+  "dash.projectConfigTitle": "Project Codex config bypasses OpenCodex",
+  "dash.projectConfigHint": "These repo-local settings override the OpenCodex proxy (e.g. route to OpenCode Go directly). Remove them so ~/.codex/config.toml routing applies in that project.",
   "dash.checkUpdate": "Check update",
   "dash.updateTitle": "Update opencodex",
   "dash.updateDesc": "Check npm for the selected channel, then choose whether to restart the proxy after installation.",

--- a/gui/src/i18n/ko.ts
+++ b/gui/src/i18n/ko.ts
@@ -58,6 +58,8 @@ export const ko: Record<TKey, string> = {
   "dash.syncOk": "동기화 완료. {count}개 모델이 추가됐습니다.",
   "dash.syncStaleHint": "Codex App에 여전히 예전 목록이 보이면 오래 실행 중인 app-server 프로세스를 재시작하세요.",
   "dash.syncFailed": "동기화 실패: {error}",
+  "dash.projectConfigTitle": "프로젝트 Codex 설정이 OpenCodex를 우회합니다",
+  "dash.projectConfigHint": "저장소 로컬 설정이 OpenCodex 프록시를 덮어씁니다(예: OpenCode Go로 직접 라우팅). 해당 프로젝트에서 ~/.codex/config.toml 프록시를 쓰려면 제거하세요.",
   "dash.checkUpdate": "업데이트 확인",
   "dash.updateTitle": "opencodex 업데이트",
   "dash.updateDesc": "선택한 채널의 npm 최신 버전을 확인한 뒤, 설치 후 프록시를 재시작할지 선택합니다.",

--- a/gui/src/i18n/zh.ts
+++ b/gui/src/i18n/zh.ts
@@ -58,6 +58,8 @@ export const zh: Record<TKey, string> = {
   "dash.syncOk": "同步完成。已追加 {count} 个模型。",
   "dash.syncStaleHint": "如果 Codex App 仍显示旧列表，请重启长期运行的 app-server 进程。",
   "dash.syncFailed": "同步失败：{error}",
+  "dash.projectConfigTitle": "项目 Codex 配置绕过了 OpenCodex",
+  "dash.projectConfigHint": "这些仓库级设置会覆盖 OpenCodex 代理（例如直接走 OpenCode Go）。请移除它们，以便该项目使用 ~/.codex/config.toml 的代理路由。",
   "dash.checkUpdate": "检查更新",
   "dash.updateTitle": "更新 opencodex",
   "dash.updateDesc": "检查所选 npm 频道的最新版本，然后选择安装后是否重启代理。",

--- a/gui/src/pages/Dashboard.tsx
+++ b/gui/src/pages/Dashboard.tsx
@@ -22,6 +22,18 @@ interface SyncResult {
   message: string;
   warning?: string;
   staleAppServerHint?: string;
+  projectConfigWarnings?: ProjectCodexConfigWarning[];
+}
+interface ProjectCodexConfigWarning {
+  path: string;
+  code: string;
+  detail: string;
+  message: string;
+}
+interface ProjectCodexConfigGroup {
+  path: string;
+  issues: string[];
+  bypass: string;
 }
 interface UpdateCheckData {
   currentVersion: string;
@@ -69,6 +81,7 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
   const [syncing, setSyncing] = useState(false);
   const [syncResult, setSyncResult] = useState<SyncResult | null>(null);
   const [syncError, setSyncError] = useState<string | null>(null);
+  const [projectConfigWarnings, setProjectConfigWarnings] = useState<ProjectCodexConfigGroup[]>([]);
   const [updateOpen, setUpdateOpen] = useState(false);
   const [updateChannel, setUpdateChannel] = useState<UpdateChannel>("latest");
   const [updateRestart, setUpdateRestart] = useState(true);
@@ -82,18 +95,25 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const [hRes, pRes, sRes, scRes, uRes] = await Promise.all([
+        const [hRes, pRes, sRes, scRes, uRes, pcRes] = await Promise.all([
           fetch(`${apiBase}/healthz`),
           fetch(`${apiBase}/api/providers`),
           fetch(`${apiBase}/api/settings`),
           fetch(`${apiBase}/api/sidecar-settings`),
           fetch(`${apiBase}/api/usage?range=30d`),
+          fetch(`${apiBase}/api/diagnostics/project-config`),
         ]);
         setHealth(await hRes.json());
         setProviders(await pRes.json());
         setSettings(await sRes.json());
         setSidecar(await scRes.json());
         try { setUsage30d(uRes.ok ? await uRes.json() : null); } catch { setUsage30d(null); }
+        try {
+          const pcData = pcRes.ok ? await pcRes.json() as { grouped?: ProjectCodexConfigGroup[] } : null;
+          setProjectConfigWarnings(pcData?.grouped ?? []);
+        } catch {
+          setProjectConfigWarnings([]);
+        }
         setError(false);
       } catch {
         setError(true);
@@ -227,6 +247,8 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
       const data = await res.json() as SyncResult | { error?: string };
       if (!res.ok) throw new Error("error" in data && data.error ? data.error : "sync failed");
       setSyncResult(data as SyncResult);
+      const grouped = (data as SyncResult & { projectConfigGrouped?: ProjectCodexConfigGroup[] }).projectConfigGrouped;
+      if (grouped) setProjectConfigWarnings(grouped);
     } catch (err) {
       setSyncError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -316,6 +338,24 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
           )}
         </div>
       </div>
+
+      {projectConfigWarnings.length > 0 && (
+        <div className="notice notice-err maintenance-notice" style={{ marginBottom: 24 }} role="alert">
+          <IconAlert />
+          <div>
+            <div style={{ fontWeight: 650 }}>{t("dash.projectConfigTitle")}</div>
+            <div className="muted" style={{ fontSize: 13, marginTop: 4 }}>{t("dash.projectConfigHint")}</div>
+            <ul style={{ margin: "10px 0 0", paddingLeft: 18, fontSize: 13 }}>
+              {projectConfigWarnings.map(g => (
+                <li key={g.path} style={{ marginBottom: 8 }}>
+                  <code>{g.path}</code> — {g.issues.join(", ")}
+                  <div className="muted" style={{ marginTop: 2 }}>{g.bypass}</div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
 
       <div className="panel maintenance-panel" style={{ marginBottom: 24 }}>
         <div className="spread maintenance-head">

--- a/gui/src/pages/Dashboard.tsx
+++ b/gui/src/pages/Dashboard.tsx
@@ -95,25 +95,18 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const [hRes, pRes, sRes, scRes, uRes, pcRes] = await Promise.all([
+        const [hRes, pRes, sRes, scRes, uRes] = await Promise.all([
           fetch(`${apiBase}/healthz`),
           fetch(`${apiBase}/api/providers`),
           fetch(`${apiBase}/api/settings`),
           fetch(`${apiBase}/api/sidecar-settings`),
           fetch(`${apiBase}/api/usage?range=30d`),
-          fetch(`${apiBase}/api/diagnostics/project-config`),
         ]);
         setHealth(await hRes.json());
         setProviders(await pRes.json());
         setSettings(await sRes.json());
         setSidecar(await scRes.json());
         try { setUsage30d(uRes.ok ? await uRes.json() : null); } catch { setUsage30d(null); }
-        try {
-          const pcData = pcRes.ok ? await pcRes.json() as { grouped?: ProjectCodexConfigGroup[] } : null;
-          setProjectConfigWarnings(pcData?.grouped ?? []);
-        } catch {
-          setProjectConfigWarnings([]);
-        }
         setError(false);
       } catch {
         setError(true);
@@ -121,6 +114,21 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
     };
     fetchData();
     const interval = setInterval(fetchData, 5000);
+    return () => clearInterval(interval);
+  }, [apiBase]);
+
+  useEffect(() => {
+    const fetchDiagnostics = async () => {
+      try {
+        const pcRes = await fetch(`${apiBase}/api/diagnostics/project-config`);
+        const pcData = pcRes.ok ? await pcRes.json() as { grouped?: ProjectCodexConfigGroup[] } : null;
+        setProjectConfigWarnings(pcData?.grouped ?? []);
+      } catch {
+        setProjectConfigWarnings([]);
+      }
+    };
+    void fetchDiagnostics();
+    const interval = setInterval(() => void fetchDiagnostics(), 30_000);
     return () => clearInterval(interval);
   }, [apiBase]);
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -15,6 +15,7 @@ import { readCodexTokens } from "../codex/auth-collision";
 import { resolveCodexHomeDir as resolveCodexHomeDirImpl, isWslRuntime, listWslWindowsCodexHomes, wslAutomountRoot, type CodexHomeDeps } from "../codex/home";
 import { findCodexOnPath, isWindowsInteropDir } from "../codex/shim";
 import { countPendingOpencodexHistory } from "../codex/history-provider";
+import { collectProjectCodexConfigWarnings, formatProjectCodexConfigWarningsForDoctor } from "../codex/project-config-warnings";
 export { resolveCodexHomeDir } from "../codex/home";
 
 const WHAM_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
@@ -371,6 +372,16 @@ export async function runDoctor(): Promise<void> {
     console.log("  ok     no legacy opencodex-tagged threads pending");
   } else {
     console.log(`  --     ${pending.pendingRows} thread(s) still tagged opencodex, ${pending.backupEntries} backup manifest entr${pending.backupEntries === 1 ? "y" : "ies"}`);
+  }
+
+  console.log("\nProject Codex configs");
+  const projectWarnings = collectProjectCodexConfigWarnings();
+  if (projectWarnings.length === 0) {
+    console.log("  ok     no project-local provider bypass detected");
+  } else {
+    for (const line of formatProjectCodexConfigWarningsForDoctor(projectWarnings)) {
+      console.log(line);
+    }
   }
 
   const dual = collectWslDualInstall();

--- a/src/codex/project-config-warnings.ts
+++ b/src/codex/project-config-warnings.ts
@@ -1,0 +1,296 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { expandUserPath } from "../config";
+import { defaultCodexHome } from "./home";
+import { readRootTomlString } from "./paths";
+
+const OCX_SECTION_MARKER = "# Auto-injected by opencodex";
+
+function resolveCodexConfigPath(): string {
+  const raw = process.env.CODEX_HOME?.trim();
+  const home = raw ? resolve(expandUserPath(raw)) : defaultCodexHome();
+  return join(home, "config.toml");
+}
+
+export type ProjectCodexConfigIssueCode = "model_providers_table" | "profile_selector" | "model_provider_root";
+
+export interface ProjectCodexConfigWarning {
+  path: string;
+  code: ProjectCodexConfigIssueCode;
+  /** Provider id, profile name, or model_provider value when relevant. */
+  detail: string;
+  message: string;
+}
+
+function hasInjectedOpenaiBaseUrl(content: string): boolean {
+  const lines = content.split("\n");
+  const firstTable = lines.findIndex(l => /^\s*\[/.test(l));
+  const rootEnd = firstTable === -1 ? lines.length : firstTable;
+  for (let i = 1; i < rootEnd; i++) {
+    if (/^\s*openai_base_url\s*=/.test(lines[i]) && lines[i - 1].includes(OCX_SECTION_MARKER)) return true;
+  }
+  return false;
+}
+
+/** True when global Codex config routes through the opencodex proxy. */
+export function isGlobalOpencodexRoutingActive(
+  codexConfigPath: string = resolveCodexConfigPath(),
+  content?: string,
+): boolean {
+  let text = content;
+  if (text === undefined) {
+    if (!existsSync(codexConfigPath)) return false;
+    try {
+      text = readFileSync(codexConfigPath, "utf-8");
+    } catch {
+      return false;
+    }
+  }
+  if (hasInjectedOpenaiBaseUrl(text)) return true;
+  if (readRootTomlString(text, "model_provider") === "opencodex") return true;
+  if (text.includes("[model_providers.opencodex]")) return true;
+  return false;
+}
+
+export function parseTrustedProjectPathsFromCodexConfig(content: string): string[] {
+  const paths: string[] = [];
+  const re = /^\[projects\.(?:'([^']*)'|"([^"]*)")\]/gm;
+  for (const match of content.matchAll(re)) {
+    const raw = (match[1] ?? match[2] ?? "").trim();
+    if (raw) paths.push(raw);
+  }
+  return paths;
+}
+
+export function analyzeProjectCodexConfig(content: string, configPath: string): ProjectCodexConfigWarning[] {
+  const warnings: ProjectCodexConfigWarning[] = [];
+  const lines = content.split("\n");
+  const firstTable = lines.findIndex(l => /^\s*\[/.test(l));
+  const rootEnd = firstTable === -1 ? lines.length : firstTable;
+
+  for (let i = 0; i < lines.length; i++) {
+    const table = lines[i].match(/^\s*\[model_providers\.([^\]]+)\]\s*$/);
+    if (!table) continue;
+    const provider = table[1]!.trim();
+    if (provider === "opencodex") continue;
+    warnings.push({
+      path: configPath,
+      code: "model_providers_table",
+      detail: provider,
+      message:
+        `Project Codex config defines [model_providers.${provider}] (${relPath(configPath)}). `
+        + "That routes this trusted project away from the OpenCodex proxy. "
+        + "Remove the provider table (and any profile = line that selects it) so global routing from "
+        + "~/.codex/config.toml applies.",
+    });
+  }
+
+  for (let i = 0; i < rootEnd; i++) {
+    const profileMatch = lines[i].match(/^\s*profile\s*=\s*("(?:\\.|[^"])*"|'[^']*')\s*$/);
+    if (profileMatch) {
+      const profile = parseTomlString(profileMatch[1]!);
+      if (profile && profile !== "opencodex") {
+        warnings.push({
+          path: configPath,
+          code: "profile_selector",
+          detail: profile,
+          message:
+            `Project Codex config sets profile = "${profile}" (${relPath(configPath)}). `
+            + "Profiles can bypass the OpenCodex proxy for this project. "
+            + "Remove the profile line or switch to global proxy routing only.",
+        });
+      }
+      continue;
+    }
+    const providerMatch = lines[i].match(/^\s*model_provider\s*=\s*("(?:\\.|[^"])*"|'[^']*')\s*$/);
+    if (providerMatch) {
+      const provider = parseTomlString(providerMatch[1]!);
+      if (provider && provider !== "opencodex") {
+        warnings.push({
+          path: configPath,
+          code: "model_provider_root",
+          detail: provider,
+          message:
+            `Project Codex config sets model_provider = "${provider}" (${relPath(configPath)}). `
+            + "Use global ~/.codex/config.toml for OpenCodex routing instead of a project-local provider override.",
+        });
+      }
+    }
+  }
+
+  return dedupeRelatedProjectCodexWarnings(warnings);
+}
+
+/** profile/model_provider that selects an already-flagged [model_providers.X] table is one bypass, not two. */
+export function dedupeRelatedProjectCodexWarnings(
+  warnings: ProjectCodexConfigWarning[],
+): ProjectCodexConfigWarning[] {
+  const providerTables = new Set(
+    warnings.filter(w => w.code === "model_providers_table").map(w => w.detail),
+  );
+  if (providerTables.size === 0) return warnings;
+  return warnings.filter(w => {
+    if (w.code === "profile_selector" && providerTables.has(w.detail)) return false;
+    if (w.code === "model_provider_root" && providerTables.has(w.detail)) return false;
+    return true;
+  });
+}
+
+function parseTomlString(raw: string): string {
+  if (raw.startsWith("\"")) {
+    try {
+      return JSON.parse(raw) as string;
+    } catch {
+      return raw.slice(1, -1);
+    }
+  }
+  return raw.slice(1, -1);
+}
+
+function relPath(abs: string): string {
+  const home = process.env.USERPROFILE ?? process.env.HOME ?? "";
+  if (home && abs.toLowerCase().startsWith(home.toLowerCase())) {
+    return `~${abs.slice(home.length).replace(/\\/g, "/")}`;
+  }
+  return abs;
+}
+
+export function discoverProjectCodexConfigPaths(options: {
+  cwd?: string;
+  codexConfigPath?: string;
+  maxWalkParents?: number;
+} = {}): string[] {
+  const found = new Set<string>();
+  const codexConfigPath = options.codexConfigPath ?? resolveCodexConfigPath();
+  const addIfExists = (projectRoot: string) => {
+    const path = join(resolve(projectRoot), ".codex", "config.toml");
+    if (existsSync(path)) found.add(path);
+  };
+
+  let cwd = resolve(options.cwd ?? process.cwd());
+  const maxWalk = options.maxWalkParents ?? 12;
+  for (let depth = 0; depth < maxWalk; depth++) {
+    addIfExists(cwd);
+    const parent = dirname(cwd);
+    if (parent === cwd) break;
+    cwd = parent;
+  }
+
+  if (existsSync(codexConfigPath)) {
+    try {
+      const global = readFileSync(codexConfigPath, "utf-8");
+      for (const projectPath of parseTrustedProjectPathsFromCodexConfig(global)) {
+        addIfExists(projectPath);
+      }
+    } catch {
+      /* ignore unreadable global config */
+    }
+  }
+
+  return [...found];
+}
+
+export function collectProjectCodexConfigWarnings(options: {
+  cwd?: string;
+  codexConfigPath?: string;
+  requireOpencodexRouting?: boolean;
+} = {}): ProjectCodexConfigWarning[] {
+  const codexConfigPath = options.codexConfigPath ?? resolveCodexConfigPath();
+  const requireRouting = options.requireOpencodexRouting ?? true;
+  if (requireRouting && !isGlobalOpencodexRoutingActive(codexConfigPath)) return [];
+
+  const warnings: ProjectCodexConfigWarning[] = [];
+  for (const path of discoverProjectCodexConfigPaths({ cwd: options.cwd, codexConfigPath })) {
+    try {
+      const content = readFileSync(path, "utf-8");
+      warnings.push(...analyzeProjectCodexConfig(content, path));
+    } catch {
+      /* skip unreadable project config */
+    }
+  }
+  return warnings;
+}
+
+export function summarizeProjectCodexIssue(warning: ProjectCodexConfigWarning): string {
+  switch (warning.code) {
+    case "model_providers_table":
+      return `[model_providers.${warning.detail}]`;
+    case "profile_selector":
+      return `profile="${warning.detail}"`;
+    case "model_provider_root":
+      return `model_provider="${warning.detail}"`;
+  }
+}
+
+function humanizeProviderDetail(detail: string): string {
+  if (detail === "opencode_go") return "OpenCode Go";
+  if (detail.startsWith("opencode")) return "OpenCode";
+  if (detail === "opencodex") return "OpenCodex";
+  return detail;
+}
+
+/** Short "why" line: what this project config overrides and where traffic goes instead. */
+export function explainProjectConfigBypass(warnings: ProjectCodexConfigWarning[]): string {
+  const targets = [...new Set(warnings.map(w => humanizeProviderDetail(w.detail)))];
+  const via = targets.length === 1 ? targets[0]! : targets.join(" / ");
+  return `Overrides OpenCodex — Codex uses ${via} for this repo instead of the proxy (~/.codex/config.toml).`;
+}
+
+export interface ProjectCodexConfigWarningGroup {
+  path: string;
+  issues: string[];
+  bypass: string;
+}
+
+export function groupProjectCodexConfigWarningsByPath(
+  warnings: ProjectCodexConfigWarning[],
+): ProjectCodexConfigWarningGroup[] {
+  const grouped = new Map<string, ProjectCodexConfigWarning[]>();
+  for (const warning of warnings) {
+    const list = grouped.get(warning.path) ?? [];
+    list.push(warning);
+    grouped.set(warning.path, list);
+  }
+  return [...grouped.entries()].map(([path, pathWarnings]) => ({
+    path,
+    issues: pathWarnings.map(summarizeProjectCodexIssue),
+    bypass: explainProjectConfigBypass(pathWarnings),
+  }));
+}
+
+export function formatProjectCodexConfigWarningsForDoctor(warnings: ProjectCodexConfigWarning[]): string[] {
+  const grouped = groupProjectCodexConfigWarningsByPath(warnings);
+  if (grouped.length === 0) return [];
+  const lines: string[] = [];
+  for (const { path, issues, bypass } of grouped) {
+    lines.push(`  --     ${relPath(path)} — ${issues.join(", ")}`);
+    lines.push(`         ${bypass}`);
+  }
+  lines.push("       fix: remove those entries so OpenCodex proxy routing applies in this project");
+  return lines;
+}
+
+export function formatProjectCodexConfigWarningsForConsole(warnings: ProjectCodexConfigWarning[]): string[] {
+  const grouped = groupProjectCodexConfigWarningsByPath(warnings);
+  if (grouped.length === 0) return [];
+  const lines = ["⚠️  Project Codex config bypasses OpenCodex:"];
+  for (const { path, issues, bypass } of grouped) {
+    lines.push(`    ${relPath(path)} — ${issues.join(", ")}`);
+    lines.push(`    ${bypass}`);
+  }
+  lines.push("    fix: remove those entries so OpenCodex proxy routing applies in this project");
+  return lines;
+}
+
+export function printProjectCodexConfigWarnings(
+  log?: Pick<Console, "log"> | null,
+  options?: Parameters<typeof collectProjectCodexConfigWarnings>[0],
+): ProjectCodexConfigWarning[] {
+  const warnings = collectProjectCodexConfigWarnings(options);
+  if (log) {
+    for (const line of formatProjectCodexConfigWarningsForConsole(warnings)) {
+      log.log(line);
+    }
+  }
+  return warnings;
+}

--- a/src/codex/project-config-warnings.ts
+++ b/src/codex/project-config-warnings.ts
@@ -5,6 +5,7 @@ import { defaultCodexHome } from "./home";
 import { readRootTomlString } from "./paths";
 
 const OCX_SECTION_MARKER = "# Auto-injected by opencodex";
+const DIAGNOSTICS_CACHE_TTL_MS = 30_000;
 
 function resolveCodexConfigPath(): string {
   const raw = process.env.CODEX_HOME?.trim();
@@ -17,10 +18,19 @@ export type ProjectCodexConfigIssueCode = "model_providers_table" | "profile_sel
 export interface ProjectCodexConfigWarning {
   path: string;
   code: ProjectCodexConfigIssueCode;
-  /** Provider id, profile name, or model_provider value when relevant. */
+  /** Effective provider id that bypasses OpenCodex. */
   detail: string;
+  /** Profile name when the bypass is selected via profile = "…". */
+  profileName?: string;
   message: string;
 }
+
+interface TomlDocument {
+  root: Record<string, string>;
+  sections: Map<string, Record<string, string>>;
+}
+
+let diagnosticsCache: { at: number; warnings: ProjectCodexConfigWarning[] } | null = null;
 
 function hasInjectedOpenaiBaseUrl(content: string): boolean {
   const lines = content.split("\n");
@@ -30,6 +40,94 @@ function hasInjectedOpenaiBaseUrl(content: string): boolean {
     if (/^\s*openai_base_url\s*=/.test(lines[i]) && lines[i - 1].includes(OCX_SECTION_MARKER)) return true;
   }
   return false;
+}
+
+function parseTomlString(raw: string): string {
+  if (raw.startsWith("\"")) {
+    try {
+      return JSON.parse(raw) as string;
+    } catch {
+      return raw.slice(1, -1);
+    }
+  }
+  return raw.slice(1, -1);
+}
+
+/** Lightweight TOML parse for root keys and [section] tables (Codex config shape). */
+export function parseTomlDocument(content: string): TomlDocument {
+  const root: Record<string, string> = {};
+  const sections = new Map<string, Record<string, string>>();
+  let current = root;
+
+  for (const line of content.split("\n")) {
+    const table = line.match(/^\s*\[([^\]]+)\]\s*$/);
+    if (table) {
+      const name = table[1]!.trim();
+      const section = sections.get(name) ?? {};
+      sections.set(name, section);
+      current = section;
+      continue;
+    }
+    const kv = line.match(/^\s*([A-Za-z0-9_.-]+)\s*=\s*("(?:\\.|[^"])*"|'[^']*'|[^\s#]+)\s*(?:#.*)?$/);
+    if (kv) current[kv[1]!] = parseTomlString(kv[2]!);
+  }
+
+  return { root, sections };
+}
+
+function profileSectionKeys(profileName: string): string[] {
+  return [
+    `profiles.${profileName}`,
+    `profiles."${profileName}"`,
+    `profiles.'${profileName}'`,
+  ];
+}
+
+function readProfileModelProvider(sections: Map<string, Record<string, string>>, profileName: string): string | null {
+  for (const key of profileSectionKeys(profileName)) {
+    const provider = sections.get(key)?.model_provider;
+    if (provider) return provider;
+  }
+  return null;
+}
+
+function hasModelProviderTable(sections: Map<string, Record<string, string>>, provider: string): boolean {
+  return sections.has(`model_providers.${provider}`);
+}
+
+/** Built-in openai provider still routes through the proxy under Design B (marker-owned openai_base_url). */
+function isProxyCompatibleProvider(provider: string): boolean {
+  return provider === "opencodex" || provider === "openai";
+}
+
+export interface EffectiveProjectModelRouting {
+  provider: string | null;
+  profileName: string | null;
+  via: "profile" | "root" | null;
+}
+
+/** Resolve the provider Codex would actually use from a project .codex/config.toml. */
+export function resolveEffectiveProjectModelProvider(content: string): EffectiveProjectModelRouting {
+  const { root, sections } = parseTomlDocument(content);
+  const rootProfile = root.profile ?? null;
+  const rootProvider = root.model_provider ?? null;
+
+  if (rootProfile) {
+    const fromProfile = readProfileModelProvider(sections, rootProfile);
+    if (fromProfile) {
+      return { provider: fromProfile, profileName: rootProfile, via: "profile" };
+    }
+    if (rootProvider) {
+      return { provider: rootProvider, profileName: rootProfile, via: "root" };
+    }
+    return { provider: null, profileName: rootProfile, via: null };
+  }
+
+  if (rootProvider) {
+    return { provider: rootProvider, profileName: null, via: "root" };
+  }
+
+  return { provider: null, profileName: null, via: null };
 }
 
 /** True when global Codex config routes through the opencodex proxy. */
@@ -48,77 +146,66 @@ export function isGlobalOpencodexRoutingActive(
   }
   if (hasInjectedOpenaiBaseUrl(text)) return true;
   if (readRootTomlString(text, "model_provider") === "opencodex") return true;
-  if (text.includes("[model_providers.opencodex]")) return true;
   return false;
 }
 
 export function parseTrustedProjectPathsFromCodexConfig(content: string): string[] {
+  const { sections } = parseTomlDocument(content);
   const paths: string[] = [];
-  const re = /^\[projects\.(?:'([^']*)'|"([^"]*)")\]/gm;
-  for (const match of content.matchAll(re)) {
-    const raw = (match[1] ?? match[2] ?? "").trim();
-    if (raw) paths.push(raw);
+
+  for (const [name, keys] of sections) {
+    const quoted = name.match(/^projects\.(?:'([^']*)'|"([^"]*)")$/);
+    if (!quoted) continue;
+    const raw = (quoted[1] ?? quoted[2] ?? "").trim();
+    if (!raw) continue;
+    if ((keys.trust_level ?? "").toLowerCase() !== "trusted") continue;
+    paths.push(raw);
   }
+
   return paths;
 }
 
 export function analyzeProjectCodexConfig(content: string, configPath: string): ProjectCodexConfigWarning[] {
-  const warnings: ProjectCodexConfigWarning[] = [];
-  const lines = content.split("\n");
-  const firstTable = lines.findIndex(l => /^\s*\[/.test(l));
-  const rootEnd = firstTable === -1 ? lines.length : firstTable;
+  const { sections } = parseTomlDocument(content);
+  const routing = resolveEffectiveProjectModelProvider(content);
+  const provider = routing.provider;
 
-  for (let i = 0; i < lines.length; i++) {
-    const table = lines[i].match(/^\s*\[model_providers\.([^\]]+)\]\s*$/);
-    if (!table) continue;
-    const provider = table[1]!.trim();
-    if (provider === "opencodex") continue;
-    warnings.push({
+  if (!provider || isProxyCompatibleProvider(provider)) return [];
+
+  const rel = relPath(configPath);
+  if (hasModelProviderTable(sections, provider)) {
+    return [{
       path: configPath,
       code: "model_providers_table",
       detail: provider,
+      profileName: routing.profileName ?? undefined,
       message:
-        `Project Codex config defines [model_providers.${provider}] (${relPath(configPath)}). `
-        + "That routes this trusted project away from the OpenCodex proxy. "
-        + "Remove the provider table (and any profile = line that selects it) so global routing from "
-        + "~/.codex/config.toml applies.",
-    });
+        `Project Codex config selects provider "${provider}" via `
+        + `${routing.via === "profile" ? `profile = "${routing.profileName}"` : "model_provider"} and defines `
+        + `[model_providers.${provider}] (${rel}). That routes this trusted project away from the OpenCodex proxy.`,
+    }];
   }
 
-  for (let i = 0; i < rootEnd; i++) {
-    const profileMatch = lines[i].match(/^\s*profile\s*=\s*("(?:\\.|[^"])*"|'[^']*')\s*$/);
-    if (profileMatch) {
-      const profile = parseTomlString(profileMatch[1]!);
-      if (profile && profile !== "opencodex") {
-        warnings.push({
-          path: configPath,
-          code: "profile_selector",
-          detail: profile,
-          message:
-            `Project Codex config sets profile = "${profile}" (${relPath(configPath)}). `
-            + "Profiles can bypass the OpenCodex proxy for this project. "
-            + "Remove the profile line or switch to global proxy routing only.",
-        });
-      }
-      continue;
-    }
-    const providerMatch = lines[i].match(/^\s*model_provider\s*=\s*("(?:\\.|[^"])*"|'[^']*')\s*$/);
-    if (providerMatch) {
-      const provider = parseTomlString(providerMatch[1]!);
-      if (provider && provider !== "opencodex") {
-        warnings.push({
-          path: configPath,
-          code: "model_provider_root",
-          detail: provider,
-          message:
-            `Project Codex config sets model_provider = "${provider}" (${relPath(configPath)}). `
-            + "Use global ~/.codex/config.toml for OpenCodex routing instead of a project-local provider override.",
-        });
-      }
-    }
+  if (routing.via === "profile" && routing.profileName) {
+    return [{
+      path: configPath,
+      code: "profile_selector",
+      detail: provider,
+      profileName: routing.profileName,
+      message:
+        `Project Codex config profile "${routing.profileName}" sets model_provider = "${provider}" (${rel}). `
+        + "That routes this trusted project away from the OpenCodex proxy.",
+    }];
   }
 
-  return dedupeRelatedProjectCodexWarnings(warnings);
+  return [{
+    path: configPath,
+    code: "model_provider_root",
+    detail: provider,
+    message:
+      `Project Codex config sets model_provider = "${provider}" (${rel}). `
+      + "Use global ~/.codex/config.toml for OpenCodex routing instead of a project-local provider override.",
+  }];
 }
 
 /** profile/model_provider that selects an already-flagged [model_providers.X] table is one bypass, not two. */
@@ -134,17 +221,6 @@ export function dedupeRelatedProjectCodexWarnings(
     if (w.code === "model_provider_root" && providerTables.has(w.detail)) return false;
     return true;
   });
-}
-
-function parseTomlString(raw: string): string {
-  if (raw.startsWith("\"")) {
-    try {
-      return JSON.parse(raw) as string;
-    } catch {
-      return raw.slice(1, -1);
-    }
-  }
-  return raw.slice(1, -1);
 }
 
 function relPath(abs: string): string {
@@ -211,12 +287,28 @@ export function collectProjectCodexConfigWarnings(options: {
   return warnings;
 }
 
+export function invalidateProjectConfigDiagnosticsCache(): void {
+  diagnosticsCache = null;
+}
+
+export function getCachedProjectConfigDiagnostics(): {
+  warnings: ProjectCodexConfigWarning[];
+  grouped: ProjectCodexConfigWarningGroup[];
+} {
+  const now = Date.now();
+  if (!diagnosticsCache || now - diagnosticsCache.at > DIAGNOSTICS_CACHE_TTL_MS) {
+    diagnosticsCache = { at: now, warnings: collectProjectCodexConfigWarnings() };
+  }
+  const warnings = diagnosticsCache.warnings;
+  return { warnings, grouped: groupProjectCodexConfigWarningsByPath(warnings) };
+}
+
 export function summarizeProjectCodexIssue(warning: ProjectCodexConfigWarning): string {
   switch (warning.code) {
     case "model_providers_table":
       return `[model_providers.${warning.detail}]`;
     case "profile_selector":
-      return `profile="${warning.detail}"`;
+      return warning.profileName ? `profile="${warning.profileName}"` : `model_provider="${warning.detail}"`;
     case "model_provider_root":
       return `model_provider="${warning.detail}"`;
   }

--- a/src/codex/sync.ts
+++ b/src/codex/sync.ts
@@ -1,4 +1,5 @@
 import { injectCodexConfig } from "./inject";
+import { printProjectCodexConfigWarnings, groupProjectCodexConfigWarningsByPath, type ProjectCodexConfigWarning } from "./project-config-warnings";
 import { refreshCodexModelCatalog } from "./refresh";
 import { applyProxyEnv, loadConfig } from "../config";
 import type { OcxConfig } from "../types";
@@ -11,6 +12,8 @@ export interface CodexSyncResult {
   cacheSynced: boolean;
   message: string;
   warning?: string;
+  projectConfigWarnings?: ProjectCodexConfigWarning[];
+  projectConfigGrouped?: { path: string; issues: string[]; bypass: string }[];
 }
 
 interface CodexSyncDeps {
@@ -58,6 +61,7 @@ export async function syncModelsToCodex(
 
   const result = await deps.injectCodexConfig(p, config, { catalogPath: catalogPathForInjection });
   log?.log(result.message);
+  const projectConfigWarnings = printProjectCodexConfigWarnings(log, { cwd: process.cwd() });
   return {
     ok: result.success,
     added,
@@ -66,5 +70,9 @@ export async function syncModelsToCodex(
     cacheSynced,
     message: result.message,
     ...(warning ? { warning } : {}),
+    ...(projectConfigWarnings.length > 0 ? {
+      projectConfigWarnings,
+      projectConfigGrouped: groupProjectCodexConfigWarningsByPath(projectConfigWarnings),
+    } : {}),
   };
 }

--- a/src/server/management-api.ts
+++ b/src/server/management-api.ts
@@ -89,6 +89,12 @@ export async function handleManagementAPI(req: Request, url: URL, config: OcxCon
     return jsonResponse({ ok: true, codexAutoStart: codexAutoStartEnabled(config) });
   }
 
+  if (url.pathname === "/api/diagnostics/project-config" && req.method === "GET") {
+    const { collectProjectCodexConfigWarnings, groupProjectCodexConfigWarningsByPath } = await import("../codex/project-config-warnings");
+    const warnings = collectProjectCodexConfigWarnings();
+    return jsonResponse({ warnings, grouped: groupProjectCodexConfigWarningsByPath(warnings) });
+  }
+
   if (url.pathname === "/api/sync" && req.method === "POST") {
     const { syncModelsToCodex } = await import("../codex/sync");
     const result = await syncModelsToCodex(undefined, config, null);

--- a/src/server/management-api.ts
+++ b/src/server/management-api.ts
@@ -90,9 +90,9 @@ export async function handleManagementAPI(req: Request, url: URL, config: OcxCon
   }
 
   if (url.pathname === "/api/diagnostics/project-config" && req.method === "GET") {
-    const { collectProjectCodexConfigWarnings, groupProjectCodexConfigWarningsByPath } = await import("../codex/project-config-warnings");
-    const warnings = collectProjectCodexConfigWarnings();
-    return jsonResponse({ warnings, grouped: groupProjectCodexConfigWarningsByPath(warnings) });
+    const { getCachedProjectConfigDiagnostics } = await import("../codex/project-config-warnings");
+    const { warnings, grouped } = getCachedProjectConfigDiagnostics();
+    return jsonResponse({ warnings, grouped });
   }
 
   if (url.pathname === "/api/sync" && req.method === "POST") {

--- a/tests/codex-sync-api.test.ts
+++ b/tests/codex-sync-api.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { syncModelsToCodex } from "../src/codex/sync";
 import type { OcxConfig } from "../src/types";
+
+const TEST_DIR = join(import.meta.dir, ".tmp-codex-sync-api");
+const TEST_CODEX_HOME = join(TEST_DIR, "codex");
+let prevCodexHome: string | undefined;
 
 const config = {
   port: 10100,
@@ -9,6 +15,19 @@ const config = {
 } as OcxConfig;
 
 describe("GUI/CLI Codex sync backend", () => {
+  beforeEach(() => {
+    prevCodexHome = process.env.CODEX_HOME;
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_CODEX_HOME, { recursive: true });
+    process.env.CODEX_HOME = TEST_CODEX_HOME;
+    writeFileSync(join(TEST_CODEX_HOME, "config.toml"), 'model = "gpt-5.5"\n', "utf8");
+  });
+
+  afterEach(() => {
+    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodexHome;
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  });
   test("returns the structured sync result used by POST /api/sync", async () => {
     let injectedPort = 0;
     let injectedCatalogPath: string | null | undefined;

--- a/tests/project-config-warnings.test.ts
+++ b/tests/project-config-warnings.test.ts
@@ -1,131 +1,193 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   analyzeProjectCodexConfig,
   collectProjectCodexConfigWarnings,
-  dedupeRelatedProjectCodexWarnings,
-  discoverProjectCodexConfigPaths,
-  groupProjectCodexConfigWarningsByPath,
+  getCachedProjectConfigDiagnostics,
   isGlobalOpencodexRoutingActive,
+  invalidateProjectConfigDiagnosticsCache,
   parseTrustedProjectPathsFromCodexConfig,
+  resolveEffectiveProjectModelProvider,
 } from "../src/codex/project-config-warnings";
 
-const TEST_DIR = join(import.meta.dir, ".tmp-project-config-warnings");
-const TEST_CODEX_HOME = join(TEST_DIR, "codex");
-const TEST_PROJECT = join(TEST_DIR, "streamer-content");
+let testDir = "";
+let previousHome: string | undefined;
 
-let prevCodexHome: string | undefined;
+beforeEach(() => {
+  previousHome = process.env.OPENCODEX_HOME;
+  testDir = join(tmpdir(), `ocx-proj-warn-${Date.now()}`);
+  mkdirSync(testDir, { recursive: true });
+  process.env.OPENCODEX_HOME = testDir;
+  invalidateProjectConfigDiagnosticsCache();
+});
 
-describe("project config warnings", () => {
-  beforeEach(() => {
-    prevCodexHome = process.env.CODEX_HOME;
-    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
-    mkdirSync(join(TEST_PROJECT, ".codex"), { recursive: true });
-    process.env.CODEX_HOME = TEST_CODEX_HOME;
+afterEach(() => {
+  if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = previousHome;
+  invalidateProjectConfigDiagnosticsCache();
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+function writeGlobalRoutingConfig(extra = ""): void {
+  const codexDir = join(testDir, ".codex");
+  mkdirSync(codexDir, { recursive: true });
+  writeFileSync(join(codexDir, "config.toml"), `
+model_provider = "opencodex"
+${extra}
+`);
+}
+
+describe("isGlobalOpencodexRoutingActive", () => {
+  test("detects injected openai_base_url marker", () => {
+    const text = `
+# Auto-injected by opencodex
+openai_base_url = "http://127.0.0.1:10100/v1"
+model_provider = "opencodex"
+`;
+    expect(isGlobalOpencodexRoutingActive("unused", text)).toBe(true);
   });
 
-  afterEach(() => {
-    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
-    else process.env.CODEX_HOME = prevCodexHome;
-    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  test("does not treat dormant model_providers.opencodex table as active routing", () => {
+    const text = `
+[model_providers.opencodex]
+name = "opencodex"
+base_url = "http://127.0.0.1:10100/v1"
+`;
+    expect(isGlobalOpencodexRoutingActive("unused", text)).toBe(false);
+  });
+});
+
+describe("parseTrustedProjectPathsFromCodexConfig", () => {
+  test("collects only trusted project paths", () => {
+    const text = `
+[projects.'C:\\repo-a']
+trust_level = "trusted"
+
+[projects.'C:\\repo-b']
+trust_level = "untrusted"
+
+[projects.'C:\\repo-c']
+`;
+    expect(parseTrustedProjectPathsFromCodexConfig(text)).toEqual(["C:\\repo-a"]);
+  });
+});
+
+describe("resolveEffectiveProjectModelProvider", () => {
+  test("resolves provider from selected profile", () => {
+    const text = `
+profile = "work"
+model_provider = "openai"
+
+[profiles.work]
+model_provider = "anthropic"
+`;
+    expect(resolveEffectiveProjectModelProvider(text)).toEqual({
+      provider: "anthropic",
+      profileName: "work",
+      via: "profile",
+    });
   });
 
-  test("detects model_providers tables in project config", () => {
-    const content = [
-      'profile = "opencode_go"',
-      "",
-      "[model_providers.opencode_go]",
-      'name = "OpenCode Go"',
-      'base_url = "https://opencode.ai/zen/go/v1"',
-      "",
-    ].join("\n");
-    const warnings = analyzeProjectCodexConfig(content, "/repo/.codex/config.toml");
-    expect(warnings.some(w => w.code === "model_providers_table" && w.detail === "opencode_go")).toBe(true);
-    expect(warnings.some(w => w.code === "profile_selector")).toBe(false);
+  test("root model_provider applies when profile has no model_provider", () => {
+    const text = `
+profile = "work"
+model_provider = "anthropic"
+
+[profiles.work]
+approval_policy = "on-request"
+`;
+    expect(resolveEffectiveProjectModelProvider(text)).toEqual({
+      provider: "anthropic",
+      profileName: "work",
+      via: "root",
+    });
+  });
+});
+
+describe("analyzeProjectCodexConfig", () => {
+  test("ignores dormant provider tables", () => {
+    const text = `
+[model_providers.anthropic]
+name = "anthropic"
+base_url = "https://api.anthropic.com"
+`;
+    expect(analyzeProjectCodexConfig(text, "C:\\repo\\.codex\\config.toml")).toEqual([]);
   });
 
-  test("keeps profile warning when no matching provider table exists", () => {
-    const warnings = analyzeProjectCodexConfig('profile = "opencode_go"\n', "/repo/.codex/config.toml");
+  test("ignores profile without model_provider override", () => {
+    const text = `
+profile = "work"
+
+[profiles.work]
+approval_policy = "on-request"
+`;
+    expect(analyzeProjectCodexConfig(text, "C:\\repo\\.codex\\config.toml")).toEqual([]);
+  });
+
+  test("warns when effective provider bypasses proxy", () => {
+    const text = `
+profile = "work"
+
+[profiles.work]
+model_provider = "anthropic"
+
+[model_providers.anthropic]
+name = "anthropic"
+`;
+    const warnings = analyzeProjectCodexConfig(text, "C:\\repo\\.codex\\config.toml");
     expect(warnings).toHaveLength(1);
-    expect(warnings[0]?.code).toBe("profile_selector");
+    expect(warnings[0]!.code).toBe("model_providers_table");
+    expect(warnings[0]!.detail).toBe("anthropic");
+    expect(warnings[0]!.profileName).toBe("work");
   });
 
-  test("ignores opencodex provider table in project config", () => {
-    const warnings = analyzeProjectCodexConfig("[model_providers.opencodex]\n", "/repo/.codex/config.toml");
-    expect(warnings).toHaveLength(0);
+  test("does not warn for openai provider under Design B", () => {
+    const text = `
+model_provider = "openai"
+`;
+    expect(analyzeProjectCodexConfig(text, "C:\\repo\\.codex\\config.toml")).toEqual([]);
+  });
+});
+
+describe("collectProjectCodexConfigWarnings", () => {
+  test("skips untrusted projects even when they define bypass config", () => {
+    const escaped = testDir.replace(/\\/g, "\\\\");
+    const projectDir = join(testDir, "proj");
+    writeGlobalRoutingConfig(`
+[projects.'${escaped}\\proj']
+trust_level = "untrusted"
+`);
+    mkdirSync(join(projectDir, ".codex"), { recursive: true });
+    writeFileSync(join(projectDir, ".codex", "config.toml"), `
+model_provider = "anthropic"
+[model_providers.anthropic]
+name = "anthropic"
+`);
+    expect(collectProjectCodexConfigWarnings()).toEqual([]);
   });
 
-  test("parses trusted project paths from global config", () => {
-    const content = [
-      "[projects.'c:/users/jk/repo']",
-      "trust_level = \"trusted\"",
-      "",
-    ].join("\n");
-    expect(parseTrustedProjectPathsFromCodexConfig(content)).toEqual(["c:/users/jk/repo"]);
-  });
-
-  test("collects warnings only when global opencodex routing is active", () => {
-    mkdirSync(TEST_CODEX_HOME, { recursive: true });
-    writeFileSync(join(TEST_CODEX_HOME, "config.toml"), [
-      "# Auto-injected by opencodex",
-      'openai_base_url = "http://127.0.0.1:10100/v1"',
-      "",
-      `[projects.'${TEST_PROJECT.replace(/\\/g, "\\\\")}']`,
-      'trust_level = "trusted"',
-      "",
-    ].join("\n"), "utf8");
-    writeFileSync(join(TEST_PROJECT, ".codex", "config.toml"), [
-      "[model_providers.opencode_go]",
-      'name = "OpenCode Go"',
-      "",
-    ].join("\n"), "utf8");
-
-    const active = isGlobalOpencodexRoutingActive(join(TEST_CODEX_HOME, "config.toml"));
-    expect(active).toBe(true);
-
-    const warnings = collectProjectCodexConfigWarnings({
-      cwd: TEST_PROJECT,
-      codexConfigPath: join(TEST_CODEX_HOME, "config.toml"),
-    });
-    expect(warnings.some(w => w.code === "model_providers_table")).toBe(true);
-  });
-
-  test("returns no warnings when global routing is inactive", () => {
-    mkdirSync(TEST_CODEX_HOME, { recursive: true });
-    writeFileSync(join(TEST_CODEX_HOME, "config.toml"), 'model = "gpt-5.5"\n', "utf8");
-    writeFileSync(join(TEST_PROJECT, ".codex", "config.toml"), "[model_providers.opencode_go]\n", "utf8");
-
-    const warnings = collectProjectCodexConfigWarnings({
-      cwd: TEST_PROJECT,
-      codexConfigPath: join(TEST_CODEX_HOME, "config.toml"),
-    });
-    expect(warnings).toHaveLength(0);
-  });
-
-  test("discovers project config from cwd walk", () => {
-    writeFileSync(join(TEST_PROJECT, ".codex", "config.toml"), "model = \"gpt-5.5\"\n", "utf8");
-    const nested = join(TEST_PROJECT, "src", "app");
-    mkdirSync(nested, { recursive: true });
-    const paths = discoverProjectCodexConfigPaths({
-      cwd: nested,
-      codexConfigPath: join(TEST_CODEX_HOME, "config.toml"),
-    });
-    expect(paths).toContain(join(TEST_PROJECT, ".codex", "config.toml"));
-  });
-
-  test("groups warnings by project path for compact output", () => {
-    const warnings = analyzeProjectCodexConfig([
-      'profile = "opencode_go"',
-      "",
-      "[model_providers.opencode_go]",
-      'name = "OpenCode Go"',
-      "",
-    ].join("\n"), "/repo/.codex/config.toml");
-    const grouped = groupProjectCodexConfigWarningsByPath(warnings);
-    expect(grouped).toHaveLength(1);
-    expect(grouped[0]?.issues).toEqual(["[model_providers.opencode_go]"]);
-    expect(grouped[0]?.bypass).toContain("OpenCode Go");
-    expect(grouped[0]?.bypass).toContain("Overrides OpenCodex");
+  test("caches diagnostics for repeated API reads", () => {
+    const escaped = testDir.replace(/\\/g, "\\\\");
+    const projectDir = join(testDir, "proj");
+    writeGlobalRoutingConfig(`
+[projects.'${escaped}\\proj']
+trust_level = "trusted"
+`);
+    mkdirSync(join(projectDir, ".codex"), { recursive: true });
+    writeFileSync(join(projectDir, ".codex", "config.toml"), `
+model_provider = "anthropic"
+[model_providers.anthropic]
+name = "anthropic"
+`);
+    const first = getCachedProjectConfigDiagnostics();
+    expect(first.warnings.length).toBe(1);
+    writeFileSync(join(projectDir, ".codex", "config.toml"), `model_provider = "openai"`);
+    const second = getCachedProjectConfigDiagnostics();
+    expect(second.warnings.length).toBe(1);
+    invalidateProjectConfigDiagnosticsCache();
+    const third = getCachedProjectConfigDiagnostics();
+    expect(third.warnings).toEqual([]);
   });
 });

--- a/tests/project-config-warnings.test.ts
+++ b/tests/project-config-warnings.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  analyzeProjectCodexConfig,
+  collectProjectCodexConfigWarnings,
+  dedupeRelatedProjectCodexWarnings,
+  discoverProjectCodexConfigPaths,
+  groupProjectCodexConfigWarningsByPath,
+  isGlobalOpencodexRoutingActive,
+  parseTrustedProjectPathsFromCodexConfig,
+} from "../src/codex/project-config-warnings";
+
+const TEST_DIR = join(import.meta.dir, ".tmp-project-config-warnings");
+const TEST_CODEX_HOME = join(TEST_DIR, "codex");
+const TEST_PROJECT = join(TEST_DIR, "streamer-content");
+
+let prevCodexHome: string | undefined;
+
+describe("project config warnings", () => {
+  beforeEach(() => {
+    prevCodexHome = process.env.CODEX_HOME;
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(join(TEST_PROJECT, ".codex"), { recursive: true });
+    process.env.CODEX_HOME = TEST_CODEX_HOME;
+  });
+
+  afterEach(() => {
+    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodexHome;
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  });
+
+  test("detects model_providers tables in project config", () => {
+    const content = [
+      'profile = "opencode_go"',
+      "",
+      "[model_providers.opencode_go]",
+      'name = "OpenCode Go"',
+      'base_url = "https://opencode.ai/zen/go/v1"',
+      "",
+    ].join("\n");
+    const warnings = analyzeProjectCodexConfig(content, "/repo/.codex/config.toml");
+    expect(warnings.some(w => w.code === "model_providers_table" && w.detail === "opencode_go")).toBe(true);
+    expect(warnings.some(w => w.code === "profile_selector")).toBe(false);
+  });
+
+  test("keeps profile warning when no matching provider table exists", () => {
+    const warnings = analyzeProjectCodexConfig('profile = "opencode_go"\n', "/repo/.codex/config.toml");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.code).toBe("profile_selector");
+  });
+
+  test("ignores opencodex provider table in project config", () => {
+    const warnings = analyzeProjectCodexConfig("[model_providers.opencodex]\n", "/repo/.codex/config.toml");
+    expect(warnings).toHaveLength(0);
+  });
+
+  test("parses trusted project paths from global config", () => {
+    const content = [
+      "[projects.'c:/users/jk/repo']",
+      "trust_level = \"trusted\"",
+      "",
+    ].join("\n");
+    expect(parseTrustedProjectPathsFromCodexConfig(content)).toEqual(["c:/users/jk/repo"]);
+  });
+
+  test("collects warnings only when global opencodex routing is active", () => {
+    mkdirSync(TEST_CODEX_HOME, { recursive: true });
+    writeFileSync(join(TEST_CODEX_HOME, "config.toml"), [
+      "# Auto-injected by opencodex",
+      'openai_base_url = "http://127.0.0.1:10100/v1"',
+      "",
+      `[projects.'${TEST_PROJECT.replace(/\\/g, "\\\\")}']`,
+      'trust_level = "trusted"',
+      "",
+    ].join("\n"), "utf8");
+    writeFileSync(join(TEST_PROJECT, ".codex", "config.toml"), [
+      "[model_providers.opencode_go]",
+      'name = "OpenCode Go"',
+      "",
+    ].join("\n"), "utf8");
+
+    const active = isGlobalOpencodexRoutingActive(join(TEST_CODEX_HOME, "config.toml"));
+    expect(active).toBe(true);
+
+    const warnings = collectProjectCodexConfigWarnings({
+      cwd: TEST_PROJECT,
+      codexConfigPath: join(TEST_CODEX_HOME, "config.toml"),
+    });
+    expect(warnings.some(w => w.code === "model_providers_table")).toBe(true);
+  });
+
+  test("returns no warnings when global routing is inactive", () => {
+    mkdirSync(TEST_CODEX_HOME, { recursive: true });
+    writeFileSync(join(TEST_CODEX_HOME, "config.toml"), 'model = "gpt-5.5"\n', "utf8");
+    writeFileSync(join(TEST_PROJECT, ".codex", "config.toml"), "[model_providers.opencode_go]\n", "utf8");
+
+    const warnings = collectProjectCodexConfigWarnings({
+      cwd: TEST_PROJECT,
+      codexConfigPath: join(TEST_CODEX_HOME, "config.toml"),
+    });
+    expect(warnings).toHaveLength(0);
+  });
+
+  test("discovers project config from cwd walk", () => {
+    writeFileSync(join(TEST_PROJECT, ".codex", "config.toml"), "model = \"gpt-5.5\"\n", "utf8");
+    const nested = join(TEST_PROJECT, "src", "app");
+    mkdirSync(nested, { recursive: true });
+    const paths = discoverProjectCodexConfigPaths({
+      cwd: nested,
+      codexConfigPath: join(TEST_CODEX_HOME, "config.toml"),
+    });
+    expect(paths).toContain(join(TEST_PROJECT, ".codex", "config.toml"));
+  });
+
+  test("groups warnings by project path for compact output", () => {
+    const warnings = analyzeProjectCodexConfig([
+      'profile = "opencode_go"',
+      "",
+      "[model_providers.opencode_go]",
+      'name = "OpenCode Go"',
+      "",
+    ].join("\n"), "/repo/.codex/config.toml");
+    const grouped = groupProjectCodexConfigWarningsByPath(warnings);
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0]?.issues).toEqual(["[model_providers.opencode_go]"]);
+    expect(grouped[0]?.bypass).toContain("OpenCode Go");
+    expect(grouped[0]?.bypass).toContain("Overrides OpenCodex");
+  });
+});


### PR DESCRIPTION
## Summary
- Detect repo-local `.codex/config.toml` settings (non-opencodex `model_providers` tables, `profile`, and `model_provider`) that route trusted projects away from the OpenCodex proxy when global proxy routing is active.
- Surface warnings in `ocx doctor`, `ocx start`/`sync` console output, and the dashboard via `GET /api/diagnostics/project-config`.
- Deduplicate redundant profile warnings when they only select an already-flagged provider table.

## Test plan
- [x] `bun test tests/project-config-warnings.test.ts`
- [x] `bun test tests/codex-sync-api.test.ts`
- [ ] `ocx doctor` shows grouped warning for a trusted project with `profile = "opencode_go"` + `[model_providers.opencode_go]`
- [ ] Dashboard at `http://localhost:10100` shows the red bypass banner after proxy restart
- [ ] Removing project-local provider/profile entries clears the warning
