### PR TITLE
fix(workflows): remove duplicate labelBasedKind declaration crashing issue quality enforcement

### DIFF
--- a/.github/workflows/enforce-issue-quality.yml
+++ b/.github/workflows/enforce-issue-quality.yml
@@ -264,18 +264,3 @@ jobs:
               "",
               "Once the report passes the automated checks, it will be reopened automatically unless a maintainer has changed its state.",
             ].join("\n"));
-            // If headings were stripped but the form label is still present,
-            // treat the issue as that kind so contributors cannot bypass
-            // validation by editing out headings after submission.
-            const labelBasedKind = (() => {
-              if (labels.includes("bug")) return "bug";
-              if (labels.includes("provider-compatibility")) return "provider-compatibility";
-              if (labels.includes("documentation")) return "documentation";
-              if (labels.includes("enhancement")) return "feature";
-              return null;
-            })();
-            if (!kind && !labelBasedKind) {
-              core.info("Issue is not a structured form; skipping validation.");
-              return;
-            }
-            const resolvedKind = kind ?? labelBasedKind;


### PR DESCRIPTION
## Summary

The `enforce-issue-quality` workflow has been failing with a `SyntaxError` on every issue event since the duplicate block was introduced. This caused **all newly opened issues to bypass quality enforcement entirely** -- the workflow crashed before executing any logic.

## Root Cause

The `labelBasedKind` block was accidentally duplicated at the end of the script, after the closing `upsertComment` call. JavaScript does not allow two `const` declarations with the same identifier in the same scope, so the runner threw immediately:

```
SyntaxError: Identifier 'labelBasedKind' has already been declared
```

This is visible in the workflow run for issue #275 and the prior run for the Chinese-language issue -- both show `conclusion: failure` at the syntax-check stage before any logic runs.

## Fix

Remove the 15 duplicate lines. The first declaration remains in place and is correct.

## Verification

- Only one `const labelBasedKind` declaration remains in the script
- Workflow will now run to completion and enforce quality checks on opened/edited/reopened issues

Fixes the enforcement gap that allowed issue #275 and others to slip through without label validation.
