### PR TITLE
fix(release): full channel changelog in GitHub release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,9 +329,10 @@ jobs:
             prerelease_flag="--prerelease"
           fi
 
-          # Build notes once for create and edit: PR categories from generate-notes, plus
-          # every commit in the channel range (branch merges and direct commits that
-          # generate-notes omits because it is PR-only).
+          # Build notes once: PR categories from generate-notes, plus every commit in the
+          # channel range (branch merges and direct commits that generate-notes omits
+          # because it is PR-only). Preflight already rejects an existing GitHub Release
+          # for non-dry runs, so this step only creates.
           notes_file="$(mktemp)"
           generate_notes_api=(
             "repos/${GITHUB_REPOSITORY}/releases/generate-notes"
@@ -341,7 +342,8 @@ jobs:
           if [ -n "$previous_tag" ]; then
             generate_notes_api+=(-f "previous_tag_name=${previous_tag}")
           fi
-          pr_notes="$(gh api "${generate_notes_api[@]}" --jq '.body' 2>/dev/null || true)"
+          # Fail closed: missing PR categories is a broken release note, not a soft skip.
+          pr_notes="$(gh api "${generate_notes_api[@]}" --jq '.body')"
           # Drop generate-notes' trailing compare link; we re-append it after the commit list.
           pr_notes="$(printf '%s\n' "$pr_notes" | sed '/^\*\*Full Changelog\*\*:/d')"
 
@@ -349,6 +351,8 @@ jobs:
             commit_range="${previous_tag}..${GITHUB_SHA}"
             commits="$(git log --pretty=format:'- %s (%h)' "$commit_range")"
           else
+            # First release on a channel has no previous tag; cap history so the notes
+            # body stays within GitHub release size limits.
             commits="$(git log --pretty=format:'- %s (%h)' --max-count=100 "$GITHUB_SHA")"
           fi
 
@@ -367,9 +371,5 @@ jobs:
             fi
           } > "$notes_file"
 
-          if gh release view "$release_tag" >/dev/null 2>&1; then
-            gh release edit "$release_tag" --title "$release_tag" --notes-file "$notes_file" ${prerelease_flag:+$prerelease_flag}
-          else
-            gh release create "$release_tag" --target "$GITHUB_SHA" --title "$release_tag" \
-              --notes-file "$notes_file" ${prerelease_flag:+$prerelease_flag}
-          fi
+          gh release create "$release_tag" --target "$GITHUB_SHA" --title "$release_tag" \
+            --notes-file "$notes_file" ${prerelease_flag:+$prerelease_flag}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,18 +329,23 @@ jobs:
           # tag need not exist yet. Preflight already rejects an existing GitHub Release for
           # non-dry runs, so this step only creates.
           notes_file="$(mktemp)"
-          generate_notes_api=(
-            "repos/${GITHUB_REPOSITORY}/releases/generate-notes"
-            -f "tag_name=${release_tag}"
-            -f "target_commitish=${GITHUB_SHA}"
-          )
+          pr_notes=""
           if [ -n "$previous_tag" ]; then
-            generate_notes_api+=(-f "previous_tag_name=${previous_tag}")
+            generate_notes_api=(
+              "repos/${GITHUB_REPOSITORY}/releases/generate-notes"
+              -f "tag_name=${release_tag}"
+              -f "target_commitish=${GITHUB_SHA}"
+              -f "previous_tag_name=${previous_tag}"
+            )
+            # Fail closed: missing PR categories is a broken release note, not a soft skip.
+            pr_notes="$(gh api "${generate_notes_api[@]}" --jq '.body')"
+            # Drop generate-notes' trailing compare link; we re-append it after the commit list.
+            pr_notes="$(printf '%s\n' "$pr_notes" | sed '/^\*\*Full Changelog\*\*:/d')"
+          else
+            # First release on this channel: never call generate-notes without previous_tag_name.
+            # GitHub would baseline the newest repo tag, which may belong to the other channel.
+            echo "::notice::No previous channel tag; skipping generate-notes (commits-only notes)"
           fi
-          # Fail closed: missing PR categories is a broken release note, not a soft skip.
-          pr_notes="$(gh api "${generate_notes_api[@]}" --jq '.body')"
-          # Drop generate-notes' trailing compare link; we re-append it after the commit list.
-          pr_notes="$(printf '%s\n' "$pr_notes" | sed '/^\*\*Full Changelog\*\*:/d')"
 
           if [ -n "$previous_tag" ]; then
             commit_range="${previous_tag}..${GITHUB_SHA}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,26 +329,47 @@ jobs:
             prerelease_flag="--prerelease"
           fi
 
