### PR TITLE
fix(anthropic): guard premature no-tool completions

### DIFF
--- a/docs-site/src/content/docs/reference/adapters.md
+++ b/docs-site/src/content/docs/reference/adapters.md
@@ -64,6 +64,10 @@ streams the response back **untranslated**.
 - Always sends `anthropic-version: 2023-06-01`. Streams `content_block_delta` (`text_delta`,
   `thinking_delta`, compatible `reasoning_delta`, `input_json_delta`). The SSE decoder preserves
   event state across fetch chunks and accepts a terminal `message_stop` without a trailing newline.
+- For routed Anthropic Responses turns with client tools, a bounded terminal guard detects the
+  high-confidence case where the user requested an action but Claude ends with an execution claim
+  and no tool call. It performs at most one internal continuation; normal answers, clarification
+  questions, tool-using turns, and transport-incomplete responses are not auto-retried.
 
 ## `google`
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -456,6 +456,17 @@ export function bridgeToResponsesSSE(
             if (event.type !== "done" && event.type !== "incomplete" && event.type !== "error") continue;
           }
           switch (event.type) {
+            case "assistant_boundary": {
+              // A guarded continuation starts a fresh assistant output item while keeping the
+              // intermediate, suspicious text in the same Responses turn.
+              if (currentMsg) closeCurrentMessage();
+              if (currentReasoning) closeCurrentReasoning();
+              if (currentRawReasoning) closeCurrentRawReasoning();
+              flushHiddenRawReasoning();
+              if (currentToolCall) closeCurrentToolCall();
+              flushHiddenReasoningEnvelope();
+              break;
+            }
             case "text_delta": {
               if (currentReasoning) closeCurrentReasoning();
               if (currentRawReasoning) closeCurrentRawReasoning();
@@ -971,6 +982,12 @@ export function buildResponseJSON(
 
   for (const e of events) {
     switch (e.type) {
+      case "assistant_boundary":
+        flushText();
+        flushSummaryReasoning();
+        flushRawReasoning();
+        flushToolCall();
+        break;
       case "text_delta":
         if (currentText && currentTextPhase !== e.phase) flushText();
         if (currentSummaryReasoning) flushSummaryReasoning();

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -105,6 +105,7 @@ import type { EffectiveSubagentRoster, SpawnAgentSurface } from "../../codex/cat
 import { buildToolBridgeMaps, collabSurface, injectDeveloperMessage, multiAgentGuidanceText } from "./collaboration";
 import { hasUnreadableEncryptedAgentTask, looksLikeBackendCiphertext, sanitizeEncryptedContentInPlace } from "./encrypted-payload";
 import { fetchWithHeaderTimeout, providerFetch, safeHostLabel } from "./fetch-helpers";
+import { guardTerminalEventStream } from "./terminal-guard";
 
 /**
  * Adapters whose continuation state must survive Codex's store:false requests.
@@ -1622,8 +1623,124 @@ export async function handleResponses(
 
   cancelBodyOnAbort(upstreamResponse.body, upstream.signal);
 
+  // Claude can return a clean end_turn after announcing an edit without emitting any tool call.
+  // Keep the normal request/recovery path above intact, and use this bounded callback only for the
+  // one internal continuation pass. A continuation failure becomes an in-stream adapter error so
+  // the client never sees a second hidden HTTP response or an unbounded retry loop.
+  const terminalGuardEnabled = activeAdapter.name === "anthropic" && !options.comboAttempt && !routedCompaction;
+  const fetchTerminalGuardContinuation = async function* (nextParsed: OcxParsedRequest): AsyncGenerator<AdapterEvent> {
+    let imageTierBias = 0;
+    let response: Response | undefined;
+    while (true) {
+      try {
+        const continuationRequest = await activeAdapter.buildRequest(nextParsed, {
+          headers: selectedForwardHeaders,
+          ...(imageTierBias > 0 ? { imageTierBias } : {}),
+        });
+        const continuationEstimate = typeof continuationRequest.usageLog?.inputTokens === "number"
+          ? continuationRequest.usageLog.inputTokens
+          : undefined;
+        if (continuationEstimate !== undefined) logCtx.usageLogInputTokens = continuationEstimate;
+        if (activeAdapter.fetchResponse) {
+          noteAttemptSend(logCtx.activeAttempt, continuationEstimate);
+          response = await activeAdapter.fetchResponse(continuationRequest, {
+              abortSignal: upstream.signal,
+              timeoutMs: connectMs,
+              stream: nextParsed.stream,
+            });
+        } else {
+          response = await fetchWithResetRetry(
+              recovery => {
+                noteAttemptSend(logCtx.activeAttempt, continuationEstimate, recovery);
+                return fetchWithHeaderTimeout(
+                  continuationRequest.url,
+                  applyUpstreamRecoveryInit({
+                    method: continuationRequest.method,
+                    headers: continuationRequest.headers,
+                    body: continuationRequest.body,
+                  }, recovery),
+                  upstream.signal,
+                  connectMs,
+                  nextParsed.stream,
+                  providerFetch(route.provider),
+                );
+              },
+              { abortSignal: upstream.signal, label: safeHostLabel(continuationRequest.url) },
+            );
+        }
+      } catch (error) {
+        if (options.abortSignal?.aborted) {
+          yield { type: "error", message: "client closed request during terminal continuation", status: 499 };
+        } else {
+          yield { type: "error", message: `Provider continuation failed: ${error instanceof Error ? error.message : String(error)}` };
+        }
+        return;
+      }
+
+      if (response.status === 429 && hasKeyPoolFailover(route.provider)) {
+        const rotated = rotateProviderTransportOn429(config, route.providerName, {
+          retryAfter: response.headers.get("retry-after"),
+          now: Date.now(),
+          attemptedKey: route.provider.apiKey,
+          promptCacheKey: nextParsed.options.promptCacheKey,
+        });
+        if (rotated) {
+          try { void response.body?.cancel().catch(() => {}); } catch { /* already closed */ }
+          route.provider = rotated;
+          activeAdapter = resolveAdapter(
+            resolveWireProtocolOverride(route.providerName, route.modelId, route.provider),
+            config.cacheRetention,
+          );
+          continue;
+        }
+      }
+      if (shouldAttemptImageTierRetry({
+        status: response.status,
+        adapterName: activeAdapter.name,
+        parsed: nextParsed,
+        alreadyAttempted: imageTierBias > 0,
+      })) {
+        imageTierBias = 1;
+        try { void response.body?.cancel().catch(() => {}); } catch { /* already closed */ }
+        continue;
+      }
+      break;
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "unknown error");
+      yield {
+        type: "error",
+        status: response.status,
+        message: `Provider continuation error ${response.status}: ${redactSecretString(errorText.slice(0, 500))}`,
+      };
+      return;
+    }
+
+    try {
+      if (nextParsed.stream) {
+        yield* activeAdapter.parseStream(response);
+      } else if (activeAdapter.parseResponse) {
+        yield* await activeAdapter.parseResponse(response);
+      } else {
+        yield { type: "error", message: "Provider continuation does not support response parsing" };
+      }
+    } catch (error) {
+      yield { type: "error", message: `Provider continuation parse failed: ${error instanceof Error ? error.message : String(error)}` };
+    }
+  };
+
   if (parsed.stream) {
-    const eventStream = activeAdapter.parseStream(upstreamResponse);
+    const initialEventStream = activeAdapter.parseStream(upstreamResponse);
+    const eventStream = terminalGuardEnabled
+      ? guardTerminalEventStream({
+          parsed,
+          firstEvents: initialEventStream,
+          adapterName: activeAdapter.name,
+          maxAutoContinuations: 1,
+          continuation: fetchTerminalGuardContinuation,
+        })
+      : initialEventStream;
     const { toolNsMap, freeformToolNames, toolSearchToolNames } = buildToolBridgeMaps(parsed);
     const sseStream = bridgeToResponsesSSE(
       eventStream, parsed.modelId, toolNsMap, freeformToolNames, toolSearchToolNames,
@@ -1658,7 +1775,19 @@ export async function handleResponses(
   if (activeAdapter.parseResponse) {
     let events: AdapterEvent[];
     try {
-      events = await activeAdapter.parseResponse(upstreamResponse);
+      const initialEvents = await activeAdapter.parseResponse(upstreamResponse);
+      if (terminalGuardEnabled) {
+        events = [];
+        for await (const event of guardTerminalEventStream({
+          parsed,
+          firstEvents: (async function* () { yield* initialEvents; })(),
+          adapterName: activeAdapter.name,
+          maxAutoContinuations: 1,
+          continuation: fetchTerminalGuardContinuation,
+        })) events.push(event);
+      } else {
+        events = initialEvents;
+      }
     } finally {
       cleanupUpstreamAbort();
     }

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -1718,15 +1718,27 @@ export async function handleResponses(
     }
 
     try {
-      if (nextParsed.stream) {
-        yield* activeAdapter.parseStream(response);
-      } else if (activeAdapter.parseResponse) {
-        yield* await activeAdapter.parseResponse(response);
-      } else {
-        yield { type: "error", message: "Provider continuation does not support response parsing" };
+      // Protect the continuation body against a client abort landing between fetch resolution and
+      // reader attach, exactly as the initial response is guarded above (#390/366e3053). Without
+      // this, a client cancel during the continuation reopens the Bun fetch-to-reader abort race.
+      const detachContinuationBodyGuard = cancelBodyOnAbort(response.body, upstream.signal);
+      try {
+        if (nextParsed.stream) {
+          yield* activeAdapter.parseStream(response);
+        } else if (activeAdapter.parseResponse) {
+          yield* await activeAdapter.parseResponse(response);
+        } else {
+          yield { type: "error", message: "Provider continuation does not support response parsing" };
+        }
+      } finally {
+        detachContinuationBodyGuard();
       }
     } catch (error) {
-      yield { type: "error", message: `Provider continuation parse failed: ${error instanceof Error ? error.message : String(error)}` };
+      if (options.abortSignal?.aborted) {
+        yield { type: "error", message: "client closed request during terminal continuation", status: 499 };
+      } else {
+        yield { type: "error", message: `Provider continuation parse failed: ${redactSecretString(error instanceof Error ? error.message : String(error))}` };
+      }
     }
   };
 

--- a/src/server/responses/terminal-guard.ts
+++ b/src/server/responses/terminal-guard.ts
@@ -1,0 +1,230 @@
+import type {
+  AdapterEvent,
+  OcxAssistantContentPart,
+  OcxAssistantMessage,
+  OcxParsedRequest,
+  OcxUsage,
+} from "../../types";
+
+const ACTIONABLE_REQUEST_RE = /(?:\b(?:add|change|check|continue|create|debug|delete|deploy|edit|execute|fix|implement|inspect|keep going|modify|patch|proceed|refactor|remove|review|run|test|update|write)\b|继续|接着|往下|升级|修改|改(?:一下|下)?|修复|实现|添加|新增|删除|重构|更新|运行|执行|检查|查看|排查|调试|创建|写入|提交|推送|部署|看下|改成|修一下)/iu;
+const PLAN_ONLY_REQUEST_RE = /(?:只(?:给|要|需)(?:我)?(?:一个|个|一下)?(?:计划|方案)|先(?:给|说)(?:我)?(?:一个|个|一下)?(?:计划|方案)|暂时不要(?:调用|使用)工具|不要调用工具|不用执行|只回复(?:计划|方案)|\b(?:just give|provide)\s+(?:me\s+)?(?:a\s+)?plan\b|\b(?:do not|don't)\s+(?:use|call)\s+tools?\b)/iu;
+const PLAN_INTENT_RE = /(?:\b(?:i(?:'|’)m going to|i will|i(?:'|’)ll|let me|next i)\b|我(?:先|会|将|接下来)|下一步)/iu;
+const PLAN_OR_COMPLETION_RE = /(?:\b(?:i(?:'|’)m going to|i will|i(?:'|’)ll|let me|next i|i(?:'|’)ve (?:already )?(?:added|applied|changed|completed|fixed|implemented|modified|updated))\b|\b(?:done|completed|fixed|implemented|updated|applied)\b|我(?:先|会|将|接下来)|下一步|已(?:经)?(?:修改|修复|完成|应用|更新|实现|处理)|完成了|已经好了)/iu;
+const WAITING_FOR_USER_RE = /(?:[?？]\s*$|需要我|请(?:确认|选择|提供)|是否|要不要|可以吗|\b(?:do you want|should i|which file|please confirm|please provide)\b)/iu;
+const EXPLICIT_CONTINUE_RE = /^(?:继续|接着|往下|go on|continue|proceed|keep going)\s*[.!。！]?$/iu;
+const MAX_ANNOUNCEMENT_CHARS = 280;
+
+export const TERMINAL_GUARD_NUDGE =
+  "你刚才只描述了计划，没有执行任何工具。不要再次解释计划，现在立即调用必要工具执行用户任务。" +
+  "只有工具返回后才总结；如果确实无法执行，请明确说明阻塞原因。";
+
+export type TerminalGuardDecision = "pass" | "continue" | "ambiguous";
+
+export interface TerminalTurnAnalysis {
+  decision: TerminalGuardDecision;
+  reason: "normal" | "waiting_for_user" | "no_tools" | "no_actionable_request" | "no_execution_claim" | "recent_tool_activity" | "substantive_answer" | "suspicious_no_tool";
+  assistantText: string;
+  userText: string;
+  hasToolCall: boolean;
+}
+
+function messageText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (!Array.isArray(value)) return "";
+  return value
+    .filter((part): part is { type?: unknown; text?: unknown } => !!part && typeof part === "object")
+    .filter(part => part.type === "text" && typeof part.text === "string")
+    .map(part => part.text as string)
+    .join("");
+}
+
+function latestUserText(parsed: OcxParsedRequest): string {
+  for (let i = parsed.context.messages.length - 1; i >= 0; i -= 1) {
+    const message = parsed.context.messages[i];
+    if (message.role === "user") return messageText(message.content);
+  }
+  return "";
+}
+
+function recentTurnHasToolActivity(parsed: OcxParsedRequest): boolean {
+  let latestUserIndex = -1;
+  for (let i = parsed.context.messages.length - 1; i >= 0; i -= 1) {
+    if (parsed.context.messages[i]?.role === "user") {
+      latestUserIndex = i;
+      break;
+    }
+  }
+  if (latestUserIndex < 0) return false;
+  let lastAssistant: OcxAssistantMessage | undefined;
+  for (let i = latestUserIndex - 1; i >= 0; i -= 1) {
+    const message = parsed.context.messages[i];
+    if (message.role === "assistant") {
+      lastAssistant = message;
+      break;
+    }
+  }
+  if (lastAssistant?.role === "assistant") {
+    const hasToolCall = lastAssistant.content.some(part => part.type === "toolCall");
+    const text = lastAssistant.content
+      .filter(part => part.type === "text")
+      .map(part => part.text)
+      .join("");
+    if (!hasToolCall && PLAN_INTENT_RE.test(text)) return false;
+  }
+  for (let i = latestUserIndex - 1; i >= 0 && parsed.context.messages[i]?.role !== "user"; i -= 1) {
+    const message = parsed.context.messages[i];
+    if (message.role === "toolResult") return true;
+    if (message.role === "assistant" && message.content.some(part => part.type === "toolCall")) return true;
+  }
+  return false;
+}
+
+function assistantText(events: readonly AdapterEvent[]): string {
+  return events
+    .filter((event): event is Extract<AdapterEvent, { type: "text_delta" }> => event.type === "text_delta")
+    .map(event => event.text)
+    .join("");
+}
+
+export function analyzeTerminalTurn(parsed: OcxParsedRequest, events: readonly AdapterEvent[]): TerminalTurnAnalysis {
+  const userText = latestUserText(parsed);
+  const text = assistantText(events);
+  const hasToolCall = events.some(event => event.type === "tool_call_start");
+  if (hasToolCall) {
+    return { decision: "pass", reason: "normal", assistantText: text, userText, hasToolCall };
+  }
+  if (!parsed.context.tools || parsed.context.tools.length === 0 || parsed.options.toolChoice === "none") {
+    return { decision: "pass", reason: "no_tools", assistantText: text, userText, hasToolCall };
+  }
+  if (!ACTIONABLE_REQUEST_RE.test(userText)) {
+    return { decision: "pass", reason: "no_actionable_request", assistantText: text, userText, hasToolCall };
+  }
+  if (PLAN_ONLY_REQUEST_RE.test(userText)) {
+    return { decision: "pass", reason: "no_actionable_request", assistantText: text, userText, hasToolCall };
+  }
+  if (EXPLICIT_CONTINUE_RE.test(userText) && recentTurnHasToolActivity(parsed)) {
+    return { decision: "pass", reason: "recent_tool_activity", assistantText: text, userText, hasToolCall };
+  }
+  if (WAITING_FOR_USER_RE.test(text)) {
+    return { decision: "pass", reason: "waiting_for_user", assistantText: text, userText, hasToolCall };
+  }
+  if (text.trim().length > MAX_ANNOUNCEMENT_CHARS) {
+    return { decision: "pass", reason: "substantive_answer", assistantText: text, userText, hasToolCall };
+  }
+  if (!PLAN_OR_COMPLETION_RE.test(text)) {
+    return { decision: "ambiguous", reason: "no_execution_claim", assistantText: text, userText, hasToolCall };
+  }
+  return { decision: "continue", reason: "suspicious_no_tool", assistantText: text, userText, hasToolCall };
+}
+
+function assistantMessageFromEvents(events: readonly AdapterEvent[]): OcxAssistantMessage | undefined {
+  let text = "";
+  let thinking = "";
+  let signature: string | undefined;
+  const redacted: string[] = [];
+  for (const event of events) {
+    if (event.type === "text_delta") text += event.text;
+    else if (event.type === "thinking_delta") thinking += event.thinking;
+    else if (event.type === "thinking_signature") signature = event.signature;
+    else if (event.type === "redacted_thinking") redacted.push(event.data);
+  }
+  const content: OcxAssistantContentPart[] = [];
+  if (thinking || signature || redacted.length > 0) {
+    content.push({ type: "thinking", thinking, ...(signature ? { signature } : {}), ...(redacted.length > 0 ? { redacted } : {}) });
+  }
+  if (text) content.push({ type: "text", text });
+  if (content.length === 0) return undefined;
+  return { role: "assistant", content, timestamp: Date.now() };
+}
+
+export function buildContinuationRequest(parsed: OcxParsedRequest, events: readonly AdapterEvent[]): OcxParsedRequest {
+  const messages = [...parsed.context.messages];
+  const assistant = assistantMessageFromEvents(events);
+  if (assistant) messages.push(assistant);
+  messages.push({ role: "developer", content: TERMINAL_GUARD_NUDGE, timestamp: Date.now() });
+  return { ...parsed, context: { ...parsed.context, messages } };
+}
+
+export interface GuardedEventStreamOptions {
+  parsed: OcxParsedRequest;
+  firstEvents: AsyncIterable<AdapterEvent>;
+  continuation: (parsed: OcxParsedRequest) => AsyncIterable<AdapterEvent> | Promise<AsyncIterable<AdapterEvent>>;
+  adapterName?: string;
+  maxAutoContinuations?: number;
+}
+
+function mergeUsage(first: OcxUsage | undefined, second: OcxUsage | undefined): OcxUsage | undefined {
+  if (!first) return second;
+  if (!second) return first;
+  const sumOptional = (key: keyof OcxUsage): number | undefined => {
+    const left = first[key];
+    const right = second[key];
+    return typeof left === "number" || typeof right === "number"
+      ? (typeof left === "number" ? left : 0) + (typeof right === "number" ? right : 0)
+      : undefined;
+  };
+  const cachedInputTokens = sumOptional("cachedInputTokens");
+  const cacheReadInputTokens = sumOptional("cacheReadInputTokens");
+  const cacheCreationInputTokens = sumOptional("cacheCreationInputTokens");
+  const reasoningOutputTokens = sumOptional("reasoningOutputTokens");
+  const inputTokens = first.inputTokens + second.inputTokens;
+  const outputTokens = first.outputTokens + second.outputTokens;
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+    ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
+    ...(cacheReadInputTokens !== undefined ? { cacheReadInputTokens } : {}),
+    ...(cacheCreationInputTokens !== undefined ? { cacheCreationInputTokens } : {}),
+    ...(reasoningOutputTokens !== undefined ? { reasoningOutputTokens } : {}),
+    ...(first.estimated || second.estimated ? { estimated: true } : {}),
+  };
+}
+
+/** Preserve normal terminals, but withhold one suspicious no-tool terminal for a bounded re-ask. */
+export async function* guardTerminalEventStream(options: GuardedEventStreamOptions): AsyncGenerator<AdapterEvent> {
+  const maxContinuations = Math.max(0, Math.min(2, Math.floor(options.maxAutoContinuations ?? 1)));
+  let parsed = options.parsed;
+  let continuations = 0;
+  let accumulatedUsage: OcxUsage | undefined;
+  let source: AsyncIterable<AdapterEvent> = options.firstEvents;
+
+  while (true) {
+    const seen: AdapterEvent[] = [];
+    let terminalSeen = false;
+    for await (const event of source) {
+      if (event.type === "done") {
+        terminalSeen = true;
+        const analysis = options.adapterName === "anthropic"
+          ? analyzeTerminalTurn(parsed, seen)
+          : { decision: "pass" as const };
+        const normalStop = event.stopReason !== "max_tokens" && event.stopReason !== "content_filter";
+        if (normalStop && analysis.decision === "continue" && continuations < maxContinuations) {
+          accumulatedUsage = mergeUsage(accumulatedUsage, event.usage);
+          continuations += 1;
+          parsed = buildContinuationRequest(parsed, seen);
+          yield { type: "assistant_boundary" };
+          try {
+            source = await options.continuation(parsed);
+          } catch (error) {
+            yield { type: "error", message: error instanceof Error ? error.message : String(error) };
+            return;
+          }
+          break;
+        }
+        const usage = mergeUsage(accumulatedUsage, event.usage);
+        yield usage ? { ...event, usage } : event;
+        return;
+      }
+      if (event.type === "incomplete" || event.type === "error") {
+        terminalSeen = true;
+        const usage = mergeUsage(accumulatedUsage, event.usage);
+        yield usage ? { ...event, usage } : event;
+        return;
+      }
+      seen.push(event);
+      yield event;
+    }
+    if (!terminalSeen) return;
+  }
+}

--- a/src/server/responses/terminal-guard.ts
+++ b/src/server/responses/terminal-guard.ts
@@ -7,7 +7,7 @@ import type {
 } from "../../types";
 
 const ACTIONABLE_REQUEST_RE = /(?:\b(?:add|change|check|continue|create|debug|delete|deploy|edit|execute|fix|implement|inspect|keep going|modify|patch|proceed|refactor|remove|review|run|test|update|write)\b|继续|接着|往下|升级|修改|改(?:一下|下)?|修复|实现|添加|新增|删除|重构|更新|运行|执行|检查|查看|排查|调试|创建|写入|提交|推送|部署|看下|改成|修一下)/iu;
-const PLAN_ONLY_REQUEST_RE = /(?:只(?:给|要|需)(?:我)?(?:一个|个|一下)?(?:计划|方案)|先(?:给|说)(?:我)?(?:一个|个|一下)?(?:计划|方案)|暂时不要(?:调用|使用)工具|不要调用工具|不用执行|只回复(?:计划|方案)|\b(?:just give|provide)\s+(?:me\s+)?(?:a\s+)?plan\b|\b(?:do not|don't)\s+(?:use|call)\s+tools?\b)/iu;
+const PLAN_ONLY_REQUEST_RE = /(?:暂时不要(?:调用|使用)工具|不要调用工具|不用执行|只回复(?:计划|方案)|(?:只|先|给|说|写|出|来)(?:我)?(?:一个|个|一下|份)?[^。！？\n]{0,8}?(?:计划|方案|草案|提案|思路)|(?:计划|方案|草案|提案|思路)(?:就(?:行|好|可以)|即可)|\b(?:just give|provide)\s+(?:me\s+)?(?:a\s+)?plan\b|\b(?:do not|don't)\s+(?:use|call)\s+tools?\b|\b(?:write|draft|outline|propose|give|provide|create|make|share|suggest|sketch)\s+(?:me\s+)?(?:a\s+|an\s+|the\s+|your\s+)?(?:(?:brief|concise|short|detailed|high[-\s]?level|rough|quick|step[-\s]?by[-\s]?step|implementation|migration|refactor(?:ing)?|design|technical)\s+)*(?:plan|proposal|draft|outline|approach|strategy|design\s+doc)\b)/iu;
 const PLAN_INTENT_RE = /(?:\b(?:i(?:'|’)m going to|i will|i(?:'|’)ll|let me|next i)\b|我(?:先|会|将|接下来)|下一步)/iu;
 const PLAN_OR_COMPLETION_RE = /(?:\b(?:i(?:'|’)m going to|i will|i(?:'|’)ll|let me|next i|i(?:'|’)ve (?:already )?(?:added|applied|changed|completed|fixed|implemented|modified|updated))\b|\b(?:done|completed|fixed|implemented|updated|applied)\b|我(?:先|会|将|接下来)|下一步|已(?:经)?(?:修改|修复|完成|应用|更新|实现|处理)|完成了|已经好了)/iu;
 const WAITING_FOR_USER_RE = /(?:[?？]\s*$|需要我|请(?:确认|选择|提供)|是否|要不要|可以吗|\b(?:do you want|should i|which file|please confirm|please provide)\b)/iu;

--- a/src/types.ts
+++ b/src/types.ts
@@ -246,6 +246,8 @@ export type AdapterEvent =
   | { type: "tool_call_start"; id: string; name: string }
   | { type: "tool_call_delta"; arguments: string }
   | { type: "tool_call_end" }
+  /** Internal boundary between a guarded first pass and its one-shot continuation. */
+  | { type: "assistant_boundary" }
   // Native web-search activity surfaced by the web-search sidecar so Codex renders a "Searched the
   // web" cell. Emitted as a lifecycle PAIR at real wall-clock moments by src/web-search/loop.ts
   // (routed adapters never emit these): `begin` right before the sidecar runs so Codex shows the

--- a/tests/abort-race.test.ts
+++ b/tests/abort-race.test.ts
@@ -113,4 +113,81 @@ describe("Responses abort guards", () => {
       process.off("unhandledRejection", onUnhandledRejection);
     }
   });
+
+  test("terminal-guard continuation body is cancelled on a late client abort (#394 review)", async () => {
+    // The terminal guard opens a SECOND upstream response (the continuation). Its body must be
+    // bound to the abort signal exactly like the initial response, or the fetch-to-reader race
+    // (#390/366e3053) reopens on the continuation path. First turn: an anthropic end_turn with no
+    // tool call (triggers exactly one continuation). Continuation: a body whose reader attaches
+    // only after the client has aborted; cancelBodyOnAbort must cancel it.
+    const clientAbort = new AbortController();
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => { unhandledRejections.push(reason); };
+    let continuationBodyCancelled = false;
+    let fetches = 0;
+
+    process.on("unhandledRejection", onUnhandledRejection);
+    try {
+      adapterFactory = provider => ({
+        name: "anthropic",
+        buildRequest: () => ({ url: provider.baseUrl, method: "POST", headers: {}, body: "" }),
+        async fetchResponse() {
+          fetches += 1;
+          if (fetches === 1) {
+            // First turn: a complete anthropic-style stream that ends without a tool call.
+            return new Response(new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode(
+                  'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":10,"output_tokens":1}}}\n\n' +
+                  'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+                  'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"我接下来会修改相关文件。"}}\n\n' +
+                  'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n' +
+                  'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}\n\n' +
+                  'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+                ));
+                controller.close();
+              },
+            }), { status: 200, headers: { "content-type": "text/event-stream" } });
+          }
+          // Continuation turn: reader attaches only after the client aborts.
+          return new Response(new ReadableStream<Uint8Array>({
+            start(controller) { controller.enqueue(new Uint8Array([1])); },
+            cancel() { continuationBodyCancelled = true; },
+          }), { status: 200, headers: { "content-type": "text/event-stream" } });
+        },
+        async *parseStream(response): AsyncGenerator<AdapterEvent> {
+          if (fetches >= 2) {
+            // We are now parsing the continuation stream — abort before attaching the reader.
+            clientAbort.abort(new DOMException("client disconnected", "AbortError"));
+            await Promise.resolve();
+            const reader = response.body!.getReader();
+            try { await reader.read(); } finally { reader.releaseLock(); }
+            return;
+          }
+          // First turn: emit an end_turn with no tool call so the guard opens a continuation.
+          yield { type: "text_delta", text: "我接下来会修改相关文件。" };
+          yield { type: "done", usage: { inputTokens: 10, outputTokens: 2 } };
+        },
+      });
+
+      const response = await handleResponses(new Request("http://localhost/v1/responses", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "fixture/model",
+          input: "请检查这个问题并修复代码",
+          stream: true,
+          tools: [{ type: "function", name: "exec_command", description: "run a command", parameters: { type: "object" } }],
+        }),
+      }), config("anthropic"), { model: "", provider: "" }, { abortSignal: clientAbort.signal });
+      await response.text().catch(() => {});
+      await new Promise<void>(resolve => setImmediate(resolve));
+
+      expect(fetches).toBe(2);
+      expect(continuationBodyCancelled).toBe(true);
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
 });

--- a/tests/terminal-guard-server.test.ts
+++ b/tests/terminal-guard-server.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { handleResponses } from "../src/server/responses";
+import type { OcxConfig } from "../src/types";
+
+const config = {
+  port: 0,
+  defaultProvider: "claude-se",
+  providers: {
+    "claude-se": {
+      adapter: "anthropic",
+      baseUrl: "https://example.test",
+      apiKey: "sk-test",
+    },
+  },
+} as unknown as OcxConfig;
+
+function anthropicSse(body: string): Response {
+  return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+const firstTurn = [
+  'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":10,"output_tokens":1}}}\n\n',
+  'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+  'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"我接下来会修改相关文件。"}}\n\n',
+  'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+  'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}\n\n',
+  'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+].join("");
+
+const continuationTurn = [
+  'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":20,"output_tokens":1}}}\n\n',
+  'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"exec_command","input":{}}}\n\n',
+  'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{}"}}\n\n',
+  'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+  'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}\n\n',
+  'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+].join("");
+
+describe("server terminal guard integration", () => {
+  let originalFetch: typeof fetch;
+  let calls: number;
+  let requestBodies: Record<string, unknown>[];
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    calls = 0;
+    requestBodies = [];
+    globalThis.fetch = (async (_input, init) => {
+      calls += 1;
+      requestBodies.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+      return anthropicSse(calls === 1 ? firstTurn : continuationTurn);
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("re-asks Claude once inside the same Responses turn and forwards the tool call", async () => {
+    const response = await handleResponses(new Request("http://localhost/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "se-claude-opus-4.8",
+        input: "请检查这个问题并修复代码",
+        stream: true,
+        tools: [{ type: "function", name: "exec_command", description: "run a command", parameters: { type: "object" } }],
+      }),
+    }), config, { model: "", provider: "" });
+
+    const text = await response.text();
+    expect(response.status).toBe(200);
+    expect(calls).toBe(2);
+    expect(text).toContain("response.completed");
+    expect(text).toContain("exec_command");
+    const messages = requestBodies[1]?.messages as Array<{ role?: string; content?: Array<{ text?: string }> }>;
+    expect(messages.at(-1)?.role).toBe("user");
+    expect(messages.at(-1)?.content?.[0]?.text).toContain("你刚才只描述了计划");
+  });
+});

--- a/tests/terminal-guard-server.test.ts
+++ b/tests/terminal-guard-server.test.ts
@@ -77,4 +77,5 @@ describe("server terminal guard integration", () => {
     expect(messages.at(-1)?.role).toBe("user");
     expect(messages.at(-1)?.content?.[0]?.text).toContain("你刚才只描述了计划");
   });
+
 });

--- a/tests/terminal-guard.test.ts
+++ b/tests/terminal-guard.test.ts
@@ -48,6 +48,28 @@ describe("terminal guard", () => {
     expect(analysis.decision).toBe("pass");
   });
 
+  test("does not force tools for an ordinary plan/proposal request without explicit tool prohibition", () => {
+    // Regression (#394 review blocker 2): a plain 'write a concise implementation plan' request
+    // must NOT be treated as a suspicious no-tool completion, even though it contains the
+    // actionable verbs 'write'/'implementation'. Otherwise the guard nudges Claude to run tools
+    // against a plan-only ask, causing side effects.
+    for (const ask of [
+      "Write a concise implementation plan for this change",
+      "Give me a high-level plan before we start",
+      "Draft a migration plan for the schema",
+      "Propose an approach for refactoring the router",
+      "先写一个实现方案",
+      "给我一个重构计划",
+    ]) {
+      const analysis = analyzeTerminalTurn(parsed(ask), [
+        { type: "text_delta", text: "Here is the plan: 1) ... 2) ... 3) ..." },
+        { type: "done" },
+      ]);
+      expect(analysis.decision).toBe("pass");
+      expect(analysis.reason).toBe("no_actionable_request");
+    }
+  });
+
   test("does not auto-repeat an explicit continue after a recent tool-backed turn", () => {
     const request = parsed("继续");
     request.context.messages = [

--- a/tests/terminal-guard.test.ts
+++ b/tests/terminal-guard.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, test } from "bun:test";
+import {
+  analyzeTerminalTurn,
+  buildContinuationRequest,
+  guardTerminalEventStream,
+} from "../src/server/responses/terminal-guard";
+import { buildResponseJSON } from "../src/bridge";
+import type { AdapterEvent, OcxParsedRequest } from "../src/types";
+
+function parsed(userText: string, withTools = true): OcxParsedRequest {
+  return {
+    modelId: "se-claude-opus-4.8",
+    stream: true,
+    options: {},
+    context: {
+      messages: [{ role: "user", content: userText, timestamp: 1 }],
+      ...(withTools ? { tools: [{ name: "exec_command", description: "run a command", parameters: {} }] } : {}),
+    },
+  };
+}
+
+describe("terminal guard", () => {
+  test("recognizes an actionable no-tool completion as suspicious", () => {
+    const analysis = analyzeTerminalTurn(parsed("请检查这个问题并修复代码"), [
+      { type: "text_delta", text: "我接下来会修改相关文件。" },
+      { type: "done" },
+    ]);
+
+    expect(analysis.decision).toBe("continue");
+    expect(analysis.hasToolCall).toBe(false);
+  });
+
+  test("treats an explicit continue command as actionable", () => {
+    const analysis = analyzeTerminalTurn(parsed("继续"), [
+      { type: "text_delta", text: "Let me poll again for completion." },
+      { type: "done" },
+    ]);
+
+    expect(analysis.decision).toBe("continue");
+  });
+
+  test("does not continue when the user explicitly requested a plan without tool execution", () => {
+    const analysis = analyzeTerminalTurn(parsed("先给我一个修改方案，暂时不要调用工具，只回复计划"), [
+      { type: "text_delta", text: "我会先列出修改计划。" },
+      { type: "done" },
+    ]);
+
+    expect(analysis.decision).toBe("pass");
+  });
+
+  test("does not auto-repeat an explicit continue after a recent tool-backed turn", () => {
+    const request = parsed("继续");
+    request.context.messages = [
+      { role: "user", content: "请检查代码", timestamp: 1 },
+      { role: "assistant", content: [{ type: "toolCall", id: "call_1", name: "exec_command", arguments: {} }], timestamp: 2 },
+      { role: "toolResult", toolCallId: "call_1", toolName: "exec_command", content: "ok", isError: false, timestamp: 3 },
+      { role: "user", content: "继续", timestamp: 4 },
+    ];
+
+    const analysis = analyzeTerminalTurn(request, [
+      { type: "text_delta", text: "已经完成了。" },
+      { type: "done" },
+    ]);
+
+    expect(analysis.decision).toBe("pass");
+    expect(analysis.reason).toBe("recent_tool_activity");
+  });
+
+  test("continues when the last assistant message was a plan-only stop after earlier tools", () => {
+    const request = parsed("继续");
+    request.context.messages = [
+      { role: "user", content: "请检查代码", timestamp: 1 },
+      { role: "assistant", content: [{ type: "toolCall", id: "call_1", name: "exec_command", arguments: {} }], timestamp: 2 },
+      { role: "toolResult", toolCallId: "call_1", toolName: "exec_command", content: "ok", isError: false, timestamp: 3 },
+      { role: "assistant", content: [{ type: "text", text: "Let me verify the final result." }], timestamp: 4 },
+      { role: "user", content: "继续", timestamp: 5 },
+    ];
+
+    const analysis = analyzeTerminalTurn(request, [
+      { type: "text_delta", text: "Let me poll again for completion." },
+      { type: "done" },
+    ]);
+
+    expect(analysis.decision).toBe("continue");
+  });
+
+  test("does not continue a normal explanatory answer", () => {
+    const analysis = analyzeTerminalTurn(parsed("为什么会出现这个错误？", false), [
+      { type: "text_delta", text: "这是因为请求在上游被限流。" },
+      { type: "done" },
+    ]);
+
+    expect(analysis.decision).toBe("pass");
+  });
+
+  test("does not continue a substantive final answer that merely contains a completion phrase", () => {
+    const analysis = analyzeTerminalTurn(parsed("请检查这个问题并给出分析"), [
+      { type: "text_delta", text: `已完成分析。${"这是完整结论和依据。".repeat(30)}` },
+      { type: "done" },
+    ]);
+
+    expect(analysis.decision).toBe("pass");
+    expect(analysis.reason).toBe("substantive_answer");
+  });
+
+  test("does not continue after a real tool call", () => {
+    const analysis = analyzeTerminalTurn(parsed("请检查并修复代码"), [
+      { type: "tool_call_start", id: "call_1", name: "exec_command" },
+      { type: "tool_call_delta", arguments: "{}" },
+      { type: "tool_call_end" },
+      { type: "text_delta", text: "已完成。" },
+      { type: "done" },
+    ]);
+
+    expect(analysis.decision).toBe("pass");
+    expect(analysis.hasToolCall).toBe(true);
+  });
+
+  test("does not auto-continue an explicit clarification question", () => {
+    const analysis = analyzeTerminalTurn(parsed("请修复这个问题"), [
+      { type: "text_delta", text: "需要我修改哪个文件？" },
+      { type: "done" },
+    ]);
+
+    expect(analysis.decision).toBe("pass");
+    expect(analysis.reason).toBe("waiting_for_user");
+  });
+
+  test("builds an internal continuation request without changing the original history", () => {
+    const original = parsed("请检查这个问题并修复代码");
+    const next = buildContinuationRequest(original, [
+      { type: "text_delta", text: "我接下来会修改相关文件。" },
+      { type: "done" },
+    ]);
+
+    expect(original.context.messages).toHaveLength(1);
+    expect(next.context.messages).toHaveLength(3);
+    expect(next.context.messages[1]).toMatchObject({ role: "assistant" });
+    expect(next.context.messages[2]).toMatchObject({ role: "developer" });
+  });
+
+  test("can guard a fetch-based adapter stream with a continuation callback", async () => {
+    let continuations = 0;
+    const actual: AdapterEvent[] = [];
+    for await (const event of guardTerminalEventStream({
+      parsed: parsed("请检查这个问题并修复代码"),
+      firstEvents: (async function* () {
+        yield { type: "text_delta", text: "我接下来会修改相关文件。" } as AdapterEvent;
+        yield { type: "done", usage: { inputTokens: 10, outputTokens: 2 } } as AdapterEvent;
+      })(),
+      continuation: next => {
+        continuations += 1;
+        expect(next.context.messages.at(-1)).toMatchObject({ role: "developer" });
+        return (async function* () {
+          yield { type: "tool_call_start", id: "call_1", name: "exec_command" } as AdapterEvent;
+          yield { type: "tool_call_end" } as AdapterEvent;
+          yield { type: "done", usage: { inputTokens: 20, outputTokens: 3 } } as AdapterEvent;
+        })();
+      },
+      adapterName: "anthropic",
+    })) actual.push(event);
+
+    expect(continuations).toBe(1);
+    expect(actual.filter(event => event.type === "done")).toHaveLength(1);
+    expect(actual.some(event => event.type === "assistant_boundary")).toBe(true);
+    expect(actual.at(-1)).toMatchObject({ usage: { inputTokens: 30, outputTokens: 5, totalTokens: 35 } });
+  });
+
+  test("stops after the configured continuation bound", async () => {
+    let continuations = 0;
+    const actual: AdapterEvent[] = [];
+    const suspicious = () => (async function* () {
+      yield { type: "text_delta", text: "Let me check again." } as AdapterEvent;
+      yield { type: "done" } as AdapterEvent;
+    })();
+
+    for await (const event of guardTerminalEventStream({
+      parsed: parsed("继续"),
+      firstEvents: suspicious(),
+      continuation: () => {
+        continuations += 1;
+        return suspicious();
+      },
+      adapterName: "anthropic",
+      maxAutoContinuations: 1,
+    })) actual.push(event);
+
+    expect(continuations).toBe(1);
+    expect(actual.filter(event => event.type === "assistant_boundary")).toHaveLength(1);
+    expect(actual.filter(event => event.type === "done")).toHaveLength(1);
+  });
+
+  test("serializes the guarded boundary as separate assistant output items", () => {
+    const response = buildResponseJSON([
+      { type: "text_delta", text: "我接下来会修改。" },
+      { type: "assistant_boundary" },
+      { type: "tool_call_start", id: "call_1", name: "exec_command" },
+      { type: "tool_call_end" },
+      { type: "done" },
+    ], "se-claude-opus-4.8");
+
+    expect((response.output as { type: string }[]).map(item => item.type)).toEqual(["message", "function_call"]);
+  });
+});


### PR DESCRIPTION
## Summary

- detect the high-confidence Anthropic case where an actionable request ends with a short execution claim but no tool call
- keep the response open and make at most one internal continuation, preserving one terminal Responses event and merging usage from both upstream calls
- avoid auto-continuing normal answers, clarification questions, explicit plan-only requests, substantive final answers, and recent tool-backed completions
- preserve the first assistant output as a separate Responses item before any tool call from the continuation

## Tests

- `bun run test` — 3947 pass, 0 fail
- `bun run typecheck`
- `bun run privacy:scan`
- focused terminal-guard and Anthropic bridge tests
- isolated live probe against a configured Anthropic-compatible account: HTTP 200, one `response.completed`, zero `response.failed`, and the expected client tool call in the same Responses turn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Anthropic requests can now perform one bounded continuation when an action is requested but no tool call is produced.
  - Streaming and non-streaming responses now segment assistant output cleanly across the initial response and its one-shot continuation.

- **Bug Fixes**
  - Prevents unsafe/unbounded continuation behavior and ensures continuation token usage and tool-call results are aggregated correctly.
  - Cancels the continuation fetch body if the client aborts mid-continuation.

- **Documentation**
  - Clarified Anthropic terminal-guard continuation behavior and which response types are not retried.

- **Tests**
  - Added coverage for continuation decisions, boundary emission, usage aggregation, retry limits, and late client abort cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->