### PR TITLE
fix(ci): soft-pass detailed issues after maintainer retitle

### DIFF
--- a/.github/scripts/issue-quality.cjs
+++ b/.github/scripts/issue-quality.cjs
@@ -150,10 +150,11 @@ function resolveSection(body, headings) {
 }
 
 /**
- * True when the body has at least one non-empty h2–h4 section with enough
- * detail. Used for soft-pass only — unstructured length alone is not enough.
+ * True when the body has multiple non-empty h2–h4 sections with enough detail.
+ * Soft-pass only — unstructured length alone is not enough, and a single
+ * arbitrary heading must not bypass the quality gate (Codex on #564).
  */
-function hasSubstantialStructuredContent(body, minSectionLen = 40) {
+function hasSubstantialStructuredContent(body, minSectionLen = 40, minRichSections = 2) {
   if (typeof body !== "string") return false;
   const lines = body.split("\n");
   let capturing = false;
@@ -173,7 +174,7 @@ function hasSubstantialStructuredContent(body, minSectionLen = 40) {
     if (capturing) bucket.push(line);
   }
   if (capturing) flush();
-  return richSections >= 1;
+  return richSections >= minRichSections;
 }
 
 // ---------------------------------------------------------------------------
@@ -695,7 +696,8 @@ function validateIssue(issue) {
       // Same soft-pass as bug/feature: label- or maintainer-scoped provider
       // reports often use non-English structured headings after a retitle.
       const mappedHeadingPresent =
-        current !== null || expected !== null || repro !== null || response !== null || docs !== null;
+        current !== null || expected !== null || repro !== null || response !== null || docs !== null ||
+        provider !== null || version !== null || endpoint !== null;
       const canSoftPass =
         !mappedHeadingPresent &&
         hasSubstantialStructuredContent(body);

--- a/.github/scripts/issue-quality.cjs
+++ b/.github/scripts/issue-quality.cjs
@@ -541,7 +541,6 @@ function validateIssue(issue) {
   const reasons = [];
   const guidance = [];
   let softPass = false;
-  const titleLower = title.toLowerCase();
 
   if (!kind) {
     const failure = untemplatedIssueFailure(issue);
@@ -578,9 +577,11 @@ function validateIssue(issue) {
       goal !== null || blocker !== null || behaviour !== null || example !== null;
 
     if (emptyCore.length > 0) {
+      // Soft-pass rich non-template bodies once kind is already feature (title
+      // prefix, enhancement label, or stored kind). Do not require the title to
+      // keep a `[Feature]:` prefix — maintainer retitles must not re-arm closure.
       const canSoftPass =
         !mappedHeadingPresent &&
-        titleLower.startsWith("[feature]:") &&
         hasSubstantialStructuredContent(body);
       if (canSoftPass) {
         softPass = true;
@@ -625,10 +626,14 @@ function validateIssue(issue) {
     const os = extractSection(body, "Operating system") ?? extractSection(body, "OS");
 
     if (isEmpty(summary) && isEmpty(repro)) {
+      // Soft-pass substantial non-English / freeform structured reports once
+      // kind is already bug (label, stored kind, or prior `[Bug]:` detection).
+      // Requiring the title to keep a `[Bug]:` prefix caused #545: a maintainer
+      // retitle of an already detailed report was treated as empty Summary/
+      // Reproduction and auto-closed.
       const canSoftPass =
         summary === null &&
         repro === null &&
-        titleLower.startsWith("[bug]:") &&
         hasSubstantialStructuredContent(body);
       if (canSoftPass) {
         softPass = true;
@@ -687,27 +692,38 @@ function validateIssue(issue) {
     if (version !== null && isRawPlaceholder(version) === false && isEmpty(version)) emptyCore.push("OpenCodex version");
     if (endpoint !== null && isEmpty(endpoint)) emptyCore.push("endpoint or capability");
     if (emptyCore.length > 0) {
-      reasons.push(`Required sections are missing or empty: ${emptyCore.join(", ")}.`);
-      guidance.push("Describe both the current and expected behaviour.");
+      // Same soft-pass as bug/feature: label- or maintainer-scoped provider
+      // reports often use non-English structured headings after a retitle.
+      const mappedHeadingPresent =
+        current !== null || expected !== null || repro !== null || response !== null || docs !== null;
+      const canSoftPass =
+        !mappedHeadingPresent &&
+        hasSubstantialStructuredContent(body);
+      if (canSoftPass) {
+        softPass = true;
+      } else {
+        reasons.push(`Required sections are missing or empty: ${emptyCore.join(", ")}.`);
+        guidance.push("Describe both the current and expected behaviour.");
+      }
     }
 
-    if (!isEmpty(current) && !isEmpty(expected) && canonicalise(current) === canonicalise(expected)) {
+    if (!softPass && !isEmpty(current) && !isEmpty(expected) && canonicalise(current) === canonicalise(expected)) {
       reasons.push("Current and expected behaviour are effectively identical.");
       guidance.push("Explain the difference between what happens now and what should happen.");
     }
 
     const allSections = [current, expected, repro, response].filter((s) => !isEmpty(s));
-    if (allSections.length >= 2 && allRepeatTitle(allSections, title)) {
+    if (!softPass && allSections.length >= 2 && allRepeatTitle(allSections, title)) {
       reasons.push("All sections merely repeat the issue title.");
       guidance.push("Add specific detail in each section.");
     }
 
-    if (isEmpty(repro) && isEmpty(response)) {
+    if (!softPass && isEmpty(repro) && isEmpty(response)) {
       reasons.push("Both the request/reproduction and the actual response/error are absent.");
       guidance.push("Include at least a minimal redacted request or the actual error output.");
     }
 
-    if (isEmpty(docs)) {
+    if (!softPass && isEmpty(docs)) {
       reasons.push("Upstream documentation is empty without stating that no public specification exists.");
       guidance.push("Add a URL to the provider specification, or state that no public spec exists.");
     }

--- a/.github/scripts/issue-quality.test.cjs
+++ b/.github/scripts/issue-quality.test.cjs
@@ -1049,6 +1049,44 @@ describe("translated feature headings and soft-pass", () => {
     assert.equal(result.valid, false);
   });
 
+  it("does not soft-pass a single arbitrary rich heading (Codex #564)", () => {
+    const result = validateIssue({
+      title: "Something broke after upgrade",
+      body: [
+        "## Notes",
+        "x".repeat(80),
+      ].join("\n"),
+      labels: ["bug"],
+      storedKind: "bug",
+    });
+    assert.equal(result.kind, "bug");
+    assert.equal(result.softPass, false);
+    assert.equal(result.valid, false);
+    assert.match(result.reasons.join(" "), /Summary and Reproduction are empty/);
+  });
+
+  it("does not soft-pass provider reports that only fill mapped metadata headings", () => {
+    const result = validateIssue({
+      title: "Provider X fails on Responses",
+      body: [
+        "### Provider or upstream service",
+        "custom-openai-compatible gateway hosted on our internal mesh",
+        "### OpenCodex version",
+        "2.7.41",
+        "### Endpoint or capability",
+        "`POST /v1/responses` with streaming tool calls",
+        "## Extra notes",
+        "We see intermittent 502s after rotating the upstream API key for this gateway.",
+      ].join("\n"),
+      labels: ["provider-compatibility"],
+      storedKind: "provider-compatibility",
+    });
+    assert.equal(result.kind, "provider-compatibility");
+    assert.equal(result.softPass, false);
+    assert.equal(result.valid, false);
+    assert.match(result.reasons.join(" "), /current behaviour|expected behaviour/i);
+  });
+
   it("still rejects empty [Feature]: bodies", () => {
     const result = validateIssue({
       title: "[Feature]: do something cool",

--- a/.github/scripts/issue-quality.test.cjs
+++ b/.github/scripts/issue-quality.test.cjs
@@ -998,6 +998,57 @@ describe("translated feature headings and soft-pass", () => {
     assert.equal(result.valid, false);
   });
 
+  it("soft-passes retitled feature reports that drop the [Feature]: prefix", () => {
+    const body = [
+      "### Concrete user workflow that fails",
+      "User pastes an image in Codex App while a text-only routed model is selected and the App blocks upload.",
+      "### Why this matters",
+      "Vision sidecar is advertised but never reached from the App client path.",
+      "### Verification",
+      "Same proxy config works end-to-end in Claude Code with the sidecar describing the image.",
+    ].join("\n");
+    const result = validateIssue({
+      title: "Vision sidecar unusable from Codex App",
+      body,
+      labels: ["enhancement"],
+      storedKind: "feature",
+    });
+    assert.equal(result.kind, "feature");
+    assert.equal(result.softPass, true);
+  });
+
+  it("soft-passes retitled bug reports with substantial non-English structure (#545)", () => {
+    // Maintainer retitle removed `[Bug]:`; Korean structured body has no English
+    // Summary/Reproduction headings but is clearly actionable.
+    const body = [
+      "## 환경",
+      "- opencodex 2.7.41 (launchd, port 10100)",
+      "- Claude Desktop 3P + Anthropic OAuth (Pro/Max)",
+      "- Auto Mode classifier model = `claude-sonnet-5`",
+      "",
+      "## 증상",
+      "Auto Mode classifier requests truncate at outputTokens=64 with max_output_tokens,",
+      "then retry the same payload up to 5 times. Dashboard previously showed 502.",
+      "",
+      "## 재현",
+      "1. `ocx login anthropic` and enable Claude Desktop 3P gateway key mode",
+      "2. Enable Auto Mode and trigger a tool permission classifier turn",
+      "3. Observe five identical 64-token incomplete terminals for one approval",
+      "",
+      "## 증거",
+      "Inbound+outbound correlated captures show max_tokens:64 and stop_sequences preserved.",
+    ].join("\n");
+    const result = validateIssue({
+      title: "Claude Desktop 3P Auto Mode classifier retries after 64-token Anthropic OAuth outputs",
+      body,
+      labels: ["bug", "provider-compatibility"],
+      storedKind: "bug",
+    });
+    assert.equal(result.kind, "bug");
+    assert.equal(result.softPass, true, `Expected soft-pass but got: ${result.reasons.join("; ")}`);
+    assert.equal(result.valid, false);
+  });
+
   it("still rejects empty [Feature]: bodies", () => {
     const result = validateIssue({
       title: "[Feature]: do something cool",


### PR DESCRIPTION
## Summary
- Soft-pass no longer requires a `[Bug]:` / `[Feature]:` title prefix once issue kind is already established (label / stored kind) and the body has substantial structured content.
- Prevents the #545 false close: maintainer retitle of a detailed non-English report was treated as empty Summary/Reproduction.
- Same soft-pass path for provider-compatibility when English template headings are absent.

## Test plan
- [x] `node --test .github/scripts/issue-quality.test.cjs` (81/81)
- [x] Reproduced #545 body + retitled English title → softPass true
- [ ] After merge to `main` (default branch), confirm a retitle of a substantial labeled bug no longer auto-closes

Note: live `Enforce issue quality` loads scripts from the repo default branch (`main`), so this only takes effect after promotion from `dev`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue validation for feature and bug reports when titles are retitled or use translated headings.
  * Added more flexible validation for provider compatibility reports with substantial structured content.
  * Prevented additional validation errors from appearing when an issue qualifies for a soft pass.

* **Tests**
  * Added coverage for retitled and non-English feature and bug reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->