### PR TITLE
fix(proxy): attach Retry-After on retryable 429s for Codex

### DIFF
--- a/gui/tests/storage-loading-race.test.tsx
+++ b/gui/tests/storage-loading-race.test.tsx
@@ -132,6 +132,33 @@ test("effect cleanup invalidates generation before abort so loading stays owned 
   const container = document.createElement("div");
   document.body.append(container);
 
+  // Hold Storage's delay-0 deferred fetches so Windows/act timer flushing cannot
+  // collapse the cleanup→replacement gap this test is asserting.
+  type DeferredTimer = { id: number; run: () => void };
+  const deferredZero: DeferredTimer[] = [];
+  let nextTimerId = 1_000_000;
+  const realSetTimeout = window.setTimeout.bind(window);
+  const realClearTimeout = window.clearTimeout.bind(window);
+  window.setTimeout = ((handler: TimerHandler, delay?: number, ...args: unknown[]) => {
+    if (delay === 0 && typeof handler === "function") {
+      const id = nextTimerId++;
+      deferredZero.push({
+        id,
+        run: () => { (handler as (...a: unknown[]) => void)(...args); },
+      });
+      return id as unknown as ReturnType<typeof setTimeout>;
+    }
+    return realSetTimeout(handler as never, delay as never, ...(args as never[]));
+  }) as typeof setTimeout;
+  window.clearTimeout = ((id?: ReturnType<typeof setTimeout>) => {
+    const idx = deferredZero.findIndex(entry => entry.id === id);
+    if (idx >= 0) {
+      deferredZero.splice(idx, 1);
+      return;
+    }
+    return realClearTimeout(id as never);
+  }) as typeof clearTimeout;
+
   type Gate = {
     resolve: (body: unknown) => void;
     reject: (reason?: unknown) => void;
@@ -166,45 +193,51 @@ test("effect cleanup invalidates generation before abort so loading stays owned 
   }
 
   let root!: Root;
-  await act(async () => {
-    root = createRoot(container);
-    root.render(<Harness />);
-  });
-  await act(async () => {
-    await new Promise<void>(resolve => testWindow.setTimeout(resolve, 0));
-  });
-  await waitFor(() => gates.length === 1);
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<Harness />);
+    });
+    expect(deferredZero.length).toBe(1);
+    await act(async () => {
+      deferredZero.shift()!.run();
+    });
+    await waitFor(() => gates.length === 1);
 
-  // Cleanup aborts + invalidates generation; replacement is still deferred (setTimeout 0).
-  await act(async () => {
-    (window as unknown as { __bumpApiBase: () => void }).__bumpApiBase();
-  });
+    // Cleanup aborts + invalidates generation; replacement stays queued until we flush it.
+    await act(async () => {
+      (window as unknown as { __bumpApiBase: () => void }).__bumpApiBase();
+    });
+    expect(deferredZero.length).toBe(1);
 
-  // Flush abort rejection / finally microtasks without running the deferred fetch.
-  await act(async () => {
-    await Promise.resolve();
-    await Promise.resolve();
-  });
+    // Flush abort rejection / finally microtasks without running the deferred fetch.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
 
-  const refresh = container.querySelector<HTMLButtonElement>("button.btn");
-  expect(gates.length).toBe(1);
-  expect(container.textContent).toContain("Scanning storage");
-  expect(refresh?.disabled).toBe(true);
+    const refresh = container.querySelector<HTMLButtonElement>("button.btn");
+    expect(gates.length).toBe(1);
+    expect(container.textContent).toContain("Scanning storage");
+    expect(refresh?.disabled).toBe(true);
 
-  await act(async () => {
-    await new Promise<void>(resolve => testWindow.setTimeout(resolve, 0));
-  });
-  await waitFor(() => gates.length === 2);
+    await act(async () => {
+      deferredZero.shift()!.run();
+    });
+    await waitFor(() => gates.length === 2);
 
-  await act(async () => {
-    gates[1]!.resolve(REPORT_B);
-    await Promise.resolve();
-  });
-  await waitFor(() => (container.textContent ?? "").includes("/tmp/b"));
-  expect(refresh?.disabled).toBe(false);
-
-  await act(async () => {
-    root.unmount();
-  });
-  container.remove();
+    await act(async () => {
+      gates[1]!.resolve(REPORT_B);
+      await Promise.resolve();
+    });
+    await waitFor(() => (container.textContent ?? "").includes("/tmp/b"));
+    expect(refresh?.disabled).toBe(false);
+  } finally {
+    window.setTimeout = realSetTimeout as typeof setTimeout;
+    window.clearTimeout = realClearTimeout as typeof clearTimeout;
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  }
 });

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1159,7 +1159,7 @@ export function formatErrorResponse(
   status: number,
   type: string,
   message: string,
-  options?: { code?: string | null },
+  options?: { code?: string | null; retryAfter?: string | null },
 ): Response {
   const error = classifyError(status, type, message);
   if (isCyberPolicyCode(options?.code)) {
@@ -1167,8 +1167,13 @@ export function formatErrorResponse(
     error.type = "invalid_request_error";
   }
   const finalStatus = error.code === CYBER_POLICY_ERROR_CODE ? 400 : status;
+  const headers = new Headers({ "Content-Type": "application/json" });
+  const retryAfter = options?.retryAfter?.trim();
+  if (retryAfter && retryAfter.length > 0 && retryAfter.length <= 128) {
+    headers.set("Retry-After", retryAfter);
+  }
   return new Response(JSON.stringify({ error }), {
     status: finalStatus,
-    headers: { "Content-Type": "application/json" },
+    headers,
   });
 }

--- a/src/lib/retry-after.ts
+++ b/src/lib/retry-after.ts
@@ -7,6 +7,9 @@ export const DEFAULT_RETRYABLE_429_RETRY_AFTER_SEC = "2";
 function sanitizedRetryAfterHeader(value: string | null | undefined, now: number): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed || trimmed.length > 128) return undefined;
