### PR TITLE
feat(debug): unified provider/usage debug CLI and GUI tab

### DIFF
--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -4,19 +4,20 @@ import Providers from "./pages/Providers";
 import Models from "./pages/Models";
 import Subagents from "./pages/Subagents";
 import Logs from "./pages/Logs";
+import Debug from "./pages/Debug";
 import Usage from "./pages/Usage";
 import CodexAuth from "./pages/CodexAuth";
 import ApiKeys from "./pages/ApiKeys";
-import { IconGrid, IconServer, IconBoxes, IconBot, IconList, IconActivity, IconKey, IconGithub, IconSun, IconMoon, IconMonitor, IconGlobe, IconPower } from "./icons";
+import { IconGrid, IconServer, IconBoxes, IconBot, IconList, IconTerminal, IconActivity, IconKey, IconGithub, IconSun, IconMoon, IconMonitor, IconGlobe, IconPower } from "./icons";
 import { useI18n, useT, LOCALES, type TKey } from "./i18n";
 import { installApiAuthFetch } from "./api";
 
 installApiAuthFetch();
 
-type Page = "dashboard" | "providers" | "models" | "subagents" | "logs" | "usage" | "codex-auth" | "api";
+type Page = "dashboard" | "providers" | "models" | "subagents" | "logs" | "debug" | "usage" | "codex-auth" | "api";
 type Theme = "light" | "dark" | "system";
 
