### PR TITLE
fix(proxy): stop empty 503 bodies becoming Codex Unknown error (#452)

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -2,6 +2,7 @@ import type { ProviderAdapter } from "./base";
 import type { AdapterEvent, OcxAssistantMessage, OcxContentPart, OcxMessage, OcxParsedRequest, OcxProviderConfig, OcxTextContent, OcxThinkingContent, OcxToolCall, OcxUsage } from "../types";
 import { isAllowedToolChoice, modelInList, namespacedToolName, resolveToolChoiceWireName, toolAllowedByChoice } from "../types";
 import { mapReasoningEffort, modelRecordValue } from "../reasoning-effort";
+import { debugProviderDiagnostic } from "../lib/debug";
 import { redactSecretString } from "../lib/redact";
 import { contentPartsToText } from "./image";
 import { neutralizeIdentity } from "./identity";
@@ -588,6 +589,16 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
       if (hasCredential) headers["Authorization"] = `Bearer ${provider.apiKey}`;
       if (provider.headers) Object.assign(headers, provider.headers);
 
+      debugProviderDiagnostic("openai-chat", "request", {
+        url,
+        model: body.model,
+        stream: parsed.stream,
+        messageCount: Array.isArray(messages) ? messages.length : 0,
+        toolCount: Array.isArray(tools) ? tools.length : 0,
+        hasCredential,
+        bodyBytes: new TextEncoder().encode(JSON.stringify(body)).length,
+      });
+
       return { url, method: "POST", headers, body: JSON.stringify(body) };
     },
 
@@ -658,8 +669,10 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
         // classified response.failed (bridge case "error") — never a truncated completion.
         if (chunk.error) {
           const err = chunk.error as { message?: string } | undefined;
+          const message = err?.message ?? "upstream error";
+          debugProviderDiagnostic("openai-chat", "stream-error", { message });
           yield* flushToolCalls();
-          yield { type: "error", message: err?.message ?? "upstream error" };
+          yield { type: "error", message };
           return "terminate";
         }
 
