### PR TITLE
fix(codex): rebind sticky pool threads after connect/transient failures

### DIFF
--- a/src/codex/routing.ts
+++ b/src/codex/routing.ts
@@ -27,12 +27,21 @@ type CodexUpstreamHealth = {
   consecutiveFailures: number;
   lastFailureStatus?: number;
   lastFailureAt?: number;
+  /** Hard cooldown (quota 429). Survives a later 2xx; blocks auth + selection. */
   cooldownUntil?: number;
+  /**
+   * Soft avoid after connect_error / timeout / transient 5xx. Cleared on 2xx.
+   * Blocks pool selection + thread affinity reuse so a sticky session can leave a
+   * flaky account without throwing CodexAccountCooldownError (hard-only).
+   */
+  softAvoidUntil?: number;
 };
 
 const CODEX_DEFAULT_QUOTA_COOLDOWN_MS = 60_000;
 const CODEX_MAX_QUOTA_COOLDOWN_MS = 24 * 60 * 60_000;
 export const CODEX_FAILURE_WINDOW_MS = 5 * 60_000;
+/** How long a transient failure keeps the account out of pool selection. */
+export const CODEX_TRANSIENT_SOFT_AVOID_MS = 30_000;
 export const CODEX_THREAD_AFFINITY_IDLE_TTL_MS = 24 * 60 * 60_000;
 export const CODEX_THREAD_AFFINITY_MAX_ENTRIES = 2048;
 // Min interval between quota threshold re-evaluations for a single bound thread.
@@ -47,6 +56,8 @@ export type CodexUpstreamOutcomeMeta = {
   retryAfter?: string | null;
   resetAt?: unknown | unknown[];
   now?: number;
+  /** When set, clears affinity for this thread immediately on transient failure. */
+  threadId?: string | null;
 };
 
 function hasConfiguredPoolAccount(config: OcxConfig, accountId: string): boolean {
@@ -162,8 +173,21 @@ export function isCodexAccountInCooldown(accountId: string, now = Date.now()): b
   return getCodexAccountCooldownUntil(accountId, now) !== null;
 }
 
