### PR TITLE
[WRONG BRANCH] fix: stop repeating multi-agent guidance on tool continuations

### DIFF
--- a/src/server/responses.ts
+++ b/src/server/responses.ts
@@ -1,6 +1,6 @@
 // AUTO-SPLIT facade: original responses.ts body moved into ./responses/* modules.
 // Public surface preserved exactly; importers keep using "src/server/responses".
-export { buildToolBridgeMaps, isV1CollabSurface, collabSurface, multiAgentGuidanceText, V2_GUIDANCE_CHAR_BUDGET, injectDeveloperMessage } from "./responses/collaboration";
+export { buildToolBridgeMaps, isV1CollabSurface, collabSurface, isToolOutputContinuation, multiAgentGuidanceForRequest, multiAgentGuidanceText, V2_GUIDANCE_CHAR_BUDGET, injectDeveloperMessage } from "./responses/collaboration";
 export type { MultiAgentGuidanceOptions, MultiAgentGuidanceDeps } from "./responses/collaboration";
 export { hasUnreadableEncryptedAgentTask, sanitizeEncryptedContentInPlace } from "./responses/encrypted-payload";
 export { COMPACT_RESPONSE_MAX_BYTES, bufferCompactResponse, handleResponsesCompact } from "./responses/compact";

--- a/src/server/responses/collaboration.ts
+++ b/src/server/responses/collaboration.ts
@@ -200,6 +200,11 @@ export async function multiAgentGuidanceText(
   if (surface === null) return null;
 
   if (surface === "v2") {
+    // A whitespace-only override used to produce `<multi_agent_mode> </multi_agent_mode>`.
+    // Treat an explicitly blank custom prompt as silent instead of emitting a no-op
+    // developer message on every request continuation.
+    if (injectionPrompt !== undefined && injectionPrompt.trim() === "") return null;
+
     // codex-rs supplies the Proactive text on v2; the proxy only adds model-designation
     // guidance, and only when there is something concrete to designate: a configured
     // injectionModel and/or a roster entry that resolves in the injected catalog.
@@ -252,6 +257,30 @@ export async function multiAgentGuidanceText(
   return `<multi_agent_mode>${PROACTIVE_MULTI_AGENT_MODE_TEXT}</multi_agent_mode>`;
 }
 
+/** True when the raw Responses request contains only tool-result delta items. */
+export function isToolOutputContinuation(body: unknown): boolean {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return false;
+  const input = (body as { input?: unknown }).input;
+  return Array.isArray(input)
+    && input.length > 0
+    && input.every(item => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) return false;
+      const type = (item as { type?: unknown }).type;
+      return typeof type === "string" && type.endsWith("_call_output");
+    });
+}
+
+/** Build guidance for a raw Responses request, excluding tool-result continuations. */
+export async function multiAgentGuidanceForRequest(
+  parsed: OcxParsedRequest,
+  rawBody: unknown,
+  options: MultiAgentGuidanceOptions = {},
+  deps: MultiAgentGuidanceDeps = {},
+): Promise<string | null> {
+  if (isToolOutputContinuation(rawBody)) return null;
+  return multiAgentGuidanceText(parsed, options, deps);
+}
+
 
 
 export const V2_GUIDANCE_CHAR_BUDGET = 700;
@@ -296,5 +325,3 @@ export function injectDeveloperMessage(parsed: OcxParsedRequest, text: string): 
     }
   }
 }
