### PR TITLE
fix(ci): close freeform issue-quality template bypass

### DIFF
--- a/.github/scripts/issue-quality.cjs
+++ b/.github/scripts/issue-quality.cjs
@@ -421,7 +421,97 @@ function isRawPlaceholder(raw) {
 }
 
 /**
+ * Near-miss freeform headings that often appear in API-opened or copy-pasted
+ * bug reports instead of the Bug report template (e.g. Description / Log entry).
+ */
+const FREEFORM_BUG_NEAR_MISS_HEADINGS = [
+  "Description",
+  "Steps to reproduce",
+  "Steps to Reproduce",
+  "How to reproduce",
+  "Log",
+  "Logs",
+  "Log entry",
+  "Error",
+  "Error output",
+  "Stack trace",
+];
+
+/**
+ * True when an unclassified body looks like a bug report that skipped the
+ * template (near-miss headings and/or repro/error signals).
+ *
+ * @param {{ title?: string, body?: string }} issue
+ * @returns {boolean}
+ */
+function looksLikeUntemplatedBugReport(issue) {
+  const body = typeof issue?.body === "string" ? issue.body : "";
+  if (!body.trim()) return false;
+
+  const nearMissCount = countHeadings(body, FREEFORM_BUG_NEAR_MISS_HEADINGS);
+  const hasReproduction =
+    extractSection(body, "Reproduction") !== null ||
+    extractSection(body, "Steps to reproduce") !== null ||
+    extractSection(body, "Steps to Reproduce") !== null ||
+    extractSection(body, "How to reproduce") !== null;
+  const hasDescription = extractSection(body, "Description") !== null;
+  const hasLogOrError =
+    extractSection(body, "Log") !== null ||
+    extractSection(body, "Logs") !== null ||
+    extractSection(body, "Log entry") !== null ||
+    extractSection(body, "Logs or error output") !== null ||
+    extractSection(body, "Error") !== null ||
+    extractSection(body, "Error output") !== null ||
+    extractSection(body, "Stack trace") !== null;
+
+  if (hasDescription && (hasReproduction || hasLogOrError)) return true;
+  if (hasReproduction && hasLogOrError) return true;
+  if (nearMissCount >= 2) return true;
+
+  // Body-level signals for heading-free freeform dumps.
+  const signalRe =
+    /\b(repro(?:duce|duction| steps)?|stack\s*traces?|traceback|segfault|panic|exception|error\s*output|ECONNREFUSED|SIGSEGV)\b/i;
+  if (signalRe.test(body) && (hasDescription || hasReproduction || hasLogOrError || nearMissCount >= 1)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Reasons/guidance when no structured issue kind was detected.
+ *
+ * @param {{ title?: string, body?: string }} issue
+ * @returns {{ reasons: string[], guidance: string[] }}
+ */
+function untemplatedIssueFailure(issue) {
+  if (looksLikeUntemplatedBugReport(issue)) {
+    return {
+      reasons: [
+        "This looks like a bug report but it does not use the Bug report template headings (for example Description/Log entry instead of Summary).",
+      ],
+      guidance: [
+        "Use the Bug report template, or edit this issue to include: Client or integration, Summary, Reproduction, Version, and Operating system.",
+        "Retitling with `[Bug]:` and applying the `bug` label alone is not enough without those section headings filled in.",
+      ],
+    };
+  }
+  return {
+    reasons: [
+      "This issue does not use a recognized issue template.",
+    ],
+    guidance: [
+      "Open a new issue with the Bug report, Feature request, Documentation, or Provider compatibility template.",
+      "Or edit this issue so the body uses the template section headings for the kind of report you are filing.",
+    ],
+  };
+}
+
+/**
  * Validate an issue body for its detected kind.
+ *
+ * Unclassified (freeform / non-template) issues are invalid so API-opened
+ * reports cannot skip the quality gate. Trusted-author exemption is enforced
+ * by the workflow, not here.
  *
  * @param {{ title: string, body: string, labels: string[], storedKind?: string|null }} issue
  * @returns {{ kind: string|null, valid: boolean, softPass: boolean, reasons: string[], guidance: string[] }}
@@ -435,8 +525,14 @@ function validateIssue(issue) {
   const titleLower = title.toLowerCase();
 
   if (!kind) {
-    // Not a structured form we validate.
-    return { kind: null, valid: true, softPass: false, reasons: [], guidance: [] };
+    const failure = untemplatedIssueFailure(issue);
+    return {
+      kind: null,
+      valid: false,
+      softPass: false,
+      reasons: failure.reasons,
+      guidance: failure.guidance,
+    };
   }
 
   if (kind === "feature") {
@@ -720,6 +816,7 @@ module.exports = {
   resolveSection,
   detectIssueKind,
   validateIssue,
+  looksLikeUntemplatedBugReport,
   shouldReopen,
   shouldEnforceClosure,
   isPlaceholderOnlyValue,

--- a/.github/scripts/issue-quality.test.cjs
+++ b/.github/scripts/issue-quality.test.cjs
@@ -9,6 +9,7 @@ const {
   extractSection,
   detectIssueKind,
   validateIssue,
+  looksLikeUntemplatedBugReport,
   shouldReopen,
   shouldEnforceClosure,
   labelForKind,
@@ -1087,6 +1088,111 @@ describe("labelForKind", () => {
     assert.equal(labelForKind("provider-compatibility"), "provider-compatibility");
     assert.equal(labelForKind(null), null);
     assert.equal(labelForKind("unknown"), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Freeform / non-template bypass (e.g. issue #521)
+// ---------------------------------------------------------------------------
+
+describe("validateIssue - freeform / non-template", () => {
+  it("rejects a plain freeform body that previously skipped validation", () => {
+    const result = validateIssue({
+      title: "How do I configure?",
+      body: "Just a random question about setup.",
+      labels: [],
+    });
+    assert.equal(result.kind, null);
+    assert.equal(result.valid, false);
+    assert.equal(result.softPass, false);
+    assert.ok(result.reasons.some((r) => /recognized issue template/i.test(r)));
+    assert.ok(result.guidance.some((g) => /Bug report|Feature request/i.test(g)));
+  });
+
+  it("rejects a #521-shaped Description/Reproduction/Log entry body with a clear message", () => {
+    const body = [
+      "### Description",
+      "Proxy returns 502 when streaming is enabled on Windows.",
+      "### Reproduction",
+      "1. ocx start",
+      "2. Send a streaming request",
+      "3. Observe 502",
+      "### Log entry",
+      "```",
+      "upstream connect error or disconnect/reset before headers",
+      "```",
+    ].join("\n");
+    assert.equal(
+      detectIssueKind({ title: "Proxy 502 on streaming", body, labels: [] }),
+      null,
+      "near-miss headings must not silently classify as a structured bug",
+    );
+    assert.equal(looksLikeUntemplatedBugReport({ title: "Proxy 502 on streaming", body }), true);
+
+    const result = validateIssue({
+      title: "Proxy 502 on streaming",
+      body,
+      labels: [],
+    });
+    assert.equal(result.kind, null);
+    assert.equal(result.valid, false);
+    assert.ok(
+      result.reasons.some((r) => /bug report/i.test(r) && /template/i.test(r)),
+      `Expected bug-template reason, got: ${result.reasons.join("; ")}`,
+    );
+    assert.ok(
+      result.guidance.some((g) => /Client or integration|Summary|Reproduction/i.test(g)),
+      `Expected template-heading guidance, got: ${result.guidance.join("; ")}`,
+    );
+  });
+
+  it("still detects and validates a real structured bug as before", () => {
+    const body = [
+      "### Client or integration",
+      "Codex CLI",
+      "### Summary",
+      "Proxy segfaults on ARM64 when streaming is enabled.",
+      "### Reproduction",
+      "ocx start on Raspberry Pi 4, send any streaming request.",
+      "### Version",
+      "2.7.30",
+      "### Operating system",
+      "Debian 12 aarch64",
+    ].join("\n");
+    const result = validateIssue({
+      title: "Segfault on ARM64 streaming",
+      body,
+      labels: ["bug"],
+    });
+    assert.equal(result.kind, "bug");
+    assert.equal(result.valid, true);
+  });
+
+  it("does not treat Summary+Reproduction alone as a bug without prefix or label", () => {
+    // Existing anti-false-positive rule; freeform gate still fails these as untemplated.
+    const body = [
+      "### Summary",
+      "Something went wrong in the proxy.",
+      "### Reproduction",
+      "Run ocx start.",
+    ].join("\n");
+    assert.equal(detectIssueKind({ title: "Something went wrong", body, labels: [] }), null);
+    const result = validateIssue({ title: "Something went wrong", body, labels: [] });
+    assert.equal(result.kind, null);
+    assert.equal(result.valid, false);
+  });
+
+  it("keeps label-backed storedKind validation for enhancement freeform", () => {
+    // Workflow passes storedKind from the enhancement label; empty feature form still fails.
+    const result = validateIssue({
+      title: "How do I configure?",
+      body: "Just a random question about setup.",
+      labels: ["enhancement"],
+      storedKind: "feature",
+    });
+    assert.equal(result.kind, "feature");
+    assert.equal(result.valid, false);
+    assert.ok(result.reasons.some((r) => /missing or empty/i.test(r)));
   });
 });
 

--- a/.github/workflows/enforce-issue-quality.yml
+++ b/.github/workflows/enforce-issue-quality.yml
@@ -540,8 +540,13 @@ jobs:
               return null;
             })();
             if (!kind && !labelBasedKind) {
-              core.info("Issue is not a structured form; skipping validation.");
-              return;
+              // Freeform / API-opened issues used to skip here, which let reports
+              // like non-template Description/Reproduction bodies bypass the gate.
+              // Continue into validateIssue (invalid) so non-trusted authors are
+              // closed with template guidance; trusted authors remain exempt below.
+              core.info(
+                "Issue is not a structured form; requiring a template for non-trusted authors.",
+              );
             }
             const resolvedKind = kind ?? labelBasedKind;
 
@@ -680,6 +685,7 @@ jobs:
             // Close (or re-close) the issue.
             const reasonList = result.reasons.map((r) => `- ${r}`).join("\n");
             const guidanceList = result.guidance.map((g) => `- ${g}`).join("\n");
+            const missingTemplate = !resolvedKind;
 
             // Close as not_planned.
             await github.rest.issues.update({
@@ -699,13 +705,20 @@ jobs:
               stateReason: closedIssue.state_reason || "not_planned",
             };
 
+            const closeHeading = missingTemplate
+              ? "### Issue closed: use an issue template"
+              : "### Issue closed: insufficient detail";
+            const closeIntro = missingTemplate
+              ? "Thanks for taking the time to submit this issue. It was closed automatically because it was not opened with a recognized issue template (Bug report, Feature request, Documentation, or Provider compatibility). Freeform and API-opened issues cannot skip this check."
+              : "Thanks for taking the time to submit this issue. It was closed automatically because the structured report is missing information needed to evaluate or reproduce it.";
+
             await upsertComment([
               BOT_MARKER,
               stateTag(newBotState),
               "",
-              "### Issue closed: insufficient detail",
+              closeHeading,
               "",
-              "Thanks for taking the time to submit this issue. It was closed automatically because the structured report is missing information needed to evaluate or reproduce it.",
+              closeIntro,
               "",
               reasonList,
               "",


### PR DESCRIPTION
## Summary
- Freeform / API-opened issues with no detected template kind no longer skip the issue-quality gate (the old `Issue is not a structured form; skipping validation.` path).
- Non-trusted authors are closed `not_planned` with clear guidance to use Bug/Feature/Documentation/Provider templates; near-miss bodies like Description/Reproduction/Log entry (#521-shaped) get a bug-template-specific message.
- Trusted authors (OWNER/MEMBER/COLLABORATOR) remain exempt. Structured bug/feature/docs/provider validation is unchanged.

## Test plan
- [x] `node --test .github/scripts/issue-quality.test.cjs` (77 pass)
- [ ] Confirm after merge to `dev` that live gate behavior still loads scripts from default branch `main` until this change is promoted
- [ ] Optional: `workflow_dispatch` on an untrusted freeform issue after promotion to `main`

## Deployment note
Issue events load `enforce-issue-quality.yml` (and checked-out scripts) from the repository **default branch (`main`)**, not `dev`. Landing on `dev` alone does not change live issue-quality behavior until promotion to `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved issue validation to detect freeform bug reports that omit required template sections.
  - Unrecognized or incomplete issue submissions are now rejected instead of bypassing validation.
  - Validation messages now distinguish between missing templates and missing report details.
  - Added targeted guidance to help authors provide the required bug-report information.
  - Preserved support for valid structured bug reports and trusted-author exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->