### PR TITLE
fix(winsw): detect sc.exe error 1060 under Bun truncation and localized output

### DIFF
--- a/src/lib/winsw.ts
+++ b/src/lib/winsw.ts
@@ -223,7 +223,12 @@ export function probeScmRegistration(run: () => string = queryScmForService): bo
     const text = [e.stderr, e.stdout, e.message]
       .map(v => (typeof v === "string" ? v : ""))
       .join("\n");
-    if (e.status === 1060 || /FAILED 1060/i.test(text)) return false;
+    // Two traps hide the 1060 signal:
+    // 1. Bun on Windows truncates exit codes to 8 bits, so 1060 arrives as status 36.
+    // 2. sc.exe localizes the "FAILED" prefix (pt-BR "FALHA 1060", de-DE "FEHLER 1060", ...).
+    // The numeric Win32 code itself is locale-independent and always printed, so match it
+    // with word boundaries (guards against 10600 etc.) anywhere in the captured output.
+    if (e.status === 1060 || /\b1060\b/.test(text)) return false;
     return "error";
   }
 }

--- a/src/lib/winsw.ts
+++ b/src/lib/winsw.ts
@@ -219,9 +219,13 @@ export function probeScmRegistration(run: () => string = queryScmForService): bo
   } catch (err) {
     const e = err as { status?: number | null; stderr?: string | Buffer | null; stdout?: string | Buffer | null; message?: string };
     // sc.exe does not reliably channel the 1060 line — it can land on stderr OR stdout
-    // depending on the host — so scan every captured stream and the error message.
-    const text = [e.stderr, e.stdout, e.message]
-      .map(v => (typeof v === "string" ? v : ""))
+    // depending on the host — so scan both captured streams.
+    // e.message is intentionally excluded: it is a Node wrapper string that can embed
+    // arbitrary content (paths, spawn messages) that may contain "1060" coincidentally,
+    // which would produce a false confirmed-absence on an unrelated failure.
+    // Buffer values are decoded via .toString() to guard against missing encoding option.
+    const text = [e.stderr, e.stdout]
+      .map(v => (v instanceof Buffer ? v.toString() : typeof v === "string" ? v : ""))
       .join("\n");
     // Two traps hide the 1060 signal:
     // 1. Bun on Windows truncates exit codes to 8 bits, so 1060 arrives as status 36.

--- a/tests/winsw.test.ts
+++ b/tests/winsw.test.ts
@@ -134,6 +134,18 @@ describe("winsw fail-closed lifecycle", () => {
     expect(probeScmRegistration(() => { throw new Error("spawn sc.exe ENOENT"); })).toBe("error");
   });
 
+  test("SCM probe detects 1060 under Bun exit-code truncation and localized sc.exe output", () => {
+    // Bun on Windows truncates exit codes to 8 bits: 1060 arrives as status 36 (#216).
+    expect(probeScmRegistration(() => { const e = new Error("fail") as Error & { status: number; stderr: string }; e.status = 36; e.stderr = "[SC] OpenService FAILED 1060:"; throw e; })).toBe(false);
+    // Localized sc.exe output: the "FAILED" word changes, the numeric code does not.
+    expect(probeScmRegistration(() => { const e = new Error("fail") as Error & { status: number; stderr: string }; e.status = 36; e.stderr = "[SC] OpenService FALHA 1060:"; throw e; })).toBe(false);
+    expect(probeScmRegistration(() => { const e = new Error("fail") as Error & { status: number; stderr: string }; e.status = 1; e.stderr = "[SC] OpenService FEHLER 1060:"; throw e; })).toBe(false);
+    // Word boundary: a longer number containing 1060 is NOT proof of absence.
+    expect(probeScmRegistration(() => { const e = new Error("fail") as Error & { status: number; stderr: string }; e.status = 1; e.stderr = "[SC] OpenService FAILED 10600:"; throw e; })).toBe("error");
+    // Truncated status 36 alone (no 1060 in any stream) is NOT proof of absence.
+    expect(probeScmRegistration(() => { const e = new Error("denied") as Error & { status: number }; e.status = 36; throw e; })).toBe("error");
+  });
+
   test("uninstall removes a stale SCM registration via sc.exe when the exe is gone", () => {
     const winsw = readFileSync(new URL("../src/lib/winsw.ts", import.meta.url), "utf8");
     const fn = winsw.slice(winsw.indexOf("export function uninstallWinswService"), winsw.indexOf("export function winswStatusSummary"));

--- a/tests/winsw.test.ts
+++ b/tests/winsw.test.ts
@@ -146,6 +146,15 @@ describe("winsw fail-closed lifecycle", () => {
     expect(probeScmRegistration(() => { const e = new Error("denied") as Error & { status: number }; e.status = 36; throw e; })).toBe("error");
   });
 
+  test("SCM probe guards e.message false positives and decodes Buffer streams", () => {
+    // e.message may embed "1060" incidentally (paths, spawn text) — must NOT count as absence.
+    expect(probeScmRegistration(() => { const e = new Error("Command failed: sc.exe query opencodex-proxy-native [1060]") as Error & { status: number }; e.status = 1; throw e; })).toBe("error");
+    // Buffer-typed stderr is decoded and still matched correctly.
+    expect(probeScmRegistration(() => { const e = new Error("fail") as Error & { status: number; stderr: Buffer }; e.status = 1; e.stderr = Buffer.from("[SC] OpenService FAILED 1060:"); throw e; })).toBe(false);
+    // Buffer-typed stdout likewise.
+    expect(probeScmRegistration(() => { const e = new Error("fail") as Error & { status: number; stdout: Buffer }; e.status = 36; e.stdout = Buffer.from("FALHA 1060"); throw e; })).toBe(false);
+  });
+
   test("uninstall removes a stale SCM registration via sc.exe when the exe is gone", () => {
     const winsw = readFileSync(new URL("../src/lib/winsw.ts", import.meta.url), "utf8");
     const fn = winsw.slice(winsw.indexOf("export function uninstallWinswService"), winsw.indexOf("export function winswStatusSummary"));


### PR DESCRIPTION
## Problem

`probeScmRegistration()` missed `ERROR_SERVICE_DOES_NOT_EXIST` (1060) on non-English Windows under Bun, so `ocx service` / `ocx update` aborted with a false "possibly installed" verdict. Two compounding traps:

1. **Bun truncates exit codes to 8 bits on Windows** — `sc.exe` exit 1060 arrives as `status 36` (1060 % 256), so the numeric guard never matches.
2. **sc.exe localizes the `FAILED` prefix** — pt-BR prints `FALHA 1060`, de-DE `FEHLER 1060`, etc., so `/FAILED 1060/i` only matches English output.

The probe then returned `"error"` instead of confirmed absence, and lifecycle callers correctly fail closed on `"error"` — blocking installs and updates entirely.

## Fix

This implements the solution proposed in the issue, which is the right one: the numeric Win32 code `1060` is locale-independent and always printed by sc.exe, so match it anywhere in the captured streams with word boundaries:

```ts
if (e.status === 1060 || /\b1060\b/.test(text)) return false;
```

- `e.status === 1060` kept for runtimes without truncation.
- `\b` word boundaries guard against longer numbers (`10600`) — verified by test.
- Bare truncated `status 36` with no `1060` in any stream still returns `"error"` (fail-closed preserved) — verified by test.

Alternatives considered and rejected: special-casing `status === 36` alone (could be a different error), and matching localized `FAILED` words (unbounded list; the numeric code is the stable signal).

## Tests

New test case `SCM probe detects 1060 under Bun exit-code truncation and localized sc.exe output` in `tests/winsw.test.ts` covers: Bun-truncated `status: 36` + `FAILED 1060`, pt-BR `FALHA 1060`, de-DE `FEHLER 1060`, `10600` word-boundary guard → `"error"`, and bare `status 36` → `"error"`.

Verified: `bun test --isolate ./tests/winsw.test.ts` (22 pass), `bun test --isolate ./tests/service.test.ts` (30 pass), `bun x tsc --noEmit` clean.

Closes #216