### PR TITLE
feat: add GitHub Copilot App support via OpenAI-compatible chat completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ next Codex session. opencodex keeps these behaviors:
 
 - **Use any LLM with Codex.** 5 protocol adapters cover Anthropic Messages, Google Gemini, Azure, OpenAI Responses passthrough, and every OpenAI-compatible Chat Completions endpoint — that's 40+ providers out of the box.
 - **Use any LLM with Claude Code too.** The same daemon serves the Anthropic Messages API (`/v1/messages` + `count_tokens`): `ocx claude` launches Claude Code fully wired, and routed models appear in its native `/model` picker via gateway model discovery (`claude-ocx-<provider>--<model>` aliases, Claude Code 2.1.129+). Configure slots and model maps on the dashboard's Claude page.
+- **Use any LLM with GitHub Copilot App too.** Point Copilot's Model providers at `http://127.0.0.1:10100/v1` — OpenCodex serves OpenAI-compatible `GET /v1/models` and `POST /v1/chat/completions` so routed models sync into the app. See [docs/github-copilot-app.md](docs/github-copilot-app.md).
 - **Pool ChatGPT accounts safely.** Keep existing Codex threads on one account while new sessions
   can auto-pick a lower-usage account from the pool, with quota refresh and non-PII request labels.
 - **Log in once, skip the API key.** OAuth support for xAI, Anthropic, and Kimi means you can authenticate with your existing account. Tokens auto-refresh. Or forward your `codex login`, paste an API key, or use `${ENV_VAR}` references — your call.

--- a/docs/github-copilot-app.md
+++ b/docs/github-copilot-app.md
@@ -1,0 +1,59 @@
+# GitHub Copilot App
+
+OpenCodex can act as an **OpenAI-compatible model provider** for the GitHub Copilot
+desktop app (Settings → Model providers). This is a client integration: Copilot App
+calls OpenCodex; it is separate from the experimental upstream `github-copilot`
+provider that uses a Copilot subscription as a backend.
+
+## Requirements
+
+1. OpenCodex proxy running locally (`ocx start` / `ocx gui`).
+2. At least one configured provider with models (dashboard → Providers).
+3. GitHub Copilot desktop app with **Model providers** support.
+
+## Setup
+
+1. Start OpenCodex and confirm health:
+
+   ```bash
+   curl http://127.0.0.1:10100/healthz
+   curl http://127.0.0.1:10100/v1/models
+   ```
+
+2. In GitHub Copilot App: **Settings → Model providers → Add provider**.
+
+3. Configure:
+
+   | Field | Value |
+   | --- | --- |
+   | Name | `OpenCodex Gateway` (any label) |
+   | Base URL | `http://127.0.0.1:10100/v1` |
+   | API key | leave blank on loopback; for non-loopback binds use `OPENCODEX_API_AUTH_TOKEN` |
+
+4. Sync models from the endpoint, or add a model by id (`provider/model`, e.g.
+   `anthropic/claude-sonnet-4-6`).
+
+5. Select a synced model and chat.
+
+## Endpoints used
+
+| Method | Path | Role |
+| --- | --- | --- |
+| `GET` | `/v1/models` | Model discovery (OpenAI list shape) |
+| `POST` | `/v1/chat/completions` | Chat turns (stream + non-stream) |
+
+OpenCodex translates Chat Completions into its internal Responses path, so all
+existing providers, routing, OAuth, and sidecars apply.
+
+## Troubleshooting
+
+- **No models configured** — ensure the proxy is up, base URL ends with `/v1`
+  (not `/v1/chat/completions`), and `GET /v1/models` returns a non-empty `data`
+  array. Add/enable providers in the OpenCodex dashboard, then sync again.
+- **401** — remote (non-loopback) binds require an admission token as
+  `Authorization: Bearer …` or `x-opencodex-api-key`.
+- **404 on chat** — older OpenCodex builds lacked `/v1/chat/completions`; upgrade
+  to a build that includes this surface.
+- **Model ids with `/`** — prefer the namespaced `provider/model` form returned
+  by `/v1/models`. If a client rejects slashes, add the model by an alias id you
+  control or open an issue for slash-safe aliases.

--- a/docs/github-copilot-app.md
+++ b/docs/github-copilot-app.md
@@ -45,13 +45,23 @@ provider that uses a Copilot subscription as a backend.
 OpenCodex translates Chat Completions into its internal Responses path, so all
 existing providers, routing, OAuth, and sidecars apply.
 
+## Supported fields
+
+The compatibility surface supports `model`, `messages`, `stream`, function tools
+and tool choice, token limits, temperature/top-p/stop, reasoning effort, parallel
+tool calls, prompt cache keys, metadata, and `response_format` on native Responses
+routes. Routed `openai-chat` models reject `response_format` with HTTP 400 because
+their structured-output support is not verified. Other Chat Completions fields,
+including penalties, `n`, and logprobs, are not currently supported.
+
 ## Troubleshooting
 
 - **No models configured** — ensure the proxy is up, base URL ends with `/v1`
   (not `/v1/chat/completions`), and `GET /v1/models` returns a non-empty `data`
   array. Add/enable providers in the OpenCodex dashboard, then sync again.
-- **401** — remote (non-loopback) binds require an admission token as
-  `Authorization: Bearer …` or `x-opencodex-api-key`.
+- **401** — remote (non-loopback) binds require the OpenCodex admission token in
+  `x-opencodex-api-key`. `Authorization` remains the upstream identity for native
+  direct-account mode.
 - **404 on chat** — older OpenCodex builds lacked `/v1/chat/completions`; upgrade
   to a build that includes this surface.
 - **Model ids with `/`** — prefer the namespaced `provider/model` form returned

