### PR TITLE
fix(responses): strip max_output_tokens and metadata in forward mode

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -462,6 +462,23 @@ function stripPreviousResponseId(body: unknown, strip: boolean): unknown {
 }
 
 /**
+ * Remove top-level parameters the ChatGPT backend (`authMode: "forward"`) rejects
+ * with `{"detail":"Unsupported parameter: …"}` (strict allowlist). Codex CLI never
+ * sends these — it controls output length via `reasoning.effort` — but third-party
+ * Responses API clients (GJC, SDK wrappers) include `max_output_tokens` per the
+ * public spec. `metadata` is likewise absent from the allowlist. No-op when the
+ * body carries neither field, keeping the common Codex path allocation-free.
+ */
+function stripUnsupportedForwardParams(body: unknown): unknown {
+  if (!isPlainObject(body)) return body;
+  const hasMot = Object.prototype.hasOwnProperty.call(body, "max_output_tokens");
+  const hasMeta = Object.prototype.hasOwnProperty.call(body, "metadata");
+  if (!hasMot && !hasMeta) return body;
+  const { max_output_tokens: _mot, metadata: _meta, ...rest } = body;
+  return rest;
+}
+
+/**
  * Hosted tool types whose server-side function names collide with the client tools Codex
  * declares for the matching app skill. Codex sends BOTH (e.g. hosted `image_generation` plus a
  * declared `image_gen.imagegen` function/namespace tool for the imagegen skill). The ChatGPT
@@ -644,6 +661,7 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
       );
       if (forward) {
         outBody = repairOrphanedInputItems(outBody, unexpandedMiss);
+        outBody = stripUnsupportedForwardParams(outBody);
       }
       else outBody = stripConflictingHostedTools(outBody);
       if (forward || parsed._previousResponseInputExpanded === true) {

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -667,3 +667,69 @@ describe("OpenAI Responses hosted-tool name conflicts", () => {
     expect(body.tools.some(t => t.type === "function" && t.name === "image_gen.imagegen")).toBe(true);
   });
 });
+
+describe("OpenAI Responses forward-mode unsupported param stripping", () => {
+  const meta = { headers: new Headers({ authorization: "Bearer token" }) };
+  const rawBody = {
+    model: "gpt-5.6-sol",
+    input: [{ role: "user", content: [{ type: "input_text", text: "ping" }] }],
+    stream: true,
+    store: false,
+    max_output_tokens: 32000,
+    metadata: { user_id: "u-1" },
+    reasoning: { effort: "low" },
+  };
+
+  test("forward mode strips max_output_tokens and metadata", () => {
+    const adapter = createResponsesPassthroughAdapter(provider);
+    const request = adapter.buildRequest({
+      modelId: "gpt-5.6-sol",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: { ...rawBody },
+    }, meta);
+    const body = JSON.parse(request.body) as Record<string, unknown>;
+
+    expect(body).not.toHaveProperty("max_output_tokens");
+    expect(body).not.toHaveProperty("metadata");
+    expect(body.reasoning).toEqual({ effort: "low" });
+    expect(body.model).toBe("gpt-5.6-sol");
+  });
+
+  test("forward mode is a no-op when neither field is present", () => {
+    const adapter = createResponsesPassthroughAdapter(provider);
+    const { max_output_tokens: _m, metadata: _d, ...codexBody } = rawBody;
+    const request = adapter.buildRequest({
+      modelId: "gpt-5.6-sol",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: { ...codexBody },
+    }, meta);
+    const body = JSON.parse(request.body) as Record<string, unknown>;
+
+    expect(body.reasoning).toEqual({ effort: "low" });
+    expect(body.store).toBe(false);
+  });
+
+  test("key-auth mode preserves max_output_tokens and metadata", () => {
+    const adapter = createResponsesPassthroughAdapter({
+      adapter: "openai-responses",
+      baseUrl: "https://api.openai.example/v1",
+      authMode: "key",
+      apiKey: "sk-test",
+    });
+    const request = adapter.buildRequest({
+      modelId: "gpt-5.6-sol",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: { ...rawBody },
+    }, { headers: new Headers() });
+    const body = JSON.parse(request.body) as Record<string, unknown>;
+
+    expect(body.max_output_tokens).toBe(32000);
+    expect(body.metadata).toEqual({ user_id: "u-1" });
+  });
+});


### PR DESCRIPTION
## Summary

The ChatGPT backend (`authMode: "forward"`) enforces a strict parameter allowlist and rejects unknown top-level fields with HTTP 400 `{"detail":"Unsupported parameter: …"}`.

The `stripPreviousResponseId` doc-comment (line 452) already documents that the backend also rejects `metadata` and `max_output_tokens`, but only `previous_response_id` was actually stripped. Third-party Responses API clients (e.g. GJC, SDK wrappers) send `max_output_tokens` per the public OpenAI `/v1/responses` spec, causing **every** request through a forward-mode provider to fail with 400.

Codex CLI never sends these fields — it controls output length via `reasoning.effort` — so the strip is a no-op for the primary client. Claude Code uses the `anthropic.ts` adapter and is unaffected. Key-auth mode preserves both fields (the platform API supports them).

**Change:** add `stripUnsupportedForwardParams()` inside the existing `if (forward)` block in `buildRequest()`, removing both `max_output_tokens` and `metadata` before the wire request is serialized.

## Verification

- `bun test tests/openai-responses-passthrough.test.ts` — 29/29 pass (3 new tests)
- `bun run typecheck` — clean
- Live reproduction: the exact request shape that returned 400 (`max_output_tokens: 32000`, `reasoning.effort: "low"`, `store: false`) now returns HTTP 200 with `response.completed` through a forward-mode provider
- New tests cover: forward strips both fields, forward no-op when absent, key-auth preserves both fields

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forwarding compatibility by removing unsupported `max_output_tokens` and `metadata` request parameters before submission.
  * Preserved supported request fields and ensured parameters remain unchanged when using key-based authentication.

* **Tests**
  * Added coverage for parameter removal, no-op behavior when fields are absent, and preservation in key-authenticated requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->