-const VALID_PAGES = new Set<Page>(["dashboard", "providers", "models", "subagents", "logs", "usage", "codex-auth", "api"]);
+const VALID_PAGES = new Set<Page>(["dashboard", "providers", "models", "subagents", "logs", "debug", "usage", "codex-auth", "api"]);
 
 function readPageFromHash(): Page {
   const raw = location.hash.replace(/^#\/?/, "");
@@ -32,6 +33,7 @@ const NAV: { id: Page; tkey: TKey; Icon: typeof IconGrid }[] = [
   { id: "models", tkey: "nav.models", Icon: IconBoxes },
   { id: "subagents", tkey: "nav.subagents", Icon: IconBot },
   { id: "logs", tkey: "nav.logs", Icon: IconList },
+  { id: "debug", tkey: "nav.debug", Icon: IconTerminal },
   { id: "usage", tkey: "nav.usage", Icon: IconActivity },
   { id: "codex-auth", tkey: "nav.codexAuth", Icon: IconKey },
   { id: "api", tkey: "nav.api", Icon: IconGlobe },
@@ -147,6 +149,7 @@ export default function App() {
           {page === "models" && <Models apiBase={API_BASE} />}
           {page === "subagents" && <Subagents apiBase={API_BASE} />}
           {page === "logs" && <Logs apiBase={API_BASE} />}
+          {page === "debug" && <Debug apiBase={API_BASE} />}
           {page === "usage" && <Usage apiBase={API_BASE} />}
           {page === "codex-auth" && <CodexAuth apiBase={API_BASE} />}
           {page === "api" && <ApiKeys apiBase={API_BASE} />}

--- a/gui/src/i18n/en.ts
+++ b/gui/src/i18n/en.ts
@@ -215,7 +215,7 @@ export const en = {
 
   // debug page
   "debug.title": "Debug",
-  "debug.subtitle": "Provider transport and usage-extraction diagnostics. Stays in sync with ocx debug provider|usage.",
+  "debug.subtitle": "Opt-in provider transport and usage-extraction diagnostics. Request errors and 502s stay on Logs.",
   "debug.debug": "Provider debug",
   "debug.usage": "Usage extraction",
   "debug.reset": "Clear runtime overrides",
@@ -223,8 +223,11 @@ export const en = {
   "debug.follow": "Follow",
   "debug.streamProvider": "Provider",
   "debug.streamUsage": "Usage",
-  "debug.empty": "Enable provider or usage debug to view diagnostic lines.",
-  "debug.noLines": "No debug lines yet. Send a request or enable debug from the CLI.",
+  "debug.loading": "Loading debug settings…",
+  "debug.emptyTitle": "Debug logging is off",
+  "debug.empty": "Turn on Provider debug or Usage extraction in the card above. Lines appear here after you send a request through the proxy.",
+  "debug.noLinesTitle": "Waiting for lines",
+  "debug.noLines": "Debug is on but nothing has been captured yet. Send a chat/request through Codex, or run ocx debug provider logs -f in a terminal.",
 
   // usage page
   "usage.title": "Usage",

--- a/gui/src/i18n/en.ts
+++ b/gui/src/i18n/en.ts
@@ -7,6 +7,7 @@ export const en = {
   "nav.models": "Models",
   "nav.subagents": "Subagents",
   "nav.logs": "Logs",
+  "nav.debug": "Debug",
   "nav.usage": "Usage",
   "common.github": "GitHub",
   "common.save": "Save",
@@ -211,6 +212,19 @@ export const en = {
   "logs.details": "Details",
   "logs.detailTitle": "Request details",
   "logs.detailRaw": "Raw log entry",
+
+  // debug page
+  "debug.title": "Debug",
+  "debug.subtitle": "Provider transport and usage-extraction diagnostics. Stays in sync with ocx debug provider|usage.",
+  "debug.debug": "Provider debug",
+  "debug.usage": "Usage extraction",
+  "debug.reset": "Clear runtime overrides",
+  "debug.refresh": "Refresh",
+  "debug.follow": "Follow",
+  "debug.streamProvider": "Provider",
+  "debug.streamUsage": "Usage",
+  "debug.empty": "Enable provider or usage debug to view diagnostic lines.",
+  "debug.noLines": "No debug lines yet. Send a request or enable debug from the CLI.",
 
   // usage page
   "usage.title": "Usage",

--- a/gui/src/i18n/ko.ts
+++ b/gui/src/i18n/ko.ts
@@ -7,6 +7,7 @@ export const ko: Record<TKey, string> = {
   "nav.models": "모델",
   "nav.subagents": "서브에이전트",
   "nav.logs": "로그",
+  "nav.debug": "디버그",
   "nav.usage": "사용량",
   "common.github": "GitHub",
   "common.save": "저장",
@@ -211,6 +212,18 @@ export const ko: Record<TKey, string> = {
   "logs.details": "상세보기",
   "logs.detailTitle": "요청 상세",
   "logs.detailRaw": "원본 로그",
+
+  "debug.title": "디버그",
+  "debug.subtitle": "Provider transport 및 usage 추출 진단. ocx debug provider|usage와 동기화됩니다.",
+  "debug.debug": "Provider debug",
+  "debug.usage": "Usage 추출",
+  "debug.reset": "런타임 재정의 해제",
+  "debug.refresh": "새로고침",
+  "debug.follow": "Follow",
+  "debug.streamProvider": "Provider",
+  "debug.streamUsage": "Usage",
+  "debug.empty": "Provider 또는 usage debug를 켜면 진단 라인을 볼 수 있습니다.",
+  "debug.noLines": "아직 debug 라인이 없습니다. 요청을 보내거나 CLI에서 debug를 켜세요.",
 
   // usage page
   "usage.title": "사용량",

--- a/gui/src/i18n/ko.ts
+++ b/gui/src/i18n/ko.ts
@@ -214,7 +214,7 @@ export const ko: Record<TKey, string> = {
   "logs.detailRaw": "원본 로그",
 
   "debug.title": "디버그",
-  "debug.subtitle": "Provider transport 및 usage 추출 진단. ocx debug provider|usage와 동기화됩니다.",
+  "debug.subtitle": "선택적 provider transport 및 usage 추출 진단. 요청 오류와 502는 Logs에 표시됩니다.",
   "debug.debug": "Provider debug",
   "debug.usage": "Usage 추출",
   "debug.reset": "런타임 재정의 해제",
@@ -222,8 +222,11 @@ export const ko: Record<TKey, string> = {
   "debug.follow": "Follow",
   "debug.streamProvider": "Provider",
   "debug.streamUsage": "Usage",
-  "debug.empty": "Provider 또는 usage debug를 켜면 진단 라인을 볼 수 있습니다.",
-  "debug.noLines": "아직 debug 라인이 없습니다. 요청을 보내거나 CLI에서 debug를 켜세요.",
+  "debug.loading": "디버그 설정 로딩 중…",
+  "debug.emptyTitle": "디버그 로깅 꺼짐",
+  "debug.empty": "위 카드에서 Provider debug 또는 Usage extraction을 켜세요. 프록시로 요청을 보낸 뒤 라인이 표시됩니다.",
+  "debug.noLinesTitle": "라인 대기 중",
+  "debug.noLines": "디버그는 켜져 있지만 아직 캡처된 라인이 없습니다. Codex로 요청을 보내거나 ocx debug provider logs -f를 실행하세요.",
 
   // usage page
   "usage.title": "사용량",

--- a/gui/src/i18n/zh.ts
+++ b/gui/src/i18n/zh.ts
@@ -7,6 +7,7 @@ export const zh: Record<TKey, string> = {
   "nav.models": "模型",
   "nav.subagents": "子代理",
   "nav.logs": "日志",
+  "nav.debug": "调试",
   "nav.usage": "用量",
   "common.github": "GitHub",
   "common.save": "保存",
@@ -211,6 +212,18 @@ export const zh: Record<TKey, string> = {
   "logs.details": "查看详情",
   "logs.detailTitle": "请求详情",
   "logs.detailRaw": "原始日志",
+
+  "debug.title": "调试",
+  "debug.subtitle": "Provider transport 与 usage 提取诊断。与 ocx debug provider|usage 保持同步。",
+  "debug.debug": "Provider debug",
+  "debug.usage": "Usage 提取",
+  "debug.reset": "清除运行时覆盖",
+  "debug.refresh": "刷新",
+  "debug.follow": "跟随滚动",
+  "debug.streamProvider": "Provider",
+  "debug.streamUsage": "Usage",
+  "debug.empty": "启用 provider 或 usage debug 后可查看诊断行。",
+  "debug.noLines": "尚无 debug 行。发送请求或在 CLI 中启用 debug。",
 
   // usage page
   "usage.title": "用量",

--- a/gui/src/i18n/zh.ts
+++ b/gui/src/i18n/zh.ts
@@ -214,7 +214,7 @@ export const zh: Record<TKey, string> = {
   "logs.detailRaw": "原始日志",
 
   "debug.title": "调试",
-  "debug.subtitle": "Provider transport 与 usage 提取诊断。与 ocx debug provider|usage 保持同步。",
+  "debug.subtitle": "可选的 provider transport 与 usage 提取诊断。请求错误和 502 在 Logs 页面。",
   "debug.debug": "Provider debug",
   "debug.usage": "Usage 提取",
   "debug.reset": "清除运行时覆盖",
@@ -222,8 +222,11 @@ export const zh: Record<TKey, string> = {
   "debug.follow": "跟随滚动",
   "debug.streamProvider": "Provider",
   "debug.streamUsage": "Usage",
-  "debug.empty": "启用 provider 或 usage debug 后可查看诊断行。",
-  "debug.noLines": "尚无 debug 行。发送请求或在 CLI 中启用 debug。",
+  "debug.loading": "正在加载调试设置…",
+  "debug.emptyTitle": "调试日志已关闭",
+  "debug.empty": "请在上方卡片中开启 Provider debug 或 Usage extraction。通过代理发送请求后，诊断行会显示在这里。",
+  "debug.noLinesTitle": "等待诊断行",
+  "debug.noLines": "调试已开启但尚未捕获任何行。请通过 Codex 发送请求，或运行 ocx debug provider logs -f。",
 
   // usage page
   "usage.title": "用量",

--- a/gui/src/icons.tsx
+++ b/gui/src/icons.tsx
@@ -12,6 +12,7 @@ export const IconServer = (p: P) => (<svg {...S(p)}><rect x="3" y="4" width="18"
 export const IconBoxes = (p: P) => (<svg {...S(p)}><path d="M12 2 4 6v6l8 4 8-4V6l-8-4Z"/><path d="m4 6 8 4 8-4M12 10v8"/></svg>);
 export const IconBot = (p: P) => (<svg {...S(p)}><rect x="4" y="8" width="16" height="11" rx="3"/><path d="M12 8V4M8 2h8"/><circle cx="9" cy="13" r="1"/><circle cx="15" cy="13" r="1"/></svg>);
 export const IconList = (p: P) => (<svg {...S(p)}><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"/></svg>);
+export const IconTerminal = (p: P) => (<svg {...S(p)}><path d="m4 17 6-5-6-5"/><path d="M12 19h8"/></svg>);
 export const IconActivity = (p: P) => (<svg {...S(p)}><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>);
 
 export const IconCheck = (p: P) => (<svg {...S(p)}><path d="m20 6-11 11-5-5"/></svg>);

--- a/gui/src/pages/Debug.tsx
+++ b/gui/src/pages/Debug.tsx
@@ -11,6 +11,7 @@ interface DebugSettings {
 }
 
 interface DebugLogEntry {
+  seq: number;
   at: number;
   line: string;
 }
@@ -25,7 +26,7 @@ export default function Debug({ apiBase }: { apiBase: string }) {
   const [lines, setLines] = useState<string[]>([]);
   const [follow, setFollow] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
-  const sinceRef = useRef(0);
+  const afterRef = useRef(0);
   const logRef = useRef<HTMLPreElement | null>(null);
 
   useEffect(() => {
@@ -52,13 +53,13 @@ export default function Debug({ apiBase }: { apiBase: string }) {
   const fetchLogs = useCallback(async (initial: boolean) => {
     if (!streamEnabled) {
       setLines([]);
-      sinceRef.current = 0;
+      afterRef.current = 0;
       return;
     }
     setRefreshing(true);
     try {
       const params = new URLSearchParams({ limit: "500" });
-      if (!initial && sinceRef.current > 0) params.set("since", String(sinceRef.current));
+      if (!initial && afterRef.current > 0) params.set("after", String(afterRef.current));
       const res = await fetch(`${logsPath}?${params}`);
       if (!res.ok) return;
       const entries = await res.json() as DebugLogEntry[];
@@ -66,14 +67,14 @@ export default function Debug({ apiBase }: { apiBase: string }) {
       setLines(prev => initial
         ? entries.map(entry => entry.line)
         : [...prev, ...entries.map(entry => entry.line)].slice(-2000));
-      sinceRef.current = entries[entries.length - 1]!.at;
+      afterRef.current = entries[entries.length - 1]!.seq;
     } catch { /* ignore */ } finally {
       setRefreshing(false);
     }
   }, [logsPath, streamEnabled]);
 
   useEffect(() => {
-    sinceRef.current = 0;
+    afterRef.current = 0;
     setLines([]);
     void fetchLogs(true);
   }, [stream, streamEnabled, fetchLogs]);

--- a/gui/src/pages/Debug.tsx
+++ b/gui/src/pages/Debug.tsx
@@ -139,7 +139,9 @@ export default function Debug({ apiBase }: { apiBase: string }) {
       </div>
       <p className="page-sub">{t("debug.subtitle")}</p>
 
-      {debug && (
+      {!debug ? (
+        <div className="empty">{t("debug.loading")}</div>
+      ) : (
         <div className="card" style={{ marginBottom: 16, padding: "12px 14px" }}>
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
             <div style={{ display: "flex", flexWrap: "wrap", gap: 16 }}>
@@ -188,13 +190,19 @@ export default function Debug({ apiBase }: { apiBase: string }) {
         </div>
       )}
 
-      {!streamEnabled ? (
-        <div className="empty">{t("debug.empty")}</div>
-      ) : lines.length === 0 ? (
-        <div className="empty">{t("debug.noLines")}</div>
-      ) : (
+      {debug && !streamEnabled ? (
+        <div className="empty">
+          <div style={{ fontWeight: 600, marginBottom: 6 }}>{t("debug.emptyTitle")}</div>
+          <div className="muted" style={{ fontSize: 13, maxWidth: 560 }}>{t("debug.empty")}</div>
+        </div>
+      ) : debug && streamEnabled && lines.length === 0 ? (
+        <div className="empty">
+          <div style={{ fontWeight: 600, marginBottom: 6 }}>{t("debug.noLinesTitle")}</div>
+          <div className="muted" style={{ fontSize: 13, maxWidth: 560 }}>{t("debug.noLines")}</div>
+        </div>
+      ) : debug && streamEnabled ? (
         <pre ref={logRef} className="log-detail-json" style={{ maxHeight: "calc(100vh - 280px)" }}>{lines.join("\n")}</pre>
-      )}
+      ) : null}
     </>
   );
 }

--- a/gui/src/pages/Debug.tsx
+++ b/gui/src/pages/Debug.tsx
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useI18n } from "../i18n";
+import { IconRefresh } from "../icons";
+import { Switch } from "../ui";
+
+interface DebugSettings {
+  enabled: boolean;
+  usage: boolean;
+  runtimeOverride: Partial<Record<"debug" | "usage", boolean>>;
+  env: Record<"debug" | "usage", boolean>;
+}
+
+interface DebugLogEntry {
+  at: number;
+  line: string;
+}
+
+type LogStream = "provider" | "usage";
+
+export default function Debug({ apiBase }: { apiBase: string }) {
+  const { t } = useI18n();
+  const [debug, setDebug] = useState<DebugSettings | null>(null);
+  const [debugBusy, setDebugBusy] = useState(false);
+  const [stream, setStream] = useState<LogStream>("provider");
+  const [lines, setLines] = useState<string[]>([]);
+  const [follow, setFollow] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const sinceRef = useRef(0);
+  const logRef = useRef<HTMLPreElement | null>(null);
+
+  useEffect(() => {
+    const fetchDebug = async () => {
+      try {
+        const res = await fetch(`${apiBase}/api/debug`);
+        if (res.ok) setDebug(await res.json());
+      } catch { /* ignore */ }
+    };
+    void fetchDebug();
+    const interval = setInterval(() => void fetchDebug(), 2000);
+    return () => clearInterval(interval);
+  }, [apiBase]);
+
+  useEffect(() => {
+    if (!debug) return;
+    if (debug.enabled && stream === "usage" && !debug.usage) setStream("provider");
+    if (debug.usage && stream === "provider" && !debug.enabled) setStream("usage");
+  }, [debug, stream]);
+
+  const streamEnabled = stream === "provider" ? !!debug?.enabled : !!debug?.usage;
+  const logsPath = stream === "provider" ? `${apiBase}/api/debug/logs` : `${apiBase}/api/debug/usage-logs`;
+
+  const fetchLogs = useCallback(async (initial: boolean) => {
+    if (!streamEnabled) {
+      setLines([]);
+      sinceRef.current = 0;
+      return;
+    }
+    setRefreshing(true);
+    try {
+      const params = new URLSearchParams({ limit: "500" });
+      if (!initial && sinceRef.current > 0) params.set("since", String(sinceRef.current));
+      const res = await fetch(`${logsPath}?${params}`);
+      if (!res.ok) return;
+      const entries = await res.json() as DebugLogEntry[];
+      if (entries.length === 0) return;
+      setLines(prev => initial
+        ? entries.map(entry => entry.line)
+        : [...prev, ...entries.map(entry => entry.line)].slice(-2000));
+      sinceRef.current = entries[entries.length - 1]!.at;
+    } catch { /* ignore */ } finally {
+      setRefreshing(false);
+    }
+  }, [logsPath, streamEnabled]);
+
+  useEffect(() => {
+    sinceRef.current = 0;
+    setLines([]);
+    void fetchLogs(true);
+  }, [stream, streamEnabled, fetchLogs]);
+
+  useEffect(() => {
+    if (!follow || !streamEnabled) return;
+    const interval = setInterval(() => void fetchLogs(false), 1000);
+    return () => clearInterval(interval);
+  }, [follow, streamEnabled, fetchLogs]);
+
+  useEffect(() => {
+    if (!follow || !logRef.current) return;
+    logRef.current.scrollTop = logRef.current.scrollHeight;
+  }, [lines, follow]);
+
+  const setDebugFlag = async (flag: "debug" | "usage", enabled: boolean) => {
+    setDebugBusy(true);
+    try {
+      const res = await fetch(`${apiBase}/api/debug`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ [flag]: enabled }),
+      });
+      if (res.ok) setDebug(await res.json());
+    } catch { /* ignore */ } finally {
+      setDebugBusy(false);
+    }
+  };
+
+  const resetDebug = async () => {
+    setDebugBusy(true);
+    try {
+      const res = await fetch(`${apiBase}/api/debug`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ reset: true }),
+      });
+      if (res.ok) setDebug(await res.json());
+    } catch { /* ignore */ } finally {
+      setDebugBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="page-head">
+        <h2>{t("debug.title")}</h2>
+        <div style={{ display: "inline-flex", alignItems: "center", gap: 12 }}>
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm"
+            disabled={refreshing || !streamEnabled}
+            onClick={() => void fetchLogs(true)}
+          >
+            <IconRefresh /> {t("debug.refresh")}
+          </button>
+          <label className="muted" style={{ fontSize: 13, cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 6 }}>
+            <input type="checkbox" checked={follow} onChange={e => setFollow(e.target.checked)} />
+            {t("debug.follow")}
+          </label>
+        </div>
+      </div>
+      <p className="page-sub">{t("debug.subtitle")}</p>
+
+      {debug && (
+        <div className="card" style={{ marginBottom: 16, padding: "12px 14px" }}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 16 }}>
+              {(["debug", "usage"] as const).map(flag => {
+                const checked = flag === "debug" ? debug.enabled : debug.usage;
+                return (
+                  <div key={flag} style={{ display: "inline-flex", alignItems: "center", gap: 10, minWidth: 220 }}>
+                    <Switch
+                      on={checked}
+                      disabled={debugBusy}
+                      label={t(`debug.${flag}`)}
+                      onClick={() => void setDebugFlag(flag, !checked)}
+                    />
+                    <span style={{ fontSize: 13 }}>{t(`debug.${flag}`)}</span>
+                  </div>
+                );
+              })}
+            </div>
+            <button type="button" className="btn btn-ghost btn-sm" disabled={debugBusy} onClick={() => void resetDebug()}>
+              {t("debug.reset")}
+            </button>
+          </div>
+
+          {(debug.enabled || debug.usage) && (
+            <div style={{ display: "inline-flex", gap: 6, marginTop: 12 }}>
+              {debug.enabled && (
+                <button
+                  type="button"
+                  className={`btn btn-sm${stream === "provider" ? " btn-primary" : " btn-ghost"}`}
+                  onClick={() => setStream("provider")}
+                >
+                  {t("debug.streamProvider")}
+                </button>
+              )}
+              {debug.usage && (
+                <button
+                  type="button"
+                  className={`btn btn-sm${stream === "usage" ? " btn-primary" : " btn-ghost"}`}
+                  onClick={() => setStream("usage")}
+                >
+                  {t("debug.streamUsage")}
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {!streamEnabled ? (
+        <div className="empty">{t("debug.empty")}</div>
+      ) : lines.length === 0 ? (
+        <div className="empty">{t("debug.noLines")}</div>
+      ) : (
+        <pre ref={logRef} className="log-detail-json" style={{ maxHeight: "calc(100vh - 280px)" }}>{lines.join("\n")}</pre>
+      )}
+    </>
+  );
+}

--- a/src/cli/debug.ts
+++ b/src/cli/debug.ts
@@ -1,0 +1,209 @@
+import { findLiveProxy, probeHostname } from "../server/proxy-liveness";
+import { DEBUG_ENV, type DebugSettingsView } from "../lib/debug-settings";
+import { runningProxyUpdateHeaders } from "../oauth/login-cli";
+import { getConfigDir } from "../config";
+import { join } from "node:path";
+import { readFileSync, statSync } from "node:fs";
+
+type DebugScope = "provider" | "usage";
+
+async function requireLiveProxy() {
+  const live = await findLiveProxy();
+  if (!live) {
+    console.error("Proxy is not running. Start it with: ocx start");
+    process.exit(1);
+  }
+  return live;
+}
+
+async function fetchDebugSettings(): Promise<DebugSettingsView> {
+  const live = await requireLiveProxy();
+  try {
+    const res = await fetch(`http://${probeHostname(live.hostname)}:${live.port}/api/debug`, {
+      headers: runningProxyUpdateHeaders(),
+    });
+    if (!res.ok) {
+      console.error(`Failed to read debug settings (${res.status})`);
+      process.exit(1);
+    }
+    return await res.json() as DebugSettingsView;
+  } catch (err) {
+    console.error(`Proxy is running but /api/debug is unreachable: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+}
+
+async function putDebugSettings(body: Record<string, unknown>): Promise<DebugSettingsView> {
+  const live = await requireLiveProxy();
+  const res = await fetch(`http://${probeHostname(live.hostname)}:${live.port}/api/debug`, {
+    method: "PUT",
+    headers: runningProxyUpdateHeaders(),
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    console.error(`Failed to update debug settings (${res.status})${text ? `: ${text.slice(0, 200)}` : ""}`);
+    process.exit(1);
+  }
+  return await res.json() as DebugSettingsView;
+}
+
+function printScopeStatus(scope: DebugScope, view: DebugSettingsView): void {
+  if (scope === "provider") {
+    console.log(`Provider debug: ${view.enabled ? "ON" : "off"}`);
+    console.log(`  env=${view.env.debug ? "on" : "off"}, runtime=${view.runtimeOverride.debug === undefined ? "env/default" : view.runtimeOverride.debug ? "on" : "off"}`);
+    console.log("  Tail: ocx debug provider logs [-f]");
+  } else {
+    console.log(`Usage debug: ${view.usage ? "ON" : "off"}`);
+    console.log(`  env=${view.env.usage ? "on" : "off"}, runtime=${view.runtimeOverride.usage === undefined ? "env/default" : view.runtimeOverride.usage ? "on" : "off"}`);
+    console.log(`  File: ${join(getConfigDir(), "usage-debug.jsonl")}`);
+    console.log("  Tail: ocx debug usage logs [-f]");
+  }
+}
+
+function envDebugEnabled(): boolean {
+  return process.env.OCX_DEBUG === "1"
+    || process.env.OCX_DEBUG_FRAMES === "1";
+}
+
+async function printProviderLogs(follow: boolean): Promise<void> {
+  const live = await requireLiveProxy();
+  const base = `http://${probeHostname(live.hostname)}:${live.port}/api/debug/logs`;
+
+  let since = 0;
+  try {
+    const res = await fetch(`${base}?limit=500`, { headers: runningProxyUpdateHeaders() });
+    if (!res.ok) {
+      console.error(`Failed to read debug logs (${res.status})`);
+      process.exit(1);
+    }
+    const entries = await res.json() as { at: number; line: string }[];
+    for (const entry of entries) console.log(entry.line);
+    if (entries.length > 0) since = entries[entries.length - 1]!.at;
+  } catch (err) {
+    console.error(`Failed to read debug logs: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
+  if (!follow) return;
+
+  while (true) {
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    try {
+      const res = await fetch(`${base}?since=${since}&limit=500`, { headers: runningProxyUpdateHeaders() });
+      if (!res.ok) continue;
+      const entries = await res.json() as { at: number; line: string }[];
+      for (const entry of entries) console.log(entry.line);
+      if (entries.length > 0) since = entries[entries.length - 1]!.at;
+    } catch {
+      /* keep following */
+    }
+  }
+}
+
+async function printUsageLogs(follow: boolean): Promise<void> {
+  const path = join(getConfigDir(), "usage-debug.jsonl");
+  if (!follow) {
+    try {
+      const content = readFileSync(path, "utf8");
+      const lines = content.split("\n").filter(Boolean);
+      const tail = lines.slice(-100);
+      for (const line of tail) console.log(line);
+      if (lines.length === 0) console.log("(empty — enable with: ocx debug usage on)");
+    } catch {
+      console.log("(no file yet — enable with: ocx debug usage on)");
+      console.log(`  path: ${path}`);
+    }
+    return;
+  }
+
+  let offset = 0;
+  try {
+    offset = statSync(path).size;
+  } catch {
+    console.log(`Waiting for ${path} … (enable with: ocx debug usage on)`);
+  }
+
+  while (true) {
+    try {
+      const content = readFileSync(path, "utf8");
+      if (content.length > offset) {
+        const chunk = content.slice(offset);
+        offset = content.length;
+        for (const line of chunk.split("\n").filter(Boolean)) console.log(line);
+      }
+    } catch {
+      /* file may not exist yet */
+    }
+    await new Promise(resolve => setTimeout(resolve, 1000));
+  }
+}
+
+async function handleScopeCommand(scope: DebugScope, actionArgv: string[]): Promise<void> {
+  const action = (actionArgv[0] ?? "status").trim().toLowerCase();
+
+  if (action === "on" || action === "off") {
+    const enabled = action === "on";
+    const body = scope === "provider" ? { debug: enabled } : { usage: enabled };
+    printScopeStatus(scope, await putDebugSettings(body));
+    console.log(`\n${scope} debug is now ${enabled ? "enabled" : "disabled"}.`);
+    return;
+  }
+
+  if (action === "status") {
+    printScopeStatus(scope, await fetchDebugSettings());
+    return;
+  }
+
+  if (action === "reset") {
+    const resetKey = scope === "provider" ? "provider" : "usage";
+    printScopeStatus(scope, await putDebugSettings({ reset: resetKey }));
+    console.log(`\nRuntime override cleared for ${scope}; effective value follows env again.`);
+    return;
+  }
+
+  if (action === "logs") {
+    const follow = actionArgv.slice(1).some(arg => arg === "-f" || arg === "--follow");
+    if (scope === "provider") await printProviderLogs(follow);
+    else await printUsageLogs(follow);
+    return;
+  }
+
+  console.error(`Usage: ocx debug ${scope} on|off|status|reset|logs [-f]`);
+  process.exit(1);
+}
+
+function printTopLevelHelp(): void {
+  console.log("Debug commands (proxy must be running):");
+  console.log("");
+  console.log("  ocx debug provider on|off|status|reset|logs [-f]");
+  console.log("  ocx debug usage on|off|status|reset|logs [-f]");
+  console.log("");
+  console.log("Env defaults on start:");
+  console.log("  provider → OCX_DEBUG=1 (legacy OCX_DEBUG_FRAMES still works)");
+  console.log(`  usage    → ${DEBUG_ENV.usage}=1`);
+}
+
+export async function handleDebugCommand(argv: string[]): Promise<void> {
+  const sub = (argv[0] ?? "").trim().toLowerCase();
+
+  if (sub === "provider" || sub === "usage") {
+    await handleScopeCommand(sub, argv.slice(1));
+    return;
+  }
+
+  if (sub === "" || sub === "help" || sub === "--help" || sub === "-h") {
+    const live = await findLiveProxy();
+    if (!live) {
+      console.log("Proxy is not running — env defaults for the next start:");
+      console.log(`  provider → OCX_DEBUG = ${envDebugEnabled() ? "on" : "off"}`);
+      console.log(`  usage    → ${DEBUG_ENV.usage} = ${process.env[DEBUG_ENV.usage] === "1" ? "on" : "off"}`);
+      console.log("");
+    }
+    printTopLevelHelp();
+    return;
+  }
+
+  printTopLevelHelp();
+  process.exit(1);
+}

--- a/src/cli/debug.ts
+++ b/src/cli/debug.ts
@@ -1,9 +1,6 @@
 import { findLiveProxy, probeHostname } from "../server/proxy-liveness";
 import { DEBUG_ENV, type DebugSettingsView } from "../lib/debug-settings";
 import { runningProxyUpdateHeaders } from "../oauth/login-cli";
-import { getConfigDir } from "../config";
-import { join } from "node:path";
-import { readFileSync, statSync } from "node:fs";
 
 type DebugScope = "provider" | "usage";
 
@@ -56,8 +53,7 @@ function printScopeStatus(scope: DebugScope, view: DebugSettingsView): void {
   } else {
     console.log(`Usage debug: ${view.usage ? "ON" : "off"}`);
     console.log(`  env=${view.env.usage ? "on" : "off"}, runtime=${view.runtimeOverride.usage === undefined ? "env/default" : view.runtimeOverride.usage ? "on" : "off"}`);
-    console.log(`  File: ${join(getConfigDir(), "usage-debug.jsonl")}`);
-    console.log("  Tail: ocx debug usage logs [-f]");
+    console.log("  Tail: ocx debug usage logs [-f] (via running proxy API)");
   }
 }
 
@@ -70,16 +66,16 @@ async function printProviderLogs(follow: boolean): Promise<void> {
   const live = await requireLiveProxy();
   const base = `http://${probeHostname(live.hostname)}:${live.port}/api/debug/logs`;
 
-  let since = 0;
+  let after = 0;
   try {
     const res = await fetch(`${base}?limit=500`, { headers: runningProxyUpdateHeaders() });
     if (!res.ok) {
       console.error(`Failed to read debug logs (${res.status})`);
       process.exit(1);
     }
-    const entries = await res.json() as { at: number; line: string }[];
+    const entries = await res.json() as { seq: number; line: string }[];
     for (const entry of entries) console.log(entry.line);
-    if (entries.length > 0) since = entries[entries.length - 1]!.at;
+    if (entries.length > 0) after = entries[entries.length - 1]!.seq;
   } catch (err) {
     console.error(`Failed to read debug logs: ${err instanceof Error ? err.message : String(err)}`);
     process.exit(1);
@@ -90,11 +86,11 @@ async function printProviderLogs(follow: boolean): Promise<void> {
   while (true) {
     await new Promise(resolve => setTimeout(resolve, 1000));
     try {
-      const res = await fetch(`${base}?since=${since}&limit=500`, { headers: runningProxyUpdateHeaders() });
+      const res = await fetch(`${base}?after=${after}&limit=500`, { headers: runningProxyUpdateHeaders() });
       if (!res.ok) continue;
-      const entries = await res.json() as { at: number; line: string }[];
+      const entries = await res.json() as { seq: number; line: string }[];
       for (const entry of entries) console.log(entry.line);
-      if (entries.length > 0) since = entries[entries.length - 1]!.at;
+      if (entries.length > 0) after = entries[entries.length - 1]!.seq;
     } catch {
       /* keep following */
     }
@@ -102,40 +98,38 @@ async function printProviderLogs(follow: boolean): Promise<void> {
 }
 
 async function printUsageLogs(follow: boolean): Promise<void> {
-  const path = join(getConfigDir(), "usage-debug.jsonl");
-  if (!follow) {
-    try {
-      const content = readFileSync(path, "utf8");
-      const lines = content.split("\n").filter(Boolean);
-      const tail = lines.slice(-100);
-      for (const line of tail) console.log(line);
-      if (lines.length === 0) console.log("(empty — enable with: ocx debug usage on)");
-    } catch {
-      console.log("(no file yet — enable with: ocx debug usage on)");
-      console.log(`  path: ${path}`);
+  const live = await requireLiveProxy();
+  const base = `http://${probeHostname(live.hostname)}:${live.port}/api/debug/usage-logs`;
+
+  let after = 0;
+  try {
+    const res = await fetch(`${base}?limit=500`, { headers: runningProxyUpdateHeaders() });
+    if (!res.ok) {
+      console.error(`Failed to read usage debug logs (${res.status})`);
+      process.exit(1);
     }
-    return;
+    const entries = await res.json() as { seq: number; line: string }[];
+    for (const entry of entries) console.log(entry.line);
+    if (entries.length === 0) console.log("(empty — enable with: ocx debug usage on)");
+    if (entries.length > 0) after = entries[entries.length - 1]!.seq;
+  } catch (err) {
+    console.error(`Failed to read usage debug logs: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
   }
 
-  let offset = 0;
-  try {
-    offset = statSync(path).size;
-  } catch {
-    console.log(`Waiting for ${path} … (enable with: ocx debug usage on)`);
-  }
+  if (!follow) return;
 
   while (true) {
-    try {
-      const content = readFileSync(path, "utf8");
-      if (content.length > offset) {
-        const chunk = content.slice(offset);
-        offset = content.length;
-        for (const line of chunk.split("\n").filter(Boolean)) console.log(line);
-      }
-    } catch {
-      /* file may not exist yet */
-    }
     await new Promise(resolve => setTimeout(resolve, 1000));
+    try {
+      const res = await fetch(`${base}?after=${after}&limit=500`, { headers: runningProxyUpdateHeaders() });
+      if (!res.ok) continue;
+      const entries = await res.json() as { seq: number; line: string }[];
+      for (const entry of entries) console.log(entry.line);
+      if (entries.length > 0) after = entries[entries.length - 1]!.seq;
+    } catch {
+      /* keep following */
+    }
   }
 }
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -54,6 +54,15 @@ const helpEntries: Record<string, HelpEntry> = {
   "sync-cache": { usage: "ocx sync-cache", summary: "Refresh Codex's model cache from the active catalog." },
   status: { usage: "ocx status", summary: "Check proxy server status." },
   doctor: { usage: "ocx doctor", summary: "Diagnose environment/network issues (paths, WSL /mnt, proxy env, ChatGPT reachability)." },
+  debug: {
+    usage: "ocx debug [provider on|off|status|reset|logs [-f]|usage on|off|status|reset|logs [-f]]",
+    summary: "Show or toggle runtime provider debug logging on the running proxy.",
+    details: [
+      "Provider: ocx debug provider on | off | status | reset | logs [-f]",
+      "Usage JSONL: ocx debug usage on | off | status | reset | logs [-f]",
+      "Env default: OCX_DEBUG=1 (legacy OCX_DEBUG_FRAMES still works)",
+    ],
+  },
   login: { usage: "ocx login <provider>", summary: "OAuth or API-key login for a provider." },
   logout: { usage: "ocx logout <provider>", summary: "Remove a stored provider login." },
   gui: { usage: "ocx gui", summary: "Open the opencodex dashboard." },
@@ -115,6 +124,8 @@ Usage:
   ocx sync-cache              Refresh Codex's model cache from the active catalog
   ocx status                  Check proxy server status
   ocx doctor                  Diagnose environment/network issues (WSL, proxy, ChatGPT reachability)
+  ocx debug [provider|usage ...]
+                              provider/usage on|off|status|reset|logs [-f]
   ocx login <provider>        OAuth login (xai) — opens browser, stores token in ~/.opencodex/auth.json
   ocx logout <provider>       Remove a stored OAuth login
   ocx gui                     Open the opencodex dashboard

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -449,6 +449,11 @@ switch (command) {
     await runDoctor();
     break;
   }
+  case "debug": {
+    const { handleDebugCommand } = await import("./debug");
+    await handleDebugCommand(args.slice(1));
+    break;
+  }
   case "ensure":
     await handleEnsure();
     break;

--- a/src/lib/debug-log-buffer.ts
+++ b/src/lib/debug-log-buffer.ts
@@ -1,0 +1,39 @@
+/** In-memory ring buffer of debug log lines for `ocx debug logs` / GUI tailing. */
+
+export interface DebugLogEntry {
+  at: number;
+  line: string;
+}
+
+const MAX_LINES = 2_000;
+const buffer: DebugLogEntry[] = [];
+const listeners = new Set<(entry: DebugLogEntry) => void>();
+
+export function appendDebugLogLine(line: string): void {
+  const entry: DebugLogEntry = { at: Date.now(), line };
+  buffer.push(entry);
+  if (buffer.length > MAX_LINES) buffer.splice(0, buffer.length - MAX_LINES);
+  for (const listener of listeners) {
+    try { listener(entry); } catch { /* listeners must not break logging */ }
+  }
+}
+
+export function getDebugLogEntries(options?: { since?: number; limit?: number }): DebugLogEntry[] {
+  const since = options?.since ?? 0;
+  const limit = options?.limit ?? 500;
+  const filtered = since > 0 ? buffer.filter(entry => entry.at > since) : buffer;
+  if (filtered.length <= limit) return filtered;
+  return filtered.slice(-limit);
+}
+
+export function subscribeDebugLogEntries(listener: (entry: DebugLogEntry) => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/** Test isolation. */
+export function resetDebugLogBufferForTests(): void {
+  buffer.length = 0;
+  listeners.clear();
+}
+

--- a/src/lib/debug-log-buffer.ts
+++ b/src/lib/debug-log-buffer.ts
@@ -1,6 +1,8 @@
 /** In-memory ring buffer of debug log lines for `ocx debug logs` / GUI tailing. */
 
 export interface DebugLogEntry {
+  /** Monotonic cursor for pagination; survives same-millisecond bursts. */
+  seq: number;
   at: number;
   line: string;
 }
@@ -8,9 +10,10 @@ export interface DebugLogEntry {
 const MAX_LINES = 2_000;
 const buffer: DebugLogEntry[] = [];
 const listeners = new Set<(entry: DebugLogEntry) => void>();
+let nextSeq = 1;
 
 export function appendDebugLogLine(line: string): void {
-  const entry: DebugLogEntry = { at: Date.now(), line };
+  const entry: DebugLogEntry = { seq: nextSeq++, at: Date.now(), line };
   buffer.push(entry);
   if (buffer.length > MAX_LINES) buffer.splice(0, buffer.length - MAX_LINES);
   for (const listener of listeners) {
@@ -18,10 +21,10 @@ export function appendDebugLogLine(line: string): void {
   }
 }
 
-export function getDebugLogEntries(options?: { since?: number; limit?: number }): DebugLogEntry[] {
-  const since = options?.since ?? 0;
+export function getDebugLogEntries(options?: { after?: number; limit?: number }): DebugLogEntry[] {
+  const after = options?.after ?? 0;
   const limit = options?.limit ?? 500;
-  const filtered = since > 0 ? buffer.filter(entry => entry.at > since) : buffer;
+  const filtered = after > 0 ? buffer.filter(entry => entry.seq > after) : buffer;
   if (filtered.length <= limit) return filtered;
   return filtered.slice(-limit);
 }
@@ -35,5 +38,5 @@ export function subscribeDebugLogEntries(listener: (entry: DebugLogEntry) => voi
 export function resetDebugLogBufferForTests(): void {
   buffer.length = 0;
   listeners.clear();
+  nextSeq = 1;
 }
-

--- a/src/lib/debug-settings.ts
+++ b/src/lib/debug-settings.ts
@@ -1,0 +1,84 @@
+/**
+ * Runtime-controllable debug flags.
+ * Provider debug: `ocx debug provider on|off|status|reset|logs [-f]` (or OCX_DEBUG=1 on start).
+ * Usage capture: `ocx debug usage on|off|status|reset|logs [-f]` (or OPENCODEX_USAGE_DEBUG=1).
+ * `/api/debug` and `ocx debug` override env defaults without restart.
+ */
+
+export const DEBUG_ENV = {
+  debug: "OCX_DEBUG",
+  usage: "OPENCODEX_USAGE_DEBUG",
+} as const;
+
+/** Legacy env var that still enables provider debug logging. */
+const LEGACY_DEBUG_ENV = ["OCX_DEBUG_FRAMES"] as const;
+
+export type DebugFlag = keyof typeof DEBUG_ENV;
+
+export interface DebugSettingsView {
+  enabled: boolean;
+  usage: boolean;
+  runtimeOverride: Partial<Record<DebugFlag, boolean>>;
+  env: Record<DebugFlag, boolean>;
+}
+
+const runtimeOverride: Partial<Record<DebugFlag, boolean>> = {};
+
+function envFlag(name: string): boolean {
+  return process.env[name] === "1";
+}
+
+function legacyDebugEnvEnabled(): boolean {
+  return LEGACY_DEBUG_ENV.some(name => envFlag(name));
+}
+
+export function isDebugEnabled(): boolean {
+  if (runtimeOverride.debug !== undefined) return runtimeOverride.debug;
+  return envFlag(DEBUG_ENV.debug) || legacyDebugEnvEnabled();
+}
+
+/** @deprecated Use isDebugEnabled(). */
+export function isFramesDebugEnabled(): boolean {
+  return isDebugEnabled();
+}
+
+export function isUsageDebugEnabled(): boolean {
+  if (runtimeOverride.usage !== undefined) return runtimeOverride.usage;
+  return envFlag(DEBUG_ENV.usage);
+}
+
+export function getDebugSettings(): DebugSettingsView {
+  return {
+    enabled: isDebugEnabled(),
+    usage: isUsageDebugEnabled(),
+    runtimeOverride: { ...runtimeOverride },
+    env: {
+      debug: envFlag(DEBUG_ENV.debug) || legacyDebugEnvEnabled(),
+      usage: envFlag(DEBUG_ENV.usage),
+    },
+  };
+}
+
+export function setDebugSettings(partial: Partial<Record<DebugFlag, boolean>>): DebugSettingsView {
+  for (const key of ["debug", "usage"] as const) {
+    if (partial[key] !== undefined) runtimeOverride[key] = partial[key];
+  }
+  return getDebugSettings();
+}
+
+export function clearDebugSetting(flag: DebugFlag): DebugSettingsView {
+  delete runtimeOverride[flag];
+  return getDebugSettings();
+}
+
+export function clearDebugSettings(): DebugSettingsView {
+  for (const key of ["debug", "usage"] as const) {
+    delete runtimeOverride[key];
+  }
+  return getDebugSettings();
+}
+
+/** Test isolation: drop runtime overrides only (env vars untouched). */
+export function resetDebugSettingsForTests(): void {
+  clearDebugSettings();
+}

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -1,21 +1,30 @@
+import { appendDebugLogLine } from "./debug-log-buffer";
+import { isDebugEnabled } from "./debug-settings";
 import { redactSecrets } from "./redact";
 
-// Opt-in frame-drop visibility. The streaming path is intentionally quiet (no unconditional
-// console output), so this no-ops unless OCX_DEBUG_FRAMES=1. Lets a malformed/chunk-split
-// upstream frame be detected instead of silently truncating content.
-function debugFramesEnabled(): boolean {
-  return process.env.OCX_DEBUG_FRAMES === "1";
+function emitDebugLine(line: string): void {
+  if (!isDebugEnabled()) return;
+  try {
+    appendDebugLogLine(line);
+    console.error(line);
+  } catch {
+    /* diagnostics must never affect request handling */
+  }
 }
+
+// Opt-in provider diagnostics. Streaming adapters stay quiet unless provider debug is on
+// (`ocx debug provider on`, GUI Logs toggle, or OCX_DEBUG=1). Tail with `ocx debug provider logs -f`.
 
 export function debugDroppedFrame(adapter: string, payload: string): void {
-  if (!debugFramesEnabled()) return;
-  console.error(`[ocx:frame-drop] ${adapter}: dropped malformed upstream frame (payload redacted, bytes=${payload.length})`);
+  if (!isDebugEnabled()) return;
+  emitDebugLine(`[ocx:frame-drop] ${adapter}: dropped malformed upstream frame (payload redacted, bytes=${payload.length})`);
 }
 
+/** Provider-agnostic diagnostic logging: `[ocx:<adapter>:<event>] {...}`. */
 export function debugProviderDiagnostic(adapter: string, event: string, details: Record<string, unknown>): void {
-  if (!debugFramesEnabled()) return;
+  if (!isDebugEnabled()) return;
   try {
-    console.error(`[ocx:${adapter}:${event}] ${JSON.stringify(redactSecrets(details))}`);
+    emitDebugLine(`[ocx:${adapter}:${event}] ${JSON.stringify(redactSecrets(details))}`);
   } catch {
     /* diagnostics must never affect request handling */
   }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -68,9 +68,7 @@ import {
 export {
   addFinalRequestLog,
   filterRequestLogs,
-  httpStatusForRequestLogTerminal,
   httpStatusForTerminalStatus,
-  httpStatusFromTerminalError,
   nextRequestLogId,
   requestLogErrorCode,
   requestLogSpeedLabel,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -68,7 +68,9 @@ import {
 export {
   addFinalRequestLog,
   filterRequestLogs,
+  httpStatusForRequestLogTerminal,
   httpStatusForTerminalStatus,
+  httpStatusFromTerminalError,
   nextRequestLogId,
   requestLogErrorCode,
   requestLogSpeedLabel,

--- a/src/server/management-api.ts
+++ b/src/server/management-api.ts
@@ -24,8 +24,17 @@ import { deriveProviderPresets } from "../providers/derive";
 import { fetchProviderQuotaReports } from "../providers/quota";
 import { DEFAULT_PROVIDER_CONTEXT_CAP, globalContextCapValue, providerContextCap, providerContextCaps, setAllProviderContextCaps, setGlobalContextCapValue, setProviderContextCap } from "../providers/context-cap";
 import { readUsageEntries } from "../usage/log";
+import { getUsageDebugLogEntries } from "../usage/debug";
 import { parseRange, summarizeUsage } from "../usage/summary";
 import { stripCodexRuntimeProviderFields } from "../codex/auth-context";
+import { getDebugLogEntries } from "../lib/debug-log-buffer";
+import {
+  clearDebugSettings,
+  clearDebugSetting,
+  getDebugSettings,
+  setDebugSettings,
+  type DebugFlag,
+} from "../lib/debug-settings";
 import type { OcxConfig, OcxProviderConfig } from "../types";
 import { drainAndShutdown } from "./lifecycle";
 import { filterRequestLogs, getRequestLogEntries } from "./request-log";
@@ -167,6 +176,46 @@ export async function handleManagementAPI(req: Request, url: URL, config: OcxCon
 
   if (url.pathname === "/api/logs" && req.method === "GET") {
     return jsonResponse(filterRequestLogs(getRequestLogEntries(), url.searchParams));
+  }
+
+  if (url.pathname === "/api/debug" && req.method === "GET") {
+    return jsonResponse(getDebugSettings());
+  }
+
+  if (url.pathname === "/api/debug/logs" && req.method === "GET") {
+    const since = Number(url.searchParams.get("since") ?? "0");
+    const limit = Number(url.searchParams.get("limit") ?? "500");
+    return jsonResponse(getDebugLogEntries({
+      since: Number.isFinite(since) && since > 0 ? since : 0,
+      limit: Number.isFinite(limit) && limit > 0 ? Math.min(limit, 2000) : 500,
+    }));
+  }
+
+  if (url.pathname === "/api/debug/usage-logs" && req.method === "GET") {
+    const since = Number(url.searchParams.get("since") ?? "0");
+    const limit = Number(url.searchParams.get("limit") ?? "500");
+    return jsonResponse(getUsageDebugLogEntries({
+      since: Number.isFinite(since) && since > 0 ? since : 0,
+      limit: Number.isFinite(limit) && limit > 0 ? Math.min(limit, 2000) : 500,
+    }));
+  }
+
+  if (url.pathname === "/api/debug" && req.method === "PUT") {
+    let body: { debug?: unknown; usage?: unknown; reset?: unknown };
+    try { body = await req.json(); } catch { return jsonResponse({ error: "invalid JSON body" }, 400); }
+    if (body.reset === true) return jsonResponse(clearDebugSettings());
+    if (body.reset === "debug" || body.reset === "provider") return jsonResponse(clearDebugSetting("debug"));
+    if (body.reset === "usage") return jsonResponse(clearDebugSetting("usage"));
+    const partial: Partial<Record<DebugFlag, boolean>> = {};
+    for (const key of ["debug", "usage"] as const) {
+      if (body[key] === undefined) continue;
+      if (typeof body[key] !== "boolean") return jsonResponse({ error: `${key} must be a boolean` }, 400);
+      partial[key] = body[key];
+    }
+    if (Object.keys(partial).length === 0) {
+      return jsonResponse({ error: "provide debug/usage booleans or reset:true" }, 400);
+    }
+    return jsonResponse(setDebugSettings(partial));
   }
 
   if (url.pathname === "/api/usage" && req.method === "GET") {

--- a/src/server/management-api.ts
+++ b/src/server/management-api.ts
@@ -50,6 +50,15 @@ export const VERSION = (() => {
   }
 })();
 
+function parseDebugLogQuery(url: URL): { after: number; limit: number } {
+  const after = Number(url.searchParams.get("after") ?? url.searchParams.get("since") ?? "0");
+  const limit = Number(url.searchParams.get("limit") ?? "500");
+  return {
+    after: Number.isFinite(after) && after > 0 ? after : 0,
+    limit: Number.isFinite(limit) && limit > 0 ? Math.min(limit, 2000) : 500,
+  };
+}
+
 export async function handleManagementAPI(req: Request, url: URL, config: OcxConfig): Promise<Response | null> {
   if (!isAllowedRequestOrigin(req, config)) {
     return jsonResponse({ error: "cross-origin request blocked" }, 403, req, config);
@@ -183,21 +192,13 @@ export async function handleManagementAPI(req: Request, url: URL, config: OcxCon
   }
 
   if (url.pathname === "/api/debug/logs" && req.method === "GET") {
-    const since = Number(url.searchParams.get("since") ?? "0");
-    const limit = Number(url.searchParams.get("limit") ?? "500");
-    return jsonResponse(getDebugLogEntries({
-      since: Number.isFinite(since) && since > 0 ? since : 0,
-      limit: Number.isFinite(limit) && limit > 0 ? Math.min(limit, 2000) : 500,
-    }));
+    const { after, limit } = parseDebugLogQuery(url);
+    return jsonResponse(getDebugLogEntries({ after, limit }));
   }
 
   if (url.pathname === "/api/debug/usage-logs" && req.method === "GET") {
-    const since = Number(url.searchParams.get("since") ?? "0");
-    const limit = Number(url.searchParams.get("limit") ?? "500");
-    return jsonResponse(getUsageDebugLogEntries({
-      since: Number.isFinite(since) && since > 0 ? since : 0,
-      limit: Number.isFinite(limit) && limit > 0 ? Math.min(limit, 2000) : 500,
-    }));
+    const { after, limit } = parseDebugLogQuery(url);
+    return jsonResponse(getUsageDebugLogEntries({ after, limit }));
   }
 
   if (url.pathname === "/api/debug" && req.method === "PUT") {

--- a/src/usage/debug.ts
+++ b/src/usage/debug.ts
@@ -69,20 +69,22 @@ export function appendUsageDebug(record: UsageDebugRecord): void {
 }
 
 /** Tail usage-debug.jsonl for GUI / management API (same shape as provider debug buffer). */
-export function getUsageDebugLogEntries(options?: { since?: number; limit?: number }): DebugLogEntry[] {
-  const since = options?.since ?? 0;
+export function getUsageDebugLogEntries(options?: { after?: number; limit?: number }): DebugLogEntry[] {
+  const after = options?.after ?? 0;
   const limit = options?.limit ?? 500;
   try {
     const content = readFileSync(usageDebugPath(), "utf8");
     const entries: DebugLogEntry[] = [];
+    let seq = 0;
     for (const line of content.split(/\r?\n/).filter(Boolean)) {
+      seq += 1;
+      if (after > 0 && seq <= after) continue;
       try {
         const record = JSON.parse(line) as UsageDebugRecord;
         const at = typeof record.ts === "number" ? record.ts : 0;
-        if (since > 0 && at <= since) continue;
-        entries.push({ at, line });
+        entries.push({ seq, at, line });
       } catch {
-        entries.push({ at: 0, line });
+        entries.push({ seq, at: 0, line });
       }
     }
     if (entries.length <= limit) return entries;

--- a/src/usage/debug.ts
+++ b/src/usage/debug.ts
@@ -1,10 +1,15 @@
+/** Usage-shape diagnostic JSONL. Enable with `ocx debug usage on` or OPENCODEX_USAGE_DEBUG=1. */
+
 import { appendFileSync, chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { getConfigDir } from "../config";
+import { DEBUG_ENV } from "../lib/debug-settings";
+import type { DebugLogEntry } from "../lib/debug-log-buffer";
 import { redactSecretString, redactSecrets } from "../lib/redact";
 import type { OcxUsage } from "../types";
 
-export const USAGE_DEBUG_ENV = "OPENCODEX_USAGE_DEBUG";
+export const USAGE_DEBUG_ENV = DEBUG_ENV.usage;
+export { isUsageDebugEnabled } from "../lib/debug-settings";
 export const USAGE_DEBUG_BODY_SAMPLE_BYTES = 2048;
 export const USAGE_DEBUG_MAX_LINES = 200;
 export const USAGE_DEBUG_KEEP_LINES = 100;
@@ -21,10 +26,6 @@ export interface UsageDebugRecord {
   bodyKind: UsageDebugBodyKind;
   bodySample: string;
   extractedUsage: OcxUsage | null;
-}
-
-export function isUsageDebugEnabled(): boolean {
-  return process.env[USAGE_DEBUG_ENV] === "1";
 }
 
 export function usageDebugPath(): string {
@@ -64,5 +65,29 @@ export function appendUsageDebug(record: UsageDebugRecord): void {
     if (existsSync(path)) trimRollingFile(path);
   } catch {
     /* debug capture must never break the proxy */
+  }
+}
+
+/** Tail usage-debug.jsonl for GUI / management API (same shape as provider debug buffer). */
+export function getUsageDebugLogEntries(options?: { since?: number; limit?: number }): DebugLogEntry[] {
+  const since = options?.since ?? 0;
+  const limit = options?.limit ?? 500;
+  try {
+    const content = readFileSync(usageDebugPath(), "utf8");
+    const entries: DebugLogEntry[] = [];
+    for (const line of content.split(/\r?\n/).filter(Boolean)) {
+      try {
+        const record = JSON.parse(line) as UsageDebugRecord;
+        const at = typeof record.ts === "number" ? record.ts : 0;
+        if (since > 0 && at <= since) continue;
+        entries.push({ at, line });
+      } catch {
+        entries.push({ at: 0, line });
+      }
+    }
+    if (entries.length <= limit) return entries;
+    return entries.slice(-limit);
+  } catch {
+    return [];
   }
 }

--- a/structure/05_gui-and-management-api.md
+++ b/structure/05_gui-and-management-api.md
@@ -19,6 +19,7 @@ starts the proxy when needed and opens `http://localhost:<port>`.
 | Key providers | Expose API-key provider presets for setup and dashboard flows. Multi-key pool per key-auth provider: `GET /api/providers/keys`, `POST /api/providers/keys`, `PUT /api/providers/keys/active`, `DELETE /api/providers/keys` masked list, add (upsert + activate), switch, and remove keys. `provider.apiKey` always mirrors the active pool entry so routing stays single-key. |
 | Subagents | Read/write the featured `subagentModels` list capped at five ids. |
 | Logs | Surface request/runtime logs for local diagnosis. |
+| Debug | Debug page (`/#debug`): provider + usage toggles, refresh/follow log viewer. `GET/PUT /api/debug`; `GET /api/debug/logs` (provider buffer); `GET /api/debug/usage-logs` (usage JSONL tail). CLI: `ocx debug provider|usage …`. |
 | Usage | `GET /api/usage` aggregate read-only summary derived from `~/.opencodex/usage.jsonl`; measured / reported / unreported / unsupported / estimated counts, daily zero-filled grid, model and provider breakdowns. Never exposes prompts. |
 | Stop | `POST /api/stop` — restore native Codex, stop any installed service, and exit the proxy. |
 
@@ -46,8 +47,18 @@ Missing usage is never treated as zero. The dashboard Usage tab renders the same
 main Dashboard surfaces a 30d token / coverage summary. The in-memory `requestLog` is capped at
 200 entries and is **not** the source of truth for aggregation — the JSONL on disk is.
 
-For diagnosing upstream-shape issues set `OPENCODEX_USAGE_DEBUG=1`; the proxy then writes a
-rolling debug record per finalized request to `~/.opencodex/usage-debug.jsonl` (mode `0o600`,
-auto-trimmed to the most-recent 100 lines once it exceeds 200) with the upstream content-type,
-body kind (`sse / json / other / none`), a 2KB body sample, and the extracted usage. The flag
-is off by default and the hot path is guarded so production stays untouched.
+For diagnosing upstream-shape / usage-extraction issues run `ocx debug usage on` (or set
+`OPENCODEX_USAGE_DEBUG=1` before start). The proxy then writes a rolling debug record per finalized
+request to `~/.opencodex/usage-debug.jsonl` (mode `0o600`, auto-trimmed to the most-recent 100 lines
+once it exceeds 200) with the upstream content-type, body kind (`sse / json / other / none`), a 2KB
+body sample, and the extracted usage. Off by default; the hot path is guarded so production stays
+untouched.
+
+## Provider debug logging
+
+Provider transport diagnostics (dropped SSE frames, adapter dial/stream events, etc.) are opt-in:
+`ocx debug provider on` / `ocx debug provider off` on the running proxy, the Debug-page toggle, or `OCX_DEBUG=1` on
+the next start (legacy `OCX_DEBUG_FRAMES` still enables the same path). Lines
+use the `[ocx:<adapter>:<event>]` prefix, go to the proxy terminal, and are buffered for
+`ocx debug provider logs` / `ocx debug provider logs -f`. Usage JSONL tails with
+`ocx debug usage logs [-f]`. Separate from provider buffered logs above.

--- a/structure/05_gui-and-management-api.md
+++ b/structure/05_gui-and-management-api.md
@@ -19,7 +19,7 @@ starts the proxy when needed and opens `http://localhost:<port>`.
 | Key providers | Expose API-key provider presets for setup and dashboard flows. Multi-key pool per key-auth provider: `GET /api/providers/keys`, `POST /api/providers/keys`, `PUT /api/providers/keys/active`, `DELETE /api/providers/keys` masked list, add (upsert + activate), switch, and remove keys. `provider.apiKey` always mirrors the active pool entry so routing stays single-key. |
 | Subagents | Read/write the featured `subagentModels` list capped at five ids. |
 | Logs | Surface request/runtime logs for local diagnosis. |
-| Debug | Debug page (`/#debug`): provider + usage toggles, refresh/follow log viewer. `GET/PUT /api/debug`; `GET /api/debug/logs` (provider buffer); `GET /api/debug/usage-logs` (usage JSONL tail). CLI: `ocx debug provider|usage …`. |
+| Debug | Debug page (`/#debug`): provider + usage toggles, refresh/follow log viewer. `GET/PUT /api/debug`; `GET /api/debug/logs` and `GET /api/debug/usage-logs` (monotonic `after` cursor, legacy `since` accepted). CLI: `ocx debug provider|usage …` (both streams via running proxy API). |
 | Usage | `GET /api/usage` aggregate read-only summary derived from `~/.opencodex/usage.jsonl`; measured / reported / unreported / unsupported / estimated counts, daily zero-filled grid, model and provider breakdowns. Never exposes prompts. |
 | Stop | `POST /api/stop` — restore native Codex, stop any installed service, and exit the proxy. |
 

--- a/tests/api-debug.test.ts
+++ b/tests/api-debug.test.ts
@@ -162,7 +162,8 @@ describe("management API /api/debug/logs", () => {
     setDebugSettings({ debug: true });
     debugProviderDiagnostic("cursor", "dial", {
       host: "api2.cursor.sh",
-      authorization: "Bearer super-secret-token",
+      // Placeholder token shape is constrained by scripts/privacy-scan.ts's tests/ allowlist.
+      authorization: "Bearer access-token-value-testonly123",
     });
 
     const server = startServer(0);
@@ -171,7 +172,7 @@ describe("management API /api/debug/logs", () => {
       const entries = await res.json() as { line: string }[];
       expect(entries).toHaveLength(1);
       expect(entries[0]!.line).toContain("api2.cursor.sh");
-      expect(entries[0]!.line).not.toContain("super-secret-token");
+      expect(entries[0]!.line).not.toContain("access-token-value-testonly123");
       expect(entries[0]!.line).toContain("[REDACTED]");
     } finally {
       await server.stop(true);
@@ -231,7 +232,8 @@ describe("management API /api/debug/usage-logs", () => {
       upstreamContentType: "application/json",
       upstreamStatus: 200,
       bodyKind: "json",
-      bodySample: "Bearer wire-secret-token-abcdef",
+      // Placeholder token shape is constrained by scripts/privacy-scan.ts's tests/ allowlist.
+      bodySample: "Bearer usage-debug-token-value-testonly123",
       extractedUsage: null,
     });
 
@@ -239,11 +241,10 @@ describe("management API /api/debug/usage-logs", () => {
     try {
       const res = await fetch(new URL("/api/debug/usage-logs", server.url));
       const entries = await res.json() as { line: string }[];
-      expect(entries[0]!.line).not.toContain("wire-secret-token");
+      expect(entries[0]!.line).not.toContain("usage-debug-token-value-testonly123");
       expect(entries[0]!.line).toContain("[REDACTED]");
     } finally {
       await server.stop(true);
     }
   });
 });
-

--- a/tests/api-debug.test.ts
+++ b/tests/api-debug.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { saveConfig } from "../src/config";
+import { appendDebugLogLine, getDebugLogEntries, resetDebugLogBufferForTests } from "../src/lib/debug-log-buffer";
+import { clearDebugSettings, setDebugSettings } from "../src/lib/debug-settings";
+import { debugProviderDiagnostic } from "../src/lib/debug";
+import { startServer } from "../src/server";
+import { appendUsageDebug } from "../src/usage/debug";
+import type { OcxConfig } from "../src/types";
+import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+
+let testDir = "";
+let previousHome: string | undefined;
+let isolatedCodexHome: IsolatedCodexHome | null = null;
+
+function baseConfig(): OcxConfig {
+  return {
+    port: 0,
+    hostname: "127.0.0.1",
+    defaultProvider: "openai",
+    providers: {
+      openai: {
+        adapter: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+        authMode: "forward",
+      },
+    },
+  } as OcxConfig;
+}
+
+function loopbackOrigin(server: { port: number }): string {
+  return `http://127.0.0.1:${server.port}`;
+}
+
+beforeEach(() => {
+  previousHome = process.env.OPENCODEX_HOME;
+  isolatedCodexHome = installIsolatedCodexHome("ocx-api-debug-codex-");
+  testDir = mkdtempSync(join(tmpdir(), "ocx-api-debug-"));
+  process.env.OPENCODEX_HOME = testDir;
+  saveConfig(baseConfig());
+  resetDebugLogBufferForTests();
+  clearDebugSettings();
+  delete process.env.OCX_DEBUG;
+  delete process.env.OPENCODEX_USAGE_DEBUG;
+});
+
+afterEach(() => {
+  if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = previousHome;
+  isolatedCodexHome?.restore();
+  isolatedCodexHome = null;
+  resetDebugLogBufferForTests();
+  clearDebugSettings();
+  if (testDir) rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("management API /api/debug", () => {
+  test("GET returns provider + usage debug view", async () => {
+    const server = startServer(0);
+    try {
+      const res = await fetch(new URL("/api/debug", server.url));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toMatchObject({
+        enabled: false,
+        usage: false,
+      });
+      expect(body).toHaveProperty("runtimeOverride");
+      expect(body).toHaveProperty("env");
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("PUT toggles runtime flags and reset clears overrides", async () => {
+    const server = startServer(0);
+    const origin = loopbackOrigin(server);
+    try {
+      const on = await fetch(new URL("/api/debug", server.url), {
+        method: "PUT",
+        headers: { "content-type": "application/json", origin },
+        body: JSON.stringify({ debug: true, usage: true }),
+      });
+      expect(on.status).toBe(200);
+      expect(await on.json()).toMatchObject({ enabled: true, usage: true });
+
+      const reset = await fetch(new URL("/api/debug", server.url), {
+        method: "PUT",
+        headers: { "content-type": "application/json", origin },
+        body: JSON.stringify({ reset: true }),
+      });
+      expect(reset.status).toBe(200);
+      expect(await reset.json()).toMatchObject({ enabled: false, usage: false });
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("PUT rejects invalid bodies", async () => {
+    const server = startServer(0);
+    const origin = loopbackOrigin(server);
+    try {
+      const badType = await fetch(new URL("/api/debug", server.url), {
+        method: "PUT",
+        headers: { "content-type": "application/json", origin },
+        body: JSON.stringify({ debug: "yes" }),
+      });
+      expect(badType.status).toBe(400);
+
+      const empty = await fetch(new URL("/api/debug", server.url), {
+        method: "PUT",
+        headers: { "content-type": "application/json", origin },
+        body: JSON.stringify({}),
+      });
+      expect(empty.status).toBe(400);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("rejects non-local Origin on debug endpoints", async () => {
+    const server = startServer(0);
+    try {
+      const res = await fetch(new URL("/api/debug/logs", server.url), {
+        headers: { origin: "https://attacker.test" },
+      });
+      expect(res.status).toBe(403);
+      expect(await res.json()).toMatchObject({ error: "cross-origin request blocked" });
+    } finally {
+      await server.stop(true);
+    }
+  });
+});
+
+describe("management API /api/debug/logs", () => {
+  test("returns buffered provider lines with seq cursor and limit", async () => {
+    setDebugSettings({ debug: true });
+    appendDebugLogLine("[ocx:test:one]");
+    appendDebugLogLine("[ocx:test:two]");
+
+    const server = startServer(0);
+    try {
+      const all = await fetch(new URL("/api/debug/logs?limit=500", server.url));
+      expect(all.status).toBe(200);
+      const entries = await all.json() as { seq: number; line: string }[];
+      expect(entries).toHaveLength(2);
+      expect(entries[0]!.seq).toBe(1);
+      expect(entries[1]!.line).toContain("two");
+
+      const tail = await fetch(new URL(`/api/debug/logs?after=${entries[0]!.seq}&limit=500`, server.url));
+      const tailEntries = await tail.json() as { seq: number; line: string }[];
+      expect(tailEntries).toHaveLength(1);
+      expect(tailEntries[0]!.line).toContain("two");
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("redacts secrets in provider diagnostics served over HTTP", async () => {
+    setDebugSettings({ debug: true });
+    debugProviderDiagnostic("cursor", "dial", {
+      host: "api2.cursor.sh",
+      authorization: "Bearer super-secret-token",
+    });
+
+    const server = startServer(0);
+    try {
+      const res = await fetch(new URL("/api/debug/logs", server.url));
+      const entries = await res.json() as { line: string }[];
+      expect(entries).toHaveLength(1);
+      expect(entries[0]!.line).toContain("api2.cursor.sh");
+      expect(entries[0]!.line).not.toContain("super-secret-token");
+      expect(entries[0]!.line).toContain("[REDACTED]");
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("caps limit query param at 2000", async () => {
+    for (let i = 0; i < 5; i += 1) appendDebugLogLine(`[ocx:test:${i}]`);
+    const server = startServer(0);
+    try {
+      const res = await fetch(new URL("/api/debug/logs?limit=99999", server.url));
+      const entries = await res.json() as unknown[];
+      expect(entries.length).toBeLessThanOrEqual(2000);
+      expect(entries.length).toBe(getDebugLogEntries().length);
+    } finally {
+      await server.stop(true);
+    }
+  });
+});
+
+describe("management API /api/debug/usage-logs", () => {
+  test("tails usage-debug.jsonl from the running proxy home", async () => {
+    appendUsageDebug({
+      ts: Date.now(),
+      requestId: "ocx-usage-wire",
+      provider: "cursor",
+      model: "gpt-5.4",
+      upstreamContentType: "text/event-stream",
+      upstreamStatus: 200,
+      bodyKind: "sse",
+      bodySample: "data: ok",
+      extractedUsage: null,
+    });
+
+    const server = startServer(0);
+    try {
+      const res = await fetch(new URL("/api/debug/usage-logs", server.url));
+      expect(res.status).toBe(200);
+      const entries = await res.json() as { seq: number; line: string }[];
+      expect(entries.length).toBeGreaterThanOrEqual(1);
+      expect(entries[0]!.seq).toBe(1);
+      expect(entries[0]!.line).toContain("ocx-usage-wire");
+
+      const tail = await fetch(new URL(`/api/debug/usage-logs?after=${entries[0]!.seq}`, server.url));
+      expect(await tail.json()).toEqual([]);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("serves redacted usage samples without leaking bearer tokens", async () => {
+    appendUsageDebug({
+      ts: Date.now(),
+      requestId: "ocx-usage-secret",
+      provider: "cursor",
+      model: "gpt-5.4",
+      upstreamContentType: "application/json",
+      upstreamStatus: 200,
+      bodyKind: "json",
+      bodySample: "Bearer wire-secret-token-abcdef",
+      extractedUsage: null,
+    });
+
+    const server = startServer(0);
+    try {
+      const res = await fetch(new URL("/api/debug/usage-logs", server.url));
+      const entries = await res.json() as { line: string }[];
+      expect(entries[0]!.line).not.toContain("wire-secret-token");
+      expect(entries[0]!.line).toContain("[REDACTED]");
+    } finally {
+      await server.stop(true);
+    }
+  });
+});
+

--- a/tests/debug-settings.test.ts
+++ b/tests/debug-settings.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  clearDebugSettings,
+  clearDebugSetting,
+  getDebugSettings,
+  isDebugEnabled,
+  isFramesDebugEnabled,
+  isUsageDebugEnabled,
+  resetDebugSettingsForTests,
+  setDebugSettings,
+} from "../src/lib/debug-settings";
+
+describe("debug settings", () => {
+  const prevFrames = process.env.OCX_DEBUG_FRAMES;
+  const prevDebug = process.env.OCX_DEBUG;
+  const prevUsage = process.env.OPENCODEX_USAGE_DEBUG;
+
+  afterEach(() => {
+    resetDebugSettingsForTests();
+    if (prevFrames === undefined) delete process.env.OCX_DEBUG_FRAMES;
+    else process.env.OCX_DEBUG_FRAMES = prevFrames;
+    if (prevDebug === undefined) delete process.env.OCX_DEBUG;
+    else process.env.OCX_DEBUG = prevDebug;
+    if (prevUsage === undefined) delete process.env.OPENCODEX_USAGE_DEBUG;
+    else process.env.OPENCODEX_USAGE_DEBUG = prevUsage;
+  });
+
+  test("env defaults are off when unset", () => {
+    delete process.env.OCX_DEBUG;
+    delete process.env.OCX_DEBUG_FRAMES;
+    delete process.env.OPENCODEX_USAGE_DEBUG;
+    expect(isDebugEnabled()).toBe(false);
+    expect(isFramesDebugEnabled()).toBe(false);
+    expect(isUsageDebugEnabled()).toBe(false);
+  });
+
+  test("runtime override enables debug without env", () => {
+    delete process.env.OCX_DEBUG;
+    delete process.env.OCX_DEBUG_FRAMES;
+    setDebugSettings({ debug: true });
+    expect(isDebugEnabled()).toBe(true);
+    expect(getDebugSettings().runtimeOverride.debug).toBe(true);
+  });
+
+  test("legacy env vars still enable provider debug", () => {
+    delete process.env.OCX_DEBUG;
+    process.env.OCX_DEBUG_FRAMES = "1";
+    expect(isDebugEnabled()).toBe(true);
+  });
+
+  test("clear restores env defaults", () => {
+    process.env.OCX_DEBUG = "1";
+    setDebugSettings({ debug: false });
+    expect(isDebugEnabled()).toBe(false);
+    clearDebugSetting("debug");
+    expect(isDebugEnabled()).toBe(true);
+  });
+
+  test("clearDebugSetting only clears one scope", () => {
+    process.env.OCX_DEBUG = "1";
+    process.env.OPENCODEX_USAGE_DEBUG = "1";
+    setDebugSettings({ debug: false, usage: false });
+    clearDebugSetting("debug");
+    expect(isDebugEnabled()).toBe(true);
+    expect(isUsageDebugEnabled()).toBe(false);
+    clearDebugSettings();
+  });
+});

--- a/tests/debug.test.ts
+++ b/tests/debug.test.ts
@@ -1,16 +1,20 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { appendDebugLogLine, getDebugLogEntries, resetDebugLogBufferForTests } from "../src/lib/debug-log-buffer";
 import { debugDroppedFrame, debugProviderDiagnostic } from "../src/lib/debug";
+import { resetDebugSettingsForTests, setDebugSettings } from "../src/lib/debug-settings";
 
 describe("debug frame logging", () => {
-  const previous = process.env.OCX_DEBUG_FRAMES;
+  const previous = process.env.OCX_DEBUG;
 
   afterEach(() => {
-    if (previous === undefined) delete process.env.OCX_DEBUG_FRAMES;
-    else process.env.OCX_DEBUG_FRAMES = previous;
+    resetDebugSettingsForTests();
+    resetDebugLogBufferForTests();
+    if (previous === undefined) delete process.env.OCX_DEBUG;
+    else process.env.OCX_DEBUG = previous;
   });
 
   test("debugDroppedFrame redacts payload content", () => {
-    process.env.OCX_DEBUG_FRAMES = "1";
+    process.env.OCX_DEBUG = "1";
     const error = spyOn(console, "error").mockImplementation(() => {});
     try {
       debugDroppedFrame("openai-chat", "secret frame body bearer-token@example.test");
@@ -20,13 +24,68 @@ describe("debug frame logging", () => {
       expect(line).toContain("payload redacted");
       expect(line).not.toContain("secret frame body");
       expect(line).not.toContain("bearer-token@example.test");
+      expect(getDebugLogEntries().some(entry => entry.line.includes("openai-chat"))).toBe(true);
+    } finally {
+      error.mockRestore();
+    }
+  });
+
+  test("debugProviderDiagnostic emits under OCX_DEBUG with provider prefix and redacts secrets", () => {
+    process.env.OCX_DEBUG = "1";
+    const error = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      debugProviderDiagnostic("cursor", "dial", { host: "api2.cursor.sh", authorization: "Bearer secret-cursor-token" });
+      expect(error).toHaveBeenCalledTimes(1);
+      const line = String(error.mock.calls[0]?.[0] ?? "");
+      expect(line).toContain("[ocx:cursor:dial]");
+      expect(line).toContain("api2.cursor.sh");
+      expect(line).not.toContain("secret-cursor-token");
+      expect(line).toContain("[REDACTED]");
+    } finally {
+      error.mockRestore();
+    }
+  });
+
+  test("legacy OCX_DEBUG_FRAMES still enables provider diagnostics", () => {
+    delete process.env.OCX_DEBUG;
+    process.env.OCX_DEBUG_FRAMES = "1";
+    const error = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      debugProviderDiagnostic("cursor", "connected", { connectMs: 12 });
+      expect(error).toHaveBeenCalledTimes(1);
+      expect(String(error.mock.calls[0]?.[0] ?? "")).toContain("[ocx:cursor:connected]");
+    } finally {
+      error.mockRestore();
+    }
+  });
+
+  test("debugProviderDiagnostic stays quiet unless explicitly enabled", () => {
+    delete process.env.OCX_DEBUG;
+    delete process.env.OCX_DEBUG_FRAMES;
+    const error = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      debugProviderDiagnostic("cursor", "dial", { host: "api2.cursor.sh" });
+      expect(error).not.toHaveBeenCalled();
+    } finally {
+      error.mockRestore();
+    }
+  });
+
+  test("debugProviderDiagnostic emits when enabled via runtime settings API", () => {
+    delete process.env.OCX_DEBUG;
+    setDebugSettings({ debug: true });
+    const error = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      debugProviderDiagnostic("cursor", "connected", { connectMs: 42 });
+      expect(error).toHaveBeenCalledTimes(1);
+      expect(String(error.mock.calls[0]?.[0] ?? "")).toContain("[ocx:cursor:connected]");
     } finally {
       error.mockRestore();
     }
   });
 
   test("debugDroppedFrame stays quiet unless explicitly enabled", () => {
-    delete process.env.OCX_DEBUG_FRAMES;
+    delete process.env.OCX_DEBUG;
     const error = spyOn(console, "error").mockImplementation(() => {});
     try {
       debugDroppedFrame("openai-chat", "secret frame body");
@@ -36,19 +95,8 @@ describe("debug frame logging", () => {
     }
   });
 
-  test("debugProviderDiagnostic stays quiet unless explicitly enabled", () => {
-    delete process.env.OCX_DEBUG_FRAMES;
-    const error = spyOn(console, "error").mockImplementation(() => {});
-    try {
-      debugProviderDiagnostic("kiro", "request", { accessToken: "secret-token" });
-      expect(error).not.toHaveBeenCalled();
-    } finally {
-      error.mockRestore();
-    }
-  });
-
   test("debugProviderDiagnostic redacts structured secrets", () => {
-    process.env.OCX_DEBUG_FRAMES = "1";
+    process.env.OCX_DEBUG = "1";
     const error = spyOn(console, "error").mockImplementation(() => {});
     try {
       debugProviderDiagnostic("kiro", "request", {
@@ -66,5 +114,15 @@ describe("debug frame logging", () => {
     } finally {
       error.mockRestore();
     }
+  });
+
+  test("appendDebugLogLine supports since/limit queries", () => {
+    appendDebugLogLine("[ocx:test:one]");
+    appendDebugLogLine("[ocx:test:two]");
+    const all = getDebugLogEntries();
+    expect(all).toHaveLength(2);
+    const since = getDebugLogEntries({ since: all[0]!.at - 1, limit: 10 });
+    expect(since.length).toBeGreaterThanOrEqual(1);
+    expect(since[since.length - 1]!.line).toContain("two");
   });
 });

--- a/tests/debug.test.ts
+++ b/tests/debug.test.ts
@@ -116,13 +116,30 @@ describe("debug frame logging", () => {
     }
   });
 
-  test("appendDebugLogLine supports since/limit queries", () => {
+  test("appendDebugLogLine supports after/limit queries with monotonic seq", () => {
     appendDebugLogLine("[ocx:test:one]");
     appendDebugLogLine("[ocx:test:two]");
     const all = getDebugLogEntries();
     expect(all).toHaveLength(2);
-    const since = getDebugLogEntries({ since: all[0]!.at - 1, limit: 10 });
-    expect(since.length).toBeGreaterThanOrEqual(1);
-    expect(since[since.length - 1]!.line).toContain("two");
+    expect(all[0]!.seq).toBe(1);
+    expect(all[1]!.seq).toBe(2);
+    const tail = getDebugLogEntries({ after: all[0]!.seq, limit: 10 });
+    expect(tail).toHaveLength(1);
+    expect(tail[0]!.line).toContain("two");
+  });
+
+  test("same-millisecond bursts keep every line via seq cursor", () => {
+    const now = Date.now();
+    const spy = spyOn(Date, "now").mockReturnValue(now);
+    try {
+      appendDebugLogLine("[ocx:test:a]");
+      appendDebugLogLine("[ocx:test:b]");
+      const all = getDebugLogEntries();
+      const tail = getDebugLogEntries({ after: all[0]!.seq, limit: 10 });
+      expect(tail).toHaveLength(1);
+      expect(tail[0]!.line).toContain("b");
+    } finally {
+      spy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Adds a unified debug system for provider transport diagnostics and usage extraction, with matching CLI commands, management API endpoints, and a dedicated GUI tab.

## Changes

### CLI
- `ocx debug provider on|off|status|reset|logs [-f]`
- `ocx debug usage on|off|status|reset|logs [-f]`
- Runtime toggles on the running proxy (no restart required)

### Server API
- `GET/PUT /api/debug` — provider + usage flags with runtime overrides
- `GET /api/debug/logs` — in-memory provider diagnostic buffer (`[ocx:…]` lines)
- `GET /api/debug/usage-logs` — tail of `~/.opencodex/usage-debug.jsonl`

### GUI
- New sidebar tab **`/#debug`**
- Provider debug + Usage extraction toggles (sync with CLI via polling)
- Refresh + Follow controls for live log viewing
- Debug controls removed from `/#logs` (request logs only)

### Internals
- `src/lib/debug-settings.ts`, `src/lib/debug-log-buffer.ts`
- Generic `debugProviderDiagnostic(adapter, event, details)` for all providers
- Legacy env: `OCX_DEBUG=1` and `OCX_DEBUG_FRAMES=1` still enable provider debug

## Testing

- `bun test tests/debug.test.ts tests/debug-settings.test.ts`

## Dependencies

Standalone debug-only PR (single commit). Can merge independently of #73; if both land around the same time, merge #73 first to reduce overlap on shared adapter wiring.

