### PR TITLE
fix(google): never emit empty or malformed content parts (#420)

### DIFF
--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -87,6 +87,23 @@ function toolResultImageParts(content: string | OcxContentPart[]): unknown[] {
   return parts;
 }
 
+/**
+ * Antigravity translates these Gemini `contents` into Anthropic `messages` for Claude models, and
+ * Anthropic rejects a text block whose `text` is empty or absent. An empty Gemini text part reaches
+ * that upstream as `{"type":"text"}` — a proto3 empty string is omitted from the translated JSON —
+ * and 400s with `messages.N.content.M.text.text: Field required` (issue #420). An empty `parts: []`
+ * model turn fails the same way. Gemini itself accepts both shapes, which is why this only ever
+ * surfaced on Claude-on-Antigravity; the guard lives here because this is where the parts are
+ * built. Mirrors the Anthropic adapter's own empty-block guard (src/adapters/anthropic.ts).
+ */
+const GEMINI_EMPTY_PLACEHOLDER = "(empty)";
+const GEMINI_EMPTY_TOOL_OUTPUT_PLACEHOLDER = "(empty tool output)";
+
+/** A Gemini text part, or undefined when the value cannot form a valid non-empty text block. */
+function geminiTextPart(text: unknown): { text: string } | undefined {
+  return typeof text === "string" && text.length > 0 ? { text } : undefined;
+}
+
 function messagesToGeminiFormat(parsed: OcxParsedRequest): { systemInstruction?: unknown; contents: unknown[] } {
   // Neutralize Codex's GPT-5 identity line (Gemini/Antigravity share this path) so a routed model
   // never misreports as GPT-5/OpenAI, and never leaks the proxy identity upstream.
@@ -105,18 +122,22 @@ function messagesToGeminiFormat(parsed: OcxParsedRequest): { systemInstruction?:
       case "user":
       case "developer": {
         if (typeof msg.content === "string") {
-          contents.push({ role: "user", parts: [{ text: msg.content }] });
+          contents.push({ role: "user", parts: [{ text: msg.content || GEMINI_EMPTY_PLACEHOLDER }] });
         } else {
-          const parts = (msg.content as OcxContentPart[]).map(p => {
+          const parts: unknown[] = [];
+          for (const p of msg.content as OcxContentPart[]) {
             if (p.type === "image") {
               const data = parseDataUrl(p.imageUrl);
               // Gemini takes base64 via inline_data; a remote URL needs a mime type we don't have, so
               // fall back to a short marker rather than inlining the URL as a huge text blob.
-              return data ? { inline_data: { mime_type: data.mediaType, data: data.base64 } } : { text: `[image: ${p.imageUrl}]` };
+              parts.push(data ? { inline_data: { mime_type: data.mediaType, data: data.base64 } } : { text: `[image: ${p.imageUrl}]` });
+              continue;
             }
-            return { text: p.text };
-          });
-          contents.push({ role: "user", parts });
+            // Drop empty/malformed text instead of emitting `{ text: "" }` or a bare `{}` part.
+            const textPart = geminiTextPart(p.text);
+            if (textPart) parts.push(textPart);
+          }
+          contents.push({ role: "user", parts: parts.length > 0 ? parts : [{ text: GEMINI_EMPTY_PLACEHOLDER }] });
         }
         break;
       }
@@ -124,8 +145,10 @@ function messagesToGeminiFormat(parsed: OcxParsedRequest): { systemInstruction?:
         const aMsg = msg as OcxAssistantMessage;
         const parts: unknown[] = [];
         for (const p of aMsg.content) {
-          if (p.type === "text") parts.push({ text: (p as OcxTextContent).text });
-          else if (p.type === "toolCall") {
+          if (p.type === "text") {
+            const textPart = geminiTextPart((p as OcxTextContent).text);
+            if (textPart) parts.push(textPart);
+          } else if (p.type === "toolCall") {
             const tc = p as OcxToolCall;
             // Preserve the thought signature on the function-call part so Antigravity/Gemini-3
             // reasoning continuity survives history-driven (stateless) turns, not just same-process
@@ -142,6 +165,10 @@ function messagesToGeminiFormat(parsed: OcxParsedRequest): { systemInstruction?:
             parts.push(part);
           }
         }
+        // A turn with nothing Gemini can represent (e.g. thinking-only) would serialize as
+        // `parts: []`, which the Anthropic translation rejects. Skip it, as the Anthropic
+        // adapter does for its own empty assistant content.
+        if (parts.length === 0) break;
         contents.push({ role: "model", parts });
         break;
       }
@@ -151,7 +178,7 @@ function messagesToGeminiFormat(parsed: OcxParsedRequest): { systemInstruction?:
         // tool-result screenshots (e.g. Computer Use) ride along as inline_data instead of being
         // flattened to a "[image]" marker the model can't actually see.
         const responseId = geminiToolCallId(msg.toolCallId);
-        const functionResponse: Record<string, unknown> = { name: namespacedToolName(msg.toolNamespace, msg.toolName), response: { result: contentPartsToText(msg.content) } };
+        const functionResponse: Record<string, unknown> = { name: namespacedToolName(msg.toolNamespace, msg.toolName), response: { result: contentPartsToText(msg.content) || GEMINI_EMPTY_TOOL_OUTPUT_PLACEHOLDER } };
         // Mirror the matching functionCall id so Claude-on-Antigravity can pair this result with its
         // `tool_use` block (-> Anthropic `tool_result.tool_use_id`).
         if (responseId !== undefined) functionResponse.id = responseId;

--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -104,6 +104,18 @@ function geminiTextPart(text: unknown): { text: string } | undefined {
   return typeof text === "string" && text.length > 0 ? { text } : undefined;
 }
 
+/**
+ * Text for `functionResponse.response.result`. `contentPartsToText` collapses an empty array — or one
+ * holding only empty text — to its "[image]" marker, which would claim an image the turn does not
+ * actually carry (`toolResultImageParts` adds none). Fall back to the placeholder unless the content
+ * has something representable.
+ */
+function geminiToolResultText(content: string | OcxContentPart[]): string {
+  if (typeof content === "string") return content || GEMINI_EMPTY_TOOL_OUTPUT_PLACEHOLDER;
+  const hasContent = content.some(p => p.type === "image" || (typeof p.text === "string" && p.text.length > 0));
+  return hasContent ? contentPartsToText(content) : GEMINI_EMPTY_TOOL_OUTPUT_PLACEHOLDER;
+}
+
 function messagesToGeminiFormat(parsed: OcxParsedRequest): { systemInstruction?: unknown; contents: unknown[] } {
   // Neutralize Codex's GPT-5 identity line (Gemini/Antigravity share this path) so a routed model
   // never misreports as GPT-5/OpenAI, and never leaks the proxy identity upstream.
@@ -178,7 +190,7 @@ function messagesToGeminiFormat(parsed: OcxParsedRequest): { systemInstruction?:
         // tool-result screenshots (e.g. Computer Use) ride along as inline_data instead of being
         // flattened to a "[image]" marker the model can't actually see.
         const responseId = geminiToolCallId(msg.toolCallId);
-        const functionResponse: Record<string, unknown> = { name: namespacedToolName(msg.toolNamespace, msg.toolName), response: { result: contentPartsToText(msg.content) || GEMINI_EMPTY_TOOL_OUTPUT_PLACEHOLDER } };
+        const functionResponse: Record<string, unknown> = { name: namespacedToolName(msg.toolNamespace, msg.toolName), response: { result: geminiToolResultText(msg.content) } };
         // Mirror the matching functionCall id so Claude-on-Antigravity can pair this result with its
         // `tool_use` block (-> Anthropic `tool_result.tool_use_id`).
         if (responseId !== undefined) functionResponse.id = responseId;

--- a/tests/google-empty-content.test.ts
+++ b/tests/google-empty-content.test.ts
@@ -116,6 +116,57 @@ describe("google adapter — empty content part guard (#420)", () => {
     });
   });
 
+  test("a tool result with an empty parts array does not claim a phantom image", async () => {
+    // contentPartsToText([]) collapses to its "[image]" marker, but toolResultImageParts()
+    // contributes no image part — the result would assert an image the turn does not carry.
+    const contents = await geminiContents(parsedWith([
+      { role: "assistant", content: [{ type: "toolCall", id: "call_1", name: "bash", arguments: {} }], timestamp: 0 },
+      { role: "toolResult", toolCallId: "call_1", toolName: "bash", content: [], isError: false, timestamp: 0 },
+    ]));
+
+    const toolTurn = contents.find(c => c.parts.some(p => "functionResponse" in p));
+    expect(toolTurn!.parts).toEqual([
+      { functionResponse: { name: "bash", response: { result: "(empty tool output)" }, id: "call_1" } },
+    ]);
+  });
+
+  test("a tool result holding only empty text parts uses the placeholder", async () => {
+    const contents = await geminiContents(parsedWith([
+      { role: "assistant", content: [{ type: "toolCall", id: "call_1", name: "bash", arguments: {} }], timestamp: 0 },
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "bash",
+        content: [{ type: "text", text: "" }, { type: "text", text: "" }],
+        isError: false,
+        timestamp: 0,
+      },
+    ]));
+
+    const toolTurn = contents.find(c => c.parts.some(p => "functionResponse" in p));
+    const fr = toolTurn!.parts[0] as { functionResponse: { response: { result: string } } };
+    expect(fr.functionResponse.response.result).toBe("(empty tool output)");
+  });
+
+  test("a genuine image-only tool result still reports [image]", async () => {
+    const contents = await geminiContents(parsedWith([
+      { role: "assistant", content: [{ type: "toolCall", id: "call_1", name: "snap", arguments: {} }], timestamp: 0 },
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "snap",
+        content: [{ type: "image", imageUrl: "data:image/png;base64,aGVsbG8=" }],
+        isError: false,
+        timestamp: 0,
+      },
+    ]));
+
+    const toolTurn = contents.find(c => c.parts.some(p => "functionResponse" in p));
+    const fr = toolTurn!.parts[0] as { functionResponse: { response: { result: string } } };
+    expect(fr.functionResponse.response.result).toBe("[image]");
+    expect(toolTurn!.parts[1]).toEqual({ inline_data: { mime_type: "image/png", data: "aGVsbG8=" } });
+  });
+
   test("non-empty content is unchanged", async () => {
     const contents = await geminiContents(parsedWith([
       { role: "user", content: "hello", timestamp: 0 },

--- a/tests/google-empty-content.test.ts
+++ b/tests/google-empty-content.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import { createGoogleAdapter } from "../src/adapters/google";
+import type { OcxParsedRequest } from "../src/types";
+
+// Antigravity translates these Gemini `contents` into Anthropic `messages` for Claude models, and
+// Anthropic rejects empty/absent text and empty content arrays. An empty Gemini text part reaches
+// that upstream as `{"type":"text"}` (a proto3 empty string is omitted from JSON), producing
+// `messages.0.content.N.text.text: Field required` (issue #420). Gemini itself tolerates the same
+// parts, which is why this only ever surfaced on Claude-on-Antigravity.
+
+const provider = { adapter: "google", baseUrl: "https://generativelanguage.googleapis.com", apiKey: "key" };
+
+function parsedWith(messages: unknown[]): OcxParsedRequest {
+  return { modelId: "gemini-3-pro", stream: false, options: {}, context: { messages } } as unknown as OcxParsedRequest;
+}
+
+async function geminiContents(parsed: OcxParsedRequest): Promise<{ role: string; parts: Record<string, unknown>[] }[]> {
+  const { body } = await createGoogleAdapter(provider).buildRequest(parsed);
+  return JSON.parse(body).contents;
+}
+
+/** Every emitted text part must survive a JSON round-trip with a non-empty string `text`. */
+function assertNoEmptyTextParts(contents: { role: string; parts: Record<string, unknown>[] }[]): void {
+  for (const turn of contents) {
+    expect(Array.isArray(turn.parts)).toBe(true);
+    expect(turn.parts.length).toBeGreaterThan(0);
+    for (const part of turn.parts) {
+      if (!("text" in part)) continue;
+      expect(typeof part.text).toBe("string");
+      expect((part.text as string).length).toBeGreaterThan(0);
+    }
+  }
+}
+
+describe("google adapter — empty content part guard (#420)", () => {
+  test("user message with empty string content emits a placeholder, not an empty text part", async () => {
+    const contents = await geminiContents(parsedWith([
+      { role: "user", content: "", timestamp: 0 },
+    ]));
+
+    expect(contents[0].parts).toEqual([{ text: "(empty)" }]);
+    assertNoEmptyTextParts(contents);
+  });
+
+  test("empty text parts are dropped from a user message", async () => {
+    const contents = await geminiContents(parsedWith([
+      { role: "user", content: [{ type: "text", text: "" }, { type: "text", text: "hello" }], timestamp: 0 },
+    ]));
+
+    expect(contents[0].parts).toEqual([{ text: "hello" }]);
+    assertNoEmptyTextParts(contents);
+  });
+
+  test("a user message whose parts are all empty falls back to a placeholder", async () => {
+    const contents = await geminiContents(parsedWith([
+      { role: "user", content: [{ type: "text", text: "" }], timestamp: 0 },
+    ]));
+
+    expect(contents[0].parts).toEqual([{ text: "(empty)" }]);
+    assertNoEmptyTextParts(contents);
+  });
+
+  test("a malformed part with a missing text field never becomes a bare {} part", async () => {
+    // A Responses `input_text` block with no `text` key parses into this shape
+    // (src/responses/parser.ts casts without validating), and `{ text: undefined }`
+    // serializes to `{}` — exactly the block Anthropic reports as `Field required`.
+    const contents = await geminiContents(parsedWith([
+      { role: "user", content: [{ type: "text" }, { type: "text", text: "real" }], timestamp: 0 },
+    ]));
+
+    expect(contents[0].parts).toEqual([{ text: "real" }]);
+    assertNoEmptyTextParts(contents);
+  });
+
+  test("a non-string text value is dropped rather than sent as an object", async () => {
+    const contents = await geminiContents(parsedWith([
+      { role: "user", content: [{ type: "text", text: { nested: "object" } }, { type: "text", text: "real" }], timestamp: 0 },
+    ]));
+
+    expect(contents[0].parts).toEqual([{ text: "real" }]);
+    assertNoEmptyTextParts(contents);
+  });
+
+  test("empty assistant text parts are dropped", async () => {
+    const contents = await geminiContents(parsedWith([
+      { role: "user", content: "start", timestamp: 0 },
+      { role: "assistant", content: [{ type: "text", text: "" }, { type: "text", text: "visible" }], timestamp: 0 },
+    ]));
+
+    const model = contents.find(c => c.role === "model");
+    expect(model!.parts).toEqual([{ text: "visible" }]);
+    assertNoEmptyTextParts(contents);
+  });
+
+  test("an assistant turn with no emittable parts is skipped, not sent with parts: []", async () => {
+    // Thinking-only assistant turns carry no Gemini-representable part: the loop handles
+    // text and toolCall only, so the turn would otherwise serialize as `parts: []`.
+    const contents = await geminiContents(parsedWith([
+      { role: "user", content: "start", timestamp: 0 },
+      { role: "assistant", content: [{ type: "thinking", thinking: "internal", signature: "sig" }], timestamp: 0 },
+    ]));
+
+    expect(contents.find(c => c.role === "model")).toBeUndefined();
+    assertNoEmptyTextParts(contents);
+  });
+
+  test("an empty tool result emits a placeholder result string", async () => {
+    const contents = await geminiContents(parsedWith([
+      { role: "assistant", content: [{ type: "toolCall", id: "call_1", name: "bash", arguments: {} }], timestamp: 0 },
+      { role: "toolResult", toolCallId: "call_1", toolName: "bash", content: "", isError: false, timestamp: 0 },
+    ]));
+
+    const toolTurn = contents.find(c => c.parts.some(p => "functionResponse" in p));
+    expect(toolTurn!.parts[0]).toEqual({
+      functionResponse: { name: "bash", response: { result: "(empty tool output)" }, id: "call_1" },
+    });
+  });
+
+  test("non-empty content is unchanged", async () => {
+    const contents = await geminiContents(parsedWith([
+      { role: "user", content: "hello", timestamp: 0 },
+      { role: "assistant", content: [{ type: "text", text: "hi" }], timestamp: 0 },
+      { role: "user", content: [{ type: "text", text: "again" }], timestamp: 0 },
+    ]));
+
+    expect(contents).toEqual([
+      { role: "user", parts: [{ text: "hello" }] },
+      { role: "model", parts: [{ text: "hi" }] },
+      { role: "user", parts: [{ text: "again" }] },
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #420.

## Problem

`google-antigravity` is registered with `adapter: "google"` (`src/providers/registry.ts`), so
opencodex sends **Gemini `contents`** and Antigravity translates them into Anthropic `messages` for
Claude models. The `req_vrtx_...` id in the report is a Vertex Anthropic request, so the 400 is
raised *after* that translation — the issue attributes the block to `messagesToAnthropicFormat`, but
the producer is the Google serializer.

`messagesToGeminiFormat` (`src/adapters/google.ts`) had no empty-content guard, so four shapes could
reach the wire:

| Source | Emitted part | After translation |
|---|---|---|
| `content: ""` | `{ text: "" }` | `{"type":"text"}` → `content.N.text.text: Field required` |
| a part with `text: ""` | `{ text: "" }` | same |
| a part with a missing/non-string `text` | `{}` (bare part) | same |
| a thinking-only assistant turn | `{ role: "model", parts: [] }` | empty `content` array → 400 |

The bare `{}` is reachable from ordinary input: `src/responses/parser.ts` builds
`{ type: "text", text: (block as { text: string }).text }` without validating the cast, so a
Responses `input_text` block with no `text` key becomes `{ text: undefined }`, which
`JSON.stringify` drops entirely.

That Anthropic rejects empty text blocks is already established in this repo by `7ff4c7c`
("guard against empty text content blocks (400 rejection)"). **Gemini accepts all four shapes**,
which is why this only surfaces on Claude-on-Antigravity, and why the reproduction needs a long
tool-heavy session — more turns, more chances for one empty part.

## Fix

All in `messagesToGeminiFormat` (`src/adapters/google.ts`). Every emitted turn now has at least one
part, and every text part a non-empty string `text`:

- **Empty string content** → `"(empty)"` placeholder.
- **Empty or non-string text parts** → dropped via a small `geminiTextPart()` helper; a user turn
  left with nothing falls back to the `"(empty)"` placeholder.
- **Assistant turns with nothing representable** (e.g. thinking-only) → skipped instead of sent as
  `parts: []`, matching what the Anthropic adapter already does for its own empty assistant content
  (`src/adapters/anthropic.ts`).
- **Empty tool-result text** → `"(empty tool output)"` placeholder.

Placeholder strings are reused from the Anthropic adapter so the two adapters stay symmetric. Image
parts, `functionCall` / `functionResponse` parts, thought signatures, and tool-call id pairing are
untouched.

The guard applies to every Google provider, not only Antigravity: an empty part carries no
information for Gemini either, and one code path keeps the same bug from reappearing on Vertex.

## Tests

- `tests/google-empty-content.test.ts` (new, 12 cases): one per malformed shape above, an
  `assertNoEmptyTextParts` invariant applied across the whole `contents` array, the empty
  tool-result-array cases from review, and unchanged-passthrough controls. **All 10 guard cases fail
  without the source change**; the controls pass either way.
- Google suites green — adapter, antigravity-wire, antigravity-replay, hardening, wire-compiler,
  vertex-stream, tool-schema, plus the new file: **118 passed across 8 files**.
- `bun run typecheck` and `bun run privacy:scan` pass.
- Full suite: **4,048 passed, 4 failed, 4 skipped across 323 files**. All 4 failures are
  pre-existing on this Windows machine and reproduce on a clean `dev` checkout:
  - `ci-workflows` (2) — `Bun.spawnSync(["bun", …])` resolves `bun` from `PATH`, which this machine
    does not have; the file passes 10/10 once `bun` is on `PATH`.
  - `codex-catalog` routed-normalization (1) — cross-file state pollution; the identical 12-file
    group produces the identical failures on clean `dev` (222 pass / 3 fail both sides).
  - `openai-provider-option-e2e` spine (1) — same cross-file effect; the identical file set gives
    137 pass / 1 fail on clean `dev` too, and the file passes 1/1 alone.

No test makes a live provider request.

A note on how the full suite was run: a single `bun test` process hangs on this machine partway
through the anthropic e2e files, and **that hang reproduces on a clean `dev` checkout with no
changes applied**, so it is environmental rather than something this PR introduces. To get real
coverage anyway I ran the suite in 27 batches; the one batch that hit the hang was then re-run
file-by-file (120 passed, 0 failed). The batched run was performed at the pre-rebase commit; the
rebase since then only pulled in the CI/issue-bot commits (`#423`), which touch no `src/` path in
this diff's neighbourhood, and the Google suites, typecheck, and privacy scan were re-run after the
rebase. CI remains the authority here.

## Notes

- I considered validating the cast in `src/responses/parser.ts` instead. The serializer is the right
  place: it is the last point that knows what the wire accepts, it has to hold for content arriving
  from the Claude ingress, sidecars, and replayed history too, and it keeps the Google and Anthropic
  adapters symmetric. Happy to send parser-side hardening separately if you want it.
- Skipping an empty model turn can leave two consecutive `user` turns. The previous `parts: []`
  shape was itself rejected upstream, so this is not a regression, and the Anthropic adapter already
  skips empty assistant content the same way — flagging it as the one behavioral change beyond
  dropping empties.
- No authentication, credential, logging, or workflow path is touched.

## Review follow-up (CodeRabbit, #430)

`contentPartsToText` collapses an empty array — or one holding only empty text — to its `"[image]"`
marker, so the first commit's `|| placeholder` was unreachable for array content and the tool result
claimed an image the turn does not carry (`toolResultImageParts` contributes none). Fixed in
`8704ab7b` with a `geminiToolResultText()` helper gated on representable text or image content, plus
three cases: empty array, all-empty-text array, and an image-only control that must still report
`[image]`. The two guard cases fail against the pre-fix source; the control passes either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google (Gemini) request formatting to avoid sending invalid empty text blocks.
  * Added placeholder text handling for empty/malformed user messages and tool outputs.
  * Filtered assistant messages so empty/non-emittable content is not sent, and tool results now always include a safe, non-empty result when applicable.
* **Tests**
  * Added coverage to verify empty, malformed, and valid content cases for user, assistant, and tool messages are translated into correct Gemini request payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->