### PR TITLE
fix: repair oversized Responses call IDs on replay

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { IncomingMeta, ProviderAdapter } from "./base";
 import type { AdapterEvent, OcxParsedRequest, OcxProviderConfig } from "../types";
 import { catalogModelSupportsReasoningSummaries } from "../codex/catalog";
@@ -328,6 +329,55 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
   return !!v && typeof v === "object" && !Array.isArray(v);
 }
 
+const MAX_RESPONSES_CALL_ID_LENGTH = 64;
+const REPAIRED_CALL_ID_PREFIX = "call_ocx_";
+const REPAIRED_CALL_ID_DIGEST_LENGTH = MAX_RESPONSES_CALL_ID_LENGTH - REPAIRED_CALL_ID_PREFIX.length;
+
+/**
+ * The ChatGPT Responses backend rejects input `call_id` values longer than 64 characters. Codex
+ * sidechat/fork replay can namespace call ids from routed providers past that limit. Forward mode
+ * already sends explicit replay input without `previous_response_id`, so it is safe to replace each
+ * oversized id and every matching call/output occurrence with one deterministic request-local alias.
+ * Raw API-key continuations are intentionally excluded because an output-only continuation may
+ * reference a call stored upstream under the original id. Proxy-expanded API-key replays are
+ * explicit and stateless here, so they are safe to repair too.
+ */
+function repairOversizedReplayCallIds(body: unknown): unknown {
+  if (!isPlainObject(body) || !Array.isArray(body.input)) return body;
+
+  const occupied = new Set<string>();
+  for (const item of body.input) {
+    if (!isPlainObject(item) || typeof item.call_id !== "string") continue;
+    if (item.call_id.length <= MAX_RESPONSES_CALL_ID_LENGTH) occupied.add(item.call_id);
+  }
+
+  const aliases = new Map<string, string>();
+  let changed = false;
+  const input = body.input.map(item => {
+    if (!isPlainObject(item) || typeof item.call_id !== "string") return item;
+    const original = item.call_id;
+    if (original.length <= MAX_RESPONSES_CALL_ID_LENGTH) return item;
+
+    let alias = aliases.get(original);
+    if (!alias) {
+      let salt = 0;
+      do {
+        const hashInput = salt === 0 ? original : `${original}\0${salt}`;
+        const digest = createHash("sha256").update(hashInput).digest("hex");
+        alias = `${REPAIRED_CALL_ID_PREFIX}${digest.slice(0, REPAIRED_CALL_ID_DIGEST_LENGTH)}`;
+        salt += 1;
+      } while (occupied.has(alias));
+      aliases.set(original, alias);
+      occupied.add(alias);
+    }
+
+    changed = true;
+    return { ...item, call_id: alias };
+  });
+
+  return changed ? { ...body, input } : body;
+}
+
 /** Flatten a Responses tool-output `output` value (string or content-part array) to plain text. */
 function toolOutputText(output: unknown): string {
   if (typeof output === "string") return output;
@@ -515,8 +565,13 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
         parsed._rawBody,
         forward || parsed._previousResponseInputExpanded === true,
       );
-      if (forward) outBody = repairOrphanedInputItems(outBody, unexpandedMiss);
+      if (forward) {
+        outBody = repairOrphanedInputItems(outBody, unexpandedMiss);
+      }
       else outBody = stripConflictingHostedTools(outBody);
