### PR TITLE
fix: use PROD_API for Antigravity onboarding

### DIFF
--- a/src/oauth/google-antigravity.ts
+++ b/src/oauth/google-antigravity.ts
@@ -21,7 +21,6 @@ const CLIENT_SECRET = process.env.GOOGLE_ANTIGRAVITY_CLIENT_SECRET
 const AUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth";
 const TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
 const PROD_API = "https://cloudcode-pa.googleapis.com";
-const DAILY_API = "https://daily-cloudcode-pa.googleapis.com";
 const API_VERSION = "v1internal";
 const SCOPES = [
   "https://www.googleapis.com/auth/cloud-platform",
@@ -106,7 +105,7 @@ async function loadCodeAssistProject(accessToken: string, signal?: AbortSignal):
 async function onboardProject(accessToken: string, signal?: AbortSignal): Promise<string | undefined> {
   for (let attempt = 0; attempt < ONBOARD_ATTEMPTS; attempt++) {
     if (signal?.aborted) throw signal.reason ?? new Error("Antigravity onboarding aborted");
-    const response = await fetch(`${DAILY_API}/${API_VERSION}:onboardUser`, {
+    const response = await fetch(`${PROD_API}/${API_VERSION}:onboardUser`, {
       method: "POST",
       headers: { Authorization: `Bearer ${accessToken}`, Accept: "*/*", "Content-Type": "application/json", "User-Agent": antigravityUserAgent(), "x-goog-api-client": ANTIGRAVITY_GOOG_API_CLIENT_UA },
       body: JSON.stringify({ tier_id: "free-tier", metadata: { ide_type: "ANTIGRAVITY", ide_name: "antigravity", ide_version: antigravityUserAgent() } }),


### PR DESCRIPTION
Here is the English version of the PR description:

***

### **Title**
fix: use PROD_API instead of DAILY_API for Antigravity onboarding

### **Description**

**Background**
When using this project to reverse proxy Antigravity (Cloud Code Assist), new accounts that haven't been onboarded encounter the following error during login, preventing them from using the service:
> `google-antigravity 登录错误：Antigravity login could not discover a Cloud Code Assist project for this account. Ensure the account has Antigravity/Cloud Code Assist access and try again.`

Meanwhile, existing accounts that have already been onboarded work perfectly fine.

**Root Cause Analysis**
When an account logs in, the system first calls `loadCodeAssistProject` to fetch the Project ID. This call hits the production environment (`PROD_API`). For new accounts, this request naturally returns empty, and the code correctly falls back to the `onboardProject` (onboarding) logic.

However, in the `onboardProject` function, the API request was incorrectly directed to the testing environment `DAILY_API` (`https://daily-cloudcode-pa.googleapis.com`) instead of `PROD_API`. This caused the onboarding process for new accounts to fail or mismatch environments, making it impossible to successfully discover or create the required production project, which ultimately threw the exception mentioned above.

**Changes**
- In the `onboardProject` method of `src/oauth/google-antigravity.ts`, corrected the called endpoint from `DAILY_API` to `PROD_API`.
- Removed the unused `DAILY_API` constant from the codebase.

**Testing**
- [x] New accounts that have not initialized Cloud Code Assist can now properly go through the onboarding flow and log in successfully.
- [x] Existing accounts with an established project continue to work as expected without any impact.