### PR TITLE
ci: enforce issue quality for feature requests + disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -59,6 +59,8 @@ body:
       label: Version
       description: The installed `@bitkyc08/opencodex` version or commit SHA.
       placeholder: 2.7.7
+    validations:
+      required: true
 
   - type: input
     id: os

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Security policy
     url: https://github.com/lidge-jun/opencodex/blob/main/SECURITY.md

--- a/.github/workflows/enforce-issue-quality.yml
+++ b/.github/workflows/enforce-issue-quality.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Validate feature request quality
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const COMMENT_MARKER = "<!-- issue-quality-enforcer -->";
@@ -34,21 +34,26 @@ jobs:
             const issue = context.payload.issue;
             const issue_number = issue.number;
 
-            const labels = new Set(
-              (issue.labels ?? []).map(label =>
-                typeof label === "string" ? label : label.name
-              )
-            );
-
             /*
              * Only inspect feature requests.
              *
-             * The feature form applies the "enhancement" label and uses
-             * the "[Feature]:" title prefix.
+             * The feature form applies the "enhancement" label and uses the
+             * "[Feature]:" title prefix, but labels can be added manually to
+             * non-feature issues. Require the feature title prefix AND the
+             * feature-form section headings so a bug/support issue that merely
+             * carries the label is never validated as a feature request.
              */
-            const isFeatureRequest =
-              labels.has("enhancement") ||
+            const hasFeatureTitle =
               /^\[feature\]\s*:/i.test(issue.title);
