### PR TITLE
fix: verify GUI update restarts stay healthy

### DIFF
--- a/docs/adr/0001-gui-update-worker.md
+++ b/docs/adr/0001-gui-update-worker.md
@@ -22,9 +22,17 @@ the existing npm self-update guard is reused. For Bun global installs, it runs t
 global update command. Source checkouts remain manual-only and show `git pull && bun install &&
 bun run build:gui`.
 
+After an update requests a restart, the worker now waits for an identity-checked `/healthz` to
+return and remain healthy for a short stability window before marking the job successful. This
+keeps `update-job.json` honest on Windows cases where npm leaves the bundled Bun runtime in a bad
+state and the restarted proxy dies a few seconds later.
+
 ## Consequences
 
 - The GUI request handler stays responsive and does not overwrite its own running module graph.
 - Update status survives a proxy restart because it is stored in the opencodex config directory.
 - Restart handling can branch between service-managed installs and direct detached proxy starts.
+- A completed install can still finish with `status: "failed"` when the replacement proxy never
+  becomes healthy or flaps during the stability window; the job log then points the user at
+  `ocx start` and the Bun `--allow-scripts` reinstall path.
 - The dashboard must poll both the job endpoint and `/healthz` while reconnecting.

--- a/src/update/job.ts
+++ b/src/update/job.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { atomicWriteFile, getConfigDir, loadConfig, readPid, readRuntimePort } from "../config";
 import { killProxy } from "../lib/process-control";
 import { waitForPortAvailable } from "../server/ports";
