### PR TITLE
fix: stabilize cache inputs

### DIFF
--- a/docs-site/src/content/docs/guides/claude-code.md
+++ b/docs-site/src/content/docs/guides/claude-code.md
@@ -378,9 +378,10 @@ other 5xx `api_error`. `Retry-After` is preserved.
 and the penultimate user message, plus top-level automatic `cache_control`. Stable turns normally
 produce about a 99.9% cache hit rate.
 
-**Native OpenAI/ChatGPT routing:** derives a session-scoped `prompt_cache_key` (from
-`metadata.user_id` when present, falling back to a system-content hash) and `session_id` header
-for cache affinity. The cache key includes model and full tool schemas.
+**Native OpenAI/ChatGPT routing:** derives a content-scoped `prompt_cache_key` from the
+resolved model, normalized system content, and full tool schemas. When `metadata.user_id` is
+present, it separately derives a per-session `session_id` header for backend affinity. Tool and
+system-reminder listings are canonicalized before either cache input is built.
 
 **Token math:** Anthropic output subtracts `cached_tokens` and `cache_write_tokens` from
 `input_tokens`, exposing them as `cache_read_input_tokens` and `cache_creation_input_tokens`.

--- a/src/adapters/anthropic-sort-stabilize.ts
+++ b/src/adapters/anthropic-sort-stabilize.ts
@@ -1,0 +1,78 @@
+/**
+ * Deterministic ordering of Claude Code's own tool/skills/deferred-tools listings on
+ * the native Anthropic passthrough (`anthropicNativePassthrough`, `claude-messages.ts`).
+ * Claude Code enumerates MCP tools/skills in whatever order its own reconnect/discovery
+ * race resolves them, so byte-identical conversations can arrive with different array
+ * order turn to turn — busting Anthropic's prompt-cache prefix for no reason. Sorting is
+ * safe: `tool_choice` targets tools by name, not position, and the two system-reminder
+ * blocks below are pure listings with no inherent order the model depends on.
+ *
+ * Ported (algorithm only, re-implemented in TypeScript) from `sort-stabilization.mjs`,
+ * MIT licensed, github.com/cnighswonger/claude-code-cache-fix.
+ */
+
+type Rec = Record<string, unknown>;
+
+function isRec(v: unknown): v is Rec {
+  return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
+const SKILLS_BLOCK_RE = /^([\s\S]*?\n\n)(- [\s\S]+?)(\n<\/system-reminder>\s*)$/;
+const DEFERRED_TOOLS_BLOCK_RE = /^(<system-reminder>\nThe following deferred tools are now available[^\n]*\n)([\s\S]+?)(\n<\/system-reminder>\s*)$/;
+
+export function isSkillsBlockText(text: unknown): text is string {
+  return typeof text === "string" && text.includes("User-invocable skills");
+}
+
+export function isDeferredToolsBlockText(text: unknown): text is string {
+  return typeof text === "string" && text.includes("deferred tools are now available");
+}
+
+export function sortSkillsBlockText(text: string): string {
+  const match = text.match(SKILLS_BLOCK_RE);
+  if (!match) return text;
+  const [, header, entriesText, footer] = match;
+  const entries = entriesText.split(/\n(?=- )/);
+  entries.sort();
+  return header + entries.join("\n") + footer;
+}
+
+export function sortDeferredToolsBlockText(text: string): string {
+  const match = text.match(DEFERRED_TOOLS_BLOCK_RE);
+  if (!match) return text;
+  const [, header, toolsList, footer] = match;
+  const tools = toolsList.split("\n").map(t => t.trim()).filter(Boolean);
+  tools.sort();
+  return header + tools.join("\n") + footer;
+}
+
+/** Normalize known system-reminder listings; leave all other instructions untouched. */
+export function normalizeSystemReminderText(text: string): string {
+  if (isSkillsBlockText(text)) return sortSkillsBlockText(text);
+  if (isDeferredToolsBlockText(text)) return sortDeferredToolsBlockText(text);
+  return text;
+}
+
+/** Sort tool definitions by name; unnamed server tools sort first. */
+export function sortToolsByName(tools: unknown[]): void {
+  tools.sort((a, b) => {
+    const nameA = isRec(a) && typeof a.name === "string" ? a.name : "";
+    const nameB = isRec(b) && typeof b.name === "string" ? b.name : "";
+    return nameA.localeCompare(nameB);
+  });
+}
+
+/** Sort `body.system` skills/deferred-tools listings and `body.tools` by name, in place. */
+export function stabilizeSystemAndToolOrder(body: Rec): void {
+  if (Array.isArray(body.system)) {
+    const system = body.system as unknown[];
+    for (let i = 0; i < system.length; i++) {
+      const block = system[i];
+      if (!isRec(block) || block.type !== "text" || typeof block.text !== "string") continue;
+      const normalized = normalizeSystemReminderText(block.text);
+      if (normalized !== block.text) system[i] = { ...block, text: normalized };
+    }
+  }
+
+  if (Array.isArray(body.tools)) sortToolsByName(body.tools as unknown[]);
+}

--- a/src/claude/inbound.ts
+++ b/src/claude/inbound.ts
@@ -10,6 +10,10 @@
  *  - top_k is accepted and silently dropped (no Responses equivalent, CCR parity).
  */
 import type { OcxClaudeCodeConfig } from "../types";
+import {
+  normalizeSystemReminderText,
+  sortToolsByName,
+} from "../adapters/anthropic-sort-stabilize";
 import { resolveAlias } from "./alias";
 import { stripOneMillionMarker } from "./context-windows";
 import { resolveDesktop3pAlias } from "./desktop-3p";
@@ -69,11 +73,12 @@ export function effortFromOutputConfig(outputConfig: unknown): string | undefine
 }
 
 function systemToInstructions(system: unknown): string | undefined {
-  if (typeof system === "string") return system.length > 0 ? system : undefined;
+  if (typeof system === "string") return system.length > 0 ? normalizeSystemReminderText(system) : undefined;
   if (Array.isArray(system)) {
     const parts: string[] = [];
     for (const block of system) {
-      if (isRec(block) && block.type === "text" && typeof block.text === "string") parts.push(block.text);
+      if (!isRec(block) || block.type !== "text" || typeof block.text !== "string") continue;
+      parts.push(normalizeSystemReminderText(block.text));
     }
     return parts.length > 0 ? parts.join("\n\n") : undefined;
   }
@@ -229,11 +234,13 @@ function blockedSkillCallIds(messages: readonly unknown[], blocked: readonly str
  * `instructions` is the only shape that works on every route.
  */
 function systemMessageText(content: unknown): string {
-  if (typeof content === "string") return content;
+  if (typeof content === "string") return normalizeSystemReminderText(content);
   if (!Array.isArray(content)) return "";
   const parts: string[] = [];
   for (const raw of content) {
-    if (isRec(raw) && raw.type === "text" && typeof raw.text === "string") parts.push(raw.text);
+    if (isRec(raw) && raw.type === "text" && typeof raw.text === "string") {
+      parts.push(normalizeSystemReminderText(raw.text));
+    }
   }
   return parts.join("\n\n");
 }
@@ -340,7 +347,14 @@ function toolsToResponses(tools: unknown): Rec[] | undefined {
     }
     // Other server tools (bash_*, text_editor_*, ...) have no routed equivalent: drop.
   }
-  return out.length > 0 ? out : undefined;
+  if (out.length === 0) return undefined;
+  // Claude Code's MCP tool discovery races non-deterministically turn to turn, so this
+  // array can arrive in a different order for an otherwise-identical conversation. This
+  // feeds both the outgoing wire body and prompt_cache_key below, so an unstable order
+  // busts the cache prefix and the cache-key routing together. tool_choice targets by
+  // name (see toolChoiceToResponses), not position, so sorting is behavior-preserving.
+  sortToolsByName(out);
+  return out;
 }
 
 function toolChoiceToResponses(choice: unknown, body: Rec): void {

--- a/src/server/claude-messages.ts
+++ b/src/server/claude-messages.ts
@@ -6,6 +6,7 @@
  * internal Request, so routing/OAuth/account-pool/failover/sidecars are inherited
  * unchanged. The Responses output (SSE or JSON) is converted back to Anthropic shape.
  */
+import { createHash } from "node:crypto";
 import { FORWARD_HEADERS } from "../adapters/openai-responses";
 import { enforceAnthropicImageLimits } from "../adapters/anthropic-image-guard";
 import { normalizeAnthropicImages } from "../adapters/anthropic-image-normalize";
@@ -102,6 +103,11 @@ function wantsNativePassthrough(req: Request, config: OcxConfig, model: unknown)
 function uuidFromHex(hex32: string): string {
   const h = (hex32 + "0".repeat(32)).slice(0, 32);
   return `${h.slice(0, 8)}-${h.slice(8, 12)}-4${h.slice(13, 16)}-8${h.slice(17, 20)}-${h.slice(20, 32)}`;
+}
+
+function claudeMetadataUserId(body: unknown): string | undefined {
+  if (!isRec(body) || !isRec(body.metadata)) return undefined;
+  return typeof body.metadata.user_id === "string" ? body.metadata.user_id : undefined;
 }
 
 function anthropicUsageToOcx(usage: Rec | undefined): { inputTokens: number; outputTokens: number; cachedInputTokens?: number; cacheReadInputTokens?: number; cacheCreationInputTokens?: number } | undefined {
@@ -649,15 +655,16 @@ export async function handleClaudeMessages(
       headers.set("authorization", `Bearer ${token.accessToken}`);
       headers.set("chatgpt-account-id", token.chatgptAccountId);
     }
-    // ChatGPT-backend prompt-cache affinity rides the session_id HEADER (codex
-    // clients always send their session uuid; devlog 090 follow-up: body-level
-    // prompt_cache_key alone still yielded cached_tokens:0). Claude Code never sends
-    // the header, so synthesize a stable per-session uuid from the same cache key —
-    // but ONLY for a real per-session key (metadata.user_id). The system-hash fallback
-    // key is shared across Desktop conversations, and a shared session_id's backend
-    // semantics are unproven (audit 133 R2#3): body prompt_cache_key only there.
-    if (cacheKeySource === "metadata" && !headers.has("session_id") && typeof internalBody.prompt_cache_key === "string") {
-      headers.set("session_id", uuidFromHex(internalBody.prompt_cache_key));
+    // ChatGPT-backend prompt-cache affinity rides the session_id HEADER. Keep it
+    // session-scoped even when prompt_cache_key is content-first: metadata.user_id
+    // identifies the Claude Code session, while the content hash is shared across
+    // equivalent conversations and must never become a shared session identifier.
+    const metadataUserId = claudeMetadataUserId(anthropicBody);
+    if (!headers.has("session_id") && metadataUserId) {
+      headers.set(
+        "session_id",
+        uuidFromHex(createHash("sha256").update(metadataUserId).digest("hex").slice(0, 32)),
+      );
     }
   }
   const internalReq = new Request("http://localhost/v1/responses", {

--- a/tests/claude-inbound.test.ts
+++ b/tests/claude-inbound.test.ts
@@ -74,11 +74,12 @@ describe("claude inbound translation", () => {
 
     const tools = body.tools as Record<string, any>[];
     expect(tools).toHaveLength(2);
-    expect(tools[0]).toEqual({
+    // Sorted by name (devlog 260727b_routed_tool_sort): unnamed web_search sorts first.
+    expect(tools[0]).toEqual({ type: "web_search" });
+    expect(tools[1]).toEqual({
       type: "function", name: "Read", description: "Read a file",
       parameters: { type: "object", properties: { file_path: { type: "string" } }, required: ["file_path"] },
     });
-    expect(tools[1]).toEqual({ type: "web_search" });
 
     const input = body.input as Record<string, any>[];
     // user text, assistant text (thinking dropped), function_call, function_call_output, user tail
@@ -235,7 +236,7 @@ describe("prompt cache key provenance (devlog 130 B3)", () => {
     }
   });
 
-  test("cache cohort key: model and full tool schemas participate, wire order preserved (devlog 260712 B4)", () => {
+  test("cache cohort key: model and full tool schemas participate, tool order canonicalized (devlog 260712 B4, 260727b)", () => {
     const tool = (desc: string) => ({ name: "Read", description: desc, input_schema: { type: "object", properties: { a: { type: "string" }, b: { type: "number" } } } });
     const base = { max_tokens: 1, messages, system: "be nice" };
     const k = (body: Record<string, unknown>) => anthropicToResponsesTranslation(body).body.prompt_cache_key as string;
@@ -247,16 +248,103 @@ describe("prompt cache key provenance (devlog 130 B3)", () => {
     const orderedA = { name: "Read", description: "d", input_schema: { type: "object", properties: { a: { type: "string" }, b: { type: "number" } } } };
     const orderedB = { name: "Read", input_schema: { properties: { b: { type: "number" }, a: { type: "string" } }, type: "object" }, description: "d" };
     expect(k({ ...base, model: "m", tools: [orderedA] })).toBe(k({ ...base, model: "m", tools: [orderedB] }));
-    // different WIRE ORDER of the tool array -> different cohort (Pro review: the key
-    // must correspond to the actual outbound prefix, so array order participates).
+    // Wire order no longer participates for the SAME tool set (devlog 260727b_routed_tool_sort):
+    // toolsToResponses canonicalizes tool order by name before the wire body and this hash both
+    // see it, so any permutation of an identical tool set hashes identically — a stronger
+    // guarantee than "faithfully tracks whatever order arrived" (Claude Code's own MCP
+    // discovery race made that order turn-to-turn unstable, busting the cache prefix for no
+    // reason). A different tool SET still changes the cohort (covered above).
     const t1 = { name: "A", description: "a", input_schema: { type: "object" } };
     const t2 = { name: "B", description: "b", input_schema: { type: "object" } };
-    expect(k({ ...base, model: "m", tools: [t1, t2] })).not.toBe(k({ ...base, model: "m", tools: [t2, t1] }));
+    expect(k({ ...base, model: "m", tools: [t1, t2] })).toBe(k({ ...base, model: "m", tools: [t2, t1] }));
   });
 
   test("[1m] strip works for both alias families before decode", () => {
     // Legacy claude-ocx-* (pure decode, no registry needed).
     expect(resolveInboundModel("claude-ocx-cursor--gpt-5.6-luna[1m]")).toBe("cursor/gpt-5.6-luna");
+  });
+});
+
+describe("tool/system order stabilization (devlog 260727b_routed_tool_sort)", () => {
+  const messages = [{ role: "user", content: "hi" }];
+
+  test("toolsToResponses sorts tools by name regardless of input order", () => {
+    const toolB = { name: "B", description: "b", input_schema: { type: "object" } };
+    const toolA = { name: "A", description: "a", input_schema: { type: "object" } };
+    const body = anthropicToResponsesBody({ model: "m", max_tokens: 1, messages, tools: [toolB, toolA] }) as Record<string, any>;
+    expect((body.tools as Record<string, any>[]).map(t => t.name)).toEqual(["A", "B"]);
+  });
+
+  test("unnamed tools (e.g. web_search) sort first; ties keep relative order", () => {
+    const named = { name: "Read", input_schema: { type: "object" } };
+    const search = { type: "web_search_20250305", name: "web_search", max_uses: 1 };
+    const body = anthropicToResponsesBody({ model: "m", max_tokens: 1, messages, tools: [named, search] }) as Record<string, any>;
+    expect((body.tools as Record<string, any>[]).map(t => t.type)).toEqual(["web_search", "function"]);
+  });
+
+  test("prompt_cache_key is stable across any permutation of the same tool set", () => {
+    const t1 = { name: "A", input_schema: { type: "object" } };
+    const t2 = { name: "B", input_schema: { type: "object" } };
+    const t3 = { name: "C", input_schema: { type: "object" } };
+    const base = { model: "m", max_tokens: 1, messages, system: "be nice" };
+    const k = (tools: unknown[]) => anthropicToResponsesTranslation({ ...base, tools }).body.prompt_cache_key as string;
+    const key1 = k([t1, t2, t3]);
+    expect(k([t3, t1, t2])).toBe(key1);
+    expect(k([t2, t3, t1])).toBe(key1);
+  });
+
+  test("skills-list and deferred-tools-list system-reminder text sorted before joining into instructions", () => {
+    const skillsText =
+      "<system-reminder>\nUser-invocable skills:\n\n" +
+      "- zeta: does z things\n- alpha: does a things" +
+      "\n</system-reminder>";
+    const deferredText =
+      "<system-reminder>\nThe following deferred tools are now available via ToolSearch:\n" +
+      "zeta_tool\nalpha_tool" +
+      "\n</system-reminder>";
+    const body = anthropicToResponsesBody({
+      model: "m", max_tokens: 1, messages,
+      system: [{ type: "text", text: skillsText }, { type: "text", text: deferredText }],
+    }) as Record<string, any>;
+    const instructions = body.instructions as string;
+    expect(instructions.indexOf("- alpha: does a things")).toBeLessThan(instructions.indexOf("- zeta: does z things"));
+    expect(instructions.indexOf("alpha_tool")).toBeLessThan(instructions.indexOf("zeta_tool"));
+  });
+
+  test("normalizes reminder listings in system strings and role-system messages", () => {
+    const skillsText =
+      "<system-reminder>\nUser-invocable skills:\n\n" +
+      "- zeta: does z things\n- alpha: does a things" +
+      "\n</system-reminder>";
+    const deferredText =
+      "<system-reminder>\nThe following deferred tools are now available via ToolSearch:\n" +
+      "zeta_tool\nalpha_tool" +
+      "\n</system-reminder>";
+    const fromSystem = anthropicToResponsesTranslation({
+      model: "m", max_tokens: 1, messages, system: skillsText,
+    });
+    const fromMessage = anthropicToResponsesTranslation({
+      model: "m", max_tokens: 1,
+      messages: [{ role: "system", content: [{ type: "text", text: skillsText }] }, ...messages],
+    });
+    const deferred = anthropicToResponsesBody({
+      model: "m", max_tokens: 1,
+      messages: [{ role: "system", content: deferredText }, ...messages],
+    }) as Record<string, any>;
+    expect(fromSystem.body.instructions).toBe(fromMessage.body.instructions);
+    expect(fromSystem.body.prompt_cache_key).toBe(fromMessage.body.prompt_cache_key);
+    expect(String(fromMessage.body.instructions).indexOf("- alpha: does a things"))
+      .toBeLessThan(String(fromMessage.body.instructions).indexOf("- zeta: does z things"));
+    expect(String(deferred.instructions).indexOf("alpha_tool"))
+      .toBeLessThan(String(deferred.instructions).indexOf("zeta_tool"));
+  });
+
+  test("non-matching system text is left unchanged", () => {
+    const body = anthropicToResponsesBody({
+      model: "m", max_tokens: 1, messages,
+      system: [{ type: "text", text: "You are Claude Code." }],
+    }) as Record<string, any>;
+    expect(body.instructions).toBe("You are Claude Code.");
   });
 });
 

--- a/tests/claude-messages-endpoint.test.ts
+++ b/tests/claude-messages-endpoint.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -530,6 +531,7 @@ test("native openai-responses route carries prompt_cache_key + synthesized sessi
       body: JSON.stringify({
         model: "native/gpt-test",
         max_tokens: 128,
+        system: "cache-stable instructions",
         messages: [{ role: "user", content: "hi" }],
         metadata: { user_id: "user_abc123_account__session_11111111-2222-3333-4444-555555555555" },
         thinking: { type: "adaptive", display: "omitted" },
@@ -545,7 +547,10 @@ test("native openai-responses route carries prompt_cache_key + synthesized sessi
     expect(capture.body?.user).toBeUndefined();
     expect(capture.body?.max_output_tokens).toBeUndefined();
     expect(capture.body?.reasoning?.effort).toBe("high");
-    expect(capture.headers?.["session_id"]).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-8[0-9a-f]{3}-[0-9a-f]{12}$/);
+    const metadataUserId = "user_abc123_account__session_11111111-2222-3333-4444-555555555555";
+    const h = createHash("sha256").update(metadataUserId).digest("hex").slice(0, 32);
+    const expectedSessionId = `${h.slice(0, 8)}-${h.slice(8, 12)}-4${h.slice(13, 16)}-8${h.slice(17, 20)}-${h.slice(20, 32)}`;
+    expect(capture.headers?.["session_id"]).toBe(expectedSessionId);
   } finally {
     server.stop(true);
     upstream.stop(true);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Claude Code request handling with consistent ordering for tools and system-reminder listings.
  - Added deterministic session affinity for requests that include a session identifier.

- **Bug Fixes**
  - Prompt cache keys now remain stable when equivalent tools are supplied in different orders.
  - Preserved non-matching system instructions without modification.
  - Clarified caching and session-routing behavior in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->