### PR TITLE
fix(codex): rework soft-avoid pool affinity with semantic terminal status

### DIFF
--- a/src/codex/routing.ts
+++ b/src/codex/routing.ts
@@ -27,12 +27,21 @@ type CodexUpstreamHealth = {
   consecutiveFailures: number;
   lastFailureStatus?: number;
   lastFailureAt?: number;
+  /** Hard cooldown (quota 429). Survives a later 2xx; blocks auth + selection. */
   cooldownUntil?: number;
+  /**
+   * Soft avoid after connect_error / timeout / transient 5xx. Cleared on 2xx.
+   * Blocks pool selection + thread affinity reuse so a sticky session can leave a
+   * flaky account without throwing CodexAccountCooldownError (hard-only).
+   */
+  softAvoidUntil?: number;
 };
 
 const CODEX_DEFAULT_QUOTA_COOLDOWN_MS = 60_000;
 const CODEX_MAX_QUOTA_COOLDOWN_MS = 24 * 60 * 60_000;
 export const CODEX_FAILURE_WINDOW_MS = 5 * 60_000;
+/** How long a transient failure keeps the account out of pool selection. */
+export const CODEX_TRANSIENT_SOFT_AVOID_MS = 30_000;
 export const CODEX_THREAD_AFFINITY_IDLE_TTL_MS = 24 * 60 * 60_000;
 export const CODEX_THREAD_AFFINITY_MAX_ENTRIES = 2048;
 // Min interval between quota threshold re-evaluations for a single bound thread.
@@ -47,6 +56,8 @@ export type CodexUpstreamOutcomeMeta = {
   retryAfter?: string | null;
   resetAt?: unknown | unknown[];
   now?: number;
+  /** When set, clears affinity for this thread immediately on transient failure. */
+  threadId?: string | null;
 };
 
 function hasConfiguredPoolAccount(config: OcxConfig, accountId: string): boolean {
@@ -162,8 +173,21 @@ export function isCodexAccountInCooldown(accountId: string, now = Date.now()): b
   return getCodexAccountCooldownUntil(accountId, now) !== null;
 }
 
