### PR TITLE
fix(gui): clear remaining react-doctor code findings

### DIFF
--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -14,7 +14,7 @@ import ClaudeCode from "./pages/ClaudeCode";
 import Startup from "./pages/Startup";
 import ErrorBoundary from "./components/ErrorBoundary";
 import { IconGrid, IconServer, IconBoxes, IconBot, IconList, IconActivity, IconHardDrive, IconKey, IconGithub, IconMenu, IconSun, IconMoon, IconMonitor, IconGlobe, IconPower, IconSparkle, IconX } from "./icons";
-import { useI18n, useT, LOCALES, type Locale, type TKey } from "./i18n";
+import { useI18n, useT, LOCALES, type Locale, type TKey } from "./i18n/shared";
 import { Select, Switch } from "./ui";
 import { installApiAuthFetch } from "./api";
 import { readJsonIfOk } from "./fetch-json";

--- a/gui/src/components/AddCodexAccountModal.tsx
+++ b/gui/src/components/AddCodexAccountModal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useReducer, useRef } from "react";
-import { useT } from "../i18n";
+import { useT } from "../i18n/shared";
 import {
   addCodexAccountUiReducer,
   initialAddCodexAccountUiState,

--- a/gui/src/components/AddProviderModal.tsx
+++ b/gui/src/components/AddProviderModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useReducer, useRef } from "react";
 import { IconX } from "../icons";
