### PR TITLE
[WRONG BRANCH] feat: add GitHub Copilot App support via OpenAI-compatible chat completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ next Codex session. opencodex keeps these behaviors:
 
 - **Use any LLM with Codex.** 5 protocol adapters cover Anthropic Messages, Google Gemini, Azure, OpenAI Responses passthrough, and every OpenAI-compatible Chat Completions endpoint — that's 40+ providers out of the box.
 - **Use any LLM with Claude Code too.** The same daemon serves the Anthropic Messages API (`/v1/messages` + `count_tokens`): `ocx claude` launches Claude Code fully wired, and routed models appear in its native `/model` picker via gateway model discovery (`claude-ocx-<provider>--<model>` aliases, Claude Code 2.1.129+). Configure slots and model maps on the dashboard's Claude page.
+- **Use any LLM with GitHub Copilot App too.** Point Copilot's Model providers at `http://127.0.0.1:10100/v1` — OpenCodex serves OpenAI-compatible `GET /v1/models` and `POST /v1/chat/completions` so routed models sync into the app. See [docs/github-copilot-app.md](docs/github-copilot-app.md).
 - **Pool ChatGPT accounts safely.** Keep existing Codex threads on one account while new sessions
   can auto-pick a lower-usage account from the pool, with quota refresh and non-PII request labels.
 - **Log in once, skip the API key.** OAuth support for xAI, Anthropic, and Kimi means you can authenticate with your existing account. Tokens auto-refresh. Or forward your `codex login`, paste an API key, or use `${ENV_VAR}` references — your call.

--- a/docs/github-copilot-app.md
+++ b/docs/github-copilot-app.md
@@ -1,0 +1,59 @@
+# GitHub Copilot App
+
+OpenCodex can act as an **OpenAI-compatible model provider** for the GitHub Copilot
+desktop app (Settings → Model providers). This is a client integration: Copilot App
+calls OpenCodex; it is separate from the experimental upstream `github-copilot`
+provider that uses a Copilot subscription as a backend.
+
+## Requirements
+
+1. OpenCodex proxy running locally (`ocx start` / `ocx gui`).
+2. At least one configured provider with models (dashboard → Providers).
+3. GitHub Copilot desktop app with **Model providers** support.
+
+## Setup
+
+1. Start OpenCodex and confirm health:
+
+   ```bash
+   curl http://127.0.0.1:10100/healthz
+   curl http://127.0.0.1:10100/v1/models
+   ```
+
+2. In GitHub Copilot App: **Settings → Model providers → Add provider**.
+
+3. Configure:
+
+   | Field | Value |
+   | --- | --- |
+   | Name | `OpenCodex Gateway` (any label) |
+   | Base URL | `http://127.0.0.1:10100/v1` |
+   | API key | leave blank on loopback; for non-loopback binds use `OPENCODEX_API_AUTH_TOKEN` |
+
+4. Sync models from the endpoint, or add a model by id (`provider/model`, e.g.
+   `anthropic/claude-sonnet-4-6`).
+
+5. Select a synced model and chat.
+
+## Endpoints used
+
+| Method | Path | Role |
+| --- | --- | --- |
+| `GET` | `/v1/models` | Model discovery (OpenAI list shape) |
+| `POST` | `/v1/chat/completions` | Chat turns (stream + non-stream) |
+
+OpenCodex translates Chat Completions into its internal Responses path, so all
+existing providers, routing, OAuth, and sidecars apply.
+
+## Troubleshooting
+
+- **No models configured** — ensure the proxy is up, base URL ends with `/v1`
+  (not `/v1/chat/completions`), and `GET /v1/models` returns a non-empty `data`
+  array. Add/enable providers in the OpenCodex dashboard, then sync again.
+- **401** — remote (non-loopback) binds require an admission token as
+  `Authorization: Bearer …` or `x-opencodex-api-key`.
+- **404 on chat** — older OpenCodex builds lacked `/v1/chat/completions`; upgrade
+  to a build that includes this surface.
+- **Model ids with `/`** — prefer the namespaced `provider/model` form returned
+  by `/v1/models`. If a client rejects slashes, add the model by an alias id you
+  control or open an issue for slash-safe aliases.

