### PR TITLE
fix(antigravity): stop forwarding Responses item ids as thoughtSignature

### DIFF
--- a/src/adapters/google-antigravity-wire.ts
+++ b/src/adapters/google-antigravity-wire.ts
@@ -12,16 +12,23 @@ export const ANTIGRAVITY_REQUEST_UA = process.env.GOOGLE_ANTIGRAVITY_USER_AGENT 
 
 /**
  * Whether a stored `OcxToolCall.thoughtSignature` is a REAL upstream Gemini signature versus a
- * synthetic Responses item id (`fc_...`, `call_...`, `rs_...`, etc) that the bridge/parser stashes
- * on the field. Only real signatures may be forwarded to Gemini/Antigravity — sending a synthetic
- * id as `thoughtSignature` breaks multi-turn reasoning continuity (upstream rejects it). Real
- * signatures are opaque base64-ish blobs with no Responses-id prefix.
+ * foreign id that must not be forwarded to Gemini/Antigravity.
+ *
+ * Foreign ids that have 400'd Antigravity (`TYPE_BYTES` / Base64 decoding failed) include:
+ * - Responses/bridge item ids: `fc_...`, `ctc_...` (custom_tool_call), `call_...`, `rs_...`, …
+ * - Anthropic tool-use ids: `toolu_...`
+ *
+ * Only real signatures may be forwarded — sending a foreign id as `thoughtSignature` breaks
+ * multi-turn reasoning continuity. Real signatures are opaque base64-ish blobs with no
+ * Responses/Anthropic id prefix.
+ *
+ * Note: do NOT reject a bare `sig_` / `sig-` prefix — existing Gemini replay fixtures and some
+ * upstream blobs use that shape; a deny-list entry for `sig` would drop valid continuity tokens.
  */
 export function isLikelyRealThoughtSignature(sig: string | undefined): boolean {
   if (typeof sig !== "string" || sig.length < 16) return false;
-  // Reject synthetic Responses/tool-call ids in both `_` and `-` separated spellings
-  // (e.g. `fc_...`, `call_...`, `function-call-...`, `tool-call-...`).
-  if (/^(fc|call|msg|rs|resp|reasoning|item|ws|tool|func|function)[-_]/i.test(sig)) return false;
+  // Reject synthetic Responses/tool-call ids and Anthropic tool-use ids (`_` or `-` separators).
+  if (/^(fc|ctc|call|msg|rs|resp|reasoning|item|ws|toolu|tool|func|function)[-_]/i.test(sig)) return false;
   // Real Gemini thought signatures are opaque base64/base64url blobs: only [A-Za-z0-9+/_=-].
   // Anything containing other characters (or whitespace) is not a real signature.
   return /^[A-Za-z0-9+/_=-]+$/.test(sig);

--- a/src/adapters/google-antigravity-wire.ts
+++ b/src/adapters/google-antigravity-wire.ts
@@ -15,7 +15,8 @@ export const ANTIGRAVITY_REQUEST_UA = process.env.GOOGLE_ANTIGRAVITY_USER_AGENT 
  * foreign id that must not be forwarded to Gemini/Antigravity.
  *
  * Foreign ids that have 400'd Antigravity (`TYPE_BYTES` / Base64 decoding failed) include:
- * - Responses/bridge item ids: `fc_...`, `ctc_...` (custom_tool_call), `call_...`, `rs_...`, …
+ * - Responses/bridge item ids: `fc_...`, `ctc_...` (custom_tool_call), `tsc_...` (tool_search_call),
+ *   `call_...`, `rs_...`, …
  * - Anthropic tool-use ids: `toolu_...`
  *
  * Only real signatures may be forwarded — sending a foreign id as `thoughtSignature` breaks
@@ -28,7 +29,7 @@ export const ANTIGRAVITY_REQUEST_UA = process.env.GOOGLE_ANTIGRAVITY_USER_AGENT 
 export function isLikelyRealThoughtSignature(sig: string | undefined): boolean {
   if (typeof sig !== "string" || sig.length < 16) return false;
   // Reject synthetic Responses/tool-call ids and Anthropic tool-use ids (`_` or `-` separators).
-  if (/^(fc|ctc|call|msg|rs|resp|reasoning|item|ws|toolu|tool|func|function)[-_]/i.test(sig)) return false;
+  if (/^(fc|ctc|tsc|call|msg|rs|resp|reasoning|item|ws|toolu|tool|func|function)[-_]/i.test(sig)) return false;
   // Real Gemini thought signatures are opaque base64/base64url blobs: only [A-Za-z0-9+/_=-].
   // Anything containing other characters (or whitespace) is not a real signature.
   return /^[A-Za-z0-9+/_=-]+$/.test(sig);

--- a/src/responses/parser.ts
+++ b/src/responses/parser.ts
@@ -404,9 +404,12 @@ export function parseRequest(body: unknown): OcxParsedRequest {
             console.warn(`[parser] function_call ${call.call_id} has non-JSON arguments; defaulting to {}`);
           }
         }
+        // Do NOT map Responses item `id` (fc_/ctc_/…) onto `thoughtSignature`. That field is
+        // reserved for Gemini/Antigravity opaque thought tokens; forwarding item ids as
+        // thoughtSignature 400s Antigravity (Base64 / TYPE_BYTES). Continuity for CCA comes from
+        // the in-process replay cache (and any already-real signature stored on the tool call).
         const toolCall: OcxToolCall = {
           type: "toolCall", id: call.call_id, name: call.name, arguments: args,
-          ...(call.id ? { thoughtSignature: call.id } : {}),
           ...(call.namespace ? { namespace: call.namespace } : {}),
         };
         assistantHolderWithReasoning().content.push(toolCall);
@@ -419,7 +422,6 @@ export function parseRequest(body: unknown): OcxParsedRequest {
           type: "toolCall", id: call.call_id, name: call.name,
           arguments: { input: call.input ?? "" },
           customWireName: call.name,
-          ...(call.id ? { thoughtSignature: call.id } : {}),
         };
         assistantHolderWithReasoning().content.push(toolCall);
         continue;

--- a/tests/google-antigravity-wire.test.ts
+++ b/tests/google-antigravity-wire.test.ts
@@ -223,6 +223,7 @@ describe("isLikelyRealThoughtSignature", () => {
     for (const id of [
       "fc_d8df7548e31a4130b7624f3d27571cdd",
       "ctc_038f26d3f20962bc016a54f0fcfa208190a8ec0f289c2ba211",
+      "tsc_0123456789abcdef01234567",
       "call_1f57fdea0000",
       "function-call-1234567890",
       "tool-call-abcdef123456",

--- a/tests/google-antigravity-wire.test.ts
+++ b/tests/google-antigravity-wire.test.ts
@@ -196,11 +196,40 @@ describe("antigravity history preserves tool-call thoughtSignature", () => {
     const fcPart = modelTurn?.parts.find(part => "functionCall" in part);
     expect(fcPart?.thoughtSignature).toBeUndefined();
   });
+
+  test("custom_tool_call item ids (ctc_...) from Claude/mixed history are NOT forwarded (issue #174)", async () => {
+    const p = {
+      modelId: "gemini-3-pro",
+      stream: false,
+      context: {
+        messages: [
+          { role: "user", content: "go" },
+          { role: "assistant", content: [{ type: "toolCall", id: "c1", name: "get_x", namespace: "mcp__t", arguments: {}, thoughtSignature: "ctc_038f26d3f20962bc016a54f0fcfa208190a8ec0f289c2ba211" }] },
+        ],
+        systemPrompt: [], tools: [],
+      },
+      options: {},
+    } as unknown as OcxParsedRequest;
+    const req = await createGoogleAdapter(provider).buildRequest(p);
+    const env = JSON.parse(req.body);
+    const modelTurn = (env.request.contents as { role: string; parts: Record<string, unknown>[] }[]).find(c => c.role === "model");
+    const fcPart = modelTurn?.parts.find(part => "functionCall" in part);
+    expect(fcPart?.thoughtSignature).toBeUndefined();
+  });
 });
 
 describe("isLikelyRealThoughtSignature", () => {
   test("rejects synthetic Responses/tool-call ids (underscore and hyphen variants)", () => {
-    for (const id of ["fc_d8df7548e31a4130b7624f3d27571cdd", "call_1f57fdea0000", "function-call-1234567890", "tool-call-abcdef123456", "msg_0123456789abcdef", "rs_0123456789abcdef"]) {
+    for (const id of [
+      "fc_d8df7548e31a4130b7624f3d27571cdd",
+      "ctc_038f26d3f20962bc016a54f0fcfa208190a8ec0f289c2ba211",
+      "call_1f57fdea0000",
+      "function-call-1234567890",
+      "tool-call-abcdef123456",
+      "toolu_01AbCdEfGhIjKlMnOpQrStUv",
+      "msg_0123456789abcdef",
+      "rs_0123456789abcdef",
+    ]) {
       expect(isLikelyRealThoughtSignature(id)).toBe(false);
     }
   });
@@ -212,5 +241,7 @@ describe("isLikelyRealThoughtSignature", () => {
   test("accepts an opaque base64/base64url signature blob", () => {
     expect(isLikelyRealThoughtSignature("CisBVKhc7+abcDEF0123456789/xyz==")).toBe(true);
     expect(isLikelyRealThoughtSignature("abcd1234abcd1234abcd1234")).toBe(true);
+    // `sig-…` shapes are used by replay fixtures / some upstream blobs — must NOT be deny-listed.
+    expect(isLikelyRealThoughtSignature("sig-abcdef0123456789")).toBe(true);
   });
 });

--- a/tests/responses-parser-agent-message.test.ts
+++ b/tests/responses-parser-agent-message.test.ts
@@ -87,8 +87,9 @@ describe("Responses parser agent_message boundaries", () => {
       id: "call_after_agent",
       name: "shell_command",
       arguments: { command: "echo ok" },
-      thoughtSignature: "fc_after_agent",
     });
+    // Responses item ids must not be copied onto thoughtSignature (Antigravity rejects them).
+    expect((secondAssistant.content[1] as { thoughtSignature?: string }).thoughtSignature).toBeUndefined();
 
     expect(messages[2]).toMatchObject({
       role: "toolResult",


### PR DESCRIPTION
## Summary
- Fixes #174: switching a Codex thread from Claude (or any history with `ctc_*` / similar item ids) to `google-antigravity` Gemini 400s because foreign ids were forwarded as `thoughtSignature`.
- **Root fix:** Responses parser no longer maps item `id` (`fc_` / `ctc_` / …) onto `OcxToolCall.thoughtSignature` — that field is for Gemini/Antigravity opaque tokens; CCA continuity stays on the in-process replay cache.
- **Defense in depth:** `isLikelyRealThoughtSignature` now also rejects `ctc_` and `toolu_`. Explicitly does **not** deny-list `sig_*` (that would break valid replay fixtures / upstream blobs). This is stricter than growing a vague prefix list alone.

## Why not only the issue’s patch?
A deny-list-only change (`ctc|toolu|sig|…`) is whack-a-mole and rejecting `sig_` is incorrect. Stopping the parser from contaminating the field is the durable fix; the filter catches already-poisoned history.

## Test plan
- [x] `bun test tests/google-antigravity-wire.test.ts tests/responses-parser-agent-message.test.ts tests/google-antigravity-replay.test.ts`
- [ ] Repro from #174: Claude/tool history → switch to `google-antigravity/gemini-3.1-pro-high` → no Base64/`thought_signature` 400
- [ ] Gemini→Gemini same-process multi-turn with tools still works (replay cache)
- [ ] Real `sig-…` / base64 thought signatures still forward when present on the tool call