### PR TITLE
fix: add output defaults and hide web-search replay markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,13 +350,16 @@ Here's a typical multi-provider setup:
 }
 ```
 
-Provider entries can also annotate routed catalog metadata. Use `contextWindow` for a provider-wide
-Codex-visible context cap, `modelContextWindows` for model-specific caps, and
+Provider entries can also annotate routed catalog metadata and output defaults. Use `contextWindow`
+for a provider-wide Codex-visible context cap, `modelContextWindows` for model-specific caps, and
 `modelInputModalities` for model-specific catalog input hints such as `["text"]` or
-`["text", "image"]`. Context values cap live `/models` metadata; they never raise a smaller live
-context window. The bundled GPT-5.6 Sol/Terra/Luna fallback metadata uses a 1,050,000-token context
-window for OpenAI API key and OpenRouter catalog entries; it does not bypass upstream preview
-access. See the configuration reference for the full field list.
+`["text", "image"]`. For OpenAI-compatible chat providers whose upstream default response budget is
+too small, set `defaultMaxOutputTokens` or per-model `modelMaxOutputTokens`; explicit
+`max_output_tokens` from the client still wins, and unset configs still omit `max_tokens`. Context
+values cap live `/models` metadata; they never raise a smaller live context window. The bundled
+GPT-5.6 Sol/Terra/Luna fallback metadata uses a 1,050,000-token context window for OpenAI API key
+and OpenRouter catalog entries; it does not bypass upstream preview access. See the configuration
+reference for the full field list.
 
 > **GLM-5.2 1M context via Z.AI:** through the `openai-chat` adapter, both `glm-5.2`
 > and `glm-5.2[1m]` work — opencodex strips the trailing `[1m]` suffix before

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -155,6 +155,9 @@ network. Only do this on trusted networks, and always set a strong `OPENCODEX_AP
 | `contextWindow?` | `number` | Provider-wide Codex-visible context-window cap for routed catalog entries. Live metadata below this value is kept. |
 | `modelContextWindows?` | `Record<string,number>` | Model-specific context-window caps. These override `contextWindow` for matching model ids and never raise smaller live metadata. |
 | `modelInputModalities?` | `Record<string,string[]>` | Model-specific catalog input hints such as `["text"]` or `["text", "image"]`. |
+| `modelMaxInputTokens?` | `Record<string,number>` | Model-specific max input token limits used for catalog auto-compaction hints. Values must be positive integers. |
+| `defaultMaxOutputTokens?` | `number` | Provider-wide `openai-chat` fallback for `max_tokens` when the client omits `max_output_tokens`. Explicit requests still win. |
+| `modelMaxOutputTokens?` | `Record<string,number>` | Model-specific `openai-chat` fallback output budgets. Exact/model-pattern matches beat `defaultMaxOutputTokens`; all values must be positive integers. |
 | `headers?` | `Record<string,string>` | Extra upstream headers. Authorization, cookies, API-key headers, embedded newlines, and invalid header names are rejected. |
 | `openRouterRouting?` | `OpenRouterProviderRouting` | Default OpenRouter provider preferences. Supports `order`, `only`, and `allowFallbacks`; valid only with the canonical OpenRouter base URL and `openai-chat` adapter. |
 | `modelOpenRouterRouting?` | `Record<string,OpenRouterProviderRouting>` | Exact model-id overrides for `openRouterRouting`. A matching entry replaces the provider-wide default. |

