### PR TITLE
fix: preserve routed sub-agent task payloads by sanitizing before parse

### DIFF
--- a/src/server/responses.ts
+++ b/src/server/responses.ts
@@ -298,10 +298,19 @@ function encryptedSlotParts(payload: string): Array<Record<string, string>> {
   return parts.length > 0 ? parts : [{ type: "input_text", text: payload }];
 }
 
+function hasEncryptedContentPart(content: unknown): boolean {
+  return Array.isArray(content) && content.some(part => (
+    part && typeof part === "object"
+    && (part as { type?: unknown }).type === "encrypted_content"
+  ));
+}
+
 /**
  * Rewrite non-ciphertext `{type:"encrypted_content"}` parts into `{type:"input_text"}`
- * throughout a native-bound request's input items (message content and
- * function_call_output content arrays share the part shape, codex-rs protocol/models.rs).
+ * throughout a request's input items (message content and function_call_output content
+ * arrays share the part shape, codex-rs protocol/models.rs). An `agent_message` whose
+ * payload becomes entirely plaintext is normalized to a user message so routed parsers
+ * that do not understand the internal item type still deliver the spawn task.
  * Genuine backend blobs are left byte-identical so replay/cache semantics survive, and
  * MIXED slots (plaintext preamble + embedded Fernet task body) are split so the backend
  * decrypts the blob while the prose passes as text. Returns the number of parts rewritten.
@@ -309,7 +318,8 @@ function encryptedSlotParts(payload: string): Array<Record<string, string>> {
 export function sanitizeEncryptedContentInPlace(input: unknown): number {
   if (!Array.isArray(input)) return 0;
   let rewritten = 0;
-  const visit = (node: unknown): void => {
+  const visit = (node: unknown): number => {
+    const before = rewritten;
     if (Array.isArray(node)) {
       for (let i = 0; i < node.length; i += 1) {
         const child = node[i] as unknown;
@@ -327,13 +337,26 @@ export function sanitizeEncryptedContentInPlace(input: unknown): number {
             continue;
           }
         }
-        visit(child);
+        const childRewrites = visit(child);
+        if (
+          childRewrites > 0
+          && child && typeof child === "object"
+          && (child as { type?: unknown }).type === "agent_message"
+          && !hasEncryptedContentPart((child as { content?: unknown }).content)
+        ) {
+          const message = child as { type: string; role?: string; author?: unknown; recipient?: unknown };
+          message.type = "message";
+          message.role = "user";
+          delete message.author;
+          delete message.recipient;
+        }
       }
-      return;
+      return rewritten - before;
     }
     if (node && typeof node === "object") {
       for (const value of Object.values(node)) visit(value);
     }
+    return rewritten - before;
   };
   visit(input);
   return rewritten;

--- a/src/server/responses.ts
+++ b/src/server/responses.ts
@@ -410,6 +410,21 @@ export async function handleResponses(
   body = expandPreviousResponseInput(body);
   const previousResponseInputExpanded = body !== originalBody;
 
+  // Spawn-message compatibility (both directions): agent_message task payloads ride in
+  // encrypted_content slots as plaintext. Rewrite them to input_text on the RAW body BEFORE
+  // parsing so every consumer sees the payload: parseRequest (routed/translated providers read
+  // the parsed messages) and the native passthrough (_rawBody is this same object, serialized
+  // verbatim). Genuine backend ciphertext is left byte-identical (looksLikeBackendCiphertext).
+  {
+    const rewritten = sanitizeEncryptedContentInPlace(
+      (body as { input?: unknown } | undefined)?.input,
+    );
+    if (rewritten > 0)
+      console.warn(
+        `[opencodex] rewrote ${rewritten} plaintext encrypted_content part(s) to input_text (spawn-message compatibility)`,
+      );
+  }
+
   let parsed;
   try {
     parsed = parseRequest(body);
@@ -452,15 +467,6 @@ export async function handleResponses(
   // Runs BEFORE the mock-max clamp below so the synthetic top tier (ultra arrives
   // as max on the codex wire) is still visible. Both request shapes are rewritten.
   {
-    const requestedModelId = logCtx.requestedModel ?? route.modelId;
-    // Cross-provider spawn poison fix: native-bound requests may carry plaintext parked in
-    // encrypted_content slots (spawn messages minted under a routed parent). Rewrite them
-    // to input_text before the passthrough serializes _rawBody verbatim.
-    if (!requestedModelId.includes("/")) {
-      const raw = parsed._rawBody as { input?: unknown } | undefined;
-      const rewritten = sanitizeEncryptedContentInPlace(raw?.input);
-      if (rewritten > 0) console.warn(`[opencodex] ${route.modelId}: rewrote ${rewritten} plaintext encrypted_content part(s) to input_text (routed-parent spawn compatibility)`);
-    }
     const guidance = await multiAgentGuidanceText(parsed, config.injectionModel, config.injectionEffort, config.subagentModels, config.injectionPrompt);
     if (guidance) {
       injectDeveloperMessage(parsed, guidance);

--- a/tests/multi-agent-compat.test.ts
+++ b/tests/multi-agent-compat.test.ts
@@ -414,3 +414,31 @@ describe("sanitizeEncryptedContentInPlace", () => {
     expect(parts[0]).toEqual({ type: "encrypted_content", encrypted_content: fernet });
   });
 });
+
+describe("spawn-message delivery (agent_message + encrypted slot)", () => {
+  test("sanitize-then-parse delivers the spawn task payload as a user message on routed paths", () => {
+    // Mirrors handleResponses order: sanitizeEncryptedContentInPlace on the RAW input,
+    // then parseRequest. Regression for spawned sub-agents receiving empty task payloads
+    // (agent_message payload rides in a plaintext encrypted_content slot).
+    const body = {
+      model: "anthropic/claude-fable-5",
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "env context" }] },
+        { type: "agent_message", author: "/root", recipient: "/root/worker", content: [
+          { type: "input_text", text: "Message Type: NEW_TASK\nTask name: /root/worker\nSender: /root\nPayload:\n" },
+          { type: "encrypted_content", encrypted_content: "TASK: build the thing exactly as specified." },
+        ] },
+      ],
+    };
+    expect(sanitizeEncryptedContentInPlace(body.input)).toBe(1);
+    const parsed = parseRequest(body);
+    const users = parsed.context.messages.filter(m => m.role === "user");
+    expect(users).toHaveLength(2);
+    const content = users[1].content;
+    const flat = typeof content === "string"
+      ? content
+      : (content as Array<{ type: string; text?: string }>).map(p => p.text ?? "").join("");
+    expect(flat).toContain("Message Type: NEW_TASK");
+    expect(flat).toContain("TASK: build the thing exactly as specified.");
+  });
+});

--- a/tests/multi-agent-compat.test.ts
+++ b/tests/multi-agent-compat.test.ts
@@ -417,9 +417,9 @@ describe("sanitizeEncryptedContentInPlace", () => {
 
 describe("spawn-message delivery (agent_message + encrypted slot)", () => {
   test("sanitize-then-parse delivers the spawn task payload as a user message on routed paths", () => {
-    // Mirrors handleResponses order: sanitizeEncryptedContentInPlace on the RAW input,
-    // then parseRequest. Regression for spawned sub-agents receiving empty task payloads
-    // (agent_message payload rides in a plaintext encrypted_content slot).
+    // Mirrors handleResponses order: sanitize and normalize the RAW input, then parseRequest.
+    // Regression for spawned sub-agents receiving empty task payloads when the routed parser
+    // does not understand agent_message and its task rides in a plaintext encrypted slot.
     const body = {
       model: "anthropic/claude-fable-5",
       input: [
@@ -431,6 +431,7 @@ describe("spawn-message delivery (agent_message + encrypted slot)", () => {
       ],
     };
     expect(sanitizeEncryptedContentInPlace(body.input)).toBe(1);
+    expect(body.input[1]).toMatchObject({ type: "message", role: "user" });
     const parsed = parseRequest(body);
     const users = parsed.context.messages.filter(m => m.role === "user");
     expect(users).toHaveLength(2);


### PR DESCRIPTION
## Summary

This fixes a routed multi-agent regression where spawned sub-agents woke up with the environment/context but **without the actual task payload**.

On the wire, the task body can arrive parked as plaintext inside an `encrypted_content` slot inside an internal `agent_message`. Two transformations are required before provider translation:

1. rewrite the plaintext encrypted slot to `input_text`
2. normalize the now-plaintext `agent_message` to a standard user `message` that `parseRequest` understands

Previously the sanitizer ran only on the native-bound path and only after parsing. Moving it before `parseRequest` exposed a second gap: the routed parser intentionally ignores unknown input item types, so merely making the content readable still left the entire `agent_message` undispatched. The sanitizer now performs both operations when the payload is entirely plaintext.

## What changed

- `src/server/responses.ts`
  - run `sanitizeEncryptedContentInPlace` on `body.input` immediately after `expandPreviousResponseInput(body)` and before `parseRequest(body)`
  - normalize a rewritten `agent_message` to `{ type: "message", role: "user" }` only when no genuine encrypted content remains
  - preserve genuine backend ciphertext and mixed plaintext/Fernet payloads without coercing their container
  - remove the old native-only post-parse sanitize block

- `tests/multi-agent-compat.test.ts`
  - mirror the real request order: sanitize/normalize raw input, then parse
  - assert both the container normalization and delivery of the complete `NEW_TASK` payload in parsed user messages

## Root cause

`parseRequest` tolerates unknown input items at the schema boundary but only emits context messages for recognized item types. After the first version of this patch, the encrypted slot became readable `input_text`, yet its parent still had `type: "agent_message"`. The parser therefore skipped it, producing one user message instead of two and dropping the spawned task.

This is why the regression test failed in CI with:

- expected user-message count: `2`
- received user-message count: `1`

The follow-up commit fixes that actual boundary rather than weakening the assertion.

## Safety properties

- Plaintext spawn payloads become ordinary user input before routed translation.
- Genuine ciphertext remains byte-identical.
- Mixed payloads retaining a Fernet token are not coerced into a user message.
- The implementation remains confined to the request normalization layer.

## Scope

This PR intentionally contains only:

- `src/server/responses.ts`
- `tests/multi-agent-compat.test.ts`

## Verification

- `bun test tests/multi-agent-compat.test.ts --test-name-pattern "sanitize-then-parse delivers"` - pass
- `bun test tests/multi-agent-compat.test.ts` - 27 pass, 0 fail
- `bun run typecheck` - pass
- `git diff --check` - pass
- full `bun test` - the spawn regression passes; the local run remains red on five unrelated pre-existing environment/integration tests (Cursor MCP live stdio x3, server pool-health, Windows service task)

The upstream cross-platform CI rerun was triggered by the follow-up push.