### PR TITLE
Document Cursor exec policy and catalog troubleshooting

### DIFF
--- a/docs-site/src/content/docs/guides/codex-integration.md
+++ b/docs-site/src/content/docs/guides/codex-integration.md
@@ -127,6 +127,33 @@ Routed catalog entries also get their GPT-5 identity rewritten to the real upstr
 Reasoning controls come from provider/model metadata across Codex's `low | medium | high | xhigh |
 max | ultra` ladder; unsupported values are mapped or clamped before the upstream request.
 
+### Catalog troubleshooting
+
+If a model is missing from Codex, or the catalog order/visibility looks wrong, check in order:
+
+1. **`selectedModels`** on the provider — a non-empty allowlist exposes only those ids to Codex;
+   empty or omitted exposes all discovered models. An id not in the allowlist never reaches the
+   catalog.
+2. **`disabledModels`** (top level) — hides models from both the catalog and `/v1/models`, and flips
+   bare native GPT slugs to `visibility: "hide"`.
+3. **`liveModels: false` with empty `models`** — when live discovery is off and `models` is empty or
+   omitted, opencodex exposes no routed models for that provider.
+4. **Cursor `GetUsableModels`** — the Cursor adapter discovers models through its protobuf
+   `GetUsableModels` RPC, not `/models`, so a Cursor-side change can alter which ids are visible
+   independently of other providers.
+5. **Cache and `ocx sync`** — live catalogs are cached for about five minutes (`modelCacheTtlMs`,
+   default `300000`). Run `ocx sync` to force a fresh fetch and rewrite the catalog immediately.
+
+:::caution[Other local writers]
+Catalog writes (`opencodex-catalog.json`, `config.toml`) are atomic **inside** opencodex, which only
+prevents half-written files when two opencodex-owned writers race. That does **not** stop another
+local process, file watcher, or sync agent from rewriting catalog visibility or order after opencodex
+has written. Codex keeps its separate `models_cache.json` and can refresh it independently, changing
+the visible list without rewriting `opencodex-catalog.json`. If models flip unexpectedly while the
+proxy is running, stop or reconfigure the competing writers, then run `ocx sync` — this is an
+external-writer hazard, not a confirmed opencodex defect.
+:::
+
 ## The subagent picker
 
 Codex's `spawn_agent` advertises the first **5 picker-visible catalog models** after sorting by

--- a/docs-site/src/content/docs/reference/adapters.md
+++ b/docs-site/src/content/docs/reference/adapters.md
@@ -99,8 +99,9 @@ streams the response back **untranslated**.
   discovers live Cursor models through the protobuf `GetUsableModels` RPC, and retries only before a
   run request is committed to the wire.
 - Cursor-native local filesystem/shell/network execution is denied by default. Explicit `mcpServers`
-  and `desktopExecutor` integrations have separate opt-ins; `unsafeAllowNativeLocalExec` enables the
-  broader built-in executor and bypasses Codex approval/sandbox semantics.
+  and `desktopExecutor` integrations have separate opt-ins; `nativeLocalExec: "on"` enables the
+  broader built-in executor and bypasses Codex approval/sandbox semantics, and legacy
+  `unsafeAllowNativeLocalExec: true` remains equivalent only when `nativeLocalExec` is unset.
 
 ## `azure-openai` (alias: `azure`)
 

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -185,7 +185,8 @@ network. Only do this on trusted networks, and always set a strong `OPENCODEX_AP
 | `location?` | `string` | Vertex location; environment fallback is `GOOGLE_CLOUD_LOCATION`. |
 | `mcpServers?` | `Record<string,CursorMcpServerConfig>` | **Cursor only.** MCP servers started over stdio or reached over Streamable HTTP; fields are listed below. |
 | `desktopExecutor?` | `DesktopExecutorConfig` | **Cursor only.** External computer-use/record-screen commands; fields are listed below. |
