### PR TITLE
fix(cursor): replay external model tool continuations with fresh conversation ids

### DIFF
--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -6,7 +6,11 @@ import { isCursorExternalWireModel } from "./cursor/discovery";
 import { createCursorKvStore, type CursorKvStore } from "./cursor/kv-store";
 import { mapCursorServerMessage } from "./cursor/message-mapper";
 import { createCursorRequest, generatedCursorConversationId } from "./cursor/request-builder";
-import { createLiveCursorTransport, CursorMissingCredentialError } from "./cursor/live-transport";
+import {
+  createLiveCursorTransport,
+  CursorMissingCredentialError,
+  rekeyCursorContextUsage,
+} from "./cursor/live-transport";
 import { runCursorTurnWithRetry } from "./cursor/transport-retry";
 import {
   createDisabledCursorTransport,
@@ -71,10 +75,16 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
         const makeTransport = deps.createTransport ?? createLiveCursorTransport;
         const kv = deps.kv ?? createCursorKvStore();
         _parsed._cursorConversationId ??= generatedCursorConversationId();
+        const previousConversationId = _parsed._cursorConversationId;
         let request = createCursorRequest(_parsed);
         // Keep remembered conversation id in sync when the request builder mints a fresh id
         // for external-model tool-result continuations (stateless replay).
+        if (request.conversationId !== previousConversationId) {
+          rekeyCursorContextUsage(previousConversationId, request.conversationId);
+        }
         _parsed._cursorConversationId = request.conversationId;
+        let emittedOutput = false;
+        const lastRawIsToolResult = _parsed.context.messages.at(-1)?.role === "toolResult";
 
         const runOnce = async (activeRequest: ReturnType<typeof createCursorRequest>) => {
           await runCursorTurnWithRetry(
@@ -97,7 +107,10 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
                   void activeTransport.writeClient(clientMessage);
                 },
               });
-              for (const event of events) emit(event);
+              for (const event of events) {
+                if (event.type !== "heartbeat") emittedOutput = true;
+                emit(event);
+              }
             },
           );
         };
@@ -105,18 +118,22 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
         try {
           await runOnce(request);
         } catch (err) {
-          // One-shot fallback: external Cursor models can reject resume/continuation on a
-          // stale server-side conversation with Connect invalid_argument after stepCompleted.
-          // Replay once with a fresh conversation id and full history.
+          // One-shot fallback: only for external-model tool-result continuations that fail
+          // with Connect invalid_argument before any non-heartbeat output was forwarded.
+          // Replaying after text/tool events would duplicate output.
           if (
             !isCursorInvalidArgumentError(err)
             || !isCursorExternalWireModel(request.modelId)
+            || !lastRawIsToolResult
+            || emittedOutput
             || incoming.abortSignal?.aborted
           ) {
             throw err;
           }
+          const failedConversationId = request.conversationId;
           _parsed._cursorConversationId = undefined;
           request = createCursorRequest(_parsed, { forceFreshConversation: true });
+          rekeyCursorContextUsage(failedConversationId, request.conversationId);
           _parsed._cursorConversationId = request.conversationId;
           await runOnce(request);
         }

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -1,7 +1,8 @@
 import type { AdapterEvent, OcxProviderConfig } from "../types";
 import type { ProviderAdapter } from "./base";
 import { cursorExecDeniedMessage, cursorRequestDeclaresFullAccess } from "./cursor/exec-policy";
-import { isCursorBenignCancelError, safeCursorErrorMessage } from "./cursor/cursor-errors";
+import { isCursorBenignCancelError, isCursorInvalidArgumentError, safeCursorErrorMessage } from "./cursor/cursor-errors";
+import { isCursorExternalWireModel } from "./cursor/discovery";
 import { createCursorKvStore, type CursorKvStore } from "./cursor/kv-store";
 import { mapCursorServerMessage } from "./cursor/message-mapper";
 import { createCursorRequest, generatedCursorConversationId } from "./cursor/request-builder";
@@ -70,26 +71,55 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
         const makeTransport = deps.createTransport ?? createLiveCursorTransport;
         const kv = deps.kv ?? createCursorKvStore();
         _parsed._cursorConversationId ??= generatedCursorConversationId();