+export function getCodexAccountSoftAvoidUntil(accountId: string, now = Date.now()): number | null {
+  const softAvoidUntil = upstreamHealth.get(accountId)?.softAvoidUntil;
+  return typeof softAvoidUntil === "number" && Number.isFinite(softAvoidUntil) && softAvoidUntil > now
+    ? softAvoidUntil
+    : null;
+}
+
+export function isCodexAccountSoftAvoided(accountId: string, now = Date.now()): boolean {
+  return getCodexAccountSoftAvoidUntil(accountId, now) !== null;
+}
+
 function isCodexAccountSelectable(config: OcxConfig, accountId: string, now: number): boolean {
-  return !isCodexAccountInCooldown(accountId, now) && isCodexAccountUsable(config, accountId);
+  return !isCodexAccountInCooldown(accountId, now)
+    && !isCodexAccountSoftAvoided(accountId, now)
+    && isCodexAccountUsable(config, accountId);
 }
 
 function isThreadAffinityExpired(entry: ThreadAffinityEntry, now: number): boolean {
@@ -215,6 +239,7 @@ function getEligiblePoolAccounts(config: OcxConfig, excludeId?: string, now = Da
   const ids = (config.codexAccounts ?? [])
     .filter(account => !account.isMain && account.id !== excludeId && !isAccountNeedsReauth(account.id))
     .filter(account => !isCodexAccountInCooldown(account.id, now))
+    .filter(account => !isCodexAccountSoftAvoided(account.id, now))
     .filter(account => isCodexAccountUsable(config, account.id))
     .map(account => account.id);
   // The main Codex account is not stored in config.codexAccounts; include it as a
@@ -223,6 +248,7 @@ function getEligiblePoolAccounts(config: OcxConfig, excludeId?: string, now = Da
     excludeId !== MAIN_CODEX_ACCOUNT_ID
     && !isAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID)
     && !isCodexAccountInCooldown(MAIN_CODEX_ACCOUNT_ID, now)
+    && !isCodexAccountSoftAvoided(MAIN_CODEX_ACCOUNT_ID, now)
     && isCodexAccountUsable(config, MAIN_CODEX_ACCOUNT_ID)
   ) {
     ids.unshift(MAIN_CODEX_ACCOUNT_ID);
@@ -352,6 +378,9 @@ export function resolveCodexAccountForThreadDetailed(
     if (
       isThreadAffinityGenerationLive(entry)
       && isCodexAccountSelectable(config, entry.accountId, now)
+      // Affined threads must leave a failing account once the streak trips failover
+      // (soft-avoid covers the first-hit case; this catches post-avoid residual streaks).
+      && !shouldFailover(config, entry.accountId, now)
     ) {
       entry.lastUsedAt = now;
       // Periodic quota re-eval: a long-lived bound thread must still switch when
@@ -420,6 +449,7 @@ export function recordCodexUpstreamOutcome(
   const now = meta.now ?? Date.now();
   const outcomeClass = classifyCodexUpstreamOutcome(outcome);
   if (outcomeClass === "success") {
+    // Soft avoid clears on success; hard quota cooldown intentionally survives.
     const cooldownUntil = getCodexAccountCooldownUntil(accountId, now);
     if (cooldownUntil) upstreamHealth.set(accountId, { consecutiveFailures: 0, cooldownUntil });
     else upstreamHealth.delete(accountId);
@@ -454,15 +484,40 @@ export function recordCodexUpstreamOutcome(
     return;
   }
 
+  // transient (connect_error / timeout / 5xx)
   const current = upstreamHealth.get(accountId);
   const stale = current?.lastFailureAt ? now - current.lastFailureAt > CODEX_FAILURE_WINDOW_MS : false;
-  const cooldownUntil = getCodexAccountCooldownUntil(accountId, now) ?? undefined;
+  const hardCooldownUntil = getCodexAccountCooldownUntil(accountId, now) ?? undefined;
+  // Soft avoid + affinity clears are part of failover. When threshold is 0, leave
+  // sticky sessions alone (same as shouldFailover / applyFailureFailover no-ops).
+  const failoverEnabled = (config.upstreamFailoverThreshold ?? 3) > 0;
+  const softAvoidUntil = failoverEnabled
+    ? Math.max(
+      getCodexAccountSoftAvoidUntil(accountId, now) ?? 0,
+      now + CODEX_TRANSIENT_SOFT_AVOID_MS,
+    )
+    : undefined;
   upstreamHealth.set(accountId, {
     consecutiveFailures: stale ? 1 : (current?.consecutiveFailures ?? 0) + 1,
     lastFailureStatus,
     lastFailureAt: now,
-    ...(cooldownUntil ? { cooldownUntil } : {}),
+    ...(hardCooldownUntil ? { cooldownUntil: hardCooldownUntil } : {}),
+    ...(softAvoidUntil !== undefined ? { softAvoidUntil } : {}),
   });
+  // Drop this thread's pin immediately so the next continue can rebind without
+  // waiting for the soft-avoid selectable check. Guard: only delete when the
+  // thread is still pinned to the FAILING account — a late failure from account A
+  // must not delete a newer healthy binding to account B (race: T→A, A fails,
+  // T→B, late A failure must not delete B's mapping).
+  if (failoverEnabled && meta.threadId) {
+    const bound = threadAccountMap.get(meta.threadId);
+    if (bound?.accountId === accountId) threadAccountMap.delete(meta.threadId);
+  }
+  // Once the account is past the failover streak, clear every thread still pinned
+  // to it — matching 429 affinity behavior so "continue" cannot stay on a bad peer.
+  if (shouldFailover(config, accountId, now)) {
+    clearThreadAccountMapForAccount(accountId);
+  }
   if (config.activeCodexAccountId === accountId) applyFailureFailover(config, accountId, now);
 }
 

--- a/src/lib/upstream-retry.ts
+++ b/src/lib/upstream-retry.ts
@@ -149,6 +149,27 @@ export type UpstreamSendRecovery = "connection-reset" | "transient-5xx";
 type ReplayableFetch = (recovery?: UpstreamSendRecovery) => Promise<Response>;
 
 /**
+ * Opt out of Bun's keep-alive pool after a connection-reset retry.
+ *
+ * Prefer the Bun fetch extension `keepalive: false` (transport-level) over
+ * relying on the hop-by-hop `Connection: close` header alone — Bun has ignored
+ * that header in past releases (oven-sh/bun#20492), so a header-only retry can
+ * still reuse the same half-closed pooled socket. Still set Connection: close
+ * as a belt-and-suspenders signal for intermediaries that honor it.
+ */
+export function applyUpstreamRecoveryInit<T extends RequestInit>(
+  init: T,
+  recovery?: UpstreamSendRecovery,
+): T & { headers: Headers } {
+  const headers = new Headers(init.headers);
+  if (recovery !== "connection-reset") {
+    return { ...init, headers };
+  }
+  headers.set("connection", "close");
+  return { ...init, headers, keepalive: false };
+}
+
+/**
  * Run `doFetch`, retrying only connection-reset-shaped rejections (see
  * isConnectionResetError) with jittered backoff. The caller's thunk must be replay-safe
  * (string body); every retry is logged so persistent resets stay visible.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -537,7 +537,7 @@ export function startServer(port?: number) {
         void (async () => {
           const start = Date.now();
           const requestId = nextRequestLogId(start);
-          const logCtx = { model: "unknown", provider: "unknown" };
+          const logCtx: RequestLogContext = { model: "unknown", provider: "unknown" };
           let logged = false;
           const finalizeLog = (
             status: number,
@@ -556,7 +556,7 @@ export function startServer(port?: number) {
             body: JSON.stringify({ ...payload, stream: true }),
           });
           try {
-            let terminalRecorder: ((status: ResponsesTerminalStatus) => void) | undefined;
+            let terminalRecorder: ((status: ResponsesTerminalStatus, httpStatusOverride?: number) => void) | undefined;
             const response = await handleResponses(req, config, logCtx, {
               forceEmptyResponseId: true,
               abortSignal: turnAbort.signal,
@@ -570,7 +570,7 @@ export function startServer(port?: number) {
             await sendResponseToWebSocket(ws, response, isCurrent, {
               onSsePayload: payload => inspectResponseLogSsePayload(logCtx, payload),
               onTerminal: status => {
-                terminalRecorder?.(status);
+                terminalRecorder?.(status, logCtx.terminalHttpStatus);
                 finalizeLog(httpStatusForRequestLogTerminal(status, logCtx), {
                   terminalStatus: status,
                   closeReason: "terminal",

--- a/src/server/responses.ts
+++ b/src/server/responses.ts
@@ -55,7 +55,7 @@ import {
   recordCodexUpstreamOutcome,
   type CodexUpstreamOutcome,
 } from "../codex/routing";
-import { fetchWithResetRetry, fetchWithTransientRetry } from "../lib/upstream-retry";
+import { fetchWithResetRetry, fetchWithTransientRetry, applyUpstreamRecoveryInit } from "../lib/upstream-retry";
 import { ForwardAdmissionCredentialError, validateForwardAdmissionCredential } from "./auth-cors";
 import { listOpenAiForwardSidecarCandidates, resolveFirstUsableOpenAiSidecar, type ResolvedOpenAiForwardSidecar } from "../providers/openai-sidecar";
 import { applyOpenAiVirtualModel, resolveOpenAiCompactModel } from "../providers/openai-virtual-models";
@@ -395,9 +395,13 @@ export function sanitizeEncryptedContentInPlace(input: unknown): number {
   return rewritten;
 }
 
-export function sidecarOutcomeRecorder(config: OcxConfig, authCtx: CodexAuthContext): ((outcome: CodexUpstreamOutcome) => void) | undefined {
+export function sidecarOutcomeRecorder(
+  config: OcxConfig,
+  authCtx: CodexAuthContext,
+  threadId?: string | null,
+): ((outcome: CodexUpstreamOutcome) => void) | undefined {
   return authCtx.kind === "pool" || authCtx.kind === "main-pool"
-    ? outcome => recordCodexUpstreamOutcome(config, authCtx.accountId, outcome)
+    ? outcome => recordCodexUpstreamOutcome(config, authCtx.accountId, outcome, { threadId })
     : undefined;
 }
 
@@ -418,9 +422,21 @@ export function codexForwardTerminalOutcomeRecorder(
   config: OcxConfig,
   authCtx: CodexAuthContext,
   provider: OcxProviderConfig,
+  logCtx?: RequestLogContext,
+  threadId?: string | null,
 ): ((status: ResponsesTerminalStatus) => void) | undefined {
   if (!usesCodexForwardPoolAuth(authCtx, provider)) return undefined;
-  return status => recordCodexUpstreamOutcome(config, authCtx.accountId, status === "completed" ? 200 : 502);
+  return status => {
+    // Use the semantic HTTP status derived from the terminal SSE error payload
+    // (httpStatusFromTerminalError in request-log inspection) instead of collapsing
+    // every non-completed terminal to 502. A 400 invalid_request_error must not
+    // soft-avoid the account or rebind threads — only genuine transport/5xx failures
+    // should trigger transient health recording.
+    const outcome = status === "completed"
+      ? 200
+      : (logCtx?.terminalHttpStatus ?? 502);
+    recordCodexUpstreamOutcome(config, authCtx.accountId, outcome, { threadId });
+  };
 }
 
 /**
@@ -1092,11 +1108,11 @@ export async function handleResponses(
       upstreamResponse = await fetchWithTransientRetry(
         recovery => {
           noteAttemptSend(logCtx.activeAttempt, passthroughEstimate, recovery);
-          return fetchWithHeaderTimeout(request.url, {
+          return fetchWithHeaderTimeout(request.url, applyUpstreamRecoveryInit({
             method: request.method,
             headers: request.headers,
             body: request.body,
-          }, upstream.signal, connectMs, parsed.stream, providerFetch(route.provider));
+          }, recovery), upstream.signal, connectMs, parsed.stream, providerFetch(route.provider));
         },
         { abortSignal: upstream.signal, label: safeHostLabel(request.url) },
       );
@@ -1104,7 +1120,11 @@ export async function handleResponses(
       upstream.abort();
       if (options.abortSignal?.aborted) return clientCancelledResponse();
       const outcome = err instanceof Error && err.name === "TimeoutError" ? "timeout" : "connect_error";
-      if (usesCodexForwardPoolAuth(authCtx, route.provider)) recordCodexUpstreamOutcome(config, authCtx.accountId, outcome);
+      if (usesCodexForwardPoolAuth(authCtx, route.provider)) {
+        recordCodexUpstreamOutcome(config, authCtx.accountId, outcome, {
+          threadId: req.headers.get("x-codex-parent-thread-id"),
+        });
+      }
       const msg = outcome === "timeout"
         ? `Provider connect timeout after ${connectMs}ms`
         : `Provider unreachable: ${err instanceof Error ? err.message : String(err)}`;
@@ -1122,7 +1142,13 @@ export async function handleResponses(
     const passthroughCt = headers.get("content-type")?.toLowerCase();
     const isEventStream = passthroughCt?.includes("text/event-stream")
       || (upstreamResponse.ok && !!upstreamResponse.body && !passthroughCt && parsed.stream);
-    const terminalRecorder = codexForwardTerminalOutcomeRecorder(config, authCtx, route.provider);
+    const terminalRecorder = codexForwardTerminalOutcomeRecorder(
+      config,
+      authCtx,
+      route.provider,
+      logCtx,
+      req.headers.get("x-codex-parent-thread-id"),
+    );
     const terminalBodyWillRecord = !!terminalRecorder && upstreamResponse.ok && isEventStream;
     // Capture quota from upstream response for multi-account tracking
    if (usesCodexForwardPoolAuth(authCtx, route.provider)) {
@@ -1156,6 +1182,7 @@ export async function handleResponses(
         recordCodexUpstreamOutcome(config, authCtx.accountId, upstreamResponse.status, {
         retryAfter: retryAfterRaw,
          resetAt: [primaryResetRaw, secondaryResetRaw, monthlyResetRaw].filter(Boolean),
+         threadId: req.headers.get("x-codex-parent-thread-id"),
         });
       }
     }
@@ -1390,9 +1417,11 @@ export async function handleResponses(
       upstreamResponse = await fetchWithResetRetry(
         recovery => {
           noteAttemptSend(logCtx.activeAttempt, inputTokenEstimate, recovery);
-          return fetchWithHeaderTimeout(request.url, {
-            method: request.method, headers: request.headers, body: request.body,
-          }, upstream.signal, connectMs, parsed.stream, providerFetch(route.provider));
+          return fetchWithHeaderTimeout(request.url, applyUpstreamRecoveryInit({
+            method: request.method,
+            headers: request.headers,
+            body: request.body,
+          }, recovery), upstream.signal, connectMs, parsed.stream, providerFetch(route.provider));
         },
         { abortSignal: upstream.signal, label: safeHostLabel(request.url) },
       );
@@ -1710,10 +1739,11 @@ export async function handleResponsesCompact(
     // headers would run compaction on the wrong account (or 401) whenever a pool account is
     // active for this thread while normal turns succeed.
     let compactProvider = route.provider;
+    let authCtx: CodexAuthContext = { kind: "main", accountId: null };
     const headers = new Headers({ "content-type": "application/json" });
     try {
       if (route.codexAccountMode) {
-        const authCtx = await resolveCodexAuthContext(req.headers, config, route.codexAccountMode);
+        authCtx = await resolveCodexAuthContext(req.headers, config, route.codexAccountMode);
         const selected = headersForCodexAuthContext(req.headers, authCtx);
         compactProvider = applyCodexAuthContextToProvider(route.provider, authCtx, route.codexAccountMode);
         for (const name of FORWARD_HEADERS) {
@@ -1744,19 +1774,54 @@ export async function handleResponsesCompact(
     const base = (compactProvider.baseUrl ?? "").replace(/\/$/, "");
     if (compactProvider.apiKey) headers.set("authorization", `Bearer ${resolveEnvValue(compactProvider.apiKey)}`);
     const { reasoning: _reasoning, ...compactBody } = raw as typeof raw & { reasoning?: unknown };
+    const compactUrl = `${base}/responses/compact`;
+    const compactThreadId = req.headers.get("x-codex-parent-thread-id");
+    const connectMs = config.connectTimeoutMs ?? 200_000;
+    const recordCompactPoolOutcome = (outcome: CodexUpstreamOutcome, meta: { retryAfter?: string | null } = {}) => {
+      if (!usesCodexForwardPoolAuth(authCtx, route.provider)) return;
+      recordCodexUpstreamOutcome(config, authCtx.accountId, outcome, {
+        ...meta,
+        threadId: compactThreadId,
+      });
+    };
     let upstream: Response;
     try {
-      upstream = await fetch(`${base}/responses/compact`, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({ ...compactBody, model: route.modelId }),
-        signal: req.signal,
-      });
-    } catch {
+      // Same connect timeout + keep-alive reset + transient-5xx recovery as /v1/responses —
+      // compact hits the same ChatGPT host and must soft-avoid / clear affinity (#186).
+      upstream = await fetchWithTransientRetry(
+        recovery => fetchWithHeaderTimeout(
+          compactUrl,
+          applyUpstreamRecoveryInit({
+            method: "POST",
+            headers,
+            body: JSON.stringify({ ...compactBody, model: route.modelId }),
+          }, recovery),
+          req.signal,
+          connectMs,
+          false,
+          providerFetch(compactProvider),
+        ),
+        { abortSignal: req.signal, label: safeHostLabel(compactUrl) },
+      );
+    } catch (err) {
       if (req.signal.aborted) return formatErrorResponse(499, "client_cancelled", "Client cancelled compact request");
+      const outcome = err instanceof Error && err.name === "TimeoutError" ? "timeout" : "connect_error";
+      recordCompactPoolOutcome(outcome);
       return formatErrorResponse(502, "upstream_error", "Failed to connect to compact upstream");
     }
-    return bufferCompactResponse(upstream, req.signal);
+    const retryAfter = upstream.headers.get("retry-after");
+    const buffered = await bufferCompactResponse(upstream, req.signal);
+    // Record pool health only after the body is fully delivered (or definitively failed).
+    // A premature 200 would clear soft-avoid while the client still sees a buffer 502.
+    if (buffered.status === 499) {
+      return buffered;
+    }
+    if (upstream.ok && buffered.status >= 500) {
+      recordCompactPoolOutcome("connect_error");
+    } else {
+      recordCompactPoolOutcome(upstream.status, { retryAfter });
+    }
+    return buffered;
   }
 
   // ROUTED model: run the v2 synthetic-compaction turn internally (appends COMPACT_PROMPT, no

--- a/src/server/responses.ts
+++ b/src/server/responses.ts
@@ -424,17 +424,28 @@ export function codexForwardTerminalOutcomeRecorder(
   provider: OcxProviderConfig,
   logCtx?: RequestLogContext,
   threadId?: string | null,
-): ((status: ResponsesTerminalStatus) => void) | undefined {
+): ((status: ResponsesTerminalStatus, httpStatusOverride?: number) => void) | undefined {
   if (!usesCodexForwardPoolAuth(authCtx, provider)) return undefined;
-  return status => {
-    // Use the semantic HTTP status derived from the terminal SSE error payload
-    // (httpStatusFromTerminalError in request-log inspection) instead of collapsing
-    // every non-completed terminal to 502. A 400 invalid_request_error must not
-    // soft-avoid the account or rebind threads — only genuine transport/5xx failures
-    // should trigger transient health recording.
+  return (status, httpStatusOverride) => {
+    if (status === "incomplete") {
+      // Normal limit/content-filter/stall terminal — the account served the
+      // request. Don't penalize account health; record success to clear any
+      // prior soft-avoid so a healthy account isn't stuck avoided.
+      recordCodexUpstreamOutcome(config, authCtx.accountId, 200, { threadId });
+      return;
+    }
+    // status === "completed" or "failed": use the semantic HTTP status derived
+    // from the terminal SSE error payload (httpStatusFromTerminalError in
+    // request-log inspection) instead of collapsing every non-completed terminal
+    // to 502. A 400 invalid_request_error must not soft-avoid the account or
+    // rebind threads — only genuine transport/5xx failures should trigger
+    // transient health recording.
+    // httpStatusOverride: the combo WS path inspects SSE payloads into the parent
+    // logCtx, but this recorder closes over the child logCtx. The caller passes
+    // the parent's terminalHttpStatus so the semantic status is not lost.
     const outcome = status === "completed"
       ? 200
-      : (logCtx?.terminalHttpStatus ?? 502);
+      : (httpStatusOverride ?? logCtx?.terminalHttpStatus ?? 502);
     recordCodexUpstreamOutcome(config, authCtx.accountId, outcome, { threadId });
   };
 }
@@ -482,7 +493,7 @@ interface HandleResponsesOptions {
   onFirstOutput?: () => void;
   onCodexAuthContextResolved?: (context: CodexAuthContext | undefined) => void;
   recordTerminalOutcomes?: boolean;
-  setTerminalOutcomeRecorder?: (recorder: ((status: ResponsesTerminalStatus) => void) | undefined) => void;
+  setTerminalOutcomeRecorder?: (recorder: ((status: ResponsesTerminalStatus, httpStatusOverride?: number) => void) | undefined) => void;
   onNativePassthroughTerminal?: (status: ResponsesTerminalStatus) => void;
   onNativePassthroughCancel?: () => void;
   /** Internal recursion guard; callers outside this module must not set it. */
@@ -624,7 +635,7 @@ async function handleComboResponses(
       body: JSON.stringify(childBody),
     });
     let resolvedAuth: CodexAuthContext | undefined;
-    let terminalRecorder: ((status: ResponsesTerminalStatus) => void) | undefined;
+    let terminalRecorder: ((status: ResponsesTerminalStatus, httpStatusOverride?: number) => void) | undefined;
     const started = Date.now();
     const attempt = beginRequestAttempt(
       (logCtx.attempts?.length ?? 0) + 1,
@@ -1174,8 +1185,8 @@ export async function handleResponses(
         );
       }
       if (terminalBodyWillRecord) {
-        options.setTerminalOutcomeRecorder?.(status => {
-          terminalRecorder(status);
+        options.setTerminalOutcomeRecorder?.((status, httpStatusOverride) => {
+          terminalRecorder(status, httpStatusOverride);
           options.onNativePassthroughTerminal?.(status);
         });
       } else {
@@ -1817,7 +1828,12 @@ export async function handleResponsesCompact(
       return buffered;
     }
     if (upstream.ok && buffered.status >= 500) {
-      recordCompactPoolOutcome("connect_error");
+      // The upstream account returned 200 — it is healthy. The buffering failure
+      // (oversized body exceeding COMPACT_RESPONSE_MAX_BYTES, or a rare mid-read
+      // reset on a small JSON payload) is a local proxy issue, not account flakiness.
+      // Record the upstream status so a deterministic payload-size limit does not
+      // soft-avoid a healthy account and rotate a thread for 30s.
+      recordCompactPoolOutcome(upstream.status, { retryAfter });
     } else {
       recordCompactPoolOutcome(upstream.status, { retryAfter });
     }

--- a/tests/codex-routing.test.ts
+++ b/tests/codex-routing.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   CODEX_FAILURE_WINDOW_MS,
+  CODEX_TRANSIENT_SOFT_AVOID_MS,
   CODEX_THREAD_AFFINITY_IDLE_TTL_MS,
   CODEX_THREAD_AFFINITY_MAX_ENTRIES,
   CODEX_THREAD_AFFINITY_REEVAL_INTERVAL_MS,
@@ -13,8 +14,10 @@ import {
   clearThreadAccountMapForAccount,
   computeCodexUsageScore,
   getCodexAccountCooldownUntil,
+  getCodexAccountSoftAvoidUntil,
   getCodexUpstreamHealth,
   isCodexAccountInCooldown,
+  isCodexAccountSoftAvoided,
   pickLowestUsageCodexAccount,
   parseRetryAfterMs,
   recordCodexUpstreamOutcome,
@@ -198,7 +201,9 @@ describe("codex routing", () => {
     recordCodexUpstreamOutcome(config, "a", 503);
     recordCodexUpstreamOutcome(config, "a", 503);
     recordCodexUpstreamOutcome(config, "a", 503);
-    expect(resolveCodexAccountForThread("existing", config)).toBe("a");
+    // After the failover streak trips, all affinities for "a" are cleared and
+    // the account is soft-avoided — even the previously-bound thread rebinds.
+    expect(resolveCodexAccountForThread("existing", config)).toBe("b");
     expect(resolveCodexAccountForThread("next", config)).toBe("b");
   });
 
@@ -320,18 +325,25 @@ describe("codex routing", () => {
     recordCodexUpstreamOutcome(config, "a", 503, { now: now + CODEX_FAILURE_WINDOW_MS + 1 });
 
     expect(getCodexUpstreamHealth("a")).toMatchObject({ consecutiveFailures: 1, lastFailureStatus: 503 });
-    expect(resolveCodexAccountForThread("stale-failure-next", config)).toBe("a");
+    // Resolve after both the failure window AND the soft-avoid window have expired.
+    const afterBoth = now + CODEX_FAILURE_WINDOW_MS + CODEX_TRANSIENT_SOFT_AVOID_MS + 2;
+    expect(resolveCodexAccountForThread("stale-failure-next", config, afterBoth)).toBe("a");
   });
 
   test("2xx responses reset the failure streak", () => {
     const config = makeConfig();
     updateAccountQuota("a", 10);
     updateAccountQuota("b", 10);
-    recordCodexUpstreamOutcome(config, "a", 503);
-    recordCodexUpstreamOutcome(config, "a", 200);
-    recordCodexUpstreamOutcome(config, "a", 503);
-    recordCodexUpstreamOutcome(config, "a", 503);
-    expect(resolveCodexAccountForThread("next", config)).toBe("a");
+    const now = 1_800_000_000_000;
+    recordCodexUpstreamOutcome(config, "a", 503, { now });
+    recordCodexUpstreamOutcome(config, "a", 200, { now: now + 1 });
+    recordCodexUpstreamOutcome(config, "a", 503, { now: now + 2 });
+    recordCodexUpstreamOutcome(config, "a", 503, { now: now + 3 });
+    // 2 failures after a success (streak=2) is under the failover threshold (3),
+    // but soft-avoid still blocks for 30s. After it expires, "a" is selectable.
+    // Soft-avoid was last set at now+3, so it expires at now+3+30s.
+    const afterSoftAvoid = now + 3 + CODEX_TRANSIENT_SOFT_AVOID_MS + 1;
+    expect(resolveCodexAccountForThread("next", config, afterSoftAvoid)).toBe("a");
   });
 
   test("failure failover can be disabled independently from quota switching", () => {
@@ -634,5 +646,119 @@ describe("codex routing", () => {
     expect(resolveCodexAccountForThread("t1", config, reuse)).toBe("a");
     const nearIdle = reuse + CODEX_THREAD_AFFINITY_IDLE_TTL_MS - 1;
     expect(resolveCodexAccountForThread("t1", config, nearIdle)).toBe("a");
+  });
+
+  // Soft-avoid: transient failures block pool selection for a bounded window.
+  test("single transient failure soft-avoids the account for 30s", () => {
+    const config = makeConfig();
+    const now = 1_800_000_000_000;
+    updateAccountQuota("a", 10);
+    updateAccountQuota("b", 20);
+
+    recordCodexUpstreamOutcome(config, "a", 503, { now });
+
+    expect(isCodexAccountSoftAvoided("a", now + 1)).toBe(true);
+    expect(getCodexAccountSoftAvoidUntil("a", now + 1)).toBe(now + CODEX_TRANSIENT_SOFT_AVOID_MS);
+    // New threads skip the soft-avoided account.
+    expect(resolveCodexAccountForThread("soft-next", config, now + 1)).toBe("b");
+    // After the window expires, the account is selectable again.
+    expect(isCodexAccountSoftAvoided("a", now + CODEX_TRANSIENT_SOFT_AVOID_MS + 1)).toBe(false);
+    // Active switched to "b" during soft-avoid; reset it to verify "a" is selectable.
+    config.activeCodexAccountId = "a";
+    expect(resolveCodexAccountForThread("soft-after", config, now + CODEX_TRANSIENT_SOFT_AVOID_MS + 1)).toBe("a");
+  });
+
+  test("2xx clears soft-avoid but preserves hard quota cooldown", () => {
+    const config = makeConfig();
+    const now = 1_800_000_000_000;
+    // First put "a" into hard cooldown via 429.
+    recordCodexUpstreamOutcome(config, "a", 429, { retryAfter: "120", now });
+    // Then a transient failure adds soft-avoid on top.
+    recordCodexUpstreamOutcome(config, "a", 503, { now: now + 1_000 });
+    expect(isCodexAccountSoftAvoided("a", now + 1_001)).toBe(true);
+
+    // Success clears soft-avoid but the hard cooldown survives.
+    recordCodexUpstreamOutcome(config, "a", 200, { now: now + 2_000 });
+    expect(isCodexAccountSoftAvoided("a", now + 2_001)).toBe(false);
+    expect(isCodexAccountInCooldown("a", now + 2_001)).toBe(true);
+  });
+
+  test("soft-avoid extends on repeated transient failures", () => {
+    const config = makeConfig();
+    const now = 1_800_000_000_000;
+    recordCodexUpstreamOutcome(config, "a", "connect_error", { now });
+    const firstAvoid = getCodexAccountSoftAvoidUntil("a", now);
+    expect(firstAvoid).toBe(now + CODEX_TRANSIENT_SOFT_AVOID_MS);
+
+    // A second failure 10s later extends the window from that point.
+    recordCodexUpstreamOutcome(config, "a", "timeout", { now: now + 10_000 });
+    expect(getCodexAccountSoftAvoidUntil("a", now + 10_001)).toBe(now + 10_000 + CODEX_TRANSIENT_SOFT_AVOID_MS);
+  });
+
+  test("soft-avoid is not applied when failover threshold is 0", () => {
+    const config = makeConfig({ upstreamFailoverThreshold: 0 });
+    const now = 1_800_000_000_000;
+    updateAccountQuota("a", 10);
+    updateAccountQuota("b", 20);
+
+    recordCodexUpstreamOutcome(config, "a", 503, { now });
+    recordCodexUpstreamOutcome(config, "a", 503, { now: now + 1 });
+    recordCodexUpstreamOutcome(config, "a", 503, { now: now + 2 });
+
+    expect(isCodexAccountSoftAvoided("a", now + 3)).toBe(false);
+    expect(resolveCodexAccountForThread("disabled-next", config, now + 3)).toBe("a");
+  });
+
+  // Race-safe affinity: late failures must not delete a newer healthy binding.
+  test("late failure from old account does not delete a newer healthy affinity", () => {
+    const config = makeConfig();
+    const now = 1_800_000_000_000;
+    updateAccountQuota("a", 10);
+    updateAccountQuota("b", 20);
+
+    // Bind thread T to account A.
+    expect(resolveCodexAccountForThread("race-thread", config, now)).toBe("a");
+
+    // A fails; thread rebinds to B (soft-avoid pushes selection to B).
+    recordCodexUpstreamOutcome(config, "a", 503, { now: now + 1, threadId: "race-thread" });
+    expect(resolveCodexAccountForThread("race-thread", config, now + 2)).toBe("b");
+
+    // Late failure from A arrives AFTER the thread is already on B.
+    // Must NOT delete B's healthy mapping.
+    recordCodexUpstreamOutcome(config, "a", 503, { now: now + 3, threadId: "race-thread" });
+    expect(resolveCodexAccountForThread("race-thread", config, now + 4)).toBe("b");
+  });
+
+  test("threadId meta clears affinity only for the failing account", () => {
+    const config = makeConfig();
+    const now = 1_800_000_000_000;
+    updateAccountQuota("a", 10);
+    updateAccountQuota("b", 20);
+
+    // Bind to A, then a transient failure with threadId clears the pin.
+    expect(resolveCodexAccountForThread("unbind-thread", config, now)).toBe("a");
+    recordCodexUpstreamOutcome(config, "a", "connect_error", { now: now + 1, threadId: "unbind-thread" });
+    // Next resolve rebinds (to B, since A is soft-avoided).
+    expect(resolveCodexAccountForThread("unbind-thread", config, now + 2)).toBe("b");
+  });
+
+  test("failover streak clears all affinities for the failing account", () => {
+    const config = makeConfig();
+    const now = 1_800_000_000_000;
+    updateAccountQuota("a", 10);
+    updateAccountQuota("b", 20);
+
+    // Bind two threads to A.
+    expect(resolveCodexAccountForThread("t1", config, now)).toBe("a");
+    expect(resolveCodexAccountForThread("t2", config, now + 1)).toBe("a");
+
+    // Three failures trip the failover streak, clearing ALL pins to A.
+    recordCodexUpstreamOutcome(config, "a", 503, { now: now + 2 });
+    recordCodexUpstreamOutcome(config, "a", 503, { now: now + 3 });
+    recordCodexUpstreamOutcome(config, "a", 503, { now: now + 4 });
+
+    // Both threads rebind to B.
+    expect(resolveCodexAccountForThread("t1", config, now + 5)).toBe("b");
+    expect(resolveCodexAccountForThread("t2", config, now + 6)).toBe("b");
   });
 });


### PR DESCRIPTION
## Summary

Rework the transient-failure soft-avoid mechanism to address the two fundamental design issues identified in #194:

### Blocker 1: Non-transient failures no longer trigger soft avoidance

The terminal outcome recorder now uses the semantic HTTP status from `logCtx.terminalHttpStatus` (derived from the SSE error payload via `httpStatusFromTerminalError`) instead of collapsing every non-completed terminal to 502. A `400 invalid_request_error` no longer soft-avoids the account or rebinds threads — only genuine transport/timeout/5xx outcomes trigger transient health recording.

### Blocker 2: Late failures can no longer delete a newer healthy affinity

The `threadId` meta now guards `threadAccountMap.delete` with an ownership check (`bound?.accountId === accountId`), preventing the race: T→A, A fails, T→B, late A failure must not delete B's mapping.

### Additional improvements

- **Transport-level `keepalive: false`** via `applyUpstreamRecoveryInit` for connection-reset retries (Bun has historically ignored the `Connection: close` header alone — oven-sh/bun#20492)
- **Compact endpoint** (`/v1/responses/compact`) now uses the same transient-retry + recovery-init + pool-outcome recording as `/v1/responses`
- **Failover streak clears all affinities** for the failing account (matching 429 behavior)
- **Soft-avoid extends** on repeated transient failures and clears on 2xx (hard quota cooldown intentionally survives)
- **Affinity reuse checks `shouldFailover`** to catch post-avoid residual streaks

## Test plan

- [x] `bun x tsc --noEmit` — clean
- [x] `bun test ./tests/codex-routing.test.ts` — 51 pass, 0 fail (7 new tests for soft-avoid + race-safe affinity)
- [x] `bun test ./tests/upstream-retry.test.ts` — 14 pass
- [x] `bun test ./tests/responses-parser.test.ts` — 19 pass
- [x] `bun test ./tests/server-auth.test.ts` — 58 pass

Closes https://github.com/lidge-jun/opencodex/issues/186