### PR TITLE
fix(codex): reset main runtime state after account switch

### DIFF
--- a/src/codex/account-lifecycle.ts
+++ b/src/codex/account-lifecycle.ts
@@ -5,15 +5,17 @@ import { MAIN_CODEX_ACCOUNT_ID, setMainAccountPlan } from "./main-account";
 import { clearAccountQuota } from "./quota";
 import { clearCodexUpstreamHealthForAccount, clearThreadAccountMapForAccount } from "./routing";
 import { invalidateCodexWebSocketsForAccount } from "./websocket-registry";
+import { clearMainAccountInfoCache } from "./main-account-cache";
 import type { OcxConfig } from "../types";
 
-let observedMainChatgptAccountId: string | null | undefined;
+let observedMainChatgptAccountId: string | undefined;
 
 export function purgeCodexAccountRuntimeState(accountId: string): void {
   clearAccountNeedsReauth(accountId);
   clearAccountQuota(accountId);
   clearThreadAccountMapForAccount(accountId);
   clearCodexUpstreamHealthForAccount(accountId);
+  if (accountId === MAIN_CODEX_ACCOUNT_ID) clearMainAccountInfoCache();
 }
 
 /**
@@ -24,6 +26,9 @@ export function purgeCodexAccountRuntimeState(accountId: string): void {
  */
 export function reconcileMainCodexAccountRuntimeState(): boolean {
   const currentAccountId = getMainChatgptAccountId();
+  // A missing/malformed auth.json is an unknown identity, not a confirmed account switch. Keep the
+  // prior observation and its safety state until a real account id can be read again.
+  if (currentAccountId === null) return false;
   const previousAccountId = observedMainChatgptAccountId;
   observedMainChatgptAccountId = currentAccountId;
   if (previousAccountId === undefined || previousAccountId === currentAccountId) return false;

--- a/src/codex/account-lifecycle.ts
+++ b/src/codex/account-lifecycle.ts
@@ -1,15 +1,41 @@
 import { removeCodexAccountCredential } from "./account-store";
 import { clearAccountNeedsReauth } from "./account-runtime-state";
+import { getMainChatgptAccountId } from "./auth-collision";
+import { MAIN_CODEX_ACCOUNT_ID, setMainAccountPlan } from "./main-account";
 import { clearAccountQuota } from "./quota";
 import { clearCodexUpstreamHealthForAccount, clearThreadAccountMapForAccount } from "./routing";
 import { invalidateCodexWebSocketsForAccount } from "./websocket-registry";
 import type { OcxConfig } from "../types";
+
+let observedMainChatgptAccountId: string | null | undefined;
 
 export function purgeCodexAccountRuntimeState(accountId: string): void {
   clearAccountNeedsReauth(accountId);
   clearAccountQuota(accountId);
   clearThreadAccountMapForAccount(accountId);
   clearCodexUpstreamHealthForAccount(accountId);
+}
+
+/**
+ * The main Codex login is stored under the stable `__main__` alias, while
+ * `~/.codex/auth.json` can be replaced with credentials for another physical
+ * ChatGPT account. Drop alias-keyed runtime state when that identity changes so
+ * cooldown, quota, reauth, and thread affinity do not leak across accounts.
+ */
+export function reconcileMainCodexAccountRuntimeState(): boolean {
+  const currentAccountId = getMainChatgptAccountId();
+  const previousAccountId = observedMainChatgptAccountId;
+  observedMainChatgptAccountId = currentAccountId;
+  if (previousAccountId === undefined || previousAccountId === currentAccountId) return false;
+
+  purgeCodexAccountRuntimeState(MAIN_CODEX_ACCOUNT_ID);
+  setMainAccountPlan(null);
+  invalidateCodexWebSocketsForAccount(MAIN_CODEX_ACCOUNT_ID);
+  return true;
+}
+
+export function resetMainCodexAccountIdentityTrackingForTests(): void {
+  observedMainChatgptAccountId = undefined;
 }
 
 export function deleteCodexAccount(runtimeConfig: OcxConfig, accountId: string): void {

--- a/src/codex/auth-api.ts
+++ b/src/codex/auth-api.ts
@@ -9,7 +9,7 @@ import {
   CodexCredentialRefreshLockTimeoutError,
   TokenRefreshError,
 } from "./account-store";
-import { deleteCodexAccount } from "./account-lifecycle";
+import { deleteCodexAccount, reconcileMainCodexAccountRuntimeState } from "./account-lifecycle";
 import { checkAccountIdCollision, readCodexTokens } from "./auth-collision";
 export { checkAccountIdCollision, getMainChatgptAccountId } from "./auth-collision";
 export { clearAccountNeedsReauth, isAccountNeedsReauth, markAccountNeedsReauth } from "./account-runtime-state";
@@ -26,6 +26,13 @@ import {
 export { clearAccountQuota, getAccountQuota, parseUsageQuota, updateAccountQuota } from "./quota";
 import { extractAccountId, decodeJwtPayload } from "../oauth/chatgpt";
 import { MAIN_CODEX_ACCOUNT_ID, setMainAccountPlan } from "./main-account";
+import {
+  clearMainAccountInfoCache,
+  getMainAccountInfoCache,
+  setMainAccountInfoCache,
+  type MainAccountInfo,
+} from "./main-account-cache";
+export { clearMainAccountInfoCache } from "./main-account-cache";
 import { maskEmail } from "../lib/privacy";
 import { CodexWarmupError, codexWarmupFailureReason, warmCodexAccount } from "./warmup";
 export { maskEmail } from "../lib/privacy";
@@ -179,7 +186,6 @@ function expireCodexAuthFlow(flowId: string | null, error = "Login cancelled"): 
   }
 }
 
-let mainAccountCache: { email: string | null; plan: string | null; quota: Omit<StoredAccountQuota, "updatedAt"> | null; ts: number } | null = null;
 const MAIN_CACHE_TTL = 5 * 60_000;
 const POOL_CACHE_TTL = 5 * 60_000;
 const POOL_QUOTA_REFRESH_CONCURRENCY = 4;
@@ -245,15 +251,16 @@ async function isTerminalMainAuthResponse(resp: Response): Promise<boolean> {
   }
 }
 