--- a/src/chat/inbound.ts
+++ b/src/chat/inbound.ts
@@ -1,0 +1,279 @@
+/**
+ * Chat Completions inbound: OpenAI-compatible request -> internal /v1/responses body.
+ *
+ * Used by GitHub Copilot App (and other OpenAI-compatible clients) via POST /v1/chat/completions.
+ * Same translate-and-replay pattern as Claude Messages: the produced body must pass
+ * responsesRequestSchema so routing/OAuth/pool/sidecars are inherited unchanged.
+ */
+export class ChatCompletionsRequestError extends Error {}
+
+type Rec = Record<string, unknown>;
+
+function isRec(v: unknown): v is Rec {
+  return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
+const OUTPUT_CONFIG_EFFORTS = new Set(["minimal", "low", "medium", "high", "xhigh", "max", "ultra"]);
+
+function contentToText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const raw of content) {
+    if (typeof raw === "string") {
+      parts.push(raw);
+      continue;
+    }
+    if (!isRec(raw)) continue;
+    if ((raw.type === "text" || raw.type === "input_text" || raw.type === "output_text") && typeof raw.text === "string") {
+      parts.push(raw.text);
+    }
+  }
+  return parts.join("\n");
+}
+
+function imageUrlFromPart(part: Rec): string | null {
+  if (part.type !== "image_url") return null;
+  const imageUrl = part.image_url;
+  if (typeof imageUrl === "string" && imageUrl.length > 0) return imageUrl;
+  if (isRec(imageUrl) && typeof imageUrl.url === "string" && imageUrl.url.length > 0) return imageUrl.url;
+  return null;
+}
+
+function userContentToBlocks(content: unknown): Rec[] {
+  if (typeof content === "string") {
+    return content.length > 0 ? [{ type: "input_text", text: content }] : [];
+  }
+  if (!Array.isArray(content)) return [];
+  const blocks: Rec[] = [];
+  for (const raw of content) {
+    if (typeof raw === "string") {
+      if (raw.length > 0) blocks.push({ type: "input_text", text: raw });
+      continue;
+    }
+    if (!isRec(raw)) continue;
+    if ((raw.type === "text" || raw.type === "input_text") && typeof raw.text === "string") {
+      blocks.push({ type: "input_text", text: raw.text });
+      continue;
+    }
+    const imageUrl = imageUrlFromPart(raw);
+    if (imageUrl) blocks.push({ type: "input_image", image_url: imageUrl });
+  }
+  return blocks;
+}
+
+function assistantContentToBlocks(content: unknown): Rec[] {
+  if (typeof content === "string") {
+    return content.length > 0 ? [{ type: "output_text", text: content }] : [];
+  }
+  if (!Array.isArray(content)) return [];
+  const blocks: Rec[] = [];
+  for (const raw of content) {
+    if (typeof raw === "string") {
+      if (raw.length > 0) blocks.push({ type: "output_text", text: raw });
+      continue;
+    }
+    if (!isRec(raw)) continue;
+    if ((raw.type === "text" || raw.type === "output_text") && typeof raw.text === "string") {
+      blocks.push({ type: "output_text", text: raw.text });
+    }
+  }
+  return blocks;
+}
+
+function pushSystemText(parts: string[], content: unknown): void {
+  const text = contentToText(content).trim();
+  if (text) parts.push(text);
+}
+
+function toolCallsToItems(toolCalls: unknown, input: Rec[]): void {
+  if (!Array.isArray(toolCalls)) return;
+  for (const raw of toolCalls) {
+    if (!isRec(raw)) continue;
+    const fn = isRec(raw.function) ? raw.function : null;
+    const name = typeof fn?.name === "string" ? fn.name : typeof raw.name === "string" ? raw.name : "";
+    const args = typeof fn?.arguments === "string"
+      ? fn.arguments
+      : typeof raw.arguments === "string"
+        ? raw.arguments
+        : JSON.stringify(fn?.arguments ?? raw.arguments ?? {});
+    const callId = typeof raw.id === "string" && raw.id.length > 0
+      ? raw.id
+      : typeof raw.call_id === "string" && raw.call_id.length > 0
+        ? raw.call_id
+        : `call_${crypto.randomUUID().replace(/-/g, "").slice(0, 24)}`;
+    if (!name) throw new ChatCompletionsRequestError("tool_calls entries require function.name");
+    input.push({ type: "function_call", call_id: callId, name, arguments: args });
+  }
+}
+
+function toolsToResponses(tools: unknown): Rec[] | undefined {
+  if (!Array.isArray(tools) || tools.length === 0) return undefined;
+  const out: Rec[] = [];
+  for (const raw of tools) {
+    if (!isRec(raw)) continue;
+    if (raw.type === "function" && typeof raw.name === "string" && raw.name.length > 0) {
+      out.push({
+        type: "function",
+        name: raw.name,
+        ...(typeof raw.description === "string" ? { description: raw.description } : {}),
+        ...(isRec(raw.parameters) ? { parameters: raw.parameters } : {}),
+        ...(typeof raw.strict === "boolean" ? { strict: raw.strict } : {}),
+      });
+      continue;
+    }
+    if (raw.type === "function" && isRec(raw.function) && typeof raw.function.name === "string" && raw.function.name.length > 0) {
+      out.push({
+        type: "function",
+        name: raw.function.name,
+        ...(typeof raw.function.description === "string" ? { description: raw.function.description } : {}),
+        ...(isRec(raw.function.parameters) ? { parameters: raw.function.parameters } : {}),
+        ...(typeof raw.function.strict === "boolean" ? { strict: raw.function.strict } : {}),
+      });
+      continue;
+    }
+    if (raw.type === "web_search" || raw.type === "web_search_preview") {
+      out.push({ type: "web_search" });
+    }
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function toolChoiceToResponses(choice: unknown, body: Rec): void {
+  if (choice === undefined || choice === null) return;
+  if (choice === "auto" || choice === "none" || choice === "required") {
+    body.tool_choice = choice;
+    return;
+  }
+  if (!isRec(choice)) return;
+  if (choice.type === "function") {
+    const name = typeof choice.name === "string"
+      ? choice.name
+      : isRec(choice.function) && typeof choice.function.name === "string"
+        ? choice.function.name
+        : "";
+    if (!name) throw new ChatCompletionsRequestError("tool_choice.function requires a name");
+    body.tool_choice = { type: "function", name };
+    return;
+  }
+  if (isRec(choice.function) && typeof choice.function.name === "string") {
+    body.tool_choice = { type: "function", name: choice.function.name };
+  }
+}
+
+function responseFormatToText(format: unknown): Rec | undefined {
+  if (!isRec(format)) return undefined;
+  if (format.type === "json_object") return { format: { type: "json_object" } };
+  if (format.type === "json_schema" && isRec(format.json_schema)) {
+    const schema = format.json_schema;
+    return {
+      format: {
+        type: "json_schema",
+        name: typeof schema.name === "string" ? schema.name : "response",
+        ...(typeof schema.description === "string" ? { description: schema.description } : {}),
+        ...(schema.schema !== undefined ? { schema: schema.schema } : {}),
+        ...(typeof schema.strict === "boolean" ? { strict: schema.strict } : {}),
+      },
+    };
+  }
+  return undefined;
+}
+
+function resolveReasoningEffort(raw: Rec): string | undefined {
+  if (typeof raw.reasoning_effort === "string" && OUTPUT_CONFIG_EFFORTS.has(raw.reasoning_effort)) {
+    return raw.reasoning_effort;
+  }
+  if (isRec(raw.reasoning) && typeof raw.reasoning.effort === "string" && OUTPUT_CONFIG_EFFORTS.has(raw.reasoning.effort)) {
+    return raw.reasoning.effort;
+  }
+  return undefined;
+}
+
+/**
+ * Translate an OpenAI Chat Completions request body into a /v1/responses request body.
+ * Throws ChatCompletionsRequestError (-> 400) on malformed input.
+ */
+export function chatCompletionsToResponsesBody(raw: unknown): Rec {
+  if (!isRec(raw)) throw new ChatCompletionsRequestError("request body must be a JSON object");
+  if (typeof raw.model !== "string" || raw.model.length === 0) {
+    throw new ChatCompletionsRequestError("model is required");
+  }
+  if (!Array.isArray(raw.messages) || raw.messages.length === 0) {
+    throw new ChatCompletionsRequestError("messages must be a non-empty array");
+  }
+
+  const systemParts: string[] = [];
+  const input: Rec[] = [];
+
+  for (const msg of raw.messages) {
+    if (!isRec(msg)) continue;
+    const role = typeof msg.role === "string" ? msg.role : "";
+    switch (role) {
+      case "system":
+      case "developer":
+        pushSystemText(systemParts, msg.content);
+        break;
+      case "user": {
+        const blocks = userContentToBlocks(msg.content);
+        if (blocks.length > 0) input.push({ type: "message", role: "user", content: blocks });
+        break;
+      }
+      case "assistant": {
+        const blocks = assistantContentToBlocks(msg.content);
+        if (blocks.length > 0) input.push({ type: "message", role: "assistant", content: blocks });
+        if (msg.tool_calls !== undefined) toolCallsToItems(msg.tool_calls, input);
+        break;
+      }
+      case "tool": {
+        const callId = typeof msg.tool_call_id === "string" ? msg.tool_call_id
+          : typeof msg.tool_use_id === "string" ? msg.tool_use_id
+          : "";
+        if (!callId) throw new ChatCompletionsRequestError("tool messages require tool_call_id");
+        const output = typeof msg.content === "string" ? msg.content : contentToText(msg.content);
+        input.push({ type: "function_call_output", call_id: callId, output });
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  if (input.length === 0 && systemParts.length === 0) {
+    throw new ChatCompletionsRequestError("messages must include at least one user/assistant/tool turn");
+  }
+
+  const body: Rec = {
+    model: raw.model,
+    input,
+    stream: raw.stream === true,
+    store: false,
+  };
+
+  if (systemParts.length > 0) body.instructions = systemParts.join("\n\n");
+
+  const tools = toolsToResponses(raw.tools);
+  if (tools) body.tools = tools;
+  toolChoiceToResponses(raw.tool_choice, body);
+
+  const maxTokens = typeof raw.max_completion_tokens === "number"
+    ? raw.max_completion_tokens
+    : typeof raw.max_tokens === "number"
+      ? raw.max_tokens
+      : undefined;
+  if (typeof maxTokens === "number") body.max_output_tokens = maxTokens;
+  if (typeof raw.temperature === "number") body.temperature = raw.temperature;
+  if (typeof raw.top_p === "number") body.top_p = raw.top_p;
+  if (raw.stop !== undefined) body.stop = raw.stop;
+  if (typeof raw.user === "string") body.user = raw.user;
+  if (typeof raw.parallel_tool_calls === "boolean") body.parallel_tool_calls = raw.parallel_tool_calls;
+  if (typeof raw.prompt_cache_key === "string") body.prompt_cache_key = raw.prompt_cache_key;
+  if (raw.metadata !== undefined) body.metadata = raw.metadata;
+
+  const effort = resolveReasoningEffort(raw);
+  if (effort) body.reasoning = { effort };
+
+  const text = responseFormatToText(raw.response_format);
+  if (text) body.text = text;
+
+  return body;
+}

--- a/src/chat/inbound.ts
+++ b/src/chat/inbound.ts
@@ -162,9 +162,13 @@ function toolChoiceToResponses(choice: unknown, body: Rec): void {
 }
 
 function responseFormatToText(format: unknown): Rec | undefined {
-  if (!isRec(format)) return undefined;
+  if (format === undefined) return undefined;
+  if (!isRec(format)) throw new ChatCompletionsRequestError("response_format must be an object");
   if (format.type === "json_object") return { format: { type: "json_object" } };
-  if (format.type === "json_schema" && isRec(format.json_schema)) {
+  if (format.type === "json_schema") {
+    if (!isRec(format.json_schema)) {
+      throw new ChatCompletionsRequestError("response_format.json_schema is required for type json_schema");
+    }
     const schema = format.json_schema;
     return {
       format: {
@@ -176,7 +180,8 @@ function responseFormatToText(format: unknown): Rec | undefined {
       },
     };
   }
-  return undefined;
+  if (format.type === "text") return undefined;
+  throw new ChatCompletionsRequestError(`unsupported response_format.type: ${String(format.type)}`);
 }
 
 function resolveReasoningEffort(raw: Rec): string | undefined {

--- a/src/chat/inbound.ts
+++ b/src/chat/inbound.ts
@@ -88,10 +88,19 @@ function pushSystemText(parts: string[], content: unknown): void {
 
 function toolCallsToItems(toolCalls: unknown, input: Rec[]): void {
   if (!Array.isArray(toolCalls)) return;
+  // Recover names from earlier function_call items in the same transcript when a client
+  // re-sends tool_calls with only id/arguments (replace-style merge lost function.name).
+  const knownNameByCallId = new Map<string, string>();
+  for (const item of input) {
+    if (!isRec(item) || item.type !== "function_call") continue;
+    if (typeof item.call_id === "string" && typeof item.name === "string" && item.name.length > 0) {
+      knownNameByCallId.set(item.call_id, item.name);
+    }
+  }
   for (const raw of toolCalls) {
     if (!isRec(raw)) continue;
     const fn = isRec(raw.function) ? raw.function : null;
-    const name = typeof fn?.name === "string" ? fn.name : typeof raw.name === "string" ? raw.name : "";
+    let name = typeof fn?.name === "string" ? fn.name : typeof raw.name === "string" ? raw.name : "";
     const args = typeof fn?.arguments === "string"
       ? fn.arguments
       : typeof raw.arguments === "string"
@@ -102,7 +111,9 @@ function toolCallsToItems(toolCalls: unknown, input: Rec[]): void {
       : typeof raw.call_id === "string" && raw.call_id.length > 0
         ? raw.call_id
         : `call_${crypto.randomUUID().replace(/-/g, "").slice(0, 24)}`;
+    if (!name) name = knownNameByCallId.get(callId) ?? "";
     if (!name) throw new ChatCompletionsRequestError("tool_calls entries require function.name");
+    knownNameByCallId.set(callId, name);
     input.push({ type: "function_call", call_id: callId, name, arguments: args });
   }
 }

--- a/src/chat/outbound.ts
+++ b/src/chat/outbound.ts
@@ -132,6 +132,7 @@ export function responsesSseToChatCompletionsSse(
   // tool call_id -> streaming index (OpenAI requires stable indices per tool call)
   const toolIndexByCallId = new Map<string, number>();
   const toolIndexByItemId = new Map<string, number>();
+  const toolNameByIndex = new Map<number, string>();
   let nextToolIndex = 0;
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
 
@@ -231,6 +232,7 @@ export function responsesSseToChatCompletionsSse(
               toolIndexByCallId.set(callId, toolIndex);
             }
             if (typeof item.id === "string") toolIndexByItemId.set(item.id, toolIndex);
+            if (name) toolNameByIndex.set(toolIndex, name);
             const frame = chunkBase(id, model, created);
             frame.choices = [{
               index: 0,
@@ -239,6 +241,8 @@ export function responsesSseToChatCompletionsSse(
                   index: toolIndex,
                   id: callId,
                   type: "function",
+                  // Always include name so clients that replace (not merge) tool_calls
+                  // deltas never end up with function.name-less history.
                   function: { name, arguments: "" },
                 }],
               },
@@ -253,13 +257,18 @@ export function responsesSseToChatCompletionsSse(
             const toolIndex = (itemId ? toolIndexByItemId.get(itemId) : undefined)
               ?? (nextToolIndex > 0 ? nextToolIndex - 1 : 0);
             ensureRole();
+            const knownName = toolNameByIndex.get(toolIndex) ?? "";
+            const fn: Rec = { arguments: data.delta };
+            // Re-emit name on every args delta: GitHub Copilot App / some ChatGPT clients
+            // replace the whole function object instead of merging, which otherwise drops name.
+            if (knownName) fn.name = knownName;
             const frame = chunkBase(id, model, created);
             frame.choices = [{
               index: 0,
               delta: {
                 tool_calls: [{
                   index: toolIndex,
-                  function: { arguments: data.delta },
+                  function: fn,
                 }],
               },
               finish_reason: null,
@@ -284,27 +293,23 @@ export function responsesSseToChatCompletionsSse(
                 toolIndexByCallId.set(callId, toolIndex);
               }
               if (typeof item.id === "string") toolIndexByItemId.set(item.id, toolIndex);
+              if (name) toolNameByIndex.set(toolIndex, name);
+              const finalName = name || toolNameByIndex.get(toolIndex) || "";
               // Last-write-wins: the done-frame snapshot is authoritative final arguments.
-              // Emit a final arguments snapshot so clients that only saw partial deltas
-              // (or no deltas) still get the correct tool call payload.
-              if (args.length > 0 || isNew) {
+              // Always re-emit full identity (id/type/name) so replace-style clients keep function.name.
+              if (args.length > 0 || isNew || finalName) {
                 ensureRole();
-                const toolCall: Rec = {
-                  index: toolIndex,
-                  function: { arguments: args },
-                };
-                if (isNew) {
-                  toolCall.id = callId;
-                  toolCall.type = "function";
-                  (toolCall.function as Rec).name = name;
-                } else if (name) {
-                  // Some providers only put the final name on the done frame.
-                  (toolCall.function as Rec).name = name;
-                }
                 const frame = chunkBase(id, model, created);
                 frame.choices = [{
                   index: 0,
-                  delta: { tool_calls: [toolCall] },
+                  delta: {
+                    tool_calls: [{
+                      index: toolIndex,
+                      id: callId,
+                      type: "function",
+                      function: { name: finalName, arguments: args },
+                    }],
+                  },
                   finish_reason: null,
                 }];
                 emit(frame);

--- a/src/chat/outbound.ts
+++ b/src/chat/outbound.ts
@@ -95,6 +95,7 @@ export function responsesSseToChatCompletionsSse(
   const created = Math.floor(Date.now() / 1000);
   // tool call_id -> streaming index (OpenAI requires stable indices per tool call)
   const toolIndexByCallId = new Map<string, number>();
+  const toolIndexByItemId = new Map<string, number>();
   let nextToolIndex = 0;
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
 
@@ -172,6 +173,7 @@ export function responsesSseToChatCompletionsSse(
               toolIndex = nextToolIndex++;
               toolIndexByCallId.set(callId, toolIndex);
             }
+            if (typeof item.id === "string") toolIndexByItemId.set(item.id, toolIndex);
             const frame = chunkBase(id, model, created);
             frame.choices = [{
               index: 0,
@@ -190,12 +192,9 @@ export function responsesSseToChatCompletionsSse(
           }
           case "response.function_call_arguments.delta": {
             if (typeof data.delta !== "string" || data.delta.length === 0) break;
-            // Prefer item_id matching when present; otherwise use the last open tool index.
-            let toolIndex = nextToolIndex > 0 ? nextToolIndex - 1 : 0;
             const itemId = typeof data.item_id === "string" ? data.item_id : undefined;
-            if (itemId) {
-              // Some bridges put call_id on the item, not item_id; keep last index.
-            }
+            const toolIndex = (itemId ? toolIndexByItemId.get(itemId) : undefined)
+              ?? (nextToolIndex > 0 ? nextToolIndex - 1 : 0);
             ensureRole();
             const frame = chunkBase(id, model, created);
             frame.choices = [{

--- a/src/chat/outbound.ts
+++ b/src/chat/outbound.ts
@@ -1,0 +1,473 @@
+/**
+ * Chat Completions outbound: internal /v1/responses output -> OpenAI Chat Completions shapes.
+ *
+ * Wire contract for GitHub Copilot App / OpenAI-compatible clients:
+ *  - Streaming: `data: {choices:[{delta:...}]}` frames ending with `data: [DONE]`
+ *  - Non-streaming: `{ id, object:"chat.completion", choices:[{message}], usage }`
+ */
+type Rec = Record<string, unknown>;
+
+function isRec(v: unknown): v is Rec {
+  return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
+function uuid(): string {
+  return crypto.randomUUID().replace(/-/g, "");
+}
+
+function completionId(): string {
+  return `chatcmpl-${uuid().slice(0, 24)}`;
+}
+
+/** Responses usage (inclusive input_tokens) -> Chat Completions usage. */
+export function chatCompletionsUsage(usage: unknown): Rec {
+  const u = isRec(usage) ? usage : {};
+  const details = isRec(u.input_tokens_details) ? u.input_tokens_details : {};
+  const prompt = typeof u.input_tokens === "number" ? u.input_tokens : 0;
+  const completion = typeof u.output_tokens === "number" ? u.output_tokens : 0;
+  const cached = typeof details.cached_tokens === "number" ? details.cached_tokens : undefined;
+  const out: Rec = {
+    prompt_tokens: prompt,
+    completion_tokens: completion,
+    total_tokens: prompt + completion,
+  };
+  if (cached !== undefined) {
+    out.prompt_tokens_details = { cached_tokens: cached };
+  }
+  const outDetails = isRec(u.output_tokens_details) ? u.output_tokens_details : {};
+  if (typeof outDetails.reasoning_tokens === "number") {
+    out.completion_tokens_details = { reasoning_tokens: outDetails.reasoning_tokens };
+  }
+  return out;
+}
+
+export function chatCompletionsErrorBody(status: number, message: string, type = "invalid_request_error"): Rec {
+  return {
+    error: {
+      message,
+      type,
+      param: null,
+      code: status === 401 ? "invalid_api_key"
+        : status === 404 ? "model_not_found"
+        : status === 429 ? "rate_limit_exceeded"
+        : null,
+    },
+  };
+}
+
+export function chatCompletionsErrorResponse(status: number, message: string, type?: string): Response {
+  return new Response(JSON.stringify(chatCompletionsErrorBody(status, message, type)), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function dataFrame(payload: Rec | "[DONE]"): string {
+  if (payload === "[DONE]") return "data: [DONE]\n\n";
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+function chunkBase(id: string, model: string, created: number): Rec {
+  return {
+    id,
+    object: "chat.completion.chunk",
+    created,
+    model,
+    choices: [],
+  };
+}
+
+/**
+ * Streaming: Responses SSE bytes -> Chat Completions SSE bytes.
+ */
+export function responsesSseToChatCompletionsSse(
+  upstream: ReadableStream<Uint8Array>,
+  model: string,
+): ReadableStream<Uint8Array> {
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let buffer = "";
+  let terminated = false;
+  let cancelled = false;
+  let started = false;
+  let sawToolUse = false;
+  const id = completionId();
+  const created = Math.floor(Date.now() / 1000);
+  // tool call_id -> streaming index (OpenAI requires stable indices per tool call)
+  const toolIndexByCallId = new Map<string, number>();
+  let nextToolIndex = 0;
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      const emit = (payload: Rec | "[DONE]") => controller.enqueue(encoder.encode(dataFrame(payload)));
+      const ensureRole = () => {
+        if (started) return;
+        started = true;
+        const frame = chunkBase(id, model, created);
+        frame.choices = [{ index: 0, delta: { role: "assistant", content: "" }, finish_reason: null }];
+        emit(frame);
+      };
+      const emitContent = (text: string) => {
+        if (!text) return;
+        ensureRole();
+        const frame = chunkBase(id, model, created);
+        frame.choices = [{ index: 0, delta: { content: text }, finish_reason: null }];
+        emit(frame);
+      };
+      const emitReasoning = (text: string) => {
+        if (!text) return;
+        ensureRole();
+        // Many OpenAI-compatible clients accept reasoning_content; harmless if ignored.
+        const frame = chunkBase(id, model, created);
+        frame.choices = [{ index: 0, delta: { reasoning_content: text }, finish_reason: null }];
+        emit(frame);
+      };
+      const finish = (finishReason: string, usage: unknown) => {
+        if (terminated) return;
+        terminated = true;
+        ensureRole();
+        const frame = chunkBase(id, model, created);
+        frame.choices = [{ index: 0, delta: {}, finish_reason: finishReason }];
+        if (usage) frame.usage = chatCompletionsUsage(usage);
+        emit(frame);
+        emit("[DONE]");
+      };
+      const fail = (message: string) => {
+        if (terminated) return;
+        terminated = true;
+        ensureRole();
+        // Mid-stream error as a final frame with finish_reason stop, then DONE.
+        // Clients that only parse deltas still terminate cleanly.
+        const frame = chunkBase(id, model, created);
+        frame.choices = [{ index: 0, delta: { content: `\n\n[error] ${message}` }, finish_reason: "stop" }];
+        emit(frame);
+        emit("[DONE]");
+      };
+
+      const handleFrame = (eventName: string, data: Rec) => {
+        switch (eventName) {
+          case "response.created":
+          case "response.heartbeat":
+            ensureRole();
+            break;
+          case "response.output_text.delta": {
+            if (typeof data.delta === "string") emitContent(data.delta);
+            break;
+          }
+          case "response.reasoning_summary_text.delta":
+          case "response.reasoning_text.delta": {
+            if (typeof data.delta === "string") emitReasoning(data.delta);
+            break;
+          }
+          case "response.output_item.added": {
+            const item = isRec(data.item) ? data.item : null;
+            if (!item || item.type !== "function_call") break;
+            ensureRole();
+            sawToolUse = true;
+            const callId = typeof item.call_id === "string" ? item.call_id : `call_${uuid().slice(0, 16)}`;
+            const name = typeof item.name === "string" ? item.name : "";
+            let toolIndex = toolIndexByCallId.get(callId);
+            if (toolIndex === undefined) {
+              toolIndex = nextToolIndex++;
+              toolIndexByCallId.set(callId, toolIndex);
+            }
+            const frame = chunkBase(id, model, created);
+            frame.choices = [{
+              index: 0,
+              delta: {
+                tool_calls: [{
+                  index: toolIndex,
+                  id: callId,
+                  type: "function",
+                  function: { name, arguments: "" },
+                }],
+              },
+              finish_reason: null,
+            }];
+            emit(frame);
+            break;
+          }
+          case "response.function_call_arguments.delta": {
+            if (typeof data.delta !== "string" || data.delta.length === 0) break;
+            // Prefer item_id matching when present; otherwise use the last open tool index.
+            let toolIndex = nextToolIndex > 0 ? nextToolIndex - 1 : 0;
+            const itemId = typeof data.item_id === "string" ? data.item_id : undefined;
+            if (itemId) {
+              // Some bridges put call_id on the item, not item_id; keep last index.
+            }
+            ensureRole();
+            const frame = chunkBase(id, model, created);
+            frame.choices = [{
+              index: 0,
+              delta: {
+                tool_calls: [{
+                  index: toolIndex,
+                  function: { arguments: data.delta },
+                }],
+              },
+              finish_reason: null,
+            }];
+            emit(frame);
+            break;
+          }
+          case "response.output_item.done": {
+            const item = isRec(data.item) ? data.item : null;
+            if (!item) break;
+            if (item.type === "function_call") {
+              sawToolUse = true;
+              const callId = typeof item.call_id === "string" ? item.call_id : "";
+              const name = typeof item.name === "string" ? item.name : "";
+              const args = typeof item.arguments === "string" ? item.arguments : "";
+              if (!callId) break;
+              let toolIndex = toolIndexByCallId.get(callId);
+              if (toolIndex === undefined) {
+                // No prior added event — emit a complete tool call chunk.
+                toolIndex = nextToolIndex++;
+                toolIndexByCallId.set(callId, toolIndex);
+                ensureRole();
+                const frame = chunkBase(id, model, created);
+                frame.choices = [{
+                  index: 0,
+                  delta: {
+                    tool_calls: [{
+                      index: toolIndex,
+                      id: callId,
+                      type: "function",
+                      function: { name, arguments: args },
+                    }],
+                  },
+                  finish_reason: null,
+                }];
+                emit(frame);
+              }
+            }
+            break;
+          }
+          case "response.completed": {
+            const response = isRec(data.response) ? data.response : {};
+            finish(sawToolUse ? "tool_calls" : "stop", response.usage);
+            break;
+          }
+          case "response.incomplete": {
+            const response = isRec(data.response) ? data.response : {};
+            const details = isRec(response.incomplete_details) ? response.incomplete_details : {};
+            const reason = details.reason === "max_output_tokens" ? "length"
+              : details.reason === "content_filter" ? "content_filter"
+              : sawToolUse ? "tool_calls" : "stop";
+            finish(reason, response.usage);
+            break;
+          }
+          case "response.failed": {
+            const response = isRec(data.response) ? data.response : {};
+            const error = isRec(response.error) ? response.error : {};
+            const message = typeof error.message === "string" ? error.message : "upstream request failed";
+            fail(message);
+            break;
+          }
+          default:
+            break;
+        }
+      };
+
+      reader = upstream.getReader();
+      void (async () => {
+        try {
+          for (;;) {
+            const { done, value } = await reader!.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            let sep: number;
+            while ((sep = buffer.indexOf("\n\n")) !== -1) {
+              const rawFrame = buffer.slice(0, sep);
+              buffer = buffer.slice(sep + 2);
+              let eventName = "";
+              let dataLine = "";
+              for (const line of rawFrame.split("\n")) {
+                if (line.startsWith("event: ")) eventName = line.slice(7).trim();
+                else if (line.startsWith("data: ")) dataLine += line.slice(6);
+              }
+              if (!eventName || !dataLine) continue;
+              let data: unknown;
+              try { data = JSON.parse(dataLine); } catch { continue; }
+              if (!isRec(data)) continue;
+              if (terminated) continue;
+              handleFrame(eventName, data);
+            }
+          }
+          if (!cancelled && !terminated) {
+            fail("upstream stream ended before a terminal frame (truncated response)");
+          }
+        } catch (err) {
+          fail(err instanceof Error ? err.message : String(err));
+        } finally {
+          reader?.releaseLock();
+          if (!cancelled) {
+            try { controller.close(); } catch { /* already closed */ }
+          }
+        }
+      })();
+    },
+    cancel(reason) {
+      cancelled = true;
+      return reader?.cancel(reason);
+    },
+  });
+}
+
+/** Non-streaming: /v1/responses JSON -> Chat Completions message JSON. */
+export function responsesJsonToChatCompletion(json: unknown, model: string): Rec {
+  const body = isRec(json) ? json : {};
+  const output = Array.isArray(body.output) ? body.output : [];
+  let content = "";
+  let reasoning = "";
+  const toolCalls: Rec[] = [];
+
+  for (const raw of output) {
+    if (!isRec(raw)) continue;
+    if (raw.type === "message" && Array.isArray(raw.content)) {
+      for (const part of raw.content) {
+        if (isRec(part) && part.type === "output_text" && typeof part.text === "string") {
+          content += part.text;
+        }
+      }
+    } else if (raw.type === "reasoning") {
+      if (Array.isArray(raw.summary)) {
+        for (const part of raw.summary) {
+          if (isRec(part) && part.type === "summary_text" && typeof part.text === "string") {
+            reasoning += part.text;
+          }
+        }
+      }
+      if (Array.isArray(raw.content)) {
+        for (const part of raw.content) {
+          if (isRec(part) && part.type === "reasoning_text" && typeof part.text === "string") {
+            reasoning += part.text;
+          }
+        }
+      }
+    } else if (raw.type === "function_call") {
+      toolCalls.push({
+        id: typeof raw.call_id === "string" ? raw.call_id : `call_${uuid().slice(0, 16)}`,
+        type: "function",
+        function: {
+          name: typeof raw.name === "string" ? raw.name : "",
+          arguments: typeof raw.arguments === "string" ? raw.arguments : "{}",
+        },
+      });
+    }
+  }
+
+  const finishReason = toolCalls.length > 0 ? "tool_calls"
+    : body.status === "incomplete" ? "length"
+    : "stop";
+
+  const message: Rec = {
+    role: "assistant",
+    content: content || null,
+  };
+  if (reasoning) message.reasoning_content = reasoning;
+  if (toolCalls.length > 0) message.tool_calls = toolCalls;
+
+  return {
+    id: completionId(),
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [{
+      index: 0,
+      message,
+      finish_reason: finishReason,
+      logprobs: null,
+    }],
+    usage: chatCompletionsUsage(body.usage),
+  };
+}
+
+/** Fold a Chat Completions SSE stream into a final completion JSON. */
+export async function collectChatCompletion(
+  stream: ReadableStream<Uint8Array>,
+  model: string,
+): Promise<Rec> {
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let content = "";
+  let reasoning = "";
+  const toolCalls = new Map<number, { id: string; name: string; arguments: string }>();
+  let finishReason = "stop";
+  let usage: unknown;
+  const reader = stream.getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let sep: number;
+      while ((sep = buffer.indexOf("\n\n")) !== -1) {
+        const rawFrame = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+        for (const line of rawFrame.split("\n")) {
+          if (!line.startsWith("data: ")) continue;
+          const data = line.slice(6).trim();
+          if (!data || data === "[DONE]") continue;
+          let parsed: unknown;
+          try { parsed = JSON.parse(data); } catch { continue; }
+          if (!isRec(parsed)) continue;
+          if (parsed.usage) usage = parsed.usage;
+          const choices = Array.isArray(parsed.choices) ? parsed.choices : [];
+          const choice = isRec(choices[0]) ? choices[0] : null;
+          if (!choice) continue;
+          if (typeof choice.finish_reason === "string") finishReason = choice.finish_reason;
+          const delta = isRec(choice.delta) ? choice.delta : null;
+          if (!delta) continue;
+          if (typeof delta.content === "string") content += delta.content;
+          if (typeof delta.reasoning_content === "string") reasoning += delta.reasoning_content;
+          if (Array.isArray(delta.tool_calls)) {
+            for (const tc of delta.tool_calls) {
+              if (!isRec(tc)) continue;
+              const index = typeof tc.index === "number" ? tc.index : 0;
+              const current = toolCalls.get(index) ?? { id: "", name: "", arguments: "" };
+              if (typeof tc.id === "string") current.id = tc.id;
+              const fn = isRec(tc.function) ? tc.function : {};
+              if (typeof fn.name === "string") current.name += fn.name;
+              if (typeof fn.arguments === "string") current.arguments += fn.arguments;
+              toolCalls.set(index, current);
+            }
+          }
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const message: Rec = {
+    role: "assistant",
+    content: content || null,
+  };
+  if (reasoning) message.reasoning_content = reasoning;
+  if (toolCalls.size > 0) {
+    message.tool_calls = [...toolCalls.entries()]
+      .sort((a, b) => a[0] - b[0])
+      .map(([, tc]) => ({
+        id: tc.id || `call_${uuid().slice(0, 16)}`,
+        type: "function",
+        function: { name: tc.name, arguments: tc.arguments },
+      }));
+    if (finishReason === "stop") finishReason = "tool_calls";
+  }
+
+  return {
+    id: completionId(),
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [{
+      index: 0,
+      message,
+      finish_reason: finishReason,
+      logprobs: null,
+    }],
+    usage: usage && isRec(usage) ? usage : chatCompletionsUsage(undefined),
+  };
+}

--- a/src/chat/outbound.ts
+++ b/src/chat/outbound.ts
@@ -62,6 +62,42 @@ export function chatCompletionsErrorResponse(status: number, message: string, ty
   });
 }
 
+/** Thrown when a Chat Completions SSE stream ends in a typed failure/truncation. */
+export class ChatCompletionsStreamError extends Error {
+  readonly status: number;
+  readonly type: string;
+  readonly code: string | null;
+
+  constructor(message: string, options: { status?: number; type?: string; code?: string | null } = {}) {
+    super(message);
+    this.name = "ChatCompletionsStreamError";
+    this.status = options.status ?? 502;
+    this.type = options.type ?? "server_error";
+    this.code = options.code ?? null;
+  }
+}
+
+export function isChatCompletionsStreamError(err: unknown): err is ChatCompletionsStreamError {
+  return err instanceof ChatCompletionsStreamError;
+}
+
+function streamErrorStatus(message: string): number {
+  const lower = message.toLowerCase();
+  if (lower.includes("truncated")) return 502;
+  if (lower.includes("rate") || lower.includes("429")) return 429;
+  if (lower.includes("unauthor") || lower.includes("401") || lower.includes("api key")) return 401;
+  if (lower.includes("not found") || lower.includes("404")) return 404;
+  if (lower.includes("invalid") || lower.includes("400")) return 400;
+  return 502;
+}
+
+function streamErrorType(status: number): string {
+  if (status === 401) return "authentication_error";
+  if (status === 429) return "rate_limit_error";
+  if (status >= 500) return "server_error";
+  return "invalid_request_error";
+}
+
 function dataFrame(payload: Rec | "[DONE]"): string {
   if (payload === "[DONE]") return "data: [DONE]\n\n";
   return `data: ${JSON.stringify(payload)}\n\n`;
@@ -101,7 +137,11 @@ export function responsesSseToChatCompletionsSse(
 
   return new ReadableStream<Uint8Array>({
     start(controller) {
-      const emit = (payload: Rec | "[DONE]") => controller.enqueue(encoder.encode(dataFrame(payload)));
+      let failed = false;
+      const emit = (payload: Rec | "[DONE]") => {
+        if (failed) return;
+        controller.enqueue(encoder.encode(dataFrame(payload)));
+      };
       const ensureRole = () => {
         if (started) return;
         started = true;
@@ -137,13 +177,30 @@ export function responsesSseToChatCompletionsSse(
       const fail = (message: string) => {
         if (terminated) return;
         terminated = true;
-        ensureRole();
-        // Mid-stream error as a final frame with finish_reason stop, then DONE.
-        // Clients that only parse deltas still terminate cleanly.
-        const frame = chunkBase(id, model, created);
-        frame.choices = [{ index: 0, delta: { content: `\n\n[error] ${message}` }, finish_reason: "stop" }];
-        emit(frame);
-        emit("[DONE]");
+        failed = true;
+        // OpenAI-compatible clients need a real error event, not a success completion
+        // that embeds `[error] ...` text followed by a clean [DONE].
+        // Deliver the error frame then close the stream abnormally (no [DONE]).
+        // Do not controller.error() — that can drop already-enqueued bytes from consumers
+        // like response.text().
+        const status = streamErrorStatus(message);
+        const type = streamErrorType(status);
+        try {
+          controller.enqueue(encoder.encode(dataFrame({
+            error: {
+              message,
+              type,
+              param: null,
+              code: status === 401 ? "invalid_api_key"
+                : status === 404 ? "model_not_found"
+                : status === 429 ? "rate_limit_exceeded"
+                : null,
+            },
+          })));
+        } catch {
+          /* controller may already be closed */
+        }
+        try { controller.close(); } catch { /* already closed */ }
       };
 
       const handleFrame = (eventName: string, data: Rec) => {
@@ -220,22 +277,34 @@ export function responsesSseToChatCompletionsSse(
               const args = typeof item.arguments === "string" ? item.arguments : "";
               if (!callId) break;
               let toolIndex = toolIndexByCallId.get(callId);
-              if (toolIndex === undefined) {
-                // No prior added event — emit a complete tool call chunk.
+              const isNew = toolIndex === undefined;
+              if (isNew) {
+                // No prior added event — register and emit a complete tool call chunk.
                 toolIndex = nextToolIndex++;
                 toolIndexByCallId.set(callId, toolIndex);
+              }
+              if (typeof item.id === "string") toolIndexByItemId.set(item.id, toolIndex);
+              // Last-write-wins: the done-frame snapshot is authoritative final arguments.
+              // Emit a final arguments snapshot so clients that only saw partial deltas
+              // (or no deltas) still get the correct tool call payload.
+              if (args.length > 0 || isNew) {
                 ensureRole();
+                const toolCall: Rec = {
+                  index: toolIndex,
+                  function: { arguments: args },
+                };
+                if (isNew) {
+                  toolCall.id = callId;
+                  toolCall.type = "function";
+                  (toolCall.function as Rec).name = name;
+                } else if (name) {
+                  // Some providers only put the final name on the done frame.
+                  (toolCall.function as Rec).name = name;
+                }
                 const frame = chunkBase(id, model, created);
                 frame.choices = [{
                   index: 0,
-                  delta: {
-                    tool_calls: [{
-                      index: toolIndex,
-                      id: callId,
-                      type: "function",
-                      function: { name, arguments: args },
-                    }],
-                  },
+                  delta: { tool_calls: [toolCall] },
                   finish_reason: null,
                 }];
                 emit(frame);
@@ -294,14 +363,15 @@ export function responsesSseToChatCompletionsSse(
               handleFrame(eventName, data);
             }
           }
-          if (!cancelled && !terminated) {
-            fail("upstream stream ended before a terminal frame (truncated response)");
-          }
         } catch (err) {
           fail(err instanceof Error ? err.message : String(err));
         } finally {
           reader?.releaseLock();
-          if (!cancelled) {
+          if (!cancelled && !terminated) {
+            fail("upstream stream ended before a terminal frame (truncated response)");
+          }
+          // Success path: close after [DONE]. Failure path closes inside fail().
+          if (!cancelled && terminated && !failed) {
             try { controller.close(); } catch { /* already closed */ }
           }
         }
@@ -395,10 +465,18 @@ export async function collectChatCompletion(
   const toolCalls = new Map<number, { id: string; name: string; arguments: string }>();
   let finishReason = "stop";
   let usage: unknown;
+  let streamError: ChatCompletionsStreamError | null = null;
   const reader = stream.getReader();
   try {
     for (;;) {
-      const { done, value } = await reader.read();
+      let readResult: ReadableStreamReadResult<Uint8Array>;
+      try {
+        readResult = await reader.read();
+      } catch (err) {
+        if (isChatCompletionsStreamError(err)) throw err;
+        throw new ChatCompletionsStreamError(err instanceof Error ? err.message : String(err));
+      }
+      const { done, value } = readResult;
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
       let sep: number;
@@ -412,6 +490,15 @@ export async function collectChatCompletion(
           let parsed: unknown;
           try { parsed = JSON.parse(data); } catch { continue; }
           if (!isRec(parsed)) continue;
+          if (isRec(parsed.error)) {
+            const message = typeof parsed.error.message === "string"
+              ? parsed.error.message
+              : "upstream request failed";
+            const type = typeof parsed.error.type === "string" ? parsed.error.type : "server_error";
+            const status = streamErrorStatus(message);
+            streamError = new ChatCompletionsStreamError(message, { status, type });
+            continue;
+          }
           if (parsed.usage) usage = parsed.usage;
           const choices = Array.isArray(parsed.choices) ? parsed.choices : [];
           const choice = isRec(choices[0]) ? choices[0] : null;
@@ -428,8 +515,15 @@ export async function collectChatCompletion(
               const current = toolCalls.get(index) ?? { id: "", name: "", arguments: "" };
               if (typeof tc.id === "string") current.id = tc.id;
               const fn = isRec(tc.function) ? tc.function : {};
-              if (typeof fn.name === "string") current.name += fn.name;
-              if (typeof fn.arguments === "string") current.arguments += fn.arguments;
+              // Done-frame final arguments are authoritative last-write-wins snapshots.
+              if (typeof fn.name === "string" && fn.name.length > 0) current.name = fn.name;
+              if (typeof fn.arguments === "string") {
+                if (fn.arguments.startsWith("{") || fn.arguments.startsWith("[") || current.arguments.length === 0) {
+                  current.arguments = fn.arguments;
+                } else {
+                  current.arguments += fn.arguments;
+                }
+              }
               toolCalls.set(index, current);
             }
           }
@@ -439,6 +533,7 @@ export async function collectChatCompletion(
   } finally {
     reader.releaseLock();
   }
+  if (streamError) throw streamError;
 
   const message: Rec = {
     role: "assistant",

--- a/src/chat/outbound.ts
+++ b/src/chat/outbound.ts
@@ -285,13 +285,10 @@ export function responsesSseToChatCompletionsSse(
               const name = typeof item.name === "string" ? item.name : "";
               const args = typeof item.arguments === "string" ? item.arguments : "";
               if (!callId) break;
-              let toolIndex = toolIndexByCallId.get(callId);
-              const isNew = toolIndex === undefined;
-              if (isNew) {
-                // No prior added event — register and emit a complete tool call chunk.
-                toolIndex = nextToolIndex++;
-                toolIndexByCallId.set(callId, toolIndex);
-              }
+              const existingIndex = toolIndexByCallId.get(callId);
+              const isNew = existingIndex === undefined;
+              const toolIndex = existingIndex ?? nextToolIndex++;
+              if (isNew) toolIndexByCallId.set(callId, toolIndex);
               if (typeof item.id === "string") toolIndexByItemId.set(item.id, toolIndex);
               if (name) toolNameByIndex.set(toolIndex, name);
               const finalName = name || toolNameByIndex.get(toolIndex) || "";
@@ -474,15 +471,16 @@ export async function collectChatCompletion(
   const reader = stream.getReader();
   try {
     for (;;) {
-      let readResult: ReadableStreamReadResult<Uint8Array>;
+      let done = false;
+      let value: Uint8Array | undefined;
       try {
-        readResult = await reader.read();
+        ({ done, value } = await reader.read());
       } catch (err) {
         if (isChatCompletionsStreamError(err)) throw err;
         throw new ChatCompletionsStreamError(err instanceof Error ? err.message : String(err));
       }
-      const { done, value } = readResult;
       if (done) break;
+      if (!value) continue;
       buffer += decoder.decode(value, { stream: true });
       let sep: number;
       while ((sep = buffer.indexOf("\n\n")) !== -1) {

--- a/src/server/chat-completions.ts
+++ b/src/server/chat-completions.ts
@@ -17,7 +17,13 @@ import { estimateTokens } from "../lib/token-estimate";
 import { routeModel } from "../router";
 import type { OcxConfig } from "../types";
 import { readJsonRequestBody } from "./request-decompress";
-import { addFinalRequestLog, type RequestLogContext } from "./request-log";
+import {
+  addFinalRequestLog,
+  httpStatusForTerminalStatus,
+  recordFirstOutput,
+  type RequestLogContext,
+  type RequestLogEntry,
+} from "./request-log";
 import { responseWithDeferredRequestLog } from "./relay";
 import { handleResponses } from "./responses";
 
@@ -58,7 +64,8 @@ export async function handleChatCompletions(
   // for non-streaming clients.
   internalBody.stream = true;
 
-  let _nativeRoute = false;
+  let nativeRoute = false;
+  let directRoute = false;
   try {
     const route = routeModel(config, internalBody.model as string);
     logCtx.model = route.modelId;
@@ -66,7 +73,8 @@ export async function handleChatCompletions(
     logCtx.requestedModel = requestedModel;
     logCtx.provider = route.providerName;
     if (route.provider.adapter === "openai-responses") {
-      _nativeRoute = true;
+      nativeRoute = true;
+      directRoute = route.codexAccountMode === "direct";
       // ChatGPT backend rejects store:true and unsupported sampling knobs.
       internalBody.store = false;
       delete internalBody.max_output_tokens;
@@ -76,6 +84,10 @@ export async function handleChatCompletions(
       delete internalBody.user;
     } else if (internalBody.store === undefined) {
       internalBody.store = false;
+    }
+    if (route.provider.adapter === "openai-chat" && internalBody.text !== undefined) {
+      if (logIds) addFinalRequestLog(logIds.requestId, logIds.start, logCtx, 400, { closeReason: "non_stream" });
+      return chatCompletionsErrorResponse(400, "response_format is not supported for routed openai-chat models");
     }
     if (route.provider.adapter === "cursor" || route.provider.adapter === "kiro") {
       const raw = chatBody as Rec;
@@ -92,16 +104,16 @@ export async function handleChatCompletions(
   } catch {
     /* unknown model: let handleResponses shape the 404 */
   }
-  void _nativeRoute;
+  void nativeRoute;
 
   const headers = new Headers({ "content-type": "application/json" });
   for (const name of FORWARD_HEADERS) {
-    if (name === "authorization") continue;
+    if (name === "authorization" && !directRoute) continue;
     const value = req.headers.get(name);
     if (value) headers.set(name, value);
   }
   // Prefer main ChatGPT auth so OpenAI-backed sidecars remain reachable on routed turns.
-  try {
+  if (!directRoute) try {
     const { getMainAccountToken } = await import("../codex/main-account");
     const token = getMainAccountToken();
     if (token) {
@@ -118,8 +130,17 @@ export async function handleChatCompletions(
     body: JSON.stringify(internalBody),
   });
 
+  let nativeLogged = false;
+  const finalizeNativeLog = (status: number, meta: { terminalStatus?: RequestLogEntry["terminalStatus"]; closeReason: "terminal" | "client_cancel" }) => {
+    if (!logIds || nativeLogged) return;
+    nativeLogged = true;
+    addFinalRequestLog(logIds.requestId, logIds.start, logCtx, status, meta);
+  };
   const upstream = await handleResponses(internalReq, config, logCtx, {
     abortSignal: req.signal,
+    ...(logIds ? { onFirstOutput: () => recordFirstOutput(logCtx, logIds.start) } : {}),
+    onNativePassthroughTerminal: status => finalizeNativeLog(httpStatusForTerminalStatus(status), { terminalStatus: status, closeReason: "terminal" }),
+    onNativePassthroughCancel: () => finalizeNativeLog(499, { closeReason: "client_cancel" }),
   });
   const response = logIds
     ? responseWithDeferredRequestLog(upstream, logIds.requestId, logIds.start, logCtx)
@@ -222,5 +243,4 @@ export async function handleChatCompletions(
     },
   });
 }
-
 

--- a/src/server/chat-completions.ts
+++ b/src/server/chat-completions.ts
@@ -1,0 +1,226 @@
+/**
+ * OpenAI Chat Completions inbound (/v1/chat/completions) for GitHub Copilot App
+ * and other OpenAI-compatible clients.
+ *
+ * Translate-and-replay: Chat Completions body -> /v1/responses via handleResponses,
+ * then bridge the Responses output back to Chat Completions SSE/JSON.
+ */
+import { FORWARD_HEADERS } from "../adapters/openai-responses";
+import { ChatCompletionsRequestError, chatCompletionsToResponsesBody } from "../chat/inbound";
+import {
+  chatCompletionsErrorResponse,
+  collectChatCompletion,
+  responsesJsonToChatCompletion,
+  responsesSseToChatCompletionsSse,
+} from "../chat/outbound";
+import { estimateTokens } from "../lib/token-estimate";
+import { routeModel } from "../router";
+import type { OcxConfig } from "../types";
+import { readJsonRequestBody } from "./request-decompress";
+import { addFinalRequestLog, type RequestLogContext } from "./request-log";
+import { responseWithDeferredRequestLog } from "./relay";
+import { handleResponses } from "./responses";
+
+type Rec = Record<string, unknown>;
+
+function isRec(v: unknown): v is Rec {
+  return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
+async function readChatBody(req: Request): Promise<unknown> {
+  try {
+    return await readJsonRequestBody(req);
+  } catch (err) {
+    throw new ChatCompletionsRequestError(err instanceof Error && err.message ? err.message : "Invalid JSON body");
+  }
+}
+
+export async function handleChatCompletions(
+  req: Request,
+  config: OcxConfig,
+  logCtx: RequestLogContext,
+  logIds?: { requestId: string; start: number },
+): Promise<Response> {
+  let chatBody: unknown;
+  let internalBody: Rec;
+  try {
+    chatBody = await readChatBody(req);
+    internalBody = chatCompletionsToResponsesBody(chatBody);
+  } catch (err) {
+    const status = err instanceof ChatCompletionsRequestError ? 400 : 500;
+    if (logIds) addFinalRequestLog(logIds.requestId, logIds.start, logCtx, status, { closeReason: "non_stream" });
+    return chatCompletionsErrorResponse(status, err instanceof Error ? err.message : String(err));
+  }
+
+  const requestedModel = (chatBody as Rec).model as string;
+  const stream = internalBody.stream === true;
+  // Routed adapters only support streamed turns; always stream internally and fold
+  // for non-streaming clients.
+  internalBody.stream = true;
+
+  let _nativeRoute = false;
+  try {
+    const route = routeModel(config, internalBody.model as string);
+    logCtx.model = route.modelId;
+    logCtx.providerAdapter = route.provider.adapter;
+    logCtx.requestedModel = requestedModel;
+    logCtx.provider = route.providerName;
+    if (route.provider.adapter === "openai-responses") {
+      _nativeRoute = true;
+      // ChatGPT backend rejects store:true and unsupported sampling knobs.
+      internalBody.store = false;
+      delete internalBody.max_output_tokens;
+      delete internalBody.temperature;
+      delete internalBody.top_p;
+      delete internalBody.stop;
+      delete internalBody.user;
+    } else if (internalBody.store === undefined) {
+      internalBody.store = false;
+    }
+    if (route.provider.adapter === "cursor" || route.provider.adapter === "kiro") {
+      const raw = chatBody as Rec;
+      const parts: string[] = [];
+      if (raw.messages !== undefined) parts.push(JSON.stringify(raw.messages));
+      if (raw.tools !== undefined) parts.push(JSON.stringify(raw.tools));
+      logCtx.usageLogInputTokens = Math.max(1, estimateTokens(parts.join("\n"), requestedModel));
+    }
+    if (internalBody.reasoning !== undefined) {
+      const { supportedLadderFor } = await import("./effort-policy");
+      const ladder = supportedLadderFor({ provider: route.provider, modelId: route.modelId });
+      if (ladder !== undefined && ladder.length === 0) delete internalBody.reasoning;
+    }
+  } catch {
+    /* unknown model: let handleResponses shape the 404 */
+  }
+  void _nativeRoute;
+
+  const headers = new Headers({ "content-type": "application/json" });
+  for (const name of FORWARD_HEADERS) {
+    if (name === "authorization") continue;
+    const value = req.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+  // Prefer main ChatGPT auth so OpenAI-backed sidecars remain reachable on routed turns.
+  try {
+    const { getMainAccountToken } = await import("../codex/main-account");
+    const token = getMainAccountToken();
+    if (token) {
+      headers.set("authorization", `Bearer ${token.accessToken}`);
+      headers.set("chatgpt-account-id", token.chatgptAccountId);
+    }
+  } catch {
+    /* optional */
+  }
+
+  const internalReq = new Request("http://localhost/v1/responses", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(internalBody),
+  });
+
+  const upstream = await handleResponses(internalReq, config, logCtx, {
+    abortSignal: req.signal,
+  });
+  const response = logIds
+    ? responseWithDeferredRequestLog(upstream, logIds.requestId, logIds.start, logCtx)
+    : upstream;
+
+  if (!response.ok) {
+    let message = `upstream error (${response.status})`;
+    try {
+      const text = await response.text();
+      try {
+        const parsed = JSON.parse(text) as { error?: { message?: string; type?: string } | string; message?: string };
+        const nested = typeof parsed?.error === "object" && parsed.error ? parsed.error.message : undefined;
+        const flat = typeof parsed?.error === "string" ? parsed.error : parsed?.message;
+        message = nested || flat || (text ? `upstream error (${response.status}): ${text.slice(0, 400)}` : message);
+      } catch {
+        if (text) message = `upstream error (${response.status}): ${text.slice(0, 400)}`;
+      }
+    } catch { /* keep fallback */ }
+    const retryAfter = response.headers.get("retry-after");
+    return new Response(JSON.stringify({
+      error: {
+        message,
+        type: response.status === 401 ? "authentication_error"
+          : response.status === 429 ? "rate_limit_error"
+          : response.status >= 500 ? "server_error"
+          : "invalid_request_error",
+        param: null,
+        code: null,
+      },
+    }), {
+      status: response.status,
+      headers: {
+        "Content-Type": "application/json",
+        ...(retryAfter ? { "Retry-After": retryAfter } : {}),
+      },
+    });
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("text/event-stream") && response.body) {
+    const chatSse = responsesSseToChatCompletionsSse(response.body, requestedModel);
+    if (stream) {
+      return new Response(chatSse, {
+        status: 200,
+        headers: {
+          "Content-Type": "text/event-stream; charset=utf-8",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        },
+      });
+    }
+    const completion = await collectChatCompletion(chatSse, requestedModel);
+    return new Response(JSON.stringify(completion), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // Defensive: JSON despite stream:true.
+  let json: unknown;
+  try {
+    json = await response.json();
+  } catch {
+    return chatCompletionsErrorResponse(502, "internal replay returned a non-JSON response", "server_error");
+  }
+  const status = (json as Rec)?.status;
+  if (status === "failed") {
+    const error = (json as { error?: { message?: string } }).error;
+    return chatCompletionsErrorResponse(502, error?.message ?? "upstream request failed", "server_error");
+  }
+  const completion = responsesJsonToChatCompletion(json, requestedModel);
+  if (!stream) {
+    return new Response(JSON.stringify(completion), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // Streaming client + JSON upstream: synthesize a minimal Chat Completions stream.
+  const encoder = new TextEncoder();
+  const id = typeof completion.id === "string" ? completion.id : `chatcmpl-${Date.now()}`;
+  const created = typeof completion.created === "number" ? completion.created : Math.floor(Date.now() / 1000);
+  const message = isRec((completion.choices as Rec[] | undefined)?.[0])
+    ? ((completion.choices as Rec[])[0] as Rec).message as Rec | undefined
+    : undefined;
+  const content = message && typeof message.content === "string" ? message.content : "";
+  const frames = [
+    `data: ${JSON.stringify({ id, object: "chat.completion.chunk", created, model: requestedModel, choices: [{ index: 0, delta: { role: "assistant", content: "" }, finish_reason: null }] })}\n\n`,
+    ...(content
+      ? [`data: ${JSON.stringify({ id, object: "chat.completion.chunk", created, model: requestedModel, choices: [{ index: 0, delta: { content }, finish_reason: null }] })}\n\n`]
+      : []),
+    `data: ${JSON.stringify({ id, object: "chat.completion.chunk", created, model: requestedModel, choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: completion.usage })}\n\n`,
+    "data: [DONE]\n\n",
+  ];
+  return new Response(encoder.encode(frames.join("")), {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache",
+    },
+  });
+}
+
+

--- a/src/server/chat-completions.ts
+++ b/src/server/chat-completions.ts
@@ -33,7 +33,6 @@ type Rec = Record<string, unknown>;
 function isRec(v: unknown): v is Rec {
   return !!v && typeof v === "object" && !Array.isArray(v);
 }
-
 async function readChatBody(req: Request): Promise<unknown> {
   try {
     return await readJsonRequestBody(req);
@@ -257,4 +256,3 @@ export async function handleChatCompletions(
     },
   });
 }
-

--- a/src/server/chat-completions.ts
+++ b/src/server/chat-completions.ts
@@ -10,6 +10,7 @@ import { ChatCompletionsRequestError, chatCompletionsToResponsesBody } from "../
 import {
   chatCompletionsErrorResponse,
   collectChatCompletion,
+  isChatCompletionsStreamError,
   responsesJsonToChatCompletion,
   responsesSseToChatCompletionsSse,
 } from "../chat/outbound";
@@ -183,6 +184,8 @@ export async function handleChatCompletions(
   if (contentType.includes("text/event-stream") && response.body) {
     const chatSse = responsesSseToChatCompletionsSse(response.body, requestedModel);
     if (stream) {
+      // Stream failures surface as an error SSE frame then abort the body — never a
+      // success completion that embeds `[error] ...` + clean [DONE].
       return new Response(chatSse, {
         status: 200,
         headers: {
@@ -192,11 +195,22 @@ export async function handleChatCompletions(
         },
       });
     }
-    const completion = await collectChatCompletion(chatSse, requestedModel);
-    return new Response(JSON.stringify(completion), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    });
+    try {
+      const completion = await collectChatCompletion(chatSse, requestedModel);
+      return new Response(JSON.stringify(completion), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    } catch (err) {
+      if (isChatCompletionsStreamError(err)) {
+        return chatCompletionsErrorResponse(err.status, err.message, err.type);
+      }
+      return chatCompletionsErrorResponse(
+        502,
+        err instanceof Error ? err.message : String(err),
+        "server_error",
+      );
+    }
   }
 
   // Defensive: JSON despite stream:true.

--- a/src/server/gui-static.ts
+++ b/src/server/gui-static.ts
@@ -92,6 +92,7 @@ export function rootFallbackPayload() {
       health: "/healthz",
       models: "/v1/models",
       responses: "/v1/responses",
+      chatCompletions: "/v1/chat/completions",
       management: "/api/*",
     },
   };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -249,7 +249,7 @@ export function startServer(port?: number) {
       }
 
       if (url.pathname === "/v1/models" && req.method === "GET") {
-        const apiAuthError = requireApiAuth(req, config, "data-plane");
+        const apiAuthError = requireResponsesApiAuth(req, config);
         if (apiAuthError) return withCors(apiAuthError, req, config);
         if (!isAllowedRequestOrigin(req, config)) {
           return withCors(formatErrorResponse(403, "origin_rejected", "cross-origin data-plane request blocked"), req, config);
@@ -475,7 +475,7 @@ export function startServer(port?: number) {
         if (isDraining()) {
           return new Response("Service shutting down", { status: 503, headers: { ...corsHeaders(req, config), "Retry-After": "5" } });
         }
-        const apiAuthError = requireApiAuth(req, config, "data-plane");
+        const apiAuthError = requireResponsesApiAuth(req, config);
         if (apiAuthError) return withCors(apiAuthError, req, config);
         if (!isAllowedRequestOrigin(req, config)) {
           return withCors(formatErrorResponse(403, "origin_rejected", "cross-origin data-plane request blocked"), req, config);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -117,6 +117,7 @@ export {
 import { disableResponsesRequestTimeout, handleResponses, handleResponsesCompact } from "./responses";
 export { disableResponsesRequestTimeout, linkAbortSignal } from "./responses";
 import { handleClaudeCountTokens, handleClaudeMessages } from "./claude-messages";
+import { handleChatCompletions } from "./chat-completions";
 import { anthropicErrorResponse } from "../claude/outbound";
 import { buildDesktop3pRegistry } from "../claude/desktop-3p";
 import { handleImages } from "./images";
@@ -467,6 +468,25 @@ export function startServer(port?: number) {
         return withCors(response, req, config);
       }
 
+
+      // OpenAI Chat Completions inbound (GitHub Copilot App / OpenAI-compatible clients).
+      if (url.pathname === "/v1/chat/completions" && req.method === "POST") {
+        disableResponsesRequestTimeout(req, requestServer);
+        if (isDraining()) {
+          return new Response("Service shutting down", { status: 503, headers: { ...corsHeaders(req, config), "Retry-After": "5" } });
+        }
+        const apiAuthError = requireApiAuth(req, config, "data-plane");
+        if (apiAuthError) return withCors(apiAuthError, req, config);
+        if (!isAllowedRequestOrigin(req, config)) {
+          return withCors(formatErrorResponse(403, "origin_rejected", "cross-origin data-plane request blocked"), req, config);
+        }
+        const start = Date.now();
+        const requestId = nextRequestLogId(start);
+        const logCtx: RequestLogContext = { model: "unknown", provider: "unknown" };
+        const response = await handleChatCompletions(req, config, logCtx, { requestId, start });
+        return withCors(response, req, config);
+      }
+
       // Data-plane guard: unknown /v1/* paths must fail with JSON 404, never fall through to the
       // GUI static handler (extensionless paths would get index.html with HTTP 200 and codex-rs
       // endpoint clients — memories/*, realtime/* — would surface confusing
@@ -620,6 +640,7 @@ export function startServer(port?: number) {
 
   console.log(`🚀 opencodex proxy running on http://localhost:${actualPort}`);
   console.log(`   POST /v1/responses → provider translation`);
+  console.log(`   POST /v1/chat/completions → OpenAI-compatible clients`);
   console.log(`   GET  /healthz      → health check`);
   console.log(`   GET  /api/*        → management API`);
   console.log(`   GET  /             → GUI dashboard`);

--- a/tests/chat-completions-endpoint.test.ts
+++ b/tests/chat-completions-endpoint.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { saveConfig } from "../src/config";
+import { startServer } from "../src/server";
+import type { OcxConfig } from "../src/types";
+import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+import { chatCompletionsToResponsesBody, ChatCompletionsRequestError } from "../src/chat/inbound";
+
+let testDir = "";
+let previousHome: string | undefined;
+let isolatedCodexHome: IsolatedCodexHome | null = null;
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  previousHome = process.env.OPENCODEX_HOME;
+  isolatedCodexHome = installIsolatedCodexHome("ocx-chat-completions-");
+  testDir = mkdtempSync(join(tmpdir(), "ocx-chat-completions-"));
+  process.env.OPENCODEX_HOME = testDir;
+  globalThis.fetch = originalFetch;
+});
+
+afterEach(() => {
+  if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = previousHome;
+  isolatedCodexHome?.restore();
+  isolatedCodexHome = null;
+  globalThis.fetch = originalFetch;
+  if (testDir) rmSync(testDir, { recursive: true, force: true });
+});
+
+function mockChatUpstream() {
+  return mockChatUpstreamCapturing().server;
+}
+
+function mockChatUpstreamCapturing() {
+  const captured: Array<Record<string, unknown>> = [];
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (!url.pathname.endsWith("/chat/completions")) {
+        return Response.json({ error: { message: `unexpected path ${url.pathname}` } }, { status: 404 });
+      }
+      try { captured.push(await req.json() as Record<string, unknown>); } catch { /* keep streaming */ }
+      const frames = [
+        `data: ${JSON.stringify({ choices: [{ index: 0, delta: { role: "assistant", content: "Hello" } }] })}\n\n`,
+        `data: ${JSON.stringify({ choices: [{ index: 0, delta: { content: " from mock" } }] })}\n\n`,
+        `data: ${JSON.stringify({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 12, completion_tokens: 3 } })}\n\n`,
+        "data: [DONE]\n\n",
+      ];
+      return new Response(frames.join(""), { headers: { "Content-Type": "text/event-stream" } });
+    },
+  });
+  return { server, captured };
+}
+
+function mockConfig(baseUrl: string): OcxConfig {
+  return {
+    port: 0,
+    defaultProvider: "mock",
+    providers: {
+      mock: { adapter: "openai-chat", baseUrl, apiKey: "k", allowPrivateNetwork: true },
+    },
+  } as OcxConfig;
+}
+
+test("chatCompletionsToResponsesBody maps messages/tools/system", () => {
+  const body = chatCompletionsToResponsesBody({
+    model: "mock/test-model",
+    stream: true,
+    messages: [
+      { role: "system", content: "be brief" },
+      { role: "user", content: "hi" },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [{ id: "call_1", type: "function", function: { name: "lookup", arguments: "{\"q\":\"x\"}" } }],
+      },
+      { role: "tool", tool_call_id: "call_1", content: "result" },
+    ],
+    tools: [{
+      type: "function",
+      function: {
+        name: "lookup",
+        description: "look up",
+        parameters: { type: "object", properties: { q: { type: "string" } } },
+      },
+    }],
+    tool_choice: "auto",
+    max_tokens: 64,
+    reasoning_effort: "high",
+  });
+  expect(body.model).toBe("mock/test-model");
+  expect(body.stream).toBe(true);
+  expect(body.instructions).toBe("be brief");
+  expect(body.max_output_tokens).toBe(64);
+  expect(body.reasoning).toEqual({ effort: "high" });
+  expect(body.tool_choice).toBe("auto");
+  expect(Array.isArray(body.tools)).toBe(true);
+  expect((body.tools as Array<Record<string, unknown>>)[0]).toMatchObject({ type: "function", name: "lookup" });
+  const input = body.input as Array<Record<string, unknown>>;
+  expect(input.some(i => i.type === "message" && i.role === "user")).toBe(true);
+  expect(input.some(i => i.type === "function_call" && i.call_id === "call_1")).toBe(true);
+  expect(input.some(i => i.type === "function_call_output" && i.call_id === "call_1")).toBe(true);
+});
+
+test("chatCompletionsToResponsesBody rejects missing model", () => {
+  expect(() => chatCompletionsToResponsesBody({ messages: [{ role: "user", content: "x" }] }))
+    .toThrow(ChatCompletionsRequestError);
+});
+
+test("POST /v1/chat/completions streams OpenAI-shaped chunks end to end", async () => {
+  const upstream = mockChatUpstream();
+  saveConfig(mockConfig(`${upstream.url.toString().replace(/\/$/, "")}/v1`));
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/chat/completions", server.url), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "mock/test-model",
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type") ?? "").toContain("text/event-stream");
+    const text = await response.text();
+    expect(text).toContain("chat.completion.chunk");
+    expect(text).toContain("Hello");
+    expect(text).toContain("from mock");
+    expect(text).toContain("data: [DONE]");
+    expect(text).toContain("\"finish_reason\":\"stop\"");
+  } finally {
+    server.stop(true);
+    upstream.stop(true);
+  }
+});
+
+test("non-streaming /v1/chat/completions returns chat.completion JSON", async () => {
+  const upstream = mockChatUpstream();
+  saveConfig(mockConfig(`${upstream.url.toString().replace(/\/$/, "")}/v1`));
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/chat/completions", server.url), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "mock/test-model",
+        stream: false,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(response.status).toBe(200);
+    const json = await response.json() as {
+      object: string;
+      model: string;
+      choices: Array<{ message: { role: string; content: string | null }; finish_reason: string }>;
+    };
+    expect(json.object).toBe("chat.completion");
+    expect(json.model).toBe("mock/test-model");
+    expect(json.choices[0]?.message.role).toBe("assistant");
+    expect(json.choices[0]?.message.content).toContain("Hello");
+    expect(json.choices[0]?.finish_reason).toBe("stop");
+  } finally {
+    server.stop(true);
+    upstream.stop(true);
+  }
+});
+
+test("GET /v1/models returns OpenAI list shape for Copilot App discovery", async () => {
+  const upstream = mockChatUpstream();
+  saveConfig(mockConfig(`${upstream.url.toString().replace(/\/$/, "")}/v1`));
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/models", server.url));
+    expect(response.status).toBe(200);
+    const json = await response.json() as { object: string; data: Array<{ id: string; object: string }> };
+    expect(json.object).toBe("list");
+    expect(Array.isArray(json.data)).toBe(true);
+    // Routed mock model may or may not appear depending on liveModels; list shape is the contract.
+    expect(json.data.every(m => m.object === "model" && typeof m.id === "string")).toBe(true);
+  } finally {
+    server.stop(true);
+    upstream.stop(true);
+  }
+});
+
+test("invalid chat completions body returns OpenAI-style 400", async () => {
+  const upstream = mockChatUpstream();
+  saveConfig(mockConfig(`${upstream.url.toString().replace(/\/$/, "")}/v1`));
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/chat/completions", server.url), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ messages: [] }),
+    });
+    expect(response.status).toBe(400);
+    const json = await response.json() as { error: { message: string; type: string } };
+    expect(json.error.message).toContain("model");
+    expect(json.error.type).toBe("invalid_request_error");
+  } finally {
+    server.stop(true);
+    upstream.stop(true);
+  }
+});

--- a/tests/chat-completions-endpoint.test.ts
+++ b/tests/chat-completions-endpoint.test.ts
@@ -207,3 +207,202 @@ test("invalid chat completions body returns OpenAI-style 400", async () => {
     upstream.stop(true);
   }
 });
+
+
+test("chatCompletionsToResponsesBody maps response_format and rejects unknown types", () => {
+  const jsonObject = chatCompletionsToResponsesBody({
+    model: "mock/test-model",
+    messages: [{ role: "user", content: "hi" }],
+    response_format: { type: "json_object" },
+  });
+  expect(jsonObject.text).toEqual({ format: { type: "json_object" } });
+
+  expect(() => chatCompletionsToResponsesBody({
+    model: "mock/test-model",
+    messages: [{ role: "user", content: "hi" }],
+    response_format: { type: "xml" },
+  })).toThrow(ChatCompletionsRequestError);
+});
+
+test("responsesSseToChatCompletionsSse routes parallel tool argument deltas by item_id", async () => {
+  const { responsesSseToChatCompletionsSse } = await import("../src/chat/outbound");
+  const frames = [
+    `event: response.output_item.added\ndata: ${JSON.stringify({ type: "response.output_item.added", output_index: 0, item: { type: "function_call", id: "fc_a", call_id: "call_a", name: "alpha", arguments: "" } })}\n\n`,
+    `event: response.output_item.added\ndata: ${JSON.stringify({ type: "response.output_item.added", output_index: 1, item: { type: "function_call", id: "fc_b", call_id: "call_b", name: "beta", arguments: "" } })}\n\n`,
+    `event: response.function_call_arguments.delta\ndata: ${JSON.stringify({ type: "response.function_call_arguments.delta", item_id: "fc_a", delta: '{"a":' })}\n\n`,
+    `event: response.function_call_arguments.delta\ndata: ${JSON.stringify({ type: "response.function_call_arguments.delta", item_id: "fc_b", delta: '{"b":' })}\n\n`,
+    `event: response.function_call_arguments.delta\ndata: ${JSON.stringify({ type: "response.function_call_arguments.delta", item_id: "fc_a", delta: "1}" })}\n\n`,
+    `event: response.completed\ndata: ${JSON.stringify({ type: "response.completed", response: { status: "completed", usage: { input_tokens: 1, output_tokens: 1 } } })}\n\n`,
+  ];
+  const stream = responsesSseToChatCompletionsSse(new ReadableStream({
+    start(controller) {
+      const enc = new TextEncoder();
+      for (const frame of frames) controller.enqueue(enc.encode(frame));
+      controller.close();
+    },
+  }), "mock/test-model");
+  const text = await new Response(stream).text();
+  const chunks = text.split("\n\n")
+    .map(block => block.trim())
+    .filter(block => block.startsWith("data: ") && !block.includes("[DONE]"))
+    .map(block => JSON.parse(block.slice(6)) as {
+      choices?: Array<{ delta?: { tool_calls?: Array<{ index?: number; function?: { arguments?: string } }> } }>;
+    });
+  const argDeltas = chunks.flatMap(chunk => chunk.choices?.[0]?.delta?.tool_calls ?? [])
+    .filter(tc => typeof tc.function?.arguments === "string" && tc.function.arguments.length > 0);
+  expect(argDeltas.map(tc => ({ index: tc.index, arguments: tc.function?.arguments }))).toEqual([
+    { index: 0, arguments: '{"a":' },
+    { index: 1, arguments: '{"b":' },
+    { index: 0, arguments: "1}" },
+  ]);
+});
+
+test("POST /v1/chat/completions rejects response_format for routed openai-chat", async () => {
+  const upstream = mockChatUpstream();
+  saveConfig(mockConfig(`${upstream.url.toString().replace(/\/$/, "")}/v1`));
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/chat/completions", server.url), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "mock/test-model",
+        stream: false,
+        messages: [{ role: "user", content: "hi" }],
+        response_format: { type: "json_object" },
+      }),
+    });
+    expect(response.status).toBe(400);
+    const json = await response.json() as { error: { message: string; type: string } };
+    expect(json.error.message).toContain("response_format");
+    expect(json.error.type).toBe("invalid_request_error");
+  } finally {
+    server.stop(true);
+    upstream.stop(true);
+  }
+});
+
+test("POST /v1/chat/completions direct mode forwards caller Authorization", async () => {
+  const seen: Array<{ authorization: string | null }> = [];
+  const upstream = Bun.serve({
+    port: 0,
+    fetch(req) {
+      seen.push({ authorization: req.headers.get("authorization") });
+      return Response.json({
+        id: "resp_direct",
+        object: "response",
+        status: "completed",
+        output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "ok" }] }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      });
+    },
+  });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const requestUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const url = new URL(requestUrl);
+    if (url.hostname === "chatgpt.com" && url.pathname.startsWith("/backend-api/codex")) {
+      return originalFetch(new URL(`${url.pathname.slice("/backend-api/codex".length)}${url.search}`, upstream.url), init);
+    }
+    return originalFetch(input, init);
+  }) as typeof fetch;
+  saveConfig({
+    port: 0,
+    defaultProvider: "openai",
+    providers: {
+      openai: {
+        adapter: "openai-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        authMode: "forward",
+        codexAccountMode: "direct",
+      },
+    },
+  } as OcxConfig);
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/chat/completions", server.url), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: ["Bear" + "er", "caller-direct-token"].join(" "),
+      },
+      body: JSON.stringify({
+        model: "gpt-test",
+        stream: false,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(response.status).toBe(200);
+    expect(seen.some(hit => hit.authorization === ["Bear" + "er", "caller-direct-token"].join(" "))).toBe(true);
+  } finally {
+    server.stop(true);
+    upstream.stop(true);
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("POST /v1/chat/completions finalizes native passthrough request logs", async () => {
+  const { clearRequestLogsForTests, getRequestLogEntries } = await import("../src/server/request-log");
+  clearRequestLogsForTests();
+  const upstream = Bun.serve({
+    port: 0,
+    fetch() {
+      const frames = [
+        `event: response.created\ndata: ${JSON.stringify({ type: "response.created", response: { id: "resp_log" } })}\n\n`,
+        `event: response.output_text.delta\ndata: ${JSON.stringify({ type: "response.output_text.delta", delta: "hi" })}\n\n`,
+        `event: response.completed\ndata: ${JSON.stringify({ type: "response.completed", response: { id: "resp_log", status: "completed", usage: { input_tokens: 3, output_tokens: 2 } } })}\n\n`,
+      ];
+      return new Response(frames.join(""), { headers: { "Content-Type": "text/event-stream" } });
+    },
+  });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const requestUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const url = new URL(requestUrl);
+    if (url.hostname === "chatgpt.com" && url.pathname.startsWith("/backend-api/codex")) {
+      return originalFetch(new URL(`${url.pathname.slice("/backend-api/codex".length)}${url.search}`, upstream.url), init);
+    }
+    return originalFetch(input, init);
+  }) as typeof fetch;
+  saveConfig({
+    port: 0,
+    defaultProvider: "openai",
+    providers: {
+      openai: {
+        adapter: "openai-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        authMode: "forward",
+        codexAccountMode: "direct",
+      },
+    },
+  } as OcxConfig);
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/chat/completions", server.url), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: ["Bear" + "er", "caller-direct-token"].join(" "),
+      },
+      body: JSON.stringify({
+        model: "gpt-test",
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("hi");
+    await Bun.sleep(50);
+    const entry = getRequestLogEntries().findLast(e =>
+      e.path === "/v1/chat/completions" || e.model === "gpt-test" || e.requestedModel === "gpt-test"
+    );
+    expect(entry).toBeTruthy();
+    expect(entry?.status).toBe(200);
+  } finally {
+    server.stop(true);
+    upstream.stop(true);
+    globalThis.fetch = originalFetch;
+    clearRequestLogsForTests();
+  }
+});

--- a/tests/chat-completions-endpoint.test.ts
+++ b/tests/chat-completions-endpoint.test.ts
@@ -609,3 +609,80 @@ test("streaming /v1/chat/completions does not clean-DONE after response.failed",
     globalThis.fetch = originalFetch;
   }
 });
+
+
+test("responsesSseToChatCompletionsSse always re-emits function.name on args/done deltas", async () => {
+  const { responsesSseToChatCompletionsSse, collectChatCompletion } = await import("../src/chat/outbound");
+  const frames = [
+    `event: response.output_item.added\ndata: ${JSON.stringify({ type: "response.output_item.added", item: { type: "function_call", id: "fc_a", call_id: "call_a", name: "exec_command", arguments: "" } })}\n\n`,
+    `event: response.function_call_arguments.delta\ndata: ${JSON.stringify({ type: "response.function_call_arguments.delta", item_id: "fc_a", delta: '{"cmd":' })}\n\n`,
+    `event: response.function_call_arguments.delta\ndata: ${JSON.stringify({ type: "response.function_call_arguments.delta", item_id: "fc_a", delta: '"ls"}' })}\n\n`,
+    `event: response.output_item.done\ndata: ${JSON.stringify({ type: "response.output_item.done", item: { type: "function_call", id: "fc_a", call_id: "call_a", name: "exec_command", arguments: '{"cmd":"ls"}' } })}\n\n`,
+    `event: response.completed\ndata: ${JSON.stringify({ type: "response.completed", response: { status: "completed", usage: { input_tokens: 1, output_tokens: 1 } } })}\n\n`,
+  ];
+  const stream = responsesSseToChatCompletionsSse(new ReadableStream({
+    start(controller) {
+      const enc = new TextEncoder();
+      for (const frame of frames) controller.enqueue(enc.encode(frame));
+      controller.close();
+    },
+  }), "gpt-test");
+  const text = await new Response(stream).text();
+  const chunks = text.split("\n\n")
+    .map(block => block.trim())
+    .filter(block => block.startsWith("data: ") && !block.includes("[DONE]"))
+    .map(block => JSON.parse(block.slice(6)) as {
+      choices?: Array<{ delta?: { tool_calls?: Array<{ function?: { name?: string; arguments?: string } }> } }>;
+    });
+  const toolDeltas = chunks.flatMap(c => c.choices?.[0]?.delta?.tool_calls ?? [])
+    .filter(tc => tc.function && ("arguments" in (tc.function ?? {}) || "name" in (tc.function ?? {})));
+  // Every tool delta that carries arguments must also carry the name for replace-style clients.
+  for (const tc of toolDeltas) {
+    if (typeof tc.function?.arguments === "string") {
+      expect(tc.function?.name).toBe("exec_command");
+    }
+  }
+  // Last-write-wins collect still yields a complete named tool call.
+  const completion = await collectChatCompletion(responsesSseToChatCompletionsSse(new ReadableStream({
+    start(controller) {
+      const enc = new TextEncoder();
+      for (const frame of frames) controller.enqueue(enc.encode(frame));
+      controller.close();
+    },
+  }), "gpt-test"), "gpt-test");
+  const toolCalls = (completion.choices as Array<{ message?: { tool_calls?: Array<{ function?: { name?: string; arguments?: string } }> } }>)[0]
+    ?.message?.tool_calls ?? [];
+  expect(toolCalls[0]?.function?.name).toBe("exec_command");
+  expect(toolCalls[0]?.function?.arguments).toBe('{"cmd":"ls"}');
+});
+
+test("chatCompletionsToResponsesBody recovers tool_calls function.name from earlier call_id", () => {
+  // Simulate replace-style client history: a later assistant tool_call has id+args but empty name,
+  // while an earlier function_call in the same transcript already named it.
+  // Our translator processes messages in order; recovery looks at previously emitted function_calls.
+  // First push a prior named call via a previous assistant message, then a nameless replay.
+  const body = chatCompletionsToResponsesBody({
+    model: "gpt-test",
+    messages: [
+      { role: "user", content: "run ls" },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [{ id: "call_a", type: "function", function: { name: "exec_command", arguments: '{"cmd":"ls"}' } }],
+      },
+      { role: "tool", tool_call_id: "call_a", content: "ok" },
+      {
+        role: "assistant",
+        content: null,
+        // Client lost the name on a re-serialized tool_call with same id (should still recover if same turn
+        // already registered the name earlier in the same tool_calls array / prior items).
+        tool_calls: [
+          { id: "call_b", type: "function", function: { name: "exec_command", arguments: '{"cmd":"pwd"}' } },
+          { id: "call_b", type: "function", function: { arguments: '{"cmd":"pwd"}' } },
+        ],
+      },
+    ],
+  });
+  const calls = (body.input as Array<Record<string, unknown>>).filter(i => i.type === "function_call");
+  expect(calls.some(c => c.call_id === "call_b" && c.name === "exec_command")).toBe(true);
+});

--- a/tests/chat-completions-endpoint.test.ts
+++ b/tests/chat-completions-endpoint.test.ts
@@ -406,3 +406,206 @@ test("POST /v1/chat/completions finalizes native passthrough request logs", asyn
     clearRequestLogsForTests();
   }
 });
+
+
+test("responsesSseToChatCompletionsSse reconciles done-frame final arguments (last-write-wins)", async () => {
+  const { responsesSseToChatCompletionsSse, collectChatCompletion } = await import("../src/chat/outbound");
+  const frames = [
+    `event: response.output_item.added\ndata: ${JSON.stringify({ type: "response.output_item.added", item: { type: "function_call", id: "fc_a", call_id: "call_a", name: "alpha", arguments: "" } })}\n\n`,
+    `event: response.function_call_arguments.delta\ndata: ${JSON.stringify({ type: "response.function_call_arguments.delta", item_id: "fc_a", delta: '{"q":"partial' })}\n\n`,
+    // Done frame carries the authoritative final arguments after partial deltas.
+    `event: response.output_item.done\ndata: ${JSON.stringify({ type: "response.output_item.done", item: { type: "function_call", id: "fc_a", call_id: "call_a", name: "alpha", arguments: '{"q":"final"}' } })}\n\n`,
+    `event: response.completed\ndata: ${JSON.stringify({ type: "response.completed", response: { status: "completed", usage: { input_tokens: 1, output_tokens: 1 } } })}\n\n`,
+  ];
+  const stream = responsesSseToChatCompletionsSse(new ReadableStream({
+    start(controller) {
+      const enc = new TextEncoder();
+      for (const frame of frames) controller.enqueue(enc.encode(frame));
+      controller.close();
+    },
+  }), "mock/test-model");
+  const completion = await collectChatCompletion(stream, "mock/test-model");
+  const toolCalls = (completion.choices as Array<{ message?: { tool_calls?: Array<{ function?: { arguments?: string } }> } }>)[0]
+    ?.message?.tool_calls ?? [];
+  expect(toolCalls).toHaveLength(1);
+  expect(toolCalls[0]?.function?.arguments).toBe('{"q":"final"}');
+});
+
+test("responsesSseToChatCompletionsSse emits error frame on response.failed (no clean DONE)", async () => {
+  const { responsesSseToChatCompletionsSse, collectChatCompletion, ChatCompletionsStreamError } = await import("../src/chat/outbound");
+  const frames = [
+    `event: response.created\ndata: ${JSON.stringify({ type: "response.created", response: { id: "resp_fail" } })}\n\n`,
+    `event: response.output_text.delta\ndata: ${JSON.stringify({ type: "response.output_text.delta", delta: "partial" })}\n\n`,
+    `event: response.failed\ndata: ${JSON.stringify({ type: "response.failed", response: { status: "failed", error: { message: "upstream exploded" } } })}\n\n`,
+  ];
+  const stream = responsesSseToChatCompletionsSse(new ReadableStream({
+    start(controller) {
+      const enc = new TextEncoder();
+      for (const frame of frames) controller.enqueue(enc.encode(frame));
+      controller.close();
+    },
+  }), "mock/test-model");
+
+  const text = await new Response(stream).text();
+  expect(text).toContain('"error"');
+  expect(text).toContain("upstream exploded");
+  expect(text).not.toContain("[error]");
+  expect(text).not.toContain("data: [DONE]");
+
+  // Non-stream collectors must surface a typed error, not a 200 completion.
+  const stream2 = responsesSseToChatCompletionsSse(new ReadableStream({
+    start(controller) {
+      const enc = new TextEncoder();
+      for (const frame of frames) controller.enqueue(enc.encode(frame));
+      controller.close();
+    },
+  }), "mock/test-model");
+  await expect(collectChatCompletion(stream2, "mock/test-model")).rejects.toBeInstanceOf(ChatCompletionsStreamError);
+});
+
+test("responsesSseToChatCompletionsSse emits error frame on truncated stream", async () => {
+  const { responsesSseToChatCompletionsSse, collectChatCompletion, ChatCompletionsStreamError } = await import("../src/chat/outbound");
+  const frames = [
+    `event: response.created\ndata: ${JSON.stringify({ type: "response.created", response: { id: "resp_trunc" } })}\n\n`,
+    `event: response.output_text.delta\ndata: ${JSON.stringify({ type: "response.output_text.delta", delta: "half" })}\n\n`,
+    // No terminal frame — stream ends abruptly.
+  ];
+  const stream = responsesSseToChatCompletionsSse(new ReadableStream({
+    start(controller) {
+      const enc = new TextEncoder();
+      for (const frame of frames) controller.enqueue(enc.encode(frame));
+      controller.close();
+    },
+  }), "mock/test-model");
+
+  const text = await new Response(stream).text();
+  expect(text).toContain("truncated response");
+  expect(text).not.toContain("data: [DONE]");
+  await expect(collectChatCompletion(responsesSseToChatCompletionsSse(new ReadableStream({
+    start(controller) {
+      const enc = new TextEncoder();
+      for (const frame of frames) controller.enqueue(enc.encode(frame));
+      controller.close();
+    },
+  }), "mock/test-model"), "mock/test-model")).rejects.toBeInstanceOf(ChatCompletionsStreamError);
+});
+
+test("non-streaming /v1/chat/completions returns error status on upstream failure", async () => {
+  // Mock openai-chat upstream that streams a Responses-like failure through our adapter
+  // is hard; instead drive handleResponses via a native responses mock that fails.
+  const upstream = Bun.serve({
+    port: 0,
+    fetch() {
+      const frames = [
+        `event: response.created\ndata: ${JSON.stringify({ type: "response.created", response: { id: "resp_fail" } })}\n\n`,
+        `event: response.failed\ndata: ${JSON.stringify({ type: "response.failed", response: { status: "failed", error: { message: "provider blew up" } } })}\n\n`,
+      ];
+      return new Response(frames.join(""), { headers: { "Content-Type": "text/event-stream" } });
+    },
+  });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const requestUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const url = new URL(requestUrl);
+    if (url.hostname === "chatgpt.com" && url.pathname.startsWith("/backend-api/codex")) {
+      return originalFetch(new URL(`${url.pathname.slice("/backend-api/codex".length)}${url.search}`, upstream.url), init);
+    }
+    return originalFetch(input, init);
+  }) as typeof fetch;
+  saveConfig({
+    port: 0,
+    defaultProvider: "openai",
+    providers: {
+      openai: {
+        adapter: "openai-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        authMode: "forward",
+        codexAccountMode: "direct",
+      },
+    },
+  } as OcxConfig);
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/chat/completions", server.url), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: ["Bear" + "er", "caller-direct-token"].join(" "),
+      },
+      body: JSON.stringify({
+        model: "gpt-test",
+        stream: false,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    const json = await response.json() as { error?: { message?: string; type?: string }; choices?: unknown };
+    expect(json.error?.message ?? "").toContain("provider blew up");
+    expect(json.choices).toBeUndefined();
+  } finally {
+    server.stop(true);
+    upstream.stop(true);
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("streaming /v1/chat/completions does not clean-DONE after response.failed", async () => {
+  const upstream = Bun.serve({
+    port: 0,
+    fetch() {
+      const frames = [
+        `event: response.created\ndata: ${JSON.stringify({ type: "response.created", response: { id: "resp_fail" } })}\n\n`,
+        `event: response.output_text.delta\ndata: ${JSON.stringify({ type: "response.output_text.delta", delta: "hi" })}\n\n`,
+        `event: response.failed\ndata: ${JSON.stringify({ type: "response.failed", response: { status: "failed", error: { message: "stream boom" } } })}\n\n`,
+      ];
+      return new Response(frames.join(""), { headers: { "Content-Type": "text/event-stream" } });
+    },
+  });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const requestUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const url = new URL(requestUrl);
+    if (url.hostname === "chatgpt.com" && url.pathname.startsWith("/backend-api/codex")) {
+      return originalFetch(new URL(`${url.pathname.slice("/backend-api/codex".length)}${url.search}`, upstream.url), init);
+    }
+    return originalFetch(input, init);
+  }) as typeof fetch;
+  saveConfig({
+    port: 0,
+    defaultProvider: "openai",
+    providers: {
+      openai: {
+        adapter: "openai-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        authMode: "forward",
+        codexAccountMode: "direct",
+      },
+    },
+  } as OcxConfig);
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/chat/completions", server.url), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: ["Bear" + "er", "caller-direct-token"].join(" "),
+      },
+      body: JSON.stringify({
+        model: "gpt-test",
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    // Stream opens with 200, then body carries an error frame and ends without [DONE].
+    expect(response.status).toBe(200);
+    const text = await response.text();
+    expect(text).toContain("stream boom");
+    expect(text).toContain('"error"');
+    expect(text).not.toContain("[error]");
+    expect(text).not.toContain("data: [DONE]");
+  } finally {
+    server.stop(true);
+    upstream.stop(true);
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -285,6 +285,7 @@ describe("server local API auth", () => {
         health: "/healthz",
         models: "/v1/models",
         responses: "/v1/responses",
+        chatCompletions: "/v1/chat/completions",
         management: "/api/*",
       },
     });


### PR DESCRIPTION
﻿## Summary
- Add OpenAI-compatible `POST /v1/chat/completions` so GitHub Copilot App can use OpenCodex as a custom Model provider.
- Translate Chat Completions requests into the existing Responses path and bridge stream/non-stream replies back to Chat Completions shape.
- Document setup (`docs/github-copilot-app.md`) and cover discovery/chat endpoint behavior with tests.

This is a **client integration** for GitHub Copilot App (BYOK / Model providers). It is separate from the existing experimental upstream `github-copilot` provider.

Replaces #278 (opened against `main` by mistake).

## How to use
1. Run OpenCodex (`ocx start`)
2. In GitHub Copilot App → Settings → Model providers → Add provider
3. Base URL: `http://127.0.0.1:10100/v1`
4. API key: empty on loopback
5. Sync models / add model by id (`provider/model`)

## Test plan
- [x] `bun test tests/chat-completions-endpoint.test.ts`
- [x] `bun test tests/server-auth.test.ts -t "root fallback"`
- [x] Manual: `GET /v1/models` returns OpenAI list shape
- [x] Manual: `POST /v1/chat/completions` stream + non-stream succeed for configured providers
- [x] Manual: GitHub Copilot App can chat after pointing at `/v1` and selecting an authenticated model
