### PR TITLE
ci: close stale needs-info even with roadmap labels

### DIFF
--- a/.github/workflows/stale-needs-info.yml
+++ b/.github/workflows/stale-needs-info.yml
@@ -85,14 +85,12 @@ jobs:
           close-issue-reason: not_planned
           # Any new comment/update removes the stale label and restarts the clock.
           remove-stale-when-updated: true
-          # Skip long-lived tracker / roadmap items even if they also carry needs-info.
-          exempt-issue-labels: upstream-tracking,roadmap
           ascending: true
           operations-per-run: 60
           stale-issue-message: |
             This issue has the `needs-info` label and has had no activity for 14 days.
 
-            It will be closed in 7 days if there is still no reply with the requested details (reproduction steps, logs, or a concrete spec). A comment or edit resets this timer. Maintainers can remove `needs-info` once the report is actionable.
+            It will be closed in 7 days if there is still no reply with the requested details (reproduction steps, logs, or a concrete spec). A comment or edit resets this timer. Maintainers can remove `needs-info` once the report is actionable — for example when promoting it to `roadmap`.
           close-issue-message: |
             Closing this issue because it stayed on `needs-info` with no further reply.
 

--- a/docs-site/src/content/docs/contributing.md
+++ b/docs-site/src/content/docs/contributing.md
@@ -73,8 +73,8 @@ GitHub Actions intentionally stay small:
   have a successful Cross-platform CI run.
 - **Stale needs-info** (`.github/workflows/stale-needs-info.yml`) runs daily on the default branch.
   Open issues labeled `needs-info` with no activity for 14 days get a warning; after 7 more idle
-  days they close as not planned. `upstream-tracking` and `roadmap` are exempt. Any update clears
-  the stale warning.
+  days they close as not planned. Any update clears the stale warning. To keep long-lived work open,
+  remove `needs-info` (for example when promoting an issue to `roadmap`).
 
 Use the helper for releases:
 

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -161,7 +161,7 @@ describe("GitHub Actions hardening", () => {
     expect(stale.with?.["days-before-issue-stale"]).toBe(14);
     expect(stale.with?.["days-before-issue-close"]).toBe(7);
     expect(stale.with?.["stale-issue-label"]).toBe("stale");
-    expect(stale.with?.["exempt-issue-labels"]).toBe("upstream-tracking,roadmap");
+    expect(stale.with?.["exempt-issue-labels"]).toBeUndefined();
     expect(stale.with?.["remove-stale-when-updated"]).toBe(true);
     expect(text).not.toMatch(/uses:\s+\S+@(?:v\d+|main|master)\b/);
   });


### PR DESCRIPTION
## Summary
- Remove `roadmap` / `upstream-tracking` exemptions from the needs-info stale workflow so silence still closes those issues.
- Document that long-lived work should drop `needs-info` (e.g. when promoting to `roadmap`).
- Update the workflow regression test to assert no label exemptions.

## Test plan
- [ ] Confirm `.github/workflows/stale-needs-info.yml` has no `exempt-issue-labels`.
- [ ] Confirm contributing docs no longer claim roadmap/upstream-tracking are exempt.
- [ ] `bun test --isolate tests/ci-workflows.test.ts -t "stale needs-info"` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated stale issue handling so all issues marked `needs-info` can be processed, including those also labeled `upstream-tracking` or `roadmap`.

* **Documentation**
  * Clarified guidance for removing the `needs-info` label when an issue progresses, such as being promoted to the roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->