### PR TITLE
fix(server): relay /v1/images to an OpenAI upstream for built-in image_gen

### DIFF
--- a/devlog/260710_issue83_images_endpoint/000_plan.md
+++ b/devlog/260710_issue83_images_endpoint/000_plan.md
@@ -1,0 +1,85 @@
+# 260710 — /v1/images relay for codex's built-in image_gen (issue #83)
+
+## Problem
+
+GitHub issue #83: the built-in `image_gen` tool fails instantly with
+`http 404 Not Found: {"error":{"message":"Unknown endpoint: POST /v1/images/generations",...}}`.
+
+The 404 is ours: codex-rs's standalone image-generation extension executes CLIENT-SIDE —
+it POSTs `{base_url}/images/generations` (edits variant: `/images/edits`) with the same
+ChatGPT bearer auth it uses for chat (`ext/image-generation`, request body
+`{prompt, background, model:"gpt-image-2", quality, size}`, expected response
+`{created, data:[{b64_json}]}`, both strict serde). Under Design B injection `base_url`
+IS the proxy, and the request died on the `/v1/*` JSON-404 guard (previously even
+test-pinned as an intentional 404 in server-auth.test.ts).
+
+Why now: codex 0.144.0 graduated `image_generation` from the disabled-by-default
+`imagegenext` experiment to Stage::Stable / default-enabled, so ChatGPT-signed-in users
+started hitting the tool organically. The hosted `image_generation` tools[] entry on
+`/v1/responses` was never affected (passthrough already forwards it); only the
+extension's direct REST call 404'd.
+
+## Fix
+
+New relay route `POST /v1/images/{generations,edits}` (src/server/images.ts), inserted
+before the /v1/* guard with the standard data-plane preamble (drain 503, requireApiAuth,
+origin check, withCors, request log with `client_cancel` meta on 499).
+
+Upstream selection (`findImagesUpstreams` collects BOTH candidates; selection is
+per-request):
+
+1. **ChatGPT forward provider** — preferred, same precedence as the vision/web-search
+   sidecars; it is the backend codex itself would have called absent the base_url
+   override, so request/response bodies relay verbatim (no mapping). Auth via
+   `resolveCodexAuthContext`/`headersForCodexAuthContext`: forwarded caller bearer, or
+   the routed multi-account pool token. Guards:
+   - `startServer` auto-upserts a `chatgpt` forward entry into every config, so the
+     forward candidate is only used when the resolved headers actually carry an
+     authorization value — otherwise an unauthenticated request would bounce off
+     chatgpt.com as an opaque `{"detail":"Unauthorized"}`.
+   - A bearer equal to the proxy's own admission secret (non-loopback binds accept
+     `Authorization: Bearer <OPENCODEX_API_AUTH_TOKEN>`) is stripped before selection —
+     the proxy secret must never be relayed to chatgpt.com
+     (`isProxyAdmissionSecret`, extracted from `hasValidApiAuth`).
+   - Forward-auth FAILURES (pool cooldown 429, reauth 401, affinity 409) are captured,
+     not returned: a configured keyed provider still serves the request, and the
+     captured error only surfaces when no keyed candidate exists. Without this, "all
+     pool accounts cooling down" would 429 image_gen while api.openai.com sat idle.
+   - Pool upstream outcomes are recorded via `sidecarOutcomeRecorder` (status /
+     timeout / connect_error), keeping rotation failover signals alive.
+2. **Keyed openai-responses provider** (e.g. api.openai.com) — fallback when no
+   relayable ChatGPT auth; its `/v1/images/*` is the real platform Images API. URL is
+   normalized like the adapter (`baseUrl.replace(/\/v1\/?$/,"")` + `/v1/images/…`), so
+   baseUrl with or without `/v1` both work; forward URLs stay bare
+   (`${baseUrl}/images/…`, the ChatGPT-backend convention).
+3. **Neither** — honest 400 (`invalid_request_error`) naming the fix
+   (`codex features disable image_generation` or add an OpenAI provider). 400, not 5xx:
+   codex retries every 5xx up to 5 total attempts and this is a permanent config state.
+
+Relay details: `readJsonRequestBody` (zstd/gzip decode + 256MB cap) → JSON re-serialize →
+`fetchWithResetRetry` (stale keep-alive resets) with a `config.images.timeoutMs`
+(default 300s) timeout linked to the client abort; response buffered (single JSON
+document, few MB) and passed through status+content-type+body verbatim so upstream
+plan-gating errors stay legible. Client cancel returns 499 (`client_closed_request`),
+never a fake 502; genuine timeout returns 504 (retriable by codex, acceptable for a
+transient hang).
+
+Deliberately NOT done:
+
+- No auto-injection of `[features] image_generation = false` — it would remove a
+  capability the relay makes work, and openai/codex#21952 suggests app-server ignores
+  the flag anyway. Documented as a user opt-out instead (docs-site codex-integration,
+  en/ko/zh-cn).
+- No image generation via routed providers (Gemini image models etc.) — the adapter
+  event pipeline has no image-output event; separate feature, not this bug fix.
+
+## Tests
+
+tests/server-images.test.ts (16): forward relay (auth + path + body), edits path,
+pool-token override (caller bearer must not leak), zstd body decode, keyed fallback +
+`/v1` URL normalization (with and without suffix), unauthenticated-request gate (keyed
+fallback / 401), forward-auth-failure fallback (keyed / surfaced 401), no-upstream 400,
+upstream error passthrough, 504 timeout via `config.images.timeoutMs`, GET falls to 404
+guard, non-loopback auth/origin, admission-secret never relayed.
+server-auth.test.ts's 404-guard list swaps `/v1/images/generations` for
+`/v1/realtime/sessions`.

--- a/docs-site/src/content/docs/guides/codex-integration.md
+++ b/docs-site/src/content/docs/guides/codex-integration.md
@@ -23,7 +23,24 @@ fast_mode = true
 ```
 
 The proxy listens on port `10100` by default and serves `POST /v1/responses`,
-`POST /v1/responses/compact`, `GET /v1/models`, `GET /healthz`, and the `/api/*` management surface.
+`POST /v1/responses/compact`, `POST /v1/images/generations`, `POST /v1/images/edits`,
+`GET /v1/models`, `GET /healthz`, and the `/api/*` management surface.
+
+### Built-in image generation (`image_gen`)
+
+Codex's built-in `image_gen` tool does not go through `/v1/responses` — the codex-rs extension
+POSTs `{base_url}/images/generations` (or `/images/edits` when reference images are attached)
+directly, with the same ChatGPT bearer auth it uses for chat. Because the injected `base_url`
+points at opencodex, the proxy relays those calls to the OpenAI upstream:
+
+- **ChatGPT login (default):** the request is forwarded to `chatgpt.com/backend-api/codex` with
+  the caller's OAuth token (or the routed multi-account pool token). No API key is needed.
+- **OpenAI API-key provider:** if no ChatGPT auth is available on the request, the relay falls
+  back to a configured `openai-responses` API-key provider (e.g. `api.openai.com`).
+- **Neither:** the proxy returns a clear error instead of a generic 404. Routed providers
+  (Cursor, Gemini, Kiro, …) cannot serve image generation; if you don't want the tool offered at
+  all, disable it in Codex with `codex features disable image_generation`
+  (`[features] image_generation = false` in `config.toml`).
 
 For a non-loopback `hostname`, Codex must send the generated API auth header. The injector therefore
 uses a dedicated provider instead:

--- a/docs-site/src/content/docs/ko/guides/codex-integration.md
+++ b/docs-site/src/content/docs/ko/guides/codex-integration.md
@@ -22,7 +22,24 @@ fast_mode = true
 ```
 
 프록시의 기본 포트는 `10100`입니다. `POST /v1/responses`, `POST /v1/responses/compact`,
-`GET /v1/models`, `GET /healthz`, `/api/*` 관리 API를 제공합니다.
+`POST /v1/images/generations`, `POST /v1/images/edits`, `GET /v1/models`, `GET /healthz`,
+`/api/*` 관리 API를 제공합니다.
+
+### 내장 이미지 생성 (`image_gen`)
+
+Codex의 내장 `image_gen` 도구는 `/v1/responses`를 거치지 않습니다. codex-rs 확장이
+`{base_url}/images/generations`(참조 이미지가 있으면 `/images/edits`)를 채팅과 동일한
+ChatGPT bearer 인증으로 직접 POST합니다. 주입된 `base_url`이 opencodex를 가리키므로,
+프록시가 이 호출을 OpenAI 업스트림으로 중계합니다.
+
+- **ChatGPT 로그인(기본):** 호출자의 OAuth 토큰(또는 멀티 계정 풀에서 선택된 계정의 토큰)으로
+  `chatgpt.com/backend-api/codex`에 전달합니다. API 키가 필요 없습니다.
+- **OpenAI API 키 프로바이더:** 요청에 사용할 ChatGPT 인증이 없으면, 설정된 `openai-responses`
+  API 키 프로바이더(예: `api.openai.com`)로 대신 전달합니다.
+- **둘 다 없음:** 모호한 404 대신 명확한 오류를 반환합니다. 라우팅되는 다른 프로바이더(Cursor,
+  Gemini, Kiro 등)는 이미지 생성을 제공할 수 없습니다. 도구 자체를 끄고 싶다면 Codex에서
+  `codex features disable image_generation`(`config.toml`의 `[features] image_generation = false`)을
+  사용하세요.
 
 `hostname`이 loopback 주소가 아니면 Codex가 자동 생성된 API 인증 헤더를 보내야 합니다. 이때는 전용
 프로바이더를 주입합니다.

--- a/docs-site/src/content/docs/ko/reference/architecture.md
+++ b/docs-site/src/content/docs/ko/reference/architecture.md
@@ -40,7 +40,9 @@ HTTP 경계는 `server/index.ts`가 맡고, Responses 데이터 플레인은 `se
 
 1. `server/index.ts`에서 CORS와 API 인증을 확인하고, 종료 대기 중이면 새 요청을 거부한 뒤 요청 수명
    주기를 기록합니다. 여기서 `GET /v1/models`, `POST /v1/responses`,
-   `POST /v1/responses/compact`, `/v1/responses`의 선택적 WebSocket 업그레이드를 제공합니다.
+   `POST /v1/responses/compact`, `POST /v1/images/generations` / `POST /v1/images/edits`
+   (Codex 내장 `image_gen` 도구용 — `server/images.ts`가 OpenAI 계열 업스트림으로 중계),
+   `/v1/responses`의 선택적 WebSocket 업그레이드를 제공합니다.
 2. `server/responses.ts`가 압축을 풀고 JSON을 읽습니다. 기억해 둔 `previous_response_id` 입력이 있으면
    펼친 다음 `responses/parser.ts`로 넘깁니다.
 3. `router.ts`가 일반 모델 id 또는 `provider/model` id를 해석합니다. 이어서 Codex 계정 affinity를

--- a/docs-site/src/content/docs/reference/architecture.md
+++ b/docs-site/src/content/docs/reference/architecture.md
@@ -41,7 +41,9 @@ src/
 
 1. `server/index.ts` applies CORS and API authentication, rejects new work while draining, and
    records request lifecycle metadata. It serves `GET /v1/models`, `POST /v1/responses`,
-   `POST /v1/responses/compact`, and the optional WebSocket upgrade on `/v1/responses`.
+   `POST /v1/responses/compact`, `POST /v1/images/generations` / `POST /v1/images/edits`
+   (relayed to an OpenAI-family upstream by `server/images.ts` for codex's built-in `image_gen`
+   tool), and the optional WebSocket upgrade on `/v1/responses`.
 2. `server/responses.ts` decompresses and parses JSON, expands locally remembered
    `previous_response_id` input when available, then calls `responses/parser.ts`.
 3. `router.ts` resolves a bare or `provider/model` id. The server then resolves Codex account

--- a/docs-site/src/content/docs/zh-cn/guides/codex-integration.md
+++ b/docs-site/src/content/docs/zh-cn/guides/codex-integration.md
@@ -21,7 +21,24 @@ fast_mode = true
 ```
 
 proxy 的默认端口为 `10100`，提供 `POST /v1/responses`、`POST /v1/responses/compact`、
-`GET /v1/models`、`GET /healthz` 以及 `/api/*` 管理 API。
+`POST /v1/images/generations`、`POST /v1/images/edits`、`GET /v1/models`、`GET /healthz`
+以及 `/api/*` 管理 API。
+
+### 内置图像生成（`image_gen`）
+
+Codex 的内置 `image_gen` 工具不经过 `/v1/responses`——codex-rs 扩展直接 POST
+`{base_url}/images/generations`（附带参考图像时为 `/images/edits`），使用与聊天相同的
+ChatGPT bearer 认证。由于注入的 `base_url` 指向 opencodex，proxy 会把这些调用中继到
+OpenAI 上游：
+
+- **ChatGPT 登录（默认）：** 请求会携带调用方的 OAuth token（或多账户池选中账户的 token）
+  转发到 `chatgpt.com/backend-api/codex`，无需 API key。
+- **OpenAI API key 提供商：** 如果请求中没有可用的 ChatGPT 认证，中继会退回到已配置的
+  `openai-responses` API key 提供商（例如 `api.openai.com`）。
+- **两者都没有：** proxy 返回明确的错误而不是含糊的 404。其他路由提供商（Cursor、Gemini、
+  Kiro 等）无法提供图像生成；如果想完全关闭该工具，可在 Codex 中执行
+  `codex features disable image_generation`（即 `config.toml` 的
+  `[features] image_generation = false`）。
 
 如果 `hostname` 不是 loopback 地址，Codex 必须发送自动生成的 API 认证请求头。此时注入器会改用
 专用提供商：

--- a/docs-site/src/content/docs/zh-cn/reference/architecture.md
+++ b/docs-site/src/content/docs/zh-cn/reference/architecture.md
@@ -40,7 +40,9 @@ src/
 
 1. `server/index.ts` 应用 CORS 和 API 认证，在 drain 期间拒绝新请求，并记录请求生命周期
    metadata。它提供 `GET /v1/models`、`POST /v1/responses`、
-   `POST /v1/responses/compact`，以及 `/v1/responses` 上可选的 WebSocket upgrade。
+   `POST /v1/responses/compact`、`POST /v1/images/generations` / `POST /v1/images/edits`
+   （供 Codex 内置 `image_gen` 工具使用——由 `server/images.ts` 中继到 OpenAI 系上游），
+   以及 `/v1/responses` 上可选的 WebSocket upgrade。
 2. `server/responses.ts` 解压并解析 JSON；如果本地记住了对应输入，则展开
    `previous_response_id`，随后调用 `responses/parser.ts`。
 3. `router.ts` 解析 bare id 或 `provider/model` id。server 随后确定 Codex account affinity，

--- a/src/server/auth-cors.ts
+++ b/src/server/auth-cors.ts
@@ -117,29 +117,32 @@ export function assertServerAuthConfig(config: OcxConfig): void {
   }
 }
 
+/** Whether `token` is one of the proxy's own admission secrets (env token or config API keys). */
+export function isProxyAdmissionSecret(token: string, config: OcxConfig): boolean {
+  const actual = token.trim();
+  if (!actual) return false;
+  const enc = new TextEncoder();
+  const actualBytes = enc.encode(actual);
+  // Check env-based token
+  const expected = configuredApiAuthToken(config);
+  if (expected) {
+    const expectedBytes = enc.encode(expected);
+    if (expectedBytes.length === actualBytes.length && timingSafeEqual(actualBytes, expectedBytes)) return true;
+  }
+  // Check config-based API keys
+  for (const k of config.apiKeys ?? []) {
+    const keyBytes = enc.encode(k.key);
+    if (keyBytes.length === actualBytes.length && timingSafeEqual(actualBytes, keyBytes)) return true;
+  }
+  return false;
+}
+
 export function hasValidApiAuth(req: Request, config: OcxConfig): boolean {
   if (!isApiAuthRequired(config)) return true;
   const actual = req.headers.get("x-opencodex-api-key")?.trim()
     || req.headers.get("authorization")?.replace(/^Bearer\s+/i, "").trim();
   if (!actual) return false;
-  // Check env-based token
-  const expected = configuredApiAuthToken(config);
-  if (expected) {
-    const enc = new TextEncoder();
-    const expectedBytes = enc.encode(expected);
-    const actualBytes = enc.encode(actual);
-    if (expectedBytes.length === actualBytes.length && timingSafeEqual(actualBytes, expectedBytes)) return true;
-  }
-  // Check config-based API keys
-  if (config.apiKeys?.length) {
-    const enc = new TextEncoder();
-    const actualBytes = enc.encode(actual);
-    for (const k of config.apiKeys) {
-      const keyBytes = enc.encode(k.key);
-      if (keyBytes.length === actualBytes.length && timingSafeEqual(actualBytes, keyBytes)) return true;
-    }
-  }
-  return false;
+  return isProxyAdmissionSecret(actual, config);
 }
 
 export function requireApiAuth(req: Request, config: OcxConfig, kind: "management" | "data-plane"): Response | null {

--- a/src/server/images.ts
+++ b/src/server/images.ts
@@ -1,0 +1,209 @@
+/**
+ * /v1/images/{generations,edits} relay (issue #83).
+ *
+ * codex-rs's standalone image_gen extension executes CLIENT-SIDE: it POSTs
+ * `{base_url}/images/generations` (edits when reference images are attached) with the same
+ * ChatGPT bearer auth it uses for chat. Under Design B injection base_url IS this proxy, so
+ * without a route the tool died on the /v1/* JSON-404 guard. Only an OpenAI-family upstream
+ * can serve these endpoints — routed providers (Cursor, Kiro, Gemini, …) have no image
+ * generation surface — so the handler relays the body verbatim to the ChatGPT forward
+ * provider (or an OpenAI API-key provider) and passes the response through untouched:
+ * codex's images client parses `{created, data:[{b64_json}]}` strictly and Debug-prints
+ * error bodies into the model-visible failure, so upstream errors must stay legible.
+ */
+import { formatErrorResponse } from "../bridge";
+import {
+  CodexAccountCooldownError,
+  CodexAuthContextError,
+  CodexThreadAffinityExpiredError,
+  headersForCodexAuthContext,
+  isCodexAuthContextUsable,
+  resolveCodexAuthContext,
+} from "../codex/auth-context";
+import { formatCodexProviderForLog } from "../codex/routing";
+import { resolveEnvValue } from "../config";
+import { signalWithTimeout } from "../lib/abort";
+import { sidecarEnter } from "../lib/sidecar-tracker";
+import { fetchWithResetRetry } from "../lib/upstream-retry";
+import type { OcxConfig, OcxProviderConfig } from "../types";
+import { isProxyAdmissionSecret } from "./auth-cors";
+import { readJsonRequestBody } from "./request-decompress";
+import type { RequestLogContext } from "./request-log";
+import { codexLogAccountId, decodeRequestErrorResponse, sidecarOutcomeRecorder } from "./responses";
+
+export type ImagesEndpoint = "generations" | "edits";
+
+/** Image generation is slow (tens of seconds); bound a hung upstream, not a working one. */
+const IMAGES_UPSTREAM_TIMEOUT_MS = 300_000;
+
+interface NamedProvider {
+  name: string;
+  provider: OcxProviderConfig;
+}
+
+interface ImagesUpstreamCandidates {
+  /** ChatGPT passthrough — the backend codex itself would have called absent the base_url override. */
+  forward?: NamedProvider;
+  /** Keyed openai-responses provider (e.g. api.openai.com), whose /v1/images/* is the platform Images API. */
+  keyed?: NamedProvider & { apiKey: string };
+}
+
+/**
+ * Collect the upstreams that can serve /images/*. The forward provider is preferred (same
+ * precedence as the vision/web-search sidecars) but only usable when the request actually
+ * carries relayable ChatGPT auth — startServer auto-upserts a `chatgpt` forward entry into
+ * every config, so its mere presence proves nothing about credentials.
+ */
+function findImagesUpstreams(config: OcxConfig): ImagesUpstreamCandidates {
+  const candidates: ImagesUpstreamCandidates = {};
+  for (const [name, provider] of Object.entries(config.providers)) {
+    if (provider.disabled === true) continue;
+    if (provider.authMode === "forward") {
+      candidates.forward ??= { name, provider };
+      continue;
+    }
+    if (candidates.keyed || provider.adapter !== "openai-responses" || provider.authMode === "oauth") continue;
+    const apiKey = resolveEnvValue(provider.apiKey);
+    if (apiKey) candidates.keyed = { name, provider, apiKey };
+  }
+  return candidates;
+}
+
+export async function handleImages(
+  req: Request,
+  config: OcxConfig,
+  endpoint: ImagesEndpoint,
+  logCtx: RequestLogContext,
+): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await readJsonRequestBody(req);
+  } catch (err) {
+    return decodeRequestErrorResponse(err, "images");
+  }
+  const model = (body as { model?: unknown } | null)?.model;
+  if (typeof model === "string" && model) logCtx.model = model;
+
+  const candidates = findImagesUpstreams(config);
+  if (!candidates.forward && !candidates.keyed) {
+    // 400, not 5xx: codex retries every 5xx up to 5 total attempts, and this is a permanent
+    // configuration state that must surface on the first attempt.
+    return formatErrorResponse(
+      400,
+      "invalid_request_error",
+      "Built-in image generation needs an OpenAI upstream (ChatGPT login or an OpenAI API-key provider), "
+      + "but none is configured in opencodex. Routed providers cannot serve /v1/images/* — "
+      + "add an OpenAI provider or disable the tool with `codex features disable image_generation`.",
+    );
+  }
+
+  // Resolve forward auth first; failures are captured, not returned, so a configured keyed
+  // provider can still serve the request (e.g. every pool account cooling down must not
+  // 429 image_gen while api.openai.com sits idle).
+  let forwardAuthHeaders: Headers | undefined;
+  let forwardAuthError: Response | undefined;
+  let recordOutcome: ReturnType<typeof sidecarOutcomeRecorder>;
+  if (candidates.forward) {
+    try {
+      const authCtx = await resolveCodexAuthContext(req.headers, config);
+      if (!isCodexAuthContextUsable(authCtx, config)) {
+        forwardAuthError = formatErrorResponse(401, "authentication_error", "Selected Codex account needs reauthentication");
+      } else {
+        // Forwarded caller auth, overridden by the routed pool account's token when one is selected.
+        const authHeaders = headersForCodexAuthContext(req.headers, authCtx);
+        const bearer = authHeaders.get("authorization")?.replace(/^Bearer\s+/i, "") ?? "";
+        // A caller may authenticate to the proxy itself with `Authorization: Bearer <admission
+        // token>` (non-loopback binds); that secret must never be relayed to chatgpt.com.
+        if (bearer && isProxyAdmissionSecret(bearer, config)) authHeaders.delete("authorization");
+        // Only relay through the ChatGPT backend when there is a bearer to relay: startServer
+        // auto-upserts the `chatgpt` provider, so an unauthenticated request must not be bounced
+        // off chatgpt.com when a keyed OpenAI provider (or an honest error) serves it better.
+        if (authHeaders.get("authorization")) {
+          forwardAuthHeaders = authHeaders;
+          recordOutcome = sidecarOutcomeRecorder(config, authCtx);
+          logCtx.provider = formatCodexProviderForLog(candidates.forward.name, codexLogAccountId(authCtx), config);
+        }
+      }
+    } catch (err) {
+      if (err instanceof CodexAccountCooldownError) {
+        forwardAuthError = formatErrorResponse(429, "rate_limit_error", "Selected Codex account is cooling down");
+      } else if (err instanceof CodexThreadAffinityExpiredError) {
+        forwardAuthError = formatErrorResponse(409, "invalid_request_error", "Codex thread account affinity expired; start a new session");
+      } else if (err instanceof CodexAuthContextError) {
+        const safeAccountLabel = formatCodexProviderForLog(candidates.forward.name, err.accountId, config);
+        console.error(`[images] Pool account ${safeAccountLabel} token failed; reauthentication required`);
+        forwardAuthError = formatErrorResponse(401, "authentication_error", "Selected Codex account needs reauthentication");
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  let url: string;
+  if (forwardAuthHeaders && candidates.forward) {
+    const { provider } = candidates.forward;
+    if (provider.headers) Object.assign(headers, provider.headers);
+    for (const [name, value] of forwardAuthHeaders) headers[name] = value;
+    // The ChatGPT codex backend takes bare paths (matches the adapter's `${baseUrl}/responses`).
+    url = `${provider.baseUrl}/images/${endpoint}`;
+  } else if (candidates.keyed) {
+    const { provider, apiKey, name } = candidates.keyed;
+    if (provider.headers) Object.assign(headers, provider.headers);
+    headers["authorization"] = `Bearer ${apiKey}`;
+    logCtx.provider = name;
+    // Keyed providers tolerate baseUrl with or without /v1 (mirrors openai-responses.ts).
+    url = `${provider.baseUrl.replace(/\/v1\/?$/, "")}/v1/images/${endpoint}`;
+  } else if (forwardAuthError) {
+    return forwardAuthError;
+  } else {
+    return formatErrorResponse(
+      401,
+      "authentication_error",
+      "image generation relay needs ChatGPT auth (Authorization header) or an OpenAI API-key provider",
+    );
+  }
+
+  const timeoutMs = config.images?.timeoutMs ?? IMAGES_UPSTREAM_TIMEOUT_MS;
+  const linkedSignal = signalWithTimeout(timeoutMs, req.signal);
+  const sidecarExit = sidecarEnter("images");
+  try {
+    const upstreamResponse = await fetchWithResetRetry(
+      () => fetch(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+        signal: linkedSignal.signal,
+      }),
+      { abortSignal: linkedSignal.signal, label: "images-relay" },
+    );
+    // Buffer rather than stream: the payload is one JSON document (base64 image, a few MB),
+    // and buffering keeps the timeout window covering the whole exchange.
+    const payload = await upstreamResponse.arrayBuffer();
+    recordOutcome?.(upstreamResponse.status);
+    const relayHeaders: Record<string, string> = {};
+    const contentType = upstreamResponse.headers.get("content-type");
+    if (contentType) relayHeaders["content-type"] = contentType;
+    return new Response(payload, { status: upstreamResponse.status, headers: relayHeaders });
+  } catch (err) {
+    // Client cancel first: it aborts the linked signal too, and must not be logged as an
+    // upstream failure (499 maps to client_closed_request in the request log).
+    if (req.signal.aborted) {
+      return formatErrorResponse(499, "client_closed_request", `image ${endpoint} request canceled by client`);
+    }
+    if (err instanceof Error && err.name === "TimeoutError") {
+      recordOutcome?.("timeout");
+      // codex retries 5xx up to 4 more times; a retried 504 is acceptable for a transient hang.
+      return formatErrorResponse(504, "upstream_error", `image ${endpoint} upstream timed out`);
+    }
+    recordOutcome?.("connect_error");
+    return formatErrorResponse(
+      502,
+      "upstream_error",
+      `image ${endpoint} relay failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  } finally {
+    sidecarExit();
+    linkedSignal.cleanup();
+  }
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -115,6 +115,7 @@ export {
   safeConfigDTO,
 } from "./auth-cors";
 import { disableResponsesRequestTimeout, handleResponses, handleResponsesCompact } from "./responses";
+import { handleImages } from "./images";
 export { disableResponsesRequestTimeout, linkAbortSignal } from "./responses";
 import { fetchAllModels, handleManagementAPI, VERSION } from "./management-api";
 
@@ -341,9 +342,31 @@ export function startServer(port?: number) {
         return withCors(responseWithDeferredRequestLog(response, requestId, start, logCtx), req, config);
       }
 
+      // codex-rs's standalone image_gen extension POSTs {base_url}/images/{generations,edits}
+      // client-side with its ChatGPT bearer auth (issue #83); under Design B injection base_url
+      // is this proxy. Relay to the OpenAI-family upstream — the only backend that can serve it.
+      if ((url.pathname === "/v1/images/generations" || url.pathname === "/v1/images/edits") && req.method === "POST") {
+        disableResponsesRequestTimeout(req, requestServer);
+        if (isDraining()) {
+          return new Response("Service shutting down", { status: 503, headers: { ...corsHeaders(req, config), "Retry-After": "5" } });
+        }
+        const apiAuthError = requireApiAuth(req, config, "data-plane");
+        if (apiAuthError) return withCors(apiAuthError, req, config);
+        if (!isAllowedRequestOrigin(req, config)) {
+          return withCors(formatErrorResponse(403, "origin_rejected", "cross-origin data-plane request blocked"), req, config);
+        }
+        const start = Date.now();
+        const requestId = nextRequestLogId(start);
+        const logCtx: RequestLogContext = { model: "image_gen", provider: "unknown" };
+        const endpoint = url.pathname.endsWith("/edits") ? "edits" as const : "generations" as const;
+        const response = await handleImages(req, config, endpoint, logCtx);
+        addFinalRequestLog(requestId, start, logCtx, response.status, response.status === 499 ? { closeReason: "client_cancel" } : undefined);
+        return withCors(response, req, config);
+      }
+
       // Data-plane guard: unknown /v1/* paths must fail with JSON 404, never fall through to the
       // GUI static handler (extensionless paths would get index.html with HTTP 200 and codex-rs
-      // endpoint clients — alpha/search, images/*, memories/*, realtime/* — would surface confusing
+      // endpoint clients — alpha/search, memories/*, realtime/* — would surface confusing
       // serde decode errors instead of a clean not-found).
       if (url.pathname.startsWith("/v1/")) {
         return withCors(formatErrorResponse(404, "not_found", `Unknown endpoint: ${req.method} ${url.pathname}`), req, config);

--- a/src/server/responses.ts
+++ b/src/server/responses.ts
@@ -374,7 +374,7 @@ export function codexForwardTerminalOutcomeRecorder(
  * zstd-compressed screenshot history exceeds the limit), or a genuine JSON syntax error (400). The
  * real decode error was previously swallowed, so log it before returning the generic 400.
  */
-function decodeRequestErrorResponse(err: unknown, label: string): Response {
+export function decodeRequestErrorResponse(err: unknown, label: string): Response {
   if (err instanceof UnsupportedContentEncodingError) {
     return formatErrorResponse(415, "invalid_request_error", err.message);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -312,6 +312,8 @@ export interface OcxConfig {
   webSearchSidecar?: OcxWebSearchSidecarConfig;
   /** Vision sidecar: describe images via a gpt vision model so text-only models can "see" them. */
   visionSidecar?: OcxVisionSidecarConfig;
+  /** /v1/images relay for codex's built-in image_gen tool. */
+  images?: OcxImagesConfig;
   /** Codex multi-account pool. */
   codexAccounts?: CodexAccount[];
   /** Active pool account id for next session. undefined = main (passthrough as-is). */
@@ -355,6 +357,11 @@ export interface OcxTokenGuardianConfig {
   codexWarmupMaxAgeSeconds?: number;
   /** Model used for optional Codex pool warmup. Default gpt-5.4-mini. */
   codexWarmupModel?: string;
+}
+
+export interface OcxImagesConfig {
+  /** Upstream timeout (ms) for one /v1/images relay. Default 300000 — generation is slow. */
+  timeoutMs?: number;
 }
 
 export interface OcxVisionSidecarConfig {

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -1026,9 +1026,10 @@ describe("server local API auth", () => {
 
     const server = startServer(0);
     try {
-      // codex-rs endpoint clients (alpha/search, images/*, memories/*) must get a clean 404
+      // codex-rs endpoint clients (alpha/search, memories/*, realtime/*) must get a clean 404
       // instead of a 200 HTML page that fails serde with a confusing decode error.
-      for (const path of ["/v1/alpha/search", "/v1/images/generations", "/v1/memories/trace_summarize"]) {
+      // (/v1/images/* is a real relay route now — covered in server-images.test.ts.)
+      for (const path of ["/v1/alpha/search", "/v1/realtime/sessions", "/v1/memories/trace_summarize"]) {
         const response = await fetch(new URL(path, server.url), { method: "POST" });
         expect(response.status).toBe(404);
         expect(response.headers.get("content-type")).toContain("application/json");

--- a/tests/server-images.test.ts
+++ b/tests/server-images.test.ts
@@ -1,0 +1,552 @@
+/**
+ * /v1/images/{generations,edits} relay (issue #83): codex-rs's image_gen extension POSTs these
+ * paths against the injected base_url, so the proxy must relay them to an OpenAI-family upstream
+ * instead of the /v1/* JSON-404 guard.
+ */
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { saveCodexAccountCredential } from "../src/codex/account-store";
+import { clearAccountNeedsReauth, clearAccountQuota } from "../src/codex/auth-api";
+import { clearCodexUpstreamHealth, clearThreadAccountMap } from "../src/codex/routing";
+import { saveConfig } from "../src/config";
+import { startServer } from "../src/server";
+import type { OcxConfig } from "../src/types";
+import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+
+const previousApiToken = process.env.OPENCODEX_API_AUTH_TOKEN;
+const previousOpencodexHome = process.env.OPENCODEX_HOME;
+const TEST_DIR = join(import.meta.dir, ".tmp-server-images-test");
+let isolatedCodexHome: IsolatedCodexHome | null = null;
+
+beforeEach(() => {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  mkdirSync(TEST_DIR, { recursive: true });
+  process.env.OPENCODEX_HOME = TEST_DIR;
+  delete process.env.OPENCODEX_API_AUTH_TOKEN;
+  isolatedCodexHome = installIsolatedCodexHome("ocx-server-images-codex-");
+  clearCodexUpstreamHealth();
+  clearThreadAccountMap();
+  clearAccountNeedsReauth("pool-a");
+  clearAccountQuota();
+});
+
+afterEach(() => {
+  if (previousApiToken === undefined) delete process.env.OPENCODEX_API_AUTH_TOKEN;
+  else process.env.OPENCODEX_API_AUTH_TOKEN = previousApiToken;
+  if (previousOpencodexHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = previousOpencodexHome;
+  isolatedCodexHome?.restore();
+  isolatedCodexHome = null;
+  clearCodexUpstreamHealth();
+  clearThreadAccountMap();
+  clearAccountNeedsReauth("pool-a");
+  clearAccountQuota();
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+});
+
+interface CapturedRequest {
+  path: string;
+  headers: Headers;
+  body: unknown;
+}
+
+function fakeImagesUpstream(captured: CapturedRequest[], status = 200, payload?: unknown) {
+  return Bun.serve({
+    port: 0,
+    async fetch(req) {
+      captured.push({
+        path: new URL(req.url).pathname,
+        headers: req.headers,
+        body: await req.json(),
+      });
+      return Response.json(
+        payload ?? { created: 1_767_000_000, data: [{ b64_json: "aGVsbG8=" }] },
+        { status },
+      );
+    },
+  });
+}
+
+// Named "chatgpt" so startServer's auto-upsert of the real ChatGPT provider does not add a
+// second forward candidate pointing at the live chatgpt.com backend.
+function forwardConfig(baseUrl: string): OcxConfig {
+  return {
+    port: 0,
+    defaultProvider: "chatgpt",
+    providers: {
+      chatgpt: { adapter: "openai-responses", baseUrl, authMode: "forward" },
+    },
+  } as OcxConfig;
+}
+
+/** Keeps startServer from upserting a live chatgpt.com forward provider into the test config. */
+const disabledChatgptProvider = {
+  adapter: "openai-responses",
+  baseUrl: "https://chatgpt.example/backend-api/codex",
+  authMode: "forward",
+  disabled: true,
+} as const;
+
+/** An ENABLED forward provider whose relay would fail loudly if it were (wrongly) used. */
+const unreachableChatgptProvider = {
+  adapter: "openai-responses",
+  baseUrl: "http://127.0.0.1:1/backend-api/codex",
+  authMode: "forward",
+} as const;
+
+function keyedProvider(baseUrl: string) {
+  return { adapter: "openai-responses", baseUrl, apiKey: "sk-platform-key" };
+}
+
+test("POST /v1/images/generations relays to the ChatGPT forward provider with forwarded auth", async () => {
+  const captured: CapturedRequest[] = [];
+  const upstream = fakeImagesUpstream(captured);
+  saveConfig(forwardConfig(upstream.url.toString().replace(/\/$/, "")));
+
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/images/generations", server.url), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer chatgpt-user-token",
+        "chatgpt-account-id": "acct-123",
+      },
+      body: JSON.stringify({ prompt: "a halftone gothic hero", model: "gpt-image-2", size: "auto" }),
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ created: 1_767_000_000, data: [{ b64_json: "aGVsbG8=" }] });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].path).toBe("/images/generations");
+    expect(captured[0].headers.get("authorization")).toBe("Bearer chatgpt-user-token");
+    expect(captured[0].headers.get("chatgpt-account-id")).toBe("acct-123");
+    expect(captured[0].body).toMatchObject({ prompt: "a halftone gothic hero", model: "gpt-image-2" });
+  } finally {
+    await server.stop(true);
+    await upstream.stop(true);
+  }
+});
+
+test("POST /v1/images/edits relays to the /images/edits upstream path", async () => {
+  const captured: CapturedRequest[] = [];
+  const upstream = fakeImagesUpstream(captured);
+  saveConfig(forwardConfig(upstream.url.toString().replace(/\/$/, "")));
+
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/images/edits", server.url), {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer chatgpt-user-token" },
+      body: JSON.stringify({
+        prompt: "add gold ink",
+        model: "gpt-image-2",
+        images: [{ image_url: "data:image/png;base64,aGk=" }],
+      }),
+    });
+    expect(response.status).toBe(200);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].path).toBe("/images/edits");
+    expect(captured[0].body).toMatchObject({ prompt: "add gold ink" });
+  } finally {
+    await server.stop(true);
+    await upstream.stop(true);
+  }
+});
+
+test("a routed pool account's token overrides the caller bearer on the forward relay", async () => {
+  const captured: CapturedRequest[] = [];
+  const upstream = fakeImagesUpstream(captured);
+  saveConfig({
+    ...forwardConfig(upstream.url.toString().replace(/\/$/, "")),
+    codexAccounts: [
+      { id: "main", email: "main@example.test", isMain: true },
+      { id: "pool-a", email: "pool@example.test", isMain: false, chatgptAccountId: "acct-pool-a" },
+    ],
+    activeCodexAccountId: "pool-a",
+  } as OcxConfig);
+  saveCodexAccountCredential("pool-a", {
+    accessToken: "pool-access-token",
+    refreshToken: "pool-refresh-token",
+    expiresAt: Date.now() + 3_600_000,
+    chatgptAccountId: "acct-pool-a",
+  });
+
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/images/generations", server.url), {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer caller-token" },
+      body: JSON.stringify({ prompt: "a cat", model: "gpt-image-2" }),
+    });
+    expect(response.status).toBe(200);
+    expect(captured).toHaveLength(1);
+    // Pool routing selected pool-a; the caller token must NOT reach upstream.
+    expect(captured[0].headers.get("authorization")).toBe("Bearer pool-access-token");
+    expect(captured[0].headers.get("chatgpt-account-id")).toBe("acct-pool-a");
+  } finally {
+    await server.stop(true);
+    await upstream.stop(true);
+  }
+});
+
+test("zstd-compressed request bodies are decoded before the relay", async () => {
+  const captured: CapturedRequest[] = [];
+  const upstream = fakeImagesUpstream(captured);
+  saveConfig(forwardConfig(upstream.url.toString().replace(/\/$/, "")));
+
+  const server = startServer(0);
+  try {
+    const raw = JSON.stringify({ prompt: "compressed prompt", model: "gpt-image-2" });
+    const response = await fetch(new URL("/v1/images/generations", server.url), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-encoding": "zstd",
+        authorization: "Bearer chatgpt-user-token",
+      },
+      body: Bun.zstdCompressSync(Buffer.from(raw)),
+    });
+    expect(response.status).toBe(200);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].headers.get("content-encoding")).toBeNull();
+    expect(captured[0].body).toMatchObject({ prompt: "compressed prompt" });
+  } finally {
+    await server.stop(true);
+    await upstream.stop(true);
+  }
+});
+
+test("falls back to a keyed openai-responses provider when no forward provider exists", async () => {
+  const captured: CapturedRequest[] = [];
+  const upstream = fakeImagesUpstream(captured);
+  saveConfig({
+    port: 0,
+    defaultProvider: "openai-apikey",
+    providers: {
+      chatgpt: disabledChatgptProvider,
+      "openai-apikey": keyedProvider(upstream.url.toString().replace(/\/$/, "")),
+    },
+  } as OcxConfig);
+
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/images/generations", server.url), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        // The caller's ChatGPT OAuth token must NOT reach a platform API-key upstream.
+        authorization: "Bearer chatgpt-user-token",
+      },
+      body: JSON.stringify({ prompt: "a cat", model: "gpt-image-2" }),
+    });
+    expect(response.status).toBe(200);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].headers.get("authorization")).toBe("Bearer sk-platform-key");
+    // Keyed baseUrl had no /v1 suffix — the relay normalizes to the platform path.
+    expect(captured[0].path).toBe("/v1/images/generations");
+  } finally {
+    await server.stop(true);
+    await upstream.stop(true);
+  }
+});
+
+test("keyed baseUrl with a /v1 suffix is normalized (no double /v1)", async () => {
+  const captured: CapturedRequest[] = [];
+  const upstream = fakeImagesUpstream(captured);
+  saveConfig({
+    port: 0,
+    defaultProvider: "openai-apikey",
+    providers: {
+      chatgpt: disabledChatgptProvider,
+      "openai-apikey": keyedProvider(`${upstream.url.toString().replace(/\/$/, "")}/v1`),
+    },
+  } as OcxConfig);
+
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/images/generations", server.url), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt: "a cat", model: "gpt-image-2" }),
+    });
+    expect(response.status).toBe(200);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].path).toBe("/v1/images/generations");
+  } finally {
+    await server.stop(true);
+    await upstream.stop(true);
+  }
+});
+
+test("an unauthenticated request skips the forward provider when a keyed provider exists", async () => {
+  const captured: CapturedRequest[] = [];
+  const upstream = fakeImagesUpstream(captured);
+  saveConfig({
+    port: 0,
+    defaultProvider: "chatgpt",
+    providers: {
+      // ENABLED forward provider: an accidental forward relay would fail loudly (port 1).
+      chatgpt: unreachableChatgptProvider,
+      "openai-apikey": keyedProvider(upstream.url.toString().replace(/\/$/, "")),
+    },
+  } as OcxConfig);
+
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/images/generations", server.url), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt: "a cat", model: "gpt-image-2" }),
+    });
+    expect(response.status).toBe(200);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].headers.get("authorization")).toBe("Bearer sk-platform-key");
+  } finally {
+    await server.stop(true);
+    await upstream.stop(true);
+  }
+});
+
+test("an unauthenticated request gets 401 when only the forward provider exists", async () => {
+  saveConfig({
+    port: 0,
+    defaultProvider: "chatgpt",
+    providers: { chatgpt: unreachableChatgptProvider },
+  } as OcxConfig);
+
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/images/generations", server.url), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt: "a cat", model: "gpt-image-2" }),
+    });
+    expect(response.status).toBe(401);
+    const json = await response.json() as { error: { message: string } };
+    expect(json.error.message).toContain("ChatGPT auth");
+  } finally {
+    await server.stop(true);
+  }
+});
+
+test("forward-auth failure falls back to the keyed provider instead of surfacing 401", async () => {
+  const captured: CapturedRequest[] = [];
+  const upstream = fakeImagesUpstream(captured);
+  saveConfig({
+    port: 0,
+    defaultProvider: "chatgpt",
+    providers: {
+      chatgpt: unreachableChatgptProvider,
+      "openai-apikey": keyedProvider(upstream.url.toString().replace(/\/$/, "")),
+    },
+    codexAccounts: [
+      { id: "main", email: "main@example.test", isMain: true },
+      { id: "pool-a", email: "pool@example.test", isMain: false, chatgptAccountId: "acct-pool-a" },
+    ],
+    // pool-a has NO stored credential, so forward-auth resolution throws CodexAuthContextError.
+    activeCodexAccountId: "pool-a",
+  } as OcxConfig);
+
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/images/generations", server.url), {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer caller-token" },
+      body: JSON.stringify({ prompt: "a cat", model: "gpt-image-2" }),
+    });
+    expect(response.status).toBe(200);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].headers.get("authorization")).toBe("Bearer sk-platform-key");
+  } finally {
+    await server.stop(true);
+    await upstream.stop(true);
+  }
+});
+
+test("forward-auth failure surfaces its own error when no keyed provider exists", async () => {
+  saveConfig({
+    port: 0,
+    defaultProvider: "chatgpt",
+    providers: { chatgpt: unreachableChatgptProvider },
+    codexAccounts: [
+      { id: "main", email: "main@example.test", isMain: true },
+      { id: "pool-a", email: "pool@example.test", isMain: false, chatgptAccountId: "acct-pool-a" },
+    ],
+    activeCodexAccountId: "pool-a",
+  } as OcxConfig);
+
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/images/generations", server.url), {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer caller-token" },
+      body: JSON.stringify({ prompt: "a cat", model: "gpt-image-2" }),
+    });
+    expect(response.status).toBe(401);
+    const json = await response.json() as { error: { message: string } };
+    expect(json.error.message).toContain("reauthentication");
+  } finally {
+    await server.stop(true);
+  }
+});
+
+test("returns an honest 400 when no OpenAI-family upstream is configured", async () => {
+  saveConfig({
+    port: 0,
+    defaultProvider: "groq",
+    providers: {
+      chatgpt: disabledChatgptProvider,
+      groq: { adapter: "openai-chat", baseUrl: "https://api.groq.example/v1", apiKey: "gsk-x" },
+    },
+  } as OcxConfig);
+
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/images/generations", server.url), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt: "a cat", model: "gpt-image-2" }),
+    });
+    // 4xx (not 5xx): codex retries every 5xx up to 5 total attempts, and this is a permanent
+    // configuration state. The actionable part is the message, which codex Debug-prints into
+    // the model-visible tool failure.
+    expect(response.status).toBe(400);
+    const json = await response.json() as { error: { type: string; message: string } };
+    expect(json.error.message).toContain("image generation");
+    expect(json.error.message).toContain("disable image_generation");
+  } finally {
+    await server.stop(true);
+  }
+});
+
+test("relays upstream error status and body verbatim", async () => {
+  const captured: CapturedRequest[] = [];
+  const upstream = fakeImagesUpstream(captured, 403, {
+    error: { message: "Your plan does not allow image generation.", type: "forbidden" },
+  });
+  saveConfig(forwardConfig(upstream.url.toString().replace(/\/$/, "")));
+
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/images/generations", server.url), {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer chatgpt-user-token" },
+      body: JSON.stringify({ prompt: "a cat", model: "gpt-image-2" }),
+    });
+    expect(response.status).toBe(403);
+    const json = await response.json() as { error: { message: string } };
+    expect(json.error.message).toBe("Your plan does not allow image generation.");
+  } finally {
+    await server.stop(true);
+    await upstream.stop(true);
+  }
+});
+
+test("a hung upstream times out with 504 after config.images.timeoutMs", async () => {
+  const upstream = Bun.serve({
+    port: 0,
+    fetch(req) {
+      return new Promise<Response>((_, reject) => {
+        req.signal.addEventListener("abort", () => reject(new Error("client aborted")), { once: true });
+      });
+    },
+  });
+  saveConfig({
+    ...forwardConfig(upstream.url.toString().replace(/\/$/, "")),
+    images: { timeoutMs: 100 },
+  } as OcxConfig);
+
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/images/generations", server.url), {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer chatgpt-user-token" },
+      body: JSON.stringify({ prompt: "a cat", model: "gpt-image-2" }),
+    });
+    expect(response.status).toBe(504);
+    const json = await response.json() as { error: { message: string } };
+    expect(json.error.message).toContain("timed out");
+  } finally {
+    await server.stop(true);
+    await upstream.stop(true);
+  }
+}, 5_000);
+
+test("GET /v1/images/generations still falls through to the JSON 404 guard", async () => {
+  saveConfig(forwardConfig("https://chatgpt.example/backend-api/codex"));
+
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/images/generations", server.url));
+    expect(response.status).toBe(404);
+    expect(response.headers.get("content-type")).toContain("application/json");
+  } finally {
+    await server.stop(true);
+  }
+});
+
+test("images routes require API auth and local Origin on non-loopback bindings", async () => {
+  process.env.OPENCODEX_API_AUTH_TOKEN = "local-secret";
+  saveConfig({
+    ...forwardConfig("https://chatgpt.example/backend-api/codex"),
+    hostname: "0.0.0.0",
+  });
+
+  const server = startServer(0);
+  const imagesUrl = `http://127.0.0.1:${server.port}/v1/images/generations`;
+  try {
+    const missingAuth = await fetch(imagesUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt: "a cat" }),
+    });
+    expect(missingAuth.status).toBe(401);
+
+    const badOrigin = await fetch(imagesUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-opencodex-api-key": "local-secret",
+        origin: "https://attacker.test",
+      },
+      body: JSON.stringify({ prompt: "a cat" }),
+    });
+    expect(badOrigin.status).toBe(403);
+  } finally {
+    await server.stop(true);
+  }
+});
+
+test("the proxy admission secret is never relayed to the forward upstream", async () => {
+  process.env.OPENCODEX_API_AUTH_TOKEN = "local-secret";
+  const captured: CapturedRequest[] = [];
+  const upstream = fakeImagesUpstream(captured);
+  saveConfig({
+    port: 0,
+    hostname: "0.0.0.0",
+    defaultProvider: "chatgpt",
+    providers: {
+      chatgpt: unreachableChatgptProvider,
+      "openai-apikey": keyedProvider(upstream.url.toString().replace(/\/$/, "")),
+    },
+  } as OcxConfig);
+
+  const server = startServer(0);
+  try {
+    // Authorization carries the proxy's OWN admission token — it authenticates the caller to the
+    // proxy, but must be stripped before upstream selection (else it would leak to chatgpt.com).
+    const response = await fetch(`http://127.0.0.1:${server.port}/v1/images/generations`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer local-secret" },
+      body: JSON.stringify({ prompt: "a cat", model: "gpt-image-2" }),
+    });
+    expect(response.status).toBe(200);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].headers.get("authorization")).toBe("Bearer sk-platform-key");
+  } finally {
+    await server.stop(true);
+    await upstream.stop(true);
+  }
+});


