### PR TITLE
fix(providers): honor saved baseUrl for alibaba-token-plan via override + choices

### DIFF
--- a/src/providers/base-url-choices.ts
+++ b/src/providers/base-url-choices.ts
@@ -21,6 +21,23 @@ export const QWEN_CLOUD_BASE_URL_CHOICES: readonly ProviderBaseUrlChoice[] = [
   { id: "custom", label: "Custom" },
 ];
 
+/**
+ * Alibaba Token Plan OpenAI-compatible endpoint presets.
+ * Beijing is the registry default (Personal Edition); the international
+ * Singapore endpoint (Team Edition) and custom are selectable, so a saved
+ * non-Beijing baseUrl is honored instead of silently overridden.
+ */
+export const ALIBABA_TOKEN_PLAN_BEIJING_BASE_URL =
+  "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1";
+export const ALIBABA_TOKEN_PLAN_INTL_BASE_URL =
+  "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1";
+
+export const ALIBABA_TOKEN_PLAN_BASE_URL_CHOICES: readonly ProviderBaseUrlChoice[] = [
+  { id: "beijing", label: "China (Beijing)", baseUrl: ALIBABA_TOKEN_PLAN_BEIJING_BASE_URL },
+  { id: "intl", label: "International (Singapore)", baseUrl: ALIBABA_TOKEN_PLAN_INTL_BASE_URL },
+  { id: "custom", label: "Custom" },
+];
+
 /** Match a saved baseUrl to a known choice id (`custom` when it does not match). */
 export function matchBaseUrlChoice(
   choices: readonly ProviderBaseUrlChoice[],

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -2,7 +2,7 @@ import type { CodexAccountMode, OcxProviderConfig } from "../types";
 import { KIRO_MODELS, KIRO_MODEL_CONTEXT_WINDOWS, KIRO_MODEL_REASONING_EFFORTS } from "./kiro-models";
 import { ANTIGRAVITY_MODELS, ANTIGRAVITY_MODEL_CONTEXT_WINDOWS } from "./antigravity-models";
 import type { ProviderBaseUrlChoice } from "./base-url-choices";
-import { QWEN_CLOUD_BASE_URL_CHOICES, QWEN_CLOUD_TOKEN_PLAN_BASE_URL } from "./base-url-choices";
+import { ALIBABA_TOKEN_PLAN_BASE_URL_CHOICES, ALIBABA_TOKEN_PLAN_BEIJING_BASE_URL, QWEN_CLOUD_BASE_URL_CHOICES, QWEN_CLOUD_TOKEN_PLAN_BASE_URL } from "./base-url-choices";
 import {
   CURSOR_STATIC_MODELS,
   cursorModelContextWindows,
@@ -690,9 +690,11 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
   {
     id: "alibaba-token-plan",
     label: "Alibaba Token Plan (Beijing)",
-    baseUrl: "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+    baseUrl: ALIBABA_TOKEN_PLAN_BEIJING_BASE_URL,
     adapter: "openai-chat",
     authKind: "key",
+    allowBaseUrlOverride: true,
+    baseUrlChoices: ALIBABA_TOKEN_PLAN_BASE_URL_CHOICES,
     dashboardUrl: "https://bailian.console.aliyun.com/cn-beijing?tab=plan",
     defaultModel: "qwen3.8-max-preview",
     models: ALIBABA_TOKEN_PLAN_MODELS,

--- a/tests/alibaba-token-plan-endpoints.test.ts
+++ b/tests/alibaba-token-plan-endpoints.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ALIBABA_TOKEN_PLAN_BASE_URL_CHOICES,
+  ALIBABA_TOKEN_PLAN_BEIJING_BASE_URL,
+  ALIBABA_TOKEN_PLAN_INTL_BASE_URL,
+  matchBaseUrlChoice,
+} from "../src/providers/base-url-choices";
+import { PROVIDER_REGISTRY } from "../src/providers/registry";
+import { deriveProviderPresets } from "../src/providers/derive";
+
+describe("alibaba-token-plan endpoint choices", () => {
+  test("registry defaults to Beijing and exposes intl + custom choices", () => {
+    const entry = PROVIDER_REGISTRY.find(e => e.id === "alibaba-token-plan");
+    expect(entry).toBeDefined();
+    expect(entry!.baseUrl).toBe(ALIBABA_TOKEN_PLAN_BEIJING_BASE_URL);
+    expect(entry!.allowBaseUrlOverride).toBe(true);
+    expect(entry!.baseUrlChoices?.map(c => c.id)).toEqual(["beijing", "intl", "custom"]);
+    expect(entry!.baseUrlChoices).toEqual([...ALIBABA_TOKEN_PLAN_BASE_URL_CHOICES]);
+  });
+
+  test("presets API projection includes baseUrlChoices", () => {
+    const preset = deriveProviderPresets().find(p => p.id === "alibaba-token-plan");
+    expect(preset?.baseUrl).toBe(ALIBABA_TOKEN_PLAN_BEIJING_BASE_URL);
+    expect(preset?.baseUrlChoices?.map(c => c.id)).toEqual(["beijing", "intl", "custom"]);
+    const intl = preset?.baseUrlChoices?.find(c => c.id === "intl");
+    expect(intl?.baseUrl).toBe(ALIBABA_TOKEN_PLAN_INTL_BASE_URL);
+    expect(preset?.baseUrlChoices?.find(c => c.id === "custom")?.baseUrl).toBeUndefined();
+  });
+
+  test("matchBaseUrlChoice maps known hosts and falls back to custom", () => {
+    expect(matchBaseUrlChoice(ALIBABA_TOKEN_PLAN_BASE_URL_CHOICES, ALIBABA_TOKEN_PLAN_BEIJING_BASE_URL)).toBe("beijing");
+    expect(matchBaseUrlChoice(ALIBABA_TOKEN_PLAN_BASE_URL_CHOICES, ALIBABA_TOKEN_PLAN_INTL_BASE_URL + "/")).toBe("intl");
+    expect(matchBaseUrlChoice(ALIBABA_TOKEN_PLAN_BASE_URL_CHOICES, "https://example.com/v1")).toBe("custom");
+  });
+});

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -418,7 +418,7 @@ describe("provider registry parity", () => {
   test("base URL override permission is registry-only and limited to opted-in providers", () => {
     const optedIn = PROVIDER_REGISTRY.filter(entry => entry.allowBaseUrlOverride);
 
-    expect(optedIn.map(entry => entry.id)).toEqual(["ollama", "vllm", "lm-studio", "qwen-cloud", "litellm"]);
+    expect(optedIn.map(entry => entry.id)).toEqual(["ollama", "vllm", "lm-studio", "qwen-cloud", "alibaba-token-plan", "litellm"]);
     for (const entry of optedIn) {
       expect(providerConfigSeed(entry)).not.toHaveProperty("allowBaseUrlOverride");
     }


### PR DESCRIPTION
Fixes #457

## Problem

The `alibaba-token-plan` registry entry (Beijing) lacks `allowBaseUrlOverride`, so the router silently discards any user-saved `baseUrl` and forces the Beijing endpoint (`router.ts`: registry URL wins unless the entry is a template or opts into override).

After the July provider migration merged user configs into the id `alibaba-token-plan`, configs holding an international (`ap-southeast-1`) baseUrl are still routed to `cn-beijing` → **all requests fail with 401**, with no warning that the saved URL was ignored.

## Fix

Mirror the existing `qwen-cloud` pattern:

- `src/providers/base-url-choices.ts`: add `ALIBABA_TOKEN_PLAN_BEIJING_BASE_URL`, `ALIBABA_TOKEN_PLAN_INTL_BASE_URL`, and `ALIBABA_TOKEN_PLAN_BASE_URL_CHOICES` (`beijing` / `intl` / `custom`).
- `src/providers/registry.ts`: `alibaba-token-plan` gets `allowBaseUrlOverride: true` + `baseUrlChoices`, and uses the Beijing constant (value unchanged).

Default resolution is unchanged when no user `baseUrl` is set — only configs with a saved URL now have it honored, and the GUI can offer the region choice.

## Tests

- New `tests/alibaba-token-plan-endpoints.test.ts` mirrors the qwen-cloud endpoint tests (registry shape, presets projection, `matchBaseUrlChoice` mapping).
- Updated the override allowlist assertion in `tests/provider-registry-parity.test.ts`.
- `tsc --noEmit` clean, full suite: **3231 pass / 0 fail**, privacy scan passed.

## Notes

- Issue #457 also documents two wider follow-ups left for maintainer discretion (router warning when a saved baseUrl is discarded; migration renaming semantics) — intentionally not in this PR.
