### PR TITLE
fix(kiro): keep progress text nonterminal

### DIFF
--- a/src/adapters/kiro.ts
+++ b/src/adapters/kiro.ts
@@ -917,23 +917,9 @@ async function* parseKiroAttempt(
         terminal: { type: "done", usage: finalUsage, endTurn: false, ...(finalProviderState ? { providerState: finalProviderState } : {}) },
       };
     }
-    // A clean Smithy EOF after ordinary assistant text is a complete answer even when the
-    // private completion tool was advertised. Replaying that answer through a second Kiro
-    // request adds latency and can hang an otherwise-finished Codex turn if the retry stalls.
-    // Reasoning-only output still needs the bounded fallback because it has no user-facing text.
-    if (mode === "required" && sawText) {
-      return {
-        assistantText,
-        sawReasoning,
-        terminal: {
-          type: "done",
-          usage: finalUsage,
-          endTurn: true,
-          ...(finalProviderState ? { providerState: finalProviderState } : {}),
-        },
-      };
-    }
-    if (mode === "required" && sawReasoning) {
+    // Kiro text has no trustworthy final/progress marker. When completion is required, ordinary
+    // text and reasoning remain unfinished until the one bounded fallback validates the turn.
+    if (mode === "required" && (sawText || sawReasoning)) {
       return { assistantText, sawReasoning, needsFallback: true, usage: finalUsage, providerState: finalProviderState };
     }
     if (!sawText && !sawReasoning) {

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -108,8 +108,8 @@ the watchdog.
 The web-search loop requests `stream: true` for every routed-model iteration, but buffers the events
 needed to decide whether to intercept a synthetic search call. Text explicitly phased as
 `commentary` is safe to forward live because it cannot terminate the turn; this keeps Kiro's
-progress visible. A clean Kiro stream EOF after user-facing text completes directly; reasoning-only
-output still gets one bounded completion retry. Synthetic search calls, real tool calls,
+progress visible. A Kiro stream EOF after user-facing text or reasoning gets one bounded completion
+retry, because the upstream text event does not distinguish progress from a final answer. Synthetic search calls, real tool calls,
 and terminal events remain buffered until the iteration validates. Only the first iteration's final
 response headers/status and any 429 key rotations are handled eagerly. A failure before downstream
 SSE starts returns non-2xx JSON; once headers have started the final response, a generation failure

--- a/tests/kiro-stream.test.ts
+++ b/tests/kiro-stream.test.ts
@@ -279,23 +279,31 @@ describe("kiro adapter — parseStream", () => {
     }
   });
 
-  test("text-only required response completes without a second upstream request", async () => {
-    let fetches = 0;
-    globalThis.fetch = (async () => {
-      fetches++;
-      throw new Error("unexpected fallback");
+  test("progress-only required response makes exactly one structural text fallback", async () => {
+    const requests: Record<string, any>[] = [];
+    globalThis.fetch = (async (_input, init) => {
+      requests.push(JSON.parse(String(init?.body)));
+      return new Response(streamOf(eventFrame({ content: "Final from fallback." })));
     }) as typeof fetch;
     const adapter = createKiroAdapter(provider);
     await adapter.buildRequest(parsedWith([{ role: "user", content: "do it" }], [bashTool]));
 
     const events = await collectAdapterEvents(adapter.parseStream(new Response(streamOf(
-      eventFrame({ content: "Task complete." }),
+      eventFrame({ content: "I am checking." }),
       eventFrame({ conversationId: "returned-conversation-42" }),
     ))));
 
-    expect(fetches).toBe(0);
+    expect(requests).toHaveLength(1);
+    const retry = requests[0].conversationState;
+    expect(retry.conversationId).toBe("returned-conversation-42");
+    expect(retry.history.at(-1).assistantResponseMessage).toEqual({ content: "I am checking." });
+    expect(retry.currentMessage.userInputMessage.content).toBe(KIRO_COMPLETION_RETRY_MESSAGE);
+    expect(retry.currentMessage.userInputMessage.userInputMessageContext.tools.map(
+      (tool: { toolSpecification: { name: string } }) => tool.toolSpecification.name,
+    )).toEqual(["bash", KIRO_COMPLETION_TOOL_NAME]);
     expect(events.filter(event => event.type === "text_delta")).toEqual([
-      { type: "text_delta", text: "Task complete.", phase: "commentary" },
+      { type: "text_delta", text: "I am checking.", phase: "commentary" },
+      { type: "text_delta", text: "Final from fallback.", phase: "final_answer" },
     ]);
     expect(events.at(-1)).toMatchObject({
       type: "done",

--- a/tests/server-kiro-completion-e2e.test.ts
+++ b/tests/server-kiro-completion-e2e.test.ts
@@ -49,10 +49,6 @@ function textFrame(text: string): Uint8Array {
   return eventFrame("assistantResponseEvent", { content: text });
 }
 
-function reasoningFrame(text: string): Uint8Array {
-  return eventFrame("reasoningContentEvent", { text });
-}
-
 function completionFrames(answer: string, id = "completion-1"): Uint8Array[] {
   const input = JSON.stringify({ answer });
   return [
@@ -132,9 +128,9 @@ function anthropicEvents(sse: string): Array<{ name: string; data: Record<string
 }
 
 describe("Kiro completion through public server endpoints", () => {
-  test("/v1/responses lets the bounded fallback complete after reasoning-only output", async () => {
+  test("/v1/responses keeps progress nonterminal and lets only the bounded fallback complete", async () => {
     const upstream = scriptedKiroUpstream([
-      [reasoningFrame("Checking the workspace.")],
+      [textFrame("Checking the workspace.")],
       completionFrames("The workspace is ready."),
     ]);
     saveConfig(kiroConfig(upstream.server.url.toString()));
@@ -156,20 +152,21 @@ describe("Kiro completion through public server endpoints", () => {
       const events = responseEvents(wire);
       const text = events.filter(event => event.name === "response.output_text.delta");
       expect(text.map(event => [event.data.delta, event.data.phase])).toEqual([
+        ["Checking the workspace.", undefined],
         ["The workspace is ready.", undefined],
       ]);
       const completed = events.filter(event => event.name === "response.completed");
       expect(completed).toHaveLength(1);
       expect(events.at(-1)?.name).toBe("response.completed");
       const messages = completed[0].data.response.output.filter((item: { type: string }) => item.type === "message");
-      expect(messages.map((item: { phase?: string }) => item.phase)).toEqual(["final_answer"]);
+      expect(messages.map((item: { phase?: string }) => item.phase)).toEqual(["commentary", "final_answer"]);
       expect(wire).not.toContain(KIRO_COMPLETION_TOOL_NAME);
 
       expect(upstream.requests).toHaveLength(2);
       expect(kiroToolNames(upstream.requests[0])).toEqual(["bash", KIRO_COMPLETION_TOOL_NAME]);
       expect(kiroToolNames(upstream.requests[1])).toEqual(["bash", KIRO_COMPLETION_TOOL_NAME]);
       expect(upstream.requests[1].conversationState.history.at(-1).assistantResponseMessage.content)
-        .toBe("");
+        .toBe("Checking the workspace.");
     } finally {
       proxy.stop(true);
       upstream.server.stop(true);
@@ -181,7 +178,7 @@ describe("Kiro completion through public server endpoints", () => {
     ["accepted text fallback", [textFrame("The Claude task is complete.")]],
   ])("/v1/messages hides the private tool and ends after %s", async (_label, fallbackFrames) => {
     const upstream = scriptedKiroUpstream([
-      [reasoningFrame("I am checking the Claude task.")],
+      [textFrame("I am checking the Claude task.")],
       fallbackFrames,
     ]);
     saveConfig(kiroConfig(upstream.server.url.toString()));
@@ -205,7 +202,7 @@ describe("Kiro completion through public server endpoints", () => {
       const deltas = events
         .filter(event => event.name === "content_block_delta" && event.data.delta?.type === "text_delta")
         .map(event => event.data.delta.text);
-      expect(deltas).toEqual(["The Claude task is complete."]);
+      expect(deltas).toEqual(["I am checking the Claude task.", "The Claude task is complete."]);
       expect(events.filter(event => event.name === "message_delta")).toHaveLength(1);
       expect(events.find(event => event.name === "message_delta")?.data.delta.stop_reason).toBe("end_turn");
       expect(events.at(-1)?.name).toBe("message_stop");


### PR DESCRIPTION
## Summary

- Reproduction: on a tool-enabled Kiro request, an `assistantResponseEvent` containing progress text followed by a clean Smithy EOF was emitted as commentary but also completed with `end_turn: true`. A response such as "I am checking" could therefore terminate Codex or Claude Code before the model produced a final answer.
- Keep ordinary text and reasoning nonterminal while Kiro explicit completion is required. Both now enter the existing single bounded continuation; a validated private completion or accepted fallback text remains the only final terminal.
- Add adapter and public `/v1/responses` plus `/v1/messages` regressions proving progress is preserved structurally, the continuation runs exactly once, and the private completion tool never leaks.
- Update the transport source of truth to match the restored behavior.

## Verification

- `bun test --isolate tests/kiro-stream.test.ts tests/server-kiro-completion-e2e.test.ts` (58 pass)
- `bun run typecheck`
- `bun run test` (3933 pass across 314 files)
- `bun run privacy:scan`
- `git diff --check`

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. No authentication or credential code changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete streamed responses by validating progress before finalizing.
  * Added a single bounded completion attempt when text or reasoning ends without a final answer.
  * Preserved progress messages as commentary before displaying the final response.
  * Prevented internal completion details from appearing in streamed output.

* **Tests**
  * Expanded coverage for progress-only responses and fallback completion behavior across supported endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->