### PR DESCRIPTION
Closes #83.

## Problem

Codex's built-in `image_gen` tool failed instantly with:

```
image generation failed: http 404 Not Found: Some("{\"error\":{\"message\":\"Unknown endpoint: POST /v1/images/generations\",...}")
```

The 404 is opencodex's own `/v1/*` data-plane guard. codex-rs's standalone image-generation extension executes **client-side**: it POSTs `{base_url}/images/generations` (`/images/edits` when reference images are attached) with the same ChatGPT bearer auth it uses for chat. Under Design B injection `base_url` is the proxy, and no route existed — the path was even test-pinned as an intentional 404.

Why reports started now: codex 0.144.0 graduated `image_generation` from the disabled-by-default `imagegenext` experiment to **stable / default-enabled**, so ChatGPT-signed-in users hit the tool organically. (The hosted `image_generation` entry in `tools[]` on `/v1/responses` was never affected — passthrough already forwards it; only the extension's direct REST call 404'd.)

## Fix

New relay route `POST /v1/images/{generations,edits}` ([src/server/images.ts](../blob/fix/issue-83-images-endpoint/src/server/images.ts)), inserted before the `/v1/*` guard with the standard data-plane preamble (drain 503, `requireApiAuth`, origin check, `withCors`, request log incl. `client_cancel` meta).

