### PR TITLE
fix(responses): strip mismatched agent_message item ids before passthrough

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -57,6 +57,7 @@ function stripInvalidItemIds(body: unknown): unknown {
 
   const validPrefixes: Record<string, string> = {
     message: "msg_",
+    agent_message: "amsg_",
     reasoning: "rs_",
     function_call: "fc_",
     custom_tool_call: "ctc_",

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -41,6 +41,8 @@ describe("OpenAI Responses passthrough sanitization", () => {
       { item: { type: "tool_search_call", id: "tsc_1", call_id: "call_5", execution: "client", arguments: {} }, expectedId: "tsc_1" },
       { item: { type: "web_search_call", id: "fc_wrong", status: "completed" }, expectedId: undefined },
       { item: { type: "web_search_call", id: "ws_valid", status: "completed" }, expectedId: "ws_valid" },
+      { item: { type: "agent_message", id: "msg_wrong-dialect", content: [{ type: "output_text", text: "routed reply" }] }, expectedId: undefined },
+      { item: { type: "agent_message", id: "amsg_1", content: [{ type: "output_text", text: "routed reply" }] }, expectedId: "amsg_1" },
     ];
     const input = cases.map(({ item }) => item);
     const request = adapter.buildRequest({


### PR DESCRIPTION
## Summary

- `stripInvalidItemIds` strips input item ids whose prefix does not match the item type, but `agent_message` is missing from the map. A replayed `agent_message` whose id lost its `amsg_` prefix (dialect-mixed thread history) makes the ChatGPT Responses backend reject the whole request with `Invalid 'input[N].id': 'msg_…'. Expected an ID that begins with 'amsg'.` — and since the same history is resent on every retry, the thread is permanently bricked.
- Add the missing `agent_message → amsg_` mapping so mismatched ids are stripped exactly like every other item type.
- Observed in production on 2026-07-21: two Codex app threads bricked with this 400 through the proxy; stripping/normalizing the id at the passthrough boundary resolved both.

## Verification

- `bun test tests/openai-responses-passthrough.test.ts` — 17 pass, 0 fail (adds 2 cases: mismatched `msg_*` id stripped, valid `amsg_*` id preserved)
- `bun test --isolate ./tests/` — 3295 pass; the 3 remaining failures reproduce identically on a clean `dev` checkout (winsw.test.ts reads the local service port config, GUI tests miss gui workspace deps, vision sidecar offline) and are unrelated to this change

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [ ] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)