### PR TITLE
chore(gui): pin react-doctor to 0.9.1

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -50,7 +50,7 @@ jobs:
           directory: gui
           # Pin the npm engine — the action wrapper would otherwise fetch
           # react-doctor@latest, silently skewing CI from the local pinned runs.
-          version: "0.7.8"
+          version: "0.9.1"
           # Advisory contract: report to the step log only; never gate, never write.
           blocking: none
           comment: false

--- a/gui/README.md
+++ b/gui/README.md
@@ -49,6 +49,6 @@ bun run setup:hooks             # pre-push runs doctor when gui/ changed
 | Tool | Role |
 |------|------|
 | **ESLint** (`bun run lint`) | Hard gate in CI and expected before merge |
-| **React Doctor** (`bun run doctor`) | Advisory React health check pinned to react-doctor 0.7.8. Pre-push runs it only if `gui/` changed and never blocks the push. The CI workflow reports to the step log only |
+| **React Doctor** (`bun run doctor`) | Advisory React health check pinned to react-doctor 0.9.1. Pre-push runs it only if `gui/` changed and never blocks the push. The CI workflow reports to the step log only |
 
 Fix ESLint errors first. Use `doctor` / `doctor:full` for deeper React triage.

--- a/gui/package.json
+++ b/gui/package.json
@@ -9,8 +9,8 @@
     "lint": "eslint .",
     "test": "bun test tests",
     "lint:i18n": "eslint src/pages src/components src/App.tsx src/ui.tsx",
-    "doctor": "npx --yes react-doctor@0.7.8 --verbose --scope changed --base origin/main --no-telemetry",
-    "doctor:full": "npx --yes react-doctor@0.7.8 --verbose --scope full --no-telemetry",
+    "doctor": "npx --yes react-doctor@0.9.1 --verbose --scope changed --base origin/main --no-telemetry",
+    "doctor:full": "npx --yes react-doctor@0.9.1 --verbose --scope full --no-telemetry",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -228,9 +228,9 @@ describe("GitHub Actions hardening", () => {
     expect(workflow).not.toMatch(/uses:\s+\S+@(?:v\d+|main|master)\b/);
 
     // Engine pin: the action wrapper would fetch react-doctor@latest without it.
-    expect(workflow).toContain('version: "0.7.8"');
+    expect(workflow).toContain('version: "0.9.1"');
 
-    // Action pin must accept CLI JSON schemaVersion 3 (baseline reports from 0.7.8).
+    // Action pin must accept CLI JSON schemaVersion 3 (baseline reports from 0.9.1).
     // v2.1.0's ensure-json-report only knew schemas 1–2 and failed every PR scan.
     // Advisory + least privilege: read-only token, all write-scoped outputs off.
     // pull-requests: read is required so the action can list PR files for
@@ -249,7 +249,7 @@ describe("GitHub Actions hardening", () => {
     const guiPkg = await readText("gui/package.json");
     const rootPkg = await readText("package.json");
 
-    expect(guiPkg).toContain("react-doctor@0.7.8");
+    expect(guiPkg).toContain("react-doctor@0.9.1");
     expect(guiPkg).not.toContain("react-doctor@latest");
     expect(rootPkg).not.toContain("react-doctor@latest");
     expect(rootPkg).toContain('"doctor:gui:if-changed": "bun scripts/doctor-gui-if-changed.ts"');


### PR DESCRIPTION
## Summary
- Bump the advisory React Doctor engine pin from `0.7.8` to `0.9.1` in GUI scripts, CI workflow, README, and contract tests so local/`doctor:gui` and CI stay aligned.

## Test plan
- [x] `bun test tests/ci-workflows.test.ts`
- [ ] Confirm React Doctor CI workflow still runs advisory-only against `gui/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated React Doctor to version 0.9.1 across automated checks and project commands.
  * Refreshed documentation to reflect the updated React Doctor version.
* **Tests**
  * Updated validation checks to confirm React Doctor 0.9.1 is configured consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->