+  // Instant-retry "0" is a valid client directive but rejected by cooldown parsers
+  // (parseRetryAfterMs requires seconds > 0). Preserve it for client headers.
+  if (trimmed === "0") return trimmed;
   return parseRetryAfterMs(trimmed, now) !== undefined ? trimmed : undefined;
 }
 
@@ -16,12 +19,16 @@ function sanitizedRetryAfterHeader(value: string | null | undefined, now: number
  * Order: validated upstream header → delay embedded in the error message →
  * small default for retryable rate-limit 429s. Quota-exhausted 429s get no
  * default — hammering a spent quota is not a backoff problem.
+ *
+ * Pass `includeDefault: false` when the value feeds cooldown/failover metadata:
+ * the synthetic client fallback must not shorten combo cooldowns from 60s to 2s.
  */
 export function resolveClientRetryAfter(opts: {
   status: number;
   message?: string;
   upstreamRetryAfter?: string | null;
   now?: number;
+  includeDefault?: boolean;
 }): string | undefined {
   const now = opts.now ?? Date.now();
   const fromHeader = sanitizedRetryAfterHeader(opts.upstreamRetryAfter, now);
@@ -31,6 +38,7 @@ export function resolveClientRetryAfter(opts: {
   const fromMessage = parseRetryAfterFromMessage(message);
   if (fromMessage !== undefined) return String(fromMessage);
 
+  if (opts.includeDefault === false) return undefined;
   if (opts.status !== 429) return undefined;
   const classified = classifyError(429, "rate_limit_error", message || "Too Many Requests");
   if (classified.type === "insufficient_quota" || classified.code === "insufficient_quota") {

--- a/src/lib/retry-after.ts
+++ b/src/lib/retry-after.ts
@@ -4,7 +4,14 @@ import { classifyError, parseRetryAfterFromMessage } from "./errors";
 /** Small default when a retryable 429 has no upstream Retry-After (#507). */
 export const DEFAULT_RETRYABLE_429_RETRY_AFTER_SEC = "2";
 
-function sanitizedRetryAfterHeader(value: string | null | undefined, now: number): string | undefined {
+/**
+ * Validate a raw upstream Retry-After for client exposure.
+ * Instant-retry `"0"` is kept even though cooldown parsers reject it.
+ */
+export function validateClientRetryAfterHeader(
+  value: string | null | undefined,
+  now: number,
+): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed || trimmed.length > 128) return undefined;
   // Instant-retry "0" is a valid client directive but rejected by cooldown parsers
@@ -31,7 +38,7 @@ export function resolveClientRetryAfter(opts: {
   includeDefault?: boolean;
 }): string | undefined {
   const now = opts.now ?? Date.now();
-  const fromHeader = sanitizedRetryAfterHeader(opts.upstreamRetryAfter, now);
+  const fromHeader = validateClientRetryAfterHeader(opts.upstreamRetryAfter, now);
   if (fromHeader) return fromHeader;
 
   const message = opts.message ?? "";

--- a/src/lib/retry-after.ts
+++ b/src/lib/retry-after.ts
@@ -1,0 +1,40 @@
+import { parseRetryAfterMs } from "../combos";
+import { classifyError, parseRetryAfterFromMessage } from "./errors";
+
+/** Small default when a retryable 429 has no upstream Retry-After (#507). */
+export const DEFAULT_RETRYABLE_429_RETRY_AFTER_SEC = "2";
+
+function sanitizedRetryAfterHeader(value: string | null | undefined, now: number): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.length > 128) return undefined;
+  return parseRetryAfterMs(trimmed, now) !== undefined ? trimmed : undefined;
+}
+
+/**
+ * Pick a Retry-After value that clients (especially Codex) can back off on.
+ *
+ * Order: validated upstream header → delay embedded in the error message →
+ * small default for retryable rate-limit 429s. Quota-exhausted 429s get no
+ * default — hammering a spent quota is not a backoff problem.
+ */
+export function resolveClientRetryAfter(opts: {
+  status: number;
+  message?: string;
+  upstreamRetryAfter?: string | null;
+  now?: number;
+}): string | undefined {
+  const now = opts.now ?? Date.now();
+  const fromHeader = sanitizedRetryAfterHeader(opts.upstreamRetryAfter, now);
+  if (fromHeader) return fromHeader;
+
+  const message = opts.message ?? "";
+  const fromMessage = parseRetryAfterFromMessage(message);
+  if (fromMessage !== undefined) return String(fromMessage);
+
+  if (opts.status !== 429) return undefined;
+  const classified = classifyError(429, "rate_limit_error", message || "Too Many Requests");
+  if (classified.type === "insufficient_quota" || classified.code === "insufficient_quota") {
+    return undefined;
+  }
+  return DEFAULT_RETRYABLE_429_RETRY_AFTER_SEC;
+}

--- a/src/server/chat-completions.ts
+++ b/src/server/chat-completions.ts
@@ -16,6 +16,7 @@ import {
 } from "../chat/outbound";
 import { classifyError, CYBER_POLICY_ERROR_CODE, isCyberPolicyCode } from "../lib/errors";
 import { redactSecretString } from "../lib/redact";
+import { resolveClientRetryAfter } from "../lib/retry-after";
 import { estimateTokens } from "../lib/token-estimate";
 import { routeModel } from "../router";
 import { resolveWireProtocolOverride } from "./adapter-resolve";
@@ -180,7 +181,11 @@ export async function handleChatCompletions(
         if (text) message = `upstream error (${upstream.status}): ${redactSecretString(text).slice(0, 400)}`;
       }
     } catch { /* keep fallback */ }
-    const retryAfter = upstream.headers.get("retry-after");
+    const retryAfter = resolveClientRetryAfter({
+      status: upstream.status,
+      message,
+      upstreamRetryAfter: upstream.headers.get("retry-after"),
+    });
     const classified = classifyError(
       upstream.status,
       upstreamType

--- a/src/server/claude-messages.ts
+++ b/src/server/claude-messages.ts
@@ -15,6 +15,7 @@ import { recordDesktopRequest } from "../claude/desktop-health";
 import { stripOneMillionMarker } from "../claude/context-windows";
 import { captureClaudeInbound } from "../claude/inbound-debug";
 import { isTransientUpstreamStatus } from "../lib/upstream-retry";
+import { resolveClientRetryAfter } from "../lib/retry-after";
 import {
   anthropicErrorBody,
   anthropicErrorResponse,
@@ -689,12 +690,22 @@ export async function handleClaudeMessages(
         if (text) message = `upstream error (${response.status}): ${text.slice(0, 400)}`;
       }
     } catch { /* keep fallback message */ }
-    const retryAfter = response.headers.get("retry-after");
+    const upstreamRetryAfter = response.headers.get("retry-after");
+    const retryAfter = resolveClientRetryAfter({
+      status: response.status,
+      message,
+      upstreamRetryAfter,
+    })
+      // Instant-retry "0" is a valid client directive but rejected by cooldown parsers.
+      // Preserve it so it still wins over the transient "2" fallback (claude-529 mapping).
+      ?? (upstreamRetryAfter?.trim() === "0" ? "0" : undefined);
     // Transient upstream 5xx (already retried pre-stream, 010): reclassify as Anthropic
     // 529 overloaded_error so the Claude Code client applies its built-in backoff retry
     // instead of dying on a fatal api_error (260716 sol-builder incident). The request
     // log keeps the upstream status (captured in the deferred-log closure before this
     // rewrite): log = upstream truth, client = retry signal.
+    // Retryable 429s also get Retry-After (#507) so Codex-shaped clients and Claude Code
+    // share a backoff hint when the upstream omitted the header.
     const transient = isTransientUpstreamStatus(response.status);
     const outStatus = transient ? 529 : response.status;
     const out = new Response(JSON.stringify(anthropicErrorBody(outStatus, message)), {

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -27,6 +27,7 @@ import {
 } from "../../combos";
 import { isInjectionDebugEnabled } from "../../lib/debug-settings";
 import { injectionDebugLog } from "../../lib/injection-debug-log";
+import { resolveClientRetryAfter } from "../../lib/retry-after";
 import { modelInList, namespacedToolName } from "../../types";
 import type { AdapterEvent, OcxConfig, OcxParsedRequest, OcxProviderConfig, OcxProviderContinuationState, OcxUsage } from "../../types";
 import {
@@ -347,10 +348,16 @@ export async function consumeComboFailure(
   const message = classificationText === fallback
     ? fallback
     : `${fallback}: ${classificationText}`;
-  const retryAfter = sanitizedRetryAfter(response.headers.get("retry-after"), now);
+  const retryAfter = resolveClientRetryAfter({
+    status: response.status,
+    message,
+    upstreamRetryAfter: response.headers.get("retry-after"),
+    now,
+  });
   return {
     response: formatErrorResponse(response.status, "upstream_error", message, {
       ...(upstreamCode !== undefined ? { code: upstreamCode } : {}),
+      ...(retryAfter !== undefined ? { retryAfter } : {}),
     }),
     classificationText,
     ...(upstreamCode !== undefined ? { upstreamCode } : {}),
@@ -1830,7 +1837,15 @@ export async function handleResponses(
       );
       // Upstreams occasionally echo request details in error bodies — scrub token-shaped
       // material before it reaches the client-facing error surface.
-      return formatErrorResponse(upstreamResponse.status, "upstream_error", `Provider error ${upstreamResponse.status}: ${redactSecretString(errorText.slice(0, 500))}`);
+      const message = `Provider error ${upstreamResponse.status}: ${redactSecretString(errorText.slice(0, 500))}`;
+      const retryAfter = resolveClientRetryAfter({
+        status: upstreamResponse.status,
+        message,
+        upstreamRetryAfter: upstreamResponse.headers.get("retry-after"),
+      });
+      return formatErrorResponse(upstreamResponse.status, "upstream_error", message, {
+        ...(retryAfter !== undefined ? { retryAfter } : {}),
+      });
     }
   }
 

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -348,20 +348,30 @@ export async function consumeComboFailure(
   const message = classificationText === fallback
     ? fallback
     : `${fallback}: ${classificationText}`;
-  const retryAfter = resolveClientRetryAfter({
+  const upstreamRetryAfter = response.headers.get("retry-after");
+  // Client response may get the synthetic "2" fallback; cooldown metadata must not —
+  // otherwise coolComboTarget treats it as a 2s cooldown instead of the 60s default.
+  const clientRetryAfter = resolveClientRetryAfter({
     status: response.status,
     message,
-    upstreamRetryAfter: response.headers.get("retry-after"),
+    upstreamRetryAfter,
     now,
+  });
+  const cooldownRetryAfter = resolveClientRetryAfter({
+    status: response.status,
+    message,
+    upstreamRetryAfter,
+    now,
+    includeDefault: false,
   });
   return {
     response: formatErrorResponse(response.status, "upstream_error", message, {
       ...(upstreamCode !== undefined ? { code: upstreamCode } : {}),
-      ...(retryAfter !== undefined ? { retryAfter } : {}),
+      ...(clientRetryAfter !== undefined ? { retryAfter: clientRetryAfter } : {}),
     }),
     classificationText,
     ...(upstreamCode !== undefined ? { upstreamCode } : {}),
-    ...(retryAfter !== undefined ? { retryAfter } : {}),
+    ...(cooldownRetryAfter !== undefined ? { retryAfter: cooldownRetryAfter } : {}),
     ...(usage ? { usage } : {}),
   };
 }

--- a/src/server/responses/passthrough-error.ts
+++ b/src/server/responses/passthrough-error.ts
@@ -1,11 +1,5 @@
 import { formatErrorResponse } from "../../bridge";
-import { parseRetryAfterMs } from "../../combos";
-
-function sanitizedRetryAfter(value: string | null | undefined, now: number): string | undefined {
-  const trimmed = value?.trim();
-  if (!trimmed || trimmed.length > 128) return undefined;
-  return parseRetryAfterMs(trimmed, now) !== undefined ? trimmed : undefined;
-}
+import { resolveClientRetryAfter } from "../../lib/retry-after";
 
 /**
  * Passthrough adapters historically relayed upstream non-2xx bodies verbatim.
@@ -16,9 +10,8 @@ function sanitizedRetryAfter(value: string | null | undefined, now: number): str
  * HTML/text errors) must keep their original bytes and headers so pool-retry
  * activation and client diagnostics stay honest.
  *
- * Normalized (empty-body) responses force `Content-Type: application/json` and
- * preserve a validated `Retry-After` so Responses clients and the chat-completions
- * / Claude bridges that copy that header keep correct backoff.
+ * When Retry-After is missing on a retryable 429, inject a small default so
+ * Codex/Responses clients can back off the same way Claude Code does (#507).
  */
 export function formatPassthroughUpstreamError(
   status: number,
@@ -31,9 +24,25 @@ export function formatPassthroughUpstreamError(
 ): Response {
   const trimmed = bodyText.trim();
   const now = options?.now ?? Date.now();
-  const retryAfter = sanitizedRetryAfter(options?.headers?.get("retry-after"), now);
+  const retryAfter = resolveClientRetryAfter({
+    status,
+    message: trimmed || `Provider error ${status}: (empty body)`,
+    upstreamRetryAfter: options?.headers?.get("retry-after"),
+    now,
+  });
 
   if (trimmed) {
+    if (retryAfter && !options?.headers?.get("retry-after")?.trim()) {
+      const headers = options?.headers
+        ? new Headers(options.headers)
+        : new Headers({ "Content-Type": "application/json" });
+      headers.set("Retry-After", retryAfter);
+      return new Response(bodyText, {
+        status,
+        ...(options?.statusText ? { statusText: options.statusText } : {}),
+        headers,
+      });
+    }
     return new Response(bodyText, {
       status,
       ...(options?.statusText ? { statusText: options.statusText } : {}),
@@ -45,6 +54,7 @@ export function formatPassthroughUpstreamError(
     status,
     "upstream_error",
     `Provider error ${status}: (empty body)`,
+    retryAfter !== undefined ? { retryAfter } : undefined,
   );
   const headers = new Headers(response.headers);
   headers.set("Content-Type", "application/json");

--- a/src/server/responses/passthrough-error.ts
+++ b/src/server/responses/passthrough-error.ts
@@ -1,5 +1,8 @@
 import { formatErrorResponse } from "../../bridge";
-import { resolveClientRetryAfter } from "../../lib/retry-after";
+import {
+  resolveClientRetryAfter,
+  validateClientRetryAfterHeader,
+} from "../../lib/retry-after";
 
 /**
  * Passthrough adapters historically relayed upstream non-2xx bodies verbatim.
@@ -10,8 +13,11 @@ import { resolveClientRetryAfter } from "../../lib/retry-after";
  * HTML/text errors) must keep their original bytes and headers so pool-retry
  * activation and client diagnostics stay honest.
  *
- * When Retry-After is missing on a retryable 429, inject a small default so
- * Codex/Responses clients can back off the same way Claude Code does (#507).
+ * Retry-After is validated independently of the body path:
+ * - valid upstream values are preserved
+ * - missing/malformed values are replaced when resolveClientRetryAfter yields a value
+ * - malformed/expired values are removed when the resolver returns undefined
+ *   (e.g. quota-exhausted 429s must not keep junk headers or get the synthetic "2")
  */
 export function formatPassthroughUpstreamError(
   status: number,
@@ -24,8 +30,9 @@ export function formatPassthroughUpstreamError(
 ): Response {
   const trimmed = bodyText.trim();
   const now = options?.now ?? Date.now();
-  const upstreamRetryAfter = options?.headers?.get("retry-after")?.trim();
-  const retryAfter = resolveClientRetryAfter({
+  const upstreamRetryAfter = options?.headers?.get("retry-after")?.trim() || undefined;
+  const originalValid = validateClientRetryAfterHeader(upstreamRetryAfter, now);
+  const resolved = resolveClientRetryAfter({
     status,
     message: trimmed || `Provider error ${status}: (empty body)`,
     upstreamRetryAfter,
@@ -33,22 +40,28 @@ export function formatPassthroughUpstreamError(
   });
 
   if (trimmed) {
-    // Replace missing *or* malformed upstream Retry-After with the resolved value.
-    if (retryAfter && upstreamRetryAfter !== retryAfter) {
-      const headers = options?.headers
-        ? new Headers(options.headers)
-        : new Headers({ "Content-Type": "application/json" });
-      headers.set("Retry-After", retryAfter);
+    const needsSet = resolved !== undefined && upstreamRetryAfter !== resolved;
+    const needsDelete = resolved === undefined
+      && upstreamRetryAfter !== undefined
+      && originalValid === undefined;
+
+    if (!needsSet && !needsDelete) {
       return new Response(bodyText, {
         status,
         ...(options?.statusText ? { statusText: options.statusText } : {}),
-        headers,
+        ...(options?.headers ? { headers: options.headers } : { headers: { "Content-Type": "application/json" } }),
       });
     }
+
+    const headers = options?.headers
+      ? new Headers(options.headers)
+      : new Headers({ "Content-Type": "application/json" });
+    if (needsSet) headers.set("Retry-After", resolved!);
+    else headers.delete("Retry-After");
     return new Response(bodyText, {
       status,
       ...(options?.statusText ? { statusText: options.statusText } : {}),
-      ...(options?.headers ? { headers: options.headers } : { headers: { "Content-Type": "application/json" } }),
+      headers,
     });
   }
 
@@ -56,10 +69,10 @@ export function formatPassthroughUpstreamError(
     status,
     "upstream_error",
     `Provider error ${status}: (empty body)`,
-    retryAfter !== undefined ? { retryAfter } : undefined,
+    resolved !== undefined ? { retryAfter: resolved } : undefined,
   );
   const headers = new Headers(response.headers);
   headers.set("Content-Type", "application/json");
-  if (retryAfter !== undefined) headers.set("Retry-After", retryAfter);
+  if (resolved !== undefined) headers.set("Retry-After", resolved);
   return new Response(response.body, { status: response.status, headers });
 }

--- a/src/server/responses/passthrough-error.ts
+++ b/src/server/responses/passthrough-error.ts
@@ -24,15 +24,17 @@ export function formatPassthroughUpstreamError(
 ): Response {
   const trimmed = bodyText.trim();
   const now = options?.now ?? Date.now();
+  const upstreamRetryAfter = options?.headers?.get("retry-after")?.trim();
   const retryAfter = resolveClientRetryAfter({
     status,
     message: trimmed || `Provider error ${status}: (empty body)`,
-    upstreamRetryAfter: options?.headers?.get("retry-after"),
+    upstreamRetryAfter,
     now,
   });
 
   if (trimmed) {
-    if (retryAfter && !options?.headers?.get("retry-after")?.trim()) {
+    // Replace missing *or* malformed upstream Retry-After with the resolved value.
+    if (retryAfter && upstreamRetryAfter !== retryAfter) {
       const headers = options?.headers
         ? new Headers(options.headers)
         : new Headers({ "Content-Type": "application/json" });

--- a/tests/issue-452-empty-503.test.ts
+++ b/tests/issue-452-empty-503.test.ts
@@ -82,11 +82,19 @@ describe("formatPassthroughUpstreamError (#452)", () => {
   });
 
   test("empty body drops invalid Retry-After values", async () => {
-    for (const bad of ["", "nope", "-1", "0", "1e6", "not-a-delay"]) {
+    // "0" is intentionally preserved as an instant-retry client directive
+    // (see resolveClientRetryAfter / #507 review hardening).
+    for (const bad of ["", "nope", "-1", "1e6", "not-a-delay"]) {
       const headers = new Headers({ "retry-after": bad });
       const response = formatPassthroughUpstreamError(503, "", { headers, now: Date.now() });
       expect(response.headers.get("retry-after")).toBeNull();
     }
+  });
+
+  test("empty body preserves Retry-After: 0", async () => {
+    const headers = new Headers({ "retry-after": "0" });
+    const response = formatPassthroughUpstreamError(503, "", { headers, now: Date.now() });
+    expect(response.headers.get("retry-after")).toBe("0");
   });
 
   test("JSON with error.message is preserved for Codex", async () => {

--- a/tests/retry-after-429.test.ts
+++ b/tests/retry-after-429.test.ts
@@ -5,6 +5,7 @@ import {
   resolveClientRetryAfter,
 } from "../src/lib/retry-after";
 import { formatPassthroughUpstreamError } from "../src/server/responses/passthrough-error";
+import { consumeComboFailure } from "../src/server/responses/core";
 
 describe("resolveClientRetryAfter (#507)", () => {
   test("prefers a validated upstream Retry-After header", () => {
@@ -50,6 +51,44 @@ describe("resolveClientRetryAfter (#507)", () => {
       upstreamRetryAfter: "not-a-delay",
     })).toBe(DEFAULT_RETRYABLE_429_RETRY_AFTER_SEC);
   });
+
+  test("preserves an explicit Retry-After: 0 on 429", () => {
+    expect(resolveClientRetryAfter({
+      status: 429,
+      message: "Too Many Requests",
+      upstreamRetryAfter: "0",
+    })).toBe("0");
+  });
+
+  test("preserves an explicit Retry-After: 0 on 503 (chat/Claude bridge)", () => {
+    expect(resolveClientRetryAfter({
+      status: 503,
+      message: "Service Unavailable",
+      upstreamRetryAfter: "0",
+    })).toBe("0");
+  });
+
+  test("includeDefault:false omits the synthetic retryable-429 fallback", () => {
+    expect(resolveClientRetryAfter({
+      status: 429,
+      message: "Too many requests — please slow down",
+      includeDefault: false,
+    })).toBeUndefined();
+  });
+
+  test("includeDefault:false still keeps header and message-derived delays", () => {
+    expect(resolveClientRetryAfter({
+      status: 429,
+      message: "rate limited",
+      upstreamRetryAfter: "12",
+      includeDefault: false,
+    })).toBe("12");
+    expect(resolveClientRetryAfter({
+      status: 429,
+      message: "Please try again in 9s.",
+      includeDefault: false,
+    })).toBe("9");
+  });
 });
 
 describe("formatErrorResponse Retry-After (#507)", () => {
@@ -92,5 +131,40 @@ describe("formatPassthroughUpstreamError Retry-After (#507)", () => {
     const headers = new Headers({ "retry-after": "30", "content-type": "application/json" });
     const response = formatPassthroughUpstreamError(429, body, { headers });
     expect(response.headers.get("Retry-After")).toBe("30");
+  });
+
+  test("replaces a malformed non-empty upstream Retry-After on retryable 429", () => {
+    const body = JSON.stringify({ error: { message: "Too many requests" } });
+    const headers = new Headers({ "retry-after": "not-a-delay", "content-type": "application/json" });
+    const response = formatPassthroughUpstreamError(429, body, { headers });
+    expect(response.headers.get("Retry-After")).toBe(DEFAULT_RETRYABLE_429_RETRY_AFTER_SEC);
+  });
+
+  test("preserves Retry-After: 0 on non-empty 429", () => {
+    const body = JSON.stringify({ error: { message: "Too many requests" } });
+    const headers = new Headers({ "retry-after": "0", "content-type": "application/json" });
+    const response = formatPassthroughUpstreamError(429, body, { headers });
+    expect(response.headers.get("Retry-After")).toBe("0");
+  });
+});
+
+describe("consumeComboFailure Retry-After separation (#507 review)", () => {
+  test("missing Retry-After attaches client fallback but omits it from cooldown metadata", async () => {
+    const upstream = new Response(JSON.stringify({ error: { message: "Too many requests" } }), {
+      status: 429,
+    });
+    const failure = await consumeComboFailure(upstream);
+    expect(failure.response.headers.get("Retry-After")).toBe(DEFAULT_RETRYABLE_429_RETRY_AFTER_SEC);
+    expect(failure.retryAfter).toBeUndefined();
+  });
+
+  test("valid upstream Retry-After is kept for both client and cooldown metadata", async () => {
+    const upstream = new Response(JSON.stringify({ error: { message: "Too many requests" } }), {
+      status: 429,
+      headers: { "retry-after": "45" },
+    });
+    const failure = await consumeComboFailure(upstream);
+    expect(failure.response.headers.get("Retry-After")).toBe("45");
+    expect(failure.retryAfter).toBe("45");
   });
 });

--- a/tests/retry-after-429.test.ts
+++ b/tests/retry-after-429.test.ts
@@ -140,11 +140,63 @@ describe("formatPassthroughUpstreamError Retry-After (#507)", () => {
     expect(response.headers.get("Retry-After")).toBe(DEFAULT_RETRYABLE_429_RETRY_AFTER_SEC);
   });
 
-  test("preserves Retry-After: 0 on non-empty 429", () => {
+  test("removes malformed Retry-After on quota-exhausted non-empty 429 (no synthetic 2)", async () => {
+    const body = JSON.stringify({ error: { message: "exceeded your current quota" } });
+    const headers = new Headers({
+      "retry-after": "not-a-delay",
+      "content-type": "application/json",
+      "x-pool-retry-test": "keep-me",
+    });
+    const response = formatPassthroughUpstreamError(429, body, {
+      statusText: "Too Many Requests",
+      headers,
+    });
+    expect(response.status).toBe(429);
+    expect(response.statusText).toBe("Too Many Requests");
+    expect(response.headers.get("Retry-After")).toBeNull();
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(response.headers.get("x-pool-retry-test")).toBe("keep-me");
+    expect(await response.text()).toBe(body);
+  });
+
+  test("removes expired Retry-After on quota-exhausted non-empty 429 (no synthetic 2)", async () => {
+    const now = Date.UTC(2026, 6, 26, 12, 0, 0);
+    const expired = new Date(now - 60_000).toUTCString();
+    const body = JSON.stringify({ error: { message: "exceeded your current quota" } });
+    const headers = new Headers({
+      "retry-after": expired,
+      "content-type": "application/json",
+      "x-pool-retry-test": "keep-me",
+    });
+    const response = formatPassthroughUpstreamError(429, body, {
+      statusText: "Too Many Requests",
+      headers,
+      now,
+    });
+    expect(response.status).toBe(429);
+    expect(response.statusText).toBe("Too Many Requests");
+    expect(response.headers.get("Retry-After")).toBeNull();
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(response.headers.get("x-pool-retry-test")).toBe("keep-me");
+    expect(await response.text()).toBe(body);
+  });
+
+  test("preserves valid Retry-After: 0 and unrelated headers on non-empty 429", async () => {
     const body = JSON.stringify({ error: { message: "Too many requests" } });
-    const headers = new Headers({ "retry-after": "0", "content-type": "application/json" });
-    const response = formatPassthroughUpstreamError(429, body, { headers });
+    const headers = new Headers({
+      "retry-after": "0",
+      "content-type": "application/json",
+      "x-pool-retry-test": "keep-me",
+    });
+    const response = formatPassthroughUpstreamError(429, body, {
+      statusText: "Too Many Requests",
+      headers,
+    });
+    expect(response.status).toBe(429);
+    expect(response.statusText).toBe("Too Many Requests");
     expect(response.headers.get("Retry-After")).toBe("0");
+    expect(response.headers.get("x-pool-retry-test")).toBe("keep-me");
+    expect(await response.text()).toBe(body);
   });
 });
 

--- a/tests/retry-after-429.test.ts
+++ b/tests/retry-after-429.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { formatErrorResponse } from "../src/bridge";
+import {
+  DEFAULT_RETRYABLE_429_RETRY_AFTER_SEC,
+  resolveClientRetryAfter,
+} from "../src/lib/retry-after";
+import { formatPassthroughUpstreamError } from "../src/server/responses/passthrough-error";
+
+describe("resolveClientRetryAfter (#507)", () => {
+  test("prefers a validated upstream Retry-After header", () => {
+    expect(resolveClientRetryAfter({
+      status: 429,
+      message: "Too Many Requests",
+      upstreamRetryAfter: "15",
+    })).toBe("15");
+  });
+
+  test("parses delay hints embedded in the error message", () => {
+    expect(resolveClientRetryAfter({
+      status: 429,
+      message: "Throttled. Please try again in 7s.",
+    })).toBe("7");
+  });
+
+  test("defaults retryable rate-limit 429s when upstream omitted Retry-After", () => {
+    expect(resolveClientRetryAfter({
+      status: 429,
+      message: "Too many requests — please slow down",
+    })).toBe(DEFAULT_RETRYABLE_429_RETRY_AFTER_SEC);
+  });
+
+  test("does not invent Retry-After for quota-exhausted 429s", () => {
+    expect(resolveClientRetryAfter({
+      status: 429,
+      message: "Kiro quota exhausted: monthly quota exceeded",
+    })).toBeUndefined();
+  });
+
+  test("does not invent Retry-After for non-429 statuses", () => {
+    expect(resolveClientRetryAfter({
+      status: 503,
+      message: "Service Unavailable",
+    })).toBeUndefined();
+  });
+
+  test("drops invalid upstream Retry-After and falls through to the 429 default", () => {
+    expect(resolveClientRetryAfter({
+      status: 429,
+      message: "rate limited",
+      upstreamRetryAfter: "not-a-delay",
+    })).toBe(DEFAULT_RETRYABLE_429_RETRY_AFTER_SEC);
+  });
+});
+
+describe("formatErrorResponse Retry-After (#507)", () => {
+  test("attaches Retry-After when provided", () => {
+    const response = formatErrorResponse(429, "rate_limit_error", "Too Many Requests", {
+      retryAfter: "2",
+    });
+    expect(response.headers.get("Retry-After")).toBe("2");
+  });
+});
+
+describe("formatPassthroughUpstreamError Retry-After (#507)", () => {
+  test("empty-body retryable 429 gets a default Retry-After", async () => {
+    const response = formatPassthroughUpstreamError(429, "");
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe(DEFAULT_RETRYABLE_429_RETRY_AFTER_SEC);
+    const json = await response.json() as { error?: { message?: string } };
+    expect(json.error?.message).toContain("429");
+  });
+
+  test("empty-body quota 429 does not invent Retry-After", () => {
+    // Message used for classification comes from the body text.
+    const response = formatPassthroughUpstreamError(
+      429,
+      JSON.stringify({ error: { message: "exceeded your current quota" } }),
+    );
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBeNull();
+  });
+
+  test("non-empty retryable 429 without Retry-After gets the default", () => {
+    const body = JSON.stringify({ error: { message: "Too many requests" } });
+    const response = formatPassthroughUpstreamError(429, body);
+    expect(response.headers.get("Retry-After")).toBe(DEFAULT_RETRYABLE_429_RETRY_AFTER_SEC);
+    expect(response.headers.get("content-type")).toContain("application/json");
+  });
+
+  test("preserves an explicit upstream Retry-After on non-empty 429", () => {
+    const body = JSON.stringify({ error: { message: "Too many requests" } });
+    const headers = new Headers({ "retry-after": "30", "content-type": "application/json" });
+    const response = formatPassthroughUpstreamError(429, body, { headers });
+    expect(response.headers.get("Retry-After")).toBe("30");
+  });
+});

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -889,6 +889,9 @@ describe("server local API auth", () => {
     }
   });
 
+  // Windows CI under the full suite can spend >1s opening WS turns and >5s on this
+  // multi-server matrix; tight budgets flake as "tier websocket timeout" and cascade
+  // into the next test via a late fetch restore (502 instead of the mocked 500).
   test("OpenAI option auth matrix keeps direct, pool, and API credentials independent", async () => {
     if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
     mkdirSync(TEST_DIR, { recursive: true });
@@ -910,7 +913,7 @@ describe("server local API auth", () => {
       },
     });
     let whamRequests = 0;
-    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const matrixFetch = ((input: RequestInfo | URL, init?: RequestInit) => {
       const requestUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       const url = new URL(requestUrl);
       if (url.hostname === "chatgpt.com" && url.pathname.startsWith("/backend-api/wham/")) {
@@ -925,6 +928,7 @@ describe("server local API auth", () => {
       }
       return originalGlobalFetch(input, init);
     }) as typeof fetch;
+    globalThis.fetch = matrixFetch;
 
     const request = (server: ReturnType<typeof startServer>, headers?: HeadersInit, model = "gpt-test") => {
       const requestHeaders = new Headers(headers);
@@ -951,7 +955,7 @@ describe("server local API auth", () => {
       url.protocol = "ws:";
       const ws = new WebSocket(url, { headers: { "x-opencodex-api-key": "local-secret", ...(headers ?? {}) } } as unknown as string[]);
       return new Promise<string>((resolve, reject) => {
-        const timer = setTimeout(() => reject(new Error("tier websocket timeout")), 1000);
+        const timer = setTimeout(() => reject(new Error("tier websocket timeout")), 5_000);
         ws.addEventListener("open", () => {
           ws.send(JSON.stringify({ type: "response.create", model, input: "hello" }));
         }, { once: true });
@@ -1184,7 +1188,7 @@ describe("server local API auth", () => {
       const sendFrame = async (model: string) => {
         const before = seen.length;
         const message = new Promise<string>((resolve, reject) => {
-          const timer = setTimeout(() => reject(new Error(`sequential websocket timeout: ${model}`)), 1000);
+          const timer = setTimeout(() => reject(new Error(`sequential websocket timeout: ${model}`)), 5_000);
           const onMessage = (event: MessageEvent) => {
             const value = typeof event.data === "string" ? event.data : "";
             if (!value.includes('"type":"response.completed"')) return;
@@ -1225,10 +1229,12 @@ describe("server local API auth", () => {
         await sequential.stop(true);
       }
     } finally {
-      globalThis.fetch = originalGlobalFetch;
+      // Only clear our mock if a later/timeout race has not already replaced it.
+      // afterEach always restores originalGlobalFetch once this test settles.
+      if (globalThis.fetch === matrixFetch) globalThis.fetch = originalGlobalFetch;
       await upstream.stop(true);
     }
-  });
+  }, { timeout: 30_000 });
 
   test("internal web-search and vision never forward a non-ChatGPT bearer as Direct sidecar auth", async () => {
     if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });


### PR DESCRIPTION
## Summary
- Add `resolveClientRetryAfter` so retryable HTTP 429s always expose a client `Retry-After` (upstream header → message hint → default `2`), while quota-exhausted 429s stay without a fabricated backoff (#507).
- Wire it through Responses, chat completions, Claude messages, and passthrough empty/non-empty error paths so Codex can back off the same way Claude Code already does when Kiro omits the header.
- Cover the helper and passthrough behavior with focused regression tests.

## Test plan
- [x] `bun test tests/retry-after-429.test.ts tests/claude-529-mapping.test.ts tests/issue-452-empty-503.test.ts`
- [x] `bun run typecheck`
- [ ] Reproduce Kiro 429 without `Retry-After` via Codex and confirm the client sees `Retry-After: 2` and recovers
- [ ] Confirm quota-exhausted 429 responses still omit a default `Retry-After`

Closes #507


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved `Retry-After` handling across upstream error responses, including chat/completions, Claude message rewriting, and response passthrough.
  - Prefers valid upstream timing; can extract retry delays hinted in error messages.
  - Applies a short default backoff for retryable HTTP 429 when upstream timing is missing.
  - Continues to avoid retry guidance for quota-exhausted 429 errors.

- **Bug Fixes**
  - Preserves explicit `Retry-After: 0` for instant retries.
  - Ensures `Retry-After` headers and JSON content type are retained for passthrough errors.
  - Separates client-facing retry timing from combo cooldown metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->