### PR TITLE
fix(actions): allow PR labeler to label fork PRs

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,7 @@
 name: PR Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize]
 
 concurrency:


### PR DESCRIPTION
## Summary

Fork PRs were failing the PR Labeler with:

```text
RequestError [HttpError]: Resource not accessible by integration
POST /repos/lidge-jun/opencodex/issues/<n>/labels
status: 403
```

## Why `permissions: pull-requests: write` was not enough

The workflow ran on `pull_request`. For PRs from forks, GitHub gives `GITHUB_TOKEN` read-only access even when the workflow declares write permissions. Same-repo PRs worked; fork PRs did not.

## Fix

Switch the trigger to `pull_request_target` so the workflow runs in the base-repo context with a write-capable token.

```diff
-on:
-  pull_request:
-    types: [opened, edited, synchronize]
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
```

Permissions stay `pull-requests: write`. Event types remain `opened`, `edited`, and `synchronize`.

## Security check

This workflow is metadata-only:

- no checkout of the PR head
- no execution of PR-supplied scripts or actions
- only uses `actions/github-script` with inline logic against PR title/event metadata

So `pull_request_target` is appropriate here.

## Validation

- Inspected the full workflow: no checkout, no untrusted code execution
- Confirmed trigger types still include opened/edited/synchronize
- Validated YAML structure after the change
- Diff is limited to the event name

## Note

The Node 20 deprecation warning in the Actions log is unrelated to this 403.