### PR TITLE
Preserve custom model display names across catalog syncs

### DIFF
--- a/docs-site/src/content/docs/guides/codex-integration.md
+++ b/docs-site/src/content/docs/guides/codex-integration.md
@@ -127,6 +127,32 @@ Routed catalog entries also get their GPT-5 identity rewritten to the real upstr
 Reasoning controls come from provider/model metadata across Codex's `low | medium | high | xhigh |
 max | ultra` ladder; unsupported values are mapped or clamped before the upstream request.
 
+### Custom model display names
+
+A custom model can carry a human-readable **display name** that overrides the label Codex shows in
+its model picker, without changing anything about how the model is routed. The display name maps to
+the catalog entry's `display_name` field only — the routing slug (`<provider>/<model>`), alias
+collision order, provider, and native OpenAI marketing names are all left untouched.
+
+Add a display name from the CLI (the proxy syncs the catalog right away when live):
+
+```bash
+ocx models add deepseek deepseek-v4 --display-name "DeepSeek V4" --context-window 128000
+```
+
+You can also set or edit it through the management API (`POST /api/custom-models`,
+`PUT /api/custom-models/<id>` with a `displayName` string) and the web dashboard. A `/` is rejected
+because it would collide with the routed-slug separator.
+
+The display name is **display-only and stable across regeneration**. Every `ocx sync` and catalog
+refresh re-derives routed entries from `config.json` (including `customModels`), so the configured
+name is reapplied instead of drifting back to the routed slug. A managed service restart also attempts
+this sync shortly after the proxy binds. If that best-effort boot sync fails, for example during an
+offline login, the previously persisted catalog is retained and the next successful `ocx sync`
+reapplies the configured name. Genuine upstream native names (e.g. `gpt-5.6-sol` →
+"GPT-5.6-Sol") come from the pinned upstream snapshot and are never overridden by a custom display
+name.
+
 ## The subagent picker
 
 Codex's `spawn_agent` advertises the first **5 picker-visible catalog models** after sorting by

--- a/src/codex/catalog.ts
+++ b/src/codex/catalog.ts
@@ -371,6 +371,14 @@ export interface CatalogModel {
   provider: string;
   /** Public Codex-facing slug override (used by combo aliases). */
   alias?: string;
+  /**
+   * Display-only Codex catalog `display_name` override. Relabels the picker row ONLY — it never
+   * affects the routing slug, alias-collision order, native marketing-name precedence, or provider
+   * behavior. When unset, the entry falls back to its Codex-facing slug (the historical behavior).
+   * Native upstream entries (e.g. gpt-5.6-sol → "GPT-5.6-Sol") come from the pinned snapshot path
+   * which carries no CatalogModel, so a configured displayName can never override a native name.
+   */
+  displayName?: string;
   owned_by?: string;
   reasoningEfforts?: string[];
   defaultReasoningEffort?: string;
@@ -801,6 +809,14 @@ function applyCatalogModelMetadata(entry: RawEntry, model?: CatalogModel): void 
   // This marker survives strict catalog normalization and lets sync distinguish a stale
   // bare combo alias from a genuine native model row.
   if (model.provider === COMBO_NAMESPACE) entry.owned_by = model.owned_by ?? COMBO_NAMESPACE;
+  // displayName is DISPLAY-ONLY: it relabels the picker row but never touches the routing
+  // slug, alias, or provider. deriveEntry already stamped the slug as display_name; a
+  // configured displayName overrides just the label. The `/` separator is rejected at every
+  // input boundary (CLI `ocx models add`, management API), so the catalog trusts its source.
+  // Combos carry no displayName, and natives never reach here (no CatalogModel), so genuine
+  // upstream marketing names and combo alias labels are preserved untouched.
+  const displayName = typeof model.displayName === "string" ? model.displayName.trim() : "";
+  if (displayName) entry.display_name = displayName;
   if (typeof model.contextWindow === "number" && model.contextWindow > 0) {
     entry.context_window = model.contextWindow;
     entry.max_context_window = model.contextWindow;
@@ -1644,6 +1660,8 @@ export async function gatherRoutedModels(config: OcxConfig): Promise<CatalogMode
   const customModels = (config.customModels ?? []).map(cm => ({
     id: cm.modelId,
     provider: cm.provider,
+    // Display-only label: never feeds routing (customModels are keyed by routedSlug below).
+    ...(cm.displayName ? { displayName: cm.displayName } : {}),
     ...(cm.contextWindow ? { contextWindow: cm.contextWindow } : {}),
     ...(cm.inputModalities ? { inputModalities: cm.inputModalities } : {}),
   }));

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { augmentRoutedModelsWithJawcodeMetadata, augmentRoutedModelsWithRegistryOpenAiApiRows, buildCatalogEntries, clampCatalogModelsToCodexSupport, clampEntryToCodexSupportedEfforts, clampedDefaultEffort, deriveComboCatalogModel, exactComboCatalogSlugs, filterCatalogVisibleModels, filterSupportedNativeSlugs, gatherRoutedModels, isDatedVariantId, isMediaGenerationModelId, loadBundledCodexCatalog, materializeBundledCodexCatalog, mergeCatalogEntriesForSync, NATIVE_OPENAI_MODELS, normalizeRoutedCatalogEntry, resetCatalogRuntimeStateForTests, resetOpenAiApiCatalogWarningStateForTests } from "../src/codex/catalog";
+import { augmentRoutedModelsWithJawcodeMetadata, augmentRoutedModelsWithRegistryOpenAiApiRows, buildCatalogEntries, catalogModelSlug, clampCatalogModelsToCodexSupport, clampEntryToCodexSupportedEfforts, clampedDefaultEffort, deriveComboCatalogModel, exactComboCatalogSlugs, filterCatalogVisibleModels, filterSupportedNativeSlugs, gatherRoutedModels, isDatedVariantId, isMediaGenerationModelId, loadBundledCodexCatalog, materializeBundledCodexCatalog, mergeCatalogEntriesForSync, NATIVE_OPENAI_MODELS, normalizeRoutedCatalogEntry, resetCatalogRuntimeStateForTests, resetOpenAiApiCatalogWarningStateForTests } from "../src/codex/catalog";
 import {
   CURSOR_STATIC_MODELS,
   filterCursorConfiguredModelsByLiveDiscovery,
@@ -518,6 +518,129 @@ describe("Google Gemini catalog metadata", () => {
       .toEqual(["low", "medium", "high", "max", "ultra"]);
     expect(entry?.input_modalities).toEqual(["text", "image"]);
     expect(entry?.context_window).toBe(1_048_576);
+  });
+});
+
+describe("configured CatalogModel displayName -> catalog display_name", () => {
+  test("a routed CatalogModel displayName becomes the catalog display_name", () => {
+    const model = { provider: "deepseek", id: "deepseek-v4", displayName: "DeepSeek V4", owned_by: "deepseek" };
+    const entries = buildCatalogEntries(nativeTemplate(), [], [model]);
+    const row = entries.find(e => e.slug === "deepseek/deepseek-v4");
+
+    expect(row?.display_name).toBe("DeepSeek V4");
+    // Routing slug is untouched — displayName is display-only.
+    expect(row?.slug).toBe("deepseek/deepseek-v4");
+    expect(catalogModelSlug(model)).toBe("deepseek/deepseek-v4");
+  });
+
+  test("absent displayName leaves display_name as the slug (unchanged behavior)", () => {
+    const entries = buildCatalogEntries(nativeTemplate(), [], [
+      { provider: "anthropic", id: "claude-sonnet-4-6", owned_by: "anthropic" },
+    ]);
+    const row = entries.find(e => e.slug === "anthropic/claude-sonnet-4-6");
+
+    expect(row?.display_name).toBe("anthropic/claude-sonnet-4-6");
+    expect(row?.slug).toBe("anthropic/claude-sonnet-4-6");
+  });
+
+  test("empty/whitespace displayName is ignored and falls back to the slug", () => {
+    const entries = buildCatalogEntries(nativeTemplate(), [], [
+      { provider: "deepseek", id: "deepseek-v4", displayName: "   ", owned_by: "deepseek" },
+    ]);
+    const row = entries.find(e => e.slug === "deepseek/deepseek-v4");
+    expect(row?.display_name).toBe("deepseek/deepseek-v4");
+  });
+
+  test("displayName never affects the routing slug, alias, or provider", () => {
+    const withAlias = { provider: "combo", id: "x", alias: "fast-chat", displayName: "Fast Chat", owned_by: "combo" };
+    const entries = buildCatalogEntries(nativeTemplate(), [], [withAlias], undefined, false, "default", new Set(["fast-chat"]));
+    const row = entries.find(e => e.slug === "fast-chat")!;
+
+    // The public alias is still the slug; only the label changed.
+    expect(row.slug).toBe("fast-chat");
+    expect(catalogModelSlug(withAlias)).toBe("fast-chat");
+    expect(row.display_name).toBe("Fast Chat");
+    expect(row.owned_by).toBe("combo");
+  });
+
+  test("displayName stays stable across repeated catalog sync (idempotent regeneration)", () => {
+    const model = { provider: "deepseek", id: "deepseek-v4", displayName: "DeepSeek V4", owned_by: "deepseek" };
+    const rebuild = () => buildCatalogEntries(nativeTemplate(), [], [model]);
+
+    // First sync: freshly built entries merged into an empty on-disk catalog.
+    const firstSync = mergeCatalogEntriesForSync([], rebuild(), new Map(), [], false);
+    const firstRow = firstSync.find(e => e.slug === "deepseek/deepseek-v4")!;
+    expect(firstRow.display_name).toBe("DeepSeek V4");
+
+    // Second sync: re-derive from the SAME config and merge against the now-populated catalog.
+    // Routed entries are rebuilt from gatherRoutedModels each sync, so display_name must be
+    // re-derived deterministically and never drift back to the bare slug.
+    const secondSync = mergeCatalogEntriesForSync(firstSync, rebuild(), new Map(), [], false);
+    const secondRow = secondSync.find(e => e.slug === "deepseek/deepseek-v4")!;
+    expect(secondRow.display_name).toBe("DeepSeek V4");
+    expect(secondRow.slug).toBe("deepseek/deepseek-v4");
+  });
+
+  test("configured displayName does not override genuine native upstream marketing names", () => {
+    // Native gpt-5.6-* entries come from the pinned upstream snapshot with their real display
+    // names; they carry no CatalogModel (isRouted=false), so a configured displayName can never
+    // reach them — and the fallback-quality discriminator (display_name === slug) still works.
+    const entries = buildCatalogEntries(nativeTemplate(), ["gpt-5.6-sol"], []);
+    const sol = entries.find(e => e.slug === "gpt-5.6-sol");
+    expect(sol?.display_name).toBe("GPT-5.6-Sol");
+
+    // A fallback-quality native (display_name stamped with the bare slug) is still upgraded to
+    // the upstream entry by sync — displayName on routed models does not interfere with that path.
+    const synthesizedLuna = {
+      ...nativeTemplate(),
+      slug: "gpt-5.6-luna",
+      display_name: "gpt-5.6-luna",
+      priority: 9,
+    };
+    const merged = mergeCatalogEntriesForSync([synthesizedLuna], [], new Map(), [], false);
+    expect(merged.find(e => e.slug === "gpt-5.6-luna")?.display_name).toBe("GPT-5.6-Luna");
+  });
+
+  test("a configured customModel displayName propagates end-to-end through gatherRoutedModels", async () => {
+    clearModelCache("custom-provider");
+    const originalFetch = globalThis.fetch;
+    let fetchCalls = 0;
+    globalThis.fetch = (() => {
+      fetchCalls += 1;
+      throw new Error("fetch should not be called");
+    }) as typeof fetch;
+    try {
+      const models = await gatherRoutedModels({
+        port: 10100,
+        defaultProvider: "custom-provider",
+        providers: {
+          "custom-provider": {
+            baseUrl: "https://example.invalid/v1",
+            adapter: "openai-chat",
+            authMode: "key",
+            liveModels: false,
+            models: ["baseline-model"],
+          },
+        },
+        customModels: [
+          { id: "cm-1", provider: "custom-provider", modelId: "renamed-model", displayName: "Renamed Model", addedAt: "2026-01-01T00:00:00.000Z" },
+        ],
+      });
+
+      expect(fetchCalls).toBe(0);
+      // The configured custom row is added alongside the provider's baseline model; displayName
+      // rides only on the custom row.
+      const custom = models.find(m => m.provider === "custom-provider" && m.id === "renamed-model");
+      expect(custom?.displayName).toBe("Renamed Model");
+
+      const entries = buildCatalogEntries(nativeTemplate(), [], models);
+      const row = entries.find(e => e.slug === "custom-provider/renamed-model");
+      expect(row?.display_name).toBe("Renamed Model");
+      expect(row?.slug).toBe("custom-provider/renamed-model");
+    } finally {
+      globalThis.fetch = originalFetch;
+      clearModelCache("custom-provider");
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- preserve `customModels[].displayName` when OpenCodex regenerates the Codex model catalog
- change only the picker label (`display_name`), leaving routing slugs, aliases, providers, and native OpenAI marketing names untouched
- document repeated-sync and managed-restart behavior, including the best-effort offline-boot fallback

## Root cause

OpenCodex already accepted and persisted `displayName` for custom models, but `gatherRoutedModels()` dropped it before catalog generation. Each `ocx sync` therefore rebuilt the row with its routed slug as the visible label.

This change carries the configured label into `CatalogModel` and applies it only to the generated catalog row `display_name`.

## Restart behavior

The managed service attempts a catalog sync after the proxy binds on startup. A successful restart therefore reapplies configured display names from `config.json`. If that best-effort sync cannot complete, the previously persisted catalog remains in place and the next successful `ocx sync` reapplies the label.

## Safety

- no authentication, credential, launchd, routing, alias, provider, or native-model behavior changed
- no custom model catalog is made global
- display names cannot alter the provider/model slug

## Validation

- `bun run typecheck`
- `bun run prepush`: 3,520 tests passed, GUI lint passed, privacy scan passed
- `bun test tests/codex-catalog.test.ts`: 90 tests passed
- `bun run build` in `docs-site`: 121 pages built
- `git diff --check`

## Regression coverage

- configured label reaches `display_name`
- absent or whitespace-only label retains historical fallback
- slug, alias, and provider remain unchanged
- repeated catalog regeneration is idempotent
- native OpenAI marketing names remain untouched
- `customModels` propagation is covered end to end

Authored by Diego Cantarero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom model display names in the Codex model picker.
  * Display names can be configured through the CLI or proxy management API.
  * Custom names are preserved during catalog refreshes and syncs.
  * Display names affect presentation only and do not change routing, aliases, or model identity.

* **Documentation**
  * Added setup, validation, persistence, and fallback behavior guidance for custom model display names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->