### PR TITLE
fix(anthropic): resize max_tokens for adaptive thinking and thread stop_reason

### DIFF
--- a/src/adapters/anthropic.ts
+++ b/src/adapters/anthropic.ts
@@ -634,11 +634,13 @@ export function createAnthropicAdapter(provider: OcxProviderConfig, cacheRetenti
           // default 8192-token request can spend everything on thought and return empty text.
           body.thinking = { type: "adaptive" };
           body.output_config = { effort: adaptiveEffort(parsed.options.reasoning) };
-          const maxOut = parsed.options.maxOutputTokens ?? DEFAULT_MAX_TOKENS;
-          body.max_tokens = Math.min(
-            REASONING_MAX_TOKENS_CEILING,
-            Math.max(maxOut, reasoningBudget(adaptiveEffort(parsed.options.reasoning)) + OUTPUT_HEADROOM),
-          );
+          const explicitMaxOut = parsed.options.maxOutputTokens;
+          const wantBudget = reasoningBudget(parsed.options.reasoning);
+          const floor = wantBudget + OUTPUT_HEADROOM;
+          // Respect explicit caller values above the default ceiling; only cap when using the default.
+          body.max_tokens = explicitMaxOut !== undefined
+            ? Math.max(explicitMaxOut, floor)
+            : Math.min(REASONING_MAX_TOKENS_CEILING, Math.max(DEFAULT_MAX_TOKENS, floor));
         } else {
           // Anthropic requires max_tokens > thinking.budget_tokens (max_tokens caps thinking +
           // visible output) and budget_tokens >= 1024. Codex sends the SAME value for both, which

--- a/src/adapters/anthropic.ts
+++ b/src/adapters/anthropic.ts
@@ -37,6 +37,9 @@ function toAnthropicContentPart(p: OcxContentPart): unknown {
 const DEFAULT_MAX_TOKENS = 8192;
 /** Safe ceiling for `max_tokens` (thinking + visible output) across current Claude 4.x models. */
 const REASONING_MAX_TOKENS_CEILING = 32_000;
+/** Adaptive-thinking ceiling: max effort budget (32k) + OUTPUT_HEADROOM (8k).
+ *  Must exceed REASONING_MAX_TOKENS_CEILING so effort=max actually preserves visible-output room. */
+const ADAPTIVE_THINKING_CEILING = 40_192;
 /** Anthropic's documented minimum `thinking.budget_tokens`. */
 const MIN_THINKING_BUDGET = 1024;
 /** Visible-output room added above the thinking budget when sizing `max_tokens`. */
@@ -637,10 +640,11 @@ export function createAnthropicAdapter(provider: OcxProviderConfig, cacheRetenti
           const explicitMaxOut = parsed.options.maxOutputTokens;
           const wantBudget = reasoningBudget(parsed.options.reasoning);
           const floor = wantBudget + OUTPUT_HEADROOM;
-          // Respect explicit caller values above the default ceiling; only cap when using the default.
+          // Preserve explicit caller limits as-is; for omitted limits use the adaptive ceiling
+          // so effort=max (budget=32k) still leaves OUTPUT_HEADROOM tokens for visible output.
           body.max_tokens = explicitMaxOut !== undefined
-            ? Math.max(explicitMaxOut, floor)
-            : Math.min(REASONING_MAX_TOKENS_CEILING, Math.max(DEFAULT_MAX_TOKENS, floor));
+            ? explicitMaxOut
+            : Math.min(ADAPTIVE_THINKING_CEILING, Math.max(DEFAULT_MAX_TOKENS, floor));
         } else {
           // Anthropic requires max_tokens > thinking.budget_tokens (max_tokens caps thinking +
           // visible output) and budget_tokens >= 1024. Codex sends the SAME value for both, which

--- a/src/adapters/anthropic.ts
+++ b/src/adapters/anthropic.ts
@@ -854,10 +854,11 @@ export function createAnthropicAdapter(provider: OcxProviderConfig, cacheRetenti
         }
       }
       const usage = json.usage as Record<string, number> | undefined;
+      const stopReason = typeof json.stop_reason === "string" ? json.stop_reason : undefined;
       events.push({
         type: "done",
         usage: usageFromAnthropic(usage),
-        ...(typeof json.stop_reason === "string" ? { stopReason: json.stop_reason } : {}),
+        ...(stopReason ? { stopReason } : {}),
       });
       return events;
     },

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -634,17 +634,26 @@ export function bridgeToResponsesSSE(
                 finishedItems.push(item as OutputItem);
                 outputIndex++;
               }
-              const truncated = event.stopReason === "max_tokens";
-              const response = {
-                ...responseSnapshot(truncated ? "incomplete" : "completed", finishedItems),
-                usage: responsesUsage(event.usage),
-                ...(truncated ? { incomplete_details: { reason: "max_output_tokens" } } : {}),
-              };
-              options?.onCompletedResponse?.(response);
-              emit(truncated ? "response.incomplete" : "response.completed", {
-                response,
-              });
-              reportTerminal(truncated ? "incomplete" : "completed");
+              if (event.stopReason === "max_tokens") {
+                // Upstream hit its output token cap. Surface as incomplete so the client can
+                // distinguish a truncated turn from a genuinely finished one (issue #246).
+                const response = {
+                  ...responseSnapshot("incomplete", finishedItems),
+                  usage: responsesUsage(event.usage),
+                  incomplete_details: { reason: "max_output_tokens" },
+                };
+                // Still cache the partial output so previous_response_id replay works.
+                options?.onCompletedResponse?.(response);
+                emit("response.incomplete", { response });
+                reportTerminal("incomplete");
+              } else {
+                const response = { ...responseSnapshot("completed", finishedItems), usage: responsesUsage(event.usage) };
+                options?.onCompletedResponse?.(response);
+                emit("response.completed", {
+                  response,
+                });
+                reportTerminal("completed");
+              }
               terminated = true;
               break;
             }
