### PR TITLE
Unify the Claude sidebar controls

### DIFF
--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -14,7 +14,7 @@ import Startup from "./pages/Startup";
 import ErrorBoundary from "./components/ErrorBoundary";
 import { IconGrid, IconServer, IconBoxes, IconBot, IconList, IconActivity, IconHardDrive, IconKey, IconGithub, IconMenu, IconSun, IconMoon, IconMonitor, IconGlobe, IconPower, IconSparkle, IconX } from "./icons";
 import { useI18n, useT, LOCALES, type Locale, type TKey } from "./i18n";
-import { Select } from "./ui";
+import { Select, Switch } from "./ui";
 import { installApiAuthFetch } from "./api";
 
 installApiAuthFetch();
@@ -204,7 +204,7 @@ export default function App() {
   const displayedVersion = runtimeVersion ?? __APP_VERSION__;
 
   const [stopping, setStopping] = useState(false);
-  // Sidebar "Claude ON" toggle — literal label in every locale (product name).
+  // Claude navigation row also owns the connection toggle.
   const [claudeEnabled, setClaudeEnabled] = useState<boolean | null>(null);
 
   useEffect(() => {
@@ -299,26 +299,24 @@ export default function App() {
         </div>
         <nav>
           {NAV.map(({ id, tkey, Icon }) => (
-            <button key={id} className={`nav-item${page === id ? " active" : ""}`} data-page={id}
-              onClick={() => {
-                // Always sync the hash on nav click so Providers restores Classic/Workspace preference.
-                window.location.hash = id === "providers" ? providersHashForPage() : id;
-                setPageState(id);
-                setNavOpen(false);
-              }}
-              aria-current={page === id ? "page" : undefined}>
-              <Icon /> {t(tkey)}
-            </button>
+            <div key={id} className={`nav-entry${id === "claude" ? ` nav-entry-claude${page === id ? " active" : ""}` : ""}`}>
+              <button className={`nav-item${page === id ? " active" : ""}`} data-page={id}
+                onClick={() => {
+                  // Always sync the hash on nav click so Providers restores Classic/Workspace preference.
+                  window.location.hash = id === "providers" ? providersHashForPage() : id;
+                  setPageState(id);
+                  setNavOpen(false);
+                }}
+                aria-current={page === id ? "page" : undefined}>
+                <Icon /> {t(tkey)}
+              </button>
+              {id === "claude" && claudeEnabled !== null && (
+                <Switch on={claudeEnabled} onClick={() => void toggleClaude()} label={t("claude.toggleAria")} />
+              )}
+            </div>
           ))}
         </nav>
         <div className="sidebar-foot">
-          {claudeEnabled !== null && (
-            <button type="button" className="theme-toggle" onClick={toggleClaude}
-              aria-pressed={claudeEnabled} aria-label={t("claude.toggleAria")} title={t("claude.toggleAria")}
-              style={claudeEnabled ? { color: "var(--accent)" } : undefined}>
-              <IconSparkle /> <span className="mode">{claudeEnabled ? t("app.claudeOn") : t("app.claudeOff")}</span>
-            </button>
-          )}
           <div className="lang-toggle">
             <IconGlobe aria-hidden />
             <Select

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -281,10 +281,10 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
 .nav-entry-claude .switch::before {
   content: "";
   position: absolute;
-  top: 8px;
-  left: 5px;
-  width: 34px;
-  height: 20px;
+  top: 10px;
+  left: 8px;
+  width: 28px;
+  height: 16px;
   border: 1px solid var(--border);
   border-radius: var(--radius-pill);
   background: var(--raised);
@@ -292,7 +292,8 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
 }
 .nav-entry-claude .switch.on { border-color: transparent; background: transparent; }
 .nav-entry-claude .switch.on::before { border-color: var(--toggle-on-bg); background: var(--toggle-on-bg); }
-.nav-entry-claude .switch .knob { position: absolute; top: 11px; left: 8px; z-index: 1; }
+.nav-entry-claude .switch .knob { position: absolute; top: 13px; left: 11px; z-index: 1; width: 10px; height: 10px; }
+.nav-entry-claude .switch.on .knob { transform: translateX(12px); }
 .nav-entry-claude .switch:focus-visible { outline: 2px solid var(--accent-ring); outline-offset: 0; }
 
 .sidebar-foot { margin-top: auto; padding-top: 12px; display: flex; flex-direction: column; gap: 2px; }

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -259,6 +259,42 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
 .nav-item svg { width: 17px; height: 17px; color: var(--faint); flex-shrink: 0; }
 .nav-item.active svg { color: var(--text); }
 
+.nav-entry { display: flex; align-items: center; min-width: 0; border-radius: var(--radius-sm); }
+.nav-entry .nav-item { flex: 1 1 auto; min-width: 0; }
+.nav-entry-claude {
+  padding-right: 2px;
+  transition: background var(--motion-fast), color var(--motion-fast);
+}
+.nav-entry-claude:hover,
+.nav-entry-claude.active { background: var(--accent-soft); color: var(--text); }
+.nav-entry-claude .nav-item,
+.nav-entry-claude .nav-item:hover,
+.nav-entry-claude .nav-item.active { width: auto; background: transparent; }
+.nav-entry-claude .switch {
+  position: relative;
+  width: 44px;
+  height: 36px;
+  padding: 0;
+  border-color: transparent;
+  background: transparent;
+}
+.nav-entry-claude .switch::before {
+  content: "";
+  position: absolute;
+  top: 8px;
+  left: 5px;
+  width: 34px;
+  height: 20px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: var(--raised);
+  transition: background var(--motion-normal), border-color var(--motion-normal);
+}
+.nav-entry-claude .switch.on { border-color: transparent; background: transparent; }
+.nav-entry-claude .switch.on::before { border-color: var(--toggle-on-bg); background: var(--toggle-on-bg); }
+.nav-entry-claude .switch .knob { position: absolute; top: 11px; left: 8px; z-index: 1; }
+.nav-entry-claude .switch:focus-visible { outline: 2px solid var(--accent-ring); outline-offset: 0; }
+
 .sidebar-foot { margin-top: auto; padding-top: 12px; display: flex; flex-direction: column; gap: 2px; }
 
 /* drawer header row: brand + close button (close is mobile-only) */


### PR DESCRIPTION
## Summary

- merge the Claude navigation entry and connection toggle into one sidebar row
- keep navigation and connection changes as separate accessible controls
- reduce the visible switch to 28×16 while preserving a 44×36 hit target

## Why

The sidebar exposed two separate Claude controls for navigation and connection state. Combining them removes the duplicate entry while retaining clear interaction boundaries and a compact visual footprint.

## Impact

- the Claude label still navigates to the Claude settings section
- the switch toggles the Claude connection without triggering navigation
- active, hover, focus, disabled, desktop, and mobile states remain supported

## Validation

- `bun run typecheck`
- `bun run test` — 3977 passed, 0 failed
- `bun run lint:gui`
- `cd gui && bun run build`
- `bun run privacy:scan`
- pre-push React Doctor — no issues found
- agbrowse desktop and mobile smoke test, including independent navigation/toggle behavior and restored Claude enabled state