### PR TITLE
fix(alibaba): preserve reasoning_content for qwen3.8-max-preview

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -707,7 +707,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     },
     modelReasoningEffortMap: { "deepseek-v4-pro": DEEPSEEK_THINKING_REASONING_MAP },
     thinkingBudgetModels: ALIBABA_TOKEN_PLAN_QWEN_MODELS,
-    preserveReasoningContentModels: ["glm-5.2", "deepseek-v4-pro"],
+    preserveReasoningContentModels: ["glm-5.2", "deepseek-v4-pro", "qwen3.8-max-preview"],
   },
   // NEEDS_HUMAN 2026-07-10: kept for config compatibility, but this is a dashboard URL,
   // no /models endpoint is documented, and tools are silently ignored upstream per docs.parallel.ai.

--- a/tests/qwen38-preserve-reasoning.test.ts
+++ b/tests/qwen38-preserve-reasoning.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
+import type { OcxParsedRequest, OcxProviderConfig } from "../src/types";
+
+function provider(overrides: Partial<OcxProviderConfig> = {}): OcxProviderConfig {
+  return {
+    adapter: "openai-chat",
+    baseUrl: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+    apiKey: "sk-test",
+    authMode: "key",
+    preserveReasoningContentModels: ["qwen3.8-max-preview"],
+    thinkingBudgetModels: ["qwen3.8-max-preview"],
+    ...overrides,
+  };
+}
+
+function parsedWithThinkingHistory(): OcxParsedRequest {
+  return {
+    modelId: "qwen3.8-max-preview",
+    context: {
+      messages: [
+        { role: "user", content: "fix the bug in auth.ts", timestamp: 1 },
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "Let me analyze the auth flow step by step..." },
+            { type: "text", text: "I found the issue. Let me read the file." },
+            { type: "toolCall", id: "call_1", name: "read_file", arguments: { path: "auth.ts" } },
+          ],
+          timestamp: 2,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call_1",
+          toolName: "read_file",
+          content: "export function login() { ... }",
+          isError: false,
+          timestamp: 3,
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "The token validation is missing expiry check..." },
+            { type: "text", text: "I see the problem. Applying fix." },
+            { type: "toolCall", id: "call_2", name: "apply_patch", arguments: { patch: "..." } },
+          ],
+          timestamp: 4,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call_2",
+          toolName: "apply_patch",
+          content: "patch applied",
+          isError: false,
+          timestamp: 5,
+        },
+        { role: "user", content: "now run the tests", timestamp: 6 },
+      ],
+    },
+    stream: false,
+    options: {},
+  };
+}
+
+describe("Qwen 3.8 reasoning_content preservation", () => {
+ test("replays reasoning_content for all prior assistant turns when model is in preserveReasoningContentModels", () => {
+   const adapter = createOpenAIChatAdapter(provider());
+    const result = adapter.buildRequest(parsedWithThinkingHistory());
+    const body = JSON.parse(result.body as string) as Record<string, unknown>;
+    const messages = body.messages as Record<string, unknown>[];
+
+    // Find assistant messages
+    const assistantMsgs = messages.filter(m => m.role === "assistant");
+    expect(assistantMsgs.length).toBe(2);
+
+    // Both should have reasoning_content
+    expect(assistantMsgs[0].reasoning_content).toBe("Let me analyze the auth flow step by step...");
+    expect(assistantMsgs[1].reasoning_content).toBe("The token validation is missing expiry check...");
+
+    // reasoning_content should NOT be merged into content
+    expect(assistantMsgs[0].content).not.toContain("Let me analyze");
+    expect(assistantMsgs[1].content).not.toContain("The token validation");
+
+    // tool_calls should still be present
+    expect(assistantMsgs[0].tool_calls).toBeDefined();
+    expect(assistantMsgs[1].tool_calls).toBeDefined();
+  });
+
+ test("does NOT replay reasoning_content for models outside preserveReasoningContentModels", () => {
+   const adapter = createOpenAIChatAdapter(provider({
+     preserveReasoningContentModels: ["some-other-model"],
+   }));
+    const result = adapter.buildRequest(parsedWithThinkingHistory());
+    const body = JSON.parse(result.body as string) as Record<string, unknown>;
+    const messages = body.messages as Record<string, unknown>[];
+
+    const assistantMsgs = messages.filter(m => m.role === "assistant");
+    expect(assistantMsgs.length).toBe(2);
+
+    // Neither should have reasoning_content
+    expect(assistantMsgs[0].reasoning_content).toBeUndefined();
+    expect(assistantMsgs[1].reasoning_content).toBeUndefined();
+  });
+
+  test("registry includes qwen3.8-max-preview in alibaba-token-plan preserveReasoningContentModels", async () => {
+    const { PROVIDER_REGISTRY } = await import("../src/providers/registry");
+    const alibaba = PROVIDER_REGISTRY.find(e => e.id === "alibaba-token-plan");
+    expect(alibaba).toBeDefined();
+    expect(alibaba!.preserveReasoningContentModels).toContain("qwen3.8-max-preview");
+  });
+});


### PR DESCRIPTION
## Problem

`qwen3.8-max-preview` is missing from `preserveReasoningContentModels` in the `alibaba-token-plan` registry entry. OpenCodex drops `reasoning_content` from assistant history between agent turns, causing the model to lose its thinking chain.

Alibaba documents `preserve_thinking=true` as the default for Qwen 3.8. The server expects prior `reasoning_content` fields to be replayed verbatim. Without them, multi-tool debugging and autonomous tasks degrade silently (no API error, just weaker results).

See issue #TBD for full details.

## Fix

One-line registry change: add `"qwen3.8-max-preview"` to `preserveReasoningContentModels` in the `alibaba-token-plan` entry.

## Scope

Only `qwen3.8-max-preview` is added. Older Qwen models (3.7, 3.6) default to `preserve_thinking=false` and would need additional request-body changes — out of scope here.

## Tests

3 new regression tests in `tests/qwen38-preserve-reasoning.test.ts`:

1. **Replay verification**: builds a multi-turn request with thinking + tool calls, confirms `reasoning_content` appears in all prior assistant messages and is NOT merged into `content`
2. **Negative control**: same request with a model outside the preserve list — confirms `reasoning_content` is absent
3. **Registry assertion**: confirms `qwen3.8-max-preview` is in the `alibaba-token-plan` preserve list

All 3 pass. `tsc --noEmit` clean.