### PR TITLE
fix(cursor): steer Windows bridge shell away from PS 5.1 syntax loops

### DIFF
--- a/src/adapters/cursor/native-exec-shell.ts
+++ b/src/adapters/cursor/native-exec-shell.ts
@@ -23,17 +23,18 @@ import { errorText, execBytes, execStreamCloseBytes } from "./native-exec-common
 const backgroundShells = new Map<number, { child: ChildProcessWithoutNullStreams; outputLength: number }>();
 let nextShellId = 1;
 
-function nativeShellDisabledMessage(): string {
-  // Do not insist on "the same command" — on Windows PowerShell 5.1 that steers the
-  // model into replaying bash/CMD idioms (`cd /d`, `&&`, heredocs) through the bridge
-  // and looping (issue #604).
-  const adapt = process.platform === "win32"
-    ? "Adapt the command for Windows PowerShell 5.1 before calling the bridge (no CMD `cd /d`, no bash heredocs, no `&&` — use `;` / PowerShell cmdlets). After a shell failure, fix the syntax once; do not repeat the same failing command."
-    : "Adapt the command for the host shell if needed before calling the bridge. After a shell failure, fix the command once; do not repeat the same failing command.";
+/** Rejection text when Cursor-native shell is denied by policy (issue #604). */
+export function nativeShellDisabledMessage(): string {
+  // Do not insist on "the same command" — that steers models into replaying bash/CMD
+  // idioms through the Codex bridge on Windows PowerShell 5.1 and looping (#604).
+  // Keep this host-shell-neutral: OpenCodex may run on a different OS than the Codex
+  // client that executes the bridge (LAN/SSH remote-proxy).
   return (
     "Route this through the Codex bridge shell tool from the current catalog (`shell_command` or `exec_command`, including the long `mcp_opencodex-responses_*` display name if listed). "
     + "Do not tell the user shell access is blocked, disabled, or denied — silently call that bridge tool. "
-    + adapt
+    + "Adapt the command for the Codex client host shell before calling the bridge "
+    + "(Windows PowerShell 5.1: no CMD `cd /d`, no bash heredocs; prefer the bridge working-directory argument for directory changes, and use `if ($?) { ... }` when a later step must run only after success — do not treat `;` as a substitute for `&&`). "
+    + "Make at most one corrected bridge attempt after a failure, then report the error and stop — do not repeat equivalent failing commands."
   );
 }
 

--- a/src/adapters/cursor/native-exec-shell.ts
+++ b/src/adapters/cursor/native-exec-shell.ts
@@ -33,7 +33,7 @@ export function nativeShellDisabledMessage(): string {
     "Route this through the Codex bridge shell tool from the current catalog (`shell_command` or `exec_command`, including the long `mcp_opencodex-responses_*` display name if listed). "
     + "Do not tell the user shell access is blocked, disabled, or denied — silently call that bridge tool. "
     + "Adapt the command for the Codex client host shell before calling the bridge "
-    + "(Windows PowerShell 5.1: no CMD `cd /d`, no bash heredocs; prefer the bridge working-directory argument for directory changes, and use `if ($?) { ... }` when a later step must run only after success — do not treat `;` as a substitute for `&&`). "
+    + "(Windows PowerShell 5.1: no CMD `cd /d`, no bash heredocs; `&&`/`||` are unsupported parser errors — prefer the bridge working-directory argument for directory changes, and use `if ($?) { ... }` for success-gated follow-up steps; do not treat `;` as a substitute for `&&`). "
     + "Make at most one corrected bridge attempt after a failure, then report the error and stop — do not repeat equivalent failing commands."
   );
 }

--- a/src/adapters/cursor/native-exec-shell.ts
+++ b/src/adapters/cursor/native-exec-shell.ts
@@ -23,8 +23,19 @@ import { errorText, execBytes, execStreamCloseBytes } from "./native-exec-common
 const backgroundShells = new Map<number, { child: ChildProcessWithoutNullStreams; outputLength: number }>();
 let nextShellId = 1;
 
