### PR TITLE
ci: add issue deduplicator workflow

### DIFF
--- a/.github/workflows/issue-deduplicator.yml
+++ b/.github/workflows/issue-deduplicator.yml
@@ -1,0 +1,150 @@
+﻿name: Issue Deduplicator
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+
+permissions:
+  contents: read
+  issues: write
+  models: read
+
+jobs:
+  find-similar:
+    name: Find similar open issues
+    if: |
+      github.event.action == 'opened' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'codex-deduplicate')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch issues and build prompt
+        id: build-prompt
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -eo pipefail
+
+          gh issue list --repo "$REPO" \
+            --json number,title,body \
+            --limit 500 \
+            --state open \
+            --search "sort:created-desc" \
+            | jq --arg cur "$ISSUE_NUMBER" '[
+                .[] | select(.number != ($cur | tonumber)) |
+                { number, title, body: ((.body // "")[0:800]) }
+              ]' \
+            > existing-issues.json
+
+          gh issue view "$ISSUE_NUMBER" --repo "$REPO" \
+            --json number,title,body \
+            | jq '{ number, title, body: ((.body // "")[0:2000]) }' \
+            > current-issue.json
+
+          echo "open_count=$(jq 'length' existing-issues.json)"
+
+          # Write the full prompt to a file so actions/ai-inference can read it
+          cat > dedup-prompt.txt <<'PROMPT'
+New issue (JSON):
+PROMPT
+          cat current-issue.json >> dedup-prompt.txt
+          cat >> dedup-prompt.txt <<'PROMPT'
+
+Existing open issues (JSON array):
+PROMPT
+          cat existing-issues.json >> dedup-prompt.txt
+          cat >> dedup-prompt.txt <<'PROMPT'
+
+Return a JSON object with this exact shape and nothing else:
+{"issues": ["<number>", ...], "reason": "<one sentence>"}
+
+List only issue numbers (as strings) that are clear duplicates of the new
+issue. At most five. Empty array if none are convincing matches.
+PROMPT
+
+      - name: Run semantic duplicate detection
+        id: ai
+        uses: actions/ai-inference@v1
+        with:
+          model: openai/gpt-4o-mini
+          max-completion-tokens: 200
+          system-prompt: >
+            You are a GitHub issue triage assistant. Identify duplicate issues
+            based on semantic similarity — same underlying problem, error, or
+            feature request — not just shared keywords. Respond only with the
+            requested JSON. No markdown, no explanation outside the JSON.
+          prompt-file: dedup-prompt.txt
+
+      - name: Post duplicate comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          AI_RESPONSE: ${{ steps.ai.outputs.response }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue = context.payload.issue;
+            const BOT_MARKER = "<!-- opencodex-dedup-bot -->";
+
+            const raw = process.env.AI_RESPONSE ?? '';
+            let parsed;
+            try {
+              // Strip potential markdown code fences
+              const cleaned = raw.replace(/^```(?:json)?\s*/m, '').replace(/\s*```\s*$/m, '').trim();
+              parsed = JSON.parse(cleaned);
+            } catch (err) {
+              core.warning(`AI response was not valid JSON: ${raw}`);
+              return;
+            }
+
+            const currentNum = String(issue.number);
+            const matches = [...new Set(
+              (Array.isArray(parsed?.issues) ? parsed.issues : [])
+                .map(String)
+                .filter(n => n !== currentNum)
+            )].slice(0, 5);
+
+            if (matches.length === 0) {
+              core.info('No similar issues found.');
+              return;
+            }
+
+            // Upsert: update existing bot comment if present
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: issue.number, per_page: 100,
+            });
+            const existing = comments.find(
+              c => c.user?.type === 'Bot' && c.body?.includes(BOT_MARKER),
+            );
+
+            const list = matches.map(n => `- #${n}`).join('\n');
+            const body = [
+              BOT_MARKER,
+              'Potential duplicates found — please check whether your issue is already covered:',
+              '',
+              list,
+              '',
+              '_Detected automatically via GitHub Models. Matches may not be exact._',
+            ].join('\n');
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+              core.info(`Updated dedup comment on #${issue.number}.`);
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issue.number, body,
+              });
+              core.info(`Posted dedup comment on #${issue.number} with ${matches.length} match(es).`);
+            }
+
+      - name: Remove codex-deduplicate label
+        if: github.event.action == 'labeled' && github.event.label.name == 'codex-deduplicate'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue edit "${{ github.event.issue.number }}" --remove-label "codex-deduplicate" || true

