### PR TITLE
ci: auto-close stale needs-info issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ on:
       - ".github/workflows/ci.yml"
       - ".github/workflows/release.yml"
       - ".github/workflows/enforce-pr-target.yml"
+      - ".github/workflows/stale-needs-info.yml"
   push:
     branches: [main, preview, dev]
     paths:
@@ -33,6 +34,7 @@ on:
       - ".github/workflows/ci.yml"
       - ".github/workflows/release.yml"
       - ".github/workflows/enforce-pr-target.yml"
+      - ".github/workflows/stale-needs-info.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/stale-needs-info.yml
+++ b/.github/workflows/stale-needs-info.yml
@@ -13,7 +13,6 @@ on:
   # default-branch review. Schedule-only keeps the trusted revision on main.
 
 permissions:
-  contents: read
   issues: write
   # actions/stale requires this even when PR processing is disabled below.
   pull-requests: write

--- a/.github/workflows/stale-needs-info.yml
+++ b/.github/workflows/stale-needs-info.yml
@@ -8,7 +8,9 @@ on:
   schedule:
     # Daily at 06:15 UTC (offset from the hour to reduce Action load spikes).
     - cron: "15 6 * * *"
-  workflow_dispatch:
+  # No workflow_dispatch: a branch-selected manual run would execute that
+  # branch's workflow body with issues:write / pull-requests:write, bypassing
+  # default-branch review. Schedule-only keeps the trusted revision on main.
 
 permissions:
   contents: read

--- a/.github/workflows/stale-needs-info.yml
+++ b/.github/workflows/stale-needs-info.yml
@@ -1,0 +1,54 @@
+name: Close stale needs-info issues
+
+# Scheduled workflows only run from the repository DEFAULT branch
+# (currently `main`), not from `dev`. Landing here on `dev` alone does not
+# change live issue-stale behavior until the change is also on that default
+# branch.
+on:
+  schedule:
+    # Daily at 06:15 UTC (offset from the hour to reduce Action load spikes).
+    - cron: "15 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  # actions/stale requires this even when PR processing is disabled below.
+  pull-requests: write
+
+concurrency:
+  group: stale-needs-info
+  cancel-in-progress: false
+
+jobs:
+  stale:
+    name: Stale needs-info issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark and close inactive needs-info issues
+        uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
+        with:
+          # Only issues maintainers labeled as waiting on the reporter.
+          only-issue-labels: needs-info
+          # Do not auto-stale pull requests.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          # Warn after 14 days of inactivity; close 7 days after the warning.
+          days-before-issue-stale: 14
+          days-before-issue-close: 7
+          stale-issue-label: stale
+          close-issue-reason: not_planned
+          # Any new comment/update removes the stale label and restarts the clock.
+          remove-stale-when-updated: true
+          # Skip long-lived tracker / roadmap items even if they also carry needs-info.
+          exempt-issue-labels: upstream-tracking,roadmap
+          ascending: true
+          operations-per-run: 60
+          stale-issue-message: |
+            This issue has the `needs-info` label and has had no activity for 14 days.
+
+            It will be closed in 7 days if there is still no reply with the requested details (reproduction steps, logs, or a concrete spec). A comment or edit resets this timer. Maintainers can remove `needs-info` once the report is actionable.
+          close-issue-message: |
+            Closing this issue because it stayed on `needs-info` with no further reply.
+
+            Please open a new issue (or comment here to reopen) when you can provide the missing reproduction details or specification. Thanks for the report.

--- a/.github/workflows/stale-needs-info.yml
+++ b/.github/workflows/stale-needs-info.yml
@@ -27,6 +27,48 @@ jobs:
     name: Stale needs-info issues
     runs-on: ubuntu-latest
     steps:
+      - name: Ensure stale label exists
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const name = "stale";
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name });
+              core.info(`Label "${name}" already exists.`);
+              return;
+            } catch (err) {
+              if (err.status !== 404) {
+                core.setFailed(`Failed to look up label "${name}": ${err.message || err}`);
+                return;
+              }
+            }
+            try {
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name,
+                color: "ffffff",
+                description: "No activity on a needs-info issue; will close soon unless updated",
+              });
+              core.info(`Created label "${name}".`);
+            } catch (err) {
+              // Concurrent scheduled runs may race on first create.
+              if (err.status === 422) {
+                try {
+                  await github.rest.issues.getLabel({ owner, repo, name });
+                  core.info(`Label "${name}" appeared concurrently; continuing.`);
+                  return;
+                } catch (lookupErr) {
+                  core.setFailed(
+                    `Failed to create label "${name}" (422) and re-check failed: ${lookupErr.message || lookupErr}`,
+                  );
+                  return;
+                }
+              }
+              core.setFailed(`Failed to create label "${name}": ${err.message || err}`);
+            }
+
       - name: Mark and close inactive needs-info issues
         uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
@@ -35,6 +77,8 @@ jobs:
           # Do not auto-stale pull requests.
           days-before-pr-stale: -1
           days-before-pr-close: -1
