### PR TITLE
fix(catalog): stop respawning the codex --version probe on every catalog read

### DIFF
--- a/src/codex/catalog/bundled.ts
+++ b/src/codex/catalog/bundled.ts
@@ -151,14 +151,21 @@ export function loadBundledCodexCatalog(deps: BundledCatalogDeps = {}): RawCatal
   let cacheKey: string | null = null;
   const candidates = deps.commandCandidates?.() ?? (() => {
     const resolved = resolveAndPersistCodexRuntime({
-      execFileSync: execFile,
+      // Forward an INJECTED execFileSync only. Passing the real one unconditionally made
+      // resolveCacheKey() bail out (it refuses to memoize injected-dep resolves), so every
+      // catalog read re-ran the ~1s `codex --version` probe even on a warm cache hit.
+      ...(deps.execFileSync ? { execFileSync: deps.execFileSync } : {}),
       configDir: deps.configDir,
       env: deps.env,
       platform: deps.platform,
       existsSync: deps.existsSync,
       readFileSync: deps.readFileSync,
       now: deps.now,
-      discoverAlternatives: deps.discoverAlternatives,
+      // Catalog loading only consumes `resolved.runtime.command`, never `newerAvailable`.
+      // Full PATH discovery probes every candidate launcher (100+ on a dev machine, ~1.2s),
+      // which alone can exceed the 3s budget `ocx claude` allows /api/claude-code. Priority
+      // selection is identical either way; callers wanting discovery diagnostics opt in.
+      discoverAlternatives: deps.discoverAlternatives ?? false,
     });
     if (useCache) {
       cacheKey = [

--- a/src/codex/runtime.ts
+++ b/src/codex/runtime.ts
@@ -510,7 +510,7 @@ export function resolveAndPersistCodexRuntime(
   const selectionUnchanged = persistedRuntime !== null
     && persistedRuntime.command === result.runtime.command
     && persistedRuntime.source === result.runtime.source
-    && (persistedRuntime.selectedVersion ?? null) === result.runtime.version;
+    && (persistedRuntime.selectedVersion ?? null) === (result.runtime.version ?? null);
   if (result.runtime.command && result.runtime.source !== "fallback" && !selectionUnchanged) {
     try {
       persistCodexRuntime(result.runtime, deps);

--- a/src/codex/runtime.ts
+++ b/src/codex/runtime.ts
@@ -502,7 +502,16 @@ export function resolveAndPersistCodexRuntime(
   deps: ResolveCodexRuntimeDeps = {},
 ): ResolveCodexRuntimeResult {
   const result = resolveCodexRuntime(deps);
-  if (result.runtime.command && result.runtime.source !== "fallback") {
+  // Only WRITE when the selection actually changed. persistCodexRuntime() clears the
+  // in-process resolve memo and persistedRuntimeCacheStamp() folds `updatedAt` into the
+  // cache key, so an unconditional rewrite made every caller re-run the ~1s
+  // `codex --version` probe even when the resolved runtime was byte-identical.
+  const persistedRuntime = loadPersistedCodexRuntime(deps);
+  const selectionUnchanged = persistedRuntime !== null
+    && persistedRuntime.command === result.runtime.command
+    && persistedRuntime.source === result.runtime.source
+    && (persistedRuntime.selectedVersion ?? null) === result.runtime.version;
+  if (result.runtime.command && result.runtime.source !== "fallback" && !selectionUnchanged) {
     try {
       persistCodexRuntime(result.runtime, deps);
     } catch (error) {

--- a/tests/codex-runtime.test.ts
+++ b/tests/codex-runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import {
@@ -285,6 +285,124 @@ describe("resolveCodexRuntime", () => {
     expect(failed.runtime.command).toBe("C:\\keep\\codex.exe");
     expect(typeof failed.persistError).toBe("string");
     expect(failed.persistError!.length).toBeGreaterThan(0);
+  });
+
+  test("repeated catalog reads reuse the runtime probe instead of respawning it", async () => {
+    const { chmodSync, mkdirSync } = await import("node:fs");
+    const {
+      loadBundledCodexCatalog,
+      resetBundledCatalogCacheForTests,
+    } = await import("../src/codex/catalog/bundled");
+
+    const home = tempConfigDir();
+    const binDir = join(home, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const bin = process.platform === "win32" ? join(binDir, "codex.cmd") : join(binDir, "codex");
+
+    // Count --version probes by having the launcher append a line per invocation.
+    const probeLog = join(binDir, "probes.log");
+    const catalog = JSON.stringify({
+      models: [{
+        slug: "gpt-5.5",
+        base_instructions: "x",
+        supported_reasoning_levels: [{ effort: "medium", description: "medium" }],
+        default_reasoning_level: "medium",
+      }],
+    });
+    writeFileSync(join(binDir, "catalog.json"), `${catalog}\n`, "utf8");
+    if (process.platform === "win32") {
+      writeFileSync(bin, [
+        "@echo off",
+        `if "%~1"=="--version" (`,
+        `  echo probe>>"%~dp0probes.log"`,
+        "  echo codex-cli 0.145.0-alpha.30",
+        "  exit /b 0",
+        ")",
+        `type "%~dp0catalog.json"`,
+        "",
+      ].join("\r\n"), "utf8");
+    } else {
+      writeFileSync(bin, [
+        "#!/bin/sh",
+        `d=$(dirname "$0")`,
+        `if [ "$1" = "--version" ]; then`,
+        `  echo probe >> "$d/probes.log"`,
+        `  echo "codex-cli 0.145.0-alpha.30"`,
+        "  exit 0",
+        "fi",
+        `cat "$d/catalog.json"`,
+        "",
+      ].join("\n"), "utf8");
+      chmodSync(bin, 0o755);
+    }
+
+    const countProbes = (): number => {
+      if (!existsSync(probeLog)) return 0;
+      return readFileSync(probeLog, "utf8").split("\n").filter(line => line.trim().length > 0).length;
+    };
+
+    const previousHome = process.env.OPENCODEX_HOME;
+    const previousCli = process.env.CODEX_CLI_PATH;
+    const previousPath = process.env.PATH;
+    process.env.OPENCODEX_HOME = home;
+    process.env.CODEX_CLI_PATH = bin;
+    process.env.PATH = "";
+    resetCodexRuntimeResolveCacheForTests();
+    resetBundledCatalogCacheForTests();
+
+    try {
+      expect(loadBundledCodexCatalog()?.models?.[0]?.slug).toBe("gpt-5.5");
+      expect(countProbes()).toBeGreaterThan(0);
+
+      // The first read has no persisted selection yet, so it legitimately writes one and the
+      // write clears the resolve memo — the second read re-probes once and then persists
+      // nothing. From there the count must STOP GROWING.
+      expect(loadBundledCodexCatalog()?.models?.[0]?.slug).toBe("gpt-5.5");
+      const warm = countProbes();
+
+      // Warm reads must not respawn the probe. Two regressions broke this and made the count
+      // grow once per read: (1) loadBundledCodexCatalog forwarding its own already-defaulted
+      // execFileSync, which opts resolveCacheKey() out of memoizing, and (2) an unconditional
+      // persist whose `updatedAt` both clears the memo and rekeys it. Either one made every
+      // catalog read spawn `codex --version` (~1s), pushing /api/claude-code past the 3s
+      // budget ocx claude allows and silently skipping the gateway-model cache refresh.
+      for (let i = 0; i < 4; i++) {
+        expect(loadBundledCodexCatalog()?.models?.[0]?.slug).toBe("gpt-5.5");
+      }
+      expect(countProbes()).toBe(warm);
+    } finally {
+      if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+      else process.env.OPENCODEX_HOME = previousHome;
+      if (previousCli === undefined) delete process.env.CODEX_CLI_PATH;
+      else process.env.CODEX_CLI_PATH = previousCli;
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      resetCodexRuntimeResolveCacheForTests();
+      resetBundledCatalogCacheForTests();
+    }
+  });
+
+  test("repeat resolveAndPersistCodexRuntime keeps an unchanged selection's persisted stamp", () => {
+    const configDir = tempConfigDir();
+    const deps = {
+      configDir,
+      env: { CODEX_CLI_PATH: "C:\\keep\\codex.exe", PATH: "" },
+      platform: "win32" as const,
+      existsSync: () => true,
+      execFileSync: (() => "codex-cli 0.145.0-alpha.30") as RuntimeExecFile,
+    };
+
+    const first = resolveAndPersistCodexRuntime(deps);
+    expect(first.persistError).toBeUndefined();
+    const firstStamp = loadPersistedCodexRuntime({ configDir })?.updatedAt;
+    expect(typeof firstStamp).toBe("string");
+
+    // An identical selection must not rewrite the file: the write clears the resolve memo
+    // and its `updatedAt` feeds the memo cache key, so rewriting defeats caching entirely.
+    const second = resolveAndPersistCodexRuntime(deps);
+    expect(second.runtime.command).toBe(first.runtime.command);
+    expect(second.runtime.version).toBe(first.runtime.version);
+    expect(loadPersistedCodexRuntime({ configDir })?.updatedAt).toBe(firstStamp);
   });
 
   test("catalog clamp clears diagnostics inside deps.configDir when probe fails", async () => {

--- a/tests/codex-runtime.test.ts
+++ b/tests/codex-runtime.test.ts
@@ -324,13 +324,15 @@ describe("resolveCodexRuntime", () => {
     } else {
       writeFileSync(bin, [
         "#!/bin/sh",
-        `d=$(dirname "$0")`,
+        "d=${0%/*}",
         `if [ "$1" = "--version" ]; then`,
-        `  echo probe >> "$d/probes.log"`,
-        `  echo "codex-cli 0.145.0-alpha.30"`,
+        `  printf "%s\\n" probe >> "$d/probes.log"`,
+        `  printf "%s\\n" "codex-cli 0.145.0-alpha.30"`,
         "  exit 0",
         "fi",
-        `cat "$d/catalog.json"`,
+        `while IFS= read -r line || [ -n "$line" ]; do`,
+        `  printf "%s\\n" "$line"`,
+        `done < "$d/catalog.json"`,
         "",
       ].join("\n"), "utf8");
       chmodSync(bin, 0o755);
@@ -384,12 +386,14 @@ describe("resolveCodexRuntime", () => {
 
   test("repeat resolveAndPersistCodexRuntime keeps an unchanged selection's persisted stamp", () => {
     const configDir = tempConfigDir();
+    let now = 0;
     const deps = {
       configDir,
       env: { CODEX_CLI_PATH: "C:\\keep\\codex.exe", PATH: "" },
       platform: "win32" as const,
       existsSync: () => true,
       execFileSync: (() => "codex-cli 0.145.0-alpha.30") as RuntimeExecFile,
+      now: () => ++now,
     };
 
     const first = resolveAndPersistCodexRuntime(deps);
@@ -403,6 +407,38 @@ describe("resolveCodexRuntime", () => {
     expect(second.runtime.command).toBe(first.runtime.command);
     expect(second.runtime.version).toBe(first.runtime.version);
     expect(loadPersistedCodexRuntime({ configDir })?.updatedAt).toBe(firstStamp);
+  });
+
+  test("treats missing persisted and resolved versions as the same selection", () => {
+    const configDir = tempConfigDir();
+    const statePath = join(configDir, "codex-runtime.json");
+    writeFileSync(statePath, JSON.stringify({
+      version: 1,
+      command: "codex",
+      source: "environment",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    }));
+
+    const previousHome = process.env.OPENCODEX_HOME;
+    process.env.OPENCODEX_HOME = configDir;
+    resetCodexRuntimeResolveCacheForTests();
+    const deps = { env: { PATH: "" }, discoverAlternatives: false };
+
+    try {
+      const cached = resolveCodexRuntime(deps);
+      expect(cached.runtime.source).toBe("fallback");
+      cached.runtime.source = "environment";
+      (cached.runtime as { version?: string | null }).version = undefined;
+      const before = readFileSync(statePath, "utf8");
+
+      resolveAndPersistCodexRuntime(deps);
+
+      expect(readFileSync(statePath, "utf8")).toBe(before);
+    } finally {
+      if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+      else process.env.OPENCODEX_HOME = previousHome;
+      resetCodexRuntimeResolveCacheForTests();
+    }
   });
 
   test("catalog clamp clears diagnostics inside deps.configDir when probe fails", async () => {


### PR DESCRIPTION
Fixes the root cause behind #606.

## Problem

`loadBundledCodexCatalog()` spawns `codex --version` on every call, including warm
60s cache hits. On Windows that pushes `/api/claude-code` and `/v1/models` to 5-8s,
past the 3s budget `cmdClaude` allows each, so `ocx claude` aborts both and prints:

```
⚠ 모델 컨텍스트 정보를 불러오지 못했습니다 — 1M 자동 표시는 이번 실행에서 생략됩니다.
⚠ Gateway model cache could not be refreshed; the model picker may be stale.
```

The consequences are quiet: `[1m]` marking is skipped for the run, and
`~/.claude/cache/gateway-models.json` is never rewritten. Since Claude Code only
refreshes that cache itself when it holds a credential — and the
subscription-preserving launch deliberately injects none — the picker keeps serving
whatever is on disk. Mine was 6 days stale (80 entries vs 98 current).

## Root causes

**1. The bundled-catalog cache can never be hit.** `candidates` is computed in an
IIFE that runs *before* the `bundledCatalogCache` lookup, because `cacheKey` is
assigned inside it — so the runtime resolve happens on every call. That would still
be cheap if it were memoized, but the call forwarded its own already-defaulted
`execFileSync`:

```ts
const execFile = deps.execFileSync ?? (execFileSync as unknown as ExecFile);
// ...
resolveAndPersistCodexRuntime({ execFileSync: execFile, /* always truthy */ });
```

and `resolveCacheKey()` deliberately refuses to memoize injected-dependency
resolves. The guard is right in intent (injected deps imply a test double), but this
caller defeated it for the real-runtime path. Now only a genuinely injected
`execFileSync` is forwarded.

**2. The persist write cleared its own memo.** `resolveAndPersistCodexRuntime()`
wrote on any non-fallback selection. `persistCodexRuntime()` ends with
`resolveCache = null`, and `persistedRuntimeCacheStamp()` folds the on-disk
`updatedAt` into the cache key — so each write both cleared the memo and changed the
key it would have been stored under, even when the resolved runtime was
byte-identical to what was already persisted. Now it only writes when the selection
actually changed.

**3. Cold reads probed every `codex` on PATH.** The catalog path passed
`discoverAlternatives: deps.discoverAlternatives` (i.e. `undefined`), which
`resolveCodexRuntimeUncached()` treats as "discover". It then probed every candidate
to populate `newerAvailable`, each probe spawning `codex --version` with a fresh
`mkdtempSync` sandbox:

```
resolveCodexRuntime({})                              1224 ms   failures: 102
resolveCodexRuntime({ discoverAlternatives: false })    60 ms
```

Both select the identical runtime, and catalog loading never reads `newerAvailable`
or `failures`. Defaulted to `false` here; callers that want discovery diagnostics
still opt in explicitly.

## Measurements

`/api/claude-code` over HTTP, Windows 11:

| | before | after |
|---|---|---|
| cold (fresh proxy) | 5000-8300 ms | 165 ms |
| warm | 6300 ms | ~25 ms |
| after 65s idle (cache expired) | 6325 ms | 1440 ms |

`loadBundledCodexCatalog()` three times in a row, nothing changing on disk:

```
before:  1214 ms / 1136 ms / 1186 ms
after:   1483 ms /    1 ms /    0 ms
```

After the fix `ocx claude` runs clean and `gateway-models.json` refreshed from 80
stale entries to 98 current ones, 25 carrying `[1m]`.

## Tests

Three regression tests in `tests/codex-runtime.test.ts`, all failing on `dev` and
passing here:

- **`repeated catalog reads reuse the runtime probe instead of respawning it`** —
  uses a real launcher script that appends to a log on each `--version`, so it counts
  actual subprocess spawns rather than mocking them. Asserts the count stops growing
  across repeated reads. Note it deliberately allows the *second* read to probe once
  more: the first read has no persisted selection yet, so it legitimately writes one
  and that write clears the memo. Observed progression is `[1,2,2,2,2,2]` — the
  invariant is convergence, not a single probe. The POSIX launcher uses shell built-ins
  only, so the test remains isolated with `PATH=""` on Linux and macOS.
- **`repeat resolveAndPersistCodexRuntime keeps an unchanged selection's persisted
  stamp`** — injects a monotonic clock and asserts an identical selection does not
  rewrite `updatedAt`.
- **`treats missing persisted and resolved versions as the same selection`** —
  covers JavaScript callers that surface `undefined` despite the TypeScript `null`
  contract, preventing the same rewrite/memo invalidation loop for unversioned runtimes.

## Verification

- `bun run typecheck` — clean
- `bun run privacy:scan` — passed
- `bun test tests/codex-runtime.test.ts tests/codex-catalog*.test.ts` — **145 pass,
  0 fail** across 5 files (655 assertions)
- Confirmed all three regression tests fail against the relevant prior implementation
- POSIX launcher smoke-tested through Git Bash with `PATH=""`

One gap I should be upfront about: the full `bun run test` sweep did not complete on
my machine. Bun 1.3.14 on Windows panics with `Internal assertion failure` at
~2.9GB peak RSS partway through the 415-file suite — the same runtime memory issue
`ocx doctor` warns about on this platform. It is not triggered by this change, so
please treat CI's cross-platform run as authoritative for the full suite.

## Suggestions beyond this fix (not implemented here)

1. **Check `bundledCatalogCache` before resolving the runtime.** Deriving the cache
   key from the very probe the cache exists to avoid means a warm hit can only ever
   save the `codex debug models` call (~87ms), never the probe (~1.2s) that
   dominates. A cheaper key would let warm hits skip both. I left the ordering alone
   to keep this change minimal.
2. **Attribute the timeout in the warning text.** Both messages read like auth or
   network faults; something like `timed out after 3000ms` would point straight at
   the cause. I went looking at OAuth state and provider connectivity first.
3. **Consider making the 3s budget configurable.** Even fully patched, a cold read is
   ~1.4s here, so a slower machine or longer `PATH` could still trip it silently.

## Tradeoff worth reviewing

Defaulting `discoverAlternatives` to `false` on the catalog path means catalog-path
callers no longer receive `newerAvailable` diagnostics. Nothing in that path consumes
them today, but if you would rather keep discovery observable, moving it to a slow
background interval instead of every catalog read would preserve the diagnostics
while keeping the request path fast. Happy to rework it that way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex runtime caching so repeated bundled catalog reads reuse the existing version probe.
  * Avoids rewriting the persisted Codex runtime when the resolved selection is unchanged, preserving timestamps.
  * Improved bundled runtime discovery behavior when optional injected execution settings are present, including safer defaults for alternative discovery.
* **Tests**
  * Added/expanded coverage for cache warm-start behavior and persisted-selection stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
