### PR TITLE
ci: add PR auto-labeler and auto-generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+# GitHub release notes category config.
+# Maps PR labels (applied by pr-labeler.yml) to release note section headings.
+# Docs: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Chores
+      labels:
+        - chore
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,91 @@
+name: PR Labeler
+
+# Automatically applies a single type label to every PR based on its title
+# prefix (conventional-commits style). No secrets or external services needed.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+concurrency:
+  group: pr-labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply type label from PR title
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const title = context.payload.pull_request.title || '';
+            const pr    = context.payload.pull_request.number;
+
+            // Map conventional-commit prefix -> GitHub label name.
+            const PREFIX_TO_LABEL = {
+              'feat':     'enhancement',
+              'feature':  'enhancement',
+              'fix':      'bug',
+              'bugfix':   'bug',
+              'hotfix':   'bug',
+              'docs':     'documentation',
+              'doc':      'documentation',
+              'chore':    'chore',
+              'refactor': 'chore',
+              'style':    'chore',
+              'test':     'chore',
+              'tests':    'chore',
+              'ci':       'chore',
+              'build':    'chore',
+              'perf':     'enhancement',
+              'revert':   'chore',
+            };
+
+            const TYPE_LABELS = new Set(Object.values(PREFIX_TO_LABEL));
+
+            // Match "prefix:" or "prefix(scope):" at the start of the title.
+            const match = title.match(/^([a-zA-Z]+)(?:\([^)]*\))?[!]?\s*:/);
+            const detected = match ? PREFIX_TO_LABEL[match[1].toLowerCase()] : null;
+
+            if (!detected) {
+              core.info(`No conventional-commit prefix detected in: "${title}" — skipping`);
+              return;
+            }
+
+            // Read current labels on the PR.
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              issue_number: pr,
+            });
+            const current = new Set(currentLabels.map(l => l.name));
+
+            // Remove any stale type label that no longer matches.
+            for (const label of TYPE_LABELS) {
+              if (current.has(label) && label !== detected) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo:  context.repo.repo,
+                  issue_number: pr,
+                  name: label,
+                });
+              }
+            }
+
+            // Add the detected label if not already present.
+            if (!current.has(detected)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: pr,
+                labels: [detected],
+              });
+              core.info(`Applied label "${detected}" to PR #${pr}`);
+            } else {
+              core.info(`Label "${detected}" already present on PR #${pr}`);
+            }

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -75,12 +75,12 @@ jobs:
               }
 
               const creator = context.payload.pull_request.user.login;
