### PR TITLE
fix(responses): reconstruct dropped SSE output items + dedupe replayed multi-agent guidance (#334, #326)

### DIFF
--- a/devlog/_plan/260724_bugfix_train/000_plan.md
+++ b/devlog/_plan/260724_bugfix_train/000_plan.md
@@ -1,0 +1,124 @@
+# 000 — 260724_bugfix_train: Plan
+
+> Roadmap master for the bugfix train. One work-phase = one full PABCD cycle.
+> Bound goalplan: `.codexclaw/goalplans/opencodex-bugfix-train-6-pabcd-cycles-bookkeepin/goalplan.json`
+> (session 019f8f62-c778-7550-bd4c-aa4419fce259).
+
+## Objective
+
+Land every verified-unpatched bug from the 2026-07-23 issue sweep as reviewable PRs
+against `dev`, and bring the two open contributor PRs to merge-ready quality.
+
+Evidence base: three Sol reviewer reports against origin/dev tip `d9e06c8d`
+(issues #334/#326, issues #335/#331/#329/#324/#320/#241/#92, PRs #336/#337) plus a
+3-Mind contradiction rescan (14 contradictions; 4 high folded into this plan as
+corrections, 6 medium recorded as OPEN ASSUMPTIONS below).
+
+## Loop-spec
+
+- Loop archetype: verifier-defined (spec-satisfaction repair) for every phase.
+- Trigger: owner directive 2026-07-24 — auto-resolve open questions via subagent
+  opinion, run repeated small PABCD cycles, push + open PR per cycle.
+- Goal: cycles 1-6 each closed through D with branch pushed and PR opened; #324
+  closed; #92/#241 status comments posted.
+- Non-goals: upstream-blocked fixes (#92/#241 root causes), #42 Phase 2/3, all
+  feature-request issues, merging any PR (owner decision; gui/ merges need fresh
+  explicit approval).
+- Verifier per cycle: `bun run typecheck` + `bun run test` + `bun run privacy:scan`
+  green; cycle 4/6 add `bun run lint:gui` + `bun run build:gui`; docs-site sync
+  decision recorded in the D summary.
+- Stop condition: all goalplan criteria met, or a stated terminal outcome
+  (BLOCKED / NEEDS_HUMAN / UNSAFE / BUDGET_EXHAUSTED with evidence).
+- Memory artifact: this unit + goalplan + `.codexclaw/ledger.jsonl`.
+- Escalation: upward — main reclaims a slice after two distinct agent failures on
+  the same packet (DISPATCH-RETIRE-01); downward — pushing a slice to a worker is a
+  P-phase amendment, never mid-B improvisation.
+- Resource bounds: tools = local git/gh/bun + GitHub via gh; write scope = the
+  ocx-bugfix-train worktree + contributor PR branches (maintainerCanModify verified);
+  push scope = per-cycle `codex/260724-*` branches and the two contributor branches
+  only (owner pre-approved for this exact scope).
+
+## Topology (corrected per contradiction scan)
+
+- One worktree: `/Users/jun/.codex/worktrees/ocx-bugfix-train` (deps installed).
+- Per-cycle branches `codex/260724-<unit>` cut from CURRENT `origin/dev` — never
+  stacked on unmerged predecessors (keeps every PR independently reviewable).
+- Cycles 5/6 fetch the contributor head branches and push fix commits there
+  (attribution preserved; no superseding PRs).
+- The review worktree `codex-260723-issue-pr-review` stays pinned at d9e06c8d as
+  read-only reference; all post-cycle-1 verification runs in this worktree.
+
+## Work-phase map (dependency-ordered, PHASE-SPLIT-01)
+
+| WP  | Doc  | Slice | Depends on |
+|-----|------|-------|------------|
+| wp0 | 000  | This roadmap (docs-only cycle) | — |
+| wp1 | 010  | #334 SSE output backfill + #326 idempotent guidance injection (file set per 010: src/server/relay.ts, src/types.ts, src/responses/parser.ts, src/server/responses/collaboration.ts — core.ts/state.ts explicitly untouched) | wp0 |
+| wp2 | 020  | #335 bounded single pool retry on allow-listed account-specific 400 (SECURITY GATE) | wp1 |
+| wp3 | 030  | #320 codex-shim auto-restore after external npm update (SECURITY GATE) | wp1 |
+| wp4 | 040  | #329 discovery-error badge + #331 helper-fallback UX copy (gui) | wp1 |
+| wp5 | 050  | PR #336 takeover: refresh to live head (87af85fb, 8 files, Cross-platform CI already GREEN), rebase onto post-wp1 dev, interdiff review, re-run gates. Expected textual overlap with wp1 is LOW (wp1 avoids core.ts); treat any collaboration.ts adjacency case-by-case | wp1 MERGED |
+| wp6 | 060  | PR #337 takeover: interactive component tests + split 840-line component + root-suite failures | wp4 merged preferred (i18n overlap) |
+| wp7 | —    | Bookkeeping: close #324 (docs pointer), status comments on #92/#241 | wp1 |
+
+Dependency rationale: wp1 is the foundation (passthrough state machine; PR #336
+edits the same subsystem, so it rebases after wp1 lands to keep semantics
+consistent even though direct textual conflict is expected to be low). wp2-wp4
+are independent capability lanes. wp5 is integration gated on wp1 merging. wp6
+prefers wp4 merged to avoid i18n hunk collisions. wp7 is hygiene.
+
+## wp0 artifact map (docs-only cycle, DIFFLEVEL-ROADMAP-01)
+
+| Action | Path (relative to repo root) |
+|--------|------------------------------|
+| NEW    | devlog/_plan/260724_bugfix_train/000_plan.md (this file) |
+| NEW    | devlog/_plan/260724_bugfix_train/010_passthrough_state.md |
+| NEW    | devlog/_plan/260724_bugfix_train/020_pool_retry_400.md |
+| NEW    | devlog/_plan/260724_bugfix_train/030_shim_autorestore.md |
+| NEW    | devlog/_plan/260724_bugfix_train/040_ux_discovery_badge.md |
+| NEW    | devlog/_plan/260724_bugfix_train/050_pr336_takeover.md |
+| NEW    | devlog/_plan/260724_bugfix_train/060_pr337_takeover.md |
+| NEW    | devlog/_plan/260724_bugfix_train/061_root_suite_investigation.md (wp6 research artifact, split per LEXICO-SPLIT-01) |
+| DELETE | devlog/_plan/260724_bugfix_train/010_phase1.md (scaffold, replaced by 010_passthrough_state.md) |
+| DELETE | devlog/_plan/260724_bugfix_train/020_phase2.md (scaffold, replaced by 020_pool_retry_400.md) |
+| DELETE | devlog/_plan/260724_bugfix_train/030_phase3.md (scaffold, replaced by 030_shim_autorestore.md) |
+| DELETE | devlog/_plan/260724_bugfix_train/040_phase4.md (scaffold, replaced by 040_ux_discovery_badge.md) |
+| DELETE | devlog/_plan/260724_bugfix_train/050_phase5.md (scaffold, replaced by 050_pr336_takeover.md) |
+| DELETE | devlog/_plan/260724_bugfix_train/060_phase6.md (scaffold, replaced by 060_pr337_takeover.md) |
+
+No production code changes in wp0. Activation proof for this cycle: the A-gate
+reviewer verdict (adversarial repo-grounded audit) + `git status` showing only
+devlog/_plan additions + the D attestation in `.codexclaw/ledger.jsonl`.
+devlog/ is gitignored with tracked content: force-add these artifacts when
+committing (`git add -f devlog/_plan/260724_bugfix_train`).
+
+## OPEN ASSUMPTIONS (carried from Interview, recorded)
+
+1. #335 intentionally refines the 35d28a02 "4xx = caller, no failover" policy; PR
+   description must say so explicitly; the pinned no-penalty test stays green.
+2. Done-gate extended beyond the user's "PR open": + privacy:scan + docs-site sync
+   decision per cycle (AGENTS.md requirements).
+3. Cycles 5/6 push fix commits to contributor branches (maintainerCanModify=true);
+   no superseding PRs; original authors keep attribution.
+4. #326 fix = idempotent injection (option a) with replayPrefixLen plumbed through
+   parseRequest; option (b) strip-at-persist rejected (5 call sites).
+5. #334 fix = one shared SSE item-accumulator helper for both consumers;
+   trackSseForRequestLog needs no backfill (terminal-status only).
+6. Cycles 2 and 3 carry security-review checkpoints (MAINTAINERS.md security
+   boundary); gui/ merges are outside this loop's authority.
+7. (superseded assumption, corrected by A-gate round 1) PR #336's required CI was
+   NOT missing — the initial gap was the first-time-contributor approval gate;
+   Cross-platform CI is green on live head 87af85fb. wp5 scope is rebase +
+   interdiff + gates re-run, not CI restoration.
+
+## Accept criteria (mirrored in goalplan criteria[])
+
+- c0: this roadmap closes its own PABCD cycle with reviewer PASS/near-pass.
+- c1-c6: each cycle's branch pushed, PR opened, gates output captured.
+- c7: #324 closed with docs-pointer comment; #92/#241 status comments posted.
+
+## SoT sync (SOT-SYNC-01)
+
+Repo SoT targets: `structure/` maintainer invariants + `docs-site/` user docs.
+Each cycle's P names which docs-site page (if any) its behavior change touches;
+the D summary records the sync decision.

--- a/devlog/_plan/260724_bugfix_train/000_plan.md
+++ b/devlog/_plan/260724_bugfix_train/000_plan.md
@@ -79,12 +79,9 @@ prefers wp4 merged to avoid i18n hunk collisions. wp7 is hygiene.
 | NEW    | devlog/_plan/260724_bugfix_train/050_pr336_takeover.md |
 | NEW    | devlog/_plan/260724_bugfix_train/060_pr337_takeover.md |
 | NEW    | devlog/_plan/260724_bugfix_train/061_root_suite_investigation.md (wp6 research artifact, split per LEXICO-SPLIT-01) |
-| DELETE | devlog/_plan/260724_bugfix_train/010_phase1.md (scaffold, replaced by 010_passthrough_state.md) |
-| DELETE | devlog/_plan/260724_bugfix_train/020_phase2.md (scaffold, replaced by 020_pool_retry_400.md) |
-| DELETE | devlog/_plan/260724_bugfix_train/030_phase3.md (scaffold, replaced by 030_shim_autorestore.md) |
-| DELETE | devlog/_plan/260724_bugfix_train/040_phase4.md (scaffold, replaced by 040_ux_discovery_badge.md) |
-| DELETE | devlog/_plan/260724_bugfix_train/050_phase5.md (scaffold, replaced by 050_pr336_takeover.md) |
-| DELETE | devlog/_plan/260724_bugfix_train/060_phase6.md (scaffold, replaced by 060_pr337_takeover.md) |
+
+Note: the six `0N0_phaseN.md` scaffolds were replaced before the unit's first
+commit and were never tracked by git — no DELETE rows apply to this map.
 
 No production code changes in wp0. Activation proof for this cycle: the A-gate
 reviewer verdict (adversarial repo-grounded audit) + `git status` showing only

--- a/devlog/_plan/260724_bugfix_train/010_passthrough_state.md
+++ b/devlog/_plan/260724_bugfix_train/010_passthrough_state.md
@@ -1,0 +1,678 @@
+# 010 — Cycle 1: passthrough record/replay state machine (#334 + #326)
+
+> DIFFLEVEL-ROADMAP-01: this is the copy-paste-executable implementation PRD for Cycle 1. The implementer must keep the production and test paths, signatures, branch semantics, and verification gates below unless new repository evidence makes the design impossible. Any expansion is escalated to the main agent before editing.
+
+## Loop spec
+
+- **Loop archetype:** spec-satisfaction repair.
+- **Trigger:** issue #334 reports that native Responses SSE persistence loses completed output items when `response.completed.response.output` is absent or empty; issue #326 reports that proxy-generated multi-agent guidance is persisted and then appended again on every `previous_response_id` continuation.
+- **Goal:** make passthrough continuation recording reconstruct terminal output from `response.output_item.done` events when necessary, and make proxy-generated guidance injection idempotent across replayed prefixes, without altering client-facing SSE bytes or compaction ordering.
+- **Non-goals:** redesign the Responses state store; strip guidance at persistence time; merge the inspection and metadata consumer loops; backfill request-log-only SSE tracking; synthesize items from delta events; change upstream payloads, adapter routing, provider continuation state, retention limits, snapshots, compaction behavior, or GUI/docs behavior.
+- **Verifier:** `bun run typecheck`; `bun run test`; `bun run privacy:scan`.
+- **Stop condition:** all focused regressions below pass, all three repository verifiers exit 0, native client SSE remains byte-identical, empty/missing terminal output is backfilled in `output_index` order for both persistence-capable consumers, non-empty terminal output remains authoritative, and a two-continuation replay contains exactly one proxy guidance item in outbound input and persisted state.
+- **Memory artifact:** this file, `devlog/_plan/260724_bugfix_train/010_passthrough_state.md`, updated only by the owning main agent if implementation evidence forces a correction.
+- **Expected terminal outcomes:** `PASS` (implementation and all verifiers satisfy this spec); `FAIL` (a verifier or acceptance assertion fails and the cycle returns to implementation); `BLOCKED` (the required behavior cannot be achieved inside the file/scope map and is escalated).
+- **Escalation:** upward — main reclaims after two agent failures; downward — none planned.
+
+## Failure model and invariants
+
+### #334 — terminal response is not the whole streamed response
+
+`src/server/relay.ts` currently extracts only the `response` object carried by `response.completed`. Native Responses streams can instead finalize authoritative output items in earlier `response.output_item.done` events while the terminal event has `output: []` or no `output`. `rememberResponseState` accepts any array, including an empty one, so the current terminal-only callback either stores no assistant/reasoning/function-call items or does not store at all when `output` is absent. The next locally expanded continuation is therefore incomplete and can repeat a tool call forever.
+
+The repair law is:
+
+1. Observe only `response.output_item.done` events.
+2. Store each valid item in one `Map<number, unknown>` keyed by integer, non-negative `output_index`; later observations for the same index replace earlier ones.
+3. On `response.completed`, leave a non-empty terminal `response.output` exactly untouched.
+4. If terminal `output` is missing or an empty array and at least one done item was accumulated, provide a shallow response copy whose `output` is the accumulated items sorted by ascending index.
+5. Invoke `onCompletedResponse` only after rule 3 or 4 has been applied.
+6. Never rewrite, buffer, re-encode, or emit the client-facing SSE branch.
+
+The two persistence-capable consumers deliberately keep different control loops:
+
+- `consumeForInspection` stops inspecting post-terminal payloads only when there is no completion callback (`if (reported && !onCompletedResponse) continue`). Preserve that condition and route each payload that remains eligible through the accumulator.
+- `consumeForResponseLogMetadata` never applies that skip. Preserve its loop and route every parsed payload through the same accumulator.
+- `trackSseForRequestLog` is terminal-status/request-log tracking only. It has no `onCompletedResponse`, never calls `rememberResponseState`, and must not allocate or use the item accumulator. It needs no backfill.
+
+### #326 — replay provenance must reach injection
+
+`expandPreviousResponseInput` already records the replay prefix length in a proxy-private `WeakMap` keyed by the exact expanded request object. `parseRequest` reads that length for compaction-boundary logic, but discards it from `OcxParsedRequest`. `injectDeveloperMessage` therefore cannot distinguish replayed proxy guidance from a new request suffix and always appends another copy to both parsed messages and `_rawBody.input`. Passthrough persistence records the mutated `_rawBody`, producing one extra guidance item per continuation.
+
+The repair law is:
+
+1. Add optional proxy-private `OcxParsedRequest._replayPrefixLen?: number`.
+2. `parseRequest` copies its already-read `replayedInputPrefixLength` into that field when the value is positive.
+3. `injectDeveloperMessage` constructs the exact wire item it would inject, scans every item in `_rawBody.input.slice(0, _replayPrefixLen)`, and skips both parsed-message and raw-input insertion if an exact generated item is present.
+4. “Exact generated item” means `{type:"message", role:"developer", content:[{type:"input_text", text}]}` with exactly one content part and the exact requested text. Do not match arbitrary developer messages, substrings, or suffix items.
+5. Detection searches the whole replay prefix. It never assumes guidance is first, last, adjacent to a user item, or adjacent to `compaction_trigger`.
+6. Fresh insertion retains the existing invariant: if the final raw item is `compaction_trigger`, insert immediately before it; otherwise append.
+7. Do not implement the rejected persist-time stripping alternative. It would spread policy across five persistence call sites and enlarge the blast radius.
+
+## Exact file change map
+
+### Planning artifact changes for this cycle
+
+- **NEW** `devlog/_plan/260724_bugfix_train/010_passthrough_state.md` — this diff-level implementation contract.
+- **DELETE** `devlog/_plan/260724_bugfix_train/010_phase1.md` — superseded empty scaffold.
+
+### Production and regression changes to implement
+
+- **MODIFY** `src/server/relay.ts` — add one shared stateful completion accumulator and use it from `consumeForInspection` and `consumeForResponseLogMetadata`; retain `completedResponseFromSsePayload` and leave `trackSseForRequestLog` unchanged.
+- **MODIFY** `src/types.ts` — add `_replayPrefixLen?: number` to `OcxParsedRequest`.
+- **MODIFY** `src/responses/parser.ts` — preserve the already-computed replay prefix length on the parsed request.
+- **MODIFY** `src/server/responses/collaboration.ts` — detect the exact generated guidance item anywhere in the replay prefix and make dual-write injection idempotent.
+- **MODIFY** `tests/responses-state.test.ts` — add focused stream/persistence tests for both relay consumers, terminal-output authority, and the two-continuation guidance regression.
+
+No other file is part of Cycle 1. In particular, do not modify `src/server/responses/core.ts`, `src/responses/state.ts`, `src/server/request-log.ts`, adapters, snapshots, docs, GUI, workflows, dependencies, or release automation.
+
+## Diff-level implementation
+
+### 1. `src/server/relay.ts`
+
+#### Keep the terminal extractor signature unchanged
+
+Current code:
+
+```ts
+/** Extract the response object from a `response.completed` SSE payload, or null. */
+export function completedResponseFromSsePayload(payload: string): { id?: unknown; output?: unknown; status?: unknown } | null {
+  if (payload === "[DONE]") return null;
+  try {
+    const json = JSON.parse(payload) as { type?: unknown; response?: unknown };
+    if (json.type !== "response.completed") return null;
+    const response = json.response;
+    if (!response || typeof response !== "object" || Array.isArray(response)) return null;
+    return response as { id?: unknown; output?: unknown; status?: unknown };
+  } catch {
+    return null;
+  }
+}
+```
+
+After: retain this function byte-for-byte. Add the following immediately after it. The new helper is file-private because only the two background consumers own this reconstruction responsibility.
+
+```ts
+type CompletedResponse = { id?: unknown; output?: unknown; status?: unknown };
+
+function createCompletedResponseAccumulator(
+  onCompletedResponse?: (response: CompletedResponse) => void,
+): (payload: string | null) => void {
+  const itemsByOutputIndex = new Map<number, unknown>();
+  return payload => {
+    if (!payload || payload === "[DONE]") return;
+    try {
+      const event = JSON.parse(payload) as {
+        type?: unknown;
+        output_index?: unknown;
+        item?: unknown;
+      };
+      if (event.type === "response.output_item.done") {
+        if (Number.isInteger(event.output_index)
+          && (event.output_index as number) >= 0
+          && event.item !== undefined) {
+          itemsByOutputIndex.set(event.output_index as number, event.item);
+        }
+        return;
+      }
+    } catch {
+      return;
+    }
+
+    let response = completedResponseFromSsePayload(payload);
+    if (!response) return;
+    if ((!Array.isArray(response.output) || response.output.length === 0)
+      && itemsByOutputIndex.size > 0) {
+      response = {
+        ...response,
+        output: [...itemsByOutputIndex.entries()]
+          .sort(([left], [right]) => left - right)
+          .map(([, item]) => item),
+      };
+    }
+    onCompletedResponse?.(response);
+  };
+}
+```
+
+Implementation note: the first parse handles item-done observation; non-item events then flow to the existing terminal extractor. A malformed payload remains best-effort/no-throw. Do not export this helper and do not broaden `CompletedResponse` beyond the existing callback contract.
+
+#### Modify `consumeForInspection`
+
+Real signature (unchanged):
+
+```ts
+export function consumeForInspection(
+  body: ReadableStream<Uint8Array>,
+  onTerminal: (status: ResponsesTerminalStatus, httpStatusOverride?: number) => void,
+  signal?: AbortSignal,
+  onDone?: () => void,
+  logCtx?: RequestLogContext,
+  onCancel?: () => void,
+  onCompletedResponse?: (response: { id?: unknown; output?: unknown; status?: unknown }) => void,
+  onFirstOutput?: () => void,
+): void {
+```
+
+Current initialization:
+
+```ts
+  let reported = false;
+  let cancelled = false;
+  const reportFirstOutput = createFirstOutputReporter(onFirstOutput);
+```
+
+After:
+
+```ts
+  let reported = false;
+  let cancelled = false;
+  const reportFirstOutput = createFirstOutputReporter(onFirstOutput);
+  const observeCompletedResponse = createCompletedResponseAccumulator(onCompletedResponse);
+```
+
+Current EOF completion block:
+
+```ts
+              if (onCompletedResponse) {
+                const response = completedResponseFromSsePayload(payload);
+                if (response) onCompletedResponse(response);
+              }
+```
+
+After:
+
+```ts
+              observeCompletedResponse(payload);
+```
+
+Current normal-loop completion block:
+
+```ts
+          if (onCompletedResponse) {
+            const response = completedResponseFromSsePayload(payload);
+            if (response) onCompletedResponse(response);
+          }
+```
+
+After:
+
+```ts
+          observeCompletedResponse(payload);
+```
+
+Do not alter `if (reported && !onCompletedResponse) continue`, terminal reporting, logging, first-output reporting, cancellation, synthetic status behavior, or `onDone` ordering. The accumulator runs only on payloads the existing loop already permits. The normal event ordering (`output_item.done` before `response.completed`) guarantees backfill is complete before the callback.
+
+#### Modify `consumeForResponseLogMetadata`
+
+Real signature (unchanged):
+
+```ts
+export function consumeForResponseLogMetadata(
+  body: ReadableStream<Uint8Array>,
+  logCtx: RequestLogContext,
+  signal?: AbortSignal,
+  onDone?: () => void,
+  onCompletedResponse?: (response: { id?: unknown; output?: unknown; status?: unknown }) => void,
+  onFirstOutput?: () => void,
+): void {
+```
+
+Current initialization:
+
+```ts
+  let buffer = "";
+  const reportFirstOutput = createFirstOutputReporter(onFirstOutput);
+```
+
+After:
+
+```ts
+  let buffer = "";
+  const reportFirstOutput = createFirstOutputReporter(onFirstOutput);
+  const observeCompletedResponse = createCompletedResponseAccumulator(onCompletedResponse);
+```
+
+Replace both identical callback blocks (one in EOF residual handling, one in the normal block loop):
+
+```ts
+            if (payload && onCompletedResponse) {
+              const response = completedResponseFromSsePayload(payload);
+              if (response) onCompletedResponse(response);
+            }
+```
+
+and
+
+```ts
+          if (payload && onCompletedResponse) {
+            const response = completedResponseFromSsePayload(payload);
+            if (response) onCompletedResponse(response);
+          }
+```
+
+with, respectively:
+
+```ts
+            observeCompletedResponse(payload);
+```
+
+and
+
+```ts
+          observeCompletedResponse(payload);
+```
+
+Do not add a reported/terminal skip to this consumer. It must continue inspecting every payload for request-log metadata exactly as before.
+
+#### Explicit no-change: `trackSseForRequestLog`
+
+Real signature:
+
+```ts
+export function trackSseForRequestLog(
+  body: ReadableStream<Uint8Array>,
+  onTerminal: (status: ResponsesTerminalStatus) => void,
+  onCancel: () => void,
+  logCtx?: RequestLogContext,
+  onFirstOutput?: () => void,
+): ReadableStream<Uint8Array> {
+```
+
+Before and after are identical. This function only calls `terminalStatusFromSsePayload`, reports log terminal state, and relays bytes. It has no response-state callback. Adding the accumulator here would create unused state and blur the persistence boundary.
+
+### 2. `src/types.ts`
+
+Current excerpt:
+
+```ts
+export interface OcxParsedRequest {
+  modelId: string;
+  previousResponseId?: string;
+  context: OcxContext;
+  stream: boolean;
+  options: OcxRequestOptions;
+  _rawBody?: unknown;
+  /** True when the proxy expanded a previous_response_id request into a full input replay. */
+  _previousResponseInputExpanded?: boolean;
+```
+
+After:
+
+```ts
+export interface OcxParsedRequest {
+  modelId: string;
+  previousResponseId?: string;
+  context: OcxContext;
+  stream: boolean;
+  options: OcxRequestOptions;
+  _rawBody?: unknown;
+  /** Number of leading raw input items restored from local previous_response_id state. */
+  _replayPrefixLen?: number;
+  /** True when the proxy expanded a previous_response_id request into a full input replay. */
+  _previousResponseInputExpanded?: boolean;
+```
+
+Keep the field optional so existing hand-built `OcxParsedRequest` fixtures remain valid. It is proxy-private metadata and must never be serialized into `_rawBody` or sent upstream.
+
+### 3. `src/responses/parser.ts`
+
+Real signature:
+
+```ts
+export function parseRequest(body: unknown): OcxParsedRequest {
+```
+
+Current opening already captures provenance and remains unchanged:
+
+```ts
+export function parseRequest(body: unknown): OcxParsedRequest {
+  const replayedInputPrefixLength = previousResponseReplayPrefixLength(body);
+  const parsed = responsesRequestSchema.safeParse(body);
+```
+
+Current return excerpt:
+
+```ts
+  return {
+    modelId: data.model,
+    ...(data.previous_response_id ? { previousResponseId: data.previous_response_id } : {}),
+    context,
+    stream: data.stream === true,
+    options,
+    _rawBody: body,
+    ...(webSearch ? { _webSearch: webSearch } : {}),
+```
+
+After:
+
+```ts
+  return {
+    modelId: data.model,
+    ...(data.previous_response_id ? { previousResponseId: data.previous_response_id } : {}),
+    context,
+    stream: data.stream === true,
+    options,
+    _rawBody: body,
+    ...(replayedInputPrefixLength > 0 ? { _replayPrefixLen: replayedInputPrefixLength } : {}),
+    ...(webSearch ? { _webSearch: webSearch } : {}),
+```
+
+Do not replace the existing `WeakMap`, add a wire field, or change the existing `inputIndex >= replayedInputPrefixLength` compaction-boundary test. This is a second consumer of the provenance already read at function entry.
+
+### 4. `src/server/responses/collaboration.ts`
+
+#### Add exact-item predicates immediately above `injectDeveloperMessage`
+
+After:
+
+```ts
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isGeneratedDeveloperItem(item: unknown, text: string): boolean {
+  if (!isRecord(item) || item.type !== "message" || item.role !== "developer") return false;
+  if (!Array.isArray(item.content) || item.content.length !== 1) return false;
+  const [part] = item.content;
+  return isRecord(part) && part.type === "input_text" && part.text === text;
+}
+```
+
+If this file already has an equivalent record guard at implementation time, reuse it instead of adding a duplicate. The semantic check must remain exact as shown.
+
+#### Modify `injectDeveloperMessage`
+
+Real signature:
+
+```ts
+export function injectDeveloperMessage(parsed: OcxParsedRequest, text: string): void {
+```
+
+Current function:
+
+```ts
+export function injectDeveloperMessage(parsed: OcxParsedRequest, text: string): void {
+  parsed.context.messages.push({ role: "developer", content: text, timestamp: Date.now() });
+  const raw = parsed._rawBody as { input?: unknown } | undefined;
+  if (raw && Array.isArray(raw.input)) {
+    const devItem = { type: "message", role: "developer", content: [{ type: "input_text", text }] };
+    // compaction_trigger must remain the final input item (codex-rs + ChatGPT backend both
+    // validate this). Insert the developer message BEFORE the trigger when present.
+    const last = raw.input[raw.input.length - 1];
+    if (last && typeof last === "object" && (last as { type?: string }).type === "compaction_trigger") {
+      raw.input.splice(raw.input.length - 1, 0, devItem);
+    } else {
+      raw.input.push(devItem);
+    }
+  }
+}
+```
+
+After:
+
+```ts
+export function injectDeveloperMessage(parsed: OcxParsedRequest, text: string): void {
+  const raw = parsed._rawBody as { input?: unknown } | undefined;
+  const devItem = { type: "message", role: "developer", content: [{ type: "input_text", text }] };
+  if (raw && Array.isArray(raw.input)) {
+    const replayPrefixLen = Math.min(parsed._replayPrefixLen ?? 0, raw.input.length);
+    if (raw.input.slice(0, replayPrefixLen).some(item => isGeneratedDeveloperItem(item, text))) {
+      return;
+    }
+  }
+
+  parsed.context.messages.push({ role: "developer", content: text, timestamp: Date.now() });
+  if (raw && Array.isArray(raw.input)) {
+    // compaction_trigger must remain the final input item (codex-rs + ChatGPT backend both
+    // validate this). Insert the developer message BEFORE the trigger when present.
+    const last = raw.input[raw.input.length - 1];
+    if (last && typeof last === "object" && (last as { type?: string }).type === "compaction_trigger") {
+      raw.input.splice(raw.input.length - 1, 0, devItem);
+    } else {
+      raw.input.push(devItem);
+    }
+  }
+}
+```
+
+The early return is intentionally before the parsed-message push. `parseRequest` has already converted the replayed wire guidance into one developer message in `parsed.context.messages`; adding another parsed-only copy would still duplicate model context. If raw input is a string/non-array, preserve current behavior: parsed context receives the message and raw input is untouched. A matching item in the new suffix does not suppress injection because only replayed proxy state is trusted for idempotence.
+
+## Regression test plan
+
+All new tests go in **MODIFY** `tests/responses-state.test.ts`, whose existing `beforeEach`/`afterEach` isolate `OPENCODEX_HOME`, clear memory, and remove snapshots. Extend imports with `injectDeveloperMessage` from `../src/server/responses` and `consumeForInspection`, `consumeForResponseLogMetadata`, plus the request-log context type or a minimal cast from `../src/server`/the existing export surface. Add a local SSE stream builder and use an `onDone` promise rather than timing sleeps.
+
+Suggested shared fixture:
+
+```ts
+function sseStream(events: Record<string, unknown>[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+      }
+      controller.close();
+    },
+  });
+}
+```
+
+Use a structurally valid minimal `RequestLogContext` fixture already accepted by relay tests, or import its type and cast a local `{}` only if the inspector functions tolerate it for the selected events. Prefer the real existing helper if one is present at implementation time.
+
+### Test 1 — inspection consumer backfills and persists done items
+
+Name:
+
+```ts
+test("inspection consumer backfills empty completed output before passthrough persistence (#334)", async () => { ... });
+```
+
+Fixture/event order:
+
+1. `response.output_item.done`, `output_index: 2`, completed `function_call` item.
+2. `response.output_item.done`, `output_index: 0`, completed `reasoning` item.
+3. `response.output_item.done`, `output_index: 1`, completed assistant `message` item.
+4. `response.completed`, response `{id:"resp_334_inspection", status:"completed", output:[]}`.
+
+Wire `consumeForInspection(..., onCompletedResponse)` so the callback calls `rememberResponseState(requestBody, response, undefined, {force:true})`. Await `onDone`, expand a next request with `previous_response_id: "resp_334_inspection"`, and assert the replayed output types are exactly `reasoning`, `message`, `function_call` after the original input and before the new suffix.
+
+**C-ACTIVATION-GROUNDING-01:** out-of-order indices activate the sort path; all three valid done events activate `Map.set`; the terminal empty array activates backfill; `rememberResponseState` plus the next expansion proves the callback received the reconstructed array and that saved state contains assistant/reasoning/tool-call items. Reading the untouched tee is not part of this unit, so byte preservation is established structurally by the production diff (inspection-only branch) and by the full passthrough suite.
+
+### Test 2 — metadata consumer uses the same backfill path
+
+Name:
+
+```ts
+test("metadata consumer backfills missing completed output before passthrough persistence (#334)", async () => { ... });
+```
+
+Use at least a `message` done item at index 0 and a `function_call` done item at index 1, followed by `response.completed` whose response has an id/status but **omits** `output`. Wire `consumeForResponseLogMetadata` to the same persistence callback, await `onDone`, expand by that response id, and assert both items are present in index order.
+
+**C-ACTIVATION-GROUNDING-01:** omitted `output` activates the `!Array.isArray(response.output)` side of backfill, while invoking the metadata consumer proves its independent payload loop is wired to the shared accumulator. Successful local replay is the observable persistence proof.
+
+### Test 3 — non-empty terminal output remains authoritative
+
+Name:
+
+```ts
+test("non-empty completed output remains authoritative over accumulated done items (#334)", async () => { ... });
+```
+
+Send a done event containing a sentinel `function_call`, then complete with a non-empty `output` containing a different sentinel assistant message. Capture the callback response and persist it. Assert the callback's `output` is the exact terminal array/reference and the next replay contains the terminal assistant item but not the accumulated sentinel call.
+
+**C-ACTIVATION-GROUNDING-01:** the prior done event makes the map non-empty, so the only reason the call is excluded is activation of the `Array.isArray(output) && output.length > 0` authoritative path. Reference equality (when captured before stream construction) plus replay content proves the terminal array was not replaced or merged.
+
+### Test 4 — two chained continuations keep one guidance copy
+
+Name:
+
+```ts
+test("two previous_response_id continuations keep one replayed guidance item (#326)", () => { ... });
+```
+
+Use one stable guidance string and perform this sequence:
+
+1. Parse request 1 with array input, inject guidance once, and persist response 1. Response 1's `output` must include a completed `function_call` item, modeling the post-#334 persisted shape.
+2. Expand request 2 from response 1 with a `function_call_output` suffix, parse it, and assert `_replayPrefixLen` covers the saved request-1 input plus output. The replay prefix order must place the guidance before the backfilled function call, so guidance is not at the prefix edge. Call `injectDeveloperMessage` with the same text and assert raw outbound input and parsed context each contain exactly one copy. Persist response 2.
+3. Expand request 3 from response 2 with a new user suffix, parse it, call injection again, and assert raw outbound input and parsed context still contain exactly one copy. Persist response 3, expand an audit-only request from response 3, and assert saved state also contains exactly one exact generated wire item.
+
+Count only exact wire items matching the generated shape, and separately count parsed developer messages whose content equals the guidance. Retain the existing `injectDeveloperMessage` test `inserts BEFORE compaction_trigger so it stays the final input item` unchanged.
+
+**C-ACTIVATION-GROUNDING-01:** request 1 activates fresh insertion; request 2's interior replayed guidance activates whole-prefix search and early return; the replayed `function_call` grounds fixture ordering after #334; request 3 activates idempotence on a second chained continuation; raw `_rawBody.input` is the passthrough outbound body observable; audit expansion from response 3 is the saved-state observable. Exact counts of one prove neither dual-write destination accumulated duplicates.
+
+### Test 5 — duplicate output indices are last-write-wins
+
+Name:
+
+```ts
+test("duplicate output_index keeps only the final done item (#334)", async () => { ... });
+```
+
+Send two valid `response.output_item.done` events at `output_index: 2`: first a sentinel
+assistant message, then the final completed `function_call`. Follow them with an empty
+`response.completed.response.output`, persist through the inspection consumer, and replay the
+saved response. Assert index 2 appears exactly once, contains the final function call, and does not
+contain the earlier sentinel. This fixture mandatorily activates the existing `Map.set` replacement
+branch rather than merely exercising insertion.
+
+### Test 6 — malformed done events are rejected
+
+Name:
+
+```ts
+test("malformed output_item.done events do not enter reconstructed output (#334)", async () => { ... });
+```
+
+Interleave one valid index-0 message with done events whose `output_index` is missing, negative,
+fractional, and a string, plus one valid-index event whose `item` is missing. Complete with
+`output: []`. Assert the callback fires once and reconstructed/persisted output contains only the
+valid index-0 item. This is the mandatory activation for every index/item rejection guard.
+
+### Test 7 — exact guidance in the current suffix does not suppress injection
+
+Name:
+
+```ts
+test("matching guidance in the current suffix does not suppress replay-prefix injection (#326)", () => { ... });
+```
+
+Build an expanded request whose replay prefix contains no exact generated guidance, but whose new
+caller suffix contains an item with the exact generated wire shape/text. Set `_replayPrefixLen` to
+end immediately before that suffix item, call `injectDeveloperMessage`, and assert a new generated
+item is inserted in addition to the suffix item and parsed context receives the injected message.
+The observable count is two raw exact-shape items, proving the scan is restricted to trusted replay
+provenance rather than all current input.
+
+### Test 8 — malformed SSE payload is skipped without losing completion
+
+Name:
+
+```ts
+test("malformed SSE payload is skipped before a valid completed response (#334)", async () => { ... });
+```
+
+Use a raw SSE fixture (not the JSON-only helper) containing `data: {not-json}\n\n`, then a valid
+index-0 done event and a valid empty-output completion. Run it through each persistence-capable
+consumer (table-driven subcases are allowed). Assert no throw, one completion callback per
+consumer, and replay contains the valid item. This mandatorily activates the accumulator's JSON
+parse catch while proving later frames are still processed.
+
+### Conditional-path activation matrix
+
+| New/changed conditional | Activation scenario | Observable proof |
+|---|---|---|
+| Null or `[DONE]` payload is ignored | Append `[DONE]` to Test 1 and retain existing null/no-payload coverage | Callback fires once and no throw/regression occurs |
+| Malformed SSE payload is ignored | Mandatory Test 8 places raw invalid JSON before valid done/completed frames in both consumers | No throw; one callback; later valid item persists |
+| Valid `response.output_item.done` index/item | Tests 1–3 send valid done events | Saved/captured output contains the item |
+| Duplicate `output_index` uses Map last-write-wins | Mandatory Test 5 sends two valid items at index 2 | Replay contains exactly one final index-2 item and no sentinel |
+| Invalid/missing index or missing item is ignored | Mandatory Test 6 covers missing, negative, fractional, string index and missing item | Callback/replay contains only the one valid item |
+| Missing terminal output backfills | Test 2 omits `output` | Saved replay has message + function call |
+| Empty terminal output backfills | Test 1 uses `output: []` | Saved replay has reasoning + message + function call |
+| Non-empty terminal output is untouched | Test 3 supplies a non-empty terminal array while map is populated | Reference equality and no sentinel call in replay |
+| Completion callback absent | Existing cancel/incomplete tests call `consumeForInspection` without it | Existing terminal/cancel assertions remain green; no behavior change |
+| Replay prefix length is zero | Existing fresh injection tests plus request 1 in Test 4 | One parsed and one raw guidance insertion |
+| Exact guidance exists anywhere in replay prefix | Test 4 places it before a backfilled function call | Injection returns early; counts remain one |
+| Similar/non-exact developer item does not suppress | Add a required table-driven subcase to Test 7 with different text and an extra content part in the prefix | Requested exact guidance is still inserted once |
+| Matching item exists only in current suffix | Mandatory Test 7 places exact shape/text after `_replayPrefixLen` | Prefix-only scan inserts one new item; raw exact-shape count becomes two |
+| Raw input is non-array | Existing `string raw input is left alone` test | Parsed message added; raw string unchanged |
+| Fresh raw input ends in `compaction_trigger` | Existing `inserts BEFORE compaction_trigger so it stays the final input item` test | Trigger remains final |
+
+Tests 1–8 and every matrix row marked mandatory/required are acceptance requirements. Table-driven
+subcases may share setup, but none may be omitted, folded into an unnamed “existing coverage” claim,
+or have its observable weakened.
+
+## Scope boundary
+
+### IN
+
+- Native Responses SSE background inspection used by passthrough response-state recording.
+- Reconstruction from finalized output items only.
+- Replay-prefix provenance propagation from parser to collaboration injection.
+- Exact, prefix-scoped idempotence for proxy-generated developer guidance.
+- Focused state-machine regressions and repository-wide verification.
+
+### OUT
+
+- Client-facing SSE mutation, buffering, reordering, or synthesis.
+- Delta-to-item reconstruction (`response.output_text.delta`, reasoning deltas, function argument deltas).
+- Changes to `rememberResponseState`, `expandPreviousResponseInput`, WeakMap ownership, snapshot schema/version, TTL, byte caps, or eviction.
+- Persist-time removal of guidance.
+- Changes to `trackSseForRequestLog` beyond a clarifying comment if absolutely necessary; no code-path change is authorized.
+- Compaction trigger placement or compaction persistence policy changes.
+- Routed-provider bridge output, JSON passthrough, provider adapters, request routing, auth, credentials, workflows, dependencies, release scripts, GUI, or docs-site.
+
+Any need to touch an OUT path or any file not listed in the exact change map is a scope expansion and must be reported to the main agent before editing.
+
+## Docs-site sync decision
+
+No docs-site update. Both issues repair internal continuation correctness and preserve the public wire contract. There is no new option, endpoint, model behavior, or user-facing workflow to document. The regression tests and this devlog artifact are the appropriate durable record.
+
+## Security and privacy
+
+- No authentication, credential, OAuth, workflow, dependency, release, or permission boundary changes are in scope.
+- Never log request bodies, replayed input, guidance text, completed output items, tool arguments, account identifiers, or response-state contents.
+- The new replay prefix field remains in the in-process parsed object only; it must not be copied into `_rawBody`, serialized upstream, or persisted as a new snapshot field.
+- The accumulator is per-consumer/per-stream local state and is released when the consumer finishes. It does not create cross-request global state.
+- `bun run privacy:scan` is mandatory even though no new logging is planned.
+
+## Implementation and verification sequence
+
+1. Confirm the worktree is at the intended `origin/dev` baseline and preserve unrelated dirty work.
+2. Implement `src/server/relay.ts` helper and consumer wiring without touching the client relay branch.
+3. Add `_replayPrefixLen` in `src/types.ts` and populate it in `src/responses/parser.ts`.
+4. Implement exact replay-prefix detection in `src/server/responses/collaboration.ts`, retaining fresh compaction-trigger ordering.
+5. Add ALL EIGHT named regressions (the four core regressions plus the four
+   mandatory matrix tests: duplicate-index last-write-wins, malformed done-event
+   rejection, suffix-guidance non-dedupe, malformed-SSE skip) and their
+   activation assertions to `tests/responses-state.test.ts`.
+6. Run focused tests: `bun test tests/responses-state.test.ts tests/multi-agent-compat.test.ts tests/consume-for-inspection-cancel.test.ts tests/passthrough-abort.test.ts`.
+7. Run `bun run typecheck` and require exit 0.
+8. Run `bun run test` and require exit 0.
+9. Run `bun run privacy:scan` and require exit 0.
+10. Inspect `git diff --check`, `git diff --stat`, and the exact changed-path list. Fail if any path outside the implementation map changed.
+
+## Acceptance checklist
+
+- [ ] One shared `Map<output_index, item>` accumulator is used by both persistence-capable SSE consumers.
+- [ ] Empty and missing terminal output are backfilled in ascending index order before `onCompletedResponse`.
+- [ ] Non-empty terminal output is passed through unchanged and is never merged with accumulated items.
+- [ ] `trackSseForRequestLog` remains terminal-status-only and receives no backfill logic.
+- [ ] Client-facing native SSE bytes and relay selection remain unchanged.
+- [ ] `OcxParsedRequest` receives proxy-private replay prefix length without changing the wire body.
+- [ ] Guidance detection searches the whole replay prefix for the exact generated item shape.
+- [ ] A replay hit skips both parsed-context and raw-input insertion.
+- [ ] Fresh guidance insertion still precedes a final `compaction_trigger`.
+- [ ] #326 fixtures include the post-#334 persisted `function_call` shape.
+- [ ] Two chained continuations produce one guidance copy in outbound input and one in persisted/replayed state.
+- [ ] Focused tests, typecheck, full test suite, and privacy scan all exit 0.
+- [ ] No request-body or response-item logging was introduced.
+
+## Issue-comment traceability self-check
+
+- [ ] **#334 reporter — `relay.ts` empty-output backfill:** implemented by the file-private accumulator, `output_index` Map ordering, and both consumer wiring sections above.
+- [ ] **#334 reporter — regression test:** covered by the inspection empty-output persistence test, metadata missing-output persistence test, and non-empty authoritative-output test.
+- [ ] **#326 reporter kdnsna — idempotent injection or persist exclusion:** implemented using the accepted idempotent injection option; replay provenance is copied to `OcxParsedRequest`, the exact guidance item is searched across the prefix, and the rejected five-call-site persist exclusion is explicitly out of scope.
+- [ ] **#326 reporter kdnsna — two-continuation regression:** covered by the request-1 → response-1 → request-2 → response-2 → request-3 sequence, with raw outbound and audit-replayed saved-state counts fixed at one.
+- [ ] **Cross-issue ordering:** the #326 fixture deliberately replays a #334-style completed `function_call`, proving guidance detection does not assume a prefix-edge position.
+- [ ] **Compaction invariant:** the existing regression requiring generated guidance before final `compaction_trigger` remains mandatory and unchanged.

--- a/devlog/_plan/260724_bugfix_train/010_passthrough_state.md
+++ b/devlog/_plan/260724_bugfix_train/010_passthrough_state.md
@@ -2,14 +2,16 @@
 
 > DIFFLEVEL-ROADMAP-01: this is the copy-paste-executable implementation PRD for Cycle 1. The implementer must keep the production and test paths, signatures, branch semantics, and verification gates below unless new repository evidence makes the design impossible. Any expansion is escalated to the main agent before editing.
 
+> **Stale-check (2026-07-24): verified against `origin/dev` `097cadc1` (supersedes the original `d9e06c8d` baseline).** Commits `3781448a` + `e0c7caba` (#314 WP1/WP2) added `OcxConfig.streamMode`, introduced `src/server/relay-eager.ts`, and refactored both legacy SSE consumers around the exported per-chunk `createSseInspector` state machine at `src/server/relay.ts:407-482`. The former plan to add a second shared completion helper is superseded: #334 state now belongs inside `createSseInspector`, which also covers the eager relay wired at `src/server/responses/core.ts:1037-1076`. #326 behavior is unchanged; its current anchors and the five shifted `rememberResponseState` call sites are recorded below. The nine new `src/types.ts` lines are `OcxConfig.streamMode` at `src/types.ts:448-456` and do not collide with the planned `OcxParsedRequest._replayPrefixLen` insertion at `src/types.ts:7-10`.
+
 ## Loop spec
 
 - **Loop archetype:** spec-satisfaction repair.
 - **Trigger:** issue #334 reports that native Responses SSE persistence loses completed output items when `response.completed.response.output` is absent or empty; issue #326 reports that proxy-generated multi-agent guidance is persisted and then appended again on every `previous_response_id` continuation.
 - **Goal:** make passthrough continuation recording reconstruct terminal output from `response.output_item.done` events when necessary, and make proxy-generated guidance injection idempotent across replayed prefixes, without altering client-facing SSE bytes or compaction ordering.
-- **Non-goals:** redesign the Responses state store; strip guidance at persistence time; merge the inspection and metadata consumer loops; backfill request-log-only SSE tracking; synthesize items from delta events; change upstream payloads, adapter routing, provider continuation state, retention limits, snapshots, compaction behavior, or GUI/docs behavior.
+- **Non-goals:** redesign the Responses state store; strip guidance at persistence time; add a second completion accumulator/helper outside `createSseInspector`; modify the legacy consumer or eager-relay control loops; backfill request-log-only SSE tracking; synthesize items from delta events; change upstream payloads, adapter routing, provider continuation state, retention limits, snapshots, compaction behavior, or GUI/docs behavior.
 - **Verifier:** `bun run typecheck`; `bun run test`; `bun run privacy:scan`.
-- **Stop condition:** all focused regressions below pass, all three repository verifiers exit 0, native client SSE remains byte-identical, empty/missing terminal output is backfilled in `output_index` order for both persistence-capable consumers, non-empty terminal output remains authoritative, and a two-continuation replay contains exactly one proxy guidance item in outbound input and persisted state.
+- **Stop condition:** all focused regressions below pass, all three repository verifiers exit 0, native client SSE remains byte-identical, empty/missing terminal output is backfilled in `output_index` order through the shared inspector for both legacy wrappers and the eager relay, non-empty terminal output remains authoritative, and a two-continuation replay contains exactly one proxy guidance item in outbound input and persisted state.
 - **Memory artifact:** this file, `devlog/_plan/260724_bugfix_train/010_passthrough_state.md`, updated only by the owning main agent if implementation evidence forces a correction.
 - **Expected terminal outcomes:** `PASS` (implementation and all verifiers satisfy this spec); `FAIL` (a verifier or acceptance assertion fails and the cycle returns to implementation); `BLOCKED` (the required behavior cannot be achieved inside the file/scope map and is escalated).
 - **Escalation:** upward — main reclaims after two agent failures; downward — none planned.
@@ -18,7 +20,7 @@
 
 ### #334 — terminal response is not the whole streamed response
 
-`src/server/relay.ts` currently extracts only the `response` object carried by `response.completed`. Native Responses streams can instead finalize authoritative output items in earlier `response.output_item.done` events while the terminal event has `output: []` or no `output`. `rememberResponseState` accepts any array, including an empty one, so the current terminal-only callback either stores no assistant/reasoning/function-call items or does not store at all when `output` is absent. The next locally expanded continuation is therefore incomplete and can repeat a tool call forever.
+`src/server/relay.ts:431-482` now centralizes chunk decoding, SSE block framing, terminal/log inspection, and `onCompletedResponse` dispatch in `createSseInspector`, but its completion branch at `src/server/relay.ts:457-460` still extracts only the `response` object carried by `response.completed`. Native Responses streams can instead finalize authoritative output items in earlier `response.output_item.done` events while the terminal event has `output: []` or no `output`. `rememberResponseState` accepts any array, including an empty one, so the current terminal-only callback either stores no assistant/reasoning/function-call items or does not store at all when `output` is absent. The next locally expanded continuation is therefore incomplete and can repeat a tool call forever.
 
 The repair law is:
 
@@ -29,15 +31,17 @@ The repair law is:
 5. Invoke `onCompletedResponse` only after rule 3 or 4 has been applied.
 6. Never rewrite, buffer, re-encode, or emit the client-facing SSE branch.
 
-The two persistence-capable consumers deliberately keep different control loops:
+One inspector implementation now serves all persistence-capable stream shapes:
 
-- `consumeForInspection` stops inspecting post-terminal payloads only when there is no completion callback (`if (reported && !onCompletedResponse) continue`). Preserve that condition and route each payload that remains eligible through the accumulator.
-- `consumeForResponseLogMetadata` never applies that skip. Preserve its loop and route every parsed payload through the same accumulator.
-- `trackSseForRequestLog` is terminal-status/request-log tracking only. It has no `onCompletedResponse`, never calls `rememberResponseState`, and must not allocate or use the item accumulator. It needs no backfill.
+- `consumeForInspection` constructs `createSseInspector({ onTerminal, logCtx, onCompletedResponse, onFirstOutput })` at `src/server/relay.ts:484-495` and only calls `feed`/`finish` at `src/server/relay.ts:516-529`.
+- `consumeForResponseLogMetadata` constructs the same inspector without `onTerminal` at `src/server/relay.ts:548-559` and only calls `feed`/`finish` at `src/server/relay.ts:570-579`. With no terminal handler, `reported` stays false, preserving unconditional metadata inspection.
+- The eager path constructs `createSseInspector` with `onCompletedResponse: rememberPassthroughResponse` at `src/server/responses/core.ts:1047-1052`; `relaySseEagerBounded` receives `inspector.feed`, `inspector.finish`, and `inspector.reported` at `src/server/responses/core.ts:1053-1056`, then invokes the feed hook for every upstream chunk and the finish hook at clean EOF (`src/server/relay-eager.ts:119-135`). It has no separate completed-response path. Therefore an accumulator inside `createSseInspector` covers eager delivery, normal delivery, and post-cancel discard-drain inspection without any `relay-eager.ts` or `core.ts` change.
+- Preserve `createSseInspector.feed`'s current `if (reported && !handlers.onCompletedResponse) continue` gate at `src/server/relay.ts:467-471`, its `finish()` trailing-buffer asymmetry at `src/server/relay.ts:473-479`, and terminal/log callback ordering. The accumulator observes only payloads the state machine already scans.
+- `trackSseForRequestLog` at `src/server/relay.ts:171-230` is a separate terminal-status/request-log relay. It has no `onCompletedResponse`, never calls `rememberResponseState`, and must not allocate or use the item accumulator.
 
 ### #326 — replay provenance must reach injection
 
-`expandPreviousResponseInput` already records the replay prefix length in a proxy-private `WeakMap` keyed by the exact expanded request object. `parseRequest` reads that length for compaction-boundary logic, but discards it from `OcxParsedRequest`. `injectDeveloperMessage` therefore cannot distinguish replayed proxy guidance from a new request suffix and always appends another copy to both parsed messages and `_rawBody.input`. Passthrough persistence records the mutated `_rawBody`, producing one extra guidance item per continuation.
+`expandPreviousResponseInput` still records the replay prefix length in the proxy-private `WeakMap` at `src/responses/state.ts:78,209-229`, keyed by the exact expanded request object. `parseRequest` still reads that length at `src/responses/parser.ts:227-229` and uses it only for the current-suffix compaction boundary at `src/responses/parser.ts:270-295`, but discards it from `OcxParsedRequest`. `injectDeveloperMessage` remains unchanged at `src/server/responses/collaboration.ts:284-298`, so it cannot distinguish replayed proxy guidance from a new request suffix and always appends another copy to both parsed messages and `_rawBody.input`. Passthrough persistence records the mutated `_rawBody`, producing one extra guidance item per continuation.
 
 The repair law is:
 
@@ -54,25 +58,34 @@ The repair law is:
 ### Planning artifact changes for this cycle
 
 - **NEW** `devlog/_plan/260724_bugfix_train/010_passthrough_state.md` — this diff-level implementation contract.
-- **DELETE** `devlog/_plan/260724_bugfix_train/010_phase1.md` — superseded empty scaffold.
+  (The `010_phase1.md` scaffold was replaced pre-commit and never tracked; no DELETE entry applies.)
 
 ### Production and regression changes to implement
 
-- **MODIFY** `src/server/relay.ts` — add one shared stateful completion accumulator and use it from `consumeForInspection` and `consumeForResponseLogMetadata`; retain `completedResponseFromSsePayload` and leave `trackSseForRequestLog` unchanged.
+- **MODIFY** `src/server/relay.ts` — add the per-stream `output_item.done` accumulator inside the existing exported `createSseInspector`; retain `completedResponseFromSsePayload`, both consumer wrappers, and `trackSseForRequestLog` unchanged.
 - **MODIFY** `src/types.ts` — add `_replayPrefixLen?: number` to `OcxParsedRequest`.
 - **MODIFY** `src/responses/parser.ts` — preserve the already-computed replay prefix length on the parsed request.
 - **MODIFY** `src/server/responses/collaboration.ts` — detect the exact generated guidance item anywhere in the replay prefix and make dual-write injection idempotent.
-- **MODIFY** `tests/responses-state.test.ts` — add focused stream/persistence tests for both relay consumers, terminal-output authority, and the two-continuation guidance regression.
+- **MODIFY** `tests/responses-state.test.ts` — add focused inspector-to-persistence tests, terminal-output authority, and the two-continuation guidance regression.
+- **MODIFY** `tests/relay-eager.test.ts` — extend the existing `createSseInspector`/eager-relay fixtures with direct accumulator and eager-path coverage where this is cleaner than reconstructing legacy consumer plumbing.
 
-No other file is part of Cycle 1. In particular, do not modify `src/server/responses/core.ts`, `src/responses/state.ts`, `src/server/request-log.ts`, adapters, snapshots, docs, GUI, workflows, dependencies, or release automation.
+No other file is part of Cycle 1. In particular, do not modify `src/server/relay-eager.ts`, `src/server/responses/core.ts`, `src/responses/state.ts`, `src/server/request-log.ts`, adapters, snapshots, docs, GUI, workflows, dependencies, or release automation. The eager path is covered by changing the inspector it already calls and by regression tests only.
 
 ## Diff-level implementation
 
 ### 1. `src/server/relay.ts`
 
-#### Keep the terminal extractor signature unchanged
+#### Keep the terminal extractor and public inspector contract unchanged
 
-Current code:
+Current anchors on `097cadc1`:
+
+- `completedResponseFromSsePayload`: `src/server/relay.ts:157-169`.
+- `SseInspector`: `src/server/relay.ts:407-414`.
+- `createSseInspector`: `src/server/relay.ts:431-482`.
+- `consumeForInspection`: `src/server/relay.ts:484-546`.
+- `consumeForResponseLogMetadata`: `src/server/relay.ts:548-587`.
+
+Retain the terminal extractor byte-for-byte:
 
 ```ts
 /** Extract the response object from a `response.completed` SSE payload, or null. */
@@ -90,184 +103,114 @@ export function completedResponseFromSsePayload(payload: string): { id?: unknown
 }
 ```
 
-After: retain this function byte-for-byte. Add the following immediately after it. The new helper is file-private because only the two background consumers own this reconstruction responsibility.
+Do not add `CompletedResponse`, `createCompletedResponseAccumulator`, or any other second shared helper after this function. That earlier design is superseded by the upstream `createSseInspector` seam.
+
+Retain the exported `SseInspector` type and `createSseInspector` handler signature unchanged. The accumulator is private closure state inside each inspector instance.
+
+#### Modify `createSseInspector` at the single shared implementation point
+
+Current state initialization (`src/server/relay.ts:437-440`):
 
 ```ts
-type CompletedResponse = { id?: unknown; output?: unknown; status?: unknown };
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let reported = false;
+  const reportFirstOutput = createFirstOutputReporter(handlers.onFirstOutput);
+```
 
-function createCompletedResponseAccumulator(
-  onCompletedResponse?: (response: CompletedResponse) => void,
-): (payload: string | null) => void {
-  const itemsByOutputIndex = new Map<number, unknown>();
-  return payload => {
-    if (!payload || payload === "[DONE]") return;
-    try {
-      const event = JSON.parse(payload) as {
-        type?: unknown;
-        output_index?: unknown;
-        item?: unknown;
-      };
-      if (event.type === "response.output_item.done") {
-        if (Number.isInteger(event.output_index)
+After:
+
+```ts
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let reported = false;
+  const reportFirstOutput = createFirstOutputReporter(handlers.onFirstOutput);
+  // Allocate reconstruction state only for persistence-capable inspectors.
+  const completedItemsByOutputIndex = handlers.onCompletedResponse
+    ? new Map<number, unknown>()
+    : null;
+```
+
+Current completion branch inside `scanPayload` (`src/server/relay.ts:457-460`):
+
+```ts
+    if (handlers.onCompletedResponse) {
+      const response = completedResponseFromSsePayload(payload);
+      if (response) handlers.onCompletedResponse(response);
+    }
+```
+
+After:
+
+```ts
+    if (handlers.onCompletedResponse) {
+      try {
+        const event = JSON.parse(payload) as {
+          type?: unknown;
+          output_index?: unknown;
+          item?: unknown;
+        };
+        if (event.type === "response.output_item.done"
+          && Number.isInteger(event.output_index)
           && (event.output_index as number) >= 0
-          && event.item !== undefined) {
-          itemsByOutputIndex.set(event.output_index as number, event.item);
+          && typeof event.item === "object"
+          && event.item !== null
+          && !Array.isArray(event.item)
+          && typeof (event.item as { type?: unknown }).type === "string") {
+          completedItemsByOutputIndex!.set(event.output_index as number, event.item);
         }
-        return;
+      } catch {
+        /* malformed SSE payloads remain best-effort/no-throw */
       }
-    } catch {
-      return;
+
+      let response = completedResponseFromSsePayload(payload);
+      if (response
+        && (!Array.isArray(response.output) || response.output.length === 0)
+        && completedItemsByOutputIndex!.size > 0) {
+        response = {
+          ...response,
+          output: [...completedItemsByOutputIndex!.entries()]
+            .sort(([left], [right]) => left - right)
+            .map(([, item]) => item),
+        };
+      }
+      if (response) handlers.onCompletedResponse(response);
     }
-
-    let response = completedResponseFromSsePayload(payload);
-    if (!response) return;
-    if ((!Array.isArray(response.output) || response.output.length === 0)
-      && itemsByOutputIndex.size > 0) {
-      response = {
-        ...response,
-        output: [...itemsByOutputIndex.entries()]
-          .sort(([left], [right]) => left - right)
-          .map(([, item]) => item),
-      };
-    }
-    onCompletedResponse?.(response);
-  };
-}
 ```
 
-Implementation note: the first parse handles item-done observation; non-item events then flow to the existing terminal extractor. A malformed payload remains best-effort/no-throw. Do not export this helper and do not broaden `CompletedResponse` beyond the existing callback contract.
+Implementation constraints:
 
-#### Modify `consumeForInspection`
+- The map is per `createSseInspector` call/per upstream stream, not global and not shared across requests.
+- Allocate it only when `handlers.onCompletedResponse` exists. `trackSseForRequestLog` and inspectors used only for terminal/log metadata must not acquire unused output-item state.
+- Observe only `response.output_item.done`; malformed JSON, invalid indices, missing items, deltas, and `[DONE]` remain ignored.
+- Keep the existing terminal/log/first-output operations before this completion branch. In particular, `onTerminal("completed")` may fire before `onCompletedResponse`; only the latter is persistence-bearing and must receive the reconstructed response.
+- Keep `completedResponseFromSsePayload` as the sole terminal-response extractor. The inline parse owns done-item observation only.
+- Do not clear the map at terminal. Existing `feed` semantics intentionally permit per-block completion callbacks after `reported` when `onCompletedResponse` exists; preserving the map preserves that extraction lock.
+- Do not alter decoding, SSE framing, `feed`'s post-terminal gate, `finish`'s trailing-buffer gate, `reported()`, logging, or first-output reporting.
 
-Real signature (unchanged):
+#### Explicit no-change: legacy consumers
+
+`consumeForInspection` (`src/server/relay.ts:484-546`) and `consumeForResponseLogMetadata` (`src/server/relay.ts:548-587`) already construct and delegate every chunk/EOF to `createSseInspector`. Before and after are identical. Do not reintroduce accumulator logic into either wrapper.
+
+The critical existing wiring remains:
 
 ```ts
-export function consumeForInspection(
-  body: ReadableStream<Uint8Array>,
-  onTerminal: (status: ResponsesTerminalStatus, httpStatusOverride?: number) => void,
-  signal?: AbortSignal,
-  onDone?: () => void,
-  logCtx?: RequestLogContext,
-  onCancel?: () => void,
-  onCompletedResponse?: (response: { id?: unknown; output?: unknown; status?: unknown }) => void,
-  onFirstOutput?: () => void,
-): void {
+const inspector = createSseInspector({ onTerminal, logCtx, onCompletedResponse, onFirstOutput });
+// ... inspector.finish(); ... inspector.feed(value)
+
+const inspector = createSseInspector({ logCtx, onCompletedResponse, onFirstOutput });
+// ... inspector.finish(); ... inspector.feed(value)
 ```
 
-Current initialization:
+#### Explicit no-change: eager bounded relay and core wiring
 
-```ts
-  let reported = false;
-  let cancelled = false;
-  const reportFirstOutput = createFirstOutputReporter(onFirstOutput);
-```
+`src/server/relay-eager.ts` does not parse completed responses itself. It accepts generic inspection hooks (`src/server/relay-eager.ts:27-39`), calls `finishInspection()` at clean EOF (`:123-127`), and calls `inspectChunk(value)` before queueing or discard-draining each chunk (`:130-139`). `src/server/responses/core.ts:1047-1056` binds those hooks directly to the same `createSseInspector` instance and passes `rememberPassthroughResponse` as `onCompletedResponse`.
 
-After:
-
-```ts
-  let reported = false;
-  let cancelled = false;
-  const reportFirstOutput = createFirstOutputReporter(onFirstOutput);
-  const observeCompletedResponse = createCompletedResponseAccumulator(onCompletedResponse);
-```
-
-Current EOF completion block:
-
-```ts
-              if (onCompletedResponse) {
-                const response = completedResponseFromSsePayload(payload);
-                if (response) onCompletedResponse(response);
-              }
-```
-
-After:
-
-```ts
-              observeCompletedResponse(payload);
-```
-
-Current normal-loop completion block:
-
-```ts
-          if (onCompletedResponse) {
-            const response = completedResponseFromSsePayload(payload);
-            if (response) onCompletedResponse(response);
-          }
-```
-
-After:
-
-```ts
-          observeCompletedResponse(payload);
-```
-
-Do not alter `if (reported && !onCompletedResponse) continue`, terminal reporting, logging, first-output reporting, cancellation, synthetic status behavior, or `onDone` ordering. The accumulator runs only on payloads the existing loop already permits. The normal event ordering (`output_item.done` before `response.completed`) guarantees backfill is complete before the callback.
-
-#### Modify `consumeForResponseLogMetadata`
-
-Real signature (unchanged):
-
-```ts
-export function consumeForResponseLogMetadata(
-  body: ReadableStream<Uint8Array>,
-  logCtx: RequestLogContext,
-  signal?: AbortSignal,
-  onDone?: () => void,
-  onCompletedResponse?: (response: { id?: unknown; output?: unknown; status?: unknown }) => void,
-  onFirstOutput?: () => void,
-): void {
-```
-
-Current initialization:
-
-```ts
-  let buffer = "";
-  const reportFirstOutput = createFirstOutputReporter(onFirstOutput);
-```
-
-After:
-
-```ts
-  let buffer = "";
-  const reportFirstOutput = createFirstOutputReporter(onFirstOutput);
-  const observeCompletedResponse = createCompletedResponseAccumulator(onCompletedResponse);
-```
-
-Replace both identical callback blocks (one in EOF residual handling, one in the normal block loop):
-
-```ts
-            if (payload && onCompletedResponse) {
-              const response = completedResponseFromSsePayload(payload);
-              if (response) onCompletedResponse(response);
-            }
-```
-
-and
-
-```ts
-          if (payload && onCompletedResponse) {
-            const response = completedResponseFromSsePayload(payload);
-            if (response) onCompletedResponse(response);
-          }
-```
-
-with, respectively:
-
-```ts
-            observeCompletedResponse(payload);
-```
-
-and
-
-```ts
-          observeCompletedResponse(payload);
-```
-
-Do not add a reported/terminal skip to this consumer. It must continue inspecting every payload for request-log metadata exactly as before.
+Before and after are identical. This evidence means the single inspector change covers eager relay completion persistence, including chunks inspected during bounded post-cancel discard-drain.
 
 #### Explicit no-change: `trackSseForRequestLog`
 
-Real signature:
+Real signature at `src/server/relay.ts:171-178`:
 
 ```ts
 export function trackSseForRequestLog(
@@ -279,11 +222,11 @@ export function trackSseForRequestLog(
 ): ReadableStream<Uint8Array> {
 ```
 
-Before and after are identical. This function only calls `terminalStatusFromSsePayload`, reports log terminal state, and relays bytes. It has no response-state callback. Adding the accumulator here would create unused state and blur the persistence boundary.
+Before and after are identical. This function only calls `terminalStatusFromSsePayload`, reports log terminal state, and relays bytes. It has no response-state callback. Adding reconstruction here would create unused state and blur the persistence boundary.
 
 ### 2. `src/types.ts`
 
-Current excerpt:
+Current excerpt at `src/types.ts:1-10`:
 
 ```ts
 export interface OcxParsedRequest {
@@ -315,15 +258,17 @@ export interface OcxParsedRequest {
 
 Keep the field optional so existing hand-built `OcxParsedRequest` fixtures remain valid. It is proxy-private metadata and must never be serialized into `_rawBody` or sent upstream.
 
+The #314 WP1 delta is elsewhere: `streamMode?: "auto" | "legacy-tee" | "eager-relay"` was added to `OcxConfig` at `src/types.ts:448-456`. It neither overlaps nor semantically conflicts with this proxy-private parsed-request field.
+
 ### 3. `src/responses/parser.ts`
 
-Real signature:
+Real signature at `src/responses/parser.ts:227`:
 
 ```ts
 export function parseRequest(body: unknown): OcxParsedRequest {
 ```
 
-Current opening already captures provenance and remains unchanged:
+Current opening at `src/responses/parser.ts:227-230` already captures provenance and remains unchanged:
 
 ```ts
 export function parseRequest(body: unknown): OcxParsedRequest {
@@ -331,7 +276,7 @@ export function parseRequest(body: unknown): OcxParsedRequest {
   const parsed = responsesRequestSchema.safeParse(body);
 ```
 
-Current return excerpt:
+Current return excerpt at `src/responses/parser.ts:590-601`:
 
 ```ts
   return {
@@ -358,11 +303,11 @@ After:
     ...(webSearch ? { _webSearch: webSearch } : {}),
 ```
 
-Do not replace the existing `WeakMap`, add a wire field, or change the existing `inputIndex >= replayedInputPrefixLength` compaction-boundary test. This is a second consumer of the provenance already read at function entry.
+Do not replace the existing `WeakMap` (`src/responses/state.ts:78`), alter `expandPreviousResponseInput`/`previousResponseReplayPrefixLength` (`src/responses/state.ts:209-229`), add a wire field, or change the existing `inputIndex >= replayedInputPrefixLength` compaction-boundary test (`src/responses/parser.ts:270-295`). This is a second consumer of provenance already read at function entry.
 
 ### 4. `src/server/responses/collaboration.ts`
 
-#### Add exact-item predicates immediately above `injectDeveloperMessage`
+#### Add exact-item predicates immediately above `injectDeveloperMessage` (`src/server/responses/collaboration.ts:284`)
 
 After:
 
@@ -383,7 +328,7 @@ If this file already has an equivalent record guard at implementation time, reus
 
 #### Modify `injectDeveloperMessage`
 
-Real signature:
+Real signature at `src/server/responses/collaboration.ts:284`:
 
 ```ts
 export function injectDeveloperMessage(parsed: OcxParsedRequest, text: string): void {
@@ -438,34 +383,53 @@ export function injectDeveloperMessage(parsed: OcxParsedRequest, text: string): 
 
 The early return is intentionally before the parsed-message push. `parseRequest` has already converted the replayed wire guidance into one developer message in `parsed.context.messages`; adding another parsed-only copy would still duplicate model context. If raw input is a string/non-array, preserve current behavior: parsed context receives the message and raw input is untouched. A matching item in the new suffix does not suppress injection because only replayed proxy state is trusted for idempotence.
 
+### 5. Read-only #326 integration anchor audit (`src/server/responses/core.ts`)
+
+#314 WP2's `core.ts` delta touched 53 lines (52 additions, 1 deletion): it added three imports near the top and the eager-relay branch before the legacy tee path. It did not change #326 ordering or persistence policy, but it shifted current line anchors:
+
+- `expandPreviousResponseInput(body)` remains before parsing at `src/server/responses/core.ts:558-560` (was `:555-557` on `d9e06c8d`).
+- `parseRequest(body)` remains after raw-body compatibility rewriting at `src/server/responses/core.ts:580-585` (was `:577-582`).
+- `injectDeveloperMessage(parsed, guidance)` remains after parse/route selection and before request construction at `src/server/responses/core.ts:669-679` (was `:666-676`).
+- The five `rememberResponseState` call sites remain exactly five and keep their prior roles:
+  1. native passthrough closure — `src/server/responses/core.ts:913-916` (was `:910-913`);
+  2. routed `runTurn` streaming bridge — `src/server/responses/core.ts:1202-1208` (was `:1151-1157`);
+  3. routed `runTurn` JSON response — `src/server/responses/core.ts:1239-1245` (was `:1188-1194`);
+  4. standard adapter streaming bridge — `src/server/responses/core.ts:1488-1496` (was `:1437-1445`);
+  5. standard adapter JSON response — `src/server/responses/core.ts:1524-1530` (was `:1473-1479`).
+
+No `core.ts` change is required for #326. The accepted injection-side idempotence still avoids spreading policy across these five persistence sites. No `core.ts` change is required for #334 either: the eager branch already passes `rememberPassthroughResponse` into `createSseInspector` at `:1047-1052`, while both legacy branches pass the same callback into wrappers that instantiate the inspector at `:1090-1108`.
+
 ## Regression test plan
 
-All new tests go in **MODIFY** `tests/responses-state.test.ts`, whose existing `beforeEach`/`afterEach` isolate `OPENCODEX_HOME`, clear memory, and remove snapshots. Extend imports with `injectDeveloperMessage` from `../src/server/responses` and `consumeForInspection`, `consumeForResponseLogMetadata`, plus the request-log context type or a minimal cast from `../src/server`/the existing export surface. Add a local SSE stream builder and use an `onDone` promise rather than timing sleeps.
+Split tests at the current owning seams:
+
+- **MODIFY** `tests/responses-state.test.ts`: its existing `beforeEach`/`afterEach` isolate `OPENCODEX_HOME`, clear memory, and remove snapshots. Extend imports with `injectDeveloperMessage` from `../src/server/responses` and `createSseInspector` from `../src/server/relay`. Use the inspector callback to call `rememberResponseState` directly; no fake `RequestLogContext`, background-consumer timing, or sleep is needed.
+- **MODIFY** `tests/relay-eager.test.ts`: this file already imports `createSseInspector` and `relaySseEagerBounded`, defines `sse(...)`, `makeHooks()`, and deterministic controlled-upstream fixtures (`tests/relay-eager.test.ts:7-77`), and owns the inspector extraction locks at `tests/relay-eager.test.ts:275-325`. Extend those fixtures for the eager-path regression instead of adding another relay harness.
 
 Suggested shared fixture:
 
 ```ts
-function sseStream(events: Record<string, unknown>[]): ReadableStream<Uint8Array> {
+function feedInspector(
+  inspector: ReturnType<typeof createSseInspector>,
+  events: Array<Record<string, unknown> | "[DONE]">,
+): void {
   const encoder = new TextEncoder();
-  return new ReadableStream({
-    start(controller) {
-      for (const event of events) {
-        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
-      }
-      controller.close();
-    },
-  });
+  for (const event of events) {
+    const payload = typeof event === "string" ? event : JSON.stringify(event);
+    inspector.feed(encoder.encode(`data: ${payload}\n\n`));
+  }
+  inspector.finish();
 }
 ```
 
-Use a structurally valid minimal `RequestLogContext` fixture already accepted by relay tests, or import its type and cast a local `{}` only if the inspector functions tolerate it for the selected events. Prefer the real existing helper if one is present at implementation time.
+The direct inspector fixture is the preferred unit seam because all three production stream paths already delegate to it. Keep one eager integration regression to prove the new #314 path uses the same completion callback; existing #314 extraction-lock tests retain legacy state-machine semantics.
 
-### Test 1 — inspection consumer backfills and persists done items
+### Test 1 — shared inspector backfills and persists done items
 
 Name:
 
 ```ts
-test("inspection consumer backfills empty completed output before passthrough persistence (#334)", async () => { ... });
+test("SSE inspector backfills empty completed output before passthrough persistence (#334)", () => { ... });
 ```
 
 Fixture/event order:
@@ -475,21 +439,27 @@ Fixture/event order:
 3. `response.output_item.done`, `output_index: 1`, completed assistant `message` item.
 4. `response.completed`, response `{id:"resp_334_inspection", status:"completed", output:[]}`.
 
-Wire `consumeForInspection(..., onCompletedResponse)` so the callback calls `rememberResponseState(requestBody, response, undefined, {force:true})`. Await `onDone`, expand a next request with `previous_response_id: "resp_334_inspection"`, and assert the replayed output types are exactly `reasoning`, `message`, `function_call` after the original input and before the new suffix.
+Create `createSseInspector({ onCompletedResponse })`; make the callback call `rememberResponseState(requestBody, response, undefined, {force:true})`. Feed all events through the inspector, expand a next request with `previous_response_id: "resp_334_inspection"`, and assert the replayed output types are exactly `reasoning`, `message`, `function_call` after the original input and before the new suffix. Append `[DONE]` after completion and assert the callback still fires once.
 
-**C-ACTIVATION-GROUNDING-01:** out-of-order indices activate the sort path; all three valid done events activate `Map.set`; the terminal empty array activates backfill; `rememberResponseState` plus the next expansion proves the callback received the reconstructed array and that saved state contains assistant/reasoning/tool-call items. Reading the untouched tee is not part of this unit, so byte preservation is established structurally by the production diff (inspection-only branch) and by the full passthrough suite.
+**C-ACTIVATION-GROUNDING-01:** out-of-order indices activate the sort path; all three valid done events activate `Map.set`; the terminal empty array activates backfill; `rememberResponseState` plus the next expansion proves the callback received the reconstructed array and that saved state contains assistant/reasoning/tool-call items. Client bytes are outside the inspector and remain structurally untouched; passthrough suites retain wire proof.
 
-### Test 2 — metadata consumer uses the same backfill path
+### Test 2 — eager relay uses the same backfill path
 
 Name:
 
 ```ts
-test("metadata consumer backfills missing completed output before passthrough persistence (#334)", async () => { ... });
+test("eager relay backfills missing completed output before passthrough persistence (#334)", async () => { ... });
 ```
 
-Use at least a `message` done item at index 0 and a `function_call` done item at index 1, followed by `response.completed` whose response has an id/status but **omits** `output`. Wire `consumeForResponseLogMetadata` to the same persistence callback, await `onDone`, expand by that response id, and assert both items are present in index order.
+In `tests/relay-eager.test.ts`, extend `makeHooks` or construct an inspector that captures `onCompletedResponse`. Feed at least a `message` done item at index 0 and a `function_call` done item at index 1 through `relaySseEagerBounded`, followed by `response.completed` whose response has an id/status but **omits** `output`. Drain the returned client stream, await `hooks.onDone`, and assert the callback receives both items in index order. Test 1 owns the state-store/replay assertion, so this eager integration test must not introduce `OPENCODEX_HOME` or snapshot side effects.
 
-**C-ACTIVATION-GROUNDING-01:** omitted `output` activates the `!Array.isArray(response.output)` side of backfill, while invoking the metadata consumer proves its independent payload loop is wired to the shared accumulator. Successful local replay is the observable persistence proof.
+Additionally (mandatory wire-fidelity assertion): capture the drained client bytes and assert
+exact byte equality with the original upstream frames for both the `output_item.done` events and
+the terminal `response.completed` frame — in particular, the terminal frame on the wire must
+still OMIT `output` (backfill exists only in the inspector callback, never in client-facing
+bytes). This converts the byte-identical delivery guarantee from prose into a regression.
+
+**C-ACTIVATION-GROUNDING-01:** omitted `output` activates the `!Array.isArray(response.output)` side of backfill. Driving `relaySseEagerBounded` through hooks bound to `createSseInspector` proves #314's single-reader path reaches the same reconstructed completion callback; Test 1 separately grounds persistence/replay. The current wrapper construction at `src/server/relay.ts:495,559` is unchanged and requires no duplicate consumer-specific fixture.
 
 ### Test 3 — non-empty terminal output remains authoritative
 
@@ -531,7 +501,7 @@ test("duplicate output_index keeps only the final done item (#334)", async () =>
 
 Send two valid `response.output_item.done` events at `output_index: 2`: first a sentinel
 assistant message, then the final completed `function_call`. Follow them with an empty
-`response.completed.response.output`, persist through the inspection consumer, and replay the
+`response.completed.response.output`, persist through `createSseInspector`, and replay the
 saved response. Assert index 2 appears exactly once, contains the final function call, and does not
 contain the earlier sentinel. This fixture mandatorily activates the existing `Map.set` replacement
 branch rather than merely exercising insertion.
@@ -545,9 +515,12 @@ test("malformed output_item.done events do not enter reconstructed output (#334)
 ```
 
 Interleave one valid index-0 message with done events whose `output_index` is missing, negative,
-fractional, and a string, plus one valid-index event whose `item` is missing. Complete with
+fractional, and a string, plus valid-index events whose `item` is missing, `null`, a scalar
+(`"text"`, `42`), an array, and an object without a string `type`. Complete with
 `output: []`. Assert the callback fires once and reconstructed/persisted output contains only the
-valid index-0 item. This is the mandatory activation for every index/item rejection guard.
+valid index-0 item. This is the mandatory activation for every index/item rejection guard,
+including the item-shape guard (non-array record with string `type`) that keeps malformed
+members out of persisted replay state (schema.ts:87/133 would reject them on the next parse).
 
 ### Test 7 — exact guidance in the current suffix does not suppress injection
 
@@ -572,28 +545,30 @@ Name:
 test("malformed SSE payload is skipped before a valid completed response (#334)", async () => { ... });
 ```
 
-Use a raw SSE fixture (not the JSON-only helper) containing `data: {not-json}\n\n`, then a valid
-index-0 done event and a valid empty-output completion. Run it through each persistence-capable
-consumer (table-driven subcases are allowed). Assert no throw, one completion callback per
-consumer, and replay contains the valid item. This mandatorily activates the accumulator's JSON
-parse catch while proving later frames are still processed.
+Use a raw inspector feed containing `data: {not-json}\n\n`, then a valid index-0 done event and a
+valid empty-output completion. Assert no throw, one completion callback, and replay contains the
+valid item. Repeat the malformed-before-valid sequence through the eager relay fixture (table-driven
+subcases are allowed) and assert one reconstructed callback there too. This mandatorily activates
+the accumulator's JSON parse catch while proving later frames are still processed through both the
+unit seam and #314's production relay shape.
 
 ### Conditional-path activation matrix
 
 | New/changed conditional | Activation scenario | Observable proof |
 |---|---|---|
 | Null or `[DONE]` payload is ignored | Append `[DONE]` to Test 1 and retain existing null/no-payload coverage | Callback fires once and no throw/regression occurs |
-| Malformed SSE payload is ignored | Mandatory Test 8 places raw invalid JSON before valid done/completed frames in both consumers | No throw; one callback; later valid item persists |
+| Malformed SSE payload is ignored | Mandatory Test 8 places raw invalid JSON before valid done/completed frames in direct-inspector and eager-relay subcases | No throw; one callback; later valid item persists |
 | Valid `response.output_item.done` index/item | Tests 1–3 send valid done events | Saved/captured output contains the item |
 | Duplicate `output_index` uses Map last-write-wins | Mandatory Test 5 sends two valid items at index 2 | Replay contains exactly one final index-2 item and no sentinel |
 | Invalid/missing index or missing item is ignored | Mandatory Test 6 covers missing, negative, fractional, string index and missing item | Callback/replay contains only the one valid item |
-| Missing terminal output backfills | Test 2 omits `output` | Saved replay has message + function call |
+| Missing terminal output backfills | Test 2 omits `output` | Eager-path callback has message + function call |
 | Empty terminal output backfills | Test 1 uses `output: []` | Saved replay has reasoning + message + function call |
+| Eager relay reaches reconstructed completion | Test 2 drives `relaySseEagerBounded` with hooks bound to the inspector | Captured callback output is index-ordered despite missing terminal `output` |
 | Non-empty terminal output is untouched | Test 3 supplies a non-empty terminal array while map is populated | Reference equality and no sentinel call in replay |
-| Completion callback absent | Existing cancel/incomplete tests call `consumeForInspection` without it | Existing terminal/cancel assertions remain green; no behavior change |
+| Completion callback absent / map not allocated | Existing inspector extraction locks and cancel/incomplete tests omit `onCompletedResponse` | Existing terminal/log/cancel assertions remain green; no completion state is needed |
 | Replay prefix length is zero | Existing fresh injection tests plus request 1 in Test 4 | One parsed and one raw guidance insertion |
 | Exact guidance exists anywhere in replay prefix | Test 4 places it before a backfilled function call | Injection returns early; counts remain one |
-| Similar/non-exact developer item does not suppress | Add a required table-driven subcase to Test 7 with different text and an extra content part in the prefix | Requested exact guidance is still inserted once |
+| Similar/non-exact developer item does not suppress | MANDATORY table-driven Test 7 subcases exercising EVERY rejection guard of the exact-guidance predicate: non-record item, wrong `type`, wrong `role`, non-array `content`, wrong content length, non-record part, wrong part `type`, different text, extra content part | Each near-match subcase still causes exactly one fresh injection (parsed + raw counts assert one new copy) |
 | Matching item exists only in current suffix | Mandatory Test 7 places exact shape/text after `_replayPrefixLen` | Prefix-only scan inserts one new item; raw exact-shape count becomes two |
 | Raw input is non-array | Existing `string raw input is left alone` test | Parsed message added; raw string unchanged |
 | Fresh raw input ends in `compaction_trigger` | Existing `inserts BEFORE compaction_trigger so it stays the final input item` test | Trigger remains final |
@@ -618,7 +593,7 @@ or have its observable weakened.
 - Delta-to-item reconstruction (`response.output_text.delta`, reasoning deltas, function argument deltas).
 - Changes to `rememberResponseState`, `expandPreviousResponseInput`, WeakMap ownership, snapshot schema/version, TTL, byte caps, or eviction.
 - Persist-time removal of guidance.
-- Changes to `trackSseForRequestLog` beyond a clarifying comment if absolutely necessary; no code-path change is authorized.
+- Any change to `trackSseForRequestLog`; its separate request-log-only path is already correct.
 - Compaction trigger placement or compaction persistence policy changes.
 - Routed-provider bridge output, JSON passthrough, provider adapters, request routing, auth, credentials, workflows, dependencies, release scripts, GUI, or docs-site.
 
@@ -633,20 +608,21 @@ No docs-site update. Both issues repair internal continuation correctness and pr
 - No authentication, credential, OAuth, workflow, dependency, release, or permission boundary changes are in scope.
 - Never log request bodies, replayed input, guidance text, completed output items, tool arguments, account identifiers, or response-state contents.
 - The new replay prefix field remains in the in-process parsed object only; it must not be copied into `_rawBody`, serialized upstream, or persisted as a new snapshot field.
-- The accumulator is per-consumer/per-stream local state and is released when the consumer finishes. It does not create cross-request global state.
+- The accumulator is per-inspector/per-stream local state and is released when inspection finishes. It does not create cross-request global state.
 - `bun run privacy:scan` is mandatory even though no new logging is planned.
 
 ## Implementation and verification sequence
 
 1. Confirm the worktree is at the intended `origin/dev` baseline and preserve unrelated dirty work.
-2. Implement `src/server/relay.ts` helper and consumer wiring without touching the client relay branch.
+2. Implement the accumulator only inside `createSseInspector` in `src/server/relay.ts`; do not change either legacy consumer, the eager relay, core wiring, or the client relay branch.
 3. Add `_replayPrefixLen` in `src/types.ts` and populate it in `src/responses/parser.ts`.
 4. Implement exact replay-prefix detection in `src/server/responses/collaboration.ts`, retaining fresh compaction-trigger ordering.
 5. Add ALL EIGHT named regressions (the four core regressions plus the four
    mandatory matrix tests: duplicate-index last-write-wins, malformed done-event
-   rejection, suffix-guidance non-dedupe, malformed-SSE skip) and their
-   activation assertions to `tests/responses-state.test.ts`.
-6. Run focused tests: `bun test tests/responses-state.test.ts tests/multi-agent-compat.test.ts tests/consume-for-inspection-cancel.test.ts tests/passthrough-abort.test.ts`.
+   rejection, suffix-guidance non-dedupe, malformed-SSE skip) and their activation
+   assertions across `tests/responses-state.test.ts` and `tests/relay-eager.test.ts`
+   exactly as assigned above.
+6. Run focused tests: `bun test tests/responses-state.test.ts tests/relay-eager.test.ts tests/multi-agent-compat.test.ts tests/consume-for-inspection-cancel.test.ts tests/passthrough-abort.test.ts`.
 7. Run `bun run typecheck` and require exit 0.
 8. Run `bun run test` and require exit 0.
 9. Run `bun run privacy:scan` and require exit 0.
@@ -654,7 +630,8 @@ No docs-site update. Both issues repair internal continuation correctness and pr
 
 ## Acceptance checklist
 
-- [ ] One shared `Map<output_index, item>` accumulator is used by both persistence-capable SSE consumers.
+- [ ] One per-stream `Map<output_index, item>` accumulator lives inside `createSseInspector`, with no second helper or wrapper-local implementation.
+- [ ] Both legacy wrappers and the eager bounded relay reach the same inspector completion path; `relay-eager.ts` and `core.ts` remain unchanged.
 - [ ] Empty and missing terminal output are backfilled in ascending index order before `onCompletedResponse`.
 - [ ] Non-empty terminal output is passed through unchanged and is never merged with accumulated items.
 - [ ] `trackSseForRequestLog` remains terminal-status-only and receives no backfill logic.
@@ -670,8 +647,8 @@ No docs-site update. Both issues repair internal continuation correctness and pr
 
 ## Issue-comment traceability self-check
 
-- [ ] **#334 reporter — `relay.ts` empty-output backfill:** implemented by the file-private accumulator, `output_index` Map ordering, and both consumer wiring sections above.
-- [ ] **#334 reporter — regression test:** covered by the inspection empty-output persistence test, metadata missing-output persistence test, and non-empty authoritative-output test.
+- [ ] **#334 reporter — `relay.ts` empty-output backfill:** implemented by the inspector-local accumulator and `output_index` Map ordering; existing legacy-wrapper and eager-relay wiring reaches that single implementation point.
+- [ ] **#334 reporter — regression test:** covered by the shared-inspector empty-output persistence test, eager-relay missing-output callback test, and non-empty authoritative-output test.
 - [ ] **#326 reporter kdnsna — idempotent injection or persist exclusion:** implemented using the accepted idempotent injection option; replay provenance is copied to `OcxParsedRequest`, the exact guidance item is searched across the prefix, and the rejected five-call-site persist exclusion is explicitly out of scope.
 - [ ] **#326 reporter kdnsna — two-continuation regression:** covered by the request-1 → response-1 → request-2 → response-2 → request-3 sequence, with raw outbound and audit-replayed saved-state counts fixed at one.
 - [ ] **Cross-issue ordering:** the #326 fixture deliberately replays a #334-style completed `function_call`, proving guidance detection does not assume a prefix-edge position.

--- a/devlog/_plan/260724_bugfix_train/020_pool_retry_400.md
+++ b/devlog/_plan/260724_bugfix_train/020_pool_retry_400.md
@@ -4,6 +4,17 @@
 > fixes one account/model capability mismatch without changing the general 4xx
 > health taxonomy introduced by `35d28a02`.
 
+> **Stale-check 2026-07-24:** re-verified against `origin/dev` design base
+> `097cadc1` plus PR #350 / cycle-1 head `4b60f5ee`. Since the original
+> `d9e06c8d` draft, `3781448a`/`e0c7caba` inserted the runtime stream-capability
+> gate and eager bounded SSE relay at `src/server/responses/core.ts:1023-1123`,
+> after this cycle's retry insertion point. Cycle 1 changed replay metadata and
+> SSE completion reconstruction but did not change `core.ts`: `_replayPrefixLen`
+> is parser/collaboration metadata, while the new inspector accumulator exists
+> only after a successful SSE response enters a relay. The dispatch, outcome,
+> error-classifier, and bounded-body anchors and both stream-mode commitment
+> boundaries were re-validated below.
+
 ## Loop-spec
 
 - **Work class:** C4 for the affected slice. The implementation changes pooled
@@ -12,8 +23,8 @@
 - **Loop archetype:** verifier-defined **spec-satisfaction repair**.
 - **Specification:** in canonical OpenAI Pool mode, recognize only the captured
   ChatGPT account/model rejection, then make at most one additional upstream
-  dispatch with a different eligible pooled account before any response bytes are
-  exposed to the client.
+  dispatch with a different eligible pooled account before any client-facing
+  `Response` or relay is constructed.
 - **Primary verifier:** activation tests in `tests/server-auth.test.ts` plus the
   focused auth-selection tests in `tests/codex-auth-context.test.ts`.
 - **Policy-preservation verifier:** the existing test named `caller and model 4xx
@@ -25,9 +36,10 @@
 - **Escalate up:** stop and return to Plan/Audit if implementation needs to (a)
   classify generic `unsupported model`, `model not found`, or `invalid request`
   substrings, (b) change `classifyCodexUpstreamOutcome`, health penalties,
-  cooldowns, or global active-account state, (c) retry after a client-visible
-  byte or after an SSE `200` terminal event, (d) make more than one
-  account-switch retry, or (e) expose account IDs/tokens/error bodies in logs.
+  cooldowns, or global active-account state, (c) retry after a client-facing relay
+  is constructed, after a visible byte, or after an SSE `200` terminal event, (d)
+  make more than one account-switch retry, or (e) expose account IDs/tokens/error
+  bodies in logs.
 - **Escalate down:** once the exact-body matcher, one-account exclusion, four
   required activation scenarios, streaming safety scenario, and C4 gates are
   green, do not add diagnostics, catalog changes, affinity redesign, or broader
@@ -58,15 +70,22 @@ or source capture supports broader alternatives such as bare `unsupported model`
 - `src/codex/routing.ts:450-480` returns without mutating health for `caller`.
 - `tests/codex-routing.test.ts:217-226` pins 400/404/422 as zero-penalty and keeps
   account `a` selectable.
-- `src/server/responses/core.ts:920-948` builds a replayable passthrough request
+- `src/server/responses/core.ts:923-951` builds a replayable passthrough request
   and performs the existing bounded transient/5xx dispatch before returning a
   client `Response`.
-- `src/server/responses/core.ts:1011-1017` records the selected pool account's
+- `src/server/responses/core.ts:1015-1020` records the selected pool account's
   HTTP outcome. The new retry must converge back into this path with the final
   account/response; it must not invent a model-health penalty.
+- `src/server/responses/core.ts:1023-1123` now chooses between the eager bounded
+  single-reader relay and the legacy tee relay for successful SSE responses. Both
+  branches remain downstream of the retry decision and must observe only the
+  final account/response.
 - `src/lib/errors.ts:79-190` is response/error-envelope classification. Its broad
   `model unavailable` / `model not found` / `unsupported model` bucket at
   `src/lib/errors.ts:172-183` is intentionally unsuitable as a retry signal.
+- `src/lib/bounded-body.ts:1-5,75-201` still owns the 64 KiB cap, 5 s total and
+  inactivity defaults, abort propagation, unsafe timeout/oversize results, and
+  cancellation without waiting. No matcher-specific unbounded read is allowed.
 
 ### Policy statement for the PR description
 
@@ -146,11 +165,12 @@ evidence.
 
 The retry decision occurs after `fetchWithTransientRetry(...)` has returned an
 HTTP response but **before** `sanitizePassthroughHeaders`, terminal recorder
-installation, body tee/relay, or construction/return of the client-facing
-`Response` (`src/server/responses/core.ts:938-963`). At that point:
+installation, either body relay, or construction/return of the client-facing
+`Response` (`src/server/responses/core.ts:941-966`). At that point:
 
 - the request body is already a replayable string from `adapter.buildRequest`;
-- no upstream body byte has been relayed to the client;
+- no upstream body byte has been relayed to the client (although clone inspection
+  deliberately reads the HTTP 400 body from upstream);
 - no client response headers have been committed;
 - an HTTP 400 is a pre-stream rejection even when `parsed.stream === true`.
 
@@ -160,10 +180,29 @@ invalid JSON, missing/non-string `detail`, or normalization mismatch means **no
 retry** and returns the untouched original response. The clone prevents matcher
 inspection from consuming or rewriting a non-matching response.
 
-Once a client-facing `Response` has been returned, or once an HTTP 200 SSE body is
-being relayed/inspected, the retry window is closed. A later
-`response.failed`/EOF/error event never enters this path. This defines
-“non-streaming or pre-first-byte” precisely and avoids duplicate visible output.
+The stream-capability gate does not move or narrow this decision point. In
+`legacy-tee` mode, tee/inspection setup begins only in the successful-SSE branch
+at `src/server/responses/core.ts:1077-1123`. In `eager-relay` mode,
+`relaySseEagerBounded` is constructed at `src/server/responses/core.ts:1037-1075`;
+its `ReadableStream.start()` immediately starts the producer and may read/queue
+upstream bytes before the downstream client pulls. That eager read still happens
+only after the HTTP status classifier has declined retry and the code has entered
+the successful-SSE branch. Therefore eager relay does **not** cause client bytes
+to flow before the 400 decision, but it makes the post-construction boundary
+especially strict: never attempt account switching after either relay is created.
+
+Accordingly, “pre-first-byte” means **before any client-facing `Response` or relay
+is constructed/returned**, not before any upstream body byte has been read. Once
+an HTTP 200 SSE response enters either relay mode, the retry window is closed. A
+later `response.failed`/EOF/error event never enters this path, even if no client
+pull has happened yet. This avoids duplicate visible output and mode-dependent
+retry behavior.
+
+Cycle 1 does not alter clone inspection. `_replayPrefixLen` stays on the parsed
+request and is reused unchanged when the alternate adapter rebuilds the same
+request; it is not consulted by the 400 matcher. The SSE completion accumulator
+is allocated by `createSseInspector` only for a final successful SSE relay, after
+the retry decision, and never sees the cloned 400 body.
 
 The unsupported-model budget is one account switch and one alternate HTTP
 dispatch. The initial account is excluded from alternate selection, the alternate
@@ -179,7 +218,7 @@ pre-existing policy. No recursive call to `handleResponses` is permitted.
 | MODIFY | `src/codex/auth-context.ts` | Add an optional request-local excluded account to `resolveCodexAuthContext`; use existing eligible-pool ranking for the alternate and reuse the exact credential resolution path. |
 | MODIFY | `src/server/responses/core.ts` | Add the exact `detail` matcher and bounded clone inspection; perform one alternate-account request rebuild/dispatch before response commitment; preserve final response fidelity and health policy. |
 | MODIFY | `tests/codex-auth-context.test.ts` | Prove exclusion selects a different eligible account and fails closed when none exists. |
-| MODIFY | `tests/server-auth.test.ts` | Add endpoint activation scenarios for success, one-account, malformed 400, bounded double rejection, and pre-first-byte streaming safety. |
+| MODIFY | `tests/server-auth.test.ts` | Add endpoint activation scenarios for success, one-account, malformed 400, bounded double rejection, and both-mode pre-response streaming safety. |
 | NEW | none | No new abstraction/module is justified for one private matcher and one optional auth-resolution input. |
 | DELETE | none | No production/test file is removed. |
 
@@ -323,7 +362,7 @@ field and cannot safely authorize cross-account dispatch.
 
 ### 3. `src/server/responses/core.ts` — rebuild and dispatch once
 
-Before (`src/server/responses/core.ts:920-963`):
+Before (`src/server/responses/core.ts:923-966`):
 
 ```ts
 const request = await adapter.buildRequest(parsed, { headers: selectedForwardHeaders });
@@ -348,7 +387,8 @@ const headers = sanitizePassthroughHeaders(upstreamResponse.headers);
 ```
 
 After, retain the existing transport error catch but place one non-recursive
-account-switch block before header sanitization:
+account-switch block before header sanitization. This insertion remains before
+the stream-mode decision at `src/server/responses/core.ts:1023-1123`:
 
 ```ts
 let request = await adapter.buildRequest(parsed, { headers: selectedForwardHeaders });
@@ -400,6 +440,7 @@ if (
 
     await upstreamResponse.body?.cancel().catch(() => undefined);
     authCtx = retryAuthCtx;
+    options.onCodexAuthContextResolved?.(retryAuthCtx);
     selectedForwardHeaders = retryHeaders;
     route.provider = retryProvider;
     logCtx.provider = formatCodexProviderForLog(
@@ -436,7 +477,7 @@ Implementation audit notes for this sketch:
 - Extracting the duplicated fetch body into a private local dispatch function is
   acceptable and preferred if it keeps `handleResponses` readable. The helper
   must take the concrete request/provider and must not recurse or own selection.
-- The existing catch behavior at lines 949-962 must be extracted/reused around
+- The existing catch behavior at lines 952-965 must be extracted/reused around
   the second dispatch. A second-attempt connect failure returns the existing 502
   and records against the second account; it must not retry that same account or
   select a third account.
@@ -489,6 +530,25 @@ export function recordCodexUpstreamOutcome(
 `pickLowestUsageCodexAccount(config, firstAccountId)` already supplies the exact
 eligibility and exclusion semantics needed by auth resolution: reauth-needed,
 hard-cooldown, soft-avoided, unusable, and the excluded account are omitted.
+
+Eligibility definition (ELIGIBLE-01, binding): "eligible" for the retry target B
+means credential/health eligible ONLY — not reauth-needed, not hard-cooled,
+usable credential, and not account A. There is NO per-model capability
+predicate in the pool (routing.ts:246/285 have no model dimension), so whether
+B supports the routed model is UNKNOWN until the single bounded probe runs; a
+second allow-listed 400 from B is the expected negative outcome and is returned
+directly (no third dispatch). Pool mutation between A's selection and the
+retry selection is handled best-effort at selection time: the retry re-reads
+the pool snapshot at the retry point; if no eligible B exists at that moment,
+the original A response is returned unchanged.
+
+Account-context republication (WS-REBIND-01, binding): the initial auth context
+is published via `options.onCodexAuthContextResolved` (core.ts:744-746) and the
+WebSocket layer registers the socket under that account (index.ts:594,
+websocket-registry.ts:37). A successful retry MUST republish the final context
+(`options.onCodexAuthContextResolved?.(retryAuthCtx)` — included in the retry
+sketch above) so the registry migrates A -> B; otherwise invalidating B leaves
+a stale A-bound socket and invalidating A closes a B-backed socket.
 
 ## Test plan and activation scenarios
 
@@ -557,22 +617,37 @@ burn.
 - Assert there is no third dispatch, no return to A, and both health states are
   `null`.
 
-#### Activation E — streaming request is retried only before first byte
+#### Activation E — both stream modes share the pre-response commitment boundary
 
-- Send `stream: true`; A returns the exact HTTP 400 before any SSE response.
-- B returns a valid completed SSE stream.
-- Assert the client receives only B's SSE frames and dispatch count is 2.
-- Add the negative half: A returns HTTP 200 then an SSE `response.failed` payload
-  containing the same sentence; assert dispatch count is 1. This proves the
-  matcher cannot activate after response commitment/stream relay.
+Run both halves below as a table over `streamMode: "legacy-tee"` and
+`streamMode: "eager-relay"`. Because the production gate consults `streamMode`
+only for win32 without item-ID repair, the endpoint test must temporarily set
+`process.platform` to `"win32"`, keep `responsesItemIdRepair` disabled, and restore
+the original descriptor in `finally` (the repository already uses this pattern in
+`tests/config.test.ts:758-830`). Do not treat setting `streamMode` on a non-Windows
+test as coverage of the eager branch.
+
+- Positive half: send `stream: true`; A returns the exact HTTP 400 before any SSE
+  response and B returns a valid completed SSE stream. Assert the client receives
+  only B's frames and dispatch count/order is exactly `[A, B]` under each mode.
+- Negative half: A returns HTTP 200 then an SSE `response.failed` payload containing
+  the same sentence. Assert dispatch count/order is `[A]` under each mode and the
+  failure frames come from A. This proves neither the tee inspector nor the eager
+  producer can reactivate account retry after the response/relay boundary.
+- Keep the platform override serial and tightly scoped so unrelated endpoint cases
+  cannot observe the synthetic platform.
 
 ### Mandatory negative activation matrix — hostile/non-authorizing bodies
 
-Every case below uses two eligible accounts, records dispatch order, and compares the client-visible
-status, sanitized headers, and body bytes with account A's original HTTP 400. The invariant is one
-dispatch (`[A]`), no request to B, unchanged original 400, and null health for both accounts. Use
-`readBoundedResponseBody`'s real timeout/truncation/oversize/display-safety behavior; do not replace
-the production reader with a permissive test stub.
+Every case below uses two eligible accounts and records dispatch order. Rows 1-8
+(the hostile/no-authorization bodies) share this invariant: one dispatch (`[A]`),
+no request to B, client receives A's original 400 status/sanitized headers/body
+bytes unchanged, and null health for both accounts. Rows 9-10 (the retry-failure
+negatives) use their row-specific assertions instead: row 9 preserves A after a
+failed alternate resolution (`[A]` only), row 10 dispatches `[A,B]` with the
+transport failure attributed to B and no third attempt. Use
+`readBoundedResponseBody`'s real timeout/truncation/oversize/display-safety
+behavior; do not replace the production reader with a permissive test stub.
 
 | Name (mandatory test) | Fixture/activation | Observable assertion |
 |---|---|---|
@@ -583,10 +658,23 @@ the production reader with a permissive test stub.
 | `missing or non-string detail never authorizes a pool retry` | Table-driven A bodies: `{}`, `{"detail":null}`, `{"detail":400}`, `{"detail":{"message":"..."}}` | Every subcase dispatches once, never contacts B, and returns that exact original body/status |
 | `wrong model id in exact sentence never authorizes a pool retry` | Requested route model is `gpt-5.6-sol`, but A's otherwise exact sentence names `other-model` | Model interpolation mismatch keeps dispatches at `[A]`; original 400 is unchanged |
 | `normalization near-misses never authorize a pool retry` | Table-driven near misses outside the allow-list: removed terminal period, changed quote characters, extra prefix/suffix text, or punctuation removal; include one whitespace/case-only variant as the positive control | Every near miss returns A unchanged with no B dispatch; only the whitespace/case-only positive control may dispatch `[A,B]`, proving normalization is narrow |
+| `valid JSON wrong top-level shape never authorizes a pool retry` | Table-driven A bodies that parse as valid JSON but are not objects: `"string"`, `42`, `true`, `null`, `["detail"]` | Non-object top-level rejection branch fires; dispatches are `[A]`; exact original bytes/status reach the client |
+| `alternate account resolution failure preserves the original 400` | Allow-listed 400 from A; the retry-target credential refresh throws (auth-context.ts:126 path) or the only alternate is hard-cooled at the retry snapshot | Resolution failure is swallowed; dispatches are `[A]`; A's original 400 status/headers/body are returned unchanged; no health mutation for either account |
+| `retry-dispatch transport failure records only B and never triple-dispatches` | Allow-listed 400 from A; B's dispatch throws a connect/timeout transport error through the existing boundary (core.ts:941 region) | Dispatch order is `[A,B]` with no third attempt; the transport failure surfaces through the existing transport-error path attributed to B; A's health remains untouched |
 
-These seven named tests are additional to Activations A–E. A shared parameterized harness is allowed,
-but each hostile-body class must appear by name in test output and assert response fidelity, not only
-dispatch count.
+These ten named tests (eight hostile-body plus two retry-failure negatives) are
+additional to Activations A–E. A shared parameterized harness is allowed, but
+each class must appear by name in test output and assert response fidelity (or
+its row-specific retry-failure assertion), not only dispatch count.
+
+The three rows added after audit round 1 (wrong top-level shape, alternate
+resolution failure, retry transport failure) are equally mandatory, bringing the
+negative matrix to ten named tests.
+
+Additionally mandatory (WS-REBIND-01 activation): a WebSocket-mode test in which
+account A returns the allow-listed 400 and the retry succeeds on B — assert
+`onCodexAuthContextResolved` fires twice (A then B) and the WebSocket account
+registry ends bound to B (registry migration A -> B).
 
 ### `tests/codex-routing.test.ts` policy-preservation gate
 
@@ -624,7 +712,7 @@ changes authentication/account-selection behavior.
 - **Controls:** exact status, exact top-level field, model-bound full-sentence
   equality, bounded clone read, one excluded-account selection, one non-recursive
   retry, existing eligibility checks, zero health penalty, no body/token logging,
-  and no post-first-byte activation.
+  and no activation after either client relay is constructed.
 - **Residual risk:** upstream wording changes cause a false negative (no retry),
   which preserves current behavior and is safer than a false-positive quota burn.
 
@@ -639,7 +727,8 @@ changes authentication/account-selection behavior.
       eligibility checks; no caller bearer fallback occurs.
 - [ ] Dispatch count is bounded and cannot recurse; double rejection is exactly
       two account dispatches.
-- [ ] No response byte/header is client-visible before the retry decision.
+- [ ] No client-facing response/relay exists before the retry decision; both
+      `legacy-tee` and `eager-relay` commitment scenarios are covered.
 - [ ] `classifyCodexUpstreamOutcome` and caller-health behavior are unchanged.
 - [ ] No credential, account identifier, request body, or raw upstream body is
       added to logs or error diagnostics.
@@ -681,19 +770,26 @@ bun run privacy:scan
 ```
 
 Expected result for every command: exit code 0. The focused endpoint test output
-must name all activation scenarios A-E and all seven mandatory hostile-body negatives. Completion evidence records command,
+must name all activation scenarios A-E and all ten mandatory negatives (eight
+hostile-body + two retry-failure). Completion evidence records command,
 commit SHA, exit code, pass/fail counts, and the explicit security-review result.
 
 ## Acceptance criteria
 
 - [ ] Exact captured `detail` from A with at least two eligible accounts dispatches
       once to B and can recover.
-- [ ] The retry account is eligible and not A.
+- [ ] The retry account is credential/health eligible (ELIGIBLE-01) and not A;
+      model support on B is probed, not assumed.
 - [ ] One eligible account returns the original 400 without another dispatch.
 - [ ] Malformed-input/non-allow-listed 400 never contacts B.
+- [ ] A successful retry republishes the auth context (WS-REBIND-01): the
+      WebSocket registry migrates A -> B.
+- [ ] Alternate-resolution failure and B transport failure behave per the two
+      dedicated negative tests (original 400 preserved / no third dispatch).
 - [ ] A then B allow-listed rejection stops at two dispatches and returns B's 400.
-- [ ] Streaming requests retry only on an HTTP 400 before response handoff; HTTP
-      200/SSE terminal failures never retry.
+- [ ] Streaming requests retry only on an HTTP 400 before response/relay
+      construction; HTTP 200/SSE terminal failures never retry under either
+      `legacy-tee` or `eager-relay`.
 - [ ] A's allow-listed 400 creates no health penalty, cooldown, soft avoid, reauth
       state, active-account mutation, or global affinity rewrite.
 - [ ] `classifyCodexUpstreamOutcome` and its pinned 4xx test are unchanged and green.

--- a/devlog/_plan/260724_bugfix_train/020_pool_retry_400.md
+++ b/devlog/_plan/260724_bugfix_train/020_pool_retry_400.md
@@ -1,0 +1,704 @@
+# 020 — Cycle 2: bounded pool retry for account-specific unsupported-model 400
+
+> DIFFLEVEL-ROADMAP-01: this is the implementation contract for issue #335. It
+> fixes one account/model capability mismatch without changing the general 4xx
+> health taxonomy introduced by `35d28a02`.
+
+## Loop-spec
+
+- **Work class:** C4 for the affected slice. The implementation changes pooled
+  account selection and therefore crosses an authentication/security boundary;
+  the change remains a narrowly bounded spec-satisfaction repair.
+- **Loop archetype:** verifier-defined **spec-satisfaction repair**.
+- **Specification:** in canonical OpenAI Pool mode, recognize only the captured
+  ChatGPT account/model rejection, then make at most one additional upstream
+  dispatch with a different eligible pooled account before any response bytes are
+  exposed to the client.
+- **Primary verifier:** activation tests in `tests/server-auth.test.ts` plus the
+  focused auth-selection tests in `tests/codex-auth-context.test.ts`.
+- **Policy-preservation verifier:** the existing test named `caller and model 4xx
+  responses do not penalize account health` in `tests/codex-routing.test.ts` must
+  remain unchanged and green.
+- **Completion verifier:** `bun run typecheck`, `bun run test`, and
+  `bun run privacy:scan`, all exit 0. Run the focused files first for fast
+  diagnosis, then the repository gates.
+- **Escalate up:** stop and return to Plan/Audit if implementation needs to (a)
+  classify generic `unsupported model`, `model not found`, or `invalid request`
+  substrings, (b) change `classifyCodexUpstreamOutcome`, health penalties,
+  cooldowns, or global active-account state, (c) retry after a client-visible
+  byte or after an SSE `200` terminal event, (d) make more than one
+  account-switch retry, or (e) expose account IDs/tokens/error bodies in logs.
+- **Escalate down:** once the exact-body matcher, one-account exclusion, four
+  required activation scenarios, streaming safety scenario, and C4 gates are
+  green, do not add diagnostics, catalog changes, affinity redesign, or broader
+  provider retry abstractions in this cycle.
+- **Budget/bounds:** one logical bug fix; no dependencies, schema/config changes,
+  GUI changes, release work, or public API additions.
+
+## Evidence and invariant lock
+
+### Reproduction evidence
+
+Issue #335 captured this exact upstream payload for `gpt-5.6-sol`:
+
+```json
+{"detail":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}
+```
+
+Repository search found the same ChatGPT/Codex sentence in
+`devlog/_plan/issue_017_mobile-thread-bypass-proxy/00_review.md`; no test fixture
+or source capture supports broader alternatives such as bare `unsupported model`,
+`model is not supported`, or `model not found for this account`.
+
+### Existing behavior that must remain true
+
+- `src/codex/auth-context.ts:92-141` resolves one pool account and its credential
+  before provider dispatch.
+- `src/codex/routing.ts:116-125` maps every non-auth/non-quota 4xx to `caller`.
+- `src/codex/routing.ts:450-480` returns without mutating health for `caller`.
+- `tests/codex-routing.test.ts:217-226` pins 400/404/422 as zero-penalty and keeps
+  account `a` selectable.
+- `src/server/responses/core.ts:920-948` builds a replayable passthrough request
+  and performs the existing bounded transient/5xx dispatch before returning a
+  client `Response`.
+- `src/server/responses/core.ts:1011-1017` records the selected pool account's
+  HTTP outcome. The new retry must converge back into this path with the final
+  account/response; it must not invent a model-health penalty.
+- `src/lib/errors.ts:79-190` is response/error-envelope classification. Its broad
+  `model unavailable` / `model not found` / `unsupported model` bucket at
+  `src/lib/errors.ts:172-183` is intentionally unsuitable as a retry signal.
+
+### Policy statement for the PR description
+
+The PR description must include this sentence (wording may be lightly edited,
+meaning may not):
+
+> This intentionally refines the request-dispatch behavior around the
+> `35d28a02` outcome policy: allow-listed account/model 400s may trigger one
+> different-account Pool retry, while all 4xx responses remain caller outcomes
+> with zero account-health penalty.
+
+## Scope
+
+### IN
+
+- Canonical OpenAI `openai-responses` passthrough with `codexAccountMode: "pool"`.
+- HTTP status exactly `400`.
+- Top-level JSON `detail` exactly matching the captured account/model sentence
+  after narrow normalization, with the requested routed model interpolated.
+- At most one alternate-account dispatch, selected from the existing eligible
+  pool while excluding the first account.
+- Both `stream: false` and a streaming request whose upstream rejects with HTTP
+  400 before the server returns a `Response` to the client.
+- Preservation of current status/body/headers when no retry is allowed or the
+  alternate account also rejects.
+
+### OUT
+
+- Generic 400/404/422 retry, substring/keyword heuristics, fuzzy matching, locale
+  variants, and provider-specific error taxonomies outside canonical ChatGPT.
+- Model catalog correction, capability caching, per-model account health, quota
+  penalty, cooldown, reauth marking, or permanent account quarantine.
+- Changing global active-account selection or thread-affinity persistence. This
+  cycle makes a request-local alternate selection; a successful retry does not
+  rewrite global account preference.
+- Retry of an HTTP `200` SSE stream that later emits `response.failed`, even if
+  the terminal payload contains similar text.
+- WebSocket-specific replay, diagnostics fields, GUI/history account labels, and
+  issue #335's optional diagnostics suggestion.
+- Compact endpoint behavior, release/version changes, and dependency changes.
+
+## Allow-list contract
+
+### Accepted phrase template
+
+The allow-list contains exactly one evidence-backed template:
+
+```text
+The '<requested routed model id>' model is not supported when using Codex with a ChatGPT account.
+```
+
+Normalization is deliberately limited to:
+
+1. parse JSON and require a **top-level string** property named `detail`;
+2. trim leading/trailing whitespace;
+3. collapse internal ASCII/Unicode whitespace runs to one space;
+4. compare case-insensitively to the expected sentence built from
+   `route.modelId`.
+
+Do not strip punctuation, remove quotes, search substrings, inspect arbitrary
+nested fields, or accept a different model ID. Consequently these remain false:
+
+```text
+unsupported model
+model is not supported
+model not found for this account
+The 'other-model' model is not supported when using Codex with a ChatGPT account.
+Invalid request: malformed tool schema
+```
+
+The three generic phrases are leads only. Add one in a later change only after a
+sanitized primary ChatGPT response fixture proves its complete envelope and exact
+wording. This is the tightest defensible list from current repository and issue
+evidence.
+
+## Safe retry boundary
+
+The retry decision occurs after `fetchWithTransientRetry(...)` has returned an
+HTTP response but **before** `sanitizePassthroughHeaders`, terminal recorder
+installation, body tee/relay, or construction/return of the client-facing
+`Response` (`src/server/responses/core.ts:938-963`). At that point:
+
+- the request body is already a replayable string from `adapter.buildRequest`;
+- no upstream body byte has been relayed to the client;
+- no client response headers have been committed;
+- an HTTP 400 is a pre-stream rejection even when `parsed.stream === true`.
+
+Inspect only `upstreamResponse.clone()` with `readBoundedResponseBody`, using the
+existing 64 KiB/5 s bounds and the request abort signal. A timeout, oversized body,
+invalid JSON, missing/non-string `detail`, or normalization mismatch means **no
+retry** and returns the untouched original response. The clone prevents matcher
+inspection from consuming or rewriting a non-matching response.
+
+Once a client-facing `Response` has been returned, or once an HTTP 200 SSE body is
+being relayed/inspected, the retry window is closed. A later
+`response.failed`/EOF/error event never enters this path. This defines
+“non-streaming or pre-first-byte” precisely and avoids duplicate visible output.
+
+The unsupported-model budget is one account switch and one alternate HTTP
+dispatch. The initial account is excluded from alternate selection, the alternate
+dispatch is deliberately **not** wrapped in `fetchWithTransientRetry`, and its
+response is returned directly. Existing transient transport/5xx retry behavior on
+the initial dispatch before this classifier is not broadened; it is a separate
+pre-existing policy. No recursive call to `handleResponses` is permitted.
+
+## Exact file change map
+
+| Action | Path | Diff responsibility |
+| --- | --- | --- |
+| MODIFY | `src/codex/auth-context.ts` | Add an optional request-local excluded account to `resolveCodexAuthContext`; use existing eligible-pool ranking for the alternate and reuse the exact credential resolution path. |
+| MODIFY | `src/server/responses/core.ts` | Add the exact `detail` matcher and bounded clone inspection; perform one alternate-account request rebuild/dispatch before response commitment; preserve final response fidelity and health policy. |
+| MODIFY | `tests/codex-auth-context.test.ts` | Prove exclusion selects a different eligible account and fails closed when none exists. |
+| MODIFY | `tests/server-auth.test.ts` | Add endpoint activation scenarios for success, one-account, malformed 400, bounded double rejection, and pre-first-byte streaming safety. |
+| NEW | none | No new abstraction/module is justified for one private matcher and one optional auth-resolution input. |
+| DELETE | none | No production/test file is removed. |
+
+Explicitly unchanged:
+
+- `src/codex/routing.ts`: no outcome-class, health, cooldown, affinity, or active
+  account changes.
+- `src/lib/errors.ts`: no retry semantics added to provider-agnostic error
+  presentation.
+- `tests/codex-routing.test.ts`: do not weaken or rewrite the pinned 4xx test;
+  execute it as a policy-preservation gate.
+- `docs-site/`: no user-configurable or public contract change; see Docs sync.
+
+## Diff-level implementation sketches
+
+The sketches below use current names/signatures and define the intended diff.
+Minor extraction for formatting is allowed only if behavior remains identical.
+
+### 1. `src/codex/auth-context.ts` — alternate selection with one exclusion
+
+Before (`src/codex/auth-context.ts:92-105`):
+
+```ts
+export async function resolveCodexAuthContext(
+  headers: Headers,
+  config: OcxConfig,
+  mode: CodexAccountMode,
+): Promise<CodexAuthContext> {
+  if (mode === "direct") {
+    if (!hasCallerCodexBearer(headers)) throw new CodexDirectAuthenticationError();
+    return { kind: "main", accountId: null };
+  }
+  const threadId = headers.get("x-codex-parent-thread-id");
+  const resolution = resolveCodexAccountForThreadDetailed(threadId, config);
+  if (resolution.status === "expired") throw new CodexThreadAffinityExpiredError(resolution.accountId);
+  const accountId = resolution.status === "selected" ? resolution.accountId : null;
+  if (!accountId) throw new CodexPoolAuthenticationError();
+```
+
+After:
+
+```ts
+export interface ResolveCodexAuthContextOptions {
+  excludeAccountId?: string;
+}
+
+export async function resolveCodexAuthContext(
+  headers: Headers,
+  config: OcxConfig,
+  mode: CodexAccountMode,
+  options: ResolveCodexAuthContextOptions = {},
+): Promise<CodexAuthContext> {
+  if (mode === "direct") {
+    if (!hasCallerCodexBearer(headers)) throw new CodexDirectAuthenticationError();
+    return { kind: "main", accountId: null };
+  }
+  const threadId = headers.get("x-codex-parent-thread-id");
+  const resolution = options.excludeAccountId
+    ? (() => {
+        const accountId = pickLowestUsageCodexAccount(config, options.excludeAccountId);
+        return accountId
+          ? { status: "selected" as const, accountId }
+          : { status: "none" as const };
+      })()
+    : resolveCodexAccountForThreadDetailed(threadId, config);
+  if (resolution.status === "expired") throw new CodexThreadAffinityExpiredError(resolution.accountId);
+  const accountId = resolution.status === "selected" ? resolution.accountId : null;
+  if (!accountId) throw new CodexPoolAuthenticationError();
+```
+
+Required import change:
+
+```ts
+import {
+  getCodexAccountCooldownUntil,
+  pickLowestUsageCodexAccount,
+  resolveCodexAccountForThreadDetailed,
+} from "./routing";
+```
+
+The remainder of `resolveCodexAuthContext` at lines 106-140 stays the single
+credential owner for main-pool and stored pool accounts. The exclusion branch
+must not call `setActiveCodexAccount`, bind/clear thread affinity, bypass
+`isCodexAccountUsable`, or fall back to the inbound caller bearer.
+
+### 2. `src/server/responses/core.ts` — exact matcher
+
+Add private helpers near the existing Codex passthrough helpers
+(`codexLogAccountId`, `usesCodexForwardPoolAuth`):
+
+```ts
+function normalizeCodexUnsupportedModelDetail(value: string): string {
+  return value.trim().replace(/\s+/gu, " ").toLocaleLowerCase("en-US");
+}
+
+function isAllowListedCodexAccountModel400(
+  status: number,
+  bodyText: string,
+  modelId: string,
+): boolean {
+  if (status !== 400) return false;
+  try {
+    const payload = JSON.parse(bodyText) as unknown;
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
+    const detail = (payload as { detail?: unknown }).detail;
+    if (typeof detail !== "string") return false;
+    const expected = `The '${modelId}' model is not supported when using Codex with a ChatGPT account.`;
+    return normalizeCodexUnsupportedModelDetail(detail)
+      === normalizeCodexUnsupportedModelDetail(expected);
+  } catch {
+    return false;
+  }
+}
+
+async function shouldRetryCodexPoolAccountModel400(
+  response: Response,
+  modelId: string,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  if (response.status !== 400) return false;
+  try {
+    const body = await readBoundedResponseBody(response.clone(), { signal });
+    return body.displaySafe
+      && !body.truncated
+      && isAllowListedCodexAccountModel400(response.status, body.text, modelId);
+  } catch {
+    return false;
+  }
+}
+```
+
+Do not use `classifyError(...)` as the predicate. Its real signature remains:
+
+```ts
+export function classifyError(status: number, type: string, message: string): OcxErrorPayload
+```
+
+That function intentionally maps presentation/error codes and broadly groups
+model text. It has neither account context nor the original structured `detail`
+field and cannot safely authorize cross-account dispatch.
+
+### 3. `src/server/responses/core.ts` — rebuild and dispatch once
+
+Before (`src/server/responses/core.ts:920-963`):
+
+```ts
+const request = await adapter.buildRequest(parsed, { headers: selectedForwardHeaders });
+// ...
+let upstreamResponse: Response;
+try {
+  upstreamResponse = await fetchWithTransientRetry(
+    recovery => {
+      noteAttemptSend(logCtx.activeAttempt, passthroughEstimate, recovery);
+      return fetchWithHeaderTimeout(request.url, applyUpstreamRecoveryInit({
+        method: request.method,
+        headers: request.headers,
+        body: request.body,
+      }, recovery), upstream.signal, connectMs, parsed.stream, providerFetch(route.provider));
+    },
+    { abortSignal: upstream.signal, label: safeHostLabel(request.url) },
+  );
+} catch (err) {
+  // existing transport failure handling
+}
+const headers = sanitizePassthroughHeaders(upstreamResponse.headers);
+```
+
+After, retain the existing transport error catch but place one non-recursive
+account-switch block before header sanitization:
+
+```ts
+let request = await adapter.buildRequest(parsed, { headers: selectedForwardHeaders });
+// ... existing first dispatch, assigning upstreamResponse ...
+
+if (
+  usesCodexForwardPoolAuth(authCtx, route.provider)
+  && await shouldRetryCodexPoolAccountModel400(
+    upstreamResponse,
+    route.modelId,
+    options.abortSignal,
+  )
+) {
+  const firstAuthCtx = authCtx;
+  let retryAuthCtx: CodexAuthContext | undefined;
+  try {
+    retryAuthCtx = await resolveCodexAuthContext(
+      req.headers,
+      config,
+      "pool",
+      { excludeAccountId: firstAuthCtx.accountId },
+    );
+  } catch (error) {
+    if (
+      !(error instanceof CodexPoolAuthenticationError)
+      && !(error instanceof CodexAuthContextError)
+      && !(error instanceof CodexAccountCooldownError)
+    ) throw error;
+  }
+
+  if (retryAuthCtx && (retryAuthCtx.kind === "pool" || retryAuthCtx.kind === "main-pool")) {
+    // Preserve 35d28a02 explicitly: first 400 is recorded through the existing
+    // classifier and remains a caller/no-health-mutation outcome.
+    recordCodexUpstreamOutcome(config, firstAuthCtx.accountId, 400, {
+      threadId: req.headers.get("x-codex-parent-thread-id"),
+    });
+
+    const retryHeaders = headersForCodexAuthContext(req.headers, retryAuthCtx);
+    const retryProvider = applyCodexAuthContextToProvider(
+      stripCodexRuntimeProviderFields(route.provider),
+      retryAuthCtx,
+      "pool",
+    );
+    const retryAdapter = resolveAdapter(
+      resolveWireProtocolOverride(route.providerName, route.modelId, retryProvider),
+      config.cacheRetention,
+    );
+    request = await retryAdapter.buildRequest(parsed, { headers: retryHeaders });
+
+    await upstreamResponse.body?.cancel().catch(() => undefined);
+    authCtx = retryAuthCtx;
+    selectedForwardHeaders = retryHeaders;
+    route.provider = retryProvider;
+    logCtx.provider = formatCodexProviderForLog(
+      route.providerName,
+      retryAuthCtx.accountId,
+      config,
+    );
+
+    noteAttemptSend(logCtx.activeAttempt, passthroughEstimate);
+    upstreamResponse = await fetchWithHeaderTimeout(
+      request.url,
+      {
+        method: request.method,
+        headers: request.headers,
+        body: request.body,
+      },
+      upstream.signal,
+      connectMs,
+      parsed.stream,
+      providerFetch(route.provider),
+    );
+    // No transient wrapper and no call back into the matcher: the entire retry
+    // budget is spent by this one different-account HTTP dispatch.
+  }
+}
+
+const headers = sanitizePassthroughHeaders(upstreamResponse.headers);
+```
+
+Implementation audit notes for this sketch:
+
+- Import and use existing `stripCodexRuntimeProviderFields`; otherwise the second
+  adapter can retain the first account's runtime override.
+- Extracting the duplicated fetch body into a private local dispatch function is
+  acceptable and preferred if it keeps `handleResponses` readable. The helper
+  must take the concrete request/provider and must not recurse or own selection.
+- The existing catch behavior at lines 949-962 must be extracted/reused around
+  the second dispatch. A second-attempt connect failure returns the existing 502
+  and records against the second account; it must not retry that same account or
+  select a third account.
+- The first 400 response body is canceled only after alternate auth and request
+  construction succeed. If no alternate exists or alternate auth cannot be
+  resolved, preserve and return the original 400 unchanged.
+- After the switch, all existing quota, terminal-recorder, response logging, and
+  health logic must observe the final `authCtx`, provider, and response. Do not
+  record success for the first account.
+- `recordCodexUpstreamOutcome(config, firstAuthCtx.accountId, 400, ...)` is a
+  deliberate no-op health-wise. The existing `caller` early return remains the
+  policy owner; do not special-case health in the new matcher.
+- A second allow-listed 400 passes directly to current response forwarding. There
+  is no loop and no third `resolveCodexAuthContext` call.
+- A 5xx/connect failure from B also ends the request after B's single dispatch;
+  the pre-existing same-account transient helper remains confined to the initial
+  dispatch so this repair's retry can never target the same account.
+
+### 4. `src/codex/routing.ts` — explicit no-diff policy pin
+
+The following real signatures and branches remain byte-for-byte unchanged:
+
+```ts
+export function classifyCodexUpstreamOutcome(
+  outcome: CodexUpstreamOutcome,
+): CodexUpstreamOutcomeClass {
+  // ...
+  if (outcome >= 400 && outcome < 500) return "caller";
+  // ...
+}
+
+export function pickLowestUsageCodexAccount(
+  config: OcxConfig,
+  excludeId?: string,
+  now = Date.now(),
+): string | null
+
+export function recordCodexUpstreamOutcome(
+  config: OcxConfig,
+  accountId: string | null,
+  outcome: CodexUpstreamOutcome,
+  meta: CodexUpstreamOutcomeMeta = {},
+): void {
+  // ...
+  if (outcomeClass === "caller") return;
+  // ...
+}
+```
+
+`pickLowestUsageCodexAccount(config, firstAccountId)` already supplies the exact
+eligibility and exclusion semantics needed by auth resolution: reauth-needed,
+hard-cooldown, soft-avoided, unusable, and the excluded account are omitted.
+
+## Test plan and activation scenarios
+
+### `tests/codex-auth-context.test.ts`
+
+Add a second stored account fixture only inside the new cases and clear its
+credential/reauth state in cleanup.
+
+1. **Exclusion selects another eligible account.** Configure `pool-a` active and
+   usable, `pool-b` usable, and deterministic quota scores. Call the real API:
+
+   ```ts
+   await resolveCodexAuthContext(headers, config, "pool", {
+     excludeAccountId: "pool-a",
+   });
+   ```
+
+   Assert `accountId === "pool-b"`, B's token/account header values are returned,
+   and `config.activeCodexAccountId` remains `pool-a`.
+
+2. **Exclusion fails closed with no alternate.** With only usable `pool-a`, call
+   the same API excluding `pool-a`; assert `CodexPoolAuthenticationError`. It must
+   not return `main`, use the inbound bearer, or retry `pool-a`.
+
+### `tests/server-auth.test.ts`
+
+Use `redirectCanonicalCodexTo`, two saved test credentials, deterministic quotas,
+and an upstream server that records `authorization` / `chatgpt-account-id` and
+returns account-specific responses. Assertions must observe the public
+`/v1/responses` behavior, dispatch count/order, response fidelity, and
+`getCodexUpstreamHealth`.
+
+#### Activation A — allow-listed 400 and at least two eligible accounts
+
+- A receives the exact payload for the requested model and returns 400.
+- B returns 200.
+- Assert dispatch accounts are exactly `[A, B]`; B differs from A.
+- Assert the client gets B's successful response.
+- Assert health for A and B is `null` (A's 400 has zero penalty; B's clean success
+  creates no failure state).
+- Assert the configured active account is still A (request-local selection).
+
+#### Activation B — allow-listed 400 and only one eligible account
+
+- A returns the exact allow-listed 400; no usable B exists.
+- Assert one upstream dispatch only.
+- Assert status, sanitized headers, and body equal A's original response.
+- Assert A health is `null` and active account remains A.
+
+#### Activation C — non-allow-listed malformed-input 400
+
+- A returns `{"detail":"Invalid request: malformed tool schema"}` with B eligible.
+- Assert one upstream dispatch only and B is never contacted.
+- Assert the same 400 body reaches the client.
+- Assert A and B health are `null` and neither is marked reauth-needed.
+
+This scenario is mandatory and is the security regression proving broad keyword
+or status matching did not turn malformed caller input into a cross-account quota
+burn.
+
+#### Activation D — second account also returns the allow-listed 400
+
+- A and B both return the exact sentence for the requested model.
+- Assert dispatch order/count is exactly `[A, B]` / 2.
+- Assert B's final 400 reaches the client.
+- Assert there is no third dispatch, no return to A, and both health states are
+  `null`.
+
+#### Activation E — streaming request is retried only before first byte
+
+- Send `stream: true`; A returns the exact HTTP 400 before any SSE response.
+- B returns a valid completed SSE stream.
+- Assert the client receives only B's SSE frames and dispatch count is 2.
+- Add the negative half: A returns HTTP 200 then an SSE `response.failed` payload
+  containing the same sentence; assert dispatch count is 1. This proves the
+  matcher cannot activate after response commitment/stream relay.
+
+### Mandatory negative activation matrix — hostile/non-authorizing bodies
+
+Every case below uses two eligible accounts, records dispatch order, and compares the client-visible
+status, sanitized headers, and body bytes with account A's original HTTP 400. The invariant is one
+dispatch (`[A]`), no request to B, unchanged original 400, and null health for both accounts. Use
+`readBoundedResponseBody`'s real timeout/truncation/oversize/display-safety behavior; do not replace
+the production reader with a permissive test stub.
+
+| Name (mandatory test) | Fixture/activation | Observable assertion |
+|---|---|---|
+| `oversized 400 body never authorizes a pool retry` | A returns a body larger than 64 KiB whose retained prefix resembles or contains the allow-listed JSON sentence | Reader reports unsafe oversized/truncated inspection; dispatches are `[A]`; B is untouched; the original 400 status/headers/full body are returned unchanged |
+| `stalled 400 body timeout never authorizes a pool retry` | A's clone-readable body emits a partial allow-listed-looking JSON prefix, stalls beyond the configured inactivity/total deadline, then is released for client read | Timeout/display-unsafe branch executes; dispatches are `[A]`; after release the client receives A's original 400 bytes and headers unchanged |
+| `aborted 400 inspection never authorizes a pool retry` | Abort the request signal while bounded clone inspection is pending on A's 400 body | Abort is caught only as matcher-false; B is untouched (no second dispatch). NOTE: the request abort also cancels A's upstream fetch (core.ts links options.abortSignal to upstream.signal and aborts the controller on request-signal fire), so the original body is NOT observable post-abort — assert the client-cancel outcome (aborted response surface), never body fidelity. If original-body fidelity must be exercised, use a matcher-local inspection signal decoupled from the request signal |
+| `invalid JSON 400 never authorizes a pool retry` | A returns `{"detail":` or non-JSON text with content type JSON | JSON parse fails; dispatches are `[A]`; exact malformed bytes and original 400 metadata reach the client |
+| `missing or non-string detail never authorizes a pool retry` | Table-driven A bodies: `{}`, `{"detail":null}`, `{"detail":400}`, `{"detail":{"message":"..."}}` | Every subcase dispatches once, never contacts B, and returns that exact original body/status |
+| `wrong model id in exact sentence never authorizes a pool retry` | Requested route model is `gpt-5.6-sol`, but A's otherwise exact sentence names `other-model` | Model interpolation mismatch keeps dispatches at `[A]`; original 400 is unchanged |
+| `normalization near-misses never authorize a pool retry` | Table-driven near misses outside the allow-list: removed terminal period, changed quote characters, extra prefix/suffix text, or punctuation removal; include one whitespace/case-only variant as the positive control | Every near miss returns A unchanged with no B dispatch; only the whitespace/case-only positive control may dispatch `[A,B]`, proving normalization is narrow |
+
+These seven named tests are additional to Activations A–E. A shared parameterized harness is allowed,
+but each hostile-body class must appear by name in test output and assert response fidelity, not only
+dispatch count.
+
+### `tests/codex-routing.test.ts` policy-preservation gate
+
+Do not change the existing assertions at lines 217-226. Run the test and ensure
+400, 404, and 422 still produce no health object and do not move future routing
+away from account A. The endpoint scenarios add stronger per-account assertions;
+they do not replace this test.
+
+### Test hygiene
+
+- Reset both A and B credentials, reauth flags, quota state, upstream health, and
+  thread map after each scenario.
+- Use synthetic account IDs/tokens only; never include a real email, token,
+  ChatGPT account ID, or raw local path in fixtures/log snapshots.
+- Do not add skips, weaken assertions, lower coverage, or introduce test-only
+  production branches.
+
+## Security-review checkpoint
+
+This checkpoint is mandatory before merge under `MAINTAINERS.md` because the diff
+changes authentication/account-selection behavior.
+
+### Threat model
+
+- **Assets:** pooled OAuth credentials, account quota, caller request integrity,
+  thread/account routing state, and privacy-safe logs.
+- **Entrypoint:** an untrusted ChatGPT backend HTTP 400 body plus the caller's
+  requested model ID.
+- **Trust boundary:** upstream free text authorizes one additional credentialed
+  request under another account. A false positive can spend another account's
+  quota; an unbounded retry can amplify cost.
+- **Attacker/failure capability:** malformed caller input can induce arbitrary
+  400s; an upstream/proxy can return large, stalled, invalid, or crafted bodies;
+  account credentials can become unusable between selection and dispatch.
+- **Controls:** exact status, exact top-level field, model-bound full-sentence
+  equality, bounded clone read, one excluded-account selection, one non-recursive
+  retry, existing eligibility checks, zero health penalty, no body/token logging,
+  and no post-first-byte activation.
+- **Residual risk:** upstream wording changes cause a false negative (no retry),
+  which preserves current behavior and is safer than a false-positive quota burn.
+
+### Reviewer checklist
+
+- [ ] A maintainer explicitly performs security review; author self-approval is
+      not sufficient.
+- [ ] PR targets `dev`, not `main`.
+- [ ] Matcher accepts only the evidence-backed `detail` template and requested
+      model; generic phrase cases are negative tests.
+- [ ] Alternate selection excludes the first account and uses existing
+      eligibility checks; no caller bearer fallback occurs.
+- [ ] Dispatch count is bounded and cannot recurse; double rejection is exactly
+      two account dispatches.
+- [ ] No response byte/header is client-visible before the retry decision.
+- [ ] `classifyCodexUpstreamOutcome` and caller-health behavior are unchanged.
+- [ ] No credential, account identifier, request body, or raw upstream body is
+      added to logs or error diagnostics.
+- [ ] Full typecheck/test/privacy gates pass on the reviewed commit.
+
+## Privacy notes
+
+- The matcher reads an already-received bounded clone in memory and retains no
+  new data.
+- Do not log `detail`, model/account tuples, access tokens, ChatGPT account IDs,
+  email addresses, request bodies, or authorization headers.
+- Existing provider log labels may update to the final account through the normal
+  sanitized formatter; this cycle adds no dedicated diagnostics field.
+- Test fixtures use `pool-a`, `pool-b`, fake bearer values, and `.example.test`
+  identities only.
+- `bun run privacy:scan` is a hard completion gate.
+
+## Docs-site sync decision
+
+**No `docs-site/` change.** This repairs internal Pool dispatch behavior without a
+new setting, command, endpoint, model catalog entry, error contract, or user action.
+The upstream 400 or alternate response remains the public wire response when the
+bounded retry cannot recover. Documenting exact private backend wording would also
+create a brittle public contract. If a future cycle adds configurable retry policy
+or diagnostics fields, that cycle must update the English docs source and verify
+translations do not contradict it.
+
+## Verification (C)
+
+Run from repository root at the implementation commit:
+
+```bash
+bun test tests/codex-auth-context.test.ts
+bun test tests/server-auth.test.ts
+bun test tests/codex-routing.test.ts
+bun run typecheck
+bun run test
+bun run privacy:scan
+```
+
+Expected result for every command: exit code 0. The focused endpoint test output
+must name all activation scenarios A-E and all seven mandatory hostile-body negatives. Completion evidence records command,
+commit SHA, exit code, pass/fail counts, and the explicit security-review result.
+
+## Acceptance criteria
+
+- [ ] Exact captured `detail` from A with at least two eligible accounts dispatches
+      once to B and can recover.
+- [ ] The retry account is eligible and not A.
+- [ ] One eligible account returns the original 400 without another dispatch.
+- [ ] Malformed-input/non-allow-listed 400 never contacts B.
+- [ ] A then B allow-listed rejection stops at two dispatches and returns B's 400.
+- [ ] Streaming requests retry only on an HTTP 400 before response handoff; HTTP
+      200/SSE terminal failures never retry.
+- [ ] A's allow-listed 400 creates no health penalty, cooldown, soft avoid, reauth
+      state, active-account mutation, or global affinity rewrite.
+- [ ] `classifyCodexUpstreamOutcome` and its pinned 4xx test are unchanged and green.
+- [ ] Response body/status/header fidelity is retained whenever no retry occurs.
+- [ ] No secrets/PII/account IDs or raw bodies are newly logged.
+- [ ] Security reviewer approves the auth-boundary refinement and the PR states
+      its intentional relationship to `35d28a02`.
+- [ ] Focused tests, full typecheck/test, and privacy scan all exit 0.

--- a/devlog/_plan/260724_bugfix_train/020_pool_retry_400.md
+++ b/devlog/_plan/260724_bugfix_train/020_pool_retry_400.md
@@ -450,20 +450,29 @@ if (
     );
 
     noteAttemptSend(logCtx.activeAttempt, passthroughEstimate);
-    upstreamResponse = await fetchWithHeaderTimeout(
-      request.url,
-      {
-        method: request.method,
-        headers: request.headers,
-        body: request.body,
-      },
-      upstream.signal,
-      connectMs,
-      parsed.stream,
-      providerFetch(route.provider),
-    );
-    // No transient wrapper and no call back into the matcher: the entire retry
-    // budget is spent by this one different-account HTTP dispatch.
+    // The retry dispatch reuses the SAME transport-error boundary as the first
+    // dispatch: a connect/timeout failure here surfaces through the existing
+    // catch that maps transport errors to 502/504, attributed to the retry
+    // account (B). No transient wrapper and no call back into the matcher: the
+    // entire retry budget is spent by this one different-account HTTP dispatch.
+    try {
+      upstreamResponse = await fetchWithHeaderTimeout(
+        request.url,
+        {
+          method: request.method,
+          headers: request.headers,
+          body: request.body,
+        },
+        upstream.signal,
+        connectMs,
+        parsed.stream,
+        providerFetch(route.provider),
+      );
+    } catch (err) {
+      // Route through the existing transport-error helper (same code path the
+      // first dispatch uses at core.ts:941 region); health/log attribution is B.
+      throw err; // caught by the surrounding dispatch transport boundary
+    }
   }
 }
 

--- a/devlog/_plan/260724_bugfix_train/030_shim_autorestore.md
+++ b/devlog/_plan/260724_bugfix_train/030_shim_autorestore.md
@@ -1,0 +1,707 @@
+# 030 — Cycle 3: codex-shim auto-restore after external Codex update
+
+> Evidence baseline: `origin/dev` / `d9e06c8dd08df6635f5ca042bf6aa469fe1a10a8` (2026-07-24).
+> This is a diff-level implementation design, not an implementation patch.
+
+## Loop spec
+
+- Loop archetype: **spec-satisfaction repair** for issue #320 part 2.
+- Success condition: a previously installed OpenCodex Codex shim that a completed external
+  `@openai/codex` npm update replaced is restored by the next real `ocx` command without requiring
+  `ocx codex-shim install`.
+- Verifier: `bun run typecheck`, `bun run test`, and `bun run privacy:scan`, plus the focused
+  activation scenarios and the healthy-probe timing check in this document.
+- Bounds: one bugfix slice; no daemon, watcher, dependency, auth-flow, release, or GUI work.
+- Escalation: return to A/maintainer review rather than widening the patch if (a) the healthy probe
+  cannot stay below 5 ms typical, (b) a platform requires process enumeration or a filesystem
+  watcher, (c) replacement stability cannot be established without waiting, or (d) any proposed
+  diagnostic would read or print credential contents. A security reviewer must explicitly approve
+  the final diff before merge because the shim state is colocated with `auth.json`.
+
+## Objective and evidence
+
+Issue #320 part 2 is a lifecycle gap, not a missing repair primitive:
+
+- `installCodexShim()` already recognizes a tracked wrapper replaced by a non-shim, moves the new
+  launcher into the owned backup, and writes a fresh shim (`src/codex/shim.ts:445-487`).
+- `diagnoseCodexShim()` already reports the exact stale condition as `present but not an opencodex
+  shim` (`src/codex/shim.ts:546-577`).
+- The repair path is only called explicitly from `ocx codex-shim install`
+  (`src/cli/index.ts:659-665`) or after OpenCodex's own updater succeeds
+  (`src/update/index.ts:255-267`). An external Codex npm update reaches neither call site.
+- The published `ocx` entry always reaches `src/cli/index.ts`; the runtime SOT identifies that file
+  as the CLI entry and `src/codex/shim.ts` as the shim lifecycle owner
+  (`structure/01_runtime.md:7-16`).
+- Credential handling and other security-boundary changes require explicit security review
+  (`MAINTAINERS.md:16-25`). `loadConfig()` hardens both config and adjacent `auth.json`
+  (`src/config.ts:645-650`), so the startup probe must use the read-only diagnostics loader and must
+  never read auth data.
+
+## Scope
+
+### IN
+
+- Auto-restore only a **previously installed, validly tracked** shim after its tracked wrapper path
+  has been replaced by a complete, stable, non-OpenCodex launcher.
+- Run a bounded, read-only probe on ordinary `ocx` CLI startup and synchronously execute the existing
+  repair transaction only on the rare confirmed-replacement path.
+- Add opt-out controls: `config.codexShimAutoRestore` and
+  `OPENCODEX_CODEX_SHIM_AUTO_RESTORE=0`.
+- Preserve macOS/Linux, native Windows, Git-Bash, and WSL safety behavior.
+- Warn on successful automatic repair and on repair failure; never change the requested command's
+  exit behavior because repair failed.
+- Update runtime SOT, root README copies, and docs-site CLI/configuration copies in every maintained
+  locale so no published page retains the old “manual install/update only” claim.
+
+### OUT
+
+- **Issue #320 part 1, the native Codex login gate, is UPSTREAM and explicitly OUT.** No auth/login,
+  `auth.json`, account-pool, or token behavior changes.
+- Fresh shim installation. Missing/corrupt state, a missing wrapper, a missing backup, a platform
+  mismatch, and an untracked Codex executable remain explicit/manual repair cases.
+- `codex.exe` wrapping. Windows discovery intentionally refuses a real `.exe`
+  (`src/codex/shim.ts:176-207`).
+- Background filesystem watcher, npm-process scanner, polling timer, sleep/retry loop, service
+  install, proxy lifecycle, GUI control, dependency, release, or schema migration.
+- Changing `codexAutoStart`; it controls whether an installed shim runs `ocx ensure`
+  (`src/config.ts:772-774`, `src/types.ts:530-531`) and is not the lifecycle-repair opt-out.
+
+## Design decisions
+
+### 1. Hook point: ordinary CLI startup
+
+**Choose:** invoke a best-effort helper in `src/cli/index.ts` after the existing version/help early
+exits and before `switch (command)` (`src/cli/index.ts:44-60`, `src/cli/index.ts:540`). Skip explicit
+destructive/repair lifecycle commands: top-level `uninstall`/`remove`, and `codex-shim install`,
+`uninstall`, or `remove`. Keep `codex-shim status` eligible so it reports the repaired state.
+
+| Candidate | Coverage | Cost / invasiveness | Decision |
+| --- | --- | --- | --- |
+| Every real `ocx` CLI startup | The next user command, even when no proxy starts | One state read plus bounded wrapper-prefix/metadata reads on the healthy path; no writes | **Chosen** |
+| `ocx start` / serve hook | Only commands that start the foreground proxy | Misses `status`, `login`, `doctor`, service-managed/no-start workflows | Reject |
+| Proxy startup | Only a newly created server process | Couples launcher mutation to server/auth startup and misses commands using an existing proxy | Reject |
+| Filesystem watcher | Continuous detection | Long-lived resource, platform-specific semantics, update races, teardown and permission surface | Reject |
+
+The hook is deliberately not placed in `bin/ocx.mjs`: the runtime SOT assigns that file bundled-Bun
+bootstrap only (`structure/01_runtime.md:7-9`). Shim lifecycle remains owned by
+`src/codex/shim.ts` (`structure/01_runtime.md:16`).
+
+“Never block” means no network, subprocess, watcher, sleep, polling, or retry on startup, and no
+repair failure may block/fail the requested command. The healthy check is synchronous but bounded so
+the shim is known-restored before command dispatch. The rare repair transaction may add local rename
+and write latency; making that detached would violate the “next command restored it” contract.
+
+### 2. Restore reuses install behavior inside a real multi-wrapper transaction
+
+**Choose:** extract the body of current `installCodexShim()` into a private
+`installCodexShimInternal(options)` and keep the public no-argument signature unchanged. Explicit
+install calls the internal function without a replacement guard. Auto-restore calls the same
+internal function with the stable fingerprints captured by the probe. Do not copy the
+backup/rename/write logic.
+
+The current helpers preserve one path on failure, but `installCodexShim()` mutates siblings
+sequentially (`src/codex/shim.ts:471-483`). That is not sufficient for the promised all-or-nothing
+multi-wrapper repair. The guarded auto-restore path must therefore wrap the existing branch behavior
+in a transaction-wide preflight and rollback journal:
+
+1. `refreshShimFile()` recognizes a tracked non-shim wrapper (`src/codex/shim.ts:445-468`).
+2. `replaceOwnedBackup()` remains the single-path primitive, but guarded multi-wrapper restore must
+   retain its staged prior backup until the whole sibling set commits; deleting it after each sibling
+   would make later rollback impossible.
+3. `writeShim()` emits `.cmd`, `.ps1`, Git-Bash sh, or Unix sh content and applies Unix execute bits
+   (`src/codex/shim.ts:397-419`).
+4. `installCodexShim()` writes canonical state only after every planned sibling mutation succeeds.
+   On any mid-sequence mismatch/write/rename failure, reverse the journal before returning/throwing
+   and leave state bytes unchanged.
+
+The accepted residual TOCTOU window is explicit: filesystem contents can change after transaction-
+wide preflight. Revalidate each source fingerprint immediately before its own first rename; if that
+late check fails after an earlier sibling was repaired, roll back the earlier sibling(s) in reverse
+order and return `deferred`. A rollback failure is an explicit filesystem repair failure reported by
+the CLI warning path, never a false `restored` result.
+
+### 3. Opt-out names and precedence
+
+- Config: `codexShimAutoRestore?: boolean`, default `true`.
+- Environment: `OPENCODEX_CODEX_SHIM_AUTO_RESTORE=0` disables auto-restore for that process.
+- Effective rule: enabled only when the config value is not `false` **and** the env value is not
+  exactly `"0"`. The env variable is an opt-out, not a force-enable; `=1` does not override config
+  `false`.
+
+The names follow current boundaries: persisted config uses camelCase boolean fields such as
+`codexAutoStart` (`src/types.ts:526-531`), while public OpenCodex environment controls use the
+`OPENCODEX_` prefix (`src/config.ts:308`, `src/cli/index.ts:134-135`). Internal shim recursion remains
+the separate `OCX_SHIM_BYPASS` concern (`src/codex/shim.ts:254-260`, `src/codex/shim.ts:348-350`).
+
+The common healthy/not-installed path never parses config. The shim owner first probes tracked state;
+only a stable restore candidate invokes a lazy `enabled()` callback. That callback uses
+`readConfigDiagnostics().config` (`src/config.ts:730-752`), not `loadConfig()`, so startup does not
+chmod, back up, or read adjacent credential files.
+
+### 4. Cross-platform contract
+
+- macOS/Linux: preserve the executable-bit health check (`src/codex/shim.ts:91-99`) and Unix shim
+  writer/chmod (`src/codex/shim.ts:415-418`). Symlink launchers are allowed only when the symlink and
+  resolved target fingerprints are stable and the target is a non-empty regular file.
+- Windows: operate only on the state-tracked `.cmd`, `.ps1`, and extensionless Git-Bash launcher set;
+  writer selection and UTF-8 BOM behavior stay centralized in `writeShim()`
+  (`src/codex/shim.ts:397-414`). Never discover or rename `codex.exe`.
+- WSL: auto-restore performs no PATH rediscovery. It requires `state.platform === process.platform`,
+  so Windows-owned state is not repaired from WSL. Fresh/manual discovery retains the existing WSL
+  interop refusal (`src/codex/shim.ts:132-173`).
+- Multi-wrapper state: all changed tracked launchers must pass stability checks before any one is
+  mutated. A mixed “npm is still replacing siblings” state is deferred as one unit.
+
+### 5. Completed/stable replacement check
+
+Do not sleep and stat twice over time. A candidate is safe only when all of these hold in one bounded
+probe:
+
+1. `codex-shim.json` parses through existing `readState()` and its platform equals the runtime.
+2. Every non-`preserveOnly` tracked entry still has its owned backup (or valid `realPath`), and every
+   wrapper exists. Corrupt/missing state is not auto-repaired.
+3. At least one tracked wrapper lacks the marker in a bounded prefix; intact wrappers remain healthy.
+4. For each changed wrapper, `lstat` before and after the bounded read has the same
+   device/inode/type/size/mtime; for symlinks, the followed target's corresponding fingerprint is
+   also unchanged and is a non-empty regular file.
+5. The newest `mtime`/`ctime` in those snapshots is at least `100 ms` old. This catches a just-created
+   partial launcher without adding a startup wait. A younger/changing candidate returns `deferred`
+   silently and is retried by the next command.
+6. Immediately before **any** mutation, `installCodexShimInternal` rechecks every captured wrapper
+   fingerprint transaction-wide. Any mismatch aborts with zero mutation. During application it also
+   rechecks each source immediately before that sibling's first rename; a later mismatch rolls back
+   all already-mutated siblings in reverse order. Concurrent `ocx` or npm activity therefore
+   degrades to a later retry rather than leaving a partially refreshed wrapper set.
+
+Use a named `CODEX_SHIM_REPLACEMENT_STABLE_MS = 100` and a bounded marker read (16 KiB is sufficient:
+the generated marker is at the top of every builder at `src/codex/shim.ts:222-224`,
+`src/codex/shim.ts:287-289`, and `src/codex/shim.ts:329-331`). Do not use current `isShim()` for the
+startup probe because it reads the entire path (`src/codex/shim.ts:83-89`), which can be an updated
+native launcher/binary. Explicit install and full diagnostics may retain their current behavior.
+
+This is a stability check, not an npm-brand check: OpenCodex does not need to parse npm launcher
+contents or enumerate npm processes. A replacement that is still being written is deferred; a stable
+non-shim at an OpenCodex-owned tracked path is the exact existing repair trigger.
+
+## Structural map
+
+```text
+src/cli/index.ts
+  -> src/cli/codex-shim-autorestore.ts       best-effort CLI boundary
+       -> src/config.ts                      lazy effective opt-out
+       -> src/codex/shim.ts                  probe + guarded shared install transaction
+            -> src/lib/bun-runtime.ts        existing shim writer dependency
+            -> src/lib/service-secrets.ts    existing token-file path baked into shim
+
+src/types.ts                                 persisted config type
+tests/config.test.ts                         flag/env contract
+tests/codex-shim.test.ts                     filesystem/platform/stability transaction
+tests/codex-shim-autorestore.test.ts         CLI policy + activation boundary
+```
+
+Dependency direction remains CLI policy -> config/domain owners. No server/proxy module imports the
+CLI helper, and shim code does not import CLI policy. Coupling is functional and one-way. No new
+public package export is introduced.
+
+## Exact file change map
+
+### Production and tests
+
+| Action | Exact path | Diff responsibility |
+| --- | --- | --- |
+| MODIFY | `src/types.ts` | Add typed persisted `codexShimAutoRestore?: boolean`. |
+| MODIFY | `src/config.ts` | Validate/default the field; export env constant and effective opt-out helper. |
+| MODIFY | `src/codex/shim.ts` | Add bounded probe, stable fingerprints, guarded internal install reuse, and `autoRestoreCodexShim()`. |
+| NEW | `src/cli/codex-shim-autorestore.ts` | Own skip policy, lazy config callback, warnings, and catch-all non-fatal boundary. |
+| MODIFY | `src/cli/index.ts` | Call helper after help/version exits and before command dispatch. |
+| MODIFY | `tests/config.test.ts` | Cover default, config false, env `0`, and precedence/type validation. |
+| MODIFY | `tests/codex-shim.test.ts` | Cover intact fast path, stable replacement, young/changing defer, platform guard, and real repair transaction. |
+| NEW | `tests/codex-shim-autorestore.test.ts` | Cover CLI skip policy, warning-only failures, opt-out, and a spawned next-command activation. |
+
+### Source of truth and public docs
+
+| Action | Exact path(s) | Diff responsibility |
+| --- | --- | --- |
+| MODIFY | `structure/01_runtime.md` | Record CLI startup auto-restore ownership and no-watcher/stable-replacement invariant. |
+| MODIFY | `README.md`, `README.ko.md`, `README.ja.md`, `README.zh-CN.md`, `README.ru.md` | Replace the contradictory “repair only on install/update” row and name both opt-outs. |
+| MODIFY | `docs-site/src/content/docs/reference/cli.md`, `docs-site/src/content/docs/ko/reference/cli.md`, `docs-site/src/content/docs/ja/reference/cli.md`, `docs-site/src/content/docs/zh-cn/reference/cli.md`, `docs-site/src/content/docs/ru/reference/cli.md` | Describe next-command automatic repair, stable-update defer, warning-only failure, and manual fallback. |
+| MODIFY | `docs-site/src/content/docs/reference/configuration.md`, `docs-site/src/content/docs/ko/reference/configuration.md`, `docs-site/src/content/docs/ja/reference/configuration.md`, `docs-site/src/content/docs/zh-cn/reference/configuration.md`, `docs-site/src/content/docs/ru/reference/configuration.md` | Add `codexShimAutoRestore` and `OPENCODEX_CODEX_SHIM_AUTO_RESTORE=0`. |
+
+### Deletes
+
+- No production/test/docs file is deleted by the implementation.
+- Planning scaffold `devlog/_plan/260724_bugfix_train/030_phase3.md` is replaced by this document,
+  `devlog/_plan/260724_bugfix_train/030_shim_autorestore.md`.
+
+## Diff-level code sketches
+
+Line anchors below refer to baseline `d9e06c8d`; implementation line numbers will shift.
+
+### `src/types.ts` — config contract
+
+Before (`src/types.ts:526-531`):
+
+```ts
+/** Advertise supports_websockets so Codex opens the WS endpoint. Default false; set true to opt in. */
+websockets?: boolean;
+/** Generated API keys for external access to the proxy's /v1/responses endpoint. */
+apiKeys?: Array<{ id: string; name: string; key: string; createdAt: string }>;
+/** Auto-start/sync the proxy from the Codex shim before launching Codex. Default true. */
+codexAutoStart?: boolean;
+```
+
+After:
+
+```ts
+/** Advertise supports_websockets so Codex opens the WS endpoint. Default false; set true to opt in. */
+websockets?: boolean;
+/** Generated API keys for external access to the proxy's /v1/responses endpoint. */
+apiKeys?: Array<{ id: string; name: string; key: string; createdAt: string }>;
+/** Auto-start/sync the proxy from the Codex shim before launching Codex. Default true. */
+codexAutoStart?: boolean;
+/** Restore a previously installed shim after a stable external Codex update replaces it. Default true. */
+codexShimAutoRestore?: boolean;
+```
+
+### `src/config.ts` — schema/default/effective flag
+
+Before (`src/config.ts:437-445`, `src/config.ts:772-805`):
+
+```ts
+const configSchema = z.object({
+  // ...
+  multiAgentGuidanceEnabled: z.boolean().optional(),
+}).passthrough().superRefine((config, ctx) => {
+
+export function codexAutoStartEnabled(config: Pick<OcxConfig, "codexAutoStart">): boolean {
+  return config.codexAutoStart !== false;
+}
+
+export function getDefaultConfig(): OcxConfig {
+  return {
+    // ...
+    codexAutoStart: true,
+  };
+}
+```
+
+After:
+
+```ts
+export const CODEX_SHIM_AUTO_RESTORE_ENV = "OPENCODEX_CODEX_SHIM_AUTO_RESTORE";
+
+const configSchema = z.object({
+  // ...
+  multiAgentGuidanceEnabled: z.boolean().optional(),
+  codexShimAutoRestore: z.boolean().optional(),
+}).passthrough().superRefine((config, ctx) => {
+
+export function codexShimAutoRestoreEnabled(
+  config: Pick<OcxConfig, "codexShimAutoRestore">,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return config.codexShimAutoRestore !== false && env[CODEX_SHIM_AUTO_RESTORE_ENV] !== "0";
+}
+
+export function getDefaultConfig(): OcxConfig {
+  return {
+    // ...
+    codexAutoStart: true,
+    codexShimAutoRestore: true,
+  };
+}
+```
+
+Place the schema key beside other top-level booleans, not as a post-parse cast. Keep the exported env
+name canonical so docs/tests do not duplicate the literal.
+
+### `src/codex/shim.ts` — probe and shared guarded install
+
+Before (`src/codex/shim.ts:445-517`):
+
+```ts
+function refreshShimFile(file: ShimFileState): boolean {
+  // ... current replacement/backup/write branches ...
+}
+
+export function installCodexShim(): { installed: boolean; message: string } {
+  const existing = readState();
+  if (existing) {
+    const files = stateFiles(existing);
+    let refreshed = false;
+    for (const file of files) refreshed = refreshShimFile(file) || refreshed;
+    // ... current allInstalled/state write/result ...
+  }
+  // ... current discovery/fresh install ...
+}
+```
+
+After (signatures and control flow; retain current branch bodies verbatim inside the internal owner):
+
+```ts
+const CODEX_SHIM_PROBE_BYTES = 16 * 1024;
+export const CODEX_SHIM_REPLACEMENT_STABLE_MS = 100;
+
+interface ShimPathFingerprint {
+  dev: number;
+  ino: number;
+  kind: "file" | "symlink";
+  size: number;
+  mtimeMs: number;
+  ctimeMs: number;
+  target?: Omit<ShimPathFingerprint, "target">;
+}
+
+interface InstallCodexShimInternalOptions {
+  expectedReplacements?: ReadonlyMap<string, ShimPathFingerprint>;
+  allowFreshInstall: boolean;
+}
+
+export type CodexShimAutoRestoreResult =
+  | { status: "not-installed" | "healthy" | "ineligible" | "deferred" | "disabled" }
+  | { status: "restored"; message: string };
+
+function readShimProbePrefix(path: string): string {
+  // open/read/close at most CODEX_SHIM_PROBE_BYTES; never read a replaced binary in full.
+}
+
+function stableReplacementFingerprint(
+  path: string,
+  nowMs: number,
+): ShimPathFingerprint | null {
+  // lstat -> bounded read -> lstat; follow and fingerprint a symlink target.
+  // Return null for changing, too-young, empty, non-file, unreadable, or dangling paths.
+}
+
+function refreshShimFile(
+  file: ShimFileState,
+  expectedReplacement?: ShimPathFingerprint,
+): boolean {
+  // Existing branch classification stays authoritative for explicit/manual install.
+}
+
+interface GuardedRefreshOperation {
+  file: ShimFileState;
+  expectedReplacement: ShimPathFingerprint;
+  sourcePath: string;
+  writesWrapper: boolean;
+}
+
+interface GuardedRefreshJournalEntry {
+  operation: GuardedRefreshOperation;
+  stagedOldBackupPath?: string;
+  stagedOldWrapperPath?: string;
+  replacementMovedToBackup: boolean;
+  shimWritten: boolean;
+}
+
+function planGuardedRefreshTransaction(
+  files: readonly ShimFileState[],
+  expectedReplacements: ReadonlyMap<string, ShimPathFingerprint>,
+): GuardedRefreshOperation[] | null {
+  // BEFORE ANY rename/write: classify every changed sibling and fingerprint-check ALL
+  // expected source paths. Return null on any mismatch/ineligible branch.
+}
+
+function applyGuardedRefreshTransaction(
+  operations: readonly GuardedRefreshOperation[],
+): boolean {
+  // For each operation, recheck its source fingerprint immediately before mutation.
+  // Stage any prior backup and any wrapper that would be overwritten under unique
+  // transaction-owned names; move the replacement to backup; write the new shim; append
+  // every completed rename/write to the journal.
+  // On mismatch or failure, reverse the journal: remove the generated shim, move the
+  // replacement backup back to sourcePath, restore the staged wrapper, then restore the
+  // staged prior backup. Only after all siblings succeed may staged files be removed.
+  // Return false for a cleanly rolled-back mismatch; throw an AggregateError if apply or
+  // rollback has an unrecovered filesystem failure.
+}
+
+function installCodexShimInternal(
+  options: InstallCodexShimInternalOptions,
+): { installed: boolean; message: string } {
+  // Existing installCodexShim body. When expectedReplacements exists, build the complete
+  // operation list with planGuardedRefreshTransaction(), then apply it atomically through
+  // applyGuardedRefreshTransaction(). Never call the old sequential refresh loop, never
+  // write state before commit, and never enter fresh discovery when allowFreshInstall=false.
+}
+
+export function installCodexShim(): { installed: boolean; message: string } {
+  return installCodexShimInternal({ allowFreshInstall: true });
+}
+
+export function autoRestoreCodexShim(options: {
+  enabled: () => boolean;
+  nowMs?: number;
+}): CodexShimAutoRestoreResult {
+  const state = readState();
+  if (!state) return { status: "not-installed" };
+  if (state.platform !== process.platform) return { status: "ineligible" };
+
+  // Bounded marker/health probe. Return healthy without calling options.enabled().
+  // Require complete tracked state; collect all stable non-shim fingerprints.
+  // Return deferred before mutation if any changed sibling is young/changing.
+
+  if (!options.enabled()) return { status: "disabled" };
+  const result = installCodexShimInternal({
+    allowFreshInstall: false,
+    expectedReplacements,
+  });
+  return result.installed
+    ? { status: "restored", message: result.message }
+    : { status: "deferred" };
+}
+```
+
+Implementation constraint: fingerprint mismatch must be represented as a non-mutating deferred
+outcome, not be mistaken for “already installed.” A mismatch found after a sibling mutation must
+first restore every journaled sibling and the prior state bytes, then return deferred. Throw only for
+actual apply/rollback filesystem failures; the CLI boundary catches those.
+
+### `src/cli/codex-shim-autorestore.ts` — non-fatal policy boundary (NEW)
+
+Complete intended shape:
+
+```ts
+import { autoRestoreCodexShim } from "../codex/shim";
+import {
+  codexShimAutoRestoreEnabled,
+  readConfigDiagnostics,
+} from "../config";
+
+export interface CodexShimAutoRestoreCliDeps {
+  env: NodeJS.ProcessEnv;
+  warn: (message: string) => void;
+  restore: typeof autoRestoreCodexShim;
+  readConfig: typeof readConfigDiagnostics;
+}
+
+const DEFAULT_DEPS: CodexShimAutoRestoreCliDeps = {
+  env: process.env,
+  warn: message => console.warn(message),
+  restore: autoRestoreCodexShim,
+  readConfig: readConfigDiagnostics,
+};
+
+export function skipsCodexShimAutoRestore(command: string | undefined, args: string[]): boolean {
+  if (command === "uninstall" || command === "remove") return true;
+  return command === "codex-shim" && ["install", "uninstall", "remove"].includes(args[1] ?? "");
+}
+
+export function maybeAutoRestoreCodexShim(
+  command: string | undefined,
+  args: string[],
+  deps: CodexShimAutoRestoreCliDeps = DEFAULT_DEPS,
+): void {
+  if (skipsCodexShimAutoRestore(command, args)) return;
+  try {
+    const result = deps.restore({
+      enabled: () => codexShimAutoRestoreEnabled(deps.readConfig().config, deps.env),
+    });
+    if (result.status === "restored") {
+      deps.warn(`⚠️  ${result.message} (automatic repair after Codex update)`);
+    }
+  } catch (error) {
+    deps.warn(
+      `⚠️  Codex shim auto-restore failed; continuing without it: ${
+        error instanceof Error ? error.message : String(error)
+      }. Run 'ocx codex-shim install' after the Codex update finishes.`,
+    );
+  }
+}
+```
+
+The final warning text may be tightened, but it must remain secret-free, identify the manual fallback,
+and contain no stack, config contents, launcher contents, token, or account identifier.
+
+### `src/cli/index.ts` — hook
+
+Before (`src/cli/index.ts:39-60`, `src/cli/index.ts:540`):
+
+```ts
+import { maybeShowStarPrompt } from "./star-prompt";
+import { maybeShowUpdatePrompt } from "../update/notify";
+
+if (command !== undefined && command !== "help" && hasHelpFlag(args.slice(1))) {
+  printSubcommandUsage(command);
+  process.exit(0);
+}
+
+// ...
+switch (command) {
+```
+
+After:
+
+```ts
+import { maybeAutoRestoreCodexShim } from "./codex-shim-autorestore";
+import { maybeShowStarPrompt } from "./star-prompt";
+import { maybeShowUpdatePrompt } from "../update/notify";
+
+if (command !== undefined && command !== "help" && hasHelpFlag(args.slice(1))) {
+  printSubcommandUsage(command);
+  process.exit(0);
+}
+
+maybeAutoRestoreCodexShim(command, args);
+
+// ...
+switch (command) {
+```
+
+Do not put the hook before version/help exits: those paths currently terminate at
+`src/cli/index.ts:47-60` and should stay read-only/instant. Do not put it inside `handleStart()`; that
+would reduce coverage to the rejected start-only design.
+
+### Docs sketches
+
+Configuration row, translated equivalently in every docs-site locale:
+
+```md
+| `codexShimAutoRestore?` | `boolean` | `true` | Restore a previously installed Codex shim when a completed external Codex update replaces it. Set `false`, or set `OPENCODEX_CODEX_SHIM_AUTO_RESTORE=0` for a process-level opt-out. |
+```
+
+CLI/README behavior replacement:
+
+```md
+If a completed external Codex update overwrites an installed shim, the next ordinary `ocx` command
+backs up the new launcher and restores the shim. A launcher that is still changing is left untouched
+and retried on a later command. Failures warn without failing the requested command; manual fallback:
+`ocx codex-shim install`.
+```
+
+## Test plan
+
+### Focused unit and integration tests
+
+#### `tests/config.test.ts` (MODIFY)
+
+1. Default config contains `codexShimAutoRestore: true`.
+2. `codexShimAutoRestoreEnabled({})` and explicit `true` are enabled.
+3. Config `false` disables with env unset or `=1`.
+4. Env `OPENCODEX_CODEX_SHIM_AUTO_RESTORE=0` disables config unset/true.
+5. Invalid persisted values (`null`, `"false"`, `0`) fail diagnostics at
+   `codexShimAutoRestore`, matching current boolean validation tests at `tests/config.test.ts:106-134`.
+
+#### `tests/codex-shim.test.ts` (MODIFY)
+
+Use temp `PATH`/`OPENCODEX_HOME`, install through public `installCodexShim()`, and restore environment
+and files in `finally`, following the current real filesystem setup at
+`tests/codex-shim.test.ts:280-320`.
+
+1. Healthy installed shim -> `healthy`; `enabled()` is never called; wrapper/backup/state bytes and
+   mtimes do not change.
+2. Stable non-shim replacement (mtime/ctime beyond the 100 ms gate) -> `restored`; the replacement
+   becomes the backup and wrapper contains the marker.
+3. Just-written replacement -> `deferred`; no path changes. Age it, retry, then restore.
+4. Fingerprint mismatch before guarded rename -> `deferred`; no backup or wrapper mutation.
+5. **Mandatory transactional race — second sibling changes after the first is applied.** Name:
+   `test("multi-wrapper restore rolls back when a later sibling fingerprint changes", () => { ... })`.
+   Create stable changed `.cmd` and `.ps1` siblings and capture both fingerprints. Inject a narrow
+   filesystem seam/hook that changes the second sibling after the first sibling's guarded repair has
+   completed but before the second sibling's immediate pre-rename recheck. Assert result is
+   `deferred`; first and second wrapper bytes, both prior backup bytes, execute bits where relevant,
+   and state JSON are byte-for-byte/metadata-equivalent to their pre-transaction values; no staged
+   transaction path remains; no `restored` message is emitted. This activates mid-sequence rollback,
+   not only transaction-wide zero-mutation preflight.
+6. Missing backup, missing wrapper, corrupt state, directory/dangling symlink, and state platform
+   mismatch -> `ineligible`/`deferred`; never fresh-install.
+7. Windows CI verifies `.cmd`, `.ps1`, and extensionless tracked siblings restore as one transaction;
+   Unix CI verifies execute bit and symlink-target stability. WSL guard remains covered by existing
+   tests at `tests/codex-shim.test.ts:323-370`.
+
+#### `tests/codex-shim-autorestore.test.ts` (NEW)
+
+1. Helper skips top-level uninstall/remove and shim install/uninstall/remove; it does not skip
+   `codex-shim status` or ordinary commands.
+2. Injected `restore` throw -> exactly one warning with manual fallback; helper returns normally.
+3. Injected `restored` -> exactly one automatic-repair warning.
+4. Injected `healthy`, `not-installed`, `disabled`, or `deferred` -> no warning.
+5. Lazy config assertion: `readConfig` is not called when core reports healthy/not-installed.
+6. Spawned activation: install a temp shim, replace it with a stable real launcher, run the next
+   `ocx codex-shim status`, assert exit 0, repair warning on stderr, healthy shim status on stdout,
+   marker at wrapper, and new launcher bytes in backup.
+
+### Required activation scenarios
+
+| Scenario | Setup | Trigger | Required observation |
+| --- | --- | --- | --- |
+| Shim replaced by real Codex binary | Valid installed state; overwrite tracked wrapper(s) with stable non-shim launcher(s) | Next ordinary `ocx` command | Wrapper auto-restored before dispatch; new launcher backed up; one warning; requested command exits normally. |
+| Shim intact / zero-mutation overhead path | Valid healthy state | Any ordinary `ocx` command | Bounded state/prefix/metadata reads only; no config parse, rename, write, warning, subprocess, timer, or network. Typical probe <5 ms. |
+| Restore failure | Stable candidate; injected/real filesystem failure | Ordinary `ocx` command | Warning includes manual fallback; command's own output and exit status are unchanged. |
+| Opt-out set | Config false and, separately, env `=0` | Ordinary `ocx` command | Candidate remains untouched; no restore warning; explicit `ocx codex-shim install` still works. |
+| npm update in progress | Changed wrapper is too young or fingerprint changes | Ordinary `ocx` command | Silent defer; no rename/write; later command after stability restores. |
+
+### Performance proof
+
+Add a small focused benchmark script invocation to the implementation devlog (not a permanent timing
+assertion, which would be flaky in shared CI): create one Unix tracked wrapper or the three Windows
+tracked wrappers, warm the module, run the healthy probe 1,000 times, report median and p95 using
+`performance.now()`. Acceptance: median and p95 both `< 5 ms` on the maintainer test machine; no sample
+performs a write. Keep the permanent test structural: assert `enabled()`/config and repair paths are not
+called for healthy state.
+
+## Verification (C)
+
+Run in this order from repository root:
+
+```bash
+bun test --isolate tests/config.test.ts tests/codex-shim.test.ts tests/codex-shim-autorestore.test.ts
+bun run typecheck
+bun run test
+bun run privacy:scan
+```
+
+Expected: every command exits `0`; full tests report zero failures; privacy scan reports no credential,
+personal-path, token, or account leakage. Also run the focused healthy-probe benchmark above on at least
+one Unix host and use Cross-platform CI for Windows behavior. Do not claim cross-platform completion
+from a macOS-only local run.
+
+## Security-review checkpoint
+
+This checkpoint is mandatory before merge under `MAINTAINERS.md:22-25`.
+
+### Threat model
+
+- Assets: the real Codex launcher, OpenCodex-owned launcher backup, shim state, nearby OpenCodex config
+  directory, and credentials stored separately under that directory.
+- Entrypoints: external npm launcher replacement, ordinary CLI startup, persisted config flag, env
+  opt-out, and state JSON read from disk.
+- Attacker/failure capabilities: interrupted or concurrent npm update; local process modifying tracked
+  paths/state; symlink swap; concurrent `ocx` commands; malformed state; filesystem permission error.
+- Trust boundary: filesystem contents and environment are runtime inputs. Auto-restore may mutate only
+  paths already recorded by a valid prior shim install; it must not rediscover arbitrary PATH targets.
+- Blast radius: tracked Codex launcher and owned backup only. No auth/account/token file may be read,
+  written, serialized, or logged.
+
+### Must-pass reviewer checks
+
+- [ ] Auto-restore requires valid prior state, same platform, complete backups, stable fingerprints,
+      and at least one tracked non-shim; it cannot fresh-install.
+- [ ] All sibling fingerprints are revalidated before any mutation; a preflight mismatch causes zero
+      mutation.
+- [ ] Each sibling is revalidated again immediately before its first rename; a later mismatch rolls
+      back already-mutated siblings, leaves state unchanged, and returns `deferred`.
+- [ ] Symlink target must be a stable non-empty regular file; no directory/dangling-link traversal.
+- [ ] Existing single-path rollback in `replaceOwnedBackup()` remains intact for manual install, and
+      guarded auto-restore adds transaction-wide reverse-order sibling rollback.
+- [ ] Windows `.exe` refusal and WSL interop guard remain intact (`src/codex/shim.ts:132-207`).
+- [ ] Startup opt-out uses `readConfigDiagnostics()`, not `loadConfig()`, and never opens `auth.json`.
+- [ ] Warning/error strings contain status and path-safe context only; no file contents, env dump,
+      stack, token, account id, request body, or credential identifier.
+- [ ] `OPENCODEX_CODEX_SHIM_AUTO_RESTORE=0` and config false prevent automatic writes but do not weaken
+      explicit install/uninstall semantics.
+- [ ] `bun run privacy:scan`, focused negative tests, full tests, and Cross-platform CI are green.
+
+## Acceptance checklist
+
+- [ ] The chosen hook is before ordinary CLI dispatch and after help/version exits.
+- [ ] Healthy/not-installed probes are bounded, read-only, lazy-config, and <5 ms typical.
+- [ ] Stable external update replacement is restored through the same internal transaction used by
+      `ocx codex-shim install`.
+- [ ] Partial/changing update, race, or failure never breaks the requested command.
+- [ ] Config and env opt-outs are typed, documented, and tested.
+- [ ] macOS/Linux/Windows/Git-Bash/WSL guards are preserved.
+- [ ] Issue #320 part 1 remains untouched and documented as upstream/out of scope.
+- [ ] Runtime SOT, all root README locales, and all docs-site CLI/config locales agree.
+- [ ] Explicit security review is recorded before merge.

--- a/devlog/_plan/260724_bugfix_train/040_ux_discovery_badge.md
+++ b/devlog/_plan/260724_bugfix_train/040_ux_discovery_badge.md
@@ -1,0 +1,817 @@
+# 040 — Cycle 4: discovery failure visibility and honest helper fallback copy
+
+> DIFFLEVEL-ROADMAP-01: this is the implementation SSOT for Cycle 4 of
+> `260724_bugfix_train`. Re-verify every cited line against the cycle-start SHA before B;
+> do not implement from the issue summaries alone.
+
+## Loop spec
+
+- **Loop archetype:** verifier-defined, spec-satisfaction repair.
+- **Trigger:** issue #329's core zero-model grouping/manual-add repair is present, but
+  live discovery failures such as HTTP 401 remain log-only; issue #331's empty
+  `smallFastModel` runtime behavior leaves both helper overrides unset while the GUI says
+  “Claude default (Haiku).”
+- **Goal / user-visible outcome:** an active provider whose latest live model discovery
+  failed exposes a safe machine-readable reason through `GET /api/providers`; when that
+  provider has no model rows, Models shows a compact failure badge and reason beside the
+  existing recovery guidance. The Claude page accurately says that an unset helper model
+  delegates selection to Claude Code and warns that native Sonnet usage may incur native
+  provider cost.
+- **Non-goals:** no retry button, no new discovery request, no persistence of transient
+  discovery state, no upstream response body/status-text exposure, no routing or fallback
+  behavior change, no provider editor redesign, no broad Claude settings redesign, and no
+  #337 auto-switch takeover work.
+- **Verifier:** `bun run typecheck`, `bun run test`, `bun run lint:gui`,
+  `bun run build:gui`, and `bun run privacy:scan` must each exit 0. Focused tests prove
+  the status contract and both conditional UI states. A real Vite render and observed
+  screenshot prove the empty-provider badge is visible and legible.
+- **Stop condition:** stop only when the 401, successful discovery, helper-unset, and
+  helper-set activation scenarios below pass; all five repository gates pass; the Vite
+  screenshot has been opened and observed; docs/locales agree; and the final diff still
+  avoids #337's changed keys and CSS hunks.
+- **Memory artifact:** this document, later moved by the parent workflow to the unit's
+  `_fin/` location with C/D evidence. The delegated writer does not operate parent loop or
+  goal state.
+- **Expected terminal outcomes:** `DONE`; `BLOCKED` if a required existing seam cannot
+  represent last-attempt status without changing discovery semantics; `NEEDS_HUMAN` if
+  product owners reject the native-Sonnet/cost wording.
+- **Escalation:** upward to the parent before expanding the API beyond an additive optional
+  field, exposing provider-controlled text, touching auth/token material, altering runtime
+  selection, or editing a #337-owned key/hunk. No downward delegation is planned; any such
+  delegation is a P-phase amendment owned by the parent, not a B-phase improvisation.
+
+## Grounding and necessity gate
+
+Cycle-start base is `origin/dev` / `d9e06c8dd08df6635f5ca042bf6aa469fe1a10a8`.
+
+- `src/codex/catalog/provider-fetch.ts:207-388` owns live discovery, fallback, cooldown
+  activation, logs, and successful cache writes. HTTP non-OK is reduced to a warning at
+  `:307-313`; valid discovery is cached at `:343-380`.
+- `src/codex/model-cache.ts:20-61` already owns per-provider cache and failed-fetch
+  cooldown lifecycle. `clearModelCache()` is therefore the correct owner for clearing the
+  associated last-attempt diagnostic; a second independent map module would drift.
+- `src/server/management/provider-routes.ts:71-81` builds the additive provider DTO.
+- `gui/src/models-groups.ts:1-53` is the pure join between `/api/providers` and model rows;
+  configured zero-row providers are retained at `:29-37`.
+- `gui/src/pages/Models.tsx:180-224` loads both endpoints; `:729-795` renders groups and
+  passes empty providers to `EmptyProviderHint`; `:1111-1121` owns the current generic
+  guidance and is the smallest render seam. Because the current `Promise.all` starts
+  `/api/models` and `/api/providers` concurrently, the provider DTO can win the race before
+  discovery records its result; order the DTO read after the model read so the first render
+  is grounded in the attempt it displays.
+- `src/claude/context-windows.ts:152-173` proves `tierModels.haiku ?? smallFastModel` is
+  written to both helper env variables only when non-empty. Existing runtime regression
+  coverage includes the unset case at `tests/claude-cli.test.ts:214`.
+- `gui/src/pages/ClaudeCode.tsx:141-144` labels the empty option with
+  `claude.slotUnset`; `:348-356` renders the misleading helper copy and picker.
+- The six GUI dictionaries are type-locked by English `TKey` through
+  `gui/src/i18n/shared.ts:1-12`; every new English key must be added to de/ja/ko/ru/zh.
+- Existing `.badge`, `.badge-amber`, and `.notice-warn` rules at
+  `gui/src/styles.css:498-502,730-731` satisfy the visual need. Reuse them; do not add or
+  edit CSS.
+
+No-code options rejected: doing nothing leaves #329 log-only and #331 factually wrong;
+configuration cannot surface a runtime HTTP result; deleting copy would hide the cost
+consequence; reusing only the generic empty hint cannot distinguish an authoritative empty
+catalog from a failed request. The plan reuses the model-cache lifecycle, provider DTO,
+grouping seam, existing badge/warning classes, and existing i18n system; it introduces no
+dependency or background polling.
+
+## Scope
+
+### IN
+
+1. Ephemeral last-attempt discovery status in the model-cache lifecycle.
+2. Additive optional discovery metadata on each `GET /api/providers` row.
+3. Empty-provider failure badge/reason in Models, with successful/unknown/static states
+   retaining the current non-error guidance.
+4. Accurate helper description, unset-option label, and conditional native Sonnet/cost
+   warning in all six GUI locales.
+5. English plus all existing translated Claude Code guides kept semantically aligned.
+6. Focused backend/API/SSR tests, full gates, and a real rendered screenshot observation.
+
+### OUT
+
+- Discovery retries, timestamps, history, telemetry, disk persistence, status for disabled
+  or forward-auth providers, and showing a badge when stale/static rows are already present.
+- Any raw response body, URL, API key, account identifier, `statusText`, or thrown message in
+  the API/UI.
+- Changes to `src/claude/context-windows.ts` or Claude Code's actual model choice.
+- Changes to provider setup, account auto-switch, global visual tokens, or release files.
+
+## API contract
+
+`GET /api/providers` remains an array of provider rows. Add one optional field:
+
+```ts
+export type ProviderModelDiscoveryFailureReason =
+  | "http"
+  | "blocked"
+  | "invalid_response"
+  | "network"
+  | "provider";
+
+export type ProviderModelDiscoveryStatus =
+  | { status: "ok" }
+  | {
+      status: "failed";
+      reason: ProviderModelDiscoveryFailureReason;
+      httpStatus?: number;
+    };
+
+// GET /api/providers row (new field only)
+{
+  name: "example",
+  // ...existing fields unchanged...
+  discovery?: ProviderModelDiscoveryStatus
+}
+```
+
+Example 401 row:
+
+```json
+{
+  "name": "example",
+  "liveModels": true,
+  "models": [],
+  "discovery": {
+    "status": "failed",
+    "reason": "http",
+    "httpStatus": 401
+  }
+}
+```
+
+Contract rules:
+
+- `status: "ok"` means the most recent attempted live discovery returned a valid models
+  payload, including an authoritative empty array. It does not promise that models exist.
+- `status: "failed"` means the most recent attempted live discovery took a fallback path.
+  `httpStatus` is present only for `reason: "http"` and is the integer HTTP status.
+- No status exists before an attempt or for paths that intentionally do not discover
+  (`liveModels: false`, forward auth, or OAuth without a token). Because object properties
+  with `undefined` are omitted by JSON serialization, old consumers receive their existing
+  row shape plus, at most, an unknown additive field.
+- Cache hits/cooldown reads preserve the last attempted status. A later valid live response
+  replaces `failed` with `ok`. `clearModelCache(provider)` and global clear remove both cache
+  and status, preventing a provider edit from retaining stale diagnostics.
+- `reason` is a closed server-owned code. The UI localizes it; it never parses or displays
+  a provider-controlled message. For issue #329 the visible detail is derived as `HTTP 401`.
+
+## Exact change map
+
+### Backend and management API
+
+#### MODIFY `src/codex/model-cache.ts`
+
+Before:
+
+```ts
+const cache = new Map<string, CacheEntry>();
+const failureAt = new Map<string, number>();
+
+export function markModelsFetchFailure(provider: string, now = Date.now()): void {
+  failureAt.set(provider, now);
+}
+
+export function clearModelCache(provider?: string): void {
+  if (provider) {
+    cache.delete(provider);
+    failureAt.delete(provider);
+  } else {
+    cache.clear();
+    failureAt.clear();
+  }
+}
+```
+
+After:
+
+```ts
+export type ProviderModelDiscoveryFailureReason =
+  | "http" | "blocked" | "invalid_response" | "network" | "provider";
+
+export type ProviderModelDiscoveryStatus =
+  | { status: "ok" }
+  | { status: "failed"; reason: ProviderModelDiscoveryFailureReason; httpStatus?: number };
+
+const discoveryStatus = new Map<string, ProviderModelDiscoveryStatus>();
+
+export function markProviderDiscoveryOk(provider: string): void {
+  discoveryStatus.set(provider, { status: "ok" });
+}
+
+export function markProviderDiscoveryFailed(
+  provider: string,
+  failure: Omit<Extract<ProviderModelDiscoveryStatus, { status: "failed" }>, "status">,
+): void {
+  discoveryStatus.set(provider, { status: "failed", ...failure });
+}
+
+export function getProviderDiscoveryStatus(
+  provider: string,
+): ProviderModelDiscoveryStatus | undefined {
+  return discoveryStatus.get(provider);
+}
+
+// Existing cache/failureAt clearing remains, plus discoveryStatus delete/clear.
+```
+
+Keep `markModelsFetchFailure(provider, now?)` unchanged for cooldown compatibility. Do not
+make `setCached()` imply discovery success because tests and non-fetch callers seed cache
+entries directly.
+
+#### MODIFY `src/codex/catalog/provider-fetch.ts`
+
+Extend the existing model-cache import with
+`markProviderDiscoveryOk` and `markProviderDiscoveryFailed`.
+
+Before:
+
+```ts
+const failedDiscoveryFallback = (): { models: CatalogModel[]; fallback: "stale" | "configured" } => {
+  markModelsFetchFailure(name);
+  // ...
+};
+
+if (!res.ok) {
+  const { models, fallback } = failedDiscoveryFallback();
+  // log only
+  return models;
+}
+
+setCached(name, live);
+return live;
+```
+
+After:
+
+```ts
+type DiscoveryFailure = Omit<
+  Extract<ProviderModelDiscoveryStatus, { status: "failed" }>,
+  "status"
+>;
+
+const failedDiscoveryFallback = (
+  failure: DiscoveryFailure,
+): { models: CatalogModel[]; fallback: "stale" | "configured" } => {
+  markModelsFetchFailure(name);
+  markProviderDiscoveryFailed(name, failure);
+  // existing stale/configured fallback is byte-for-byte unchanged
+};
+
+if (!res.ok) {
+  const { models, fallback } = failedDiscoveryFallback({
+    reason: "http",
+    httpStatus: res.status,
+  });
+  // existing sanitized warning remains
+  return models;
+}
+
+markProviderDiscoveryOk(name);
+setCached(name, live);
+return live;
+```
+
+Use the same helper for every generic failure path:
+
+| Existing branch | Recorded failure |
+|---|---|
+| destination-policy rejection (`:295-305`) | `{ reason: "blocked" }` |
+| HTTP non-OK (`:307-314`) | `{ reason: "http", httpStatus: res.status }` |
+| invalid JSON 2xx (`:316-332`) | `{ reason: "invalid_response" }` |
+| malformed `data` 2xx (`:333-342`) | `{ reason: "invalid_response" }` |
+| thrown fetch/timeout (`:381-387`) | `{ reason: "network" }` |
+| Cursor `liveResult.ok === false` (`:249-261`) | `{ reason: "provider" }` |
+
+Call `markProviderDiscoveryOk(name)` in both successful live seams: Cursor immediately
+before its `setCached(name, result)` and generic discovery immediately before
+`setCached(name, live)`. Do not mark static, forward-auth, missing-token, fresh-cache, or
+cooldown-only returns as newly successful; they did not perform an attempt.
+
+#### MODIFY `src/server/management/provider-routes.ts`
+
+Import `getProviderDiscoveryStatus` from `../../codex/model-cache` and append one property
+to the existing DTO at `:72-81`:
+
+```ts
+return jsonResponse(Object.entries(config.providers).map(([name, p]) => ({
+  // existing fields unchanged
+  codexAccountMode: providerCodexAccountMode(name, p),
+  discovery: getProviderDiscoveryStatus(name),
+})));
+```
+
+Do not trigger discovery from this route. The Models implementation below orders
+`/api/providers` after `/api/models` on each existing load (`gui/src/pages/Models.tsx:180-219`),
+so the route reports the completed fetch lifecycle rather than duplicating it.
+
+#### MODIFY `tests/codex-catalog.test.ts`
+
+- Extend the existing HTTP non-OK case at `:1567-1594` to use 401 and assert
+  `getProviderDiscoveryStatus(provider)` equals
+  `{ status: "failed", reason: "http", httpStatus: 401 }` while configured fallback rows
+  remain unchanged.
+- Extend a valid live-discovery case (the private-network opt-in case at `:1460-1485` is
+  suitable) to assert `{ status: "ok" }`.
+- Retain the existing sanitized-log assertions. Cleanup continues through
+  `clearModelCache(provider)`, now also proving status isolation between tests.
+
+#### MODIFY `tests/management-provider-validation.test.ts`
+
+Add a direct management contract test using the existing `handleManagementAPI` seam:
+
+```ts
+markProviderDiscoveryFailed("auth-broken", { reason: "http", httpStatus: 401 });
+const response = await handleManagementAPI(
+  new Request("http://127.0.0.1/api/providers"),
+  new URL("http://127.0.0.1/api/providers"),
+  { providers: { "auth-broken": providerFixture } },
+);
+expect(await response!.json()).toContainEqual(expect.objectContaining({
+  name: "auth-broken",
+  discovery: { status: "failed", reason: "http", httpStatus: 401 },
+}));
+```
+
+Also include an unattempted provider and assert it has no own `discovery` property after
+JSON serialization. Clear status in `finally` with `clearModelCache()`.
+
+### Models GUI
+
+#### MODIFY `gui/src/models-groups.ts`
+
+Before, `ConfiguredProviderSummary` and `ProviderModelGroup` carry only live/static model
+metadata. After, add the API union and thread it through the pure join:
+
+```ts
+export type ProviderDiscoverySummary =
+  | { status: "ok" }
+  | {
+      status: "failed";
+      reason: "http" | "blocked" | "invalid_response" | "network" | "provider";
+      httpStatus?: number;
+    };
+
+export interface ConfiguredProviderSummary {
+  // existing fields
+  discovery?: ProviderDiscoverySummary;
+}
+
+export interface ProviderModelGroup<Row> {
+  // existing fields
+  discovery?: ProviderDiscoverySummary;
+}
+
+// map result
+discovery: configured?.discovery,
+```
+
+No new client fetch, store, parser, or component-level status map.
+
+#### MODIFY `gui/src/pages/Models.tsx`
+
+Make the load order explicit. Keep `/api/models` and context caps parallel, then read
+`/api/providers` only after `/api/models` has completed and recorded discovery status:
+
+```ts
+const [data, capsData] = await Promise.all([
+  fetch(`${apiBase}/api/models`).then(r => r.json()) as Promise<ModelRow[]>,
+  fetch(`${apiBase}/api/provider-context-caps`).then(r => r.json())
+    as Promise<ProviderContextCapsResponse>,
+]);
+const providerData = await fetch(`${apiBase}/api/providers`)
+  .then(r => r.json()) as ConfiguredProviderSummary[];
+```
+
+This changes request ordering only; it adds no request, retry, or timer. Retain the existing
+ten-second refresh and busy guard. The ordering is required so a first-load 401 reaches the
+same render rather than waiting for the next poll.
+
+Destructure `discovery` from each group and pass it only to the zero-row hint:
+
+```tsx
+groups.map(({ provider, rows, native: isNative, liveModels, discovery }) => {
+  // ...
+  {rows.length === 0 && (
+    <EmptyProviderHint liveModels={liveModels} discovery={discovery} />
+  )}
+})
+```
+
+Before:
+
+```tsx
+export function EmptyProviderHint({ liveModels }: { liveModels: boolean }) {
+  // generic status row only
+}
+```
+
+After:
+
+```tsx
+export function EmptyProviderHint({
+  liveModels,
+  discovery,
+}: {
+  liveModels: boolean;
+  discovery?: ProviderDiscoverySummary;
+}) {
+  const t = useT();
+  const failed = liveModels && discovery?.status === "failed";
+  const reason = !failed
+    ? ""
+    : discovery.reason === "http" && discovery.httpStatus !== undefined
+      ? t("models.discoveryFailedHttp", { status: discovery.httpStatus })
+      : discovery.reason === "blocked"
+        ? t("models.discoveryFailedBlocked")
+        : discovery.reason === "invalid_response"
+          ? t("models.discoveryFailedInvalidResponse")
+          : discovery.reason === "network"
+            ? t("models.discoveryFailedNetwork")
+            : discovery.reason === "provider"
+              ? t("models.discoveryFailedProvider")
+              : t("models.discoveryFailedGeneric");
+
+  return (
+    <div className="row muted text-label leading-body" role="status" /* existing layout */>
+      <IconInfo /* existing accessible decoration */ />
+      <span>
+        {failed && (
+          <span className="badge badge-amber">{t("models.discoveryFailedBadge")}</span>
+        )}
+        {failed ? `${reason} ` : t(liveModels
+          ? "models.emptyDiscovery"
+          : "models.emptyDiscoveryDisabled") + " "}
+        <a href="#providers">{t("models.openProviderSettings")}</a>
+      </span>
+    </div>
+  );
+}
+```
+
+Keep failure meaning in text as well as color. Use existing `.badge badge-amber`; **no
+`gui/src/styles.css` change**. Exact JSX spacing may use nested spans rather than string
+concatenation, but rendered text and accessible order must be: badge → reason → settings
+link. An `ok` or absent discovery status renders no badge.
+
+#### MODIFY `gui/tests/models-empty-provider.test.tsx`
+
+Change `renderHint` to accept optional `ProviderDiscoverySummary`, then cover:
+
+1. `liveModels=true` + failed/http/401 renders `Discovery failed`, `HTTP 401`, existing
+   settings link, `badge badge-amber`, and `role="status"`.
+2. `liveModels=true` + `{ status: "ok" }` renders existing generic empty guidance and no
+   failure badge.
+3. Existing `liveModels=false` test remains and renders no failure badge even if no status
+   exists.
+
+#### MODIFY `tests/models-page-groups.test.ts`
+
+Extend the configured zero-row provider fixture with a failed discovery object and assert
+the resulting group preserves it. This prevents the API metadata from being dropped at the
+pure grouping seam.
+
+### Claude helper UX
+
+#### MODIFY `gui/src/pages/ClaudeCode.tsx`
+
+Replace the helper-only use of the misleading old keys with new keys; keep the old keys in
+dictionaries for compatibility and to avoid #337-adjacent edits.
+
+Extract a focused render seam:
+
+```tsx
+export function SmallFastModelSetting({
+  value,
+  options,
+  onChange,
+}: {
+  value: string;
+  options: SelectOption[];
+  onChange: (value: string) => void;
+}) {
+  const t = useT();
+  return (
+    <>
+      <div className="h-section">{t("claude.smallFastModel")}</div>
+      <p className="muted text-label" style={{ margin: "0 0 8px" }}>
+        {t("claude.smallFastModelAccurateHint")}
+      </p>
+      <Select value={value} options={options} onChange={onChange}
+        label={t("claude.smallFastModel")} style={{ maxWidth: 420 }} />
+      {value === "" && (
+        <p className="notice-warn" role="note" style={{ marginTop: 8 }}>
+          {t("claude.smallFastModelNativeWarning")}
+        </p>
+      )}
+    </>
+  );
+}
+```
+
+Import `SelectOption` as a type from `../ui`. Build the empty option with the new key:
+
+```ts
+return [
+  { value: "", label: t("claude.smallFastModelUnsetOption") },
+  ...options,
+];
+```
+
+Replace `:348-356` with `SmallFastModelSetting`. The callback remains exactly
+`smallFastModel => setState({ ...state, smallFastModel })`; saving and runtime behavior are
+unchanged. A selected value hides only the warning, not the accurate neutral description.
+
+#### NEW `gui/tests/claude-code-background-helper.test.tsx`
+
+Use `renderToStaticMarkup` + `LanguageProvider`, matching
+`gui/tests/claude-code-autoconnect.test.tsx:1-31`.
+
+- Unset (`value=""`): rendered selected label says “Let Claude Code choose (native
+  model)”; neutral description is present; warning says native Sonnet may be used and may
+  incur provider charges; `role="note"` is present.
+- Set (`value="gemini/gemini-3-flash"`): selected routed model remains visible; neutral
+  description remains; native Sonnet/cost warning and `role="note"` are absent.
+
+The runtime no-override behavior is already asserted at `tests/claude-cli.test.ts:214`; run
+that file in focused C rather than duplicating the same backend assertion in a GUI test.
+
+### GUI locale additions — six files, new keys only
+
+#### MODIFY `gui/src/i18n/en.ts`
+
+```ts
+"models.discoveryFailedBadge": "Discovery failed",
+"models.discoveryFailedHttp": "Model discovery failed (HTTP {status}).",
+"models.discoveryFailedBlocked": "Model discovery was blocked by the destination policy.",
+"models.discoveryFailedInvalidResponse": "Model discovery returned an invalid response.",
+"models.discoveryFailedNetwork": "Model discovery failed due to a network error.",
+"models.discoveryFailedProvider": "The provider reported a model discovery error.",
+"models.discoveryFailedGeneric": "Model discovery failed.",
+"claude.smallFastModelAccurateHint": "The model Claude Code uses for background work such as chat summaries and topic detection. The haiku subagent alias uses it too.",
+"claude.smallFastModelUnsetOption": "Let Claude Code choose (native model)",
+"claude.smallFastModelNativeWarning": "When unset, OpenCodex leaves the helper-model overrides unset. Claude Code may use its native Sonnet model, which may incur charges from your native provider.",
+```
+
+#### MODIFY `gui/src/i18n/de.ts`
+
+```ts
+"models.discoveryFailedBadge": "Erkennung fehlgeschlagen",
+"models.discoveryFailedHttp": "Die Modellerkennung ist fehlgeschlagen (HTTP {status}).",
+"models.discoveryFailedBlocked": "Die Modellerkennung wurde durch die Zielrichtlinie blockiert.",
+"models.discoveryFailedInvalidResponse": "Die Modellerkennung lieferte eine ungültige Antwort.",
+"models.discoveryFailedNetwork": "Die Modellerkennung ist an einem Netzwerkfehler gescheitert.",
+"models.discoveryFailedProvider": "Der Anbieter meldete einen Fehler bei der Modellerkennung.",
+"models.discoveryFailedGeneric": "Die Modellerkennung ist fehlgeschlagen.",
+"claude.smallFastModelAccurateHint": "Das Modell, das Claude Code für Hintergrundaufgaben wie Chat-Zusammenfassungen und Themenerkennung verwendet. Auch der haiku-Alias der Subagenten nutzt es.",
+"claude.smallFastModelUnsetOption": "Claude Code wählen lassen (natives Modell)",
+"claude.smallFastModelNativeWarning": "Wenn kein Modell gewählt ist, setzt OpenCodex keine Hilfsmodell-Overrides. Claude Code kann dann sein natives Sonnet-Modell verwenden, wodurch Kosten bei deinem nativen Anbieter entstehen können.",
+```
+
+#### MODIFY `gui/src/i18n/ja.ts`
+
+```ts
+"models.discoveryFailedBadge": "検出に失敗",
+"models.discoveryFailedHttp": "モデル検出に失敗しました（HTTP {status}）。",
+"models.discoveryFailedBlocked": "モデル検出は宛先ポリシーによりブロックされました。",
+"models.discoveryFailedInvalidResponse": "モデル検出が無効な応答を返しました。",
+"models.discoveryFailedNetwork": "ネットワークエラーによりモデル検出に失敗しました。",
+"models.discoveryFailedProvider": "プロバイダーがモデル検出エラーを報告しました。",
+"models.discoveryFailedGeneric": "モデル検出に失敗しました。",
+"claude.smallFastModelAccurateHint": "チャットの要約やトピック検出など、Claude Code がバックグラウンド処理に使うモデルです。サブエージェントの haiku エイリアスもこのモデルを使います。",
+"claude.smallFastModelUnsetOption": "Claude Code に選択させる（ネイティブモデル）",
+"claude.smallFastModelNativeWarning": "未設定の場合、OpenCodex はヘルパーモデルの上書きを設定しません。Claude Code がネイティブの Sonnet モデルを使用し、ネイティブプロバイダーで料金が発生する可能性があります。",
+```
+
+#### MODIFY `gui/src/i18n/ko.ts`
+
+```ts
+"models.discoveryFailedBadge": "검색 실패",
+"models.discoveryFailedHttp": "모델 검색에 실패했습니다(HTTP {status}).",
+"models.discoveryFailedBlocked": "대상 정책 때문에 모델 검색이 차단되었습니다.",
+"models.discoveryFailedInvalidResponse": "모델 검색이 잘못된 응답을 받았습니다.",
+"models.discoveryFailedNetwork": "네트워크 오류로 모델 검색에 실패했습니다.",
+"models.discoveryFailedProvider": "프로바이더가 모델 검색 오류를 보고했습니다.",
+"models.discoveryFailedGeneric": "모델 검색에 실패했습니다.",
+"claude.smallFastModelAccurateHint": "Claude Code가 대화 요약, 주제 감지 같은 백그라운드 작업에 쓰는 모델입니다. 서브에이전트의 haiku 별칭도 이 모델을 사용합니다.",
+"claude.smallFastModelUnsetOption": "Claude Code가 선택(네이티브 모델)",
+"claude.smallFastModelNativeWarning": "비워 두면 OpenCodex가 보조 모델 환경 변수를 설정하지 않습니다. Claude Code가 네이티브 Sonnet 모델을 사용할 수 있으며, 네이티브 프로바이더 요금이 발생할 수 있습니다.",
+```
+
+#### MODIFY `gui/src/i18n/ru.ts`
+
+```ts
+"models.discoveryFailedBadge": "Ошибка обнаружения",
+"models.discoveryFailedHttp": "Не удалось обнаружить модели (HTTP {status}).",
+"models.discoveryFailedBlocked": "Обнаружение моделей заблокировано политикой назначения.",
+"models.discoveryFailedInvalidResponse": "Обнаружение моделей вернуло недопустимый ответ.",
+"models.discoveryFailedNetwork": "Обнаружение моделей не удалось из-за сетевой ошибки.",
+"models.discoveryFailedProvider": "Провайдер сообщил об ошибке обнаружения моделей.",
+"models.discoveryFailedGeneric": "Не удалось обнаружить модели.",
+"claude.smallFastModelAccurateHint": "Модель, которую Claude Code использует для фоновых задач, например суммаризации чатов и определения тем. Её также использует алиас подагента haiku.",
+"claude.smallFastModelUnsetOption": "Разрешить Claude Code выбрать нативную модель",
+"claude.smallFastModelNativeWarning": "Если модель не выбрана, OpenCodex не задаёт переопределения вспомогательной модели. Claude Code может использовать нативную модель Sonnet, что может привести к расходам у вашего нативного провайдера.",
+```
+
+#### MODIFY `gui/src/i18n/zh.ts`
+
+```ts
+"models.discoveryFailedBadge": "发现失败",
+"models.discoveryFailedHttp": "模型发现失败（HTTP {status}）。",
+"models.discoveryFailedBlocked": "模型发现被目标策略阻止。",
+"models.discoveryFailedInvalidResponse": "模型发现返回了无效响应。",
+"models.discoveryFailedNetwork": "由于网络错误，模型发现失败。",
+"models.discoveryFailedProvider": "提供方报告了模型发现错误。",
+"models.discoveryFailedGeneric": "模型发现失败。",
+"claude.smallFastModelAccurateHint": "Claude Code 用于聊天摘要、主题识别等后台工作的模型。子代理的 haiku 别名也使用此模型。",
+"claude.smallFastModelUnsetOption": "让 Claude Code 选择（原生模型）",
+"claude.smallFastModelNativeWarning": "留空时，OpenCodex 不会设置辅助模型覆盖项。Claude Code 可能使用其原生 Sonnet 模型，并可能产生原生提供方费用。",
+```
+
+Do not edit or delete existing `claude.smallFastModelHint` or `claude.slotUnset`; only this
+component stops rendering them. Add the three `models.*` keys beside existing empty-discovery
+keys and the three `claude.*` keys beside existing small-fast keys in every dictionary.
+
+### Documentation sync
+
+The runtime behavior does not change, but the user-facing meaning of “unset” is materially
+corrected. AGENTS.md requires user-facing behavior documentation not to contradict the GUI,
+so docs sync is **IN**. Add one sentence after each guide's effective-Haiku paragraph saying:
+when both `tierModels.haiku` and `smallFastModel` are absent, OpenCodex leaves both helper
+variables unset; Claude Code then chooses its native helper model (currently Sonnet), which
+may incur native-provider charges.
+
+#### MODIFY
+
+- `docs-site/src/content/docs/guides/claude-code.md`
+- `docs-site/src/content/docs/ko/guides/claude-code.md`
+- `docs-site/src/content/docs/zh-cn/guides/claude-code.md`
+- `docs-site/src/content/docs/ja/guides/claude-code.md`
+- `docs-site/src/content/docs/ru/guides/claude-code.md`
+
+There is no German docs locale in this repository; do not create one in this bugfix cycle.
+Keep the five existing guide locales semantically equivalent. No Models-page guide change is
+needed because the API field is additive and the existing recovery action remains provider
+settings/manual model addition.
+
+### Planning artifact rename
+
+- **NEW** `devlog/_plan/260724_bugfix_train/040_ux_discovery_badge.md` — this document.
+- **DELETE** `devlog/_plan/260724_bugfix_train/040_phase4.md` — empty scaffold replaced by
+  the diff-level named phase document.
+
+## #337 collision proof and landing discipline
+
+Live command used on 2026-07-24:
+
+```bash
+gh pr diff 337 --repo lidge-jun/opencodex --name-only
+gh pr diff 337 --repo lidge-jun/opencodex \
+  | rg '^diff --git|^@@|^[+-]  "[^"]+"'
+```
+
+Observed #337 GUI ownership:
+
+- files: `gui/src/components/CodexAccountPool.tsx`, `gui/src/codex-auto-switch.ts`, all
+  six `gui/src/i18n/*.ts`, `gui/src/styles.css`, and
+  `gui/tests/codex-account-auto-switch.test.tsx`;
+- i18n hunk namespace: existing/new `codexAuth.autoSwitch*` keys plus
+  `codexAuth.loadFailed` only (en hunk near line 896; analogous locale hunks);
+- CSS hunks: additions near current lines 727 and 959 for `.toggle:disabled` and
+  `.codex-auto-switch-*` rules;
+- docs: localized `guides/web-dashboard.md`, not `guides/claude-code.md`.
+
+Cycle 4 overlaps #337 only at the six locale **files**, not at keys or hunks. Cycle 4 adds
+only these namespaces/keys:
+
+```text
+models.discoveryFailedBadge
+models.discoveryFailedHttp
+models.discoveryFailedGeneric
+claude.smallFastModelAccurateHint
+claude.smallFastModelUnsetOption
+claude.smallFastModelNativeWarning
+```
+
+They are inserted beside `models.emptyDiscovery*` and `claude.smallFastModel*`, never in
+the `codexAuth.*` hunk. Cycle 4 does not touch `CodexAccountPool.tsx`,
+`codex-auto-switch.ts`, the auto-switch test, or `styles.css`; it reuses existing badge and
+warning classes. Its docs files are `guides/claude-code.md`, disjoint from #337's
+`guides/web-dashboard.md`. Before commit, rerun both diff commands and fail the cycle if
+#337 has expanded into any listed Cycle 4 key, component, test, or docs hunk.
+
+## Activation scenarios and test matrix
+
+| Scenario | Trigger | Required observation |
+|---|---|---|
+| Failed discovery 401 | Live provider `/models` returns HTTP 401 with no stale/configured rows | `getProviderDiscoveryStatus` and `/api/providers` expose `failed/http/401`; Models retains the provider, renders `Discovery failed` + `HTTP 401` badge/warning + settings link |
+| Destination blocked | `providerDestinationResolvedError` rejects a public-discovery fixture before `fetch` | status and `/api/providers` expose `failed/blocked` with no `httpStatus`; fetch is not called; empty provider renders failure badge + localized blocked reason + settings link |
+| Invalid response | Table-driven 2xx fixtures: invalid JSON and valid JSON whose `data` is missing/malformed | each subcase exposes `failed/invalid_response` with no `httpStatus`; fallback rows are preserved; empty provider renders failure badge + localized invalid-response reason |
+| Network failure | `fetch` rejects with a synthetic `TypeError` or timeout `DOMException` without sensitive message text entering state | status and API expose only `failed/network`; empty provider renders failure badge + localized network reason; thrown message/URL is absent |
+| Provider-specific failure | Cursor `fetchCursorUsableModels` returns `{ ok:false, error:<sanitized fixture> }` | status and API expose only `failed/provider`; configured fallback remains; empty-provider fixture renders failure badge + localized provider reason without raw provider detail |
+| Successful discovery | Same provider returns valid `{ data: [] }` or model rows after cache/status clear or cooldown expiry | status becomes `{ status: "ok" }`; empty authoritative result has generic guidance and no failure badge; model rows render normally |
+| No attempt/static path | `liveModels: false` or provider has not attempted discovery | `discovery` omitted; existing static-disabled guidance; no failure badge |
+| Helper unset | `smallFastModel === ""` | picker says Claude Code chooses a native model; native Sonnet/cost warning is visible; runtime helper env vars remain undefined |
+| Helper set | `smallFastModel === "gemini/gemini-3-flash"` | selected routed model remains; warning is hidden; existing runtime maps both helper env vars to that value |
+
+Focused commands:
+
+```bash
+bun test tests/codex-catalog.test.ts
+bun test tests/management-provider-validation.test.ts
+bun test tests/models-page-groups.test.ts
+bun test gui/tests/models-empty-provider.test.tsx
+bun test gui/tests/claude-code-background-helper.test.tsx
+bun test tests/claude-cli.test.ts tests/claude-context-windows.test.ts
+```
+
+## C verification
+
+Run from repository root, fresh, and retain exit codes/output in the parent evidence record:
+
+```bash
+bun run typecheck
+bun run test
+bun run lint:gui
+bun run build:gui
+bun run privacy:scan
+```
+
+Expected: exit 0 for all five. `privacy:scan` is a hard gate because discovery diagnostics
+must not expose URLs, bodies, keys, account IDs, thrown messages, or upstream status text.
+
+### C-ACTIVATION-GROUNDING-01
+
+1. **401:** fault-inject a `Response(null, { status: 401 })`; observe both the backend
+   status assertion and SSR badge/reason assertion execute.
+2. **Blocked — mandatory named test:**
+   `test("destination-blocked discovery exposes blocked status and badge", async () => { ... })`.
+   Use a destination-policy rejection fixture, assert no fetch, exact API DTO
+   `{status:"failed",reason:"blocked"}`, and SSR badge plus localized blocked reason.
+3. **Invalid response — mandatory named test:**
+   `test("invalid JSON or malformed model data exposes invalid-response status and badge", async () => { ... })`.
+   Run invalid JSON and malformed-`data` 2xx subcases, assert exact API DTO
+   `{status:"failed",reason:"invalid_response"}`, fallback preservation, and SSR badge/reason.
+4. **Network — mandatory named test:**
+   `test("network discovery failure exposes sanitized network status and badge", async () => { ... })`.
+   Reject fetch with a synthetic error carrying a sentinel secret/message; assert exact API DTO
+   `{status:"failed",reason:"network"}`, SSR badge/reason, and absence of the sentinel from JSON/HTML.
+5. **Provider-specific — mandatory named test:**
+   `test("Cursor discovery failure exposes provider status and badge", async () => { ... })`.
+   Return Cursor `ok:false`, assert exact API DTO `{status:"failed",reason:"provider"}`, configured
+   fallback preservation, and SSR badge/reason without raw provider error detail.
+6. **Status reset — mandatory named test:**
+   `test("successful discovery clears every prior failure reason", async () => { ... })`.
+   Table-drive prior `blocked`, `http`, `invalid_response`, `network`, and `provider` statuses; perform
+   the appropriate successful live attempt and assert `{status:"ok"}` plus no failure badge/reason.
+   Then call `clearModelCache(provider)` and assert the provider returns to omitted/`unknown`, proving
+   per-test/provider reset rather than status leakage.
+7. **Recovery/ok:** perform a valid live response after clearing status/cache (or advancing
+   beyond cooldown); observe `{ status: "ok" }` and an explicit no-badge assertion.
+8. **Helper unset/set:** render the extracted setting twice and read both HTML outputs;
+   assert warning presence only in the unset output. Run existing Claude runtime tests to
+   confirm unset still emits no helper variables and set still emits both.
+
+All eight activation items are mandatory. Backend cases may be table-driven, but the four non-HTTP
+reason-code tests and status-reset test must retain the exact names, API assertions, and applicable
+empty-provider SSR badge assertions above.
+
+### C-RENDER-GROUNDING-01
+
+After `bun run build:gui` succeeds:
+
+1. Start an isolated mock provider whose `/v1/models` returns 401. Start an isolated
+   OpenCodex runtime with both `OPENCODEX_HOME` and `CODEX_HOME` pointed at temporary
+   directories, a non-live port, one enabled `liveModels` provider with `models: []`, and
+   `allowPrivateNetwork: true`. Do not touch the user's live 10100 runtime.
+2. Confirm via HTTP that isolated `GET /api/providers` contains
+   `discovery: { status: "failed", reason: "http", httpStatus: 401 }` before browser QA.
+3. Start Vite with `OPENCODEX_PROXY_TARGET` set to the isolated runtime. Use the native
+   in-app browser QA ladder (do not install Playwright), open the Models page at 1280×720,
+   expand the zero-model provider if needed, and capture a screenshot.
+4. Open/read the screenshot. Record that the amber failure badge, `HTTP 401` reason,
+   provider name, manual `+` action, and provider-settings link are visible without clipping,
+   overlap, color-only meaning, or accidental collapse. Also inspect browser console/network.
+5. If observation finds a defect, fix, rebuild, re-render, and re-observe; stop after one
+   clean observation. Record screenshot path and observation in C evidence, then terminate
+   Vite, mock provider, and isolated runtime and record teardown receipts.
+
+Also visit the Claude page in the same render session and observe the unset native
+Sonnet/cost warning; choose a routed helper model and observe the warning disappear. The
+badge screenshot is the mandatory persisted artifact for this C2-C3 UI repair.
+
+## Implementation order and atomicity
+
+1. Add model-cache status lifecycle and provider-fetch recording; run catalog tests.
+2. Add the management DTO field and API contract test.
+3. Thread status through pure grouping and render the empty failure badge; run group/SSR
+   tests.
+4. Add new i18n keys, helper setting seam, and set/unset SSR tests.
+5. Sync all existing Claude Code guide locales.
+6. Run focused tests, all five gates, collision recheck, activation checks, and rendered QA.
+
+Keep implementation commits atomic by the above boundaries. Do not push without the
+parent's explicit authorization. Any divergence from this map is reported to the parent
+before expanding scope.

--- a/devlog/_plan/260724_bugfix_train/040_ux_discovery_badge.md
+++ b/devlog/_plan/260724_bugfix_train/040_ux_discovery_badge.md
@@ -113,10 +113,11 @@ export type ProviderModelDiscoveryFailureReason =
 
 export type ProviderModelDiscoveryStatus =
   | { status: "ok" }
+  | { status: "failed"; reason: "http"; httpStatus: number }
   | {
       status: "failed";
-      reason: ProviderModelDiscoveryFailureReason;
-      httpStatus?: number;
+      reason: Exclude<ProviderModelDiscoveryFailureReason, "http">;
+      httpStatus?: never;
     };
 
 // GET /api/providers row (new field only)
@@ -193,7 +194,8 @@ export type ProviderModelDiscoveryFailureReason =
 
 export type ProviderModelDiscoveryStatus =
   | { status: "ok" }
-  | { status: "failed"; reason: ProviderModelDiscoveryFailureReason; httpStatus?: number };
+  | { status: "failed"; reason: "http"; httpStatus: number }
+  | { status: "failed"; reason: Exclude<ProviderModelDiscoveryFailureReason, "http">; httpStatus?: never };
 
 const discoveryStatus = new Map<string, ProviderModelDiscoveryStatus>();
 

--- a/devlog/_plan/260724_bugfix_train/050_pr336_takeover.md
+++ b/devlog/_plan/260724_bugfix_train/050_pr336_takeover.md
@@ -1,0 +1,413 @@
+# 050 — Cycle 5: PR #336 takeover
+
+> DIFFLEVEL-ROADMAP-01 implementation design for `fix(v2): harden unreadable
+> routed agent tasks`, contributor `MathiasHeinke`, head branch
+> `codex/v2-fernet-guard-hardening`.
+
+## Loop spec
+
+- Archetype: **spec-satisfaction repair**. Preserve PR #336's reviewed behavior
+  while replaying it on the post-Cycle-1 `dev` tip, proving a clean interdiff,
+  and refreshing all SHA-bound local/CI evidence.
+- Starting facts: PR #336 targets `dev`, is a cross-repository PR from
+  `MathiasHeinke/opencodex`, has `maintainerCanModify=true`, is mergeable, and
+  currently points to `87af85fb9df8bf8a4fbe0e1ae5fbb122bfe84fa9`, based on
+  `d9e06c8dd08df6635f5ca042bf6aa469fe1a10a8`. The live head contains two commits:
+  `733cec4dc4ab5fdc871e1e3cc88b885d3ae5827a` (code/tests) followed by
+  `87af85fb9df8bf8a4fbe0e1ae5fbb122bfe84fa9` (localized docs).
+- Required verifier: on the rebased head, all of `bun run typecheck`,
+  `bun run test`, and `bun run privacy:scan` exit 0 locally. The Cross-platform
+  CI `ubuntu-latest`, `windows-latest`, and `macos-latest` jobs must also be
+  successful for the exact rebased head SHA before merge; a green older SHA is
+  not transferable evidence.
+- Bound: one takeover/rebase of the contributor branch after Cycle 1 lands.
+  Preserve the PR's eight-file material scope unless conflict resolution or a
+  focused regression requires a minimal adjacent edit.
+- Escalation: stop before push if the rebase changes guard semantics, expands
+  into auth/credentials/workflows/dependency installation, or requires force
+  updating anything except the contributor's authorized head branch. Stop
+  before merge if any local gate fails, the fresh CI matrix is absent or red,
+  privacy scan is absent/red, or a maintainer approval is missing. Workflow
+  edits are a security-boundary change and require explicit security review.
+
+## Outcome and non-goals
+
+Take over PR #336 after Cycle 1's issue #326 guidance-accumulation repair is in
+`dev`, rebase both contributor commits onto that new tip, review the old-vs-new
+commit series with `git range-diff`, include both localized docs in the material
+review, run the complete local gates and focused PR tests, and only then push the
+rebased commit series with lease protection. Fresh checks on the new SHA replace
+the currently green-but-pre-rebase evidence.
+
+This PR is the corrected rebuild of merged-and-reverted PR #283. It is a
+fail-fast mitigation for issue #92: it prevents unreadable encrypted routed
+agent tasks from being dispatched to providers that cannot decrypt them. It
+does **not** decrypt those tasks or solve issue #92, so neither code, commit
+message, PR body, nor comment may say `Closes #92` or otherwise claim closure.
+
+## Scope
+
+### IN
+
+- Rebase PR #336's existing eight-file/two-commit diff onto the post-Cycle-1
+  `origin/dev`.
+- Review the low textual-overlap rebase plus the semantic call contract between
+  Cycle 1's `src/server/responses/collaboration.ts` injection owner and PR #336's
+  `src/server/responses/core.ts` caller.
+- Preserve structural Fernet validation, current-task-only classification,
+  static 400 error content, and decrypt-capable combo selection/failover.
+- Refresh tests only if post-rebase names/fixtures require a mechanical update.
+- Review both localized docs files for accuracy and English/Chinese consistency.
+- Push the rebased contributor head with a lease and post the English takeover
+  comment drafted below.
+
+### OUT
+
+- Redesigning the Fernet classifier or adding decryption/key handling.
+- Broad routing/combo refactors, response-facade changes, or moving logic back
+  into `src/server/responses.ts` (that file is only the post-AUTO-SPLIT facade).
+- Reworking Cycle 1's guidance fix.
+- Editing `.github/workflows/**` merely to manufacture a check.
+- Closing issue #92, merging PR #336 without required evidence, releasing, or
+  promoting `dev` to `main`.
+
+## Exact file map and required resulting diff
+
+The takeover retains the PR's actual eight files. Refresh this list and both commit anchors before
+rebase with `gh pr view 336 --repo lidge-jun/opencodex --json headRefOid,files,commits`; abort and
+amend this plan if the live material diff has drifted. The earlier
+`src/server/responses.ts` attribution is invalid and must not appear in the
+rebased material diff.
+
+### MODIFY `docs-site/src/content/docs/guides/sub-agent-surface.md`
+
+Retain the contributor's English explanation of encrypted routed-task eligibility and fail-fast
+behavior. Verify it describes mitigation rather than decryption and does not claim issue #92 closed.
+
+### MODIFY `docs-site/src/content/docs/zh-cn/guides/sub-agent-surface.md`
+
+Retain the localized counterpart and review it against the English source for the same eligibility,
+static-error, and non-closure semantics.
+
+### MODIFY `src/combos/resolve.ts`
+
+Before, `advanceComboAfterFailure()` accepts only `retryAfter` and `now`, and
+its next pick checks cooldown only. After, add an optional
+`eligible(target: Required<OcxComboTarget>): boolean` callback and compose it
+with cooldown eligibility:
+
+```diff
+ options: {
+   retryAfter?: string | null;
+   now?: number;
++  eligible?: (target: Required<OcxComboTarget>) => boolean;
+ }
+ ...
+-eligible: target => !isComboTargetInCooldown(...)
++eligible: target => !isComboTargetInCooldown(...)
++  && (options.eligible?.(target) ?? true)
+```
+
+This ensures a failover cannot escape the encrypted-payload eligibility filter
+applied to the initial combo pick.
+
+### MODIFY `src/server/responses/core.ts`
+
+Retain four PR #336 changes after applying Cycle 1:
+
+1. Add a shared `UNREADABLE_ENCRYPTED_AGENT_TASK_MESSAGE` and
+   `unreadableEncryptedAgentTaskResponse()`. The response is HTTP 400 JSON with
+   `type: "invalid_request_error"` and
+   `code: "unreadable_encrypted_agent_task"`; it contains only static text and
+   never request content or ciphertext.
+2. In `handleComboResponses()`, classify `rawBody.input` before dispatch. Add a
+   decryptability predicate that resolves each configured combo target and
+   accepts only `isCanonicalOpenAiForwardProvider(route.provider)`. Compose it
+   with cooldown eligibility for initial selection and pass the same predicate
+   to `advanceComboAfterFailure()`. If an unreadable task has no eligible native
+   target, return the shared 400 before creating a child request or calling a
+   provider.
+3. In `handleResponses()`, classify the raw current input **before**
+   `expandPreviousResponseInput()`. Preserve the expanded-body bookkeeping and
+   run sanitization/parsing afterward. This prevents encrypted historical tasks
+   replayed through `previous_response_id` from poisoning a later plaintext
+   current task.
+4. Replace the inline non-native guard error with the shared static response.
+
+The intended ordering after rebase is:
+
+```text
+read raw JSON
+  -> combo guard/eligible native selection (combo requests)
+  -> classify raw current task (non-combo requests)
+  -> expand previous-response history
+  -> sanitize plaintext encrypted_content compatibility slots
+  -> parse and route
+  -> reject unreadable task on non-native route
+  -> apply Cycle 1's idempotent guidance injection
+  -> dispatch
+```
+
+Do not move Fernet classification below history expansion and do not move
+Cycle 1's guidance logic before parse/route.
+
+### MODIFY `src/server/responses/encrypted-payload.ts`
+
+Replace the permissive `gAAAA...` run heuristic with key-independent Fernet
+wire validation:
+
+- match a maximal boundary-delimited base64url candidate;
+- require canonical padded encoding and a round-trip-equal unpadded form;
+- require version byte `0x80`;
+- require at least 73 decoded bytes;
+- derive ciphertext length as `decoded.length - 57`, require at least one
+  16-byte block, and require AES-CBC block alignment;
+- remove only structurally valid runs when deciding whether readable text
+  remains.
+
+Expand the bounded CXC compatibility preamble matcher to repeated/current and
+future `[CXC-*]` tags without consuming later untagged task paragraphs. In
+`hasUnreadableEncryptedAgentTask()`, walk backward over trailing
+`compaction_trigger`/`additional_tools` metadata and inspect only the newest
+`agent_message`; do not scan historical agent messages. Treat accepted input
+text record types as readable, strip routing/control envelopes before deciding
+whether meaningful plaintext remains, and require a valid Fernet run before
+classifying the task unreadable.
+
+### MODIFY `tests/combos.test.ts`
+
+Add `advancement preserves an explicit payload-eligibility filter`: after a
+first combo pick, pass an eligibility callback selecting provider `c`; assert
+the next target is `c` and attempted order is `["a/m1", "c/m3"]`.
+
+### MODIFY `tests/multi-agent-compat.test.ts`
+
+Replace malformed Fernet-looking fixtures with a synthetic structurally valid
+73-byte fixture (version, timestamp, IV, one ciphertext block, HMAC shape).
+Retain the mixed-slot split and pure-token byte-identity assertions. Resolve
+any Cycle 1 additions in this file additively; do not delete its guidance
+idempotence/continuation regression coverage.
+
+### MODIFY `tests/v2-agent-message-failfast.test.ts`
+
+Retain the synthetic Fernet fixture helper and the focused cases covering:
+
+- pure token and exact routing-envelope rejection;
+- current/future CXC preambles and mixed slots;
+- readable text before/after metadata or envelope;
+- malformed padding, too-short token, invalid version, invalid CBC block
+  length, noncanonical token boundaries, and output-only text;
+- encrypted historical task plus plaintext current task;
+- readable history plus unreadable current task;
+- string content passthrough and canonical native passthrough;
+- mixed combo initial filtering, no-native zero-dispatch 400, and native-only
+  failover after a retryable native failure;
+- static machine-readable error code and absence of ciphertext in the response.
+
+## Rebase and conflict plan
+
+### Preconditions
+
+1. Wait until Cycle 1 is merged into `dev`; record `CYCLE1_DEV_SHA` and verify
+   `git merge-base --is-ancestor <cycle-1-merge-sha> origin/dev` exits 0.
+2. Re-read PR #336 metadata and files. Require `state=OPEN`, base `dev`, head
+   `MathiasHeinke:codex/v2-fernet-guard-hardening`, and
+   `maintainerCanModify=true`.
+3. Fetch `origin/dev` and the contributor head, then assert the fetched head is
+   the PR API's exact `head.sha`. Abort on drift and review the new diff first.
+4. Record the old head as `PR336_OLD_SHA` and create a local safety ref. Do not
+   push a backup branch to the contributor repository.
+
+Suggested execution shape:
+
+```bash
+git fetch origin dev
+git fetch https://github.com/MathiasHeinke/opencodex.git \
+  codex/v2-fernet-guard-hardening:refs/remotes/pr336/codex/v2-fernet-guard-hardening
+git switch -C codex/pr336-takeover \
+  refs/remotes/pr336/codex/v2-fernet-guard-hardening
+git rebase origin/dev
+```
+
+### Predicted conflict and semantic-review map
+
+Cycle 1 does **not** modify `src/server/responses/core.ts` or
+`src/responses/state.ts`. Its exact production file set is
+`src/server/relay.ts`, `src/types.ts`, `src/responses/parser.ts`, and
+`src/server/responses/collaboration.ts`; its focused test owner is
+`tests/responses-state.test.ts`. `injectDeveloperMessage` is implemented at
+`src/server/responses/collaboration.ts:284`; `core.ts:667-675` only calls it.
+
+PR #336's actual code/test files are `src/combos/resolve.ts`,
+`src/server/responses/core.ts`, `src/server/responses/encrypted-payload.ts`,
+`tests/combos.test.ts`, `tests/multi-agent-compat.test.ts`, and
+`tests/v2-agent-message-failfast.test.ts`, plus the two docs files listed above.
+That set is textually disjoint from Cycle 1, so predicted textual conflict risk
+is **LOW**. Do not manufacture a `core.ts` conflict resolution step if Git reports
+none.
+
+Mandatory semantic review remains because the files meet at a call contract:
+
+1. Confirm `core.ts` still calls `injectDeveloperMessage` only after raw-current
+   Fernet classification, previous-response expansion, parse, and route selection.
+2. Confirm `collaboration.ts` still receives Cycle 1's `_replayPrefixLen` and can
+   return early without duplicating parsed/raw guidance; PR #336 must not bypass,
+   duplicate, or reorder that call.
+3. Confirm encrypted historical tasks remain excluded from current-task
+   classification while an unreadable current task still fails before provider
+   dispatch.
+4. Review the combo helper, encrypted-payload classifier, all three focused test
+   files, and both docs files even if the rebase is conflict-free.
+
+After rebase, compare the complete old and new series:
+
+```bash
+git range-diff \
+  d9e06c8dd08df6635f5ca042bf6aa469fe1a10a8..87af85fb9df8bf8a4fbe0e1ae5fbb122bfe84fa9 \
+  "$POST_WP1_DEV_SHA"..HEAD
+git diff --stat "$POST_WP1_DEV_SHA"...HEAD
+git diff "$POST_WP1_DEV_SHA"...HEAD -- \
+  docs-site/src/content/docs/guides/sub-agent-surface.md \
+  docs-site/src/content/docs/zh-cn/guides/sub-agent-surface.md \
+  src/combos/resolve.ts src/server/responses/core.ts \
+  src/server/responses/encrypted-payload.ts tests/combos.test.ts \
+  tests/multi-agent-compat.test.ts tests/v2-agent-message-failfast.test.ts
+```
+
+The range-diff must show only rebase-equivalent commit rewriting or explicitly
+reviewed conflict/context adjustments. Any unexplained semantic delta, dropped
+docs commit, ninth file, or call-contract drift blocks force-push and requires a
+P-phase amendment.
+
+### Push
+
+After all local checks pass, update only the authorized contributor branch:
+
+```bash
+git push --force-with-lease=<full-ref>:<PR336_OLD_SHA> \
+  https://github.com/MathiasHeinke/opencodex.git \
+  HEAD:refs/heads/codex/v2-fernet-guard-hardening
+```
+
+Re-read PR metadata immediately after push and record the new `head.sha`. Never
+use an unqualified `--force`; if the lease fails, stop and review contributor
+changes rather than overwriting them.
+
+## Post-rebase SHA-bound CI refresh
+
+### Workflow finding
+
+`.github/workflows/ci.yml` is the applicable `Cross-platform CI` workflow. Its
+`pull_request` trigger includes base branches `main` and `dev` and path filters
+covering `src/**` and `tests/**`, so the six code/test files qualify; the docs
+files remain part of the reviewed PR scope. Each of the
+Ubuntu, Windows, and macOS jobs runs install, typecheck, isolated full tests,
+GUI tests, privacy scan, release-helper syntax check, GUI lint/build, and CLI
+help smoke. The three npm-global jobs are additional packaging smoke evidence.
+`service-lifecycle.yml` is not applicable because none of its narrowly filtered
+service/CLI/runtime paths changes.
+
+At the live pre-rebase head
+`87af85fb9df8bf8a4fbe0e1ae5fbb122bfe84fa9`, all six Cross-platform CI jobs
+(Linux, Windows, macOS, and the three npm-global jobs) are completed/SUCCESS.
+There is no missing-CI blocker to repair.
+
+`MAINTAINERS.md` makes successful required CI a merge policy even though the
+live API reports no `dev` branch-protection rule/ruleset enforcing named status
+contexts. The takeover requirement is to re-run the full local gates before
+push and obtain a new successful Cross-platform CI run whose `headSha` equals
+the post-Cycle-1 rebased PR head; the current green run at `87af85fb...` becomes
+stale after push.
+
+### Concrete SHA-refresh decision
+
+The maintainer push to the approved contributor head produces a PR
+`synchronize` event and should retrigger `ci.yml`; the workflow has no blocking
+path or branch mismatch. Do **not** edit a workflow preemptively. Poll the PR's
+check rollup and verify all three OS jobs and their privacy-scan steps are green
+for the exact new SHA.
+
+If no `pull_request` run appears after the push:
+
+1. verify the PR is open, targets `dev`, includes `src/**`/`tests/**`, and the
+   PR head SHA equals the pushed SHA;
+2. inspect Actions for a waiting-approval state and approve the fork run through
+   repository controls if GitHub requests it;
+3. if GitHub still suppresses the run, retain the three successful local gates,
+   report the missing required signal, and stop before merge;
+4. propose a workflow change only after proving a trigger defect. Any such edit
+   is a separate security-boundary scope expansion requiring explicit
+   justification, explicit security review, pinned actions, and its own tests.
+
+## Verification plan
+
+Run from a clean rebased worktree. Record exit code, head SHA, and concise test
+counts for every command.
+
+```bash
+bun install --frozen-lockfile
+bun test --isolate tests/v2-agent-message-failfast.test.ts \
+  tests/multi-agent-compat.test.ts tests/combos.test.ts
+bun run typecheck
+bun run test
+bun run privacy:scan
+```
+
+All commands must exit 0. The focused run must include every listed PR #336
+case, especially zero-dispatch combo rejection, native-only failover,
+malformed Fernet-like values, current-vs-historical task scoping, native
+passthrough, and mixed-slot sanitization.
+
+Cycle 1 regression checks are additive:
+
+- run its focused issue #326 continuation/guidance test(s) by exact file after
+  they land;
+- confirm two or more `previous_response_id` continuations never accumulate
+  duplicate proxy-generated developer guidance in outbound input or saved
+  state;
+- confirm the same continuation path still rejects an unreadable **current**
+  non-native worker task, while an encrypted historical task followed by a
+  plaintext current task remains allowed;
+- inspect `git diff --check` and require a clean worktree after verification.
+
+After push, query the PR check rollup by exact SHA. Require successful
+`Cross-platform CI / ubuntu-latest`, `/ windows-latest`, and `/ macos-latest`.
+Confirm each job's Privacy scan step succeeded. The npm-global matrix should
+also remain green because it is part of the same workflow. React Doctor is
+advisory and no service-lifecycle run is expected for this path set.
+
+## PR communication plan
+
+Post only after the rebase, local gates, and push are complete; replace all
+angle-bracket placeholders with recorded facts:
+
+```markdown
+Maintainer takeover update for PR #336:
+
+- Rebased `MathiasHeinke:codex/v2-fernet-guard-hardening` onto the current `dev` tip `<DEV_SHA>`, after the Cycle 1 issue #326 guidance-continuation fix landed.
+- `git range-diff` confirmed the two-commit series remained equivalent after rebase. Textual conflict risk was low because Cycle 1 owns `collaboration.ts`, not `core.ts`; semantic review confirmed the `collaboration.ts` injection contract and `core.ts` call ordering preserve both current-task fail-fast and replay-guidance idempotence.
+- Kept the material scope to the reviewed eight files: `docs-site/src/content/docs/guides/sub-agent-surface.md`, `docs-site/src/content/docs/zh-cn/guides/sub-agent-surface.md`, `src/combos/resolve.ts`, `src/server/responses/core.ts`, `src/server/responses/encrypted-payload.ts`, `tests/combos.test.ts`, `tests/multi-agent-compat.test.ts`, and `tests/v2-agent-message-failfast.test.ts`.
+- Local verification on `<NEW_HEAD_SHA>`: `bun run typecheck` PASS; `bun run test` PASS (`<COUNTS>`); `bun run privacy:scan` PASS; focused PR #336 and Cycle 1 regression tests PASS (`<COUNTS>`).
+- Pushed the rebased head with lease protection. Fresh Cross-platform CI must pass on `<NEW_HEAD_SHA>` before merge; the previous green run on `87af85fb` is intentionally treated as stale.
+
+This remains the corrected follow-up to the reverted PR #283 and a fail-fast mitigation for issue #92. It does not solve or close #92.
+```
+
+If CI is still pending, say so explicitly and do not use merge-ready language.
+Once fresh checks are green, append a short follow-up with links to the exact
+run and maintainer approval; do not edit the evidence into a claim before it
+exists.
+
+## Completion criteria
+
+- PR #336 head is rebased onto post-Cycle-1 `origin/dev` with lease-safe push.
+- The material diff remains the intended eight files, with any deviation reviewed
+  and explained before push.
+- The `git range-diff` is clean/reviewed, both docs are in scope, and the
+  `collaboration.ts` ↔ `core.ts` call contract preserves current-task Fernet
+  fail-fast plus Cycle 1 guidance idempotence.
+- Focused tests, full tests, typecheck, and privacy scan pass locally.
+- Fresh Cross-platform CI and privacy-scan steps pass for the exact rebased SHA.
+- At least one maintainer approval is present and the English takeover comment
+  reports actual evidence only.
+- No workflow/security scope expansion and no claim that PR #336 closes #92.

--- a/devlog/_plan/260724_bugfix_train/060_pr337_takeover.md
+++ b/devlog/_plan/260724_bugfix_train/060_pr337_takeover.md
@@ -1,0 +1,369 @@
+# 060 — Cycle 6: PR #337 takeover (`codex/gui-auto-switch-threshold`)
+
+> **DIFFLEVEL-ROADMAP-01 / loop spec — spec-satisfaction repair.** Take over
+> contributor PR #337 at head `5f84301252865dc6f792d3272c2fe0db6d09eb0e`
+> (`maintainerCanModify=true`) and repair the missing executable interaction
+> specification without changing the feature contract. Completion means the
+> controller is extracted from `CodexAccountPool`, the four async interaction
+> regressions below execute through a mounted React DOM, the independent
+> root-suite research artifact `061_root_suite_investigation.md` records a
+> repeatable classification/disposition, and all verifiers exit 0: `bun run lint:gui`, `bun run build:gui`,
+> `bun run test`, `bun run typecheck`, and `bun run privacy:scan` (plus the
+> focused GUI suite). Escalate rather than broaden scope if the failures require
+> release/security-boundary changes, dependencies, API/schema behavior, or files
+> unrelated to the observed failures. Push repair commits to the contributor
+> branch only after verification. Stop at **branch updated + green**: because
+> this is a `gui/` PR, merge requires explicit owner approval and is not part of
+> this cycle.
+
+## Ground truth and constraints
+
+- PR: `#337`, base `dev`, head `codex/gui-auto-switch-threshold`.
+- Current PR footprint: 15 files, including `+343/-38` in
+  `gui/src/components/CodexAccountPool.tsx`; the base file is 535 lines, so the
+  PR version is approximately 840 lines.
+- Existing behavior is retained: persisted threshold `0..100`, enabled input
+  `1..100`, initial loading/failure/retry states, inclusive threshold copy,
+  Enter/blur commit, Escape cancel, failed-write rollback, toggle restore,
+  stale-refresh protection, localized feedback, and responsive styling.
+- The endpoint remains `PUT /api/codex-auth/auto-switch` with
+  `{ threshold: number }`; no server, config, routing, locale-copy, docs, or CSS
+  semantics are redesigned in this repair.
+- GUI tests are not Vitest and do not use Testing Library. `gui/package.json`
+  runs `bun test tests`; `happy-dom` is already a dev dependency. Existing
+  interactive tests install a `happy-dom` `Window`, set DOM globals and
+  `IS_REACT_ACT_ENVIRONMENT`, mount with React 19 `createRoot`, dispatch native
+  DOM events inside `act`, and unmount/restore globals in `afterEach`.
+- The root `bun run test` invokes `scripts/test.ts`, which isolates HOME and runs
+  only `./tests/`; therefore `bun test ./gui/tests` is an additional mandatory
+  verifier and cannot be inferred from a green root suite.
+
+## Scope
+
+### IN
+
+1. Mechanical extraction of the auto-switch presentation and controller from
+   `CodexAccountPool` with behavior-preserving interfaces.
+2. Mounted component tests for the four missing async/race scenarios.
+3. Existing helper/endpoint/SSR test import updates caused by extraction.
+4. English PR update describing the repair and evidence; maintainer push to the
+   contributor branch.
+
+### OUT
+
+- New threshold behavior, API/schema/config changes, locale/docs/CSS copy or
+  design changes, general `CodexAccountPool` cleanup, dependency additions, and
+  unrelated test modernization.
+- Release automation or security-boundary edits without explicit expansion and
+  security review.
+- Merge, squash, close, release, promotion to `main`, or changes to
+  `claudedesktop`.
+
+## Exact file change map
+
+Line anchors below refer to PR head `5f843012`; re-anchor after checking out the
+contributor branch, but preserve the named ownership boundaries.
+
+### NEW `gui/src/components/CodexAutoSwitchSetting.tsx`
+
+Move the exported `AutoSwitchSetting` JSX currently added at
+`CodexAccountPool.tsx:25-156` without markup, accessibility, class-name, or copy
+changes. Export these public view types beside the component:
+
+```ts
+export type AutoSwitchFeedback = { tone: "ok" | "err"; message: string } | null;
+
+export interface CodexAutoSwitchSettingProps {
+  threshold: number | null;
+  draft: string;
+  saving: boolean;
+  loadError: boolean;
+  feedback: AutoSwitchFeedback;
+  onDraftChange(value: string): void;
+  onEditingChange(editing: boolean): void;
+  onCommit(): Promise<boolean>;
+  onCancel(): void;
+  onToggle(): Promise<boolean>;
+  onRetry(): void;
+}
+```
+
+Before: presentation, keyboard handling, blur handling, and controller state all
+share the account-pool module. After: this file owns only rendering and DOM event
+translation. Keep the control-group blur guard (`contains(relatedTarget)`),
+composition guard, `aria-busy`, `aria-describedby`, status/alert roles,
+read-only-on-save behavior, retry button, and toggle semantics byte-for-byte
+equivalent. The default export is `CodexAutoSwitchSetting`; no barrel export.
+
+### NEW `gui/src/hooks/useCodexAutoSwitch.ts`
+
+Move all auto-switch state, refs, effects, and callbacks currently added around
+`CodexAccountPool.tsx:171-279` and `:388-487` into one controller hook. It owns:
+
+- state: confirmed threshold, draft, initial-load error, saving, feedback;
+- refs: confirmed threshold, last enabled value, editing/saving flags, revision,
+  deferred server value, feedback timer;
+- operations: apply, queue/apply, reconcile deferred value, clear/show feedback,
+  save, reject, cancel, commit, toggle, and timeout cleanup;
+- read reconciliation used by the account pool's `/active` request.
+
+Exact interface:
+
+```ts
+export interface CodexAutoSwitchController {
+  threshold: number | null;
+  draft: string;
+  saving: boolean;
+  loadError: boolean;
+  feedback: AutoSwitchFeedback;
+  beginServerRead(): number;
+  acceptServerRead(value: unknown, startedRevision: number): void;
+  rejectServerRead(): void;
+  setDraft(value: string): void;
+  setEditing(editing: boolean): void;
+  commit(): Promise<boolean>;
+  cancel(): void;
+  toggle(): Promise<boolean>;
+}
+
+export function useCodexAutoSwitch(
+  apiBase: string,
+  messages: {
+    updated: string;
+    updateFailed: string;
+    invalid: string;
+  },
+): CodexAutoSwitchController;
+```
+
+`beginServerRead()` returns the current revision before `/active` starts.
+`acceptServerRead()` runs the existing `autoSwitchThresholdReadDisposition`
+against that captured revision; an edit/save defers the value and a revision
+mismatch ignores it. `rejectServerRead()` sets the load error only while no
+confirmed threshold exists. These methods make the read/write race an explicit
+controller contract while leaving the parent responsible for fetching active
+account data.
+
+Preserve these invariants exactly:
+
+1. A write increments revision before and after the request.
+2. A successful write clears deferred reads and installs its value.
+3. A failed write first applies a valid deferred confirmed value, otherwise
+   restores the pre-write confirmed value.
+4. Enter followed by blur observes the synchronous saving ref and cannot start
+   a second PUT.
+5. Escape clears feedback, restores the last confirmed/deferred draft, and does
+   not write.
+6. Toggle-off remembers a valid dirty draft as the page-lifetime restore value;
+   toggle-on writes that remembered value.
+7. The 5-second feedback timer is replaced/cleared and is cleared on unmount.
+
+Keep pure validation/planning and transport in
+`gui/src/codex-auto-switch.ts`; do not duplicate or move
+`normalizeAutoSwitchThreshold`, `parseEnabledAutoSwitchThreshold`,
+`planAutoSwitchToggleWrite`, `autoSwitchThresholdReadDisposition`, or
+`putAutoSwitchThreshold`.
+
+### MODIFY `gui/src/components/CodexAccountPool.tsx`
+
+Before: the approximately 840-line PR component owns account loading plus the
+entire auto-switch view/controller. After: it imports
+`CodexAutoSwitchSetting` and `useCodexAutoSwitch`, leaving account-pool fetching
+and composition in place.
+
+Concrete edits:
+
+- Remove the six auto-switch imports from `../codex-auto-switch`, the
+  `AutoSwitchSetting` declaration, five auto-switch `useState` calls, seven
+  auto-switch refs, auto-switch feedback cleanup effect, and all controller
+  callbacks.
+- Construct the controller once with `apiBase` and translated messages.
+- At the beginning of each `load`, call `const autoSwitchReadRevision =
+  autoSwitch.beginServerRead()`.
+- On a successful `/active` response, continue setting `activeId`, then call
+  `autoSwitch.acceptServerRead(active.autoSwitchThreshold,
+  autoSwitchReadRevision)`.
+- On `/active` failure call `autoSwitch.rejectServerRead()`; preserve existing
+  account and overall load-state handling.
+- Pass `autoSwitch.threshold ?? 0` to both `QuotaBars` sites.
+- Render `<CodexAutoSwitchSetting>` with controller fields and handlers; Retry
+  remains `void load()` because it reloads the shared `/active` payload.
+- Keep `load` callback dependencies stable by destructuring stable hook methods
+  or memoizing the hook callbacks. The initial 50 ms load and 30-second interval
+  must not be recreated on each state update.
+
+Target after extraction: `CodexAccountPool.tsx` below 650 lines and with no
+auto-switch revision/deferred-write refs. This is a containment target, not an
+invitation to refactor unrelated account behavior.
+
+### MODIFY `gui/tests/codex-account-auto-switch.test.tsx`
+
+- Import `CodexAutoSwitchSetting` from its new component path rather than from
+  `CodexAccountPool`.
+- Retain all 16 pure helper, transport, validation, and static SSR cases.
+- Rename the local renderer only if needed for clarity; do not rewrite these
+  tests into the mounted suite.
+
+### NEW `gui/tests/codex-auto-switch-controller.test.tsx`
+
+Use `bun:test`, `happy-dom`, React `createRoot`, and `act`; no new package or
+runner. Follow `combo-workspace-empty.test.tsx` and
+`error-boundary.test.tsx` for global installation and cleanup. Mount the real
+`CodexAccountPool` under `LanguageProvider`, not a reimplementation of the
+hook. Provide a route-aware `globalThis.fetch` fake and deferred `Response`
+promises for:
+
+- `GET /api/codex-auth/accounts` → a minimal successful account payload;
+- `GET /api/codex-auth/active` → controlled threshold payloads;
+- `PUT /api/codex-auth/auto-switch` → controlled success/failure and a write
+  log parsed from `RequestInit.body`.
+
+Capture the callback registered by the component's 30-second `setInterval`
+and invoke it inside `act`; this deterministically activates the production
+refresh path without waiting 30 seconds. Prefer this narrow interval shim over
+global fake timers because the component also has a 50 ms initial-load timeout
+and a 5-second feedback timeout. If Bun fake timers are used instead, advance
+only the initial 50 ms and one 30,000 ms tick, flush microtasks after every
+advance, and restore real timers in `afterEach`.
+
+Shared activation setup for every case:
+
+1. Install `happy-dom` globals, English locale, fetch router, and interval
+   capture; mount with `apiBase="http://localhost"`.
+2. Complete initial account + active reads with threshold `80`; await React
+   updates and assert the number input is enabled with value `80`.
+3. Drive value changes with the native `HTMLInputElement.value` setter plus a
+   bubbling `input` event, and drive keyboard/focus transitions with native
+   `KeyboardEvent`, `focus()`, and focus on an outside button.
+4. Flush the controlled promises in `act`, then assert both PUT count/body and
+   rendered confirmed state. Always unmount and restore fetch/timers/globals.
+
+Concrete executable cases:
+
+1. **`Enter then blur issues exactly one write`.** Focus input, change `80` to
+   `95`, dispatch Enter, immediately move focus outside while the PUT promise is
+   unresolved, and assert one PUT `{threshold:95}`. Resolve 204; assert value
+   `95`, success status, and still one PUT after microtask flush.
+2. **`stale 30-second refresh cannot overwrite a successful edit`.** Invoke the
+   captured interval callback and leave its `/active` response pending. Edit to
+   `95`, Enter, resolve PUT 204, then resolve the older refresh with threshold
+   `80`. Assert input/copy remain `95` and exactly one PUT occurred. This order
+   proves revision-based ignore, rather than merely testing an editing defer.
+3. **`failed write restores the last confirmed value`.** Starting from confirmed
+   `80`, edit to `95`, Enter, return HTTP 500 (or reject transport), flush, and
+   assert input/copy return to `80`, an alert contains the update-failed copy,
+   and exactly one PUT `{threshold:95}` was attempted.
+4. **`Escape cancels without writing`.** Focus input, change to `95`, dispatch
+   Escape, then move focus outside to activate the real blur path. Assert draft
+   returns to `80`, no PUT exists after microtask flush, and no success status
+   is shown.
+
+The test file may include small `deferred<T>()`, `flush()`, `setInputValue()`,
+and fetch-router helpers local to the file. Do not export production internals
+solely for testing.
+
+### CONDITIONAL scope: root-suite findings
+
+Root-suite reproduction, classification, and disposition live exclusively in
+`061_root_suite_investigation.md`; execute that research artifact before claiming
+the root gate. No root-suite fix file is pre-authorized in this document.
+
+If 061 demonstrates a required fix that touches any path not already named in
+this Cycle 6 change map, stop before build and perform a P-phase amendment to
+this file. The amendment must name the exact `MODIFY` path and include the exact
+before/after diff; only then may implementation begin. `scripts/release.ts`,
+workflow, dependency, auth, credential, or other security/release-surface changes
+remain escalation boundaries even if 061 reproduces a failure there.
+
+## Verification and rendered observation (C-RENDER-GROUNDING-01)
+
+Run from repository root at the final contributor-branch head:
+
+```bash
+bun test ./gui/tests/codex-account-auto-switch.test.tsx \
+  ./gui/tests/codex-auto-switch-controller.test.tsx
+bun test ./gui/tests
+bun run lint:gui
+bun run build:gui
+bun run typecheck
+bun run privacy:scan
+bun run test
+bun run test
+git diff --check
+```
+
+Every command must exit 0. Record focused case counts, full GUI/root counts, and
+the final SHA. `bun run build:gui` may retain the already-known large-chunk
+advisory, but no new warning/error is accepted.
+
+Rendered observation plan:
+
+1. Build and serve the PR GUI against a local proxy with at least one Codex
+   account; open the Codex account pool at 1280×720 and 390×844.
+2. Read back screenshots (do not treat capture success as observation). Confirm
+   the card remains aligned, 80/custom threshold text matches the input, `%` is
+   visible, toggle state is truthful, no clipping/overflow occurs, and mobile
+   controls stack as intended.
+3. Observe initial loading and simulated load failure/retry. With the input
+   focused, verify Enter saves once, Escape restores, pending save is read-only,
+   success uses a status, and failure uses an alert with confirmed-value
+   restoration.
+4. Trigger quota refresh while editing and after a successful save; verify quota
+   content can refresh but an old threshold response never replaces the saved
+   value. Inspect console and network: no React warnings, duplicate PUTs, or
+   failed requests except the intentionally simulated failure.
+5. Store screenshot paths and concise observations in the cycle evidence; avoid
+   real account identifiers in screenshots/logs.
+
+## Commit, push, and owner gate
+
+- Rebase/fetch-check the contributor head before editing and before push; do not
+  rewrite contributor commits unnecessarily.
+- Use one focused repair commit for extraction/tests. A separate root-suite fix
+  commit is allowed only after 061 evidence and the required P-phase amendment
+  to this file authorize its exact path/diff.
+- Push to `codex/gui-auto-switch-threshold` using maintainer modification rights.
+- Verify the remote head equals the local verified SHA and required Linux,
+  macOS, Windows, target-enforcement, and GUI checks are green.
+- Do **not** merge. Hand back for explicit owner approval because `gui/` is
+  touched.
+
+## English PR comment draft
+
+> Maintainer takeover update: I preserved the threshold feature and API contract
+> while extracting the auto-switch view/controller from `CodexAccountPool` so
+> its async reconciliation rules have a focused ownership boundary. I also added
+> mounted `happy-dom` interaction coverage for the four previously untested
+> cases: Enter followed by blur emits one PUT, an older 30-second refresh cannot
+> overwrite a successful edit, a failed PUT restores the last confirmed value,
+> and Escape cancels without writing.
+>
+> Root-suite follow-up: `[insert the four original test names and classification]`.
+> `[insert exact fix or baseline/flake evidence; do not claim fixed if it only
+> passed standalone]`.
+>
+> Final verification at `[SHA]`: focused GUI `[counts]`; full GUI `[counts]`;
+> `bun run lint:gui`, `bun run build:gui`, `bun run typecheck`,
+> `bun run privacy:scan`, and two consecutive `bun run test` runs all passed.
+> Render checks at 1280×720 and 390×844 confirmed loading, edit/save/cancel,
+> rollback, refresh reconciliation, accessibility feedback, and responsive
+> layout with no duplicate PUTs or console errors.
+>
+> The contributor branch is updated and green. This PR still requires explicit
+> owner approval before merge because it changes `gui/`; no merge was performed.
+
+## Acceptance checklist
+
+- [ ] PR head revalidated and no unrelated contributor changes folded in.
+- [ ] View and controller extracted; `CodexAccountPool.tsx` is below 650 lines.
+- [ ] All four mounted interaction cases fail before/ pass after the repair.
+- [ ] Existing 16 helper/SSR/transport tests remain green.
+- [ ] `061_root_suite_investigation.md` contains the four root failure names,
+      logs, classification, and evidence-backed disposition; any fix outside
+      this change map was authorized by an exact-path/before-after P amendment;
+      final root suite is green twice.
+- [ ] Static, privacy, build, focused/full GUI, and render-grounding evidence is
+      recorded at the pushed SHA.
+- [ ] Contributor branch remote head and required CI are green.
+- [ ] English PR comment posted with exact evidence and no unsupported claims.
+- [ ] No merge performed; explicit owner approval remains pending.

--- a/devlog/_plan/260724_bugfix_train/061_root_suite_investigation.md
+++ b/devlog/_plan/260724_bugfix_train/061_root_suite_investigation.md
@@ -1,0 +1,112 @@
+# 061 — PR #337 root-suite failure investigation
+
+> Research-only companion to `060_pr337_takeover.md`. This artifact owns reproduction and
+> classification of the four root-suite failures reported on PR #337. It does not pre-authorize a
+> production/test fix or widen Cycle 6's file map.
+
+## Question and evidence baseline
+
+The PR report recorded `3780 passed, 4 skipped, 4 failed`, with all four failures in unchanged
+`tests/release-helper.test.ts`; a standalone rerun reportedly passed 5/5. Determine whether each
+failure is caused by the PR, deterministic on post-WP1 `dev`, order/concurrency-sensitive, or not
+reproduced. Record evidence without inferring causality from unchanged-file status alone.
+
+For every run retain: OS/architecture, `bun --version`, branch name, exact SHA, isolated HOME path,
+command, start/end time, exit code, pass/skip/fail counts, all four test names, assertion text, stderr,
+and neighboring test output. Sanitize local paths and never retain credentials/account identifiers.
+
+## Reproduction commands
+
+Run from a clean PR #337 worktree. Store logs under the parent cycle's approved evidence location;
+this research file records only paths/counts/classification.
+
+```bash
+git status --short
+git rev-parse HEAD
+bun --version
+uname -a
+
+bun run test 2>&1 | tee <evidence>/pr337-root-initial.log
+
+bun test --isolate tests/release-helper.test.ts 2>&1 | tee <evidence>/release-helper-1.log
+bun test --isolate tests/release-helper.test.ts 2>&1 | tee <evidence>/release-helper-2.log
+bun test --isolate tests/release-helper.test.ts 2>&1 | tee <evidence>/release-helper-3.log
+
+bun run test 2>&1 | tee <evidence>/pr337-root-repeat-1.log
+bun run test 2>&1 | tee <evidence>/pr337-root-repeat-2.log
+```
+
+Use `scripts/test.ts` via `bun run test` for the root repeats so its real HOME isolation and suite
+ordering execute. If the failure appears order-sensitive, rerun the smallest preceding/failing test
+sequence that reproduces it and record that exact command; do not substitute a new runner or add
+test-only production branches.
+
+Baseline definition (CYCLE6-BASE-01): the comparison base is NOT a fixed
+"post-WP1 dev". Record `CYCLE6_BASE_SHA` = the exact `origin/dev` tip onto which
+PR #337 is actually rebased at cycle-6 start (which may already include WP2-WP4
+merges per the 000 phase map). Every baseline run below executes against that
+recorded SHA in a separate clean worktree; a failure only counts as PR-caused if
+it reproduces on the rebased PR branch and NOT on `CYCLE6_BASE_SHA`:
+
+```bash
+# in the clean baseline worktree, checked out at CYCLE6_BASE_SHA
+git rev-parse HEAD
+bun test --isolate tests/release-helper.test.ts
+bun run test
+bun run test
+```
+
+Inspect failed release-helper temporary shim directories, logs, child-process lifetime, port/path
+reuse, environment restoration, and overlap with neighboring tests. Read-only inspection is allowed;
+do not patch while classification is incomplete.
+
+## Per-failure classification rubric
+
+Classify each of the four named failures independently and cite its log/run evidence:
+
+- **PR-caused** — reproduces on the PR head, does not reproduce on the exact post-WP1 `dev` base
+  under the same environment/order, and a concrete causal path from an actual PR diff hunk to the
+  assertion/resource exists.
+- **Baseline deterministic** — reproduces on post-WP1 `dev` under the same environment/order with a
+  stable assertion and repeatable owner.
+- **Order/concurrency flake** — standalone remains green, but a repeatable suite order, shared path,
+  process overlap, environment leak, or resource collision triggers the failure on PR and/or base.
+- **Non-reproduced** — neither the required standalone repetitions nor two full-suite repetitions
+  produce the failure and no causal path is evidenced. Label it an unconfirmed flake, never “fixed.”
+
+For PR-caused or reproducible order/concurrency defects, identify the smallest owning test/helper and
+the focused regression that would fail before/pass after. For baseline deterministic findings,
+report the evidence and escalate rather than silently bundling unrelated repair. For non-reproduced
+findings, retain the original failure log plus clean reruns and require final CI/root gates.
+
+## Mandatory amendment rule before any fix
+
+No file is writable merely because this investigation identifies it. If the required fix touches a
+path not already present in `060_pr337_takeover.md`'s exact change map:
+
+1. stop before Build/implementation;
+2. enter P phase for Cycle 6 and amend `060_pr337_takeover.md`;
+3. add the exact `MODIFY path/to/file` entry;
+4. include the exact current **before** excerpt and proposed **after** diff, the classified failure it
+   resolves, and its focused verifier;
+5. obtain the parent/maintainer audit decision, then build only within that amended scope.
+
+This rule applies even to `tests/release-helper.test.ts` or a seemingly test-only helper. Any fix in
+`scripts/release.ts`, `.github/workflows/**`, dependencies, auth, credentials, release automation, or
+another security boundary additionally requires explicit scope expansion/security review; the P
+amendment alone does not waive that gate.
+
+## Disposition and closure gate
+
+Record a four-row table with: test name, first failing log/line, reproduction matrix, classification,
+causal evidence, owner path, and disposition. If a fix is authorized and implemented, rerun its
+focused regression, three standalone release-helper runs, and two full root suites after the last
+code change.
+
+Cycle 6 may update the contributor branch only when:
+
+- every reported failure has an evidence-backed classification/disposition;
+- any out-of-map fix has the exact P-phase amendment required above;
+- two consecutive post-change `bun run test` executions pass;
+- the focused release-helper run is supporting evidence, not sole closure; and
+- required Cross-platform CI is green on the exact pushed head.

--- a/devlog/_plan/260724_bugfix_train/061_root_suite_investigation.md
+++ b/devlog/_plan/260724_bugfix_train/061_root_suite_investigation.md
@@ -67,7 +67,7 @@ Classify each of the four named failures independently and cite its log/run evid
 - **PR-caused** — reproduces on the PR head, does not reproduce on the exact post-WP1 `dev` base
   under the same environment/order, and a concrete causal path from an actual PR diff hunk to the
   assertion/resource exists.
-- **Baseline deterministic** — reproduces on post-WP1 `dev` under the same environment/order with a
+- **Baseline deterministic** — reproduces on `CYCLE6_BASE_SHA` under the same environment/order with a
   stable assertion and repeatable owner.
 - **Order/concurrency flake** — standalone remains green, but a repeatable suite order, shared path,
   process overlap, environment leak, or resource collision triggers the failure on PR and/or base.

--- a/src/responses/parser.ts
+++ b/src/responses/parser.ts
@@ -594,6 +594,7 @@ export function parseRequest(body: unknown): OcxParsedRequest {
     stream: data.stream === true,
     options,
     _rawBody: body,
+    ...(replayedInputPrefixLength > 0 ? { _replayPrefixLen: replayedInputPrefixLength } : {}),
     ...(webSearch ? { _webSearch: webSearch } : {}),
     ...(structuredOutput ? { _structuredOutput: true } : {}),
     ...(compactionRequest ? { _compactionRequest: true } : {}),

--- a/src/server/relay.ts
+++ b/src/server/relay.ts
@@ -438,6 +438,10 @@ export function createSseInspector(handlers: {
   let buffer = "";
   let reported = false;
   const reportFirstOutput = createFirstOutputReporter(handlers.onFirstOutput);
+  // Allocate reconstruction state only for persistence-capable inspectors.
+  const completedItemsByOutputIndex = handlers.onCompletedResponse
+    ? new Map<number, unknown>()
+    : null;
 
   const scanPayload = (payload: string | null): void => {
     if (!reported && handlers.logCtx) inspectResponseLogSsePayload(handlers.logCtx, payload);
@@ -455,7 +459,36 @@ export function createSseInspector(handlers: {
       }
     }
     if (handlers.onCompletedResponse) {
-      const response = completedResponseFromSsePayload(payload);
+      try {
+        const event = JSON.parse(payload) as {
+          type?: unknown;
+          output_index?: unknown;
+          item?: unknown;
+        };
+        if (event.type === "response.output_item.done"
+          && Number.isInteger(event.output_index)
+          && (event.output_index as number) >= 0
+          && typeof event.item === "object"
+          && event.item !== null
+          && !Array.isArray(event.item)
+          && typeof (event.item as { type?: unknown }).type === "string") {
+          completedItemsByOutputIndex!.set(event.output_index as number, event.item);
+        }
+      } catch {
+        /* malformed SSE payloads remain best-effort/no-throw */
+      }
+
+      let response = completedResponseFromSsePayload(payload);
+      if (response
+        && (!Array.isArray(response.output) || response.output.length === 0)
+        && completedItemsByOutputIndex!.size > 0) {
+        response = {
+          ...response,
+          output: [...completedItemsByOutputIndex!.entries()]
+            .sort(([left], [right]) => left - right)
+            .map(([, item]) => item),
+        };
+      }
       if (response) handlers.onCompletedResponse(response);
     }
   };

--- a/src/server/relay.ts
+++ b/src/server/relay.ts
@@ -159,13 +159,20 @@ export function completedResponseFromSsePayload(payload: string): { id?: unknown
   if (payload === "[DONE]") return null;
   try {
     const json = JSON.parse(payload) as { type?: unknown; response?: unknown };
-    if (json.type !== "response.completed") return null;
-    const response = json.response;
-    if (!response || typeof response !== "object" || Array.isArray(response)) return null;
-    return response as { id?: unknown; output?: unknown; status?: unknown };
+    return completedResponseFromParsedEvent(json);
   } catch {
     return null;
   }
+}
+
+/** Extract the response object from an already-parsed `response.completed` event, or null. */
+function completedResponseFromParsedEvent(
+  json: { type?: unknown; response?: unknown } | null,
+): { id?: unknown; output?: unknown; status?: unknown } | null {
+  if (!json || json.type !== "response.completed") return null;
+  const response = json.response;
+  if (!response || typeof response !== "object" || Array.isArray(response)) return null;
+  return response as { id?: unknown; output?: unknown; status?: unknown };
 }
 
 export function trackSseForRequestLog(
@@ -459,26 +466,26 @@ export function createSseInspector(handlers: {
       }
     }
     if (handlers.onCompletedResponse) {
+      type ParsedSseEvent = { type?: unknown; output_index?: unknown; item?: unknown; response?: unknown };
+      let parsedEvent: ParsedSseEvent | null = null;
       try {
-        const event = JSON.parse(payload) as {
-          type?: unknown;
-          output_index?: unknown;
-          item?: unknown;
-        };
-        if (event.type === "response.output_item.done"
-          && Number.isInteger(event.output_index)
-          && (event.output_index as number) >= 0
-          && typeof event.item === "object"
-          && event.item !== null
-          && !Array.isArray(event.item)
-          && typeof (event.item as { type?: unknown }).type === "string") {
-          completedItemsByOutputIndex!.set(event.output_index as number, event.item);
-        }
+        if (payload !== "[DONE]") parsedEvent = JSON.parse(payload) as ParsedSseEvent;
       } catch {
         /* malformed SSE payloads remain best-effort/no-throw */
       }
+      const doneItem = parsedEvent?.type === "response.output_item.done" ? parsedEvent.item : undefined;
+      if (parsedEvent
+        && doneItem !== undefined
+        && Number.isInteger(parsedEvent.output_index)
+        && (parsedEvent.output_index as number) >= 0
+        && typeof doneItem === "object"
+        && doneItem !== null
+        && !Array.isArray(doneItem)
+        && typeof (doneItem as { type?: unknown }).type === "string") {
+        completedItemsByOutputIndex!.set(parsedEvent.output_index as number, doneItem);
+      }
 
-      let response = completedResponseFromSsePayload(payload);
+      let response = completedResponseFromParsedEvent(parsedEvent);
       if (response
         && (!Array.isArray(response.output) || response.output.length === 0)
         && completedItemsByOutputIndex!.size > 0) {

--- a/src/server/responses/collaboration.ts
+++ b/src/server/responses/collaboration.ts
@@ -281,11 +281,29 @@ export function subagentRosterText(models: Array<{ model: string; efforts: strin
 
 
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isGeneratedDeveloperItem(item: unknown, text: string): boolean {
+  if (!isRecord(item) || item.type !== "message" || item.role !== "developer") return false;
+  if (!Array.isArray(item.content) || item.content.length !== 1) return false;
+  const [part] = item.content;
+  return isRecord(part) && part.type === "input_text" && part.text === text;
+}
+
 export function injectDeveloperMessage(parsed: OcxParsedRequest, text: string): void {
-  parsed.context.messages.push({ role: "developer", content: text, timestamp: Date.now() });
   const raw = parsed._rawBody as { input?: unknown } | undefined;
+  const devItem = { type: "message", role: "developer", content: [{ type: "input_text", text }] };
   if (raw && Array.isArray(raw.input)) {
-    const devItem = { type: "message", role: "developer", content: [{ type: "input_text", text }] };
+    const replayPrefixLen = Math.min(parsed._replayPrefixLen ?? 0, raw.input.length);
+    if (raw.input.slice(0, replayPrefixLen).some(item => isGeneratedDeveloperItem(item, text))) {
+      return;
+    }
+  }
+
+  parsed.context.messages.push({ role: "developer", content: text, timestamp: Date.now() });
+  if (raw && Array.isArray(raw.input)) {
     // compaction_trigger must remain the final input item (codex-rs + ChatGPT backend both
     // validate this). Insert the developer message BEFORE the trigger when present.
     const last = raw.input[raw.input.length - 1];
@@ -296,5 +314,4 @@ export function injectDeveloperMessage(parsed: OcxParsedRequest, text: string): 
     }
   }
 }
-
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,8 @@ export interface OcxParsedRequest {
   stream: boolean;
   options: OcxRequestOptions;
   _rawBody?: unknown;
+  /** Number of leading raw input items restored from local previous_response_id state. */
+  _replayPrefixLen?: number;
   /** True when the proxy expanded a previous_response_id request into a full input replay. */
   _previousResponseInputExpanded?: boolean;
   /** Provider-private stable Cursor conversation id resolved from the Responses previous_response_id chain. */

--- a/tests/multi-agent-compat.test.ts
+++ b/tests/multi-agent-compat.test.ts
@@ -562,6 +562,23 @@ describe("multiAgentGuidanceText", () => {
 });
 
 describe("injectDeveloperMessage", () => {
+  const guidance = "guidance text";
+  const generatedItem = (text = guidance) => ({
+    type: "message",
+    role: "developer",
+    content: [{ type: "input_text", text }],
+  });
+  const countExact = (input: unknown[], text = guidance): number => input.filter(item => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) return false;
+    const record = item as Record<string, unknown>;
+    if (record.type !== "message" || record.role !== "developer" || !Array.isArray(record.content)) return false;
+    if (record.content.length !== 1) return false;
+    const part = record.content[0];
+    return !!part && typeof part === "object" && !Array.isArray(part)
+      && (part as Record<string, unknown>).type === "input_text"
+      && (part as Record<string, unknown>).text === text;
+  }).length;
+
   test("appends to both the parsed messages and the raw passthrough input", () => {
     const parsed = parsedFixture({ reasoning: "max" });
     injectDeveloperMessage(parsed, "hello there");
@@ -596,6 +613,51 @@ describe("injectDeveloperMessage", () => {
     expect((input[1] as { type: string }).type).toBe("message");
     expect((input[1] as { role: string }).role).toBe("developer");
     expect((input[2] as { type: string }).type).toBe("compaction_trigger");
+  });
+
+  test("exact-guidance predicate rejects every near-match replay-prefix shape (#326)", () => {
+    const nearMatches: Array<[string, unknown]> = [
+      ["non-record item", null],
+      ["wrong type", { ...generatedItem(), type: "other" }],
+      ["wrong role", { ...generatedItem(), role: "user" }],
+      ["non-array content", { type: "message", role: "developer", content: "guidance text" }],
+      ["wrong content length", { type: "message", role: "developer", content: [] }],
+      ["non-record part", { type: "message", role: "developer", content: [null] }],
+      ["wrong part type", { type: "message", role: "developer", content: [{ type: "output_text", text: guidance }] }],
+      ["different text", generatedItem("different guidance")],
+      ["extra content part", {
+        type: "message",
+        role: "developer",
+        content: [{ type: "input_text", text: guidance }, { type: "input_text", text: "extra" }],
+      }],
+    ];
+
+    for (const [label, nearMatch] of nearMatches) {
+      const parsed = parsedFixture({ reasoning: "max", rawInput: [nearMatch] });
+      parsed._replayPrefixLen = 1;
+      injectDeveloperMessage(parsed, guidance);
+      const rawInput = (parsed._rawBody as { input: unknown[] }).input;
+      expect(countExact(rawInput), label).toBe(1);
+      expect(parsed.context.messages.filter(message => message.role === "developer" && message.content === guidance), label)
+        .toHaveLength(1);
+    }
+  });
+
+  test("matching guidance in the current suffix does not suppress replay-prefix injection (#326)", () => {
+    const parsed = parsedFixture({
+      reasoning: "max",
+      rawInput: [
+        { type: "message", role: "user", content: "replayed" },
+        generatedItem(),
+      ],
+    });
+    parsed._replayPrefixLen = 1;
+    injectDeveloperMessage(parsed, guidance);
+
+    const rawInput = (parsed._rawBody as { input: unknown[] }).input;
+    expect(countExact(rawInput)).toBe(2);
+    expect(parsed.context.messages.filter(message => message.role === "developer" && message.content === guidance))
+      .toHaveLength(1);
   });
 });
 

--- a/tests/relay-eager.test.ts
+++ b/tests/relay-eager.test.ts
@@ -93,6 +93,35 @@ async function readAll(stream: ReadableStream<Uint8Array>): Promise<string> {
   return text;
 }
 
+async function readAllBytes(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    length += value.byteLength;
+  }
+  const joined = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    joined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return joined;
+}
+
+function joinBytes(chunks: Uint8Array[]): Uint8Array {
+  const joined = new Uint8Array(chunks.reduce((total, chunk) => total + chunk.byteLength, 0));
+  let offset = 0;
+  for (const chunk of chunks) {
+    joined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return joined;
+}
+
 describe("relaySseEagerBounded — side-effect parity", () => {
   test("(a) relays bytes verbatim; terminal recorded once; completed captured; onDone once", async () => {
     const { hooks, rec } = makeHooks();
@@ -122,6 +151,63 @@ describe("relaySseEagerBounded — side-effect parity", () => {
     await settle();
     expect(rec.synthetics).toEqual(["incomplete"]);
     expect(rec.dones).toBe(1);
+  });
+
+  test("eager relay backfills missing completed output before passthrough persistence (#334)", async () => {
+    const { hooks, rec } = makeHooks();
+    const up = controlledUpstream();
+    const relayed = relaySseEagerBounded(up.stream, new AbortController(), hooks);
+    const frames = [
+      sse(JSON.stringify({
+        type: "response.output_item.done",
+        output_index: 0,
+        item: { type: "message", role: "assistant", content: [{ type: "output_text", text: "hello" }] },
+      })),
+      sse(JSON.stringify({
+        type: "response.output_item.done",
+        output_index: 1,
+        item: { type: "function_call", call_id: "call_eager", name: "lookup", arguments: "{}" },
+      })),
+      sse(JSON.stringify({
+        type: "response.completed",
+        response: { id: "resp_334_eager", status: "completed" },
+      })),
+    ];
+    for (const frame of frames) up.push(frame);
+    up.close();
+
+    const clientBytes = await readAllBytes(relayed);
+    await settle();
+    expect(clientBytes).toEqual(joinBytes(frames));
+    const wireText = new TextDecoder().decode(clientBytes);
+    expect(wireText).not.toContain('"output":');
+    expect(rec.completed).toHaveLength(1);
+    expect((rec.completed[0] as { output: Array<{ type: string }> }).output.map(item => item.type))
+      .toEqual(["message", "function_call"]);
+    expect(rec.dones).toBe(1);
+  });
+
+  test("malformed SSE payload is skipped before a valid completed response (#334) — eager relay subcase", async () => {
+    const { hooks, rec } = makeHooks();
+    const up = controlledUpstream();
+    const relayed = relaySseEagerBounded(up.stream, new AbortController(), hooks);
+    up.push(enc.encode("data: {not-json}\n\n"));
+    up.push(sse(JSON.stringify({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { type: "message", role: "assistant", content: [{ type: "output_text", text: "survived" }] },
+    })));
+    up.push(sse(JSON.stringify({
+      type: "response.completed",
+      response: { id: "resp_334_eager_malformed", status: "completed", output: [] },
+    })));
+    up.close();
+
+    await readAll(relayed);
+    await settle();
+    expect(rec.completed).toHaveLength(1);
+    expect((rec.completed[0] as { output: Array<{ type: string }> }).output.map(item => item.type))
+      .toEqual(["message"]);
   });
 });
 

--- a/tests/responses-state.test.ts
+++ b/tests/responses-state.test.ts
@@ -6,6 +6,7 @@ import { buildResponseJSON } from "../src/bridge";
 import { createCursorRequest } from "../src/adapters/cursor/request-builder";
 import { createCursorContextUsageTracker } from "../src/adapters/cursor/protobuf-events";
 import { parseRequest } from "../src/responses/parser";
+import { createSseInspector } from "../src/server/relay";
 import {
   clearResponseStateForTests,
   clearResponseStateMemoryForTests,
@@ -17,7 +18,30 @@ import {
   setResponseStateByteCapForTests,
   getStoredResponseBytesForTests,
 } from "../src/responses/state";
-import { adapterNeedsForcedContinuation } from "../src/server/responses";
+import { adapterNeedsForcedContinuation, injectDeveloperMessage } from "../src/server/responses";
+
+function feedInspector(
+  inspector: ReturnType<typeof createSseInspector>,
+  events: Array<Record<string, unknown> | "[DONE]">,
+): void {
+  const encoder = new TextEncoder();
+  for (const event of events) {
+    const payload = typeof event === "string" ? event : JSON.stringify(event);
+    inspector.feed(encoder.encode(`data: ${payload}\n\n`));
+  }
+  inspector.finish();
+}
+
+function isExactGuidanceItem(item: unknown, text: string): boolean {
+  if (!item || typeof item !== "object" || Array.isArray(item)) return false;
+  const record = item as Record<string, unknown>;
+  if (record.type !== "message" || record.role !== "developer" || !Array.isArray(record.content)) return false;
+  if (record.content.length !== 1) return false;
+  const part = record.content[0];
+  return !!part && typeof part === "object" && !Array.isArray(part)
+    && (part as Record<string, unknown>).type === "input_text"
+    && (part as Record<string, unknown>).text === text;
+}
 
 describe("Responses previous_response_id state", () => {
   // Sandbox OPENCODEX_HOME: the state store now snapshots to disk, and these tests must never
@@ -121,6 +145,250 @@ describe("Responses previous_response_id state", () => {
       (first.output as unknown[])[0],
       { role: "user", content: "next" },
     ]);
+  });
+
+  test("SSE inspector backfills empty completed output before passthrough persistence (#334)", () => {
+    const requestBody = {
+      model: "gpt-5.5",
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "start" }] }],
+    };
+    const reasoning = { type: "reasoning", id: "rs_334", summary: [{ type: "summary_text", text: "think" }] };
+    const message = {
+      type: "message",
+      id: "msg_334",
+      role: "assistant",
+      content: [{ type: "output_text", text: "working" }],
+    };
+    const call = {
+      type: "function_call",
+      id: "fc_334",
+      call_id: "call_334",
+      name: "lookup",
+      arguments: "{}",
+    };
+    let callbacks = 0;
+    const inspector = createSseInspector({
+      onCompletedResponse: response => {
+        callbacks += 1;
+        rememberResponseState(requestBody, response, undefined, { force: true });
+      },
+    });
+
+    feedInspector(inspector, [
+      { type: "response.output_item.done", output_index: 2, item: call },
+      { type: "response.output_item.done", output_index: 0, item: reasoning },
+      { type: "response.output_item.done", output_index: 1, item: message },
+      { type: "response.completed", response: { id: "resp_334_inspection", status: "completed", output: [] } },
+      "[DONE]",
+    ]);
+
+    const expanded = expandPreviousResponseInput({
+      model: "gpt-5.5",
+      previous_response_id: "resp_334_inspection",
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "continue" }] }],
+    }) as { input: Array<{ type?: string }> };
+    expect(callbacks).toBe(1);
+    expect(expanded.input.slice(1, -1).map(item => item.type)).toEqual([
+      "reasoning",
+      "message",
+      "function_call",
+    ]);
+  });
+
+  test("non-empty completed output remains authoritative over accumulated done items (#334)", () => {
+    const requestBody = { model: "gpt-5.5", input: "start" };
+    const accumulated = {
+      type: "function_call",
+      call_id: "call_accumulated",
+      name: "must_not_replay",
+      arguments: "{}",
+    };
+    const terminalOutput = [{
+      type: "message",
+      role: "assistant",
+      content: [{ type: "output_text", text: "terminal wins" }],
+    }];
+    let captured: { output?: unknown } | undefined;
+    const inspector = createSseInspector({
+      onCompletedResponse: response => {
+        captured = response;
+        rememberResponseState(requestBody, response, undefined, { force: true });
+      },
+    });
+
+    feedInspector(inspector, [
+      { type: "response.output_item.done", output_index: 0, item: accumulated },
+      { type: "response.completed", response: { id: "resp_334_authoritative", status: "completed", output: terminalOutput } },
+    ]);
+
+    expect(captured?.output).toEqual(terminalOutput);
+    const expanded = expandPreviousResponseInput({
+      model: "gpt-5.5",
+      previous_response_id: "resp_334_authoritative",
+      input: "next",
+    }) as { input: Array<Record<string, unknown>> };
+    expect(expanded.input.some(item => item.type === "message" && item.role === "assistant")).toBe(true);
+    expect(expanded.input.some(item => item.type === "function_call" && item.name === "must_not_replay")).toBe(false);
+  });
+
+  test("two previous_response_id continuations keep one replayed guidance item (#326)", () => {
+    const guidance = "Use the delegated agent workflow.";
+    const countRawGuidance = (body: unknown): number => {
+      const input = (body as { input?: unknown }).input;
+      return Array.isArray(input) ? input.filter(item => isExactGuidanceItem(item, guidance)).length : 0;
+    };
+    const countParsedGuidance = (parsed: ReturnType<typeof parseRequest>): number => parsed.context.messages
+      .filter(message => message.role === "developer" && message.content === guidance).length;
+
+    const request1 = { model: "gpt-5.5", input: [{ type: "message", role: "user", content: "start" }] };
+    const parsed1 = parseRequest(request1);
+    injectDeveloperMessage(parsed1, guidance);
+    expect(countRawGuidance(request1)).toBe(1);
+    const response1 = {
+      id: "resp_326_1",
+      status: "completed",
+      output: [{ type: "function_call", call_id: "call_326", name: "lookup", arguments: "{}" }],
+    };
+    rememberResponseState(request1, response1, undefined, { force: true });
+
+    const request2 = expandPreviousResponseInput({
+      model: "gpt-5.5",
+      previous_response_id: response1.id,
+      input: [{ type: "function_call_output", call_id: "call_326", output: "ok" }],
+    });
+    const parsed2 = parseRequest(request2);
+    expect(parsed2._replayPrefixLen).toBe(3);
+    const request2Input = (request2 as { input: Array<Record<string, unknown>> }).input;
+    expect(request2Input[1]).toMatchObject({ role: "developer" });
+    expect(request2Input[2]).toMatchObject({ type: "function_call" });
+    injectDeveloperMessage(parsed2, guidance);
+    expect(countRawGuidance(request2)).toBe(1);
+    expect(countParsedGuidance(parsed2)).toBe(1);
+    const response2 = {
+      id: "resp_326_2",
+      status: "completed",
+      output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "done" }] }],
+    };
+    rememberResponseState(request2, response2, undefined, { force: true });
+
+    const request3 = expandPreviousResponseInput({
+      model: "gpt-5.5",
+      previous_response_id: response2.id,
+      input: [{ type: "message", role: "user", content: "again" }],
+    });
+    const parsed3 = parseRequest(request3);
+    injectDeveloperMessage(parsed3, guidance);
+    expect(countRawGuidance(request3)).toBe(1);
+    expect(countParsedGuidance(parsed3)).toBe(1);
+    const response3 = {
+      id: "resp_326_3",
+      status: "completed",
+      output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "finished" }] }],
+    };
+    rememberResponseState(request3, response3, undefined, { force: true });
+
+    const audit = expandPreviousResponseInput({
+      model: "gpt-5.5",
+      previous_response_id: response3.id,
+      input: [{ type: "message", role: "user", content: "audit" }],
+    });
+    expect(countRawGuidance(audit)).toBe(1);
+  });
+
+  test("duplicate output_index keeps only the final done item (#334)", () => {
+    const requestBody = { model: "gpt-5.5", input: "start" };
+    const inspector = createSseInspector({
+      onCompletedResponse: response => rememberResponseState(requestBody, response, undefined, { force: true }),
+    });
+    feedInspector(inspector, [
+      {
+        type: "response.output_item.done",
+        output_index: 2,
+        item: { type: "message", role: "assistant", content: [{ type: "output_text", text: "stale sentinel" }] },
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 2,
+        item: { type: "function_call", call_id: "call_final", name: "final_lookup", arguments: "{}" },
+      },
+      { type: "response.completed", response: { id: "resp_334_duplicate", status: "completed", output: [] } },
+    ]);
+
+    const expanded = expandPreviousResponseInput({
+      model: "gpt-5.5",
+      previous_response_id: "resp_334_duplicate",
+      input: "next",
+    }) as { input: Array<Record<string, unknown>> };
+    const calls = expanded.input.filter(item => item.type === "function_call");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ call_id: "call_final", name: "final_lookup" });
+    expect(JSON.stringify(expanded.input)).not.toContain("stale sentinel");
+  });
+
+  test("malformed output_item.done events do not enter reconstructed output (#334)", () => {
+    const requestBody = { model: "gpt-5.5", input: "start" };
+    let callbacks = 0;
+    let captured: unknown;
+    const inspector = createSseInspector({
+      onCompletedResponse: response => {
+        callbacks += 1;
+        captured = response.output;
+        rememberResponseState(requestBody, response, undefined, { force: true });
+      },
+    });
+    const valid = { type: "message", role: "assistant", content: [{ type: "output_text", text: "valid" }] };
+    feedInspector(inspector, [
+      { type: "response.output_item.done", output_index: 0, item: valid },
+      { type: "response.output_item.done", item: valid },
+      { type: "response.output_item.done", output_index: -1, item: valid },
+      { type: "response.output_item.done", output_index: 1.5, item: valid },
+      { type: "response.output_item.done", output_index: "1", item: valid },
+      { type: "response.output_item.done", output_index: 1 },
+      { type: "response.output_item.done", output_index: 1, item: null },
+      { type: "response.output_item.done", output_index: 1, item: "text" },
+      { type: "response.output_item.done", output_index: 1, item: 42 },
+      { type: "response.output_item.done", output_index: 1, item: [] },
+      { type: "response.output_item.done", output_index: 1, item: {} },
+      { type: "response.output_item.done", output_index: 1, item: { type: 42 } },
+      { type: "response.completed", response: { id: "resp_334_malformed_done", status: "completed", output: [] } },
+    ]);
+
+    expect(callbacks).toBe(1);
+    expect(captured).toEqual([valid]);
+    const expanded = expandPreviousResponseInput({
+      model: "gpt-5.5",
+      previous_response_id: "resp_334_malformed_done",
+      input: "next",
+    }) as { input: Array<Record<string, unknown>> };
+    expect(expanded.input.filter(item => item.role === "assistant")).toHaveLength(1);
+  });
+
+  test("malformed SSE payload is skipped before a valid completed response (#334)", () => {
+    const requestBody = { model: "gpt-5.5", input: "start" };
+    let callbacks = 0;
+    const inspector = createSseInspector({
+      onCompletedResponse: response => {
+        callbacks += 1;
+        rememberResponseState(requestBody, response, undefined, { force: true });
+      },
+    });
+    inspector.feed(new TextEncoder().encode("data: {not-json}\n\n"));
+    feedInspector(inspector, [
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: { type: "message", role: "assistant", content: [{ type: "output_text", text: "survived" }] },
+      },
+      { type: "response.completed", response: { id: "resp_334_malformed_sse", status: "completed", output: [] } },
+    ]);
+
+    expect(callbacks).toBe(1);
+    const expanded = expandPreviousResponseInput({
+      model: "gpt-5.5",
+      previous_response_id: "resp_334_malformed_sse",
+      input: "next",
+    }) as { input: Array<Record<string, unknown>> };
+    expect(expanded.input.some(item => item.role === "assistant")).toBe(true);
   });
 
   test("force records Kiro provider continuation despite store:false", () => {


### PR DESCRIPTION
## Summary

Fixes the two P0 passthrough record/replay defects verified on `dev`:

- **#334 — tool-call dead loop:** `createSseInspector` now accumulates `response.output_item.done` items per stream (guarded: non-array record with string `type`, valid non-negative integer index, last-write-wins). When the terminal `response.completed` payload has a missing/empty `output`, the completion callback receives the reconstructed items in index order — so `rememberResponseState` persists assistant/reasoning/tool_call items instead of dropping them, and the model no longer re-calls the same tool in a loop. Client-facing SSE bytes remain byte-identical (regression-asserted); the backfill exists only in the inspector callback. Covers all three inspector consumers including the #314 eager bounded relay.
- **#326 — duplicated developer guidance accumulation:** `parseRequest` now carries the replay-prefix length (`_replayPrefixLen`) from the `previous_response_id` expansion onto the parsed request; `injectDeveloperMessage` scans the replayed prefix for the exact proxy-generated guidance item and skips re-insertion when present. Near-match items (wrong role/type/content shape/text) still inject fresh guidance — asserted by a mandatory rejection-guard table. The guidance-before-`compaction_trigger` invariant is preserved.

`src/server/responses/core.ts` and `src/responses/state.ts` are intentionally untouched.

## Tests

Eight named regressions + guard tables added across `tests/responses-state.test.ts`, `tests/relay-eager.test.ts`, `tests/multi-agent-compat.test.ts` (RED-first: 7 failing before the fix). Full local gates green:

- `bun run typecheck` — exit 0
- `bun run test` — 3851 pass / 0 fail (313 files)
- `bun run privacy:scan` — passed

## Notes

- Design/audit trail: `devlog/_plan/260724_bugfix_train/010_passthrough_state.md` (two adversarial audit rounds folded).
- Closes #334. Closes #326.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconstruction of incomplete terminal output using prior streamed frames, while preserving exact SSE bytes delivered to clients.
  * Made developer guidance injection idempotent during replay to prevent duplicate guidance entries.
  * Increased resilience by safely skipping malformed streaming events without interrupting subsequent processing.
* **Tests**
  * Added regression coverage for replay handling, output backfilling, duplicate-event behavior, malformed payload handling, and byte-level SSE compatibility.
* **Refactor**
  * Reorganized SSE event parsing/inspection flow while keeping external behavior unchanged.
* **Documentation**
  * Added “bugfix train” planning/spec documents covering upcoming reliability, UI discovery, and recovery workstreams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->