### PR TITLE
fix(upstream): suppress Accept-Encoding to fix OpenRouter SSE streaming batching

### DIFF
--- a/src/server/responses.ts
+++ b/src/server/responses.ts
@@ -1176,6 +1176,12 @@ export async function fetchWithHeaderTimeout(
   try {
     return await fetch(url, {
       ...init,
+      // Suppress automatic content-encoding negotiation (Bun adds Accept-Encoding: br,gzip,...
+      // by default; providers like OpenRouter respond with Brotli/gzip which Bun decompresses
+      // in blocks — causing SSE frames to be buffered until a full decompression block is ready
+      // rather than being yielded token-by-token). Requesting identity ensures chunks arrive
+      // unencoded and are forwarded to the client immediately.
+      headers: { "Accept-Encoding": "identity", ...init.headers },
       signal: AbortSignal.any([abortSignal, timeout.signal]),
     });
   } finally {


### PR DESCRIPTION
## Problem

Fixes #114.

When using the openai-chat adapter (e.g. OpenRouter models), responses are delivered in batches at the end rather than token-by-token, even though the debug log shows correct per-token SSE deltas being produced by the adapter.

Root cause: Bun's fetch() automatically sends Accept-Encoding: br, gzip, deflate, zstd. Providers like OpenRouter honour this and reply with a Brotli or gzip compressed body. Bun decompresses transparently, but Brotli works in block frames - it cannot yield a decompressed byte until a full frame is complete. This means SSE data: lines accumulate in the decompressor's internal buffer and only flush when a compression boundary is crossed, producing the observed batch behaviour.

The ChatGPT passthrough (openai-responses adapter) is unaffected because it bypasses fetchWithHeaderTimeout entirely and uses Bun's native SSE relay directly.

## Fix

Inject Accept-Encoding: identity as the first entry in the headers passed to fetch() inside fetchWithHeaderTimeout. This tells every upstream provider not to compress the response body, so SSE frames are forwarded to the client immediately as they arrive.

Why this is safe:
- SSE (text/event-stream) is already plain text; per-token compression gives negligible size savings and actively hurts streaming latency.
- Non-streaming JSON responses are small enough that the bandwidth difference is immaterial.
- Any caller-supplied Accept-Encoding header still takes precedence via the spread order ({ 'Accept-Encoding': 'identity', ...init.headers }), so providers that genuinely require compression can still opt in via the adapter's header map.

## Change

Single line change in src/server/responses.ts - fetchWithHeaderTimeout now prepends Accept-Encoding: identity before spreading init.headers.

## Testing

- All 41 openai-chat focused tests pass (EOF, hardening, model suffix, parallel tool call assembly).
- All 14 upstream-retry tests pass.
- Verified no other test files import or stub fetchWithHeaderTimeout in a way that would be sensitive to the added header.