### PR TITLE
fix(oauth): stop OAuth login from deleting a stored provider API key

### DIFF
--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -13,7 +13,7 @@ import { loginAntigravity, refreshAntigravityToken } from "./google-antigravity"
 import { loginCursor, refreshCursorToken } from "./cursor";
 import { loginGithubCopilot, refreshGithubCopilotToken, validateCopilotApiBaseUrl } from "./github-copilot";
 import { deriveOAuthDefaultModel, deriveOAuthProviderConfig } from "../providers/derive";
-import { effectiveGoogleMode } from "../providers/registry";
+import { effectiveGoogleMode, getProviderRegistryEntry } from "../providers/registry";
 import { resolveProviderTransport } from "../providers/xai-transport";
 import { detectClaudeCodeToken, detectGrokCliToken, hasComparableGrokIdentity, isSameGrokIdentity, shouldAdoptGrokGeneration } from "./local-token-detect";
 import { logOAuthEvent } from "./log";
@@ -566,12 +566,29 @@ export function reconcileOAuthProviders(config: OcxConfig): boolean {
   return changed;
 }
 
-/** Add/refresh an OAuth provider's config entry on a config object (does not persist). */
+/**
+ * Add/refresh an OAuth provider's config entry on a config object (does not persist).
+ *
+ * Providers whose registry entry sets `allowKeyAuthOverride` (xai, github-copilot) can be
+ * billed through a stored API key instead of the OAuth login (router.ts honors
+ * `authMode: "key"` for them). A blind preset overwrite here deletes `apiKey`/`apiKeyPool`
+ * on every OAuth login, silently destroying the stored key and forcing a re-paste — and it
+ * flips billing back to the subscription without the user asking. Carry the key fields over
+ * and keep an explicitly chosen `authMode: "key"`, so logging in never changes which
+ * credential bills the request.
+ */
 export function upsertOAuthProvider(config: OcxConfig, provider: string): void {
   if (provider === "chatgpt") return;
   const def = OAUTH_PROVIDERS[provider];
   if (!def) return;
-  config.providers[provider] = { ...def.providerConfig };
+  const existing = config.providers[provider];
+  const next: OcxProviderConfig = { ...def.providerConfig };
+  if (existing && getProviderRegistryEntry(provider)?.allowKeyAuthOverride === true) {
+    if (existing.apiKey !== undefined) next.apiKey = existing.apiKey;
+    if (existing.apiKeyPool !== undefined) next.apiKeyPool = existing.apiKeyPool;
+    if (existing.authMode === "key") next.authMode = "key";
+  }
+  config.providers[provider] = next;
 }
 
 /** Run the login flow, persist the credential + upsert the provider entry to disk, return cred. */

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -611,9 +611,9 @@ function preservableApiKeyPool(value: unknown): NonNullable<OcxProviderConfig["a
  *
  * After preservation, `apiKey` always has exactly one matching pool entry (inserting via the
  * same content-derived id as the API-key manager when the active key was missing from the
- * pool). Key mode is restored only when the previous mode was `"key"` or omitted *and*
- * `resolveEnvValue(apiKey)` yields a non-empty secret — unresolved env references stay
- * preserved as literals but do not flip billing away from the OAuth preset.
+ * pool). Key mode reflects stored user intent (explicit `"key"` or omitted mode with safe
+ * key material) — never whether the login CLI process can resolve an env reference. Env-backed
+ * availability is decided at proxy routing time in `router.ts`.
  */
 export function upsertOAuthProvider(config: OcxConfig, provider: string): void {
   if (provider === "chatgpt") return;
@@ -639,10 +639,8 @@ export function upsertOAuthProvider(config: OcxConfig, provider: string): void {
       }
       next.apiKey = storedApiKey;
       next.apiKeyPool = pool;
-      const resolved = resolveEnvValue(storedApiKey);
-      const usable = typeof resolved === "string" && resolved.trim().length > 0;
       const previousModeAllowsKey = existing.authMode === "key" || existing.authMode === undefined;
-      if (usable && previousModeAllowsKey) next.authMode = "key";
+      if (previousModeAllowsKey) next.authMode = "key";
     }
   }
   config.providers[provider] = next;

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -566,6 +566,42 @@ export function reconcileOAuthProviders(config: OcxConfig): boolean {
   return changed;
 }
 