+
+            const body = String(issue.body ?? "");
+
+            const hasFeatureFormSections =
+              /(?:^|\r?\n)###\s+Problem to solve\s*\r?\n/i.test(body) &&
+              /(?:^|\r?\n)###\s+Proposed solution\s*\r?\n/i.test(body);
+
+            const isFeatureRequest =
+              hasFeatureTitle && hasFeatureFormSections;
 
             if (!isFeatureRequest) {
               core.info("Not a feature request. Skipping.");
@@ -84,7 +89,7 @@ jobs:
             function normalise(value) {
               return clean(value)
                 .toLowerCase()
-                .replace(/[^a-z0-9]+/g, " ")
+                .replace(/[^\p{L}\p{N}]+/gu, " ")
                 .trim();
             }
 
@@ -108,14 +113,26 @@ jobs:
             function wordCount(value) {
               const normalised = normalise(value);
 
-              return normalised
-                ? normalised.split(/\s+/).length
-                : 0;
+              if (!normalised) {
+                return 0;
+              }
+
+              // Whitespace-tokenised count works for spaced scripts. CJK and
+              // other unspaced scripts collapse to a single "word", so fall back
+              // to a character count for those to avoid rejecting a detailed
+              // localized answer as too short.
+              const tokens = normalised.split(/\s+/);
+
+              if (tokens.length > 1) {
+                return tokens.length;
+              }
+
+              return [...normalised].length;
             }
 
             function getSection(heading) {
               const pattern = new RegExp(
-                `(?:^|\\r?\\n)###\\s+${escapeRegExp(heading)}\\s*\\r?\\n([\\s\\S]*?)(?=\\r?\\n###\\s+|$)`,
+                `(?:^|\\r?\\n)###\\s+${escapeRegExp(heading)}\\s*\\r?\\n([\\s\\S]*?)(?=\\r?\\n###\\s+(?:Problem to solve|Proposed solution|Alternatives considered|Additional context)\\s*(?:\\r?\\n|$)|$)`,
                 "i"
               );
 
@@ -341,8 +358,20 @@ jobs:
             /*
              * The author edited the issue sufficiently.
              * Reopen it only because this workflow previously closed it.
+             *
+             * Fetch the live issue state rather than trusting the event
+             * payload: a queued "edited" run can carry a stale state of
+             * "open" while a concurrent "opened" run has already closed it,
+             * which would otherwise skip the reopen and leave the bot state
+             * inactive so later valid edits never reopen automatically.
              */
-            if (issue.state === "closed") {
+            const { data: liveIssue } = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number
+            });
+
+            if (liveIssue.state === "closed") {
               await github.rest.issues.update({
                 owner,
                 repo,

--- a/.github/workflows/enforce-issue-quality.yml
+++ b/.github/workflows/enforce-issue-quality.yml
@@ -1,0 +1,367 @@
+name: Enforce issue quality
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  issues: write
+
+concurrency:
+  group: enforce-issue-quality-${{ github.event.issue.number }}
+
+jobs:
+  validate:
+    if: github.event.issue.pull_request == null
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate feature request quality
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const COMMENT_MARKER = "<!-- issue-quality-enforcer -->";
+            const STATE_PATTERN =
+              /<!-- issue-quality-enforcer-state:([\s\S]*?) -->/;
+
+            const CONTRIBUTING_URL =
+              "https://lidge-jun.github.io/opencodex/contributing/";
+
+            const { owner, repo } = context.repo;
+            const issue = context.payload.issue;
+            const issue_number = issue.number;
+
+            const labels = new Set(
+              (issue.labels ?? []).map(label =>
+                typeof label === "string" ? label : label.name
+              )
+            );
+
+            /*
+             * Only inspect feature requests.
+             *
+             * The feature form applies the "enhancement" label and uses
+             * the "[Feature]:" title prefix.
+             */
+            const isFeatureRequest =
+              labels.has("enhancement") ||
+              /^\[feature\]\s*:/i.test(issue.title);
+
+            if (!isFeatureRequest) {
+              core.info("Not a feature request. Skipping.");
+              return;
+            }
+
+            /*
+             * Maintainers may intentionally create short internal issues.
+             * Do not make the bot police its own maintainers.
+             */
+            const trustedAssociations = new Set([
+              "OWNER",
+              "MEMBER",
+              "COLLABORATOR"
+            ]);
+
+            if (trustedAssociations.has(issue.author_association)) {
+              core.info("Trusted repository contributor. Skipping.");
+              return;
+            }
+
+            function escapeRegExp(value) {
+              return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+            }
+
+            function clean(value) {
+              return String(value ?? "")
+                .replace(/<!--([\s\S]*?)-->/g, "")
+                .replace(/^No response$/gim, "")
+                .trim();
+            }
+
+            function normalise(value) {
+              return clean(value)
+                .toLowerCase()
+                .replace(/[^a-z0-9]+/g, " ")
+                .trim();
+            }
+
+            /*
+             * Remove meaningless introductory wording so that:
+             *
+             * "Need to add support for X"
+             * "We need to add support for X"
+             *
+             * are recognised as the same answer.
+             */
+            function canonicalise(value) {
+              return normalise(value)
+                .replace(
+                  /^(we\s+)?(need|want|would like)\s+to\s+/,
+                  ""
+                )
+                .trim();
+            }
+
+            function wordCount(value) {
+              const normalised = normalise(value);
+
+              return normalised
+                ? normalised.split(/\s+/).length
+                : 0;
+            }
+
+            function getSection(heading) {
+              const pattern = new RegExp(
+                `(?:^|\\r?\\n)###\\s+${escapeRegExp(heading)}\\s*\\r?\\n([\\s\\S]*?)(?=\\r?\\n###\\s+|$)`,
+                "i"
+              );
+
+              return clean(
+                issue.body?.match(pattern)?.[1]
+              );
+            }
+
+            function parseState(body) {
+              const match = body?.match(STATE_PATTERN);
+
+              if (!match) {
+                return null;
+              }
+
+              try {
+                return JSON.parse(match[1]);
+              } catch (error) {
+                core.warning(
+                  `Could not parse stored issue state: ${error.message}`
+                );
+
+                return null;
+              }
+            }
+
+            function stateMarker(state) {
+              return (
+                "<!-- issue-quality-enforcer-state:" +
+                JSON.stringify(state) +
+                " -->"
+              );
+            }
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner,
+                repo,
+                issue_number,
+                per_page: 100
+              }
+            );
+
+            const botComment = comments.find(
+              comment =>
+                comment.user?.login ===
+                  "github-actions[bot]" &&
+                comment.body?.includes(COMMENT_MARKER)
+            );
+
+            const storedState =
+              parseState(botComment?.body);
+
+            async function upsertComment(body) {
+              if (botComment) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: botComment.id,
+                  body
+                });
+
+                return;
+              }
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body
+              });
+            }
+
+            const problem =
+              getSection("Problem to solve");
+
+            const solution =
+              getSection("Proposed solution");
+
+            const title = issue.title.replace(
+              /^\[feature\]\s*:\s*/i,
+              ""
+            );
+
+            const reasons = [];
+
+            /*
+             * Reject genuinely empty or nearly empty sections.
+             */
+            if (
+              problem.length < 25 ||
+              wordCount(problem) < 5
+            ) {
+              reasons.push(
+                "The **Problem to solve** section is missing or too short to identify a concrete limitation."
+              );
+            }
+
+            if (
+              solution.length < 25 ||
+              wordCount(solution) < 5
+            ) {
+              reasons.push(
+                "The **Proposed solution** section is missing or too short to describe the expected behaviour."
+              );
+            }
+
+            /*
+             * Two extremely brief required sections usually provide no
+             * actionable context, even when each technically contains text.
+             */
+            if (
+              problem.length < 80 &&
+              solution.length < 80
+            ) {
+              reasons.push(
+                "Both required sections are too brief to provide enough actionable context."
+              );
+            }
+
+            /*
+             * The problem and solution must describe different things.
+             */
+            if (
+              canonicalise(problem) &&
+              canonicalise(problem) ===
+                canonicalise(solution)
+            ) {
+              reasons.push(
+                "The problem and proposed solution repeat the same text instead of describing two distinct things."
+              );
+            }
+
+            /*
+             * Reject submissions where the entire body merely repeats
+             * the title, as issue #208 does.
+             */
+            if (
+              canonicalise(title) &&
+              canonicalise(title) ===
+                canonicalise(problem) &&
+              canonicalise(title) ===
+                canonicalise(solution)
+            ) {
+              reasons.push(
+                "The issue body only repeats the title and adds no actionable detail."
+              );
+            }
+
+            const invalid = reasons.length > 0;
+
+            if (invalid) {
+              /*
+               * Do not take ownership of an issue that a maintainer
+               * already closed manually for another reason.
+               */
+              if (
+                issue.state === "closed" &&
+                !storedState?.active &&
+                context.payload.action === "edited"
+              ) {
+                core.info(
+                  "Issue is already closed manually and has no active bot state."
+                );
+
+                return;
+              }
+
+              const state = {
+                version: 1,
+                active: true
+              };
+
+              await upsertComment(
+                [
+                  COMMENT_MARKER,
+                  stateMarker(state),
+                  "",
+                  "### Issue closed: insufficient detail",
+                  "",
+                  "Thanks for the request. This issue was closed automatically because the required sections do not contain enough distinct, actionable information.",
+                  "",
+                  ...reasons.map(
+                    reason => `- ${reason}`
+                  ),
+                  "",
+                  "Please edit the issue to include:",
+                  "",
+                  "- the specific workflow or limitation you are trying to improve",
+                  "- the exact behaviour you expect",
+                  "- an example request, response, CLI command, configuration, or upstream API reference",
+                  "- why the existing behaviour is insufficient",
+                  "",
+                  `See the [Contributing guide](${CONTRIBUTING_URL}) for additional guidance. Once the issue contains enough detail, it will be reopened automatically.`
+                ].join("\n")
+              );
+
+              if (issue.state !== "closed") {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number,
+                  state: "closed",
+                  state_reason: "not_planned"
+                });
+              }
+
+              return;
+            }
+
+            /*
+             * Valid issue with no previous bot closure.
+             */
+            if (!storedState?.active) {
+              core.info(
+                "Issue passes validation and has no active bot state."
+              );
+
+              return;
+            }
+
+            /*
+             * The author edited the issue sufficiently.
+             * Reopen it only because this workflow previously closed it.
+             */
+            if (issue.state === "closed") {
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number,
+                state: "open",
+                state_reason: "reopened"
+              });
+            }
+
+            await upsertComment(
+              [
+                COMMENT_MARKER,
+                stateMarker({
+                  version: 1,
+                  active: false
+                }),
+                "",
+                "### Issue reopened",
+                "",
+                "The issue now contains enough distinct information to pass the automated quality check. Thanks for updating it."
+              ].join("\n")
+            );

