### PR TITLE
fix(combos): surface catalog omissions in sync and GUI

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -80,10 +80,12 @@ when **every** target has discoverable capabilities that can be intersected:
   `modelContextWindows` / `contextWindow`)
 - a non-empty `inputModalities` intersection (defaults to `["text"]` when a member omits modalities)
 
-When a member is a bare relay id with no context metadata, the combo is **omitted from the catalog**
-even though direct requests still work. `ocx sync` prints each omission; the Combos dashboard flags
-it under Needs attention. Fix by setting `modelContextWindows` (and modalities if needed) on the
-relay provider, or by pointing the target at a model that already advertises those fields.
+When a member is a bare relay id with no context metadata, or when members advertise **disjoint**
+`inputModalities` (empty intersection), the combo is **omitted from the catalog** even though direct
+requests still work. `ocx sync` surfaces a summary warning (and `console.warn` once per combo); the
+Combos dashboard flags it under Needs attention. Fix by setting `modelContextWindows` / matching
+modalities on the relay provider, or by pointing targets at models that already advertise compatible
+fields.
 
 If an older development build already ran `syncResumeHistory` before backup support existed, you can
 also force the same native-provider recovery with `ocx recover-history --legacy-openai`.

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -67,6 +67,24 @@ differing backup and rewrites known legacy namespaced selected ids to bare ids.
 `max_concurrent_threads_per_session` value under `[features.multi_agent_v2]` in Codex's
 `$CODEX_HOME/config.toml`; enable v2 first so that table exists.
 
+## Combos (`config.combos`)
+
+Failover / round-robin aliases live under `combos.<id>` with `targets` (provider + model), optional
+`strategy`, `alias`, and `defaultEffort`. A combo is always routable by `combo/<id>` or its alias
+when requested explicitly.
+
+Catalog listing is stricter. `ocx sync`, `/v1/models`, and Codex's model picker only include a combo
+when **every** target has discoverable capabilities that can be intersected:
+
+- a positive `contextWindow` (from live `/models`, registry hints, or provider
+  `modelContextWindows` / `contextWindow`)
+- a non-empty `inputModalities` intersection (defaults to `["text"]` when a member omits modalities)
+
+When a member is a bare relay id with no context metadata, the combo is **omitted from the catalog**
+even though direct requests still work. `ocx sync` prints each omission; the Combos dashboard flags
+it under Needs attention. Fix by setting `modelContextWindows` (and modalities if needed) on the
+relay provider, or by pointing the target at a model that already advertises those fields.
+
 If an older development build already ran `syncResumeHistory` before backup support existed, you can
 also force the same native-provider recovery with `ocx recover-history --legacy-openai`.
 

--- a/gui/src/combo-workspace-data.ts
+++ b/gui/src/combo-workspace-data.ts
@@ -47,7 +47,7 @@ export interface ComboSections {
 export interface ComboAttentionItem {
   id: string;
   model: string;
-  reason: "few-targets" | "empty-targets";
+  reason: "few-targets" | "empty-targets" | "catalog-omitted";
 }
 
 export const COMBO_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/;
@@ -153,13 +153,23 @@ export function filterCombos(items: ComboItem[], query: string): ComboItem[] {
   });
 }
 
