### PR TITLE
fix(storage): harden #558 satellite backup writes and zst restore

### DIFF
--- a/src/codex/history-provider.ts
+++ b/src/codex/history-provider.ts
@@ -1,9 +1,17 @@
 import { createHash } from "node:crypto";
 import { closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, readSync, unlinkSync, writeSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { zstdDecompressSync } from "node:zlib";
 import { Database } from "bun:sqlite";
 import { CODEX_HOME } from "./paths";
 import { atomicWriteFile, getConfigDir } from "../config";
+
+/**
+ * Cap for decompressing a lone `.jsonl.zst` rollout during quarantine restore.
+ * Bounds peak memory while reconstructing thread rows; never write the decoded
+ * JSONL to disk.
+ */
+export const MAX_ROLLOUT_ZST_DECOMPRESSED_BYTES = 64 * 1024 * 1024;
 
 const STATE_DB_PATH = join(CODEX_HOME, "state_5.sqlite");
 function historyBackupPathFor(stateDbPath: string): string {
@@ -332,15 +340,39 @@ function extractUserMessagePreview(line: string): string | null {
 /**
  * Reconstruct thread identity + listing fields from a staged/restored rollout JSONL.
  * Returns null when the file is missing or has no parseable `session_meta`.
+ *
+ * Accepts plain `.jsonl` or a lone `.jsonl.zst` (legacy Phase-2 quarantine). Compressed
+ * rollouts are decompressed in memory with {@link MAX_ROLLOUT_ZST_DECOMPRESSED_BYTES};
+ * no decompressed copy is written to disk.
  */
 export function readThreadFieldsFromRollout(path: string): RolloutThreadFields | null {
   if (!path || !existsSync(path)) return null;
   let raw: string;
   try {
-    raw = readFileSync(path, "utf8");
+    raw = path.endsWith(".zst")
+      ? decompressRolloutZstUtf8(path)
+      : readFileSync(path, "utf8");
   } catch {
     return null;
   }
+  return parseThreadFieldsFromRolloutText(raw);
+}
+
+function decompressRolloutZstUtf8(
+  path: string,
+  maxBytes: number = MAX_ROLLOUT_ZST_DECOMPRESSED_BYTES,
+): string {
+  const compressed = readFileSync(path);
+  const decoded = zstdDecompressSync(compressed as Uint8Array<ArrayBuffer>, {
+    maxOutputLength: maxBytes,
+  });
+  if (decoded.byteLength > maxBytes) {
+    throw new Error("rollout_zst_too_large");
+  }
+  return new TextDecoder().decode(decoded);
+}
+
+function parseThreadFieldsFromRolloutText(raw: string): RolloutThreadFields | null {
   const lines = raw.split("\n");
   let latest: ParsedSessionMeta | null = null;
   let firstUserMessage = "";

--- a/src/server/management/logs-usage-routes.ts
+++ b/src/server/management/logs-usage-routes.ts
@@ -362,13 +362,12 @@ export async function handleLogsUsageRoutes(ctx: ManagementContext): Promise<Res
     }
   }
 
-  if (
-    process.env.OPENCODEX_CLEANUP_TEST_HOOKS === "1" &&
-    url.pathname === "/api/storage/trash/restore/test-stream" &&
-    req.method === "GET"
-  ) {
-    const stream = getRestoreTrashTestStreamResponse();
-    if (stream) return stream;
+  if (url.pathname === "/api/storage/trash/restore/test-stream" && req.method === "GET") {
+    if (process.env.OPENCODEX_CLEANUP_TEST_HOOKS === "1") {
+      const stream = getRestoreTrashTestStreamResponse();
+      if (stream) return stream;
+    }
+    // Always answer this test-only path — never fall through to the GUI SPA (200 HTML).
     return jsonResponse({ error: "not_available" }, 404);
   }
 

--- a/src/storage/cleanup.ts
+++ b/src/storage/cleanup.ts
@@ -739,6 +739,12 @@ interface ReconcileTestHooks {
   failBeforeStateCommit?: boolean;
   failSatelliteRestore?: boolean;
   failSatelliteBackupWrite?: boolean;
+  /**
+   * Fail a satellite-backup.json *replacement* after the temp is durable but before
+   * rename — exercises crash-safety of the post-memories rewrite without truncating
+   * the last valid backup.
+   */
+  failSatelliteBackupReplace?: boolean;
   /** Runs after satellite deletes are committed, before state thread deletion. */
   afterSatelliteMutations?: () => void;
 }
@@ -746,6 +752,7 @@ interface ReconcileTestHooks {
 const SATELLITE_BACKUP_FILE = "satellite-backup.json";
 /** Marks an incomplete restore so retries can accept dest files and resume metadata. */
 const RESTORE_PENDING_FILE = "restore-pending.json";
+let _satelliteBackupSeq = 0;
 
 type StagedFile = { from: string; to: string; relPath: string };
 
@@ -971,8 +978,62 @@ function restoreConsolidateGlobalJob(
   }
 }
 
-function writeSatelliteBackup(stageDir: string, backup: SatelliteBackup): void {
-  writePrivateFile(join(stageDir, SATELLITE_BACKUP_FILE), JSON.stringify(backup));
+/**
+ * Best-effort directory fsync so a preceding rename is durable on crash.
+ * Unsupported on some Windows setups — never treat failure as fatal.
+ */
+function fsyncDirectoryBestEffort(dirPath: string): void {
+  let fd: number | undefined;
+  try {
+    fd = openSync(dirPath, "r");
+    fsyncSync(fd);
+  } catch {
+    /* best-effort */
+  } finally {
+    if (fd !== undefined) {
+      try { closeSync(fd); } catch { /* */ }
+    }
+  }
+}
+
+/**
+ * Atomically replace satellite-backup.json: private temp in the stage, fsync, rename,
+ * then best-effort directory fsync. An interrupted update never truncates the last
+ * valid backup that was written before a satellite DB commit.
+ */
+function writeSatelliteBackup(
+  stageDir: string,
+  backup: SatelliteBackup,
+  options?: { failWrite?: boolean; failReplaceBeforeRename?: boolean },
+): void {
+  if (options?.failWrite) throw new Error("test_fail_satellite_backup_write");
+  const dest = join(stageDir, SATELLITE_BACKUP_FILE);
+  const replacing = existsSync(dest);
+  const tmp = join(stageDir, `${SATELLITE_BACKUP_FILE}.${process.pid}.${++_satelliteBackupSeq}.tmp`);
+  const payload = JSON.stringify(backup);
+  const fd = openSync(tmp, "w", 0o600);
+  try {
+    writeSync(fd, payload, null, "utf8");
+    fsyncSync(fd);
+  } catch (error) {
+    try { closeSync(fd); } catch { /* */ }
+    try { unlinkSync(tmp); } catch { /* */ }
+    throw error;
+  }
+  closeSync(fd);
+  chmodPrivatePath(tmp, 0o600);
+  if (options?.failReplaceBeforeRename && replacing) {
+    try { unlinkSync(tmp); } catch { /* */ }
+    throw new Error("test_fail_satellite_backup_replace");
+  }
+  try {
+    renameSync(tmp, dest);
+  } catch (error) {
+    try { unlinkSync(tmp); } catch { /* */ }
+    throw error;
+  }
+  chmodPrivatePath(dest, 0o600);
+  fsyncDirectoryBestEffort(stageDir);
 }
 
 function clearSatelliteBackup(stageDir: string): void {
@@ -1240,15 +1301,17 @@ function deleteAndCommitSatellites(
       deleteMemoriesInTx(locks.memories.db, backup.memories);
       if (backup.memories.consolidateTouched) {
         // Capture under the write lock, but persist only after COMMIT+close.
-        // Holding BEGIN IMMEDIATE across writeFileSync lets Windows CI disk/AV
-        // latency stall the lock long enough for concurrent reopen hooks (and
-        // bun's default 5s test timeout) to hang — see PR #558 windows-latest.
+        // Holding BEGIN IMMEDIATE across a durable backup rewrite lets Windows CI
+        // disk/AV latency stall the lock long enough for concurrent reopen hooks
+        // (and bun's default 5s test timeout) to hang — see PR #558 windows-latest.
         backup.memories.consolidatePostImage = readConsolidateGlobalJob(locks.memories.db);
       }
       commitSatelliteLock(locks.memories);
       locks.memories = undefined;
       if (backup.memories.consolidateTouched) {
-        writeSatelliteBackup(stageDir, backup);
+        writeSatelliteBackup(stageDir, backup, {
+          failReplaceBeforeRename: hooks?.failSatelliteBackupReplace,
+        });
       }
       if (hooks?.failAfterMemoriesMutation) throw new Error("test_fail_after_memories");
     }
@@ -1420,10 +1483,9 @@ function reconcileDeletedThreads(
       backup.dynamicTools = stateDeps.dynamicTools;
       backup.spawnEdges = stateDeps.spawnEdges;
       try {
-        if (hooks?.failSatelliteBackupWrite) {
-          throw new Error("test_fail_satellite_backup_write");
-        }
-        writeSatelliteBackup(stageDir, backup);
+        writeSatelliteBackup(stageDir, backup, {
+          failWrite: hooks?.failSatelliteBackupWrite,
+        });
       } catch {
         rollbackAllSatelliteLocks(satelliteLocks);
         stateDb.exec("ROLLBACK");
@@ -1606,6 +1668,7 @@ export interface ExecuteCleanupOptions {
     failBeforeStateCommit?: boolean;
     failSatelliteRestore?: boolean;
     failSatelliteBackupWrite?: boolean;
+    failSatelliteBackupReplace?: boolean;
     afterSatelliteMutations?: () => void;
   };
 }
@@ -1635,6 +1698,7 @@ export function pickWireCleanupTestHooks(raw: unknown): CleanupWireTestHooks | u
   if (typeof o.failBeforeStateCommit === "boolean") out.failBeforeStateCommit = o.failBeforeStateCommit;
   if (typeof o.failSatelliteRestore === "boolean") out.failSatelliteRestore = o.failSatelliteRestore;
   if (typeof o.failSatelliteBackupWrite === "boolean") out.failSatelliteBackupWrite = o.failSatelliteBackupWrite;
+  if (typeof o.failSatelliteBackupReplace === "boolean") out.failSatelliteBackupReplace = o.failSatelliteBackupReplace;
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
@@ -2350,16 +2414,30 @@ function restoreThreadsFromManifest(
     );
     const reconstructed: SqlRow[] = [];
     for (const entry of toReconstruct) {
-      let abs: string;
+      let abs: string | undefined;
       try {
         abs = absFromRel(codexHome, entry.rolloutPath!);
       } catch {
-        // Prefer the first restored physical path under archived_sessions.
-        const rel = entry.physicalRelPaths[0];
-        if (!rel) throw new Error("missing_rollout_for_thread");
-        abs = absFromRel(codexHome, rel);
+        abs = undefined;
       }
-      // .jsonl.zst cannot be parsed here — require a plain .jsonl sibling or path.
+      // Legacy compressed-only quarantine: manifest rolloutPath is often the logical
+      // `.jsonl` name while the only restored physical file is `.jsonl.zst`.
+      if (!abs || !existsSync(abs)) {
+        for (const rel of entry.physicalRelPaths) {
+          try {
+            const candidate = absFromRel(codexHome, rel);
+            if (existsSync(candidate)) {
+              abs = candidate;
+              break;
+            }
+          } catch {
+            /* try next physical path */
+          }
+        }
+      }
+      if (!abs) throw new Error("missing_rollout_for_thread");
+      // Prefer a plain .jsonl sibling when present; otherwise readThreadFieldsFromRollout
+      // decompresses a lone .jsonl.zst in memory (bounded) for legacy quarantine restores.
       if (abs.endsWith(ZST_SUFFIX)) {
         const plain = abs.slice(0, -".zst".length);
         if (existsSync(plain)) abs = plain;

--- a/src/storage/cleanup.ts
+++ b/src/storage/cleanup.ts
@@ -34,6 +34,7 @@ import { basename, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { Database } from "bun:sqlite";
 import { resolveCodexHomeDir } from "../codex/home";
 import { readThreadFieldsFromRollout } from "../codex/history-provider";
+import { renameAtomicFile } from "../config";
 
 export const ARCHIVED_SESSIONS_DIR = "archived_sessions";
 export const TRASH_DIR = ".trash";
@@ -997,9 +998,10 @@ function fsyncDirectoryBestEffort(dirPath: string): void {
 }
 
 /**
- * Atomically replace satellite-backup.json: private temp in the stage, fsync, rename,
- * then best-effort directory fsync. An interrupted update never truncates the last
- * valid backup that was written before a satellite DB commit.
+ * Atomically replace satellite-backup.json: private temp in the stage, full write + fsync,
+ * rename (with Windows sharing-violation retries), then best-effort directory fsync.
+ * An interrupted update never truncates the last valid backup that was written before a
+ * satellite DB commit.
  */
 function writeSatelliteBackup(
   stageDir: string,
@@ -1010,10 +1012,13 @@ function writeSatelliteBackup(
   const dest = join(stageDir, SATELLITE_BACKUP_FILE);
   const replacing = existsSync(dest);
   const tmp = join(stageDir, `${SATELLITE_BACKUP_FILE}.${process.pid}.${++_satelliteBackupSeq}.tmp`);
-  const payload = JSON.stringify(backup);
+  const payload = Buffer.from(JSON.stringify(backup), "utf8");
   const fd = openSync(tmp, "w", 0o600);
   try {
-    writeSync(fd, payload, null, "utf8");
+    let offset = 0;
+    while (offset < payload.length) {
+      offset += writeSync(fd, payload, offset, payload.length - offset, null);
+    }
     fsyncSync(fd);
   } catch (error) {
     try { closeSync(fd); } catch { /* */ }
@@ -1027,7 +1032,7 @@ function writeSatelliteBackup(
     throw new Error("test_fail_satellite_backup_replace");
   }
   try {
-    renameSync(tmp, dest);
+    renameAtomicFile(tmp, dest);
   } catch (error) {
     try { unlinkSync(tmp); } catch { /* */ }
     throw error;

--- a/tests/storage-cleanup.test.ts
+++ b/tests/storage-cleanup.test.ts
@@ -789,6 +789,139 @@ describe("executeArchivedCleanup", () => {
     stateAfter.close();
   });
 
+  test("failed post-memories satellite-backup replace keeps prior backup parseable and restorable", () => {
+    home = buildHome({ withSatelliteStores: true });
+    const logsBefore = new Database(join(home, "logs_2.sqlite"), { readonly: true });
+    const logs = logsBefore.query(
+      "SELECT id, ts, level, target, thread_id, estimated_bytes FROM logs ORDER BY id",
+    ).all();
+    logsBefore.close();
+    const goalsBefore = new Database(join(home, "goals_1.sqlite"), { readonly: true });
+    const goals = goalsBefore.query(
+      "SELECT thread_id, goal_id, objective, status FROM thread_goals ORDER BY thread_id",
+    ).all();
+    const deferrals = goalsBefore.query(
+      "SELECT thread_id FROM thread_goal_continuation_deferrals ORDER BY thread_id",
+    ).all();
+    goalsBefore.close();
+    const memBefore = new Database(join(home, "memories_1.sqlite"), { readonly: true });
+    const stage1 = memBefore.query(
+      "SELECT thread_id, raw_memory, rollout_summary, selected_for_phase2 FROM stage1_outputs ORDER BY thread_id",
+    ).all();
+    const jobs = memBefore.query(
+      "SELECT kind, job_key, status FROM jobs ORDER BY kind, job_key",
+    ).all();
+    memBefore.close();
+
+    // tmid has selected_for_phase2=1 → consolidateTouched forces a post-commit backup rewrite.
+    // failSatelliteRestore keeps the prior on-disk snapshot so we can prove it was never truncated.
+    const result = runWithDigest(100, "permanent", home, {
+      now: 96,
+      _test: { failSatelliteBackupReplace: true, failSatelliteRestore: true },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("db_reconcile_failed");
+    expect(result.trashDir).toBe(".trash/96");
+
+    const backupPath = join(home, ".trash", "96", "satellite-backup.json");
+    expect(existsSync(backupPath)).toBe(true);
+    const backup = JSON.parse(readFileSync(backupPath, "utf8")) as {
+      threadIds: string[];
+      logs?: { rows: Array<Record<string, unknown>> };
+      memories?: {
+        stage1: Array<Record<string, unknown>>;
+        stage1Jobs: Array<Record<string, unknown>>;
+        consolidateTouched?: boolean;
+        consolidateJob?: Record<string, unknown> | null;
+        consolidatePostImage?: unknown;
+      };
+      goals?: {
+        goals: Array<Record<string, unknown>>;
+        deferrals: Array<Record<string, unknown>>;
+      };
+    };
+    expect(backup.threadIds).toEqual(expect.arrayContaining(["told", "tmid", "tnew"]));
+    expect(backup.logs?.rows.length).toBeGreaterThan(0);
+    expect(backup.memories?.stage1.length).toBeGreaterThan(0);
+    expect(backup.memories?.consolidateTouched).toBe(true);
+    // Replacement never landed — prior snapshot must not carry the post-commit image.
+    expect(backup.memories?.consolidatePostImage).toBeUndefined();
+    expect(backup.goals?.goals.length).toBeGreaterThan(0);
+
+    // Injected restore failure left satellites deleted; re-apply the kept prior backup.
+    const logsDb = new Database(join(home, "logs_2.sqlite"));
+    logsDb.exec("BEGIN IMMEDIATE");
+    for (const row of backup.logs?.rows ?? []) {
+      const cols = Object.keys(row);
+      logsDb.run(
+        `INSERT INTO logs (${cols.join(", ")}) VALUES (${cols.map(() => "?").join(", ")}) ON CONFLICT DO NOTHING`,
+        cols.map(c => row[c] as string | number | null),
+      );
+    }
+    logsDb.exec("COMMIT");
+    logsDb.close();
+
+    const memDb = new Database(join(home, "memories_1.sqlite"));
+    memDb.exec("BEGIN IMMEDIATE");
+    for (const row of backup.memories?.stage1 ?? []) {
+      const cols = Object.keys(row);
+      memDb.run(
+        `INSERT INTO stage1_outputs (${cols.join(", ")}) VALUES (${cols.map(() => "?").join(", ")}) ON CONFLICT DO NOTHING`,
+        cols.map(c => row[c] as string | number | null),
+      );
+    }
+    for (const row of backup.memories?.stage1Jobs ?? []) {
+      const cols = Object.keys(row);
+      memDb.run(
+        `INSERT INTO jobs (${cols.join(", ")}) VALUES (${cols.map(() => "?").join(", ")}) ON CONFLICT DO NOTHING`,
+        cols.map(c => row[c] as string | number | null),
+      );
+    }
+    memDb.exec("COMMIT");
+    memDb.close();
+
+    const goalsDb = new Database(join(home, "goals_1.sqlite"));
+    goalsDb.exec("BEGIN IMMEDIATE");
+    for (const row of backup.goals?.goals ?? []) {
+      const cols = Object.keys(row);
+      goalsDb.run(
+        `INSERT INTO thread_goals (${cols.join(", ")}) VALUES (${cols.map(() => "?").join(", ")}) ON CONFLICT DO NOTHING`,
+        cols.map(c => row[c] as string | number | null),
+      );
+    }
+    for (const row of backup.goals?.deferrals ?? []) {
+      const cols = Object.keys(row);
+      goalsDb.run(
+        `INSERT INTO thread_goal_continuation_deferrals (${cols.join(", ")}) VALUES (${cols.map(() => "?").join(", ")}) ON CONFLICT DO NOTHING`,
+        cols.map(c => row[c] as string | number | null),
+      );
+    }
+    goalsDb.exec("COMMIT");
+    goalsDb.close();
+
+    const logsAfter = new Database(join(home, "logs_2.sqlite"), { readonly: true });
+    expect(logsAfter.query("SELECT id, ts, level, target, thread_id, estimated_bytes FROM logs ORDER BY id").all()).toEqual(logs);
+    logsAfter.close();
+    const goalsAfter = new Database(join(home, "goals_1.sqlite"), { readonly: true });
+    expect(goalsAfter.query("SELECT thread_id, goal_id, objective, status FROM thread_goals ORDER BY thread_id").all()).toEqual(goals);
+    expect(goalsAfter.query("SELECT thread_id FROM thread_goal_continuation_deferrals ORDER BY thread_id").all()).toEqual(deferrals);
+    goalsAfter.close();
+    const memAfter = new Database(join(home, "memories_1.sqlite"), { readonly: true });
+    expect(memAfter.query("SELECT thread_id, raw_memory, rollout_summary, selected_for_phase2 FROM stage1_outputs ORDER BY thread_id").all()).toEqual(stage1);
+    // stage1 jobs restored; consolidate-global may have been mutated before the failed rewrite —
+    // only assert stage1 keys are present (every deleted satellite row from the prior backup).
+    const jobKeys = memAfter.query<{ kind: string; job_key: string }, []>(
+      "SELECT kind, job_key FROM jobs ORDER BY kind, job_key",
+    ).all();
+    memAfter.close();
+    for (const expected of jobs.filter(j => (j as { kind: string }).kind === "memory_stage1")) {
+      expect(jobKeys).toContainEqual({
+        kind: (expected as { kind: string }).kind,
+        job_key: (expected as { job_key: string }).job_key,
+      });
+    }
+  }, { timeout: 30_000 });
+
   test("permanent cleanup works with logs-only satellite store", () => {
     home = buildHome({ satellites: "logs" });
     const result = runWithDigest(100, "permanent", home);
@@ -1213,6 +1346,96 @@ describe("listTrashEntries + restoreTrashEntry", () => {
       model_provider: "openai",
       source: "cli",
       first_user_message: "restore me please",
+      has_user_event: 1,
+      archived: 1,
+    });
+  });
+
+  test("legacy compressed-only quarantine restores .jsonl.zst and reconstructs the thread row", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ocx-cleanup-legacy-zst-"));
+    home = dir;
+    mkdirSync(join(dir, "archived_sessions"), { recursive: true });
+
+    const rolloutBody = [
+      JSON.stringify({
+        type: "session_meta",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        payload: {
+          id: "told",
+          model_provider: "openai",
+          source: "cli",
+          cwd: "/tmp/project",
+        },
+      }),
+      JSON.stringify({
+        type: "event_msg",
+        timestamp: "2026-01-01T00:00:01.000Z",
+        payload: { type: "user_message", message: "compressed restore please" },
+      }),
+    ].join("\n") + "\n";
+    const compressed = Bun.zstdCompressSync(Buffer.from(rolloutBody, "utf8"));
+
+    const stage = join(dir, ".trash", "1700000000910");
+    mkdirSync(stage, { recursive: true });
+    // Sparse legacy manifest: no threads snapshot, only the compressed physical file.
+    writeFileSync(join(stage, "rollout-old.jsonl.zst"), compressed);
+    writeFileSync(join(stage, "manifest.json"), JSON.stringify({
+      quarantinedAt: 1_700_000_000_910,
+      mode: "quarantine",
+      entries: [
+        {
+          relPath: "archived_sessions/rollout-old.jsonl",
+          bytes: compressed.byteLength,
+          mtimeMs: OLD.getTime(),
+          physicalRelPaths: ["archived_sessions/rollout-old.jsonl.zst"],
+          threadId: "told",
+          rolloutPath: "archived_sessions/rollout-old.jsonl",
+          archived: 1,
+        },
+      ],
+    }));
+    // Intentionally no satellite-backup.json and no plain .jsonl sibling.
+
+    const db = new Database(join(dir, "state_5.sqlite"));
+    db.exec(`CREATE TABLE threads (
+      id TEXT PRIMARY KEY,
+      rollout_path TEXT NOT NULL,
+      model_provider TEXT NOT NULL,
+      source TEXT NOT NULL,
+      first_user_message TEXT NOT NULL,
+      has_user_event INTEGER NOT NULL DEFAULT 0,
+      archived INTEGER,
+      archived_at INTEGER
+    )`);
+    db.close();
+
+    const restored = restoreTrashEntry(".trash/1700000000910", { codexHome: home });
+    expect(restored.ok).toBe(true);
+    expect(existsSync(join(dir, "archived_sessions", "rollout-old.jsonl.zst"))).toBe(true);
+    // Must not materialize an unbounded plain decompressed sibling on disk.
+    expect(existsSync(join(dir, "archived_sessions", "rollout-old.jsonl"))).toBe(false);
+    expect(existsSync(stage)).toBe(false);
+
+    const state = new Database(join(dir, "state_5.sqlite"), { readonly: true });
+    const row = state.query<{
+      id: string;
+      rollout_path: string;
+      model_provider: string;
+      source: string;
+      first_user_message: string;
+      has_user_event: number;
+      archived: number | null;
+    }, []>(
+      `SELECT id, rollout_path, model_provider, source, first_user_message, has_user_event, archived
+       FROM threads WHERE id='told'`,
+    ).get();
+    state.close();
+    expect(row).toEqual({
+      id: "told",
+      rollout_path: "archived_sessions/rollout-old.jsonl",
+      model_provider: "openai",
+      source: "cli",
+      first_user_message: "compressed restore please",
       has_user_event: 1,
       archived: 1,
     });

--- a/tests/storage-restore-job-responsive.test.ts
+++ b/tests/storage-restore-job-responsive.test.ts
@@ -78,6 +78,8 @@ describe("storage trash restore job responsiveness", () => {
     try {
       const res = await fetch(new URL("/api/storage/trash/restore/test-stream", server.url));
       expect(res.status).toBe(404);
+      expect(res.headers.get("content-type") ?? "").toContain("application/json");
+      expect(await res.json()).toEqual({ error: "not_available" });
     } finally {
       await server.stop(true);
     }


### PR DESCRIPTION
## Summary

Follow-up fixes for already-merged PR #558 (Phase 2.1 quarantine restore).

### Bugs

1. **Non-atomic `satellite-backup.json` writes** — `writeSatelliteBackup` used plain `writeFileSync`, so a crash during the post-memories rewrite (after a satellite DB commit) could truncate or destroy the last valid backup and leave recovery impossible.
2. **Legacy compressed-only quarantine restore failed** — manifests whose only rollout file is `.jsonl.zst` (no plain sibling, no `satellite-backup.json` thread snapshot) could not reconstruct production-shaped `threads` rows because restore resolved the logical `.jsonl` path and refused to parse zstd.

### Implementation

1. **Crash-safe satellite backup writes**
   - Write to a private temp file in the same stage directory
   - `fsync` the temp, atomically `rename` over `satellite-backup.json`
   - Best-effort directory `fsync` where supported
   - Applies to the initial backup and every later post-commit update
   - `failSatelliteBackupReplace` test hook fails after durable temp write / before rename

2. **Legacy `.jsonl.zst` restore**
   - Prefer an existing physical path when the logical `rolloutPath` is missing
   - `readThreadFieldsFromRollout` decompresses `.zst` in memory with `zstdDecompressSync({ maxOutputLength })` (64 MiB cap)
   - Never writes an unbounded decompressed copy to disk

Also: test-only `/api/storage/trash/restore/test-stream` now returns JSON 404 when the cleanup test-hooks env is off, instead of falling through to the GUI SPA (200 HTML) — keeps the #558 responsive-suite gate deterministic.

### Test plan

- [x] Regression: fail post-memories backup replace → prior backup remains parseable and restores every deleted satellite row
- [x] Regression: sparse legacy manifest + only `.jsonl.zst` → restore recovers compressed file and correct thread row
- [x] Focused storage suite + `bun run typecheck`
- [ ] CI green on Linux / Windows / macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved restoration of archived sessions stored only in compressed history (`.jsonl.zst`), including legacy quarantine scenarios.
  - Preserved valid `satellite-backup` snapshots when cleanup encounters a failure.
- **Reliability**
  - Added safeguards for decompressed history size.
  - Improved durability and atomicity of satellite backup replacement to prevent partial/corrupt writes.
- **Tests**
  - Added coverage for satellite cleanup/restore failure handling and compressed-only legacy restore behavior.
  - Strengthened assertions for the absent test-stream endpoint response format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->