### PR TITLE
test(storage): cover restore test-stream route gate cases

### DIFF
--- a/tests/storage-restore-job-responsive.test.ts
+++ b/tests/storage-restore-job-responsive.test.ts
@@ -85,6 +85,37 @@ describe("storage trash restore job responsiveness", () => {
     }
   });
 
+  test("test-stream route returns JSON 404 when hooks are enabled but stream is null", async () => {
+    process.env.OPENCODEX_CLEANUP_TEST_HOOKS = "1";
+    // enableTestStream omitted → getRestoreTrashTestStreamResponse() returns null
+    setRestoreTrashJobTestHooks({ blockMs: 0 });
+    const server = startServer(0);
+    try {
+      const res = await fetch(new URL("/api/storage/trash/restore/test-stream", server.url));
+      expect(res.status).toBe(404);
+      expect(res.headers.get("content-type") ?? "").toContain("application/json");
+      expect(await res.json()).toEqual({ error: "not_available" });
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("test-stream route serves the enabled hook stream", async () => {
+    process.env.OPENCODEX_CLEANUP_TEST_HOOKS = "1";
+    setRestoreTrashJobTestHooks({ enableTestStream: true });
+    const server = startServer(0);
+    try {
+      const res = await fetch(new URL("/api/storage/trash/restore/test-stream", server.url));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type") ?? "").toContain("text/plain");
+      const body = await res.text();
+      expect(body).toContain("chunk-0");
+      expect(body).toContain("chunk-7");
+    } finally {
+      await server.stop(true);
+    }
+  }, { timeout: 10_000 });
+
   test("blocked worker keeps /healthz and streaming response responsive", async () => {
     const blockMs = 1200;
     setRestoreTrashJobTestHooks({ blockMs, enableTestStream: true });

--- a/tests/storage-restore-job-responsive.test.ts
+++ b/tests/storage-restore-job-responsive.test.ts
@@ -71,49 +71,72 @@ afterEach(() => {
 });
 
 describe("storage trash restore job responsiveness", () => {
-  test("test-stream route is absent without OPENCODEX_CLEANUP_TEST_HOOKS", async () => {
-    delete process.env.OPENCODEX_CLEANUP_TEST_HOOKS;
-    setRestoreTrashJobTestHooks({ enableTestStream: true });
+  async function withTestStreamRoute(
+    setup: () => void,
+    assert: (serverUrl: string) => Promise<void>,
+  ): Promise<void> {
+    const previousHooksEnv = process.env.OPENCODEX_CLEANUP_TEST_HOOKS;
+    setup();
     const server = startServer(0);
     try {
-      const res = await fetch(new URL("/api/storage/trash/restore/test-stream", server.url));
-      expect(res.status).toBe(404);
-      expect(res.headers.get("content-type") ?? "").toContain("application/json");
-      expect(await res.json()).toEqual({ error: "not_available" });
+      await assert(server.url.toString());
     } finally {
-      await server.stop(true);
+      try {
+        await server.stop(true);
+      } finally {
+        setRestoreTrashJobTestHooks(null);
+        if (previousHooksEnv === undefined) delete process.env.OPENCODEX_CLEANUP_TEST_HOOKS;
+        else process.env.OPENCODEX_CLEANUP_TEST_HOOKS = previousHooksEnv;
+      }
     }
+  }
+
+  test("test-stream route is absent without OPENCODEX_CLEANUP_TEST_HOOKS", async () => {
+    await withTestStreamRoute(
+      () => {
+        delete process.env.OPENCODEX_CLEANUP_TEST_HOOKS;
+        setRestoreTrashJobTestHooks({ enableTestStream: true });
+      },
+      async (serverUrl) => {
+        const res = await fetch(new URL("/api/storage/trash/restore/test-stream", serverUrl));
+        expect(res.status).toBe(404);
+        expect(res.headers.get("content-type") ?? "").toContain("application/json");
+        expect(await res.json()).toEqual({ error: "not_available" });
+      },
+    );
   });
 
   test("test-stream route returns JSON 404 when hooks are enabled but stream is null", async () => {
-    process.env.OPENCODEX_CLEANUP_TEST_HOOKS = "1";
-    // enableTestStream omitted → getRestoreTrashTestStreamResponse() returns null
-    setRestoreTrashJobTestHooks({ blockMs: 0 });
-    const server = startServer(0);
-    try {
-      const res = await fetch(new URL("/api/storage/trash/restore/test-stream", server.url));
-      expect(res.status).toBe(404);
-      expect(res.headers.get("content-type") ?? "").toContain("application/json");
-      expect(await res.json()).toEqual({ error: "not_available" });
-    } finally {
-      await server.stop(true);
-    }
+    await withTestStreamRoute(
+      () => {
+        process.env.OPENCODEX_CLEANUP_TEST_HOOKS = "1";
+        // enableTestStream omitted → getRestoreTrashTestStreamResponse() returns null
+        setRestoreTrashJobTestHooks({ blockMs: 0 });
+      },
+      async (serverUrl) => {
+        const res = await fetch(new URL("/api/storage/trash/restore/test-stream", serverUrl));
+        expect(res.status).toBe(404);
+        expect(res.headers.get("content-type") ?? "").toContain("application/json");
+        expect(await res.json()).toEqual({ error: "not_available" });
+      },
+    );
   });
 
   test("test-stream route serves the enabled hook stream", async () => {
-    process.env.OPENCODEX_CLEANUP_TEST_HOOKS = "1";
-    setRestoreTrashJobTestHooks({ enableTestStream: true });
-    const server = startServer(0);
-    try {
-      const res = await fetch(new URL("/api/storage/trash/restore/test-stream", server.url));
-      expect(res.status).toBe(200);
-      expect(res.headers.get("content-type") ?? "").toContain("text/plain");
-      const body = await res.text();
-      expect(body).toContain("chunk-0");
-      expect(body).toContain("chunk-7");
-    } finally {
-      await server.stop(true);
-    }
+    await withTestStreamRoute(
+      () => {
+        process.env.OPENCODEX_CLEANUP_TEST_HOOKS = "1";
+        setRestoreTrashJobTestHooks({ enableTestStream: true });
+      },
+      async (serverUrl) => {
+        const res = await fetch(new URL("/api/storage/trash/restore/test-stream", serverUrl));
+        expect(res.status).toBe(200);
+        expect(res.headers.get("content-type") ?? "").toContain("text/plain");
+        const body = await res.text();
+        expect(body).toContain("chunk-0");
+        expect(body).toContain("chunk-7");
+      },
+    );
   }, { timeout: 10_000 });
 
   test("blocked worker keeps /healthz and streaming response responsive", async () => {


### PR DESCRIPTION
## Summary

Follow-up for merged [#571](https://github.com/lidge-jun/opencodex/pull/571) / CodeRabbit review:

- Codex P2s on #571 (short-write loop + `renameAtomicFile`) were already merged in `ba53cc0e` / squash `c573bd9d`.
- Remaining CodeRabbit ask: expand regression coverage for `GET /api/storage/trash/restore/test-stream`.

### Added coverage
1. Env unset + hooks enabled → JSON 404 `{ error: "not_available" }` (already present; kept)
2. Env=`1` but stream hook null → JSON 404 (new)
3. Env=`1` + `enableTestStream` → `200 text/plain` with chunked body (new)

## Test plan
- [x] `bun test tests/storage-restore-job-responsive.test.ts --test-name-pattern test-stream`
- [x] `bun run typecheck`
- [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when restore test streaming is unavailable, returning a clear not-available response.
  * Verified that enabled restore test streaming responds successfully with the expected stream content.
  * Confirmed health and streaming endpoints remain responsive during blocked restore processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->