### PR TITLE
fix(anthropic): normalize tool input schemas

### DIFF
--- a/src/adapters/anthropic.ts
+++ b/src/adapters/anthropic.ts
@@ -482,9 +482,71 @@ function toolsToAnthropicFormat(parsed: OcxParsedRequest, toolNames: { toWire: (
   const converted = tools.map(t => ({
     name: toolNames.toWire(namespacedToolName(t.namespace, t.name)),
     description: t.description,
-    input_schema: t.parameters,
+    input_schema: normalizeAnthropicInputSchema(t.parameters),
   }));
   return converted;
+}
+
+function normalizeAnthropicInputSchema(schema: unknown): Record<string, unknown> {
+  const obj = schema && typeof schema === "object" && !Array.isArray(schema)
+    ? schema as Record<string, unknown>
+    : {};
+  /*
+   * [Decision Log]
+   * - 목적: Anthropic Messages API가 tool input_schema 루트의 type 누락과 oneOf/anyOf/allOf를 400으로 거부하는 것을 방지한다.
+   * - 대안 분석: (1) t.parameters 원본 유지: OpenAI 호환성은 좋지만 Anthropic에서 실패한다. (2) Kiro sanitizer 재사용: 루트 보정은 맞지만 additionalProperties 등 Anthropic이 받을 수 있는 정보를 과하게 삭제한다. (3) Anthropic 루트만 정규화: 실패 조건만 제거하고 중첩 스키마와 부가 키는 보존한다.
+   * - 선택 근거: Anthropic 어댑터의 wire 요구사항만 해결하는 좁은 수정이며, root composition required 병합도 oneOf/anyOf를 과도하게 강제하지 않는다.
+   */
+  const compositionKeys = ["oneOf", "anyOf", "allOf"] as const;
+  const hasRootComposition = compositionKeys.some(key => Array.isArray(obj[key]));
+  const type = obj.type;
+  const rootObjectType = type === "object" || (Array.isArray(type) && type.includes("object"));
+
+  if (!hasRootComposition) {
+    const normalized: Record<string, unknown> = rootObjectType && type === "object"
+      ? { ...obj }
+      : { ...obj, type: "object" };
+    if (normalized.properties === undefined || normalized.properties === null) {
+      normalized.properties = {};
+    }
+    return normalized;
+  }
+
+  const properties: Record<string, unknown> = {};
+  const required = new Set<string>();
+  if (obj.properties && typeof obj.properties === "object" && !Array.isArray(obj.properties)) {
+    Object.assign(properties, obj.properties as Record<string, unknown>);
+  }
+  if (Array.isArray(obj.required)) {
+    for (const item of obj.required) if (typeof item === "string") required.add(item);
+  }
+
+  for (const key of compositionKeys) {
+    const variants = obj[key];
+    if (!Array.isArray(variants)) continue;
+    const mergeRequired = key === "allOf";
+    for (const variant of variants) {
+      if (!variant || typeof variant !== "object" || Array.isArray(variant)) continue;
+      const v = variant as Record<string, unknown>;
+      if (v.properties && typeof v.properties === "object" && !Array.isArray(v.properties)) {
+        Object.assign(properties, v.properties as Record<string, unknown>);
+      }
+      if (mergeRequired && Array.isArray(v.required)) {
+        for (const item of v.required) if (typeof item === "string") required.add(item);
+      }
+    }
+  }
+
+  const normalized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === "oneOf" || key === "anyOf" || key === "allOf") continue;
+    if (key === "type" || key === "properties" || key === "required") continue;
+    normalized[key] = value;
+  }
+  normalized.type = "object";
+  normalized.properties = properties;
+  if (required.size > 0) normalized.required = [...required];
+  return normalized;
 }
 
 export function createAnthropicAdapter(provider: OcxProviderConfig, cacheRetention?: "none" | "short" | "long"): ProviderAdapter {

--- a/tests/anthropic-tool-schema.test.ts
+++ b/tests/anthropic-tool-schema.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { createAnthropicAdapter } from "../src/adapters/anthropic";
+import type { OcxParsedRequest, OcxProviderConfig } from "../src/types";
+
+const provider = { adapter: "anthropic", baseUrl: "https://api.anthropic.com", apiKey: "sk-x", authMode: "apiKey" } as unknown as OcxProviderConfig;
+
+function toolSchema(parameters: unknown): Record<string, unknown> {
+  const { body } = createAnthropicAdapter(provider).buildRequest({
+    modelId: "anthropic/claude-opus-4.1",
+    stream: false,
+    options: {},
+    context: {
+      messages: [{ role: "user", content: "use the tool", timestamp: 0 }],
+      tools: [{ name: "sample_tool", description: "Sample", parameters }],
+    },
+  } as unknown as OcxParsedRequest);
+  const parsed = JSON.parse(body as string) as { tools: Array<{ input_schema: Record<string, unknown> }> };
+  return parsed.tools[0].input_schema;
+}
+
+describe("anthropic tool input_schema normalization", () => {
+  test("missing root type becomes an object schema with properties", () => {
+    expect(toolSchema({ properties: { query: { type: "string" } }, required: ["query"] })).toEqual({
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+    });
+    expect(toolSchema({})).toEqual({ type: "object", properties: {} });
+  });
+
+  test("root oneOf and anyOf are flattened without promoting branch required fields", () => {
+    const anyOf = toolSchema({
+      anyOf: [
+        { type: "object", properties: { a: { type: "string" } }, required: ["a"] },
+        { type: "object", properties: { b: { type: "number" } }, required: ["b"] },
+      ],
+    });
+    expect(anyOf.anyOf).toBeUndefined();
+    expect(anyOf.oneOf).toBeUndefined();
+    expect(anyOf.allOf).toBeUndefined();
+    expect(anyOf).toEqual({
+      type: "object",
+      properties: { a: { type: "string" }, b: { type: "number" } },
+    });
+
+    const oneOf = toolSchema({
+      oneOf: [
+        { type: "object", properties: { path: { type: "string" } }, required: ["path"] },
+      ],
+    });
+    expect(oneOf).toEqual({
+      type: "object",
+      properties: { path: { type: "string" } },
+    });
+  });
+
+  test("root allOf merges required fields and preserves sibling schema metadata", () => {
+    expect(toolSchema({
+      title: "Search options",
+      additionalProperties: false,
+      properties: { existing: { type: "string" } },
+      required: ["existing"],
+      allOf: [
+        { type: "object", properties: { limit: { type: "number" } }, required: ["limit"] },
+        { type: "object", properties: { sort: { type: "string" } } },
+      ],
+    })).toEqual({
+      title: "Search options",
+      additionalProperties: false,
+      type: "object",
+      properties: {
+        existing: { type: "string" },
+        limit: { type: "number" },
+        sort: { type: "string" },
+      },
+      required: ["existing", "limit"],
+    });
+  });
+
+  test("nested composition under properties is preserved", () => {
+    expect(toolSchema({
+      properties: {
+        value: {
+          anyOf: [{ type: "string" }, { type: "number" }],
+        },
+      },
+    })).toEqual({
+      type: "object",
+      properties: {
+        value: {
+          anyOf: [{ type: "string" }, { type: "number" }],
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #75.

Anthropic tool conversion now normalizes tool `input_schema` before sending requests upstream. This prevents Claude/Anthropic 400s when Codex attaches tools whose parameter schema omits a root `type` or contains root-level `oneOf` / `anyOf` / `allOf`.

## Root Cause

`toolsToAnthropicFormat` passed `t.parameters` directly into Anthropic `input_schema`. Some Codex/MCP/sub-agent/browser tools can produce schemas that OpenAI-compatible wires tolerate but Anthropic rejects:

- missing top-level `type`
- root-level `oneOf`, `anyOf`, or `allOf`

## Changes

- Add Anthropic-only input schema normalization.
- Ensure root schemas are `type: "object"` and always include `properties`.
- Flatten root `oneOf` / `anyOf` / `allOf` while preserving nested property schemas.
- Merge `required` only for `allOf` to avoid over-constraining `oneOf` / `anyOf` schemas.
- Add focused regression tests for the reported cases.

## Validation

- `bun test tests/anthropic-tool-schema.test.ts tests/anthropic-empty-content.test.ts tests/kiro-adapter.test.ts` -> 38 pass
- `bun run typecheck` -> pass
- `bun test ./tests/` -> 1677 pass, 0 fail