### PR TITLE
fix(server): return 400 instead of 500 for non-streaming adapter request

### DIFF
--- a/src/server/responses.ts
+++ b/src/server/responses.ts
@@ -1635,7 +1635,7 @@ export async function handleResponses(
     return new Response(JSON.stringify(json), { headers: { "Content-Type": "application/json" } });
   }
 
-  return formatErrorResponse(500, "internal_error", "Non-streaming not supported by this adapter");
+  return formatErrorResponse(400, "invalid_request_error", "Non-streaming not supported by this adapter");
 }
 
 export function linkAbortSignal(upstream: AbortController, signal?: AbortSignal): () => void {


### PR DESCRIPTION
## Summary

Change non-streaming response on adapters that don't implement `parseResponse` from HTTP 500 to 400.

## Why

`parsed.stream === false` on an adapter without `parseResponse` is a **client/configuration error** (the caller asked for non-streaming on an unsupported adapter), not a server internal error. Returning 500:

1. Masks the real cause in `/api/logs`
2. Triggers needless alarm for what is a correctable client-side issue
3. Violates HTTP semantics — 500 means "the server screwed up", not "your request shape is incompatible"

## What changed

- `src/server/responses.ts:1638`: `500, "internal_error"` → `400, "invalid_request_error"`
- Single line change, zero risk, no behavior change beyond status code

## Test plan

- [ ] Manual: send non-streaming request to an adapter that only supports streaming (e.g., anthropic adapter) — should get 400 with clear error message, not 500