### PR TITLE
fix(deps): raise fast-uri floor to 3.1.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,9 @@
   "trustedDependencies": [
     "bun",
   ],
+  "overrides": {
+    "fast-uri": "^3.1.4",
+  },
   "packages": {
     "@bufbuild/protobuf": ["@bufbuild/protobuf@2.12.1", "", {}, "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg=="],
 
@@ -122,7 +125,7 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
     "@types/bun": "1.3.14",
     "typescript": "5.9.3"
   },
+  "overrides": {
+    "fast-uri": "^3.1.4"
+  },
   "keywords": [
     "codex",
     "openai",


### PR DESCRIPTION
## Summary

- raise transitive `fast-uri` from `3.1.2` to `3.1.4` with a `^3.1.4` override
- clear [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx)
  and [GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6)
- keep the lockfile change to that one package; no source files or other dependency resolutions move

On `dev`, `bun audit` reports three vulnerabilities: two high and one moderate. This branch reports
one moderate.

## Why an override

`fast-uri` enters through one path:
`@modelcontextprotocol/sdk@1.29.0` → `ajv@8.20.0` → `fast-uri`. Ajv already allows
`fast-uri ^3.0.1`, but the existing lock resolved the affected `3.1.2`. The root override sets a
safe floor within the same major line without forcing a parent upgrade or refreshing unrelated
packages.

The remaining moderate finding,
[GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9), is in
`@hono/node-server`. The current MCP SDK requires its 1.x line, while the fix starts at 2.0.5.
OpenCodex uses the SDK's client transports; the vulnerable `serve-static` path belongs to the
server adapter. That upgrade is left for a separate compatibility change.

## Verification

- `bun install --frozen-lockfile`
- `bun run test` — 3,617 passed, 4 skipped, 0 failed
- `bun run typecheck`
- `bun run privacy:scan`
- `bun audit` — both `fast-uri` findings cleared; one pre-existing Hono moderate remains
- `git diff --check`

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No user-visible behavior changes.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Because this changes dependency resolution, it still requires explicit maintainer security review
before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a transitive dependency version to improve compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->