### PR TITLE
fix(gui): clarify missing Cursor cache telemetry

### DIFF
--- a/gui/src/i18n/de.ts
+++ b/gui/src/i18n/de.ts
@@ -383,6 +383,8 @@ export const de = {
   "logs.tokens.reasoning": "Reasoning",
   "logs.tokens.noCache": "keine Cache-Daten",
   "logs.tokens.noCacheNote": "dieser Anbieter meldet keine Cache-Tokens",
+  "logs.tokens.noCacheCursor": "Cursor-Cache-Details nicht gemeldet",
+  "logs.tokens.noCacheCursorNote": "Cursor liefert keine Cache-Read/Write-Tokenzahlen; das ist unbekannt und kein bestätigter Cache-Miss",
   "logs.tokens.estimatedNote": "Schätzung (Anbieter meldet keine exakte Nutzung)",
   "logs.details": "Details",
   "logs.detailTitle": "Anfragedetails",

--- a/gui/src/i18n/en.ts
+++ b/gui/src/i18n/en.ts
@@ -400,6 +400,8 @@ export const en = {
   "logs.tokens.reasoning": "reasoning",
   "logs.tokens.noCache": "no cache data",
   "logs.tokens.noCacheNote": "this provider does not report cache tokens",
+  "logs.tokens.noCacheCursor": "Cursor cache detail unreported",
+  "logs.tokens.noCacheCursorNote": "Cursor does not expose cache read/write token counts; this is unknown, not a confirmed cache miss",
   "logs.tokens.estimatedNote": "estimated (provider reports no exact usage)",
   "logs.details": "Details",
   "logs.detailTitle": "Request details",

--- a/gui/src/i18n/ja.ts
+++ b/gui/src/i18n/ja.ts
@@ -365,6 +365,8 @@ export const ja: Record<TKey, string> = {
   "logs.tokens.reasoning": "推論",
   "logs.tokens.noCache": "キャッシュデータなし",
   "logs.tokens.noCacheNote": "このプロバイダーはキャッシュトークンを報告しません",
+  "logs.tokens.noCacheCursor": "Cursor のキャッシュ詳細は未報告",
+  "logs.tokens.noCacheCursorNote": "Cursor はキャッシュ read/write トークン数を公開しません。これは不明という意味で、キャッシュミスの確定ではありません",
   "logs.tokens.estimatedNote": "推定(プロバイダーは正確な使用量を報告しません)",
   "logs.details": "詳細",
   "logs.detailTitle": "リクエストの詳細",

--- a/gui/src/i18n/ko.ts
+++ b/gui/src/i18n/ko.ts
@@ -395,6 +395,8 @@ export const ko: Record<TKey, string> = {
   "logs.tokens.reasoning": "추론",
   "logs.tokens.noCache": "캐시 미보고",
   "logs.tokens.noCacheNote": "이 프로바이더는 캐시 토큰 수치를 제공하지 않습니다",
+  "logs.tokens.noCacheCursor": "Cursor 캐시 상세 미보고",
+  "logs.tokens.noCacheCursorNote": "Cursor 프로토콜은 캐시 read/write 토큰 수치를 제공하지 않습니다. 캐시 미스가 확인됐다는 뜻은 아닙니다",
   "logs.tokens.estimatedNote": "추정치 (프로바이더가 정확한 사용량을 제공하지 않음)",
   "logs.details": "상세보기",
   "logs.detailTitle": "요청 상세",

--- a/gui/src/i18n/ru.ts
+++ b/gui/src/i18n/ru.ts
@@ -400,6 +400,8 @@ export const ru: Record<TKey, string> = {
   "logs.tokens.reasoning": "рассуждения",
   "logs.tokens.noCache": "нет данных кэша",
   "logs.tokens.noCacheNote": "этот провайдер не сообщает данные о кэш-токенах",
+  "logs.tokens.noCacheCursor": "детализация кэша Cursor не сообщается",
+  "logs.tokens.noCacheCursorNote": "Cursor не передает число токенов чтения/записи кэша; это неизвестно, а не подтвержденный промах кэша",
   "logs.tokens.estimatedNote": "оценка (провайдер не сообщает точные данные использования)",
   "logs.details": "Детали",
   "logs.detailTitle": "Детали запроса",

--- a/gui/src/i18n/zh.ts
+++ b/gui/src/i18n/zh.ts
@@ -395,6 +395,8 @@ export const zh: Record<TKey, string> = {
   "logs.tokens.reasoning": "推理",
   "logs.tokens.noCache": "无缓存数据",
   "logs.tokens.noCacheNote": "该提供商不报告缓存 token 数",
+  "logs.tokens.noCacheCursor": "Cursor 未报告缓存明细",
+  "logs.tokens.noCacheCursorNote": "Cursor 不提供缓存读写 token 数；这表示未知，并不代表已确认缓存未命中",
   "logs.tokens.estimatedNote": "估算值（提供商不报告精确用量）",
   "logs.details": "查看详情",
   "logs.detailTitle": "请求详情",

--- a/gui/src/pages/Logs.tsx
+++ b/gui/src/pages/Logs.tsx
@@ -117,6 +117,10 @@ interface LogEntry {
   displayMetrics?: LogDisplayMetrics;
 }
 
+function isCursorUsageProvider(provider: string): boolean {
+  return provider === "cursor" || provider.startsWith("cursor-");
+}
+
 function tokensTitle(log: LogEntry, t: TFn): string | undefined {
   if (!log.usage) return undefined;
   const split = cacheSplit(log);
@@ -129,7 +133,7 @@ function tokensTitle(log: LogEntry, t: TFn): string | undefined {
   if (typeof log.usage.reasoningOutputTokens === "number") parts.push(`${t("logs.tokens.reasoning")}=${log.usage.reasoningOutputTokens}`);
   if (log.usageStatus === "estimated") parts.push(t("logs.tokens.estimatedNote"));
   if (log.usageStatus === "estimated" && split.read === undefined && split.write === undefined) {
-    parts.push(t("logs.tokens.noCacheNote"));
+    parts.push(t(isCursorUsageProvider(log.provider) ? "logs.tokens.noCacheCursorNote" : "logs.tokens.noCacheNote"));
   }
   return parts.join(" \xC2\xB7 ");
 }
@@ -428,7 +432,7 @@ export default function Logs({ apiBase }: { apiBase: string }) {
                               )}
                               {(log.usageStatus === "estimated" && read === undefined && write === undefined) && (
                                 <span className="muted text-caption leading-tight">
-                                  {t("logs.tokens.noCache")}
+                                  {t(isCursorUsageProvider(log.provider) ? "logs.tokens.noCacheCursor" : "logs.tokens.noCache")}
                                 </span>
                               )}
                             </span>


### PR DESCRIPTION
## Summary

- distinguish missing Cursor cache telemetry from a confirmed cache miss
- explain that Cursor does not expose cache read/write token counts on the current protobuf path
- keep the generic wording for other providers
- localize the clarification across every supported GUI locale

## Evidence

`ConversationTokenDetails` exposes only `usedTokens` and `maxTokens`; there is no cache read/write field to map into `OcxUsage`. The safe fix is truthful UI wording rather than fabricated zeroes or estimated cache hits.

## Verification

- `bun run typecheck`
- `bun run lint:gui`
- `bun run build:gui`
- `bun run privacy:scan`
- `git diff --check`

Fixes #275.