-import { useT } from "../i18n";
+import { useT } from "../i18n/shared";
 import { useKeyedClientResource } from "../client-resource";
 import {
   buildProviderPostBody,

--- a/gui/src/components/CodexAccountPool.tsx
+++ b/gui/src/components/CodexAccountPool.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { useT } from "../i18n";
+import { useT } from "../i18n/shared";
 import { IconPlus } from "../icons";
 import { Notice, EmptyState } from "../ui";
 import AddCodexAccountModal from "./AddCodexAccountModal";

--- a/gui/src/components/CodexAutoSwitchSetting.tsx
+++ b/gui/src/components/CodexAutoSwitchSetting.tsx
@@ -1,5 +1,5 @@
 import { useRef } from "react";
-import { useT } from "../i18n";
+import { useT } from "../i18n/shared";
 
 export type AutoSwitchFeedback = { tone: "ok" | "err"; message: string } | null;
 

--- a/gui/src/components/MemoryObservabilityCard.tsx
+++ b/gui/src/components/MemoryObservabilityCard.tsx
@@ -115,13 +115,17 @@ export default function MemoryObservabilityCard({ apiBase }: { apiBase: string }
       if (inFlight) return;
       inFlight = true;
       // Bound each poll so a hung request cannot pin inFlight forever and
-      // starve the unavailable fallback. AbortSignal.timeout avoids a manual
-      // setTimeout that the effect-cleanup detector cannot always see.
+      // starve the unavailable fallback. Prefer AbortSignal.timeout; fall back
+      // to a manual timer when the browser lacks AbortSignal.any/timeout.
       const controller = new AbortController();
       activeController = controller;
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
       const signal = typeof AbortSignal !== "undefined" && "any" in AbortSignal && "timeout" in AbortSignal
         ? AbortSignal.any([controller.signal, AbortSignal.timeout(10_000)])
-        : controller.signal;
+        : (() => {
+          timeoutId = setTimeout(() => controller.abort(), 10_000);
+          return controller.signal;
+        })();
       try {
         const res = await fetch(`${apiBase}/api/system/memory`, { signal });
         if (!res.ok) throw new Error("memory unavailable");
@@ -134,6 +138,7 @@ export default function MemoryObservabilityCard({ apiBase }: { apiBase: string }
         // Old servers (pre-#314) 404 this route; degrade to a quiet unavailable note.
         if (!cancelled) setUnavailable(true);
       } finally {
+        if (timeoutId !== undefined) clearTimeout(timeoutId);
         if (activeController === controller) activeController = null;
         inFlight = false;
       }

--- a/gui/src/components/MemoryObservabilityCard.tsx
+++ b/gui/src/components/MemoryObservabilityCard.tsx
@@ -42,15 +42,35 @@ interface SystemMemory {
  * memory diagnostic must not introduce. The number itself goes through the active locale so it
  * matches every other figure on this dashboard.
  */
+const byteNumberFormats = new Map<string, Intl.NumberFormat>();
+function byteNumberFormat(locale: Locale, fractionDigits: number): Intl.NumberFormat {
+  const key = `${locale}:${fractionDigits}`;
+  let fmt = byteNumberFormats.get(key);
+  if (!fmt) {
+    fmt = new Intl.NumberFormat(locale, {
+      minimumFractionDigits: fractionDigits,
+      maximumFractionDigits: fractionDigits,
+    });
+    byteNumberFormats.set(key, fmt);
+  }
+  return fmt;
+}
+const plainNumberFormats = new Map<string, Intl.NumberFormat>();
+function plainNumberFormat(locale: Locale): Intl.NumberFormat {
+  let fmt = plainNumberFormats.get(locale);
+  if (!fmt) {
+    fmt = new Intl.NumberFormat(locale);
+    plainNumberFormats.set(locale, fmt);
+  }
+  return fmt;
+}
+
 function formatBytes(bytes: number, locale: Locale): string {
   if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
   const units = ["B", "KiB", "MiB", "GiB", "TiB"];
   const exp = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
   const value = bytes / 1024 ** exp;
-  const formatted = new Intl.NumberFormat(locale, {
-    minimumFractionDigits: exp === 0 ? 0 : 1,
-    maximumFractionDigits: exp === 0 ? 0 : 1,
-  }).format(value);
+  const formatted = byteNumberFormat(locale, exp === 0 ? 0 : 1).format(value);
   return `${formatted} ${units[exp]}`;
 }
 
@@ -95,12 +115,15 @@ export default function MemoryObservabilityCard({ apiBase }: { apiBase: string }
       if (inFlight) return;
       inFlight = true;
       // Bound each poll so a hung request cannot pin inFlight forever and
-      // starve the unavailable fallback.
+      // starve the unavailable fallback. AbortSignal.timeout avoids a manual
+      // setTimeout that the effect-cleanup detector cannot always see.
       const controller = new AbortController();
       activeController = controller;
-      const timeout = setTimeout(() => controller.abort(), 10_000);
+      const signal = typeof AbortSignal !== "undefined" && "any" in AbortSignal && "timeout" in AbortSignal
+        ? AbortSignal.any([controller.signal, AbortSignal.timeout(10_000)])
+        : controller.signal;
       try {
-        const res = await fetch(`${apiBase}/api/system/memory`, { signal: controller.signal });
+        const res = await fetch(`${apiBase}/api/system/memory`, { signal });
         if (!res.ok) throw new Error("memory unavailable");
         const json = await res.json() as SystemMemory;
         if (!cancelled) {
@@ -111,7 +134,6 @@ export default function MemoryObservabilityCard({ apiBase }: { apiBase: string }
         // Old servers (pre-#314) 404 this route; degrade to a quiet unavailable note.
         if (!cancelled) setUnavailable(true);
       } finally {
-        clearTimeout(timeout);
         if (activeController === controller) activeController = null;
         inFlight = false;
       }
@@ -166,7 +188,7 @@ export default function MemoryObservabilityCard({ apiBase }: { apiBase: string }
         <div className="muted text-label" style={{ margin: "14px 0 6px" }}>{t("dash.mem.store")}</div>
         <div className="muted text-control" style={{ marginBottom: 10 }}>{t("dash.mem.storeHint")}</div>
         <div className="stat-row">
-          <Stat label={t("dash.mem.storeEntries")} value={responseState ? new Intl.NumberFormat(locale).format(responseState.count) : "—"} />
+          <Stat label={t("dash.mem.storeEntries")} value={responseState ? plainNumberFormat(locale).format(responseState.count) : "—"} />
           <Stat label={t("dash.mem.storeTotal")} value={responseState ? formatBytes(responseState.totalBytes, locale) : "—"} />
           <Stat label={t("dash.mem.storeLargest")} value={responseState ? formatBytes(responseState.largestBytes, locale) : "—"} />
           <Stat

--- a/gui/src/components/OAuthTosWarningModal.tsx
+++ b/gui/src/components/OAuthTosWarningModal.tsx
@@ -3,7 +3,7 @@
  * are restricted (or risky) when used outside the official client.
  */
 import { useCallback, useEffect, useId, useRef, useState } from "react";
-import { useT } from "../i18n";
+import { useT } from "../i18n/shared";
 import { IconAlert } from "../icons";
 import {
   oauthTosRisk,
@@ -68,26 +68,8 @@ export default function OAuthTosWarningModal({
        aria-describedby={bodyId}
       className="modal-overlay"
       onCancel={handleCancel}
-      onClick={onCancel}
-      onKeyDown={e => {
-        if (e.key !== "Tab") return;
-        const dialog = dialogRef.current;
-        if (!dialog) return;
-        const focusable = dialog.querySelectorAll<HTMLElement>(
-          "input:not([disabled]), button:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])",
-        );
-        if (focusable.length === 0) return;
-        const first = focusable.item(0);
-        const last = focusable.item(focusable.length - 1);
-        if (e.shiftKey && document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        } else if (!e.shiftKey && document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }}
     >
+      <button type="button" className="modal-backdrop-dismiss" aria-label={t("common.close")} tabIndex={-1} onClick={onCancel} />
       <div
         className="modal-card"
         onClick={e => e.stopPropagation()}

--- a/gui/src/components/QuotaBars.tsx
+++ b/gui/src/components/QuotaBars.tsx
@@ -1,5 +1,5 @@
-import type { Locale, TFn } from "../i18n";
-import { useI18n } from "../i18n";
+import type { Locale, TFn } from "../i18n/shared";
+import { useI18n } from "../i18n/shared";
 import { IconAlert } from "../icons";
 import { type AccountQuota, normalizeQuotaForPlan } from "../codex-quota-utils";
 
@@ -148,17 +148,17 @@ export default function QuotaBars({ quota, plan, threshold, t, className, layout
   if (layout === "stacked") {
     return (
       <div className={`quota-stacked${className ? ` ${className}` : ""}`}>
-        {rows.map((row, index) => (
-          <StackedQuotaRow key={`${row.limitLabel}-${index}`} row={row} threshold={threshold} t={t} locale={locale} />
+        {rows.map(row => (
+          <StackedQuotaRow key={row.limitLabel} row={row} threshold={threshold} t={t} locale={locale} />
         ))}
       </div>
     );
   }
   return (
     <div className={`quota-compact${className ? ` ${className}` : ""}`}>
-      {rows.map((row, index) => (
+      {rows.map(row => (
         <QuotaRow
-          key={`${row.label}-${index}`}
+          key={row.label}
           label={row.label}
           percent={row.percent}
           resetAt={row.resetAt}

--- a/gui/src/components/add-codex-account-pick-step.tsx
+++ b/gui/src/components/add-codex-account-pick-step.tsx
@@ -1,5 +1,5 @@
 import { IconGlobe } from "../icons";
-import { useT } from "../i18n";
+import { useT } from "../i18n/shared";
 
 export function AddCodexAccountPickStep({
   id,

--- a/gui/src/components/add-codex-account-waiting-step.tsx
+++ b/gui/src/components/add-codex-account-waiting-step.tsx
@@ -1,5 +1,5 @@
 import { IconLink } from "../icons";
-import { useT } from "../i18n";
+import { useT } from "../i18n/shared";
 import type { StatusTone } from "./add-codex-account-reducer";
 
 export function AddCodexAccountWaitingStep({

--- a/gui/src/components/add-provider-form-pane.tsx
+++ b/gui/src/components/add-provider-form-pane.tsx
@@ -1,5 +1,5 @@
 import { IconExternal, IconKey } from "../icons";
-import { useT } from "../i18n";
+import { useT } from "../i18n/shared";
 import type { CatalogPreset } from "./provider-catalog/provider-presets";
 import type { ProviderPayloadForm } from "../provider-payload";
 import { AddProviderField } from "./add-provider-modal-field";

--- a/gui/src/components/add-provider-oauth-pane.tsx
+++ b/gui/src/components/add-provider-oauth-pane.tsx
@@ -1,5 +1,5 @@
 import { IconLock } from "../icons";
-import { useT } from "../i18n";
+import { useT } from "../i18n/shared";
 import type { CatalogPreset } from "./provider-catalog/provider-presets";
 
 export function AddProviderOAuthPane({

--- a/gui/src/components/codex-account-pool-cards.tsx
+++ b/gui/src/components/codex-account-pool-cards.tsx
@@ -1,4 +1,4 @@
-import { useT } from "../i18n";
+import { useT } from "../i18n/shared";
 import { IconAlert, IconX } from "../icons";
 import type { CodexAccountEntry } from "./codex-account-pool-types";
 import type { CodexAccountModeState } from "../codex-multi-state";

--- a/gui/src/components/codex-account-pool-handlers.ts
+++ b/gui/src/components/codex-account-pool-handlers.ts
@@ -1,4 +1,4 @@
-import type { TFn } from "../i18n";
+import type { TFn } from "../i18n/shared";
 import { readJsonIfOk } from "../fetch-json";
 
 function remainingCreditsToast(

--- a/gui/src/components/codex-account-pool-helpers.tsx
+++ b/gui/src/components/codex-account-pool-helpers.tsx
@@ -1,4 +1,4 @@
-import type { TFn } from "../i18n";
+import type { TFn } from "../i18n/shared";
 import { IconTicket } from "../icons";
 import type { CodexAccountEntry } from "./codex-account-pool-types";
 import { daysUntil, formatCreditDate } from "./codex-account-pool-utils";

--- a/gui/src/components/codex-account-pool-main-card.tsx
+++ b/gui/src/components/codex-account-pool-main-card.tsx
@@ -4,7 +4,7 @@ import QuotaBars from "./QuotaBars";
 import { CodexTicketBadge } from "./codex-account-pool-helpers";
 import type { CodexAccountEntry } from "./codex-account-pool-types";
 import type { CodexAccountModeState } from "../codex-multi-state";
-import type { TFn } from "../i18n";
+import type { TFn } from "../i18n/shared";
 
 export function CodexAccountPoolMainCard({
   t,

--- a/gui/src/components/codex-account-reset-modal.tsx
+++ b/gui/src/components/codex-account-reset-modal.tsx
@@ -47,7 +47,7 @@ export function CodexAccountResetModal({
       onCancel={handleCancel}
      
     >
-      <button type="button" className="modal-backdrop-dismiss" aria-label={t("common.close")} onClick={onClose} />
+      <button type="button" className="modal-backdrop-dismiss" aria-label={t("common.close")} tabIndex={-1} onClick={onClose} />
       <div className="modal-card" onClick={e => e.stopPropagation()} role="document">
         {!resetConfirm ? (
           <>

--- a/gui/src/components/codex-account-reset-modal.tsx
+++ b/gui/src/components/codex-account-reset-modal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
-import { useT } from "../i18n";
+import { useT } from "../i18n/shared";
 import { IconAlert, IconTicket } from "../icons";
 import type { CodexAccountEntry } from "./codex-account-pool-types";
 import { CodexCreditItem } from "./codex-account-pool-helpers";
@@ -45,8 +45,9 @@ export function CodexAccountResetModal({
       className="modal-overlay"
       aria-labelledby="codex-reset-title"
       onCancel={handleCancel}
-      onClick={onClose}
+     
     >
+      <button type="button" className="modal-backdrop-dismiss" aria-label={t("common.close")} onClick={onClose} />
       <div className="modal-card" onClick={e => e.stopPropagation()} role="document">
         {!resetConfirm ? (
           <>

--- a/gui/src/components/codex-account-switch-modal.tsx
+++ b/gui/src/components/codex-account-switch-modal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
-import { useT } from "../i18n";
+import { useT } from "../i18n/shared";
 import { IconAlert } from "../icons";
 import type { CodexAccountEntry } from "./codex-account-pool-types";
 import type { CodexAccountModeState } from "../codex-multi-state";
@@ -38,8 +38,9 @@ export function CodexAccountSwitchModal({
       className="modal-overlay"
       aria-labelledby="codex-switch-title"
       onCancel={handleCancel}
-      onClick={onCancel}
+     
     >
+      <button type="button" className="modal-backdrop-dismiss" aria-label={t("common.close")} onClick={onCancel} />
       <div className="modal-card" onClick={e => e.stopPropagation()} role="document">
         <h3 id="codex-switch-title">{accountModeState === "direct"
           ? t("codexAuth.preparePoolTitle")

--- a/gui/src/components/codex-account-switch-modal.tsx
+++ b/gui/src/components/codex-account-switch-modal.tsx
@@ -40,7 +40,7 @@ export function CodexAccountSwitchModal({
       onCancel={handleCancel}
      
     >
-      <button type="button" className="modal-backdrop-dismiss" aria-label={t("common.close")} onClick={onCancel} />
+      <button type="button" className="modal-backdrop-dismiss" aria-label={t("common.close")} tabIndex={-1} onClick={onCancel} />
       <div className="modal-card" onClick={e => e.stopPropagation()} role="document">
         <h3 id="codex-switch-title">{accountModeState === "direct"
           ? t("codexAuth.preparePoolTitle")

--- a/gui/src/components/combo-workspace-add-modal.tsx
+++ b/gui/src/components/combo-workspace-add-modal.tsx
@@ -81,10 +81,8 @@ export function AddComboModal({
       className="modal-overlay"
       aria-labelledby="cwi-add-title"
       onCancel={handleCancel}
-      onClick={(e) => {
-        if (e.target === e.currentTarget) requestClose();
-      }}
     >
+      <button type="button" className="modal-backdrop-dismiss" aria-label={t("common.close")} tabIndex={-1} onClick={requestClose} />
       <div className="modal-card" style={{ width: "min(560px, 94vw)" }} onClick={(e) => e.stopPropagation()}>
         <div className="row" style={{ justifyContent: "space-between", marginBottom: 8 }}>
           <h3 id="cwi-add-title" style={{ margin: 0 }}>{t("cws.addTitle")}</h3>

--- a/gui/src/components/combo-workspace-dialogs.tsx
+++ b/gui/src/components/combo-workspace-dialogs.tsx
@@ -1,10 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useT } from "../i18n/shared";
 
-function dismissIfBackdrop(e: React.MouseEvent<HTMLDialogElement>, onDismiss: () => void) {
-  if (e.target === e.currentTarget) onDismiss();
-}
-
 export function RemoveComboDialog({
   model,
   onCancel,
@@ -33,8 +29,8 @@ export function RemoveComboDialog({
       className="modal-overlay"
       aria-labelledby="cwi-remove-title"
       onCancel={handleCancel}
-      onClick={(e) => dismissIfBackdrop(e, onCancel)}
     >
+      <button type="button" className="modal-backdrop-dismiss" aria-label={t("common.close")} tabIndex={-1} onClick={onCancel} />
       <div className="modal-card pwi-remove-confirm-card" onClick={(e) => e.stopPropagation()}>
         <h3 id="cwi-remove-title" className="pwi-remove-confirm-title">
           {t("cws.removeConfirmTitle", { model })}
@@ -75,8 +71,8 @@ export function UnsavedLeaveDialog({
       className="modal-overlay"
       aria-labelledby="cwi-unsaved-title"
       onCancel={handleCancel}
-      onClick={(e) => dismissIfBackdrop(e, onKeep)}
     >
+      <button type="button" className="modal-backdrop-dismiss" aria-label={t("common.close")} tabIndex={-1} onClick={onKeep} />
       <div className="modal-card pwi-json-unsaved-card" onClick={(e) => e.stopPropagation()}>
         <h3 id="cwi-unsaved-title" className="pwi-json-unsaved-title">{t("cws.unsavedTitle")}</h3>
         <p className="muted pwi-json-unsaved-desc">{t("cws.unsavedDesc")}</p>

--- a/gui/src/components/provider-catalog/ProviderCatalog.tsx
+++ b/gui/src/components/provider-catalog/ProviderCatalog.tsx
@@ -5,7 +5,7 @@
  * view state (tab, query) lives here; selection lifts up.
  */
 import { useMemo, useState } from "react";
-import { useT } from "../../i18n";
+import { useT } from "../../i18n/shared";
 import {
   bucketPresets,
   filterPresets,
@@ -24,15 +24,19 @@ export type AccountLoginRow = {
 
 export type CatalogTier = "accounts" | "free" | "paid";
 
+const EMPTY_USAGE_RANK: Record<string, number> = {};
+const EMPTY_ACCOUNT_ROWS: AccountLoginRow[] = [];
+const EMPTY_ACCOUNT_STATUS: Record<string, AccountLoginStatus> = {};
+
 export default function ProviderCatalog({
   presets,
-  usageRank = {},
+  usageRank = EMPTY_USAGE_RANK,
   presetsLoading = false,
   initialTier = "free",
   onSelectPreset,
   onSelectCustom,
-  accountRows = [],
-  accountStatus = {},
+  accountRows = EMPTY_ACCOUNT_ROWS,
+  accountStatus = EMPTY_ACCOUNT_STATUS,
   busyProvider = null,
   onLogin,
   onCancelLogin,
@@ -59,7 +63,7 @@ export default function ProviderCatalog({
   const catalog = useMemo(() => presets.filter(p => p.id !== "custom"), [presets]);
 
   /** Usage-ranked order: requests desc, then label (050a sortPresets is the no-usage fallback). */
-  const ranked = useMemo(() => [...catalog].sort((a, b) => {
+  const ranked = useMemo(() => catalog.toSorted((a, b) => {
     const ra = usageRank[a.id] ?? 0;
     const rb = usageRank[b.id] ?? 0;
     if (rb !== ra) return rb - ra;
@@ -90,7 +94,7 @@ export default function ProviderCatalog({
     <div className="provider-catalog">
       <div className="provider-catalog-tabs" role="tablist">
         {(["accounts", "free", "paid"] as const).map(candidate => (
-          <button
+          <button type="button"
             key={candidate}
             role="tab"
             aria-selected={tier === candidate}
@@ -120,7 +124,7 @@ export default function ProviderCatalog({
           <div className="muted text-control provider-catalog-empty">{t("modal.catalogLoading")}</div>
         )}
         {tier !== "accounts" && rows.map(p => (
-          <button key={p.id} className="list-row" onClick={() => onSelectPreset(p)}>
+          <button type="button" key={p.id} className="list-row" onClick={() => onSelectPreset(p)}>
             <div>
               <div className="title">{p.label}</div>
               <div className="sub"><code className="chip">{p.adapter}</code>{p.note ? ` · ${p.note}` : ""}</div>
@@ -152,7 +156,7 @@ export default function ProviderCatalog({
                       <a className="btn btn-ghost" href={row.href ?? "#codex-auth"}>{t("modal.accountManage")}</a>
                     )}
                     {onLogin && (
-                      <button
+                      <button type="button"
                         className={loggedIn ? "btn btn-ghost" : "btn btn-primary"}
                         disabled={busy}
                         onClick={() => { if (!busy) onLogin(row.id); }}
@@ -162,11 +166,11 @@ export default function ProviderCatalog({
                     )}
                   </>
                 ) : loggedIn ? (
-                  onLogout && <button className="btn btn-ghost" onClick={() => onLogout(row.id)}>{t("modal.accountLogout")}</button>
+                  onLogout && <button type="button" className="btn btn-ghost" onClick={() => onLogout(row.id)}>{t("modal.accountLogout")}</button>
                 ) : busy ? (
-                  onCancelLogin && <button className="btn btn-ghost" onClick={() => onCancelLogin(row.id)}>{t("common.cancel")}</button>
+                  onCancelLogin && <button type="button" className="btn btn-ghost" onClick={() => onCancelLogin(row.id)}>{t("common.cancel")}</button>
                 ) : (
-                  onLogin && <button className="btn btn-primary" onClick={() => onLogin(row.id)}>{t("modal.accountLogin")}</button>
+                  onLogin && <button type="button" className="btn btn-primary" onClick={() => onLogin(row.id)}>{t("modal.accountLogin")}</button>
                 )}
               </div>
             </div>
@@ -180,7 +184,7 @@ export default function ProviderCatalog({
       <div className="provider-catalog-footer">
         <div style={{ flex: 1 }} />
         {tier !== "accounts" && (
-          <button className="link-btn" onClick={onSelectCustom}>{t("modal.notListed")}</button>
+          <button type="button" className="link-btn" onClick={onSelectCustom}>{t("modal.notListed")}</button>
         )}
       </div>
     </div>

--- a/gui/src/components/provider-catalog/provider-presets.ts
+++ b/gui/src/components/provider-catalog/provider-presets.ts
@@ -68,8 +68,3 @@ export function filterPresets(presets: CatalogPreset[], query: string): CatalogP
   return presets.filter(p => p.label.toLowerCase().includes(q) || p.id.toLowerCase().includes(q));
 }
 
-/** Deterministic catalog order: label A→Z (case-insensitive), id as tiebreak. */
-export function sortPresets(presets: CatalogPreset[]): CatalogPreset[] {
-  return [...presets].sort((a, b) =>
-    a.label.localeCompare(b.label, undefined, { sensitivity: "base" }) || a.id.localeCompare(b.id));
-}

--- a/gui/src/components/provider-workspace/ProviderAuthPanel.tsx
+++ b/gui/src/components/provider-workspace/ProviderAuthPanel.tsx
@@ -4,7 +4,7 @@
  * handlers via props-down; no internal auth machinery.
  */
 import { useState } from "react";
-import { useT } from "../../i18n";
+import { useT } from "../../i18n/shared";
 import { IconLock, IconExternal, IconTrash } from "../../icons";
 import type { WorkspaceItem } from "../../provider-workspace/catalog";
 import { oauthAccountDisplayLabel, providerAuthSurface } from "../../provider-workspace/auth";
@@ -68,9 +68,12 @@ export default function ProviderAuthPanel({
     const key = newKey.trim();
     if (!key) return;
     setKeyBusy(true);
-    const ok = await authHandlers.onAddApiKey(item.name, key);
-    setKeyBusy(false);
-    if (ok) { setNewKey(""); setAddingKey(false); }
+    try {
+      const ok = await authHandlers.onAddApiKey(item.name, key);
+      if (ok) { setNewKey(""); setAddingKey(false); }
+    } finally {
+      setKeyBusy(false);
+    }
   };
 
   return (
@@ -149,12 +152,12 @@ export default function ProviderAuthPanel({
               </div>
             )}
             {accounts.length > 0 && (
-              <div className="pwi-auth-list" role="list">
+              <ul className="pwi-auth-list">
                 {accounts.map(account => {
                   const label = oauthAccountDisplayLabel(accounts, account, t);
                   const switching = switchingAccountId === account.id;
                   return (
-                  <div key={account.id} className={`pwi-auth-row${account.active ? " pwi-auth-row--active" : ""}`} role="listitem">
+                  <li key={account.id} className={`pwi-auth-row${account.active ? " pwi-auth-row--active" : ""}`}>
                     <button type="button" className="pwi-auth-row-main"
                       onClick={() => { if (!account.active && !account.needsReauth && !switchingAccountId) void authHandlers.onSwitchAccount(item.name, account); }}
                       aria-current={account.active ? "true" : undefined}
@@ -190,10 +193,10 @@ export default function ProviderAuthPanel({
                       onClick={() => void authHandlers.onRemoveAccount(item.name, account)}>
                       <IconTrash style={{ width: 13, height: 13 }} aria-hidden="true" />
                     </button>
-                  </div>
+                  </li>
                   );
                 })}
-              </div>
+              </ul>
             )}
             {accountLoadState === "ready" && loggedIn && accounts.length === 0 && (
               <div className="pwi-auth-state pwi-auth-state--empty">{t("pws.noAccounts")}</div>
@@ -210,9 +213,9 @@ export default function ProviderAuthPanel({
         {isKeyAuth && (
           <>
             {keys.length > 0 && (
-              <div className="pwi-auth-list" role="list">
+              <ul className="pwi-auth-list">
                 {keys.map(entry => (
-                  <div key={entry.id} className={`pwi-auth-row${entry.active ? " pwi-auth-row--active" : ""}`} role="listitem">
+                  <li key={entry.id} className={`pwi-auth-row${entry.active ? " pwi-auth-row--active" : ""}`}>
                     <button type="button" className="pwi-auth-row-main"
                       onClick={() => void authHandlers.onSwitchApiKey(item.name, entry)}
                       disabled={entry.active}>
@@ -233,9 +236,9 @@ export default function ProviderAuthPanel({
                       onClick={() => void authHandlers.onRemoveApiKey(item.name, entry)}>
                       <IconTrash style={{ width: 13, height: 13 }} aria-hidden="true" />
                     </button>
-                  </div>
+                  </li>
                 ))}
-              </div>
+              </ul>
             )}
             {addingKey ? (
               <div className="pwi-auth-add-key">

--- a/gui/src/components/provider-workspace/ProviderDetails.tsx
+++ b/gui/src/components/provider-workspace/ProviderDetails.tsx
@@ -3,7 +3,7 @@
  * and composes the Overview/Models/Usage/Settings panels.
  */
 import { useCallback, useMemo, useRef, useState } from "react";
-import { useT } from "../../i18n";
+import { useT } from "../../i18n/shared";
 import type { WorkspaceItem } from "../../provider-workspace/catalog";
 import { formatProviderDisplayName } from "../../provider-icons";
 import { isFreeProvider } from "../../provider-workspace/catalog";

--- a/gui/src/components/provider-workspace/ProviderDialogs.tsx
+++ b/gui/src/components/provider-workspace/ProviderDialogs.tsx
@@ -2,7 +2,7 @@
  * ProviderDialogs — confirmation and warning dialogs for the workspace
  * Settings tab (WP091): remove provider, unsaved-leave, JSON save-before-leave.
  */
-import { useT } from "../../i18n";
+import { useT } from "../../i18n/shared";
 
 export function RemoveConfirmDialog({
   providerName, onConfirm, onCancel,

--- a/gui/src/components/provider-workspace/ProviderJsonEditor.tsx
+++ b/gui/src/components/provider-workspace/ProviderJsonEditor.tsx
@@ -3,7 +3,7 @@
  * Dirty/leave/save guards are managed via the parent's jsonEditor prop contract.
  */
 import { useRef, useEffect } from "react";
-import { useT } from "../../i18n";
+import { useT } from "../../i18n/shared";
 
 export interface JsonEditorState {
   open: boolean;
@@ -55,6 +55,7 @@ export default function ProviderJsonEditor({
         onChange={e => editor.onDraftChange(e.target.value)}
         spellCheck={false}
         rows={20}
+        aria-label={t("pws.jsonEditorDesc")}
       />
       {message && (
         <div className={message.ok ? "pwi-settings-msg pwi-settings-msg--ok" : "pwi-settings-msg pwi-settings-msg--err"}>

--- a/gui/src/components/provider-workspace/ProviderModels.tsx
+++ b/gui/src/components/provider-workspace/ProviderModels.tsx
@@ -4,7 +4,7 @@
  * short lists fill horizontal space instead of a tall single-column stack.
  */
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useT } from "../../i18n";
+import { useT } from "../../i18n/shared";
 import type { WorkspaceItem } from "../../provider-workspace/catalog";
 import { filterModels } from "../../provider-workspace/report";
 
@@ -62,12 +62,11 @@ export default function ProviderModels({
 
   useEffect(() => {
     let active = true;
-    void fetch(`${apiBase}/api/custom-models`)
-      .then(response => {
+    const load = async () => {
+      try {
+        const response = await fetch(`${apiBase}/api/custom-models`);
         if (!response.ok) throw new Error();
-        return response.json();
-      })
-      .then((rows: unknown) => {
+        const rows: unknown = await response.json();
         if (!Array.isArray(rows)) throw new Error("Invalid custom model list");
         if (!active) return;
         setCustomModelIds(rows.flatMap(row => {
@@ -78,8 +77,7 @@ export default function ProviderModels({
         setCustomModelsLoadFailed(false);
         setCustomError("");
         setCustomModelsReady(true);
-      })
-      .catch(() => {
+      } catch {
         if (!active) return;
         setCustomModelIds([]);
         // Without this the component stays permanently unable to add a model: `customModelsReady`
@@ -88,7 +86,9 @@ export default function ProviderModels({
         setCustomModelsReady(false);
         setCustomModelsLoadFailed(true);
         setCustomError(t("models.networkError"));
-      });
+      }
+    };
+    void load();
     return () => { active = false; };
   }, [apiBase, item.name, t, customModelsLoadEpoch]);
 
@@ -236,13 +236,13 @@ export default function ProviderModels({
       ) : models.length === 0 ? (
         <p className="muted" role="status">{t("pws.noModelMatch")}</p>
       ) : (
-        <div className="pws-model-list" role="list">
+        <div className="pws-model-list">
           {visibleModels.map(modelId => {
             const isDefault = modelId === item.defaultModel;
             const isSelected = selectedSet.has(modelId);
             const copied = copiedId === modelId;
             return (
-              <div key={modelId} className="pws-model-chip" role="listitem">
+              <div key={modelId} className="pws-model-chip">
                 <button
                   type="button"
                   className="pws-model-chip-main"

--- a/gui/src/components/provider-workspace/ProviderModels.tsx
+++ b/gui/src/components/provider-workspace/ProviderModels.tsx
@@ -236,13 +236,13 @@ export default function ProviderModels({
       ) : models.length === 0 ? (
         <p className="muted" role="status">{t("pws.noModelMatch")}</p>
       ) : (
-        <div className="pws-model-list">
+        <ul className="pws-model-list">
           {visibleModels.map(modelId => {
             const isDefault = modelId === item.defaultModel;
             const isSelected = selectedSet.has(modelId);
             const copied = copiedId === modelId;
             return (
-              <div key={modelId} className="pws-model-chip">
+              <li key={modelId} className="pws-model-chip">
                 <button
                   type="button"
                   className="pws-model-chip-main"
@@ -254,10 +254,10 @@ export default function ProviderModels({
                 </button>
                 {isDefault ? <span className="badge badge-muted pws-model-flag">{t("prov.defaultBadge")}</span> : null}
                 {isSelected ? <span className="badge badge-accent pws-model-flag">{t("pws.selected")}</span> : null}
-              </div>
+              </li>
             );
           })}
-        </div>
+        </ul>
       )}
       {capped && (
         <p className="muted text-label" style={{ marginTop: 10 }}>

--- a/gui/src/components/provider-workspace/ProviderOverview.tsx
+++ b/gui/src/components/provider-workspace/ProviderOverview.tsx
@@ -2,7 +2,7 @@
  * ProviderOverview — 2-column layout: left (CONNECTION + Auth summary) / right
  * (STATS + Notes). Phase 030 of workspace design parity.
  */
-import { useCallback, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { useT, useI18n } from "../../i18n/shared";
 import { IconAlert, IconCheck } from "../../icons";
 import { binProviderStatus, type WorkspaceItem } from "../../provider-workspace/catalog";
@@ -196,22 +196,34 @@ function NotesSection({ item, onUpdateProvider }: {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
   const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (editing) textareaRef.current?.focus();
+  }, [editing]);
 
   const save = useCallback(async () => {
     if (saving || !onUpdateProvider) return;
     const trimmed = draft.trim();
     if (trimmed === (item.note ?? "")) {
       setEditing(false);
+      setError("");
       return;
     }
     setSaving(true);
     try {
-      await onUpdateProvider(item.name, { note: trimmed || undefined });
+      const result = await onUpdateProvider(item.name, { note: trimmed || undefined });
+      if (!result.ok) {
+        setError(result.error || t("prov.saveFailed"));
+        return;
+      }
+      setError("");
       setEditing(false);
     } finally {
       setSaving(false);
     }
-  }, [draft, item.name, item.note, onUpdateProvider, saving]);
+  }, [draft, item.name, item.note, onUpdateProvider, saving, t]);
 
   if (!editing) {
     return (
@@ -223,6 +235,7 @@ function NotesSection({ item, onUpdateProvider }: {
           onClick={() => {
             if (!onUpdateProvider) return;
             setDraft(item.note ?? "");
+            setError("");
             setEditing(true);
           }}
           disabled={!onUpdateProvider}
@@ -237,17 +250,19 @@ function NotesSection({ item, onUpdateProvider }: {
     <section className="pws-section pws-notes-section" aria-label={t("pws.notes")}>
       <h3 className="pws-section-title">{t("pws.notes")}</h3>
       <textarea
+        ref={textareaRef}
         className="pws-notes-textarea"
         value={draft}
         onChange={e => setDraft(e.target.value)}
         onBlur={() => void save()}
         onKeyDown={e => {
-          if (e.key === "Escape") { setDraft(item.note ?? ""); setEditing(false); }
+          if (e.key === "Escape") { setDraft(item.note ?? ""); setError(""); setEditing(false); }
         }}
         placeholder={t("pws.notePlaceholder")}
         rows={3}
         disabled={saving}
       />
+      {error ? <p className="pws-inline-error" role="alert">{error}</p> : null}
     </section>
   );
 }

--- a/gui/src/components/provider-workspace/ProviderOverview.tsx
+++ b/gui/src/components/provider-workspace/ProviderOverview.tsx
@@ -3,7 +3,7 @@
  * (STATS + Notes). Phase 030 of workspace design parity.
  */
 import { useCallback, useState, type ReactNode } from "react";
-import { useT, useI18n } from "../../i18n";
+import { useT, useI18n } from "../../i18n/shared";
 import { IconAlert, IconCheck } from "../../icons";
 import { binProviderStatus, type WorkspaceItem } from "../../provider-workspace/catalog";
 import { formatRelativeTime, relativeTimeLabelsFromT, formatRequestCount, formatTokenCount } from "../../provider-workspace/usage";
@@ -205,9 +205,12 @@ function NotesSection({ item, onUpdateProvider }: {
       return;
     }
     setSaving(true);
-    await onUpdateProvider(item.name, { note: trimmed || undefined });
-    setSaving(false);
-    setEditing(false);
+    try {
+      await onUpdateProvider(item.name, { note: trimmed || undefined });
+      setEditing(false);
+    } finally {
+      setSaving(false);
+    }
   }, [draft, item.name, item.note, onUpdateProvider, saving]);
 
   if (!editing) {
@@ -242,7 +245,6 @@ function NotesSection({ item, onUpdateProvider }: {
           if (e.key === "Escape") { setDraft(item.note ?? ""); setEditing(false); }
         }}
         placeholder={t("pws.notePlaceholder")}
-        autoFocus
         rows={3}
         disabled={saving}
       />

--- a/gui/src/components/provider-workspace/ProviderOverviewDashboard.tsx
+++ b/gui/src/components/provider-workspace/ProviderOverviewDashboard.tsx
@@ -4,7 +4,7 @@
  * recently-used ranking, and Edit JSON entry.
  */
 import { useMemo } from "react";
-import { useT, useI18n } from "../../i18n";
+import { useT, useI18n } from "../../i18n/shared";
 import { IconAlert, IconChevron } from "../../icons";
 import type { WorkspaceSections, WorkspaceItem } from "../../provider-workspace/catalog";
 import { accountQuotaFromReport, type ProviderQuotaReportView } from "../../provider-workspace/report";

--- a/gui/src/components/provider-workspace/ProviderRail.tsx
+++ b/gui/src/components/provider-workspace/ProviderRail.tsx
@@ -4,7 +4,7 @@
  * chrome) arrives in WP080b; detail panels in WP090/091.
  */
 /* eslint-disable react-refresh/only-export-components -- label helpers co-locate with the rail row */
-import { useT, type TFn } from "../../i18n";
+import { useT, type TFn } from "../../i18n/shared";
 import { IconServer, IconStar } from "../../icons";
 import {
   binProviderStatus,

--- a/gui/src/components/provider-workspace/ProviderSettings.tsx
+++ b/gui/src/components/provider-workspace/ProviderSettings.tsx
@@ -10,7 +10,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { baseUrlForChoice, matchChoiceId, resolvedBaseUrlForChoice } from "../../base-url-choice";
 import { readJsonIfOk } from "../../fetch-json";
-import { useT } from "../../i18n";
+import { useT } from "../../i18n/shared";
 import { IconLock } from "../../icons";
 import { isCatalogProviderId } from "../../provider-icons";
 import type { CatalogPreset } from "../provider-catalog/provider-presets";
@@ -18,11 +18,12 @@ import { authModeLabel } from "./ProviderRail";
 import type { WorkspaceItem, ProviderUpdatePatch } from "./types";
 
 const ADAPTERS = ["openai-responses", "openai-chat", "anthropic", "google", "azure-openai", "cursor"] as const;
+const EMPTY_MODELS: string[] = [];
 
 type ChoicesStatus = "idle" | "loading" | "ready" | "error";
 
 export default function ProviderSettings({
-  item, availableModels = [], apiBase, onUpdateProvider, onDirtyChange, onRegisterSave,
+  item, availableModels = EMPTY_MODELS, apiBase, onUpdateProvider, onDirtyChange, onRegisterSave,
 }: {
   item: WorkspaceItem;
   availableModels?: string[];

--- a/gui/src/components/provider-workspace/ProviderUsage.tsx
+++ b/gui/src/components/provider-workspace/ProviderUsage.tsx
@@ -3,7 +3,7 @@
  * per-model cost breakdown table, and rate-limit windows on QuotaBars.
  */
 import { useMemo, useState } from "react";
-import { useT, useI18n } from "../../i18n";
+import { useT, useI18n } from "../../i18n/shared";
 import QuotaBars from "../QuotaBars";
 import type { WorkspaceItem } from "../../provider-workspace/catalog";
 import { formatRelativeTime, relativeTimeLabelsFromT, formatRequestCount, formatTokenCount, formatCostUsd } from "../../provider-workspace/usage";
@@ -26,7 +26,7 @@ export default function ProviderUsage({ item, usageTotals, quotaReport, modelUsa
 
   const sortedModels = useMemo(() => {
     if (!modelUsage?.length) return [];
-    return [...modelUsage].sort((a, b) => b.totalTokens - a.totalTokens);
+    return modelUsage.toSorted((a, b) => b.totalTokens - a.totalTokens);
   }, [modelUsage]);
 
   const providerCost = useMemo(() => {
@@ -89,7 +89,21 @@ export default function ProviderUsage({ item, usageTotals, quotaReport, modelUsa
                   const isExpanded = expandedModel === key;
                   return (
                     <>
-                      <tr key={key} className="pws-model-row" onClick={() => setExpandedModel(isExpanded ? null : key)} style={{ cursor: "pointer" }}>
+                      <tr
+                        key={key}
+                        className="pws-model-row"
+                        onClick={() => setExpandedModel(isExpanded ? null : key)}
+                        onKeyDown={e => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            setExpandedModel(isExpanded ? null : key);
+                          }
+                        }}
+                        tabIndex={0}
+                        role="button"
+                        aria-expanded={isExpanded}
+                        style={{ cursor: "pointer" }}
+                      >
                         <td className="mono">{row.model}</td>
                         <td className="num mono">{formatCostUsd(row.estimatedCostUsd, locale)}</td>
                         <td className="num mono">{formatTokenCount(row.totalTokens, locale)}</td>

--- a/gui/src/components/provider-workspace/ProviderUsage.tsx
+++ b/gui/src/components/provider-workspace/ProviderUsage.tsx
@@ -2,7 +2,7 @@
  * ProviderUsage — the usage tab (WP090): 30-day cost/request/token metrics,
  * per-model cost breakdown table, and rate-limit windows on QuotaBars.
  */
-import { useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import { useT, useI18n } from "../../i18n/shared";
 import QuotaBars from "../QuotaBars";
 import type { WorkspaceItem } from "../../provider-workspace/catalog";
@@ -88,23 +88,18 @@ export default function ProviderUsage({ item, usageTotals, quotaReport, modelUsa
                   const key = row.model;
                   const isExpanded = expandedModel === key;
                   return (
-                    <>
-                      <tr
-                        key={key}
-                        className="pws-model-row"
-                        onClick={() => setExpandedModel(isExpanded ? null : key)}
-                        onKeyDown={e => {
-                          if (e.key === "Enter" || e.key === " ") {
-                            e.preventDefault();
-                            setExpandedModel(isExpanded ? null : key);
-                          }
-                        }}
-                        tabIndex={0}
-                        role="button"
-                        aria-expanded={isExpanded}
-                        style={{ cursor: "pointer" }}
-                      >
-                        <td className="mono">{row.model}</td>
+                    <Fragment key={key}>
+                      <tr className="pws-model-row">
+                        <td className="mono">
+                          <button
+                            type="button"
+                            className="pws-model-expand"
+                            aria-expanded={isExpanded}
+                            onClick={() => setExpandedModel(isExpanded ? null : key)}
+                          >
+                            {row.model}
+                          </button>
+                        </td>
                         <td className="num mono">{formatCostUsd(row.estimatedCostUsd, locale)}</td>
                         <td className="num mono">{formatTokenCount(row.totalTokens, locale)}</td>
                         <td className="num">{row.requests}</td>
@@ -115,7 +110,7 @@ export default function ProviderUsage({ item, usageTotals, quotaReport, modelUsa
                         </td>
                       </tr>
                       {isExpanded && (
-                        <tr key={`${key}-detail`} className="pws-model-detail">
+                        <tr className="pws-model-detail">
                           <td colSpan={5}>
                             <div className="pws-model-detail-grid">
                               <div>
@@ -130,7 +125,7 @@ export default function ProviderUsage({ item, usageTotals, quotaReport, modelUsa
                           </td>
                         </tr>
                       )}
-                    </>
+                    </Fragment>
                   );
                 })}
               </tbody>

--- a/gui/src/components/provider-workspace/ProviderWorkspaceShell.tsx
+++ b/gui/src/components/provider-workspace/ProviderWorkspaceShell.tsx
@@ -322,14 +322,14 @@ export default function ProviderWorkspaceShell({
               className={`pws-filter-btn${filterActive || filterOpen ? " pws-filter-btn--active" : ""}`}
               onClick={() => setFilterOpen(open => !open)}
               aria-label={t("pws.filterAria")}
-              aria-haspopup="menu"
               aria-expanded={filterOpen}
+              aria-controls="pws-provider-filters"
             >
               <IconFilter width={18} height={18} aria-hidden="true" />
               {filterActive && <span className="pws-filter-dot" aria-hidden="true" />}
             </button>
             {filterOpen && (
-              <div className="pws-filter-menu" role="group" aria-label={t("pws.providerFiltersAria")}>
+              <div id="pws-provider-filters" className="pws-filter-menu" role="group" aria-label={t("pws.providerFiltersAria")}>
                 <div className="pws-filter-title">{t("pws.filters")}</div>
                 <div className="pws-filter-head">{t("pws.filterStatus")}</div>
                 {statusFilterOptions.map(({ key, label, count }) => (

--- a/gui/src/components/provider-workspace/ProviderWorkspaceShell.tsx
+++ b/gui/src/components/provider-workspace/ProviderWorkspaceShell.tsx
@@ -5,7 +5,7 @@
  * arrive in WP090/091; until then the slot renders a real placeholder message.
  */
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { useT } from "../../i18n";
+import { useT } from "../../i18n/shared";
 import { IconFilter, IconSearch, IconBoxes, IconGlobe, IconLock, IconKey, IconTrash } from "../../icons";
 import {
   applyActiveAccountReauth,
@@ -272,7 +272,11 @@ export default function ProviderWorkspaceShell({
       const label = formatProviderDisplayName(item.name);
       counts.set(label, (counts.get(label) ?? 0) + 1);
     }
-    return new Set([...counts.entries()].filter(([, n]) => n > 1).map(([label]) => label));
+    const dups = new Set<string>();
+    for (const [label, n] of counts.entries()) {
+      if (n > 1) dups.add(label);
+    }
+    return dups;
   }, [allItems]);
 
   if (allItems.length === 0) {
@@ -325,11 +329,11 @@ export default function ProviderWorkspaceShell({
               {filterActive && <span className="pws-filter-dot" aria-hidden="true" />}
             </button>
             {filterOpen && (
-              <div className="pws-filter-menu" role="menu" aria-label={t("pws.providerFiltersAria")}>
+              <div className="pws-filter-menu" role="group" aria-label={t("pws.providerFiltersAria")}>
                 <div className="pws-filter-title">{t("pws.filters")}</div>
                 <div className="pws-filter-head">{t("pws.filterStatus")}</div>
                 {statusFilterOptions.map(({ key, label, count }) => (
-                  <label key={key} className="pws-filter-option" role="menuitemcheckbox" aria-checked={statusFilter[key]}>
+                  <label key={key} className="pws-filter-option">
                     <input
                       type="checkbox"
                       checked={statusFilter[key]}
@@ -340,12 +344,12 @@ export default function ProviderWorkspaceShell({
                   </label>
                 ))}
                 <div className="pws-filter-head">{t("pws.pricing")}</div>
-                <label className="pws-filter-option" role="menuitemcheckbox" aria-checked={pricingFilter.free}>
+                <label className="pws-filter-option">
                   <input type="checkbox" checked={pricingFilter.free} onChange={() => setPricingFilter(prev => ({ ...prev, free: !prev.free }))} />
                   <span className="pws-filter-label">{t("modal.badge.free")}</span>
                   <span className="pws-filter-count">{freeCount}</span>
                 </label>
-                <label className="pws-filter-option" role="menuitemcheckbox" aria-checked={pricingFilter.paid}>
+                <label className="pws-filter-option">
                   <input type="checkbox" checked={pricingFilter.paid} onChange={() => setPricingFilter(prev => ({ ...prev, paid: !prev.paid }))} />
                   <span className="pws-filter-label">{t("pws.paid")}</span>
                   <span className="pws-filter-count">{paidCount}</span>
@@ -357,7 +361,7 @@ export default function ProviderWorkspaceShell({
                   { key: "selfHosted" as const, label: t("pws.type.selfHosted"), count: typeCounts.selfHosted },
                   { key: "login" as const, label: t("pws.type.login"), count: typeCounts.login },
                 ]).map(({ key, label, count }) => (
-                  <label key={key} className="pws-filter-option" role="menuitemcheckbox" aria-checked={typeFilter[key]}>
+                  <label key={key} className="pws-filter-option">
                     <input
                       type="checkbox"
                       checked={typeFilter[key]}

--- a/gui/src/components/use-add-codex-account-oauth.ts
+++ b/gui/src/components/use-add-codex-account-oauth.ts
@@ -5,7 +5,7 @@ import type {
   AddCodexAccountUiAction,
   ManualCodeState,
 } from "./add-codex-account-reducer";
-import type { TFn } from "../i18n";
+import type { TFn } from "../i18n/shared";
 import { readJsonIfOk, readJsonOrThrow } from "../fetch-json";
 
 export function useAddCodexAccountOAuth({

--- a/gui/src/components/use-add-provider-oauth.ts
+++ b/gui/src/components/use-add-provider-oauth.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import type { TFn } from "../i18n";
+import type { TFn } from "../i18n/shared";
 import { readJsonIfOk } from "../fetch-json";
 
 export function useAddProviderOAuth({

--- a/gui/src/formatUptime.ts
+++ b/gui/src/formatUptime.ts
@@ -1,4 +1,4 @@
-import type { Locale } from "./i18n";
+import type { Locale } from "./i18n/shared";
 
 const UPTIME_UNITS: Record<Locale, { day: string; hour: string; minute: string; second: string }> = {
   en: { day: "d", hour: "h", minute: "m", second: "s" },

--- a/gui/src/hooks/useCodexAutoSwitch.ts
+++ b/gui/src/hooks/useCodexAutoSwitch.ts
@@ -146,19 +146,22 @@ export function useCodexAutoSwitch(
     clearFeedback();
     setSaving(true);
     revisionRef.current += 1;
-    const ok = await putAutoSwitchThreshold(apiBase, next);
-    revisionRef.current += 1;
-    savingRef.current = false;
-    if (ok) {
-      deferredServerValueRef.current = null;
-      apply(next);
-      if (showSuccess) showFeedback(messages.updated, false);
-    } else {
-      if (!reconcileDeferred()) apply(previous);
-      showFeedback(messages.updateFailed, true);
+    try {
+      const ok = await putAutoSwitchThreshold(apiBase, next);
+      revisionRef.current += 1;
+      if (ok) {
+        deferredServerValueRef.current = null;
+        apply(next);
+        if (showSuccess) showFeedback(messages.updated, false);
+      } else {
+        if (!reconcileDeferred()) apply(previous);
+        showFeedback(messages.updateFailed, true);
+      }
+      return ok;
+    } finally {
+      savingRef.current = false;
+      setSaving(false);
     }
-    setSaving(false);
-    return ok;
   }, [apiBase, apply, clearFeedback, messages.updateFailed, messages.updated, reconcileDeferred, showFeedback]);
 
   const rejectDraft = useCallback(() => {

--- a/gui/src/hooks/useJsonConfigEditor.ts
+++ b/gui/src/hooks/useJsonConfigEditor.ts
@@ -37,21 +37,21 @@ export function useJsonConfigEditor(deps: {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(parsed),
       });
-      if (res.ok) {
-        notify(t("prov.saved"), true);
-        setEditing(false);
-        setJsonEditorOpen(false);
-        jsonEditorOpenRef.current = false;
-        setJsonLeaveOpen(false);
-        setJsonBaseline(JSON.stringify(parsed, null, 2));
-        fetchConfig();
-        fetchProviderQuotas(true);
-        onSaved();
-        return true;
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({})) as { error?: string };
+        notify(data.error || t("prov.saveFailed"), false);
+        return false;
       }
-      const data = await res.json().catch(() => ({})) as { error?: string };
-      notify(data.error || t("prov.saveFailed"), false);
-      return false;
+      notify(t("prov.saved"), true);
+      setEditing(false);
+      setJsonEditorOpen(false);
+      jsonEditorOpenRef.current = false;
+      setJsonLeaveOpen(false);
+      setJsonBaseline(JSON.stringify(parsed, null, 2));
+      fetchConfig();
+      fetchProviderQuotas(true);
+      onSaved();
+      return true;
     } catch {
       notify(t("prov.invalidJson"), false);
       return false;

--- a/gui/src/hooks/useProviderAccountPools.ts
+++ b/gui/src/hooks/useProviderAccountPools.ts
@@ -67,7 +67,7 @@ export function useProviderAccountPools(deps: {
 
   const fetchKeyPools = useCallback(async (providers: string[]) => {
     const entries = await Promise.all(providers.map(async name => {
-      const data = await fetch(`${apiBase}/api/providers/keys?name=${encodeURIComponent(name)}`).then(r => r.json()).catch(() => null) as { keys?: ApiKeyEntry[] } | null;
+      const data = await fetch(`${apiBase}/api/providers/keys?name=${encodeURIComponent(name)}`).then(async r => { if (!r.ok) throw new Error(String(r.status)); return r.json(); }).catch(() => null) as { keys?: ApiKeyEntry[] } | null;
       return [name, data?.keys ?? []] as const;
     }));
     setKeyPools(Object.fromEntries(entries));
@@ -125,18 +125,18 @@ export function useProviderAccountPools(deps: {
     if (!key) return false;
     try {
       const res = await fetch(`${apiBase}/api/providers/keys`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ name: provider, key }) });
-      if (res.ok) {
-        notify(t("prov.keyAdded", { name: provider }), true);
-        setAddingKeyFor(null);
-        await Promise.all([
-          fetchKeyPools(Object.keys(keyPools).includes(provider) ? Object.keys(keyPools) : [...Object.keys(keyPools), provider]),
-          fetchConfig(), fetchProviderQuotas(true),
-        ]);
-        return true;
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({})) as { error?: string };
+        notify(data.error || t("prov.keyAddFail"), false);
+        return false;
       }
-      const data = await res.json().catch(() => ({})) as { error?: string };
-      notify(data.error || t("prov.keyAddFail"), false);
-      return false;
+      notify(t("prov.keyAdded", { name: provider }), true);
+      setAddingKeyFor(null);
+      await Promise.all([
+        fetchKeyPools(Object.keys(keyPools).includes(provider) ? Object.keys(keyPools) : [...Object.keys(keyPools), provider]),
+        fetchConfig(), fetchProviderQuotas(true),
+      ]);
+      return true;
     } catch {
       notify(t("prov.keyAddFail"), false);
       return false;

--- a/gui/src/icons.tsx
+++ b/gui/src/icons.tsx
@@ -8,7 +8,6 @@ const S = (props: P) => ({
 });
 
 export const IconGrid = (p: P) => (<svg {...S(p)}><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg>);
-export const IconLayoutSidebar = (p: P) => (<svg {...S(p)}><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M9 3v18"/></svg>);
 export const IconServer = (p: P) => (<svg {...S(p)}><rect x="3" y="4" width="18" height="7" rx="2"/><rect x="3" y="13" width="18" height="7" rx="2"/><path d="M7 7.5h.01M7 16.5h.01"/></svg>);
 export const IconBoxes = (p: P) => (<svg {...S(p)}><path d="M12 2 4 6v6l8 4 8-4V6l-8-4Z"/><path d="m4 6 8 4 8-4M12 10v8"/></svg>);
 export const IconBot = (p: P) => (<svg {...S(p)}><rect x="4" y="8" width="16" height="11" rx="3"/><path d="M12 8V4M8 2h8"/><circle cx="9" cy="13" r="1"/><circle cx="15" cy="13" r="1"/></svg>);

--- a/gui/src/main.tsx
+++ b/gui/src/main.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
-import { LanguageProvider } from "./i18n";
+import { LanguageProvider } from "./i18n/provider";
 import "./styles.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/gui/src/pages/ClaudeCode.tsx
+++ b/gui/src/pages/ClaudeCode.tsx
@@ -12,7 +12,7 @@ import {
   ClaudeCodeSettingsCard,
 } from "./claude-code-sections";
 import { serializeSidecarOverride } from "./claude-code-sidecar";
-import { formatCompactWindow, type ClaudeCodeState, type MapRow } from "./claude-code-types";
+import { formatCompactWindow, newClientId, type ClaudeCodeState, type MapRow } from "./claude-code-types";
 import { SmallFastModelSetting } from "./claude-code-settings";
 
 export { AutoConnectSetting, SmallFastModelSetting } from "./claude-code-settings";
@@ -50,7 +50,7 @@ export default function ClaudeCode({ apiBase }: { apiBase: string }) {
         injectAgents: r.injectAgents !== false,
         effectiveModelEnv: r.effectiveModelEnv ?? {},
       });
-      setRows(Object.entries(r.modelMap ?? {}).map(([from, to]) => ({ id: crypto.randomUUID(), from, to: String(to) })));
+      setRows(Object.entries(r.modelMap ?? {}).map(([from, to]) => ({ id: newClientId(), from, to: String(to) })));
     } catch (error) {
       setOk(false);
       setStatus(error instanceof Error && error.message ? error.message : t("claude.loadFail"));

--- a/gui/src/pages/ClaudeCode.tsx
+++ b/gui/src/pages/ClaudeCode.tsx
@@ -50,7 +50,7 @@ export default function ClaudeCode({ apiBase }: { apiBase: string }) {
         injectAgents: r.injectAgents !== false,
         effectiveModelEnv: r.effectiveModelEnv ?? {},
       });
-      setRows(Object.entries(r.modelMap ?? {}).map(([from, to]) => ({ from, to: String(to) })));
+      setRows(Object.entries(r.modelMap ?? {}).map(([from, to]) => ({ id: crypto.randomUUID(), from, to: String(to) })));
     } catch (error) {
       setOk(false);
       setStatus(error instanceof Error && error.message ? error.message : t("claude.loadFail"));

--- a/gui/src/pages/CodexAuth.tsx
+++ b/gui/src/pages/CodexAuth.tsx
@@ -95,7 +95,10 @@ export default function CodexAuth({ apiBase }: { apiBase: string }) {
       const mode = codexAccountModeState(config);
       setBannerState(mode);
       setAccountModeState(mode);
-    } catch { /* banner degrades to no badge */ }
+    } catch {
+      setBannerState(null);
+      setAccountModeState(null);
+    }
   }, [apiBase]);
 
   useEffect(() => {

--- a/gui/src/pages/CodexAuth.tsx
+++ b/gui/src/pages/CodexAuth.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { useT } from "../i18n";
+import { useT } from "../i18n/shared";
 import CodexAccountPool from "../components/CodexAccountPool";
 import { codexAccountModeState, type CodexAccountModeState } from "../codex-multi-state";
 import { ensureOpenAiProvider, openAiAccountProviderState, OpenAiEnableError } from "../provider-payload";
@@ -34,7 +34,7 @@ export function OpenAiAccountModeBanner({
       {(state === "absent" || state === "disabled") && (
         <div className="row" style={{ alignItems: "center", marginTop: 8 }}>
           <p className="card-sub" style={{ flex: 1, margin: 0 }}>{t("codexAuth.openaiUnavailableDesc")}</p>
-          <button className="btn btn-primary btn-sm" disabled={busy} onClick={onEnable}>
+          <button type="button" className="btn btn-primary btn-sm" disabled={busy} onClick={onEnable}>
             {busy ? t("codexAuth.enablingOpenai") : t("codexAuth.enableOpenai")}
           </button>
         </div>
@@ -82,7 +82,9 @@ export default function CodexAuth({ apiBase }: { apiBase: string }) {
 
   const loadMode = useCallback(async () => {
     try {
-      const config = await fetch(`${apiBase}/api/config`).then(r => r.json());
+      const res = await fetch(`${apiBase}/api/config`);
+      if (!res.ok) throw new Error(String(res.status));
+      const config = await res.json();
       const providerState = openAiAccountProviderState(openaiProviderFromConfig(config));
       if (providerState === "absent" || providerState === "disabled" || providerState === "invalid") {
         setBannerState(providerState);

--- a/gui/src/pages/Dashboard.tsx
+++ b/gui/src/pages/Dashboard.tsx
@@ -13,6 +13,11 @@ import {
 } from "./dashboard-shared";
 import { useDashboardData } from "./use-dashboard-data";
 
+function selectDashboardTab(next: DashboardSection) {
+  // Deliberate navigation: push a history entry so Back/Forward restore the tab.
+  navigateHash(dashboardHashForSection(next));
+}
+
 export default function Dashboard({ apiBase }: { apiBase: string }) {
   const d = useDashboardData(apiBase);
   const {
@@ -52,10 +57,7 @@ export default function Dashboard({ apiBase }: { apiBase: string }) {
     { id: "models", label: t("dash.availableModels"), body: modelsSection },
   ];
   const selected = sections.find(s => s.id === selectedSection) ?? sections[0];
-  const selectTab = (next: DashboardSection) => {
-    // Deliberate navigation: push a history entry so Back/Forward restore the tab.
-    navigateHash(dashboardHashForSection(next));
-  };
+  const selectTab = selectDashboardTab;
   const onTabKeyDown = (e: React.KeyboardEvent) => {
     const index = sections.findIndex(s => s.id === selectedSection);
     let next = -1;

--- a/gui/src/pages/Logs.tsx
+++ b/gui/src/pages/Logs.tsx
@@ -645,7 +645,7 @@ function LogDetailDialog({
                   <th className="num">{t("logs.col.estimatedCost")}</th>
                   <th>{t("logs.detail.attempt.reason")}</th>
                 </tr></thead>
-                <tbody>{[...detail.attempts].sort((a, b) => a.ordinal - b.ordinal).map(attempt => {
+                <tbody>{detail.attempts.toSorted((a, b) => a.ordinal - b.ordinal).map(attempt => {
                   const attemptCost = attempt.displayMetrics?.cost;
                   const matched = attemptCost?.kind === "value" ? attemptCost.estimate.price : undefined;
                   const reason = attempt.errorCode

--- a/gui/src/pages/Models.tsx
+++ b/gui/src/pages/Models.tsx
@@ -591,7 +591,7 @@ export default function Models({ apiBase }: { apiBase: string }) {
     // stay findable in long lists. The sort is stable, so the server order is kept
     // inside each partition, and this does not affect the picker order above
     // (visibility toggles still only filter).
-    const sorted = [...filtered].sort((a, b) => Number(!isVisible(a)) - Number(!isVisible(b)));
+    const sorted = filtered.toSorted((a, b) => Number(!isVisible(a)) - Number(!isVisible(b)));
     const shown = limit[provider] ?? PAGE;
     const visible = sorted.slice(0, shown);
     const remaining = filtered.length - visible.length;
@@ -611,8 +611,14 @@ export default function Models({ apiBase }: { apiBase: string }) {
      };
     return (
       <div key={provider} className="card models-provider-card" style={{ marginBottom: 8, overflow: "hidden" }}>
-       <div onClick={() => toggleCollapse(provider)}
-          className={`row group-head models-provider-head${isCollapsed ? "" : " open"}`}>
+       <div className={`row group-head models-provider-head${isCollapsed ? "" : " open"}`}>
+          <button
+            type="button"
+            className="row models-provider-toggle"
+            onClick={() => toggleCollapse(provider)}
+            aria-expanded={!isCollapsed}
+            style={{ flex: 1, border: 0, background: "transparent", padding: 0, color: "inherit", cursor: "pointer", textAlign: "left" }}
+          >
           <IconChevron style={{ width: 14, height: 14, color: "var(--muted)", transform: isCollapsed ? "none" : "rotate(90deg)", transition: "transform .12s" }} />
           <span className="text-body font-semibold">{provider}</span>
           {isNative && <span className="muted mono text-caption" style={{ padding: "1px 6px", border: "1px solid var(--border)", borderRadius: "var(--radius-pill)" }}>{t("models.nativeGroupLabel")}</span>}
@@ -626,7 +632,8 @@ export default function Models({ apiBase }: { apiBase: string }) {
            </span>
          )}
           <span className="muted mono text-label">{t("models.active", { active: activeCount, total: rows.length })}</span>
-           <div className="row models-provider-actions" onClick={e => e.stopPropagation()}>
+          </button>
+           <div className="row models-provider-actions">
              {!isNative && (
                <button
                  type="button"

--- a/gui/src/pages/Providers.tsx
+++ b/gui/src/pages/Providers.tsx
@@ -6,7 +6,7 @@ import { ensureOpenAiProvider, openAiAccountProviderState, OpenAiEnableError } f
 import { oauthTosRisk } from "../oauth-tos-risk";
 import { Notice } from "../ui";
 import { IconPlus } from "../icons";
-import { useT } from "../i18n";
+import { useT } from "../i18n/shared";
 import { formatProviderDisplayName } from "../provider-icons";
 import { useProviderAccountPools } from "../hooks/useProviderAccountPools";
 import { useCodexAccountPool } from "../hooks/useCodexAccountPool";
@@ -178,7 +178,7 @@ export default function Providers({ apiBase }: { apiBase: string }) {
       <div className="page-head">
         <h2>{t("nav.providers")}</h2>
         <div className="row">
-          <button className="btn btn-primary" onClick={() => setAdding(true)}><IconPlus />{t("prov.add")}</button>
+          <button type="button" className="btn btn-primary" onClick={() => setAdding(true)}><IconPlus />{t("prov.add")}</button>
         </div>
       </div>
       {status && <Notice tone={statusOk ? "ok" : "err"}>{status}</Notice>}

--- a/gui/src/pages/claude-code-sections.tsx
+++ b/gui/src/pages/claude-code-sections.tsx
@@ -10,6 +10,7 @@ import {
 } from "./claude-code-sidecar";
 import { AutoConnectSetting, SettingToggle } from "./claude-code-settings";
 import type { ClaudeCodeState, MapRow } from "./claude-code-types";
+import { newClientId } from "./claude-code-types";
 
 export function ClaudeCodeSettingsCard({
   state,
@@ -221,7 +222,7 @@ export function ClaudeCodeModelMapSection({
         ))}
       </div>
       <div style={{ marginTop: 8 }}>
-        <button type="button" className="btn btn-ghost btn-sm" onClick={() => onRowsChange([...rows, { id: crypto.randomUUID(), from: "", to: "" }])}>
+        <button type="button" className="btn btn-ghost btn-sm" onClick={() => onRowsChange([...rows, { id: newClientId(), from: "", to: "" }])}>
           <IconPlus /> {t("claude.addMapping")}
         </button>
       </div>

--- a/gui/src/pages/claude-code-sections.tsx
+++ b/gui/src/pages/claude-code-sections.tsx
@@ -195,7 +195,7 @@ export function ClaudeCodeModelMapSection({
       <p className="muted text-label" style={{ margin: "0 0 8px" }}>{t("claude.modelMapHint")}</p>
       <div className="stack" style={{ gap: 8 }}>
         {rows.map((row, i) => (
-          <div key={i} className="row" style={{ gap: 8 }}>
+          <div key={row.id} className="row" style={{ gap: 8 }}>
             <input
               className="input mono"
               value={row.from}
@@ -221,7 +221,7 @@ export function ClaudeCodeModelMapSection({
         ))}
       </div>
       <div style={{ marginTop: 8 }}>
-        <button type="button" className="btn btn-ghost btn-sm" onClick={() => onRowsChange([...rows, { from: "", to: "" }])}>
+        <button type="button" className="btn btn-ghost btn-sm" onClick={() => onRowsChange([...rows, { id: crypto.randomUUID(), from: "", to: "" }])}>
           <IconPlus /> {t("claude.addMapping")}
         </button>
       </div>

--- a/gui/src/pages/claude-code-types.ts
+++ b/gui/src/pages/claude-code-types.ts
@@ -1,6 +1,7 @@
 import type { SidecarOverride } from "./claude-manual-env";
 
 export interface MapRow {
+  id: string;
   from: string;
   to: string;
 }

--- a/gui/src/pages/claude-code-types.ts
+++ b/gui/src/pages/claude-code-types.ts
@@ -6,6 +6,27 @@ export interface MapRow {
   to: string;
 }
 
+/** Stable client key for list rows; works outside secure contexts (LAN HTTP). */
+export function newClientId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    try {
+      return crypto.randomUUID();
+    } catch {
+      // crypto.randomUUID throws outside a secure context in some browsers.
+    }
+  }
+  const bytes = new Uint8Array(16);
+  if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+    crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
 export interface ClaudeCodeState {
   enabled: boolean;
   authMode: "subscription" | "proxy";

--- a/gui/src/pages/dashboard-dialogs.tsx
+++ b/gui/src/pages/dashboard-dialogs.tsx
@@ -140,8 +140,8 @@ export function DashboardDialogs(d: Dash) {
         style={{ display: maHelpOpen ? "flex" : "none", border: "none", margin: 0, maxWidth: "none", maxHeight: "none", width: "100%", height: "100%" }}
         aria-labelledby="multi-agent-help-title"
         onCancel={event => { event.preventDefault(); setMaHelpOpen(false); }}
-        onClick={event => { if (event.target === event.currentTarget) setMaHelpOpen(false); }}
       >
+        <button type="button" className="modal-backdrop-dismiss" aria-label={t("common.close")} tabIndex={-1} onClick={() => setMaHelpOpen(false)} />
         <div className="modal-card" onClick={e => e.stopPropagation()}>
           <div className="modal-head">
             <h3 id="multi-agent-help-title">{t("dash.multiAgent")}</h3>
@@ -168,8 +168,8 @@ export function DashboardDialogs(d: Dash) {
         style={{ display: effortCapHelpOpen ? "flex" : "none", border: "none", margin: 0, maxWidth: "none", maxHeight: "none", width: "100%", height: "100%" }}
         aria-labelledby="effort-cap-help-title"
         onCancel={event => { event.preventDefault(); setEffortCapHelpOpen(false); }}
-        onClick={event => { if (event.target === event.currentTarget) setEffortCapHelpOpen(false); }}
       >
+        <button type="button" className="modal-backdrop-dismiss" aria-label={t("common.close")} tabIndex={-1} onClick={() => setEffortCapHelpOpen(false)} />
         <div className="modal-card" onClick={e => e.stopPropagation()}>
           <div className="modal-head">
             <h3 id="effort-cap-help-title">{t("dash.effortCapLabel")}</h3>
@@ -191,8 +191,8 @@ export function DashboardDialogs(d: Dash) {
         style={{ display: shadowCallHelpOpen ? "flex" : "none", border: "none", margin: 0, maxWidth: "none", maxHeight: "none", width: "100%", height: "100%" }}
         aria-labelledby="shadow-call-help-title"
         onCancel={event => { event.preventDefault(); setShadowCallHelpOpen(false); }}
-        onClick={event => { if (event.target === event.currentTarget) setShadowCallHelpOpen(false); }}
       >
+        <button type="button" className="modal-backdrop-dismiss" aria-label={t("common.close")} tabIndex={-1} onClick={() => setShadowCallHelpOpen(false)} />
         <div className="modal-card" onClick={e => e.stopPropagation()}>
           <div className="modal-head">
             <h3 id="shadow-call-help-title">{t("dash.shadowCallIntercept")}</h3>

--- a/gui/src/pages/providers-page-utils.ts
+++ b/gui/src/pages/providers-page-utils.ts
@@ -16,8 +16,8 @@ export function buildAddModalAccountRows(
         kind: "codex" as const,
         href: "#codex-auth",
       })),
-    ...[...oauthProviders]
-      .sort((a, b) => a.localeCompare(b))
+    ...oauthProviders
+      .toSorted((a, b) => a.localeCompare(b))
       .map(id => ({ id, label: oauthLabel(id), kind: "oauth" as const })),
   ];
 }

--- a/gui/src/pages/use-providers-crud.ts
+++ b/gui/src/pages/use-providers-crud.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import type { TFn } from "../i18n";
+import type { TFn } from "../i18n/shared";
 import type { ProviderUpdatePatch } from "../components/provider-workspace/types";
 import { apiErrorMessage } from "../api-error";
 

--- a/gui/src/pages/use-providers-crud.ts
+++ b/gui/src/pages/use-providers-crud.ts
@@ -82,7 +82,9 @@ export function useProvidersCrud({
         const data = await res.json().catch(() => ({})) as { error?: string };
         return { ok: false, error: data.error || "Update failed" };
       }
-      fetchConfig();
+      // Await refresh so callers (e.g. notes editor) only leave edit mode once
+      // item.note reflects the saved value.
+      await fetchConfig();
       return { ok: true };
     } catch {
       return { ok: false, error: "Network error" };

--- a/gui/src/pages/use-providers-fetch.ts
+++ b/gui/src/pages/use-providers-fetch.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import type { TFn } from "../i18n";
+import type { TFn } from "../i18n/shared";
 import { readJsonIfOk, readJsonOrThrow } from "../fetch-json";
 import type { OAuthStatus, ProviderQuotaReport, ProvidersConfig } from "./providers-shared";
 

--- a/gui/src/pages/use-providers-oauth.ts
+++ b/gui/src/pages/use-providers-oauth.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import type { TFn } from "../i18n";
+import type { TFn } from "../i18n/shared";
 import { readJsonIfOk } from "../fetch-json";
 import type { OAuthAccount, OAuthStatus } from "./providers-shared";
 import { oauthLabel } from "./providers-shared";

--- a/gui/src/provider-icons.ts
+++ b/gui/src/provider-icons.ts
@@ -44,32 +44,6 @@ const PROVIDER_ICON_ALIASES: Record<string, string> = {
   xiaomi: "xiaomi-color.svg",
 };
 
-/** Brand colors for monochrome Simple-Icons SVGs (fill is black by default). */
-const PROVIDER_BRAND_COLORS: Record<string, string> = {
-  nvidia: "#76B900",
-  "mimo-free": "#FF6900",
-  xiaomi: "#FF6900",
-  anthropic: "#D97757",
-  "anthropic-apikey": "#D97757",
-  openai: "#10A37F",
-  "openai-apikey": "#10A37F",
-  chatgpt: "#10A37F",
-  "azure-openai": "#10A37F",
-  // xAI / Ollama monochrome marks stay as-authored (black/white per theme SVG).
-  deepseek: "#4D6BFE",
-  groq: "#F55036",
-  mistral: "#FF7000",
-  openrouter: "#6566F1",
-  google: "#8E75B2",
- "google-vertex": "#8E75B2",
-  alibaba: "#FF6A00",
-  "alibaba-token-plan": "#FF6A00",
-  "alibaba-token-plan-intl": "#FF6A00",
- kimi: "#1A6CFF",
-  "kimi-code": "#1A6CFF",
-  moonshot: "#1A6CFF",
-};
-
 /**
  * Canonical brand casing for known provider ids (config keys stay lowercase).
  * Current OpenAI ids follow the registry labels; legacy `chatgpt` keeps its historical label.
@@ -132,11 +106,6 @@ export function providerIconSrc(provider: string, _hints?: ProviderIconHints): s
   void _hints;
   const icon = providerIconAlias(provider);
   return icon ? `/provider-icons/${icon}` : undefined;
-}
-
-/** Brand accent for monochrome icons; undefined = leave SVG as-authored. */
-export function providerBrandColor(provider: string): string | undefined {
-  return PROVIDER_BRAND_COLORS[provider.toLowerCase()];
 }
 
 /** Display label with proper brand casing when known; otherwise original name. */

--- a/gui/src/provider-payload.ts
+++ b/gui/src/provider-payload.ts
@@ -114,7 +114,7 @@ function buildReservedProviderPostBody(
   if (!preset.provider) throw new Error(`Missing canonical provider seed for ${preset.id}`);
   return {
     name: preset.id,
-    provider: JSON.parse(JSON.stringify(preset.provider)) as ProviderPayload,
+    provider: structuredClone(preset.provider) as ProviderPayload,
   };
 }
 

--- a/gui/src/provider-workspace/auth.ts
+++ b/gui/src/provider-workspace/auth.ts
@@ -1,4 +1,4 @@
-import type { TFn } from "../i18n";
+import type { TFn } from "../i18n/shared";
 import { isAccountProvider, type WorkspaceItem } from "./catalog";
 import { isLocalProvider } from "./kind";
 

--- a/gui/src/provider-workspace/catalog.ts
+++ b/gui/src/provider-workspace/catalog.ts
@@ -144,10 +144,6 @@ export function isFreeProvider(p: WorkspaceProvider): boolean {
     || hasLoopbackBaseUrl(p.baseUrl);
 }
 
-export function isPaidProvider(name: string, p: WorkspaceProvider): boolean {
-  return providerTier(name, p) === "paid";
-}
-
 /** Three-way tier: accounts wins over free; everything else is paid. */
 export function providerTier(name: string, p: WorkspaceProvider): ProviderTier {
   if (isAccountProvider(name, p)) return "accounts";
@@ -281,15 +277,4 @@ export function hideRedundantChatGptForwardProviders<T extends WorkspaceProvider
   const rest = { ...providers };
   delete rest.chatgpt;
   return rest;
-}
-
-/**
- * Resolve the one current Codex-account provider used by account-management links.
- * Legacy or custom forward-shaped rows are not eligible owners.
- */
-export function pickCanonicalForwardProvider(
-  providers: Record<string, WorkspaceProvider>,
-): string | null {
-  if (providers.openai && isAccountProvider("openai", providers.openai)) return "openai";
-  return null;
 }

--- a/gui/src/styles-models-workspace.css
+++ b/gui/src/styles-models-workspace.css
@@ -200,9 +200,14 @@
   min-width: 0;
 }
 
-.models-provider-head > span.text-body {
+.models-provider-head > span.text-body,
+.models-provider-toggle > span.text-body {
   min-width: 0;
   overflow-wrap: anywhere;
+}
+
+.models-provider-toggle {
+  min-width: 0;
 }
 
 .models-provider-actions {

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -1248,3 +1248,15 @@ button.prov-account-row.active { cursor: default; }
   from { opacity: 0; }
   to { opacity: 1; }
 }
+
+
+/* Invisible full-area control for native <dialog> backdrop dismiss (a11y). */
+.modal-backdrop-dismiss {
+  position: fixed;
+  inset: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -782,7 +782,7 @@ dialog.modal-overlay {
 dialog.modal-overlay::backdrop {
   background: transparent;
 }
-.modal-card { background: color-mix(in oklab, canvas 92%, transparent); backdrop-filter: blur(20px) saturate(1.4); -webkit-backdrop-filter: blur(20px) saturate(1.4); border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 20px; width: 100%; max-width: 520px; box-shadow: 0 8px 32px rgb(0 0 0 / 0.18); max-height: 84vh; overflow-y: auto; }
+.modal-card { position: relative; z-index: 1; background: color-mix(in oklab, canvas 92%, transparent); backdrop-filter: blur(20px) saturate(1.4); -webkit-backdrop-filter: blur(20px) saturate(1.4); border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 20px; width: 100%; max-width: 520px; box-shadow: 0 8px 32px rgb(0 0 0 / 0.18); max-height: 84vh; overflow-y: auto; }
 .modal-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
 .modal-head h3 { font-size: var(--text-subtitle); }
 
@@ -1254,6 +1254,7 @@ button.prov-account-row.active { cursor: default; }
 .modal-backdrop-dismiss {
   position: fixed;
   inset: 0;
+  z-index: 0;
   margin: 0;
   padding: 0;
   border: 0;

--- a/gui/src/styles/provider-workspace-settings.css
+++ b/gui/src/styles/provider-workspace-settings.css
@@ -35,7 +35,7 @@
 .pwi-auth-row-secondary { max-width: 100%; overflow: hidden; text-overflow: ellipsis; font-size: var(--text-label); color: var(--muted); }
 .pwi-auth-open-link  { font-size: var(--text-label); color: var(--accent); text-decoration: underline; cursor: pointer; }
 
-.pwi-auth-list { display: flex; flex-direction: column; gap: 4px; }
+.pwi-auth-list { display: flex; flex-direction: column; gap: 4px; margin: 0; padding: 0; list-style: none; }
 .pwi-auth-row {
   display: flex; align-items: center; gap: 8px;
   padding: 6px 8px; border-radius: var(--radius-xs);

--- a/gui/src/styles/provider-workspace-shell.css
+++ b/gui/src/styles/provider-workspace-shell.css
@@ -898,7 +898,21 @@
   flex-wrap: wrap;
   align-items: center;
   gap: 12px 12px;
-  margin-top: 4px;
+  margin: 4px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.pws-model-expand {
+  display: inline;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
 }
 
 .pws-model-chip {

--- a/gui/src/ui.tsx
+++ b/gui/src/ui.tsx
@@ -260,7 +260,8 @@ export function Tooltip({ content, children, side = "top", maxWidth = 280 }: {
   useEffect(() => () => { if (timer.current !== null) window.clearTimeout(timer.current); }, []);
 
   return (
-    <span
+    <button
+      type="button"
       className="ocx-tooltip"
       onMouseEnter={show}
       onMouseLeave={hide}
@@ -270,7 +271,7 @@ export function Tooltip({ content, children, side = "top", maxWidth = 280 }: {
         if (event.key === "Escape") hide();
       }}
       aria-describedby={open ? tipId : undefined}
-      tabIndex={0}
+      style={{ display: "inline", border: 0, background: "transparent", padding: 0, margin: 0, color: "inherit", font: "inherit", cursor: "inherit" }}
     >
       {children}
       {open && (
@@ -278,6 +279,6 @@ export function Tooltip({ content, children, side = "top", maxWidth = 280 }: {
           {content}
         </span>
       )}
-    </span>
+    </button>
   );
 }

--- a/gui/tests/models-provider-head.test.ts
+++ b/gui/tests/models-provider-head.test.ts
@@ -1,11 +1,14 @@
 import { expect, test } from "bun:test";
 
-test("Models provider headers use wrap-safe classes and stop collapse on action clicks", async () => {
+test("Models provider headers use wrap-safe classes and a sibling toggle boundary", async () => {
   const src = await Bun.file(new URL("../src/pages/Models.tsx", import.meta.url)).text();
   expect(src).toContain("models-provider-head");
   expect(src).toContain("models-provider-actions");
-  // Actions live in their own stopPropagation wrapper so All On / caps do not toggle collapse.
-  expect(src).toMatch(/className="row models-provider-actions"\s+onClick=\{e => e\.stopPropagation\(\)\}/);
+  expect(src).toContain("models-provider-toggle");
+  // Collapse lives on a sibling button; the actions row no longer needs stopPropagation.
+  expect(src).toMatch(/className="row models-provider-toggle"/);
+  expect(src).toMatch(/className="row models-provider-actions"/);
+  expect(src).not.toMatch(/className="row models-provider-actions"\s+onClick=\{e => e\.stopPropagation\(\)\}/);
   // Both Classic and Workspace share renderGroup — no duplicate unclassed group-head for providers.
   const providerHeads = src.match(/models-provider-head/g) ?? [];
   expect(providerHeads.length).toBeGreaterThanOrEqual(1);
@@ -20,8 +23,10 @@ test("Models workspace stacks via content-width container query before mobile dr
   expect(css).toContain("@container models-workspace (max-width: 720px)");
   expect(css).toContain(".models-provider-head");
   expect(css).toContain(".models-provider-actions");
+  expect(css).toContain(".models-provider-toggle");
   expect(css).toMatch(/\.models-provider-head\s*\{[^}]*flex-wrap:\s*wrap/s);
   expect(css).toMatch(/\.models-provider-actions\s*\{[^}]*flex-wrap:\s*wrap/s);
+  expect(css).toMatch(/\.models-provider-toggle\s*\{[^}]*min-width:\s*0/s);
   // Mobile media rule retained for drawer layouts.
   expect(css).toContain("@media (max-width: 768px)");
 });

--- a/gui/tests/provider-overview-notes-save.test.tsx
+++ b/gui/tests/provider-overview-notes-save.test.tsx
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act } from "react";
+import type { Root } from "react-dom/client";
+import { LanguageProvider } from "../src/i18n/provider";
+import ProviderOverview from "../src/components/provider-workspace/ProviderOverview";
+import type { WorkspaceItem } from "../src/provider-workspace/catalog";
+
+const globals = ["document", "window", "navigator", "localStorage", "IS_REACT_ACT_ENVIRONMENT"] as const;
+let previousGlobals: Record<(typeof globals)[number], unknown>;
+let testWindow: Window;
+
+beforeEach(() => {
+  previousGlobals = Object.fromEntries(globals.map(key => [key, Reflect.get(globalThis, key)])) as typeof previousGlobals;
+  testWindow = new Window({ url: "http://localhost/#providers/workspace" });
+  Object.defineProperty(testWindow.navigator, "language", { configurable: true, value: "en-US" });
+  Object.defineProperties(globalThis, {
+    document: { configurable: true, value: testWindow.document },
+    window: { configurable: true, value: testWindow },
+    navigator: { configurable: true, value: testWindow.navigator },
+    localStorage: { configurable: true, value: testWindow.localStorage },
+  });
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(() => {
+  testWindow.close();
+  for (const key of globals) {
+    Object.defineProperty(globalThis, key, { configurable: true, value: previousGlobals[key] });
+  }
+});
+
+const item = {
+  name: "openai",
+  adapter: "openai-responses",
+  baseUrl: "https://example.test/v1",
+  note: "existing note",
+} as WorkspaceItem;
+
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await new Promise<void>(resolve => testWindow.setTimeout(resolve, 0));
+  await Promise.resolve();
+}
+
+async function mountOverview(
+  onUpdateProvider: (name: string, patch: { note?: string }) => Promise<{ ok: boolean; error?: string }>,
+  providerItem = item,
+): Promise<{ root: Root; container: HTMLElement }> {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const { createRoot } = await import("react-dom/client");
+  let root!: Root;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <LanguageProvider>
+        <ProviderOverview item={providerItem} onUpdateProvider={onUpdateProvider} />
+      </LanguageProvider>,
+    );
+  });
+  return { root, container };
+}
+
+async function openNotesEditor(container: HTMLElement): Promise<HTMLTextAreaElement> {
+  const display = container.querySelector<HTMLButtonElement>(".pws-notes-display")!;
+  await act(async () => {
+    display.click();
+  });
+  const textarea = container.querySelector<HTMLTextAreaElement>(".pws-notes-textarea")!;
+  expect(textarea).toBeTruthy();
+  return textarea;
+}
+
+async function setDraft(textarea: HTMLTextAreaElement, value: string): Promise<void> {
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(testWindow.HTMLTextAreaElement.prototype, "value")!
+      .set!.call(textarea, value);
+    textarea.dispatchEvent(new testWindow.Event("input", { bubbles: true }));
+  });
+}
+
+async function blurNotes(textarea: HTMLTextAreaElement): Promise<void> {
+  await act(async () => {
+    textarea.dispatchEvent(new testWindow.FocusEvent("focusout", {
+      bubbles: true,
+      relatedTarget: null,
+    }));
+    await flush();
+  });
+}
+
+test("notes save keeps editor open, draft, and error when update is rejected", async () => {
+  let calls = 0;
+  const onUpdateProvider = async () => {
+    calls += 1;
+    return { ok: false as const, error: "quota exceeded" };
+  };
+
+  const { root, container } = await mountOverview(onUpdateProvider);
+  const textarea = await openNotesEditor(container);
+  await setDraft(textarea, "draft that must survive");
+  await blurNotes(textarea);
+
+  expect(calls).toBe(1);
+  expect(container.querySelector(".pws-notes-textarea")).toBeTruthy();
+  expect(container.querySelector<HTMLTextAreaElement>(".pws-notes-textarea")!.value).toBe("draft that must survive");
+  expect(container.querySelector('[role="alert"]')?.textContent).toBe("quota exceeded");
+  expect(container.querySelector<HTMLTextAreaElement>(".pws-notes-textarea")!.disabled).toBe(false);
+
+  await act(async () => { root.unmount(); });
+});
+
+test("notes save closes editor only after an acknowledged success", async () => {
+  let resolveUpdate!: (value: { ok: true }) => void;
+  const updatePromise = new Promise<{ ok: true }>(resolve => {
+    resolveUpdate = resolve;
+  });
+  let calls = 0;
+  const onUpdateProvider = async () => {
+    calls += 1;
+    return updatePromise;
+  };
+
+  const { root, container } = await mountOverview(onUpdateProvider);
+  const textarea = await openNotesEditor(container);
+  await setDraft(textarea, "saved note");
+  await blurNotes(textarea);
+
+  expect(calls).toBe(1);
+  expect(container.querySelector(".pws-notes-textarea")).toBeTruthy();
+  expect(container.querySelector<HTMLTextAreaElement>(".pws-notes-textarea")!.disabled).toBe(true);
+
+  await act(async () => {
+    resolveUpdate({ ok: true });
+    await flush();
+  });
+
+  expect(container.querySelector(".pws-notes-textarea")).toBeNull();
+  expect(container.querySelector(".pws-notes-display")?.textContent).toContain("existing note");
+
+  await act(async () => { root.unmount(); });
+});

--- a/gui/tests/use-providers-crud-update.test.tsx
+++ b/gui/tests/use-providers-crud-update.test.tsx
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { act, useEffect, useRef, useState } from "react";
+import type { Root } from "react-dom/client";
+import { Window } from "happy-dom";
+import { useProvidersCrud } from "../src/pages/use-providers-crud";
+import type { ProviderUpdatePatch } from "../src/components/provider-workspace/types";
+
+const globals = ["document", "window", "navigator", "localStorage", "IS_REACT_ACT_ENVIRONMENT"] as const;
+const originalFetch = globalThis.fetch;
+let previousGlobals: Record<(typeof globals)[number], unknown>;
+let testWindow: Window;
+
+beforeEach(() => {
+  previousGlobals = Object.fromEntries(globals.map(key => [key, Reflect.get(globalThis, key)])) as typeof previousGlobals;
+  testWindow = new Window({ url: "http://localhost/" });
+  Object.defineProperties(globalThis, {
+    document: { configurable: true, value: testWindow.document },
+    window: { configurable: true, value: testWindow },
+    navigator: { configurable: true, value: testWindow.navigator },
+    localStorage: { configurable: true, value: testWindow.localStorage },
+  });
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  testWindow.close();
+  for (const key of globals) {
+    Object.defineProperty(globalThis, key, { configurable: true, value: previousGlobals[key] });
+  }
+});
+
+test("updateProvider awaits fetchConfig before returning success", async () => {
+  let resolveConfig!: () => void;
+  const configPromise = new Promise<void>(resolve => {
+    resolveConfig = resolve;
+  });
+  const fetchConfig = mock(() => configPromise);
+  globalThis.fetch = (async () => Response.json({ ok: true })) as typeof fetch;
+
+  const container = document.createElement("div");
+  document.body.append(container);
+  const { createRoot } = await import("react-dom/client");
+  let root!: Root;
+  let updateProvider!: (name: string, patch: ProviderUpdatePatch) => Promise<{ ok: boolean; error?: string }>;
+
+  function Harness() {
+    const removeBusyRef = useRef(false);
+    const crud = useProvidersCrud({
+      apiBase: "http://localhost:10100",
+      t: ((key: string) => key) as never,
+      removeBusyRef,
+      workspaceSelected: null,
+      setWorkspaceSelected: () => {},
+      setRemoveConfirmName: () => {},
+      notify: () => {},
+      fetchConfig,
+      fetchOauth: async () => {},
+      fetchProviderQuotas: async () => {},
+    });
+    const [ready, setReady] = useState(false);
+    useEffect(() => {
+      updateProvider = crud.updateProvider;
+      setReady(true);
+    }, [crud.updateProvider]);
+    return ready ? <div data-ready="1" /> : null;
+  }
+
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<Harness />);
+  });
+  expect(container.querySelector("[data-ready]")).toBeTruthy();
+
+  let settled: { ok: boolean; error?: string } | undefined;
+  const pending = updateProvider("openai", { note: "next" }).then(result => {
+    settled = result;
+  });
+
+  await act(async () => {
+    await Promise.resolve();
+  });
+  expect(fetchConfig).toHaveBeenCalledTimes(1);
+  expect(settled).toBeUndefined();
+
+  await act(async () => {
+    resolveConfig();
+    await pending;
+  });
+  expect(settled).toEqual({ ok: true });
+
+  await act(async () => { root.unmount(); });
+});

--- a/tests/provider-workspace-data.test.ts
+++ b/tests/provider-workspace-data.test.ts
@@ -6,8 +6,6 @@ import {
   hideRedundantChatGptForwardProviders,
   isAccountProvider,
   isFreeProvider,
-  isPaidProvider,
-  pickCanonicalForwardProvider,
   providerTier,
   sortWorkspaceItems,
   type WorkspaceItem,
@@ -27,13 +25,11 @@ import {
 import {
   formatProviderDisplayName,
   isCatalogProviderId,
-  providerBrandColor,
 } from "../gui/src/provider-icons";
 import {
   bucketPresets,
   filterPresets,
   presetTier,
-  sortPresets,
   type CatalogPreset,
 } from "../gui/src/components/provider-catalog/provider-presets";
 import { isLocalProvider, providerKind } from "../gui/src/provider-workspace/kind";
@@ -188,8 +184,6 @@ describe("catalog: three-way tiers", () => {
     expect(isFreeProvider(prov())).toBe(false);
     expect(providerTier("nvidia", prov({ freeTier: true }))).toBe("free");
     expect(providerTier("venice", prov({ authMode: "key", hasApiKey: true }))).toBe("paid");
-    expect(isPaidProvider("venice", prov({ authMode: "key", hasApiKey: true }))).toBe(true);
-    expect(isPaidProvider("nvidia", prov({ freeTier: true }))).toBe(false);
     // Accounts precedence pinned: a canonical provider that ALSO carries freeTier is accounts.
     expect(providerTier("openai", forwardProv({ freeTier: true }))).toBe("accounts");
   });
@@ -251,7 +245,7 @@ describe("catalog: sorting", () => {
   });
 });
 
-describe("catalog: chatgpt hiding + canonical picker", () => {
+describe("catalog: chatgpt hiding", () => {
   test("hides legacy chatgpt only when canonical openai covers the same passthrough", () => {
     const both = { openai: forwardProv(), chatgpt: forwardProv() };
     expect(Object.keys(hideRedundantChatGptForwardProviders(both))).toEqual(["openai"]);
@@ -275,16 +269,6 @@ describe("catalog: chatgpt hiding + canonical picker", () => {
     expect(out).not.toBe(both);
   });
 
-  test("pickCanonicalForwardProvider prefers canonical openai", () => {
-    expect(pickCanonicalForwardProvider({ "openai-multi": forwardProv(), openai: forwardProv() })).toBe("openai");
-    expect(pickCanonicalForwardProvider({ openai: forwardProv() })).toBe("openai");
-    expect(pickCanonicalForwardProvider({ chatgpt: forwardProv() })).toBeNull();
-    expect(pickCanonicalForwardProvider({ venice: prov({ authMode: "key", hasApiKey: true }) })).toBeNull();
-    // Legacy Multi never wins, regardless of shape.
-    expect(pickCanonicalForwardProvider({ "openai-multi": prov({ authMode: "key" }), openai: forwardProv() })).toBe("openai");
-    expect(pickCanonicalForwardProvider({ "my-forward": forwardProv() })).toBeNull();
-    expect(pickCanonicalForwardProvider({ "my-forward": forwardProv(), openai: forwardProv() })).toBe("openai");
-  });
 });
 
 describe("usage: model parsing", () => {
@@ -462,10 +446,7 @@ describe("provider-icons", () => {
     expect(formatProviderDisplayName("MyProxy")).toBe("MyProxy");
   });
 
-  test("brand colors and catalog membership", () => {
-    expect(providerBrandColor("nvidia")).toBe("#76B900");
-    expect(providerBrandColor("openai-multi")).toBeUndefined();
-    expect(providerBrandColor("unknown")).toBeUndefined();
+  test("catalog membership excludes legacy Multi and custom ids", () => {
     expect(isCatalogProviderId("openai-multi")).toBe(false);
     expect(isCatalogProviderId("my-proxy")).toBe(false);
   });
@@ -527,16 +508,6 @@ describe("add-provider catalog presets (WP050a)", () => {
     expect(filterPresets(rows, "").map(p => p.id)).toEqual(["nvidia", "groq"]);
   });
 
-  test("sortPresets is deterministic: label case-insensitive, id tiebreak, input not mutated", () => {
-    const rows = [
-      preset({ id: "b-provider", label: "zeta" }),
-      preset({ id: "a-provider", label: "Zeta" }),
-      preset({ id: "c-provider", label: "alpha" }),
-    ];
-    const sorted = sortPresets(rows);
-    expect(sorted.map(p => p.id)).toEqual(["c-provider", "a-provider", "b-provider"]);
-    expect(rows.map(p => p.id)).toEqual(["b-provider", "a-provider", "c-provider"]);
-  });
 });
 
 describe("provider kind classification (WP080a)", () => {


### PR DESCRIPTION
## Summary
- Rewritten from the original combined follow-up: **code fixes only** (correctness/a11y + mechanical react-doctor findings).
- Fixes effect cleanup, barrel→shared i18n imports, button types, dialog/menu roles, fetch status checks, loading `finally` resets, unused exports, toSorted/structuredClone, provider catalog polish, and related GUI issues.
- Doctor policy/config (`gui/doctor.config.json`, `gui/.react-doctor-ignores.md`) moved to #481 so this lands independently of intentional rule disables.

## Note on doctor score
Full `npx react-doctor@0.9.1 --scope full` **100/100** still needs #481 (rule disables for SPA fetch-in-effect, giant components / useReducer, parent sync effects, draft JSON editor derived state, etc.). This PR alone may leave policy-gated diagnostics.

## Test plan
- [x] `bun run lint:gui`
- [ ] `bun x tsc -p gui/tsconfig.app.json --noEmit` (same 3 pre-existing errors currently on `dev`)
- [ ] Spot-check provider workspace filter menu, modals (backdrop dismiss), and Models provider collapse header
- [ ] Confirm #481 is reviewed for full doctor 100

## Split
Companion policy/config: https://github.com/lidge-jun/opencodex/pull/481


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard and focus behavior for expandable model/usage rows and tooltips (now button-based).
  * Updated multiple modals to use explicit backdrop-dismiss controls; added/adjusted ARIA labels and semantic list markup.
  * Enhanced “edit notes” UX by focusing the notes field when entering edit mode.
* **Provider Management**
  * Refreshed provider workspace catalog tiering/sorting/status and reauth overlay behavior; improved provider name branding/display.
* **Bug Fixes**
  * More reliable polling cancellation/timeouts and improved locale-aware number formatting performance (cached formatters).
  * Strengthened request/save error handling and state cleanup across configuration and key workflows.
* **Tests**
  * Updated tests for models header behavior and provider workspace catalog/preset logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->