### PR TITLE
fix(claude): preserve subscription OAuth with host routing

### DIFF
--- a/gui/src/pages/claude-manual-env.ts
+++ b/gui/src/pages/claude-manual-env.ts
@@ -34,12 +34,14 @@ export function buildManualEnv(state: ClaudeManualEnvState): string {
   return [
     `export ANTHROPIC_BASE_URL=${baseUrl}`,
     ...(state.authMode === "proxy"
-      ? ["export ANTHROPIC_AUTH_TOKEN=opencodex-proxy"]
+      ? [
+        "export ANTHROPIC_AUTH_TOKEN=opencodex-proxy",
+        // Host-managed routing guard (devlog 260720 020): only pair this with the
+        // host-supplied proxy token. The conditional preserves a user's opt-out.
+        '[ -z "${CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST+x}" ] && export CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1',
+      ]
       : ["# no ANTHROPIC_AUTH_TOKEN: your claude.ai login (and connectors) stay active"]),
     "export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1",
-    // Host-managed routing guard (devlog 260720 020): CONDITIONAL so a shell where
-    // the user already exported =0 keeps its opt-out even after pasting this block.
-    '[ -z "${CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST+x}" ] && export CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1',
     ...(autoCompactActive ? [`export CLAUDE_CODE_AUTO_COMPACT_WINDOW=${state.autoCompactWindow ?? 350000}`] : []),
     ...modelEnvExports,
     "claude",

--- a/src/cli/claude.ts
+++ b/src/cli/claude.ts
@@ -65,15 +65,15 @@ export function buildClaudeEnv(config: OcxConfig, port: number, base: ClaudeLaun
   // Connectors still work because they check OAuth state ($o()), not base URL (Gd()).
   // Native /model picker discovery ("From gateway", Claude Code >= 2.1.129).
   setDefault("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY", "1");
-  // Host-managed routing guard (devlog 260720_claude_authmode_persist/020): with
-  // this flag in the spawn env, Claude Code strips provider-managed vars
-  // (ANTHROPIC_BASE_URL/AUTH_TOKEN/API_KEY, model slots) from settings-sourced
-  // env (managedEnv.ts), so a leftover cc-switch/CCR ~/.claude/settings.json
-  // env block cannot silently hijack proxy routing away from opencodex.
-  // setDefault: an explicit user export (e.g. =0, isEnvTruthy-false) still wins.
-  // Intentional contract change: settings.env model slots are also stripped in
-  // ocx claude runs — use the top-level settings "model" field or opt out.
-  setDefault("CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST", "1");
+  // Host-managed routing guard (devlog 260720_claude_authmode_persist/020): when
+  // opencodex supplies the auth token, strip provider-managed vars from settings
+  // so a leftover cc-switch/CCR env block cannot hijack proxy routing. Do not set
+  // this in native subscription mode: Claude Code treats the flag as host-owned
+  // auth and reports no usable login when opencodex intentionally supplies none.
+  // setDefault preserves an explicit user opt-in or opt-out.
+  if (env.ANTHROPIC_AUTH_TOKEN) {
+    setDefault("CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST", "1");
+  }
   // Opt-in effort forcing (devlog 136 B6): opus-shaped aliases already carry
   // output_config.effort, so this is OFF unless the user enables it in config.
   if (config.claudeCode?.alwaysEnableEffort === true) {

--- a/tests/claude-cli.test.ts
+++ b/tests/claude-cli.test.ts
@@ -40,31 +40,49 @@ describe("ocx claude env assembly", () => {
   });
 
   // Host-managed routing guard (devlog 260720_claude_authmode_persist/020):
-  // defends the spawn env against leftover cc-switch/CCR settings.json env hijack.
-  test("sets CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1 by default", () => {
+  // use it only when opencodex also supplies the credential that the flag promises.
+  test("subscription mode keeps native OAuth and does not claim host-managed auth", () => {
     const env = buildClaudeEnv(cfg({ claudeCode: {} }), 10100, {});
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    expect(env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST).toBeUndefined();
+  });
+
+  test("proxy mode pairs its dummy token with the host-managed routing guard", () => {
+    const env = buildClaudeEnv(cfg({ claudeCode: { authMode: "proxy" } }), 10100, {});
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe("opencodex-proxy");
     expect(env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST).toBe("1");
   });
 
-  test("a user pre-export of the host-managed flag wins (opt-out preserved)", () => {
-    const env = buildClaudeEnv(cfg({ claudeCode: {} }), 10100, {
+  test("configured API key pairs its admission token with the routing guard", () => {
+    const env = buildClaudeEnv(cfg({
+      apiKeys: [{ id: "1", name: "main", key: "sk-ocx-123", createdAt: "2026-01-01" }],
+    }), 10100, {});
+    expect(env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST).toBe("1");
+  });
+
+  test("a user pre-export of the host-managed flag wins in every auth mode", () => {
+    const proxy = buildClaudeEnv(cfg({ claudeCode: { authMode: "proxy" } }), 10100, {
       CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: "0",
     });
     // isEnvTruthy("0") is false inside Claude Code, so "0" disables the strip.
-    expect(env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST).toBe("0");
+    expect(proxy.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST).toBe("0");
+
+    const subscription = buildClaudeEnv(cfg({ claudeCode: {} }), 10100, {
+      CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: "1",
+    });
+    expect(subscription.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST).toBe("1");
   });
 
-  test("model-slot injection is independent of the host-managed flag", () => {
-    // With no configured model, the flag rides along but no model slots appear —
-    // the intentional contract: settings.env slots are stripped by Claude Code,
-    // so users migrate to config model or the top-level settings "model" field.
-    const env = buildClaudeEnv(cfg({ claudeCode: {} }), 10100, {});
-    expect(env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST).toBe("1");
-    expect(env.ANTHROPIC_MODEL).toBeUndefined();
-    // And with a configured model both coexist.
-    const withModel = buildClaudeEnv(cfg({ claudeCode: { model: "mock/test-model" } }), 10100, {});
-    expect(withModel.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST).toBe("1");
-    expect(withModel.ANTHROPIC_MODEL).toBe("mock/test-model");
+  test("model-slot injection remains independent of the auth guard", () => {
+    const subscription = buildClaudeEnv(cfg({ claudeCode: { model: "mock/test-model" } }), 10100, {});
+    expect(subscription.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST).toBeUndefined();
+    expect(subscription.ANTHROPIC_MODEL).toBe("mock/test-model");
+
+    const proxy = buildClaudeEnv(cfg({
+      claudeCode: { authMode: "proxy", model: "mock/test-model" },
+    }), 10100, {});
+    expect(proxy.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST).toBe("1");
+    expect(proxy.ANTHROPIC_MODEL).toBe("mock/test-model");
   });
 
   test("lever env defaults OFF: no effort forcing, no context override (devlog 136 B6)", () => {

--- a/tests/claude-manual-env.test.ts
+++ b/tests/claude-manual-env.test.ts
@@ -25,11 +25,12 @@ test("proxy mode emits the dummy token plus the conditional host-managed flag", 
   expect(env).not.toContain("\nexport CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1");
 });
 
-test("subscription mode keeps the login comment and still carries the conditional flag", () => {
+test("subscription mode keeps native login without claiming host-managed auth", () => {
   const env = buildManualEnv(state());
   expect(env).toContain("# no ANTHROPIC_AUTH_TOKEN: your claude.ai login (and connectors) stay active");
   expect(env).not.toContain("export ANTHROPIC_AUTH_TOKEN=");
-  expect(env).toContain(CONDITIONAL_FLAG_LINE);
+  expect(env).not.toContain(CONDITIONAL_FLAG_LINE);
+  expect(env).not.toContain("CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST");
 });
 
 test("model env slots and auto-compact window are appended before the claude launch line", () => {


### PR DESCRIPTION
## Summary

- preserve Claude Code's native claude.ai OAuth path by not injecting `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST` when OpenCodex supplies no auth token
- retain the host-managed routing guard for proxy mode and configured admission-key paths
- keep explicit user `0`/`1` overrides and make the GUI manual environment block follow the same auth-mode rule
- add regression coverage for subscription, proxy, admission-key, model-slot, and manual-env behavior

Fixes #253.

## Why

Since v2.7.27, the launcher has injected the host-managed provider flag in every auth mode. Default subscription mode deliberately leaves `ANTHROPIC_AUTH_TOKEN` unset so Claude Code can use the existing claude.ai OAuth session. On Claude Code 2.1.206 for Windows, that combination reports `Not logged in · Please run /login`.

The fix gates the flag on the resulting `ANTHROPIC_AUTH_TOKEN`, rather than on a Claude Code version. This preserves the original protection against settings-sourced provider variables whenever OpenCodex actually owns the credential and routing path.

## Verification

### Focused tests

```text
25 pass
0 fail
```

Covered files:

- `tests/claude-cli.test.ts`
- `tests/claude-manual-env.test.ts`

### Runtime

Using the modified launcher with the existing Windows subscription login and no flag override:

```text
$ env -u CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST bun run src/cli/index.ts claude -p "Reply with exactly: OK" --output-format text
OK
```

Explicit user opt-out remains functional:

```text
$ CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=0 bun run src/cli/index.ts claude -p "Reply with exactly: OK" --output-format text
OK
```

An isolated proxy-mode run passed the login gate and reached upstream routing. The configured Claude alias then received an unrelated upstream 400 because that Claude-shaped model is unsupported by the available ChatGPT/Codex account; importantly, it did not produce `Not logged in`.

### Project checks

- typecheck: pass
- GUI lint: pass
- privacy scan: pass
- GUI doctor gate: pass/skip as not required by push range
- full tests: 3350 pass, 4 skip, 1 fail

The single failure is pre-existing/environmental and unrelated to this change: `tests/openai-provider-option-e2e.test.ts` detects that the real Claude config directory changes during its run. It reproduced when run alone, while both changed test files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
