### PR TITLE
fix(claude): resolve Desktop 3P paths by target platform

### DIFF
--- a/src/claude/desktop-3p-paths.ts
+++ b/src/claude/desktop-3p-paths.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { posix, win32 } from "node:path";
 
 /**
  * Claude Desktop's own configLibrary location, ported from the shipped app bundle.
@@ -27,6 +27,10 @@ import { join } from "node:path";
 const SUFFIX = "-3p";
 const APP_DIR = `Claude${SUFFIX}`;
 
+function joinForPlatform(platform: NodeJS.Platform, ...parts: string[]): string {
+  return platform === "win32" ? win32.join(...parts) : posix.join(...parts);
+}
+
 export interface DesktopPathInputs {
   env: Record<string, string | undefined>;
   platform: NodeJS.Platform;
@@ -38,11 +42,11 @@ export function resolveElectronUserData(inputs: DesktopPathInputs): string {
   const { env, platform, home } = inputs;
   if (platform === "win32") {
     const appData = env.APPDATA?.trim();
-    return appData ? join(appData, "Claude") : join(home, "AppData", "Roaming", "Claude");
+    return appData ? win32.join(appData, "Claude") : win32.join(home, "AppData", "Roaming", "Claude");
   }
-  if (platform === "darwin") return join(home, "Library", "Application Support", "Claude");
+  if (platform === "darwin") return posix.join(home, "Library", "Application Support", "Claude");
   const xdg = env.XDG_CONFIG_HOME?.trim();
-  return xdg ? join(xdg, "Claude") : join(home, ".config", "Claude");
+  return xdg ? posix.join(xdg, "Claude") : posix.join(home, ".config", "Claude");
 }
 
 /** Desktop's userData root, mirroring `GE()` branch for branch. */