-        const request = createCursorRequest(_parsed);
-        await runCursorTurnWithRetry(
-          makeTransport,
-          { provider, headers: incoming.headers, requestDeclaresFullAccess: cursorRequestDeclaresFullAccess(request) },
-          request,
-          incoming.abortSignal,
-          (message, activeTransport) => {
-            if (incoming.abortSignal?.aborted) {
-              emit({ type: "error", message: "Cursor turn was aborted." });
-              return;
-            }
-            const events = mapCursorServerMessage(message, {
-              kv,
-              writeClient: clientMessage => {
-                void activeTransport.writeClient(clientMessage);
-              },
-            });
-            for (const event of events) emit(event);
-          },
-        );
+        let request = createCursorRequest(_parsed);
+        // Keep remembered conversation id in sync when the request builder mints a fresh id
+        // for external-model tool-result continuations (stateless replay).
+        _parsed._cursorConversationId = request.conversationId;
+
+        const runOnce = async (activeRequest: ReturnType<typeof createCursorRequest>) => {
+          await runCursorTurnWithRetry(
+            makeTransport,
+            {
+              provider,
+              headers: incoming.headers,
+              requestDeclaresFullAccess: cursorRequestDeclaresFullAccess(activeRequest),
+            },
+            activeRequest,
+            incoming.abortSignal,
+            (message, activeTransport) => {
+              if (incoming.abortSignal?.aborted) {
+                emit({ type: "error", message: "Cursor turn was aborted." });
+                return;
+              }
+              const events = mapCursorServerMessage(message, {
+                kv,
+                writeClient: clientMessage => {
+                  void activeTransport.writeClient(clientMessage);
+                },
+              });
+              for (const event of events) emit(event);
+            },
+          );
+        };
+
+        try {
+          await runOnce(request);
+        } catch (err) {
+          // One-shot fallback: external Cursor models can reject resume/continuation on a
+          // stale server-side conversation with Connect invalid_argument after stepCompleted.
+          // Replay once with a fresh conversation id and full history.
+          if (
+            !isCursorInvalidArgumentError(err)
+            || !isCursorExternalWireModel(request.modelId)
+            || incoming.abortSignal?.aborted
+          ) {
+            throw err;
+          }
+          _parsed._cursorConversationId = undefined;
+          request = createCursorRequest(_parsed, { forceFreshConversation: true });
+          _parsed._cursorConversationId = request.conversationId;
+          await runOnce(request);
+        }
       } catch (err) {
         if (isCursorBenignCancelError(err)) return;
         const partialUsage = (err as { partialUsage?: import("../types").OcxUsage }).partialUsage;

--- a/src/adapters/cursor/cursor-errors.ts
+++ b/src/adapters/cursor/cursor-errors.ts
@@ -37,6 +37,17 @@ export function isCursorBenignCancelError(value: unknown): boolean {
 }
 
 /**
+ * True when Cursor Connect rejected the turn with invalid_argument.
+ * Seen after stepCompleted on brittle external-model continuations.
+ */
+export function isCursorInvalidArgumentError(value: unknown): boolean {
+  const code = errorCode(value).toLowerCase();
+  if (code === "invalid_argument") return true;
+  const message = errorMessage(value).toLowerCase();
+  return message.includes("invalid_argument");
+}
+
+/**
  * Classify a Cursor transport/Connect/gRPC error message into an actionable category.
  * The returned prefix string is recognized by `src/lib/errors.ts` `classifyError` keywords,
  * so bridge-level error mapping produces the right Codex error type (rate_limit, auth, etc.).

--- a/src/adapters/cursor/discovery.ts
+++ b/src/adapters/cursor/discovery.ts
@@ -120,6 +120,31 @@ export function cursorCodexToWireModelId(modelId: string): string {
   return cursorWireModelSelection(modelId).modelId;
 }
 
+/**
+ * Cursor-native wire models keep server-side conversation state reliably.
+ * External models (gpt/claude/gemini/grok families and similar) are more brittle on resumeAction.
+ */
+export function isCursorNativeWireModel(modelId: string): boolean {
+  const wire = cursorCodexToWireModelId(modelId).trim().toLowerCase();
+  const bare = stripCursorEffortSuffix(wire);
+  if (bare === CURSOR_AUTO_WIRE_MODEL_ID || bare === CURSOR_AUTO_MODEL_ID) return true;
+  return bare.startsWith("composer-");
+}
+
+/** Inverse of {@link isCursorNativeWireModel}. */
+export function isCursorExternalWireModel(modelId: string): boolean {
+  return !isCursorNativeWireModel(modelId);
+}
+
+function stripCursorEffortSuffix(wireModelId: string): string {
+  const suffixes = [...CANONICAL_EFFORT_SUFFIXES].sort((a, b) => b.length - a.length);
+  for (const suffix of suffixes) {
+    const marker = `-${suffix}`;
+    if (wireModelId.endsWith(marker)) return wireModelId.slice(0, -marker.length);
+  }
+  return wireModelId;
+}
+
 export function isCursorRouterModelId(modelId: string): boolean {
   return (CURSOR_ROUTER_MODEL_IDS as readonly string[]).includes(modelId);
 }

--- a/src/adapters/cursor/live-transport.ts
+++ b/src/adapters/cursor/live-transport.ts
@@ -70,6 +70,11 @@ const GENERIC_TOOL_COUNT_MAX_FINALIZE_GRACE_MS = 1_800;
 const GENERIC_TOOL_COUNT_PER_TOOL_GRACE_MS = 125;
 const cursorContextUsageTracker = createCursorContextUsageTracker();
 
+/** Carry context-usage totals across conversation-id rotation for external-model replay. */
+export function rekeyCursorContextUsage(fromConversationId: string, toConversationId: string): void {
+  cursorContextUsageTracker.rekey(fromConversationId, toConversationId);
+}
+
 export class CursorMissingCredentialError extends Error {
   readonly code = "cursor_missing_credential";
 

--- a/src/adapters/cursor/protobuf-events.ts
+++ b/src/adapters/cursor/protobuf-events.ts
@@ -22,6 +22,8 @@ export interface CursorContextUsageTracker {
   controlsForConversation(conversationId: string, options?: { clearPrior?: boolean; storeCheckpoints?: boolean }): CursorContextUsageControls;
   get(conversationId: string): number | undefined;
   record(conversationId: string, tokens: number): void;
+  /** Copy numeric carry-forward totals when a conversation id is rotated for replay. */
+  rekey(fromConversationId: string, toConversationId: string): void;
   clear(conversationId: string): void;
   clearAll(): void;
 }
@@ -91,6 +93,18 @@ export function createCursorContextUsageTracker(options: { maxEntries?: number; 
     },
     get,
     record,
+    rekey(fromConversationId, toConversationId) {
+      if (!fromConversationId || !toConversationId || fromConversationId === toConversationId) return;
+      prune();
+      const from = entries.get(fromConversationId);
+      if (!from) return;
+      const to = entries.get(toConversationId);
+      const tokens = Math.max(from.tokens, to?.tokens ?? 0);
+      entries.delete(fromConversationId);
+      entries.delete(toConversationId);
+      entries.set(toConversationId, { tokens, updatedAt: now() });
+      prune();
+    },
     clear(conversationId) {
       entries.delete(conversationId);
     },

--- a/src/adapters/cursor/protobuf-request.ts
+++ b/src/adapters/cursor/protobuf-request.ts
@@ -4,6 +4,8 @@ import { ValueSchema } from "@bufbuild/protobuf/wkt";
 import type { OcxAssistantContentPart, OcxMessage, OcxToolResultMessage } from "../../types";
 import { namespacedToolName } from "../../types";
 import type { CursorRunRequest } from "./types";
+import { isCursorExternalWireModel } from "./discovery";
+import { debugProviderDiagnostic } from "../../lib/debug";
 import { storeCursorBlob } from "./native-exec";
 import {
   AgentClientMessageSchema,
@@ -326,8 +328,9 @@ export function encodeCursorRunRequest(request: CursorRunRequest): Uint8Array {
   // would pollute the model input and double-deliver the result. Use ResumeAction so Cursor picks up
   // from the history we provided.
   const lastRawIsToolResult = request.rawMessages?.at(-1)?.role === "toolResult";
+  const actionCase = !lastRawIsToolResult && text.trim().length > 0 ? "userMessageAction" : "resumeAction";
   const action = create(ConversationActionSchema, {
-    action: !lastRawIsToolResult && text.trim().length > 0
+    action: actionCase === "userMessageAction"
       ? {
           case: "userMessageAction",
           value: create(UserMessageActionSchema, {
@@ -344,6 +347,13 @@ export function encodeCursorRunRequest(request: CursorRunRequest): Uint8Array {
             requestContext: buildRequestContext(),
           }),
         },
+  });
+  debugProviderDiagnostic("cursor", "run-request", {
+    wireModel: request.modelId,
+    action: actionCase,
+    conversationId: request.conversationId,
+    turnType: lastRawIsToolResult ? "tool-continuation" : "initial",
+    externalModel: isCursorExternalWireModel(request.modelId),
   });
 
   const runRequest = create(AgentRunRequestSchema, {

--- a/src/adapters/cursor/request-builder.ts
+++ b/src/adapters/cursor/request-builder.ts
@@ -8,7 +8,7 @@ import type {
 } from "../../types";
 import { isAllowedToolChoice, namespacedToolName, toolChoiceAliases, type OcxTool, type OcxToolChoice } from "../../types";
 import type { CursorRequestMessage, CursorRunRequest } from "./types";
-import { cursorWireModelSelection, type CursorRoutingLevel } from "./discovery";
+import { cursorWireModelSelection, isCursorExternalWireModel, type CursorRoutingLevel } from "./discovery";
 import { cursorEffortSuffix } from "./effort-map";
 import {
   cursorMcpToolEncodedSize,
@@ -159,7 +159,15 @@ export function generatedCursorConversationId(): string {
   return `cursor_${crypto.randomUUID().replace(/-/g, "")}`;
 }
 
-export function createCursorRequest(parsed: OcxParsedRequest): CursorRunRequest {
+export interface CreateCursorRequestOptions {
+  /** Force a brand-new Cursor conversation id even when remembered state exists. */
+  forceFreshConversation?: boolean;
+}
+
+export function createCursorRequest(
+  parsed: OcxParsedRequest,
+  options: CreateCursorRequestOptions = {},
+): CursorRunRequest {
   const messages = parsed.context.messages
     .map(requestMessage)
     .filter((message): message is CursorRequestMessage => !!message && message.content.length > 0);
@@ -168,6 +176,13 @@ export function createCursorRequest(parsed: OcxParsedRequest): CursorRunRequest 
   const budget = applyCursorToolBudget(visibleTools, parsed.options.toolChoice);
   const limitNote = catalogLimitNote(budget.tools, budget.omitted);
   const model = normalizeCursorModelId(parsed.modelId, parsed.options.reasoning);
+  const lastRaw = parsed.context.messages.at(-1);
+  // External Cursor models (e.g. gpt-5.6-sol) can corrupt server-side conversation state across
+  // tool-result continuations when ResumeAction reuses the same conversationId. Force a fresh id
+  // so the full history is replayed without depending on that state.
+  const forceFreshConversation =
+    options.forceFreshConversation === true
+    || (lastRaw?.role === "toolResult" && isCursorExternalWireModel(model.modelId));
   return {
     modelId: model.modelId,
     ...(model.routingLevel ? { routingLevel: model.routingLevel } : {}),
@@ -175,7 +190,9 @@ export function createCursorRequest(parsed: OcxParsedRequest): CursorRunRequest 
     // back to the OpenAI Responses previous_response_id (resp_*): that is a Responses-chain id in a
     // different namespace and would start an unrelated Cursor conversation, breaking tool-result
     // continuation. If we have no remembered Cursor conversation, start a fresh one.
-    conversationId: parsed._cursorConversationId ?? generatedCursorConversationId(),
+    conversationId: forceFreshConversation
+      ? generatedCursorConversationId()
+      : (parsed._cursorConversationId ?? generatedCursorConversationId()),
     system: [...(parsed.context.systemPrompt ?? []), ...(limitNote ? [limitNote] : [])],
     messages,
     rawMessages: parsed.context.messages,

--- a/tests/cursor-adapter.test.ts
+++ b/tests/cursor-adapter.test.ts
@@ -203,3 +203,56 @@ describe("Cursor adapter live transport", () => {
   });
 });
 
+  test("does not replay invalid_argument after non-heartbeat output was already emitted", async () => {
+    let attempts = 0;
+    const adapter = createCursorAdapter({
+      ...provider,
+      apiKey: "cursor-token",
+    }, {
+      createTransport: () => ({
+        async *run() {
+          attempts += 1;
+          yield { type: "text", text: "partial output" } satisfies CursorServerMessage;
+          throw Object.assign(
+            new Error("Cursor invalid request: Cursor Connect error invalid_argument: Error"),
+            { code: "invalid_argument" },
+          );
+        },
+        writeClient() {},
+      }),
+    });
+
+    const events: AdapterEvent[] = [];
+    const body: OcxParsedRequest = {
+      modelId: "cursor/gpt-5.6-sol",
+      context: {
+        messages: [
+          { role: "user", content: "read a file", timestamp: 1 },
+          {
+            role: "assistant",
+            model: "cursor/gpt-5.6-sol",
+            timestamp: 2,
+            content: [{ type: "toolCall", id: "call_1", name: "read_file", namespace: "mcp__fs", arguments: { path: "a.txt" } }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "read_file",
+            toolNamespace: "mcp__fs",
+            content: "FILE CONTENTS HERE",
+            isError: false,
+            timestamp: 3,
+          },
+        ],
+      },
+      stream: false,
+      options: { reasoning: "xhigh" },
+      _cursorConversationId: "cursor_corrupt",
+    };
+
+    await adapter.runTurn?.(body, { headers: new Headers() }, event => events.push(event));
+
+    expect(attempts).toBe(1);
+    expect(events.some(event => event.type === "text_delta")).toBe(true);
+    expect(events.some(event => event.type === "error")).toBe(true);
+  });

--- a/tests/cursor-adapter.test.ts
+++ b/tests/cursor-adapter.test.ts
@@ -140,4 +140,66 @@ describe("Cursor adapter live transport", () => {
     expect(cursorExecDeniedMessage("shellArgs")).toContain("shellArgs");
     expect(cursorExecDeniedMessage("shellArgs")).toContain("legacy mock transport cannot execute");
   });
+
+  test("retries external-model invalid_argument once with a fresh conversation id", async () => {
+    const seen: string[] = [];
+    let attempts = 0;
+    const adapter = createCursorAdapter({
+      ...provider,
+      apiKey: "cursor-token",
+    }, {
+      createTransport: () => ({
+        async *run(request) {
+          attempts += 1;
+          seen.push(request.conversationId);
+          if (attempts === 1) {
+            throw Object.assign(
+              new Error("Cursor invalid request: Cursor Connect error invalid_argument: Error"),
+              { code: "invalid_argument" },
+            );
+          }
+          yield { type: "done" } satisfies CursorServerMessage;
+        },
+        writeClient() {},
+      }),
+    });
+
+    const events: AdapterEvent[] = [];
+    const body: OcxParsedRequest = {
+      modelId: "cursor/gpt-5.6-sol",
+      context: {
+        messages: [
+          { role: "user", content: "read a file", timestamp: 1 },
+          {
+            role: "assistant",
+            model: "cursor/gpt-5.6-sol",
+            timestamp: 2,
+            content: [{ type: "toolCall", id: "call_1", name: "read_file", namespace: "mcp__fs", arguments: { path: "a.txt" } }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "read_file",
+            toolNamespace: "mcp__fs",
+            content: "FILE CONTENTS HERE",
+            isError: false,
+            timestamp: 3,
+          },
+        ],
+      },
+      stream: false,
+      options: { reasoning: "xhigh" },
+      _cursorConversationId: "cursor_corrupt",
+    };
+
+    await adapter.runTurn?.(body, { headers: new Headers() }, event => events.push(event));
+
+    expect(attempts).toBe(2);
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).not.toBe("cursor_corrupt");
+    expect(seen[1]).not.toBe(seen[0]);
+    expect(body._cursorConversationId).toBe(seen[1]);
+    expect(events.filter(event => event.type === "error")).toHaveLength(0);
+  });
 });
+

--- a/tests/cursor-discovery.test.ts
+++ b/tests/cursor-discovery.test.ts
@@ -14,6 +14,8 @@ import {
   cursorModelReasoningEfforts,
   cursorWireModelSelection,
   inferCursorContextWindow,
+  isCursorExternalWireModel,
+  isCursorNativeWireModel,
   normalizeCursorModels,
 } from "../src/adapters/cursor/discovery";
 
@@ -144,5 +146,16 @@ describe("Cursor discovery metadata", () => {
     expect(efforts["grok-4.3"]).toEqual([]);
     expect(efforts["unknown-reasoning-model"]).toEqual([]);
     expect(efforts["composer-2.5"]).toEqual([]);
+  });
+
+  test("classifies native vs external Cursor wire models", () => {
+    expect(isCursorNativeWireModel("default")).toBe(true);
+    expect(isCursorNativeWireModel("auto")).toBe(true);
+    expect(isCursorNativeWireModel("composer-2.5")).toBe(true);
+    expect(isCursorNativeWireModel("composer-2.5-fast")).toBe(true);
+    expect(isCursorExternalWireModel("gpt-5.6-sol")).toBe(true);
+    expect(isCursorExternalWireModel("gpt-5.6-sol-xhigh")).toBe(true);
+    expect(isCursorExternalWireModel("claude-4.6-sonnet-high")).toBe(true);
+    expect(isCursorExternalWireModel("cursor/gpt-5.6-sol")).toBe(true);
   });
 });

--- a/tests/cursor-errors.test.ts
+++ b/tests/cursor-errors.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   classifyCursorError,
   isCursorBenignCancelError,
+  isCursorInvalidArgumentError,
   safeCursorErrorMessage,
 } from "../src/adapters/cursor/cursor-errors";
 
@@ -79,5 +80,14 @@ describe("safeCursorErrorMessage", () => {
     expect(msg).toContain("Cursor resource limit exceeded");
     expect(msg).not.toContain("resource_exhausted");
     expect(msg).not.toContain("rate limit");
+  });
+});
+
+
+describe("isCursorInvalidArgumentError", () => {
+  test("matches Connect invalid_argument code and message", () => {
+    expect(isCursorInvalidArgumentError({ code: "invalid_argument", message: "Cursor invalid request" })).toBe(true);
+    expect(isCursorInvalidArgumentError(new Error("Cursor invalid request: Cursor Connect error invalid_argument: Error"))).toBe(true);
+    expect(isCursorInvalidArgumentError(new Error("Cursor connection failed"))).toBe(false);
   });
 });

--- a/tests/cursor-protobuf-events.test.ts
+++ b/tests/cursor-protobuf-events.test.ts
@@ -589,6 +589,16 @@ describe("Cursor protobuf tool-call events", () => {
     ]);
     expect(tracker.get("cursor_conv_1")).toBeUndefined();
   });
+
+  test("rekey copies carry-forward totals onto a rotated conversation id", () => {
+    const tracker = createCursorContextUsageTracker();
+    tracker.record("cursor_old", 12_500);
+    tracker.rekey("cursor_old", "cursor_new");
+
+    expect(tracker.get("cursor_old")).toBeUndefined();
+    expect(tracker.get("cursor_new")).toBe(12_500);
+    expect(tracker.controlsForConversation("cursor_new").carryForwardTokens).toBe(12_500);
+  });
 });
 
 describe("Cursor MCP display-name alias", () => {

--- a/tests/cursor-request-builder.test.ts
+++ b/tests/cursor-request-builder.test.ts
@@ -223,4 +223,79 @@ describe("Cursor request builder", () => {
     expect(withoutSearch.system.join("\n")).toContain("unavailable this turn");
     expect(withoutSearch.system.join("\n")).not.toContain("Use tool_search");
   });
+
+
+  test("external Cursor tool-result continuation forces a fresh conversation id", () => {
+    const request = createCursorRequest({
+      modelId: "cursor/gpt-5.6-sol",
+      context: {
+        messages: [
+          { role: "user", content: "read a file", timestamp: 1 },
+          {
+            role: "assistant",
+            model: "cursor/gpt-5.6-sol",
+            timestamp: 2,
+            content: [{ type: "toolCall", id: "call_1", name: "read_file", namespace: "mcp__fs", arguments: { path: "a.txt" } }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "read_file",
+            toolNamespace: "mcp__fs",
+            content: "FILE CONTENTS HERE",
+            isError: false,
+            timestamp: 3,
+          },
+        ],
+      },
+      stream: false,
+      options: { reasoning: "xhigh" },
+      _cursorConversationId: "cursor_old_external",
+    });
+
+    expect(request.modelId).toBe("gpt-5.6-sol-xhigh");
+    expect(request.conversationId).not.toBe("cursor_old_external");
+    expect(request.conversationId.startsWith("cursor_")).toBe(true);
+  });
+
+  test("native Cursor tool-result continuation keeps the remembered conversation id", () => {
+    const request = createCursorRequest({
+      modelId: "cursor/composer-2.5",
+      context: {
+        messages: [
+          { role: "user", content: "read a file", timestamp: 1 },
+          {
+            role: "assistant",
+            model: "cursor/composer-2.5",
+            timestamp: 2,
+            content: [{ type: "toolCall", id: "call_1", name: "read_file", namespace: "mcp__fs", arguments: { path: "a.txt" } }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "read_file",
+            toolNamespace: "mcp__fs",
+            content: "FILE CONTENTS HERE",
+            isError: false,
+            timestamp: 3,
+          },
+        ],
+      },
+      stream: false,
+      options: {},
+      _cursorConversationId: "cursor_native_stable",
+    });
+
+    expect(request.conversationId).toBe("cursor_native_stable");
+  });
+
+  test("forceFreshConversation always mints a new conversation id", () => {
+    const request = createCursorRequest({
+      ...base,
+      _cursorConversationId: "cursor_force_me",
+    }, { forceFreshConversation: true });
+
+    expect(request.conversationId).not.toBe("cursor_force_me");
+    expect(request.conversationId.startsWith("cursor_")).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Cursor Connect tool-result continuations for external models like `cursor/gpt-5.6-sol` were reusing the same conversation id via `resumeAction`. That works for Cursor-native models (`composer-*`, `auto`/`default`), but external models often lose server-side conversation state and then fail after `stepCompleted` with:

`connect-end-stream invalid_argument`
followed by reconnect + `getBlobArgs` burst + another failed follow-up turn.

Native openai `gpt-5.6-sol` and Cursor `composer-2.5` stayed stable. The bug is specific to external Cursor Connect continuation.

## Root cause

For tool-result-only turns, OpenCodex correctly uses `resumeAction` and structured conversation history. It previously kept the remembered `_cursorConversationId` for every model.

For external Cursor models, that resume path is brittle: Cursor hydrates blob/checkpoint state, then rejects the next step with a generic `invalid_argument` instead of emitting `turnEnded`. OpenCodex then reconnects and can loop.

## Fix

1. Detect Cursor-native vs external wire models (`composer-*`, `auto`/`default` = native).
2. For external-model tool-result continuations, mint a fresh `conversationId` while still sending full replay history (`conversationTurns` + `rootPromptMessagesJson`) under `resumeAction`.
3. Keep native Cursor models on the remembered conversation id path.
4. One-shot adapter retry: if an external model still hits `invalid_argument`, rebuild once with `forceFreshConversation: true`.
5. Sync `_cursorConversationId` to the conversation id actually used for the turn.
6. Add debug diagnostics for `wireModel`, `action`, `conversationId`, turn type, and `externalModel`.

## Why this is not "use openai instead"

Sol remains on the Cursor provider. Only the continuation strategy changes for external Cursor models.

## Tests

- `bun run typecheck`
- `bun test tests/cursor-adapter.test.ts tests/cursor-request-builder.test.ts tests/cursor-discovery.test.ts tests/cursor-errors.test.ts tests/cursor-tool-continuation.test.ts`

Added coverage for:
- external tool-result continuation forces a fresh conversation id
- native tool-result continuation keeps the remembered id
- `forceFreshConversation` always mints a new id
- one-shot invalid_argument retry with a second conversation id
- native/external wire-model classification
- invalid_argument detector

## Files

- `src/adapters/cursor.ts`
- `src/adapters/cursor/discovery.ts`
- `src/adapters/cursor/request-builder.ts`
- `src/adapters/cursor/protobuf-request.ts`
- `src/adapters/cursor/cursor-errors.ts`
- matching Cursor tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cursor conversation handling for tool-result continuations, preventing conversation-state corruption across external-model replay.
  * Added a one-time retry for specific Cursor `invalid_argument` failures that can occur during resume, using a fresh conversation identifier when safe.
  * Preserves existing conversation continuity when continuation is supported.
* **Diagnostics**
  * Enhanced Cursor run request diagnostics with action type, model type, and conversation identifiers.
* **Tests**
  * Added unit tests covering retry logic, conversation refresh behavior, model classification, and invalid-argument detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->