### PR TITLE
fix(gui): expose private-network opt-in for provider presets

### DIFF
--- a/gui/src/components/AddProviderModal.tsx
+++ b/gui/src/components/AddProviderModal.tsx
@@ -475,12 +475,13 @@ export default function AddProviderModal({
                     <input className="input" value={form.baseUrl} onChange={e => setForm({ ...form, baseUrl: e.target.value })} placeholder={t("modal.baseUrlPlaceholder")} />
                   </Field>
                 )}
-                {(isCustom || isLocal) && (
-                  <label className="modal-field" style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
-                    <input type="checkbox" checked={form?.allowPrivateNetwork ?? false} onChange={e => setForm(f => f ? { ...f, allowPrivateNetwork: e.target.checked } : f)} />
+                <label className="modal-field" style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
+                  <input type="checkbox" checked={form?.allowPrivateNetwork ?? false} onChange={e => setForm(f => f ? { ...f, allowPrivateNetwork: e.target.checked } : f)} />
+                  <span>
                     <span className="muted text-control">{t("modal.allowPrivateNetwork")}</span>
-                  </label>
-                )}
+                    <span className="muted text-label" style={{ display: "block" }}>{t("modal.allowPrivateNetworkHint")}</span>
+                  </span>
+                </label>
               </>}
               {form.authMode === "forward" ? (
                 <div className="text-label" style={{ color: "var(--green)", background: "var(--green-soft)", border: "1px solid var(--green)", borderRadius: "var(--radius-sm)", padding: "8px 10px" }}>

--- a/tests/provider-payload.test.ts
+++ b/tests/provider-payload.test.ts
@@ -13,6 +13,13 @@ import { deriveProviderPresets, providerConfigSeed } from "../src/providers/deri
 import { PROVIDER_REGISTRY } from "../src/providers/registry";
 
 describe("provider dashboard payload", () => {
+  test("offers private-network opt-in while adding built-in cloud providers", async () => {
+    const modal = await Bun.file("gui/src/components/AddProviderModal.tsx").text();
+    expect(modal).not.toContain("{(isCustom || isLocal) && (");
+    expect(modal).toContain('t("modal.allowPrivateNetwork")');
+    expect(modal).toContain('t("modal.allowPrivateNetworkHint")');
+  });
+
   test("persists explicit API-key mode for built-in OAuth providers", () => {
     expect(buildProviderPayload({
       name: "xai",


### PR DESCRIPTION
## Summary

- show the existing `allowPrivateNetwork` checkbox for built-in provider presets, not only custom/local providers
- render the existing security warning next to the opt-in
- cover the DeepSeek/Clash fake-IP regression in the provider dashboard test

This keeps the setting disabled by default and does not auto-approve private destinations.

Fixes #212

## Verification

- `bun run typecheck`
- `bun run lint:gui`
- `bun run privacy:scan`
- `bun test --isolate tests/provider-payload.test.ts` (9 passed)
- `cd gui && bun run build`

The full local suite reached 3298 passes and 5 unrelated `server-auth.test.ts` failures because this machine intentionally resolves public fixture hosts into Clash/Mihomo `198.18.0.0/16` fake-IP space; the focused regression and all GUI/type/privacy gates pass.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No public behavior docs currently describe this advanced toggle.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.