### PR TITLE
fix(release): baseline preview notes on last prior release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,20 +154,15 @@ jobs:
 
           echo "Cross-platform CI passed for ${GITHUB_SHA}: ${ci_url}"
 
-          # Compare within the release channel so preview and stable gates use matching history.
-          if [[ "$RELEASE_VERSION" == *-preview.* ]]; then
-            previous_tag="$(
-              git tag --merged HEAD --list 'v[0-9]*' --sort=-v:refname |
-                grep -- '-preview\.' |
-                head -n 1 || true
-            )"
-          else
-            previous_tag="$(
-              git tag --merged HEAD --list 'v[0-9]*' --sort=-v:refname |
-                grep -v -- '-preview\.' |
-                head -n 1 || true
-            )"
-          fi
+          # Notes / service baseline:
+          # - Preview: newest prior release of either channel (stable or preview). A
+          #   preview→preview-only baseline skips a shipped stable and restates it.
+          # - Stable: newest prior stable only (matching preview carry adjusts the
+          #   generate-notes range separately below).
+          previous_tag="$(
+            git tag --merged HEAD --list 'v[0-9]*' |
+              bun scripts/release-notes.ts previous-release-tag "$RELEASE_VERSION"
+          )"
           if [ -n "$previous_tag" ]; then
             changed_files="$(git diff --name-only "${previous_tag}..HEAD")"
           else
@@ -299,22 +294,12 @@ jobs:
             exit 1
           fi
 
-          # Channel previous tag (stable↔stable / preview↔preview) for the Full Changelog link.
-          if [[ "$RELEASE_VERSION" == *-preview.* ]]; then
-            previous_tag="$(
-              git tag --merged HEAD --list 'v[0-9]*' --sort=-v:refname |
-                grep -- '-preview\.' |
-                grep -vx "$release_tag" |
-                head -n 1 || true
-            )"
-          else
-            previous_tag="$(
-              git tag --merged HEAD --list 'v[0-9]*' --sort=-v:refname |
-                grep -v -- '-preview\.' |
-                grep -vx "$release_tag" |
-                head -n 1 || true
-            )"
-          fi
+          # Channel previous tag for Full Changelog + default notes baseline.
+          # Preview baselines any prior release; stable baselines prior stable only.
+          previous_tag="$(
+            git tag --merged HEAD --list 'v[0-9]*' |
+              bun scripts/release-notes.ts previous-release-tag "$RELEASE_VERSION"
+          )"
           npm_metadata="Published to npm as \`@bitkyc08/opencodex@${RELEASE_VERSION}\` with dist-tag \`${NPM_DIST_TAG}\`."
 
           # Preview builds must be marked prerelease so GitHub "latest" keeps pointing at the

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -8,9 +8,14 @@
  *   bun scripts/release-notes.ts strip-carried <body-file>
  *   bun scripts/release-notes.ts matching-preview-tag <version>
  *   bun scripts/release-notes.ts matching-preview-tags <version>
+ *   bun scripts/release-notes.ts previous-release-tag <version>
  *   bun scripts/release-notes.ts has-meaningful [body-file]
  *   bun scripts/release-notes.ts assemble --npm-metadata ... --out ...
  */
