### PR TITLE
fix(openai-chat): keep system messages first

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -61,6 +61,13 @@ function extractErrorDetail(parsed: unknown): string | undefined {
   return undefined;
 }
 
+function developerSystemText(message: OcxMessage): string | undefined {
+  if (message.role !== "developer") return undefined;
+  if (typeof message.content === "string") return message.content;
+  if (message.content.some(part => part.type === "image")) return undefined;
+  return message.content.map(part => (part as OcxTextContent).text).join("");
+}
+
 function messagesToChatFormat(parsed: OcxParsedRequest, provider: OcxProviderConfig): unknown[] {
   const out: unknown[] = [];
   const { context, options } = parsed;
@@ -112,7 +119,20 @@ function messagesToChatFormat(parsed: OcxParsedRequest, provider: OcxProviderCon
   const toolCatalogNudge = shouldInjectNonOpenAIToolCatalogNudge(provider)
     ? buildNonOpenAIToolCatalogNudgeForTools(context.tools, options.toolChoice)
     : undefined;
-  const systemParts = [...(context.systemPrompt ?? []), ...(toolCatalogNudge ? [toolCatalogNudge] : [])];
+  // Chat templates used by LM Studio, llama.cpp, and other strict OpenAI-compatible
+  // backends require every system instruction to precede conversation history. Codex can
+  // append developer reminders after user turns, so fold text-only developer messages into
+  // the single leading system message instead of emitting role:"system" in place. Developer
+  // messages with images cannot be represented as system content and remain user-compatible
+  // vision messages at their original position below.
+  const developerSystemParts = context.messages
+    .map(developerSystemText)
+    .filter((part): part is string => part !== undefined && part.length > 0);
+  const systemParts = [
+    ...(context.systemPrompt ?? []),
+    ...developerSystemParts,
+    ...(toolCatalogNudge ? [toolCatalogNudge] : []),
+  ];
   if (systemParts.length > 0) {
     // Codex sends its GPT-5 identity prompt for EVERY model (the per-model catalog
     // base_instructions is ignored at request time). Neutralize that one identity line
@@ -126,18 +146,19 @@ function messagesToChatFormat(parsed: OcxParsedRequest, provider: OcxProviderCon
     switch (msg.role) {
       case "user":
       case "developer": {
-        const role = msg.role === "developer" ? "system" : "user";
+        const parts = typeof msg.content === "string" ? undefined : msg.content as OcxContentPart[];
+        const hasImages = parts?.some(p => p.type === "image") ?? false;
+        if (msg.role === "developer" && !hasImages) break;
         let chatMsg: Record<string, unknown>;
         if (typeof msg.content === "string") {
-          chatMsg = { role, content: msg.content };
+          chatMsg = { role: "user", content: msg.content };
         } else {
-          const parts = msg.content as OcxContentPart[];
-          if (!parts.some(p => p.type === "image")) {
-            chatMsg = { role, content: parts.map(p => (p as OcxTextContent).text).join("") };
+          if (!hasImages) {
+            chatMsg = { role: "user", content: parts!.map(p => (p as OcxTextContent).text).join("") };
           } else {
             // Vision: chat-completions content-parts array. Images are only valid on the user role,
             // and the data URL goes straight into image_url.url (never the token-exploding text path).
-            const chatParts = parts.map(p => p.type === "image"
+            const chatParts = parts!.map(p => p.type === "image"
               ? { type: "image_url", image_url: { url: p.imageUrl, ...(p.detail ? { detail: p.detail } : {}) } }
               : { type: "text", text: (p as OcxTextContent).text });
             chatMsg = { role: "user", content: chatParts };

--- a/tests/openai-chat-dangling-toolcalls.test.ts
+++ b/tests/openai-chat-dangling-toolcalls.test.ts
@@ -90,7 +90,7 @@ function assertWireInvariants(messages: ChatMsg[]): void {
 }
 
 describe("openai-chat dangling tool_calls hardening", () => {
-  test("T1 incident: call -> developer barrier -> real result reattaches to the original call", () => {
+  test("T1 incident: developer guidance is hoisted while the real result reattaches to the original call", () => {
     const messages = wire([
       user("hi"),
       assistantWithCalls([{ id: "call_x", name: "request_user_input" }]),
@@ -100,13 +100,14 @@ describe("openai-chat dangling tool_calls hardening", () => {
     ]);
     assertWireInvariants(messages);
     const roles = messages.map(m => m.role);
-    // canonical order: assistant, tool(real), developer-mapped system, user
+    expect(messages[0]).toEqual({ role: "system", content: "[injected guidance]" });
+    // canonical history order: assistant, tool(real), user; no in-history system barrier
     const aIdx = roles.indexOf("assistant");
     expect(roles[aIdx + 1]).toBe("tool");
     expect(messages[aIdx + 1].tool_call_id).toBe("call_x");
     expect(messages[aIdx + 1].content).toBe('{"answers":{}}');
-    expect(roles[aIdx + 2]).toBe("system");
-    expect(roles[aIdx + 3]).toBe("user");
+    expect(roles[aIdx + 2]).toBe("user");
+    expect(messages.slice(1).some(m => m.role === "system")).toBe(false);
     // no synthetic result fabricated for an answered call
     expect(messages.some(m => typeof m.content === "string" && m.content.includes("no tool result was recorded"))).toBe(false);
   });
@@ -165,8 +166,9 @@ describe("openai-chat dangling tool_calls hardening", () => {
     expect(String(synth?.content)).toContain("no tool result was recorded");
     const real = block.find(m => m.tool_call_id === "call_2");
     expect(real?.content).toBe("img-ok");
-    // deferred barrier lands after the round closes, before the next assistant
-    expect(messages[aIdx + 3].role).toBe("system");
+    expect(messages[0]).toEqual({ role: "system", content: "barrier while call_1 pending" });
+    expect(messages[aIdx + 3].role).toBe("assistant");
+    expect(messages.slice(1).some(m => m.role === "system")).toBe(false);
   });
 
   test("T6 mismatched result while calls pending: round closes synthetically, then orphan pair", () => {
@@ -181,7 +183,9 @@ describe("openai-chat dangling tool_calls hardening", () => {
     expect(messages[aIdx + 1].role).toBe("tool");
     expect(messages[aIdx + 1].tool_call_id).toBe("call_p");
     expect(String(messages[aIdx + 1].content)).toContain("no tool result was recorded");
-    expect(messages[aIdx + 2].role).toBe("system"); // released deferred barrier
+    expect(messages[0]).toEqual({ role: "system", content: "deferred barrier" });
+    expect(messages[aIdx + 2].role).toBe("assistant");
+    expect(messages.slice(1).some(m => m.role === "system")).toBe(false);
     const orphanIdx = messages.findIndex((m, i) => i > aIdx && m.role === "assistant");
     expect(messages[orphanIdx].tool_calls?.[0].id).toBe("call_unknown");
     expect(messages[orphanIdx + 1].tool_call_id).toBe("call_unknown");

--- a/tests/openai-chat-system-order.test.ts
+++ b/tests/openai-chat-system-order.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
+import type { OcxParsedRequest, OcxProviderConfig } from "../src/types";
+
+const provider: OcxProviderConfig = {
+  adapter: "openai-chat",
+  baseUrl: "http://localhost:1234/v1",
+  apiKey: "local",
+};
+
+function buildMessages(context: OcxParsedRequest["context"]): Array<Record<string, unknown>> {
+  const request = createOpenAIChatAdapter(provider).buildRequest({
+    modelId: "local-model",
+    context,
+    stream: false,
+    options: {},
+  });
+  return (JSON.parse(request.body) as { messages: Array<Record<string, unknown>> }).messages;
+}
+
+describe("openai-chat system message ordering", () => {
+  test("folds interleaved developer reminders into one leading system message", () => {
+    const messages = buildMessages({
+      systemPrompt: ["base instructions"],
+      messages: [
+        { role: "user", content: "hello", timestamp: 0 },
+        { role: "developer", content: "first reminder", timestamp: 0 },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "hi" }],
+          model: "local-model",
+          timestamp: 0,
+        },
+        {
+          role: "developer",
+          content: [{ type: "text", text: "second reminder" }],
+          timestamp: 0,
+        },
+        { role: "user", content: "continue", timestamp: 0 },
+      ],
+    });
+
+    expect(messages[0]).toEqual({
+      role: "system",
+      content: "base instructions\n\nfirst reminder\n\nsecond reminder",
+    });
+    expect(messages.slice(1).map(message => message.role)).toEqual(["user", "assistant", "user"]);
+    expect(messages.slice(1).some(message => message.role === "system")).toBe(false);
+  });
+
+  test("keeps tool calls and results adjacent when a developer reminder follows the call", () => {
+    const messages = buildMessages({
+      messages: [
+        { role: "user", content: "inspect", timestamp: 0 },
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", id: "call_1", name: "read_file", arguments: {} }],
+          model: "local-model",
+          timestamp: 0,
+        },
+        { role: "developer", content: "remember the policy", timestamp: 0 },
+        {
+          role: "toolResult",
+          toolCallId: "call_1",
+          toolName: "read_file",
+          content: "contents",
+          isError: false,
+          timestamp: 0,
+        },
+      ],
+    });
+
+    expect(messages[0]).toEqual({ role: "system", content: "remember the policy" });
+    expect(messages.map(message => message.role)).toEqual(["system", "user", "assistant", "tool"]);
+    expect(messages[3]).toMatchObject({ role: "tool", tool_call_id: "call_1" });
+  });
+
+  test("keeps developer vision content as a user-compatible message in place", () => {
+    const messages = buildMessages({
+      messages: [
+        { role: "user", content: "before", timestamp: 0 },
+        {
+          role: "developer",
+          content: [
+            { type: "text", text: "inspect this" },
+            { type: "image", imageUrl: "data:image/png;base64,AA==", detail: "low" },
+          ],
+          timestamp: 0,
+        },
+        { role: "user", content: "after", timestamp: 0 },
+      ],
+    });
+
+    expect(messages.map(message => message.role)).toEqual(["user", "user", "user"]);
+    expect(messages[1]).toEqual({
+      role: "user",
+      content: [
+        { type: "text", text: "inspect this" },
+        { type: "image_url", image_url: { url: "data:image/png;base64,AA==", detail: "low" } },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fold text-only Codex developer messages into the single leading OpenAI chat system message.
- Keep developer messages containing images as user-compatible vision messages in their original position.
- Preserve tool-call and tool-result adjacency after developer guidance is hoisted.

## Problem

Codex can append developer reminders after user or assistant history. The openai-chat adapter mapped each reminder to an in-place system message. Strict LM Studio and llama.cpp chat templates reject that shape with `System message must be at the beginning`.

## Verification

- `bun test --isolate ./tests/`: 4031 passed, 0 failed.
- Focused adapter and tool-history tests: 42 passed after rebasing onto current `dev`.
- `bun run typecheck`: passed.
- `bun run privacy:scan`: passed.
- Live OpenCodex Responses request with user followed by developer content returned `SYSTEM_ORDER_OK` through LM Studio Qwen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with OpenAI-compatible providers by consolidating text-only developer instructions into the initial system message.
  - Preserved developer messages containing images in their original position and format.
  - Maintained correct tool-call and tool-result ordering when developer instructions are present.

- **Tests**
  - Added coverage for system-message ordering, tool-call adjacency, and developer vision content handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->