+import { proxyIdentityAt } from "../server/proxy-liveness";
 import { isServiceInstalled } from "../service";
 import {
   type Channel,
@@ -24,6 +25,8 @@ const RELEASE_NOTES_URL = "https://github.com/lidge-jun/opencodex/releases/lates
 const UPDATE_JOB_FILENAME = "update-job.json";
 const UPDATE_TIMEOUT_MS = 180_000;
 const RESTART_TIMEOUT_MS = 60_000;
+const RESTART_HEALTH_TIMEOUT_MS = 15_000;
+const RESTART_STABILITY_WINDOW_MS = 15_000;
 
 export type UpdateJobStatus = "running" | "restarting" | "succeeded" | "failed";
 
@@ -291,6 +294,9 @@ export interface RestartIo {
   waitForPort?: typeof waitForPortAvailable;
   spawnStart?: (job: UpdateJobState, installer: Installer, port?: number) => void;
   serviceInstalledFn?: () => boolean;
+  probeProxy?: (port: number, hostname?: string) => Promise<boolean>;
+  sleepMs?: (ms: number) => Promise<void>;
+  now?: () => number;
   /** Service-mode install/reinstall command (defaults to spawnSync via runLoggedCommand). */
   runService?: (
     job: UpdateJobState,
@@ -377,6 +383,79 @@ export function restartAfterUpdateForTests(
   return restartAfterUpdate(job, captured, io);
 }
 
+function restartFailureHint(port: number): string {
+  return `Update installed, but the restarted proxy did not stay healthy on port ${port}. `
+    + "Try 'ocx start'. If the update log shows bun postinstall or EPERM warnings, "
+    + "reinstall with 'npm install -g --allow-scripts=bun @bitkyc08/opencodex'.";
+}
+
+/**
+ * Confirm that the detached/service restart really came back and stayed up. The GUI worker
+ * used to mark success immediately after spawning the new process, which hid Windows cases
+ * where npm left the bundled Bun runtime half-updated and the restarted proxy died seconds
+ * later. A healthy /healthz must appear, then remain healthy for one short stability window.
+ */
+async function confirmRestartedProxy(
+  job: UpdateJobState,
+  captured: { port: number; hostname: string },
+  io: RestartIo = {},
+): Promise<boolean> {
+  /* [Decision Log]
+  - 목적과 의도: GUI update job이 detached restart 요청만 보고 성공 처리하지 않도록, 실제 프록시 복귀 여부를 확인한다.
+  - 기존 구현 및 제약 조건: update-job.json은 spawn/service reinstall 직후 `succeeded`로 끝났고, Windows npm/Bun 교체 실패처럼 몇 초 후 죽는 재시작을 잡지 못했다.
+  - 검토한 주요 대안: (1) 포트 점유만 확인 — 외부 프로세스/죽기 직전 프로세스를 성공으로 오인할 수 있다. (2) 무기한 /healthz 폴링 — UX가 느려지고 worker 종료 시점이 불명확하다. (3) 짧은 healthy 등장 + 안정성 창 확인 — 실제 복귀를 확인하면서도 대기 시간을 제한할 수 있다.
+  - 선택한 방식: identity-aware /healthz probe가 일정 시간 안에 나타나고, 추가 안정성 창 동안 유지되는지 확인한다.
+  - 다른 대안 대신 이 방식을 선택한 이유: GUI는 "업데이트가 설치됐지만 재시작은 실패"를 분리해 알려줘야 하며, 이 방식이 가장 적은 오탐으로 그 경계를 만든다.
+  - 장점, 단점 및 영향: 장점은 silent restart failure가 update-job 상태로 드러난다는 점이다. 단점은 성공 판정이 최대 30초 늦어질 수 있다는 점이며, 대신 실제 복귀를 더 정확히 반영한다.
+  */
+  const probe = io.probeProxy ?? (async (port: number, hostname?: string) => (
+    !!(await proxyIdentityAt(port, { hostname }))
+  ));
+  const sleep = io.sleepMs ?? (async (ms: number) => {
+    await new Promise(resolve => setTimeout(resolve, ms));
+  });
+  const now = io.now ?? (() => Date.now());
+  const port = captured.port;
+  const hostname = captured.hostname;
+  const startDeadline = now() + RESTART_HEALTH_TIMEOUT_MS;
+
+  while (now() < startDeadline) {
+    if (await probe(port, hostname)) {
+      updateJob(job, {}, `Proxy reported healthy on ${hostname}:${port}; confirming it stays up...`);
+      const stableUntil = now() + RESTART_STABILITY_WINDOW_MS;
+      while (now() < stableUntil) {
+        if (!(await probe(port, hostname))) {
+          updateJob(job, {
+            status: "failed",
+            restarted: false,
+            error: `proxy restart became unhealthy on ${hostname}:${port}`,
+          }, restartFailureHint(port));
+          return false;
+        }
+        await sleep(500);
+      }
+      updateJob(job, {}, `Proxy stayed healthy for ${Math.trunc(RESTART_STABILITY_WINDOW_MS / 1000)}s after restart.`);
+      return true;
+    }
+    await sleep(250);
+  }
+
+  updateJob(job, {
+    status: "failed",
+    restarted: false,
+    error: `proxy restart never became healthy on ${hostname}:${port}`,
+  }, restartFailureHint(port));
+  return false;
+}
+
+export function confirmRestartAfterUpdateForTests(
+  job: UpdateJobState,
+  captured: { port: number; hostname: string },
+  io: RestartIo,
+): Promise<boolean> {
+  return confirmRestartedProxy(job, captured, io);
+}
+
 export async function runGuiUpdateWorker(jobId: string, channel: Channel, restart: boolean): Promise<void> {
   let job = readUpdateJob(jobId);
   const check = checkForUpdate(channel);
@@ -457,7 +536,8 @@ export async function runGuiUpdateWorker(jobId: string, channel: Channel, restar
     if (restart) {
       job = updateJob(job, { status: "restarting" }, "Update installed. Restarting proxy...");
       await restartAfterUpdate(job, captured);
-      updateJob(job, { status: "succeeded", restarted: true }, "Restart requested.");
+      if (!(await confirmRestartedProxy(job, captured))) return;
+      updateJob(job, { status: "succeeded", restarted: true }, "Restart requested and proxy is healthy.");
       return;
     }
 

--- a/tests/update-job.test.ts
+++ b/tests/update-job.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   checkForUpdate,
+  confirmRestartAfterUpdateForTests,
+  readUpdateJob,
   restartCommand,
   restartAfterUpdateForTests,
   startUpdateJob,
@@ -210,6 +212,89 @@ describe("GUI update execution decisions", () => {
     });
     // The fallback must fire: direct proxy start instead of throwing.
     expect(spawned).toEqual([{ port: 19999 }]);
+  });
+
+  test("restart confirmation fails when the proxy never becomes healthy", async () => {
+    let now = 0;
+    const job: UpdateJobState = {
+      id: "restart-health-timeout",
+      status: "restarting",
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      currentVersion: "2.7.32",
+      latestVersion: "2.7.33",
+      channel: "latest",
+      installer: "npm",
+      restart: true,
+      command: "",
+      log: [],
+    };
+    writeFileSync(updateJobPath(job.id), JSON.stringify(job));
+    const ok = await confirmRestartAfterUpdateForTests(job, { port: 10100, hostname: "127.0.0.1" }, {
+      probeProxy: async () => false,
+      now: () => now,
+      sleepMs: async (ms) => { now += ms; },
+    });
+    expect(ok).toBe(false);
+    expect(readUpdateJob(job.id)).toMatchObject({
+      status: "failed",
+      restarted: false,
+      error: "proxy restart never became healthy on 127.0.0.1:10100",
+    });
+  });
+
+  test("restart confirmation fails when the proxy dies during the stability window", async () => {
+    let now = 0;
+    const job: UpdateJobState = {
+      id: "restart-health-flap",
+      status: "restarting",
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      currentVersion: "2.7.32",
+      latestVersion: "2.7.33",
+      channel: "latest",
+      installer: "npm",
+      restart: true,
+      command: "",
+      log: [],
+    };
+    writeFileSync(updateJobPath(job.id), JSON.stringify(job));
+    const ok = await confirmRestartAfterUpdateForTests(job, { port: 10100, hostname: "127.0.0.1" }, {
+      probeProxy: async () => now < 12_000,
+      now: () => now,
+      sleepMs: async (ms) => { now += ms; },
+    });
+    expect(ok).toBe(false);
+    expect(readUpdateJob(job.id)).toMatchObject({
+      status: "failed",
+      restarted: false,
+      error: "proxy restart became unhealthy on 127.0.0.1:10100",
+    });
+  });
+
+  test("restart confirmation succeeds only after the proxy stays healthy through the stability window", async () => {
+    let now = 0;
+    const job: UpdateJobState = {
+      id: "restart-health-ok",
+      status: "restarting",
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      currentVersion: "2.7.32",
+      latestVersion: "2.7.33",
+      channel: "latest",
+      installer: "npm",
+      restart: true,
+      command: "",
+      log: [],
+    };
+    writeFileSync(updateJobPath(job.id), JSON.stringify(job));
+    const ok = await confirmRestartAfterUpdateForTests(job, { port: 10100, hostname: "127.0.0.1" }, {
+      probeProxy: async () => now >= 1_000,
+      now: () => now,
+      sleepMs: async (ms) => { now += ms; },
+    });
+    expect(ok).toBe(true);
+    expect(readUpdateJob(job.id)?.log.some(line => line.includes("stayed healthy for 15s after restart"))).toBe(true);
   });
 
   test("a running job prevents a second update job", () => {


### PR DESCRIPTION
## Summary
- verify GUI update restarts with an identity-checked health/stability window before marking update-job success
- fail the job with a Windows-specific recovery hint when the replacement proxy never becomes healthy or dies shortly after start
- cover the new restart confirmation lanes with targeted updater regression tests and update the worker ADR

## Root cause
The GUI update worker marked `update-job.json` as succeeded immediately after requesting a restart. On Windows, npm/Bun update failures can leave the replacement proxy dead within seconds, but the dashboard still reported success because no post-restart health confirmation existed.

## User impact
Users now get an honest failed update-job state plus recovery guidance instead of a silent "restart requested" success while the proxy is already down.

## Validation
- `bun test tests/update-job.test.ts`
- `bun run typecheck`
- `bun run privacy:scan`