### PR TITLE
fix(claude): clear Anthropic passthrough deadline after headers

### DIFF
--- a/src/server/claude-messages.ts
+++ b/src/server/claude-messages.ts
@@ -19,6 +19,7 @@ import {
   responsesJsonToAnthropicMessage,
   responsesSseToAnthropicSse,
 } from "../claude/outbound";
+import { clearableDeadline } from "../lib/abort";
 import { estimateTokens } from "../lib/token-estimate";
 import { routeModel } from "../router";
 import type { OcxConfig } from "../types";
@@ -204,24 +205,24 @@ async function anthropicNativePassthrough(
   });
   headers.set("content-type", "application/json");
 
-  const timeoutSignal = AbortSignal.timeout(config.connectTimeoutMs ?? 120_000);
-  const upstreamSignal = AbortSignal.any([req.signal, timeoutSignal]);
+  const headerDeadline = clearableDeadline(config.connectTimeoutMs ?? 120_000, req.signal);
   let upstream: Response;
   try {
     upstream = await fetch(`${base}${pathname}${search}`, {
       method: "POST",
       headers,
       body: JSON.stringify(body),
-      signal: upstreamSignal,
+      signal: headerDeadline.signal,
     });
   } catch (err) {
-    if (timeoutSignal.aborted && upstreamSignal.reason === timeoutSignal.reason) {
+    if (headerDeadline.didExpire()) {
       finalize(504, { closeReason: "non_stream" });
       return anthropicErrorResponse(504, "anthropic passthrough timed out waiting for response headers", "timeout_error");
     }
     finalize(502, { closeReason: "non_stream" });
     return anthropicErrorResponse(502, `anthropic passthrough failed: ${err instanceof Error ? err.message : String(err)}`, "api_error");
   }
+  headerDeadline.clear();
 
   const contentType = upstream.headers.get("content-type") ?? "application/json";
   if (upstream.ok && contentType.includes("text/event-stream") && upstream.body) {

--- a/tests/claude-messages-endpoint.test.ts
+++ b/tests/claude-messages-endpoint.test.ts
@@ -142,6 +142,48 @@ test("non-streaming /v1/messages returns an Anthropic message JSON", async () =>
   }
 });
 
+test("native Anthropic passthrough clears the header deadline before streaming the body", async () => {
+  const encoder = new TextEncoder();
+  const upstream = Bun.serve({
+    port: 0,
+    fetch() {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode('event: message_start\ndata: {"type":"message_start"}\n\n'));
+          setTimeout(() => {
+            controller.enqueue(encoder.encode('event: message_stop\ndata: {"type":"message_stop"}\n\n'));
+            controller.close();
+          }, 600);
+        },
+      });
+      return new Response(body, { headers: { "content-type": "text/event-stream" } });
+    },
+  });
+  const config = mockConfig("http://127.0.0.1:1/v1", {
+    anthropicBaseUrl: upstream.url.toString().replace(/\/$/, ""),
+  });
+  config.connectTimeoutMs = 200;
+  saveConfig(config);
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/messages", server.url), {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-api-key": "sk-ant-test" },
+      body: JSON.stringify({
+        model: "claude-test",
+        max_tokens: 16,
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("message_stop");
+  } finally {
+    server.stop(true);
+    upstream.stop(true);
+  }
+});
+
 test("native openai-responses route carries prompt_cache_key + synthesized session_id header", async () => {
   const capture: { headers?: Record<string, string>; body?: Record<string, any> } = {};
   const upstream = Bun.serve({


### PR DESCRIPTION
## Summary

- replace the native Anthropic passthrough's non-clearable
  `AbortSignal.timeout()` with the existing `clearableDeadline()` helper
- clear the deadline as soon as upstream response headers arrive
- keep the response body linked to the client request signal
- add a regression test whose SSE body outlives `connectTimeoutMs`

Fixes #135

## Problem

`connectTimeoutMs` is a response-header arrival budget, but the native
Anthropic passthrough kept its timeout signal attached to the entire response
body.

As a result, a valid SSE response could be terminated after the deadline even
when its headers arrived immediately.

## Test coverage

The new endpoint regression test uses a local mock Anthropic upstream:

- response headers and `message_start` arrive immediately
- `connectTimeoutMs` is 200 ms
- `message_stop` arrives after 600 ms

Before this change, reading the response body ends at the timeout and the
final event is missing. After this change, the complete SSE body arrives.

## Verification

- focused regression test: pass
- `tests/claude-messages-endpoint.test.ts`: 12 passed
- typecheck: pass
- privacy scan: pass
- runtime proxy verification:
  - body completed after 681 ms with a 200 ms header deadline
  - delayed response headers still returned 504 after approximately 200 ms

The full Windows test run also reported three unrelated pre-existing
environment/path failures in `codex-v2-gate.test.ts` and `doctor.test.ts`;
the Claude endpoint test file passed in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