Upstream selection:

1. **ChatGPT forward provider** (preferred — the backend codex itself would have called absent the base_url override, so bodies relay verbatim, zero mapping). Auth = forwarded caller bearer or the routed multi-account **pool token** (`resolveCodexAuthContext` / `headersForCodexAuthContext`); pool upstream outcomes are recorded for rotation failover.
   - Used only when the request actually carries a relayable bearer — `startServer` auto-upserts a `chatgpt` forward entry into every config, so its presence proves nothing; without this gate an unauthenticated request bounces off chatgpt.com as an opaque `{"detail":"Unauthorized"}`.
   - A bearer equal to the proxy's own admission secret (non-loopback binds accept `Authorization: Bearer $OPENCODEX_API_AUTH_TOKEN`) is stripped and **never relayed** to chatgpt.com.
   - Forward-auth failures (pool cooldown 429 / reauth 401 / affinity 409) fall back to the keyed provider instead of failing the request; the captured error surfaces only when no keyed candidate exists.
2. **Keyed `openai-responses` provider** (e.g. `api.openai.com`) — URL normalized like the adapter (`baseUrl` with or without `/v1` both work).
3. **Neither** — honest **400** naming the fix (add an OpenAI provider, or `codex features disable image_generation`). 4xx, not 5xx, because codex retries every 5xx up to 5 total attempts and this is a permanent config state.

