### PR TITLE
fix: add opt-in responses item id repair

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -173,6 +173,7 @@ network. Only do this on trusted networks, and always set a strong `OPENCODEX_AP
 | `noTopPModels?` | `string[]` | Models that reject caller-specified `top_p`. |
 | `noPenaltyModels?` | `string[]` | Models that reject presence/frequency penalties. |
 | `parallelToolCalls?` | `boolean` | Enable/disable parallel tool calls. OpenAI Chat defaults on; non-chat adapters advertise support only on explicit `true`. |
+| `responsesItemIdRepair?` | `{ message?: string[]; reasoning?: string[]; repairMissingTerminalIds?: boolean }` | Provider-local, disabled-by-default passthrough SSE repair for exact `message` / `reasoning` placeholder ids and missing terminal ids. Downstream only; function-call ids and `call_id` are never rewritten. |
 | `autoToolChoiceOnlyModels?` | `string[]` | Models whose `tool_choice` accepts only `auto` or `none`; forced/named choices are downgraded. |
 | `preserveReasoningContentModels?` | `string[]` | Models that require prior assistant `reasoning_content` to remain in chat history. |
 | `thinkingToggleModels?` | `string[]` | Chat models using a vendor `thinking.enabled` toggle instead of an effort ladder. |
@@ -185,6 +186,29 @@ network. Only do this on trusted networks, and always set a strong `OPENCODEX_AP
 | `mcpServers?` | `Record<string,CursorMcpServerConfig>` | **Cursor only.** MCP servers started over stdio or reached over Streamable HTTP; fields are listed below. |
 | `desktopExecutor?` | `DesktopExecutorConfig` | **Cursor only.** External computer-use/record-screen commands; fields are listed below. |
 | `unsafeAllowNativeLocalExec?` | `boolean` | **Cursor adapter only.** Opt-in escape hatch for Cursor server-driven local `read` / `write` / `delete` / `ls` / `grep` / `shell` / `fetch` execution. Defaults to `false` so remote Cursor messages cannot bypass Codex approval and sandbox enforcement. See [Cursor provider](#cursor-provider-adapter-cursor) below. |
+
+For broken `openai-responses` compatibility gateways, `responsesItemIdRepair` belongs on the
+provider object itself, for example:
+
+```json
+{
+  "providers": {
+    "custom-gateway": {
+      "adapter": "openai-responses",
+      "baseUrl": "https://gateway.example/v1",
+      "apiKey": "${GATEWAY_KEY}",
+      "responsesItemIdRepair": {
+        "reasoning": ["rs_0"],
+        "message": ["msg_0"],
+        "repairMissingTerminalIds": true
+      }
+    }
+  }
+}
+```
+
+The placeholder lists are exact string matches only. Leave the field unset for normal/stateful
+Responses providers so passthrough stays byte-for-byte identical to upstream.
 
 ## Cursor provider (`adapter: "cursor"`)
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -331,6 +331,11 @@ const providerConfigSchema = z.object({
   baseUrl: z.string().min(1),
   allowPrivateNetwork: z.boolean().optional(),
   codexAccountMode: z.enum(["pool", "direct"]).optional(),
+  responsesItemIdRepair: z.object({
+    message: z.array(z.string().min(1)).optional(),
+    reasoning: z.array(z.string().min(1)).optional(),
+    repairMissingTerminalIds: z.boolean().optional(),
+  }).strict().optional(),
 }).passthrough();
 
 const RESERVED_PROVIDER_NAMES = new Set(["__proto__", "prototype", "constructor"]);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -134,9 +134,12 @@ const WEBSOCKET_IDLE_TIMEOUT_SECONDS = 0;
 // Source invariant for tests/passthrough-abort.test.ts after the pure module split:
 // if (isEventStream && upstreamResponse.body) {
 // upstreamResponse.body.tee()
+// const repairConfig = route.provider.responsesItemIdRepair;
+// const repairedBody = hasResponsesItemIdRepair(repairConfig)
 // process.platform === "win32"
+// && !hasResponsesItemIdRepair(repairConfig)
 // ? nativeBody
-// relaySseWithFailedTail(nativeBody, upstream)
+// relaySseWithFailedTail(repairedBody, upstream)
 // new Response(clientBody
 // markNativePassthroughSseResponse
 // const body = relayWithAbort(upstreamResponse.body, upstream);

--- a/src/server/responses-item-id-repair.ts
+++ b/src/server/responses-item-id-repair.ts
@@ -1,0 +1,281 @@
+import { randomUUID } from "node:crypto";
+import type { ResponsesItemIdRepairConfig } from "../types";
+
+type RepairableItemType = "message" | "reasoning";
+
+interface ResponsesItemIdRepairState {
+  readonly repairMissingTerminalIds: boolean;
+  readonly placeholders: Record<RepairableItemType, ReadonlySet<string>>;
+  readonly outputIds: Record<RepairableItemType, Map<number, string>>;
+  readonly scope: string;
+}
+
+const REPAIRABLE_PREFIXES: Record<RepairableItemType, string> = {
+  message: "msg_",
+  reasoning: "rs_",
+};
+
+const ITEM_ID_EVENT_TYPES: Readonly<Record<string, RepairableItemType>> = {
+  "response.content_part.added": "message",
+  "response.content_part.done": "message",
+  "response.output_text.annotation.added": "message",
+  "response.output_text.delta": "message",
+  "response.output_text.done": "message",
+  "response.refusal.delta": "message",
+  "response.refusal.done": "message",
+  "response.reasoning_summary_part.added": "reasoning",
+  "response.reasoning_summary_part.done": "reasoning",
+  "response.reasoning_summary_text.delta": "reasoning",
+  "response.reasoning_summary_text.done": "reasoning",
+  "response.reasoning_text.delta": "reasoning",
+  "response.reasoning_text.done": "reasoning",
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function nextSseBlock(buffer: string): { block: string; delimiter: string; rest: string } | null {
+  const match = buffer.match(/\r?\n\r?\n/);
+  if (!match || match.index === undefined) return null;
+  return {
+    block: buffer.slice(0, match.index),
+    delimiter: match[0],
+    rest: buffer.slice(match.index + match[0].length),
+  };
+}
+
+function sseDataPayload(block: string): string | null {
+  const data: string[] = [];
+  for (const line of block.split(/\r?\n/)) {
+    if (!line.startsWith("data:")) continue;
+    const value = line.slice(5);
+    data.push(value.startsWith(" ") ? value.slice(1) : value);
+  }
+  return data.length > 0 ? data.join("\n") : null;
+}
+
+function replaceSseDataPayload(block: string, payload: string): string {
+  const newline = block.includes("\r\n") ? "\r\n" : "\n";
+  const lines = block.split(/\r?\n/);
+  const rewritten: string[] = [];
+  let replaced = false;
+  for (const line of lines) {
+    if (!line.startsWith("data:")) {
+      rewritten.push(line);
+      continue;
+    }
+    if (!replaced) {
+      rewritten.push(`data: ${payload}`);
+      replaced = true;
+    }
+  }
+  return replaced ? rewritten.join(newline) : block;
+}
+
+function asOutputIndex(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function repairableItemType(item: Record<string, unknown>): RepairableItemType | null {
+  return item.type === "message" || item.type === "reasoning" ? item.type : null;
+}
+
+function mintCanonicalId(type: RepairableItemType, scope: string, outputIndex: number): string {
+  return `${REPAIRABLE_PREFIXES[type]}ocx_${scope}_${outputIndex}`;
+}
+
+function createRepairState(config: ResponsesItemIdRepairConfig): ResponsesItemIdRepairState {
+  return {
+    repairMissingTerminalIds: config.repairMissingTerminalIds === true,
+    placeholders: {
+      message: new Set(config.message ?? []),
+      reasoning: new Set(config.reasoning ?? []),
+    },
+    outputIds: {
+      message: new Map<number, string>(),
+      reasoning: new Map<number, string>(),
+    },
+    scope: randomUUID().replace(/-/g, ""),
+  };
+}
+
+function rememberMappedId(
+  state: ResponsesItemIdRepairState,
+  outputIndex: number,
+  item: Record<string, unknown>,
+): string | null {
+  const type = repairableItemType(item);
+  if (!type) return null;
+  const existing = state.outputIds[type].get(outputIndex);
+  if (existing) return existing;
+  const rawId = typeof item.id === "string" ? item.id : undefined;
+  if (!rawId) return null;
+  const mapped = state.placeholders[type].has(rawId)
+    ? mintCanonicalId(type, state.scope, outputIndex)
+    : state.repairMissingTerminalIds
+      ? rawId
+      : null;
+  if (!mapped) return null;
+  state.outputIds[type].set(outputIndex, mapped);
+  return mapped;
+}
+
+function rewriteOutputItem(
+  state: ResponsesItemIdRepairState,
+  outputIndex: number,
+  item: Record<string, unknown>,
+): { item: Record<string, unknown>; changed: boolean } {
+  const mapped = rememberMappedId(state, outputIndex, item);
+  if (!mapped) return { item, changed: false };
+  const currentId = typeof item.id === "string" ? item.id : undefined;
+  if (currentId === mapped) return { item, changed: false };
+  if (currentId === undefined && !state.repairMissingTerminalIds) return { item, changed: false };
+  return { item: { ...item, id: mapped }, changed: true };
+}
+
+function rewriteItemIdField(
+  state: ResponsesItemIdRepairState,
+  event: Record<string, unknown>,
+  outputIndex: number,
+): { event: Record<string, unknown>; changed: boolean } {
+  const eventType = typeof event.type === "string" ? ITEM_ID_EVENT_TYPES[event.type] : undefined;
+  if (!eventType) return { event, changed: false };
+  const mapped = state.outputIds[eventType].get(outputIndex);
+  if (!mapped) return { event, changed: false };
+  const currentId = typeof event.item_id === "string" ? event.item_id : undefined;
+  if (currentId === mapped) return { event, changed: false };
+  if (currentId === undefined && !state.repairMissingTerminalIds) return { event, changed: false };
+  return { event: { ...event, item_id: mapped }, changed: true };
+}
+
+function rewriteResponseSnapshot(
+  state: ResponsesItemIdRepairState,
+  response: Record<string, unknown>,
+): { response: Record<string, unknown>; changed: boolean } {
+  if (!Array.isArray(response.output)) return { response, changed: false };
+  let changed = false;
+  const output = response.output.map((item, outputIndex) => {
+    if (!isPlainObject(item)) return item;
+    const rewritten = rewriteOutputItem(state, outputIndex, item);
+    changed = changed || rewritten.changed;
+    return rewritten.item;
+  });
+  return changed ? { response: { ...response, output }, changed: true } : { response, changed: false };
+}
+
+function repairEventPayload(
+  payload: string,
+  state: ResponsesItemIdRepairState,
+): string {
+  let event: unknown;
+  try {
+    event = JSON.parse(payload);
+  } catch {
+    return payload;
+  }
+  if (!isPlainObject(event)) return payload;
+
+  let changed = false;
+  let nextEvent = event;
+  const outputIndex = asOutputIndex(event.output_index);
+  if (outputIndex !== null && isPlainObject(event.item)) {
+    const rewritten = rewriteOutputItem(state, outputIndex, event.item);
+    if (rewritten.changed) {
+      nextEvent = { ...nextEvent, item: rewritten.item };
+      changed = true;
+    }
+  }
+  if (outputIndex !== null) {
+    const rewritten = rewriteItemIdField(state, nextEvent, outputIndex);
+    if (rewritten.changed) {
+      nextEvent = rewritten.event;
+      changed = true;
+    }
+  }
+  if (isPlainObject(event.response)) {
+    const rewritten = rewriteResponseSnapshot(state, event.response);
+    if (rewritten.changed) {
+      nextEvent = { ...nextEvent, response: rewritten.response };
+      changed = true;
+    }
+  }
+  return changed ? JSON.stringify(nextEvent) : payload;
+}
+
+/**
+ * [Decision Log]
+ * - 목적과 의도: 일부 openai-responses 호환 게이트웨이가 재사용/누락하는 message·reasoning item id를
+ *   downstream SSE에서만 선택적으로 보정해 Codex Desktop 카드 상관관계를 안정화한다.
+ * - 기존 구현 및 제약 조건: 기본 passthrough는 바이트 단위 그대로 relay되고, local replay 상태는 raw
+ *   upstream 응답을 기억한다. function_call id / call_id는 upstream 의미가 있으므로 절대 바꾸면 안 된다.
+ * - 검토한 주요 대안: 모든 passthrough SSE를 항상 재작성하기, raw inspect 분기까지 함께 재작성하기,
+ *   function_call 포함 전체 item id를 정규화하기.
+ * - 선택한 방식: provider-local opt-in 설정이 있을 때만 client-facing SSE 분기에 한정해 exact
+ *   message/reasoning placeholder id와 missing terminal id를 item type + output_index 기준으로 보정하고,
+ *   event-level item_id는 명시적인 message/reasoning lifecycle allowlist에서만 바꾼다.
+ * - 다른 대안 대신 이 방식을 선택한 이유: disabled-by-default byte-for-byte passthrough를 유지하면서,
+ *   previous_response_id replay는 raw upstream snapshot을 계속 사용해 synthetic id가 upstream으로
+ *   역류하지 않게 막을 수 있다.
+ * - 장점, 단점 및 영향: 기본 경로는 변하지 않는다. malformed stream이 output_index를 다른 item
+ *   type에 재사용해도 function_call id/call_id는 보존된다. opt-in 게이트웨이는 sequential streams에서도
+ *   고유한 canonical id를 얻지만, 보정이 필요한 경우에만 JS stream 재작성 비용을 지불한다.
+ */
+export function relaySseWithResponsesItemIdRepair(
+  body: ReadableStream<Uint8Array>,
+  config: ResponsesItemIdRepairConfig,
+): ReadableStream<Uint8Array> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  const state = createRepairState(config);
+  let buffer = "";
+
+  const emitProcessedBlocks = (
+    controller: ReadableStreamDefaultController<Uint8Array>,
+    flushFinal = false,
+  ): void => {
+    let next: { block: string; delimiter: string; rest: string } | null;
+    while ((next = nextSseBlock(buffer))) {
+      buffer = next.rest;
+      const payload = sseDataPayload(next.block);
+      const repairedPayload = payload ? repairEventPayload(payload, state) : undefined;
+      const block = payload && repairedPayload !== undefined && repairedPayload !== payload
+        ? replaceSseDataPayload(next.block, repairedPayload)
+        : next.block;
+      controller.enqueue(encoder.encode(block + next.delimiter));
+    }
+    if (flushFinal && buffer.length > 0) {
+      const payload = sseDataPayload(buffer);
+      const repairedPayload = payload ? repairEventPayload(payload, state) : undefined;
+      const block = payload && repairedPayload !== undefined && repairedPayload !== payload
+        ? replaceSseDataPayload(buffer, repairedPayload)
+        : buffer;
+      controller.enqueue(encoder.encode(block));
+      buffer = "";
+    }
+  };
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (done) {
+        buffer += decoder.decode();
+        emitProcessedBlocks(controller, true);
+        controller.close();
+        return;
+      }
+      buffer += decoder.decode(value, { stream: true });
+      emitProcessedBlocks(controller);
+    },
+    cancel(reason) {
+      reader.cancel(reason).catch(() => {});
+    },
+  });
+}
+
+export function hasResponsesItemIdRepair(config: ResponsesItemIdRepairConfig | undefined): boolean {
+  return config?.repairMissingTerminalIds === true
+    || (config?.message?.length ?? 0) > 0
+    || (config?.reasoning?.length ?? 0) > 0;
+}

