### PR TITLE
fix(state): recover abandoned response snapshots

### DIFF
--- a/src/responses/state.ts
+++ b/src/responses/state.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, truncateSync, unlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { atomicWriteFile, getConfigDir } from "../config";
 import type { OcxProviderContinuationState } from "../types";
@@ -14,6 +14,10 @@ const MAX_STORED_RESPONSE_BYTES = 64 * 1024 * 1024;
  * carry base64 `input_image` data URLs, and one screenshot-heavy thread must not balloon the file. */
 const SNAPSHOT_ENTRY_MAX_BYTES = 2 * 1024 * 1024;
 const SNAPSHOT_TOTAL_MAX_BYTES = 24 * 1024 * 1024;
+const STALE_TEMP_GRACE_MS = 15 * 60 * 1_000;
+const STALE_TEMP_MAX_CANDIDATES = 4_096;
+const STALE_TEMP_MAX_CLEANUPS = 512;
+const RESPONSE_STATE_TEMP_NAME = /^responses-state\.json\.ocx\.(\d+)\.(\d+)\.tmp$/;
 
 interface StoredResponseState {
   createdAt: number;
@@ -88,6 +92,102 @@ function snapshotPath(): string {
   return join(getConfigDir(), "responses-state.json");
 }
 
+export interface ResponseStateTempRecoveryResult {
+  matched: number;
+  removed: number;
+  scrubbed: number;
+  failed: number;
+  bytesRemoved: number;
+}
+
+interface ResponseStateTempRecoveryIO {
+  now: () => number;
+  list: (dir: string) => string[];
+  inspect: (path: string) => { isFile: boolean; mtimeMs: number; size: number };
+  isProcessAlive: (pid: number) => boolean;
+  truncate: (path: string) => void;
+  unlink: (path: string) => void;
+}
+
+function processIsAlive(pid: number): boolean {
+  if (pid === process.pid) return true;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists but cannot be signalled. Unknown platform errors
+    // are also protected; cleanup should prefer a false negative over touching a live writer.
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+const responseStateTempRecoveryIO: ResponseStateTempRecoveryIO = {
+  now: Date.now,
+  list: dir => readdirSync(dir),
+  inspect: path => {
+    const stat = lstatSync(path);
+    return { isFile: stat.isFile() && !stat.isSymbolicLink(), mtimeMs: stat.mtimeMs, size: stat.size };
+  },
+  isProcessAlive: processIsAlive,
+  truncate: path => truncateSync(path, 0),
+  unlink: unlinkSync,
+};
+
+/**
+ * Recover only abandoned response-state atomic-write files. The exact basename,
+ * regular-file check, age gate, and PID liveness check protect unrelated/active files.
+ * Cleanup is capped and best-effort because continuation state is only a cache.
+ */
+export function recoverStaleResponseStateTemps(
+  dir = getConfigDir(),
+  overrides: Partial<ResponseStateTempRecoveryIO> = {},
+): ResponseStateTempRecoveryResult {
+  const io = { ...responseStateTempRecoveryIO, ...overrides };
+  const result: ResponseStateTempRecoveryResult = {
+    matched: 0,
+    removed: 0,
+    scrubbed: 0,
+    failed: 0,
+    bytesRemoved: 0,
+  };
+  let names: string[];
+  try { names = io.list(dir); } catch { return result; }
+  let candidates = 0;
+  for (const name of names) {
+    const match = RESPONSE_STATE_TEMP_NAME.exec(name);
+    if (!match) continue;
+    candidates += 1;
+    if (candidates > STALE_TEMP_MAX_CANDIDATES || result.removed + result.failed >= STALE_TEMP_MAX_CLEANUPS) break;
+    result.matched += 1;
+    const pid = Number(match[1]);
+    const sequence = Number(match[2]);
+    if (!Number.isSafeInteger(pid) || pid <= 0 || !Number.isSafeInteger(sequence) || sequence <= 0) continue;
+    const path = join(dir, name);
+    let file: ReturnType<ResponseStateTempRecoveryIO["inspect"]>;
+    try { file = io.inspect(path); } catch { continue; }
+    if (!file.isFile || io.now() - file.mtimeMs < STALE_TEMP_GRACE_MS) continue;
+    if (pid === process.pid || io.isProcessAlive(pid)) continue;
+
+    let scrubbed = false;
+    try {
+      io.truncate(path);
+      scrubbed = true;
+      result.scrubbed += 1;
+    } catch { /* unlink may still remove the sensitive snapshot */ }
+    try {
+      io.unlink(path);
+      result.removed += 1;
+      result.bytesRemoved += file.size;
+    } catch {
+      // A zero-byte residual is harmless privacy-wise but should still count as a
+      // cleanup failure so a later startup can retry its removal.
+      result.failed += 1;
+      if (!scrubbed) continue;
+    }
+  }
+  return result;
+}
+
 /**
  * Best-effort disk snapshot so previous_response_id chains survive a proxy restart (the
  * dominant expansion-miss cause: an in-memory-only store dies with the process, and the next
@@ -100,6 +200,7 @@ function ensureLoaded(): void {
   loaded = true;
   try {
     const path = snapshotPath();
+    recoverStaleResponseStateTemps(dirname(path));
     if (!existsSync(path)) return;
     const raw = JSON.parse(readFileSync(path, "utf-8")) as { version?: unknown; states?: unknown };
     if ((raw.version !== 1 && raw.version !== 2) || !Array.isArray(raw.states)) return;

--- a/src/responses/state.ts
+++ b/src/responses/state.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, truncateSync, unlinkSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, mkdirSync, opendirSync, readFileSync, unlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { atomicWriteFile, getConfigDir } from "../config";
 import type { OcxProviderContinuationState } from "../types";
@@ -95,19 +95,22 @@ function snapshotPath(): string {
 export interface ResponseStateTempRecoveryResult {
   matched: number;
   removed: number;
-  scrubbed: number;
   failed: number;
   bytesRemoved: number;
 }
 
 interface ResponseStateTempRecoveryIO {
   now: () => number;
-  list: (dir: string) => string[];
+  list: (dir: string) => Iterable<string>;
   inspect: (path: string) => { isFile: boolean; mtimeMs: number; size: number };
   isProcessAlive: (pid: number) => boolean;
-  truncate: (path: string) => void;
   unlink: (path: string) => void;
 }
+
+type ResponseStateTempRecoveryOptions = Partial<ResponseStateTempRecoveryIO> & {
+  maxCandidates?: number;
+  maxCleanups?: number;
+};
 
 function processIsAlive(pid: number): boolean {
   if (pid === process.pid) return true;
@@ -123,41 +126,48 @@ function processIsAlive(pid: number): boolean {
 
 const responseStateTempRecoveryIO: ResponseStateTempRecoveryIO = {
   now: Date.now,
-  list: dir => readdirSync(dir),
+  list: function* list(dir) {
+    const handle = opendirSync(dir);
+    try {
+      for (let entry = handle.readSync(); entry; entry = handle.readSync()) yield entry.name;
+    } finally {
+      handle.closeSync();
+    }
+  },
   inspect: path => {
     const stat = lstatSync(path);
     return { isFile: stat.isFile() && !stat.isSymbolicLink(), mtimeMs: stat.mtimeMs, size: stat.size };
   },
   isProcessAlive: processIsAlive,
-  truncate: path => truncateSync(path, 0),
   unlink: unlinkSync,
 };
 
 /**
  * Recover only abandoned response-state atomic-write files. The exact basename,
  * regular-file check, age gate, and PID liveness check protect unrelated/active files.
- * Cleanup is capped and best-effort because continuation state is only a cache.
+ * Cleanup is capped and best-effort because continuation state is only a cache. Removal
+ * deliberately uses unlink only: path-based truncation could follow a replacement symlink.
  */
 export function recoverStaleResponseStateTemps(
   dir = getConfigDir(),
-  overrides: Partial<ResponseStateTempRecoveryIO> = {},
+  options: ResponseStateTempRecoveryOptions = {},
 ): ResponseStateTempRecoveryResult {
+  const { maxCandidates = STALE_TEMP_MAX_CANDIDATES, maxCleanups = STALE_TEMP_MAX_CLEANUPS, ...overrides } = options;
   const io = { ...responseStateTempRecoveryIO, ...overrides };
   const result: ResponseStateTempRecoveryResult = {
     matched: 0,
     removed: 0,
-    scrubbed: 0,
     failed: 0,
     bytesRemoved: 0,
   };
-  let names: string[];
+  let names: Iterable<string>;
   try { names = io.list(dir); } catch { return result; }
   let candidates = 0;
   for (const name of names) {
     const match = RESPONSE_STATE_TEMP_NAME.exec(name);
     if (!match) continue;
     candidates += 1;
-    if (candidates > STALE_TEMP_MAX_CANDIDATES || result.removed + result.failed >= STALE_TEMP_MAX_CLEANUPS) break;
+    if (candidates > maxCandidates || result.removed + result.failed >= maxCleanups) break;
     result.matched += 1;
     const pid = Number(match[1]);
     const sequence = Number(match[2]);
@@ -168,21 +178,14 @@ export function recoverStaleResponseStateTemps(
     if (!file.isFile || io.now() - file.mtimeMs < STALE_TEMP_GRACE_MS) continue;
     if (pid === process.pid || io.isProcessAlive(pid)) continue;
 
-    let scrubbed = false;
-    try {
-      io.truncate(path);
-      scrubbed = true;
-      result.scrubbed += 1;
-    } catch { /* unlink may still remove the sensitive snapshot */ }
     try {
       io.unlink(path);
       result.removed += 1;
       result.bytesRemoved += file.size;
     } catch {
-      // A zero-byte residual is harmless privacy-wise but should still count as a
-      // cleanup failure so a later startup can retry its removal.
+      // Locked files remain for a later startup. Do not truncate by path: a same-user
+      // replacement could turn that fallback into an arbitrary symlink-target write.
       result.failed += 1;
-      if (!scrubbed) continue;
     }
   }
   return result;
@@ -198,9 +201,13 @@ export function recoverStaleResponseStateTemps(
 function ensureLoaded(): void {
   if (loaded) return;
   loaded = true;
+  const path = snapshotPath();
   try {
-    const path = snapshotPath();
     recoverStaleResponseStateTemps(dirname(path));
+  } catch {
+    /* best-effort cleanup only; snapshot loading must remain independent */
+  }
+  try {
     if (!existsSync(path)) return;
     const raw = JSON.parse(readFileSync(path, "utf-8")) as { version?: unknown; states?: unknown };
     if ((raw.version !== 1 && raw.version !== 2) || !Array.isArray(raw.states)) return;

--- a/src/responses/state.ts
+++ b/src/responses/state.ts
@@ -15,7 +15,7 @@ const MAX_STORED_RESPONSE_BYTES = 64 * 1024 * 1024;
 const SNAPSHOT_ENTRY_MAX_BYTES = 2 * 1024 * 1024;
 const SNAPSHOT_TOTAL_MAX_BYTES = 24 * 1024 * 1024;
 const STALE_TEMP_GRACE_MS = 15 * 60 * 1_000;
-const STALE_TEMP_MAX_CANDIDATES = 4_096;
+const STALE_TEMP_MAX_ENTRIES = 4_096;
 const STALE_TEMP_MAX_CLEANUPS = 512;
 const RESPONSE_STATE_TEMP_NAME = /^responses-state\.json\.ocx\.(\d+)\.(\d+)\.tmp$/;
 
@@ -108,7 +108,7 @@ interface ResponseStateTempRecoveryIO {
 }
 
 type ResponseStateTempRecoveryOptions = Partial<ResponseStateTempRecoveryIO> & {
-  maxCandidates?: number;
+  maxEntries?: number;
   maxCleanups?: number;
 };
 
@@ -152,7 +152,7 @@ export function recoverStaleResponseStateTemps(
   dir = getConfigDir(),
   options: ResponseStateTempRecoveryOptions = {},
 ): ResponseStateTempRecoveryResult {
-  const { maxCandidates = STALE_TEMP_MAX_CANDIDATES, maxCleanups = STALE_TEMP_MAX_CLEANUPS, ...overrides } = options;
+  const { maxEntries = STALE_TEMP_MAX_ENTRIES, maxCleanups = STALE_TEMP_MAX_CLEANUPS, ...overrides } = options;
   const io = { ...responseStateTempRecoveryIO, ...overrides };
   const result: ResponseStateTempRecoveryResult = {
     matched: 0,
@@ -162,12 +162,12 @@ export function recoverStaleResponseStateTemps(
   };
   let names: Iterable<string>;
   try { names = io.list(dir); } catch { return result; }
-  let candidates = 0;
+  let scanned = 0;
   for (const name of names) {
+    scanned += 1;
+    if (scanned > maxEntries || result.removed + result.failed >= maxCleanups) break;
     const match = RESPONSE_STATE_TEMP_NAME.exec(name);
     if (!match) continue;
-    candidates += 1;
-    if (candidates > maxCandidates || result.removed + result.failed >= maxCleanups) break;
     result.matched += 1;
     const pid = Number(match[1]);
     const sequence = Number(match[2]);

--- a/src/responses/state.ts
+++ b/src/responses/state.ts
@@ -162,8 +162,14 @@ export function recoverStaleResponseStateTemps(
   };
   let names: Iterable<string>;
   try { names = io.list(dir); } catch { return result; }
+  let iterator: Iterator<string>;
+  try { iterator = names[Symbol.iterator](); } catch { return result; }
   let scanned = 0;
-  for (const name of names) {
+  for (;;) {
+    let next: IteratorResult<string>;
+    try { next = iterator.next(); } catch { return result; }
+    if (next.done) break;
+    const name = next.value;
     scanned += 1;
     if (scanned > maxEntries || result.removed + result.failed >= maxCleanups) break;
     const match = RESPONSE_STATE_TEMP_NAME.exec(name);

--- a/structure/02_config-and-codex-home.md
+++ b/structure/02_config-and-codex-home.md
@@ -19,6 +19,21 @@ the resolved `CODEX_HOME`.
 sequence number) to avoid collisions when concurrent writers (e.g. `ocx stop` and the proxy's own
 shutdown handler) both restore Codex config simultaneously. The temp is renamed atomically into place.
 
+Response-state loading performs a bounded recovery pass for interrupted snapshot writes. It only
+matches regular files named `responses-state.json.ocx.<pid>.<sequence>.tmp`, waits at least 15
+minutes, and skips the current or any live PID. Eligible files are truncated before unlinking so a
+Windows lock that prevents deletion can still leave a privacy-safe zero-byte residual. Unrelated
+temporary files, symlinks, directories, and young/active writes are never touched; at most 512 stale
+files are attempted per process start.
+
+[Decision Log]
+- 목적과 의도: Bound disk and conversation-state retention after abrupt process termination.
+- 기존 구현 및 제약 조건: Ordinary write failures clean up immediately, but a killed process cannot run that path and Windows may temporarily lock files.
+- 검토한 주요 대안: Delete every `.tmp`, rely on manual cleanup, or recover only exact response-state remnants with age and PID guards.
+- 선택한 방식: Run a capped, best-effort, truncate-before-unlink sweep on lazy response-state startup.
+- 다른 대안 대신 이 방식을 선택한 이유: It repairs known remnants without broad authority over unrelated temp files or active writers.
+- 장점, 단점 및 영향: Old dead-PID files are reclaimed automatically; locked or conservatively classified files remain for a later retry.
+
 ## Config injection
 
 `src/codex/inject.ts` inserts root-level keys and an opencodex provider table:

--- a/structure/02_config-and-codex-home.md
+++ b/structure/02_config-and-codex-home.md
@@ -22,15 +22,16 @@ shutdown handler) both restore Codex config simultaneously. The temp is renamed 
 Response-state loading performs a bounded recovery pass for interrupted snapshot writes. It only
 matches regular files named `responses-state.json.ocx.<pid>.<sequence>.tmp`, waits at least 15
 minutes, and skips the current or any live PID. Eligible files are truncated before unlinking so a
-Windows lock that prevents deletion can still leave a privacy-safe zero-byte residual. Unrelated
-temporary files, symlinks, directories, and young/active writes are never touched; at most 512 stale
-files are attempted per process start.
+matching stale path is unlinked without following it. Path-based truncation is intentionally avoided:
+a same-user replacement could otherwise turn cleanup into a write through a symlink. Unrelated
+temporary files, symlinks, directories, and young/active writes are never touched; directory entries
+are consumed incrementally and at most 512 stale files are attempted per process start.
 
 [Decision Log]
 - 목적과 의도: Bound disk and conversation-state retention after abrupt process termination.
 - 기존 구현 및 제약 조건: Ordinary write failures clean up immediately, but a killed process cannot run that path and Windows may temporarily lock files.
 - 검토한 주요 대안: Delete every `.tmp`, rely on manual cleanup, or recover only exact response-state remnants with age and PID guards.
-- 선택한 방식: Run a capped, best-effort, truncate-before-unlink sweep on lazy response-state startup.
+- 선택한 방식: Run a capped, best-effort, unlink-only sweep on lazy response-state startup.
 - 다른 대안 대신 이 방식을 선택한 이유: It repairs known remnants without broad authority over unrelated temp files or active writers.
 - 장점, 단점 및 영향: Old dead-PID files are reclaimed automatically; locked or conservatively classified files remain for a later retry.
 

--- a/tests/responses-state.test.ts
+++ b/tests/responses-state.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildResponseJSON } from "../src/bridge";
@@ -14,6 +14,7 @@ import {
   flushResponseState,
   previousResponseConversationId,
   previousResponseProviderState,
+  recoverStaleResponseStateTemps,
   rememberResponseState,
   responseStateMetrics,
   setResponseStateByteCapForTests,
@@ -648,6 +649,44 @@ describe("Responses previous_response_id state", () => {
       { role: "user", content: "next" },
     ]);
     expect(previousResponseConversationId(first.id as string)).toBe("cursor_conv_9");
+  });
+
+  test("recovers only old response-state temps owned by dead processes", () => {
+    const old = new Date(Date.now() - 60 * 60 * 1_000);
+    const stale = join(home, "responses-state.json.ocx.4242.1.tmp");
+    const live = join(home, "responses-state.json.ocx.5252.2.tmp");
+    const current = join(home, `responses-state.json.ocx.${process.pid}.3.tmp`);
+    const young = join(home, "responses-state.json.ocx.6262.4.tmp");
+    const unrelated = join(home, "responses-state.json.ocx.7272.tmp");
+    const directory = join(home, "responses-state.json.ocx.8282.5.tmp");
+    for (const path of [stale, live, current, young, unrelated]) writeFileSync(path, "private state");
+    mkdirSync(directory);
+    for (const path of [stale, live, current, unrelated, directory]) utimesSync(path, old, old);
+
+    const result = recoverStaleResponseStateTemps(home, {
+      isProcessAlive: pid => pid === 5252,
+    });
+
+    expect(result).toMatchObject({ matched: 5, removed: 1, scrubbed: 1, failed: 0 });
+    expect(result.bytesRemoved).toBe("private state".length);
+    expect(existsSync(stale)).toBe(false);
+    for (const path of [live, current, young, unrelated, directory]) expect(existsSync(path)).toBe(true);
+  });
+
+  test("stale temp recovery is best-effort when scrub and unlink both fail", () => {
+    const path = join(home, "responses-state.json.ocx.4242.1.tmp");
+    writeFileSync(path, "private state");
+    const old = new Date(Date.now() - 60 * 60 * 1_000);
+    utimesSync(path, old, old);
+
+    const result = recoverStaleResponseStateTemps(home, {
+      isProcessAlive: () => false,
+      truncate: () => { throw new Error("locked"); },
+      unlink: () => { throw new Error("locked"); },
+    });
+
+    expect(result).toMatchObject({ matched: 1, removed: 0, scrubbed: 0, failed: 1, bytesRemoved: 0 });
+    expect(readFileSync(path, "utf-8")).toBe("private state");
   });
 
   test("v1 Cursor snapshot migrates to versioned provider state", () => {

--- a/tests/responses-state.test.ts
+++ b/tests/responses-state.test.ts
@@ -653,7 +653,8 @@ describe("Responses previous_response_id state", () => {
 
   test("recovers only old response-state temps owned by dead processes", () => {
     const old = new Date(Date.now() - 60 * 60 * 1_000);
-    const stale = join(home, "responses-state.json.ocx.4242.1.tmp");
+    const deadPid = process.pid === 4242 ? 4243 : 4242;
+    const stale = join(home, `responses-state.json.ocx.${deadPid}.1.tmp`);
     const live = join(home, "responses-state.json.ocx.5252.2.tmp");
     const current = join(home, `responses-state.json.ocx.${process.pid}.3.tmp`);
     const young = join(home, "responses-state.json.ocx.6262.4.tmp");
@@ -667,26 +668,54 @@ describe("Responses previous_response_id state", () => {
       isProcessAlive: pid => pid === 5252,
     });
 
-    expect(result).toMatchObject({ matched: 5, removed: 1, scrubbed: 1, failed: 0 });
+    expect(result).toMatchObject({ matched: 5, removed: 1, failed: 0 });
     expect(result.bytesRemoved).toBe("private state".length);
     expect(existsSync(stale)).toBe(false);
     for (const path of [live, current, young, unrelated, directory]) expect(existsSync(path)).toBe(true);
   });
 
-  test("stale temp recovery is best-effort when scrub and unlink both fail", () => {
-    const path = join(home, "responses-state.json.ocx.4242.1.tmp");
+  test("stale temp recovery is best-effort when unlink fails", () => {
+    const deadPid = process.pid === 4242 ? 4243 : 4242;
+    const path = join(home, `responses-state.json.ocx.${deadPid}.1.tmp`);
     writeFileSync(path, "private state");
     const old = new Date(Date.now() - 60 * 60 * 1_000);
     utimesSync(path, old, old);
 
     const result = recoverStaleResponseStateTemps(home, {
       isProcessAlive: () => false,
-      truncate: () => { throw new Error("locked"); },
       unlink: () => { throw new Error("locked"); },
     });
 
-    expect(result).toMatchObject({ matched: 1, removed: 0, scrubbed: 0, failed: 1, bytesRemoved: 0 });
+    expect(result).toMatchObject({ matched: 1, removed: 0, failed: 1, bytesRemoved: 0 });
     expect(readFileSync(path, "utf-8")).toBe("private state");
+  });
+
+  test("stale temp recovery stops at injectable candidate and cleanup caps", () => {
+    const old = new Date(Date.now() - 60 * 60 * 1_000);
+    const first = "responses-state.json.ocx.7001.1.tmp";
+    const second = "responses-state.json.ocx.7002.2.tmp";
+    for (const name of [first, second]) {
+      const path = join(home, name);
+      writeFileSync(path, "private state");
+      utimesSync(path, old, old);
+    }
+
+    const candidateBound = recoverStaleResponseStateTemps(home, {
+      list: () => [first, second],
+      isProcessAlive: pid => pid === 7001,
+      maxCandidates: 1,
+    });
+    expect(candidateBound).toMatchObject({ matched: 1, removed: 0, failed: 0 });
+    expect(existsSync(join(home, second))).toBe(true);
+
+    const cleanupBound = recoverStaleResponseStateTemps(home, {
+      list: () => [first, second],
+      isProcessAlive: () => false,
+      maxCleanups: 1,
+    });
+    expect(cleanupBound).toMatchObject({ matched: 1, removed: 1, failed: 0 });
+    expect(existsSync(join(home, first))).toBe(false);
+    expect(existsSync(join(home, second))).toBe(true);
   });
 
   test("v1 Cursor snapshot migrates to versioned provider state", () => {

--- a/tests/responses-state.test.ts
+++ b/tests/responses-state.test.ts
@@ -718,6 +718,17 @@ describe("Responses previous_response_id state", () => {
     expect(existsSync(join(home, second))).toBe(true);
   });
 
+  test("stale temp recovery remains best-effort when enumeration fails", () => {
+    const result = recoverStaleResponseStateTemps(home, {
+      list: function* () {
+        yield "unrelated.txt";
+        throw new Error("directory read failed");
+      },
+    });
+
+    expect(result).toEqual({ matched: 0, removed: 0, failed: 0, bytesRemoved: 0 });
+  });
+
   test("v1 Cursor snapshot migrates to versioned provider state", () => {
     mkdirSync(home, { recursive: true });
     writeFileSync(join(home, "responses-state.json"), JSON.stringify({

--- a/tests/responses-state.test.ts
+++ b/tests/responses-state.test.ts
@@ -690,7 +690,7 @@ describe("Responses previous_response_id state", () => {
     expect(readFileSync(path, "utf-8")).toBe("private state");
   });
 
-  test("stale temp recovery stops at injectable candidate and cleanup caps", () => {
+  test("stale temp recovery stops at injectable enumeration and cleanup caps", () => {
     const old = new Date(Date.now() - 60 * 60 * 1_000);
     const first = "responses-state.json.ocx.7001.1.tmp";
     const second = "responses-state.json.ocx.7002.2.tmp";
@@ -700,12 +700,12 @@ describe("Responses previous_response_id state", () => {
       utimesSync(path, old, old);
     }
 
-    const candidateBound = recoverStaleResponseStateTemps(home, {
-      list: () => [first, second],
-      isProcessAlive: pid => pid === 7001,
-      maxCandidates: 1,
+    const enumerationBound = recoverStaleResponseStateTemps(home, {
+      list: () => ["unrelated.txt", second],
+      isProcessAlive: () => false,
+      maxEntries: 1,
     });
-    expect(candidateBound).toMatchObject({ matched: 1, removed: 0, failed: 0 });
+    expect(enumerationBound).toMatchObject({ matched: 0, removed: 0, failed: 0 });
     expect(existsSync(join(home, second))).toBe(true);
 
     const cleanupBound = recoverStaleResponseStateTemps(home, {


### PR DESCRIPTION
## Summary
- recover only exact `responses-state.json.ocx.<pid>.<seq>.tmp` remnants on first state load
- require a 15-minute grace period and skip current/live PIDs, symlinks, directories, and unrelated names
- enumerate directory entries incrementally and cap both total entries scanned and cleanup attempts
- use unlink-only cleanup to avoid path-based truncate/symlink TOCTOU writes
- keep failures isolated and best-effort so cleanup cannot block snapshot loading or requests

## Validation
- `bun test tests/responses-state.test.ts` (37 passed)
- `bun run typecheck`

Closes #499