### PR TITLE
fix: preserve configured Alibaba Token Plan base URL

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -691,6 +691,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     id: "alibaba-token-plan",
     label: "Alibaba Token Plan (Beijing)",
     baseUrl: "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+    allowBaseUrlOverride: true,
     adapter: "openai-chat",
     authKind: "key",
     dashboardUrl: "https://bailian.console.aliyun.com/cn-beijing?tab=plan",

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -418,7 +418,9 @@ describe("provider registry parity", () => {
   test("base URL override permission is registry-only and limited to opted-in providers", () => {
     const optedIn = PROVIDER_REGISTRY.filter(entry => entry.allowBaseUrlOverride);
 
-    expect(optedIn.map(entry => entry.id)).toEqual(["ollama", "vllm", "lm-studio", "qwen-cloud", "litellm"]);
+    expect(optedIn.map(entry => entry.id)).toEqual([
+      "ollama", "vllm", "lm-studio", "qwen-cloud", "alibaba-token-plan", "litellm",
+    ]);
     for (const entry of optedIn) {
       expect(providerConfigSeed(entry)).not.toHaveProperty("allowBaseUrlOverride");
     }

--- a/tests/router-template-baseurl.test.ts
+++ b/tests/router-template-baseurl.test.ts
@@ -6,6 +6,10 @@ const OVERRIDE_PROVIDERS = [
   { id: "ollama", registryBaseUrl: "http://localhost:11434/v1" },
   { id: "vllm", registryBaseUrl: "http://localhost:8000/v1" },
   { id: "lm-studio", registryBaseUrl: "http://localhost:1234/v1" },
+  {
+    id: "alibaba-token-plan",
+    registryBaseUrl: "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+  },
   { id: "litellm", registryBaseUrl: "http://localhost:4000/v1" },
 ] as const;
 
@@ -19,7 +23,7 @@ function configFor(providerName: string, provider: OcxProviderConfig): OcxConfig
 
 for (const { id, registryBaseUrl } of OVERRIDE_PROVIDERS) {
   test(`${id} trims and preserves a configured base URL override`, () => {
-    const override = `http://${id}.lan:3210/v1`;
+    const override = `https://${id}.example.test/v1`;
     const config = configFor(id, {
       adapter: "openai-chat",
       baseUrl: `  ${override}  `,


### PR DESCRIPTION
## Problem

OpenCodex persisted a custom `baseUrl` for Alibaba Token Plan, but request routing silently discarded it and used the registry default. This could send valid credentials to the wrong upstream and surface misleading authentication failures such as `401 Invalid API-key`.

## Fix

- opt Alibaba Token Plan into registry-controlled base URL overrides
- add router regression coverage proving that an arbitrary valid configured URL is preserved unchanged
- update registry parity coverage for the provider's override permission

## Validation

- `bun test --isolate ./tests/` — 3,233 passed, 0 failed
- `bun run typecheck`
- `bun run privacy:scan`
- `cd gui && bun run lint`