@@ -748,6 +761,10 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
         // closed so the bridge emits a classified response.failed rather than a silent truncation.
         const sawFinish = finishReason !== undefined;
         if (!sawFinish && pendingUsage === undefined) {
+          debugProviderDiagnostic("openai-chat", "stream-truncated", {
+            finishReason: finishReason ?? null,
+            hadUsage: false,
+          });
           yield { type: "error", message: "upstream stream ended without a terminal signal ([DONE] or finish_reason) — possible truncation" };
           return;
         }

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -3,6 +3,7 @@ import type { AdapterEvent, OcxAssistantMessage, OcxContentPart, OcxMessage, Ocx
 import { isAllowedToolChoice, modelInList, namespacedToolName, resolveToolChoiceWireName, toolAllowedByChoice } from "../types";
 import { mapReasoningEffort, modelRecordValue } from "../reasoning-effort";
 import { debugProviderDiagnostic } from "../lib/debug";
+import { isDebugEnabled } from "../lib/debug-settings";
 import { redactSecretString } from "../lib/redact";
 import { contentPartsToText } from "./image";
 import { neutralizeIdentity } from "./identity";
@@ -589,17 +590,24 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
       if (hasCredential) headers["Authorization"] = `Bearer ${provider.apiKey}`;
       if (provider.headers) Object.assign(headers, provider.headers);
 
-      debugProviderDiagnostic("openai-chat", "request", {
-        url,
-        model: body.model,
-        stream: parsed.stream,
-        messageCount: Array.isArray(messages) ? messages.length : 0,
-        toolCount: Array.isArray(tools) ? tools.length : 0,
-        hasCredential,
-        bodyBytes: new TextEncoder().encode(JSON.stringify(body)).length,
-      });
+      const bodyJson = JSON.stringify(body);
+      // Never log pathname/query — tenant-scoped hosts (e.g. Cloudflare
+      // /accounts/<account_id>/ai/v1) would otherwise leak account identifiers (#452).
+      if (isDebugEnabled()) {
+        let host = "upstream";
+        try { host = new URL(url).host; } catch { /* keep fallback */ }
+        debugProviderDiagnostic("openai-chat", "request", {
+          host,
+          model: body.model,
+          stream: parsed.stream,
+          messageCount: Array.isArray(messages) ? messages.length : 0,
+          toolCount: Array.isArray(tools) ? tools.length : 0,
+          hasCredential,
+          bodyBytes: new TextEncoder().encode(bodyJson).length,
+        });
+      }
 
-      return { url, method: "POST", headers, body: JSON.stringify(body) };
+      return { url, method: "POST", headers, body: bodyJson };
     },
 
     async *parseStream(response: Response): AsyncGenerator<AdapterEvent> {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -282,6 +282,18 @@ export function startServer(port?: number) {
   // (0.0.0.0/::) and specific hosts are left untouched so intentional exposure is preserved.
   const bindHost = /^localhost$/i.test(config.hostname ?? "") ? "127.0.0.1" : (config.hostname ?? "127.0.0.1");
 
+  // Codex treats empty / non-JSON 503 bodies as "Unknown error" (#452). Keep Retry-After and
+  // the server_is_overloaded code so clients can back off, but always return a JSON envelope.
+  function drainingResponse(req: Request): Response {
+    const response = formatErrorResponse(503, "server_error", "Service shutting down");
+    const headers = new Headers(response.headers);
+    for (const [name, value] of Object.entries(corsHeaders(req, config))) {
+      headers.set(name, value);
+    }
+    headers.set("Retry-After", "5");
+    return new Response(response.body, { status: 503, headers });
+  }
+
   const server: Server<WsData> = Bun.serve<WsData>({
     port: listenPort,
     hostname: bindHost,
@@ -301,7 +313,7 @@ export function startServer(port?: number) {
       // handshake-time only, so capture inbound headers and thread them into the pipeline.
       if (url.pathname === "/v1/responses" && req.headers.get("upgrade")?.toLowerCase() === "websocket") {
         if (isDraining()) {
-          return new Response("Service shutting down", { status: 503, headers: { ...corsHeaders(req, config), "Retry-After": "5" } });
+          return drainingResponse(req);
         }
         const apiAuthError = requireResponsesApiAuth(req, config);
         if (apiAuthError) return withCors(apiAuthError, req, config);
@@ -406,7 +418,7 @@ export function startServer(port?: number) {
       // before the /v1/* 404 guard below.
       if (url.pathname === "/v1/responses/compact" && req.method === "POST") {
         if (isDraining()) {
-          return new Response("Service shutting down", { status: 503, headers: { ...corsHeaders(req, config), "Retry-After": "5" } });
+          return drainingResponse(req);
         }
         const apiAuthError = requireResponsesApiAuth(req, config);
         if (apiAuthError) return withCors(apiAuthError, req, config);
@@ -438,10 +450,7 @@ export function startServer(port?: number) {
       ) {
         disableResponsesRequestTimeout(req, requestServer);
         if (isDraining()) {
-          return new Response("Service shutting down", {
-            status: 503,
-            headers: { ...corsHeaders(req, config), "Retry-After": "5" },
-          });
+          return drainingResponse(req);
         }
         const apiAuthError = requireApiAuth(req, config, "data-plane");
         if (apiAuthError) return withCors(apiAuthError, req, config);
@@ -460,10 +469,7 @@ export function startServer(port?: number) {
       if (url.pathname === "/v1/alpha/search" && req.method === "POST") {
         disableResponsesRequestTimeout(req, requestServer);
         if (isDraining()) {
-          return new Response("Service shutting down", {
-            status: 503,
-            headers: { ...corsHeaders(req, config), "Retry-After": "5" },
-          });
+          return drainingResponse(req);
         }
         const apiAuthError = requireApiAuth(req, config, "data-plane");
         if (apiAuthError) return withCors(apiAuthError, req, config);
@@ -487,7 +493,7 @@ export function startServer(port?: number) {
       if (url.pathname === "/v1/responses" && req.method === "POST") {
         disableResponsesRequestTimeout(req, requestServer);
         if (isDraining()) {
-          return new Response("Service shutting down", { status: 503, headers: { ...corsHeaders(req, config), "Retry-After": "5" } });
+          return drainingResponse(req);
         }
         const apiAuthError = requireResponsesApiAuth(req, config);
         if (apiAuthError) return withCors(apiAuthError, req, config);
@@ -526,7 +532,7 @@ export function startServer(port?: number) {
       // Claude Code posts `/v1/messages?beta=true` — pathname match ignores the query (003 G9).
       if (url.pathname === "/v1/messages/count_tokens" && req.method === "POST") {
         if (isDraining()) {
-          return new Response("Service shutting down", { status: 503, headers: { ...corsHeaders(req, config), "Retry-After": "5" } });
+          return drainingResponse(req);
         }
         if (!hasValidApiAuth(req, config)) {
           return withCors(anthropicErrorResponse(401, "opencodex API key required", "authentication_error"), req, config);
@@ -541,7 +547,7 @@ export function startServer(port?: number) {
       if (url.pathname === "/v1/messages" && req.method === "POST") {
         disableResponsesRequestTimeout(req, requestServer);
         if (isDraining()) {
-          return new Response("Service shutting down", { status: 503, headers: { ...corsHeaders(req, config), "Retry-After": "5" } });
+          return drainingResponse(req);
         }
         if (!hasValidApiAuth(req, config)) {
           return withCors(anthropicErrorResponse(401, "opencodex API key required", "authentication_error"), req, config);
@@ -564,7 +570,7 @@ export function startServer(port?: number) {
       if (url.pathname === "/v1/chat/completions" && req.method === "POST") {
         disableResponsesRequestTimeout(req, requestServer);
         if (isDraining()) {
-          return new Response("Service shutting down", { status: 503, headers: { ...corsHeaders(req, config), "Retry-After": "5" } });
+          return drainingResponse(req);
         }
         const apiAuthError = requireResponsesApiAuth(req, config);
         if (apiAuthError) return withCors(apiAuthError, req, config);
@@ -587,10 +593,7 @@ export function startServer(port?: number) {
       ) {
         disableResponsesRequestTimeout(req, requestServer);
         if (isDraining()) {
-          return new Response("Service shutting down", {
-            status: 503,
-            headers: { ...corsHeaders(req, config), "Retry-After": "5" },
-          });
+          return drainingResponse(req);
         }
         const apiAuthError = requireApiAuth(req, config, "data-plane");
         if (apiAuthError) return withCors(apiAuthError, req, config);
@@ -618,10 +621,7 @@ export function startServer(port?: number) {
         : null;
       if (liveSidebandTarget) {
         if (isDraining()) {
-          return new Response("Service shutting down", {
-            status: 503,
-            headers: { ...corsHeaders(req, config), "Retry-After": "5" },
-          });
+          return drainingResponse(req);
         }
         const apiAuthError = requireApiAuth(req, config, "data-plane");
         if (apiAuthError) return withCors(apiAuthError, req, config);

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -1,5 +1,6 @@
 import type { Server } from "bun";
 import { bridgeToResponsesSSE, buildResponseJSON, formatErrorResponse, type ResponsesTerminalStatus } from "../../bridge";
+import { formatPassthroughUpstreamError } from "./passthrough-error";
 import {
   getConfigPath,
   multiAgentGuidanceEnabled,
@@ -1169,6 +1170,19 @@ export async function handleResponses(
       }
     }
 
+    // Non-2xx passthrough failures must never reach Codex as an empty body —
+    // Codex renders that as the opaque "Unknown error" (#452). Combo attempts
+    // keep their typed failure envelope; everything else is normalized below.
+    if (!upstreamResponse.ok) {
+      if (options.comboAttempt) {
+        const failure = await consumeComboFailure(upstreamResponse, options.abortSignal);
+        options.onConsumedComboFailure?.(failure);
+        return failure.response;
+      }
+      const errorText = await upstreamResponse.text().catch(() => "");
+      return formatPassthroughUpstreamError(upstreamResponse.status, errorText);
+    }
+
     // Bun#32111 workaround: passthrough SSE uses tee()+native relay to avoid the
     // async-pull segfault on Windows. Branch[0] goes directly to the Response (Bun
     // native relay, never enters JS Sink.write); branch[1] is consumed in the
@@ -1179,7 +1193,7 @@ export async function handleResponses(
     // bounded reader with inline inspection (see src/server/relay-eager.ts and
     // devlog/_plan/260723_win_mem_safestream/020). Default on the bundled
     // known-bad runtime remains the tee path below.
-    if (upstreamResponse.ok && isEventStream && upstreamResponse.body) {
+    if (isEventStream && upstreamResponse.body) {
       const repairConfig = route.provider.responsesItemIdRepair;
       const winNoRepair = process.platform === "win32" && !hasResponsesItemIdRepair(repairConfig);
       const eagerDecision = winNoRepair ? decideEagerRelay(config.streamMode ?? "auto") : null;
@@ -1272,14 +1286,9 @@ export async function handleResponses(
       }));
     }
     if (headers.get("content-type")?.toLowerCase().includes("application/json")) {
-      if (!upstreamResponse.ok && options.comboAttempt) {
-        const failure = await consumeComboFailure(upstreamResponse, options.abortSignal);
-        options.onConsumedComboFailure?.(failure);
-        return failure.response;
-      }
       const text = await upstreamResponse.text();
       inspectResponseLogJson(logCtx, text);
-      if (upstreamResponse.ok && rememberPassthroughResponse) {
+      if (rememberPassthroughResponse) {
         try {
           rememberPassthroughResponse(JSON.parse(text) as { id?: unknown; output?: unknown; status?: unknown });
         } catch { /* non-JSON despite content-type; recording is best-effort */ }

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -1172,7 +1172,8 @@ export async function handleResponses(
 
     // Non-2xx passthrough failures must never reach Codex as an empty body —
     // Codex renders that as the opaque "Unknown error" (#452). Combo attempts
-    // keep their typed failure envelope; everything else is normalized below.
+    // keep their typed failure envelope. Non-empty bodies are relayed verbatim
+    // (headers included) so pool-retry Activation B/D and client diagnostics stay intact.
     if (!upstreamResponse.ok) {
       if (options.comboAttempt) {
         const failure = await consumeComboFailure(upstreamResponse, options.abortSignal);
@@ -1180,7 +1181,10 @@ export async function handleResponses(
         return failure.response;
       }
       const errorText = await upstreamResponse.text().catch(() => "");
-      return formatPassthroughUpstreamError(upstreamResponse.status, errorText);
+      return formatPassthroughUpstreamError(upstreamResponse.status, errorText, {
+        statusText: upstreamResponse.statusText,
+        headers,
+      });
     }
 
     // Bun#32111 workaround: passthrough SSE uses tee()+native relay to avoid the

--- a/src/server/responses/passthrough-error.ts
+++ b/src/server/responses/passthrough-error.ts
@@ -1,0 +1,34 @@
+import { formatErrorResponse } from "../../bridge";
+import { redactSecretString } from "../../lib/redact";
+
+/**
+ * Passthrough adapters historically relayed upstream non-2xx bodies verbatim.
+ * Codex maps an empty body to the literal client string "Unknown error"
+ * (UnexpectedResponseError), which hid ChatGPT empty-503 failures behind
+ * issue #452. Preserve OpenAI-style JSON that already has error.message;
+ * otherwise wrap so the client always gets a non-empty message.
+ */
+export function formatPassthroughUpstreamError(status: number, bodyText: string): Response {
+  const trimmed = bodyText.trim();
+  if (trimmed) {
+    try {
+      const json = JSON.parse(trimmed) as { error?: { message?: unknown } };
+      const message = json?.error?.message;
+      if (typeof message === "string" && message.trim().length > 0) {
+        return new Response(trimmed, {
+          status,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    } catch {
+      /* non-JSON: wrap below */
+    }
+  }
+
+  const detail = trimmed || "(empty body)";
+  return formatErrorResponse(
+    status,
+    "upstream_error",
+    `Provider error ${status}: ${redactSecretString(detail.slice(0, 500))}`,
+  );
+}

--- a/src/server/responses/passthrough-error.ts
+++ b/src/server/responses/passthrough-error.ts
@@ -1,4 +1,11 @@
 import { formatErrorResponse } from "../../bridge";
+import { parseRetryAfterMs } from "../../combos";
+
+function sanitizedRetryAfter(value: string | null | undefined, now: number): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.length > 128) return undefined;
+  return parseRetryAfterMs(trimmed, now) !== undefined ? trimmed : undefined;
+}
 
 /**
  * Passthrough adapters historically relayed upstream non-2xx bodies verbatim.
@@ -8,6 +15,10 @@ import { formatErrorResponse } from "../../bridge";
  * Non-empty bodies (including ChatGPT `{detail: ...}` account-model 400s and
  * HTML/text errors) must keep their original bytes and headers so pool-retry
  * activation and client diagnostics stay honest.
+ *
+ * Normalized (empty-body) responses force `Content-Type: application/json` and
+ * preserve a validated `Retry-After` so Responses clients and the chat-completions
+ * / Claude bridges that copy that header keep correct backoff.
  */
 export function formatPassthroughUpstreamError(
   status: number,
@@ -15,9 +26,13 @@ export function formatPassthroughUpstreamError(
   options?: {
     statusText?: string;
     headers?: Headers;
+    now?: number;
   },
 ): Response {
   const trimmed = bodyText.trim();
+  const now = options?.now ?? Date.now();
+  const retryAfter = sanitizedRetryAfter(options?.headers?.get("retry-after"), now);
+
   if (trimmed) {
     return new Response(bodyText, {
       status,
@@ -26,9 +41,13 @@ export function formatPassthroughUpstreamError(
     });
   }
 
-  return formatErrorResponse(
+  const response = formatErrorResponse(
     status,
     "upstream_error",
     `Provider error ${status}: (empty body)`,
   );
+  const headers = new Headers(response.headers);
+  headers.set("Content-Type", "application/json");
+  if (retryAfter !== undefined) headers.set("Retry-After", retryAfter);
+  return new Response(response.body, { status: response.status, headers });
 }

--- a/src/server/responses/passthrough-error.ts
+++ b/src/server/responses/passthrough-error.ts
@@ -1,34 +1,34 @@
 import { formatErrorResponse } from "../../bridge";
-import { redactSecretString } from "../../lib/redact";
 
 /**
  * Passthrough adapters historically relayed upstream non-2xx bodies verbatim.
- * Codex maps an empty body to the literal client string "Unknown error"
- * (UnexpectedResponseError), which hid ChatGPT empty-503 failures behind
- * issue #452. Preserve OpenAI-style JSON that already has error.message;
- * otherwise wrap so the client always gets a non-empty message.
+ * Codex maps an *empty* body to the literal client string "Unknown error"
+ * (UnexpectedResponseError) — issue #452. Only empty bodies need wrapping.
+ *
+ * Non-empty bodies (including ChatGPT `{detail: ...}` account-model 400s and
+ * HTML/text errors) must keep their original bytes and headers so pool-retry
+ * activation and client diagnostics stay honest.
  */
-export function formatPassthroughUpstreamError(status: number, bodyText: string): Response {
+export function formatPassthroughUpstreamError(
+  status: number,
+  bodyText: string,
+  options?: {
+    statusText?: string;
+    headers?: Headers;
+  },
+): Response {
   const trimmed = bodyText.trim();
   if (trimmed) {
-    try {
-      const json = JSON.parse(trimmed) as { error?: { message?: unknown } };
-      const message = json?.error?.message;
-      if (typeof message === "string" && message.trim().length > 0) {
-        return new Response(trimmed, {
-          status,
-          headers: { "Content-Type": "application/json" },
-        });
-      }
-    } catch {
-      /* non-JSON: wrap below */
-    }
+    return new Response(bodyText, {
+      status,
+      ...(options?.statusText ? { statusText: options.statusText } : {}),
+      ...(options?.headers ? { headers: options.headers } : { headers: { "Content-Type": "application/json" } }),
+    });
   }
 
-  const detail = trimmed || "(empty body)";
   return formatErrorResponse(
     status,
     "upstream_error",
-    `Provider error ${status}: ${redactSecretString(detail.slice(0, 500))}`,
+    `Provider error ${status}: (empty body)`,
   );
 }

--- a/tests/issue-452-empty-503.test.ts
+++ b/tests/issue-452-empty-503.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { saveCodexAccountCredential } from "../src/codex/account-store";
+import { clearAccountNeedsReauth, clearAccountQuota, updateAccountQuota } from "../src/codex/auth-api";
+import { clearCodexUpstreamHealth, clearThreadAccountMap } from "../src/codex/routing";
+import { saveConfig } from "../src/config";
+import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
+import { getDebugLogEntries, resetDebugLogBufferForTests } from "../src/lib/debug-log-buffer";
+import { resetDebugSettingsForTests } from "../src/lib/debug-settings";
+import { setDraining } from "../src/server/lifecycle";
+import { startServer } from "../src/server";
+import { formatPassthroughUpstreamError } from "../src/server/responses/passthrough-error";
+import type { OcxConfig, OcxParsedRequest } from "../src/types";
+import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+
+const previousApiToken = process.env.OPENCODEX_API_AUTH_TOKEN;
+const previousOpencodexHome = process.env.OPENCODEX_HOME;
+const previousOcxDebug = process.env.OCX_DEBUG;
+const originalGlobalFetch = globalThis.fetch;
+const TEST_DIR = join(import.meta.dir, ".tmp-issue-452-empty-503");
+let isolatedCodexHome: IsolatedCodexHome | null = null;
+
+function redirectCanonicalCodexTo(baseUrl: string): void {
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const requestUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const url = new URL(requestUrl);
+    const prefix = "/backend-api/codex";
+    if (url.hostname === "chatgpt.com" && url.pathname.startsWith(prefix)) {
+      const target = new URL(`${url.pathname.slice(prefix.length)}${url.search}`, baseUrl);
+      return originalGlobalFetch(target, init);
+    }
+    return originalGlobalFetch(input, init);
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  isolatedCodexHome = installIsolatedCodexHome("ocx-issue-452-");
+  resetDebugSettingsForTests();
+  resetDebugLogBufferForTests();
+  setDraining(false);
+});
+
+afterEach(() => {
+  globalThis.fetch = originalGlobalFetch;
+  setDraining(false);
+  if (previousApiToken === undefined) delete process.env.OPENCODEX_API_AUTH_TOKEN;
+  else process.env.OPENCODEX_API_AUTH_TOKEN = previousApiToken;
+  if (previousOpencodexHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = previousOpencodexHome;
+  if (previousOcxDebug === undefined) delete process.env.OCX_DEBUG;
+  else process.env.OCX_DEBUG = previousOcxDebug;
+  resetDebugSettingsForTests();
+  resetDebugLogBufferForTests();
+  isolatedCodexHome?.restore();
+  isolatedCodexHome = null;
+  clearCodexUpstreamHealth();
+  clearThreadAccountMap();
+  clearAccountNeedsReauth("pool-a");
+  clearAccountQuota();
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe("formatPassthroughUpstreamError (#452)", () => {
+  test("empty body becomes a JSON error with a non-empty message", async () => {
+    const response = formatPassthroughUpstreamError(503, "");
+    expect(response.status).toBe(503);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    const json = await response.json() as { error?: { message?: string; code?: string | null } };
+    expect(json.error?.message?.trim().length).toBeGreaterThan(0);
+    expect(json.error?.message).toContain("503");
+    expect(json.error?.message?.toLowerCase()).not.toBe("unknown error");
+  });
+
+  test("JSON with error.message is preserved for Codex", async () => {
+    const body = JSON.stringify({ error: { message: "no healthy upstream", type: "server_error" } });
+    const response = formatPassthroughUpstreamError(503, body);
+    expect(response.status).toBe(503);
+    const json = await response.json() as { error?: { message?: string } };
+    expect(json.error?.message).toBe("no healthy upstream");
+  });
+
+  test("JSON without error.message is wrapped", async () => {
+    const body = JSON.stringify({ detail: "overloaded" });
+    const response = formatPassthroughUpstreamError(503, body);
+    const json = await response.json() as { error?: { message?: string } };
+    expect(json.error?.message).toContain("503");
+    expect(json.error?.message).toContain("overloaded");
+  });
+});
+
+describe("passthrough empty 503 (#452)", () => {
+  test("ChatGPT passthrough empty-body 503 becomes JSON Codex can parse", async () => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    delete process.env.OPENCODEX_API_AUTH_TOKEN;
+    clearCodexUpstreamHealth();
+    clearThreadAccountMap();
+    clearAccountQuota();
+    clearAccountNeedsReauth("pool-a");
+
+    const upstream = Bun.serve({
+      port: 0,
+      fetch() {
+        // Codex shows "Unknown error" when the body is empty — the historical passthrough bug.
+        return new Response(null, { status: 503 });
+      },
+    });
+    redirectCanonicalCodexTo(upstream.url.toString());
+
+    saveConfig({
+      port: 0,
+      defaultProvider: "openai",
+      openaiProviderTierVersion: 2,
+      providers: {
+        openai: {
+          adapter: "openai-responses",
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+          authMode: "forward",
+          codexAccountMode: "pool",
+        },
+      },
+      codexAccounts: [
+        { id: "main", email: "main@example.test", isMain: true },
+        { id: "pool-a", email: "pool-a@example.test", isMain: false, chatgptAccountId: "acct-pool-a" },
+      ],
+      activeCodexAccountId: "pool-a",
+    } as OcxConfig);
+    saveCodexAccountCredential("pool-a", {
+      accessToken: "pool-a-token",
+      refreshToken: "pool-a-refresh",
+      expiresAt: Date.now() + 10 * 60_000,
+      chatgptAccountId: "acct-pool-a",
+    });
+    updateAccountQuota("pool-a", 10);
+
+    const server = startServer(0);
+    try {
+      const response = await originalGlobalFetch(new URL("/v1/responses", server.url), {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: "Bearer inbound-token" },
+        body: JSON.stringify({ model: "gpt-5.6-sol", input: "hi", stream: false }),
+      });
+      expect(response.status).toBe(503);
+      const text = await response.text();
+      expect(text.trim().length).toBeGreaterThan(0);
+      const json = JSON.parse(text) as { error?: { message?: string } };
+      expect(typeof json.error?.message).toBe("string");
+      expect(json.error!.message!.trim().length).toBeGreaterThan(0);
+      expect(json.error!.message!.toLowerCase()).not.toBe("unknown error");
+    } finally {
+      await server.stop(true);
+      await upstream.stop(true);
+    }
+  });
+});
+
+describe("drain 503 JSON (#452)", () => {
+  test("POST /v1/responses while draining returns JSON error body", async () => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    delete process.env.OPENCODEX_API_AUTH_TOKEN;
+    saveConfig({
+      port: 0,
+      defaultProvider: "xiaomi",
+      providers: {
+        xiaomi: {
+          adapter: "openai-chat",
+          baseUrl: "https://api.xiaomimimo.com/v1",
+          apiKey: "key-xiaomi-000111222333",
+          defaultModel: "mimo-v2.5-pro",
+        },
+      },
+    } as OcxConfig);
+
+    const server = startServer(0);
+    try {
+      setDraining(true);
+      const response = await originalGlobalFetch(new URL("/v1/responses", server.url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "mimo-v2.5-pro", input: "hi" }),
+      });
+      expect(response.status).toBe(503);
+      expect(response.headers.get("retry-after")).toBe("5");
+      const json = await response.json() as { error?: { message?: string; code?: string | null } };
+      expect(json.error?.message).toContain("shutting down");
+      expect(json.error?.code).toBe("server_is_overloaded");
+    } finally {
+      setDraining(false);
+      await server.stop(true);
+    }
+  });
+});
+
+describe("openai-chat provider debug (#452)", () => {
+  test("buildRequest emits debugProviderDiagnostic when OCX_DEBUG=1", () => {
+    process.env.OCX_DEBUG = "1";
+    resetDebugLogBufferForTests();
+    const adapter = createOpenAIChatAdapter({
+      adapter: "openai-chat",
+      baseUrl: "https://api.xiaomimimo.com/v1",
+      apiKey: "sk-secret-xiaomi-key",
+    });
+    const parsed = {
+      modelId: "mimo-v2.5-pro",
+      stream: true,
+      context: {
+        messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+        tools: [{ type: "function", name: "shell_command", description: "run", parameters: { type: "object" } }],
+      },
+      options: {},
+    } as unknown as OcxParsedRequest;
+    adapter.buildRequest(parsed);
+    const lines = getDebugLogEntries().map(e => e.line);
+    expect(lines.some(line => line.includes("[ocx:openai-chat:request]"))).toBe(true);
+    expect(lines.join("\n")).not.toContain("sk-secret-xiaomi-key");
+  });
+});

--- a/tests/issue-452-empty-503.test.ts
+++ b/tests/issue-452-empty-503.test.ts
@@ -72,6 +72,23 @@ describe("formatPassthroughUpstreamError (#452)", () => {
     expect(json.error?.message?.toLowerCase()).not.toBe("unknown error");
   });
 
+  test("empty body preserves validated Retry-After and forces application/json", async () => {
+    const headers = new Headers({ "retry-after": "12", "x-other": "drop-me" });
+    const response = formatPassthroughUpstreamError(429, "", { headers });
+    expect(response.status).toBe(429);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(response.headers.get("retry-after")).toBe("12");
+    expect(response.headers.get("x-other")).toBeNull();
+  });
+
+  test("empty body drops invalid Retry-After values", async () => {
+    for (const bad of ["", "nope", "-1", "0", "1e6", "not-a-delay"]) {
+      const headers = new Headers({ "retry-after": bad });
+      const response = formatPassthroughUpstreamError(503, "", { headers, now: Date.now() });
+      expect(response.headers.get("retry-after")).toBeNull();
+    }
+  });
+
   test("JSON with error.message is preserved for Codex", async () => {
     const body = JSON.stringify({ error: { message: "no healthy upstream", type: "server_error" } });
     const response = formatPassthroughUpstreamError(503, body);
@@ -90,70 +107,134 @@ describe("formatPassthroughUpstreamError (#452)", () => {
   });
 });
 
+async function withPoolPassthrough(
+  reply: (request: Request) => Response | Promise<Response>,
+  run: (serverUrl: string) => Promise<void>,
+): Promise<void> {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true, force: true });
+  mkdirSync(TEST_DIR, { recursive: true });
+  process.env.OPENCODEX_HOME = TEST_DIR;
+  delete process.env.OPENCODEX_API_AUTH_TOKEN;
+  clearCodexUpstreamHealth();
+  clearThreadAccountMap();
+  clearAccountQuota();
+  clearAccountNeedsReauth("pool-a");
+
+  const upstream = Bun.serve({
+    port: 0,
+    fetch(request) {
+      return reply(request);
+    },
+  });
+  redirectCanonicalCodexTo(upstream.url.toString());
+
+  saveConfig({
+    port: 0,
+    defaultProvider: "openai",
+    openaiProviderTierVersion: 2,
+    providers: {
+      openai: {
+        adapter: "openai-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        authMode: "forward",
+        codexAccountMode: "pool",
+      },
+    },
+    codexAccounts: [
+      { id: "main", email: "main@example.test", isMain: true },
+      { id: "pool-a", email: "pool-a@example.test", isMain: false, chatgptAccountId: "acct-pool-a" },
+    ],
+    activeCodexAccountId: "pool-a",
+  } as OcxConfig);
+  saveCodexAccountCredential("pool-a", {
+    accessToken: "pool-a-token",
+    refreshToken: "pool-a-refresh",
+    expiresAt: Date.now() + 10 * 60_000,
+    chatgptAccountId: "acct-pool-a",
+  });
+  updateAccountQuota("pool-a", 10);
+
+  const server = startServer(0);
+  try {
+    await run(server.url.toString());
+  } finally {
+    await server.stop(true);
+    await upstream.stop(true);
+  }
+}
+
 describe("passthrough empty 503 (#452)", () => {
   test("ChatGPT passthrough empty-body 503 becomes JSON Codex can parse", async () => {
-    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true, force: true });
-    mkdirSync(TEST_DIR, { recursive: true });
-    process.env.OPENCODEX_HOME = TEST_DIR;
-    delete process.env.OPENCODEX_API_AUTH_TOKEN;
-    clearCodexUpstreamHealth();
-    clearThreadAccountMap();
-    clearAccountQuota();
-    clearAccountNeedsReauth("pool-a");
-
-    const upstream = Bun.serve({
-      port: 0,
-      fetch() {
-        // Codex shows "Unknown error" when the body is empty — the historical passthrough bug.
-        return new Response(null, { status: 503 });
+    await withPoolPassthrough(
+      () => new Response(null, { status: 503 }),
+      async (serverUrl) => {
+        const response = await originalGlobalFetch(new URL("/v1/responses", serverUrl), {
+          method: "POST",
+          headers: { "content-type": "application/json", authorization: "Bearer inbound-token" },
+          body: JSON.stringify({ model: "gpt-5.6-sol", input: "hi", stream: false }),
+        });
+        expect(response.status).toBe(503);
+        const text = await response.text();
+        expect(text.trim().length).toBeGreaterThan(0);
+        const json = JSON.parse(text) as { error?: { message?: string } };
+        expect(typeof json.error?.message).toBe("string");
+        expect(json.error!.message!.trim().length).toBeGreaterThan(0);
+        expect(json.error!.message!.toLowerCase()).not.toBe("unknown error");
       },
-    });
-    redirectCanonicalCodexTo(upstream.url.toString());
+    );
+  });
 
-    saveConfig({
-      port: 0,
-      defaultProvider: "openai",
-      openaiProviderTierVersion: 2,
-      providers: {
-        openai: {
-          adapter: "openai-responses",
-          baseUrl: "https://chatgpt.com/backend-api/codex",
-          authMode: "forward",
-          codexAccountMode: "pool",
+  test("direct /v1/responses preserves Retry-After on empty-body 429 and 503", async () => {
+    for (const status of [429, 503] as const) {
+      await withPoolPassthrough(
+        () => new Response(null, { status, headers: { "Retry-After": "1" } }),
+        async (serverUrl) => {
+          const response = await originalGlobalFetch(new URL("/v1/responses", serverUrl), {
+            method: "POST",
+            headers: { "content-type": "application/json", authorization: "Bearer inbound-token" },
+            body: JSON.stringify({ model: "gpt-5.6-sol", input: "hi", stream: false }),
+          });
+          expect(response.status).toBe(status);
+          expect(response.headers.get("content-type")).toContain("application/json");
+          expect(response.headers.get("retry-after")).toBe("1");
         },
-      },
-      codexAccounts: [
-        { id: "main", email: "main@example.test", isMain: true },
-        { id: "pool-a", email: "pool-a@example.test", isMain: false, chatgptAccountId: "acct-pool-a" },
-      ],
-      activeCodexAccountId: "pool-a",
-    } as OcxConfig);
-    saveCodexAccountCredential("pool-a", {
-      accessToken: "pool-a-token",
-      refreshToken: "pool-a-refresh",
-      expiresAt: Date.now() + 10 * 60_000,
-      chatgptAccountId: "acct-pool-a",
-    });
-    updateAccountQuota("pool-a", 10);
-
-    const server = startServer(0);
-    try {
-      const response = await originalGlobalFetch(new URL("/v1/responses", server.url), {
-        method: "POST",
-        headers: { "content-type": "application/json", authorization: "Bearer inbound-token" },
-        body: JSON.stringify({ model: "gpt-5.6-sol", input: "hi", stream: false }),
-      });
-      expect(response.status).toBe(503);
-      const text = await response.text();
-      expect(text.trim().length).toBeGreaterThan(0);
-      const json = JSON.parse(text) as { error?: { message?: string } };
-      expect(typeof json.error?.message).toBe("string");
-      expect(json.error!.message!.trim().length).toBeGreaterThan(0);
-      expect(json.error!.message!.toLowerCase()).not.toBe("unknown error");
-    } finally {
-      await server.stop(true);
-      await upstream.stop(true);
+      );
     }
+  });
+
+  test("direct /v1/responses drops invalid Retry-After on empty-body 503", async () => {
+    await withPoolPassthrough(
+      () => new Response(null, { status: 503, headers: { "Retry-After": "not-a-delay" } }),
+      async (serverUrl) => {
+        const response = await originalGlobalFetch(new URL("/v1/responses", serverUrl), {
+          method: "POST",
+          headers: { "content-type": "application/json", authorization: "Bearer inbound-token" },
+          body: JSON.stringify({ model: "gpt-5.6-sol", input: "hi", stream: false }),
+        });
+        expect(response.status).toBe(503);
+        expect(response.headers.get("retry-after")).toBeNull();
+      },
+    );
+  });
+
+  test("/v1/chat/completions forwards Retry-After from empty-body upstream 429", async () => {
+    await withPoolPassthrough(
+      () => new Response(null, { status: 429, headers: { "Retry-After": "3" } }),
+      async (serverUrl) => {
+        const response = await originalGlobalFetch(new URL("/v1/chat/completions", serverUrl), {
+          method: "POST",
+          headers: { "content-type": "application/json", authorization: "Bearer inbound-token" },
+          body: JSON.stringify({
+            model: "gpt-5.6-sol",
+            messages: [{ role: "user", content: "hi" }],
+            stream: false,
+          }),
+        });
+        expect(response.status).toBe(429);
+        expect(response.headers.get("content-type")).toContain("application/json");
+        expect(response.headers.get("retry-after")).toBe("3");
+      },
+    );
   });
 });
 
@@ -217,6 +298,35 @@ describe("openai-chat provider debug (#452)", () => {
     adapter.buildRequest(parsed);
     const lines = getDebugLogEntries().map(e => e.line);
     expect(lines.some(line => line.includes("[ocx:openai-chat:request]"))).toBe(true);
+    expect(lines.join("\n")).toContain('"host":"api.xiaomimimo.com"');
     expect(lines.join("\n")).not.toContain("sk-secret-xiaomi-key");
+    expect(lines.join("\n")).not.toContain("/v1/chat/completions");
+  });
+
+  test("tenant-scoped baseUrl logs host only — account id never appears", () => {
+    process.env.OCX_DEBUG = "1";
+    resetDebugLogBufferForTests();
+    const accountId = "cf-account-abc123secret";
+    const adapter = createOpenAIChatAdapter({
+      adapter: "openai-chat",
+      baseUrl: `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/v1`,
+      apiKey: "cf-key-should-not-appear",
+    });
+    const parsed = {
+      modelId: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+      stream: false,
+      context: {
+        messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      },
+      options: {},
+    } as unknown as OcxParsedRequest;
+    adapter.buildRequest(parsed);
+    const joined = getDebugLogEntries().map(e => e.line).join("\n");
+    expect(joined).toContain("[ocx:openai-chat:request]");
+    expect(joined).toContain('"host":"api.cloudflare.com"');
+    expect(joined).not.toContain(accountId);
+    expect(joined).not.toContain("/accounts/");
+    expect(joined).not.toContain("cf-key-should-not-appear");
+    expect(joined).not.toContain("/ai/v1");
   });
 });

--- a/tests/issue-452-empty-503.test.ts
+++ b/tests/issue-452-empty-503.test.ts
@@ -80,12 +80,13 @@ describe("formatPassthroughUpstreamError (#452)", () => {
     expect(json.error?.message).toBe("no healthy upstream");
   });
 
-  test("JSON without error.message is wrapped", async () => {
+  test("non-empty body without error.message is relayed verbatim with headers", async () => {
     const body = JSON.stringify({ detail: "overloaded" });
-    const response = formatPassthroughUpstreamError(503, body);
-    const json = await response.json() as { error?: { message?: string } };
-    expect(json.error?.message).toContain("503");
-    expect(json.error?.message).toContain("overloaded");
+    const headers = new Headers({ "content-type": "application/json", "x-pool-retry-test": "original" });
+    const response = formatPassthroughUpstreamError(400, body, { statusText: "Bad Request", headers });
+    expect(response.status).toBe(400);
+    expect(response.headers.get("x-pool-retry-test")).toBe("original");
+    expect(await response.text()).toBe(body);
   });
 });
 


### PR DESCRIPTION
## Summary
- Never relay empty or non-JSON ChatGPT passthrough error bodies; wrap them so Codex always gets a non-empty `error.message` instead of `Unknown error`.
- Make drain `503` responses JSON (`server_is_overloaded`) with `Retry-After: 5`.
- Add `debugProviderDiagnostic` hooks to `openai-chat` so `ocx debug provider logs` captures Xiaomi/openai-chat traffic.
- Focused regression tests for #452.

## Test plan
- [x] `bun run typecheck`
- [x] `bun test ./tests/issue-452-empty-503.test.ts ./tests/shutdown-drain.test.ts ./tests/debug.test.ts`
- [ ] Reproduce #452: Codex against a routed openai-chat provider; confirm failures (if any) show a real message, and `ocx debug provider on` + `logs -f` shows openai-chat request lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error responses when upstream services return empty or unsuccessful responses.
  * Preserved relevant status details and validated retry timing information.
  * Standardized shutdown responses as JSON and included retry guidance.
  * Improved handling of streaming errors and truncated streams.
* **Diagnostics**
  * Added optional debug logging for outbound requests and stream failures while redacting sensitive credentials.
* **Tests**
  * Added coverage for upstream errors, shutdown behavior, retry headers, and diagnostic redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->