### PR TITLE
Fix xAI OAuth subscription transport routing

### DIFF
--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -12,6 +12,7 @@ import { loginAntigravity, refreshAntigravityToken } from "./google-antigravity"
 import { loginCursor, refreshCursorToken } from "./cursor";
 import { deriveOAuthDefaultModel, deriveOAuthProviderConfig } from "../providers/derive";
 import { effectiveGoogleMode } from "../providers/registry";
+import { resolveProviderTransport } from "../providers/xai-transport";
 
 const REFRESH_SKEW_MS = 60_000;
 const tokenRefreshes = new Map<string, Promise<string>>();
@@ -254,27 +255,28 @@ export async function resolveModelsAuthToken(name: string, prov: OcxProviderConf
  * response.
  */
 export function buildModelsRequest(prov: OcxProviderConfig, apiKey: string | undefined, providerName = ""): { url: string; headers: Record<string, string> } {
-  const headers: Record<string, string> = { ...(prov.headers ?? {}) };
-  if (effectiveGoogleMode(providerName, prov) === "ai-studio") {
+  const effectiveProvider = resolveProviderTransport(providerName, prov);
+  const headers: Record<string, string> = { ...(effectiveProvider.headers ?? {}) };
+  if (effectiveGoogleMode(providerName, effectiveProvider) === "ai-studio") {
     // Generative Language API: API key goes in x-goog-api-key (never Authorization: Bearer),
     // models live under /v1beta (v1 misses preview models), and pageSize maxes at 1000 —
     // enough to list everything without a pageToken loop. Vertex/antigravity keep the
     // generic branch (they fall back to their static model lists).
     if (apiKey) headers["x-goog-api-key"] = apiKey;
-    return { url: `${prov.baseUrl}/v1beta/models?pageSize=1000`, headers };
+    return { url: `${effectiveProvider.baseUrl}/v1beta/models?pageSize=1000`, headers };
   }
-  if (prov.adapter === "anthropic") {
+  if (effectiveProvider.adapter === "anthropic") {
     headers["anthropic-version"] = "2023-06-01";
-    if (prov.authMode === "oauth") {
+    if (effectiveProvider.authMode === "oauth") {
       headers["anthropic-beta"] = ANTHROPIC_OAUTH_BETA;
       if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
     } else if (apiKey) {
       headers["x-api-key"] = apiKey;
     }
-    return { url: `${prov.baseUrl}/v1/models?limit=1000`, headers };
+    return { url: `${effectiveProvider.baseUrl}/v1/models?limit=1000`, headers };
   }
   if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
-  return { url: `${prov.baseUrl}/models`, headers };
+  return { url: `${effectiveProvider.baseUrl}/models`, headers };
 }
 
 /**

--- a/src/providers/xai-transport.ts
+++ b/src/providers/xai-transport.ts
@@ -1,0 +1,39 @@
+import type { OcxProviderConfig } from "../types";
+
+/**
+ * xAI account OAuth and xAI API keys share a bearer shape but not a billing
+ * transport. OAuth represents the Grok CLI subscription entitlement, while a
+ * key represents the API team. Keep the saved provider preset compatible with
+ * the dashboard's "Use an API key instead" switch and resolve the transport at
+ * request time.
+ */
+export const XAI_GROK_CLI_BASE_URL = "https://cli-chat-proxy.grok.com/v1";
+
+/** Minimum-compatible official Grok CLI wire version verified with the proxy. */
+export const XAI_GROK_CLIENT_VERSION = "0.2.93";
+
+const XAI_GROK_CLI_HEADERS: Readonly<Record<string, string>> = {
+  "x-grok-client-identifier": "opencodex",
+  "x-grok-client-version": XAI_GROK_CLIENT_VERSION,
+  "x-xai-token-auth": "xai-grok-cli",
+};
+
+/**
+ * Resolve the effective xAI transport without mutating persisted config.
+ * User-provided headers are preserved and may advance the compatibility
+ * version without waiting for an opencodex release.
+ */
+export function resolveProviderTransport(
+  providerName: string,
+  provider: OcxProviderConfig,
+): OcxProviderConfig {
+  if (providerName !== "xai" || provider.authMode !== "oauth") return provider;
+  return {
+    ...provider,
+    baseUrl: XAI_GROK_CLI_BASE_URL,
+    headers: {
+      ...XAI_GROK_CLI_HEADERS,
+      ...(provider.headers ?? {}),
+    },
+  };
+}

--- a/src/server/responses.ts
+++ b/src/server/responses.ts
@@ -41,6 +41,7 @@ import { isUsageDebugEnabled } from "../usage/debug";
 import { readJsonRequestBody, DecompressedBodyTooLargeError, UnsupportedContentEncodingError } from "./request-decompress";
 import { resolveAdapter, resolveWireProtocolOverride } from "./adapter-resolve";
 import { hasKeyPoolFailover, rotateKeyOn429 } from "../providers/key-failover";
+import { resolveProviderTransport } from "../providers/xai-transport";
 import type { WsData } from "./ws-bridge";
 import { registerTurn, trackStreamLifetime, unregisterTurn } from "./lifecycle";
 import { redactSecretString } from "../lib/redact";
@@ -600,6 +601,7 @@ export async function handleResponses(
       return formatErrorResponse(401, "authentication_error", err instanceof Error ? err.message : String(err));
     }
   }
+  route.provider = resolveProviderTransport(route.providerName, route.provider);
 
   // Vision sidecar: the routed model can't see images (provider.noVisionModels). Give it "eyes" —
   // describe each attached image with a gpt vision model via the ChatGPT passthrough and replace it

--- a/tests/xai-transport.test.ts
+++ b/tests/xai-transport.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
+import { buildModelsRequest } from "../src/oauth";
+import {
+  resolveProviderTransport,
+  XAI_GROK_CLI_BASE_URL,
+  XAI_GROK_CLIENT_VERSION,
+} from "../src/providers/xai-transport";
+import type { OcxParsedRequest, OcxProviderConfig } from "../src/types";
+
+function provider(authMode: "oauth" | "key"): OcxProviderConfig {
+  return {
+    adapter: "openai-chat",
+    baseUrl: "https://api.x.ai/v1",
+    authMode,
+    apiKey: authMode === "oauth" ? "oauth-token" : "xai-api-key",
+    defaultModel: "grok-4.5",
+  };
+}
+
+function parsed(): OcxParsedRequest {
+  return {
+    modelId: "grok-4.5",
+    context: { messages: [{ role: "user", content: "hi", timestamp: 0 }] },
+    stream: false,
+    options: { reasoning: "low" },
+  };
+}
+
+describe("xAI auth-mode transport selection", () => {
+  test("OAuth selects the Grok CLI subscription transport and required headers", () => {
+    const effective = resolveProviderTransport("xai", provider("oauth"));
+    const request = createOpenAIChatAdapter(effective).buildRequest(parsed());
+
+    expect(effective.baseUrl).toBe(XAI_GROK_CLI_BASE_URL);
+    expect(request.url).toBe(`${XAI_GROK_CLI_BASE_URL}/chat/completions`);
+    expect(request.headers).toMatchObject({
+      Authorization: "Bearer oauth-token",
+      "x-grok-client-identifier": "opencodex",
+      "x-grok-client-version": XAI_GROK_CLIENT_VERSION,
+      "x-xai-token-auth": "xai-grok-cli",
+    });
+  });
+
+  test("OAuth model discovery uses the subscription transport", () => {
+    const request = buildModelsRequest(provider("oauth"), "oauth-token", "xai");
+
+    expect(request.url).toBe(`${XAI_GROK_CLI_BASE_URL}/models`);
+    expect(request.headers).toMatchObject({
+      Authorization: "Bearer oauth-token",
+      "x-grok-client-identifier": "opencodex",
+      "x-grok-client-version": XAI_GROK_CLIENT_VERSION,
+      "x-xai-token-auth": "xai-grok-cli",
+    });
+  });
+
+  test("API key keeps the xAI API transport without subscription headers", () => {
+    const configured = provider("key");
+    const effective = resolveProviderTransport("xai", configured);
+    const request = createOpenAIChatAdapter(effective).buildRequest(parsed());
+    const modelsRequest = buildModelsRequest(configured, "xai-api-key", "xai");
+
+    expect(effective).toBe(configured);
+    expect(request.url).toBe("https://api.x.ai/v1/chat/completions");
+    expect(modelsRequest.url).toBe("https://api.x.ai/v1/models");
+    expect(request.headers).toEqual({
+      "Content-Type": "application/json",
+      Authorization: "Bearer xai-api-key",
+    });
+    expect(modelsRequest.headers).toEqual({ Authorization: "Bearer xai-api-key" });
+  });
+
+  test("custom providers and configured header overrides remain untouched", () => {
+    const custom = provider("oauth");
+    custom.headers = { "x-grok-client-version": "0.2.94", "x-custom": "kept" };
+
+    expect(resolveProviderTransport("custom-xai", custom)).toBe(custom);
+    expect(resolveProviderTransport("xai", custom).headers).toMatchObject({
+      "x-grok-client-version": "0.2.94",
+      "x-custom": "kept",
+      "x-grok-client-identifier": "opencodex",
+      "x-xai-token-auth": "xai-grok-cli",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Route the built-in `xai` provider through the Grok CLI subscription endpoint only when `authMode` is `oauth`.
- Preserve the existing `api.x.ai` transport for API-key authentication.
- Apply the same auth-mode-aware transport selection to live model discovery.
- Add regression coverage for OAuth inference, OAuth model discovery, API-key isolation, custom providers, and header overrides.

## Why

The xAI preset accepts both OAuth and API-key credentials, but both modes currently share `https://api.x.ai/v1`. A valid Grok subscription OAuth token is therefore evaluated against API-team spend limits and can receive HTTP 429 with an RPM limit of `0/0`, even while subscription quota is available.

The same OAuth token succeeds against `https://cli-chat-proxy.grok.com/v1` with the Grok CLI client markers. This change keeps the persisted preset compatible with the dashboard's "Use an API key instead" switch and resolves the effective transport at request time, so the two billing surfaces cannot silently cross.

Closes #112.

## Verification

- `bun run typecheck`
- `bun test tests/xai-transport.test.ts tests/provider-live-models.test.ts tests/provider-quota.test.ts tests/openai-chat-hardening.test.ts` — 20 passed
- `bun run test`
- `bun run privacy:scan`
- `bun run build:gui`
- `npm pack --dry-run`
- Installed the packed fork into an isolated runtime and ran a real Codex/OpenCodex `xai/grok-4.5` structured-output smoke: upstream HTTP 200, reported usage, zero retry/correction, canonical output valid, VM advanced successfully.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were reviewed; the README already documents xAI as `oauth / key`, so no user-facing text change is required.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.