Relay: `readJsonRequestBody` (zstd/gzip + 256MB cap) → `fetchWithResetRetry` with `config.images.timeoutMs` (default 300s) linked to client abort → response passed through status+content-type+body verbatim so upstream plan-gating errors stay legible to codex (it Debug-prints the body into the model-visible failure). Client cancel → 499, upstream hang → 504.

Docs: endpoint lists + new "Built-in image generation" section in the codex-integration guide (en/ko/zh-cn) and architecture reference (en/ko/zh-cn). Design notes in `devlog/260710_issue83_images_endpoint/`.

## Tests

- 16 new tests in `tests/server-images.test.ts`: forward relay (auth/path/body), edits path, pool-token override (caller bearer must not leak), zstd decode, keyed fallback + `/v1` normalization, unauthenticated-request gate, forward-auth-failure fallback, no-upstream 400, upstream error passthrough, 504 timeout, GET→404 guard, non-loopback auth/origin, admission-secret never relayed.
- `tests/server-auth.test.ts` 404-guard list swaps `/v1/images/generations` for `/v1/realtime/sessions`.
- Full suite: **1945 pass / 0 fail**; `tsc --noEmit` clean.
- Reviewed by a 4-lens adversarial multi-agent pass (correctness / security / codex-client compat vs rust-v0.144.0 source / project fit); all 13 confirmed findings addressed in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)