### PR TITLE
fix: gate native effort clamp by route identity

### DIFF
--- a/src/codex/catalog.ts
+++ b/src/codex/catalog.ts
@@ -17,7 +17,7 @@ import { routedSlug, slugEquals, slugsEquivalent } from "../providers/slug-codec
 import { CODEX_GPT5_IDENTITY_LINE } from "../adapters/identity";
 import { filterCursorConfiguredModelsByLiveDiscovery } from "../adapters/cursor/discovery";
 import { fetchCursorUsableModels } from "../adapters/cursor/live-models";
-import { OPENAI_API_PROVIDER_ID } from "../providers/openai-tiers";
+import { isCanonicalOpenAiForwardProvider, OPENAI_API_PROVIDER_ID, OPENAI_CODEX_PROVIDER_ID } from "../providers/openai-tiers";
 import {
   COMBO_NAMESPACE,
   comboModelId,
@@ -298,6 +298,22 @@ export function nativeEffortClamp(slug: string, effort: string | undefined): str
     .sort((a, b) => rank.indexOf(a) - rank.indexOf(b))
     .at(-1);
   return highest ?? null;
+}
+
+/**
+ * Request-time guard for `nativeEffortClamp`: only the canonical built-in OpenAI/Codex
+ * forward provider should ever use the native mock-max repair. Bare third-party
+ * `defaultModel` selectors are still routed models whose adapters own effort mapping,
+ * and explicit `provider/model` requests are routed by construction.
+ */
+export function shouldApplyNativeEffortClamp(
+  providerName: string,
+  provider: OcxProviderConfig,
+  requestedModelId: string,
+): boolean {
+  return !requestedModelId.includes("/")
+    && providerName === OPENAI_CODEX_PROVIDER_ID
+    && isCanonicalOpenAiForwardProvider(provider);
 }
 
 /**

--- a/src/server/responses.ts
+++ b/src/server/responses.ts
@@ -941,16 +941,17 @@ export async function handleResponses(
   // receive `max` when the user picks Ultra (codex converts ultra->max client-side).
   // Clamp to the model's highest real effort BEFORE any adapter — the ChatGPT
   // passthrough serializes _rawBody verbatim, so both shapes must be rewritten.
-  // GUARD: judge nativeness by the ORIGINALLY REQUESTED id (logCtx.requestedModel),
-  // never by route.modelId — routing strips the "<provider>/" namespace, so a routed
-  // model (anthropic/claude-opus-4-6, real max) would masquerade as an off-snapshot
-  // bare native and get wrongly clamped. Routed efforts belong to their adapters.
+  // GUARD: judge nativeness by BOTH the originally requested id (logCtx.requestedModel)
+  // and the resolved provider identity. Routing strips the "<provider>/" namespace, and
+  // some third-party providers expose bare `defaultModel` selectors, so route.modelId
+  // alone can make a routed model masquerade as an off-snapshot native. Only the
+  // canonical built-in ChatGPT forward provider should receive the native clamp.
   {
     const requestedModelId = logCtx.requestedModel ?? route.modelId;
-    const { nativeEffortClamp } = await import("../codex/catalog");
-    const clamped = requestedModelId.includes("/")
-      ? null
-      : nativeEffortClamp(route.modelId, parsed.options.reasoning);
+    const { nativeEffortClamp, shouldApplyNativeEffortClamp } = await import("../codex/catalog");
+    const clamped = shouldApplyNativeEffortClamp(route.providerName, route.provider, requestedModelId)
+      ? nativeEffortClamp(route.modelId, parsed.options.reasoning)
+      : null;
     if (clamped) {
       parsed.options.reasoning = clamped;
       const raw = parsed._rawBody as { reasoning?: { effort?: string } } | undefined;

--- a/structure/03_catalog-and-subagents.md
+++ b/structure/03_catalog-and-subagents.md
@@ -59,6 +59,23 @@ Ultra is always advertised in the catalog regardless of the `multi_agent_v2` tog
 controls only the multi-agent collab surface, not ultra visibility. The `nativeEffortClamp` function
 wire-clamps ultra/max to each model's real top rung (e.g. gpt-5.5 ultra → xhigh on the wire).
 
+[Decision Log]
+- 목적과 의도: bare `defaultModel` selectors that route into third-party providers must keep their
+  adapter-owned effort ladder; only true ChatGPT-native requests should receive the mock-max repair.
+- 기존 구현 및 제약 조건: `nativeEffortClamp` already needed the original request id because
+  routing strips `provider/`, but bare third-party selectors like `glm-5.2-fast-preview` still look
+  native after that strip.
+- 검토한 주요 대안: (1) infer nativeness from the bare slug prefix alone, (2) gate clamping by the
+  resolved provider identity, (3) disable the clamp for all off-snapshot slugs.
+- 선택한 방식: request-time clamp entry is allowed only when the resolved route is the canonical
+  built-in OpenAI/Codex forward provider and the original request id is still bare.
+- 다른 대안 대신 이 방식을 선택한 이유: provider identity is the only durable signal that
+  distinguishes true native ChatGPT traffic from third-party `defaultModel` routes when both share a
+  bare model id shape.
+- 장점, 단점 및 영향: preserves `gpt-5.5 max -> xhigh` repair for native traffic, removes false
+  clamps for bare routed models, and keeps adapter-specific effort mapping as the single source of
+  truth for third-party providers.
+
 ## Subagents
 
 Codex `spawn_agent` advertises only the highest-priority first five catalog models. `subagentModels`

--- a/tests/codex-v2-gate.test.ts
+++ b/tests/codex-v2-gate.test.ts
@@ -8,7 +8,7 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { readFileSync } from "node:fs";
-import { buildCatalogEntries, mergeCatalogEntriesForSync, nativeEffortClamp, type MultiAgentMode } from "../src/codex/catalog";
+import { buildCatalogEntries, mergeCatalogEntriesForSync, nativeEffortClamp, shouldApplyNativeEffortClamp, type MultiAgentMode } from "../src/codex/catalog";
 import {
   getAgentsMaxThreads,
   getLogicalMaxThreads,
@@ -476,6 +476,24 @@ describe("mock-max wire clamp (nativeEffortClamp)", () => {
   test("real-max natives are untouched", () => {
     expect(nativeEffortClamp("gpt-5.6-sol", "max")).toBe(null);
     expect(nativeEffortClamp("gpt-5.6-luna", "max")).toBe(null);
+  });
+
+  test("only the canonical built-in OpenAI forward route enters the native clamp gate", () => {
+    const nativeProvider = {
+      adapter: "openai-responses",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+      authMode: "forward",
+    } as const;
+    const routedProvider = {
+      adapter: "openai-chat",
+      baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      authMode: "key",
+      apiKey: "dashscope-test",
+    } as const;
+
+    expect(shouldApplyNativeEffortClamp("openai", nativeProvider as never, "gpt-5.5")).toBe(true);
+    expect(shouldApplyNativeEffortClamp("bailian", routedProvider as never, "glm-5.2-fast-preview")).toBe(false);
+    expect(shouldApplyNativeEffortClamp("bailian", routedProvider as never, "bailian/glm-5.2-fast-preview")).toBe(false);
   });
 
   test("ordinary efforts and routed slugs pass through; unknown BARE natives clamp conservatively", () => {

--- a/tests/server-combo-failover-e2e.test.ts
+++ b/tests/server-combo-failover-e2e.test.ts
@@ -240,6 +240,29 @@ async function postLogged(
   );
 }
 
+async function postModelLogged(
+  config: OcxConfig,
+  model: string,
+  raw: Record<string, unknown> = {},
+  options: HandleOptions = {},
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  const logCtx: RequestLogContext = { model: "", provider: "" };
+  const start = Date.now();
+  const response = await handleResponses(new Request("http://localhost/v1/responses", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify({ model, input: "hello", stream: false, ...raw }),
+  }), config, logCtx, options);
+  loggedRequestSequence += 1;
+  return responseWithDeferredRequestLog(
+    response,
+    `direct-test-${loggedRequestSequence}`,
+    start,
+    logCtx,
+  );
+}
+
 async function latestAttemptReceipts(config: OcxConfig) {
   const response = await management(config, "GET", "/api/logs?tail=1");
   const logs = await response!.json() as Array<Record<string, unknown>>;
@@ -937,6 +960,62 @@ describe("server combo failover 030 activation matrix", () => {
     }, undefined, { defaultEffort: "high" });
     expect((await post(config)).status).toBe(200);
     expect(backupBody).not.toHaveProperty("reasoning_effort");
+  });
+
+  test("bare third-party defaultModel keeps max off the native clamp path", async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    customFetchResponse = async request => {
+      const body = JSON.parse(String(request.body)) as Record<string, unknown>;
+      seen.push(body);
+      return chatSuccess("ok", String(body.model ?? "glm-5.2-fast-preview"));
+    };
+    const config: OcxConfig = {
+      port: 0,
+      defaultProvider: "bailian",
+      providers: {
+        bailian: provider("test-response", "https://test.invalid/v1", "key-b", {
+          defaultModel: "glm-5.2-fast-preview",
+          modelReasoningEfforts: { "glm-5.2-fast-preview": ["low", "medium", "high", "xhigh", "max"] },
+        }),
+      },
+    };
+
+    const bare = await postModelLogged(config, "glm-5.2-fast-preview", { reasoning: { effort: "max" } });
+    expect(bare.status).toBe(200);
+    await bare.text();
+    expect(seen[0]!.reasoning_effort).toBe("max");
+    let { log, usage } = await latestAttemptReceipts(config);
+    expect(log).toMatchObject({
+      provider: "bailian",
+      requestedModel: "glm-5.2-fast-preview",
+      requestedEffort: "max",
+      resolvedModel: "glm-5.2-fast-preview",
+    });
+    expect(usage).toMatchObject({
+      provider: "bailian",
+      requestedModel: "glm-5.2-fast-preview",
+      requestedEffort: "max",
+      resolvedModel: "glm-5.2-fast-preview",
+    });
+
+    seen.length = 0;
+    const prefixed = await postModelLogged(config, "bailian/glm-5.2-fast-preview", { reasoning: { effort: "max" } });
+    expect(prefixed.status).toBe(200);
+    await prefixed.text();
+    expect(seen[0]!.reasoning_effort).toBe("max");
+    ({ log, usage } = await latestAttemptReceipts(config));
+    expect(log).toMatchObject({
+      provider: "bailian",
+      requestedModel: "bailian/glm-5.2-fast-preview",
+      requestedEffort: "max",
+      resolvedModel: "glm-5.2-fast-preview",
+    });
+    expect(usage).toMatchObject({
+      provider: "bailian",
+      requestedModel: "bailian/glm-5.2-fast-preview",
+      requestedEffort: "max",
+      resolvedModel: "glm-5.2-fast-preview",
+    });
   });
 
   test("xAI 401 refresh stays within one target and succeeds without backup", async () => {


### PR DESCRIPTION
## Summary
- gate `nativeEffortClamp` by resolved route/provider identity instead of bare slug shape alone
- keep bare and prefixed third-party `defaultModel` requests off the native clamp path while preserving native `gpt-5.5 max -> xhigh`
- add request-path regression coverage, unit coverage, and a Decision Log update in the architecture docs

## Testing
- `bun test --isolate tests/codex-v2-gate.test.ts tests/server-combo-failover-e2e.test.ts`
- `bun run typecheck`
- `bun run privacy:scan`
- `git diff --check`

## Issue
- Fixes #267