### PR TITLE
fix(codex): clamp advertised reasoning efforts to the installed binary's ladder (unbreaks Codex 0.133.0)

### DIFF
--- a/src/codex/catalog.ts
+++ b/src/codex/catalog.ts
@@ -690,7 +690,13 @@ export function materializeBundledCodexCatalog(path: string, deps: BundledCatalo
 
 function loadCatalogForSync(path: string): RawCatalog | null {
   const bundled = isDefaultCatalogPath(path) ? loadBundledCodexCatalog() : null;
-  if (bundled) return bundled;
+  // Deep-clone the bundled catalog: syncCatalogModels mutates catalog.models IN PLACE (mergeCatalog-
+  // EntriesForSync/ensureUltraReasoningLevel append the mock max/ultra rungs to the native entries),
+  // and loadBundledCodexCatalog hands back the SHARED 60s cache by reference. Returning it directly
+  // poisons that cache — a later reader in the same process (e.g. codexSupportedReasoningEfforts, or
+  // the /v1/models handler) would then see the pristine bundled ladder as low..ultra and stop
+  // clamping. The clone keeps the cache pristine so the effort probe stays trustworthy.
+  if (bundled) return JSON.parse(JSON.stringify(bundled)) as RawCatalog;
   const catalog = readCatalog(path);
   if (catalog && findNativeTemplate(catalog)) return catalog;
   return readCatalog(catalogBackupPathFor(path))

--- a/src/codex/catalog.ts
+++ b/src/codex/catalog.ts
@@ -830,6 +830,85 @@ function ensureUltraReasoningLevel(entry: RawEntry): void {
 }
 
 /**
+ * Reasoning-effort labels the INSTALLED Codex binary can actually parse, read from its OWN
+ * bundled catalog (`codex debug models --bundled`). codex-rs deserializes every catalog reasoning
+ * level into a strict `ReasoningEffort` enum and rejects the ENTIRE catalog file on the first
+ * unknown variant — Codex 0.133.0 knows none..xhigh but NOT the `max`/`ultra` rungs opencodex mocks
+ * onto every model, so an unguarded catalog fails to load ("failed to create task ... unknown
+ * variant `max`"). The bundled catalog — not the on-disk file, which a prior sync may already have
+ * polluted with max/ultra — is the authoritative record of what the binary accepts. Returns null
+ * when the binary can't be probed (no codex on PATH), so callers keep the prior behavior instead of
+ * clamping against an empty set.
+ */
+export function codexSupportedReasoningEfforts(deps: BundledCatalogDeps = {}): Set<string> | null {
+  const bundled = loadBundledCodexCatalog(deps);
+  if (!bundled) return null;
+  const efforts = new Set<string>();
+  for (const model of bundled.models ?? []) {
+    if (typeof model.slug !== "string" || model.slug.includes("/")) continue;
+    const levels = Array.isArray(model.supported_reasoning_levels) ? model.supported_reasoning_levels : [];
+    for (const level of levels) {
+      const effort = (level as { effort?: unknown })?.effort;
+      if (typeof effort === "string") efforts.add(effort);
+    }
+    if (typeof model.default_reasoning_level === "string") efforts.add(model.default_reasoning_level);
+  }
+  return efforts.size > 0 ? efforts : null;
+}
+
+/**
+ * Repaired `default_reasoning_level` once unsupported rungs are dropped: the highest surviving rung
+ * at or below the original, else the lowest surviving rung. Keeps a model's default effort pointing
+ * at a label the installed binary accepts (e.g. a native defaulted to `max` on Codex 0.133.0 falls
+ * back to `xhigh`).
+ */
+function clampedDefaultEffort(original: string, surviving: readonly string[]): string {
+  if (surviving.length === 0) return original;
+  const ranked = [...surviving]
+    .map(effort => ({ effort, rank: codexEffortRank(effort) }))
+    .sort((a, b) => a.rank - b.rank);
+  const originalRank = codexEffortRank(original);
+  const atOrBelow = ranked.filter(item => item.rank >= 0 && item.rank <= originalRank);
+  return (atOrBelow.at(-1) ?? ranked[0]!).effort;
+}
+
+/**
+ * Drop reasoning rungs the installed Codex can't parse from ONE catalog entry and repair its
+ * default. Never empties a non-empty ladder: the universal low/medium/high rungs are always in the
+ * supported set, so the filter always leaves at least those. No-op when `supported` is null.
+ */
+export function clampEntryToCodexSupportedEfforts(entry: RawEntry, supported: Set<string> | null): void {
+  if (!supported) return;
+  const levels = Array.isArray(entry.supported_reasoning_levels)
+    ? entry.supported_reasoning_levels as Array<{ effort?: string }>
+    : null;
+  if (levels && levels.length > 0) {
+    const kept = levels.filter(level => typeof level?.effort === "string" && supported.has(level.effort));
+    if (kept.length > 0 && kept.length < levels.length) entry.supported_reasoning_levels = kept;
+  }
+  const currentDefault = entry.default_reasoning_level;
+  if (typeof currentDefault === "string" && !supported.has(currentDefault)) {
+    const surviving = (Array.isArray(entry.supported_reasoning_levels) ? entry.supported_reasoning_levels : [])
+      .flatMap(level => typeof (level as { effort?: string })?.effort === "string" ? [(level as { effort: string }).effort] : [])
+      .filter(effort => supported.has(effort));
+    entry.default_reasoning_level = clampedDefaultEffort(currentDefault, surviving);
+  }
+}
+
+/**
+ * Final catalog-emission guard: clamp EVERY entry's reasoning ladder to what the installed Codex
+ * binary can parse. Applied at each on-wire boundary (on-disk sync + the /v1/models catalog shape)
+ * so a mocked max/ultra rung can never reach a codex-rs build whose enum predates it and abort
+ * catalog loading. Returns the same list unchanged when the binary can't be probed.
+ */
+export function clampCatalogModelsToCodexSupport(models: RawEntry[], deps: BundledCatalogDeps = {}): RawEntry[] {
+  const supported = codexSupportedReasoningEfforts(deps);
+  if (!supported) return models;
+  for (const entry of models) clampEntryToCodexSupportedEfforts(entry, supported);
+  return models;
+}
+
+/**
  * Native entry from the pinned upstream snapshot, finished for emission. Keeps the entry's
  * OWN identity (display_name, description, priority, availability_nux — it is the model's own
  * NUX, not another model's) instead of the caller's generic passthrough blurb. The caller's
@@ -1865,7 +1944,7 @@ export function mergeCatalogEntriesForSync(
  *  - the catalog is backed up to ~/.opencodex/catalog-backup.json before writing.
  * No-op if the catalog file does not exist.
  */
-export async function syncCatalogModels(config: OcxConfig): Promise<{ added: number; path: string }> {
+export async function syncCatalogModels(config: OcxConfig, catalogDeps: BundledCatalogDeps = {}): Promise<{ added: number; path: string }> {
   const catalogPath = readCodexCatalogPath();
   const catalog = loadCatalogForSync(catalogPath);
   if (!catalog) return { added: 0, path: catalogPath };
@@ -1903,6 +1982,12 @@ export async function syncCatalogModels(config: OcxConfig): Promise<{ added: num
   // native template can never leak supports_websockets while the flag is off.
   const wsEnabled = websocketsEnabled(config);
   catalog.models = mergeCatalogEntriesForSync(catalog.models ?? [], goEntries, baseline, featured, wsEnabled, goIds, template, disabledNativeSlugs(config), gatheredProviderNames, multiAgentMode, exactComboSlugs, hasPhysicalComboProvider);
+
+  // Final guard before the file Codex parses: strip any reasoning rung the installed binary can't
+  // deserialize (e.g. the mocked max/ultra tiers on Codex 0.133.0, whose enum stops at xhigh). An
+  // unclamped rung makes codex-rs reject the WHOLE catalog ("unknown variant `max`"), which surfaces
+  // as "failed to create task". No-op when codex isn't probeable — behavior then matches the prior release.
+  catalog.models = clampCatalogModelsToCodexSupport(catalog.models ?? [], catalogDeps);
 
   atomicWriteFile(catalogPath, JSON.stringify(catalog, null, 2) + "\n");
   return { added: goEntries.length, path: catalogPath };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -251,7 +251,7 @@ export function startServer(port?: number) {
           return withCors(formatErrorResponse(403, "origin_rejected", "cross-origin data-plane request blocked"), req, config);
         }
         const goModels = await fetchAllModels(config);
-        const { applyNativeVisibility, buildCatalogEntries, disabledNativeSlugs, exactComboCatalogSlugs, loadCatalogTemplate, nativeOpenAiSlugs, orderForSubagents, filterCatalogVisibleModels, visibleNativeSlugs } = await import("../codex/catalog");
+        const { applyNativeVisibility, buildCatalogEntries, clampCatalogModelsToCodexSupport, disabledNativeSlugs, exactComboCatalogSlugs, loadCatalogTemplate, nativeOpenAiSlugs, orderForSubagents, filterCatalogVisibleModels, visibleNativeSlugs } = await import("../codex/catalog");
         const nativeSlugs = nativeOpenAiSlugs();
         const goEnabled = filterCatalogVisibleModels(goModels, config);
         const goOrdered = orderForSubagents(goEnabled, config.subagentModels);
@@ -295,7 +295,11 @@ export function startServer(port?: number) {
           // on-disk sync; codex-rs keeps them out of the picker itself).
           const maMode = config.multiAgentMode === "v1" || config.multiAgentMode === "v2" ? config.multiAgentMode : "default";
           const entries = buildCatalogEntries(loadCatalogTemplate(), nativeSlugs, goOrdered, config.subagentModels, websocketsEnabled(config), maMode as "v1" | "default" | "v2", exactComboCatalogSlugs(config));
-          return jsonResponse({ models: applyNativeVisibility(entries, disabledNativeSlugs(config)) }, 200, req, config);
+          // Clamp mocked max/ultra rungs to what the installed Codex can parse (mirrors the on-disk
+          // sync). codex-rs ingests this catalog shape strictly, so an unsupported rung here breaks
+          // model discovery exactly like the on-disk file does.
+          const clamped = clampCatalogModelsToCodexSupport(entries);
+          return jsonResponse({ models: applyNativeVisibility(clamped, disabledNativeSlugs(config)) }, 200, req, config);
         }
         // OpenAI list shape: native gpt bare + routed models namespaced "<provider>/<id>"
         // (pure availability list — disabled natives are omitted entirely).

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { augmentRoutedModelsWithJawcodeMetadata, augmentRoutedModelsWithRegistryOpenAiApiRows, buildCatalogEntries, deriveComboCatalogModel, exactComboCatalogSlugs, filterCatalogVisibleModels, filterSupportedNativeSlugs, gatherRoutedModels, isDatedVariantId, isMediaGenerationModelId, loadBundledCodexCatalog, materializeBundledCodexCatalog, mergeCatalogEntriesForSync, NATIVE_OPENAI_MODELS, normalizeRoutedCatalogEntry, resetCatalogRuntimeStateForTests, resetOpenAiApiCatalogWarningStateForTests } from "../src/codex/catalog";
+import { augmentRoutedModelsWithJawcodeMetadata, augmentRoutedModelsWithRegistryOpenAiApiRows, buildCatalogEntries, clampCatalogModelsToCodexSupport, clampEntryToCodexSupportedEfforts, codexSupportedReasoningEfforts, deriveComboCatalogModel, exactComboCatalogSlugs, filterCatalogVisibleModels, filterSupportedNativeSlugs, gatherRoutedModels, isDatedVariantId, isMediaGenerationModelId, loadBundledCodexCatalog, materializeBundledCodexCatalog, mergeCatalogEntriesForSync, NATIVE_OPENAI_MODELS, normalizeRoutedCatalogEntry, resetCatalogRuntimeStateForTests, resetOpenAiApiCatalogWarningStateForTests } from "../src/codex/catalog";
 import {
   CURSOR_STATIC_MODELS,
   filterCursorConfiguredModelsByLiveDiscovery,
@@ -1685,5 +1685,91 @@ describe("media-generation model filtering", () => {
     ]) {
       expect(isMediaGenerationModelId(id)).toBe(false);
     }
+  });
+});
+
+describe("Codex reasoning-effort capability clamp (regression: max/ultra on Codex 0.133.0)", () => {
+  // A bundled catalog exactly as `codex debug models --bundled` prints it. The native models'
+  // supported_reasoning_levels are the ground truth of the reasoning enum the installed binary accepts.
+  function bundledDeps(efforts: string[]) {
+    return {
+      commandCandidates: () => ["codex"],
+      execFileSync: () => JSON.stringify({
+        models: [{
+          slug: "gpt-5.5",
+          display_name: "GPT-5.5",
+          base_instructions: "x",
+          supported_reasoning_levels: efforts.map(effort => ({ effort, description: effort })),
+          default_reasoning_level: "medium",
+        }],
+      }),
+    };
+  }
+
+  const failingDeps = {
+    commandCandidates: () => ["codex"],
+    execFileSync: () => { throw new Error("codex not on PATH"); },
+  };
+
+  function routedEntry() {
+    return {
+      slug: "openrouter/some-model",
+      supported_reasoning_levels: [
+        { effort: "low" }, { effort: "medium" }, { effort: "high" }, { effort: "xhigh" }, { effort: "max" }, { effort: "ultra" },
+      ],
+      default_reasoning_level: "max",
+    } as Record<string, unknown>;
+  }
+
+  test("codexSupportedReasoningEfforts reads the installed binary's ladder (0.133.0 stops at xhigh)", () => {
+    const supported = codexSupportedReasoningEfforts(bundledDeps(["low", "medium", "high", "xhigh"]));
+    expect(supported && [...supported].sort()).toEqual(["high", "low", "medium", "xhigh"]);
+    expect(supported?.has("max")).toBe(false);
+    expect(supported?.has("ultra")).toBe(false);
+  });
+
+  test("codexSupportedReasoningEfforts returns null when codex can't be probed", () => {
+    expect(codexSupportedReasoningEfforts(failingDeps)).toBeNull();
+  });
+
+  test("clampCatalogModelsToCodexSupport strips the max/ultra rungs a 0.133.0-era binary rejects", () => {
+    const models = [routedEntry()];
+    clampCatalogModelsToCodexSupport(models, bundledDeps(["low", "medium", "high", "xhigh"]));
+    expect((models[0]!.supported_reasoning_levels as Array<{ effort: string }>).map(l => l.effort))
+      .toEqual(["low", "medium", "high", "xhigh"]);
+    // default was `max` (unsupported) -> repaired to the highest surviving rung.
+    expect(models[0]!.default_reasoning_level).toBe("xhigh");
+  });
+
+  test("clampCatalogModelsToCodexSupport preserves max/ultra when the installed binary advertises them", () => {
+    const models = [routedEntry()];
+    clampCatalogModelsToCodexSupport(models, bundledDeps(["low", "medium", "high", "xhigh", "max", "ultra"]));
+    expect((models[0]!.supported_reasoning_levels as Array<{ effort: string }>).map(l => l.effort))
+      .toEqual(["low", "medium", "high", "xhigh", "max", "ultra"]);
+    expect(models[0]!.default_reasoning_level).toBe("max");
+  });
+
+  test("clampCatalogModelsToCodexSupport is a no-op when codex isn't probeable (prior behavior preserved)", () => {
+    const models = [routedEntry()];
+    clampCatalogModelsToCodexSupport(models, failingDeps);
+    expect((models[0]!.supported_reasoning_levels as Array<{ effort: string }>).map(l => l.effort))
+      .toEqual(["low", "medium", "high", "xhigh", "max", "ultra"]);
+    expect(models[0]!.default_reasoning_level).toBe("max");
+  });
+
+  test("clampEntryToCodexSupportedEfforts never empties a ladder and repairs the default at/below the original", () => {
+    const supported = new Set(["low", "medium", "high", "xhigh"]);
+    const entry: Record<string, unknown> = {
+      supported_reasoning_levels: [{ effort: "high" }, { effort: "xhigh" }, { effort: "max" }],
+      default_reasoning_level: "max",
+    };
+    clampEntryToCodexSupportedEfforts(entry, supported);
+    expect((entry.supported_reasoning_levels as Array<{ effort: string }>).map(l => l.effort)).toEqual(["high", "xhigh"]);
+    expect(entry.default_reasoning_level).toBe("xhigh");
+
+    // Defensive: an entirely-unsupported ladder is left intact rather than emptied (would break the picker).
+    const edge: Record<string, unknown> = { supported_reasoning_levels: [{ effort: "max" }, { effort: "ultra" }] };
+    clampEntryToCodexSupportedEfforts(edge, supported);
+    expect((edge.supported_reasoning_levels as Array<{ effort: string }>).map(l => l.effort)).toEqual(["max", "ultra"]);
   });
 });


### PR DESCRIPTION
## Problem

On Codex `0.133.0`, opencodex breaks catalog loading outright:

```
failed to resolve feature override precedence: failed to parse model_catalog_json
path `.../opencodex-catalog.json` as JSON: unknown variant `max`, expected one of
`none`, `minimal`, `low`, `medium`, `high`, `xhigh`
```

Codex then reports **"failed to create task"**. Every catalog resync reproduces it.

## Root cause

opencodex mocks `max`/`ultra` reasoning rungs onto every catalog model (`applyReasoningLevels`, `ensureUltraReasoningLevel`, `ensureGpt56ReasoningLevels`), assuming a Codex build whose `ReasoningEffort` enum accepts them. Codex `0.133.0`'s enum stops at `xhigh`, and codex-rs deserializes the catalog strictly — so the first unknown variant rejects the **entire** catalog file.

## Fix

Derive the reasoning ladder the **installed** binary actually parses from its own bundled catalog (`codex debug models --bundled`) and clamp every emitted entry to it, at both on-wire boundaries:

- `syncCatalogModels` — the on-disk catalog Codex reads
- `/v1/models?client_version` — the catalog shape served to the Codex client

New helpers in `src/codex/catalog.ts`:
- `codexSupportedReasoningEfforts(deps?)` — the binary's supported effort set, or `null` when codex can't be probed
- `clampEntryToCodexSupportedEfforts(entry, supported)` — filters rungs + repairs `default_reasoning_level` to the highest surviving rung
- `clampCatalogModelsToCodexSupport(models, deps?)` — the emission-boundary guard

### Properties

- **Self-adapting.** A newer Codex whose bundled catalog advertises `max`/`ultra` keeps them unchanged; the clamp only removes what the installed binary can't parse.
- **Safe fallback.** When codex isn't probeable, it's a no-op — behavior matches the prior release.
- **Pure builders untouched.** `buildCatalogEntries` / `mergeCatalogEntriesForSync` still emit the mock tiers; the clamp runs only at the write boundaries, so their existing max/ultra unit tests are unaffected.
- **Never empties a ladder** — the universal low/medium/high rungs are always in the supported set.

## Testing

- `bun x tsc --noEmit` — clean
- Full suite: **3308 pass, 0 fail** (6 new regression tests: strip, preserve, no-op, default repair)
- End-to-end against a real Codex `0.133.0`: a catalog polluted with `max`/`ultra` run through `syncCatalogModels` comes out with ladders capped at `xhigh` and no `max`/`ultra` anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
