### PR TITLE
fix(oauth): resolve Kiro login flow before blocking on manual paste

### DIFF
--- a/src/oauth/kiro.ts
+++ b/src/oauth/kiro.ts
@@ -50,7 +50,9 @@ export function readKiroCliSqlite(): ImportedKiroToken | null {
 
 /**
  * Import-first login: kiro-cli SQLite → KIRO_ACCESS_TOKEN env → manual paste (CLI only).
- * In GUI (no onManualCodeInput) with no SQLite token and no env, throws a clear error — never hangs.
+ * When no local token is available, resolves the login flow via onAuth with instructions
+ * so the GUI renders the paste-input field, then blocks on onManualCodeInput for the token.
+ * If neither onAuth nor onManualCodeInput is available, throws a clear error.
  */
 export async function loginKiro(ctrl: OAuthController): Promise<OAuthCredentials> {
   const imported = readImportedKiroCredential();
@@ -71,6 +73,15 @@ export async function loginKiro(ctrl: OAuthController): Promise<OAuthCredentials
   }
 
   if (ctrl.onManualCodeInput) {
+    // Resolve the login flow immediately so the GUI receives instructions and
+    // shows the paste-input field. Without this, onManualCodeInput blocks
+    // forever and the HTTP response never reaches the dashboard.
+    ctrl.onAuth?.({
+      url: "",
+      instructions:
+        "No kiro-cli token found. Paste a Kiro access token below (starts with 'aoa'). " +
+        "Run `kiro-cli login` first, or set KIRO_ACCESS_TOKEN.",
+    });
     ctrl.onProgress?.("No kiro-cli token found. Paste a Kiro access token (starts with 'aoa').");
     const raw = (await ctrl.onManualCodeInput()).trim();
     if (raw) return { access: raw, refresh: "", expires: Date.now() + 3600_000, source: "manual" };


### PR DESCRIPTION
## Problem

Clicking "Login" on Kiro in the Accounts tab does nothing visible. The button changes to "Cancel" but no instructions, paste field, or browser window appears. The user is stuck with no way to complete the login.

## Root cause

`loginKiro()` in `src/oauth/kiro.ts` is an import-first flow: it tries kiro-cli SQLite, then `KIRO_ACCESS_TOKEN` env, then falls back to `ctrl.onManualCodeInput()` which blocks waiting for a pasted token. But it never calls `ctrl.onAuth()` before blocking, so `startLoginFlow()` never resolves, the HTTP response is never sent, and the GUI's `fetch` hangs indefinitely.

The GUI sets `busy` state before the fetch (showing the Cancel button), but since the response never arrives, `loginInfo` is never populated and the paste-input field never renders.

## Fix

Call `ctrl.onAuth()` with instructions immediately before blocking on `ctrl.onManualCodeInput()`. This resolves the login flow, sends the HTTP response with instructions, and the GUI renders the paste-input field so the user can enter their Kiro access token.

## Verification

- `bun x tsc --noEmit` passes
- The fix is a 9-line addition to `src/oauth/kiro.ts`
