### PR TITLE
fix(actions): wire issue-triage job outputs to parse step

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -15,10 +15,10 @@ jobs:
     permissions:
       models: read
     outputs:
-      requires_translation: ${{ steps.ai.outputs.requires_translation }}
-      translated_title: ${{ steps.ai.outputs.translated_title }}
-      translated_body: ${{ steps.ai.outputs.translated_body }}
-      detected_language: ${{ steps.ai.outputs.detected_language }}
+      requires_translation: ${{ steps.parse.outputs.requires_translation }}
+      translated_title: ${{ steps.parse.outputs.translated_title }}
+      translated_body: ${{ steps.parse.outputs.translated_body }}
+      detected_language: ${{ steps.parse.outputs.detected_language }}
     steps:
       - name: Detect and translate
         id: ai


### PR DESCRIPTION
## Summary

Issue triage detection/translation worked, but `Apply translation` was always skipped.

Root cause from run [29986431948](https://github.com/lidge-jun/opencodex/actions/runs/29986431948):

- `detect-language` step `parse` wrote `GITHUB_OUTPUT` values
- job outputs still referenced `steps.ai.outputs.*`
- `apply-translation` never saw `requires_translation=true`

## Fix

```diff
 outputs:
-  requires_translation: ${{ steps.ai.outputs.requires_translation }}
-  translated_title: ${{ steps.ai.outputs.translated_title }}
-  translated_body: ${{ steps.ai.outputs.translated_body }}
-  detected_language: ${{ steps.ai.outputs.detected_language }}
+  requires_translation: ${{ steps.parse.outputs.requires_translation }}
+  translated_title: ${{ steps.parse.outputs.translated_title }}
+  translated_body: ${{ steps.parse.outputs.translated_body }}
+  detected_language: ${{ steps.parse.outputs.detected_language }}
```

## Notes

- Duplicate posting was skipped for a different reason in that run: the model returned `{"issues":[]}`. That path already reads `steps.parse.outputs.matches` correctly.
- Diff is limited to the four output wires.

## Validation

- Inspected workflow and run logs
- Confirmed YAML structure after the change
- Diff limited to the broken output references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue triage reliability by ensuring downstream steps use parsed, validated language detection and translation outputs.
  * Prevented inconsistencies caused by consuming unparsed AI-generated values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->