-const NATIVE_SHELL_DISABLED =
-  "Route this through the Codex bridge shell tool from the current catalog (`shell_command` or `exec_command`, including the long `mcp_opencodex-responses_*` display name if listed). Do not tell the user shell access is blocked, disabled, or denied — silently call that bridge tool with the same command.";
+function nativeShellDisabledMessage(): string {
+  // Do not insist on "the same command" — on Windows PowerShell 5.1 that steers the
+  // model into replaying bash/CMD idioms (`cd /d`, `&&`, heredocs) through the bridge
+  // and looping (issue #604).
+  const adapt = process.platform === "win32"
+    ? "Adapt the command for Windows PowerShell 5.1 before calling the bridge (no CMD `cd /d`, no bash heredocs, no `&&` — use `;` / PowerShell cmdlets). After a shell failure, fix the syntax once; do not repeat the same failing command."
+    : "Adapt the command for the host shell if needed before calling the bridge. After a shell failure, fix the command once; do not repeat the same failing command.";
+  return (
+    "Route this through the Codex bridge shell tool from the current catalog (`shell_command` or `exec_command`, including the long `mcp_opencodex-responses_*` display name if listed). "
+    + "Do not tell the user shell access is blocked, disabled, or denied — silently call that bridge tool. "
+    + adapt
+  );
+}
 
 function rejectedShellResult(command: string, cwd: string, started: number) {
   return create(ShellResultSchema, {
@@ -36,7 +47,7 @@ function rejectedShellResult(command: string, cwd: string, started: number) {
         exitCode: 1,
         signal: "",
         stdout: "",
-        stderr: NATIVE_SHELL_DISABLED,
+        stderr: nativeShellDisabledMessage(),
         executionTime: Date.now() - started,
         aborted: true,
       }),
@@ -95,7 +106,7 @@ export function rejectShellStreamExecForPolicy(execMsg: ExecServerMessage): Uint
       event: { case: "start", value: create(ShellStreamStartSchema, { sandboxPolicy: args.requestedSandboxPolicy }) },
     })),
     execBytes(execMsg, "shellStream", create(ShellStreamSchema, {
-      event: { case: "stderr", value: create(ShellStreamStderrSchema, { data: NATIVE_SHELL_DISABLED }) },
+      event: { case: "stderr", value: create(ShellStreamStderrSchema, { data: nativeShellDisabledMessage() }) },
     })),
     execBytes(execMsg, "shellStream", create(ShellStreamSchema, {
       event: { case: "exit", value: create(ShellStreamExitSchema, { code: 1, cwd, aborted: true }) },
@@ -196,7 +207,7 @@ export function rejectBackgroundShellSpawnExecForPolicy(execMsg: ExecServerMessa
   const args = execMsg.message.value;
   const cwd = resolve(args.workingDirectory || process.cwd());
   return execBytes(execMsg, "backgroundShellSpawnResult", create(BackgroundShellSpawnResultSchema, {
-    result: { case: "error", value: create(BackgroundShellSpawnErrorSchema, { command: args.command, workingDirectory: cwd, error: NATIVE_SHELL_DISABLED }) },
+    result: { case: "error", value: create(BackgroundShellSpawnErrorSchema, { command: args.command, workingDirectory: cwd, error: nativeShellDisabledMessage() }) },
   }));
 }
 
@@ -233,7 +244,7 @@ export function backgroundShellSpawnExec(execMsg: ExecServerMessage): Uint8Array
 export function rejectWriteShellStdinExecForPolicy(execMsg: ExecServerMessage): Uint8Array {
   if (execMsg.message.case !== "writeShellStdinArgs") throw new Error("invalid shell stdin exec");
   return execBytes(execMsg, "writeShellStdinResult", create(WriteShellStdinResultSchema, {
-    result: { case: "error", value: create(WriteShellStdinErrorSchema, { error: NATIVE_SHELL_DISABLED }) },
+    result: { case: "error", value: create(WriteShellStdinErrorSchema, { error: nativeShellDisabledMessage() }) },
   }));
 }
 

--- a/src/adapters/cursor/tool-definitions.ts
+++ b/src/adapters/cursor/tool-definitions.ts
@@ -401,10 +401,8 @@ function discoveryToolLabel(wireNames: readonly string[]): string | undefined {
 export function buildCursorToolGuidanceSystemNote(
   tools: readonly Pick<OcxTool, "namespace" | "name" | "freeform">[] | undefined,
   toolChoice?: OcxRequestOptions["toolChoice"],
-  options?: { platform?: NodeJS.Platform },
 ): string | undefined {
   if (!tools?.length) return undefined;
-  const platform = options?.platform ?? process.platform;
   const wireNames = [...new Set(
     tools
       .filter(tool => cursorToolAllowedByChoice(tool, toolChoice, tools))
@@ -419,13 +417,10 @@ export function buildCursorToolGuidanceSystemNote(
   const hasApplyPatch = cursorRequestAdvertisesApplyPatch(tools, toolChoice);
   const discoveryTools = discoveryToolLabel(wireNames);
   const unavailableNeighborNames = unavailableNeighborAgentToolNames(wireNames);
-  const windowsShellNote = hasBareExec && platform === "win32"
-    ? "Host shell is Windows PowerShell 5.1-compatible: use PowerShell syntax only. Do not use CMD `cd /d`, bash heredocs (`<<EOF`), or `&&` chaining (unsupported on Windows PowerShell 5.1). Prefer `Set-Location`, `Get-Content`, `Select-String`, and `;` between statements. After a shell failure, fix the syntax once — do not repeat the same failing command through the bridge."
-    : undefined;
-  const bridgeFallbackNote = hasBareExec
-    ? (platform === "win32"
-      ? `If a Cursor-native file read, directory listing, grep, or shell operation is rejected by the runtime, silently use ${shellBridgeLabel} with an equivalent PowerShell-safe command (e.g. \`Get-Content\`, \`Get-ChildItem\`, \`Select-String\`). Do not tell the user access is blocked. For file edits, use \`apply_patch\` when available.`
-      : `If a Cursor-native file read, directory listing, grep, or shell operation is rejected by the runtime, silently use ${shellBridgeLabel} with the equivalent shell command instead (e.g. \`cat\`, \`ls\`, \`rg\`, \`grep\`). Do not tell the user access is blocked. For file edits, use \`apply_patch\` when available.`)
+  // Host-shell-neutral: the Codex client executes bridge commands, and may differ from
+  // the OpenCodex proxy OS (LAN/SSH remote-proxy). Always cover PowerShell 5.1 pitfalls.
+  const hostShellNote = hasBareExec
+    ? "Match shell syntax to the Codex client host that runs the bridge (not only the proxy OS). Windows PowerShell 5.1: no CMD `cd /d`, no bash heredocs (`<<EOF`); prefer the bridge working-directory argument for directory changes, and use `if ($?) { ... }` when a later step must run only after success — do not treat `;` as a substitute for `&&`. POSIX: use portable commands. After a shell failure, make at most one corrected bridge attempt, then report the error and stop — do not repeat equivalent failing commands."
     : undefined;
   const notes = [
     `Cursor tool calls: available tool names are exactly ${listedNames}.`,
@@ -442,7 +437,7 @@ export function buildCursorToolGuidanceSystemNote(
     hasBareExec
       ? "Never tell the user that shell or read access is blocked, disabled, or denied unless the Codex shell bridge tool itself fails. Prefer the bridge over Cursor-native Shell/Read; do not narrate phrases like \"Native shell access is blocked\" — silently call `shell_command` / `exec_command`."
       : undefined,
-    windowsShellNote,
+    hostShellNote,
     "Cursor product features (Chronicle, screen recording, Notes, Plans, background agents) are available only if this turn's catalog lists a matching tool; do not offer or promise them otherwise.",
     hasBareExec
       ? `For file read/search/listing, use ${shellBridgeLabel} when no more specific listed tool is available.`
@@ -461,7 +456,9 @@ export function buildCursorToolGuidanceSystemNote(
       ? `Use ${discoveryTools} only for explicit discovery/resource tasks, not generic tool-count demos.`
       : undefined,
     "Do not count or report a tool call unless a tool result was actually returned.",
-    bridgeFallbackNote,
+    hasBareExec
+      ? `If a Cursor-native file read, directory listing, grep, or shell operation is rejected by the runtime, silently use ${shellBridgeLabel} with an equivalent host-shell-safe command (POSIX: \`cat\`/\`ls\`/\`rg\`; Windows PowerShell: \`Get-Content\`/\`Get-ChildItem\`/\`Select-String\`). Do not tell the user access is blocked. For file edits, use \`apply_patch\` when available.`
+      : undefined,
   ].filter((note): note is string => typeof note === "string");
   return notes.join(" ");
 }

--- a/src/adapters/cursor/tool-definitions.ts
+++ b/src/adapters/cursor/tool-definitions.ts
@@ -420,7 +420,7 @@ export function buildCursorToolGuidanceSystemNote(
   // Host-shell-neutral: the Codex client executes bridge commands, and may differ from
   // the OpenCodex proxy OS (LAN/SSH remote-proxy). Always cover PowerShell 5.1 pitfalls.
   const hostShellNote = hasBareExec
-    ? "Match shell syntax to the Codex client host that runs the bridge (not only the proxy OS). Windows PowerShell 5.1: no CMD `cd /d`, no bash heredocs (`<<EOF`); prefer the bridge working-directory argument for directory changes, and use `if ($?) { ... }` when a later step must run only after success — do not treat `;` as a substitute for `&&`. POSIX: use portable commands. After a shell failure, make at most one corrected bridge attempt, then report the error and stop — do not repeat equivalent failing commands."
+    ? "Match shell syntax to the Codex client host that runs the bridge (not only the proxy OS). Windows PowerShell 5.1: no CMD `cd /d`, no bash heredocs (`<<EOF`); `&&`/`||` are unsupported parser errors — prefer the bridge working-directory argument for directory changes, and use `if ($?) { ... }` for success-gated follow-up steps; do not treat `;` as a substitute for `&&`. POSIX: use portable commands. After a shell failure, make at most one corrected bridge attempt, then report the error and stop — do not repeat equivalent failing commands."
     : undefined;
   const notes = [
     `Cursor tool calls: available tool names are exactly ${listedNames}.`,

--- a/src/adapters/cursor/tool-definitions.ts
+++ b/src/adapters/cursor/tool-definitions.ts
@@ -401,8 +401,10 @@ function discoveryToolLabel(wireNames: readonly string[]): string | undefined {
 export function buildCursorToolGuidanceSystemNote(
   tools: readonly Pick<OcxTool, "namespace" | "name" | "freeform">[] | undefined,
   toolChoice?: OcxRequestOptions["toolChoice"],
+  options?: { platform?: NodeJS.Platform },
 ): string | undefined {
   if (!tools?.length) return undefined;
+  const platform = options?.platform ?? process.platform;
   const wireNames = [...new Set(
     tools
       .filter(tool => cursorToolAllowedByChoice(tool, toolChoice, tools))
@@ -417,6 +419,14 @@ export function buildCursorToolGuidanceSystemNote(
   const hasApplyPatch = cursorRequestAdvertisesApplyPatch(tools, toolChoice);
   const discoveryTools = discoveryToolLabel(wireNames);
   const unavailableNeighborNames = unavailableNeighborAgentToolNames(wireNames);
+  const windowsShellNote = hasBareExec && platform === "win32"
+    ? "Host shell is Windows PowerShell 5.1-compatible: use PowerShell syntax only. Do not use CMD `cd /d`, bash heredocs (`<<EOF`), or `&&` chaining (unsupported on Windows PowerShell 5.1). Prefer `Set-Location`, `Get-Content`, `Select-String`, and `;` between statements. After a shell failure, fix the syntax once — do not repeat the same failing command through the bridge."
+    : undefined;
+  const bridgeFallbackNote = hasBareExec
+    ? (platform === "win32"
+      ? `If a Cursor-native file read, directory listing, grep, or shell operation is rejected by the runtime, silently use ${shellBridgeLabel} with an equivalent PowerShell-safe command (e.g. \`Get-Content\`, \`Get-ChildItem\`, \`Select-String\`). Do not tell the user access is blocked. For file edits, use \`apply_patch\` when available.`
+      : `If a Cursor-native file read, directory listing, grep, or shell operation is rejected by the runtime, silently use ${shellBridgeLabel} with the equivalent shell command instead (e.g. \`cat\`, \`ls\`, \`rg\`, \`grep\`). Do not tell the user access is blocked. For file edits, use \`apply_patch\` when available.`)
+    : undefined;
   const notes = [
     `Cursor tool calls: available tool names are exactly ${listedNames}.`,
     "Use the current tool catalog as ground truth and call only those exact names with their listed argument keys.",
@@ -432,6 +442,7 @@ export function buildCursorToolGuidanceSystemNote(
     hasBareExec
       ? "Never tell the user that shell or read access is blocked, disabled, or denied unless the Codex shell bridge tool itself fails. Prefer the bridge over Cursor-native Shell/Read; do not narrate phrases like \"Native shell access is blocked\" — silently call `shell_command` / `exec_command`."
       : undefined,
+    windowsShellNote,
     "Cursor product features (Chronicle, screen recording, Notes, Plans, background agents) are available only if this turn's catalog lists a matching tool; do not offer or promise them otherwise.",
     hasBareExec
       ? `For file read/search/listing, use ${shellBridgeLabel} when no more specific listed tool is available.`
@@ -450,9 +461,7 @@ export function buildCursorToolGuidanceSystemNote(
       ? `Use ${discoveryTools} only for explicit discovery/resource tasks, not generic tool-count demos.`
       : undefined,
     "Do not count or report a tool call unless a tool result was actually returned.",
-    hasBareExec
-      ? `If a Cursor-native file read, directory listing, grep, or shell operation is rejected by the runtime, silently use ${shellBridgeLabel} with the equivalent shell command instead (e.g. \`cat\`, \`ls\`, \`rg\`, \`grep\`). Do not tell the user access is blocked. For file edits, use \`apply_patch\` when available.`
-      : undefined,
+    bridgeFallbackNote,
   ].filter((note): note is string => typeof note === "string");
   return notes.join(" ");
 }

--- a/tests/cursor-native-exec-policy.test.ts
+++ b/tests/cursor-native-exec-policy.test.ts
@@ -143,7 +143,10 @@ describe("Cursor native exec sandbox policy", () => {
     expect(deniedShellText).toContain("mcp_opencodex-responses_*");
     expect(deniedShellText).toContain("Do not tell the user");
     expect(deniedShellText).not.toContain("with the same command");
-    expect(deniedShellText).toContain("do not repeat the same failing command");
+    expect(deniedShellText).toContain("at most one corrected bridge attempt");
+    expect(deniedShellText).toContain("if ($?)");
+    expect(deniedShellText).toContain("do not treat `;` as a substitute for `&&`");
+    expect(deniedShellText).toContain("Windows PowerShell 5.1");
     expect(deniedShellText).not.toContain("disabled by OpenCodex policy");
     expect(deniedShellText).not.toContain("sandbox denial");
     expect(deniedShell.message.case).toBe("shellResult");

--- a/tests/cursor-native-exec-policy.test.ts
+++ b/tests/cursor-native-exec-policy.test.ts
@@ -145,6 +145,7 @@ describe("Cursor native exec sandbox policy", () => {
     expect(deniedShellText).not.toContain("with the same command");
     expect(deniedShellText).toContain("at most one corrected bridge attempt");
     expect(deniedShellText).toContain("if ($?)");
+    expect(deniedShellText).toContain("`&&`/`||` are unsupported parser errors");
     expect(deniedShellText).toContain("do not treat `;` as a substitute for `&&`");
     expect(deniedShellText).toContain("Windows PowerShell 5.1");
     expect(deniedShellText).not.toContain("disabled by OpenCodex policy");

--- a/tests/cursor-native-exec-policy.test.ts
+++ b/tests/cursor-native-exec-policy.test.ts
@@ -142,6 +142,8 @@ describe("Cursor native exec sandbox policy", () => {
     expect(deniedShellText).toContain("exec_command");
     expect(deniedShellText).toContain("mcp_opencodex-responses_*");
     expect(deniedShellText).toContain("Do not tell the user");
+    expect(deniedShellText).not.toContain("with the same command");
+    expect(deniedShellText).toContain("do not repeat the same failing command");
     expect(deniedShellText).not.toContain("disabled by OpenCodex policy");
     expect(deniedShellText).not.toContain("sandbox denial");
     expect(deniedShell.message.case).toBe("shellResult");

--- a/tests/cursor-tool-definitions.test.ts
+++ b/tests/cursor-tool-definitions.test.ts
@@ -324,33 +324,20 @@ describe("Cursor tool definitions", () => {
     expect(note).toContain("Never tell the user that shell or read access is blocked");
   });
 
-  test("adds Windows PowerShell 5.1 host-shell guidance when platform is win32 (#604)", () => {
-    const note = buildCursorToolGuidanceSystemNote(
-      [{ name: "shell_command", description: "Run", parameters: {} }],
-      undefined,
-      { platform: "win32" },
-    );
+  test("adds host-shell-neutral PowerShell and one-retry-stop guidance (#604)", () => {
+    const note = buildCursorToolGuidanceSystemNote([{ name: "shell_command", description: "Run", parameters: {} }]);
     expect(note).toBeDefined();
     if (!note) throw new Error("Expected Cursor tool guidance note");
 
     expect(note).toContain("Windows PowerShell 5.1");
     expect(note).toContain("cd /d");
     expect(note).toContain("<<EOF");
-    expect(note).toContain("do not repeat the same failing command");
+    expect(note).toContain("if ($?)");
+    expect(note).toContain("do not treat `;` as a substitute for `&&`");
+    expect(note).toContain("at most one corrected bridge attempt");
     expect(note).toContain("Get-Content");
-    expect(note).not.toContain("`cat`, `ls`, `rg`, `grep`");
-  });
-
-  test("keeps POSIX shell examples off Windows when platform is linux (#604)", () => {
-    const note = buildCursorToolGuidanceSystemNote(
-      [{ name: "exec_command", description: "Run", parameters: {} }],
-      undefined,
-      { platform: "linux" },
-    );
-    expect(note).toBeDefined();
-    if (!note) throw new Error("Expected Cursor tool guidance note");
-    expect(note).not.toContain("Windows PowerShell 5.1");
-    expect(note).toContain("`cat`, `ls`, `rg`, `grep`");
+    expect(note).toContain("`cat`/`ls`/`rg`");
+    expect(note).toContain("Codex client host");
   });
 
   test("adds codex-native edit guidance only when apply_patch is advertised", () => {

--- a/tests/cursor-tool-definitions.test.ts
+++ b/tests/cursor-tool-definitions.test.ts
@@ -333,6 +333,7 @@ describe("Cursor tool definitions", () => {
     expect(note).toContain("cd /d");
     expect(note).toContain("<<EOF");
     expect(note).toContain("if ($?)");
+    expect(note).toContain("`&&`/`||` are unsupported parser errors");
     expect(note).toContain("do not treat `;` as a substitute for `&&`");
     expect(note).toContain("at most one corrected bridge attempt");
     expect(note).toContain("Get-Content");

--- a/tests/cursor-tool-definitions.test.ts
+++ b/tests/cursor-tool-definitions.test.ts
@@ -324,6 +324,35 @@ describe("Cursor tool definitions", () => {
     expect(note).toContain("Never tell the user that shell or read access is blocked");
   });
 
+  test("adds Windows PowerShell 5.1 host-shell guidance when platform is win32 (#604)", () => {
+    const note = buildCursorToolGuidanceSystemNote(
+      [{ name: "shell_command", description: "Run", parameters: {} }],
+      undefined,
+      { platform: "win32" },
+    );
+    expect(note).toBeDefined();
+    if (!note) throw new Error("Expected Cursor tool guidance note");
+
+    expect(note).toContain("Windows PowerShell 5.1");
+    expect(note).toContain("cd /d");
+    expect(note).toContain("<<EOF");
+    expect(note).toContain("do not repeat the same failing command");
+    expect(note).toContain("Get-Content");
+    expect(note).not.toContain("`cat`, `ls`, `rg`, `grep`");
+  });
+
+  test("keeps POSIX shell examples off Windows when platform is linux (#604)", () => {
+    const note = buildCursorToolGuidanceSystemNote(
+      [{ name: "exec_command", description: "Run", parameters: {} }],
+      undefined,
+      { platform: "linux" },
+    );
+    expect(note).toBeDefined();
+    if (!note) throw new Error("Expected Cursor tool guidance note");
+    expect(note).not.toContain("Windows PowerShell 5.1");
+    expect(note).toContain("`cat`, `ls`, `rg`, `grep`");
+  });
+
   test("adds codex-native edit guidance only when apply_patch is advertised", () => {
     const tools: OcxTool[] = [
       { name: "exec_command", description: "Run", parameters: {} },


### PR DESCRIPTION
## Summary
- Fixes [#604](https://github.com/lidge-jun/opencodex/issues/604): `cursor/auto` on Windows PowerShell 5.1 could burn 20–45 tool calls after shell failures by repeatedly replaying bash/CMD syntax through the Codex shell bridge.
- Screenshots on the issue show near-duplicate “continue / Codex shell bridge” progress lines after small repo tasks — matching a bridge-continuation loop, not a single stuck turn.
- Stop telling the model to call the bridge with the **same** native-shell command; tell it to adapt for the host shell and not repeat a failing command.
- On `win32`, inject PowerShell 5.1 guidance into Cursor tool system notes (no `cd /d`, no bash heredocs, no `&&`; prefer PowerShell cmdlets / `;`).

## Why
Native Cursor shell is deny-by-default; rejection stderr previously said “silently call that bridge tool with the same command.” Models then replay `cd /d … && …` and bash heredocs into PS 5.1, fail, and continue — a known Cursor/Codex Windows pattern (forum reports + Webwright #53-style loops). Guidance previously only listed POSIX `cat`/`ls`/`rg` examples.

## Test plan
- [x] `bun test tests/cursor-tool-definitions.test.ts tests/cursor-native-exec-policy.test.ts`
- [x] `bun run typecheck` / `privacy:scan`
- [ ] CI green
- [ ] CodeRabbit + Codex threads resolved

Closes #604

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform-aware tool guidance that directs shell commands to be compatible with the client host, including Windows PowerShell 5.1 examples and POSIX alternatives.
* **Bug Fixes**
  * Refined native execution policy-denial messaging with clearer, host-shell-neutral guidance across all native-shell rejection scenarios.
* **Tests**
  * Expanded assertions to verify the updated denial text and the new Windows PowerShell 5.1 guidance content, including specific parser and command-syntax expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->