--- a/src/chat/inbound.ts
+++ b/src/chat/inbound.ts
@@ -1,0 +1,279 @@
+/**
+ * Chat Completions inbound: OpenAI-compatible request -> internal /v1/responses body.
+ *
+ * Used by GitHub Copilot App (and other OpenAI-compatible clients) via POST /v1/chat/completions.
+ * Same translate-and-replay pattern as Claude Messages: the produced body must pass
+ * responsesRequestSchema so routing/OAuth/pool/sidecars are inherited unchanged.
+ */
+export class ChatCompletionsRequestError extends Error {}
+
+type Rec = Record<string, unknown>;
+
+function isRec(v: unknown): v is Rec {
+  return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
+const OUTPUT_CONFIG_EFFORTS = new Set(["minimal", "low", "medium", "high", "xhigh", "max", "ultra"]);
+
+function contentToText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const raw of content) {
+    if (typeof raw === "string") {
+      parts.push(raw);
+      continue;
+    }
+    if (!isRec(raw)) continue;
+    if ((raw.type === "text" || raw.type === "input_text" || raw.type === "output_text") && typeof raw.text === "string") {
+      parts.push(raw.text);
+    }
+  }
+  return parts.join("\n");
+}
+
+function imageUrlFromPart(part: Rec): string | null {
+  if (part.type !== "image_url") return null;
+  const imageUrl = part.image_url;
+  if (typeof imageUrl === "string" && imageUrl.length > 0) return imageUrl;
+  if (isRec(imageUrl) && typeof imageUrl.url === "string" && imageUrl.url.length > 0) return imageUrl.url;
+  return null;
+}
+
+function userContentToBlocks(content: unknown): Rec[] {
+  if (typeof content === "string") {
+    return content.length > 0 ? [{ type: "input_text", text: content }] : [];
+  }
+  if (!Array.isArray(content)) return [];
+  const blocks: Rec[] = [];
+  for (const raw of content) {
+    if (typeof raw === "string") {
+      if (raw.length > 0) blocks.push({ type: "input_text", text: raw });
+      continue;
+    }
+    if (!isRec(raw)) continue;
+    if ((raw.type === "text" || raw.type === "input_text") && typeof raw.text === "string") {
+      blocks.push({ type: "input_text", text: raw.text });
+      continue;
+    }
+    const imageUrl = imageUrlFromPart(raw);
+    if (imageUrl) blocks.push({ type: "input_image", image_url: imageUrl });
+  }
+  return blocks;
+}
+
+function assistantContentToBlocks(content: unknown): Rec[] {
+  if (typeof content === "string") {
+    return content.length > 0 ? [{ type: "output_text", text: content }] : [];
+  }
+  if (!Array.isArray(content)) return [];
+  const blocks: Rec[] = [];
+  for (const raw of content) {
+    if (typeof raw === "string") {
+      if (raw.length > 0) blocks.push({ type: "output_text", text: raw });
+      continue;
+    }
+    if (!isRec(raw)) continue;
+    if ((raw.type === "text" || raw.type === "output_text") && typeof raw.text === "string") {
+      blocks.push({ type: "output_text", text: raw.text });
+    }
+  }
+  return blocks;
+}
+
+function pushSystemText(parts: string[], content: unknown): void {
+  const text = contentToText(content).trim();
+  if (text) parts.push(text);
+}
+
+function toolCallsToItems(toolCalls: unknown, input: Rec[]): void {
+  if (!Array.isArray(toolCalls)) return;
+  for (const raw of toolCalls) {
+    if (!isRec(raw)) continue;
+    const fn = isRec(raw.function) ? raw.function : null;
+    const name = typeof fn?.name === "string" ? fn.name : typeof raw.name === "string" ? raw.name : "";
+    const args = typeof fn?.arguments === "string"
+      ? fn.arguments
+      : typeof raw.arguments === "string"
+        ? raw.arguments
+        : JSON.stringify(fn?.arguments ?? raw.arguments ?? {});
+    const callId = typeof raw.id === "string" && raw.id.length > 0
+      ? raw.id
+      : typeof raw.call_id === "string" && raw.call_id.length > 0
+        ? raw.call_id
+        : `call_${crypto.randomUUID().replace(/-/g, "").slice(0, 24)}`;
+    if (!name) throw new ChatCompletionsRequestError("tool_calls entries require function.name");
+    input.push({ type: "function_call", call_id: callId, name, arguments: args });
+  }
+}
+
+function toolsToResponses(tools: unknown): Rec[] | undefined {
+  if (!Array.isArray(tools) || tools.length === 0) return undefined;
+  const out: Rec[] = [];
+  for (const raw of tools) {
+    if (!isRec(raw)) continue;
+    if (raw.type === "function" && typeof raw.name === "string" && raw.name.length > 0) {
+      out.push({
+        type: "function",
+        name: raw.name,
+        ...(typeof raw.description === "string" ? { description: raw.description } : {}),
+        ...(isRec(raw.parameters) ? { parameters: raw.parameters } : {}),
+        ...(typeof raw.strict === "boolean" ? { strict: raw.strict } : {}),
+      });
+      continue;
+    }
+    if (raw.type === "function" && isRec(raw.function) && typeof raw.function.name === "string" && raw.function.name.length > 0) {
+      out.push({
+        type: "function",
+        name: raw.function.name,
+        ...(typeof raw.function.description === "string" ? { description: raw.function.description } : {}),
+        ...(isRec(raw.function.parameters) ? { parameters: raw.function.parameters } : {}),
+        ...(typeof raw.function.strict === "boolean" ? { strict: raw.function.strict } : {}),
+      });
+      continue;
+    }
+    if (raw.type === "web_search" || raw.type === "web_search_preview") {
+      out.push({ type: "web_search" });
+    }
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function toolChoiceToResponses(choice: unknown, body: Rec): void {
+  if (choice === undefined || choice === null) return;
+  if (choice === "auto" || choice === "none" || choice === "required") {
+    body.tool_choice = choice;
+    return;
+  }
+  if (!isRec(choice)) return;
+  if (choice.type === "function") {
+    const name = typeof choice.name === "string"
+      ? choice.name
+      : isRec(choice.function) && typeof choice.function.name === "string"
+        ? choice.function.name
+        : "";
+    if (!name) throw new ChatCompletionsRequestError("tool_choice.function requires a name");
+    body.tool_choice = { type: "function", name };
+    return;
+  }
+  if (isRec(choice.function) && typeof choice.function.name === "string") {
+    body.tool_choice = { type: "function", name: choice.function.name };
+  }
+}
+
+function responseFormatToText(format: unknown): Rec | undefined {
+  if (!isRec(format)) return undefined;
+  if (format.type === "json_object") return { format: { type: "json_object" } };
+  if (format.type === "json_schema" && isRec(format.json_schema)) {
+    const schema = format.json_schema;
+    return {
+      format: {
+        type: "json_schema",
+        name: typeof schema.name === "string" ? schema.name : "response",
+        ...(typeof schema.description === "string" ? { description: schema.description } : {}),
+        ...(schema.schema !== undefined ? { schema: schema.schema } : {}),
+        ...(typeof schema.strict === "boolean" ? { strict: schema.strict } : {}),
+      },
+    };
+  }
+  return undefined;
+}
+
+function resolveReasoningEffort(raw: Rec): string | undefined {
+  if (typeof raw.reasoning_effort === "string" && OUTPUT_CONFIG_EFFORTS.has(raw.reasoning_effort)) {
+    return raw.reasoning_effort;
+  }
+  if (isRec(raw.reasoning) && typeof raw.reasoning.effort === "string" && OUTPUT_CONFIG_EFFORTS.has(raw.reasoning.effort)) {
+    return raw.reasoning.effort;
+  }
+  return undefined;
+}
+
+/**
+ * Translate an OpenAI Chat Completions request body into a /v1/responses request body.
+ * Throws ChatCompletionsRequestError (-> 400) on malformed input.
+ */
+export function chatCompletionsToResponsesBody(raw: unknown): Rec {
+  if (!isRec(raw)) throw new ChatCompletionsRequestError("request body must be a JSON object");
+  if (typeof raw.model !== "string" || raw.model.length === 0) {
+    throw new ChatCompletionsRequestError("model is required");
+  }
+  if (!Array.isArray(raw.messages) || raw.messages.length === 0) {
+    throw new ChatCompletionsRequestError("messages must be a non-empty array");
+  }
+
+  const systemParts: string[] = [];
+  const input: Rec[] = [];
+
+  for (const msg of raw.messages) {
+    if (!isRec(msg)) continue;
+    const role = typeof msg.role === "string" ? msg.role : "";
+    switch (role) {
+      case "system":
+      case "developer":
+        pushSystemText(systemParts, msg.content);
+        break;
+      case "user": {
+        const blocks = userContentToBlocks(msg.content);
+        if (blocks.length > 0) input.push({ type: "message", role: "user", content: blocks });
+        break;
+      }
+      case "assistant": {
+        const blocks = assistantContentToBlocks(msg.content);
+        if (blocks.length > 0) input.push({ type: "message", role: "assistant", content: blocks });
+        if (msg.tool_calls !== undefined) toolCallsToItems(msg.tool_calls, input);
+        break;
+      }
+      case "tool": {
+        const callId = typeof msg.tool_call_id === "string" ? msg.tool_call_id
+          : typeof msg.tool_use_id === "string" ? msg.tool_use_id
+          : "";
+        if (!callId) throw new ChatCompletionsRequestError("tool messages require tool_call_id");
+        const output = typeof msg.content === "string" ? msg.content : contentToText(msg.content);
+        input.push({ type: "function_call_output", call_id: callId, output });
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  if (input.length === 0 && systemParts.length === 0) {
+    throw new ChatCompletionsRequestError("messages must include at least one user/assistant/tool turn");
+  }
+
+  const body: Rec = {
+    model: raw.model,
+    input,
+    stream: raw.stream === true,
+    store: false,
+  };
+
+  if (systemParts.length > 0) body.instructions = systemParts.join("\n\n");
+
+  const tools = toolsToResponses(raw.tools);
+  if (tools) body.tools = tools;
+  toolChoiceToResponses(raw.tool_choice, body);
+
+  const maxTokens = typeof raw.max_completion_tokens === "number"
+    ? raw.max_completion_tokens
+    : typeof raw.max_tokens === "number"
+      ? raw.max_tokens
+      : undefined;
+  if (typeof maxTokens === "number") body.max_output_tokens = maxTokens;
+  if (typeof raw.temperature === "number") body.temperature = raw.temperature;
+  if (typeof raw.top_p === "number") body.top_p = raw.top_p;
+  if (raw.stop !== undefined) body.stop = raw.stop;
+  if (typeof raw.user === "string") body.user = raw.user;
+  if (typeof raw.parallel_tool_calls === "boolean") body.parallel_tool_calls = raw.parallel_tool_calls;
+  if (typeof raw.prompt_cache_key === "string") body.prompt_cache_key = raw.prompt_cache_key;
+  if (raw.metadata !== undefined) body.metadata = raw.metadata;
+
+  const effort = resolveReasoningEffort(raw);
+  if (effort) body.reasoning = { effort };
+
+  const text = responseFormatToText(raw.response_format);
+  if (text) body.text = text;
+
+  return body;
+}

--- a/src/chat/outbound.ts
+++ b/src/chat/outbound.ts
@@ -1,0 +1,473 @@
+/**
+ * Chat Completions outbound: internal /v1/responses output -> OpenAI Chat Completions shapes.
+ *
+ * Wire contract for GitHub Copilot App / OpenAI-compatible clients:
+ *  - Streaming: `data: {choices:[{delta:...}]}` frames ending with `data: [DONE]`
+ *  - Non-streaming: `{ id, object:"chat.completion", choices:[{message}], usage }`
+ */
+type Rec = Record<string, unknown>;
+
+function isRec(v: unknown): v is Rec {
+  return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
+function uuid(): string {
+  return crypto.randomUUID().replace(/-/g, "");
+}
+
+function completionId(): string {
+  return `chatcmpl-${uuid().slice(0, 24)}`;
+}
+
+/** Responses usage (inclusive input_tokens) -> Chat Completions usage. */
+export function chatCompletionsUsage(usage: unknown): Rec {
+  const u = isRec(usage) ? usage : {};
+  const details = isRec(u.input_tokens_details) ? u.input_tokens_details : {};
+  const prompt = typeof u.input_tokens === "number" ? u.input_tokens : 0;
+  const completion = typeof u.output_tokens === "number" ? u.output_tokens : 0;
+  const cached = typeof details.cached_tokens === "number" ? details.cached_tokens : undefined;
+  const out: Rec = {
+    prompt_tokens: prompt,
+    completion_tokens: completion,
+    total_tokens: prompt + completion,
+  };
+  if (cached !== undefined) {
+    out.prompt_tokens_details = { cached_tokens: cached };
+  }
+  const outDetails = isRec(u.output_tokens_details) ? u.output_tokens_details : {};
+  if (typeof outDetails.reasoning_tokens === "number") {
+    out.completion_tokens_details = { reasoning_tokens: outDetails.reasoning_tokens };
+  }
+  return out;
+}
+
+export function chatCompletionsErrorBody(status: number, message: string, type = "invalid_request_error"): Rec {
+  return {
+    error: {
+      message,
+      type,
+      param: null,
+      code: status === 401 ? "invalid_api_key"
+        : status === 404 ? "model_not_found"
+        : status === 429 ? "rate_limit_exceeded"
+        : null,
+    },
+  };
+}
+
+export function chatCompletionsErrorResponse(status: number, message: string, type?: string): Response {
+  return new Response(JSON.stringify(chatCompletionsErrorBody(status, message, type)), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function dataFrame(payload: Rec | "[DONE]"): string {
+  if (payload === "[DONE]") return "data: [DONE]\n\n";
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+function chunkBase(id: string, model: string, created: number): Rec {
+  return {
+    id,
+    object: "chat.completion.chunk",
+    created,
+    model,
+    choices: [],
+  };
+}
+
+/**
+ * Streaming: Responses SSE bytes -> Chat Completions SSE bytes.
+ */
+export function responsesSseToChatCompletionsSse(
+  upstream: ReadableStream<Uint8Array>,
+  model: string,
+): ReadableStream<Uint8Array> {
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let buffer = "";
+  let terminated = false;
+  let cancelled = false;
+  let started = false;
+  let sawToolUse = false;
+  const id = completionId();
+  const created = Math.floor(Date.now() / 1000);
+  // tool call_id -> streaming index (OpenAI requires stable indices per tool call)
+  const toolIndexByCallId = new Map<string, number>();
+  let nextToolIndex = 0;
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      const emit = (payload: Rec | "[DONE]") => controller.enqueue(encoder.encode(dataFrame(payload)));
+      const ensureRole = () => {
+        if (started) return;
+        started = true;
+        const frame = chunkBase(id, model, created);
+        frame.choices = [{ index: 0, delta: { role: "assistant", content: "" }, finish_reason: null }];
+        emit(frame);
+      };
+      const emitContent = (text: string) => {
+        if (!text) return;
+        ensureRole();
+        const frame = chunkBase(id, model, created);
+        frame.choices = [{ index: 0, delta: { content: text }, finish_reason: null }];
+        emit(frame);
+      };
+      const emitReasoning = (text: string) => {
+        if (!text) return;
+        ensureRole();
+        // Many OpenAI-compatible clients accept reasoning_content; harmless if ignored.
+        const frame = chunkBase(id, model, created);
+        frame.choices = [{ index: 0, delta: { reasoning_content: text }, finish_reason: null }];
+        emit(frame);
+      };
+      const finish = (finishReason: string, usage: unknown) => {
+        if (terminated) return;
+        terminated = true;
+        ensureRole();
+        const frame = chunkBase(id, model, created);
+        frame.choices = [{ index: 0, delta: {}, finish_reason: finishReason }];
+        if (usage) frame.usage = chatCompletionsUsage(usage);
+        emit(frame);
+        emit("[DONE]");
+      };
+      const fail = (message: string) => {
+        if (terminated) return;
+        terminated = true;
+        ensureRole();
+        // Mid-stream error as a final frame with finish_reason stop, then DONE.
+        // Clients that only parse deltas still terminate cleanly.
+        const frame = chunkBase(id, model, created);
+        frame.choices = [{ index: 0, delta: { content: `\n\n[error] ${message}` }, finish_reason: "stop" }];
+        emit(frame);
+        emit("[DONE]");
+      };
+
+      const handleFrame = (eventName: string, data: Rec) => {
+        switch (eventName) {
+          case "response.created":
+          case "response.heartbeat":
+            ensureRole();
+            break;
+          case "response.output_text.delta": {
+            if (typeof data.delta === "string") emitContent(data.delta);
+            break;
+          }
+          case "response.reasoning_summary_text.delta":
+          case "response.reasoning_text.delta": {
+            if (typeof data.delta === "string") emitReasoning(data.delta);
+            break;
+          }
+          case "response.output_item.added": {
+            const item = isRec(data.item) ? data.item : null;
+            if (!item || item.type !== "function_call") break;
+            ensureRole();
+            sawToolUse = true;
+            const callId = typeof item.call_id === "string" ? item.call_id : `call_${uuid().slice(0, 16)}`;
+            const name = typeof item.name === "string" ? item.name : "";
+            let toolIndex = toolIndexByCallId.get(callId);
+            if (toolIndex === undefined) {
+              toolIndex = nextToolIndex++;
+              toolIndexByCallId.set(callId, toolIndex);
+            }
+            const frame = chunkBase(id, model, created);
+            frame.choices = [{
+              index: 0,
+              delta: {
+                tool_calls: [{
+                  index: toolIndex,
+                  id: callId,
+                  type: "function",
+                  function: { name, arguments: "" },
+                }],
+              },
+              finish_reason: null,
+            }];
+            emit(frame);
+            break;
+          }
+          case "response.function_call_arguments.delta": {
+            if (typeof data.delta !== "string" || data.delta.length === 0) break;
+            // Prefer item_id matching when present; otherwise use the last open tool index.
+            let toolIndex = nextToolIndex > 0 ? nextToolIndex - 1 : 0;
+            const itemId = typeof data.item_id === "string" ? data.item_id : undefined;
+            if (itemId) {
+              // Some bridges put call_id on the item, not item_id; keep last index.
+            }
+            ensureRole();
+            const frame = chunkBase(id, model, created);
+            frame.choices = [{
+              index: 0,
+              delta: {
+                tool_calls: [{
+                  index: toolIndex,
+                  function: { arguments: data.delta },
+                }],
+              },
+              finish_reason: null,
+            }];
+            emit(frame);
+            break;
+          }
+          case "response.output_item.done": {
+            const item = isRec(data.item) ? data.item : null;
+            if (!item) break;
+            if (item.type === "function_call") {
+              sawToolUse = true;
+              const callId = typeof item.call_id === "string" ? item.call_id : "";
+              const name = typeof item.name === "string" ? item.name : "";
+              const args = typeof item.arguments === "string" ? item.arguments : "";
+              if (!callId) break;
+              let toolIndex = toolIndexByCallId.get(callId);
+              if (toolIndex === undefined) {
+                // No prior added event — emit a complete tool call chunk.
+                toolIndex = nextToolIndex++;
+                toolIndexByCallId.set(callId, toolIndex);
+                ensureRole();
+                const frame = chunkBase(id, model, created);
+                frame.choices = [{
+                  index: 0,
+                  delta: {
+                    tool_calls: [{
+                      index: toolIndex,
+                      id: callId,
+                      type: "function",
+                      function: { name, arguments: args },
+                    }],
+                  },
+                  finish_reason: null,
+                }];
+                emit(frame);
+              }
+            }
+            break;
+          }
+          case "response.completed": {
+            const response = isRec(data.response) ? data.response : {};
+            finish(sawToolUse ? "tool_calls" : "stop", response.usage);
+            break;
+          }
+          case "response.incomplete": {
+            const response = isRec(data.response) ? data.response : {};
+            const details = isRec(response.incomplete_details) ? response.incomplete_details : {};
+            const reason = details.reason === "max_output_tokens" ? "length"
+              : details.reason === "content_filter" ? "content_filter"
+              : sawToolUse ? "tool_calls" : "stop";
+            finish(reason, response.usage);
+            break;
+          }
+          case "response.failed": {
+            const response = isRec(data.response) ? data.response : {};
+            const error = isRec(response.error) ? response.error : {};
+            const message = typeof error.message === "string" ? error.message : "upstream request failed";
+            fail(message);
+            break;
+          }
+          default:
+            break;
+        }
+      };
+
+      reader = upstream.getReader();
+      void (async () => {
+        try {
+          for (;;) {
+            const { done, value } = await reader!.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            let sep: number;
+            while ((sep = buffer.indexOf("\n\n")) !== -1) {
+              const rawFrame = buffer.slice(0, sep);
+              buffer = buffer.slice(sep + 2);
+              let eventName = "";
+              let dataLine = "";
+              for (const line of rawFrame.split("\n")) {
+                if (line.startsWith("event: ")) eventName = line.slice(7).trim();
+                else if (line.startsWith("data: ")) dataLine += line.slice(6);
+              }
+              if (!eventName || !dataLine) continue;
+              let data: unknown;
+              try { data = JSON.parse(dataLine); } catch { continue; }
+              if (!isRec(data)) continue;
+              if (terminated) continue;
+              handleFrame(eventName, data);
+            }
+          }
+          if (!cancelled && !terminated) {
+            fail("upstream stream ended before a terminal frame (truncated response)");
+          }
+        } catch (err) {
+          fail(err instanceof Error ? err.message : String(err));
+        } finally {
+          reader?.releaseLock();
+          if (!cancelled) {
+            try { controller.close(); } catch { /* already closed */ }
+          }
+        }
+      })();
+    },
+    cancel(reason) {
+      cancelled = true;
+      return reader?.cancel(reason);
+    },
+  });
+}
+
+/** Non-streaming: /v1/responses JSON -> Chat Completions message JSON. */
+export function responsesJsonToChatCompletion(json: unknown, model: string): Rec {
+  const body = isRec(json) ? json : {};
+  const output = Array.isArray(body.output) ? body.output : [];
+  let content = "";
+  let reasoning = "";
+  const toolCalls: Rec[] = [];
+
+  for (const raw of output) {
+    if (!isRec(raw)) continue;
+    if (raw.type === "message" && Array.isArray(raw.content)) {
+      for (const part of raw.content) {
+        if (isRec(part) && part.type === "output_text" && typeof part.text === "string") {
+          content += part.text;
+        }
+      }
+    } else if (raw.type === "reasoning") {
+      if (Array.isArray(raw.summary)) {
+        for (const part of raw.summary) {
+          if (isRec(part) && part.type === "summary_text" && typeof part.text === "string") {
+            reasoning += part.text;
+          }
+        }
+      }
+      if (Array.isArray(raw.content)) {
+        for (const part of raw.content) {
+          if (isRec(part) && part.type === "reasoning_text" && typeof part.text === "string") {
+            reasoning += part.text;
+          }
+        }
+      }
+    } else if (raw.type === "function_call") {
+      toolCalls.push({
+        id: typeof raw.call_id === "string" ? raw.call_id : `call_${uuid().slice(0, 16)}`,
+        type: "function",
+        function: {
+          name: typeof raw.name === "string" ? raw.name : "",
+          arguments: typeof raw.arguments === "string" ? raw.arguments : "{}",
+        },
+      });
+    }
+  }
+
+  const finishReason = toolCalls.length > 0 ? "tool_calls"
+    : body.status === "incomplete" ? "length"
+    : "stop";
+
+  const message: Rec = {
+    role: "assistant",
+    content: content || null,
+  };
+  if (reasoning) message.reasoning_content = reasoning;
+  if (toolCalls.length > 0) message.tool_calls = toolCalls;
+
+  return {
+    id: completionId(),
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [{
+      index: 0,
+      message,
+      finish_reason: finishReason,
+      logprobs: null,
+    }],
+    usage: chatCompletionsUsage(body.usage),
+  };
+}
+
+/** Fold a Chat Completions SSE stream into a final completion JSON. */
+export async function collectChatCompletion(
+  stream: ReadableStream<Uint8Array>,
+  model: string,
+): Promise<Rec> {
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let content = "";
+  let reasoning = "";
+  const toolCalls = new Map<number, { id: string; name: string; arguments: string }>();
+  let finishReason = "stop";
+  let usage: unknown;
+  const reader = stream.getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let sep: number;
+      while ((sep = buffer.indexOf("\n\n")) !== -1) {
+        const rawFrame = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+        for (const line of rawFrame.split("\n")) {
+          if (!line.startsWith("data: ")) continue;
+          const data = line.slice(6).trim();
+          if (!data || data === "[DONE]") continue;
+          let parsed: unknown;
+          try { parsed = JSON.parse(data); } catch { continue; }
+          if (!isRec(parsed)) continue;
+          if (parsed.usage) usage = parsed.usage;
+          const choices = Array.isArray(parsed.choices) ? parsed.choices : [];
+          const choice = isRec(choices[0]) ? choices[0] : null;
+          if (!choice) continue;
+          if (typeof choice.finish_reason === "string") finishReason = choice.finish_reason;
+          const delta = isRec(choice.delta) ? choice.delta : null;
+          if (!delta) continue;
+          if (typeof delta.content === "string") content += delta.content;
+          if (typeof delta.reasoning_content === "string") reasoning += delta.reasoning_content;
+          if (Array.isArray(delta.tool_calls)) {
+            for (const tc of delta.tool_calls) {
+              if (!isRec(tc)) continue;
+              const index = typeof tc.index === "number" ? tc.index : 0;
+              const current = toolCalls.get(index) ?? { id: "", name: "", arguments: "" };
+              if (typeof tc.id === "string") current.id = tc.id;
+              const fn = isRec(tc.function) ? tc.function : {};
+              if (typeof fn.name === "string") current.name += fn.name;
+              if (typeof fn.arguments === "string") current.arguments += fn.arguments;
+              toolCalls.set(index, current);
+            }
+          }
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const message: Rec = {
+    role: "assistant",
+    content: content || null,
+  };
+  if (reasoning) message.reasoning_content = reasoning;
+  if (toolCalls.size > 0) {
+    message.tool_calls = [...toolCalls.entries()]
+      .sort((a, b) => a[0] - b[0])
+      .map(([, tc]) => ({
+        id: tc.id || `call_${uuid().slice(0, 16)}`,
+        type: "function",
+        function: { name: tc.name, arguments: tc.arguments },
+      }));
+    if (finishReason === "stop") finishReason = "tool_calls";
+  }
+
+  return {
+    id: completionId(),
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [{
+      index: 0,
+      message,
+      finish_reason: finishReason,
+      logprobs: null,
+    }],
+    usage: usage && isRec(usage) ? usage : chatCompletionsUsage(undefined),
+  };
+}

--- a/src/server/chat-completions.ts
+++ b/src/server/chat-completions.ts
@@ -1,0 +1,226 @@
+/**
+ * OpenAI Chat Completions inbound (/v1/chat/completions) for GitHub Copilot App
+ * and other OpenAI-compatible clients.
+ *
+ * Translate-and-replay: Chat Completions body -> /v1/responses via handleResponses,
+ * then bridge the Responses output back to Chat Completions SSE/JSON.
+ */
+import { FORWARD_HEADERS } from "../adapters/openai-responses";
+import { ChatCompletionsRequestError, chatCompletionsToResponsesBody } from "../chat/inbound";
+import {
+  chatCompletionsErrorResponse,
+  collectChatCompletion,
+  responsesJsonToChatCompletion,
+  responsesSseToChatCompletionsSse,
+} from "../chat/outbound";
+import { estimateTokens } from "../lib/token-estimate";
+import { routeModel } from "../router";
+import type { OcxConfig } from "../types";
+import { readJsonRequestBody } from "./request-decompress";
+import { addFinalRequestLog, type RequestLogContext } from "./request-log";
+import { responseWithDeferredRequestLog } from "./relay";
+import { handleResponses } from "./responses";
+
+type Rec = Record<string, unknown>;
+
+function isRec(v: unknown): v is Rec {
+  return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
+async function readChatBody(req: Request): Promise<unknown> {
+  try {
+    return await readJsonRequestBody(req);
+  } catch (err) {
+    throw new ChatCompletionsRequestError(err instanceof Error && err.message ? err.message : "Invalid JSON body");
+  }
+}
+
+export async function handleChatCompletions(
+  req: Request,
+  config: OcxConfig,
+  logCtx: RequestLogContext,
+  logIds?: { requestId: string; start: number },
+): Promise<Response> {
+  let chatBody: unknown;
+  let internalBody: Rec;
+  try {
+    chatBody = await readChatBody(req);
+    internalBody = chatCompletionsToResponsesBody(chatBody);
+  } catch (err) {
+    const status = err instanceof ChatCompletionsRequestError ? 400 : 500;
+    if (logIds) addFinalRequestLog(logIds.requestId, logIds.start, logCtx, status, { closeReason: "non_stream" });
+    return chatCompletionsErrorResponse(status, err instanceof Error ? err.message : String(err));
+  }
+
+  const requestedModel = (chatBody as Rec).model as string;
+  const stream = internalBody.stream === true;
+  // Routed adapters only support streamed turns; always stream internally and fold
+  // for non-streaming clients.
+  internalBody.stream = true;
+
+  let _nativeRoute = false;
+  try {
+    const route = routeModel(config, internalBody.model as string);
+    logCtx.model = route.modelId;
+    logCtx.providerAdapter = route.provider.adapter;
+    logCtx.requestedModel = requestedModel;
+    logCtx.provider = route.providerName;
+    if (route.provider.adapter === "openai-responses") {
+      _nativeRoute = true;
+      // ChatGPT backend rejects store:true and unsupported sampling knobs.
+      internalBody.store = false;
+      delete internalBody.max_output_tokens;
+      delete internalBody.temperature;
+      delete internalBody.top_p;
+      delete internalBody.stop;
+      delete internalBody.user;
+    } else if (internalBody.store === undefined) {
+      internalBody.store = false;
+    }
+    if (route.provider.adapter === "cursor" || route.provider.adapter === "kiro") {
+      const raw = chatBody as Rec;
+      const parts: string[] = [];
+      if (raw.messages !== undefined) parts.push(JSON.stringify(raw.messages));
+      if (raw.tools !== undefined) parts.push(JSON.stringify(raw.tools));
+      logCtx.usageLogInputTokens = Math.max(1, estimateTokens(parts.join("\n"), requestedModel));
+    }
+    if (internalBody.reasoning !== undefined) {
+      const { supportedLadderFor } = await import("./effort-policy");
+      const ladder = supportedLadderFor({ provider: route.provider, modelId: route.modelId });
+      if (ladder !== undefined && ladder.length === 0) delete internalBody.reasoning;
+    }
+  } catch {
+    /* unknown model: let handleResponses shape the 404 */
+  }
+  void _nativeRoute;
+
+  const headers = new Headers({ "content-type": "application/json" });
+  for (const name of FORWARD_HEADERS) {
+    if (name === "authorization") continue;
+    const value = req.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+  // Prefer main ChatGPT auth so OpenAI-backed sidecars remain reachable on routed turns.
+  try {
+    const { getMainAccountToken } = await import("../codex/main-account");
+    const token = getMainAccountToken();
+    if (token) {
+      headers.set("authorization", `Bearer ${token.accessToken}`);
+      headers.set("chatgpt-account-id", token.chatgptAccountId);
+    }
+  } catch {
+    /* optional */
+  }
+
+  const internalReq = new Request("http://localhost/v1/responses", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(internalBody),
+  });
+
+  const upstream = await handleResponses(internalReq, config, logCtx, {
+    abortSignal: req.signal,
+  });
+  const response = logIds
+    ? responseWithDeferredRequestLog(upstream, logIds.requestId, logIds.start, logCtx)
+    : upstream;
+
+  if (!response.ok) {
+    let message = `upstream error (${response.status})`;
+    try {
+      const text = await response.text();
+      try {
+        const parsed = JSON.parse(text) as { error?: { message?: string; type?: string } | string; message?: string };
+        const nested = typeof parsed?.error === "object" && parsed.error ? parsed.error.message : undefined;
+        const flat = typeof parsed?.error === "string" ? parsed.error : parsed?.message;
+        message = nested || flat || (text ? `upstream error (${response.status}): ${text.slice(0, 400)}` : message);
+      } catch {
+        if (text) message = `upstream error (${response.status}): ${text.slice(0, 400)}`;
+      }
+    } catch { /* keep fallback */ }
+    const retryAfter = response.headers.get("retry-after");
+    return new Response(JSON.stringify({
+      error: {
+        message,
+        type: response.status === 401 ? "authentication_error"
+          : response.status === 429 ? "rate_limit_error"
+          : response.status >= 500 ? "server_error"
+          : "invalid_request_error",
+        param: null,
+        code: null,
+      },
+    }), {
+      status: response.status,
+      headers: {
+        "Content-Type": "application/json",
+        ...(retryAfter ? { "Retry-After": retryAfter } : {}),
+      },
+    });
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("text/event-stream") && response.body) {
+    const chatSse = responsesSseToChatCompletionsSse(response.body, requestedModel);
+    if (stream) {
+      return new Response(chatSse, {
+        status: 200,
+        headers: {
+          "Content-Type": "text/event-stream; charset=utf-8",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        },
+      });
+    }
+    const completion = await collectChatCompletion(chatSse, requestedModel);
+    return new Response(JSON.stringify(completion), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // Defensive: JSON despite stream:true.
+  let json: unknown;
+  try {
+    json = await response.json();
+  } catch {
+    return chatCompletionsErrorResponse(502, "internal replay returned a non-JSON response", "server_error");
+  }
+  const status = (json as Rec)?.status;
+  if (status === "failed") {
+    const error = (json as { error?: { message?: string } }).error;
+    return chatCompletionsErrorResponse(502, error?.message ?? "upstream request failed", "server_error");
+  }
+  const completion = responsesJsonToChatCompletion(json, requestedModel);
+  if (!stream) {
+    return new Response(JSON.stringify(completion), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // Streaming client + JSON upstream: synthesize a minimal Chat Completions stream.
+  const encoder = new TextEncoder();
+  const id = typeof completion.id === "string" ? completion.id : `chatcmpl-${Date.now()}`;
+  const created = typeof completion.created === "number" ? completion.created : Math.floor(Date.now() / 1000);
+  const message = isRec((completion.choices as Rec[] | undefined)?.[0])
+    ? ((completion.choices as Rec[])[0] as Rec).message as Rec | undefined
+    : undefined;
+  const content = message && typeof message.content === "string" ? message.content : "";
+  const frames = [
+    `data: ${JSON.stringify({ id, object: "chat.completion.chunk", created, model: requestedModel, choices: [{ index: 0, delta: { role: "assistant", content: "" }, finish_reason: null }] })}\n\n`,
+    ...(content
+      ? [`data: ${JSON.stringify({ id, object: "chat.completion.chunk", created, model: requestedModel, choices: [{ index: 0, delta: { content }, finish_reason: null }] })}\n\n`]
+      : []),
+    `data: ${JSON.stringify({ id, object: "chat.completion.chunk", created, model: requestedModel, choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: completion.usage })}\n\n`,
+    "data: [DONE]\n\n",
+  ];
+  return new Response(encoder.encode(frames.join("")), {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache",
+    },
+  });
+}
+
+

--- a/src/server/gui-static.ts
+++ b/src/server/gui-static.ts
@@ -92,6 +92,7 @@ export function rootFallbackPayload() {
       health: "/healthz",
       models: "/v1/models",
       responses: "/v1/responses",
+      chatCompletions: "/v1/chat/completions",
       management: "/api/*",
     },
   };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -117,6 +117,7 @@ export {
 import { disableResponsesRequestTimeout, handleResponses, handleResponsesCompact } from "./responses";
 export { disableResponsesRequestTimeout, linkAbortSignal } from "./responses";
 import { handleClaudeCountTokens, handleClaudeMessages } from "./claude-messages";
+import { handleChatCompletions } from "./chat-completions";
 import { anthropicErrorResponse } from "../claude/outbound";
 import { buildDesktop3pRegistry } from "../claude/desktop-3p";
 import { handleImages } from "./images";
@@ -464,6 +465,25 @@ export function startServer(port?: number) {
         return withCors(response, req, config);
       }
 
+
+      // OpenAI Chat Completions inbound (GitHub Copilot App / OpenAI-compatible clients).
+      if (url.pathname === "/v1/chat/completions" && req.method === "POST") {
+        disableResponsesRequestTimeout(req, requestServer);
+        if (isDraining()) {
+          return new Response("Service shutting down", { status: 503, headers: { ...corsHeaders(req, config), "Retry-After": "5" } });
+        }
+        const apiAuthError = requireApiAuth(req, config, "data-plane");
+        if (apiAuthError) return withCors(apiAuthError, req, config);
+        if (!isAllowedRequestOrigin(req, config)) {
+          return withCors(formatErrorResponse(403, "origin_rejected", "cross-origin data-plane request blocked"), req, config);
+        }
+        const start = Date.now();
+        const requestId = nextRequestLogId(start);
+        const logCtx: RequestLogContext = { model: "unknown", provider: "unknown" };
+        const response = await handleChatCompletions(req, config, logCtx, { requestId, start });
+        return withCors(response, req, config);
+      }
+
       // Data-plane guard: unknown /v1/* paths must fail with JSON 404, never fall through to the
       // GUI static handler (extensionless paths would get index.html with HTTP 200 and codex-rs
       // endpoint clients — memories/*, realtime/* — would surface confusing
@@ -617,6 +637,7 @@ export function startServer(port?: number) {
 
   console.log(`🚀 opencodex proxy running on http://localhost:${actualPort}`);
   console.log(`   POST /v1/responses → provider translation`);
+  console.log(`   POST /v1/chat/completions → OpenAI-compatible clients`);
   console.log(`   GET  /healthz      → health check`);
   console.log(`   GET  /api/*        → management API`);
   console.log(`   GET  /             → GUI dashboard`);

--- a/tests/chat-completions-endpoint.test.ts
+++ b/tests/chat-completions-endpoint.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { saveConfig } from "../src/config";
+import { startServer } from "../src/server";
+import type { OcxConfig } from "../src/types";
+import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+import { chatCompletionsToResponsesBody, ChatCompletionsRequestError } from "../src/chat/inbound";
+
+let testDir = "";
+let previousHome: string | undefined;
+let isolatedCodexHome: IsolatedCodexHome | null = null;
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  previousHome = process.env.OPENCODEX_HOME;
+  isolatedCodexHome = installIsolatedCodexHome("ocx-chat-completions-");
+  testDir = mkdtempSync(join(tmpdir(), "ocx-chat-completions-"));
+  process.env.OPENCODEX_HOME = testDir;
+  globalThis.fetch = originalFetch;
+});
+
+afterEach(() => {
+  if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = previousHome;
+  isolatedCodexHome?.restore();
+  isolatedCodexHome = null;
+  globalThis.fetch = originalFetch;
+  if (testDir) rmSync(testDir, { recursive: true, force: true });
+});
+
+function mockChatUpstream() {
+  return mockChatUpstreamCapturing().server;
+}
+
+function mockChatUpstreamCapturing() {
+  const captured: Array<Record<string, unknown>> = [];
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (!url.pathname.endsWith("/chat/completions")) {
+        return Response.json({ error: { message: `unexpected path ${url.pathname}` } }, { status: 404 });
+      }
+      try { captured.push(await req.json() as Record<string, unknown>); } catch { /* keep streaming */ }
+      const frames = [
+        `data: ${JSON.stringify({ choices: [{ index: 0, delta: { role: "assistant", content: "Hello" } }] })}\n\n`,
+        `data: ${JSON.stringify({ choices: [{ index: 0, delta: { content: " from mock" } }] })}\n\n`,
+        `data: ${JSON.stringify({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 12, completion_tokens: 3 } })}\n\n`,
+        "data: [DONE]\n\n",
+      ];
+      return new Response(frames.join(""), { headers: { "Content-Type": "text/event-stream" } });
+    },
+  });
+  return { server, captured };
+}
+
+function mockConfig(baseUrl: string): OcxConfig {
+  return {
+    port: 0,
+    defaultProvider: "mock",
+    providers: {
+      mock: { adapter: "openai-chat", baseUrl, apiKey: "k", allowPrivateNetwork: true },
+    },
+  } as OcxConfig;
+}
+
+test("chatCompletionsToResponsesBody maps messages/tools/system", () => {
+  const body = chatCompletionsToResponsesBody({
+    model: "mock/test-model",
+    stream: true,
+    messages: [
+      { role: "system", content: "be brief" },
+      { role: "user", content: "hi" },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [{ id: "call_1", type: "function", function: { name: "lookup", arguments: "{\"q\":\"x\"}" } }],
+      },
+      { role: "tool", tool_call_id: "call_1", content: "result" },
+    ],
+    tools: [{
+      type: "function",
+      function: {
+        name: "lookup",
+        description: "look up",
+        parameters: { type: "object", properties: { q: { type: "string" } } },
+      },
+    }],
+    tool_choice: "auto",
+    max_tokens: 64,
+    reasoning_effort: "high",
+  });
+  expect(body.model).toBe("mock/test-model");
+  expect(body.stream).toBe(true);
+  expect(body.instructions).toBe("be brief");
+  expect(body.max_output_tokens).toBe(64);
+  expect(body.reasoning).toEqual({ effort: "high" });
+  expect(body.tool_choice).toBe("auto");
+  expect(Array.isArray(body.tools)).toBe(true);
+  expect((body.tools as Array<Record<string, unknown>>)[0]).toMatchObject({ type: "function", name: "lookup" });
+  const input = body.input as Array<Record<string, unknown>>;
+  expect(input.some(i => i.type === "message" && i.role === "user")).toBe(true);
+  expect(input.some(i => i.type === "function_call" && i.call_id === "call_1")).toBe(true);
+  expect(input.some(i => i.type === "function_call_output" && i.call_id === "call_1")).toBe(true);
+});
+
+test("chatCompletionsToResponsesBody rejects missing model", () => {
+  expect(() => chatCompletionsToResponsesBody({ messages: [{ role: "user", content: "x" }] }))
+    .toThrow(ChatCompletionsRequestError);
+});
+
+test("POST /v1/chat/completions streams OpenAI-shaped chunks end to end", async () => {
+  const upstream = mockChatUpstream();
+  saveConfig(mockConfig(`${upstream.url.toString().replace(/\/$/, "")}/v1`));
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/chat/completions", server.url), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "mock/test-model",
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type") ?? "").toContain("text/event-stream");
+    const text = await response.text();
+    expect(text).toContain("chat.completion.chunk");
+    expect(text).toContain("Hello");
+    expect(text).toContain("from mock");
+    expect(text).toContain("data: [DONE]");
+    expect(text).toContain("\"finish_reason\":\"stop\"");
+  } finally {
+    server.stop(true);
+    upstream.stop(true);
+  }
+});
+
+test("non-streaming /v1/chat/completions returns chat.completion JSON", async () => {
+  const upstream = mockChatUpstream();
+  saveConfig(mockConfig(`${upstream.url.toString().replace(/\/$/, "")}/v1`));
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/chat/completions", server.url), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "mock/test-model",
+        stream: false,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(response.status).toBe(200);
+    const json = await response.json() as {
+      object: string;
+      model: string;
+      choices: Array<{ message: { role: string; content: string | null }; finish_reason: string }>;
+    };
+    expect(json.object).toBe("chat.completion");
+    expect(json.model).toBe("mock/test-model");
+    expect(json.choices[0]?.message.role).toBe("assistant");
+    expect(json.choices[0]?.message.content).toContain("Hello");
+    expect(json.choices[0]?.finish_reason).toBe("stop");
+  } finally {
+    server.stop(true);
+    upstream.stop(true);
+  }
+});
+
+test("GET /v1/models returns OpenAI list shape for Copilot App discovery", async () => {
+  const upstream = mockChatUpstream();
+  saveConfig(mockConfig(`${upstream.url.toString().replace(/\/$/, "")}/v1`));
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/models", server.url));
+    expect(response.status).toBe(200);
+    const json = await response.json() as { object: string; data: Array<{ id: string; object: string }> };
+    expect(json.object).toBe("list");
+    expect(Array.isArray(json.data)).toBe(true);
+    // Routed mock model may or may not appear depending on liveModels; list shape is the contract.
+    expect(json.data.every(m => m.object === "model" && typeof m.id === "string")).toBe(true);
+  } finally {
+    server.stop(true);
+    upstream.stop(true);
+  }
+});
+
+test("invalid chat completions body returns OpenAI-style 400", async () => {
+  const upstream = mockChatUpstream();
+  saveConfig(mockConfig(`${upstream.url.toString().replace(/\/$/, "")}/v1`));
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/chat/completions", server.url), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ messages: [] }),
+    });
+    expect(response.status).toBe(400);
+    const json = await response.json() as { error: { message: string; type: string } };
+    expect(json.error.message).toContain("model");
+    expect(json.error.type).toBe("invalid_request_error");
+  } finally {
+    server.stop(true);
+    upstream.stop(true);
+  }
+});

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -284,6 +284,7 @@ describe("server local API auth", () => {
         health: "/healthz",
         models: "/v1/models",
         responses: "/v1/responses",
+        chatCompletions: "/v1/chat/completions",
         management: "/api/*",
       },
     });


### PR DESCRIPTION
﻿## Summary
- Add OpenAI-compatible `POST /v1/chat/completions` so GitHub Copilot App can use OpenCodex as a custom Model provider.
- Translate Chat Completions requests into the existing Responses path and bridge stream/non-stream replies back to Chat Completions shape.
- Document setup (`docs/github-copilot-app.md`) and cover discovery/chat endpoint behavior with tests.

This is a **client integration** for GitHub Copilot App (BYOK / Model providers). It is separate from the existing experimental upstream `github-copilot` provider.

## How to use
1. Run OpenCodex (`ocx start`)
2. In GitHub Copilot App → Settings → Model providers → Add provider
3. Base URL: `http://127.0.0.1:10100/v1`
4. API key: empty on loopback
5. Sync models / add model by id (`provider/model`)

## Test plan
- [x] `bun test tests/chat-completions-endpoint.test.ts`
- [x] `bun test tests/server-auth.test.ts -t "root fallback"`
- [x] Manual: `GET /v1/models` returns OpenAI list shape
- [x] Manual: `POST /v1/chat/completions` stream + non-stream succeed for configured providers
- [x] Manual: GitHub Copilot App can chat after pointing at `/v1` and selecting an authenticated model
