### PR TITLE
fix(gui): show the combo workspace before first setup

### DIFF
--- a/gui/bun.lock
+++ b/gui/bun.lock
@@ -19,6 +19,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.6.0",
+        "happy-dom": "20.11.1",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.59.2",
         "vite": "^8.1.0",
@@ -154,6 +155,10 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.61.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/type-utils": "8.61.1", "@typescript-eslint/utils": "8.61.1", "@typescript-eslint/visitor-keys": "8.61.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.61.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ=="],
 
     "@typescript-eslint/parser": ["@typescript-eslint/parser@8.61.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1", "@typescript-eslint/visitor-keys": "8.61.1", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg=="],
@@ -190,6 +195,8 @@
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
+
     "caniuse-lite": ["caniuse-lite@1.0.30001799", "", {}, "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
@@ -205,6 +212,8 @@
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.375", "", {}, "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -253,6 +262,8 @@
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "globals": ["globals@17.6.0", "", {}, "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA=="],
+
+    "happy-dom": ["happy-dom@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg=="],
 
     "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
 
@@ -378,9 +389,13 @@
 
     "vite": ["vite@8.1.0", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "~1.1.2", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 

--- a/gui/package.json
+++ b/gui/package.json
@@ -28,6 +28,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
+    "happy-dom": "20.11.1",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.59.2",
     "vite": "^8.1.0"

--- a/gui/src/components/ComboWorkspace.tsx
+++ b/gui/src/components/ComboWorkspace.tsx
@@ -592,23 +592,9 @@ function OverviewPanel({
   );
 }
 
-function EmptyState({ onAdd }: { onAdd: () => void }) {
-  const t = useT();
-  return (
-    <div className="combos-workspace-empty-root">
-      <button type="button" className="cwi-empty-cta" onClick={onAdd}>
-        <span className="pwi-empty-right-icon" aria-hidden="true">
-          <IconShuffle style={{ width: 64, height: 64 }} />
-        </span>
-        <span className="cwi-empty-cta-title">{t("cws.emptyTitle")}</span>
-        <span className="pwi-empty-right-sub">{t("cws.empty.createDesc")}</span>
-      </button>
-    </div>
-  );
-}
-
 function DetailPanel({
   baseline,
+  isCreate = false,
   otherIds,
   otherAliases,
   providerMap,
@@ -621,6 +607,7 @@ function DetailPanel({
   onDirtyChange,
 }: {
   baseline: ComboItem;
+  isCreate?: boolean;
   /** Ids of all OTHER combos — rename collisions validate against these. */
   otherIds: string[];
   /** Aliases of all OTHER combos — alias uniqueness validates against these. */
@@ -628,9 +615,9 @@ function DetailPanel({
   providerMap: Readonly<Record<string, { disabled?: boolean }>>;
   providers: ProviderOption[];
   models: ModelOption[];
-  onBack: () => void;
+  onBack?: () => void;
   onSaved: (item: ComboItem) => void;
-  onRequestRemove: () => void;
+  onRequestRemove?: () => void;
   onSave: (item: ComboItem, isCreate: boolean, renameFrom?: string) => Promise<{ ok: boolean; error?: string }>;
   onDirtyChange: (dirty: boolean) => void;
 }) {
@@ -672,7 +659,7 @@ function DetailPanel({
     const code = validateComboDraft(draft, {
       existingIds: otherIds,
       existingAliases: otherAliases,
-      isCreate: false,
+      isCreate,
       providers: providerMap,
     });
     if (code) {
@@ -681,34 +668,54 @@ function DetailPanel({
     }
     setBusy(true);
     const trimmedId = draft.id.trim();
-    const renameFrom = trimmedId !== baseline.id ? baseline.id : undefined;
-    const res = await onSave({ ...draft, id: trimmedId }, false, renameFrom);
+    const alias = draft.alias?.trim() || null;
+    const item = {
+      ...draft,
+      id: trimmedId,
+      alias,
+      model: comboPublicModelId(trimmedId, alias),
+    };
+    const renameFrom = !isCreate && trimmedId !== baseline.id ? baseline.id : undefined;
+    const res = await onSave(item, isCreate, renameFrom);
     setBusy(false);
     if (!res.ok) {
       setMsg({ ok: false, text: res.error || t("cws.saveFailed") });
       return;
     }
-    setMsg({ ok: true, text: t("cws.saved") });
-    onSaved(draft);
+    setMsg({
+      ok: true,
+      text: isCreate ? t("cws.created", { model: item.model }) : t("cws.saved"),
+    });
+    onSaved(item);
   };
+
+  const headerModel = isCreate
+    ? (draft.id.trim() ? comboPublicModelId(draft.id, draft.alias) : t("cws.addTitle"))
+    : baseline.model;
 
   return (
     <div className="combos-workspace-detail">
       <div className="combos-workspace-detail-head">
-        <button type="button" className="btn btn-ghost btn-sm pwi-back-overview" onClick={onBack} aria-label={t("cws.backToAll")}>
-          <IconChevron style={{ width: 14, height: 14, transform: "rotate(180deg)" }} aria-hidden="true" />
-          {t("cws.allCombos")}
-        </button>
-        <h2 className="combos-workspace-detail-title">{baseline.model}</h2>
-        <button type="button" className="chip cwi-copy-chip" onClick={() => { void copyModel(); }} title={t("cws.copyModel")}>
-          {copied ? t("cws.copied") : t("cws.copyModel")}
-        </button>
-        <div className="combos-workspace-detail-actions">
-          <button type="button" className="btn btn-ghost btn-sm" onClick={onRequestRemove}>
-            <IconTrash width={14} height={14} /> {t("common.remove")}
+        {onBack && (
+          <button type="button" className="btn btn-ghost btn-sm pwi-back-overview" onClick={onBack} aria-label={t("cws.backToAll")}>
+            <IconChevron style={{ width: 14, height: 14, transform: "rotate(180deg)" }} aria-hidden="true" />
+            {t("cws.allCombos")}
           </button>
-          <button type="button" className="btn btn-primary btn-sm" disabled={!dirty || busy} onClick={() => { void save(); }}>
-            {busy ? t("common.saving") : t("common.save")}
+        )}
+        <h2 className="combos-workspace-detail-title">{headerModel}</h2>
+        {!isCreate && (
+          <button type="button" className="chip cwi-copy-chip" onClick={() => { void copyModel(); }} title={t("cws.copyModel")}>
+            {copied ? t("cws.copied") : t("cws.copyModel")}
+          </button>
+        )}
+        <div className="combos-workspace-detail-actions">
+          {!isCreate && onRequestRemove && (
+            <button type="button" className="btn btn-ghost btn-sm" onClick={onRequestRemove}>
+              <IconTrash width={14} height={14} /> {t("common.remove")}
+            </button>
+          )}
+          <button type="button" className="btn btn-primary btn-sm" disabled={(!isCreate && !dirty) || busy} onClick={() => { void save(); }}>
+            {busy ? t("common.saving") : t(isCreate ? "cws.create" : "common.save")}
           </button>
         </div>
       </div>
@@ -741,7 +748,9 @@ function DetailPanel({
                 }))}
               />
               <p className="muted" style={{ fontSize: 12, margin: "4px 0 0" }}>
-                {t("cws.field.idHintEdit", { model: comboPublicModelId(draft.id, draft.alias) })}
+                {isCreate
+                  ? t("cws.field.idInternalHint")
+                  : t("cws.field.idHintEdit", { model: comboPublicModelId(draft.id, draft.alias) })}
               </p>
             </div>
             <div className="cwi-field">
@@ -848,6 +857,7 @@ export default function ComboWorkspace({
   const [pendingSelect, setPendingSelect] = useState<string | null | undefined>(undefined);
   const [removeId, setRemoveId] = useState<string | null>(null);
   const [localBaseline, setLocalBaseline] = useState<ComboItem | null>(null);
+  const firstComboDraft = useMemo(() => emptyDraft(), []);
 
   const filtered = useMemo(() => filterCombos(combos, query), [combos, query]);
   const sections = useMemo(() => groupCombos(filtered), [filtered]);
@@ -894,33 +904,14 @@ export default function ComboWorkspace({
   const cancelPending = () => setPendingSelect(undefined);
 
   const showUnsaved = pendingSelect !== undefined && detailDirty;
-
-  if (!loading && combos.length === 0) {
-    return (
-      <>
-        <EmptyState onAdd={onAdd} />
-        {adding && (
-          <AddComboModal
-            existingIds={combos.map((c) => c.id)}
-            existingAliases={existingComboAliases}
-            providerMap={providerMap}
-            providers={providers}
-            models={models}
-            onClose={onCloseAdd}
-            onSubmit={async (item) => {
-              const res = await onSave(item, true);
-              if (res.ok) {
-                onCloseAdd();
-                onCreated(item.id);
-                setSelectedId(item.id);
-              }
-              return res;
-            }}
-          />
-        )}
-      </>
-    );
-  }
+  const creatingFirstCombo = !loading && combos.length === 0;
+  const handleAdd = () => {
+    if (creatingFirstCombo) {
+      document.getElementById("cwi-edit-id")?.focus();
+      return;
+    }
+    onAdd();
+  };
 
   return (
     <div className="combos-workspace-root">
@@ -930,7 +921,7 @@ export default function ComboWorkspace({
             <div className="combos-workspace-rail-title">{t("nav.combos")}</div>
             <div className="combos-workspace-rail-count">{combos.length}</div>
           </div>
-          <button type="button" className="btn btn-primary btn-sm" onClick={onAdd} aria-label={t("cws.add")}>
+          <button type="button" className="btn btn-primary btn-sm" onClick={handleAdd} aria-label={t("cws.add")}>
             <IconPlus width={14} height={14} /> {t("cws.add")}
           </button>
         </div>
@@ -947,7 +938,7 @@ export default function ComboWorkspace({
           </div>
         </div>
         <div className="combos-workspace-rail-list">
-          {filtered.length === 0 ? (
+          {filtered.length === 0 && combos.length > 0 ? (
             <p className="muted" style={{ padding: "16px" }}>{t("cws.noSearchResults")}</p>
           ) : (
             <>
@@ -1017,12 +1008,31 @@ export default function ComboWorkspace({
             onSave={onSave}
             onDirtyChange={setDetailDirty}
           />
+        ) : creatingFirstCombo ? (
+          <DetailPanel
+            key="first-combo"
+            baseline={firstComboDraft}
+            isCreate
+            otherIds={[]}
+            otherAliases={[]}
+            providerMap={providerMap}
+            providers={providers}
+            models={models}
+            onSaved={(item) => {
+              setDetailDirty(false);
+              setSelectedId(item.id);
+              setLocalBaseline(item);
+              onCreated(item.id);
+            }}
+            onSave={onSave}
+            onDirtyChange={setDetailDirty}
+          />
         ) : (
           <OverviewPanel combos={combos} onSelect={(id) => trySelect(id)} onAdd={onAdd} />
         )}
       </div>
 
-      {adding && (
+      {adding && !creatingFirstCombo && (
         <AddComboModal
           existingIds={combos.map((c) => c.id)}
           existingAliases={existingComboAliases}

--- a/gui/src/styles-combos-workspace.css
+++ b/gui/src/styles-combos-workspace.css
@@ -175,68 +175,6 @@
   padding: 20px 24px 32px;
 }
 
-.combos-workspace-empty-root {
-  display: flex;
-  min-height: 100%;
-  height: 100%;
-  align-items: center;
-  justify-content: center;
-}
-
-.cwi-empty-cta {
-  appearance: none;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  max-width: 44ch;
-  width: 100%;
-  margin: 0;
-  padding: 40px 28px;
-  border: 1px solid color-mix(in srgb, var(--border, var(--text)) 55%, transparent);
-  border-radius: 10px;
-  background: color-mix(in srgb, var(--surface, transparent) 40%, transparent);
-  font: inherit;
-  text-align: center;
-  color: inherit;
-  cursor: pointer;
-  transition:
-    border-color 0.15s ease,
-    background-color 0.15s ease,
-    box-shadow 0.15s ease;
-}
-
-.cwi-empty-cta-title {
-  font-size: 20px;
-  font-weight: 650;
-  color: var(--text);
-  transition: color 0.15s ease;
-}
-
-.cwi-empty-cta .pwi-empty-right-icon {
-  transition: color 0.15s ease;
-}
-
-.cwi-empty-cta:hover {
-  border-color: color-mix(in srgb, var(--accent, var(--text)) 35%, var(--border, var(--text)));
-  background: color-mix(in srgb, var(--accent, var(--text)) 6%, transparent);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent, var(--text)) 12%, transparent);
-}
-
-.cwi-empty-cta:hover .pwi-empty-right-icon {
-  color: var(--muted);
-}
-
-.cwi-empty-cta:hover .cwi-empty-cta-title {
-  color: var(--accent, var(--text));
-}
-
-.cwi-empty-cta:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent, var(--text)) 45%, transparent);
-  outline-offset: 3px;
-}
-
 .combos-workspace-overview-head {
   display: flex;
   align-items: baseline;

--- a/gui/tests/combo-workspace-empty.test.tsx
+++ b/gui/tests/combo-workspace-empty.test.tsx
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import ComboWorkspace from "../src/components/ComboWorkspace";
+import { LanguageProvider } from "../src/i18n/provider";
+
+let previousLanguage: unknown;
+
+beforeEach(() => {
+  previousLanguage = (globalThis.navigator as { language?: unknown } | undefined)?.language;
+  Object.defineProperty(globalThis.navigator, "language", {
+    configurable: true,
+    value: "en-US",
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(globalThis.navigator, "language", {
+    configurable: true,
+    value: previousLanguage,
+  });
+});
+
+test("an empty combo list renders the first-combo editor inline", () => {
+  const html = renderToStaticMarkup(
+    <LanguageProvider>
+      <ComboWorkspace
+        combos={[]}
+        providers={[{ name: "openai" }]}
+        models={[{ provider: "openai", id: "gpt-5" }]}
+        loading={false}
+        onRefresh={() => {}}
+        onSave={async () => ({ ok: true })}
+        onRemove={async () => ({ ok: true })}
+        onAdd={() => {}}
+        adding={false}
+        onCloseAdd={() => {}}
+        onCreated={() => {}}
+      />
+    </LanguageProvider>,
+  );
+
+  expect(html).toContain("combos-workspace-root");
+  expect(html).toContain('id="cwi-edit-id"');
+  expect(html).toContain("Create combo");
+  expect(html).not.toContain('role="dialog"');
+  expect(html).not.toContain("Create your first combo");
+});

--- a/gui/tests/combo-workspace-empty.test.tsx
+++ b/gui/tests/combo-workspace-empty.test.tsx
@@ -1,23 +1,34 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act } from "react";
+import type { Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import ComboWorkspace from "../src/components/ComboWorkspace";
 import { LanguageProvider } from "../src/i18n/provider";
 
-let previousLanguage: unknown;
+const globals = ["document", "window", "navigator", "localStorage", "IS_REACT_ACT_ENVIRONMENT"] as const;
+let previousGlobals: Record<(typeof globals)[number], unknown>;
+let testWindow: Window;
 
 beforeEach(() => {
-  previousLanguage = (globalThis.navigator as { language?: unknown } | undefined)?.language;
-  Object.defineProperty(globalThis.navigator, "language", {
-    configurable: true,
-    value: "en-US",
+  previousGlobals = Object.fromEntries(globals.map((key) => [key, Reflect.get(globalThis, key)])) as typeof previousGlobals;
+  testWindow = new Window({ url: "http://localhost/" });
+  Object.defineProperty(testWindow.navigator, "language", { configurable: true, value: "en-US" });
+  Object.defineProperties(globalThis, {
+    document: { configurable: true, value: testWindow.document },
+    window: { configurable: true, value: testWindow },
+    navigator: { configurable: true, value: testWindow.navigator },
+    localStorage: { configurable: true, value: testWindow.localStorage },
   });
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true;
 });
 
 afterEach(() => {
-  Object.defineProperty(globalThis.navigator, "language", {
-    configurable: true,
-    value: previousLanguage,
-  });
+  testWindow.close();
+  for (const key of globals) {
+    Object.defineProperty(globalThis, key, { configurable: true, value: previousGlobals[key] });
+  }
 });
 
 test("an empty combo list renders the first-combo editor inline", () => {
@@ -41,7 +52,76 @@ test("an empty combo list renders the first-combo editor inline", () => {
 
   expect(html).toContain("combos-workspace-root");
   expect(html).toContain('id="cwi-edit-id"');
+  expect(html).toContain("Internal combo id. You can change it after creation.");
   expect(html).toContain("Create combo");
   expect(html).not.toContain('role="dialog"');
   expect(html).not.toContain("Create your first combo");
+});
+
+test("an empty combo list creates the first combo and shows confirmation", async () => {
+  const { createRoot } = await import("react-dom/client");
+  const saved: Array<{ id: string; isCreate: boolean }> = [];
+  let createdId = "";
+  const container = document.createElement("div");
+  document.body.append(container);
+  let root: Root;
+
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <LanguageProvider>
+        <ComboWorkspace
+          combos={[]}
+          providers={[{ name: "openai" }]}
+          models={[{ provider: "openai", id: "gpt-5" }]}
+          loading={false}
+          onRefresh={() => {}}
+          onSave={async (item, isCreate) => {
+            saved.push({ id: item.id, isCreate });
+            return { ok: true };
+          }}
+          onRemove={async () => ({ ok: true })}
+          onAdd={() => {}}
+          adding={false}
+          onCloseAdd={() => {}}
+          onCreated={(id) => { createdId = id; }}
+        />
+      </LanguageProvider>,
+    );
+  });
+  await act(async () => {
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+
+  const idInput = container.querySelector<HTMLInputElement>("#cwi-edit-id")!;
+  const providerSelect = container.querySelector<HTMLSelectElement>('select[aria-label="Provider"]')!;
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(testWindow.HTMLInputElement.prototype, "value")!
+      .set!.call(idInput, "first");
+    idInput.dispatchEvent(new testWindow.Event("input", { bubbles: true }));
+  });
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(testWindow.HTMLSelectElement.prototype, "value")!
+      .set!.call(providerSelect, "openai");
+    providerSelect.dispatchEvent(new testWindow.Event("change", { bubbles: true }));
+  });
+  expect(idInput.value).toBe("first");
+  expect(providerSelect.value).toBe("openai");
+  expect(container.querySelector<HTMLSelectElement>('select[aria-label="Model"]')?.value).toBe("gpt-5");
+
+  const createButton = [...container.querySelectorAll<HTMLButtonElement>("button")]
+    .find((button) => button.textContent?.trim() === "Create combo");
+  expect(createButton).toBeDefined();
+
+  await act(async () => {
+    createButton!.click();
+  });
+
+  expect(saved).toEqual([{ id: "first", isCreate: true }]);
+  expect(createdId).toBe("first");
+  expect(container.textContent).toContain("Created combo/first.");
+
+  await act(async () => {
+    root.unmount();
+  });
 });


### PR DESCRIPTION
## Summary

- Keep the Combos workspace shell visible when no combos are configured.
- Reuse the detail editor as the inline first-combo creation flow instead of opening a modal.
- Add an SSR regression test and remove the obsolete standalone empty-state styles.

## Verification

- `bun test ./gui/tests/combo-workspace-empty.test.tsx`
- `cd gui && bun run test`
- `cd gui && bun run lint`
- `cd gui && bun run lint:i18n`
- `cd gui && bun run build`
- `bun run typecheck`
- `bun run privacy:scan`
- Full `bun run test`: 3,674 passed and 24 failed. The failures reproduce on a clean upstream `dev` worktree in the current DNS environment because public test hosts resolve into the `198.18.0.0/15` benchmark range; `tests/vertex-catalog.test.ts` reproduces 2 failures unchanged.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an inline editor for creating the first combo directly in the workspace.
  * Updated controls and messaging to clearly distinguish combo creation from editing.
  * The combo ID field is automatically focused when starting the first combo.

* **Bug Fixes**
  * Improved empty-workspace handling so “no search results” is not shown before any combos exist.

* **Tests**
  * Added coverage verifying the first-combo editor appears without the previous empty-state dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


### Wrong

<img width="2000" height="1063" alt="Resources 2026-07-23 at 17 43 44" src="https://github.com/user-attachments/assets/059adc60-5b0b-497a-88a8-b5cde827d281" />

### Correct
<img width="2000" height="975" alt="Resources 2026-07-23 at 17 58 25" src="https://github.com/user-attachments/assets/075da028-b5f3-4431-99e9-580ac3db1dd8" />

