### PR TITLE
fix(google): comprehensively eliminate Antigravity request-shape 400s

### DIFF
--- a/src/adapters/google-http.ts
+++ b/src/adapters/google-http.ts
@@ -1,5 +1,6 @@
 import type { AdapterFetchContext, AdapterRequest } from "./base";
 import { isQuotaExhaustedBody, retryableGoogleStatus, safeGoogleHttpErrorMessage } from "./google-errors";
+import { repairGoogleInvalidRequestBody } from "./google-wire-compiler";
 import { normalizeUpstreamHttpErrorResponse, readDisplaySafeErrorPayloadText } from "./upstream-http-error";
 import {
   abortError,
@@ -29,14 +30,32 @@ async function normalizeFinalGoogleError(label: string, res: Response, signal?: 
 export async function fetchGoogleWithRetry(label: string, request: AdapterRequest, ctx: AdapterFetchContext = {}): Promise<Response> {
   const timeoutMs = ctx.timeoutMs ?? 200_000;
   let lastError: unknown;
+  let activeRequest = request;
+  let compatibilityReplayUsed = false;
   for (let attempt = 0; attempt < GOOGLE_RETRY_ATTEMPTS; attempt++) {
     if (ctx.abortSignal?.aborted) throw abortError(ctx.abortSignal);
     try {
-      const res = await fetchWithAttemptDeadline(request.url, {
-        method: request.method,
-        headers: request.headers,
-        body: request.body,
+      const res = await fetchWithAttemptDeadline(activeRequest.url, {
+        method: activeRequest.method,
+        headers: activeRequest.headers,
+        body: activeRequest.body,
       }, timeoutMs, ctx.abortSignal, ctx.stream);
+      if (res.status === 400 && !compatibilityReplayUsed) {
+        let payloadText = "";
+        try {
+          payloadText = await readDisplaySafeErrorPayloadText(res.clone(), ctx.abortSignal);
+        } catch (error) {
+          if (ctx.abortSignal?.aborted) throw error;
+        }
+        const repairedBody = repairGoogleInvalidRequestBody(activeRequest.body, payloadText);
+        if (repairedBody !== undefined) {
+          compatibilityReplayUsed = true;
+          activeRequest = { ...activeRequest, body: repairedBody };
+          cancelResponseBodyBestEffort(res);
+          attempt--; // The changed-request replay is separate from transient retry accounting.
+          continue;
+        }
+      }
       if (!retryableGoogleStatus(res.status) || attempt === GOOGLE_RETRY_ATTEMPTS - 1) {
         return ctx.returnRawErrors ? res : normalizeFinalGoogleError(label, res, ctx.abortSignal);
       }

--- a/src/adapters/google-tool-schema.ts
+++ b/src/adapters/google-tool-schema.ts
@@ -1,98 +1,173 @@
 type Schema = Record<string, unknown>;
 
-// Gemini / Antigravity (CCA) accept only an OpenAPI-3.0 subset for function `parameters`. Codex
-// emits full JSON-Schema (draft 2020-12) tool definitions, so passing them through verbatim makes
-// CCA reject the whole request with "Request contains an invalid argument" / "Unknown name ...".
-// Every keyword below was confirmed live against the Antigravity backend to trigger a 400.
-// `encrypted` is Codex's Responses-only marker (openai/codex 5f4d06ef, PR #26210) stamped on v2
-// collaboration tool schemas (spawn_agent/send_message/followup_task `message`); CCA rejects it
-// with 400 "Unknown name \"encrypted\"" (issue #85). It is an annotation for the ChatGPT backend
-// only, so dropping it never changes tool behavior.
-const DROPPED_SCHEMA_KEYS = new Set([
-  "$schema", "$id", "$comment", "$ref", "$defs", "definitions",
-  "examples", "patternProperties", "if", "then", "else",
-  "uniqueItems", "additionalItems", "unevaluatedProperties", "unevaluatedItems",
-  "dependentRequired", "dependentSchemas", "propertyNames", "contains",
-  "encrypted",
-]);
+// Google documents this function-schema subset: type, nullable, required, format, description,
+// properties, items, enum, anyOf, $ref, and $defs. We inline local refs and normalize anyOf, so
+// only the eight scalar/container keywords below are ever emitted. Building from an allowlist
+// prevents new MCP/JSON-Schema annotations from turning into provider-wide 400 responses.
+const ALLOWED_TYPES = new Set(["string", "integer", "number", "boolean", "array", "object"]);
+const MAX_SCHEMA_DEPTH = 24; // Google's documented nesting limit is 32; leave headroom for CCA.
+const MAX_DEREF_DEPTH = 16;
 
-const MAX_DEREF_DEPTH = 64;
+function isRecord(value: unknown): value is Schema {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
 
 function resolveRef(ref: string, defs: Map<string, unknown>): unknown {
-  // Only local pointers into the schema's own $defs/definitions are supported (e.g.
-  // "#/$defs/Foo"). Anything else cannot be inlined, so it collapses to an unconstrained object.
+  // Only local pointers into the schema's own $defs/definitions are safe to inline.
   const match = /^#\/(?:\$defs|definitions)\/(.+)$/.exec(ref);
   if (!match) return undefined;
-  return defs.get(decodeURIComponent(match[1].replace(/~1/g, "/").replace(/~0/g, "~")));
+  try {
+    return defs.get(decodeURIComponent(match[1].replace(/~1/g, "/").replace(/~0/g, "~")));
+  } catch {
+    return undefined;
+  }
 }
 
 function collectDefs(root: unknown, defs: Map<string, unknown>): void {
-  if (!root || typeof root !== "object") return;
+  if (!isRecord(root)) return;
   for (const bag of ["$defs", "definitions"] as const) {
-    const group = (root as Schema)[bag];
-    if (group && typeof group === "object" && !Array.isArray(group)) {
-      for (const [name, value] of Object.entries(group as Schema)) {
-        if (!defs.has(name)) defs.set(name, value);
-      }
+    const group = root[bag];
+    if (!isRecord(group)) continue;
+    for (const [name, value] of Object.entries(group)) {
+      if (!defs.has(name)) defs.set(name, value);
     }
   }
 }
 
-function normalizeType(value: unknown, out: Schema): void {
-  // JSON-Schema allows `type` to be an array (e.g. ["string","null"]); OpenAPI 3.0 does not.
-  // Collapse to the first non-null type and mark the field nullable when "null" was present.
-  if (!Array.isArray(value)) {
-    out.type = value;
-    return;
+function normalizeType(value: unknown, out: Schema, preserveNullType: boolean): void {
+  const candidates = Array.isArray(value) ? value : [value];
+  let sawNull = false;
+
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string") continue;
+    const type = candidate.toLowerCase();
+    if (type === "null") {
+      sawNull = true;
+    } else if (out.type === undefined && ALLOWED_TYPES.has(type)) {
+      out.type = type;
+    }
   }
-  const nonNull = value.filter(t => t !== "null");
-  if (value.includes("null")) out.nullable = true;
-  if (nonNull.length > 0) out.type = nonNull[0];
+
+  if (!sawNull) return;
+  if (out.type !== undefined) out.nullable = true;
+  else if (preserveNullType) out.type = "null";
+  else out.nullable = true;
 }
 
-function sanitize(node: unknown, defs: Map<string, unknown>, depth: number): unknown {
-  if (Array.isArray(node)) return node.map(item => sanitize(item, defs, depth));
-  if (!node || typeof node !== "object") return node;
-  const input = node as Schema;
+function sanitizeEnum(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const values = [...new Set(value.filter((item): item is string => typeof item === "string"))];
+  return values.length > 0 ? values : undefined;
+}
 
-  if (typeof input.$ref === "string" && depth < MAX_DEREF_DEPTH) {
-    const target = resolveRef(input.$ref, defs);
-    if (target && typeof target === "object") {
-      const merged: Schema = { ...(target as Schema) };
-      for (const [key, value] of Object.entries(input)) {
+function normalizeAnyOf(
+  value: unknown,
+  defs: Map<string, unknown>,
+  depth: number,
+  refDepth: number,
+): Schema {
+  if (!Array.isArray(value) || value.length === 0) return {};
+  const schemas = value.map(item => sanitizeSchema(item, defs, depth + 1, refDepth, true));
+
+  const nonNullSchemas = schemas.filter(schema => schema.type !== "null");
+  const nullSchemas = schemas.filter(schema => schema.type === "null");
+  if (
+    nonNullSchemas.length === 1
+    && nullSchemas.length > 0
+    && nullSchemas.every(schema => Object.keys(schema).every(key => key === "type"))
+  ) {
+    return { ...nonNullSchemas[0], nullable: true };
+  }
+
+  const type = schemas[0]?.type;
+  const sameType = schemas.length > 0 && schemas.every(schema => schema.type === type);
+  const enumOnly = schemas.every(schema => {
+    const allowedKeys = type === undefined ? new Set(["enum"]) : new Set(["type", "enum"]);
+    return Array.isArray(schema.enum) && Object.keys(schema).every(key => allowedKeys.has(key));
+  });
+  if (sameType && enumOnly && type !== "null") {
+    const values = sanitizeEnum(schemas.flatMap(schema => schema.enum as unknown[]));
+    if (values) return { ...(typeof type === "string" ? { type } : {}), enum: values };
+  }
+
+  // CCA's Claude bridge turns typed anyOf branches into an invalid input_schema. Widen only this
+  // node when a union cannot be collapsed losslessly; parent annotations and structure survive.
+  return {};
+}
+
+function sanitizeProperties(
+  value: unknown,
+  defs: Map<string, unknown>,
+  depth: number,
+  refDepth: number,
+): Record<string, Schema> | undefined {
+  if (!isRecord(value)) return undefined;
+  const properties: Record<string, Schema> = Object.create(null) as Record<string, Schema>;
+  for (const [name, schema] of Object.entries(value)) {
+    // Property names form a name bag and must never be interpreted as schema keywords.
+    properties[name] = sanitizeSchema(schema, defs, depth + 1, refDepth, false);
+  }
+  return properties;
+}
+
+function sanitizeSchema(
+  node: unknown,
+  defs: Map<string, unknown>,
+  depth: number,
+  refDepth: number,
+  preserveNullType: boolean,
+): Schema {
+  if (depth >= MAX_SCHEMA_DEPTH || !isRecord(node)) return {};
+
+  if (typeof node.$ref === "string" && refDepth < MAX_DEREF_DEPTH) {
+    const target = resolveRef(node.$ref, defs);
+    if (isRecord(target)) {
+      const merged: Schema = { ...target };
+      for (const [key, value] of Object.entries(node)) {
         if (key !== "$ref") merged[key] = value;
       }
-      return sanitize(merged, defs, depth + 1);
+      return sanitizeSchema(merged, defs, depth, refDepth + 1, preserveNullType);
     }
   }
 
   const out: Schema = {};
-  for (const [key, value] of Object.entries(input)) {
-    if (DROPPED_SCHEMA_KEYS.has(key)) continue;
-    if (key === "type") { normalizeType(value, out); continue; }
-    if (key === "const") { out.enum = [value]; continue; }
-    if (key === "exclusiveMinimum" && typeof value === "number") { out.minimum = value; continue; }
-    if (key === "exclusiveMaximum" && typeof value === "number") { out.maximum = value; continue; }
-    if (key === "required" && Array.isArray(value)) {
-      out.required = [...new Set(value.filter((item): item is string => typeof item === "string"))];
-      continue;
-    }
-    if (key === "additionalProperties") {
-      // A boolean additionalProperties is accepted, but a nested schema is only meaningful with
-      // its own sanitize pass.
-      out.additionalProperties = typeof value === "boolean" ? value : sanitize(value, defs, depth);
-      continue;
-    }
-    out[key] = sanitize(value, defs, depth);
+  normalizeType(node.type, out, preserveNullType);
+
+  if (typeof node.nullable === "boolean") out.nullable = node.nullable;
+  if (typeof node.description === "string") out.description = node.description;
+  if (typeof node.format === "string") out.format = node.format;
+
+  const enumValues = sanitizeEnum(node.enum ?? (typeof node.const === "string" ? [node.const] : undefined));
+  if (enumValues) out.enum = enumValues;
+
+  const properties = sanitizeProperties(node.properties, defs, depth, refDepth);
+  if (properties) out.properties = properties;
+
+  if (isRecord(node.items)) {
+    out.items = sanitizeSchema(node.items, defs, depth + 1, refDepth, false);
   }
+
+  if (Array.isArray(node.required)) {
+    out.required = [...new Set(node.required.filter((item): item is string => typeof item === "string"))];
+  }
+
+  if (node.anyOf !== undefined) Object.assign(out, normalizeAnyOf(node.anyOf, defs, depth, refDepth));
   return out;
 }
 
 export function sanitizeGeminiToolParameters(parameters: unknown): Record<string, unknown> {
-  const defs = new Map<string, unknown>();
-  collectDefs(parameters, defs);
-  const result = sanitize(parameters, defs, 0);
-  return result && typeof result === "object" && !Array.isArray(result)
-    ? result as Record<string, unknown>
-    : { type: "object" };
+  try {
+    const defs = new Map<string, unknown>();
+    collectDefs(parameters, defs);
+    const root = sanitizeSchema(parameters, defs, 0, 0, false);
+
+    // Function arguments are always an object. Claude additionally rejects root composition and a
+    // missing root type even when those forms are valid general-purpose JSON Schema.
+    root.type = "object";
+    if (!isRecord(root.properties)) root.properties = {};
+    return root;
+  } catch {
+    // Last-resort containment: no third-party schema may break every tool in the request.
+    return { type: "object", properties: {} };
+  }
 }

--- a/src/adapters/google-wire-compiler.ts
+++ b/src/adapters/google-wire-compiler.ts
@@ -1,0 +1,228 @@
+import { createHash } from "node:crypto";
+import { sanitizeGeminiToolParameters } from "./google-tool-schema";
+
+type JsonObject = Record<string, unknown>;
+
+const GOOGLE_TOOL_NAME = /^[A-Za-z_][A-Za-z0-9_-]{0,63}$/;
+const GOOGLE_THINKING_LEVELS = new Set(["minimal", "low", "medium", "high"]);
+
+function isObject(value: unknown): value is JsonObject {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function toolNameCodec(names: readonly string[]): {
+  toWire: (name: string) => string;
+  fromWire: (name: string) => string;
+} {
+  const toWire = new Map<string, string>();
+  const fromWire = new Map<string, string>();
+  const used = new Set<string>();
+
+  for (const name of names) {
+    if (toWire.has(name)) continue;
+    if (GOOGLE_TOOL_NAME.test(name) && !used.has(name)) {
+      toWire.set(name, name);
+      fromWire.set(name, name);
+      used.add(name);
+      continue;
+    }
+
+    let cleaned = name.replace(/[^A-Za-z0-9_-]/g, "_");
+    if (!/^[A-Za-z_]/.test(cleaned)) cleaned = `_${cleaned}`;
+    const prefix = (cleaned || "tool").slice(0, 55);
+    for (let salt = 0; ; salt++) {
+      const hashInput = salt === 0 ? name : `${name}#${salt}`;
+      const suffix = createHash("sha256").update(hashInput).digest("hex").slice(0, 8);
+      const candidate = `${prefix}_${suffix}`;
+      if (used.has(candidate)) continue;
+      toWire.set(name, candidate);
+      fromWire.set(candidate, name);
+      used.add(candidate);
+      break;
+    }
+  }
+
+  return {
+    toWire: name => toWire.get(name) ?? name,
+    fromWire: name => fromWire.get(name) ?? name,
+  };
+}
+
+function collectToolNames(body: JsonObject): string[] {
+  const names: string[] = [];
+  if (Array.isArray(body.tools)) {
+    for (const rawTool of body.tools) {
+      if (!isObject(rawTool) || !Array.isArray(rawTool.functionDeclarations)) continue;
+      for (const rawDeclaration of rawTool.functionDeclarations) {
+        if (isObject(rawDeclaration) && typeof rawDeclaration.name === "string") names.push(rawDeclaration.name);
+      }
+    }
+  }
+  if (Array.isArray(body.contents)) {
+    for (const rawContent of body.contents) {
+      if (!isObject(rawContent) || !Array.isArray(rawContent.parts)) continue;
+      for (const rawPart of rawContent.parts) {
+        if (!isObject(rawPart)) continue;
+        for (const key of ["functionCall", "functionResponse"]) {
+          const call = rawPart[key];
+          if (isObject(call) && typeof call.name === "string") names.push(call.name);
+        }
+      }
+    }
+  }
+  return names;
+}
+
+function compileContents(value: unknown, toWireName: (name: string) => string): unknown[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.map(rawContent => {
+    if (!isObject(rawContent)) return {};
+    const content = { ...rawContent };
+    if (!Array.isArray(rawContent.parts)) return content;
+    content.parts = rawContent.parts.map(rawPart => {
+      if (!isObject(rawPart)) return {};
+      const part = { ...rawPart };
+      for (const key of ["functionCall", "functionResponse"]) {
+        const call = rawPart[key];
+        if (isObject(call) && typeof call.name === "string") {
+          part[key] = { ...call, name: toWireName(call.name) };
+        }
+      }
+      return part;
+    });
+    return content;
+  });
+}
+
+function compileTools(value: unknown, toWireName: (name: string) => string): unknown[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const tools = value.flatMap(rawTool => {
+    if (!isObject(rawTool) || !Array.isArray(rawTool.functionDeclarations)) return [];
+    const functionDeclarations = rawTool.functionDeclarations.flatMap(rawDeclaration => {
+      if (!isObject(rawDeclaration) || typeof rawDeclaration.name !== "string") return [];
+      return [{
+        name: toWireName(rawDeclaration.name),
+        ...(typeof rawDeclaration.description === "string" ? { description: rawDeclaration.description } : {}),
+        parameters: sanitizeGeminiToolParameters(rawDeclaration.parameters),
+      }];
+    });
+    return functionDeclarations.length > 0 ? [{ functionDeclarations }] : [];
+  });
+  return tools.length > 0 ? tools : undefined;
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function compileGenerationConfig(value: unknown): JsonObject | undefined {
+  if (!isObject(value)) return undefined;
+  const out: JsonObject = {};
+  const maxOutputTokens = finiteNumber(value.maxOutputTokens);
+  if (maxOutputTokens !== undefined && maxOutputTokens > 0) out.maxOutputTokens = Math.floor(maxOutputTokens);
+  const temperature = finiteNumber(value.temperature);
+  if (temperature !== undefined && temperature >= 0) out.temperature = Math.min(2, temperature);
+  const topP = finiteNumber(value.topP);
+  if (topP !== undefined && topP >= 0) out.topP = Math.min(1, topP);
+  if (Array.isArray(value.stopSequences)) {
+    const stopSequences = [...new Set(value.stopSequences.filter(
+      (item): item is string => typeof item === "string" && item.length > 0,
+    ))].slice(0, 5);
+    if (stopSequences.length > 0) out.stopSequences = stopSequences;
+  }
+  if (isObject(value.thinkingConfig) && typeof value.thinkingConfig.thinkingLevel === "string") {
+    const raw = value.thinkingConfig.thinkingLevel.toLowerCase();
+    const thinkingLevel = GOOGLE_THINKING_LEVELS.has(raw)
+      ? raw
+      : (["xhigh", "max", "ultra"].includes(raw) ? "high" : undefined);
+    if (thinkingLevel) out.thinkingConfig = { thinkingLevel };
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function compileToolConfig(value: unknown, toWireName: (name: string) => string): JsonObject | undefined {
+  if (!isObject(value) || !isObject(value.functionCallingConfig)) return undefined;
+  const raw = value.functionCallingConfig;
+  const out: JsonObject = {};
+  if (typeof raw.mode === "string" && ["AUTO", "ANY", "NONE", "VALIDATED"].includes(raw.mode.toUpperCase())) {
+    out.mode = raw.mode.toUpperCase();
+  }
+  if (Array.isArray(raw.allowedFunctionNames)) {
+    const names = raw.allowedFunctionNames
+      .filter((name): name is string => typeof name === "string")
+      .map(toWireName);
+    if (names.length > 0) out.allowedFunctionNames = names;
+  }
+  return Object.keys(out).length > 0 ? { functionCallingConfig: out } : undefined;
+}
+
+/**
+ * Final trust boundary for every Google-family request. The adapter may build a convenient
+ * Gemini-shaped object; only this compiler is allowed to decide what reaches the wire.
+ */
+export function compileGoogleWireBody(input: unknown): {
+  body: JsonObject;
+  restoreToolName: (name: string) => string;
+} {
+  const source = isObject(input) ? input : {};
+  const names = toolNameCodec(collectToolNames(source));
+  const body: JsonObject = {};
+  const contents = compileContents(source.contents, names.toWire);
+  if (contents) body.contents = contents;
+  if (isObject(source.systemInstruction)) body.systemInstruction = source.systemInstruction;
+  const tools = compileTools(source.tools, names.toWire);
+  if (tools) body.tools = tools;
+  const generationConfig = compileGenerationConfig(source.generationConfig);
+  if (generationConfig) body.generationConfig = generationConfig;
+  const toolConfig = compileToolConfig(source.toolConfig, names.toWire);
+  if (toolConfig) body.toolConfig = toolConfig;
+  if (typeof source.sessionId === "string" && source.sessionId.length > 0) body.sessionId = source.sessionId;
+  return { body, restoreToolName: names.fromWire };
+}
+
+function functionDeclarations(root: JsonObject): JsonObject[] {
+  if (!Array.isArray(root.tools)) return [];
+  return root.tools.flatMap(rawTool => {
+    if (!isObject(rawTool) || !Array.isArray(rawTool.functionDeclarations)) return [];
+    return rawTool.functionDeclarations.filter(isObject);
+  });
+}
+
+/** Build a changed request for one known-safe replay of an INVALID_ARGUMENT response. */
+export function repairGoogleInvalidRequestBody(body: string, errorPayload: string): string | undefined {
+  const schemaError = /(?:input[_ ]schema|json schema|function[_ ]declarations?|x-mcp-header)/i.test(errorPayload);
+  const thinkingError = /thinking[_ ]?(?:config|level)/i.test(errorPayload);
+  if (!schemaError && !thinkingError) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body) as unknown;
+  } catch {
+    return undefined;
+  }
+  if (!isObject(parsed)) return undefined;
+  const root = isObject(parsed.request) ? parsed.request : parsed;
+  let changed = false;
+
+  if (thinkingError && isObject(root.generationConfig) && "thinkingConfig" in root.generationConfig) {
+    delete root.generationConfig.thinkingConfig;
+    if (Object.keys(root.generationConfig).length === 0) delete root.generationConfig;
+    changed = true;
+  }
+
+  if (schemaError) {
+    const declarations = functionDeclarations(root);
+    if (declarations.length > 0) {
+      const indexed = /tools(?:\.|\[)(\d+)(?:\])?\.custom\.input_schema/i.exec(errorPayload)?.[1]
+        ?? /function[_]?declarations(?:\.|\[)(\d+)/i.exec(errorPayload)?.[1];
+      const index = indexed === undefined ? -1 : Number.parseInt(indexed, 10);
+      const rejected = declarations[index];
+      const targets = rejected ? [rejected] : declarations;
+      for (const declaration of targets) {
+        declaration.parameters = { type: "object", properties: {} };
+        delete declaration.parametersJsonSchema;
+      }
+      changed = true;
+    }
+  }
+  return changed ? JSON.stringify(parsed) : undefined;
+}

--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -18,7 +18,7 @@ import { fetchAntigravityWithRetry, fetchVertexWithRetry } from "./google-http";
 import { safeAntigravityHttpErrorMessage, safeVertexHttpErrorMessage } from "./google-errors";
 import { isVertexTruncationReason, vertexTruncationErrorMessage } from "./google-truncation";
 import { ANTIGRAVITY_REQUEST_UA, antigravitySessionId, isLikelyRealThoughtSignature, sanitizeAntigravityClaudeSignatures } from "./google-antigravity-wire";
-import { sanitizeGeminiToolParameters } from "./google-tool-schema";
+import { compileGoogleWireBody } from "./google-wire-compiler";
 import { neutralizeIdentity } from "./identity";
 import { antigravityUsesReplayCache, applyAntigravityReplay, clearAntigravityReplay, observeAntigravityReplay } from "./google-antigravity-replay";
 import { resolveAntigravityEffortWireModel } from "../providers/antigravity-models";
@@ -179,7 +179,7 @@ function toolsToGeminiFormat(parsed: OcxParsedRequest): unknown[] | undefined {
     functionDeclarations: tools.map(t => ({
       name: namespacedToolName(t.namespace, t.name),
       description: t.description,
-      parameters: sanitizeGeminiToolParameters(t.parameters),
+      parameters: t.parameters,
     })),
   }];
 }
@@ -199,6 +199,7 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
   // can stash the CCA model/session for parseStream's reasoning-replay observation.
   let antigravityModel: string | undefined;
   let antigravitySession: string | undefined;
+  let restoreGoogleToolName = (name: string): string => name;
   return {
     name: "google",
 
@@ -262,23 +263,27 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
         }
         // Reasoning continuity: Gemini models re-inject cached thoughtSignatures; Claude-on-Antigravity
         // sanitizes signatures inline (no cache). Both guard against the upstream 400 on bad signatures.
-        if (Array.isArray((body as { contents?: unknown[] }).contents)) {
-          const contents = (body as { contents: unknown[] }).contents;
+        // The real Antigravity client puts the session id ONLY at `request.sessionId` (camelCase,
+        // nested) — matching CLIProxyAPI `generateStableSessionID`. An extra top-level/snake_case
+        // spelling is a non-first-party key, so we send the single canonical location.
+        const draftRequest: Record<string, unknown> = { ...body, sessionId };
+        // Claude-on-Antigravity forces VALIDATED function calling (the real client always sets it).
+        if (/claude/i.test(wireModelId)) {
+          const existing = (draftRequest.toolConfig ?? {}) as Record<string, unknown>;
+          const fcc = (existing.functionCallingConfig ?? {}) as Record<string, unknown>;
+          draftRequest.toolConfig = { ...existing, functionCallingConfig: { ...fcc, mode: "VALIDATED" } };
+        }
+        const compiled = compileGoogleWireBody(draftRequest);
+        const request = compiled.body;
+        restoreGoogleToolName = compiled.restoreToolName;
+        // Compile names before replay: signatures are keyed by the exact provider-visible name.
+        if (Array.isArray((request as { contents?: unknown[] }).contents)) {
+          const contents = (request as { contents: unknown[] }).contents;
           if (antigravityUsesReplayCache(wireModelId)) {
             applyAntigravityReplay(wireModelId, sessionId, contents);
           } else {
             sanitizeAntigravityClaudeSignatures(contents);
           }
-        }
-        // The real Antigravity client puts the session id ONLY at `request.sessionId` (camelCase,
-        // nested) — matching CLIProxyAPI `generateStableSessionID`. An extra top-level/snake_case
-        // spelling is a non-first-party key, so we send the single canonical location.
-        const request: Record<string, unknown> = { ...body, sessionId };
-        // Claude-on-Antigravity forces VALIDATED function calling (the real client always sets it).
-        if (/claude/i.test(wireModelId)) {
-          const existing = (request.toolConfig ?? {}) as Record<string, unknown>;
-          const fcc = (existing.functionCallingConfig ?? {}) as Record<string, unknown>;
-          request.toolConfig = { ...existing, functionCallingConfig: { ...fcc, mode: "VALIDATED" } };
         }
         const envelope = {
           model: wireModelId,
@@ -297,12 +302,14 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
       }
 
       if (provider.googleMode === "vertex") {
+        const compiled = compileGoogleWireBody(body);
+        restoreGoogleToolName = compiled.restoreToolName;
         // Vertex AI: project/location endpoint with GCP ADC, or x-goog-api-key fast path.
         const apiKey = resolveVertexApiKey(provider.apiKey);
         if (apiKey) {
           const url = `https://aiplatform.googleapis.com/v1/publishers/google/models/${parsed.modelId}:${method}${streamParam}`;
           headers["x-goog-api-key"] = apiKey;
-          return { url, method: "POST", headers, body: JSON.stringify(body) };
+          return { url, method: "POST", headers, body: JSON.stringify(compiled.body) };
         }
         const project = provider.project || process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT;
         if (!project) throw new Error("Vertex AI requires a project id (provider.project or GOOGLE_CLOUD_PROJECT/GCLOUD_PROJECT).");
@@ -312,7 +319,7 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
         const url = `https://${host}/v1/projects/${project}/locations/${location}/publishers/google/models/${parsed.modelId}:${method}${streamParam}`;
         const token = await getVertexAccessToken();
         headers["Authorization"] = `Bearer ${token}`;
-        return { url, method: "POST", headers, body: JSON.stringify(body) };
+        return { url, method: "POST", headers, body: JSON.stringify(compiled.body) };
       }
 
       // ai-studio (default): Generative Language API + x-goog-api-key.
@@ -321,7 +328,9 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
       if (!apiKey) throw new Error("google (AI Studio) requires a non-empty API key");
       headers["x-goog-api-key"] = apiKey;
 
-      return { url, method: "POST", headers, body: JSON.stringify(body) };
+      const compiled = compileGoogleWireBody(body);
+      restoreGoogleToolName = compiled.restoreToolName;
+      return { url, method: "POST", headers, body: JSON.stringify(compiled.body) };
     },
 
     async *parseStream(response: Response): AsyncGenerator<AdapterEvent> {
@@ -403,7 +412,7 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
                 if (part.functionCall) {
                   const id = `call_${crypto.randomUUID().slice(0, 8)}`;
                   toolCallsStarted++;
-                  yield { type: "tool_call_start", id, name: part.functionCall.name };
+                  yield { type: "tool_call_start", id, name: restoreGoogleToolName(part.functionCall.name) };
                   yield { type: "tool_call_delta", arguments: JSON.stringify(part.functionCall.args ?? {}) };
                   yield { type: "tool_call_end" };
                 }
@@ -456,7 +465,7 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
           if (part.functionCall) {
             const id = `call_${crypto.randomUUID().slice(0, 8)}`;
             toolCallsStarted++;
-            events.push({ type: "tool_call_start", id, name: part.functionCall.name });
+            events.push({ type: "tool_call_start", id, name: restoreGoogleToolName(part.functionCall.name) });
             events.push({ type: "tool_call_delta", arguments: JSON.stringify(part.functionCall.args ?? {}) });
             events.push({ type: "tool_call_end" });
           }

--- a/src/providers/antigravity-models.ts
+++ b/src/providers/antigravity-models.ts
@@ -47,6 +47,13 @@ const ANTIGRAVITY_DEFAULT_EFFORT: Record<string, string> = {
   "gemini-3.1-pro": "high",
 };
 
+const ANTIGRAVITY_THINKING_LEVELS = new Set(["minimal", "low", "medium", "high"]);
+
+function resolveAntigravityThinkingLevel(effort: string): string | undefined {
+  if (effort === "xhigh" || effort === "max" || effort === "ultra") return "high";
+  return ANTIGRAVITY_THINKING_LEVELS.has(effort) ? effort : undefined;
+}
+
 // ── Visible client aliases (kept for saved-config compat, not picker-visible) ──
 const ANTIGRAVITY_VISIBLE_MODEL_ALIASES: Record<string, string> = {
   "gemini-3.1-pro-high": "gemini-pro-agent",
@@ -152,10 +159,9 @@ export function resolveAntigravityEffortWireModel(
   }
 
   // Rule 4: Claude models — effort via thinkingConfig only (no suffix variants).
-  // Anthropic adaptive thinking supports low/medium/high/max for both Sonnet 4.6 and Opus 4.6.
-  // CLIProxyAPI proves CCA accepts thinkingConfig on base IDs (validation confirmed).
+  // CCA validates this field as Google's ThinkingLevel enum, whose highest value is `high`.
   if (/^claude-/.test(modelId) && effort) {
-    return { wireModelId: modelId, thinkingLevel: effort };
+    return { wireModelId: modelId, thinkingLevel: resolveAntigravityThinkingLevel(effort) };
   }
 
   // Rule 5: everything else.

--- a/tests/google-antigravity-wire.test.ts
+++ b/tests/google-antigravity-wire.test.ts
@@ -246,18 +246,18 @@ describe("antigravity CCA envelope", () => {
     expect(env.request.generationConfig?.thinkingConfig?.thinkingLevel).toBe("high");
   });
 
-  test("claude-opus-4-6-thinking with effort=max sends thinkingConfig max", async () => {
+  test("claude-opus-4-6-thinking with effort=max clamps CCA thinkingLevel to high", async () => {
     const req = await createGoogleAdapter(effortProvider).buildRequest(parsedWithEffort("claude-opus-4-6-thinking", "max"));
     const env = JSON.parse(req.body);
     expect(env.model).toBe("claude-opus-4-6-thinking");
-    expect(env.request.generationConfig?.thinkingConfig?.thinkingLevel).toBe("max");
+    expect(env.request.generationConfig?.thinkingConfig?.thinkingLevel).toBe("high");
   });
 
-  test("claude-opus-4-6-thinking with effort=ultra clamps to max", async () => {
+  test("claude-opus-4-6-thinking with effort=ultra clamps CCA thinkingLevel to high", async () => {
     const req = await createGoogleAdapter(effortProvider).buildRequest(parsedWithEffort("claude-opus-4-6-thinking", "ultra"));
     const env = JSON.parse(req.body);
     expect(env.model).toBe("claude-opus-4-6-thinking");
-    expect(env.request.generationConfig?.thinkingConfig?.thinkingLevel).toBe("max");
+    expect(env.request.generationConfig?.thinkingConfig?.thinkingLevel).toBe("high");
   });
 
   test("claude-opus-4-6-thinking with no effort sends no thinkingConfig", async () => {
@@ -276,11 +276,11 @@ describe("antigravity CCA envelope", () => {
     expect(env.request.generationConfig?.thinkingConfig?.thinkingLevel).toBe("high");
   });
 
-  test("claude-sonnet-4-6 with effort=max sends thinkingConfig max", async () => {
+  test("claude-sonnet-4-6 with effort=max clamps CCA thinkingLevel to high", async () => {
     const req = await createGoogleAdapter(effortProvider).buildRequest(parsedWithEffort("claude-sonnet-4-6", "max"));
     const env = JSON.parse(req.body);
     expect(env.model).toBe("claude-sonnet-4-6");
-    expect(env.request.generationConfig?.thinkingConfig?.thinkingLevel).toBe("max");
+    expect(env.request.generationConfig?.thinkingConfig?.thinkingLevel).toBe("high");
   });
 
   test("claude-sonnet-4-6 with no effort sends no thinkingConfig", async () => {

--- a/tests/google-tool-schema.test.ts
+++ b/tests/google-tool-schema.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { sanitizeGeminiToolParameters } from "../src/adapters/google-tool-schema";
 
 describe("sanitizeGeminiToolParameters", () => {
-  test("drops JSON-Schema keywords CCA rejects", () => {
+  test("drops JSON-Schema keywords outside Google's documented function-schema subset", () => {
     const out = sanitizeGeminiToolParameters({
       $schema: "http://json-schema.org/draft-07/schema#",
       $id: "x",
@@ -24,7 +24,7 @@ describe("sanitizeGeminiToolParameters", () => {
     expect(out.then).toBeUndefined();
     const props = out.properties as Record<string, Record<string, unknown>>;
     expect(props.a.examples).toBeUndefined();
-    expect(props.a.pattern).toBe("^a$");
+    expect(props.a.pattern).toBeUndefined();
     expect(props.b.uniqueItems).toBeUndefined();
     expect((props.b.items as Record<string, unknown>).type).toBe("string");
   });
@@ -56,6 +56,71 @@ describe("sanitizeGeminiToolParameters", () => {
     expect(JSON.stringify(input)).toBe(before); // input object is never mutated
   });
 
+  test("drops MCP header annotations that CCA rejects recursively", () => {
+    const out = sanitizeGeminiToolParameters({
+      type: "object",
+      properties: {
+        token: { type: "string", "x-mcp-header": "Authorization" },
+        nested: {
+          type: "object",
+          properties: {
+            trace: { type: "string", "x-mcp-header": "X-Trace-Id" },
+          },
+        },
+        headers: {
+          type: "array",
+          items: { type: "string", "x-mcp-header": true },
+        },
+      },
+    });
+    const props = out.properties as Record<string, Record<string, unknown>>;
+    expect(props.token["x-mcp-header"]).toBeUndefined();
+    const nested = props.nested.properties as Record<string, Record<string, unknown>>;
+    expect(nested.trace["x-mcp-header"]).toBeUndefined();
+    expect((props.headers.items as Record<string, unknown>)["x-mcp-header"]).toBeUndefined();
+    expect(props.token.type).toBe("string");
+  });
+
+  test("drops draft 2020-12 keywords outside OpenAPI 3.0 subset", () => {
+    const out = sanitizeGeminiToolParameters({
+      type: "object",
+      $vocabulary: { "https://json-schema.org/draft/2020-12/vocab/core": true },
+      $anchor: "root",
+      properties: {
+        payload: {
+          type: "string",
+          contentMediaType: "application/json",
+          contentEncoding: "base64",
+          contentSchema: { type: "object" },
+          deprecated: true,
+        },
+        tuple: {
+          type: "array",
+          prefixItems: [{ type: "string" }, { type: "number" }],
+          items: { type: "string" },
+        },
+        refLike: {
+          $dynamicRef: "#node",
+          $dynamicAnchor: "node",
+          type: "object",
+        },
+      },
+    });
+    expect(out.$vocabulary).toBeUndefined();
+    expect(out.$anchor).toBeUndefined();
+    const props = out.properties as Record<string, Record<string, unknown>>;
+    expect(props.payload.contentMediaType).toBeUndefined();
+    expect(props.payload.contentEncoding).toBeUndefined();
+    expect(props.payload.contentSchema).toBeUndefined();
+    expect(props.payload.deprecated).toBeUndefined();
+    expect(props.payload.type).toBe("string");
+    expect(props.tuple.prefixItems).toBeUndefined();
+    expect((props.tuple.items as Record<string, unknown>).type).toBe("string");
+    expect(props.refLike.$dynamicRef).toBeUndefined();
+    expect(props.refLike.$dynamicAnchor).toBeUndefined();
+    expect(props.refLike.type).toBe("object");
+  });
+
   test("collapses type arrays to a single nullable type", () => {
     const out = sanitizeGeminiToolParameters({
       type: "object",
@@ -66,7 +131,7 @@ describe("sanitizeGeminiToolParameters", () => {
     expect(a.nullable).toBe(true);
   });
 
-  test("rewrites const to enum and exclusive bounds to inclusive", () => {
+  test("rewrites string const to enum and drops unsupported exclusive bounds", () => {
     const out = sanitizeGeminiToolParameters({
       type: "object",
       properties: {
@@ -77,8 +142,8 @@ describe("sanitizeGeminiToolParameters", () => {
     const props = out.properties as Record<string, Record<string, unknown>>;
     expect(props.a.enum).toEqual(["fixed"]);
     expect(props.a.const).toBeUndefined();
-    expect(props.n.minimum).toBe(0);
-    expect(props.n.maximum).toBe(10);
+    expect(props.n.minimum).toBeUndefined();
+    expect(props.n.maximum).toBeUndefined();
     expect(props.n.exclusiveMinimum).toBeUndefined();
   });
 
@@ -88,6 +153,171 @@ describe("sanitizeGeminiToolParameters", () => {
       properties: { query: { type: "string" } },
       required: ["query", "query", 42],
     }).required).toEqual(["query"]);
+  });
+
+  test("drops size constraints outside the strict Google allowlist", () => {
+    const out = sanitizeGeminiToolParameters({
+      type: "object",
+      properties: {
+        text: { type: "string", minLength: -1, maxLength: -2 },
+        list: { type: "array", minItems: -1, maxItems: -2, items: { type: "string" } },
+        object: { type: "object", minProperties: -1, maxProperties: -2, properties: {} },
+        zeroIsValid: { type: "string", minLength: 0 },
+      },
+    });
+    const props = out.properties as Record<string, Record<string, unknown>>;
+    expect(props.text.minLength).toBeUndefined();
+    expect(props.text.maxLength).toBeUndefined();
+    expect(props.list.minItems).toBeUndefined();
+    expect(props.list.maxItems).toBeUndefined();
+    expect(props.object.minProperties).toBeUndefined();
+    expect(props.object.maxProperties).toBeUndefined();
+    expect(props.zeroIsValid.minLength).toBeUndefined();
+  });
+
+  test("collapses same-type enum anyOf branches for Claude-on-Antigravity", () => {
+    const out = sanitizeGeminiToolParameters({
+      type: "object",
+      properties: {
+        status: {
+          description: "New status for the task",
+          anyOf: [
+            { type: "string", enum: ["pending", "in_progress", "completed"] },
+            { type: "string", enum: ["deleted"] },
+          ],
+        },
+      },
+    });
+    const status = (out.properties as Record<string, Record<string, unknown>>).status;
+    expect(status).toEqual({
+      description: "New status for the task",
+      type: "string",
+      enum: ["pending", "in_progress", "completed", "deleted"],
+    });
+  });
+
+  test("collapses Serena nullable anyOf schemas for Claude-on-Antigravity", () => {
+    const out = sanitizeGeminiToolParameters({
+      type: "object",
+      properties: {
+        occurrence_ids: {
+          anyOf: [
+            { type: "array", items: { type: "string" } },
+            { type: "null" },
+          ],
+          default: null,
+          title: "Occurrence Ids",
+          description: "Optional occurrence ids from a dry run.",
+        },
+      },
+    });
+    const occurrenceIds = (out.properties as Record<string, Record<string, unknown>>).occurrence_ids;
+    expect(occurrenceIds).toEqual({
+      type: "array",
+      items: { type: "string" },
+      nullable: true,
+      description: "Optional occurrence ids from a dry run.",
+    });
+  });
+
+  test("widens unsupported typed anyOf unions instead of forwarding a request-breaking schema", () => {
+    const out = sanitizeGeminiToolParameters({
+      type: "object",
+      properties: {
+        value: {
+          description: "A string or number.",
+          anyOf: [
+            { type: "string", minLength: 1 },
+            { type: "number", minimum: 0 },
+          ],
+        },
+      },
+    });
+    const value = (out.properties as Record<string, Record<string, unknown>>).value;
+    expect(value).toEqual({ description: "A string or number." });
+  });
+
+  test("enforces an object root without composition for Claude tool input schemas", () => {
+    expect(sanitizeGeminiToolParameters({})).toEqual({
+      type: "object",
+      properties: {},
+    });
+    expect(sanitizeGeminiToolParameters({
+      anyOf: [
+        { type: "string" },
+        { type: "number" },
+      ],
+    })).toEqual({
+      type: "object",
+      properties: {},
+    });
+  });
+
+  test("emits only the documented Google function-schema allowlist recursively", () => {
+    const out = sanitizeGeminiToolParameters({
+      type: "object",
+      title: "Dropped root title",
+      default: {},
+      futureKeyword: { surprise: true },
+      properties: {
+        safe: {
+          type: "string",
+          description: "Kept description",
+          format: "date-time",
+          title: "Dropped nested title",
+          default: "x",
+          pattern: "^x$",
+          minLength: 1,
+          "x-future-keyword": true,
+        },
+        title: { type: "string" },
+      },
+    });
+    expect(out).toEqual({
+      type: "object",
+      properties: {
+        safe: {
+          type: "string",
+          description: "Kept description",
+          format: "date-time",
+        },
+        title: { type: "string" },
+      },
+    });
+  });
+
+  test("falls back to an open object schema when hostile refs cannot be decoded", () => {
+    expect(sanitizeGeminiToolParameters({
+      $ref: "#/$defs/%E0%A4%A",
+      $defs: { safe: { type: "string" } },
+    })).toEqual({
+      type: "object",
+      properties: {},
+    });
+  });
+
+  test("never leaks the internal null type used while normalizing unions", () => {
+    const out = sanitizeGeminiToolParameters({
+      type: "object",
+      properties: {
+        impossible: {
+          anyOf: [
+            { type: "null", enum: ["x"] },
+            { type: "null", enum: ["y"] },
+          ],
+        },
+      },
+    });
+    expect((out.properties as Record<string, unknown>).impossible).toEqual({});
+  });
+
+  test("preserves property names that overlap JavaScript prototype keys", () => {
+    const properties = JSON.parse('{"__proto__":{"type":"string"},"constructor":{"type":"number"}}');
+    const out = sanitizeGeminiToolParameters({ type: "object", properties });
+    const sanitized = out.properties as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(sanitized, "__proto__")).toBe(true);
+    expect(sanitized.__proto__).toEqual({ type: "string" });
+    expect(sanitized.constructor).toEqual({ type: "number" });
   });
 
   test("inlines local $ref into $defs and removes the defs bag", () => {
@@ -114,7 +344,7 @@ describe("sanitizeGeminiToolParameters", () => {
   });
 
   test("falls back to an object schema for non-object input", () => {
-    expect(sanitizeGeminiToolParameters(undefined)).toEqual({ type: "object" });
-    expect(sanitizeGeminiToolParameters("nope")).toEqual({ type: "object" });
+    expect(sanitizeGeminiToolParameters(undefined)).toEqual({ type: "object", properties: {} });
+    expect(sanitizeGeminiToolParameters("nope")).toEqual({ type: "object", properties: {} });
   });
 });

--- a/tests/google-vertex-http.test.ts
+++ b/tests/google-vertex-http.test.ts
@@ -133,6 +133,35 @@ describe("vertex retry fetch", () => {
     expect(mock.calls).toHaveLength(1);
   });
 
+  test("replays one structurally repaired request after a provider schema 400", async () => {
+    const repairableRequest: AdapterRequest = {
+      ...request,
+      body: JSON.stringify({
+        request: {
+          contents: [{ role: "user", parts: [{ text: "hi" }] }],
+          tools: [{ functionDeclarations: [{
+            name: "replace_in_files",
+            parameters: { type: "object", properties: { occurrence_ids: { type: "array", items: { type: "string" } } } },
+          }] }],
+        },
+      }),
+    };
+    const mock = mockFetch([
+      new Response(vertexError(400, "INVALID_ARGUMENT", "tools.0.custom.input_schema: JSON schema is invalid"), { status: 400 }),
+      new Response("ok", { status: 200 }),
+    ]);
+
+    const res = await fetchAntigravityWithRetry(repairableRequest, { timeoutMs: 5_000 });
+
+    expect(res.status).toBe(200);
+    expect(mock.calls).toHaveLength(2);
+    const replay = JSON.parse(mock.calls[1].body as string);
+    expect(replay.request.tools[0].functionDeclarations[0].parameters).toEqual({
+      type: "object",
+      properties: {},
+    });
+  });
+
   test("raw mode preserves final error body and headers without normalization", async () => {
     const raw = vertexError(400, "INVALID_ARGUMENT", "provider-private-detail");
     const mock = mockFetch([new Response(raw, { status: 400, headers: { "x-provider-error": "raw" } })]);

--- a/tests/google-wire-compiler.test.ts
+++ b/tests/google-wire-compiler.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import { createGoogleAdapter } from "../src/adapters/google";
+import { compileGoogleWireBody, repairGoogleInvalidRequestBody } from "../src/adapters/google-wire-compiler";
+import type { OcxParsedRequest } from "../src/types";
+
+describe("Google wire compiler", () => {
+  test("enforces the conservative wire contract at the final serialization boundary", () => {
+    const originalName = `9 bad.tool name ${"x".repeat(80)}`;
+    const compiled = compileGoogleWireBody({
+      contents: [
+        { role: "model", parts: [{ functionCall: { name: originalName, args: {} } }] },
+        { role: "user", parts: [{ functionResponse: { name: originalName, response: { result: "ok" } } }] },
+      ],
+      tools: [{
+        functionDeclarations: [{
+          name: originalName,
+          description: "A hostile MCP tool",
+          parameters: {
+            type: "object",
+            properties: {
+              token: { type: "string", "x-mcp-header": "Authorization" },
+            },
+          },
+          futureDeclarationField: true,
+        }],
+        futureToolField: true,
+      }],
+      generationConfig: {
+        maxOutputTokens: -2,
+        temperature: 99,
+        topP: -1,
+        thinkingConfig: { thinkingLevel: "max", futureThinkingField: true },
+        futureGenerationField: true,
+      },
+      futureTopLevelField: true,
+    });
+
+    const body = compiled.body;
+    const declaration = (body.tools as Array<{ functionDeclarations: Array<Record<string, unknown>> }>)[0]
+      .functionDeclarations[0];
+    const wireName = declaration.name as string;
+    expect(wireName).toMatch(/^[A-Za-z_][A-Za-z0-9_-]{0,63}$/);
+    expect(compiled.restoreToolName(wireName)).toBe(originalName);
+    expect(JSON.stringify(declaration.parameters)).not.toContain("x-mcp-header");
+    expect(declaration.futureDeclarationField).toBeUndefined();
+    expect((body.tools as Array<Record<string, unknown>>)[0].futureToolField).toBeUndefined();
+
+    const contents = body.contents as Array<{ parts: Array<Record<string, any>> }>;
+    expect(contents[0].parts[0].functionCall.name).toBe(wireName);
+    expect(contents[1].parts[0].functionResponse.name).toBe(wireName);
+    expect(body.generationConfig).toEqual({
+      temperature: 2,
+      thinkingConfig: { thinkingLevel: "high" },
+    });
+    expect(body.futureTopLevelField).toBeUndefined();
+  });
+
+  test("the Google adapter compiles tool names on request and restores them on response", async () => {
+    const originalName = `9 invalid tool ${"x".repeat(80)}`;
+    const adapter = createGoogleAdapter({
+      adapter: "google",
+      baseUrl: "https://generativelanguage.googleapis.com",
+      apiKey: "test-key",
+    });
+    const request = await adapter.buildRequest({
+      modelId: "gemini-3.5-flash",
+      stream: false,
+      options: {},
+      context: {
+        messages: [{ role: "user", content: "Use the tool" }],
+        tools: [{ name: originalName, description: "Test", parameters: { type: "object" } }],
+      },
+    } as OcxParsedRequest);
+    const body = JSON.parse(request.body);
+    const wireName = body.tools[0].functionDeclarations[0].name as string;
+
+    expect(wireName).not.toBe(originalName);
+    expect(wireName).toMatch(/^[A-Za-z_][A-Za-z0-9_-]{0,63}$/);
+
+    const events = await adapter.parseResponse!(new Response(JSON.stringify({
+      candidates: [{ content: { parts: [{ functionCall: { name: wireName, args: {} } }] } }],
+    })));
+    expect(events.find(event => event.type === "tool_call_start")).toMatchObject({
+      type: "tool_call_start",
+      name: originalName,
+    });
+  });
+
+  test("repairs only the tool schema named by a Claude-on-Antigravity 400", () => {
+    const body = JSON.stringify({
+      model: "claude-sonnet-4-6",
+      request: {
+        contents: [{ role: "user", parts: [{ text: "hi" }] }],
+        tools: [{ functionDeclarations: [
+          { name: "safe", parameters: { type: "object", properties: { value: { type: "string" } } } },
+          { name: "rejected", parameters: { type: "object", properties: { ids: { type: "array", items: { type: "string" } } } } },
+        ] }],
+      },
+    });
+    const error = JSON.stringify({
+      error: {
+        type: "invalid_request_error",
+        message: "tools.1.custom.input_schema: JSON schema is invalid",
+      },
+    });
+
+    const repaired = JSON.parse(repairGoogleInvalidRequestBody(body, error)!);
+    const declarations = repaired.request.tools[0].functionDeclarations;
+    expect(declarations[0].parameters).toEqual({
+      type: "object",
+      properties: { value: { type: "string" } },
+    });
+    expect(declarations[1].parameters).toEqual({ type: "object", properties: {} });
+  });
+
+  test("repairs an unsupported thinking level without discarding other generation config", () => {
+    const body = JSON.stringify({
+      request: {
+        contents: [{ role: "user", parts: [{ text: "hi" }] }],
+        generationConfig: {
+          maxOutputTokens: 4096,
+          thinkingConfig: { thinkingLevel: "high" },
+        },
+      },
+    });
+    const error = "Invalid value at 'request.generation_config.thinking_config.thinking_level'";
+
+    const repaired = JSON.parse(repairGoogleInvalidRequestBody(body, error)!);
+    expect(repaired.request.generationConfig).toEqual({ maxOutputTokens: 4096 });
+  });
+});


### PR DESCRIPTION
## Summary

This introduces a single conservative wire compiler for every Google-family request and comprehensively fixes the known Antigravity `400 invalid request` class caused by request-shape incompatibilities.

- Compile AI Studio, Vertex, and Cloud Code Assist payloads through one final trust boundary before serialization.
- Normalize arbitrary MCP / JSON Schema input into Google's supported function-schema subset, including `x-mcp-header`, draft 2020-12 annotations, nullable `anyOf`, local refs, hostile values, and recursion limits.
- Clamp unsupported Antigravity thinking levels (`xhigh`, `max`, `ultra`) to Google's highest accepted `high` value.
- Normalize invalid, long, or colliding tool names and restore the original name when the model calls the tool.
- On a provider schema/thinking `400`, rebuild a materially changed request and replay it exactly once; unrelated `400` responses remain non-retryable.

## Root cause

Google request compatibility was previously enforced incrementally while building the payload. There was no final compiler guaranteeing wire invariants, so one provider-specific field or one third-party MCP schema could invalidate the entire tool catalog. The transport also treated every `400` as terminal even when the provider identified a safely repairable schema or thinking field.

## Why this is comprehensive for Antigravity request-shape failures

The strict allowlist prevents unknown third-party schema keywords from reaching Antigravity, while the final compiler also covers generation config and tool-name constraints. If the Claude bridge still rejects a documented construct, the targeted open-schema fallback repairs the named tool and replays once. This closes the observed `thinking_level=max`, `x-mcp-header`, Serena nullable-union, and generic `tools.N.custom.input_schema` failure modes without depending on Serena or any specific MCP server.

This scope intentionally does not claim to suppress authentication, quota, permission, network, or upstream availability failures; those are separate provider conditions rather than malformed-request bugs.

## Impact

- A single malformed MCP tool can no longer poison every tool in the request.
- Users without Serena are unaffected; all MCP catalogs receive the same provider-boundary normalization.
- Other providers are unchanged.
- No new dependency is added.

## Validation

- `bun run typecheck`
- 128 Google / Vertex / Antigravity tests passed across 10 files.
- Full local suite: 3453 passed, 4 skipped; the only 2 failures are the existing Windows Cursor `printf` fixtures.
- Live isolated-dev E2E against Antigravity: 112 tools (22 Serena, 7 Yith, 20 adversarial schemas), with global `tools.64 = serena_replace_in_files`, returned HTTP 200 and `OK.`.
- `git diff --check`

References:

- [Google function-calling schema contract](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling)
- [Google retry strategy](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/retry-strategy)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved compatibility with Google and Gemini request formats.
  * Automatically retries certain invalid requests after safely repairing unsupported tool schemas or thinking settings.
  * Preserves tool names across requests and responses, including names requiring compatibility formatting.
  * Normalizes reasoning effort values to supported provider settings.

* **Bug Fixes**
  * Improved handling of unsupported and complex tool parameter schemas.
  * Prevented invalid schema fields from being sent to Google services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->