--- a/src/server/responses.ts
+++ b/src/server/responses.ts
@@ -91,6 +91,7 @@ import {
   relayWithAbort,
   sanitizePassthroughHeaders,
 } from "./relay";
+import { hasResponsesItemIdRepair, relaySseWithResponsesItemIdRepair } from "./responses-item-id-repair";
 
 export function buildToolBridgeMaps(parsed: OcxParsedRequest): {
   toolNsMap: Map<string, { namespace: string; name: string }>;
@@ -1222,6 +1223,7 @@ export async function handleResponses(
     // background for terminal-outcome/quota inspection only.
     if (upstreamResponse.ok && isEventStream && upstreamResponse.body) {
       const [nativeBody, inspectBody] = upstreamResponse.body.tee();
+      const repairConfig = route.provider.responsesItemIdRepair;
       const turnAc = new AbortController();
       linkAbortSignal(upstream, turnAc.signal);
       registerTurn(turnAc);
@@ -1258,9 +1260,12 @@ export async function handleResponses(
       // win32 must keep the pure native relay (Bun#32111 JS-sink segfault); elsewhere a JS pull
       // relay is established practice (relayWithAbort, relaySseWithHeartbeat) and lets a
       // mid-stream reset end with a clean response.failed terminal instead of a raw socket error.
-      const clientBody = process.platform === "win32"
+      const repairedBody = hasResponsesItemIdRepair(repairConfig)
+        ? relaySseWithResponsesItemIdRepair(nativeBody, repairConfig!)
+        : nativeBody;
+      const clientBody = process.platform === "win32" && !hasResponsesItemIdRepair(repairConfig)
         ? nativeBody
-        : relaySseWithFailedTail(nativeBody, upstream);
+        : relaySseWithFailedTail(repairedBody, upstream);
       return markNativePassthroughSseResponse(new Response(clientBody, {
         status: upstreamResponse.status,
         headers,

--- a/src/types.ts
+++ b/src/types.ts
@@ -620,6 +620,15 @@ export interface OpenRouterProviderRouting {
   allowFallbacks?: boolean;
 }
 
+export interface ResponsesItemIdRepairConfig {
+  /** Exact `message` item ids that the proxy should rewrite to request-local canonical ids. */
+  message?: string[];
+  /** Exact `reasoning` item ids that the proxy should rewrite to request-local canonical ids. */
+  reasoning?: string[];
+  /** Backfill missing `output_item.done` / terminal snapshot ids from the matching output_index. */
+  repairMissingTerminalIds?: boolean;
+}
+
 export interface OcxProviderConfig {
   adapter: string;
   baseUrl: string;
@@ -744,6 +753,12 @@ export interface OcxProviderConfig {
    * fields. Default off; only enable for providers that document this parameter.
    */
   promptCacheKey?: boolean;
+  /**
+   * Provider-local passthrough SSE repair for broken openai-responses gateways that reuse exact
+   * placeholder message/reasoning ids or omit the terminal id after a stable added event.
+   * Disabled by default; function_call ids and call_id pairing are never rewritten.
+   */
+  responsesItemIdRepair?: ResponsesItemIdRepairConfig;
   /** Model ids whose tool_choice only accepts `auto` or `none`; forced/named choices are downgraded. */
   autoToolChoiceOnlyModels?: string[];
   /** Model ids that expect prior assistant `reasoning_content` to be preserved in chat history. */

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -140,6 +140,46 @@ describe("opencodex config defaults", () => {
     }
   });
 
+  test("accepts the exact responsesItemIdRepair shape and rejects the old nested placeholderIds proposal", () => {
+    writeConfig({
+      port: 12345,
+      providers: {
+        custom: {
+          adapter: "openai-responses",
+          baseUrl: "https://example.test/v1",
+          responsesItemIdRepair: {
+            reasoning: ["rs_0"],
+            message: ["msg_0"],
+            repairMissingTerminalIds: true,
+          },
+        },
+      },
+      defaultProvider: "custom",
+    });
+    expect(readConfigDiagnostics().error).toBeNull();
+    expect(readConfigDiagnostics().config.providers.custom.responsesItemIdRepair).toEqual({
+      reasoning: ["rs_0"],
+      message: ["msg_0"],
+      repairMissingTerminalIds: true,
+    });
+
+    writeConfig({
+      port: 12345,
+      providers: {
+        custom: {
+          adapter: "openai-responses",
+          baseUrl: "https://example.test/v1",
+          responsesItemIdRepair: {
+            placeholderIds: { reasoning: ["rs_0"] },
+          },
+        },
+      },
+      defaultProvider: "custom",
+    });
+    expect(readConfigDiagnostics().source).toBe("fallback");
+    expect(readConfigDiagnostics().error).toContain("responsesItemIdRepair");
+  });
+
   test("reads valid config diagnostics without mutation", () => {
     writeConfig({
       port: 12345,

--- a/tests/passthrough-abort.test.ts
+++ b/tests/passthrough-abort.test.ts
@@ -42,11 +42,15 @@ describe("passthrough relayWithAbort (RC2, passthrough path)", () => {
     );
 
     expect(sseBranch).toContain("upstreamResponse.body.tee()");
-    // win32 must receive the tee'd body untouched — no JS pull wrapper (Bun#32111 segfault).
+    // win32 must receive the tee'd body untouched when repair is disabled — no JS pull wrapper
+    // on the default path (Bun#32111 segfault).
+    expect(sseBranch).toContain("const repairConfig = route.provider.responsesItemIdRepair;");
+    expect(sseBranch).toContain("const repairedBody = hasResponsesItemIdRepair(repairConfig)");
     expect(sseBranch).toContain('process.platform === "win32"');
+    expect(sseBranch).toContain("&& !hasResponsesItemIdRepair(repairConfig)");
     expect(sseBranch).toContain("? nativeBody");
     // Elsewhere the failed-tail relay converts mid-stream resets into a clean response.failed.
-    expect(sseBranch).toContain("relaySseWithFailedTail(nativeBody, upstream)");
+    expect(sseBranch).toContain("relaySseWithFailedTail(repairedBody, upstream)");
     expect(sseBranch).toContain("new Response(clientBody");
     expect(sseBranch).toContain("markNativePassthroughSseResponse");
     expect(sseBranch).not.toContain("relaySseWithHeartbeat(");

--- a/tests/responses-item-id-repair.test.ts
+++ b/tests/responses-item-id-repair.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "bun:test";
+import { hasResponsesItemIdRepair, relaySseWithResponsesItemIdRepair } from "../src/server/responses-item-id-repair";
+
+function streamFromText(text: string): ReadableStream<Uint8Array> {
+  const chunk = new TextEncoder().encode(text);
+  let sent = false;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (sent) {
+        controller.close();
+        return;
+      }
+      sent = true;
+      controller.enqueue(chunk);
+    },
+  });
+}
+
+async function readAll(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+  }
+  return text;
+}
+
+async function parseSse(text: string): Promise<Record<string, unknown>[]> {
+  return text
+    .trim()
+    .split(/\r?\n\r?\n/)
+    .map(block => block.split(/\r?\n/).find(line => line.startsWith("data:"))?.slice(5).trim())
+    .filter((payload): payload is string => !!payload && payload !== "[DONE]")
+    .map(payload => JSON.parse(payload) as Record<string, unknown>);
+}
+
+describe("Responses passthrough item-id repair", () => {
+  test("repairs placeholder message/reasoning ids across added, delta, done, and completed", async () => {
+    const upstream = [
+      'event: response.output_item.added\ndata: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"rs_0"}}\n\n',
+      'event: response.reasoning_summary_text.delta\ndata: {"type":"response.reasoning_summary_text.delta","output_index":0,"summary_index":0,"item_id":"rs_0","delta":"thinking"}\n\n',
+      'event: response.output_item.done\ndata: {"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","id":"rs_0"}}\n\n',
+      'event: response.output_item.added\ndata: {"type":"response.output_item.added","output_index":1,"item":{"type":"message","id":"msg_0","role":"assistant"}}\n\n',
+      'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","output_index":1,"content_index":0,"item_id":"msg_0","delta":"hello"}\n\n',
+      'event: response.output_item.done\ndata: {"type":"response.output_item.done","output_index":1,"item":{"type":"message","role":"assistant"}}\n\n',
+      'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_gateway","status":"completed","output":[{"type":"reasoning","id":"rs_0"},{"type":"message","role":"assistant"},{"type":"function_call","id":"call_redacted","call_id":"call_redacted","name":"shell","arguments":"{}"}]}}\n\n',
+      "data: [DONE]\n\n",
+    ].join("");
+
+    const repaired = await readAll(relaySseWithResponsesItemIdRepair(streamFromText(upstream), {
+      reasoning: ["rs_0"],
+      message: ["msg_0"],
+      repairMissingTerminalIds: true,
+    }));
+    const events = await parseSse(repaired);
+
+    const reasoningAdded = events[0].item as Record<string, unknown>;
+    const reasoningDelta = events[1];
+    const reasoningDone = events[2].item as Record<string, unknown>;
+    const messageAdded = events[3].item as Record<string, unknown>;
+    const messageDelta = events[4];
+    const messageDone = events[5].item as Record<string, unknown>;
+    const completed = events[6].response as { output: Record<string, unknown>[] };
+
+    expect(reasoningAdded.id).toMatch(/^rs_ocx_[0-9a-f]+_0$/);
+    expect(reasoningDelta.item_id).toBe(reasoningAdded.id);
+    expect(reasoningDone.id).toBe(reasoningAdded.id);
+
+    expect(messageAdded.id).toMatch(/^msg_ocx_[0-9a-f]+_1$/);
+    expect(messageDelta.item_id).toBe(messageAdded.id);
+    expect(messageDone.id).toBe(messageAdded.id);
+
+    expect(completed.output[0].id).toBe(reasoningAdded.id);
+    expect(completed.output[1].id).toBe(messageAdded.id);
+    expect(completed.output[2].id).toBe("call_redacted");
+    expect(completed.output[2].call_id).toBe("call_redacted");
+  });
+
+  test("mints unique canonical ids across sequential passthrough streams", async () => {
+    const upstream = [
+      'event: response.output_item.added\ndata: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"rs_0"}}\n\n',
+      'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_gateway","status":"completed","output":[{"type":"reasoning","id":"rs_0"}]}}\n\n',
+      "data: [DONE]\n\n",
+    ].join("");
+
+    const firstEvents = await parseSse(await readAll(relaySseWithResponsesItemIdRepair(streamFromText(upstream), {
+      reasoning: ["rs_0"],
+    })));
+    const secondEvents = await parseSse(await readAll(relaySseWithResponsesItemIdRepair(streamFromText(upstream), {
+      reasoning: ["rs_0"],
+    })));
+
+    const firstId = (firstEvents[0].item as Record<string, unknown>).id;
+    const secondId = (secondEvents[0].item as Record<string, unknown>).id;
+    expect(firstId).not.toBe(secondId);
+    expect((firstEvents[1].response as { output: Record<string, unknown>[] }).output[0].id).toBe(firstId);
+    expect((secondEvents[1].response as { output: Record<string, unknown>[] }).output[0].id).toBe(secondId);
+  });
+
+  test("does not rewrite function_call fields when a malformed stream reuses a repaired output_index", async () => {
+    const upstream = [
+      'event: response.output_item.added\ndata: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"rs_0"}}\n\n',
+      'event: response.reasoning_summary_text.delta\ndata: {"type":"response.reasoning_summary_text.delta","output_index":0,"summary_index":0,"item_id":"rs_0","delta":"thinking"}\n\n',
+      'event: response.function_call_arguments.delta\ndata: {"type":"response.function_call_arguments.delta","output_index":0,"item_id":"fc_1","call_id":"call_1","delta":"{}"}\n\n',
+      'event: response.output_item.done\ndata: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"shell","arguments":"{}"}}\n\n',
+      'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_1","status":"completed","output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"shell","arguments":"{}"}]}}\n\n',
+      "data: [DONE]\n\n",
+    ].join("");
+
+    const events = await parseSse(await readAll(relaySseWithResponsesItemIdRepair(streamFromText(upstream), {
+      reasoning: ["rs_0"],
+      repairMissingTerminalIds: true,
+    })));
+    const reasoning = events[0].item as Record<string, unknown>;
+    const functionDelta = events[2];
+    const functionDone = events[3].item as Record<string, unknown>;
+    const completed = events[4].response as { output: Record<string, unknown>[] };
+
+    expect(reasoning.id).toMatch(/^rs_ocx_[0-9a-f]+_0$/);
+    expect(events[1].item_id).toBe(reasoning.id);
+    expect(functionDelta.item_id).toBe("fc_1");
+    expect(functionDelta.call_id).toBe("call_1");
+    expect(functionDone.id).toBe("fc_1");
+    expect(functionDone.call_id).toBe("call_1");
+    expect(completed.output[0].id).toBe("fc_1");
+    expect(completed.output[0].call_id).toBe("call_1");
+  });
+
+  test("keeps message and reasoning mappings separate when output_index is reused", async () => {
+    const upstream = [
+      'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"rs_0"}}\n\n',
+      'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_0","role":"assistant"}}\n\n',
+      'data: {"type":"response.reasoning_summary_text.delta","output_index":0,"item_id":"rs_0","delta":"r"}\n\n',
+      'data: {"type":"response.output_text.delta","output_index":0,"item_id":"msg_0","delta":"m"}\n\n',
+    ].join("");
+
+    const events = await parseSse(await readAll(relaySseWithResponsesItemIdRepair(streamFromText(upstream), {
+      reasoning: ["rs_0"],
+      message: ["msg_0"],
+    })));
+    const reasoningId = (events[0].item as Record<string, unknown>).id;
+    const messageId = (events[1].item as Record<string, unknown>).id;
+
+    expect(reasoningId).toMatch(/^rs_ocx_[0-9a-f]+_0$/);
+    expect(messageId).toMatch(/^msg_ocx_[0-9a-f]+_0$/);
+    expect(events[2].item_id).toBe(reasoningId);
+    expect(events[3].item_id).toBe(messageId);
+  });
+
+  test("preserves untouched SSE blocks byte-for-byte even when repair is enabled", async () => {
+    const upstream = [
+      ': gateway heartbeat\r\n',
+      'event: response.function_call_arguments.delta\r\n',
+      'data:{"type":"response.function_call_arguments.delta","output_index":0,"item_id":"fc_1","call_id":"call_1","delta":"{}"}\r\n\r\n',
+      'data: [DONE]\r\n\r\n',
+    ].join("");
+
+    const repaired = await readAll(relaySseWithResponsesItemIdRepair(streamFromText(upstream), {
+      reasoning: ["rs_0"],
+    }));
+
+    expect(repaired).toBe(upstream);
+  });
+
+  test("reports whether a provider actually opted into repair", () => {
+    expect(hasResponsesItemIdRepair(undefined)).toBe(false);
+    expect(hasResponsesItemIdRepair({})).toBe(false);
+    expect(hasResponsesItemIdRepair({ repairMissingTerminalIds: true })).toBe(true);
+    expect(hasResponsesItemIdRepair({ message: ["msg_0"] })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add provider-local `responsesItemIdRepair` config for exact `message` / `reasoning` placeholder ids plus `repairMissingTerminalIds`
- repair downstream passthrough SSE item ids by `output_index` only when the provider opts in
- keep the tee'd inspection/replay path raw so synthetic ids never replay upstream
- document the config and cover single-stream plus sequential-stream lifecycles

## Root Cause
Some `openai-responses` compatibility gateways reuse placeholder `message` / `reasoning` ids (for example `rs_0`, `msg_0`) across sequential tool-loop responses and sometimes omit terminal ids. Codex Desktop correlates downstream reasoning/message activity by item id, so reused or missing ids can merge unrelated activity cards.

## Scope / Safety
- disabled by default
- exact string matches only for `message` / `reasoning`
- `function_call` ids and `call_id` remain untouched
- default passthrough bytes remain unchanged unless a provider explicitly opts in
- replay state still stores raw upstream responses, so repaired ids are not sent back upstream on later turns

## Validation
- `bun x tsc --noEmit`
- `bun test --isolate ./tests/responses-item-id-repair.test.ts ./tests/config.test.ts ./tests/passthrough-abort.test.ts ./tests/openai-responses-passthrough.test.ts`
- `bun run privacy:scan`