### PR TITLE
fix(server): sanitize reasoning content in v1 compact endpoint

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -25,7 +25,7 @@ export const FORWARD_HEADERS = [
   "x-responsesapi-include-timing-metrics",
 ];
 
-function sanitizeReasoningInputContent(body: unknown): unknown {
+export function sanitizeReasoningInputContent(body: unknown): unknown {
   if (!body || typeof body !== "object" || Array.isArray(body)) return body;
   const raw = body as Record<string, unknown>;
   if (!Array.isArray(raw.input)) return body;

--- a/src/server/responses.ts
+++ b/src/server/responses.ts
@@ -6,7 +6,7 @@ import {
 } from "../config";
 import { parseRequest } from "../responses/parser";
 import { buildCompactV1Output, COMPACT_PROMPT, decodeCompactionSummary, extractCompactUserMessages } from "../responses/compaction";
-import { FORWARD_HEADERS } from "../adapters/openai-responses";
+import { FORWARD_HEADERS, sanitizeReasoningInputContent } from "../adapters/openai-responses";
 import { expandPreviousResponseInput, previousResponseConversationId, rememberResponseState } from "../responses/state";
 import { routeModel } from "../router";
 import {
@@ -1787,7 +1787,11 @@ export async function handleResponsesCompact(
     }
     const base = (compactProvider.baseUrl ?? "").replace(/\/$/, "");
     if (compactProvider.apiKey) headers.set("authorization", `Bearer ${resolveEnvValue(compactProvider.apiKey)}`);
-    const { reasoning: _reasoning, ...compactBody } = raw as typeof raw & { reasoning?: unknown };
+    const { reasoning: _reasoning, ...compactBodyRaw } = raw as typeof raw & { reasoning?: unknown };
+    // The regular /v1/responses path applies sanitizeReasoningInputContent via the adapter's
+    // buildRequest, but the compact endpoint forwards directly. Apply the same sanitizer here
+    // so routed-model reasoning items (reasoning_text content) don't 400 the ChatGPT backend.
+    const compactBody = sanitizeReasoningInputContent(compactBodyRaw) as typeof compactBodyRaw;
     const compactUrl = `${base}/responses/compact`;
     const compactThreadId = req.headers.get("x-codex-parent-thread-id");
     const connectMs = config.connectTimeoutMs ?? 200_000;


### PR DESCRIPTION
## Problem

Issue #234: Threads mixing routed models (Kimi) with native OpenAI models permanently brick when remote compaction triggers. The error is `400 array_above_max_length` on `input[201].content`.

## Root cause

The bridge emits reasoning items with `content: [{ type: "reasoning_text", text: ... }]` for routed models. The regular `/v1/responses` path applies `sanitizeReasoningInputContent` via the adapter's `buildRequest`, which strips this non-standard content before forwarding to OpenAI.

But the `/v1/responses/compact` endpoint (v1 remote compaction) forwarded the request body verbatim, bypassing the sanitizer entirely. When Codex tried to compact a thread containing routed-model reasoning items, OpenAI rejected it because it expects reasoning items to have empty `content` arrays.

## Fix

Export `sanitizeReasoningInputContent` from `src/adapters/openai-responses.ts` and apply it to the compact body in `src/server/responses.ts` before forwarding, matching the regular `/v1/responses` path behavior.

## Impact

This fixes both new threads going forward and already-bricked threads, since the sanitizer runs on every compact request. No bridge changes needed.

## Verification

- `bun x tsc --noEmit` passes
- The fix is a 7-line change across 2 files
