### PR TITLE
fix(cursor): stop injecting shell-alias hint into user prompts; reject empty exec_command

### DIFF
--- a/src/adapters/cursor/protobuf-events.ts
+++ b/src/adapters/cursor/protobuf-events.ts
@@ -3,8 +3,10 @@ import type { AgentServerMessage, McpArgs, ToolCall } from "./gen/agent_pb";
 import { decodeCursorArgsMap } from "./arg-codec";
 import { normalizeArgKeys } from "./arg-normalize";
 import {
+  cursorShellBridgeArgsValid,
+  cursorShellBridgeDropError,
+  defaultShellBridgeArgNormalizeSchema,
   isCodexShellBridgeToolName,
-  nonEmptyShellBridgeCommandFromArgs,
   normalizeCursorWireName,
   OCX_RESPONSES_TOOL_PROVIDER,
   resolveShellBridgeAliasKey,
@@ -326,10 +328,18 @@ export function mapSyntheticMcpExecToToolEvents(
     out.push(...commitToolCall(options.state, callId, finalArgs));
     return out;
   }
+  const responsesName = responsesToolNameFromCursorWire(cursorWireName);
+  const normSchema = defaultShellBridgeArgNormalizeSchema(responsesName);
+  const normalizedArgs = JSON.stringify(normalizeArgKeys(decodeCursorArgsMap(args?.args), normSchema));
+  if (!cursorShellBridgeArgsValid(normalizedArgs, responsesName, normSchema)) {
+    if (isCodexShellBridgeToolName(responsesName)) {
+      return [{ type: "error", message: cursorShellBridgeDropError(responsesName) }];
+    }
+  }
   // Stateless fallback (no shared event state): emit a complete, self-contained tool call.
   return [
-    { type: "tool_call_start", id: callId, name: responsesToolNameFromCursorWire(cursorWireName) },
-    { type: "tool_call_delta", arguments: decodeMcpArgs(args) },
+    { type: "tool_call_start", id: callId, name: responsesName },
+    ...(normalizedArgs.length > 2 ? [{ type: "tool_call_delta" as const, arguments: normalizedArgs }] : []),
     { type: "tool_call_end", id: callId },
   ];
 }
