### PR TITLE
fix: restore GUI request logs after ocx stop/start

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -54,6 +54,7 @@ export {
 } from "./lifecycle";
 import {
   addFinalRequestLog,
+  hydrateRequestLogsFromDisk,
   httpStatusForRequestLogTerminal,
   httpStatusForTerminalStatus,
   inspectResponseLogSsePayload,
@@ -65,6 +66,7 @@ import {
 export {
   addFinalRequestLog,
   filterRequestLogs,
+  hydrateRequestLogsFromDisk,
   httpStatusForTerminalStatus,
   httpStatusFromTerminalError,
   nextRequestLogId,
@@ -175,6 +177,9 @@ export function startServer(port?: number) {
     }
   }
   invalidateCodexModelsCache();
+  // usage.jsonl already persists every request; rehydrate the in-memory Logs ring so
+  // /api/logs (and the GUI) survive `ocx stop` / `ocx start` process restarts.
+  hydrateRequestLogsFromDisk();
 
   const listenPort = port ?? config.port ?? 10100;
   setCorsOrigin(listenPort);

--- a/src/server/request-log.ts
+++ b/src/server/request-log.ts
@@ -11,7 +11,7 @@ import type { OcxUsage } from "../types";
 import { redactSecretString } from "../lib/redact";
 import {
   appendUsageEntry,
-  readUsageEntries,
+  readRecentUsageEntries,
   usageForFinalLog,
   usageStatusForFinalLog,
   usageTotalTokens,
@@ -130,6 +130,15 @@ export function requestLogEntryFromPersistedUsage(entry: PersistedUsageEntry): R
     ...(entry.firstOutputMs !== undefined ? { firstOutputMs: entry.firstOutputMs } : {}),
     ...(entry.surface === "claude" ? { surface: entry.surface } : {}),
     ...(entry.requestedModel ? { requestedModel: entry.requestedModel } : {}),
+    ...(entry.requestedEffort ? { requestedEffort: entry.requestedEffort } : {}),
+    ...(entry.requestedServiceTier ? { requestedServiceTier: entry.requestedServiceTier } : {}),
+    ...(entry.requestedSpeedLabel ? { requestedSpeedLabel: entry.requestedSpeedLabel } : {}),
+    ...(entry.configuredServiceTier ? { configuredServiceTier: entry.configuredServiceTier } : {}),
+    ...(entry.configuredSpeedLabel ? { configuredSpeedLabel: entry.configuredSpeedLabel } : {}),
+    ...(entry.modelSupportsServiceTier !== undefined
+      ? { modelSupportsServiceTier: entry.modelSupportsServiceTier }
+      : {}),
+    ...(entry.responseServiceTier ? { responseServiceTier: entry.responseServiceTier } : {}),
     ...(entry.resolvedModel ? { resolvedModel: entry.resolvedModel } : {}),
     status: entry.status,
     durationMs: entry.durationMs,
@@ -147,21 +156,32 @@ export function requestLogEntryFromPersistedUsage(entry: PersistedUsageEntry): R
 /**
  * Seed the in-memory Logs ring buffer from usage.jsonl so GUI /api/logs survives
  * `ocx stop` / `ocx start` (process restart). Idempotent per process; no-ops when
- * the buffer already has live entries.
+ * the buffer already has live entries. Read failures are non-fatal (same as /api/usage).
  */
 export function hydrateRequestLogsFromDisk(
-  reader: () => PersistedUsageEntry[] = readUsageEntries,
+  reader: () => PersistedUsageEntry[] = () => readRecentUsageEntries(MAX_LOG_SIZE),
 ): number {
   if (requestLogsHydratedFromDisk) return 0;
-  requestLogsHydratedFromDisk = true;
-  if (requestLog.length > 0) return 0;
-  const persisted = reader();
-  if (persisted.length === 0) return 0;
-  const slice = persisted.length > MAX_LOG_SIZE
-    ? persisted.slice(persisted.length - MAX_LOG_SIZE)
-    : persisted;
-  for (const entry of slice) requestLog.push(requestLogEntryFromPersistedUsage(entry));
-  return slice.length;
+  if (requestLog.length > 0) {
+    requestLogsHydratedFromDisk = true;
+    return 0;
+  }
+  try {
+    const persisted = reader();
+    requestLogsHydratedFromDisk = true;
+    if (persisted.length === 0) return 0;
+    const slice = persisted.length > MAX_LOG_SIZE
+      ? persisted.slice(persisted.length - MAX_LOG_SIZE)
+      : persisted;
+    for (const entry of slice) requestLog.push(requestLogEntryFromPersistedUsage(entry));
+    return slice.length;
+  } catch (err) {
+    requestLogsHydratedFromDisk = true;
+    console.warn(
+      `[request-log] failed to hydrate from usage.jsonl: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return 0;
+  }
 }
 
 export function addRequestLog(entry: RequestLogEntry) {
@@ -187,6 +207,15 @@ export function addRequestLog(entry: RequestLogEntry) {
       ...(entry.surface === "claude" ? { surface: entry.surface } : {}),
       ...(entry.resolvedModel ? { resolvedModel: entry.resolvedModel } : {}),
       ...(entry.requestedModel ? { requestedModel: entry.requestedModel } : {}),
+      ...(entry.requestedEffort ? { requestedEffort: entry.requestedEffort } : {}),
+      ...(entry.requestedServiceTier ? { requestedServiceTier: entry.requestedServiceTier } : {}),
+      ...(entry.requestedSpeedLabel ? { requestedSpeedLabel: entry.requestedSpeedLabel } : {}),
+      ...(entry.configuredServiceTier ? { configuredServiceTier: entry.configuredServiceTier } : {}),
+      ...(entry.configuredSpeedLabel ? { configuredSpeedLabel: entry.configuredSpeedLabel } : {}),
+      ...(entry.modelSupportsServiceTier !== undefined
+        ? { modelSupportsServiceTier: entry.modelSupportsServiceTier }
+        : {}),
+      ...(entry.responseServiceTier ? { responseServiceTier: entry.responseServiceTier } : {}),
       status: entry.status,
       durationMs: entry.durationMs,
       ...(entry.firstOutputMs !== undefined ? { firstOutputMs: entry.firstOutputMs } : {}),

--- a/src/server/request-log.ts
+++ b/src/server/request-log.ts
@@ -11,11 +11,13 @@ import type { OcxUsage } from "../types";
 import { redactSecretString } from "../lib/redact";
 import {
   appendUsageEntry,
+  readUsageEntries,
   usageForFinalLog,
   usageStatusForFinalLog,
   usageTotalTokens,
   type AttemptRecoveryKind,
   type PersistedUsageAttempt,
+  type PersistedUsageEntry,
   type UsageStatus,
 } from "../usage/log";
 import {
@@ -95,6 +97,72 @@ export interface RequestLogEntry {
 const requestLog: RequestLogEntry[] = [];
 const MAX_LOG_SIZE = 200;
 let requestLogSeq = 0;
+/** True after hydrateRequestLogsFromDisk ran once in this process. */
+let requestLogsHydratedFromDisk = false;
+
+function asTerminalStatus(value: string | undefined): ResponsesTerminalStatus | undefined {
+  if (value === "completed" || value === "failed" || value === "incomplete") return value;
+  return undefined;
+}
+
+function asCloseReason(value: string | undefined): RequestLogEntry["closeReason"] | undefined {
+  switch (value) {
+    case "terminal":
+    case "client_cancel":
+    case "non_stream":
+    case "body_stall":
+    case "body_overflow":
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+/** Project a persisted usage.jsonl row back into the in-memory /api/logs shape. */
+export function requestLogEntryFromPersistedUsage(entry: PersistedUsageEntry): RequestLogEntry {
+  const terminalStatus = asTerminalStatus(entry.terminalStatus);
+  const closeReason = asCloseReason(entry.closeReason);
+  return {
+    requestId: entry.requestId,
+    timestamp: entry.timestamp,
+    model: entry.model,
+    provider: entry.provider,
+    ...(entry.firstOutputMs !== undefined ? { firstOutputMs: entry.firstOutputMs } : {}),
+    ...(entry.surface === "claude" ? { surface: entry.surface } : {}),
+    ...(entry.requestedModel ? { requestedModel: entry.requestedModel } : {}),
+    ...(entry.resolvedModel ? { resolvedModel: entry.resolvedModel } : {}),
+    status: entry.status,
+    durationMs: entry.durationMs,
+    ...(entry.errorCode ? { errorCode: entry.errorCode } : {}),
+    ...(terminalStatus ? { terminalStatus } : {}),
+    ...(closeReason ? { closeReason } : {}),
+    ...(entry.upstreamError ? { upstreamError: entry.upstreamError } : {}),
+    usageStatus: entry.usageStatus,
+    ...(entry.usage ? { usage: entry.usage } : {}),
+    ...(entry.totalTokens !== undefined ? { totalTokens: entry.totalTokens } : {}),
+    ...(entry.attempts?.length ? { attempts: entry.attempts } : {}),
+  };
+}
+
+/**
+ * Seed the in-memory Logs ring buffer from usage.jsonl so GUI /api/logs survives
+ * `ocx stop` / `ocx start` (process restart). Idempotent per process; no-ops when
+ * the buffer already has live entries.
+ */
+export function hydrateRequestLogsFromDisk(
+  reader: () => PersistedUsageEntry[] = readUsageEntries,
+): number {
+  if (requestLogsHydratedFromDisk) return 0;
+  requestLogsHydratedFromDisk = true;
+  if (requestLog.length > 0) return 0;
+  const persisted = reader();
+  if (persisted.length === 0) return 0;
+  const slice = persisted.length > MAX_LOG_SIZE
+    ? persisted.slice(persisted.length - MAX_LOG_SIZE)
+    : persisted;
+  for (const entry of slice) requestLog.push(requestLogEntryFromPersistedUsage(entry));
+  return slice.length;
+}
 
 export function addRequestLog(entry: RequestLogEntry) {
   requestLog.push(entry);
@@ -687,4 +755,5 @@ export function getRequestLogEntries(): RequestLogEntry[] { return requestLog; }
 export function clearRequestLogsForTests(): void {
   requestLog.length = 0;
   requestLogSeq = 0;
+  requestLogsHydratedFromDisk = false;
 }

--- a/src/usage/log.ts
+++ b/src/usage/log.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, appendFileSync } from "node:fs";
+import { chmodSync, closeSync, existsSync, fstatSync, mkdirSync, openSync, readFileSync, readSync, appendFileSync } from "node:fs";
 import { join } from "node:path";
 import { getConfigDir } from "../config";
 import { usageDisplayTotalTokens } from "./totals";
@@ -39,6 +39,14 @@ export interface PersistedUsageEntry {
   surface?: "claude";
   resolvedModel?: string;
   requestedModel?: string;
+  /** Reasoning effort / service-tier metadata for GUI Logs after restart. */
+  requestedEffort?: string;
+  requestedServiceTier?: string;
+  requestedSpeedLabel?: string;
+  configuredServiceTier?: string;
+  configuredSpeedLabel?: string;
+  modelSupportsServiceTier?: boolean;
+  responseServiceTier?: string;
   status: number;
   durationMs: number;
   /** TTFT relative to the request start (WP4); unset for non-streaming/tool-only. */
@@ -207,6 +215,27 @@ function normalizeUsageEntry(entry: PersistedUsageEntry): PersistedUsageEntry {
     ...(entry.surface === "claude" ? { surface: entry.surface } : {}),
     ...(entry.resolvedModel ? { resolvedModel: entry.resolvedModel } : {}),
     ...(entry.requestedModel ? { requestedModel: entry.requestedModel } : {}),
+    ...(typeof entry.requestedEffort === "string" && entry.requestedEffort
+      ? { requestedEffort: entry.requestedEffort }
+      : {}),
+    ...(typeof entry.requestedServiceTier === "string" && entry.requestedServiceTier
+      ? { requestedServiceTier: entry.requestedServiceTier }
+      : {}),
+    ...(typeof entry.requestedSpeedLabel === "string" && entry.requestedSpeedLabel
+      ? { requestedSpeedLabel: entry.requestedSpeedLabel }
+      : {}),
+    ...(typeof entry.configuredServiceTier === "string" && entry.configuredServiceTier
+      ? { configuredServiceTier: entry.configuredServiceTier }
+      : {}),
+    ...(typeof entry.configuredSpeedLabel === "string" && entry.configuredSpeedLabel
+      ? { configuredSpeedLabel: entry.configuredSpeedLabel }
+      : {}),
+    ...(typeof entry.modelSupportsServiceTier === "boolean"
+      ? { modelSupportsServiceTier: entry.modelSupportsServiceTier }
+      : {}),
+    ...(typeof entry.responseServiceTier === "string" && entry.responseServiceTier
+      ? { responseServiceTier: entry.responseServiceTier }
+      : {}),
     status: entry.status,
     durationMs: entry.durationMs,
     ...(isNonNegativeFiniteNumber(entry.firstOutputMs)
@@ -253,4 +282,65 @@ export function readUsageEntries(): PersistedUsageEntry[] {
     }
   }
   return entries;
+}
+
+function parseUsageLines(lines: string[]): PersistedUsageEntry[] {
+  const entries: PersistedUsageEntry[] = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line) as PersistedUsageEntry;
+      if (parsed && typeof parsed === "object" && typeof parsed.requestId === "string") {
+        entries.push(normalizeUsageEntry(parsed));
+      }
+    } catch {
+      /* skip partial / hand-edited lines */
+    }
+  }
+  return entries;
+}
+
+/**
+ * Read only the newest `limit` usage.jsonl rows without loading the whole append-only
+ * file into memory. Used by request-log hydration on `ocx start`.
+ */
+export function readRecentUsageEntries(limit: number): PersistedUsageEntry[] {
+  if (!Number.isFinite(limit) || limit <= 0) return [];
+  const path = usageLogPath();
+  if (!existsSync(path)) return [];
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, "r");
+    const size = fstatSync(fd).size;
+    if (size <= 0) return [];
+    // ~4 KiB/row budget with a floor; expand once if the window yields too few lines.
+    let windowBytes = Math.min(size, Math.max(64 * 1024, Math.ceil(limit) * 4 * 1024));
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const start = Math.max(0, size - windowBytes);
+      const buf = Buffer.alloc(size - start);
+      readSync(fd, buf, 0, buf.length, start);
+      let text = buf.toString("utf-8");
+      if (start > 0) {
+        const nl = text.indexOf("\n");
+        if (nl < 0) {
+          if (start === 0) break;
+          windowBytes = Math.min(size, windowBytes * 4);
+          continue;
+        }
+        text = text.slice(nl + 1);
+      }
+      const lines = text.split(/\r?\n/).filter(line => line.trim());
+      const recent = lines.slice(-Math.ceil(limit));
+      const entries = parseUsageLines(recent);
+      if (entries.length >= limit || start === 0 || windowBytes >= size) return entries.slice(-limit);
+      windowBytes = Math.min(size, windowBytes * 4);
+    }
+    return [];
+  } catch {
+    return [];
+  } finally {
+    if (fd !== undefined) {
+      try { closeSync(fd); } catch { /* ignore */ }
+    }
+  }
 }

--- a/tests/request-log.test.ts
+++ b/tests/request-log.test.ts
@@ -12,12 +12,17 @@ import {
 import {
   aggregateAttemptUsage,
   beginRequestAttempt,
+  clearRequestLogsForTests,
   finishRequestAttempt,
+  getRequestLogEntries,
+  hydrateRequestLogsFromDisk,
   noteAttemptSend,
   recordFirstOutput,
+  requestLogEntryFromPersistedUsage,
   sealRequestAttemptIdentity,
   type RequestLogContext,
 } from "../src/server/request-log";
+import type { PersistedUsageEntry } from "../src/usage/log";
 
 function log(overrides: Partial<RequestLogEntry>): RequestLogEntry {
   return {
@@ -817,5 +822,100 @@ describe("request log metadata", () => {
     });
     expect(entries[0].upstreamError).toContain("adapter_eof");
     expect(entries[0].upstreamError).toContain("ended unexpectedly");
+  });
+});
+
+describe("request log restart hydrate", () => {
+  test("projects persisted usage rows into /api/logs entries", () => {
+    const persisted: PersistedUsageEntry = {
+      requestId: "ocx-revive",
+      timestamp: 1_800_000_000_000,
+      provider: "chatgpt-pabcdef",
+      model: "gpt-5.6-sol",
+      requestedModel: "gpt-5.6-sol",
+      status: 502,
+      durationMs: 42,
+      usageStatus: "unreported",
+      errorCode: "upstream_server_error",
+      terminalStatus: "failed",
+      closeReason: "terminal",
+      upstreamError: "socket connection was closed unexpectedly",
+    };
+    expect(requestLogEntryFromPersistedUsage(persisted)).toEqual({
+      requestId: "ocx-revive",
+      timestamp: 1_800_000_000_000,
+      provider: "chatgpt-pabcdef",
+      model: "gpt-5.6-sol",
+      requestedModel: "gpt-5.6-sol",
+      status: 502,
+      durationMs: 42,
+      usageStatus: "unreported",
+      errorCode: "upstream_server_error",
+      terminalStatus: "failed",
+      closeReason: "terminal",
+      upstreamError: "socket connection was closed unexpectedly",
+    });
+  });
+
+  test("hydrateRequestLogsFromDisk restores the last ring of usage.jsonl after a process wipe", () => {
+    clearRequestLogsForTests();
+    expect(getRequestLogEntries()).toHaveLength(0);
+
+    const persisted: PersistedUsageEntry[] = [
+      {
+        requestId: "ocx-old",
+        timestamp: 1,
+        provider: "openai",
+        model: "gpt-a",
+        status: 200,
+        durationMs: 1,
+        usageStatus: "reported",
+        usage: { inputTokens: 1, outputTokens: 1 },
+        totalTokens: 2,
+      },
+      {
+        requestId: "ocx-sticky-502",
+        timestamp: 2,
+        provider: "openai",
+        model: "gpt-b",
+        status: 502,
+        durationMs: 9,
+        usageStatus: "unreported",
+        errorCode: "upstream_server_error",
+        terminalStatus: "failed",
+        closeReason: "terminal",
+        upstreamError: "Provider unreachable",
+      },
+    ];
+
+    expect(hydrateRequestLogsFromDisk(() => persisted)).toBe(2);
+    expect(getRequestLogEntries().map(e => e.requestId)).toEqual(["ocx-old", "ocx-sticky-502"]);
+    expect(getRequestLogEntries()[1]).toMatchObject({
+      requestId: "ocx-sticky-502",
+      status: 502,
+      errorCode: "upstream_server_error",
+      upstreamError: "Provider unreachable",
+    });
+
+    // Idempotent: a second start in the same process must not duplicate.
+    expect(hydrateRequestLogsFromDisk(() => persisted)).toBe(0);
+    expect(getRequestLogEntries()).toHaveLength(2);
+  });
+
+  test("hydrate keeps only the newest MAX_LOG_SIZE rows from a long usage.jsonl", () => {
+    clearRequestLogsForTests();
+    const persisted: PersistedUsageEntry[] = Array.from({ length: 205 }, (_, i) => ({
+      requestId: `ocx-${i}`,
+      timestamp: i,
+      provider: "openai",
+      model: "gpt",
+      status: 200,
+      durationMs: 1,
+      usageStatus: "unreported" as const,
+    }));
+    expect(hydrateRequestLogsFromDisk(() => persisted)).toBe(200);
+    const ids = getRequestLogEntries().map(e => e.requestId);
+    expect(ids[0]).toBe("ocx-5");
+    expect(ids.at(-1)).toBe("ocx-204");
   });
 });

--- a/tests/request-log.test.ts
+++ b/tests/request-log.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import {
   filterRequestLogs,
   addFinalRequestLog,
@@ -833,6 +833,11 @@ describe("request log restart hydrate", () => {
       provider: "chatgpt-pabcdef",
       model: "gpt-5.6-sol",
       requestedModel: "gpt-5.6-sol",
+      requestedEffort: "high",
+      requestedServiceTier: "priority",
+      requestedSpeedLabel: "fast",
+      configuredServiceTier: "auto",
+      modelSupportsServiceTier: true,
       status: 502,
       durationMs: 42,
       usageStatus: "unreported",
@@ -847,6 +852,11 @@ describe("request log restart hydrate", () => {
       provider: "chatgpt-pabcdef",
       model: "gpt-5.6-sol",
       requestedModel: "gpt-5.6-sol",
+      requestedEffort: "high",
+      requestedServiceTier: "priority",
+      requestedSpeedLabel: "fast",
+      configuredServiceTier: "auto",
+      modelSupportsServiceTier: true,
       status: 502,
       durationMs: 42,
       usageStatus: "unreported",
@@ -878,6 +888,7 @@ describe("request log restart hydrate", () => {
         timestamp: 2,
         provider: "openai",
         model: "gpt-b",
+        requestedEffort: "xhigh",
         status: 502,
         durationMs: 9,
         usageStatus: "unreported",
@@ -895,6 +906,7 @@ describe("request log restart hydrate", () => {
       status: 502,
       errorCode: "upstream_server_error",
       upstreamError: "Provider unreachable",
+      requestedEffort: "xhigh",
     });
 
     // Idempotent: a second start in the same process must not duplicate.
@@ -917,5 +929,23 @@ describe("request log restart hydrate", () => {
     const ids = getRequestLogEntries().map(e => e.requestId);
     expect(ids[0]).toBe("ocx-5");
     expect(ids.at(-1)).toBe("ocx-204");
+  });
+
+  test("hydrate swallows usage.jsonl read failures instead of crashing startup", () => {
+    clearRequestLogsForTests();
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(hydrateRequestLogsFromDisk(() => {
+        throw new Error("EISDIR: illegal operation on a directory");
+      })).toBe(0);
+      expect(getRequestLogEntries()).toHaveLength(0);
+      expect(warn).toHaveBeenCalled();
+      // Still idempotent after the failed attempt.
+      expect(hydrateRequestLogsFromDisk(() => {
+        throw new Error("should not run");
+      })).toBe(0);
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/tests/usage-log.test.ts
+++ b/tests/usage-log.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   appendUsageEntry,
+  readRecentUsageEntries,
   readUsageEntries,
   usageForFinalLog,
   usageLogPath,
@@ -411,5 +412,56 @@ describe("usage log", () => {
       },
       totalTokens: 110,
     });
+  });
+
+  test("persists and reads back effort / service-tier GUI metadata", () => {
+    appendUsageEntry({
+      requestId: "ocx-effort",
+      timestamp: 9,
+      provider: "openai",
+      model: "gpt-5.6-sol",
+      requestedModel: "gpt-5.6-sol",
+      requestedEffort: "high",
+      requestedServiceTier: "priority",
+      requestedSpeedLabel: "fast",
+      configuredServiceTier: "auto",
+      modelSupportsServiceTier: true,
+      responseServiceTier: "priority",
+      status: 200,
+      durationMs: 5,
+      usageStatus: "unreported",
+    });
+    expect(readUsageEntries()[0]).toMatchObject({
+      requestId: "ocx-effort",
+      requestedEffort: "high",
+      requestedServiceTier: "priority",
+      requestedSpeedLabel: "fast",
+      configuredServiceTier: "auto",
+      modelSupportsServiceTier: true,
+      responseServiceTier: "priority",
+    });
+  });
+
+  test("readRecentUsageEntries returns only the newest N rows", () => {
+    for (let i = 0; i < 12; i++) {
+      appendUsageEntry({
+        requestId: `ocx-tail-${i}`,
+        timestamp: i,
+        provider: "openai",
+        model: "gpt",
+        status: 200,
+        durationMs: 1,
+        usageStatus: "unreported",
+      });
+    }
+    expect(readRecentUsageEntries(5).map(e => e.requestId)).toEqual([
+      "ocx-tail-7",
+      "ocx-tail-8",
+      "ocx-tail-9",
+      "ocx-tail-10",
+      "ocx-tail-11",
+    ]);
+    expect(readRecentUsageEntries(0)).toEqual([]);
+    expect(readRecentUsageEntries(-1)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- `/api/logs` (GUI Logs) only lived in an in-memory 200-entry ring buffer, so `ocx stop` wiped the page even though every request was already appended to `usage.jsonl`
- On server start, hydrate that ring from the newest 200 `usage.jsonl` rows so Logs survive process restart
- Separate from the sticky-502 / pool-affinity work in #194 (called out on #186 as its own bug)

## Test plan
- [x] `bun test tests/request-log.test.ts` (hydrate + MAX_LOG_SIZE slice)
- [x] Pre-push full suite
- [ ] Manual: run a few turns, `ocx stop`, `ocx start`, confirm Logs page still shows prior requests

Fixes the log-loss side note from #186.