### PR TITLE
fix(cursor): pin native composer conversation id to prompt_cache_key

### DIFF
--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -5,7 +5,7 @@ import { isCursorBenignCancelError, isCursorInvalidArgumentError, safeCursorErro
 import { isCursorExternalWireModel } from "./cursor/discovery";
 import { createCursorKvStore, type CursorKvStore } from "./cursor/kv-store";
 import { mapCursorServerMessage } from "./cursor/message-mapper";
-import { createCursorRequest, generatedCursorConversationId } from "./cursor/request-builder";
+import { createCursorRequest } from "./cursor/request-builder";
 import {
   createLiveCursorTransport,
   CursorMissingCredentialError,
@@ -77,12 +77,15 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
         const makeTransport = deps.createTransport ?? createLiveCursorTransport;
         const kv = deps.kv ?? createCursorKvStore();
         const rekeyContextUsage = deps.rekeyContextUsage ?? rekeyCursorContextUsage;
-        _parsed._cursorConversationId ??= generatedCursorConversationId();
+        // Do NOT pre-mint a random conversation id here. createCursorRequest resolves
+        // remembered id → native prompt_cache_key pin → random. Pre-minting would hide
+        // the prompt_cache_key pin and break Cursor cache/context carry-forward when
+        // Codex sends full history under store:false without previous_response_id.
         const previousConversationId = _parsed._cursorConversationId;
         let request = createCursorRequest(_parsed);
         // Keep remembered conversation id in sync when the request builder mints a fresh id
         // for external-model tool-result continuations (stateless replay).
-        if (request.conversationId !== previousConversationId) {
+        if (previousConversationId && request.conversationId !== previousConversationId) {
           rekeyContextUsage(previousConversationId, request.conversationId);
         }
         _parsed._cursorConversationId = request.conversationId;

--- a/src/adapters/cursor/request-builder.ts
+++ b/src/adapters/cursor/request-builder.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type {
   OcxAssistantContentPart,
   OcxContentPart,
@@ -8,7 +9,7 @@ import type {
 } from "../../types";
 import { isAllowedToolChoice, namespacedToolName, toolChoiceAliases, type OcxTool, type OcxToolChoice } from "../../types";
 import type { CursorRequestMessage, CursorRunRequest } from "./types";
-import { cursorWireModelSelection, isCursorExternalWireModel, type CursorRoutingLevel } from "./discovery";
+import { cursorWireModelSelection, isCursorExternalWireModel, isCursorNativeWireModel, type CursorRoutingLevel } from "./discovery";
 import { cursorEffortSuffix } from "./effort-map";
 import {
   cursorMcpToolEncodedSize,
@@ -164,6 +165,46 @@ export interface CreateCursorRequestOptions {
   forceFreshConversation?: boolean;
 }
 
+/**
+ * Stable Cursor conversation id derived from Codex's prompt_cache_key (thread id).
+ * Used when previous_response_id continuation state is missing but the client still
+ * replays full history under store:false — without this, every turn mints a fresh
+ * cursor_* id and Cursor prompt-cache / context-usage carry-forward never hit.
+ */
+export function stableCursorConversationIdFromPromptCacheKey(promptCacheKey: string): string {
+  const digest = createHash("sha256")
+    .update("ocx-cursor-conv:")
+    .update(promptCacheKey)
+    .digest("hex")
+    .slice(0, 32);
+  return `cursor_${digest}`;
+}
+
+/**
+ * Resolve the Cursor conversation id for this turn.
+ * Priority: force-fresh → remembered `_cursorConversationId` → native+prompt_cache_key → random.
+ * Never use OpenAI Responses `previous_response_id` (resp_*) — different namespace.
+ */
+export function resolveCursorConversationId(
+  parsed: OcxParsedRequest,
+  wireModelId: string,
+  options: CreateCursorRequestOptions = {},
+): string {
+  const lastRaw = parsed.context.messages.at(-1);
+  const forceFreshConversation =
+    options.forceFreshConversation === true
+    || (lastRaw?.role === "toolResult" && isCursorExternalWireModel(wireModelId));
+  if (forceFreshConversation) return generatedCursorConversationId();
+  if (parsed._cursorConversationId) return parsed._cursorConversationId;
+  // Native composer/auto: pin to the Codex thread so full-history turns without
+  // previous_response_id still share one Cursor conversation (cache + checkpoints).
+  if (isCursorNativeWireModel(wireModelId)) {
+    const key = parsed.options.promptCacheKey?.trim();
+    if (key) return stableCursorConversationIdFromPromptCacheKey(key);
+  }
+  return generatedCursorConversationId();
+}
+
 export function createCursorRequest(
   parsed: OcxParsedRequest,
   options: CreateCursorRequestOptions = {},
@@ -176,23 +217,10 @@ export function createCursorRequest(
   const budget = applyCursorToolBudget(visibleTools, parsed.options.toolChoice);
   const limitNote = catalogLimitNote(budget.tools, budget.omitted);
   const model = normalizeCursorModelId(parsed.modelId, parsed.options.reasoning);
-  const lastRaw = parsed.context.messages.at(-1);
-  // External Cursor models (e.g. gpt-5.6-sol) can corrupt server-side conversation state across
-  // tool-result continuations when ResumeAction reuses the same conversationId. Force a fresh id
-  // so the full history is replayed without depending on that state.
-  const forceFreshConversation =
-    options.forceFreshConversation === true
-    || (lastRaw?.role === "toolResult" && isCursorExternalWireModel(model.modelId));
   return {
     modelId: model.modelId,
     ...(model.routingLevel ? { routingLevel: model.routingLevel } : {}),
-    // The Cursor conversation id comes ONLY from remembered state (_cursorConversationId). Do NOT fall
-    // back to the OpenAI Responses previous_response_id (resp_*): that is a Responses-chain id in a
-    // different namespace and would start an unrelated Cursor conversation, breaking tool-result
-    // continuation. If we have no remembered Cursor conversation, start a fresh one.
-    conversationId: forceFreshConversation
-      ? generatedCursorConversationId()
-      : (parsed._cursorConversationId ?? generatedCursorConversationId()),
+    conversationId: resolveCursorConversationId(parsed, model.modelId, options),
     system: [...(parsed.context.systemPrompt ?? []), ...(limitNote ? [limitNote] : [])],
     messages,
     rawMessages: parsed.context.messages,

--- a/tests/cursor-request-builder.test.ts
+++ b/tests/cursor-request-builder.test.ts
@@ -38,6 +38,68 @@ describe("Cursor request builder", () => {
     expect(request.conversationId).toBe("cursor_stable");
   });
 
+  test("native composer pins conversation id to prompt_cache_key when none remembered", () => {
+    const a = createCursorRequest({
+      modelId: "cursor/composer-2.5",
+      context: { messages: [{ role: "user", content: "hi", timestamp: 1 }] },
+      stream: false,
+      options: { promptCacheKey: "thread-abc" },
+    });
+    const b = createCursorRequest({
+      modelId: "composer-2.5",
+      context: {
+        messages: [
+          { role: "user", content: "hi", timestamp: 1 },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "shell",
+            content: "ok",
+            isError: false,
+            timestamp: 2,
+          },
+        ],
+      },
+      stream: false,
+      options: { promptCacheKey: "thread-abc" },
+    });
+    expect(a.conversationId).toBe(b.conversationId);
+    expect(a.conversationId.startsWith("cursor_")).toBe(true);
+    expect(a.conversationId).toHaveLength("cursor_".length + 32);
+  });
+
+  test("external toolResult still force-fresh even with prompt_cache_key", () => {
+    const first = createCursorRequest({
+      modelId: "cursor/grok-4.5",
+      context: { messages: [{ role: "user", content: "hi", timestamp: 1 }] },
+      stream: false,
+      options: { promptCacheKey: "thread-xyz" },
+      _cursorConversationId: "cursor_prior",
+    });
+    expect(first.conversationId).toBe("cursor_prior");
+
+    const second = createCursorRequest({
+      modelId: "cursor/grok-4.5",
+      context: {
+        messages: [
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "shell",
+            content: "ok",
+            isError: false,
+            timestamp: 2,
+          },
+        ],
+      },
+      stream: false,
+      options: { promptCacheKey: "thread-xyz" },
+      _cursorConversationId: "cursor_prior",
+    });
+    expect(second.conversationId).not.toBe("cursor_prior");
+    expect(second.conversationId.startsWith("cursor_")).toBe(true);
+  });
+
   test("marks Cursor context-usage boundaries for compaction epochs", () => {
     expect(createCursorRequest({ ...base, _contextCompactionBoundary: true }).contextUsageReset).toBe(true);
 

--- a/tests/server-combo-failover-e2e.test.ts
+++ b/tests/server-combo-failover-e2e.test.ts
@@ -1555,4 +1555,83 @@ describe("cursor conversation continuity across store:false chains", () => {
     const { previousResponseProviderState } = await import("../src/responses/state");
     expect(previousResponseProviderState(secondJson.id)?.cursor?.conversationId).toBe(seen[1]);
   });
+
+  test("native composer-2.5 toolResult stream chain reuses conversationId", async () => {
+    const seen: string[] = [];
+    customCursorTransportFactory = () => ({
+      async *run(request) {
+        seen.push(request.conversationId);
+        if (seen.length === 1) {
+          yield { type: "tool_call_start", id: "call_1", name: "shell" };
+          yield { type: "tool_call_delta", arguments: "{}" };
+          yield { type: "tool_call_end", id: "call_1" };
+        } else {
+          yield { type: "text", text: "done" };
+        }
+        yield { type: "done", usage: { inputTokens: 10, outputTokens: 2, estimated: true } };
+      },
+      writeClient() {},
+      close() {},
+    });
+    const config = cursorConfig();
+
+    const postStream = async (raw: Record<string, unknown>) =>
+      handleResponses(new Request("http://localhost/v1/responses", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ stream: true, store: false, ...raw }),
+      }), config, { model: "", provider: "" }, {});
+
+    const first = await postStream({ model: "cursortest/composer-2.5", input: "hello" });
+    expect(first.status).toBe(200);
+    const text1 = await first.text();
+    const completed = [...text1.matchAll(/event: response\.completed\ndata: ({.*})\n/g)]
+      .map(match => JSON.parse(match[1]!) as { response?: { id?: string }; id?: string });
+    const firstId = completed.at(-1)?.response?.id ?? completed.at(-1)?.id;
+    expect(typeof firstId).toBe("string");
+    expect(seen).toHaveLength(1);
+
+    const { previousResponseProviderState } = await import("../src/responses/state");
+    expect(previousResponseProviderState(firstId!)?.cursor?.conversationId).toBe(seen[0]);
+
+    const second = await postStream({
+      model: "cursortest/composer-2.5",
+      previous_response_id: firstId,
+      input: [{ type: "function_call_output", call_id: "call_1", output: "ok" }],
+    });
+    expect(second.status).toBe(200);
+    await second.text();
+    expect(seen).toHaveLength(2);
+    expect(seen[1]).toBe(seen[0]);
+  });
+
+  test("native composer reuses conversationId across store:false turns via prompt_cache_key alone", async () => {
+    const seen: string[] = [];
+    customCursorTransportFactory = fakeCursorTransportFactory(seen);
+    const config = cursorConfig();
+
+    const first = await postCursor(config, {
+      model: "cursortest/composer-2.5",
+      input: "hello",
+      prompt_cache_key: "desktop-thread-1",
+    });
+    expect(first.status).toBe(200);
+    await first.json();
+    expect(seen).toHaveLength(1);
+
+    // No previous_response_id — Codex Desktop often replays full history under store:false.
+    const second = await postCursor(config, {
+      model: "cursortest/composer-2.5",
+      input: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "cursor ok" },
+        { role: "user", content: "continue" },
+      ],
+      prompt_cache_key: "desktop-thread-1",
+    });
+    expect(second.status).toBe(200);
+    await second.json();
+    expect(seen).toHaveLength(2);
+    expect(seen[1]).toBe(seen[0]);
+  });
 });


### PR DESCRIPTION
## Summary

- Native Cursor models (e.g. `composer-2.5`) now derive a stable conversation id from Codex `prompt_cache_key` when `_cursorConversationId` is not restored from `previous_response_id`.
- Stops minting a fresh `cursor_*` id on every `store:false` full-history turn, so Cursor prompt-cache / context-usage carry-forward can hit again.
- External-model tool-result force-fresh behavior is unchanged; the adapter no longer pre-mints a random id that would hide the cache-key pin.

## Verification

- `bun run typecheck`
- `bun test tests/cursor-request-builder.test.ts tests/cursor-adapter.test.ts tests/server-combo-failover-e2e.test.ts tests/responses-state.test.ts` (91 pass)
- `bun run privacy:scan`
- Live proxy restarted with the patched files; unit probe confirmed same `prompt_cache_key` → same conversation id

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. *(internal continuity only — no user-doc change)*
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cursor conversation continuity across follow-up requests.
  * Preserved conversation context for native Composer models using the same prompt cache key.
  * Ensured tool-result continuations start fresh conversations when required.
  * Improved continuity for streamed and non-stored conversation flows.

* **Tests**
  * Added coverage for stable conversation reuse and fresh conversations after external tool results.
  * Added end-to-end checks for conversation continuity across multiple request patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->