### PR TITLE
fix: clearer labels for upstream 403 permission failures

### DIFF
--- a/gui/src/status-codes.ts
+++ b/gui/src/status-codes.ts
@@ -23,10 +23,10 @@ const STATUS_CODES: Record<number, LocalizedInfo> = {
     de: { label: "Zahlung erforderlich", description: "Der Upstream-Anbieter hat die Anfrage abgelehnt, weil Abrechnung, Guthaben oder Planzugriff nicht verfügbar ist. Guthaben aufladen, Abrechnung aktualisieren oder Anbieter wechseln." },
   },
   403: {
-    en: { label: "Forbidden", description: "The account is authenticated but not allowed to use this model or operation. Check provider permissions, org access, and policy restrictions." },
-    ko: { label: "권한 없음", description: "계정 인증은 되었지만 이 모델 또는 작업을 사용할 권한이 없습니다. 제공자 권한, 조직 접근, 정책 제한을 확인해야 합니다." },
-    zh: { label: "禁止访问", description: "账号已认证，但无权使用此模型或操作。请检查提供商权限、组织访问权限和策略限制。" },
-    de: { label: "Verboten", description: "Das Konto ist authentifiziert, darf dieses Modell oder diese Operation aber nicht nutzen. Prüfe Anbieterberechtigungen, Organisationszugriff und Richtlinien." },
+    en: { label: "Forbidden", description: "The account is authenticated but not allowed to use this model or operation. Often a plan/subscription gate (e.g. Ollama Cloud Pro), org policy, or model permission — not necessarily a bad API key." },
+    ko: { label: "권한 없음", description: "계정 인증은 되었지만 이 모델 또는 작업을 사용할 권한이 없습니다. 플랜/구독 제한(예: Ollama Cloud Pro), 조직 정책, 모델 권한 문제인 경우가 많으며 API 키가 잘못된 것은 아닐 수 있습니다." },
+    zh: { label: "禁止访问", description: "账号已认证，但无权使用此模型或操作。常见原因是套餐/订阅限制（例如 Ollama Cloud Pro）、组织策略或模型权限——不一定是 API 密钥无效。" },
+    de: { label: "Verboten", description: "Das Konto ist authentifiziert, darf dieses Modell oder diese Operation aber nicht nutzen. Oft Plan-/Abo-Sperre (z. B. Ollama Cloud Pro), Organisationsrichtlinie oder Modellrecht — nicht zwingend ein ungültiger API-Key." },
   },
   404: {
     en: { label: "Not found", description: "The requested route, model, account, or upstream resource was not found. Verify the model name and opencodex provider configuration." },

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -4,75 +4,122 @@ export interface OcxErrorPayload {
   code: string | null;
 }
 
+function isSubscriptionGateMessage(text: string): boolean {
+  return (
+    text.includes("requires a subscription")
+    || text.includes("requires subscription")
+    || text.includes("subscription required")
+    || text.includes("upgrade for access")
+    || text.includes("upgrade to pro")
+    || text.includes("pro subscription")
+    || text.includes("ollama.com/upgrade")
+    || (text.includes("upgrade") && text.includes("subscription"))
+  );
+}
+
+function isAuthenticationMessage(text: string): boolean {
+  return (
+    text.includes("authentication failed")
+    || text.includes("invalid_api_key")
+    || text.includes("invalid api key")
+    || text.includes("invalid token")
+    || text.includes("unauthorizedexception")
+    || text.includes("unrecognizedclientexception")
+    || text.includes("unrecognizedclient")
+    || text.includes("expired token")
+    || text.includes("expiredtoken")
+    || text.includes("unauthenticated")
+    || text.includes("unauthorized")
+    // Kiro / AWS often wrap credential failures as AccessDeniedException.
+    || text.includes("access denied")
+  );
+}
+
+function isPermissionMessage(text: string): boolean {
+  return (
+    text.includes("permission_denied")
+    || text.includes("permission denied")
+    || text.includes("forbidden")
+    || text.includes("not allowed to use")
+    || text.includes("model access")
+    || isSubscriptionGateMessage(text)
+  );
+}
+
 export function classifyError(status: number, type: string, message: string): OcxErrorPayload {
   const text = message.toLowerCase();
   if (
-    text.includes("context_length_exceeded") ||
-    text.includes("context window") ||
-    text.includes("context length") ||
-    text.includes("maximum context") ||
-    text.includes("too many tokens")
+    text.includes("context_length_exceeded")
+    || text.includes("context window")
+    || text.includes("context length")
+    || text.includes("maximum context")
+    || text.includes("too many tokens")
   ) {
     return { message, type: "invalid_request_error", code: "context_length_exceeded" };
   }
   if (
-    text.includes("insufficient_quota") ||
-    text.includes("exceeded your current quota") ||
-    text.includes("quota exhausted") ||
-    text.includes("account quota exceeded") ||
-    text.includes("monthly quota exceeded") ||
-    text.includes("daily quota exceeded")
+    text.includes("insufficient_quota")
+    || text.includes("exceeded your current quota")
+    || text.includes("quota exhausted")
+    || text.includes("account quota exceeded")
+    || text.includes("monthly quota exceeded")
+    || text.includes("daily quota exceeded")
   ) {
     return { message, type: "insufficient_quota", code: "insufficient_quota" };
   }
   if (
-    status === 429 ||
-    text.includes("rate limit") ||
-    text.includes("rate limited") ||
-    text.includes("too many requests") ||
-    text.includes("resource_exhausted") ||
-    text.includes("resource exhausted") ||
-    text.includes("throttlingexception") ||
-    text.includes("throttling")
+    status === 429
+    || text.includes("rate limit")
+    || text.includes("rate limited")
+    || text.includes("too many requests")
+    || text.includes("resource_exhausted")
+    || text.includes("resource exhausted")
+    || text.includes("throttlingexception")
+    || text.includes("throttling")
   ) {
     return { message, type: "rate_limit_error", code: "rate_limit_exceeded" };
   }
   if (type === "origin_rejected") {
     return { message, type: "invalid_request_error", code: "origin_rejected" };
   }
+  // Plan / model gates before auth: providers (e.g. Ollama Cloud) return 403 for Pro-only
+  // models with a valid key. Those must not look like invalid_api_key in Logs.
+  if (isSubscriptionGateMessage(text)) {
+    return { message, type: "permission_error", code: "subscription_required" };
+  }
   if (
-    status === 401 ||
-    status === 403 ||
-    type === "authentication_error" ||
-    text.includes("authentication failed") ||
-    text.includes("access denied") ||
-    text.includes("unauthorizedexception") ||
-    text.includes("unrecognizedclientexception") ||
-    text.includes("unrecognizedclient") ||
-    text.includes("expired token") ||
-    text.includes("expiredtoken")
+    status === 401
+    || type === "authentication_error"
+    || isAuthenticationMessage(text)
   ) {
     return { message, type: "authentication_error", code: "invalid_api_key" };
   }
   if (
-    status === 503 ||
-    text.includes("overloaded") ||
-    text.includes("server is busy") ||
-    text.includes("temporarily unavailable")
+    status === 403
+    || type === "permission_error"
+    || isPermissionMessage(text)
+  ) {
+    return { message, type: "permission_error", code: "permission_denied" };
+  }
+  if (
+    status === 503
+    || text.includes("overloaded")
+    || text.includes("server is busy")
+    || text.includes("temporarily unavailable")
   ) {
     // Codex recognizes "server_is_overloaded" and applies retry-after backoff
     // (responses.rs is_server_overloaded_error); generic "upstream_server_error" is not recognized.
     return { message, type: "server_error", code: "server_is_overloaded" };
   }
   if (
-    text.includes("validationexception") ||
-    text.includes("invalid request") ||
-    text.includes("model unavailable") ||
-    text.includes("model not found") ||
-    text.includes("unsupported model") ||
-    text.includes("profile arn") ||
-    text.includes("wrong region") ||
-    text.includes("invalid region")
+    text.includes("validationexception")
+    || text.includes("invalid request")
+    || text.includes("model unavailable")
+    || text.includes("model not found")
+    || text.includes("unsupported model")
+    || text.includes("profile arn")
+    || text.includes("wrong region")
+    || text.includes("invalid region")
   ) {
     return { message, type: "invalid_request_error", code: "invalid_request_error" };
   }
@@ -105,41 +152,42 @@ export function parseRetryAfterFromMessage(message: string): number | undefined 
 export function inferHttpStatusFromAdapterMessage(message: string): number {
   const lower = message.toLowerCase();
   if (
-    lower.includes("resource_exhausted") ||
-    lower.includes("resource exhausted") ||
-    lower.includes("rate limit") ||
-    lower.includes("too many requests") ||
-    lower.includes("throttling")
+    lower.includes("resource_exhausted")
+    || lower.includes("resource exhausted")
+    || lower.includes("rate limit")
+    || lower.includes("too many requests")
+    || lower.includes("throttling")
   ) return 429;
+  if (isSubscriptionGateMessage(lower) || isPermissionMessage(lower)) return 403;
   if (
-    lower.includes("unauthenticated") ||
-    lower.includes("unauthorized") ||
-    lower.includes("permission_denied") ||
-    lower.includes("permission denied") ||
-    lower.includes("forbidden") ||
-    lower.includes("invalid token") ||
-    lower.includes("expired token") ||
-    lower.includes("authentication") ||
-    lower.includes("access denied")
+    lower.includes("unauthenticated")
+    || lower.includes("unauthorized")
+    || lower.includes("invalid token")
+    || lower.includes("expired token")
+    || lower.includes("authentication")
+    || lower.includes("invalid api key")
+    || lower.includes("invalid_api_key")
   ) return 401;
+  // AccessDenied without an auth/subscription cue — keep historical 401 mapping for Kiro-style text.
+  if (lower.includes("access denied")) return 401;
   if (
-    lower.includes("unavailable") ||
-    lower.includes("overloaded") ||
-    lower.includes("temporarily") ||
-    lower.includes("server is busy")
+    lower.includes("unavailable")
+    || lower.includes("overloaded")
+    || lower.includes("temporarily")
+    || lower.includes("server is busy")
   ) return 503;
   if (
-    lower.includes("invalid") ||
-    lower.includes("not found") ||
-    lower.includes("unsupported") ||
-    lower.includes("malformed") ||
-    lower.includes("unimplemented")
+    lower.includes("invalid")
+    || lower.includes("not found")
+    || lower.includes("unsupported")
+    || lower.includes("malformed")
+    || lower.includes("unimplemented")
   ) return 400;
   if (
-    lower.includes("timed out") ||
-    lower.includes("timeout") ||
-    lower.includes("etimedout") ||
-    lower.includes("deadline")
+    lower.includes("timed out")
+    || lower.includes("timeout")
+    || lower.includes("etimedout")
+    || lower.includes("deadline")
   ) return 504;
   return 502;
 }
@@ -156,11 +204,13 @@ export function adapterFailureFromMessage(message: string): { httpStatus: number
     ? "rate_limit_error"
     : httpStatus === 401
       ? "authentication_error"
-      : httpStatus === 503 || httpStatus === 504
-        ? "server_error"
-        : httpStatus === 400
-          ? "invalid_request_error"
-          : "upstream_error";
+      : httpStatus === 403
+        ? "permission_error"
+        : httpStatus === 503 || httpStatus === 504
+          ? "server_error"
+          : httpStatus === 400
+            ? "invalid_request_error"
+            : "upstream_error";
   return {
     httpStatus,
     error: classifyError(httpStatus, errorType, finalMessage),
@@ -176,6 +226,11 @@ export function httpStatusFromTerminalError(error: {
   if (!error) return 502;
   if (error.type === "rate_limit_error" || error.code === "rate_limit_exceeded") return 429;
   if (error.type === "authentication_error" || error.code === "invalid_api_key") return 401;
+  if (
+    error.type === "permission_error"
+    || error.code === "permission_denied"
+    || error.code === "subscription_required"
+  ) return 403;
   if (error.type === "insufficient_quota" || error.code === "insufficient_quota") return 429;
   if (error.type === "server_error" && error.code === "server_is_overloaded") return 503;
   if (error.type === "invalid_request_error") return 400;

--- a/src/server/request-log.ts
+++ b/src/server/request-log.ts
@@ -1,6 +1,9 @@
 import { existsSync, readFileSync } from "node:fs";
 import type { ResponsesTerminalStatus } from "../bridge";
-import { httpStatusFromTerminalError as httpStatusFromClassifiedTerminalError } from "../lib/errors";
+import {
+  classifyError,
+  httpStatusFromTerminalError as httpStatusFromClassifiedTerminalError,
+} from "../lib/errors";
 import { CODEX_CONFIG_PATH, readRootTomlString } from "../codex/paths";
 import { readCodexCatalogPath } from "../codex/catalog";
 import type { OcxUsage } from "../types";
@@ -119,10 +122,19 @@ export function nextRequestLogId(timestamp = Date.now()): string {
   return `ocx-${timestamp.toString(36)}-${requestLogSeq.toString(36)}`;
 }
 
-export function requestLogErrorCode(status: number): string | undefined {
+export function requestLogErrorCode(status: number, upstreamError?: string): string | undefined {
   if (status >= 200 && status < 400) return undefined;
   if (status === 400 || status === 409) return "invalid_request_error";
-  if (status === 401 || status === 403) return "invalid_api_key";
+  if (status === 401) return "invalid_api_key";
+  if (status === 403) {
+    // Prefer message-aware codes (e.g. Ollama Cloud subscription gates) over a blunt
+    // invalid_api_key — 403 usually means authenticated but not allowed.
+    if (upstreamError?.trim()) {
+      const code = classifyError(403, "upstream_error", upstreamError).code;
+      if (code) return code;
+    }
+    return "permission_denied";
+  }
   if (status === 429) return "rate_limit_exceeded";
   if (status === 499) return "client_closed_request";
   if (status === 503) return "server_is_overloaded";
@@ -375,7 +387,7 @@ export function addFinalRequestLog(
   meta?: Pick<RequestLogEntry, "terminalStatus" | "closeReason">,
   addLog: (entry: RequestLogEntry) => void = addRequestLog,
 ): void {
-  const errorCode = requestLogErrorCode(status);
+  const errorCode = requestLogErrorCode(status, logCtx.upstreamError);
   // Estimated-usage detection prefers the route ADAPTER: configured provider names
   // ("cursor-mykey") broke the old exact-name match and cursor rows logged as
   // accurately "reported" (devlog 130 B2).

--- a/tests/error-fidelity.test.ts
+++ b/tests/error-fidelity.test.ts
@@ -54,6 +54,14 @@ describe("error fidelity", () => {
       type: "authentication_error",
       code: "invalid_api_key",
     });
+    expect(classifyError(403, "upstream_error", "Provider error 403")).toMatchObject({
+      type: "permission_error",
+      code: "permission_denied",
+    });
+    expect(classifyError(403, "upstream_error", "this model requires a subscription, upgrade for access: https://ollama.com/upgrade")).toMatchObject({
+      type: "permission_error",
+      code: "subscription_required",
+    });
     expect(classifyError(502, "upstream_error", "Kiro invalid request: ValidationException: model not found")).toMatchObject({
       type: "invalid_request_error",
       code: "invalid_request_error",

--- a/tests/errors-adapter-failure.test.ts
+++ b/tests/errors-adapter-failure.test.ts
@@ -25,4 +25,15 @@ describe("adapterFailureFromMessage", () => {
       error: { type: "authentication_error" },
     });
   });
+
+  test("maps forbidden / subscription gates to 403 permission_error", () => {
+    expect(adapterFailureFromMessage("Provider stream error: forbidden")).toMatchObject({
+      httpStatus: 403,
+      error: { type: "permission_error", code: "permission_denied" },
+    });
+    expect(adapterFailureFromMessage("this model requires a subscription, upgrade for access: https://ollama.com/upgrade")).toMatchObject({
+      httpStatus: 403,
+      error: { type: "permission_error", code: "subscription_required" },
+    });
+  });
 });

--- a/tests/request-log.test.ts
+++ b/tests/request-log.test.ts
@@ -91,12 +91,57 @@ describe("request log metadata", () => {
     expect(requestLogErrorCode(200)).toBeUndefined();
     expect(requestLogErrorCode(400)).toBe("invalid_request_error");
     expect(requestLogErrorCode(401)).toBe("invalid_api_key");
+    expect(requestLogErrorCode(403)).toBe("permission_denied");
+    expect(requestLogErrorCode(403, "Provider error 403")).toBe("permission_denied");
+    expect(requestLogErrorCode(
+      403,
+      "Provider error 403: this model requires a subscription, upgrade for access: https://ollama.com/upgrade",
+    )).toBe("subscription_required");
     expect(requestLogErrorCode(429)).toBe("rate_limit_exceeded");
     expect(requestLogErrorCode(499)).toBe("client_closed_request");
     expect(requestLogErrorCode(503)).toBe("server_is_overloaded");
     expect(requestLogErrorCode(502)).toBe("upstream_server_error");
     expect(requestLogErrorCode(404)).toBe("http_404");
     expect(requestLogErrorCode(418)).toBe("http_418");
+  });
+
+  test("final 403 logs use permission/subscription codes instead of invalid_api_key", () => {
+    const entries: RequestLogEntry[] = [];
+    addFinalRequestLog(
+      "ocx-test-403-perm",
+      Date.now(),
+      {
+        model: "kimi-k2.7-code",
+        provider: "ollama-cloud",
+        upstreamError: "Provider error 403",
+      },
+      403,
+      { closeReason: "non_stream" },
+      entry => entries.push(entry),
+    );
+    expect(entries[0]).toMatchObject({
+      status: 403,
+      errorCode: "permission_denied",
+      upstreamError: "Provider error 403",
+    });
+
+    const subEntries: RequestLogEntry[] = [];
+    addFinalRequestLog(
+      "ocx-test-403-sub",
+      Date.now(),
+      {
+        model: "kimi-k2.7-code",
+        provider: "ollama-cloud",
+        upstreamError: "Provider error 403: this model requires a subscription, upgrade for access: https://ollama.com/upgrade",
+      },
+      403,
+      { closeReason: "non_stream" },
+      entry => subEntries.push(entry),
+    );
+    expect(subEntries[0]).toMatchObject({
+      status: 403,
+      errorCode: "subscription_required",
+    });
   });
 
   test("maps Codex fast service tier spellings to a display speed label", () => {


### PR DESCRIPTION
## Summary
- Upstream **403**s (e.g. Ollama Cloud plan/model gates) no longer classify as `invalid_api_key`.
- New codes: `permission_denied` (default 403) and `subscription_required` when the upstream text mentions subscription/upgrade.
- Request logs use the upstream message when classifying 403s; GUI Forbidden copy mentions plan/subscription gates.
- Fixes confusing Details UI reported in #142.

## Test plan
- [x] `bun test tests/error-fidelity.test.ts tests/errors-adapter-failure.test.ts tests/request-log.test.ts`
- [ ] Reproduce an Ollama Cloud Pro-gated model → Logs Details shows `permission_denied` or `subscription_required`, not `invalid_api_key`
- [ ] Confirm real 401 / bad-key failures still show `invalid_api_key`