+export function getCodexAccountSoftAvoidUntil(accountId: string, now = Date.now()): number | null {
+  const softAvoidUntil = upstreamHealth.get(accountId)?.softAvoidUntil;
+  return typeof softAvoidUntil === "number" && Number.isFinite(softAvoidUntil) && softAvoidUntil > now
+    ? softAvoidUntil
+    : null;
+}
+
+export function isCodexAccountSoftAvoided(accountId: string, now = Date.now()): boolean {
+  return getCodexAccountSoftAvoidUntil(accountId, now) !== null;
+}
+
 function isCodexAccountSelectable(config: OcxConfig, accountId: string, now: number): boolean {
-  return !isCodexAccountInCooldown(accountId, now) && isCodexAccountUsable(config, accountId);
+  return !isCodexAccountInCooldown(accountId, now)
+    && !isCodexAccountSoftAvoided(accountId, now)
+    && isCodexAccountUsable(config, accountId);
 }
 
 function isThreadAffinityExpired(entry: ThreadAffinityEntry, now: number): boolean {
@@ -215,6 +239,7 @@ function getEligiblePoolAccounts(config: OcxConfig, excludeId?: string, now = Da
   const ids = (config.codexAccounts ?? [])
     .filter(account => !account.isMain && account.id !== excludeId && !isAccountNeedsReauth(account.id))
     .filter(account => !isCodexAccountInCooldown(account.id, now))
+    .filter(account => !isCodexAccountSoftAvoided(account.id, now))
     .filter(account => isCodexAccountUsable(config, account.id))
     .map(account => account.id);
   // The main Codex account is not stored in config.codexAccounts; include it as a
@@ -223,6 +248,7 @@ function getEligiblePoolAccounts(config: OcxConfig, excludeId?: string, now = Da
     excludeId !== MAIN_CODEX_ACCOUNT_ID
     && !isAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID)
     && !isCodexAccountInCooldown(MAIN_CODEX_ACCOUNT_ID, now)
+    && !isCodexAccountSoftAvoided(MAIN_CODEX_ACCOUNT_ID, now)
     && isCodexAccountUsable(config, MAIN_CODEX_ACCOUNT_ID)
   ) {
     ids.unshift(MAIN_CODEX_ACCOUNT_ID);
@@ -352,6 +378,9 @@ export function resolveCodexAccountForThreadDetailed(
     if (
       isThreadAffinityGenerationLive(entry)
       && isCodexAccountSelectable(config, entry.accountId, now)
+      // Affined threads must leave a failing account once the streak trips failover
+      // (soft-avoid covers the first-hit case; this catches post-avoid residual streaks).
+      && !shouldFailover(config, entry.accountId, now)
     ) {
       entry.lastUsedAt = now;
       // Periodic quota re-eval: a long-lived bound thread must still switch when
@@ -420,6 +449,7 @@ export function recordCodexUpstreamOutcome(
   const now = meta.now ?? Date.now();
   const outcomeClass = classifyCodexUpstreamOutcome(outcome);
   if (outcomeClass === "success") {
+    // Soft avoid clears on success; hard quota cooldown intentionally survives.
     const cooldownUntil = getCodexAccountCooldownUntil(accountId, now);
     if (cooldownUntil) upstreamHealth.set(accountId, { consecutiveFailures: 0, cooldownUntil });
     else upstreamHealth.delete(accountId);
@@ -454,15 +484,34 @@ export function recordCodexUpstreamOutcome(
     return;
   }
 
+  // transient (connect_error / timeout / 5xx)
   const current = upstreamHealth.get(accountId);
   const stale = current?.lastFailureAt ? now - current.lastFailureAt > CODEX_FAILURE_WINDOW_MS : false;
-  const cooldownUntil = getCodexAccountCooldownUntil(accountId, now) ?? undefined;
+  const hardCooldownUntil = getCodexAccountCooldownUntil(accountId, now) ?? undefined;
+  // Soft avoid + affinity clears are part of failover. When threshold is 0, leave
+  // sticky sessions alone (same as shouldFailover / applyFailureFailover no-ops).
+  const failoverEnabled = (config.upstreamFailoverThreshold ?? 3) > 0;
+  const softAvoidUntil = failoverEnabled
+    ? Math.max(
+      getCodexAccountSoftAvoidUntil(accountId, now) ?? 0,
+      now + CODEX_TRANSIENT_SOFT_AVOID_MS,
+    )
+    : undefined;
   upstreamHealth.set(accountId, {
     consecutiveFailures: stale ? 1 : (current?.consecutiveFailures ?? 0) + 1,
     lastFailureStatus,
     lastFailureAt: now,
-    ...(cooldownUntil ? { cooldownUntil } : {}),
+    ...(hardCooldownUntil ? { cooldownUntil: hardCooldownUntil } : {}),
+    ...(softAvoidUntil !== undefined ? { softAvoidUntil } : {}),
   });
+  // Drop this thread's pin immediately so the next continue can rebind without
+  // waiting for the soft-avoid selectable check (same request path may not re-resolve).
+  if (failoverEnabled && meta.threadId) threadAccountMap.delete(meta.threadId);
+  // Once the account is past the failover streak, clear every thread still pinned
+  // to it — matching 429 affinity behavior so "continue" cannot stay on a bad peer.
+  if (shouldFailover(config, accountId, now)) {
+    clearThreadAccountMapForAccount(accountId);
+  }
   if (config.activeCodexAccountId === accountId) applyFailureFailover(config, accountId, now);
 }
 

--- a/src/lib/upstream-retry.ts
+++ b/src/lib/upstream-retry.ts
@@ -149,6 +149,21 @@ export type UpstreamSendRecovery = "connection-reset" | "transient-5xx";
 type ReplayableFetch = (recovery?: UpstreamSendRecovery) => Promise<Response>;
 
 /**
+ * On connection-reset retries, force Connection: close so Bun does not reuse the
+ * same half-closed keep-alive socket that just failed (chatgpt.com/Cloudflare).
+ */
+export function applyUpstreamRecoveryHeaders(
+  headers: HeadersInit | undefined,
+  recovery?: UpstreamSendRecovery,
+): Headers {
+  const next = new Headers(headers);
+  if (recovery === "connection-reset") {
+    next.set("connection", "close");
+  }
+  return next;
+}
+
+/**
  * Run `doFetch`, retrying only connection-reset-shaped rejections (see
  * isConnectionResetError) with jittered backoff. The caller's thunk must be replay-safe
  * (string body); every retry is logged so persistent resets stay visible.

--- a/src/lib/upstream-retry.ts
+++ b/src/lib/upstream-retry.ts
@@ -149,18 +149,32 @@ export type UpstreamSendRecovery = "connection-reset" | "transient-5xx";
 type ReplayableFetch = (recovery?: UpstreamSendRecovery) => Promise<Response>;
 
 /**
- * On connection-reset retries, force Connection: close so Bun does not reuse the
- * same half-closed keep-alive socket that just failed (chatgpt.com/Cloudflare).
+ * Opt out of Bun's keep-alive pool after a connection-reset retry.
+ *
+ * Prefer the Bun fetch extension `keepalive: false` (transport-level) over
+ * relying on the hop-by-hop `Connection: close` header alone — Bun has ignored
+ * that header in past releases (oven-sh/bun#20492), so a header-only retry can
+ * still reuse the same half-closed pooled socket. Still set Connection: close
+ * as a belt-and-suspenders signal for intermediaries that honor it.
  */
+export function applyUpstreamRecoveryInit<T extends RequestInit>(
+  init: T,
+  recovery?: UpstreamSendRecovery,
+): T & { headers: Headers } {
+  const headers = new Headers(init.headers);
+  if (recovery !== "connection-reset") {
+    return { ...init, headers };
+  }
+  headers.set("connection", "close");
+  return { ...init, headers, keepalive: false };
+}
+
+/** @deprecated Prefer {@link applyUpstreamRecoveryInit} so keepalive:false is applied. */
 export function applyUpstreamRecoveryHeaders(
   headers: HeadersInit | undefined,
   recovery?: UpstreamSendRecovery,
 ): Headers {
-  const next = new Headers(headers);
-  if (recovery === "connection-reset") {
-    next.set("connection", "close");
-  }
-  return next;
+  return applyUpstreamRecoveryInit({ headers }, recovery).headers;
 }
 
 /**

--- a/src/providers/openai-sidecar.ts
+++ b/src/providers/openai-sidecar.ts
@@ -68,7 +68,14 @@ export async function resolveFirstUsableOpenAiSidecar(
       authContext,
       headers: headersForCodexAuthContext(incomingHeaders, authContext),
       ...(authContext.kind === "pool" || authContext.kind === "main-pool"
-        ? { recordOutcome: (outcome: CodexUpstreamOutcome) => recordCodexUpstreamOutcome(config, authContext.accountId, outcome) }
+        ? {
+          recordOutcome: (outcome: CodexUpstreamOutcome) => recordCodexUpstreamOutcome(
+            config,
+            authContext.accountId,
+            outcome,
+            { threadId: incomingHeaders.get("x-codex-parent-thread-id") },
+          ),
+        }
         : {}),
     };
   }

--- a/src/server/responses.ts
+++ b/src/server/responses.ts
@@ -55,7 +55,7 @@ import {
   recordCodexUpstreamOutcome,
   type CodexUpstreamOutcome,
 } from "../codex/routing";
-import { fetchWithResetRetry, fetchWithTransientRetry } from "../lib/upstream-retry";
+import { fetchWithResetRetry, fetchWithTransientRetry, applyUpstreamRecoveryHeaders } from "../lib/upstream-retry";
 import { ForwardAdmissionCredentialError, validateForwardAdmissionCredential } from "./auth-cors";
 import { listOpenAiForwardSidecarCandidates, resolveFirstUsableOpenAiSidecar, type ResolvedOpenAiForwardSidecar } from "../providers/openai-sidecar";
 import { applyOpenAiVirtualModel, resolveOpenAiCompactModel } from "../providers/openai-virtual-models";
@@ -395,9 +395,13 @@ export function sanitizeEncryptedContentInPlace(input: unknown): number {
   return rewritten;
 }
 
-export function sidecarOutcomeRecorder(config: OcxConfig, authCtx: CodexAuthContext): ((outcome: CodexUpstreamOutcome) => void) | undefined {
+export function sidecarOutcomeRecorder(
+  config: OcxConfig,
+  authCtx: CodexAuthContext,
+  threadId?: string | null,
+): ((outcome: CodexUpstreamOutcome) => void) | undefined {
   return authCtx.kind === "pool" || authCtx.kind === "main-pool"
-    ? outcome => recordCodexUpstreamOutcome(config, authCtx.accountId, outcome)
+    ? outcome => recordCodexUpstreamOutcome(config, authCtx.accountId, outcome, { threadId })
     : undefined;
 }
 
@@ -418,9 +422,15 @@ export function codexForwardTerminalOutcomeRecorder(
   config: OcxConfig,
   authCtx: CodexAuthContext,
   provider: OcxProviderConfig,
+  threadId?: string | null,
 ): ((status: ResponsesTerminalStatus) => void) | undefined {
   if (!usesCodexForwardPoolAuth(authCtx, provider)) return undefined;
-  return status => recordCodexUpstreamOutcome(config, authCtx.accountId, status === "completed" ? 200 : 502);
+  return status => recordCodexUpstreamOutcome(
+    config,
+    authCtx.accountId,
+    status === "completed" ? 200 : 502,
+    { threadId },
+  );
 }
 
 /**
@@ -1094,7 +1104,7 @@ export async function handleResponses(
           noteAttemptSend(logCtx.activeAttempt, passthroughEstimate, recovery);
           return fetchWithHeaderTimeout(request.url, {
             method: request.method,
-            headers: request.headers,
+            headers: applyUpstreamRecoveryHeaders(request.headers, recovery),
             body: request.body,
           }, upstream.signal, connectMs, parsed.stream, providerFetch(route.provider));
         },
@@ -1104,7 +1114,11 @@ export async function handleResponses(
       upstream.abort();
       if (options.abortSignal?.aborted) return clientCancelledResponse();
       const outcome = err instanceof Error && err.name === "TimeoutError" ? "timeout" : "connect_error";
-      if (usesCodexForwardPoolAuth(authCtx, route.provider)) recordCodexUpstreamOutcome(config, authCtx.accountId, outcome);
+      if (usesCodexForwardPoolAuth(authCtx, route.provider)) {
+        recordCodexUpstreamOutcome(config, authCtx.accountId, outcome, {
+          threadId: req.headers.get("x-codex-parent-thread-id"),
+        });
+      }
       const msg = outcome === "timeout"
         ? `Provider connect timeout after ${connectMs}ms`
         : `Provider unreachable: ${err instanceof Error ? err.message : String(err)}`;
@@ -1122,7 +1136,12 @@ export async function handleResponses(
     const passthroughCt = headers.get("content-type")?.toLowerCase();
     const isEventStream = passthroughCt?.includes("text/event-stream")
       || (upstreamResponse.ok && !!upstreamResponse.body && !passthroughCt && parsed.stream);
-    const terminalRecorder = codexForwardTerminalOutcomeRecorder(config, authCtx, route.provider);
+    const terminalRecorder = codexForwardTerminalOutcomeRecorder(
+      config,
+      authCtx,
+      route.provider,
+      req.headers.get("x-codex-parent-thread-id"),
+    );
     const terminalBodyWillRecord = !!terminalRecorder && upstreamResponse.ok && isEventStream;
     // Capture quota from upstream response for multi-account tracking
    if (usesCodexForwardPoolAuth(authCtx, route.provider)) {
@@ -1156,6 +1175,7 @@ export async function handleResponses(
         recordCodexUpstreamOutcome(config, authCtx.accountId, upstreamResponse.status, {
         retryAfter: retryAfterRaw,
          resetAt: [primaryResetRaw, secondaryResetRaw, monthlyResetRaw].filter(Boolean),
+         threadId: req.headers.get("x-codex-parent-thread-id"),
         });
       }
     }
@@ -1391,7 +1411,9 @@ export async function handleResponses(
         recovery => {
           noteAttemptSend(logCtx.activeAttempt, inputTokenEstimate, recovery);
           return fetchWithHeaderTimeout(request.url, {
-            method: request.method, headers: request.headers, body: request.body,
+            method: request.method,
+            headers: applyUpstreamRecoveryHeaders(request.headers, recovery),
+            body: request.body,
           }, upstream.signal, connectMs, parsed.stream, providerFetch(route.provider));
         },
         { abortSignal: upstream.signal, label: safeHostLabel(request.url) },

--- a/src/server/responses.ts
+++ b/src/server/responses.ts
@@ -55,7 +55,7 @@ import {
   recordCodexUpstreamOutcome,
   type CodexUpstreamOutcome,
 } from "../codex/routing";
-import { fetchWithResetRetry, fetchWithTransientRetry, applyUpstreamRecoveryHeaders } from "../lib/upstream-retry";
+import { fetchWithResetRetry, fetchWithTransientRetry, applyUpstreamRecoveryInit } from "../lib/upstream-retry";
 import { ForwardAdmissionCredentialError, validateForwardAdmissionCredential } from "./auth-cors";
 import { listOpenAiForwardSidecarCandidates, resolveFirstUsableOpenAiSidecar, type ResolvedOpenAiForwardSidecar } from "../providers/openai-sidecar";
 import { applyOpenAiVirtualModel, resolveOpenAiCompactModel } from "../providers/openai-virtual-models";
@@ -1102,11 +1102,11 @@ export async function handleResponses(
       upstreamResponse = await fetchWithTransientRetry(
         recovery => {
           noteAttemptSend(logCtx.activeAttempt, passthroughEstimate, recovery);
-          return fetchWithHeaderTimeout(request.url, {
+          return fetchWithHeaderTimeout(request.url, applyUpstreamRecoveryInit({
             method: request.method,
-            headers: applyUpstreamRecoveryHeaders(request.headers, recovery),
+            headers: request.headers,
             body: request.body,
-          }, upstream.signal, connectMs, parsed.stream, providerFetch(route.provider));
+          }, recovery), upstream.signal, connectMs, parsed.stream, providerFetch(route.provider));
         },
         { abortSignal: upstream.signal, label: safeHostLabel(request.url) },
       );
@@ -1410,11 +1410,11 @@ export async function handleResponses(
       upstreamResponse = await fetchWithResetRetry(
         recovery => {
           noteAttemptSend(logCtx.activeAttempt, inputTokenEstimate, recovery);
-          return fetchWithHeaderTimeout(request.url, {
+          return fetchWithHeaderTimeout(request.url, applyUpstreamRecoveryInit({
             method: request.method,
-            headers: applyUpstreamRecoveryHeaders(request.headers, recovery),
+            headers: request.headers,
             body: request.body,
-          }, upstream.signal, connectMs, parsed.stream, providerFetch(route.provider));
+          }, recovery), upstream.signal, connectMs, parsed.stream, providerFetch(route.provider));
         },
         { abortSignal: upstream.signal, label: safeHostLabel(request.url) },
       );
@@ -1784,11 +1784,11 @@ export async function handleResponsesCompact(
       upstream = await fetchWithTransientRetry(
         recovery => fetchWithHeaderTimeout(
           compactUrl,
-          {
+          applyUpstreamRecoveryInit({
             method: "POST",
-            headers: applyUpstreamRecoveryHeaders(headers, recovery),
+            headers,
             body: JSON.stringify({ ...compactBody, model: route.modelId }),
-          },
+          }, recovery),
           req.signal,
           connectMs,
           false,

--- a/src/server/responses.ts
+++ b/src/server/responses.ts
@@ -1732,10 +1732,11 @@ export async function handleResponsesCompact(
     // headers would run compaction on the wrong account (or 401) whenever a pool account is
     // active for this thread while normal turns succeed.
     let compactProvider = route.provider;
+    let authCtx: CodexAuthContext = { kind: "main", accountId: null };
     const headers = new Headers({ "content-type": "application/json" });
     try {
       if (route.codexAccountMode) {
-        const authCtx = await resolveCodexAuthContext(req.headers, config, route.codexAccountMode);
+        authCtx = await resolveCodexAuthContext(req.headers, config, route.codexAccountMode);
         const selected = headersForCodexAuthContext(req.headers, authCtx);
         compactProvider = applyCodexAuthContextToProvider(route.provider, authCtx, route.codexAccountMode);
         for (const name of FORWARD_HEADERS) {
@@ -1766,19 +1767,54 @@ export async function handleResponsesCompact(
     const base = (compactProvider.baseUrl ?? "").replace(/\/$/, "");
     if (compactProvider.apiKey) headers.set("authorization", `Bearer ${resolveEnvValue(compactProvider.apiKey)}`);
     const { reasoning: _reasoning, ...compactBody } = raw as typeof raw & { reasoning?: unknown };
+    const compactUrl = `${base}/responses/compact`;
+    const compactThreadId = req.headers.get("x-codex-parent-thread-id");
+    const connectMs = config.connectTimeoutMs ?? 200_000;
+    const recordCompactPoolOutcome = (outcome: CodexUpstreamOutcome, meta: { retryAfter?: string | null } = {}) => {
+      if (!usesCodexForwardPoolAuth(authCtx, route.provider)) return;
+      recordCodexUpstreamOutcome(config, authCtx.accountId, outcome, {
+        ...meta,
+        threadId: compactThreadId,
+      });
+    };
     let upstream: Response;
     try {
-      upstream = await fetch(`${base}/responses/compact`, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({ ...compactBody, model: route.modelId }),
-        signal: req.signal,
-      });
-    } catch {
+      // Same connect timeout + keep-alive reset + transient-5xx recovery as /v1/responses —
+      // compact hits the same ChatGPT host and must soft-avoid / clear affinity (#186).
+      upstream = await fetchWithTransientRetry(
+        recovery => fetchWithHeaderTimeout(
+          compactUrl,
+          {
+            method: "POST",
+            headers: applyUpstreamRecoveryHeaders(headers, recovery),
+            body: JSON.stringify({ ...compactBody, model: route.modelId }),
+          },
+          req.signal,
+          connectMs,
+          false,
+          providerFetch(compactProvider),
+        ),
+        { abortSignal: req.signal, label: safeHostLabel(compactUrl) },
+      );
+    } catch (err) {
       if (req.signal.aborted) return formatErrorResponse(499, "client_cancelled", "Client cancelled compact request");
+      const outcome = err instanceof Error && err.name === "TimeoutError" ? "timeout" : "connect_error";
+      recordCompactPoolOutcome(outcome);
       return formatErrorResponse(502, "upstream_error", "Failed to connect to compact upstream");
     }
-    return bufferCompactResponse(upstream, req.signal);
+    const retryAfter = upstream.headers.get("retry-after");
+    const buffered = await bufferCompactResponse(upstream, req.signal);
+    // Record pool health only after the body is fully delivered (or definitively failed).
+    // A premature 200 would clear soft-avoid while the client still sees a buffer 502.
+    if (buffered.status === 499) {
+      return buffered;
+    }
+    if (upstream.ok && buffered.status >= 500) {
+      recordCompactPoolOutcome("connect_error");
+    } else {
+      recordCompactPoolOutcome(upstream.status, { retryAfter });
+    }
+    return buffered;
   }
 
   // ROUTED model: run the v2 synthetic-compaction turn internally (appends COMPACT_PROMPT, no

--- a/src/vision/anthropic-describe.ts
+++ b/src/vision/anthropic-describe.ts
@@ -2,7 +2,7 @@ import type { OcxProviderConfig } from "../types";
 import { CLAUDE_CODE_HEADERS, claudeCodeSessionId } from "../adapters/client-fingerprint";
 import { signalWithTimeout, cancelBodyOnAbort } from "../lib/abort";
 import { sidecarEnter } from "../lib/sidecar-tracker";
-import { fetchWithResetRetry } from "../lib/upstream-retry";
+import { fetchWithResetRetry, applyUpstreamRecoveryHeaders } from "../lib/upstream-retry";
 import { getValidAccessToken } from "../oauth";
 import { ANTHROPIC_OAUTH_BETA, CLAUDE_CODE_SYSTEM_INSTRUCTION } from "../oauth/anthropic";
 import type { DescribeOutcome, VisionSettings } from "./describe";
@@ -155,9 +155,9 @@ export async function describeImageAnthropic(
   const startedAt = Date.now();
   try {
     const res = await fetchWithResetRetry(
-      () => fetch(`${base}/v1/messages`, {
+      recovery => fetch(`${base}/v1/messages`, {
         method: "POST",
-        headers,
+        headers: applyUpstreamRecoveryHeaders(headers, recovery),
         body: JSON.stringify(body),
         signal: linkedSignal.signal,
       }),

--- a/src/vision/anthropic-describe.ts
+++ b/src/vision/anthropic-describe.ts
@@ -2,7 +2,7 @@ import type { OcxProviderConfig } from "../types";
 import { CLAUDE_CODE_HEADERS, claudeCodeSessionId } from "../adapters/client-fingerprint";
 import { signalWithTimeout, cancelBodyOnAbort } from "../lib/abort";
 import { sidecarEnter } from "../lib/sidecar-tracker";
-import { fetchWithResetRetry, applyUpstreamRecoveryHeaders } from "../lib/upstream-retry";
+import { fetchWithResetRetry, applyUpstreamRecoveryInit } from "../lib/upstream-retry";
 import { getValidAccessToken } from "../oauth";
 import { ANTHROPIC_OAUTH_BETA, CLAUDE_CODE_SYSTEM_INSTRUCTION } from "../oauth/anthropic";
 import type { DescribeOutcome, VisionSettings } from "./describe";
@@ -155,12 +155,12 @@ export async function describeImageAnthropic(
   const startedAt = Date.now();
   try {
     const res = await fetchWithResetRetry(
-      recovery => fetch(`${base}/v1/messages`, {
+      recovery => fetch(`${base}/v1/messages`, applyUpstreamRecoveryInit({
         method: "POST",
-        headers: applyUpstreamRecoveryHeaders(headers, recovery),
+        headers,
         body: JSON.stringify(body),
         signal: linkedSignal.signal,
-      }),
+      }, recovery)),
       { abortSignal: linkedSignal.signal, label: "vision-sidecar-anthropic" },
     );
     if (!res.ok) {

--- a/src/vision/describe.ts
+++ b/src/vision/describe.ts
@@ -2,7 +2,7 @@ import type { OcxProviderConfig } from "../types";
 import { FORWARD_HEADERS } from "../adapters/openai-responses";
 import { signalWithTimeout, cancelBodyOnAbort } from "../lib/abort";
 import { sidecarEnter } from "../lib/sidecar-tracker";
-import { fetchWithResetRetry } from "../lib/upstream-retry";
+import { fetchWithResetRetry, applyUpstreamRecoveryHeaders } from "../lib/upstream-retry";
 import { parseSidecarSSE } from "../web-search/parse";
 import type { SidecarOutcomeRecorder } from "../web-search/executor";
 
@@ -87,9 +87,9 @@ export async function describeImage(
   const t0 = Date.now();
   try {
     const res = await fetchWithResetRetry(
-      () => fetch(`${forwardProvider.baseUrl}/responses`, {
+      recovery => fetch(`${forwardProvider.baseUrl}/responses`, {
         method: "POST",
-        headers,
+        headers: applyUpstreamRecoveryHeaders(headers, recovery),
         body: JSON.stringify(body),
         signal: linkedSignal.signal,
       }),

--- a/src/vision/describe.ts
+++ b/src/vision/describe.ts
@@ -2,7 +2,7 @@ import type { OcxProviderConfig } from "../types";
 import { FORWARD_HEADERS } from "../adapters/openai-responses";
 import { signalWithTimeout, cancelBodyOnAbort } from "../lib/abort";
 import { sidecarEnter } from "../lib/sidecar-tracker";
-import { fetchWithResetRetry, applyUpstreamRecoveryHeaders } from "../lib/upstream-retry";
+import { fetchWithResetRetry, applyUpstreamRecoveryInit } from "../lib/upstream-retry";
 import { parseSidecarSSE } from "../web-search/parse";
 import type { SidecarOutcomeRecorder } from "../web-search/executor";
 
@@ -87,12 +87,12 @@ export async function describeImage(
   const t0 = Date.now();
   try {
     const res = await fetchWithResetRetry(
-      recovery => fetch(`${forwardProvider.baseUrl}/responses`, {
+      recovery => fetch(`${forwardProvider.baseUrl}/responses`, applyUpstreamRecoveryInit({
         method: "POST",
-        headers: applyUpstreamRecoveryHeaders(headers, recovery),
+        headers,
         body: JSON.stringify(body),
         signal: linkedSignal.signal,
-      }),
+      }, recovery)),
       { abortSignal: linkedSignal.signal, label: "vision-sidecar" },
     );
     recordOutcome?.(res.status);

--- a/src/web-search/anthropic-executor.ts
+++ b/src/web-search/anthropic-executor.ts
@@ -4,7 +4,7 @@ import { ANTHROPIC_OAUTH_BETA, CLAUDE_CODE_SYSTEM_INSTRUCTION } from "../oauth/a
 import { CLAUDE_CODE_HEADERS, claudeCodeSessionId } from "../adapters/client-fingerprint";
 import { signalWithTimeout, cancelBodyOnAbort } from "../lib/abort";
 import { sidecarEnter } from "../lib/sidecar-tracker";
-import { fetchWithResetRetry } from "../lib/upstream-retry";
+import { fetchWithResetRetry, applyUpstreamRecoveryHeaders } from "../lib/upstream-retry";
 import type { WebSearchSource } from "./parse";
 import { BASE_INSTRUCTION, IMAGE_INSTRUCTION, type SidecarOutcome, type SidecarSettings } from "./executor";
 
@@ -162,7 +162,12 @@ export async function runAnthropicWebSearch(
   const t0 = Date.now();
   try {
     const res = await fetchWithResetRetry(
-      () => fetch(url, { method: "POST", headers, body: JSON.stringify(body), signal: linkedSignal.signal }),
+      recovery => fetch(url, {
+        method: "POST",
+        headers: applyUpstreamRecoveryHeaders(headers, recovery),
+        body: JSON.stringify(body),
+        signal: linkedSignal.signal,
+      }),
       { abortSignal: linkedSignal.signal, label: "web-search-sidecar-anthropic" },
     );
     if (!res.ok) {

--- a/src/web-search/anthropic-executor.ts
+++ b/src/web-search/anthropic-executor.ts
@@ -4,7 +4,7 @@ import { ANTHROPIC_OAUTH_BETA, CLAUDE_CODE_SYSTEM_INSTRUCTION } from "../oauth/a
 import { CLAUDE_CODE_HEADERS, claudeCodeSessionId } from "../adapters/client-fingerprint";
 import { signalWithTimeout, cancelBodyOnAbort } from "../lib/abort";
 import { sidecarEnter } from "../lib/sidecar-tracker";
-import { fetchWithResetRetry, applyUpstreamRecoveryHeaders } from "../lib/upstream-retry";
+import { fetchWithResetRetry, applyUpstreamRecoveryInit } from "../lib/upstream-retry";
 import type { WebSearchSource } from "./parse";
 import { BASE_INSTRUCTION, IMAGE_INSTRUCTION, type SidecarOutcome, type SidecarSettings } from "./executor";
 
@@ -162,12 +162,12 @@ export async function runAnthropicWebSearch(
   const t0 = Date.now();
   try {
     const res = await fetchWithResetRetry(
-      recovery => fetch(url, {
+      recovery => fetch(url, applyUpstreamRecoveryInit({
         method: "POST",
-        headers: applyUpstreamRecoveryHeaders(headers, recovery),
+        headers,
         body: JSON.stringify(body),
         signal: linkedSignal.signal,
-      }),
+      }, recovery)),
       { abortSignal: linkedSignal.signal, label: "web-search-sidecar-anthropic" },
     );
     if (!res.ok) {

--- a/src/web-search/executor.ts
+++ b/src/web-search/executor.ts
@@ -2,7 +2,7 @@ import type { OcxProviderConfig } from "../types";
 import { FORWARD_HEADERS } from "../adapters/openai-responses";
 import { signalWithTimeout, cancelBodyOnAbort } from "../lib/abort";
 import { sidecarEnter } from "../lib/sidecar-tracker";
-import { fetchWithResetRetry, applyUpstreamRecoveryHeaders } from "../lib/upstream-retry";
+import { fetchWithResetRetry, applyUpstreamRecoveryInit } from "../lib/upstream-retry";
 import { parseSidecarSSE, type WebSearchResult } from "./parse";
 import type { CodexUpstreamOutcome } from "../codex/routing";
 
@@ -72,12 +72,12 @@ export async function runWebSearch(
   const t0 = Date.now();
   try {
     const res = await fetchWithResetRetry(
-      recovery => fetch(url, {
+      recovery => fetch(url, applyUpstreamRecoveryInit({
         method: "POST",
-        headers: applyUpstreamRecoveryHeaders(headers, recovery),
+        headers,
         body: JSON.stringify(body),
         signal: linkedSignal.signal,
-      }),
+      }, recovery)),
       { abortSignal: linkedSignal.signal, label: "web-search-sidecar" },
     );
     recordOutcome?.(res.status);

--- a/src/web-search/executor.ts
+++ b/src/web-search/executor.ts
@@ -2,7 +2,7 @@ import type { OcxProviderConfig } from "../types";
 import { FORWARD_HEADERS } from "../adapters/openai-responses";
 import { signalWithTimeout, cancelBodyOnAbort } from "../lib/abort";
 import { sidecarEnter } from "../lib/sidecar-tracker";
-import { fetchWithResetRetry } from "../lib/upstream-retry";
+import { fetchWithResetRetry, applyUpstreamRecoveryHeaders } from "../lib/upstream-retry";
 import { parseSidecarSSE, type WebSearchResult } from "./parse";
 import type { CodexUpstreamOutcome } from "../codex/routing";
 
@@ -72,9 +72,9 @@ export async function runWebSearch(
   const t0 = Date.now();
   try {
     const res = await fetchWithResetRetry(
-      () => fetch(url, {
+      recovery => fetch(url, {
         method: "POST",
-        headers,
+        headers: applyUpstreamRecoveryHeaders(headers, recovery),
         body: JSON.stringify(body),
         signal: linkedSignal.signal,
       }),

--- a/src/web-search/loop.ts
+++ b/src/web-search/loop.ts
@@ -6,7 +6,7 @@ import { runWebSearch, type SidecarOutcome, type SidecarOutcomeRecorder, type Si
 import { runAnthropicWebSearch } from "./anthropic-executor";
 import { clearableDeadline } from "../lib/abort";
 import { readBoundedResponseBody } from "../lib/bounded-body";
-import { fetchWithResetRetry } from "../lib/upstream-retry";
+import { fetchWithResetRetry, applyUpstreamRecoveryHeaders } from "../lib/upstream-retry";
 import { formatWebSearchResults } from "./format-result";
 import { parseStreamWithProgress, RoutedModelInactivityError, WebSearchStreamProtocolError } from "./progress-stream";
 import { WEB_SEARCH_TOOL_NAME } from "./synthetic-tool";
@@ -276,8 +276,8 @@ export async function runWithWebSearch(deps: WebSearchLoopDeps): Promise<Respons
               stream: true,
             })
           : await fetchWithResetRetry(
-              () => {
-                const h = new Headers(request.headers);
+              recovery => {
+                const h = applyUpstreamRecoveryHeaders(request.headers, recovery);
                 if (!h.has("accept-encoding")) h.set("accept-encoding", "identity");
                 return fetch(request.url, {
                   method: request.method,

--- a/src/web-search/loop.ts
+++ b/src/web-search/loop.ts
@@ -6,7 +6,7 @@ import { runWebSearch, type SidecarOutcome, type SidecarOutcomeRecorder, type Si
 import { runAnthropicWebSearch } from "./anthropic-executor";
 import { clearableDeadline } from "../lib/abort";
 import { readBoundedResponseBody } from "../lib/bounded-body";
-import { fetchWithResetRetry, applyUpstreamRecoveryHeaders } from "../lib/upstream-retry";
+import { fetchWithResetRetry, applyUpstreamRecoveryInit } from "../lib/upstream-retry";
 import { formatWebSearchResults } from "./format-result";
 import { parseStreamWithProgress, RoutedModelInactivityError, WebSearchStreamProtocolError } from "./progress-stream";
 import { WEB_SEARCH_TOOL_NAME } from "./synthetic-tool";
@@ -277,14 +277,15 @@ export async function runWithWebSearch(deps: WebSearchLoopDeps): Promise<Respons
             })
           : await fetchWithResetRetry(
               recovery => {
-                const h = applyUpstreamRecoveryHeaders(request.headers, recovery);
-                if (!h.has("accept-encoding")) h.set("accept-encoding", "identity");
-                return fetch(request.url, {
+                const init = applyUpstreamRecoveryInit({
                   method: request.method,
-                  headers: h,
+                  headers: request.headers,
                   body: request.body,
                   signal: headerDeadline.signal,
-                });
+                }, recovery);
+                const h = new Headers(init.headers);
+                if (!h.has("accept-encoding")) h.set("accept-encoding", "identity");
+                return fetch(request.url, { ...init, headers: h });
               },
               { abortSignal: headerDeadline.signal, label: "web-search-loop" },
             );

--- a/tests/codex-routing.test.ts
+++ b/tests/codex-routing.test.ts
@@ -6,6 +6,7 @@ import {
   CODEX_THREAD_AFFINITY_IDLE_TTL_MS,
   CODEX_THREAD_AFFINITY_MAX_ENTRIES,
   CODEX_THREAD_AFFINITY_REEVAL_INTERVAL_MS,
+  CODEX_TRANSIENT_SOFT_AVOID_MS,
   classifyCodexUpstreamOutcome,
   clearCodexUpstreamHealth,
   clearCodexUpstreamHealthForAccount,
@@ -13,8 +14,10 @@ import {
   clearThreadAccountMapForAccount,
   computeCodexUsageScore,
   getCodexAccountCooldownUntil,
+  getCodexAccountSoftAvoidUntil,
   getCodexUpstreamHealth,
   isCodexAccountInCooldown,
+  isCodexAccountSoftAvoided,
   pickLowestUsageCodexAccount,
   parseRetryAfterMs,
   recordCodexUpstreamOutcome,
@@ -190,7 +193,7 @@ describe("codex routing", () => {
     expect(classifyCodexUpstreamOutcome(102)).toBe("unknown");
   });
 
-  test("three consecutive transient failures fail over future new threads", () => {
+  test("three consecutive transient failures fail over affined and new threads", () => {
     const config = makeConfig();
     updateAccountQuota("a", 10);
     updateAccountQuota("b", 20);
@@ -198,7 +201,8 @@ describe("codex routing", () => {
     recordCodexUpstreamOutcome(config, "a", 503);
     recordCodexUpstreamOutcome(config, "a", 503);
     recordCodexUpstreamOutcome(config, "a", 503);
-    expect(resolveCodexAccountForThread("existing", config)).toBe("a");
+    // Soft-avoid + failover clear affinity so "continue" leaves the failing account (#186).
+    expect(resolveCodexAccountForThread("existing", config)).toBe("b");
     expect(resolveCodexAccountForThread("next", config)).toBe("b");
   });
 
@@ -297,6 +301,55 @@ describe("codex routing", () => {
     expect(resolveCodexAccountForThread("quota-next", config)).toBe("b");
   });
 
+  test("connect_error soft-avoids the pinned account so the same thread rebinds on continue", () => {
+    const config = makeConfig();
+    const now = 1_800_000_000_000;
+    updateAccountQuota("a", 10);
+    updateAccountQuota("b", 20);
+    expect(resolveCodexAccountForThread("sticky-session", config, now)).toBe("a");
+
+    recordCodexUpstreamOutcome(config, "a", "connect_error", { now, threadId: "sticky-session" });
+
+    expect(isCodexAccountSoftAvoided("a", now)).toBe(true);
+    expect(getCodexAccountSoftAvoidUntil("a", now)).toBe(now + CODEX_TRANSIENT_SOFT_AVOID_MS);
+    // Soft avoid must not masquerade as a hard quota cooldown (auth would throw).
+    expect(isCodexAccountInCooldown("a", now)).toBe(false);
+    expect(resolveCodexAccountForThread("sticky-session", config, now)).toBe("b");
+    expect(resolveCodexAccountForThread("sibling-session", config, now)).toBe("b");
+  });
+
+  test("transient failover streak clears all affinities pinned to the failing account", () => {
+    const config = makeConfig();
+    const now = 1_800_000_000_000;
+    updateAccountQuota("a", 10);
+    updateAccountQuota("b", 20);
+    expect(resolveCodexAccountForThread("affined-1", config, now)).toBe("a");
+    expect(resolveCodexAccountForThread("affined-2", config, now)).toBe("a");
+
+    recordCodexUpstreamOutcome(config, "a", "connect_error", { now });
+    recordCodexUpstreamOutcome(config, "a", "timeout", { now: now + 1 });
+    recordCodexUpstreamOutcome(config, "a", "connect_error", { now: now + 2 });
+
+    expect(getCodexUpstreamHealth("a")).toMatchObject({ consecutiveFailures: 3, lastFailureStatus: 0 });
+    expect(config.activeCodexAccountId).toBe("b");
+    expect(resolveCodexAccountForThread("affined-1", config, now + 2)).toBe("b");
+    expect(resolveCodexAccountForThread("affined-2", config, now + 2)).toBe("b");
+  });
+
+  test("2xx clears soft avoid without clearing an unexpired hard cooldown", () => {
+    const config = makeConfig();
+    const now = 1_800_000_000_000;
+    recordCodexUpstreamOutcome(config, "a", 429, { retryAfter: "120", now });
+    recordCodexUpstreamOutcome(config, "a", "connect_error", { now: now + 500 });
+    expect(isCodexAccountSoftAvoided("a", now + 500)).toBe(true);
+
+    recordCodexUpstreamOutcome(config, "a", 200, { now: now + 1_000 });
+
+    expect(getCodexAccountCooldownUntil("a", now + 1_000)).toBe(now + 120_000);
+    expect(isCodexAccountSoftAvoided("a", now + 1_000)).toBe(false);
+    expect(getCodexUpstreamHealth("a")).toMatchObject({ consecutiveFailures: 0, cooldownUntil: now + 120_000 });
+  });
+
   test("2xx responses clear transient failures without clearing an unexpired cooldown", () => {
     const config = makeConfig();
     const now = 1_800_000_000_000;
@@ -317,21 +370,33 @@ describe("codex routing", () => {
     const now = 1_800_000_000_000;
 
     recordCodexUpstreamOutcome(config, "a", 503, { now });
-    recordCodexUpstreamOutcome(config, "a", 503, { now: now + CODEX_FAILURE_WINDOW_MS + 1 });
+    const afterWindow = now + CODEX_FAILURE_WINDOW_MS + 1;
+    recordCodexUpstreamOutcome(config, "a", 503, { now: afterWindow });
 
     expect(getCodexUpstreamHealth("a")).toMatchObject({ consecutiveFailures: 1, lastFailureStatus: 503 });
-    expect(resolveCodexAccountForThread("stale-failure-next", config)).toBe("a");
+    // Soft avoid from the latest 503 must expire before we assert no failover.
+    expect(resolveCodexAccountForThread(
+      "stale-failure-next",
+      config,
+      afterWindow + CODEX_TRANSIENT_SOFT_AVOID_MS + 1,
+    )).toBe("a");
   });
 
   test("2xx responses reset the failure streak", () => {
     const config = makeConfig();
     updateAccountQuota("a", 10);
     updateAccountQuota("b", 10);
-    recordCodexUpstreamOutcome(config, "a", 503);
-    recordCodexUpstreamOutcome(config, "a", 200);
-    recordCodexUpstreamOutcome(config, "a", 503);
-    recordCodexUpstreamOutcome(config, "a", 503);
-    expect(resolveCodexAccountForThread("next", config)).toBe("a");
+    const now = 1_800_000_000_000;
+    recordCodexUpstreamOutcome(config, "a", 503, { now });
+    recordCodexUpstreamOutcome(config, "a", 200, { now: now + 1 });
+    recordCodexUpstreamOutcome(config, "a", 503, { now: now + 2 });
+    recordCodexUpstreamOutcome(config, "a", 503, { now: now + 3 });
+    // Streak is 2 (< threshold 3); after soft avoid expires, stay on active "a".
+    expect(resolveCodexAccountForThread(
+      "next",
+      config,
+      now + 3 + CODEX_TRANSIENT_SOFT_AVOID_MS + 1,
+    )).toBe("a");
   });
 
   test("failure failover can be disabled independently from quota switching", () => {

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -9,7 +9,9 @@ import {
   clearCodexUpstreamHealth,
   clearThreadAccountMap,
   getCodexUpstreamHealth,
+  isCodexAccountSoftAvoided,
   recordCodexUpstreamOutcome,
+  resolveCodexAccountForThread,
 } from "../src/codex/routing";
 import { loadConfig, saveConfig } from "../src/config";
 import { deriveProviderPresets } from "../src/providers/derive";
@@ -2482,6 +2484,67 @@ describe("server local API auth", () => {
         consecutiveFailures: 1,
         lastFailureStatus: 0,
       });
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("compact connect failure records pool health and soft-avoids the pinned thread", async () => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    clearCodexUpstreamHealth();
+    clearThreadAccountMap();
+    clearAccountNeedsReauth("pool-a");
+    clearAccountNeedsReauth("pool-b");
+
+    redirectCanonicalCodexTo("http://127.0.0.1:9/");
+    const cfg = {
+      port: 0,
+      defaultProvider: "openai",
+      openaiProviderTierVersion: 2,
+      providers: poolProviders(),
+      codexAccounts: [
+        { id: "main", email: "main@example.test", isMain: true },
+        { id: "pool-a", email: "pool-a@example.test", isMain: false, chatgptAccountId: "acct-pool-a" },
+        { id: "pool-b", email: "pool-b@example.test", isMain: false, chatgptAccountId: "acct-pool-b" },
+      ],
+      activeCodexAccountId: "pool-a",
+      upstreamFailoverThreshold: 3,
+      connectTimeoutMs: 200,
+    } as OcxConfig;
+    saveConfig(cfg);
+    for (const id of ["pool-a", "pool-b"] as const) {
+      saveCodexAccountCredential(id, {
+        accessToken: `${id}-access-token`,
+        refreshToken: `${id}-refresh-token`,
+        expiresAt: Date.now() + 5 * 60_000,
+        chatgptAccountId: `acct-${id}`,
+      });
+    }
+    updateAccountQuota("pool-a", 10, 5);
+    updateAccountQuota("pool-b", 20, 5);
+    expect(resolveCodexAccountForThread("compact-sticky", cfg)).toBe("pool-a");
+
+    const server = startServer(0);
+    try {
+      const response = await fetch(new URL("/v1/responses/compact", server.url), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer inbound-main-token",
+          "x-codex-parent-thread-id": "compact-sticky",
+        },
+        body: JSON.stringify({ model: "gpt-test", input: [] }),
+      });
+
+      expect(response.status).toBe(502);
+      expect(getCodexUpstreamHealth("pool-a")).toMatchObject({
+        consecutiveFailures: 1,
+        lastFailureStatus: 0,
+      });
+      expect(isCodexAccountSoftAvoided("pool-a")).toBe(true);
+      expect(resolveCodexAccountForThread("compact-sticky", cfg)).toBe("pool-b");
     } finally {
       await server.stop(true);
     }

--- a/tests/upstream-retry.test.ts
+++ b/tests/upstream-retry.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import {
   fetchWithResetRetry,
+  applyUpstreamRecoveryHeaders,
   isConnectionResetError,
   retryBackoffDelayMs,
 } from "../src/lib/upstream-retry";
@@ -30,6 +31,16 @@ function silenceWarn(): void {
 
 afterEach(() => {
   for (const spy of warnSpies.splice(0)) spy.mockRestore();
+});
+
+describe("applyUpstreamRecoveryHeaders", () => {
+  test("sets Connection: close only on connection-reset recovery", () => {
+    const base = new Headers({ authorization: "Bearer x" });
+    expect(applyUpstreamRecoveryHeaders(base)?.get("connection")).toBeNull();
+    expect(applyUpstreamRecoveryHeaders(base, "transient-5xx").get("connection")).toBeNull();
+    expect(applyUpstreamRecoveryHeaders(base, "connection-reset").get("connection")).toBe("close");
+    expect(applyUpstreamRecoveryHeaders(base, "connection-reset").get("authorization")).toBe("Bearer x");
+  });
 });
 
 describe("isConnectionResetError", () => {
@@ -138,6 +149,18 @@ describe("fetchWithResetRetry", () => {
       throw bunResetError();
     };
     await expect(fetchWithResetRetry(doFetch, { abortSignal: ac.signal })).rejects.toThrow("socket connection was closed unexpectedly");
+  });
+  test("passes connection-reset recovery into the retry thunk", async () => {
+    silenceWarn();
+    const recoveries: Array<string | undefined> = [];
+    let attempt = 0;
+    const res = await fetchWithResetRetry(async recovery => {
+      recoveries.push(recovery);
+      if (attempt++ === 0) throw bunResetError();
+      return new Response("ok", { status: 200 });
+    });
+    expect(res.status).toBe(200);
+    expect(recoveries).toEqual([undefined, "connection-reset"]);
   });
 });
 

--- a/tests/upstream-retry.test.ts
+++ b/tests/upstream-retry.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import {
   fetchWithResetRetry,
+  applyUpstreamRecoveryInit,
   applyUpstreamRecoveryHeaders,
   isConnectionResetError,
   retryBackoffDelayMs,
@@ -33,13 +34,23 @@ afterEach(() => {
   for (const spy of warnSpies.splice(0)) spy.mockRestore();
 });
 
-describe("applyUpstreamRecoveryHeaders", () => {
-  test("sets Connection: close only on connection-reset recovery", () => {
+describe("applyUpstreamRecoveryInit", () => {
+  test("sets keepalive:false and Connection: close only on connection-reset recovery", () => {
+    const base = { headers: { authorization: "Bearer x" } };
+    expect(applyUpstreamRecoveryInit(base).keepalive).toBeUndefined();
+    expect(applyUpstreamRecoveryInit(base, "transient-5xx").keepalive).toBeUndefined();
+    expect(new Headers(applyUpstreamRecoveryInit(base, "transient-5xx").headers).get("connection")).toBeNull();
+
+    const reset = applyUpstreamRecoveryInit(base, "connection-reset");
+    expect(reset.keepalive).toBe(false);
+    expect(new Headers(reset.headers).get("connection")).toBe("close");
+    expect(new Headers(reset.headers).get("authorization")).toBe("Bearer x");
+  });
+
+  test("legacy applyUpstreamRecoveryHeaders still sets Connection: close", () => {
     const base = new Headers({ authorization: "Bearer x" });
     expect(applyUpstreamRecoveryHeaders(base)?.get("connection")).toBeNull();
-    expect(applyUpstreamRecoveryHeaders(base, "transient-5xx").get("connection")).toBeNull();
     expect(applyUpstreamRecoveryHeaders(base, "connection-reset").get("connection")).toBe("close");
-    expect(applyUpstreamRecoveryHeaders(base, "connection-reset").get("authorization")).toBe("Bearer x");
   });
 });
 


### PR DESCRIPTION
## Summary
- Soft-avoid Codex pool accounts for 30s after `connect_error` / `timeout` / transient 5xx so thread affinity can leave a flaky peer on the next continue (#186)
- Clear all affinities pinned to an account once the failover streak trips (same behavior as 429), and plumb `x-codex-parent-thread-id` into outcome recording for immediate per-thread unbind
- Force `Connection: close` on keep-alive connection-reset retries so Bun does not reuse the half-closed socket

## Test plan
- [x] `bun test tests/codex-routing.test.ts tests/upstream-retry.test.ts`
- [x] Pre-push hook full suite (`bun test`, typecheck, lint)
- [ ] Manual: multi-account OpenAI pool, provoke `Provider unreachable: socket connection was closed unexpectedly` in one Codex session, confirm continue rebinds to another account instead of sticky 502s