### PR TITLE
gui: unify design system and typography

### DIFF
--- a/docs/adr/0004-gui-toggle-contrast-and-nav-spacing.md
+++ b/docs/adr/0004-gui-toggle-contrast-and-nav-spacing.md
@@ -1,0 +1,28 @@
+# ADR 0004: GUI toggle contrast and sidebar item spacing
+
+## Status
+
+Accepted
+
+## Context
+
+In dark mode, enabled switches used the monochrome accent for the track. The bright track could
+visually merge with the switch knob, making the enabled state and knob position difficult to read.
+Sidebar navigation items also had no vertical separation, so adjacent hover and active backgrounds
+appeared as one continuous block.
+
+## Decision
+
+Keep the existing shared switch components and CSS tokens. Use the existing dark-theme success
+green for enabled switch tracks while retaining a dark knob, and make `.switch` consume the same
+toggle tokens as the label-based `.toggle` control.
+
+Lay out the sidebar `nav` as a vertical flex container with a 4px gap. This preserves each item's
+full click target while separating adjacent hover and active surfaces.
+
+## Consequences
+
+- Enabled switches have distinct track and knob silhouettes in dark mode.
+- Both switch implementations share one enabled-state color rule.
+- Sidebar hover and active states remain visually separate without adding divider noise.
+- No component API or dependency changes are required.

--- a/docs/adr/0005-gui-design-token-system.md
+++ b/docs/adr/0005-gui-design-token-system.md
@@ -1,0 +1,49 @@
+# ADR 0005: GUI uses role-based CSS design tokens
+
+## Status
+
+Accepted
+
+## Context
+
+The GUI accumulated thirteen font sizes, several near-duplicate weights, page-local radii, and
+inline typography values. Those values made equivalent labels, controls, helper text, and machine
+data render differently across pages and made dark/light maintenance harder.
+
+The GUI must also remain usable when served locally or offline, including Korean locales. A remote
+font or runtime styling dependency would add network and packaging failure modes to a management
+surface that should remain available while the proxy is being repaired.
+
+## Decision
+
+Use native CSS custom properties in `gui/src/styles.css` as the runtime source of truth. Define:
+
+- semantic light/dark color tokens;
+- a Korean-safe UI font stack and a separate code/data font stack;
+- eight role-based type sizes, four weights, and four line heights;
+- a 4px-based spacing scale;
+- shared radius, control height, icon size, and motion tokens;
+- small typography utility classes for TSX contexts that previously used inline numeric values.
+
+Keep component styling in the existing CSS and React primitives instead of adding CSS-in-JS,
+Tailwind, a component framework, or a remote font. Document the contract under
+`docs/design-system/` and require new visual values to use tokens.
+
+For local integrated visual QA, use Vite's opt-in `OPENCODEX_PROXY_TARGET` proxy so the development
+GUI can call the running management API through the same origin without changing production output.
+
+## Alternatives considered
+
+- **CSS-in-JS:** strong component co-location, but adds runtime and migration cost for no functional gain.
+- **Utility framework:** broad ecosystem, but would duplicate the existing CSS and enlarge the change surface.
+- **Remote or bundled web font:** stronger cross-platform identity, but remote loading harms offline reliability
+  and bundling adds package size/licensing work. System Korean fallbacks are sufficient for this console.
+- **Page-local cleanup only:** smaller initial diff, but leaves the inconsistency mechanism intact.
+
+## Consequences
+
+- Equivalent UI roles render consistently across all pages and locales.
+- Dark/light changes can be made at the token layer.
+- New contributors have a documented component and token contract.
+- Existing layout-specific inline values remain allowed when they are algorithmic rather than visual roles.
+- A future branded font can be introduced by changing `--font-ui` after packaging and licensing are decided.

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -1,0 +1,71 @@
+# OpenCodex GUI Design System
+
+OpenCodex 관리 GUI의 시각 언어와 구현 규칙을 정의한다. 목표는 화면마다 새 스타일을
+만드는 것이 아니라, 같은 역할의 요소가 어떤 페이지에서도 같은 글꼴, 크기, 간격,
+표면, 상태 표현을 사용하게 하는 것이다.
+
+## 원칙
+
+1. **역할이 값보다 먼저다.** `13px` 대신 `control`, `12px` 대신 `label`처럼 UI 역할을 선택한다.
+2. **기계 데이터만 monospace를 쓴다.** 모델 ID, URL, 버전, 토큰 수, 코드에 한정한다.
+3. **4px 그리드를 따른다.** 반복 간격은 spacing token을 우선 사용한다.
+4. **상태에는 의미 색상을 쓴다.** 성공/활성은 green, 경고는 amber, 위험은 red다.
+5. **라이트와 다크를 함께 설계한다.** 색상은 `light-dark()` 기반 semantic token으로 정의한다.
+6. **새 의존성보다 네이티브 CSS를 우선한다.** 디자인 시스템은 런타임 라이브러리 없이 동작한다.
+
+## 소스 구조
+
+```text
+gui/src/styles.css
+├── semantic color tokens
+├── spacing / radius / motion tokens
+├── typography tokens and utilities
+├── app shell and responsive rules
+└── shared component styles
+
+gui/src/ui.tsx
+├── Switch
+├── Field
+├── Select
+└── EmptyState
+
+docs/design-system/
+├── README.md
+├── foundations.md
+├── components.md
+└── contributing.md
+```
+
+실행 시점의 유일한 스타일 소스는 `gui/src/styles.css`다. 이 폴더의 문서는 해당 코드의
+사용 계약을 설명하며, 토큰 값이 바뀌면 코드와 문서를 같은 변경에서 갱신해야 한다.
+
+## 빠른 사용법
+
+```tsx
+<h2 className="text-title font-semibold">Models</h2>
+<p className="text-body muted">라우팅 가능한 모델을 관리합니다.</p>
+<code className="mono text-label">openrouter/gpt-5</code>
+<span className="badge badge-green">active</span>
+```
+
+```css
+.feature-row {
+  display: flex;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  transition: background var(--motion-fast);
+}
+```
+
+## 문서 안내
+
+- [Foundations](./foundations.md): 색상, 폰트, 크기, 간격, 반경, 모션
+- [Components](./components.md): 버튼, 입력, 패널, 표, 배지, 토글, 내비게이션
+- [Contributing](./contributing.md): 새 화면/컴포넌트 추가 규칙과 QA 체크리스트
+
+## 관련 결정 기록
+
+- [ADR 0004](../adr/0004-gui-toggle-contrast-and-nav-spacing.md)
+- [ADR 0005](../adr/0005-gui-design-token-system.md)

--- a/docs/design-system/components.md
+++ b/docs/design-system/components.md
@@ -1,0 +1,77 @@
+# Components
+
+## App shell and navigation
+
+- 데스크톱은 232px sidebar와 main content의 2열 구조다.
+- 760px 이하에서는 sidebar가 off-canvas drawer로 전환된다.
+- `.nav-item`은 아이콘 17px, control text, 4px 세로 간격을 사용한다.
+- hover와 active는 같은 surface family를 쓰되 active는 semibold로 구분한다.
+- 메뉴마다 margin을 직접 추가하지 않고 `.sidebar nav`의 `gap`을 사용한다.
+
+## Buttons
+
+| 변형 | 클래스 | 용도 |
+|---|---|---|
+| Primary | `.btn.btn-primary` | 저장, 로그인, 확정 |
+| Ghost | `.btn.btn-ghost` | 보조 액션, 취소 |
+| Danger | `.btn.btn-danger` | 삭제, 중단 |
+| Small | `.btn.btn-sm` | 필터, 행 내부 액션 |
+| Icon | `.btn-icon` | 닫기, 도움말, 제거 |
+
+버튼은 기본적으로 control text와 medium weight를 사용한다. 액션 중요도는 크기가 아니라
+색상 변형으로 표현한다. 아이콘 전용 버튼에는 반드시 접근 가능한 label/title을 제공한다.
+
+## Inputs and selects
+
+- `.input`, `.select-trigger`, `.select-option`, `.field-label`을 재사용한다.
+- 라벨은 label text, 입력값은 control text를 사용한다.
+- placeholder는 `--faint`, 값은 `--text`, 오류는 `--red`를 사용한다.
+- focus는 border와 `--accent-soft` ring을 함께 사용한다.
+- 네이티브 select를 새로 만들기보다 `ui.tsx`의 `Select`를 우선한다.
+
+## Cards and panels
+
+- `.card`: 경계와 배경만 제공한다. 내부 padding은 문맥이 소유한다.
+- `.panel`: 기본 18px padding이 포함된 독립 구획이다.
+- `.panel-accent`: 선택되거나 강조된 구획이다.
+- 카드 중첩은 최대 한 단계로 제한한다. 정보를 나누기 위해 무조건 카드부터 추가하지 않는다.
+
+## Tables and rows
+
+- `.tbl`/`.tbl-wrap`은 데이터 표의 기본 조합이다.
+- 본문은 control text, 헤더는 label text + medium weight다.
+- 숫자 열은 `.num` 또는 `.mono`로 tabular 숫자를 사용한다.
+- 작은 화면에서는 열을 억지로 접지 않고 `.tbl-wrap`에서 가로 스크롤한다.
+
+## Badges and status
+
+- `.badge-green`: 성공, 연결됨, 활성
+- `.badge-amber`: 경고, 다음 적용, 주의 필요
+- `.badge-muted`: 중립 메타데이터
+- `.notice-ok/.notice-err/.notice-warn`: 한 줄 이상의 상태 메시지
+
+배지는 핵심 본문을 대신하지 않는다. 매우 작은 `.text-micro`는 짧은 상태 문자열에만 허용한다.
+
+## Toggle and switch
+
+두 마크업 형태가 있지만 동일한 토큰을 사용한다.
+
+- 버튼형: `ui.tsx`의 `Switch`, `.switch`, `.knob`
+- label/input형: `.toggle`, `.slider`
+
+켜짐은 `--toggle-on-bg`, 꺼짐은 `--toggle-off-bg`, 핸들은 `--toggle-dot-color`를 사용한다.
+다크 모드 활성 상태는 녹색 트랙과 짙은 핸들로 분리한다. 화면별 토글 색상 override는 금지한다.
+
+## Icons
+
+- 기본 아이콘은 `icons.tsx`의 동일한 outline family를 사용한다.
+- 기본 크기는 `--icon-md(16px)`, 조밀한 메타 UI는 `--icon-sm(14px)`, 상단 액션은 `--icon-lg(20px)`다.
+- 아이콘만으로 의미가 불명확하면 텍스트를 함께 배치한다.
+- active 아이콘은 `--text`, inactive 아이콘은 `--faint`를 사용한다.
+
+## Responsive behavior
+
+- 760px 이하: drawer navigation, 세로형 form row, 44px 터치 대상
+- 640px 이하: dashboard stat 2열
+- 데이터 표와 heatmap은 정보 손실보다 가로 스크롤을 우선한다.
+- 모바일에서 제목/본문 크기를 임의 축소하지 않는다. 같은 역할은 같은 type token을 유지한다.

--- a/docs/design-system/contributing.md
+++ b/docs/design-system/contributing.md
@@ -1,0 +1,62 @@
+# Design System Contribution Guide
+
+## 새 UI를 만들기 전
+
+1. `gui/src/ui.tsx`와 `gui/src/styles.css`에 같은 역할의 컴포넌트가 있는지 검색한다.
+2. 기존 컴포넌트를 변형으로 확장할지, 새 컴포넌트가 필요한지 판단한다.
+3. 새 값이 아니라 기존 semantic token으로 표현 가능한지 확인한다.
+4. 새 토큰이 필요하면 최소 두 곳에서 재사용될 역할인지 설명하고 ADR 또는 Decision Log를 남긴다.
+
+## 금지 규칙
+
+- TSX에 숫자형 `fontSize`, `fontWeight`, `lineHeight`, `letterSpacing` 추가
+- hex/rgb 색상을 페이지 컴포넌트에 직접 추가
+- `borderRadius: 999`처럼 토큰을 우회하는 값 추가
+- 한 화면만을 위한 새로운 폰트 family 추가
+- 기존 `Switch`, `Select`, `.btn`, `.card`, `.panel`, `.badge`와 중복되는 컴포넌트 생성
+- hover만 있고 keyboard focus가 없는 인터랙션 추가
+
+## 허용되는 예외
+
+차트 셀 크기, 가상화 row height, viewport 계산처럼 데이터/알고리즘에 종속된 값은 인라인으로
+남길 수 있다. 다만 시각적 역할을 나타내는 값은 반드시 token을 사용한다.
+
+## 권장 구현 예시
+
+```tsx
+<div className="panel">
+  <div className="text-body font-semibold">설정 이름</div>
+  <div className="muted text-control leading-body">설정 설명</div>
+  <Switch on={enabled} onClick={toggle} label="설정 이름" />
+</div>
+```
+
+## 검증 체크리스트
+
+- [ ] 라이트/다크에서 텍스트와 상태 색상이 읽힌다.
+- [ ] 페이지 제목, 본문, 라벨, 코드가 역할별 type token을 사용한다.
+- [ ] 데스크톱과 760px 이하 viewport에서 overflow/clipping이 없다.
+- [ ] hover, active, focus-visible, disabled 상태가 존재한다.
+- [ ] 토글과 입력이 실제 상태를 변경한다.
+- [ ] `bun run lint`가 오류 없이 끝난다.
+- [ ] `bun run build`가 성공한다.
+- [ ] Playwright 또는 Browser로 console error와 framework overlay가 없음을 확인한다.
+- [ ] 시각 변경 시 전/후 또는 기준/구현 스크린샷을 `view_image`로 직접 비교한다.
+
+## 리뷰 명령
+
+```bash
+rg -n 'font-size:\s*[0-9]|font-weight:\s*[0-9]' gui/src/styles.css
+rg -n 'fontSize:\s*[0-9]|fontWeight:\s*[0-9]|lineHeight:\s*[0-9]' gui/src --glob '*.tsx'
+rg -n 'border-radius:\s*[0-9]|borderRadius:\s*[0-9]' gui/src --glob '*.{css,tsx}'
+cd gui && bun run lint && bun run build
+```
+
+첫 세 명령은 결과가 없어야 한다.
+
+실제 로컬 API와 함께 화면을 확인할 때는 Vite의 opt-in proxy를 사용한다.
+
+```bash
+cd gui
+OPENCODEX_PROXY_TARGET=http://127.0.0.1:10101 bun run dev --host 127.0.0.1
+```

--- a/docs/design-system/foundations.md
+++ b/docs/design-system/foundations.md
@@ -1,0 +1,84 @@
+# Foundations
+
+## Color
+
+색상 토큰은 역할을 나타낸다. 컴포넌트에서 hex 값을 직접 사용하지 않는다.
+
+| 역할 | 토큰 | 라이트 | 다크 |
+|---|---|---:|---:|
+| 앱 배경 | `--bg` | `#ffffff` | `#212121` |
+| 사이드바 | `--rail` | `#f9f9f9` | `#171717` |
+| 기본 표면 | `--surface` | `#ffffff` | `#262626` |
+| 올라온 표면 | `--raised` | `#f4f4f4` | `#303030` |
+| 기본 텍스트 | `--text` | `#0d0d0d` | `#ececec` |
+| 보조 텍스트 | `--muted` | `#6e6e6e` | `#a6a6a6` |
+| 약한 텍스트 | `--faint` | `#707070` | `#9a9a9a` |
+| 성공/활성 | `--green` | `#0a7d5c` | `#4ecb9d` |
+| 경고 | `--amber` | `#9a4a08` | `#fbbf24` |
+| 위험 | `--red` | `#b91c1c` | `#f87171` |
+
+`--accent`는 기본 액션과 포커스에 사용한다. 활성 토글은 다크 모드에서 트랙과 핸들이
+겹쳐 보이지 않도록 `--toggle-on-bg`와 `--toggle-dot-color`를 사용한다.
+
+## Typography
+
+### Font families
+
+- `--font-ui`: 일반 UI, 제목, 본문, 버튼, 입력. Pretendard/Noto Sans KR/Apple SD Gothic Neo/Malgun Gothic을 포함해 한글 fallback을 보장한다.
+- `--font-code`: 모델 ID, URL, 버전, 토큰 수, 로그, 코드. 숫자는 tabular 형태로 정렬한다.
+
+외부 CDN 폰트를 사용하지 않는다. 프록시 관리 화면은 오프라인에서도 열려야 하고, 폰트
+다운로드 실패가 레이아웃 이동이나 한글 누락으로 이어지면 안 되기 때문이다.
+
+### Type scale
+
+| 역할 | 클래스 | 토큰 | 크기 | 대표 용도 |
+|---|---|---|---:|---|
+| Micro | `.text-micro` | `--text-micro` | 10px | 매우 작은 상태 배지 |
+| Caption | `.text-caption` | `--text-caption` | 11px | 메타데이터, 보조 수치 |
+| Label | `.text-label` | `--text-label` | 12px | 필드 라벨, 표 헤더, 코드 |
+| Control | `.text-control` | `--text-control` | 13px | 버튼, 메뉴, 필터, 알림 |
+| Body | `.text-body` | `--text-body` | 14px | 본문, 카드 제목 |
+| Subtitle | `.text-subtitle` | `--text-subtitle` | 16px | 모달 제목, 브랜드명 |
+| Title | `.text-title` | `--text-title` | 20px | 페이지 제목, 주요 수치 |
+| Display | `.text-display` | `--text-display` | 24px | 제한적인 대형 수치/빈 상태 |
+
+굵기는 `regular(400)`, `medium(500)`, `semibold(600)`, `bold(700)` 네 단계만 사용한다.
+행간은 `tight(1.2)`, `ui(1.35)`, `body(1.5)`, `relaxed(1.6)` 네 단계만 사용한다.
+
+## Spacing
+
+기본 단위는 4px이다.
+
+| 토큰 | 값 | 토큰 | 값 |
+|---|---:|---|---:|
+| `--space-0-5` | 2px | `--space-1` | 4px |
+| `--space-1-5` | 6px | `--space-2` | 8px |
+| `--space-3` | 12px | `--space-4` | 16px |
+| `--space-5` | 20px | `--space-6` | 24px |
+| `--space-8` | 32px | `--space-10` | 40px |
+| `--space-12` | 48px | `--space-16` | 64px |
+
+컴팩트 컨트롤 내부는 4–8px, 카드 내부는 12–20px, 페이지 구획은 24–64px 범위를 사용한다.
+
+## Radius and controls
+
+| 토큰 | 값 | 용도 |
+|---|---:|---|
+| `--radius-2xs` | 4px | 작은 차트 셀, 포커스 보정 |
+| `--radius-xs` | 6px | 칩, 작은 아이콘 표면 |
+| `--radius-sm` | 8px | 입력, 메뉴 항목, 작은 카드 |
+| `--radius` | 12px | 기본 카드/패널 |
+| `--radius-lg` | 16px | 모달 |
+| `--radius-round` | 50% | 점, 원형 아이콘 |
+| `--radius-pill` | 999px | 버튼, 토글, segmented control |
+
+컨트롤 높이는 `28/34/40/44px` 단계다. 44px는 모바일 터치 영역에 사용한다.
+
+## Motion
+
+- `--motion-fast: 120ms`: hover, border, color 변화
+- `--motion-normal: 180ms`: drawer, toggle, 위치 변화
+- `prefers-reduced-motion: reduce`에서는 transition과 animation을 제거한다.
+
+모션은 상태 이해를 돕는 범위에서만 사용하며 장식 목적의 반복 애니메이션은 추가하지 않는다.