--- a/.github/workflows/enforce-issue-quality.yml
+++ b/.github/workflows/enforce-issue-quality.yml
@@ -35,28 +35,29 @@ jobs:
             const issue_number = issue.number;
 
             /*
-             * Only inspect feature requests.
+             * Detect which structured form this issue came from. Labels can be
+             * added manually, so require the form's title prefix AND its section
+             * headings; an issue that merely carries a label is never validated
+             * with the wrong form's rules.
              *
-             * The feature form applies the "enhancement" label and uses the
-             * "[Feature]:" title prefix, but labels can be added manually to
-             * non-feature issues. Require the feature title prefix AND the
-             * feature-form section headings so a bug/support issue that merely
-             * carries the label is never validated as a feature request.
+             * Feature requests get the full quality check. Bug reports get a
+             * deliberately narrow check (empty body or title-only) so a terse
+             * but real crash report is never auto-closed.
              */
-            const hasFeatureTitle =
-              /^\[feature\]\s*:/i.test(issue.title);
-
             const body = String(issue.body ?? "");
 
-            const hasFeatureFormSections =
+            const isFeatureRequest =
+              /^\[feature\]\s*:/i.test(issue.title) &&
               /(?:^|\r?\n)###\s+Problem to solve\s*\r?\n/i.test(body) &&
               /(?:^|\r?\n)###\s+Proposed solution\s*\r?\n/i.test(body);
 
