### PR TITLE
fix(proxy): raise default upstream stall timeout to 300s

### DIFF
--- a/docs-site/src/content/docs/ko/reference/architecture.md
+++ b/docs-site/src/content/docs/ko/reference/architecture.md
@@ -95,7 +95,7 @@ HTTP 경계는 `server/index.ts`가 맡고, Responses 데이터 플레인은 `se
 
 브리지는 **하트비트 킵얼라이브**(RC3)도 실행합니다. 업스트림에서 데이터가 오지 않을 때 2초마다
 파서가 무시하는 `response.heartbeat` SSE 이벤트를 보내 Codex의 유휴 타이머를 다시 시작합니다.
-기본 **stall deadline**은 90초(`stallTimeoutSec`)입니다. 이 시간을 넘기면 업스트림을 중단하고
+기본 **stall deadline**은 300초(`stallTimeoutSec`)입니다. 이 시간을 넘기면 업스트림을 중단하고
 이유가 `upstream_stall_timeout`인 `response.incomplete`를 내보내 연결이 끝없이 매달리지 않게 합니다.
 
 툴 호출은 파서가 캡처한 네임스페이스 맵, freeform 집합, tool-search 집합을 사용하여 세 가지

--- a/docs-site/src/content/docs/ko/reference/configuration.md
+++ b/docs-site/src/content/docs/ko/reference/configuration.md
@@ -41,7 +41,7 @@ namespaced selected id를 bare id로 바꿉니다.
 | `multiAgentMode?` | `"v1" \| "default" \| "v2"` | `"default"` | 3단계 multi-agent surface override. `"v1"`은 업스트림 pin보다 우선해 모든 모델을 v1로, `"default"`는 업스트림 model pin(sol/terra=v2, luna=v1)을 따르고, `"v2"`는 모두 v2로 강제합니다. 대시보드 Models 페이지나 `ocx v2 mode`에서 설정합니다. |
 | `providerContextCaps?` | `Record<string,number>` | `{}` | 프로바이더별 Codex 표시 context cap. 알려진 context window를 낮추기만 합니다. |
 | `contextCapValue?` | `number` | `350000` | 대시보드 context-cap control에서 쓸 값. 바꾸면 `providerContextCaps`에서 활성화된 모든 항목을 갱신합니다. |
-| `stallTimeoutSec?` | `number` | `90` | 업스트림 데이터가 오지 않을 때 bridge가 중단하고 `response.incomplete`를 내보내기까지의 초. 최소 1. |
+| `stallTimeoutSec?` | `number` | `300` | 업스트림 데이터가 오지 않을 때 bridge가 중단하고 `response.incomplete`를 내보내기까지의 초. 최소 1. |
 | `connectTimeoutMs?` | `number` | `200000` | DNS/TCP/TLS와 최종 응답 헤더만 기다리는 시도별 deadline. 응답 body 생성 전 종료됩니다. |
 | `shutdownTimeoutMs?` | `number` | `5000` | 진행 중인 turn을 중단하기 전 graceful drain deadline. |
 | `websockets?` | `boolean` | `false` | `supports_websockets`를 알려 Codex가 Responses WebSocket 경로를 쓰게 합니다. 생략하거나 `false`이면 HTTP/SSE를 유지합니다. |

--- a/docs-site/src/content/docs/reference/architecture.md
+++ b/docs-site/src/content/docs/reference/architecture.md
@@ -96,7 +96,7 @@ understands:
 
 The bridge also runs a **heartbeat keep-alive** (RC3): during upstream silence, it emits a
 parser-ignored `response.heartbeat` SSE event every 2 seconds to re-arm Codex's idle timer. The
-default **stall deadline** is 90 seconds (`stallTimeoutSec`); reaching it aborts the upstream and emits
+default **stall deadline** is 300 seconds (`stallTimeoutSec`); reaching it aborts the upstream and emits
 `response.incomplete` with reason `upstream_stall_timeout`, preventing a hung connection from blocking
 Codex indefinitely.
 

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -42,7 +42,7 @@ differing backup and rewrites known legacy namespaced selected ids to bare ids.
 | `multiAgentMode?` | `"v1" \| "default" \| "v2"` | `"default"` | 3-state multi-agent surface override. `"v1"` forces all models to the v1 surface (overrides upstream pins); `"default"` respects upstream model pins (sol/terra=v2, luna=v1); `"v2"` forces all models to v2. Settable from the dashboard Models page or `ocx v2 mode`. |
 | `providerContextCaps?` | `Record<string,number>` | `{}` | Per-provider Codex-visible context caps. A cap only lowers known context windows. |
 | `contextCapValue?` | `number` | `350000` | Value used by the dashboard's context-cap controls; changing it updates every enabled entry in `providerContextCaps`. |
-| `stallTimeoutSec?` | `number` | `90` | Seconds without upstream data before the bridge aborts and emits `response.incomplete`. Minimum 1. |
+| `stallTimeoutSec?` | `number` | `300` | Seconds without upstream data before the bridge aborts and emits `response.incomplete`. Minimum 1. |
 | `connectTimeoutMs?` | `number` | `200000` | Per-attempt deadline for DNS/TCP/TLS and final response headers only; it ends before response-body generation. |
 | `shutdownTimeoutMs?` | `number` | `5000` | Graceful drain deadline before active turns are aborted. |
 | `websockets?` | `boolean` | `false` | Advertise `supports_websockets` so Codex uses the Responses WebSocket path. Omit or set `false` to keep HTTP/SSE. |

--- a/docs-site/src/content/docs/zh-cn/reference/architecture.md
+++ b/docs-site/src/content/docs/zh-cn/reference/architecture.md
@@ -94,7 +94,7 @@ src/
 | `error` | `response.failed`（带 `last_error`） |
 
 桥接器还会运行**心跳保活**（RC3）：上游没有数据时，每 2 秒发送一次解析器会忽略的
-`response.heartbeat` SSE event，以重新启动 Codex 的空闲计时器。默认**停滞截止时间**为 90 秒
+`response.heartbeat` SSE event，以重新启动 Codex 的空闲计时器。默认**停滞截止时间**为 300 秒
 （`stallTimeoutSec`）；达到该时限后会中止上游，并发出 reason 为
 `upstream_stall_timeout` 的 `response.incomplete`，避免挂起的连接无限期阻塞 Codex。
 

--- a/docs-site/src/content/docs/zh-cn/reference/configuration.md
+++ b/docs-site/src/content/docs/zh-cn/reference/configuration.md
@@ -39,7 +39,7 @@ no-replace 方式创建 `config.json.pre-openai-tiers-v2.bak`，并把已知旧 
 | `multiAgentMode?` | `"v1" \| "default" \| "v2"` | `"default"` | 三态 multi-agent surface override。`"v1"` 覆盖 upstream pin，强制全部模型使用 v1；`"default"` 遵循 upstream model pin（sol/terra=v2，luna=v1）；`"v2"` 强制全部模型使用 v2。可在仪表盘 Models 页面或 `ocx v2 mode` 中设置。 |
 | `providerContextCaps?` | `Record<string,number>` | `{}` | provider 级 Codex 可见 context cap。只会降低已知 context window。 |
 | `contextCapValue?` | `number` | `350000` | 仪表盘 context-cap 控件使用的值；修改后会更新 `providerContextCaps` 中所有已启用条目。 |
-| `stallTimeoutSec?` | `number` | `90` | 上游无数据后 bridge 中止并发出 `response.incomplete` 前等待的秒数。最小值 1。 |
+| `stallTimeoutSec?` | `number` | `300` | 上游无数据后 bridge 中止并发出 `response.incomplete` 前等待的秒数。最小值 1。 |
 | `connectTimeoutMs?` | `number` | `200000` | 每次尝试仅等待 DNS/TCP/TLS 和最终响应 header 的 deadline；在响应 body 生成前结束。 |
 | `shutdownTimeoutMs?` | `number` | `5000` | 中止活跃 turn 前的 graceful drain deadline。 |
 | `websockets?` | `boolean` | `false` | 公布 `supports_websockets`，让 Codex 使用 Responses WebSocket 路径。省略或设为 `false` 会保持 HTTP/SSE。 |

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -2,6 +2,7 @@ import type { AdapterEvent, OcxUsage } from "./types";
 import { adapterFailureFromMessage, classifyError, type OcxErrorPayload } from "./lib/errors";
 import { encodeCompactionSummary } from "./responses/compaction";
 import { encodeReasoningEnvelope, type ReasoningEnvelope } from "./responses/reasoning-envelope";
+import { resolveStallTimeoutSec } from "./stall-timeout";
 import { usageDisplayTotalTokens } from "./usage/totals";
 
 function uuid(): string {
@@ -181,7 +182,7 @@ export function bridgeToResponsesSSE(
       // whenever a real event was emitted since the last tick, so it only fires on a genuine stall.
       const heartbeatFrame = encoder.encode('event: response.heartbeat\ndata: {"type":"response.heartbeat"}\n\n');
       let stallTicks = 0;
-      const stallSec = Math.max(1, options?.stallTimeoutSec ?? 90);
+      const stallSec = resolveStallTimeoutSec(options?.stallTimeoutSec);
       const maxStallTicks = Math.ceil((stallSec * 1000) / heartbeatMs);
       beat = setInterval(() => {
         if (closed) return;

--- a/src/stall-timeout.ts
+++ b/src/stall-timeout.ts
@@ -1,0 +1,20 @@
+/**
+ * Bridge upstream stall budget: seconds of silence (no adapter events) before the
+ * Responses bridge emits `response.incomplete` / `upstream_stall_timeout`.
+ *
+ * Raised from 90s so long reasoning + large tool writes are not cut mid-turn.
+ * Hung streams still die; they just get a more realistic window.
+ */
+export const DEFAULT_STALL_TIMEOUT_SEC = 300;
+
+/**
+ * Resolve the effective bridge stall deadline for a turn.
+ * - unset / non-finite config → {@link DEFAULT_STALL_TIMEOUT_SEC}
+ * - finite config → ceil, minimum 1
+ */
+export function resolveStallTimeoutSec(configuredSec: number | undefined): number {
+  if (typeof configuredSec === "number" && Number.isFinite(configuredSec)) {
+    return Math.max(1, Math.ceil(configuredSec));
+  }
+  return DEFAULT_STALL_TIMEOUT_SEC;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -430,7 +430,10 @@ export interface OcxConfig {
    * those are unset — Bun's fetch honors them for all outbound calls; localhost is excluded.
    */
   proxy?: string;
-  /** Upstream stall timeout (seconds). After this many seconds of no upstream data, emits response.incomplete. Default 90. Min 1. */
+  /**
+   * Upstream stall timeout (seconds). After this many seconds of no upstream data, emits
+   * response.incomplete. Default 300. Min 1.
+   */
   stallTimeoutSec?: number;
   /** Connect timeout (ms) for upstream fetch — covers DNS, TCP, TLS, and response header. Default 200000. */
   connectTimeoutMs?: number;

--- a/src/web-search/index.ts
+++ b/src/web-search/index.ts
@@ -3,6 +3,7 @@ import { modelInList } from "../types";
 import type { SidecarSettings } from "./executor";
 import type { ResolvedOpenAiForwardSidecar } from "../providers/openai-sidecar";
 import { getAccountSet } from "../oauth/store";
+import { DEFAULT_STALL_TIMEOUT_SEC } from "../stall-timeout";
 
 export { runWithWebSearch } from "./loop";
 export { buildWebSearchTool, extractHostedWebSearch, WEB_SEARCH_TOOL_NAME } from "./synthetic-tool";
@@ -18,8 +19,6 @@ const DEFAULT_MAX_SEARCHES = 3;
 const DEFAULT_TIMEOUT_MS = 200_000;
 const DEFAULT_ROUTED_MODEL_STALL_TIMEOUT_MS = 200_000;
 const MAX_ROUTED_MODEL_STALL_TIMEOUT_MS = 2_147_483_647;
-// Mirrors the bridge's stall default (bridge.ts `options?.stallTimeoutSec ?? 90`).
-const DEFAULT_STALL_TIMEOUT_SEC = 90;
 const STALL_MARGIN_SEC = 30;
 
 /**
@@ -47,7 +46,7 @@ function finiteCeil(value: number | undefined, fallback: number): number {
  * are individually bounded by the configured bridge stall, response-header connect timeout,
  * routed-model response-body inactivity timeout, or sidecar timeout. The stall deadline must cover
  * the largest unit plus a margin;
- * otherwise a legitimately slow search trips the bridge's 90s default upstream_stall_timeout and
+ * otherwise a legitimately slow search trips the bridge's default upstream_stall_timeout and
  * kills the whole turn. Stays finite so a genuine hang is still cut off.
  */
 export function webSearchStallTimeoutSec(

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -60,7 +60,7 @@ frame rather than always emitting `response.completed`. If the response status i
 The HTTP/SSE bridge emits `response.heartbeat` events during upstream silence to re-arm Codex's idle
 timer (Codex's default `stream_idle_timeout` is 300 s and ANY SSE event re-arms it). Those
 bridge-enqueued keepalive frames do NOT count as activity for the bridge's own watchdog: a bounded
-stall deadline (default 90 s, configurable via `stallTimeoutSec`, checked on the 2 s heartbeat tick)
+stall deadline (default 300 s, configurable via `stallTimeoutSec`, checked on the 2 s heartbeat tick)
 closes the stream with `response.incomplete` / `upstream_stall_timeout` and cancels the upstream
 request if no real adapter events arrive. Adapter-yielded `{ type: "heartbeat" }` events DO reset
 the watchdog.

--- a/tests/stall-timeout.test.ts
+++ b/tests/stall-timeout.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_STALL_TIMEOUT_SEC, resolveStallTimeoutSec } from "../src/stall-timeout";
+
+describe("resolveStallTimeoutSec", () => {
+  test("defaults to 300 seconds when unset", () => {
+    expect(DEFAULT_STALL_TIMEOUT_SEC).toBe(300);
+    expect(resolveStallTimeoutSec(undefined)).toBe(300);
+  });
+
+  test("honors finite configured values with a minimum of 1", () => {
+    expect(resolveStallTimeoutSec(90)).toBe(90);
+    expect(resolveStallTimeoutSec(600.2)).toBe(601);
+    expect(resolveStallTimeoutSec(0)).toBe(1);
+    expect(resolveStallTimeoutSec(-5)).toBe(1);
+  });
+
+  test("rejects non-finite values back to the default", () => {
+    expect(resolveStallTimeoutSec(Number.NaN)).toBe(300);
+    expect(resolveStallTimeoutSec(Number.POSITIVE_INFINITY)).toBe(300);
+    expect(resolveStallTimeoutSec(Number.NEGATIVE_INFINITY)).toBe(300);
+  });
+});

--- a/tests/web-search-timeout-plan.test.ts
+++ b/tests/web-search-timeout-plan.test.ts
@@ -88,8 +88,8 @@ describe("routed-model web-search inactivity timeout", () => {
   });
 
   test("bridge budget covers every timeout plus a thirty-second margin", () => {
-    expect(webSearchStallTimeoutSec(undefined, 200_000, 200_000, 200_000)).toBe(230);
-    expect(webSearchStallTimeoutSec(undefined, 200_000, 240_000, 200_000)).toBe(270);
+    expect(webSearchStallTimeoutSec(undefined, 200_000, 200_000, 200_000)).toBe(330);
+    expect(webSearchStallTimeoutSec(undefined, 200_000, 240_000, 200_000)).toBe(330);
     expect(webSearchStallTimeoutSec(600, 200_000, 240_000, 200_000)).toBe(630);
 
     const maximum = webSearchStallTimeoutSec(undefined, 200_000, 2_147_483_647, 200_000);
@@ -103,7 +103,7 @@ describe("routed-model web-search inactivity timeout", () => {
       webSearchSidecar: { routedModelStallTimeoutMs: 240_000 },
     }))).toMatchObject({
       routedModelStallTimeoutMs: 240_000,
-      stallTimeoutSec: 270,
+      stallTimeoutSec: 330,
     });
   });
 });

--- a/tests/web-search.test.ts
+++ b/tests/web-search.test.ts
@@ -1101,25 +1101,25 @@ describe("web-search stall deadline", () => {
   test("planWebSearch computes the effective stall deadline covering bounded silent units", () => {
     const parsed = parsedWithWebSearch();
     const auth = new Headers({ authorization: "Bearer chatgpt" });
-    // defaults: max(90, connect 200s, sidecar 200s) + 30 margin
-    expect(planWebSearch(config(), parsed, false, auth, routedProvider, "model")?.stallTimeoutSec).toBe(230);
+    // defaults: max(300 bridge, connect 200s, sidecar 200s) + 30 margin
+    expect(planWebSearch(config(), parsed, false, auth, routedProvider, "model")?.stallTimeoutSec).toBe(330);
     // a larger user-configured stallTimeoutSec dominates
     expect(planWebSearch(config({ stallTimeoutSec: 600 }), parsed, false, auth, routedProvider, "model")?.stallTimeoutSec).toBe(630);
-    // small unit budgets -> the bridge's 90s default dominates
+    // small unit budgets -> the bridge's 300s default dominates
     expect(planWebSearch(
       config({
         connectTimeoutMs: 30_000,
         webSearchSidecar: { timeoutMs: 30_000, routedModelStallTimeoutMs: 30_000 },
       }),
       parsed, false, auth, routedProvider, "model",
-    )?.stallTimeoutSec).toBe(120);
+    )?.stallTimeoutSec).toBe(330);
   });
 
   test("webSearchStallTimeoutSec helper covers the largest bounded unit plus margin", () => {
-    expect(webSearchStallTimeoutSec(undefined, undefined, 200_000)).toBe(230);
+    expect(webSearchStallTimeoutSec(undefined, undefined, 200_000)).toBe(330);
     expect(webSearchStallTimeoutSec(90, 200_000, 200_000)).toBe(230);
     expect(webSearchStallTimeoutSec(600, 200_000, 200_000)).toBe(630);
-    expect(webSearchStallTimeoutSec(undefined, 30_000, 30_000)).toBe(120);
+    expect(webSearchStallTimeoutSec(undefined, 30_000, 30_000)).toBe(330);
   });
 
   test("threaded stallTimeoutSec reaches the bridge: a hung sidecar trips upstream_stall_timeout", async () => {


### PR DESCRIPTION
## Summary
- Raise the default bridge `stallTimeoutSec` from **90s → 300s** so long quiet generations (large tool writes / reasoning) are not cut as `upstream_stall_timeout` → 502.
- Centralize the default in `resolveStallTimeoutSec()` so non-finite config values fall back cleanly instead of disabling the watchdog.
- Update docs (en/ko/zh) and web-search stall-budget expectations to match the new default.

## Why
Seen on Kimi k3 with large single-shot writes (~105s silence). Users should not need to split patches or tune config for normal long generations. Hung upstreams still abort — just with a more realistic window.

## Test plan
- [x] `bun test tests/stall-timeout.test.ts tests/web-search-timeout-plan.test.ts tests/web-search.test.ts tests/bridge-lifecycle.test.ts tests/bridge.test.ts`
- [x] Full pre-push suite (3130 pass)
- [ ] Reproduce a long Kimi write that previously 502'd around ~90–105s; confirm it completes under the new default
- [ ] Optional: set `stallTimeoutSec: 30` in config and confirm hangs still abort promptly