+      if (forward || parsed._previousResponseInputExpanded === true) {
+        outBody = repairOversizedReplayCallIds(outBody);
+      }
       outBody = stripUnsupportedReasoningSummaryDelivery(outBody, parsed.modelId);
       return {
         url,

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -142,6 +142,13 @@ messages until the round completes, reattaching real results to their original c
 and synthesizing explicit "no tool result was recorded" answers only when no real result exists
 (Kimi/Moonshot 400 `ocx-mrqaiw05-269`; unit `devlog/_plan/260718_dangling_toolcall_hardening`).
 
+Forward-mode OpenAI passthrough also repairs replayed `call_id` values longer than the Responses
+API's 64-character limit. Sidechat/fork replay can namespace routed-provider ids beyond that limit,
+so each oversized id and all matching call/output items receive the same deterministic,
+request-local alias. Raw API-key continuations deliberately preserve ids because an output-only
+continuation may reference a call stored upstream under its original id; proxy-expanded API-key
+replays are explicit and receive the same repair.
+
 These compatibility guards are covered by focused tests and should stay close to the adapters that
 need them.
 

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -432,6 +432,116 @@ describe("OpenAI Responses passthrough sanitization", () => {
     expect(body.input).toEqual(input);
   });
 
+  test("forward mode repairs oversized call ids consistently across paired replay items", () => {
+    const adapter = createResponsesPassthroughAdapter(provider);
+    const oversizedCallId = `call_${"x".repeat(80)}`;
+    const input = [
+      { type: "function_call", call_id: oversizedCallId, name: "ping", arguments: "{}" },
+      { type: "function_call_output", call_id: oversizedCallId, output: "pong" },
+      { type: "function_call", call_id: "call_short", name: "keep", arguments: "{}" },
+      { type: "function_call_output", call_id: "call_short", output: "kept" },
+    ];
+
+    const body = JSON.parse(adapter.buildRequest({
+      modelId: "gpt-5.6-sol",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: { model: "gpt-5.6-sol", input },
+    }, meta).body) as { input: Record<string, unknown>[] };
+
+    const repairedCallId = body.input[0].call_id as string;
+    expect(repairedCallId).toStartWith("call_ocx_");
+    expect(repairedCallId.length).toBeLessThanOrEqual(64);
+    expect(body.input[1].call_id).toBe(repairedCallId);
+    expect(body.input[2].call_id).toBe("call_short");
+    expect(body.input[3].call_id).toBe("call_short");
+    expect(input[0].call_id).toBe(oversizedCallId);
+    expect(input[1].call_id).toBe(oversizedCallId);
+  });
+
+  test("forward mode assigns distinct stable aliases to oversized custom and tool-search pairs", () => {
+    const adapter = createResponsesPassthroughAdapter(provider);
+    const customCallId = `call_custom_${"a".repeat(80)}`;
+    const searchCallId = `call_search_${"b".repeat(80)}`;
+    const input = [
+      { type: "custom_tool_call", call_id: customCallId, name: "apply_patch", input: "patch" },
+      { type: "custom_tool_call_output", call_id: customCallId, output: "done" },
+      { type: "tool_search_call", call_id: searchCallId, execution: "client", arguments: {} },
+      { type: "tool_search_output", call_id: searchCallId, tools: [] },
+    ];
+
+    const build = () => JSON.parse(adapter.buildRequest({
+      modelId: "gpt-5.6-sol",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: { model: "gpt-5.6-sol", input },
+    }, meta).body) as { input: Record<string, unknown>[] };
+
+    const first = build().input;
+    const second = build().input;
+    expect(first[0].call_id).toBe(first[1].call_id);
+    expect(first[2].call_id).toBe(first[3].call_id);
+    expect(first[0].call_id).not.toBe(first[2].call_id);
+    expect((first[0].call_id as string).length).toBeLessThanOrEqual(64);
+    expect((first[2].call_id as string).length).toBeLessThanOrEqual(64);
+    expect(second.map(item => item.call_id)).toEqual(first.map(item => item.call_id));
+  });
+
+  test("api-key mode preserves oversized call ids that may reference upstream stored state", () => {
+    const adapter = createResponsesPassthroughAdapter({
+      adapter: "openai-responses",
+      baseUrl: "https://api.openai.example/v1",
+      authMode: "key" as const,
+      apiKey: "sk-test",
+    });
+    const oversizedCallId = `call_${"stored".repeat(14)}`;
+    const input = [
+      { type: "function_call_output", call_id: oversizedCallId, output: "pong" },
+    ];
+
+    const body = JSON.parse(adapter.buildRequest({
+      ...parsedBase,
+      _rawBody: {
+        model: "gpt-5.5",
+        previous_response_id: "resp_stored",
+        input,
+      },
+    }, meta).body) as { previous_response_id: string; input: Array<{ call_id: string }> };
+
+    expect(body.previous_response_id).toBe("resp_stored");
+    expect(body.input[0]?.call_id).toBe(oversizedCallId);
+  });
+
+  test("api-key mode repairs oversized call ids after proxy-expanded replay", () => {
+    const adapter = createResponsesPassthroughAdapter({
+      adapter: "openai-responses",
+      baseUrl: "https://api.openai.example/v1",
+      authMode: "key" as const,
+      apiKey: "sk-test",
+    });
+    const oversizedCallId = `call_${"expanded".repeat(12)}`;
+
+    const body = JSON.parse(adapter.buildRequest({
+      ...parsedBase,
+      _previousResponseInputExpanded: true,
+      _rawBody: {
+        model: "gpt-5.5",
+        previous_response_id: "resp_expanded",
+        input: [
+          { type: "function_call", call_id: oversizedCallId, name: "ping", arguments: "{}" },
+          { type: "function_call_output", call_id: oversizedCallId, output: "pong" },
+        ],
+      },
+    }, meta).body) as { previous_response_id?: string; input: Array<{ call_id: string }> };
+
+    expect(body.previous_response_id).toBeUndefined();
+    expect(body.input[0]?.call_id).toStartWith("call_ocx_");
+    expect(body.input[0]?.call_id.length).toBe(64);
+    expect(body.input[1]?.call_id).toBe(body.input[0]?.call_id);
+  });
+
   test("forward expanded replay keeps reasoning items (chain is intact)", () => {
     const adapter = createResponsesPassthroughAdapter(provider);
     const body = JSON.parse(adapter.buildRequest({


### PR DESCRIPTION
## Summary

- repair replayed Responses `call_id` values that exceed the upstream 64-character limit
- preserve call/output pairing with deterministic request-local aliases
- keep raw API-key continuations unchanged while repairing explicit proxy-expanded replays
- document the compatibility behavior and add focused regression coverage

## Root cause

A Codex sidechat/fork can replay tool history produced by a routed provider into a native OpenAI model. Namespacing during that replay can produce `call_id` values longer than 64 characters, causing the ChatGPT Responses backend to reject the request, for example:

```text
Invalid 'input[32].call_id': string too long. Expected a string with maximum length 64, but got a string with length 85 instead.
```

Forward mode already removes `previous_response_id` and sends explicit replay input, so every occurrence of an oversized ID can safely be remapped together. Raw API-key continuations retain their original IDs because they may reference upstream-stored state; API-key requests are repaired only after the proxy has expanded the replay locally.

## Validation

- `bun test --isolate ./tests/openai-responses-passthrough.test.ts ./tests/responses-state.test.ts` — 53 passed
- `bun run typecheck`
- `bun run privacy:scan`
- manual end-to-end verification on OpenCodex 2.7.35: the previously failing routed-task → native-GPT sidechat now succeeds

The complete local suite was not used as a gate because this macOS environment lacks the `Bun.Image` runtime used by unrelated image-normalization tests and showed unrelated integration-test timeouts; focused tests and CI cover this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OpenAI Responses passthrough requests that contained oversized replayed call IDs.
  * Repaired affected call and tool-result pairs with deterministic, bounded-length aliases while preserving their relationships.
  * Added safeguards to keep distinct tool call types from receiving conflicting aliases.

* **Documentation**
  * Documented call ID compatibility behavior across forwarded and proxy-expanded replays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->