### PR TITLE
Fix Console Go tool schema sanitization

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -349,7 +349,9 @@ function ensureZenRootObjectSchema(schema: unknown): Record<string, unknown> {
 }
 
 function shouldSanitizeZenToolParameters(provider: OcxProviderConfig): boolean {
-  return provider.baseUrl.replace(/\/+$/, "") === "https://opencode.ai/zen/v1";
+  const baseUrl = provider.baseUrl.replace(/\/+$/, "");
+  return baseUrl === "https://opencode.ai/zen/v1"
+    || baseUrl === "https://opencode.ai/zen/go/v1";
 }
 
 const XAI_SCHEMA_BASE_URLS = new Set(["api.x.ai", "cli-chat-proxy.grok.com"]);

--- a/tests/opencode-go-deepseek.test.ts
+++ b/tests/opencode-go-deepseek.test.ts
@@ -53,6 +53,52 @@ function buildToolCallBody(modelId: string, reasoning: string): {
 }
 
 describe("opencode-go DeepSeek V4 thinking mode", () => {
+  test("normalizes Desktop-style root composition schemas for Console Go", () => {
+    const route = routeModel(configFor("deepseek-v4-pro"), "opencode-go/deepseek-v4-pro");
+    const req = createOpenAIChatAdapter(route.provider).buildRequest({
+      modelId: route.modelId,
+      context: {
+        messages: [{ role: "user", content: "inspect the repo", timestamp: 0 }],
+        tools: [{
+          name: "automation_update",
+          description: "Update an automation",
+          parameters: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { mode: { $ref: "#/$defs/mode" } },
+                required: ["mode"],
+              },
+              {
+                type: "object",
+                properties: { id: { type: "string" } },
+                required: ["id"],
+              },
+            ],
+            $defs: { mode: { type: "string", enum: ["create", "update"] } },
+          },
+        }],
+      },
+      stream: true,
+      options: { reasoning: "high" },
+    });
+
+    const body = JSON.parse(req.body as string) as {
+      tools: Array<{ function: { parameters: Record<string, unknown> } }>;
+    };
+    const parameters = body.tools[0].function.parameters;
+
+    expect(parameters.type).toBe("object");
+    expect(parameters.oneOf).toBeUndefined();
+    expect(parameters.properties).toEqual({
+      mode: { $ref: "#/$defs/mode" },
+      id: { type: "string" },
+    });
+    expect(parameters.$defs).toEqual({
+      mode: { type: "string", enum: ["create", "update"] },
+    });
+  });
+
   test.each(["deepseek-v4-flash", "deepseek-v4-pro"])(
     "%s replays tool-call reasoning and maps Codex efforts",
     modelId => {


### PR DESCRIPTION
> **LLM-authored PR disclaimer:** This pull request was authored by OpenAI Codex at a human user's request. The bug, reproduction, fix, and regression coverage were derived from a real Codex Desktop failure and verified against that failing path.

## Core intent

Make OpenCode Go accept the same normalized function-tool schemas that OpenCode Zen already receives. Without this, a fresh Codex Desktop task can fail before the model produces any output when its tool catalog contains a root composition schema such as `codex_app__automation_update`.

## Root cause

`shouldSanitizeZenToolParameters` enabled the existing Zen schema normalizer only for the exact `https://opencode.ai/zen/v1` base URL. The OpenCode Go provider uses `https://opencode.ai/zen/go/v1`, so its tool schemas bypassed normalization.

Codex Desktop's automation tool includes a root `oneOf` plus `$defs`/`$ref`. Forwarding that schema unchanged to Console Go produced HTTP 400:

`Error from provider (Console Go): Upstream request failed`

## What changed

- Apply the existing Zen tool-schema normalizer to both `/zen/v1` and `/zen/go/v1`.
- Add a regression test using a Desktop-style root `oneOf` schema with `$defs`/`$ref`.

## Impact

Fresh Codex Desktop tasks using OpenCode Go models such as DeepSeek V4 Pro can start normally even when Codex exposes complex app-tool schemas. Other providers remain unchanged because the URL gate is still restricted to the two OpenCode Zen endpoints.

## Validation

- Exact 19-tool Desktop-derived upstream payload: HTTP 400 before the fix, HTTP 200 after normalization.
- Original failing Codex Desktop task: multiple consecutive HTTP 200 responses after applying the fix.
- `bun test tests/opencode-free-provider.test.ts tests/opencode-go-deepseek.test.ts` — 16 passed, 0 failed.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with OpenCode Zen’s Go endpoint by ensuring tool parameters are sanitized correctly.
  * Fixed handling of Desktop-style tool schemas for DeepSeek V4, preserving supported fields while normalizing the request format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->