### PR TITLE
fix(actions): soft-pass translated issue headings and kind-label

### DIFF
--- a/.github/scripts/issue-quality.cjs
+++ b/.github/scripts/issue-quality.cjs
@@ -127,6 +127,7 @@ const FEATURE_LEGACY_HEADINGS = ["Problem to solve", "Proposed solution"];
 const FEATURE_GOAL_HEADINGS = [
   "What are you trying to accomplish?",
   "Goal / Problem",
+  "Goal/Problem",
   "Problem to solve",
 ];
 const FEATURE_BLOCKER_HEADINGS = [
@@ -137,6 +138,7 @@ const FEATURE_BLOCKER_HEADINGS = [
 const FEATURE_BEHAVIOUR_HEADINGS = [
   "What should OpenCodex do?",
   "Expected behaviour",
+  "Expected behavior",
   "Proposed solution",
 ];
 const FEATURE_EXAMPLE_HEADINGS = [
@@ -146,7 +148,9 @@ const FEATURE_EXAMPLE_HEADINGS = [
 ];
 const FEATURE_ALIAS_DETECT_HEADINGS = [
   "Goal / Problem",
+  "Goal/Problem",
   "Expected behaviour",
+  "Expected behavior",
   "Current limitation",
   "Current workaround",
   "Example usage",
@@ -210,15 +214,14 @@ function detectIssueKindFromContent(issue) {
   if (countHeadings(body, FEATURE_NEW_HEADINGS) >= 2) return "feature";
 
   // Translated / alternate feature headings (e.g. after issue-triage).
-  // Gate on a feature hint so common headings like "Expected behaviour"
-  // cannot reclassify bug/freeform reports as features.
-  if (countHeadings(body, FEATURE_ALIAS_DETECT_HEADINGS) >= 2) {
-    const hasGoalHeading = countHeadings(body, FEATURE_GOAL_HEADINGS) >= 1;
-    const featureHint =
-      titleLower.startsWith("[feature]:") ||
-      labels.includes("enhancement") ||
-      hasGoalHeading;
-    if (featureHint) return "feature";
+  // Require a feature-specific goal heading so common headings like
+  // "Expected behaviour" cannot reclassify bug/freeform reports as features.
+  // ([Feature]: prefix and enhancement labels are handled elsewhere.)
+  if (
+    countHeadings(body, FEATURE_ALIAS_DETECT_HEADINGS) >= 2 &&
+    countHeadings(body, FEATURE_GOAL_HEADINGS) >= 1
+  ) {
+    return "feature";
   }
 
   // New bug form: Client or integration + Summary + Reproduction.
@@ -246,11 +249,41 @@ function detectIssueKindFromContent(issue) {
 }
 
 /**
+ * True when body evidence for `kind` is a full structured form, not merely a
+ * title prefix or leftover label. Used to decide whether detected kind may
+ * override a stored bot kind.
+ */
+function hasStrongKindEvidence(kind, issue) {
+  const { body = "" } = issue;
+  switch (kind) {
+    case "provider-compatibility":
+      return countHeadings(body, PROVIDER_HEADINGS) >= 3;
+    case "documentation":
+      return countHeadings(body, DOCS_HEADINGS) >= 2;
+    case "feature":
+      return (
+        countHeadings(body, FEATURE_NEW_HEADINGS) >= 2 ||
+        countHeadings(body, FEATURE_LEGACY_HEADINGS) >= 2 ||
+        (countHeadings(body, FEATURE_ALIAS_DETECT_HEADINGS) >= 2 &&
+          countHeadings(body, FEATURE_GOAL_HEADINGS) >= 1)
+      );
+    case "bug":
+      return (
+        extractSection(body, "Client or integration") !== null &&
+        extractSection(body, "Summary") !== null &&
+        extractSection(body, "Reproduction") !== null
+      );
+    default:
+      return false;
+  }
+}
+
+/**
  * Detect the issue kind from body headings, title prefix, labels, and
  * optional stored bot kind.
  *
- * Stored kind survives heading removal (bypass protection), but a strong
- * conflicting form in the body wins so stale bot state cannot sticky-wrong-kind.
+ * Stored kind survives heading removal (bypass protection). A different
+ * detected kind overrides it only when the body has strong form evidence.
  *
  * @param {{ title: string, body: string, labels: string[], storedKind?: string|null }} issue
  * @returns {"feature"|"bug"|"provider-compatibility"|"documentation"|null}
@@ -260,7 +293,13 @@ function detectIssueKind(issue) {
   const detected = detectIssueKindFromContent(issue);
 
   if (storedKind) {
-    if (detected && detected !== storedKind) return detected;
+    if (
+      detected &&
+      detected !== storedKind &&
+      hasStrongKindEvidence(detected, issue)
+    ) {
+      return detected;
+    }
     return storedKind;
   }
 

--- a/.github/scripts/issue-quality.cjs
+++ b/.github/scripts/issue-quality.cjs
@@ -89,7 +89,7 @@ function resolveSection(body, headings) {
 
 /**
  * True when the body has at least one non-empty h2–h4 section with enough
- * detail, or a long unstructured body. Used for soft-pass only.
+ * detail. Used for soft-pass only — unstructured length alone is not enough.
  */
 function hasSubstantialStructuredContent(body, minSectionLen = 40) {
   if (typeof body !== "string") return false;
@@ -111,8 +111,7 @@ function hasSubstantialStructuredContent(body, minSectionLen = 40) {
     if (capturing) bucket.push(line);
   }
   if (capturing) flush();
-  if (richSections >= 1) return true;
-  return clean(body).length >= 200;
+  return richSections >= 1;
 }
 
 // ---------------------------------------------------------------------------
@@ -151,7 +150,7 @@ const FEATURE_ALIAS_DETECT_HEADINGS = [
   "Current limitation",
   "Current workaround",
   "Example usage",
-  "Example",
+  // Intentionally omit bare "Example" — too common in freeform/bug reports.
 ];
 const BUG_NEW_HEADINGS = ["Client or integration", "Summary", "Reproduction"];
 const BUG_LEGACY_HEADINGS = ["Summary", "Reproduction"];
@@ -197,12 +196,8 @@ function countHeadings(body, headings) {
  * @param {{ title: string, body: string, labels: string[], storedKind?: string|null }} issue
  * @returns {"feature"|"bug"|"provider-compatibility"|"documentation"|null}
  */
-function detectIssueKind(issue) {
-  const { title = "", body = "", labels = [], storedKind } = issue;
-
-  // Stored bot kind takes precedence (survives heading removal).
-  if (storedKind) return storedKind;
-
+function detectIssueKindFromContent(issue) {
+  const { title = "", body = "", labels = [] } = issue;
   const titleLower = title.toLowerCase();
 
   // Provider compatibility: distinct headings.
@@ -215,7 +210,16 @@ function detectIssueKind(issue) {
   if (countHeadings(body, FEATURE_NEW_HEADINGS) >= 2) return "feature";
 
   // Translated / alternate feature headings (e.g. after issue-triage).
-  if (countHeadings(body, FEATURE_ALIAS_DETECT_HEADINGS) >= 2) return "feature";
+  // Gate on a feature hint so common headings like "Expected behaviour"
+  // cannot reclassify bug/freeform reports as features.
+  if (countHeadings(body, FEATURE_ALIAS_DETECT_HEADINGS) >= 2) {
+    const hasGoalHeading = countHeadings(body, FEATURE_GOAL_HEADINGS) >= 1;
+    const featureHint =
+      titleLower.startsWith("[feature]:") ||
+      labels.includes("enhancement") ||
+      hasGoalHeading;
+    if (featureHint) return "feature";
+  }
 
   // New bug form: Client or integration + Summary + Reproduction.
   if (
@@ -239,6 +243,28 @@ function detectIssueKind(issue) {
   }
 
   return null;
+}
+
+/**
+ * Detect the issue kind from body headings, title prefix, labels, and
+ * optional stored bot kind.
+ *
+ * Stored kind survives heading removal (bypass protection), but a strong
+ * conflicting form in the body wins so stale bot state cannot sticky-wrong-kind.
+ *
+ * @param {{ title: string, body: string, labels: string[], storedKind?: string|null }} issue
+ * @returns {"feature"|"bug"|"provider-compatibility"|"documentation"|null}
+ */
+function detectIssueKind(issue) {
+  const { storedKind } = issue;
+  const detected = detectIssueKindFromContent(issue);
+
+  if (storedKind) {
+    if (detected && detected !== storedKind) return detected;
+    return storedKind;
+  }
+
+  return detected;
 }
 
 // ---------------------------------------------------------------------------

--- a/.github/scripts/issue-quality.cjs
+++ b/.github/scripts/issue-quality.cjs
@@ -554,6 +554,20 @@ function validateIssue(issue) {
 // ---------------------------------------------------------------------------
 
 /**
+ * Decide whether the bot may auto-close an invalid issue.
+ *
+ * After a maintainer reopens and deactivates enforcement, later `edited`
+ * events must not close the issue again.
+ *
+ * @param {{ active?: boolean, maintainerOverride?: boolean }|null|undefined} botState
+ * @returns {boolean}
+ */
+function shouldEnforceClosure(botState) {
+  if (botState && botState.maintainerOverride === true) return false;
+  return true;
+}
+
+/**
  * Decide whether the bot may reopen a closed issue.
  *
  * @param {{ active: boolean, closedAt: string|null, stateReason: string }} botState
@@ -586,6 +600,7 @@ module.exports = {
   detectIssueKind,
   validateIssue,
   shouldReopen,
+  shouldEnforceClosure,
   isRawPlaceholder,
   labelForKind,
   KIND_TO_LABEL,

--- a/.github/scripts/issue-quality.cjs
+++ b/.github/scripts/issue-quality.cjs
@@ -70,6 +70,51 @@ function extractSection(body, heading) {
   return out.join("\n").trim();
 }
 
+/**
+ * Resolve a logical section from the first matching heading.
+ * Prefers the first non-empty match; if every present heading is empty,
+ * returns that empty string so callers can distinguish "missing" (null)
+ * from "present but blank".
+ */
+function resolveSection(body, headings) {
+  let firstPresent = null;
+  for (const heading of headings) {
+    const section = extractSection(body, heading);
+    if (section === null) continue;
+    if (firstPresent === null) firstPresent = section;
+    if (!isEmpty(section)) return section;
+  }
+  return firstPresent;
+}
+
+/**
+ * True when the body has at least one non-empty h2–h4 section with enough
+ * detail, or a long unstructured body. Used for soft-pass only.
+ */
+function hasSubstantialStructuredContent(body, minSectionLen = 40) {
+  if (typeof body !== "string") return false;
+  const lines = body.split("\n");
+  let capturing = false;
+  let bucket = [];
+  let richSections = 0;
+  const flush = () => {
+    if (clean(bucket.join("\n")).length >= minSectionLen) richSections += 1;
+    bucket = [];
+  };
+  for (const line of lines) {
+    const m = line.match(/^#{2,4}\s+(.*)/);
+    if (m) {
+      if (capturing) flush();
+      capturing = true;
+      continue;
+    }
+    if (capturing) bucket.push(line);
+  }
+  if (capturing) flush();
+  if (richSections >= 1) return true;
+  return clean(body).length >= 200;
+}
+
 // ---------------------------------------------------------------------------
 // Issue kind detection
 // ---------------------------------------------------------------------------
@@ -80,6 +125,34 @@ const FEATURE_NEW_HEADINGS = [
   "What should OpenCodex do?",
 ];
 const FEATURE_LEGACY_HEADINGS = ["Problem to solve", "Proposed solution"];
+const FEATURE_GOAL_HEADINGS = [
+  "What are you trying to accomplish?",
+  "Goal / Problem",
+  "Problem to solve",
+];
+const FEATURE_BLOCKER_HEADINGS = [
+  "What prevents this today?",
+  "Current limitation",
+  "Current workaround",
+];
+const FEATURE_BEHAVIOUR_HEADINGS = [
+  "What should OpenCodex do?",
+  "Expected behaviour",
+  "Proposed solution",
+];
+const FEATURE_EXAMPLE_HEADINGS = [
+  "Example usage or interface",
+  "Example usage",
+  "Example",
+];
+const FEATURE_ALIAS_DETECT_HEADINGS = [
+  "Goal / Problem",
+  "Expected behaviour",
+  "Current limitation",
+  "Current workaround",
+  "Example usage",
+  "Example",
+];
 const BUG_NEW_HEADINGS = ["Client or integration", "Summary", "Reproduction"];
 const BUG_LEGACY_HEADINGS = ["Summary", "Reproduction"];
 const PROVIDER_HEADINGS = [
@@ -93,6 +166,21 @@ const DOCS_HEADINGS = [
   "Documentation location",
   "What is wrong or missing?",
 ];
+
+const KIND_TO_LABEL = {
+  bug: "bug",
+  feature: "enhancement",
+  documentation: "documentation",
+  "provider-compatibility": "provider-compatibility",
+};
+
+/**
+ * Map a detected issue kind to its triage label. Returns null when unknown.
+ */
+function labelForKind(kind) {
+  if (!kind || typeof kind !== "string") return null;
+  return KIND_TO_LABEL[kind] || null;
+}
 
 function countHeadings(body, headings) {
   let n = 0;
@@ -125,6 +213,9 @@ function detectIssueKind(issue) {
 
   // New feature form: at least 2 of the 3 core headings.
   if (countHeadings(body, FEATURE_NEW_HEADINGS) >= 2) return "feature";
+
+  // Translated / alternate feature headings (e.g. after issue-triage).
+  if (countHeadings(body, FEATURE_ALIAS_DETECT_HEADINGS) >= 2) return "feature";
 
   // New bug form: Client or integration + Summary + Reproduction.
   if (
@@ -202,55 +293,68 @@ function isRawPlaceholder(raw) {
  * Validate an issue body for its detected kind.
  *
  * @param {{ title: string, body: string, labels: string[], storedKind?: string|null }} issue
- * @returns {{ kind: string|null, valid: boolean, reasons: string[], guidance: string[] }}
+ * @returns {{ kind: string|null, valid: boolean, softPass: boolean, reasons: string[], guidance: string[] }}
  */
 function validateIssue(issue) {
   const { title = "", body = "" } = issue;
   const kind = detectIssueKind(issue);
   const reasons = [];
   const guidance = [];
+  let softPass = false;
+  const titleLower = title.toLowerCase();
 
   if (!kind) {
     // Not a structured form we validate.
-    return { kind: null, valid: true, reasons: [], guidance: [] };
+    return { kind: null, valid: true, softPass: false, reasons: [], guidance: [] };
   }
 
   if (kind === "feature") {
-    const goal = extractSection(body, "What are you trying to accomplish?") ??
-      extractSection(body, "Problem to solve");
-    const blocker = extractSection(body, "What prevents this today?");
-    const behaviour = extractSection(body, "What should OpenCodex do?") ??
-      extractSection(body, "Proposed solution");
-    const example = extractSection(body, "Example usage or interface");
+    const goal = resolveSection(body, FEATURE_GOAL_HEADINGS);
+    const blocker = resolveSection(body, FEATURE_BLOCKER_HEADINGS);
+    const behaviour = resolveSection(body, FEATURE_BEHAVIOUR_HEADINGS);
+    const example = resolveSection(body, FEATURE_EXAMPLE_HEADINGS);
 
     const coreSections = [goal, blocker, behaviour, example];
     const emptyCore = [];
     if (isEmpty(goal)) emptyCore.push("goal / problem");
-    // blocker and example are only required on the new form (heading exists).
-    // On the legacy form these sections are absent (null), which is acceptable.
+    // blocker and example are only required when those headings exist.
+    // On the legacy / translated forms these sections may be absent (null).
     if (blocker !== null && isEmpty(blocker)) emptyCore.push("current limitation");
     if (isEmpty(behaviour)) emptyCore.push("expected behaviour");
     if (example !== null && isEmpty(example)) emptyCore.push("example usage");
 
+    const mappedHeadingPresent =
+      goal !== null || blocker !== null || behaviour !== null || example !== null;
+
     if (emptyCore.length > 0) {
-      reasons.push(`Required sections are missing or empty: ${emptyCore.join(", ")}.`);
-      guidance.push("Fill in each required section with specific detail about your workflow.");
+      const canSoftPass =
+        !mappedHeadingPresent &&
+        titleLower.startsWith("[feature]:") &&
+        hasSubstantialStructuredContent(body);
+      if (canSoftPass) {
+        softPass = true;
+      } else {
+        reasons.push(`Required sections are missing or empty: ${emptyCore.join(", ")}.`);
+        guidance.push("Fill in each required section with specific detail about your workflow.");
+      }
     }
 
-    const nonEmpty = coreSections.filter((s) => !isEmpty(s));
-    if (nonEmpty.length >= 2 && allSameCanonical(nonEmpty)) {
-      reasons.push("All core sections contain the same content.");
-      guidance.push("Each section should describe a different aspect: goal, limitation, expected behaviour, and a concrete example.");
-    }
+    if (!softPass) {
+      const nonEmpty = coreSections.filter((s) => !isEmpty(s));
+      if (nonEmpty.length >= 2 && allSameCanonical(nonEmpty)) {
+        reasons.push("All core sections contain the same content.");
+        guidance.push("Each section should describe a different aspect: goal, limitation, expected behaviour, and a concrete example.");
+      }
 
-    if (nonEmpty.length >= 2 && allRepeatTitle(nonEmpty, title)) {
-      reasons.push("All core sections merely repeat the issue title.");
-      guidance.push("Expand each section with details beyond the title.");
-    }
+      if (nonEmpty.length >= 2 && allRepeatTitle(nonEmpty, title)) {
+        reasons.push("All core sections merely repeat the issue title.");
+        guidance.push("Expand each section with details beyond the title.");
+      }
 
-    if (nonEmpty.length > 0 && nonEmpty.every(isPlaceholder)) {
-      reasons.push("Required sections contain only placeholder text.");
-      guidance.push("Replace placeholder text with your actual proposal.");
+      if (nonEmpty.length > 0 && nonEmpty.every(isPlaceholder)) {
+        reasons.push("Required sections contain only placeholder text.");
+        guidance.push("Replace placeholder text with your actual proposal.");
+      }
     }
   }
 
@@ -261,8 +365,17 @@ function validateIssue(issue) {
     const os = extractSection(body, "Operating system") ?? extractSection(body, "OS");
 
     if (isEmpty(summary) && isEmpty(repro)) {
-      reasons.push("Both Summary and Reproduction are empty.");
-      guidance.push("Describe what happened and how to reproduce it.");
+      const canSoftPass =
+        summary === null &&
+        repro === null &&
+        titleLower.startsWith("[bug]:") &&
+        hasSubstantialStructuredContent(body);
+      if (canSoftPass) {
+        softPass = true;
+      } else {
+        reasons.push("Both Summary and Reproduction are empty.");
+        guidance.push("Describe what happened and how to reproduce it.");
+      }
     }
 
     // Required environment fields removed after submission.
@@ -271,26 +384,28 @@ function validateIssue(issue) {
     // Skip when the raw value is a "No response" placeholder -- the old form had
     // both fields as optional, so legacy issues legitimately contain those headings
     // with the GitHub placeholder. Only close when the field was actively cleared.
-    if (version !== null && os !== null && isEmpty(version) && isEmpty(os) &&
+    if (!softPass && version !== null && os !== null && isEmpty(version) && isEmpty(os) &&
         !isRawPlaceholder(version) && !isRawPlaceholder(os)) {
       reasons.push("Version and Operating system are both missing.");
       guidance.push("Add your OpenCodex version and OS so we can reproduce the environment.");
     }
 
-    const nonEmpty = [summary, repro].filter((s) => !isEmpty(s));
-    if (nonEmpty.length >= 2 && allSameCanonical(nonEmpty)) {
-      reasons.push("Summary and Reproduction contain the same content.");
-      guidance.push("Summary should describe the symptom; Reproduction should list the exact steps.");
-    }
+    if (!softPass) {
+      const nonEmpty = [summary, repro].filter((s) => !isEmpty(s));
+      if (nonEmpty.length >= 2 && allSameCanonical(nonEmpty)) {
+        reasons.push("Summary and Reproduction contain the same content.");
+        guidance.push("Summary should describe the symptom; Reproduction should list the exact steps.");
+      }
 
-    if (nonEmpty.length >= 1 && allRepeatTitle(nonEmpty, title)) {
-      reasons.push("Summary and Reproduction merely repeat the title.");
-      guidance.push("Add detail beyond the title: what you observed, what you expected, and the exact steps.");
-    }
+      if (nonEmpty.length >= 1 && allRepeatTitle(nonEmpty, title)) {
+        reasons.push("Summary and Reproduction merely repeat the title.");
+        guidance.push("Add detail beyond the title: what you observed, what you expected, and the exact steps.");
+      }
 
-    if (nonEmpty.length > 0 && nonEmpty.every(isPlaceholder)) {
-      reasons.push("Required sections contain only placeholder text.");
-      guidance.push("Replace placeholder text with your actual report.");
+      if (nonEmpty.length > 0 && nonEmpty.every(isPlaceholder)) {
+        reasons.push("Required sections contain only placeholder text.");
+        guidance.push("Replace placeholder text with your actual report.");
+      }
     }
   }
 
@@ -362,7 +477,8 @@ function validateIssue(issue) {
 
   return {
     kind,
-    valid: reasons.length === 0,
+    valid: reasons.length === 0 && !softPass,
+    softPass,
     reasons,
     guidance,
   };
@@ -401,8 +517,12 @@ module.exports = {
   normalise,
   canonicalise,
   extractSection,
+  resolveSection,
   detectIssueKind,
   validateIssue,
   shouldReopen,
   isRawPlaceholder,
+  labelForKind,
+  KIND_TO_LABEL,
+  hasSubstantialStructuredContent,
 };

--- a/.github/scripts/issue-quality.test.cjs
+++ b/.github/scripts/issue-quality.test.cjs
@@ -648,6 +648,49 @@ describe("translated feature headings and soft-pass", () => {
     assert.equal(result.kind, "bug");
     assert.equal(result.valid, true, `Expected valid bug but got: ${result.reasons.join("; ")}`);
   });
+
+  it("accepts US spelling Expected behavior as a behaviour alias", () => {
+    const result = validateIssue({
+      title: "[Feature]: Auto-advertise image inputModalities",
+      body: [
+        "### Goal / Problem",
+        "App blocks images before the vision sidecar can run.",
+        "### Expected behavior",
+        "Catalog should advertise image input when the sidecar covers the model.",
+      ].join("\n"),
+      labels: [],
+    });
+    assert.equal(result.kind, "feature");
+    assert.equal(result.valid, true, `Expected valid but got: ${result.reasons.join("; ")}`);
+  });
+
+  it("does not treat enhancement + non-goal aliases as a feature detect hit", () => {
+    assert.equal(
+      detectIssueKind({
+        title: "Something odd in the proxy",
+        body: [
+          "### Current limitation",
+          "No fallback provider today for upstream 5xx responses.",
+          "### Expected behaviour",
+          "Auto failover to a backup provider.",
+        ].join("\n"),
+        labels: ["enhancement"],
+      }),
+      null,
+    );
+  });
+
+  it("does not let a weak title-prefix detection override stored documentation kind", () => {
+    assert.equal(
+      detectIssueKind({
+        title: "[Feature]: rewrite the docs",
+        body: "Still working on the write-up.",
+        labels: [],
+        storedKind: "documentation",
+      }),
+      "documentation",
+    );
+  });
 });
 
 describe("labelForKind", () => {

--- a/.github/scripts/issue-quality.test.cjs
+++ b/.github/scripts/issue-quality.test.cjs
@@ -10,6 +10,7 @@ const {
   detectIssueKind,
   validateIssue,
   shouldReopen,
+  labelForKind,
 } = require("./issue-quality.cjs");
 
 // ---------------------------------------------------------------------------
@@ -515,5 +516,82 @@ describe("shouldReopen", () => {
       closed_by: "github-actions[bot]",
     };
     assert.equal(shouldReopen(baseBotState, issue, false), true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Translated / soft-pass / labels
+// ---------------------------------------------------------------------------
+
+describe("translated feature headings and soft-pass", () => {
+  it("accepts Goal / Problem + Expected behaviour as a valid feature", () => {
+    const body = [
+      "### Goal / Problem",
+      "Codex App rejects image paste for noVisionModels before the vision sidecar can run.",
+      "### Expected behaviour",
+      "Catalog should advertise image input when the vision sidecar covers the model.",
+      "### Environment",
+      "opencodex 2.7.36 on macOS with Codex App.",
+    ].join("\n");
+    const result = validateIssue({
+      title: "[Feature]: Auto-advertise image inputModalities for noVisionModels",
+      body,
+      labels: [],
+    });
+    assert.equal(result.kind, "feature");
+    assert.equal(result.valid, true, `Expected valid but got: ${result.reasons.join("; ")}`);
+    assert.equal(result.softPass, false);
+  });
+
+  it("soft-passes [Feature]: with rich custom headings outside the alias map", () => {
+    const body = [
+      "### Concrete user workflow that fails",
+      "User pastes an image in Codex App while a text-only routed model is selected and the App blocks upload.",
+      "### Why this matters",
+      "Vision sidecar is advertised but never reached from the App client path.",
+      "### Verification",
+      "Same proxy config works end-to-end in Claude Code with the sidecar describing the image.",
+    ].join("\n");
+    const result = validateIssue({
+      title: "[Feature]: Vision sidecar unusable from Codex App",
+      body,
+      labels: [],
+    });
+    assert.equal(result.kind, "feature");
+    assert.equal(result.softPass, true);
+    assert.equal(result.valid, false);
+  });
+
+  it("still rejects empty [Feature]: bodies", () => {
+    const result = validateIssue({
+      title: "[Feature]: do something cool",
+      body: "please add this",
+      labels: [],
+    });
+    assert.equal(result.kind, "feature");
+    assert.equal(result.valid, false);
+    assert.equal(result.softPass, false);
+  });
+
+  it("does not treat a title containing problem as a bug", () => {
+    assert.equal(
+      detectIssueKind({
+        title: "Problem with documentation wording",
+        body: "The docs are confusing about install.",
+        labels: [],
+      }),
+      null,
+    );
+  });
+});
+
+describe("labelForKind", () => {
+  it("maps kinds to triage labels", () => {
+    assert.equal(labelForKind("bug"), "bug");
+    assert.equal(labelForKind("feature"), "enhancement");
+    assert.equal(labelForKind("documentation"), "documentation");
+    assert.equal(labelForKind("provider-compatibility"), "provider-compatibility");
+    assert.equal(labelForKind(null), null);
+    assert.equal(labelForKind("unknown"), null);
   });
 });

--- a/.github/scripts/issue-quality.test.cjs
+++ b/.github/scripts/issue-quality.test.cjs
@@ -10,6 +10,7 @@ const {
   detectIssueKind,
   validateIssue,
   shouldReopen,
+  shouldEnforceClosure,
   labelForKind,
 } = require("./issue-quality.cjs");
 
@@ -516,6 +517,52 @@ describe("shouldReopen", () => {
       closed_by: "github-actions[bot]",
     };
     assert.equal(shouldReopen(baseBotState, issue, false), true);
+  });
+});
+
+describe("shouldEnforceClosure", () => {
+  it("enforces when there is no bot state yet", () => {
+    assert.equal(shouldEnforceClosure(null), true);
+  });
+
+  it("enforces while the bot still owns an active closure", () => {
+    assert.equal(
+      shouldEnforceClosure({
+        version: 2,
+        active: true,
+        kind: "feature",
+        closedAt: "2026-07-20T10:00:00Z",
+        stateReason: "not_planned",
+      }),
+      true,
+    );
+  });
+
+  it("does not enforce after a maintainer override", () => {
+    assert.equal(
+      shouldEnforceClosure({
+        version: 2,
+        active: false,
+        kind: "feature",
+        closedAt: "2026-07-20T10:00:00Z",
+        stateReason: "not_planned",
+        maintainerOverride: true,
+      }),
+      false,
+    );
+  });
+
+  it("still enforces after a normal active:false without maintainer override", () => {
+    assert.equal(
+      shouldEnforceClosure({
+        version: 2,
+        active: false,
+        kind: "feature",
+        closedAt: "2026-07-20T10:00:00Z",
+        stateReason: "not_planned",
+      }),
+      true,
+    );
   });
 });
 

--- a/.github/scripts/issue-quality.test.cjs
+++ b/.github/scripts/issue-quality.test.cjs
@@ -583,6 +583,71 @@ describe("translated feature headings and soft-pass", () => {
       null,
     );
   });
+
+  it("does not soft-pass long unstructured bodies without headings", () => {
+    const result = validateIssue({
+      title: "[Feature]: please add thing",
+      body: "x".repeat(250),
+      labels: [],
+    });
+    assert.equal(result.kind, "feature");
+    assert.equal(result.softPass, false);
+    assert.equal(result.valid, false);
+  });
+
+  it("does not classify Expected behaviour + Example as feature without a feature hint", () => {
+    assert.equal(
+      detectIssueKind({
+        title: "Something broke in the proxy",
+        body: [
+          "### Expected behaviour",
+          "Proxy should return 200.",
+          "### Example",
+          "curl localhost:10100/v1/responses",
+        ].join("\n"),
+        labels: [],
+      }),
+      null,
+    );
+  });
+
+  it("classifies alias headings as feature when a goal heading is present", () => {
+    assert.equal(
+      detectIssueKind({
+        title: "Advertise image input for sidecar models",
+        body: [
+          "### Goal / Problem",
+          "App blocks images before the sidecar runs.",
+          "### Expected behaviour",
+          "Catalog should advertise image input.",
+        ].join("\n"),
+        labels: [],
+      }),
+      "feature",
+    );
+  });
+
+  it("lets a strong bug form override a stale stored feature kind", () => {
+    const result = validateIssue({
+      title: "Crash on start",
+      body: [
+        "### Client or integration",
+        "Codex CLI",
+        "### Summary",
+        "Proxy segfaults on ARM64 when streaming is enabled.",
+        "### Reproduction",
+        "ocx start on Raspberry Pi 4, send any streaming request.",
+        "### Version",
+        "2.7.36",
+        "### Operating system",
+        "Linux",
+      ].join("\n"),
+      labels: ["bug"],
+      storedKind: "feature",
+    });
+    assert.equal(result.kind, "bug");
+    assert.equal(result.valid, true, `Expected valid bug but got: ${result.reasons.join("; ")}`);
+  });
 });
 
 describe("labelForKind", () => {

--- a/.github/workflows/enforce-issue-quality.yml
+++ b/.github/workflows/enforce-issue-quality.yml
@@ -1,7 +1,9 @@
 name: Enforce issue quality
 
-# Issue events use the workflow file from the repository default branch.
-# Merging this to `dev` alone does not activate it until it reaches that branch.
+# Issue events always load this workflow from the repository DEFAULT branch
+# (currently `main`), not from `dev`. Landing here on `dev` alone does not
+# change live issue-quality behavior until the change is also on that default
+# branch.
 on:
   issues:
     types:

--- a/.github/workflows/enforce-issue-quality.yml
+++ b/.github/workflows/enforce-issue-quality.yml
@@ -36,6 +36,7 @@ jobs:
               detectIssueKind,
               validateIssue,
               shouldReopen,
+              labelForKind,
             } = require(path.join(process.cwd(), ".github", "scripts", "issue-quality.cjs"));
 
             const { owner, repo } = context.repo;
@@ -133,6 +134,18 @@ jobs:
             const resolvedKind = kind ?? labelBasedKind;
 
             // -----------------------------------------------------------------
+            // Kind-based label (additive only)
+            // -----------------------------------------------------------------
+            const kindLabel = labelForKind(resolvedKind);
+            if (kindLabel && !labels.includes(kindLabel)) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number, labels: [kindLabel],
+              });
+              labels.push(kindLabel);
+              core.info(`Applied kind label "${kindLabel}".`);
+            }
+
+            // -----------------------------------------------------------------
             // Validate
             // -----------------------------------------------------------------
             const result = validateIssue({
@@ -143,9 +156,12 @@ jobs:
             });
 
             // -----------------------------------------------------------------
-            // VALID issue
+            // VALID or soft-pass issue (do not close)
             // -----------------------------------------------------------------
-            if (result.valid) {
+            if (result.valid || result.softPass) {
+              if (result.softPass) {
+                core.info("Soft-pass: substantial content without mapped form headings; skipping closure.");
+              }
               // If the bot previously closed it, consider reopening.
               if (botState?.active && issue.state === "closed") {
                 // Normalise closed_by from the API object to a plain login string.
@@ -241,7 +257,7 @@ jobs:
             const newBotState = {
               version: 2,
               active: true,
-              kind,
+              kind: resolvedKind,
               closedAt: closedIssue.closed_at,
               stateReason: closedIssue.state_reason || "not_planned",
             };

--- a/.github/workflows/enforce-issue-quality.yml
+++ b/.github/workflows/enforce-issue-quality.yml
@@ -1,5 +1,7 @@
 name: Enforce issue quality
 
+# Issue events use the workflow file from the repository default branch.
+# Merging this to `dev` alone does not activate it until it reaches that branch.
 on:
   issues:
     types:
@@ -110,11 +112,12 @@ jobs:
             const labels = (issue.labels || []).map((l) =>
               typeof l === "string" ? l : l.name,
             );
+            const activeBotKind = botState?.active ? (botState.kind || null) : null;
             const kind = detectIssueKind({
               title: issue.title,
               body: issue.body || "",
               labels,
-              storedKind: botState?.kind || null,
+              storedKind: activeBotKind,
             });
 
             // If headings were stripped but the form label is still present,
@@ -138,11 +141,15 @@ jobs:
             // -----------------------------------------------------------------
             const kindLabel = labelForKind(resolvedKind);
             if (kindLabel && !labels.includes(kindLabel)) {
-              await github.rest.issues.addLabels({
-                owner, repo, issue_number, labels: [kindLabel],
-              });
-              labels.push(kindLabel);
-              core.info(`Applied kind label "${kindLabel}".`);
+              try {
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number, labels: [kindLabel],
+                });
+                labels.push(kindLabel);
+                core.info(`Applied kind label "${kindLabel}".`);
+              } catch (err) {
+                core.warning(`Failed to apply kind label "${kindLabel}": ${err.message || err}`);
+              }
             }
 
             // -----------------------------------------------------------------
@@ -152,7 +159,10 @@ jobs:
               title: issue.title,
               body: issue.body || "",
               labels,
-              storedKind: botState?.kind || resolvedKind || null,
+              // Active bot kind survives heading removal; resolvedKind covers
+              // label-based enforcement. Strong conflicting body forms override
+              // inside detectIssueKind.
+              storedKind: activeBotKind || resolvedKind || null,
             });
 
             // -----------------------------------------------------------------
@@ -178,13 +188,16 @@ jobs:
                     owner, repo, issue_number, state: "open",
                   });
                   const doneState = { ...botState, active: false };
+                  const reopenBlurb = result.softPass
+                    ? "The automated check no longer treats this report as insufficient detail (substantial structured content was found). Thanks for updating it."
+                    : "The report now contains the information required by the automated check. Thanks for updating it.";
                   await upsertComment([
                     BOT_MARKER,
                     stateTag(doneState),
                     "",
                     "### Issue reopened",
                     "",
-                    "The report now contains the information required by the automated check. Thanks for updating it.",
+                    reopenBlurb,
                   ].join("\n"));
                 } else if (actorIsMaintainer) {
                   // Maintainer changed the state — respect it, mark inactive.
@@ -201,13 +214,16 @@ jobs:
               } else if (botState?.active && issue.state === "open") {
                 // Already open and valid — deactivate bot state silently.
                 const doneState = { ...botState, active: false };
+                const reopenBlurb = result.softPass
+                  ? "The automated check no longer treats this report as insufficient detail (substantial structured content was found). Thanks for updating it."
+                  : "The report now contains the information required by the automated check. Thanks for updating it.";
                 await upsertComment([
                   BOT_MARKER,
                   stateTag(doneState),
                   "",
                   "### Issue reopened",
                   "",
-                  "The report now contains the information required by the automated check. Thanks for updating it.",
+                  reopenBlurb,
                 ].join("\n"));
               }
               return;

--- a/.github/workflows/enforce-issue-quality.yml
+++ b/.github/workflows/enforce-issue-quality.yml
@@ -40,6 +40,7 @@ jobs:
               detectIssueKind,
               validateIssue,
               shouldReopen,
+              shouldEnforceClosure,
               labelForKind,
             } = require(path.join(process.cwd(), ".github", "scripts", "issue-quality.cjs"));
 
@@ -241,20 +242,32 @@ jobs:
               return;
             }
 
-            // Maintainer intentionally reopened — do not close again.
+            // Maintainer intentionally reopened — deactivate enforcement permanently
+            // for this issue so later `edited` runs do not close it again.
             if (eventType === "reopened" && actorIsMaintainer) {
               core.info("Maintainer reopened the issue; respecting their decision.");
-              if (botState?.active) {
-                const doneState = { ...botState, active: false };
-                await upsertComment([
-                  BOT_MARKER,
-                  stateTag(doneState),
-                  "",
-                  "### Maintainer decision respected",
-                  "",
-                  "A maintainer has reopened this issue. The automated closure has been deactivated.",
-                ].join("\n"));
-              }
+              const doneState = {
+                version: 2,
+                active: false,
+                kind: botState?.kind || resolvedKind || null,
+                closedAt: botState?.closedAt || null,
+                stateReason: botState?.stateReason || null,
+                maintainerOverride: true,
+              };
+              await upsertComment([
+                BOT_MARKER,
+                stateTag(doneState),
+                "",
+                "### Maintainer decision respected",
+                "",
+                "A maintainer has reopened this issue. The automated closure has been deactivated.",
+              ].join("\n"));
+              return;
+            }
+
+            // Prior maintainer override — do not re-close on later edits.
+            if (!shouldEnforceClosure(botState)) {
+              core.info("Bot enforcement was deactivated by a maintainer; skipping closure.");
               return;
             }
 


### PR DESCRIPTION
## Summary
- Accept translated/legacy feature headings (`Goal / Problem`, `Expected behaviour`, …) so triage-translated issues validate instead of auto-closing.
- Soft-pass rich `[Feature]:` / `[Bug]:` bodies that have real `###` content but no mapped form headings (no close).
- When kind is known, add the matching triage label (`bug` / `enhancement` / `documentation` / `provider-compatibility`) if missing; never remove labels; never keyword-guess.

## Why
`enforce-issue-quality` closed detailed reports like #344 / #349 because `[Feature]:` forced English form-heading checks after translation rewrote section titles. Labels from PR #229 only apply via issue forms — freeform/translated issues stayed unlabeled.

## Test plan
- [x] `node --test .github/scripts/issue-quality.test.cjs` (41 pass)
- [ ] Open a `[Feature]:` issue with `Goal / Problem` + `Expected behaviour` filled → stays open, gets `enhancement`
- [ ] Open a `[Feature]:` issue with rich custom headings only → stays open (soft-pass), gets `enhancement`
- [ ] Open empty `[Feature]:` / blank form → still auto-closes
- [ ] Official English feature/bug/docs/provider forms still enforce as before