### PR TITLE
fix(cursor): preserve context usage on client-tool turns

### DIFF
--- a/src/adapters/cursor/live-transport.ts
+++ b/src/adapters/cursor/live-transport.ts
@@ -409,6 +409,7 @@ class LiveCursorTransport implements CursorTransport {
           framesReceived: this.framesReceived,
           outputTokens: state.usage.outputTokens,
           contextTokens: state.contextTokens,
+          fallbackInputTokens: state.fallbackInputTokens,
           firstFrameMs: this.firstFrameAt ? this.firstFrameAt - this.turnStartedAt : undefined,
           elapsedMs: this.turnStartedAt ? Date.now() - this.turnStartedAt : undefined,
           classified: classifyCursorError(err.message),
@@ -452,6 +453,7 @@ class LiveCursorTransport implements CursorTransport {
       parallelToolCalls: request.parallelToolCalls,
       toolSchemas,
       cursorToolNameMap,
+      fallbackInputTokens: request.fallbackInputTokens,
     });
 
     this.open(request, signal, state, push, err => {
@@ -553,10 +555,15 @@ class LiveCursorTransport implements CursorTransport {
       const terminal = finalizeAfterDrain(state);
       if (terminal.length === 0) return;
       for (const event of terminal) push(event);
+      const done = terminal.find(event => event.type === "done");
       debugProviderDiagnostic("cursor", "client-tool-suspend", {
         reason: "Responses bridge owns client tools; ending turn without fake mcpResult",
         framesReceived: this.framesReceived,
         elapsedMs: Date.now() - this.turnStartedAt,
+        checkpointTokens: state.contextTokens,
+        fallbackInputTokens: state.fallbackInputTokens,
+        outputTokens: state.usage.outputTokens,
+        reportedTotalTokens: done?.type === "done" ? done.usage?.totalTokens : undefined,
       });
       this.cancelCursorRun();
     }, this.activeClientToolFinalizeGraceMs);
@@ -782,10 +789,15 @@ class LiveCursorTransport implements CursorTransport {
 export function partialUsageFromEventState(state: ReturnType<typeof createCursorProtobufEventState>): OcxUsage | undefined {
   const out = state.usage.outputTokens;
   const ctx = state.contextTokens;
-  if (ctx === undefined && out <= 0) return undefined;
-  return ctx !== undefined
-    ? { ...state.usage, inputTokens: Math.max(0, ctx - out), totalTokens: ctx, estimated: true }
-    : { ...state.usage, estimated: true };
+  const fallback = state.fallbackInputTokens;
+  if (ctx === undefined && fallback === undefined && out <= 0) return undefined;
+  if (ctx !== undefined) {
+    return { ...state.usage, inputTokens: Math.max(0, ctx - out), totalTokens: ctx, estimated: true };
+  }
+  if (fallback !== undefined) {
+    return { ...state.usage, inputTokens: fallback, totalTokens: fallback + out, estimated: true };
+  }
+  return { ...state.usage, estimated: true };
 }
 
 /**

--- a/src/adapters/cursor/protobuf-events.ts
+++ b/src/adapters/cursor/protobuf-events.ts
@@ -16,6 +16,8 @@ export interface CursorProtobufEventState {
    * share one field, or Codex double-counts (e.g. 10000 then 10300 surfacing as 20300).
    */
   contextTokens?: number;
+  /** Best-effort active input context used only when Cursor never emits a checkpoint this turn. */
+  fallbackInputTokens?: number;
   openToolCalls: Map<string, { name: string; args: string }>;
   completedToolCalls: Set<string>;
   /** Set once a terminal `done`/truncation has been emitted, so post-terminal frames stay inert. */
@@ -29,11 +31,12 @@ export interface CursorProtobufEventState {
   cursorToolNameMap?: Map<string, string>;
 }
 
-export function createCursorProtobufEventState(options: { clientToolNames?: Iterable<string>; parallelToolCalls?: boolean; toolSchemas?: Map<string, unknown>; cursorToolNameMap?: Map<string, string> } = {}): CursorProtobufEventState {
+export function createCursorProtobufEventState(options: { clientToolNames?: Iterable<string>; parallelToolCalls?: boolean; toolSchemas?: Map<string, unknown>; cursorToolNameMap?: Map<string, string>; fallbackInputTokens?: number } = {}): CursorProtobufEventState {
   return {
     // Cursor provides no authoritative usage frame; token counts are heuristic estimates from
     // checkpoint/delta events, so mark estimated from the start.
     usage: { inputTokens: 0, outputTokens: 0, estimated: true },
+    ...(options.fallbackInputTokens !== undefined ? { fallbackInputTokens: options.fallbackInputTokens } : {}),
     openToolCalls: new Map(),
     completedToolCalls: new Set(),
     ...(options.clientToolNames ? { clientToolNames: new Set(options.clientToolNames) } : {}),
@@ -304,6 +307,12 @@ export function finalizeTurnEvents(state: CursorProtobufEventState): CursorServe
         inputTokens: Math.max(0, state.contextTokens - state.usage.outputTokens),
         totalTokens: state.contextTokens,
       }
+    : state.fallbackInputTokens !== undefined
+      ? {
+          ...state.usage,
+          inputTokens: state.fallbackInputTokens,
+          totalTokens: state.fallbackInputTokens + state.usage.outputTokens,
+        }
     : { ...state.usage };
   return [{ type: "done", usage }];
 }

--- a/src/adapters/cursor/request-builder.ts
+++ b/src/adapters/cursor/request-builder.ts
@@ -7,6 +7,7 @@ import type {
   OcxToolResultMessage,
 } from "../../types";
 import { isAllowedToolChoice, namespacedToolName, toolChoiceAliases, type OcxTool, type OcxToolChoice } from "../../types";
+import { estimateTokens } from "../../lib/token-estimate";
 import type { CursorRequestMessage, CursorRunRequest } from "./types";
 import { cursorCodexToWireModelId } from "./discovery";
 import { cursorEffortSuffix } from "./effort-map";
@@ -166,6 +167,14 @@ export function createCursorRequest(parsed: OcxParsedRequest): CursorRunRequest 
   const visibleTools = cursorToolsForActivePrompt(parsed.context.tools, activeText, parsed.options.toolChoice);
   const budget = applyCursorToolBudget(visibleTools, parsed.options.toolChoice);
   const limitNote = catalogLimitNote(budget.tools, budget.omitted);
+  const system = [...(parsed.context.systemPrompt ?? []), ...(limitNote ? [limitNote] : [])];
+  // Cursor can end a client-tool turn before sending conversationCheckpointUpdate. Estimate the
+  // complete input that is actually serialized for this turn and never let it fall below the last
+  // reported active context from the Responses chain. finalizeTurnEvents adds the current output.
+  const fallbackInputTokens = Math.max(
+    parsed._cursorPreviousContextTokens ?? 0,
+    estimateTokens(JSON.stringify({ system, messages, tools: budget.tools }), parsed.modelId),
+  );
   return {
     modelId: normalizeCursorModelId(parsed.modelId, parsed.options.reasoning),
     // The Cursor conversation id comes ONLY from remembered state (_cursorConversationId). Do NOT fall
@@ -173,9 +182,10 @@ export function createCursorRequest(parsed: OcxParsedRequest): CursorRunRequest 
     // different namespace and would start an unrelated Cursor conversation, breaking tool-result
     // continuation. If we have no remembered Cursor conversation, start a fresh one.
     conversationId: parsed._cursorConversationId ?? generatedCursorConversationId(),
-    system: [...(parsed.context.systemPrompt ?? []), ...(limitNote ? [limitNote] : [])],
+    system,
     messages,
     rawMessages: parsed.context.messages,
+    fallbackInputTokens,
     ...(budget.tools.length ? { tools: budget.tools } : {}),
     ...(parsed.options.toolChoice ? { toolChoice: parsed.options.toolChoice } : {}),
     ...(parsed.options.parallelToolCalls !== undefined ? { parallelToolCalls: parsed.options.parallelToolCalls } : {}),

--- a/src/adapters/cursor/types.ts
+++ b/src/adapters/cursor/types.ts
@@ -10,6 +10,8 @@ export interface CursorRunRequest {
   tools?: OcxTool[];
   toolChoice?: OcxRequestOptions["toolChoice"];
   parallelToolCalls?: boolean;
+  /** Best-effort active input context used when this turn is finalized before a Cursor checkpoint. */
+  fallbackInputTokens?: number;
 }
 
 export interface CursorRequestMessage {

--- a/src/responses/state.ts
+++ b/src/responses/state.ts
@@ -14,6 +14,7 @@ interface StoredResponseState {
   createdAt: number;
   items: unknown[];
   conversationId?: string;
+  cursorContextTokens?: number;
   cursorCheckpointUsable?: boolean;
 }
 
@@ -144,9 +145,17 @@ export function previousResponseConversationId(responseId: string | undefined): 
   return states.get(responseId)?.conversationId;
 }
 
+/** Last active Cursor context reported on the preceding Responses turn. */
+export function previousResponseCursorContextTokens(responseId: string | undefined): number | undefined {
+  if (!responseId) return undefined;
+  ensureLoaded();
+  pruneResponses();
+  return states.get(responseId)?.cursorContextTokens;
+}
+
 export function rememberResponseState(
   requestBody: unknown,
-  response: { id?: unknown; output?: unknown; status?: unknown },
+  response: { id?: unknown; output?: unknown; status?: unknown; usage?: unknown },
   conversationId?: string,
   opts?: { force?: boolean },
 ): void {
@@ -160,6 +169,17 @@ export function rememberResponseState(
   if (request.store === false && !opts?.force) return;
   if (typeof response.id !== "string" || !Array.isArray(response.output)) return;
   if (response.status !== undefined && response.status !== "completed") return;
+  const rawContextTokens = conversationId
+    && response.usage
+    && typeof response.usage === "object"
+    && !Array.isArray(response.usage)
+    ? (response.usage as { total_tokens?: unknown }).total_tokens
+    : undefined;
+  const cursorContextTokens = typeof rawContextTokens === "number"
+    && Number.isFinite(rawContextTokens)
+    && rawContextTokens > 0
+    ? Math.floor(rawContextTokens)
+    : undefined;
   ensureLoaded();
   states.set(response.id, {
     createdAt: now(),
@@ -170,6 +190,7 @@ export function rememberResponseState(
     // incomplete agent turn on the Cursor side (we suspended without a real mcpResult), so its
     // checkpoint must not be reused — but the conversation id string itself is still valid.
     ...(conversationId ? { conversationId } : {}),
+    ...(cursorContextTokens !== undefined ? { cursorContextTokens } : {}),
     cursorCheckpointUsable: !response.output.some(item => {
       return !!item && typeof item === "object" && (item as { type?: unknown }).type === "function_call";
     }),

--- a/src/server/responses.ts
+++ b/src/server/responses.ts
@@ -7,7 +7,7 @@ import {
 import { parseRequest } from "../responses/parser";
 import { buildCompactV1Output, COMPACT_PROMPT, decodeCompactionSummary, extractCompactUserMessages } from "../responses/compaction";
 import { FORWARD_HEADERS, sanitizeReasoningInputContent } from "../adapters/openai-responses";
-import { expandPreviousResponseInput, previousResponseConversationId, rememberResponseState } from "../responses/state";
+import { expandPreviousResponseInput, previousResponseConversationId, previousResponseCursorContextTokens, rememberResponseState } from "../responses/state";
 import { routeModel } from "../router";
 import {
   advanceComboAfterFailure,
@@ -829,6 +829,12 @@ export async function handleResponses(
     parsed = parseRequest(body);
     if (previousResponseInputExpanded) parsed._previousResponseInputExpanded = true;
     parsed._cursorConversationId = previousResponseConversationId(parsed.previousResponseId);
+    // A compaction request intentionally resets active-context accounting. Normal Cursor turns carry
+    // the preceding reported total as a floor so an early client-tool finalize cannot make Codex's
+    // Context left jump back toward 100% when no fresh checkpoint arrives.
+    if (!parsed._compactionRequest) {
+      parsed._cursorPreviousContextTokens = previousResponseCursorContextTokens(parsed.previousResponseId);
+    }
   } catch (err) {
     return formatErrorResponse(400, "invalid_request_error", err instanceof Error ? err.message : String(err));
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export interface OcxParsedRequest {
   _previousResponseInputExpanded?: boolean;
   /** Provider-private stable Cursor conversation id resolved from the Responses previous_response_id chain. */
   _cursorConversationId?: string;
+  /** Last reported active Cursor context from the preceding Responses turn, used as a usage floor. */
+  _cursorPreviousContextTokens?: number;
   /**
    * The hosted `{type:"web_search", ...}` tool config, stashed when Codex enables web search. Routed
    * (non-OpenAI) providers can't run it server-side, so the proxy re-exposes it as a function tool and

--- a/tests/cursor-interaction-query.test.ts
+++ b/tests/cursor-interaction-query.test.ts
@@ -168,6 +168,19 @@ describe("partialUsageFromEventState", () => {
     expect(partialUsageFromEventState(state)).toEqual({ inputTokens: 0, outputTokens: 7, estimated: true });
   });
 
+  test("uses the input fallback for a failed turn without a checkpoint", async () => {
+    const { partialUsageFromEventState } = await import("../src/adapters/cursor/live-transport");
+    const { createCursorProtobufEventState } = await import("../src/adapters/cursor/protobuf-events");
+    const state = createCursorProtobufEventState({ fallbackInputTokens: 120_000 });
+    state.usage.outputTokens = 7;
+    expect(partialUsageFromEventState(state)).toEqual({
+      inputTokens: 120_000,
+      outputTokens: 7,
+      totalTokens: 120_007,
+      estimated: true,
+    });
+  });
+
   test("returns undefined when the stream died before any token signal", async () => {
     const { partialUsageFromEventState } = await import("../src/adapters/cursor/live-transport");
     const { createCursorProtobufEventState } = await import("../src/adapters/cursor/protobuf-events");

--- a/tests/cursor-live-transport.test.ts
+++ b/tests/cursor-live-transport.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { createLiveCursorTransport, CursorMissingCredentialError, parseConnectEndStreamError, resolveCursorToken } from "../src/adapters/cursor/live-transport";
+import { createLiveCursorTransport, CursorMissingCredentialError, finalizeAfterDrain, parseConnectEndStreamError, resolveCursorToken } from "../src/adapters/cursor/live-transport";
+import type { CursorProtobufEventState } from "../src/adapters/cursor/protobuf-events";
+import type { CursorServerMessage } from "../src/adapters/cursor/types";
 
 describe("Cursor live transport", () => {
   test("fails before network when no Cursor credential is configured", () => {
@@ -25,6 +27,42 @@ describe("Cursor live transport", () => {
     expect(transport).toHaveProperty("run");
     expect(JSON.stringify(transport)).not.toContain("secret-cursor-token");
     transport.close?.();
+  });
+
+  test("seeds early-finalize usage from the request fallback before opening the wire", async () => {
+    const transport = createLiveCursorTransport({
+      provider: { adapter: "cursor", baseUrl: "https://api2.cursor.sh", apiKey: "test-token" },
+      headers: new Headers(),
+    });
+    const internals = transport as unknown as {
+      open(
+        request: unknown,
+        signal: AbortSignal | undefined,
+        state: CursorProtobufEventState,
+        push: (event: CursorServerMessage) => void,
+        fail: (error: Error) => void,
+        finish: () => void,
+      ): void;
+    };
+    internals.open = (_request, _signal, state, push, _fail, finish) => {
+      state.usage.outputTokens = 42;
+      for (const event of finalizeAfterDrain(state)) push(event);
+      finish();
+    };
+
+    const events: CursorServerMessage[] = [];
+    for await (const event of transport.run({
+      modelId: "grok-4.5",
+      conversationId: "cursor-context-fallback",
+      system: [],
+      messages: [{ role: "user", content: "use a tool" }],
+      fallbackInputTokens: 120_000,
+    })) events.push(event);
+
+    expect(events).toEqual([
+      { type: "done", usage: { inputTokens: 120_000, outputTokens: 42, totalTokens: 120_042, estimated: true } },
+    ]);
+    await transport.close?.();
   });
 
   test("fails the turn when MCP preparation rejects", async () => {

--- a/tests/cursor-protobuf-events.test.ts
+++ b/tests/cursor-protobuf-events.test.ts
@@ -464,6 +464,24 @@ describe("Cursor protobuf tool-call events", () => {
     expect(state.terminated).toBe(true);
   });
 
+  test("uses the seeded input fallback when a client-tool turn ends before any checkpoint", () => {
+    const state = createCursorProtobufEventState({ fallbackInputTokens: 120_000 });
+    const turnEnd = create(AgentServerMessageSchema, {
+      message: { case: "interactionUpdate", value: create(InteractionUpdateSchema, {
+        message: { case: "turnEnded", value: {} },
+      }) },
+    });
+
+    mapCursorProtobufServerMessage(
+      interaction({ case: "tokenDelta", value: create(TokenDeltaUpdateSchema, { tokens: 42 }) }),
+      state,
+    );
+
+    expect(mapCursorProtobufServerMessage(turnEnd, state)).toEqual([
+      { type: "done", usage: { inputTokens: 120_000, outputTokens: 42, totalTokens: 120_042, estimated: true } },
+    ]);
+  });
+
   test("checkpoint usage clamps inferred input when output delta exceeds context", () => {
     const state = createCursorProtobufEventState();
     const checkpoint = create(AgentServerMessageSchema, {

--- a/tests/cursor-request-builder.test.ts
+++ b/tests/cursor-request-builder.test.ts
@@ -38,6 +38,25 @@ describe("Cursor request builder", () => {
     expect(request.conversationId).toBe("cursor_stable");
   });
 
+  test("carries the last known active context into the next Cursor turn", () => {
+    const request = createCursorRequest({
+      ...base,
+      _cursorPreviousContextTokens: 120_000,
+      context: { messages: [{ role: "user", content: "next", timestamp: 1 }] },
+    });
+
+    expect(request.fallbackInputTokens).toBe(120_000);
+  });
+
+  test("estimates active input context when no preceding checkpoint is available", () => {
+    const request = createCursorRequest({
+      ...base,
+      context: { messages: [{ role: "user", content: "x".repeat(4_000), timestamp: 1 }] },
+    });
+
+    expect(request.fallbackInputTokens).toBeGreaterThanOrEqual(1_000);
+  });
+
   test("maps system, developer, user, assistant, and tool result text", () => {
     const request = createCursorRequest({
       ...base,

--- a/tests/responses-state.test.ts
+++ b/tests/responses-state.test.ts
@@ -10,6 +10,7 @@ import {
   expandPreviousResponseInput,
   flushResponseState,
   previousResponseConversationId,
+  previousResponseCursorContextTokens,
   rememberResponseState,
 } from "../src/responses/state";
 
@@ -232,6 +233,19 @@ describe("Responses previous_response_id state", () => {
     rememberResponseState(firstBody, first, "cursor_conversation_1");
 
     expect(previousResponseConversationId(first.id as string)).toBe("cursor_conversation_1");
+  });
+
+  test("stores the last reported Cursor context total alongside the Responses chain", () => {
+    const first = buildResponseJSON([
+      { type: "text_delta", text: "done" },
+      { type: "done", usage: { inputTokens: 119_900, outputTokens: 100, totalTokens: 120_000, estimated: true } },
+    ], "cursor/grok-4.5");
+
+    rememberResponseState({ model: "cursor/grok-4.5", input: "work" }, first, "cursor_conversation_1");
+    flushResponseState();
+    clearResponseStateMemoryForTests();
+
+    expect(previousResponseCursorContextTokens(first.id as string)).toBe(120_000);
   });
 
   test("preserves provider conversation id after a client tool-call response (multi-turn continuation)", () => {


### PR DESCRIPTION
## Summary

- preserve the last reported Cursor context total across Responses continuations
- seed turns without a checkpoint from the larger of the previous context total or a full-input estimate
- report fallback usage when client-tool turns finalize early or fail before a checkpoint
- keep fresh Cursor checkpoints authoritative and avoid carrying context into compaction requests
- add regression coverage and numeric provider diagnostics

## Root cause

Cursor client-tool turns are intentionally finalized and cancelled before a delayed `conversationCheckpointUpdate` can arrive. Without a fallback, `finalizeTurnEvents` reports only the current output-token delta, so Codex overwrites `last_token_usage.total_tokens` with a tiny value and the UI jumps back to nearly `Context 100% left`.

## User impact

Agent and tool turns now preserve a meaningful active-context total instead of resetting the visible context usage. Normal turns still use Cursor's authoritative checkpoint whenever one is available.

## Validation

- `bun test tests/cursor-protobuf-events.test.ts tests/cursor-request-builder.test.ts tests/cursor-live-transport.test.ts tests/cursor-interaction-query.test.ts tests/cursor-tool-continuation.test.ts tests/responses-state.test.ts` — 79 passed
- `bun run typecheck`
- `git diff --check origin/dev...HEAD`

Fixes #245
