### PR TITLE
fix(ci): sticky visible issue-translation control comments

### DIFF
--- a/.github/scripts/issue-translation.cjs
+++ b/.github/scripts/issue-translation.cjs
@@ -134,11 +134,20 @@ function scrubDetectedLanguage(value) {
 
 /**
  * True when the model (or caller) reported English / no translation needed.
- * Used to omit visible English bookkeeping text from the bot control comment.
  */
 function isEnglishDetectedLanguage(value) {
   const lang = scrubDetectedLanguage(value).toLowerCase();
-  return !lang || lang === "english" || lang === "en" || lang === "eng";
+  return lang === "english" || lang === "en" || lang === "eng";
+}
+
+/**
+ * Visible bookkeeping language label for the sticky control comment.
+ * Always non-empty so the bot bubble never renders as a blank ghost comment.
+ */
+function bookkeepingLanguageLabel(state) {
+  if (state?.detectedLanguage) return scrubDetectedLanguage(state.detectedLanguage);
+  if (!state?.requiresTranslation) return "English";
+  return scrubDetectedLanguage(null);
 }
 
 /**
@@ -283,6 +292,7 @@ function parseControlStateFromCommentBody(body, now = Date.now()) {
 /**
  * Newest github-actions control comment with a valid decoded state.
  * Author-forged comments and far-future poisoned payloads are ignored.
+ * Used for *reading* authoritative rate-limit state.
  */
 function findControlComment(comments, now = Date.now()) {
   let best = null;
@@ -296,6 +306,22 @@ function findControlComment(comments, now = Date.now()) {
     }
   }
   return best;
+}
+
+/**
+ * Sticky upsert target: the oldest bot-owned control comment (by id).
+ * Prefer updating this in place so the bubble stays near the top of the
+ * thread instead of creating a new comment at the bottom after every
+ * English classification. Corrupt/unparseable bodies still qualify — we
+ * overwrite them — so a bad decode never forces a duplicate create.
+ */
+function findStickyControlComment(comments) {
+  let sticky = null;
+  for (const comment of findAllControlComments(comments)) {
+    if (!Number.isSafeInteger(comment?.id) || comment.id <= 0) continue;
+    if (!sticky || comment.id < sticky.id) sticky = comment;
+  }
+  return sticky;
 }
 
 function extractTranslationControlState(comments, now = Date.now()) {
@@ -314,13 +340,12 @@ function resolveControlState(comments, _issueNumber, now = Date.now()) {
 }
 
 /**
- * English / no-translation attempts use a marker-only bot comment (no visible text).
- * requiresTranslation:true is never treated as marker-only solely because language is empty.
+ * Always false: control comments always include a visible bookkeeping line
+ * so GitHub never renders an HTML-comment-only ghost bubble.
+ * Kept as an exported predicate for workflow/tests that assert the contract.
  */
-function shouldOmitVisibleBookkeeping(state) {
-  if (!state?.requiresTranslation) return true;
-  return Boolean(state.detectedLanguage)
-    && isEnglishDetectedLanguage(state.detectedLanguage);
+function shouldOmitVisibleBookkeeping(_state) {
+  return false;
 }
 
 function buildTranslationControlComment(state) {
@@ -334,18 +359,13 @@ function buildTranslationControlComment(state) {
     detectedLanguage: null,
   };
   const encoded = encodeControlState(safe);
-  const lines = [
+  const lang = bookkeepingLanguageLabel(safe);
+  return [
     CONTROL_MARKER,
     `<!-- opencodex-issue-inline-translator-control-state-v2:${encoded} -->`,
-  ];
-  if (!shouldOmitVisibleBookkeeping(safe)) {
-    const lang = scrubDetectedLanguage(safe.detectedLanguage);
-    lines.push(
-      "",
-      `<sub>Automated translation bookkeeping — detected language: ${lang}.</sub>`,
-    );
-  }
-  return lines.join("\n");
+    "",
+    `<sub>Automated translation bookkeeping — detected language: ${lang}.</sub>`,
+  ].join("\n");
 }
 
 function pruneRecent(recent, now, windowMs = 3_600_000) {
@@ -499,8 +519,9 @@ async function deleteVerifiedControlComments({
 
 /**
  * Upsert the canonical bot-owned control comment.
- * English / no-translation: marker-only (no visible bookkeeping sentence).
- * Non-English: includes visible detected-language bookkeeping.
+ * Always includes a visible detected-language bookkeeping line (English too).
+ * Updates the oldest sticky bot control comment in place when one exists —
+ * including corrupt bodies — so classification never spams a new bottom bubble.
  * Never mutates the issue title or body.
  */
 async function upsertTranslationControlComment({
@@ -515,7 +536,9 @@ async function upsertTranslationControlComment({
 }) {
   const merged = mergeTranslationAttemptState({ priorState, attempt, now });
   const body = buildTranslationControlComment(merged);
-  const existing = findControlComment(comments, now);
+  // Sticky target ≠ newest valid state: prefer oldest marker comment so the
+  // thread position stays stable even when state on that comment is corrupt.
+  const existing = findStickyControlComment(comments);
 
   if (existing) {
     if (existing.body !== body) {
@@ -612,7 +635,8 @@ async function persistTranslationControlState({
     storage: "comment",
     state: upserted.state,
     comment: upserted.comment,
-    markerOnly: shouldOmitVisibleBookkeeping(upserted.state),
+    // Always false: bookkeeping line is always visible (no ghost HTML-only bubble).
+    markerOnly: false,
     cleanup,
   };
 }
@@ -836,6 +860,7 @@ module.exports = {
   stripTranslationBlock,
   extractTranslationState,
   findControlComment,
+  findStickyControlComment,
   findAllControlComments,
   deleteVerifiedControlComments,
   extractTranslationControlState,
@@ -862,6 +887,7 @@ module.exports = {
   sanitizeTranslationBody,
   scrubDetectedLanguage,
   isEnglishDetectedLanguage,
+  bookkeepingLanguageLabel,
   stripOrphanBodyControlState,
   buildTranslationBlock,
   maxTranslationChars,

--- a/.github/scripts/issue-translation.cjs
+++ b/.github/scripts/issue-translation.cjs
@@ -144,16 +144,12 @@ function isEnglishDetectedLanguage(value) {
  * Language written into control-state on the no-translation persist path.
  *
  * Confirmed English only when `sourceComplete` is true (valid parsed
- * `requires_translation: false`). Missing/blank language on incomplete
- * AI/parse/action failures must record `unknown`, never default to English.
+ * `requires_translation: false`). Incomplete AI/parse/action failures always
+ * record `unknown` — never retain a language label that could look confirmed.
  */
 function detectedLanguageForControlPersist({ detectedLanguage, sourceComplete } = {}) {
-  if (sourceComplete === true) {
-    return scrubDetectedLanguage(detectedLanguage || "English");
-  }
-  const raw = String(detectedLanguage ?? "").trim();
-  if (!raw) return "unknown";
-  return scrubDetectedLanguage(raw);
+  if (sourceComplete !== true) return "unknown";
+  return scrubDetectedLanguage(detectedLanguage || "English");
 }
 
 /**

--- a/.github/scripts/issue-translation.cjs
+++ b/.github/scripts/issue-translation.cjs
@@ -141,13 +141,29 @@ function isEnglishDetectedLanguage(value) {
 }
 
 /**
+ * Language written into control-state on the no-translation persist path.
+ *
+ * Confirmed English only when `sourceComplete` is true (valid parsed
+ * `requires_translation: false`). Missing/blank language on incomplete
+ * AI/parse/action failures must record `unknown`, never default to English.
+ */
+function detectedLanguageForControlPersist({ detectedLanguage, sourceComplete } = {}) {
+  if (sourceComplete === true) {
+    return scrubDetectedLanguage(detectedLanguage || "English");
+  }
+  const raw = String(detectedLanguage ?? "").trim();
+  if (!raw) return "unknown";
+  return scrubDetectedLanguage(raw);
+}
+
+/**
  * Visible bookkeeping language label for the sticky control comment.
  * Always non-empty so the bot bubble never renders as a blank ghost comment.
+ * Missing language is `unknown` — never invent a confirmed English label.
  */
 function bookkeepingLanguageLabel(state) {
   if (state?.detectedLanguage) return scrubDetectedLanguage(state.detectedLanguage);
-  if (!state?.requiresTranslation) return "English";
-  return scrubDetectedLanguage(null);
+  return "unknown";
 }
 
 /**
@@ -887,6 +903,7 @@ module.exports = {
   sanitizeTranslationBody,
   scrubDetectedLanguage,
   isEnglishDetectedLanguage,
+  detectedLanguageForControlPersist,
   bookkeepingLanguageLabel,
   stripOrphanBodyControlState,
   buildTranslationBlock,

--- a/.github/scripts/issue-translation.test.cjs
+++ b/.github/scripts/issue-translation.test.cjs
@@ -16,6 +16,7 @@ const {
   buildTranslationBlock,
   buildTranslationControlComment,
   findControlComment,
+  findStickyControlComment,
   extractTranslationControlState,
   resolveControlState,
   encodeControlState,
@@ -282,8 +283,8 @@ describe("isPreparedSourceStillCurrent", () => {
 });
 
 describe("bot-owned control state", () => {
-  it("keeps visible bookkeeping only when a non-English translation was applied", () => {
-    const comment = buildTranslationControlComment({
+  it("always includes visible bookkeeping, including English", () => {
+    const german = buildTranslationControlComment({
       v: 2,
       sourceHash: HASH_A,
       attemptedAt: 1,
@@ -291,14 +292,28 @@ describe("bot-owned control state", () => {
       requiresTranslation: true,
       detectedLanguage: "German",
     });
-    assert.match(comment, /Automated translation bookkeeping — detected language: German/);
+    assert.match(german, /Automated translation bookkeeping — detected language: German/);
     assert.equal(shouldOmitVisibleBookkeeping({
       requiresTranslation: true,
       detectedLanguage: "German",
     }), false);
+
+    const english = buildTranslationControlComment({
+      v: 2,
+      sourceHash: HASH_A,
+      attemptedAt: 1,
+      recent: [1],
+      requiresTranslation: false,
+      detectedLanguage: "English",
+    });
+    assert.match(english, /Automated translation bookkeeping — detected language: English/);
+    assert.equal(shouldOmitVisibleBookkeeping({
+      requiresTranslation: false,
+      detectedLanguage: "English",
+    }), false);
   });
 
-  it("English creates a marker-only bot comment with no visible bookkeeping", async () => {
+  it("English creates a bot comment with visible English bookkeeping", async () => {
     const { github, calls } = mockGithub({ nextId: 42 });
     const result = await persistTranslationControlState({
       github,
@@ -315,12 +330,11 @@ describe("bot-owned control state", () => {
       now: 100,
     });
     assert.equal(result.storage, "comment");
-    assert.equal(result.markerOnly, true);
+    assert.equal(result.markerOnly, false);
     assert.equal(result.comment.id, 42);
     assert.deepEqual(calls.map((c) => c[0]), ["create"]);
     assert.match(calls[0][1].body, new RegExp(CONTROL_MARKER));
-    assert.doesNotMatch(calls[0][1].body, /Automated translation bookkeeping/);
-    assert.doesNotMatch(calls[0][1].body, /detected language/);
+    assert.match(calls[0][1].body, /Automated translation bookkeeping — detected language: English/);
     assert.equal(extractTranslationControlState([botComment(calls[0][1].body, 42)]).sourceHash, HASH_A);
   });
 
@@ -353,7 +367,44 @@ describe("bot-owned control state", () => {
     assert.equal(result.comment.id, 11);
     assert.deepEqual(calls.map((c) => c[0]), ["update"]);
     assert.equal(calls[0][1].comment_id, 11);
-    assert.doesNotMatch(calls[0][1].body, /Automated translation bookkeeping/);
+    assert.match(calls[0][1].body, /Automated translation bookkeeping — detected language: English/);
+  });
+
+  it("updates the oldest sticky control comment even when its state is corrupt", async () => {
+    const corrupt = botComment(
+      `${CONTROL_MARKER}\n<!-- opencodex-issue-inline-translator-control-state-v2:!!! -->`,
+      3,
+    );
+    const validNewer = botComment(buildTranslationControlComment({
+      v: 2,
+      sourceHash: HASH_B,
+      attemptedAt: 50,
+      recent: [50],
+      requiresTranslation: false,
+      detectedLanguage: "English",
+    }), 9);
+    const { github, calls } = mockGithub();
+    const result = await persistTranslationControlState({
+      github,
+      owner: "o",
+      repo: "r",
+      issue_number: 7,
+      comments: [corrupt, validNewer],
+      priorState: extractTranslationControlState([corrupt, validNewer]),
+      attempt: {
+        sourceHash: HASH_A,
+        requiresTranslation: false,
+        detectedLanguage: "English",
+        sourceComplete: true,
+      },
+      now: 100,
+    });
+    assert.equal(findStickyControlComment([corrupt, validNewer]).id, 3);
+    assert.equal(result.comment.id, 3);
+    assert.deepEqual(calls.map((c) => c[0]), ["update", "delete"]);
+    assert.equal(calls[0][1].comment_id, 3);
+    assert.match(calls[0][1].body, /detected language: English/);
+    assert.equal(calls[1][1].comment_id, 9);
   });
 
   it("non-English persist writes or updates a visible bot-owned comment", async () => {
@@ -447,16 +498,16 @@ describe("bot-owned control state", () => {
     assert.equal(stripOrphanBodyControlState(orphan).includes("control-state-v2:"), false);
   });
 
-  it("failed comment create preserves existing state and does not delete", async () => {
-    // Marker-bearing bot comment with undecodable state: forces create while a
-    // redundant id remains available for cleanup if create had succeeded.
+  it("failed sticky update preserves existing control comments and does not delete", async () => {
+    // Corrupt sticky comment is still the upsert target; update failure must
+    // not cascade into deleting it (or any sibling) as "redundant."
     const stale = botComment(
       `${CONTROL_MARKER}\n<!-- opencodex-issue-inline-translator-control-state-v2:!!! -->`,
       5,
     );
     const { github, calls } = mockGithub({
-      create: async () => {
-        throw new Error("API create failed");
+      update: async () => {
+        throw new Error("API update failed");
       },
     });
     await assert.rejects(
@@ -470,14 +521,16 @@ describe("bot-owned control state", () => {
           sourceHash: HASH_A,
           requiresTranslation: false,
           detectedLanguage: "English",
-        sourceComplete: true,
-      },
+          sourceComplete: true,
+        },
       }),
       /persistence failed/,
     );
-    assert.deepEqual(calls.map((c) => c[0]), ["create"]);
+    assert.deepEqual(calls.map((c) => c[0]), ["update"]);
+    assert.equal(calls[0][1].comment_id, 5);
     assert.ok(!calls.some((c) => c[0] === "delete"));
     assert.equal(findControlComment([stale]), null);
+    assert.equal(findStickyControlComment([stale]).id, 5);
   });
 
   it("re-fetches comments when none are supplied and still verifies authorship", async () => {
@@ -545,7 +598,7 @@ describe("bot-owned control state", () => {
     assert.equal(extractTranslationControlState([prior]).sourceHash, HASH_B);
   });
 
-  it("deletes redundant bot comments only after canonical replacement succeeds", async () => {
+  it("deletes redundant bot comments only after sticky replacement succeeds", async () => {
     const older = botComment(buildTranslationControlComment({
       v: 2,
       sourceHash: HASH_B,
@@ -578,11 +631,12 @@ describe("bot-owned control state", () => {
       },
       now: 300,
     });
-    assert.equal(result.comment.id, 2);
+    // Sticky = oldest id; update it in place and delete the newer duplicate.
+    assert.equal(result.comment.id, 1);
     assert.deepEqual(calls.map((c) => c[0]), ["update", "delete"]);
-    assert.equal(calls[0][1].comment_id, 2);
-    assert.equal(calls[1][1].comment_id, 1);
-    assert.deepEqual(result.cleanup.deleted, [1]);
+    assert.equal(calls[0][1].comment_id, 1);
+    assert.equal(calls[1][1].comment_id, 2);
+    assert.deepEqual(result.cleanup.deleted, [2]);
   });
 
   it("cleanup failure leaves valid fallback comments intact", async () => {
@@ -622,11 +676,12 @@ describe("bot-owned control state", () => {
       },
       now: 300,
     });
-    assert.equal(result.comment.id, 2);
+    assert.equal(result.comment.id, 1);
     assert.equal(result.cleanup.failed.length, 1);
-    assert.equal(result.cleanup.failed[0].id, 1);
+    assert.equal(result.cleanup.failed[0].id, 2);
     assert.ok(calls.some((c) => c[0] === "update"));
-    // Older comment body is unchanged in the caller's list — durable fallback remains.
+    // Newer duplicate remains when delete fails — durable fallback remains.
+    assert.equal(extractTranslationControlState([older, newer]).sourceHash, HASH_A);
     assert.equal(extractTranslationControlState([older]).sourceHash, HASH_B);
   });
 

--- a/.github/scripts/issue-translation.test.cjs
+++ b/.github/scripts/issue-translation.test.cjs
@@ -35,6 +35,8 @@ const {
   sanitizeTranslationBody,
   scrubDetectedLanguage,
   isEnglishDetectedLanguage,
+  detectedLanguageForControlPersist,
+  bookkeepingLanguageLabel,
   stripOrphanBodyControlState,
   fitTranslationBody,
   shouldOmitVisibleBookkeeping,
@@ -43,6 +45,7 @@ const {
   collectMergedRecentFromComments,
   isValidControlTimestamp,
   pruneRecent,
+  completedHashFor,
 } = require("./issue-translation.cjs");
 
 const HASH_A = "aaaaaaaaaaaaaaaa";
@@ -311,6 +314,57 @@ describe("bot-owned control state", () => {
       requiresTranslation: false,
       detectedLanguage: "English",
     }), false);
+  });
+
+  it("incomplete AI/parse failures bookkeep as unknown, never false-English", async () => {
+    assert.equal(
+      detectedLanguageForControlPersist({ detectedLanguage: "", sourceComplete: false }),
+      "unknown",
+    );
+    assert.equal(
+      detectedLanguageForControlPersist({ detectedLanguage: undefined, sourceComplete: false }),
+      "unknown",
+    );
+    assert.equal(
+      detectedLanguageForControlPersist({ detectedLanguage: "unknown", sourceComplete: false }),
+      "unknown",
+    );
+    assert.equal(
+      detectedLanguageForControlPersist({ detectedLanguage: "", sourceComplete: true }),
+      "English",
+    );
+    assert.equal(
+      detectedLanguageForControlPersist({ detectedLanguage: "English", sourceComplete: true }),
+      "English",
+    );
+    assert.equal(bookkeepingLanguageLabel({ requiresTranslation: false, detectedLanguage: null }), "unknown");
+    assert.equal(bookkeepingLanguageLabel({ requiresTranslation: false, detectedLanguage: "English" }), "English");
+
+    const { github, calls } = mockGithub({ nextId: 77 });
+    const result = await persistTranslationControlState({
+      github,
+      owner: "o",
+      repo: "r",
+      issue_number: 9,
+      comments: [],
+      attempt: {
+        sourceHash: HASH_A,
+        requiresTranslation: false,
+        detectedLanguage: detectedLanguageForControlPersist({
+          detectedLanguage: "",
+          sourceComplete: false,
+        }),
+        sourceComplete: false,
+      },
+      now: 100,
+    });
+    assert.equal(result.state.sourceHash, "0000000000000000");
+    assert.equal(result.state.detectedLanguage, "unknown");
+    assert.match(calls[0][1].body, /detected language: unknown/);
+    assert.doesNotMatch(calls[0][1].body, /detected language: English/);
+    // Attempt counted (recent) but source stays retryable.
+    assert.deepEqual(result.state.recent, [100]);
+    assert.equal(completedHashFor(result.state, "issue"), null);
   });
 
   it("English creates a bot comment with visible English bookkeeping", async () => {

--- a/.github/scripts/issue-translation.test.cjs
+++ b/.github/scripts/issue-translation.test.cjs
@@ -330,6 +330,10 @@ describe("bot-owned control state", () => {
       "unknown",
     );
     assert.equal(
+      detectedLanguageForControlPersist({ detectedLanguage: "English", sourceComplete: false }),
+      "unknown",
+    );
+    assert.equal(
       detectedLanguageForControlPersist({ detectedLanguage: "", sourceComplete: true }),
       "English",
     );

--- a/.github/workflows/enforce-issue-quality.yml
+++ b/.github/workflows/enforce-issue-quality.yml
@@ -352,7 +352,7 @@ jobs:
             const {
               resolveControlState,
               persistTranslationControlState,
-              scrubDetectedLanguage,
+              detectedLanguageForControlPersist,
             } = require(path.join(process.cwd(), ".github", "scripts", "issue-translation.cjs"));
 
             const { owner, repo } = context.repo;
@@ -367,6 +367,7 @@ jobs:
               owner, repo, issue_number, per_page: 100,
             });
             const priorState = resolveControlState(comments, issue_number);
+            const sourceComplete = process.env.SOURCE_COMPLETE === "true";
             try {
               const result = await persistTranslationControlState({
                 github,
@@ -379,9 +380,13 @@ jobs:
                   sourceHash: process.env.SOURCE_HASH,
                   sourceKey: "issue",
                   requiresTranslation: false,
-                  detectedLanguage: scrubDetectedLanguage(process.env.DETECTED_LANG || "English"),
+                  // Incomplete AI/parse skips must not bookkeep as English.
+                  detectedLanguage: detectedLanguageForControlPersist({
+                    detectedLanguage: process.env.DETECTED_LANG,
+                    sourceComplete,
+                  }),
                   // Invalid/empty AI JSON sets source_complete=false and stays retryable.
-                  sourceComplete: process.env.SOURCE_COMPLETE === "true",
+                  sourceComplete,
                 },
               });
               if (result.cleanup?.failed?.length) {
@@ -635,7 +640,7 @@ jobs:
             const {
               resolveControlState,
               persistTranslationControlState,
-              scrubDetectedLanguage,
+              detectedLanguageForControlPersist,
             } = require(path.join(process.cwd(), ".github", "scripts", "issue-translation.cjs"));
 
             const { owner, repo } = context.repo;
@@ -644,6 +649,7 @@ jobs:
               owner, repo, issue_number, per_page: 100,
             });
             const priorState = resolveControlState(comments, issue_number);
+            const sourceComplete = process.env.SOURCE_COMPLETE === "true";
             try {
               const result = await persistTranslationControlState({
                 github,
@@ -656,8 +662,12 @@ jobs:
                   sourceHash: process.env.SOURCE_HASH,
                   sourceKey: process.env.SOURCE_TITLE || "issue",
                   requiresTranslation: false,
-                  detectedLanguage: scrubDetectedLanguage(process.env.DETECTED_LANG || "English"),
-                  sourceComplete: process.env.SOURCE_COMPLETE === "true",
+                  // Incomplete AI/parse skips must not bookkeep as English.
+                  detectedLanguage: detectedLanguageForControlPersist({
+                    detectedLanguage: process.env.DETECTED_LANG,
+                    sourceComplete,
+                  }),
+                  sourceComplete,
                 },
               });
               if (result.cleanup?.failed?.length) {

--- a/gui/tests/rail-hover-delete-dom.test.tsx
+++ b/gui/tests/rail-hover-delete-dom.test.tsx
@@ -32,6 +32,8 @@ beforeEach(() => {
   originalFetch = globalThis.fetch;
   win = new Window({ url: "http://localhost/" });
   Object.defineProperty(win.navigator, "language", { configurable: true, value: "en-US" });
+  // React 19 resolveUpdatePriority reads window.event; happy-dom omits the IE legacy field.
+  Object.defineProperty(win, "event", { configurable: true, writable: true, value: undefined });
   Object.defineProperties(globalThis, {
     document: { configurable: true, value: win.document },
     window: { configurable: true, value: win },
@@ -59,6 +61,10 @@ afterEach(async () => {
     await act(async () => { current.unmount(); });
     root = null;
   }
+  // Flush React 19 scheduler work (setImmediate/MessageChannel) while window still
+  // exists. Restoring globals first lets a late dispatchSetState hit undefined
+  // window.event and fail the suite as an unhandled error between tests (macOS CI).
+  await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
   for (const key of globals) {
     Object.defineProperty(globalThis, key, { configurable: true, value: previous[key] });
   }

--- a/gui/tests/rail-hover-delete-dom.test.tsx
+++ b/gui/tests/rail-hover-delete-dom.test.tsx
@@ -13,6 +13,8 @@ import { LanguageProvider } from "../src/i18n/provider";
  */
 
 const globals = ["document", "window", "navigator", "localStorage", "IS_REACT_ACT_ENVIRONMENT"] as const;
+/** Survives afterEach restore so a late React 19 dispatchSetState can read window.event. */
+const WINDOW_EVENT_STUB: { event: undefined } = { event: undefined };
 let previous: Record<(typeof globals)[number], unknown>;
 let win: Window;
 let host: HTMLElement;
@@ -61,12 +63,34 @@ afterEach(async () => {
     await act(async () => { current.unmount(); });
     root = null;
   }
-  // Flush React 19 scheduler work (setImmediate/MessageChannel) while window still
-  // exists. Restoring globals first lets a late dispatchSetState hit undefined
-  // window.event and fail the suite as an unhandled error between tests (macOS CI).
-  await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+  // Drain React 19 scheduler work (setImmediate/MessageChannel) while happy-dom is
+  // still installed. ProviderWorkspaceShell defers setState via window.setTimeout(0)
+  // + fetch; on slow macOS CI one tick is not enough and a late dispatchSetState
+  // then evaluates window.event after globals were restored to undefined.
+  await act(async () => {
+    for (let i = 0; i < 5; i++) {
+      await new Promise<void>((r) => setTimeout(r, 0));
+      await Promise.resolve();
+    }
+  });
   for (const key of globals) {
-    Object.defineProperty(globalThis, key, { configurable: true, value: previous[key] });
+    let value = previous[key];
+    if (key === "window") {
+      if (value == null || typeof value !== "object") {
+        value = WINDOW_EVENT_STUB;
+      } else if (!Object.prototype.hasOwnProperty.call(value, "event")) {
+        try {
+          Object.defineProperty(value, "event", {
+            configurable: true,
+            writable: true,
+            value: undefined,
+          });
+        } catch {
+          value = WINDOW_EVENT_STUB;
+        }
+      }
+    }
+    Object.defineProperty(globalThis, key, { configurable: true, value });
   }
   Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
 });

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -359,7 +359,12 @@ describe("GitHub Actions hardening", () => {
     expect(persistStep).toContain("requires_translation != 'true'");
     expect(persistStep).toContain("persistTranslationControlState");
     expect(persistStep).toContain("SOURCE_COMPLETE");
-    expect(persistStep).toContain('sourceComplete: process.env.SOURCE_COMPLETE === "true"');
+    expect(persistStep).toContain("detectedLanguageForControlPersist");
+    expect(persistStep).toContain('const sourceComplete = process.env.SOURCE_COMPLETE === "true"');
+    expect(persistStep).toMatch(/sourceComplete,\s*\n\s*\}/);
+    // Missing DETECTED_LANG on incomplete/skipped parse must not default to English.
+    expect(persistStep).not.toContain('DETECTED_LANG || "English"');
+    expect(persistStep).not.toContain("DETECTED_LANG || 'English'");
     expect(persistStep).not.toContain("silent_state");
     expect(persistStep).not.toContain("cleanup_comment_ids");
     expect(workflow).not.toContain("Save translation control state cache");
@@ -369,7 +374,11 @@ describe("GitHub Actions hardening", () => {
     const commentPersist = workflow
       .split("- name: Persist comment translation control state")[1]!
       .split(/\n {2}[a-zA-Z]/)[0]!;
-    expect(commentPersist).toContain('sourceComplete: process.env.SOURCE_COMPLETE === "true"');
+    expect(commentPersist).toContain('const sourceComplete = process.env.SOURCE_COMPLETE === "true"');
+    expect(commentPersist).toContain("detectedLanguageForControlPersist");
+    expect(commentPersist).toMatch(/sourceComplete,\s*\n\s*\}/);
+    expect(commentPersist).not.toContain('DETECTED_LANG || "English"');
+    expect(commentPersist).not.toContain("DETECTED_LANG || 'English'");
     const commentApplyStep = workflow
       .split("- name: Apply inline comment translation")[1]!
       .split("- name: Persist comment translation control state")[0]!;
@@ -387,6 +396,7 @@ describe("GitHub Actions hardening", () => {
     const helperSrc = await readText(".github/scripts/issue-translation.cjs");
     expect(helperSrc).toContain("shouldOmitVisibleBookkeeping");
     expect(helperSrc).toContain("findStickyControlComment");
+    expect(helperSrc).toContain("detectedLanguageForControlPersist");
     expect(helperSrc).toContain("Automated translation bookkeeping");
     expect(helperSrc).toContain("canonical comment first");
     expect(helperSrc).toContain("Authoritative control state comes only from verified bot-owned comments");

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -383,9 +383,10 @@ describe("GitHub Actions hardening", () => {
     expect(commentUpdateAt).toBeGreaterThanOrEqual(0);
     expect(commentMissingAt).toBeLessThan(commentUpdateAt);
 
-    // Helper contract: marker-only English comments; replace-before-cleanup; body non-authoritative.
+    // Helper contract: always-visible bookkeeping; sticky oldest upsert; body non-authoritative.
     const helperSrc = await readText(".github/scripts/issue-translation.cjs");
     expect(helperSrc).toContain("shouldOmitVisibleBookkeeping");
+    expect(helperSrc).toContain("findStickyControlComment");
     expect(helperSrc).toContain("Automated translation bookkeeping");
     expect(helperSrc).toContain("canonical comment first");
     expect(helperSrc).toContain("Authoritative control state comes only from verified bot-owned comments");


### PR DESCRIPTION
## Summary
- Always show a visible bookkeeping line on the bot control comment, including English, so GitHub never renders an HTML-comment-only ghost bubble.
- Upsert the **oldest** bot-owned control comment in place (even if its encoded state is corrupt) and only then delete newer duplicates, so English classification does not create a new comment at the bottom of the thread.

Follow-up to the empty `github-actions` bubble under https://github.com/lidge-jun/opencodex/issues/509#issuecomment-5085002987 (run https://github.com/lidge-jun/opencodex/actions/runs/30216602448).

## Test plan
- [x] `node --test .github/scripts/issue-translation.test.cjs` (67/67)
- [x] `bun test tests/ci-workflows.test.ts`
- [ ] Confirm on a test issue: English comment updates the existing control comment in place with `detected language: English`
- [ ] Confirm corrupt sticky control body is overwritten via update, not replaced by a new bottom comment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Detected-language bookkeeping is now always shown on translation control comments, including for English; missing/empty values are no longer treated as English.
  - Translation control comments remain stably anchored by updating the oldest “sticky” bot comment, even when that target is malformed.
  - Persistence behavior for issue and comment control state was corrected to derive completion status consistently from CI environment.
- **Tests**
  - Updated CI and GUI tests for the new “sticky” anchoring and enhanced React 19 / happy-dom isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->