### PR TITLE
fix(cursor): strip cursor- wire prefix from GetUsableModels IDs (#117)

### DIFF
--- a/src/adapters/cursor/discovery.ts
+++ b/src/adapters/cursor/discovery.ts
@@ -61,12 +61,23 @@ export function normalizeCursorModels(models: readonly CursorModelInfo[]): Curso
 const LIVE_EFFORT_SUFFIXES = ["low", "medium", "high", "xhigh", "max"] as const;
 
 /**
+ * Strip the `cursor-` wire prefix that some Cursor GetUsableModels responses prepend to model ids
+ * (e.g. `cursor-grok-4.5-high` instead of `grok-4.5-high`). Applied at the comparison boundary
+ * so upstream wire ids stay verbatim everywhere else (issue #117).
+ */
+function stripCursorWirePrefix(id: string): string {
+  return id.startsWith("cursor-") ? id.slice("cursor-".length) : id;
+}
+
+/**
  * True when a configured Cursor base model should remain exposed after live GetUsableModels filtering.
  * Live ids are full effort-suffixed variants (`claude-4.6-opus-high`); base ids match exactly or by prefix.
  */
 export function isCursorModelAvailableForAccount(modelId: string, liveIds: readonly string[]): boolean {
-  return liveIds.some(id =>
-    id === modelId || LIVE_EFFORT_SUFFIXES.some(suffix => id === `${modelId}-${suffix}`));
+  return liveIds.some(raw => {
+    const id = stripCursorWirePrefix(raw);
+    return id === modelId || LIVE_EFFORT_SUFFIXES.some(suffix => id === `${modelId}-${suffix}`);
+  });
 }
 
 /** Codex-facing id for Cursor's auto-router. Always kept in the catalog even when live discovery omits it. */

--- a/tests/cursor-discovery.test.ts
+++ b/tests/cursor-discovery.test.ts
@@ -53,6 +53,14 @@ describe("Cursor discovery metadata", () => {
     expect(isCursorModelAvailableForAccount("gpt-5.5", ["gpt-5.5-extra-high"])).toBe(false);
     expect(isCursorModelAvailableForAccount("gpt-5.5-extra", ["gpt-5.5-extra-high"])).toBe(true);
 
+    // Issue #117: Cursor GetUsableModels may return ids with a `cursor-` wire prefix.
+    expect(isCursorModelAvailableForAccount("grok-4.5", ["cursor-grok-4.5-high"])).toBe(true);
+    expect(isCursorModelAvailableForAccount("grok-4.5-fast", ["cursor-grok-4.5-fast-medium"])).toBe(true);
+    expect(isCursorModelAvailableForAccount("gpt-5.4", ["cursor-gpt-5.4-high"])).toBe(true);
+    // Prefixed sibling rejection: cursor- prefix must not bypass sibling-model checks.
+    expect(isCursorModelAvailableForAccount("gpt-5.5", ["cursor-gpt-5.5-extra-high"])).toBe(false);
+    expect(isCursorModelAvailableForAccount("claude-4-sonnet", ["cursor-claude-4-sonnet-1m"])).toBe(false);
+
     const filtered = filterCursorConfiguredModelsByLiveDiscovery(
       [{ id: "gpt-5.4" }, { id: "claude-fable-5" }],
       ["gpt-5.4-high"],


### PR DESCRIPTION
## Summary

- strip Cursor's optional `cursor-` wire prefix when comparing `GetUsableModels` IDs with configured base model IDs
- keep upstream wire IDs unchanged outside the comparison boundary
- add regression coverage for prefixed matching and sibling-model rejection

## Bug

Cursor's `GetUsableModels` RPC may return IDs such as `cursor-grok-4.5-high`, while the configured catalog uses base IDs such as `grok-4.5`. The availability filter compared these forms directly, failed to match them, and removed affected Grok 4.5 models during catalog sync.

## Fix

Normalize only at the `isCursorModelAvailableForAccount` comparison boundary by removing one leading `cursor-` prefix. Existing exact and effort-suffix matching then works as intended without changing stored or upstream wire IDs.

## Validation

- `bun test --isolate ./tests/cursor-discovery.test.ts` (8 passed, 55 assertions)
- `bun run typecheck`

Fixes #117