### PR TITLE
fix(cursor): carry context usage across tool finalizes

### DIFF
--- a/src/adapters/cursor/live-transport.ts
+++ b/src/adapters/cursor/live-transport.ts
@@ -3,7 +3,15 @@ import { create, fromBinary, toBinary } from "@bufbuild/protobuf";
 import { namespacedToolName, type OcxProviderConfig, type OcxUsage } from "../../types";
 import { CONNECT_FLAG_END_STREAM, decodeAvailableConnectFrames, encodeConnectFrame } from "./framing";
 import { activePromptText, encodeCursorRunRequest } from "./protobuf-request";
-import { createCursorProtobufEventState, finalizeTurnEvents, mapCursorProtobufServerMessage, mapSyntheticMcpExecToToolEvents } from "./protobuf-events";
+import {
+  createCursorContextUsageTracker,
+  createCursorProtobufEventState,
+  finalizeTurnEvents,
+  mapCursorProtobufServerMessage,
+  mapSyntheticMcpExecToToolEvents,
+  reportableContextTokens,
+  usageFromContextTokens,
+} from "./protobuf-events";
 import {
   AgentClientMessageSchema,
   AgentServerMessageSchema,
@@ -60,6 +68,7 @@ const CLIENT_TOOL_FINALIZE_GRACE_MS = 50;
 const GENERIC_TOOL_COUNT_MIN_FINALIZE_GRACE_MS = 750;
 const GENERIC_TOOL_COUNT_MAX_FINALIZE_GRACE_MS = 1_800;
 const GENERIC_TOOL_COUNT_PER_TOOL_GRACE_MS = 125;
+const cursorContextUsageTracker = createCursorContextUsageTracker();
 
 export class CursorMissingCredentialError extends Error {
   readonly code = "cursor_missing_credential";
@@ -452,6 +461,10 @@ class LiveCursorTransport implements CursorTransport {
       parallelToolCalls: request.parallelToolCalls,
       toolSchemas,
       cursorToolNameMap,
+      contextUsage: cursorContextUsageTracker.controlsForConversation(request.conversationId, {
+        clearPrior: request.contextUsageReset === true,
+        storeCheckpoints: request.contextUsageStoreCheckpoints !== false,
+      }),
     });
 
     this.open(request, signal, state, push, err => {
@@ -781,10 +794,10 @@ class LiveCursorTransport implements CursorTransport {
  */
 export function partialUsageFromEventState(state: ReturnType<typeof createCursorProtobufEventState>): OcxUsage | undefined {
   const out = state.usage.outputTokens;
-  const ctx = state.contextTokens;
+  const ctx = reportableContextTokens(state);
   if (ctx === undefined && out <= 0) return undefined;
   return ctx !== undefined
-    ? { ...state.usage, inputTokens: Math.max(0, ctx - out), totalTokens: ctx, estimated: true }
+    ? { ...usageFromContextTokens(state, ctx), estimated: true }
     : { ...state.usage, estimated: true };
 }
 

--- a/src/adapters/cursor/live-transport.ts
+++ b/src/adapters/cursor/live-transport.ts
@@ -794,8 +794,13 @@ class LiveCursorTransport implements CursorTransport {
  */
 export function partialUsageFromEventState(state: ReturnType<typeof createCursorProtobufEventState>): OcxUsage | undefined {
   const out = state.usage.outputTokens;
+  const hasCurrentCheckpoint = Number.isFinite(state.contextTokens) && (state.contextTokens ?? 0) > 0;
+  const hasCurrentOutput = Number.isFinite(out) && out > 0;
+  // A carry-forward value belongs to an earlier successful turn. It can complete current-turn
+  // usage math after this turn emits output, but cannot by itself prove that a first-frame failure
+  // consumed anything.
+  if (!hasCurrentCheckpoint && !hasCurrentOutput) return undefined;
   const ctx = reportableContextTokens(state);
-  if (ctx === undefined && out <= 0) return undefined;
   return ctx !== undefined
     ? { ...usageFromContextTokens(state, ctx), estimated: true }
     : { ...state.usage, estimated: true };

--- a/src/adapters/cursor/protobuf-events.ts
+++ b/src/adapters/cursor/protobuf-events.ts
@@ -5,6 +5,101 @@ import { normalizeArgKeys } from "./arg-normalize";
 import { OCX_RESPONSES_TOOL_PROVIDER, normalizeCursorWireName, responsesToolNameFromCursorWire } from "./tool-definitions";
 import type { CursorServerMessage } from "./types";
 
+const DEFAULT_CONTEXT_USAGE_MAX_ENTRIES = 200;
+const DEFAULT_CONTEXT_USAGE_TTL_MS = 60 * 60 * 1_000;
+
+export interface CursorContextUsageControls {
+  /**
+   * Last observed absolute context size for the same Cursor conversation and uncompacted context
+   * epoch. Used only when the current turn produces output but no checkpoint.
+   */
+  carryForwardTokens?: number;
+  /** Persist a fresh checkpoint for later turns in this conversation. */
+  recordContextTokens?: (tokens: number) => void;
+}
+
+export interface CursorContextUsageTracker {
+  controlsForConversation(conversationId: string, options?: { clearPrior?: boolean; storeCheckpoints?: boolean }): CursorContextUsageControls;
+  get(conversationId: string): number | undefined;
+  record(conversationId: string, tokens: number): void;
+  clear(conversationId: string): void;
+  clearAll(): void;
+}
+
+interface CursorContextUsageEntry {
+  tokens: number;
+  updatedAt: number;
+}
+
+/**
+ * Bounded numeric-only carry-forward for Cursor context usage. Cursor checkpoints are absolute
+ * active-context sizes, but client-tool suspension can end a turn before a checkpoint arrives. Keep
+ * only the last known total per provider conversation so a no-checkpoint finalize does not overwrite
+ * a real active-context value with the current turn's tiny output delta. Context text, tool args,
+ * and model output are never stored here.
+ */
+export function createCursorContextUsageTracker(options: { maxEntries?: number; ttlMs?: number; now?: () => number } = {}): CursorContextUsageTracker {
+  const maxEntries = options.maxEntries ?? DEFAULT_CONTEXT_USAGE_MAX_ENTRIES;
+  const ttlMs = options.ttlMs ?? DEFAULT_CONTEXT_USAGE_TTL_MS;
+  const now = options.now ?? (() => Date.now());
+  const entries = new Map<string, CursorContextUsageEntry>();
+
+  const prune = () => {
+    const at = now();
+    for (const [conversationId, entry] of entries) {
+      if (at - entry.updatedAt > ttlMs) entries.delete(conversationId);
+    }
+    while (entries.size > maxEntries) {
+      const oldest = entries.keys().next().value;
+      if (!oldest) break;
+      entries.delete(oldest);
+    }
+  };
+
+  const record = (conversationId: string, tokens: number) => {
+    if (!Number.isFinite(tokens) || tokens <= 0) return;
+    prune();
+    const existing = entries.get(conversationId);
+    if (existing && existing.tokens >= tokens) {
+      entries.delete(conversationId);
+      entries.set(conversationId, { tokens: existing.tokens, updatedAt: now() });
+      return;
+    }
+    entries.delete(conversationId);
+    entries.set(conversationId, { tokens, updatedAt: now() });
+    prune();
+  };
+
+  const get = (conversationId: string): number | undefined => {
+    prune();
+    const entry = entries.get(conversationId);
+    if (!entry) return undefined;
+    entries.delete(conversationId);
+    entries.set(conversationId, { tokens: entry.tokens, updatedAt: now() });
+    return entry.tokens;
+  };
+
+  return {
+    controlsForConversation(conversationId, requestOptions = {}) {
+      if (requestOptions.clearPrior === true) entries.delete(conversationId);
+      const storeCheckpoints = requestOptions.storeCheckpoints !== false;
+      const carryForwardTokens = storeCheckpoints ? get(conversationId) : undefined;
+      return {
+        ...(carryForwardTokens !== undefined ? { carryForwardTokens } : {}),
+        ...(storeCheckpoints ? { recordContextTokens: tokens => record(conversationId, tokens) } : {}),
+      };
+    },
+    get,
+    record,
+    clear(conversationId) {
+      entries.delete(conversationId);
+    },
+    clearAll() {
+      entries.clear();
+    },
+  };
+}
+
 export interface CursorProtobufEventState {
   usage: OcxUsage;
   /**
@@ -16,6 +111,14 @@ export interface CursorProtobufEventState {
    * share one field, or Codex double-counts (e.g. 10000 then 10300 surfacing as 20300).
    */
   contextTokens?: number;
+  /**
+   * Session-level last-known absolute context size for this Cursor conversation. This is a fallback
+   * for no-checkpoint client-tool finalize turns only; any checkpoint observed during the current
+   * turn remains authoritative, with monotonic max semantics unless a compaction boundary reset the
+   * conversation cache before the turn.
+   */
+  contextCarryForwardTokens?: number;
+  recordContextTokens?: (tokens: number) => void;
   openToolCalls: Map<string, { name: string; args: string }>;
   completedToolCalls: Set<string>;
   /** Set once a terminal `done`/truncation has been emitted, so post-terminal frames stay inert. */
@@ -29,7 +132,13 @@ export interface CursorProtobufEventState {
   cursorToolNameMap?: Map<string, string>;
 }
 
-export function createCursorProtobufEventState(options: { clientToolNames?: Iterable<string>; parallelToolCalls?: boolean; toolSchemas?: Map<string, unknown>; cursorToolNameMap?: Map<string, string> } = {}): CursorProtobufEventState {
+export function createCursorProtobufEventState(options: {
+  clientToolNames?: Iterable<string>;
+  parallelToolCalls?: boolean;
+  toolSchemas?: Map<string, unknown>;
+  cursorToolNameMap?: Map<string, string>;
+  contextUsage?: CursorContextUsageControls;
+} = {}): CursorProtobufEventState {
   return {
     // Cursor provides no authoritative usage frame; token counts are heuristic estimates from
     // checkpoint/delta events, so mark estimated from the start.
@@ -41,6 +150,30 @@ export function createCursorProtobufEventState(options: { clientToolNames?: Iter
     startedClientToolCalls: 0,
     ...(options.toolSchemas ? { toolSchemas: options.toolSchemas } : {}),
     ...(options.cursorToolNameMap ? { cursorToolNameMap: options.cursorToolNameMap } : {}),
+    ...(options.contextUsage?.carryForwardTokens !== undefined ? { contextCarryForwardTokens: options.contextUsage.carryForwardTokens } : {}),
+    ...(options.contextUsage?.recordContextTokens ? { recordContextTokens: options.contextUsage.recordContextTokens } : {}),
+  };
+}
+
+function observeContextTokens(state: CursorProtobufEventState, usedTokens: number): void {
+  if (!Number.isFinite(usedTokens) || usedTokens <= 0) return;
+  if (usedTokens > (state.contextTokens ?? 0)) state.contextTokens = usedTokens;
+  state.recordContextTokens?.(usedTokens);
+}
+
+export function reportableContextTokens(state: CursorProtobufEventState): number | undefined {
+  const current = state.contextTokens;
+  const carry = state.contextCarryForwardTokens;
+  if (current === undefined) return carry;
+  if (carry === undefined) return current;
+  return Math.max(current, carry);
+}
+
+export function usageFromContextTokens(state: CursorProtobufEventState, contextTokens: number): OcxUsage {
+  return {
+    ...state.usage,
+    inputTokens: Math.max(0, contextTokens - state.usage.outputTokens),
+    totalTokens: contextTokens,
   };
 }
 
@@ -204,12 +337,14 @@ export function mapCursorProtobufServerMessage(
   serverMessage: AgentServerMessage,
   state: CursorProtobufEventState,
 ): CursorServerMessage[] {
+  if (state.terminated) return [];
+
   if (serverMessage.message.case === "conversationCheckpointUpdate") {
     const usedTokens = serverMessage.message.value.tokenDetails?.usedTokens ?? 0;
     // `usedTokens` is the ABSOLUTE conversation context size, not a per-turn output delta. Track it
     // separately (monotonic max) and surface it as `done.usage.totalTokens`; folding it into
     // `outputTokens` (which also accumulates `tokenDelta`) double-counts in Codex. See contextTokens.
-    if (usedTokens > (state.contextTokens ?? 0)) state.contextTokens = usedTokens;
+    observeContextTokens(state, usedTokens);
     return [];
   }
 
@@ -298,12 +433,9 @@ export function finalizeTurnEvents(state: CursorProtobufEventState): CursorServe
   // render the additive pair instead of total_tokens, so leaving inputTokens at 0 makes a 16k-context
   // first turn display as "9 used". Keep outputTokens as the per-turn delta and clamp the inferred
   // input to 0 in case Cursor reports a checkpoint smaller than the streamed output delta.
-  const usage: OcxUsage = state.contextTokens !== undefined
-    ? {
-        ...state.usage,
-        inputTokens: Math.max(0, state.contextTokens - state.usage.outputTokens),
-        totalTokens: state.contextTokens,
-      }
+  const contextTokens = reportableContextTokens(state);
+  const usage: OcxUsage = contextTokens !== undefined
+    ? usageFromContextTokens(state, contextTokens)
     : { ...state.usage };
   return [{ type: "done", usage }];
 }

--- a/src/adapters/cursor/request-builder.ts
+++ b/src/adapters/cursor/request-builder.ts
@@ -176,6 +176,8 @@ export function createCursorRequest(parsed: OcxParsedRequest): CursorRunRequest 
     system: [...(parsed.context.systemPrompt ?? []), ...(limitNote ? [limitNote] : [])],
     messages,
     rawMessages: parsed.context.messages,
+    ...(parsed._compactionRequest === true || parsed._contextCompactionBoundary === true ? { contextUsageReset: true } : {}),
+    ...(parsed._compactionRequest === true ? { contextUsageStoreCheckpoints: false } : {}),
     ...(budget.tools.length ? { tools: budget.tools } : {}),
     ...(parsed.options.toolChoice ? { toolChoice: parsed.options.toolChoice } : {}),
     ...(parsed.options.parallelToolCalls !== undefined ? { parallelToolCalls: parsed.options.parallelToolCalls } : {}),

--- a/src/adapters/cursor/types.ts
+++ b/src/adapters/cursor/types.ts
@@ -11,8 +11,9 @@ export interface CursorRunRequest {
   toolChoice?: OcxRequestOptions["toolChoice"];
   parallelToolCalls?: boolean;
   /**
-   * Clear provider-private context-usage carry-forward before this run. Used when Codex starts or
-   * replays a compacted context epoch, so pre-compaction active-context totals are not over-reported.
+   * Clear provider-private context-usage carry-forward before this run. Used when Codex starts a
+   * newly observed compacted context epoch, so pre-compaction totals are not over-reported while
+   * historical previous_response_id replay remains idempotent.
    */
   contextUsageReset?: boolean;
   /**

--- a/src/adapters/cursor/types.ts
+++ b/src/adapters/cursor/types.ts
@@ -10,6 +10,16 @@ export interface CursorRunRequest {
   tools?: OcxTool[];
   toolChoice?: OcxRequestOptions["toolChoice"];
   parallelToolCalls?: boolean;
+  /**
+   * Clear provider-private context-usage carry-forward before this run. Used when Codex starts or
+   * replays a compacted context epoch, so pre-compaction active-context totals are not over-reported.
+   */
+  contextUsageReset?: boolean;
+  /**
+   * Defaults to true. Set false for compaction summarizer turns: their checkpoints describe the
+   * pre-compaction history being summarized and must not become the next turn's carry-forward total.
+   */
+  contextUsageStoreCheckpoints?: boolean;
 }
 
 export interface CursorRequestMessage {

--- a/src/responses/parser.ts
+++ b/src/responses/parser.ts
@@ -13,6 +13,7 @@ import type {
 import { namespacedToolName } from "../types";
 import { responsesRequestSchema } from "./schema";
 import { compactionItemToText } from "./compaction";
+import { previousResponseReplayPrefixLength } from "./state";
 import { decodeReasoningEnvelope } from "./reasoning-envelope";
 import { extractHostedWebSearch, WEB_SEARCH_TOOL_NAME } from "../web-search/synthetic-tool";
 
@@ -220,6 +221,7 @@ function findToolById(messages: OcxMessage[], callId: string): { name: string; n
 const REASONING_EFFORTS = new Set(["none", "minimal", "low", "medium", "high", "xhigh", "max"]);
 
 export function parseRequest(body: unknown): OcxParsedRequest {
+  const replayedInputPrefixLength = previousResponseReplayPrefixLength(body);
   const parsed = responsesRequestSchema.safeParse(body);
   if (!parsed.success) {
     throw new Error(`responses parse error: ${parsed.error.message}`);
@@ -257,7 +259,8 @@ export function parseRequest(body: unknown): OcxParsedRequest {
   if (typeof data.input === "string") {
     messages.push({ role: "user", content: data.input, timestamp: now });
   } else if (data.input) {
-    for (const item of data.input) {
+    for (let inputIndex = 0; inputIndex < data.input.length; inputIndex++) {
+      const item = data.input[inputIndex];
       const effectiveType = (item as { type?: string }).type ?? ("role" in item ? "message" : undefined);
 
       if (effectiveType === "compaction_trigger") {
@@ -282,9 +285,10 @@ export function parseRequest(body: unknown): OcxParsedRequest {
         // the routed model keeps the compacted context; real OpenAI-encrypted blobs degrade to a note.
         // `context_compaction` (encrypted_content optional) is codex-rs's local-compaction marker;
         // with no payload it is a pure marker (the summary follows as its own user message), so it
-        // is dropped silently. It must NOT flag _compactionRequest, but it does mark a context epoch
-        // boundary for provider-private carry-forward state such as Cursor's active-context usage.
-        contextCompactionBoundary = true;
+        // is dropped silently. It must NOT flag _compactionRequest. Only a marker newly appended in
+        // this request starts a provider-private context epoch; markers inside the prefix restored by
+        // previous_response_id were already acknowledged on the turn that introduced them.
+        if (inputIndex >= replayedInputPrefixLength) contextCompactionBoundary = true;
         const encrypted = (item as { encrypted_content?: unknown }).encrypted_content;
         if (effectiveType === "context_compaction" && typeof encrypted !== "string") continue;
         pendingReasoning.length = 0;

--- a/src/responses/parser.ts
+++ b/src/responses/parser.ts
@@ -248,6 +248,7 @@ export function parseRequest(body: unknown): OcxParsedRequest {
   // Remote compaction v2: the input tail carries `{type:"compaction_trigger"}` and Codex expects a
   // synthetic `{type:"compaction"}` output item (src/responses/compaction.ts). Flagged for the server.
   let compactionRequest = false;
+  let contextCompactionBoundary = false;
 
   if (typeof data.instructions === "string" && data.instructions.length > 0) {
     systemPrompt.push(data.instructions);
@@ -281,7 +282,9 @@ export function parseRequest(body: unknown): OcxParsedRequest {
         // the routed model keeps the compacted context; real OpenAI-encrypted blobs degrade to a note.
         // `context_compaction` (encrypted_content optional) is codex-rs's local-compaction marker;
         // with no payload it is a pure marker (the summary follows as its own user message), so it
-        // is dropped silently. It must NOT flag _compactionRequest.
+        // is dropped silently. It must NOT flag _compactionRequest, but it does mark a context epoch
+        // boundary for provider-private carry-forward state such as Cursor's active-context usage.
+        contextCompactionBoundary = true;
         const encrypted = (item as { encrypted_content?: unknown }).encrypted_content;
         if (effectiveType === "context_compaction" && typeof encrypted !== "string") continue;
         pendingReasoning.length = 0;
@@ -583,6 +586,7 @@ export function parseRequest(body: unknown): OcxParsedRequest {
     ...(webSearch ? { _webSearch: webSearch } : {}),
     ...(structuredOutput ? { _structuredOutput: true } : {}),
     ...(compactionRequest ? { _compactionRequest: true } : {}),
+    ...(contextCompactionBoundary ? { _contextCompactionBoundary: true } : {}),
   };
 }
 

--- a/src/responses/state.ts
+++ b/src/responses/state.ts
@@ -18,6 +18,10 @@ interface StoredResponseState {
 }
 
 const states = new Map<string, StoredResponseState>();
+// Expansion provenance must stay proxy-private: a WeakMap distinguishes replayed history from the
+// newly appended input suffix without adding an unknown field that native passthrough could send
+// upstream. The parser uses this boundary to acknowledge historical compaction markers exactly once.
+const replayedInputPrefixLengths = new WeakMap<object, number>();
 let loaded = false;
 let persistTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingPersistPath: string | null = null;
@@ -131,10 +135,18 @@ export function expandPreviousResponseInput(body: unknown): unknown {
   pruneResponses();
   const previous = states.get(previousId);
   if (!previous) return body;
-  return {
+  const expanded = {
     ...request,
     input: [...previous.items, ...inputItems(request.input)],
   };
+  replayedInputPrefixLengths.set(expanded, previous.items.length);
+  return expanded;
+}
+
+/** Number of leading input items restored from previous_response_id state for this exact body. */
+export function previousResponseReplayPrefixLength(body: unknown): number {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return 0;
+  return replayedInputPrefixLengths.get(body) ?? 0;
 }
 
 export function previousResponseConversationId(responseId: string | undefined): string | undefined {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,9 +29,9 @@ export interface OcxParsedRequest {
    */
   _compactionRequest?: boolean;
   /**
-   * True when parsed input included a stored compaction summary/marker. Routed adapters receive the
-   * compacted epoch, so provider-private continuation caches must not carry pre-compaction state
-   * across this request.
+   * True when the current request newly introduced a stored compaction summary/marker. Historical
+   * markers restored by previous_response_id expansion were already acknowledged and do not reset
+   * provider-private continuation caches again on every later turn.
    */
   _contextCompactionBoundary?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,12 @@ export interface OcxParsedRequest {
    * (see src/responses/compaction.ts).
    */
   _compactionRequest?: boolean;
+  /**
+   * True when parsed input included a stored compaction summary/marker. Routed adapters receive the
+   * compacted epoch, so provider-private continuation caches must not carry pre-compaction state
+   * across this request.
+   */
+  _contextCompactionBoundary?: boolean;
 }
 
 export interface OcxContext {

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -109,6 +109,8 @@ before Cursor emits a new checkpoint; those turns carry forward the last observe
 Cursor conversation instead of reporting only the tiny current-turn output delta. The carry-forward
 cache is process-local, numeric-only, bounded, and keyed by Cursor conversation id. Compaction
 boundaries clear the carry so pre-compaction totals are not reused after Codex replaces history.
+Historical compaction markers restored by `previous_response_id` expansion are acknowledged as a
+replayed prefix and do not clear a fresh post-compaction checkpoint again on every later turn.
 Compaction summarizer turns may still report their own checkpoint for that response, but their
 pre-compaction checkpoint is not persisted for later carry-forward.
 
@@ -117,8 +119,8 @@ pre-compaction checkpoint is not persisted for later carry-forward.
 - 목적과 의도: Keep Codex's visible "context left" indicator aligned with Cursor's active-context usage on client-tool turns that finalize before a checkpoint arrives.
 - 기존 구현 및 제약 조건: Checkpoint turns reported totalTokens correctly, but no-checkpoint client-tool finalize fell back to output-only usage and could overwrite a meaningful prior total with values like 109 tokens.
 - 검토한 주요 대안: Add a longer wait for late checkpoints; infer prior+output totals; store full prompt/history state; carry forward only the last numeric checkpoint per Cursor conversation.
-- 선택한 방식: Carry forward the last numeric absolute checkpoint per Cursor conversation with bounded LRU/TTL storage, update it only from live checkpoint frames, and clear/suppress it across compaction boundaries.
-- 다른 대안 대신 이 방식을 선택한 이유: It fixes the UI regression without delaying tool turns, fabricating token growth, or storing prompt/tool content; compaction resets prevent stale over-report when history is replaced.
+- 선택한 방식: Carry forward the last numeric absolute checkpoint per Cursor conversation with bounded LRU/TTL storage, update it only from live checkpoint frames, and clear/suppress it once when a newly appended compaction boundary starts an epoch; previous_response replay provenance acknowledges historical markers without serializing private metadata upstream.
+- 다른 대안 대신 이 방식을 선택한 이유: It fixes the UI regression without delaying tool turns, fabricating token growth, storing prompt/tool content, or repeatedly clearing valid post-compaction usage when historical markers replay; one-time compaction resets still prevent stale over-report when history is replaced.
 - 장점, 단점 및 영향: Active-context reporting stays monotonic within an uncompacted Cursor conversation; no-checkpoint turns remain estimated; a process restart loses the numeric cache and safely falls back to current-turn usage until the next checkpoint.
 ```
 

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -101,6 +101,27 @@ and synthesizing explicit "no tool result was recorded" answers only when no rea
 These compatibility guards are covered by focused tests and should stay close to the adapters that
 need them.
 
+## Cursor active-context usage
+
+Cursor's `conversationCheckpointUpdate.tokenDetails.usedTokens` is treated as the authoritative
+absolute active-context size for a Cursor conversation. Some client-tool suspension turns must end
+before Cursor emits a new checkpoint; those turns carry forward the last observed total for the same
+Cursor conversation instead of reporting only the tiny current-turn output delta. The carry-forward
+cache is process-local, numeric-only, bounded, and keyed by Cursor conversation id. Compaction
+boundaries clear the carry so pre-compaction totals are not reused after Codex replaces history.
+Compaction summarizer turns may still report their own checkpoint for that response, but their
+pre-compaction checkpoint is not persisted for later carry-forward.
+
+```text
+[Decision Log]
+- 목적과 의도: Keep Codex's visible "context left" indicator aligned with Cursor's active-context usage on client-tool turns that finalize before a checkpoint arrives.
+- 기존 구현 및 제약 조건: Checkpoint turns reported totalTokens correctly, but no-checkpoint client-tool finalize fell back to output-only usage and could overwrite a meaningful prior total with values like 109 tokens.
+- 검토한 주요 대안: Add a longer wait for late checkpoints; infer prior+output totals; store full prompt/history state; carry forward only the last numeric checkpoint per Cursor conversation.
+- 선택한 방식: Carry forward the last numeric absolute checkpoint per Cursor conversation with bounded LRU/TTL storage, update it only from live checkpoint frames, and clear/suppress it across compaction boundaries.
+- 다른 대안 대신 이 방식을 선택한 이유: It fixes the UI regression without delaying tool turns, fabricating token growth, or storing prompt/tool content; compaction resets prevent stale over-report when history is replaced.
+- 장점, 단점 및 영향: Active-context reporting stays monotonic within an uncompacted Cursor conversation; no-checkpoint turns remain estimated; a process restart loses the numeric cache and safely falls back to current-turn usage until the next checkpoint.
+```
+
 ## OpenRouter provider routing
 
 The canonical OpenRouter `openai-chat` transport may carry optional provider-routing preferences

--- a/tests/cursor-interaction-query.test.ts
+++ b/tests/cursor-interaction-query.test.ts
@@ -168,6 +168,23 @@ describe("partialUsageFromEventState", () => {
     expect(partialUsageFromEventState(state)).toEqual({ inputTokens: 0, outputTokens: 7, estimated: true });
   });
 
+  test("carries prior context usage on failure when the current turn had no checkpoint", async () => {
+    const { partialUsageFromEventState } = await import("../src/adapters/cursor/live-transport");
+    const { createCursorContextUsageTracker, createCursorProtobufEventState } = await import("../src/adapters/cursor/protobuf-events");
+    const tracker = createCursorContextUsageTracker();
+    tracker.record("cursor_conv_1", 18_000);
+    const state = createCursorProtobufEventState({
+      contextUsage: tracker.controlsForConversation("cursor_conv_1"),
+    });
+    state.usage.outputTokens = 8;
+    expect(partialUsageFromEventState(state)).toEqual({
+      inputTokens: 17_992,
+      outputTokens: 8,
+      totalTokens: 18_000,
+      estimated: true,
+    });
+  });
+
   test("returns undefined when the stream died before any token signal", async () => {
     const { partialUsageFromEventState } = await import("../src/adapters/cursor/live-transport");
     const { createCursorProtobufEventState } = await import("../src/adapters/cursor/protobuf-events");

--- a/tests/cursor-interaction-query.test.ts
+++ b/tests/cursor-interaction-query.test.ts
@@ -190,4 +190,17 @@ describe("partialUsageFromEventState", () => {
     const { createCursorProtobufEventState } = await import("../src/adapters/cursor/protobuf-events");
     expect(partialUsageFromEventState(createCursorProtobufEventState())).toBeUndefined();
   });
+
+  test("does not report seeded carry when a fresh turn failed before any token signal", async () => {
+    const { partialUsageFromEventState } = await import("../src/adapters/cursor/live-transport");
+    const { createCursorContextUsageTracker, createCursorProtobufEventState } = await import("../src/adapters/cursor/protobuf-events");
+    const tracker = createCursorContextUsageTracker();
+    tracker.record("cursor_conv_1", 18_000);
+
+    const state = createCursorProtobufEventState({
+      contextUsage: tracker.controlsForConversation("cursor_conv_1"),
+    });
+
+    expect(partialUsageFromEventState(state)).toBeUndefined();
+  });
 });

--- a/tests/cursor-protobuf-events.test.ts
+++ b/tests/cursor-protobuf-events.test.ts
@@ -13,7 +13,12 @@ import {
   ToolCallSchema,
   ToolCallStartedUpdateSchema,
 } from "../src/adapters/cursor/gen/agent_pb";
-import { createCursorProtobufEventState, mapCursorProtobufServerMessage } from "../src/adapters/cursor/protobuf-events";
+import {
+  createCursorContextUsageTracker,
+  createCursorProtobufEventState,
+  finalizeTurnEvents,
+  mapCursorProtobufServerMessage,
+} from "../src/adapters/cursor/protobuf-events";
 
 const encoder = new TextEncoder();
 
@@ -42,6 +47,25 @@ function mcpToolCall(toolName: string, args: Record<string, string>) {
         }),
       }),
     },
+  });
+}
+
+function checkpointUpdate(usedTokens: number) {
+  return create(AgentServerMessageSchema, {
+    message: {
+      case: "conversationCheckpointUpdate",
+      value: create(ConversationStateStructureSchema, {
+        tokenDetails: create(ConversationTokenDetailsSchema, { usedTokens }),
+      }),
+    },
+  });
+}
+
+function turnEndedFrame() {
+  return create(AgentServerMessageSchema, {
+    message: { case: "interactionUpdate", value: create(InteractionUpdateSchema, {
+      message: { case: "turnEnded", value: {} },
+    }) },
   });
 }
 
@@ -486,6 +510,84 @@ describe("Cursor protobuf tool-call events", () => {
     expect(mapCursorProtobufServerMessage(turnEnd, state)).toEqual([
       { type: "done", usage: { inputTokens: 0, outputTokens: 42, totalTokens: 10, estimated: true } },
     ]);
+  });
+
+  test("ordinary checkpoints update the per-conversation carry-forward for later no-checkpoint turns", () => {
+    const tracker = createCursorContextUsageTracker();
+    const first = createCursorProtobufEventState({
+      contextUsage: tracker.controlsForConversation("cursor_conv_1"),
+    });
+    first.usage.outputTokens = 42;
+
+    expect(mapCursorProtobufServerMessage(checkpointUpdate(10_300), first)).toEqual([]);
+    expect(mapCursorProtobufServerMessage(turnEndedFrame(), first)).toEqual([
+      { type: "done", usage: { inputTokens: 10_258, outputTokens: 42, totalTokens: 10_300, estimated: true } },
+    ]);
+    expect(tracker.get("cursor_conv_1")).toBe(10_300);
+
+    const next = createCursorProtobufEventState({
+      contextUsage: tracker.controlsForConversation("cursor_conv_1"),
+    });
+    next.usage.outputTokens = 7;
+    expect(finalizeTurnEvents(next)).toEqual([
+      { type: "done", usage: { inputTokens: 10_293, outputTokens: 7, totalTokens: 10_300, estimated: true } },
+    ]);
+  });
+
+  test("same-session checkpoints cannot regress below a carried context total", () => {
+    const tracker = createCursorContextUsageTracker();
+    tracker.record("cursor_conv_1", 10_300);
+    const state = createCursorProtobufEventState({
+      contextUsage: tracker.controlsForConversation("cursor_conv_1"),
+    });
+    state.usage.outputTokens = 20;
+
+    expect(mapCursorProtobufServerMessage(checkpointUpdate(9_900), state)).toEqual([]);
+    expect(mapCursorProtobufServerMessage(turnEndedFrame(), state)).toEqual([
+      { type: "done", usage: { inputTokens: 10_280, outputTokens: 20, totalTokens: 10_300, estimated: true } },
+    ]);
+    expect(tracker.get("cursor_conv_1")).toBe(10_300);
+  });
+
+  test("late checkpoint after terminal done is inert and does not seed carry-forward", () => {
+    const tracker = createCursorContextUsageTracker();
+    const state = createCursorProtobufEventState({
+      contextUsage: tracker.controlsForConversation("cursor_conv_1"),
+    });
+    state.usage.outputTokens = 5;
+
+    expect(finalizeTurnEvents(state)).toEqual([
+      { type: "done", usage: { inputTokens: 0, outputTokens: 5, estimated: true } },
+    ]);
+    expect(mapCursorProtobufServerMessage(checkpointUpdate(12_000), state)).toEqual([]);
+    expect(state.contextTokens).toBeUndefined();
+    expect(tracker.get("cursor_conv_1")).toBeUndefined();
+  });
+
+  test("compaction boundary controls clear stale carry and can suppress checkpoint persistence", () => {
+    const tracker = createCursorContextUsageTracker();
+    tracker.record("cursor_conv_1", 80_000);
+
+    const postCompaction = createCursorProtobufEventState({
+      contextUsage: tracker.controlsForConversation("cursor_conv_1", { clearPrior: true }),
+    });
+    postCompaction.usage.outputTokens = 6;
+    expect(finalizeTurnEvents(postCompaction)).toEqual([
+      { type: "done", usage: { inputTokens: 0, outputTokens: 6, estimated: true } },
+    ]);
+    expect(tracker.get("cursor_conv_1")).toBeUndefined();
+
+    const summarizer = createCursorProtobufEventState({
+      contextUsage: tracker.controlsForConversation("cursor_conv_1", {
+        clearPrior: true,
+        storeCheckpoints: false,
+      }),
+    });
+    expect(mapCursorProtobufServerMessage(checkpointUpdate(90_000), summarizer)).toEqual([]);
+    expect(mapCursorProtobufServerMessage(turnEndedFrame(), summarizer)).toEqual([
+      { type: "done", usage: { inputTokens: 90_000, outputTokens: 0, totalTokens: 90_000, estimated: true } },
+    ]);
+    expect(tracker.get("cursor_conv_1")).toBeUndefined();
   });
 });
 

--- a/tests/cursor-request-builder.test.ts
+++ b/tests/cursor-request-builder.test.ts
@@ -38,6 +38,14 @@ describe("Cursor request builder", () => {
     expect(request.conversationId).toBe("cursor_stable");
   });
 
+  test("marks Cursor context-usage boundaries for compaction epochs", () => {
+    expect(createCursorRequest({ ...base, _contextCompactionBoundary: true }).contextUsageReset).toBe(true);
+
+    const compactionRequest = createCursorRequest({ ...base, _compactionRequest: true });
+    expect(compactionRequest.contextUsageReset).toBe(true);
+    expect(compactionRequest.contextUsageStoreCheckpoints).toBe(false);
+  });
+
   test("maps system, developer, user, assistant, and tool result text", () => {
     const request = createCursorRequest({
       ...base,

--- a/tests/cursor-tool-continuation.test.ts
+++ b/tests/cursor-tool-continuation.test.ts
@@ -91,7 +91,7 @@ describe("363-B: tool result reaches the model via rootPromptMessagesJson", () =
 
 import { create as createPb } from "@bufbuild/protobuf";
 import { ExecServerMessageSchema, McpArgsSchema } from "../src/adapters/cursor/gen/agent_pb";
-import { createCursorProtobufEventState } from "../src/adapters/cursor/protobuf-events";
+import { createCursorContextUsageTracker, createCursorProtobufEventState } from "../src/adapters/cursor/protobuf-events";
 import { planMcpArgsHandling, finalizeAfterDrain } from "../src/adapters/cursor/live-transport";
 
 function execMcpArgs(opts: { provider?: string; toolName?: string; toolCallId?: string; args?: Record<string, Uint8Array> }) {
@@ -134,6 +134,20 @@ describe("363-A: turn-1 termination for Responses client tool via exec mcpArgs",
     // When the grace window elapses with the call set still drained, finalize emits exactly one done.
     const finalized = finalizeAfterDrain(state);
     expect(finalized.map(e => e.type)).toEqual(["done"]);
+  });
+
+  test("no-checkpoint client-tool finalize carries forward the last known active context usage", () => {
+    const tracker = createCursorContextUsageTracker();
+    tracker.record("cursor_conv_1", 183_336);
+    const state = createCursorProtobufEventState({
+      clientToolNames: ["mcp__fs__read_file"],
+      contextUsage: tracker.controlsForConversation("cursor_conv_1"),
+    });
+    state.usage.outputTokens = 109;
+
+    expect(finalizeAfterDrain(state)).toEqual([
+      { type: "done", usage: { inputTokens: 183_227, outputTokens: 109, totalTokens: 183_336, estimated: true } },
+    ]);
   });
 
   test("non-Responses mcpArgs is left to native exec (not handled by the bridge)", () => {

--- a/tests/responses-parser.test.ts
+++ b/tests/responses-parser.test.ts
@@ -176,6 +176,7 @@ describe("codex-rs compat surface (260707)", () => {
     expect(first.role).toBe("user");
     expect(first.content as string).toContain(summary);
     expect(parsed._compactionRequest).toBeUndefined();
+    expect(parsed._contextCompactionBoundary).toBe(true);
   });
 
   test("context_compaction without payload is a silent marker (no opaque note)", () => {
@@ -185,6 +186,7 @@ describe("codex-rs compat surface (260707)", () => {
     ]});
     expect(parsed.context.messages).toHaveLength(1);
     expect(parsed.context.messages[0].content).toBe("hello");
+    expect(parsed._contextCompactionBoundary).toBe(true);
   });
 
   test("local_shell_call pairs with its function_call_output", () => {

--- a/tests/responses-state.test.ts
+++ b/tests/responses-state.test.ts
@@ -3,6 +3,8 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildResponseJSON } from "../src/bridge";
+import { createCursorRequest } from "../src/adapters/cursor/request-builder";
+import { createCursorContextUsageTracker } from "../src/adapters/cursor/protobuf-events";
 import { parseRequest } from "../src/responses/parser";
 import {
   clearResponseStateForTests,
@@ -248,5 +250,51 @@ describe("Responses previous_response_id state", () => {
     // continues the SAME Cursor conversation. The Cursor checkpoint is not reusable (the agent turn
     // was suspended without a real mcpResult), but the conversation id string itself is preserved.
     expect(previousResponseConversationId(first.id as string)).toBe("cursor_conversation_1");
+  });
+
+  test("replayed compaction marker preserves post-compaction Cursor usage while a new marker resets it", () => {
+    const conversationId = "cursor_conversation_1";
+    const firstBody = {
+      model: "cursor/auto",
+      input: [
+        { type: "context_compaction" },
+        { type: "message", role: "user", content: "post-compaction turn" },
+      ],
+    };
+    const first = buildResponseJSON([
+      { type: "text_delta", text: "post-compaction answer" },
+      { type: "done" },
+    ], "cursor/auto");
+    rememberResponseState(firstBody, first, conversationId);
+
+    const tracker = createCursorContextUsageTracker();
+    tracker.record(conversationId, 5_000);
+
+    const replayed = parseRequest(expandPreviousResponseInput({
+      model: "cursor/auto",
+      previous_response_id: first.id,
+      input: [{ type: "message", role: "user", content: "next turn" }],
+    }));
+    const replayedRequest = createCursorRequest({ ...replayed, _cursorConversationId: conversationId });
+    expect(replayed._contextCompactionBoundary).toBeUndefined();
+    expect(replayedRequest.contextUsageReset).toBeUndefined();
+    expect(tracker.controlsForConversation(conversationId, {
+      clearPrior: replayedRequest.contextUsageReset === true,
+    }).carryForwardTokens).toBe(5_000);
+
+    const newlyCompacted = parseRequest(expandPreviousResponseInput({
+      model: "cursor/auto",
+      previous_response_id: first.id,
+      input: [
+        { type: "context_compaction" },
+        { type: "message", role: "user", content: "new compacted epoch" },
+      ],
+    }));
+    const newlyCompactedRequest = createCursorRequest({ ...newlyCompacted, _cursorConversationId: conversationId });
+    expect(newlyCompacted._contextCompactionBoundary).toBe(true);
+    expect(newlyCompactedRequest.contextUsageReset).toBe(true);
+    expect(tracker.controlsForConversation(conversationId, {
+      clearPrior: newlyCompactedRequest.contextUsageReset === true,
+    }).carryForwardTokens).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- carry forward the last numeric Cursor conversation checkpoint when a client-tool turn finalizes without a fresh checkpoint
- keep checkpoint reporting monotonic within an uncompacted Cursor conversation, while clearing or suppressing carry-forward across compaction boundaries
- require a current-turn checkpoint or positive finite output before attaching carry-forward to failed-turn partial usage
- acknowledge compaction markers restored by previous_response_id replay so post-compaction carry survives later turns, while genuinely new markers still reset it
- make post-terminal checkpoint frames inert and document the Cursor active-context usage policy

## Review follow-up
- zero-signal first-frame failures now return no partial usage even when the conversation cache is seeded
- previous-response replay tracks a proxy-private input-prefix boundary in a WeakMap, avoiding private fields on the upstream wire and making compaction reset idempotent
- regression coverage proves a 5,000-token post-compaction checkpoint survives historical marker replay and a newly appended marker clears it

Fixes #245.

## Tests
- `bun test tests/cursor-protobuf-events.test.ts tests/cursor-tool-continuation.test.ts tests/cursor-interaction-query.test.ts tests/cursor-request-builder.test.ts tests/responses-parser.test.ts tests/responses-state.test.ts` (91 pass)
- `bun run typecheck`
- `bun run privacy:scan`
- `bun run lint:gui` (initial implementation)
- `git diff --check origin/dev...HEAD`
