### PR TITLE
fix(service): retry Windows background install with UAC elevation

### DIFF
--- a/src/lib/windows-elevation.ts
+++ b/src/lib/windows-elevation.ts
@@ -1,0 +1,83 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+function windowsAccessDeniedText(text: string): boolean {
+  const normalized = text.toLowerCase();
+  return normalized.includes("access denied")
+    || normalized.includes("access is denied")
+    || normalized.includes("zugriff verweigert");
+}
+
+/** True when a captured stderr/stdout/message indicates Windows access denial. */
+export function isWindowsAccessDenied(detail: string): boolean {
+  return windowsAccessDeniedText(detail);
+}
+
+/** True when a thrown exec error looks like Windows access denial. */
+export function isWindowsAccessDeniedError(error: unknown): boolean {
+  if (!(error instanceof Error)) return isWindowsAccessDenied(String(error));
+  const exec = error as NodeJS.ErrnoException & { stderr?: string | Buffer; stdout?: string | Buffer };
+  const parts = [error.message, exec.stderr, exec.stdout]
+    .map(part => (typeof part === "string" ? part : part ? String(part) : ""));
+  return parts.some(part => windowsAccessDeniedText(part));
+}
+
+/** Replace raw schtasks access-denied output with dashboard-friendly guidance. */
+export function formatWindowsSchtasksError(error: unknown, args: string[]): string {
+  if (!isWindowsAccessDeniedError(error)) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  const argsText = args.map(arg => (/\s/.test(arg) ? `"${arg}"` : arg)).join(" ");
+  return [
+    "Windows denied access while running Task Scheduler.",
+    `Command: schtasks ${argsText}`,
+    "Approve the Windows UAC prompt to install the background service, or run `ocx service install` from an elevated PowerShell window.",
+  ].join(" ");
+}
+
+function windowsPowerShell(): string {
+  const candidate = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+  return existsSync(candidate) ? candidate : "powershell.exe";
+}
+
+function psSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+/** Launch a file with UAC elevation and wait for it to exit. */
+export function runWindowsElevated(file: string, args: string[]): Promise<number> {
+  if (process.platform !== "win32") {
+    return Promise.reject(new Error("Windows elevation is only supported on Windows."));
+  }
+  const argumentList = args.map(arg => psSingleQuote(arg)).join(", ");
+  const script = [
+    `$p = Start-Process -FilePath ${psSingleQuote(file)}`,
+    argumentList.length > 0 ? ` -ArgumentList ${argumentList}` : "",
+    " -Verb RunAs -WindowStyle Hidden -PassThru -Wait;",
+    "if ($null -eq $p) { exit 1223 }",
+    "exit $p.ExitCode",
+  ].join("");
+  return new Promise((resolve, reject) => {
+    try {
+      execFileSync(windowsPowerShell(), ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", script], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      });
+      resolve(0);
+    } catch (error) {
+      const exec = error as { status?: number | null; message?: string };
+      if (typeof exec.status === "number") {
+        resolve(exec.status);
+        return;
+      }
+      reject(error instanceof Error ? error : new Error(String(error)));
+    }
+  });
+}
+
+export function runWindowsElevatedCommand(file: string, args: string[]): Promise<number> {
+  return runWindowsElevated(file, args);
+}
+

--- a/src/lib/windows-elevation.ts
+++ b/src/lib/windows-elevation.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
@@ -6,6 +6,7 @@ function windowsAccessDeniedText(text: string): boolean {
   const normalized = text.toLowerCase();
   return normalized.includes("access denied")
     || normalized.includes("access is denied")
+    || normalized.includes("denied access")
     || normalized.includes("zugriff verweigert");
 }
 
@@ -30,10 +31,20 @@ export function formatWindowsSchtasksError(error: unknown, args: string[]): stri
   }
   const argsText = args.map(arg => (/\s/.test(arg) ? `"${arg}"` : arg)).join(" ");
   return [
-    "Windows denied access while running Task Scheduler.",
+    "Windows access denied while running Task Scheduler.",
     `Command: schtasks ${argsText}`,
     "Approve the Windows UAC prompt to install the background service, or run `ocx service install` from an elevated PowerShell window.",
   ].join(" ");
+}
+
+function windowsCmdQuote(value: string): string {
+  if (!/[\s"]/.test(value)) return value;
+  return `"${value.replace(/"/g, '\\"')}"`;
+}
+
+/** Build one Win32 argument-list string for Start-Process -ArgumentList. */
+export function buildWindowsElevatedArgumentList(args: string[]): string {
+  return args.map(windowsCmdQuote).join(" ");
 }
 
 function windowsPowerShell(): string {
@@ -46,38 +57,40 @@ function psSingleQuote(value: string): string {
 }
 
 /** Launch a file with UAC elevation and wait for it to exit. */
-export function runWindowsElevated(file: string, args: string[]): Promise<number> {
+export function runWindowsElevated(file: string, args: string[], timeoutMs = 120_000): Promise<number> {
   if (process.platform !== "win32") {
     return Promise.reject(new Error("Windows elevation is only supported on Windows."));
   }
-  const argumentList = args.map(arg => psSingleQuote(arg)).join(", ");
+  const argumentList = buildWindowsElevatedArgumentList(args);
   const script = [
     `$p = Start-Process -FilePath ${psSingleQuote(file)}`,
-    argumentList.length > 0 ? ` -ArgumentList ${argumentList}` : "",
+    argumentList.length > 0 ? ` -ArgumentList ${psSingleQuote(argumentList)}` : "",
     " -Verb RunAs -WindowStyle Hidden -PassThru -Wait;",
     "if ($null -eq $p) { exit 1223 }",
     "exit $p.ExitCode",
   ].join("");
   return new Promise((resolve, reject) => {
-    try {
-      execFileSync(windowsPowerShell(), ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", script], {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-        windowsHide: true,
-      });
-      resolve(0);
-    } catch (error) {
-      const exec = error as { status?: number | null; message?: string };
+    execFile(windowsPowerShell(), ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", script], {
+      encoding: "utf8",
+      timeout: timeoutMs,
+      windowsHide: true,
+      maxBuffer: 256 * 1024,
+    }, (error, _stdout, stderr) => {
+      if (!error) {
+        resolve(0);
+        return;
+      }
+      const exec = error as NodeJS.ErrnoException & { status?: number | null };
+      if (exec.code === "ETIMEDOUT") {
+        reject(new Error(`Windows elevation timed out after ${timeoutMs}ms.`));
+        return;
+      }
       if (typeof exec.status === "number") {
         resolve(exec.status);
         return;
       }
-      reject(error instanceof Error ? error : new Error(String(error)));
-    }
+      const detail = stderr.trim() || exec.message;
+      reject(new Error(detail || "Windows elevation failed."));
+    });
   });
 }
-
-export function runWindowsElevatedCommand(file: string, args: string[]): Promise<number> {
-  return runWindowsElevated(file, args);
-}
-

--- a/src/lib/windows-elevation.ts
+++ b/src/lib/windows-elevation.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve as resolvePath } from "node:path";
+import { dlopen, ptr, type Pointer } from "bun:ffi";
 
 type ElevationSpawn = (
   command: string,
@@ -13,6 +14,112 @@ let elevationSpawn: ElevationSpawn = spawn;
 /** Test-only seam for the elevated PowerShell launcher. */
 export function setWindowsElevationSpawnForTests(next: ElevationSpawn | null): void {
   elevationSpawn = next ?? spawn;
+}
+
+type GetSystemDirectoryW = (buffer: Pointer, size: number) => number;
+type TrustedSystemDirectoryResolver = () => string;
+
+let getSystemDirectoryWFn: GetSystemDirectoryW | null | undefined;
+let trustedSystemDirectoryResolverForTests: TrustedSystemDirectoryResolver | null = null;
+
+/** Test-only seam to replace GetSystemDirectoryW-backed resolution. */
+export function setTrustedWindowsSystemDirectoryResolverForTests(
+  next: TrustedSystemDirectoryResolver | null,
+): void {
+  trustedSystemDirectoryResolverForTests = next;
+}
+
+function loadGetSystemDirectoryW(): GetSystemDirectoryW | null {
+  if (getSystemDirectoryWFn !== undefined) return getSystemDirectoryWFn;
+  if (process.platform !== "win32") {
+    getSystemDirectoryWFn = null;
+    return null;
+  }
+  try {
+    const lib = dlopen("kernel32.dll", {
+      GetSystemDirectoryW: {
+        args: ["ptr", "u32"],
+        returns: "u32",
+      },
+    });
+    getSystemDirectoryWFn = (buffer, size) => lib.symbols.GetSystemDirectoryW(buffer, size) as number;
+  } catch {
+    getSystemDirectoryWFn = null;
+  }
+  return getSystemDirectoryWFn;
+}
+
+function decodeWideCString(buf: Uint16Array, length: number): string {
+  return String.fromCharCode(...buf.subarray(0, length));
+}
+
+/**
+ * Resolve the real Windows system directory via GetSystemDirectoryW.
+ * Must never trust process.env.SystemRoot / WINDIR — those are caller-controlled and
+ * must not select binaries for UAC elevation.
+ */
+export function resolveTrustedWindowsSystemDirectory(): string {
+  if (trustedSystemDirectoryResolverForTests) {
+    return trustedSystemDirectoryResolverForTests();
+  }
+  if (process.platform !== "win32") {
+    throw new Error("Trusted Windows system directory resolution is only supported on Windows.");
+  }
+  const getSystemDirectoryW = loadGetSystemDirectoryW();
+  if (!getSystemDirectoryW) {
+    throw new Error("Failed to load GetSystemDirectoryW from kernel32.dll.");
+  }
+
+  let size = 260;
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const buf = new Uint16Array(size);
+    const written = getSystemDirectoryW(ptr(buf.buffer), size);
+    if (written === 0) {
+      throw new Error("GetSystemDirectoryW failed while resolving the trusted system directory.");
+    }
+    // When the buffer is too small, the return value is the required size including NUL.
+    if (written >= size) {
+      size = written + 1;
+      continue;
+    }
+    const directory = decodeWideCString(buf, written).replace(/[/\\]+$/, "");
+    if (!directory || !existsSync(directory)) {
+      throw new Error("GetSystemDirectoryW returned an unusable system directory.");
+    }
+    return resolvePath(directory);
+  }
+  throw new Error("GetSystemDirectoryW required a system directory path larger than expected.");
+}
+
+function assertTrustedSystemExecutable(candidate: string, label: string): string {
+  const systemDir = resolveTrustedWindowsSystemDirectory();
+  const resolved = resolvePath(candidate);
+  const systemPrefix = systemDir.toLowerCase().replace(/[/\\]+$/, "") + "\\";
+  const resolvedLower = resolved.toLowerCase();
+  if (resolvedLower !== systemDir.toLowerCase() && !resolvedLower.startsWith(systemPrefix)) {
+    throw new Error(`${label} resolved outside the trusted Windows system directory.`);
+  }
+  if (!existsSync(resolved)) {
+    throw new Error(`Trusted ${label} was not found at ${resolved}.`);
+  }
+  return resolved;
+}
+
+/** Absolute path to System32\\WindowsPowerShell\\v1.0\\powershell.exe from a trusted system directory. */
+export function resolveTrustedWindowsPowerShellExe(): string {
+  const candidate = join(
+    resolveTrustedWindowsSystemDirectory(),
+    "WindowsPowerShell",
+    "v1.0",
+    "powershell.exe",
+  );
+  return assertTrustedSystemExecutable(candidate, "PowerShell");
+}
+
+/** Absolute path to System32\\schtasks.exe from a trusted system directory. */
+export function resolveTrustedWindowsSchtasksExe(): string {
+  const candidate = join(resolveTrustedWindowsSystemDirectory(), "schtasks.exe");
+  return assertTrustedSystemExecutable(candidate, "schtasks.exe");
 }
 
 /** Stable machine-readable marker for a denied `schtasks /create`. Crosses the CLI→proxy boundary. */
@@ -210,8 +317,7 @@ export function classifyElevatedSchedulerExitCode(exitCode: number): ElevatedSch
 }
 
 function windowsPowerShell(): string {
-  const candidate = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
-  return existsSync(candidate) ? candidate : "powershell.exe";
+  return resolveTrustedWindowsPowerShellExe();
 }
 
 function psSingleQuote(value: string): string {

--- a/src/lib/windows-elevation.ts
+++ b/src/lib/windows-elevation.ts
@@ -105,6 +105,11 @@ function assertTrustedSystemExecutable(candidate: string, label: string): string
   return resolved;
 }
 
+/** Test-only access to the trusted-path containment check. */
+export function assertTrustedSystemExecutableForTests(candidate: string, label: string): string {
+  return assertTrustedSystemExecutable(candidate, label);
+}
+
 type ElevationExeOverrides = { powershell?: string; schtasks?: string };
 let elevationExeOverridesForTests: ElevationExeOverrides | null = null;
 