-            const isFeatureRequest =
-              hasFeatureTitle && hasFeatureFormSections;
+            const isBugReport =
+              /^\[bug\]\s*:/i.test(issue.title) &&
+              /(?:^|\r?\n)###\s+Summary\s*\r?\n/i.test(body) &&
+              /(?:^|\r?\n)###\s+Reproduction\s*\r?\n/i.test(body);
 
-            if (!isFeatureRequest) {
-              core.info("Not a feature request. Skipping.");
+            if (!isFeatureRequest && !isBugReport) {
+              core.info("Not a feature request or bug report form. Skipping.");
               return;
             }
 
@@ -132,7 +133,7 @@ jobs:
 
             function getSection(heading) {
               const pattern = new RegExp(
-                `(?:^|\\r?\\n)###\\s+${escapeRegExp(heading)}\\s*\\r?\\n([\\s\\S]*?)(?=\\r?\\n###\\s+(?:Problem to solve|Proposed solution|Alternatives considered|Additional context)\\s*(?:\\r?\\n|$)|$)`,
+                `(?:^|\\r?\\n)###\\s+${escapeRegExp(heading)}\\s*\\r?\\n([\\s\\S]*?)(?=\\r?\\n###\\s+(?:Problem to solve|Proposed solution|Alternatives considered|Additional context|Summary|Reproduction|Logs and screenshots|Area|Version|OS|Config shape|Checks)\\s*(?:\\r?\\n|$)|$)`,
                 "i"
               );
 
@@ -207,80 +208,122 @@ jobs:
               });
             }
 
-            const problem =
-              getSection("Problem to solve");
-
-            const solution =
-              getSection("Proposed solution");
-
-            const title = issue.title.replace(
-              /^\[feature\]\s*:\s*/i,
-              ""
-            );
-
             const reasons = [];
 
