### PR TITLE
fix(cursor): enforce tool budget to prevent resource_exhausted with large catalogs

### DIFF
--- a/src/adapters/cursor/live-transport.ts
+++ b/src/adapters/cursor/live-transport.ts
@@ -434,7 +434,7 @@ class LiveCursorTransport implements CursorTransport {
     const activeText = activePromptText(request);
     this.activeClientToolFinalizeGraceMs = clientToolFinalizeGraceMsForRequest(request, this.clientToolFinalizeGraceMs);
     const cursorVisibleTools = cursorToolsForActivePrompt(request.tools, activeText, request.toolChoice);
-    const clientToolDefs = buildCursorToolDefinitions(cursorVisibleTools, request.toolChoice);
+    const clientToolDefs = buildCursorToolDefinitions(cursorVisibleTools, request.toolChoice, request.stubbedToolNames);
     this.execContext = {
       ...this.execContext,
       clientToolDefs,

--- a/src/adapters/cursor/protobuf-request.ts
+++ b/src/adapters/cursor/protobuf-request.ts
@@ -379,7 +379,7 @@ export function encodeCursorRunRequest(request: CursorRunRequest): Uint8Array {
     // tool-count prompt, so a call to it would be rejected as an unknown Responses tool.
     ...(() => {
       const visibleTools = cursorToolsForActivePrompt(request.tools, activePromptText(request), request.toolChoice);
-      const mcpToolDefs = buildCursorToolDefinitions(visibleTools, request.toolChoice);
+      const mcpToolDefs = buildCursorToolDefinitions(visibleTools, request.toolChoice, request.stubbedToolNames);
       return mcpToolDefs.length > 0 ? { mcpTools: create(McpToolsSchema, { mcpTools: mcpToolDefs }) } : {};
     })(),
   });

--- a/src/adapters/cursor/request-builder.ts
+++ b/src/adapters/cursor/request-builder.ts
@@ -11,6 +11,8 @@ import type { CursorRequestMessage, CursorRunRequest } from "./types";
 import { cursorCodexToWireModelId } from "./discovery";
 import { cursorEffortSuffix } from "./effort-map";
 import type { OcxTool } from "../../types";
+import { toolChoiceAliases, isAllowedToolChoice } from "../../types";
+import type { OcxToolChoice } from "../../types";
 
 /**
  * Maximum number of tools (native + namespace-inner) that the Cursor Connect
@@ -26,18 +28,64 @@ const CURSOR_DEFERRED_TOOLS_NOTE = [
   "and load tools by keyword when the task requires them.",
 ].join(" ");
 
+const CURSOR_DEFERRED_TOOLS_NOTE_NO_SEARCH = [
+  "[opencodex] Not all tools could be advertised to Cursor due to a transport limit.",
+  "Some MCP/app tools were omitted. Start a new session if you need access to them.",
+].join(" ");
+
+/**
+ * Extract the set of tool wire-names that are explicitly required or allowed by
+ * the current `toolChoice` option, so the budget pass can reserve them.
+ */
+function toolChoiceRequiredNames(toolChoice: OcxToolChoice | undefined): Set<string> {
+  if (!toolChoice || toolChoice === "auto" || toolChoice === "none") return new Set();
+  if (toolChoice === "required") return new Set(); // "required" doesn't name specific tools
+  if ("name" in toolChoice) return new Set([toolChoice.name]);
+  if (isAllowedToolChoice(toolChoice)) return new Set(toolChoice.allowedTools);
+  return new Set();
+}
+
+/**
+ * Collect tool wire-names that appear in prior tool-result messages, indicating
+ * they were loaded via `tool_search` in a previous turn and must remain callable.
+ */
+function previouslyUsedToolNames(messages: readonly OcxMessage[]): Set<string> {
+  const names = new Set<string>();
+  for (const msg of messages) {
+    if (msg.role === "toolResult") {
+      const wire = msg.toolNamespace ? `${msg.toolNamespace}__${msg.toolName}` : msg.toolName;
+      names.add(wire);
+      names.add(msg.toolName);
+    }
+  }
+  return names;
+}
+
 /**
  * Enforce a tool budget for the Cursor transport. Native (non-namespace) tools
  * are always kept. Namespaces are added smallest-first until the budget is full;
  * remaining namespaces are dropped (the model can still discover them via
  * tool_search). Returns the filtered tool list and whether any trimming occurred.
+ *
+ * Tools that are explicitly required by `toolChoice` or that appear in prior
+ * tool-result messages (i.e. loaded via tool_search) are reserved and always kept,
+ * even if their namespace would otherwise be trimmed.
  */
-function enforceCursorToolBudget(tools: readonly OcxTool[]): { tools: OcxTool[]; trimmed: boolean } {
+function enforceCursorToolBudget(
+  tools: readonly OcxTool[],
+  reservedNames: ReadonlySet<string>,
+): { tools: OcxTool[]; trimmed: boolean } {
   if (tools.length <= CURSOR_TOOL_BUDGET) return { tools: [...tools], trimmed: false };
 
   const native: OcxTool[] = [];
+  const reserved: OcxTool[] = [];
   const namespaceGroups = new Map<string, OcxTool[]>();
   for (const tool of tools) {
+    const wireName = tool.namespace ? `${tool.namespace}__${tool.name}` : tool.name;
+    if (reservedNames.has(wireName) || reservedNames.has(tool.name)) {
+      reserved.push(tool);
+      continue;
+    }
     if (tool.namespace) {
       const group = namespaceGroups.get(tool.namespace) ?? [];
       group.push(tool);
@@ -47,12 +95,17 @@ function enforceCursorToolBudget(tools: readonly OcxTool[]): { tools: OcxTool[];
     }
   }
 
+  // Cap native tools at budget if there are too many bare-function tools.
+  let trimmed = false;
+  const cappedNative = native.length > CURSOR_TOOL_BUDGET
+    ? (() => { trimmed = true; return native.slice(0, CURSOR_TOOL_BUDGET); })()
+    : native;
+
   // Sort namespaces smallest-first to maximise the number of namespaces that fit.
   const sorted = [...namespaceGroups.entries()].sort((a, b) => a[1].length - b[1].length);
 
-  let remaining = CURSOR_TOOL_BUDGET - native.length;
-  const kept: OcxTool[] = [...native];
-  let trimmed = false;
+  let remaining = CURSOR_TOOL_BUDGET - cappedNative.length - reserved.length;
+  const kept: OcxTool[] = [...cappedNative, ...reserved];
 
   for (const [, group] of sorted) {
     if (group.length <= remaining) {
@@ -141,7 +194,19 @@ export function generatedCursorConversationId(): string {
 
 export function createCursorRequest(parsed: OcxParsedRequest): CursorRunRequest {
   const rawTools = parsed.context.tools ?? [];
-  const { tools: budgetedTools, trimmed } = enforceCursorToolBudget(rawTools);
+
+  // Collect names that must survive trimming: toolChoice targets + previously used tools.
+  const required = toolChoiceRequiredNames(parsed.options.toolChoice);
+  const used = previouslyUsedToolNames(parsed.context.messages);
+  const reservedNames = new Set([...required, ...used]);
+
+  const { tools: budgetedTools, trimmed } = enforceCursorToolBudget(rawTools, reservedNames);
+
+  // Only suggest tool_search if it actually survived the budget.
+  const hasToolSearch = budgetedTools.some(t => t.name === "tool_search");
+  const deferredNote = trimmed
+    ? (hasToolSearch ? CURSOR_DEFERRED_TOOLS_NOTE : CURSOR_DEFERRED_TOOLS_NOTE_NO_SEARCH)
+    : undefined;
 
   return {
     modelId: normalizeCursorModelId(parsed.modelId, parsed.options.reasoning),
@@ -152,7 +217,7 @@ export function createCursorRequest(parsed: OcxParsedRequest): CursorRunRequest 
     conversationId: parsed._cursorConversationId ?? generatedCursorConversationId(),
     system: [
       ...(parsed.context.systemPrompt ?? []),
-      ...(trimmed ? [CURSOR_DEFERRED_TOOLS_NOTE] : []),
+      ...(deferredNote ? [deferredNote] : []),
     ],
     messages: parsed.context.messages
       .map(requestMessage)

--- a/src/adapters/cursor/request-builder.ts
+++ b/src/adapters/cursor/request-builder.ts
@@ -15,22 +15,46 @@ import { toolChoiceAliases, isAllowedToolChoice } from "../../types";
 import type { OcxToolChoice } from "../../types";
 
 /**
- * Maximum number of tools (native + namespace-inner) that the Cursor Connect
- * transport can register per session before returning `resource_exhausted`.
- * Empirically determined: 230 works, 340 fails. 200 provides safe margin.
+ * Cursor Connect transport limits (probe-verified 2026-07-21):
+ *
+ * COUNT limit: ~332 tools per AgentRunRequest.mcp_tools.  Sending 333+
+ * McpToolDefinition entries triggers `resource_exhausted` regardless of
+ * payload size (verified with minimal stub schemas).
+ *
+ * BYTE limit: ~128 KB total protobuf payload for mcp_tools.  With full
+ * JSON schemas (~566 bytes/tool average), this caps us at ~230 tools.
+ *
+ * Hybrid strategy: send up to CURSOR_TOOL_COUNT_BUDGET tools, but stub
+ * the inputSchema for tools beyond the byte budget so the model sees all
+ * tool names/descriptions while staying under both limits.  Full schemas
+ * for stubbed tools are provided via a text catalog in the system prompt
+ * and via tool_search on demand.
+ *
  * See https://github.com/lidge-jun/opencodex/issues/190
  */
-const CURSOR_TOOL_BUDGET = 200;
+const CURSOR_TOOL_COUNT_BUDGET = 330;
+
+/**
+ * Approximate byte budget for the mcp_tools protobuf field.  Probe showed
+ * 128 KB is the server-side ceiling; we use 120 KB for margin.
+ */
+const CURSOR_TOOL_BYTE_BUDGET = 120_000;
+
+/**
+ * Approximate encoded size of a stub schema (`{"type":"object","properties":{}}`).
+ * Used to estimate how much byte-space stubbed tools consume.
+ */
+const STUB_SCHEMA_BYTES = 30;
 
 const CURSOR_DEFERRED_TOOLS_NOTE = [
-  "[opencodex] Not all tools could be advertised to Cursor due to a transport limit.",
-  "Additional MCP/app tools are available via `tool_search` — use it to discover",
-  "and load tools by keyword when the task requires them.",
+  "[opencodex] Some tools have abbreviated schemas due to a transport limit.",
+  "Their full argument schemas are listed in the tool catalog below.",
+  "Use `tool_search` to load any tool's full schema on demand.",
 ].join(" ");
 
 const CURSOR_DEFERRED_TOOLS_NOTE_NO_SEARCH = [
-  "[opencodex] Not all tools could be advertised to Cursor due to a transport limit.",
-  "Some MCP/app tools were omitted. Start a new session if you need access to them.",
+  "[opencodex] Some tools have abbreviated schemas due to a transport limit.",
+  "Their full argument schemas are listed in the tool catalog below.",
 ].join(" ");
 
 /**
@@ -74,8 +98,8 @@ function previouslyUsedToolNames(messages: readonly OcxMessage[]): Set<string> {
 function enforceCursorToolBudget(
   tools: readonly OcxTool[],
   reservedNames: ReadonlySet<string>,
-): { tools: OcxTool[]; trimmed: boolean } {
-  if (tools.length <= CURSOR_TOOL_BUDGET) return { tools: [...tools], trimmed: false };
+): { tools: OcxTool[]; trimmed: boolean; countTrimmed: boolean } {
+  if (tools.length <= CURSOR_TOOL_COUNT_BUDGET) return { tools: [...tools], trimmed: false, countTrimmed: false };
 
   const native: OcxTool[] = [];
   const reserved: OcxTool[] = [];
@@ -97,14 +121,15 @@ function enforceCursorToolBudget(
 
   // Cap native tools at budget if there are too many bare-function tools.
   let trimmed = false;
-  const cappedNative = native.length > CURSOR_TOOL_BUDGET
-    ? (() => { trimmed = true; return native.slice(0, CURSOR_TOOL_BUDGET); })()
+  let countTrimmed = false;
+  const cappedNative = native.length > CURSOR_TOOL_COUNT_BUDGET
+    ? (() => { trimmed = true; countTrimmed = true; return native.slice(0, CURSOR_TOOL_COUNT_BUDGET); })()
     : native;
 
   // Sort namespaces smallest-first to maximise the number of namespaces that fit.
   const sorted = [...namespaceGroups.entries()].sort((a, b) => a[1].length - b[1].length);
 
-  let remaining = CURSOR_TOOL_BUDGET - cappedNative.length - reserved.length;
+  let remaining = CURSOR_TOOL_COUNT_BUDGET - cappedNative.length - reserved.length;
   const kept: OcxTool[] = [...cappedNative, ...reserved];
 
   for (const [, group] of sorted) {
@@ -113,15 +138,84 @@ function enforceCursorToolBudget(
       remaining -= group.length;
     } else {
       trimmed = true;
+      countTrimmed = true;
       // Stop — no more namespaces fit.
       break;
     }
   }
 
   // If we broke early, all subsequent namespaces are also trimmed.
-  if (kept.length < tools.length) trimmed = true;
+  if (kept.length < tools.length) { trimmed = true; countTrimmed = true; }
 
-  return { tools: kept, trimmed };
+  return { tools: kept, trimmed, countTrimmed };
+}
+
+/**
+ * Estimate the encoded protobuf size of a tool's inputSchema.
+ * Uses JSON stringification length as a proxy (protobuf Value encoding
+ * is roughly 1.1-1.3x the JSON length for typical schemas).
+ */
+function estimateSchemaBytes(tool: OcxTool): number {
+  const schema = tool.parameters ?? {};
+  const jsonLen = JSON.stringify(schema).length;
+  // protobuf Value encoding overhead: ~1.2x JSON + field tags
+  return Math.ceil(jsonLen * 1.2) + 20;
+}
+
+/**
+ * Determine which tools should have their schemas stubbed to stay under
+ * the byte budget.  Native tools and the first N namespace tools keep
+ * full schemas; the rest get stubs.  Returns the set of wire-names that
+ * should be stubbed.
+ */
+function computeStubbedTools(tools: readonly OcxTool[]): Set<string> {
+  const stubbed = new Set<string>();
+  let cumulativeBytes = 0;
+
+  // Process tools in order: native first (they keep full schemas),
+  // then namespace tools in their existing order.
+  for (const tool of tools) {
+    const wireName = tool.namespace ? `${tool.namespace}__${tool.name}` : tool.name;
+    const schemaBytes = estimateSchemaBytes(tool);
+
+    if (cumulativeBytes + schemaBytes > CURSOR_TOOL_BYTE_BUDGET) {
+      // This tool's full schema would exceed the byte budget — stub it.
+      stubbed.add(wireName);
+      cumulativeBytes += STUB_SCHEMA_BYTES;
+    } else {
+      cumulativeBytes += schemaBytes;
+    }
+  }
+
+  return stubbed;
+}
+
+/**
+ * Build a compact text catalog of stubbed tools for injection into the
+ * system prompt.  The model reads this to understand argument structures
+ * for tools whose protobuf schemas were stubbed.
+ */
+function buildTextCatalog(tools: readonly OcxTool[], stubbedNames: ReadonlySet<string>): string | undefined {
+  const entries: string[] = [];
+  for (const tool of tools) {
+    const wireName = tool.namespace ? `${tool.namespace}__${tool.name}` : tool.name;
+    if (!stubbedNames.has(wireName)) continue;
+    const schema = tool.parameters ?? {};
+    const props = (schema as Record<string, unknown>).properties;
+    const required = (schema as Record<string, unknown>).required;
+    const propSummary = props && typeof props === "object"
+      ? Object.entries(props as Record<string, Record<string, unknown>>)
+          .map(([k, v]) => `${k}: ${v?.type ?? "any"}${(required as string[] | undefined)?.includes(k) ? "*" : ""}`)
+          .join(", ")
+      : "";
+    entries.push(`- ${wireName}: ${tool.description.slice(0, 120)} | args: {${propSummary}}`);
+  }
+  if (entries.length === 0) return undefined;
+  return [
+    "[opencodex] Tool schema catalog (abbreviated schemas — use these to construct arguments):",
+    ...entries,
+    "(*) = required parameter",
+  ].join("\n");
 }
 
 /**
@@ -200,13 +294,21 @@ export function createCursorRequest(parsed: OcxParsedRequest): CursorRunRequest 
   const used = previouslyUsedToolNames(parsed.context.messages);
   const reservedNames = new Set([...required, ...used]);
 
-  const { tools: budgetedTools, trimmed } = enforceCursorToolBudget(rawTools, reservedNames);
+  const { tools: budgetedTools, trimmed, countTrimmed } = enforceCursorToolBudget(rawTools, reservedNames);
+
+  // Compute which tools need stubbed schemas to stay under the byte budget.
+  const stubbedToolNames = computeStubbedTools(budgetedTools);
+  const hasStubbedTools = stubbedToolNames.size > 0;
 
   // Only suggest tool_search if it actually survived the budget.
   const hasToolSearch = budgetedTools.some(t => t.name === "tool_search");
-  const deferredNote = trimmed
+  const needsNote = trimmed || hasStubbedTools;
+  const deferredNote = needsNote
     ? (hasToolSearch ? CURSOR_DEFERRED_TOOLS_NOTE : CURSOR_DEFERRED_TOOLS_NOTE_NO_SEARCH)
     : undefined;
+
+  // Build text catalog for stubbed tools.
+  const textCatalog = hasStubbedTools ? buildTextCatalog(budgetedTools, stubbedToolNames) : undefined;
 
   return {
     modelId: normalizeCursorModelId(parsed.modelId, parsed.options.reasoning),
@@ -218,12 +320,14 @@ export function createCursorRequest(parsed: OcxParsedRequest): CursorRunRequest 
     system: [
       ...(parsed.context.systemPrompt ?? []),
       ...(deferredNote ? [deferredNote] : []),
+      ...(textCatalog ? [textCatalog] : []),
     ],
     messages: parsed.context.messages
       .map(requestMessage)
       .filter((message): message is CursorRequestMessage => !!message && message.content.length > 0),
     rawMessages: parsed.context.messages,
     ...(budgetedTools.length ? { tools: budgetedTools } : {}),
+    ...(stubbedToolNames.size > 0 ? { stubbedToolNames } : {}),
     ...(parsed.options.toolChoice ? { toolChoice: parsed.options.toolChoice } : {}),
     ...(parsed.options.parallelToolCalls !== undefined ? { parallelToolCalls: parsed.options.parallelToolCalls } : {}),
   };

--- a/src/adapters/cursor/request-builder.ts
+++ b/src/adapters/cursor/request-builder.ts
@@ -10,6 +10,66 @@ import { namespacedToolName } from "../../types";
 import type { CursorRequestMessage, CursorRunRequest } from "./types";
 import { cursorCodexToWireModelId } from "./discovery";
 import { cursorEffortSuffix } from "./effort-map";
+import type { OcxTool } from "../../types";
+
+/**
+ * Maximum number of tools (native + namespace-inner) that the Cursor Connect
+ * transport can register per session before returning `resource_exhausted`.
+ * Empirically determined: 230 works, 340 fails. 200 provides safe margin.
+ * See https://github.com/lidge-jun/opencodex/issues/190
+ */
+const CURSOR_TOOL_BUDGET = 200;
+
+const CURSOR_DEFERRED_TOOLS_NOTE = [
+  "[opencodex] Not all tools could be advertised to Cursor due to a transport limit.",
+  "Additional MCP/app tools are available via `tool_search` — use it to discover",
+  "and load tools by keyword when the task requires them.",
+].join(" ");
+
+/**
+ * Enforce a tool budget for the Cursor transport. Native (non-namespace) tools
+ * are always kept. Namespaces are added smallest-first until the budget is full;
+ * remaining namespaces are dropped (the model can still discover them via
+ * tool_search). Returns the filtered tool list and whether any trimming occurred.
+ */
+function enforceCursorToolBudget(tools: readonly OcxTool[]): { tools: OcxTool[]; trimmed: boolean } {
+  if (tools.length <= CURSOR_TOOL_BUDGET) return { tools: [...tools], trimmed: false };
+
+  const native: OcxTool[] = [];
+  const namespaceGroups = new Map<string, OcxTool[]>();
+  for (const tool of tools) {
+    if (tool.namespace) {
+      const group = namespaceGroups.get(tool.namespace) ?? [];
+      group.push(tool);
+      namespaceGroups.set(tool.namespace, group);
+    } else {
+      native.push(tool);
+    }
+  }
+
+  // Sort namespaces smallest-first to maximise the number of namespaces that fit.
+  const sorted = [...namespaceGroups.entries()].sort((a, b) => a[1].length - b[1].length);
+
+  let remaining = CURSOR_TOOL_BUDGET - native.length;
+  const kept: OcxTool[] = [...native];
+  let trimmed = false;
+
+  for (const [, group] of sorted) {
+    if (group.length <= remaining) {
+      kept.push(...group);
+      remaining -= group.length;
+    } else {
+      trimmed = true;
+      // Stop — no more namespaces fit.
+      break;
+    }
+  }
+
+  // If we broke early, all subsequent namespaces are also trimmed.
+  if (kept.length < tools.length) trimmed = true;
+
+  return { tools: kept, trimmed };
+}
 
 /**
  * Resolve a `cursor/<model>` selection + Codex reasoning effort to the actual Cursor model id. Cursor
@@ -80,6 +140,9 @@ export function generatedCursorConversationId(): string {
 }
 
 export function createCursorRequest(parsed: OcxParsedRequest): CursorRunRequest {
+  const rawTools = parsed.context.tools ?? [];
+  const { tools: budgetedTools, trimmed } = enforceCursorToolBudget(rawTools);
+
   return {
     modelId: normalizeCursorModelId(parsed.modelId, parsed.options.reasoning),
     // The Cursor conversation id comes ONLY from remembered state (_cursorConversationId). Do NOT fall
@@ -87,12 +150,15 @@ export function createCursorRequest(parsed: OcxParsedRequest): CursorRunRequest 
     // different namespace and would start an unrelated Cursor conversation, breaking tool-result
     // continuation. If we have no remembered Cursor conversation, start a fresh one.
     conversationId: parsed._cursorConversationId ?? generatedCursorConversationId(),
-    system: [...(parsed.context.systemPrompt ?? [])],
+    system: [
+      ...(parsed.context.systemPrompt ?? []),
+      ...(trimmed ? [CURSOR_DEFERRED_TOOLS_NOTE] : []),
+    ],
     messages: parsed.context.messages
       .map(requestMessage)
       .filter((message): message is CursorRequestMessage => !!message && message.content.length > 0),
     rawMessages: parsed.context.messages,
-    ...(parsed.context.tools?.length ? { tools: parsed.context.tools } : {}),
+    ...(budgetedTools.length ? { tools: budgetedTools } : {}),
     ...(parsed.options.toolChoice ? { toolChoice: parsed.options.toolChoice } : {}),
     ...(parsed.options.parallelToolCalls !== undefined ? { parallelToolCalls: parsed.options.parallelToolCalls } : {}),
   };

--- a/src/adapters/cursor/tool-definitions.ts
+++ b/src/adapters/cursor/tool-definitions.ts
@@ -286,19 +286,30 @@ export function encodeCursorInputSchema(schema: unknown): Uint8Array {
   return toBinary(ValueSchema, fromJson(ValueSchema, value));
 }
 
+/** Pre-encoded stub schema — reused for every stubbed tool to avoid re-encoding. */
+let _stubSchemaBytes: Uint8Array | undefined;
+export function stubCursorInputSchema(): Uint8Array {
+  if (!_stubSchemaBytes) {
+    _stubSchemaBytes = encodeCursorInputSchema({ type: "object", properties: {} });
+  }
+  return _stubSchemaBytes;
+}
+
 export function buildCursorToolDefinitions(
   tools: readonly OcxTool[] | undefined,
   toolChoice?: OcxRequestOptions["toolChoice"],
+  stubbedToolNames?: ReadonlySet<string>,
 ): McpToolDefinition[] {
   if (!tools?.length) return [];
   return tools.filter(tool => toolChoiceAllows(tool, toolChoice)).map(tool => {
     const wireName = cursorToolWireName(tool);
+    const useStub = stubbedToolNames?.has(wireName) ?? false;
     return create(McpToolDefinitionSchema, {
       name: wireName,
       toolName: wireName,
       providerIdentifier: OCX_RESPONSES_TOOL_PROVIDER,
       description: tool.description,
-      inputSchema: encodeCursorInputSchema(cursorToolInputSchema(tool)),
+      inputSchema: useStub ? stubCursorInputSchema() : encodeCursorInputSchema(cursorToolInputSchema(tool)),
     });
   });
 }

--- a/src/adapters/cursor/types.ts
+++ b/src/adapters/cursor/types.ts
@@ -10,6 +10,8 @@ export interface CursorRunRequest {
   tools?: OcxTool[];
   toolChoice?: OcxRequestOptions["toolChoice"];
   parallelToolCalls?: boolean;
+  /** Wire-names of tools whose inputSchema was stubbed to stay under the byte budget. */
+  stubbedToolNames?: ReadonlySet<string>;
 }
 
 export interface CursorRequestMessage {

--- a/tests/cursor-request-builder.test.ts
+++ b/tests/cursor-request-builder.test.ts
@@ -147,7 +147,7 @@ describe("Cursor request builder", () => {
  });
 
   test("enforces a Cursor tool budget — keeps native tools and trims namespaces when over limit", () => {
-    // Build a realistic catalog: 11 native tools + 4 namespaces totalling 340 inner tools.
+    // Build a catalog that exceeds the 330 count budget: 11 native + 4 namespaces = 351 tools.
     const nativeTools = Array.from({ length: 11 }, (_, i) => ({
       name: `native_${i}`,
       description: `Native tool ${i}`,
@@ -177,9 +177,9 @@ describe("Cursor request builder", () => {
       },
     });
 
-    // Budget is 200 total tools. Native (11) always kept.
-    // Remaining budget: 189. ns_small(5) + ns_medium(30) + ns_large(89) = 124 ≤ 189.
-    // ns_huge(216) would push to 340 > 189, so it's cut.
+    // Budget is 330 total tools. Native (11) always kept.
+    // Remaining budget: 319. ns_small(5) + ns_medium(30) + ns_large(89) + ns_huge(216) = 340 > 319.
+    // ns_small + ns_medium + ns_large = 124 ≤ 319. ns_huge(216) would push to 343 > 319, so it's cut.
     const kept = request.tools ?? [];
     const keptNamespaces = new Set(kept.filter(t => t.namespace).map(t => t.namespace));
     expect(keptNamespaces.has("ns_small")).toBe(true);
@@ -187,7 +187,7 @@ describe("Cursor request builder", () => {
     expect(keptNamespaces.has("ns_large")).toBe(true);
     expect(keptNamespaces.has("ns_huge")).toBe(false);
     expect(kept.length).toBe(11 + 5 + 30 + 89); // 135
-    expect(kept.length).toBeLessThanOrEqual(200);
+    expect(kept.length).toBeLessThanOrEqual(330);
   });
 
   test("does not trim when catalog is under the Cursor tool budget", () => {
@@ -230,7 +230,7 @@ describe("Cursor request builder", () => {
     });
     const systemText = (request.system ?? []).join("\n");
     expect(systemText).toContain("tool_search");
-    expect(systemText).toContain("Not all tools could be advertised");
+    expect(systemText).toContain("abbreviated schemas");
   });
 
   test("does not add deferred-tools note when nothing is trimmed", () => {
@@ -243,7 +243,7 @@ describe("Cursor request builder", () => {
       context: { messages: [{ role: "user", content: "hi", timestamp: 1 }], tools },
     });
     const systemText = (request.system ?? []).join("\n");
-    expect(systemText).not.toContain("Not all tools could be advertised");
+    expect(systemText).not.toContain("abbreviated schemas");
   });
 
   // --- Review-finding tests (PR #192 round 2) ---
@@ -302,13 +302,13 @@ describe("Cursor request builder", () => {
       },
     });
     const systemText = (request.system ?? []).join("\n");
-    expect(systemText).toContain("Not all tools could be advertised");
+    expect(systemText).toContain("abbreviated schemas");
     expect(systemText).not.toContain("tool_search");
   });
 
   test("caps oversized bare-function catalogs at the budget", () => {
-    // 250 native (non-namespace) tools — exceeds budget without any namespaces
-    const tools = Array.from({ length: 250 }, (_, i) => ({
+    // 350 native (non-namespace) tools — exceeds 330 count budget
+    const tools = Array.from({ length: 350 }, (_, i) => ({
       name: `func_${i}`,
       description: `Function tool ${i}`,
       parameters: { type: "object" as const, properties: {} },
@@ -318,9 +318,9 @@ describe("Cursor request builder", () => {
       context: { messages: [{ role: "user", content: "hi", timestamp: 1 }], tools },
     });
     const kept = request.tools ?? [];
-    expect(kept.length).toBeLessThanOrEqual(200);
+    expect(kept.length).toBeLessThanOrEqual(330);
     const systemText = (request.system ?? []).join("\n");
-    expect(systemText).toContain("Not all tools could be advertised");
+    expect(systemText).toContain("abbreviated schemas");
   });
 
   test("keeps previously-used tools from trimmed namespaces across turns", () => {
@@ -365,5 +365,89 @@ describe("Cursor request builder", () => {
     const kept = request.tools ?? [];
     const hasSearched = kept.some(t => t.name === "special_action" && t.namespace === "ns_huge");
     expect(hasSearched).toBe(true);
+  });
+
+  // --- Hybrid budget tests (probe-verified 2026-07-21) ---
+
+  test("stubs schemas for tools beyond byte budget while keeping all under count budget", () => {
+    // 300 tools with large schemas — should exceed byte budget but not count budget (330).
+    const largeSchema = {
+      type: "object" as const,
+      properties: Object.fromEntries(
+        Array.from({ length: 20 }, (_, i) => [`param_${i}`, { type: "string", description: `Parameter ${i} with a long description to inflate the schema size significantly` }]),
+      ),
+      required: Array.from({ length: 5 }, (_, i) => `param_${i}`),
+    };
+    const tools = Array.from({ length: 300 }, (_, i) => ({
+      name: `big_tool_${i}`,
+      namespace: "ns_big",
+      description: `Big tool ${i}`,
+      parameters: largeSchema,
+    }));
+    const request = createCursorRequest({
+      ...base,
+      context: { messages: [{ role: "user", content: "hi", timestamp: 1 }], tools },
+    });
+    // All 300 tools should survive (under 330 count budget).
+    expect(request.tools?.length).toBe(300);
+    // Some tools should have stubbed schemas (byte budget exceeded).
+    expect(request.stubbedToolNames).toBeDefined();
+    expect(request.stubbedToolNames!.size).toBeGreaterThan(0);
+    expect(request.stubbedToolNames!.size).toBeLessThan(300);
+  });
+
+  test("does not stub schemas when catalog fits within byte budget", () => {
+    const tools = Array.from({ length: 50 }, (_, i) => ({
+      name: `small_tool_${i}`,
+      description: `Small tool ${i}`,
+      parameters: { type: "object" as const, properties: { x: { type: "string" } } },
+    }));
+    const request = createCursorRequest({
+      ...base,
+      context: { messages: [{ role: "user", content: "hi", timestamp: 1 }], tools },
+    });
+    expect(request.tools?.length).toBe(50);
+    expect(request.stubbedToolNames).toBeUndefined();
+  });
+
+  test("injects text catalog for stubbed tools into system prompt", () => {
+    const largeSchema = {
+      type: "object" as const,
+      properties: Object.fromEntries(
+        Array.from({ length: 20 }, (_, i) => [`param_${i}`, { type: "string", description: `Parameter ${i} with a long description to inflate the schema size significantly` }]),
+      ),
+      required: Array.from({ length: 5 }, (_, i) => `param_${i}`),
+    };
+    const tools = Array.from({ length: 300 }, (_, i) => ({
+      name: `big_tool_${i}`,
+      namespace: "ns_big",
+      description: `Big tool ${i}`,
+      parameters: largeSchema,
+    }));
+    const request = createCursorRequest({
+      ...base,
+      context: { messages: [{ role: "user", content: "hi", timestamp: 1 }], tools },
+    });
+    const systemText = (request.system ?? []).join("\n");
+    expect(systemText).toContain("Tool schema catalog");
+    expect(systemText).toContain("big_tool_");
+    expect(systemText).toContain("param_0: string*");
+  });
+
+  test("keeps all tools when catalog is between old and new count budget", () => {
+    // 250 tools with tiny schemas — would have been trimmed at old 200 budget,
+    // but should all survive at 330 count budget with no stubbing needed.
+    const tools = Array.from({ length: 250 }, (_, i) => ({
+      name: `tool_${i}`,
+      namespace: "ns_a",
+      description: `Tool ${i}`,
+      parameters: { type: "object" as const, properties: {} },
+    }));
+    const request = createCursorRequest({
+      ...base,
+      context: { messages: [{ role: "user", content: "hi", timestamp: 1 }], tools },
+    });
+    expect(request.tools?.length).toBe(250);
+    expect(request.stubbedToolNames).toBeUndefined();
   });
 });

--- a/tests/cursor-request-builder.test.ts
+++ b/tests/cursor-request-builder.test.ts
@@ -142,7 +142,101 @@ describe("Cursor request builder", () => {
     });
     const request = createCursorRequest(parsed);
 
-    expect(request.toolChoice).toEqual({ mode: "required", allowedTools: ["read_file"] });
-    expect(request.parallelToolCalls).toBe(false);
+   expect(request.toolChoice).toEqual({ mode: "required", allowedTools: ["read_file"] });
+   expect(request.parallelToolCalls).toBe(false);
+ });
+
+  test("enforces a Cursor tool budget — keeps native tools and trims namespaces when over limit", () => {
+    // Build a realistic catalog: 11 native tools + 4 namespaces totalling 340 inner tools.
+    const nativeTools = Array.from({ length: 11 }, (_, i) => ({
+      name: `native_${i}`,
+      description: `Native tool ${i}`,
+      parameters: { type: "object" as const, properties: {} },
+    }));
+    const namespaces = [
+      { name: "ns_small", innerCount: 5 },
+      { name: "ns_medium", innerCount: 30 },
+      { name: "ns_large", innerCount: 89 },
+      { name: "ns_huge", innerCount: 216 },
+    ];
+    const namespaceTools = namespaces.flatMap(ns =>
+      Array.from({ length: ns.innerCount }, (_, i) => ({
+        name: `tool_${i}`,
+        namespace: ns.name,
+        description: `${ns.name} tool ${i}`,
+        parameters: { type: "object" as const, properties: {} },
+      })),
+    );
+
+    const allTools = [...nativeTools, ...namespaceTools]; // 11 + 340 = 351
+    const request = createCursorRequest({
+      ...base,
+      context: {
+        messages: [{ role: "user", content: "hello", timestamp: 1 }],
+        tools: allTools,
+      },
+    });
+
+    // Budget is 200 total tools. Native (11) always kept.
+    // Remaining budget: 189. ns_small(5) + ns_medium(30) + ns_large(89) = 124 ≤ 189.
+    // ns_huge(216) would push to 340 > 189, so it's cut.
+    const kept = request.tools ?? [];
+    const keptNamespaces = new Set(kept.filter(t => t.namespace).map(t => t.namespace));
+    expect(keptNamespaces.has("ns_small")).toBe(true);
+    expect(keptNamespaces.has("ns_medium")).toBe(true);
+    expect(keptNamespaces.has("ns_large")).toBe(true);
+    expect(keptNamespaces.has("ns_huge")).toBe(false);
+    expect(kept.length).toBe(11 + 5 + 30 + 89); // 135
+    expect(kept.length).toBeLessThanOrEqual(200);
+  });
+
+  test("does not trim when catalog is under the Cursor tool budget", () => {
+    const tools = [
+      { name: "exec_command", description: "Run", parameters: {} },
+      { name: "read_file", namespace: "mcp__fs", description: "Read", parameters: {} },
+      { name: "write_file", namespace: "mcp__fs", description: "Write", parameters: {} },
+    ];
+    const request = createCursorRequest({
+      ...base,
+      context: { messages: [{ role: "user", content: "hi", timestamp: 1 }], tools },
+    });
+    expect(request.tools).toEqual(tools);
+  });
+
+  test("adds deferred-tools system note when namespaces are trimmed", () => {
+    const nativeTools = Array.from({ length: 11 }, (_, i) => ({
+      name: `native_${i}`,
+      description: `Native tool ${i}`,
+      parameters: { type: "object" as const, properties: {} },
+    }));
+    const namespaceTools = Array.from({ length: 340 }, (_, i) => ({
+      name: `tool_${i}`,
+      namespace: `ns_${Math.floor(i / 50)}`,
+      description: `NS tool ${i}`,
+      parameters: { type: "object" as const, properties: {} },
+    }));
+    const request = createCursorRequest({
+      ...base,
+      context: {
+        messages: [{ role: "user", content: "hello", timestamp: 1 }],
+        tools: [...nativeTools, ...namespaceTools],
+      },
+    });
+    const systemText = (request.system ?? []).join("\n");
+    expect(systemText).toContain("tool_search");
+    expect(systemText).toContain("Not all tools could be advertised");
+  });
+
+  test("does not add deferred-tools note when nothing is trimmed", () => {
+    const tools = [
+      { name: "exec_command", description: "Run", parameters: {} },
+      { name: "read_file", namespace: "mcp__fs", description: "Read", parameters: {} },
+    ];
+    const request = createCursorRequest({
+      ...base,
+      context: { messages: [{ role: "user", content: "hi", timestamp: 1 }], tools },
+    });
+    const systemText = (request.system ?? []).join("\n");
+    expect(systemText).not.toContain("Not all tools could be advertised");
   });
 });

--- a/tests/cursor-request-builder.test.ts
+++ b/tests/cursor-request-builder.test.ts
@@ -209,6 +209,12 @@ describe("Cursor request builder", () => {
       description: `Native tool ${i}`,
       parameters: { type: "object" as const, properties: {} },
     }));
+    // Include tool_search so the deferred note references it
+    const toolSearch = {
+      name: "tool_search",
+      description: "Search for tools",
+      parameters: { type: "object" as const, properties: {} },
+    };
     const namespaceTools = Array.from({ length: 340 }, (_, i) => ({
       name: `tool_${i}`,
       namespace: `ns_${Math.floor(i / 50)}`,
@@ -219,7 +225,7 @@ describe("Cursor request builder", () => {
       ...base,
       context: {
         messages: [{ role: "user", content: "hello", timestamp: 1 }],
-        tools: [...nativeTools, ...namespaceTools],
+        tools: [...nativeTools, toolSearch, ...namespaceTools],
       },
     });
     const systemText = (request.system ?? []).join("\n");
@@ -238,5 +244,126 @@ describe("Cursor request builder", () => {
     });
     const systemText = (request.system ?? []).join("\n");
     expect(systemText).not.toContain("Not all tools could be advertised");
+  });
+
+  // --- Review-finding tests (PR #192 round 2) ---
+
+  test("preserves toolChoice-targeted tools even when their namespace is trimmed", () => {
+    const nativeTools = Array.from({ length: 11 }, (_, i) => ({
+      name: `native_${i}`,
+      description: `Native tool ${i}`,
+      parameters: { type: "object" as const, properties: {} },
+    }));
+    // One huge namespace that will be trimmed
+    const hugeNs = Array.from({ length: 250 }, (_, i) => ({
+      name: `huge_${i}`,
+      namespace: "ns_huge",
+      description: `Huge tool ${i}`,
+      parameters: { type: "object" as const, properties: {} },
+    }));
+    // The specific tool we force via toolChoice
+    const forcedTool = {
+      name: "critical_action",
+      namespace: "ns_huge",
+      description: "Must survive",
+      parameters: { type: "object" as const, properties: {} },
+    };
+    const request = createCursorRequest({
+      ...base,
+      context: {
+        messages: [{ role: "user", content: "do it", timestamp: 1 }],
+        tools: [...nativeTools, ...hugeNs, forcedTool],
+      },
+      options: { toolChoice: { name: "ns_huge__critical_action" } },
+    });
+    const kept = request.tools ?? [];
+    const hasForced = kept.some(t => t.name === "critical_action" && t.namespace === "ns_huge");
+    expect(hasForced).toBe(true);
+  });
+
+  test("does not suggest tool_search when it is not in the kept catalog", () => {
+    const nativeTools = Array.from({ length: 11 }, (_, i) => ({
+      name: `native_${i}`,
+      description: `Native tool ${i}`,
+      parameters: { type: "object" as const, properties: {} },
+    }));
+    const namespaceTools = Array.from({ length: 340 }, (_, i) => ({
+      name: `tool_${i}`,
+      namespace: `ns_${Math.floor(i / 50)}`,
+      description: `NS tool ${i}`,
+      parameters: { type: "object" as const, properties: {} },
+    }));
+    // No tool_search in the catalog at all
+    const request = createCursorRequest({
+      ...base,
+      context: {
+        messages: [{ role: "user", content: "hello", timestamp: 1 }],
+        tools: [...nativeTools, ...namespaceTools],
+      },
+    });
+    const systemText = (request.system ?? []).join("\n");
+    expect(systemText).toContain("Not all tools could be advertised");
+    expect(systemText).not.toContain("tool_search");
+  });
+
+  test("caps oversized bare-function catalogs at the budget", () => {
+    // 250 native (non-namespace) tools — exceeds budget without any namespaces
+    const tools = Array.from({ length: 250 }, (_, i) => ({
+      name: `func_${i}`,
+      description: `Function tool ${i}`,
+      parameters: { type: "object" as const, properties: {} },
+    }));
+    const request = createCursorRequest({
+      ...base,
+      context: { messages: [{ role: "user", content: "hi", timestamp: 1 }], tools },
+    });
+    const kept = request.tools ?? [];
+    expect(kept.length).toBeLessThanOrEqual(200);
+    const systemText = (request.system ?? []).join("\n");
+    expect(systemText).toContain("Not all tools could be advertised");
+  });
+
+  test("keeps previously-used tools from trimmed namespaces across turns", () => {
+    const nativeTools = Array.from({ length: 11 }, (_, i) => ({
+      name: `native_${i}`,
+      description: `Native tool ${i}`,
+      parameters: { type: "object" as const, properties: {} },
+    }));
+    // Huge namespace that will be trimmed
+    const hugeNs = Array.from({ length: 250 }, (_, i) => ({
+      name: `huge_${i}`,
+      namespace: "ns_huge",
+      description: `Huge tool ${i}`,
+      parameters: { type: "object" as const, properties: {} },
+    }));
+    // A tool that was loaded via tool_search in a prior turn
+    const searchedTool = {
+      name: "special_action",
+      namespace: "ns_huge",
+      description: "Previously loaded",
+      parameters: { type: "object" as const, properties: {} },
+    };
+    const request = createCursorRequest({
+      ...base,
+      context: {
+        messages: [
+          { role: "user", content: "use it", timestamp: 1 },
+          // Prior tool result referencing the searched tool
+          {
+            role: "toolResult",
+            toolCallId: "call_prev",
+            toolName: "special_action",
+            toolNamespace: "ns_huge",
+            content: "result from previous turn",
+            isError: false,
+            timestamp: 2,
+          },
+        ],
+        tools: [...nativeTools, ...hugeNs, searchedTool],
+      },
+    });
+    const kept = request.tools ?? [];
+    const hasSearched = kept.some(t => t.name === "special_action" && t.namespace === "ns_huge");
+    expect(hasSearched).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

Cursor Connect returns `resource_exhausted` when the aggregate tool catalog exceeds an internal registration limit. This is **not** a quota issue — the account has remaining credits and native Cursor works fine.

Reproduced with 340 namespace-inner tools (443 KB serialized). Both halves of the catalog (230 and 110 tools) work independently, confirming the failure depends on the aggregate size, not a single malformed schema.

See #190 for full reproduction, measurements, and isolation results.

## Fix

Add a Cursor-specific tool budget (default 200) in `createCursorRequest`:

- **Native tools** (no namespace) are always preserved — `exec_command`, `apply_patch`, `web_search`, `tool_search`, etc.
- **Namespace groups** are sorted smallest-first and added until the budget is full.
- **Remaining namespaces** are dropped from the initial advertisement. The model can still discover and load them via `tool_search`.
- A **system-prompt note** is appended when trimming occurs, so the model knows to use `tool_search` for unavailable tools.

## Why 200?

Empirically determined: 230 tools succeed, 340 fail. 200 provides safe margin while still covering most real-world setups (typical Codex installs with a few MCP servers stay well under 200).

## Testing

- 4 new unit tests in `cursor-request-builder.test.ts`:
  - Budget enforcement with mixed native + namespace tools
  - No trimming when under budget
  - Deferred-tools system note when trimmed
  - No note when nothing trimmed
- All 277 existing cursor tests pass
- `tsc --noEmit` clean

## Future work

A more complete fix would implement full deferred loading for Cursor (send only tool names in the initial `mcp_tools` registration, load full schemas on `tool_search`). This PR provides an immediate, safe mitigation that unblocks all users with large plugin/app catalogs.