### PR TITLE
fix(combo): strip content-encoding on re-serialized child requests

### DIFF
--- a/src/server/responses.ts
+++ b/src/server/responses.ts
@@ -631,7 +631,12 @@ async function handleComboResponses(
       supportedLadderFor({ provider: targetRoute.provider, modelId: targetRoute.modelId }),
     );
     const childHeaders = new Headers(req.headers);
+    // Combo children re-serialize already-decoded JSON. Drop transport headers from the
+    // original compressed request or readJsonRequestBody will try to zstd-decompress
+    // uncompressed JSON ("Unknown frame descriptor" -> Invalid JSON body) and combo
+    // failover will stop before trying later targets.
     childHeaders.delete("content-length");
+    childHeaders.delete("content-encoding");
     const childRequest = new Request(req.url, {
       method: req.method,
       headers: childHeaders,

--- a/tests/combo-child-headers.test.ts
+++ b/tests/combo-child-headers.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { zstdCompressSync } from "node:zlib";
+import { readJsonRequestBody } from "../src/server/request-decompress";
+
+describe("combo child request headers", () => {
+  test("strips content-encoding when re-serializing an already-decoded combo body", async () => {
+    const payload = {
+      model: "combo/xai_grok_fallback",
+      input: "hello",
+      stream: false,
+    };
+    const json = JSON.stringify(payload);
+    const compressed = zstdCompressSync(Buffer.from(json, "utf8"));
+
+    // Parent request: Codex sends zstd and we decode it once.
+    const parent = new Request("http://127.0.0.1:10100/v1/responses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-encoding": "zstd",
+      },
+      body: compressed,
+    });
+    const decoded = await readJsonRequestBody(parent);
+    expect(decoded).toEqual(payload);
+
+    // Child request: combo path re-serializes plain JSON and must not keep zstd.
+    const childBody = { ...payload, model: "xai/grok-4.5" };
+    const buggyHeaders = new Headers(parent.headers);
+    buggyHeaders.delete("content-length");
+    await expect(
+      readJsonRequestBody(
+        new Request(parent.url, {
+          method: parent.method,
+          headers: buggyHeaders,
+          body: JSON.stringify(childBody),
+        }),
+      ),
+    ).rejects.toThrow(/Unknown frame descriptor|Invalid JSON|Unexpected token/i);
+
+    const fixedHeaders = new Headers(parent.headers);
+    fixedHeaders.delete("content-length");
+    fixedHeaders.delete("content-encoding");
+    const childDecoded = await readJsonRequestBody(
+      new Request(parent.url, {
+        method: parent.method,
+        headers: fixedHeaders,
+        body: JSON.stringify(childBody),
+      }),
+    );
+    expect(childDecoded).toEqual(childBody);
+  });
+});


### PR DESCRIPTION
## Summary
- Combo failover re-serializes an already-decoded request body as plain JSON for each target, but it only stripped `content-length` and left the parent's `Content-Encoding` header in place.
- When Codex sends `content-encoding: zstd`, the combo child path then tries to zstd-decompress uncompressed JSON. That fails as `Unknown frame descriptor`, gets mapped to `Invalid JSON body`, and combo failover stops before later targets run.
- Observed with `combo/xai_grok_fallback`: first attempt (`xai/grok-4.5`) failed in ~1ms with `sendCount: 0`, and Cursor never got a turn even though direct `cursor/grok-4.5` worked.

## Fix
- In `handleComboResponses`, also delete `content-encoding` when building the child `Request`.
- Add a focused regression that proves the buggy header rewrite fails and the fixed rewrite succeeds.

## Test plan
- [x] `bun test --isolate tests/request-decompress.test.ts tests/combo-child-headers.test.ts tests/combos.test.ts`
- [x] `bun x tsc --noEmit`
- [x] Manual repro against a live proxy: zstd-encoded `POST /v1/responses` with `model=combo/xai_grok_fallback` returned `200` and `COMBO_OK` after the local patch
- [ ] CI green on this PR

## Notes
- Upstream `main` / `v2.7.31` still has the bug.
- This is independent of provider auth; the 400 happens locally while decoding the combo child request body.