### PR TITLE
docs: clarify Bun requirement for source development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,10 @@ Agent-facing repository and review rules live in [`AGENTS.md`](./AGENTS.md).
 For local development commands, architecture notes, and release workflow details, use the hosted
 contributing guide above instead of duplicating instructions here.
 
+Source development requires the `bun` CLI on your `PATH`. The published npm package bundles its own
+Bun runtime for end users, but contributor commands such as `bun install`, `bun run test`, and
+`bun run prepush` run from your local Bun installation.
+
 ## Pre-push hook
 
 After cloning, run once to install a local pre-push hook that runs the typecheck,

--- a/README.md
+++ b/README.md
@@ -456,6 +456,9 @@ lives in [`SECURITY.md`](./SECURITY.md).
 
 ## Development
 
+Source development requires the `bun` CLI on your `PATH`. This is separate from the published npm
+package's bundled Bun runtime, which is used only by installed `ocx` commands.
+
 ```bash
 git clone https://github.com/lidge-jun/opencodex.git
 cd opencodex

--- a/docs-site/src/content/docs/contributing.md
+++ b/docs-site/src/content/docs/contributing.md
@@ -5,6 +5,9 @@ description: Develop opencodex — setup, layout, conventions, and how to add a 
 
 ## Setup
 
+Source development requires the `bun` CLI on your `PATH`. The published npm package bundles its own
+Bun runtime for users, but this checkout's scripts run through your local Bun installation.
+
 ```bash
 git clone https://github.com/lidge-jun/opencodex.git
 cd opencodex


### PR DESCRIPTION
## Summary
- Clarify that source development requires a local `bun` CLI on `PATH`
- Distinguish contributor commands from the published npm package's bundled Bun runtime
- Add the note to the root contributor entry point, README development section, and hosted contributing docs source

## Validation
- `git diff --check`
- Not run: Bun-based project commands, because this cron host currently has `node`/`npm` but no `bun` binary on `PATH`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that source development requires the Bun CLI to be installed and available on the system `PATH`.
  * Explained the distinction between the locally installed Bun used for development commands and the bundled runtime included with the published package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->