### PR TITLE
fix(windows): hide icacls during secret ACL hardening

### DIFF
--- a/src/lib/windows-secret-acl.ts
+++ b/src/lib/windows-secret-acl.ts
@@ -64,11 +64,14 @@ function runIcacls(targetPath: string, directory: boolean): void {
     throw new Error("Cannot determine current Windows user for ACL hardening");
   }
 
+  // windowsHide: console-subsystem tools (icacls) otherwise flash a visible window
+  // and can hang until the 5s timeout when spawned from a GUI/proxy process (ETIMEDOUT).
   // Step 1: disable inheritance and remove inherited ACEs
   execFileSync("icacls.exe", [targetPath, "/inheritance:r"], {
     stdio: ["ignore", "pipe", "ignore"],
     timeout: 5000,
     shell: false,
+    windowsHide: true,
   });
 
   // Step 2: remove broad explicit grants using stable SIDs (not localized names).
@@ -82,6 +85,7 @@ function runIcacls(targetPath: string, directory: boolean): void {
     stdio: ["ignore", "pipe", "ignore"],
     timeout: 5000,
     shell: false,
+    windowsHide: true,
   });
 
   // Step 3: grant current user full control.
@@ -90,6 +94,7 @@ function runIcacls(targetPath: string, directory: boolean): void {
     stdio: ["ignore", "pipe", "ignore"],
     timeout: 5000,
     shell: false,
+    windowsHide: true,
   });
 }
 

--- a/tests/windows-secret-acl.test.ts
+++ b/tests/windows-secret-acl.test.ts
@@ -208,3 +208,12 @@ describe("diagnostics sanitization contract", () => {
     }
   });
 });
+
+describe("Windows icacls spawn contract", () => {
+  test("runIcacls always passes windowsHide so GUI/proxy spawns do not hang", async () => {
+    const src = await Bun.file(new URL("../src/lib/windows-secret-acl.ts", import.meta.url)).text();
+    const hideCount = [...src.matchAll(/windowsHide:\s*true/g)].length;
+    // Three icacls steps (inheritance / remove / grant) each need windowsHide.
+    expect(hideCount).toBeGreaterThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Kimi login failed with `ACL hardening failed (ETIMEDOUT)` because writing `auth.json` runs `icacls` with a 5s timeout.
- On Windows, spawning `icacls.exe` without `windowsHide: true` from the GUI/proxy process can hang until that timeout.
- This PR only adds `windowsHide: true` to the three ACL hardening `icacls` calls so OAuth login can finish.

## Test plan
- [ ] `bun test tests/windows-secret-acl.test.ts`
- [ ] GUI Providers → Login Kimi (Moonshot) on Windows completes without ACL ETIMEDOUT