### PR TITLE
fix(update): hard-pin listen port after update (complete #152)

### DIFF
--- a/bin/ocx.mjs
+++ b/bin/ocx.mjs
@@ -124,6 +124,19 @@ function runNpmSelfUpdate() {
     return [launcher, "service", "install"];
   }
 
+  // Capture listen target before stop clears runtime-port.json (mirrors GUI/CLI update worker).
+  let bakePort = 10100;
+  try {
+    const rt = JSON.parse(readFileSync(join(configDir(), "runtime-port.json"), "utf8"));
+    if (Number.isFinite(rt?.port) && rt.port > 0) bakePort = Math.trunc(rt.port);
+  } catch { /* fall through to config */ }
+  if (bakePort === 10100) {
+    try {
+      const cfg = JSON.parse(readFileSync(join(configDir(), "config.json"), "utf8"));
+      if (Number.isFinite(cfg?.port) && cfg.port > 0) bakePort = Math.trunc(cfg.port);
+    } catch { /* keep default */ }
+  }
+
   // Never replace package files under a live proxy — stop it first (full `ocx stop`
   // semantics: graceful drain, service stop, native Codex restore). Gate on the service
   // and the runtime-port record too: a service-managed or orphaned proxy can be live
@@ -163,9 +176,16 @@ function runNpmSelfUpdate() {
     // launcher so the new files write the baked paths and the service restarts.
     if (serviceWasInstalled) {
       console.log("Reinstalling the background service with the updated files...");
-      const svcArgs = serviceReinstallArgs();
-      const svc = spawnSync(process.execPath, svcArgs, { stdio: "inherit", windowsHide: true });
-      if (svc.status !== 0) console.warn("opencodex: service refresh failed — run 'ocx service install' manually.");
+      const prevBake = process.env.OCX_BAKE_PORT;
+      process.env.OCX_BAKE_PORT = String(bakePort);
+      try {
+        const svcArgs = serviceReinstallArgs();
+        const svc = spawnSync(process.execPath, svcArgs, { stdio: "inherit", windowsHide: true });
+        if (svc.status !== 0) console.warn("opencodex: service refresh failed — run 'ocx service install' manually.");
+      } finally {
+        if (prevBake === undefined) delete process.env.OCX_BAKE_PORT;
+        else process.env.OCX_BAKE_PORT = prevBake;
+      }
     } else {
       console.log("Restart the proxy:  ocx start");
     }

--- a/bin/ocx.mjs
+++ b/bin/ocx.mjs
@@ -125,15 +125,33 @@ function runNpmSelfUpdate() {
   }
 
   // Capture listen target before stop clears runtime-port.json (mirrors GUI/CLI update worker).
+  // Do not treat a live runtime port of 10100 as "missing" — track whether the read succeeded.
   let bakePort = 10100;
+  let sawRuntimePort = false;
   try {
     const rt = JSON.parse(readFileSync(join(configDir(), "runtime-port.json"), "utf8"));
-    if (Number.isFinite(rt?.port) && rt.port > 0) bakePort = Math.trunc(rt.port);
+    if (Number.isFinite(rt?.port) && rt.port > 0 && rt.port <= 65535) {
+      // Only trust runtime when its pid still looks alive (stale crash leftovers fall back to config).
+      const rtPid = Number(rt?.pid);
+      let runtimeLive = false;
+      if (Number.isSafeInteger(rtPid) && rtPid > 0) {
+        try {
+          process.kill(rtPid, 0);
+          runtimeLive = true;
+        } catch (e) {
+          if (e && typeof e === "object" && "code" in e && e.code === "EPERM") runtimeLive = true;
+        }
+      }
+      if (runtimeLive) {
+        bakePort = Math.trunc(rt.port);
+        sawRuntimePort = true;
+      }
+    }
   } catch { /* fall through to config */ }
-  if (bakePort === 10100) {
+  if (!sawRuntimePort) {
     try {
       const cfg = JSON.parse(readFileSync(join(configDir(), "config.json"), "utf8"));
-      if (Number.isFinite(cfg?.port) && cfg.port > 0) bakePort = Math.trunc(cfg.port);
+      if (Number.isFinite(cfg?.port) && cfg.port > 0 && cfg.port <= 65535) bakePort = Math.trunc(cfg.port);
     } catch { /* keep default */ }
   }
 

--- a/src/cli/claude.ts
+++ b/src/cli/claude.ts
@@ -135,7 +135,8 @@ export async function fetchClaudeContextWindows(config: OcxConfig, port: number,
 async function ensureProxyForClaude(): Promise<number | null> {
   const live = await findLiveProxy();
   if (live) return live.port;
-  const pinPort = loadConfig().port ?? 10100;
+  const cfgPort = loadConfig().port;
+  const pinPort = typeof cfgPort === "number" && cfgPort > 0 ? cfgPort : 10100;
   const child = spawn(process.execPath, [process.argv[1], "start", "--port", String(pinPort)], {
     detached: true,
     stdio: "ignore",

--- a/src/cli/claude.ts
+++ b/src/cli/claude.ts
@@ -135,7 +135,8 @@ export async function fetchClaudeContextWindows(config: OcxConfig, port: number,
 async function ensureProxyForClaude(): Promise<number | null> {
   const live = await findLiveProxy();
   if (live) return live.port;
-  const child = spawn(process.execPath, [process.argv[1], "start"], {
+  const pinPort = loadConfig().port ?? 10100;
+  const child = spawn(process.execPath, [process.argv[1], "start", "--port", String(pinPort)], {
     detached: true,
     stdio: "ignore",
     windowsHide: true,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -96,7 +96,7 @@ function startArgv(port?: number): string[] {
 
 async function chooseListenPort(requestedPort?: number): Promise<number> {
   const config = loadConfig();
-  const preferred = requestedPort ?? config.port ?? 10100;
+  const preferred = requestedPort ?? (config.port && config.port > 0 ? config.port : 10100);
   const hardPin = requestedPort !== undefined;
   // Soft start: brief prefer-retry then ephemeral hop.
   // Explicit `--port` (service wrappers / update restart): longer prefer-retry, never hop.
@@ -280,7 +280,7 @@ async function handleEnsure() {
       return;
     }
 
-  const pinPort = config.port ?? 10100;
+  const pinPort = config.port && config.port > 0 ? config.port : 10100;
   const child = spawn(process.execPath, startArgv(pinPort), {
     detached: true,
     stdio: "ignore",
@@ -569,7 +569,7 @@ switch (command) {
     let live = await findLiveProxy();
     if (!live) {
       console.log("Proxy not running. Starting...");
-      const child = spawn(process.execPath, startArgv(config.port ?? 10100), {
+      const child = spawn(process.execPath, startArgv(config.port && config.port > 0 ? config.port : 10100), {
         detached: true,
         stdio: "ignore",
         windowsHide: true,
@@ -577,6 +577,10 @@ switch (command) {
       });
       child.unref();
       live = await waitForProxy();
+      if (!live) {
+        console.error("❌ Proxy did not become healthy after starting. Not opening the GUI.");
+        process.exit(1);
+      }
     }
     // Open the host the proxy actually binds — `localhost` only answers for
     // loopback/wildcard binds, not a concrete LAN/IPv6 hostname.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -22,7 +22,7 @@ import {
 import { collectStatus } from "./status";
 import { installCrashGuards } from "../lib/crash-guard";
 import { hasHelpFlag, printSubcommandUsage, printUsage, printVersion } from "./help";
-import { findAvailablePort, isAddrInUse, shouldPersistSelectedPort } from "../server/ports";
+import { findAvailablePort, isAddrInUse, PortUnavailableError, shouldPersistSelectedPort, waitForPortAvailable } from "../server/ports";
 import { findLiveProxy, probeHostname, type LiveProxy } from "../server/proxy-liveness";
 import { stopProxy } from "../lib/process-control";
 import { loadServiceTokenFromFile } from "../lib/service-secrets";
@@ -85,23 +85,43 @@ async function waitForProxy(timeoutMs = 8_000): Promise<LiveProxy | null> {
   return null;
 }
 
+/** Argv for detached `start`, optionally hard-pinning the listen port. */
+function startArgv(port?: number): string[] {
+  const args = [process.argv[1], "start"];
+  if (typeof port === "number" && Number.isFinite(port) && port > 0 && port <= 65535) {
+    args.push("--port", String(Math.trunc(port)));
+  }
+  return args;
+}
+
 async function chooseListenPort(requestedPort?: number): Promise<number> {
   const config = loadConfig();
   const preferred = requestedPort ?? config.port ?? 10100;
-  // Brief prefer-retry covers stop→start races (update restart, `ocx restart`) where the
-  // old process has exited but the listen socket is still draining.
-  const selected = await findAvailablePort(preferred, config.hostname ?? "127.0.0.1", {
-    preferRetryMs: 750,
-    preferRetryIntervalMs: 50,
-  });
-  if (selected !== preferred) {
-    console.log(`⚠️  Port ${preferred} is busy; starting opencodex on ${selected}.`);
+  const hardPin = requestedPort !== undefined;
+  // Soft start: brief prefer-retry then ephemeral hop.
+  // Explicit `--port` (service wrappers / update restart): longer prefer-retry, never hop.
+  try {
+    const selected = await findAvailablePort(preferred, config.hostname ?? "127.0.0.1", {
+      preferRetryMs: hardPin ? 8_000 : 750,
+      preferRetryIntervalMs: 50,
+      allowEphemeralFallback: !hardPin,
+    });
+    if (selected !== preferred) {
+      console.log(`⚠️  Port ${preferred} is busy; starting opencodex on ${selected}.`);
+    }
+    if (shouldPersistSelectedPort(config.port, selected, preferred)) {
+      config.port = selected;
+      saveConfig(config);
+    }
+    return selected;
+  } catch (err) {
+    if (err instanceof PortUnavailableError) {
+      console.error(`❌ ${err.message}`);
+      console.error("   Stop whatever holds that port, or change config.port, then retry.");
+      process.exit(1);
+    }
+    throw err;
   }
-  if (shouldPersistSelectedPort(config.port, selected, preferred)) {
-    config.port = selected;
-    saveConfig(config);
-  }
-  return selected;
 }
 
 async function handleStart(options: { block?: boolean } = {}) {
@@ -128,7 +148,8 @@ async function handleStart(options: { block?: boolean } = {}) {
   await maybeShowUpdatePrompt();
 
   // Port selection is check-then-bind: a concurrent `ocx start`/`ensure` can win the port
-  // between the probe and Bun.serve. Retry the pick instead of dying on EADDRINUSE.
+  // between the probe and Bun.serve. Soft starts may re-pick; hard-pinned `--port` retries
+  // the same port only (never hop — that was the remaining PR #152 gap).
   let port = await chooseListenPort(requestedPort);
   let server: ReturnType<typeof startServer>;
   for (let attempt = 0; ; attempt++) {
@@ -137,6 +158,16 @@ async function handleStart(options: { block?: boolean } = {}) {
       break;
     } catch (err) {
       if (!isAddrInUse(err) || attempt >= 2) throw err;
+      if (requestedPort !== undefined) {
+        console.log(`⚠️  Port ${port} was taken while starting; waiting to retry the same port...`);
+        const hostname = loadConfig().hostname ?? "127.0.0.1";
+        const freed = await waitForPortAvailable(port, hostname, { timeoutMs: 3_000, intervalMs: 50 });
+        if (!freed) {
+          console.error(`❌ Port ${port} stayed busy; refusing to hop to an ephemeral port.`);
+          process.exit(1);
+        }
+        continue;
+      }
       console.log(`⚠️  Port ${port} was taken while starting; picking another...`);
       port = await chooseListenPort(requestedPort);
     }
@@ -249,7 +280,8 @@ async function handleEnsure() {
       return;
     }
 
-  const child = spawn(process.execPath, [process.argv[1], "start"], {
+  const pinPort = config.port ?? 10100;
+  const child = spawn(process.execPath, startArgv(pinPort), {
     detached: true,
     stdio: "ignore",
     windowsHide: true,
@@ -537,7 +569,7 @@ switch (command) {
     let live = await findLiveProxy();
     if (!live) {
       console.log("Proxy not running. Starting...");
-      const child = spawn(process.execPath, [process.argv[1], "start"], {
+      const child = spawn(process.execPath, startArgv(config.port ?? 10100), {
         detached: true,
         stdio: "ignore",
         windowsHide: true,

--- a/src/lib/winsw.ts
+++ b/src/lib/winsw.ts
@@ -18,7 +18,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
-import { expandUserPath, getConfigDir } from "../config";
+import { expandUserPath, getConfigDir, loadConfig } from "../config";
 import { durableBunPath } from "./bun-runtime";
 import { serviceApiTokenFilePath } from "./service-secrets";
 
@@ -72,9 +72,18 @@ export interface WinswEntry {
  * Task Scheduler wrapper / launchd / systemd: the SCM service environment lacks the
  * user's interactive PATH, which provider subprocesses may need.
  */
-export function buildWinswXml(entry: WinswEntry, env: NodeJS.ProcessEnv = process.env): string {
+export function buildWinswXml(entry: WinswEntry, env: NodeJS.ProcessEnv = process.env, port?: number): string {
   const domain = env.USERDOMAIN?.trim() || ".";
   const user = env.USERNAME?.trim() || "";
+  const listenPort = (() => {
+    if (typeof port === "number" && Number.isFinite(port) && port > 0 && port <= 65535) return Math.trunc(port);
+    const baked = env.OCX_BAKE_PORT?.trim();
+    if (baked && /^\d+$/.test(baked)) {
+      const n = Number(baked);
+      if (n > 0 && n <= 65535) return n;
+    }
+    return loadConfig().port ?? 10100;
+  })();
   const envLines = [
     `  <env name="OCX_SERVICE" value="1"/>`,
     `  <env name="OCX_API_TOKEN_FILE" value="${xmlEscape(serviceApiTokenFilePath())}"/>`,
@@ -88,7 +97,7 @@ export function buildWinswXml(entry: WinswEntry, env: NodeJS.ProcessEnv = proces
   <name>OpenCodex Proxy (native)</name>
   <description>OpenCodex proxy running as a native Windows service (windowless, starts at boot).</description>
   <executable>${xmlEscape(entry.bun)}</executable>
-  <arguments>${xmlEscape(`"${entry.cli}" start`)}</arguments>
+  <arguments>${xmlEscape(`"${entry.cli}" start --port ${listenPort}`)}</arguments>
 ${envLines.join("\n")}
   <logpath>${xmlEscape(winswLogDir())}</logpath>
   <log mode="roll-by-size">

--- a/src/lib/winsw.ts
+++ b/src/lib/winsw.ts
@@ -84,6 +84,8 @@ export function buildWinswXml(entry: WinswEntry, env: NodeJS.ProcessEnv = proces
     }
     return loadConfig().port ?? 10100;
   })();
+  // Services never bake `--port 0` (parsePortOption rejects it); treat as default.
+  const safeListenPort = listenPort > 0 && listenPort <= 65535 ? listenPort : 10100;
   const envLines = [
     `  <env name="OCX_SERVICE" value="1"/>`,
     `  <env name="OCX_API_TOKEN_FILE" value="${xmlEscape(serviceApiTokenFilePath())}"/>`,
@@ -97,7 +99,7 @@ export function buildWinswXml(entry: WinswEntry, env: NodeJS.ProcessEnv = proces
   <name>OpenCodex Proxy (native)</name>
   <description>OpenCodex proxy running as a native Windows service (windowless, starts at boot).</description>
   <executable>${xmlEscape(entry.bun)}</executable>
-  <arguments>${xmlEscape(`"${entry.cli}" start --port ${listenPort}`)}</arguments>
+  <arguments>${xmlEscape(`"${entry.cli}" start --port ${safeListenPort}`)}</arguments>
 ${envLines.join("\n")}
   <logpath>${xmlEscape(winswLogDir())}</logpath>
   <log mode="roll-by-size">

--- a/src/server/ports.ts
+++ b/src/server/ports.ts
@@ -49,7 +49,22 @@ export type FindAvailablePortOptions = {
   /** How long to keep retrying the preferred port before falling back to an ephemeral port. */
   preferRetryMs?: number;
   preferRetryIntervalMs?: number;
+  /**
+   * When false, never bind `port: 0` — prefer-retry then throw if the preferred port
+   * stays busy. Used for explicit `ocx start --port N` and service-baked pins so an
+   * update restart cannot hop to a random ephemeral listener (PR #152 gap).
+   */
+  allowEphemeralFallback?: boolean;
 };
+
+export class PortUnavailableError extends Error {
+  readonly port: number;
+  constructor(port: number, hostname: string) {
+    super(`Port ${port} on ${hostname} is still busy after prefer-retry; refusing ephemeral fallback.`);
+    this.name = "PortUnavailableError";
+    this.port = port;
+  }
+}
 
 export async function findAvailablePort(
   preferredPort: number,
@@ -57,6 +72,7 @@ export async function findAvailablePort(
   opts: FindAvailablePortOptions = {},
 ): Promise<number> {
   const preferRetryMs = opts.preferRetryMs ?? 0;
+  const allowEphemeral = opts.allowEphemeralFallback !== false;
   if (preferRetryMs > 0) {
     if (await waitForPortAvailable(preferredPort, hostname, {
       timeoutMs: preferRetryMs,
@@ -66,6 +82,10 @@ export async function findAvailablePort(
     }
   } else if (await isPortAvailable(preferredPort, hostname)) {
     return preferredPort;
+  }
+
+  if (!allowEphemeral) {
+    throw new PortUnavailableError(preferredPort, hostname);
   }
 
   return await new Promise((resolve, reject) => {

--- a/src/service.ts
+++ b/src/service.ts
@@ -245,6 +245,8 @@ function shellQuote(value: string): string {
 /**
  * Listen port baked into service wrappers / WinSW XML.
  * Priority: explicit override → OCX_BAKE_PORT (update restart) → config.port → 10100.
+ * `config.port === 0` means ephemeral for interactive start; services need a stable pin,
+ * so treat 0 / invalid like unset (default 10100) instead of baking `--port 0`.
  */
 export function resolveServiceListenPort(override?: number): number {
   if (typeof override === "number" && Number.isFinite(override) && override > 0 && override <= 65535) {
@@ -255,7 +257,9 @@ export function resolveServiceListenPort(override?: number): number {
     const n = Number(baked);
     if (n > 0 && n <= 65535) return n;
   }
-  return loadConfig().port ?? 10100;
+  const configured = loadConfig().port;
+  if (typeof configured === "number" && configured > 0 && configured <= 65535) return configured;
+  return 10100;
 }
 
 function buildServiceShellCommand(bun: string, cli: string, port = resolveServiceListenPort()): string {

--- a/src/service.ts
+++ b/src/service.ts
@@ -242,9 +242,25 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
-function buildServiceShellCommand(bun: string, cli: string): string {
+/**
+ * Listen port baked into service wrappers / WinSW XML.
+ * Priority: explicit override → OCX_BAKE_PORT (update restart) → config.port → 10100.
+ */
+export function resolveServiceListenPort(override?: number): number {
+  if (typeof override === "number" && Number.isFinite(override) && override > 0 && override <= 65535) {
+    return Math.trunc(override);
+  }
+  const baked = process.env.OCX_BAKE_PORT?.trim();
+  if (baked && /^\d+$/.test(baked)) {
+    const n = Number(baked);
+    if (n > 0 && n <= 65535) return n;
+  }
+  return loadConfig().port ?? 10100;
+}
+
+function buildServiceShellCommand(bun: string, cli: string, port = resolveServiceListenPort()): string {
   const tokenFile = serviceApiTokenFilePath();
-  return `if [ -f ${shellQuote(tokenFile)} ]; then OPENCODEX_API_AUTH_TOKEN="$(cat ${shellQuote(tokenFile)})"; export OPENCODEX_API_AUTH_TOKEN; fi; exec ${shellQuote(bun)} ${shellQuote(cli)} start`;
+  return `if [ -f ${shellQuote(tokenFile)} ]; then OPENCODEX_API_AUTH_TOKEN="$(cat ${shellQuote(tokenFile)})"; export OPENCODEX_API_AUTH_TOKEN; fi; exec ${shellQuote(bun)} ${shellQuote(cli)} start --port ${port}`;
 }
 
 function systemdQuote(value: string): string {
@@ -316,7 +332,7 @@ function taskXmlString(value: string): string {
     .replace(/'/g, "&apos;");
 }
 
-export function buildWindowsServiceScript(entry = cliEntry()): string {
+export function buildWindowsServiceScript(entry = cliEntry(), port = resolveServiceListenPort()): string {
   const { bun, cli } = entry;
   const bunRuntime = durableBunRuntime();
   const path = process.env.PATH ?? "";
@@ -345,7 +361,7 @@ export function buildWindowsServiceScript(entry = cliEntry()): string {
     '>>"%OCX_SERVICE_LOG%" echo opencodex_home="%OPENCODEX_HOME%"',
     '>>"%OCX_SERVICE_LOG%" echo codex_home="%CODEX_HOME%"',
     '>>"%OCX_SERVICE_LOG%" echo token_file="%OCX_API_TOKEN_FILE%"',
-    '"%OCX_BUN%" "%OCX_CLI%" start >>"%OCX_SERVICE_LOG%" 2>&1',
+    `"%OCX_BUN%" "%OCX_CLI%" start --port ${port} >>"%OCX_SERVICE_LOG%" 2>&1`,
     "if %ERRORLEVEL% NEQ 0 (",
     '  >>"%OCX_SERVICE_LOG%" echo [%DATE% %TIME%] child exited with code %ERRORLEVEL%; restarting in 5s',
     // `timeout` needs console stdin and dies with "Input redirection is not supported"

--- a/src/update/index.ts
+++ b/src/update/index.ts
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { getConfigDir, readPid, readRuntimePort } from "../config";
+import { getConfigDir, loadConfig, readPid, readRuntimePort } from "../config";
 
 /**
  * A `codex-history-backup-*.json` surviving a stop means the native-history restore was
@@ -171,6 +171,14 @@ export async function runUpdate(): Promise<void> {
     serviceWasInstalled = isServiceInstalled();
   } catch { /* best-effort */ }
 
+  // Capture listen target before stop clears runtime state (same contract as GUI update worker).
+  const preUpdateRt = readRuntimePort();
+  const preUpdateConfig = loadConfig();
+  const capturedListen = {
+    port: preUpdateRt?.port ?? preUpdateConfig.port ?? 10100,
+    hostname: preUpdateRt?.hostname ?? preUpdateConfig.hostname ?? "127.0.0.1",
+  };
+
   // Never replace package files under a live proxy: the running server dynamic-imports
   // modules after startup, so an in-place update leaves it executing mixed old/new code.
   // Gate on the service and the runtime-port record too, not just the pid file — a
@@ -230,14 +238,27 @@ export async function runUpdate(): Promise<void> {
     if (serviceWasInstalled) {
       console.log("🔁 Reinstalling the background service with the updated files...");
       const { serviceReinstallArgs } = await import("../service");
-      const svcStdio = updateChildStdio();
-      const svc = spawnSync(process.execPath, [process.argv[1], ...serviceReinstallArgs()], {
-        stdio: svcStdio,
-        encoding: svcStdio === "pipe" ? "utf8" : undefined,
-        windowsHide: true,
+      const { waitForPortAvailable } = await import("../server/ports");
+      const freed = await waitForPortAvailable(capturedListen.port, capturedListen.hostname, {
+        timeoutMs: 5_000,
+        intervalMs: 25,
       });
-      if (svcStdio === "pipe") logSpawnOutput("", svc);
-      if (svc.status !== 0) console.warn("⚠️  Service refresh failed — run 'ocx service install' manually.");
+      if (!freed) console.warn(`⚠️  Port ${capturedListen.port} still busy; reinstalling with pinned --port anyway.`);
+      const prevBake = process.env.OCX_BAKE_PORT;
+      process.env.OCX_BAKE_PORT = String(capturedListen.port);
+      try {
+        const svcStdio = updateChildStdio();
+        const svc = spawnSync(process.execPath, [process.argv[1], ...serviceReinstallArgs()], {
+          stdio: svcStdio,
+          encoding: svcStdio === "pipe" ? "utf8" : undefined,
+          windowsHide: true,
+        });
+        if (svcStdio === "pipe") logSpawnOutput("", svc);
+        if (svc.status !== 0) console.warn("⚠️  Service refresh failed — run 'ocx service install' manually.");
+      } finally {
+        if (prevBake === undefined) delete process.env.OCX_BAKE_PORT;
+        else process.env.OCX_BAKE_PORT = prevBake;
+      }
     } else {
       console.log("Restart the proxy:  ocx start");
     }

--- a/src/update/index.ts
+++ b/src/update/index.ts
@@ -172,11 +172,17 @@ export async function runUpdate(): Promise<void> {
   } catch { /* best-effort */ }
 
   // Capture listen target before stop clears runtime state (same contract as GUI update worker).
-  const preUpdateRt = readRuntimePort();
+  // Prefer a live runtime record; a stale crashed leftover must not override config.port.
   const preUpdateConfig = loadConfig();
+  const preUpdateRt = readRuntimePort();
+  const livePid = readPid();
+  const runtimeTrusted = !!(preUpdateRt && livePid && preUpdateRt.pid === livePid);
+  const configPort = typeof preUpdateConfig.port === "number" && preUpdateConfig.port > 0
+    ? preUpdateConfig.port
+    : 10100;
   const capturedListen = {
-    port: preUpdateRt?.port ?? preUpdateConfig.port ?? 10100,
-    hostname: preUpdateRt?.hostname ?? preUpdateConfig.hostname ?? "127.0.0.1",
+    port: runtimeTrusted ? preUpdateRt.port : configPort,
+    hostname: (runtimeTrusted ? preUpdateRt.hostname : undefined) ?? preUpdateConfig.hostname ?? "127.0.0.1",
   };
 
   // Never replace package files under a live proxy: the running server dynamic-imports

--- a/src/update/job.ts
+++ b/src/update/job.ts
@@ -313,10 +313,25 @@ async function restartAfterUpdate(
     } catch { /* fallback to default service install */ }
   }
   const cmd = restartCommand(serviceInstalled, job.installer, packageLauncherPath(), port, svcArgs);
+  const waitFn = io.waitForPort ?? waitForPortAvailable;
+
   if (serviceInstalled) {
-    const result = runLoggedCommand(job, cmd.bin, cmd.args, RESTART_TIMEOUT_MS);
-    if (result.status !== 0) {
-      throw new Error(`service restart failed (${cmd.display}, exit ${result.status ?? "?"})`);
+    // Stop-first update already unloaded the service; wait for the socket to drain,
+    // then reinstall wrappers that bake `--port` via OCX_BAKE_PORT (PR #152 gap).
+    const freed = await waitFn(port, hostname, { timeoutMs: 5_000, intervalMs: 25 });
+    if (!freed) {
+      updateJob(job, {}, `Port ${port} still busy after stop; reinstalling service with pinned --port ${port} anyway.`);
+    }
+    const prevBake = process.env.OCX_BAKE_PORT;
+    process.env.OCX_BAKE_PORT = String(Math.trunc(port));
+    try {
+      const result = runLoggedCommand(job, cmd.bin, cmd.args, RESTART_TIMEOUT_MS);
+      if (result.status !== 0) {
+        throw new Error(`service restart failed (${cmd.display}, exit ${result.status ?? "?"})`);
+      }
+    } finally {
+      if (prevBake === undefined) delete process.env.OCX_BAKE_PORT;
+      else process.env.OCX_BAKE_PORT = prevBake;
     }
     return;
   }
@@ -329,8 +344,7 @@ async function restartAfterUpdate(
   // The old socket can stay busy briefly after stop (Windows taskkill drain, or the
   // stop-first update path that already killed the proxy before we got here) — wait
   // unconditionally on the captured port so the pinned start does not race the drain.
-  const waitFn = io.waitForPort ?? waitForPortAvailable;
-  const freed = await waitFn(port, hostname, { timeoutMs: 2000, intervalMs: 25 });
+  const freed = await waitFn(port, hostname, { timeoutMs: 2_000, intervalMs: 25 });
   if (!freed) {
     updateJob(job, {}, `Port ${port} still busy after stop; starting with --port ${port} anyway.`);
   }

--- a/src/update/job.ts
+++ b/src/update/job.ts
@@ -291,6 +291,12 @@ export interface RestartIo {
   waitForPort?: typeof waitForPortAvailable;
   spawnStart?: (job: UpdateJobState, installer: Installer, port?: number) => void;
   serviceInstalledFn?: () => boolean;
+  /** Service-mode install/reinstall command (defaults to spawnSync via runLoggedCommand). */
+  runService?: (
+    job: UpdateJobState,
+    bin: string,
+    args: string[],
+  ) => { status: number | null; signal?: NodeJS.Signals | null };
 }
 
 async function restartAfterUpdate(
@@ -325,7 +331,8 @@ async function restartAfterUpdate(
     const prevBake = process.env.OCX_BAKE_PORT;
     process.env.OCX_BAKE_PORT = String(Math.trunc(port));
     try {
-      const result = runLoggedCommand(job, cmd.bin, cmd.args, RESTART_TIMEOUT_MS);
+      const run = io.runService ?? ((j, bin, args) => runLoggedCommand(j, bin, args, RESTART_TIMEOUT_MS));
+      const result = run(job, cmd.bin, cmd.args);
       if (result.status !== 0) {
         throw new Error(`service restart failed (${cmd.display}, exit ${result.status ?? "?"})`);
       }

--- a/src/update/job.ts
+++ b/src/update/job.ts
@@ -373,11 +373,17 @@ export async function runGuiUpdateWorker(jobId: string, channel: Channel, restar
   const now = new Date().toISOString();
   // Capture the live listen target BEFORE the update command runs: the stop-first update
   // flow clears pid/runtime state, so this is the last moment the real port is knowable.
+  // Only trust runtime-port.json when its pid matches the live pidfile process.
   const rt = readRuntimePort();
+  const livePid = readPid();
   const preUpdateConfig = loadConfig();
+  const runtimeTrusted = !!(rt && livePid && rt.pid === livePid);
+  const configPort = typeof preUpdateConfig.port === "number" && preUpdateConfig.port > 0
+    ? preUpdateConfig.port
+    : 10100;
   const captured = {
-    port: rt?.port ?? preUpdateConfig.port ?? 10100,
-    hostname: rt?.hostname ?? preUpdateConfig.hostname ?? "127.0.0.1",
+    port: runtimeTrusted ? rt.port : configPort,
+    hostname: (runtimeTrusted ? rt.hostname : undefined) ?? preUpdateConfig.hostname ?? "127.0.0.1",
   };
   if (!job) {
     job = {

--- a/tests/ports.test.ts
+++ b/tests/ports.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createServer, type Server } from "node:net";
-import { findAvailablePort, isAddrInUse, isPortAvailable, shouldPersistSelectedPort, waitForPortAvailable } from "../src/server/ports";
+import { findAvailablePort, isAddrInUse, isPortAvailable, PortUnavailableError, shouldPersistSelectedPort, waitForPortAvailable } from "../src/server/ports";
 
 const servers: Server[] = [];
 
@@ -87,6 +87,18 @@ describe("port selection", () => {
     }, 60);
 
     expect(await pending).toBe(port);
+  });
+
+  test("refuses ephemeral hop when allowEphemeralFallback is false", async () => {
+    const { port } = await listen();
+    expect(await isPortAvailable(port)).toBe(false);
+    await expect(
+      findAvailablePort(port, "127.0.0.1", {
+        preferRetryMs: 80,
+        preferRetryIntervalMs: 20,
+        allowEphemeralFallback: false,
+      }),
+    ).rejects.toBeInstanceOf(PortUnavailableError);
   });
 
   test("isAddrInUse recognizes bind conflicts by code or message and rejects everything else", () => {

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { saveConfig } from "../src/config";
 import { windowsEnvIndirectBatchValue } from "../src/lib/win-paths";
-import { assertServiceAuthEnvironment, assertServiceEnvironmentMatchesInstall, bakedServicePathsDiagnostic, buildPlist, buildUnit, buildWindowsLauncherVbs, buildWindowsSchtasksCreateArgs, buildWindowsServiceScript, buildWindowsTaskXml, normalizeServiceSubcommand, serviceLogPath, serviceStatusSummary } from "../src/service";
+import { assertServiceAuthEnvironment, assertServiceEnvironmentMatchesInstall, bakedServicePathsDiagnostic, buildPlist, buildUnit, buildWindowsLauncherVbs, buildWindowsSchtasksCreateArgs, buildWindowsServiceScript, buildWindowsTaskXml, normalizeServiceSubcommand, resolveServiceListenPort, serviceLogPath, serviceStatusSummary } from "../src/service";
 import { serviceApiTokenFilePath } from "../src/lib/service-secrets";
 import type { OcxConfig } from "../src/types";
 
@@ -49,6 +49,35 @@ function pathVariants(path: string): string[] {
 function expectTextToContainPath(text: string, path: string): void {
   expect(pathVariants(path).some(candidate => text.includes(candidate))).toBe(true);
 }
+
+describe("service listen-port bake", () => {
+  test("resolveServiceListenPort prefers override, then OCX_BAKE_PORT, then config", () => {
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    mkdirSync(TEST_DIR, { recursive: true });
+    saveConfig({ port: 10100, hostname: "127.0.0.1", defaultProvider: "openai", providers: {} } as OcxConfig);
+    expect(resolveServiceListenPort(18765)).toBe(18765);
+    const prev = process.env.OCX_BAKE_PORT;
+    try {
+      process.env.OCX_BAKE_PORT = "15555";
+      expect(resolveServiceListenPort()).toBe(15555);
+      delete process.env.OCX_BAKE_PORT;
+      expect(resolveServiceListenPort()).toBe(10100);
+    } finally {
+      if (prev === undefined) delete process.env.OCX_BAKE_PORT;
+      else process.env.OCX_BAKE_PORT = prev;
+    }
+  });
+
+  test("Windows batch and launchd/systemd shell commands bake start --port", () => {
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    mkdirSync(TEST_DIR, { recursive: true });
+    saveConfig({ port: 13337, hostname: "127.0.0.1", defaultProvider: "openai", providers: {} } as OcxConfig);
+    const script = buildWindowsServiceScript({ bun: "C:\\OpenCodex\\bun.exe", cli: "C:\\OpenCodex\\cli.ts" });
+    expect(script).toContain("start --port 13337");
+    expect(buildPlist()).toContain("start --port 13337");
+    expect(buildUnit()).toContain("start --port 13337");
+  });
+});
 
 describe("systemd service unit", () => {
   test("bare service command defaults to the install/update/start path", async () => {
@@ -269,7 +298,7 @@ describe("Windows service task", () => {
 
     expect(script).toContain('set "OCX_BUN=C:\\Bun&Dir\\100%%bun^^\\bun.exe"');
     expect(script).toContain('set "OCX_CLI=C:\\OpenCodex&Dir\\cli.ts"');
-    expect(script).toContain('"%OCX_BUN%" "%OCX_CLI%" start');
+    expect(script).toContain('"%OCX_BUN%" "%OCX_CLI%" start --port');
     expect(script).not.toContain('"C:\\Bun&Dir\\100%bun^\\bun.exe"');
   });
 
@@ -326,7 +355,7 @@ describe("Windows service task", () => {
       expect(script).toContain('echo opencodex_home="%OPENCODEX_HOME%"');
       expect(script).toContain('echo codex_home="%CODEX_HOME%"');
       expect(script).toContain('echo token_file="%OCX_API_TOKEN_FILE%"');
-      expect(script).toContain('"%OCX_BUN%" "%OCX_CLI%" start >>"%OCX_SERVICE_LOG%" 2>&1');
+      expect(script).toMatch(/"%OCX_BUN%" "%OCX_CLI%" start --port \d+ >>"%OCX_SERVICE_LOG%" 2>&1/);
       expect(script).toContain("child exited with code %ERRORLEVEL%");
       expect(script).not.toContain("local-secret");
       expect(script).not.toContain('set "OPENCODEX_API_AUTH_TOKEN=');

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -62,6 +62,8 @@ describe("service listen-port bake", () => {
       expect(resolveServiceListenPort()).toBe(15555);
       delete process.env.OCX_BAKE_PORT;
       expect(resolveServiceListenPort()).toBe(10100);
+      saveConfig({ port: 0, hostname: "127.0.0.1", defaultProvider: "openai", providers: {} } as OcxConfig);
+      expect(resolveServiceListenPort()).toBe(10100);
     } finally {
       if (prev === undefined) delete process.env.OCX_BAKE_PORT;
       else process.env.OCX_BAKE_PORT = prev;

--- a/tests/update-job.test.ts
+++ b/tests/update-job.test.ts
@@ -104,7 +104,7 @@ describe("GUI update execution decisions", () => {
     expect(proxy.mode).toBe("proxy");
     expect(proxy.args).toEqual(["/pkg/bin/ocx.mjs", "start", "--port", "10100"]);
     expect(proxy.display).toContain("start --port 10100");
-    // Service reinstall keeps its own port contract — do not append --port.
+    // Service reinstall stays install-only at the argv level; wrappers bake --port via OCX_BAKE_PORT.
     expect(restartCommand(true, "npm", "/pkg/bin/ocx.mjs", 10100).args).toEqual([
       "/pkg/bin/ocx.mjs", "service", "install",
     ]);
@@ -141,6 +141,41 @@ describe("GUI update execution decisions", () => {
     });
     expect(waited).toEqual([{ port: 12345, hostname: "127.0.0.1" }]);
     expect(spawned).toEqual([{ port: 12345 }]);
+  });
+
+  test("service restart waits on the captured port and clears OCX_BAKE_PORT after install", async () => {
+    const waited: Array<{ port: number; hostname: string }> = [];
+    const job: UpdateJobState = {
+      id: "restart-svc",
+      status: "restarting",
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      currentVersion: "2.7.26",
+      latestVersion: "2.7.28",
+      channel: "latest",
+      installer: "npm",
+      restart: true,
+      command: "",
+      log: [],
+    };
+    writeFileSync(updateJobPath(job.id), JSON.stringify(job));
+    const prev = process.env.OCX_BAKE_PORT;
+    delete process.env.OCX_BAKE_PORT;
+    try {
+      await expect(restartAfterUpdateForTests(job, { port: 18765, hostname: "127.0.0.1" }, {
+        serviceInstalledFn: () => true,
+        waitForPort: async (port, hostname) => {
+          waited.push({ port, hostname: hostname ?? "" });
+          expect(process.env.OCX_BAKE_PORT).toBeUndefined();
+          return true;
+        },
+      })).rejects.toThrow(/service restart failed/);
+      expect(waited).toEqual([{ port: 18765, hostname: "127.0.0.1" }]);
+      expect(process.env.OCX_BAKE_PORT).toBeUndefined();
+    } finally {
+      if (prev === undefined) delete process.env.OCX_BAKE_PORT;
+      else process.env.OCX_BAKE_PORT = prev;
+    }
   });
 
   test("a running job prevents a second update job", () => {

--- a/tests/update-job.test.ts
+++ b/tests/update-job.test.ts
@@ -145,6 +145,7 @@ describe("GUI update execution decisions", () => {
 
   test("service restart waits on the captured port and clears OCX_BAKE_PORT after install", async () => {
     const waited: Array<{ port: number; hostname: string }> = [];
+    const bakeDuringInstall: string[] = [];
     const job: UpdateJobState = {
       id: "restart-svc",
       status: "restarting",
@@ -162,15 +163,20 @@ describe("GUI update execution decisions", () => {
     const prev = process.env.OCX_BAKE_PORT;
     delete process.env.OCX_BAKE_PORT;
     try {
-      await expect(restartAfterUpdateForTests(job, { port: 18765, hostname: "127.0.0.1" }, {
+      await restartAfterUpdateForTests(job, { port: 18765, hostname: "127.0.0.1" }, {
         serviceInstalledFn: () => true,
         waitForPort: async (port, hostname) => {
           waited.push({ port, hostname: hostname ?? "" });
           expect(process.env.OCX_BAKE_PORT).toBeUndefined();
           return true;
         },
-      })).rejects.toThrow(/service restart failed/);
+        runService: () => {
+          bakeDuringInstall.push(process.env.OCX_BAKE_PORT ?? "");
+          return { status: 0 };
+        },
+      });
       expect(waited).toEqual([{ port: 18765, hostname: "127.0.0.1" }]);
+      expect(bakeDuringInstall).toEqual(["18765"]);
       expect(process.env.OCX_BAKE_PORT).toBeUndefined();
     } finally {
       if (prev === undefined) delete process.env.OCX_BAKE_PORT;

--- a/tests/update-stop-first.test.ts
+++ b/tests/update-stop-first.test.ts
@@ -46,6 +46,11 @@ describe("update stops the running proxy before replacing files", () => {
     expect(launcherSource).toContain("serviceReinstallArgs");
     // The launcher reads the state path for both service-installed detection and backend choice.
     expect(launcherSource).toContain('"service-state.json"');
+    expect(updateSource).toContain("OCX_BAKE_PORT");
+    expect(launcherSource).toContain("OCX_BAKE_PORT");
+    // Live runtime port 10100 must not be discarded as a missing-port sentinel.
+    expect(launcherSource).toContain("sawRuntimePort");
+    expect(updateSource).toContain("runtimeTrusted");
   });
 
   test("both update paths surface a skipped history restore after the stop", () => {

--- a/tests/windows-deploy-close-regressions.test.ts
+++ b/tests/windows-deploy-close-regressions.test.ts
@@ -26,7 +26,9 @@ describe("update-job restart avoids the shell-less .cmd EINVAL (Windows, bun/sou
   test("service update restart bakes OCX_BAKE_PORT so wrappers hard-pin the captured port", () => {
     expect(src).toContain("OCX_BAKE_PORT");
     expect(src).toContain("reinstalling service with pinned --port");
+    expect(src).toContain("runtimeTrusted");
     expect(read("src/cli/index.ts")).toContain("allowEphemeralFallback: !hardPin");
+    expect(read("src/cli/index.ts")).toContain("Not opening the GUI");
     expect(read("src/server/ports.ts")).toContain("allowEphemeralFallback");
   });
 });

--- a/tests/windows-deploy-close-regressions.test.ts
+++ b/tests/windows-deploy-close-regressions.test.ts
@@ -23,6 +23,12 @@ describe("update-job restart avoids the shell-less .cmd EINVAL (Windows, bun/sou
     expect(src).toContain('? [launcher, "start", "--port", String(Math.trunc(port))]');
     expect(src).toContain(': [launcher, "start"]');
   });
+  test("service update restart bakes OCX_BAKE_PORT so wrappers hard-pin the captured port", () => {
+    expect(src).toContain("OCX_BAKE_PORT");
+    expect(src).toContain("reinstalling service with pinned --port");
+    expect(read("src/cli/index.ts")).toContain("allowEphemeralFallback: !hardPin");
+    expect(read("src/server/ports.ts")).toContain("allowEphemeralFallback");
+  });
 });
 
 describe("systemd detection tolerates a no-DBUS SSH session (F9)", () => {

--- a/tests/winsw.test.ts
+++ b/tests/winsw.test.ts
@@ -38,11 +38,15 @@ describe("winsw xml", () => {
     const xml = buildWinswXml(entry, env);
 
     expect(xml).toContain("<executable>C:\\OpenCodex\\bun.exe</executable>");
-    expect(xml).toContain("<arguments>&quot;C:\\Open Codex\\cli &amp; co\\index.ts&quot; start</arguments>");
+    expect(xml).toContain("<arguments>&quot;C:\\Open Codex\\cli &amp; co\\index.ts&quot; start --port 10100</arguments>");
     expect(xml).toContain('<onfailure action="restart" delay="5 sec"/>');
     expect(xml).toContain("<stoptimeout>20 sec</stoptimeout>");
     expect(xml).toContain('<log mode="roll-by-size">');
     expect(xml).toContain(`<id>${WINSW_SERVICE_ID}</id>`);
+  });
+  test("honors OCX_BAKE_PORT when building WinSW arguments", () => {
+    const xml = buildWinswXml(entry, { ...env, OCX_BAKE_PORT: "14444" });
+    expect(xml).toContain("start --port 14444");
   });
 });
 


### PR DESCRIPTION
## Summary
- Follow-up to [#152](https://github.com/lidge-jun/opencodex/pull/152) / absorb `2435836`: that fix pinned non-service GUI restart with `--port`, but **did not stop port hops** on real updates (especially 2.7.26 → 2.7.28) when a service was installed or when the preferred port stayed busy past the short prefer-retry window.
- **Hard-pin when `--port` is explicit**: longer prefer-retry, `allowEphemeralFallback: false`, and same-port bind retries — never allocate an ephemeral listener.
- **Bake `--port` into every service start path** (Windows batch, WinSW XML, launchd, systemd) from `config.port` / `OCX_BAKE_PORT`.
- **Service update restart** now waits on the captured pre-update port and sets `OCX_BAKE_PORT` before reinstall (GUI worker, `ocx update`, and npm `bin/ocx.mjs`).
- Detached ensure/gui/claude starts also pass `--port` from config.

## Why #152 was not enough
1. Service wrappers still ran `ocx start` with no `--port`.
2. Service update reinstall did not wait for the old socket to free.
3. Even `start --port N` could still fall back to an ephemeral port after ~750ms.

## Test plan
- [ ] `bun test tests/ports.test.ts tests/update-job.test.ts tests/service.test.ts tests/winsw.test.ts tests/windows-deploy-close-regressions.test.ts tests/update-stop-first.test.ts`
- [ ] Non-service: GUI update → Restart after update → stays on configured port
- [ ] Service (`ocx service install`): update → reinstall → wrapper contains `start --port <captured>` and proxy stays on that port
- [ ] Force a busy preferred port with explicit `--port` → start fails closed (no ephemeral hop)