### PR TITLE
fix(anthropic): raise adaptive-thinking max_tokens default

### DIFF
--- a/src/adapters/anthropic.ts
+++ b/src/adapters/anthropic.ts
@@ -35,6 +35,13 @@ function toAnthropicContentPart(p: OcxContentPart): unknown {
 
 /** Default `max_tokens` when Codex omits `max_output_tokens`. */
 const DEFAULT_MAX_TOKENS = 8192;
+/**
+ * Default `max_tokens` for adaptive-thinking models (Fable 5, Sonnet 5, Opus 4.7+)
+ * when Codex omits `max_output_tokens`. Adaptive path previously left the 8192 default
+ * in place, so long parent turns hit max_tokens mid-work and finished with no final message.
+ * Matches Anthropic metadata max for these models (128k).
+ */
+const ADAPTIVE_DEFAULT_MAX_TOKENS = 128_000;
 /** Safe ceiling for `max_tokens` (thinking + visible output) across current Claude 4.x models. */
 const REASONING_MAX_TOKENS_CEILING = 32_000;
 /** Anthropic's documented minimum `thinking.budget_tokens`. */
@@ -629,9 +636,13 @@ export function createAnthropicAdapter(provider: OcxProviderConfig, cacheRetenti
       if (typeof parsed.options.reasoning === "string" && parsed.options.reasoning !== "none") {
         if (usesAdaptiveThinking(parsed.modelId)) {
           // Adaptive-thinking models replace the token budget with an effort knob and reject
-          // `thinking.type: "enabled"` outright — no budget/max_tokens re-sizing needed.
+          // `thinking.type: "enabled"` outright. They still enforce max_tokens as a hard cap
+          // on thinking + visible output, so leave a large default when Codex omits one.
           body.thinking = { type: "adaptive" };
           body.output_config = { effort: adaptiveEffort(parsed.options.reasoning) };
+          if (parsed.options.maxOutputTokens === undefined) {
+            body.max_tokens = ADAPTIVE_DEFAULT_MAX_TOKENS;
+          }
         } else {
           // Anthropic requires max_tokens > thinking.budget_tokens (max_tokens caps thinking +
           // visible output) and budget_tokens >= 1024. Codex sends the SAME value for both, which

--- a/tests/anthropic-reasoning.test.ts
+++ b/tests/anthropic-reasoning.test.ts
@@ -58,6 +58,22 @@ describe("anthropic extended-thinking gate", () => {
     expect(b.top_p).toBeUndefined();
   });
 
+  test.each([
+    "claude-sonnet-5",
+    "claude-fable-5",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+  ])("adaptive-thinking model %s defaults max_tokens well above 8192 when Codex omits it", async (modelId) => {
+    const b = await bodyOf(parsed("xhigh", {}, modelId));
+    expect(b.max_tokens).toBe(128_000);
+  });
+
+  test("adaptive-thinking model preserves explicit maxOutputTokens", async () => {
+    const b = await bodyOf(parsed("high", { maxOutputTokens: 20_000 }, "claude-fable-5"));
+    expect(b.thinking).toEqual({ type: "adaptive" });
+    expect(b.max_tokens).toBe(20_000);
+  });
+
   test("adaptive-thinking model maps unsupported 'minimal' effort to 'low'", async () => {
     const b = await bodyOf(parsed("minimal", {}, "claude-fable-5"));
     expect(b.output_config).toEqual({ effort: "low" });


### PR DESCRIPTION
## Summary

- Adaptive Claude models (`claude-fable-5`, `claude-sonnet-5`, `claude-opus-4-7`, `claude-opus-4-8`) previously kept the generic `max_tokens = 8192` default when Codex omitted `max_output_tokens`.
- The adaptive path only set `thinking.type = "adaptive"` and `output_config.effort`, and never resized `max_tokens`.
- Long Codex parent turns hit that ceiling mid-work and finished with no final message, even though those models support a 128k output ceiling.
- Default adaptive `max_tokens` to `128000` when Codex omits a budget, and preserve explicit `maxOutputTokens`.

## Verification

- `bun test tests/anthropic-reasoning.test.ts`
- Added regression coverage that adaptive models default to `128000` and preserve explicit budgets.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.