### PR TITLE
fix(upstream): pass stream flag to fetchWithAttemptDeadline for ident…

### DIFF
--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -51,4 +51,6 @@ export interface AdapterFetchContext {
   timeoutMs?: number;
   /** Return final non-2xx responses untouched so the caller can own the error-body read. */
   returnRawErrors?: boolean;
+  stream?: boolean;
+
 }

--- a/src/adapters/google-http.ts
+++ b/src/adapters/google-http.ts
@@ -36,7 +36,7 @@ export async function fetchGoogleWithRetry(label: string, request: AdapterReques
         method: request.method,
         headers: request.headers,
         body: request.body,
-      }, timeoutMs, ctx.abortSignal);
+      }, timeoutMs, ctx.abortSignal, ctx.stream);
       if (!retryableGoogleStatus(res.status) || attempt === GOOGLE_RETRY_ATTEMPTS - 1) {
         return ctx.returnRawErrors ? res : normalizeFinalGoogleError(label, res, ctx.abortSignal);
       }

--- a/src/adapters/kiro-retry.ts
+++ b/src/adapters/kiro-retry.ts
@@ -39,7 +39,7 @@ export async function fetchKiroWithRetry(request: AdapterRequest, ctx: AdapterFe
         method: request.method,
         headers: request.headers,
         body: request.body,
-      }, timeoutMs, ctx.abortSignal);
+      }, timeoutMs, ctx.abortSignal, ctx.stream);
       if (!retryableKiroStatus(res.status) || attempt === KIRO_RETRY_ATTEMPTS - 1) {
         return ctx.returnRawErrors ? res : normalizeFinalKiroHttpError(res, ctx.abortSignal);
       }

--- a/src/lib/upstream-retry.ts
+++ b/src/lib/upstream-retry.ts
@@ -94,11 +94,17 @@ export async function fetchWithAttemptDeadline(
   init: RequestInit,
   timeoutMs: number,
   abortSignal?: AbortSignal,
+  preferIdentityEncoding = false,
 ): Promise<Response> {
   const attemptTimeout = clearableDeadline(timeoutMs, abortSignal);
+  const headers = new Headers(init.headers);
+  if (preferIdentityEncoding && !headers.has("accept-encoding")) {
+    headers.set("accept-encoding", "identity");
+  }
   try {
     return await fetch(url, {
       ...init,
+      headers,
       signal: attemptTimeout.signal,
     });
   } finally {

--- a/src/server/responses.ts
+++ b/src/server/responses.ts
@@ -923,7 +923,7 @@ export async function handleResponses(
   let upstreamResponse: Response;
   try {
     upstreamResponse = adapter.fetchResponse
-      ? await adapter.fetchResponse(request, { abortSignal: upstream.signal, timeoutMs: connectMs })
+      ? await adapter.fetchResponse(request, { abortSignal: upstream.signal, timeoutMs: connectMs, stream: parsed.stream })
       : await fetchWithResetRetry(
           () => fetchWithHeaderTimeout(request.url, {
             method: request.method, headers: request.headers, body: request.body,
@@ -962,7 +962,7 @@ export async function handleResponses(
       const retryRequest = await retryAdapter.buildRequest(parsed, { headers: selectedForwardHeaders });
       try {
         upstreamResponse = retryAdapter.fetchResponse
-          ? await retryAdapter.fetchResponse(retryRequest, { abortSignal: upstream.signal, timeoutMs: connectMs })
+          ? await retryAdapter.fetchResponse(retryRequest, { abortSignal: upstream.signal, timeoutMs: connectMs, stream: parsed.stream })
           : await fetchWithHeaderTimeout(retryRequest.url, {
               method: retryRequest.method, headers: retryRequest.headers, body: retryRequest.body,
             }, upstream.signal, connectMs, parsed.stream);


### PR DESCRIPTION
Fixes #120

Commit `54462c0` added `preferIdentityEncoding` to `fetchWithHeaderTimeout` to prevent Bun from buffering compressed SSE streams. However, adapters using `fetchWithAttemptDeadline` (`google-http` and `kiro-retry`) were not updated to request identity encoding for streaming requests, causing Gemini, Antigravity, and Kiro models to continue buffering.

This PR propagates the `stream` flag through `AdapterFetchContext` so these adapters correctly disable compression during streaming, restoring real-time SSE delivery.