@@ -54,7 +58,7 @@ export function resolveUserDataDir(inputs: DesktopPathInputs): string {
 
   if (inputs.platform === "win32") {
     const localAppData = inputs.env.LOCALAPPDATA?.trim();
-    if (localAppData) return join(localAppData, APP_DIR);
+    if (localAppData) return win32.join(localAppData, APP_DIR);
   }
 
   const root = resolveElectronUserData(inputs);
@@ -71,7 +75,7 @@ export function resolveUserDataDir(inputs: DesktopPathInputs): string {
 export function resolveConfigLibraryDir(inputs: DesktopPathInputs): string {
   const override = inputs.env.OPENCODEX_CLAUDE_DESKTOP_CONFIG_DIR?.trim();
   if (override) return override;
-  return join(resolveUserDataDir(inputs), "configLibrary");
+  return joinForPlatform(inputs.platform, resolveUserDataDir(inputs), "configLibrary");
 }
 
 /** Runtime wrapper. Keep it thin: all branching lives in the pure functions above. */

--- a/tests/claude-desktop-config-path.test.ts
+++ b/tests/claude-desktop-config-path.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, describe } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, posix, win32 } from "node:path";
 import { startServer } from "../src/server";
 import {
   claudeDesktopConfigLibraryDir,
@@ -30,13 +30,13 @@ describe("Claude Desktop configLibrary resolution", () => {
       platform: "darwin",
       home: HOME,
     });
-    expect(dir).toBe(join("/custom/user-data", "configLibrary"));
+    expect(dir).toBe(posix.join("/custom/user-data", "configLibrary"));
     expect(dir).not.toContain("-3p");
   });
 
   test("the macOS default stays Claude-3p (regression guard for existing users)", () => {
     const dir = resolveConfigLibraryDir({ env: {}, platform: "darwin", home: HOME });
-    expect(dir).toBe(join(HOME, "Library", "Application Support", "Claude-3p", "configLibrary"));
+    expect(dir).toBe(posix.join(HOME, "Library", "Application Support", "Claude-3p", "configLibrary"));
   });
 
   test("win32 with LOCALAPPDATA resolves under LOCALAPPDATA, not the macOS tree", () => {
@@ -44,7 +44,7 @@ describe("Claude Desktop configLibrary resolution", () => {
     const win = resolveConfigLibraryDir({ env, platform: "win32", home: HOME });
     const mac = resolveConfigLibraryDir({ env, platform: "darwin", home: HOME });
 
-    expect(win).toBe(join("C:\\Users\\tester\\AppData\\Local", "Claude-3p", "configLibrary"));
+    expect(win).toBe(win32.join("C:\\Users\\tester\\AppData\\Local", "Claude-3p", "configLibrary"));
     // The defect was returning the macOS path on Windows: prove the branch diverges.
     expect(win).not.toBe(mac);
     expect(win).not.toContain("Application Support");
@@ -56,14 +56,14 @@ describe("Claude Desktop configLibrary resolution", () => {
       platform: "win32",
       home: HOME,
     });
-    expect(dir).toBe(`${join("C:\\Users\\tester\\AppData\\Roaming", "Claude")}-3p`);
+    expect(dir).toBe(`${win32.join("C:\\Users\\tester\\AppData\\Roaming", "Claude")}-3p`);
   });
 
   test("linux uses XDG_CONFIG_HOME when set, otherwise ~/.config", () => {
     expect(resolveElectronUserData({ env: { XDG_CONFIG_HOME: "/xdg" }, platform: "linux", home: HOME }))
-      .toBe(join("/xdg", "Claude"));
+      .toBe(posix.join("/xdg", "Claude"));
     expect(resolveConfigLibraryDir({ env: {}, platform: "linux", home: HOME }))
-      .toBe(join(HOME, ".config", "Claude-3p", "configLibrary"));
+      .toBe(posix.join(HOME, ".config", "Claude-3p", "configLibrary"));
   });
 
   test("a userData root already ending in -3p is not double-suffixed", () => {

--- a/tests/desktop-3p.test.ts
+++ b/tests/desktop-3p.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, spyOn, test } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, posix, win32 } from "node:path";
 import {
   atomicReplaceDesktopConfig,
   buildDesktop3pRegistry,
@@ -32,19 +32,19 @@ describe("Claude Desktop 3P models", () => {
       env: { CLAUDE_USER_DATA_DIR: "/profiles/claude" },
       platform: "darwin",
       homeDir: "/Users/test",
-    })).toBe("/profiles/claude/configLibrary");
+    })).toBe(posix.join("/profiles/claude", "configLibrary"));
     expect(resolveDesktop3pConfigLibraryPath({
       env: {},
       platform: "darwin",
       homeDir: "/Users/test",
     })).toBe("/Users/test/Library/Application Support/Claude-3p/configLibrary");
     // Windows reads LOCALAPPDATA first; APPDATA is only the Electron userData fallback.
-    // Asserted with `join` because the separator follows the HOST, not the target platform.
+    // Asserted with `win32.join` because the separator follows the target platform, not the host.
     expect(resolveDesktop3pConfigLibraryPath({
       env: { LOCALAPPDATA: "C:\\Users\\test\\AppData\\Local" },
       platform: "win32",
       homeDir: "C:\\Users\\test",
-    })).toBe(join("C:\\Users\\test\\AppData\\Local", "Claude-3p", "configLibrary"));
+    })).toBe(win32.join("C:\\Users\\test\\AppData\\Local", "Claude-3p", "configLibrary"));
     expect(resolveDesktop3pConfigLibraryPath({
       env: { XDG_CONFIG_HOME: "/xdg/config" },
       platform: "linux",


### PR DESCRIPTION
## Summary
- resolve Claude Desktop 3P config-library paths with target-platform separators instead of the CI host separator
- preserve OPENCODEX_CLAUDE_DESKTOP_CONFIG_DIR trim-then-verbatim override semantics
- update Desktop 3P regression tests to assert POSIX vs win32 expectations explicitly

## Verification
- bun test tests/desktop-3p.test.ts tests/claude-desktop-config-path.test.ts — 30 pass, 0 fail
- bun x tsc --noEmit
- git diff --check origin/dev
- pre-push: bun run typecheck && bun run lint:gui && bun run test && bun run privacy:scan && bun run doctor:gui:if-changed — 5047 pass, 0 fail, privacy scan passed, GUI doctor skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop configuration path handling across Windows, macOS, and Linux.
  * Ensured platform-appropriate path separators are used when resolving configuration directories.

* **Tests**
  * Updated configuration path coverage to validate platform-specific behavior, including Windows fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->