### PR TITLE
fix(cursor): stable conversation continuity for store:false turns

### DIFF
--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -11,6 +11,7 @@ import {
   CursorMissingCredentialError,
   rekeyCursorContextUsage,
 } from "./cursor/live-transport";
+import { rememberCursorThreadConversation } from "./cursor/thread-continuity";
 import { runCursorTurnWithRetry } from "./cursor/transport-retry";
 import {
   createDisabledCursorTransport,
@@ -123,8 +124,8 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
           await runOnce(request);
         } catch (err) {
           // One-shot fallback for external-model Connect invalid_argument before any
-          // non-heartbeat output. Covers plain-user continuations as well as tool-result
-          // resumes (PR #318); replaying after text/tool events would duplicate output.
+          // non-heartbeat output. Retries apply only to safe plain-user turns; tool-result
+          // resumes, local exec/MCP side effects, and already-emitted output fail closed.
           if (
             !isCursorInvalidArgumentError(err)
             || !isCursorExternalWireModel(request.modelId)
@@ -140,6 +141,15 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
           request = createCursorRequest(_parsed, { forceFreshConversation: true });
           rekeyContextUsage(failedConversationId, request.conversationId);
           _parsed._cursorConversationId = request.conversationId;
+          // Persist recovery for store:false clients that only send a parent thread id, so the
+          // next turn does not recompute the stale deterministic thread hash.
+          if (_parsed._clientThreadId) {
+            rememberCursorThreadConversation(
+              _parsed._clientThreadId,
+              request.conversationId,
+              _parsed._cursorIdentityScope,
+            );
+          }
           await runOnce(request);
         }
       } catch (err) {

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { AdapterEvent, OcxProviderConfig } from "../types";
 import type { ProviderAdapter } from "./base";
 import { cursorExecDeniedMessage, cursorRequestDeclaresFullAccess } from "./cursor/exec-policy";
@@ -10,6 +11,7 @@ import {
   createLiveCursorTransport,
   CursorMissingCredentialError,
   rekeyCursorContextUsage,
+  resolveCursorToken,
 } from "./cursor/live-transport";
 import { rememberCursorThreadConversation } from "./cursor/thread-continuity";
 import { runCursorTurnWithRetry } from "./cursor/transport-retry";
@@ -78,6 +80,21 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
         const makeTransport = deps.createTransport ?? createLiveCursorTransport;
         const kv = deps.kv ?? createCursorKvStore();
         const rekeyContextUsage = deps.rekeyContextUsage ?? rekeyCursorContextUsage;
+        // Namespace thread→conversation derivation by the authenticated Cursor credential so
+        // shared-proxy tenants with different Cursor accounts cannot collide on a parent thread id.
+        // Prefer an already-set auth scope (e.g. Codex pool account) when present.
+        if (!_parsed._cursorIdentityScope) {
+          try {
+            const token = resolveCursorToken(provider, incoming.headers);
+            _parsed._cursorIdentityScope = createHash("sha256")
+              .update("ocx:cursor:acct:")
+              .update(token)
+              .digest("hex")
+              .slice(0, 16);
+          } catch {
+            /* Missing credential is handled by the live transport path below. */
+          }
+        }
         const previousConversationId = _parsed._cursorConversationId;
         let request = createCursorRequest(_parsed);
         // The builder may derive a stable provider id from the client thread when Responses state

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -98,8 +98,13 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
         const previousConversationId = _parsed._cursorConversationId;
         let request = createCursorRequest(_parsed);
         // The builder may derive a stable provider id from the client thread when Responses state
-        // is unavailable. Rekey only existing state; there is nothing to migrate on a fresh turn.
-        if (previousConversationId && request.conversationId !== previousConversationId) {
+        // is unavailable. Rekey only existing state; there is nothing to migrate on a fresh turn,
+        // and isolated helper/compaction turns must never inherit or donate the parent's usage state.
+        if (
+          previousConversationId
+          && request.conversationId !== previousConversationId
+          && _parsed._cursorIsolateConversation !== true
+        ) {
           rekeyContextUsage(previousConversationId, request.conversationId);
         }
         _parsed._cursorConversationId = request.conversationId;
@@ -159,8 +164,9 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
           rekeyContextUsage(failedConversationId, request.conversationId);
           _parsed._cursorConversationId = request.conversationId;
           // Persist recovery for store:false clients that only send a parent thread id, so the
-          // next turn does not recompute the stale deterministic thread hash.
-          if (_parsed._clientThreadId) {
+          // next turn does not recompute the stale deterministic thread hash. Isolated helper /
+          // compaction turns must not park their throwaway id under the parent thread key.
+          if (_parsed._clientThreadId && _parsed._cursorIsolateConversation !== true) {
             rememberCursorThreadConversation(
               _parsed._clientThreadId,
               request.conversationId,

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -87,7 +87,6 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
         }
         _parsed._cursorConversationId = request.conversationId;
         let emittedOutput = false;
-        const lastRawIsToolResult = _parsed.context.messages.at(-1)?.role === "toolResult";
 
         const runOnce = async (activeRequest: ReturnType<typeof createCursorRequest>) => {
           await runCursorTurnWithRetry(
@@ -121,13 +120,12 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
         try {
           await runOnce(request);
         } catch (err) {
-          // One-shot fallback: only for external-model tool-result continuations that fail
-          // with Connect invalid_argument before any non-heartbeat output was forwarded.
-          // Replaying after text/tool events would duplicate output.
+          // One-shot fallback for external-model Connect invalid_argument before any
+          // non-heartbeat output. Covers plain-user continuations as well as tool-result
+          // resumes (PR #318); replaying after text/tool events would duplicate output.
           if (
             !isCursorInvalidArgumentError(err)
             || !isCursorExternalWireModel(request.modelId)
-            || !lastRawIsToolResult
             || emittedOutput
             || incoming.abortSignal?.aborted
           ) {

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -5,7 +5,7 @@ import { isCursorBenignCancelError, isCursorInvalidArgumentError, safeCursorErro
 import { isCursorExternalWireModel } from "./cursor/discovery";
 import { createCursorKvStore, type CursorKvStore } from "./cursor/kv-store";
 import { mapCursorServerMessage } from "./cursor/message-mapper";
-import { createCursorRequest, generatedCursorConversationId } from "./cursor/request-builder";
+import { createCursorRequest } from "./cursor/request-builder";
 import {
   createLiveCursorTransport,
   CursorMissingCredentialError,
@@ -77,16 +77,17 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
         const makeTransport = deps.createTransport ?? createLiveCursorTransport;
         const kv = deps.kv ?? createCursorKvStore();
         const rekeyContextUsage = deps.rekeyContextUsage ?? rekeyCursorContextUsage;
-        _parsed._cursorConversationId ??= generatedCursorConversationId();
         const previousConversationId = _parsed._cursorConversationId;
         let request = createCursorRequest(_parsed);
-        // Keep remembered conversation id in sync when the request builder mints a fresh id
-        // for external-model tool-result continuations (stateless replay).
-        if (request.conversationId !== previousConversationId) {
+        // The builder may derive a stable provider id from the client thread when Responses state
+        // is unavailable. Rekey only existing state; there is nothing to migrate on a fresh turn.
+        if (previousConversationId && request.conversationId !== previousConversationId) {
           rekeyContextUsage(previousConversationId, request.conversationId);
         }
         _parsed._cursorConversationId = request.conversationId;
         let emittedOutput = false;
+        let replayUnsafe = false;
+        const lastRawIsToolResult = _parsed.context.messages.at(-1)?.role === "toolResult";
 
         const runOnce = async (activeRequest: ReturnType<typeof createCursorRequest>) => {
           await runCursorTurnWithRetry(
@@ -103,6 +104,7 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
                 emit({ type: "error", message: "Cursor turn was aborted." });
                 return;
               }
+              if (message.type === "local_side_effect") replayUnsafe = true;
               const events = mapCursorServerMessage(message, {
                 kv,
                 writeClient: clientMessage => {
@@ -126,7 +128,9 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
           if (
             !isCursorInvalidArgumentError(err)
             || !isCursorExternalWireModel(request.modelId)
+            || lastRawIsToolResult
             || emittedOutput
+            || replayUnsafe
             || incoming.abortSignal?.aborted
           ) {
             throw err;

--- a/src/adapters/cursor/live-transport.ts
+++ b/src/adapters/cursor/live-transport.ts
@@ -826,6 +826,11 @@ class LiveCursorTransport implements CursorTransport {
           return;
         }
       }
+      // Native exec/MCP is handled inside this transport and can mutate files/process state
+      // without emitting a Responses tool event. Mark the turn replay-unsafe before executing so
+      // an eventual invalid_argument cannot cause the adapter's fresh-conversation fallback to
+      // run the same local action twice.
+      push({ type: "local_side_effect" });
       const replies = await handleCursorNativeExec(message.message.value, this.execContext);
       for (const reply of replies) this.stream.write(encodeConnectFrame(reply));
       return;
@@ -916,6 +921,8 @@ function describeCursorServerFrame(message: AgentServerMessage): Record<string, 
     out.id = message.message.value.id;
   } else if (message.message.case === "kvServerMessage") {
     out.kv = message.message.value.message.case ?? "unknown";
+  } else if (message.message.case === "conversationCheckpointUpdate") {
+    out.usedTokens = message.message.value.tokenDetails?.usedTokens ?? 0;
   }
   return out;
 }

--- a/src/adapters/cursor/message-mapper.ts
+++ b/src/adapters/cursor/message-mapper.ts
@@ -42,5 +42,8 @@ export function mapCursorServerMessage(
     case "exec":
       state.writeClient(cursorExecResult(message.requestId, message.execCase));
       return [];
+    case "local_side_effect":
+      // Internal retry-safety signal only; keep the bridge alive without producing protocol output.
+      return [{ type: "heartbeat" }];
   }
 }

--- a/src/adapters/cursor/protobuf-request.ts
+++ b/src/adapters/cursor/protobuf-request.ts
@@ -82,12 +82,36 @@ function jsonBlob(value: unknown): Uint8Array {
 type StoredRootBlob = {
   id: Uint8Array;
   byteLength: number;
-  role: "system" | "user" | "assistant";
+  role: "system" | "user" | "assistant" | "toolResult";
+  messageIndex?: number;
+  /** Original JSON text payload used when an active tool result must be truncated to fit. */
+  text?: string;
 };
 
-function storedRootBlob(value: unknown, role: StoredRootBlob["role"]): StoredRootBlob {
+function storedRootBlob(
+  value: unknown,
+  role: StoredRootBlob["role"],
+  opts?: { messageIndex?: number; text?: string },
+): StoredRootBlob {
   const data = jsonBlob(value);
-  return { id: storeCursorBlob(data), byteLength: data.byteLength, role };
+  return {
+    id: storeCursorBlob(data),
+    byteLength: data.byteLength,
+    role,
+    ...(opts?.messageIndex !== undefined ? { messageIndex: opts.messageIndex } : {}),
+    ...(opts?.text !== undefined ? { text: opts.text } : {}),
+  };
+}
+
+function truncateToolResultBlob(entry: StoredRootBlob, maxBytes: number): StoredRootBlob {
+  if (entry.byteLength <= maxBytes || entry.role !== "toolResult" || entry.text === undefined) return entry;
+  const keep = Math.max(0, maxBytes - 128);
+  const truncated = `${entry.text.slice(0, keep)}\n…[truncated for Cursor external replay budget]`;
+  return storedRootBlob(
+    { role: "user", content: [{ type: "text", text: truncated }] },
+    "toolResult",
+    { messageIndex: entry.messageIndex, text: truncated },
+  );
 }
 
 function systemPromptBlobs(request: CursorRunRequest): StoredRootBlob[] {
@@ -118,7 +142,11 @@ function assistantRootText(
 // because it travels in the action. Tool results are rendered as user-role text with a marker, and
 // each entry is a SHA-256 blob ID (Cursor fetches the bytes back via getBlobArgs). Mirrors the
 // danger-pi reference buildRootPromptMessagesJson.
-function rootPromptMessages(request: CursorRunRequest): { ids: Uint8Array[]; byteLength: number } {
+function rootPromptMessages(request: CursorRunRequest): {
+  ids: Uint8Array[];
+  byteLength: number;
+  historyMessageStart: number;
+} {
   const entries = systemPromptBlobs(request);
   const systemEntryCount = entries.length;
   const messages = request.rawMessages;
@@ -126,6 +154,7 @@ function rootPromptMessages(request: CursorRunRequest): { ids: Uint8Array[]; byt
     return {
       ids: entries.map(entry => entry.id),
       byteLength: entries.reduce((sum, entry) => sum + entry.byteLength, 0),
+      historyMessageStart: 0,
     };
   }
 
@@ -146,50 +175,91 @@ function rootPromptMessages(request: CursorRunRequest): { ids: Uint8Array[]; byt
         entries.push(storedRootBlob({
           role: "user",
           content: [{ type: "text", text }],
-        }, "user"));
+        }, "user", { messageIndex: i }));
       }
     } else if (message.role === "assistant") {
       // External Cursor clients do not replay hidden reasoning as assistant-visible prompt text.
       // Native Composer state can preserve it through ThinkingMessage/history structures.
       const text = assistantRootText(message, !externalModel).trim();
       if (text.length > 0) {
-        entries.push(storedRootBlob({ role: "assistant", content: [{ type: "text", text }] }, "assistant"));
+        entries.push(storedRootBlob(
+          { role: "assistant", content: [{ type: "text", text }] },
+          "assistant",
+          { messageIndex: i },
+        ));
       }
       // Assistant tool CALLS are intentionally NOT replayed as visible "[Tool Call]" text here.
-      // rootPromptMessagesJson is the model-visible prompt, so a synthetic "[Tool Call]" marker in an
-      // assistant turn gets few-shot-mimicked: the model then emits later (esp. parallel/mixed) tool
-      // calls as inert text instead of real tool frames, halting multi-tool continuations. The paired
-      // tool result below ([Tool Result]/[Tool Error]) carries the call id/name/output Cursor needs to
-      // continue, and conversationTurns replays the native mcpToolCall step. Mirrors request-builder.ts
-      // contentPartToText() which returns undefined for toolCall for the same reason.
     } else if (message.role === "toolResult") {
       const prefix = message.isError ? "[Tool Error]" : "[Tool Result]";
       const text = `${prefix}\n${toolResultToText(message)}`;
-      entries.push(storedRootBlob({ role: "user", content: [{ type: "text", text }] }, "user"));
+      entries.push(storedRootBlob(
+        { role: "user", content: [{ type: "text", text }] },
+        "toolResult",
+        { messageIndex: i, text },
+      ));
     }
   }
+
   let selected = entries;
+  let historyMessageStart = 0;
   if (externalModel) {
     const systemEntries = entries.slice(0, systemEntryCount);
+    const history = entries.slice(systemEntryCount);
     const systemBytes = systemEntries.reduce((sum, entry) => sum + entry.byteLength, 0);
     const historyLimit = Math.max(0, CURSOR_EXTERNAL_ROOT_BLOB_LIMIT - systemEntryCount);
     const historyBudget = Math.max(0, CURSOR_EXTERNAL_ROOT_BYTE_LIMIT - systemBytes);
-    const historyEntries: StoredRootBlob[] = [];
-    let historyBytes = 0;
-    for (let i = entries.length - 1; i >= systemEntryCount && historyEntries.length < historyLimit; i--) {
-      const entry = entries[i];
-      if (!entry || historyBytes + entry.byteLength > historyBudget) break;
-      historyEntries.unshift(entry);
-      historyBytes += entry.byteLength;
+
+    // Always retain the active trailing tool-result block (may truncate text to fit).
+    let activeStart = history.length;
+    while (activeStart > 0 && history[activeStart - 1]?.role === "toolResult") activeStart -= 1;
+    const active = history.slice(activeStart).map(entry => truncateToolResultBlob(entry, historyBudget));
+    let activeBytes = active.reduce((sum, entry) => sum + entry.byteLength, 0);
+    while (active.length > 1 && activeBytes > historyBudget) {
+      const dropped = active.shift();
+      activeBytes -= dropped?.byteLength ?? 0;
     }
-    // A bounded suffix can otherwise begin with an orphan assistant response. External workers
-    // validate replay ordering before tokenization and reject that shape with usedTokens=0.
-    while (historyEntries[0]?.role === "assistant") historyEntries.shift();
+    if (active.length === 1 && active[0] && activeBytes > historyBudget) {
+      active[0] = truncateToolResultBlob(active[0], historyBudget);
+      activeBytes = active[0].byteLength;
+    }
+
+    const prior = history.slice(0, activeStart);
+    const keptPrior: StoredRootBlob[] = [];
+    let priorBytes = 0;
+    // Take complete turns from the end: a turn starts at a user/developer root entry.
+    let i = prior.length - 1;
+    while (i >= 0 && keptPrior.length + active.length < historyLimit) {
+      let turnStart = i;
+      while (turnStart > 0 && prior[turnStart]?.role !== "user") turnStart -= 1;
+      const turn = prior.slice(turnStart, i + 1);
+      const turnBytes = turn.reduce((sum, entry) => sum + entry.byteLength, 0);
+      if (
+        keptPrior.length + active.length + turn.length > historyLimit
+        || priorBytes + activeBytes + turnBytes > historyBudget
+      ) {
+        break;
+      }
+      keptPrior.unshift(...turn);
+      priorBytes += turnBytes;
+      i = turnStart - 1;
+    }
+
+    const historyEntries = [...keptPrior, ...active];
+    // Guard against orphan assistant / toolResult at the start of the retained suffix.
+    while (historyEntries[0]?.role === "assistant" || historyEntries[0]?.role === "toolResult") {
+      // Never drop the sole active tool-result block.
+      if (historyEntries.length <= active.length) break;
+      historyEntries.shift();
+    }
     selected = [...systemEntries, ...historyEntries];
+    const firstKept = historyEntries.find(entry => entry.messageIndex !== undefined);
+    historyMessageStart = firstKept?.messageIndex ?? (messages.length);
   }
+
   return {
     ids: selected.map(entry => entry.id),
     byteLength: selected.reduce((sum, entry) => sum + entry.byteLength, 0),
+    historyMessageStart,
   };
 }
 
@@ -302,12 +372,13 @@ function lastActionIndex(messages: readonly OcxMessage[] | undefined): number {
   return -1;
 }
 
-function conversationTurns(request: CursorRunRequest): Uint8Array[] {
+function conversationTurns(request: CursorRunRequest, historyMessageStart = 0): Uint8Array[] {
   const messages = request.rawMessages;
   if (!messages?.length) return [];
   const end = lastActionIndex(messages);
   const externalModel = isCursorExternalWireModel(request.modelId);
   const historyEnd = messages.at(-1)?.role === "toolResult" ? messages.length : Math.max(0, end);
+  const start = externalModel ? Math.max(0, historyMessageStart) : 0;
   const turns: Uint8Array[] = [];
   let current: { userMessage: Uint8Array; steps: Uint8Array[] } | undefined;
   const pendingToolCalls = new Map<string, Extract<OcxAssistantContentPart, { type: "toolCall" }>>();
@@ -324,7 +395,7 @@ function conversationTurns(request: CursorRunRequest): Uint8Array[] {
     pendingToolCalls.clear();
   };
 
-  for (const message of messages.slice(0, historyEnd)) {
+  for (const message of messages.slice(start, historyEnd)) {
     if (message.role === "assistant") {
       if (!current) continue;
       for (const part of message.content) {
@@ -435,7 +506,7 @@ export function encodeCursorRunRequest(request: CursorRunRequest): Uint8Array {
   });
   const rootPromptMessagesState = rootPromptMessages(request);
   const rootPromptMessageIds = rootPromptMessagesState.ids;
-  const turnIds = conversationTurns(request);
+  const turnIds = conversationTurns(request, rootPromptMessagesState.historyMessageStart);
   debugProviderDiagnostic("cursor", "run-request", {
     wireModel: request.modelId,
     action: actionCase,

--- a/src/adapters/cursor/protobuf-request.ts
+++ b/src/adapters/cursor/protobuf-request.ts
@@ -46,6 +46,7 @@ import {
 } from "./tool-definitions";
 
 const encoder = new TextEncoder();
+const decoder = new TextDecoder();
 
 /** Parameter id advertised by Cursor's `default` model for its Cost/Balance/Intelligence control. */
 export const CURSOR_ROUTING_LEVEL_PARAMETER_ID = "optimization";
@@ -105,12 +106,26 @@ function storedRootBlob(
 
 function truncateToolResultBlob(entry: StoredRootBlob, maxBytes: number): StoredRootBlob {
   if (entry.byteLength <= maxBytes || entry.role !== "toolResult" || entry.text === undefined) return entry;
-  const keep = Math.max(0, maxBytes - 128);
-  const truncated = `${entry.text.slice(0, keep)}\n…[truncated for Cursor external replay budget]`;
+  const marker = "\n…[truncated for Cursor external replay budget]";
+  const encoded = encoder.encode(entry.text);
+  // Leave headroom for JSON envelope (`role`/`content` wrapper) around the truncated text.
+  let keepBytes = Math.min(encoded.byteLength, Math.max(0, maxBytes - encoder.encode(marker).byteLength - 96));
+  for (let attempt = 0; attempt < 8; attempt++) {
+    let end = keepBytes;
+    while (end > 0 && end < encoded.byteLength && (encoded[end]! & 0xc0) === 0x80) end -= 1;
+    const truncated = `${decoder.decode(encoded.subarray(0, end))}${marker}`;
+    const result = storedRootBlob(
+      { role: "user", content: [{ type: "text", text: truncated }] },
+      "toolResult",
+      { messageIndex: entry.messageIndex, text: truncated },
+    );
+    if (result.byteLength <= maxBytes || end === 0) return result;
+    keepBytes = Math.max(0, end - (result.byteLength - maxBytes) - 16);
+  }
   return storedRootBlob(
-    { role: "user", content: [{ type: "text", text: truncated }] },
+    { role: "user", content: [{ type: "text", text: marker.trimStart() }] },
     "toolResult",
-    { messageIndex: entry.messageIndex, text: truncated },
+    { messageIndex: entry.messageIndex, text: marker.trimStart() },
   );
 }
 

--- a/src/adapters/cursor/protobuf-request.ts
+++ b/src/adapters/cursor/protobuf-request.ts
@@ -49,6 +49,13 @@ const encoder = new TextEncoder();
 
 /** Parameter id advertised by Cursor's `default` model for its Cost/Balance/Intelligence control. */
 export const CURSOR_ROUTING_LEVEL_PARAMETER_ID = "optimization";
+// Cursor external workers reject oversized root replay sets with a late invalid_argument after
+// hydrating every blob (observed at 208 roots with usedTokens=0). Keep headroom below that boundary,
+// retaining all system prompts and the newest model-visible history. Cursor IDE similarly bounds /
+// compacts long conversations rather than replaying an unbounded message list.
+export const CURSOR_EXTERNAL_ROOT_BLOB_LIMIT = 192;
+/** Approximate prompt-size guard; tool schemas and protocol framing consume context separately. */
+export const CURSOR_EXTERNAL_ROOT_BYTE_LIMIT = 512 * 1024;
 
 /** Runtime timezone for protobuf RequestContextEnv (dynamic, never hardcoded). */
 function runtimeTimeZone(): string {
@@ -72,7 +79,18 @@ function jsonBlob(value: unknown): Uint8Array {
   return encoder.encode(JSON.stringify(value));
 }
 
-function systemPromptBlobs(request: CursorRunRequest): Uint8Array[] {
+type StoredRootBlob = {
+  id: Uint8Array;
+  byteLength: number;
+  role: "system" | "user" | "assistant";
+};
+
+function storedRootBlob(value: unknown, role: StoredRootBlob["role"]): StoredRootBlob {
+  const data = jsonBlob(value);
+  return { id: storeCursorBlob(data), byteLength: data.byteLength, role };
+}
+
+function systemPromptBlobs(request: CursorRunRequest): StoredRootBlob[] {
   const prompts = request.system.length > 0 ? [...request.system] : ["You are a helpful assistant."];
   if (cursorRequestHasShellAlias(request.tools)) prompts.push(CURSOR_SHELL_ALIAS_SYSTEM_NOTE);
   const cursorToolGuidance = buildCursorToolGuidanceSystemNote(
@@ -80,13 +98,16 @@ function systemPromptBlobs(request: CursorRunRequest): Uint8Array[] {
     request.toolChoice,
   );
   if (cursorToolGuidance) prompts.push(cursorToolGuidance);
-  return prompts.map(content => storeCursorBlob(jsonBlob({ role: "system", content })));
+  return prompts.map(content => storedRootBlob({ role: "system", content }, "system"));
 }
 
-function assistantRootText(message: Extract<OcxMessage, { role: "assistant" }>): string {
+function assistantRootText(
+  message: Extract<OcxMessage, { role: "assistant" }>,
+  includeThinking: boolean,
+): string {
   if (typeof message.content === "string") return message.content;
   return message.content
-    .map(part => (part.type === "text" ? part.text : part.type === "thinking" ? part.thinking : undefined))
+    .map(part => (part.type === "text" ? part.text : includeThinking && part.type === "thinking" ? part.thinking : undefined))
     .filter((value): value is string => typeof value === "string" && value.length > 0)
     .join("\n");
 }
@@ -97,11 +118,18 @@ function assistantRootText(message: Extract<OcxMessage, { role: "assistant" }>):
 // because it travels in the action. Tool results are rendered as user-role text with a marker, and
 // each entry is a SHA-256 blob ID (Cursor fetches the bytes back via getBlobArgs). Mirrors the
 // danger-pi reference buildRootPromptMessagesJson.
-function rootPromptMessages(request: CursorRunRequest): Uint8Array[] {
+function rootPromptMessages(request: CursorRunRequest): { ids: Uint8Array[]; byteLength: number } {
   const entries = systemPromptBlobs(request);
+  const systemEntryCount = entries.length;
   const messages = request.rawMessages;
-  if (!messages?.length) return entries;
+  if (!messages?.length) {
+    return {
+      ids: entries.map(entry => entry.id),
+      byteLength: entries.reduce((sum, entry) => sum + entry.byteLength, 0),
+    };
+  }
 
+  const externalModel = isCursorExternalWireModel(request.modelId);
   const lastRawIsToolResult = messages.at(-1)?.role === "toolResult";
   const activeUserIndex = lastRawIsToolResult ? -1 : lastActionIndex(messages);
 
@@ -111,10 +139,22 @@ function rootPromptMessages(request: CursorRunRequest): Uint8Array[] {
     if (!message) continue;
     if (message.role === "user" || message.role === "developer") {
       const text = contentText(message).trim();
-      if (text.length > 0) entries.push(storeCursorBlob(jsonBlob({ role: "user", content: text })));
+      // Cursor root replay expects OpenAI-style content parts for historical user messages.
+      // A bare string survives blob hydration but external workers reject the completed replay
+      // before tokenization (`usedTokens: 0`, then invalid_argument).
+      if (text.length > 0) {
+        entries.push(storedRootBlob({
+          role: "user",
+          content: [{ type: "text", text }],
+        }, "user"));
+      }
     } else if (message.role === "assistant") {
-      const text = assistantRootText(message).trim();
-      if (text.length > 0) entries.push(storeCursorBlob(jsonBlob({ role: "assistant", content: [{ type: "text", text }] })));
+      // External Cursor clients do not replay hidden reasoning as assistant-visible prompt text.
+      // Native Composer state can preserve it through ThinkingMessage/history structures.
+      const text = assistantRootText(message, !externalModel).trim();
+      if (text.length > 0) {
+        entries.push(storedRootBlob({ role: "assistant", content: [{ type: "text", text }] }, "assistant"));
+      }
       // Assistant tool CALLS are intentionally NOT replayed as visible "[Tool Call]" text here.
       // rootPromptMessagesJson is the model-visible prompt, so a synthetic "[Tool Call]" marker in an
       // assistant turn gets few-shot-mimicked: the model then emits later (esp. parallel/mixed) tool
@@ -125,10 +165,32 @@ function rootPromptMessages(request: CursorRunRequest): Uint8Array[] {
     } else if (message.role === "toolResult") {
       const prefix = message.isError ? "[Tool Error]" : "[Tool Result]";
       const text = `${prefix}\n${toolResultToText(message)}`;
-      entries.push(storeCursorBlob(jsonBlob({ role: "user", content: [{ type: "text", text }] })));
+      entries.push(storedRootBlob({ role: "user", content: [{ type: "text", text }] }, "user"));
     }
   }
-  return entries;
+  let selected = entries;
+  if (externalModel) {
+    const systemEntries = entries.slice(0, systemEntryCount);
+    const systemBytes = systemEntries.reduce((sum, entry) => sum + entry.byteLength, 0);
+    const historyLimit = Math.max(0, CURSOR_EXTERNAL_ROOT_BLOB_LIMIT - systemEntryCount);
+    const historyBudget = Math.max(0, CURSOR_EXTERNAL_ROOT_BYTE_LIMIT - systemBytes);
+    const historyEntries: StoredRootBlob[] = [];
+    let historyBytes = 0;
+    for (let i = entries.length - 1; i >= systemEntryCount && historyEntries.length < historyLimit; i--) {
+      const entry = entries[i];
+      if (!entry || historyBytes + entry.byteLength > historyBudget) break;
+      historyEntries.unshift(entry);
+      historyBytes += entry.byteLength;
+    }
+    // A bounded suffix can otherwise begin with an orphan assistant response. External workers
+    // validate replay ordering before tokenization and reject that shape with usedTokens=0.
+    while (historyEntries[0]?.role === "assistant") historyEntries.shift();
+    selected = [...systemEntries, ...historyEntries];
+  }
+  return {
+    ids: selected.map(entry => entry.id),
+    byteLength: selected.reduce((sum, entry) => sum + entry.byteLength, 0),
+  };
 }
 
 function contentText(message: OcxMessage): string {
@@ -244,6 +306,7 @@ function conversationTurns(request: CursorRunRequest): Uint8Array[] {
   const messages = request.rawMessages;
   if (!messages?.length) return [];
   const end = lastActionIndex(messages);
+  const externalModel = isCursorExternalWireModel(request.modelId);
   const historyEnd = messages.at(-1)?.role === "toolResult" ? messages.length : Math.max(0, end);
   const turns: Uint8Array[] = [];
   let current: { userMessage: Uint8Array; steps: Uint8Array[] } | undefined;
@@ -265,6 +328,20 @@ function conversationTurns(request: CursorRunRequest): Uint8Array[] {
     if (message.role === "assistant") {
       if (!current) continue;
       for (const part of message.content) {
+        if (externalModel) {
+          // Working external-model clients replay only assistant text. Native mcpToolCall and
+          // ThinkingMessage structures are Composer state and cause external workers to hydrate
+          // the blobs, reach stepCompleted, then reject the turn with invalid_argument.
+          if (part.type === "text" && part.text.length > 0) {
+            current.steps.push(storeCursorBlob(toBinary(ConversationStepSchema, create(ConversationStepSchema, {
+              message: {
+                case: "assistantMessage",
+                value: create(AssistantMessageSchema, { text: part.text }),
+              },
+            }))));
+          }
+          continue;
+        }
         if (part.type === "toolCall") {
           pendingToolCalls.set(part.id, part);
           continue;
@@ -276,6 +353,16 @@ function conversationTurns(request: CursorRunRequest): Uint8Array[] {
     }
     if (message.role === "toolResult") {
       if (!current) continue;
+      if (externalModel) {
+        const prefix = message.isError ? "[Tool Error]" : "[Tool Result]";
+        current.steps.push(storeCursorBlob(toBinary(ConversationStepSchema, create(ConversationStepSchema, {
+          message: {
+            case: "assistantMessage",
+            value: create(AssistantMessageSchema, { text: `${prefix}\n${contentToText(message.content)}` }),
+          },
+        }))));
+        continue;
+      }
       const priorCall = pendingToolCalls.get(message.toolCallId);
       if (priorCall) {
         current.steps.push(toolCallStep(priorCall, message));
@@ -322,13 +409,11 @@ export function encodeCursorRunRequest(request: CursorRunRequest): Uint8Array {
   const text = lastRole === "user" || lastRole === "developer"
     ? appendCursorShellAliasHint(request.tools, appendCursorGenericToolUseHint(request.tools, rawText))
     : rawText;
-  // A tool-result-only turn (the last raw message is a toolResult) continues the SAME Cursor
-  // conversation with the tool result carried as structured conversation history (mcpToolCall.result
-  // in conversationTurns). It must NOT inject the tool result text as a new UserMessageAction — that
-  // would pollute the model input and double-deliver the result. Use ResumeAction so Cursor picks up
-  // from the history we provided.
+  // Tool-result-only turns resume the remembered Cursor conversation with results in history.
   const lastRawIsToolResult = request.rawMessages?.at(-1)?.role === "toolResult";
-  const actionCase = !lastRawIsToolResult && text.trim().length > 0 ? "userMessageAction" : "resumeAction";
+  const actionCase = !lastRawIsToolResult && text.trim().length > 0
+    ? "userMessageAction"
+    : "resumeAction";
   const action = create(ConversationActionSchema, {
     action: actionCase === "userMessageAction"
       ? {
@@ -348,19 +433,27 @@ export function encodeCursorRunRequest(request: CursorRunRequest): Uint8Array {
           }),
         },
   });
+  const rootPromptMessagesState = rootPromptMessages(request);
+  const rootPromptMessageIds = rootPromptMessagesState.ids;
+  const turnIds = conversationTurns(request);
   debugProviderDiagnostic("cursor", "run-request", {
     wireModel: request.modelId,
     action: actionCase,
     conversationId: request.conversationId,
     turnType: lastRawIsToolResult ? "tool-continuation" : "initial",
     externalModel: isCursorExternalWireModel(request.modelId),
+    rawMessages: request.rawMessages?.length ?? 0,
+    rootBlobs: rootPromptMessageIds.length,
+    rootBytes: rootPromptMessagesState.byteLength,
+    turnBlobs: turnIds.length,
+    tools: request.tools?.length ?? 0,
   });
 
   const runRequest = create(AgentRunRequestSchema, {
     conversationId: request.conversationId,
     conversationState: create(ConversationStateStructureSchema, {
-      rootPromptMessagesJson: rootPromptMessages(request),
-      turns: conversationTurns(request),
+      rootPromptMessagesJson: rootPromptMessageIds,
+      turns: turnIds,
       todos: [],
       pendingToolCalls: [],
       previousWorkspaceUris: [],
@@ -379,20 +472,19 @@ export function encodeCursorRunRequest(request: CursorRunRequest): Uint8Array {
       displayNameShort: request.modelId,
       aliases: [],
     }),
-    // Always populate requested_model. Cursor is deprecating model_details in favor of
-    // requested_model; omitting it for non-router (external) models caused intermittent
-    // Connect invalid_argument on gpt-5.6-* shards while the IDE client (which always
-    // sends both) stayed stable.
-    requestedModel: create(RequestedModelSchema, {
-      modelId: request.modelId,
-      maxMode: false,
-      ...(request.routingLevel ? {
+    // requested_model is currently a Cursor Router-only surface. External model clients still
+    // send model_details alone; sending both makes external workers reach stepCompleted and then
+    // reject the turn with invalid_argument.
+    ...(request.routingLevel ? {
+      requestedModel: create(RequestedModelSchema, {
+        modelId: request.modelId,
+        maxMode: false,
         parameters: [create(RequestedModel_ModelParameterbytesSchema, {
           id: CURSOR_ROUTING_LEVEL_PARAMETER_ID,
           value: request.routingLevel,
         })],
-      } : {}),
-    }),
+      }),
+    } : {}),
     // Mirror the client (Responses) tool definitions into the top-level AgentRunRequest.mcp_tools
     // channel. Advertising them ONLY via native-exec `requestContextArgs` (RequestContext.tools) is
     // insufficient: cursor models report those tools as unavailable and fall back to native tools.

--- a/src/adapters/cursor/protobuf-request.ts
+++ b/src/adapters/cursor/protobuf-request.ts
@@ -104,8 +104,9 @@ function storedRootBlob(
   };
 }
 
-function truncateToolResultBlob(entry: StoredRootBlob, maxBytes: number): StoredRootBlob {
-  if (entry.byteLength <= maxBytes || entry.role !== "toolResult" || entry.text === undefined) return entry;
+function truncateToolResultBlob(entry: StoredRootBlob, maxBytes: number): StoredRootBlob | null {
+  if (entry.byteLength <= maxBytes) return entry;
+  if (entry.role !== "toolResult" || entry.text === undefined) return null;
   const marker = "\n…[truncated for Cursor external replay budget]";
   const encoded = encoder.encode(entry.text);
   // Leave headroom for JSON envelope (`role`/`content` wrapper) around the truncated text.
@@ -119,14 +120,16 @@ function truncateToolResultBlob(entry: StoredRootBlob, maxBytes: number): Stored
       "toolResult",
       { messageIndex: entry.messageIndex, text: truncated },
     );
-    if (result.byteLength <= maxBytes || end === 0) return result;
+    if (result.byteLength <= maxBytes) return result;
+    if (end === 0) break;
     keepBytes = Math.max(0, end - (result.byteLength - maxBytes) - 16);
   }
-  return storedRootBlob(
+  const markerOnly = storedRootBlob(
     { role: "user", content: [{ type: "text", text: marker.trimStart() }] },
     "toolResult",
     { messageIndex: entry.messageIndex, text: marker.trimStart() },
   );
+  return markerOnly.byteLength <= maxBytes ? markerOnly : null;
 }
 
 function systemPromptBlobs(request: CursorRunRequest): StoredRootBlob[] {
@@ -224,18 +227,29 @@ function rootPromptMessages(request: CursorRunRequest): {
     const historyLimit = Math.max(0, CURSOR_EXTERNAL_ROOT_BLOB_LIMIT - systemEntryCount);
     const historyBudget = Math.max(0, CURSOR_EXTERNAL_ROOT_BYTE_LIMIT - systemBytes);
 
-    // Always retain the active trailing tool-result block (may truncate text to fit).
+    // Retain the active trailing tool-result block when it fits (may truncate text).
+    // If even a truncation marker cannot fit the remaining budget, omit it rather than
+    // emitting an oversized root blob.
     let activeStart = history.length;
     while (activeStart > 0 && history[activeStart - 1]?.role === "toolResult") activeStart -= 1;
-    const active = history.slice(activeStart).map(entry => truncateToolResultBlob(entry, historyBudget));
+    const active = history
+      .slice(activeStart)
+      .map(entry => truncateToolResultBlob(entry, historyBudget))
+      .filter((entry): entry is StoredRootBlob => entry !== null);
     let activeBytes = active.reduce((sum, entry) => sum + entry.byteLength, 0);
     while (active.length > 1 && activeBytes > historyBudget) {
       const dropped = active.shift();
       activeBytes -= dropped?.byteLength ?? 0;
     }
     if (active.length === 1 && active[0] && activeBytes > historyBudget) {
-      active[0] = truncateToolResultBlob(active[0], historyBudget);
-      activeBytes = active[0].byteLength;
+      const truncated = truncateToolResultBlob(active[0], historyBudget);
+      if (truncated) {
+        active[0] = truncated;
+        activeBytes = truncated.byteLength;
+      } else {
+        active.length = 0;
+        activeBytes = 0;
+      }
     }
 
     const prior = history.slice(0, activeStart);

--- a/src/adapters/cursor/protobuf-request.ts
+++ b/src/adapters/cursor/protobuf-request.ts
@@ -379,16 +379,20 @@ export function encodeCursorRunRequest(request: CursorRunRequest): Uint8Array {
       displayNameShort: request.modelId,
       aliases: [],
     }),
-    ...(request.routingLevel ? {
-      requestedModel: create(RequestedModelSchema, {
-        modelId: request.modelId,
-        maxMode: false,
+    // Always populate requested_model. Cursor is deprecating model_details in favor of
+    // requested_model; omitting it for non-router (external) models caused intermittent
+    // Connect invalid_argument on gpt-5.6-* shards while the IDE client (which always
+    // sends both) stayed stable.
+    requestedModel: create(RequestedModelSchema, {
+      modelId: request.modelId,
+      maxMode: false,
+      ...(request.routingLevel ? {
         parameters: [create(RequestedModel_ModelParameterbytesSchema, {
           id: CURSOR_ROUTING_LEVEL_PARAMETER_ID,
           value: request.routingLevel,
         })],
-      }),
-    } : {}),
+      } : {}),
+    }),
     // Mirror the client (Responses) tool definitions into the top-level AgentRunRequest.mcp_tools
     // channel. Advertising them ONLY via native-exec `requestContextArgs` (RequestContext.tools) is
     // insufficient: cursor models report those tools as unavailable and fall back to native tools.

--- a/src/adapters/cursor/request-builder.ts
+++ b/src/adapters/cursor/request-builder.ts
@@ -9,7 +9,7 @@ import type {
 } from "../../types";
 import { isAllowedToolChoice, namespacedToolName, toolChoiceAliases, type OcxTool, type OcxToolChoice } from "../../types";
 import type { CursorRequestMessage, CursorRunRequest } from "./types";
-import { cursorWireModelSelection, isCursorNativeWireModel, type CursorRoutingLevel } from "./discovery";
+import { cursorWireModelSelection, type CursorRoutingLevel } from "./discovery";
 import { cursorEffortSuffix } from "./effort-map";
 import {
   cursorMcpToolEncodedSize,
@@ -18,6 +18,7 @@ import {
   cursorToolWireName,
   cursorToolsForActivePrompt,
 } from "./tool-definitions";
+import { lookupCursorThreadConversation } from "./thread-continuity";
 
 /** Probe-verified Cursor Connect boundaries, with byte headroom for the enclosing field. */
 export const CURSOR_TOOL_COUNT_LIMIT = 330;
@@ -161,9 +162,11 @@ export function generatedCursorConversationId(): string {
 }
 
 /** Derive an opaque provider-scoped Cursor id from the upstream client's conversation identity. */
-export function cursorConversationIdFromClientThread(threadId: string): string {
+export function cursorConversationIdFromClientThread(threadId: string, identityScope?: string): string {
   const digest = createHash("sha256")
     .update("ocx:cursor:thread:")
+    .update(identityScope?.trim() || "local")
+    .update("\0")
     .update(threadId)
     .digest("hex")
     .slice(0, 32);
@@ -171,37 +174,25 @@ export function cursorConversationIdFromClientThread(threadId: string): string {
 }
 
 /**
- * Stable Cursor conversation id derived from Codex's prompt_cache_key.
- * Native Composer only: used when previous_response_id state and thread headers are missing but
- * the client still replays full history under store:false.
- */
-export function stableCursorConversationIdFromPromptCacheKey(promptCacheKey: string): string {
-  const digest = createHash("sha256")
-    .update("ocx-cursor-conv:")
-    .update(promptCacheKey)
-    .digest("hex")
-    .slice(0, 32);
-  return `cursor_${digest}`;
-}
-
-/**
  * Resolve the Cursor conversation id for this turn.
- * Priority: force-fresh → remembered → client thread → native+prompt_cache_key → random.
- * Never use OpenAI Responses `previous_response_id` (resp_*) — different namespace.
+ * Priority: force-fresh → remembered → thread override → client thread → random.
+ * Never use OpenAI Responses `previous_response_id` (resp_*) or shared `prompt_cache_key`
+ * (cache-cohort fingerprint, not conversation ownership).
  */
 export function resolveCursorConversationId(
   parsed: OcxParsedRequest,
-  wireModelId: string,
+  _wireModelId: string,
   options: CreateCursorRequestOptions = {},
 ): string {
   if (options.forceFreshConversation === true) return generatedCursorConversationId();
   if (parsed._cursorConversationId) return parsed._cursorConversationId;
-  if (parsed._clientThreadId) return cursorConversationIdFromClientThread(parsed._clientThreadId);
-  // Native composer/auto only: pin to prompt_cache_key so store:false full-history turns still
-  // share one Cursor conversation. External models skip this to avoid cross-thread collisions.
-  if (isCursorNativeWireModel(wireModelId)) {
-    const key = parsed.options.promptCacheKey?.trim();
-    if (key) return stableCursorConversationIdFromPromptCacheKey(key);
+  // Helper/shadow/compaction turns must not append into the parent's Cursor conversation.
+  if (parsed._cursorIsolateConversation === true) return generatedCursorConversationId();
+  const threadId = parsed._clientThreadId?.trim();
+  if (threadId) {
+    const recovered = lookupCursorThreadConversation(threadId, parsed._cursorIdentityScope);
+    if (recovered) return recovered;
+    return cursorConversationIdFromClientThread(threadId, parsed._cursorIdentityScope);
   }
   return generatedCursorConversationId();
 }

--- a/src/adapters/cursor/request-builder.ts
+++ b/src/adapters/cursor/request-builder.ts
@@ -175,7 +175,7 @@ export function cursorConversationIdFromClientThread(threadId: string, identityS
 
 /**
  * Resolve the Cursor conversation id for this turn.
- * Priority: force-fresh → remembered → thread override → client thread → random.
+ * Priority: force-fresh → isolate helper → remembered → thread override → client thread → random.
  * Never use OpenAI Responses `previous_response_id` (resp_*) or shared `prompt_cache_key`
  * (cache-cohort fingerprint, not conversation ownership).
  */
@@ -185,9 +185,10 @@ export function resolveCursorConversationId(
   options: CreateCursorRequestOptions = {},
 ): string {
   if (options.forceFreshConversation === true) return generatedCursorConversationId();
-  if (parsed._cursorConversationId) return parsed._cursorConversationId;
-  // Helper/shadow/compaction turns must not append into the parent's Cursor conversation.
+  // Helper/shadow/compaction turns must not append into the parent's Cursor conversation,
+  // even when previous_response_id restored the parent's remembered id.
   if (parsed._cursorIsolateConversation === true) return generatedCursorConversationId();
+  if (parsed._cursorConversationId) return parsed._cursorConversationId;
   const threadId = parsed._clientThreadId?.trim();
   if (threadId) {
     const recovered = lookupCursorThreadConversation(threadId, parsed._cursorIdentityScope);

--- a/src/adapters/cursor/request-builder.ts
+++ b/src/adapters/cursor/request-builder.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type {
   OcxAssistantContentPart,
   OcxContentPart,
@@ -8,7 +9,7 @@ import type {
 } from "../../types";
 import { isAllowedToolChoice, namespacedToolName, toolChoiceAliases, type OcxTool, type OcxToolChoice } from "../../types";
 import type { CursorRequestMessage, CursorRunRequest } from "./types";
-import { cursorWireModelSelection, isCursorExternalWireModel, type CursorRoutingLevel } from "./discovery";
+import { cursorWireModelSelection, isCursorNativeWireModel, type CursorRoutingLevel } from "./discovery";
 import { cursorEffortSuffix } from "./effort-map";
 import {
   cursorMcpToolEncodedSize,
@@ -159,6 +160,52 @@ export function generatedCursorConversationId(): string {
   return `cursor_${crypto.randomUUID().replace(/-/g, "")}`;
 }
 
+/** Derive an opaque provider-scoped Cursor id from the upstream client's conversation identity. */
+export function cursorConversationIdFromClientThread(threadId: string): string {
+  const digest = createHash("sha256")
+    .update("ocx:cursor:thread:")
+    .update(threadId)
+    .digest("hex")
+    .slice(0, 32);
+  return `cursor_${digest}`;
+}
+
+/**
+ * Stable Cursor conversation id derived from Codex's prompt_cache_key.
+ * Native Composer only: used when previous_response_id state and thread headers are missing but
+ * the client still replays full history under store:false.
+ */
+export function stableCursorConversationIdFromPromptCacheKey(promptCacheKey: string): string {
+  const digest = createHash("sha256")
+    .update("ocx-cursor-conv:")
+    .update(promptCacheKey)
+    .digest("hex")
+    .slice(0, 32);
+  return `cursor_${digest}`;
+}
+
+/**
+ * Resolve the Cursor conversation id for this turn.
+ * Priority: force-fresh → remembered → client thread → native+prompt_cache_key → random.
+ * Never use OpenAI Responses `previous_response_id` (resp_*) — different namespace.
+ */
+export function resolveCursorConversationId(
+  parsed: OcxParsedRequest,
+  wireModelId: string,
+  options: CreateCursorRequestOptions = {},
+): string {
+  if (options.forceFreshConversation === true) return generatedCursorConversationId();
+  if (parsed._cursorConversationId) return parsed._cursorConversationId;
+  if (parsed._clientThreadId) return cursorConversationIdFromClientThread(parsed._clientThreadId);
+  // Native composer/auto only: pin to prompt_cache_key so store:false full-history turns still
+  // share one Cursor conversation. External models skip this to avoid cross-thread collisions.
+  if (isCursorNativeWireModel(wireModelId)) {
+    const key = parsed.options.promptCacheKey?.trim();
+    if (key) return stableCursorConversationIdFromPromptCacheKey(key);
+  }
+  return generatedCursorConversationId();
+}
+
 export interface CreateCursorRequestOptions {
   /** Force a brand-new Cursor conversation id even when remembered state exists. */
   forceFreshConversation?: boolean;
@@ -176,23 +223,10 @@ export function createCursorRequest(
   const budget = applyCursorToolBudget(visibleTools, parsed.options.toolChoice);
   const limitNote = catalogLimitNote(budget.tools, budget.omitted);
   const model = normalizeCursorModelId(parsed.modelId, parsed.options.reasoning);
-  const lastRaw = parsed.context.messages.at(-1);
-  // External Cursor models (e.g. gpt-5.6-sol) can corrupt server-side conversation state across
-  // tool-result continuations when ResumeAction reuses the same conversationId. Force a fresh id
-  // so the full history is replayed without depending on that state.
-  const forceFreshConversation =
-    options.forceFreshConversation === true
-    || (lastRaw?.role === "toolResult" && isCursorExternalWireModel(model.modelId));
   return {
     modelId: model.modelId,
     ...(model.routingLevel ? { routingLevel: model.routingLevel } : {}),
-    // The Cursor conversation id comes ONLY from remembered state (_cursorConversationId). Do NOT fall
-    // back to the OpenAI Responses previous_response_id (resp_*): that is a Responses-chain id in a
-    // different namespace and would start an unrelated Cursor conversation, breaking tool-result
-    // continuation. If we have no remembered Cursor conversation, start a fresh one.
-    conversationId: forceFreshConversation
-      ? generatedCursorConversationId()
-      : (parsed._cursorConversationId ?? generatedCursorConversationId()),
+    conversationId: resolveCursorConversationId(parsed, model.modelId, options),
     system: [...(parsed.context.systemPrompt ?? []), ...(limitNote ? [limitNote] : [])],
     messages,
     rawMessages: parsed.context.messages,

--- a/src/adapters/cursor/thread-continuity.ts
+++ b/src/adapters/cursor/thread-continuity.ts
@@ -1,0 +1,67 @@
+/**
+ * Bounded in-memory overrides for Cursor conversation continuity.
+ *
+ * When an invalid_argument recovery mints a fresh conversation id for a store:false
+ * thread-identified client, later turns without previous_response_id must reuse that
+ * recovered id instead of recomputing the stale deterministic thread hash.
+ */
+
+const OVERRIDE_TTL_MS = 60 * 60 * 1000;
+const OVERRIDE_MAX_ENTRIES = 2048;
+
+const overrides = new Map<string, { conversationId: string; updatedAt: number }>();
+
+function now(): number {
+  return Date.now();
+}
+
+function prune(at: number): void {
+  for (const [key, entry] of overrides) {
+    if (at - entry.updatedAt > OVERRIDE_TTL_MS) overrides.delete(key);
+    else break; // Map iterates insertion order; refreshed entries are moved to the end
+  }
+  while (overrides.size > OVERRIDE_MAX_ENTRIES) {
+    const oldest = overrides.keys().next().value;
+    if (oldest === undefined) break;
+    overrides.delete(oldest);
+  }
+}
+
+/** Scope key for a client thread, optionally namespaced by authenticated tenant/operator identity. */
+export function cursorThreadScopeKey(threadId: string, identityScope?: string): string {
+  const scope = identityScope?.trim() || "local";
+  return `${scope}\0${threadId}`;
+}
+
+export function rememberCursorThreadConversation(
+  threadId: string,
+  conversationId: string,
+  identityScope?: string,
+): void {
+  const key = cursorThreadScopeKey(threadId, identityScope);
+  const at = now();
+  overrides.delete(key);
+  overrides.set(key, { conversationId, updatedAt: at });
+  prune(at);
+}
+
+export function lookupCursorThreadConversation(
+  threadId: string,
+  identityScope?: string,
+): string | undefined {
+  const key = cursorThreadScopeKey(threadId, identityScope);
+  const entry = overrides.get(key);
+  if (!entry) return undefined;
+  const at = now();
+  if (at - entry.updatedAt > OVERRIDE_TTL_MS) {
+    overrides.delete(key);
+    return undefined;
+  }
+  overrides.delete(key);
+  overrides.set(key, { conversationId: entry.conversationId, updatedAt: at });
+  return entry.conversationId;
+}
+
+export function clearCursorThreadContinuityForTests(): void {
+  overrides.clear();
+}

--- a/src/adapters/cursor/types.ts
+++ b/src/adapters/cursor/types.ts
@@ -42,7 +42,9 @@ export type CursorServerMessage =
   | { type: "heartbeat" }
   | { type: "kv_get"; key: string }
   | { type: "kv_set"; key: string; value: Uint8Array }
-  | { type: "exec"; execCase: string; requestId: string };
+  | { type: "exec"; execCase: string; requestId: string }
+  /** A native exec/MCP action ran locally; retrying this turn could duplicate its side effects. */
+  | { type: "local_side_effect" };
 
 export type CursorClientMessage =
   | { type: "kv_value"; key: string; value?: Uint8Array }

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -688,7 +688,10 @@ export async function handleResponses(
       (parsed._rawBody as Record<string, unknown>).reasoning = { effort: "low" };
     }
     (logCtx as unknown as Record<string, unknown>).shadowCallRewrittenFrom = _sciOriginal;
+    // Helpers must not resume/append into the parent thread's Cursor conversation.
+    parsed._cursorIsolateConversation = true;
   }
+  if (parsed._compactionRequest === true) parsed._cursorIsolateConversation = true;
 
   let route;
   try {
@@ -851,6 +854,10 @@ export async function handleResponses(
   }
   route.provider = applyCodexAuthContextToProvider(route.provider, authCtx, route.codexAccountMode);
   logCtx.provider = formatCodexProviderForLog(route.providerName, codexLogAccountId(authCtx), config);
+  // Namespace Cursor thread→conversation derivation by authenticated pool account when present
+  // so shared-proxy tenants cannot collide on a client-supplied parent thread id.
+  const identityScope = codexLogAccountId(authCtx);
+  if (identityScope) parsed._cursorIdentityScope = identityScope;
 
   // OAuth providers: swap in a fresh access token (auto-refreshed) as the Bearer key, so the
   // existing openai-chat / anthropic adapters authenticate with no change.

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -854,8 +854,8 @@ export async function handleResponses(
   }
   route.provider = applyCodexAuthContextToProvider(route.provider, authCtx, route.codexAccountMode);
   logCtx.provider = formatCodexProviderForLog(route.providerName, codexLogAccountId(authCtx), config);
-  // Namespace Cursor thread→conversation derivation by authenticated pool account when present
-  // so shared-proxy tenants cannot collide on a client-supplied parent thread id.
+  // Prefer Codex pool account as the Cursor thread namespace when present. Cursor routes without
+  // codexAccountMode still get a credential-derived scope inside the Cursor adapter.
   const identityScope = codexLogAccountId(authCtx);
   if (identityScope) parsed._cursorIdentityScope = identityScope;
 

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -661,6 +661,8 @@ export async function handleResponses(
     if (previousResponseInputExpanded) parsed._previousResponseInputExpanded = true;
     parsed._providerContinuation = previousResponseProviderState(parsed.previousResponseId);
     parsed._cursorConversationId = parsed._providerContinuation?.cursor?.conversationId;
+    const clientThreadId = req.headers.get("x-codex-parent-thread-id")?.trim();
+    if (clientThreadId) parsed._clientThreadId = clientThreadId;
   } catch (err) {
     return formatErrorResponse(400, "invalid_request_error", err instanceof Error ? err.message : String(err));
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,16 @@ export interface OcxParsedRequest {
   _cursorConversationId?: string;
   /** Stable upstream client thread identity, used only to derive provider-scoped continuation ids. */
   _clientThreadId?: string;
+  /**
+   * Optional authenticated tenant/operator namespace for Cursor thread→conversation derivation.
+   * When absent (single-operator local proxy), derivation stays local-scoped.
+   */
+  _cursorIdentityScope?: string;
+  /**
+   * True for helper/shadow/compaction turns that must not append into the main Cursor conversation
+   * derived from the parent thread id.
+   */
+  _cursorIsolateConversation?: boolean;
   /** Provider-private continuation metadata resolved from the Responses previous_response_id chain. */
   _providerContinuation?: OcxProviderContinuationState;
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export interface OcxParsedRequest {
   _previousResponseInputExpanded?: boolean;
   /** Provider-private stable Cursor conversation id resolved from the Responses previous_response_id chain. */
   _cursorConversationId?: string;
+  /** Stable upstream client thread identity, used only to derive provider-scoped continuation ids. */
+  _clientThreadId?: string;
   /** Provider-private continuation metadata resolved from the Responses previous_response_id chain. */
   _providerContinuation?: OcxProviderContinuationState;
   /**

--- a/tests/cursor-adapter.test.ts
+++ b/tests/cursor-adapter.test.ts
@@ -125,6 +125,36 @@ describe("Cursor adapter live transport", () => {
     expect(JSON.stringify(events).includes("secret-token-123")).toBe(false);
   });
 
+  test("derives distinct thread conversation ids per Cursor credential", async () => {
+    const ids: string[] = [];
+    const scopes: Array<string | undefined> = [];
+    for (const apiKey of ["cursor-token-a", "cursor-token-b"]) {
+      const adapter = createCursorAdapter({ ...provider, apiKey }, {
+        createTransport: () => ({
+          async *run(request) {
+            ids.push(request.conversationId);
+            yield { type: "done" } satisfies CursorServerMessage;
+          },
+          writeClient() {},
+        }),
+      });
+      const body: OcxParsedRequest = {
+        modelId: "cursor/auto",
+        context: { messages: [{ role: "user", content: "hi", timestamp: 1 }] },
+        stream: false,
+        options: {},
+        _clientThreadId: `cred-scope-thread`,
+      };
+      await adapter.runTurn?.(body, { headers: new Headers() }, () => {});
+      scopes.push(body._cursorIdentityScope);
+    }
+    expect(scopes[0]).toBeTruthy();
+    expect(scopes[1]).toBeTruthy();
+    expect(scopes[0]).not.toBe(scopes[1]);
+    expect(ids).toHaveLength(2);
+    expect(ids[0]).not.toBe(ids[1]);
+  });
+
   test("parseStream reports that the fetch path is disabled", async () => {
     const adapter = createCursorAdapter(provider);
 

--- a/tests/cursor-adapter.test.ts
+++ b/tests/cursor-adapter.test.ts
@@ -3,6 +3,10 @@ import {
   createCursorAdapter,
   cursorExecDeniedMessage,
 } from "../src/adapters/cursor";
+import {
+  clearCursorThreadContinuityForTests,
+  lookupCursorThreadConversation,
+} from "../src/adapters/cursor/thread-continuity";
 import type { AdapterEvent, OcxParsedRequest, OcxProviderConfig } from "../src/types";
 import type { CursorClientMessage, CursorRunRequest, CursorServerMessage } from "../src/adapters/cursor/types";
 
@@ -365,7 +369,81 @@ describe("Cursor adapter live transport", () => {
     expect(rekeyCalls).toEqual([]);
     expect(body._cursorConversationId).toBe("cursor_prior");
   });
-});
+
+  test("isolated helper turns do not rekey parent context usage", async () => {
+    const rekeyCalls: Array<[string, string]> = [];
+    const seen: string[] = [];
+    const adapter = createCursorAdapter({
+      ...provider,
+      apiKey: "cursor-token",
+    }, {
+      createTransport: () => ({
+        async *run(request) {
+          seen.push(request.conversationId);
+          yield { type: "done" } satisfies CursorServerMessage;
+        },
+        writeClient() {},
+      }),
+      rekeyContextUsage: (from, to) => rekeyCalls.push([from, to]),
+    });
+
+    const body: OcxParsedRequest = {
+      modelId: "cursor/auto",
+      context: { messages: [{ role: "user", content: "summarize", timestamp: 1 }] },
+      stream: false,
+      options: {},
+      _clientThreadId: "parent-thread-isolate-rekey",
+      _cursorConversationId: "cursor_parent_real",
+      _cursorIsolateConversation: true,
+    };
+
+    await adapter.runTurn?.(body, { headers: new Headers() }, () => {});
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).not.toBe("cursor_parent_real");
+    expect(seen[0]?.startsWith("cursor_")).toBe(true);
+    expect(rekeyCalls).toEqual([]);
+  });
+
+  test("isolated invalid_argument recovery does not remember under the parent thread", async () => {
+    clearCursorThreadContinuityForTests();
+    let attempts = 0;
+    const adapter = createCursorAdapter({
+      ...provider,
+      apiKey: "cursor-token",
+    }, {
+      createTransport: () => ({
+        async *run() {
+          attempts += 1;
+          if (attempts === 1) {
+            throw Object.assign(
+              new Error("Cursor invalid request: Cursor Connect error invalid_argument: Error"),
+              { code: "invalid_argument" },
+            );
+          }
+          yield { type: "done" } satisfies CursorServerMessage;
+        },
+        writeClient() {},
+      }),
+    });
+
+    const threadId = "parent-thread-isolate-remember";
+    const body: OcxParsedRequest = {
+      modelId: "cursor/gpt-5.6-sol",
+      context: { messages: [{ role: "user", content: "helper ask", timestamp: 1 }] },
+      stream: false,
+      options: { reasoning: "xhigh" },
+      _clientThreadId: threadId,
+      _cursorConversationId: "cursor_parent_real",
+      _cursorIsolateConversation: true,
+      _cursorIdentityScope: "acct-isolate-test",
+    };
+
+    await adapter.runTurn?.(body, { headers: new Headers() }, () => {});
+
+    expect(attempts).toBe(2);
+    expect(lookupCursorThreadConversation(threadId, "acct-isolate-test")).toBeUndefined();
+  });
 
   test("does not replay invalid_argument after non-heartbeat output was already emitted", async () => {
     let attempts = 0;
@@ -420,3 +498,4 @@ describe("Cursor adapter live transport", () => {
     expect(events.some(event => event.type === "text_delta")).toBe(true);
     expect(events.some(event => event.type === "error")).toBe(true);
   });
+});

--- a/tests/cursor-adapter.test.ts
+++ b/tests/cursor-adapter.test.ts
@@ -141,7 +141,7 @@ describe("Cursor adapter live transport", () => {
     expect(cursorExecDeniedMessage("shellArgs")).toContain("legacy mock transport cannot execute");
   });
 
-  test("retries external-model invalid_argument once with a fresh conversation id", async () => {
+  test("does not retry external tool-result invalid_argument with a fresh conversation id", async () => {
     const seen: string[] = [];
     let attempts = 0;
     const adapter = createCursorAdapter({
@@ -152,13 +152,10 @@ describe("Cursor adapter live transport", () => {
         async *run(request) {
           attempts += 1;
           seen.push(request.conversationId);
-          if (attempts === 1) {
-            throw Object.assign(
-              new Error("Cursor invalid request: Cursor Connect error invalid_argument: Error"),
-              { code: "invalid_argument" },
-            );
-          }
-          yield { type: "done" } satisfies CursorServerMessage;
+          throw Object.assign(
+            new Error("Cursor invalid request: Cursor Connect error invalid_argument: Error"),
+            { code: "invalid_argument" },
+          );
         },
         writeClient() {},
       }),
@@ -194,12 +191,10 @@ describe("Cursor adapter live transport", () => {
 
     await adapter.runTurn?.(body, { headers: new Headers() }, event => events.push(event));
 
-    expect(attempts).toBe(2);
-    expect(seen).toHaveLength(2);
-    expect(seen[0]).not.toBe("cursor_corrupt");
-    expect(seen[1]).not.toBe(seen[0]);
-    expect(body._cursorConversationId).toBe(seen[1]);
-    expect(events.filter(event => event.type === "error")).toHaveLength(0);
+    expect(attempts).toBe(1);
+    expect(seen).toEqual(["cursor_corrupt"]);
+    expect(body._cursorConversationId).toBe("cursor_corrupt");
+    expect(events.filter(event => event.type === "error")).toHaveLength(1);
   });
 
   test("retries external-model invalid_argument on plain-user continuations too", async () => {
@@ -254,7 +249,41 @@ describe("Cursor adapter live transport", () => {
     expect(events.filter(event => event.type === "error")).toHaveLength(0);
   });
 
-  test("rotation rekeys context usage through the injectable seam", async () => {
+  test("does not replay invalid_argument after a local side effect", async () => {
+    let attempts = 0;
+    const adapter = createCursorAdapter({
+      ...provider,
+      apiKey: "cursor-token",
+    }, {
+      createTransport: () => ({
+        async *run() {
+          attempts += 1;
+          yield { type: "local_side_effect" } satisfies CursorServerMessage;
+          throw Object.assign(
+            new Error("Cursor invalid request: Cursor Connect error invalid_argument: Error"),
+            { code: "invalid_argument" },
+          );
+        },
+        writeClient() {},
+      }),
+    });
+
+    const events: AdapterEvent[] = [];
+    const body: OcxParsedRequest = {
+      modelId: "cursor/gpt-5.6-sol",
+      context: { messages: [{ role: "user", content: "run a command", timestamp: 1 }] },
+      stream: false,
+      options: { reasoning: "xhigh" },
+      _cursorConversationId: "cursor_side_effect",
+    };
+
+    await adapter.runTurn?.(body, { headers: new Headers() }, event => events.push(event));
+
+    expect(attempts).toBe(1);
+    expect(events.some(event => event.type === "error")).toBe(true);
+  });
+
+  test("same-id tool continuation does not rekey context usage", async () => {
     const rekeyCalls: Array<[string, string]> = [];
     const seen: string[] = [];
     const adapter = createCursorAdapter({
@@ -301,12 +330,10 @@ describe("Cursor adapter live transport", () => {
     const events: AdapterEvent[] = [];
     await adapter.runTurn?.(body, { headers: new Headers() }, event => events.push(event));
 
-    // External-model toolResult continuation rotates the conversation id and the
-    // adapter must rekey the carry-forward context usage onto the new id.
     expect(seen).toHaveLength(1);
-    expect(seen[0]).not.toBe("cursor_prior");
-    expect(rekeyCalls).toEqual([["cursor_prior", seen[0]!]]);
-    expect(body._cursorConversationId).toBe(seen[0]);
+    expect(seen[0]).toBe("cursor_prior");
+    expect(rekeyCalls).toEqual([]);
+    expect(body._cursorConversationId).toBe("cursor_prior");
   });
 });
 

--- a/tests/cursor-adapter.test.ts
+++ b/tests/cursor-adapter.test.ts
@@ -202,6 +202,58 @@ describe("Cursor adapter live transport", () => {
     expect(events.filter(event => event.type === "error")).toHaveLength(0);
   });
 
+  test("retries external-model invalid_argument on plain-user continuations too", async () => {
+    const seen: string[] = [];
+    let attempts = 0;
+    const adapter = createCursorAdapter({
+      ...provider,
+      apiKey: "cursor-token",
+    }, {
+      createTransport: () => ({
+        async *run(request) {
+          attempts += 1;
+          seen.push(request.conversationId);
+          if (attempts === 1) {
+            throw Object.assign(
+              new Error("Cursor invalid request: Cursor Connect error invalid_argument: Error"),
+              { code: "invalid_argument" },
+            );
+          }
+          yield { type: "done" } satisfies CursorServerMessage;
+        },
+        writeClient() {},
+      }),
+    });
+
+    const events: AdapterEvent[] = [];
+    const body: OcxParsedRequest = {
+      modelId: "cursor/gpt-5.6-sol",
+      context: {
+        messages: [
+          { role: "user", content: "first turn", timestamp: 1 },
+          {
+            role: "assistant",
+            model: "cursor/gpt-5.6-sol",
+            timestamp: 2,
+            content: [{ type: "text", text: "ack" }],
+          },
+          { role: "user", content: "second turn", timestamp: 3 },
+        ],
+      },
+      stream: false,
+      options: { reasoning: "xhigh" },
+      _cursorConversationId: "cursor_stale",
+    };
+
+    await adapter.runTurn?.(body, { headers: new Headers() }, event => events.push(event));
+
+    expect(attempts).toBe(2);
+    expect(seen[0]).toBe("cursor_stale");
+    expect(seen[1]).not.toBe("cursor_stale");
+    expect(body._cursorConversationId).toBe(seen[1]);
+    expect(events.filter(event => event.type === "error")).toHaveLength(0);
+  });
+
   test("rotation rekeys context usage through the injectable seam", async () => {
     const rekeyCalls: Array<[string, string]> = [];
     const seen: string[] = [];

--- a/tests/cursor-blob.test.ts
+++ b/tests/cursor-blob.test.ts
@@ -146,6 +146,43 @@ describe("Cursor blob handshake", () => {
     expect(rootRoles.find(role => role !== "system")).toBe("user");
   });
 
+  test("preserves oversized active tool result under external byte budget", () => {
+    const huge = "y".repeat(CURSOR_EXTERNAL_ROOT_BYTE_LIMIT);
+    const bytes = encodeCursorRunRequest({
+      modelId: "gpt-5.6-sol-xhigh",
+      conversationId: "c-tool-cap",
+      system: ["system"],
+      messages: [{ role: "tool", content: "ignored" }],
+      rawMessages: [
+        { role: "user", content: "read it", timestamp: 1 },
+        {
+          role: "assistant",
+          model: "cursor/gpt-5.6-sol",
+          content: [{ type: "toolCall", id: "call_1", name: "read_file", arguments: { path: "a.txt" } }],
+          timestamp: 2,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call_1",
+          toolName: "read_file",
+          content: huge,
+          isError: false,
+          timestamp: 3,
+        },
+      ],
+    });
+    const msg = fromBinary(AgentClientMessageSchema, bytes);
+    const run = msg.message.case === "runRequest" ? msg.message.value : undefined;
+    const roots = decodeRootMessages(bytes) as Array<{ role?: string; content?: unknown }>;
+    const rootBytes = (run?.conversationState?.rootPromptMessagesJson ?? [])
+      .reduce((sum, id) => sum + blobData(id).byteLength, 0);
+
+    expect(run?.action?.action.case).toBe("resumeAction");
+    expect(rootBytes).toBeLessThanOrEqual(CURSOR_EXTERNAL_ROOT_BYTE_LIMIT);
+    expect(JSON.stringify(roots)).toContain("[Tool Result]");
+    expect(JSON.stringify(roots)).toContain("truncated for Cursor external replay budget");
+  });
+
   test("encodes Cursor Router levels through requested_model parameters", () => {
     const bytes = encodeCursorRunRequest({
       modelId: "default",

--- a/tests/cursor-blob.test.ts
+++ b/tests/cursor-blob.test.ts
@@ -183,6 +183,39 @@ describe("Cursor blob handshake", () => {
     expect(JSON.stringify(roots)).toContain("truncated for Cursor external replay budget");
   });
 
+  test("truncates multi-byte tool results by UTF-8 byte budget", () => {
+    const huge = "한".repeat(200_000); // 3 bytes per character
+    const bytes = encodeCursorRunRequest({
+      modelId: "gpt-5.6-sol-xhigh",
+      conversationId: "c-cjk-cap",
+      system: ["system"],
+      messages: [{ role: "tool", content: "ignored" }],
+      rawMessages: [
+        { role: "user", content: "read it", timestamp: 1 },
+        {
+          role: "assistant",
+          model: "cursor/gpt-5.6-sol",
+          content: [{ type: "toolCall", id: "call_1", name: "read_file", arguments: { path: "a.txt" } }],
+          timestamp: 2,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call_1",
+          toolName: "read_file",
+          content: huge,
+          isError: false,
+          timestamp: 3,
+        },
+      ],
+    });
+    const msg = fromBinary(AgentClientMessageSchema, bytes);
+    const run = msg.message.case === "runRequest" ? msg.message.value : undefined;
+    const rootBytes = (run?.conversationState?.rootPromptMessagesJson ?? [])
+      .reduce((sum, id) => sum + blobData(id).byteLength, 0);
+    expect(rootBytes).toBeLessThanOrEqual(CURSOR_EXTERNAL_ROOT_BYTE_LIMIT);
+    expect(JSON.stringify(decodeRootMessages(bytes))).toContain("truncated for Cursor external replay budget");
+  });
+
   test("encodes Cursor Router levels through requested_model parameters", () => {
     const bytes = encodeCursorRunRequest({
       modelId: "default",

--- a/tests/cursor-blob.test.ts
+++ b/tests/cursor-blob.test.ts
@@ -216,6 +216,44 @@ describe("Cursor blob handshake", () => {
     expect(JSON.stringify(decodeRootMessages(bytes))).toContain("truncated for Cursor external replay budget");
   });
 
+  test("omits tool result when system leaves too little budget for the truncation marker", () => {
+    // Leave ~40 bytes of history room — less than the JSON-wrapped truncation marker (~100 bytes).
+    const overhead = new TextEncoder().encode(JSON.stringify({ role: "system", content: "" })).byteLength;
+    const leave = 40;
+    const system = "s".repeat(Math.max(0, CURSOR_EXTERNAL_ROOT_BYTE_LIMIT - leave - overhead));
+    const bytes = encodeCursorRunRequest({
+      modelId: "gpt-5.6-sol-xhigh",
+      conversationId: "c-system-cap",
+      system: [system],
+      messages: [{ role: "tool", content: "ignored" }],
+      rawMessages: [
+        { role: "user", content: "read it", timestamp: 1 },
+        {
+          role: "assistant",
+          model: "cursor/gpt-5.6-sol",
+          content: [{ type: "toolCall", id: "call_1", name: "read_file", arguments: { path: "a.txt" } }],
+          timestamp: 2,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call_1",
+          toolName: "read_file",
+          content: "y".repeat(10_000),
+          isError: false,
+          timestamp: 3,
+        },
+      ],
+    });
+    const msg = fromBinary(AgentClientMessageSchema, bytes);
+    const run = msg.message.case === "runRequest" ? msg.message.value : undefined;
+    const roots = decodeRootMessages(bytes) as Array<{ role?: string; content?: unknown }>;
+    const rootBytes = (run?.conversationState?.rootPromptMessagesJson ?? [])
+      .reduce((sum, id) => sum + blobData(id).byteLength, 0);
+
+    expect(rootBytes).toBeLessThanOrEqual(CURSOR_EXTERNAL_ROOT_BYTE_LIMIT);
+    expect(JSON.stringify(roots)).not.toContain("truncated for Cursor external replay budget");
+  });
+
   test("encodes Cursor Router levels through requested_model parameters", () => {
     const bytes = encodeCursorRunRequest({
       modelId: "default",

--- a/tests/cursor-blob.test.ts
+++ b/tests/cursor-blob.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { create, fromBinary } from "@bufbuild/protobuf";
 import { handleCursorNativeKv, storeCursorBlob } from "../src/adapters/cursor/native-exec";
-import { CURSOR_ROUTING_LEVEL_PARAMETER_ID, encodeCursorRunRequest } from "../src/adapters/cursor/protobuf-request";
+import {
+  CURSOR_EXTERNAL_ROOT_BYTE_LIMIT,
+  CURSOR_EXTERNAL_ROOT_BLOB_LIMIT,
+  CURSOR_ROUTING_LEVEL_PARAMETER_ID,
+  encodeCursorRunRequest,
+} from "../src/adapters/cursor/protobuf-request";
 import {
   AgentClientMessageSchema,
   ConversationStepSchema,
@@ -81,6 +86,66 @@ describe("Cursor blob handshake", () => {
     expect(run?.mcpTools?.mcpTools[0]?.toolName).toBe("mcp__fs__read_file");
   });
 
+  test("caps external root replay while preserving system and newest history", () => {
+    const rawMessages = Array.from({ length: 210 }, (_, index) =>
+      index % 2 === 0
+        ? { role: "user" as const, content: `user-${index}`, timestamp: index }
+        : {
+            role: "assistant" as const,
+            model: "cursor/gpt-5.6-sol",
+            content: [{ type: "text" as const, text: `assistant-${index}` }],
+            timestamp: index,
+          });
+    rawMessages.push({ role: "user", content: "active-user", timestamp: 211 });
+    const bytes = encodeCursorRunRequest({
+      modelId: "gpt-5.6-sol-xhigh",
+      conversationId: "c1",
+      system: ["system-marker"],
+      messages: [{ role: "user", content: "active-user" }],
+      rawMessages,
+    });
+
+    const roots = decodeRootMessages(bytes);
+    expect(roots.length).toBeLessThanOrEqual(CURSOR_EXTERNAL_ROOT_BLOB_LIMIT);
+    expect(JSON.stringify(roots[0])).toContain("system-marker");
+    expect((roots[1] as { role?: string }).role).toBe("user");
+    expect(JSON.stringify(roots)).toContain("assistant-209");
+    expect(JSON.stringify(roots)).not.toContain("user-0");
+  });
+
+  test("caps external root replay by serialized bytes", () => {
+    const large = "x".repeat(40_000);
+    const rawMessages = Array.from({ length: 12 }, (_, index) => [
+      { role: "user" as const, content: `user-${index}:${large}`, timestamp: index * 2 + 1 },
+      {
+        role: "assistant" as const,
+        model: "cursor/gpt-5.6-sol",
+        content: [{ type: "text" as const, text: `assistant-${index}:${large}` }],
+        timestamp: index * 2 + 2,
+      },
+    ]).flat();
+    rawMessages.push({ role: "user", content: "current", timestamp: 100 });
+
+    const bytes = encodeCursorRunRequest({
+      modelId: "gpt-5.6-sol-xhigh",
+      conversationId: "c-byte-cap",
+      system: ["system"],
+      messages: [{ role: "user", content: "current" }],
+      rawMessages,
+    });
+    const msg = fromBinary(AgentClientMessageSchema, bytes);
+    const run = msg.message.case === "runRequest" ? msg.message.value : undefined;
+    const roots = run?.conversationState?.rootPromptMessagesJson ?? [];
+    const rootBytes = roots.reduce((sum, id) => sum + blobData(id).byteLength, 0);
+    const rootRoles = roots.map(id =>
+      (JSON.parse(new TextDecoder().decode(blobData(id))) as { role?: string }).role
+    );
+
+    expect(rootBytes).toBeLessThanOrEqual(CURSOR_EXTERNAL_ROOT_BYTE_LIMIT);
+    expect(roots.length).toBeLessThan(rawMessages.length);
+    expect(rootRoles.find(role => role !== "system")).toBe("user");
+  });
+
   test("encodes Cursor Router levels through requested_model parameters", () => {
     const bytes = encodeCursorRunRequest({
       modelId: "default",
@@ -100,7 +165,7 @@ describe("Cursor blob handshake", () => {
     });
   });
 
-  test("always encodes requested_model for external Cursor models", () => {
+  test("does not encode router-only requested_model for external Cursor models", () => {
     const bytes = encodeCursorRunRequest({
       modelId: "gpt-5.6-sol-xhigh",
       conversationId: "c1",
@@ -111,9 +176,7 @@ describe("Cursor blob handshake", () => {
     const run = msg.message.case === "runRequest" ? msg.message.value : undefined;
 
     expect(run?.modelDetails?.modelId).toBe("gpt-5.6-sol-xhigh");
-    expect(run?.requestedModel?.modelId).toBe("gpt-5.6-sol-xhigh");
-    expect(run?.requestedModel?.maxMode).toBe(false);
-    expect(run?.requestedModel?.parameters ?? []).toEqual([]);
+    expect(run?.requestedModel).toBeUndefined();
   });
 
   test("adds Cursor exact-tool guidance to system prompt blobs when tools are advertised", () => {
@@ -256,9 +319,9 @@ describe("Cursor blob handshake", () => {
     }
   });
 
-  test("encodeCursorRunRequest preserves prior assistant tool calls with tool results in turn steps", () => {
+  test("native Cursor replay preserves tool calls with results in turn steps", () => {
     const bytes = encodeCursorRunRequest({
-      modelId: "claude-4.6-opus-high",
+      modelId: "composer-2.5",
       conversationId: "c1",
       system: ["You are helpful."],
       messages: [{ role: "tool", content: "[tool_result]\ncall_id: call_1\nname: read_file\nis_error: false\noutput:\ncontents" }],
@@ -294,9 +357,63 @@ describe("Cursor blob handshake", () => {
         if (content?.case === "text") expect(content.value.text).toBe("contents");
       }
     }
-    // The last raw message is a toolResult, so the turn continues the same Cursor conversation with
-    // the tool result carried as structured history (mcpToolCall.result above). The action must be
-    // ResumeAction, NOT a UserMessageAction that would re-inject the tool result as user text.
+    expect(run?.action?.action.case).toBe("resumeAction");
+  });
+
+  test("external Cursor replay uses text history instead of native tool/thinking structures", () => {
+    const bytes = encodeCursorRunRequest({
+      modelId: "gpt-5.6-sol-xhigh",
+      conversationId: "c1",
+      system: ["You are helpful."],
+      messages: [{ role: "tool", content: "[tool_result]\ncall_id: call_1\nname: read_file\nis_error: false\noutput:\ncontents" }],
+      rawMessages: [
+        { role: "user", content: "read a file", timestamp: 1 },
+        {
+          role: "assistant",
+          model: "cursor/gpt-5.6-sol",
+          timestamp: 2,
+          content: [
+            { type: "thinking", thinking: "hidden reasoning" },
+            { type: "toolCall", id: "call_1", name: "read_file", arguments: { path: "a.txt" } },
+          ],
+        },
+        { role: "toolResult", toolCallId: "call_1", toolName: "read_file", content: "contents", isError: false, timestamp: 3 },
+      ],
+    });
+    const msg = fromBinary(AgentClientMessageSchema, bytes);
+    const run = msg.message.case === "runRequest" ? msg.message.value : undefined;
+    const turn = fromBinary(ConversationTurnStructureSchema, blobData(run?.conversationState?.turns[0] ?? new Uint8Array()));
+    expect(turn.turn.case).toBe("agentConversationTurn");
+    const steps = turn.turn.case === "agentConversationTurn" ? turn.turn.value.steps : [];
+    expect(steps).toHaveLength(1);
+    const roots = decodeRootMessages(bytes) as Array<{ role?: string; content?: unknown }>;
+    const historicalUser = roots.find(root => root.role === "user");
+    expect(historicalUser?.content).toEqual([{ type: "text", text: "read a file" }]);
+    expect(run?.action?.action.case).toBe("resumeAction");
+    expect(JSON.stringify(roots)).toContain("contents");
+    expect(JSON.stringify(roots)).not.toContain("hidden reasoning");
+  });
+
+  test("keeps ResumeAction for native-model tool-result continuations", () => {
+    const bytes = encodeCursorRunRequest({
+      modelId: "composer-2.5",
+      conversationId: "c1",
+      system: ["You are helpful."],
+      messages: [{ role: "tool", content: "[tool_result]\ncall_id: call_1\nname: read_file\nis_error: false\noutput:\ncontents" }],
+      rawMessages: [
+        { role: "user", content: "read a file", timestamp: 1 },
+        {
+          role: "assistant",
+          model: "cursor/composer-2.5",
+          timestamp: 2,
+          content: [{ type: "toolCall", id: "call_1", name: "read_file", arguments: { path: "a.txt" } }],
+        },
+        { role: "toolResult", toolCallId: "call_1", toolName: "read_file", content: "contents", isError: false, timestamp: 3 },
+      ],
+    });
+    const msg = fromBinary(AgentClientMessageSchema, bytes);
+    const run = msg.message.case === "runRequest" ? msg.message.value : undefined;
+
     expect(run?.action?.action.case).toBe("resumeAction");
   });
 });

--- a/tests/cursor-blob.test.ts
+++ b/tests/cursor-blob.test.ts
@@ -100,6 +100,22 @@ describe("Cursor blob handshake", () => {
     });
   });
 
+  test("always encodes requested_model for external Cursor models", () => {
+    const bytes = encodeCursorRunRequest({
+      modelId: "gpt-5.6-sol-xhigh",
+      conversationId: "c1",
+      system: [],
+      messages: [{ role: "user", content: "hi" }],
+    });
+    const msg = fromBinary(AgentClientMessageSchema, bytes);
+    const run = msg.message.case === "runRequest" ? msg.message.value : undefined;
+
+    expect(run?.modelDetails?.modelId).toBe("gpt-5.6-sol-xhigh");
+    expect(run?.requestedModel?.modelId).toBe("gpt-5.6-sol-xhigh");
+    expect(run?.requestedModel?.maxMode).toBe(false);
+    expect(run?.requestedModel?.parameters ?? []).toEqual([]);
+  });
+
   test("adds Cursor exact-tool guidance to system prompt blobs when tools are advertised", () => {
     const bytes = encodeCursorRunRequest({
       modelId: "claude-4.6-sonnet",

--- a/tests/cursor-request-builder.test.ts
+++ b/tests/cursor-request-builder.test.ts
@@ -81,67 +81,61 @@ describe("Cursor request builder", () => {
     expect(second.conversationId).not.toBe(first.conversationId);
   });
 
-  test("native composer pins conversation id to prompt_cache_key when none remembered", () => {
-    const a = createCursorRequest({
-      modelId: "cursor/composer-2.5",
-      context: { messages: [{ role: "user", content: "hi", timestamp: 1 }] },
-      stream: false,
-      options: { promptCacheKey: "thread-abc" },
-    });
-    const b = createCursorRequest({
-      modelId: "composer-2.5",
-      context: {
-        messages: [
-          { role: "user", content: "hi", timestamp: 1 },
-          {
-            role: "toolResult",
-            toolCallId: "call_1",
-            toolName: "shell",
-            content: "ok",
-            isError: false,
-            timestamp: 2,
-          },
-        ],
-      },
-      stream: false,
-      options: { promptCacheKey: "thread-abc" },
-    });
-    expect(a.conversationId).toBe(b.conversationId);
-    expect(a.conversationId.startsWith("cursor_")).toBe(true);
-    expect(a.conversationId).toHaveLength("cursor_".length + 32);
-  });
-
-  test("client thread wins over native prompt_cache_key pin", () => {
-    const fromThread = createCursorRequest({
-      modelId: "cursor/composer-2.5",
-      context: { messages: [{ role: "user", content: "hi", timestamp: 1 }] },
-      stream: false,
-      _clientThreadId: "thread-a",
-      options: { promptCacheKey: "shared-cache-key" },
-    });
-    const fromCacheOnly = createCursorRequest({
+  test("native and external models do not pin conversation id from prompt_cache_key alone", () => {
+    const nativeA = createCursorRequest({
       modelId: "cursor/composer-2.5",
       context: { messages: [{ role: "user", content: "hi", timestamp: 1 }] },
       stream: false,
       options: { promptCacheKey: "shared-cache-key" },
     });
-    expect(fromThread.conversationId).not.toBe(fromCacheOnly.conversationId);
-  });
+    const nativeB = createCursorRequest({
+      modelId: "cursor/composer-2.5",
+      context: { messages: [{ role: "user", content: "hi again", timestamp: 2 }] },
+      stream: false,
+      options: { promptCacheKey: "shared-cache-key" },
+    });
+    expect(nativeA.conversationId).not.toBe(nativeB.conversationId);
 
-  test("external models do not pin conversation id from prompt_cache_key alone", () => {
-    const first = createCursorRequest({
+    const externalA = createCursorRequest({
       modelId: "cursor/gpt-5.6-sol",
       context: { messages: [{ role: "user", content: "hi", timestamp: 1 }] },
       stream: false,
-      options: { promptCacheKey: "thread-xyz" },
+      options: { promptCacheKey: "shared-cache-key" },
     });
-    const second = createCursorRequest({
+    const externalB = createCursorRequest({
       modelId: "cursor/gpt-5.6-sol",
       context: { messages: [{ role: "user", content: "hi again", timestamp: 2 }] },
       stream: false,
-      options: { promptCacheKey: "thread-xyz" },
+      options: { promptCacheKey: "shared-cache-key" },
     });
-    expect(first.conversationId).not.toBe(second.conversationId);
+    expect(externalA.conversationId).not.toBe(externalB.conversationId);
+  });
+
+  test("identity scope namespaces client thread conversation ids", () => {
+    const a = createCursorRequest({
+      ...base,
+      _clientThreadId: "thread-a",
+      _cursorIdentityScope: "account-1",
+    });
+    const b = createCursorRequest({
+      ...base,
+      _clientThreadId: "thread-a",
+      _cursorIdentityScope: "account-2",
+    });
+    expect(a.conversationId).not.toBe(b.conversationId);
+  });
+
+  test("isolated helper turns mint a fresh conversation id", () => {
+    const main = createCursorRequest({
+      ...base,
+      _clientThreadId: "thread-a",
+    });
+    const helper = createCursorRequest({
+      ...base,
+      _clientThreadId: "thread-a",
+      _cursorIsolateConversation: true,
+    });
+    expect(helper.conversationId).not.toBe(main.conversationId);
   });
 
   test("marks Cursor context-usage boundaries for compaction epochs", () => {

--- a/tests/cursor-request-builder.test.ts
+++ b/tests/cursor-request-builder.test.ts
@@ -138,6 +138,17 @@ describe("Cursor request builder", () => {
     expect(helper.conversationId).not.toBe(main.conversationId);
   });
 
+  test("isolation wins over a remembered parent conversation id", () => {
+    const helper = createCursorRequest({
+      ...base,
+      _clientThreadId: "thread-a",
+      _cursorConversationId: "cursor_parent_remembered",
+      _cursorIsolateConversation: true,
+    });
+    expect(helper.conversationId).not.toBe("cursor_parent_remembered");
+    expect(helper.conversationId.startsWith("cursor_")).toBe(true);
+  });
+
   test("marks Cursor context-usage boundaries for compaction epochs", () => {
     expect(createCursorRequest({ ...base, _contextCompactionBoundary: true }).contextUsageReset).toBe(true);
 

--- a/tests/cursor-request-builder.test.ts
+++ b/tests/cursor-request-builder.test.ts
@@ -38,6 +38,112 @@ describe("Cursor request builder", () => {
     expect(request.conversationId).toBe("cursor_stable");
   });
 
+  test("uses stable client thread identity for external store:false continuations", () => {
+    const initial = createCursorRequest({
+      ...base,
+      modelId: "cursor/gpt-5.6-sol",
+      context: { messages: [{ role: "user", content: "start", timestamp: 1 }] },
+      _clientThreadId: "thread-a",
+      options: { promptCacheKey: "shared-cache-key" },
+    });
+    const continuation = createCursorRequest({
+      ...base,
+      modelId: "cursor/gpt-5.6-sol",
+      context: {
+        messages: [{
+          role: "toolResult",
+          toolCallId: "call-1",
+          toolName: "read_file",
+          content: "result",
+          isError: false,
+          timestamp: 2,
+        }],
+      },
+      _clientThreadId: "thread-a",
+      options: { promptCacheKey: "shared-cache-key" },
+    });
+
+    expect(continuation.conversationId).toBe(initial.conversationId);
+  });
+
+  test("isolates client threads even when they share a prompt cache key", () => {
+    const first = createCursorRequest({
+      ...base,
+      _clientThreadId: "thread-a",
+      options: { promptCacheKey: "shared-cache-key" },
+    });
+    const second = createCursorRequest({
+      ...base,
+      _clientThreadId: "thread-b",
+      options: { promptCacheKey: "shared-cache-key" },
+    });
+
+    expect(second.conversationId).not.toBe(first.conversationId);
+  });
+
+  test("native composer pins conversation id to prompt_cache_key when none remembered", () => {
+    const a = createCursorRequest({
+      modelId: "cursor/composer-2.5",
+      context: { messages: [{ role: "user", content: "hi", timestamp: 1 }] },
+      stream: false,
+      options: { promptCacheKey: "thread-abc" },
+    });
+    const b = createCursorRequest({
+      modelId: "composer-2.5",
+      context: {
+        messages: [
+          { role: "user", content: "hi", timestamp: 1 },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "shell",
+            content: "ok",
+            isError: false,
+            timestamp: 2,
+          },
+        ],
+      },
+      stream: false,
+      options: { promptCacheKey: "thread-abc" },
+    });
+    expect(a.conversationId).toBe(b.conversationId);
+    expect(a.conversationId.startsWith("cursor_")).toBe(true);
+    expect(a.conversationId).toHaveLength("cursor_".length + 32);
+  });
+
+  test("client thread wins over native prompt_cache_key pin", () => {
+    const fromThread = createCursorRequest({
+      modelId: "cursor/composer-2.5",
+      context: { messages: [{ role: "user", content: "hi", timestamp: 1 }] },
+      stream: false,
+      _clientThreadId: "thread-a",
+      options: { promptCacheKey: "shared-cache-key" },
+    });
+    const fromCacheOnly = createCursorRequest({
+      modelId: "cursor/composer-2.5",
+      context: { messages: [{ role: "user", content: "hi", timestamp: 1 }] },
+      stream: false,
+      options: { promptCacheKey: "shared-cache-key" },
+    });
+    expect(fromThread.conversationId).not.toBe(fromCacheOnly.conversationId);
+  });
+
+  test("external models do not pin conversation id from prompt_cache_key alone", () => {
+    const first = createCursorRequest({
+      modelId: "cursor/gpt-5.6-sol",
+      context: { messages: [{ role: "user", content: "hi", timestamp: 1 }] },
+      stream: false,
+      options: { promptCacheKey: "thread-xyz" },
+    });
+    const second = createCursorRequest({
+      modelId: "cursor/gpt-5.6-sol",
+      context: { messages: [{ role: "user", content: "hi again", timestamp: 2 }] },
+      stream: false,
+      options: { promptCacheKey: "thread-xyz" },
+    });
+    expect(first.conversationId).not.toBe(second.conversationId);
+  });
+
   test("marks Cursor context-usage boundaries for compaction epochs", () => {
     expect(createCursorRequest({ ...base, _contextCompactionBoundary: true }).contextUsageReset).toBe(true);
 
@@ -225,7 +331,7 @@ describe("Cursor request builder", () => {
   });
 
 
-  test("external Cursor tool-result continuation forces a fresh conversation id", () => {
+  test("external Cursor tool-result continuation keeps the remembered conversation id", () => {
     const request = createCursorRequest({
       modelId: "cursor/gpt-5.6-sol",
       context: {
@@ -254,8 +360,7 @@ describe("Cursor request builder", () => {
     });
 
     expect(request.modelId).toBe("gpt-5.6-sol-xhigh");
-    expect(request.conversationId).not.toBe("cursor_old_external");
-    expect(request.conversationId.startsWith("cursor_")).toBe(true);
+    expect(request.conversationId).toBe("cursor_old_external");
   });
 
   test("native Cursor tool-result continuation keeps the remembered conversation id", () => {

--- a/tests/server-combo-failover-e2e.test.ts
+++ b/tests/server-combo-failover-e2e.test.ts
@@ -1583,32 +1583,32 @@ describe("cursor conversation continuity across store:false chains", () => {
     expect(seen[1]).toBe(seen[0]);
   });
 
-  test("native composer reuses conversationId across store:false turns via prompt_cache_key alone", async () => {
+  test("native composer reuses conversationId across store:false turns via parent thread id", async () => {
     const seen: string[] = [];
     customCursorTransportFactory = fakeCursorTransportFactory(seen);
     const config = cursorConfig();
+    const postThreadTurn = (input: unknown) => handleResponses(new Request("http://localhost/v1/responses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-codex-parent-thread-id": "desktop-thread-native",
+      },
+      body: JSON.stringify({
+        model: "cursortest/composer-2.5",
+        input,
+        stream: false,
+        store: false,
+        prompt_cache_key: "shared-cache-key",
+      }),
+    }), config, { model: "", provider: "" }, {});
 
-    const first = await postCursor(config, {
-      model: "cursortest/composer-2.5",
-      input: "hello",
-      prompt_cache_key: "desktop-thread-1",
-    });
-    expect(first.status).toBe(200);
-    await first.json();
-    expect(seen).toHaveLength(1);
+    expect((await postThreadTurn("hello")).status).toBe(200);
+    expect((await postThreadTurn([
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "cursor ok" },
+      { role: "user", content: "continue" },
+    ])).status).toBe(200);
 
-    // No previous_response_id — Codex Desktop often replays full history under store:false.
-    const second = await postCursor(config, {
-      model: "cursortest/composer-2.5",
-      input: [
-        { role: "user", content: "hello" },
-        { role: "assistant", content: "cursor ok" },
-        { role: "user", content: "continue" },
-      ],
-      prompt_cache_key: "desktop-thread-1",
-    });
-    expect(second.status).toBe(200);
-    await second.json();
     expect(seen).toHaveLength(2);
     expect(seen[1]).toBe(seen[0]);
   });

--- a/tests/server-combo-failover-e2e.test.ts
+++ b/tests/server-combo-failover-e2e.test.ts
@@ -1529,7 +1529,7 @@ describe("cursor conversation continuity across store:false chains", () => {
     expect(seen[1]).toBe(seen[0]);
   });
 
-  test("external-model toolResult continuation rotates and persists the NEW id", async () => {
+  test("external-model toolResult continuation preserves and persists the same id", async () => {
     const seen: string[] = [];
     customCursorTransportFactory = fakeCursorTransportFactory(seen);
     const config = cursorConfig();
@@ -1539,8 +1539,6 @@ describe("cursor conversation continuity across store:false chains", () => {
     const firstJson = await first.json() as { id: string };
     expect(seen).toHaveLength(1);
 
-    // A toolResult-terminated continuation on an external wire model forces a fresh
-    // conversation id (stateless replay; request-builder.ts forceFreshConversation).
     const second = await postCursor(config, {
       model: "cursortest/grok-4.5",
       previous_response_id: firstJson.id,
@@ -1548,11 +1546,70 @@ describe("cursor conversation continuity across store:false chains", () => {
     });
     expect(second.status).toBe(200);
     expect(seen).toHaveLength(2);
-    expect(seen[1]).not.toBe(seen[0]);
+    expect(seen[1]).toBe(seen[0]);
 
-    // The NEW id is what continuation state persists for the next turn.
     const secondJson = await second.json() as { id: string };
     const { previousResponseProviderState } = await import("../src/responses/state");
     expect(previousResponseProviderState(secondJson.id)?.cursor?.conversationId).toBe(seen[1]);
+  });
+
+  test("external store:false full-history turns reuse the client thread identity", async () => {
+    const seen: string[] = [];
+    customCursorTransportFactory = fakeCursorTransportFactory(seen);
+    const config = cursorConfig();
+    const postThreadTurn = (input: unknown) => handleResponses(new Request("http://localhost/v1/responses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-codex-parent-thread-id": "desktop-thread-external",
+      },
+      body: JSON.stringify({
+        model: "cursortest/grok-4.5",
+        input,
+        stream: false,
+        store: false,
+        prompt_cache_key: "shared-cache-key",
+      }),
+    }), config, { model: "", provider: "" }, {});
+
+    expect((await postThreadTurn("start")).status).toBe(200);
+    expect((await postThreadTurn([
+      { role: "user", content: "start" },
+      { role: "assistant", content: "working" },
+      { type: "function_call_output", call_id: "call_x", output: "tool result" },
+    ])).status).toBe(200);
+
+    expect(seen).toHaveLength(2);
+    expect(seen[1]).toBe(seen[0]);
+  });
+
+  test("native composer reuses conversationId across store:false turns via prompt_cache_key alone", async () => {
+    const seen: string[] = [];
+    customCursorTransportFactory = fakeCursorTransportFactory(seen);
+    const config = cursorConfig();
+
+    const first = await postCursor(config, {
+      model: "cursortest/composer-2.5",
+      input: "hello",
+      prompt_cache_key: "desktop-thread-1",
+    });
+    expect(first.status).toBe(200);
+    await first.json();
+    expect(seen).toHaveLength(1);
+
+    // No previous_response_id — Codex Desktop often replays full history under store:false.
+    const second = await postCursor(config, {
+      model: "cursortest/composer-2.5",
+      input: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "cursor ok" },
+        { role: "user", content: "continue" },
+      ],
+      prompt_cache_key: "desktop-thread-1",
+    });
+    expect(second.status).toBe(200);
+    await second.json();
+    expect(seen).toHaveLength(2);
+    expect(seen[1]).toBe(seen[0]);
   });
 });


### PR DESCRIPTION
## Summary

- Stable Cursor conversation identity across `store:false` full-history / tool continuations for **native Composer and external models**, so Resume / context carry-forward can hit again (covers the gap closed #367 targeted for Composer).
- Resolution order: force-fresh → **isolate helper/shadow/compaction** → remembered `_cursorConversationId` → thread override → `x-codex-parent-thread-id` (scoped) → random. Never uses Responses `previous_response_id` or shared `prompt_cache_key` as conversation ownership.
- External-only hardening: bounded root replay (count + UTF-8 byte budget + turn-atomic truncation + always-keep/truncate active tool result), same-id tool resumes, no-retry after local side effects / already-emitted output — reduces Connect `invalid_argument` after hydration (`usedTokens: 0`).
- Thread→conversation mapping is namespaced by Codex pool account when present, otherwise by a hash of the authenticated Cursor credential (avoids unscoped `local` collisions on shared gateways).
- Cache detail stays honestly unreported: Cursor Connect does not expose cache read/write token counts; continuity is what makes upstream cache/context reuse possible.
- Thanks [@kimrinking-cell](https://github.com/kimrinking-cell) / closed #367 for the continuity diagnosis; this PR supersedes that approach with thread-first identity and covers external models too.

## Test plan

- [x] `bun run typecheck`
- [x] `bun test tests/cursor-request-builder.test.ts tests/cursor-blob.test.ts tests/cursor-adapter.test.ts` (+ continuity cases in `server-combo-failover-e2e`)
- [x] Isolation wins over remembered parent id (compaction/helper + `previous_response_id` path)
- [x] Multi-byte (CJK) tool-result fixture stays within `CURSOR_EXTERNAL_ROOT_BYTE_LIMIT`
- [x] Rebased onto current `dev` (post-#360 / terminal-truth)
- [x] Live external same-id tool-result verification against Cursor Connect — operator sessions on this tip (e.g. `gpt-5.6-luna` / other externals) stay up through multi-turn tool resumes; prior tip repeatedly disconnected / `invalid_argument` after hydration

## Maintainer triage (2026-07-24)

Addressed on tip `bb18b7b5` after rebase onto current `dev`:

| Finding | Status |
|---|---|
| High — isolation bypassed when remembered id present | Fixed — isolate checked before remembered id + regression test |
| Medium — UTF-16 slice vs byte budget | Fixed — UTF-8 byte truncate + CJK fixture |
| Privacy — `local` scope on Cursor routes | Fixed — credential-derived `_cursorIdentityScope` in Cursor adapter |
| Rebuild on current `dev` | Done — clean rebase, no conflicts with #360 / terminal-truth |
| Live same-id verification | Done — live external sessions on this tip no longer hit the prior disconnect / `invalid_argument` loop |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Cursor conversation continuity across requests, including stable reuse for store-free workflows via client thread header tracking.
  * Added bounded external-model replay handling, including external root prompt limits, byte-budget compaction, and tool-result truncation.
  * Provider diagnostics now include token usage details and improved checkpoint descriptors.

* **Bug Fixes**
  * Prevented unsafe retries after local side effects; adjusted invalid-argument retry behavior to match replay-safety rules.
  * Preserved conversation IDs for valid continuations while isolating helper and compaction operations to avoid cross-thread mixing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->