--- a/gui/src/components/AddProviderModal.tsx
+++ b/gui/src/components/AddProviderModal.tsx
@@ -240,33 +240,32 @@ export default function AddProviderModal({
                   </div>
                 </button>
               ))}
-              {filtered.length === 0 && <div className="muted" style={{ fontSize: 13, padding: 8 }}>No match.</div>}
+              {filtered.length === 0 && <div className="muted text-control" style={{ padding: 8 }}>No match.</div>}
             </div>
           </>
         ) : form && (
           preset.auth === "oauth" && form.authMode === "oauth" ? (
             // OAuth login pane
             <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-              <div className="muted" style={{ fontSize: 13 }}>{preset.note ?? "Log in with your account — no API key needed."}</div>
+              <div className="muted text-control">{preset.note ?? "Log in with your account — no API key needed."}</div>
               {oauthSupported.includes(preset.oauthProvider ?? "") ? (
                 <button className="btn btn-primary" onClick={() => loginOAuth(preset.oauthProvider!)} disabled={oauthBusy}
-                  style={{ width: "100%", padding: "12px 16px", fontSize: 14 }}>
+                  style={{ width: "100%", padding: "12px 16px" }}>
                   <IconLock />{oauthBusy ? "Waiting for browser…" : `Log in with ${preset.label}`}
                 </button>
               ) : (
-                <div style={{ fontSize: 13, color: "var(--amber)", background: "var(--amber-soft)", border: "1px solid var(--amber)", borderRadius: "var(--radius-sm)", padding: "10px 12px" }}>
+                <div className="text-control" style={{ color: "var(--amber)", background: "var(--amber-soft)", border: "1px solid var(--amber)", borderRadius: "var(--radius-sm)", padding: "10px 12px" }}>
                   OAuth login for {preset.label} arrives in the next update. Use an API key for now.
                 </div>
               )}
-              {oauthMsg && <div style={{ fontSize: 12, color: /error|update|timed/.test(oauthMsg) ? "var(--amber)" : "var(--accent-hover)" }}>{oauthMsg}</div>}
+              {oauthMsg && <div className="text-label" style={{ color: /error|update|timed/.test(oauthMsg) ? "var(--amber)" : "var(--accent-hover)" }}>{oauthMsg}</div>}
               {oauthBusy && (
                 <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-                  <div className="muted" style={{ fontSize: 12 }}>
+                  <div className="muted text-label">
                     {t("prov.pasteRedirectHint")}
                   </div>
                   <div style={{ display: "flex", gap: 8 }}>
                     <input
-                      className="input"
                       type="text"
                       autoComplete="off"
                       spellCheck={false}
@@ -281,7 +280,8 @@ export default function AddProviderModal({
                       placeholder={t("prov.pasteRedirect")}
                       aria-label={t("prov.pasteRedirect")}
                       disabled={manualCodeBusy}
-                      style={{ flex: 1, fontSize: 12 }}
+                      className="input text-label"
+                      style={{ flex: 1 }}
                     />
                     <button
                       className="btn btn-ghost"
@@ -293,7 +293,7 @@ export default function AddProviderModal({
                     </button>
                   </div>
                   {manualCodeMsg && (
-                    <div style={{ fontSize: 12, color: manualCodeOk ? "var(--accent-hover)" : "var(--amber)" }}>
+                    <div className="text-label" style={{ color: manualCodeOk ? "var(--accent-hover)" : "var(--amber)" }}>
                       {manualCodeMsg}
                     </div>
                   )}
@@ -311,18 +311,18 @@ export default function AddProviderModal({
               {!isCustom && !isLocal && !preset.keyOptional && preset.note && (
                 <details className="setup-guide">
                   <summary>Setup guide</summary>
-                  <ol style={{ margin: "8px 0 0", paddingLeft: 18, fontSize: 12, color: "var(--muted)", lineHeight: 1.7 }}>
+                  <ol className="text-label leading-relaxed" style={{ margin: "8px 0 0", paddingLeft: 18, color: "var(--muted)" }}>
                     <li>Go to <a href={preset.dashboardUrl} target="_blank" rel="noreferrer">{preset.label} dashboard</a> and copy your API key</li>
                     <li>Paste it in the API key field below</li>
                     <li>Click Add provider — models are auto-discovered</li>
                   </ol>
-                  {preset.note && <div style={{ fontSize: 12, color: "var(--muted)", marginTop: 6, fontStyle: "italic" }}>{preset.note}</div>}
+                  {preset.note && <div className="text-label" style={{ color: "var(--muted)", marginTop: 6, fontStyle: "italic" }}>{preset.note}</div>}
                 </details>
               )}
               <Field label="Provider name">
                 <input className="input" value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} placeholder="e.g. openrouter" />
               </Field>
-              {dup && <div style={{ fontSize: 12, color: "var(--amber)" }}>Provider "{form.name.trim()}" exists and will be overwritten.</div>}
+              {dup && <div className="text-label" style={{ color: "var(--amber)" }}>Provider "{form.name.trim()}" exists and will be overwritten.</div>}
               <Field label="Adapter">
                 <select className="input" value={form.adapter} onChange={e => setForm({ ...form, adapter: e.target.value })}>
                   {["openai-responses", "openai-chat", "anthropic", "google", "azure-openai", "cursor"].map(a => <option key={a} value={a}>{a}</option>)}
@@ -332,21 +332,21 @@ export default function AddProviderModal({
                 <input className="input" value={form.baseUrl} onChange={e => setForm({ ...form, baseUrl: e.target.value })} placeholder="https://..." />
               </Field>
               {form.authMode === "forward" ? (
-                <div style={{ fontSize: 12, color: "var(--green)", background: "var(--green-soft)", border: "1px solid var(--green)", borderRadius: "var(--radius-sm)", padding: "8px 10px" }}>
+                <div className="text-label" style={{ color: "var(--green)", background: "var(--green-soft)", border: "1px solid var(--green)", borderRadius: "var(--radius-sm)", padding: "8px 10px" }}>
                   No key needed — the proxy forwards your <code className="chip">codex login</code> credentials to this provider.
                 </div>
               ) : form.authMode === "local" ? (
-                <div style={{ fontSize: 12, color: "var(--amber)", background: "var(--amber-soft)", border: "1px solid var(--amber)", borderRadius: "var(--radius-sm)", padding: "8px 10px", lineHeight: 1.55 }}>
+                <div className="text-label leading-relaxed" style={{ color: "var(--amber)", background: "var(--amber-soft)", border: "1px solid var(--amber)", borderRadius: "var(--radius-sm)", padding: "8px 10px" }}>
                   No API key is stored. This adds Cursor's static public model catalog for Codex, but live Cursor transport and native file/shell execution remain disabled until audited.
                 </div>
               ) : preset.keyOptional ? (
-                <div style={{ fontSize: 12, color: "var(--green)", background: "var(--green-soft)", border: "1px solid var(--green)", borderRadius: "var(--radius-sm)", padding: "10px 12px", lineHeight: 1.6 }}>
+                <div className="text-label leading-relaxed" style={{ color: "var(--green)", background: "var(--green-soft)", border: "1px solid var(--green)", borderRadius: "var(--radius-sm)", padding: "10px 12px" }}>
                   <strong>Free tier</strong> — {preset.note ?? "No API key required. Works out of the box."}
                 </div>
               ) : (
                 <>
                   {preset.dashboardUrl && (
-                    <a href={preset.dashboardUrl} target="_blank" rel="noreferrer" style={{ fontSize: 12, display: "inline-flex", alignItems: "center", gap: 5 }}>
+                    <a className="text-label" href={preset.dashboardUrl} target="_blank" rel="noreferrer" style={{ display: "inline-flex", alignItems: "center", gap: 5 }}>
                       <IconKey style={{ width: 14, height: 14 }} />Get your {preset.label} API key<IconExternal style={{ width: 13, height: 13 }} />
                     </a>
                   )}
@@ -358,7 +358,7 @@ export default function AddProviderModal({
               <Field label="Default model (optional)">
                 <input className="input" value={form.defaultModel} onChange={e => setForm({ ...form, defaultModel: e.target.value })} placeholder="e.g. gpt-5.5" />
               </Field>
-              {error && <div role="alert" style={{ fontSize: 13, color: "var(--red)" }}>{error}</div>}
+              {error && <div className="text-control" role="alert" style={{ color: "var(--red)" }}>{error}</div>}
               <div style={{ display: "flex", gap: 8, marginTop: 4, alignItems: "center" }}>
                 <button className="btn btn-primary" onClick={submit} disabled={saving}>{saving ? "Adding…" : "Add provider"}</button>
                 {preset.auth === "oauth" && <button className="link-btn" onClick={() => { setForm({ ...form, authMode: "oauth" }); setError(""); }}>← Use OAuth login</button>}

--- a/gui/src/pages/ClaudeCode.tsx
+++ b/gui/src/pages/ClaudeCode.tsx
@@ -193,7 +193,8 @@ export default function ClaudeCode({ apiBase }: { apiBase: string }) {
               const v = e.target.value;
               setState({ ...state, fastMode: v === "auto" ? null : v === "on" });
             }}
-            style={{ padding: "5px 10px", borderRadius: "var(--radius-xs)", border: "1px solid var(--border)", background: "var(--surface)", color: "var(--text)", fontSize: 12.5, fontWeight: 500 }}
+            className="text-label font-medium"
+            style={{ padding: "5px 10px", borderRadius: "var(--radius-xs)", border: "1px solid var(--border)", background: "var(--surface)", color: "var(--text)" }}
           >
             <option value="auto">{t("claude.fastAuto")}</option>
             <option value="on">{t("claude.fastOn")}</option>
@@ -284,16 +285,16 @@ export default function ClaudeCode({ apiBase }: { apiBase: string }) {
       </div>
 
       <div className="h-section">{t("claude.quickstart")}</div>
-      <p className="muted" style={{ fontSize: 12.5, margin: "0 0 8px" }}><Trans k="claude.quickstartHint" cmd="ocx claude" /></p>
+      <p className="muted text-label" style={{ margin: "0 0 8px" }}><Trans k="claude.quickstartHint" cmd="ocx claude" /></p>
       <pre className="mono card" style={{ padding: "10px 14px", overflowX: "auto", margin: 0 }}>ocx claude</pre>
       {/* Advanced manual setup: collapsed by default (audit 080 UX-1). */}
       <details style={{ margin: "10px 0 0" }}>
-        <summary className="muted" style={{ fontSize: 12.5, cursor: "pointer", padding: "2px 2px" }}>{t("claude.manualEnv")}</summary>
-        <pre className="mono card" style={{ padding: "10px 14px", overflowX: "auto", margin: "6px 0 0", fontSize: 12 }}>{manualEnv}</pre>
+        <summary className="muted text-label" style={{ cursor: "pointer", padding: "2px 2px" }}>{t("claude.manualEnv")}</summary>
+        <pre className="mono card text-label" style={{ padding: "10px 14px", overflowX: "auto", margin: "6px 0 0" }}>{manualEnv}</pre>
       </details>
 
       <div className="h-section">{t("claude.smallFastModel")}</div>
-      <p className="muted" style={{ fontSize: 12.5, margin: "0 0 8px" }}>{t("claude.smallFastModelHint")}</p>
+      <p className="muted text-label" style={{ margin: "0 0 8px" }}>{t("claude.smallFastModelHint")}</p>
       <Select
         value={state.smallFastModel}
         options={modelOptions}
@@ -303,7 +304,7 @@ export default function ClaudeCode({ apiBase }: { apiBase: string }) {
       />
 
       <div className="h-section">{t("claude.modelMap")} <span className="count">{rows.length}</span></div>
-      <p className="muted" style={{ fontSize: 12.5, margin: "0 0 8px" }}>{t("claude.modelMapHint")}</p>
+      <p className="muted text-label" style={{ margin: "0 0 8px" }}>{t("claude.modelMapHint")}</p>
       <div className="stack" style={{ gap: 8 }}>
         {rows.map((row, i) => (
           <div key={i} className="row" style={{ gap: 8 }}>
@@ -340,9 +341,9 @@ export default function ClaudeCode({ apiBase }: { apiBase: string }) {
       </div>
 
       <div className="h-section">{t("claude.aliases")} <span className="count">{state.aliases.length}</span></div>
-      <p className="muted" style={{ fontSize: 12.5, margin: "0 0 8px" }}>{t("claude.aliasesHint")}</p>
+      <p className="muted text-label" style={{ margin: "0 0 8px" }}>{t("claude.aliasesHint")}</p>
       {state.aliases.length === 0 ? (
-        <div className="muted" style={{ fontSize: 12.5 }}>{t("claude.none")}</div>
+        <div className="muted text-label">{t("claude.none")}</div>
       ) : (
         // Grouped by provider (audit 080 UX-2): one scroll area, group labels first.
         <div className="stack" style={{ gap: 6, maxHeight: 320, overflowY: "auto" }}>
@@ -355,12 +356,12 @@ export default function ClaudeCode({ apiBase }: { apiBase: string }) {
             }, new Map<string, { id: string; display_name: string }[]>()),
           ).map(([provider, rows]) => (
             <div key={provider}>
-              <div className="muted" style={{ fontSize: 11.5, fontWeight: 600, textTransform: "uppercase", letterSpacing: 0, margin: "6px 2px 4px" }}>{provider} · {rows.length}</div>
+              <div className="muted text-caption font-semibold" style={{ textTransform: "uppercase", letterSpacing: "var(--tracking-wide)", margin: "6px 2px 4px" }}>{provider} · {rows.length}</div>
               <div className="stack" style={{ gap: 4 }}>
                 {rows.map(a => (
                   <div key={a.id} className="card row" style={{ padding: "6px 12px", gap: 10 }}>
-                    <code className="mono" style={{ flex: 1, fontSize: 12 }}>{a.id}</code>
-                    <span className="muted" style={{ fontSize: 12 }}>{a.display_name}</span>
+                    <code className="mono text-label" style={{ flex: 1 }}>{a.id}</code>
+                    <span className="muted text-label">{a.display_name}</span>
                   </div>
                 ))}
               </div>

--- a/gui/src/pages/CodexAuth.tsx
+++ b/gui/src/pages/CodexAuth.tsx
@@ -259,7 +259,7 @@ export default function CodexAuth({ apiBase }: { apiBase: string }) {
                   {(resetPopup.quota?.resetCredits ?? 0) > 0 ? (
                     <>
                       <p style={{ marginBottom: 12 }}>{t("codexAuth.resetCreditsAvailable", { count: String(resetPopup.quota?.resetCredits ?? 0) })}</p>
-                      {creditDetailsLoading && <p className="faint" style={{ fontSize: 12 }}>Loading...</p>}
+                      {creditDetailsLoading && <p className="faint text-label">Loading...</p>}
                       {creditDetails && creditDetails.length > 0 && (
                         <div className="credit-list">
                           {creditDetails.map((c, i) => (
@@ -271,7 +271,7 @@ export default function CodexAuth({ apiBase }: { apiBase: string }) {
                         onClick={() => setResetConfirm(true)} disabled={redeeming}>
                         {t("codexAuth.useOneCredit")}
                       </button>
-                      <p className="card-sub" style={{ fontSize: 11, marginTop: 8, textAlign: "center" }}>{t("codexAuth.fifoNote")}</p>
+                      <p className="card-sub text-caption" style={{ marginTop: 8, textAlign: "center" }}>{t("codexAuth.fifoNote")}</p>
                     </>
                   ) : (
                     <>
@@ -288,11 +288,11 @@ export default function CodexAuth({ apiBase }: { apiBase: string }) {
                   <h3>{t("codexAuth.confirmResetTitle")}</h3>
                   <p className="modal-desc">{t("codexAuth.confirmResetDesc", { count: String(resetPopup.quota?.resetCredits ?? 0) })}</p>
                   {creditDetails && creditDetails[0] && (
-                    <p className="faint" style={{ fontSize: 12 }}>
+                    <p className="faint text-label">
                       {t("codexAuth.confirmWhichCredit", { date: formatCreditDate(creditDetails[0].granted_at) })}
                     </p>
                   )}
-                  <p className="faint" style={{ fontSize: 12 }}>{t("codexAuth.irreversible")}</p>
+                  <p className="faint text-label">{t("codexAuth.irreversible")}</p>
                 </div>
                 <div className="modal-actions">
                   <button className="btn btn-ghost" onClick={() => setResetConfirm(false)}>{t("codexAuth.cancel")}</button>
@@ -338,7 +338,7 @@ function CreditItem({ index, grantedAt, expiresAt, isNext, t }: {
         <span className="credit-item-label">
           {isNext ? t("codexAuth.creditNext") : t("codexAuth.creditLabel", { n: String(index + 1) })}
         </span>
-        {isNext && <span className="badge badge-amber" style={{ fontSize: 10, padding: "1px 6px" }}>{t("codexAuth.creditNextBadge")}</span>}
+        {isNext && <span className="badge badge-amber text-micro" style={{ padding: "1px 6px" }}>{t("codexAuth.creditNextBadge")}</span>}
       </div>
       <div className="credit-item-dates">
         <span>{t("codexAuth.creditGranted", { date: formatCreditDate(grantedAt) })}</span>

--- a/gui/src/pages/Dashboard.tsx
+++ b/gui/src/pages/Dashboard.tsx
@@ -489,7 +489,7 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
             <button
               type="button"
               className="btn btn-ghost btn-sm"
-              style={{ width: 24, height: 24, minWidth: 24, flex: "0 0 24px", padding: 0, borderRadius: 999, color: "var(--muted)" }}
+              style={{ width: 24, height: 24, minWidth: 24, flex: "0 0 24px", padding: 0, borderRadius: "var(--radius-pill)", color: "var(--muted)" }}
               onClick={() => setMaHelpOpen(true)}
               aria-label={t("dash.multiAgent")}
               aria-haspopup="dialog"
@@ -498,15 +498,15 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
             </button>
           </div>
           <div className="value" style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
-            <div role="radiogroup" aria-label={t("dash.multiAgent")} style={{ display: "inline-flex", borderRadius: 999, background: "var(--surface-soft, var(--raised))", padding: 3, gap: 2 }}>
+            <div role="radiogroup" aria-label={t("dash.multiAgent")} style={{ display: "inline-flex", borderRadius: "var(--radius-pill)", background: "var(--surface-soft, var(--raised))", padding: 3, gap: 2 }}>
               {(["v1", "default", "v2"] as const).map(mode => (
                 <button
                   key={mode}
                   type="button"
                   role="radio"
                   aria-checked={maMode === mode}
-                  className={`btn btn-sm${maMode === mode ? " btn-primary" : " btn-ghost"}`}
-                  style={{ borderRadius: 999, minWidth: 36, fontSize: 11, padding: "5px 10px", border: "none", background: maMode === mode ? undefined : "transparent", color: maMode === mode ? undefined : "var(--muted)" }}
+                  className={`btn btn-sm text-caption${maMode === mode ? " btn-primary" : " btn-ghost"}`}
+                  style={{ borderRadius: "var(--radius-pill)", minWidth: 36, padding: "5px 10px", border: "none", background: maMode === mode ? undefined : "transparent", color: maMode === mode ? undefined : "var(--muted)" }}
                   disabled={maBusy}
                   onClick={() => void switchMaMode(mode)}
                 >{mode === "default" ? "base" : mode}</button>
@@ -527,7 +527,7 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
           <div className="label">{t("dash.tokens30d")}</div>
           <div className="value mono">{usage30d && usage30d.summary.requests > 0 ? formatTokens(usage30d.summary.totalTokens, locale) : "—"}</div>
           {usage30d && usage30d.summary.requests > 0 && (
-            <div className="muted" style={{ fontSize: 12, marginTop: 2 }}>
+            <div className="muted text-label" style={{ marginTop: 2 }}>
               {t("dash.coverage").replace("{pct}", `${Math.round(usage30d.summary.coverageRatio * 100)}%`)}
             </div>
           )}
@@ -538,9 +538,9 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
         <div className="notice notice-err maintenance-notice" style={{ marginBottom: 24 }} role="alert">
           <IconAlert />
           <div>
-            <div style={{ fontWeight: 650 }}>{t("dash.projectConfigTitle")}</div>
-            <div className="muted" style={{ fontSize: 13, marginTop: 4 }}>{t("dash.projectConfigHint")}</div>
-            <ul style={{ margin: "10px 0 0", paddingLeft: 18, fontSize: 13 }}>
+            <div className="font-semibold">{t("dash.projectConfigTitle")}</div>
+            <div className="muted text-control" style={{ marginTop: 4 }}>{t("dash.projectConfigHint")}</div>
+            <ul className="text-control" style={{ margin: "10px 0 0", paddingLeft: 18 }}>
               {projectConfigWarnings.map(g => (
                 <li key={g.path} style={{ marginBottom: 8 }}>
                   <code>{g.path}</code> — {g.issues.join(", ")}
@@ -561,7 +561,7 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
                 <button
                   type="button"
                   className="btn btn-ghost btn-sm"
-                  style={{ width: 22, height: 22, minWidth: 22, padding: 0, borderRadius: 999, color: "var(--muted)" }}
+                  style={{ width: 22, height: 22, minWidth: 22, padding: 0, borderRadius: "var(--radius-pill)", color: "var(--muted)" }}
                   onClick={() => setEffortCapHelpOpen(open => !open)}
                   aria-label={t("dash.effortCapLabel")}
                   aria-expanded={effortCapHelpOpen}
@@ -572,8 +572,8 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
                 {effortCapHelpOpen && (
                   <div
                     role="dialog"
-                    className="help-popup"
-                    style={{ position: "absolute", top: "calc(100% + 8px)", left: 0, width: "min(360px, calc(100vw - 48px))", padding: "12px 16px", border: "1px solid var(--border)", borderRadius: 8, background: "var(--bg)", boxShadow: "0 8px 24px rgba(0, 0, 0, 0.14)", color: "var(--text)", fontSize: 13, fontWeight: 400, lineHeight: 1.5, zIndex: 10 }}
+                    className="help-popup text-control font-regular leading-body"
+                    style={{ position: "absolute", top: "calc(100% + 8px)", left: 0, width: "min(360px, calc(100vw - 48px))", padding: "12px 16px", border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", background: "var(--bg)", boxShadow: "0 8px 24px rgba(0, 0, 0, 0.14)", color: "var(--text)", zIndex: 10 }}
                   >
                     <button
                       type="button"
@@ -702,16 +702,16 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
               label={t("dash.injectionEffortLabel")}
             />
           )}
-          {injectionModel && <span className="badge badge-green" style={{ fontSize: 10 }}>{t("dash.injectionActive")}</span>}
+          {injectionModel && <span className="badge badge-green text-micro">{t("dash.injectionActive")}</span>}
         </div>
-        <div className="muted" style={{ fontSize: 13, marginTop: 6 }}>{t("dash.injectionHint")}</div>
+        <div className="muted text-control" style={{ marginTop: 6 }}>{t("dash.injectionHint")}</div>
       </div>
 
       <div className="panel maintenance-panel" style={{ marginBottom: 24 }}>
         <div className="spread maintenance-head">
           <div>
-            <div style={{ fontWeight: 650 }}>{t("dash.maintenance")}</div>
-            <div className="muted" style={{ fontSize: 13, marginTop: 3 }}>{t("dash.maintenanceHint")}</div>
+            <div className="font-semibold">{t("dash.maintenance")}</div>
+            <div className="muted text-control" style={{ marginTop: 3 }}>{t("dash.maintenanceHint")}</div>
           </div>
           <div className="maintenance-actions">
             <button type="button" className="btn btn-ghost" onClick={runSync} disabled={syncing}>
@@ -753,7 +753,7 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
       <div className="panel" style={{ marginBottom: 24 }}>
         <div className="spread">
           <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{ fontWeight: 650 }}>{t("dash.codexAutoStart")}</div>
+            <div className="font-semibold">{t("dash.codexAutoStart")}</div>
             <div className="muted setting-hint">{t("dash.codexAutoStartHint")}</div>
           </div>
           <button
@@ -771,7 +771,7 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
       <div className="panel" style={{ marginBottom: 12 }}>
         <div className="spread setting-row" style={{ alignItems: "flex-start" }}>
           <div className="setting-copy" style={{ flex: 1 }}>
-            <div style={{ fontWeight: 650 }}>{t("dash.webSearchSidecar")}</div>
+            <div className="font-semibold">{t("dash.webSearchSidecar")}</div>
             <div className="muted setting-hint">{t("dash.webSearchSidecarHint")}</div>
           </div>
           <div className="setting-controls">
@@ -789,7 +789,7 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
       <div className="panel" style={{ marginBottom: 24 }}>
         <div className="spread setting-row">
           <div className="setting-copy" style={{ flex: 1 }}>
-            <div style={{ fontWeight: 650 }}>{t("dash.visionSidecar")}</div>
+            <div className="font-semibold">{t("dash.visionSidecar")}</div>
             <div className="muted setting-hint">{t("dash.visionSidecarHint")}</div>
           </div>
           <div className="setting-controls">
@@ -807,9 +807,9 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
       <div className="panel" style={{ marginBottom: 12 }}>
         <div className="spread setting-row" style={{ alignItems: "center" }}>
           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <span style={{ fontWeight: 650 }}>{t("dash.shadowCallIntercept")}</span>
+            <span className="font-semibold">{t("dash.shadowCallIntercept")}</span>
             <span title={t("dash.shadowCallTooltip")} style={{ cursor: "help", opacity: 0.5 }}>ⓘ</span>
-            <code className="muted" style={{ fontSize: 11 }}>⚠ 5.4-mini</code>
+            <code className="muted text-caption">⚠ 5.4-mini</code>
           </div>
           <div className="setting-controls" style={{ display: "flex", gap: 8, alignItems: "center" }}>
             <button
@@ -842,9 +842,9 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
             <tbody>
               {providers.map(p => (
                 <tr key={p.name}>
-                  <td style={{ fontWeight: 600 }}>{p.name}</td>
+                  <td className="font-semibold">{p.name}</td>
                   <td><span className="chip">{p.adapter}</span></td>
-                  <td className="muted mono" style={{ fontSize: 12 }}>{p.baseUrl}</td>
+                  <td className="muted mono text-label">{p.baseUrl}</td>
                   <td className="muted">{p.defaultModel ?? "—"}</td>
                 </tr>
               ))}
@@ -904,11 +904,11 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
               <div className="update-box">
                 <div className="spread">
                   <div>
-                    <div className="muted" style={{ fontSize: 12 }}>{t("dash.updateInstalled")}</div>
+                    <div className="muted text-label">{t("dash.updateInstalled")}</div>
                     <div className="mono">{updateCheck.currentVersion}</div>
                   </div>
                   <div>
-                    <div className="muted" style={{ fontSize: 12 }}>{t("dash.updateLatest")}</div>
+                    <div className="muted text-label">{t("dash.updateLatest")}</div>
                     <div className="mono">{updateCheck.latestVersion ?? "—"}</div>
                   </div>
                   <span className={`badge ${updateCheck.updateAvailable ? "badge-green" : "badge-muted"}`}>
@@ -951,8 +951,8 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
                 {updateCheck.canUpdate && (
                   <div className="spread update-restart">
                     <div>
-                      <div style={{ fontWeight: 600 }}>{t("dash.updateRestart")}</div>
-                      <div className="muted" style={{ fontSize: 12 }}>{t("dash.updateRestartHint")}</div>
+                      <div className="font-semibold">{t("dash.updateRestart")}</div>
+                      <div className="muted text-label">{t("dash.updateRestartHint")}</div>
                     </div>
                     <button
                       type="button"
@@ -989,11 +989,11 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
               <h3>{t("dash.multiAgent")}</h3>
               <button type="button" className="btn btn-ghost btn-icon" onClick={() => setMaHelpOpen(false)} aria-label="Close"><IconX /></button>
             </div>
-            <div className="modal-desc" style={{ whiteSpace: "pre-line", lineHeight: 1.6 }}>
+            <div className="modal-desc leading-relaxed" style={{ whiteSpace: "pre-line" }}>
               {t("models.v2Help")}
             </div>
             <div style={{ marginTop: 12 }}>
-              <a href="https://lidge-jun.github.io/opencodex/guides/sub-agent-surface/" target="_blank" rel="noreferrer" style={{ fontSize: 13, color: "var(--accent)" }}>
+              <a className="text-control" href="https://lidge-jun.github.io/opencodex/guides/sub-agent-surface/" target="_blank" rel="noreferrer" style={{ color: "var(--accent)" }}>
                 {t("models.v2DocsLink")}
               </a>
             </div>

--- a/gui/src/pages/Debug.tsx
+++ b/gui/src/pages/Debug.tsx
@@ -202,7 +202,7 @@ export default function Debug({ apiBase }: { apiBase: string }) {
           >
             <IconRefresh /> {t("debug.refresh")}
           </button>
-          <label className="muted" style={{ fontSize: 13, cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 6 }}>
+          <label className="muted text-control" style={{ cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 6 }}>
             <input type="checkbox" checked={follow} onChange={e => setFollow(e.target.checked)} />
             {t("debug.follow")}
           </label>
@@ -226,7 +226,7 @@ export default function Debug({ apiBase }: { apiBase: string }) {
                       label={t(`debug.${flag}`)}
                       onClick={() => void setDebugFlag(flag, !checked)}
                     />
-                    <span style={{ fontSize: 13 }}>{t(`debug.${flag}`)}</span>
+                    <span className="text-control">{t(`debug.${flag}`)}</span>
                   </div>
                 );
               })}
@@ -272,13 +272,13 @@ export default function Debug({ apiBase }: { apiBase: string }) {
 
       {debug?.claude && (
         <div className="card" style={{ marginBottom: 16, padding: "12px 14px" }}>
-          <div style={{ fontWeight: 600, marginBottom: 4 }}>{t("debug.claudeInbound.title")}</div>
-          <div className="muted" style={{ fontSize: 13, marginBottom: 10 }}>{t("debug.claudeInbound.sub")}</div>
+          <div className="font-semibold" style={{ marginBottom: 4 }}>{t("debug.claudeInbound.title")}</div>
+          <div className="muted text-control" style={{ marginBottom: 10 }}>{t("debug.claudeInbound.sub")}</div>
           {claudeEntries.length === 0 ? (
-            <div className="muted" style={{ fontSize: 13 }}>{t("debug.claudeInbound.empty")}</div>
+            <div className="muted text-control">{t("debug.claudeInbound.empty")}</div>
           ) : (
             <div style={{ overflowX: "auto" }}>
-              <table className="table" style={{ fontSize: 12 }}>
+              <table className="table text-label">
                 <thead>
                   <tr>
                     <th>{t("debug.claudeInbound.time")}</th>
@@ -323,13 +323,13 @@ export default function Debug({ apiBase }: { apiBase: string }) {
 
       {debug && !streamEnabled ? (
         <div className="empty">
-          <div style={{ fontWeight: 600, marginBottom: 6 }}>{t("debug.emptyTitle")}</div>
-          <div className="muted" style={{ fontSize: 13, maxWidth: 560, marginInline: "auto" }}>{t("debug.empty")}</div>
+          <div className="font-semibold" style={{ marginBottom: 6 }}>{t("debug.emptyTitle")}</div>
+          <div className="muted text-control" style={{ maxWidth: 560, marginInline: "auto" }}>{t("debug.empty")}</div>
         </div>
       ) : debug && streamEnabled && entries.length === 0 ? (
         <div className="empty">
-          <div style={{ fontWeight: 600, marginBottom: 6 }}>{t("debug.noLinesTitle")}</div>
-          <div className="muted" style={{ fontSize: 13, maxWidth: 560, marginInline: "auto" }}>{t(`debug.noLines.${stream}`)}</div>
+          <div className="font-semibold" style={{ marginBottom: 6 }}>{t("debug.noLinesTitle")}</div>
+          <div className="muted text-control" style={{ maxWidth: 560, marginInline: "auto" }}>{t(`debug.noLines.${stream}`)}</div>
         </div>
       ) : debug && streamEnabled ? (
         <div

--- a/gui/src/pages/Logs.tsx
+++ b/gui/src/pages/Logs.tsx
@@ -145,7 +145,7 @@ export default function Logs({ apiBase }: { apiBase: string }) {
     <>
       <div className="page-head">
         <h2>{t("logs.title")}</h2>
-        <label className="muted" style={{ fontSize: 13, cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 6 }}>
+        <label className="muted text-control" style={{ cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 6 }}>
           <input type="checkbox" checked={autoRefresh} onChange={e => setAutoRefresh(e.target.checked)} />
           {t("logs.autoRefresh")}
         </label>
@@ -153,8 +153,8 @@ export default function Logs({ apiBase }: { apiBase: string }) {
       <p className="page-sub">{t("logs.subtitle")}</p>
 
       <div className="row" style={{ gap: 8, marginBottom: 12, alignItems: "center" }}>
-        <span className="muted" style={{ fontSize: 13 }}>{t("logs.filter.surface.label")}</span>
-        <div className="segmented" role="radiogroup" aria-label={t("logs.filter.surface.label")} style={{ display: "inline-flex", borderRadius: 999, background: "var(--surface-soft, var(--raised))", padding: 3, gap: 2 }}>
+        <span className="muted text-control">{t("logs.filter.surface.label")}</span>
+        <div className="segmented" role="radiogroup" aria-label={t("logs.filter.surface.label")} style={{ display: "inline-flex", borderRadius: "var(--radius-pill)", background: "var(--surface-soft, var(--raised))", padding: 3, gap: 2 }}>
           {(["all", "claude", "codex"] as const).map(surface => (
             <button
               key={surface}
@@ -162,7 +162,7 @@ export default function Logs({ apiBase }: { apiBase: string }) {
               role="radio"
               aria-checked={surfaceFilter === surface}
               className={`btn btn-sm${surfaceFilter === surface ? " btn-primary" : " btn-ghost"}`}
-              style={{ borderRadius: 999, minWidth: 64, fontSize: 12, padding: "5px 12px", border: "none", background: surfaceFilter === surface ? undefined : "transparent", color: surfaceFilter === surface ? undefined : "var(--muted)" }}
+              style={{ borderRadius: "var(--radius-pill)", minWidth: 64, padding: "5px 12px", border: "none", background: surfaceFilter === surface ? undefined : "transparent", color: surfaceFilter === surface ? undefined : "var(--muted)" }}
               onClick={() => setSurfaceFilter(surface)}
             >
               {t(`logs.filter.surface.${surface}`)}
@@ -212,17 +212,17 @@ export default function Logs({ apiBase }: { apiBase: string }) {
                             <span style={{ display: "inline-flex", flexDirection: "column", alignItems: "flex-end", gap: 2 }}>
                               <span>{log.usageStatus === "estimated" ? "~" : ""}{formatTokens(tokenTotal, locale)}</span>
                               {(read !== undefined && read > 0) && (
-                                <span className="muted" style={{ fontSize: 11, lineHeight: 1 }}>
+                                <span className="muted text-caption leading-tight">
                                   c {formatTokens(read, locale)}
                                 </span>
                               )}
                               {(write !== undefined && write > 0) && (
-                                <span className="muted" style={{ fontSize: 11, lineHeight: 1 }}>
+                                <span className="muted text-caption leading-tight">
                                   w {formatTokens(write, locale)}
                                 </span>
                               )}
                               {(log.usageStatus === "estimated" && read === undefined && write === undefined) && (
-                                <span className="muted" style={{ fontSize: 11, lineHeight: 1 }}>
+                                <span className="muted text-caption leading-tight">
                                   {t("logs.tokens.noCache")}
                                 </span>
                               )}
@@ -242,7 +242,7 @@ export default function Logs({ apiBase }: { apiBase: string }) {
                   <td className="muted">{log.provider}</td>
                   <td>
                     <span className="log-status-cell">
-                      <span className="mono" style={{ color: statusColor(log.status), fontWeight: 600 }}>{log.status}</span>
+                      <span className="mono font-semibold" style={{ color: statusColor(log.status) }}>{log.status}</span>
                       {log.status >= 400 && (
                         <button type="button" className="log-detail-btn" onClick={() => setDetail(log)}>
                           {t("logs.details")}
@@ -285,7 +285,7 @@ export default function Logs({ apiBase }: { apiBase: string }) {
               {detail.upstreamError && (<><span className="muted">{t("logs.col.upstreamReason")}</span><span className="mono log-detail-break">{detail.upstreamError}</span></>)}
               <span className="muted">{t("logs.col.duration")}</span><span className="mono">{detail.durationMs}ms</span>
             </div>
-            <div className="muted" style={{ fontSize: 12, margin: "12px 0 6px" }}>{t("logs.detailRaw")}</div>
+            <div className="muted text-label" style={{ margin: "12px 0 6px" }}>{t("logs.detailRaw")}</div>
             <pre className="log-detail-json">{JSON.stringify(detail, null, 2)}</pre>
           </div>
         </div>

--- a/gui/src/pages/Models.tsx
+++ b/gui/src/pages/Models.tsx
@@ -373,22 +373,22 @@ export default function Models({ apiBase }: { apiBase: string }) {
     <>
       <div className="page-head">
         <h2>{t("nav.models")}</h2>
-        <span className="muted mono" style={{ fontSize: 12 }}>{t("models.active", { active: models.length - disabled.size, total: models.length })}</span>
+        <span className="muted mono text-label">{t("models.active", { active: models.length - disabled.size, total: models.length })}</span>
       </div>
       <p className="page-sub">{t("models.subtitle")}</p>
       {status && <Notice tone={ok ? "ok" : "err"}>{status}</Notice>}
 
-      <div className="row muted" style={{ gap: 6, marginBottom: 8, alignItems: "center", fontSize: 13 }}>
+      <div className="row muted text-control" style={{ gap: 6, marginBottom: 8, alignItems: "center" }}>
         <span title={t("models.shadowCallInterceptHint")} style={{ cursor: "help" }}>{t("models.shadowCallIntercept")} ⓘ</span>
-        <code style={{ fontSize: 11, opacity: 0.6 }}>⚠ 5.4-mini →</code>
+        <code className="text-caption" style={{ opacity: 0.6 }}>⚠ 5.4-mini →</code>
         <Switch on={shadowCall?.enabled ?? false} onClick={() => void saveShadowCall({ enabled: !shadowCall?.enabled })} disabled={!shadowCall || shadowCallSaving} label={t("models.shadowCallIntercept")} />
         <Select value={shadowCall?.model ?? ""} options={[{ value: "", label: "\u2014" }, ...models.filter(m => !disabled.has(m.id) && !disabled.has(m.namespaced)).map(m => ({ value: m.namespaced, label: m.namespaced }))]} onChange={v => { setShadowCall(c => c ? { ...c, model: v } : c); void saveShadowCall({ model: v }); }} disabled={!shadowCall || shadowCallSaving || !shadowCall.enabled} label={t("models.shadowCallIntercept")} />
       </div>
 
       {v2 && (
         <div className="row" style={{ gap: 8, marginBottom: 8, flexWrap: "wrap", alignItems: "center" }}>
-          <span className="muted" style={{ fontSize: 13 }}>{t("models.v2Label")}</span>
-          <div className="segmented" role="radiogroup" aria-label={t("models.v2Label")} style={{ display: "inline-flex", borderRadius: 999, background: "var(--surface-soft, var(--raised))", padding: 3, gap: 2 }}>
+          <span className="muted text-control">{t("models.v2Label")}</span>
+          <div className="segmented" role="radiogroup" aria-label={t("models.v2Label")} style={{ display: "inline-flex", borderRadius: "var(--radius-pill)", background: "var(--surface-soft, var(--raised))", padding: 3, gap: 2 }}>
             {(["v1", "default", "v2"] as const).map(mode => (
               <button
                 key={mode}
@@ -396,7 +396,7 @@ export default function Models({ apiBase }: { apiBase: string }) {
                 role="radio"
                 aria-checked={(v2.multiAgentMode ?? "default") === mode}
                 className={`btn btn-sm${(v2.multiAgentMode ?? "default") === mode ? " btn-primary" : " btn-ghost"}`}
-                style={{ borderRadius: 999, minWidth: 64, fontSize: 12, padding: "5px 12px", border: "none", background: (v2.multiAgentMode ?? "default") === mode ? undefined : "transparent", color: (v2.multiAgentMode ?? "default") === mode ? undefined : "var(--muted)" }}
+                style={{ borderRadius: "var(--radius-pill)", minWidth: 64, padding: "5px 12px", border: "none", background: (v2.multiAgentMode ?? "default") === mode ? undefined : "transparent", color: (v2.multiAgentMode ?? "default") === mode ? undefined : "var(--muted)" }}
                 disabled={v2Busy}
                 onClick={() => void setMultiAgentMode(mode)}
               >
@@ -407,7 +407,7 @@ export default function Models({ apiBase }: { apiBase: string }) {
           <button
             type="button"
             className="btn btn-ghost btn-sm"
-            style={{ width: 24, height: 24, minWidth: 24, flex: "0 0 24px", padding: 0, borderRadius: 999, color: "var(--muted)" }}
+            style={{ width: 24, height: 24, minWidth: 24, flex: "0 0 24px", padding: 0, borderRadius: "var(--radius-pill)", color: "var(--muted)" }}
             onClick={() => setV2HelpOpen(true)}
             aria-label={t("models.v2Label")}
             aria-haspopup="dialog"
@@ -416,7 +416,7 @@ export default function Models({ apiBase }: { apiBase: string }) {
           </button>
           {v2.enabled && (
             <>
-              <span className="muted" style={{ fontSize: 13, marginLeft: 8 }}>{t("models.v2ThreadsLabel")}</span>
+              <span className="muted text-control" style={{ marginLeft: 8 }}>{t("models.v2ThreadsLabel")}</span>
               <Select
                 value={showThreadsCustom
                   ? CUSTOM_OPTION
@@ -456,14 +456,14 @@ export default function Models({ apiBase }: { apiBase: string }) {
             </>
           )}
           {v2.enabled && v2.agentsMaxThreadsConflict && (
-            <span className="mono" style={{ fontSize: 12, color: "var(--err, #e5484d)" }}>{t("models.v2Conflict")}</span>
+            <span className="mono text-label" style={{ color: "var(--err, #e5484d)" }}>{t("models.v2Conflict")}</span>
           )}
-          {v2Note && <span className="muted" style={{ fontSize: 12 }}>{v2Note}</span>}
+          {v2Note && <span className="muted text-label">{v2Note}</span>}
         </div>
       )}
 
       <div className="row" style={{ gap: 8, marginBottom: 8, flexWrap: "wrap" }}>
-        <span className="muted" style={{ fontSize: 13 }}>{t("models.contextCapLabel")}</span>
+        <span className="muted text-control">{t("models.contextCapLabel")}</span>
         <Select
           value={showCustom ? CUSTOM_OPTION : (CAP_OPTIONS.includes(contextCapValue) ? String(contextCapValue) : CUSTOM_OPTION)}
           options={[
@@ -493,10 +493,10 @@ export default function Models({ apiBase }: { apiBase: string }) {
         )}
         <div style={{ flex: 1 }} />
         <Switch on={allCapped} onClick={setAll} disabled={busy} label={t("models.setAll")} />
-        <span className="muted mono" style={{ fontSize: 12 }}>{t("models.setAll")}</span>
+        <span className="muted mono text-label">{t("models.setAll")}</span>
       </div>
 
-      <div className="row muted" style={{ alignItems: "flex-start", gap: 8, marginBottom: 12, maxWidth: "80ch", fontSize: 12.5, lineHeight: 1.5 }}>
+      <div className="row muted text-label leading-body" style={{ alignItems: "flex-start", gap: 8, marginBottom: 12, maxWidth: "80ch" }}>
         <IconInfo width={15} height={15} aria-hidden="true" style={{ flexShrink: 0, marginTop: 2 }} />
         <span>{t("models.orderHint")}</span>
       </div>
@@ -523,22 +523,22 @@ export default function Models({ apiBase }: { apiBase: string }) {
           <div onClick={() => toggleCollapse(provider)}
              className={`row group-head${isCollapsed ? "" : " open"}`}>
              <IconChevron style={{ width: 14, height: 14, color: "var(--muted)", transform: isCollapsed ? "none" : "rotate(90deg)", transition: "transform .12s" }} />
-             <span style={{ fontWeight: 600, fontSize: 14 }}>{provider}</span>
-             {isNative && <span className="muted mono" style={{ fontSize: 11, padding: "1px 6px", border: "1px solid var(--border)", borderRadius: 999 }}>{t("models.nativeGroupLabel")}</span>}
-             <span className="muted mono" style={{ fontSize: 12 }}>{t("models.active", { active: activeCount, total: rows.length })}</span>
+             <span className="text-body font-semibold">{provider}</span>
+             {isNative && <span className="muted mono text-caption" style={{ padding: "1px 6px", border: "1px solid var(--border)", borderRadius: "var(--radius-pill)" }}>{t("models.nativeGroupLabel")}</span>}
+             <span className="muted mono text-label">{t("models.active", { active: activeCount, total: rows.length })}</span>
              <div style={{ flex: 1 }} />
               <div className="row" onClick={e => e.stopPropagation()} style={{ gap: 6 }}>
-                <button className="btn btn-ghost btn-sm" disabled={busy || allOn} onClick={() => bulkToggle(true)} style={{ fontSize: 11, padding: "2px 8px" }}>{t("models.allOn")}</button>
-                <button className="btn btn-ghost btn-sm" disabled={busy || allOff} onClick={() => bulkToggle(false)} style={{ fontSize: 11, padding: "2px 8px" }}>{t("models.allOff")}</button>
+                <button className="btn btn-ghost btn-sm text-caption" disabled={busy || allOn} onClick={() => bulkToggle(true)} style={{ padding: "2px 8px" }}>{t("models.allOn")}</button>
+                <button className="btn btn-ghost btn-sm text-caption" disabled={busy || allOff} onClick={() => bulkToggle(false)} style={{ padding: "2px 8px" }}>{t("models.allOff")}</button>
                 {!isNative && <>
                   <Switch on={capOn} onClick={() => toggleProviderCap(provider)} disabled={busy} label={t("models.capValue", { value: fmtK(contextCapValue) })} />
-                  <span className="muted mono" style={{ fontSize: 12 }}>{t("models.capValue", { value: fmtK(contextCapValue) })}</span>
+                  <span className="muted mono text-label">{t("models.capValue", { value: fmtK(contextCapValue) })}</span>
                 </>}
               </div>
            </div>
            {!isCollapsed && (
              <div style={{ padding: "6px 12px" }}>
-               {isNative && <p className="muted" style={{ fontSize: 12, margin: "2px 0 6px" }}>{t("models.nativeHint")}</p>}
+               {isNative && <p className="muted text-label" style={{ margin: "2px 0 6px" }}>{t("models.nativeHint")}</p>}
                {rows.length > PAGE / 2 && (
                  <input
                    className="input"
@@ -553,8 +553,8 @@ export default function Models({ apiBase }: { apiBase: string }) {
                   return (
                     <div key={m.namespaced} className="row" style={{ padding: "5px 0" }}>
                       <Switch on={!off} onClick={() => toggle(m.namespaced)} disabled={busy} label={m.id} />
-                      <code className="mono" style={{ fontSize: 13, color: off ? "var(--faint)" : "var(--text)", textDecoration: off ? "line-through" : "none" }}>{modelLabel(m.id)}</code>
-                      {m.contextCapped && <span className="muted mono" style={{ fontSize: 11, padding: "1px 6px", border: "1px solid var(--border)", borderRadius: 999 }}>{t("models.contextCappedValue", { value: fmtK(m.contextCap ?? contextCapValue) })}</span>}
+                      <code className="mono text-control" style={{ color: off ? "var(--faint)" : "var(--text)", textDecoration: off ? "line-through" : "none" }}>{modelLabel(m.id)}</code>
+                      {m.contextCapped && <span className="muted mono text-caption" style={{ padding: "1px 6px", border: "1px solid var(--border)", borderRadius: "var(--radius-pill)" }}>{t("models.contextCappedValue", { value: fmtK(m.contextCap ?? contextCapValue) })}</span>}
                     </div>
                   );
                 })}
@@ -583,11 +583,11 @@ export default function Models({ apiBase }: { apiBase: string }) {
               <h3>{t("models.v2Label")}</h3>
               <button type="button" className="btn btn-ghost btn-sm" onClick={() => setV2HelpOpen(false)} aria-label="Close">&times;</button>
             </div>
-            <div className="modal-desc" style={{ whiteSpace: "pre-line", lineHeight: 1.6 }}>
+            <div className="modal-desc leading-relaxed" style={{ whiteSpace: "pre-line" }}>
               {t("models.v2Help")}
             </div>
             <div style={{ marginTop: 12 }}>
-              <a href="https://lidge-jun.github.io/opencodex/guides/sub-agent-surface/" target="_blank" rel="noreferrer" style={{ fontSize: 13, color: "var(--accent)" }}>
+              <a className="text-control" href="https://lidge-jun.github.io/opencodex/guides/sub-agent-surface/" target="_blank" rel="noreferrer" style={{ color: "var(--accent)" }}>
                 {t("models.v2DocsLink")}
               </a>
             </div>

--- a/gui/src/pages/Providers.tsx
+++ b/gui/src/pages/Providers.tsx
@@ -386,11 +386,11 @@ export default function Providers({ apiBase }: { apiBase: string }) {
       <div className="panel panel-accent" style={{ marginBottom: 18 }}>
         <div className="row" style={{ marginBottom: 14 }}>
           <IconLock style={{ width: 16, height: 16, color: "var(--accent)" }} />
-          <span style={{ fontWeight: 600 }}>{t("prov.accountLogin")}</span>
+          <span className="font-semibold">{t("prov.accountLogin")}</span>
         </div>
         <div className="oauth-grid">
           {oauthProviders.length === 0 && keyProviders.length === 0 && (
-            <span className="muted" style={{ fontSize: 13, gridColumn: "1 / -1" }}>{t("prov.noOauth")}</span>
+            <span className="muted text-control" style={{ gridColumn: "1 / -1" }}>{t("prov.noOauth")}</span>
           )}
           {oauthProviders.map(p => {
             const st = oauthStatus[p] ?? { loggedIn: false };
@@ -447,7 +447,7 @@ export default function Providers({ apiBase }: { apiBase: string }) {
                         {manualCodeBusy ? t("prov.pasteSubmitting") : t("prov.pasteSubmit")}
                       </button>
                     </span>
-                    <span style={{ fontSize: 11 }}>{manualCodeMsg || t("prov.pasteRedirectHint")}</span>
+                    <span className="text-caption">{manualCodeMsg || t("prov.pasteRedirectHint")}</span>
                   </span>
                 )}
               </div>
@@ -483,7 +483,7 @@ export default function Providers({ apiBase }: { apiBase: string }) {
         />
       ) : (
         <div className="stack" style={{ gap: 8 }}>
-          <div className="muted" style={{ fontSize: 13, marginBottom: 4 }}>
+          <div className="muted text-control" style={{ marginBottom: 4 }}>
             {t("prov.port")}: <code className="chip">{config.port}</code> · {t("prov.default")}: <code className="chip">{config.defaultProvider}</code>
           </div>
           {Object.entries(config.providers).map(([name, prov]) => {
@@ -504,14 +504,14 @@ export default function Providers({ apiBase }: { apiBase: string }) {
                     {icon && <span className="provider-icon"><img src={icon} alt="" aria-hidden="true" /></span>}
                     <div className="prov-card-copy">
                       <div className="prov-title">
-                        <span style={{ fontWeight: 600 }}>{name}</span>
+                        <span className="font-semibold">{name}</span>
                         {isDefault && <span className="badge badge-primary">{t("prov.defaultBadge")}</span>}
                         {isDisabled ? <span className="badge badge-muted">{t("prov.disabledBadge")}</span> : <span className="badge badge-green">{t("prov.activeBadge")}</span>}
                         {prov.authMode === "oauth" && <span className="badge badge-accent">oauth</span>}
                         {prov.authMode === "forward" && <span className="badge badge-amber">passthrough</span>}
                         {prov.keyOptional && <span className="badge badge-green">Free</span>}
                       </div>
-                      <div className="muted prov-meta" style={{ fontSize: 13 }}>
+                      <div className="muted prov-meta text-control">
                         <code className="chip">{prov.adapter}</code>
                         <span>{prov.baseUrl}</span>
                         {prov.defaultModel && <span>{prov.defaultModel}</span>}
@@ -519,7 +519,7 @@ export default function Providers({ apiBase }: { apiBase: string }) {
                         {prov.hasHeaders && <span>{t("prov.hasHeaders")}</span>}
                       </div>
                       {prov.note && (
-                        <div className="muted" style={{ fontSize: 12, marginTop: 4, lineHeight: 1.5 }}>
+                        <div className="muted text-label leading-body" style={{ marginTop: 4 }}>
                           {prov.note}
                         </div>
                       )}

--- a/gui/src/pages/Subagents.tsx
+++ b/gui/src/pages/Subagents.tsx
@@ -81,7 +81,7 @@ export default function Subagents({ apiBase }: { apiBase: string }) {
       {status && <Notice tone={ok ? "ok" : "err"}>{status}</Notice>}
 
       <div className="h-section">{t("sub.featured")} <span className="count">{chosen.length}/5</span></div>
-      <div className="row muted" style={{ alignItems: "flex-start", gap: 8, margin: "-2px 0 10px", maxWidth: "80ch", fontSize: 12.5, lineHeight: 1.5 }}>
+      <div className="row muted text-label leading-body" style={{ alignItems: "flex-start", gap: 8, margin: "-2px 0 10px", maxWidth: "80ch" }}>
         <IconInfo width={15} height={15} aria-hidden="true" style={{ flexShrink: 0, marginTop: 2 }} />
         <span><Trans k="sub.orderHint" cmd="spawn_agent" /></span>
       </div>
@@ -91,7 +91,7 @@ export default function Subagents({ apiBase }: { apiBase: string }) {
         <div className="stack" style={{ gap: 8 }}>
           {chosen.map((m, i) => (
             <div key={m} className="card panel-accent row" style={{ padding: "8px 12px", gap: 10 }}>
-              <span className="mono" style={{ width: 18, color: "var(--accent)", fontWeight: 700 }}>{i + 1}</span>
+              <span className="mono font-bold" style={{ width: 18, color: "var(--accent)" }}>{i + 1}</span>
               <code className="mono" style={{ flex: 1, color: "var(--text)" }}>{modelLabel(m)}</code>
               <button className="btn btn-ghost btn-icon btn-sm" onClick={() => move(i, -1)} disabled={i === 0} aria-label={t("sub.moveUp", { m })}>
                 <IconArrowUp />

--- a/gui/src/pages/Usage.tsx
+++ b/gui/src/pages/Usage.tsx
@@ -283,7 +283,7 @@ export default function Usage({ apiBase }: { apiBase: string }) {
               <div className="muted">{t("usage.card.cachedTokens")}</div>
               <div className="stat-value">{formatTokens(data.summary.cacheReadInputTokens ?? data.summary.cachedInputTokens, locale)}</div>
               {(data.summary.cacheCreationInputTokens ?? 0) > 0 && (
-                <div className="muted" style={{ fontSize: 11 }}>
+                <div className="muted text-caption">
                   {t("usage.card.cacheWriteTokens")}: {formatTokens(data.summary.cacheCreationInputTokens ?? 0, locale)}
                 </div>
               )}
@@ -456,7 +456,7 @@ export default function Usage({ apiBase }: { apiBase: string }) {
               <div className="stat"><div className="muted">{t("logs.tokens.unreported")}</div><div className="stat-value">{data.summary.unreportedRequests}</div></div>
               <div className="stat"><div className="muted">{t("logs.tokens.unsupported")}</div><div className="stat-value">{data.summary.unsupportedRequests}</div></div>
             </div>
-            <p className="muted" style={{ marginTop: 12, fontSize: 13 }}>{t("usage.coverage.note")}</p>
+            <p className="muted text-control" style={{ marginTop: 12 }}>{t("usage.coverage.note")}</p>
           </section>
         </>
       )}

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -38,13 +38,66 @@
   --amber:      light-dark(#9a4a08, #fbbf24);
   --amber-soft: light-dark(rgba(180, 83, 9, 0.10), rgba(251, 191, 36, 0.13));
 
+  /* geometry: 4px base grid, three surface radii, and one pill radius */
+  --space-0-5: 2px;
+  --space-1: 4px;
+  --space-1-5: 6px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  --radius-2xs: 4px;
   --radius: 12px;
   --radius-sm: 8px;
   --radius-xs: 6px;
+  --radius-lg: 16px;
+  --radius-round: 50%;
   --radius-pill: 999px;
 
-  --font: "OpenAI Sans", "Söhne", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, system-ui, "Helvetica Neue", sans-serif;
-  --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas, monospace;
+  /* typography: product UI first, Korean-safe fallbacks, mono only for machine data */
+  --font-ui: "OpenAI Sans", "Pretendard Variable", Pretendard, "Noto Sans KR", "Apple SD Gothic Neo", "Malgun Gothic", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, system-ui, sans-serif;
+  --font-code: ui-monospace, "SFMono-Regular", "Cascadia Code", "JetBrains Mono", "Noto Sans Mono CJK KR", Menlo, Consolas, monospace;
+  --font: var(--font-ui);
+  --mono: var(--font-code);
+
+  --text-micro: 10px;
+  --text-caption: 11px;
+  --text-label: 12px;
+  --text-control: 13px;
+  --text-body: 14px;
+  --text-subtitle: 16px;
+  --text-title: 20px;
+  --text-display: 24px;
+
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --weight-bold: 700;
+
+  --leading-tight: 1.2;
+  --leading-ui: 1.35;
+  --leading-body: 1.5;
+  --leading-relaxed: 1.6;
+  --tracking-normal: 0;
+  --tracking-wide: 0.04em;
+
+  --control-sm: 28px;
+  --control-md: 34px;
+  --control-lg: 40px;
+  --control-touch: 44px;
+
+  --icon-sm: 14px;
+  --icon-md: 16px;
+  --icon-lg: 20px;
+
+  --motion-fast: 120ms;
+  --motion-normal: 180ms;
 
   --shadow: 0 1px 2px light-dark(rgba(16, 24, 40, 0.06), rgba(0, 0, 0, 0.5)), 0 10px 28px light-dark(rgba(16, 24, 40, 0.07), rgba(0, 0, 0, 0.30));
   --shadow-sm: 0 1px 2px light-dark(rgba(16, 24, 40, 0.06), rgba(0, 0, 0, 0.4));
@@ -54,7 +107,7 @@
   --toggle-h: 20px;
   --toggle-dot: 14px;
   --toggle-off-bg: light-dark(#d4d4d4, #4a4a4a);
-  --toggle-on-bg: light-dark(#0d0d0d, #ececec);
+  --toggle-on-bg: light-dark(#0d0d0d, #4ecb9d);
   --toggle-dot-color: light-dark(#ffffff, #0d0d0d);
 }
 
@@ -80,9 +133,9 @@ body {
   overflow-x: hidden;
   background: transparent;
   color: var(--text);
-  font-family: var(--font);
-  font-size: 14px;
-  line-height: 1.5;
+  font-family: var(--font-ui);
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
@@ -105,9 +158,32 @@ body::before {
 a { color: var(--text); text-decoration: underline; text-decoration-color: var(--faint); text-underline-offset: 2px; }
 a:hover { text-decoration-color: var(--text); }
 
-code, .mono { font-family: var(--mono); font-size: 0.92em; }
+code { font-family: var(--font-code); font-size: var(--text-label); }
+.mono { font-family: var(--font-code); font-variant-numeric: tabular-nums; }
 
-h1, h2, h3, h4 { margin: 0; font-weight: 600; letter-spacing: 0; }
+h1, h2, h3, h4 { margin: 0; font-weight: var(--weight-semibold); letter-spacing: 0; line-height: var(--leading-tight); }
+
+/* [Decision Log]
+- 목적: 화면마다 임의로 지정된 폰트 크기와 굵기를 역할 기반 타이포그래피로 통일한다.
+- 대안 분석: 태그 선택자만 사용하면 문맥별 역할이 불명확하고, 페이지별 인라인 값은 중복되며, 역할 유틸리티는 UI 의미와 토큰을 직접 연결한다.
+- 선택 근거: 8단계 타입 스케일과 4단계 굵기를 공통화하면 한글/영문/숫자 화면이 같은 위계로 렌더링되고 새 화면도 동일 규칙을 재사용할 수 있다.
+*/
+.text-micro { font-size: var(--text-micro) !important; line-height: var(--leading-ui); }
+.text-caption { font-size: var(--text-caption) !important; line-height: var(--leading-ui); }
+.text-label { font-size: var(--text-label) !important; line-height: var(--leading-ui); }
+.text-control { font-size: var(--text-control) !important; line-height: var(--leading-ui); }
+.text-body { font-size: var(--text-body) !important; line-height: var(--leading-body); }
+.text-subtitle { font-size: var(--text-subtitle) !important; line-height: var(--leading-tight); }
+.text-title { font-size: var(--text-title) !important; line-height: var(--leading-tight); }
+.text-display { font-size: var(--text-display) !important; line-height: var(--leading-tight); }
+.font-regular { font-weight: var(--weight-regular) !important; }
+.font-medium { font-weight: var(--weight-medium) !important; }
+.font-semibold { font-weight: var(--weight-semibold) !important; }
+.font-bold { font-weight: var(--weight-bold) !important; }
+.leading-tight { line-height: var(--leading-tight) !important; }
+.leading-ui { line-height: var(--leading-ui) !important; }
+.leading-body { line-height: var(--leading-body) !important; }
+.leading-relaxed { line-height: var(--leading-relaxed) !important; }
 
 ::selection { background: var(--accent-soft); }
 
@@ -116,10 +192,10 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
 
 /* scrollbars */
 *::-webkit-scrollbar { width: 10px; height: 10px; }
-*::-webkit-scrollbar-thumb { background: var(--border); border-radius: 99px; border: 2px solid var(--bg); }
+*::-webkit-scrollbar-thumb { background: var(--border); border-radius: var(--radius-pill); border: 2px solid var(--bg); }
 *::-webkit-scrollbar-thumb:hover { background: var(--faint); }
 
-:focus-visible { outline: 2px solid var(--accent-ring); outline-offset: 2px; border-radius: 4px; }
+:focus-visible { outline: 2px solid var(--accent-ring); outline-offset: 2px; border-radius: var(--radius-2xs); }
 
 /* ---- layout shell ---- */
 .app { display: grid; grid-template-columns: 232px 1fr; min-height: 100dvh; }
@@ -138,23 +214,34 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
    stays visible in BOTH light and dark (a plain <img> was invisible white-on-white in light). */
 .brand-logo { width: 26px; height: 26px; flex-shrink: 0; background: var(--text);
   -webkit-mask: url(/logo.png) center / contain no-repeat; mask: url(/logo.png) center / contain no-repeat; }
-.brand .name { font-weight: 600; font-size: 15px; letter-spacing: 0; line-height: 26px; }
+.brand .name { font-weight: var(--weight-semibold); font-size: var(--text-subtitle); letter-spacing: 0; line-height: 26px; }
 .brand .ver {
-  font-family: var(--mono); font-size: 10px; color: var(--muted); line-height: 1;
-  background: var(--raised); border: 1px solid var(--border); padding: 2px 6px; border-radius: 99px;
+  font-family: var(--font-code); font-size: var(--text-micro); color: var(--muted); line-height: var(--leading-tight);
+  background: var(--raised); border: 1px solid var(--border); padding: 2px 6px; border-radius: var(--radius-pill);
   align-self: center;
+}
+
+/* [Decision Log]
+- 목적: 인접한 사이드바 메뉴의 hover/active 배경이 한 덩어리처럼 보이지 않게 한다.
+- 대안 분석: 항목 margin은 클릭 영역 바깥 정렬이 복잡해지고, 구분선은 시각적 잡음이 크며, nav flex gap은 항목 구조를 유지한 채 일정한 간격을 만든다.
+- 선택 근거: 기존 sidebar-foot의 flex gap 패턴과 동일하고 메뉴별 예외 없이 작은 간격을 일관되게 적용할 수 있다.
+*/
+.sidebar nav {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .nav-item {
   display: flex; align-items: center; gap: 10px;
   padding: 8px 10px; border-radius: var(--radius-sm);
   background: none; border: none; width: 100%; text-align: left; cursor: pointer;
-  color: var(--muted); font: inherit; font-size: 13.5px; font-weight: 500;
-  transition: background 0.12s, color 0.12s;
+  color: var(--muted); font: inherit; font-size: var(--text-control); font-weight: var(--weight-medium);
+  transition: background var(--motion-fast), color var(--motion-fast);
 }
 .nav-item:hover { background: var(--accent-soft); color: var(--text); }
 .nav-item.active { background: var(--accent-soft); color: var(--text); }
-.nav-item.active { font-weight: 600; }
+.nav-item.active { font-weight: var(--weight-semibold); }
 .nav-item svg { width: 17px; height: 17px; color: var(--faint); flex-shrink: 0; }
 .nav-item.active svg { color: var(--text); }
 
@@ -171,7 +258,7 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
   min-width: 44px; min-height: 44px; padding: 8px;
   background: none; border: none; border-radius: var(--radius-sm);
   color: var(--muted); cursor: pointer;
-  transition: background 0.12s, color 0.12s;
+  transition: background var(--motion-fast), color var(--motion-fast);
 }
 .menu-toggle:hover { background: var(--accent-soft); color: var(--text); }
 .menu-toggle svg { width: 20px; height: 20px; }
@@ -180,19 +267,19 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
   background: light-dark(rgba(20, 20, 20, 0.32), rgba(0, 0, 0, 0.52));
 }
 
-.sidebar-link { display: flex; align-items: center; gap: 9px; padding: 8px 10px; color: var(--muted); font-size: 13px; border-radius: var(--radius-sm); text-decoration: none; }
+.sidebar-link { display: flex; align-items: center; gap: 9px; padding: 8px 10px; color: var(--muted); font-size: var(--text-control); border-radius: var(--radius-sm); text-decoration: none; }
 .sidebar-link:hover { background: var(--accent-soft); color: var(--text); text-decoration: none; }
 .sidebar-link svg { width: 16px; height: 16px; }
 
-.lang-toggle { display: flex; align-items: center; gap: 9px; padding: 8px 10px; width: 100%; color: var(--muted); font-size: 13px; border-radius: var(--radius-sm); transition: background 0.12s, color 0.12s; position: relative; }
+.lang-toggle { display: flex; align-items: center; gap: 9px; padding: 8px 10px; width: 100%; color: var(--muted); font-size: var(--text-control); border-radius: var(--radius-sm); transition: background var(--motion-fast), color var(--motion-fast); position: relative; }
 .lang-toggle:hover { background: var(--accent-soft); color: var(--text); }
 .lang-toggle svg { width: 16px; height: 16px; flex-shrink: 0; }
 .lang-toggle .custom-select { width: 100%; position: static !important; }
-.lang-toggle .select-trigger { width: 100%; justify-content: space-between; border: none; background: none; color: inherit; font-size: 13px; padding: 0; min-height: auto; box-shadow: none; backdrop-filter: none; -webkit-backdrop-filter: none; }
+.lang-toggle .select-trigger { width: 100%; justify-content: space-between; border: none; background: none; color: inherit; font-size: var(--text-control); padding: 0; min-height: auto; box-shadow: none; backdrop-filter: none; -webkit-backdrop-filter: none; }
 .lang-toggle .select-trigger:hover:not(:disabled) { border: none; background: none; color: inherit; box-shadow: none; }
 .lang-toggle .select-dropdown { background: var(--glass-rail); backdrop-filter: var(--glass-blur); -webkit-backdrop-filter: var(--glass-blur); border: 1px solid var(--border); box-shadow: var(--shadow-sm); }
 .lang-toggle .select-dropdown-beside { top: 0; left: calc(100% + 6px); right: auto; min-width: 10rem; }
-.theme-toggle { display: flex; align-items: center; gap: 9px; padding: 8px 10px; width: 100%; text-align: left; background: none; border: none; cursor: pointer; color: var(--muted); font: inherit; font-size: 13px; border-radius: var(--radius-sm); transition: background 0.12s, color 0.12s; }
+.theme-toggle { display: flex; align-items: center; gap: 9px; padding: 8px 10px; width: 100%; text-align: left; background: none; border: none; cursor: pointer; color: var(--muted); font: inherit; font-size: var(--text-control); border-radius: var(--radius-sm); transition: background var(--motion-fast), color var(--motion-fast); }
 .theme-toggle:hover { background: var(--accent-soft); color: var(--text); }
 .theme-toggle svg { width: 16px; height: 16px; flex-shrink: 0; }
 .theme-toggle .mode { text-transform: capitalize; }
@@ -205,12 +292,12 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
 
 /* ---- page header ---- */
 .page-head { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 6px; }
-.page-head h2 { font-size: 19px; }
-.page-sub { color: var(--muted); font-size: 13.5px; margin: 4px 0 22px; max-width: 70ch; }
-.page-sub b { color: var(--text); font-weight: 600; }
+.page-head h2 { font-size: var(--text-title); }
+.page-sub { color: var(--muted); font-size: var(--text-body); margin: 4px 0 22px; max-width: 70ch; }
+.page-sub b { color: var(--text); font-weight: var(--weight-semibold); }
 .api-page h2 svg { width: 1em; height: 1em; vertical-align: -0.16em; }
 .api-page .page-sub code {
-  font-size: 0.92em;
+  font-size: var(--text-label);
   color: var(--text);
   background: var(--raised);
   border: 1px solid var(--border-soft);
@@ -222,8 +309,8 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
 .btn {
   display: inline-flex; align-items: center; justify-content: center; gap: 7px;
   padding: 8px 16px; border-radius: var(--radius-pill);
-  font: inherit; font-size: 13px; font-weight: 500; cursor: pointer;
-  border: 1px solid transparent; transition: background 0.12s, border-color 0.12s, opacity 0.12s; white-space: nowrap;
+  font: inherit; font-size: var(--text-control); font-weight: var(--weight-medium); line-height: var(--leading-ui); cursor: pointer;
+  border: 1px solid transparent; transition: background var(--motion-fast), border-color var(--motion-fast), opacity var(--motion-fast); white-space: nowrap;
 }
 .btn svg { width: 15px; height: 15px; }
 .btn:disabled { opacity: 0.55; cursor: default; }
@@ -233,7 +320,7 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
 .btn-ghost:hover:not(:disabled) { background: var(--raised); }
 .btn-danger { background: transparent; color: var(--red); border-color: rgba(248, 113, 113, 0.3); }
 .btn-danger:hover:not(:disabled) { background: var(--red-soft); }
-.btn-sm { padding: 4px 12px; font-size: 12px; border-radius: var(--radius-pill); }
+.btn-sm { padding: 4px 12px; font-size: var(--text-label); border-radius: var(--radius-pill); }
 .btn-icon {
   appearance: none;
   border: none;
@@ -248,7 +335,7 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
   padding: 0;
   color: var(--muted);
   border-radius: var(--radius-sm);
-  transition: background 0.12s, color 0.12s;
+  transition: background var(--motion-fast), color var(--motion-fast);
 }
 .btn-icon:hover { background: var(--raised-hover); color: var(--text); }
 .btn-icon:focus-visible { outline: 2px solid var(--accent-ring); outline-offset: 1px; }
@@ -275,9 +362,9 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
   background: var(--raised);
   border: 1px solid var(--border-soft);
   border-radius: var(--radius-sm);
-  font-family: var(--mono);
-  font-size: 12.5px;
-  line-height: 1.55;
+  font-family: var(--font-code);
+  font-size: var(--text-label);
+  line-height: var(--leading-relaxed);
   white-space: pre;
 }
 .api-code-inline { white-space: nowrap; }
@@ -289,7 +376,7 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
 .update-row .field-label { margin: 0; }
 .update-empty { padding: 18px; margin-bottom: 14px; }
 .update-box { display: flex; flex-direction: column; gap: 12px; }
-.update-command { display: flex; align-items: flex-start; gap: 6px; flex-wrap: wrap; font-size: 12px; }
+.update-command { display: flex; align-items: flex-start; gap: 6px; flex-wrap: wrap; font-size: var(--text-label); }
 .update-command .chip {
   max-width: 100%;
   min-width: 0;
@@ -301,10 +388,10 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
 }
 .update-recheck { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 .update-recheck .btn { flex: 0 0 auto; }
-.update-recheck-reason { flex: 1 1 200px; min-width: 0; font-size: 12px; color: var(--muted); }
+.update-recheck-reason { flex: 1 1 200px; min-width: 0; font-size: var(--text-label); color: var(--muted); }
 .update-restart { border-top: 1px solid var(--border-soft); padding-top: 12px; }
 .injection-head { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-.injection-label { font-weight: 650; }
+.injection-label { font-weight: var(--weight-semibold); }
 
 @media (max-width: 800px) {
   .injection-head { gap: 8px; }
@@ -321,78 +408,78 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
 .stat-row > .stat { min-height: 80px; display: flex; flex-direction: column; justify-content: center; }
 @media (max-width: 1100px) { .stat-row { grid-template-columns: repeat(3, 1fr); } }
 @media (max-width: 640px) { .stat-row { grid-template-columns: repeat(2, 1fr); } }
-.stat { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 14px 16px; transition: border-color 0.12s; }
+.stat { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 14px 16px; transition: border-color var(--motion-fast); }
 .stat:hover { border-color: var(--faint); }
-.stat .label { font-size: 12px; color: var(--muted); margin-bottom: 6px; display: flex; align-items: center; gap: 6px; font-weight: 500; }
+.stat .label { font-size: var(--text-label); color: var(--muted); margin-bottom: 6px; display: flex; align-items: center; gap: 6px; font-weight: var(--weight-medium); }
 .stat .label svg { width: 14px; height: 14px; }
-.stat .value { font-size: 20px; font-weight: 600; letter-spacing: 0; line-height: 1.15; }
-.stat .value.mono { font-family: var(--mono); font-size: 17px; }
+.stat .value { font-size: var(--text-title); font-weight: var(--weight-semibold); letter-spacing: 0; line-height: var(--leading-tight); }
+.stat .value.mono { font-family: var(--font-code); font-size: var(--text-subtitle); }
 
 /* ---- dashboard model grid (grouped by provider) ---- */
-.model-group-head { display: flex; align-items: baseline; gap: 8px; margin: 0 0 8px; font-size: 13px; font-weight: 600; color: var(--text); }
-.model-group-head .count { font-family: var(--mono); font-weight: 500; color: var(--faint); font-size: 12px; }
+.model-group-head { display: flex; align-items: baseline; gap: 8px; margin: 0 0 8px; font-size: var(--text-control); font-weight: var(--weight-semibold); color: var(--text); }
+.model-group-head .count { font-family: var(--font-code); font-weight: var(--weight-medium); color: var(--faint); font-size: var(--text-label); }
 /* collapsible provider group header: same surface as the card body, hairline
    separation instead of a raised slab — matches the app's flat texture */
-.group-head { padding: 10px 12px; cursor: pointer; background: var(--surface); transition: background 0.12s; }
+.group-head { padding: 10px 12px; cursor: pointer; background: var(--surface); transition: background var(--motion-fast); }
 .group-head:hover { background: var(--hover); }
 .group-head.open { border-bottom: 1px solid var(--border-soft); }
 .model-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 8px; }
-.model-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 10px 12px; transition: border-color 0.12s, background 0.12s; }
+.model-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 10px 12px; transition: border-color var(--motion-fast), background var(--motion-fast); }
 .model-card:hover { border-color: var(--faint); background: var(--hover); }
-.model-card .id { font-family: var(--mono); font-weight: 600; font-size: 13px; letter-spacing: 0; color: var(--text); }
+.model-card .id { font-family: var(--font-code); font-weight: var(--weight-semibold); font-size: var(--text-control); letter-spacing: 0; color: var(--text); }
 
 /* ---- badges / status dot ---- */
-.badge { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 99px; border: 1px solid transparent; font-family: var(--mono); letter-spacing: 0; }
+.badge { display: inline-flex; align-items: center; gap: 5px; font-size: var(--text-caption); font-weight: var(--weight-semibold); line-height: var(--leading-ui); padding: 2px 8px; border-radius: var(--radius-pill); border: 1px solid transparent; font-family: var(--font-code); letter-spacing: 0; }
 .badge-accent { background: var(--accent-soft); color: var(--text); }
 .badge-green { background: var(--green-soft); color: var(--green); }
 .badge-amber { background: var(--amber-soft); color: var(--amber); }
 .badge-muted { background: var(--raised); color: var(--muted); border: 1px solid var(--border); }
-.badge-clickable { cursor: pointer; transition: filter 0.12s; appearance: none; }
+.badge-clickable { cursor: pointer; transition: filter var(--motion-fast); appearance: none; }
 .badge-clickable:hover { filter: brightness(1.1); }
 .badge-disabled { opacity: 0.5; cursor: default; }
 .card-badges { display: inline-flex; align-items: center; gap: 8px; flex-wrap: wrap; min-width: 0; }
 .card-badges .badge { flex-shrink: 0; }
-.confirm-icon { width: 44px; height: 44px; border-radius: 50%; background: var(--amber-soft); display: flex; align-items: center; justify-content: center; margin: 0 auto 12px; color: var(--amber); }
+.confirm-icon { width: 44px; height: 44px; border-radius: var(--radius-round); background: var(--amber-soft); display: flex; align-items: center; justify-content: center; margin: 0 auto 12px; color: var(--amber); }
 .credit-list { display: flex; flex-direction: column; gap: 6px; }
-.credit-item { padding: 8px 10px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--raised); transition: border-color 0.12s; }
+.credit-item { padding: 8px 10px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--raised); transition: border-color var(--motion-fast); }
 .credit-next { border-color: var(--amber); background: var(--amber-soft); }
-.credit-item-head { display: flex; align-items: center; gap: 6px; color: var(--text); font-size: 12px; font-weight: 600; margin-bottom: 3px; }
+.credit-item-head { display: flex; align-items: center; gap: 6px; color: var(--text); font-size: var(--text-label); font-weight: var(--weight-semibold); margin-bottom: 3px; }
 .credit-item-head svg { color: var(--amber); flex-shrink: 0; }
-.credit-item-dates { display: flex; justify-content: space-between; font-size: 11px; font-family: var(--mono); color: var(--muted); }
-.credit-urgent { color: var(--red); font-weight: 600; }
-.dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
+.credit-item-dates { display: flex; justify-content: space-between; font-size: var(--text-caption); font-family: var(--font-code); color: var(--muted); }
+.credit-urgent { color: var(--red); font-weight: var(--weight-semibold); }
+.dot { width: 7px; height: 7px; border-radius: var(--radius-round); flex-shrink: 0; }
 .dot-green { background: var(--green); box-shadow: 0 0 0 3px var(--green-soft); }
 .dot-red { background: var(--red); box-shadow: 0 0 0 3px var(--red-soft); }
 
 /* ---- tables ---- */
-.tbl { width: 100%; border-collapse: collapse; font-size: 13px; }
-.tbl thead th { text-align: left; padding: 9px 12px; color: var(--muted); font-weight: 500; font-size: 12px; border-bottom: 1px solid var(--border); }
+.tbl { width: 100%; border-collapse: collapse; font-size: var(--text-control); }
+.tbl thead th { text-align: left; padding: 9px 12px; color: var(--muted); font-weight: var(--weight-medium); font-size: var(--text-label); border-bottom: 1px solid var(--border); }
 .tbl tbody td { padding: 10px 12px; border-bottom: 1px solid var(--border-soft); }
 .tbl tbody tr:last-child td { border-bottom: none; }
 .tbl tbody tr:hover td { background: var(--hover); }
-.tbl .num { text-align: right; font-family: var(--mono); }
+.tbl .num { text-align: right; font-family: var(--font-code); font-variant-numeric: tabular-nums; }
 .tbl-wrap { border: 1px solid var(--border); border-radius: var(--radius); overflow-x: auto; background: var(--surface); }
 
 /* ---- inputs ---- */
 .input, textarea.input {
   width: 100%; padding: 8px 11px; border-radius: var(--radius-sm);
   background: var(--raised); border: 1px solid var(--border); color: var(--text);
-  font: inherit; font-size: 13px; transition: border-color 0.12s;
+  font: inherit; font-size: var(--text-control); line-height: var(--leading-ui); transition: border-color var(--motion-fast);
 }
 .input::placeholder { color: var(--faint); }
 .input:focus { border-color: var(--faint); outline: none; box-shadow: 0 0 0 3px var(--accent-soft); }
-textarea.input { resize: vertical; font-family: var(--mono); line-height: 1.55; }
-.field-label { font-size: 12px; color: var(--muted); font-weight: 500; margin-bottom: 5px; display: block; }
+textarea.input { resize: vertical; font-family: var(--font-code); line-height: var(--leading-relaxed); }
+.field-label { font-size: var(--text-label); color: var(--muted); font-weight: var(--weight-medium); margin-bottom: 5px; display: block; }
 select.input { appearance: none; }
 .select-sm {
-  padding: 6px 12px; border-radius: 999px;
+  padding: 6px 12px; border-radius: var(--radius-pill);
   background: color-mix(in oklab, canvas 75%, transparent);
   backdrop-filter: blur(12px) saturate(1.3);
   -webkit-backdrop-filter: blur(12px) saturate(1.3);
   border: 1px solid var(--border);
   box-shadow: 0 2px 8px rgb(0 0 0 / 0.06);
-  color: var(--text); font: inherit; font-size: 13px; cursor: pointer;
-  transition: border-color 0.12s, box-shadow 0.12s;
+  color: var(--text); font: inherit; font-size: var(--text-control); line-height: var(--leading-ui); cursor: pointer;
+  transition: border-color var(--motion-fast), box-shadow var(--motion-fast);
 }
 .select-sm:focus { border-color: var(--accent); outline: none; box-shadow: 0 0 0 3px var(--accent-soft); }
 .select-sm:hover:not(:disabled) { border-color: var(--faint); box-shadow: 0 2px 12px rgb(0 0 0 / 0.10); }
@@ -401,14 +488,14 @@ select.input { appearance: none; }
 /* Custom select (replaces native <select>) */
 .select-trigger {
   display: inline-flex; align-items: center; gap: 6px;
-  padding: 6px 12px; border-radius: 999px;
+  padding: 6px 12px; border-radius: var(--radius-pill);
   background: color-mix(in oklab, canvas 75%, transparent);
   backdrop-filter: blur(12px) saturate(1.3);
   -webkit-backdrop-filter: blur(12px) saturate(1.3);
   border: 1px solid var(--border);
   box-shadow: 0 2px 8px rgb(0 0 0 / 0.06);
-  color: var(--text); font: inherit; font-size: 13px; cursor: pointer;
-  transition: border-color 0.12s, box-shadow 0.12s;
+  color: var(--text); font: inherit; font-size: var(--text-control); line-height: var(--leading-ui); cursor: pointer;
+  transition: border-color var(--motion-fast), box-shadow var(--motion-fast);
   white-space: nowrap;
 }
 .select-trigger:hover:not(:disabled) { border-color: var(--faint); box-shadow: 0 2px 12px rgb(0 0 0 / 0.10); }
@@ -419,26 +506,26 @@ select.input { appearance: none; }
   background: color-mix(in oklab, canvas 84%, transparent);
   backdrop-filter: blur(20px) saturate(1.4);
   -webkit-backdrop-filter: blur(20px) saturate(1.4);
-  border: 1px solid var(--border); border-radius: 12px;
+  border: 1px solid var(--border); border-radius: var(--radius);
   padding: 4px; box-shadow: 0 8px 32px rgb(0 0 0 / 0.16);
 }
 .select-dropdown-right { left: auto !important; right: 0; }
 .select-dropdown-beside { top: 0; left: calc(100% + 6px); right: auto; min-width: 10rem; }
 .select-option {
   display: block; width: 100%; text-align: left;
-  padding: 7px 12px; border: none; border-radius: 8px;
-  background: transparent; color: var(--text); font: inherit; font-size: 13px;
-  cursor: pointer; transition: background 0.1s;
+  padding: 7px 12px; border: none; border-radius: var(--radius-sm);
+  background: transparent; color: var(--text); font: inherit; font-size: var(--text-control); line-height: var(--leading-ui);
+  cursor: pointer; transition: background var(--motion-fast);
   white-space: nowrap;
 }
 .select-option:hover { background: var(--hover); }
-.select-option.active { background: var(--accent-soft); color: var(--accent); font-weight: 600; }
+.select-option.active { background: var(--accent-soft); color: var(--accent); font-weight: var(--weight-semibold); }
 
 /* ---- switch ---- */
 .switch {
   width: 34px;
   height: 20px;
-  border-radius: 99px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--border);
   cursor: pointer;
   background: var(--raised);
@@ -448,24 +535,29 @@ select.input { appearance: none; }
   flex-shrink: 0;
   line-height: 0;
   vertical-align: middle;
-  transition: background 0.15s, border-color 0.15s;
+  transition: background var(--motion-normal), border-color var(--motion-normal);
   appearance: none;
   -webkit-appearance: none;
 }
-.switch.on { background: var(--accent); border-color: var(--accent); }
+.switch.on { background: var(--toggle-on-bg); border-color: var(--toggle-on-bg); }
 .switch:disabled { opacity: 0.6; cursor: default; }
 .switch .knob {
   width: 14px;
   height: 14px;
-  border-radius: 50%;
+  border-radius: var(--radius-round);
   background: light-dark(#ffffff, #ececec);
   box-shadow: 0 0 0 1px rgba(16, 24, 40, 0.08), 0 1px 1px rgba(16, 24, 40, 0.18);
   transform: translateX(0);
-  transition: transform 0.15s, background 0.15s;
+  transition: transform var(--motion-normal), background var(--motion-normal);
 }
 .switch.on .knob {
   transform: translateX(14px);
-  background: var(--accent-ink);
+  /* [Decision Log]
+  - 목적: 다크 모드의 활성 트랙과 핸들이 모두 밝게 뭉개지는 문제를 없앤다.
+  - 대안 분석: 테두리만 강화하면 상태 구분이 약하고, 화면별 색상 지정은 중복되며, 공통 토글 토큰은 모든 스위치에 같은 대비 규칙을 적용한다.
+  - 선택 근거: 활성 트랙은 다크 모드 성공 색상, 핸들은 어두운 색으로 분리해 상태와 위치를 동시에 읽기 쉽다.
+  */
+  background: var(--toggle-dot-color);
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.12);
 }
 
@@ -474,23 +566,23 @@ select.input { appearance: none; }
 .faint { color: var(--faint); }
 .row { display: flex; align-items: center; gap: 10px; }
 .spread { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
-.setting-hint { font-size: 13px; margin-top: 3px; }
+.setting-hint { font-size: var(--text-control); line-height: var(--leading-body); margin-top: 3px; }
 .stack { display: flex; flex-direction: column; }
-.chip { font-family: var(--mono); font-size: 12px; background: var(--raised); border: 1px solid var(--border); padding: 1px 7px; border-radius: var(--radius-xs); color: var(--text); }
+.chip { font-family: var(--font-code); font-size: var(--text-label); line-height: var(--leading-ui); background: var(--raised); border: 1px solid var(--border); padding: 1px 7px; border-radius: var(--radius-xs); color: var(--text); }
 
 .empty { text-align: center; padding: 56px 20px; border: 1px dashed var(--border); border-radius: var(--radius); color: var(--muted); }
 .empty svg { width: 30px; height: 30px; color: var(--faint); margin-bottom: 12px; }
-.empty .title { color: var(--text); font-weight: 600; margin-bottom: 6px; }
+.empty .title { color: var(--text); font-weight: var(--weight-semibold); margin-bottom: 6px; }
 
-.notice { font-size: 13px; padding: 9px 12px; border-radius: var(--radius-sm); margin-bottom: 14px; display: flex; align-items: center; gap: 8px; }
+.notice { font-size: var(--text-control); line-height: var(--leading-body); padding: 9px 12px; border-radius: var(--radius-sm); margin-bottom: 14px; display: flex; align-items: center; gap: 8px; }
 .notice svg { width: 15px; height: 15px; flex-shrink: 0; }
 .notice-ok { background: var(--green-soft); color: var(--green); }
 .notice-err { background: var(--red-soft); color: var(--red); }
 
-.h-section { font-size: 13px; font-weight: 600; color: var(--text); margin: 30px 0 12px; display: flex; align-items: center; gap: 8px; }
-.h-section .count { color: var(--muted); font-weight: 500; font-family: var(--mono); font-size: 12px; }
+.h-section { font-size: var(--text-control); font-weight: var(--weight-semibold); line-height: var(--leading-ui); color: var(--text); margin: 30px 0 12px; display: flex; align-items: center; gap: 8px; }
+.h-section .count { color: var(--muted); font-weight: var(--weight-medium); font-family: var(--font-code); font-size: var(--text-label); }
 
-.spin { width: 14px; height: 14px; border: 2px solid var(--border); border-top-color: var(--accent); border-radius: 50%; display: inline-block; animation: spin 0.7s linear infinite; }
+.spin { width: 14px; height: 14px; border: 2px solid var(--border); border-top-color: var(--accent); border-radius: var(--radius-round); display: inline-block; animation: spin 0.7s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
 
 @media (prefers-reduced-motion: reduce) { * { transition: none !important; animation: none !important; } }
@@ -512,16 +604,16 @@ select.input { appearance: none; }
 /* ---- modal ---- */
 /* Liquid-glass modal: heavy tint + blur so background content is unreadable */
 .modal-overlay { position: fixed; inset: 0; background: light-dark(rgba(17, 19, 28, 0.78), rgba(0, 0, 0, 0.82)); backdrop-filter: blur(40px) saturate(1.2); -webkit-backdrop-filter: blur(40px) saturate(1.2); display: flex; align-items: flex-start; justify-content: center; padding: 8vh 16px; z-index: 50; }
-.modal-card { background: color-mix(in oklab, canvas 92%, transparent); backdrop-filter: blur(20px) saturate(1.4); -webkit-backdrop-filter: blur(20px) saturate(1.4); border: 1px solid var(--border); border-radius: 16px; padding: 20px; width: 100%; max-width: 520px; box-shadow: 0 8px 32px rgb(0 0 0 / 0.18); max-height: 84vh; overflow-y: auto; }
+.modal-card { background: color-mix(in oklab, canvas 92%, transparent); backdrop-filter: blur(20px) saturate(1.4); -webkit-backdrop-filter: blur(20px) saturate(1.4); border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 20px; width: 100%; max-width: 520px; box-shadow: 0 8px 32px rgb(0 0 0 / 0.18); max-height: 84vh; overflow-y: auto; }
 .modal-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
-.modal-head h3 { font-size: 16px; }
+.modal-head h3 { font-size: var(--text-subtitle); }
 
 /* ---- codex auth page ---- */
 .card-head { display: flex; align-items: center; gap: 8px; padding: 14px 16px 6px; flex-wrap: wrap; min-width: 0; }
 .card-head strong { min-width: 0; overflow-wrap: anywhere; }
-.card-sub { font-size: 12px; color: var(--muted); padding: 0 16px 10px; min-width: 0; overflow-wrap: anywhere; }
+.card-sub { font-size: var(--text-label); line-height: var(--leading-body); color: var(--muted); padding: 0 16px 10px; min-width: 0; overflow-wrap: anywhere; }
 .card-active { border-color: var(--accent-ring); }
-.card-right { margin-left: auto; display: flex; align-items: center; gap: 4px; font-size: 11px; color: var(--faint); }
+.card-right { margin-left: auto; display: flex; align-items: center; gap: 4px; font-size: var(--text-caption); color: var(--faint); }
 .btn-icon-danger.card-right {
   appearance: none;
   background: transparent;
@@ -537,27 +629,27 @@ select.input { appearance: none; }
 .dot-muted { background: var(--muted); }
 .dot-amber { background: var(--amber); box-shadow: 0 0 0 3px var(--amber-soft); }
 .section-sep { display: flex; align-items: center; gap: 10px; margin: 20px 0 12px; }
-.section-label { font-size: 12.5px; color: var(--muted); font-weight: 500; white-space: nowrap; }
+.section-label { font-size: var(--text-label); color: var(--muted); font-weight: var(--weight-medium); white-space: nowrap; }
 .sep-line { flex: 1; height: 1px; background: var(--border); }
 .quota-compact { padding: 2px 16px 12px; display: grid; gap: 4px; }
 .quota-row { display: grid; grid-template-columns: minmax(34px, max-content) 34px minmax(34px, 44px) minmax(38px, 42px) minmax(58px, 1fr) minmax(30px, max-content); align-items: center; gap: 8px; min-width: 0; }
-.quota-label { font-size: 11px; color: var(--muted); font-weight: 600; }
-.quota-val { font-size: 11px; font-family: var(--mono); color: var(--text); text-align: right; }
-.quota-reset-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 11px; color: var(--faint); }
+.quota-label { font-size: var(--text-caption); color: var(--muted); font-weight: var(--weight-semibold); }
+.quota-val { font-size: var(--text-caption); font-family: var(--font-code); color: var(--text); text-align: right; }
+.quota-reset-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: var(--text-caption); color: var(--faint); }
 .quota-reset-day,
-.quota-reset-time { font-size: 11px; color: var(--muted); white-space: nowrap; }
-.quota-reset-time { font-family: var(--mono); }
-.bar { height: 5px; background: var(--raised); border-radius: 3px; overflow: hidden; min-width: 0; }
-.bar-fill { height: 100%; border-radius: 3px; transition: width 0.3s; }
+.quota-reset-time { font-size: var(--text-caption); color: var(--muted); white-space: nowrap; }
+.quota-reset-time { font-family: var(--font-code); }
+.bar { height: 5px; background: var(--raised); border-radius: var(--radius-2xs); overflow: hidden; min-width: 0; }
+.bar-fill { height: 100%; border-radius: var(--radius-2xs); transition: width var(--motion-normal); }
 .bar-green { background: var(--green); }
 .bar-amber { background: linear-gradient(90deg, var(--green), var(--amber)); }
-.toggle { width: 36px; height: 20px; border-radius: 10px; background: var(--raised); border: 1px solid var(--border); cursor: pointer; position: relative; transition: background 0.15s; flex-shrink: 0; }
-.toggle.on { background: var(--accent); border-color: var(--accent); }
-.toggle-knob { width: 16px; height: 16px; background: white; border-radius: 50%; position: absolute; top: 1px; left: 1px; transition: left 0.15s; }
-.toggle.on .toggle-knob { left: 17px; }
-.notice-warn { font-size: 12px; padding: 8px 10px; border-radius: var(--radius-sm); background: var(--amber-soft); color: var(--amber); display: flex; align-items: center; gap: 6px; margin-bottom: 12px; }
+.toggle { width: var(--toggle-w); height: var(--toggle-h); border-radius: var(--radius-pill); background: var(--toggle-off-bg); border: 1px solid var(--border); cursor: pointer; position: relative; transition: background var(--motion-normal), border-color var(--motion-normal); flex-shrink: 0; }
+.toggle.on { background: var(--toggle-on-bg); border-color: var(--toggle-on-bg); }
+.toggle-knob { width: 16px; height: 16px; background: light-dark(#ffffff, #ececec); border-radius: var(--radius-round); position: absolute; top: 1px; left: 1px; transition: left var(--motion-normal), background var(--motion-normal); }
+.toggle.on .toggle-knob { left: 17px; background: var(--toggle-dot-color); }
+.notice-warn { font-size: var(--text-label); line-height: var(--leading-body); padding: 8px 10px; border-radius: var(--radius-sm); background: var(--amber-soft); color: var(--amber); display: flex; align-items: center; gap: 6px; margin-bottom: 12px; }
 .notice-warn svg { width: 14px; height: 14px; flex-shrink: 0; }
-.modal-desc { font-size: 13px; color: var(--muted); margin-bottom: 14px; }
+.modal-desc { font-size: var(--text-control); line-height: var(--leading-body); color: var(--muted); margin-bottom: 14px; }
 .modal-actions { display: flex; gap: 8px; margin-top: 16px; }
 .modal-actions .btn { flex: 1; }
 
@@ -572,27 +664,27 @@ select.input { appearance: none; }
 .log-status-cell { display: inline-flex; flex-direction: column; align-items: flex-start; gap: 2px; }
 .log-detail-btn {
   background: none; border: none; padding: 0; cursor: pointer;
-  color: var(--accent-hover); font: inherit; font-size: 11px; text-decoration: underline;
+  color: var(--accent-hover); font: inherit; font-size: var(--text-caption); text-decoration: underline;
   white-space: nowrap;
 }
-.log-detail-grid { display: grid; grid-template-columns: max-content minmax(0, 1fr); gap: 6px 14px; font-size: 13px; }
+.log-detail-grid { display: grid; grid-template-columns: max-content minmax(0, 1fr); gap: 6px 14px; font-size: var(--text-control); }
 .log-detail-break { word-break: break-all; }
 .log-detail-json {
   background: var(--raised); border: 1px solid var(--border-soft); border-radius: var(--radius-sm);
-  padding: 10px 12px; font-family: var(--mono); font-size: 11.5px; line-height: 1.5;
+  padding: 10px 12px; font-family: var(--font-code); font-size: var(--text-caption); line-height: var(--leading-body);
   overflow: auto; max-height: 40vh; white-space: pre-wrap; word-break: break-all; margin: 0;
 }
 
-.setup-guide { font-size: 13px; border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 8px 12px; margin-bottom: 4px; }
-.setup-guide summary { cursor: pointer; color: var(--accent-hover); font-weight: 500; }
+.setup-guide { font-size: var(--text-control); line-height: var(--leading-body); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 8px 12px; margin-bottom: 4px; }
+.setup-guide summary { cursor: pointer; color: var(--accent-hover); font-weight: var(--weight-medium); }
 .setup-guide summary:hover { text-decoration: underline; }
 .setup-guide a { color: var(--accent-hover); }
 
 /* clickable list rows (preset picker, provider cards) */
-.list-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; width: 100%; text-align: left; padding: 11px 13px; border-radius: var(--radius-sm); border: 1px solid var(--border); background: var(--raised); cursor: pointer; color: var(--text); font: inherit; transition: background 0.12s, border-color 0.12s; }
+.list-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; width: 100%; text-align: left; padding: 11px 13px; border-radius: var(--radius-sm); border: 1px solid var(--border); background: var(--raised); cursor: pointer; color: var(--text); font: inherit; transition: background var(--motion-fast), border-color var(--motion-fast); }
 .list-row:hover { background: var(--raised-hover); border-color: var(--accent-ring); }
-.list-row .title { font-weight: 600; font-size: 14px; }
-.list-row .sub { font-size: 12px; color: var(--muted); margin-top: 2px; }
+.list-row .title { font-weight: var(--weight-semibold); font-size: var(--text-body); }
+.list-row .sub { font-size: var(--text-label); color: var(--muted); margin-top: 2px; }
 
 /* provider config card (Providers page) */
 .prov-card { overflow: hidden; }
@@ -601,29 +693,29 @@ select.input { appearance: none; }
 .prov-card-info { display: flex; align-items: flex-start; gap: 11px; min-width: 0; flex: 1 1 360px; }
 .prov-card-copy { min-width: 0; flex: 1; }
 .prov-title { display: flex; align-items: center; gap: 8px; margin-bottom: 5px; flex-wrap: wrap; min-width: 0; }
-.provider-icon { width: 31px; height: 31px; border-radius: 7px; flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center; background: var(--raised); border: 1px solid var(--border-soft); color: var(--text); }
+.provider-icon { width: 31px; height: 31px; border-radius: var(--radius-xs); flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center; background: var(--raised); border: 1px solid var(--border-soft); color: var(--text); }
 .provider-icon img { width: 19px; height: 19px; object-fit: contain; display: block; }
 .prov-meta { display: flex; align-items: center; gap: 5px; flex-wrap: wrap; min-width: 0; }
 .prov-meta > span { min-width: 0; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .provider-quota { padding-left: 58px; }
 .provider-actions { margin-left: auto; display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
-.link-btn { background: none; border: none; color: var(--accent-hover); font: inherit; font-size: 13px; cursor: pointer; padding: 6px 2px; text-decoration: underline; }
+.link-btn { background: none; border: none; color: var(--accent-hover); font: inherit; font-size: var(--text-control); cursor: pointer; padding: 6px 2px; text-decoration: underline; }
 
 /* provider card accounts dropdown (multiauth) */
 .prov-accounts-toggle {
   width: 100%; display: flex; align-items: center; justify-content: center; gap: 6px;
   background: none; border: none; border-top: 1px solid var(--border-soft);
-  color: var(--muted); font: inherit; font-size: 12px; padding: 4px 0; cursor: pointer; min-height: 24px;
+  color: var(--muted); font: inherit; font-size: var(--text-label); padding: 4px 0; cursor: pointer; min-height: 24px;
 }
 .prov-accounts-toggle:hover { color: var(--text); background: var(--raised); }
-.prov-accounts-toggle .chev { transition: transform 0.15s ease; display: inline-flex; }
+.prov-accounts-toggle .chev { transition: transform var(--motion-normal) ease; display: inline-flex; }
 .prov-accounts-toggle .chev svg { width: 12px; height: 12px; transform: rotate(90deg); }
 .prov-accounts-toggle.open .chev svg { transform: rotate(-90deg); }
 .prov-accounts-list { border-top: 1px solid var(--border-soft); padding: 6px 16px 10px; display: flex; flex-direction: column; gap: 2px; }
 .prov-account-row {
   display: flex; align-items: center; gap: 8px; width: 100%; text-align: left;
   background: none; border: none; border-radius: var(--radius-xs);
-  color: var(--text); font: inherit; font-size: 13px; padding: 6px 8px; cursor: pointer; min-height: 32px;
+  color: var(--text); font: inherit; font-size: var(--text-control); line-height: var(--leading-ui); padding: 6px 8px; cursor: pointer; min-height: 32px;
 }
 .prov-account-row:hover { background: var(--raised); }
 .prov-account-row.active { cursor: default; }
@@ -631,26 +723,26 @@ select.input { appearance: none; }
 .prov-account-row .badge { flex: 0 0 auto; }
 .prov-account-remove { flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center; background: none; border: none; color: var(--muted); cursor: pointer; padding: 4px; border-radius: var(--radius-xs); }
 .prov-account-remove:hover { color: var(--red); background: var(--red-soft); }
-.prov-account-add { color: var(--muted); font-size: 12.5px; }
+.prov-account-add { color: var(--muted); font-size: var(--text-label); }
 .prov-account-add:hover { color: var(--accent-hover); }
 .prov-account-keyform { cursor: default; gap: 6px; }
 .prov-account-keyform:hover { background: none; }
-.prov-account-keyform .input-sm { flex: 1 1 auto; min-width: 0; padding: 4px 8px; font-size: 12.5px; height: 28px; }
+.prov-account-keyform .input-sm { flex: 1 1 auto; min-width: 0; padding: 4px 8px; font-size: var(--text-label); height: var(--control-sm); }
 
 /* account login grid (Providers page): shared name | status | action columns across rows */
 .oauth-grid { display: grid; grid-template-columns: minmax(140px, max-content) minmax(0, 1fr) max-content; column-gap: 16px; row-gap: 10px; align-items: center; }
 .oauth-row { grid-column: 1 / -1; display: grid; grid-template-columns: subgrid; align-items: center; min-height: 30px; }
-.oauth-name { display: inline-flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 600; min-width: 0; }
+.oauth-name { display: inline-flex; align-items: center; gap: 8px; font-size: var(--text-control); font-weight: var(--weight-semibold); min-width: 0; }
 .oauth-name-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.provider-icon-sm { width: 24px; height: 24px; border-radius: 6px; }
+.provider-icon-sm { width: 24px; height: 24px; border-radius: var(--radius-xs); }
 .provider-icon-sm img { width: 15px; height: 15px; }
-.oauth-status { display: inline-flex; align-items: center; gap: 7px; font-size: 13px; min-width: 0; }
+.oauth-status { display: inline-flex; align-items: center; gap: 7px; font-size: var(--text-control); min-width: 0; }
 .oauth-email { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
 .oauth-actions { display: inline-flex; justify-content: flex-end; align-items: center; gap: 8px; min-width: 0; }
-.oauth-login-hint { grid-column: 1 / -1; font-size: 12px; display: flex; flex-direction: column; align-items: stretch; gap: 8px; }
+.oauth-login-hint { grid-column: 1 / -1; font-size: var(--text-label); line-height: var(--leading-body); display: flex; flex-direction: column; align-items: stretch; gap: 8px; }
 .oauth-login-hint-links { display: inline-flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .oauth-login-paste { display: flex; gap: 8px; align-items: center; width: 100%; }
-.oauth-login-paste .input { flex: 1; min-width: 0; font-size: 12px; padding: 6px 10px; }
+.oauth-login-paste .input { flex: 1; min-width: 0; font-size: var(--text-label); padding: 6px 10px; }
 
 /* responsive: compact sticky top bar (menu + brand + stop) with the desktop sidebar
    reused as an off-canvas drawer — 10 destinations no longer fit an always-visible
@@ -681,7 +773,7 @@ select.input { appearance: none; }
     background: light-dark(rgba(249, 249, 249, 0.97), rgba(23, 23, 23, 0.96));
     transform: translateX(-100%);
     visibility: hidden;   /* removes the closed drawer from the tab order / a11y tree */
-    transition: transform 0.18s ease, visibility 0.18s;
+    transition: transform var(--motion-normal) ease, visibility var(--motion-normal);
     overflow-y: auto; outline: none;
   }
   .sidebar.open {
@@ -712,11 +804,11 @@ select.input { appearance: none; }
 }
 
 .usage-cards { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; margin-top: 8px; }
-.usage-cards .stat-value { font-size: 20px; font-weight: 600; margin-top: 4px; }
-.usage-range { display: inline-flex; border: 1px solid var(--border); border-radius: 999px; padding: 2px; gap: 2px; background: var(--surface); }
-.usage-range-btn { border: none; background: transparent; color: var(--muted); padding: 4px 12px; border-radius: 999px; cursor: pointer; font: inherit; }
-.usage-range-btn.active { background: var(--raised); color: var(--text); font-weight: 600; }
-.panel-title { margin: 0 0 12px; font-size: 14px; font-weight: 600; color: var(--text); }
+.usage-cards .stat-value { font-size: var(--text-title); font-weight: var(--weight-semibold); margin-top: 4px; }
+.usage-range { display: inline-flex; border: 1px solid var(--border); border-radius: var(--radius-pill); padding: 2px; gap: 2px; background: var(--surface); }
+.usage-range-btn { border: none; background: transparent; color: var(--muted); padding: 4px 12px; border-radius: var(--radius-pill); cursor: pointer; font: inherit; }
+.usage-range-btn.active { background: var(--raised); color: var(--text); font-weight: var(--weight-semibold); }
+.panel-title { margin: 0 0 12px; font-size: var(--text-body); font-weight: var(--weight-semibold); color: var(--text); }
 .panel-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
 .panel-head .panel-title { margin: 0; }
 .panel-head .input { max-width: 220px; }
@@ -724,45 +816,45 @@ select.input { appearance: none; }
    grid overflows horizontally instead, and JS keeps the scroll pinned to the right
    (most recent weeks). */
 .heatmap { --hm-cell: 11px; --hm-gap: 3px; display: flex; flex-direction: column; gap: 6px; overflow-x: auto; padding-bottom: 4px; }
-.heatmap-months { display: grid; font-size: 11px; color: var(--muted); margin-bottom: -2px; width: max-content; }
+.heatmap-months { display: grid; font-size: var(--text-caption); color: var(--muted); margin-bottom: -2px; width: max-content; }
 .heatmap-day-spacer { grid-column: 1; }
 .heatmap-month { white-space: nowrap; }
 .heatmap-body { display: flex; gap: var(--hm-gap); width: max-content; }
-.heatmap-days { display: grid; grid-template-rows: repeat(7, var(--hm-cell)); row-gap: var(--hm-gap); font-size: 10px; color: var(--muted); width: 25px; flex-shrink: 0; align-items: center; position: sticky; left: 0; background: var(--surface); z-index: 1; }
+.heatmap-days { display: grid; grid-template-rows: repeat(7, var(--hm-cell)); row-gap: var(--hm-gap); font-size: var(--text-micro); color: var(--muted); width: 25px; flex-shrink: 0; align-items: center; position: sticky; left: 0; background: var(--surface); z-index: 1; }
 .heatmap-grid { display: grid; gap: var(--hm-gap); }
 .heatmap-week { display: grid; grid-template-rows: repeat(7, var(--hm-cell)); gap: var(--hm-gap); }
-.heatmap-cell { width: var(--hm-cell); height: var(--hm-cell); border-radius: 2px; background: var(--border); }
+.heatmap-cell { width: var(--hm-cell); height: var(--hm-cell); border-radius: var(--radius-2xs); background: var(--border); }
 .heatmap-cell-0 { background: var(--border); }
 .heatmap-cell-1 { background: color-mix(in oklch, var(--green) 25%, var(--surface)); }
 .heatmap-cell-2 { background: color-mix(in oklch, var(--green) 50%, var(--surface)); }
 .heatmap-cell-3 { background: color-mix(in oklch, var(--green) 75%, var(--surface)); }
 .heatmap-cell-4 { background: var(--green); }
-.heatmap-legend { display: inline-flex; align-items: center; gap: 4px; font-size: 12px; align-self: flex-end; position: sticky; right: 0; }
+.heatmap-legend { display: inline-flex; align-items: center; gap: 4px; font-size: var(--text-label); align-self: flex-end; position: sticky; right: 0; }
 .heatmap-legend .heatmap-cell { width: 10px; height: 10px; }
 .heatmap-tip { position: fixed; z-index: 10; transform: translate(-50%, -100%) translateY(-8px); pointer-events: none;
-  background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 6px 10px;
-  box-shadow: 0 6px 20px rgba(0,0,0,0.35); white-space: nowrap; font-size: 12px; }
-.heatmap-tip-date { font-weight: 600; color: var(--text); margin-bottom: 2px; }
+  background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 6px 10px;
+  box-shadow: 0 6px 20px rgba(0,0,0,0.35); white-space: nowrap; font-size: var(--text-label); }
+.heatmap-tip-date { font-weight: var(--weight-semibold); color: var(--text); margin-bottom: 2px; }
 .heatmap-tip-val { color: var(--text); font-variant-numeric: tabular-nums; }
-.heatmap-tip-req { font-size: 11px; }
-.usage-bar { width: 100%; height: 6px; background: var(--border); border-radius: 999px; overflow: hidden; min-width: 60px; }
-.usage-bar-fill { height: 100%; background: var(--green); border-radius: 999px; }
+.heatmap-tip-req { font-size: var(--text-caption); }
+.usage-bar { width: 100%; height: 6px; background: var(--border); border-radius: var(--radius-pill); overflow: hidden; min-width: 60px; }
+.usage-bar-fill { height: 100%; background: var(--green); border-radius: var(--radius-pill); }
 
 /* 7d view: per-day request bar chart (replaces the year heatmap on the 7d toggle). */
 .daybars { display: grid; grid-template-columns: repeat(7, 1fr); gap: 10px; align-items: end; height: 180px; padding-top: 8px; }
 .daybar { position: relative; display: flex; flex-direction: column; align-items: center; gap: 6px; height: 100%; justify-content: flex-end; }
-.daybar-track { width: 100%; max-width: 48px; flex: 1; display: flex; align-items: flex-end; background: var(--border); border-radius: 6px; overflow: hidden; }
-.daybar-stack { width: 100%; display: flex; flex-direction: column-reverse; border-radius: 6px 6px 0 0; overflow: hidden; min-height: 2px; transition: height 0.2s ease; }
+.daybar-track { width: 100%; max-width: 48px; flex: 1; display: flex; align-items: flex-end; background: var(--border); border-radius: var(--radius-xs); overflow: hidden; }
+.daybar-stack { width: 100%; display: flex; flex-direction: column-reverse; border-radius: var(--radius-xs) var(--radius-xs) 0 0; overflow: hidden; min-height: 2px; transition: height var(--motion-normal) ease; }
 .daybar-seg { width: 100%; min-height: 1px; }
-.daybar-count { font-size: 12px; font-weight: 600; color: var(--text); }
-.daybar-label { font-size: 11px; white-space: nowrap; }
+.daybar-count { font-size: var(--text-label); font-weight: var(--weight-semibold); color: var(--text); }
+.daybar-label { font-size: var(--text-caption); white-space: nowrap; }
 .daybar:hover .daybar-track { outline: 1px solid var(--border); }
 .daybar-tip { position: absolute; bottom: calc(100% + 6px); left: 50%; transform: translateX(-50%); z-index: 5;
-  background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 8px 10px;
+  background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 8px 10px;
   min-width: 160px; box-shadow: 0 6px 20px rgba(0,0,0,0.35); pointer-events: none; }
-.daybar-tip-date { font-size: 12px; font-weight: 600; color: var(--text); margin-bottom: 6px; white-space: nowrap; }
-.daybar-tip-row { display: flex; align-items: center; gap: 8px; font-size: 12px; line-height: 1.7; }
-.daybar-tip-swatch { width: 10px; height: 10px; border-radius: 2px; flex-shrink: 0; }
+.daybar-tip-date { font-size: var(--text-label); font-weight: var(--weight-semibold); color: var(--text); margin-bottom: 6px; white-space: nowrap; }
+.daybar-tip-row { display: flex; align-items: center; gap: 8px; font-size: var(--text-label); line-height: var(--leading-relaxed); }
+.daybar-tip-swatch { width: 10px; height: 10px; border-radius: var(--radius-2xs); flex-shrink: 0; }
 .daybar-tip-name { color: var(--text); flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 160px; }
 .daybar-tip-val { color: var(--muted); font-variant-numeric: tabular-nums; }
 
@@ -773,8 +865,8 @@ select.input { appearance: none; }
 /* ── Toggle switch ── */
 .toggle { position: relative; display: inline-block; width: var(--toggle-w); height: var(--toggle-h); flex-shrink: 0; }
 .toggle input { opacity: 0; width: 0; height: 0; position: absolute; }
-.toggle .slider { position: absolute; inset: 0; background: var(--toggle-off-bg); border-radius: var(--radius-pill); cursor: pointer; transition: background 0.15s ease; }
-.toggle .slider::after { content: ""; position: absolute; top: 3px; left: 3px; width: var(--toggle-dot); height: var(--toggle-dot); background: var(--toggle-dot-color); border-radius: 50%; transition: transform 0.15s ease; }
+.toggle .slider { position: absolute; inset: 0; background: var(--toggle-off-bg); border-radius: var(--radius-pill); cursor: pointer; transition: background var(--motion-normal) ease; }
+.toggle .slider::after { content: ""; position: absolute; top: 3px; left: 3px; width: var(--toggle-dot); height: var(--toggle-dot); background: var(--toggle-dot-color); border-radius: var(--radius-round); transition: transform var(--motion-normal) ease; }
 .toggle input:checked + .slider { background: var(--toggle-on-bg); }
 .toggle input:checked + .slider::after { transform: translateX(calc(var(--toggle-w) - var(--toggle-dot) - 6px)); }
 .toggle input:focus-visible + .slider { outline: 2px solid var(--accent-ring); outline-offset: 2px; }
@@ -783,5 +875,5 @@ select.input { appearance: none; }
 .setting-row { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; gap: 16px; }
 .setting-row + .setting-row { border-top: 1px solid var(--border-soft); }
 .setting-label { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.setting-label .title { font-size: 13.5px; font-weight: 550; color: var(--text); }
-.setting-label .desc { font-size: 12px; color: var(--muted); line-height: 1.4; }
+.setting-label .title { font-size: var(--text-body); font-weight: var(--weight-semibold); color: var(--text); }
+.setting-label .desc { font-size: var(--text-label); color: var(--muted); line-height: var(--leading-body); }

--- a/gui/src/ui.tsx
+++ b/gui/src/ui.tsx
@@ -84,7 +84,7 @@ export function EmptyState({ icon, title, children, className, style }: { icon?:
     <div className={className ? `empty ${className}` : "empty"} style={style}>
       {icon}
       <div className="title">{title}</div>
-      {children && <div style={{ fontSize: 13 }}>{children}</div>}
+      {children && <div className="text-control">{children}</div>}
     </div>
   );
 }

--- a/gui/vite.config.ts
+++ b/gui/vite.config.ts
@@ -5,9 +5,21 @@ import react from '@vitejs/plugin-react'
 // Bake the parent package version into the bundle as a fallback for moments when the runtime
 // `/healthz` version is not reachable yet.
 const version = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')).version
+const proxyTarget = process.env.OPENCODEX_PROXY_TARGET
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   define: { __APP_VERSION__: JSON.stringify(version) },
+  /* [Decision Log]
+  - 목적: 로컬 Vite GUI가 실행 중인 opencodex API를 same-origin으로 호출해 CORS 잡음 없이 실제 데이터를 보여준다.
+  - 대안 분석: API 없이 정적 화면만 띄우면 기능 검증이 불가능하고, 별도 프록시 서버는 유지보수 대상이 늘며, Vite 내장 proxy는 개발 시에만 기존 서버를 재사용한다.
+  - 선택 근거: 환경변수가 있을 때만 활성화되어 프로덕션 번들과 기본 개발 동작을 바꾸지 않고 로컬 통합 검증에 필요한 경로만 연결한다.
+  */
+  server: proxyTarget ? {
+    proxy: {
+      '/api': { target: proxyTarget, changeOrigin: true },
+      '/healthz': { target: proxyTarget, changeOrigin: true },
+    },
+  } : undefined,
 })


### PR DESCRIPTION
## What changed

- introduce role-based typography, spacing, radius, motion, icon, and control tokens for the GUI
- normalize page-level typography across Dashboard, Providers, Models, Logs, Debug, Usage, Codex Auth, Subagents, and Claude Code
- improve dark-mode enabled-toggle contrast and add separation between sidebar navigation items
- add an opt-in Vite same-origin proxy for integrated local GUI testing
- document foundations, components, contribution rules, and architecture decisions under `docs/design-system/`

## Why

The GUI had thirteen near-duplicate font sizes, page-local weights/radii, and two switch implementations with inconsistent dark-mode contrast. Adjacent sidebar hover/active surfaces also visually merged. Centralizing these decisions gives every page the same hierarchy and makes future light/dark changes maintainable.

## User impact

- clearer enabled-toggle state in dark mode
- more distinct sidebar hover and active states
- consistent UI, body, label, code, and heading typography across the full GUI
- documented rules for future GUI changes

## Validation

- `cd gui && bun run lint` (0 errors; 2 existing TanStack Virtual compiler warnings)
- `cd gui && bun run build`
- Playwright Chromium QA across all 10 navigation destinations
- dark, light, and 390x844 mobile drawer visual checks
- no console errors or framework overlay
- local Vite GUI, `/healthz`, and `/api/settings` all returned HTTP 200 through the opt-in proxy
- token audits confirmed no direct numeric font size/weight/line-height or border-radius values remain in GUI CSS/TSX
