### PR TITLE
fix(cursor): upstream errors, transport stability, auto model, request logs

### DIFF
--- a/gui/src/i18n/en.ts
+++ b/gui/src/i18n/en.ts
@@ -203,6 +203,7 @@ export const en = {
   "logs.col.status": "Status",
   "logs.col.tokens": "Tokens",
   "logs.col.error": "Error",
+  "logs.col.upstreamReason": "Upstream reason",
   "logs.col.duration": "Duration",
   "logs.tokens.reported": "reported",
   "logs.tokens.unreported": "unreported",

--- a/gui/src/i18n/ko.ts
+++ b/gui/src/i18n/ko.ts
@@ -203,6 +203,7 @@ export const ko: Record<TKey, string> = {
   "logs.col.status": "상태",
   "logs.col.tokens": "토큰",
   "logs.col.error": "오류",
+  "logs.col.upstreamReason": "업스트림 원인",
   "logs.col.duration": "소요 시간",
   "logs.tokens.reported": "측정됨",
   "logs.tokens.unreported": "미보고",

--- a/gui/src/i18n/zh.ts
+++ b/gui/src/i18n/zh.ts
@@ -203,6 +203,7 @@ export const zh: Record<TKey, string> = {
   "logs.col.status": "状态",
   "logs.col.tokens": "Token 数",
   "logs.col.error": "错误",
+  "logs.col.upstreamReason": "上游原因",
   "logs.col.duration": "耗时",
   "logs.tokens.reported": "已上报",
   "logs.tokens.unreported": "未上报",

--- a/gui/src/pages/Logs.tsx
+++ b/gui/src/pages/Logs.tsx
@@ -32,6 +32,7 @@ interface LogEntry {
   status: number;
   durationMs: number;
   errorCode?: string;
+  upstreamError?: string;
   usageStatus?: LogUsageStatus;
   usage?: UsageBreakdown;
   totalTokens?: number;
@@ -204,6 +205,7 @@ export default function Logs({ apiBase }: { apiBase: string }) {
               <span className="muted">{t("logs.col.model")}</span><span className="mono">{detail.resolvedModel ?? detail.model}</span>
               <span className="muted">{t("logs.col.provider")}</span><span>{detail.provider}</span>
               {detail.errorCode && (<><span className="muted">{t("logs.col.error")}</span><span className="mono">{detail.errorCode}</span></>)}
+              {detail.upstreamError && (<><span className="muted">{t("logs.col.upstreamReason")}</span><span className="mono log-detail-break">{detail.upstreamError}</span></>)}
               <span className="muted">{t("logs.col.duration")}</span><span className="mono">{detail.durationMs}ms</span>
             </div>
             <div className="muted" style={{ fontSize: 12, margin: "12px 0 6px" }}>{t("logs.detailRaw")}</div>

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -1,7 +1,7 @@
 import type { AdapterEvent, OcxProviderConfig } from "../types";
 import type { ProviderAdapter } from "./base";
 import { cursorExecDeniedMessage } from "./cursor/exec-policy";
-import { safeCursorErrorMessage } from "./cursor/cursor-errors";
+import { isCursorBenignCancelError, safeCursorErrorMessage } from "./cursor/cursor-errors";
 import { createCursorKvStore, type CursorKvStore } from "./cursor/kv-store";
 import { mapCursorServerMessage } from "./cursor/message-mapper";
 import { createCursorRequest, generatedCursorConversationId } from "./cursor/request-builder";
@@ -91,6 +91,7 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
           },
         );
       } catch (err) {
+        if (isCursorBenignCancelError(err)) return;
         const partialUsage = (err as { partialUsage?: import("../types").OcxUsage }).partialUsage;
         emit({ type: "error", message: safeCursorTransportError(err), ...(partialUsage ? { usage: partialUsage } : {}) });
       }

--- a/src/adapters/cursor/cursor-errors.ts
+++ b/src/adapters/cursor/cursor-errors.ts
@@ -11,6 +11,31 @@ function sanitize(value: string): string {
     .replace(ABSOLUTE_PATH_PATTERN, "[REDACTED_PATH]");
 }
 
+function errorMessage(value: unknown): string {
+  if (value instanceof Error) return value.message;
+  if (typeof value === "string") return value;
+  return String(value ?? "");
+}
+
+function errorCode(value: unknown): string {
+  if (typeof value !== "object" || !value || !("code" in value)) return "";
+  const code = (value as { code?: unknown }).code;
+  return code === undefined || code === null ? "" : String(code);
+}
+
+/**
+ * True when Cursor intentionally cancelled the HTTP/2 stream after a client-tool suspend.
+ * These are expected between multi-turn Responses bridge cycles, not upstream failures.
+ */
+export function isCursorBenignCancelError(value: unknown): boolean {
+  const message = errorMessage(value).toLowerCase();
+  const code = errorCode(value).toUpperCase();
+  if (code === "NGHTTP2_CANCEL") return true;
+  if (message.includes("nghttp2_cancel")) return true;
+  if (message.includes("cursor stream suspended")) return true;
+  return false;
+}
+
 /**
  * Classify a Cursor transport/Connect/gRPC error message into an actionable category.
  * The returned prefix string is recognized by `src/lib/errors.ts` `classifyError` keywords,
@@ -19,13 +44,15 @@ function sanitize(value: string): string {
 export function classifyCursorError(message: string): string {
   const lower = message.toLowerCase();
 
+  if (isCursorBenignCancelError(message)) return "Cursor stream suspended";
+
   if (
     lower.includes("resource_exhausted") ||
     lower.includes("resource exhausted") ||
     lower.includes("rate limit") ||
     lower.includes("rate-limit") ||
     lower.includes("too many requests") ||
-    lower.includes("quota")
+    lower.includes("throttling")
   ) return "Cursor rate limit exceeded";
 
   if (

--- a/src/adapters/cursor/discovery.ts
+++ b/src/adapters/cursor/discovery.ts
@@ -51,6 +51,36 @@ export function normalizeCursorModels(models: readonly CursorModelInfo[]): Curso
   return [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
 }
 
+/**
+ * True when a configured Cursor base model should remain exposed after live GetUsableModels filtering.
+ * Live ids are full effort-suffixed variants (`claude-4.6-opus-high`); base ids match exactly or by prefix.
+ */
+export function isCursorModelAvailableForAccount(modelId: string, liveIds: readonly string[]): boolean {
+  return liveIds.some(id => id === modelId || id.startsWith(`${modelId}-`));
+}
+
+/** Codex-facing id for Cursor's auto-router. Always kept in the catalog even when live discovery omits it. */
+export const CURSOR_AUTO_MODEL_ID = "auto";
+
+/** Wire id Cursor Connect expects for the auto-router (GetUsableModels returns `default`, not `auto`). */
+export const CURSOR_AUTO_WIRE_MODEL_ID = "default";
+
+/** Map a Codex-facing Cursor model id to the upstream wire id. */
+export function cursorCodexToWireModelId(modelId: string): string {
+  const normalized = modelId.startsWith("cursor/") ? modelId.slice("cursor/".length) : modelId;
+  return normalized === CURSOR_AUTO_MODEL_ID ? CURSOR_AUTO_WIRE_MODEL_ID : normalized;
+}
+
+/** Filter the static Cursor seed to models this account can use. */
+export function filterCursorConfiguredModelsByLiveDiscovery<T extends { id: string }>(
+  configured: readonly T[],
+  liveIds: readonly string[],
+): T[] {
+  return configured.filter(model =>
+    model.id === CURSOR_AUTO_MODEL_ID || isCursorModelAvailableForAccount(model.id, liveIds),
+  );
+}
+
 export const CURSOR_STATIC_MODELS: readonly CursorModelInfo[] = normalizeCursorModels([
   // Context windows and the model lineup mirror Cursor's public models/pricing docs plus the jawcode
   // SOT (../jawcode/packages/ai/src/models.json, `cursor` provider), which mirrors the real
@@ -62,7 +92,7 @@ export const CURSOR_STATIC_MODELS: readonly CursorModelInfo[] = normalizeCursorM
   // gemini/grok/kimi/gpt-5-mini are reasoning models in the SOT but are sent bare (no tier picker).
   { id: "auto", contextWindow: CONTEXT_200K, supportsReasoningEffort: false },
 
-  { id: "claude-sonnet-5", contextWindow: CONTEXT_200K },
+  { id: "claude-sonnet-5", contextWindow: CONTEXT_200K, supportsReasoningEffort: true },
   { id: "claude-4-sonnet", contextWindow: CONTEXT_200K },
   { id: "claude-4-sonnet-1m", contextWindow: CONTEXT_1M },
   { id: "claude-4.5-haiku", contextWindow: CONTEXT_200K },
@@ -108,7 +138,7 @@ export const CURSOR_STATIC_MODELS: readonly CursorModelInfo[] = normalizeCursorM
   { id: "grok-build-0.1", contextWindow: CONTEXT_256K },
   { id: "grok-code-fast-1", contextWindow: CONTEXT_256K },
 
-  { id: "glm-5.2", contextWindow: CONTEXT_200K },
+  { id: "glm-5.2", contextWindow: CONTEXT_200K, supportsReasoningEffort: true },
   { id: "kimi-k2.5", contextWindow: CONTEXT_262K },
 ]);
 

--- a/src/adapters/cursor/effort-map.ts
+++ b/src/adapters/cursor/effort-map.ts
@@ -19,6 +19,8 @@ const CURSOR_MODEL_EFFORT_TIERS: Record<string, readonly string[]> = {
   "claude-fable-5": ["low", "medium", "high", "max", "xhigh"],
   "claude-opus-4-7": ["low", "medium", "high", "max", "xhigh"],
   "claude-opus-4-8": ["low", "medium", "high", "max", "xhigh"],
+  "claude-sonnet-5": ["low", "medium", "high", "xhigh", "max"],
+  "glm-5.2": ["high", "max"],
   "gpt-5.1": ["low", "high"],
   "gpt-5.1-codex-max": ["low", "medium", "high", "xhigh"],
   "gpt-5.1-codex-mini": ["low", "high"],

--- a/src/adapters/cursor/live-models.ts
+++ b/src/adapters/cursor/live-models.ts
@@ -79,6 +79,8 @@ export async function fetchCursorUsableModels(opts: CursorUsableModelsOptions): 
       if (status !== 200) return close(null);
       try {
         const response = fromBinary(GetUsableModelsResponseSchema, new Uint8Array(Buffer.concat(chunks)));
+        // Account filtering uses wire `model_id` values only. Aliases like `composer-2-5` must not
+        // make stale configured ids such as `composer-2` look activated.
         const ids = (response.models ?? [])
           .map(model => (model as { modelId?: string }).modelId)
           .filter((id): id is string => typeof id === "string" && id.length > 0);

--- a/src/adapters/cursor/live-transport.ts
+++ b/src/adapters/cursor/live-transport.ts
@@ -31,6 +31,7 @@ import {
   type InteractionResponse,
 } from "./gen/agent_pb";
 import { debugProviderDiagnostic } from "../../lib/debug";
+import { classifyCursorError, isCursorBenignCancelError, safeCursorErrorMessage } from "./cursor-errors";
 import { mcpArgsFromToolCall } from "./protobuf-events";
 import { OCX_RESPONSES_TOOL_PROVIDER } from "./tool-definitions";
 import { cursorUnsafeNativeLocalExecEnabled, handleCursorNativeExec, handleCursorNativeKv, type CursorNativeExecContext } from "./native-exec";
@@ -323,6 +324,12 @@ class LiveCursorTransport implements CursorTransport {
   private readonly desktopDeps: CursorNativeToolDeps;
   private execContext: CursorNativeExecContext = {};
   private mcpPrepared?: Promise<void>;
+  // Per-turn diagnostic counters/timestamps when provider debug is on (`ocx debug provider on`). Stamped in open(), cleared on
+  // close; safe to read after a stream failure because open() owns the only writer before run().
+  private turnStartedAt = 0;
+  private framesReceived = 0;
+  private firstFrameAt?: number;
+  private firstFrameLogged = false;
 
   constructor(private readonly input: CursorTransportFactoryInput) {
     this.token = resolveCursorToken(input.provider, input.headers);
@@ -379,6 +386,27 @@ class LiveCursorTransport implements CursorTransport {
     let done = false;
     let failure: Error | undefined;
     let state = createCursorProtobufEventState();
+    let failureLogged = false;
+    // One per-turn summary of the failure path (end-stream error, socket reset, abort) so the
+    // operator can see how far the turn got and how it was classified without re-scanning every
+    // frame. Gated behind provider debug (`ocx debug provider on`).
+    const summarizeFailure = (err: Error): Error => {
+      if (!failureLogged && !isCursorBenignCancelError(err)) {
+        failureLogged = true;
+        debugProviderDiagnostic("cursor", "turn-failed", {
+          committed: this.committed,
+          framesReceived: this.framesReceived,
+          outputTokens: state.usage.outputTokens,
+          contextTokens: state.contextTokens,
+          firstFrameMs: this.firstFrameAt ? this.firstFrameAt - this.turnStartedAt : undefined,
+          elapsedMs: this.turnStartedAt ? Date.now() - this.turnStartedAt : undefined,
+          classified: classifyCursorError(err.message),
+          errorCode: (err as { code?: unknown }).code ?? undefined,
+          message: redactCursorForLog(err.message),
+        });
+      }
+      return err;
+    };
     const wake = () => {
       const fn = notify;
       notify = undefined;
@@ -428,13 +456,19 @@ class LiveCursorTransport implements CursorTransport {
         const message = queue.shift();
         if (message) yield message;
       }
-      if (failure) throw attachPartialUsage(failure, state);
+      if (failure) {
+        if (isCursorBenignCancelError(failure)) return;
+        throw attachPartialUsage(summarizeFailure(failure), state);
+      }
       if (done) break;
       await new Promise<void>(resolve => {
         notify = resolve;
       });
     }
-    if (failure) throw attachPartialUsage(failure, state);
+    if (failure) {
+      if (isCursorBenignCancelError(failure)) return;
+      throw attachPartialUsage(summarizeFailure(failure), state);
+    }
   }
 
   writeClient(_message: CursorClientMessage): void {}
@@ -506,6 +540,11 @@ class LiveCursorTransport implements CursorTransport {
       const terminal = finalizeAfterDrain(state);
       if (terminal.length === 0) return;
       for (const event of terminal) push(event);
+      debugProviderDiagnostic("cursor", "client-tool-suspend", {
+        reason: "Responses bridge owns client tools; ending turn without fake mcpResult",
+        framesReceived: this.framesReceived,
+        elapsedMs: Date.now() - this.turnStartedAt,
+      });
       this.cancelCursorRun();
     }, this.activeClientToolFinalizeGraceMs);
   }
@@ -518,11 +557,20 @@ class LiveCursorTransport implements CursorTransport {
     fail: (error: Error) => void,
     finish: () => void,
   ): void {
+    this.turnStartedAt = Date.now();
+    this.framesReceived = 0;
+    this.firstFrameAt = undefined;
+    this.firstFrameLogged = false;
+    const dialHost = cursorHostLabel(this.input.provider.baseUrl || "https://api2.cursor.sh");
+    debugProviderDiagnostic("cursor", "dial", { host: dialHost });
     this.session = http2.connect(this.input.provider.baseUrl || "https://api2.cursor.sh");
     // The run request is buffered until the HTTP/2 session connects. Failures before `connect`
     // (DNS, ECONNREFUSED, TLS, connect timeout) mean the server never received the request, so they
     // are safe to retry. Once connected, bytes flush to the server and the turn must not be replayed.
-    this.session.on("connect", () => { this.committed = true; });
+    this.session.on("connect", () => {
+      this.committed = true;
+      debugProviderDiagnostic("cursor", "connected", { connectMs: Date.now() - this.turnStartedAt });
+    });
     this.stream = this.session.request({
       ":method": "POST",
       ":path": CURSOR_RUN_PATH,
@@ -543,6 +591,12 @@ class LiveCursorTransport implements CursorTransport {
       if (this.expectedClose) {
         // We already emitted a terminal `done` and cancelled the run (client-tool suspension). The
         // RST_STREAM CANCEL surfaces here as a stream error/abort; it is expected, not a failure.
+        debugProviderDiagnostic("cursor", "stream-cancel-expected", {
+          code: (error as { code?: unknown }).code,
+          message: redactCursorForLog(error.message),
+          framesReceived: this.framesReceived,
+          elapsedMs: Date.now() - this.turnStartedAt,
+        });
         finish();
         return;
       }
@@ -552,6 +606,7 @@ class LiveCursorTransport implements CursorTransport {
     const stream = this.stream;
     this.firstFrameTimer = setTimeout(() => {
       this.firstFrameTimer = undefined;
+      debugProviderDiagnostic("cursor", "first-frame-timeout", { timeoutMs: this.input.firstFrameTimeoutMs ?? CURSOR_FIRST_FRAME_TIMEOUT_MS });
       try { stream.close(); } catch { /* already closing */ }
       try { session.close(); } catch { /* already closing */ }
       fail(new Error("Cursor transport timed out before first response"));
@@ -560,6 +615,11 @@ class LiveCursorTransport implements CursorTransport {
     let pending: Uint8Array<ArrayBufferLike> = new Uint8Array();
     this.stream.on("data", chunk => {
       this.clearFirstFrameTimer();
+      if (!this.firstFrameLogged) {
+        this.firstFrameLogged = true;
+        this.firstFrameAt = Date.now();
+        debugProviderDiagnostic("cursor", "first-frame", { latencyMs: this.firstFrameAt - this.turnStartedAt });
+      }
       const bytes = typeof chunk === "string" ? new TextEncoder().encode(chunk) : new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength);
       pending = concatBytes(pending, bytes);
       try {
@@ -567,8 +627,16 @@ class LiveCursorTransport implements CursorTransport {
         pending = decoded.remainder;
         const frames = decoded.frames;
         for (const frame of frames) {
+          this.framesReceived++;
           if ((frame.flags & CONNECT_FLAG_END_STREAM) === CONNECT_FLAG_END_STREAM) {
             const endError = parseConnectEndStreamError(frame.payload);
+            debugProviderDiagnostic("cursor", "connect-end-stream", endError ? {
+              code: cursorConnectErrorCode(frame.payload),
+              message: redactCursorForLog(endError.message),
+              classified: classifyCursorError(endError.message),
+              framesReceived: this.framesReceived,
+              elapsedMs: Date.now() - this.turnStartedAt,
+            } : { framesReceived: this.framesReceived, elapsedMs: Date.now() - this.turnStartedAt });
             if (endError) failAndClear(endError);
             continue;
           }
@@ -582,10 +650,38 @@ class LiveCursorTransport implements CursorTransport {
     });
     this.stream.on("trailers", trailers => {
       const status = trailers["grpc-status"];
+      if (status !== undefined) debugProviderDiagnostic("cursor", "trailers", { grpcStatus: String(status) });
       if (status && status !== "0") failAndClear(new Error(`Cursor gRPC error ${status}`));
     });
-    this.stream.on("error", err => failAndClear(err instanceof Error ? err : new Error(String(err))));
-    this.stream.on("end", () => { this.clearFirstFrameTimer(); finish(); });
+    this.stream.on("error", err => {
+      const realErr = err instanceof Error ? err : new Error(String(err));
+      if (this.expectedClose) {
+        failAndClear(realErr);
+        return;
+      }
+      const code = (realErr as { code?: unknown }).code;
+      const errno = (realErr as { errno?: unknown }).errno;
+      debugProviderDiagnostic("cursor", "stream-error", {
+        code: typeof code === "string" || typeof code === "number" ? String(code) : undefined,
+        errno: typeof errno === "string" || typeof errno === "number" ? String(errno) : undefined,
+        name: realErr.name,
+        message: redactCursorForLog(realErr.message),
+        committed: this.committed,
+        framesReceived: this.framesReceived,
+        elapsedMs: Date.now() - this.turnStartedAt,
+      });
+      failAndClear(realErr);
+    });
+    this.stream.on("end", () => {
+      this.clearFirstFrameTimer();
+      debugProviderDiagnostic("cursor", "stream-end", {
+        committed: this.committed,
+        framesReceived: this.framesReceived,
+        expectedClose: this.expectedClose,
+        elapsedMs: Date.now() - this.turnStartedAt,
+      });
+      finish();
+    });
 
     signal?.addEventListener("abort", () => {
       this.close();
@@ -689,7 +785,7 @@ function attachPartialUsage(failure: Error, state: ReturnType<typeof createCurso
 }
 
 /**
- * Compact frame descriptor for OCX_DEBUG_FRAMES diagnostics: outer case plus the inner
+ * Compact frame descriptor for provider debug (`ocx debug provider on`): outer case plus the inner
  * interactionUpdate/exec case and tool-call union case when present. No payload content is logged.
  */
 function describeCursorServerFrame(message: AgentServerMessage): Record<string, unknown> {
@@ -756,6 +852,34 @@ function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
   out.set(a);
   out.set(b, a.length);
   return out;
+}
+
+/** Host-only label for Cursor transport diagnostics — never leaks path/query/credentials. */
+function cursorHostLabel(baseUrl: string): string {
+  try {
+    return new URL(baseUrl).host;
+  } catch {
+    return "cursor";
+  }
+}
+
+/** Redact a Cursor error message for diagnostic output. Cursor error strings can carry raw
+ * credential key=value pairs beyond what redactSecretString covers; safeCursorErrorMessage
+ * already applies the full sanitizer plus the classified prefix, so reuse it verbatim. */
+function redactCursorForLog(message: string): string {
+  return safeCursorErrorMessage(message).slice(0, 300);
+}
+
+/** Extract the Connect end-stream `error.code` from the raw trailer frame payload without
+ * surfacing the (potentially secret-bearing) message — used for `[ocx:cursor:connect-end-stream]`
+ * diagnostics. Returns undefined when the payload is not the expected Connect error shape. */
+function cursorConnectErrorCode(payload: Uint8Array): string | undefined {
+  try {
+    const parsed = JSON.parse(new TextDecoder().decode(payload)) as { error?: { code?: string } };
+    return parsed?.error?.code;
+  } catch {
+    return undefined;
+  }
 }
 
 export function createLiveCursorTransport(input: CursorTransportFactoryInput): CursorTransport {

--- a/src/adapters/cursor/request-builder.ts
+++ b/src/adapters/cursor/request-builder.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../types";
 import { namespacedToolName } from "../../types";
 import type { CursorRequestMessage, CursorRunRequest } from "./types";
+import { cursorCodexToWireModelId } from "./discovery";
 import { cursorEffortSuffix } from "./effort-map";
 
 /**
@@ -18,7 +19,7 @@ import { cursorEffortSuffix } from "./effort-map";
  * known effort base) passes through unchanged.
  */
 function normalizeCursorModelId(modelId: string, reasoning?: string): string {
-  const id = modelId.startsWith("cursor/") ? modelId.slice("cursor/".length) : modelId;
+  const id = cursorCodexToWireModelId(modelId);
   const suffix = cursorEffortSuffix(id, reasoning);
   return suffix ? `${id}-${suffix}` : id;
 }

--- a/src/adapters/cursor/transport-retry.ts
+++ b/src/adapters/cursor/transport-retry.ts
@@ -1,6 +1,8 @@
 import type { CursorRunRequest, CursorServerMessage } from "./types";
 import type { CursorTransport, CursorTransportFactory, CursorTransportFactoryInput } from "./transport";
 import { abortError, sleepWithAbort } from "../../lib/upstream-retry";
+import { debugProviderDiagnostic } from "../../lib/debug";
+import { safeCursorErrorMessage } from "./cursor-errors";
 
 // Compat: historical name for the shared abortable sleep, kept for external callers.
 export { sleepWithAbort as abortAwareSleep } from "../../lib/upstream-retry";
@@ -20,6 +22,8 @@ export function isRetryableCursorError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : typeof err === "string" ? err : "";
   const haystack = `${code} ${message}`.toLowerCase();
   if (/auth|unauthor|forbidden|invalid|permission|denied|not found|unsupported/.test(haystack)) return false;
+  if (/resource.exhausted|resource_exhausted|rate limit|too many requests|throttl/.test(haystack)) return false;
+  if (haystack.includes("nghttp2_cancel") || haystack.includes("stream suspended")) return false;
   return (
     haystack.includes("econnreset") ||
     haystack.includes("econnrefused") ||
@@ -27,7 +31,7 @@ export function isRetryableCursorError(err: unknown): boolean {
     haystack.includes("enetunreach") ||
     haystack.includes("eai_again") ||
     haystack.includes("goaway") ||
-    haystack.includes("nghttp2") ||
+    (haystack.includes("nghttp2") && !haystack.includes("nghttp2_cancel")) ||
     haystack.includes("socket hang up") ||
     haystack.includes("connection reset") ||
     haystack.includes("unavailable") ||
@@ -83,8 +87,23 @@ export async function runCursorTurnWithRetry(
         !signal?.aborted &&
         requestUncommitted(transport) &&
         isRetryableCursorError(err);
-      if (!canRetry) throw err;
-      await sleepWithAbort(cursorRetryDelayMs(attempt), signal);
+      if (!canRetry) {
+        debugProviderDiagnostic("cursor", "no-retry", {
+          attempt,
+          reason: safeCursorErrorMessage(err instanceof Error ? err.message : String(err)),
+          emittedAny,
+          committed: !requestUncommitted(transport),
+          aborted: !!signal?.aborted,
+        });
+        throw err;
+      }
+      const backoffMs = cursorRetryDelayMs(attempt);
+      debugProviderDiagnostic("cursor", "retry", {
+        attempt,
+        reason: safeCursorErrorMessage(err instanceof Error ? err.message : String(err)),
+        backoffMs,
+      });
+      await sleepWithAbort(backoffMs, signal);
     } finally {
       await transport.close?.();
     }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1,5 +1,5 @@
 import type { AdapterEvent, OcxUsage } from "./types";
-import { classifyError, type OcxErrorPayload } from "./lib/errors";
+import { adapterFailureFromMessage, classifyError, type OcxErrorPayload } from "./lib/errors";
 import { encodeCompactionSummary } from "./responses/compaction";
 import { encodeReasoningEnvelope, type ReasoningEnvelope } from "./responses/reasoning-envelope";
 import { usageDisplayTotalTokens, usageInputTokensWithCacheDetail } from "./usage/totals";
@@ -39,6 +39,8 @@ function responsesUsage(usage: OcxUsage | undefined): Record<string, unknown> {
 function responseError(status: number, type: string, message: string): OcxErrorPayload {
   return classifyError(status, type, message);
 }
+
+export { adapterFailureFromMessage } from "./lib/errors";
 
 /**
  * Build the native `WebSearchAction::Search` payload from the queries that ran. codex-rs prefers a
@@ -586,14 +588,15 @@ export function bridgeToResponsesSSE(
               if (currentRawReasoning) closeCurrentRawReasoning();
               if (currentToolCall) closeCurrentToolCall();
               if (currentWebSearch) closeCurrentWebSearch("failed", []);
+              const failure = adapterFailureFromMessage(event.message);
               emit("response.failed", {
                 response: {
                   ...responseSnapshot("failed", finishedItems),
                   // Partial consumption from a mid-stream upstream failure: surfaced so the request
                   // log can record real tokens instead of usageStatus "unreported" with 0.
                   ...(event.usage ? { usage: responsesUsage(event.usage) } : {}),
-                  error: responseError(502, "upstream_error", event.message),
-                  last_error: responseError(502, "upstream_error", event.message),
+                  error: failure.error,
+                  last_error: failure.error,
                 },
               });
               reportTerminal("failed");

--- a/src/codex/catalog.ts
+++ b/src/codex/catalog.ts
@@ -14,6 +14,7 @@ import { getJawcodeModelMetadata, getJawcodeModelMetadataCaseInsensitive, listJa
 import { enrichProviderFromRegistry, shouldCaseFoldMetadataModelId } from "../providers/derive";
 import { applyProviderContextCap, providerContextCap } from "../providers/context-cap";
 import { CODEX_GPT5_IDENTITY_LINE } from "../adapters/identity";
+import { filterCursorConfiguredModelsByLiveDiscovery } from "../adapters/cursor/discovery";
 import { fetchCursorUsableModels } from "../adapters/cursor/live-models";
 
 const BUNDLED_CATALOG_CACHE_MS = 60_000;
@@ -806,7 +807,7 @@ async function fetchProviderModels(name: string, prov: OcxProviderConfig, ttlMs:
     if (cachedCursor) return applyConfigHintsToCachedModels(name, prov, cachedCursor);
     const liveIds = await fetchCursorUsableModels({ apiKey, baseUrl: prov.baseUrl });
     if (liveIds) {
-      const available = configured.filter(m => liveIds.some(id => id === m.id || id.startsWith(`${m.id}-`)));
+      const available = filterCursorConfiguredModelsByLiveDiscovery(configured, liveIds);
       const result = available.length > 0 ? available : configured;
       setCached(name, result);
       return result;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -30,7 +30,10 @@ export function classifyError(status: number, type: string, message: string): Oc
     text.includes("rate limit") ||
     text.includes("rate limited") ||
     text.includes("too many requests") ||
-    text.includes("throttlingexception")
+    text.includes("resource_exhausted") ||
+    text.includes("resource exhausted") ||
+    text.includes("throttlingexception") ||
+    text.includes("throttling")
   ) {
     return { message, type: "rate_limit_error", code: "rate_limit_exceeded" };
   }
@@ -80,4 +83,104 @@ export function classifyError(status: number, type: string, message: string): Oc
     return { message, type: "invalid_request_error", code: "invalid_request_error" };
   }
   return { message, type, code: type || null };
+}
+
+/** Best-effort parse of a retry delay embedded in an upstream error message. */
+export function parseRetryAfterFromMessage(message: string): number | undefined {
+  const patterns = [
+    /try again in (\d+(?:\.\d+)?)\s*s(?:ec(?:ond)?s?)?/i,
+    /retry after (\d+(?:\.\d+)?)\s*s(?:ec(?:ond)?s?)?/i,
+    /retry[- ]after[:\s]+(\d+)/i,
+  ];
+  for (const pattern of patterns) {
+    const match = message.match(pattern);
+    if (!match?.[1]) continue;
+    const seconds = Number.parseFloat(match[1]);
+    if (Number.isFinite(seconds) && seconds > 0) return Math.ceil(seconds);
+  }
+  return undefined;
+}
+
+/** Infer HTTP status from adapter terminal error text (provider-agnostic keyword matching). */
+export function inferHttpStatusFromAdapterMessage(message: string): number {
+  const lower = message.toLowerCase();
+  if (
+    lower.includes("resource_exhausted") ||
+    lower.includes("resource exhausted") ||
+    lower.includes("rate limit") ||
+    lower.includes("too many requests") ||
+    lower.includes("throttling")
+  ) return 429;
+  if (
+    lower.includes("unauthenticated") ||
+    lower.includes("unauthorized") ||
+    lower.includes("permission_denied") ||
+    lower.includes("permission denied") ||
+    lower.includes("forbidden") ||
+    lower.includes("invalid token") ||
+    lower.includes("expired token") ||
+    lower.includes("authentication") ||
+    lower.includes("access denied")
+  ) return 401;
+  if (
+    lower.includes("unavailable") ||
+    lower.includes("overloaded") ||
+    lower.includes("temporarily") ||
+    lower.includes("server is busy")
+  ) return 503;
+  if (
+    lower.includes("invalid") ||
+    lower.includes("not found") ||
+    lower.includes("unsupported") ||
+    lower.includes("malformed") ||
+    lower.includes("unimplemented")
+  ) return 400;
+  if (
+    lower.includes("timed out") ||
+    lower.includes("timeout") ||
+    lower.includes("etimedout") ||
+    lower.includes("deadline")
+  ) return 504;
+  return 502;
+}
+
+/** Map an adapter terminal error message to HTTP status + classified Codex error payload. */
+export function adapterFailureFromMessage(message: string): { httpStatus: number; error: OcxErrorPayload } {
+  const httpStatus = inferHttpStatusFromAdapterMessage(message);
+  let finalMessage = message;
+  const retryAfterSeconds = parseRetryAfterFromMessage(message);
+  if (retryAfterSeconds && !/please try again in /i.test(message)) {
+    finalMessage = `${message} Please try again in ${retryAfterSeconds}s.`;
+  }
+  const errorType = httpStatus === 429
+    ? "rate_limit_error"
+    : httpStatus === 401
+      ? "authentication_error"
+      : httpStatus === 503 || httpStatus === 504
+        ? "server_error"
+        : httpStatus === 400
+          ? "invalid_request_error"
+          : "upstream_error";
+  return {
+    httpStatus,
+    error: classifyError(httpStatus, errorType, finalMessage),
+  };
+}
+
+/** Map a terminal Responses error object to the HTTP status we record in /api/logs. */
+export function httpStatusFromTerminalError(error: {
+  type?: string;
+  code?: string | null;
+  message?: string;
+} | undefined): number {
+  if (!error) return 502;
+  if (error.type === "rate_limit_error" || error.code === "rate_limit_exceeded") return 429;
+  if (error.type === "authentication_error" || error.code === "invalid_api_key") return 401;
+  if (error.type === "insufficient_quota" || error.code === "insufficient_quota") return 429;
+  if (error.type === "server_error" && error.code === "server_is_overloaded") return 503;
+  if (error.type === "invalid_request_error") return 400;
+  if (error.type === "proxy_error") return 500;
+  const message = error.message ?? "";
+  if (message) return inferHttpStatusFromAdapterMessage(message);
+  return 502;
 }

--- a/src/server/relay.ts
+++ b/src/server/relay.ts
@@ -3,7 +3,7 @@ import { isUsageDebugEnabled } from "../usage/debug";
 import {
   addRequestLog,
   addFinalRequestLog,
-  httpStatusForTerminalStatus,
+  httpStatusForRequestLogTerminal,
   inspectResponseLogJson,
   inspectResponseLogSsePayload,
   type RequestLogContext,
@@ -249,7 +249,7 @@ export function responseWithDeferredRequestLog(
     status => {
       if (logged) return;
       logged = true;
-      addFinalRequestLog(requestId, start, logCtx, httpStatusForTerminalStatus(status), {
+      addFinalRequestLog(requestId, start, logCtx, httpStatusForRequestLogTerminal(status, logCtx), {
         terminalStatus: status,
         closeReason: "terminal",
       }, addLog);

--- a/src/server/request-log.ts
+++ b/src/server/request-log.ts
@@ -1,8 +1,10 @@
 import { existsSync, readFileSync } from "node:fs";
 import type { ResponsesTerminalStatus } from "../bridge";
+import { httpStatusFromTerminalError as httpStatusFromClassifiedTerminalError } from "../lib/errors";
 import { CODEX_CONFIG_PATH, readRootTomlString } from "../codex/paths";
 import { readCodexCatalogPath } from "../codex/catalog";
 import type { OcxUsage } from "../types";
+import { redactSecretString } from "../lib/redact";
 import {
   appendUsageEntry,
   usageForFinalLog,
@@ -35,6 +37,12 @@ export interface RequestLogContext {
   usageDebugBodyKind?: UsageDebugBodyKind;
   usageDebugBodySample?: string;
   usageDebugContentType?: string;
+  /** Secret-redacted upstream error reason (e.g. the granular Cursor "rate limit exceeded…"
+   * message) extracted from a `response.failed` SSE payload or non-streaming error body, so the
+   * request log / GUI shows the actual upstream failure rather than only the HTTP-mapped code. */
+  upstreamError?: string;
+  /** HTTP status derived from a terminal `response.failed` SSE payload (429/401/503/etc.). */
+  terminalHttpStatus?: number;
 }
 
 export interface RequestLogEntry {
@@ -56,6 +64,8 @@ export interface RequestLogEntry {
   errorCode?: string;
   terminalStatus?: ResponsesTerminalStatus;
   closeReason?: "terminal" | "client_cancel" | "non_stream";
+  /** Secret-redacted upstream error reason, surfaced in /api/logs and the GUI detail modal. */
+  upstreamError?: string;
   usageStatus: UsageStatus;
   usage?: OcxUsage;
   totalTokens?: number;
@@ -208,6 +218,7 @@ export function inspectResponseLogJson(logCtx: RequestLogContext, text: string):
   } catch {
     /* body may not be JSON; request log metadata is best-effort only */
   }
+  captureUpstreamError(logCtx, text);
   if (isUsageDebugEnabled() && logCtx.usageDebugBodyKind === undefined) {
     logCtx.usageDebugBodyKind = "json";
     logCtx.usageDebugBodySample = truncateForDebug(text);
@@ -223,6 +234,7 @@ export function inspectResponseLogSsePayload(logCtx: RequestLogContext, payload:
   } catch {
     /* SSE block payload may not be JSON; metadata inspection is best-effort */
   }
+  captureUpstreamError(logCtx, payload);
   if (debugEnabled) {
     if (!sseAlreadyMarked) {
       logCtx.usageDebugBodyKind = "sse";
@@ -235,8 +247,73 @@ export function inspectResponseLogSsePayload(logCtx: RequestLogContext, payload:
   }
 }
 
+/**
+ * Capture the upstream error reason into the request log context. Codex/consumer surfaces only
+ * see an HTTP-mapped error code (502 → upstream_server_error); the granular reason lives inside
+ * a `response.failed` SSE payload's `error.message` (the adapter's redacted upstream message) or
+ * a non-streaming JSON error body. We keep the FIRST non-empty reason (the original failure) and
+ * run it through redactSecretString so secrets never reach /api/logs. Pure; safe on any text.
+ */
+function captureUpstreamError(logCtx: RequestLogContext, text: string | null): void {
+  if (!text || logCtx.upstreamError) return;
+  try {
+    const json = JSON.parse(text) as {
+      type?: unknown;
+      error?: { message?: unknown };
+      last_error?: { message?: unknown };
+      response?: { error?: { type?: unknown; code?: unknown; message?: unknown } };
+    };
+    captureTerminalHttpStatus(logCtx, json);
+    const message = json?.error?.message
+      ?? json?.last_error?.message
+      ?? json?.response?.error?.message;
+    if (typeof message === "string" && message.trim()) {
+      logCtx.upstreamError = redactSecretString(message).slice(0, 500);
+    }
+  } catch {
+    /* not JSON; nothing to capture */
+  }
+}
+
+function captureTerminalHttpStatus(
+  logCtx: RequestLogContext,
+  json: {
+    type?: unknown;
+    response?: { error?: { type?: unknown; code?: unknown; message?: unknown } };
+  },
+): void {
+  if (logCtx.terminalHttpStatus !== undefined) return;
+  if (json.type !== "response.failed") return;
+  const error = json.response?.error;
+  if (!error || typeof error !== "object") return;
+  logCtx.terminalHttpStatus = httpStatusFromTerminalError({
+    type: typeof error.type === "string" ? error.type : undefined,
+    code: error.code === null || typeof error.code === "string" ? error.code : undefined,
+    message: typeof error.message === "string" ? error.message : undefined,
+  });
+}
+
+/** Map a terminal Responses error object to the HTTP status we record in /api/logs. */
+export function httpStatusFromTerminalError(error: {
+  type?: string;
+  code?: string | null;
+  message?: string;
+} | undefined): number {
+  return httpStatusFromClassifiedTerminalError(error);
+}
+
 export function httpStatusForTerminalStatus(status: ResponsesTerminalStatus): number {
   return status === "completed" ? 200 : 502;
+}
+
+export function httpStatusForRequestLogTerminal(
+  status: ResponsesTerminalStatus,
+  logCtx?: RequestLogContext,
+): number {
+  if (status === "failed" && logCtx?.terminalHttpStatus !== undefined) {
+    return logCtx.terminalHttpStatus;
+  }
+  return httpStatusForTerminalStatus(status);
 }
 
 export function addFinalRequestLog(
@@ -276,6 +353,7 @@ export function addFinalRequestLog(
     ...(errorCode ? { errorCode } : {}),
     ...(meta?.terminalStatus ? { terminalStatus: meta.terminalStatus } : {}),
     ...(meta?.closeReason ? { closeReason: meta.closeReason } : {}),
+    ...(logCtx.upstreamError ? { upstreamError: logCtx.upstreamError } : {}),
     usageStatus,
     ...(loggedUsage ? { usage: loggedUsage } : {}),
     ...(totalTokens !== undefined ? { totalTokens } : {}),

--- a/tests/adapter-error-inline.test.ts
+++ b/tests/adapter-error-inline.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
 import { createGoogleAdapter } from "../src/adapters/google";
-import { bridgeToResponsesSSE } from "../src/bridge";
+import { adapterFailureFromMessage, bridgeToResponsesSSE } from "../src/bridge";
 import type { AdapterEvent } from "../src/types";
 
 const provider = { adapter: "openai-chat", baseUrl: "https://example.test/v1", apiKey: "key" };
@@ -57,5 +57,25 @@ describe("inline error envelope in a 200 stream (F1)", () => {
     expect(failed).toBeDefined();
     expect((failed!.data.response as Record<string, unknown>).error).toMatchObject({ code: "rate_limit_exceeded" });
     expect(frames.some(f => f.event === "response.completed")).toBe(false);
+  });
+
+  test("Cursor resource_exhausted maps to 429 rate_limit_error in response.failed", async () => {
+    async function* gen(): AsyncGenerator<AdapterEvent> {
+      yield {
+        type: "error",
+        message: "Cursor rate limit exceeded: Cursor Connect error resource_exhausted: too many requests",
+      };
+    }
+    const frames = await collectSse(bridgeToResponsesSSE(gen(), "cursor/gpt-5"));
+    const failed = frames.find(f => f.event === "response.failed");
+    expect(failed).toBeDefined();
+    expect((failed!.data.response as Record<string, unknown>).error).toMatchObject({
+      type: "rate_limit_error",
+      code: "rate_limit_exceeded",
+    });
+    expect(adapterFailureFromMessage("Cursor rate limit exceeded: Cursor Connect error resource_exhausted: too many requests")).toMatchObject({
+      httpStatus: 429,
+      error: { type: "rate_limit_error", code: "rate_limit_exceeded" },
+    });
   });
 });

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { augmentRoutedModelsWithJawcodeMetadata, buildCatalogEntries, filterSupportedNativeSlugs, gatherRoutedModels, isMediaGenerationModelId, loadBundledCodexCatalog, materializeBundledCodexCatalog, mergeCatalogEntriesForSync, normalizeRoutedCatalogEntry } from "../src/codex/catalog";
 import {
   CURSOR_STATIC_MODELS,
+  filterCursorConfiguredModelsByLiveDiscovery,
   cursorModelContextWindows,
   cursorModelIds,
   cursorModelInputModalities,
@@ -388,6 +389,14 @@ describe("Codex catalog routed normalization", () => {
       globalThis.fetch = originalFetch;
       clearModelCache("cursor");
     }
+  });
+
+  test("Cursor live discovery keeps auto even when GetUsableModels omits it", () => {
+    const configured = [{ id: "auto" }, { id: "gpt-5.4" }, { id: "claude-fable-5" }];
+    expect(filterCursorConfiguredModelsByLiveDiscovery(configured, ["gpt-5.4-high"]).map(model => model.id)).toEqual([
+      "auto",
+      "gpt-5.4",
+    ]);
   });
 
   test("liveModels false ignores a fresh live-model cache", async () => {

--- a/tests/cursor-adapter.test.ts
+++ b/tests/cursor-adapter.test.ts
@@ -73,7 +73,7 @@ describe("Cursor adapter live transport", () => {
       event => events.push(event),
     );
 
-    expect(requests[0]?.modelId).toBe("auto");
+    expect(requests[0]?.modelId).toBe("default");
     expect(writes).toEqual([]);
     expect(events).toEqual([
       { type: "thinking_delta", thinking: "검토 중" },

--- a/tests/cursor-discovery.test.ts
+++ b/tests/cursor-discovery.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
+  CURSOR_AUTO_WIRE_MODEL_ID,
   CURSOR_DEFAULT_CONTEXT_WINDOW,
   CURSOR_STATIC_MODELS,
+  cursorCodexToWireModelId,
+  filterCursorConfiguredModelsByLiveDiscovery,
+  isCursorModelAvailableForAccount,
   cursorModelContextWindows,
   cursorModelIds,
   cursorModelInputModalities,
@@ -32,6 +36,32 @@ describe("Cursor discovery metadata", () => {
     // `auto` mirrors the jawcode SOT `default` entry (200k), not the generic fallback window.
     expect(cursorModelContextWindows(CURSOR_STATIC_MODELS).auto).toBe(200_000);
     expect(cursorModelContextWindows(CURSOR_STATIC_MODELS)["composer-2.5-fast"]).toBe(200_000);
+  });
+
+  test("auto is not activated by live GetUsableModels wire ids alone", () => {
+    expect(isCursorModelAvailableForAccount("gpt-5.4", ["gpt-5.4-high"])).toBe(true);
+    expect(isCursorModelAvailableForAccount("claude-fable-5", ["gpt-5.4-high"])).toBe(false);
+    expect(isCursorModelAvailableForAccount("auto", ["default"])).toBe(false);
+
+    const filtered = filterCursorConfiguredModelsByLiveDiscovery(
+      [{ id: "gpt-5.4" }, { id: "claude-fable-5" }],
+      ["gpt-5.4-high"],
+    );
+    expect(filtered.map(model => model.id)).toEqual(["gpt-5.4"]);
+  });
+
+  test("live discovery filter always keeps auto even when GetUsableModels omits it", () => {
+    const filtered = filterCursorConfiguredModelsByLiveDiscovery(
+      [{ id: "auto" }, { id: "gpt-5.4" }, { id: "claude-fable-5" }],
+      ["gpt-5.4-high"],
+    );
+    expect(filtered.map(model => model.id)).toEqual(["auto", "gpt-5.4"]);
+  });
+
+  test("auto maps to default on the Cursor wire", () => {
+    expect(cursorCodexToWireModelId("auto")).toBe(CURSOR_AUTO_WIRE_MODEL_ID);
+    expect(cursorCodexToWireModelId("cursor/auto")).toBe(CURSOR_AUTO_WIRE_MODEL_ID);
+    expect(cursorCodexToWireModelId("gpt-5.4")).toBe("gpt-5.4");
   });
 
   test("normalization trims, deduplicates, sorts, and fills context windows", () => {

--- a/tests/cursor-effort-suffix.test.ts
+++ b/tests/cursor-effort-suffix.test.ts
@@ -43,4 +43,11 @@ describe("Cursor per-model reasoning-effort suffix", () => {
     expect(modelIdFor("cursor/claude-4.6-opus-max", "low")).toBe("claude-4.6-opus-max");
     expect(cursorEffortSuffix("composer-2.5", "high")).toBeUndefined();
   });
+
+  test("claude-sonnet-5 and glm-5.2 map to live effort suffixes", () => {
+    expect(modelIdFor("cursor/claude-sonnet-5", "low")).toBe("claude-sonnet-5-low");
+    expect(modelIdFor("cursor/claude-sonnet-5", "high")).toBe("claude-sonnet-5-max");
+    expect(modelIdFor("cursor/glm-5.2", "low")).toBe("glm-5.2-high");
+    expect(modelIdFor("cursor/glm-5.2", "high")).toBe("glm-5.2-max");
+  });
 });

--- a/tests/cursor-errors.test.ts
+++ b/tests/cursor-errors.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { classifyCursorError, safeCursorErrorMessage } from "../src/adapters/cursor/cursor-errors";
+import {
+  classifyCursorError,
+  isCursorBenignCancelError,
+  safeCursorErrorMessage,
+} from "../src/adapters/cursor/cursor-errors";
 
 describe("classifyCursorError", () => {
   test("rate limit / resource exhausted", () => {
@@ -33,8 +37,20 @@ describe("classifyCursorError", () => {
     expect(classifyCursorError("Stream closed with GOAWAY")).toBe("Cursor connection failed");
   });
 
+  test("client-tool suspend cancel is not a connection failure", () => {
+    expect(classifyCursorError("Cursor connection failed: Stream closed with error code NGHTTP2_CANCEL")).toBe("Cursor stream suspended");
+  });
+
   test("unknown / generic", () => {
     expect(classifyCursorError("something unexpected happened")).toBe("Cursor upstream error");
+  });
+});
+
+describe("isCursorBenignCancelError", () => {
+  test("recognizes NGHTTP2_CANCEL and suspension markers", () => {
+    expect(isCursorBenignCancelError(Object.assign(new Error("Stream closed with error code NGHTTP2_CANCEL"), { code: "ERR_HTTP2_STREAM_ERROR" }))).toBe(true);
+    expect(isCursorBenignCancelError("Cursor stream suspended after client tools")).toBe(true);
+    expect(isCursorBenignCancelError(new Error("read ECONNRESET"))).toBe(false);
   });
 });
 

--- a/tests/cursor-request-builder.test.ts
+++ b/tests/cursor-request-builder.test.ts
@@ -14,7 +14,7 @@ describe("Cursor request builder", () => {
   test("normalizes cursor model prefix and never uses Responses response id as Cursor conversation id", () => {
     const request = createCursorRequest({ ...base, previousResponseId: "resp_123" });
 
-    expect(request.modelId).toBe("auto");
+    expect(request.modelId).toBe("default");
     // resp_* is an OpenAI Responses chain id, not a Cursor conversation id. Without a remembered
     // Cursor conversation (_cursorConversationId) we start a fresh one — never fall back to resp_*,
     // which would start an unrelated Cursor conversation and break tool-result continuation.

--- a/tests/cursor-transport-retry.test.ts
+++ b/tests/cursor-transport-retry.test.ts
@@ -44,6 +44,11 @@ describe("isRetryableCursorError", () => {
     expect(isRetryableCursorError(new Error("Cursor invalid request: bad model"))).toBe(false);
     expect(isRetryableCursorError(new Error("some unknown failure"))).toBe(false);
   });
+
+  test("does not retry rate limits or expected client-tool cancels", () => {
+    expect(isRetryableCursorError(new Error("Cursor rate limit exceeded: resource_exhausted"))).toBe(false);
+    expect(isRetryableCursorError(Object.assign(new Error("Stream closed with error code NGHTTP2_CANCEL"), { code: "ERR_HTTP2_STREAM_ERROR" }))).toBe(false);
+  });
 });
 
 describe("cursorRetryDelayMs", () => {

--- a/tests/errors-adapter-failure.test.ts
+++ b/tests/errors-adapter-failure.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import {
+  adapterFailureFromMessage,
+  parseRetryAfterFromMessage,
+} from "../src/lib/errors";
+
+describe("adapterFailureFromMessage", () => {
+  test("maps resource_exhausted to 429 rate_limit_error", () => {
+    const message = "Cursor rate limit exceeded: Cursor Connect error resource_exhausted: too many requests";
+    expect(adapterFailureFromMessage(message)).toMatchObject({
+      httpStatus: 429,
+      error: { type: "rate_limit_error", code: "rate_limit_exceeded" },
+    });
+  });
+
+  test("parses retry-after hints from upstream text", () => {
+    const message = "rate limit exceeded: try again in 12.5 seconds";
+    expect(parseRetryAfterFromMessage(message)).toBe(13);
+    expect(adapterFailureFromMessage(message).error.message).toContain("Please try again in 13s.");
+  });
+
+  test("maps authentication failures to 401", () => {
+    expect(adapterFailureFromMessage("Cursor authentication failed: unauthorized")).toMatchObject({
+      httpStatus: 401,
+      error: { type: "authentication_error" },
+    });
+  });
+});

--- a/tests/request-log.test.ts
+++ b/tests/request-log.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   filterRequestLogs,
+  httpStatusFromTerminalError,
   nextRequestLogId,
   responseWithDeferredRequestLog,
   requestLogErrorCode,
@@ -215,6 +216,75 @@ describe("request log metadata", () => {
       totalTokens: 13,
       usage: { inputTokens: 9, outputTokens: 4, estimated: true },
     });
+  });
+
+  test("deferred SSE logging captures the granular upstream reason from response.failed", async () => {
+    const entries: RequestLogEntry[] = [];
+    const cursorMessage = "Cursor rate limit exceeded: Cursor Connect error resource_exhausted: too many requests";
+    const failedPayload = JSON.stringify({
+      type: "response.failed",
+      response: {
+        error: { type: "rate_limit_error", code: "rate_limit_exceeded", message: cursorMessage },
+        last_error: { type: "rate_limit_error", code: "rate_limit_exceeded", message: cursorMessage },
+      },
+    });
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(`data: ${failedPayload}\n\n`));
+        controller.close();
+      },
+    });
+    const response = responseWithDeferredRequestLog(
+      new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } }),
+      "ocx-test-cursor-rate-limit",
+      Date.now(),
+      { model: "cursor/gpt-5", provider: "cursor" },
+      entry => entries.push(entry),
+    );
+
+    await response.text();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      terminalStatus: "failed",
+      upstreamError: cursorMessage,
+      status: 429,
+      errorCode: "rate_limit_exceeded",
+    });
+  });
+
+  test("httpStatusFromTerminalError maps Cursor rate limits to 429", () => {
+    expect(httpStatusFromTerminalError({
+      type: "rate_limit_error",
+      code: "rate_limit_exceeded",
+      message: "Cursor rate limit exceeded: Cursor Connect error resource_exhausted: too many requests",
+    })).toBe(429);
+  });
+
+  test("upstream reason capture redacts secret-shaped error messages", async () => {
+    const entries: RequestLogEntry[] = [];
+    const failedPayload = JSON.stringify({
+      type: "response.failed",
+      error: { message: "unauthorized: Bearer secret-leak-abc123" },
+    });
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(`data: ${failedPayload}\n\n`));
+        controller.close();
+      },
+    });
+    const response = responseWithDeferredRequestLog(
+      new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } }),
+      "ocx-test-cursor-redact",
+      Date.now(),
+      { model: "cursor/gpt-5", provider: "cursor" },
+      entry => entries.push(entry),
+    );
+
+    const text = await response.text();
+    expect(text).toContain("\"message\":\"unauthorized: Bearer secret-leak-abc123\"");
+    expect(entries).toHaveLength(1);
+    expect(entries[0].upstreamError).not.toContain("secret-leak-abc123");
+    expect(entries[0].upstreamError).toContain("[REDACTED]");
   });
 
   test("deferred SSE logging uses adapter-provided Kiro log input tokens", async () => {


### PR DESCRIPTION
## Summary

Improves Cursor provider reliability and request-log diagnosis when upstream calls fail or streams cancel benignly. Also fixes `cursor/auto` disappearing after live model discovery and maps it to Cursor wire id `default`.

## Changes

### Upstream error mapping
- Add shared adapter failure helpers in `src/lib/errors.ts`
- Map `resource_exhausted` / rate limits to **429** (`rate_limit_error`) instead of generic 502
- Map auth, overloaded, invalid, and timeout failures to appropriate HTTP statuses
- Use shared mapping in `bridge`, relay, and request-log terminal status handling

### Cursor transport stability
- Treat benign `NGHTTP2_CANCEL` after client-tool suspend as non-fatal
- Skip retries for rate limits and benign cancels in `transport-retry.ts`
- Add opt-in provider transport diagnostics via unified `debugProviderDiagnostic("cursor", ...)`

### Request logs
- Persist richer terminal fields: `upstreamError`, `requestedModel`, `requestedEffort`, `resolvedModel`, usage status
- Show upstream reason in GUI log detail panel

### `cursor/auto`
- Keep `auto` in catalog even when `GetUsableModels` omits it
- Map Codex-facing `auto` / `cursor/auto` to wire id **`default`**
- Add effort tiers for `claude-sonnet-5` and `glm-5.2`

## Testing

- `bun test tests/errors-adapter-failure.test.ts`
- `bun test tests/cursor-discovery.test.ts tests/codex-catalog.test.ts tests/cursor-request-builder.test.ts tests/cursor-adapter.test.ts`
- `bun test tests/cursor-transport-retry.test.ts tests/request-log.test.ts tests/adapter-error-inline.test.ts`

## Notes

- Does **not** include the unified debug CLI/GUI work (see PR #74)
- PR #74 should be rebased after this lands if both are merged separately

