### PR TITLE
fix(request-log): surface incomplete_details.reason as upstreamError

### DIFF
--- a/src/server/request-log.ts
+++ b/src/server/request-log.ts
@@ -261,7 +261,10 @@ function captureUpstreamError(logCtx: RequestLogContext, text: string | null): v
       type?: unknown;
       error?: { message?: unknown };
       last_error?: { message?: unknown };
-      response?: { error?: { type?: unknown; code?: unknown; message?: unknown } };
+      response?: {
+        error?: { type?: unknown; code?: unknown; message?: unknown };
+        incomplete_details?: { reason?: unknown };
+      };
     };
     captureTerminalHttpStatus(logCtx, json);
     const message = json?.error?.message
@@ -269,9 +272,30 @@ function captureUpstreamError(logCtx: RequestLogContext, text: string | null): v
       ?? json?.response?.error?.message;
     if (typeof message === "string" && message.trim()) {
       logCtx.upstreamError = redactSecretString(message).slice(0, 500);
+      return;
+    }
+    // No human-readable error message: fall back to the structured incomplete reason emitted by
+    // the bridge on a stall-timeout or adapter EOF (response.incomplete). Maps the raw reason to a
+    // reader-facing label so a generic 502 in /api/logs explains WHY the turn ended, not just the
+    // mapped HTTP code.
+    const reason = json?.response?.incomplete_details?.reason;
+    if (typeof reason === "string" && reason.trim()) {
+      logCtx.upstreamError = redactSecretString(incompleteReasonLabel(reason.trim())).slice(0, 500);
     }
   } catch {
     /* not JSON; nothing to capture */
+  }
+}
+
+/** Map a raw `incomplete_details.reason` (emitted by the bridge) to a reader-facing label. */
+function incompleteReasonLabel(reason: string): string {
+  switch (reason) {
+    case "upstream_stall_timeout":
+      return `Upstream stalled: no data for the stall-timeout window (${reason})`;
+    case "adapter_eof":
+      return `Upstream stream ended unexpectedly without a terminal event (${reason})`;
+    default:
+      return `Upstream incomplete: ${reason}`;
   }
 }
 

--- a/tests/request-log.test.ts
+++ b/tests/request-log.test.ts
@@ -332,4 +332,72 @@ describe("request log metadata", () => {
       usage: { inputTokens: 133_900, outputTokens: 0, estimated: true },
     });
   });
+
+  test("deferred SSE logging surfaces upstream_stall_timeout reason as upstreamError", async () => {
+    const entries: RequestLogEntry[] = [];
+    const incompletePayload = JSON.stringify({
+      type: "response.incomplete",
+      response: {
+        status: "incomplete",
+        incomplete_details: { reason: "upstream_stall_timeout" },
+      },
+    });
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(`data: ${incompletePayload}\n\n`));
+        controller.close();
+      },
+    });
+    const response = responseWithDeferredRequestLog(
+      new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } }),
+      "ocx-test-stall-timeout",
+      Date.now(),
+      { model: "cursor/kimi-k2.7-code", provider: "cursor" },
+      entry => entries.push(entry),
+    );
+
+    await response.text();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      terminalStatus: "incomplete",
+      status: 502,
+      errorCode: "upstream_server_error",
+    });
+    expect(entries[0].upstreamError).toContain("upstream_stall_timeout");
+    expect(entries[0].upstreamError).toContain("Upstream stalled");
+  });
+
+  test("deferred SSE logging surfaces adapter_eof reason as upstreamError", async () => {
+    const entries: RequestLogEntry[] = [];
+    const incompletePayload = JSON.stringify({
+      type: "response.incomplete",
+      response: {
+        status: "incomplete",
+        incomplete_details: { reason: "adapter_eof" },
+      },
+    });
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(`data: ${incompletePayload}\n\n`));
+        controller.close();
+      },
+    });
+    const response = responseWithDeferredRequestLog(
+      new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } }),
+      "ocx-test-adapter-eof",
+      Date.now(),
+      { model: "cursor/kimi-k2.7-code", provider: "cursor" },
+      entry => entries.push(entry),
+    );
+
+    await response.text();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      terminalStatus: "incomplete",
+      status: 502,
+      errorCode: "upstream_server_error",
+    });
+    expect(entries[0].upstreamError).toContain("adapter_eof");
+    expect(entries[0].upstreamError).toContain("ended unexpectedly");
+  });
 });


### PR DESCRIPTION
## What

response.incomplete SSE payloads (stall-timeout, adapter EOF) previously left upstreamError empty in /api/logs, making 502s opaque — the GUI showed "Bad upstream response" with no hint whether it was a stall timeout, adapter EOF, or a real server error.

Now captureUpstreamError in request-log.ts falls back to incomplete_details.reason when no error.message is present, mapping upstream_stall_timeout and adapter_eof to human-readable labels.

## Changes

- src/server/request-log.ts: extended the captureUpstreamError type annotation to include incomplete_details, added an early return after the existing error.message capture, and added a fallback that reads incomplete_details.reason when no message is found. A private incompleteReasonLabel helper maps raw reason strings to reader-facing labels.
- tests/request-log.test.ts: two new tests that simulate response.incomplete SSE payloads with upstream_stall_timeout and adapter_eof reasons and assert the resulting upstreamError contains the expected substrings.

## Verification

- bun test tests/request-log.test.ts: 16 pass, 0 fail (14 existing + 2 new)
- git diff --check: no whitespace errors
- Diff: 2 files, +93/-1