--- a/docs/adr/0006-provider-output-defaults-and-web-search-replay.md
+++ b/docs/adr/0006-provider-output-defaults-and-web-search-replay.md
@@ -1,0 +1,36 @@
+# ADR 0006: Provider output defaults and web-search replay privacy
+
+## Status
+
+Accepted
+
+## Context
+
+Codex clients may omit Responses `max_output_tokens`. OpenAI-compatible chat
+providers then inherit their own default `max_tokens`, which can be much smaller
+than the model supports. This is especially visible on reasoning-heavy coding
+models where the default budget covers both thinking and visible output.
+
+Routed providers also receive expanded Responses history. Historical
+`web_search_call` output items are internal evidence that a prior hosted search
+cell was rendered, but they do not contain a paired result payload that a routed
+adapter can replay safely.
+
+## Decision
+
+[Decision Log]
+- 목적과 의도: Allow operators to set honest provider/model output-token fallbacks without changing explicit caller requests, and prevent internal web-search replay markers from becoming model-visible text.
+- 기존 구현 및 제약 조건: `openai-chat` only sent `max_tokens` from request `max_output_tokens`; provider config already had input/context metadata but no output fallback. Historical `web_search_call` replay was converted to `[web search performed: ...]` assistant text, which could be echoed when no sidecar plan was available.
+- 검토한 주요 대안: Force a global `max_tokens`; add provider-only defaults; add provider plus model-specific defaults; filter the marker from final output; convert replayed hosted search cells into synthetic tool calls.
+- 선택한 방식: Resolve `max_tokens` in the `openai-chat` adapter with precedence explicit request, model-specific provider config, provider default, then omit. Validate both config fields as positive integers and thread them through registry/derive/router plumbing. Drop replayed hosted search cells from assistant-visible history instead of post-filtering output.
+- 다른 대안 대신 이 방식을 선택한 이유: Adapter-time resolution preserves passthrough behavior and keeps the field closest to the OpenAI Chat wire. Model-specific defaults cover providers with mixed ceilings. Hiding replay cells at parse time removes the leak source without claiming a current search ran or altering the active sidecar loop.
+- 장점, 단점 및 영향: Long routed turns can opt into larger budgets while existing configs remain byte-for-byte compatible when unset. Historical search cells no longer create echoable sentinel text; the tradeoff is that routed models do not receive a separate text hint that a prior search cell existed when no actual search result payload is available.
+
+## Consequences
+
+- Existing configs continue omitting `max_tokens` unless they add
+  `defaultMaxOutputTokens` or `modelMaxOutputTokens`.
+- Explicit Responses `max_output_tokens` remains authoritative.
+- Registry defaults can be added later without changing adapter behavior.
+- The active web-search sidecar still emits real `web_search_call` cells only
+  when a sidecar executes a search.

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -1,7 +1,7 @@
 import type { ProviderAdapter } from "./base";
 import type { AdapterEvent, OcxAssistantMessage, OcxContentPart, OcxMessage, OcxParsedRequest, OcxProviderConfig, OcxTextContent, OcxThinkingContent, OcxToolCall, OcxUsage } from "../types";
 import { isAllowedToolChoice, modelInList, namespacedToolName, resolveToolChoiceWireName, toolAllowedByChoice } from "../types";
-import { mapReasoningEffort } from "../reasoning-effort";
+import { mapReasoningEffort, modelRecordValue } from "../reasoning-effort";
 import { redactSecretString } from "../lib/redact";
 import { contentPartsToText } from "./image";
 import { neutralizeIdentity } from "./identity";
@@ -460,9 +460,15 @@ function usageFromOpenAIChat(usage: Record<string, unknown> | undefined): OcxUsa
   };
 }
 
