### PR TITLE
Fix Antigravity tool schemas with duplicate required fields

### DIFF
--- a/src/adapters/google-tool-schema.ts
+++ b/src/adapters/google-tool-schema.ts
@@ -73,6 +73,10 @@ function sanitize(node: unknown, defs: Map<string, unknown>, depth: number): unk
     if (key === "const") { out.enum = [value]; continue; }
     if (key === "exclusiveMinimum" && typeof value === "number") { out.minimum = value; continue; }
     if (key === "exclusiveMaximum" && typeof value === "number") { out.maximum = value; continue; }
+    if (key === "required" && Array.isArray(value)) {
+      out.required = [...new Set(value.filter((item): item is string => typeof item === "string"))];
+      continue;
+    }
     if (key === "additionalProperties") {
       // A boolean additionalProperties is accepted, but a nested schema is only meaningful with
       // its own sanitize pass.

--- a/tests/google-tool-schema.test.ts
+++ b/tests/google-tool-schema.test.ts
@@ -82,6 +82,14 @@ describe("sanitizeGeminiToolParameters", () => {
     expect(props.n.exclusiveMinimum).toBeUndefined();
   });
 
+  test("deduplicates required names for Claude-on-Antigravity", () => {
+    expect(sanitizeGeminiToolParameters({
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query", "query", 42],
+    }).required).toEqual(["query"]);
+  });
+
   test("inlines local $ref into $defs and removes the defs bag", () => {
     const out = sanitizeGeminiToolParameters({
       type: "object",


### PR DESCRIPTION
## Summary

- Deduplicate `required` entries while sanitizing Google-family tool schemas.
- Filter non-string `required` entries in the same pass so the emitted schema remains valid JSON Schema.
- Prevent Claude-on-Antigravity from rejecting the entire request with `tools.N.custom.input_schema: JSON schema is invalid. It must match JSON Schema draft 2020-12`.

Draft 2020-12 requires `required` arrays to contain unique strings. The sanitizer already walks every nested schema, so fixing that shared path covers native and MCP tools without provider-specific workarounds.

## Verification

- Live Antigravity reproduction: duplicate `required` entries returned HTTP 400 before sanitization; the sanitized payload returned HTTP 200.
- `bun test tests/google-tool-schema.test.ts tests/google-adapter.test.ts tests/google-antigravity-wire.test.ts` — 33 pass
- `bun run typecheck`
- `bun run privacy:scan`

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (not needed for this compatibility fix).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.