-          if gh release view "$release_tag" >/dev/null 2>&1; then
-            notes_file="$(mktemp)"
-            generate_notes_api=(
-              "repos/${GITHUB_REPOSITORY}/releases/generate-notes"
-              -f "tag_name=${release_tag}"
-              -f "target_commitish=${GITHUB_SHA}"
-            )
-            if [ -n "$previous_tag" ]; then
-              generate_notes_api+=(-f "previous_tag_name=${previous_tag}")
+          # Build notes once for create and edit: PR categories from generate-notes, plus
+          # every commit in the channel range (branch merges and direct commits that
+          # generate-notes omits because it is PR-only).
+          notes_file="$(mktemp)"
+          generate_notes_api=(
+            "repos/${GITHUB_REPOSITORY}/releases/generate-notes"
+            -f "tag_name=${release_tag}"
+            -f "target_commitish=${GITHUB_SHA}"
+          )
+          if [ -n "$previous_tag" ]; then
+            generate_notes_api+=(-f "previous_tag_name=${previous_tag}")
+          fi
+          pr_notes="$(gh api "${generate_notes_api[@]}" --jq '.body' 2>/dev/null || true)"
+          # Drop generate-notes' trailing compare link; we re-append it after the commit list.
+          pr_notes="$(printf '%s\n' "$pr_notes" | sed '/^\*\*Full Changelog\*\*:/d')"
+
+          if [ -n "$previous_tag" ]; then
+            commit_range="${previous_tag}..${GITHUB_SHA}"
+            commits="$(git log --pretty=format:'- %s (%h)' "$commit_range")"
+          else
+            commits="$(git log --pretty=format:'- %s (%h)' --max-count=100 "$GITHUB_SHA")"
+          fi
+
+          {
+            printf '%s\n\n' "$npm_metadata"
+            if [ -n "$(printf '%s' "$pr_notes" | tr -d '[:space:]')" ]; then
+              printf '%s\n\n' "$pr_notes"
             fi
-            {
-              printf '%s\n\n' "$npm_metadata"
-              gh api "${generate_notes_api[@]}" --jq '.body'
-            } > "$notes_file"
+            if [ -n "$commits" ]; then
+              printf '## Commits\n\n'
+              printf '%s\n\n' "$commits"
+            fi
+            if [ -n "$previous_tag" ]; then
+              printf '**Full Changelog**: https://github.com/%s/compare/%s...%s\n' \
+                "$GITHUB_REPOSITORY" "$previous_tag" "$release_tag"
+            fi
+          } > "$notes_file"
+
+          if gh release view "$release_tag" >/dev/null 2>&1; then
             gh release edit "$release_tag" --title "$release_tag" --notes-file "$notes_file" ${prerelease_flag:+$prerelease_flag}
           else
-            generate_notes_args=(--generate-notes)
-            if [ -n "$previous_tag" ]; then
-              generate_notes_args+=(--notes-start-tag "$previous_tag")
-            fi
             gh release create "$release_tag" --target "$GITHUB_SHA" --title "$release_tag" \
-              --notes "$npm_metadata" "${generate_notes_args[@]}" ${prerelease_flag:+$prerelease_flag}
+              --notes-file "$notes_file" ${prerelease_flag:+$prerelease_flag}
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,11 +317,6 @@ jobs:
           fi
           npm_metadata="Published to npm as \`@bitkyc08/opencodex@${RELEASE_VERSION}\` with dist-tag \`${NPM_DIST_TAG}\`."
 
-          if [ -z "$existing_tag_sha" ]; then
-            git tag "$release_tag" "$GITHUB_SHA"
-            git push origin "refs/tags/${release_tag}"
-          fi
-
           # Preview builds must be marked prerelease so GitHub "latest" keeps pointing at the
           # stable channel (matching npm dist-tags); see issue #64.
           prerelease_flag=""
@@ -329,10 +324,10 @@ jobs:
             prerelease_flag="--prerelease"
           fi
 
-          # Build notes once: PR categories from generate-notes, plus every commit in the
-          # channel range (branch merges and direct commits that generate-notes omits
-          # because it is PR-only). Preflight already rejects an existing GitHub Release
-          # for non-dry runs, so this step only creates.
+          # Build notes before tagging: if generate-notes fails after a tag push, preflight
+          # blocks retries because the tag already exists. API uses target_commitish, so the
+          # tag need not exist yet. Preflight already rejects an existing GitHub Release for
+          # non-dry runs, so this step only creates.
           notes_file="$(mktemp)"
           generate_notes_api=(
             "repos/${GITHUB_REPOSITORY}/releases/generate-notes"
@@ -370,6 +365,11 @@ jobs:
                 "$GITHUB_REPOSITORY" "$previous_tag" "$release_tag"
             fi
           } > "$notes_file"
