### PR TITLE
docs: document maintainers and review ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Default reviewers
+* @lidge-jun @Ingwannu
+
+# Repository automation and release security
+/.github/ @lidge-jun @Ingwannu
+/scripts/release.ts @lidge-jun @Ingwannu
+/package.json @lidge-jun @Ingwannu
+/bun.lock @lidge-jun @Ingwannu
+
+# Authentication, credentials, and management API
+/src/oauth/ @lidge-jun @Ingwannu
+/src/codex/auth-context.ts @lidge-jun @Ingwannu
+/src/server/auth-cors.ts @lidge-jun @Ingwannu
+/src/server/management-api.ts @lidge-jun @Ingwannu
+
+# Governance and security policy
+/MAINTAINERS.md @lidge-jun @Ingwannu
+/SECURITY.md @lidge-jun @Ingwannu

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Thanks for helping with opencodex.
 - Start with the canonical guide: [Contributing](https://lidge-jun.github.io/opencodex/contributing/)
 - Public user docs live in [`docs-site/`](./docs-site)
 - Current maintainer invariants live in [`structure/`](./structure)
+- Maintainer roles and merge policy live in [`MAINTAINERS.md`](./MAINTAINERS.md)
 - Historical investigations live in [`docs/`](./docs)
 
 For local development commands, architecture notes, and release workflow details, use the hosted

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,41 @@
+# Maintainers
+
+This document lists the people responsible for maintaining opencodex and defines the project's
+review and merge policy.
+
+## Current maintainers
+
+| GitHub account | Project role | Responsibilities |
+| --- | --- | --- |
+| [@lidge-jun](https://github.com/lidge-jun) | Project owner | Project direction, releases, repository administration, and final governance decisions |
+| [@Ingwannu](https://github.com/Ingwannu) | Maintainer | Issue and pull-request triage, `dev` integration, security review, and repository maintenance |
+
+The table describes project responsibilities. Actual repository permissions remain controlled
+through GitHub repository settings.
+
+## Review and merge policy
+
+- Normal pull requests target `dev`.
+- A pull request requires approval from at least one maintainer and successful required CI checks
+  before merge.
+- Authors do not approve their own pull requests.
+- Authentication, credential handling, GitHub Actions, release automation, dependency installation,
+  and other security-boundary changes require explicit security review.
+- Security-sensitive and release-related changes should be reviewed by both maintainers when
+  practical.
+- Direct pushes are reserved for maintainer-owned integration work, urgent repairs, or incident
+  recovery. The same CI and documentation requirements still apply.
+- Promotion from `dev` to `main` and npm releases is maintainer-controlled.
+
+## Maintainer changes
+
+Adding or removing a maintainer requires:
+
+1. agreement from the project owner,
+2. review by another current maintainer when available, and
+3. updates to this file and [`.github/CODEOWNERS`](./.github/CODEOWNERS).
+
+## Security reports
+
+Private vulnerability reports are handled by the current maintainers according to
+[`SECURITY.md`](./SECURITY.md). Do not disclose secrets or exploit details in a public issue.

--- a/docs-site/src/content/docs/contributing.md
+++ b/docs-site/src/content/docs/contributing.md
@@ -77,6 +77,12 @@ bun run release <version> --publish # publish after the CI-gated dry run is unde
 bun run release:watch               # watch the newest Release workflow run
 ```
 
+## Project maintainers
+
+The current maintainers, their responsibilities, and the review and merge policy are documented in
+[`MAINTAINERS.md`](https://github.com/lidge-jun/opencodex/blob/main/MAINTAINERS.md). GitHub review
+ownership for the repository and security-sensitive paths is declared in `.github/CODEOWNERS`.
+
 ## Conventions
 
 - **ES Modules only** (`import`/`export`), TypeScript, `strict` mode. Keep `bun x tsc --noEmit` clean.

--- a/structure/06_docs-and-release.md
+++ b/structure/06_docs-and-release.md
@@ -53,6 +53,22 @@ invariants belong in `structure/`, not the README.
 manual. When an investigation graduates into a maintained invariant, summarize it here under
 `structure/` and link public workflows from `docs-site/`.
 
+## Maintenance governance
+
+`MAINTAINERS.md` is the source of truth for current project roles and the review and merge policy.
+`.github/CODEOWNERS` declares default reviewers and repeats ownership for authentication, repository
+automation, release, and governance paths where an explicit security review is required. GitHub
+repository settings remain the source of truth for actual account permissions and protected-branch
+enforcement.
+
+[Decision Log]
+- 목적과 의도: Make project ownership and review authority discoverable without exposing credentials or treating a documentation file as an access-control mechanism.
+- 기존 구현 및 제약 조건: Contribution and security docs referred to maintainers generically, while the repository had no maintainer roster or CODEOWNERS policy. GitHub permissions can change independently of the source tree.
+- 검토한 주요 대안: Keep the roster only in GitHub settings; introduce a larger standalone governance charter; list raw GitHub permission levels in the repository.
+- 선택한 방식: Add a concise maintainer roster and merge policy, use CODEOWNERS for review routing, and keep actual permission state authoritative in GitHub settings.
+- 다른 대안 대신 이 방식을 선택한 이유: A two-maintainer project needs clear ownership and sensitive-path review rules but does not yet need a separate governance framework.
+- 장점, 단점 및 영향: Contributors can identify reviewers and merge expectations directly from the repository. The roster must be updated when responsibilities change, and CODEOWNERS still requires branch-protection configuration to enforce approvals.
+
 ## Package runtime (bundled Bun)
 
 The source runs on Bun, but the published package does **not** require a user-installed Bun.


### PR DESCRIPTION
## Summary

- add MAINTAINERS.md with the current project roster, responsibilities, and review/merge policy
- add .github/CODEOWNERS for default reviewers and security-sensitive repository paths
- link the policy from the root and hosted contributing documentation
- record the governance decision in the docs/release structure source of truth

## Why

The repository referred to maintainers generically but did not identify the current maintainers or document review ownership. This makes merge expectations and security-sensitive review routing unclear to contributors.

The roster describes project responsibilities while keeping GitHub repository settings authoritative for actual permissions.

## Impact

- contributors can identify the current maintainers and expected merge path
- changes to authentication, automation, releases, and governance automatically request the declared owners
- no runtime, package, credential, or permission changes are included

## Verification

- confirmed the listed accounts are the repository's current direct administrators
- git diff --check
- cd docs-site && bun run build