-              const existing = await github.rest.issues.listComments({
+              const allComments = await github.paginate(github.rest.issues.listComments, {
                 owner: context.repo.owner,
                 repo:  context.repo.repo,
                 issue_number: pr,
               });
-              const alreadyCommented = existing.data.some(
+              const alreadyCommented = allComments.some(
                 c => c.user.login === 'github-actions[bot]' &&
                      c.body.includes('<!-- opencodex-label-nudge -->')
               );

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -4,7 +4,7 @@ name: PR Labeler
 # prefix (conventional-commits style). No secrets or external services needed.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize]
 
 concurrency:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -54,6 +54,23 @@ jobs:
             const detected = match ? PREFIX_TO_LABEL[match[1].toLowerCase()] : null;
 
             if (!detected) {
+              // Clear any stale type labels left from a previous prefix.
+              const { data: staleCheck } = await github.rest.issues.listLabelsOnIssue({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: pr,
+              });
+              for (const label of staleCheck) {
+                if (TYPE_LABELS.has(label.name)) {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo:  context.repo.repo,
+                    issue_number: pr,
+                    name: label.name,
+                  });
+                }
+              }
+
               const creator = context.payload.pull_request.user.login;
               const existing = await github.rest.issues.listComments({
                 owner: context.repo.owner,

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -51,7 +51,10 @@ jobs:
 
             // Match "prefix:" or "prefix(scope):" at the start of the title.
             const match = title.match(/^([a-zA-Z]+)(?:\([^)]*\))?[!]?\s*:/);
-            const detected = match ? PREFIX_TO_LABEL[match[1].toLowerCase()] : null;
+            const key = match ? match[1].toLowerCase() : null;
+            const detected = key && Object.prototype.hasOwnProperty.call(PREFIX_TO_LABEL, key)
+              ? PREFIX_TO_LABEL[key]
+              : null;
 
             if (!detected) {
               // Clear any stale type labels left from a previous prefix.

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -14,6 +14,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   label:
@@ -53,7 +54,35 @@ jobs:
             const detected = match ? PREFIX_TO_LABEL[match[1].toLowerCase()] : null;
 
             if (!detected) {
-              core.info(`No conventional-commit prefix detected in: "${title}" — skipping`);
+              const creator = context.payload.pull_request.user.login;
+              const existing = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: pr,
+              });
+              const alreadyCommented = existing.data.some(
+                c => c.user.login === 'github-actions[bot]' &&
+                     c.body.includes('<!-- opencodex-label-nudge -->')
+              );
+              if (!alreadyCommented) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo:  context.repo.repo,
+                  issue_number: pr,
+                  body: [
+                    '<!-- opencodex-label-nudge -->',
+                    `Hey @${creator} — could you add a [conventional-commit](https://www.conventionalcommits.org) prefix to the PR title? This lets the release notes generator categorize it automatically.`,
+                    '',
+                    'Examples:',
+                    '- `feat: Add Cursor Router optimization levels`',
+                    '- `fix: Resolve auth token refresh loop`',
+                    '- `docs: Update provider setup guide`',
+                    '- `chore: Bump bun to 1.3.15`',
+                    '',
+                    'Once updated, this workflow will re-run and apply the label automatically.',
+                  ].join('\n'),
+                });
+              }
               return;
             }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,7 +265,6 @@ jobs:
           set -euo pipefail
 
           release_tag="v${RELEASE_VERSION}"
-          notes_file="$(mktemp)"
 
           git fetch --force --tags origin
 
@@ -273,37 +272,6 @@ jobs:
           if [ -n "$existing_tag_sha" ] && [ "$existing_tag_sha" != "$GITHUB_SHA" ]; then
             echo "::error::${release_tag} already points at ${existing_tag_sha}, not ${GITHUB_SHA}"
             exit 1
-          fi
-
-          previous_tag="$(
-            git tag --merged HEAD --list 'v[0-9]*' --sort=-v:refname |
-              grep -vx "$release_tag" |
-              head -n 1 || true
-          )"
-
-          {
-            echo "Published to npm as \`@bitkyc08/opencodex@${RELEASE_VERSION}\` with dist-tag \`${NPM_DIST_TAG}\`."
-            echo
-            echo "## Commit log"
-            echo
-            if [ -n "$previous_tag" ]; then
-              echo "Changes since \`${previous_tag}\`:"
-              echo
-              git log --reverse --no-merges --pretty=format:'- %s (%h)' "${previous_tag}..HEAD" |
-                grep -vE '^- release: v[0-9]+\.[0-9]+\.[0-9]+' || true
-              echo
-              echo
-              echo "[Full diff](https://github.com/${GITHUB_REPOSITORY}/compare/${previous_tag}...${release_tag})"
-            else
-              echo "Initial release commits:"
-              echo
-              git log --reverse --no-merges --pretty=format:'- %s (%h)' HEAD |
-                grep -vE '^- release: v[0-9]+\.[0-9]+\.[0-9]+' || true
-            fi
-          } > "$notes_file"
-
-          if ! grep -q '^- ' "$notes_file"; then
-            printf '\n- Release version bump only.\n' >> "$notes_file"
           fi
 
           if [ -z "$existing_tag_sha" ]; then
@@ -318,8 +286,10 @@ jobs:
             prerelease_flag="--prerelease"
           fi
 
+          # Release notes are generated automatically from merged PR labels using
+          # .github/release.yml categories (populated by pr-labeler.yml).
           if gh release view "$release_tag" >/dev/null 2>&1; then
-            gh release edit "$release_tag" --title "$release_tag" --notes-file "$notes_file" ${prerelease_flag:+$prerelease_flag}
+            gh release edit "$release_tag" --title "$release_tag" --generate-notes ${prerelease_flag:+$prerelease_flag}
           else