-| `unsafeAllowNativeLocalExec?` | `boolean` | **Cursor adapter only.** Opt-in escape hatch for Cursor server-driven local `read` / `write` / `delete` / `ls` / `grep` / `shell` / `fetch` execution. Defaults to `false` so remote Cursor messages cannot bypass Codex approval and sandbox enforcement. See [Cursor provider](#cursor-provider-adapter-cursor) below. |
+| `unsafeAllowNativeLocalExec?` | `boolean` | **Cursor adapter only.** Legacy compatibility boolean for the Cursor server-driven local `read` / `write` / `delete` / `ls` / `grep` / `shell` / `fetch` executor. Equivalent to `nativeLocalExec: "on"` when `nativeLocalExec` is unset; an explicit `nativeLocalExec` value always wins. Defaults to `false`. Prefer `nativeLocalExec` for new configs. See [Cursor provider](#cursor-provider-adapter-cursor) below. |
+| `nativeLocalExec?` | `"off" \| "codex-sandbox" \| "on"` | **Cursor adapter only.** Native local exec policy for the Cursor server-driven executor. `"off"` (default) rejects it; `"on"` is the trusted-local opt-in; `"codex-sandbox"` is accepted for backwards compatibility but is fail-closed like `"off"`. See [Cursor provider](#cursor-provider-adapter-cursor) below. |
 
 For broken `openai-responses` compatibility gateways, `responsesItemIdRepair` belongs on the
 provider object itself, for example:
@@ -216,9 +217,17 @@ The Cursor bridge is experimental. After `ocx login cursor`, add or edit the `cu
 `providers` in `~/.opencodex/config.json` (Windows: `%USERPROFILE%\.opencodex\config.json`).
 
 By default, Cursor's server-driven native local tools stay **disabled**. Codex keeps using its own
-tools (`apply_patch`, `exec_command`, and so on) with approval and sandbox policy. Set
-`unsafeAllowNativeLocalExec` only for trusted local experiments where you accept that Cursor may
-read, write, delete, list, grep, shell, or fetch on your machine **without** Codex's approval path.
+tools (`apply_patch`, `exec_command`, and so on) with approval and sandbox policy. Use the
+`nativeLocalExec` field to choose a policy:
+
+- **`"off"` (default, safest)** — rejects all Cursor server-driven local `read`, `write`, `delete`,
+  `ls`, `grep`, `shell`, and `fetch` execution. Use this unless you have deliberately opted in.
+- **`"on"` (trusted-local opt-in)** — always allows Cursor-native local execution for this provider.
+  Use it only for a trusted local experiment on a host where every data-plane caller is trusted.
+- **`"codex-sandbox"` (accepted, fail-closed)** — recognized for backwards compatibility, but
+  currently behaves like `"off"`. Responses `instructions` / `system` / `developer` text is
+  caller-controlled prose, and opencodex has no trustworthy per-request attestation that it reflects
+  a real Codex sandbox state, so it never authorizes native local exec.
 
 ```json
 {
@@ -228,21 +237,25 @@ read, write, delete, list, grep, shell, or fetch on your machine **without** Cod
       "baseUrl": "https://api2.cursor.sh",
       "authMode": "oauth",
       "defaultModel": "auto",
-      "unsafeAllowNativeLocalExec": true
+      "nativeLocalExec": "off"
     }
   }
 }
 ```
 
-The flag belongs on the **provider object** (`providers.cursor`), not at the top level of
+The field belongs on the **provider object** (`providers.cursor`), not at the top level of
 `config.json`.
 
 You can also set it from the [web dashboard](/opencodex/guides/web-dashboard/): **Providers →
-Cursor → Edit JSON**, add `"unsafeAllowNativeLocalExec": true`, save, then restart the proxy
-(`ocx restart` or `ocx stop` + `ocx start`).
+Cursor → Edit JSON**, set `"nativeLocalExec"` to `"off"`, `"on"`, or `"codex-sandbox"`, save, then
+restart the proxy (`ocx restart` or `ocx stop` + `ocx start`).
+
+The legacy `unsafeAllowNativeLocalExec: true` boolean is still accepted and is equivalent to
+`nativeLocalExec: "on"` when `nativeLocalExec` is unset; an explicit `nativeLocalExec` value always
+wins. Prefer `nativeLocalExec` for new configs.
 
 MCP, screen recording, and computer-use use separate `mcpServers` / `desktopExecutor` config and are
-not controlled by this flag.
+not controlled by this field.
 
 ### Cursor integration records
 
@@ -256,8 +269,11 @@ accept `headers?: Record<string,string>`. Both forms support `enabled?: boolean`
 one JSON request from stdin, and must write one JSON result to stdout.
 
 :::caution[Security]
-Leave `unsafeAllowNativeLocalExec` unset or `false` unless you explicitly want Cursor-native local
-execution that bypasses Codex approval and sandbox semantics.
+`"off"` is the safest default. The default loopback bind admits **any** local process without auth
+(including other local users on multi-user machines), and request text such as Codex sandbox
+markers never authorizes native local exec. Leave `nativeLocalExec` unset or set it to `"off"`
+unless you explicitly want Cursor-native local execution that bypasses Codex approval and sandbox
+semantics.
 :::
 
 ## OpenRouter provider routing


### PR DESCRIPTION
## What changed

- document the current `nativeLocalExec` modes for the experimental Cursor adapter
- mark `unsafeAllowNativeLocalExec` as the legacy compatibility option
- explain the fail-closed behavior of `codex-sandbox` and the loopback trust boundary
- add catalog troubleshooting for discovery filters, Cursor `GetUsableModels`, cache refresh, and `ocx sync`
- clarify that competing local writers and Codex model-cache refreshes can make model visibility appear unstable without implying an OpenCodex defect

## Why

The runtime already implements `nativeLocalExec: "off" | "codex-sandbox" | "on"`, but the public configuration reference documented only the legacy boolean. That made the safest current configuration and precedence rules difficult to discover.

Catalog visibility can also look intermittent when filters, cached discovery, or another local writer changes the managed files. The new troubleshooting section keeps those causes separate and explicitly identifies external writers as an operator-side hazard rather than a confirmed OpenCodex bug.

## Safety

- `off` remains the documented safest default
- `on` is described as a trusted-local opt-in that bypasses Codex approval and sandbox semantics
- `codex-sandbox` is documented as currently fail-closed because caller-controlled request text cannot attest a real sandbox
- no runtime, authentication, credential, or provider behavior changes

## Validation

- `bun run prepush` — passed
- 3513 tests passed, 0 failed
- typecheck passed
- GUI lint passed
- privacy scan passed
- docs-site Astro/Starlight build passed (121 pages)
- `git diff --check` passed

## Localization

This PR updates the English source documentation. Existing localized pages still describe the functional legacy boolean and can be synchronized separately by fluent contributors.