### PR TITLE
fix(quota): accurate Cursor totals and restore missing Kimi usage

### DIFF
--- a/src/providers/quota.ts
+++ b/src/providers/quota.ts
@@ -1,5 +1,6 @@
 import { fetchMainAccountInfo, listCodexAuthAccounts } from "../codex/auth-api";
 import { MAIN_CODEX_ACCOUNT_ID } from "../codex/main-account";
+import { resolveEnvValue } from "../config";
 import { getValidAccessToken } from "../oauth";
 import { getCredential } from "../oauth/store";
 import { antigravityUserAgent } from "../adapters/client-fingerprint";
@@ -79,7 +80,14 @@ function providerLabel(providerId: string): string {
 function normalizeResetAt(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) return value > 10_000_000_000 ? value : value * 1000;
   if (typeof value === "string" && value.trim()) {
-    const parsed = Date.parse(value);
+    const trimmed = value.trim();
+    // Cursor Connect RPC returns billingCycleEnd as a unix-ms decimal string ("1771077734000").
+    // Date.parse treats that as invalid; numeric epoch strings must be handled explicitly.
+    if (/^\d+(\.\d+)?$/.test(trimmed)) {
+      const numeric = Number(trimmed);
+      if (Number.isFinite(numeric)) return numeric > 10_000_000_000 ? numeric : numeric * 1000;
+    }
+    const parsed = Date.parse(trimmed);
     return Number.isFinite(parsed) ? parsed : undefined;
   }
   return undefined;
@@ -231,38 +239,67 @@ function quotaResetAt(row: Record<string, unknown>): number | undefined {
   return normalizeResetAt(row.resetTime ?? row.resetAt ?? row.reset_time ?? row.reset_at);
 }
 
+function isCanonicalKimiCodeBaseUrl(baseUrl: string): boolean {
+  return normalizedBaseUrl(baseUrl) === KIMI_CODE_BASE_URL;
+}
+
+/** Prefer the nested `data` shell when the outer object is only an envelope. */
+function unwrapKimiQuotaPayload(value: unknown): Record<string, unknown> | null {
+  const body = asRecord(value);
+  if (!body) return null;
+  const nested = asRecord(body.data);
+  if (!nested) return body;
+  const outerHasUsage = body.usage !== undefined || body.limits !== undefined || body.totalQuota !== undefined;
+  const nestedHasUsage = nested.usage !== undefined || nested.limits !== undefined || nested.totalQuota !== undefined;
+  return !outerHasUsage && nestedHasUsage ? nested : body;
+}
+
+function kimiLimitLabel(item: Record<string, unknown>, detail: Record<string, unknown>): string {
+  return [item.name, item.title, item.scope, detail.name, detail.title]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ")
+    .toLowerCase();
+}
+
 function parseKimiQuotaRow(value: unknown, resetFallback?: Record<string, unknown>): { percent: number; resetAt?: number } | null {
   const row = asRecord(value);
   if (!row) return null;
-  const limit = toFiniteNumber(row.limit);
-  if (limit === undefined || limit <= 0) return null;
-  let used = toFiniteNumber(row.used);
-  if (used === undefined) {
-    const remaining = toFiniteNumber(row.remaining);
-    if (remaining === undefined) return null;
-    used = limit - remaining;
-  }
-  const percent = normalizePercent((used / limit) * 100);
-  if (percent === undefined) return null;
   const resetAt = quotaResetAt(row) ?? (resetFallback ? quotaResetAt(resetFallback) : undefined);
-  return { percent, ...(resetAt !== undefined ? { resetAt } : {}) };
+  const limit = toFiniteNumber(row.limit);
+  if (limit !== undefined && limit > 0) {
+    let used = toFiniteNumber(row.used);
+    if (used === undefined) {
+      const remaining = toFiniteNumber(row.remaining);
+      if (remaining !== undefined) used = limit - remaining;
+    }
+    if (used !== undefined) {
+      const percent = normalizePercent((used / limit) * 100);
+      if (percent !== undefined) return { percent, ...(resetAt !== undefined ? { resetAt } : {}) };
+    }
+  }
+  // Some payloads expose utilisation directly when limit/used arithmetic is absent.
+  const direct = normalizePercent(row.utilization ?? row.percent ?? row.usedPercent ?? row.used_percent);
+  return direct === undefined ? null : { percent: direct, ...(resetAt !== undefined ? { resetAt } : {}) };
 }
 
 function isKimiFiveHourLimit(item: Record<string, unknown>, detail: Record<string, unknown>, window: Record<string, unknown>): boolean {
   const duration = toFiniteNumber(window.duration ?? item.duration ?? detail.duration);
   const unit = String(window.timeUnit ?? item.timeUnit ?? detail.timeUnit ?? "").toUpperCase();
   if ((unit.includes("MINUTE") && duration === 300) || (unit.includes("HOUR") && duration === 5)) return true;
-  const label = [item.name, item.title, item.scope, detail.name, detail.title]
-    .filter((value): value is string => typeof value === "string")
-    .join(" ")
-    .toLowerCase();
-  return /(^|\b)5\s*(?:h|hour)/.test(label);
+  return /(^|\b)5\s*(?:h|hour)/.test(kimiLimitLabel(item, detail));
+}
+
+function isKimiWeeklyLimit(item: Record<string, unknown>, detail: Record<string, unknown>, window: Record<string, unknown>): boolean {
+  const duration = toFiniteNumber(window.duration ?? item.duration ?? detail.duration);
+  const unit = String(window.timeUnit ?? item.timeUnit ?? detail.timeUnit ?? "").toUpperCase();
+  if ((unit.includes("DAY") && duration === 7) || (unit.includes("HOUR") && duration === 168)) return true;
+  return /weekly|7\s*(?:d|day)/.test(kimiLimitLabel(item, detail));
 }
 
 function parseKimiQuotaPayload(value: unknown): ProviderQuota | null {
-  const body = asRecord(value);
+  const body = unwrapKimiQuotaPayload(value);
   if (!body) return null;
-  const weekly = parseKimiQuotaRow(body.usage);
+  let weekly = parseKimiQuotaRow(body.usage);
   const total = parseKimiQuotaRow(body.totalQuota);
   let fiveHour: { percent: number; resetAt?: number } | null = null;
   if (Array.isArray(body.limits)) {
@@ -271,9 +308,13 @@ function parseKimiQuotaPayload(value: unknown): ProviderQuota | null {
       if (!item) continue;
       const detail = asRecord(item.detail) ?? item;
       const window = asRecord(item.window) ?? {};
-      if (!isKimiFiveHourLimit(item, detail, window)) continue;
-      fiveHour = parseKimiQuotaRow(detail, window);
-      if (fiveHour) break;
+      if (!fiveHour && isKimiFiveHourLimit(item, detail, window)) {
+        fiveHour = parseKimiQuotaRow(detail, window);
+      }
+      if (!weekly && isKimiWeeklyLimit(item, detail, window)) {
+        weekly = parseKimiQuotaRow(detail, window);
+      }
+      if (fiveHour && weekly) break;
     }
   }
   const quota: ProviderQuota = {
@@ -291,15 +332,28 @@ function parseKimiQuotaPayload(value: unknown): ProviderQuota | null {
   return hasQuotaRows(quota) ? quota : null;
 }
 
-async function fetchKimiQuota(provider: string, config: OcxProviderConfig): Promise<ProviderQuotaReport | null> {
-  // Never release an OAuth token to a user-edited or lookalike provider host.
-  if (normalizedBaseUrl(config.baseUrl) !== KIMI_CODE_BASE_URL) return null;
-  let accessToken: string;
-  try {
-    accessToken = await getValidAccessToken("kimi");
-  } catch {
-    return null;
+async function resolveKimiQuotaBearer(config: OcxProviderConfig): Promise<string | null> {
+  if (config.authMode === "oauth") {
+    try {
+      return await getValidAccessToken("kimi");
+    } catch {
+      return null;
+    }
   }
+  const primary = resolveEnvValue(config.apiKey)?.trim();
+  if (primary) return primary;
+  for (const entry of config.apiKeyPool ?? []) {
+    const key = resolveEnvValue(entry.key)?.trim();
+    if (key) return key;
+  }
+  return null;
+}
+
+async function fetchKimiQuota(provider: string, config: OcxProviderConfig): Promise<ProviderQuotaReport | null> {
+  // Never release credentials to a user-edited or lookalike provider host.
+  if (!isCanonicalKimiCodeBaseUrl(config.baseUrl)) return null;
+  const accessToken = await resolveKimiQuotaBearer(config);
+  if (!accessToken) return null;
   const response = await fetch(KIMI_CODE_USAGE_URL, {
     headers: { Accept: "application/json", Authorization: `Bearer ${accessToken}` },
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
@@ -342,7 +396,22 @@ async function fetchCursorQuota(provider: string): Promise<ProviderQuotaReport |
       const planUsage = asRecord(body?.planUsage);
       if (planUsage) {
         const resetAt = normalizeResetAt(body?.billingCycleEnd ?? planUsage.billingCycleEnd ?? body?.periodEnd);
-        // Cursor tracks two linked pools: First-party models (Auto/Composer/Grok) and API usage.
+
+        // Primary meter: overall included allowance (Cursor Settings → Usage total %).
+        // autoPercentUsed / apiPercentUsed are secondary pools and must not replace the total.
+        const limit = toFiniteNumber(planUsage.limit ?? planUsage.limitCents ?? planUsage.totalLimitCents);
+        const remaining = toFiniteNumber(planUsage.remaining ?? planUsage.remainingCents);
+        const includedSpend = toFiniteNumber(planUsage.includedSpend ?? planUsage.usedCents ?? planUsage.used);
+        const totalSpend = toFiniteNumber(planUsage.totalSpend);
+        let used: number | undefined;
+        if (includedSpend !== undefined) used = includedSpend;
+        else if (limit !== undefined && remaining !== undefined) used = Math.max(0, limit - remaining);
+        else if (totalSpend !== undefined) used = totalSpend;
+        const totalPercent = normalizePercent(planUsage.totalPercentUsed ?? planUsage.percentUsed)
+          ?? (limit !== undefined && limit > 0 && used !== undefined
+            ? normalizePercent((used / limit) * 100)
+            : undefined);
+
         const autoPercent = normalizePercent(planUsage.autoPercentUsed);
         const apiPercent = normalizePercent(planUsage.apiPercentUsed);
         const customWindows: ProviderQuotaWindow[] = [];
@@ -360,37 +429,14 @@ async function fetchCursorQuota(provider: string): Promise<ProviderQuotaReport |
             ...(resetAt !== undefined ? { resetAt } : {}),
           });
         }
-        if (customWindows.length > 0) {
-          const built = report(provider, "cursor:period-usage", {
-            customWindows,
-            updatedAt: Date.now(),
-          });
-          if (built) return { ...built, reverseEngineered: true };
-        }
 
-        const limit = toFiniteNumber(planUsage.limit ?? planUsage.limitCents ?? planUsage.totalLimitCents);
-        const remaining = toFiniteNumber(planUsage.remaining ?? planUsage.remainingCents);
-        const includedSpend = toFiniteNumber(planUsage.includedSpend ?? planUsage.usedCents ?? planUsage.used);
-        const totalSpend = toFiniteNumber(planUsage.totalSpend);
-        let used: number | undefined;
-        if (includedSpend !== undefined) used = includedSpend;
-        else if (limit !== undefined && remaining !== undefined) used = Math.max(0, limit - remaining);
-        else if (totalSpend !== undefined) used = totalSpend;
-        const totalPercent = normalizePercent(planUsage.totalPercentUsed ?? planUsage.percentUsed);
-        if (limit !== undefined && limit > 0 && used !== undefined) {
-          const percent = totalPercent ?? normalizePercent((used / limit) * 100);
-          if (percent !== undefined) {
-            const built = report(provider, "cursor:period-usage", {
-              monthlyPercent: percent,
-              ...(resetAt !== undefined ? { monthlyResetAt: resetAt } : {}),
-              updatedAt: Date.now(),
-            });
-            if (built) return { ...built, reverseEngineered: true };
-          }
-        } else if (totalPercent !== undefined) {
+        if (totalPercent !== undefined || customWindows.length > 0) {
           const built = report(provider, "cursor:period-usage", {
-            monthlyPercent: totalPercent,
-            ...(resetAt !== undefined ? { monthlyResetAt: resetAt } : {}),
+            ...(totalPercent !== undefined ? {
+              monthlyPercent: totalPercent,
+              ...(resetAt !== undefined ? { monthlyResetAt: resetAt } : {}),
+            } : {}),
+            ...(customWindows.length > 0 ? { customWindows } : {}),
             updatedAt: Date.now(),
           });
           if (built) return { ...built, reverseEngineered: true };
@@ -596,7 +642,11 @@ async function maybeFetchProviderQuota(
     if (provider.authMode === "oauth" && name === "anthropic") return fetchAnthropicQuota(name);
     if (provider.authMode === "oauth" && name === "cursor") return fetchCursorQuota(name);
     if (provider.authMode === "oauth" && name === "google-antigravity") return fetchAntigravityQuota(name, provider);
+    // Kimi Code `/usages` accepts OAuth or coding-plan API keys, but only on the canonical host.
     if (provider.authMode === "oauth" && name === "kimi") return fetchKimiQuota(name, provider);
+    if (provider.authMode !== "oauth" && isCanonicalKimiCodeBaseUrl(provider.baseUrl)) {
+      return fetchKimiQuota(name, provider);
+    }
     return null;
   } catch {
     return null;

--- a/tests/provider-quota.test.ts
+++ b/tests/provider-quota.test.ts
@@ -195,6 +195,8 @@ describe("fetchProviderQuotaReports", () => {
     ]);
     expect(byProvider.cursor?.source).toBe("cursor:period-usage");
     expect(byProvider.cursor?.reverseEngineered).toBe(true);
+    expect(byProvider.cursor?.quota.monthlyPercent).toBe(30);
+    expect(byProvider.cursor?.quota.monthlyResetAt).toBe(Date.parse("2026-08-01T00:00:00.000Z"));
     expect(byProvider.cursor?.quota.customWindows).toEqual([
       { label: "First-party models", percent: 12.5, resetAt: Date.parse("2026-08-01T00:00:00.000Z") },
       { label: "API usage", percent: 58, resetAt: Date.parse("2026-08-01T00:00:00.000Z") },
@@ -310,6 +312,87 @@ describe("fetchProviderQuotaReports", () => {
 
     expect(result.reports[0]?.quota.fiveHourPercent).toBe(25);
     expect(result.reports[0]?.quota.fiveHourResetAt).toBe(Date.parse("2026-07-18T08:00:00Z"));
+  });
+
+  test("Kimi quota unwraps a data envelope and maps weekly from limits when usage is absent", async () => {
+    await saveCredential("kimi", { access: "kimi-access-secret", refresh: "kimi-refresh-secret", expires: Date.now() + 3600_000 });
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      data: {
+        limits: [
+          {
+            window: { duration: 300, timeUnit: "TIME_UNIT_MINUTE" },
+            detail: { limit: "100", remaining: "80", resetTime: "2026-07-18T08:00:00Z" },
+          },
+          {
+            name: "Weekly limit",
+            window: { duration: 7, timeUnit: "TIME_UNIT_DAY" },
+            detail: { limit: "200", used: "50", resetTime: "2026-07-24T12:00:00Z" },
+          },
+        ],
+        totalQuota: { limit: "100", remaining: "90" },
+      },
+    }), { status: 200 })) as typeof fetch;
+
+    const result = await fetchProviderQuotaReports(kimiOnlyConfig(), true);
+
+    expect(result.reports[0]?.source).toBe("kimi:usages");
+    expect(result.reports[0]?.quota.fiveHourPercent).toBe(20);
+    expect(result.reports[0]?.quota.weeklyPercent).toBe(25);
+    expect(result.reports[0]?.quota.weeklyResetAt).toBe(Date.parse("2026-07-24T12:00:00Z"));
+    expect(result.reports[0]?.quota.customWindows).toEqual([{ label: "Total subscription credits", percent: 10 }]);
+  });
+
+  test("Kimi Code API-key providers on the canonical host receive usages probes", async () => {
+    const seen: Array<{ url: string; authorization?: string }> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string> | undefined;
+      seen.push({ url: String(input), authorization: headers?.Authorization });
+      return new Response(JSON.stringify({ usage: { limit: "100", used: "40" } }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await fetchProviderQuotaReports({
+      defaultProvider: "kimi-code",
+      providers: {
+        "kimi-code": {
+          adapter: "openai-chat",
+          authMode: "key",
+          baseUrl: "https://api.kimi.com/coding/v1",
+          apiKey: "sk-kimi-quota-secret",
+        },
+      },
+    } as OcxConfig, true);
+
+    expect(result.reports).toHaveLength(1);
+    expect(result.reports[0]?.provider).toBe("kimi-code");
+    expect(result.reports[0]?.source).toBe("kimi:usages");
+    expect(result.reports[0]?.quota.weeklyPercent).toBe(40);
+    expect(seen).toEqual([{
+      url: "https://api.kimi.com/coding/v1/usages",
+      authorization: "Bearer sk-kimi-quota-secret",
+    }]);
+  });
+
+  test("Kimi key providers never send credentials to a non-canonical base URL", async () => {
+    const seen: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      seen.push(String(input));
+      return new Response("unexpected", { status: 500 });
+    }) as typeof fetch;
+
+    const result = await fetchProviderQuotaReports({
+      defaultProvider: "kimi-code",
+      providers: {
+        "kimi-code": {
+          adapter: "openai-chat",
+          authMode: "key",
+          baseUrl: "https://attacker.example/coding/v1",
+          apiKey: "sk-kimi-quota-secret",
+        },
+      },
+    } as OcxConfig, true);
+
+    expect(result.reports).toEqual([]);
+    expect(seen).toEqual([]);
   });
 
   test("Kimi quota preserves a last-good row after 401 only within the shared age bound", async () => {
@@ -430,6 +513,37 @@ describe("fetchProviderQuotaReports", () => {
     expect(result.reports[0]?.source).toBe("cursor:usage-summary");
     expect(result.reports[0]?.quota.monthlyPercent).toBe(42);
     expect(result.reports[0]?.quota.monthlyResetAt).toBe(Date.parse("2026-08-01T00:00:00.000Z"));
+  });
+
+  test("cursor period-usage keeps totalPercentUsed as monthly while retaining auto/API pool windows", async () => {
+    await saveCredential("cursor", { access: "cursor-access-secret", refresh: "cursor-refresh-secret", expires: Date.now() + 3600_000 });
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      if (String(input).endsWith("GetCurrentPeriodUsage")) {
+        return new Response(JSON.stringify({
+          planUsage: {
+            includedSpend: 23222,
+            remaining: 16778,
+            limit: 40000,
+            autoPercentUsed: 0,
+            apiPercentUsed: 46.444,
+            totalPercentUsed: 15.48,
+          },
+          // Connect RPC shape: unix ms as a decimal string (Date.parse would fail).
+          billingCycleEnd: "1771077734000",
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+
+    const result = await fetchProviderQuotaReports(cursorOnlyConfig(), true);
+    expect(result.reports).toHaveLength(1);
+    expect(result.reports[0]?.source).toBe("cursor:period-usage");
+    expect(result.reports[0]?.quota.monthlyPercent).toBe(15.48);
+    expect(result.reports[0]?.quota.monthlyResetAt).toBe(1_771_077_734_000);
+    expect(result.reports[0]?.quota.customWindows).toEqual([
+      { label: "First-party models", percent: 0, resetAt: 1_771_077_734_000 },
+      { label: "API usage", percent: 46.444, resetAt: 1_771_077_734_000 },
+    ]);
   });
 
   test("cursor falls back to auth-usage with a UTC month rollover when the richer endpoints fail", async () => {


### PR DESCRIPTION
## Summary
- Cursor period-usage now keeps `totalPercentUsed` as the monthly meter (matching Settings → Usage) while still showing First-party / API pool bars as secondary windows, and parses Connect RPC unix-ms reset strings.
- Kimi quota probing is hardened: unwrap `data` envelopes, map weekly windows from `limits[]` when top-level `usage` is absent, accept direct percent fields, and probe coding-host API-key providers (`kimi-code`) without ever sending credentials to non-canonical hosts.

## Test plan
- [x] `bun test tests/provider-quota.test.ts tests/quota-bars-rows.test.ts`
- [ ] GUI: Cursor OAuth provider shows monthly % matching Cursor Settings, plus optional First-party/API bars
- [ ] GUI: Kimi OAuth and/or `kimi-code` API-key on `https://api.kimi.com/coding/v1` shows 5h / weekly / total subscription credits
- [ ] Force refresh: `GET /api/provider-quotas?refresh=1` returns `cursor:period-usage` and `kimi:usages` without leaking tokens/raw payloads