### PR TITLE
Fix apply_patch envelope guidance

### DIFF
--- a/src/responses/parser.ts
+++ b/src/responses/parser.ts
@@ -129,7 +129,7 @@ function buildTools(tools: unknown[] | undefined): OcxTool[] | undefined {
       out.push({
         name: t.name,
         description: (t.description as string) ?? "",
-        parameters: { type: "object", properties: { input: { type: "string", description: "Raw tool input (verbatim body, e.g. the apply_patch envelope)." } }, required: ["input"] },
+        parameters: { type: "object", properties: { input: { type: "string", description: "Raw tool input. For apply_patch, begin exactly with `*** Begin Patch` (no trailing `***`), then use its standard patch envelope." } }, required: ["input"] },
         freeform: true,
       });
     }

--- a/tests/responses-parser.test.ts
+++ b/tests/responses-parser.test.ts
@@ -2,6 +2,26 @@ import { describe, expect, test } from "bun:test";
 import { parseRequest } from "../src/responses/parser";
 
 describe("Responses parser", () => {
+  test("describes the exact apply_patch freeform envelope", () => {
+    const parsed = parseRequest({
+      model: "xai/grok-4.5",
+      input: "Update a file",
+      tools: [{ type: "custom", name: "apply_patch", description: "Apply a patch" }],
+    });
+
+    expect(parsed.context.tools?.[0]).toMatchObject({
+      name: "apply_patch",
+      freeform: true,
+      parameters: {
+        properties: {
+          input: {
+            description: expect.stringContaining("begin exactly with `*** Begin Patch`"),
+          },
+        },
+      },
+    });
+  });
+
   test("preserves assistant message phase when replaying Responses output", () => {
     const parsed = parseRequest({
       model: "kiro/gpt-5.6-sol",


### PR DESCRIPTION
Fixes #372.\n\nClarifies the freeform pply_patch input contract so routed models emit the exact required *** Begin Patch header rather than the invalid *** Begin Patch *** variant.\n\nValidation: un test tests/responses-parser.test.ts, un run typecheck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of freeform patch tool inputs by clarifying the required patch format.

* **Tests**
  * Added coverage to verify that patch-based tool definitions retain the correct name, freeform behavior, and input guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->