### PR TITLE
fix(adapter): ensure root object type for Kimi tool schemas

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -337,6 +337,28 @@ function isXaiSchemaTarget(provider: OcxProviderConfig): boolean {
   }
 }
 
+function isKimiSchemaTarget(provider: OcxProviderConfig): boolean {
+  try {
+    return new URL(provider.baseUrl).hostname === "api.kimi.com";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Kimi requires function.parameters.type to be exactly "object" at the root.
+ * Codex tools with oneOf/anyOf schemas omit the root type, causing 400 errors.
+ * Add type: "object" at the root while preserving oneOf, $defs, and other schema keys.
+ */
+function ensureKimiRootObjectType(parameters: unknown): Record<string, unknown> {
+  if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
+    return { type: "object", properties: {} };
+  }
+  const obj = parameters as Record<string, unknown>;
+  if (obj.type === "object") return obj;
+  return { ...obj, type: "object" };
+}
+
 function expandXaiRootObjectSchemas(schema: unknown): Record<string, unknown>[] | undefined {
   if (!schema || typeof schema !== "object" || Array.isArray(schema)) return undefined;
   const obj = schema as Record<string, unknown>;
@@ -379,8 +401,13 @@ function toolsToChatFormat(parsed: OcxParsedRequest, provider: OcxProviderConfig
     : parsed.context.tools;
   if (tools.length === 0) return undefined;
   const xaiTarget = isXaiSchemaTarget(provider);
+  const kimiTarget = isKimiSchemaTarget(provider);
   const formatted = tools.flatMap(t => {
-    const parameters = xaiTarget ? normalizeXaiToolParameters(t.parameters) : t.parameters;
+    const parameters = xaiTarget
+      ? normalizeXaiToolParameters(t.parameters)
+      : kimiTarget
+        ? ensureKimiRootObjectType(t.parameters)
+        : t.parameters;
     if (parameters === undefined) return [];
     return [{
     type: "function",


### PR DESCRIPTION
## Problem

Issue #228: Kimi returns HTTP 400 when a Codex tool schema has no root `type: "object"`. The error is `tools.function.parameters.type is required and must be "object"`.

Codex tools like `automation_update` use valid JSON Schema with a root `oneOf` and no explicit root `type`. OpenCodex forwards that schema unchanged to Kimi's OpenAI-compatible function format. Kimi requires `function.parameters.type` to be exactly `"object"`, so it rejects the complete request before the model can call the tool.

## Root cause

In `src/adapters/openai-chat.ts`, `toolsToChatFormat()` passes `t.parameters` through unchanged for Kimi. There are already provider-specific schema paths for xAI and Zen, but Kimi currently uses the unmodified path.

## Fix

Add provider-scoped normalization for `api.kimi.com` that ensures `type: "object"` at the root while preserving `oneOf`, `$defs`, descriptions, and other schema keys. Similar to the existing xAI and Zen schema handling.

## Verification

- `bun x tsc --noEmit` passes
- The fix is a 28-line addition to `src/adapters/openai-chat.ts`
- The reporter confirmed this approach works locally with both the minimized reproduction and the full `automation_update` schema