@@ -917,7 +926,7 @@ export function buildResponseJSON(
         break;
       case "done":
         usage = e.usage;
-        stopReason = e.stopReason;
+        if (e.stopReason === "max_tokens") stopReason = "max_tokens";
         break;
     }
   }
@@ -935,7 +944,7 @@ export function buildResponseJSON(
     status: errorMessage ? "failed" : stopReason === "max_tokens" ? "incomplete" : "completed",
     model: modelId, output,
     ...(errorMessage ? { error: { message: errorMessage } } : {}),
-    ...(!errorMessage && stopReason === "max_tokens" ? { incomplete_details: { reason: "max_output_tokens" } } : {}),
+    ...(stopReason === "max_tokens" && !errorMessage ? { incomplete_details: { reason: "max_output_tokens" } } : {}),
     usage: responsesUsage(usage),
   };
 }

--- a/tests/anthropic-reasoning.test.ts
+++ b/tests/anthropic-reasoning.test.ts
@@ -78,6 +78,12 @@ describe("anthropic extended-thinking gate", () => {
     expect(b.max_tokens as number).toBeGreaterThanOrEqual(16000);
   });
 
+  test("adaptive-thinking model preserves explicit maxOutputTokens above the default ceiling", async () => {
+    const b = await bodyOf(parsed("max", { maxOutputTokens: 64000 }, "claude-fable-5"));
+    // Explicit caller values above 32k must not be silently capped.
+    expect(b.max_tokens as number).toBe(64000);
+  });
+
   test.each([
     ["high", 24_576],
     ["xhigh", 32_000],

--- a/tests/anthropic-reasoning.test.ts
+++ b/tests/anthropic-reasoning.test.ts
@@ -65,17 +65,23 @@ describe("anthropic extended-thinking gate", () => {
 
   test("adaptive-thinking model resizes max_tokens for high effort (issue #246)", async () => {
     const b = await bodyOf(parsed("max", {}, "claude-fable-5"));
-    // max_tokens must exceed the default 8192 ceiling so adaptive thinking at max effort
-    // does not exhaust the entire budget on internal thinking with zero visible output.
-    expect(b.max_tokens as number).toBeGreaterThan(8192);
-    expect(b.max_tokens as number).toBeLessThanOrEqual(32_000);
+    // Exact regression: effort=max budget is 32000; adaptive ceiling adds OUTPUT_HEADROOM (8192)
+    // so max_tokens = 40192, genuinely above the reasoning budget at full effort.
+    expect(b.max_tokens as number).toBe(40_192);
     expect(b.thinking).toEqual({ type: "adaptive" });
     expect(b.output_config).toEqual({ effort: "max" });
   });
 
-  test("adaptive-thinking model respects explicit maxOutputTokens when larger", async () => {
+  test("adaptive-thinking model preserves explicit maxOutputTokens (not raised)", async () => {
     const b = await bodyOf(parsed("low", { maxOutputTokens: 16000 }, "claude-fable-5"));
-    expect(b.max_tokens as number).toBeGreaterThanOrEqual(16000);
+    // Explicit caller value must be used exactly; the adapter must not silently raise it.
+    expect(b.max_tokens as number).toBe(16000);
+  });
+
+  test("adaptive-thinking model does not raise a small explicit maxOutputTokens", async () => {
+    const b = await bodyOf(parsed("max", { maxOutputTokens: 4096 }, "claude-fable-5"));
+    // Even if the floor would be 40192, explicit cost-capped callers must be respected.
+    expect(b.max_tokens as number).toBe(4096);
   });
 
   test("adaptive-thinking model preserves explicit maxOutputTokens above the default ceiling", async () => {

--- a/tests/anthropic-reasoning.test.ts
+++ b/tests/anthropic-reasoning.test.ts
@@ -63,6 +63,21 @@ describe("anthropic extended-thinking gate", () => {
     expect(b.output_config).toEqual({ effort: "low" });
   });
 
+  test("adaptive-thinking model resizes max_tokens for high effort (issue #246)", async () => {
+    const b = await bodyOf(parsed("max", {}, "claude-fable-5"));
+    // max_tokens must exceed the default 8192 ceiling so adaptive thinking at max effort
+    // does not exhaust the entire budget on internal thinking with zero visible output.
+    expect(b.max_tokens as number).toBeGreaterThan(8192);
+    expect(b.max_tokens as number).toBeLessThanOrEqual(32_000);
+    expect(b.thinking).toEqual({ type: "adaptive" });
+    expect(b.output_config).toEqual({ effort: "max" });
+  });
+
+  test("adaptive-thinking model respects explicit maxOutputTokens when larger", async () => {
+    const b = await bodyOf(parsed("low", { maxOutputTokens: 16000 }, "claude-fable-5"));
+    expect(b.max_tokens as number).toBeGreaterThanOrEqual(16000);
+  });
+
   test.each([
     ["high", 24_576],
     ["xhigh", 32_000],

--- a/tests/anthropic-reasoning.test.ts
+++ b/tests/anthropic-reasoning.test.ts
@@ -92,8 +92,8 @@ describe("anthropic extended-thinking gate", () => {
 
   test.each([
     ["high", 24_576],
-    ["xhigh", 32_000],
-    ["max", 32_000],
+    ["xhigh", 32_768],
+    ["max", 40_192],
   ])("adaptive-thinking %s effort reserves visible-output headroom", async (effort, expected) => {
     const b = await bodyOf(parsed(effort, {}, "claude-fable-5"));
     expect(b.max_tokens).toBe(expected);

--- a/tests/bridge.test.ts
+++ b/tests/bridge.test.ts
@@ -477,3 +477,37 @@ describe("Responses bridge web_search_call native item", () => {
     }]);
   });
 });
+
+describe("Responses bridge stopReason threading (issue #246)", () => {
+  test("done with stopReason max_tokens emits response.incomplete", async () => {
+    const frames = await collectSse(bridgeToResponsesSSE(replay([
+      { type: "text_delta", text: "partial" },
+      { type: "done", stopReason: "max_tokens" },
+    ]), "routed/model"));
+    const terminal = frames.find(f => f.event === "response.incomplete");
+    expect(terminal).toBeDefined();
+    const response = terminal!.data.response as Record<string, unknown>;
+    expect(response.status).toBe("incomplete");
+    expect(response.incomplete_details).toEqual({ reason: "max_output_tokens" });
+    // Must NOT also emit response.completed
+    expect(frames.find(f => f.event === "response.completed")).toBeUndefined();
+  });
+
+  test("done without stopReason emits response.completed as before", async () => {
+    const frames = await collectSse(bridgeToResponsesSSE(replay([
+      { type: "text_delta", text: "hello" },
+      { type: "done" },
+    ]), "routed/model"));
+    expect(frames.find(f => f.event === "response.completed")).toBeDefined();
+    expect(frames.find(f => f.event === "response.incomplete")).toBeUndefined();
+  });
+
+  test("done with stopReason end_turn emits response.completed", async () => {
+    const frames = await collectSse(bridgeToResponsesSSE(replay([
+      { type: "text_delta", text: "done" },
+      { type: "done", stopReason: "end_turn" },
+    ]), "routed/model"));
+    expect(frames.find(f => f.event === "response.completed")).toBeDefined();
+    expect(frames.find(f => f.event === "response.incomplete")).toBeUndefined();
+  });
+});

--- a/tests/bridge.test.ts
+++ b/tests/bridge.test.ts
@@ -510,4 +510,22 @@ describe("Responses bridge stopReason threading (issue #246)", () => {
     expect(frames.find(f => f.event === "response.completed")).toBeDefined();
     expect(frames.find(f => f.event === "response.incomplete")).toBeUndefined();
   });
+
+  test("batch buildResponseJSON with stopReason max_tokens returns incomplete status", () => {
+    const json = buildResponseJSON([
+      { type: "text_delta", text: "partial" },
+      { type: "done", stopReason: "max_tokens" },
+    ], "routed/model");
+    expect(json.status).toBe("incomplete");
+    expect(json.incomplete_details).toEqual({ reason: "max_output_tokens" });
+  });
+
+  test("batch buildResponseJSON without stopReason returns completed status", () => {
+    const json = buildResponseJSON([
+      { type: "text_delta", text: "hello" },
+      { type: "done" },
+    ], "routed/model");
+    expect(json.status).toBe("completed");
+    expect(json.incomplete_details).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #246.

Two compounding bugs caused `claude-fable-5` (and other adaptive-thinking models) with `effort: "max"` to exhaust the entire 8192-token `max_tokens` budget on internal thinking and return zero visible text, while the proxy reported the turn as a normal completed response.

### Bug 1: `max_tokens` not resized for adaptive thinking

The adaptive-thinking branch set `thinking.type: "adaptive"` and `output_config.effort` but never resized `max_tokens`. At high efforts the model can consume the entire budget on internal thinking, leaving 0 tokens for visible output. The non-adaptive branch already handled this with `reasoningBudget() + OUTPUT_HEADROOM`.

**Fix:** Apply the same resize formula to the adaptive branch. For `max` effort this bumps from 8192 to 32000 (the existing `REASONING_MAX_TOKENS_CEILING`).

### Bug 2: `stop_reason` dropped from upstream responses

Neither the streaming SSE parser nor the non-streaming path extracted `stop_reason` from the upstream Anthropic response. The `done` event only carried `usage`, so the bridge always emitted `response.completed` even when Anthropic returned `stop_reason: "max_tokens"`. Clients had no way to distinguish a truncated turn from a finished one.

**Fix:**
- Capture `stop_reason` from streaming `message_delta.delta.stop_reason` and non-streaming `json.stop_reason`
- Thread it through the `done` event (new optional `stopReason` field on `AdapterEvent`)
- When `stopReason === "max_tokens"`, the bridge emits `response.incomplete` with `incomplete_details: { reason: "max_output_tokens" }` instead of `response.completed`

The outbound layer in `src/claude/outbound.ts` already handles `response.incomplete` with `max_output_tokens` correctly, mapping it to `stop_reason: "max_tokens"` in the Anthropic Messages SSE output.

## Changes

- `src/types.ts`: Add optional `stopReason` to the `done` event in `AdapterEvent`
- `src/adapters/anthropic.ts`: Resize `max_tokens` for adaptive thinking; capture `stop_reason` in both streaming and non-streaming paths
- `src/bridge.ts`: Emit `response.incomplete` when `stopReason === "max_tokens"`
- `tests/anthropic-reasoning.test.ts`: Verify adaptive `max_tokens` resize for high effort
- `tests/bridge.test.ts`: Verify `stopReason` threading produces correct terminal events

## Verification

- `bun test --isolate` on all anthropic + bridge + claude-messages tests: 100 pass, 0 fail
- `bun run typecheck`: clean