+          # -1 PR timers still allow unstaling existing PR labels; keep that off.
+          remove-pr-stale-when-updated: false
           # Warn after 14 days of inactivity; close 7 days after the warning.
           days-before-issue-stale: 14
           days-before-issue-close: 7

--- a/docs-site/src/content/docs/contributing.md
+++ b/docs-site/src/content/docs/contributing.md
@@ -71,6 +71,10 @@ GitHub Actions intentionally stay small:
 - **Release** (`.github/workflows/release.yml`) is manual. It does not act as a second full CI
   pipeline; before dry-run or publish it requires the exact release commit (`GITHUB_SHA`) to already
   have a successful Cross-platform CI run.
+- **Stale needs-info** (`.github/workflows/stale-needs-info.yml`) runs daily on the default branch.
+  Open issues labeled `needs-info` with no activity for 14 days get a warning; after 7 more idle
+  days they close as not planned. `upstream-tracking` and `roadmap` are exempt. Any update clears
+  the stale warning.
 
 Use the helper for releases:
 

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -113,6 +113,37 @@ describe("GitHub Actions hardening", () => {
     expect(workflow).toContain("bun run build");
   });
 
+  test("cross-platform CI path filters include the stale needs-info workflow", async () => {
+    const workflow = await readText(".github/workflows/ci.yml");
+    // pull_request + push allowlists must both list privileged workflow files.
+    expect(count(workflow, '".github/workflows/stale-needs-info.yml"')).toBe(2);
+  });
+
+  test("stale needs-info workflow is schedule-only and least-privilege", async () => {
+    const text = await readText(".github/workflows/stale-needs-info.yml");
+    const workflow = Bun.YAML.parse(text) as {
+      on?: Record<string, unknown>;
+      permissions?: Record<string, string>;
+      jobs?: Record<string, { steps?: Array<{ uses?: string; with?: Record<string, unknown> }> }>;
+    };
+
+    // Branch-selected workflow_dispatch would run an unreviewed YAML with write tokens.
+    expect(workflow.on).toBeDefined();
+    expect(Object.keys(workflow.on ?? {})).toEqual(["schedule"]);
+    expect(workflow.permissions).toEqual({
+      contents: "read",
+      issues: "write",
+      "pull-requests": "write",
+    });
+
+    const step = workflow.jobs?.stale?.steps?.[0];
+    expect(step?.uses).toBe("actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629");
+    expect(step?.with?.["only-issue-labels"]).toBe("needs-info");
+    expect(step?.with?.["days-before-pr-stale"]).toBe(-1);
+    expect(step?.with?.["days-before-pr-close"]).toBe(-1);
+    expect(text).not.toMatch(/uses:\s+\S+@(?:v\d+|main|master)\b/);
+  });
+
   test("service lifecycle is least-privilege, bounded, and cannot swallow health failures", async () => {
     const workflow = await readText(".github/workflows/service-lifecycle.yml");
 

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -86,6 +86,7 @@ describe("GitHub Actions hardening", () => {
       ".github/workflows/ci.yml",
       ".github/workflows/enforce-pr-target.yml",
       ".github/workflows/release.yml",
+      ".github/workflows/stale-needs-info.yml",
       ".npmignore",
       "bin/**",
       "bun.lock",

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -124,7 +124,13 @@ describe("GitHub Actions hardening", () => {
     const workflow = Bun.YAML.parse(text) as {
       on?: Record<string, unknown>;
       permissions?: Record<string, string>;
-      jobs?: Record<string, { steps?: Array<{ uses?: string; with?: Record<string, unknown> }> }>;
+      jobs?: Record<string, {
+        steps?: Array<{
+          name?: string;
+          uses?: string;
+          with?: Record<string, unknown>;
+        }>;
+      }>;
     };
 
     // Branch-selected workflow_dispatch would run an unreviewed YAML with write tokens.
@@ -136,11 +142,32 @@ describe("GitHub Actions hardening", () => {
       "pull-requests": "write",
     });
 
-    const step = workflow.jobs?.stale?.steps?.[0];
-    expect(step?.uses).toBe("actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629");
-    expect(step?.with?.["only-issue-labels"]).toBe("needs-info");
-    expect(step?.with?.["days-before-pr-stale"]).toBe(-1);
-    expect(step?.with?.["days-before-pr-close"]).toBe(-1);
+    const steps = workflow.jobs?.stale?.steps ?? [];
+    expect(steps).toHaveLength(2);
+
+    const ensureLabel = steps[0]!;
+    expect(ensureLabel.name).toBe("Ensure stale label exists");
+    expect(ensureLabel.uses).toBe(
+      "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
+    );
+    const ensureScript = String(ensureLabel.with?.script ?? "");
+    expect(ensureScript).toContain("createLabel");
+    expect(ensureScript).toContain('const name = "stale"');
+    expect(ensureScript).toContain("core.setFailed");
+    expect(ensureScript).toContain("getLabel");
+
+    const stale = steps[1]!;
+    expect(stale.name).toBe("Mark and close inactive needs-info issues");
+    expect(stale.uses).toBe("actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629");
+    expect(stale.with?.["only-issue-labels"]).toBe("needs-info");
+    expect(stale.with?.["days-before-pr-stale"]).toBe(-1);
+    expect(stale.with?.["days-before-pr-close"]).toBe(-1);
+    expect(stale.with?.["remove-pr-stale-when-updated"]).toBe(false);
+    expect(stale.with?.["days-before-issue-stale"]).toBe(14);
+    expect(stale.with?.["days-before-issue-close"]).toBe(7);
+    expect(stale.with?.["stale-issue-label"]).toBe("stale");
+    expect(stale.with?.["exempt-issue-labels"]).toBe("upstream-tracking,roadmap");
+    expect(stale.with?.["remove-stale-when-updated"]).toBe(true);
     expect(text).not.toMatch(/uses:\s+\S+@(?:v\d+|main|master)\b/);
   });
 

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -114,20 +114,6 @@ describe("GitHub Actions hardening", () => {
     expect(workflow).toContain("bun run build");
   });
 
-  test("cross-platform CI path filters include the stale needs-info workflow", async () => {
-    const workflow = Bun.YAML.parse(await readText(".github/workflows/ci.yml")) as {
-      on?: {
-        pull_request?: { paths?: string[] };
-        push?: { paths?: string[] };
-      };
-    };
-    const path = ".github/workflows/stale-needs-info.yml";
-    // Assert each trigger separately so a duplicated pull_request entry cannot
-    // satisfy a whole-file count while push is missing the path.
-    expect(workflow.on?.pull_request?.paths ?? []).toContain(path);
-    expect(workflow.on?.push?.paths ?? []).toContain(path);
-  });
-
   test("stale needs-info workflow is schedule-only and least-privilege", async () => {
     const text = await readText(".github/workflows/stale-needs-info.yml");
     const workflow = Bun.YAML.parse(text) as {

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -115,9 +115,17 @@ describe("GitHub Actions hardening", () => {
   });
 
   test("cross-platform CI path filters include the stale needs-info workflow", async () => {
-    const workflow = await readText(".github/workflows/ci.yml");
-    // pull_request + push allowlists must both list privileged workflow files.
-    expect(count(workflow, '".github/workflows/stale-needs-info.yml"')).toBe(2);
+    const workflow = Bun.YAML.parse(await readText(".github/workflows/ci.yml")) as {
+      on?: {
+        pull_request?: { paths?: string[] };
+        push?: { paths?: string[] };
+      };
+    };
+    const path = ".github/workflows/stale-needs-info.yml";
+    // Assert each trigger separately so a duplicated pull_request entry cannot
+    // satisfy a whole-file count while push is missing the path.
+    expect(workflow.on?.pull_request?.paths ?? []).toContain(path);
+    expect(workflow.on?.push?.paths ?? []).toContain(path);
   });
 
   test("stale needs-info workflow is schedule-only and least-privilege", async () => {
@@ -138,10 +146,10 @@ describe("GitHub Actions hardening", () => {
     expect(workflow.on).toBeDefined();
     expect(Object.keys(workflow.on ?? {})).toEqual(["schedule"]);
     expect(workflow.permissions).toEqual({
-      contents: "read",
       issues: "write",
       "pull-requests": "write",
     });
+    expect(workflow.permissions).not.toHaveProperty("contents");
 
     const steps = workflow.jobs?.stale?.steps ?? [];
     expect(steps).toHaveLength(2);


### PR DESCRIPTION
## Summary
- Add a daily `actions/stale` workflow that only targets open issues labeled `needs-info`.
- Warn after 14 days of inactivity, then close as `not_planned` after 7 more idle days; any update clears the warning and restarts the clock.
- Exempt `upstream-tracking` and `roadmap`; leave PRs alone. Document the behavior in the contributing guide.

## Test plan
- [ ] Confirm the workflow YAML validates in the Actions UI after merge (or via `workflow_dispatch` once it is on the default branch).
- [ ] Spot-check an existing `needs-info` issue: it should not be touched until 14 idle days, and a comment should remove `stale`.
- [ ] Confirm issues with `upstream-tracking` or `roadmap` are skipped even if they also have `needs-info`.
- [ ] Note: scheduled runs only execute from the repository default branch (`main`); landing on `dev` alone does not activate the cron until promotion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a daily scheduled automation for issues labeled `needs-info` to warn after 14 days and close after 7 additional idle days.
  * Updates clear the stale warning; `upstream-tracking` and `roadmap` are exempt.
* **Documentation**
  * Updated the contributing guide to include the new scheduled stale-issue workflow and its timing/behavior.
* **Chores**
  * Updated CI to run when the new workflow file changes.
  * Expanded CI workflow validation tests to enforce schedule-only behavior and pinned, least-privilege action usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->