### PR TITLE
feat(providers): add BizRouter preset to the provider registry

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -644,6 +644,18 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     preserveReasoningContentModels: ["deepseek/deepseek-v4-pro"],
     note: "OpenAI-compatible adaptive router. Default is a tool-capable model; orcarouter/auto (adaptive routing) is also selectable. Full catalog: https://www.orcarouter.ai/models",
   },
+  {
+    // BizRouter: Korean enterprise LLM gateway (api.bizrouter.ai). Model ids are
+    // vendor-namespaced (`<vendor>/<model>`) and pass through to the upstream as-is.
+    // Live-verified 2026-07-24: /v1/chat/completions accepts the `tools` field and
+    // streams, and GET /v1/models returns the per-API-key allowed catalog in the
+    // OpenAI list shape, so live model discovery narrows to what the key can use.
+    id: "bizrouter", label: "BizRouter", adapter: "openai-chat", baseUrl: "https://api.bizrouter.ai/v1",
+    authKind: "key", dashboardUrl: "https://bizrouter.ai/settings/keys",
+    defaultModel: "openai/gpt-5.6-sol",
+    models: ["openai/gpt-5.6-sol", "anthropic/claude-sonnet-5", "google/gemini-3.5-flash"],
+    note: "Korean enterprise LLM gateway. Per-key allowed models are discovered live from /v1/models. Full catalog: https://bizrouter.ai/models",
+  },
   { id: "groq", label: "Groq", adapter: "openai-chat", baseUrl: "https://api.groq.com/openai/v1", authKind: "key", featured: true, dashboardUrl: "https://console.groq.com/keys" },
   // 2026-07-10 Gemini API refresh: Tier-2 ai.google.dev evidence recorded in
   // devlog/_plan/260710_provider_hardening/001_research_frontier.md.

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -29,7 +29,7 @@ function nativeTemplate(): Record<string, unknown> {
 }
 
 const EXPECTED_KEY_PROVIDER_IDS = [
-  "anthropic-apikey", "openai-apikey", "umans", "opencode-go", "neuralwatt", "openrouter", "orcarouter", "groq", "google", "google-vertex", "azure-openai",
+  "anthropic-apikey", "openai-apikey", "umans", "opencode-go", "neuralwatt", "openrouter", "orcarouter", "bizrouter", "groq", "google", "google-vertex", "azure-openai",
   "deepseek", "cerebras", "together", "fireworks", "firepass", "moonshot",
   "huggingface", "nvidia", "venice", "zai", "nanogpt", "synthetic", "siliconflow", "qwen-cloud", "tencent-coding-plan",
   "qianfan", "alibaba", "alibaba-token-plan", "alibaba-token-plan-intl", "parallel", "zenmux", "litellm", "ollama-cloud", "mistral",


### PR DESCRIPTION
## Summary

Adds [BizRouter](https://bizrouter.ai) (`api.bizrouter.ai`) — a Korean enterprise LLM gateway with an OpenAI-compatible surface — as a key-auth provider preset, modeled on the existing OrcaRouter entry. Model ids are vendor-namespaced (`<vendor>/<model>`, e.g. `anthropic/claude-sonnet-5`) and pass through to the upstream as-is.

Also adds `bizrouter` to `EXPECTED_KEY_PROVIDER_IDS` in the registry parity test.

## Live verification (2026-07-24, api.bizrouter.ai)

- `POST /v1/chat/completions` accepts the `tools` field and streams SSE.
- `GET /v1/models` returns the per-API-key allowed catalog in the OpenAI list shape (`object: "list"`, `data[].id`), so live model discovery narrows to exactly the models the key can use.
- End-to-end through opencodex 2.7.35 registered as a custom `openai-chat` provider: a Codex `/v1/responses` request routed to `bizrouter/anthropic/claude-haiku-4.5` returned the expected completion in both non-streaming and streaming modes, and the real Codex CLI (0.144.1) completed a turn through the proxy.

## Testing

- `bun run typecheck` clean
- `bun run test`: 4022 pass / 0 fail (includes the updated `provider-registry-parity` suite)

Disclosure: I work with the BizRouter team.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BizRouter as an available AI provider.
  * Supports OpenAI-compatible chat, tool usage, API-key authentication, and model discovery.
  * Includes a default model and a selection of available models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->