### PR TITLE
fix(server): harden drain-and-restart spawn failure path (#580 follow-up)

### DIFF
--- a/src/server/management/system-restart.ts
+++ b/src/server/management/system-restart.ts
@@ -11,6 +11,9 @@
  *   Task Scheduler ERRORLEVEL loop) bring the proxy back.
  * - Otherwise: detached `ocx start --port <live>` (bypasses ensure's
  *   codexAutoStart gate), mark recycle so exit cleanup keeps injection, exit(0).
+ * - If detached spawn fails (sync throw or pre-start `error`): exit(1) without
+ *   markRecycling — after drain the listen socket is already closed, so a latch
+ *   reset cannot recover serving.
  */
 import { spawn } from "node:child_process";
 import {
@@ -31,7 +34,8 @@ export interface SystemRestartIo {
   drainAndShutdown?: typeof drainAndShutdown;
   isServiceInstalled?: () => boolean;
   isSupervisedServiceChild?: () => boolean;
-  spawnStart?: (port?: number) => void;
+  /** Must resolve only after the replacement process has actually started. */
+  spawnStart?: (port?: number) => void | Promise<void>;
   markRecycling?: () => void;
   exitProcess?: (code: number) => void;
   schedule?: (fn: () => void | Promise<void>, ms: number) => void;
@@ -63,18 +67,40 @@ function isSupervisedServiceChild(): boolean {
   return process.env.OCX_SERVICE === "1" && isServiceInstalled();
 }
 
-function spawnDetachedStart(port?: number): void {
+function spawnDetachedStart(port?: number): Promise<void> {
   const args = [process.argv[1], "start"];
   if (typeof port === "number" && Number.isFinite(port) && port > 0 && port <= 65535) {
     args.push("--port", String(Math.trunc(port)));
   }
-  const child = spawn(process.execPath, args, {
-    detached: true,
-    stdio: "ignore",
-    windowsHide: true,
-    env: { ...process.env, OCX_SERVICE: "1" },
+  return new Promise<void>((resolve, reject) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(process.execPath, args, {
+        detached: true,
+        stdio: "ignore",
+        windowsHide: true,
+        env: { ...process.env, OCX_SERVICE: "1" },
+      });
+    } catch (err) {
+      reject(err);
+      return;
+    }
+    let settled = false;
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      fn();
+    };
+    child.once("error", (err) => {
+      finish(() => reject(err));
+    });
+    child.once("spawn", () => {
+      finish(() => {
+        child.unref();
+        resolve();
+      });
+    });
   });
-  child.unref();
 }
 
 /**
@@ -106,9 +132,18 @@ export function acceptSystemRestart(io: SystemRestartIo = restartIo): {
         return;
       }
       const port = (io.listenPort ?? resolveListenPort)();
-      (io.spawnStart ?? spawnDetachedStart)(port);
+      const exitProcess = io.exitProcess ?? ((code: number) => { process.exit(code); });
+      try {
+        await (io.spawnStart ?? spawnDetachedStart)(port);
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : "unknown error";
+        console.warn(`⚠️  Drain-and-restart spawn failed (${detail}); exiting without replacement`);
+        // Listen socket is already stopped; do not markRecycling — no child to inherit fences.
+        exitProcess(1);
+        return;
+      }
       (io.markRecycling ?? markRecyclingForExit)();
-      (io.exitProcess ?? ((code: number) => { process.exit(code); }))(0);
+      exitProcess(0);
     }, 200);
   }
 

--- a/src/server/management/system-restart.ts
+++ b/src/server/management/system-restart.ts
@@ -13,7 +13,10 @@
  *   codexAutoStart gate), mark recycle so exit cleanup keeps injection, exit(0).
  * - If detached spawn fails (sync throw or pre-start `error`): exit(1) without
  *   markRecycling — after drain the listen socket is already closed, so a latch
- *   reset cannot recover serving.
+ *   reset cannot recover serving. Clear inherited `OCX_SERVICE` so exit cleanup
+ *   can restore Codex/Grok fences (ensure/tray daemons set the marker without a
+ *   real supervisor). Log only a stable errno code — never the raw message
+ *   (paths in ENOENT often include the OS username).
  */
 import { spawn } from "node:child_process";
 import {
@@ -65,6 +68,15 @@ function resolveListenPort(): number | undefined {
 
 function isSupervisedServiceChild(): boolean {
   return process.env.OCX_SERVICE === "1" && isServiceInstalled();
+}
+
+/** Stable, path-free spawn failure label for logs (never interpolate err.message). */
+function spawnFailureCode(err: unknown): string {
+  if (err && typeof err === "object" && "code" in err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (typeof code === "string" && code.length > 0 && code.length <= 64) return code;
+  }
+  return "spawn_failed";
 }
 
 function spawnDetachedStart(port?: number): Promise<void> {
@@ -136,9 +148,13 @@ export function acceptSystemRestart(io: SystemRestartIo = restartIo): {
       try {
         await (io.spawnStart ?? spawnDetachedStart)(port);
       } catch (err) {
-        const detail = err instanceof Error ? err.message : "unknown error";
-        console.warn(`⚠️  Drain-and-restart spawn failed (${detail}); exiting without replacement`);
+        console.warn(
+          `⚠️  Drain-and-restart spawn failed (${spawnFailureCode(err)}); exiting without replacement`,
+        );
         // Listen socket is already stopped; do not markRecycling — no child to inherit fences.
+        // ensure/tray children inherit OCX_SERVICE=1 without an installed service; clear it so
+        // syncCleanup can restore Codex/Grok fences instead of leaving clients pointed at a dead port.
+        delete process.env.OCX_SERVICE;
         exitProcess(1);
         return;
       }

--- a/tests/system-restart.test.ts
+++ b/tests/system-restart.test.ts
@@ -87,25 +87,40 @@ describe("acceptSystemRestart", () => {
   test("spawn sync throw exits 1 without marking recycle", async () => {
     const calls: string[] = [];
     let scheduled: (() => void | Promise<void>) | null = null;
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
 
-    acceptSystemRestart({
-      isDraining: () => false,
-      getActiveTurnCount: () => 0,
-      isSupervisedServiceChild: () => false,
-      listenPort: () => 10123,
-      schedule: (fn) => { scheduled = fn; },
-      setDraining: () => {},
-      drainAndShutdown: async () => { calls.push("drain"); },
-      spawnStart: () => {
-        calls.push("start");
-        throw new Error("ENOENT");
-      },
-      markRecycling: () => { calls.push("recycle"); },
-      exitProcess: (code) => { calls.push(`exit:${code}`); },
-    });
+    try {
+      acceptSystemRestart({
+        isDraining: () => false,
+        getActiveTurnCount: () => 0,
+        isSupervisedServiceChild: () => false,
+        listenPort: () => 10123,
+        schedule: (fn) => { scheduled = fn; },
+        setDraining: () => {},
+        drainAndShutdown: async () => { calls.push("drain"); },
+        spawnStart: () => {
+          calls.push("start");
+          const err = new Error(
+            "ENOENT: no such file or directory, uv_spawn 'C:\\Users\\Alice\\AppData\\Local\\bun\\bun.exe'",
+          ) as NodeJS.ErrnoException;
+          err.code = "ENOENT";
+          throw err;
+        },
+        markRecycling: () => { calls.push("recycle"); },
+        exitProcess: (code) => { calls.push(`exit:${code}`); },
+      });
 
-    await scheduled!();
-    expect(calls).toEqual(["drain", "start", "exit:1"]);
+      await scheduled!();
+      expect(calls).toEqual(["drain", "start", "exit:1"]);
+      expect(warnings.some((w) => w.includes("ENOENT"))).toBe(true);
+      expect(warnings.some((w) => /Alice|AppData|bun\.exe/i.test(w))).toBe(false);
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 
   test("spawn async rejection exits 1 without marking recycle", async () => {
@@ -130,6 +145,39 @@ describe("acceptSystemRestart", () => {
 
     await scheduled!();
     expect(calls).toEqual(["drain", "start", "exit:1"]);
+  });
+
+  test("spawn failure clears OCX_SERVICE so exit cleanup can restore fences", async () => {
+    const calls: string[] = [];
+    let scheduled: (() => void | Promise<void>) | null = null;
+    const prev = process.env.OCX_SERVICE;
+    process.env.OCX_SERVICE = "1";
+
+    try {
+      acceptSystemRestart({
+        isDraining: () => false,
+        getActiveTurnCount: () => 0,
+        // ensure/tray: marker set, but no installed service → unsupervised spawn path
+        isSupervisedServiceChild: () => false,
+        listenPort: () => 10123,
+        schedule: (fn) => { scheduled = fn; },
+        setDraining: () => {},
+        drainAndShutdown: async () => { calls.push("drain"); },
+        spawnStart: () => {
+          calls.push("start");
+          throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        },
+        markRecycling: () => { calls.push("recycle"); },
+        exitProcess: (code) => { calls.push(`exit:${code}`); },
+      });
+
+      await scheduled!();
+      expect(calls).toEqual(["drain", "start", "exit:1"]);
+      expect(process.env.OCX_SERVICE).toBeUndefined();
+    } finally {
+      if (prev === undefined) delete process.env.OCX_SERVICE;
+      else process.env.OCX_SERVICE = prev;
+    }
   });
 
   test("does not schedule a second drain while already draining", async () => {

--- a/tests/system-restart.test.ts
+++ b/tests/system-restart.test.ts
@@ -84,6 +84,54 @@ describe("acceptSystemRestart", () => {
     expect(calls).toEqual(["drain", "exit:1"]);
   });
 
+  test("spawn sync throw exits 1 without marking recycle", async () => {
+    const calls: string[] = [];
+    let scheduled: (() => void | Promise<void>) | null = null;
+
+    acceptSystemRestart({
+      isDraining: () => false,
+      getActiveTurnCount: () => 0,
+      isSupervisedServiceChild: () => false,
+      listenPort: () => 10123,
+      schedule: (fn) => { scheduled = fn; },
+      setDraining: () => {},
+      drainAndShutdown: async () => { calls.push("drain"); },
+      spawnStart: () => {
+        calls.push("start");
+        throw new Error("ENOENT");
+      },
+      markRecycling: () => { calls.push("recycle"); },
+      exitProcess: (code) => { calls.push(`exit:${code}`); },
+    });
+
+    await scheduled!();
+    expect(calls).toEqual(["drain", "start", "exit:1"]);
+  });
+
+  test("spawn async rejection exits 1 without marking recycle", async () => {
+    const calls: string[] = [];
+    let scheduled: (() => void | Promise<void>) | null = null;
+
+    acceptSystemRestart({
+      isDraining: () => false,
+      getActiveTurnCount: () => 0,
+      isSupervisedServiceChild: () => false,
+      listenPort: () => 10123,
+      schedule: (fn) => { scheduled = fn; },
+      setDraining: () => {},
+      drainAndShutdown: async () => { calls.push("drain"); },
+      spawnStart: async () => {
+        calls.push("start");
+        throw new Error("spawn error before start");
+      },
+      markRecycling: () => { calls.push("recycle"); },
+      exitProcess: (code) => { calls.push(`exit:${code}`); },
+    });
+
+    await scheduled!();
+    expect(calls).toEqual(["drain", "start", "exit:1"]);
+  });
+
   test("does not schedule a second drain while already draining", async () => {
     let scheduled = 0;
     const result = acceptSystemRestart({


### PR DESCRIPTION
## Summary
- Follow-up to #580 / issue-author note: wait for detached `ocx start` `spawn` success before `markRecyclingForExit` + `exit(0)`.
- On sync spawn throw or pre-start `error`, exit `1` without recycling so a drained process does not stay latched or die with no replacement.
- Adds regression coverage for sync throw and async rejection paths.

## Test plan
- [x] `bun test tests/system-restart.test.ts`
- [x] `bun run typecheck`
- [x] `bun run privacy:scan`
- [ ] CI green on Linux/Windows/macOS