+
+          if [ -z "$existing_tag_sha" ]; then
+            git tag "$release_tag" "$GITHUB_SHA"
+            git push origin "refs/tags/${release_tag}"
+          fi
 
           gh release create "$release_tag" --target "$GITHUB_SHA" --title "$release_tag" \
             --notes-file "$notes_file" ${prerelease_flag:+$prerelease_flag}

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -125,12 +125,17 @@ describe("GitHub Actions hardening", () => {
     expect(workflow).toContain("preview releases must use a preview prerelease version");
 
     // Release notes must include PR categories and the full channel commit range
-    // (branch merges + direct commits), for both create and edit paths.
+    // (branch merges + direct commits). Preflight forbids an existing release, so
+    // only create (not edit) is wired.
     expect(workflow).toContain("releases/generate-notes");
     expect(workflow).toContain("## Commits");
     expect(workflow).toContain("git log --pretty=format:'- %s (%h)'");
-    expect(workflow).toContain("--notes-file \"$notes_file\"");
+    expect(workflow).toContain('commit_range="${previous_tag}..${GITHUB_SHA}"');
+    expect(workflow).toMatch(/gh release create[\s\S]*?--notes-file "\$notes_file"/);
+    expect(workflow).not.toContain("gh release edit");
     expect(workflow).not.toContain("--generate-notes");
+    // Fail closed when generate-notes fails (no soft skip).
+    expect(workflow).not.toMatch(/generate-notes[\s\S]*?\|\| true/);
   });
 
   test("docs deployment is pinned, bounded, and scoped to Pages", async () => {

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -123,6 +123,14 @@ describe("GitHub Actions hardening", () => {
     expect(workflow).toContain("Release must run from main or preview");
     expect(workflow).toContain("main releases must use a stable semver version");
     expect(workflow).toContain("preview releases must use a preview prerelease version");
+
+    // Release notes must include PR categories and the full channel commit range
+    // (branch merges + direct commits), for both create and edit paths.
+    expect(workflow).toContain("releases/generate-notes");
+    expect(workflow).toContain("## Commits");
+    expect(workflow).toContain("git log --pretty=format:'- %s (%h)'");
+    expect(workflow).toContain("--notes-file \"$notes_file\"");
+    expect(workflow).not.toContain("--generate-notes");
   });
 
   test("docs deployment is pinned, bounded, and scoped to Pages", async () => {

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -131,6 +131,8 @@ describe("GitHub Actions hardening", () => {
     expect(workflow).toContain("## Commits");
     expect(workflow).toContain("git log --pretty=format:'- %s (%h)'");
     expect(workflow).toContain('commit_range="${previous_tag}..${GITHUB_SHA}"');
+    expect(workflow).toContain('previous_tag_name=${previous_tag}');
+    expect(workflow).toContain("skipping generate-notes (commits-only notes)");
     expect(workflow).toMatch(/gh release create[\s\S]*?--notes-file "\$notes_file"/);
     expect(workflow).not.toContain("gh release edit");
     expect(workflow).not.toContain("--generate-notes");
@@ -142,6 +144,11 @@ describe("GitHub Actions hardening", () => {
     expect(createStep.indexOf("gh api")).toBeGreaterThan(-1);
     expect(createStep.indexOf('git tag "$release_tag"')).toBeGreaterThan(-1);
     expect(createStep.indexOf("gh api")).toBeLessThan(createStep.indexOf('git tag "$release_tag"'));
+    // First-channel releases must not call generate-notes without an explicit channel baseline
+    // (GitHub would otherwise pick the newest repo tag, possibly from the other channel).
+    expect(createStep).toMatch(
+      /if \[ -n "\$previous_tag" \]; then[\s\S]*previous_tag_name=\$\{previous_tag\}[\s\S]*else[\s\S]*skipping generate-notes/,
+    );
   });
 
   test("docs deployment is pinned, bounded, and scoped to Pages", async () => {

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -136,6 +136,12 @@ describe("GitHub Actions hardening", () => {
     expect(workflow).not.toContain("--generate-notes");
     // Fail closed when generate-notes fails (no soft skip).
     expect(workflow).not.toMatch(/generate-notes[\s\S]*?\|\| true/);
+    // Notes must be assembled before tagging so a notes API failure does not leave
+    // a remote tag that blocks release retries at preflight.
+    const createStep = workflow.split("- name: Create GitHub release")[1]!.split(/\n {6}- name:/)[0]!;
+    expect(createStep.indexOf("gh api")).toBeGreaterThan(-1);
+    expect(createStep.indexOf('git tag "$release_tag"')).toBeGreaterThan(-1);
+    expect(createStep.indexOf("gh api")).toBeLessThan(createStep.indexOf('git tag "$release_tag"'));
   });
 
   test("docs deployment is pinned, bounded, and scoped to Pages", async () => {


### PR DESCRIPTION
## Summary
- Release notes for both **preview** and **latest** now keep GitHub `generate-notes` PR categories and append a `## Commits` section from the channel-scoped previous tag (branch merges + direct commits that PR-only notes omit).
- Create and edit paths both use the same `--notes-file` body so republishing a tag gets the same full notes.
- Contract test asserts the commits log and that `--generate-notes` is no longer used alone on create.

## Test plan
- [x] `bun test tests/ci-workflows.test.ts`
- [ ] Next preview/latest `workflow_dispatch` publish: verify release body has PR categories, Commits list, and Full Changelog compare link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * GitHub releases now consistently generate complete release notes from pull request content using a dedicated notes document.
  * Notes include a regenerated single “Full Changelog” compare link and a curated “Commits” section for the relevant range.
  * Release creation behavior is now uniform, with prerelease handling supported and tagging performed after notes are assembled.

* **Tests**
  * CI assertions were expanded to verify the release-notes generation flow, commit formatting/range, and that note-generation failures are not silently ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->