### PR TITLE
fix(proxy): preserve OpenAI cyber_policy errors end-to-end

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -688,10 +688,10 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
             message,
             ...(typeof err?.code === "string" ? { code: err.code } : {}),
             ...(typeof err?.type === "string" ? { errorType: err.type } : {}),
-            ...(typeof err?.status === "number" && Number.isInteger(err.status)
-              ? { status: err.status }
-              : isCyberPolicyCode(err?.code)
-                ? { status: 400 }
+            ...(isCyberPolicyCode(err?.code)
+              ? { status: 400 }
+              : typeof err?.status === "number" && Number.isInteger(err.status)
+                ? { status: err.status }
                 : {}),
           };
           return "terminate";
@@ -807,10 +807,10 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
         const message = typeof upstreamError.message === "string" ? upstreamError.message : "upstream error";
         const code = typeof upstreamError.code === "string" ? upstreamError.code : undefined;
         const errorType = typeof upstreamError.type === "string" ? upstreamError.type : undefined;
-        const status = typeof upstreamError.status === "number" && Number.isInteger(upstreamError.status)
-          ? upstreamError.status
-          : isCyberPolicyCode(code)
-            ? 400
+        const status = isCyberPolicyCode(code)
+          ? 400
+          : typeof upstreamError.status === "number" && Number.isInteger(upstreamError.status)
+            ? upstreamError.status
             : undefined;
         return [{
           type: "error",

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -4,6 +4,7 @@ import { isAllowedToolChoice, modelInList, namespacedToolName, resolveToolChoice
 import { mapReasoningEffort, modelRecordValue } from "../reasoning-effort";
 import { debugProviderDiagnostic } from "../lib/debug";
 import { isDebugEnabled } from "../lib/debug-settings";
+import { isCyberPolicyCode } from "../lib/errors";
 import { redactSecretString } from "../lib/redact";
 import { contentPartsToText } from "./image";
 import { neutralizeIdentity } from "./identity";
@@ -689,7 +690,7 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
             ...(typeof err?.type === "string" ? { errorType: err.type } : {}),
             ...(typeof err?.status === "number" && Number.isInteger(err.status)
               ? { status: err.status }
-              : err?.code === "cyber_policy"
+              : isCyberPolicyCode(err?.code)
                 ? { status: 400 }
                 : {}),
           };
@@ -808,7 +809,7 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
         const errorType = typeof upstreamError.type === "string" ? upstreamError.type : undefined;
         const status = typeof upstreamError.status === "number" && Number.isInteger(upstreamError.status)
           ? upstreamError.status
-          : code === "cyber_policy"
+          : isCyberPolicyCode(code)
             ? 400
             : undefined;
         return [{

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -678,11 +678,21 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
         // instead of a clean [DONE]. Surface it as a terminal error so the bridge emits a
         // classified response.failed (bridge case "error") — never a truncated completion.
         if (chunk.error) {
-          const err = chunk.error as { message?: string } | undefined;
+          const err = chunk.error as { message?: string; code?: string; type?: string; status?: number } | undefined;
           const message = err?.message ?? "upstream error";
           debugProviderDiagnostic("openai-chat", "stream-error", { message });
           yield* flushToolCalls();
-          yield { type: "error", message };
+          yield {
+            type: "error",
+            message,
+            ...(typeof err?.code === "string" ? { code: err.code } : {}),
+            ...(typeof err?.type === "string" ? { errorType: err.type } : {}),
+            ...(typeof err?.status === "number" && Number.isInteger(err.status)
+              ? { status: err.status }
+              : err?.code === "cyber_policy"
+                ? { status: 400 }
+                : {}),
+          };
           return "terminate";
         }
 
@@ -792,10 +802,21 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
     async parseResponse(response: Response): Promise<AdapterEvent[]> {
       const json = await response.json() as Record<string, unknown>;
       if (json.error) {
-        const upstreamError = json.error as { message?: unknown };
+        const upstreamError = json.error as { message?: unknown; code?: unknown; type?: unknown; status?: unknown };
+        const message = typeof upstreamError.message === "string" ? upstreamError.message : "upstream error";
+        const code = typeof upstreamError.code === "string" ? upstreamError.code : undefined;
+        const errorType = typeof upstreamError.type === "string" ? upstreamError.type : undefined;
+        const status = typeof upstreamError.status === "number" && Number.isInteger(upstreamError.status)
+          ? upstreamError.status
+          : code === "cyber_policy"
+            ? 400
+            : undefined;
         return [{
           type: "error",
-          message: typeof upstreamError.message === "string" ? upstreamError.message : "upstream error",
+          message,
+          ...(code !== undefined ? { code } : {}),
+          ...(errorType !== undefined ? { errorType } : {}),
+          ...(status !== undefined ? { status } : {}),
         }];
       }
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1,5 +1,5 @@
 import type { AdapterEvent, OcxMessagePhase, OcxProviderContinuationState, OcxUsage } from "./types";
-import { adapterFailureFromMessage, classifyError, type OcxErrorPayload } from "./lib/errors";
+import { adapterFailureFromMessage, classifyError, CYBER_POLICY_ERROR_CODE, isCyberPolicyCode, type OcxErrorPayload } from "./lib/errors";
 import { encodeCompactionSummary } from "./responses/compaction";
 import { encodeReasoningEnvelope, type ReasoningEnvelope } from "./responses/reasoning-envelope";
 import { resolveStallTimeoutSec } from "./stall-timeout";
@@ -57,10 +57,16 @@ function adapterFailureFromEvent(event: Extract<AdapterEvent, { type: "error" }>
     return adapterFailureFromMessage(event.message);
   }
   const fallback = adapterFailureFromMessage(event.message);
-  const httpStatus = event.status ?? fallback.httpStatus;
+  let httpStatus = event.status ?? fallback.httpStatus;
   const error = classifyError(httpStatus, event.errorType ?? fallback.error.type, event.message);
   if (event.errorType !== undefined) error.type = event.errorType;
   if (event.code !== undefined) error.code = event.code;
+  // Codex maps cyber_policy on HTTP 400 (body) or mid-stream code; never leave it as 502.
+  if (isCyberPolicyCode(error.code) || isCyberPolicyCode(event.code)) {
+    error.code = CYBER_POLICY_ERROR_CODE;
+    error.type = "invalid_request_error";
+    httpStatus = 400;
+  }
   return { httpStatus, error };
 }
 
@@ -1121,8 +1127,20 @@ export function buildResponseJSON(
   };
 }
 
-export function formatErrorResponse(status: number, type: string, message: string): Response {
-  return new Response(JSON.stringify({ error: classifyError(status, type, message) }), {
-    status, headers: { "Content-Type": "application/json" },
+export function formatErrorResponse(
+  status: number,
+  type: string,
+  message: string,
+  options?: { code?: string | null },
+): Response {
+  const error = classifyError(status, type, message);
+  if (isCyberPolicyCode(options?.code)) {
+    error.code = CYBER_POLICY_ERROR_CODE;
+    error.type = "invalid_request_error";
+  }
+  const finalStatus = error.code === CYBER_POLICY_ERROR_CODE ? 400 : status;
+  return new Response(JSON.stringify({ error }), {
+    status: finalStatus,
+    headers: { "Content-Type": "application/json" },
   });
 }

--- a/src/chat/outbound.ts
+++ b/src/chat/outbound.ts
@@ -8,6 +8,7 @@
 type Rec = Record<string, unknown>;
 
 import { decodeServerSentEvents } from "../lib/sse-decoder";
+import { classifyError, CYBER_POLICY_ERROR_CODE, isCyberPolicyCode, isCyberPolicyMessage } from "../lib/errors";
 
 function isRec(v: unknown): v is Rec {
   return !!v && typeof v === "object" && !Array.isArray(v);
@@ -43,23 +44,53 @@ export function chatCompletionsUsage(usage: unknown): Rec {
   return out;
 }
 
-export function chatCompletionsErrorBody(status: number, message: string, type = "invalid_request_error"): Rec {
+export function chatCompletionsErrorBody(
+  status: number,
+  message: string,
+  type = "invalid_request_error",
+  code?: string | null,
+): Rec {
+  const classified = classifyError(status, type, message);
+  let resolvedCode: string | null;
+  if (isCyberPolicyCode(code) || classified.code === CYBER_POLICY_ERROR_CODE) {
+    resolvedCode = CYBER_POLICY_ERROR_CODE;
+  } else if (code !== undefined) {
+    resolvedCode = code;
+  } else if (classified.code) {
+    resolvedCode = classified.code;
+  } else if (status === 401) {
+    resolvedCode = "invalid_api_key";
+  } else if (status === 404) {
+    resolvedCode = "model_not_found";
+  } else if (status === 429) {
+    resolvedCode = "rate_limit_exceeded";
+  } else {
+    resolvedCode = null;
+  }
+  const resolvedType = resolvedCode === CYBER_POLICY_ERROR_CODE
+    ? "invalid_request_error"
+    : (classified.type || type);
   return {
     error: {
       message,
-      type,
+      type: resolvedType,
       param: null,
-      code: status === 401 ? "invalid_api_key"
-        : status === 404 ? "model_not_found"
-        : status === 429 ? "rate_limit_exceeded"
-        : null,
+      code: resolvedCode,
     },
   };
 }
 
-export function chatCompletionsErrorResponse(status: number, message: string, type?: string): Response {
-  return new Response(JSON.stringify(chatCompletionsErrorBody(status, message, type)), {
-    status,
+export function chatCompletionsErrorResponse(
+  status: number,
+  message: string,
+  type?: string,
+  code?: string | null,
+): Response {
+  const body = chatCompletionsErrorBody(status, message, type, code);
+  const err = body.error as { code?: string | null };
+  const finalStatus = err.code === CYBER_POLICY_ERROR_CODE ? 400 : status;
+  return new Response(JSON.stringify(body), {
+    status: finalStatus,
     headers: { "Content-Type": "application/json" },
   });
 }
@@ -85,19 +116,13 @@ export function isChatCompletionsStreamError(err: unknown): err is ChatCompletio
 
 function streamErrorStatus(message: string): number {
   const lower = message.toLowerCase();
+  if (isCyberPolicyMessage(lower)) return 400;
   if (lower.includes("truncated")) return 502;
   if (lower.includes("rate") || lower.includes("429")) return 429;
   if (lower.includes("unauthor") || lower.includes("401") || lower.includes("api key")) return 401;
   if (lower.includes("not found") || lower.includes("404")) return 404;
   if (lower.includes("invalid") || lower.includes("400")) return 400;
   return 502;
-}
-
-function streamErrorType(status: number): string {
-  if (status === 401) return "authentication_error";
-  if (status === 429) return "rate_limit_error";
-  if (status >= 500) return "server_error";
-  return "invalid_request_error";
 }
 
 function dataFrame(payload: Rec | "[DONE]"): string {
@@ -220,7 +245,7 @@ export function responsesSseToChatCompletionsSse(
         emit(frame);
         emit("[DONE]");
       };
-      const fail = (message: string) => {
+      const fail = (message: string, details?: { code?: string | null; type?: string; status?: number }) => {
         if (terminated) return;
         terminated = true;
         failed = true;
@@ -229,18 +254,21 @@ export function responsesSseToChatCompletionsSse(
         // Deliver the error frame then close the stream abnormally (no [DONE]).
         // Do not controller.error() — that can drop already-enqueued bytes from consumers
         // like response.text().
-        const status = streamErrorStatus(message);
-        const type = streamErrorType(status);
+        const statusHint = details?.status ?? streamErrorStatus(message);
+        const classified = classifyError(statusHint, details?.type ?? "upstream_error", message);
+        if (isCyberPolicyCode(details?.code) || classified.code === CYBER_POLICY_ERROR_CODE) {
+          classified.code = CYBER_POLICY_ERROR_CODE;
+          classified.type = "invalid_request_error";
+        } else if (details?.code !== undefined && details.code !== null && !classified.code) {
+          classified.code = details.code;
+        }
         try {
           controller.enqueue(encoder.encode(dataFrame({
             error: {
-              message,
-              type,
+              message: classified.message,
+              type: classified.type,
               param: null,
-              code: status === 401 ? "invalid_api_key"
-                : status === 404 ? "model_not_found"
-                : status === 429 ? "rate_limit_exceeded"
-                : null,
+              code: classified.code,
             },
           })));
           emittedFrames++;
@@ -373,7 +401,13 @@ export function responsesSseToChatCompletionsSse(
             const response = isRec(data.response) ? data.response : {};
             const error = isRec(response.error) ? response.error : {};
             const message = typeof error.message === "string" ? error.message : "upstream request failed";
-            fail(message);
+            const code = typeof error.code === "string" ? error.code : null;
+            const type = typeof error.type === "string" ? error.type : undefined;
+            fail(message, {
+              code,
+              type,
+              ...(code === CYBER_POLICY_ERROR_CODE ? { status: 400 } : {}),
+            });
             break;
           }
           default:
@@ -555,8 +589,11 @@ export async function collectChatCompletion(
               ? parsed.error.message
               : "upstream request failed";
             const type = typeof parsed.error.type === "string" ? parsed.error.type : "server_error";
-            const status = streamErrorStatus(message);
-            streamError = new ChatCompletionsStreamError(message, { status, type });
+            const code = typeof parsed.error.code === "string" ? parsed.error.code : null;
+            const status = code === CYBER_POLICY_ERROR_CODE || isCyberPolicyMessage(message)
+              ? 400
+              : streamErrorStatus(message);
+            streamError = new ChatCompletionsStreamError(message, { status, type, code });
             continue;
           }
           if (parsed.usage) usage = parsed.usage;

--- a/src/chat/outbound.ts
+++ b/src/chat/outbound.ts
@@ -50,32 +50,27 @@ export function chatCompletionsErrorBody(
   type = "invalid_request_error",
   code?: string | null,
 ): Rec {
-  const classified = classifyError(status, type, message);
-  let resolvedCode: string | null;
-  if (isCyberPolicyCode(code) || classified.code === CYBER_POLICY_ERROR_CODE) {
-    resolvedCode = CYBER_POLICY_ERROR_CODE;
-  } else if (code !== undefined) {
-    resolvedCode = code;
-  } else if (classified.code) {
-    resolvedCode = classified.code;
-  } else if (status === 401) {
-    resolvedCode = "invalid_api_key";
-  } else if (status === 404) {
-    resolvedCode = "model_not_found";
-  } else if (status === 429) {
-    resolvedCode = "rate_limit_exceeded";
-  } else {
-    resolvedCode = null;
+  if (isCyberPolicyCode(code) || isCyberPolicyMessage(message)) {
+    return {
+      error: {
+        message,
+        type: "invalid_request_error",
+        param: null,
+        code: CYBER_POLICY_ERROR_CODE,
+      },
+    };
   }
-  const resolvedType = resolvedCode === CYBER_POLICY_ERROR_CODE
-    ? "invalid_request_error"
-    : (classified.type || type);
   return {
     error: {
       message,
-      type: resolvedType,
+      type,
       param: null,
-      code: resolvedCode,
+      code: code !== undefined
+        ? code
+        : status === 401 ? "invalid_api_key"
+          : status === 404 ? "model_not_found"
+          : status === 429 ? "rate_limit_exceeded"
+          : null,
     },
   };
 }

--- a/src/combos/failover.ts
+++ b/src/combos/failover.ts
@@ -1,4 +1,4 @@
-import { classifyError } from "../lib/errors";
+import { classifyError, isCyberPolicyCode } from "../lib/errors";
 import type { OcxComboTarget } from "../types";
 import { targetKey } from "./types";
 
@@ -79,12 +79,18 @@ export function clearComboTargetCooldowns(comboId?: string): void {
 
 export type ComboFailureDecision = "hop" | "stop";
 
-export function comboFailureDecision(status: number, message: string): ComboFailureDecision {
+export function comboFailureDecision(
+  status: number,
+  message: string,
+  options?: { code?: string | null },
+): ComboFailureDecision {
   if (status === 499) return "stop";
   if (message.toLowerCase().includes("origin_rejected")) return "stop";
+  // Cyber policy is a hard non-retryable refusal — honor structured code even when
+  // classificationText was truncated before the JSON code field.
+  if (isCyberPolicyCode(options?.code)) return "stop";
   const error = classifyError(status, "upstream_error", message);
-  // Cyber policy is a hard non-retryable refusal — do not hop even if status looks transient.
-  if (error.code === "cyber_policy") return "stop";
+  if (isCyberPolicyCode(error.code)) return "stop";
   if (["origin_rejected", "context_length_exceeded", "invalid_request_error"].includes(error.code ?? "")) {
     return "stop";
   }

--- a/src/combos/failover.ts
+++ b/src/combos/failover.ts
@@ -83,6 +83,8 @@ export function comboFailureDecision(status: number, message: string): ComboFail
   if (status === 499) return "stop";
   if (message.toLowerCase().includes("origin_rejected")) return "stop";
   const error = classifyError(status, "upstream_error", message);
+  // Cyber policy is a hard non-retryable refusal — do not hop even if status looks transient.
+  if (error.code === "cyber_policy") return "stop";
   if (["origin_rejected", "context_length_exceeded", "invalid_request_error"].includes(error.code ?? "")) {
     return "stop";
   }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -14,10 +14,14 @@ export function isCyberPolicyCode(code: string | null | undefined): boolean {
 /**
  * Detect OpenAI cyber-policy refusals from message text when structured `code` was stripped.
  * Matches Codex fallback copy and Cursor/API agent wording (session evidence 2026-07-24).
+ * Does not treat a bare `cyber_policy` token as conclusive — model ids / routing errors can
+ * include that substring without being a policy refusal.
  */
 export function isCyberPolicyMessage(text: string): boolean {
   const lower = text.toLowerCase();
-  if (lower.includes("cyber_policy")) return true;
+  // Serialized error-code signatures only (not bare model-id collisions).
+  if (/"code"\s*:\s*"cyber_policy"/.test(lower)) return true;
+  if (/\bcode\s*[:=]\s*["']?cyber_policy\b/.test(lower)) return true;
   if (lower.includes("high-risk cybersecurity")) return true;
   if (lower.includes("high-risk cyber activity") || lower.includes("high-risk cyber ")) return true;
   if (lower.includes("possible cybersecurity risk")) return true;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -4,6 +4,28 @@ export interface OcxErrorPayload {
   code: string | null;
 }
 
+/** OpenAI / Codex hard block for high-risk cybersecurity activity (HTTP 400 or mid-stream). */
+export const CYBER_POLICY_ERROR_CODE = "cyber_policy";
+
+export function isCyberPolicyCode(code: string | null | undefined): boolean {
+  return code === CYBER_POLICY_ERROR_CODE;
+}
+
+/**
+ * Detect OpenAI cyber-policy refusals from message text when structured `code` was stripped.
+ * Matches Codex fallback copy and Cursor/API agent wording (session evidence 2026-07-24).
+ */
+export function isCyberPolicyMessage(text: string): boolean {
+  const lower = text.toLowerCase();
+  if (lower.includes("cyber_policy")) return true;
+  if (lower.includes("high-risk cybersecurity")) return true;
+  if (lower.includes("high-risk cyber activity") || lower.includes("high-risk cyber ")) return true;
+  if (lower.includes("possible cybersecurity risk")) return true;
+  if (lower.includes("flagged") && lower.includes("cybersecurity")) return true;
+  if (lower.includes("flagged") && lower.includes("cyber activity")) return true;
+  return false;
+}
+
 function isSubscriptionGateMessage(text: string): boolean {
   return (
     text.includes("requires a subscription") ||
@@ -89,6 +111,11 @@ export function classifyError(status: number, type: string, message: string): Oc
     isClientClosedMessage(text)
   ) {
     return { message, type: "invalid_request_error", code: "client_closed_request" };
+  }
+  // Codex only shows the dedicated cyber UI when error.code === "cyber_policy".
+  // Prefer that code (and invalid_request_error) over generic remaps / 502 upstream_server_error.
+  if (type === CYBER_POLICY_ERROR_CODE || isCyberPolicyMessage(text)) {
+    return { message, type: "invalid_request_error", code: CYBER_POLICY_ERROR_CODE };
   }
   if (
     text.includes("context_length_exceeded") ||
@@ -234,6 +261,8 @@ export function inferHttpStatusFromAdapterMessage(message: string): number {
   const lower = message.toLowerCase();
   // Client aborts (e.g. mid web-search loop) must not look like upstream 502s in /api/logs.
   if (isClientClosedMessage(lower)) return 499;
+  // Codex Transport maps cyber_policy only on HTTP 400 (SSE is code-based).
+  if (isCyberPolicyMessage(lower)) return 400;
   // See classifyError: this prefix now only means explicit request-size overflow (400);
   // quota-style Cursor resource exhaustion carries the rate-limit prefix and maps to 429.
   if (lower.includes("cursor resource limit exceeded")) return 400;
@@ -305,6 +334,9 @@ export function httpStatusFromTerminalError(error: {
 } | undefined): number {
   if (!error) return 502;
   if (error.code === "client_closed_request" || error.code === "client_cancelled") return 499;
+  if (isCyberPolicyCode(error.code) || (error.message ? isCyberPolicyMessage(error.message) : false)) {
+    return 400;
+  }
   if (error.type === "rate_limit_error" || error.code === "rate_limit_exceeded") return 429;
   if (error.type === "authentication_error" || error.code === "invalid_api_key") return 401;
   if (

--- a/src/server/chat-completions.ts
+++ b/src/server/chat-completions.ts
@@ -14,6 +14,7 @@ import {
   responsesJsonToChatCompletion,
   responsesSseToChatCompletionsSse,
 } from "../chat/outbound";
+import { classifyError } from "../lib/errors";
 import { estimateTokens } from "../lib/token-estimate";
 import { routeModel } from "../router";
 import { resolveWireProtocolOverride } from "./adapter-resolve";
@@ -152,30 +153,52 @@ export async function handleChatCompletions(
 
   if (!response.ok) {
     let message = `upstream error (${response.status})`;
+    let upstreamCode: string | null | undefined;
+    let upstreamType: string | undefined;
     try {
       const text = await response.text();
       try {
-        const parsed = JSON.parse(text) as { error?: { message?: string; type?: string } | string; message?: string };
-        const nested = typeof parsed?.error === "object" && parsed.error ? parsed.error.message : undefined;
+        const parsed = JSON.parse(text) as {
+          error?: { message?: string; type?: string; code?: string | null } | string;
+          message?: string;
+        };
+        const nested = typeof parsed?.error === "object" && parsed.error ? parsed.error : undefined;
         const flat = typeof parsed?.error === "string" ? parsed.error : parsed?.message;
-        message = nested || flat || (text ? `upstream error (${response.status}): ${text.slice(0, 400)}` : message);
+        message = nested?.message || flat || (text ? `upstream error (${response.status}): ${text.slice(0, 400)}` : message);
+        if (nested) {
+          if (typeof nested.type === "string") upstreamType = nested.type;
+          if (nested.code === null || typeof nested.code === "string") upstreamCode = nested.code;
+        }
       } catch {
         if (text) message = `upstream error (${response.status}): ${text.slice(0, 400)}`;
       }
     } catch { /* keep fallback */ }
     const retryAfter = response.headers.get("retry-after");
-    return new Response(JSON.stringify({
-      error: {
-        message,
-        type: response.status === 401 ? "authentication_error"
+    const classified = classifyError(
+      response.status,
+      upstreamType
+        ?? (response.status === 401 ? "authentication_error"
           : response.status === 429 ? "rate_limit_error"
           : response.status >= 500 ? "server_error"
-          : "invalid_request_error",
+          : "invalid_request_error"),
+      message,
+    );
+    if (upstreamCode === "cyber_policy") {
+      classified.code = "cyber_policy";
+      classified.type = "invalid_request_error";
+    } else if (upstreamCode !== undefined && upstreamCode !== null && classified.code == null) {
+      classified.code = upstreamCode;
+    }
+    const status = classified.code === "cyber_policy" ? 400 : response.status;
+    return new Response(JSON.stringify({
+      error: {
+        message: classified.message,
+        type: classified.type,
         param: null,
-        code: null,
+        code: classified.code,
       },
     }), {
-      status: response.status,
+      status,
       headers: {
         "Content-Type": "application/json",
         ...(retryAfter ? { "Retry-After": retryAfter } : {}),
@@ -206,7 +229,7 @@ export async function handleChatCompletions(
       });
     } catch (err) {
       if (isChatCompletionsStreamError(err)) {
-        return chatCompletionsErrorResponse(err.status, err.message, err.type);
+        return chatCompletionsErrorResponse(err.status, err.message, err.type, err.code);
       }
       return chatCompletionsErrorResponse(
         502,
@@ -225,8 +248,19 @@ export async function handleChatCompletions(
   }
   const status = (json as Rec)?.status;
   if (status === "failed") {
-    const error = (json as { error?: { message?: string } }).error;
-    return chatCompletionsErrorResponse(502, error?.message ?? "upstream request failed", "server_error");
+    const error = (json as { error?: { message?: string; type?: string; code?: string | null } }).error;
+    const message = error?.message ?? "upstream request failed";
+    const classified = classifyError(502, error?.type ?? "server_error", message);
+    if (error?.code === "cyber_policy") {
+      classified.code = "cyber_policy";
+      classified.type = "invalid_request_error";
+    }
+    return chatCompletionsErrorResponse(
+      classified.code === "cyber_policy" ? 400 : 502,
+      message,
+      classified.type,
+      classified.code,
+    );
   }
   const completion = responsesJsonToChatCompletion(json, requestedModel);
   if (!stream) {

--- a/src/server/chat-completions.ts
+++ b/src/server/chat-completions.ts
@@ -189,6 +189,10 @@ export async function handleChatCompletions(
     if (isCyberPolicyCode(upstreamCode)) {
       classified.code = CYBER_POLICY_ERROR_CODE;
       classified.type = "invalid_request_error";
+    } else if (upstreamCode === "model_not_found") {
+      // Structured model_not_found must win over classifyError's generic remaps.
+      classified.code = "model_not_found";
+      classified.type = "invalid_request_error";
     } else if (upstreamCode !== undefined && upstreamCode !== null && classified.code == null) {
       classified.code = upstreamCode;
     }
@@ -263,6 +267,10 @@ export async function handleChatCompletions(
     const classified = classifyError(502, error?.type ?? "server_error", message);
     if (isCyberPolicyCode(error?.code)) {
       classified.code = CYBER_POLICY_ERROR_CODE;
+      classified.type = "invalid_request_error";
+    } else if (error?.code === "model_not_found") {
+      // Same deliberate preserve as the non-OK path: structured code beats generic classify.
+      classified.code = "model_not_found";
       classified.type = "invalid_request_error";
     }
     return chatCompletionsErrorResponse(

--- a/src/server/chat-completions.ts
+++ b/src/server/chat-completions.ts
@@ -14,7 +14,8 @@ import {
   responsesJsonToChatCompletion,
   responsesSseToChatCompletionsSse,
 } from "../chat/outbound";
-import { classifyError } from "../lib/errors";
+import { classifyError, CYBER_POLICY_ERROR_CODE, isCyberPolicyCode } from "../lib/errors";
+import { redactSecretString } from "../lib/redact";
 import { estimateTokens } from "../lib/token-estimate";
 import { routeModel } from "../router";
 import { resolveWireProtocolOverride } from "./adapter-resolve";
@@ -147,16 +148,15 @@ export async function handleChatCompletions(
     onNativePassthroughTerminal: status => finalizeNativeLog(httpStatusForTerminalStatus(status), { terminalStatus: status, closeReason: "terminal" }),
     onNativePassthroughCancel: () => finalizeNativeLog(499, { closeReason: "client_cancel" }),
   });
-  const response = logIds
-    ? responseWithDeferredRequestLog(upstream, logIds.requestId, logIds.start, logCtx)
-    : upstream;
 
-  if (!response.ok) {
-    let message = `upstream error (${response.status})`;
+  // Rewrite non-2xx before deferred logging so /api/logs records the client-facing status
+  // (e.g. cyber_policy remapped from a passthrough 5xx to HTTP 400).
+  if (!upstream.ok) {
+    let message = `upstream error (${upstream.status})`;
     let upstreamCode: string | null | undefined;
     let upstreamType: string | undefined;
     try {
-      const text = await response.text();
+      const text = await upstream.text();
       try {
         const parsed = JSON.parse(text) as {
           error?: { message?: string; type?: string; code?: string | null } | string;
@@ -164,33 +164,36 @@ export async function handleChatCompletions(
         };
         const nested = typeof parsed?.error === "object" && parsed.error ? parsed.error : undefined;
         const flat = typeof parsed?.error === "string" ? parsed.error : parsed?.message;
-        message = nested?.message || flat || (text ? `upstream error (${response.status}): ${text.slice(0, 400)}` : message);
+        const rawFallback = text
+          ? `upstream error (${upstream.status}): ${redactSecretString(text).slice(0, 400)}`
+          : message;
+        message = nested?.message || flat || rawFallback;
         if (nested) {
           if (typeof nested.type === "string") upstreamType = nested.type;
           if (nested.code === null || typeof nested.code === "string") upstreamCode = nested.code;
         }
       } catch {
-        if (text) message = `upstream error (${response.status}): ${text.slice(0, 400)}`;
+        if (text) message = `upstream error (${upstream.status}): ${redactSecretString(text).slice(0, 400)}`;
       }
     } catch { /* keep fallback */ }
-    const retryAfter = response.headers.get("retry-after");
+    const retryAfter = upstream.headers.get("retry-after");
     const classified = classifyError(
-      response.status,
+      upstream.status,
       upstreamType
-        ?? (response.status === 401 ? "authentication_error"
-          : response.status === 429 ? "rate_limit_error"
-          : response.status >= 500 ? "server_error"
+        ?? (upstream.status === 401 ? "authentication_error"
+          : upstream.status === 429 ? "rate_limit_error"
+          : upstream.status >= 500 ? "server_error"
           : "invalid_request_error"),
       message,
     );
-    if (upstreamCode === "cyber_policy") {
-      classified.code = "cyber_policy";
+    if (isCyberPolicyCode(upstreamCode)) {
+      classified.code = CYBER_POLICY_ERROR_CODE;
       classified.type = "invalid_request_error";
     } else if (upstreamCode !== undefined && upstreamCode !== null && classified.code == null) {
       classified.code = upstreamCode;
     }
-    const status = classified.code === "cyber_policy" ? 400 : response.status;
-    return new Response(JSON.stringify({
+    const status = isCyberPolicyCode(classified.code) ? 400 : upstream.status;
+    const rewritten = new Response(JSON.stringify({
       error: {
         message: classified.message,
         type: classified.type,
@@ -204,7 +207,14 @@ export async function handleChatCompletions(
         ...(retryAfter ? { "Retry-After": retryAfter } : {}),
       },
     });
+    return logIds
+      ? responseWithDeferredRequestLog(rewritten, logIds.requestId, logIds.start, logCtx)
+      : rewritten;
   }
+
+  const response = logIds
+    ? responseWithDeferredRequestLog(upstream, logIds.requestId, logIds.start, logCtx)
+    : upstream;
 
   const contentType = response.headers.get("content-type") ?? "";
   if (contentType.includes("text/event-stream") && response.body) {
@@ -251,12 +261,12 @@ export async function handleChatCompletions(
     const error = (json as { error?: { message?: string; type?: string; code?: string | null } }).error;
     const message = error?.message ?? "upstream request failed";
     const classified = classifyError(502, error?.type ?? "server_error", message);
-    if (error?.code === "cyber_policy") {
-      classified.code = "cyber_policy";
+    if (isCyberPolicyCode(error?.code)) {
+      classified.code = CYBER_POLICY_ERROR_CODE;
       classified.type = "invalid_request_error";
     }
     return chatCompletionsErrorResponse(
-      classified.code === "cyber_policy" ? 400 : 502,
+      isCyberPolicyCode(classified.code) ? 400 : 502,
       message,
       classified.type,
       classified.code,

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -274,6 +274,8 @@ export function comboUnavailableResponse(message: string): Response {
 export interface ConsumedComboFailure {
   response: Response;
   classificationText: string;
+  /** Structured upstream `error.code` when present in the failure body. */
+  upstreamCode?: string;
   /** Valid numeric/date value used only for cooldown calculation. */
   retryAfter?: string;
   /** Reserved for 040 usage attribution without adding another body read. */
@@ -350,6 +352,7 @@ export async function consumeComboFailure(
       ...(upstreamCode !== undefined ? { code: upstreamCode } : {}),
     }),
     classificationText,
+    ...(upstreamCode !== undefined ? { upstreamCode } : {}),
     ...(retryAfter !== undefined ? { retryAfter } : {}),
     ...(usage ? { usage } : {}),
   };
@@ -785,7 +788,9 @@ export async function handleComboResponses(
     (logCtx.attempts ??= []).push(attempt);
     attemptRetained = true;
     lastFailure = failure.response;
-    if (comboFailureDecision(response.status, failure.classificationText) === "stop") {
+    if (comboFailureDecision(failure.response.status, failure.classificationText, {
+      code: failure.upstreamCode,
+    }) === "stop") {
       Object.assign(logCtx, childLog, {
         requestedModel,
         model: requestedModel,

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -322,12 +322,20 @@ export async function consumeComboFailure(
   const fallback = `Provider error ${response.status}`;
   let classificationText = fallback;
   let usage: OcxUsage | undefined;
+  let upstreamCode: string | undefined;
   try {
     const body = await readBoundedResponseBody(response, { signal });
     usage = usageFromComboFailureText(body.text);
     if (body.displaySafe) {
       const safeText = redactSecretString(body.text).slice(0, 500);
       if (safeText) classificationText = safeText;
+      try {
+        const parsed = JSON.parse(body.text) as { error?: { code?: unknown } | string };
+        const nested = typeof parsed?.error === "object" && parsed.error ? parsed.error.code : undefined;
+        if (typeof nested === "string" && nested.length > 0) upstreamCode = nested;
+      } catch {
+        /* non-JSON upstream body — message-only classification */
+      }
     }
   } catch (error) {
     if (signal?.aborted) throw error;
@@ -338,7 +346,9 @@ export async function consumeComboFailure(
     : `${fallback}: ${classificationText}`;
   const retryAfter = sanitizedRetryAfter(response.headers.get("retry-after"), now);
   return {
-    response: formatErrorResponse(response.status, "upstream_error", message),
+    response: formatErrorResponse(response.status, "upstream_error", message, {
+      ...(upstreamCode !== undefined ? { code: upstreamCode } : {}),
+    }),
     classificationText,
     ...(retryAfter !== undefined ? { retryAfter } : {}),
     ...(usage ? { usage } : {}),

--- a/tests/chat-completions-endpoint.test.ts
+++ b/tests/chat-completions-endpoint.test.ts
@@ -1104,3 +1104,131 @@ test("inbound chat-completions honors the override when stripping sampling (#404
     upstream.stop(true);
   }
 });
+
+test("/v1/chat/completions non-OK upstream preserves structured model_not_found", async () => {
+  const upstream = Bun.serve({
+    port: 0,
+    fetch() {
+      // Generic message would classify to invalid_request_error; structured code must win.
+      return Response.json({
+        error: {
+          message: "Request failed",
+          type: "invalid_request_error",
+          code: "model_not_found",
+        },
+      }, { status: 404 });
+    },
+  });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const requestUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const url = new URL(requestUrl);
+    if (url.hostname === "chatgpt.com" && url.pathname.startsWith("/backend-api/codex")) {
+      return originalFetch(new URL(`${url.pathname.slice("/backend-api/codex".length)}${url.search}`, upstream.url), init);
+    }
+    return originalFetch(input, init);
+  }) as typeof fetch;
+  saveConfig({
+    port: 0,
+    defaultProvider: "openai",
+    providers: {
+      openai: {
+        adapter: "openai-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        authMode: "forward",
+        codexAccountMode: "direct",
+      },
+    },
+  } as OcxConfig);
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/chat/completions", server.url), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: ["Bear" + "er", "caller-direct-token"].join(" "),
+      },
+      body: JSON.stringify({
+        model: "gpt-test",
+        stream: false,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(response.status).toBe(404);
+    const json = await response.json() as { error?: { code?: string; type?: string; message?: string } };
+    expect(json.error).toMatchObject({
+      code: "model_not_found",
+      type: "invalid_request_error",
+      message: "Request failed",
+    });
+  } finally {
+    server.stop(true);
+    upstream.stop(true);
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("/v1/chat/completions status:failed replay preserves structured model_not_found", async () => {
+  const upstream = Bun.serve({
+    port: 0,
+    fetch() {
+      return Response.json({
+        id: "resp_fail",
+        object: "response",
+        status: "failed",
+        error: {
+          message: "Request failed",
+          type: "invalid_request_error",
+          code: "model_not_found",
+        },
+      });
+    },
+  });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const requestUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const url = new URL(requestUrl);
+    if (url.hostname === "chatgpt.com" && url.pathname.startsWith("/backend-api/codex")) {
+      return originalFetch(new URL(`${url.pathname.slice("/backend-api/codex".length)}${url.search}`, upstream.url), init);
+    }
+    return originalFetch(input, init);
+  }) as typeof fetch;
+  saveConfig({
+    port: 0,
+    defaultProvider: "openai",
+    providers: {
+      openai: {
+        adapter: "openai-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        authMode: "forward",
+        codexAccountMode: "direct",
+      },
+    },
+  } as OcxConfig);
+  const server = startServer(0);
+  try {
+    const response = await fetch(new URL("/v1/chat/completions", server.url), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: ["Bear" + "er", "caller-direct-token"].join(" "),
+      },
+      body: JSON.stringify({
+        model: "gpt-test",
+        stream: false,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(response.status).toBe(502);
+    const json = await response.json() as { error?: { code?: string; type?: string; message?: string } };
+    expect(json.error).toMatchObject({
+      code: "model_not_found",
+      type: "invalid_request_error",
+      message: "Request failed",
+    });
+  } finally {
+    server.stop(true);
+    upstream.stop(true);
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/cyber-policy-error-fidelity.test.ts
+++ b/tests/cyber-policy-error-fidelity.test.ts
@@ -275,26 +275,6 @@ describe("cyber_policy error fidelity", () => {
     }]);
   });
 
-  test("chat completions preserves structured model_not_found through classify remaps", async () => {
-    // Mirror the non-OK rewrite path: classifyError would otherwise overwrite a structured code.
-    const classified = classifyError(404, "invalid_request_error", "No such model");
-    expect(classified.code).not.toBe("model_not_found");
-    const body = chatCompletionsErrorBody(404, "No such model", "invalid_request_error", "model_not_found");
-    expect(body).toEqual({
-      error: {
-        message: "No such model",
-        type: "invalid_request_error",
-        param: null,
-        code: "model_not_found",
-      },
-    });
-    const replay = chatCompletionsErrorResponse(502, "No such model", "server_error", "model_not_found");
-    expect(replay.status).toBe(502);
-    await expect(replay.json()).resolves.toMatchObject({
-      error: { code: "model_not_found" },
-    });
-  });
-
   test("httpStatusFromTerminalError and combo failover treat cyber as non-retryable 400", () => {
     expect(httpStatusFromTerminalError({
       type: "invalid_request_error",

--- a/tests/cyber-policy-error-fidelity.test.ts
+++ b/tests/cyber-policy-error-fidelity.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, test } from "bun:test";
+import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
+import { bridgeToResponsesSSE, formatErrorResponse } from "../src/bridge";
+import {
+  chatCompletionsErrorBody,
+  chatCompletionsErrorResponse,
+  responsesSseToChatCompletionsSse,
+} from "../src/chat/outbound";
+import { comboFailureDecision } from "../src/combos/failover";
+import {
+  adapterFailureFromMessage,
+  classifyError,
+  CYBER_POLICY_ERROR_CODE,
+  httpStatusFromTerminalError,
+} from "../src/lib/errors";
+import { formatPassthroughUpstreamError } from "../src/server/responses/passthrough-error";
+import { consumeComboFailure } from "../src/server/responses/core";
+import type { AdapterEvent } from "../src/types";
+
+/** Cursor agent transcript (2026-07-24): mangled provider prefix + OpenAI cyber flag copy. */
+const CURSOR_SESSION_CYBER_MESSAGE =
+  "Unable to reach the model provider OpenAI flagged this request for potential high-risk cybersecurity activity. Please try a less sensitive prompt. Learn more [here](https://platform.openai.com/docs/guides/safety-checks/cybersecurity).";
+
+const OPENAI_CYBER_MESSAGE =
+  "OpenAI flagged this request for potential high-risk cybersecurity activity. Please try a less sensitive prompt.";
+
+const CODEX_FALLBACK_MESSAGE = "This request has been flagged for possible cybersecurity risk.";
+
+const CYBER_ERROR_BODY = {
+  error: {
+    message: OPENAI_CYBER_MESSAGE,
+    type: "invalid_request",
+    param: null,
+    code: CYBER_POLICY_ERROR_CODE,
+  },
+};
+
+async function* replay(events: AdapterEvent[]): AsyncGenerator<AdapterEvent> {
+  for (const event of events) yield event;
+}
+
+async function collectSse(stream: ReadableStream<Uint8Array>): Promise<{ event?: string; data: Record<string, unknown> }[]> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+  }
+  return text.split("\n\n")
+    .map(frame => frame.trim())
+    .filter(frame => frame.length > 0 && frame !== "data: [DONE]")
+    .map(frame => {
+      const lines = frame.split("\n");
+      const event = lines.find(line => line.startsWith("event: "))?.slice(7);
+      const dataLine = lines.find(line => line.startsWith("data: "));
+      return { event, data: JSON.parse(dataLine?.slice(6) ?? "{}") as Record<string, unknown> };
+    });
+}
+
+async function collectAdapter(gen: AsyncGenerator<AdapterEvent>): Promise<AdapterEvent[]> {
+  const out: AdapterEvent[] = [];
+  for await (const event of gen) out.push(event);
+  return out;
+}
+
+describe("cyber_policy error fidelity", () => {
+  test("classifyError maps cyber messages and explicit type to cyber_policy", () => {
+    expect(classifyError(400, "upstream_error", OPENAI_CYBER_MESSAGE)).toMatchObject({
+      type: "invalid_request_error",
+      code: CYBER_POLICY_ERROR_CODE,
+    });
+    expect(classifyError(502, "upstream_error", CURSOR_SESSION_CYBER_MESSAGE)).toMatchObject({
+      code: CYBER_POLICY_ERROR_CODE,
+    });
+    expect(classifyError(400, "upstream_error", CODEX_FALLBACK_MESSAGE)).toMatchObject({
+      code: CYBER_POLICY_ERROR_CODE,
+    });
+    expect(classifyError(400, CYBER_POLICY_ERROR_CODE, "blocked")).toMatchObject({
+      code: CYBER_POLICY_ERROR_CODE,
+    });
+  });
+
+  test("unrelated 400 stays non-cyber", () => {
+    expect(classifyError(400, "upstream_error", "missing required parameter: model")).toMatchObject({
+      type: "invalid_request_error",
+      code: "invalid_request_error",
+    });
+  });
+
+  test("adapterFailureFromMessage prefers HTTP 400 + cyber_policy (not 502)", () => {
+    expect(adapterFailureFromMessage(OPENAI_CYBER_MESSAGE)).toMatchObject({
+      httpStatus: 400,
+      error: { type: "invalid_request_error", code: CYBER_POLICY_ERROR_CODE },
+    });
+    expect(adapterFailureFromMessage(CURSOR_SESSION_CYBER_MESSAGE)).toMatchObject({
+      httpStatus: 400,
+      error: { code: CYBER_POLICY_ERROR_CODE },
+    });
+  });
+
+  test("formatErrorResponse remaps status to 400 and preserves explicit upstream code", async () => {
+    const fromMessage = formatErrorResponse(502, "upstream_error", OPENAI_CYBER_MESSAGE);
+    expect(fromMessage.status).toBe(400);
+    await expect(fromMessage.json()).resolves.toEqual({
+      error: {
+        message: OPENAI_CYBER_MESSAGE,
+        type: "invalid_request_error",
+        code: CYBER_POLICY_ERROR_CODE,
+      },
+    });
+
+    const fromCode = formatErrorResponse(502, "upstream_error", "blocked by safety", {
+      code: CYBER_POLICY_ERROR_CODE,
+    });
+    expect(fromCode.status).toBe(400);
+    await expect(fromCode.json()).resolves.toMatchObject({
+      error: { code: CYBER_POLICY_ERROR_CODE, type: "invalid_request_error" },
+    });
+  });
+
+  test("passthrough HTTP 400 cyber body is relayed verbatim", async () => {
+    const body = JSON.stringify(CYBER_ERROR_BODY);
+    const response = formatPassthroughUpstreamError(400, body);
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe(body);
+  });
+
+  test("consumeComboFailure preserves cyber_policy code as HTTP 400", async () => {
+    const upstream = new Response(JSON.stringify(CYBER_ERROR_BODY), { status: 400 });
+    const failure = await consumeComboFailure(upstream);
+    expect(failure.response.status).toBe(400);
+    await expect(failure.response.json()).resolves.toMatchObject({
+      error: { code: CYBER_POLICY_ERROR_CODE, type: "invalid_request_error" },
+    });
+  });
+
+  test("bridged openai-chat SSE cyber error becomes response.failed with cyber_policy", async () => {
+    const adapter = createOpenAIChatAdapter({
+      adapter: "openai-chat",
+      baseUrl: "https://example.test/v1",
+      apiKey: "key",
+    });
+    const upstream = new Response([
+      'data: {"choices":[{"delta":{"content":"partial"}}]}\n\n',
+      `data: ${JSON.stringify(CYBER_ERROR_BODY)}\n\n`,
+    ].join(""));
+    const events = await collectAdapter(adapter.parseStream(upstream));
+    expect(events.find(e => e.type === "error")).toMatchObject({
+      message: OPENAI_CYBER_MESSAGE,
+      code: CYBER_POLICY_ERROR_CODE,
+      status: 400,
+    });
+
+    const frames = await collectSse(bridgeToResponsesSSE(replay([
+      { type: "text_delta", text: "partial" },
+      {
+        type: "error",
+        message: OPENAI_CYBER_MESSAGE,
+        code: CYBER_POLICY_ERROR_CODE,
+        status: 400,
+      },
+    ]), "openai/gpt-5.4"));
+    const failed = frames.find(frame => frame.event === "response.failed")?.data.response as Record<string, unknown>;
+    expect(failed.error).toMatchObject({
+      type: "invalid_request_error",
+      code: CYBER_POLICY_ERROR_CODE,
+      message: OPENAI_CYBER_MESSAGE,
+    });
+    expect(failed.last_error).toEqual(failed.error);
+    expect(frames.some(frame => frame.event === "response.completed")).toBe(false);
+  });
+
+  test("message-only cyber adapter error still classifies (no silent 502)", async () => {
+    const frames = await collectSse(bridgeToResponsesSSE(replay([
+      { type: "error", message: OPENAI_CYBER_MESSAGE },
+    ]), "openai/gpt-5.4"));
+    const failed = frames.find(frame => frame.event === "response.failed")?.data.response as Record<string, unknown>;
+    expect(failed.error).toMatchObject({ code: CYBER_POLICY_ERROR_CODE });
+  });
+
+  test("chat completions error envelope preserves cyber_policy", async () => {
+    expect(chatCompletionsErrorBody(400, OPENAI_CYBER_MESSAGE, "invalid_request_error", CYBER_POLICY_ERROR_CODE)).toEqual({
+      error: {
+        message: OPENAI_CYBER_MESSAGE,
+        type: "invalid_request_error",
+        param: null,
+        code: CYBER_POLICY_ERROR_CODE,
+      },
+    });
+    const response = chatCompletionsErrorResponse(502, OPENAI_CYBER_MESSAGE, "server_error");
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: CYBER_POLICY_ERROR_CODE, param: null },
+    });
+  });
+
+  test("Responses SSE cyber response.failed maps to chat completions error frame with code", async () => {
+    const responsesSse = [
+      "event: response.created\ndata: {\"type\":\"response.created\"}\n\n",
+      "event: response.failed\n",
+      `data: ${JSON.stringify({
+        type: "response.failed",
+        response: {
+          status: "failed",
+          error: {
+            message: OPENAI_CYBER_MESSAGE,
+            type: "invalid_request_error",
+            code: CYBER_POLICY_ERROR_CODE,
+          },
+        },
+      })}\n\n`,
+    ].join("");
+    const chatSse = responsesSseToChatCompletionsSse(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(responsesSse));
+          controller.close();
+        },
+      }),
+      "gpt-5.4",
+    );
+    const frames = await collectSse(chatSse);
+    const errorFrame = frames.find(frame => frame.data.error);
+    expect(errorFrame?.data.error).toMatchObject({
+      code: CYBER_POLICY_ERROR_CODE,
+      type: "invalid_request_error",
+      message: OPENAI_CYBER_MESSAGE,
+    });
+  });
+
+  test("httpStatusFromTerminalError and combo failover treat cyber as non-retryable 400", () => {
+    expect(httpStatusFromTerminalError({
+      type: "invalid_request_error",
+      code: CYBER_POLICY_ERROR_CODE,
+      message: OPENAI_CYBER_MESSAGE,
+    })).toBe(400);
+    expect(comboFailureDecision(400, OPENAI_CYBER_MESSAGE)).toBe("stop");
+    expect(comboFailureDecision(502, OPENAI_CYBER_MESSAGE)).toBe("stop");
+  });
+});

--- a/tests/cyber-policy-error-fidelity.test.ts
+++ b/tests/cyber-policy-error-fidelity.test.ts
@@ -248,6 +248,53 @@ describe("cyber_policy error fidelity", () => {
     });
   });
 
+  test("openai-chat cyber_policy forces HTTP 400 even when upstream status is 5xx", async () => {
+    const adapter = createOpenAIChatAdapter({
+      adapter: "openai-chat",
+      baseUrl: "https://example.test/v1",
+      apiKey: "key",
+    });
+    const streamEvents = await collectAdapter(adapter.parseStream(new Response([
+      `data: ${JSON.stringify({
+        error: { message: OPENAI_CYBER_MESSAGE, code: CYBER_POLICY_ERROR_CODE, status: 502 },
+      })}\n\n`,
+    ].join(""))));
+    expect(streamEvents.find(e => e.type === "error")).toMatchObject({
+      code: CYBER_POLICY_ERROR_CODE,
+      status: 400,
+    });
+
+    const nonStream = await adapter.parseResponse!(new Response(JSON.stringify({
+      error: { message: OPENAI_CYBER_MESSAGE, code: CYBER_POLICY_ERROR_CODE, status: 500 },
+    })));
+    expect(nonStream).toEqual([{
+      type: "error",
+      message: OPENAI_CYBER_MESSAGE,
+      code: CYBER_POLICY_ERROR_CODE,
+      status: 400,
+    }]);
+  });
+
+  test("chat completions preserves structured model_not_found through classify remaps", async () => {
+    // Mirror the non-OK rewrite path: classifyError would otherwise overwrite a structured code.
+    const classified = classifyError(404, "invalid_request_error", "No such model");
+    expect(classified.code).not.toBe("model_not_found");
+    const body = chatCompletionsErrorBody(404, "No such model", "invalid_request_error", "model_not_found");
+    expect(body).toEqual({
+      error: {
+        message: "No such model",
+        type: "invalid_request_error",
+        param: null,
+        code: "model_not_found",
+      },
+    });
+    const replay = chatCompletionsErrorResponse(502, "No such model", "server_error", "model_not_found");
+    expect(replay.status).toBe(502);
+    await expect(replay.json()).resolves.toMatchObject({
+      error: { code: "model_not_found" },
+    });
+  });
+
   test("httpStatusFromTerminalError and combo failover treat cyber as non-retryable 400", () => {
     expect(httpStatusFromTerminalError({
       type: "invalid_request_error",

--- a/tests/cyber-policy-error-fidelity.test.ts
+++ b/tests/cyber-policy-error-fidelity.test.ts
@@ -87,6 +87,9 @@ describe("cyber_policy error fidelity", () => {
       type: "invalid_request_error",
       code: "invalid_request_error",
     });
+    // Bare model-id collision must not become a cyber refusal.
+    expect(classifyError(404, "upstream_error", "No provider configured for model: cyber_policy").code)
+      .not.toBe(CYBER_POLICY_ERROR_CODE);
   });
 
   test("adapterFailureFromMessage prefers HTTP 400 + cyber_policy (not 502)", () => {
@@ -131,6 +134,7 @@ describe("cyber_policy error fidelity", () => {
     const upstream = new Response(JSON.stringify(CYBER_ERROR_BODY), { status: 400 });
     const failure = await consumeComboFailure(upstream);
     expect(failure.response.status).toBe(400);
+    expect(failure.upstreamCode).toBe(CYBER_POLICY_ERROR_CODE);
     await expect(failure.response.json()).resolves.toMatchObject({
       error: { code: CYBER_POLICY_ERROR_CODE, type: "invalid_request_error" },
     });
@@ -180,7 +184,7 @@ describe("cyber_policy error fidelity", () => {
     expect(failed.error).toMatchObject({ code: CYBER_POLICY_ERROR_CODE });
   });
 
-  test("chat completions error envelope preserves cyber_policy", async () => {
+  test("chat completions error envelope preserves cyber_policy and model_not_found", async () => {
     expect(chatCompletionsErrorBody(400, OPENAI_CYBER_MESSAGE, "invalid_request_error", CYBER_POLICY_ERROR_CODE)).toEqual({
       error: {
         message: OPENAI_CYBER_MESSAGE,
@@ -189,10 +193,24 @@ describe("cyber_policy error fidelity", () => {
         code: CYBER_POLICY_ERROR_CODE,
       },
     });
+    expect(chatCompletionsErrorBody(404, "model not found", "invalid_request_error")).toEqual({
+      error: {
+        message: "model not found",
+        type: "invalid_request_error",
+        param: null,
+        code: "model_not_found",
+      },
+    });
     const response = chatCompletionsErrorResponse(502, OPENAI_CYBER_MESSAGE, "server_error");
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toMatchObject({
       error: { code: CYBER_POLICY_ERROR_CODE, param: null },
+    });
+    // Non-cyber classification must not rewrite HTTP status.
+    const rateLimited = chatCompletionsErrorResponse(502, "Rate limit reached for model", "server_error");
+    expect(rateLimited.status).toBe(502);
+    await expect(rateLimited.json()).resolves.toMatchObject({
+      error: { type: "server_error", code: null },
     });
   });
 
@@ -238,5 +256,9 @@ describe("cyber_policy error fidelity", () => {
     })).toBe(400);
     expect(comboFailureDecision(400, OPENAI_CYBER_MESSAGE)).toBe("stop");
     expect(comboFailureDecision(502, OPENAI_CYBER_MESSAGE)).toBe("stop");
+    // Structured code wins even when the truncated message lacks cyber wording.
+    expect(comboFailureDecision(502, "Provider error 502: " + "x".repeat(600), {
+      code: CYBER_POLICY_ERROR_CODE,
+    })).toBe("stop");
   });
 });

--- a/tests/openai-chat-hardening.test.ts
+++ b/tests/openai-chat-hardening.test.ts
@@ -51,7 +51,11 @@ describe("openai-chat non-stream response hardening", () => {
       error: { message: "upstream quota exhausted", code: "quota_exceeded" },
     })));
 
-    expect(events).toEqual([{ type: "error", message: "upstream quota exhausted" }]);
+    expect(events).toEqual([{
+      type: "error",
+      message: "upstream quota exhausted",
+      code: "quota_exceeded",
+    }]);
   });
 
   test("rejects an empty choices array", async () => {


### PR DESCRIPTION
## Summary
- Preserve OpenAI `cyber_policy` refusals (`code` + HTTP 400) through classify/remap, combo failure, openai-chat bridge, and chat-completions paths so Codex/Cursor show the cyber UI instead of silently stopping.
- Detect cyber refusals from explicit upstream `error.code` or known message heuristics (including Cursor session wording); do not invent bypasses.
- Add focused regression coverage in `tests/cyber-policy-error-fidelity.test.ts` (passthrough, combo, bridged SSE, chat completions, failover stop).

## Context
When OpenAI flags high-risk cybersecurity activity, native Codex surfaces a dedicated notice only when `error.code === "cyber_policy"`. OpenCodex remapping was dropping that code (`invalid_request_error` / 502 `upstream_server_error`), so agents appeared to stop with no reason.

Session evidence (2026-07-24 Cursor transcript): turn ended with mangled `"Unable to reach the model provider OpenAI flagged this request for potential high-risk cybersecurity activity..."`.

Docs: https://developers.openai.com/api/docs/guides/safety-checks/cybersecurity

## Test plan
- [x] `bun test tests/cyber-policy-error-fidelity.test.ts tests/error-fidelity.test.ts tests/errors-adapter-failure.test.ts tests/adapter-error-inline.test.ts`
- [x] `bun run typecheck`
- [x] `bun run privacy:scan`
- [ ] Confirm Codex/Cursor shows cyber notice (not silent stop) when upstream returns 400 `{ code: "cyber_policy" }` via remapped/combo paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error responses by propagating structured `type` and `code`, and mapping cyber-policy violations to HTTP 400 with `invalid_request_error`.
  * Hardened both streaming (SSE) and non-streaming error handling to preserve upstream error details consistently.
  * Updated combo retry behavior so cyber-policy refusals are treated as non-retryable.
* **Tests**
  * Added/expanded end-to-end tests validating cyber-policy fidelity across classification, HTTP/status/body formatting, and streaming bridging.
  * Updated expectations for richer normalized error objects in OpenAI chat hardening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->