-export function buildComboAttention(items: ComboItem[]): ComboAttentionItem[] {
+export function buildComboAttention(
+  items: ComboItem[],
+  options: { cataloguedComboIds?: ReadonlySet<string> } = {},
+): ComboAttentionItem[] {
   const out: ComboAttentionItem[] = [];
+  const catalogued = options.cataloguedComboIds;
   for (const item of items) {
     if (item.targets.length === 0) {
       out.push({ id: item.id, model: item.model, reason: "empty-targets" });
     } else if (item.targets.length < 2) {
       out.push({ id: item.id, model: item.model, reason: "few-targets" });
+    }
+    // Configured combos missing from the live catalog (usually incomplete member
+    // contextWindow / modality intersection) still route by alias, but never appear
+    // in Codex's picker — flag that gap (#484).
+    if (catalogued && item.targets.length > 0 && !catalogued.has(item.id)) {
+      out.push({ id: item.id, model: item.model, reason: "catalog-omitted" });
     }
   }
   return out;

--- a/gui/src/components/ComboWorkspace.tsx
+++ b/gui/src/components/ComboWorkspace.tsx
@@ -20,6 +20,7 @@ export default function ComboWorkspace({
   combos,
   providers,
   models,
+  cataloguedComboIds,
   loading,
   onRefresh,
   onSave,
@@ -210,7 +211,12 @@ export default function ComboWorkspace({
             onDirtyChange={setDetailDirty}
           />
         ) : (
-          <OverviewPanel combos={combos} onSelect={(id) => trySelect(id)} onAdd={onAdd} />
+          <OverviewPanel
+            combos={combos}
+            cataloguedComboIds={cataloguedComboIds}
+            onSelect={(id) => trySelect(id)}
+            onAdd={onAdd}
+          />
         )}
       </div>
 

--- a/gui/src/components/combo-workspace-overview-panel.tsx
+++ b/gui/src/components/combo-workspace-overview-panel.tsx
@@ -1,11 +1,11 @@
 import type { ComboItem } from "../combo-workspace-data";
 import { buildComboAttention, groupCombos } from "../combo-workspace-data";
 import { IconAlert, IconChevron, IconPlus } from "../icons";
-import { useT } from "../i18n/shared";
+import { useT, type TFn } from "../i18n/shared";
 
 function attentionCopy(
   reason: "empty-targets" | "few-targets" | "catalog-omitted",
-  t: (key: string) => string,
+  t: TFn,
 ): string {
   if (reason === "empty-targets") return t("cws.attention.empty");
   if (reason === "catalog-omitted") return t("cws.attention.catalogOmitted");

--- a/gui/src/components/combo-workspace-overview-panel.tsx
+++ b/gui/src/components/combo-workspace-overview-panel.tsx
@@ -3,18 +3,29 @@ import { buildComboAttention, groupCombos } from "../combo-workspace-data";
 import { IconAlert, IconChevron, IconPlus } from "../icons";
 import { useT } from "../i18n/shared";
 
+function attentionCopy(
+  reason: "empty-targets" | "few-targets" | "catalog-omitted",
+  t: (key: string) => string,
+): string {
+  if (reason === "empty-targets") return t("cws.attention.empty");
+  if (reason === "catalog-omitted") return t("cws.attention.catalogOmitted");
+  return t("cws.attention.few");
+}
+
 export function OverviewPanel({
   combos,
+  cataloguedComboIds,
   onSelect,
   onAdd,
 }: {
   combos: ComboItem[];
+  cataloguedComboIds?: ReadonlySet<string>;
   onSelect: (id: string) => void;
   onAdd: () => void;
 }) {
   const t = useT();
   const sections = groupCombos(combos);
-  const attention = buildComboAttention(combos);
+  const attention = buildComboAttention(combos, { cataloguedComboIds });
 
   return (
     <div className="combos-workspace-overview">
@@ -41,12 +52,15 @@ export function OverviewPanel({
           <h3 className="pwi-section-title">{t("cws.attentionTitle")}</h3>
           <div className="cwi-attention-list">
             {attention.map((item) => (
-              <button key={item.id} type="button" className="cwi-attention-row" onClick={() => onSelect(item.id)}>
+              <button
+                key={`${item.id}:${item.reason}`}
+                type="button"
+                className="cwi-attention-row"
+                onClick={() => onSelect(item.id)}
+              >
                 <IconAlert width={14} height={14} aria-hidden="true" />
                 <code className="chip">{item.model}</code>
-                <span className="muted">
-                  {item.reason === "empty-targets" ? t("cws.attention.empty") : t("cws.attention.few")}
-                </span>
+                <span className="muted">{attentionCopy(item.reason, t)}</span>
                 <IconChevron width={14} height={14} style={{ marginLeft: "auto" }} aria-hidden="true" />
               </button>
             ))}

--- a/gui/src/components/combo-workspace-types.ts
+++ b/gui/src/components/combo-workspace-types.ts
@@ -14,6 +14,8 @@ export interface ComboWorkspaceProps {
   combos: ComboItem[];
   providers: ProviderOption[];
   models: ModelOption[];
+  /** Combo ids currently present in the live catalog (`provider === "combo"`). */
+  cataloguedComboIds?: ReadonlySet<string>;
   loading?: boolean;
   onRefresh: () => void;
   onSave: (item: ComboItem, isCreate: boolean, renameFrom?: string) => Promise<{ ok: boolean; error?: string }>;

--- a/gui/src/i18n/de.ts
+++ b/gui/src/i18n/de.ts
@@ -1172,7 +1172,7 @@ export const de: Record<TKey, string> = {
   "cws.attentionTitle": "Aufmerksamkeit nötig",
   "cws.attention.empty": "Keine Ziele konfiguriert",
   "cws.attention.few": "Nur ein Ziel — Failover hat kein Ersatzziel",
-  "cws.attention.catalogOmitted": "Fehlt im Modellkatalog — einem Mitglied fehlen Context-Window-/Fähigkeitsmetadaten (Routing per Alias funktioniert weiterhin)",
+  "cws.attention.catalogOmitted": "Fehlt im Modellkatalog — Mitgliederfähigkeiten sind unvollständig oder inkompatibel (fehlendes Context-Window/Metadaten oder leere Modalitäts-Schnittmenge). Routing per Alias funktioniert weiterhin",
   "cws.emptyTitle": "Erste Combo erstellen",
   "cws.empty.createDesc": "Virtuelles Modell benennen und zwei oder mehr Backends verketten.",
   "cws.backToAll": "Zurück zu allen Combos",

--- a/gui/src/i18n/de.ts
+++ b/gui/src/i18n/de.ts
@@ -1172,6 +1172,7 @@ export const de: Record<TKey, string> = {
   "cws.attentionTitle": "Aufmerksamkeit nötig",
   "cws.attention.empty": "Keine Ziele konfiguriert",
   "cws.attention.few": "Nur ein Ziel — Failover hat kein Ersatzziel",
+  "cws.attention.catalogOmitted": "Fehlt im Modellkatalog — einem Mitglied fehlen Context-Window-/Fähigkeitsmetadaten (Routing per Alias funktioniert weiterhin)",
   "cws.emptyTitle": "Erste Combo erstellen",
   "cws.empty.createDesc": "Virtuelles Modell benennen und zwei oder mehr Backends verketten.",
   "cws.backToAll": "Zurück zu allen Combos",

--- a/gui/src/i18n/en.ts
+++ b/gui/src/i18n/en.ts
@@ -1194,6 +1194,7 @@ export const en = {
   "cws.attentionTitle": "Needs attention",
   "cws.attention.empty": "No targets configured",
   "cws.attention.few": "Only one target — failover has nowhere to hop",
+  "cws.attention.catalogOmitted": "Missing from the model catalog — a member lacks context window / capability metadata (routing by alias still works)",
   "cws.emptyTitle": "Create your first combo",
   "cws.empty.createDesc": "Name a virtual model and chain two or more backends.",
   "cws.backToAll": "Back to all combos",

--- a/gui/src/i18n/en.ts
+++ b/gui/src/i18n/en.ts
@@ -1194,7 +1194,7 @@ export const en = {
   "cws.attentionTitle": "Needs attention",
   "cws.attention.empty": "No targets configured",
   "cws.attention.few": "Only one target — failover has nowhere to hop",
-  "cws.attention.catalogOmitted": "Missing from the model catalog — a member lacks context window / capability metadata (routing by alias still works)",
+  "cws.attention.catalogOmitted": "Missing from the model catalog — member capabilities are incomplete or incompatible (missing context window / metadata, or empty modality intersection). Routing by alias still works",
   "cws.emptyTitle": "Create your first combo",
   "cws.empty.createDesc": "Name a virtual model and chain two or more backends.",
   "cws.backToAll": "Back to all combos",

--- a/gui/src/i18n/ja.ts
+++ b/gui/src/i18n/ja.ts
@@ -1232,7 +1232,7 @@ export const ja: Record<TKey, string> = {
   "cws.attentionTitle": "要対応",
   "cws.attention.empty": "ターゲットが設定されていません",
   "cws.attention.few": "ターゲットが 1 つだけ — フェイルオーバーのホップ先がありません",
-  "cws.attention.catalogOmitted": "モデルカタログにありません — メンバーに context window / 能力メタデータが不足しています（エイリアス指定のルーティングは動作します）",
+  "cws.attention.catalogOmitted": "モデルカタログにありません — メンバー能力が不完全または非互換です（context window / メタデータ不足、または modality 交差が空）。エイリアス指定のルーティングは動作します",
   "cws.emptyTitle": "最初のコンボを作成",
   "cws.empty.createDesc": "仮想モデルに名前を付け、2 つ以上のバックエンドをつなぎます。",
   "cws.backToAll": "すべてのコンボに戻る",

--- a/gui/src/i18n/ja.ts
+++ b/gui/src/i18n/ja.ts
@@ -1232,6 +1232,7 @@ export const ja: Record<TKey, string> = {
   "cws.attentionTitle": "要対応",
   "cws.attention.empty": "ターゲットが設定されていません",
   "cws.attention.few": "ターゲットが 1 つだけ — フェイルオーバーのホップ先がありません",
+  "cws.attention.catalogOmitted": "モデルカタログにありません — メンバーに context window / 能力メタデータが不足しています（エイリアス指定のルーティングは動作します）",
   "cws.emptyTitle": "最初のコンボを作成",
   "cws.empty.createDesc": "仮想モデルに名前を付け、2 つ以上のバックエンドをつなぎます。",
   "cws.backToAll": "すべてのコンボに戻る",

--- a/gui/src/i18n/ko.ts
+++ b/gui/src/i18n/ko.ts
@@ -1192,6 +1192,7 @@ export const ko: Record<TKey, string> = {
   "cws.attentionTitle": "확인 필요",
   "cws.attention.empty": "구성된 대상 없음",
   "cws.attention.few": "대상이 하나뿐 — 장애 조치할 곳이 없음",
+  "cws.attention.catalogOmitted": "모델 카탈로그에 없음 — 멤버에 context window/능력 메타데이터가 부족함(별칭 라우팅은 계속 동작)",
   "cws.emptyTitle": "첫 콤보 만들기",
   "cws.empty.createDesc": "가상 모델 이름을 정하고 백엔드를 둘 이상 연결하세요.",
   "cws.backToAll": "모든 콤보로",

--- a/gui/src/i18n/ko.ts
+++ b/gui/src/i18n/ko.ts
@@ -1192,7 +1192,7 @@ export const ko: Record<TKey, string> = {
   "cws.attentionTitle": "확인 필요",
   "cws.attention.empty": "구성된 대상 없음",
   "cws.attention.few": "대상이 하나뿐 — 장애 조치할 곳이 없음",
-  "cws.attention.catalogOmitted": "모델 카탈로그에 없음 — 멤버에 context window/능력 메타데이터가 부족함(별칭 라우팅은 계속 동작)",
+  "cws.attention.catalogOmitted": "모델 카탈로그에 없음 — 멤버 능력이 불완전하거나 호환되지 않음(context window/메타데이터 부족 또는 modality 교집합이 비어 있음). 별칭 라우팅은 계속 동작",
   "cws.emptyTitle": "첫 콤보 만들기",
   "cws.empty.createDesc": "가상 모델 이름을 정하고 백엔드를 둘 이상 연결하세요.",
   "cws.backToAll": "모든 콤보로",

--- a/gui/src/i18n/ru.ts
+++ b/gui/src/i18n/ru.ts
@@ -1278,7 +1278,7 @@ export const ru: Record<TKey, string> = {
   "cws.attentionTitle": "Требует внимания",
   "cws.attention.empty": "Цели не настроены",
   "cws.attention.few": "Только одна цель — failover некуда переключаться",
-  "cws.attention.catalogOmitted": "Отсутствует в каталоге моделей — у участника нет context window / метаданных возможностей (маршрутизация по alias всё ещё работает)",
+  "cws.attention.catalogOmitted": "Отсутствует в каталоге моделей — возможности участников неполны или несовместимы (нет context window / метаданных, или пустое пересечение modalities). Маршрутизация по alias всё ещё работает",
   "cws.emptyTitle": "Создайте первое комбо",
   "cws.empty.createDesc": "Задайте имя виртуальной модели и объедините в цепочку два и более бэкенда.",
   "cws.backToAll": "Назад ко всем комбо",

--- a/gui/src/i18n/ru.ts
+++ b/gui/src/i18n/ru.ts
@@ -1278,6 +1278,7 @@ export const ru: Record<TKey, string> = {
   "cws.attentionTitle": "Требует внимания",
   "cws.attention.empty": "Цели не настроены",
   "cws.attention.few": "Только одна цель — failover некуда переключаться",
+  "cws.attention.catalogOmitted": "Отсутствует в каталоге моделей — у участника нет context window / метаданных возможностей (маршрутизация по alias всё ещё работает)",
   "cws.emptyTitle": "Создайте первое комбо",
   "cws.empty.createDesc": "Задайте имя виртуальной модели и объедините в цепочку два и более бэкенда.",
   "cws.backToAll": "Назад ко всем комбо",

--- a/gui/src/i18n/zh.ts
+++ b/gui/src/i18n/zh.ts
@@ -1192,6 +1192,7 @@ export const zh: Record<TKey, string> = {
   "cws.attentionTitle": "需要关注",
   "cws.attention.empty": "未配置目标",
   "cws.attention.few": "只有一个目标 — 故障转移无处可跳",
+  "cws.attention.catalogOmitted": "未出现在模型目录中 — 某个成员缺少上下文窗口/能力元数据（按别名路由仍可用）",
   "cws.emptyTitle": "创建第一个组合",
   "cws.empty.createDesc": "命名虚拟模型并串联两个或多个后端。",
   "cws.backToAll": "返回全部组合",

--- a/gui/src/i18n/zh.ts
+++ b/gui/src/i18n/zh.ts
@@ -1192,7 +1192,7 @@ export const zh: Record<TKey, string> = {
   "cws.attentionTitle": "需要关注",
   "cws.attention.empty": "未配置目标",
   "cws.attention.few": "只有一个目标 — 故障转移无处可跳",
-  "cws.attention.catalogOmitted": "未出现在模型目录中 — 某个成员缺少上下文窗口/能力元数据（按别名路由仍可用）",
+  "cws.attention.catalogOmitted": "未出现在模型目录中 — 成员能力不完整或不兼容（缺少上下文窗口/元数据，或模态交集为空）。按别名路由仍可用",
   "cws.emptyTitle": "创建第一个组合",
   "cws.empty.createDesc": "命名虚拟模型并串联两个或多个后端。",
   "cws.backToAll": "返回全部组合",

--- a/gui/src/pages/Combos.tsx
+++ b/gui/src/pages/Combos.tsx
@@ -44,6 +44,7 @@ export default function Combos({ apiBase }: { apiBase: string }) {
   const [combos, setCombos] = useState<ComboItem[]>([]);
   const [providers, setProviders] = useState<ProviderOption[]>([]);
   const [models, setModels] = useState<ModelOption[]>([]);
+  const [cataloguedComboIds, setCataloguedComboIds] = useState<ReadonlySet<string>>(() => new Set());
   const [loading, setLoading] = useState(true);
   const [status, setStatus] = useState("");
   const [statusOk, setStatusOk] = useState(false);
@@ -102,13 +103,18 @@ export default function Combos({ apiBase }: { apiBase: string }) {
       );
 
       const fromApi: ModelOption[] = [];
+      const catalogued = new Set<string>();
       for (const row of modelRows) {
         if (!row || typeof row !== "object") continue;
         const m = row as { provider?: unknown; id?: unknown; namespaced?: unknown; disabled?: unknown };
         if (typeof m.provider !== "string" || typeof m.id !== "string") continue;
         const provider = m.provider.trim();
         const id = m.id.trim();
-        if (!provider || !id || provider === "combo") continue; // combos cannot nest other combos as targets
+        if (!provider || !id) continue;
+        if (provider === "combo") {
+          catalogued.add(id);
+          continue; // combos cannot nest other combos as targets
+        }
         if (m.disabled === true) continue;
         fromApi.push({
           provider,
@@ -116,6 +122,7 @@ export default function Combos({ apiBase }: { apiBase: string }) {
           namespaced: typeof m.namespaced === "string" ? m.namespaced : undefined,
         });
       }
+      setCataloguedComboIds(catalogued);
 
       // Ensure each provider's defaultModel appears even if catalog fetch lagged.
       for (const [name, p] of Object.entries(configJson.providers ?? {})) {
@@ -221,6 +228,7 @@ export default function Combos({ apiBase }: { apiBase: string }) {
           combos={combos}
           providers={providers}
           models={models}
+          cataloguedComboIds={cataloguedComboIds}
           loading={loading}
           onRefresh={() => { void fetchAll(); }}
           onSave={saveCombo}

--- a/src/codex/catalog.ts
+++ b/src/codex/catalog.ts
@@ -6,6 +6,7 @@ export { NATIVE_OPENAI_MODELS, nativeOpenAiContextWindow, disabledNativeSlugs, v
 export { isSpawnableCodexCandidate, codexExecInvocation, loadBundledCodexCatalog, materializeBundledCodexCatalog, loadCatalogTemplate } from "./catalog/bundled";
 export { nativeEffortClamp, shouldApplyNativeEffortClamp, catalogModelEfforts, codexSupportedReasoningEfforts, clampedDefaultEffort, clampEntryToCodexSupportedEfforts, clampCatalogModelsToCodexSupport } from "./catalog/effort";
 export { applyProviderConfigHints, isDatedVariantId, filterCatalogVisibleModels, gatherRoutedModels, augmentRoutedModelsWithRegistryOpenAiApiRows, augmentRoutedModelsWithJawcodeMetadata } from "./catalog/provider-fetch";
-export { deriveComboCatalogModel, exactComboCatalogSlugs, resetOpenAiApiCatalogWarningStateForTests, uniqueCatalogModelsForPublicList, uniqueCatalogModelsForRawPublicList } from "./catalog/aggregation";
+export { deriveComboCatalogModel, exactComboCatalogSlugs, getLastComboCatalogOmissions, resetOpenAiApiCatalogWarningStateForTests, uniqueCatalogModelsForPublicList, uniqueCatalogModelsForRawPublicList } from "./catalog/aggregation";
+export type { ComboCatalogOmission } from "./catalog/aggregation";
 export { MAX_SPAWN_AGENT_MODEL_OVERRIDES, effectiveSubagentRoster, buildCatalogEntries, resetCatalogRuntimeStateForTests, orderForSubagents, mergeCatalogEntriesForSync, syncCatalogModels, restoreCodexCatalog, invalidateCodexModelsCache } from "./catalog/sync";
 export type { SpawnAgentSurface, SubagentRosterExclusionReason, EffectiveSubagentModel, SubagentRosterExclusion, EffectiveSubagentRoster } from "./catalog/sync";

--- a/src/codex/catalog.ts
+++ b/src/codex/catalog.ts
@@ -6,7 +6,7 @@ export { NATIVE_OPENAI_MODELS, nativeOpenAiContextWindow, disabledNativeSlugs, v
 export { isSpawnableCodexCandidate, codexExecInvocation, loadBundledCodexCatalog, materializeBundledCodexCatalog, loadCatalogTemplate } from "./catalog/bundled";
 export { nativeEffortClamp, shouldApplyNativeEffortClamp, catalogModelEfforts, codexSupportedReasoningEfforts, clampedDefaultEffort, clampEntryToCodexSupportedEfforts, clampCatalogModelsToCodexSupport } from "./catalog/effort";
 export { applyProviderConfigHints, isDatedVariantId, filterCatalogVisibleModels, gatherRoutedModels, augmentRoutedModelsWithRegistryOpenAiApiRows, augmentRoutedModelsWithJawcodeMetadata } from "./catalog/provider-fetch";
-export { deriveComboCatalogModel, exactComboCatalogSlugs, getLastComboCatalogOmissions, resetOpenAiApiCatalogWarningStateForTests, uniqueCatalogModelsForPublicList, uniqueCatalogModelsForRawPublicList } from "./catalog/aggregation";
-export type { ComboCatalogOmission } from "./catalog/aggregation";
+export { deriveComboCatalogModel, exactComboCatalogSlugs, getLastComboCatalogOmissions, resetOpenAiApiCatalogWarningStateForTests, uniqueCatalogModelsForPublicList, uniqueCatalogModelsForRawPublicList, buildComboCatalogOmission, comboCatalogOmissionReason, summarizeComboCatalogOmissions } from "./catalog/aggregation";
+export type { ComboCatalogOmission, ComboCatalogOmissionReason } from "./catalog/aggregation";
 export { MAX_SPAWN_AGENT_MODEL_OVERRIDES, effectiveSubagentRoster, buildCatalogEntries, resetCatalogRuntimeStateForTests, orderForSubagents, mergeCatalogEntriesForSync, syncCatalogModels, restoreCodexCatalog, invalidateCodexModelsCache } from "./catalog/sync";
 export type { SpawnAgentSurface, SubagentRosterExclusionReason, EffectiveSubagentModel, SubagentRosterExclusion, EffectiveSubagentRoster } from "./catalog/sync";

--- a/src/codex/catalog/aggregation.ts
+++ b/src/codex/catalog/aggregation.ts
@@ -55,6 +55,10 @@ export function getLastComboCatalogOmissions(): readonly ComboCatalogOmission[] 
   return lastComboCatalogOmissions;
 }
 
+export function replaceLastComboCatalogOmissions(items: readonly ComboCatalogOmission[]): void {
+  lastComboCatalogOmissions = [...items];
+}
+
 export function intersectStrings(values: readonly string[][]): string[] {
   if (values.length === 0) return [];
   const rest = values.slice(1).map(value => new Set(value));
@@ -168,20 +172,24 @@ export function buildComboCatalogOmission(
 }
 
 /**
- * Record a combo omitted from `/v1/models` + on-disk catalog, warn once per signature,
- * and always append to the per-gather omission list so sync/CLI/API can surface it (#484).
+ * Record a combo omitted from `/v1/models` + on-disk catalog and warn once per signature.
+ * Callers that need a race-free list (catalog sync) pass a local `sink` from the same
+ * gather invocation instead of reading process-global state afterward (#484 review).
  */
 export function warnUncataloguedComboOnce(
   id: string,
   combo: NormalizedComboConfig,
   members: readonly CatalogModel[],
-): void {
+  sink: ComboCatalogOmission[] = lastComboCatalogOmissions,
+): ComboCatalogOmission {
   const omission = buildComboCatalogOmission(id, combo);
-  lastComboCatalogOmissions.push(omission);
+  sink.push(omission);
   const signature = comboCatalogWarningSignature(combo, members);
-  if (comboCatalogWarningSignatures.get(id) === signature) return;
-  comboCatalogWarningSignatures.set(id, signature);
-  console.warn(omission.message);
+  if (comboCatalogWarningSignatures.get(id) !== signature) {
+    comboCatalogWarningSignatures.set(id, signature);
+    console.warn(omission.message);
+  }
+  return omission;
 }
 
 export function exactComboCatalogSlugs(

--- a/src/codex/catalog/aggregation.ts
+++ b/src/codex/catalog/aggregation.ts
@@ -38,6 +38,23 @@ export const openAiApiCollisionWarnings = new Set<string>();
 
 export const comboCatalogWarningSignatures = new Map<string, string>();
 
+/** Combos omitted from the catalog during the most recent `gatherRoutedModels` call (#484). */
+export interface ComboCatalogOmission {
+  id: string;
+  targets: string[];
+  message: string;
+}
+
+let lastComboCatalogOmissions: ComboCatalogOmission[] = [];
+
+export function clearLastComboCatalogOmissions(): void {
+  lastComboCatalogOmissions = [];
+}
+
+export function getLastComboCatalogOmissions(): readonly ComboCatalogOmission[] {
+  return lastComboCatalogOmissions;
+}
+
 export function intersectStrings(values: readonly string[][]): string[] {
   if (values.length === 0) return [];
   const rest = values.slice(1).map(value => new Set(value));
@@ -136,20 +153,35 @@ export function comboCatalogWarningSignature(
   }).sort((a, b) => a.key.localeCompare(b.key)));
 }
 
+export function buildComboCatalogOmission(
+  id: string,
+  combo: NormalizedComboConfig,
+): ComboCatalogOmission {
+  const targets = combo.targets
+    .map(target => safeCatalogWarningLabel(targetKey(target)))
+    .sort((a, b) => a.localeCompare(b));
+  return {
+    id,
+    targets,
+    message: `[opencodex] Combo "${safeCatalogWarningLabel(id)}" is omitted from the catalog because member capabilities are incomplete: ${targets.join(", ")}.`,
+  };
+}
+
+/**
+ * Record a combo omitted from `/v1/models` + on-disk catalog, warn once per signature,
+ * and always append to the per-gather omission list so sync/CLI/API can surface it (#484).
+ */
 export function warnUncataloguedComboOnce(
   id: string,
   combo: NormalizedComboConfig,
   members: readonly CatalogModel[],
 ): void {
+  const omission = buildComboCatalogOmission(id, combo);
+  lastComboCatalogOmissions.push(omission);
   const signature = comboCatalogWarningSignature(combo, members);
   if (comboCatalogWarningSignatures.get(id) === signature) return;
   comboCatalogWarningSignatures.set(id, signature);
-  const targets = combo.targets
-    .map(target => safeCatalogWarningLabel(targetKey(target)))
-    .sort((a, b) => a.localeCompare(b));
-  console.warn(
-    `[opencodex] Combo "${safeCatalogWarningLabel(id)}" is omitted from the catalog because member capabilities are incomplete: ${targets.join(", ")}.`,
-  );
+  console.warn(omission.message);
 }
 
 export function exactComboCatalogSlugs(

--- a/src/codex/catalog/aggregation.ts
+++ b/src/codex/catalog/aggregation.ts
@@ -38,10 +38,20 @@ export const openAiApiCollisionWarnings = new Set<string>();
 
 export const comboCatalogWarningSignatures = new Map<string, string>();
 
+/**
+ * Why `deriveComboCatalogModel` rejected a configured combo (#484 / #516).
+ * Distinguishes unresolved/incomplete member metadata from a complete but empty
+ * modality intersection so diagnostics do not send operators to the wrong fix.
+ */
+export type ComboCatalogOmissionReason =
+  | "incomplete_metadata"
+  | "incompatible_modalities";
+
 /** Combos omitted from the catalog during the most recent `gatherRoutedModels` call (#484). */
 export interface ComboCatalogOmission {
   id: string;
   targets: string[];
+  reason: ComboCatalogOmissionReason;
   message: string;
 }
 
@@ -81,28 +91,50 @@ export function effectiveComboDefault(
   return atOrBelow.at(-1)?.effort ?? ranked[0]!.effort;
 }
 
+/**
+ * Classify a combo derivation failure. Returns `null` when the combo would catalog.
+ * Callers that already know derivation failed can map the reason into diagnostics.
+ */
+export function comboCatalogOmissionReason(
+  combo: NormalizedComboConfig,
+  members: readonly CatalogModel[],
+): ComboCatalogOmissionReason | null {
+  if (combo.targets.length === 0) return "incomplete_metadata";
+  if (new Set(combo.targets.map(targetKey)).size !== combo.targets.length) {
+    return "incomplete_metadata";
+  }
+  if (members.length !== combo.targets.length) return "incomplete_metadata";
+  if (!members.every((member, index) => (
+    `${member.provider}/${member.id}` === targetKey(combo.targets[index]!)
+  ))) {
+    return "incomplete_metadata";
+  }
+  const contexts = members.map(member => member.contextWindow);
+  if (contexts.some(value => typeof value !== "number" || value <= 0)) {
+    return "incomplete_metadata";
+  }
+
+  const inputModalities = intersectStrings(
+    members.map(member => member.inputModalities ?? ["text"]),
+  );
+  if (inputModalities.length === 0) return "incompatible_modalities";
+  return null;
+}
+
 export function deriveComboCatalogModel(
   id: string,
   combo: NormalizedComboConfig,
   members: readonly CatalogModel[],
 ): CatalogModel | null {
-  if (combo.targets.length === 0) return null;
-  if (new Set(combo.targets.map(targetKey)).size !== combo.targets.length) return null;
-  if (members.length !== combo.targets.length) return null;
-  if (!members.every((member, index) => (
-    `${member.provider}/${member.id}` === targetKey(combo.targets[index]!)
-  ))) return null;
-  const contexts = members.map(member => member.contextWindow);
-  if (contexts.some(value => typeof value !== "number" || value <= 0)) return null;
+  if (comboCatalogOmissionReason(combo, members) !== null) return null;
 
   const inputModalities = intersectStrings(
     members.map(member => member.inputModalities ?? ["text"]),
   );
-  if (inputModalities.length === 0) return null;
   const reasoningEfforts = intersectStrings(
     members.map(member => member.reasoningEfforts ?? []),
   );
-  const contextWindow = Math.min(...contexts as number[]);
+  const contextWindow = Math.min(...members.map(member => member.contextWindow!));
   const maxInputTokens = Math.min(
     ...members.map(member => member.maxInputTokens ?? member.contextWindow!),
   );
@@ -157,17 +189,40 @@ export function comboCatalogWarningSignature(
   }).sort((a, b) => a.key.localeCompare(b.key)));
 }
 
+export function comboCatalogOmissionDetail(reason: ComboCatalogOmissionReason): string {
+  return reason === "incompatible_modalities"
+    ? "members have no common input modalities"
+    : "member capabilities are incomplete";
+}
+
+/** One-line sync/CLI summary that respects the actual omission reason(s). */
+export function summarizeComboCatalogOmissions(
+  omissions: readonly Pick<ComboCatalogOmission, "reason">[],
+): string {
+  const n = omissions.length;
+  const prefix = `${n} combo${n === 1 ? "" : "s"} omitted from the catalog`;
+  if (n === 0) return prefix + ".";
+  const reasons = new Set(omissions.map(item => item.reason));
+  if (reasons.size === 1) {
+    return `${prefix} because ${comboCatalogOmissionDetail([...reasons][0]!)}.`;
+  }
+  return `${prefix}.`;
+}
+
 export function buildComboCatalogOmission(
   id: string,
   combo: NormalizedComboConfig,
+  members: readonly CatalogModel[],
 ): ComboCatalogOmission {
   const targets = combo.targets
     .map(target => safeCatalogWarningLabel(targetKey(target)))
     .sort((a, b) => a.localeCompare(b));
+  const reason = comboCatalogOmissionReason(combo, members) ?? "incomplete_metadata";
   return {
     id,
     targets,
-    message: `[opencodex] Combo "${safeCatalogWarningLabel(id)}" is omitted from the catalog because member capabilities are incomplete: ${targets.join(", ")}.`,
+    reason,
+    message: `[opencodex] Combo "${safeCatalogWarningLabel(id)}" is omitted from the catalog because ${comboCatalogOmissionDetail(reason)}: ${targets.join(", ")}.`,
   };
 }
 
@@ -182,7 +237,7 @@ export function warnUncataloguedComboOnce(
   members: readonly CatalogModel[],
   sink: ComboCatalogOmission[] = lastComboCatalogOmissions,
 ): ComboCatalogOmission {
-  const omission = buildComboCatalogOmission(id, combo);
+  const omission = buildComboCatalogOmission(id, combo, members);
   sink.push(omission);
   const signature = comboCatalogWarningSignature(combo, members);
   if (comboCatalogWarningSignatures.get(id) !== signature) {

--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -47,7 +47,8 @@ import upstreamModelsSnapshot from "../data/upstream-models.json";
 import { JAWCODE_CATALOG_AUGMENT_PROVIDERS, catalogModelSlug, shouldExposeRoutedModel } from "./parsing";
 import type { CatalogModel } from "./parsing";
 import { disabledNativeSlugs, hasComboTargets, nativeInputModalities, nativeOpenAiContextWindow, nativeOpenAiSlugs, nativeParallelToolCalls, nativeReasoningEfforts } from "./metadata";
-import { clearLastComboCatalogOmissions, deriveComboCatalogModel, normalizedOpenAiApiSignature, openAiApiCollisionWarnings, warnUncataloguedComboOnce } from "./aggregation";
+import { deriveComboCatalogModel, normalizedOpenAiApiSignature, openAiApiCollisionWarnings, replaceLastComboCatalogOmissions, warnUncataloguedComboOnce } from "./aggregation";
+import type { ComboCatalogOmission } from "./aggregation";
 
 type OcxProviderConfigWithReasoningSummaries = OcxProviderConfig & {
   modelSupportsReasoningSummaries?: Record<string, boolean>;
@@ -464,8 +465,12 @@ export function filterCatalogVisibleModels(
   });
 }
 
-export async function gatherRoutedModels(config: OcxConfig): Promise<CatalogModel[]> {
-  clearLastComboCatalogOmissions();
+export async function gatherRoutedModels(
+  config: OcxConfig,
+  options?: { comboOmissions?: ComboCatalogOmission[] },
+): Promise<CatalogModel[]> {
+  // Per-invocation list: sync passes `comboOmissions` so overlapping gathers cannot race.
+  const localOmissions: ComboCatalogOmission[] = [];
   const ttlMs = config.modelCacheTtlMs ?? DEFAULT_MODEL_CACHE_TTL_MS;
   // Persisted provider entries can predate newer registry fields (noVisionModels,
   // modelInputModalities, ...). The ROUTER merges registry seeds at request time
@@ -543,7 +548,12 @@ export async function gatherRoutedModels(config: OcxConfig): Promise<CatalogMode
       .filter((member): member is CatalogModel => member !== undefined);
     const derived = deriveComboCatalogModel(id, combo, members);
     if (derived) all.push(derived);
-    else warnUncataloguedComboOnce(id, combo, members);
+    else warnUncataloguedComboOnce(id, combo, members, localOmissions);
+  }
+  replaceLastComboCatalogOmissions(localOmissions);
+  if (options?.comboOmissions) {
+    options.comboOmissions.length = 0;
+    options.comboOmissions.push(...localOmissions);
   }
   all.sort((a, b) => (a.provider === b.provider ? a.id.localeCompare(b.id) : a.provider.localeCompare(b.provider)));
   // Enriched (registry-hydrated) provider clones, keyed by name — the same view used above so

--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -47,7 +47,7 @@ import upstreamModelsSnapshot from "../data/upstream-models.json";
 import { JAWCODE_CATALOG_AUGMENT_PROVIDERS, catalogModelSlug, shouldExposeRoutedModel } from "./parsing";
 import type { CatalogModel } from "./parsing";
 import { disabledNativeSlugs, hasComboTargets, nativeInputModalities, nativeOpenAiContextWindow, nativeOpenAiSlugs, nativeParallelToolCalls, nativeReasoningEfforts } from "./metadata";
-import { deriveComboCatalogModel, normalizedOpenAiApiSignature, openAiApiCollisionWarnings, warnUncataloguedComboOnce } from "./aggregation";
+import { clearLastComboCatalogOmissions, deriveComboCatalogModel, normalizedOpenAiApiSignature, openAiApiCollisionWarnings, warnUncataloguedComboOnce } from "./aggregation";
 
 type OcxProviderConfigWithReasoningSummaries = OcxProviderConfig & {
   modelSupportsReasoningSummaries?: Record<string, boolean>;
@@ -465,6 +465,7 @@ export function filterCatalogVisibleModels(
 }
 
 export async function gatherRoutedModels(config: OcxConfig): Promise<CatalogModel[]> {
+  clearLastComboCatalogOmissions();
   const ttlMs = config.modelCacheTtlMs ?? DEFAULT_MODEL_CACHE_TTL_MS;
   // Persisted provider entries can predate newer registry fields (noVisionModels,
   // modelInputModalities, ...). The ROUTER merges registry seeds at request time

--- a/src/codex/catalog/sync.ts
+++ b/src/codex/catalog/sync.ts
@@ -37,7 +37,7 @@ import { applyNativeVisibility, disabledNativeSlugs, isUnsupportedOpenAiNativeSl
 import { loadCatalogForSync, resetBundledCatalogCacheForTests } from "./bundled";
 import { applyCatalogModelMetadata, applyReasoningLevels, catalogEntryEfforts, clampCatalogModelsToCodexSupport, ensureGpt56ReasoningLevels, ensureUltraReasoningLevel, isGpt56NativeSlug } from "./effort";
 import { filterCatalogVisibleModels, gatherRoutedModels, lastDropWarnSignature } from "./provider-fetch";
-import { clearLastComboCatalogOmissions, comboCatalogWarningSignatures, comboMasqueradeCollisionWarnings, exactComboCatalogSlugs, getLastComboCatalogOmissions, openAiApiCollisionWarnings, resolveSlugAliasCollisions, slugAliasCollisionWarnings, warnComboMasqueradeCollisionOnce } from "./aggregation";
+import { clearLastComboCatalogOmissions, comboCatalogWarningSignatures, comboMasqueradeCollisionWarnings, exactComboCatalogSlugs, openAiApiCollisionWarnings, resolveSlugAliasCollisions, slugAliasCollisionWarnings, warnComboMasqueradeCollisionOnce } from "./aggregation";
 import type { ComboCatalogOmission } from "./aggregation";
 
 export const MAX_SPAWN_AGENT_MODEL_OVERRIDES = 5;
@@ -465,8 +465,8 @@ export async function syncCatalogModels(config: OcxConfig): Promise<{
 
   const template = findNativeTemplate(catalog);
 
-  const goModels = await gatherRoutedModels(config);
-  const comboOmissions = [...getLastComboCatalogOmissions()];
+  const comboOmissions: ComboCatalogOmission[] = [];
+  const goModels = await gatherRoutedModels(config, { comboOmissions });
   try {
     // Once-only: preserve the PRISTINE pre-opencodex catalog as the native-priority baseline
     // (later syncs would otherwise overwrite it with featured-modified priorities).

--- a/src/codex/catalog/sync.ts
+++ b/src/codex/catalog/sync.ts
@@ -37,7 +37,8 @@ import { applyNativeVisibility, disabledNativeSlugs, isUnsupportedOpenAiNativeSl
 import { loadCatalogForSync, resetBundledCatalogCacheForTests } from "./bundled";
 import { applyCatalogModelMetadata, applyReasoningLevels, catalogEntryEfforts, clampCatalogModelsToCodexSupport, ensureGpt56ReasoningLevels, ensureUltraReasoningLevel, isGpt56NativeSlug } from "./effort";
 import { filterCatalogVisibleModels, gatherRoutedModels, lastDropWarnSignature } from "./provider-fetch";
-import { comboCatalogWarningSignatures, comboMasqueradeCollisionWarnings, exactComboCatalogSlugs, openAiApiCollisionWarnings, resolveSlugAliasCollisions, slugAliasCollisionWarnings, warnComboMasqueradeCollisionOnce } from "./aggregation";
+import { clearLastComboCatalogOmissions, comboCatalogWarningSignatures, comboMasqueradeCollisionWarnings, exactComboCatalogSlugs, getLastComboCatalogOmissions, openAiApiCollisionWarnings, resolveSlugAliasCollisions, slugAliasCollisionWarnings, warnComboMasqueradeCollisionOnce } from "./aggregation";
+import type { ComboCatalogOmission } from "./aggregation";
 
 export const MAX_SPAWN_AGENT_MODEL_OVERRIDES = 5;
 
@@ -293,6 +294,7 @@ export function resetCatalogRuntimeStateForTests(): void {
   comboCatalogWarningSignatures.clear();
   slugAliasCollisionWarnings.clear();
   comboMasqueradeCollisionWarnings.clear();
+  clearLastComboCatalogOmissions();
   clearModelCache();
 }
 
@@ -452,14 +454,19 @@ export function mergeCatalogEntriesForSync(
   return applyMultiAgentMode(applyNativeVisibility(mergedEntries, disabledNative), multiAgentMode);
 }
 
-export async function syncCatalogModels(config: OcxConfig): Promise<{ added: number; path: string }> {
+export async function syncCatalogModels(config: OcxConfig): Promise<{
+  added: number;
+  path: string;
+  comboOmissions: ComboCatalogOmission[];
+}> {
   const catalogPath = readCodexCatalogPath();
   const catalog = loadCatalogForSync(catalogPath);
-  if (!catalog) return { added: 0, path: catalogPath };
+  if (!catalog) return { added: 0, path: catalogPath, comboOmissions: [] };
 
   const template = findNativeTemplate(catalog);
 
   const goModels = await gatherRoutedModels(config);
+  const comboOmissions = [...getLastComboCatalogOmissions()];
   try {
     // Once-only: preserve the PRISTINE pre-opencodex catalog as the native-priority baseline
     // (later syncs would otherwise overwrite it with featured-modified priorities).
@@ -493,7 +500,7 @@ export async function syncCatalogModels(config: OcxConfig): Promise<{ added: num
   clampCatalogModelsToCodexSupport(catalog.models);
 
   atomicWriteFile(catalogPath, JSON.stringify(catalog, null, 2) + "\n");
-  return { added: goEntries.length, path: catalogPath };
+  return { added: goEntries.length, path: catalogPath, comboOmissions };
 }
 
 export function restoreCodexCatalog(): { removed: number; kept: number; path: string } {

--- a/src/codex/refresh.ts
+++ b/src/codex/refresh.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { invalidateCodexModelsCache, syncCatalogModels } from "./catalog";
+import type { ComboCatalogOmission } from "./catalog/aggregation";
 import { CODEX_MODELS_CACHE_PATH } from "./paths";
 import { atomicWriteFile } from "../config";
 import type { OcxConfig } from "../types";
@@ -9,6 +10,7 @@ export interface CodexCatalogRefreshResult {
   path: string;
   catalogExists: boolean;
   cacheSynced: boolean;
+  comboOmissions: ComboCatalogOmission[];
 }
 
 interface RefreshDeps {
@@ -40,7 +42,8 @@ export async function refreshCodexModelCatalog(
 ): Promise<CodexCatalogRefreshResult> {
   const result = await deps.syncCatalogModels(config);
   const catalogExists = deps.existsSync(result.path);
-  if (!catalogExists) return { ...result, catalogExists, cacheSynced: false };
+  const comboOmissions = result.comboOmissions ?? [];
+  if (!catalogExists) return { ...result, catalogExists, cacheSynced: false, comboOmissions };
   deps.invalidateCodexModelsCache();
-  return { ...result, catalogExists, cacheSynced: true };
+  return { ...result, catalogExists, cacheSynced: true, comboOmissions };
 }

--- a/src/codex/sync.ts
+++ b/src/codex/sync.ts
@@ -90,10 +90,10 @@ export async function syncModelsToCodex(
       log?.error(warning);
     }
     if (comboOmissions.length > 0) {
-      for (const omission of comboOmissions) {
-        log?.error(omission.message);
-      }
+      // Individual omission lines already went through console.warn during gather;
+      // keep a single summary on the sync logger to avoid duplicate stderr noise.
       const summary = `${comboOmissions.length} combo${comboOmissions.length === 1 ? "" : "s"} omitted from the catalog because member capabilities are incomplete.`;
+      log?.error(summary);
       warning = warning ? `${warning} ${summary}` : summary;
     }
   } catch (e) {

--- a/src/codex/sync.ts
+++ b/src/codex/sync.ts
@@ -4,6 +4,7 @@ import { refreshCodexModelCatalog } from "./refresh";
 import { applyProxyEnv, loadConfig } from "../config";
 import type { OcxConfig } from "../types";
 import { collectOrcaCodexHomeDiagnostic } from "./home";
+import type { ComboCatalogOmission } from "./catalog/aggregation";
 
 export interface CodexSyncResult {
   ok: boolean;
@@ -13,6 +14,7 @@ export interface CodexSyncResult {
   cacheSynced: boolean;
   message: string;
   warning?: string;
+  comboOmissions?: ComboCatalogOmission[];
   projectConfigWarnings?: ProjectCodexConfigWarning[];
   projectConfigGrouped?: { path: string; issues: string[]; bypass: string }[];
 }
@@ -71,6 +73,7 @@ export async function syncModelsToCodex(
   let catalogExists = false;
   let cacheSynced = false;
   let warning: string | undefined;
+  let comboOmissions: ComboCatalogOmission[] = [];
 
   try {
     const cat = await deps.refreshCodexModelCatalog(config);
@@ -79,11 +82,19 @@ export async function syncModelsToCodex(
     cacheSynced = cat.cacheSynced;
     catalogPathForInjection = cat.catalogExists ? cat.path : null;
     catalogPath = catalogPathForInjection;
+    comboOmissions = cat.comboOmissions ?? [];
     if (cat.added > 0) {
       log?.log(`   + ${cat.added} models appended to Codex catalog (${cat.path})`);
     } else if (!cat.catalogExists) {
       warning = "catalog sync skipped: no Codex catalog source found; keeping Codex's native catalog.";
       log?.error(warning);
+    }
+    if (comboOmissions.length > 0) {
+      for (const omission of comboOmissions) {
+        log?.error(omission.message);
+      }
+      const summary = `${comboOmissions.length} combo${comboOmissions.length === 1 ? "" : "s"} omitted from the catalog because member capabilities are incomplete.`;
+      warning = warning ? `${warning} ${summary}` : summary;
     }
   } catch (e) {
     warning = `catalog sync skipped: ${e instanceof Error ? e.message : String(e)}`;
@@ -102,6 +113,7 @@ export async function syncModelsToCodex(
     cacheSynced,
     message: result.message,
     ...(warning ? { warning } : {}),
+    ...(comboOmissions.length > 0 ? { comboOmissions } : {}),
     ...(projectConfigWarnings.length > 0 ? {
       projectConfigWarnings,
       projectConfigGrouped: groupProjectCodexConfigWarningsByPath(projectConfigWarnings),

--- a/src/codex/sync.ts
+++ b/src/codex/sync.ts
@@ -4,7 +4,7 @@ import { refreshCodexModelCatalog } from "./refresh";
 import { applyProxyEnv, loadConfig } from "../config";
 import type { OcxConfig } from "../types";
 import { collectOrcaCodexHomeDiagnostic } from "./home";
-import type { ComboCatalogOmission } from "./catalog/aggregation";
+import { summarizeComboCatalogOmissions, type ComboCatalogOmission } from "./catalog/aggregation";
 
 export interface CodexSyncResult {
   ok: boolean;
@@ -92,7 +92,7 @@ export async function syncModelsToCodex(
     if (comboOmissions.length > 0) {
       // Individual omission lines already went through console.warn during gather;
       // keep a single summary on the sync logger to avoid duplicate stderr noise.
-      const summary = `${comboOmissions.length} combo${comboOmissions.length === 1 ? "" : "s"} omitted from the catalog because member capabilities are incomplete.`;
+      const summary = summarizeComboCatalogOmissions(comboOmissions);
       log?.error(summary);
       warning = warning ? `${warning} ${summary}` : summary;
     }

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -477,6 +477,8 @@ describe("combo catalog capability intersection", () => {
       expect(String(warn.mock.calls[0]?.[0])).toContain("[REDACTED]");
       expect(String(warn.mock.calls[0]?.[0])).not.toContain(warningSentinel);
       expect(second).toEqual(first);
+      const { getLastComboCatalogOmissions } = await import("../src/codex/catalog");
+      expect(getLastComboCatalogOmissions().some(item => item.id === "hidden")).toBe(true);
 
       resetCatalogRuntimeStateForTests();
       await gatherRoutedModels(config);

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { augmentRoutedModelsWithJawcodeMetadata, augmentRoutedModelsWithRegistryOpenAiApiRows, buildCatalogEntries, catalogModelSlug, clampCatalogModelsToCodexSupport, clampEntryToCodexSupportedEfforts, clampedDefaultEffort, deriveComboCatalogModel, exactComboCatalogSlugs, filterCatalogVisibleModels, filterSupportedNativeSlugs, gatherRoutedModels, isDatedVariantId, isMediaGenerationModelId, loadBundledCodexCatalog, materializeBundledCodexCatalog, mergeCatalogEntriesForSync, NATIVE_OPENAI_MODELS, normalizeRoutedCatalogEntry, resetCatalogRuntimeStateForTests, resetOpenAiApiCatalogWarningStateForTests } from "../src/codex/catalog";
+import { augmentRoutedModelsWithJawcodeMetadata, augmentRoutedModelsWithRegistryOpenAiApiRows, buildCatalogEntries, buildComboCatalogOmission, catalogModelSlug, clampCatalogModelsToCodexSupport, clampEntryToCodexSupportedEfforts, clampedDefaultEffort, comboCatalogOmissionReason, deriveComboCatalogModel, exactComboCatalogSlugs, filterCatalogVisibleModels, filterSupportedNativeSlugs, gatherRoutedModels, isDatedVariantId, isMediaGenerationModelId, loadBundledCodexCatalog, materializeBundledCodexCatalog, mergeCatalogEntriesForSync, NATIVE_OPENAI_MODELS, normalizeRoutedCatalogEntry, resetCatalogRuntimeStateForTests, resetOpenAiApiCatalogWarningStateForTests } from "../src/codex/catalog";
 import {
   CURSOR_STATIC_MODELS,
   filterCursorConfiguredModelsByLiveDiscovery,
@@ -202,6 +202,33 @@ describe("combo catalog capability intersection", () => {
         { provider: "a", model: "m1", weight: 1 },
       ],
     }), [memberA, memberA])).toBeNull();
+  });
+
+  test("omission diagnostics distinguish incomplete metadata from disjoint modalities (#516)", () => {
+    const incompleteMembers = [memberA];
+    expect(comboCatalogOmissionReason(normalizedCombo(), incompleteMembers)).toBe("incomplete_metadata");
+    const incomplete = buildComboCatalogOmission("missing-meta", normalizedCombo(), incompleteMembers);
+    expect(incomplete).toMatchObject({
+      id: "missing-meta",
+      reason: "incomplete_metadata",
+    });
+    expect(incomplete.message).toContain("member capabilities are incomplete");
+    expect(incomplete.message).not.toContain("no common input modalities");
+
+    const disjointMembers = [
+      { ...memberA, inputModalities: ["image"] },
+      { ...memberB, inputModalities: ["text"] },
+    ];
+    expect(comboCatalogOmissionReason(normalizedCombo(), disjointMembers)).toBe("incompatible_modalities");
+    expect(deriveComboCatalogModel("disjoint", normalizedCombo(), disjointMembers)).toBeNull();
+    const incompatible = buildComboCatalogOmission("disjoint", normalizedCombo(), disjointMembers);
+    expect(incompatible).toMatchObject({
+      id: "disjoint",
+      reason: "incompatible_modalities",
+      targets: ["a/m1", "b/m2"],
+    });
+    expect(incompatible.message).toContain("no common input modalities");
+    expect(incompatible.message).not.toContain("member capabilities are incomplete");
   });
 
   test("requires member identity to follow target order", () => {
@@ -478,11 +505,64 @@ describe("combo catalog capability intersection", () => {
       expect(String(warn.mock.calls[0]?.[0])).not.toContain(warningSentinel);
       expect(second).toEqual(first);
       const { getLastComboCatalogOmissions } = await import("../src/codex/catalog");
-      expect(getLastComboCatalogOmissions().some(item => item.id === "hidden")).toBe(true);
+      const hidden = getLastComboCatalogOmissions().find(item => item.id === "hidden");
+      expect(hidden).toMatchObject({
+        id: "hidden",
+        reason: "incomplete_metadata",
+      });
+      expect(hidden?.message).toContain("member capabilities are incomplete");
+      expect(hidden?.message).toContain("[REDACTED]");
 
       resetCatalogRuntimeStateForTests();
       await gatherRoutedModels(config);
       expect(warn).toHaveBeenCalledTimes(2);
+    } finally {
+      warn.mockRestore();
+    }
+  }, 15_000);
+
+  test("gather warns about disjoint modalities without calling them incomplete (#516)", async () => {
+    const config: OcxConfig = {
+      port: 10100,
+      defaultProvider: "a",
+      providers: {
+        a: {
+          adapter: "openai-chat",
+          baseUrl: "https://a.example/v1",
+          liveModels: false,
+          models: ["m1"],
+          modelContextWindows: { m1: 200_000 },
+          modelInputModalities: { m1: ["image"] },
+        },
+        b: {
+          adapter: "openai-chat",
+          baseUrl: "https://b.example/v1",
+          liveModels: false,
+          models: ["m2"],
+          modelContextWindows: { m2: 128_000 },
+          modelInputModalities: { m2: ["text"] },
+        },
+      },
+      combos: {
+        disjoint: { targets: [{ provider: "a", model: "m1" }, { provider: "b", model: "m2" }] },
+      },
+    };
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      resetCatalogRuntimeStateForTests();
+      const models = await gatherRoutedModels(config);
+      expect(models.some(model => model.provider === "combo" && model.id === "disjoint")).toBe(false);
+      const { getLastComboCatalogOmissions } = await import("../src/codex/catalog");
+      const omission = getLastComboCatalogOmissions().find(item => item.id === "disjoint");
+      expect(omission).toMatchObject({
+        id: "disjoint",
+        reason: "incompatible_modalities",
+      });
+      expect(omission?.message).toContain("no common input modalities");
+      expect(omission?.message).not.toContain("member capabilities are incomplete");
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0]?.[0])).toContain("no common input modalities");
+      expect(String(warn.mock.calls[0]?.[0])).not.toContain("member capabilities are incomplete");
     } finally {
       warn.mockRestore();
     }

--- a/tests/codex-refresh.test.ts
+++ b/tests/codex-refresh.test.ts
@@ -12,7 +12,7 @@ describe("Codex catalog refresh", () => {
   test("writes an expired Codex models cache whenever the materialized catalog exists", async () => {
     let invalidated = 0;
     const result = await refreshCodexModelCatalog(config, {
-      syncCatalogModels: async () => ({ added: 0, path: "/tmp/opencodex-catalog.json" }),
+      syncCatalogModels: async () => ({ added: 0, path: "/tmp/opencodex-catalog.json", comboOmissions: [] }),
       invalidateCodexModelsCache: () => { invalidated += 1; },
       existsSync: () => true,
     });
@@ -22,6 +22,7 @@ describe("Codex catalog refresh", () => {
       path: "/tmp/opencodex-catalog.json",
       catalogExists: true,
       cacheSynced: true,
+      comboOmissions: [],
     });
     expect(invalidated).toBe(1);
   });
@@ -29,13 +30,14 @@ describe("Codex catalog refresh", () => {
   test("does not touch the cache when no Codex catalog can be materialized", async () => {
     let invalidated = 0;
     const result = await refreshCodexModelCatalog(config, {
-      syncCatalogModels: async () => ({ added: 0, path: "/tmp/missing-catalog.json" }),
+      syncCatalogModels: async () => ({ added: 0, path: "/tmp/missing-catalog.json", comboOmissions: [] }),
       invalidateCodexModelsCache: () => { invalidated += 1; },
       existsSync: () => false,
     });
 
     expect(result.catalogExists).toBe(false);
     expect(result.cacheSynced).toBe(false);
+    expect(result.comboOmissions).toEqual([]);
     expect(invalidated).toBe(0);
   });
 });

--- a/tests/codex-sync-api.test.ts
+++ b/tests/codex-sync-api.test.ts
@@ -85,6 +85,7 @@ describe("GUI/CLI Codex sync backend", () => {
     const omission = {
       id: "k3k3",
       targets: ["kimi/k3", "xianyu/kimi-k3"],
+      reason: "incomplete_metadata" as const,
       message: "[opencodex] Combo \"k3k3\" is omitted from the catalog because member capabilities are incomplete: kimi/k3, xianyu/kimi-k3.",
     };
     const result = await syncModelsToCodex(12345, config, { log: line => logs.push(String(line)), error: line => errors.push(String(line)) }, {

--- a/tests/codex-sync-api.test.ts
+++ b/tests/codex-sync-api.test.ts
@@ -102,7 +102,9 @@ describe("GUI/CLI Codex sync backend", () => {
 
     expect(result.comboOmissions).toEqual([omission]);
     expect(result.warning).toContain("1 combo omitted from the catalog");
-    expect(errors).toContain(omission.message);
+    expect(errors).toEqual([
+      "1 combo omitted from the catalog because member capabilities are incomplete.",
+    ]);
   });
 
   test("keeps injection fallback behavior when catalog refresh throws", async () => {

--- a/tests/codex-sync-api.test.ts
+++ b/tests/codex-sync-api.test.ts
@@ -108,6 +108,37 @@ describe("GUI/CLI Codex sync backend", () => {
     ]);
   });
 
+  test("CLI sync summary uses incompatible_modalities reason, not incomplete (#516)", async () => {
+    const errors: string[] = [];
+    const omission = {
+      id: "disjoint",
+      targets: ["a/m1", "b/m2"],
+      reason: "incompatible_modalities" as const,
+      message: "[opencodex] Combo \"disjoint\" is omitted from the catalog because members have no common input modalities: a/m1, b/m2.",
+    };
+    const result = await syncModelsToCodex(12345, config, { log: () => {}, error: line => errors.push(String(line)) }, {
+      refreshCodexModelCatalog: async () => ({
+        added: 0,
+        path: "/tmp/opencodex-catalog.json",
+        catalogExists: true,
+        cacheSynced: true,
+        comboOmissions: [omission],
+      }),
+      injectCodexConfig: async () => ({ success: true, message: "injected" }),
+      currentExternalCodexModelProvider: () => null,
+      collectCodexHomeDiagnostic: () => homeDiagnostic(),
+    });
+
+    expect(result.comboOmissions).toEqual([omission]);
+    expect(result.warning).toBe(
+      "1 combo omitted from the catalog because members have no common input modalities.",
+    );
+    expect(errors).toEqual([
+      "1 combo omitted from the catalog because members have no common input modalities.",
+    ]);
+    expect(errors.join("\n")).not.toContain("member capabilities are incomplete");
+  });
+
   test("keeps injection fallback behavior when catalog refresh throws", async () => {
     let injectedCatalogPath: string | null | undefined = "unset";
 

--- a/tests/codex-sync-api.test.ts
+++ b/tests/codex-sync-api.test.ts
@@ -54,6 +54,7 @@ describe("GUI/CLI Codex sync backend", () => {
         path: "/tmp/opencodex-catalog.json",
         catalogExists: true,
         cacheSynced: true,
+        comboOmissions: [],
       }),
       injectCodexConfig: async (port, _config, options) => {
         injectedPort = port;
@@ -76,6 +77,32 @@ describe("GUI/CLI Codex sync backend", () => {
     });
     expect(logs).toContain("   Target Codex home: C:\\Users\\[USER]\\.codex");
     expect(errors).toEqual([]);
+  });
+
+  test("surfaces combo catalog omissions in sync result and CLI stderr (#484)", async () => {
+    const logs: string[] = [];
+    const errors: string[] = [];
+    const omission = {
+      id: "k3k3",
+      targets: ["kimi/k3", "xianyu/kimi-k3"],
+      message: "[opencodex] Combo \"k3k3\" is omitted from the catalog because member capabilities are incomplete: kimi/k3, xianyu/kimi-k3.",
+    };
+    const result = await syncModelsToCodex(12345, config, { log: line => logs.push(String(line)), error: line => errors.push(String(line)) }, {
+      refreshCodexModelCatalog: async () => ({
+        added: 1,
+        path: "/tmp/opencodex-catalog.json",
+        catalogExists: true,
+        cacheSynced: true,
+        comboOmissions: [omission],
+      }),
+      injectCodexConfig: async () => ({ success: true, message: "injected" }),
+      currentExternalCodexModelProvider: () => null,
+      collectCodexHomeDiagnostic: () => homeDiagnostic(),
+    });
+
+    expect(result.comboOmissions).toEqual([omission]);
+    expect(result.warning).toContain("1 combo omitted from the catalog");
+    expect(errors).toContain(omission.message);
   });
 
   test("keeps injection fallback behavior when catalog refresh throws", async () => {

--- a/tests/combo-workspace-data.test.ts
+++ b/tests/combo-workspace-data.test.ts
@@ -172,6 +172,21 @@ describe("combo-workspace-data", () => {
     ]);
   });
 
+  test("attention flags combos missing from the live catalog (#484)", () => {
+    const attention = buildComboAttention(
+      [
+        combo({ id: "ok" }),
+        combo({ id: "missing", model: "combo/missing" }),
+        combo({ id: "empty", model: "combo/empty", targets: [] }),
+      ],
+      { cataloguedComboIds: new Set(["ok"]) },
+    );
+    expect(attention).toEqual([
+      { id: "missing", model: "combo/missing", reason: "catalog-omitted" },
+      { id: "empty", model: "combo/empty", reason: "empty-targets" },
+    ]);
+  });
+
   test("validates combo id boundaries and duplicate ids on create and rename", () => {
     expect(isValidComboId("a")).toBe(true);
     expect(isValidComboId(`a${"x".repeat(63)}`)).toBe(true);


### PR DESCRIPTION
## Summary
- Collect combo catalog omissions during `gatherRoutedModels` and return them through catalog sync / `ocx sync` / `POST /api/sync` (stderr + structured `comboOmissions` / warning summary).
- Combos workspace flags configured combos missing from the live catalog under Needs attention.
- Document the catalog completeness rule (context window + modality intersection) in the configuration reference.

## Test plan
- [x] `bun test tests/codex-sync-api.test.ts tests/codex-refresh.test.ts tests/combo-workspace-data.test.ts tests/codex-catalog.test.ts`
- [x] `bun run typecheck`
- [ ] Create a combo with a relay member lacking `modelContextWindows`; confirm `ocx sync` prints the omission and Combos attention shows it
- [ ] Confirm a healthy combo still catalogs and does not warn

Closes #484
