### PR TITLE
fix(logs): classify web-search client aborts as 499, not upstream 502

### DIFF
--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -73,10 +73,14 @@ export function isClientClosedMessage(text: string): boolean {
 
 export function classifyError(status: number, type: string, message: string): OcxErrorPayload {
   const text = message.toLowerCase();
+  // Preserve explicit cancel types used by compact/combo JSON errors; unify message-inferred
+  // client closes (web-search abort text) onto client_closed_request for /api/logs.
+  if (type === "client_cancelled") {
+    return { message, type: "client_cancelled", code: "client_cancelled" };
+  }
   if (
     status === 499 ||
     type === "client_closed_request" ||
-    type === "client_cancelled" ||
     isClientClosedMessage(text)
   ) {
     return { message, type: "invalid_request_error", code: "client_closed_request" };

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -57,8 +57,30 @@ function isPermissionMessage(text: string): boolean {
   );
 }
 
+/** Client cancelled / closed the turn (web-search abort, SSE cancel, compact cancel, etc.). */
+export function isClientClosedMessage(text: string): boolean {
+  const lower = text.toLowerCase();
+  return (
+    lower.includes("client closed") ||
+    lower.includes("client cancelled") ||
+    lower.includes("client canceled") ||
+    lower.includes("canceled by client") ||
+    lower.includes("cancelled by client") ||
+    lower.includes("request canceled by client") ||
+    lower.includes("request cancelled by client")
+  );
+}
+
 export function classifyError(status: number, type: string, message: string): OcxErrorPayload {
   const text = message.toLowerCase();
+  if (
+    status === 499 ||
+    type === "client_closed_request" ||
+    type === "client_cancelled" ||
+    isClientClosedMessage(text)
+  ) {
+    return { message, type: "invalid_request_error", code: "client_closed_request" };
+  }
   if (
     text.includes("context_length_exceeded") ||
     text.includes("context window") ||
@@ -166,6 +188,8 @@ export function parseRetryAfterFromMessage(message: string): number | undefined 
 /** Infer HTTP status from adapter terminal error text (provider-agnostic keyword matching). */
 export function inferHttpStatusFromAdapterMessage(message: string): number {
   const lower = message.toLowerCase();
+  // Client aborts (e.g. mid web-search loop) must not look like upstream 502s in /api/logs.
+  if (isClientClosedMessage(lower)) return 499;
   if (
     lower.includes("resource_exhausted") ||
     lower.includes("resource exhausted") ||
@@ -207,17 +231,19 @@ export function adapterFailureFromMessage(message: string): { httpStatus: number
   if (retryAfterSeconds && !/please try again in /i.test(message)) {
     finalMessage = `${message} Please try again in ${retryAfterSeconds}s.`;
   }
-  const errorType = httpStatus === 429
-    ? "rate_limit_error"
-    : httpStatus === 401
-      ? "authentication_error"
-      : httpStatus === 403
-        ? "permission_error"
-        : httpStatus === 503 || httpStatus === 504
-          ? "server_error"
-          : httpStatus === 400
-            ? "invalid_request_error"
-            : "upstream_error";
+  const errorType = httpStatus === 499
+    ? "client_closed_request"
+    : httpStatus === 429
+      ? "rate_limit_error"
+      : httpStatus === 401
+        ? "authentication_error"
+        : httpStatus === 403
+          ? "permission_error"
+          : httpStatus === 503 || httpStatus === 504
+            ? "server_error"
+            : httpStatus === 400
+              ? "invalid_request_error"
+              : "upstream_error";
   return {
     httpStatus,
     error: classifyError(httpStatus, errorType, finalMessage),
@@ -231,6 +257,7 @@ export function httpStatusFromTerminalError(error: {
   message?: string;
 } | undefined): number {
   if (!error) return 502;
+  if (error.code === "client_closed_request" || error.code === "client_cancelled") return 499;
   if (error.type === "rate_limit_error" || error.code === "rate_limit_exceeded") return 429;
   if (error.type === "authentication_error" || error.code === "invalid_api_key") return 401;
   if (
@@ -240,9 +267,12 @@ export function httpStatusFromTerminalError(error: {
   ) return 403;
   if (error.type === "insufficient_quota" || error.code === "insufficient_quota") return 429;
   if (error.type === "server_error" && error.code === "server_is_overloaded") return 503;
+  // Client-closed messages often arrive as invalid_request_error after classifyError; check message
+  // before treating every invalid_request_error as HTTP 400.
+  const message = error.message ?? "";
+  if (message && isClientClosedMessage(message)) return 499;
   if (error.type === "invalid_request_error") return 400;
   if (error.type === "proxy_error") return 500;
-  const message = error.message ?? "";
   if (message) return inferHttpStatusFromAdapterMessage(message);
   return 502;
 }

--- a/src/server/request-log.ts
+++ b/src/server/request-log.ts
@@ -3,6 +3,7 @@ import type { ResponsesTerminalStatus } from "../bridge";
 import {
   classifyError,
   httpStatusFromTerminalError as httpStatusFromClassifiedTerminalError,
+  isClientClosedMessage,
 } from "../lib/errors";
 import { CODEX_CONFIG_PATH, readRootTomlString } from "../codex/paths";
 import { readCodexCatalogPath } from "../codex/catalog";
@@ -134,6 +135,10 @@ export function nextRequestLogId(timestamp = Date.now()): string {
 
 export function requestLogErrorCode(status: number, upstreamError?: string): string | undefined {
   if (status >= 200 && status < 400) return undefined;
+  // Defense in depth: mid-stream web-search aborts used to land as 502 with this message.
+  if (status === 499 || (upstreamError?.trim() && classifyError(status, "upstream_error", upstreamError).code === "client_closed_request")) {
+    return "client_closed_request";
+  }
   if (status === 400 || status === 409) return "invalid_request_error";
   if (status === 401) return "invalid_api_key";
   if (status === 403) {
@@ -146,7 +151,6 @@ export function requestLogErrorCode(status: number, upstreamError?: string): str
     return "permission_denied";
   }
   if (status === 429) return "rate_limit_exceeded";
-  if (status === 499) return "client_closed_request";
   if (status === 503) return "server_is_overloaded";
   if (status >= 500) return "upstream_server_error";
   return `http_${status}`;
@@ -400,11 +404,21 @@ export function addFinalRequestLog(
   meta?: Pick<RequestLogEntry, "terminalStatus" | "closeReason">,
   addLog: (entry: RequestLogEntry) => void = addRequestLog,
 ): void {
-  const errorCode = requestLogErrorCode(status, logCtx.upstreamError);
+  // Mid-stream web-search aborts used to emit response.failed and land as 502/upstream_server_error.
+  // Prefer the client-close classification whenever the captured reason says so.
+  const effectiveStatus = status >= 500 && logCtx.upstreamError && isClientClosedMessage(logCtx.upstreamError)
+    ? 499
+    : status;
+  const errorCode = requestLogErrorCode(effectiveStatus, logCtx.upstreamError);
+  // A response.failed whose classified status is 499 is still a client cancel, not an upstream
+  // terminal failure — keep /api/logs closeReason aligned with that.
+  const closeReason = effectiveStatus === 499
+    ? "client_cancel"
+    : meta?.closeReason;
   if (logCtx.activeAttempt) {
     finishRequestAttempt(
       logCtx.activeAttempt,
-      status,
+      effectiveStatus,
       Date.now() - (logCtx.activeAttemptStartedAt ?? start),
       logCtx.usage,
     );
@@ -440,11 +454,11 @@ export function addFinalRequestLog(
     ...(logCtx.modelSupportsServiceTier !== undefined ? { modelSupportsServiceTier: logCtx.modelSupportsServiceTier } : {}),
     ...(logCtx.responseServiceTier ? { responseServiceTier: logCtx.responseServiceTier } : {}),
     ...(logCtx.resolvedModel ? { resolvedModel: logCtx.resolvedModel } : {}),
-    status,
+    status: effectiveStatus,
     durationMs: Date.now() - start,
     ...(errorCode ? { errorCode } : {}),
     ...(meta?.terminalStatus ? { terminalStatus: meta.terminalStatus } : {}),
-    ...(meta?.closeReason ? { closeReason: meta.closeReason } : {}),
+    ...(closeReason ? { closeReason } : {}),
     ...(logCtx.upstreamError ? { upstreamError: logCtx.upstreamError } : {}),
     usageStatus,
     ...(loggedUsage ? { usage: loggedUsage } : {}),
@@ -458,7 +472,7 @@ export function addFinalRequestLog(
       provider: logCtx.provider,
       model: logCtx.model,
       upstreamContentType: logCtx.usageDebugContentType ?? null,
-      upstreamStatus: status,
+      upstreamStatus: effectiveStatus,
       bodyKind: logCtx.usageDebugBodyKind ?? "none",
       bodySample: logCtx.usageDebugBodySample ?? "",
       extractedUsage: loggedUsage ?? null,

--- a/tests/errors-adapter-failure.test.ts
+++ b/tests/errors-adapter-failure.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   adapterFailureFromMessage,
+  classifyError,
   parseRetryAfterFromMessage,
 } from "../src/lib/errors";
 
@@ -78,6 +79,13 @@ describe("adapterFailureFromMessage", () => {
     expect(adapterFailureFromMessage("search request canceled by client")).toMatchObject({
       httpStatus: 499,
       error: { code: "client_closed_request" },
+    });
+  });
+
+  test("preserves explicit client_cancelled JSON error type from compact/combo paths", () => {
+    expect(classifyError(499, "client_cancelled", "Client cancelled request")).toMatchObject({
+      type: "client_cancelled",
+      code: "client_cancelled",
     });
   });
 });

--- a/tests/errors-adapter-failure.test.ts
+++ b/tests/errors-adapter-failure.test.ts
@@ -65,4 +65,19 @@ describe("adapterFailureFromMessage", () => {
       error: { type: "authentication_error", code: "invalid_api_key" },
     });
   });
+
+  test("maps client-closed web-search aborts to 499 client_closed_request", () => {
+    expect(adapterFailureFromMessage("client closed request during web-search")).toMatchObject({
+      httpStatus: 499,
+      error: { type: "invalid_request_error", code: "client_closed_request" },
+    });
+    expect(adapterFailureFromMessage("Client cancelled request")).toMatchObject({
+      httpStatus: 499,
+      error: { code: "client_closed_request" },
+    });
+    expect(adapterFailureFromMessage("search request canceled by client")).toMatchObject({
+      httpStatus: 499,
+      error: { code: "client_closed_request" },
+    });
+  });
 });

--- a/tests/request-log.test.ts
+++ b/tests/request-log.test.ts
@@ -276,6 +276,7 @@ describe("request log metadata", () => {
     )).toBe("invalid_api_key");
     expect(requestLogErrorCode(429)).toBe("rate_limit_exceeded");
     expect(requestLogErrorCode(499)).toBe("client_closed_request");
+    expect(requestLogErrorCode(502, "client closed request during web-search")).toBe("client_closed_request");
     expect(requestLogErrorCode(503)).toBe("server_is_overloaded");
     expect(requestLogErrorCode(502)).toBe("upstream_server_error");
     expect(requestLogErrorCode(404)).toBe("http_404");
@@ -535,12 +536,80 @@ describe("request log metadata", () => {
     });
   });
 
+  test("deferred SSE logging maps web-search client closes to 499 client_cancel", async () => {
+    const entries: RequestLogEntry[] = [];
+    const message = "client closed request during web-search";
+    const failedPayload = JSON.stringify({
+      type: "response.failed",
+      response: {
+        error: { type: "invalid_request_error", code: "client_closed_request", message },
+        last_error: { type: "invalid_request_error", code: "client_closed_request", message },
+      },
+    });
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(`data: ${failedPayload}\n\n`));
+        controller.close();
+      },
+    });
+    const response = responseWithDeferredRequestLog(
+      new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } }),
+      "ocx-test-web-search-client-close",
+      Date.now(),
+      { model: "k3", provider: "kimi" },
+      entry => entries.push(entry),
+    );
+
+    await response.text();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      terminalStatus: "failed",
+      upstreamError: message,
+      status: 499,
+      errorCode: "client_closed_request",
+      closeReason: "client_cancel",
+    });
+  });
+
+  test("addFinalRequestLog remaps legacy 502 client-close messages to 499", () => {
+    const entries: RequestLogEntry[] = [];
+    addFinalRequestLog(
+      "ocx-test-legacy-client-close",
+      Date.now(),
+      {
+        model: "k3",
+        provider: "kimi",
+        upstreamError: "client closed request during web-search",
+      },
+      502,
+      { terminalStatus: "failed", closeReason: "terminal" },
+      entry => entries.push(entry),
+    );
+    expect(entries[0]).toMatchObject({
+      status: 499,
+      errorCode: "client_closed_request",
+      closeReason: "client_cancel",
+      upstreamError: "client closed request during web-search",
+    });
+  });
+
   test("httpStatusFromTerminalError maps Cursor rate limits to 429", () => {
     expect(httpStatusFromTerminalError({
       type: "rate_limit_error",
       code: "rate_limit_exceeded",
       message: "Cursor rate limit exceeded: Cursor Connect error resource_exhausted: too many requests",
     })).toBe(429);
+  });
+
+  test("httpStatusFromTerminalError maps client-closed web-search aborts to 499", () => {
+    expect(httpStatusFromTerminalError({
+      type: "invalid_request_error",
+      code: "client_closed_request",
+      message: "client closed request during web-search",
+    })).toBe(499);
+    expect(httpStatusFromTerminalError({
+      message: "client closed request during web-search",
+    })).toBe(499);
   });
 
   test("httpStatusFromTerminalError preserves auth precedence and permission status", () => {


### PR DESCRIPTION
## Summary
- Mid-stream OpenCodex web-search cancels surface as `response.failed` with `client closed request during web-search`.
- That message was inferred as HTTP `502` / `upstream_server_error` with `closeReason: terminal`, which looked like a Kimi upstream failure.
- Classify client-close messages as `499` / `client_closed_request` / `closeReason: client_cancel`, including a legacy remap when a 5xx log still carries that reason.
- Preserve explicit `client_cancelled` JSON errors used by combo/compact paths.

This does **not** change Kimi itself or stop web-search sidecar behavior — it fixes log/error classification so cancels are not mistaken for provider outages.

## Test plan
- [x] `bun test tests/errors-adapter-failure.test.ts tests/request-log.test.ts tests/web-search.test.ts`
- [x] `bun test tests/server-combo-failover-e2e.test.ts -t ""connect cancellation""`
- [ ] Reproduce a cancelled web-search turn on a routed model (e.g. `kimi/k3`) and confirm `/api/logs` shows `499` + `client_closed_request` + `client_cancel`