-            gh release create "$release_tag" --target "$GITHUB_SHA" --title "$release_tag" --notes-file "$notes_file" ${prerelease_flag:+$prerelease_flag}
+            gh release create "$release_tag" --target "$GITHUB_SHA" --title "$release_tag" --generate-notes ${prerelease_flag:+$prerelease_flag}
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,7 +289,13 @@ jobs:
           # Release notes are generated automatically from merged PR labels using
           # .github/release.yml categories (populated by pr-labeler.yml).
           if gh release view "$release_tag" >/dev/null 2>&1; then
-            gh release edit "$release_tag" --title "$release_tag" --generate-notes ${prerelease_flag:+$prerelease_flag}
+            # gh release edit does not support --generate-notes; generate the
+            # notes via the API first, then pass them through --notes-file.
+            notes_file="$(mktemp)"
+            gh api repos/"${GITHUB_REPOSITORY}"/releases/generate-notes \
+              -f tag_name="$release_tag" \
+              --jq '.body' > "$notes_file"
+            gh release edit "$release_tag" --title "$release_tag" --notes-file "$notes_file" ${prerelease_flag:+$prerelease_flag}
           else
             gh release create "$release_tag" --target "$GITHUB_SHA" --title "$release_tag" --generate-notes ${prerelease_flag:+$prerelease_flag}
           fi


### PR DESCRIPTION
## What

Adds a zero-cost, fully automated release notes system matching the style of [openai/codex releases](https://github.com/openai/codex/releases/tag/rust-v0.145.0) (New Features / Bug Fixes / Documentation / Chores sections + full changelog link).

Three changes:

### 1. `.github/workflows/pr-labeler.yml` (new)
Fires on every PR open/edit. Reads the conventional-commit prefix from the title (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `perf:`, etc.) and applies the matching GitHub label automatically. No API keys, no external services — runs entirely with the built-in `GITHUB_TOKEN`.

| Prefix | Label |
|---|---|
| feat / feature / perf | `enhancement` |
| fix / bugfix / hotfix | `bug` |
| docs / doc | `documentation` |
| chore / refactor / style / test / ci / build / revert | `chore` |

If someone edits a PR title and changes the type, the old label is removed and the new one applied. If a PR title has no recognized prefix, the bot posts a one-time comment tagging the PR creator with examples.

### 2. `.github/release.yml` (new)
Tells GitHub how to group those labels into release note sections. GitHub reads this file automatically when `--generate-notes` is used.

### 3. `.github/workflows/release.yml` (updated)
Replaces the manual `git log` commit dump with `gh release create --generate-notes`. On every release dispatch, GitHub now builds the categorized release notes from merged PR labels instead of a flat commit list.

## Why

The old release notes were a raw `git log` dump — no structure, no categories, hard to read. This makes every release look like the openai/codex releases with zero ongoing maintenance: just label PRs (or let the labeler do it) and dispatch the release workflow.

## Setup required (one-time, before merging)

One label needs to be created manually — the others (`bug`, `documentation`, `enhancement`) already exist in this repo:

```sh
gh label create chore --repo lidge-jun/opencodex --color 'e4e669' --description 'Maintenance, refactors, CI, and non-user-facing changes'
```

## How to cut a release (after merging)

1. Bump the version in `package.json` on `main`
2. Go to **Actions → Release → Run workflow**
3. Fill in `version`, set `tag` to `latest`, leave `dry-run: true` first to verify
4. If the dry run looks good, run again with `dry-run: false`

GitHub will scan all PRs merged since the previous tag, group them by label, and the release page will look like:

```
## New Features
- Add Cursor Router optimization levels (#296)
- Add DeepSeek provider support (#291)

## Bug Fixes
- Fix auth token refresh loop (#294)

## Chores
- Bump bun to 1.3.15 (#295)

Full Changelog: https://github.com/lidge-jun/opencodex/compare/v0.3.0...v0.4.0
```

## Verification

- `pr-labeler.yml` uses `pull_request_target` so the token has write access even for fork PRs
- `pr-labeler.yml` uses a pinned SHA for `actions/github-script`
- `release.yml` follows the [GitHub changelog config schema](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options)
- `release.yml` workflow diff is minimal — only the notes generation block changed, all guards and version checks are untouched