+/** Runtime guards: provider config is intentionally passthrough, so persisted fields may be malformed. */
+function normalizePreservableApiKey(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed && !/[\r\n]/.test(trimmed) ? trimmed : undefined;
+}
+
+function preservableApiKeyPool(value: unknown): NonNullable<OcxProviderConfig["apiKeyPool"]> | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const pool: NonNullable<OcxProviderConfig["apiKeyPool"]> = [];
+  const ids = new Set<string>();
+  const keys = new Set<string>();
+  for (const entry of value as unknown[]) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+    const candidate = entry as Record<string, unknown>;
+    const id = typeof candidate.id === "string" ? candidate.id.trim() : "";
+    const key = normalizePreservableApiKey(candidate.key);
+    if (!id || !key || ids.has(id) || keys.has(key)) continue;
+    const label = typeof candidate.label === "string" ? candidate.label : undefined;
+    const addedAt = typeof candidate.addedAt === "number" && Number.isFinite(candidate.addedAt)
+      ? candidate.addedAt
+      : undefined;
+    ids.add(id);
+    keys.add(key);
+    pool.push({
+      id,
+      key,
+      ...(label !== undefined ? { label } : {}),
+      ...(addedAt !== undefined ? { addedAt } : {}),
+    });
+  }
+  // `apiKey` remains the routing source of truth. Keep valid alternate slots even when a
+  // hand-edited config left the pool out of sync, rather than deleting usable credentials.
+  return pool.length > 0 ? pool : undefined;
+}
+
 /**
  * Add/refresh an OAuth provider's config entry on a config object (does not persist).
  *
@@ -574,8 +610,10 @@ export function reconcileOAuthProviders(config: OcxConfig): boolean {
  * `authMode: "key"` for them). A blind preset overwrite here deletes `apiKey`/`apiKeyPool`
  * on every OAuth login, silently destroying the stored key and forcing a re-paste — and it
  * flips billing back to the subscription without the user asking. Carry the key fields over
- * and keep an explicitly chosen `authMode: "key"`, so logging in never changes which
- * credential bills the request.
+ * and keep an explicitly chosen `authMode: "key"` while an active stored key remains, so
+ * logging in does not change which credential bills the request. If the final key was removed
+ * and only the old key mode remains, let the OAuth preset restore `authMode: "oauth"` so the
+ * newly saved OAuth credential can be used.
  */
 export function upsertOAuthProvider(config: OcxConfig, provider: string): void {
   if (provider === "chatgpt") return;
@@ -584,9 +622,11 @@ export function upsertOAuthProvider(config: OcxConfig, provider: string): void {
   const existing = config.providers[provider];
   const next: OcxProviderConfig = { ...def.providerConfig };
   if (existing && getProviderRegistryEntry(provider)?.allowKeyAuthOverride === true) {
-    if (existing.apiKey !== undefined) next.apiKey = existing.apiKey;
-    if (existing.apiKeyPool !== undefined) next.apiKeyPool = existing.apiKeyPool;
-    if (existing.authMode === "key") next.authMode = "key";
+    const storedApiKey = normalizePreservableApiKey(existing.apiKey);
+    const storedApiKeyPool = preservableApiKeyPool(existing.apiKeyPool);
+    if (storedApiKey !== undefined) next.apiKey = storedApiKey;
+    if (storedApiKeyPool !== undefined) next.apiKeyPool = storedApiKeyPool;
+    if (existing.authMode === "key" && storedApiKey !== undefined) next.authMode = "key";
   }
   config.providers[provider] = next;
 }

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -13,7 +13,7 @@ import { loginAntigravity, refreshAntigravityToken } from "./google-antigravity"
 import { loginCursor, refreshCursorToken } from "./cursor";
 import { loginGithubCopilot, refreshGithubCopilotToken, validateCopilotApiBaseUrl } from "./github-copilot";
 import { deriveOAuthDefaultModel, deriveOAuthProviderConfig } from "../providers/derive";
-import { sanitizeApiKeyValue } from "../providers/api-keys";
+import { apiKeyPoolEntryId, sanitizeApiKeyValue } from "../providers/api-keys";
 import { effectiveGoogleMode, getProviderRegistryEntry } from "../providers/registry";
 import { resolveProviderTransport } from "../providers/xai-transport";
 import { detectClaudeCodeToken, detectGrokCliToken, hasComparableGrokIdentity, isSameGrokIdentity, shouldAdoptGrokGeneration } from "./local-token-detect";
@@ -608,6 +608,12 @@ function preservableApiKeyPool(value: unknown): NonNullable<OcxProviderConfig["a
  * and keep key billing while usable key material remains and the user was not explicitly on
  * oauth. If the final key was removed and only the old key mode remains, let the OAuth
  * preset restore `authMode: "oauth"` so the newly saved OAuth credential can be used.
+ *
+ * After preservation, `apiKey` always has exactly one matching pool entry (inserting via the
+ * same content-derived id as the API-key manager when the active key was missing from the
+ * pool). Key mode is restored only when the previous mode was `"key"` or omitted *and*
+ * `resolveEnvValue(apiKey)` yields a non-empty secret — unresolved env references stay
+ * preserved as literals but do not flip billing away from the OAuth preset.
  */
 export function upsertOAuthProvider(config: OcxConfig, provider: string): void {
   if (provider === "chatgpt") return;
@@ -624,11 +630,20 @@ export function upsertOAuthProvider(config: OcxConfig, provider: string): void {
     if (storedApiKey === undefined && storedApiKeyPool && storedApiKeyPool.length > 0) {
       storedApiKey = storedApiKeyPool[0]!.key;
     }
-    if (storedApiKey !== undefined) next.apiKey = storedApiKey;
-    if (storedApiKeyPool !== undefined) next.apiKeyPool = storedApiKeyPool;
-    // Router only honors key override when authMode is explicitly "key". Keep key mode
-    // when material survives and the user was not explicitly on oauth billing.
-    if (storedApiKey !== undefined && existing.authMode !== "oauth") next.authMode = "key";
+    if (storedApiKey !== undefined) {
+      const pool = storedApiKeyPool ? [...storedApiKeyPool] : [];
+      // Keep routing and listProviderApiKeys in sync: never leave a hidden active key that
+      // is absent from the pool (listing would fall back to pool[0] as "active").
+      if (!pool.some(entry => entry.key === storedApiKey)) {
+        pool.push({ id: apiKeyPoolEntryId(storedApiKey), key: storedApiKey });
+      }
+      next.apiKey = storedApiKey;
+      next.apiKeyPool = pool;
+      const resolved = resolveEnvValue(storedApiKey);
+      const usable = typeof resolved === "string" && resolved.trim().length > 0;
+      const previousModeAllowsKey = existing.authMode === "key" || existing.authMode === undefined;
+      if (usable && previousModeAllowsKey) next.authMode = "key";
+    }
   }
   config.providers[provider] = next;
 }

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -13,6 +13,7 @@ import { loginAntigravity, refreshAntigravityToken } from "./google-antigravity"
 import { loginCursor, refreshCursorToken } from "./cursor";
 import { loginGithubCopilot, refreshGithubCopilotToken, validateCopilotApiBaseUrl } from "./github-copilot";
 import { deriveOAuthDefaultModel, deriveOAuthProviderConfig } from "../providers/derive";
+import { sanitizeApiKeyValue } from "../providers/api-keys";
 import { effectiveGoogleMode, getProviderRegistryEntry } from "../providers/registry";
 import { resolveProviderTransport } from "../providers/xai-transport";
 import { detectClaudeCodeToken, detectGrokCliToken, hasComparableGrokIdentity, isSameGrokIdentity, shouldAdoptGrokGeneration } from "./local-token-detect";
@@ -567,12 +568,6 @@ export function reconcileOAuthProviders(config: OcxConfig): boolean {
 }
 
 /** Runtime guards: provider config is intentionally passthrough, so persisted fields may be malformed. */
-function normalizePreservableApiKey(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  const trimmed = value.trim();
-  return trimmed && !/[\r\n]/.test(trimmed) ? trimmed : undefined;
-}
-
 function preservableApiKeyPool(value: unknown): NonNullable<OcxProviderConfig["apiKeyPool"]> | undefined {
   if (!Array.isArray(value)) return undefined;
   const pool: NonNullable<OcxProviderConfig["apiKeyPool"]> = [];
@@ -582,7 +577,7 @@ function preservableApiKeyPool(value: unknown): NonNullable<OcxProviderConfig["a
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
     const candidate = entry as Record<string, unknown>;
     const id = typeof candidate.id === "string" ? candidate.id.trim() : "";
-    const key = normalizePreservableApiKey(candidate.key);
+    const key = sanitizeApiKeyValue(candidate.key);
     if (!id || !key || ids.has(id) || keys.has(key)) continue;
     const label = typeof candidate.label === "string" ? candidate.label : undefined;
     const addedAt = typeof candidate.addedAt === "number" && Number.isFinite(candidate.addedAt)
@@ -610,10 +605,9 @@ function preservableApiKeyPool(value: unknown): NonNullable<OcxProviderConfig["a
  * `authMode: "key"` for them). A blind preset overwrite here deletes `apiKey`/`apiKeyPool`
  * on every OAuth login, silently destroying the stored key and forcing a re-paste — and it
  * flips billing back to the subscription without the user asking. Carry the key fields over
- * and keep an explicitly chosen `authMode: "key"` while an active stored key remains, so
- * logging in does not change which credential bills the request. If the final key was removed
- * and only the old key mode remains, let the OAuth preset restore `authMode: "oauth"` so the
- * newly saved OAuth credential can be used.
+ * and keep key billing while usable key material remains and the user was not explicitly on
+ * oauth. If the final key was removed and only the old key mode remains, let the OAuth
+ * preset restore `authMode: "oauth"` so the newly saved OAuth credential can be used.
  */
 export function upsertOAuthProvider(config: OcxConfig, provider: string): void {
   if (provider === "chatgpt") return;
@@ -622,11 +616,19 @@ export function upsertOAuthProvider(config: OcxConfig, provider: string): void {
   const existing = config.providers[provider];
   const next: OcxProviderConfig = { ...def.providerConfig };
   if (existing && getProviderRegistryEntry(provider)?.allowKeyAuthOverride === true) {
-    const storedApiKey = normalizePreservableApiKey(existing.apiKey);
+    // Shared sanitizeApiKeyValue trim / no-CRLF checks from api-key pool writes.
+    let storedApiKey = sanitizeApiKeyValue(existing.apiKey);
     const storedApiKeyPool = preservableApiKeyPool(existing.apiKeyPool);
+    // Unsafe/blank active key with a usable pool: promote the first safe pool entry so
+    // key billing keeps working instead of falling back to oauth while pool keys remain.
+    if (storedApiKey === undefined && storedApiKeyPool && storedApiKeyPool.length > 0) {
+      storedApiKey = storedApiKeyPool[0]!.key;
+    }
     if (storedApiKey !== undefined) next.apiKey = storedApiKey;
     if (storedApiKeyPool !== undefined) next.apiKeyPool = storedApiKeyPool;
-    if (existing.authMode === "key" && storedApiKey !== undefined) next.authMode = "key";
+    // Router only honors key override when authMode is explicitly "key". Keep key mode
+    // when material survives and the user was not explicitly on oauth billing.
+    if (storedApiKey !== undefined && existing.authMode !== "oauth") next.authMode = "key";
   }
   config.providers[provider] = next;
 }

--- a/src/oauth/login-cli.ts
+++ b/src/oauth/login-cli.ts
@@ -2,7 +2,7 @@ import * as readline from "node:readline";
 import { openUrl } from "../lib/open-url";
 import { loadConfig, saveConfig } from "../config";
 import { findLiveProxy, probeHostname } from "../server/proxy-liveness";
-import { isPublicOAuthProvider, listOAuthProviders, OAUTH_PROVIDERS, runLogin } from "./index";
+import { isPublicOAuthProvider, listOAuthProviders, runLogin } from "./index";
 import { KEY_LOGIN_PROVIDERS, isKeyLoginProvider, validateApiKey, type KeyLoginProvider } from "./key-providers";
 import type { OcxProviderConfig } from "../types";
 
@@ -14,7 +14,7 @@ export function runningProxyUpdateHeaders(): Headers {
 }
 
 /** Push the new provider into a running proxy's live config so it routes without a restart. */
-async function notifyRunningProxy(name: string, provider: unknown): Promise<void> {
+export async function notifyRunningProxy(name: string, provider: unknown): Promise<void> {
   // Identity-checked runtime-port lookup: reaches a fallback-port proxy and avoids
   // posting credentials-adjacent config to whatever else answers on config.port.
   const live = await findLiveProxy();
@@ -28,6 +28,19 @@ async function notifyRunningProxy(name: string, provider: unknown): Promise<void
   } catch {
     /* proxy unreachable; disk config loads on next start */
   }
+}
+
+/**
+ * After `runLogin()` has persisted the merged provider (including preserved apiKey /
+ * apiKeyPool / authMode), push that on-disk entry into a running proxy.
+ *
+ * Must not send `OAUTH_PROVIDERS[name].providerConfig`: POST /api/providers replaces the
+ * live entry and saves it, which would drop the preserved key billing state.
+ */
+export async function notifyRunningProxyAfterOAuthLogin(name: string): Promise<void> {
+  const provider = loadConfig().providers[name];
+  if (!provider) return;
+  await notifyRunningProxy(name, provider);
 }
 
 export async function handleLogin(provider?: string): Promise<void> {
@@ -58,7 +71,7 @@ async function handleOAuthLogin(name: string): Promise<void> {
   } finally {
     rl.close();
   }
-  await notifyRunningProxy(name, OAUTH_PROVIDERS[name].providerConfig);
+  await notifyRunningProxyAfterOAuthLogin(name);
   console.log(`\n✅ Logged in to ${name}. Try: ocx sync`);
 }
 

--- a/src/providers/api-keys.ts
+++ b/src/providers/api-keys.ts
@@ -39,6 +39,13 @@ export function isKeyAuthProvider(provider: OcxProviderConfig): boolean {
   return provider.authMode !== "oauth" && provider.authMode !== "forward";
 }
 
+/** Trim and reject blank / CRLF-bearing secrets. Shared by pool writes and OAuth upsert. */
+export function sanitizeApiKeyValue(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed && !/[\r\n]/.test(trimmed) ? trimmed : undefined;
+}
+
 /** Seed the pool from a legacy bare `apiKey`, and keep `apiKey` mirrored to the active entry. */
 function ensurePool(provider: OcxProviderConfig): NonNullable<OcxProviderConfig["apiKeyPool"]> {
   if (!provider.apiKeyPool) provider.apiKeyPool = [];
@@ -75,9 +82,9 @@ export function listProviderApiKeys(config: OcxConfig, name: string): { activeId
 export function addProviderApiKey(config: OcxConfig, name: string, key: string, label?: string): { id: string } | { error: string } {
   const provider = config.providers[name];
   if (!provider || !isKeyAuthProvider(provider)) return { error: "provider does not use API-key auth" };
-  const trimmed = key.trim();
-  if (!trimmed) return { error: "key is required" };
-  if (/[\r\n]/.test(trimmed)) return { error: "key must not include line breaks" };
+  if (typeof key !== "string" || !key.trim()) return { error: "key is required" };
+  const trimmed = sanitizeApiKeyValue(key);
+  if (!trimmed) return { error: "key must not include line breaks" };
   const pool = ensurePool(provider);
   const id = keyId(trimmed);
   const existing = pool.find(e => e.id === id);

--- a/src/providers/api-keys.ts
+++ b/src/providers/api-keys.ts
@@ -30,7 +30,7 @@ export function maskApiKey(value: string): string {
 }
 
 /** Content-derived id: re-adding the same key upserts instead of duplicating. */
-function keyId(key: string): string {
+export function apiKeyPoolEntryId(key: string): string {
   return createHash("sha256").update(key).digest("hex").slice(0, 8);
 }
 
@@ -50,7 +50,7 @@ export function sanitizeApiKeyValue(value: unknown): string | undefined {
 function ensurePool(provider: OcxProviderConfig): NonNullable<OcxProviderConfig["apiKeyPool"]> {
   if (!provider.apiKeyPool) provider.apiKeyPool = [];
   if (provider.apiKeyPool.length === 0 && provider.apiKey) {
-    provider.apiKeyPool.push({ id: keyId(provider.apiKey), key: provider.apiKey });
+    provider.apiKeyPool.push({ id: apiKeyPoolEntryId(provider.apiKey), key: provider.apiKey });
   }
   return provider.apiKeyPool;
 }
@@ -86,7 +86,7 @@ export function addProviderApiKey(config: OcxConfig, name: string, key: string, 
   const trimmed = sanitizeApiKeyValue(key);
   if (!trimmed) return { error: "key must not include line breaks" };
   const pool = ensurePool(provider);
-  const id = keyId(trimmed);
+  const id = apiKeyPoolEntryId(trimmed);
   const existing = pool.find(e => e.id === id);
   if (existing) {
     if (label?.trim()) existing.label = label.trim();

--- a/src/router.ts
+++ b/src/router.ts
@@ -185,15 +185,22 @@ function warnIfBaseUrlDiscarded(providerName: string, userBaseUrl: string, effec
   );
 }
 
+function usableResolvedApiKey(apiKey: string | undefined): string | undefined {
+  const resolved = resolveEnvValue(apiKey);
+  return typeof resolved === "string" && resolved.trim().length > 0 ? resolved : undefined;
+}
+
 function routedProviderConfig(providerName: string, provider: OcxProviderConfig): OcxProviderConfig {
   const registryEntry = PROVIDER_REGISTRY.find(entry => entry.id === providerName);
   if (!registryEntry) {
     assertProviderDestinationAllowed(providerName, provider);
-    return { ...provider, apiKey: resolveEnvValue(provider.apiKey) };
+    return { ...provider, apiKey: usableResolvedApiKey(provider.apiKey) };
   }
+  const resolvedApiKey = usableResolvedApiKey(provider.apiKey);
   const explicitKeyOverride = registryEntry.authKind === "oauth"
     && registryEntry.allowKeyAuthOverride === true
-    && provider.authMode === "key";
+    && provider.authMode === "key"
+    && resolvedApiKey !== undefined;
   const canonicalAuthMode = explicitKeyOverride
     ? "key"
     : registryEntry.authKind === "forward" || registryEntry.authKind === "oauth"
@@ -239,7 +246,7 @@ function routedProviderConfig(providerName: string, provider: OcxProviderConfig)
     adapter: registryEntry.adapter,
     baseUrl,
     authMode: canonicalAuthMode,
-    apiKey: resolveEnvValue(provider.apiKey),
+    apiKey: resolvedApiKey,
     // Backfill the Google wire mode + Vertex project/location from the registry when the user
     // config omits them, so a minimal `google-vertex`/`google-antigravity` entry still routes
     // through the correct branch (CCA/Vertex) instead of falling back to AI Studio.

--- a/tests/oauth-login-cli-live-update.test.ts
+++ b/tests/oauth-login-cli-live-update.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadConfig, saveConfig } from "../src/config";
+import { upsertOAuthProvider } from "../src/oauth";
+import { notifyRunningProxyAfterOAuthLogin } from "../src/oauth/login-cli";
+import { startServer } from "../src/server";
+import type { OcxConfig } from "../src/types";
+import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+
+/**
+ * Regression: CLI OAuth login used to POST the bare OAuth preset into a running proxy.
+ * That wiped the preserved apiKey / apiKeyPool / authMode:"key" that runLogin had just
+ * written, then saved the stripped entry back to disk.
+ */
+let testDir = "";
+let previousHome: string | undefined;
+let isolatedCodexHome: IsolatedCodexHome | null = null;
+
+function keyModeXaiConfig(port = 0): OcxConfig {
+  return {
+    port,
+    hostname: "127.0.0.1",
+    defaultProvider: "xai",
+    providers: {
+      xai: {
+        adapter: "openai-chat",
+        baseUrl: "https://api.x.ai/v1",
+        authMode: "key",
+        apiKey: "live-update-sentinel-key",
+        apiKeyPool: [{ id: "livekey01", key: "live-update-sentinel-key" }],
+      },
+    },
+  } as OcxConfig;
+}
+
+beforeEach(() => {
+  previousHome = process.env.OPENCODEX_HOME;
+  isolatedCodexHome = installIsolatedCodexHome("ocx-oauth-live-codex-");
+  testDir = mkdtempSync(join(tmpdir(), "ocx-oauth-live-"));
+  process.env.OPENCODEX_HOME = testDir;
+  saveConfig(keyModeXaiConfig());
+});
+
+afterEach(() => {
+  if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = previousHome;
+  isolatedCodexHome?.restore();
+  isolatedCodexHome = null;
+  if (testDir) rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("CLI OAuth live-update credential preservation", () => {
+  test("notify after OAuth login keeps key billing on live and disk configs", async () => {
+    const server = startServer(0);
+    try {
+      const port = server.port!;
+      const boot = loadConfig();
+      boot.port = port;
+      saveConfig(boot);
+
+      // Mirror runLogin()'s disk write: upsert preserves key material, then save.
+      const afterLogin = loadConfig();
+      upsertOAuthProvider(afterLogin, "xai");
+      saveConfig(afterLogin);
+      expect(afterLogin.providers.xai!.authMode).toBe("key");
+      expect(afterLogin.providers.xai!.apiKey).toBe("live-update-sentinel-key");
+
+      await notifyRunningProxyAfterOAuthLogin("xai");
+
+      const listed = await fetch(new URL("/api/providers", server.url)).then(r => r.json()) as Array<{
+        name: string;
+        authMode?: string;
+        hasApiKey?: boolean;
+      }>;
+      const live = listed.find(entry => entry.name === "xai");
+      expect(live?.authMode).toBe("key");
+      expect(live?.hasApiKey).toBe(true);
+
+      const pool = await fetch(new URL("/api/providers/keys?name=xai", server.url)).then(r => r.json()) as {
+        activeId: string | null;
+        keys: Array<{ id: string; active: boolean }>;
+      };
+      expect(pool.activeId).toBeTruthy();
+      expect(pool.keys.some(entry => entry.active)).toBe(true);
+
+      const disk = JSON.parse(readFileSync(join(testDir, "config.json"), "utf-8")) as OcxConfig;
+      expect(disk.providers.xai!.authMode).toBe("key");
+      expect(disk.providers.xai!.apiKey).toBe("live-update-sentinel-key");
+      expect(disk.providers.xai!.apiKeyPool?.some(entry => entry.key === "live-update-sentinel-key")).toBe(true);
+    } finally {
+      await server.stop(true);
+    }
+  });
+});

--- a/tests/oauth-upsert-preserves-api-key.test.ts
+++ b/tests/oauth-upsert-preserves-api-key.test.ts
@@ -71,46 +71,91 @@ describe("upsertOAuthProvider credential preservation", () => {
     expect(routeModel(config, "xai/grok-4.5").provider.authMode).toBe("key");
   });
 
-  test("keeps key mode for a defined API key environment reference", () => {
+  test("persists key mode for env-backed keys without consulting the login CLI environment", () => {
     const config = configWithKey("xai", "openai-chat", "https://api.x.ai/v1");
     config.providers.xai!.apiKey = "${OCX_TEST_XAI_API_KEY}";
     config.providers.xai!.apiKeyPool = [{ id: "env-key", key: "${OCX_TEST_XAI_API_KEY}" }];
     const previous = process.env.OCX_TEST_XAI_API_KEY;
-    process.env.OCX_TEST_XAI_API_KEY = "resolved-xai-secret";
+    delete process.env.OCX_TEST_XAI_API_KEY;
     try {
       upsertOAuthProvider(config, "xai");
       const provider = config.providers.xai!;
       expect(provider.apiKey).toBe("${OCX_TEST_XAI_API_KEY}");
       expect(provider.apiKeyPool).toEqual([{ id: "env-key", key: "${OCX_TEST_XAI_API_KEY}" }]);
       expect(provider.authMode).toBe("key");
-      const routed = routeModel(config, "xai/grok-4.5").provider;
-      expect(routed.authMode).toBe("key");
-      expect(routed.apiKey).toBe("resolved-xai-secret");
     } finally {
       if (previous === undefined) delete process.env.OCX_TEST_XAI_API_KEY;
       else process.env.OCX_TEST_XAI_API_KEY = previous;
     }
   });
 
-  test("preserves an unresolved environment reference without forcing key billing", () => {
+  test("falls back to OAuth at routing time when the proxy cannot resolve the active key", () => {
     const config = configWithKey("xai", "openai-chat", "https://api.x.ai/v1");
     config.providers.xai!.apiKey = "${OCX_TEST_XAI_API_KEY_MISSING}";
     config.providers.xai!.apiKeyPool = [{ id: "env-key", key: "${OCX_TEST_XAI_API_KEY_MISSING}" }];
+    upsertOAuthProvider(config, "xai");
+    expect(config.providers.xai!.authMode).toBe("key");
+
     const previous = process.env.OCX_TEST_XAI_API_KEY_MISSING;
     delete process.env.OCX_TEST_XAI_API_KEY_MISSING;
     try {
-      upsertOAuthProvider(config, "xai");
-      const provider = config.providers.xai!;
-      expect(provider.apiKey).toBe("${OCX_TEST_XAI_API_KEY_MISSING}");
-      expect(provider.apiKeyPool).toEqual([{ id: "env-key", key: "${OCX_TEST_XAI_API_KEY_MISSING}" }]);
-      expect(provider.authMode).toBe("oauth");
       const routed = routeModel(config, "xai/grok-4.5").provider;
       expect(routed.authMode).toBe("oauth");
       expect(routed.apiKey).toBeUndefined();
+      expect(config.providers.xai!.authMode).toBe("key");
     } finally {
       if (previous === undefined) delete process.env.OCX_TEST_XAI_API_KEY_MISSING;
       else process.env.OCX_TEST_XAI_API_KEY_MISSING = previous;
     }
+  });
+
+  test("uses key billing at routing time when the proxy resolves the env-backed active key", () => {
+    const config = configWithKey("xai", "openai-chat", "https://api.x.ai/v1");
+    config.providers.xai!.apiKey = "${OCX_TEST_XAI_API_KEY}";
+    config.providers.xai!.apiKeyPool = [{ id: "env-key", key: "${OCX_TEST_XAI_API_KEY}" }];
+    upsertOAuthProvider(config, "xai");
+    expect(config.providers.xai!.authMode).toBe("key");
+
+    const previous = process.env.OCX_TEST_XAI_API_KEY;
+    process.env.OCX_TEST_XAI_API_KEY = "resolved-xai-secret";
+    try {
+      const routed = routeModel(config, "xai/grok-4.5").provider;
+      expect(routed.authMode).toBe("key");
+      expect(routed.apiKey).toBe("resolved-xai-secret");
+      expect(config.providers.xai!.authMode).toBe("key");
+    } finally {
+      if (previous === undefined) delete process.env.OCX_TEST_XAI_API_KEY;
+      else process.env.OCX_TEST_XAI_API_KEY = previous;
+    }
+  });
+
+  test("CLI and proxy env visibility can diverge without rewriting stored authMode", () => {
+    const config = configWithKey("xai", "openai-chat", "https://api.x.ai/v1");
+    config.providers.xai!.apiKey = "${OCX_TEST_XAI_SPLIT_ENV}";
+    config.providers.xai!.apiKeyPool = [{ id: "env-key", key: "${OCX_TEST_XAI_SPLIT_ENV}" }];
+    const previous = process.env.OCX_TEST_XAI_SPLIT_ENV;
+
+    // Login CLI sees the secret; upsert still records key intent, not CLI resolution.
+    process.env.OCX_TEST_XAI_SPLIT_ENV = "cli-only-secret";
+    upsertOAuthProvider(config, "xai");
+    expect(config.providers.xai!.authMode).toBe("key");
+
+    // Running proxy lacks the env var: route on OAuth without touching stored mode.
+    delete process.env.OCX_TEST_XAI_SPLIT_ENV;
+    const oauthFallback = routeModel(config, "xai/grok-4.5").provider;
+    expect(oauthFallback.authMode).toBe("oauth");
+    expect(oauthFallback.apiKey).toBeUndefined();
+    expect(config.providers.xai!.authMode).toBe("key");
+
+    // Proxy later gains the env var: key billing resumes without a config rewrite.
+    process.env.OCX_TEST_XAI_SPLIT_ENV = "proxy-secret";
+    const keyRoute = routeModel(config, "xai/grok-4.5").provider;
+    expect(keyRoute.authMode).toBe("key");
+    expect(keyRoute.apiKey).toBe("proxy-secret");
+    expect(config.providers.xai!.authMode).toBe("key");
+
+    if (previous === undefined) delete process.env.OCX_TEST_XAI_SPLIT_ENV;
+    else process.env.OCX_TEST_XAI_SPLIT_ENV = previous;
   });
 
   test("inserts a missing active key into the pool so listing matches routing", () => {

--- a/tests/oauth-upsert-preserves-api-key.test.ts
+++ b/tests/oauth-upsert-preserves-api-key.test.ts
@@ -3,7 +3,12 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { upsertOAuthProvider } from "../src/oauth";
-import { removeProviderApiKey } from "../src/providers/api-keys";
+import {
+  apiKeyPoolEntryId,
+  listProviderApiKeys,
+  removeProviderApiKey,
+  setActiveProviderApiKey,
+} from "../src/providers/api-keys";
 import { routeModel } from "../src/router";
 import type { OcxConfig } from "../src/types";
 
@@ -66,15 +71,96 @@ describe("upsertOAuthProvider credential preservation", () => {
     expect(routeModel(config, "xai/grok-4.5").provider.authMode).toBe("key");
   });
 
-  test("treats an API key environment reference as stored key material", () => {
+  test("keeps key mode for a defined API key environment reference", () => {
     const config = configWithKey("xai", "openai-chat", "https://api.x.ai/v1");
     config.providers.xai!.apiKey = "${OCX_TEST_XAI_API_KEY}";
     config.providers.xai!.apiKeyPool = [{ id: "env-key", key: "${OCX_TEST_XAI_API_KEY}" }];
-    upsertOAuthProvider(config, "xai");
-    const provider = config.providers.xai!;
-    expect(provider.apiKey).toBe("${OCX_TEST_XAI_API_KEY}");
-    expect(provider.apiKeyPool).toEqual([{ id: "env-key", key: "${OCX_TEST_XAI_API_KEY}" }]);
-    expect(provider.authMode).toBe("key");
+    const previous = process.env.OCX_TEST_XAI_API_KEY;
+    process.env.OCX_TEST_XAI_API_KEY = "resolved-xai-secret";
+    try {
+      upsertOAuthProvider(config, "xai");
+      const provider = config.providers.xai!;
+      expect(provider.apiKey).toBe("${OCX_TEST_XAI_API_KEY}");
+      expect(provider.apiKeyPool).toEqual([{ id: "env-key", key: "${OCX_TEST_XAI_API_KEY}" }]);
+      expect(provider.authMode).toBe("key");
+      const routed = routeModel(config, "xai/grok-4.5").provider;
+      expect(routed.authMode).toBe("key");
+      expect(routed.apiKey).toBe("resolved-xai-secret");
+    } finally {
+      if (previous === undefined) delete process.env.OCX_TEST_XAI_API_KEY;
+      else process.env.OCX_TEST_XAI_API_KEY = previous;
+    }
+  });
+
+  test("preserves an unresolved environment reference without forcing key billing", () => {
+    const config = configWithKey("xai", "openai-chat", "https://api.x.ai/v1");
+    config.providers.xai!.apiKey = "${OCX_TEST_XAI_API_KEY_MISSING}";
+    config.providers.xai!.apiKeyPool = [{ id: "env-key", key: "${OCX_TEST_XAI_API_KEY_MISSING}" }];
+    const previous = process.env.OCX_TEST_XAI_API_KEY_MISSING;
+    delete process.env.OCX_TEST_XAI_API_KEY_MISSING;
+    try {
+      upsertOAuthProvider(config, "xai");
+      const provider = config.providers.xai!;
+      expect(provider.apiKey).toBe("${OCX_TEST_XAI_API_KEY_MISSING}");
+      expect(provider.apiKeyPool).toEqual([{ id: "env-key", key: "${OCX_TEST_XAI_API_KEY_MISSING}" }]);
+      expect(provider.authMode).toBe("oauth");
+      const routed = routeModel(config, "xai/grok-4.5").provider;
+      expect(routed.authMode).toBe("oauth");
+      expect(routed.apiKey).toBeUndefined();
+    } finally {
+      if (previous === undefined) delete process.env.OCX_TEST_XAI_API_KEY_MISSING;
+      else process.env.OCX_TEST_XAI_API_KEY_MISSING = previous;
+    }
+  });
+
+  test("inserts a missing active key into the pool so listing matches routing", () => {
+    const config = {
+      port: 10100,
+      defaultProvider: "xai",
+      providers: {
+        xai: {
+          adapter: "openai-chat",
+          baseUrl: "https://api.x.ai/v1",
+          authMode: "key",
+          apiKey: "routing-only-key",
+          apiKeyPool: [{ id: "pool-visible", key: "pool-visible-key" }],
+        },
+      },
+    } as OcxConfig;
+    const previousHome = process.env.OPENCODEX_HOME;
+    const testHome = mkdtempSync(join(tmpdir(), "ocx-oauth-upsert-pool-"));
+    process.env.OPENCODEX_HOME = testHome;
+    try {
+      upsertOAuthProvider(config, "xai");
+      const provider = config.providers.xai!;
+      const activeId = apiKeyPoolEntryId("routing-only-key");
+      expect(provider.authMode).toBe("key");
+      expect(provider.apiKey).toBe("routing-only-key");
+      expect(provider.apiKeyPool).toEqual([
+        { id: "pool-visible", key: "pool-visible-key" },
+        { id: activeId, key: "routing-only-key" },
+      ]);
+
+      const listed = listProviderApiKeys(config, "xai");
+      expect(listed.activeId).toBe(activeId);
+      expect(listed.keys.find(entry => entry.id === activeId)?.active).toBe(true);
+      expect(listed.keys.find(entry => entry.id === "pool-visible")?.active).toBe(false);
+
+      expect(setActiveProviderApiKey(config, "xai", "pool-visible")).toBe(true);
+      expect(config.providers.xai!.apiKey).toBe("pool-visible-key");
+      expect(listProviderApiKeys(config, "xai").activeId).toBe("pool-visible");
+
+      expect(setActiveProviderApiKey(config, "xai", activeId)).toBe(true);
+      expect(config.providers.xai!.apiKey).toBe("routing-only-key");
+      expect(removeProviderApiKey(config, "xai", activeId)).toBe(true);
+      expect(config.providers.xai!.apiKey).toBe("pool-visible-key");
+      expect(config.providers.xai!.apiKeyPool).toEqual([{ id: "pool-visible", key: "pool-visible-key" }]);
+      expect(listProviderApiKeys(config, "xai").activeId).toBe("pool-visible");
+    } finally {
+      if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+      else process.env.OPENCODEX_HOME = previousHome;
+      rmSync(testHome, { recursive: true, force: true });
+    }
   });
 
   test("drops malformed stored key fields instead of breaking OAuth routing", () => {

--- a/tests/oauth-upsert-preserves-api-key.test.ts
+++ b/tests/oauth-upsert-preserves-api-key.test.ts
@@ -56,6 +56,16 @@ describe("upsertOAuthProvider credential preservation", () => {
     expect(provider.authMode).toBe("oauth");
   });
 
+  test("sets key mode when authMode was omitted but a stored key remains", () => {
+    const config = configWithKey("xai", "openai-chat", "https://api.x.ai/v1");
+    delete config.providers.xai!.authMode;
+    upsertOAuthProvider(config, "xai");
+    const provider = config.providers.xai!;
+    expect(provider.apiKey).toBe("stored-key-sentinel");
+    expect(provider.authMode).toBe("key");
+    expect(routeModel(config, "xai/grok-4.5").provider.authMode).toBe("key");
+  });
+
   test("treats an API key environment reference as stored key material", () => {
     const config = configWithKey("xai", "openai-chat", "https://api.x.ai/v1");
     config.providers.xai!.apiKey = "${OCX_TEST_XAI_API_KEY}";
@@ -88,7 +98,7 @@ describe("upsertOAuthProvider credential preservation", () => {
     expect(routeModel(config, "xai/grok-4.5").provider.authMode).toBe("oauth");
   });
 
-  test("rejects an unsafe active key but keeps valid alternate pool entries", () => {
+  test("rejects an unsafe active key and promotes the first safe pool entry", () => {
     const config = {
       port: 10100,
       defaultProvider: "xai",
@@ -107,10 +117,10 @@ describe("upsertOAuthProvider credential preservation", () => {
     } as OcxConfig;
     upsertOAuthProvider(config, "xai");
     const provider = config.providers.xai!;
-    expect(provider.authMode).toBe("oauth");
-    expect(provider.apiKey).toBeUndefined();
+    expect(provider.authMode).toBe("key");
+    expect(provider.apiKey).toBe("safe-alternate");
     expect(provider.apiKeyPool).toEqual([{ id: "safe", key: "safe-alternate" }]);
-    expect(routeModel(config, "xai/grok-4.5").provider.authMode).toBe("oauth");
+    expect(routeModel(config, "xai/grok-4.5").provider.authMode).toBe("key");
   });
 
   test("filters malformed and duplicate pool data without deleting valid keys", () => {

--- a/tests/oauth-upsert-preserves-api-key.test.ts
+++ b/tests/oauth-upsert-preserves-api-key.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { upsertOAuthProvider } from "../src/oauth";
+import { removeProviderApiKey } from "../src/providers/api-keys";
+import { routeModel } from "../src/router";
 import type { OcxConfig } from "../src/types";
 
 /**
@@ -51,6 +56,106 @@ describe("upsertOAuthProvider credential preservation", () => {
     expect(provider.authMode).toBe("oauth");
   });
 
+  test("treats an API key environment reference as stored key material", () => {
+    const config = configWithKey("xai", "openai-chat", "https://api.x.ai/v1");
+    config.providers.xai!.apiKey = "${OCX_TEST_XAI_API_KEY}";
+    config.providers.xai!.apiKeyPool = [{ id: "env-key", key: "${OCX_TEST_XAI_API_KEY}" }];
+    upsertOAuthProvider(config, "xai");
+    const provider = config.providers.xai!;
+    expect(provider.apiKey).toBe("${OCX_TEST_XAI_API_KEY}");
+    expect(provider.apiKeyPool).toEqual([{ id: "env-key", key: "${OCX_TEST_XAI_API_KEY}" }]);
+    expect(provider.authMode).toBe("key");
+  });
+
+  test("drops malformed stored key fields instead of breaking OAuth routing", () => {
+    const config = {
+      port: 10100,
+      defaultProvider: "xai",
+      providers: {
+        xai: {
+          adapter: "openai-chat",
+          baseUrl: "https://api.x.ai/v1",
+          authMode: "key",
+          apiKey: 12345,
+          apiKeyPool: [{ id: "bad-key", key: 67890 }],
+        },
+      },
+    } as unknown as OcxConfig;
+    upsertOAuthProvider(config, "xai");
+    expect(config.providers.xai!.authMode).toBe("oauth");
+    expect(config.providers.xai!.apiKey).toBeUndefined();
+    expect(config.providers.xai!.apiKeyPool).toBeUndefined();
+    expect(routeModel(config, "xai/grok-4.5").provider.authMode).toBe("oauth");
+  });
+
+  test("rejects an unsafe active key but keeps valid alternate pool entries", () => {
+    const config = {
+      port: 10100,
+      defaultProvider: "xai",
+      providers: {
+        xai: {
+          adapter: "openai-chat",
+          baseUrl: "https://api.x.ai/v1",
+          authMode: "key",
+          apiKey: "unsafe\r\nheader",
+          apiKeyPool: [
+            { id: "safe", key: " safe-alternate " },
+            { id: "unsafe", key: "bad\r\nheader" },
+          ],
+        },
+      },
+    } as OcxConfig;
+    upsertOAuthProvider(config, "xai");
+    const provider = config.providers.xai!;
+    expect(provider.authMode).toBe("oauth");
+    expect(provider.apiKey).toBeUndefined();
+    expect(provider.apiKeyPool).toEqual([{ id: "safe", key: "safe-alternate" }]);
+    expect(routeModel(config, "xai/grok-4.5").provider.authMode).toBe("oauth");
+  });
+
+  test("filters malformed and duplicate pool data without deleting valid keys", () => {
+    const config = configWithKey("xai", "openai-chat", "https://api.x.ai/v1");
+    config.providers.xai!.apiKeyPool = [
+      { id: "primary", key: "stored-key-sentinel" },
+      { id: "alternate", key: " alternate-key " },
+      { id: "alternate", key: "duplicate-id" },
+      { id: "duplicate-key", key: "alternate-key" },
+      { id: "bad-added-at", key: "bad-metadata", addedAt: Number.NaN },
+    ];
+    upsertOAuthProvider(config, "xai");
+    const provider = config.providers.xai!;
+    expect(provider.authMode).toBe("key");
+    expect(provider.apiKey).toBe("stored-key-sentinel");
+    expect(provider.apiKeyPool).toEqual([
+      { id: "primary", key: "stored-key-sentinel" },
+      { id: "alternate", key: "alternate-key" },
+      { id: "bad-added-at", key: "bad-metadata" },
+    ]);
+  });
+
+  test("returns to oauth after the last stored API key is removed", () => {
+    const config = configWithKey("xai", "openai-chat", "https://api.x.ai/v1");
+    const previousHome = process.env.OPENCODEX_HOME;
+    const testHome = mkdtempSync(join(tmpdir(), "ocx-oauth-upsert-"));
+    process.env.OPENCODEX_HOME = testHome;
+    try {
+      expect(removeProviderApiKey(config, "xai", "aaaaaaaa")).toBe(true);
+      expect(config.providers.xai!.authMode).toBe("key");
+      expect(config.providers.xai!.apiKey).toBeUndefined();
+      expect(config.providers.xai!.apiKeyPool).toBeUndefined();
+
+      upsertOAuthProvider(config, "xai");
+      const provider = config.providers.xai!;
+      expect(provider.authMode).toBe("oauth");
+      expect(provider.apiKey).toBeUndefined();
+      expect(provider.apiKeyPool).toBeUndefined();
+    } finally {
+      if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+      else process.env.OPENCODEX_HOME = previousHome;
+      rmSync(testHome, { recursive: true, force: true });
+    }
+  });
+
   test("still applies the plain preset for oauth-only providers", () => {
     const config = {
       port: 10100,
@@ -59,7 +164,9 @@ describe("upsertOAuthProvider credential preservation", () => {
         anthropic: {
           adapter: "anthropic",
           baseUrl: "https://api.anthropic.com",
-          authMode: "oauth",
+          authMode: "key",
+          apiKey: "stale-key",
+          apiKeyPool: [{ id: "stale", key: "stale-key" }],
           note: "stale-note",
         },
       },
@@ -68,6 +175,7 @@ describe("upsertOAuthProvider credential preservation", () => {
     const provider = config.providers.anthropic!;
     expect(provider.authMode).toBe("oauth");
     expect(provider.apiKey).toBeUndefined();
+    expect(provider.apiKeyPool).toBeUndefined();
     expect(provider.note).toBeUndefined();
   });
 

--- a/tests/oauth-upsert-preserves-api-key.test.ts
+++ b/tests/oauth-upsert-preserves-api-key.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { upsertOAuthProvider } from "../src/oauth";
+import type { OcxConfig } from "../src/types";
+
+/**
+ * Regression: `upsertOAuthProvider` used to overwrite the provider entry with the bare preset
+ * on every OAuth login, deleting a stored `apiKey`/`apiKeyPool` and silently flipping an
+ * explicit `authMode: "key"` billing choice back to the subscription. Providers whose registry
+ * entry sets `allowKeyAuthOverride` (xai, github-copilot) are the ones that can hold both.
+ */
+function configWithKey(provider: string, adapter: string, baseUrl: string): OcxConfig {
+  return {
+    port: 10100,
+    defaultProvider: provider,
+    providers: {
+      [provider]: {
+        adapter,
+        baseUrl,
+        authMode: "key",
+        apiKey: "stored-key-sentinel",
+        apiKeyPool: [{ id: "aaaaaaaa", key: "stored-key-sentinel" }],
+      },
+    },
+  } as unknown as OcxConfig;
+}
+
+describe("upsertOAuthProvider credential preservation", () => {
+  test("keeps a stored API key and the explicit key billing mode for xai", () => {
+    const config = configWithKey("xai", "openai-chat", "https://api.x.ai/v1");
+    upsertOAuthProvider(config, "xai");
+    const provider = config.providers.xai!;
+    expect(provider.apiKey).toBe("stored-key-sentinel");
+    expect(provider.apiKeyPool).toEqual([{ id: "aaaaaaaa", key: "stored-key-sentinel" }]);
+    expect(provider.authMode).toBe("key");
+  });
+
+  test("keeps a stored API key for github-copilot", () => {
+    const config = configWithKey("github-copilot", "openai-chat", "https://api.githubcopilot.com");
+    upsertOAuthProvider(config, "github-copilot");
+    const provider = config.providers["github-copilot"]!;
+    expect(provider.apiKey).toBe("stored-key-sentinel");
+    expect(provider.authMode).toBe("key");
+  });
+
+  test("carries the key over without changing oauth billing when the user did not pick key mode", () => {
+    const config = configWithKey("xai", "openai-chat", "https://api.x.ai/v1");
+    config.providers.xai!.authMode = "oauth";
+    upsertOAuthProvider(config, "xai");
+    const provider = config.providers.xai!;
+    expect(provider.apiKey).toBe("stored-key-sentinel");
+    expect(provider.authMode).toBe("oauth");
+  });
+
+  test("still applies the plain preset for oauth-only providers", () => {
+    const config = {
+      port: 10100,
+      defaultProvider: "anthropic",
+      providers: {
+        anthropic: {
+          adapter: "anthropic",
+          baseUrl: "https://api.anthropic.com",
+          authMode: "oauth",
+          note: "stale-note",
+        },
+      },
+    } as unknown as OcxConfig;
+    upsertOAuthProvider(config, "anthropic");
+    const provider = config.providers.anthropic!;
+    expect(provider.authMode).toBe("oauth");
+    expect(provider.apiKey).toBeUndefined();
+    expect(provider.note).toBeUndefined();
+  });
+
+  test("a fresh login on an unconfigured provider gets the untouched preset", () => {
+    const config = { port: 10100, defaultProvider: "openai", providers: {} } as unknown as OcxConfig;
+    upsertOAuthProvider(config, "xai");
+    const provider = config.providers.xai!;
+    expect(provider.authMode).toBe("oauth");
+    expect(provider.apiKey).toBeUndefined();
+    expect(provider.apiKeyPool).toBeUndefined();
+  });
+});

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -39,6 +39,33 @@ describe("routeModel registry effort defaults", () => {
     expect(routeModel(cursorKeyAttempt, "cursor/auto").provider.authMode).toBe("oauth");
   });
 
+  test("falls back to OAuth routing for allowKeyAuthOverride providers when the active key is unresolved", () => {
+    const envName = "OCX_TEST_XAI_ROUTER_ENV";
+    const config: OcxConfig = {
+      port: 10100,
+      defaultProvider: "xai",
+      providers: {
+        xai: {
+          adapter: "openai-chat",
+          baseUrl: "https://api.x.ai/v1",
+          authMode: "key",
+          apiKey: `\${${envName}}`,
+        },
+      },
+    };
+    const previous = process.env[envName];
+    delete process.env[envName];
+    try {
+      const routed = routeModel(config, "xai/grok-4.5").provider;
+      expect(routed.authMode).toBe("oauth");
+      expect(routed.apiKey).toBeUndefined();
+      expect(config.providers.xai!.authMode).toBe("key");
+    } finally {
+      if (previous === undefined) delete process.env[envName];
+      else process.env[envName] = previous;
+    }
+  });
+
   test("routes bare OpenAI/Codex model ids to OpenAI before adopted Cursor model lists", () => {
     const config: OcxConfig = {
       port: 10100,


### PR DESCRIPTION
## Summary

`upsertOAuthProvider` replaced a provider's config entry with the bare preset on every OAuth login:

```ts
config.providers[provider] = { ...def.providerConfig };
```

For providers that can be billed either way — registry entries with `allowKeyAuthOverride` (`xai`, `github-copilot`) — this deleted `apiKey` and `apiKeyPool` from `config.json` and silently flipped an explicit `authMode: "key"` billing choice back to the subscription. The stored key was gone and had to be pasted again, with no message saying so.

`router.ts` already honors `authMode: "key"` for exactly these providers, so the two credentials are meant to coexist. This makes the write path agree with the routing path.

## Change

Carry `apiKey` / `apiKeyPool` over, and keep an explicitly chosen `authMode: "key"`, so logging in never changes which credential bills the request. OAuth-only providers and fresh logins still get the untouched preset — only `allowKeyAuthOverride` entries with an existing config are treated specially.

## Testing

New `tests/oauth-upsert-preserves-api-key.test.ts`, 5 cases:

- xai: stored key, pool, and `authMode: "key"` all survive a login
- github-copilot: same preservation
- key carried over but `authMode: "oauth"` untouched when the user did not pick key billing
- oauth-only provider (`anthropic`) still gets the plain preset, stale user fields dropped
- fresh login on an unconfigured provider gets the untouched preset

Ran locally against this branch:

- `bun test tests/oauth-upsert-preserves-api-key.test.ts` — 5 pass
- `bun test` on the adjacent OAuth/key suites (`oauth-provider-reconcile`, `oauth-accounts-api`, `provider-api-keys`, `oauth-public-surface`, `xai-oauth-retry`, `github-copilot-oauth`) — 32 pass, 0 fail
- `bun x tsc --noEmit` — clean
- `bun scripts/privacy-scan.ts` — passed

Not run: the full `bun scripts/test.ts` suite.

## Notes

I hit this while looking into a report that Claude's API key and OAuth login could not be signed in at the same time. `anthropic` is not an `allowKeyAuthOverride` entry, so that case is separate — the dedicated `anthropic-apikey` registry entry already covers it, and this PR does not touch that. This fix is only about the key-deleting write path on the providers where both credentials are supported.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - OAuth sign-ins now preserve existing API keys and key-based authentication settings for supported providers.
  - OAuth-only providers apply the correct OAuth preset and no longer retain key credentials.
  - When stored keys are missing or invalid, the provider configuration falls back appropriately.
- **Tests**
  - Added regression coverage for credential preservation, sanitization/cleanup, and correct auth-mode transitions during OAuth provider upserts.
- **Chores**
  - Updated the package version to 2.7.40.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->