+
+function sortVersionTagsAscending(tags: string[]): string[] {
+  return [...tags].sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" }));
+}
 
 /** Newest matching preview tag for a stable version, or null. */
 export function matchingPreviewTag(version: string, tags: string[]): string | null {
@@ -29,8 +34,29 @@ export function matchingPreviewTags(version: string, tags: string[]): string[] {
   const matches = tags
     .map(tag => tag.trim())
     .filter(tag => tag.startsWith(prefix));
-  matches.sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" }));
-  return matches;
+  return sortVersionTagsAscending(matches);
+}
+
+/**
+ * Previous release tag used as the generate-notes / changelog baseline.
+ *
+ * - Preview releases: newest prior tag of either channel (stable or preview).
+ *   Channel-isolated preview→preview baselines skip a shipped stable and restate
+ *   that stable's changelog (e.g. 2.7.41-preview → 2.7.43-preview after 2.7.42).
+ * - Stable releases: newest prior stable only. Matching preview carry adjusts the
+ *   notes range start separately when assembling latest notes.
+ */
+export function previousReleaseNotesTag(version: string, tags: string[]): string | null {
+  if (!version) return null;
+  const releaseTag = version.startsWith("v") ? version : `v${version}`;
+  const candidates = tags
+    .map(tag => tag.trim())
+    .filter(tag => /^v\d/.test(tag) && tag !== releaseTag);
+  const filtered = version.includes("-preview.")
+    ? candidates
+    : candidates.filter(tag => !tag.includes("-preview."));
+  const sorted = sortVersionTagsAscending(filtered);
+  return sorted.length === 0 ? null : sorted[sorted.length - 1]!;
 }
 
 /** Drop npm blurb, Commits section, and Full Changelog link from a prior release body. */
@@ -212,7 +238,7 @@ async function main(argv: string[]): Promise<void> {
     return;
   }
 
-  if (cmd === "matching-preview-tag" || cmd === "matching-preview-tags") {
+  if (cmd === "matching-preview-tag" || cmd === "matching-preview-tags" || cmd === "previous-release-tag") {
     const version = rest[0];
     if (!version) {
       console.error(`Usage: bun scripts/release-notes.ts ${cmd} <version>`);
@@ -222,6 +248,11 @@ async function main(argv: string[]): Promise<void> {
     const tags = tagsText.split(/\r?\n/);
     if (cmd === "matching-preview-tag") {
       const tag = matchingPreviewTag(version, tags);
+      if (tag) process.stdout.write(tag + "\n");
+      return;
+    }
+    if (cmd === "previous-release-tag") {
+      const tag = previousReleaseNotesTag(version, tags);
       if (tag) process.stdout.write(tag + "\n");
       return;
     }
@@ -278,6 +309,7 @@ Usage:
   bun scripts/release-notes.ts join-carried --out <file> <part-file>...
   bun scripts/release-notes.ts matching-preview-tag <version>   # tags on stdin
   bun scripts/release-notes.ts matching-preview-tags <version>  # tags on stdin, oldest→newest
+  bun scripts/release-notes.ts previous-release-tag <version>   # tags on stdin
   bun scripts/release-notes.ts assemble --npm-metadata ... --out ...`);
   process.exit(1);
 }

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -13,8 +13,70 @@
  *   bun scripts/release-notes.ts assemble --npm-metadata ... --out ...
  */
 
+type ParsedReleaseTag = {
+  major: number;
+  minor: number;
+  patch: number;
+  /** null = stable release; otherwise the SemVer prerelease identifier string. */
+  prerelease: string | null;
+};
+
+function parseReleaseTag(tag: string): ParsedReleaseTag | null {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/.exec(tag.trim());
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ?? null,
+  };
+}
+
+/** SemVer identifier compare: numeric parts by number; numeric < non-numeric. */
+function comparePrereleaseIds(a: string, b: string): number {
+  const aParts = a.split(".");
+  const bParts = b.split(".");
+  const len = Math.max(aParts.length, bParts.length);
+  for (let i = 0; i < len; i += 1) {
+    const ap = aParts[i];
+    const bp = bParts[i];
+    if (ap === undefined) return -1;
+    if (bp === undefined) return 1;
+    const aNum = /^\d+$/.test(ap);
+    const bNum = /^\d+$/.test(bp);
+    if (aNum && bNum) {
+      const diff = Number(ap) - Number(bp);
+      if (diff !== 0) return diff;
+      continue;
+    }
+    if (aNum !== bNum) return aNum ? -1 : 1;
+    const cmp = ap.localeCompare(bp);
+    if (cmp !== 0) return cmp;
+  }
+  return 0;
+}
+
+/**
+ * Ascending SemVer-aware tag compare. Stable ranks after prereleases with the
+ * same core version (`v2.7.42-preview.*` < `v2.7.42`).
+ */
+export function compareReleaseTags(a: string, b: string): number {
+  const pa = parseReleaseTag(a);
+  const pb = parseReleaseTag(b);
+  if (!pa || !pb) {
+    return a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" });
+  }
+  if (pa.major !== pb.major) return pa.major - pb.major;
+  if (pa.minor !== pb.minor) return pa.minor - pb.minor;
+  if (pa.patch !== pb.patch) return pa.patch - pb.patch;
+  if (pa.prerelease === null && pb.prerelease === null) return 0;
+  if (pa.prerelease === null) return 1;
+  if (pb.prerelease === null) return -1;
+  return comparePrereleaseIds(pa.prerelease, pb.prerelease);
+}
+
 function sortVersionTagsAscending(tags: string[]): string[] {
-  return [...tags].sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" }));
+  return [...tags].sort(compareReleaseTags);
 }
 
 /** Newest matching preview tag for a stable version, or null. */
@@ -51,7 +113,7 @@ export function previousReleaseNotesTag(version: string, tags: string[]): string
   const releaseTag = version.startsWith("v") ? version : `v${version}`;
   const candidates = tags
     .map(tag => tag.trim())
-    .filter(tag => /^v\d/.test(tag) && tag !== releaseTag);
+    .filter(tag => /^v\d/.test(tag) && compareReleaseTags(tag, releaseTag) < 0);
   const filtered = version.includes("-preview.")
     ? candidates
     : candidates.filter(tag => !tag.includes("-preview."));

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -266,8 +266,14 @@ describe("GitHub Actions hardening", () => {
     expect(workflow).toContain("bun scripts/release-notes.ts strip-carried");
     expect(workflow).toContain("bun scripts/release-notes.ts assemble");
     expect(workflow).toContain("bun scripts/release-notes.ts matching-preview-tags");
+    expect(workflow).toContain("bun scripts/release-notes.ts previous-release-tag");
     expect(workflow).toContain("bun scripts/release-notes.ts has-meaningful");
     expect(workflow).toContain("bun scripts/release-notes.ts join-carried");
+    // Preview notes must baseline any prior release (stable or preview), not preview-only.
+    expect(workflow).toContain('bun scripts/release-notes.ts previous-release-tag "$RELEASE_VERSION"');
+    expect(workflow).not.toMatch(
+      /RELEASE_VERSION" == \*-preview\.\*[\s\S]{0,200}grep -- '-preview\\.'/,
+    );
     expect(workflow).toContain("releases/tags/");
     expect(workflow).toContain('gh api "repos/${GITHUB_REPOSITORY}" --jq \'.full_name\'');
     expect(workflow).toContain("git merge-base --is-ancestor");

--- a/tests/release-notes.test.ts
+++ b/tests/release-notes.test.ts
@@ -83,6 +83,20 @@ describe("previousReleaseNotesTag", () => {
     expect(previousReleaseNotesTag("2.7.43-preview.1", ["v2.7.43-preview.1"])).toBeNull();
     expect(previousReleaseNotesTag("2.7.43", ["v2.7.43-preview.1"])).toBeNull();
   });
+
+  test("ignores candidate tags newer than the target release", () => {
+    expect(previousReleaseNotesTag("2.7.43-preview.20260728", [
+      "v2.7.42",
+      "v2.8.0-preview.1",
+    ])).toBe("v2.7.42");
+  });
+
+  test("ranks a stable tag after its matching preview when both are prior", () => {
+    expect(previousReleaseNotesTag("2.7.43-preview.20260728", [
+      "v2.7.42-preview.20260727",
+      "v2.7.42",
+    ])).toBe("v2.7.42");
+  });
 });
 
 describe("stripCarriedReleaseNotes", () => {

--- a/tests/release-notes.test.ts
+++ b/tests/release-notes.test.ts
@@ -6,6 +6,7 @@ import {
   joinCarriedPreviewNotes,
   matchingPreviewTag,
   matchingPreviewTags,
+  previousReleaseNotesTag,
   selectNewestCarriedPreviewTag,
   stripCarriedReleaseNotes,
   stripGenerateNotesCompareLink,
@@ -49,6 +50,38 @@ describe("matchingPreviewTags", () => {
       "v2.7.39-preview.20260725.2",
       "v2.7.39-preview.20260725.10",
     ]);
+  });
+});
+
+describe("previousReleaseNotesTag", () => {
+  test("preview baselines the newest prior release of either channel", () => {
+    expect(previousReleaseNotesTag("2.7.43-preview.20260728", [
+      "v2.7.41-preview.20260726",
+      "v2.7.41",
+      "v2.7.42",
+      "v2.7.43-preview.20260728",
+    ])).toBe("v2.7.42");
+  });
+
+  test("preview after preview (no stable in between) keeps the previous preview", () => {
+    expect(previousReleaseNotesTag("2.7.43-preview.20260729", [
+      "v2.7.42",
+      "v2.7.43-preview.20260728",
+      "v2.7.43-preview.20260729",
+    ])).toBe("v2.7.43-preview.20260728");
+  });
+
+  test("stable baselines the newest prior stable only", () => {
+    expect(previousReleaseNotesTag("2.7.43", [
+      "v2.7.42",
+      "v2.7.43-preview.20260728",
+      "v2.7.43",
+    ])).toBe("v2.7.42");
+  });
+
+  test("returns null when no eligible prior tag exists", () => {
+    expect(previousReleaseNotesTag("2.7.43-preview.1", ["v2.7.43-preview.1"])).toBeNull();
+    expect(previousReleaseNotesTag("2.7.43", ["v2.7.43-preview.1"])).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- Preview release notes now baseline the newest prior **stable or preview** tag, so `2.7.43-preview` after `2.7.42` uses `v2.7.42 → v2.7.43-preview` instead of restating `v2.7.41-preview → v2.7.42`.
- Stable releases still baseline the prior stable only and keep the existing matching-preview carry into latest.
- Adds `previousReleaseNotesTag` helper + CLI + regressions for the skipped-preview-after-stable case.

## Test plan
- [x] `bun test --isolate tests/release-notes.test.ts tests/ci-workflows.test.ts`
- [ ] Dry-run or next preview cut: confirm Full Changelog / generate-notes start at the prior stable when no intervening preview exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release-note baselining for stable and preview releases.
  * Ensured “Full Changelog” comparisons consistently reference the correct previous release.

* **Tests**
  * Added coverage for preview-to-stable, preview-to-preview, and fallback release scenarios.
  * Strengthened validation of release workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->