--- a/.github/workflows/issue-deduplicator.yml
+++ b/.github/workflows/issue-deduplicator.yml
@@ -1,4 +1,4 @@
-﻿name: Issue Deduplicator
+name: Issue Deduplicator
 
 on:
   issues:
@@ -163,6 +163,7 @@ jobs:
         if: github.event.action == 'labeled' && github.event.label.name == 'codex-deduplicate'
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           # Only swallow 404 "label not found"; propagate auth/API/runner failures
           output=$(gh issue edit "${{ github.event.issue.number }}" --remove-label "codex-deduplicate" 2>&1) && exit 0 || {

--- a/.github/workflows/issue-deduplicator.yml
+++ b/.github/workflows/issue-deduplicator.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   find-similar:
-    name: Find similar open issues
+    name: Find similar issues
     concurrency:
       group: issue-deduplicator-${{ github.event.issue.number }}
       cancel-in-progress: false
@@ -31,14 +31,15 @@ jobs:
         run: |
           set -eo pipefail
 
+          # Fetch open AND closed so the AI can surface already-answered duplicates
           gh issue list --repo "$REPO" \
-            --json number,title,body \
+            --json number,title,body,state \
             --limit 500 \
-            --state open \
+            --state all \
             --search "sort:created-desc" \
             | jq --arg cur "$ISSUE_NUMBER" '[
                 .[] | select(.number != ($cur | tonumber)) |
-                { number, title, body: ((.body // "")[0:800]) }
+                { number, title, state, body: ((.body // "")[0:800]) }
               ]' \
             > existing-issues.json
 
@@ -47,38 +48,34 @@ jobs:
             | jq '{ number, title, body: ((.body // "")[0:2000]) }' \
             > current-issue.json
 
-          echo "open_count=$(jq 'length' existing-issues.json)"
+          echo "issue_count=$(jq 'length' existing-issues.json)"
 
-          # Write the full prompt to a file so actions/ai-inference can read it
-          cat > dedup-prompt.txt <<'PROMPT'
-New issue (JSON):
-PROMPT
-          cat current-issue.json >> dedup-prompt.txt
-          cat >> dedup-prompt.txt <<'PROMPT'
-
-Existing open issues (JSON array):
-PROMPT
-          cat existing-issues.json >> dedup-prompt.txt
-          cat >> dedup-prompt.txt <<'PROMPT'
-
-Return a JSON object with this exact shape and nothing else:
-{"issues": ["<number>", ...], "reason": "<one sentence>"}
-
-List only issue numbers (as strings) that are clear duplicates of the new
-issue. At most five. Empty array if none are convincing matches.
-PROMPT
+          # Build prompt file without heredocs (avoids YAML/bash indentation conflict)
+          {
+            printf 'New issue (JSON):\n'
+            cat current-issue.json
+            printf '\n\nExisting issues — open and closed (JSON array):\n'
+            cat existing-issues.json
+            printf '\n\nReturn a JSON object with this exact shape and nothing else:\n'
+            printf '{"issues": ["<number>", ...], "reason": "<one sentence>"}\n'
+            printf '\nList only issue numbers (as strings) that describe the same underlying\n'
+            printf 'problem or request as the new issue. Closed issues are valid matches if\n'
+            printf 'they already answer or resolve it. At most five. Empty array if no\n'
+            printf 'convincing matches exist.\n'
+          } > dedup-prompt.txt
 
       - name: Run semantic duplicate detection
         id: ai
-        uses: actions/ai-inference@v1
+        uses: actions/ai-inference@b81b2afb8390ee6839b494a404766bef6493c7d9 # v1
         with:
           model: openai/gpt-4o-mini
           max-completion-tokens: 200
           system-prompt: >
             You are a GitHub issue triage assistant. Identify duplicate issues
             based on semantic similarity — same underlying problem, error, or
-            feature request — not just shared keywords. Respond only with the
-            requested JSON. No markdown, no explanation outside the JSON.
+            feature request — not just shared keywords. Closed issues are valid
+            matches if they already answer or resolve the new one. Respond only
+            with the requested JSON. No markdown, no explanation outside the JSON.
           prompt-file: dedup-prompt.txt
 
       - name: Post duplicate comment
@@ -87,11 +84,12 @@ PROMPT
           AI_RESPONSE: ${{ steps.ai.outputs.response }}
         with:
           script: |
+            const fs = require('fs');
             const { owner, repo } = context.repo;
             const issue = context.payload.issue;
             const BOT_MARKER = "<!-- opencodex-dedup-bot -->";
 
-            // Always fetch existing bot comment first — needed for both match and no-match paths
+            // Always fetch existing bot comment first — needed for both paths
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner, repo, issue_number: issue.number, per_page: 100,
             });
@@ -102,7 +100,6 @@ PROMPT
             const raw = process.env.AI_RESPONSE ?? '';
             let parsed;
             try {
-              // Strip potential markdown code fences
               const cleaned = raw.replace(/^```(?:json)?\s*/m, '').replace(/\s*```\s*$/m, '').trim();
               parsed = JSON.parse(cleaned);
             } catch (err) {
@@ -110,15 +107,18 @@ PROMPT
               return;
             }
 
+            // Build a whitelist of numbers we actually fetched — guards against hallucinations
+            const fetched = JSON.parse(fs.readFileSync('existing-issues.json', 'utf8'));
+            const validNums = new Set(fetched.map(i => String(i.number)));
+
             const currentNum = String(issue.number);
             const matches = [...new Set(
               (Array.isArray(parsed?.issues) ? parsed.issues : [])
                 .map(String)
-                .filter(n => n !== currentNum)
+                .filter(n => n !== currentNum && validNums.has(n))
             )].slice(0, 5);
 
             if (matches.length === 0) {
-              // Clean up a stale duplicate comment from a prior run if present
               if (existing) {
                 await github.rest.issues.deleteComment({
                   owner, repo, comment_id: existing.id,
@@ -130,14 +130,21 @@ PROMPT
               return;
             }
 
-            const list = matches.map(n => `- #${n}`).join('\n');
+            // Annotate closed matches so reporters know they may already have an answer
+            const closedNums = new Set(
+              fetched.filter(i => i.state === 'closed').map(i => String(i.number))
+            );
+            const list = matches
+              .map(n => closedNums.has(n) ? `- #${n} _(closed)_` : `- #${n}`)
+              .join('\n');
+
             const body = [
               BOT_MARKER,
               'Potential duplicates found — please check whether your issue is already covered:',
               '',
               list,
               '',
-              '_Detected automatically via GitHub Models. Matches may not be exact._',
+              '_Detected automatically via GitHub Models. Closed issues may already contain an answer. Matches may not be exact._',
             ].join('\n');
 
             if (existing) {

--- a/.github/workflows/issue-deduplicator.yml
+++ b/.github/workflows/issue-deduplicator.yml
@@ -7,13 +7,15 @@ on:
       - labeled
 
 permissions:
-  contents: read
   issues: write
   models: read
 
 jobs:
   find-similar:
     name: Find similar open issues
+    concurrency:
+      group: issue-deduplicator-${{ github.event.issue.number }}
+      cancel-in-progress: false
     if: |
       github.event.action == 'opened' ||
       (github.event.action == 'labeled' && github.event.label.name == 'codex-deduplicate')
@@ -89,6 +91,14 @@ PROMPT
             const issue = context.payload.issue;
             const BOT_MARKER = "<!-- opencodex-dedup-bot -->";
 
+            // Always fetch existing bot comment first — needed for both match and no-match paths
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: issue.number, per_page: 100,
+            });
+            const existing = comments.find(
+              c => c.user?.type === 'Bot' && c.body?.includes(BOT_MARKER),
+            );
+
             const raw = process.env.AI_RESPONSE ?? '';
             let parsed;
             try {
@@ -108,17 +118,17 @@ PROMPT
             )].slice(0, 5);
 
             if (matches.length === 0) {
-              core.info('No similar issues found.');
+              // Clean up a stale duplicate comment from a prior run if present
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  owner, repo, comment_id: existing.id,
+                });
+                core.info(`Removed stale dedup comment on #${issue.number} — no matches on rescan.`);
+              } else {
+                core.info('No similar issues found.');
+              }
               return;
             }
-
-            // Upsert: update existing bot comment if present
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner, repo, issue_number: issue.number, per_page: 100,
-            });
-            const existing = comments.find(
-              c => c.user?.type === 'Bot' && c.body?.includes(BOT_MARKER),
-            );
 
             const list = matches.map(n => `- #${n}`).join('\n');
             const body = [
@@ -147,4 +157,9 @@ PROMPT
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh issue edit "${{ github.event.issue.number }}" --remove-label "codex-deduplicate" || true
+          # Only swallow 404 "label not found"; propagate auth/API/runner failures
+          output=$(gh issue edit "${{ github.event.issue.number }}" --remove-label "codex-deduplicate" 2>&1) && exit 0 || {
+            echo "$output" | grep -qi "could not remove label\|label.*not found\|Label.*not exist" && exit 0
+            echo "$output" >&2
+            exit 1
+          }

--- a/.github/workflows/issue-deduplicator.yml
+++ b/.github/workflows/issue-deduplicator.yml
@@ -1,4 +1,4 @@
-name: Issue Deduplicator
+﻿name: Issue Deduplicator
 
 on:
   issues:
@@ -111,9 +111,14 @@ jobs:
             const fetched = JSON.parse(fs.readFileSync('existing-issues.json', 'utf8'));
             const validNums = new Set(fetched.map(i => String(i.number)));
 
+            if (!Array.isArray(parsed?.issues)) {
+              core.warning(`AI response has unexpected schema (issues is not an array): ${raw}`);
+              return;
+            }
+
             const currentNum = String(issue.number);
             const matches = [...new Set(
-              (Array.isArray(parsed?.issues) ? parsed.issues : [])
+              parsed.issues
                 .map(String)
                 .filter(n => n !== currentNum && validNums.has(n))
             )].slice(0, 5);


### PR DESCRIPTION
## Summary

Adds `.github/workflows/issue-deduplicator.yml` — a workflow that fires on every newly opened issue and posts a bot comment listing up to five semantically similar open issues.

## How it works

1. **Fetch** — `gh issue list` pulls up to 500 open issues (number, title, first 800 chars of body) into a JSON file alongside the new issue
2. **Detect** — [`actions/ai-inference@v1`](https://github.com/actions/ai-inference) sends both files to `gpt-4o-mini` via GitHub Models with a structured JSON output schema, asking it to identify issues that share the same underlying problem, error signature, or feature request
3. **Normalize** — the response is parsed, self-references stripped, capped at 5
4. **Comment** — a bot comment is upserted (idempotent via `<!-- opencodex-dedup-bot -->` marker)

Maintainers can also manually re-trigger a scan on any issue by adding the `codex-deduplicate` label — it's removed automatically after the scan completes.

## Why `actions/ai-inference` instead of keyword search

The first draft of this used stop-word keyword extraction + `github.rest.search.issuesAndPullRequests`. That works but misses semantic matches — "reasoning effort `max` not available" and "provider dropdown not showing correct levels" describe the same bug but share no keywords. `actions/ai-inference` uses an actual LLM to judge intent, not token overlap.

## Why not `openai/codex-action` (like openai/codex uses)?

Their workflow requires a `CODEX_OPENAI_API_KEY` repo secret and an `issue-triage` environment configured by the repo owner — real setup friction and real per-run cost. `actions/ai-inference` uses the built-in `GITHUB_TOKEN` with `models: read` permission via GitHub Models. **No secrets, no extra setup, zero cost to the repo owner** — just merge this file.

## Required permissions (already declared in the workflow)

```yaml
permissions:
  contents: read
  issues: write
  models: read
```

## What the comment looks like

> Potential duplicates found — please check whether your issue is already covered:
>
> - #297
> - #241
>
> _Detected automatically via GitHub Models. Matches may not be exact._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Issue Deduplicator” GitHub Actions workflow that runs when issues are opened and when a specific deduplication label is applied.
  * Uses AI-powered semantic matching to propose up to five similar issues by comparing against a capped set of existing repository issues (including closed).
  * Posts or refreshes a single persistent bot comment with a fixed marker, and flags matches that are already closed.
  * Clears the deduplication label after processing using a best-effort approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->