### PR TITLE
docs: clarify Bun allow-scripts / no sudo npm -g

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -70,6 +70,7 @@ flowchart LR
 
 ```bash
 # 설치 (Bun 런타임이 자동으로 번들됩니다 — Node 18+ 만 있으면 됩니다)
+# 사용자 소유 Node(nvm/fnm)를 쓰세요 — `sudo npm install -g …` 는 피하세요
 npm install -g @bitkyc08/opencodex
 
 # 대화형 설정 (config 작성 + Codex 주입 + 자동 시작 shim 설치 선택)
@@ -86,15 +87,27 @@ codex "Write a hello world in Rust"
 ```
 
 <details>
-<summary><b>"bundled Bun runtime is missing" 오류가 나나요?</b></summary>
+<summary><b>"bundled Bun runtime is missing" / npm이 Bun install 스크립트를 막나요?</b></summary>
 
 <br/>
 
-opencodex는 Bun 런타임을 의존성으로 번들하고 Node 런처로 실행하므로 Bun을 직접 설치할 필요가 **없습니다**. "bundled Bun runtime is missing" 오류가 보이면 설치 과정에서 lifecycle 스크립트나 optional 의존성이 건너뛰어진 경우입니다. 해당 플래그 없이 다시 설치하세요:
+opencodex는 Bun 런타임을 의존성으로 번들하고 Node 런처로 실행하므로 Bun을 직접 설치할 필요가 **없습니다**. "bundled Bun runtime is missing" 오류가 보이거나, npm이 Bun `postinstall`을 차단했다는 경고(`install-scripts` / `allowScripts`)가 나오면 lifecycle 스크립트나 optional 의존성이 건너뛰어진 경우입니다.
+
+**`sudo npm install -g …` 로 설치하지 마세요.** root prefix에 깔리면 이후 sudo 없는 명령이 다른 디렉터리를 볼 수 있습니다. 사용자 소유 Node(nvm, fnm, 또는 user npm prefix)를 쓰세요.
+
+스크립트를 허용한 채로 다시 설치하세요 (원래 설치와 같은 컨텍스트 — **패키지 이름을 포함**하세요. npm이 짧게 보여주는 `npm install -g --allow-scripts=bun` 만으로는 opencodex가 재설치되지 **않습니다**):
 
 ```bash
-npm install -g @bitkyc08/opencodex   # --ignore-scripts, --omit=optional 없이
+npm install -g --allow-scripts=bun @bitkyc08/opencodex
 ```
