### PR TITLE
fix(bridge): CodeRabbit follow-ups for phase omit and content_filter

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -515,7 +515,11 @@ export function bridgeToResponsesSSE(
               if (currentRawReasoning) closeCurrentRawReasoning();
               flushHiddenRawReasoning();
               if (currentToolCall) closeCurrentToolCall();
-              if (currentMsg && currentMsg.phase !== event.phase) closeCurrentMessage("commentary");
+              // Only flush on an explicit phase change. A later delta that omits `phase` must
+              // keep appending to the current message rather than wiping the earlier phase.
+              if (currentMsg && event.phase !== undefined && currentMsg.phase !== event.phase) {
+                closeCurrentMessage("commentary");
+              }
               if (!currentMsg) {
                 const itemId = `msg_${uuid()}`;
                 const item = {
@@ -1048,7 +1052,9 @@ export function buildResponseJSON(
         flushToolCall();
         break;
       case "text_delta":
-        if (currentText && currentTextPhase !== e.phase) flushText("commentary");
+        // Only flush on an explicit phase change. A later delta that omits `phase` must keep
+        // appending under the previously established phase.
+        if (currentText && e.phase !== undefined && currentTextPhase !== e.phase) flushText("commentary");
         if (currentSummaryReasoning) flushSummaryReasoning();
         if (currentRawReasoning) flushRawReasoning();
         if (currentToolCallId) flushToolCall();
@@ -1056,7 +1062,7 @@ export function buildResponseJSON(
         // bridgeToResponsesSSE); it ships only inside the synthetic compaction item below.
         if (options?.compaction) compactionText += e.text;
         else {
-          currentTextPhase = e.phase;
+          if (e.phase !== undefined) currentTextPhase = e.phase;
           currentText += e.text;
         }
         break;
@@ -1131,7 +1137,8 @@ export function buildResponseJSON(
         endTurn = e.endTurn;
         cleanDone = e.stopReason === undefined;
         if (e.providerState) options?.onProviderState?.(e.providerState);
-        if (e.stopReason === "max_tokens") stopReason = "max_tokens";
+        // Match streaming: max_tokens and content_filter both terminate as incomplete.
+        if (e.stopReason === "max_tokens" || e.stopReason === "content_filter") stopReason = e.stopReason;
         break;
     }
   }
@@ -1141,14 +1148,20 @@ export function buildResponseJSON(
   flushToolCall();
   // A truncated turn must never be installed as replacement history: emit the
   // compaction item only when the turn actually completed (#422).
-  if (options?.compaction && !errorEvent && !incompleteEvent && stopReason !== "max_tokens") {
+  if (
+    options?.compaction
+    && !errorEvent
+    && !incompleteEvent
+    && stopReason !== "max_tokens"
+    && stopReason !== "content_filter"
+  ) {
     output.push({ type: "compaction", id: `cmp_${uuid()}`, encrypted_content: encodeCompactionSummary(compactionText) });
   }
 
   const failure = errorEvent ? adapterFailureFromEvent(errorEvent) : undefined;
   const status = errorEvent
     ? "failed"
-    : incompleteEvent || stopReason === "max_tokens"
+    : incompleteEvent || stopReason === "max_tokens" || stopReason === "content_filter"
       ? "incomplete"
       : "completed";
   options?.onUsage?.(incompleteEvent?.usage ?? usage);
@@ -1168,6 +1181,8 @@ export function buildResponseJSON(
       },
     } : stopReason === "max_tokens" ? {
       incomplete_details: { reason: "max_output_tokens" },
+    } : stopReason === "content_filter" ? {
+      incomplete_details: { reason: "content_filter" },
     } : {}),
     usage: responsesUsage(incompleteEvent?.usage ?? usage),
   };

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -133,8 +133,18 @@ export function bridgeToResponsesSSE(
      * from this callback instead of re-parsing the bridged SSE.
      */
     onUsage?: (usage: OcxUsage | undefined) => void;
+    /**
+     * Test seam for the wire/stall beat loop. Production omits this and uses the
+     * global timers; injecting here must not change scheduling semantics.
+     */
+    timers?: {
+      setInterval: (handler: () => void, ms: number) => unknown;
+      clearInterval: (id: unknown) => void;
+    };
   },
 ): ReadableStream<Uint8Array> {
+  const setBeatInterval = options?.timers?.setInterval ?? ((handler: () => void, ms: number) => setInterval(handler, ms));
+  const clearBeatInterval = options?.timers?.clearInterval ?? ((id: unknown) => clearInterval(id as ReturnType<typeof setInterval>));
   // Freeform/custom tools (apply_patch) carry their body in `input`; the model is given a
   // function with `{input:string}`, so unwrap it here when relaying back as a custom_tool_call.
   const freeformInput = (args: string): string => {
@@ -194,7 +204,7 @@ export function bridgeToResponsesSSE(
   // buffering + raw-byte progress). Upstream activity only resets the stall watchdog.
   let upstreamActivity = false;
   let wireActivity = false;
-  let beat: ReturnType<typeof setInterval> | undefined;
+  let beat: unknown;
   let controller: ReadableStreamDefaultController<Uint8Array>;
   let emittedFrames = 0;
   let gated = false;
@@ -813,7 +823,7 @@ export function bridgeToResponsesSSE(
         stepping = false;
         return;
       }
-      if (beat) { clearInterval(beat); beat = undefined; }
+      if (beat !== undefined) { clearBeatInterval(beat); beat = undefined; }
 
       if (!terminated) {
         // The adapter generator ended without an explicit done/error event. Mark as incomplete
@@ -852,7 +862,7 @@ export function bridgeToResponsesSSE(
         // The default ReadableStream strategy has HWM=1. Once one event's frames fill that
         // queue, pull stepping pauses; no custom FIFO or queuing strategy is layered on top.
         gated = true;
-        beat = setInterval(() => {
+        beat = setBeatInterval(() => {
           if (closed || gated) return;
           if (upstreamActivity) {
             upstreamActivity = false;
@@ -875,7 +885,7 @@ export function bridgeToResponsesSSE(
             terminated = true;
             returnIterator();
             emitDone();
-            if (beat) clearInterval(beat);
+            if (beat !== undefined) clearBeatInterval(beat);
             beat = undefined;
             try { controller.close(); } catch { /* already closed */ }
             closed = true;
@@ -906,14 +916,14 @@ export function bridgeToResponsesSSE(
     cancel() {
       // Client (Codex) disconnected. Stop emitting and let the caller abort the upstream fetch so a
       // cancelled turn does not leak the upstream stream or keep draining tokens (RC2).
-      clientCancelled = true;
-      closed = true;
-      if (beat) clearInterval(beat);
-      onCancel?.();
-      returnIterator();
-    },
-  });
-}
+        clientCancelled = true;
+        closed = true;
+        if (beat !== undefined) clearBeatInterval(beat);
+        onCancel?.();
+        returnIterator();
+      },
+    });
+  }
 
 export function buildResponseJSON(
   events: AdapterEvent[],

--- a/tests/bridge.test.ts
+++ b/tests/bridge.test.ts
@@ -529,6 +529,34 @@ describe("Responses bridge reasoning and usage parity", () => {
     expect((explicit.output as Record<string, unknown>[])[0]).toMatchObject({ phase: "commentary" });
   });
 
+  test("later text_delta omitting phase keeps the prior explicit phase", async () => {
+    const frames = await collectSse(bridgeToResponsesSSE(replay([
+      { type: "text_delta", text: "Hello ", phase: "final_answer" },
+      { type: "text_delta", text: "world." },
+      { type: "done" },
+    ]), "routed/chat-model"));
+    const completed = frames.find(frame => frame.event === "response.completed")?.data.response as Record<string, unknown>;
+    const output = completed.output as Record<string, unknown>[];
+    expect(output).toHaveLength(1);
+    expect(output[0]).toMatchObject({
+      type: "message",
+      phase: "final_answer",
+      content: [{ type: "output_text", text: "Hello world." }],
+    });
+
+    const batch = buildResponseJSON([
+      { type: "text_delta", text: "Hello ", phase: "final_answer" },
+      { type: "text_delta", text: "world." },
+      { type: "done" },
+    ], "routed/chat-model");
+    expect((batch.output as Record<string, unknown>[])).toHaveLength(1);
+    expect((batch.output as Record<string, unknown>[])[0]).toMatchObject({
+      type: "message",
+      phase: "final_answer",
+      content: [{ type: "output_text", text: "Hello world." }],
+    });
+  });
+
   test("structured adapter errors override message heuristics", () => {
     const json = buildResponseJSON([
       {
@@ -700,8 +728,8 @@ describe("Responses bridge reasoning and usage parity", () => {
     ));
     expect(frames.some(f => (f.data.response as Record<string, unknown> | undefined)?.incomplete_details)).toBe(false);
     expect(frames.some(f => f.event === "response.completed")).toBe(true);
-    // Adapter heartbeats must not be mis-translated into a rich protocol event of their own.
-    expect(frames.some(f => f.event === "response.heartbeat" && f.data.type === "heartbeat" && Object.keys(f.data).length > 2)).toBe(false);
+    // Adapter heartbeats must not be mis-translated into a protocol event of their own.
+    expect(frames.some(f => f.data.type === "heartbeat")).toBe(false);
   });
 
   test("wire response.heartbeat keeps firing while only adapter heartbeats flow", async () => {
@@ -870,6 +898,15 @@ describe("Responses bridge stopReason threading (issue #246)", () => {
     ], "routed/model");
     expect(json.status).toBe("incomplete");
     expect(json.incomplete_details).toEqual({ reason: "max_output_tokens" });
+  });
+
+  test("batch buildResponseJSON with stopReason content_filter returns incomplete status", () => {
+    const json = buildResponseJSON([
+      { type: "text_delta", text: "partial" },
+      { type: "done", stopReason: "content_filter" },
+    ], "routed/model");
+    expect(json.status).toBe("incomplete");
+    expect(json.incomplete_details).toEqual({ reason: "content_filter" });
   });
 
   test("batch buildResponseJSON without stopReason returns completed status", () => {

--- a/tests/bridge.test.ts
+++ b/tests/bridge.test.ts
@@ -904,9 +904,10 @@ describe("Responses bridge stopReason threading (issue #246)", () => {
     const json = buildResponseJSON([
       { type: "text_delta", text: "partial" },
       { type: "done", stopReason: "content_filter" },
-    ], "routed/model");
+    ], "routed/model", { compaction: true });
     expect(json.status).toBe("incomplete");
     expect(json.incomplete_details).toEqual({ reason: "content_filter" });
+    expect((json.output as Record<string, unknown>[]).some(item => item.type === "compaction")).toBe(false);
   });
 
   test("batch buildResponseJSON without stopReason returns completed status", () => {

--- a/tests/bridge.test.ts
+++ b/tests/bridge.test.ts
@@ -712,21 +712,74 @@ describe("Responses bridge reasoning and usage parity", () => {
     // calls, the adapter emits `heartbeat` events. They must keep the stall watchdog alive (no
     // upstream_stall_timeout). Adapter heartbeats themselves are not translated into Responses
     // protocol items; wire keepalives use a separate `response.heartbeat` frame (see next test).
+    //
+    // resolveStallTimeoutSec ceils to a minimum of 1s, so sub-second stallTimeoutSec values cannot
+    // prove the reset. Drive the beat loop through a test clock seam and run adapter-only progress
+    // past the effective deadline.
+    const heartbeatMs = 50;
+    const stallTimeoutSec = 1; // effective after resolveStallTimeoutSec
+    const maxStallTicks = Math.ceil((stallTimeoutSec * 1000) / heartbeatMs);
+    const cycles = maxStallTicks + 5; // wall-clock equivalent >> stall deadline
+
+    let beatTick: (() => void) | undefined;
+    const timers = {
+      setInterval(handler: () => void, _ms: number) {
+        beatTick = handler;
+        return 1;
+      },
+      clearInterval(_id: unknown) {
+        beatTick = undefined;
+      },
+    };
+
+    let waitResolve: (() => void) | undefined;
+    const waitDelay = () => new Promise<void>(resolve => { waitResolve = resolve; });
+    const releaseDelay = () => {
+      const resolve = waitResolve;
+      waitResolve = undefined;
+      resolve?.();
+    };
+    const flush = async () => {
+      for (let i = 0; i < 20; i++) await Promise.resolve();
+    };
+
     async function* heartbeatsThenDone(): AsyncGenerator<AdapterEvent> {
-      // More heartbeats than maxStallTicks would allow if they did NOT reset the counter.
-      for (let i = 0; i < 6; i++) {
+      for (let i = 0; i < cycles; i++) {
         yield { type: "heartbeat" };
-        await new Promise(r => setTimeout(r, 12));
+        await waitDelay();
       }
       yield { type: "text_delta", text: "ok" };
       yield { type: "done" };
     }
-    // heartbeatMs=10ms, stallTimeoutSec=0.03s -> maxStallTicks=3. 6 spaced heartbeats only survive
-    // if each one resets stallTicks.
-    const frames = await collectSse(bridgeToResponsesSSE(
-      heartbeatsThenDone(), "model", undefined, undefined, undefined, undefined, 10, { stallTimeoutSec: 0.03 },
+
+    const framesPromise = collectSse(bridgeToResponsesSSE(
+      heartbeatsThenDone(),
+      "model",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      heartbeatMs,
+      { stallTimeoutSec, timers },
     ));
-    expect(frames.some(f => (f.data.response as Record<string, unknown> | undefined)?.incomplete_details)).toBe(false);
+
+    // First heartbeat is pulled; step blocks on the delay gate with gated=false.
+    await flush();
+    for (let i = 0; i < cycles; i++) {
+      // maxStallTicks silent ticks would trip the watchdog if the preceding heartbeat did not
+      // count as upstream activity (first tick clears the flag; the rest must not reach the limit).
+      // Heartbeats between cycles reset the counter, so the stream must survive the full run.
+      for (let t = 0; t < maxStallTicks; t++) beatTick?.();
+      releaseDelay();
+      await flush();
+    }
+
+    const frames = await framesPromise;
+    expect(frames.some(f => {
+      const response = f.data.response as Record<string, unknown> | undefined;
+      const details = response?.incomplete_details as Record<string, unknown> | undefined;
+      return details?.reason === "upstream_stall_timeout";
+    })).toBe(false);
     expect(frames.some(f => f.event === "response.completed")).toBe(true);
     // Adapter heartbeats must not be mis-translated into a protocol event of their own.
     expect(frames.some(f => f.data.type === "heartbeat")).toBe(false);
@@ -736,20 +789,69 @@ describe("Responses bridge reasoning and usage parity", () => {
     // Issue #521: web-search buffers semantic events and yields invisible adapter heartbeats from
     // raw-byte progress. Those must not suppress wire keepalives, or Codex Desktop idle-timeouts
     // (~5 min) while OCX still considers the upstream alive.
+    const heartbeatMs = 50;
+    const stallTimeoutSec = 1;
+    const cycles = 4;
+
+    let beatTick: (() => void) | undefined;
+    const timers = {
+      setInterval(handler: () => void, _ms: number) {
+        beatTick = handler;
+        return 1;
+      },
+      clearInterval(_id: unknown) {
+        beatTick = undefined;
+      },
+    };
+
+    let waitResolve: (() => void) | undefined;
+    const waitDelay = () => new Promise<void>(resolve => { waitResolve = resolve; });
+    const releaseDelay = () => {
+      const resolve = waitResolve;
+      waitResolve = undefined;
+      resolve?.();
+    };
+    const flush = async () => {
+      for (let i = 0; i < 20; i++) await Promise.resolve();
+    };
+
     async function* adapterHeartbeatsOnly(): AsyncGenerator<AdapterEvent> {
-      for (let i = 0; i < 8; i++) {
+      for (let i = 0; i < cycles; i++) {
         yield { type: "heartbeat" };
-        await new Promise(r => setTimeout(r, 15));
+        await waitDelay();
       }
       yield { type: "text_delta", text: "ok" };
       yield { type: "done" };
     }
-    const frames = await collectSse(bridgeToResponsesSSE(
-      adapterHeartbeatsOnly(), "model", undefined, undefined, undefined, undefined, 10, { stallTimeoutSec: 1 },
+
+    const framesPromise = collectSse(bridgeToResponsesSSE(
+      adapterHeartbeatsOnly(),
+      "model",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      heartbeatMs,
+      { stallTimeoutSec, timers },
     ));
-    expect(frames.some(f => f.event === "response.heartbeat" && f.data.type === "response.heartbeat")).toBe(true);
+
+    await flush();
+    for (let i = 0; i < cycles; i++) {
+      // Several silent beat ticks per adapter-only gap → multiple wire keepalives.
+      for (let t = 0; t < 3; t++) beatTick?.();
+      releaseDelay();
+      await flush();
+    }
+
+    const frames = await framesPromise;
+    const wireHeartbeats = frames.filter(f =>
+      f.event === "response.heartbeat" && f.data.type === "response.heartbeat"
+    );
+    expect(wireHeartbeats.length).toBeGreaterThan(1);
     expect(frames.some(f => f.event === "response.completed")).toBe(true);
     expect(frames.some(f => (f.data.response as Record<string, unknown> | undefined)?.incomplete_details)).toBe(false);
+    // Reject every adapter-shaped heartbeat payload, regardless of event name or field count.
+    expect(frames.some(f => f.data.type === "heartbeat")).toBe(false);
   });
 });
 
@@ -907,6 +1009,7 @@ describe("Responses bridge stopReason threading (issue #246)", () => {
     ], "routed/model", { compaction: true });
     expect(json.status).toBe("incomplete");
     expect(json.incomplete_details).toEqual({ reason: "content_filter" });
+    // Truncated turns must not install a compaction replacement (#422).
     expect((json.output as Record<string, unknown>[]).some(item => item.type === "compaction")).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
- Tighten the adapter-heartbeat regression to reject any SSE frame with `data.type === ""heartbeat""`.
- Preserve an explicit message phase when a later `text_delta` omits `phase` (streaming and `buildResponseJSON`); flush only on an explicit phase change.
- Make batch `content_filter` stop reasons match streaming: incomplete status, `incomplete_details`, and compaction exclusion, with a regression test.

Follow-up to #555 CodeRabbit review comments (that PR is already merged).

## Test plan
- [x] `bun test --isolate tests/bridge.test.ts tests/bridge-lifecycle.test.ts`
- [x] `bun run typecheck`
- [ ] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve assistant message phases when later `text_delta` events omit phase details.
  * Treat `content_filter` results as incomplete, including `incomplete_details.reason: "content_filter"`.
  * Suppress compaction output for `content_filter` (and other incomplete scenarios).
  * Prevent internal heartbeat signals from being emitted as protocol frames.
* **Tests**
  * Added phase-propagation coverage for both streaming and batch response outputs.
  * Strengthened the stall-timeout/heartbeat regression using a controllable timer seam.
  * Added batch tests validating incomplete status for `content_filter`, with compaction disabled in that case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->