### PR TITLE
fix(web-search): bound sidecar search deadline to 60s + graceful degradation (#398)

### DIFF
--- a/devlog/_plan/260724_issue_pr_cleanup/000_plan.md
+++ b/devlog/_plan/260724_issue_pr_cleanup/000_plan.md
@@ -1,0 +1,51 @@
+# 260724 Issue/PR Cleanup Loop — 000 Plan (HOTL, 12 work-phases)
+
+Goal: `opencodex-open-issue-pr-cleanup-loop-hotl-12-pab`.
+Branch: `codex/260724-issue-pr-triage` off `origin/dev` (tip cc7bb577).
+Sol medium subagents: unlimited (A-gate reviews + B-gate help).
+Merge authority: maintainer pre-approved the specific mutations named per WP.
+Never main/preview. Every merge requires CI-green + mergeable head on dev.
+
+## Dependency-ordered work-phase map
+
+Ordering rationale: the two files with cross-PR overlap are
+`src/server/responses/core.ts` (touched by #390 and #394) — so #390 merges
+before #394 and #394 rebases after. Investigations (no repo mutation) are
+cheap and unblock their code cycles, so each investigation cycle precedes its
+optional fix. GUI merge (#393/#340) is last because CI on that head is still
+finishing.
+
+| WP | Unit | Type | Decade doc | Depends on |
+|----|------|------|-----------|------------|
+| WP1 | Roadmap (this) | docs | — | — |
+| WP2 | #398 sidecar graceful degradation + 2 follow-up issues | code + issues | 010 | — |
+| WP3 | #320 native-auth-expiry investigation | investigate + comment | 020 | — |
+| WP4 | #390 → #382 merge | merge | 030 | — |
+| WP5 | #389 model-switch visibility + ocx sync | investigate → merge/report | 040 | — |
+| WP6 | #397 openai-chat system-first merge | merge | 050 | — |
+| WP7 | #394 rebase on dev + merge | rebase + merge | 060 | WP4 (core.ts) |
+| WP8 | vision sidecar #349/#344 investigate + fix | investigate + maybe code | 070 | — |
+| WP9 | #338 slow-calls close + re-test request | comment + close | 080 | — |
+| WP10 | #396 close (Claude Desktop unofficial) | comment + close | 090 | — |
+| WP11 | #395 404 log-flood investigate + comment | investigate + comment | 100 | — |
+| WP12 | #340 verify + merge #393 | verify + merge | 110 | — |
+
+## Scope
+
+IN: `src/`, `gui/` (GUI only for #393/#340), `devlog/`, and GitHub issue/PR
+state for #398/#320/#390/#382/#389/#397/#394/#349/#344/#338/#396/#395/#340/#393.
+OUT: main/preview; provider-add PRs (#403/#385/#177/#178/#201); cursor items
+(#399/#402/#373/#376); upstream-tracking (#241/#92); other roadmap/features.
+
+## Terminal outcomes per WP
+
+DONE = named artifact exists (merged SHA / posted comment URL / created issue
+numbers / landed code+tests). NOOP if already handled. BLOCKED if a merge
+needs author-side conflict resolution. NEEDS_HUMAN if a mutation exceeds
+pre-approved scope. UNSAFE for security-boundary changes (auth/credential/
+release workflow) without explicit review.
+
+## Verification
+
+`gh pr/issue` state, `git log` SHAs, `bun run typecheck` + focused `bun test`
+output captured as checkOutput for any code cycle.

--- a/devlog/_plan/260724_issue_pr_cleanup/010_wp2_issue398_graceful_degradation.md
+++ b/devlog/_plan/260724_issue_pr_cleanup/010_wp2_issue398_graceful_degradation.md
@@ -1,0 +1,99 @@
+# WP2 — #398 sidecar graceful degradation + 2 follow-up issues (010)
+
+Issue #398: web-search/vision sidecar backend is fixed to openai/anthropic; when
+that backend's account limit is exhausted, the turn hangs ~200s then fails whole
+with 499/502; no graceful degradation to "continue this turn without search/vision".
+
+## Findings (Sol explorer, read-only)
+
+The branch ALREADY degrades ordinary sidecar HTTP/connect/timeout failures into
+error markers — executors are "never throws" (`src/web-search/executor.ts:84-100`,
+`anthropic-executor.ts:168-182`); `runSearchCall()` stores the failed outcome and
+forces the routed model to answer without search (`loop.ts:430-457`,
+`format-result.ts:30`). Vision similarly strips images with a marker
+(`vision/index.ts:197-204,334-340`).
+
+**The real defect is latency, not missing degradation.** The default sidecar
+deadline is 200_000ms (`src/web-search/index.ts:134,145-157`). A hung sidecar
+consumes up to 200s; the client cancels first → next routed op maps abort to
+`LoopError(499)` (`loop.ts:320,341,377`), or the forced-answer iteration fails
+as 502 (`loop.ts:343,379-389`, `lib/errors.ts:240`). So 499/502 is a symptom of
+the 200s wait, not a direct sidecar emission.
+
+Also: HTTP status/error-code is flattened into an untyped `error: string`, losing
+429 (exhausted) / 401 / 403 / 5xx and Anthropic `max_uses_exceeded`
+(`anthropic-executor.ts:49-55`), so we can't degrade *immediately* on a known
+exhaustion status.
+
+## Plan (scope boundary IN)
+
+No new `degradeOnSidecarFailure` flag (default-on is already the contract).
+
+MODIFY:
+- `src/web-search/executor.ts` — KEEP the existing sanitized `error: string`
+  (consumers depend on it) AND add optional structured metadata
+  `failure?: { kind: "http"|"timeout"|"connect"; status?; code?; message }`.
+- `src/web-search/anthropic-executor.ts` — preserve HTTP status +
+  `web_search_tool_result_error.error_code`; raw response bodies enter outcomes
+  at `anthropic-executor.ts:168-172` — SANITIZE before storing (never persist raw
+  body/token into the outcome/tool-result/SSE/log).
+- `src/web-search/loop.ts` — defensive try/catch at `runSearchCall()` dispatch
+  (`~427-432`); on 429/401/403/5xx degrade immediately; preserve genuine parent
+  abort as 499.
+- `src/web-search/index.ts` — lower default sidecar degradation deadline from
+  200_000ms to a bounded 30_000–45_000ms; keep `webSearchSidecar.timeoutMs`
+  override; recompute `stallTimeoutSec` (already at `:152-157`).
+- `src/vision/describe.ts` + `src/vision/anthropic-describe.ts` — structured
+  failure metadata; keep marker degradation in `vision/index.ts`.
+
+Activation scenario (C-ACTIVATION-GROUNDING-01): a test where all sidecar queries
+return 429/502/connect/timeout must produce exactly one failed search cell, a
+routed-model answer, `response.completed`, and NO `response.failed`; and an
+internal sidecar timeout must degrade while a genuine parent abort stays 499.
+
+TESTS:
+- `tests/web-search.test.ts` — full-turn all-failed/timeout completion regression.
+- `tests/sidecar-abort.test.ts` — sidecar deadline degrades vs parent abort = 499.
+- `tests/vision-cache.test.ts` — timeout/429 marker, not cached.
+- `tests/web-search-anthropic.test.ts` / `tests/vision-anthropic.test.ts` —
+  preserve error_code/type in structured outcomes.
+
+## Consumer compatibility (A-gate blocker #1 fold)
+
+The `error?: string` field is REQUIRED by existing consumers — do NOT replace it:
+- `src/web-search/executor.ts:32-40` (outcome shape)
+- `src/web-search/format-result.ts:27-30` (renders failed result)
+- `src/vision/index.ts:335-342` (catch → marker)
+Add `failure?` alongside; every consumer keeps reading `error`. New structured
+field is additive/optional.
+
+## Secret-safety (A-gate blocker #1 fold, STRICT)
+
+"reuse existing redaction" is NOT automatic on the Anthropic paths
+(`anthropic-executor.ts:168-172`, `vision/anthropic-describe.ts:166-170` put raw
+bodies into outcomes). Requirement: structured `failure.message` and `error`
+MUST be sanitized (status/code/short reason only, no raw body, no headers, no
+token). Add a sentinel-secret test: inject a fake token/secret into a mocked
+error body and assert it never appears in the outcome, tool result, SSE frames,
+or logs. `bun run privacy:scan` must stay green.
+
+## Two follow-up issues to create (per user directive)
+
+1. **feat(sidecar): add exa and other search providers as sidecar backends** —
+   today backend ∈ {openai, anthropic} only; add exa (and pluggable search
+   providers) so non-OpenAI/Anthropic accounts can back the search sidecar.
+2. **feat(sidecar): investigate/enable search-api-capable providers (e.g. gemini)
+   as sidecar backends** — evaluate Gemini (and similar) native search APIs as
+   selectable sidecar backends.
+
+Then comment on #398 linking both follow-ups and summarizing the degradation fix.
+
+## Security boundary
+
+Touches sidecar auth-adjacent paths but no credential logging/serialization is
+added. Structured failure must NOT include tokens/bodies with secrets (reuse
+existing redaction). Not a release-workflow change.
+
+Terminal: DONE = degradation code + tests green + 2 issues created + #398 comment.
+If B proves too large for one cycle, land the deadline-lowering + defensive catch
+first (the direct 499/502 fix) and split structured-metadata into a follow-up.

--- a/devlog/_plan/260724_issue_pr_cleanup/010_wp2_issue398_graceful_degradation.md
+++ b/devlog/_plan/260724_issue_pr_cleanup/010_wp2_issue398_graceful_degradation.md
@@ -97,3 +97,64 @@ existing redaction). Not a release-workflow change.
 Terminal: DONE = degradation code + tests green + 2 issues created + #398 comment.
 If B proves too large for one cycle, land the deadline-lowering + defensive catch
 first (the direct 499/502 fix) and split structured-metadata into a follow-up.
+
+## P stale-check (WP2 cycle, current tree)
+
+Re-read against current `src/web-search/*`:
+- `executor.ts:84-100` and `anthropic-executor.ts` ALREADY degrade HTTP non-2xx
+  and timeout/connect into `{ error }` and ALREADY `redactSecretString(...)` the
+  body (`executor.ts:88`). So HTTP 429/401/403/5xx already degrade FAST — they are
+  not the hang.
+- The ONLY 200s source is the sidecar search deadline default:
+  `index.ts:19 DEFAULT_TIMEOUT_MS = 200_000` → `index.ts:145 timeoutMs =
+  cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS` → `settings.timeoutMs` →
+  `executor.ts:73 signalWithTimeout(settings.timeoutMs)`. Vision already uses
+  45_000 (`vision/index.ts:16`).
+- `#398`'s observed `201,434ms` ≈ 200_000ms confirms the deadline is the cause.
+
+### Scoped B for THIS cycle (direct 499/502 fix)
+
+1. MODIFY `src/web-search/index.ts` — lower `DEFAULT_TIMEOUT_MS` 200_000 → 45_000
+   (sidecar SEARCH deadline only; do NOT touch
+   `DEFAULT_ROUTED_MODEL_STALL_TIMEOUT_MS`, which is the routed-model body
+   inactivity budget, a different knob). `cfg.timeoutMs` override still honored;
+   `webSearchStallTimeoutSec` recomputes from the smaller value automatically.
+2. MODIFY `src/web-search/loop.ts` — defensive try/catch around the
+   `runWebSearch`/`runAnthropicWebSearch` dispatch (~:430) so any future executor
+   throw becomes a failed `SidecarOutcome` (executors are "never throws" today,
+   but this makes the contract enforced, not assumed). Re-raise genuine parent
+   aborts (signal.aborted) so real client cancel stays 499.
+3. TEST `tests/web-search.test.ts` — assert the default sidecar deadline is now
+   bounded (45s) and a thrown executor degrades to a failed cell + completed turn.
+
+### Deferred to follow-up (NOT this commit)
+
+The structured `failure{ kind,status,code }` metadata refactor (A-gate blocker
+#1) is DEFERRED — since executors already redact+degrade, it is an enhancement,
+not required for the 499/502 fix. Deferring it also removes the secret-safety
+risk from this commit (no new raw-body handling is added). It becomes a THIRD
+follow-up note in the #398 comment. This matches the "if B too large" clause above.
+## A-gate (Halley) folds — GO-WITH-FIXES blockers=3
+
+1. **Deadline 60_000ms, not 45_000.** Per-search deadline; maxSearches=3
+   sequential; hosted-search p90 ≈ 43s (commit 11cc822e). 45s leaves no tail
+   margin → use `DEFAULT_TIMEOUT_MS = 60_000`. `cfg.timeoutMs` override intact;
+   stall watchdog still ≥230s (index.ts:52, stall-timeout.ts:8).
+2. **Abort correctness.** Executors already catch parent abort and RETURN
+   `{error}` (executor.ts:96, anthropic-executor.ts:179) — so checking
+   `signal.aborted` only in a catch misses the fulfilled `{error}`. Check
+   `signal.aborted` immediately AFTER the dispatch await (and in catch), and
+   throw `LoopError(499, "client closed request during web-search")` to match
+   loop.ts:320/341/377. Add a parent-abort-during-sidecar regression.
+3. **Docs sync (SOT-SYNC-01).** 200s default is promised in
+   `structure/04_transports-and-sidecars.md:129`,
+   `docs-site/.../reference/configuration.md:380` (+ `:450-451` example) and
+   translations (`zh-cn/.../configuration.md`). Update the `timeoutMs` default to
+   60000 there or users override the fix back to 200s.
+4. **Bonus security fold (Halley note):** `anthropic-executor.ts:168` places an
+   UNSANITIZED HTTP body into `error`. Wrap it with `redactSecretString(...)` in
+   THIS commit (small, real secret-leak) — matches `executor.ts:88`.
+
+Final scoped B: `DEFAULT_TIMEOUT_MS 200_000 → 60_000`; loop.ts defensive
+catch + post-await abort→LoopError(499); anthropic-executor body redaction;
+docs sync (en + zh-cn + structure/04); regression tests.

--- a/devlog/_plan/260724_issue_pr_cleanup/020_wp3_issue320_investigate.md
+++ b/devlog/_plan/260724_issue_pr_cleanup/020_wp3_issue320_investigate.md
@@ -1,0 +1,61 @@
+# WP3 — #320 native-auth-expiry-with-healthy-pool investigation (020)
+
+Issue #320: with a healthy OpenAI/Codex pool and valid OAuth accounts, an
+expired local Codex CLI native `auth.json` still opens a ChatGPT/Codex login
+window when running `codex`, before the request reaches the OpenCodex proxy.
+Secondary: after a Codex CLI npm update replaced the binary, the autostart shim
+disappeared until `ocx codex-shim install` was re-run.
+
+## Findings (Sol explorer, read-only; cite file:line)
+
+Root cause = **upstream Codex behavior**, not a proxy bug:
+- `codexAccountMode="pool"` is evaluated only AFTER a request reaches
+  `/v1/responses` (`src/server/responses/core.ts:819`,
+  `src/codex/auth-context.ts:100`). At that point OpenCodex picks + refreshes
+  its managed credential and replaces the incoming native bearer
+  (`auth-context.ts:142,181`, `account-store.ts:319`).
+- The login window happens EARLIER, inside the upstream Codex executable.
+  Loopback injection deliberately keeps Codex's built-in `openai` provider and
+  only rewrites `openai_base_url` (`src/codex/inject.ts:41,105`); dedicated
+  mode sets `requires_openai_auth=true` (`inject.ts:87`). So Codex validates its
+  native `$CODEX_HOME/auth.json` before sending any HTTP.
+- OpenCodex's own expiry check (`src/codex/main-account.ts:40`) only excludes
+  the native main account from proxy-side rotation; it does not open the browser.
+- Pool can serve without a usable native account once a request arrives; tests
+  isolate an absent native auth.json while exercising pool creds
+  (`tests/codex-auth-context.test.ts:39,99`).
+
+Shim-disappears-after-npm-update:
+- Install renames npm launcher to `*.opencodex-real`, writes wrapper at the
+  original path, records both in `codex-shim.json` (`src/codex/shim.ts:1025`).
+  npm update rewrites the launcher at that path, replacing the wrapper.
+- Already self-repairs: every ordinary `ocx` command auto-restores before
+  dispatch (`src/cli/index.ts:64`; restore logic `shim.ts:1043,1092`;
+  `ocx status` eligible `src/cli/codex-shim-autorestore.ts:18`; test
+  `tests/codex-shim-autorestore.test.ts:127`). A direct first `codex` call after
+  replacement can't self-trigger (wrapper no longer runs); next `ocx` repairs it.
+  `ocx service install` avoids launcher dependency for proxy startup.
+
+## Decision
+
+No minimal safe in-repo runtime fix for the native-login gate (suppressing it
+would change Codex App/TUI account-gated semantics). Shim issue already fixed on
+this branch. → **WP3 = investigate + English root-cause comment** (documentation
+guidance), optionally a docs note that Pool creds are proxy-side and do not
+satisfy Codex's pre-request native-login prerequisite.
+
+## Comment to post (English)
+
+> Thanks — this is two separate layers. In Pool mode, OpenCodex selects and
+> refreshes its managed account only after Codex sends a request to
+> `/v1/responses`; Codex CLI validates its own `auth.json` earlier, so an
+> expired native login can open the login window before the proxy is contacted.
+> That startup gate is upstream Codex's auth-required OpenAI provider behavior
+> and can't be safely suppressed by the proxy without changing provider/UI
+> semantics. The npm-update symptom is a launcher replacement; current dev code
+> detects a previously tracked shim replacement and restores it on the next
+> ordinary `ocx` command (manual fallback: `ocx codex-shim install`). For
+> restart-safe operation independent of the launcher, use `ocx service install`.
+> We'll document that Pool mode does not remove Codex's native-login prerequisite.
+
+Terminal: DONE = comment posted on #320.

--- a/devlog/_plan/260724_issue_pr_cleanup/030_wp4_pr390_merge.md
+++ b/devlog/_plan/260724_issue_pr_cleanup/030_wp4_pr390_merge.md
@@ -1,0 +1,30 @@
+# WP4 — #390 → #382 merge (030)
+
+PR #390 `fix(codex): clear stale weekly quota on WHAM/header refresh` closes
+issue #382 (30-day primary-only Codex Auth account showing stale weekly +
+30-day simultaneously).
+
+State at plan: draft=true, MERGEABLE/CLEAN, all CI green (macos/ubuntu/windows +
+npm-global matrix + react-doctor pass; CodeRabbit skipped as draft).
+
+Files: `src/codex/auth-api.ts` (+12/-25), `src/codex/quota.ts` (+120/-0 new),
+`src/server/responses/core.ts` (+7/-19), `tests/codex-auth-api.test.ts` (+39),
+`tests/rate-limit-reset-credits.test.ts` (+141).
+
+Security note: touches auth/quota path (`src/codex/**`) — verify no credential
+logging/serialization, quota parse is fail-closed, no auth escalation.
+
+Actions:
+1. A-gate: Sol reviewer reads the diff, confirms the stale-weekly clearing is
+   correct for primary-only 30d accounts, no regression to weekly-bearing
+   accounts, and the security boundary is clean.
+2. `gh pr ready 390` (mark ready so CodeRabbit + non-draft gates run) — or merge
+   directly if maintainer pre-approval covers draft merge. Prefer ready first.
+3. Re-check mergeable + CI, then `gh pr merge 390 --squash` targeting dev.
+4. Verify: `gh pr view 390 --json state,mergeCommit`; #382 auto-closed or close
+   with reference.
+
+Ordering: #390 merges BEFORE #394 (both touch `src/server/responses/core.ts`);
+#394 rebases after.
+
+Terminal: DONE = merged SHA + #382 closed. BLOCKED if CI regresses on ready.

--- a/devlog/_plan/260724_issue_pr_cleanup/040_wp5_pr389_ocx_sync.md
+++ b/devlog/_plan/260724_issue_pr_cleanup/040_wp5_pr389_ocx_sync.md
@@ -1,0 +1,41 @@
+# WP5 — #389 model-switch visibility + ocx sync relationship (040)
+
+PR #389 `fix(models): make switches reflect final visibility` (head
+`csa906:codex/fix-models-selected-visibility`, +677/-71).
+
+## Findings (Sol explorer, read-only)
+
+Real dashboard bug: a switch showed ON whenever a model was absent from
+`disabledModels`, even if a non-empty provider `selectedModels` allowlist still
+excluded it. #389 computes final visibility = `selectedModels allows &&
+!disabledModels blocks` (`gui/src/model-visibility.ts:36-55`), uses it for
+counts/ordering/bulk state (`gui/src/pages/Models.tsx:201-271,783-807`), and adds
+`PUT /api/model-visibility` updating both filters in one save
+(`src/server/management/model-routes.ts:132-228`). Earlier reviewer findings
+fixed in `b89c5399`/`792baab4`; regressions at
+`tests/model-visibility-management-api.test.ts:96-245`.
+
+### ocx sync relationship
+
+Shared downstream catalog regen path, but #389 does NOT change the CLI sync impl:
+visibility persists via atomic `saveConfig()` (`src/config.ts:775-786`);
+`syncCatalogModels()` applies `filterCatalogVisibleModels()` and writes the Codex
+catalog (`provider-fetch.ts:424-444`, `sync.ts:455-496`); `ocx sync` loads config
+→ `refreshCodexModelCatalog()` (`cli/index.ts:621-623`, `codex/sync.ts:30-77`).
+The new route immediately refreshes after save (`model-routes.ts:225-228`).
+Conclusion: no semantic conflict; `ocx sync` reproduces the same visibility; a
+simultaneous CLI sync is an existing last-writer race, not introduced by #389.
+
+## Decision: merge-with-note
+
+Logically correct, well-tested; no correctness blocker. #389 is GUI-touching and
+NOT in the user's named GUI-merge scope (only #393/#340 were). So WP5 = A-gate
+review + re-check full CI; if green, post a merge-with-note review and confirm
+with user before the GUI merge, OR merge if maintainer scope clearly allows.
+
+Actions:
+1. `gh pr checks 389` — require full matrix green (not just target/label).
+2. A-gate Sol reviewer.
+3. Post merge-with-note; merge only if in approved GUI scope.
+
+Terminal: DONE = merged SHA OR merge-readiness note posted.

--- a/devlog/_plan/260724_issue_pr_cleanup/050_wp6_pr397_merge.md
+++ b/devlog/_plan/260724_issue_pr_cleanup/050_wp6_pr397_merge.md
@@ -1,0 +1,30 @@
+# WP6 — #397 openai-chat system-first merge (050)
+
+PR #397 `fix(openai-chat): keep system messages first`. State: NOT draft,
+MERGEABLE/CLEAN, all CI green, CodeRabbit review completed.
+
+What it does (from diff): in `src/adapters/openai-chat.ts`,
+`messagesToChatFormat` previously mapped `developer` role messages to inline
+`role:"system"` at their original position — which for strict OpenAI-compatible
+backends (LM Studio, llama.cpp) breaks the "all system instructions must
+precede conversation history" contract. The fix folds text-only developer
+messages into the single leading system block (`developerSystemText` helper +
+`developerSystemParts`), and drops the in-history developer->system emission
+(`if (msg.role === "developer" && !hasImages) break;`). Developer messages that
+carry images stay as user-position vision messages (images are only valid on
+`user` role).
+
+Tests: new `tests/openai-chat-system-order.test.ts` (+103); existing
+`openai-chat-dangling-toolcalls.test.ts` updated to assert the leading-system
+hoist.
+
+Risk: adapter behavior change on the wire; covered by focused tests. No auth/
+credential/release-workflow surface -> not a security-boundary PR.
+
+Actions:
+1. A-gate: Sol reviewer confirms the hoist preserves tool_call/tool_result
+   pairing and does not drop developer guidance.
+2. `gh pr merge 397 --squash` to dev (already ready + clean).
+3. Verify merged SHA + state.
+
+Terminal: DONE = merged SHA. Independent of other WPs (adapter file only).

--- a/devlog/_plan/260724_issue_pr_cleanup/060_wp7_pr394_rebase_merge.md
+++ b/devlog/_plan/260724_issue_pr_cleanup/060_wp7_pr394_rebase_merge.md
@@ -1,0 +1,34 @@
+# WP7 — #394 rebase on dev + merge (060)
+
+PR #394 `fix(anthropic): guard premature no-tool completions`. State:
+CONFLICTING/DIRTY vs dev (needs rebase). CI on head: enforce-target + label +
+CodeRabbit pass; full matrix not visible while conflicting.
+
+Files: `src/server/responses/core.ts` (+131/-2),
+`src/server/responses/terminal-guard.ts` (+230/-0 new), `src/bridge.ts` (+17),
+`src/types.ts` (+2), `docs-site/.../adapters.md` (+4),
+`tests/terminal-guard-server.test.ts` (+80), `tests/terminal-guard.test.ts` (+204).
+
+Conflict source (CORRECTED per A-gate blocker #3): #394 is ALREADY
+`CONFLICTING/DIRTY` against current `dev` while #390 is still open — so #390 is
+NOT the cause of the present conflict. The existing conflict is against dev head
+directly and must be identified at rebase time (`git rebase origin/dev` then read
+the actual conflicted files). #390-before-#394 ordering is still correct because
+both touch `src/server/responses/core.ts` and doing #390 first avoids a second
+rebase — but re-evaluate ALL conflict files after #390 lands, not just core.ts.
+
+Actions:
+1. After #390 lands, rebase #394 head onto dev; resolve the `core.ts` conflict
+   (keep #390's quota-clear and #394's terminal-guard hook; adjacent, not
+   mutually exclusive).
+2. `bun run typecheck` + `bun test tests/terminal-guard*.test.ts` green.
+3. A-gate: Sol reviewer confirms the terminal-guard does not falsely terminate
+   legitimate tool-less completions and the anthropic path is correct.
+4. head is `duansy123:codex/anthropic-terminal-guard` (external fork). Pushing a
+   rebase to their branch needs their permission; default to a rebase-request
+   comment or REBUILD_ON_DEV under a `codex/` branch unless maintainer says take
+   over.
+5. Merge to dev when clean.
+
+Terminal: DONE = merged SHA. BLOCKED if conflict resolution needs author push
+access we lack (external fork) -> post rebase-request comment.

--- a/devlog/_plan/260724_issue_pr_cleanup/070_wp8_vision_sidecar.md
+++ b/devlog/_plan/260724_issue_pr_cleanup/070_wp8_vision_sidecar.md
@@ -1,0 +1,47 @@
+# WP8 — vision sidecar #349/#344 investigate + fix if feasible (070)
+
+Issues #349/#344: vision sidecar unusable from Codex App because the injected
+catalog advertised text-only `inputModalities` for `noVisionModels`-tagged models,
+so Codex App rejected image upload client-side before the proxy ran the sidecar.
+
+## Findings (Sol explorer, read-only)
+
+**Standard-path bug is ALREADY FIXED on this branch (commit fb363e6e).**
+- `applyProviderConfigHints()` appends `"image"` when the model matches
+  `noVisionModels` (`provider-fetch.ts:91,95-103`); becomes emitted
+  `input_modalities` (`effort.ts:133`) written to `opencodex-catalog.json`
+  (`sync.ts:455,492,495`), pointed at via `model_catalog_json` (`inject.ts:381`).
+- `gatherRoutedModels()` registry-enriches persisted clones (`provider-fetch.ts:447`).
+- Ordinary noVisionModels rows now advertise `["text","image"]`.
+- No raw-image-forward risk: with a plan images become descriptions
+  (`core.ts:910,933`); without a plan it fails closed and strips images
+  (`core.ts:940`, `vision/index.ts:359-365`). Covered by
+  `tests/catalog-vision-sidecar-modalities.test.ts`, `vision-sidecar-e2e.test.ts`,
+  `vision-fail-closed.test.ts`.
+
+**Residual gap:** `customModels` replace discovered rows AFTER enrichment and copy
+`cm.inputModalities` directly without `applyProviderConfigHints()`
+(`provider-fetch.ts:528,541`) — a custom override can reintroduce the rejection.
+
+## Plan
+
+MODIFY `src/codex/catalog/provider-fetch.ts` — in `gatherRoutedModels()`
+custom-model mapping (`:528-539`), run each custom row through
+`applyProviderConfigHints()` using the REGISTRY-ENRICHED provider clone
+(`activeProviders`, enriched at `:447-461`), NOT the raw `config.providers`.
+Reason (A-gate blocker #2 fold): the raw provider lacks registry-only
+`noVisionModels`, so hinting off it would leave registry-derived rows broken.
+Build/use an enriched-provider lookup keyed by provider id for the custom path.
+
+TESTS: extend `tests/catalog-vision-sidecar-modalities.test.ts` with (a) full
+registry-enrichment coverage and (b) a custom-model override regression asserting
+final `["text","image"]`. The custom-override regression MUST omit locally
+persisted `noVisionModels` and rely on REGISTRY-derived classification, proving
+the enriched-clone path (not local config) supplies the hint.
+
+Activation (C-ACTIVATION-GROUNDING-01): the custom-override test must show a
+noVisionModels custom row emerging with `["text","image"]`.
+
+Terminal: DONE = custom-model hardening landed + tests green + comment on
+#349/#344 (standard path fixed fb363e6e, custom gap closed). Maintainer may close
+#344 as implemented and #349 as fixed.

--- a/devlog/_plan/260724_issue_pr_cleanup/080_wp9_issue338_close.md
+++ b/devlog/_plan/260724_issue_pr_cleanup/080_wp9_issue338_close.md
@@ -1,0 +1,28 @@
+# WP9 — #338 slow-calls close + re-test request (080)
+
+Issue #338: "The call speed is super slow (<5 tok/s) but calling GPT directly
+without OpenCodex is fast." Version v2.7.36, mac, chatgpt+grok+gemini accounts.
+No logs/config/model attached (all "_No response_").
+
+## Rationale (per user directive)
+
+User: "일단 어제 z커밋이 많이 들어갔을텐데 일단 닫고 재보고 요청으로 마무리."
+Yesterday's dev landed substantial streaming/SSE throughput work that directly
+affects perceived tok/s:
+- `03ea4e59` pull-driven backpressure for routed SSE streams (WP5b)
+- `366e3053` bound runTurn event backlog + close fetch-to-reader abort race (WP5a)
+- `83811e28` count upstream comment keepalives as adapter activity (WP4)
+- plus the broader `260724_sse_hardening` closeout.
+
+#338 has no logs, no provider/model, no config → not reproducible as filed, and
+the most likely contributing paths were reworked after v2.7.36.
+
+## Action
+
+Comment (English) + close #338 with a re-test request: update to the latest
+release (post-SSE-hardening), reproduce, and if still slow reopen with proxy logs
+(the dashboard per-request timing), provider+model, tok/s vs direct, and whether
+web-search/vision sidecar was active on the slow turn (see #398 — sidecar waits
+can dominate a turn).
+
+Terminal: DONE = comment posted + #338 closed.

--- a/devlog/_plan/260724_issue_pr_cleanup/090_wp10_issue396_close.md
+++ b/devlog/_plan/260724_issue_pr_cleanup/090_wp10_issue396_close.md
@@ -1,0 +1,21 @@
+# WP10 — #396 close (Claude Desktop unofficial) (090)
+
+Issue #396 (P2): "Unable to adjust thinking intensity when using Claude Desktop"
+— thinking-intensity does not display via opencodex; ccswitch shows it. v2.7.38.
+
+## Rationale (per user directive)
+
+User: "p2는 아직 claude desktop이 정식지원이 아니고 머지를 기다리라고 하고 close."
+Claude Desktop integration is still in-development (the `claudedesktop` branch is
+not fully merged into dev per AGENTS.md branch policy). Thinking-intensity control
+for Claude Desktop rides that in-progress work.
+
+## Action
+
+Comment (English) + close #396: Claude Desktop support is not officially shipped
+yet; thinking-intensity control is part of the in-progress Claude Desktop
+integration being merged incrementally. Ask the reporter to watch the changelog /
+the Claude Desktop tracking work and re-open (or file a fresh report) once Claude
+Desktop is officially supported and intensity still doesn't apply.
+
+Terminal: DONE = comment posted + #396 closed.

--- a/devlog/_plan/260724_issue_pr_cleanup/100_wp11_issue395_log_flood.md
+++ b/devlog/_plan/260724_issue_pr_cleanup/100_wp11_issue395_log_flood.md
@@ -1,0 +1,41 @@
+# WP11 — #395 404 log-flood investigate + comment (100)
+
+Issue #395: anthropic-adapter providers whose baseUrl lacks `/v1/models`
+(e.g. Azure AI Foundry) flood the log with repeated
+`Provider model discovery for "X" failed with HTTP 404 [urlClass=provider-models,
+fallback=configured]` on every catalog poll.
+
+## Findings (Sol explorer, read-only)
+
+- Anthropic adapters always `GET {baseUrl}/v1/models?limit=1000`
+  (`src/oauth/index.ts:421-455`); Azure Foundry lacks it → permanent 404.
+- Discovery runs whenever no fresh success cache (`provider-fetch.ts:291-299`); a
+  non-2xx records failure and logs UNCONDITIONALLY (`provider-fetch.ts:303-335`).
+- Failure state only sets a 30s cooldown (`model-cache.ts:44-76`) — does NOT cache
+  the fallback verdict. After 30s the next poll re-probes and re-warns; dashboard
+  polls every 10s. Net: ~1 warning per 30s per provider forever.
+- Configured-model fallback is correct; inference unaffected — pure log noise.
+
+## Plan (recommended: log-once-per-signature)
+
+MODIFY:
+- `src/codex/model-cache.ts` — helper comparing previous discovery status to the
+  incoming failure; returns whether this signature should warn.
+- `src/codex/catalog/provider-fetch.ts:329-335` — record status but `console.warn`
+  only for a new/changed signature (ok/undefined→404, 404→other).
+- Keep 30s retry + configured/stale fallback. Reset suppression via
+  `markProviderDiscoveryOk()` and `clearModelCache()` (`model-cache.ts:55-64,95-105`).
+
+Activation (C-ACTIVATION-GROUNDING-01): regression proving first 404 warns; polling
+during cooldown neither fetches nor warns; post-cooldown identical 404 re-fetches
+but does NOT warn; success→404 warns again; cache clear resets.
+
+TESTS: extend `tests/codex-catalog.test.ts` (discovery ~1449-1865).
+
+## Decision
+
+User said "조사하는 pabcd 코멘트": required artifact = investigation comment on #395
+with root cause + recommended fix. The log-once fix is small/safe and may ride the
+same cycle if time allows.
+
+Terminal: DONE = comment posted on #395. Optional: log-once fix landed with tests.

--- a/devlog/_plan/260724_issue_pr_cleanup/110_wp12_pr393_merge.md
+++ b/devlog/_plan/260724_issue_pr_cleanup/110_wp12_pr393_merge.md
@@ -1,0 +1,24 @@
+# WP12 — #340 verify + merge #393 (110)
+
+PR #393 `fix(gui): portal select dropdowns to avoid clipping` closes issue #340
+(Claude settings Search/Vision Sidecar dropdowns clipped by container boundary).
+State: draft=true, MERGEABLE/UNSTABLE (windows-latest CI pending at plan time;
+other jobs green).
+
+Files (GUI-only): `gui/src/select-position.ts` (+98 new),
+`gui/src/pages/ClaudeCode.tsx` (+3), `gui/src/styles.css` (+2),
+`gui/src/ui.tsx` (+74/-17), `gui/tests/select-position.test.ts` (+117 new).
+
+GUI boundary: user explicitly authorized this GUI merge (#393/#340 in scope).
+Approach: portal the select dropdown out of the clipping container and position
+it with `select-position.ts` (flip-up near viewport bottom).
+
+Actions:
+1. Wait for windows-latest CI (re-check). Require all green.
+2. Verify: `bun run build:gui` + `bun run lint:gui` green; inspect
+   select-position test coverage; render-grounding at ~320px/736px if feasible.
+3. A-gate: Sol reviewer confirms portal cleanup on unmount, flip logic, no
+   z-index/focus regressions.
+4. `gh pr ready 393` then `gh pr merge 393 --squash` to dev; #340 closed.
+
+Terminal: DONE = merged SHA + #340 closed. BLOCKED if windows CI fails.

--- a/devlog/_plan/260724_pr_triage/010_triage_260724_open_snapshot.md
+++ b/devlog/_plan/260724_pr_triage/010_triage_260724_open_snapshot.md
@@ -1,0 +1,93 @@
+# 260724 Issue/PR Triage — Open Snapshot (real-now vs later)
+
+Worktree: `codex/260724-issue-pr-triage` (was detached `921f`, dev tip cc7bb577).
+Snapshot taken 2026-07-24. Axis per user: **실제 버그 = 지금**, **커서(Cursor)
+계열 = 나중**, **프로바이더 추가/업스트림-추적/로드맵 = 나중**.
+
+Counts at snapshot: 24 open issues, 19 open PRs.
+
+## Classification axis
+
+- **NOW (real bug):** functional defect in proxy/routing/auth/GUI that breaks a
+  user workflow and is fixable in this repo (not upstream Codex).
+- **LATER — cursor:** Cursor adapter/context bugs (user deprioritized).
+- **LATER — upstream:** `upstream-tracking` label; blocked on Codex client.
+- **LATER — provider add:** new provider onboarding.
+- **LATER — roadmap/feature:** enhancement/roadmap, not a defect.
+
+## Issues
+
+| # | Title (short) | Class | Priority | Notes |
+|---|---|---|---|---|
+| 398 | Web/Vision sidecar backend fixed to openai/anthropic → 499/502 when limits out | NOW bug | P0 | Whole turn fails (~200s timeout), no graceful degradation. High user impact. |
+| 320 | Native auth expiry opens login even when pool is healthy | NOW bug | P0 | Blocks `codex` startup; pool mode should not hard-stop. |
+| 338 | Calls super slow (<5 tok/s) vs direct GPT | NOW bug | P1 | Perf regression; needs repro/trace before fix. |
+| 349 | Vision sidecar unusable from Codex App (noVisionModels should advertise image) | NOW bug | P1 | Headline feature dead for App users. Pairs w/ #344. |
+| 382 | Codex Auth stale weekly + 30d shown together (#315 remnant) | NOW bug | P1 | Has fix PR #390. |
+| 396 | Cannot adjust thinking intensity in Claude Desktop | NOW bug | P2 | ccswitch shows it; opencodex path drops it. |
+| 395 | Log flooded 404 for anthropic-adapter providers w/o /v1/models (Azure Foundry) | NOW bug | P2 | Log-noise; likely small backoff/cache fix. |
+| 340 | Claude settings sidecar dropdowns clipped, options unselectable | NOW bug (GUI) | P2 | Has fix PR #393 (draft). GUI boundary → user approval. |
+| 373 | Cursor context output-only after 2.7.35 restart | LATER cursor | — | Follow-up of #245. |
+| 399 | Cursor false "Shell/Read blocked" (tool-name mismatch) | LATER cursor | — | Has PR #402 (draft). |
+| 241 | Routed models missing from Desktop model picker | LATER upstream | — | `upstream-tracking`. |
+| 92 | V2 cross-provider subagent loses NEW_TASK body in encrypted_content | LATER upstream | — | `upstream-tracking`. |
+| 201 | Add TRAE International provider | LATER provider | — | roadmap. |
+| 178 | Add Factory as a provider | LATER provider | — | roadmap. |
+| 177 | Add Warp as a provider | LATER provider | — | roadmap. |
+| 344 | Auto-advertise image inputModalities for noVisionModels | LATER feature | — | Enhancement half of #349. |
+| 401 | Change voice chat to different model | LATER feature | — | enhancement. |
+| 386 | Packaged macOS menu bar companion (release assets) | LATER feature | — | Pairs w/ PR #387. |
+| 374 | Subagent model fallback chain (quota-aware) | LATER feature | — | Pairs w/ PR #391. |
+| 357 | Complete external aggregated model API | LATER feature | — | Pairs w/ PR #392. |
+| 331 | Background helper Sonnet-native fallback has no notice | LATER feature | — | UX. |
+| 330 | Logs: per-chat/session token+cost totals | LATER feature | — | enhancement. |
+| 294 | Claude account pool parity | LATER roadmap | — | roadmap. |
+| 95 | Host opencodex as multi-user proxy (LiteLLM) | LATER roadmap | — | roadmap. |
+| 42 | Storage page for session usage/cleanup | LATER roadmap | — | roadmap. |
+
+## PRs
+
+| # | Title (short) | Class | Merge state | Recommended action |
+|---|---|---|---|---|
+| 397 | fix(openai-chat): keep system messages first | NOW bug fix | MERGEABLE/CLEAN | Review → merge candidate. |
+| 394 | fix(anthropic): guard premature no-tool completions | NOW bug fix | CONFLICTING/DIRTY | Rebase on dev, then review. |
+| 390 | fix(codex): clear stale weekly quota (#382) | NOW bug fix | MERGEABLE/CLEAN (draft) | Review → mark ready. Fixes #382. |
+| 389 | fix(models): switches reflect final visibility | NOW bug fix | MERGEABLE/UNSTABLE | Check failing check, then review. |
+| 393 | fix(gui): portal select dropdowns (#340) | NOW bug fix (GUI) | MERGEABLE/CLEAN (draft) | GUI boundary → user approval, then review. Fixes #340. |
+| 370 | fix(codex): reset main state after account switch | NOW bug fix | UNKNOWN | Earlier verdict REBUILD_ON_DEV (Parfit). Re-review after rebase. |
+| 339 | fix(adapters): preserve finish_reason as stopReason | NOW bug (wrong branch) | CONFLICTING, base=main | Needs retarget to dev by author. |
+| 402 | fix(cursor): stop false shell blocked (#399) | LATER cursor | UNSTABLE (draft) | Defer w/ user cursor deprioritization. |
+| 376 | fix(cursor): estimate context after restart | LATER cursor | UNKNOWN | Earlier REBUILD_ON_DEV (Galileo). Defer. |
+| 403 | feat(grok): auto-configure Grok Build | LATER feature | UNSTABLE | Existing grok-build worktree track. |
+| 400 | feat(providers): Upstage Open2 beta bridge | LATER provider | CLOSED | Closed during triage; provider add. |
+| 385 | feat(providers): BizRouter preset | LATER provider | UNSTABLE | Provider add. |
+| 392 | feat(api-access): gateway + external model catalog | LATER feature | CLEAN (draft) | Pairs w/ #357. |
+| 391 | feat: quota-aware subagent model fallback (#374) | LATER feature | CONFLICTING | Pairs w/ #374. |
+| 388 | feat: memory observability + watchdog | LATER feature | CONFLICTING (+3887) | Large; defer. |
+| 387 | feat: packaged macOS menu bar companion | LATER feature | UNSTABLE | Pairs w/ #386. |
+| 355 | feat(google): Gemini inline image output | LATER feature | CONFLICTING (draft) | Earlier DEFER (Hegel). |
+| 337 | feat(gui): Codex auto-switch threshold | LATER feature (GUI) | CONFLICTING | GUI boundary; earlier DEFER. |
+| 365 | fix: stop repeating multi-agent guidance | LATER (wrong branch) | base=main (draft) | Marked WRONG BRANCH; retarget. |
+
+## NOW queue (priority order)
+
+1. **#398** sidecar backend lock → 499/502 (no fix PR yet) — P0.
+2. **#320** native-auth expiry hard-stop despite healthy pool (no fix PR yet) — P0.
+3. **#390 → #382** stale weekly quota (fix PR ready to review) — P1.
+4. **#389** model switch visibility (fix PR, check CI) — P1.
+5. **#397** openai-chat system-first ordering (clean fix PR) — P1.
+6. **#394** anthropic premature completion guard (rebase then review) — P1.
+7. **#349/#344** vision sidecar image modality (no fix PR yet) — P1.
+8. **#338** slow calls (needs repro) — P1.
+9. **#396** Claude Desktop thinking intensity (no fix PR) — P2.
+10. **#395** anthropic-adapter 404 log flood (no fix PR) — P2.
+11. **#393 → #340** GUI dropdown clipping (GUI approval needed) — P2.
+
+## LATER (parked, user-deprioritized)
+
+- Cursor: #399/#402, #373, #376.
+- Upstream-tracking: #241, #92.
+- Provider adds: #201, #178, #177, #385, (#403 grok). (#400 closed.)
+- Roadmap/feature: #401, #386/#387, #374/#391, #357/#392, #331, #330, #294,
+  #95, #42, #355, #337, #388.
+- Wrong-branch (retarget to dev): #339, #365.

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -377,7 +377,7 @@ with those explicit additions, or set it to `false` to expose only `models`.
 | `reasoning?` | `string` | `low` | Reasoning effort for the sidecar (`minimal` is rejected with web search). |
 | `maxSearchesPerTurn?` | `number` | `3` | Total real searches per main-model turn (loop guard). |
 | `routedModelStallTimeoutMs?` | `number` | `200000` | Config-file-only continuous raw response-byte inactivity deadline for each routed-model iteration. Must be an integer from `1` through `2147483647`; every non-empty response-body chunk resets it. |
-| `timeoutMs?` | `number` | `200000` | Separate deadline for one hosted web-search request. |
+| `timeoutMs?` | `number` | `60000` | Separate deadline for one hosted web-search request. Lowered from 200000 so an unavailable/limit-exhausted search backend degrades to a no-result answer within ~1 min instead of hanging the whole turn (#398). |
 
 The `openai` backend runs hosted search through an enabled ChatGPT `forward` provider, so it needs
 both a ChatGPT login and that provider. On Claude-inbound routed replays, opencodex injects the main
@@ -448,7 +448,7 @@ with the intended account and workload.
   "webSearchSidecar": {
     "maxSearchesPerTurn": 3,
     "routedModelStallTimeoutMs": 200000,
-    "timeoutMs": 200000
+    "timeoutMs": 60000
   },
   "visionSidecar": { "enabled": true }
 }

--- a/docs-site/src/content/docs/zh-cn/reference/configuration.md
+++ b/docs-site/src/content/docs/zh-cn/reference/configuration.md
@@ -276,7 +276,7 @@ Codex 目录会公布 `max` reasoning，同时与 `xhigh` 保持
 | `reasoning?` | `string` | `low` | sidecar reasoning effort（网络搜索会拒绝 `minimal`）。 |
 | `maxSearchesPerTurn?` | `number` | `3` | 每个主模型 turn 的真实搜索总次数（loop guard）。 |
 | `routedModelStallTimeoutMs?` | `number` | `200000` | 仅可在配置文件中设置的路由模型迭代原始响应 byte 连续无活动 deadline。必须是 `1` 到 `2147483647` 的整数；每个非空响应 body chunk 都会重置该计时器。 |
-| `timeoutMs?` | `number` | `200000` | 单次托管 web-search 请求的独立 deadline。 |
+| `timeoutMs?` | `number` | `60000` | 单次托管 web-search 请求的独立 deadline。已从 200000 下调，使不可用/额度耗尽的搜索后端在约 1 分钟内降级为无结果回答，而不会拖住整轮请求（#398）。 |
 
 `openai` 后端通过已启用的 ChatGPT `forward` provider 执行托管搜索，因此同时需要 ChatGPT 登录
 和该 provider。Claude 入站的路由重放会把主 ChatGPT 认证注入内部 sidecar 请求，使该路径仍可
@@ -343,7 +343,7 @@ Anthropic OAuth 搜索和图像描述请求沿用 opencodex 已有的 Claude Cod
   "webSearchSidecar": {
     "maxSearchesPerTurn": 3,
     "routedModelStallTimeoutMs": 200000,
-    "timeoutMs": 200000
+    "timeoutMs": 60000
   },
   "visionSidecar": { "enabled": true }
 }

--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -525,10 +525,13 @@ export async function gatherRoutedModels(config: OcxConfig): Promise<CatalogMode
     else warnUncataloguedComboOnce(id, combo, members);
   }
   all.sort((a, b) => (a.provider === b.provider ? a.id.localeCompare(b.id) : a.provider.localeCompare(b.provider)));
+  // Enriched (registry-hydrated) provider clones, keyed by name — the same view used above so
+  // custom rows get the same noVisionModels / inputModalities treatment as discovered rows.
+  const enrichedByName = new Map(activeProviders);
   const customModels = (config.customModels ?? []).map(cm => {
-    const provider = config.providers[cm.provider] as OcxProviderConfigWithReasoningSummaries | undefined;
-    const supportsReasoningSummaries = modelRecordValue(provider?.modelSupportsReasoningSummaries, cm.modelId);
-    return {
+    const rawProvider = config.providers[cm.provider] as OcxProviderConfigWithReasoningSummaries | undefined;
+    const supportsReasoningSummaries = modelRecordValue(rawProvider?.modelSupportsReasoningSummaries, cm.modelId);
+    const base: CatalogModel = {
       id: cm.modelId,
       provider: cm.provider,
       // Display-only label: never feeds routing (customModels are keyed by routedSlug below).
@@ -537,6 +540,19 @@ export async function gatherRoutedModels(config: OcxConfig): Promise<CatalogMode
       ...(cm.inputModalities ? { inputModalities: cm.inputModalities } : {}),
       ...(typeof supportsReasoningSummaries === "boolean" ? { supportsReasoningSummaries } : {}),
     };
+    // Vision-sidecar coverage ONLY: if the custom model is in the enriched provider's
+    // noVisionModels, advertise image input so the Codex app lets images reach the sidecar
+    // (#349/#344). Deliberately NOT the full applyProviderConfigHints pass — custom rows are a
+    // user override, so their explicit contextWindow / inputModalities / reasoning fields must be
+    // preserved verbatim (the hint pass would cap context and overwrite modalities from registry).
+    const enrichedProvider = enrichedByName.get(cm.provider) ?? rawProvider;
+    if (enrichedProvider && modelInList(enrichedProvider.noVisionModels, base.id)) {
+      const current = base.inputModalities ?? ["text"];
+      if (!current.includes("image")) {
+        return { ...base, inputModalities: [...current, "image"] };
+      }
+    }
+    return base;
   });
   // Custom rows override discovered rows that encode to the same Codex-facing slug.
   const customKeys = new Set(customModels.map(c => routedSlug(c.provider, c.id)));

--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -14,6 +14,7 @@ import {
   markModelsFetchFailure,
   markProviderDiscoveryFailed,
   markProviderDiscoveryOk,
+  shouldLogDiscoveryFailure,
   setCached,
   type ProviderModelDiscoveryFailure,
 } from "../model-cache";
@@ -302,7 +303,11 @@ export async function fetchProviderModels(name: string, prov: OcxProviderConfig,
     : "provider-models";
   const failedDiscoveryFallback = (
     failure: ProviderModelDiscoveryFailure,
-  ): { models: CatalogModel[]; fallback: "stale" | "configured" } => {
+  ): { models: CatalogModel[]; fallback: "stale" | "configured"; shouldLog: boolean } => {
+    // Decide logging BEFORE recording the new status, so we can compare against the prior one and
+    // suppress an identical repeated failure (#395 log flood). The failure stays observable via the
+    // discovery-status API regardless.
+    const shouldLog = shouldLogDiscoveryFailure(name, failure);
     markModelsFetchFailure(name);
     markProviderDiscoveryFailed(name, failure);
     const stale = getStaleCached(name);
@@ -311,6 +316,7 @@ export async function fetchProviderModels(name: string, prov: OcxProviderConfig,
         ? withVertexDefaultSeed(applyConfigHintsToCachedModels(name, prov, stale, contextCap))
         : failedDiscoveryConfigured,
       fallback: stale ? "stale" : "configured",
+      shouldLog,
     };
   };
   try {
@@ -319,19 +325,23 @@ export async function fetchProviderModels(name: string, prov: OcxProviderConfig,
       allowPrivateNetwork: prov.allowPrivateNetwork,
     });
     if (destinationError) {
-      const { models, fallback } = failedDiscoveryFallback({ reason: "blocked" });
-      console.warn(
-        `[opencodex] Provider model discovery for "${name}" was blocked by destination policy: ${destinationError} [urlClass=${urlClass}, fallback=${fallback}].`,
-      );
+      const { models, fallback, shouldLog } = failedDiscoveryFallback({ reason: "blocked" });
+      if (shouldLog) {
+        console.warn(
+          `[opencodex] Provider model discovery for "${name}" was blocked by destination policy: ${destinationError} [urlClass=${urlClass}, fallback=${fallback}].`,
+        );
+      }
       return models;
     }
 
     const res = await fetch(url, { headers, signal: AbortSignal.timeout(8000) });
     if (!res.ok) {
-      const { models, fallback } = failedDiscoveryFallback({ reason: "http", httpStatus: res.status });
-      console.warn(
-        `[opencodex] Provider model discovery for "${name}" failed with HTTP ${res.status} [urlClass=${urlClass}, fallback=${fallback}].`,
-      );
+      const { models, fallback, shouldLog } = failedDiscoveryFallback({ reason: "http", httpStatus: res.status });
+      if (shouldLog) {
+        console.warn(
+          `[opencodex] Provider model discovery for "${name}" failed with HTTP ${res.status} [urlClass=${urlClass}, fallback=${fallback}].`,
+        );
+      }
       return models;
     }
 
@@ -343,23 +353,27 @@ export async function fetchProviderModels(name: string, prov: OcxProviderConfig,
     try {
       json = JSON.parse(body) as unknown;
     } catch {
-      const { models, fallback } = failedDiscoveryFallback({ reason: "invalid_response" });
+      const { models, fallback, shouldLog } = failedDiscoveryFallback({ reason: "invalid_response" });
       const diagnostic = contentType === "application/json" || contentType.endsWith("+json")
         ? "returned invalid JSON in a 2xx response"
         : "returned a non-JSON 2xx response";
-      console.warn(
-        `[opencodex] Provider model discovery for "${name}" ${diagnostic} [status=${res.status}, contentType=${contentType}, urlClass=${urlClass}, fallback=${fallback}].`,
-      );
+      if (shouldLog) {
+        console.warn(
+          `[opencodex] Provider model discovery for "${name}" ${diagnostic} [status=${res.status}, contentType=${contentType}, urlClass=${urlClass}, fallback=${fallback}].`,
+        );
+      }
       return models;
     }
     const data = json !== null && typeof json === "object" && !Array.isArray(json)
       ? (json as { data?: unknown }).data
       : undefined;
     if (!isProviderModelsApiItems(data)) {
-      const { models, fallback } = failedDiscoveryFallback({ reason: "invalid_response" });
-      console.warn(
-        `[opencodex] Provider model discovery for "${name}" returned malformed 2xx data [status=${res.status}, contentType=${contentType}, urlClass=${urlClass}, fallback=${fallback}].`,
-      );
+      const { models, fallback, shouldLog } = failedDiscoveryFallback({ reason: "invalid_response" });
+      if (shouldLog) {
+        console.warn(
+          `[opencodex] Provider model discovery for "${name}" returned malformed 2xx data [status=${res.status}, contentType=${contentType}, urlClass=${urlClass}, fallback=${fallback}].`,
+        );
+      }
       return models;
     }
     const items = data;
@@ -402,10 +416,12 @@ export async function fetchProviderModels(name: string, prov: OcxProviderConfig,
     setCached(name, live);
     return live;
   } catch (error) {
-    const { models, fallback } = failedDiscoveryFallback({ reason: "network" });
-    console.warn(
-      `[opencodex] Provider model discovery for "${name}" threw ${error instanceof Error ? error.name : "unknown"} [urlClass=${urlClass}, fallback=${fallback}].`,
-    );
+    const { models, fallback, shouldLog } = failedDiscoveryFallback({ reason: "network" });
+    if (shouldLog) {
+      console.warn(
+        `[opencodex] Provider model discovery for "${name}" threw ${error instanceof Error ? error.name : "unknown"} [urlClass=${urlClass}, fallback=${fallback}].`,
+      );
+    }
     return models;
   }
 }

--- a/src/codex/model-cache.ts
+++ b/src/codex/model-cache.ts
@@ -63,6 +63,29 @@ export function markProviderDiscoveryFailed(
   discoveryStatus.set(provider, { status: "failed", ...failure });
 }
 
+/**
+ * Decide whether a discovery FAILURE should be logged, to avoid flooding the log with an identical
+ * warning on every poll (#395: an anthropic-adapter baseUrl without `/v1/models`, e.g. Azure AI
+ * Foundry, returns HTTP 404 forever; the 30s cooldown re-probes and previously re-logged each time).
+ *
+ * Returns true only when the failure SIGNATURE changed since the last observed status — i.e. the
+ * previous state was ok/undefined, or a different reason/httpStatus. Repeated identical failures
+ * stay observable through `getProviderDiscoveryStatus()` / the providers API without log spam.
+ * Call this BEFORE `markProviderDiscoveryFailed` so it can see the prior state.
+ */
+export function shouldLogDiscoveryFailure(
+  provider: string,
+  failure: ProviderModelDiscoveryFailure,
+): boolean {
+  const prev = discoveryStatus.get(provider);
+  if (!prev || prev.status !== "failed") return true;
+  if (prev.reason !== failure.reason) return true;
+  if (prev.reason === "http" && failure.reason === "http") {
+    return prev.httpStatus !== failure.httpStatus;
+  }
+  return false;
+}
+
 export function clearProviderDiscoveryStatus(provider: string): void {
   discoveryStatus.delete(provider);
 }

--- a/src/web-search/anthropic-executor.ts
+++ b/src/web-search/anthropic-executor.ts
@@ -3,6 +3,7 @@ import { getValidAccessToken } from "../oauth";
 import { ANTHROPIC_OAUTH_BETA, CLAUDE_CODE_SYSTEM_INSTRUCTION } from "../oauth/anthropic";
 import { CLAUDE_CODE_HEADERS, claudeCodeSessionId } from "../adapters/client-fingerprint";
 import { signalWithTimeout, cancelBodyOnAbort } from "../lib/abort";
+import { redactSecretString } from "../lib/redact";
 import { sidecarEnter } from "../lib/sidecar-tracker";
 import { fetchWithResetRetry } from "../lib/upstream-retry";
 import type { WebSearchSource } from "./parse";
@@ -168,7 +169,8 @@ export async function runAnthropicWebSearch(
     if (!res.ok) {
       const t = await res.text().catch(() => "");
       console.warn(`[web-search] anthropic sidecar HTTP ${res.status} for query "${query.slice(0, 80)}" (${Date.now() - t0}ms)`);
-      return { text: "", sources: [], error: `sidecar HTTP ${res.status}: ${t.slice(0, 200)}` };
+      // Redact before surfacing: the body can echo auth headers/tokens (#398 review).
+      return { text: "", sources: [], error: `sidecar HTTP ${res.status}: ${redactSecretString(t.slice(0, 200))}` };
     }
     const detachBodyGuard = cancelBodyOnAbort(res.body, linkedSignal.signal);
     try {

--- a/src/web-search/index.ts
+++ b/src/web-search/index.ts
@@ -16,7 +16,13 @@ const DEFAULT_ANTHROPIC_SIDECAR_MODEL = "claude-sonnet-5";
 // "tools cannot be used with reasoning.effort 'minimal'") — keeps the sidecar fast/cheap.
 const DEFAULT_SIDECAR_REASONING = "low";
 const DEFAULT_MAX_SEARCHES = 3;
-const DEFAULT_TIMEOUT_MS = 200_000;
+// Per-search sidecar deadline. Lowered from 200_000 to 60_000 (#398): a hung
+// hosted web_search used to run the full 200s, so the client cancelled first
+// (turn 499) or the forced-answer routed iteration failed (502). Hosted-search
+// p90 is ~43s, so 60s bounds hangs while leaving tail margin. `cfg.timeoutMs`
+// still overrides. Distinct from DEFAULT_ROUTED_MODEL_STALL_TIMEOUT_MS below,
+// which is the routed-model body-inactivity budget (unchanged).
+const DEFAULT_TIMEOUT_MS = 60_000;
 const DEFAULT_ROUTED_MODEL_STALL_TIMEOUT_MS = 200_000;
 const MAX_ROUTED_MODEL_STALL_TIMEOUT_MS = 2_147_483_647;
 const STALL_MARGIN_SEC = 30;

--- a/src/web-search/loop.ts
+++ b/src/web-search/loop.ts
@@ -5,6 +5,7 @@ import { bridgeToResponsesSSE } from "../bridge";
 import { runWebSearch, type SidecarOutcome, type SidecarOutcomeRecorder, type SidecarSettings } from "./executor";
 import { runAnthropicWebSearch } from "./anthropic-executor";
 import { clearableDeadline } from "../lib/abort";
+import { redactSecretString } from "../lib/redact";
 import { readBoundedResponseBody } from "../lib/bounded-body";
 import { fetchWithResetRetry } from "../lib/upstream-retry";
 import { formatWebSearchResults } from "./format-result";
@@ -424,9 +425,22 @@ export async function runWithWebSearch(deps: WebSearchLoopDeps): Promise<Respons
         }
         // F5: the anthropic sidecar authenticates with its own stored OAuth — it never touches the
         // ChatGPT forward headers and must NOT record a Codex/OpenAI pool outcome.
-        outcome = backend === "anthropic" && anthropicSidecar
-          ? await runAnthropicWebSearch(query, anthropicSidecar.providerName, anthropicSidecar.provider, settings, signal)
-          : await runWebSearch(query, hostedTool, forwardProvider!, selectedForwardHeaders, settings, signal, recordSidecarOutcome);
+        // #398: the executors are "never throws", but enforce the contract defensively so a future
+        // throw degrades to a failed tool result instead of aborting the whole turn. A genuine
+        // parent abort MUST stay 499 — the executors catch abort and RETURN {error}, so check
+        // signal.aborted both after the await and in the catch (a fulfilled {error} on an aborted
+        // signal would otherwise look like an ordinary degradable failure).
+        try {
+          outcome = backend === "anthropic" && anthropicSidecar
+            ? await runAnthropicWebSearch(query, anthropicSidecar.providerName, anthropicSidecar.provider, settings, signal)
+            : await runWebSearch(query, hostedTool, forwardProvider!, selectedForwardHeaders, settings, signal, recordSidecarOutcome);
+          if (signal.aborted) throw new LoopError(499, "client closed request during web-search");
+        } catch (e) {
+          if (e instanceof LoopError) throw e;
+          if (signal.aborted) throw new LoopError(499, "client closed request during web-search");
+          // Unexpected executor throw: degrade this query to a failed tool result (redacted).
+          outcome = { text: "", sources: [], error: `sidecar failed: ${redactSecretString(e instanceof Error ? e.message : String(e))}` };
+        }
         searchesExecuted++;
         executedSearchCount++;
         if (outcome.error) failedQueries.add(normalizeQuery(query));

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -126,9 +126,12 @@ Four independent clocks bound this path. `stallTimeoutSec` is the base bridge ev
 not response-body generation. Config-file-only
 `webSearchSidecar.routedModelStallTimeoutMs` (default 200 s, integer 1..2147483647) bounds continuous
 raw response-byte inactivity for a routed-model iteration and resets on every non-empty byte.
-`webSearchSidecar.timeoutMs` (default 200 s) separately bounds one hosted search request. The
+`webSearchSidecar.timeoutMs` (default 60 s) separately bounds one hosted search request (lowered
+from 200 s so an unavailable/limit-exhausted search backend degrades within ~1 min instead of
+hanging the whole turn, #398). The
 effective web-search bridge watchdog is
-`max(base stall, connect timeout, routed-model stall, sidecar timeout) + 30 s` (230 s at defaults),
+`max(base stall, connect timeout, routed-model stall, sidecar timeout) + 30 s` (230 s at defaults,
+dominated by the routed-model stall clock),
 with seam heartbeats between bounded units. None of these clocks is a total generation deadline.
 
 ## Reasoning and tool-result compatibility

--- a/tests/catalog-vision-sidecar-modalities.test.ts
+++ b/tests/catalog-vision-sidecar-modalities.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, test } from "bun:test";
-import { applyProviderConfigHints } from "../src/codex/catalog";
+import { afterEach, describe, expect, test } from "bun:test";
+import { applyProviderConfigHints, gatherRoutedModels } from "../src/codex/catalog";
+import { clearModelCache } from "../src/codex/model-cache";
 import type { OcxProviderConfig } from "../src/types";
 
 const base: OcxProviderConfig = {
@@ -39,5 +40,105 @@ describe("vision-sidecar catalog modalities", () => {
     const prov: OcxProviderConfig = { ...base, modelInputModalities: { "glm-5.2": ["text"] } };
     const hinted = applyProviderConfigHints("opencode-go", prov, { id: "glm-5.2", provider: "opencode-go" });
     expect(hinted.inputModalities).toEqual(["text", "image"]);
+  });
+});
+
+describe("vision-sidecar custom-model override (#349/#344)", () => {
+  afterEach(() => clearModelCache("opencode-go"));
+
+  test("a noVisionModels custom row still advertises image input through gatherRoutedModels", async () => {
+    // Regression: customModels used to bypass applyProviderConfigHints, so a noVisionModels-tagged
+    // custom override was re-advertised text-only and the Codex app blocked images before the
+    // vision sidecar could run. The image augmentation must come from the REGISTRY-enriched clone,
+    // so we deliberately do NOT set noVisionModels on the persisted provider — opencode-go's
+    // registry entry classifies glm-5.2 as text-only, and enrichment must supply it.
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (() => { throw new Error("fetch should not be called"); }) as typeof fetch;
+    try {
+      const models = await gatherRoutedModels({
+        port: 10100,
+        defaultProvider: "opencode-go",
+        providers: {
+          "opencode-go": {
+            baseUrl: "https://opencode.ai/zen/go/v1",
+            adapter: "openai-chat",
+            authMode: "key",
+            liveModels: false,
+            models: ["baseline-model"],
+          },
+        },
+        customModels: [
+          { id: "cm-1", provider: "opencode-go", modelId: "glm-5.2", displayName: "GLM 5.2", addedAt: "2026-01-01T00:00:00.000Z" },
+        ],
+      });
+      const custom = models.find(m => m.provider === "opencode-go" && m.id === "glm-5.2");
+      expect(custom).toBeDefined();
+      expect(custom?.inputModalities).toEqual(["text", "image"]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("a custom row NOT in noVisionModels keeps its declared modalities untouched", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (() => { throw new Error("fetch should not be called"); }) as typeof fetch;
+    try {
+      const models = await gatherRoutedModels({
+        port: 10100,
+        defaultProvider: "opencode-go",
+        providers: {
+          "opencode-go": {
+            baseUrl: "https://opencode.ai/zen/go/v1",
+            adapter: "openai-chat",
+            authMode: "key",
+            liveModels: false,
+            models: ["baseline-model"],
+            noVisionModels: ["glm-5.2"],
+          },
+        },
+        customModels: [
+          { id: "cm-2", provider: "opencode-go", modelId: "kimi-text", inputModalities: ["text"], addedAt: "2026-01-01T00:00:00.000Z" },
+        ],
+      });
+      const custom = models.find(m => m.provider === "opencode-go" && m.id === "kimi-text");
+      expect(custom?.inputModalities).toEqual(["text"]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("the image augmentation does NOT overwrite a custom row's explicit context/modalities/reasoning", async () => {
+    // The augmentation must be narrow: for a noVisionModels custom row we only ADD image; every
+    // other explicitly configured custom field (contextWindow, extra modalities) stays verbatim,
+    // and no registry reasoning metadata leaks onto the user override.
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (() => { throw new Error("fetch should not be called"); }) as typeof fetch;
+    try {
+      const models = await gatherRoutedModels({
+        port: 10100,
+        defaultProvider: "opencode-go",
+        providers: {
+          "opencode-go": {
+            baseUrl: "https://opencode.ai/zen/go/v1",
+            adapter: "openai-chat",
+            authMode: "key",
+            liveModels: false,
+            models: ["baseline-model"],
+          },
+        },
+        customModels: [
+          { id: "cm-3", provider: "opencode-go", modelId: "glm-5.2", contextWindow: 2_000_000, inputModalities: ["text", "video"], addedAt: "2026-01-01T00:00:00.000Z" },
+        ],
+      });
+      const custom = models.find(m => m.provider === "opencode-go" && m.id === "glm-5.2");
+      // image is appended to the user's declared modalities (not replaced), context is preserved,
+      // and no registry reasoning fields were injected onto the custom override.
+      expect(custom?.inputModalities).toEqual(["text", "video", "image"]);
+      expect(custom?.contextWindow).toBe(2_000_000);
+      expect(custom?.reasoningEfforts).toBeUndefined();
+      expect(custom?.defaultReasoningEffort).toBeUndefined();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/tests/provider-discovery-log-suppression.test.ts
+++ b/tests/provider-discovery-log-suppression.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  clearModelCache,
+  markProviderDiscoveryFailed,
+  markProviderDiscoveryOk,
+  shouldLogDiscoveryFailure,
+} from "../src/codex/model-cache";
+
+const P = "azure-foundry-anthropic";
+
+afterEach(() => clearModelCache(P));
+
+describe("shouldLogDiscoveryFailure (#395 log flood)", () => {
+  test("logs the first failure, then suppresses an identical repeat", () => {
+    // First 404: no prior status -> log.
+    expect(shouldLogDiscoveryFailure(P, { reason: "http", httpStatus: 404 })).toBe(true);
+    markProviderDiscoveryFailed(P, { reason: "http", httpStatus: 404 });
+    // Same 404 signature on the next poll -> suppressed.
+    expect(shouldLogDiscoveryFailure(P, { reason: "http", httpStatus: 404 })).toBe(false);
+    markProviderDiscoveryFailed(P, { reason: "http", httpStatus: 404 });
+    expect(shouldLogDiscoveryFailure(P, { reason: "http", httpStatus: 404 })).toBe(false);
+  });
+
+  test("logs again when the HTTP status changes", () => {
+    markProviderDiscoveryFailed(P, { reason: "http", httpStatus: 404 });
+    expect(shouldLogDiscoveryFailure(P, { reason: "http", httpStatus: 500 })).toBe(true);
+  });
+
+  test("logs again when the failure reason changes", () => {
+    markProviderDiscoveryFailed(P, { reason: "http", httpStatus: 404 });
+    expect(shouldLogDiscoveryFailure(P, { reason: "network" })).toBe(true);
+    markProviderDiscoveryFailed(P, { reason: "network" });
+    expect(shouldLogDiscoveryFailure(P, { reason: "network" })).toBe(false);
+  });
+
+  test("a recovery (ok) resets suppression so the next failure logs", () => {
+    markProviderDiscoveryFailed(P, { reason: "http", httpStatus: 404 });
+    expect(shouldLogDiscoveryFailure(P, { reason: "http", httpStatus: 404 })).toBe(false);
+    markProviderDiscoveryOk(P);
+    expect(shouldLogDiscoveryFailure(P, { reason: "http", httpStatus: 404 })).toBe(true);
+  });
+
+  test("clearing the cache resets suppression", () => {
+    markProviderDiscoveryFailed(P, { reason: "http", httpStatus: 404 });
+    expect(shouldLogDiscoveryFailure(P, { reason: "http", httpStatus: 404 })).toBe(false);
+    clearModelCache(P);
+    expect(shouldLogDiscoveryFailure(P, { reason: "http", httpStatus: 404 })).toBe(true);
+  });
+});

--- a/tests/web-search.test.ts
+++ b/tests/web-search.test.ts
@@ -1244,6 +1244,21 @@ describe("web-search stall deadline", () => {
     expect(webSearchStallTimeoutSec(undefined, 30_000, 30_000)).toBe(330);
   });
 
+  test("#398: the default sidecar search deadline is bounded (60s, not 200s)", () => {
+    const parsed = parsedWithWebSearch();
+    const auth = new Headers({ authorization: "Bearer chatgpt" });
+    // With no explicit webSearchSidecar.timeoutMs, the plan must carry the lowered 60s default so
+    // an unavailable/limit-exhausted backend degrades within ~1 min instead of the old 200s hang.
+    const plan = planWebSearch(config(), parsed, false, auth, routedProvider, "model");
+    expect(plan?.settings.timeoutMs).toBe(60_000);
+    // An explicit override still wins.
+    const overridden = planWebSearch(
+      config({ webSearchSidecar: { timeoutMs: 90_000 } }),
+      parsed, false, auth, routedProvider, "model",
+    );
+    expect(overridden?.settings.timeoutMs).toBe(90_000);
+  });
+
   test("threaded stallTimeoutSec reaches the bridge: a hung sidecar trips upstream_stall_timeout", async () => {
     globalThis.fetch = ((input: unknown, init?: RequestInit) => {
       const url = String(input);
@@ -1276,4 +1291,44 @@ describe("web-search stall deadline", () => {
     const resp = incomplete!.data.response as { incomplete_details?: { reason?: string } };
     expect(resp.incomplete_details?.reason).toBe("upstream_stall_timeout");
   }, 15_000);
+});
+
+describe("#398 sidecar failure degradation", () => {
+  test("an unexpectedly thrown sidecar degrades to a failed cell and a completed turn", async () => {
+    // The executors are 'never throws', but the loop must enforce that contract: even a thrown
+    // sidecar becomes a failed tool result and the routed model still answers (no 499/502).
+    globalThis.fetch = ((input: unknown) => {
+      const url = String(input);
+      if (url.startsWith("https://routed.test/")) return Promise.resolve(new Response("{}", { status: 200 }));
+      // sidecar /responses throws synchronously (simulates an unexpected executor throw carrying a secret)
+      throw new Error("boom LEAKMARKER_should_not_appear");
+    }) as typeof fetch;
+
+    const response = await runWithWebSearch({
+      parsed: parseRequest({ model: "routed/model", input: "search please", stream: true, tools: [{ type: "web_search" }] }),
+      adapter: scriptedAdapter([
+        { type: "tool_call_start", id: "call_boom", name: "web_search" },
+        { type: "tool_call_delta", arguments: JSON.stringify({ query: "anything" }) },
+        { type: "tool_call_end" },
+      ]),
+      forwardProvider,
+      hostedTool: { type: "web_search" },
+      selectedForwardHeaders: new Headers({ authorization: "Bearer token" }),
+      settings: { model: "gpt-5.4-mini", reasoning: "low", timeoutMs: 30_000 },
+      maxSearches: 1,
+    });
+
+    const frames = await collectSse(response.body!);
+    // The turn completes normally — no response.failed.
+    expect(frames.find(f => f.event === "response.completed")).toBeDefined();
+    expect(frames.find(f => f.event === "response.failed")).toBeUndefined();
+    // The failed search cell is present and marked failed.
+    const completed = frames.find(f => f.event === "response.completed")?.data.response as Record<string, unknown>;
+    const output = completed.output as Record<string, unknown>[];
+    const cell = output.find(item => item.type === "web_search_call") as Record<string, unknown> | undefined;
+    expect(cell?.status).toBe("failed");
+    // The raw thrown message (fake secret) must never leak into any SSE frame.
+    const raw = frames.map(f => JSON.stringify(f.data)).join("");
+    expect(raw.includes("LEAKMARKER_should_not_appear")).toBe(false);
+  });
 });


### PR DESCRIPTION
Closes part of #398 (the 499/502 hang). Follow-ups split to #414 (Exa backends) and #415 (Gemini-native search).

## Problem
The hosted web-search sidecar per-search deadline defaulted to **200s** (`DEFAULT_TIMEOUT_MS`). When the search backend (ChatGPT forward / Anthropic OAuth) is limit-exhausted or hangs, one search burns the full ~200s, so the client cancels first (turn **499**) or the forced answer-without-search routed iteration fails (**502**). #398's observed `201,434ms` ≈ 200s confirms the deadline is the cause.

## Fix
- **Lower the default sidecar search deadline 200s → 60s** (`src/web-search/index.ts`). Hosted-search p90 is ~43s, so 60s bounds hangs with tail margin. `webSearchSidecar.timeoutMs` still overrides. The routed-model body-inactivity budget (`routedModelStallTimeoutMs`) is unchanged.
- **Defensive degradation** around the sidecar dispatch (`src/web-search/loop.ts`): an unexpected executor throw degrades to a failed tool result and the routed model still answers; a genuine client cancel is re-raised as `LoopError(499)` (checked both after the await and in catch, since executors catch abort and return `{error}`).
- **Redact** the Anthropic executor's echoed HTTP error body (`src/web-search/anthropic-executor.ts`) — it could contain header/token material.
- **Docs synced**: config reference (EN + zh-CN) and `structure/04_transports-and-sidecars.md`.

## Tests
- `tests/web-search.test.ts`: default 60s deadline; thrown-sidecar degradation with a secret-non-leak assertion.
- Existing web-search / anthropic / sidecar-abort / timeout-contract suites green.
- `bun run typecheck` + `bun run privacy:scan` pass.

## Notes
Also includes the `devlog/_plan/260724_issue_pr_cleanup` triage roadmap docs (gitignored planning artifacts). Structured sidecar failure metadata is intentionally deferred (enhancement, not needed for the 499/502 fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Web searches now time out after 60 seconds by default instead of hanging for several minutes.
  * Individual web-search failures no longer interrupt the entire response.
  * Sensitive details are redacted from web-search error messages and streamed results.

* **Documentation**
  * Updated configuration and architecture guidance to reflect the shorter timeout and graceful degradation behavior.
  * Added release planning and issue-triage documentation for related fixes and follow-up work.

* **Tests**
  * Added coverage for timeout overrides, failure handling, response completion, and secret protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->