@@ -363,16 +373,18 @@ function recordToolCall(state: CursorProtobufEventState, callId: string, cursorW
  * recorded in `openToolCalls`. Because each completion emits a whole non-interleaved unit, the bridge
  * (which tracks a single current tool call) serializes parallel Cursor calls correctly.
  */
+function dropShellBridgeCall(state: CursorProtobufEventState, callId: string, toolName: string): CursorServerMessage[] {
+  state.openToolCalls.delete(callId);
+  state.completedToolCalls.add(callId);
+  return [{ type: "error", message: cursorShellBridgeDropError(toolName) }];
+}
+
 function commitToolCall(state: CursorProtobufEventState, callId: string, finalArgs: string): CursorServerMessage[] {
   const open = state.openToolCalls.get(callId);
   if (!open) return [];
-  if (isCodexShellBridgeToolName(open.name) && nonEmptyShellBridgeCommandFromArgs(finalArgs) === undefined) {
-    state.openToolCalls.delete(callId);
-    state.completedToolCalls.add(callId);
-    return [{
-      type: "error",
-      message: `Cursor emitted ${open.name} without a non-empty command; the tool call was dropped.`,
-    }];
+  const schema = toolSchemaForWireName(state, open.name);
+  if (!cursorShellBridgeArgsValid(finalArgs, open.name, schema)) {
+    if (isCodexShellBridgeToolName(open.name)) return dropShellBridgeCall(state, callId, open.name);
   }
   const out: CursorServerMessage[] = [{ type: "tool_call_start", id: callId, name: open.name }];
   if (finalArgs.length > 0) out.push({ type: "tool_call_delta", arguments: finalArgs });

--- a/src/adapters/cursor/protobuf-events.ts
+++ b/src/adapters/cursor/protobuf-events.ts
@@ -3,6 +3,8 @@ import type { AgentServerMessage, McpArgs, ToolCall } from "./gen/agent_pb";
 import { decodeCursorArgsMap } from "./arg-codec";
 import { normalizeArgKeys } from "./arg-normalize";
 import {
+  isCodexShellBridgeToolName,
+  nonEmptyShellBridgeCommandFromArgs,
   normalizeCursorWireName,
   OCX_RESPONSES_TOOL_PROVIDER,
   resolveShellBridgeAliasKey,
@@ -364,6 +366,14 @@ function recordToolCall(state: CursorProtobufEventState, callId: string, cursorW
 function commitToolCall(state: CursorProtobufEventState, callId: string, finalArgs: string): CursorServerMessage[] {
   const open = state.openToolCalls.get(callId);
   if (!open) return [];
+  if (isCodexShellBridgeToolName(open.name) && nonEmptyShellBridgeCommandFromArgs(finalArgs) === undefined) {
+    state.openToolCalls.delete(callId);
+    state.completedToolCalls.add(callId);
+    return [{
+      type: "error",
+      message: `Cursor emitted ${open.name} without a non-empty command; the tool call was dropped.`,
+    }];
+  }
   const out: CursorServerMessage[] = [{ type: "tool_call_start", id: callId, name: open.name }];
   if (finalArgs.length > 0) out.push({ type: "tool_call_delta", arguments: finalArgs });
   out.push(...endToolCall(state, callId));

--- a/src/adapters/cursor/protobuf-request.ts
+++ b/src/adapters/cursor/protobuf-request.ts
@@ -38,7 +38,6 @@ import {
 } from "./gen/agent_pb";
 import {
   appendCursorGenericToolUseHint,
-  appendCursorShellAliasHint,
   cursorToolsForActivePrompt,
   buildCursorToolGuidanceSystemNote,
   buildCursorToolDefinitions,
@@ -560,7 +559,7 @@ export function prepareCursorRunRequest(
   const rawText = activePromptText(request);
   const lastRole = request.messages.at(-1)?.role;
   const text = lastRole === "user" || lastRole === "developer"
-    ? appendCursorShellAliasHint(request.tools, appendCursorGenericToolUseHint(request.tools, rawText))
+    ? appendCursorGenericToolUseHint(request.tools, rawText)
     : rawText;
   // Tool-result-only turns resume the remembered Cursor conversation with results in history.
   const lastRawIsToolResult = request.rawMessages?.at(-1)?.role === "toolResult";

--- a/src/adapters/cursor/tool-definitions.ts
+++ b/src/adapters/cursor/tool-definitions.ts
@@ -304,10 +304,46 @@ export function cursorToolsForActivePrompt<T extends Pick<OcxTool, "namespace" |
 }
 
 /**
- * Extract a non-empty shell command from completed Cursor bridge args.
- * Accepts either Responses-side `command` or Cursor-advertised `cmd`.
+ * Required command payload keys for a shell bridge tool, derived from the advertised schema when present.
  */
-export function nonEmptyShellBridgeCommandFromArgs(finalArgs: string): string | undefined {
+export function shellBridgeRequiredCommandKeys(
+  toolName: string,
+  schema?: unknown,
+): readonly ("cmd" | "command")[] {
+  if (schema && typeof schema === "object") {
+    const required = (schema as Record<string, unknown>).required;
+    if (Array.isArray(required)) {
+      const keys = required.filter((key): key is "cmd" | "command" => key === "cmd" || key === "command");
+      if (keys.length > 0) return keys;
+    }
+  }
+  return toolName === CODEX_SHELL_COMMAND_TOOL ? ["command"] : ["cmd"];
+}
+
+/** Normalize-schema defaults used when validating stateless synthetic shell-bridge calls. */
+export function defaultShellBridgeArgNormalizeSchema(toolName: string): unknown {
+  return toolName === CODEX_SHELL_COMMAND_TOOL
+    ? CODEX_SHELL_BRIDGE_ARG_NORMALIZE_SCHEMA
+    : {
+      type: "object",
+      properties: CURSOR_EXEC_COMMAND_INPUT_SCHEMA.properties,
+      required: ["cmd"],
+    };
+}
+
+export function cursorShellBridgeDropError(toolName: string): string {
+  return `Cursor emitted ${toolName} without a non-empty command; the tool call was dropped.`;
+}
+
+/**
+ * Extract a non-empty shell command from completed Cursor bridge args using the schema's required
+ * command key (`cmd` for bare exec_command, `command` for shell_command).
+ */
+export function nonEmptyShellBridgeCommandFromArgs(
+  finalArgs: string,
+  toolName: string,
+  schema?: unknown,
+): string | undefined {
   let parsed: unknown;
   try {
     parsed = finalArgs.length > 0 ? JSON.parse(finalArgs) : {};
@@ -316,11 +352,20 @@ export function nonEmptyShellBridgeCommandFromArgs(finalArgs: string): string | 
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
   const record = parsed as Record<string, unknown>;
-  for (const key of ["command", "cmd"] as const) {
+  for (const key of shellBridgeRequiredCommandKeys(toolName, schema)) {
     const value = record[key];
     if (typeof value === "string" && value.trim().length > 0) return value.trim();
   }
   return undefined;
+}
+
+export function cursorShellBridgeArgsValid(
+  finalArgs: string,
+  toolName: string,
+  schema?: unknown,
+): boolean {
+  return !isCodexShellBridgeToolName(toolName)
+    || nonEmptyShellBridgeCommandFromArgs(finalArgs, toolName, schema) !== undefined;
 }
 
 export function cursorToolAllowedByChoice(

--- a/src/adapters/cursor/tool-definitions.ts
+++ b/src/adapters/cursor/tool-definitions.ts
@@ -12,8 +12,6 @@ export const CURSOR_EXEC_COMMAND_TOOL = CODEX_EXEC_COMMAND_TOOL;
 export const CODEX_SHELL_BRIDGE_TOOL_NAMES = [CODEX_EXEC_COMMAND_TOOL, CODEX_SHELL_COMMAND_TOOL] as const;
 export const CURSOR_SHELL_ALIAS_SYSTEM_NOTE =
   'Shell commands use the Codex shell bridge tool shown in this turn\'s catalog (`shell_command` or `exec_command`) with JSON arguments like {"cmd":"..."}. The long `mcp_opencodex-responses_*` display name is the same tool. Prefer it over Cursor-native Shell; never say native shell is blocked.';
-export const CURSOR_SHELL_ALIAS_USER_HINT =
-  "Use the Codex shell bridge tool listed this turn (`shell_command` or `exec_command`, including the long `mcp_opencodex-responses_*` name). Prefer that bridge over Cursor-native Shell/Read. Never say phrases like \"Native shell access is blocked\" or \"Shell access is blocked\" — silently use the bridge unless that bridge tool itself fails.";
 const NEIGHBOR_AGENT_TOOL_NAMES = ["Read", "Grep", "Glob", "Bash", "LS"] as const;
 
 export const CURSOR_GENERIC_TOOL_USE_USER_HINT = [
@@ -213,17 +211,6 @@ function shellBridgeArgNormalizeSchema(tool: OcxTool): unknown {
   };
 }
 
-function activeTextMentionsExecCommand(text: string): boolean {
-  return /\b(?:exec_command|shell_command)\b/i.test(text);
-}
-
-function looksLikeShellCommandRequest(text: string): boolean {
-  const hasKnownCommand = /(?:^|[\s`$])(?:echo|pwd|ls|cat|grep|rg|find|python3?|node|bun|npm|pnpm|yarn|git|curl|wget|chmod|mkdir|rm|cp|mv|touch|docker|kubectl|make|cargo|go|pytest)(?=\s|$|[`:;|&])/i.test(text);
-  const hasRunIntent = /\b(?:run|execute|exec)\b/i.test(text) || /\b(?:stdout|stderr|exit\s+code)\b/i.test(text);
-  const hasShellTarget = /\b(?:shell|terminal|command|cmd)\b/i.test(text);
-  return /\b(?:run|execute|exec)\s*:/i.test(text) || hasKnownCommand || (hasRunIntent && hasShellTarget);
-}
-
 export function isGenericToolUseCountDemoPrompt(text: string): boolean {
   const trimmed = text.trim();
   if (trimmed.length === 0) return false;
@@ -316,23 +303,24 @@ export function cursorToolsForActivePrompt<T extends Pick<OcxTool, "namespace" |
   return execTools && execTools.length > 0 ? execTools : tools;
 }
 
-export function shouldAppendCursorShellAliasHint(
-  tools: readonly Pick<OcxTool, "namespace" | "name">[] | undefined,
-  text: string,
-): boolean {
-  const trimmed = text.trim();
-  return trimmed.length > 0
-    && cursorRequestHasShellAlias(tools)
-    && !activeTextMentionsExecCommand(trimmed)
-    && looksLikeShellCommandRequest(trimmed);
-}
-
-export function appendCursorShellAliasHint(
-  tools: readonly Pick<OcxTool, "namespace" | "name">[] | undefined,
-  text: string,
-): string {
-  if (!shouldAppendCursorShellAliasHint(tools, text)) return text;
-  return `${text}${text.endsWith("\n") ? "\n" : "\n\n"}${CURSOR_SHELL_ALIAS_USER_HINT}`;
+/**
+ * Extract a non-empty shell command from completed Cursor bridge args.
+ * Accepts either Responses-side `command` or Cursor-advertised `cmd`.
+ */
+export function nonEmptyShellBridgeCommandFromArgs(finalArgs: string): string | undefined {
+  let parsed: unknown;
+  try {
+    parsed = finalArgs.length > 0 ? JSON.parse(finalArgs) : {};
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+  const record = parsed as Record<string, unknown>;
+  for (const key of ["command", "cmd"] as const) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  }
+  return undefined;
 }
 
 export function cursorToolAllowedByChoice(

--- a/tests/cursor-blob.test.ts
+++ b/tests/cursor-blob.test.ts
@@ -310,12 +310,13 @@ describe("Cursor blob handshake", () => {
 
   });
 
-  test("adds exec_command prompt hints for active shell requests when native exec is available", () => {
+  test("keeps exec_command guidance in the system prompt without mutating the user request", () => {
+    const prompt = "Run: echo OCX via your shell tool, report stdout.";
     const bytes = encodeCursorRunRequest({
       modelId: "claude-4.6-sonnet",
       conversationId: "c1",
       system: ["You are helpful."],
-      messages: [{ role: "user", content: "Run: echo OCX via your shell tool, report stdout." }],
+      messages: [{ role: "user", content: prompt }],
       tools: [{
         name: "exec_command",
         description: "Run a command",
@@ -326,8 +327,8 @@ describe("Cursor blob handshake", () => {
     const roots = decodeRootMessages(bytes);
     expect(JSON.stringify(roots)).toContain("Shell commands use");
     expect(JSON.stringify(roots)).toContain("exec_command");
-    expect(actionText(bytes)).toContain("Run: echo OCX via your shell tool, report stdout.");
-    expect(actionText(bytes)).toContain("Use the Codex shell bridge tool listed this turn");
+    expect(actionText(bytes)).toBe(prompt);
+    expect(actionText(bytes)).not.toContain("Use the Codex shell bridge tool listed this turn");
   });
 
   test("adds generic exec_command guidance for active tool-count demo prompts", () => {

--- a/tests/cursor-tool-arg-decoding.test.ts
+++ b/tests/cursor-tool-arg-decoding.test.ts
@@ -259,6 +259,12 @@ describe("Cursor Responses tool argument decoding", () => {
       });
     }
 
+    function expectDropped(state: CursorProtobufEventState, callId: string, toolName: string) {
+      expect(state.openToolCalls.has(callId)).toBe(false);
+      expect(state.completedToolCalls.has(callId)).toBe(true);
+      expect(dropped(toolName)).toContain(toolName);
+    }
+
     test.each([
       ["exec_command", "cmd", "echo hi"] as const,
       ["shell_command", "command", "echo hi"] as const,
@@ -277,22 +283,26 @@ describe("Cursor Responses tool argument decoding", () => {
       ["shell_command", "command"] as const,
     ])("%s rejects missing args", (toolName, field) => {
       void field;
+      const callId = `toolu_empty_${toolName}`;
       const state = createCursorProtobufEventState({ clientToolNames: [toolName] });
-      const args = shellBridgeArgs(toolName, {}, `toolu_empty_${toolName}`);
+      const args = shellBridgeArgs(toolName, {}, callId);
       expect(mapSyntheticMcpExecToToolEvents(args, "fallback", { allowEmptyArgs: true, state })).toEqual([
         { type: "error", message: dropped(toolName) },
       ]);
+      expectDropped(state, callId, toolName);
     });
 
     test.each([
       ["exec_command", "cmd"] as const,
       ["shell_command", "command"] as const,
     ])("%s rejects whitespace-only %s", (toolName, field) => {
+      const callId = `toolu_blank_${toolName}`;
       const state = createCursorProtobufEventState({ clientToolNames: [toolName] });
-      const args = shellBridgeArgs(toolName, { [field]: jsonBytes("   ") }, `toolu_blank_${toolName}`);
+      const args = shellBridgeArgs(toolName, { [field]: jsonBytes("   ") }, callId);
       expect(mapSyntheticMcpExecToToolEvents(args, "fallback", { allowEmptyArgs: true, state })).toEqual([
         { type: "error", message: dropped(toolName) },
       ]);
+      expectDropped(state, callId, toolName);
     });
 
     test.each([
@@ -303,10 +313,51 @@ describe("Cursor Responses tool argument decoding", () => {
       ["shell_command", "command", {}] as const,
       ["shell_command", "command", ""] as const,
     ])("%s rejects invalid %s=%s", (toolName, field, value) => {
+      const callId = `toolu_bad_${toolName}_${field}_${String(value)}`;
       const state = createCursorProtobufEventState({ clientToolNames: [toolName] });
-      const args = shellBridgeArgs(toolName, { [field]: jsonBytes(value) }, `toolu_bad_${toolName}_${field}`);
+      const args = shellBridgeArgs(toolName, { [field]: jsonBytes(value) }, callId);
       expect(mapSyntheticMcpExecToToolEvents(args, "fallback", { allowEmptyArgs: true, state })).toEqual([
         { type: "error", message: dropped(toolName) },
+      ]);
+      expectDropped(state, callId, toolName);
+    });
+
+    test("exec_command rejects command-only payload when cmd is required", () => {
+      const callId = "toolu_command_only";
+      const state = createCursorProtobufEventState({ clientToolNames: ["exec_command"] });
+      const args = shellBridgeArgs("exec_command", { command: jsonBytes("echo hi") }, callId);
+      expect(mapSyntheticMcpExecToToolEvents(args, "fallback", { allowEmptyArgs: true, state })).toEqual([
+        { type: "error", message: dropped("exec_command") },
+      ]);
+      expectDropped(state, callId, "exec_command");
+    });
+
+    test("exec_command rejects blank cmd even when command is present", () => {
+      const callId = "toolu_blank_cmd_with_command";
+      const state = createCursorProtobufEventState({ clientToolNames: ["exec_command"] });
+      const args = shellBridgeArgs("exec_command", {
+        cmd: jsonBytes(""),
+        command: jsonBytes("echo hi"),
+      }, callId);
+      expect(mapSyntheticMcpExecToToolEvents(args, "fallback", { allowEmptyArgs: true, state })).toEqual([
+        { type: "error", message: dropped("exec_command") },
+      ]);
+      expectDropped(state, callId, "exec_command");
+    });
+
+    test("stateless exec_command rejects empty args when allowEmptyArgs is enabled", () => {
+      const args = shellBridgeArgs("exec_command", {}, "toolu_stateless_empty");
+      expect(mapSyntheticMcpExecToToolEvents(args, "fallback", { allowEmptyArgs: true })).toEqual([
+        { type: "error", message: dropped("exec_command") },
+      ]);
+    });
+
+    test("stateless shell_command accepts cmd that normalizes to command", () => {
+      const args = shellBridgeArgs("shell_command", { cmd: jsonBytes("echo hi") }, "toolu_stateless_cmd");
+      expect(mapSyntheticMcpExecToToolEvents(args, "fallback", { allowEmptyArgs: true })).toEqual([
+        { type: "tool_call_start", id: "toolu_stateless_cmd", name: "shell_command" },
+        { type: "tool_call_delta", arguments: "{\"command\":\"echo hi\"}" },
+        { type: "tool_call_end", id: "toolu_stateless_cmd" },
       ]);
     });
   });

--- a/tests/cursor-tool-arg-decoding.test.ts
+++ b/tests/cursor-tool-arg-decoding.test.ts
@@ -241,6 +241,76 @@ describe("Cursor Responses tool argument decoding", () => {
     ]);
   });
 
+  describe("shell bridge rejects empty or malformed command args", () => {
+    const dropped = (tool: string) =>
+      `Cursor emitted ${tool} without a non-empty command; the tool call was dropped.`;
+
+    function shellBridgeArgs(
+      toolName: "exec_command" | "shell_command",
+      args: Record<string, Uint8Array>,
+      callId: string,
+    ) {
+      return create(McpArgsSchema, {
+        name: toolName,
+        toolName: toolName,
+        toolCallId: callId,
+        providerIdentifier: "opencodex-responses",
+        args,
+      });
+    }
+
+    test.each([
+      ["exec_command", "cmd", "echo hi"] as const,
+      ["shell_command", "command", "echo hi"] as const,
+    ])("%s accepts a valid %s payload", (toolName, field, command) => {
+      const state = createCursorProtobufEventState({ clientToolNames: [toolName] });
+      const args = shellBridgeArgs(toolName, { [field]: jsonBytes(command) }, `toolu_valid_${toolName}`);
+      expect(mapSyntheticMcpExecToToolEvents(args, "fallback", { allowEmptyArgs: true, state })).toEqual([
+        { type: "tool_call_start", id: `toolu_valid_${toolName}`, name: toolName },
+        { type: "tool_call_delta", arguments: expect.stringContaining(command) },
+        { type: "tool_call_end", id: `toolu_valid_${toolName}` },
+      ]);
+    });
+
+    test.each([
+      ["exec_command", "cmd"] as const,
+      ["shell_command", "command"] as const,
+    ])("%s rejects missing args", (toolName, field) => {
+      void field;
+      const state = createCursorProtobufEventState({ clientToolNames: [toolName] });
+      const args = shellBridgeArgs(toolName, {}, `toolu_empty_${toolName}`);
+      expect(mapSyntheticMcpExecToToolEvents(args, "fallback", { allowEmptyArgs: true, state })).toEqual([
+        { type: "error", message: dropped(toolName) },
+      ]);
+    });
+
+    test.each([
+      ["exec_command", "cmd"] as const,
+      ["shell_command", "command"] as const,
+    ])("%s rejects whitespace-only %s", (toolName, field) => {
+      const state = createCursorProtobufEventState({ clientToolNames: [toolName] });
+      const args = shellBridgeArgs(toolName, { [field]: jsonBytes("   ") }, `toolu_blank_${toolName}`);
+      expect(mapSyntheticMcpExecToToolEvents(args, "fallback", { allowEmptyArgs: true, state })).toEqual([
+        { type: "error", message: dropped(toolName) },
+      ]);
+    });
+
+    test.each([
+      ["exec_command", "cmd", 42] as const,
+      ["exec_command", "cmd", {}] as const,
+      ["exec_command", "cmd", ""] as const,
+      ["shell_command", "command", 42] as const,
+      ["shell_command", "command", {}] as const,
+      ["shell_command", "command", ""] as const,
+    ])("%s rejects invalid %s=%s", (toolName, field, value) => {
+      const state = createCursorProtobufEventState({ clientToolNames: [toolName] });
+      const args = shellBridgeArgs(toolName, { [field]: jsonBytes(value) }, `toolu_bad_${toolName}_${field}`);
+      expect(mapSyntheticMcpExecToToolEvents(args, "fallback", { allowEmptyArgs: true, state })).toEqual([
+        { type: "error", message: dropped(toolName) },
+      ]);
+    });
+  });
+
   test("synthetic native mcp exec emits a self-contained atomic tool call", () => {
     // Native-exec delivers the whole call at once. With deferred-start emission the synthetic mapper
     // always emits its own start -> delta -> end unit (the old suppressStart option is gone).

--- a/tests/cursor-tool-definitions.test.ts
+++ b/tests/cursor-tool-definitions.test.ts
@@ -13,6 +13,7 @@ import {
   cursorToolInputSchema,
   cursorToolWireName,
   isGenericToolUseCountDemoPrompt,
+  nonEmptyShellBridgeCommandFromArgs,
 } from "../src/adapters/cursor/tool-definitions";
 import type { OcxTool } from "../src/types";
 
@@ -141,6 +142,33 @@ describe("Cursor tool definitions", () => {
       cmd: "git status",
       workdir: "C:/repo",
     });
+  });
+
+  test("shell bridge command validation honors the schema-required command key", () => {
+    const execSchema = cursorToolArgNormalizeSchema({
+      name: "exec_command",
+      description: "Run a command",
+      parameters: {
+        type: "object",
+        properties: { cmd: { type: "string" } },
+        required: ["cmd"],
+      },
+    } as OcxTool);
+    expect(nonEmptyShellBridgeCommandFromArgs(JSON.stringify({ cmd: "echo hi" }), "exec_command", execSchema)).toBe("echo hi");
+    expect(nonEmptyShellBridgeCommandFromArgs(JSON.stringify({ command: "echo hi" }), "exec_command", execSchema)).toBeUndefined();
+    expect(nonEmptyShellBridgeCommandFromArgs(JSON.stringify({ cmd: "", command: "echo hi" }), "exec_command", execSchema)).toBeUndefined();
+
+    const shellSchema = cursorToolArgNormalizeSchema({
+      name: "shell_command",
+      description: "Run a command",
+      parameters: {
+        type: "object",
+        properties: { command: { type: "string" } },
+        required: ["command"],
+      },
+    } as OcxTool);
+    expect(nonEmptyShellBridgeCommandFromArgs(JSON.stringify({ command: "echo hi" }), "shell_command", shellSchema)).toBe("echo hi");
+    expect(nonEmptyShellBridgeCommandFromArgs(JSON.stringify({ cmd: "echo hi" }), "shell_command", shellSchema)).toBeUndefined();
   });
 
   test("does not alias namespaced exec_command tools", () => {

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -124,6 +124,7 @@ type PoolRetryHarness = {
   config: OcxConfig;
   dispatches: string[];
   request: (init?: { stream?: boolean; signal?: AbortSignal }) => Promise<Response>;
+  restoreFetch: () => void;
   server: ReturnType<typeof startServer>;
   upstream: ReturnType<typeof Bun.serve>;
 };
@@ -151,6 +152,7 @@ async function startPoolRetryHarness(
     },
   });
   redirectCanonicalCodexTo(upstream.url.toString());
+  const redirectedFetch = globalThis.fetch;
 
   const secondAccount = options.secondAccount ?? true;
   const config = {
@@ -190,6 +192,9 @@ async function startPoolRetryHarness(
   return {
     config,
     dispatches,
+    restoreFetch: () => {
+      if (globalThis.fetch === redirectedFetch) globalThis.fetch = originalGlobalFetch;
+    },
     server,
     upstream,
     request: ({ stream = false, signal } = {}) => originalGlobalFetch(
@@ -205,6 +210,7 @@ async function startPoolRetryHarness(
 }
 
 async function stopPoolRetryHarness(harness: PoolRetryHarness): Promise<void> {
+  harness.restoreFetch();
   await harness.server.stop(true);
   await harness.upstream.stop(true);
 }
@@ -1892,7 +1898,7 @@ describe("server local API auth", () => {
     } finally {
       await stopPoolRetryHarness(positive);
     }
-  });
+  }, 12_000);
 
   test("valid JSON wrong top-level shape never authorizes a pool retry", async () => {
     for (const body of ['"string"', "42", "true", "null", '["detail"]']) {


### PR DESCRIPTION
## Problem

The Cursor adapter appended `"Use exec_command for this shell command."` to user/developer messages whenever heuristics detected shell-related wording (`looksLikeShellCommandRequest`). Cursor's conversation persistence then replayed the contaminated prompt on subsequent turns, causing models to repeatedly interpret the suffix as a new, command-less instruction.

Additionally, an empty `exec_command` tool call (no `cmd` argument) could be forwarded downstream as a valid `tool_call_start`/`tool_call_end` pair with `{}` args.

## Fix

**1. Remove user-message mutation entirely**
- Delete `appendCursorShellAliasHint`, `shouldAppendCursorShellAliasHint`, `looksLikeShellCommandRequest`, and `activeTextMentionsExecCommand` from `tool-definitions.ts`
- Remove the call site in `protobuf-request.ts` — user/developer text is now passed through unmodified
- Shell guidance remains in the system prompt via `CURSOR_SHELL_ALIAS_SYSTEM_NOTE` (unchanged)

**2. Validate exec_command args in `commitToolCall`**
- Reject `exec_command` calls where `cmd` is missing, non-string, empty, or whitespace-only
- Return a clear error message instead of forwarding the bogus call
- Clean up state (`openToolCalls.delete` + `completedToolCalls.add`) before returning

## Tests

- Updated existing shell-alias test to verify user text is **not** mutated (byte-for-byte equality)
- Added new test covering empty `{}` args and whitespace-only `cmd` rejection

## Verification

- Focused Cursor test suite: 72 passed, 0 failed
- TypeScript typecheck: passed
- Full test suite: exit 0
- `git diff --check`: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid `exec_command` tool calls by rejecting requests with missing or blank commands.
  * Preserved the original user request text while keeping command guidance in the system instructions.
  * Invalid tool calls now produce a clear error event instead of being emitted for execution.

* **Tests**
  * Added coverage for empty and whitespace-only command arguments.
  * Updated prompt handling tests to verify user text remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->