### PR TITLE
fix(cli): separate PowerShell recovery commands

### DIFF
--- a/src/codex/home.ts
+++ b/src/codex/home.ts
@@ -200,7 +200,7 @@ export function collectOrcaCodexHomeDiagnostic(deps: OrcaCodexHomeDeps = {}): Or
       ? `CODEX_HOME targets Orca's runtime home (${displayEffective}), while the Windows ChatGPT/Codex app uses ${displayApp}; OpenCodex injection will not reach that app.`
       : null,
     action: mismatch
-      ? "If a service was installed from Orca, run 'ocx service uninstall' in that original Orca shell first. Then in Command Prompt run set \"ORCA_CODEX_HOME=\" and set \"CODEX_HOME=%USERPROFILE%\\.codex\"; or in PowerShell run Remove-Item Env:ORCA_CODEX_HOME -ErrorAction SilentlyContinue and $env:CODEX_HOME = Join-Path $env:USERPROFILE '.codex'. Rerun the command, then reinstall with 'ocx service install'."
+      ? "If a service was installed from Orca, run 'ocx service uninstall' in that original Orca shell first. Then in Command Prompt run set \"ORCA_CODEX_HOME=\" and set \"CODEX_HOME=%USERPROFILE%\\.codex\"; or in PowerShell run Remove-Item Env:ORCA_CODEX_HOME -ErrorAction SilentlyContinue; $env:CODEX_HOME = Join-Path $env:USERPROFILE '.codex'. Rerun the command, then reinstall with 'ocx service install'."
       : null,
   };
 }

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -95,6 +95,7 @@ describe("doctor", () => {
     expect(mismatch.action).toContain("ocx service install");
     expect(mismatch.action).toContain("%USERPROFILE%\\.codex");
     expect(mismatch.action).toContain("Remove-Item Env:ORCA_CODEX_HOME");
+    expect(mismatch.action).toContain("SilentlyContinue; $env:CODEX_HOME");
     expect(mismatch.action).not.toContain("C:\\Users\\[USER]");
 
     const matching = collectOrcaCodexHomeDiagnostic({


### PR DESCRIPTION
## Summary
- use a valid PowerShell semicolon between clearing ORCA_CODEX_HOME and setting CODEX_HOME
- preserve the symbolic user-profile target and CMD alternative
- regression-test the executable separator

## Validation
- `bun test tests/doctor.test.ts` (26 passed)
- `bun run typecheck`

Follow-up to #503; completes #497.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Windows troubleshooting command shown when an Orca runtime mismatch is detected, ensuring PowerShell executes the instructions properly.
* **Tests**
  * Added coverage to verify the corrected diagnostic guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->