### PR TITLE
feat(providers): add Zhipu AI GLM provider (open.bigmodel.cn)

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -785,6 +785,29 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     modelReasoningEfforts: Object.fromEntries(ZAI_GLM_52_MODELS.map(id => [id, ZAI_GLM_52_REASONING_EFFORTS])),
     preserveReasoningContentModels: ZAI_GLM_52_MODELS,
   },
+  // Zhipu AI (BigModel) — the domestic Chinese OpenAI-compatible endpoint. Same GLM family
+  // as `zai`, but the public pay-as-you-go host at open.bigmodel.cn instead of the z.ai
+  // coding-plan subscription. Live model discovery is enabled so newly published GLM ids
+  // surface automatically without a registry edit. Evidence: docs.bigmodel.cn/api-reference.
+  {
+    id: "glm",
+    label: "Zhipu AI — GLM",
+    baseUrl: "https://open.bigmodel.cn/api/paas/v4",
+    adapter: "openai-chat",
+    authKind: "key",
+    dashboardUrl: "https://bigmodel.cn/console/usercenter/apikeys",
+    defaultModel: "glm-4.6",
+    models: ["glm-4.6", "glm-4.5", "glm-4-plus", "glm-4-air", "glm-4-airx", "glm-4-flash", "glm-4-flashx", "glm-4-long", "glm-4v"],
+    liveModels: true,
+    // GLM-4.6 exposes a binary thinking toggle: `thinking: {type: "enabled" | "disabled"}`.
+    // Evidence: docs.bigmodel.cn/cn/guide/models/text/glm-4.6, docs.z.ai/guides/capabilities/thinking-mode.
+    // Reuses the shared THINKING_TOGGLE_EFFORTS / THINKING_TOGGLE_MAP constants.
+    thinkingToggleModels: ["glm-4.6"],
+    modelReasoningEfforts: { "glm-4.6": THINKING_TOGGLE_EFFORTS },
+    modelReasoningEffortMap: { "glm-4.6": THINKING_TOGGLE_MAP },
+    preserveReasoningContentModels: ["glm-4.6"],
+    note: "Zhipu AI / ChatGLM OpenAI-compatible endpoint (open.bigmodel.cn)",
+  },
   { id: "nanogpt", label: "NanoGPT", baseUrl: "https://nano-gpt.com/api/v1", adapter: "openai-chat", authKind: "key", dashboardUrl: "https://nano-gpt.com/api" },
   { id: "synthetic", label: "Synthetic", baseUrl: "https://api.synthetic.new/openai/v1", adapter: "openai-chat", authKind: "key", dashboardUrl: "https://synthetic.new" },
   // SiliconFlow publishes an OpenAI-compatible chat endpoint and a dynamic model catalog. Do not

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -32,7 +32,7 @@ function nativeTemplate(): Record<string, unknown> {
 const EXPECTED_KEY_PROVIDER_IDS = [
   "anthropic-apikey", "openai-apikey", "umans", "opencode-go", "neuralwatt", "openrouter", "orcarouter", "bizrouter", "groq", "google", "google-vertex", "azure-openai",
   "deepseek", "cerebras", "together", "fireworks", "firepass", "moonshot",
-  "huggingface", "nvidia", "venice", "zai", "nanogpt", "synthetic", "siliconflow", "qwen-cloud", "tencent-coding-plan",
+  "huggingface", "nvidia", "venice", "zai", "glm", "nanogpt", "synthetic", "siliconflow", "qwen-cloud", "tencent-coding-plan",
   "qianfan", "alibaba", "alibaba-token-plan", "alibaba-token-plan-intl", "parallel", "zenmux", "litellm", "ollama-cloud", "mistral",
   "minimax", "minimax-cn", "kimi-code", "opencode-zen", "vercel-ai-gateway",
   "opencode-free", "xiaomi", "kilo", "mimo-free", "cloudflare-ai-gateway", "cloudflare-workers-ai", "gitlab-duo",


### PR DESCRIPTION
## Summary

Adds **Zhipu AI — GLM** (`open.bigmodel.cn/api/paas/v4`) as a built-in key-auth provider, so OpenAI Codex CLI / Claude Code can route through GLM via opencodex.

This complements the existing `zai` entry, which targets the z.ai international coding-plan subscription. The new `glm` entry targets Zhipu's domestic OpenAI-compatible pay-as-you-go endpoint — same GLM model family, different host and billing.

## Changes

- `src/providers/registry.ts`: append a `glm` entry to `PROVIDER_REGISTRY` (after `zai`).
  - `baseUrl`: `https://open.bigmodel.cn/api/paas/v4`
  - `adapter`: `openai-chat`, `authKind: "key"` (Bearer JWT)
  - `defaultModel`: `glm-4.6`
  - `liveModels: true` so newly published GLM ids surface in the picker without a registry edit
  - `thinkingToggleModels: ["glm-4.6"]` + reuse of the shared `THINKING_TOGGLE_EFFORTS` / `THINKING_TOGGLE_MAP`, since GLM-4.6 exposes the binary `thinking: {type: "enabled" | "disabled"}` knob
- `tests/provider-registry-parity.test.ts`: append `"glm"` to `EXPECTED_KEY_PROVIDER_IDS` so the `key-login export is derived from the registry` parity test stays green.

No other surfaces need changes — CLI, GUI, docs-site provider pickers are all derived from `PROVIDER_REGISTRY`.

## Evidence

- BigModel chat completions (OpenAI-compatible): https://docs.bigmodel.cn/api-reference/%E6%A8%A1%E5%9E%8B-api/%E5%AF%B9%E8%AF%9D%E8%A1%A5%E5%85%A8
- GLM-4.6 thinking parameter (`thinking: {type: "enabled" | "disabled"}`): https://docs.bigmodel.cn/cn/guide/models/text/glm-4.6 and https://docs.z.ai/guides/capabilities/thinking-mode

## Test plan

- [ ] `bun test tests/provider-registry-parity.test.ts` — passes with `glm` in `EXPECTED_KEY_PROVIDER_IDS`
- [ ] `ocx provider add glm --api-key <zhipu-jwt>` registers the provider
- [ ] `ocx start` then selecting **Zhipu AI — GLM** in Codex CLI routes a chat completion to `https://open.bigmodel.cn/api/paas/v4/chat/completions` successfully
- [ ] With `reasoning_effort: "high"` selected in Codex, the upstream request body carries `thinking: {type: "enabled"}` and returns reasoning content

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Zhipu AI GLM provider.
  * Set GLM-4.6 as the default model, with live model discovery and configurable reasoning options.
  * Added support for the provider’s OpenAI-compatible endpoint and API key authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->