### PR TITLE
fix(cursor): estimate context after restart

### DIFF
--- a/src/adapters/cursor/live-transport.ts
+++ b/src/adapters/cursor/live-transport.ts
@@ -2,7 +2,7 @@ import http2 from "node:http2";
 import { create, fromBinary, toBinary } from "@bufbuild/protobuf";
 import { namespacedToolName, type OcxProviderConfig, type OcxUsage } from "../../types";
 import { CONNECT_FLAG_END_STREAM, decodeAvailableConnectFrames, encodeConnectFrame } from "./framing";
-import { activePromptText, encodeCursorRunRequest } from "./protobuf-request";
+import { activePromptText, encodeCursorRunRequest, estimateCursorInputTokens } from "./protobuf-request";
 import {
   createCursorContextUsageTracker,
   createCursorProtobufEventState,
@@ -514,6 +514,7 @@ class LiveCursorTransport implements CursorTransport {
       parallelToolCalls: request.parallelToolCalls,
       toolSchemas,
       cursorToolNameMap,
+      estimatedInputTokens: estimateCursorInputTokens(request),
       contextUsage: cursorContextUsageTracker.controlsForConversation(request.conversationId, {
         clearPrior: request.contextUsageReset === true,
         storeCheckpoints: request.contextUsageStoreCheckpoints !== false,
@@ -888,7 +889,14 @@ export function partialUsageFromEventState(state: ReturnType<typeof createCursor
   const ctx = reportableContextTokens(state);
   return ctx !== undefined
     ? { ...usageFromContextTokens(state, ctx), estimated: true }
-    : { ...state.usage, estimated: true };
+    : state.estimatedInputTokens
+      ? {
+          ...state.usage,
+          inputTokens: state.estimatedInputTokens,
+          totalTokens: state.estimatedInputTokens + out,
+          estimated: true,
+        }
+      : { ...state.usage, estimated: true };
 }
 
 /**

--- a/src/adapters/cursor/protobuf-events.ts
+++ b/src/adapters/cursor/protobuf-events.ts
@@ -132,6 +132,8 @@ export interface CursorProtobufEventState {
    * conversation cache before the turn.
    */
   contextCarryForwardTokens?: number;
+  /** Request-local estimate used only when Cursor supplied no checkpoint or carried total. */
+  estimatedInputTokens?: number;
   recordContextTokens?: (tokens: number) => void;
   openToolCalls: Map<string, { name: string; args: string }>;
   completedToolCalls: Set<string>;
@@ -152,6 +154,7 @@ export function createCursorProtobufEventState(options: {
   toolSchemas?: Map<string, unknown>;
   cursorToolNameMap?: Map<string, string>;
   contextUsage?: CursorContextUsageControls;
+  estimatedInputTokens?: number;
 } = {}): CursorProtobufEventState {
   return {
     // Cursor provides no authoritative usage frame; token counts are heuristic estimates from
@@ -166,6 +169,7 @@ export function createCursorProtobufEventState(options: {
     ...(options.cursorToolNameMap ? { cursorToolNameMap: options.cursorToolNameMap } : {}),
     ...(options.contextUsage?.carryForwardTokens !== undefined ? { contextCarryForwardTokens: options.contextUsage.carryForwardTokens } : {}),
     ...(options.contextUsage?.recordContextTokens ? { recordContextTokens: options.contextUsage.recordContextTokens } : {}),
+    ...(options.estimatedInputTokens && options.estimatedInputTokens > 0 ? { estimatedInputTokens: options.estimatedInputTokens } : {}),
   };
 }
 
@@ -450,6 +454,12 @@ export function finalizeTurnEvents(state: CursorProtobufEventState): CursorServe
   const contextTokens = reportableContextTokens(state);
   const usage: OcxUsage = contextTokens !== undefined
     ? usageFromContextTokens(state, contextTokens)
-    : { ...state.usage };
+    : state.estimatedInputTokens
+      ? {
+          ...state.usage,
+          inputTokens: state.estimatedInputTokens,
+          totalTokens: state.estimatedInputTokens + state.usage.outputTokens,
+        }
+      : { ...state.usage };
   return [{ type: "done", usage }];
 }

--- a/src/adapters/cursor/protobuf-request.ts
+++ b/src/adapters/cursor/protobuf-request.ts
@@ -3,6 +3,7 @@ import { fromJson, type JsonValue } from "@bufbuild/protobuf";
 import { ValueSchema } from "@bufbuild/protobuf/wkt";
 import type { OcxAssistantContentPart, OcxMessage, OcxToolResultMessage } from "../../types";
 import { namespacedToolName } from "../../types";
+import { estimateTokens } from "../../lib/token-estimate";
 import type { CursorRunRequest } from "./types";
 import { isCursorExternalWireModel } from "./discovery";
 import { debugProviderDiagnostic } from "../../lib/debug";
@@ -501,6 +502,19 @@ export function activePromptText(request: CursorRunRequest): string {
     }
   }
   return last?.role === "tool" ? last.content : "";
+}
+
+/**
+ * Conservative request-local fallback when Cursor emits neither a checkpoint nor a previously
+ * observed context total. This is deliberately not persisted: a later authoritative checkpoint
+ * remains the only source carried across turns.
+ */
+export function estimateCursorInputTokens(request: CursorRunRequest): number {
+  return estimateTokens(JSON.stringify({
+    system: request.system,
+    messages: request.rawMessages ?? request.messages,
+    tools: request.tools,
+  }), request.modelId);
 }
 
 export function encodeCursorRunRequest(request: CursorRunRequest): Uint8Array {

--- a/src/adapters/cursor/protobuf-request.ts
+++ b/src/adapters/cursor/protobuf-request.ts
@@ -77,13 +77,10 @@ function buildRequestContext() {
   });
 }
 
-function jsonBlob(value: unknown): Uint8Array {
-  return encoder.encode(JSON.stringify(value));
-}
-
 type StoredRootBlob = {
   id: Uint8Array;
   byteLength: number;
+  serialized: string;
   role: "system" | "user" | "assistant" | "toolResult";
   messageIndex?: number;
   /** Original JSON text payload used when an active tool result must be truncated to fit. */
@@ -95,10 +92,12 @@ function storedRootBlob(
   role: StoredRootBlob["role"],
   opts?: { messageIndex?: number; text?: string },
 ): StoredRootBlob {
-  const data = jsonBlob(value);
+  const serialized = JSON.stringify(value);
+  const data = encoder.encode(serialized);
   return {
     id: storeCursorBlob(data),
     byteLength: data.byteLength,
+    serialized,
     role,
     ...(opts?.messageIndex !== undefined ? { messageIndex: opts.messageIndex } : {}),
     ...(opts?.text !== undefined ? { text: opts.text } : {}),
@@ -165,6 +164,7 @@ function rootPromptMessages(request: CursorRunRequest): {
   ids: Uint8Array[];
   byteLength: number;
   historyMessageStart: number;
+  serialized: string[];
 } {
   const entries = systemPromptBlobs(request);
   const systemEntryCount = entries.length;
@@ -174,6 +174,7 @@ function rootPromptMessages(request: CursorRunRequest): {
       ids: entries.map(entry => entry.id),
       byteLength: entries.reduce((sum, entry) => sum + entry.byteLength, 0),
       historyMessageStart: 0,
+      serialized: entries.map(entry => entry.serialized),
     };
   }
 
@@ -290,6 +291,7 @@ function rootPromptMessages(request: CursorRunRequest): {
     ids: selected.map(entry => entry.id),
     byteLength: selected.reduce((sum, entry) => sum + entry.byteLength, 0),
     historyMessageStart,
+    serialized: selected.map(entry => entry.serialized),
   };
 }
 
@@ -504,25 +506,37 @@ export function activePromptText(request: CursorRunRequest): string {
   return last?.role === "tool" ? last.content : "";
 }
 
+function modelVisibleRequestPayload(request: CursorRunRequest) {
+  const rawText = activePromptText(request);
+  const lastRole = request.messages.at(-1)?.role;
+  const text = lastRole === "user" || lastRole === "developer"
+    ? appendCursorShellAliasHint(request.tools, appendCursorGenericToolUseHint(request.tools, rawText))
+    : rawText;
+  return {
+    text,
+    roots: rootPromptMessages(request),
+    mcpToolDefs: buildCursorToolDefinitions(
+      cursorToolsForActivePrompt(request.tools, rawText, request.toolChoice),
+      request.toolChoice,
+    ),
+  };
+}
+
 /**
  * Conservative request-local fallback when Cursor emits neither a checkpoint nor a previously
  * observed context total. This is deliberately not persisted: a later authoritative checkpoint
  * remains the only source carried across turns.
  */
 export function estimateCursorInputTokens(request: CursorRunRequest): number {
-  return estimateTokens(JSON.stringify({
-    system: request.system,
-    messages: request.rawMessages ?? request.messages,
-    tools: request.tools,
-  }), request.modelId);
+  const payload = modelVisibleRequestPayload(request);
+  const lastRawIsToolResult = request.rawMessages?.at(-1)?.role === "toolResult";
+  const action = !lastRawIsToolResult && payload.text.trim().length > 0 ? payload.text : "";
+  return estimateTokens(JSON.stringify({ roots: payload.roots.serialized, action, tools: payload.mcpToolDefs }), request.modelId);
 }
 
 export function encodeCursorRunRequest(request: CursorRunRequest): Uint8Array {
-  const rawText = activePromptText(request);
-  const lastRole = request.messages.at(-1)?.role;
-  const text = lastRole === "user" || lastRole === "developer"
-    ? appendCursorShellAliasHint(request.tools, appendCursorGenericToolUseHint(request.tools, rawText))
-    : rawText;
+  const payload = modelVisibleRequestPayload(request);
+  const text = payload.text;
   // Tool-result-only turns resume the remembered Cursor conversation with results in history.
   const lastRawIsToolResult = request.rawMessages?.at(-1)?.role === "toolResult";
   const actionCase = !lastRawIsToolResult && text.trim().length > 0
@@ -547,7 +561,7 @@ export function encodeCursorRunRequest(request: CursorRunRequest): Uint8Array {
           }),
         },
   });
-  const rootPromptMessagesState = rootPromptMessages(request);
+  const rootPromptMessagesState = payload.roots;
   const rootPromptMessageIds = rootPromptMessagesState.ids;
   const turnIds = conversationTurns(request, rootPromptMessagesState.historyMessageStart);
   debugProviderDiagnostic("cursor", "run-request", {
@@ -612,11 +626,7 @@ export function encodeCursorRunRequest(request: CursorRunRequest): Uint8Array {
     // the event-state `clientToolNames` use (live-transport.ts). Advertising the raw `request.tools`
     // here would let mcp_tools expose a tool that the event state does not recognize for a generic
     // tool-count prompt, so a call to it would be rejected as an unknown Responses tool.
-    ...(() => {
-      const visibleTools = cursorToolsForActivePrompt(request.tools, activePromptText(request), request.toolChoice);
-      const mcpToolDefs = buildCursorToolDefinitions(visibleTools, request.toolChoice);
-      return mcpToolDefs.length > 0 ? { mcpTools: create(McpToolsSchema, { mcpTools: mcpToolDefs }) } : {};
-    })(),
+    ...(payload.mcpToolDefs.length > 0 ? { mcpTools: create(McpToolsSchema, { mcpTools: payload.mcpToolDefs }) } : {}),
   });
 
   const message = create(AgentClientMessageSchema, {

--- a/src/lib/token-estimate.ts
+++ b/src/lib/token-estimate.ts
@@ -21,7 +21,7 @@ const DEFAULT_CHARS_PER_TOKEN = 4;
  */
 const KIRO_CHARS_PER_TOKEN = 3.5;
 
-const KIRO_MODEL_PREFIXES = ["kiro", "claude", "deepseek", "minimax", "glm", "qwen"];
+const KIRO_MODEL_PREFIXES = ["kiro", "claude", "deepseek", "minimax", "glm", "qwen", "grok", "xai/"];
 
 /** Model-aware chars-per-token ratio. Unknown models fall back to the generic English ratio. */
 export function charsPerToken(modelId?: string): number {

--- a/tests/cursor-blob.test.ts
+++ b/tests/cursor-blob.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { create, fromBinary } from "@bufbuild/protobuf";
+import { estimateTokens } from "../src/lib/token-estimate";
 import { handleCursorNativeKv, storeCursorBlob } from "../src/adapters/cursor/native-exec";
 import {
   CURSOR_EXTERNAL_ROOT_BYTE_LIMIT,
   CURSOR_EXTERNAL_ROOT_BLOB_LIMIT,
   CURSOR_ROUTING_LEVEL_PARAMETER_ID,
   encodeCursorRunRequest,
+  estimateCursorInputTokens,
 } from "../src/adapters/cursor/protobuf-request";
 import {
   AgentClientMessageSchema,
@@ -144,6 +146,47 @@ describe("Cursor blob handshake", () => {
     expect(rootBytes).toBeLessThanOrEqual(CURSOR_EXTERNAL_ROOT_BYTE_LIMIT);
     expect(roots.length).toBeLessThan(rawMessages.length);
     expect(rootRoles.find(role => role !== "system")).toBe("user");
+  });
+
+  test("estimates only the externally replayed root history and filtered tool catalog", () => {
+    const current = { role: "user" as const, content: "Use any 10 tools", timestamp: 10_000 };
+    const retained = [
+      { role: "user" as const, content: "newest retained user", timestamp: 9_998 },
+      { role: "assistant" as const, model: "cursor/grok-4.5", content: [{ type: "text" as const, text: "newest retained assistant" }], timestamp: 9_999 },
+      current,
+    ];
+    const dropped = Array.from({ length: 200 }, (_, index) => ({
+      role: "user" as const,
+      content: `old-${index}:${"x".repeat(4_000)}`,
+      timestamp: index,
+    }));
+    const exec = { name: "exec_command", description: "Run a command", parameters: {} };
+    const filtered = { name: "filtered", description: "z".repeat(50_000), parameters: {} };
+    const common = {
+      modelId: "grok-4.5",
+      conversationId: "c-estimate",
+      system: ["system"],
+      messages: [{ role: "user" as const, content: current.content }],
+      tools: [exec, filtered],
+    };
+
+    const request = { ...common, rawMessages: [...dropped, ...retained] };
+    const bytes = encodeCursorRunRequest(request);
+    const msg = fromBinary(AgentClientMessageSchema, bytes);
+    const run = msg.message.case === "runRequest" ? msg.message.value : undefined;
+    const payload = JSON.stringify({
+      roots: (run?.conversationState?.rootPromptMessagesJson ?? [])
+        .map(blobId => new TextDecoder().decode(blobData(blobId))),
+      action: actionText(bytes),
+      tools: run?.mcpTools?.mcpTools ?? [],
+    });
+
+    expect(estimateCursorInputTokens(request)).toBe(estimateTokens(payload, request.modelId));
+    expect(estimateCursorInputTokens(request)).toBeLessThan(estimateTokens(JSON.stringify({
+      roots: [...dropped, ...retained],
+      action: current.content,
+      tools: [exec, filtered],
+    }), request.modelId));
   });
 
   test("preserves oversized active tool result under external byte budget", () => {

--- a/tests/cursor-interaction-query.test.ts
+++ b/tests/cursor-interaction-query.test.ts
@@ -171,12 +171,19 @@ describe("partialUsageFromEventState", () => {
   test("uses the request-local estimate after output when no checkpoint or carry exists", async () => {
     const { partialUsageFromEventState } = await import("../src/adapters/cursor/live-transport");
     const { createCursorProtobufEventState } = await import("../src/adapters/cursor/protobuf-events");
-    const state = createCursorProtobufEventState({ estimatedInputTokens: 1_200 });
+    const { estimateCursorInputTokens } = await import("../src/adapters/cursor/protobuf-request");
+    const estimatedInputTokens = estimateCursorInputTokens({
+      modelId: "grok-4.5",
+      conversationId: "partial-without-checkpoint",
+      system: ["You are helpful."],
+      messages: [{ role: "user", content: "Read this JSON: {\\\"path\\\":\\\"src/app.ts\\\"}" }],
+    });
+    const state = createCursorProtobufEventState({ estimatedInputTokens });
     state.usage.outputTokens = 7;
     expect(partialUsageFromEventState(state)).toEqual({
-      inputTokens: 1_200,
+      inputTokens: estimatedInputTokens,
       outputTokens: 7,
-      totalTokens: 1_207,
+      totalTokens: estimatedInputTokens + 7,
       estimated: true,
     });
   });

--- a/tests/cursor-interaction-query.test.ts
+++ b/tests/cursor-interaction-query.test.ts
@@ -168,6 +168,19 @@ describe("partialUsageFromEventState", () => {
     expect(partialUsageFromEventState(state)).toEqual({ inputTokens: 0, outputTokens: 7, estimated: true });
   });
 
+  test("uses the request-local estimate after output when no checkpoint or carry exists", async () => {
+    const { partialUsageFromEventState } = await import("../src/adapters/cursor/live-transport");
+    const { createCursorProtobufEventState } = await import("../src/adapters/cursor/protobuf-events");
+    const state = createCursorProtobufEventState({ estimatedInputTokens: 1_200 });
+    state.usage.outputTokens = 7;
+    expect(partialUsageFromEventState(state)).toEqual({
+      inputTokens: 1_200,
+      outputTokens: 7,
+      totalTokens: 1_207,
+      estimated: true,
+    });
+  });
+
   test("carries prior context usage on failure when the current turn had no checkpoint", async () => {
     const { partialUsageFromEventState } = await import("../src/adapters/cursor/live-transport");
     const { createCursorContextUsageTracker, createCursorProtobufEventState } = await import("../src/adapters/cursor/protobuf-events");

--- a/tests/cursor-protobuf-events.test.ts
+++ b/tests/cursor-protobuf-events.test.ts
@@ -19,6 +19,7 @@ import {
   finalizeTurnEvents,
   mapCursorProtobufServerMessage,
 } from "../src/adapters/cursor/protobuf-events";
+import { estimateCursorInputTokens } from "../src/adapters/cursor/protobuf-request";
 
 const encoder = new TextEncoder();
 
@@ -414,11 +415,17 @@ describe("Cursor protobuf tool-call events", () => {
   });
 
   test("uses a request-local input estimate when no checkpoint or carry-forward context exists", () => {
-    const state = createCursorProtobufEventState({ estimatedInputTokens: 1_200 });
+    const estimatedInputTokens = estimateCursorInputTokens({
+      modelId: "grok-4.5",
+      conversationId: "restart-without-checkpoint",
+      system: ["You are helpful."],
+      messages: [{ role: "user", content: "Explain this JSON: {\\\"path\\\":\\\"src/app.ts\\\"}" }],
+    });
+    const state = createCursorProtobufEventState({ estimatedInputTokens });
     state.usage.outputTokens = 7;
 
     expect(finalizeTurnEvents(state)).toEqual([
-      { type: "done", usage: { inputTokens: 1_200, outputTokens: 7, totalTokens: 1_207, estimated: true } },
+      { type: "done", usage: { inputTokens: estimatedInputTokens, outputTokens: 7, totalTokens: estimatedInputTokens + 7, estimated: true } },
     ]);
   });
 

--- a/tests/cursor-protobuf-events.test.ts
+++ b/tests/cursor-protobuf-events.test.ts
@@ -413,6 +413,15 @@ describe("Cursor protobuf tool-call events", () => {
     expect(events).toEqual([{ type: "done", usage: { inputTokens: 0, outputTokens: 0, estimated: true } }]);
   });
 
+  test("uses a request-local input estimate when no checkpoint or carry-forward context exists", () => {
+    const state = createCursorProtobufEventState({ estimatedInputTokens: 1_200 });
+    state.usage.outputTokens = 7;
+
+    expect(finalizeTurnEvents(state)).toEqual([
+      { type: "done", usage: { inputTokens: 1_200, outputTokens: 7, totalTokens: 1_207, estimated: true } },
+    ]);
+  });
+
   test("normalizes a mis-keyed completed tool-call arg against the advertised schema", () => {
     // The model called the right tool but used `filepath` instead of the schema's `path`.
     const toolSchemas = new Map<string, unknown>([
@@ -456,7 +465,7 @@ describe("Cursor protobuf tool-call events", () => {
     // Regression for the 10000-then-10300-shows-as-20300 bug. Cursor's checkpoint usedTokens is the
     // ABSOLUTE conversation context size; tokenDelta is additive per-turn output. They must land in
     // separate fields: totalTokens (absolute) vs outputTokens (additive), mirroring the Kiro SOT fix.
-    const state = createCursorProtobufEventState();
+    const state = createCursorProtobufEventState({ estimatedInputTokens: 1_200 });
 
     const checkpoint = (usedTokens: number) => create(AgentServerMessageSchema, {
       message: {

--- a/tests/token-estimate.test.ts
+++ b/tests/token-estimate.test.ts
@@ -25,7 +25,7 @@ describe("token-estimate sidecar", () => {
   });
 
   test("kiro text models use the 3.5 ratio", () => {
-    for (const m of ["kiro-auto", "claude-opus-4.8", "claude-opus-4.5", "deepseek-3.2", "minimax-m2.5", "minimax-m2.1", "glm-5", "qwen3-coder-next"]) {
+    for (const m of ["kiro-auto", "claude-opus-4.8", "claude-opus-4.5", "deepseek-3.2", "minimax-m2.5", "minimax-m2.1", "glm-5", "qwen3-coder-next", "grok-4.5", "xai/grok-4.5"]) {
       expect(charsPerToken(m)).toBe(3.5);
     }
   });


### PR DESCRIPTION
## Summary

- estimate the current Cursor request when neither a checkpoint nor carry-forward context total is available after a proxy restart
- preserve authoritative checkpoint and carry-forward precedence; estimates remain request-local and are never persisted
- cover terminal and partial stream-failure usage reporting

Fixes #373

## Validation

- `bun run typecheck`
- `bun test tests/cursor-protobuf-events.test.ts tests/cursor-tool-continuation.test.ts tests/cursor-interaction-query.test.ts tests/cursor-request-builder.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token usage reporting when exact input-token data isn’t available, now using a request-local input-token estimate and updating total token counts accordingly.
  * Enhanced Cursor turn usage calculations to include estimated input/total tokens (with accurate output tokens preserved).
  * Updated token estimation heuristics for additional Kiro-like model name prefixes.

* **Tests**
  * Added unit tests for estimated usage behavior when checkpoint and carry-forward context are missing.
  * Extended Cursor protobuf usage tests and updated regression expectations.
  * Added token-estimation coverage for mixed history/tool catalog payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->