### PR TITLE
fix(ci): let the PR labeler actually write labels

### DIFF
--- a/.github/scripts/pr-labeler.test.cjs
+++ b/.github/scripts/pr-labeler.test.cjs
@@ -165,8 +165,15 @@ describe("pr-labeler workflow", () => {
   it("keeps trusted default-branch checkout, concurrency cancel, and minimal permissions", () => {
     assert.match(workflow, /ref:\s*\$\{\{\s*github\.event\.repository\.default_branch\s*\}\}/);
     assert.match(workflow, /cancel-in-progress:\s*true/);
-    assert.match(workflow, /pull-requests:\s*read/);
     assert.match(workflow, /issues:\s*write/);
-    assert.doesNotMatch(workflow, /pull-requests:\s*write/);
+    // The issues label endpoints are shared with pull requests: writing a label
+    // onto a PR number needs pull_requests=write alongside issues=write, which
+    // GitHub reports as `issues=write; pull_requests=write`. Pinning this to
+    // read made the workflow fail closed on the first PR that actually needed a
+    // label applied (#565), so write is the minimum here, not an escalation.
+    assert.match(workflow, /pull-requests:\s*write/);
+    // contents stays read — the labeler never pushes.
+    assert.match(workflow, /contents:\s*read/);
+    assert.doesNotMatch(workflow, /contents:\s*write/);
   });
 });

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -17,8 +17,14 @@ concurrency:
 
 permissions:
   contents: read
-  # pulls.get only needs read; label mutations use the issues API.
-  pull-requests: read
+  # pulls.get only needs read, but the issues label endpoints are shared with
+  # pull requests: adding or removing a label on a PR number is rejected with
+  # "Resource not accessible by integration" unless the token also carries
+  # pull_requests=write (the API reports `issues=write; pull_requests=write`
+  # in x-accepted-github-permissions). Read-only here silently worked while
+  # every run happened to be a no-op sync, and failed on the first PR that
+  # actually needed a label written.
+  pull-requests: write
   issues: write
 
 jobs:


### PR DESCRIPTION
## Problem

The PR Labeler workflow fails with a 403 whenever it actually needs to write a label:

```
##[error]Unhandled error: HttpError: Resource not accessible by integration
POST /repos/lidge-jun/opencodex/issues/565/labels
body: {"labels":["enhancement"]}
```

Observed on #565 (runs [30292169466](https://github.com/lidge-jun/opencodex/actions/runs/30292169466) and [30292826165](https://github.com/lidge-jun/opencodex/actions/runs/30292826165)).

## Cause

The job token was granted exactly what the workflow asked for:

```
Contents: read
Issues: write
Metadata: read
PullRequests: read
```

But GitHub's own rejection names a wider requirement:

```
x-accepted-github-permissions: 'issues=write; pull_requests=write'
```

The issues label endpoints are shared with pull requests. Writing a label onto a
PR number needs `pull_requests=write` as well, so `pull-requests: read` cannot
satisfy `POST /issues/{number}/labels` even with `issues: write`.

This stayed invisible because almost every run is a no-op: the title already
matches the current label, `planTypeLabelSync` returns a skip, and no write is
attempted. Runs on #512, #447, and #528 all "passed" this way. #565 was the
first PR in a while that genuinely needed a label applied, so it was the first
to surface the misconfiguration.

## Fix

Raise `pull-requests` to `write` in the workflow's top-level permissions, with a
comment recording why the read-only value looked sufficient but is not.

No script or logic change: `planTypeLabelSync` and the sticky human-override
behaviour are untouched, so the labeler still refuses to overwrite a maintainer's
manual type label.

## Note on scope

This is a workflow permission increase, so it falls under the security-review
boundary in `MAINTAINERS.md`. The added scope is the minimum the API demands for
the write the workflow already performs; it grants no new capability beyond
label mutation on pull requests.

`pull_request_target` workflows load from the default branch (`main`), so this
does not take effect on live PRs until it is promoted there.

## Verification

- pre-push `bun scripts/test.ts` → 5070 pass / 0 fail
- `bun run privacy:scan` → pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the pull request labeling workflow to request the correct permission level so label updates succeed reliably.
* **Tests**
  * Adjusted the workflow test coverage to match the new permission expectations, including validation that content access remains read-only.
* **Chores**
  * Added clarifying inline documentation explaining why the workflow needs write access for label mutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->