### PR TITLE
fix(gui): dialog overlay frame and sticky Sub-agent focus ring

### DIFF
--- a/gui/src/pages/Dashboard.tsx
+++ b/gui/src/pages/Dashboard.tsx
@@ -117,6 +117,16 @@ function sidecarBackendForModel(models: ModelInfo[], modelId: string): SidecarBa
   return models.find(model => model.id === modelId)?.provider === "anthropic" ? "anthropic" : "openai";
 }
 
+/** Restore focus to the opener without painting :focus-visible (avoids a sticky ring after mouse close). */
+function focusTriggerQuietly(trigger: HTMLButtonElement | null) {
+  if (!trigger) return;
+  try {
+    trigger.focus({ preventScroll: true, focusVisible: false });
+  } catch {
+    trigger.focus({ preventScroll: true });
+  }
+}
+
 function useModalDialog(open: boolean, triggerRef: RefObject<HTMLButtonElement | null>) {
   const dialogRef = useRef<HTMLDialogElement>(null);
 
@@ -130,13 +140,13 @@ function useModalDialog(open: boolean, triggerRef: RefObject<HTMLButtonElement |
     }
 
     if (dialog.open) dialog.close();
-    triggerRef.current?.focus();
+    focusTriggerQuietly(triggerRef.current);
   }, [open, triggerRef]);
 
   useEffect(() => () => {
     const dialog = dialogRef.current;
     if (dialog?.open) dialog.close();
-    triggerRef.current?.focus();
+    focusTriggerQuietly(triggerRef.current);
   }, [triggerRef]);
 
   return dialogRef;

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -628,6 +628,20 @@ select.input { appearance: none; }
 /* ---- modal ---- */
 /* Liquid-glass modal: heavy tint + blur so background content is unreadable */
 .modal-overlay { position: fixed; inset: 0; background: light-dark(rgba(17, 19, 28, 0.78), rgba(0, 0, 0, 0.82)); backdrop-filter: blur(40px) saturate(1.2); -webkit-backdrop-filter: blur(40px) saturate(1.2); display: flex; align-items: flex-start; justify-content: center; padding: 8vh 16px; z-index: 50; }
+/* Native <dialog>.showModal() UA styles (solid border + ::backdrop) stack on top of
+   .modal-overlay and produce a white frame + double dim. Reset when the dialog IS the overlay. */
+dialog.modal-overlay {
+  border: none;
+  margin: 0;
+  max-width: none;
+  max-height: none;
+  width: 100%;
+  height: 100%;
+  color: inherit;
+}
+dialog.modal-overlay::backdrop {
+  background: transparent;
+}
 .modal-card { background: color-mix(in oklab, canvas 92%, transparent); backdrop-filter: blur(20px) saturate(1.4); -webkit-backdrop-filter: blur(20px) saturate(1.4); border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 20px; width: 100%; max-width: 520px; box-shadow: 0 8px 32px rgb(0 0 0 / 0.18); max-height: 84vh; overflow-y: auto; }
 .modal-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
 .modal-head h3 { font-size: var(--text-subtitle); }


### PR DESCRIPTION
## Summary
- Request Logs detail uses a native `<dialog class="modal-overlay">`. Browser UA styles still draw a solid border plus a separate `::backdrop`, which stacked on our full-screen tint and produced the white rectangular frame / double-dimmed background around the error modal.
- Closing Dashboard Sub-agent help restored focus to the circular info button with `:focus-visible`, so the focus ring stacked on the icon’s own circle (sticky double ring until you clicked elsewhere). Restore now uses `focus({ focusVisible: false })` so keyboard a11y focus return stays, without the leftover mouse-close ring.

## Screenshots
<img width="194" height="117" alt="image-0dff0f11-b5e5-43f6-848f-9be340a98647" src="https://github.com/user-attachments/assets/163990ed-ba1c-46cb-a4f7-41615daa5d60" />
<img width="678" height="903" alt="image-11c86a74-4d37-434b-a5d9-1b70f10fef41" src="https://github.com/user-attachments/assets/94569eb5-f768-426c-8e7a-56538c82f29f" />

## Test plan
- [ ] Open Request Logs → click a failed row → confirm full-screen dim with no white frame / double tint
- [ ] Close the log detail (X / Escape / backdrop) → overlay clears cleanly
- [ ] Dashboard → open Sub-agent info help → close it → info icon should not keep a double focus ring
- [ ] Tab to the Sub-agent info button → keyboard focus ring still appears