-export async function fetchMainAccountInfo(forceRefresh = false): Promise<{ email: string | null; plan: string | null; quota: Omit<StoredAccountQuota, "updatedAt"> | null }> {
+export async function fetchMainAccountInfo(forceRefresh = false): Promise<MainAccountInfo> {
   const tokens = readCodexTokens();
   if (!tokens) {
-    mainAccountCache = null;
+    clearMainAccountInfoCache();
     markAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID);
     return { email: null, plan: null, quota: null };
   }
-  if (!forceRefresh && mainAccountCache && Date.now() - mainAccountCache.ts < MAIN_CACHE_TTL) {
-    return mainAccountCache;
+  const cached = getMainAccountInfoCache();
+  if (!forceRefresh && cached && Date.now() - cached.ts < MAIN_CACHE_TTL) {
+    return cached;
   }
   try {
     const resp = await fetch("https://chatgpt.com/backend-api/wham/usage", {
@@ -262,7 +269,7 @@ export async function fetchMainAccountInfo(forceRefresh = false): Promise<{ emai
     });
     if (!resp.ok) {
       if (await isTerminalMainAuthResponse(resp)) {
-        mainAccountCache = null;
+        clearMainAccountInfoCache();
         markAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID);
       }
       return { email: null, plan: null, quota: null };
@@ -274,7 +281,7 @@ export async function fetchMainAccountInfo(forceRefresh = false): Promise<{ emai
       quota: parseUsageQuota(data),
       ts: Date.now(),
     };
-    mainAccountCache = result;
+    setMainAccountInfoCache(result);
     clearAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID);
     // Mirror main quota + plan into the shared stores so the rotation engine can
     // score and auto-switch the main account exactly like a pool account (Option A).
@@ -369,6 +376,10 @@ export async function primeCodexPoolQuotas(config: OcxConfig, reason: string): P
     || providerCodexAccountMode(OPENAI_CODEX_PROVIDER_ID, openai) !== "pool"
   ) return;
   if (primeInFlight) return primeInFlight;
+  // Seed the observed physical main identity before startup/lazy priming can populate quota or
+  // plan state. Otherwise the first post-startup account switch sees no previous identity and
+  // skips the purge that protects the stable __main__ alias.
+  reconcileMainCodexAccountRuntimeState();
   primeInFlight = (async () => {
     const runtimeConfig = getRuntimeConfig(config);
     const pool = (runtimeConfig.codexAccounts ?? []).filter(a => !a.isMain);

--- a/src/codex/auth-api.ts
+++ b/src/codex/auth-api.ts
@@ -10,7 +10,7 @@ import {
   TokenRefreshError,
 } from "./account-store";
 import { deleteCodexAccount, reconcileMainCodexAccountRuntimeState } from "./account-lifecycle";
-import { checkAccountIdCollision, readCodexTokens } from "./auth-collision";
+import { checkAccountIdCollision, getMainChatgptAccountId, readCodexTokens } from "./auth-collision";
 export { checkAccountIdCollision, getMainChatgptAccountId } from "./auth-collision";
 export { clearAccountNeedsReauth, isAccountNeedsReauth, markAccountNeedsReauth } from "./account-runtime-state";
 import { clearAccountNeedsReauth, isAccountNeedsReauth, markAccountNeedsReauth } from "./account-runtime-state";
@@ -252,12 +252,31 @@ async function isTerminalMainAuthResponse(resp: Response): Promise<boolean> {
 }
 
 export async function fetchMainAccountInfo(forceRefresh = false): Promise<MainAccountInfo> {
+  return fetchMainAccountInfoAttempt(forceRefresh, 1);
+}
+
+const EMPTY_MAIN_ACCOUNT_INFO: MainAccountInfo = { email: null, plan: null, quota: null };
+
+async function retryMainAccountInfoIfIdentityChanged(
+  requestAccountId: string | null,
+  retriesRemaining: number,
+): Promise<MainAccountInfo | null> {
+  if (getMainChatgptAccountId() === requestAccountId) return null;
+  reconcileMainCodexAccountRuntimeState();
+  return retriesRemaining > 0
+    ? fetchMainAccountInfoAttempt(true, retriesRemaining - 1)
+    : EMPTY_MAIN_ACCOUNT_INFO;
+}
+
+async function fetchMainAccountInfoAttempt(forceRefresh: boolean, retriesRemaining: number): Promise<MainAccountInfo> {
+  reconcileMainCodexAccountRuntimeState();
   const tokens = readCodexTokens();
   if (!tokens) {
     clearMainAccountInfoCache();
     markAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID);
-    return { email: null, plan: null, quota: null };
+    return EMPTY_MAIN_ACCOUNT_INFO;
   }
+  const requestAccountId = extractAccountId(tokens.id_token, tokens.access_token) ?? (tokens.account_id || null);
   const cached = getMainAccountInfoCache();
   if (!forceRefresh && cached && Date.now() - cached.ts < MAIN_CACHE_TTL) {
     return cached;
@@ -268,13 +287,18 @@ export async function fetchMainAccountInfo(forceRefresh = false): Promise<MainAc
       signal: AbortSignal.timeout(8000),
     });
     if (!resp.ok) {
-      if (await isTerminalMainAuthResponse(resp)) {
+      const terminalAuthFailure = await isTerminalMainAuthResponse(resp);
+      const retried = await retryMainAccountInfoIfIdentityChanged(requestAccountId, retriesRemaining);
+      if (retried) return retried;
+      if (terminalAuthFailure) {
         clearMainAccountInfoCache();
         markAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID);
       }
-      return { email: null, plan: null, quota: null };
+      return EMPTY_MAIN_ACCOUNT_INFO;
     }
     const data = (await resp.json()) as WhamUsageResponse;
+    const retried = await retryMainAccountInfoIfIdentityChanged(requestAccountId, retriesRemaining);
+    if (retried) return retried;
     const result = {
       email: data.email ?? null,
       plan: data.plan_type ?? null,
@@ -298,7 +322,8 @@ export async function fetchMainAccountInfo(forceRefresh = false): Promise<MainAc
     }
     return result;
   } catch {
-    return { email: null, plan: null, quota: null };
+    const retried = await retryMainAccountInfoIfIdentityChanged(requestAccountId, retriesRemaining);
+    return retried ?? EMPTY_MAIN_ACCOUNT_INFO;
   }
 }
 

--- a/src/codex/auth-api.ts
+++ b/src/codex/auth-api.ts
@@ -261,7 +261,8 @@ async function retryMainAccountInfoIfIdentityChanged(
   requestAccountId: string | null,
   retriesRemaining: number,
 ): Promise<MainAccountInfo | null> {
-  if (getMainChatgptAccountId() === requestAccountId) return null;
+  const currentAccountId = getMainChatgptAccountId();
+  if (currentAccountId === null || currentAccountId === requestAccountId) return null;
   reconcileMainCodexAccountRuntimeState();
   return retriesRemaining > 0
     ? fetchMainAccountInfoAttempt(true, retriesRemaining - 1)

--- a/src/codex/auth-context.ts
+++ b/src/codex/auth-context.ts
@@ -6,6 +6,7 @@ import {
 } from "./account-store";
 import { markAccountNeedsReauth } from "./account-runtime-state";
 import { isCodexAccountUsable } from "./account-usability";
+import { reconcileMainCodexAccountRuntimeState } from "./account-lifecycle";
 import { MAIN_CODEX_ACCOUNT_ID, getMainAccountToken } from "./main-account";
 import {
   getCodexAccountCooldownUntil,
@@ -107,6 +108,7 @@ export async function resolveCodexAuthContext(
     if (!hasCallerCodexBearer(headers)) throw new CodexDirectAuthenticationError();
     return { kind: "main", accountId: null };
   }
+  reconcileMainCodexAccountRuntimeState();
   const threadId = headers.get("x-codex-parent-thread-id");
   const resolution = options.excludeAccountId
     ? (() => {

--- a/src/codex/main-account-cache.ts
+++ b/src/codex/main-account-cache.ts
@@ -1,0 +1,25 @@
+import type { StoredAccountQuota } from "./quota";
+
+export interface MainAccountInfo {
+  email: string | null;
+  plan: string | null;
+  quota: Omit<StoredAccountQuota, "updatedAt"> | null;
+}
+
+export interface CachedMainAccountInfo extends MainAccountInfo {
+  ts: number;
+}
+
+let cachedMainAccountInfo: CachedMainAccountInfo | null = null;
+
+export function getMainAccountInfoCache(): CachedMainAccountInfo | null {
+  return cachedMainAccountInfo;
+}
+
+export function setMainAccountInfoCache(value: CachedMainAccountInfo): void {
+  cachedMainAccountInfo = value;
+}
+
+export function clearMainAccountInfoCache(): void {
+  cachedMainAccountInfo = null;
+}

--- a/tests/codex-main-rotation.test.ts
+++ b/tests/codex-main-rotation.test.ts
@@ -17,11 +17,14 @@ import {
   resolveCodexAuthContext,
 } from "../src/codex/auth-context";
 import { isCodexAccountUsable } from "../src/codex/account-usability";
+import { resetMainCodexAccountIdentityTrackingForTests } from "../src/codex/account-lifecycle";
 import { MAIN_CODEX_ACCOUNT_ID, setMainAccountPlan } from "../src/codex/main-account";
 import { saveCodexAccountCredential } from "../src/codex/account-store";
 import {
   clearAccountNeedsReauth,
   clearAccountQuota,
+  getAccountQuota,
+  isAccountNeedsReauth,
   markAccountNeedsReauth,
   updateAccountQuota,
 } from "../src/codex/auth-api";
@@ -74,6 +77,7 @@ describe("main account rotation (Option A)", () => {
     clearThreadAccountMap();
     clearCodexUpstreamHealth();
     clearAccountQuota();
+    resetMainCodexAccountIdentityTrackingForTests();
     setMainAccountPlan(null);
     for (const id of ["a", "b", MAIN_CODEX_ACCOUNT_ID]) clearAccountNeedsReauth(id);
     saveCred("a");
@@ -85,6 +89,7 @@ describe("main account rotation (Option A)", () => {
     clearThreadAccountMap();
     clearCodexUpstreamHealth();
     clearAccountQuota();
+    resetMainCodexAccountIdentityTrackingForTests();
     setMainAccountPlan(null);
     for (const id of ["a", "b", MAIN_CODEX_ACCOUNT_ID]) clearAccountNeedsReauth(id);
     for (const d of [STORE_DIR, CODEX_DIR]) if (existsSync(d)) rmSync(d, { recursive: true });
@@ -145,6 +150,32 @@ describe("main account rotation (Option A)", () => {
     const headers = headersForCodexAuthContext(new Headers(), ctx);
     expect(headers.get("authorization")).toBe("Bearer main_access");
     expect(headers.get("chatgpt-account-id")).toBe("main_acct");
+  });
+
+  test("switching the main auth identity discards runtime state from the previous account", async () => {
+    const config = makeConfig({ activeCodexAccountId: MAIN_CODEX_ACCOUNT_ID, autoSwitchThreshold: 0, codexAccounts: [] });
+    await expect(resolveCodexAuthContext(new Headers(), config, "pool")).resolves.toMatchObject({
+      kind: "main-pool",
+      chatgptAccountId: "main_acct",
+    });
+
+    recordCodexUpstreamOutcome(config, MAIN_CODEX_ACCOUNT_ID, 429, { retryAfter: "3600" });
+    markAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID);
+    updateAccountQuota(MAIN_CODEX_ACCOUNT_ID, 100, 0);
+    writeFileSync(
+      join(CODEX_DIR, "auth.json"),
+      JSON.stringify({ tokens: { access_token: "replacement_access", account_id: "replacement_acct" } }),
+    );
+
+    await expect(resolveCodexAuthContext(new Headers(), config, "pool")).resolves.toEqual({
+      kind: "main-pool",
+      accountId: MAIN_CODEX_ACCOUNT_ID,
+      accessToken: "replacement_access",
+      chatgptAccountId: "replacement_acct",
+    });
+    expect(isCodexAccountInCooldown(MAIN_CODEX_ACCOUNT_ID)).toBe(false);
+    expect(isAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID)).toBe(false);
+    expect(getAccountQuota(MAIN_CODEX_ACCOUNT_ID)).toBeNull();
   });
 
   test("no active id selects from main plus added accounts and binds main affinity", async () => {

--- a/tests/codex-main-rotation.test.ts
+++ b/tests/codex-main-rotation.test.ts
@@ -17,15 +17,21 @@ import {
   resolveCodexAuthContext,
 } from "../src/codex/auth-context";
 import { isCodexAccountUsable } from "../src/codex/account-usability";
-import { resetMainCodexAccountIdentityTrackingForTests } from "../src/codex/account-lifecycle";
+import {
+  reconcileMainCodexAccountRuntimeState,
+  resetMainCodexAccountIdentityTrackingForTests,
+} from "../src/codex/account-lifecycle";
 import { MAIN_CODEX_ACCOUNT_ID, setMainAccountPlan } from "../src/codex/main-account";
 import { saveCodexAccountCredential } from "../src/codex/account-store";
 import {
   clearAccountNeedsReauth,
   clearAccountQuota,
+  clearMainAccountInfoCache,
+  fetchMainAccountInfo,
   getAccountQuota,
   isAccountNeedsReauth,
   markAccountNeedsReauth,
+  primeCodexPoolQuotas,
   updateAccountQuota,
 } from "../src/codex/auth-api";
 import type { OcxConfig } from "../src/types";
@@ -77,6 +83,7 @@ describe("main account rotation (Option A)", () => {
     clearThreadAccountMap();
     clearCodexUpstreamHealth();
     clearAccountQuota();
+    clearMainAccountInfoCache();
     resetMainCodexAccountIdentityTrackingForTests();
     setMainAccountPlan(null);
     for (const id of ["a", "b", MAIN_CODEX_ACCOUNT_ID]) clearAccountNeedsReauth(id);
@@ -89,6 +96,7 @@ describe("main account rotation (Option A)", () => {
     clearThreadAccountMap();
     clearCodexUpstreamHealth();
     clearAccountQuota();
+    clearMainAccountInfoCache();
     resetMainCodexAccountIdentityTrackingForTests();
     setMainAccountPlan(null);
     for (const id of ["a", "b", MAIN_CODEX_ACCOUNT_ID]) clearAccountNeedsReauth(id);
@@ -176,6 +184,83 @@ describe("main account rotation (Option A)", () => {
     expect(isCodexAccountInCooldown(MAIN_CODEX_ACCOUNT_ID)).toBe(false);
     expect(isAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID)).toBe(false);
     expect(getAccountQuota(MAIN_CODEX_ACCOUNT_ID)).toBeNull();
+  });
+
+  test("startup quota priming observes the main identity before the first account switch", async () => {
+    const config = makeConfig({
+      activeCodexAccountId: MAIN_CODEX_ACCOUNT_ID,
+      autoSwitchThreshold: 0,
+      codexAccounts: [],
+      providers: {
+        openai: {
+          adapter: "openai-responses",
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+          authMode: "forward",
+          codexAccountMode: "pool",
+        },
+      },
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+      if (String(input).includes("/backend-api/wham/usage")) {
+        return new Response(JSON.stringify({ email: "a@example.test", plan_type: "plus" }), { status: 200 });
+      }
+      return originalFetch(input);
+    };
+    try {
+      await primeCodexPoolQuotas(config, "startup");
+      recordCodexUpstreamOutcome(config, MAIN_CODEX_ACCOUNT_ID, 429, { retryAfter: "3600" });
+      markAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID);
+      updateAccountQuota(MAIN_CODEX_ACCOUNT_ID, 100, 0);
+      writeFileSync(
+        join(CODEX_DIR, "auth.json"),
+        JSON.stringify({ tokens: { access_token: "replacement_access", account_id: "replacement_acct" } }),
+      );
+
+      expect(reconcileMainCodexAccountRuntimeState()).toBe(true);
+      expect(isCodexAccountInCooldown(MAIN_CODEX_ACCOUNT_ID)).toBe(false);
+      expect(isAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID)).toBe(false);
+      expect(getAccountQuota(MAIN_CODEX_ACCOUNT_ID)).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("does not treat a transient missing auth file as an account switch", () => {
+    expect(reconcileMainCodexAccountRuntimeState()).toBe(false);
+    recordCodexUpstreamOutcome(makeConfig(), MAIN_CODEX_ACCOUNT_ID, 429, { retryAfter: "3600" });
+    markAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID);
+    updateAccountQuota(MAIN_CODEX_ACCOUNT_ID, 100, 0);
+    rmSync(join(CODEX_DIR, "auth.json"));
+
+    expect(reconcileMainCodexAccountRuntimeState()).toBe(false);
+    expect(isCodexAccountInCooldown(MAIN_CODEX_ACCOUNT_ID)).toBe(true);
+    expect(isAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID)).toBe(true);
+    expect(getAccountQuota(MAIN_CODEX_ACCOUNT_ID)).not.toBeNull();
+  });
+
+  test("invalidates cached main account info when the auth identity changes", async () => {
+    const originalFetch = globalThis.fetch;
+    let email = "a@example.test";
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+      if (String(input).includes("/backend-api/wham/usage")) {
+        return new Response(JSON.stringify({ email, plan_type: "plus" }), { status: 200 });
+      }
+      return originalFetch(input);
+    };
+    try {
+      expect(reconcileMainCodexAccountRuntimeState()).toBe(false);
+      expect((await fetchMainAccountInfo(false)).email).toBe("a@example.test");
+      email = "b@example.test";
+      writeFileSync(
+        join(CODEX_DIR, "auth.json"),
+        JSON.stringify({ tokens: { access_token: "replacement_access", account_id: "replacement_acct" } }),
+      );
+      expect(reconcileMainCodexAccountRuntimeState()).toBe(true);
+      expect((await fetchMainAccountInfo(false)).email).toBe("b@example.test");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   test("no active id selects from main plus added accounts and binds main affinity", async () => {

--- a/tests/codex-main-rotation.test.ts
+++ b/tests/codex-main-rotation.test.ts
@@ -263,6 +263,52 @@ describe("main account rotation (Option A)", () => {
     }
   });
 
+  test("discards an in-flight usage response after the main identity changes", async () => {
+    expect(reconcileMainCodexAccountRuntimeState()).toBe(false);
+    const originalFetch = globalThis.fetch;
+    let resolveFirstUsage!: (response: Response) => void;
+    const requestedAccountIds: string[] = [];
+    globalThis.fetch = (async (input, init) => {
+      if (!String(input).includes("/backend-api/wham/usage")) return originalFetch(input, init);
+      requestedAccountIds.push(new Headers(init?.headers).get("ChatGPT-Account-Id") ?? "");
+      if (requestedAccountIds.length === 1) {
+        return new Promise<Response>(resolve => { resolveFirstUsage = resolve; });
+      }
+      return new Response(JSON.stringify({
+        email: "b@example.test",
+        plan_type: "pro",
+        rate_limit: { primary_window: { used_percent: 12, reset_at: 1_789_000_000 } },
+      }), { status: 200 });
+    }) as typeof fetch;
+    try {
+      const infoPromise = fetchMainAccountInfo(true);
+      expect(requestedAccountIds).toEqual(["main_acct"]);
+
+      writeFileSync(
+        join(CODEX_DIR, "auth.json"),
+        JSON.stringify({ tokens: { access_token: "replacement_access", account_id: "replacement_acct" } }),
+      );
+      expect(reconcileMainCodexAccountRuntimeState()).toBe(true);
+      resolveFirstUsage(new Response(JSON.stringify({
+        email: "a@example.test",
+        plan_type: "plus",
+        rate_limit: { primary_window: { used_percent: 91, reset_at: 1_788_000_000 } },
+      }), { status: 200 }));
+
+      await expect(infoPromise).resolves.toMatchObject({
+        email: "b@example.test",
+        plan: "pro",
+        quota: { weeklyPercent: 12 },
+      });
+      expect(requestedAccountIds).toEqual(["main_acct", "replacement_acct"]);
+      expect(getAccountQuota(MAIN_CODEX_ACCOUNT_ID)).toMatchObject({ weeklyPercent: 12 });
+      expect((await fetchMainAccountInfo(false)).email).toBe("b@example.test");
+      expect(requestedAccountIds).toHaveLength(2);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("no active id selects from main plus added accounts and binds main affinity", async () => {
     const config = makeConfig({ activeCodexAccountId: undefined, autoSwitchThreshold: 0 });
     updateAccountQuota(MAIN_CODEX_ACCOUNT_ID, 5, 0);

--- a/tests/codex-main-rotation.test.ts
+++ b/tests/codex-main-rotation.test.ts
@@ -309,6 +309,38 @@ describe("main account rotation (Option A)", () => {
     }
   });
 
+  test("does not retry an in-flight usage response when the current identity is temporarily unknown", async () => {
+    expect(reconcileMainCodexAccountRuntimeState()).toBe(false);
+    const originalFetch = globalThis.fetch;
+    let resolveUsage!: (response: Response) => void;
+    let usageCalls = 0;
+    globalThis.fetch = (async (input, init) => {
+      if (!String(input).includes("/backend-api/wham/usage")) return originalFetch(input, init);
+      usageCalls++;
+      expect(new Headers(init?.headers).get("ChatGPT-Account-Id")).toBe("main_acct");
+      return new Promise<Response>(resolve => { resolveUsage = resolve; });
+    }) as typeof fetch;
+    try {
+      const infoPromise = fetchMainAccountInfo(true);
+      rmSync(join(CODEX_DIR, "auth.json"));
+      resolveUsage(new Response(JSON.stringify({
+        email: "a@example.test",
+        plan_type: "plus",
+        rate_limit: { primary_window: { used_percent: 23, reset_at: 1_788_000_000 } },
+      }), { status: 200 }));
+
+      await expect(infoPromise).resolves.toMatchObject({
+        email: "a@example.test",
+        plan: "plus",
+        quota: { weeklyPercent: 23 },
+      });
+      expect(usageCalls).toBe(1);
+      expect(isAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID)).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("no active id selects from main plus added accounts and binds main affinity", async () => {
     const config = makeConfig({ activeCodexAccountId: undefined, autoSwitchThreshold: 0 });
     updateAccountQuota(MAIN_CODEX_ACCOUNT_ID, 5, 0);


### PR DESCRIPTION
## Summary

- detect when the physical ChatGPT identity in `~/.codex/auth.json` changes behind the stable `__main__` alias
- purge alias-scoped cooldown, quota, reauthentication, thread-affinity, plan, and WebSocket state before the next pool routing decision
- add a regression test covering a cooled/reauth-marked main account followed by an auth identity switch

## Root cause

The main Codex login always uses the in-memory key `__main__`. Replacing `auth.json` with another account therefore left the new physical account inheriting the previous account's runtime health state. In particular, a prior 429 cooldown caused the proxy to reject the new account locally with `Selected Codex account is cooling down` without contacting the upstream service.

## Security review

This touches authentication lifecycle behavior and should receive explicit security review. The change keeps the observed account ID in process memory only, does not persist or log it, does not expose token contents, and invalidates existing `__main__` WebSockets when the physical identity changes so they cannot continue with stale auth context. Direct mode is unchanged.

## Verification

- `bun run typecheck`
- `bun test --isolate tests/codex-main-rotation.test.ts tests/codex-auth-context.test.ts` (31 passed)
- `bun test --isolate tests/ci-workflows.test.ts` (10 passed)
- `bun run privacy:scan`
- full suite attempted: 3912 tests passed; `tests/openai-provider-option-e2e.test.ts` hit its existing 30s timeout and the same timeout reproduces on an untouched `origin/dev` worktree
- live local proxy request after applying the patch: HTTP 200 through `gpt-5.6-sol`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex behavior when the main account identity changes by reconciling account runtime state earlier in the auth flow.
  * Added safer handling for cached main account info, including invalidation and re-fetching with the replacement credentials.
  * Reduced stale quota/plan/cooldown/reauth carryover after identity rotation, including during transient missing-identity scenarios.
* **Tests**
  * Expanded coverage for main-account rotation, cache invalidation, and identity-mismatch retry behavior.
  * Added assertions for correct state cleanup and consistent targeting across in-flight requests during identity changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->