### PR TITLE
fix(ci): reject low-effort feature reports in issue-quality bot

### DIFF
--- a/.github/scripts/issue-quality.cjs
+++ b/.github/scripts/issue-quality.cjs
@@ -13,6 +13,7 @@ function clean(raw) {
   let s = raw.replace(/<!--[\s\S]*?-->/g, "");
   // Treat GitHub's "No response" placeholder as empty.
   s = s.replace(/^[\s_*]*No response[\s_*]*$/gim, "");
+  s = s.replace(/^[\s_*]*(na|n\/a|not applicable|not available)[\s_*]*$/gim, "");
   return s.trim();
 }
 
@@ -334,12 +335,41 @@ function isPlaceholder(text) {
   const lower = c.toLowerCase();
   return (
     lower === "no response" ||
+    lower === "na" ||
     lower === "n/a" ||
+    lower === "not applicable" ||
+    lower === "not available" ||
     lower === "none" ||
     lower === "todo" ||
     lower === "tbd" ||
     /^_no response_$/i.test(c)
   );
+}
+
+function countWords(text) {
+  const c = clean(text);
+  if (!c) return 0;
+  const spaced = (c.match(/\b[\p{L}\p{N}']+\b/gu) || []).length;
+  if (spaced > 0) return spaced;
+  return (c.match(/\p{L}/gu) || []).length;
+}
+
+function hasConcreteDetail(text) {
+  const c = clean(text);
+  if (!c) return false;
+  return (
+    /\d/.test(c) ||
+    /[`{}\[\]<>/\\]/.test(c) ||
+    /\b(ocx|config|api|cli|dashboard|provider|proxy|route|endpoint|workflow|command)\b/i.test(c)
+  );
+}
+
+function isTooTerseFeatureSection(text) {
+  if (isEmpty(text) || isPlaceholder(text)) return false;
+  const words = countWords(text);
+  if (words >= 8) return false;
+  if (words >= 6 && hasConcreteDetail(text)) return false;
+  return !hasConcreteDetail(text);
 }
 
 /**
@@ -386,7 +416,12 @@ function validateIssue(issue) {
     // On the legacy / translated forms these sections may be absent (null).
     if (blocker !== null && isEmpty(blocker)) emptyCore.push("current limitation");
     if (isEmpty(behaviour)) emptyCore.push("expected behaviour");
-    if (example !== null && isEmpty(example)) emptyCore.push("example usage");
+    if (example !== null && isPlaceholder(example)) {
+      reasons.push("Example usage or interface contains placeholder text instead of a concrete example.");
+      guidance.push("Add a real CLI command, config snippet, API exchange, or before/after workflow example.");
+    } else if (example !== null && isEmpty(example)) {
+      emptyCore.push("example usage");
+    }
 
     const mappedHeadingPresent =
       goal !== null || blocker !== null || behaviour !== null || example !== null;
@@ -420,6 +455,15 @@ function validateIssue(issue) {
         reasons.push("Required sections contain only placeholder text.");
         guidance.push("Replace placeholder text with your actual proposal.");
       }
+    }
+
+    const terseSections = [];
+    if (goal !== null && isTooTerseFeatureSection(goal)) terseSections.push("goal / problem");
+    if (blocker !== null && isTooTerseFeatureSection(blocker)) terseSections.push("current limitation");
+    if (behaviour !== null && isTooTerseFeatureSection(behaviour)) terseSections.push("expected behaviour");
+    if (terseSections.length > 0) {
+      reasons.push(`Required sections are too vague to act on: ${terseSections.join(", ")}.`);
+      guidance.push("Describe the workflow, limitation, and expected behaviour with enough detail for someone to implement or evaluate the request.");
     }
   }
 

--- a/.github/scripts/issue-quality.cjs
+++ b/.github/scripts/issue-quality.cjs
@@ -6,14 +6,32 @@
 // ---------------------------------------------------------------------------
 
 /**
- * Strip HTML comments, "No response" placeholders, and trim whitespace.
+ * True when the entire meaningful value is a placeholder-only token.
+ * Supports harmless Markdown emphasis/code markers and trailing punctuation.
+ * Sentences that merely contain a placeholder phrase are not matches.
+ */
+const PLACEHOLDER_ONLY_RE =
+  /^[\s_*~`]*(?:no\s+response|n\/?a|not\s+applicable|not\s+available|none|todo|tbd)[\s_*~`]*[.!?]*$/i;
+
+function isPlaceholderOnlyValue(raw) {
+  if (typeof raw !== "string") return false;
+  const withoutComments = raw.replace(/<!--[\s\S]*?-->/g, "").trim();
+  if (!withoutComments) return false;
+  return PLACEHOLDER_ONLY_RE.test(withoutComments);
+}
+
+/**
+ * Strip HTML comments, placeholder-only values, and trim whitespace.
  */
 function clean(raw) {
   if (typeof raw !== "string") return "";
   let s = raw.replace(/<!--[\s\S]*?-->/g, "");
-  // Treat GitHub's "No response" placeholder as empty.
-  s = s.replace(/^[\s_*]*No response[\s_*]*$/gim, "");
-  s = s.replace(/^[\s_*]*(na|n\/a|not applicable|not available)[\s_*]*$/gim, "");
+  // Treat placeholder-only lines (GitHub "No response", N/A, etc.) as empty.
+  s = s
+    .split("\n")
+    .map((line) => (isPlaceholderOnlyValue(line) ? "" : line))
+    .join("\n");
+  if (isPlaceholderOnlyValue(s)) return "";
   return s.trim();
 }
 
@@ -330,35 +348,19 @@ function allRepeatTitle(sections, title) {
 }
 
 function isPlaceholder(text) {
-  if (typeof text !== "string") return false;
-  const trimmed = text.trim();
-  if (!trimmed) return false;
-  const lower = trimmed.toLowerCase();
-  if (
-    lower === "no response" ||
-    lower === "na" ||
-    lower === "n/a" ||
-    lower === "not applicable" ||
-    lower === "not available" ||
-    lower === "none" ||
-    lower === "todo" ||
-    lower === "tbd" ||
-    /^_no response_$/i.test(trimmed)
-  ) {
-    return true;
-  }
-  const c = clean(text);
-  if (!c) return false;
-  const cleanedLower = c.toLowerCase();
-  return cleanedLower === "none" || cleanedLower === "todo" || cleanedLower === "tbd";
+  return isPlaceholderOnlyValue(text);
 }
 
 function countWords(text) {
   const c = clean(text);
   if (!c) return 0;
   const spaced = (c.match(/\b[\p{L}\p{N}']+\b/gu) || []).length;
-  if (spaced > 0) return spaced;
-  return (c.match(/\p{L}/gu) || []).length;
+  const letters = (c.match(/\p{L}/gu) || []).length;
+  if (spaced === 0) return letters;
+  if (letters >= 8 && /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(c) && spaced < letters) {
+    return letters;
+  }
+  return spaced;
 }
 
 function hasConcreteDetail(text) {
@@ -376,19 +378,17 @@ function isTooTerseFeatureSection(text) {
   const words = countWords(text);
   if (words >= 8) return false;
   if (words >= 6 && hasConcreteDetail(text)) return false;
-  return !hasConcreteDetail(text);
+  return true;
 }
 
 /**
- * Check if raw section text is a GitHub "No response" placeholder variant
- * without stripping it first. Used to distinguish intentionally blank optional
- * fields from actively cleared required fields.
+ * Check if raw section text is a placeholder-only variant without relying on
+ * clean() first. Used to distinguish intentionally blank optional fields
+ * (legacy "No response" / N/A) from actively cleared required fields.
  */
 function isRawPlaceholder(raw) {
   if (raw === null) return false;
-  const trimmed = raw.trim();
-  if (!trimmed) return false;
-  return /^[\s_*]*no response[\s_*]*$/i.test(trimmed);
+  return isPlaceholderOnlyValue(raw);
 }
 
 /**
@@ -638,6 +638,47 @@ function shouldReopen(botState, issue, maintainerOverride) {
   return true;
 }
 
+/**
+ * workflow_dispatch accepts a bare issue number, but GitHub reuses the same
+ * number namespace for issues and pull requests. Reject PR targets before any
+ * validation or mutation runs.
+ *
+ * @param {{ pull_request?: unknown }} issue
+ * @param {number|string} issueNumber
+ * @param {string} eventName
+ * @returns {string|null}
+ */
+function rejectsWorkflowDispatchPullRequest(issue, issueNumber, eventName) {
+  if (eventName !== "workflow_dispatch") return null;
+  if (!issue?.pull_request) return null;
+  return `#${issueNumber} is a pull request. This workflow only accepts issue numbers.`;
+}
+
+/**
+ * workflow_dispatch can be started from a selected branch. Reject runs whose
+ * selected ref is not the repository default branch so untrusted branch code
+ * cannot drive issue mutations with issues:write.
+ *
+ * @param {string} eventName
+ * @param {string|null|undefined} ref
+ * @param {string|null|undefined} defaultBranch
+ * @returns {string|null}
+ */
+function rejectsWorkflowDispatchNonDefaultBranch(eventName, ref, defaultBranch) {
+  if (eventName !== "workflow_dispatch") return null;
+  if (!defaultBranch || typeof defaultBranch !== "string") {
+    return "workflow_dispatch requires repository.default_branch to be available.";
+  }
+  const expected = `refs/heads/${defaultBranch}`;
+  if (ref !== expected) {
+    return (
+      `workflow_dispatch must run from the default branch (${defaultBranch}); ` +
+      `selected ref was ${ref || "(empty)"}.`
+    );
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Exports
 // ---------------------------------------------------------------------------
@@ -652,8 +693,12 @@ module.exports = {
   validateIssue,
   shouldReopen,
   shouldEnforceClosure,
+  isPlaceholderOnlyValue,
+  isPlaceholder,
   isRawPlaceholder,
   labelForKind,
   KIND_TO_LABEL,
   hasSubstantialStructuredContent,
+  rejectsWorkflowDispatchPullRequest,
+  rejectsWorkflowDispatchNonDefaultBranch,
 };

--- a/.github/scripts/issue-quality.cjs
+++ b/.github/scripts/issue-quality.cjs
@@ -330,10 +330,11 @@ function allRepeatTitle(sections, title) {
 }
 
 function isPlaceholder(text) {
-  const c = clean(text);
-  if (!c) return true;
-  const lower = c.toLowerCase();
-  return (
+  if (typeof text !== "string") return false;
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  const lower = trimmed.toLowerCase();
+  if (
     lower === "no response" ||
     lower === "na" ||
     lower === "n/a" ||
@@ -342,8 +343,14 @@ function isPlaceholder(text) {
     lower === "none" ||
     lower === "todo" ||
     lower === "tbd" ||
-    /^_no response_$/i.test(c)
-  );
+    /^_no response_$/i.test(trimmed)
+  ) {
+    return true;
+  }
+  const c = clean(text);
+  if (!c) return false;
+  const cleanedLower = c.toLowerCase();
+  return cleanedLower === "none" || cleanedLower === "todo" || cleanedLower === "tbd";
 }
 
 function countWords(text) {

--- a/.github/scripts/issue-quality.cjs
+++ b/.github/scripts/issue-quality.cjs
@@ -375,23 +375,21 @@ function isPlaceholder(text) {
   return isPlaceholderOnlyValue(text);
 }
 
+const CJK_RE =
+  /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/gu;
+
 function countWords(text) {
   const c = clean(text);
   if (!c) return 0;
 
-  // Use Unicode letter/number tokens so Cyrillic/Greek/Arabic words count as
-  // one token each. `\b` is ASCII-only and would miss those scripts.
-  const tokens = c.match(/[\p{L}\p{N}']+/gu) || [];
-  const letters = (c.match(/\p{L}/gu) || []).length;
-  const containsCjk =
-    /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(c);
+  // Count each CJK character as one unit, and non-CJK scripts as Unicode
+  // word tokens. Mixing one CJK glyph into a Latin/Cyrillic word must not
+  // inflate the count to letter-length.
+  const cjkChars = c.match(CJK_RE) || [];
+  const nonCjkText = c.replace(CJK_RE, " ");
+  const nonCjkTokens = nonCjkText.match(/[\p{L}\p{N}']+/gu) || [];
 
-  // CJK often has no whitespace-separated words; letter count is the detail proxy.
-  if (containsCjk && letters >= 8) {
-    return letters;
-  }
-
-  return tokens.length;
+  return cjkChars.length + nonCjkTokens.length;
 }
 
 function hasConcreteDetail(text) {

--- a/.github/scripts/issue-quality.cjs
+++ b/.github/scripts/issue-quality.cjs
@@ -13,11 +13,32 @@
 const PLACEHOLDER_ONLY_RE =
   /^[\s_*~`]*(?:no\s+response|n\/?a|not\s+applicable|not\s+available|none|todo|tbd)[\s_*~`]*[.!?]*$/i;
 
+/**
+ * If `text` is exactly one enclosing fenced code block (``` or ~~~), return the
+ * inner body; otherwise null. Real multi-statement fences are left alone by
+ * the placeholder matcher after unwrap.
+ */
+function unwrapSingleEnclosingFence(text) {
+  const trimmed = text.trim();
+  const match = trimmed.match(/^(```|~~~)[^\n]*\r?\n([\s\S]*?)\r?\n\1[ \t]*$/);
+  if (!match) return null;
+  return match[2];
+}
+
 function isPlaceholderOnlyValue(raw) {
   if (typeof raw !== "string") return false;
-  const withoutComments = raw.replace(/<!--[\s\S]*?-->/g, "").trim();
-  if (!withoutComments) return false;
-  return PLACEHOLDER_ONLY_RE.test(withoutComments);
+  let value = raw.replace(/<!--[\s\S]*?-->/g, "").trim();
+  if (!value) return false;
+
+  // A lone fenced block whose entire body is a placeholder is still placeholder
+  // text (e.g. ```text\nN/A\n```), not a real example.
+  const unwrapped = unwrapSingleEnclosingFence(value);
+  if (unwrapped !== null) {
+    value = unwrapped.trim();
+    if (!value) return false;
+  }
+
+  return PLACEHOLDER_ONLY_RE.test(value);
 }
 
 /**
@@ -26,6 +47,9 @@ function isPlaceholderOnlyValue(raw) {
 function clean(raw) {
   if (typeof raw !== "string") return "";
   let s = raw.replace(/<!--[\s\S]*?-->/g, "");
+  // Whole-value placeholders first (including a single enclosing fence), so
+  // line-by-line stripping cannot leave bare fence markers behind.
+  if (isPlaceholderOnlyValue(s)) return "";
   // Treat placeholder-only lines (GitHub "No response", N/A, etc.) as empty.
   s = s
     .split("\n")
@@ -354,13 +378,20 @@ function isPlaceholder(text) {
 function countWords(text) {
   const c = clean(text);
   if (!c) return 0;
-  const spaced = (c.match(/\b[\p{L}\p{N}']+\b/gu) || []).length;
+
+  // Use Unicode letter/number tokens so Cyrillic/Greek/Arabic words count as
+  // one token each. `\b` is ASCII-only and would miss those scripts.
+  const tokens = c.match(/[\p{L}\p{N}']+/gu) || [];
   const letters = (c.match(/\p{L}/gu) || []).length;
-  if (spaced === 0) return letters;
-  if (letters >= 8 && /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(c) && spaced < letters) {
+  const containsCjk =
+    /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(c);
+
+  // CJK often has no whitespace-separated words; letter count is the detail proxy.
+  if (containsCjk && letters >= 8) {
     return letters;
   }
-  return spaced;
+
+  return tokens.length;
 }
 
 function hasConcreteDetail(text) {
@@ -696,6 +727,8 @@ module.exports = {
   isPlaceholderOnlyValue,
   isPlaceholder,
   isRawPlaceholder,
+  countWords,
+  hasConcreteDetail,
   labelForKind,
   KIND_TO_LABEL,
   hasSubstantialStructuredContent,

--- a/.github/scripts/issue-quality.test.cjs
+++ b/.github/scripts/issue-quality.test.cjs
@@ -12,7 +12,27 @@ const {
   shouldReopen,
   shouldEnforceClosure,
   labelForKind,
+  isPlaceholderOnlyValue,
+  isPlaceholder,
+  isRawPlaceholder,
+  rejectsWorkflowDispatchPullRequest,
+  rejectsWorkflowDispatchNonDefaultBranch,
 } = require("./issue-quality.cjs");
+
+function featureBodyWithGoal(goal) {
+  return [
+    "### Area",
+    "CLI",
+    "### What are you trying to accomplish?",
+    goal,
+    "### What prevents this today?",
+    "Port resets to 10100 after every ocx stop command.",
+    "### What should OpenCodex do?",
+    "Persist the last used port in config across restarts.",
+    "### Example usage or interface",
+    "ocx start --port 8080 && ocx stop && ocx start",
+  ].join("\n");
+}
 
 // ---------------------------------------------------------------------------
 // Detection
@@ -188,19 +208,35 @@ describe("validateIssue - feature", () => {
   });
 
   it("rejects feature reports with placeholder example variants", () => {
-    const body = [
-      "### What are you trying to accomplish?",
-      "Route voice requests to a configured fallback provider when the primary quota is exhausted.",
-      "### What prevents this today?",
-      "Voice mode is hard-wired to the primary Codex quota and cannot switch providers.",
-      "### What should OpenCodex do?",
-      "Expose a setting to choose the fallback voice model and provider.",
-      "### Example usage or interface",
+    const placeholders = [
+      "NA",
       "N/A",
-    ].join("\n");
-    const result = validateIssue({ title: "Voice fallback routing", body, labels: ["enhancement"] });
-    assert.equal(result.valid, false);
-    assert.ok(result.reasons.some((r) => r.includes("placeholder")));
+      "_N/A_",
+      "NA.",
+      "N/A.",
+      "Not applicable",
+      "Not applicable.",
+      "Not available!",
+    ];
+    for (const example of placeholders) {
+      const body = [
+        "### What are you trying to accomplish?",
+        "Route voice requests to a configured fallback provider when the primary quota is exhausted.",
+        "### What prevents this today?",
+        "Voice mode is hard-wired to the primary Codex quota and cannot switch providers.",
+        "### What should OpenCodex do?",
+        "Expose a setting to choose the fallback voice model and provider.",
+        "### Example usage or interface",
+        example,
+      ].join("\n");
+      const result = validateIssue({ title: "Voice fallback routing", body, labels: ["enhancement"] });
+      assert.equal(result.valid, false, `Expected placeholder example "${example}" to be invalid`);
+      assert.ok(
+        result.reasons.some((r) => r.includes("placeholder")),
+        `Expected placeholder reason for "${example}", got: ${result.reasons.join("; ")}`,
+      );
+      assert.ok(!result.reasons.some((r) => r.includes("example usage")));
+    }
   });
 
   it("reports blank example usage as missing, not placeholder", () => {
@@ -248,6 +284,44 @@ describe("validateIssue - feature", () => {
     const result = validateIssue({ title: "\u652f\u6301\u591a\u63d0\u4f9b\u5546\u6545\u969c\u8f6c\u79fb", body, labels: ["enhancement"] });
     assert.equal(result.kind, "feature");
     assert.equal(result.valid, true);
+  });
+
+  it("rejects terse goal sections that only contain a keyword, digit, or punctuation", () => {
+    const terseGoals = ["API", "provider", "1", "/", "use CLI", "route 1"];
+    for (const goal of terseGoals) {
+      const result = validateIssue({
+        title: "Improve feature request quality",
+        body: featureBodyWithGoal(goal),
+        labels: ["enhancement"],
+      });
+      assert.equal(result.kind, "feature");
+      assert.equal(result.valid, false, `Expected terse goal "${goal}" to be invalid`);
+      assert.ok(
+        result.reasons.some((r) => r.includes("too vague")),
+        `Expected too vague reason for "${goal}", got: ${result.reasons.join(", ")}`,
+      );
+    }
+  });
+
+  it("accepts sufficiently detailed goal sections", () => {
+    const detailedGoal =
+      "Expose a dashboard setting to choose the fallback voice model and provider.";
+    const detailedResult = validateIssue({
+      title: "Voice fallback routing",
+      body: featureBodyWithGoal(detailedGoal),
+      labels: ["enhancement"],
+    });
+    assert.equal(detailedResult.kind, "feature");
+    assert.equal(detailedResult.valid, true);
+
+    const concreteGoal = "Route voice requests through the configured fallback API provider.";
+    const concreteResult = validateIssue({
+      title: "Voice fallback routing",
+      body: featureBodyWithGoal(concreteGoal),
+      labels: ["enhancement"],
+    });
+    assert.equal(concreteResult.kind, "feature");
+    assert.equal(concreteResult.valid, true);
   });
 });
 
@@ -326,6 +400,29 @@ describe("validateIssue - bug", () => {
     const result = validateIssue({ title: "[Bug]: crash", body, labels: ["bug"] });
     assert.equal(result.kind, "bug");
     assert.equal(result.valid, true, `Expected valid but got: ${result.reasons.join(", ")}`);
+  });
+
+  it("accepts a legacy bug with N/A-style placeholders in Version and Operating system", () => {
+    for (const placeholder of ["N/A", "NA", "Not applicable.", "Not available!"]) {
+      const body = [
+        "### Summary",
+        "Proxy crashes on startup when streaming is enabled.",
+        "### Reproduction",
+        "Run ocx start and send any streaming request.",
+        "### Version",
+        placeholder,
+        "### Operating system",
+        placeholder,
+      ].join("\n");
+      const result = validateIssue({ title: "[Bug]: crash", body, labels: ["bug"] });
+      assert.equal(result.kind, "bug");
+      assert.equal(
+        result.valid,
+        true,
+        `Expected legacy env placeholder "${placeholder}" to remain valid, got: ${result.reasons.join(", ")}`,
+      );
+      assert.ok(!result.reasons.some((r) => r.includes("Version")));
+    }
   });
 
   it("rejects a new-form bug where env fields were actively cleared", () => {
@@ -483,7 +580,45 @@ describe("normalisation", () => {
 
   it("treats NA and not applicable as placeholders", () => {
     assert.equal(clean("NA"), "");
+    assert.equal(clean("N/A"), "");
+    assert.equal(clean("_N/A_"), "");
+    assert.equal(clean("NA."), "");
+    assert.equal(clean("N/A."), "");
     assert.equal(clean("not applicable"), "");
+    assert.equal(clean("Not applicable."), "");
+    assert.equal(clean("Not available!"), "");
+  });
+
+  it("does not treat sentences containing placeholder phrases as empty", () => {
+    assert.equal(clean("This is N/A for voice mode today."), "This is N/A for voice mode today.");
+    assert.equal(clean("Not applicable to Claude Code."), "Not applicable to Claude Code.");
+  });
+
+  it("shares one placeholder matcher across clean, isPlaceholder, and isRawPlaceholder", () => {
+    const placeholders = [
+      "No response",
+      "NA",
+      "N/A",
+      "_N/A_",
+      "NA.",
+      "N/A.",
+      "None",
+      "Todo",
+      "TBD",
+      "Not applicable",
+      "Not applicable.",
+      "Not available!",
+    ];
+    for (const value of placeholders) {
+      assert.equal(isPlaceholderOnlyValue(value), true, value);
+      assert.equal(isPlaceholder(value), true, value);
+      assert.equal(isRawPlaceholder(value), true, value);
+      assert.equal(clean(value), "", value);
+    }
+    assert.equal(isPlaceholderOnlyValue("Route voice traffic to provider N/A fallback"), false);
+    assert.equal(isPlaceholder("use CLI"), false);
+    assert.equal(isRawPlaceholder(""), false);
+    assert.equal(isRawPlaceholder(null), false);
   });
 
   it("strips HTML comments", () => {
@@ -810,5 +945,51 @@ describe("labelForKind", () => {
     assert.equal(labelForKind("provider-compatibility"), "provider-compatibility");
     assert.equal(labelForKind(null), null);
     assert.equal(labelForKind("unknown"), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// workflow_dispatch guards
+// ---------------------------------------------------------------------------
+
+describe("rejectsWorkflowDispatchPullRequest", () => {
+  it("rejects pull request numbers on workflow_dispatch", () => {
+    assert.equal(
+      rejectsWorkflowDispatchPullRequest({ pull_request: {} }, 423, "workflow_dispatch"),
+      "#423 is a pull request. This workflow only accepts issue numbers.",
+    );
+  });
+
+  it("allows issues and non-dispatch events", () => {
+    assert.equal(rejectsWorkflowDispatchPullRequest({ pull_request: {} }, 423, "issues"), null);
+    assert.equal(rejectsWorkflowDispatchPullRequest({}, 42, "workflow_dispatch"), null);
+  });
+});
+
+describe("rejectsWorkflowDispatchNonDefaultBranch", () => {
+  it("rejects workflow_dispatch runs that are not on the default branch", () => {
+    assert.equal(
+      rejectsWorkflowDispatchNonDefaultBranch(
+        "workflow_dispatch",
+        "refs/heads/fix/issue-quality-low-effort-reports",
+        "main",
+      ),
+      "workflow_dispatch must run from the default branch (main); selected ref was refs/heads/fix/issue-quality-low-effort-reports.",
+    );
+  });
+
+  it("allows default-branch dispatches and normal issue events", () => {
+    assert.equal(
+      rejectsWorkflowDispatchNonDefaultBranch("workflow_dispatch", "refs/heads/main", "main"),
+      null,
+    );
+    assert.equal(
+      rejectsWorkflowDispatchNonDefaultBranch(
+        "issues",
+        "refs/heads/fix/issue-quality-low-effort-reports",
+        "main",
+      ),
+      null,
+    );
   });
 });

--- a/.github/scripts/issue-quality.test.cjs
+++ b/.github/scripts/issue-quality.test.cjs
@@ -163,6 +163,46 @@ describe("validateIssue - feature", () => {
     assert.equal(result.valid, true);
   });
 
+  it("rejects issue #401-style low-effort feature with placeholder example", () => {
+    const body = [
+      "### Area",
+      "Proxy and routing",
+      "### What are you trying to accomplish?",
+      "Quota for Chatgpt running out that can no longer use voice mode. Would like to change other model for that",
+      "### What prevents this today?",
+      "No usage without codex quota",
+      "### What should OpenCodex do?",
+      "Change another voice model",
+      "### Example usage or interface",
+      "NA",
+    ].join("\n");
+    const result = validateIssue({
+      title: "Change voice chat to different model",
+      body,
+      labels: ["enhancement"],
+    });
+    assert.equal(result.kind, "feature");
+    assert.equal(result.valid, false);
+    assert.ok(result.reasons.some((r) => r.includes("placeholder")));
+    assert.ok(result.reasons.some((r) => r.includes("expected behaviour")));
+  });
+
+  it("rejects feature reports with placeholder example variants", () => {
+    const body = [
+      "### What are you trying to accomplish?",
+      "Route voice requests to a configured fallback provider when the primary quota is exhausted.",
+      "### What prevents this today?",
+      "Voice mode is hard-wired to the primary Codex quota and cannot switch providers.",
+      "### What should OpenCodex do?",
+      "Expose a setting to choose the fallback voice model and provider.",
+      "### Example usage or interface",
+      "N/A",
+    ].join("\n");
+    const result = validateIssue({ title: "Voice fallback routing", body, labels: ["enhancement"] });
+    assert.equal(result.valid, false);
+    assert.ok(result.reasons.some((r) => r.includes("placeholder")));
+  });
+
   it("accepts a valid legacy feature request without blocker/example headings", () => {
     const body = [
       "### Problem to solve",
@@ -422,6 +462,11 @@ describe("normalisation", () => {
   it("treats 'No response' as empty", () => {
     assert.equal(clean("No response"), "");
     assert.equal(clean("_No response_"), "");
+  });
+
+  it("treats NA and not applicable as placeholders", () => {
+    assert.equal(clean("NA"), "");
+    assert.equal(clean("not applicable"), "");
   });
 
   it("strips HTML comments", () => {

--- a/.github/scripts/issue-quality.test.cjs
+++ b/.github/scripts/issue-quality.test.cjs
@@ -203,6 +203,23 @@ describe("validateIssue - feature", () => {
     assert.ok(result.reasons.some((r) => r.includes("placeholder")));
   });
 
+  it("reports blank example usage as missing, not placeholder", () => {
+    const body = [
+      "### What are you trying to accomplish?",
+      "Route voice requests to a configured fallback provider when the primary quota is exhausted.",
+      "### What prevents this today?",
+      "Voice mode is hard-wired to the primary Codex quota and cannot switch providers.",
+      "### What should OpenCodex do?",
+      "Expose a setting to choose the fallback voice model and provider.",
+      "### Example usage or interface",
+      "",
+    ].join("\n");
+    const result = validateIssue({ title: "Voice fallback routing", body, labels: ["enhancement"] });
+    assert.equal(result.valid, false);
+    assert.ok(result.reasons.some((r) => r.includes("example usage")));
+    assert.ok(!result.reasons.some((r) => r.includes("placeholder")));
+  });
+
   it("accepts a valid legacy feature request without blocker/example headings", () => {
     const body = [
       "### Problem to solve",

--- a/.github/scripts/issue-quality.test.cjs
+++ b/.github/scripts/issue-quality.test.cjs
@@ -15,6 +15,8 @@ const {
   isPlaceholderOnlyValue,
   isPlaceholder,
   isRawPlaceholder,
+  countWords,
+  hasConcreteDetail,
   rejectsWorkflowDispatchPullRequest,
   rejectsWorkflowDispatchNonDefaultBranch,
 } = require("./issue-quality.cjs");
@@ -31,6 +33,19 @@ function featureBodyWithGoal(goal) {
     "Persist the last used port in config across restarts.",
     "### Example usage or interface",
     "ocx start --port 8080 && ocx stop && ocx start",
+  ].join("\n");
+}
+
+function featureBodyWithExample(example) {
+  return [
+    "### What are you trying to accomplish?",
+    "Route voice requests to a configured fallback provider when the primary quota is exhausted.",
+    "### What prevents this today?",
+    "Voice mode is hard-wired to the primary Codex quota and cannot switch providers.",
+    "### What should OpenCodex do?",
+    "Expose a setting to choose the fallback voice model and provider.",
+    "### Example usage or interface",
+    example,
   ].join("\n");
 }
 
@@ -303,6 +318,29 @@ describe("validateIssue - feature", () => {
     }
   });
 
+  it("rejects a single long non-CJK word as overly terse", () => {
+    const terseGoals = [
+      "провайдер",
+      "маршрут",
+      "πάροχος",
+      "واجهة",
+    ];
+    for (const goal of terseGoals) {
+      assert.equal(countWords(goal), 1, `Expected "${goal}" to count as one word`);
+      const result = validateIssue({
+        title: "Improve feature request quality",
+        body: featureBodyWithGoal(goal),
+        labels: ["enhancement"],
+      });
+      assert.equal(result.kind, "feature");
+      assert.equal(result.valid, false, `Expected terse goal "${goal}" to be invalid`);
+      assert.ok(
+        result.reasons.some((r) => r.includes("too vague")),
+        `Expected too vague reason for "${goal}", got: ${result.reasons.join(", ")}`,
+      );
+    }
+  });
+
   it("accepts sufficiently detailed goal sections", () => {
     const detailedGoal =
       "Expose a dashboard setting to choose the fallback voice model and provider.";
@@ -313,8 +351,16 @@ describe("validateIssue - feature", () => {
     });
     assert.equal(detailedResult.kind, "feature");
     assert.equal(detailedResult.valid, true);
+    assert.ok(countWords(detailedGoal) >= 8);
+  });
 
-    const concreteGoal = "Route voice requests through the configured fallback API provider.";
+  it("accepts a 6-7 word goal when it includes concrete technical detail", () => {
+    const concreteGoal = "Route requests through the configured API provider.";
+    assert.equal(countWords(concreteGoal), 7);
+    assert.ok(countWords(concreteGoal) < 8);
+    assert.ok(countWords(concreteGoal) >= 6);
+    assert.equal(hasConcreteDetail(concreteGoal), true);
+
     const concreteResult = validateIssue({
       title: "Voice fallback routing",
       body: featureBodyWithGoal(concreteGoal),
@@ -323,8 +369,73 @@ describe("validateIssue - feature", () => {
     assert.equal(concreteResult.kind, "feature");
     assert.equal(concreteResult.valid, true);
   });
-});
 
+  it("rejects a 6-7 word goal that lacks concrete technical detail", () => {
+    // Avoid keywords that count as concrete detail (api/provider/workflow/…).
+    const vagueGoal = "Make this process easier for all users.";
+    assert.equal(countWords(vagueGoal), 7);
+    assert.equal(hasConcreteDetail(vagueGoal), false);
+
+    const vagueResult = validateIssue({
+      title: "Voice fallback routing",
+      body: featureBodyWithGoal(vagueGoal),
+      labels: ["enhancement"],
+    });
+    assert.equal(vagueResult.kind, "feature");
+    assert.equal(vagueResult.valid, false);
+    assert.ok(vagueResult.reasons.some((r) => r.includes("too vague")));
+  });
+
+  it("rejects fenced placeholder-only examples", () => {
+    const fencedPlaceholders = [
+      "```\nN/A\n```",
+      "```text\nN/A\n```",
+      "```json\nNot applicable.\n```",
+      "~~~text\nN/A\n~~~",
+    ];
+    for (const example of fencedPlaceholders) {
+      assert.equal(
+        isPlaceholderOnlyValue(example),
+        true,
+        `Expected fenced placeholder to match: ${JSON.stringify(example)}`,
+      );
+      const result = validateIssue({
+        title: "Voice fallback routing",
+        body: featureBodyWithExample(example),
+        labels: ["enhancement"],
+      });
+      assert.equal(result.valid, false, `Expected fenced placeholder to be invalid: ${JSON.stringify(example)}`);
+      assert.ok(
+        result.reasons.some((r) => r.includes("placeholder")),
+        `Expected placeholder reason for ${JSON.stringify(example)}, got: ${result.reasons.join("; ")}`,
+      );
+    }
+  });
+
+  it("accepts real fenced examples that merely mention N/A", () => {
+    const realExamples = [
+      "```text\nThe API returns N/A when no provider is configured.\n```",
+      '```json\n{"provider":"N/A","fallback":"anthropic"}\n```',
+    ];
+    for (const example of realExamples) {
+      assert.equal(
+        isPlaceholderOnlyValue(example),
+        false,
+        `Expected real example not to be placeholder-only: ${JSON.stringify(example)}`,
+      );
+      const result = validateIssue({
+        title: "Voice fallback routing",
+        body: featureBodyWithExample(example),
+        labels: ["enhancement"],
+      });
+      assert.equal(
+        result.valid,
+        true,
+        `Expected real fenced example to remain valid, got: ${result.reasons.join("; ")}`,
+      );
+    }
+  });
+});
 // ---------------------------------------------------------------------------
 // Validation: bug
 // ---------------------------------------------------------------------------
@@ -608,6 +719,10 @@ describe("normalisation", () => {
       "Not applicable",
       "Not applicable.",
       "Not available!",
+      "```\nN/A\n```",
+      "```text\nN/A\n```",
+      "```json\nNot applicable.\n```",
+      "~~~text\nN/A\n~~~",
     ];
     for (const value of placeholders) {
       assert.equal(isPlaceholderOnlyValue(value), true, value);
@@ -616,6 +731,8 @@ describe("normalisation", () => {
       assert.equal(clean(value), "", value);
     }
     assert.equal(isPlaceholderOnlyValue("Route voice traffic to provider N/A fallback"), false);
+    assert.equal(isPlaceholderOnlyValue("```text\nThe API returns N/A when no provider is configured.\n```"), false);
+    assert.equal(isPlaceholderOnlyValue('```json\n{"provider":"N/A","fallback":"anthropic"}\n```'), false);
     assert.equal(isPlaceholder("use CLI"), false);
     assert.equal(isRawPlaceholder(""), false);
     assert.equal(isRawPlaceholder(null), false);

--- a/.github/scripts/issue-quality.test.cjs
+++ b/.github/scripts/issue-quality.test.cjs
@@ -341,6 +341,31 @@ describe("validateIssue - feature", () => {
     }
   });
 
+  it("counts mixed-script CJK text without inflating non-CJK letter length", () => {
+    assert.equal(countWords("provider中"), 2);
+    assert.equal(countWords("провайдер中"), 2);
+    assert.equal(countWords("configuration中"), 2);
+    assert.equal(countWords("中provider文"), 3);
+  });
+
+  it("rejects mixed-script CJK stubs that only inflate letter counts", () => {
+    const terseGoals = ["provider中", "провайдер中", "configuration中"];
+    for (const goal of terseGoals) {
+      assert.ok(countWords(goal) < 8, `Expected "${goal}" to stay under 8 units`);
+      const result = validateIssue({
+        title: "Improve feature request quality",
+        body: featureBodyWithGoal(goal),
+        labels: ["enhancement"],
+      });
+      assert.equal(result.kind, "feature");
+      assert.equal(result.valid, false, `Expected terse goal "${goal}" to be invalid`);
+      assert.ok(
+        result.reasons.some((r) => r.includes("too vague")),
+        `Expected too vague reason for "${goal}", got: ${result.reasons.join(", ")}`,
+      );
+    }
+  });
+
   it("accepts sufficiently detailed goal sections", () => {
     const detailedGoal =
       "Expose a dashboard setting to choose the fallback voice model and provider.";

--- a/.github/workflows/enforce-issue-quality.yml
+++ b/.github/workflows/enforce-issue-quality.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Checkout trusted workflow code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          # Always load validator scripts from the repository default branch so
+          # a branch-selected workflow_dispatch cannot execute untrusted code
+          # with issues:write.
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
           sparse-checkout: .github/scripts
 
@@ -48,6 +52,8 @@ jobs:
               shouldReopen,
               shouldEnforceClosure,
               labelForKind,
+              rejectsWorkflowDispatchPullRequest,
+              rejectsWorkflowDispatchNonDefaultBranch,
             } = require(path.join(process.cwd(), ".github", "scripts", "issue-quality.cjs"));
 
             const { owner, repo } = context.repo;
@@ -74,11 +80,34 @@ jobs:
               : "";
 
             // -----------------------------------------------------------------
+            // Reject branch-selected manual dispatches before any issue API use
+            // -----------------------------------------------------------------
+            const nonDefaultBranchFailure = rejectsWorkflowDispatchNonDefaultBranch(
+              context.eventName,
+              context.ref,
+              context.payload.repository?.default_branch,
+            );
+            if (nonDefaultBranchFailure) {
+              core.setFailed(nonDefaultBranchFailure);
+              return;
+            }
+
+            // -----------------------------------------------------------------
             // Fetch live issue state
             // -----------------------------------------------------------------
             const { data: issue } = await github.rest.issues.get({
               owner, repo, issue_number,
             });
+
+            const pullRequestFailure = rejectsWorkflowDispatchPullRequest(
+              issue,
+              issue_number,
+              context.eventName,
+            );
+            if (pullRequestFailure) {
+              core.setFailed(pullRequestFailure);
+              return;
+            }
 
             // -----------------------------------------------------------------
             // Trusted-user exemption

--- a/.github/workflows/enforce-issue-quality.yml
+++ b/.github/workflows/enforce-issue-quality.yml
@@ -10,13 +10,19 @@ on:
       - opened
       - edited
       - reopened
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to validate and enforce
+        required: true
+        type: number
 
 permissions:
   contents: read
   issues: write
 
 concurrency:
-  group: issue-quality-${{ github.event.issue.number }}
+  group: issue-quality-${{ github.event.issue.number || inputs.issue_number }}
   cancel-in-progress: true
 
 jobs:
@@ -45,7 +51,9 @@ jobs:
             } = require(path.join(process.cwd(), ".github", "scripts", "issue-quality.cjs"));
 
             const { owner, repo } = context.repo;
-            const issue_number = context.payload.issue.number;
+            const issue_number = context.eventName === "workflow_dispatch"
+              ? Number(context.payload.inputs.issue_number)
+              : context.payload.issue.number;
             const actor = context.actor;
             const eventType = context.eventName === "issues"
               ? context.payload.action

--- a/.github/workflows/enforce-issue-quality.yml
+++ b/.github/workflows/enforce-issue-quality.yml
@@ -17,10 +17,6 @@ on:
         required: true
         type: number
 
-permissions:
-  contents: read
-  issues: write
-
 concurrency:
   group: issue-quality-${{ github.event.issue.number || inputs.issue_number }}
   cancel-in-progress: true
@@ -28,6 +24,10 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for issue closure, reopen, and bot comments.
+      issues: write
 
     steps:
       - name: Checkout trusted workflow code
@@ -51,9 +51,23 @@ jobs:
             } = require(path.join(process.cwd(), ".github", "scripts", "issue-quality.cjs"));
 
             const { owner, repo } = context.repo;
-            const issue_number = context.eventName === "workflow_dispatch"
-              ? Number(context.payload.inputs.issue_number)
-              : context.payload.issue.number;
+            let issue_number;
+            if (context.eventName === "workflow_dispatch") {
+              const rawIssueNumber = context.payload.inputs.issue_number;
+              const parsedIssueNumber = Number(rawIssueNumber);
+              if (
+                !Number.isSafeInteger(parsedIssueNumber) ||
+                parsedIssueNumber <= 0
+              ) {
+                core.setFailed(
+                  `Invalid workflow_dispatch issue_number: ${rawIssueNumber}. Expected a positive integer.`,
+                );
+                return;
+              }
+              issue_number = parsedIssueNumber;
+            } else {
+              issue_number = context.payload.issue.number;
+            }
             const actor = context.actor;
             const eventType = context.eventName === "issues"
               ? context.payload.action

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -164,6 +164,62 @@ describe("GitHub Actions hardening", () => {
     expect(workflow).not.toMatch(/uses:\s+\S+@(?:v\d+|main|master)\b/);
   });
 
+  test("issue-quality workflow rejects workflow_dispatch pull request numbers before mutation", async () => {
+    const workflow = await readText(".github/workflows/enforce-issue-quality.yml");
+
+    // Manual dispatch is supported, but only with a positive issue number.
+    expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).toContain("issue_number:");
+    expect(workflow).toContain("Number.isSafeInteger(parsedIssueNumber)");
+    expect(workflow).toContain("parsedIssueNumber <= 0");
+
+    // Job-scoped permissions only (no top-level issues:write).
+    expect(workflow).toMatch(
+      /jobs:\s*\n\s*validate:[\s\S]*?permissions:\s*\n\s*contents: read\s*\n\s*#.*\n\s*issues: write/,
+    );
+    const beforeJobs = workflow.split(/jobs:\s*\n/)[0]!;
+    expect(beforeJobs).not.toMatch(/^\s*permissions:/m);
+
+    // Trusted scripts always come from the repository default branch.
+    const checkoutStep = workflow
+      .split("- name: Checkout trusted workflow code")[1]!
+      .split(/\n {6}- name:/)[0]!;
+    expect(checkoutStep).toContain("ref: ${{ github.event.repository.default_branch }}");
+    expect(checkoutStep).toContain("persist-credentials: false");
+    expect(checkoutStep).toContain("sparse-checkout: .github/scripts");
+
+    const script = workflow
+      .split("script: |")[1]!
+      .split(/\n {6}- name:/)[0]!;
+
+    // Invalid issue numbers fail before any issues API call.
+    const invalidNumberIdx = script.indexOf("Invalid workflow_dispatch issue_number:");
+    const firstIssuesGetIdx = script.indexOf("github.rest.issues.get({");
+    expect(invalidNumberIdx).toBeGreaterThan(-1);
+    expect(firstIssuesGetIdx).toBeGreaterThan(-1);
+    expect(invalidNumberIdx).toBeLessThan(firstIssuesGetIdx);
+
+    // Non-default-branch dispatches fail before any issues API mutation.
+    const branchGuardIdx = script.indexOf("const nonDefaultBranchFailure = rejectsWorkflowDispatchNonDefaultBranch(");
+    const firstMutationIdx = script.indexOf("github.rest.issues.update({");
+    expect(branchGuardIdx).toBeGreaterThan(-1);
+    expect(firstMutationIdx).toBeGreaterThan(-1);
+    expect(branchGuardIdx).toBeLessThan(firstMutationIdx);
+    expect(branchGuardIdx).toBeLessThan(firstIssuesGetIdx);
+
+    // Pull-request numbers are rejected after issues.get and before mutations.
+    const prGuardIdx = script.indexOf("const pullRequestFailure = rejectsWorkflowDispatchPullRequest(");
+    const listCommentsIdx = script.indexOf("github.rest.issues.listComments");
+    const addLabelsIdx = script.indexOf("github.rest.issues.addLabels");
+    expect(prGuardIdx).toBeGreaterThan(-1);
+    expect(prGuardIdx).toBeGreaterThan(firstIssuesGetIdx);
+    expect(prGuardIdx).toBeLessThan(listCommentsIdx);
+    expect(prGuardIdx).toBeLessThan(addLabelsIdx);
+    expect(prGuardIdx).toBeLessThan(firstMutationIdx);
+    expect(script).toContain("if (pullRequestFailure) {");
+    expect(script).toContain("core.setFailed(pullRequestFailure);");
+  });
+
   test("React Doctor workflow is SHA-pinned, engine-pinned, advisory, and read-only", async () => {
     const workflow = await readText(".github/workflows/react-doctor.yml");
 


### PR DESCRIPTION
## Why

Issue #401 stayed open because enforce-issue-quality.yml was working, but the validator treated that report as valid.

## What changed
- Treat NA / not applicable as placeholder example text
- Reject placeholder examples on the feature form before empty-section logic
- Reject overly vague feature sections that lack concrete workflow detail
- Add regression tests for issue #401-style reports
- Add workflow_dispatch with issue_number so maintainers can backfill already-open issues like #401 after merge

## Test plan
- node --test .github/scripts/issue-quality.test.cjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Issue quality checks now treat a wider range of placeholder-like values (including common “not applicable” variants and fenced blocks with only placeholders) as empty, and more precisely differentiate placeholder content from missing required example text.
  * Feature reports with overly vague or terse goals/examples are rejected with more implementation-oriented guidance.
  * Manual enforcement supports workflow dispatch, requiring a valid numeric issue number and adding early safety checks (including default-branch-only dispatch and rejecting unsupported pull-request dispatch scenarios).
* **Tests**
  * Added coverage for placeholder normalization, vagueness/too-tere detection, and workflow-dispatch input validation plus guard/operation ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->