### PR TITLE
fix(ci): require non-empty bug Reproduction

### DIFF
--- a/.github/scripts/issue-quality.cjs
+++ b/.github/scripts/issue-quality.cjs
@@ -374,7 +374,10 @@ function detectIssueKind(issue) {
 // ---------------------------------------------------------------------------
 
 function isEmpty(text) {
-  return clean(text).length === 0;
+  const c = clean(text);
+  if (c.length === 0) return true;
+  // Stand-ins like "...", "…", "---" are not actionable report content.
+  return /^[\p{P}\p{S}\s]+$/u.test(c);
 }
 
 function allSameCanonical(sections) {
@@ -641,6 +644,17 @@ function validateIssue(issue) {
       } else {
         reasons.push("Both Summary and Reproduction are empty.");
         guidance.push("Describe what happened and how to reproduce it.");
+      }
+    } else {
+      // Each mapped field is required on its own — a filled Summary with an
+      // empty / ellipsis Reproduction (e.g. #598) must not pass.
+      if (isEmpty(summary)) {
+        reasons.push("Summary is empty.");
+        guidance.push("Describe what happened (the symptom or error).");
+      }
+      if (isEmpty(repro)) {
+        reasons.push("Reproduction is empty.");
+        guidance.push("List the exact steps to reproduce the problem.");
       }
     }
 

--- a/.github/scripts/issue-quality.test.cjs
+++ b/.github/scripts/issue-quality.test.cjs
@@ -362,8 +362,8 @@ describe("validateIssue - feature", () => {
       assert.equal(result.kind, "feature");
       assert.equal(result.valid, false, `Expected terse goal "${goal}" to be invalid`);
       assert.ok(
-        result.reasons.some((r) => r.includes("too vague")),
-        `Expected too vague reason for "${goal}", got: ${result.reasons.join(", ")}`,
+        result.reasons.some((r) => r.includes("too vague") || /missing or empty/i.test(r)),
+        `Expected too vague or empty reason for "${goal}", got: ${result.reasons.join(", ")}`,
       );
     }
   });
@@ -534,6 +534,70 @@ describe("validateIssue - bug", () => {
     const result = validateIssue({ title: "Bug", body, labels: ["bug"] });
     assert.equal(result.kind, "bug");
     assert.equal(result.valid, false);
+  });
+
+  it("rejects a bug with Summary filled but Reproduction empty", () => {
+    const body = [
+      "### Client or integration",
+      "Codex CLI",
+      "### Area",
+      "CLI",
+      "### Summary",
+      "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+      "### Reproduction",
+      "No response",
+      "### Version",
+      "2.7.42",
+      "### Operating system",
+      "macOS",
+    ].join("\n");
+    const result = validateIssue({ title: "Open Codex Error", body, labels: ["bug"] });
+    assert.equal(result.kind, "bug");
+    assert.equal(result.valid, false);
+    assert.ok(result.reasons.some((r) => /Reproduction is empty/i.test(r)));
+    assert.ok(!result.reasons.some((r) => /Summary is empty/i.test(r)));
+  });
+
+  it("rejects a bug whose Reproduction is only an ellipsis (#598)", () => {
+    const body = [
+      "### Client or integration",
+      "Codex CLI",
+      "### Area",
+      "CLI",
+      "### Summary",
+      "{\"detail\":\"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.\"}",
+      "### Reproduction",
+      "...",
+      "### Version",
+      "2.7.42",
+      "### Operating system",
+      "mac os",
+    ].join("\n");
+    const result = validateIssue({ title: "Open Codex Error", body, labels: ["bug"] });
+    assert.equal(result.kind, "bug");
+    assert.equal(result.valid, false);
+    assert.ok(result.reasons.some((r) => /Reproduction is empty/i.test(r)));
+  });
+
+  it("rejects a bug with Reproduction filled but Summary empty", () => {
+    const body = [
+      "### Client or integration",
+      "Codex CLI",
+      "### Area",
+      "CLI",
+      "### Summary",
+      "",
+      "### Reproduction",
+      "1. Run ocx start\n2. Send a request",
+      "### Version",
+      "2.7.42",
+      "### Operating system",
+      "macOS",
+    ].join("\n");
+    const result = validateIssue({ title: "Crash", body, labels: ["bug"] });
+    assert.equal(result.kind, "bug");
+    assert.equal(result.valid, false);
+    assert.ok(result.reasons.some((r) => /Summary is empty/i.test(r)));
   });
 
   it("accepts a terse real crash report", () => {


### PR DESCRIPTION
## Summary
- Bug reports now fail the issue-quality gate if **either** Summary or Reproduction is empty (not only when both are).
- Treat punctuation-only stand-ins like `...` / `…` as empty so #598-shaped reports cannot soft-pass with an ellipsis Reproduction.
- Soft-pass for substantial non-English freeform bodies without English Summary/Reproduction headings (#545) is unchanged.

## Test plan
- [x] `node --test .github/scripts/issue-quality.test.cjs` (86 pass)
- [ ] After merge + promote to `main`, open a throwaway bug with Summary filled and Reproduction `...` and confirm Enforce issue quality closes it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue validation to recognize punctuation-only or placeholder content as empty.
  * Bug reports with missing summaries or reproduction steps now receive specific guidance identifying the incomplete section.
  * Enhanced validation for incomplete feature-request goals.

* **Tests**
  * Added coverage for blank, placeholder, and punctuation-only bug report fields.
  * Updated validation tests to verify field-specific feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->