--- a/src/lib/windows-elevation.ts
+++ b/src/lib/windows-elevation.ts
@@ -1,6 +1,35 @@
-import { execFile } from "node:child_process";
+import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+
+type ElevationSpawn = (
+  command: string,
+  args: ReadonlyArray<string>,
+  options: SpawnOptions,
+) => ChildProcess;
+
+let elevationSpawn: ElevationSpawn = spawn;
+
+/** Test-only seam for the elevated PowerShell launcher. */
+export function setWindowsElevationSpawnForTests(next: ElevationSpawn | null): void {
+  elevationSpawn = next ?? spawn;
+}
+
+/** Stable machine-readable marker for a denied `schtasks /create`. Crosses the CLI→proxy boundary. */
+export const WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER =
+  "OCX_ERROR_CODE=WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED";
+
+export type WindowsSchtasksOperation = "create" | "run" | "query" | "delete" | "end" | "other";
+export type WindowsSchtasksFailureReason = "access-denied" | "other";
+
+export type WindowsElevationFailureReason =
+  | "cancelled"
+  | "timeout"
+  | "launch-failed"
+  | "child-failed"
+  | "terminated";
+
+const ELEVATION_OUTPUT_LIMIT = 256 * 1024;
 
 function windowsAccessDeniedText(text: string): boolean {
   const normalized = text.toLowerCase();
@@ -10,6 +39,16 @@ function windowsAccessDeniedText(text: string): boolean {
     || normalized.includes("zugriff verweigert");
 }
 
+function windowsUacCancelledText(text: string): boolean {
+  const normalized = text.toLowerCase();
+  return normalized.includes("operation was canceled by the user")
+    || normalized.includes("operation was cancelled by the user")
+    || normalized.includes("the operation was canceled")
+    || normalized.includes("the operation was cancelled")
+    || normalized.includes("vom benutzer abgebrochen")
+    || normalized.includes("durch den benutzer abgebrochen");
+}
+
 /** True when a captured stderr/stdout/message indicates Windows access denial. */
 export function isWindowsAccessDenied(detail: string): boolean {
   return windowsAccessDeniedText(detail);
@@ -17,6 +56,7 @@ export function isWindowsAccessDenied(detail: string): boolean {
 
 /** True when a thrown exec error looks like Windows access denial. */
 export function isWindowsAccessDeniedError(error: unknown): boolean {
+  if (error instanceof WindowsSchtasksError) return error.reason === "access-denied";
   if (!(error instanceof Error)) return isWindowsAccessDenied(String(error));
   const exec = error as NodeJS.ErrnoException & { stderr?: string | Buffer; stdout?: string | Buffer };
   const parts = [error.message, exec.stderr, exec.stdout]
@@ -24,22 +64,103 @@ export function isWindowsAccessDeniedError(error: unknown): boolean {
   return parts.some(part => windowsAccessDeniedText(part));
 }
 
+/** True only for a structured Task Scheduler `/create` access-denied failure. */
+export function isWindowsSchtasksCreateAccessDenied(detail: string): boolean {
+  return detail.includes(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER);
+}
+
+export function schtasksOperationFromArgs(args: string[]): WindowsSchtasksOperation {
+  const flag = (args[0] ?? "").toLowerCase();
+  if (flag === "/create") return "create";
+  if (flag === "/run") return "run";
+  if (flag === "/query") return "query";
+  if (flag === "/delete") return "delete";
+  if (flag === "/end") return "end";
+  return "other";
+}
+
+/** Structured Task Scheduler failure that survives formatting and process boundaries. */
+export class WindowsSchtasksError extends Error {
+  readonly code = "WINDOWS_SCHTASKS_ERROR" as const;
+
+  constructor(
+    readonly operation: WindowsSchtasksOperation,
+    readonly reason: WindowsSchtasksFailureReason,
+    message: string,
+  ) {
+    super(message);
+    this.name = "WindowsSchtasksError";
+  }
+
+  get machineMarker(): string | null {
+    return this.operation === "create" && this.reason === "access-denied"
+      ? WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER
+      : null;
+  }
+}
+
+export class WindowsElevationError extends Error {
+  readonly code = "WINDOWS_ELEVATION_ERROR" as const;
+
+  constructor(
+    readonly reason: WindowsElevationFailureReason,
+    message: string,
+  ) {
+    super(message);
+    this.name = "WindowsElevationError";
+  }
+}
+
 /** Replace raw schtasks access-denied output with dashboard-friendly guidance. */
 export function formatWindowsSchtasksError(error: unknown, args: string[]): string {
-  if (!isWindowsAccessDeniedError(error)) {
+  const operation = schtasksOperationFromArgs(args);
+  const accessDenied = isWindowsAccessDeniedError(error);
+  if (!accessDenied) {
     return error instanceof Error ? error.message : String(error);
   }
   const argsText = args.map(arg => (/\s/.test(arg) ? `"${arg}"` : arg)).join(" ");
-  return [
+  const guidance = [
     "Windows access denied while running Task Scheduler.",
     `Command: schtasks ${argsText}`,
     "Approve the Windows UAC prompt to install the background service, or run `ocx service install` from an elevated PowerShell window.",
   ].join(" ");
+  if (operation === "create") {
+    return `${guidance}\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`;
+  }
+  return guidance;
 }
 
-function windowsCmdQuote(value: string): string {
+export function toWindowsSchtasksError(error: unknown, args: string[]): WindowsSchtasksError {
+  if (error instanceof WindowsSchtasksError) return error;
+  const operation = schtasksOperationFromArgs(args);
+  const reason: WindowsSchtasksFailureReason = isWindowsAccessDeniedError(error) ? "access-denied" : "other";
+  return new WindowsSchtasksError(operation, reason, formatWindowsSchtasksError(error, args));
+}
+
+/**
+ * Quote one argument for Win32 CommandLineToArgvW / Start-Process -ArgumentList.
+ * Handles empty args, spaces, embedded quotes, and trailing backslashes.
+ */
+export function windowsCmdQuote(value: string): string {
+  if (value.length === 0) return '""';
   if (!/[\s"]/.test(value)) return value;
-  return `"${value.replace(/"/g, '\\"')}"`;
+  let result = '"';
+  let numBackslashes = 0;
+  for (const ch of value) {
+    if (ch === "\\") {
+      numBackslashes += 1;
+      continue;
+    }
+    if (ch === '"') {
+      result += "\\".repeat(numBackslashes * 2 + 1) + '"';
+      numBackslashes = 0;
+      continue;
+    }
+    result += "\\".repeat(numBackslashes) + ch;
+    numBackslashes = 0;
+  }
+  result += "\\".repeat(numBackslashes * 2) + '"';
+  return result;
 }
 
 /** Build one Win32 argument-list string for Start-Process -ArgumentList. */
@@ -56,10 +177,29 @@ function psSingleQuote(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
 }
 
-/** Launch a file with UAC elevation and wait for it to exit. */
+function appendBounded(current: string, chunk: string, limit = ELEVATION_OUTPUT_LIMIT): string {
+  if (current.length >= limit) return current;
+  const remaining = limit - current.length;
+  return current + chunk.slice(0, remaining);
+}
+
+export interface WindowsElevationResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Launch a file with UAC elevation and wait for it to exit.
+ * Throws WindowsElevationError for cancellation, timeout, launch failure, or signal termination.
+ * Returns the elevated process exit code for completed launches (including non-zero).
+ */
 export function runWindowsElevated(file: string, args: string[], timeoutMs = 120_000): Promise<number> {
   if (process.platform !== "win32") {
-    return Promise.reject(new Error("Windows elevation is only supported on Windows."));
+    return Promise.reject(new WindowsElevationError(
+      "launch-failed",
+      "Windows elevation is only supported on Windows.",
+    ));
   }
   const argumentList = buildWindowsElevatedArgumentList(args);
   const script = [
@@ -69,28 +209,84 @@ export function runWindowsElevated(file: string, args: string[], timeoutMs = 120
     "if ($null -eq $p) { exit 1223 }",
     "exit $p.ExitCode",
   ].join("");
+
   return new Promise((resolve, reject) => {
-    execFile(windowsPowerShell(), ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", script], {
-      encoding: "utf8",
-      timeout: timeoutMs,
-      windowsHide: true,
-      maxBuffer: 256 * 1024,
-    }, (error, _stdout, stderr) => {
-      if (!error) {
-        resolve(0);
+    let settled = false;
+    let timedOut = false;
+    let stdout = "";
+    let stderr = "";
+    let child: ChildProcess;
+
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn();
+    };
+
+    try {
+      child = elevationSpawn(
+        windowsPowerShell(),
+        ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", script],
+        {
+          windowsHide: true,
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+    } catch (error) {
+      reject(new WindowsElevationError(
+        "launch-failed",
+        error instanceof Error ? error.message : String(error),
+      ));
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try { child.kill(); } catch { /* ignore */ }
+      // The elevated child started by Start-Process -Verb RunAs may outlive this launcher.
+      settle(() => reject(new WindowsElevationError(
+        "timeout",
+        `Windows elevation timed out after ${timeoutMs}ms. The elevated Task Scheduler process may still be running.`,
+      )));
+    }, timeoutMs);
+
+    child.stdout?.setEncoding?.("utf8");
+    child.stderr?.setEncoding?.("utf8");
+    child.stdout?.on("data", (chunk: string | Buffer) => {
+      stdout = appendBounded(stdout, typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+    });
+    child.stderr?.on("data", (chunk: string | Buffer) => {
+      stderr = appendBounded(stderr, typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+    });
+
+    child.once("error", (error: NodeJS.ErrnoException) => {
+      settle(() => reject(new WindowsElevationError(
+        "launch-failed",
+        error.code === "ENOENT"
+          ? "Windows PowerShell was not found for elevation."
+          : (error.message || "Windows elevation failed to launch."),
+      )));
+    });
+
+    child.once("close", (code, signal) => {
+      if (timedOut) return;
+      const detail = stderr.trim() || stdout.trim();
+      if (typeof code === "number") {
+        if (code === 1223 || windowsUacCancelledText(detail)) {
+          settle(() => reject(new WindowsElevationError(
+            "cancelled",
+            "Windows administrator approval was required, but the UAC prompt was cancelled or denied.",
+          )));
+          return;
+        }
+        settle(() => resolve(code));
         return;
       }
-      const exec = error as NodeJS.ErrnoException & { status?: number | null };
-      if (exec.code === "ETIMEDOUT") {
-        reject(new Error(`Windows elevation timed out after ${timeoutMs}ms.`));
-        return;
-      }
-      if (typeof exec.status === "number") {
-        resolve(exec.status);
-        return;
-      }
-      const detail = stderr.trim() || exec.message;
-      reject(new Error(detail || "Windows elevation failed."));
+      settle(() => reject(new WindowsElevationError(
+        "terminated",
+        `Windows elevation terminated by ${signal ?? "unknown signal"}.`,
+      )));
     });
   });
 }

--- a/src/lib/windows-elevation.ts
+++ b/src/lib/windows-elevation.ts
@@ -338,7 +338,11 @@ export function startPowerShellCommand(commandScript: string): WindowsElevationE
     child.once("close", (code, signal) => {
       const detail = [stderr.trim(), stdout.trim()].filter(Boolean).join("\n");
       if (typeof code === "number") {
-        if (code === OCX_ELEVATED_UAC_CANCELLED || windowsUacCancelledText(detail)) {
+        // Only treat UAC-cancellation text as cancelled when the process did not succeed.
+        if (
+          code === OCX_ELEVATED_UAC_CANCELLED
+          || (code !== 0 && windowsUacCancelledText(detail))
+        ) {
           settle(() => reject(new WindowsElevationError(
             "cancelled",
             "Windows administrator approval was required, but the UAC prompt was cancelled or denied.",
@@ -373,7 +377,7 @@ export function runWindowsElevated(file: string, args: string[]): Promise<number
     argumentList.length > 0 ? ` -ArgumentList ${psSingleQuote(argumentList)}` : "",
     " -Verb RunAs -WindowStyle Hidden -PassThru -Wait;",
     `if ($null -eq $p) { exit ${OCX_ELEVATED_UAC_CANCELLED} }`,
-    "$null = $p.Handle",
+    "$null = $p.Handle;",
     // Missing ExitCode is a protocol failure for single-file elevation (not success).
     `if ($null -eq $p.ExitCode) { exit ${OCX_ELEVATED_PROTOCOL_FAILED} }`,
     "exit $p.ExitCode",
@@ -450,7 +454,7 @@ export function startElevatedSchtasksCreateAndRun(
     ]))}`,
     " -Verb RunAs -WindowStyle Hidden -PassThru -Wait;",
     `if ($null -eq $p) { exit ${OCX_ELEVATED_UAC_CANCELLED} }`,
-    "$null = $p.Handle",
+    "$null = $p.Handle;",
     `if ($null -eq $p.ExitCode) { exit ${OCX_ELEVATED_PROTOCOL_FAILED} }`,
     "exit $p.ExitCode",
   ].join("");

--- a/src/lib/windows-elevation.ts
+++ b/src/lib/windows-elevation.ts
@@ -105,8 +105,24 @@ function assertTrustedSystemExecutable(candidate: string, label: string): string
   return resolved;
 }
 
+type ElevationExeOverrides = { powershell?: string; schtasks?: string };
+let elevationExeOverridesForTests: ElevationExeOverrides | null = null;
+
+/**
+ * Test-only absolute executable overrides for Linux CI (which fakes win32 but has
+ * no kernel32/System32). Production resolution never consults this seam.
+ */
+export function setTrustedWindowsElevationExecutablesForTests(
+  next: ElevationExeOverrides | null,
+): void {
+  elevationExeOverridesForTests = next;
+}
+
 /** Absolute path to System32\\WindowsPowerShell\\v1.0\\powershell.exe from a trusted system directory. */
 export function resolveTrustedWindowsPowerShellExe(): string {
+  if (elevationExeOverridesForTests?.powershell) {
+    return elevationExeOverridesForTests.powershell;
+  }
   const candidate = join(
     resolveTrustedWindowsSystemDirectory(),
     "WindowsPowerShell",
@@ -118,6 +134,9 @@ export function resolveTrustedWindowsPowerShellExe(): string {
 
 /** Absolute path to System32\\schtasks.exe from a trusted system directory. */
 export function resolveTrustedWindowsSchtasksExe(): string {
+  if (elevationExeOverridesForTests?.schtasks) {
+    return elevationExeOverridesForTests.schtasks;
+  }
   const candidate = join(resolveTrustedWindowsSystemDirectory(), "schtasks.exe");
   return assertTrustedSystemExecutable(candidate, "schtasks.exe");
 }

--- a/src/lib/windows-elevation.ts
+++ b/src/lib/windows-elevation.ts
@@ -230,55 +230,92 @@ export interface WindowsElevationResult {
   stderr: string;
 }
 
-/** Spawn non-elevated PowerShell to run a -Command script; classify UAC/cancel/timeout outcomes. */
-function runPowerShellCommand(commandScript: string, timeoutMs: number): Promise<WindowsElevationResult> {
-  if (process.platform !== "win32") {
-    return Promise.reject(new WindowsElevationError(
-      "launch-failed",
-      "Windows elevation is only supported on Windows.",
-    ));
-  }
+export interface WindowsElevationExecution {
+  /** Settles only on launcher close/error — never killed by a request-level timeout. */
+  completion: Promise<WindowsElevationResult>;
+  launcherPid: number | null;
+}
 
+/** Request-facing wait for elevation; process observation continues separately. */
+export const ELEVATION_REQUEST_TIMEOUT_MS = 120_000;
+
+/**
+ * Wait for `promise` up to `timeoutMs` without cancelling it.
+ * On timeout the original promise remains active for late settlement.
+ */
+export function raceWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<{ status: "completed"; value: T } | { status: "timed-out" }> {
   return new Promise((resolve, reject) => {
     let settled = false;
-    let timedOut = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolve({ status: "timed-out" });
+    }, timeoutMs);
+    promise.then(
+      value => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve({ status: "completed", value });
+      },
+      error => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+/**
+ * Spawn non-elevated PowerShell to run a -Command script.
+ * Does not kill the launcher on any timeout — callers race a separate request timeout.
+ */
+export function startPowerShellCommand(commandScript: string): WindowsElevationExecution {
+  if (process.platform !== "win32") {
+    return {
+      launcherPid: null,
+      completion: Promise.reject(new WindowsElevationError(
+        "launch-failed",
+        "Windows elevation is only supported on Windows.",
+      )),
+    };
+  }
+
+  let child: ChildProcess;
+  try {
+    child = elevationSpawn(
+      windowsPowerShell(),
+      ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", commandScript],
+      {
+        windowsHide: true,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+  } catch (error) {
+    return {
+      launcherPid: null,
+      completion: Promise.reject(new WindowsElevationError(
+        "launch-failed",
+        error instanceof Error ? error.message : String(error),
+      )),
+    };
+  }
+
+  const completion = new Promise<WindowsElevationResult>((resolve, reject) => {
+    let settled = false;
     let stdout = "";
     let stderr = "";
-    let child: ChildProcess;
 
     const settle = (fn: () => void) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
       fn();
     };
-
-    try {
-      child = elevationSpawn(
-        windowsPowerShell(),
-        ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", commandScript],
-        {
-          windowsHide: true,
-          stdio: ["ignore", "pipe", "pipe"],
-        },
-      );
-    } catch (error) {
-      reject(new WindowsElevationError(
-        "launch-failed",
-        error instanceof Error ? error.message : String(error),
-      ));
-      return;
-    }
-
-    const timer = setTimeout(() => {
-      timedOut = true;
-      try { child.kill(); } catch { /* ignore */ }
-      // The elevated child started by Start-Process -Verb RunAs may outlive this launcher.
-      settle(() => reject(new WindowsElevationError(
-        "timeout",
-        `Windows elevation timed out after ${timeoutMs}ms. The elevated Task Scheduler process may still be running.`,
-      )));
-    }, timeoutMs);
 
     child.stdout?.setEncoding?.("utf8");
     child.stderr?.setEncoding?.("utf8");
@@ -299,7 +336,6 @@ function runPowerShellCommand(commandScript: string, timeoutMs: number): Promise
     });
 
     child.once("close", (code, signal) => {
-      if (timedOut) return;
       const detail = [stderr.trim(), stdout.trim()].filter(Boolean).join("\n");
       if (typeof code === "number") {
         if (code === OCX_ELEVATED_UAC_CANCELLED || windowsUacCancelledText(detail)) {
@@ -312,20 +348,23 @@ function runPowerShellCommand(commandScript: string, timeoutMs: number): Promise
         settle(() => resolve({ exitCode: code, stdout, stderr }));
         return;
       }
+      // Launcher terminated without an exit code — elevated child may still exist.
       settle(() => reject(new WindowsElevationError(
         "terminated",
         `Windows elevation terminated by ${signal ?? "unknown signal"}.`,
       )));
     });
   });
+
+  return { completion, launcherPid: child.pid ?? null };
 }
 
 /**
  * Launch a file with UAC elevation and wait for it to exit.
- * Throws WindowsElevationError for cancellation, timeout, launch failure, or signal termination.
+ * Throws WindowsElevationError for cancellation, launch failure, or signal termination.
  * Returns the elevated process exit code for completed launches (including non-zero).
  */
-export function runWindowsElevated(file: string, args: string[], timeoutMs = 120_000): Promise<number> {
+export function runWindowsElevated(file: string, args: string[]): Promise<number> {
   const argumentList = buildWindowsElevatedArgumentList(args);
   // Touch .Handle so Windows PowerShell 5.1 keeps a process handle; ExitCode can
   // otherwise stay $null after -Wait and `exit $null` becomes exit 0 (false success).
@@ -340,7 +379,7 @@ export function runWindowsElevated(file: string, args: string[], timeoutMs = 120
     "exit $p.ExitCode",
   ].join("");
 
-  return runPowerShellCommand(script, timeoutMs).then(result => result.exitCode);
+  return startPowerShellCommand(script).completion.then(result => result.exitCode);
 }
 
 /**
@@ -383,20 +422,22 @@ export interface ElevatedSchtasksCreateAndRunResult {
   stderr: string;
 }
 
+export interface ElevatedSchtasksCreateAndRunExecution {
+  completion: Promise<ElevatedSchtasksCreateAndRunResult>;
+  launcherPid: number | null;
+}
+
 /**
- * Create, run, and (on /run failure) roll back the scheduler task inside one elevated
- * PowerShell process — one UAC prompt, no user-controlled result file.
- * Throws WindowsElevationError for UAC cancel/timeout/launch/signal failures.
+ * Start create/run/rollback inside one elevated PowerShell process (one UAC prompt).
+ * The completion promise outlives any request-level timeout — do not kill the launcher.
  */
-export async function runElevatedSchtasksCreateAndRun(
+export function startElevatedSchtasksCreateAndRun(
   schtasksPath: string,
   createArgs: string[],
   runArgs: string[],
   deleteArgs: string[],
-  timeoutMs = 120_000,
-): Promise<ElevatedSchtasksCreateAndRunResult> {
+): ElevatedSchtasksCreateAndRunExecution {
   const inner = buildElevatedSchtasksCreateAndRunScript(schtasksPath, createArgs, runArgs, deleteArgs);
-  // One Start-Process -Verb RunAs elevates PowerShell; create/run/rollback execute inside that process.
   const launcher = [
     `$p = Start-Process -FilePath ${psSingleQuote(windowsPowerShell())}`,
     ` -ArgumentList ${psSingleQuote(buildWindowsElevatedArgumentList([
@@ -414,11 +455,28 @@ export async function runElevatedSchtasksCreateAndRun(
     "exit $p.ExitCode",
   ].join("");
 
-  const result = await runPowerShellCommand(launcher, timeoutMs);
+  const started = startPowerShellCommand(launcher);
   return {
-    outcome: classifyElevatedSchedulerExitCode(result.exitCode),
-    exitCode: result.exitCode,
-    stdout: result.stdout,
-    stderr: result.stderr,
+    launcherPid: started.launcherPid,
+    completion: started.completion.then(result => ({
+      outcome: classifyElevatedSchedulerExitCode(result.exitCode),
+      exitCode: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    })),
   };
+}
+
+/**
+ * Create, run, and (on /run failure) roll back the scheduler task inside one elevated
+ * PowerShell process — one UAC prompt, no user-controlled result file.
+ * Waits for the full elevated transaction (no request-timeout kill).
+ */
+export function runElevatedSchtasksCreateAndRun(
+  schtasksPath: string,
+  createArgs: string[],
+  runArgs: string[],
+  deleteArgs: string[],
+): Promise<ElevatedSchtasksCreateAndRunResult> {
+  return startElevatedSchtasksCreateAndRun(schtasksPath, createArgs, runArgs, deleteArgs).completion;
 }

--- a/src/lib/windows-elevation.ts
+++ b/src/lib/windows-elevation.ts
@@ -202,11 +202,15 @@ export function runWindowsElevated(file: string, args: string[], timeoutMs = 120
     ));
   }
   const argumentList = buildWindowsElevatedArgumentList(args);
+  // Touch .Handle so Windows PowerShell 5.1 keeps a process handle; ExitCode can
+  // otherwise stay $null after -Wait and `exit $null` becomes exit 0 (false success).
   const script = [
     `$p = Start-Process -FilePath ${psSingleQuote(file)}`,
     argumentList.length > 0 ? ` -ArgumentList ${psSingleQuote(argumentList)}` : "",
     " -Verb RunAs -WindowStyle Hidden -PassThru -Wait;",
     "if ($null -eq $p) { exit 1223 }",
+    "$null = $p.Handle",
+    "if ($null -eq $p.ExitCode) { exit 1 }",
     "exit $p.ExitCode",
   ].join("");
 

--- a/src/lib/windows-elevation.ts
+++ b/src/lib/windows-elevation.ts
@@ -1,6 +1,8 @@
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { randomBytes } from "node:crypto";
 
 type ElevationSpawn = (
   command: string,
@@ -18,6 +20,9 @@ export function setWindowsElevationSpawnForTests(next: ElevationSpawn | null): v
 /** Stable machine-readable marker for a denied `schtasks /create`. Crosses the CLI→proxy boundary. */
 export const WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER =
   "OCX_ERROR_CODE=WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED";
+
+export const OCX_SCHTASKS_CREATE_EXIT_PREFIX = "OCX_SCHTASKS_CREATE_EXIT=";
+export const OCX_SCHTASKS_RUN_EXIT_PREFIX = "OCX_SCHTASKS_RUN_EXIT=";
 
 export type WindowsSchtasksOperation = "create" | "run" | "query" | "delete" | "end" | "other";
 export type WindowsSchtasksFailureReason = "access-denied" | "other";
@@ -189,30 +194,21 @@ export interface WindowsElevationResult {
   stderr: string;
 }
 
-/**
- * Launch a file with UAC elevation and wait for it to exit.
- * Throws WindowsElevationError for cancellation, timeout, launch failure, or signal termination.
- * Returns the elevated process exit code for completed launches (including non-zero).
- */
-export function runWindowsElevated(file: string, args: string[], timeoutMs = 120_000): Promise<number> {
+function parsePrefixedExit(output: string, prefix: string): number | null {
+  const match = output.match(new RegExp(`${prefix}(-?\\d+)`, "m"));
+  if (!match) return null;
+  const value = Number(match[1]);
+  return Number.isFinite(value) ? value : null;
+}
+
+/** Spawn non-elevated PowerShell to run a -Command script; classify UAC/cancel/timeout outcomes. */
+function runPowerShellCommand(commandScript: string, timeoutMs: number): Promise<WindowsElevationResult> {
   if (process.platform !== "win32") {
     return Promise.reject(new WindowsElevationError(
       "launch-failed",
       "Windows elevation is only supported on Windows.",
     ));
   }
-  const argumentList = buildWindowsElevatedArgumentList(args);
-  // Touch .Handle so Windows PowerShell 5.1 keeps a process handle; ExitCode can
-  // otherwise stay $null after -Wait and `exit $null` becomes exit 0 (false success).
-  const script = [
-    `$p = Start-Process -FilePath ${psSingleQuote(file)}`,
-    argumentList.length > 0 ? ` -ArgumentList ${psSingleQuote(argumentList)}` : "",
-    " -Verb RunAs -WindowStyle Hidden -PassThru -Wait;",
-    "if ($null -eq $p) { exit 1223 }",
-    "$null = $p.Handle",
-    "if ($null -eq $p.ExitCode) { exit 1 }",
-    "exit $p.ExitCode",
-  ].join("");
 
   return new Promise((resolve, reject) => {
     let settled = false;
@@ -231,7 +227,7 @@ export function runWindowsElevated(file: string, args: string[], timeoutMs = 120
     try {
       child = elevationSpawn(
         windowsPowerShell(),
-        ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", script],
+        ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", commandScript],
         {
           windowsHide: true,
           stdio: ["ignore", "pipe", "pipe"],
@@ -275,7 +271,7 @@ export function runWindowsElevated(file: string, args: string[], timeoutMs = 120
 
     child.once("close", (code, signal) => {
       if (timedOut) return;
-      const detail = stderr.trim() || stdout.trim();
+      const detail = [stderr.trim(), stdout.trim()].filter(Boolean).join("\n");
       if (typeof code === "number") {
         if (code === 1223 || windowsUacCancelledText(detail)) {
           settle(() => reject(new WindowsElevationError(
@@ -284,7 +280,7 @@ export function runWindowsElevated(file: string, args: string[], timeoutMs = 120
           )));
           return;
         }
-        settle(() => resolve(code));
+        settle(() => resolve({ exitCode: code, stdout, stderr }));
         return;
       }
       settle(() => reject(new WindowsElevationError(
@@ -293,4 +289,129 @@ export function runWindowsElevated(file: string, args: string[], timeoutMs = 120
       )));
     });
   });
+}
+
+/**
+ * Launch a file with UAC elevation and wait for it to exit.
+ * Throws WindowsElevationError for cancellation, timeout, launch failure, or signal termination.
+ * Returns the elevated process exit code for completed launches (including non-zero).
+ */
+export function runWindowsElevated(file: string, args: string[], timeoutMs = 120_000): Promise<number> {
+  const argumentList = buildWindowsElevatedArgumentList(args);
+  // Touch .Handle so Windows PowerShell 5.1 keeps a process handle; ExitCode can
+  // otherwise stay $null after -Wait and `exit $null` becomes exit 0 (false success).
+  const script = [
+    `$p = Start-Process -FilePath ${psSingleQuote(file)}`,
+    argumentList.length > 0 ? ` -ArgumentList ${psSingleQuote(argumentList)}` : "",
+    " -Verb RunAs -WindowStyle Hidden -PassThru -Wait;",
+    "if ($null -eq $p) { exit 1223 }",
+    "$null = $p.Handle",
+    "if ($null -eq $p.ExitCode) { exit 1 }",
+    "exit $p.ExitCode",
+  ].join("");
+
+  return runPowerShellCommand(script, timeoutMs).then(result => result.exitCode);
+}
+
+export interface ElevatedSchtasksCreateAndRunResult {
+  createExitCode: number;
+  /** null when /run was not attempted because /create failed. */
+  runExitCode: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/** Build the elevated (post-UAC) script that runs schtasks /create then /run without a second prompt. */
+export function buildElevatedSchtasksCreateAndRunScript(
+  schtasksPath: string,
+  createArgs: string[],
+  runArgs: string[],
+  resultPath: string,
+): string {
+  const createList = buildWindowsElevatedArgumentList(createArgs);
+  const runList = buildWindowsElevatedArgumentList(runArgs);
+  const createPrefix = OCX_SCHTASKS_CREATE_EXIT_PREFIX;
+  const runPrefix = OCX_SCHTASKS_RUN_EXIT_PREFIX;
+  return [
+    `$schtasks = ${psSingleQuote(schtasksPath)}`,
+    `$resultPath = ${psSingleQuote(resultPath)}`,
+    "function Invoke-OcxSchtasks([string]$ArgList) {",
+    "  $p = Start-Process -FilePath $schtasks -ArgumentList $ArgList -Wait -PassThru -WindowStyle Hidden",
+    "  if ($null -eq $p) { return 1 }",
+    "  $null = $p.Handle",
+    "  if ($null -eq $p.ExitCode) { return 1 }",
+    "  return [int]$p.ExitCode",
+    "}",
+    "function Write-OcxResult([int]$CreateCode, $RunCode) {",
+    `  $lines = @('${createPrefix}' + $CreateCode)`,
+    `  if ($null -ne $RunCode) { $lines += ('${runPrefix}' + $RunCode) }`,
+    "  Set-Content -LiteralPath $resultPath -Value ($lines -join [Environment]::NewLine) -Encoding ascii",
+    "}",
+    `$createCode = Invoke-OcxSchtasks ${psSingleQuote(createList)}`,
+    "if ($createCode -ne 0) { Write-OcxResult $createCode $null; exit $createCode }",
+    `$runCode = Invoke-OcxSchtasks ${psSingleQuote(runList)}`,
+    "Write-OcxResult $createCode $runCode",
+    "exit $runCode",
+  ].join("; ");
+}
+
+function readElevatedResultFile(resultPath: string): string {
+  try {
+    if (!existsSync(resultPath)) return "";
+    return readFileSync(resultPath, "utf8");
+  } catch {
+    return "";
+  } finally {
+    try { if (existsSync(resultPath)) unlinkSync(resultPath); } catch { /* ignore */ }
+  }
+}
+
+/**
+ * Create and run the scheduler task inside one elevated PowerShell process (one UAC prompt).
+ * Throws WindowsElevationError for UAC cancel/timeout/launch/signal failures.
+ */
+export async function runElevatedSchtasksCreateAndRun(
+  schtasksPath: string,
+  createArgs: string[],
+  runArgs: string[],
+  timeoutMs = 120_000,
+): Promise<ElevatedSchtasksCreateAndRunResult> {
+  const resultPath = join(tmpdir(), `ocx-elev-schtasks-${randomBytes(8).toString("hex")}.txt`);
+  const inner = buildElevatedSchtasksCreateAndRunScript(schtasksPath, createArgs, runArgs, resultPath);
+  // One Start-Process -Verb RunAs elevates PowerShell; create and run execute inside that process.
+  const launcher = [
+    `$p = Start-Process -FilePath ${psSingleQuote(windowsPowerShell())}`,
+    ` -ArgumentList ${psSingleQuote(buildWindowsElevatedArgumentList([
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-Command",
+      inner,
+    ]))}`,
+    " -Verb RunAs -WindowStyle Hidden -PassThru -Wait;",
+    "if ($null -eq $p) { exit 1223 }",
+    "$null = $p.Handle",
+    "if ($null -eq $p.ExitCode) { exit 1 }",
+    "exit $p.ExitCode",
+  ].join("");
+
+  try {
+    const result = await runPowerShellCommand(launcher, timeoutMs);
+    const markerText = readElevatedResultFile(resultPath);
+    const combined = `${markerText}\n${result.stdout}\n${result.stderr}`;
+    const createExitCode = parsePrefixedExit(combined, OCX_SCHTASKS_CREATE_EXIT_PREFIX) ?? result.exitCode;
+    const runExitCode = createExitCode === 0
+      ? (parsePrefixedExit(combined, OCX_SCHTASKS_RUN_EXIT_PREFIX) ?? result.exitCode)
+      : null;
+    return {
+      createExitCode,
+      runExitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+  } catch (error) {
+    readElevatedResultFile(resultPath);
+    throw error;
+  }
 }

--- a/src/lib/windows-elevation.ts
+++ b/src/lib/windows-elevation.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { existsSync } from "node:fs";
-import { join, resolve as resolvePath } from "node:path";
+import { isAbsolute, join, relative, resolve as resolvePath, sep } from "node:path";
 import { dlopen, ptr, type Pointer } from "bun:ffi";
 
 type ElevationSpawn = (
@@ -91,12 +91,23 @@ export function resolveTrustedWindowsSystemDirectory(): string {
   throw new Error("GetSystemDirectoryW required a system directory path larger than expected.");
 }
 
+/**
+ * True when `candidatePath` is the trusted directory itself, or a contained child.
+ * Uses path.relative so containment works with host-native separators (Linux/macOS CI
+ * hosts fake win32 with `/tmp/...` paths; a literal `\\` prefix check rejects them).
+ */
+function isPathInsideTrustedDirectory(trustedDirectory: string, candidatePath: string): boolean {
+  const relativePath = relative(trustedDirectory, candidatePath);
+  return (
+    relativePath === "" ||
+    (!isAbsolute(relativePath) && relativePath !== ".." && !relativePath.startsWith(`..${sep}`))
+  );
+}
+
 function assertTrustedSystemExecutable(candidate: string, label: string): string {
   const systemDir = resolveTrustedWindowsSystemDirectory();
   const resolved = resolvePath(candidate);
-  const systemPrefix = systemDir.toLowerCase().replace(/[/\\]+$/, "") + "\\";
-  const resolvedLower = resolved.toLowerCase();
-  if (resolvedLower !== systemDir.toLowerCase() && !resolvedLower.startsWith(systemPrefix)) {
+  if (!isPathInsideTrustedDirectory(systemDir, resolved)) {
     throw new Error(`${label} resolved outside the trusted Windows system directory.`);
   }
   if (!existsSync(resolved)) {

--- a/src/lib/windows-elevation.ts
+++ b/src/lib/windows-elevation.ts
@@ -1,8 +1,6 @@
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
-import { existsSync, readFileSync, unlinkSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
-import { randomBytes } from "node:crypto";
 
 type ElevationSpawn = (
   command: string,
@@ -21,8 +19,29 @@ export function setWindowsElevationSpawnForTests(next: ElevationSpawn | null): v
 export const WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER =
   "OCX_ERROR_CODE=WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED";
 
-export const OCX_SCHTASKS_CREATE_EXIT_PREFIX = "OCX_SCHTASKS_CREATE_EXIT=";
-export const OCX_SCHTASKS_RUN_EXIT_PREFIX = "OCX_SCHTASKS_RUN_EXIT=";
+/**
+ * Reserved elevated-scheduler protocol exit codes.
+ * These are OpenCodex-owned values returned by the elevated PowerShell transaction.
+ * They must never collide with UAC cancellation (1223).
+ *
+ * The elevated script never exits with raw schtasks codes — only these protocol values —
+ * so the parent can classify the transaction without a user-controlled result file.
+ */
+export const OCX_ELEVATED_SUCCESS = 0;
+export const OCX_ELEVATED_CREATE_FAILED = 10;
+export const OCX_ELEVATED_RUN_FAILED_ROLLED_BACK = 11;
+export const OCX_ELEVATED_RUN_FAILED_ROLLBACK_FAILED = 12;
+export const OCX_ELEVATED_PROTOCOL_FAILED = 13;
+/** Windows ERROR_CANCELLED — reserved for UAC denial; never emitted by the elevated script. */
+export const OCX_ELEVATED_UAC_CANCELLED = 1223;
+
+export const OCX_ELEVATED_PROTOCOL_CODES = [
+  OCX_ELEVATED_SUCCESS,
+  OCX_ELEVATED_CREATE_FAILED,
+  OCX_ELEVATED_RUN_FAILED_ROLLED_BACK,
+  OCX_ELEVATED_RUN_FAILED_ROLLBACK_FAILED,
+  OCX_ELEVATED_PROTOCOL_FAILED,
+] as const;
 
 export type WindowsSchtasksOperation = "create" | "run" | "query" | "delete" | "end" | "other";
 export type WindowsSchtasksFailureReason = "access-denied" | "other";
@@ -33,6 +52,13 @@ export type WindowsElevationFailureReason =
   | "launch-failed"
   | "child-failed"
   | "terminated";
+
+export type ElevatedSchedulerOutcome =
+  | "success"
+  | "create-failed"
+  | "run-failed-rolled-back"
+  | "run-failed-rollback-failed"
+  | "protocol-failed";
 
 const ELEVATION_OUTPUT_LIMIT = 256 * 1024;
 
@@ -173,6 +199,16 @@ export function buildWindowsElevatedArgumentList(args: string[]): string {
   return args.map(windowsCmdQuote).join(" ");
 }
 
+/** Classify an elevated-process exit code into a stable scheduler outcome. */
+export function classifyElevatedSchedulerExitCode(exitCode: number): ElevatedSchedulerOutcome {
+  if (exitCode === OCX_ELEVATED_SUCCESS) return "success";
+  if (exitCode === OCX_ELEVATED_CREATE_FAILED) return "create-failed";
+  if (exitCode === OCX_ELEVATED_RUN_FAILED_ROLLED_BACK) return "run-failed-rolled-back";
+  if (exitCode === OCX_ELEVATED_RUN_FAILED_ROLLBACK_FAILED) return "run-failed-rollback-failed";
+  // Malformed / unexpected / missing-ExitCode-normalized codes fail closed.
+  return "protocol-failed";
+}
+
 function windowsPowerShell(): string {
   const candidate = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
   return existsSync(candidate) ? candidate : "powershell.exe";
@@ -192,13 +228,6 @@ export interface WindowsElevationResult {
   exitCode: number;
   stdout: string;
   stderr: string;
-}
-
-function parsePrefixedExit(output: string, prefix: string): number | null {
-  const match = output.match(new RegExp(`${prefix}(-?\\d+)`, "m"));
-  if (!match) return null;
-  const value = Number(match[1]);
-  return Number.isFinite(value) ? value : null;
 }
 
 /** Spawn non-elevated PowerShell to run a -Command script; classify UAC/cancel/timeout outcomes. */
@@ -273,7 +302,7 @@ function runPowerShellCommand(commandScript: string, timeoutMs: number): Promise
       if (timedOut) return;
       const detail = [stderr.trim(), stdout.trim()].filter(Boolean).join("\n");
       if (typeof code === "number") {
-        if (code === 1223 || windowsUacCancelledText(detail)) {
+        if (code === OCX_ELEVATED_UAC_CANCELLED || windowsUacCancelledText(detail)) {
           settle(() => reject(new WindowsElevationError(
             "cancelled",
             "Windows administrator approval was required, but the UAC prompt was cancelled or denied.",
@@ -304,37 +333,32 @@ export function runWindowsElevated(file: string, args: string[], timeoutMs = 120
     `$p = Start-Process -FilePath ${psSingleQuote(file)}`,
     argumentList.length > 0 ? ` -ArgumentList ${psSingleQuote(argumentList)}` : "",
     " -Verb RunAs -WindowStyle Hidden -PassThru -Wait;",
-    "if ($null -eq $p) { exit 1223 }",
+    `if ($null -eq $p) { exit ${OCX_ELEVATED_UAC_CANCELLED} }`,
     "$null = $p.Handle",
-    "if ($null -eq $p.ExitCode) { exit 1 }",
+    // Missing ExitCode is a protocol failure for single-file elevation (not success).
+    `if ($null -eq $p.ExitCode) { exit ${OCX_ELEVATED_PROTOCOL_FAILED} }`,
     "exit $p.ExitCode",
   ].join("");
 
   return runPowerShellCommand(script, timeoutMs).then(result => result.exitCode);
 }
 
-export interface ElevatedSchtasksCreateAndRunResult {
-  createExitCode: number;
-  /** null when /run was not attempted because /create failed. */
-  runExitCode: number | null;
-  stdout: string;
-  stderr: string;
-}
-
-/** Build the elevated (post-UAC) script that runs schtasks /create then /run without a second prompt. */
+/**
+ * Build the elevated (post-UAC) script: create → run → optional delete rollback.
+ * Returns only OpenCodex protocol exit codes (never raw schtasks codes, never 1223).
+ * Does not write through any user-controlled pathname.
+ */
 export function buildElevatedSchtasksCreateAndRunScript(
   schtasksPath: string,
   createArgs: string[],
   runArgs: string[],
-  resultPath: string,
+  deleteArgs: string[],
 ): string {
   const createList = buildWindowsElevatedArgumentList(createArgs);
   const runList = buildWindowsElevatedArgumentList(runArgs);
-  const createPrefix = OCX_SCHTASKS_CREATE_EXIT_PREFIX;
-  const runPrefix = OCX_SCHTASKS_RUN_EXIT_PREFIX;
+  const deleteList = buildWindowsElevatedArgumentList(deleteArgs);
   return [
     `$schtasks = ${psSingleQuote(schtasksPath)}`,
-    `$resultPath = ${psSingleQuote(resultPath)}`,
     "function Invoke-OcxSchtasks([string]$ArgList) {",
     "  $p = Start-Process -FilePath $schtasks -ArgumentList $ArgList -Wait -PassThru -WindowStyle Hidden",
     "  if ($null -eq $p) { return 1 }",
@@ -342,43 +366,37 @@ export function buildElevatedSchtasksCreateAndRunScript(
     "  if ($null -eq $p.ExitCode) { return 1 }",
     "  return [int]$p.ExitCode",
     "}",
-    "function Write-OcxResult([int]$CreateCode, $RunCode) {",
-    `  $lines = @('${createPrefix}' + $CreateCode)`,
-    `  if ($null -ne $RunCode) { $lines += ('${runPrefix}' + $RunCode) }`,
-    "  Set-Content -LiteralPath $resultPath -Value ($lines -join [Environment]::NewLine) -Encoding ascii",
-    "}",
     `$createCode = Invoke-OcxSchtasks ${psSingleQuote(createList)}`,
-    "if ($createCode -ne 0) { Write-OcxResult $createCode $null; exit $createCode }",
+    `if ($createCode -ne 0) { exit ${OCX_ELEVATED_CREATE_FAILED} }`,
     `$runCode = Invoke-OcxSchtasks ${psSingleQuote(runList)}`,
-    "Write-OcxResult $createCode $runCode",
-    "exit $runCode",
+    `if ($runCode -eq 0) { exit ${OCX_ELEVATED_SUCCESS} }`,
+    `$deleteCode = Invoke-OcxSchtasks ${psSingleQuote(deleteList)}`,
+    `if ($deleteCode -eq 0) { exit ${OCX_ELEVATED_RUN_FAILED_ROLLED_BACK} }`,
+    `exit ${OCX_ELEVATED_RUN_FAILED_ROLLBACK_FAILED}`,
   ].join("; ");
 }
 
-function readElevatedResultFile(resultPath: string): string {
-  try {
-    if (!existsSync(resultPath)) return "";
-    return readFileSync(resultPath, "utf8");
-  } catch {
-    return "";
-  } finally {
-    try { if (existsSync(resultPath)) unlinkSync(resultPath); } catch { /* ignore */ }
-  }
+export interface ElevatedSchtasksCreateAndRunResult {
+  outcome: ElevatedSchedulerOutcome;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
 }
 
 /**
- * Create and run the scheduler task inside one elevated PowerShell process (one UAC prompt).
+ * Create, run, and (on /run failure) roll back the scheduler task inside one elevated
+ * PowerShell process — one UAC prompt, no user-controlled result file.
  * Throws WindowsElevationError for UAC cancel/timeout/launch/signal failures.
  */
 export async function runElevatedSchtasksCreateAndRun(
   schtasksPath: string,
   createArgs: string[],
   runArgs: string[],
+  deleteArgs: string[],
   timeoutMs = 120_000,
 ): Promise<ElevatedSchtasksCreateAndRunResult> {
-  const resultPath = join(tmpdir(), `ocx-elev-schtasks-${randomBytes(8).toString("hex")}.txt`);
-  const inner = buildElevatedSchtasksCreateAndRunScript(schtasksPath, createArgs, runArgs, resultPath);
-  // One Start-Process -Verb RunAs elevates PowerShell; create and run execute inside that process.
+  const inner = buildElevatedSchtasksCreateAndRunScript(schtasksPath, createArgs, runArgs, deleteArgs);
+  // One Start-Process -Verb RunAs elevates PowerShell; create/run/rollback execute inside that process.
   const launcher = [
     `$p = Start-Process -FilePath ${psSingleQuote(windowsPowerShell())}`,
     ` -ArgumentList ${psSingleQuote(buildWindowsElevatedArgumentList([
@@ -390,28 +408,17 @@ export async function runElevatedSchtasksCreateAndRun(
       inner,
     ]))}`,
     " -Verb RunAs -WindowStyle Hidden -PassThru -Wait;",
-    "if ($null -eq $p) { exit 1223 }",
+    `if ($null -eq $p) { exit ${OCX_ELEVATED_UAC_CANCELLED} }`,
     "$null = $p.Handle",
-    "if ($null -eq $p.ExitCode) { exit 1 }",
+    `if ($null -eq $p.ExitCode) { exit ${OCX_ELEVATED_PROTOCOL_FAILED} }`,
     "exit $p.ExitCode",
   ].join("");
 
-  try {
-    const result = await runPowerShellCommand(launcher, timeoutMs);
-    const markerText = readElevatedResultFile(resultPath);
-    const combined = `${markerText}\n${result.stdout}\n${result.stderr}`;
-    const createExitCode = parsePrefixedExit(combined, OCX_SCHTASKS_CREATE_EXIT_PREFIX) ?? result.exitCode;
-    const runExitCode = createExitCode === 0
-      ? (parsePrefixedExit(combined, OCX_SCHTASKS_RUN_EXIT_PREFIX) ?? result.exitCode)
-      : null;
-    return {
-      createExitCode,
-      runExitCode,
-      stdout: result.stdout,
-      stderr: result.stderr,
-    };
-  } catch (error) {
-    readElevatedResultFile(resultPath);
-    throw error;
-  }
+  const result = await runPowerShellCommand(launcher, timeoutMs);
+  return {
+    outcome: classifyElevatedSchedulerExitCode(result.exitCode),
+    exitCode: result.exitCode,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
 }

--- a/src/server/startup-action-control.ts
+++ b/src/server/startup-action-control.ts
@@ -1,8 +1,8 @@
 import { execFile } from "node:child_process";
 import { join } from "node:path";
 import { durableBunPath } from "../lib/bun-runtime";
-import { isWindowsAccessDenied, runWindowsElevatedCommand } from "../lib/windows-elevation";
-import { windowsSchedulerTaskInstalled } from "../service";
+import { isWindowsAccessDenied } from "../lib/windows-elevation";
+import { finalizeWindowsSchedulerServiceRegistration, windowsSchedulerTaskInstalled } from "../service";
 
 export type StartupInstallAction = "install-service" | "install-shim";
 let activeInstall: StartupInstallAction | null = null;
@@ -17,19 +17,10 @@ function installFailureDetail(stdout: string, stderr: string, error: Error): str
   return stderr.trim() || stdout.trim() || error.message;
 }
 
-function runCliInstall(action: StartupInstallAction, elevated = false): Promise<{ stdout: string; stderr: string }> {
+function runCliInstall(action: StartupInstallAction): Promise<{ stdout: string; stderr: string }> {
   const bun = durableBunPath();
   const cli = join(import.meta.dir, "..", "cli", "index.ts");
   const argv = [cli, ...startupInstallArgv(action)];
-  if (elevated && process.platform === "win32") {
-    return runWindowsElevatedCommand(bun, argv).then(exitCode => {
-      if (exitCode === 0) return { stdout: "", stderr: "" };
-      if (exitCode === 1223) {
-        throw new Error("Windows administrator approval was required to install the background service, but the UAC prompt was cancelled or denied.");
-      }
-      throw new Error(`Background service install failed with exit code ${exitCode}.`);
-    });
-  }
   return new Promise((resolve, reject) => {
     execFile(bun, argv, {
       encoding: "utf8",
@@ -57,7 +48,7 @@ export function runStartupInstallAction(action: StartupInstallAction): Promise<{
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       if (action === "install-service" && process.platform === "win32" && isWindowsAccessDenied(detail)) {
-        await runCliInstall(action, true);
+        await finalizeWindowsSchedulerServiceRegistration();
         if (!windowsSchedulerTaskInstalled()) {
           throw new Error("Background service install still failed after requesting administrator approval.");
         }

--- a/src/server/startup-action-control.ts
+++ b/src/server/startup-action-control.ts
@@ -1,6 +1,8 @@
 import { execFile } from "node:child_process";
 import { join } from "node:path";
 import { durableBunPath } from "../lib/bun-runtime";
+import { isWindowsAccessDenied, runWindowsElevatedCommand } from "../lib/windows-elevation";
+import { windowsSchedulerTaskInstalled } from "../service";
 
 export type StartupInstallAction = "install-service" | "install-shim";
 let activeInstall: StartupInstallAction | null = null;
@@ -11,14 +13,25 @@ export function startupInstallArgv(action: StartupInstallAction): string[] {
     : ["codex-shim", "install"];
 }
 
-/** Execute the existing fixed CLI installer outside the proxy event loop. */
-export function runStartupInstallAction(action: StartupInstallAction): Promise<{ message: string }> {
-  if (activeInstall) return Promise.reject(new Error(`Another startup installation is already running: ${activeInstall}`));
-  activeInstall = action;
+function installFailureDetail(stdout: string, stderr: string, error: Error): string {
+  return stderr.trim() || stdout.trim() || error.message;
+}
+
+function runCliInstall(action: StartupInstallAction, elevated = false): Promise<{ stdout: string; stderr: string }> {
   const bun = durableBunPath();
   const cli = join(import.meta.dir, "..", "cli", "index.ts");
-  const operation = new Promise<{ message: string }>((resolve, reject) => {
-    execFile(bun, [cli, ...startupInstallArgv(action)], {
+  const argv = [cli, ...startupInstallArgv(action)];
+  if (elevated && process.platform === "win32") {
+    return runWindowsElevatedCommand(bun, argv).then(exitCode => {
+      if (exitCode === 0) return { stdout: "", stderr: "" };
+      if (exitCode === 1223) {
+        throw new Error("Windows administrator approval was required to install the background service, but the UAC prompt was cancelled or denied.");
+      }
+      throw new Error(`Background service install failed with exit code ${exitCode}.`);
+    });
+  }
+  return new Promise((resolve, reject) => {
+    execFile(bun, argv, {
       encoding: "utf8",
       env: process.env,
       timeout: 60_000,
@@ -26,16 +39,37 @@ export function runStartupInstallAction(action: StartupInstallAction): Promise<{
       maxBuffer: 256 * 1024,
     }, (error, stdout, stderr) => {
       if (error) {
-        const detail = stderr.trim() || stdout.trim() || error.message;
-        reject(new Error(detail.slice(0, 2_000)));
+        reject(new Error(installFailureDetail(stdout, stderr, error)));
         return;
       }
-      resolve({
-        message: action === "install-service"
-          ? "Background service installed."
-          : "Codex launcher shim installed.",
-      });
+      resolve({ stdout, stderr });
     });
   });
+}
+
+/** Execute the existing fixed CLI installer outside the proxy event loop. */
+export function runStartupInstallAction(action: StartupInstallAction): Promise<{ message: string }> {
+  if (activeInstall) return Promise.reject(new Error(`Another startup installation is already running: ${activeInstall}`));
+  activeInstall = action;
+  const operation = (async () => {
+    try {
+      await runCliInstall(action);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      if (action === "install-service" && process.platform === "win32" && isWindowsAccessDenied(detail)) {
+        await runCliInstall(action, true);
+        if (!windowsSchedulerTaskInstalled()) {
+          throw new Error("Background service install still failed after requesting administrator approval.");
+        }
+      } else {
+        throw error;
+      }
+    }
+    return {
+      message: action === "install-service"
+        ? "Background service installed."
+        : "Codex launcher shim installed.",
+    };
+  })();
   return operation.finally(() => { activeInstall = null; });
 }

--- a/src/server/startup-action-control.ts
+++ b/src/server/startup-action-control.ts
@@ -11,6 +11,7 @@ import {
   type ElevatedReconciliationOutcome,
   type FinalizeWindowsSchedulerOptions,
   type FinalizeWindowsSchedulerResult,
+  type WindowsSchedulerTaskProbe,
 } from "../service";
 
 export type StartupInstallAction = "install-service" | "install-shim";
@@ -75,18 +76,25 @@ export function ownsStartupInstallAttempt(attemptId: string): boolean {
 
 /**
  * Clear a partial-install block after the operator has cleaned up Task Scheduler.
- * Does not itself delete the task — callers must verify absence first.
+ * Requires an observed probe and clears only when the task is proven absent.
+ * Does not itself delete the task.
  */
-export function clearStartupInstallPartialBlock(options?: {
-  taskInstalled?: boolean;
+export function clearStartupInstallPartialBlock(options: {
+  probe: WindowsSchedulerTaskProbe;
 }): { cleared: boolean; detail: string } {
   if (installState.status !== "blocked") {
     return { cleared: false, detail: `Install lock is ${installState.status}, not blocked.` };
   }
-  if (options?.taskInstalled) {
+  if (options.probe.status === "present") {
     return {
       cleared: false,
       detail: "OpenCodex Task Scheduler task is still present; remove it before clearing the block.",
+    };
+  }
+  if (options.probe.status === "unknown") {
+    return {
+      cleared: false,
+      detail: `Could not verify Task Scheduler absence (${options.probe.detail}); not clearing the block.`,
     };
   }
   installState = { status: "idle" };

--- a/src/server/startup-action-control.ts
+++ b/src/server/startup-action-control.ts
@@ -252,9 +252,16 @@ export function runStartupInstallAction(action: StartupInstallAction): Promise<{
             timedOutAt: Date.now(),
             reconciliation: finalized.reconciliation,
           };
-          void finalized.reconciliation.then(outcome => {
-            applyReconciliationOutcome(ownedAttemptId, outcome);
-          });
+          void finalized.reconciliation.then(
+            outcome => {
+              applyReconciliationOutcome(ownedAttemptId, outcome);
+            },
+            () => {
+              // Fail closed: a rejected reconciliation must not leave an unhandled rejection
+              // or silently idle the lock while Task Scheduler state may still be partial.
+              applyReconciliationOutcome(ownedAttemptId, "blocked-partial");
+            },
+          );
           throw new Error(INDETERMINATE_MESSAGE);
         }
       } else {

--- a/src/server/startup-action-control.ts
+++ b/src/server/startup-action-control.ts
@@ -1,11 +1,16 @@
 import { execFile } from "node:child_process";
 import { join } from "node:path";
 import { durableBunPath } from "../lib/bun-runtime";
-import { isWindowsSchtasksCreateAccessDenied } from "../lib/windows-elevation";
+import {
+  WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER,
+  isWindowsSchtasksCreateAccessDenied,
+} from "../lib/windows-elevation";
 import { finalizeWindowsSchedulerServiceRegistration } from "../service";
 
 export type StartupInstallAction = "install-service" | "install-shim";
 let activeInstall: StartupInstallAction | null = null;
+
+const INSTALL_DETAIL_LIMIT = 2_000;
 
 export function startupInstallArgv(action: StartupInstallAction): string[] {
   return action === "install-service"
@@ -13,8 +18,24 @@ export function startupInstallArgv(action: StartupInstallAction): string[] {
     : ["codex-shim", "install"];
 }
 
-function installFailureDetail(stdout: string, stderr: string, error: Error): string {
-  return stderr.trim() || stdout.trim() || error.message;
+/**
+ * Build the CLI failure text used for dashboard errors and elevation detection.
+ * Combines stderr and stdout so a retry marker on either stream is preserved,
+ * and caps length so API responses stay bounded.
+ */
+export function installFailureDetail(stdout: string, stderr: string, error: Error): string {
+  const combined = [stderr.trim(), stdout.trim()].filter(Boolean).join("\n");
+  const detail = combined || error.message;
+  if (detail.length <= INSTALL_DETAIL_LIMIT) return detail;
+  const truncated = detail.slice(0, INSTALL_DETAIL_LIMIT);
+  // Keep the structured elevation marker even when truncating a large dump.
+  if (
+    detail.includes(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER)
+    && !truncated.includes(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER)
+  ) {
+    return `${truncated}\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}… (truncated)`;
+  }
+  return `${truncated}… (truncated)`;
 }
 
 function runCliInstall(action: StartupInstallAction): Promise<{ stdout: string; stderr: string }> {

--- a/src/server/startup-action-control.ts
+++ b/src/server/startup-action-control.ts
@@ -1,8 +1,8 @@
 import { execFile } from "node:child_process";
 import { join } from "node:path";
 import { durableBunPath } from "../lib/bun-runtime";
-import { isWindowsAccessDenied } from "../lib/windows-elevation";
-import { finalizeWindowsSchedulerServiceRegistration, windowsSchedulerTaskInstalled } from "../service";
+import { isWindowsSchtasksCreateAccessDenied } from "../lib/windows-elevation";
+import { finalizeWindowsSchedulerServiceRegistration } from "../service";
 
 export type StartupInstallAction = "install-service" | "install-shim";
 let activeInstall: StartupInstallAction | null = null;
@@ -47,11 +47,16 @@ export function runStartupInstallAction(action: StartupInstallAction): Promise<{
       await runCliInstall(action);
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
-      if (action === "install-service" && process.platform === "win32" && isWindowsAccessDenied(detail)) {
+      // Elevate only for a structured Task Scheduler /create access denial — never for
+      // WinSW removal, asset writes, or generic permission errors.
+      // finalizeWindowsSchedulerServiceRegistration verifies conflict-free state, rolls
+      // back on failure, and writes install state only after checks pass.
+      if (
+        action === "install-service"
+        && process.platform === "win32"
+        && isWindowsSchtasksCreateAccessDenied(detail)
+      ) {
         await finalizeWindowsSchedulerServiceRegistration();
-        if (!windowsSchedulerTaskInstalled()) {
-          throw new Error("Background service install still failed after requesting administrator approval.");
-        }
       } else {
         throw error;
       }

--- a/src/server/startup-action-control.ts
+++ b/src/server/startup-action-control.ts
@@ -12,30 +12,58 @@ let activeInstall: StartupInstallAction | null = null;
 
 const INSTALL_DETAIL_LIMIT = 2_000;
 
+type FinalizeFn = typeof finalizeWindowsSchedulerServiceRegistration;
+let finalizeImpl: FinalizeFn = finalizeWindowsSchedulerServiceRegistration;
+
+/** Test-only seam so elevation retry tests do not mock.module the service package. */
+export function setStartupInstallFinalizeForTests(next: FinalizeFn | null): void {
+  finalizeImpl = next ?? finalizeWindowsSchedulerServiceRegistration;
+}
+
 export function startupInstallArgv(action: StartupInstallAction): string[] {
   return action === "install-service"
     ? ["service", "install"]
     : ["codex-shim", "install"];
 }
 
+export interface CliInstallFailure {
+  /** Machine marker such as OCX_ERROR_CODE=..., when present in any stream. */
+  code: string | null;
+  stdout: string;
+  stderr: string;
+  message: string;
+  /** Bounded user-facing diagnostic (may append the marker if truncated away). */
+  detail: string;
+}
+
+function extractOcxErrorCode(text: string): string | null {
+  const match = text.match(/OCX_ERROR_CODE=[A-Z0-9_]+/);
+  return match ? match[0] : null;
+}
+
 /**
- * Build the CLI failure text used for dashboard errors and elevation detection.
- * Combines stderr and stdout so a retry marker on either stream is preserved,
- * and caps length so API responses stay bounded.
+ * Classify a CLI install failure, keeping the machine marker separate from the
+ * truncated user-facing diagnostic.
  */
-export function installFailureDetail(stdout: string, stderr: string, error: Error): string {
-  const combined = [stderr.trim(), stdout.trim()].filter(Boolean).join("\n");
-  const detail = combined || error.message;
-  if (detail.length <= INSTALL_DETAIL_LIMIT) return detail;
-  const truncated = detail.slice(0, INSTALL_DETAIL_LIMIT);
-  // Keep the structured elevation marker even when truncating a large dump.
-  if (
-    detail.includes(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER)
-    && !truncated.includes(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER)
-  ) {
-    return `${truncated}\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}… (truncated)`;
+export function classifyCliInstallFailure(stdout: string, stderr: string, error: Error): CliInstallFailure {
+  const stdoutText = stdout.trim();
+  const stderrText = stderr.trim();
+  const message = error.message.trim();
+  const combined = [stderrText, stdoutText, message].filter(Boolean).join("\n");
+  const code = extractOcxErrorCode(combined);
+  let detail = combined || message;
+  if (detail.length > INSTALL_DETAIL_LIMIT) {
+    const truncated = detail.slice(0, INSTALL_DETAIL_LIMIT);
+    detail = code && !truncated.includes(code)
+      ? `${truncated}\n${code}… (truncated)`
+      : `${truncated}… (truncated)`;
   }
-  return `${truncated}… (truncated)`;
+  return { code, stdout: stdoutText, stderr: stderrText, message, detail };
+}
+
+/** @deprecated Prefer classifyCliInstallFailure; kept for existing tests. */
+export function installFailureDetail(stdout: string, stderr: string, error: Error): string {
+  return classifyCliInstallFailure(stdout, stderr, error).detail;
 }
 
 function runCliInstall(action: StartupInstallAction): Promise<{ stdout: string; stderr: string }> {
@@ -51,12 +79,22 @@ function runCliInstall(action: StartupInstallAction): Promise<{ stdout: string; 
       maxBuffer: 256 * 1024,
     }, (error, stdout, stderr) => {
       if (error) {
-        reject(new Error(installFailureDetail(stdout, stderr, error)));
+        const failure = classifyCliInstallFailure(stdout, stderr, error);
+        reject(Object.assign(new Error(failure.detail), { ocxInstallFailure: failure }));
         return;
       }
       resolve({ stdout, stderr });
     });
   });
+}
+
+function installFailureCode(error: unknown): string | null {
+  if (error && typeof error === "object" && "ocxInstallFailure" in error) {
+    const failure = (error as { ocxInstallFailure?: CliInstallFailure }).ocxInstallFailure;
+    if (failure?.code) return failure.code;
+  }
+  const detail = error instanceof Error ? error.message : String(error);
+  return extractOcxErrorCode(detail);
 }
 
 /** Execute the existing fixed CLI installer outside the proxy event loop. */
@@ -67,17 +105,17 @@ export function runStartupInstallAction(action: StartupInstallAction): Promise<{
     try {
       await runCliInstall(action);
     } catch (error) {
+      const code = installFailureCode(error);
       const detail = error instanceof Error ? error.message : String(error);
       // Elevate only for a structured Task Scheduler /create access denial — never for
       // WinSW removal, asset writes, or generic permission errors.
-      // finalizeWindowsSchedulerServiceRegistration verifies conflict-free state, rolls
-      // back on failure, and writes install state only after checks pass.
       if (
         action === "install-service"
         && process.platform === "win32"
-        && isWindowsSchtasksCreateAccessDenied(detail)
+        && (code === WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER
+          || isWindowsSchtasksCreateAccessDenied(detail))
       ) {
-        await finalizeWindowsSchedulerServiceRegistration();
+        await finalizeImpl();
       } else {
         throw error;
       }

--- a/src/server/startup-action-control.ts
+++ b/src/server/startup-action-control.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { execFile } from "node:child_process";
 import { join } from "node:path";
 import { durableBunPath } from "../lib/bun-runtime";
@@ -5,19 +6,96 @@ import {
   WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER,
   isWindowsSchtasksCreateAccessDenied,
 } from "../lib/windows-elevation";
-import { finalizeWindowsSchedulerServiceRegistration } from "../service";
+import {
+  finalizeWindowsSchedulerServiceRegistration,
+  type ElevatedReconciliationOutcome,
+  type FinalizeWindowsSchedulerOptions,
+  type FinalizeWindowsSchedulerResult,
+} from "../service";
 
 export type StartupInstallAction = "install-service" | "install-shim";
-let activeInstall: StartupInstallAction | null = null;
+
+export type StartupInstallState =
+  | { status: "idle" }
+  | {
+      status: "running";
+      action: StartupInstallAction;
+      attemptId: string;
+      startedAt: number;
+    }
+  | {
+      status: "indeterminate";
+      action: "install-service";
+      attemptId: string;
+      startedAt: number;
+      timedOutAt: number;
+      reconciliation: Promise<ElevatedReconciliationOutcome>;
+    }
+  | {
+      status: "blocked";
+      reason: "partial-elevated-install";
+      action: "install-service";
+      attemptId: string;
+      detail: string;
+    };
 
 const INSTALL_DETAIL_LIMIT = 2_000;
+const INDETERMINATE_MESSAGE =
+  "Windows elevation timed out, but the elevated Task Scheduler transaction may still be running. New service installation attempts are temporarily blocked while OpenCodex reconciles its final state.";
+const RECONCILING_MESSAGE =
+  "A previous elevated Windows service installation is still being reconciled. Wait for it to finish or inspect the Task Scheduler state before retrying.";
+const BLOCKED_PARTIAL_MESSAGE =
+  "A previous elevated Windows service installation left a partial Task Scheduler state. Remove the OpenCodex scheduler task (or confirm it is absent), then clear the install block before retrying.";
 
-type FinalizeFn = typeof finalizeWindowsSchedulerServiceRegistration;
+let installState: StartupInstallState = { status: "idle" };
+
+type FinalizeFn = (
+  script?: string,
+  options?: FinalizeWindowsSchedulerOptions,
+) => Promise<FinalizeWindowsSchedulerResult>;
 let finalizeImpl: FinalizeFn = finalizeWindowsSchedulerServiceRegistration;
 
 /** Test-only seam so elevation retry tests do not mock.module the service package. */
 export function setStartupInstallFinalizeForTests(next: FinalizeFn | null): void {
   finalizeImpl = next ?? finalizeWindowsSchedulerServiceRegistration;
+}
+
+/** Snapshot of the install lock for diagnostics and tests. */
+export function getStartupInstallState(): StartupInstallState {
+  return installState;
+}
+
+/** True when this attempt still owns the active/indeterminate/blocked lock. */
+export function ownsStartupInstallAttempt(attemptId: string): boolean {
+  return (installState.status === "running"
+    || installState.status === "indeterminate"
+    || installState.status === "blocked")
+    && installState.attemptId === attemptId;
+}
+
+/**
+ * Clear a partial-install block after the operator has cleaned up Task Scheduler.
+ * Does not itself delete the task — callers must verify absence first.
+ */
+export function clearStartupInstallPartialBlock(options?: {
+  taskInstalled?: boolean;
+}): { cleared: boolean; detail: string } {
+  if (installState.status !== "blocked") {
+    return { cleared: false, detail: `Install lock is ${installState.status}, not blocked.` };
+  }
+  if (options?.taskInstalled) {
+    return {
+      cleared: false,
+      detail: "OpenCodex Task Scheduler task is still present; remove it before clearing the block.",
+    };
+  }
+  installState = { status: "idle" };
+  return { cleared: true, detail: "Partial-install block cleared." };
+}
+
+/** Test-only reset of the install lock. */
+export function resetStartupInstallStateForTests(): void {
+  installState = { status: "idle" };
 }
 
 export function startupInstallArgv(action: StartupInstallAction): string[] {
@@ -97,10 +175,55 @@ function installFailureCode(error: unknown): string | null {
   return extractOcxErrorCode(detail);
 }
 
-/** Execute the existing fixed CLI installer outside the proxy event loop. */
+function rejectIfBusy(_action: StartupInstallAction): Error | null {
+  if (installState.status === "running") {
+    return new Error(`Another startup installation is already running: ${installState.action}`);
+  }
+  if (installState.status === "indeterminate") {
+    return new Error(RECONCILING_MESSAGE);
+  }
+  if (installState.status === "blocked") {
+    return new Error(BLOCKED_PARTIAL_MESSAGE);
+  }
+  return null;
+}
+
+function applyReconciliationOutcome(
+  attemptId: string,
+  outcome: ElevatedReconciliationOutcome,
+): void {
+  if (installState.status !== "indeterminate" || installState.attemptId !== attemptId) {
+    return;
+  }
+  if (outcome === "blocked-partial") {
+    installState = {
+      status: "blocked",
+      reason: "partial-elevated-install",
+      action: "install-service",
+      attemptId,
+      detail: BLOCKED_PARTIAL_MESSAGE,
+    };
+    return;
+  }
+  installState = { status: "idle" };
+}
+
+/**
+ * Execute the existing fixed CLI installer outside the proxy event loop.
+ *
+ * After an elevation request timeout the lock becomes `indeterminate` until the
+ * original elevated transaction completes and is reconciled. A process restart
+ * clears this in-memory lock — callers must then inspect Task Scheduler reality
+ * (see evaluateSchedulerInstallRestartReconciliation) before installing again.
+ */
 export function runStartupInstallAction(action: StartupInstallAction): Promise<{ message: string }> {
-  if (activeInstall) return Promise.reject(new Error(`Another startup installation is already running: ${activeInstall}`));
-  activeInstall = action;
+  const busy = rejectIfBusy(action);
+  if (busy) return Promise.reject(busy);
+
+  const attemptId = randomUUID();
+  const startedAt = Date.now();
+  installState = { status: "running", action, attemptId, startedAt };
+
   const operation = (async () => {
     try {
       await runCliInstall(action);
@@ -115,7 +238,25 @@ export function runStartupInstallAction(action: StartupInstallAction): Promise<{
         && (code === WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER
           || isWindowsSchtasksCreateAccessDenied(detail))
       ) {
-        await finalizeImpl();
+        const finalized = await finalizeImpl(undefined, {
+          attemptId,
+          stillOwnsAttempt: ownsStartupInstallAttempt,
+        });
+        if (finalized.kind === "indeterminate") {
+          const ownedAttemptId = finalized.attemptId;
+          installState = {
+            status: "indeterminate",
+            action: "install-service",
+            attemptId: ownedAttemptId,
+            startedAt,
+            timedOutAt: Date.now(),
+            reconciliation: finalized.reconciliation,
+          };
+          void finalized.reconciliation.then(outcome => {
+            applyReconciliationOutcome(ownedAttemptId, outcome);
+          });
+          throw new Error(INDETERMINATE_MESSAGE);
+        }
       } else {
         throw error;
       }
@@ -126,5 +267,11 @@ export function runStartupInstallAction(action: StartupInstallAction): Promise<{
         : "Codex launcher shim installed.",
     };
   })();
-  return operation.finally(() => { activeInstall = null; });
+
+  return operation.finally(() => {
+    // Do not clear an indeterminate or blocked lock from a timed-out elevation.
+    if (installState.status === "running" && installState.attemptId === attemptId) {
+      installState = { status: "idle" };
+    }
+  });
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -16,7 +16,7 @@ import { isWslRuntime } from "./codex/home";
 import { durableBunPath, durableBunRuntime } from "./lib/bun-runtime";
 import { isProcessAlive, stopProxy } from "./lib/process-control";
 import { serviceApiTokenFilePath } from "./lib/service-secrets";
-import { formatWindowsSchtasksError } from "./lib/windows-elevation";
+import { formatWindowsSchtasksError, runWindowsElevated } from "./lib/windows-elevation";
 import { defaultWinswEntry, installWinswService, startWinswService, stopWinswService, statusWinswRaw, uninstallWinswService, winswStatusSummary, WINSW_SERVICE_ID, WINSW_SHA256, WINSW_VERSION } from "./lib/winsw";
 import { hardenSecretDir, hardenSecretPath } from "./lib/windows-secret-acl";
 import { windowsEnvIndirectBatchPathList, windowsEnvIndirectBatchValue } from "./lib/win-paths";
@@ -342,6 +342,29 @@ export function windowsSchedulerTaskInstalled(taskName = TASK): boolean {
   } catch {
     return false;
   }
+}
+
+async function elevateSchtasks(args: string[]): Promise<void> {
+  const exitCode = await runWindowsElevated(windowsSchtasks(), args);
+  if (exitCode === 0) return;
+  if (exitCode === 1223) {
+    throw new Error("Windows administrator approval was required to install the background service, but the UAC prompt was cancelled or denied.");
+  }
+  throw new Error(`Background service install failed with exit code ${exitCode}.`);
+}
+
+/** Re-register the scheduler task with elevation after a non-elevated install wrote assets. */
+export async function finalizeWindowsSchedulerServiceRegistration(script = windowsServiceScriptPath()): Promise<void> {
+  if (process.platform !== "win32") {
+    throw new Error("Windows scheduler registration is only supported on Windows.");
+  }
+  await elevateSchtasks(buildWindowsSchtasksCreateArgs(script));
+  try {
+    await elevateSchtasks(["/run", "/tn", TASK]);
+  } catch {
+    // Logon-triggered tasks may still start on the next sign-in even if /run fails.
+  }
+  writeServiceInstallState("scheduler");
 }
 
 function windowsBatchValue(value: string): string {

--- a/src/service.ts
+++ b/src/service.ts
@@ -16,6 +16,7 @@ import { isWslRuntime } from "./codex/home";
 import { durableBunPath, durableBunRuntime } from "./lib/bun-runtime";
 import { isProcessAlive, stopProxy } from "./lib/process-control";
 import { serviceApiTokenFilePath } from "./lib/service-secrets";
+import { formatWindowsSchtasksError } from "./lib/windows-elevation";
 import { defaultWinswEntry, installWinswService, startWinswService, stopWinswService, statusWinswRaw, uninstallWinswService, winswStatusSummary, WINSW_SERVICE_ID, WINSW_SHA256, WINSW_VERSION } from "./lib/winsw";
 import { hardenSecretDir, hardenSecretPath } from "./lib/windows-secret-acl";
 import { windowsEnvIndirectBatchPathList, windowsEnvIndirectBatchValue } from "./lib/win-paths";
@@ -321,8 +322,26 @@ function windowsWscript(): string {
   return existsSync(candidate) ? candidate : "wscript.exe";
 }
 
-function schtasks(args: string[]): string {
+function querySchtasks(args: string[]): string {
   return runFile(windowsSchtasks(), args);
+}
+
+function schtasks(args: string[]): string {
+  try {
+    return querySchtasks(args);
+  } catch (error) {
+    throw new Error(formatWindowsSchtasksError(error, args));
+  }
+}
+
+/** True when the Task Scheduler registration for the default proxy task exists. */
+export function windowsSchedulerTaskInstalled(taskName = TASK): boolean {
+  if (process.platform !== "win32") return false;
+  try {
+    return querySchtasks(["/query", "/tn", taskName]).includes(taskName);
+  } catch {
+    return false;
+  }
 }
 
 function windowsBatchValue(value: string): string {

--- a/src/service.ts
+++ b/src/service.ts
@@ -349,6 +349,8 @@ export interface WindowsSchedulerInstallVerification {
   registrationHealthy: boolean;
   assetsHealthy: boolean;
   nativeServiceAbsent: boolean;
+  /** True when SCM probe failed; not a proven WinSW presence. */
+  nativeStatusUnknown: boolean;
   conflict: boolean;
   ok: boolean;
   detail: string;
@@ -367,7 +369,10 @@ export function evaluateWindowsSchedulerInstallVerification(inputs: {
     && windowsTaskRegistrationHealthy(inputs.xml, inputs.wscript, inputs.launcher);
   const assetsHealthy = inputs.assetsExist;
   const nativeServiceAbsent = inputs.nativeStatus === "nonexistent";
-  const conflict = inputs.taskInstalled && !nativeServiceAbsent;
+  const nativeStatusUnknown = inputs.nativeStatus === "unknown";
+  // Only treat proven WinSW presence as a backend conflict — never "unknown".
+  const conflict = inputs.taskInstalled
+    && (inputs.nativeStatus === "started" || inputs.nativeStatus === "stopped");
   const ok = inputs.taskInstalled && registrationHealthy && assetsHealthy && nativeServiceAbsent && !conflict;
   const detail = !inputs.taskInstalled
     ? "Task Scheduler task is not installed."
@@ -377,12 +382,15 @@ export function evaluateWindowsSchedulerInstallVerification(inputs: {
         ? "Required scheduler service assets are missing."
         : !registrationHealthy
           ? "Task Scheduler registration is present but unhealthy."
-          : "ok";
+          : nativeStatusUnknown
+            ? `Native WinSW (${WINSW_SERVICE_ID}) status could not be verified after elevated registration.`
+            : "ok";
   return {
     taskInstalled: inputs.taskInstalled,
     registrationHealthy,
     assetsHealthy,
     nativeServiceAbsent,
+    nativeStatusUnknown,
     conflict,
     ok,
     detail,
@@ -404,16 +412,9 @@ export function verifyWindowsSchedulerInstall(taskName = TASK): WindowsScheduler
 }
 
 async function elevateSchtasks(args: string[]): Promise<void> {
-  try {
-    const exitCode = await runWindowsElevated(windowsSchtasks(), args);
-    if (exitCode === 0) return;
+  const exitCode = await runWindowsElevated(windowsSchtasks(), args);
+  if (exitCode !== 0) {
     throw new Error(`Background service install failed with exit code ${exitCode}.`);
-  } catch (error) {
-    if (error instanceof WindowsElevationError && error.reason === "cancelled") {
-      throw error;
-    }
-    if (error instanceof WindowsElevationError) throw error;
-    throw error;
   }
 }
 
@@ -435,24 +436,39 @@ export async function finalizeWindowsSchedulerServiceRegistration(script = windo
     throw new Error("Windows scheduler registration is only supported on Windows.");
   }
   await elevateSchtasks(buildWindowsSchtasksCreateArgs(script));
+  let runDetail: string | null = null;
   try {
     await elevateSchtasks(["/run", "/tn", TASK]);
   } catch (error) {
     // Logon-triggered tasks may still start on the next sign-in even if /run fails.
-    // Cancellation during /run still means the user denied elevation for that step —
-    // continue to verification; creation already succeeded.
-    if (error instanceof WindowsElevationError && error.reason === "cancelled") {
-      /* keep going to verification */
+    // Tolerate UAC cancel and non-zero schtasks /run exits; rethrow timeout/launch failures.
+    if (error instanceof WindowsElevationError) {
+      if (error.reason === "cancelled" || error.reason === "child-failed") {
+        runDetail = error.message;
+      } else {
+        throw error;
+      }
+    } else {
+      runDetail = error instanceof Error ? error.message : String(error);
     }
   }
   const verification = verifyWindowsSchedulerInstall();
   if (!verification.ok) {
-    const rollbackError = await rollbackElevatedSchedulerTask();
+    // Do not destroy a healthy elevated task solely because WinSW status is unverified.
+    const preserveElevatedTask = verification.taskInstalled
+      && verification.registrationHealthy
+      && verification.assetsHealthy
+      && !verification.conflict
+      && verification.nativeStatusUnknown;
+    const rollbackError = preserveElevatedTask ? null : await rollbackElevatedSchedulerTask();
     const parts = [
       "Elevated Task Scheduler registration did not produce a conflict-free install.",
       verification.detail,
     ];
-    if (rollbackError) {
+    if (runDetail) parts.push(`Task /run after create: ${runDetail}`);
+    if (preserveElevatedTask) {
+      parts.push("The elevated Task Scheduler task was left in place because native WinSW status could not be verified.");
+    } else if (rollbackError) {
       parts.push(`Rollback also failed: ${rollbackError}`);
       parts.push(`Remove the task manually with 'schtasks /delete /tn ${TASK} /f' and the native service with 'sc delete ${WINSW_SERVICE_ID}' if present.`);
     } else {

--- a/src/service.ts
+++ b/src/service.ts
@@ -661,8 +661,10 @@ export async function finalizeWindowsSchedulerServiceRegistration(
     if (error instanceof WindowsElevationError && error.reason === "terminated") {
       try {
         await reconcileUnknownElevatedOutcome(OCX_ELEVATED_PROTOCOL_FAILED);
-      } catch {
-        throw error;
+      } catch (reconcileError) {
+        // Prefer the reconciliation detail (partial install / cleanup guidance) over the
+        // generic signal message so callers can block retries when a task remains.
+        throw reconcileError;
       }
     }
     throw error;

--- a/src/service.ts
+++ b/src/service.ts
@@ -16,8 +16,14 @@ import { isWslRuntime } from "./codex/home";
 import { durableBunPath, durableBunRuntime } from "./lib/bun-runtime";
 import { isProcessAlive, stopProxy } from "./lib/process-control";
 import { serviceApiTokenFilePath } from "./lib/service-secrets";
-import { runWindowsElevated, runElevatedSchtasksCreateAndRun, toWindowsSchtasksError } from "./lib/windows-elevation";
-import type { ElevatedSchtasksCreateAndRunResult } from "./lib/windows-elevation";
+import {
+  classifyElevatedSchedulerExitCode,
+  runElevatedSchtasksCreateAndRun,
+  runWindowsElevated,
+  toWindowsSchtasksError,
+  type ElevatedSchedulerOutcome,
+  type ElevatedSchtasksCreateAndRunResult,
+} from "./lib/windows-elevation";
 import { defaultWinswEntry, installWinswService, startWinswService, stopWinswService, statusWinswRaw, uninstallWinswService, winswStatusSummary, WINSW_SERVICE_ID, WINSW_SHA256, WINSW_VERSION } from "./lib/winsw";
 import { hardenSecretDir, hardenSecretPath } from "./lib/windows-secret-acl";
 import { windowsEnvIndirectBatchPathList, windowsEnvIndirectBatchValue } from "./lib/win-paths";
@@ -436,6 +442,7 @@ type ElevateCreateAndRun = (
   schtasksPath: string,
   createArgs: string[],
   runArgs: string[],
+  deleteArgs: string[],
 ) => Promise<ElevatedSchtasksCreateAndRunResult>;
 
 type FinalizeHooks = {
@@ -452,20 +459,34 @@ export function setFinalizeWindowsSchedulerHooksForTests(hooks: FinalizeHooks | 
   finalizeHooks = hooks;
 }
 
-function failAfterElevatedCreate(
-  reason: string,
-  options: { rollback: boolean; rollbackError?: string | null },
-): never {
-  const parts = [reason];
-  if (options.rollback) {
-    if (options.rollbackError) {
-      parts.push(`Rollback also failed: ${options.rollbackError}`);
-      parts.push(`Remove the task manually with 'schtasks /delete /tn ${TASK} /f' and the native service with 'sc delete ${WINSW_SERVICE_ID}' if present.`);
-    } else {
-      parts.push("The elevated Task Scheduler task was rolled back.");
-    }
+function throwPartialInstall(parts: string[]): never {
+  throw new Error(parts.filter(Boolean).join(" "));
+}
+
+/**
+ * Reconcile an unrecognized elevated exit when we cannot trust the phase code.
+ * Never invent a create-vs-run classification; inspect actual task state first.
+ */
+async function reconcileUnknownElevatedOutcome(exitCode: number): Promise<never> {
+  const taskPresent = finalizeHooks?.taskInstalled?.() ?? windowsSchedulerTaskInstalled();
+  const parts = [
+    "The elevated Task Scheduler operation returned an unknown result.",
+    `Exit code: ${exitCode}.`,
+    "OpenCodex could not prove whether task creation completed, so installation state was not written.",
+  ];
+  if (!taskPresent) {
+    parts.push("No OpenCodex Task Scheduler task was found after the elevated operation.");
+    throwPartialInstall(parts);
   }
-  throw new Error(parts.join(" "));
+  parts.push("A Task Scheduler task is present; attempting cleanup.");
+  const rollbackError = await rollbackElevatedSchedulerTask();
+  if (rollbackError) {
+    parts.push(`Cleanup also failed: ${rollbackError}`);
+    parts.push(`Remove the task manually with 'schtasks /delete /tn ${TASK} /f' if it remains.`);
+  } else {
+    parts.push("The elevated Task Scheduler task was removed.");
+  }
+  throwPartialInstall(parts);
 }
 
 /** Re-register the scheduler task with elevation after a non-elevated install wrote assets. */
@@ -475,42 +496,67 @@ export async function finalizeWindowsSchedulerServiceRegistration(script = windo
   }
   const createArgs = buildWindowsSchtasksCreateArgs(script);
   const runArgs = ["/run", "/tn", TASK];
+  const deleteArgs = ["/delete", "/tn", TASK, "/f"];
   const elevateCreateAndRun = finalizeHooks?.elevateCreateAndRun
-    ?? ((schtasksPath, create, run) => runElevatedSchtasksCreateAndRun(schtasksPath, create, run));
-  const result = await elevateCreateAndRun(windowsSchtasks(), createArgs, runArgs);
+    ?? ((schtasksPath, create, run, del) => runElevatedSchtasksCreateAndRun(schtasksPath, create, run, del));
+  const result = await elevateCreateAndRun(windowsSchtasks(), createArgs, runArgs, deleteArgs);
+  const outcome: ElevatedSchedulerOutcome = result.outcome ?? classifyElevatedSchedulerExitCode(result.exitCode);
 
-  if (result.createExitCode !== 0) {
-    throw new Error(`Elevated schtasks /create failed with exit code ${result.createExitCode}.`);
+  if (outcome === "create-failed") {
+    throw new Error("Elevated schtasks /create failed. The Task Scheduler task was not registered.");
   }
-  if (result.runExitCode === null || result.runExitCode !== 0) {
-    const runCode = result.runExitCode ?? "unknown";
-    const rollbackError = await rollbackElevatedSchedulerTask();
-    failAfterElevatedCreate(
-      `Elevated schtasks /run failed with exit code ${runCode}. The Task Scheduler task was registered but could not be started.`,
-      { rollback: true, rollbackError },
+  if (outcome === "run-failed-rolled-back") {
+    throw new Error(
+      "Elevated schtasks /run failed after the task was registered. The elevated process rolled the task back. Installation state was not written.",
     );
+  }
+  if (outcome === "run-failed-rollback-failed") {
+    throwPartialInstall([
+      "Elevated schtasks /run failed after the task was registered, and elevated rollback also failed.",
+      "A partial Task Scheduler backend may remain.",
+      `Remove the task manually with 'schtasks /delete /tn ${TASK} /f' if present.`,
+      "Installation state was not written.",
+    ]);
+  }
+  if (outcome === "protocol-failed") {
+    await reconcileUnknownElevatedOutcome(result.exitCode);
+  }
+  if (outcome !== "success") {
+    await reconcileUnknownElevatedOutcome(result.exitCode);
   }
 
   const verification = (finalizeHooks?.verify ?? verifyWindowsSchedulerInstall)();
   if (!verification.ok) {
-    // Do not destroy a healthy elevated task solely because WinSW status is unverified.
+    // Preserve a healthy elevated task when WinSW absence cannot be proven (unknown SCM status).
+    // Unknown is not a confirmed dual-backend conflict; install state is still withheld.
+    // Parent-side rollback here may require a second UAC prompt — only used after a protocol
+    // success when postconditions fail for a confirmed problem (conflict / unhealthy / missing assets).
     const preserveElevatedTask = verification.taskInstalled
       && verification.registrationHealthy
       && verification.assetsHealthy
       && !verification.conflict
       && verification.nativeStatusUnknown;
     if (preserveElevatedTask) {
-      throw new Error([
+      throwPartialInstall([
         "Elevated Task Scheduler registration did not produce a conflict-free install.",
         verification.detail,
         "The elevated Task Scheduler task was left in place because native WinSW status could not be verified.",
-      ].join(" "));
+        "Installation state was not written.",
+      ]);
     }
     const rollbackError = await rollbackElevatedSchedulerTask();
-    failAfterElevatedCreate(
-      `Elevated Task Scheduler registration did not produce a conflict-free install. ${verification.detail}`,
-      { rollback: true, rollbackError },
-    );
+    const parts = [
+      "Elevated Task Scheduler registration did not produce a conflict-free install.",
+      verification.detail,
+    ];
+    if (rollbackError) {
+      parts.push(`Rollback also failed: ${rollbackError}`);
+      parts.push(`Remove the task manually with 'schtasks /delete /tn ${TASK} /f' and the native service with 'sc delete ${WINSW_SERVICE_ID}' if present.`);
+    } else {
+      parts.push("The elevated Task Scheduler task was rolled back.");
+    }
+    parts.push("Installation state was not written.");
+    throwPartialInstall(parts);
   }
   (finalizeHooks?.writeInstallState ?? (() => writeServiceInstallState("scheduler")))();
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -16,12 +16,18 @@ import { isWslRuntime } from "./codex/home";
 import { durableBunPath, durableBunRuntime } from "./lib/bun-runtime";
 import { isProcessAlive, stopProxy } from "./lib/process-control";
 import { serviceApiTokenFilePath } from "./lib/service-secrets";
+import { randomUUID } from "node:crypto";
 import {
+  ELEVATION_REQUEST_TIMEOUT_MS,
+  OCX_ELEVATED_PROTOCOL_FAILED,
   classifyElevatedSchedulerExitCode,
-  runElevatedSchtasksCreateAndRun,
+  raceWithTimeout,
+  startElevatedSchtasksCreateAndRun,
   runWindowsElevated,
   toWindowsSchtasksError,
+  WindowsElevationError,
   type ElevatedSchedulerOutcome,
+  type ElevatedSchtasksCreateAndRunExecution,
   type ElevatedSchtasksCreateAndRunResult,
 } from "./lib/windows-elevation";
 import { defaultWinswEntry, installWinswService, startWinswService, stopWinswService, statusWinswRaw, uninstallWinswService, winswStatusSummary, WINSW_SERVICE_ID, WINSW_SHA256, WINSW_VERSION } from "./lib/winsw";
@@ -438,18 +444,28 @@ async function rollbackElevatedSchedulerTask(taskName = TASK): Promise<string | 
   return null;
 }
 
-type ElevateCreateAndRun = (
+type ElevateCreateAndRunStart = (
   schtasksPath: string,
   createArgs: string[],
   runArgs: string[],
   deleteArgs: string[],
-) => Promise<ElevatedSchtasksCreateAndRunResult>;
+) => ElevatedSchtasksCreateAndRunExecution;
 
 type FinalizeHooks = {
-  elevateCreateAndRun?: ElevateCreateAndRun;
+  startElevateCreateAndRun?: ElevateCreateAndRunStart;
+  /** Legacy sync hook used by older tests — wraps a resolved result as an execution. */
+  elevateCreateAndRun?: (
+    schtasksPath: string,
+    createArgs: string[],
+    runArgs: string[],
+    deleteArgs: string[],
+  ) => Promise<ElevatedSchtasksCreateAndRunResult>;
   verify?: () => WindowsSchedulerInstallVerification;
   writeInstallState?: () => void;
   taskInstalled?: () => boolean;
+  /** Defense-in-depth: late reconciliation must still own this attempt. */
+  stillOwnsAttempt?: (attemptId: string) => boolean;
+  requestTimeoutMs?: number;
 };
 
 let finalizeHooks: FinalizeHooks | null = null;
@@ -467,7 +483,7 @@ function throwPartialInstall(parts: string[]): never {
  * Reconcile an unrecognized elevated exit when we cannot trust the phase code.
  * Never invent a create-vs-run classification; inspect actual task state first.
  */
-async function reconcileUnknownElevatedOutcome(exitCode: number): Promise<never> {
+async function reconcileUnknownElevatedOutcome(exitCode: number): Promise<void> {
   const taskPresent = finalizeHooks?.taskInstalled?.() ?? windowsSchedulerTaskInstalled();
   const parts = [
     "The elevated Task Scheduler operation returned an unknown result.",
@@ -489,17 +505,24 @@ async function reconcileUnknownElevatedOutcome(exitCode: number): Promise<never>
   throwPartialInstall(parts);
 }
 
-/** Re-register the scheduler task with elevation after a non-elevated install wrote assets. */
-export async function finalizeWindowsSchedulerServiceRegistration(script = windowsServiceScriptPath()): Promise<void> {
-  if (process.platform !== "win32") {
-    throw new Error("Windows scheduler registration is only supported on Windows.");
+type ApplyElevatedOptions = {
+  attemptId: string;
+  writeOnSuccess: boolean;
+  stillOwnsAttempt?: (attemptId: string) => boolean;
+};
+
+function attemptStillOwned(options: ApplyElevatedOptions): boolean {
+  const check = options.stillOwnsAttempt ?? finalizeHooks?.stillOwnsAttempt;
+  return !check || check(options.attemptId);
+}
+
+async function applyElevatedSchedulerResult(
+  result: ElevatedSchtasksCreateAndRunResult,
+  options: ApplyElevatedOptions,
+): Promise<void> {
+  if (!attemptStillOwned(options)) {
+    return;
   }
-  const createArgs = buildWindowsSchtasksCreateArgs(script);
-  const runArgs = ["/run", "/tn", TASK];
-  const deleteArgs = ["/delete", "/tn", TASK, "/f"];
-  const elevateCreateAndRun = finalizeHooks?.elevateCreateAndRun
-    ?? ((schtasksPath, create, run, del) => runElevatedSchtasksCreateAndRun(schtasksPath, create, run, del));
-  const result = await elevateCreateAndRun(windowsSchtasks(), createArgs, runArgs, deleteArgs);
   const outcome: ElevatedSchedulerOutcome = result.outcome ?? classifyElevatedSchedulerExitCode(result.exitCode);
 
   if (outcome === "create-failed") {
@@ -518,19 +541,15 @@ export async function finalizeWindowsSchedulerServiceRegistration(script = windo
       "Installation state was not written.",
     ]);
   }
-  if (outcome === "protocol-failed") {
+  if (outcome === "protocol-failed" || outcome !== "success") {
     await reconcileUnknownElevatedOutcome(result.exitCode);
-  }
-  if (outcome !== "success") {
-    await reconcileUnknownElevatedOutcome(result.exitCode);
+    return;
   }
 
   const verification = (finalizeHooks?.verify ?? verifyWindowsSchedulerInstall)();
   if (!verification.ok) {
     // Preserve a healthy elevated task when WinSW absence cannot be proven (unknown SCM status).
     // Unknown is not a confirmed dual-backend conflict; install state is still withheld.
-    // Parent-side rollback here may require a second UAC prompt — only used after a protocol
-    // success when postconditions fail for a confirmed problem (conflict / unhealthy / missing assets).
     const preserveElevatedTask = verification.taskInstalled
       && verification.registrationHealthy
       && verification.assetsHealthy
@@ -558,7 +577,191 @@ export async function finalizeWindowsSchedulerServiceRegistration(script = windo
     parts.push("Installation state was not written.");
     throwPartialInstall(parts);
   }
-  (finalizeHooks?.writeInstallState ?? (() => writeServiceInstallState("scheduler")))();
+  if (options.writeOnSuccess) {
+    if (!attemptStillOwned(options)) {
+      return;
+    }
+    (finalizeHooks?.writeInstallState ?? (() => writeServiceInstallState("scheduler")))();
+  }
+}
+
+/** Outcome of late reconciliation after a request-level elevation timeout. */
+export type ElevatedReconciliationOutcome =
+  | "released"
+  | "blocked-partial";
+
+export type FinalizeWindowsSchedulerResult =
+  | { kind: "done" }
+  | {
+      kind: "indeterminate";
+      attemptId: string;
+      /** Settles after the elevated transaction finishes and late reconciliation runs. */
+      reconciliation: Promise<ElevatedReconciliationOutcome>;
+    };
+
+export type FinalizeWindowsSchedulerOptions = {
+  attemptId?: string;
+  stillOwnsAttempt?: (attemptId: string) => boolean;
+  requestTimeoutMs?: number;
+};
+
+function startElevateExecution(
+  schtasksPath: string,
+  createArgs: string[],
+  runArgs: string[],
+  deleteArgs: string[],
+): ElevatedSchtasksCreateAndRunExecution {
+  if (finalizeHooks?.startElevateCreateAndRun) {
+    return finalizeHooks.startElevateCreateAndRun(schtasksPath, createArgs, runArgs, deleteArgs);
+  }
+  if (finalizeHooks?.elevateCreateAndRun) {
+    const completion = finalizeHooks.elevateCreateAndRun(schtasksPath, createArgs, runArgs, deleteArgs);
+    return { completion, launcherPid: null };
+  }
+  return startElevatedSchtasksCreateAndRun(schtasksPath, createArgs, runArgs, deleteArgs);
+}
+
+function isPartialInstallError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return /partial Task Scheduler/i.test(error.message)
+    || /Cleanup also failed/i.test(error.message)
+    || /left in place because native WinSW status could not be verified/i.test(error.message);
+}
+
+/**
+ * Re-register the scheduler task with elevation after a non-elevated install wrote assets.
+ *
+ * Request timeout does not kill the elevated launcher. On timeout this returns
+ * `indeterminate` and keeps reconciling the eventual protocol result.
+ */
+export async function finalizeWindowsSchedulerServiceRegistration(
+  script = windowsServiceScriptPath(),
+  options?: FinalizeWindowsSchedulerOptions,
+): Promise<FinalizeWindowsSchedulerResult> {
+  if (process.platform !== "win32") {
+    throw new Error("Windows scheduler registration is only supported on Windows.");
+  }
+  const attemptId = options?.attemptId ?? randomUUID();
+  const stillOwnsAttempt = options?.stillOwnsAttempt ?? finalizeHooks?.stillOwnsAttempt;
+  const createArgs = buildWindowsSchtasksCreateArgs(script);
+  const runArgs = ["/run", "/tn", TASK];
+  const deleteArgs = ["/delete", "/tn", TASK, "/f"];
+  const started = startElevateExecution(windowsSchtasks(), createArgs, runArgs, deleteArgs);
+  const timeoutMs = options?.requestTimeoutMs
+    ?? finalizeHooks?.requestTimeoutMs
+    ?? ELEVATION_REQUEST_TIMEOUT_MS;
+  const applyOpts: ApplyElevatedOptions = { attemptId, writeOnSuccess: true, stillOwnsAttempt };
+
+  let raced: { status: "completed"; value: ElevatedSchtasksCreateAndRunResult } | { status: "timed-out" };
+  try {
+    raced = await raceWithTimeout(started.completion, timeoutMs);
+  } catch (error) {
+    // Cancellation / launch failure / signal before or instead of a protocol result.
+    // Signal after Start-Process may leave an elevated child; reconcile conservatively.
+    if (error instanceof WindowsElevationError && error.reason === "terminated") {
+      try {
+        await reconcileUnknownElevatedOutcome(OCX_ELEVATED_PROTOCOL_FAILED);
+      } catch {
+        throw error;
+      }
+    }
+    throw error;
+  }
+
+  if (raced.status === "completed") {
+    await applyElevatedSchedulerResult(raced.value, applyOpts);
+    return { kind: "done" };
+  }
+
+  const reconciliation = (async (): Promise<ElevatedReconciliationOutcome> => {
+    try {
+      const result = await started.completion;
+      await applyElevatedSchedulerResult(result, applyOpts);
+      return "released";
+    } catch (error) {
+      if (error instanceof WindowsElevationError && error.reason === "cancelled") {
+        return "released";
+      }
+      if (error instanceof WindowsElevationError && error.reason === "launch-failed") {
+        return "released";
+      }
+      if (error instanceof WindowsElevationError && error.reason === "terminated") {
+        try {
+          await reconcileUnknownElevatedOutcome(OCX_ELEVATED_PROTOCOL_FAILED);
+          return "released";
+        } catch (reconcileError) {
+          return isPartialInstallError(reconcileError) ? "blocked-partial" : "released";
+        }
+      }
+      // applyElevatedSchedulerResult failures are expected (create/run/conflict); swallow for background.
+      if (isPartialInstallError(error)) {
+        return "blocked-partial";
+      }
+      return "released";
+    }
+  })();
+
+  return { kind: "indeterminate", attemptId, reconciliation };
+}
+
+/**
+ * Pure post-restart / pre-install advisory check. Does not mutate state.
+ * A process-local indeterminate lock cannot survive restart — callers must inspect reality.
+ */
+export function evaluateSchedulerInstallRestartReconciliation(inputs: {
+  taskInstalled: boolean;
+  registrationHealthy: boolean;
+  assetsHealthy: boolean;
+  nativeStatus: "started" | "stopped" | "nonexistent" | "unknown";
+  installStateBackend: "scheduler" | "native" | null;
+}): {
+  status: "healthy" | "orphan-task" | "stale-install-state" | "conflict" | "unhealthy" | "unverified";
+  detail: string;
+} {
+  const conflict = inputs.taskInstalled
+    && (inputs.nativeStatus === "started" || inputs.nativeStatus === "stopped");
+  if (conflict) {
+    return {
+      status: "conflict",
+      detail: `CONFLICT: Task Scheduler and native WinSW (${WINSW_SERVICE_ID}) are both present.`,
+    };
+  }
+  if (inputs.taskInstalled && inputs.nativeStatus === "unknown") {
+    return {
+      status: "unverified",
+      detail: "The Task Scheduler task exists, but native WinSW status could not be verified.",
+    };
+  }
+  if (inputs.taskInstalled && (!inputs.registrationHealthy || !inputs.assetsHealthy)) {
+    return {
+      status: "unhealthy",
+      detail: !inputs.assetsHealthy
+        ? "Required scheduler service assets are missing."
+        : "Task Scheduler registration is present but unhealthy.",
+    };
+  }
+  if (inputs.taskInstalled && inputs.installStateBackend !== "scheduler") {
+    return {
+      status: "orphan-task",
+      detail: "A Task Scheduler task is present without matching scheduler install state.",
+    };
+  }
+  if (!inputs.taskInstalled && inputs.installStateBackend === "scheduler") {
+    return {
+      status: "stale-install-state",
+      detail: "Scheduler install state is present but the Task Scheduler task is absent.",
+    };
+  }
+  if (
+    inputs.taskInstalled
+    && inputs.registrationHealthy
+    && inputs.assetsHealthy
+    && inputs.nativeStatus === "nonexistent"
+    && inputs.installStateBackend === "scheduler"
+  ) {
+    return { status: "healthy", detail: "ok" };
+  }
+  return { status: "healthy", detail: "ok" };
 }
 
 function windowsBatchValue(value: string): string {

--- a/src/service.ts
+++ b/src/service.ts
@@ -16,7 +16,8 @@ import { isWslRuntime } from "./codex/home";
 import { durableBunPath, durableBunRuntime } from "./lib/bun-runtime";
 import { isProcessAlive, stopProxy } from "./lib/process-control";
 import { serviceApiTokenFilePath } from "./lib/service-secrets";
-import { runWindowsElevated, toWindowsSchtasksError, WindowsElevationError } from "./lib/windows-elevation";
+import { runWindowsElevated, runElevatedSchtasksCreateAndRun, toWindowsSchtasksError } from "./lib/windows-elevation";
+import type { ElevatedSchtasksCreateAndRunResult } from "./lib/windows-elevation";
 import { defaultWinswEntry, installWinswService, startWinswService, stopWinswService, statusWinswRaw, uninstallWinswService, winswStatusSummary, WINSW_SERVICE_ID, WINSW_SHA256, WINSW_VERSION } from "./lib/winsw";
 import { hardenSecretDir, hardenSecretPath } from "./lib/windows-secret-acl";
 import { windowsEnvIndirectBatchPathList, windowsEnvIndirectBatchValue } from "./lib/win-paths";
@@ -383,7 +384,7 @@ export function evaluateWindowsSchedulerInstallVerification(inputs: {
         : !registrationHealthy
           ? "Task Scheduler registration is present but unhealthy."
           : nativeStatusUnknown
-            ? `Native WinSW (${WINSW_SERVICE_ID}) status could not be verified after elevated registration.`
+            ? "The Task Scheduler task was created, but OpenCodex could not verify that the native WinSW service is absent."
             : "ok";
   return {
     taskInstalled: inputs.taskInstalled,
@@ -424,10 +425,47 @@ async function rollbackElevatedSchedulerTask(taskName = TASK): Promise<string | 
   } catch (error) {
     return error instanceof Error ? error.message : String(error);
   }
-  if (windowsSchedulerTaskInstalled(taskName)) {
+  const stillInstalled = finalizeHooks?.taskInstalled?.() ?? windowsSchedulerTaskInstalled(taskName);
+  if (stillInstalled) {
     return `Task Scheduler task ${taskName} is still present after rollback.`;
   }
   return null;
+}
+
+type ElevateCreateAndRun = (
+  schtasksPath: string,
+  createArgs: string[],
+  runArgs: string[],
+) => Promise<ElevatedSchtasksCreateAndRunResult>;
+
+type FinalizeHooks = {
+  elevateCreateAndRun?: ElevateCreateAndRun;
+  verify?: () => WindowsSchedulerInstallVerification;
+  writeInstallState?: () => void;
+  taskInstalled?: () => boolean;
+};
+
+let finalizeHooks: FinalizeHooks | null = null;
+
+/** Test-only hooks for elevated create+run finalization. */
+export function setFinalizeWindowsSchedulerHooksForTests(hooks: FinalizeHooks | null): void {
+  finalizeHooks = hooks;
+}
+
+function failAfterElevatedCreate(
+  reason: string,
+  options: { rollback: boolean; rollbackError?: string | null },
+): never {
+  const parts = [reason];
+  if (options.rollback) {
+    if (options.rollbackError) {
+      parts.push(`Rollback also failed: ${options.rollbackError}`);
+      parts.push(`Remove the task manually with 'schtasks /delete /tn ${TASK} /f' and the native service with 'sc delete ${WINSW_SERVICE_ID}' if present.`);
+    } else {
+      parts.push("The elevated Task Scheduler task was rolled back.");
+    }
+  }
+  throw new Error(parts.join(" "));
 }
 
 /** Re-register the scheduler task with elevation after a non-elevated install wrote assets. */
@@ -435,24 +473,25 @@ export async function finalizeWindowsSchedulerServiceRegistration(script = windo
   if (process.platform !== "win32") {
     throw new Error("Windows scheduler registration is only supported on Windows.");
   }
-  await elevateSchtasks(buildWindowsSchtasksCreateArgs(script));
-  let runDetail: string | null = null;
-  try {
-    await elevateSchtasks(["/run", "/tn", TASK]);
-  } catch (error) {
-    // Logon-triggered tasks may still start on the next sign-in even if /run fails.
-    // Tolerate UAC cancel and non-zero schtasks /run exits; rethrow timeout/launch failures.
-    if (error instanceof WindowsElevationError) {
-      if (error.reason === "cancelled" || error.reason === "child-failed") {
-        runDetail = error.message;
-      } else {
-        throw error;
-      }
-    } else {
-      runDetail = error instanceof Error ? error.message : String(error);
-    }
+  const createArgs = buildWindowsSchtasksCreateArgs(script);
+  const runArgs = ["/run", "/tn", TASK];
+  const elevateCreateAndRun = finalizeHooks?.elevateCreateAndRun
+    ?? ((schtasksPath, create, run) => runElevatedSchtasksCreateAndRun(schtasksPath, create, run));
+  const result = await elevateCreateAndRun(windowsSchtasks(), createArgs, runArgs);
+
+  if (result.createExitCode !== 0) {
+    throw new Error(`Elevated schtasks /create failed with exit code ${result.createExitCode}.`);
   }
-  const verification = verifyWindowsSchedulerInstall();
+  if (result.runExitCode === null || result.runExitCode !== 0) {
+    const runCode = result.runExitCode ?? "unknown";
+    const rollbackError = await rollbackElevatedSchedulerTask();
+    failAfterElevatedCreate(
+      `Elevated schtasks /run failed with exit code ${runCode}. The Task Scheduler task was registered but could not be started.`,
+      { rollback: true, rollbackError },
+    );
+  }
+
+  const verification = (finalizeHooks?.verify ?? verifyWindowsSchedulerInstall)();
   if (!verification.ok) {
     // Do not destroy a healthy elevated task solely because WinSW status is unverified.
     const preserveElevatedTask = verification.taskInstalled
@@ -460,23 +499,20 @@ export async function finalizeWindowsSchedulerServiceRegistration(script = windo
       && verification.assetsHealthy
       && !verification.conflict
       && verification.nativeStatusUnknown;
-    const rollbackError = preserveElevatedTask ? null : await rollbackElevatedSchedulerTask();
-    const parts = [
-      "Elevated Task Scheduler registration did not produce a conflict-free install.",
-      verification.detail,
-    ];
-    if (runDetail) parts.push(`Task /run after create: ${runDetail}`);
     if (preserveElevatedTask) {
-      parts.push("The elevated Task Scheduler task was left in place because native WinSW status could not be verified.");
-    } else if (rollbackError) {
-      parts.push(`Rollback also failed: ${rollbackError}`);
-      parts.push(`Remove the task manually with 'schtasks /delete /tn ${TASK} /f' and the native service with 'sc delete ${WINSW_SERVICE_ID}' if present.`);
-    } else {
-      parts.push("The elevated Task Scheduler task was rolled back.");
+      throw new Error([
+        "Elevated Task Scheduler registration did not produce a conflict-free install.",
+        verification.detail,
+        "The elevated Task Scheduler task was left in place because native WinSW status could not be verified.",
+      ].join(" "));
     }
-    throw new Error(parts.join(" "));
+    const rollbackError = await rollbackElevatedSchedulerTask();
+    failAfterElevatedCreate(
+      `Elevated Task Scheduler registration did not produce a conflict-free install. ${verification.detail}`,
+      { rollback: true, rollbackError },
+    );
   }
-  writeServiceInstallState("scheduler");
+  (finalizeHooks?.writeInstallState ?? (() => writeServiceInstallState("scheduler")))();
 }
 
 function windowsBatchValue(value: string): string {

--- a/src/service.ts
+++ b/src/service.ts
@@ -22,6 +22,7 @@ import {
   OCX_ELEVATED_PROTOCOL_FAILED,
   classifyElevatedSchedulerExitCode,
   raceWithTimeout,
+  resolveTrustedWindowsSchtasksExe,
   startElevatedSchtasksCreateAndRun,
   runWindowsElevated,
   toWindowsSchtasksError,
@@ -326,8 +327,7 @@ function runFile(file: string, args: string[]): string {
 }
 
 function windowsSchtasks(): string {
-  const candidate = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "schtasks.exe");
-  return existsSync(candidate) ? candidate : "schtasks.exe";
+  return resolveTrustedWindowsSchtasksExe();
 }
 
 function windowsWscript(): string {

--- a/src/service.ts
+++ b/src/service.ts
@@ -20,7 +20,6 @@ import { randomUUID } from "node:crypto";
 import {
   ELEVATION_REQUEST_TIMEOUT_MS,
   OCX_ELEVATED_PROTOCOL_FAILED,
-  classifyElevatedSchedulerExitCode,
   raceWithTimeout,
   resolveTrustedWindowsSchtasksExe,
   startElevatedSchtasksCreateAndRun,
@@ -335,8 +334,16 @@ function windowsWscript(): string {
   return existsSync(candidate) ? candidate : "wscript.exe";
 }
 
+let querySchtasksForTests: ((args: string[]) => string) | null = null;
+
 function querySchtasks(args: string[]): string {
+  if (querySchtasksForTests) return querySchtasksForTests(args);
   return runFile(windowsSchtasks(), args);
+}
+
+/** Test-only seam for Task Scheduler query used by presence probes. */
+export function setQuerySchtasksForTests(next: ((args: string[]) => string) | null): void {
+  querySchtasksForTests = next;
 }
 
 function schtasks(args: string[]): string {
@@ -593,7 +600,7 @@ async function applyElevatedSchedulerResult(
   if (!attemptStillOwned(options)) {
     return;
   }
-  const outcome: ElevatedSchedulerOutcome = result.outcome ?? classifyElevatedSchedulerExitCode(result.exitCode);
+  const outcome: ElevatedSchedulerOutcome = result.outcome;
 
   if (outcome === "create-failed") {
     throw new Error("Elevated schtasks /create failed. The Task Scheduler task was not registered.");
@@ -611,9 +618,8 @@ async function applyElevatedSchedulerResult(
       "Installation state was not written.",
     ]);
   }
-  if (outcome === "protocol-failed" || outcome !== "success") {
+  if (outcome !== "success") {
     await reconcileUnknownElevatedOutcome(result.exitCode);
-    return;
   }
 
   const verification = (finalizeHooks?.verify ?? verifyWindowsSchedulerInstall)();
@@ -824,15 +830,6 @@ export function evaluateSchedulerInstallRestartReconciliation(inputs: {
       status: "stale-install-state",
       detail: "Scheduler install state is present but the Task Scheduler task is absent.",
     };
-  }
-  if (
-    inputs.taskInstalled
-    && inputs.registrationHealthy
-    && inputs.assetsHealthy
-    && inputs.nativeStatus === "nonexistent"
-    && inputs.installStateBackend === "scheduler"
-  ) {
-    return { status: "healthy", detail: "ok" };
   }
   return { status: "healthy", detail: "ok" };
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -16,7 +16,7 @@ import { isWslRuntime } from "./codex/home";
 import { durableBunPath, durableBunRuntime } from "./lib/bun-runtime";
 import { isProcessAlive, stopProxy } from "./lib/process-control";
 import { serviceApiTokenFilePath } from "./lib/service-secrets";
-import { formatWindowsSchtasksError, runWindowsElevated } from "./lib/windows-elevation";
+import { runWindowsElevated, toWindowsSchtasksError, WindowsElevationError } from "./lib/windows-elevation";
 import { defaultWinswEntry, installWinswService, startWinswService, stopWinswService, statusWinswRaw, uninstallWinswService, winswStatusSummary, WINSW_SERVICE_ID, WINSW_SHA256, WINSW_VERSION } from "./lib/winsw";
 import { hardenSecretDir, hardenSecretPath } from "./lib/windows-secret-acl";
 import { windowsEnvIndirectBatchPathList, windowsEnvIndirectBatchValue } from "./lib/win-paths";
@@ -330,7 +330,7 @@ function schtasks(args: string[]): string {
   try {
     return querySchtasks(args);
   } catch (error) {
-    throw new Error(formatWindowsSchtasksError(error, args));
+    throw toWindowsSchtasksError(error, args);
   }
 }
 
@@ -344,13 +344,89 @@ export function windowsSchedulerTaskInstalled(taskName = TASK): boolean {
   }
 }
 
+export interface WindowsSchedulerInstallVerification {
+  taskInstalled: boolean;
+  registrationHealthy: boolean;
+  assetsHealthy: boolean;
+  nativeServiceAbsent: boolean;
+  conflict: boolean;
+  ok: boolean;
+  detail: string;
+}
+
+/** Pure postcondition evaluation for an elevated scheduler install. */
+export function evaluateWindowsSchedulerInstallVerification(inputs: {
+  taskInstalled: boolean;
+  xml: string;
+  assetsExist: boolean;
+  nativeStatus: "started" | "stopped" | "nonexistent" | "unknown";
+  wscript?: string;
+  launcher?: string;
+}): WindowsSchedulerInstallVerification {
+  const registrationHealthy = inputs.xml.length > 0
+    && windowsTaskRegistrationHealthy(inputs.xml, inputs.wscript, inputs.launcher);
+  const assetsHealthy = inputs.assetsExist;
+  const nativeServiceAbsent = inputs.nativeStatus === "nonexistent";
+  const conflict = inputs.taskInstalled && !nativeServiceAbsent;
+  const ok = inputs.taskInstalled && registrationHealthy && assetsHealthy && nativeServiceAbsent && !conflict;
+  const detail = !inputs.taskInstalled
+    ? "Task Scheduler task is not installed."
+    : conflict
+      ? `CONFLICT: Task Scheduler and native WinSW (${WINSW_SERVICE_ID}) are both present.`
+      : !assetsHealthy
+        ? "Required scheduler service assets are missing."
+        : !registrationHealthy
+          ? "Task Scheduler registration is present but unhealthy."
+          : "ok";
+  return {
+    taskInstalled: inputs.taskInstalled,
+    registrationHealthy,
+    assetsHealthy,
+    nativeServiceAbsent,
+    conflict,
+    ok,
+    detail,
+  };
+}
+
+/** Conflict-free postcondition check for an elevated scheduler install. */
+export function verifyWindowsSchedulerInstall(taskName = TASK): WindowsSchedulerInstallVerification {
+  const taskInstalled = windowsSchedulerTaskInstalled(taskName);
+  const xml = taskInstalled ? (() => {
+    try { return querySchtasks(["/query", "/tn", taskName, "/xml"]); } catch { return ""; }
+  })() : "";
+  return evaluateWindowsSchedulerInstallVerification({
+    taskInstalled,
+    xml,
+    assetsExist: [windowsServiceScriptPath(), windowsLauncherVbsPath(), windowsTaskXmlPath()].every(existsSync),
+    nativeStatus: statusWinswRaw(),
+  });
+}
+
 async function elevateSchtasks(args: string[]): Promise<void> {
-  const exitCode = await runWindowsElevated(windowsSchtasks(), args);
-  if (exitCode === 0) return;
-  if (exitCode === 1223) {
-    throw new Error("Windows administrator approval was required to install the background service, but the UAC prompt was cancelled or denied.");
+  try {
+    const exitCode = await runWindowsElevated(windowsSchtasks(), args);
+    if (exitCode === 0) return;
+    throw new Error(`Background service install failed with exit code ${exitCode}.`);
+  } catch (error) {
+    if (error instanceof WindowsElevationError && error.reason === "cancelled") {
+      throw error;
+    }
+    if (error instanceof WindowsElevationError) throw error;
+    throw error;
   }
-  throw new Error(`Background service install failed with exit code ${exitCode}.`);
+}
+
+async function rollbackElevatedSchedulerTask(taskName = TASK): Promise<string | null> {
+  try {
+    await elevateSchtasks(["/delete", "/tn", taskName, "/f"]);
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  if (windowsSchedulerTaskInstalled(taskName)) {
+    return `Task Scheduler task ${taskName} is still present after rollback.`;
+  }
+  return null;
 }
 
 /** Re-register the scheduler task with elevation after a non-elevated install wrote assets. */
@@ -361,8 +437,28 @@ export async function finalizeWindowsSchedulerServiceRegistration(script = windo
   await elevateSchtasks(buildWindowsSchtasksCreateArgs(script));
   try {
     await elevateSchtasks(["/run", "/tn", TASK]);
-  } catch {
+  } catch (error) {
     // Logon-triggered tasks may still start on the next sign-in even if /run fails.
+    // Cancellation during /run still means the user denied elevation for that step —
+    // continue to verification; creation already succeeded.
+    if (error instanceof WindowsElevationError && error.reason === "cancelled") {
+      /* keep going to verification */
+    }
+  }
+  const verification = verifyWindowsSchedulerInstall();
+  if (!verification.ok) {
+    const rollbackError = await rollbackElevatedSchedulerTask();
+    const parts = [
+      "Elevated Task Scheduler registration did not produce a conflict-free install.",
+      verification.detail,
+    ];
+    if (rollbackError) {
+      parts.push(`Rollback also failed: ${rollbackError}`);
+      parts.push(`Remove the task manually with 'schtasks /delete /tn ${TASK} /f' and the native service with 'sc delete ${WINSW_SERVICE_ID}' if present.`);
+    } else {
+      parts.push("The elevated Task Scheduler task was rolled back.");
+    }
+    throw new Error(parts.join(" "));
   }
   writeServiceInstallState("scheduler");
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -347,14 +347,66 @@ function schtasks(args: string[]): string {
   }
 }
 
-/** True when the Task Scheduler registration for the default proxy task exists. */
-export function windowsSchedulerTaskInstalled(taskName = TASK): boolean {
-  if (process.platform !== "win32") return false;
-  try {
-    return querySchtasks(["/query", "/tn", taskName]).includes(taskName);
-  } catch {
-    return false;
+/** Tri-state Task Scheduler presence: never treat a failed query as proven absence. */
+export type WindowsSchedulerTaskProbe =
+  | { status: "present" }
+  | { status: "absent" }
+  | { status: "unknown"; detail: string };
+
+function schtasksErrorDetail(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** True when a schtasks CSV listing line refers to the given task name. */
+export function windowsSchedulerCsvIncludesTask(csv: string, taskName: string): boolean {
+  const needle = taskName.toLowerCase();
+  for (const line of csv.split(/\r?\n/)) {
+    const lower = line.toLowerCase();
+    if (!lower.includes(needle)) continue;
+    // Prefer exact CSV field matches ("\TaskName" / "TaskName") before a substring hit.
+    if (
+      lower.includes(`"\\${needle}"`)
+      || lower.includes(`"${needle}"`)
+      || new RegExp(`(^|[,\\\\])${needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}([,"]|$)`).test(lower)
+    ) {
+      return true;
+    }
   }
+  return false;
+}
+
+/**
+ * Probe whether the OpenCodex Task Scheduler task exists.
+ * Query failures fall back to a CSV listing before concluding absence; if both
+ * fail, returns `unknown` so callers can fail closed instead of releasing locks.
+ */
+export function probeWindowsSchedulerTask(taskName = TASK): WindowsSchedulerTaskProbe {
+  if (process.platform !== "win32") return { status: "absent" };
+
+  let queryFailure: string | null = null;
+  try {
+    const out = querySchtasks(["/query", "/tn", taskName]);
+    if (out.includes(taskName)) return { status: "present" };
+  } catch (error) {
+    queryFailure = schtasksErrorDetail(error);
+  }
+
+  try {
+    const csv = querySchtasks(["/query", "/fo", "CSV"]);
+    if (windowsSchedulerCsvIncludesTask(csv, taskName)) return { status: "present" };
+    return { status: "absent" };
+  } catch (error) {
+    const listDetail = schtasksErrorDetail(error);
+    const detail = queryFailure
+      ? `Specific query failed (${queryFailure}); CSV listing also failed (${listDetail}).`
+      : `Task query did not confirm presence and CSV listing failed (${listDetail}).`;
+    return { status: "unknown", detail };
+  }
+}
+
+/** True when the Task Scheduler registration for the default proxy task is proven present. */
+export function windowsSchedulerTaskInstalled(taskName = TASK): boolean {
+  return probeWindowsSchedulerTask(taskName).status === "present";
 }
 
 export interface WindowsSchedulerInstallVerification {
@@ -437,11 +489,12 @@ async function rollbackElevatedSchedulerTask(taskName = TASK): Promise<string | 
   } catch (error) {
     return error instanceof Error ? error.message : String(error);
   }
-  const stillInstalled = finalizeHooks?.taskInstalled?.() ?? windowsSchedulerTaskInstalled(taskName);
-  if (stillInstalled) {
-    return `Task Scheduler task ${taskName} is still present after rollback.`;
+  const probe = resolveWindowsSchedulerTaskProbe(taskName);
+  if (probe.status === "absent") return null;
+  if (probe.status === "unknown") {
+    return `Task Scheduler task ${taskName} presence could not be verified after rollback: ${probe.detail}`;
   }
-  return null;
+  return `Task Scheduler task ${taskName} is still present after rollback.`;
 }
 
 type ElevateCreateAndRunStart = (
@@ -462,6 +515,9 @@ type FinalizeHooks = {
   ) => Promise<ElevatedSchtasksCreateAndRunResult>;
   verify?: () => WindowsSchedulerInstallVerification;
   writeInstallState?: () => void;
+  /** Preferred tri-state probe for security-sensitive reconciliation. */
+  probeTask?: () => WindowsSchedulerTaskProbe;
+  /** Legacy boolean hook; mapped to present/absent when probeTask is unset. */
   taskInstalled?: () => boolean;
   /** Defense-in-depth: late reconciliation must still own this attempt. */
   stillOwnsAttempt?: (attemptId: string) => boolean;
@@ -469,6 +525,14 @@ type FinalizeHooks = {
 };
 
 let finalizeHooks: FinalizeHooks | null = null;
+
+function resolveWindowsSchedulerTaskProbe(taskName = TASK): WindowsSchedulerTaskProbe {
+  if (finalizeHooks?.probeTask) return finalizeHooks.probeTask();
+  if (finalizeHooks?.taskInstalled) {
+    return finalizeHooks.taskInstalled() ? { status: "present" } : { status: "absent" };
+  }
+  return probeWindowsSchedulerTask(taskName);
+}
 
 /** Test-only hooks for elevated create+run finalization. */
 export function setFinalizeWindowsSchedulerHooksForTests(hooks: FinalizeHooks | null): void {
@@ -482,15 +546,21 @@ function throwPartialInstall(parts: string[]): never {
 /**
  * Reconcile an unrecognized elevated exit when we cannot trust the phase code.
  * Never invent a create-vs-run classification; inspect actual task state first.
+ * An unverifiable probe must fail closed (partial / blocked), never release.
  */
 async function reconcileUnknownElevatedOutcome(exitCode: number): Promise<void> {
-  const taskPresent = finalizeHooks?.taskInstalled?.() ?? windowsSchedulerTaskInstalled();
+  const probe = resolveWindowsSchedulerTaskProbe();
   const parts = [
     "The elevated Task Scheduler operation returned an unknown result.",
     `Exit code: ${exitCode}.`,
     "OpenCodex could not prove whether task creation completed, so installation state was not written.",
   ];
-  if (!taskPresent) {
+  if (probe.status === "unknown") {
+    parts.push(`Task Scheduler presence could not be verified: ${probe.detail}`);
+    parts.push("A partial Task Scheduler backend may remain.");
+    throwPartialInstall(parts);
+  }
+  if (probe.status === "absent") {
     parts.push("No OpenCodex Task Scheduler task was found after the elevated operation.");
     throwPartialInstall(parts);
   }
@@ -625,7 +695,8 @@ function isPartialInstallError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   return /partial Task Scheduler/i.test(error.message)
     || /Cleanup also failed/i.test(error.message)
-    || /left in place because native WinSW status could not be verified/i.test(error.message);
+    || /left in place because native WinSW status could not be verified/i.test(error.message)
+    || /Task Scheduler presence could not be verified/i.test(error.message);
 }
 
 /**

--- a/tests/startup-action-control-elevation.test.ts
+++ b/tests/startup-action-control-elevation.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as childProcess from "node:child_process";
+import * as actualService from "../src/service";
+
+const execFileMock = mock((
+  _file: string,
+  _args: string[],
+  _options: unknown,
+  callback: (error: Error | null, stdout?: string, stderr?: string) => void,
+) => {
+  callback(null, "", "");
+});
+
+const finalizeWindowsSchedulerServiceRegistrationMock = mock(async () => {});
+const windowsSchedulerTaskInstalledMock = mock(() => true);
+
+mock.module("node:child_process", () => ({
+  ...childProcess,
+  execFile: execFileMock,
+}));
+
+mock.module("../src/service", () => ({
+  ...actualService,
+  finalizeWindowsSchedulerServiceRegistration: finalizeWindowsSchedulerServiceRegistrationMock,
+  windowsSchedulerTaskInstalled: windowsSchedulerTaskInstalledMock,
+}));
+
+const { runStartupInstallAction } = await import("../src/server/startup-action-control");
+
+describe("startup install elevation retry", () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    execFileMock.mockReset();
+    finalizeWindowsSchedulerServiceRegistrationMock.mockReset();
+    windowsSchedulerTaskInstalledMock.mockReset();
+    windowsSchedulerTaskInstalledMock.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  test("retries scheduler registration when the child install reports access denied", async () => {
+    execFileMock.mockImplementation((
+      _file: string,
+      _args: string[],
+      _options: unknown,
+      callback: (error: Error | null, stdout?: string, stderr?: string) => void,
+    ) => {
+      callback(new Error("Windows access denied while running Task Scheduler."), "", "");
+    });
+
+    const result = await runStartupInstallAction("install-service");
+
+    expect(result).toEqual({ message: "Background service installed." });
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(finalizeWindowsSchedulerServiceRegistrationMock).toHaveBeenCalledTimes(1);
+    expect(windowsSchedulerTaskInstalledMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("fails when scheduler registration still did not create the task", async () => {
+    execFileMock.mockImplementation((
+      _file: string,
+      _args: string[],
+      _options: unknown,
+      callback: (error: Error | null, stdout?: string, stderr?: string) => void,
+    ) => {
+      callback(new Error("Windows access denied while running Task Scheduler."), "", "");
+    });
+    windowsSchedulerTaskInstalledMock.mockReturnValue(false);
+
+    await expect(runStartupInstallAction("install-service")).rejects.toThrow(
+      "Background service install still failed after requesting administrator approval.",
+    );
+    expect(finalizeWindowsSchedulerServiceRegistrationMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not retry non-service installs", async () => {
+    execFileMock.mockImplementation((
+      _file: string,
+      _args: string[],
+      _options: unknown,
+      callback: (error: Error | null, stdout?: string, stderr?: string) => void,
+    ) => {
+      callback(new Error("Windows access denied while running Task Scheduler."), "", "");
+    });
+
+    await expect(runStartupInstallAction("install-shim")).rejects.toThrow(
+      "Windows access denied while running Task Scheduler.",
+    );
+    expect(finalizeWindowsSchedulerServiceRegistrationMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/startup-action-control-elevation.test.ts
+++ b/tests/startup-action-control-elevation.test.ts
@@ -24,7 +24,7 @@ mock.module("../src/service", () => ({
   finalizeWindowsSchedulerServiceRegistration: finalizeWindowsSchedulerServiceRegistrationMock,
 }));
 
-const { runStartupInstallAction } = await import("../src/server/startup-action-control");
+const { installFailureDetail, runStartupInstallAction } = await import("../src/server/startup-action-control");
 
 describe("startup install elevation retry", () => {
   const originalPlatform = process.platform;
@@ -51,6 +51,17 @@ describe("startup install elevation retry", () => {
     });
   }
 
+  function failCliStreams(stdout: string, stderr: string) {
+    execFileMock.mockImplementation((
+      _file: string,
+      _args: string[],
+      _options: unknown,
+      callback: (error: Error | null, stdout?: string, stderr?: string) => void,
+    ) => {
+      callback(new Error("Command failed"), stdout, stderr);
+    });
+  }
+
   test("retries only for structured schtasks /create access denied", async () => {
     failCli(`Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`);
 
@@ -59,6 +70,25 @@ describe("startup install elevation retry", () => {
     expect(result).toEqual({ message: "Background service installed." });
     expect(execFileMock).toHaveBeenCalledTimes(1);
     expect(finalizeWindowsSchedulerServiceRegistrationMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries when the create-access-denied marker is on stdout and stderr has noise", async () => {
+    // Mirrors CLI→proxy boundary: marker must survive even if stderr wins a single-stream pick.
+    failCliStreams(
+      `Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`,
+      "WARNING: unrelated installer warning",
+    );
+
+    const result = await runStartupInstallAction("install-service");
+
+    expect(result).toEqual({ message: "Background service installed." });
+    expect(finalizeWindowsSchedulerServiceRegistrationMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not elevate when marker is absent across both streams", async () => {
+    failCliStreams("service install failed", "Access is denied.");
+    await expect(runStartupInstallAction("install-service")).rejects.toThrow(/Access is denied/);
+    expect(finalizeWindowsSchedulerServiceRegistrationMock).not.toHaveBeenCalled();
   });
 
   test("does not elevate for WinSW removal access denied", async () => {
@@ -100,5 +130,29 @@ describe("startup install elevation retry", () => {
 
     await expect(runStartupInstallAction("install-service")).rejects.toThrow(/CONFLICT/);
     expect(finalizeWindowsSchedulerServiceRegistrationMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("installFailureDetail CLI→proxy marker contract", () => {
+  test("combines stderr and stdout so a stdout marker survives stderr noise", () => {
+    const detail = installFailureDetail(
+      `guidance\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`,
+      "WARNING: noisy stderr",
+      new Error("Command failed"),
+    );
+    expect(detail).toContain("WARNING: noisy stderr");
+    expect(detail).toContain(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER);
+  });
+
+  test("caps detail length while preserving the elevation marker", () => {
+    const marker = WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER;
+    const detail = installFailureDetail(
+      `${"x".repeat(3_000)}\n${marker}`,
+      "stderr-head",
+      new Error("Command failed"),
+    );
+    expect(detail.length).toBeLessThanOrEqual(2_000 + marker.length + 40);
+    expect(detail).toContain(marker);
+    expect(detail).toContain("truncated");
   });
 });

--- a/tests/startup-action-control-elevation.test.ts
+++ b/tests/startup-action-control-elevation.test.ts
@@ -241,6 +241,29 @@ describe("startup install elevation retry", () => {
     await Promise.resolve();
     expect(getStartupInstallState()).toMatchObject({ attemptId: "new-attempt", status: "indeterminate" });
   });
+
+  test("rejected reconciliation fails closed into blocked state", async () => {
+    failCli(`Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`);
+    let rejectReconciliation!: (error: Error) => void;
+    const reconciliation = new Promise<"released" | "blocked-partial">((_, reject) => {
+      rejectReconciliation = reject;
+    });
+    finalizeMock.mockResolvedValue({
+      kind: "indeterminate",
+      attemptId: "attempt-reject-1",
+      reconciliation,
+    });
+
+    await expect(runStartupInstallAction("install-service")).rejects.toThrow(/may still be running/);
+    rejectReconciliation(new Error("reconciliation boom"));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(getStartupInstallState()).toMatchObject({
+      status: "blocked",
+      reason: "partial-elevated-install",
+      attemptId: "attempt-reject-1",
+    });
+  });
 });
 
 describe("classifyCliInstallFailure marker transport", () => {

--- a/tests/startup-action-control-elevation.test.ts
+++ b/tests/startup-action-control-elevation.test.ts
@@ -79,6 +79,26 @@ describe("startup install elevation retry", () => {
     expect(getStartupInstallState().status).toBe("idle");
   });
 
+  test("UAC cancellation during elevated retry surfaces and leaves the lock idle", async () => {
+    failCli(`Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`);
+    finalizeMock.mockRejectedValue(
+      new Error("Windows administrator approval was required, but the UAC prompt was cancelled or denied."),
+    );
+    await expect(runStartupInstallAction("install-service")).rejects.toThrow(/UAC prompt was cancelled/);
+    expect(finalizeMock).toHaveBeenCalledTimes(1);
+    expect(getStartupInstallState().status).toBe("idle");
+  });
+
+  test("elevated success that cannot prove the task is present does not leave a false idle install", async () => {
+    failCli(`Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`);
+    finalizeMock.mockRejectedValue(
+      new Error("Elevated Task Scheduler registration did not produce a conflict-free install. Task Scheduler task is not installed."),
+    );
+    await expect(runStartupInstallAction("install-service")).rejects.toThrow(/not installed/);
+    expect(finalizeMock).toHaveBeenCalledTimes(1);
+    expect(getStartupInstallState().status).toBe("idle");
+  });
+
   test("retries when the create-access-denied marker is on stdout and stderr has noise", async () => {
     failCliStreams(
       `Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`,
@@ -259,8 +279,7 @@ describe("startup install elevation retry", () => {
 
     await expect(runStartupInstallAction("install-service")).rejects.toThrow(/may still be running/);
     rejectReconciliation(new Error("reconciliation boom"));
-    await Promise.resolve();
-    await Promise.resolve();
+    await reconciliation.catch(() => {});
     expect(getStartupInstallState()).toMatchObject({
       status: "blocked",
       reason: "partial-elevated-install",

--- a/tests/startup-action-control-elevation.test.ts
+++ b/tests/startup-action-control-elevation.test.ts
@@ -207,8 +207,11 @@ describe("startup install elevation retry", () => {
     });
 
     await expect(runStartupInstallAction("install-service")).rejects.toThrow(/partial Task Scheduler state/);
-    expect(clearStartupInstallPartialBlock({ taskInstalled: true }).cleared).toBe(false);
-    expect(clearStartupInstallPartialBlock({ taskInstalled: false }).cleared).toBe(true);
+    expect(clearStartupInstallPartialBlock({ probe: { status: "present" } }).cleared).toBe(false);
+    expect(clearStartupInstallPartialBlock({
+      probe: { status: "unknown", detail: "Access is denied." },
+    }).cleared).toBe(false);
+    expect(clearStartupInstallPartialBlock({ probe: { status: "absent" } }).cleared).toBe(true);
     expect(getStartupInstallState().status).toBe("idle");
   });
 

--- a/tests/startup-action-control-elevation.test.ts
+++ b/tests/startup-action-control-elevation.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import * as childProcess from "node:child_process";
+import { WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER } from "../src/lib/windows-elevation";
 import * as actualService from "../src/service";
 
 const execFileMock = mock((
@@ -12,7 +13,6 @@ const execFileMock = mock((
 });
 
 const finalizeWindowsSchedulerServiceRegistrationMock = mock(async () => {});
-const windowsSchedulerTaskInstalledMock = mock(() => true);
 
 mock.module("node:child_process", () => ({
   ...childProcess,
@@ -22,7 +22,6 @@ mock.module("node:child_process", () => ({
 mock.module("../src/service", () => ({
   ...actualService,
   finalizeWindowsSchedulerServiceRegistration: finalizeWindowsSchedulerServiceRegistrationMock,
-  windowsSchedulerTaskInstalled: windowsSchedulerTaskInstalledMock,
 }));
 
 const { runStartupInstallAction } = await import("../src/server/startup-action-control");
@@ -34,62 +33,72 @@ describe("startup install elevation retry", () => {
     Object.defineProperty(process, "platform", { value: "win32" });
     execFileMock.mockReset();
     finalizeWindowsSchedulerServiceRegistrationMock.mockReset();
-    windowsSchedulerTaskInstalledMock.mockReset();
-    windowsSchedulerTaskInstalledMock.mockReturnValue(true);
+    finalizeWindowsSchedulerServiceRegistrationMock.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
     Object.defineProperty(process, "platform", { value: originalPlatform });
   });
 
-  test("retries scheduler registration when the child install reports access denied", async () => {
+  function failCli(message: string) {
     execFileMock.mockImplementation((
       _file: string,
       _args: string[],
       _options: unknown,
       callback: (error: Error | null, stdout?: string, stderr?: string) => void,
     ) => {
-      callback(new Error("Windows access denied while running Task Scheduler."), "", "");
+      callback(new Error(message), "", message);
     });
+  }
+
+  test("retries only for structured schtasks /create access denied", async () => {
+    failCli(`Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`);
 
     const result = await runStartupInstallAction("install-service");
 
     expect(result).toEqual({ message: "Background service installed." });
     expect(execFileMock).toHaveBeenCalledTimes(1);
     expect(finalizeWindowsSchedulerServiceRegistrationMock).toHaveBeenCalledTimes(1);
-    expect(windowsSchedulerTaskInstalledMock).toHaveBeenCalledTimes(1);
   });
 
-  test("fails when scheduler registration still did not create the task", async () => {
-    execFileMock.mockImplementation((
-      _file: string,
-      _args: string[],
-      _options: unknown,
-      callback: (error: Error | null, stdout?: string, stderr?: string) => void,
-    ) => {
-      callback(new Error("Windows access denied while running Task Scheduler."), "", "");
-    });
-    windowsSchedulerTaskInstalledMock.mockReturnValue(false);
-
-    await expect(runStartupInstallAction("install-service")).rejects.toThrow(
-      "Background service install still failed after requesting administrator approval.",
-    );
-    expect(finalizeWindowsSchedulerServiceRegistrationMock).toHaveBeenCalledTimes(1);
-  });
-
-  test("does not retry non-service installs", async () => {
-    execFileMock.mockImplementation((
-      _file: string,
-      _args: string[],
-      _options: unknown,
-      callback: (error: Error | null, stdout?: string, stderr?: string) => void,
-    ) => {
-      callback(new Error("Windows access denied while running Task Scheduler."), "", "");
-    });
-
-    await expect(runStartupInstallAction("install-shim")).rejects.toThrow(
-      "Windows access denied while running Task Scheduler.",
-    );
+  test("does not elevate for WinSW removal access denied", async () => {
+    failCli("Cannot remove the native service before switching to Task Scheduler: Access is denied.");
+    await expect(runStartupInstallAction("install-service")).rejects.toThrow(/Cannot remove the native service/);
     expect(finalizeWindowsSchedulerServiceRegistrationMock).not.toHaveBeenCalled();
+  });
+
+  test("does not elevate for asset-write access denied", async () => {
+    failCli("EACCES: permission denied, open 'C:\\Users\\x\\.opencodex\\opencodex-service.cmd'");
+    await expect(runStartupInstallAction("install-service")).rejects.toThrow(/EACCES/);
+    expect(finalizeWindowsSchedulerServiceRegistrationMock).not.toHaveBeenCalled();
+  });
+
+  test("does not elevate for generic access-denied stderr", async () => {
+    failCli("Access is denied.");
+    await expect(runStartupInstallAction("install-service")).rejects.toThrow("Access is denied.");
+    expect(finalizeWindowsSchedulerServiceRegistrationMock).not.toHaveBeenCalled();
+  });
+
+  test("does not elevate install-shim", async () => {
+    failCli(`Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`);
+    await expect(runStartupInstallAction("install-shim")).rejects.toThrow(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER);
+    expect(finalizeWindowsSchedulerServiceRegistrationMock).not.toHaveBeenCalled();
+  });
+
+  test("does not elevate on non-Windows platforms", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    failCli(`Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`);
+    await expect(runStartupInstallAction("install-service")).rejects.toThrow(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER);
+    expect(finalizeWindowsSchedulerServiceRegistrationMock).not.toHaveBeenCalled();
+  });
+
+  test("surfaces finalize conflict/rollback failures without reporting success", async () => {
+    failCli(`Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`);
+    finalizeWindowsSchedulerServiceRegistrationMock.mockRejectedValue(
+      new Error("Elevated Task Scheduler registration did not produce a conflict-free install. CONFLICT: Task Scheduler and native WinSW are both present."),
+    );
+
+    await expect(runStartupInstallAction("install-service")).rejects.toThrow(/CONFLICT/);
+    expect(finalizeWindowsSchedulerServiceRegistrationMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/startup-action-control-elevation.test.ts
+++ b/tests/startup-action-control-elevation.test.ts
@@ -11,7 +11,7 @@ const execFileMock = mock((
   callback(null, "", "");
 });
 
-const finalizeMock = mock(async () => {});
+const finalizeMock = mock(async () => ({ kind: "done" as const }));
 
 mock.module("node:child_process", () => ({
   ...childProcess,
@@ -20,7 +20,10 @@ mock.module("node:child_process", () => ({
 
 const {
   classifyCliInstallFailure,
+  clearStartupInstallPartialBlock,
+  getStartupInstallState,
   installFailureDetail,
+  resetStartupInstallStateForTests,
   runStartupInstallAction,
   setStartupInstallFinalizeForTests,
 } = await import("../src/server/startup-action-control");
@@ -30,15 +33,17 @@ describe("startup install elevation retry", () => {
 
   beforeEach(() => {
     Object.defineProperty(process, "platform", { value: "win32" });
+    resetStartupInstallStateForTests();
     execFileMock.mockReset();
     finalizeMock.mockReset();
-    finalizeMock.mockResolvedValue(undefined);
+    finalizeMock.mockResolvedValue({ kind: "done" });
     setStartupInstallFinalizeForTests(finalizeMock as never);
   });
 
   afterEach(() => {
     Object.defineProperty(process, "platform", { value: originalPlatform });
     setStartupInstallFinalizeForTests(null);
+    resetStartupInstallStateForTests();
   });
 
   function failCli(message: string) {
@@ -71,6 +76,7 @@ describe("startup install elevation retry", () => {
     expect(result).toEqual({ message: "Background service installed." });
     expect(execFileMock).toHaveBeenCalledTimes(1);
     expect(finalizeMock).toHaveBeenCalledTimes(1);
+    expect(getStartupInstallState().status).toBe("idle");
   });
 
   test("retries when the create-access-denied marker is on stdout and stderr has noise", async () => {
@@ -138,6 +144,102 @@ describe("startup install elevation retry", () => {
 
     await expect(runStartupInstallAction("install-service")).rejects.toThrow(/CONFLICT/);
     expect(finalizeMock).toHaveBeenCalledTimes(1);
+    expect(getStartupInstallState().status).toBe("idle");
+  });
+
+  test("elevation request timeout enters indeterminate and blocks new installs", async () => {
+    failCli(`Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`);
+    let resolveReconciliation!: (value: "released" | "blocked-partial") => void;
+    const reconciliation = new Promise<"released" | "blocked-partial">(resolve => {
+      resolveReconciliation = resolve;
+    });
+    finalizeMock.mockResolvedValue({
+      kind: "indeterminate",
+      attemptId: "attempt-timeout-1",
+      reconciliation,
+    });
+
+    await expect(runStartupInstallAction("install-service")).rejects.toThrow(
+      /elevated Task Scheduler transaction may still be running/,
+    );
+    expect(getStartupInstallState()).toMatchObject({
+      status: "indeterminate",
+      attemptId: "attempt-timeout-1",
+      action: "install-service",
+    });
+
+    await expect(runStartupInstallAction("install-service")).rejects.toThrow(/still being reconciled/);
+    await expect(runStartupInstallAction("install-shim")).rejects.toThrow(/still being reconciled/);
+    expect(finalizeMock).toHaveBeenCalledTimes(1);
+
+    resolveReconciliation("released");
+    await reconciliation;
+    await Promise.resolve();
+    expect(getStartupInstallState().status).toBe("idle");
+
+    failCli(`Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`);
+    finalizeMock.mockResolvedValue({ kind: "done" });
+    await expect(runStartupInstallAction("install-service")).resolves.toEqual({
+      message: "Background service installed.",
+    });
+  });
+
+  test("late blocked-partial keeps install lock blocked until cleared", async () => {
+    failCli(`Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`);
+    let resolveReconciliation!: (value: "released" | "blocked-partial") => void;
+    const reconciliation = new Promise<"released" | "blocked-partial">(resolve => {
+      resolveReconciliation = resolve;
+    });
+    finalizeMock.mockResolvedValue({
+      kind: "indeterminate",
+      attemptId: "attempt-partial-1",
+      reconciliation,
+    });
+
+    await expect(runStartupInstallAction("install-service")).rejects.toThrow(/may still be running/);
+    resolveReconciliation("blocked-partial");
+    await reconciliation;
+    await Promise.resolve();
+    expect(getStartupInstallState()).toMatchObject({
+      status: "blocked",
+      reason: "partial-elevated-install",
+      attemptId: "attempt-partial-1",
+    });
+
+    await expect(runStartupInstallAction("install-service")).rejects.toThrow(/partial Task Scheduler state/);
+    expect(clearStartupInstallPartialBlock({ taskInstalled: true }).cleared).toBe(false);
+    expect(clearStartupInstallPartialBlock({ taskInstalled: false }).cleared).toBe(true);
+    expect(getStartupInstallState().status).toBe("idle");
+  });
+
+  test("stale reconciliation cannot clear a newer indeterminate attempt", async () => {
+    failCli(`Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`);
+    let resolveOld!: (value: "released" | "blocked-partial") => void;
+    const oldReconciliation = new Promise<"released" | "blocked-partial">(resolve => {
+      resolveOld = resolve;
+    });
+    finalizeMock.mockResolvedValue({
+      kind: "indeterminate",
+      attemptId: "old-attempt",
+      reconciliation: oldReconciliation,
+    });
+    await expect(runStartupInstallAction("install-service")).rejects.toThrow(/may still be running/);
+
+    // Simulate an ownership hand-off that should not happen in production, then prove defense-in-depth.
+    resetStartupInstallStateForTests();
+    finalizeMock.mockResolvedValue({
+      kind: "indeterminate",
+      attemptId: "new-attempt",
+      reconciliation: new Promise<"released">(() => {}),
+    });
+    failCli(`Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`);
+    await expect(runStartupInstallAction("install-service")).rejects.toThrow(/may still be running/);
+    expect(getStartupInstallState()).toMatchObject({ attemptId: "new-attempt", status: "indeterminate" });
+
+    resolveOld("released");
+    await oldReconciliation;
+    await Promise.resolve();
+    expect(getStartupInstallState()).toMatchObject({ attemptId: "new-attempt", status: "indeterminate" });
   });
 });
 

--- a/tests/startup-action-control-elevation.test.ts
+++ b/tests/startup-action-control-elevation.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import * as childProcess from "node:child_process";
 import { WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER } from "../src/lib/windows-elevation";
-import * as actualService from "../src/service";
 
 const execFileMock = mock((
   _file: string,
@@ -12,19 +11,19 @@ const execFileMock = mock((
   callback(null, "", "");
 });
 
-const finalizeWindowsSchedulerServiceRegistrationMock = mock(async () => {});
+const finalizeMock = mock(async () => {});
 
 mock.module("node:child_process", () => ({
   ...childProcess,
   execFile: execFileMock,
 }));
 
-mock.module("../src/service", () => ({
-  ...actualService,
-  finalizeWindowsSchedulerServiceRegistration: finalizeWindowsSchedulerServiceRegistrationMock,
-}));
-
-const { installFailureDetail, runStartupInstallAction } = await import("../src/server/startup-action-control");
+const {
+  classifyCliInstallFailure,
+  installFailureDetail,
+  runStartupInstallAction,
+  setStartupInstallFinalizeForTests,
+} = await import("../src/server/startup-action-control");
 
 describe("startup install elevation retry", () => {
   const originalPlatform = process.platform;
@@ -32,12 +31,14 @@ describe("startup install elevation retry", () => {
   beforeEach(() => {
     Object.defineProperty(process, "platform", { value: "win32" });
     execFileMock.mockReset();
-    finalizeWindowsSchedulerServiceRegistrationMock.mockReset();
-    finalizeWindowsSchedulerServiceRegistrationMock.mockResolvedValue(undefined);
+    finalizeMock.mockReset();
+    finalizeMock.mockResolvedValue(undefined);
+    setStartupInstallFinalizeForTests(finalizeMock as never);
   });
 
   afterEach(() => {
     Object.defineProperty(process, "platform", { value: originalPlatform });
+    setStartupInstallFinalizeForTests(null);
   });
 
   function failCli(message: string) {
@@ -69,11 +70,10 @@ describe("startup install elevation retry", () => {
 
     expect(result).toEqual({ message: "Background service installed." });
     expect(execFileMock).toHaveBeenCalledTimes(1);
-    expect(finalizeWindowsSchedulerServiceRegistrationMock).toHaveBeenCalledTimes(1);
+    expect(finalizeMock).toHaveBeenCalledTimes(1);
   });
 
   test("retries when the create-access-denied marker is on stdout and stderr has noise", async () => {
-    // Mirrors CLI→proxy boundary: marker must survive even if stderr wins a single-stream pick.
     failCliStreams(
       `Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`,
       "WARNING: unrelated installer warning",
@@ -82,77 +82,106 @@ describe("startup install elevation retry", () => {
     const result = await runStartupInstallAction("install-service");
 
     expect(result).toEqual({ message: "Background service installed." });
-    expect(finalizeWindowsSchedulerServiceRegistrationMock).toHaveBeenCalledTimes(1);
+    expect(finalizeMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries when the marker is only on stderr", async () => {
+    failCliStreams("", `denied\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`);
+    await expect(runStartupInstallAction("install-service")).resolves.toEqual({
+      message: "Background service installed.",
+    });
+    expect(finalizeMock).toHaveBeenCalledTimes(1);
   });
 
   test("does not elevate when marker is absent across both streams", async () => {
     failCliStreams("service install failed", "Access is denied.");
     await expect(runStartupInstallAction("install-service")).rejects.toThrow(/Access is denied/);
-    expect(finalizeWindowsSchedulerServiceRegistrationMock).not.toHaveBeenCalled();
+    expect(finalizeMock).not.toHaveBeenCalled();
   });
 
   test("does not elevate for WinSW removal access denied", async () => {
     failCli("Cannot remove the native service before switching to Task Scheduler: Access is denied.");
     await expect(runStartupInstallAction("install-service")).rejects.toThrow(/Cannot remove the native service/);
-    expect(finalizeWindowsSchedulerServiceRegistrationMock).not.toHaveBeenCalled();
+    expect(finalizeMock).not.toHaveBeenCalled();
   });
 
   test("does not elevate for asset-write access denied", async () => {
     failCli("EACCES: permission denied, open 'C:\\Users\\x\\.opencodex\\opencodex-service.cmd'");
     await expect(runStartupInstallAction("install-service")).rejects.toThrow(/EACCES/);
-    expect(finalizeWindowsSchedulerServiceRegistrationMock).not.toHaveBeenCalled();
+    expect(finalizeMock).not.toHaveBeenCalled();
   });
 
   test("does not elevate for generic access-denied stderr", async () => {
     failCli("Access is denied.");
     await expect(runStartupInstallAction("install-service")).rejects.toThrow("Access is denied.");
-    expect(finalizeWindowsSchedulerServiceRegistrationMock).not.toHaveBeenCalled();
+    expect(finalizeMock).not.toHaveBeenCalled();
   });
 
   test("does not elevate install-shim", async () => {
     failCli(`Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`);
     await expect(runStartupInstallAction("install-shim")).rejects.toThrow(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER);
-    expect(finalizeWindowsSchedulerServiceRegistrationMock).not.toHaveBeenCalled();
+    expect(finalizeMock).not.toHaveBeenCalled();
   });
 
   test("does not elevate on non-Windows platforms", async () => {
     Object.defineProperty(process, "platform", { value: "linux" });
     failCli(`Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`);
     await expect(runStartupInstallAction("install-service")).rejects.toThrow(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER);
-    expect(finalizeWindowsSchedulerServiceRegistrationMock).not.toHaveBeenCalled();
+    expect(finalizeMock).not.toHaveBeenCalled();
   });
 
   test("surfaces finalize conflict/rollback failures without reporting success", async () => {
     failCli(`Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`);
-    finalizeWindowsSchedulerServiceRegistrationMock.mockRejectedValue(
+    finalizeMock.mockRejectedValue(
       new Error("Elevated Task Scheduler registration did not produce a conflict-free install. CONFLICT: Task Scheduler and native WinSW are both present."),
     );
 
     await expect(runStartupInstallAction("install-service")).rejects.toThrow(/CONFLICT/);
-    expect(finalizeWindowsSchedulerServiceRegistrationMock).toHaveBeenCalledTimes(1);
+    expect(finalizeMock).toHaveBeenCalledTimes(1);
   });
 });
 
-describe("installFailureDetail CLI→proxy marker contract", () => {
-  test("combines stderr and stdout so a stdout marker survives stderr noise", () => {
-    const detail = installFailureDetail(
-      `guidance\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`,
-      "WARNING: noisy stderr",
-      new Error("Command failed"),
-    );
-    expect(detail).toContain("WARNING: noisy stderr");
-    expect(detail).toContain(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER);
+describe("classifyCliInstallFailure marker transport", () => {
+  test("marker in stderr only", () => {
+    const failure = classifyCliInstallFailure("", `x\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`, new Error("fail"));
+    expect(failure.code).toBe(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER);
+    expect(failure.detail).toContain(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER);
   });
 
-  test("caps detail length while preserving the elevation marker", () => {
-    const marker = WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER;
-    const detail = installFailureDetail(
-      `${"x".repeat(3_000)}\n${marker}`,
+  test("marker in stdout only", () => {
+    const failure = classifyCliInstallFailure(`x\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`, "", new Error("fail"));
+    expect(failure.code).toBe(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER);
+  });
+
+  test("marker in stdout plus unrelated stderr warning", () => {
+    const failure = classifyCliInstallFailure(
+      WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER,
+      "WARNING: noise",
+      new Error("Command failed"),
+    );
+    expect(failure.code).toBe(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER);
+    expect(failure.detail).toContain("WARNING: noise");
+  });
+
+  test("generic access-denied text without marker", () => {
+    const failure = classifyCliInstallFailure("", "Access is denied.", new Error("Command failed"));
+    expect(failure.code).toBeNull();
+  });
+
+  test("marker beyond displayed truncation boundary is preserved", () => {
+    const failure = classifyCliInstallFailure(
+      `${"x".repeat(3_000)}\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`,
       "stderr-head",
       new Error("Command failed"),
     );
-    expect(detail.length).toBeLessThanOrEqual(2_000 + marker.length + 40);
-    expect(detail).toContain(marker);
-    expect(detail).toContain("truncated");
+    expect(failure.code).toBe(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER);
+    expect(failure.detail).toContain(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER);
+    expect(failure.detail).toContain("truncated");
+  });
+
+  test("falls back to error.message when streams are empty", () => {
+    const failure = classifyCliInstallFailure("", "", new Error("only-message"));
+    expect(failure.detail).toBe("only-message");
+    expect(installFailureDetail("", "", new Error("only-message"))).toBe("only-message");
   });
 });

--- a/tests/windows-elevation-spawn.test.ts
+++ b/tests/windows-elevation-spawn.test.ts
@@ -57,6 +57,32 @@ describe("runWindowsElevated spawn contract", () => {
     await expect(runWindowsElevated("schtasks.exe", ["/query"])).resolves.toBe(0);
   });
 
+  test("PowerShell script treats a missing ExitCode as failure", async () => {
+    let commandScript = "";
+    setWindowsElevationSpawnForTests(((
+      _cmd: string,
+      args: ReadonlyArray<string>,
+    ) => {
+      commandScript = String(args[args.length - 1] ?? "");
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter & { setEncoding?: (enc: string) => void };
+        stderr: EventEmitter & { setEncoding?: (enc: string) => void };
+        kill: ReturnType<typeof mock>;
+      };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.stdout.setEncoding = () => undefined;
+      child.stderr.setEncoding = () => undefined;
+      child.kill = mock(() => true);
+      queueMicrotask(() => child.emit("close", 0, null));
+      return child as never;
+    }) as never);
+
+    await runWindowsElevated("schtasks.exe", ["/create"]);
+    expect(commandScript).toContain("if ($null -eq $p.ExitCode) { exit 1 }");
+    expect(commandScript).toContain("$null = $p.Handle");
+  });
+
   test("returns non-zero exit codes from completed elevated processes", async () => {
     fakeChild({ code: 1, stderr: "failed" });
     await expect(runWindowsElevated("schtasks.exe", ["/create"])).resolves.toBe(1);

--- a/tests/windows-elevation-spawn.test.ts
+++ b/tests/windows-elevation-spawn.test.ts
@@ -11,11 +11,15 @@ import {
   WindowsElevationError,
   buildElevatedSchtasksCreateAndRunScript,
   classifyElevatedSchedulerExitCode,
+  raceWithTimeout,
   runElevatedSchtasksCreateAndRun,
   runWindowsElevated,
   setWindowsElevationSpawnForTests,
+  startElevatedSchtasksCreateAndRun,
+  startPowerShellCommand,
 } from "../src/lib/windows-elevation";
 import {
+  evaluateSchedulerInstallRestartReconciliation,
   finalizeWindowsSchedulerServiceRegistration,
   setFinalizeWindowsSchedulerHooksForTests,
 } from "../src/service";
@@ -136,19 +140,51 @@ describe("runWindowsElevated spawn contract", () => {
     });
   });
 
-  test("times out once and kills the launcher without double settlement", async () => {
+  test("request timeout does not kill the launcher; late close still settles once", async () => {
     const child = fakeChild({ hang: true });
-    await expect(runWindowsElevated("schtasks.exe", ["/create"], 20)).rejects.toMatchObject({
-      reason: "timeout",
-    });
-    expect(child.kill).toHaveBeenCalledTimes(1);
-    child.emit("close", 0, null);
+    const started = startPowerShellCommand("Start-Process -Verb RunAs");
+    const raced = await raceWithTimeout(started.completion, 30);
+    expect(raced.status).toBe("timed-out");
+    expect(child.kill).not.toHaveBeenCalled();
+
+    let late: { exitCode: number } | null = null;
+    const lateWait = started.completion.then(value => { late = value; });
+    child.emit("close", OCX_ELEVATED_SUCCESS, null);
+    await lateWait;
+    expect(late).toEqual({ exitCode: OCX_ELEVATED_SUCCESS, stdout: "", stderr: "" });
+    child.emit("close", 1, null); // second close must not double-settle
+    await Promise.resolve();
+    expect(late?.exitCode).toBe(OCX_ELEVATED_SUCCESS);
+  });
+
+  test("launcher error before elevation settles as launch-failed without hang", async () => {
+    fakeChild({ emitError: Object.assign(new Error("spawn failed"), { code: "EACCES" }) });
+    const started = startPowerShellCommand("Start-Process -Verb RunAs");
+    await expect(started.completion).rejects.toMatchObject({ reason: "launch-failed" });
   });
 
   test("bounds captured stdout and stderr", async () => {
     const huge = "x".repeat(300_000);
     fakeChild({ code: 1, stdout: huge, stderr: huge });
     await expect(runWindowsElevated("schtasks.exe", ["/create"])).resolves.toBe(1);
+  });
+
+  test("startElevatedSchtasksCreateAndRun exposes completion after request race timeout", async () => {
+    const child = fakeChild({ hang: true });
+    const started = startElevatedSchtasksCreateAndRun(
+      "schtasks.exe",
+      ["/create", "/tn", "opencodex-proxy", "/f"],
+      ["/run", "/tn", "opencodex-proxy"],
+      ["/delete", "/tn", "opencodex-proxy", "/f"],
+    );
+    const raced = await raceWithTimeout(started.completion, 20);
+    expect(raced.status).toBe("timed-out");
+    expect(child.kill).not.toHaveBeenCalled();
+    child.emit("close", OCX_ELEVATED_CREATE_FAILED, null);
+    await expect(started.completion).resolves.toMatchObject({
+      outcome: "create-failed",
+      exitCode: OCX_ELEVATED_CREATE_FAILED,
+    });
   });
 
   test("rejects on non-Windows platforms", async () => {
@@ -258,7 +294,8 @@ describe("finalizeWindowsSchedulerServiceRegistration", () => {
       writeInstallState: () => { writeCount += 1; },
     });
 
-    await finalizeWindowsSchedulerServiceRegistration("C:\\Users\\x\\.opencodex\\opencodex-service.cmd");
+    const result = await finalizeWindowsSchedulerServiceRegistration("C:\\Users\\x\\.opencodex\\opencodex-service.cmd");
+    expect(result).toEqual({ kind: "done" });
     expect(elevateLaunches).toBe(1);
     expect(writeCount).toBe(1);
     expect(parentRollbackLaunches).toBe(0);
@@ -334,16 +371,186 @@ describe("finalizeWindowsSchedulerServiceRegistration", () => {
     expect(writeCount).toBe(0);
   });
 
-  test("timeout during create+run does not write install state", async () => {
+  test("request timeout returns indeterminate, keeps observing, and reconciles late success", async () => {
+    let resolveCompletion!: (value: {
+      outcome: "success";
+      exitCode: number;
+      stdout: string;
+      stderr: string;
+    }) => void;
+    const completion = new Promise<{
+      outcome: "success";
+      exitCode: number;
+      stdout: string;
+      stderr: string;
+    }>(resolve => { resolveCompletion = resolve; });
+
     setFinalizeWindowsSchedulerHooksForTests({
-      elevateCreateAndRun: async () => {
+      startElevateCreateAndRun: () => {
         elevateLaunches += 1;
-        throw new WindowsElevationError("timeout", "Windows elevation timed out after 20ms. The elevated Task Scheduler process may still be running.");
+        return { completion, launcherPid: 4242 };
       },
+      verify: okVerify,
       writeInstallState: () => { writeCount += 1; },
+      requestTimeoutMs: 25,
     });
 
-    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toMatchObject({ reason: "timeout" });
+    const result = await finalizeWindowsSchedulerServiceRegistration(
+      "C:\\Users\\x\\.opencodex\\opencodex-service.cmd",
+    );
+    expect(result.kind).toBe("indeterminate");
+    expect(writeCount).toBe(0);
+
+    resolveCompletion({
+      outcome: "success",
+      exitCode: OCX_ELEVATED_SUCCESS,
+      stdout: "",
+      stderr: "",
+    });
+    if (result.kind !== "indeterminate") throw new Error("expected indeterminate");
+    await expect(result.reconciliation).resolves.toBe("released");
+    expect(writeCount).toBe(1);
+    expect(elevateLaunches).toBe(1);
+  });
+
+  test("late create-failed after timeout does not write install state and releases", async () => {
+    let resolveCompletion!: (value: {
+      outcome: "create-failed";
+      exitCode: number;
+      stdout: string;
+      stderr: string;
+    }) => void;
+    const completion = new Promise<{
+      outcome: "create-failed";
+      exitCode: number;
+      stdout: string;
+      stderr: string;
+    }>(resolve => { resolveCompletion = resolve; });
+
+    setFinalizeWindowsSchedulerHooksForTests({
+      startElevateCreateAndRun: () => {
+        elevateLaunches += 1;
+        return { completion, launcherPid: 1 };
+      },
+      writeInstallState: () => { writeCount += 1; },
+      taskInstalled: () => false,
+      requestTimeoutMs: 20,
+    });
+
+    const result = await finalizeWindowsSchedulerServiceRegistration();
+    expect(result.kind).toBe("indeterminate");
+    resolveCompletion({
+      outcome: "create-failed",
+      exitCode: OCX_ELEVATED_CREATE_FAILED,
+      stdout: "",
+      stderr: "",
+    });
+    if (result.kind !== "indeterminate") throw new Error("expected indeterminate");
+    await expect(result.reconciliation).resolves.toBe("released");
+    expect(writeCount).toBe(0);
+  });
+
+  test("late run-failed-rolled-back after timeout releases without writing state", async () => {
+    let resolveCompletion!: (value: {
+      outcome: "run-failed-rolled-back";
+      exitCode: number;
+      stdout: string;
+      stderr: string;
+    }) => void;
+    const completion = new Promise<{
+      outcome: "run-failed-rolled-back";
+      exitCode: number;
+      stdout: string;
+      stderr: string;
+    }>(resolve => { resolveCompletion = resolve; });
+
+    setFinalizeWindowsSchedulerHooksForTests({
+      startElevateCreateAndRun: () => ({ completion, launcherPid: 1 }),
+      writeInstallState: () => { writeCount += 1; },
+      requestTimeoutMs: 20,
+    });
+
+    const result = await finalizeWindowsSchedulerServiceRegistration();
+    resolveCompletion({
+      outcome: "run-failed-rolled-back",
+      exitCode: OCX_ELEVATED_RUN_FAILED_ROLLED_BACK,
+      stdout: "",
+      stderr: "",
+    });
+    if (result.kind !== "indeterminate") throw new Error("expected indeterminate");
+    await expect(result.reconciliation).resolves.toBe("released");
+    expect(writeCount).toBe(0);
+  });
+
+  test("late run-failed-rollback-failed after timeout blocks further installs", async () => {
+    let resolveCompletion!: (value: {
+      outcome: "run-failed-rollback-failed";
+      exitCode: number;
+      stdout: string;
+      stderr: string;
+    }) => void;
+    const completion = new Promise<{
+      outcome: "run-failed-rollback-failed";
+      exitCode: number;
+      stdout: string;
+      stderr: string;
+    }>(resolve => { resolveCompletion = resolve; });
+
+    setFinalizeWindowsSchedulerHooksForTests({
+      startElevateCreateAndRun: () => ({ completion, launcherPid: 1 }),
+      writeInstallState: () => { writeCount += 1; },
+      requestTimeoutMs: 20,
+    });
+
+    const result = await finalizeWindowsSchedulerServiceRegistration();
+    resolveCompletion({
+      outcome: "run-failed-rollback-failed",
+      exitCode: OCX_ELEVATED_RUN_FAILED_ROLLBACK_FAILED,
+      stdout: "",
+      stderr: "",
+    });
+    if (result.kind !== "indeterminate") throw new Error("expected indeterminate");
+    await expect(result.reconciliation).resolves.toBe("blocked-partial");
+    expect(writeCount).toBe(0);
+  });
+
+  test("stale attempt ownership prevents late write", async () => {
+    let resolveCompletion!: (value: {
+      outcome: "success";
+      exitCode: number;
+      stdout: string;
+      stderr: string;
+    }) => void;
+    const completion = new Promise<{
+      outcome: "success";
+      exitCode: number;
+      stdout: string;
+      stderr: string;
+    }>(resolve => { resolveCompletion = resolve; });
+    const owned = new Set<string>(["attempt-a"]);
+
+    setFinalizeWindowsSchedulerHooksForTests({
+      startElevateCreateAndRun: () => ({ completion, launcherPid: 1 }),
+      verify: okVerify,
+      writeInstallState: () => { writeCount += 1; },
+      stillOwnsAttempt: id => owned.has(id),
+      requestTimeoutMs: 20,
+    });
+
+    const result = await finalizeWindowsSchedulerServiceRegistration(
+      undefined,
+      { attemptId: "attempt-a" },
+    );
+    expect(result.kind).toBe("indeterminate");
+    owned.delete("attempt-a");
+    resolveCompletion({
+      outcome: "success",
+      exitCode: OCX_ELEVATED_SUCCESS,
+      stdout: "",
+      stderr: "",
+    });
+    if (result.kind !== "indeterminate") throw new Error("expected indeterminate");
+    await expect(result.reconciliation).resolves.toBe("released");
     expect(writeCount).toBe(0);
   });
 
@@ -367,6 +574,7 @@ describe("finalizeWindowsSchedulerServiceRegistration", () => {
         throw new WindowsElevationError("terminated", "Windows elevation terminated by SIGTERM.");
       },
       writeInstallState: () => { writeCount += 1; },
+      taskInstalled: () => false,
     });
 
     await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toMatchObject({ reason: "terminated" });
@@ -487,5 +695,74 @@ describe("finalizeWindowsSchedulerServiceRegistration", () => {
     expect(launches).toBe(1);
     expect(result.outcome).toBe("success");
     expect(result.exitCode).toBe(OCX_ELEVATED_SUCCESS);
+  });
+});
+
+describe("evaluateSchedulerInstallRestartReconciliation", () => {
+  test("reports orphan task when scheduler task exists without install state", () => {
+    expect(evaluateSchedulerInstallRestartReconciliation({
+      taskInstalled: true,
+      registrationHealthy: true,
+      assetsHealthy: true,
+      nativeStatus: "nonexistent",
+      installStateBackend: null,
+    }).status).toBe("orphan-task");
+  });
+
+  test("reports stale install state when task is absent", () => {
+    expect(evaluateSchedulerInstallRestartReconciliation({
+      taskInstalled: false,
+      registrationHealthy: false,
+      assetsHealthy: true,
+      nativeStatus: "nonexistent",
+      installStateBackend: "scheduler",
+    }).status).toBe("stale-install-state");
+  });
+
+  test("reports conflict when task and WinSW are both present", () => {
+    expect(evaluateSchedulerInstallRestartReconciliation({
+      taskInstalled: true,
+      registrationHealthy: true,
+      assetsHealthy: true,
+      nativeStatus: "stopped",
+      installStateBackend: "scheduler",
+    }).status).toBe("conflict");
+  });
+
+  test("reports healthy for verified scheduler-only install", () => {
+    expect(evaluateSchedulerInstallRestartReconciliation({
+      taskInstalled: true,
+      registrationHealthy: true,
+      assetsHealthy: true,
+      nativeStatus: "nonexistent",
+      installStateBackend: "scheduler",
+    }).status).toBe("healthy");
+  });
+
+  test("reports unverified when WinSW status is unknown", () => {
+    expect(evaluateSchedulerInstallRestartReconciliation({
+      taskInstalled: true,
+      registrationHealthy: true,
+      assetsHealthy: true,
+      nativeStatus: "unknown",
+      installStateBackend: "scheduler",
+    }).status).toBe("unverified");
+  });
+
+  test("reports unhealthy for bad XML or missing assets", () => {
+    expect(evaluateSchedulerInstallRestartReconciliation({
+      taskInstalled: true,
+      registrationHealthy: false,
+      assetsHealthy: true,
+      nativeStatus: "nonexistent",
+      installStateBackend: "scheduler",
+    }).status).toBe("unhealthy");
+    expect(evaluateSchedulerInstallRestartReconciliation({
+      taskInstalled: true,
+      registrationHealthy: true,
+      assetsHealthy: false,
+      nativeStatus: "nonexistent",
+      installStateBackend: "scheduler",
+    }).status).toBe("unhealthy");
   });
 });

--- a/tests/windows-elevation-spawn.test.ts
+++ b/tests/windows-elevation-spawn.test.ts
@@ -1,10 +1,16 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import {
-  OCX_SCHTASKS_CREATE_EXIT_PREFIX,
-  OCX_SCHTASKS_RUN_EXIT_PREFIX,
+  OCX_ELEVATED_CREATE_FAILED,
+  OCX_ELEVATED_PROTOCOL_CODES,
+  OCX_ELEVATED_PROTOCOL_FAILED,
+  OCX_ELEVATED_RUN_FAILED_ROLLBACK_FAILED,
+  OCX_ELEVATED_RUN_FAILED_ROLLED_BACK,
+  OCX_ELEVATED_SUCCESS,
+  OCX_ELEVATED_UAC_CANCELLED,
   WindowsElevationError,
   buildElevatedSchtasksCreateAndRunScript,
+  classifyElevatedSchedulerExitCode,
   runElevatedSchtasksCreateAndRun,
   runWindowsElevated,
   setWindowsElevationSpawnForTests,
@@ -65,7 +71,7 @@ describe("runWindowsElevated spawn contract", () => {
     await expect(runWindowsElevated("schtasks.exe", ["/query"])).resolves.toBe(0);
   });
 
-  test("PowerShell script treats a missing ExitCode as failure", async () => {
+  test("PowerShell script treats a missing ExitCode as protocol failure", async () => {
     let commandScript = "";
     setWindowsElevationSpawnForTests(((
       _cmd: string,
@@ -87,7 +93,7 @@ describe("runWindowsElevated spawn contract", () => {
     }) as never);
 
     await runWindowsElevated("schtasks.exe", ["/create"]);
-    expect(commandScript).toContain("if ($null -eq $p.ExitCode) { exit 1 }");
+    expect(commandScript).toContain(`if ($null -eq $p.ExitCode) { exit ${OCX_ELEVATED_PROTOCOL_FAILED} }`);
     expect(commandScript).toContain("$null = $p.Handle");
   });
 
@@ -97,7 +103,7 @@ describe("runWindowsElevated spawn contract", () => {
   });
 
   test("maps exit 1223 to cancelled", async () => {
-    fakeChild({ code: 1223 });
+    fakeChild({ code: OCX_ELEVATED_UAC_CANCELLED });
     await expect(runWindowsElevated("schtasks.exe", ["/create"])).rejects.toMatchObject({
       name: "WindowsElevationError",
       reason: "cancelled",
@@ -153,19 +159,40 @@ describe("runWindowsElevated spawn contract", () => {
   });
 });
 
-describe("one-UAC create+run elevated script", () => {
-  test("embeds create then run without a second RunAs", () => {
+describe("elevated scheduler protocol codes", () => {
+  test("reserved codes are unique and exclude UAC cancellation", () => {
+    const set = new Set<number>(OCX_ELEVATED_PROTOCOL_CODES);
+    expect(set.size).toBe(OCX_ELEVATED_PROTOCOL_CODES.length);
+    expect(set.has(OCX_ELEVATED_UAC_CANCELLED)).toBe(false);
+    expect(classifyElevatedSchedulerExitCode(OCX_ELEVATED_SUCCESS)).toBe("success");
+    expect(classifyElevatedSchedulerExitCode(OCX_ELEVATED_CREATE_FAILED)).toBe("create-failed");
+    expect(classifyElevatedSchedulerExitCode(OCX_ELEVATED_RUN_FAILED_ROLLED_BACK)).toBe("run-failed-rolled-back");
+    expect(classifyElevatedSchedulerExitCode(OCX_ELEVATED_RUN_FAILED_ROLLBACK_FAILED)).toBe("run-failed-rollback-failed");
+    expect(classifyElevatedSchedulerExitCode(OCX_ELEVATED_PROTOCOL_FAILED)).toBe("protocol-failed");
+    expect(classifyElevatedSchedulerExitCode(1)).toBe("protocol-failed");
+    expect(classifyElevatedSchedulerExitCode(-1)).toBe("protocol-failed");
+    expect(classifyElevatedSchedulerExitCode(99999)).toBe("protocol-failed");
+    expect(classifyElevatedSchedulerExitCode(OCX_ELEVATED_UAC_CANCELLED)).toBe("protocol-failed");
+  });
+});
+
+describe("one-UAC create/run/rollback elevated script", () => {
+  test("embeds create, run, and delete rollback without a second RunAs or temp file writes", () => {
     const script = buildElevatedSchtasksCreateAndRunScript(
       "C:\\Windows\\System32\\schtasks.exe",
       ["/create", "/tn", "opencodex-proxy", "/xml", "C:\\Users\\Jane Doe\\task.xml", "/f"],
       ["/run", "/tn", "opencodex-proxy"],
-      "C:\\Temp\\ocx-result.txt",
+      ["/delete", "/tn", "opencodex-proxy", "/f"],
     );
     expect(script).toContain("Invoke-OcxSchtasks");
-    expect(script).toContain(OCX_SCHTASKS_CREATE_EXIT_PREFIX);
-    expect(script).toContain(OCX_SCHTASKS_RUN_EXIT_PREFIX);
+    expect(script).toContain(`exit ${OCX_ELEVATED_CREATE_FAILED}`);
+    expect(script).toContain(`exit ${OCX_ELEVATED_SUCCESS}`);
+    expect(script).toContain(`exit ${OCX_ELEVATED_RUN_FAILED_ROLLED_BACK}`);
+    expect(script).toContain(`exit ${OCX_ELEVATED_RUN_FAILED_ROLLBACK_FAILED}`);
     expect(script).toContain('"C:\\Users\\Jane Doe\\task.xml"');
     expect(script).not.toContain("-Verb RunAs");
+    expect(script).not.toMatch(/Set-Content|Out-File|Add-Content|New-Item/i);
+    expect(script).not.toMatch(/TEMP|tmpdir|ocx-elev/i);
   });
 });
 
@@ -173,13 +200,13 @@ describe("finalizeWindowsSchedulerServiceRegistration", () => {
   const originalPlatform = process.platform;
   let elevateLaunches = 0;
   let writeCount = 0;
-  let rollbackLaunches = 0;
+  let parentRollbackLaunches = 0;
 
   beforeEach(() => {
     Object.defineProperty(process, "platform", { value: "win32" });
     elevateLaunches = 0;
     writeCount = 0;
-    rollbackLaunches = 0;
+    parentRollbackLaunches = 0;
     setFinalizeWindowsSchedulerHooksForTests(null);
     setWindowsElevationSpawnForTests(null);
   });
@@ -203,38 +230,9 @@ describe("finalizeWindowsSchedulerServiceRegistration", () => {
     };
   }
 
-  test("successful create+run uses exactly one elevated launcher and writes install state", async () => {
-    setFinalizeWindowsSchedulerHooksForTests({
-      elevateCreateAndRun: async () => {
-        elevateLaunches += 1;
-        return { createExitCode: 0, runExitCode: 0, stdout: "", stderr: "" };
-      },
-      verify: okVerify,
-      writeInstallState: () => { writeCount += 1; },
-    });
-
-    await finalizeWindowsSchedulerServiceRegistration("C:\\Users\\x\\.opencodex\\opencodex-service.cmd");
-    expect(elevateLaunches).toBe(1);
-    expect(writeCount).toBe(1);
-  });
-
-  test("create failure does not write install state", async () => {
-    setFinalizeWindowsSchedulerHooksForTests({
-      elevateCreateAndRun: async () => {
-        elevateLaunches += 1;
-        return { createExitCode: 1, runExitCode: null, stdout: "", stderr: "" };
-      },
-      writeInstallState: () => { writeCount += 1; },
-    });
-
-    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toThrow(/\/create failed/);
-    expect(elevateLaunches).toBe(1);
-    expect(writeCount).toBe(0);
-  });
-
-  test("run non-zero exit rolls back and does not write install state", async () => {
+  function mockParentRollbackSpawn() {
     setWindowsElevationSpawnForTests((() => {
-      rollbackLaunches += 1;
+      parentRollbackLaunches += 1;
       const child = new EventEmitter() as EventEmitter & {
         stdout: EventEmitter & { setEncoding?: (enc: string) => void };
         stderr: EventEmitter & { setEncoding?: (enc: string) => void };
@@ -248,20 +246,75 @@ describe("finalizeWindowsSchedulerServiceRegistration", () => {
       queueMicrotask(() => child.emit("close", 0, null));
       return child as never;
     }) as never);
+  }
 
+  test("successful create+run uses exactly one elevated launcher and writes install state", async () => {
     setFinalizeWindowsSchedulerHooksForTests({
       elevateCreateAndRun: async () => {
         elevateLaunches += 1;
-        return { createExitCode: 0, runExitCode: 5, stdout: "", stderr: "" };
+        return { outcome: "success", exitCode: OCX_ELEVATED_SUCCESS, stdout: "", stderr: "" };
       },
+      verify: okVerify,
       writeInstallState: () => { writeCount += 1; },
-      taskInstalled: () => false,
     });
 
-    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toThrow(/\/run failed/);
+    await finalizeWindowsSchedulerServiceRegistration("C:\\Users\\x\\.opencodex\\opencodex-service.cmd");
+    expect(elevateLaunches).toBe(1);
+    expect(writeCount).toBe(1);
+    expect(parentRollbackLaunches).toBe(0);
+  });
+
+  test("create failure does not write install state or parent-rollback", async () => {
+    setFinalizeWindowsSchedulerHooksForTests({
+      elevateCreateAndRun: async () => {
+        elevateLaunches += 1;
+        return { outcome: "create-failed", exitCode: OCX_ELEVATED_CREATE_FAILED, stdout: "", stderr: "" };
+      },
+      writeInstallState: () => { writeCount += 1; },
+    });
+
+    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toThrow(/\/create failed/);
     expect(elevateLaunches).toBe(1);
     expect(writeCount).toBe(0);
-    expect(rollbackLaunches).toBe(1);
+  });
+
+  test("run failure with in-process rollback does not write install state or launch a second UAC", async () => {
+    setFinalizeWindowsSchedulerHooksForTests({
+      elevateCreateAndRun: async () => {
+        elevateLaunches += 1;
+        return {
+          outcome: "run-failed-rolled-back",
+          exitCode: OCX_ELEVATED_RUN_FAILED_ROLLED_BACK,
+          stdout: "",
+          stderr: "",
+        };
+      },
+      writeInstallState: () => { writeCount += 1; },
+    });
+
+    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toThrow(/rolled the task back/);
+    expect(elevateLaunches).toBe(1);
+    expect(writeCount).toBe(0);
+    expect(parentRollbackLaunches).toBe(0);
+  });
+
+  test("run failure with in-process rollback failure reports partial install", async () => {
+    setFinalizeWindowsSchedulerHooksForTests({
+      elevateCreateAndRun: async () => {
+        elevateLaunches += 1;
+        return {
+          outcome: "run-failed-rollback-failed",
+          exitCode: OCX_ELEVATED_RUN_FAILED_ROLLBACK_FAILED,
+          stdout: "",
+          stderr: "",
+        };
+      },
+      writeInstallState: () => { writeCount += 1; },
+    });
+
+    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toThrow(/partial Task Scheduler/);
+    expect(elevateLaunches).toBe(1);
+    expect(writeCount).toBe(0);
   });
 
   test("UAC cancellation during create+run does not write install state", async () => {
@@ -285,7 +338,7 @@ describe("finalizeWindowsSchedulerServiceRegistration", () => {
     setFinalizeWindowsSchedulerHooksForTests({
       elevateCreateAndRun: async () => {
         elevateLaunches += 1;
-        throw new WindowsElevationError("timeout", "Windows elevation timed out after 20ms.");
+        throw new WindowsElevationError("timeout", "Windows elevation timed out after 20ms. The elevated Task Scheduler process may still be running.");
       },
       writeInstallState: () => { writeCount += 1; },
     });
@@ -320,40 +373,47 @@ describe("finalizeWindowsSchedulerServiceRegistration", () => {
     expect(writeCount).toBe(0);
   });
 
-  test("unexpected elevate error does not write install state", async () => {
+  test("protocol-failed with no task present reconciles without inventing a phase", async () => {
     setFinalizeWindowsSchedulerHooksForTests({
       elevateCreateAndRun: async () => {
         elevateLaunches += 1;
-        throw new Error("boom");
+        return { outcome: "protocol-failed", exitCode: 99, stdout: "", stderr: "" };
       },
       writeInstallState: () => { writeCount += 1; },
+      taskInstalled: () => false,
     });
 
-    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toThrow("boom");
+    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toThrow(/unknown result/);
+    expect(writeCount).toBe(0);
+  });
+
+  test("protocol-failed with task present attempts parent cleanup and does not write state", async () => {
+    mockParentRollbackSpawn();
+    let calls = 0;
+    setFinalizeWindowsSchedulerHooksForTests({
+      elevateCreateAndRun: async () => {
+        elevateLaunches += 1;
+        return { outcome: "protocol-failed", exitCode: OCX_ELEVATED_PROTOCOL_FAILED, stdout: "", stderr: "" };
+      },
+      writeInstallState: () => { writeCount += 1; },
+      taskInstalled: () => {
+        calls += 1;
+        return calls === 1; // present before cleanup, absent after
+      },
+    });
+
+    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toThrow(/unknown result/);
+    expect(elevateLaunches).toBe(1);
+    expect(parentRollbackLaunches).toBe(1);
     expect(writeCount).toBe(0);
   });
 
   test("verification conflict rolls back and does not write install state", async () => {
-    setWindowsElevationSpawnForTests((() => {
-      rollbackLaunches += 1;
-      const child = new EventEmitter() as EventEmitter & {
-        stdout: EventEmitter & { setEncoding?: (enc: string) => void };
-        stderr: EventEmitter & { setEncoding?: (enc: string) => void };
-        kill: ReturnType<typeof mock>;
-      };
-      child.stdout = new EventEmitter();
-      child.stderr = new EventEmitter();
-      child.stdout.setEncoding = () => undefined;
-      child.stderr.setEncoding = () => undefined;
-      child.kill = mock(() => true);
-      queueMicrotask(() => child.emit("close", 0, null));
-      return child as never;
-    }) as never);
-
+    mockParentRollbackSpawn();
     setFinalizeWindowsSchedulerHooksForTests({
       elevateCreateAndRun: async () => {
         elevateLaunches += 1;
-        return { createExitCode: 0, runExitCode: 0, stdout: "", stderr: "" };
+        return { outcome: "success", exitCode: OCX_ELEVATED_SUCCESS, stdout: "", stderr: "" };
       },
       verify: () => ({
         taskInstalled: true,
@@ -372,14 +432,14 @@ describe("finalizeWindowsSchedulerServiceRegistration", () => {
     await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toThrow(/CONFLICT/);
     expect(elevateLaunches).toBe(1);
     expect(writeCount).toBe(0);
-    expect(rollbackLaunches).toBe(1);
+    expect(parentRollbackLaunches).toBe(1);
   });
 
   test("unknown WinSW status fails closed without claiming conflict and without rollback", async () => {
     setFinalizeWindowsSchedulerHooksForTests({
       elevateCreateAndRun: async () => {
         elevateLaunches += 1;
-        return { createExitCode: 0, runExitCode: 0, stdout: "", stderr: "" };
+        return { outcome: "success", exitCode: OCX_ELEVATED_SUCCESS, stdout: "", stderr: "" };
       },
       verify: () => ({
         taskInstalled: true,
@@ -397,9 +457,10 @@ describe("finalizeWindowsSchedulerServiceRegistration", () => {
     await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toThrow(/could not verify/);
     expect(elevateLaunches).toBe(1);
     expect(writeCount).toBe(0);
+    expect(parentRollbackLaunches).toBe(0);
   });
 
-  test("runElevatedSchtasksCreateAndRun launches PowerShell once", async () => {
+  test("runElevatedSchtasksCreateAndRun launches PowerShell once and classifies protocol exit", async () => {
     let launches = 0;
     setWindowsElevationSpawnForTests((() => {
       launches += 1;
@@ -413,10 +474,7 @@ describe("finalizeWindowsSchedulerServiceRegistration", () => {
       child.stdout.setEncoding = () => undefined;
       child.stderr.setEncoding = () => undefined;
       child.kill = mock(() => true);
-      queueMicrotask(() => {
-        child.stdout.emit("data", `${OCX_SCHTASKS_CREATE_EXIT_PREFIX}0\n${OCX_SCHTASKS_RUN_EXIT_PREFIX}0\n`);
-        child.emit("close", 0, null);
-      });
+      queueMicrotask(() => child.emit("close", OCX_ELEVATED_SUCCESS, null));
       return child as never;
     }) as never);
 
@@ -424,9 +482,10 @@ describe("finalizeWindowsSchedulerServiceRegistration", () => {
       "schtasks.exe",
       ["/create", "/tn", "opencodex-proxy", "/f"],
       ["/run", "/tn", "opencodex-proxy"],
+      ["/delete", "/tn", "opencodex-proxy", "/f"],
     );
     expect(launches).toBe(1);
-    expect(result.createExitCode).toBe(0);
-    expect(result.runExitCode).toBe(0);
+    expect(result.outcome).toBe("success");
+    expect(result.exitCode).toBe(OCX_ELEVATED_SUCCESS);
   });
 });

--- a/tests/windows-elevation-spawn.test.ts
+++ b/tests/windows-elevation-spawn.test.ts
@@ -98,7 +98,9 @@ describe("runWindowsElevated spawn contract", () => {
 
     await runWindowsElevated("schtasks.exe", ["/create"]);
     expect(commandScript).toContain(`if ($null -eq $p.ExitCode) { exit ${OCX_ELEVATED_PROTOCOL_FAILED} }`);
-    expect(commandScript).toContain("$null = $p.Handle");
+    expect(commandScript).toContain("$null = $p.Handle;");
+    expect(commandScript).not.toContain("$p.Handleif");
+    expect(commandScript).toMatch(/\$null = \$p\.Handle;\s*if \(\$null -eq \$p\.ExitCode\)/);
   });
 
   test("returns non-zero exit codes from completed elevated processes", async () => {
@@ -124,6 +126,11 @@ describe("runWindowsElevated spawn contract", () => {
       expect((error as WindowsElevationError).reason).toBe("cancelled");
       expect((error as Error).message).toContain("UAC prompt was cancelled");
     }
+  });
+
+  test("does not treat UAC-cancel text as cancelled when exit code is 0", async () => {
+    fakeChild({ code: 0, stderr: "Start-Process : The operation was canceled by the user." });
+    await expect(runWindowsElevated("schtasks.exe", ["/create"])).resolves.toBe(0);
   });
 
   test("maps ENOENT launch failure", async () => {
@@ -567,7 +574,7 @@ describe("finalizeWindowsSchedulerServiceRegistration", () => {
     expect(writeCount).toBe(0);
   });
 
-  test("signal termination during create+run does not write install state", async () => {
+  test("signal termination during create+run surfaces reconciliation detail", async () => {
     setFinalizeWindowsSchedulerHooksForTests({
       elevateCreateAndRun: async () => {
         elevateLaunches += 1;
@@ -577,8 +584,28 @@ describe("finalizeWindowsSchedulerServiceRegistration", () => {
       taskInstalled: () => false,
     });
 
-    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toMatchObject({ reason: "terminated" });
+    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toThrow(/unknown result/);
     expect(writeCount).toBe(0);
+  });
+
+  test("signal termination with leftover task reports cleanup guidance", async () => {
+    mockParentRollbackSpawn();
+    let calls = 0;
+    setFinalizeWindowsSchedulerHooksForTests({
+      elevateCreateAndRun: async () => {
+        elevateLaunches += 1;
+        throw new WindowsElevationError("terminated", "Windows elevation terminated by SIGTERM.");
+      },
+      writeInstallState: () => { writeCount += 1; },
+      taskInstalled: () => {
+        calls += 1;
+        return calls === 1;
+      },
+    });
+
+    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toThrow(/unknown result|Cleanup/);
+    expect(writeCount).toBe(0);
+    expect(parentRollbackLaunches).toBe(1);
   });
 
   test("protocol-failed with no task present reconciles without inventing a phase", async () => {

--- a/tests/windows-elevation-spawn.test.ts
+++ b/tests/windows-elevation-spawn.test.ts
@@ -1,10 +1,18 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import {
+  OCX_SCHTASKS_CREATE_EXIT_PREFIX,
+  OCX_SCHTASKS_RUN_EXIT_PREFIX,
   WindowsElevationError,
+  buildElevatedSchtasksCreateAndRunScript,
+  runElevatedSchtasksCreateAndRun,
   runWindowsElevated,
   setWindowsElevationSpawnForTests,
 } from "../src/lib/windows-elevation";
+import {
+  finalizeWindowsSchedulerServiceRegistration,
+  setFinalizeWindowsSchedulerHooksForTests,
+} from "../src/service";
 
 describe("runWindowsElevated spawn contract", () => {
   const originalPlatform = process.platform;
@@ -128,14 +136,12 @@ describe("runWindowsElevated spawn contract", () => {
       reason: "timeout",
     });
     expect(child.kill).toHaveBeenCalledTimes(1);
-    // Late close after timeout must not resolve the already-settled promise.
     child.emit("close", 0, null);
   });
 
   test("bounds captured stdout and stderr", async () => {
     const huge = "x".repeat(300_000);
     fakeChild({ code: 1, stdout: huge, stderr: huge });
-    // Completes with exit code 1; bounded capture must not throw or hang.
     await expect(runWindowsElevated("schtasks.exe", ["/create"])).resolves.toBe(1);
   });
 
@@ -144,5 +150,283 @@ describe("runWindowsElevated spawn contract", () => {
     await expect(runWindowsElevated("schtasks.exe", ["/create"])).rejects.toMatchObject({
       reason: "launch-failed",
     });
+  });
+});
+
+describe("one-UAC create+run elevated script", () => {
+  test("embeds create then run without a second RunAs", () => {
+    const script = buildElevatedSchtasksCreateAndRunScript(
+      "C:\\Windows\\System32\\schtasks.exe",
+      ["/create", "/tn", "opencodex-proxy", "/xml", "C:\\Users\\Jane Doe\\task.xml", "/f"],
+      ["/run", "/tn", "opencodex-proxy"],
+      "C:\\Temp\\ocx-result.txt",
+    );
+    expect(script).toContain("Invoke-OcxSchtasks");
+    expect(script).toContain(OCX_SCHTASKS_CREATE_EXIT_PREFIX);
+    expect(script).toContain(OCX_SCHTASKS_RUN_EXIT_PREFIX);
+    expect(script).toContain('"C:\\Users\\Jane Doe\\task.xml"');
+    expect(script).not.toContain("-Verb RunAs");
+  });
+});
+
+describe("finalizeWindowsSchedulerServiceRegistration", () => {
+  const originalPlatform = process.platform;
+  let elevateLaunches = 0;
+  let writeCount = 0;
+  let rollbackLaunches = 0;
+
+  beforeEach(() => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    elevateLaunches = 0;
+    writeCount = 0;
+    rollbackLaunches = 0;
+    setFinalizeWindowsSchedulerHooksForTests(null);
+    setWindowsElevationSpawnForTests(null);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    setFinalizeWindowsSchedulerHooksForTests(null);
+    setWindowsElevationSpawnForTests(null);
+  });
+
+  function okVerify() {
+    return {
+      taskInstalled: true,
+      registrationHealthy: true,
+      assetsHealthy: true,
+      nativeServiceAbsent: true,
+      nativeStatusUnknown: false,
+      conflict: false,
+      ok: true,
+      detail: "ok",
+    };
+  }
+
+  test("successful create+run uses exactly one elevated launcher and writes install state", async () => {
+    setFinalizeWindowsSchedulerHooksForTests({
+      elevateCreateAndRun: async () => {
+        elevateLaunches += 1;
+        return { createExitCode: 0, runExitCode: 0, stdout: "", stderr: "" };
+      },
+      verify: okVerify,
+      writeInstallState: () => { writeCount += 1; },
+    });
+
+    await finalizeWindowsSchedulerServiceRegistration("C:\\Users\\x\\.opencodex\\opencodex-service.cmd");
+    expect(elevateLaunches).toBe(1);
+    expect(writeCount).toBe(1);
+  });
+
+  test("create failure does not write install state", async () => {
+    setFinalizeWindowsSchedulerHooksForTests({
+      elevateCreateAndRun: async () => {
+        elevateLaunches += 1;
+        return { createExitCode: 1, runExitCode: null, stdout: "", stderr: "" };
+      },
+      writeInstallState: () => { writeCount += 1; },
+    });
+
+    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toThrow(/\/create failed/);
+    expect(elevateLaunches).toBe(1);
+    expect(writeCount).toBe(0);
+  });
+
+  test("run non-zero exit rolls back and does not write install state", async () => {
+    setWindowsElevationSpawnForTests((() => {
+      rollbackLaunches += 1;
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter & { setEncoding?: (enc: string) => void };
+        stderr: EventEmitter & { setEncoding?: (enc: string) => void };
+        kill: ReturnType<typeof mock>;
+      };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.stdout.setEncoding = () => undefined;
+      child.stderr.setEncoding = () => undefined;
+      child.kill = mock(() => true);
+      queueMicrotask(() => child.emit("close", 0, null));
+      return child as never;
+    }) as never);
+
+    setFinalizeWindowsSchedulerHooksForTests({
+      elevateCreateAndRun: async () => {
+        elevateLaunches += 1;
+        return { createExitCode: 0, runExitCode: 5, stdout: "", stderr: "" };
+      },
+      writeInstallState: () => { writeCount += 1; },
+      taskInstalled: () => false,
+    });
+
+    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toThrow(/\/run failed/);
+    expect(elevateLaunches).toBe(1);
+    expect(writeCount).toBe(0);
+    expect(rollbackLaunches).toBe(1);
+  });
+
+  test("UAC cancellation during create+run does not write install state", async () => {
+    setFinalizeWindowsSchedulerHooksForTests({
+      elevateCreateAndRun: async () => {
+        elevateLaunches += 1;
+        throw new WindowsElevationError(
+          "cancelled",
+          "Windows administrator approval was required, but the UAC prompt was cancelled or denied.",
+        );
+      },
+      writeInstallState: () => { writeCount += 1; },
+    });
+
+    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toMatchObject({ reason: "cancelled" });
+    expect(elevateLaunches).toBe(1);
+    expect(writeCount).toBe(0);
+  });
+
+  test("timeout during create+run does not write install state", async () => {
+    setFinalizeWindowsSchedulerHooksForTests({
+      elevateCreateAndRun: async () => {
+        elevateLaunches += 1;
+        throw new WindowsElevationError("timeout", "Windows elevation timed out after 20ms.");
+      },
+      writeInstallState: () => { writeCount += 1; },
+    });
+
+    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toMatchObject({ reason: "timeout" });
+    expect(writeCount).toBe(0);
+  });
+
+  test("launch failure during create+run does not write install state", async () => {
+    setFinalizeWindowsSchedulerHooksForTests({
+      elevateCreateAndRun: async () => {
+        elevateLaunches += 1;
+        throw new WindowsElevationError("launch-failed", "Windows PowerShell was not found for elevation.");
+      },
+      writeInstallState: () => { writeCount += 1; },
+    });
+
+    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toMatchObject({ reason: "launch-failed" });
+    expect(writeCount).toBe(0);
+  });
+
+  test("signal termination during create+run does not write install state", async () => {
+    setFinalizeWindowsSchedulerHooksForTests({
+      elevateCreateAndRun: async () => {
+        elevateLaunches += 1;
+        throw new WindowsElevationError("terminated", "Windows elevation terminated by SIGTERM.");
+      },
+      writeInstallState: () => { writeCount += 1; },
+    });
+
+    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toMatchObject({ reason: "terminated" });
+    expect(writeCount).toBe(0);
+  });
+
+  test("unexpected elevate error does not write install state", async () => {
+    setFinalizeWindowsSchedulerHooksForTests({
+      elevateCreateAndRun: async () => {
+        elevateLaunches += 1;
+        throw new Error("boom");
+      },
+      writeInstallState: () => { writeCount += 1; },
+    });
+
+    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toThrow("boom");
+    expect(writeCount).toBe(0);
+  });
+
+  test("verification conflict rolls back and does not write install state", async () => {
+    setWindowsElevationSpawnForTests((() => {
+      rollbackLaunches += 1;
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter & { setEncoding?: (enc: string) => void };
+        stderr: EventEmitter & { setEncoding?: (enc: string) => void };
+        kill: ReturnType<typeof mock>;
+      };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.stdout.setEncoding = () => undefined;
+      child.stderr.setEncoding = () => undefined;
+      child.kill = mock(() => true);
+      queueMicrotask(() => child.emit("close", 0, null));
+      return child as never;
+    }) as never);
+
+    setFinalizeWindowsSchedulerHooksForTests({
+      elevateCreateAndRun: async () => {
+        elevateLaunches += 1;
+        return { createExitCode: 0, runExitCode: 0, stdout: "", stderr: "" };
+      },
+      verify: () => ({
+        taskInstalled: true,
+        registrationHealthy: true,
+        assetsHealthy: true,
+        nativeServiceAbsent: false,
+        nativeStatusUnknown: false,
+        conflict: true,
+        ok: false,
+        detail: "CONFLICT: Task Scheduler and native WinSW are both present.",
+      }),
+      writeInstallState: () => { writeCount += 1; },
+      taskInstalled: () => false,
+    });
+
+    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toThrow(/CONFLICT/);
+    expect(elevateLaunches).toBe(1);
+    expect(writeCount).toBe(0);
+    expect(rollbackLaunches).toBe(1);
+  });
+
+  test("unknown WinSW status fails closed without claiming conflict and without rollback", async () => {
+    setFinalizeWindowsSchedulerHooksForTests({
+      elevateCreateAndRun: async () => {
+        elevateLaunches += 1;
+        return { createExitCode: 0, runExitCode: 0, stdout: "", stderr: "" };
+      },
+      verify: () => ({
+        taskInstalled: true,
+        registrationHealthy: true,
+        assetsHealthy: true,
+        nativeServiceAbsent: false,
+        nativeStatusUnknown: true,
+        conflict: false,
+        ok: false,
+        detail: "The Task Scheduler task was created, but OpenCodex could not verify that the native WinSW service is absent.",
+      }),
+      writeInstallState: () => { writeCount += 1; },
+    });
+
+    await expect(finalizeWindowsSchedulerServiceRegistration()).rejects.toThrow(/could not verify/);
+    expect(elevateLaunches).toBe(1);
+    expect(writeCount).toBe(0);
+  });
+
+  test("runElevatedSchtasksCreateAndRun launches PowerShell once", async () => {
+    let launches = 0;
+    setWindowsElevationSpawnForTests((() => {
+      launches += 1;
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter & { setEncoding?: (enc: string) => void };
+        stderr: EventEmitter & { setEncoding?: (enc: string) => void };
+        kill: ReturnType<typeof mock>;
+      };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.stdout.setEncoding = () => undefined;
+      child.stderr.setEncoding = () => undefined;
+      child.kill = mock(() => true);
+      queueMicrotask(() => {
+        child.stdout.emit("data", `${OCX_SCHTASKS_CREATE_EXIT_PREFIX}0\n${OCX_SCHTASKS_RUN_EXIT_PREFIX}0\n`);
+        child.emit("close", 0, null);
+      });
+      return child as never;
+    }) as never);
+
+    const result = await runElevatedSchtasksCreateAndRun(
+      "schtasks.exe",
+      ["/create", "/tn", "opencodex-proxy", "/f"],
+      ["/run", "/tn", "opencodex-proxy"],
+    );
+    expect(launches).toBe(1);
+    expect(result.createExitCode).toBe(0);
+    expect(result.runExitCode).toBe(0);
   });
 });

--- a/tests/windows-elevation-spawn.test.ts
+++ b/tests/windows-elevation-spawn.test.ts
@@ -15,6 +15,7 @@ import {
   runElevatedSchtasksCreateAndRun,
   runWindowsElevated,
   setWindowsElevationSpawnForTests,
+  setTrustedWindowsElevationExecutablesForTests,
   startElevatedSchtasksCreateAndRun,
   startPowerShellCommand,
 } from "../src/lib/windows-elevation";
@@ -24,15 +25,23 @@ import {
   setFinalizeWindowsSchedulerHooksForTests,
 } from "../src/service";
 
+/** Linux CI fakes win32 without a real System32; keep elevation paths production-shaped. */
+const FAKE_TRUSTED_ELEVATION_EXES = {
+  powershell: "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+  schtasks: "C:\\Windows\\System32\\schtasks.exe",
+} as const;
+
 describe("runWindowsElevated spawn contract", () => {
   const originalPlatform = process.platform;
 
   beforeEach(() => {
     Object.defineProperty(process, "platform", { value: "win32" });
+    setTrustedWindowsElevationExecutablesForTests(FAKE_TRUSTED_ELEVATION_EXES);
   });
 
   afterEach(() => {
     Object.defineProperty(process, "platform", { value: originalPlatform });
+    setTrustedWindowsElevationExecutablesForTests(null);
     setWindowsElevationSpawnForTests(null);
   });
 
@@ -247,6 +256,7 @@ describe("finalizeWindowsSchedulerServiceRegistration", () => {
 
   beforeEach(() => {
     Object.defineProperty(process, "platform", { value: "win32" });
+    setTrustedWindowsElevationExecutablesForTests(FAKE_TRUSTED_ELEVATION_EXES);
     elevateLaunches = 0;
     writeCount = 0;
     parentRollbackLaunches = 0;
@@ -256,6 +266,7 @@ describe("finalizeWindowsSchedulerServiceRegistration", () => {
 
   afterEach(() => {
     Object.defineProperty(process, "platform", { value: originalPlatform });
+    setTrustedWindowsElevationExecutablesForTests(null);
     setFinalizeWindowsSchedulerHooksForTests(null);
     setWindowsElevationSpawnForTests(null);
   });

--- a/tests/windows-elevation-spawn.test.ts
+++ b/tests/windows-elevation-spawn.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import {
+  WindowsElevationError,
+  runWindowsElevated,
+  setWindowsElevationSpawnForTests,
+} from "../src/lib/windows-elevation";
+
+describe("runWindowsElevated spawn contract", () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    setWindowsElevationSpawnForTests(null);
+  });
+
+  function fakeChild(opts: {
+    code?: number | null;
+    signal?: NodeJS.Signals | null;
+    stderr?: string;
+    stdout?: string;
+    emitError?: NodeJS.ErrnoException;
+    hang?: boolean;
+  }) {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter & { setEncoding?: (enc: string) => void };
+      stderr: EventEmitter & { setEncoding?: (enc: string) => void };
+      kill: ReturnType<typeof mock>;
+    };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stdout.setEncoding = () => undefined;
+    child.stderr.setEncoding = () => undefined;
+    child.kill = mock(() => true);
+    setWindowsElevationSpawnForTests((() => {
+      queueMicrotask(() => {
+        if (opts.emitError) {
+          child.emit("error", opts.emitError);
+          return;
+        }
+        if (opts.hang) return;
+        if (opts.stdout) child.stdout.emit("data", opts.stdout);
+        if (opts.stderr) child.stderr.emit("data", opts.stderr);
+        child.emit("close", "code" in opts ? opts.code! : 0, opts.signal ?? null);
+      });
+      return child as never;
+    }) as never);
+    return child;
+  }
+
+  test("returns exit code 0", async () => {
+    fakeChild({ code: 0 });
+    await expect(runWindowsElevated("schtasks.exe", ["/query"])).resolves.toBe(0);
+  });
+
+  test("returns non-zero exit codes from completed elevated processes", async () => {
+    fakeChild({ code: 1, stderr: "failed" });
+    await expect(runWindowsElevated("schtasks.exe", ["/create"])).resolves.toBe(1);
+  });
+
+  test("maps exit 1223 to cancelled", async () => {
+    fakeChild({ code: 1223 });
+    await expect(runWindowsElevated("schtasks.exe", ["/create"])).rejects.toMatchObject({
+      name: "WindowsElevationError",
+      reason: "cancelled",
+    });
+  });
+
+  test("maps PowerShell cancellation text to cancelled", async () => {
+    fakeChild({ code: 1, stderr: "Start-Process : The operation was canceled by the user." });
+    try {
+      await runWindowsElevated("schtasks.exe", ["/create"]);
+      throw new Error("expected cancellation");
+    } catch (error) {
+      expect(error).toBeInstanceOf(WindowsElevationError);
+      expect((error as WindowsElevationError).reason).toBe("cancelled");
+      expect((error as Error).message).toContain("UAC prompt was cancelled");
+    }
+  });
+
+  test("maps ENOENT launch failure", async () => {
+    fakeChild({ emitError: Object.assign(new Error("spawn powershell ENOENT"), { code: "ENOENT" }) });
+    await expect(runWindowsElevated("schtasks.exe", ["/create"])).rejects.toMatchObject({
+      reason: "launch-failed",
+    });
+  });
+
+  test("maps signal termination", async () => {
+    fakeChild({ code: null, signal: "SIGTERM" });
+    await expect(runWindowsElevated("schtasks.exe", ["/create"])).rejects.toMatchObject({
+      reason: "terminated",
+    });
+  });
+
+  test("times out once and kills the launcher without double settlement", async () => {
+    const child = fakeChild({ hang: true });
+    await expect(runWindowsElevated("schtasks.exe", ["/create"], 20)).rejects.toMatchObject({
+      reason: "timeout",
+    });
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    // Late close after timeout must not resolve the already-settled promise.
+    child.emit("close", 0, null);
+  });
+
+  test("bounds captured stdout and stderr", async () => {
+    const huge = "x".repeat(300_000);
+    fakeChild({ code: 1, stdout: huge, stderr: huge });
+    // Completes with exit code 1; bounded capture must not throw or hang.
+    await expect(runWindowsElevated("schtasks.exe", ["/create"])).resolves.toBe(1);
+  });
+
+  test("rejects on non-Windows platforms", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    await expect(runWindowsElevated("schtasks.exe", ["/create"])).rejects.toMatchObject({
+      reason: "launch-failed",
+    });
+  });
+});

--- a/tests/windows-elevation-spawn.test.ts
+++ b/tests/windows-elevation-spawn.test.ts
@@ -532,6 +532,40 @@ describe("finalizeWindowsSchedulerServiceRegistration", () => {
     expect(writeCount).toBe(0);
   });
 
+  test("late protocol-failed with unknown task probe stays blocked-partial and never writes state", async () => {
+    let resolveCompletion!: (value: {
+      outcome: "protocol-failed";
+      exitCode: number;
+      stdout: string;
+      stderr: string;
+    }) => void;
+    const completion = new Promise<{
+      outcome: "protocol-failed";
+      exitCode: number;
+      stdout: string;
+      stderr: string;
+    }>(resolve => { resolveCompletion = resolve; });
+
+    setFinalizeWindowsSchedulerHooksForTests({
+      startElevateCreateAndRun: () => ({ completion, launcherPid: 1 }),
+      writeInstallState: () => { writeCount += 1; },
+      probeTask: () => ({ status: "unknown", detail: "Access is denied…" }),
+      requestTimeoutMs: 20,
+    });
+
+    const result = await finalizeWindowsSchedulerServiceRegistration();
+    expect(result.kind).toBe("indeterminate");
+    resolveCompletion({
+      outcome: "protocol-failed",
+      exitCode: OCX_ELEVATED_PROTOCOL_FAILED,
+      stdout: "",
+      stderr: "",
+    });
+    if (result.kind !== "indeterminate") throw new Error("expected indeterminate");
+    await expect(result.reconciliation).resolves.toBe("blocked-partial");
+    expect(writeCount).toBe(0);
+  });
+
   test("stale attempt ownership prevents late write", async () => {
     let resolveCompletion!: (value: {
       outcome: "success";

--- a/tests/windows-elevation.test.ts
+++ b/tests/windows-elevation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import {
+  formatWindowsSchtasksError,
+  isWindowsAccessDenied,
+  isWindowsAccessDeniedError,
+} from "../src/lib/windows-elevation";
+
+describe("windows elevation helpers", () => {
+  test("detects English and German access-denied text", () => {
+    expect(isWindowsAccessDenied("FEHLER: Zugriff verweigert")).toBe(true);
+    expect(isWindowsAccessDenied("ERROR: Access is denied.")).toBe(true);
+    expect(isWindowsAccessDenied("service installed")).toBe(false);
+  });
+
+  test("detects access-denied exec errors from stderr", () => {
+    const error = Object.assign(new Error("Command failed"), {
+      stderr: "FEHLER: Zugriff verweigert\r\n",
+      stdout: "",
+      status: 1,
+    });
+    expect(isWindowsAccessDeniedError(error)).toBe(true);
+  });
+
+  test("formats schtasks access-denied errors with UAC guidance", () => {
+    const error = Object.assign(new Error("Command failed"), {
+      stderr: "FEHLER: Zugriff verweigert\r\n",
+      stdout: "",
+      status: 1,
+    });
+    const message = formatWindowsSchtasksError(error, ["/create", "/tn", "opencodex-proxy"]);
+    expect(message).toContain("Windows denied access while running Task Scheduler.");
+    expect(message).toContain("schtasks /create /tn opencodex-proxy");
+    expect(message).toContain("UAC prompt");
+  });
+
+  test("passes through non-access-denied errors unchanged", () => {
+    const error = new Error("schtasks is unavailable");
+    expect(formatWindowsSchtasksError(error, ["/query"])).toBe("schtasks is unavailable");
+  });
+});
+

--- a/tests/windows-elevation.test.ts
+++ b/tests/windows-elevation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  buildWindowsElevatedArgumentList,
   formatWindowsSchtasksError,
   isWindowsAccessDenied,
   isWindowsAccessDeniedError,
@@ -28,9 +29,26 @@ describe("windows elevation helpers", () => {
       status: 1,
     });
     const message = formatWindowsSchtasksError(error, ["/create", "/tn", "opencodex-proxy"]);
-    expect(message).toContain("Windows denied access while running Task Scheduler.");
+    expect(message).toContain("Windows access denied while running Task Scheduler.");
     expect(message).toContain("schtasks /create /tn opencodex-proxy");
     expect(message).toContain("UAC prompt");
+  });
+
+  test("recognizes formatted scheduler denial text for retry detection", () => {
+    expect(isWindowsAccessDenied("Windows access denied while running Task Scheduler.")).toBe(true);
+  });
+
+  test("builds one Win32-quoted argument list for spaced paths", () => {
+    expect(buildWindowsElevatedArgumentList([
+      "/create",
+      "/tn",
+      "opencodex-proxy",
+      "/xml",
+      "C:\\Users\\Jane Doe\\.opencodex\\opencodex-service-task.xml",
+      "/f",
+    ])).toBe(
+      '/create /tn opencodex-proxy /xml "C:\\Users\\Jane Doe\\.opencodex\\opencodex-service-task.xml" /f',
+    );
   });
 
   test("passes through non-access-denied errors unchanged", () => {
@@ -38,4 +56,3 @@ describe("windows elevation helpers", () => {
     expect(formatWindowsSchtasksError(error, ["/query"])).toBe("schtasks is unavailable");
   });
 });
-

--- a/tests/windows-elevation.test.ts
+++ b/tests/windows-elevation.test.ts
@@ -100,4 +100,41 @@ describe("windows elevation helpers", () => {
     const error = new Error("schtasks is unavailable");
     expect(formatWindowsSchtasksError(error, ["/query"])).toBe("schtasks is unavailable");
   });
+
+  test("elevated executables ignore a hostile SystemRoot", () => {
+    if (process.platform !== "win32") return;
+
+    const {
+      resolveTrustedWindowsPowerShellExe,
+      resolveTrustedWindowsSchtasksExe,
+      setTrustedWindowsSystemDirectoryResolverForTests,
+    } = require("../src/lib/windows-elevation") as typeof import("../src/lib/windows-elevation");
+
+    const previousSystemRoot = process.env.SystemRoot;
+    const previousWindir = process.env.WINDIR;
+    process.env.SystemRoot = "C:\\Users\\Public\\evil-root";
+    process.env.WINDIR = "C:\\Users\\Public\\evil-root";
+    try {
+      // Prove the production GetSystemDirectoryW path ignores env even when poisoned.
+      setTrustedWindowsSystemDirectoryResolverForTests(null);
+      const powershell = resolveTrustedWindowsPowerShellExe();
+      const schtasks = resolveTrustedWindowsSchtasksExe();
+      const evil = "evil-root";
+      expect(powershell.toLowerCase().includes(evil)).toBe(false);
+      expect(schtasks.toLowerCase().includes(evil)).toBe(false);
+      expect(powershell.toLowerCase().endsWith("\\system32\\windowspowershell\\v1.0\\powershell.exe")).toBe(true);
+      expect(schtasks.toLowerCase().endsWith("\\system32\\schtasks.exe")).toBe(true);
+
+      // Fail closed when a hostile resolver returns an untrusted directory.
+      setTrustedWindowsSystemDirectoryResolverForTests(() => "C:\\Users\\Public\\evil-root\\System32");
+      expect(() => resolveTrustedWindowsPowerShellExe()).toThrow(/not found|unusable|outside the trusted/i);
+      expect(() => resolveTrustedWindowsSchtasksExe()).toThrow(/not found|unusable|outside the trusted/i);
+    } finally {
+      setTrustedWindowsSystemDirectoryResolverForTests(null);
+      if (previousSystemRoot === undefined) delete process.env.SystemRoot;
+      else process.env.SystemRoot = previousSystemRoot;
+      if (previousWindir === undefined) delete process.env.WINDIR;
+      else process.env.WINDIR = previousWindir;
+    }
+  });
 });

--- a/tests/windows-elevation.test.ts
+++ b/tests/windows-elevation.test.ts
@@ -108,6 +108,7 @@ describe("windows elevation helpers", () => {
       resolveTrustedWindowsPowerShellExe,
       resolveTrustedWindowsSchtasksExe,
       setTrustedWindowsSystemDirectoryResolverForTests,
+      setTrustedWindowsElevationExecutablesForTests,
     } = require("../src/lib/windows-elevation") as typeof import("../src/lib/windows-elevation");
 
     const previousSystemRoot = process.env.SystemRoot;
@@ -116,6 +117,7 @@ describe("windows elevation helpers", () => {
     process.env.WINDIR = "C:\\Users\\Public\\evil-root";
     try {
       // Prove the production GetSystemDirectoryW path ignores env even when poisoned.
+      setTrustedWindowsElevationExecutablesForTests(null);
       setTrustedWindowsSystemDirectoryResolverForTests(null);
       const powershell = resolveTrustedWindowsPowerShellExe();
       const schtasks = resolveTrustedWindowsSchtasksExe();
@@ -131,6 +133,7 @@ describe("windows elevation helpers", () => {
       expect(() => resolveTrustedWindowsSchtasksExe()).toThrow(/not found|unusable|outside the trusted/i);
     } finally {
       setTrustedWindowsSystemDirectoryResolverForTests(null);
+      setTrustedWindowsElevationExecutablesForTests(null);
       if (previousSystemRoot === undefined) delete process.env.SystemRoot;
       else process.env.SystemRoot = previousSystemRoot;
       if (previousWindir === undefined) delete process.env.WINDIR;

--- a/tests/windows-elevation.test.ts
+++ b/tests/windows-elevation.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import {
+  WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER,
+  WindowsSchtasksError,
   buildWindowsElevatedArgumentList,
   formatWindowsSchtasksError,
   isWindowsAccessDenied,
   isWindowsAccessDeniedError,
+  isWindowsSchtasksCreateAccessDenied,
+  schtasksOperationFromArgs,
+  toWindowsSchtasksError,
+  windowsCmdQuote,
 } from "../src/lib/windows-elevation";
 
 describe("windows elevation helpers", () => {
@@ -22,7 +28,7 @@ describe("windows elevation helpers", () => {
     expect(isWindowsAccessDeniedError(error)).toBe(true);
   });
 
-  test("formats schtasks access-denied errors with UAC guidance", () => {
+  test("formats schtasks create access-denied errors with marker and UAC guidance", () => {
     const error = Object.assign(new Error("Command failed"), {
       stderr: "FEHLER: Zugriff verweigert\r\n",
       stdout: "",
@@ -32,10 +38,35 @@ describe("windows elevation helpers", () => {
     expect(message).toContain("Windows access denied while running Task Scheduler.");
     expect(message).toContain("schtasks /create /tn opencodex-proxy");
     expect(message).toContain("UAC prompt");
+    expect(message).toContain(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER);
+    expect(isWindowsSchtasksCreateAccessDenied(message)).toBe(true);
   });
 
-  test("recognizes formatted scheduler denial text for retry detection", () => {
-    expect(isWindowsAccessDenied("Windows access denied while running Task Scheduler.")).toBe(true);
+  test("does not emit create-access-denied marker for non-create operations", () => {
+    const error = Object.assign(new Error("Command failed"), {
+      stderr: "Access is denied.",
+      stdout: "",
+    });
+    const message = formatWindowsSchtasksError(error, ["/run", "/tn", "opencodex-proxy"]);
+    expect(message).toContain("Windows access denied while running Task Scheduler.");
+    expect(message).not.toContain(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER);
+    expect(isWindowsSchtasksCreateAccessDenied(message)).toBe(false);
+  });
+
+  test("generic access-denied text alone does not classify as create denial", () => {
+    expect(isWindowsSchtasksCreateAccessDenied("Access is denied.")).toBe(false);
+    expect(isWindowsSchtasksCreateAccessDenied("Cannot remove the native service: Access is denied.")).toBe(false);
+    expect(isWindowsSchtasksCreateAccessDenied("EACCES: permission denied, open 'token'")).toBe(false);
+  });
+
+  test("toWindowsSchtasksError preserves operation and reason", () => {
+    const error = Object.assign(new Error("Command failed"), { stderr: "Access is denied." });
+    const structured = toWindowsSchtasksError(error, ["/create", "/xml", "task.xml", "/f"]);
+    expect(structured).toBeInstanceOf(WindowsSchtasksError);
+    expect(structured.operation).toBe("create");
+    expect(structured.reason).toBe("access-denied");
+    expect(structured.machineMarker).toBe(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER);
+    expect(schtasksOperationFromArgs(["/delete", "/tn", "x"])).toBe("delete");
   });
 
   test("builds one Win32-quoted argument list for spaced paths", () => {
@@ -48,6 +79,20 @@ describe("windows elevation helpers", () => {
       "/f",
     ])).toBe(
       '/create /tn opencodex-proxy /xml "C:\\Users\\Jane Doe\\.opencodex\\opencodex-service-task.xml" /f',
+    );
+  });
+
+  test("quotes empty args, embedded quotes, trailing backslashes, and unicode paths", () => {
+    expect(windowsCmdQuote("")).toBe('""');
+    expect(windowsCmdQuote("simple")).toBe("simple");
+    expect(windowsCmdQuote('say "hi"')).toBe('"say \\"hi\\""');
+    // Unquoted paths keep a single trailing backslash; only quoted args double it.
+    expect(windowsCmdQuote("C:\\temp\\")).toBe("C:\\temp\\");
+    expect(windowsCmdQuote("C:\\temp dir\\")).toBe('"C:\\temp dir\\\\"');
+    expect(windowsCmdQuote("C:\\Users\\한글\\task")).toBe("C:\\Users\\한글\\task");
+    expect(windowsCmdQuote("task name with spaces")).toBe('"task name with spaces"');
+    expect(buildWindowsElevatedArgumentList(["/tn", "Open Codex Proxy", ""])).toBe(
+      '/tn "Open Codex Proxy" ""',
     );
   });
 

--- a/tests/windows-elevation.test.ts
+++ b/tests/windows-elevation.test.ts
@@ -1,13 +1,21 @@
 import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER,
   WindowsSchtasksError,
+  assertTrustedSystemExecutableForTests,
   buildWindowsElevatedArgumentList,
   formatWindowsSchtasksError,
   isWindowsAccessDenied,
   isWindowsAccessDeniedError,
   isWindowsSchtasksCreateAccessDenied,
+  resolveTrustedWindowsPowerShellExe,
+  resolveTrustedWindowsSchtasksExe,
   schtasksOperationFromArgs,
+  setTrustedWindowsElevationExecutablesForTests,
+  setTrustedWindowsSystemDirectoryResolverForTests,
   toWindowsSchtasksError,
   windowsCmdQuote,
 } from "../src/lib/windows-elevation";
@@ -16,6 +24,7 @@ describe("windows elevation helpers", () => {
   test("detects English and German access-denied text", () => {
     expect(isWindowsAccessDenied("FEHLER: Zugriff verweigert")).toBe(true);
     expect(isWindowsAccessDenied("ERROR: Access is denied.")).toBe(true);
+    expect(isWindowsAccessDenied("Windows denied access while running Task Scheduler.")).toBe(true);
     expect(isWindowsAccessDenied("service installed")).toBe(false);
   });
 
@@ -101,39 +110,49 @@ describe("windows elevation helpers", () => {
     expect(formatWindowsSchtasksError(error, ["/query"])).toBe("schtasks is unavailable");
   });
 
-  test("elevated executables ignore a hostile SystemRoot", () => {
-    if (process.platform !== "win32") return;
+  test("elevated executables ignore a hostile SystemRoot and enforce path containment", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
 
-    const {
-      resolveTrustedWindowsPowerShellExe,
-      resolveTrustedWindowsSchtasksExe,
-      setTrustedWindowsSystemDirectoryResolverForTests,
-      setTrustedWindowsElevationExecutablesForTests,
-    } = require("../src/lib/windows-elevation") as typeof import("../src/lib/windows-elevation");
+    const trustedRoot = mkdtempSync(join(tmpdir(), "ocx-trusted-sys-"));
+    const trustedSystem32 = join(trustedRoot, "System32");
+    mkdirSync(join(trustedSystem32, "WindowsPowerShell", "v1.0"), { recursive: true });
+    writeFileSync(join(trustedSystem32, "schtasks.exe"), "");
+    writeFileSync(join(trustedSystem32, "WindowsPowerShell", "v1.0", "powershell.exe"), "");
+
+    const evilRoot = mkdtempSync(join(tmpdir(), "ocx-evil-sys-"));
+    const evilSystem32 = join(evilRoot, "System32");
+    mkdirSync(join(evilSystem32, "WindowsPowerShell", "v1.0"), { recursive: true });
+    writeFileSync(join(evilSystem32, "schtasks.exe"), "evil");
+    writeFileSync(join(evilSystem32, "WindowsPowerShell", "v1.0", "powershell.exe"), "evil");
 
     const previousSystemRoot = process.env.SystemRoot;
     const previousWindir = process.env.WINDIR;
-    process.env.SystemRoot = "C:\\Users\\Public\\evil-root";
-    process.env.WINDIR = "C:\\Users\\Public\\evil-root";
+    process.env.SystemRoot = evilRoot;
+    process.env.WINDIR = evilRoot;
     try {
-      // Prove the production GetSystemDirectoryW path ignores env even when poisoned.
       setTrustedWindowsElevationExecutablesForTests(null);
-      setTrustedWindowsSystemDirectoryResolverForTests(null);
+      setTrustedWindowsSystemDirectoryResolverForTests(() => trustedSystem32);
+
       const powershell = resolveTrustedWindowsPowerShellExe();
       const schtasks = resolveTrustedWindowsSchtasksExe();
-      const evil = "evil-root";
-      expect(powershell.toLowerCase().includes(evil)).toBe(false);
-      expect(schtasks.toLowerCase().includes(evil)).toBe(false);
-      expect(powershell.toLowerCase().endsWith("\\system32\\windowspowershell\\v1.0\\powershell.exe")).toBe(true);
-      expect(schtasks.toLowerCase().endsWith("\\system32\\schtasks.exe")).toBe(true);
+      expect(powershell.toLowerCase().includes("ocx-evil-sys")).toBe(false);
+      expect(schtasks.toLowerCase().includes("ocx-evil-sys")).toBe(false);
+      expect(powershell.toLowerCase()).toContain(trustedSystem32.toLowerCase());
+      expect(schtasks.toLowerCase()).toContain(trustedSystem32.toLowerCase());
 
-      // Fail closed when a hostile resolver returns an untrusted directory.
-      setTrustedWindowsSystemDirectoryResolverForTests(() => "C:\\Users\\Public\\evil-root\\System32");
-      expect(() => resolveTrustedWindowsPowerShellExe()).toThrow(/not found|unusable|outside the trusted/i);
-      expect(() => resolveTrustedWindowsSchtasksExe()).toThrow(/not found|unusable|outside the trusted/i);
+      // Containment must reject an existing executable outside the trusted system directory
+      // (not merely a missing-file failure).
+      expect(() => assertTrustedSystemExecutableForTests(join(evilSystem32, "schtasks.exe"), "schtasks.exe"))
+        .toThrow(/outside the trusted/i);
+      expect(() => assertTrustedSystemExecutableForTests(
+        join(evilSystem32, "WindowsPowerShell", "v1.0", "powershell.exe"),
+        "PowerShell",
+      )).toThrow(/outside the trusted/i);
     } finally {
       setTrustedWindowsSystemDirectoryResolverForTests(null);
       setTrustedWindowsElevationExecutablesForTests(null);
+      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
       if (previousSystemRoot === undefined) delete process.env.SystemRoot;
       else process.env.SystemRoot = previousSystemRoot;
       if (previousWindir === undefined) delete process.env.WINDIR;

--- a/tests/windows-scheduler-install-verification.test.ts
+++ b/tests/windows-scheduler-install-verification.test.ts
@@ -1,10 +1,17 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import {
   buildWindowsTaskXml,
   evaluateWindowsSchedulerInstallVerification,
+  probeWindowsSchedulerTask,
+  setQuerySchtasksForTests,
   windowsSchedulerCsvIncludesTask,
+  windowsSchedulerTaskInstalled,
   windowsTaskRegistrationHealthy,
 } from "../src/service";
+
+afterEach(() => {
+  setQuerySchtasksForTests(null);
+});
 
 describe("windowsSchedulerCsvIncludesTask", () => {
   test("matches quoted Task Scheduler CSV task names", () => {
@@ -16,6 +23,63 @@ describe("windowsSchedulerCsvIncludesTask", () => {
     expect(windowsSchedulerCsvIncludesTask(csv, "opencodex-proxy")).toBe(true);
     expect(windowsSchedulerCsvIncludesTask(csv, "missing-task")).toBe(false);
     expect(windowsSchedulerCsvIncludesTask(csv, "opencodex")).toBe(false);
+  });
+});
+
+describe("probeWindowsSchedulerTask", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    setQuerySchtasksForTests(null);
+  });
+
+  test("returns present when the specific /tn query includes the task", () => {
+    Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+    setQuerySchtasksForTests((args) => {
+      if (args[0] === "/query" && args[1] === "/tn") return "Folder: \\\nTaskName: opencodex-proxy";
+      throw new Error("unexpected query");
+    });
+    expect(probeWindowsSchedulerTask("opencodex-proxy")).toEqual({ status: "present" });
+    expect(windowsSchedulerTaskInstalled("opencodex-proxy")).toBe(true);
+  });
+
+  test("falls back to CSV listing when the specific query fails", () => {
+    Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+    setQuerySchtasksForTests((args) => {
+      if (args.includes("/tn")) throw new Error("Access is denied.");
+      if (args.includes("CSV")) {
+        return `"TaskName"\n"\\opencodex-proxy"\n`;
+      }
+      throw new Error("unexpected query");
+    });
+    expect(probeWindowsSchedulerTask("opencodex-proxy")).toEqual({ status: "present" });
+  });
+
+  test("returns absent when specific query fails and CSV succeeds without the task", () => {
+    Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+    setQuerySchtasksForTests((args) => {
+      if (args.includes("/tn")) throw new Error("ERROR: The system cannot find the file specified.");
+      if (args.includes("CSV")) return `"TaskName"\n"\\other-task"\n`;
+      throw new Error("unexpected query");
+    });
+    expect(probeWindowsSchedulerTask("opencodex-proxy")).toEqual({ status: "absent" });
+    expect(windowsSchedulerTaskInstalled("opencodex-proxy")).toBe(false);
+  });
+
+  test("returns unknown with both details when specific query and CSV listing fail", () => {
+    Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+    setQuerySchtasksForTests((args) => {
+      if (args.includes("/tn")) throw new Error("Access is denied.");
+      if (args.includes("CSV")) throw new Error("RPC server is unavailable.");
+      throw new Error("unexpected query");
+    });
+    const probe = probeWindowsSchedulerTask("opencodex-proxy");
+    expect(probe.status).toBe("unknown");
+    if (probe.status !== "unknown") throw new Error("expected unknown");
+    expect(probe.detail).toContain("Access is denied.");
+    expect(probe.detail).toContain("RPC server is unavailable.");
+    expect(windowsSchedulerTaskInstalled("opencodex-proxy")).toBe(false);
   });
 });
 

--- a/tests/windows-scheduler-install-verification.test.ts
+++ b/tests/windows-scheduler-install-verification.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildWindowsTaskXml,
+  evaluateWindowsSchedulerInstallVerification,
+  windowsTaskRegistrationHealthy,
+} from "../src/service";
+
+describe("evaluateWindowsSchedulerInstallVerification", () => {
+  const wscript = "C:\\Windows\\System32\\wscript.exe";
+  const launcher = "C:\\Users\\Test\\.opencodex\\opencodex-service-launcher.vbs";
+  const healthyXml = buildWindowsTaskXml("ignored.cmd", launcher)
+    .replace(/<Command>.*?<\/Command>/, `<Command>${wscript}</Command>`);
+
+  test("succeeds when task, registration, assets, and absent WinSW all hold", () => {
+    expect(windowsTaskRegistrationHealthy(healthyXml, wscript, launcher)).toBe(true);
+    const result = evaluateWindowsSchedulerInstallVerification({
+      taskInstalled: true,
+      xml: healthyXml,
+      assetsExist: true,
+      nativeStatus: "nonexistent",
+      wscript,
+      launcher,
+    });
+    expect(result).toMatchObject({
+      ok: true,
+      conflict: false,
+      nativeServiceAbsent: true,
+      registrationHealthy: true,
+      assetsHealthy: true,
+      detail: "ok",
+    });
+  });
+
+  test("fails with conflict when WinSW remains installed", () => {
+    const result = evaluateWindowsSchedulerInstallVerification({
+      taskInstalled: true,
+      xml: healthyXml,
+      assetsExist: true,
+      nativeStatus: "stopped",
+      wscript,
+      launcher,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.conflict).toBe(true);
+    expect(result.nativeServiceAbsent).toBe(false);
+    expect(result.detail).toContain("CONFLICT");
+  });
+
+  test("fails when both scheduler and WinSW report present", () => {
+    const result = evaluateWindowsSchedulerInstallVerification({
+      taskInstalled: true,
+      xml: healthyXml,
+      assetsExist: true,
+      nativeStatus: "started",
+      wscript,
+      launcher,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.conflict).toBe(true);
+  });
+
+  test("fails when registration health is invalid", () => {
+    const badXml = healthyXml.replace("<LogonTrigger>", "<BootTrigger>");
+    const result = evaluateWindowsSchedulerInstallVerification({
+      taskInstalled: true,
+      xml: badXml,
+      assetsExist: true,
+      nativeStatus: "nonexistent",
+      wscript,
+      launcher,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.registrationHealthy).toBe(false);
+    expect(result.detail).toContain("unhealthy");
+  });
+
+  test("fails when required assets are missing", () => {
+    const result = evaluateWindowsSchedulerInstallVerification({
+      taskInstalled: true,
+      xml: healthyXml,
+      assetsExist: false,
+      nativeStatus: "nonexistent",
+      wscript,
+      launcher,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.assetsHealthy).toBe(false);
+    expect(result.detail).toContain("assets are missing");
+  });
+
+  test("fails when scheduler task is absent", () => {
+    const result = evaluateWindowsSchedulerInstallVerification({
+      taskInstalled: false,
+      xml: "",
+      assetsExist: true,
+      nativeStatus: "nonexistent",
+      wscript,
+      launcher,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.taskInstalled).toBe(false);
+    expect(result.detail).toContain("not installed");
+  });
+});

--- a/tests/windows-scheduler-install-verification.test.ts
+++ b/tests/windows-scheduler-install-verification.test.ts
@@ -2,8 +2,22 @@ import { describe, expect, test } from "bun:test";
 import {
   buildWindowsTaskXml,
   evaluateWindowsSchedulerInstallVerification,
+  windowsSchedulerCsvIncludesTask,
   windowsTaskRegistrationHealthy,
 } from "../src/service";
+
+describe("windowsSchedulerCsvIncludesTask", () => {
+  test("matches quoted Task Scheduler CSV task names", () => {
+    const csv = [
+      `"TaskName","Next Run Time","Status"`,
+      `"\\opencodex-proxy","N/A","Ready"`,
+      `"\\Other Task","N/A","Ready"`,
+    ].join("\n");
+    expect(windowsSchedulerCsvIncludesTask(csv, "opencodex-proxy")).toBe(true);
+    expect(windowsSchedulerCsvIncludesTask(csv, "missing-task")).toBe(false);
+    expect(windowsSchedulerCsvIncludesTask(csv, "opencodex")).toBe(false);
+  });
+});
 
 describe("evaluateWindowsSchedulerInstallVerification", () => {
   const wscript = "C:\\Windows\\System32\\wscript.exe";

--- a/tests/windows-scheduler-install-verification.test.ts
+++ b/tests/windows-scheduler-install-verification.test.ts
@@ -72,7 +72,7 @@ describe("evaluateWindowsSchedulerInstallVerification", () => {
     expect(result.conflict).toBe(false);
     expect(result.nativeStatusUnknown).toBe(true);
     expect(result.nativeServiceAbsent).toBe(false);
-    expect(result.detail).toContain("could not be verified");
+    expect(result.detail).toContain("could not verify");
     expect(result.detail).not.toContain("CONFLICT");
   });
 

--- a/tests/windows-scheduler-install-verification.test.ts
+++ b/tests/windows-scheduler-install-verification.test.ts
@@ -59,6 +59,23 @@ describe("evaluateWindowsSchedulerInstallVerification", () => {
     expect(result.conflict).toBe(true);
   });
 
+  test("treats unknown WinSW status as unverified, not as a conflict", () => {
+    const result = evaluateWindowsSchedulerInstallVerification({
+      taskInstalled: true,
+      xml: healthyXml,
+      assetsExist: true,
+      nativeStatus: "unknown",
+      wscript,
+      launcher,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.conflict).toBe(false);
+    expect(result.nativeStatusUnknown).toBe(true);
+    expect(result.nativeServiceAbsent).toBe(false);
+    expect(result.detail).toContain("could not be verified");
+    expect(result.detail).not.toContain("CONFLICT");
+  });
+
   test("fails when registration health is invalid", () => {
     const badXml = healthyXml.replace("<LogonTrigger>", "<BootTrigger>");
     const result = evaluateWindowsSchedulerInstallVerification({


### PR DESCRIPTION
## Summary

Fixes the Windows dashboard background service install failure when `schtasks /create` returns access denied (`Zugriff verweigert`).

## Changes

- Add Windows elevation helpers for access-denied detection and UAC relaunch.
- Improve `schtasks` error messages with actionable guidance.
- Retry dashboard `install-service` through an elevated CLI run when access is denied, then verify the scheduler task exists.

## Verification

- `bun test tests/service.test.ts tests/startup-action-control.test.ts tests/windows-elevation.test.ts`
- `bun run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows-only UAC elevation and Task Scheduler elevated create/run with rollback, including protocol exit codes and bounded output handling.
  * Added post-install verification for scheduled task registration (task/XML/asset checks) and richer reconciliation status reporting.
  * Improved CLI install error classification by extracting stable markers and preserving user-facing detail.
* **Bug Fixes**
  * Better handling of localized Task Scheduler access-denied and UAC cancellation (including “indeterminate/blocked” install-state behavior).
  * Safer elevated execution outcomes and rollback when verification fails or reconciliation is stale.
* **Tests**
  * Expanded Bun coverage for elevation, access-denied detection, scheduler verification/reconciliation, and startup install retry/state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->