-
-

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -97,7 +97,7 @@ import {
 import { hasResponsesItemIdRepair, relaySseWithResponsesItemIdRepair } from "../responses-item-id-repair";
 import type { EffectiveSubagentRoster, SpawnAgentSurface } from "../../codex/catalog";
 
-import { buildToolBridgeMaps, collabSurface, injectDeveloperMessage, multiAgentGuidanceText } from "./collaboration";
+import { buildToolBridgeMaps, collabSurface, injectDeveloperMessage, multiAgentGuidanceForRequest } from "./collaboration";
 import { hasUnreadableEncryptedAgentTask, looksLikeBackendCiphertext, sanitizeEncryptedContentInPlace } from "./encrypted-payload";
 import { fetchWithHeaderTimeout, providerFetch, safeHostLabel } from "./fetch-helpers";
 
@@ -664,7 +664,7 @@ export async function handleResponses(
   // mock-max clamp below so the synthetic top tier (ultra arrives as max on the
   // codex wire) is still visible. Both request shapes are rewritten.
   {
-    const guidance = await multiAgentGuidanceText(parsed, {
+    const guidance = await multiAgentGuidanceForRequest(parsed, originalBody, {
       multiAgentGuidanceEnabled: config.multiAgentGuidanceEnabled,
       injectionModel: config.injectionModel,
       injectionEffort: config.injectionEffort,

--- a/tests/multi-agent-compat.test.ts
+++ b/tests/multi-agent-compat.test.ts
@@ -7,7 +7,13 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { injectDeveloperMessage, multiAgentGuidanceText, sanitizeEncryptedContentInPlace } from "../src/server/responses";
+import {
+  injectDeveloperMessage,
+  isToolOutputContinuation,
+  multiAgentGuidanceForRequest,
+  multiAgentGuidanceText,
+  sanitizeEncryptedContentInPlace,
+} from "../src/server/responses";
 import { parseRequest } from "../src/responses/parser";
 import type { OcxParsedRequest } from "../src/types";
 import { effectiveSubagentRoster } from "../src/codex/catalog";
@@ -382,6 +388,18 @@ describe("multiAgentGuidanceText", () => {
     expect(text).not.toContain("gpt-5.6-luna");
   });
 
+  test("whitespace-only injectionPrompt never emits an empty developer tag", async () => {
+    const dir = codexHomeFixture(V2_ON);
+    catalogFixture(dir, [
+      { slug: "gpt-5.6-terra", efforts: ["high", "max"], multiAgentVersion: "v2" },
+    ]);
+
+    expect(await multiAgentGuidanceText(
+      parsedFixture({ tools: [{ name: "spawn_agent" }] }),
+      { subagentModels: ["gpt-5.6-terra"], injectionPrompt: " \n\t " },
+    )).toBeNull();
+  });
+
   test("v1 ignores injectionPrompt and custom prompt does not fire a bare v2 surface", async () => {
     codexHomeFixture(V2_ON);
     const custom = "CUSTOM RULES model={{model}} effort={{effort}}{{roster}}";
@@ -558,6 +576,44 @@ describe("multiAgentGuidanceText", () => {
       parsedFixture({ tools: [{ name: "spawn_agent" }] }),
       { ...v2Options, multiAgentGuidanceEnabled: true },
     ));
+  });
+});
+
+describe("isToolOutputContinuation", () => {
+  test("recognizes tool-output-only Responses deltas", () => {
+    expect(isToolOutputContinuation({
+      input: [
+        { type: "function_call_output", call_id: "call_1", output: "ok" },
+        { type: "custom_tool_call_output", call_id: "call_2", output: "done" },
+      ],
+    })).toBe(true);
+  });
+
+  test("does not suppress guidance when a user message accompanies tool output", () => {
+    expect(isToolOutputContinuation({
+      input: [
+        { type: "function_call_output", call_id: "call_1", output: "ok" },
+        { type: "message", role: "user", content: "also change the title" },
+      ],
+    })).toBe(false);
+    expect(isToolOutputContinuation({ input: [] })).toBe(false);
+    expect(isToolOutputContinuation({ input: "hello" })).toBe(false);
+  });
+
+  test("request guidance is silent for tool continuations and fires for user input", async () => {
+    const dir = codexHomeFixture(V2_ON);
+    catalogFixture(dir, [
+      { slug: "gpt-5.6-terra", efforts: ["high", "max"], multiAgentVersion: "v2" },
+    ]);
+    const parsed = parsedFixture({ tools: [{ name: "spawn_agent" }] });
+    const options = { subagentModels: ["gpt-5.6-terra"] };
+
+    expect(await multiAgentGuidanceForRequest(parsed, {
+      input: [{ type: "function_call_output", call_id: "call_1", output: "ok" }],
+    }, options)).toBeNull();
+    expect(await multiAgentGuidanceForRequest(parsed, {
+      input: [{ type: "message", role: "user", content: "continue" }],
+    }, options)).toContain("<multi_agent_mode>");
   });
 });
 


### PR DESCRIPTION
## What changed

- Skip proxy-authored multi-agent guidance when a Responses request contains only tool-call output delta items.
- Treat an explicitly whitespace-only custom injection prompt as silent instead of emitting an empty `<multi_agent_mode>` developer message.
- Preserve guidance for genuine user-input requests, including requests that combine tool output with a user message.

## Why

OpenCodex currently evaluates the guidance shim for every Responses API request. Codex sends a new request after each tool result, so a configuration such as `injectionPrompt: " "` creates `<multi_agent_mode> </multi_agent_mode>` repeatedly within one turn. Models can react to each developer message with redundant continuation narration, and non-empty guidance is duplicated in the expanded response chain.

The fix classifies the raw request before `previous_response_id` expansion, suppressing only tool-output-only continuations. User turns still receive the configured guidance.

## Validation

- `bun test tests/multi-agent-compat.test.ts tests/config.test.ts` — 89 passed
- `bun x tsc --noEmit` — passed
- `bun scripts/test.ts` — 3,792 passed, 0 failed
- `git diff --check` — passed