### PR TITLE
feat: add Gemini 3.6 Flash and 3.5 Flash-Lite

### DIFF
--- a/src/providers/antigravity-models.ts
+++ b/src/providers/antigravity-models.ts
@@ -5,6 +5,9 @@
 // client aliases. The CCA envelope's `model` field must receive the wire id (for example
 // "Gemini 3.1 Pro (High)" => gemini-pro-agent), while the picker can expose label-shaped aliases.
 const ANTIGRAVITY_WIRE_MODELS = [
+  "gemini-3.6-flash-medium",
+  "gemini-3.6-flash-low",
+  "gemini-3.6-flash-high",
   "gemini-3.5-flash-low",
   "gemini-3-flash-agent",
   "gemini-3.5-flash-extra-low",
@@ -16,6 +19,7 @@ const ANTIGRAVITY_WIRE_MODELS = [
 ];
 
 export const ANTIGRAVITY_MODEL_ALIASES: Record<string, string> = {
+  "gemini-3.6-flash": "gemini-3.6-flash-medium",
   "gemini-3.5-flash-mid": "gemini-3.5-flash-low",
   "gemini-3.5-flash-high": "gemini-3-flash-agent",
   "gemini-3.1-pro-high": "gemini-pro-agent",
@@ -29,6 +33,9 @@ export const ANTIGRAVITY_MODELS = [
 
 // Context windows from the upstream `:fetchAvailableModels` maxTokens per model.
 const ANTIGRAVITY_WIRE_MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+  "gemini-3.6-flash-medium": 1_048_576,
+  "gemini-3.6-flash-low": 1_048_576,
+  "gemini-3.6-flash-high": 1_048_576,
   "gemini-3.5-flash-low": 1_048_576,
   "gemini-3-flash-agent": 1_048_576,
   "gemini-3.5-flash-extra-low": 1_048_576,

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -632,10 +632,17 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
   // devlog/_plan/260710_provider_hardening/001_research_frontier.md.
   {
     id: "google", label: "Google Gemini", adapter: "google", baseUrl: "https://generativelanguage.googleapis.com", authKind: "key", featured: true,
-    dashboardUrl: "https://aistudio.google.com/apikey", defaultModel: "gemini-3.5-flash", models: ["gemini-3.5-flash", "gemini-3.1-pro-preview"],
-    modelContextWindows: { "gemini-3.5-flash": 1_000_000 },
+    dashboardUrl: "https://aistudio.google.com/apikey", defaultModel: "gemini-3.5-flash",
+    models: ["gemini-3.6-flash", "gemini-3.5-flash", "gemini-3.5-flash-lite", "gemini-3.1-pro-preview"],
+    modelContextWindows: {
+      "gemini-3.6-flash": 1_048_576,
+      "gemini-3.5-flash": 1_000_000,
+      "gemini-3.5-flash-lite": 1_048_576,
+    },
     modelReasoningEfforts: {
+      "gemini-3.6-flash": ["minimal", "low", "medium", "high"],
       "gemini-3.5-flash": ["minimal", "low", "medium", "high"],
+      "gemini-3.5-flash-lite": ["minimal", "low", "medium", "high"],
       "gemini-3.1-pro-preview": ["low", "medium", "high"],
     },
     jawcodeBundle: "google", extraMetadataAliases: ["gemini"],

--- a/tests/google-antigravity-wire.test.ts
+++ b/tests/google-antigravity-wire.test.ts
@@ -54,6 +54,7 @@ describe("antigravity CCA envelope", () => {
 
   test("client-visible Antigravity aliases resolve to CCA wire model ids", async () => {
     for (const [alias, wire] of [
+      ["gemini-3.6-flash", "gemini-3.6-flash-medium"],
       ["gemini-3.5-flash-mid", "gemini-3.5-flash-low"],
       ["gemini-3.5-flash-high", "gemini-3-flash-agent"],
       ["gemini-3.1-pro-high", "gemini-pro-agent"],

--- a/tests/google-hardening.test.ts
+++ b/tests/google-hardening.test.ts
@@ -116,10 +116,23 @@ describe("google provider hardening", () => {
     const vertex = PROVIDER_REGISTRY.find(entry => entry.id === "google-vertex");
 
     expect(google?.defaultModel).toBe("gemini-3.5-flash");
-    expect(google?.models).toEqual(["gemini-3.5-flash", "gemini-3.1-pro-preview"]);
+    expect(google?.models).toEqual([
+      "gemini-3.6-flash",
+      "gemini-3.5-flash",
+      "gemini-3.5-flash-lite",
+      "gemini-3.1-pro-preview",
+    ]);
+    expect(google?.modelContextWindows?.["gemini-3.6-flash"]).toBe(1_048_576);
+    expect(google?.modelContextWindows?.["gemini-3.5-flash-lite"]).toBe(1_048_576);
     expect(google?.modelContextWindows?.["gemini-3.5-flash"]).toBe(1_000_000);
     expect(google?.modelContextWindows?.["gemini-3.1-pro-preview"]).toBeUndefined();
     expect(google?.modelReasoningEfforts?.["gemini-3.5-flash"]).toEqual([
+      "minimal", "low", "medium", "high",
+    ]);
+    expect(google?.modelReasoningEfforts?.["gemini-3.6-flash"]).toEqual([
+      "minimal", "low", "medium", "high",
+    ]);
+    expect(google?.modelReasoningEfforts?.["gemini-3.5-flash-lite"]).toEqual([
       "minimal", "low", "medium", "high",
     ]);
     expect(google?.modelReasoningEfforts?.["gemini-3.1-pro-preview"]).toEqual([

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -549,7 +549,9 @@ describe("provider registry parity", () => {
     expect(OAUTH_PROVIDERS.xai.providerConfig.noVisionModels).toContain("grok-build-0.1");
     expect(OAUTH_PROVIDERS["google-antigravity"].providerConfig.models).toContain("gemini-3.5-flash-mid");
     expect(OAUTH_PROVIDERS["google-antigravity"].providerConfig.models).toContain("gemini-3.5-flash-high");
+    expect(OAUTH_PROVIDERS["google-antigravity"].providerConfig.models).toContain("gemini-3.6-flash");
     expect(OAUTH_PROVIDERS["google-antigravity"].providerConfig.models).toContain("gemini-3.1-pro-high");
+    expect(OAUTH_PROVIDERS["google-antigravity"].providerConfig.modelContextWindows?.["gemini-3.6-flash"]).toBe(1_048_576);
     expect(OAUTH_PROVIDERS["google-antigravity"].providerConfig.modelContextWindows?.["gemini-3.1-pro-high"]).toBe(1_048_576);
   });
 


### PR DESCRIPTION
## Summary

- add `gemini-3.6-flash` and `gemini-3.5-flash-lite` to the Google Gemini provider catalog
- expose the live Antigravity `gemini-3.6-flash-{low,medium,high}` wire models
- map the client-facing `gemini-3.6-flash` alias to Antigravity's medium/default wire model
- record 1,048,576-token context windows and supported thinking levels

## Why

Google released Gemini 3.6 Flash and Gemini 3.5 Flash-Lite, while the Antigravity `fetchAvailableModels` response now advertises the 3.6 Flash low, medium, and high wire IDs. This keeps the bundled catalog and request alias resolution aligned with the available upstream models.

Gemini 3.5 Flash Cyber is intentionally excluded because Google currently limits it to a CodeMender pilot rather than a public Gemini API or Antigravity endpoint.

## Validation

- `bun test tests/google-hardening.test.ts tests/google-antigravity-wire.test.ts tests/provider-registry-parity.test.ts` — 48 passed
- `bun run typecheck`
