### PR TITLE
fix(gui): remove non-actionable API-key rows from Accounts tab

### DIFF
--- a/gui/src/pages/Providers.tsx
+++ b/gui/src/pages/Providers.tsx
@@ -822,18 +822,6 @@ export default function Providers({ apiBase }: { apiBase: string }) {
     ...[...oauthProviders]
       .sort((a, b) => a.localeCompare(b))
       .map(id => ({ id, label: oauthLabel(id), kind: "oauth" as const })),
-    ...Object.entries(config.providers)
-      .filter(([name, prov]) =>
-        (prov.hasApiKey || prov.keyOptional)
-        && prov.authMode !== "oauth"
-        && prov.authMode !== "forward"
-        && !oauthProviders.includes(name))
-      .map(([name, prov]) => ({
-        id: name,
-        label: name,
-        kind: "key" as const,
-        statusLabel: prov.keyOptional && !prov.hasApiKey ? t("modal.badge.free") : t("prov.hasApiKey"),
-      })),
   ];
 
   const isForwardProvider = (name: string) => config.providers[name]?.authMode === "forward";


### PR DESCRIPTION
## Problem

The Accounts tab in the add-provider modal was showing API-key providers (those with `hasApiKey` or `keyOptional`) as rows with no buttons or actions. The `ProviderCatalog` component renders `kind: "key"` rows with `null` in the actions column, making them dead weight that confuses users.

## Fix

Removed the third group from `addModalAccountRows` in `gui/src/pages/Providers.tsx`. API-key providers already appear in the Free/Paid tabs where they can actually be configured. They don't belong in the Accounts tab, which is meant for OAuth and Codex-forward account management.

## Verification

- `bun x tsc --noEmit` passes in `gui/`
- The Accounts tab now only shows actionable rows: Codex-forward accounts (manage/login) and OAuth providers (login/logout)