+
+이미 `sudo`로 설치했고 같은 root prefix에서 Bun을 풀어야 한다면 (비권장 — 가능하면 user-owned Node로 옮기세요):
+
+```bash
+sudo npm install -g --allow-scripts=bun @bitkyc08/opencodex
+```
+
+설치 시 `--ignore-scripts`, `--omit=optional` 도 쓰지 마세요.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Requires [Node](https://nodejs.org) 18+. The Bun runtime is bundled automaticall
 
 ```bash
 # Install (bundles the Bun runtime automatically — only Node 18+ required)
+# Prefer a user-owned Node (nvm/fnm) — avoid `sudo npm install -g …`
 npm install -g @bitkyc08/opencodex
 
 # Interactive setup (writes config, injects into Codex, and offers autostart shim install)
@@ -86,18 +87,36 @@ codex "Write a hello world in Rust"
 ```
 
 <details>
-<summary><b>"bundled Bun runtime is missing" error?</b></summary>
+<summary><b>"bundled Bun runtime is missing" / npm blocked Bun install scripts?</b></summary>
 
 <br/>
 
 opencodex bundles the Bun runtime as a dependency and runs it via a Node
 launcher, so you do **not** need to install Bun yourself. If you see a
-"bundled Bun runtime is missing" error, the install skipped lifecycle scripts
-or optional dependencies. Reinstall without those flags:
+"bundled Bun runtime is missing" error, or npm warns that Bun's `postinstall`
+was blocked (`install-scripts` / `allowScripts`), the install skipped lifecycle
+scripts or optional dependencies.
+
+**Do not install with `sudo npm install -g …`.** That puts globals under a root
+prefix; later non-sudo commands can target a different directory. Use a
+user-owned Node install (nvm, fnm, or a user npm prefix) instead.
+
+Reinstall with scripts allowed (same context as the original install — include
+the package name; npm's short `npm install -g --allow-scripts=bun` hint alone
+does **not** reinstall opencodex):
 
 ```bash
-npm install -g @bitkyc08/opencodex   # no --ignore-scripts, no --omit=optional
+npm install -g --allow-scripts=bun @bitkyc08/opencodex
 ```
+
+If you already installed with `sudo` and need to unblock Bun in that same root
+prefix (not recommended — migrate to a user-owned Node when you can):
+
+```bash
+sudo npm install -g --allow-scripts=bun @bitkyc08/opencodex
+```
+
+Also avoid `--ignore-scripts` and `--omit=optional` on the install.
 
 </details>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -69,6 +69,7 @@ flowchart LR
 
 ```bash
 # 安装（自动打包 Bun 运行时 —— 只需 Node 18+）
+# 优先使用用户自有的 Node（nvm/fnm）—— 避免 `sudo npm install -g …`
 npm install -g @bitkyc08/opencodex
 
 # 交互式初始化（写入配置 + 注入 Codex）
@@ -82,15 +83,27 @@ codex "Write a hello world in Rust"
 ```
 
 <details>
-<summary><b>遇到 "bundled Bun runtime is missing" 错误？</b></summary>
+<summary><b>遇到 "bundled Bun runtime is missing" / npm 拦截了 Bun 安装脚本？</b></summary>
 
 <br/>
 
-opencodex 把 Bun 运行时作为依赖打包，并通过 Node 启动器运行，所以你**不需要**自己安装 Bun。如果看到 "bundled Bun runtime is missing" 错误，说明安装时跳过了 lifecycle 脚本或 optional 依赖。请不带这些标志重新安装：
+opencodex 把 Bun 运行时作为依赖打包，并通过 Node 启动器运行，所以你**不需要**自己安装 Bun。如果看到 "bundled Bun runtime is missing" 错误，或 npm 警告 Bun 的 `postinstall` 被拦截（`install-scripts` / `allowScripts`），说明安装时跳过了 lifecycle 脚本或 optional 依赖。
+
+**不要用 `sudo npm install -g …` 安装。** 那样会装到 root 的全局目录，之后不加 sudo 的命令可能指向别处。请改用用户自有的 Node（nvm、fnm，或用户级 npm prefix）。
+
+请在允许脚本的情况下重新安装（与原安装同一上下文 —— **带上包名**；npm 提示的短命令 `npm install -g --allow-scripts=bun` **不会**单独重装 opencodex）：
 
 ```bash
-npm install -g @bitkyc08/opencodex   # 不要加 --ignore-scripts、--omit=optional
+npm install -g --allow-scripts=bun @bitkyc08/opencodex
 ```
+
+如果你已经用 `sudo` 装过，需要在同一个 root prefix 里放开 Bun（不推荐 —— 有机会请迁到用户自有 Node）：
+
+```bash
+sudo npm install -g --allow-scripts=bun @bitkyc08/opencodex
+```
+
+安装时也不要加 `--ignore-scripts`、`--omit=optional`。
 
 </details>
 


### PR DESCRIPTION
## Summary
- Expand the install troubleshooting details for blocked Bun `postinstall` / `allowScripts`
- Document that npm’s short `--allow-scripts=bun` hint does not reinstall the package
- Prefer user-owned Node; document matching `sudo` only as last resort for an existing root prefix

Addresses docs ask in #146.

## Test plan
- [ ] Skim Quick start + details in README.md / ko / zh-CN
- [ ] Confirm commands match the Ubuntu sudo recovery path described in #146