### PR TITLE
fix(responses): validate message content blocks before use (#435)

### DIFF
--- a/src/responses/parser.ts
+++ b/src/responses/parser.ts
@@ -27,9 +27,11 @@ type InputBlock =
   | { type: "input_image"; image_url?: string; file_id?: string; detail?: string }
   | { type: "input_file"; file_id?: string; filename?: string };
 
-function inputContentParts(blocks: unknown[] | string | undefined): string | OcxContentPart[] {
+function inputContentParts(blocks: unknown): string | OcxContentPart[] {
   if (typeof blocks === "string") return blocks;
-  if (!blocks) return [];
+  // The catch-all can also hand back a non-array `content` (an object, a number), which would
+  // throw at the loop below before any per-block guard runs.
+  if (!Array.isArray(blocks)) return [];
   const parts: OcxContentPart[] = [];
   for (const raw of blocks) {
     // A malformed message item fails its strict schema and falls through to inputItemSchema's
@@ -61,9 +63,9 @@ function inputContentParts(blocks: unknown[] | string | undefined): string | Ocx
 
 type OutputBlock = { type: "output_text"; text: string } | { type: "text"; text: string } | { type: "refusal"; refusal: string };
 
-function outputTextOf(blocks: unknown[] | string | undefined): OcxTextContent[] {
+function outputTextOf(blocks: unknown): OcxTextContent[] {
   if (typeof blocks === "string") return blocks.length > 0 ? [{ type: "text", text: blocks }] : [];
-  if (!blocks) return [];
+  if (!Array.isArray(blocks)) return [];
   const out: OcxTextContent[] = [];
   for (const raw of blocks) {
     // Same catch-all caveat as inputContentParts: validate before use.
@@ -321,9 +323,7 @@ export function parseRequest(body: unknown): OcxParsedRequest {
           content?: unknown;
         };
 
-        const content = inputContentParts(
-          agentMessage.content as unknown[] | string | undefined,
-        );
+        const content = inputContentParts(agentMessage.content);
 
         const hasContent =
           typeof content === "string"
@@ -348,7 +348,7 @@ export function parseRequest(body: unknown): OcxParsedRequest {
         switch (msg.role) {
           case "system": {
             pendingReasoning.length = 0;
-            const text = inputContentParts(msg.content as unknown[] | string | undefined);
+            const text = inputContentParts(msg.content);
             const flat = typeof text === "string" ? text : text.map(p => (p.type === "text" ? p.text : "")).join("");
             if (flat.length > 0) systemPrompt.push(flat);
             break;
@@ -356,12 +356,12 @@ export function parseRequest(body: unknown): OcxParsedRequest {
           case "user":
           case "developer": {
             pendingReasoning.length = 0;
-            const content = inputContentParts(msg.content as unknown[] | string | undefined);
+            const content = inputContentParts(msg.content);
             messages.push({ role: msg.role, content, timestamp: now });
             break;
           }
           case "assistant": {
-            const parts = outputTextOf(msg.content as unknown[] | string | undefined);
+            const parts = outputTextOf(msg.content);
             messages.push({
               role: "assistant",
               content: pendingReasoning.length > 0

--- a/src/responses/parser.ts
+++ b/src/responses/parser.ts
@@ -32,20 +32,25 @@ function inputContentParts(blocks: unknown[] | string | undefined): string | Ocx
   if (!blocks) return [];
   const parts: OcxContentPart[] = [];
   for (const raw of blocks) {
+    // A malformed message item fails its strict schema and falls through to inputItemSchema's
+    // permissive catch-all, so blocks reaching here are NOT guaranteed to match the declared
+    // shape. Validate each field before use, as outputToToolResultContent already does.
+    if (!isObj(raw)) continue;
     const block = raw as InputBlock;
     if (block.type === "input_text" || block.type === "text") {
-      parts.push({ type: "text", text: (block as { text: string }).text });
+      if (typeof raw.text === "string") parts.push({ type: "text", text: raw.text });
     } else if (block.type === "input_image") {
       const b = block as { image_url?: string; file_id?: string; detail?: string };
-      if (b.image_url) {
+      if (typeof b.image_url === "string" && b.image_url.length > 0) {
         // Preserve the image as a structured part — adapters send it as a native image block.
         // NEVER inline the (often base64 data-URL) image_url as text: that explodes the token count.
-        parts.push({ type: "image", imageUrl: b.image_url, ...(b.detail ? { detail: normalizeImageDetail(b.detail) } : {}) });
+        parts.push({ type: "image", imageUrl: b.image_url, ...(typeof b.detail === "string" && b.detail.length > 0 ? { detail: normalizeImageDetail(b.detail) } : {}) });
       } else {
-        parts.push({ type: "text", text: `[image: ${b.file_id ?? "?"}]` }); // file_id ref → no inline data
+        parts.push({ type: "text", text: `[image: ${typeof b.file_id === "string" ? b.file_id : "?"}]` }); // file_id ref → no inline data
       }
     } else if (block.type === "input_file") {
-      const ref = (block as { file_id?: string; filename?: string }).file_id ?? (block as { filename?: string }).filename ?? "?";
+      const b = block as { file_id?: string; filename?: string };
+      const ref = typeof b.file_id === "string" ? b.file_id : typeof b.filename === "string" ? b.filename : "?";
       parts.push({ type: "text", text: `[file: ${ref}]` });
     }
   }
@@ -61,9 +66,14 @@ function outputTextOf(blocks: unknown[] | string | undefined): OcxTextContent[] 
   if (!blocks) return [];
   const out: OcxTextContent[] = [];
   for (const raw of blocks) {
+    // Same catch-all caveat as inputContentParts: validate before use.
+    if (!isObj(raw)) continue;
     const b = raw as OutputBlock;
-    if (b.type === "output_text" || b.type === "text") out.push({ type: "text", text: (b as { text: string }).text });
-    else if (b.type === "refusal") out.push({ type: "text", text: `[refusal: ${(b as { refusal: string }).refusal}]` });
+    if (b.type === "output_text" || b.type === "text") {
+      if (typeof raw.text === "string") out.push({ type: "text", text: raw.text });
+    } else if (b.type === "refusal") {
+      if (typeof raw.refusal === "string") out.push({ type: "text", text: `[refusal: ${raw.refusal}]` });
+    }
   }
   return out;
 }

--- a/tests/responses-parser-malformed-content.test.ts
+++ b/tests/responses-parser-malformed-content.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { parseRequest } from "../src/responses/parser";
+import { createGoogleAdapter } from "../src/adapters/google";
+import { createAnthropicAdapter } from "../src/adapters/anthropic";
+import type { OcxProviderConfig } from "../src/types";
+
+// A message item whose content blocks do not match their strict schema fails
+// `userMessageItemSchema` / `assistantMessageItemSchema` and falls through to
+// `inputItemSchema`'s permissive catch-all (`z.object({ type: z.string() }).loose()`),
+// which passes the raw content through untouched. The parser then has to validate
+// it itself — otherwise a malformed block reaches an adapter, or crashes parseRequest.
+
+function inputOf(role: string, content: unknown) {
+  return { model: "gemini-3-pro", input: [{ type: "message", role, content }] };
+}
+
+function userContent(content: unknown): unknown {
+  const parsed = parseRequest(inputOf("user", content));
+  return (parsed.context.messages[0] as { content?: unknown } | undefined)?.content;
+}
+
+describe("responses parser — malformed content blocks", () => {
+  test("a user text block with no text key is dropped, not turned into undefined content", () => {
+    expect(userContent([{ type: "input_text" }])).toEqual([]);
+  });
+
+  test("a user text block with a non-string text is dropped, not leaked as an object", () => {
+    // Previously collapsed to `parts[0].text`, making the whole message content
+    // the raw object (`{a: 1}`), which is neither a string nor an array.
+    expect(userContent([{ type: "input_text", text: { a: 1 } }])).toEqual([]);
+  });
+
+  test("a null content block does not crash the parser", () => {
+    expect(() => userContent([null])).not.toThrow();
+    expect(userContent([null])).toEqual([]);
+  });
+
+  test("a system message with a malformed block does not crash the parser", () => {
+    // parseRequest flattens system content inline, so an undefined return threw here.
+    expect(() => parseRequest(inputOf("system", [{ type: "input_text" }]))).not.toThrow();
+    const parsed = parseRequest(inputOf("system", [{ type: "input_text" }]));
+    expect(parsed.context.systemPrompt ?? []).toEqual([]);
+  });
+
+  test("valid blocks alongside malformed ones survive", () => {
+    expect(userContent([{ type: "input_text" }, { type: "input_text", text: "real" }])).toBe("real");
+    expect(userContent([{ type: "input_text", text: "a" }, { type: "input_text", text: "b" }]))
+      .toEqual([{ type: "text", text: "a" }, { type: "text", text: "b" }]);
+  });
+
+  test("an assistant output_text with no text key does not become a bare text part", () => {
+    const parsed = parseRequest(inputOf("assistant", [{ type: "output_text" }, { type: "output_text", text: "kept" }]));
+    const msg = parsed.context.messages[0] as { content: Array<{ type: string; text?: string }> };
+    expect(msg.content).toEqual([{ type: "text", text: "kept" }]);
+  });
+
+  test("a refusal block with a non-string refusal is dropped", () => {
+    const parsed = parseRequest(inputOf("assistant", [{ type: "refusal", refusal: { nope: true } }]));
+    const msg = parsed.context.messages[0] as { content: unknown[] };
+    expect(msg.content).toEqual([]);
+  });
+
+  test("an input_image with a non-string image_url degrades to a file marker instead of crashing", () => {
+    expect(userContent([{ type: "input_image", image_url: { bad: true }, file_id: "file_1" }]))
+      .toBe("[image: file_1]");
+  });
+
+  test("a valid image block is still preserved structurally", () => {
+    expect(userContent([{ type: "input_image", image_url: "data:image/png;base64,aGVsbG8=", detail: "high" }]))
+      .toEqual([{ type: "image", imageUrl: "data:image/png;base64,aGVsbG8=", detail: "high" }]);
+  });
+
+  test("adapters build a request from malformed input instead of throwing", async () => {
+    const parsed = parseRequest(inputOf("user", [{ type: "input_text" }]));
+    const google = { adapter: "google", baseUrl: "https://generativelanguage.googleapis.com", apiKey: "k" } as unknown as OcxProviderConfig;
+    const anthropic = { adapter: "anthropic", baseUrl: "https://api.anthropic.com", apiKey: "sk-x" } as unknown as OcxProviderConfig;
+
+    await expect(createGoogleAdapter(google).buildRequest(parsed)).resolves.toBeDefined();
+    await expect(createAnthropicAdapter(anthropic).buildRequest(parsed)).resolves.toBeDefined();
+  });
+});

--- a/tests/responses-parser-malformed-content.test.ts
+++ b/tests/responses-parser-malformed-content.test.ts
@@ -42,6 +42,25 @@ describe("responses parser — malformed content blocks", () => {
     expect(parsed.context.systemPrompt ?? []).toEqual([]);
   });
 
+  test("a non-array content container does not crash the parser", () => {
+    // The catch-all can also retain a `content` that is not an array at all; the block loop
+    // would throw ("{} is not iterable") before any per-block guard runs.
+    for (const container of [{ type: "input_text", text: "x" }, 42, true]) {
+      expect(() => userContent(container)).not.toThrow();
+      expect(userContent(container)).toEqual([]);
+    }
+  });
+
+  test("a non-array container on system and assistant roles is also safe", () => {
+    const container = { type: "input_text", text: "x" };
+    expect(() => parseRequest(inputOf("system", container))).not.toThrow();
+    expect(() => parseRequest(inputOf("assistant", container))).not.toThrow();
+
+    const assistant = parseRequest(inputOf("assistant", container));
+    const msg = assistant.context.messages[0] as { content: unknown[] };
+    expect(msg.content).toEqual([]);
+  });
+
   test("valid blocks alongside malformed ones survive", () => {
     expect(userContent([{ type: "input_text" }, { type: "input_text", text: "real" }])).toBe("real");
     expect(userContent([{ type: "input_text", text: "a" }, { type: "input_text", text: "b" }]))


### PR DESCRIPTION
Closes #435.

## Problem

The strict schemas do require well-formed content blocks — `inputTextSchema` is
`{ type: "input_text", text: z.string() }`. But `inputItemSchema` ends with a permissive catch-all:

```ts
export const inputItemSchema = z.union([
  userMessageItemSchema,
  // …
  z.object({ type: z.string() }).loose(),   // <-- malformed message items land here
]);
```

A message item whose content blocks fail their strict schema is therefore **not** rejected — it falls
through to that catch-all, which passes the raw `content` through untouched. `inputContentParts()`
and `outputTextOf()` then cast it without checking:

```ts
parts.push({ type: "text", text: (block as { text: string }).text });   // text may be absent
```

Five outcomes, all confirmed against `dev` at `6f4cd1d6`:

| Input block | Result |
|---|---|
| `user` + `{"type":"input_text"}` (no `text`) | message `content` becomes `undefined` → adapter throws `TypeError` |
| `system` + `{"type":"input_text"}` | **`parseRequest` throws** `undefined is not an object (evaluating 'text.map')` |
| `user` + `[null]` | **`parseRequest` throws** `null is not an object (evaluating 'block.type')` |
| `user` + `{"type":"input_text","text":{"a":1}}` | `content` becomes the object `{"a":1}` — neither string nor array |
| `assistant` + `{"type":"output_text"}` (no `text`) | emits a bare `{"type":"text"}` part with no `text` |

The `undefined` content comes from the single-part collapse, which returns the unvalidated field
directly:

```ts
if (parts.length === 1 && parts[0].type === "text") return parts[0].text;   // undefined
```

That last table row is the same malformed shape behind the Anthropic 400 in #420
(`content.N.text.text: Field required`), reached from a different direction.

`outputToToolResultContent()` in this same file already validates correctly — `if (!isObj(raw))
continue;`, `if (typeof raw.text === "string")`. This PR brings the other two readers in line with it.

## Fix

`src/responses/parser.ts`, in `inputContentParts()` and `outputTextOf()`:

- **Skip non-object blocks** — `isObj(raw)` guard, exactly as `outputToToolResultContent` does.
- **Require a string `text` / `refusal`** before emitting a part, so a malformed block is dropped
  instead of becoming `{"type":"text"}` with no `text`.
- **Require a non-empty string `image_url`** before treating a block as an image. A non-string
  previously reached `parseDataUrl()`, which calls `.match()` on it; it now falls back to the
  existing `[image: <file_id>]` marker.
- **Resolve `input_file` / `file_id` refs only from strings**, so a non-string cannot be interpolated
  into the marker.

With every emitted part well-formed, the single-part collapse can no longer return `undefined`, and
message content is always a string or an array — which is what every adapter already assumes.

Malformed blocks are dropped rather than coerced: coercing an object to text yields
`"[object Object]"`, which is worse than omitting it, and dropping matches the precedent in
`outputToToolResultContent`.

## Tests

- `tests/responses-parser-malformed-content.test.ts` (new, 10 cases): one per table row, plus
  valid-blocks-survive-alongside-malformed, a valid-image structural control, and an end-to-end case
  asserting the Google and Anthropic adapters build a request instead of throwing. **9 of 10 fail
  without the source change**; the valid-image control passes either way.
- Parser-adjacent suites green — responses, bridge, chat-completions, claude-messages, vision,
  compaction and friends (21 files): **272 passed**.
- `bun run typecheck` and `bun run privacy:scan` pass.
- Full suite: **4,094 passed, 4 failed, 4 skipped across 323 files**. The 4 failures are
  pre-existing on this Windows machine and were each reproduced on a clean `dev` checkout while
  verifying #430 — `ci-workflows` (2, `Bun.spawnSync(["bun", …])` needs `bun` on `PATH`; passes 10/10
  with it), `codex-catalog` routed-normalization (1), and `openai-provider-option-e2e` (1, passes
  alone). None touch the Responses parser.

A note on how the full suite was run: a single `bun test` process hangs on this machine partway
through the anthropic e2e files, and that hang reproduces on a clean `dev` checkout with no changes
applied, so it is environmental. I ran the suite in 27 batches instead; the one batch that hit the
hang was then re-run file-by-file (120 passed, 0 failed). CI remains the authority.

## Notes

- **Well-formed requests are unaffected.** Every guard added is satisfied by input that already
  matched the strict schema, so valid requests produce identical output. The one place I had to be
  careful was `detail`: `b.detail ? …` and `typeof b.detail === "string"` differ for `detail: ""`, so
  the check is `typeof b.detail === "string" && b.detail.length > 0` to preserve the existing
  omit-on-empty behavior.
- **Scope is deliberately the two unvalidated readers.** Tightening `inputItemSchema`'s catch-all
  would be the deeper fix, but that catch-all is load-bearing — it is how unknown and newly added
  item types pass through the proxy — so narrowing it risks rejecting items that are currently
  relayed fine. Happy to look at that separately if you want it.
- No authentication, credential, logging, or workflow path is touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened parsing of response and request content blocks with runtime validation.
  * Prevented malformed text, image, file, and refusal fields from producing undefined output or crashing.
  * Ensured malformed blocks safely degrade while preserving any valid content.
  * Continued successful processing for requests with malformed content across supported adapters.
* **Tests**
  * Added a new test suite covering malformed content blocks, null/non-array inputs, invalid images, and refusal handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->