### PR TITLE
fix(gui): render Claude helper model labels

### DIFF
--- a/gui/src/pages/ClaudeCode.tsx
+++ b/gui/src/pages/ClaudeCode.tsx
@@ -69,7 +69,7 @@ export default function ClaudeCode({ apiBase }: { apiBase: string }) {
   }, [load]);
 
   const modelOptions = useMemo(() => {
-    const options = (state?.available ?? []).map(m => ({ value: m, label: String(modelLabel(m)) }));
+    const options = (state?.available ?? []).map(m => ({ value: m, label: modelLabel(m) }));
     return [{ value: "", label: t("claude.smallFastModelUnsetOption") }, ...options];
   }, [state?.available, t]);
 

--- a/gui/tests/claudecode-fetch-errors.test.tsx
+++ b/gui/tests/claudecode-fetch-errors.test.tsx
@@ -172,3 +172,34 @@ test("ClaudeCode save treats an empty 200 body as success", async () => {
     testWindow.close();
   }
 });
+
+test("ClaudeCode helper model options render icon-backed model names", async () => {
+  globalThis.fetch = (async (input) => {
+    if (String(input).endsWith("/api/claude-code")) {
+      return Response.json({ ...CLAUDE_OK, available: ["gpt-5.6-luna"] });
+    }
+    return new Response(null, { status: 404 });
+  }) as typeof fetch;
+
+  const { container, root, testWindow } = await mountClaudeCode();
+  try {
+    const helperModel = container.querySelector<HTMLButtonElement>(
+      '[role="combobox"][aria-label="Background helper model"]',
+    );
+    expect(helperModel).toBeTruthy();
+
+    await act(async () => {
+      helperModel!.click();
+      await Promise.resolve();
+    });
+
+    const optionText = [...testWindow.document.querySelectorAll<HTMLElement>('[role="option"]')]
+      .map(option => option.textContent)
+      .join("\n");
+    expect(optionText).toContain("gpt-5.6-luna");
+    expect(optionText).not.toContain("[object Object]");
+  } finally {
+    await act(async () => root.unmount());
+    testWindow.close();
+  }
+});


### PR DESCRIPTION
## Summary

- preserve the ReactNode returned by `modelLabel()` in the Claude Code background-helper selector
- prevent icon-backed models from rendering as `[object Object]`
- add a regression test that opens the real portaled selector and verifies the model slug is visible

## Root cause

`modelLabel()` returns a React element for icon-backed models, but the Claude Code page coerced it with `String(...)`. The shared `SelectOption.label` already accepts `React.ReactNode`, so the coercion was unnecessary.

## Verification

- `bun test ./gui/tests/claudecode-fetch-errors.test.tsx ./gui/tests/claude-code-background-helper.test.tsx`
- `cd gui && bun run test` (354 passed)
- `cd gui && bun run lint`
- `cd gui && bun run build`
- `bun run typecheck`
- `bun run privacy:scan`
- `bun run test` (5,722 passed, 1 skipped)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display of available background helper model names in the Claude Code settings.
  * Prevented non-user-friendly placeholder text from appearing in the model selector.

* **Tests**
  * Added coverage verifying helper model names render correctly in the selection control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->