### PR TITLE
fix(streaming): prevent bursty Responses SSE delivery

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -146,11 +146,13 @@ export function bridgeToResponsesSSE(
 
   return new ReadableStream<Uint8Array>({
     async start(controller) {
+      let emittedSinceYield = false;
       const emit = (name: string, data: Record<string, unknown>) => {
         if (closed) return;
         activity = true;
         try {
           controller.enqueue(encoder.encode(sseEvent(name, { type: name, sequence_number: seq++, ...data })));
+          emittedSinceYield = true;
         } catch {
           closed = true;
         }
@@ -399,9 +401,19 @@ export function bridgeToResponsesSSE(
       // we synthesize response.completed below, so Codex never hits the parser's
       // "stream closed before response.completed" (responses.rs) -> ApiError::Stream.
       let terminated = false;
+      let macrotaskFired = true;
+      let macrotaskTimer: ReturnType<typeof setTimeout> | undefined;
 
       try {
         for await (const event of events) {
+          if (!macrotaskFired && emittedSinceYield) {
+            await new Promise<void>(r => setTimeout(r, 0));
+            macrotaskFired = true;
+          }
+          emittedSinceYield = false;
+          macrotaskFired = false;
+          if (macrotaskTimer !== undefined) clearTimeout(macrotaskTimer);
+          macrotaskTimer = setTimeout(() => { macrotaskFired = true; macrotaskTimer = undefined; }, 0);
           activity = true;
           stallTicks = 0;
           // Compaction turns emit ONLY the synthetic compaction item + response.completed. The
@@ -650,6 +662,7 @@ export function bridgeToResponsesSSE(
       }
 
       if (beat) clearInterval(beat);
+      if (macrotaskTimer !== undefined) clearTimeout(macrotaskTimer);
 
       if (!terminated) {
         // The adapter generator ended without an explicit done/error event. Mark as incomplete

--- a/tests/bridge-live-delivery.test.ts
+++ b/tests/bridge-live-delivery.test.ts
@@ -10,6 +10,7 @@ async function* burstGenerator(count: number): AsyncGenerator<AdapterEvent> {
 }
 
 const BURST_COUNT = 40;
+const LARGE_BURST_COUNT = 200;
 
 let srv: ReturnType<typeof Bun.serve> | null = null;
 
@@ -17,9 +18,11 @@ beforeEach(() => {
   srv = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
-    fetch(_req) {
+    fetch(req) {
+      const requestedCount = Number(new URL(req.url).searchParams.get("count"));
+      const count = Number.isSafeInteger(requestedCount) && requestedCount > 0 ? requestedCount : BURST_COUNT;
       const sseStream = bridgeToResponsesSSE(
-        burstGenerator(BURST_COUNT),
+        burstGenerator(count),
         "test/model",
       );
       return new Response(sseStream, {
@@ -38,6 +41,50 @@ afterEach(() => {
 });
 
 describe("bridge live SSE delivery (issue #114 coalescing regression)", () => {
+  async function collectTextDeltaStats(res: Response): Promise<{ count: number; groups: number; maxGroup: number }> {
+    expect(res.ok).toBe(true);
+    expect(res.body).not.toBeNull();
+
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    const groups = new Map<number, number>();
+    let readIndex = 0;
+    let rawText = "";
+    let count = 0;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      const chunk = decoder.decode(value, { stream: true });
+      rawText += chunk;
+      readIndex++;
+
+      const frames = rawText.split("\n\n");
+      rawText = frames.pop() ?? "";
+
+      for (const frame of frames) {
+        const trimmed = frame.trim();
+        if (!trimmed || trimmed === "data: [DONE]") continue;
+        const dataLine = trimmed.split("\n").find((line) => line.startsWith("data: "));
+        if (!dataLine) continue;
+        try {
+          const parsed = JSON.parse(dataLine.slice(6)) as { type?: string; delta?: string };
+          if (parsed.type === "response.output_text.delta" && typeof parsed.delta === "string") {
+            count++;
+            groups.set(readIndex, (groups.get(readIndex) ?? 0) + 1);
+          }
+        } catch {
+        }
+      }
+
+      if (count >= LARGE_BURST_COUNT) break;
+    }
+    await reader.cancel();
+
+    return { count, groups: groups.size, maxGroup: Math.max(...groups.values()) };
+  }
+
   test(
     "text_delta events arrive across multiple reads, not coalesced into one end burst",
     async () => {
@@ -47,48 +94,28 @@ describe("bridge live SSE delivery (issue #114 coalescing regression)", () => {
         headers: { Accept: "text/event-stream" },
       });
 
-      expect(res.ok).toBe(true);
-      expect(res.body).not.toBeNull();
+      const stats = await collectTextDeltaStats(res);
 
-      const reader = res.body!.getReader();
-      const decoder = new TextDecoder();
+      expect(stats.count).toBe(BURST_COUNT);
+      expect(stats.groups).toBeGreaterThan(1);
+      expect(stats.maxGroup).toBeLessThanOrEqual(Math.ceil(BURST_COUNT * 0.75));
+    },
+    10_000,
+  );
 
-      const deliveries: number[] = [];
-      let readIndex = 0;
-      let rawText = "";
+  test(
+    "large synchronous replays complete within a bounded duration",
+    async () => {
+      const startedAt = performance.now();
+      const res = await fetch(`http://127.0.0.1:${srv!.port}/stream?count=${LARGE_BURST_COUNT}`, {
+        headers: { Accept: "text/event-stream" },
+      });
+      const stats = await collectTextDeltaStats(res);
+      const elapsedMs = performance.now() - startedAt;
 
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        const chunk = decoder.decode(value, { stream: true });
-        rawText += chunk;
-        readIndex++;
-
-        const frames = rawText.split("\n\n");
-        rawText = frames.pop() ?? "";
-
-        for (const frame of frames) {
-          const trimmed = frame.trim();
-          if (!trimmed || trimmed === "data: [DONE]") continue;
-          const dataLine = trimmed.split("\n").find((l) => l.startsWith("data: "));
-          if (!dataLine) continue;
-          try {
-            const parsed = JSON.parse(dataLine.slice(6)) as { type?: string; delta?: string };
-            if (parsed.type === "response.output_text.delta" && typeof parsed.delta === "string") {
-              deliveries.push(readIndex);
-            }
-          } catch {
-          }
-        }
-
-        if (deliveries.length >= BURST_COUNT) break;
-      }
-      await reader.cancel();
-
-      expect(deliveries.length).toBe(BURST_COUNT);
-
-      expect(new Set(deliveries).size).toBeGreaterThan(1);
+      expect(stats.count).toBe(LARGE_BURST_COUNT);
+      expect(stats.groups).toBeGreaterThan(1);
+      expect(elapsedMs).toBeLessThan(5_000);
     },
     10_000,
   );

--- a/tests/bridge-live-delivery.test.ts
+++ b/tests/bridge-live-delivery.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { bridgeToResponsesSSE } from "../src/bridge";
+import type { AdapterEvent } from "../src/types";
+
+async function* burstGenerator(count: number): AsyncGenerator<AdapterEvent> {
+  for (let i = 0; i < count; i++) {
+    yield { type: "text_delta", text: `chunk-${i} ` } as AdapterEvent;
+  }
+  yield { type: "done" } as AdapterEvent;
+}
+
+const BURST_COUNT = 40;
+
+let srv: ReturnType<typeof Bun.serve> | null = null;
+
+beforeEach(() => {
+  srv = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(_req) {
+      const sseStream = bridgeToResponsesSSE(
+        burstGenerator(BURST_COUNT),
+        "test/model",
+      );
+      return new Response(sseStream, {
+        headers: {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+        },
+      });
+    },
+  });
+});
+
+afterEach(() => {
+  srv?.stop(true);
+  srv = null;
+});
+
+describe("bridge live SSE delivery (issue #114 coalescing regression)", () => {
+  test(
+    "text_delta events arrive across multiple reads, not coalesced into one end burst",
+    async () => {
+      const url = `http://127.0.0.1:${srv!.port}/stream`;
+
+      const res = await fetch(url, {
+        headers: { Accept: "text/event-stream" },
+      });
+
+      expect(res.ok).toBe(true);
+      expect(res.body).not.toBeNull();
+
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+
+      const deliveries: number[] = [];
+      let readIndex = 0;
+      let rawText = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        const chunk = decoder.decode(value, { stream: true });
+        rawText += chunk;
+        readIndex++;
+
+        const frames = rawText.split("\n\n");
+        rawText = frames.pop() ?? "";
+
+        for (const frame of frames) {
+          const trimmed = frame.trim();
+          if (!trimmed || trimmed === "data: [DONE]") continue;
+          const dataLine = trimmed.split("\n").find((l) => l.startsWith("data: "));
+          if (!dataLine) continue;
+          try {
+            const parsed = JSON.parse(dataLine.slice(6)) as { type?: string; delta?: string };
+            if (parsed.type === "response.output_text.delta" && typeof parsed.delta === "string") {
+              deliveries.push(readIndex);
+            }
+          } catch {
+          }
+        }
+
+        if (deliveries.length >= BURST_COUNT) break;
+      }
+      await reader.cancel();
+
+      expect(deliveries.length).toBe(BURST_COUNT);
+
+      expect(new Set(deliveries).size).toBeGreaterThan(1);
+    },
+    10_000,
+  );
+});


### PR DESCRIPTION
## Problem

Issue #114 remained partially unresolved after #115. The upstream `Accept-Encoding: identity` change addressed compressed provider responses, but the Codex Desktop app-server could still receive the final answer as one burst when the bridge processed many adapter events in a single JavaScript turn.

The observable symptom was:

- direct curl requests streamed progressively;
- the real Codex app-server received hundreds of `item/agentMessage/delta` notifications within roughly 30 ms;
- the proxy's SSE frames were semantically correct, but the HTTP layer could coalesce same-turn enqueues before flushing them downstream.

## Root cause

`bridgeToResponsesSSE` consumes an async adapter event burst inside the `ReadableStream.start()` task. When the upstream response body supplied many parsed text deltas without an event-loop gap, the bridge called `controller.enqueue()` repeatedly in the same turn. Bun then exposed the queued frames to the downstream client as one large delivery.

This explains why the previous compression fix could pass a simple curl reproduction while the full Codex request shape still appeared buffered.

## Fix

- Track whether the bridge emitted output during the current turn.
- Detect when the next adapter event arrives before the scheduled macrotask boundary.
- Yield once with a zero-delay timer so Bun can flush queued SSE bytes before processing the next same-turn event.
- Preserve normal provider-paced streams: when the upstream already waits between events, the scheduled timer overlaps that wait and adds no intentional fixed pacing.

## Regression coverage

`tests/bridge-live-delivery.test.ts` starts a real Bun HTTP server, feeds the bridge 40 synchronous `text_delta` events, reads the response through `fetch()`, and asserts that deltas arrive across multiple reads rather than one end burst.

## Verification

- Focused bridge, SSE, header-policy, and openai-chat suites: 83 passed.
- `bun x tsc --noEmit`: passed.
- `git diff --check`: passed.
- Full suite rerun: 2,398 passed, 3 skipped, 1 unrelated failure.
- Remaining unrelated failure: Windows cannot create the symlink used by `tests/claude-agents-inject.test.ts:92` (`EPERM`) without symlink privileges.

## Risk and rollout

The change only affects bursty streaming delivery and keeps event ordering, terminal handling, cancellation, and heartbeat behavior unchanged. It may increase the number of downstream flush opportunities for providers that deliver many deltas in one response-body read, which is the intended behavior for interactive streaming.

Please retest with the real macOS Codex Desktop app-server path from issue #114.