### PR TITLE
fix(kiro): seed GPT-5.6 Sol/Terra/Luna from official Kiro catalog

### DIFF
--- a/src/providers/kiro-models.ts
+++ b/src/providers/kiro-models.ts
@@ -1,5 +1,9 @@
 export const KIRO_MODELS = [
   "kiro-auto",
+  // OpenAI GPT-5.6 (Kiro experimental, us-east-1) — added to official catalog 2026-07-13
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
   "claude-sonnet-5",
   "claude-opus-4.8",
   "claude-opus-4.7",
@@ -17,11 +21,12 @@ export const KIRO_MODELS = [
 ];
 
 // Per-model context windows as documented on Kiro's official model catalog
-// (https://kiro.dev/docs/models/ — "Quick comparison", page updated 2026-06-19).
-// claude-sonnet-5 is pre-seeded from Anthropic/OpenRouter 1M metadata until Kiro's
-// public catalog catches up.
+// (https://kiro.dev/docs/models/ — "Quick comparison", page updated 2026-07-14).
 // "Auto" is a router with no fixed window on Kiro's table, so it is intentionally omitted.
 export const KIRO_MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+  "gpt-5.6-sol": 272_000,
+  "gpt-5.6-terra": 272_000,
+  "gpt-5.6-luna": 272_000,
   "claude-sonnet-5": 1_000_000,
   "claude-opus-4.8": 1_000_000,
   "claude-opus-4.7": 1_000_000,

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -354,6 +354,10 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     note: "Import-first: reuses your installed kiro-cli login (no browser). Experimental third-party harness — see Kiro ToS.",
     models: KIRO_MODELS,
     defaultModel: "kiro-auto",
+    // Kiro speaks CodeWhisperer wire, not OpenAI-style GET /models. Keep the static
+    // catalog authoritative so a spurious 2xx from runtime.../models cannot drop seeded ids
+    // (e.g. newly listed GPT-5.6 tiers) via live-discovery reconciliation.
+    liveModels: false,
     // Per-model context metadata is maintained next to the Kiro model list.
     modelContextWindows: KIRO_MODEL_CONTEXT_WINDOWS,
     modelReasoningEfforts: KIRO_MODEL_REASONING_EFFORTS,

--- a/tests/kiro-adapter.test.ts
+++ b/tests/kiro-adapter.test.ts
@@ -94,6 +94,11 @@ describe("kiro adapter — buildRequest", () => {
       ["claude-4.5-sonnet-high", "claude-sonnet-4.5"],
       ["claude-4-5-opus-max", "claude-opus-4.5"],
       ["minimax-m2-1", "minimax-m2.1"],
+      // GPT-5.6 tiers (Kiro 2026-07-13): keep dotted minor + tier suffix intact
+      ["gpt-5.6-sol", "gpt-5.6-sol"],
+      ["kiro/gpt-5.6-terra", "gpt-5.6-terra"],
+      ["gpt-5-6-luna", "gpt-5.6-luna"],
+      ["gpt-5.6-sol-high", "gpt-5.6-sol"],
     ]) {
       expect(normalizeKiroModelId(input)).toBe(expected);
       const { body } = await createKiroAdapter(provider).buildRequest(parsedWith([{ role: "user", content: "hi" }], undefined, input));
@@ -560,7 +565,14 @@ describe("kiro adapter — per-model context windows (kiro.dev/docs/models)", ()
   const cw = kiro.modelContextWindows ?? {};
 
   test("registry includes the currently documented Kiro models", () => {
-    for (const id of ["claude-opus-4.5", "claude-sonnet-4.0", "minimax-m2.1"]) {
+    for (const id of [
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+      "claude-opus-4.5",
+      "claude-sonnet-4.0",
+      "minimax-m2.1",
+    ]) {
       expect(kiro.models ?? []).toContain(id);
     }
   });
@@ -573,6 +585,9 @@ describe("kiro adapter — per-model context windows (kiro.dev/docs/models)", ()
   });
 
   test("smaller-context models match Kiro's published limits", () => {
+    expect(cw["gpt-5.6-sol"]).toBe(272_000);
+    expect(cw["gpt-5.6-terra"]).toBe(272_000);
+    expect(cw["gpt-5.6-luna"]).toBe(272_000);
     expect(cw["claude-opus-4.5"]).toBe(200_000);
     expect(cw["claude-sonnet-4.5"]).toBe(200_000);
     expect(cw["claude-sonnet-4.0"]).toBe(200_000);
@@ -582,6 +597,10 @@ describe("kiro adapter — per-model context windows (kiro.dev/docs/models)", ()
     expect(cw["glm-5"]).toBe(200_000);
     expect(cw["deepseek-3.2"]).toBe(128_000);
     expect(cw["qwen3-coder-next"]).toBe(256_000);
+  });
+
+  test("kiro catalog is static (no OpenAI-style live /models)", () => {
+    expect(kiro.liveModels).toBe(false);
   });
 
   test("Auto router has no fixed window (omitted)", () => {


### PR DESCRIPTION
## Summary
- Seed Kiro's official GPT-5.6 tiers (`gpt-5.6-sol` / `terra` / `luna`, 272K context) into the static `KIRO_MODELS` catalog so Codex shows `kiro/gpt-5.6-*`.
- Set `liveModels: false` for the Kiro provider — CodeWhisperer runtime is not OpenAI-style `GET /models`, so a spurious live response must not drop seeded catalog ids.
- Cover id normalization + registry context windows in tests.

## Context
Kiro published GPT-5.6 Sol/Terra/Luna on 2026-07-13 ([docs](https://kiro.dev/docs/models/)). opencodex still shipped the pre-GPT static list, so OAuth reconcile rewrote user configs and routed models never appeared as `kiro/gpt-5.6-*`.

## Test plan
- [x] `bun test tests/kiro-adapter.test.ts -t "normalizes versioned|per-model context|kiro catalog is static|registry includes"`
- [x] Local install patch: after restart, `/v1/models` lists `kiro/gpt-5.6-sol`, `kiro/gpt-5.6-terra`, `kiro/gpt-5.6-luna`
- [ ] CI full suite on this PR