### PR TITLE
fix(update): fall back to direct proxy start when service reinstall fails

### DIFF
--- a/bin/ocx.mjs
+++ b/bin/ocx.mjs
@@ -199,7 +199,24 @@ function runNpmSelfUpdate() {
       try {
         const svcArgs = serviceReinstallArgs();
         const svc = spawnSync(process.execPath, svcArgs, { stdio: "inherit", windowsHide: true });
-        if (svc.status !== 0) console.warn("opencodex: service refresh failed — run 'ocx service install' manually.");
+        if (svc.status !== 0) {
+          // On Windows, schtasks /create requires elevation. The launcher inherits the
+          // user's (non-admin) token, so the service reinstall can fail with access
+          // denied. Fall back to a direct detached proxy start so the update never
+          // leaves the user without a running proxy.
+          console.warn("opencodex: service refresh failed — starting the proxy directly instead.");
+          console.warn("  Run 'ocx service install' as administrator to refresh the background service.");
+          const env = { ...process.env };
+          delete env.OCX_SERVICE;
+          const child = spawn(process.execPath, [launcher, "start", "--port", String(bakePort)], {
+            detached: true,
+            stdio: "ignore",
+            windowsHide: true,
+            env,
+          });
+          child.unref();
+          console.log(`Proxy starting on port ${bakePort}.`);
+        }
       } finally {
         if (prevBake === undefined) delete process.env.OCX_BAKE_PORT;
         else process.env.OCX_BAKE_PORT = prevBake;

--- a/src/update/index.ts
+++ b/src/update/index.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
@@ -260,7 +260,24 @@ export async function runUpdate(): Promise<void> {
           windowsHide: true,
         });
         if (svcStdio === "pipe") logSpawnOutput("", svc);
-        if (svc.status !== 0) console.warn("⚠️  Service refresh failed — run 'ocx service install' manually.");
+        if (svc.status !== 0) {
+          // On Windows, schtasks /create requires elevation. The CLI inherits the
+          // user's (non-admin) token, so the service reinstall can fail with access
+          // denied. Fall back to a direct detached proxy start so the update never
+          // leaves the user without a running proxy.
+          console.warn("⚠️  Service refresh failed — starting the proxy directly instead.");
+          console.warn("   Run 'ocx service install' as administrator to refresh the background service.");
+          const env = { ...process.env };
+          delete env.OCX_SERVICE;
+          const child = spawn(process.execPath, [process.argv[1], "start", "--port", String(capturedListen.port)], {
+            detached: true,
+            stdio: "ignore",
+            windowsHide: true,
+            env,
+          });
+          child.unref();
+          console.log(`✅ Proxy starting on port ${capturedListen.port}.`);
+        }
       } finally {
         if (prevBake === undefined) delete process.env.OCX_BAKE_PORT;
         else process.env.OCX_BAKE_PORT = prevBake;

--- a/src/update/job.ts
+++ b/src/update/job.ts
@@ -330,17 +330,27 @@ async function restartAfterUpdate(
     }
     const prevBake = process.env.OCX_BAKE_PORT;
     process.env.OCX_BAKE_PORT = String(Math.trunc(port));
+    let serviceOk = false;
     try {
       const run = io.runService ?? ((j, bin, args) => runLoggedCommand(j, bin, args, RESTART_TIMEOUT_MS));
       const result = run(job, cmd.bin, cmd.args);
-      if (result.status !== 0) {
-        throw new Error(`service restart failed (${cmd.display}, exit ${result.status ?? "?"})`);
+      serviceOk = result.status === 0;
+      if (!serviceOk) {
+        // On Windows, `schtasks /create` requires an elevated token. The update worker
+        // inherits the (non-admin) proxy's privileges, so a service-managed install
+        // updated from the GUI or a normal terminal fails here with access denied.
+        // Falling back to a direct proxy start keeps the update from leaving the proxy
+        // stopped; the stale service manager can be refreshed later with an admin
+        // `ocx service install`.
+        updateJob(job, {}, `Service reinstall failed (exit ${result.status ?? "?"}); falling back to a direct proxy start. Run 'ocx service install' as administrator to refresh the background service manager.`);
       }
     } finally {
       if (prevBake === undefined) delete process.env.OCX_BAKE_PORT;
       else process.env.OCX_BAKE_PORT = prevBake;
     }
-    return;
+    if (serviceOk) return;
+    // Fall through to the direct proxy start below so the update never leaves the
+    // proxy stopped when the service reinstall could not run.
   }
 
   const pid = readPid();

--- a/tests/update-job.test.ts
+++ b/tests/update-job.test.ts
@@ -184,6 +184,34 @@ describe("GUI update execution decisions", () => {
     }
   });
 
+  test("service reinstall failure falls back to a direct proxy start", async () => {
+    const spawned: Array<{ port: number }> = [];
+    const job: UpdateJobState = {
+      id: "svc-fallback",
+      status: "restarting",
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      currentVersion: "2.7.26",
+      latestVersion: "2.7.28",
+      channel: "latest",
+      installer: "npm",
+      restart: true,
+      command: "",
+      log: [],
+    };
+    writeFileSync(updateJobPath(job.id), JSON.stringify(job));
+    await restartAfterUpdateForTests(job, { port: 19999, hostname: "127.0.0.1" }, {
+      serviceInstalledFn: () => true,
+      waitForPort: async () => true,
+      runService: () => ({ status: 1 }),
+      spawnStart: (_job, _installer, port) => {
+        spawned.push({ port: port ?? 0 });
+      },
+    });
+    // The fallback must fire: direct proxy start instead of throwing.
+    expect(spawned).toEqual([{ port: 19999 }]);
+  });
+
   test("a running job prevents a second update job", () => {
     const now = new Date().toISOString();
     const job: UpdateJobState = {


### PR DESCRIPTION
## Problem

On Windows, `schtasks /create` requires an elevated (admin) token. The update worker inherits the non-elevated proxy's privileges, so a service-managed install updated from the GUI or a normal terminal fails with access denied (`Zugriff verweigert`). The old code threw an error or only warned, leaving the proxy stopped after a successful update.

## Fix

Both the GUI path (`src/update/job.ts`) and the CLI path (`src/update/index.ts`) now detect the service reinstall failure and fall back to spawning the proxy directly (detached, with `--port` pinned to the pre-update port). The update never leaves the user without a running proxy.

The stale service manager can be refreshed later with an admin `ocx service install`.

## Changes

- `src/update/job.ts`: GUI restart path tracks `serviceOk` instead of throwing on non-zero exit; falls through to `spawnDetachedStart` on failure with an informative log message.
- `src/update/index.ts`: CLI restart path spawns the proxy directly (detached) when `svc.status !== 0` instead of only printing a warning.
- `tests/update-job.test.ts`: New test asserting that a service reinstall failure (`runService` returns `{ status: 1 }`) triggers the `spawnStart` fallback with the correct port.