-function thinkingBudgetForEffort(parsed: OcxParsedRequest, reasoningEffort: string): number | undefined {
+function resolveMaxTokens(provider: OcxProviderConfig, parsed: OcxParsedRequest): number | undefined {
+  return parsed.options.maxOutputTokens
+    ?? modelRecordValue(provider.modelMaxOutputTokens, parsed.modelId)
+    ?? provider.defaultMaxOutputTokens;
+}
+
+function thinkingBudgetForEffort(parsed: OcxParsedRequest, reasoningEffort: string, maxOutputTokens?: number): number | undefined {
   if (parsed.options.reasoning === "minimal") return 0;
-  const maxBudget = parsed.options.maxOutputTokens ?? 32768;
+  const maxBudget = maxOutputTokens ?? 32768;
   const fractions: Record<string, number> = {
     low: 0.20,
     medium: 0.50,
@@ -495,6 +501,7 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
         messages,
         stream: parsed.stream,
       };
+      const maxTokens = resolveMaxTokens(provider, parsed);
       const openRouterRouting = resolveOpenRouterRouting(provider, parsed.modelId);
       if (openRouterRouting) body.provider = openRouterProviderPayload(openRouterRouting);
       if (tools) body.tools = tools;
@@ -503,7 +510,7 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
           ? (toolChoice === "none" ? "none" : "auto")
           : toolChoice;
       }
-      if (parsed.options.maxOutputTokens !== undefined) body.max_tokens = parsed.options.maxOutputTokens;
+      if (maxTokens !== undefined) body.max_tokens = maxTokens;
       if (parsed.options.temperature !== undefined && !modelInList(provider.noTemperatureModels, parsed.modelId)) {
         body.temperature = parsed.options.temperature;
       }
@@ -514,7 +521,7 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
       const reasoningEffort = mapReasoningEffort(provider, parsed.modelId, parsed.options.reasoning);
       if (reasoningEffort !== undefined) {
         if (modelInList(provider.thinkingBudgetModels, parsed.modelId)) {
-          const budget = thinkingBudgetForEffort(parsed, reasoningEffort);
+          const budget = thinkingBudgetForEffort(parsed, reasoningEffort, maxTokens);
           if (budget !== undefined) body.thinking_budget = budget;
         } else if (modelInList(provider.thinkingToggleModels, parsed.modelId)) {
           // Vendor thinking-toggle wire (MiMo v2.x, GLM 5/5.1): the mapped value is the toggle

--- a/src/config.ts
+++ b/src/config.ts
@@ -396,6 +396,14 @@ export function positiveIntegerRecordConfigError(value: unknown, field: string):
   return null;
 }
 
+export function positiveIntegerConfigError(value: unknown, field: string): string | null {
+  if (value === undefined) return null;
+  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value <= 0) {
+    return `${field} must be a positive finite integer`;
+  }
+  return null;
+}
+
 const configSchema = z.object({
   port: z.number().int().min(0).max(65535).default(10100),
   providers: z.record(z.string(), providerConfigSchema),
@@ -468,6 +476,28 @@ const configSchema = z.object({
         code: "custom",
         path: ["providers", name, "modelMaxInputTokens"],
         message: maxInputError,
+      });
+    }
+    const defaultMaxOutputError = positiveIntegerConfigError(
+      (provider as { defaultMaxOutputTokens?: unknown }).defaultMaxOutputTokens,
+      "defaultMaxOutputTokens",
+    );
+    if (defaultMaxOutputError) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["providers", name, "defaultMaxOutputTokens"],
+        message: defaultMaxOutputError,
+      });
+    }
+    const maxOutputError = positiveIntegerRecordConfigError(
+      (provider as { modelMaxOutputTokens?: unknown }).modelMaxOutputTokens,
+      "modelMaxOutputTokens",
+    );
+    if (maxOutputError) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["providers", name, "modelMaxOutputTokens"],
+        message: maxOutputError,
       });
     }
     if (Object.hasOwn(provider, "codexAccountMode") && provider.codexAccountMode !== undefined) {

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -478,6 +478,8 @@ const OAUTH_RECONCILE_FIELDS: (keyof OcxProviderConfig)[] = [
   "models",
   "contextWindow",
   "modelContextWindows",
+  "defaultMaxOutputTokens",
+  "modelMaxOutputTokens",
   "modelInputModalities",
   "noReasoningModels",
   "noVisionModels",

--- a/src/oauth/login-cli.ts
+++ b/src/oauth/login-cli.ts
@@ -72,6 +72,8 @@ export function providerConfigFromKeyLoginProvider(def: KeyLoginProvider, key: s
     ...(def.contextWindow !== undefined ? { contextWindow: def.contextWindow } : {}),
     ...(def.modelContextWindows ? { modelContextWindows: { ...def.modelContextWindows } } : {}),
     ...(def.modelMaxInputTokens ? { modelMaxInputTokens: { ...def.modelMaxInputTokens } } : {}),
+    ...(def.defaultMaxOutputTokens !== undefined ? { defaultMaxOutputTokens: def.defaultMaxOutputTokens } : {}),
+    ...(def.modelMaxOutputTokens ? { modelMaxOutputTokens: { ...def.modelMaxOutputTokens } } : {}),
     ...(def.modelInputModalities ? { modelInputModalities: cloneRecordOfArrays(def.modelInputModalities) } : {}),
     ...(def.reasoningEfforts ? { reasoningEfforts: [...def.reasoningEfforts] } : {}),
     ...(def.modelReasoningEfforts ? { modelReasoningEfforts: cloneRecordOfArrays(def.modelReasoningEfforts) } : {}),

--- a/src/providers/derive.ts
+++ b/src/providers/derive.ts
@@ -13,6 +13,8 @@ export interface DerivedKeyLoginProvider {
   modelContextWindows?: Record<string, number>;
   modelInputModalities?: Record<string, string[]>;
   modelMaxInputTokens?: Record<string, number>;
+  defaultMaxOutputTokens?: number;
+  modelMaxOutputTokens?: Record<string, number>;
   reasoningEfforts?: string[];
   modelReasoningEfforts?: Record<string, string[]>;
   modelDefaultReasoningEfforts?: Record<string, string>;
@@ -96,6 +98,8 @@ export function providerConfigSeed(entry: ProviderRegistryEntry): OcxProviderCon
     ...(entry.modelContextWindows ? { modelContextWindows: { ...entry.modelContextWindows } } : {}),
     ...(entry.modelInputModalities ? { modelInputModalities: cloneRecordOfArrays(entry.modelInputModalities) } : {}),
     ...(entry.modelMaxInputTokens ? { modelMaxInputTokens: { ...entry.modelMaxInputTokens } } : {}),
+    ...(entry.defaultMaxOutputTokens !== undefined ? { defaultMaxOutputTokens: entry.defaultMaxOutputTokens } : {}),
+    ...(entry.modelMaxOutputTokens ? { modelMaxOutputTokens: { ...entry.modelMaxOutputTokens } } : {}),
     ...(entry.reasoningEfforts ? { reasoningEfforts: [...entry.reasoningEfforts] } : {}),
     ...(entry.modelReasoningEfforts ? { modelReasoningEfforts: cloneRecordOfArrays(entry.modelReasoningEfforts) } : {}),
     ...(entry.modelDefaultReasoningEfforts ? { modelDefaultReasoningEfforts: { ...entry.modelDefaultReasoningEfforts } } : {}),
@@ -135,6 +139,8 @@ export function deriveKeyLoginMap(): Record<string, DerivedKeyLoginProvider> {
       ...(entry.modelContextWindows ? { modelContextWindows: { ...entry.modelContextWindows } } : {}),
       ...(entry.modelInputModalities ? { modelInputModalities: cloneRecordOfArrays(entry.modelInputModalities) } : {}),
       ...(entry.modelMaxInputTokens ? { modelMaxInputTokens: { ...entry.modelMaxInputTokens } } : {}),
+      ...(entry.defaultMaxOutputTokens !== undefined ? { defaultMaxOutputTokens: entry.defaultMaxOutputTokens } : {}),
+      ...(entry.modelMaxOutputTokens ? { modelMaxOutputTokens: { ...entry.modelMaxOutputTokens } } : {}),
       ...(entry.reasoningEfforts ? { reasoningEfforts: [...entry.reasoningEfforts] } : {}),
       ...(entry.modelReasoningEfforts ? { modelReasoningEfforts: cloneRecordOfArrays(entry.modelReasoningEfforts) } : {}),
       ...(entry.modelDefaultReasoningEfforts ? { modelDefaultReasoningEfforts: { ...entry.modelDefaultReasoningEfforts } } : {}),
@@ -203,6 +209,8 @@ export function enrichProviderFromRegistry(name: string, prov: OcxProviderConfig
   if (prov.contextWindow === undefined && seed.contextWindow !== undefined) prov.contextWindow = seed.contextWindow;
   if (!prov.modelContextWindows && seed.modelContextWindows) prov.modelContextWindows = { ...seed.modelContextWindows };
   if (!prov.modelInputModalities && seed.modelInputModalities) prov.modelInputModalities = cloneRecordOfArrays(seed.modelInputModalities);
+  if (prov.defaultMaxOutputTokens === undefined && seed.defaultMaxOutputTokens !== undefined) prov.defaultMaxOutputTokens = seed.defaultMaxOutputTokens;
+  if (!prov.modelMaxOutputTokens && seed.modelMaxOutputTokens) prov.modelMaxOutputTokens = { ...seed.modelMaxOutputTokens };
   if (!prov.reasoningEfforts && seed.reasoningEfforts) prov.reasoningEfforts = [...seed.reasoningEfforts];
   if (!prov.modelReasoningEfforts && seed.modelReasoningEfforts) prov.modelReasoningEfforts = cloneRecordOfArrays(seed.modelReasoningEfforts);
   if (!prov.modelDefaultReasoningEfforts && seed.modelDefaultReasoningEfforts) prov.modelDefaultReasoningEfforts = { ...seed.modelDefaultReasoningEfforts };

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -53,6 +53,8 @@ export interface ProviderRegistryEntry {
   contextWindow?: number;
   modelContextWindows?: Record<string, number>;
   modelInputModalities?: Record<string, string[]>;
+  defaultMaxOutputTokens?: number;
+  modelMaxOutputTokens?: Record<string, number>;
   reasoningEfforts?: string[];
   modelReasoningEfforts?: Record<string, string[]>;
   modelDefaultReasoningEfforts?: Record<string, string>;
@@ -87,7 +89,7 @@ export type ProviderConfigSeed = Pick<
   OcxProviderConfig,
   "adapter" | "baseUrl" | "authMode" | "keyOptional" | "freeTier" | "modelSuffixBracketStrip" | "defaultModel" | "models"
   | "liveModels" | "contextWindow" | "modelContextWindows" | "modelInputModalities"
-  | "modelMaxInputTokens"
+  | "modelMaxInputTokens" | "defaultMaxOutputTokens" | "modelMaxOutputTokens"
   | "reasoningEfforts" | "modelReasoningEfforts" | "modelDefaultReasoningEfforts" | "reasoningEffortMap" | "modelReasoningEffortMap"
   | "noVisionModels" | "noReasoningModels" | "noTemperatureModels" | "noTopPModels" | "noPenaltyModels"
   | "autoToolChoiceOnlyModels" | "preserveReasoningContentModels" | "thinkingToggleModels" | "thinkingBudgetModels" | "escapeBuiltinToolNames"

--- a/src/responses/parser.ts
+++ b/src/responses/parser.ts
@@ -443,13 +443,10 @@ export function parseRequest(body: unknown): OcxParsedRequest {
       }
 
       if (effectiveType === "web_search_call") {
-        // Replayed hosted web-search evidence. Textify it into assistant history so the model
-        // knows the search already ran (prevents re-search loops); there is no output to pair.
-        const call = item as { action?: { type?: string; query?: string } };
-        const query = typeof call.action?.query === "string" ? call.action.query : "";
-        assistantHolderWithReasoning().content.push({
-          type: "text", text: query ? `[web search performed: ${query}]` : "[web search performed]",
-        });
+        // Replayed hosted web-search evidence has no paired result payload that routed providers can
+        // consume. Keep it out of assistant-visible text: the old marker was useful as an internal
+        // loop hint, but when no sidecar is available the model can echo it as a fake answer.
+        pendingReasoning.length = 0;
         continue;
       }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -49,6 +49,7 @@ export function knownModelIdsForProvider(provName: string, prov: OcxProviderConf
     registry?.modelReasoningEfforts,
     registry?.modelDefaultReasoningEfforts,
     registry?.modelReasoningEffortMap,
+    registry?.modelMaxOutputTokens,
   ]) {
     for (const id of Object.keys(map ?? {})) ids.add(id);
   }
@@ -141,6 +142,7 @@ function routedProviderConfig(providerName: string, provider: OcxProviderConfig)
   const modelMaxInputTokens = providerName === OPENAI_API_PROVIDER_ID
     ? mergePositiveNumberCaps(registryEntry.modelMaxInputTokens, provider.modelMaxInputTokens)
     : mergeRecordFill(registryEntry.modelMaxInputTokens, provider.modelMaxInputTokens);
+  const modelMaxOutputTokens = mergeRecordFill(registryEntry.modelMaxOutputTokens, provider.modelMaxOutputTokens);
   const noVisionModels = mergeStringArray(registryEntry.noVisionModels, provider.noVisionModels);
   const noReasoningModels = mergeStringArray(registryEntry.noReasoningModels, provider.noReasoningModels);
   const noTemperatureModels = mergeStringArray(registryEntry.noTemperatureModels, provider.noTemperatureModels);
@@ -183,9 +185,13 @@ function routedProviderConfig(providerName: string, provider: OcxProviderConfig)
     // opt-in, while an explicit user `false` keeps overriding registry `true`.
     ...(provider.parallelToolCalls === undefined && registryEntry.parallelToolCalls !== undefined ? { parallelToolCalls: registryEntry.parallelToolCalls } : {}),
     ...(provider.promptCacheKey === undefined && registryEntry.promptCacheKey !== undefined ? { promptCacheKey: registryEntry.promptCacheKey } : {}),
+    ...(provider.defaultMaxOutputTokens === undefined && registryEntry.defaultMaxOutputTokens !== undefined
+      ? { defaultMaxOutputTokens: registryEntry.defaultMaxOutputTokens }
+      : {}),
     ...(modelContextWindows ? { modelContextWindows } : {}),
     ...(modelInputModalities ? { modelInputModalities } : {}),
     ...(modelMaxInputTokens ? { modelMaxInputTokens } : {}),
+    ...(modelMaxOutputTokens ? { modelMaxOutputTokens } : {}),
     ...(modelReasoningEfforts ? { modelReasoningEfforts } : {}),
     ...(modelDefaultReasoningEfforts ? { modelDefaultReasoningEfforts } : {}),
     ...(reasoningEffortMap ? { reasoningEffortMap } : {}),

--- a/src/server/auth-cors.ts
+++ b/src/server/auth-cors.ts
@@ -2,6 +2,7 @@ import { timingSafeEqual } from "node:crypto";
 import { formatErrorResponse } from "../bridge";
 import {
   codexAutoStartEnabled,
+  positiveIntegerConfigError,
   positiveIntegerRecordConfigError,
   providerBaseUrlConfigError,
   providerHeadersConfigError,
@@ -227,6 +228,10 @@ export function providerManagementConfigError(name: unknown, provider: unknown):
   if (headersError) return `provider ${name} ${headersError}`;
   const maxInputError = positiveIntegerRecordConfigError(raw.modelMaxInputTokens, "modelMaxInputTokens");
   if (maxInputError) return `provider ${name} ${maxInputError}`;
+  const defaultMaxOutputError = positiveIntegerConfigError(raw.defaultMaxOutputTokens, "defaultMaxOutputTokens");
+  if (defaultMaxOutputError) return `provider ${name} ${defaultMaxOutputError}`;
+  const maxOutputError = positiveIntegerRecordConfigError(raw.modelMaxOutputTokens, "modelMaxOutputTokens");
+  if (maxOutputError) return `provider ${name} ${maxOutputError}`;
   const openRouterError = openRouterRoutingConfigError(typed);
   if (openRouterError) return `provider ${name} ${openRouterError}`;
   if (typed.authMode === "local") {
@@ -293,6 +298,8 @@ export function safeConfigDTO(config: OcxConfig): unknown {
       "models",
       "contextWindow",
       "modelContextWindows",
+      "defaultMaxOutputTokens",
+      "modelMaxOutputTokens",
       "openRouterRouting",
       "modelOpenRouterRouting",
       "reasoningEfforts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -667,6 +667,13 @@ export interface OcxProviderConfig {
   modelInputModalities?: Record<string, string[]>;
   /** Model-specific max input token limits. Values cap auto_compact_token_limit. */
   modelMaxInputTokens?: Record<string, number>;
+  /**
+   * Provider-wide fallback for chat-completions `max_tokens` when the caller omits
+   * Responses `max_output_tokens`. Adapters still let an explicit request win.
+   */
+  defaultMaxOutputTokens?: number;
+  /** Model-specific fallback output token budgets. Exact/model-pattern entries beat the provider default. */
+  modelMaxOutputTokens?: Record<string, number>;
   headers?: Record<string, string>;
   /** Default provider-routing preferences for models sent through the canonical OpenRouter API. */
   openRouterRouting?: OpenRouterProviderRouting;

--- a/structure/02_config-and-codex-home.md
+++ b/structure/02_config-and-codex-home.md
@@ -45,6 +45,17 @@ opencodex also writes `$CODEX_HOME/opencodex.config.toml` as an explicit profile
 uses `service_tier = "fast"` and `[features].fast_mode = true`; catalog/request tier metadata may use
 `priority`. Do not collapse these spellings into one value.
 
+## Provider output defaults
+
+`OcxProviderConfig.defaultMaxOutputTokens` and `modelMaxOutputTokens` are OpenAI Chat wire defaults,
+not context-window metadata. They are applied only when a Responses request omits
+`max_output_tokens`; an explicit request value wins, then a model-specific configured value, then
+the provider default, then the adapter omits `max_tokens`.
+
+Both fields must stay positive finite integers at disk-config and management validation boundaries.
+Registry entries may seed them through `providerConfigSeed`, key-login derivation, OAuth reconcile,
+and `routeModel`, but user config overrides registry defaults per field/key.
+
 ## Restore
 
 `ocx stop`, `ocx restore` / `ocx eject`, `ocx service stop`, and `ocx service uninstall` must strip

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -71,6 +71,12 @@ the client. Only the first iteration's final response headers/status and any 429
 handled eagerly. A failure before downstream SSE starts returns non-2xx JSON; once headers have
 started the final response, a generation failure is emitted as `response.failed` SSE.
 
+Historical `web_search_call` output items from previous Responses turns are not converted into
+assistant text. They are UI/search-cell evidence, not a replayable search result payload; turning
+them into strings risks routed models echoing an internal marker or implying a current search ran
+when the sidecar is unavailable. The active sidecar path is the only place that emits new
+`web_search_call_begin` / `web_search_call_end` events.
+
 Four independent clocks bound this path. `stallTimeoutSec` is the base bridge event-stall budget.
 `connectTimeoutMs` (default 200 s) covers only DNS/TCP/TLS and the wait for final response headers,
 not response-body generation. Config-file-only

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -12,6 +12,7 @@ import {
   isOcxStartCommandLine,
   loadConfig,
   parsePidFile,
+  positiveIntegerConfigError,
   positiveIntegerRecordConfigError,
   readConfigDiagnostics,
   readRuntimePort,
@@ -355,6 +356,40 @@ describe("opencodex config defaults", () => {
     for (const invalid of [null, [], { model: 0 }, { model: -1 }, { model: 1.5 }, { model: "1" }, { model: Number.POSITIVE_INFINITY }]) {
       expect(positiveIntegerRecordConfigError(invalid, "modelMaxInputTokens")).not.toBeNull();
     }
+  });
+
+  test("output token defaults accept only positive finite integers", () => {
+    expect(positiveIntegerConfigError(128_000, "defaultMaxOutputTokens")).toBeNull();
+    for (const invalid of [null, [], {}, 0, -1, 1.5, "128000", Number.POSITIVE_INFINITY]) {
+      expect(positiveIntegerConfigError(invalid, "defaultMaxOutputTokens")).not.toBeNull();
+    }
+
+    expect(positiveIntegerRecordConfigError({ "glm-5.2": 128_000 }, "modelMaxOutputTokens")).toBeNull();
+    expect(positiveIntegerRecordConfigError({ "glm-5.2": 0 }, "modelMaxOutputTokens")).not.toBeNull();
+  });
+
+  test("disk config rejects malformed output token defaults", () => {
+    writeConfig({
+      port: 10100,
+      providers: {
+        custom: { adapter: "openai-chat", baseUrl: "https://example.test/v1", defaultMaxOutputTokens: 1.5 },
+      },
+      defaultProvider: "custom",
+    });
+    expect(readConfigDiagnostics().source).toBe("fallback");
+    expect(readConfigDiagnostics().error).toContain("providers.custom.defaultMaxOutputTokens");
+
+    rmSync(testDir, { recursive: true, force: true });
+    mkdirSync(testDir, { recursive: true });
+    writeConfig({
+      port: 10100,
+      providers: {
+        custom: { adapter: "openai-chat", baseUrl: "https://example.test/v1", modelMaxOutputTokens: { model: 0 } },
+      },
+      defaultProvider: "custom",
+    });
+    expect(readConfigDiagnostics().source).toBe("fallback");
+    expect(readConfigDiagnostics().error).toContain("providers.custom.modelMaxOutputTokens");
   });
 
   test("disk config rejects malformed modelMaxInputTokens", () => {

--- a/tests/openai-chat-hardening.test.ts
+++ b/tests/openai-chat-hardening.test.ts
@@ -158,3 +158,53 @@ describe("openai-chat credential hardening", () => {
     expect(body).not.toHaveProperty("prompt_cache_key");
   });
 });
+
+describe("openai-chat max output defaults", () => {
+  test("omits max_tokens when neither request nor provider config sets a budget", () => {
+    const body = JSON.parse(createOpenAIChatAdapter(provider()).buildRequest(parsed()).body);
+
+    expect(body).not.toHaveProperty("max_tokens");
+  });
+
+  test("uses provider defaultMaxOutputTokens when Codex omits max_output_tokens", () => {
+    const body = JSON.parse(createOpenAIChatAdapter(provider({ defaultMaxOutputTokens: 32_000 })).buildRequest(parsed()).body);
+
+    expect(body.max_tokens).toBe(32_000);
+  });
+
+  test("modelMaxOutputTokens beats the provider default and supports model matching helpers", () => {
+    const req = parsed();
+    req.modelId = "gpt-oss:120b";
+    const body = JSON.parse(createOpenAIChatAdapter(provider({
+      defaultMaxOutputTokens: 16_000,
+      modelMaxOutputTokens: { "gpt-oss": 64_000 },
+    })).buildRequest(req).body);
+
+    expect(body.max_tokens).toBe(64_000);
+  });
+
+  test("explicit request max_output_tokens beats configured defaults", () => {
+    const req = parsed();
+    req.options.maxOutputTokens = 8_000;
+    const body = JSON.parse(createOpenAIChatAdapter(provider({
+      defaultMaxOutputTokens: 32_000,
+      modelMaxOutputTokens: { "test-model": 64_000 },
+    })).buildRequest(req).body);
+
+    expect(body.max_tokens).toBe(8_000);
+  });
+
+  test("thinking-budget models size thinking_budget from the effective default budget", () => {
+    const body = JSON.parse(createOpenAIChatAdapter(provider({
+      defaultMaxOutputTokens: 20_000,
+      thinkingBudgetModels: ["test-model"],
+      reasoningEffortMap: { high: "high" },
+    })).buildRequest({
+      ...parsed(),
+      options: { reasoning: "high" },
+    }).body);
+
+    expect(body.max_tokens).toBe(20_000);
+    expect(body.thinking_budget).toBe(15_000);
+  });
+});

--- a/tests/openrouter-provider-routing.test.ts
+++ b/tests/openrouter-provider-routing.test.ts
@@ -159,7 +159,17 @@ describe("OpenRouter provider-routing validation", () => {
     const openrouter = provider("https://openrouter.ai/api/v1", {
       openRouterRouting: { order: ["deepseek"], allowFallbacks: false },
     });
+    openrouter.defaultMaxOutputTokens = 32_000;
+    openrouter.modelMaxOutputTokens = { "anthropic/claude-sonnet-5": 64_000 };
     expect(providerManagementConfigError("openrouter", openrouter)).toBeNull();
+    expect(providerManagementConfigError("openrouter", {
+      ...openrouter,
+      defaultMaxOutputTokens: 0,
+    })).toContain("defaultMaxOutputTokens");
+    expect(providerManagementConfigError("openrouter", {
+      ...openrouter,
+      modelMaxOutputTokens: { "anthropic/claude-sonnet-5": 0 },
+    })).toContain("modelMaxOutputTokens");
     expect(providerManagementConfigError("custom", {
       ...openrouter,
       baseUrl: "https://example.test/v1",
@@ -168,9 +178,11 @@ describe("OpenRouter provider-routing validation", () => {
       port: 10100,
       defaultProvider: "openrouter",
       providers: { openrouter },
-    }) as { providers: Record<string, { openRouterRouting?: unknown }> };
+    }) as { providers: Record<string, { openRouterRouting?: unknown; defaultMaxOutputTokens?: unknown; modelMaxOutputTokens?: unknown }> };
     expect(dto.providers.openrouter.openRouterRouting).toEqual({
       order: ["deepseek"], allowFallbacks: false,
     });
+    expect(dto.providers.openrouter.defaultMaxOutputTokens).toBe(32_000);
+    expect(dto.providers.openrouter.modelMaxOutputTokens).toEqual({ "anthropic/claude-sonnet-5": 64_000 });
   });
 });

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -168,6 +168,46 @@ describe("provider registry parity", () => {
     }
   });
 
+  test("registry output-token defaults hydrate stale provider configs and keep user overrides", () => {
+    const registryEntry = PROVIDER_REGISTRY.find(entry => entry.id === "zai")!;
+    const originalDefaultMaxOutputTokens = registryEntry.defaultMaxOutputTokens;
+    const originalModelMaxOutputTokens = registryEntry.modelMaxOutputTokens;
+    try {
+      registryEntry.defaultMaxOutputTokens = 32_000;
+      registryEntry.modelMaxOutputTokens = {
+        "glm-5.2": 128_000,
+        "glm-5.2[1m]": 128_000,
+      };
+      const config: OcxConfig = {
+        port: 10100,
+        defaultProvider: "zai",
+        providers: {
+          zai: {
+            adapter: "openai-chat",
+            baseUrl: "https://api.z.ai/api/coding/paas/v4",
+            defaultMaxOutputTokens: 16_000,
+            modelMaxOutputTokens: { "glm-5.2": 64_000 },
+          },
+        },
+      };
+
+      const routed = routeModel(config, "zai/glm-5.2");
+
+      expect(routed.provider.defaultMaxOutputTokens).toBe(16_000);
+      expect(routed.provider.modelMaxOutputTokens).toEqual({
+        "glm-5.2": 64_000,
+        "glm-5.2[1m]": 128_000,
+      });
+      expect(providerConfigSeed(registryEntry).modelMaxOutputTokens?.["glm-5.2"]).toBe(128_000);
+      expect(deriveKeyLoginMap().zai.modelMaxOutputTokens?.["glm-5.2"]).toBe(128_000);
+    } finally {
+      if (originalDefaultMaxOutputTokens === undefined) delete registryEntry.defaultMaxOutputTokens;
+      else registryEntry.defaultMaxOutputTokens = originalDefaultMaxOutputTokens;
+      if (originalModelMaxOutputTokens === undefined) delete registryEntry.modelMaxOutputTokens;
+      else registryEntry.modelMaxOutputTokens = originalModelMaxOutputTokens;
+    }
+  });
+
   test("CN provider defaults and context windows match the audited registry refresh", () => {
     const deepseek = PROVIDER_REGISTRY.find(entry => entry.id === "deepseek");
     expect(deepseek).toMatchObject({

--- a/tests/responses-parser.test.ts
+++ b/tests/responses-parser.test.ts
@@ -204,14 +204,15 @@ describe("codex-rs compat surface (260707)", () => {
     expect(result?.content).toBe("total 0");
   });
 
-  test("web_search_call replay becomes assistant history text with the query", () => {
+  test("web_search_call replay stays out of assistant-visible history text", () => {
     const parsed = parseRequest({ ...base, input: [
       { type: "web_search_call", status: "completed", action: { type: "search", query: "bun 1.3 release" } },
       { type: "message", role: "user", content: "and now?" },
     ]});
-    const assistant = parsed.context.messages.find(m => m.role === "assistant");
-    const text = (assistant?.content as { type: string; text?: string }[]).find(p => p.type === "text");
-    expect(text?.text).toContain("bun 1.3 release");
+    const serialized = JSON.stringify(parsed.context.messages);
+    expect(serialized).not.toContain("[web search performed");
+    expect(serialized).not.toContain("bun 1.3 release");
+    expect(parsed.context.messages.map(m => m.role)).toEqual(["user"]);
   });
 
   test("tool_search_output failed status is surfaced as an error result", () => {


### PR DESCRIPTION
## Summary

Fixes #265.

- Adds provider/model output-token fallback config for `openai-chat`: explicit `max_output_tokens` > `modelMaxOutputTokens` > `defaultMaxOutputTokens` > omit `max_tokens`.
- Threads the new positive-integer fields through types, config and management validation, safe config DTO, registry/derive/router, key-login, and OAuth reconcile paths.
- Stops replayed historical `web_search_call` cells from becoming assistant-visible `[web search performed: ...]` text, so routed no-sidecar turns do not echo internal markers or imply a current search ran.
- Adds docs plus ADR 0006 with the Decision Log for the structural choices.

## Validation

- `bun test --isolate tests/openai-chat-hardening.test.ts tests/config.test.ts tests/responses-parser.test.ts tests/openrouter-provider-routing.test.ts tests/provider-registry-parity.test.ts tests/web-search.test.ts tests/web-search-timeout-plan.test.ts tests/web-search-anthropic.test.ts`
- `bun test --isolate tests/oauth-provider-reconcile.test.ts tests/provider-payload.test.ts tests/umans-provider.test.ts tests/openai-provider-option.test.ts`
- `bun run typecheck`
- `bun scripts/privacy-scan.ts`
- `git diff --check`
- `bun run lint:gui`