### PR TITLE
feat(gui): add custom models from provider workspace

### DIFF
--- a/gui/src/components/provider-workspace/ProviderDetails.tsx
+++ b/gui/src/components/provider-workspace/ProviderDetails.tsx
@@ -227,7 +227,9 @@ export default function ProviderDetails({
         )}
         {tab === "models" && (
           <ProviderModels
+            key={item.name}
             item={item}
+            apiBase={apiBase}
             availableModels={availableModels}
             selectedModels={selectedModels}
             modelsLoading={modelsLoading}

--- a/gui/src/components/provider-workspace/ProviderModels.tsx
+++ b/gui/src/components/provider-workspace/ProviderModels.tsx
@@ -10,6 +10,7 @@ import { filterModels } from "../../provider-workspace/report";
 
 export default function ProviderModels({
   item,
+  apiBase,
   availableModels,
   selectedModels,
   modelsLoading = false,
@@ -19,6 +20,7 @@ export default function ProviderModels({
   onOpenAccounts,
 }: {
   item: WorkspaceItem;
+  apiBase: string;
   availableModels: string[];
   selectedModels: string[];
   modelsLoading?: boolean;
@@ -30,14 +32,53 @@ export default function ProviderModels({
 }) {
   const t = useT();
   const [query, setQuery] = useState("");
+  const [customModelId, setCustomModelId] = useState("");
+  const [customSaving, setCustomSaving] = useState(false);
+  const [customError, setCustomError] = useState("");
+  const [customSuccess, setCustomSuccess] = useState("");
+  const [customModelIds, setCustomModelIds] = useState<string[]>([]);
+  const [customModelsReady, setCustomModelsReady] = useState(false);
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const copyResetRef = useRef<number | null>(null);
   const selectedSet = useMemo(() => new Set(selectedModels), [selectedModels]);
   const configuredModels = useMemo(() => item.models ?? [], [item.models]);
+  const trimmedCustomModelId = customModelId.trim();
+  const customModelInvalid = !customModelsReady
+    || !trimmedCustomModelId
+    || trimmedCustomModelId.includes("/")
+    || availableModels.includes(trimmedCustomModelId)
+    || customModelIds.includes(trimmedCustomModelId)
+    || configuredModels.includes(trimmedCustomModelId)
+    || item.defaultModel === trimmedCustomModelId;
   const models = useMemo(
-    () => filterModels(availableModels, item.defaultModel, query, configuredModels),
-    [availableModels, item.defaultModel, query, configuredModels],
+    () => filterModels(availableModels, item.defaultModel, query, configuredModels, customModelIds),
+    [availableModels, item.defaultModel, query, configuredModels, customModelIds],
   );
+
+  useEffect(() => {
+    let active = true;
+    void fetch(`${apiBase}/api/custom-models`)
+      .then(response => {
+        if (!response.ok) throw new Error();
+        return response.json();
+      })
+      .then((rows: unknown) => {
+        if (!Array.isArray(rows)) throw new Error("Invalid custom model list");
+        if (!active) return;
+        setCustomModelIds(rows.flatMap(row => {
+          if (!row || typeof row !== "object") return [];
+          const model = row as { provider?: unknown; modelId?: unknown };
+          return model.provider === item.name && typeof model.modelId === "string" ? [model.modelId] : [];
+        }));
+        setCustomModelsReady(true);
+      })
+      .catch(() => {
+        if (!active) return;
+        setCustomModelIds([]);
+        setCustomError(t("models.networkError"));
+      });
+    return () => { active = false; };
+  }, [apiBase, item.name, t]);
 
   useEffect(() => () => {
     if (copyResetRef.current != null) window.clearTimeout(copyResetRef.current);
@@ -57,7 +98,36 @@ export default function ProviderModels({
     }
   };
 
-  const emptyBase = availableModels.length === 0 && configuredModels.length === 0 && !item.defaultModel;
+  const addCustomModel = async () => {
+    if (customModelInvalid || customSaving) return;
+    setCustomSaving(true);
+    setCustomError("");
+    setCustomSuccess("");
+    try {
+      const response = await fetch(`${apiBase}/api/custom-models`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider: item.name, modelId: trimmedCustomModelId }),
+      });
+      if (response.ok) {
+        setCustomModelIds(ids => ids.includes(trimmedCustomModelId) ? ids : [...ids, trimmedCustomModelId]);
+        setCustomModelId("");
+        setCustomSuccess(t("models.customAdded"));
+        onRetryModels?.();
+      } else {
+        setCustomError(t("models.customSaveFailed"));
+      }
+    } catch {
+      setCustomError(t("models.networkError"));
+    } finally {
+      setCustomSaving(false);
+    }
+  };
+
+  const emptyBase = availableModels.length === 0
+    && configuredModels.length === 0
+    && customModelIds.length === 0
+    && !item.defaultModel;
   const showingConfiguredFallback = availableModels.length === 0 && configuredModels.length > 0;
   // Aggregators (OpenRouter etc.) can return thousands of ids; capping the mounted
   // chips keeps the tab responsive. Filtering narrows the list, so the cap only
@@ -87,6 +157,31 @@ export default function ProviderModels({
       {showingConfiguredFallback && !needsReauth && (
         <p className="muted text-label" style={{ marginBottom: 10 }}>{t("pws.modelsConfiguredFallback")}</p>
       )}
+      <label className="text-label pws-custom-model-label" htmlFor={`pws-custom-model-${item.name}`}>
+        {t("models.customAdd")}
+      </label>
+      <div className="row pws-custom-model-row">
+        <input
+          id={`pws-custom-model-${item.name}`}
+          className="input"
+          value={customModelId}
+          onChange={event => setCustomModelId(event.target.value)}
+          onKeyDown={event => { if (event.key === "Enter") void addCustomModel(); }}
+          placeholder={t("models.customFieldModelIdPlaceholder")}
+          aria-label={t("models.customAdd")}
+          disabled={customSaving}
+        />
+        <button
+          type="button"
+          className="btn btn-primary btn-sm"
+          onClick={() => { void addCustomModel(); }}
+          disabled={customSaving || customModelInvalid}
+        >
+          {customSaving ? t("models.customSaving") : t("models.customAddBtn")}
+        </button>
+      </div>
+      {customSuccess && <p className="muted text-label" role="status">{customSuccess}</p>}
+      {customError && <p className="pws-inline-error" role="alert">{customError}</p>}
       {!emptyBase && (
         <input
           type="search"

--- a/gui/src/provider-workspace/report.ts
+++ b/gui/src/provider-workspace/report.ts
@@ -65,12 +65,17 @@ export function filterModels(
   defaultModel: string | undefined,
   query: string,
   configuredModels?: string[],
+  customModels: string[] = [],
 ): string[] {
-  const list = base.length > 0
+  const customSet = new Set(customModels);
+  const hasLiveModels = base.some(modelId => !customSet.has(modelId));
+  const fallback = configuredModels && configuredModels.length > 0
+    ? configuredModels
+    : defaultModel ? [defaultModel] : [];
+  const primary = base.length > 0 && (hasLiveModels || customSet.size === 0)
     ? base
-    : (configuredModels && configuredModels.length > 0)
-      ? configuredModels
-      : defaultModel ? [defaultModel] : [];
+    : fallback;
+  const list = [...new Set([...primary, ...customModels])];
   const q = query.trim().toLowerCase();
   if (!q) return list;
   return list.filter(id => id.toLowerCase().includes(q));

--- a/gui/src/styles/provider-workspace-shell.css
+++ b/gui/src/styles/provider-workspace-shell.css
@@ -823,6 +823,21 @@
   margin-bottom: 18px;
 }
 
+.pws-custom-model-label {
+  display: block;
+  margin-bottom: 6px;
+}
+
+.pws-custom-model-row {
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.pws-custom-model-row .input {
+  flex: 1;
+  min-width: 0;
+}
+
 .pws-model-list {
   display: flex;
   flex-wrap: wrap;

--- a/gui/tests/provider-model-custom-add.test.tsx
+++ b/gui/tests/provider-model-custom-add.test.tsx
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act } from "react";
+import type { Root } from "react-dom/client";
+import { LanguageProvider } from "../src/i18n/provider";
+import ProviderModels from "../src/components/provider-workspace/ProviderModels";
+import type { WorkspaceItem } from "../src/provider-workspace/catalog";
+
+const globals = ["document", "window", "navigator", "localStorage", "IS_REACT_ACT_ENVIRONMENT"] as const;
+const originalFetch = globalThis.fetch;
+let previousGlobals: Record<(typeof globals)[number], unknown>;
+let testWindow: Window;
+
+beforeEach(() => {
+  previousGlobals = Object.fromEntries(globals.map(key => [key, Reflect.get(globalThis, key)])) as typeof previousGlobals;
+  testWindow = new Window({ url: "http://localhost/#providers/workspace" });
+  Object.defineProperty(testWindow.navigator, "language", { configurable: true, value: "en-US" });
+  Object.defineProperties(globalThis, {
+    document: { configurable: true, value: testWindow.document },
+    window: { configurable: true, value: testWindow },
+    navigator: { configurable: true, value: testWindow.navigator },
+    localStorage: { configurable: true, value: testWindow.localStorage },
+  });
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  testWindow.close();
+  for (const key of globals) {
+    Object.defineProperty(globalThis, key, { configurable: true, value: previousGlobals[key] });
+  }
+});
+
+const item = {
+  name: "AiCodeWith",
+  adapter: "openai-chat",
+  baseUrl: "https://example.test/v1",
+  models: ["claude-opus-5"],
+  defaultModel: "claude-opus-5",
+} as WorkspaceItem;
+
+async function mountProviderModels(
+  availableModels = ["claude-opus-5"],
+  onRetryModels?: () => void,
+  providerItem = item,
+): Promise<{ root: Root; container: HTMLElement; input: HTMLInputElement; addButton: HTMLButtonElement }> {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const { createRoot } = await import("react-dom/client");
+  let root!: Root;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <LanguageProvider>
+        <ProviderModels
+          item={providerItem}
+          availableModels={availableModels}
+          selectedModels={[]}
+          apiBase="http://localhost:10100"
+          onRetryModels={onRetryModels}
+        />
+      </LanguageProvider>,
+    );
+  });
+  const input = container.querySelector<HTMLInputElement>('input[aria-label="Add custom model"]')!;
+  const addButton = [...container.querySelectorAll("button")]
+    .find(button => button.textContent?.trim() === "Add") as HTMLButtonElement;
+  return { root, container, input, addButton };
+}
+
+async function enterModelId(input: HTMLInputElement, value: string): Promise<void> {
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(testWindow.HTMLInputElement.prototype, "value")!
+      .set!.call(input, value);
+    input.dispatchEvent(new testWindow.Event("input", { bubbles: true }));
+  });
+}
+
+test("quick-add submits the trimmed model id for the current provider", async () => {
+  const requests: Array<{ url: string; method: string; body: unknown }> = [];
+  globalThis.fetch = (async (input, init) => {
+    if (!init?.method || init.method === "GET") return Response.json([]);
+    requests.push({
+      url: String(input),
+      method: init?.method ?? "GET",
+      body: typeof init?.body === "string" ? JSON.parse(init.body) : undefined,
+    });
+    return Response.json({ id: "custom-1" }, { status: 201 });
+  }) as typeof fetch;
+
+  let refreshes = 0;
+  const { root, container, input, addButton } = await mountProviderModels(
+    ["claude-opus-5"],
+    () => { refreshes += 1; },
+  );
+  await enterModelId(input, "  claude-opus-5.1  ");
+  await act(async () => {
+    addButton.click();
+    await Promise.resolve();
+  });
+
+  expect(requests).toEqual([{
+    url: "http://localhost:10100/api/custom-models",
+    method: "POST",
+    body: { provider: "AiCodeWith", modelId: "claude-opus-5.1" },
+  }]);
+  expect(refreshes).toBe(1);
+  expect(input.value).toBe("");
+  expect(container.querySelector('[role="status"]')?.textContent).toContain("Custom model added");
+
+  await act(async () => { root.unmount(); });
+});
+
+test("quick-add blocks existing and namespaced model ids", async () => {
+  let requests = 0;
+  globalThis.fetch = (async (_input, init) => {
+    if (!init?.method || init.method === "GET") return Response.json([]);
+    requests += 1;
+    return Response.json({ id: "unexpected" }, { status: 201 });
+  }) as typeof fetch;
+  const { root, input, addButton } = await mountProviderModels();
+
+  await enterModelId(input, "claude-opus-5");
+  expect(addButton.disabled).toBe(true);
+  await enterModelId(input, "vendor/model");
+  expect(addButton.disabled).toBe(true);
+  expect(requests).toBe(0);
+
+  await act(async () => { root.unmount(); });
+});
+
+test("quick-add keeps the model id when the server rejects it", async () => {
+  globalThis.fetch = (async (_input, init) => (
+    !init?.method || init.method === "GET"
+      ? Response.json([])
+      : Response.json({ error: "duplicate model" }, { status: 409 })
+  )) as typeof fetch;
+  const { root, container, input, addButton } = await mountProviderModels();
+  await enterModelId(input, "claude-opus-5.1");
+
+  await act(async () => {
+    addButton.click();
+    await Promise.resolve();
+  });
+
+  expect(input.value).toBe("claude-opus-5.1");
+  expect(container.querySelector('[role="alert"]')?.textContent).toContain("Failed to save custom model");
+
+  await act(async () => { root.unmount(); });
+});
+
+test("quick-add recovers from a network failure", async () => {
+  globalThis.fetch = (async (_input, init) => {
+    if (!init?.method || init.method === "GET") return Response.json([]);
+    throw new Error("offline");
+  }) as typeof fetch;
+  const { root, container, input, addButton } = await mountProviderModels();
+  await enterModelId(input, "claude-opus-5.1");
+
+  await act(async () => {
+    addButton.click();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  expect(input.disabled).toBe(false);
+  expect(container.querySelector('[role="alert"]')?.textContent).toContain("Network error");
+
+  await act(async () => { root.unmount(); });
+});
+
+test("custom-only catalog keeps configured fallback models visible", async () => {
+  globalThis.fetch = (async () => Response.json([
+    { id: "custom-1", provider: "AiCodeWith", modelId: "claude-opus-5.1-custom" },
+  ])) as typeof fetch;
+
+  const { root, container } = await mountProviderModels(["claude-opus-5.1-custom"]);
+  await act(async () => { await Promise.resolve(); });
+
+  const modelIds = [...container.querySelectorAll(".pws-model-id")].map(node => node.textContent);
+  expect(modelIds).toEqual(["claude-opus-5", "claude-opus-5.1-custom"]);
+
+  await act(async () => { root.unmount(); });
+});
+
+test("successful quick-add appears immediately when catalog refresh is unavailable", async () => {
+  globalThis.fetch = (async (_input, init) => (
+    !init?.method || init.method === "GET"
+      ? Response.json([])
+      : Response.json({ id: "custom-1" }, { status: 201 })
+  )) as typeof fetch;
+  const emptyItem = { ...item, models: [], defaultModel: undefined } as WorkspaceItem;
+  const { root, container, input, addButton } = await mountProviderModels([], undefined, emptyItem);
+  await enterModelId(input, "claude-opus-5.1-custom");
+
+  await act(async () => {
+    addButton.click();
+    await Promise.resolve();
+  });
+
+  expect(container.querySelector(".pws-model-id")?.textContent).toBe("claude-opus-5.1-custom");
+  await act(async () => { root.unmount(); });
+});
+
+test("quick-add waits for custom-model duplicate knowledge", async () => {
+  let resolveLookup!: (response: Response) => void;
+  const lookup = new Promise<Response>(resolve => { resolveLookup = resolve; });
+  let posts = 0;
+  globalThis.fetch = (async (_input, init) => {
+    if (!init?.method || init.method === "GET") return lookup;
+    posts += 1;
+    return Response.json({ id: "unexpected" }, { status: 201 });
+  }) as typeof fetch;
+  const emptyItem = { ...item, models: [], defaultModel: undefined } as WorkspaceItem;
+  const { root, input, addButton } = await mountProviderModels([], undefined, emptyItem);
+  await enterModelId(input, "already-custom");
+
+  expect(addButton.disabled).toBe(true);
+  await act(async () => {
+    resolveLookup(Response.json([{ provider: "AiCodeWith", modelId: "already-custom" }]));
+    await lookup;
+    await Promise.resolve();
+  });
+  expect(addButton.disabled).toBe(true);
+  expect(posts).toBe(0);
+
+  await act(async () => { root.unmount(); });
+});
+
+test("quick-add stays blocked when custom-model lookup fails", async () => {
+  let posts = 0;
+  globalThis.fetch = (async (_input, init) => {
+    if (!init?.method || init.method === "GET") throw new Error("offline");
+    posts += 1;
+    return Response.json({ id: "unexpected" }, { status: 201 });
+  }) as typeof fetch;
+  const emptyItem = { ...item, models: [], defaultModel: undefined } as WorkspaceItem;
+  const { root, input, addButton } = await mountProviderModels([], undefined, emptyItem);
+  await enterModelId(input, "unknown-custom");
+  await act(async () => { await Promise.resolve(); });
+
+  expect(addButton.disabled).toBe(true);
+  expect(posts).toBe(0);
+
+  await act(async () => { root.unmount(); });
+});

--- a/tests/provider-workspace-state.test.ts
+++ b/tests/provider-workspace-state.test.ts
@@ -33,6 +33,23 @@ describe("workspace detail derived states (WP090)", () => {
       expect(filterModels(base, undefined, "  sol  ")).toEqual(["gpt-5.6-sol"]);
       expect(filterModels(base, undefined, "nope")).toEqual([]);
     });
+
+    test("custom-only catalog rows do not suppress configured fallback models", () => {
+      expect(filterModels(
+        ["claude-opus-5.1-custom"],
+        "ignored-default",
+        "",
+        ["claude-opus-5"],
+        ["claude-opus-5.1-custom"],
+      )).toEqual(["claude-opus-5", "claude-opus-5.1-custom"]);
+      expect(filterModels(
+        ["live-model", "claude-opus-5.1-custom"],
+        "ignored-default",
+        "",
+        ["configured-fallback"],
+        ["claude-opus-5.1-custom"],
+      )).toEqual(["live-model", "claude-opus-5.1-custom"]);
+    });
   });
 
   describe("accountQuotaFromReport (quota-unavailable paths)", () => {


### PR DESCRIPTION
## Summary

- add a provider-scoped custom model input to the workspace Models tab
- validate empty, namespaced, duplicate, loading, and failed-lookup states before submission
- show successful additions immediately while preserving configured fallback models for custom-only catalogs
- reuse the existing custom-model API and existing localized strings; no API or schema changes

Fixes #448

## Testing

- bun test ./gui/tests/provider-model-custom-add.test.tsx tests/provider-workspace-state.test.ts — 17 passed
- bun run typecheck
- bun run lint:gui
- bun run build:gui
- bun run privacy:scan
- desktop and 375px browser QA with no console errors

## Local full-suite note

bun run test completed 4,074 tests successfully and reported 25 environment-specific failures. In this local network, the affected test hostnames resolve to Clash-style 198.18.0.x fake IPs, so the destination-policy guard blocks mocked provider discovery before the tests reach their fetch stubs. The changed focused suites pass; CI remains the authoritative clean-environment full-suite result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for adding custom provider models directly from the provider workspace.
  * Custom models are loaded, displayed, deduplicated, and available immediately after being added.
  * Added validation and inline feedback for duplicate, invalid, failed, or successful additions.
  * Preserved configured fallback models when catalog results contain only custom models.

* **Bug Fixes**
  * Improved model filtering and fallback behavior for custom-only provider catalogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->