-            /*
-             * Reject genuinely empty or nearly empty sections.
-             */
-            if (
-              problem.length < 25 ||
-              wordCount(problem) < 5
-            ) {
-              reasons.push(
-                "The **Problem to solve** section is missing or too short to identify a concrete limitation."
-              );
-            }
+            if (isFeatureRequest) {
+              const problem =
+                getSection("Problem to solve");
 
-            if (
-              solution.length < 25 ||
-              wordCount(solution) < 5
-            ) {
-              reasons.push(
-                "The **Proposed solution** section is missing or too short to describe the expected behaviour."
-              );
-            }
+              const solution =
+                getSection("Proposed solution");
 
-            /*
-             * Two extremely brief required sections usually provide no
-             * actionable context, even when each technically contains text.
-             */
-            if (
-              problem.length < 80 &&
-              solution.length < 80
-            ) {
-              reasons.push(
-                "Both required sections are too brief to provide enough actionable context."
+              const title = issue.title.replace(
+                /^\[feature\]\s*:\s*/i,
+                ""
               );
-            }
 
-            /*
-             * The problem and solution must describe different things.
-             */
-            if (
-              canonicalise(problem) &&
-              canonicalise(problem) ===
-                canonicalise(solution)
-            ) {
-              reasons.push(
-                "The problem and proposed solution repeat the same text instead of describing two distinct things."
-              );
-            }
+              /*
+               * Reject genuinely empty or nearly empty sections.
+               */
+              if (
+                problem.length < 25 ||
+                wordCount(problem) < 5
+              ) {
+                reasons.push(
+                  "The **Problem to solve** section is missing or too short to identify a concrete limitation."
+                );
+              }
 
-            /*
-             * Reject submissions where the entire body merely repeats
-             * the title, as issue #208 does.
-             */
-            if (
-              canonicalise(title) &&
-              canonicalise(title) ===
+              if (
+                solution.length < 25 ||
+                wordCount(solution) < 5
+              ) {
+                reasons.push(
+                  "The **Proposed solution** section is missing or too short to describe the expected behaviour."
+                );
+              }
+
+              /*
+               * Two extremely brief required sections usually provide no
+               * actionable context, even when each technically contains text.
+               */
+              if (
+                problem.length < 80 &&
+                solution.length < 80
+              ) {
+                reasons.push(
+                  "Both required sections are too brief to provide enough actionable context."
+                );
+              }
+
+              /*
+               * The problem and solution must describe different things.
+               */
+              if (
                 canonicalise(problem) &&
-              canonicalise(title) ===
-                canonicalise(solution)
-            ) {
-              reasons.push(
-                "The issue body only repeats the title and adds no actionable detail."
+                canonicalise(problem) ===
+                  canonicalise(solution)
+              ) {
+                reasons.push(
+                  "The problem and proposed solution repeat the same text instead of describing two distinct things."
+                );
+              }
+
+              /*
+               * Reject submissions where the entire body merely repeats
+               * the title, as issue #208 does.
+               */
+              if (
+                canonicalise(title) &&
+                canonicalise(title) ===
+                  canonicalise(problem) &&
+                canonicalise(title) ===
+                  canonicalise(solution)
+              ) {
+                reasons.push(
+                  "The issue body only repeats the title and adds no actionable detail."
+                );
+              }
+            } else {
+              /*
+               * Bug reports get a deliberately narrow check. A terse but real
+               * crash report is valuable, so only close the unambiguous junk:
+               * an effectively empty body, or a body that merely repeats the
+               * title. No word-count floors, no "sections must differ" rule.
+               */
+              const summary =
+                getSection("Summary");
+
+              const reproduction =
+                getSection("Reproduction");
+
+              const title = issue.title.replace(
+                /^\[bug\]\s*:\s*/i,
+                ""
               );
+
+              /*
+               * "Effectively empty" means both required sections carry no real
+               * content (blank or the form's "No response" placeholder, which
+               * clean() strips). The section headings themselves always remain
+               * in the body, so a raw length check would never fire.
+               */
+              if (
+                summary.length === 0 &&
+                reproduction.length === 0
+              ) {
+                reasons.push(
+                  "Both the **Summary** and **Reproduction** sections are empty."
+                );
+              } else if (
+                canonicalise(title) &&
+                canonicalise(title) === canonicalise(summary) &&
+                canonicalise(title) === canonicalise(reproduction)
+              ) {
+                reasons.push(
+                  "The issue body only repeats the title and adds no actionable detail."
+                );
+              }
             }
 
             const invalid = reasons.length > 0;
@@ -307,6 +350,20 @@ jobs:
                 active: true
               };
 
+              const guidance = isFeatureRequest
+                ? [
+                    "- the specific workflow or limitation you are trying to improve",
+                    "- the exact behaviour you expect",
+                    "- an example request, response, CLI command, configuration, or upstream API reference",
+                    "- why the existing behaviour is insufficient"
+                  ]
+                : [
+                    "- a clear summary of what happened and what you expected",
+                    "- the exact steps, commands, and config needed to reproduce",
+                    "- the installed version and operating system",
+                    "- relevant logs, stack traces, or screenshots"
+                  ];
+
               await upsertComment(
                 [
                   COMMENT_MARKER,
@@ -322,10 +379,7 @@ jobs:
                   "",
                   "Please edit the issue to include:",
                   "",
-                  "- the specific workflow or limitation you are trying to improve",
-                  "- the exact behaviour you expect",
-                  "- an example request, response, CLI command, configuration, or upstream API reference",
-                  "- why the existing behaviour is insufficient",
+                  ...guidance,
                   "",
                   `See the [Contributing guide](${CONTRIBUTING_URL}) for additional guidance. Once the issue contains enough detail, it will be reopened automatically.`
                 ].join("\n")


### PR DESCRIPTION
## Summary

Two changes to reduce low-quality issue submissions:

1. **New workflow** \.github/workflows/enforce-issue-quality.yml\: auto-closes feature requests that lack actionable detail (empty/too-short sections, repeated text, title-only body). Reopens automatically when the author edits the issue to pass validation. Skips trusted contributors (OWNER/MEMBER/COLLABORATOR).

2. **Config change** \.github/ISSUE_TEMPLATE/config.yml\: sets \lank_issues_enabled: false\ to prevent bypassing the structured issue forms entirely.

## Motivation

Issues like #208 where the body merely repeats the title with no actionable detail. The structured form fields were being bypassed via blank issues, and even when the form was used, GitHub doesn't validate whether answers are useful.

## Review notes

- The workflow only targets feature requests (enhancement label or [Feature]: title prefix)
- Bug reports and other issue types are unaffected
- Trusted contributors (OWNER/MEMBER/COLLABORATOR) are exempt
- The workflow stores state in a hidden HTML comment so it can restore/reopen correctly
- Uses \ctions/github-script@v9\ with no checkout step (no contributor code execution in \issues\ trigger)
- Concurrency group prevents race conditions on rapid edits