### PR TITLE
fix(openai-responses): handle image tool conflicts in additional_tools

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -496,26 +496,81 @@ const HOSTED_TOOL_NAME_CONFLICTS: ReadonlyArray<{ hostedType: string; namePrefix
  * HOSTED_TOOL_NAME_CONFLICTS). Only applies on the API-key platform path: the ChatGPT backend
  * ("forward" mode) accepts the pair, and stripping there would disable native imagegen. No-op
  * (returns the original reference) when nothing matches.
+ *
+ * Codex Desktop Responses Lite requests do not always use top-level `body.tools`; they may place
+ * the same declarations in `body.input[]` entries of type `additional_tools`. The platform validates
+ * these containers as one tool namespace, so conflict detection must span all of them. The function
+ * uses copy-on-write semantics and preserves the original request reference when nothing is removed.
  */
 function stripConflictingHostedTools(body: unknown): unknown {
-  if (!isPlainObject(body) || !Array.isArray(body.tools)) return body;
-  const allTools = body.tools;
+  if (!isPlainObject(body)) return body;
 
-  const conflicting = HOSTED_TOOL_NAME_CONFLICTS.filter(c =>
-    allTools.some(t => {
+  // Collect every tool container in the request. Traditional HTTP/SSE requests use top-level
+  // `tools`, while Responses Lite may carry the same declarations in `additional_tools` entries.
+  const toolGroups: unknown[][] = [];
+  if (Array.isArray(body.tools)) toolGroups.push(body.tools);
+  if (Array.isArray(body.input)) {
+    for (const item of body.input) {
+      if (isPlainObject(item) && item.type === "additional_tools" && Array.isArray(item.tools)) {
+        toolGroups.push(item.tools);
+      }
+    }
+  }
+  if (toolGroups.length === 0) return body;
+
+  // Detect conflicts across containers because the client namespace and the hosted tool may be
+  // declared in different groups while still sharing one platform-validated namespace.
+  const conflicting = HOSTED_TOOL_NAME_CONFLICTS.filter(c => toolGroups.some(group =>
+    group.some(t => {
       if (!isPlainObject(t) || typeof t.name !== "string") return false;
       if (t.type === "namespace") return t.name === c.namePrefix;
       return t.name === c.namePrefix || t.name.startsWith(`${c.namePrefix}.`);
     }),
-  );
+  ));
   if (conflicting.length === 0) return body;
 
-  const tools = allTools.filter(t => {
-    const type = isPlainObject(t) && typeof t.type === "string" ? t.type : undefined;
-    if (!type) return true;
-    return !conflicting.some(c => c.hostedType === type);
-  });
-  return tools.length === allTools.length ? body : { ...body, tools };
+  // Allocate a replacement only when a hosted tool is removed. Preserve malformed entries,
+  // unrelated tools, and future tool types so this compatibility rule remains narrowly scoped.
+  const stripGroup = (tools: unknown[]): unknown[] => {
+    const filtered = tools.filter(t => {
+      const type = isPlainObject(t) && typeof t.type === "string" ? t.type : undefined;
+      if (!type) return true;
+      return !conflicting.some(c => c.hostedType === type);
+    });
+    return filtered.length === tools.length ? tools : filtered;
+  };
+
+  let changed = false;
+  let tools = body.tools;
+  if (Array.isArray(body.tools)) {
+    tools = stripGroup(body.tools);
+    changed ||= tools !== body.tools;
+  }
+
+  let input = body.input;
+  if (Array.isArray(body.input)) {
+    let nestedChanged = false;
+    const mappedInput = body.input.map(item => {
+      if (!isPlainObject(item) || item.type !== "additional_tools" || !Array.isArray(item.tools)) {
+        return item;
+      }
+      const nestedTools = stripGroup(item.tools);
+      if (nestedTools === item.tools) return item;
+      nestedChanged = true;
+      return { ...item, tools: nestedTools };
+    });
+    if (nestedChanged) {
+      input = mappedInput;
+      changed = true;
+    }
+  }
+
+  if (!changed) return body;
+  return {
+    ...body,
+    ...(Array.isArray(body.tools) ? { tools } : {}),
+    ...(Array.isArray(body.input) ? { input } : {}),
+  };
 }
 
 /**

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -56,6 +56,14 @@ existing account-health state. Unknown Images subpaths still reach the JSON `/v1
 On non-loopback binds, data-plane authentication and origin policy cover both Images routes just as
 they cover `/v1/responses`; clients must send the configured `x-opencodex-api-key`.
 
+The API-key `openai-responses` path also prevents the standalone client tool from colliding with the
+hosted Responses tool. When a request declares `image_gen.imagegen` (as a flat function or an
+`image_gen` namespace), the adapter drops hosted `image_generation` while preserving unrelated
+tools. Conflict discovery spans both top-level `body.tools` and Codex Desktop Responses Lite
+`input[].type = "additional_tools"` containers because the platform validates their merged tool
+namespace. ChatGPT forward mode preserves the pair because that backend accepts it and owns native
+image generation.
+
 ## Cursor Native Exec
 
 Cursor's experimental live transport can receive server-driven local read/write/delete/ls/grep,

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -621,6 +621,77 @@ describe("OpenAI Responses hosted-tool name conflicts", () => {
     expect(body.tools.some(t => t.type === "image_generation")).toBe(false);
   });
 
+  test("keyed responses-lite strips hosted image_generation from nested additional_tools", () => {
+    const adapter = createResponsesPassthroughAdapter(keyedProvider);
+    const request = adapter.buildRequest({
+      modelId: "gpt-5.6-sol",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: {
+        model: "gpt-5.6-sol",
+        input: [
+          {
+            type: "additional_tools",
+            role: "developer",
+            tools: [
+              { type: "namespace", name: "image_gen", tools: [] },
+              { type: "image_generation" },
+              { type: "web_search" },
+            ],
+          },
+          { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+        ],
+      },
+    }, meta);
+    const body = JSON.parse(request.body) as {
+      input: Array<{ type: string; role?: string; tools?: Array<{ type: string; name?: string }> }>;
+    };
+    const additionalTools = body.input.find(item => item.type === "additional_tools");
+
+    // Preserve the input entry and unrelated tools while removing only the hosted conflict.
+    expect(additionalTools).toBeDefined();
+    expect(additionalTools?.role).toBe("developer");
+    expect(additionalTools?.tools?.some(t => t.type === "image_generation")).toBe(false);
+    expect(additionalTools?.tools?.some(t => t.type === "namespace" && t.name === "image_gen")).toBe(true);
+    expect(additionalTools?.tools?.some(t => t.type === "web_search")).toBe(true);
+    expect(body.input.some(item => item.type === "message")).toBe(true);
+  });
+
+  test("keyed responses-lite detects image_gen conflicts across top-level and nested tool groups", () => {
+    const adapter = createResponsesPassthroughAdapter(keyedProvider);
+    const request = adapter.buildRequest({
+      modelId: "gpt-5.6-sol",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: {
+        model: "gpt-5.6-sol",
+        tools: [
+          { type: "image_generation" },
+          { type: "web_search" },
+        ],
+        input: [
+          {
+            type: "additional_tools",
+            role: "developer",
+            tools: [{ type: "function", name: "image_gen.imagegen", parameters: {} }],
+          },
+        ],
+      },
+    }, meta);
+    const body = JSON.parse(request.body) as {
+      tools: Array<{ type: string }>;
+      input: Array<{ type: string; tools?: Array<{ type: string; name?: string }> }>;
+    };
+    const additionalTools = body.input.find(item => item.type === "additional_tools");
+
+    // The platform validates one merged namespace even when declarations use different groups.
+    expect(body.tools.some(t => t.type === "image_generation")).toBe(false);
+    expect(body.tools.some(t => t.type === "web_search")).toBe(true);
+    expect(additionalTools?.tools?.some(t => t.name === "image_gen.imagegen")).toBe(true);
+  });
+
   test("keyed platform keeps hosted image_generation when no conflicting tool is declared", () => {
     const adapter = createResponsesPassthroughAdapter(keyedProvider);
     const request = adapter.buildRequest({


### PR DESCRIPTION
## Summary

- detect hosted-tool namespace conflicts across both top-level `body.tools` and Responses Lite `input[].type = "additional_tools"` tool groups
- remove conflicting hosted `image_generation` entries from every tool group on the API-key `openai-responses` path
- preserve unrelated tools, unknown entries, message input items, and ChatGPT forward-mode behavior

## Problem

Codex Desktop can send its client-side `image_gen` namespace in a nested Responses Lite item:

```json
{
  "input": [
    {
      "type": "additional_tools",
      "tools": [
        { "type": "namespace", "name": "image_gen", "tools": [] },
        { "type": "image_generation" }
      ]
    }
  ]
}
```

The platform validates these declarations as one tool namespace and rejects the request because the user-defined `image_gen` namespace collides with the hosted image-generation tool.

PR #90 added the correct API-key-path policy for the top-level `body.tools` shape, but the sanitizer returned early when no top-level array existed. Responses Lite requests therefore still reached the platform with the conflicting nested pair.

## Implementation

`stripConflictingHostedTools` now:

1. Collects top-level and nested `additional_tools` arrays.
2. Detects client namespace declarations across the combined request, including both `image_gen` namespace tools and flat `image_gen.*` function names.
3. Removes only the matching hosted tool type from every collected group.
4. Uses copy-on-write behavior so unchanged groups and requests preserve their original references.

The sanitizer remains limited to the API-key path. ChatGPT forward mode continues to preserve the hosted and client declarations because that backend accepts the pair and owns native image generation.

## Tests

- `bun test --isolate tests/openai-responses-passthrough.test.ts` — 31 passed, 0 failed
- `bun node_modules/typescript/bin/tsc --noEmit` — passed
- `bun scripts/privacy-scan.ts` — passed
- Full `bun scripts/test.ts` was stopped after unrelated Windows dependency/runtime failures: the bundled-Bun fixture could not resolve after the dependency postinstall failed, and existing Anthropic endpoint tests exceeded their built-in 5-second timeout. The full suite was not rerun with a longer timeout.

## Related work

- Follow-up to #90
- Adjacent image-generation routing issue: #83



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented conflicting hosted image-generation tools from being included when equivalent local image tools are declared.
  * Improved conflict handling for tools provided in nested request inputs while preserving unrelated tools.

* **Documentation**
  * Clarified standalone image behavior, supported tool formats, and differences between API-key and ChatGPT forwarding modes.

* **Tests**
  * Added coverage for nested tool groups and conflicts spanning multiple tool containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->