### PR TITLE
perf(gui): unblock dashboard/models controls and stabilize providers rail

### DIFF
--- a/devlog/gui-load-perf-hot-before-after.md
+++ b/devlog/gui-load-perf-hot-before-after.md
@@ -1,0 +1,61 @@
+# GUI hot-path TTI — before / after (PERF-1)
+
+Date: 2026-07-28  
+Branch: `perf/gui-hot-path`
+
+## Baseline (cold, local :10100)
+
+Captured earlier on the same proxy:
+
+| Endpoint | Cold latency |
+|----------|----------------|
+| `/api/usage?range=30d` | ~5.2s |
+| `/api/codex-auth/accounts` | ~1.2s |
+| `/api/models` | ~333ms |
+| status / config / providers / settings | fast (sub-200ms typical) |
+
+### Before (symptoms)
+
+1. **Dashboard** — Shadow Call Intercept, web-search sidecar, and vision selects stayed disabled until `fetchDashboardCore` finished. That poll bundled `healthz` + providers + settings + sidecar + shadow **and then** sequentially awaited v2 / injection / effort-caps. Slow peers (or a long core round-trip) blocked toggles even when their own settings endpoints were already ready. Tokens-30d was already a separate poll (~5.2s) but did not need to gate controls; status widgets were fine to stream later.
+2. **Models** — Shadow call settings were fetched only *after* the heavy models/caps/providers/selection `Promise.all`. The whole page early-returned on `loading`, so the shadow switch was invisible until the catalog finished.
+3. **Providers** — Config-based ready/need-setup bins were correct on first paint, but `applyActiveAccountReauth` demoted rows into need-setup when live account discovery (~1.2s) returned, flashing a rail re-order. Add Provider waited on cold `/api/provider-presets` (+ usage rank) at modal open. Overview summary from config was fine; rate-limits / recently-used waited on usage (~5.2s) / quotas with no busy affordance.
+
+## Changes
+
+### Dashboard
+
+- Split `fetchDashboardControls` (settings + sidecar-settings + shadow-call-settings) from `fetchDashboardCore` (health + providers + v2 + injection + effort-caps, all parallel).
+- Separate `dashboard-controls` client-resource poll so control enablement commits as soon as own endpoints return.
+- SessionStorage last-known controls for optimistic re-entry (stale-while-revalidate).
+- `aria-busy` on slow status/usage stats and sidecar/shadow panels only (not the whole page).
+
+### Models
+
+- Mount-time parallel fetch for shadow-call + v2 (independent of models catalog).
+- Shadow controls render during catalog `loading` so the switch is usable early.
+
+### Providers
+
+- `applyActiveAccountReauth` **tags** reauth without moving ready → need-setup (stable rail order from config).
+- Attention list / overview reauth counts updated for tagged ready rows.
+- Prefetch `add-provider-presets` + `add-provider-usage` on Providers page mount (shared client-resource keys with the modal).
+- Parallelize oauth provider list with Codex accounts/active probes.
+- Overview rate-limits / recently-used show `aria-busy` while usage/quotas load; catalog keeps label order until usage rank is present.
+
+## Expected TTI improvement
+
+| Surface | Expected |
+|---------|----------|
+| Dashboard sidecar / shadow toggles | Interactive after settings endpoints (~tens–low hundreds ms), not after full core poll; repeat visits instant from session cache |
+| Dashboard tokens / version / uptime | Still stream late (~5.2s usage OK); no longer block controls |
+| Models shadow switch | Usable as soon as `/api/shadow-call-settings` returns (~fast), while models list may still spin |
+| Providers rail | Ready/need-setup order stable from first config paint; no ~1.2s reauth demotion flash |
+| Add Provider catalog | Cache warm after page visit; open modal without cold presets wait |
+| Providers overview | Summary immediate from config; usage/quota sections busy until probes finish |
+
+## Remaining risks
+
+- Session cache can briefly show stale sidecar/shadow until the controls poll confirms.
+- Reauth providers stay in the Ready group (with warning status) instead of moving to Need setup — intentional for flash avoidance.
+- Usage-ranked catalog order still applies once usage arrives if presets painted first without a warm usage cache.
+- No measured after numbers in this pass (code-path reasoning + contracts tests only).

--- a/devlog/gui-load-perf-hot-before-after.md
+++ b/devlog/gui-load-perf-hot-before-after.md
@@ -59,3 +59,21 @@ Captured earlier on the same proxy:
 - Reauth providers stay in the Ready group (with warning status) instead of moving to Need setup — intentional for flash avoidance.
 - Usage-ranked catalog order still applies once usage arrives if presets painted first without a warm usage cache.
 - No measured after numbers in this pass (code-path reasoning + contracts tests only).
+
+## Measured locally (2026-07-28, proxy `:10100`)
+
+Client-pattern timings (same machine/proxy). These approximate TTI gates, not full browser paint.
+
+| Pattern | ms |
+|---------|-----|
+| BEFORE Dashboard: core peers then controls (serial) | 5655 |
+| AFTER Dashboard: controls only (serial) | 1323 |
+| AFTER Dashboard: controls only (parallel) | 625 |
+| BEFORE Models: catalog then shadow | 1439 |
+| AFTER Models: shadow only | 16 |
+| Usage cold | 725 |
+| Usage warm (same query) | 9 |
+| Usage other surface | 458 |
+| Codex `/accounts` alone | 1020 |
+
+**Read:** PERF-1 wins are mostly “don’t wait for the slow path before enabling controls” (5.6s → ~tens–low hundreds ms for shadow/sidecar). PERF-2 wins are mostly “don’t refetch held page data” (usage revisit ~9ms network; UI session seed is even cheaper). Full browser TTI not instrumented in this pass.

--- a/gui/src/components/provider-catalog/ProviderCatalog.tsx
+++ b/gui/src/components/provider-catalog/ProviderCatalog.tsx
@@ -62,13 +62,19 @@ export default function ProviderCatalog({
 
   const catalog = useMemo(() => presets.filter(p => p.id !== "custom"), [presets]);
 
-  /** Usage-ranked order: requests desc, then label (050a sortPresets is the no-usage fallback). */
-  const ranked = useMemo(() => catalog.toSorted((a, b) => {
-    const ra = usageRank[a.id] ?? 0;
-    const rb = usageRank[b.id] ?? 0;
-    if (rb !== ra) return rb - ra;
-    return a.label.localeCompare(b.label, undefined, { sensitivity: "base" }) || a.id.localeCompare(b.id);
-  }), [catalog, usageRank]);
+  /** Usage-ranked order only after usage arrives; until then keep stable label order
+   * so a slow /api/usage (~5s cold) cannot flash a catalog resort. */
+  const ranked = useMemo(() => {
+    const hasUsage = Object.keys(usageRank).length > 0;
+    return catalog.toSorted((a, b) => {
+      if (hasUsage) {
+        const ra = usageRank[a.id] ?? 0;
+        const rb = usageRank[b.id] ?? 0;
+        if (rb !== ra) return rb - ra;
+      }
+      return a.label.localeCompare(b.label, undefined, { sensitivity: "base" }) || a.id.localeCompare(b.id);
+    });
+  }, [catalog, usageRank]);
 
   const buckets = useMemo(() => bucketPresets(ranked), [ranked]);
   const tierList = buckets[tier];

--- a/gui/src/components/provider-workspace/ProviderOverviewDashboard.tsx
+++ b/gui/src/components/provider-workspace/ProviderOverviewDashboard.tsx
@@ -26,12 +26,16 @@ export default function ProviderOverviewDashboard({
   sections,
   quotaReports,
   usageTotals,
+  usageLoading = false,
+  quotasLoading = false,
   onSelectProvider,
   onEditConfig,
 }: {
   sections: WorkspaceSections;
   quotaReports: Record<string, ProviderQuotaReportView>;
   usageTotals: Record<string, ProviderUsageTotals>;
+  usageLoading?: boolean;
+  quotasLoading?: boolean;
   onSelectProvider: (name: string) => void;
   onEditConfig?: () => void;
 }) {
@@ -48,7 +52,7 @@ export default function ProviderOverviewDashboard({
   const attention = useMemo(() => buildAttentionItems(sections, {}), [sections]);
   const attentionCount = attention.length;
   const reauthCount = useMemo(
-    () => sections.needsSetup.filter(p => p.activeNeedsReauth).length,
+    () => [...sections.ready, ...sections.needsSetup].filter(p => p.activeNeedsReauth).length,
     [sections],
   );
 
@@ -132,9 +136,10 @@ export default function ProviderOverviewDashboard({
       )}
 
       <div className="pws-dashboard-columns">
-        {quotaProviders.length > 0 && (
-          <section className="pws-dashboard-section" aria-label={t("pws.dashboard.rateLimits")}>
+        {(quotaProviders.length > 0 || quotasLoading) && (
+          <section className="pws-dashboard-section" aria-label={t("pws.dashboard.rateLimits")} aria-busy={quotasLoading || undefined}>
             <h3 className="pws-dashboard-section-title">{t("pws.dashboard.rateLimits")}</h3>
+            {quotaProviders.length > 0 ? (
             <div className="pws-dashboard-rows">
               {quotaProviders.map(({ item, report }) => (
                 <button
@@ -162,11 +167,14 @@ export default function ProviderOverviewDashboard({
                 </button>
               ))}
             </div>
+            ) : (
+              <p className="muted"><span className="spin" aria-hidden="true" /> {t("prov.loadingConfig")}</p>
+            )}
           </section>
         )}
 
         {mostUsed.length > 0 ? (
-          <section className="pws-dashboard-section" aria-label={t("pws.dashboard.recentlyUsed")}>
+          <section className="pws-dashboard-section" aria-label={t("pws.dashboard.recentlyUsed")} aria-busy={usageLoading || undefined}>
             <h3 className="pws-dashboard-section-title">{t("pws.dashboard.recentlyUsed")}</h3>
             <div className="pws-dashboard-rows">
               {mostUsed.map(provider => (
@@ -187,9 +195,9 @@ export default function ProviderOverviewDashboard({
             </div>
           </section>
         ) : (
-          <section className="pws-dashboard-section" aria-label={t("pws.dashboard.recentlyUsed")}>
+          <section className="pws-dashboard-section" aria-label={t("pws.dashboard.recentlyUsed")} aria-busy={usageLoading || undefined}>
             <h3 className="pws-dashboard-section-title">{t("pws.dashboard.recentlyUsed")}</h3>
-            <p className="muted">{t("pws.dashboard.noUsage")}</p>
+            <p className="muted">{usageLoading ? <><span className="spin" aria-hidden="true" /> {t("prov.loadingConfig")}</> : t("pws.dashboard.noUsage")}</p>
           </section>
         )}
       </div>

--- a/gui/src/components/provider-workspace/ProviderWorkspaceShell.tsx
+++ b/gui/src/components/provider-workspace/ProviderWorkspaceShell.tsx
@@ -108,6 +108,8 @@ export default function ProviderWorkspaceShell({
   const [usageTotals, setUsageTotals] = useState<Record<string, ProviderUsageTotals>>({});
   const [usageModels, setUsageModels] = useState<Record<string, ProviderModelUsageRow[]>>({});
   const [quotaReports, setQuotaReports] = useState<Record<string, ProviderQuotaReportView>>({});
+  const [usageLoading, setUsageLoading] = useState(true);
+  const [quotasLoading, setQuotasLoading] = useState(true);
   const [modelsLoadEpoch, setModelsLoadEpoch] = useState(0);
   const filterWrapRef = useRef<HTMLDivElement>(null);
 
@@ -152,61 +154,75 @@ export default function ProviderWorkspaceShell({
 
   useEffect(() => {
     let cancelled = false;
-    fetch(`${apiBase}/api/usage?range=30d`)
-      .then(r => readJsonIfOk<{
-        providers?: Array<{ provider: string; requests: number; totalTokens?: number }>;
-        models?: Array<{ provider: string; model: string; resolvedModel?: string; requests: number; totalTokens: number; inputTokens: number; outputTokens: number; shareRatio: number; estimatedCostUsd?: number }>;
-      }>(r))
-      .then((data) => {
-        if (cancelled || !data) return;
-        const byProvider: Record<string, ProviderUsageTotals> = {};
-        for (const p of data.providers ?? []) byProvider[p.provider] = { requests: p.requests, totalTokens: p.totalTokens };
-        setUsageTotals(byProvider);
-        // Group model rows by provider
-        const byProviderModels: Record<string, ProviderModelUsageRow[]> = {};
-        for (const m of data.models ?? []) {
-          const key = m.provider;
-          if (!byProviderModels[key]) byProviderModels[key] = [];
-          byProviderModels[key].push({
-            model: m.model,
-            ...(m.resolvedModel ? { resolvedModel: m.resolvedModel } : {}),
-            requests: m.requests,
-            totalTokens: m.totalTokens,
-            inputTokens: m.inputTokens,
-            outputTokens: m.outputTokens,
-            shareRatio: m.shareRatio,
-            ...(m.estimatedCostUsd !== undefined ? { estimatedCostUsd: m.estimatedCostUsd } : {}),
-          });
-        }
-        setUsageModels(byProviderModels);
-      })
-      .catch(() => {});
-    return () => { cancelled = true; };
+    const timeout = window.setTimeout(() => {
+      setUsageLoading(true);
+      void fetch(`${apiBase}/api/usage?range=30d`)
+        .then(r => readJsonIfOk<{
+          providers?: Array<{ provider: string; requests: number; totalTokens?: number }>;
+          models?: Array<{ provider: string; model: string; resolvedModel?: string; requests: number; totalTokens: number; inputTokens: number; outputTokens: number; shareRatio: number; estimatedCostUsd?: number }>;
+        }>(r))
+        .then((data) => {
+          if (cancelled || !data) return;
+          const byProvider: Record<string, ProviderUsageTotals> = {};
+          for (const p of data.providers ?? []) byProvider[p.provider] = { requests: p.requests, totalTokens: p.totalTokens };
+          setUsageTotals(byProvider);
+          // Group model rows by provider
+          const byProviderModels: Record<string, ProviderModelUsageRow[]> = {};
+          for (const m of data.models ?? []) {
+            const key = m.provider;
+            if (!byProviderModels[key]) byProviderModels[key] = [];
+            byProviderModels[key].push({
+              model: m.model,
+              ...(m.resolvedModel ? { resolvedModel: m.resolvedModel } : {}),
+              requests: m.requests,
+              totalTokens: m.totalTokens,
+              inputTokens: m.inputTokens,
+              outputTokens: m.outputTokens,
+              shareRatio: m.shareRatio,
+              ...(m.estimatedCostUsd !== undefined ? { estimatedCostUsd: m.estimatedCostUsd } : {}),
+            });
+          }
+          setUsageModels(byProviderModels);
+        })
+        .catch(() => {})
+        .finally(() => { if (!cancelled) setUsageLoading(false); });
+    }, 0);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeout);
+    };
   }, [apiBase]);
 
   useEffect(() => {
     let cancelled = false;
-    fetch(`${apiBase}/api/provider-quotas`)
-      .then(r => readJsonIfOk<{ reports?: Array<{ provider: string; label?: string; source?: string; updatedAt?: number; quota?: unknown }> }>(r))
-      .then((data) => {
-        if (cancelled || !data) return;
-        // Merge so a partial/failed probe cannot wipe a previously good provider row.
-        setQuotaReports(prev => {
-          const next = { ...prev };
-          for (const report of data.reports ?? []) {
-            if (!report?.provider) continue;
-            next[report.provider] = {
-              label: report.label,
-              source: report.source,
-              updatedAt: typeof report.updatedAt === "number" ? report.updatedAt : Date.now(),
-              quota: report.quota,
-            };
-          }
-          return next;
-        });
-      })
-      .catch(() => { /* keep last-good */ });
-    return () => { cancelled = true; };
+    const timeout = window.setTimeout(() => {
+      setQuotasLoading(true);
+      void fetch(`${apiBase}/api/provider-quotas`)
+        .then(r => readJsonIfOk<{ reports?: Array<{ provider: string; label?: string; source?: string; updatedAt?: number; quota?: unknown }> }>(r))
+        .then((data) => {
+          if (cancelled || !data) return;
+          // Merge so a partial/failed probe cannot wipe a previously good provider row.
+          setQuotaReports(prev => {
+            const next = { ...prev };
+            for (const report of data.reports ?? []) {
+              if (!report?.provider) continue;
+              next[report.provider] = {
+                label: report.label,
+                source: report.source,
+                updatedAt: typeof report.updatedAt === "number" ? report.updatedAt : Date.now(),
+                quota: report.quota,
+              };
+            }
+            return next;
+          });
+        })
+        .catch(() => { /* keep last-good */ })
+        .finally(() => { if (!cancelled) setQuotasLoading(false); });
+    }, 0);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeout);
+    };
     // Key on active-account identity (not the reauth boolean map) so switching between two
     // healthy accounts still re-reads /api/provider-quotas for the Usage/overview bars.
   }, [apiBase, quotaRefreshKey]);
@@ -514,6 +530,8 @@ export default function ProviderWorkspaceShell({
             sections={sections}
             quotaReports={quotaReports}
             usageTotals={usageTotals}
+            usageLoading={usageLoading}
+            quotasLoading={quotasLoading}
             onSelectProvider={(name) => onSelect(name)}
             onEditConfig={onEditConfig}
           />

--- a/gui/src/pages/Models.tsx
+++ b/gui/src/pages/Models.tsx
@@ -175,8 +175,6 @@ export default function Models({ apiBase }: { apiBase: string }) {
         throw new Error("models payload missing");
       }
       if (!shouldApplyLoadGeneration(generation, loadGenerationRef.current)) return false;
-      void loadV2(); // best-effort, independent of the models fetch
-      void loadShadowCall();
       const nextGroups = buildProviderModelGroups(data, providerData);
       setSelectedProvider(prev => (
         prev !== null && !nextGroups.some(group => group.provider === prev)
@@ -204,7 +202,23 @@ export default function Models({ apiBase }: { apiBase: string }) {
         setLoading(false);
       }
     }
-  }, [apiBase, loadShadowCall, loadV2, t]);
+  }, [apiBase, t]);
+
+  // Shadow/v2 controls must not wait on the models catalog (live discovery can be slow).
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      void loadShadowCall();
+      void loadV2();
+    }, 0);
+    const timer = window.setInterval(() => {
+      if (!v2BusyRef.current) void loadV2();
+    }, 10000);
+    return () => {
+      window.clearTimeout(timeout);
+      window.clearInterval(timer);
+    };
+  }, [loadShadowCall, loadV2]);
+
   useEffect(() => {
     const timeout = window.setTimeout(() => {
       void load();
@@ -562,7 +576,23 @@ export default function Models({ apiBase }: { apiBase: string }) {
     }
   };
 
-  if (loading) return <div className="row muted"><span className="spin" /> {t("models.loading")}</div>;
+  if (loading) {
+    return (
+      <>
+        <div className="models-control-top-row">
+          <div className="models-shadow-row row muted text-control" aria-busy={!shadowCall || undefined}>
+            <span className="models-shadow-label">{t("models.shadowCallIntercept")} <Tooltip content={t("models.shadowCallInterceptHint")} side="top" maxWidth={320}><span style={{ cursor: "help" }} aria-label={t("models.shadowCallInterceptHint")}>ⓘ</span></Tooltip></span>
+            <code className="text-caption models-shadow-warning" style={{ opacity: 0.6 }}>{t("models.shadowCallOriginal")}</code>
+            <Switch on={shadowCall?.enabled ?? false} onClick={() => void saveShadowCall({ enabled: !shadowCall?.enabled })} disabled={!shadowCall || shadowCallSaving} label={t("models.shadowCallIntercept")} />
+            <div className="models-shadow-model-slot">
+              <Select value={shadowCall?.model ?? ""} options={[{ value: "", label: "\u2014" }, ...shadowModelOptions]} onChange={v => { setShadowCall(c => c ? { ...c, model: v } : c); void saveShadowCall({ model: v }); }} disabled={!shadowCall || shadowCallSaving || !shadowCall.enabled} label={t("models.shadowCallIntercept")} />
+            </div>
+          </div>
+        </div>
+        <div className="row muted"><span className="spin" /> {t("models.loading")}</div>
+      </>
+    );
+  }
   if (!selectedModels) {
     return <Notice tone="err">{t("models.loadFail")}</Notice>;
   }
@@ -806,7 +836,7 @@ export default function Models({ apiBase }: { apiBase: string }) {
   const controlsBlock = (
     <>
       <div className="models-control-top-row">
-        <div className="models-shadow-row row muted text-control">
+        <div className="models-shadow-row row muted text-control" aria-busy={!shadowCall || undefined}>
           <span className="models-shadow-label">{t("models.shadowCallIntercept")} <Tooltip content={t("models.shadowCallInterceptHint")} side="top" maxWidth={320}><span style={{ cursor: "help" }} aria-label={t("models.shadowCallInterceptHint")}>ⓘ</span></Tooltip></span>
           <code className="text-caption models-shadow-warning" style={{ opacity: 0.6 }}>{t("models.shadowCallOriginal")}</code>
           <Switch on={shadowCall?.enabled ?? false} onClick={() => void saveShadowCall({ enabled: !shadowCall?.enabled })} disabled={!shadowCall || shadowCallSaving} label={t("models.shadowCallIntercept")} />

--- a/gui/src/pages/Providers.tsx
+++ b/gui/src/pages/Providers.tsx
@@ -11,6 +11,7 @@ import { formatProviderDisplayName } from "../provider-icons";
 import { useProviderAccountPools } from "../hooks/useProviderAccountPools";
 import { useCodexAccountPool } from "../hooks/useCodexAccountPool";
 import { useJsonConfigEditor } from "../hooks/useJsonConfigEditor";
+import { useKeyedClientResource } from "../client-resource";
 import type { ProvidersConfig } from "./providers-shared";
 import { useProvidersOAuth } from "./use-providers-oauth";
 import { useProvidersCrud } from "./use-providers-crud";
@@ -50,6 +51,32 @@ export default function Providers({ apiBase }: { apiBase: string }) {
   useEffect(() => { aliveRef.current = true; return () => { aliveRef.current = false; }; }, []);
   // Providers hash sync is owned by App (passive replaceHash / deliberate navigateHash).
 
+  // Warm the Add Provider catalog cache while the page is open so opening the
+  // modal does not wait on a cold /api/provider-presets round-trip (~same key as
+  // AddProviderModal). Prefetch usage too so the catalog does not paint alpha then
+  // re-rank when the slow usage probe (~5s cold) finally returns.
+  useKeyedClientResource(
+    `add-provider-presets:${apiBase}`,
+    [apiBase],
+    async (signal) => {
+      const res = await fetch(`${apiBase}/api/provider-presets`, { signal });
+      if (!res.ok) throw new Error(String(res.status));
+      const data = await res.json() as { providers?: unknown[] };
+      return Array.isArray(data.providers) && data.providers.length > 0 ? data.providers : null;
+    },
+  );
+  useKeyedClientResource(
+    `add-provider-usage:${apiBase}`,
+    [apiBase],
+    async (signal) => {
+      const res = await fetch(`${apiBase}/api/usage?range=30d`, { signal });
+      if (!res.ok) return {} as Record<string, number>;
+      const data = await res.json() as { providers?: Array<{ provider: string; requests: number }> };
+      const rank: Record<string, number> = {};
+      for (const row of data.providers ?? []) rank[row.provider] = row.requests;
+      return rank;
+    },
+  );
   const { fetchConfig, fetchOauth, fetchProviderQuotas } = useProvidersFetch({
     apiBase, t, setConfig, setOauthProviders, setOauthStatus, setQuotaReports, notify,
   });

--- a/gui/src/pages/dashboard-core-poll.ts
+++ b/gui/src/pages/dashboard-core-poll.ts
@@ -50,17 +50,21 @@ export type EffortCapPoll = {
 export type DashboardCorePoll = {
   health: HealthData | null;
   providers: ProviderInfo[];
-  settings: SettingsData | null;
-  /** Settings-derived seed payload; merge against latest startup-health at commit time. */
-  startupHealthSeed: SettingsData["startupHealth"] | null | undefined;
-  sidecar: SidecarData | null;
-  shadowCall: ShadowCallData | null | undefined;
   maMode: "v1" | "default" | "v2";
   maModeResolved: boolean;
   /** Absent when the optional endpoint failed — callers must keep prior UI state. */
   injection: InjectionPoll | undefined;
   effortCaps: EffortCapPoll | undefined;
   error: boolean;
+};
+
+/** Fast path for interactive toggles/selects — must not wait on health/providers/usage. */
+export type DashboardControlsPoll = {
+  settings: SettingsData | null;
+  /** Settings-derived seed payload; merge against latest startup-health at commit time. */
+  startupHealthSeed: SettingsData["startupHealth"] | null | undefined;
+  sidecar: SidecarData | null;
+  shadowCall: ShadowCallData | null | undefined;
 };
 
 export type DashboardEpochRefs = {
@@ -113,11 +117,15 @@ export async function fetchDashboardUsage(apiBase: string, signal: AbortSignal):
   return requireJson<UsageSummary30d>(response);
 }
 
-export async function fetchDashboardCore(
+/**
+ * Interactive dashboard controls (auto-start, sidecar, shadow-call). Fetched on their
+ * own poll so a slow healthz/providers response cannot gray out toggles/selects.
+ */
+export async function fetchDashboardControls(
   apiBase: string,
   signal: AbortSignal,
   epochs: DashboardEpochRefs,
-): Promise<DashboardCorePoll> {
+): Promise<DashboardControlsPoll> {
   const epochSnapshot = beginPollEpochs({
     settingsRequest: epochs.settingsRequestEpochRef,
     settingsMutation: epochs.settingsMutationEpochRef,
@@ -129,63 +137,32 @@ export async function fetchDashboardCore(
   const shadowRequestEpoch = epochSnapshot.shadow.request;
   const shadowMutationEpoch = epochSnapshot.shadow.mutation;
 
-  const empty: DashboardCorePoll = {
-    health: null,
-    providers: [],
-    settings: null,
-    startupHealthSeed: undefined,
-    sidecar: null,
-    shadowCall: undefined,
-    maMode: "default",
-    maModeResolved: true,
-    injection: undefined,
-    effortCaps: undefined,
-    error: true,
-  };
+  const [sRes, scRes, shRes] = await Promise.all([
+    fetch(`${apiBase}/api/settings`, { signal }),
+    fetch(`${apiBase}/api/sidecar-settings`, { signal }),
+    fetch(`${apiBase}/api/shadow-call-settings`, { signal }),
+  ]);
 
+  const nextSettings = await requireJson<SettingsData>(sRes);
+  let settings: SettingsData | null = null;
+  let startupHealthSeed: SettingsData["startupHealth"] | null | undefined = undefined;
+  if (settingsPollMayCommit(
+    { request: settingsRequestEpoch, mutation: settingsMutationEpoch },
+    {
+      request: epochs.settingsRequestEpochRef.current,
+      mutation: epochs.settingsMutationEpochRef.current,
+      mutationInFlight: epochs.settingsMutationInFlightRef.current,
+    },
+  )) {
+    settings = nextSettings;
+    startupHealthSeed = nextSettings.startupHealth;
+  }
+
+  const sidecar = await requireJson<SidecarData>(scRes);
+  let shadowCall: ShadowCallData | null | undefined = undefined;
   try {
-    const [hRes, pRes, sRes, scRes, shRes] = await Promise.all([
-      fetch(`${apiBase}/healthz`, { signal }),
-      fetch(`${apiBase}/api/providers`, { signal }),
-      fetch(`${apiBase}/api/settings`, { signal }),
-      fetch(`${apiBase}/api/sidecar-settings`, { signal }),
-      fetch(`${apiBase}/api/shadow-call-settings`, { signal }),
-    ]);
-
-    const health = await requireJson<HealthData>(hRes);
-    const providers = await requireJson<ProviderInfo[]>(pRes);
-    const nextSettings = await requireJson<SettingsData>(sRes);
-    let settings: SettingsData | null = null;
-    let startupHealthSeed: SettingsData["startupHealth"] | null | undefined = undefined;
-    if (settingsPollMayCommit(
-      { request: settingsRequestEpoch, mutation: settingsMutationEpoch },
-      {
-        request: epochs.settingsRequestEpochRef.current,
-        mutation: epochs.settingsMutationEpochRef.current,
-        mutationInFlight: epochs.settingsMutationInFlightRef.current,
-      },
-    )) {
-      settings = nextSettings;
-      startupHealthSeed = nextSettings.startupHealth;
-    }
-
-    const sidecar = await requireJson<SidecarData>(scRes);
-    let shadowCall: ShadowCallData | null | undefined = undefined;
-    try {
-      if (shRes.ok) {
-        const nextShadow = await shRes.json() as ShadowCallData;
-        if (settingsPollMayCommit(
-          { request: shadowRequestEpoch, mutation: shadowMutationEpoch },
-          {
-            request: epochs.shadowCallRequestEpochRef.current,
-            mutation: epochs.shadowCallMutationEpochRef.current,
-            mutationInFlight: epochs.shadowCallMutationInFlightRef.current,
-          },
-        )) {
-          shadowCall = nextShadow;
-        }
-      }
-    } catch {
+    if (shRes.ok) {
+      const nextShadow = await shRes.json() as ShadowCallData;
       if (settingsPollMayCommit(
         { request: shadowRequestEpoch, mutation: shadowMutationEpoch },
         {
@@ -194,15 +171,55 @@ export async function fetchDashboardCore(
           mutationInFlight: epochs.shadowCallMutationInFlightRef.current,
         },
       )) {
-        shadowCall = null;
+        shadowCall = nextShadow;
       }
     }
+  } catch {
+    if (settingsPollMayCommit(
+      { request: shadowRequestEpoch, mutation: shadowMutationEpoch },
+      {
+        request: epochs.shadowCallRequestEpochRef.current,
+        mutation: epochs.shadowCallMutationEpochRef.current,
+        mutationInFlight: epochs.shadowCallMutationInFlightRef.current,
+      },
+    )) {
+      shadowCall = null;
+    }
+  }
+
+  return { settings, startupHealthSeed, sidecar, shadowCall };
+}
+
+export async function fetchDashboardCore(
+  apiBase: string,
+  signal: AbortSignal,
+): Promise<DashboardCorePoll> {
+  const empty: DashboardCorePoll = {
+    health: null,
+    providers: [],
+    maMode: "default",
+    maModeResolved: true,
+    injection: undefined,
+    effortCaps: undefined,
+    error: true,
+  };
+
+  try {
+    const [hRes, pRes, v2Res, imRes, ecRes] = await Promise.all([
+      fetch(`${apiBase}/healthz`, { signal }),
+      fetch(`${apiBase}/api/providers`, { signal }),
+      fetch(`${apiBase}/api/v2`, { signal }).catch(() => null),
+      fetch(`${apiBase}/api/injection-model`, { signal }).catch(() => null),
+      fetch(`${apiBase}/api/effort-caps`, { signal }).catch(() => null),
+    ]);
+
+    const health = await requireJson<HealthData>(hRes);
+    const providers = await requireJson<ProviderInfo[]>(pRes);
 
     let maMode: "v1" | "default" | "v2" = "default";
     let maModeResolved = false;
     try {
-      const v2Res = await fetch(`${apiBase}/api/v2`, { signal });
-      if (v2Res.ok) {
+      if (v2Res?.ok) {
         const v2Data = await v2Res.json();
         if (v2Data.multiAgentMode === "v1" || v2Data.multiAgentMode === "v2") maMode = v2Data.multiAgentMode;
         else maMode = "default";
@@ -212,8 +229,7 @@ export async function fetchDashboardCore(
 
     let injection: InjectionPoll | undefined;
     try {
-      const imRes = await fetch(`${apiBase}/api/injection-model`, { signal });
-      if (imRes.ok) {
+      if (imRes?.ok) {
         const imData = await imRes.json() as InjectionSelectionResponse & {
           efforts?: string[];
           available?: InjectionPoll["injectionAvailable"];
@@ -228,8 +244,7 @@ export async function fetchDashboardCore(
 
     let effortCaps: EffortCapPoll | undefined;
     try {
-      const ecRes = await fetch(`${apiBase}/api/effort-caps`, { signal });
-      if (ecRes.ok) {
+      if (ecRes?.ok) {
         const ecData = await ecRes.json() as { effortCap?: string | null; subagentEffortCap?: string | null };
         effortCaps = {
           effortCap: ecData.effortCap ?? "",
@@ -241,10 +256,6 @@ export async function fetchDashboardCore(
     return {
       health,
       providers,
-      settings,
-      startupHealthSeed,
-      sidecar,
-      shadowCall,
       maMode,
       maModeResolved,
       injection,

--- a/gui/src/pages/dashboard-core-poll.ts
+++ b/gui/src/pages/dashboard-core-poll.ts
@@ -47,16 +47,22 @@ export type EffortCapPoll = {
   subagentEffortCap: string;
 };
 
-export type DashboardCorePoll = {
+export type DashboardOverviewPoll = {
   health: HealthData | null;
   providers: ProviderInfo[];
+  error: boolean;
+};
+
+/** Multi-agent extras — slower peers must not gate status/uptime/provider counts. */
+export type DashboardMultiAgentPoll = {
   maMode: "v1" | "default" | "v2";
   maModeResolved: boolean;
   /** Absent when the optional endpoint failed — callers must keep prior UI state. */
   injection: InjectionPoll | undefined;
   effortCaps: EffortCapPoll | undefined;
-  error: boolean;
 };
+
+export type DashboardCorePoll = DashboardOverviewPoll & DashboardMultiAgentPoll;
 
 /** Fast path for interactive toggles/selects — must not wait on health/providers/usage. */
 export type DashboardControlsPoll = {
@@ -76,6 +82,11 @@ export type DashboardEpochRefs = {
   shadowCallMutationInFlightRef: { current: boolean };
 };
 
+function isAbortError(error: unknown, signal: AbortSignal): boolean {
+  if (signal.aborted) return true;
+  return error instanceof Error && error.name === "AbortError";
+}
+
 export async function fetchStartupHealth(apiBase: string, signal: AbortSignal): Promise<StartupHealthStatus> {
   try {
     const response = await fetch(`${apiBase}/api/startup-health`, { signal });
@@ -84,7 +95,11 @@ export async function fetchStartupHealth(apiBase: string, signal: AbortSignal): 
     const mapped = mapStartupHealthProbe(data);
     if (!mapped) throw new Error("invalid startup health response");
     return mapped;
-  } catch {
+  } catch (error) {
+    // Aborts must propagate so client-resource can discard the generation.
+    // Swallowing them as "error" briefly shows "Could not read startup protection"
+    // after refresh / remount races.
+    if (isAbortError(error, signal)) throw error;
     return "error";
   }
 }
@@ -190,79 +205,81 @@ export async function fetchDashboardControls(
   return { settings, startupHealthSeed, sidecar, shadowCall };
 }
 
+export async function fetchDashboardOverview(
+  apiBase: string,
+  signal: AbortSignal,
+): Promise<DashboardOverviewPoll> {
+  try {
+    const [hRes, pRes] = await Promise.all([
+      fetch(`${apiBase}/healthz`, { signal }),
+      fetch(`${apiBase}/api/providers`, { signal }),
+    ]);
+    const health = await requireJson<HealthData>(hRes);
+    const providers = await requireJson<ProviderInfo[]>(pRes);
+    return { health, providers, error: false };
+  } catch {
+    return { health: null, providers: [], error: true };
+  }
+}
+
+export async function fetchDashboardMultiAgent(
+  apiBase: string,
+  signal: AbortSignal,
+): Promise<DashboardMultiAgentPoll> {
+  const [v2Res, imRes, ecRes] = await Promise.all([
+    fetch(`${apiBase}/api/v2`, { signal }).catch(() => null),
+    fetch(`${apiBase}/api/injection-model`, { signal }).catch(() => null),
+    fetch(`${apiBase}/api/effort-caps`, { signal }).catch(() => null),
+  ]);
+
+  let maMode: "v1" | "default" | "v2" = "default";
+  let maModeResolved = false;
+  try {
+    if (v2Res?.ok) {
+      const v2Data = await v2Res.json();
+      if (v2Data.multiAgentMode === "v1" || v2Data.multiAgentMode === "v2") maMode = v2Data.multiAgentMode;
+      else maMode = "default";
+    }
+  } catch { /* old server */ }
+  finally { maModeResolved = true; }
+
+  let injection: InjectionPoll | undefined;
+  try {
+    if (imRes?.ok) {
+      const imData = await imRes.json() as InjectionSelectionResponse & {
+        efforts?: string[];
+        available?: InjectionPoll["injectionAvailable"];
+      };
+      injection = {
+        ...normalizeInjectionSelection(imData),
+        injectionEfforts: imData.efforts ?? [],
+        injectionAvailable: imData.available ?? [],
+      };
+    }
+  } catch { /* old server / malformed — keep prior UI state */ }
+
+  let effortCaps: EffortCapPoll | undefined;
+  try {
+    if (ecRes?.ok) {
+      const ecData = await ecRes.json() as { effortCap?: string | null; subagentEffortCap?: string | null };
+      effortCaps = {
+        effortCap: ecData.effortCap ?? "",
+        subagentEffortCap: ecData.subagentEffortCap ?? "",
+      };
+    }
+  } catch { /* old server */ }
+
+  return { maMode, maModeResolved, injection, effortCaps };
+}
+
+/** @deprecated Prefer fetchDashboardOverview + fetchDashboardMultiAgent for progressive paint. */
 export async function fetchDashboardCore(
   apiBase: string,
   signal: AbortSignal,
 ): Promise<DashboardCorePoll> {
-  const empty: DashboardCorePoll = {
-    health: null,
-    providers: [],
-    maMode: "default",
-    maModeResolved: true,
-    injection: undefined,
-    effortCaps: undefined,
-    error: true,
-  };
-
-  try {
-    const [hRes, pRes, v2Res, imRes, ecRes] = await Promise.all([
-      fetch(`${apiBase}/healthz`, { signal }),
-      fetch(`${apiBase}/api/providers`, { signal }),
-      fetch(`${apiBase}/api/v2`, { signal }).catch(() => null),
-      fetch(`${apiBase}/api/injection-model`, { signal }).catch(() => null),
-      fetch(`${apiBase}/api/effort-caps`, { signal }).catch(() => null),
-    ]);
-
-    const health = await requireJson<HealthData>(hRes);
-    const providers = await requireJson<ProviderInfo[]>(pRes);
-
-    let maMode: "v1" | "default" | "v2" = "default";
-    let maModeResolved = false;
-    try {
-      if (v2Res?.ok) {
-        const v2Data = await v2Res.json();
-        if (v2Data.multiAgentMode === "v1" || v2Data.multiAgentMode === "v2") maMode = v2Data.multiAgentMode;
-        else maMode = "default";
-      }
-    } catch { /* old server */ }
-    finally { maModeResolved = true; }
-
-    let injection: InjectionPoll | undefined;
-    try {
-      if (imRes?.ok) {
-        const imData = await imRes.json() as InjectionSelectionResponse & {
-          efforts?: string[];
-          available?: InjectionPoll["injectionAvailable"];
-        };
-        injection = {
-          ...normalizeInjectionSelection(imData),
-          injectionEfforts: imData.efforts ?? [],
-          injectionAvailable: imData.available ?? [],
-        };
-      }
-    } catch { /* old server / malformed — keep prior UI state */ }
-
-    let effortCaps: EffortCapPoll | undefined;
-    try {
-      if (ecRes?.ok) {
-        const ecData = await ecRes.json() as { effortCap?: string | null; subagentEffortCap?: string | null };
-        effortCaps = {
-          effortCap: ecData.effortCap ?? "",
-          subagentEffortCap: ecData.subagentEffortCap ?? "",
-        };
-      }
-    } catch { /* old server */ }
-
-    return {
-      health,
-      providers,
-      maMode,
-      maModeResolved,
-      injection,
-      effortCaps,
-      error: false,
-    };
-  } catch {
-    return empty;
-  }
+  const [overview, multiAgent] = await Promise.all([
+    fetchDashboardOverview(apiBase, signal),
+    fetchDashboardMultiAgent(apiBase, signal),
+  ]);
+  return { ...overview, ...multiAgent };
 }

--- a/gui/src/pages/dashboard-core-poll.ts
+++ b/gui/src/pages/dashboard-core-poll.ts
@@ -1,7 +1,6 @@
 import { readJsonIfOk } from "../fetch-json";
 import {
   settingsPollMayCommit,
-  beginPollEpochs,
   mapStartupHealthProbe,
   type StartupHealthStatus,
 } from "../startup-health-ui";
@@ -73,6 +72,21 @@ export type DashboardControlsPoll = {
   shadowCall: ShadowCallData | null | undefined;
 };
 
+/** Sidecar + shadow only — must not wait on /api/settings (startup-health). */
+export type DashboardSidecarPoll = {
+  sidecar: SidecarData;
+  shadowCall: ShadowCallData | null;
+};
+
+export type DashboardSettingsPoll = {
+  settings: SettingsData | null;
+  startupHealthSeed: SettingsData["startupHealth"] | null | undefined;
+};
+
+export type DashboardMaModePoll = {
+  maMode: "v1" | "default" | "v2";
+};
+
 export type DashboardEpochRefs = {
   settingsRequestEpochRef: { current: number };
   settingsMutationEpochRef: { current: number };
@@ -135,46 +149,42 @@ export async function fetchDashboardUsage(apiBase: string, signal: AbortSignal):
 /**
  * Interactive dashboard controls (auto-start, sidecar, shadow-call). Fetched on their
  * own poll so a slow healthz/providers response cannot gray out toggles/selects.
+ * @deprecated Prefer fetchDashboardSidecars + fetchDashboardSettings for progressive paint.
  */
 export async function fetchDashboardControls(
   apiBase: string,
   signal: AbortSignal,
   epochs: DashboardEpochRefs,
 ): Promise<DashboardControlsPoll> {
-  const epochSnapshot = beginPollEpochs({
-    settingsRequest: epochs.settingsRequestEpochRef,
-    settingsMutation: epochs.settingsMutationEpochRef,
-    shadowRequest: epochs.shadowCallRequestEpochRef,
-    shadowMutation: epochs.shadowCallMutationEpochRef,
-  });
-  const settingsRequestEpoch = epochSnapshot.settings.request;
-  const settingsMutationEpoch = epochSnapshot.settings.mutation;
-  const shadowRequestEpoch = epochSnapshot.shadow.request;
-  const shadowMutationEpoch = epochSnapshot.shadow.mutation;
+  const [sidecars, settings] = await Promise.all([
+    fetchDashboardSidecars(apiBase, signal, epochs),
+    fetchDashboardSettings(apiBase, signal, epochs),
+  ]);
+  return {
+    settings: settings.settings,
+    startupHealthSeed: settings.startupHealthSeed,
+    sidecar: sidecars.sidecar,
+    shadowCall: sidecars.shadowCall,
+  };
+}
 
-  const [sRes, scRes, shRes] = await Promise.all([
-    fetch(`${apiBase}/api/settings`, { signal }),
+/** Web-search / vision sidecar + shadow-call — config reads, typically sub-10ms. */
+export async function fetchDashboardSidecars(
+  apiBase: string,
+  signal: AbortSignal,
+  epochs: DashboardEpochRefs,
+): Promise<DashboardSidecarPoll> {
+  // Only bump shadow epochs — settings has its own poll and must not be invalidated here.
+  const shadowRequestEpoch = ++epochs.shadowCallRequestEpochRef.current;
+  const shadowMutationEpoch = epochs.shadowCallMutationEpochRef.current;
+
+  const [scRes, shRes] = await Promise.all([
     fetch(`${apiBase}/api/sidecar-settings`, { signal }),
     fetch(`${apiBase}/api/shadow-call-settings`, { signal }),
   ]);
 
-  const nextSettings = await requireJson<SettingsData>(sRes);
-  let settings: SettingsData | null = null;
-  let startupHealthSeed: SettingsData["startupHealth"] | null | undefined = undefined;
-  if (settingsPollMayCommit(
-    { request: settingsRequestEpoch, mutation: settingsMutationEpoch },
-    {
-      request: epochs.settingsRequestEpochRef.current,
-      mutation: epochs.settingsMutationEpochRef.current,
-      mutationInFlight: epochs.settingsMutationInFlightRef.current,
-    },
-  )) {
-    settings = nextSettings;
-    startupHealthSeed = nextSettings.startupHealth;
-  }
-
   const sidecar = await requireJson<SidecarData>(scRes);
-  let shadowCall: ShadowCallData | null | undefined = undefined;
+  let shadowCall: ShadowCallData | null = null;
   try {
     if (shRes.ok) {
       const nextShadow = await shRes.json() as ShadowCallData;
@@ -202,7 +212,54 @@ export async function fetchDashboardControls(
     }
   }
 
-  return { settings, startupHealthSeed, sidecar, shadowCall };
+  return { sidecar, shadowCall };
+}
+
+/** Codex auto-start + startup-health seed — can be slower because settings embeds startup probe. */
+export async function fetchDashboardSettings(
+  apiBase: string,
+  signal: AbortSignal,
+  epochs: DashboardEpochRefs,
+): Promise<DashboardSettingsPoll> {
+  const settingsRequestEpoch = ++epochs.settingsRequestEpochRef.current;
+  const settingsMutationEpoch = epochs.settingsMutationEpochRef.current;
+
+  const sRes = await fetch(`${apiBase}/api/settings`, { signal });
+  const nextSettings = await requireJson<SettingsData>(sRes);
+  let settings: SettingsData | null = null;
+  let startupHealthSeed: SettingsData["startupHealth"] | null | undefined = undefined;
+  if (settingsPollMayCommit(
+    { request: settingsRequestEpoch, mutation: settingsMutationEpoch },
+    {
+      request: epochs.settingsRequestEpochRef.current,
+      mutation: epochs.settingsMutationEpochRef.current,
+      mutationInFlight: epochs.settingsMutationInFlightRef.current,
+    },
+  )) {
+    settings = nextSettings;
+    startupHealthSeed = nextSettings.startupHealth;
+  }
+
+  return { settings, startupHealthSeed };
+}
+
+/** Multi-agent mode toggle only — must not wait on injection-model / effort-caps. */
+export async function fetchDashboardMaMode(
+  apiBase: string,
+  signal: AbortSignal,
+): Promise<DashboardMaModePoll> {
+  try {
+    const v2Res = await fetch(`${apiBase}/api/v2`, { signal });
+    if (!v2Res.ok) return { maMode: "default" };
+    const v2Data = await v2Res.json() as { multiAgentMode?: unknown };
+    if (v2Data.multiAgentMode === "v1" || v2Data.multiAgentMode === "v2") {
+      return { maMode: v2Data.multiAgentMode };
+    }
+    return { maMode: "default" };
+  } catch (error) {
+    if (isAbortError(error, signal)) throw error;
+    return { maMode: "default" };
+  }
 }
 
 export async function fetchDashboardOverview(
@@ -226,22 +283,14 @@ export async function fetchDashboardMultiAgent(
   apiBase: string,
   signal: AbortSignal,
 ): Promise<DashboardMultiAgentPoll> {
-  const [v2Res, imRes, ecRes] = await Promise.all([
-    fetch(`${apiBase}/api/v2`, { signal }).catch(() => null),
+  const [imRes, ecRes] = await Promise.all([
     fetch(`${apiBase}/api/injection-model`, { signal }).catch(() => null),
     fetch(`${apiBase}/api/effort-caps`, { signal }).catch(() => null),
   ]);
 
-  let maMode: "v1" | "default" | "v2" = "default";
-  let maModeResolved = false;
-  try {
-    if (v2Res?.ok) {
-      const v2Data = await v2Res.json();
-      if (v2Data.multiAgentMode === "v1" || v2Data.multiAgentMode === "v2") maMode = v2Data.multiAgentMode;
-      else maMode = "default";
-    }
-  } catch { /* old server */ }
-  finally { maModeResolved = true; }
+  // Mode is owned by fetchDashboardMaMode; keep a stable default here for composition.
+  const maMode: "v1" | "default" | "v2" = "default";
+  const maModeResolved = true;
 
   let injection: InjectionPoll | undefined;
   try {
@@ -272,14 +321,15 @@ export async function fetchDashboardMultiAgent(
   return { maMode, maModeResolved, injection, effortCaps };
 }
 
-/** @deprecated Prefer fetchDashboardOverview + fetchDashboardMultiAgent for progressive paint. */
+/** @deprecated Prefer fetchDashboardOverview + fetchDashboardMultiAgent + fetchDashboardMaMode. */
 export async function fetchDashboardCore(
   apiBase: string,
   signal: AbortSignal,
 ): Promise<DashboardCorePoll> {
-  const [overview, multiAgent] = await Promise.all([
+  const [overview, multiAgent, ma] = await Promise.all([
     fetchDashboardOverview(apiBase, signal),
     fetchDashboardMultiAgent(apiBase, signal),
+    fetchDashboardMaMode(apiBase, signal),
   ]);
-  return { ...overview, ...multiAgent };
+  return { ...overview, ...multiAgent, maMode: ma.maMode, maModeResolved: true };
 }

--- a/gui/src/pages/dashboard-overview-head.tsx
+++ b/gui/src/pages/dashboard-overview-head.tsx
@@ -11,6 +11,8 @@ export function DashboardOverviewHead({
   health,
   providers,
   usage30d,
+  usageLoading,
+  healthLoading,
   startupHealth,
   projectConfigWarnings,
   maMode,
@@ -19,7 +21,7 @@ export function DashboardOverviewHead({
   maHelpOpen,
   setMaHelpOpen,
   switchMaMode,
-}: Pick<Dash, "locale" | "health" | "providers" | "usage30d" | "startupHealth" | "projectConfigWarnings" | "maMode" | "maBusy" | "maHelpTriggerRef" | "maHelpOpen" | "setMaHelpOpen" | "switchMaMode">) {
+}: Pick<Dash, "locale" | "health" | "providers" | "usage30d" | "usageLoading" | "healthLoading" | "startupHealth" | "projectConfigWarnings" | "maMode" | "maBusy" | "maHelpTriggerRef" | "maHelpOpen" | "setMaHelpOpen" | "switchMaMode">) {
   const t = useT();
   const online = health?.status === "ok";
 
@@ -61,16 +63,16 @@ export function DashboardOverviewHead({
               </div>
             </div>
           </div>
-          <div className="stat">
+          <div className="stat" aria-busy={healthLoading || undefined}>
             <div className="label">{t("dash.status")}</div>
             <div className="value" style={{ display: "flex", alignItems: "center", gap: 9, color: online ? "var(--green)" : "var(--red)" }}>
               <span className={`dot ${online ? "dot-green" : "dot-red"}`} />{online ? t("dash.online") : t("dash.offline")}
             </div>
           </div>
-          <div className="stat"><div className="label">{t("dash.version")}</div><div className="value mono">{health?.version ?? "—"}</div></div>
-          <div className="stat"><div className="label">{t("dash.uptime")}</div><div className="value mono">{health ? formatUptime(health.uptime, locale) : "—"}</div></div>
-          <div className="stat"><div className="label">{t("dash.providers")}</div><div className="value">{providers.length}</div></div>
-          <div className="stat">
+          <div className="stat" aria-busy={healthLoading || undefined}><div className="label">{t("dash.version")}</div><div className="value mono">{health?.version ?? "—"}</div></div>
+          <div className="stat" aria-busy={healthLoading || undefined}><div className="label">{t("dash.uptime")}</div><div className="value mono">{health ? formatUptime(health.uptime, locale) : "—"}</div></div>
+          <div className="stat" aria-busy={healthLoading || undefined}><div className="label">{t("dash.providers")}</div><div className="value">{providers.length}</div></div>
+          <div className="stat" aria-busy={usageLoading || undefined}>
             <div className="label">{t("dash.tokens30d")}</div>
             <div className="value mono">{usage30d && usage30d.summary.requests > 0 ? formatTokens(usage30d.summary.totalTokens, locale) : "—"}</div>
             <div className="muted text-label dash-stat-coverage">

--- a/gui/src/pages/dashboard-overview-sections.tsx
+++ b/gui/src/pages/dashboard-overview-sections.tsx
@@ -249,7 +249,7 @@ export function DashboardSidecarPanels({ d }: { d: Dash }) {
       </div>
 
       <div className="dash-sidecar-grid">
-        <div className="panel dash-sidecar-card">
+        <div className="panel dash-sidecar-card" aria-busy={!sidecar || undefined}>
           <div className="dash-sidecar-card__row">
             <div className="font-semibold">{t("dash.webSearchSidecar")}</div>
             <Select
@@ -263,7 +263,7 @@ export function DashboardSidecarPanels({ d }: { d: Dash }) {
           <div className="muted setting-hint">{t("dash.webSearchSidecarHint")}</div>
         </div>
 
-        <div className="panel dash-sidecar-card">
+        <div className="panel dash-sidecar-card" aria-busy={!sidecar || undefined}>
           <div className="dash-sidecar-card__row">
             <div className="font-semibold">{t("dash.visionSidecar")}</div>
             <Select
@@ -278,7 +278,7 @@ export function DashboardSidecarPanels({ d }: { d: Dash }) {
         </div>
       </div>
 
-      <div className="panel">
+      <div className="panel" aria-busy={!shadowCall || undefined}>
         <div className="spread" style={{ alignItems: "center" }}>
           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
             <span className="font-semibold">{t("dash.shadowCallIntercept")}</span>

--- a/gui/src/pages/use-dashboard-data.ts
+++ b/gui/src/pages/use-dashboard-data.ts
@@ -1,16 +1,18 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useKeyedClientResource } from "../client-resource";
 import { useI18n } from "../i18n/shared";
+import { readSessionListCache, writeSessionListCache } from "../session-list-cache";
 import {
   PROJECT_CONFIG_DIAGNOSTICS_POLL_MS,
   seedStartupHealthFromSettings,
   type StartupHealthStatus,
 } from "../startup-health-ui";
 import {
-  fetchDashboardCore,
   fetchDashboardControls,
-  fetchDashboardUsage,
   fetchDashboardModels,
+  fetchDashboardMultiAgent,
+  fetchDashboardOverview,
+  fetchDashboardUsage,
   fetchProjectConfigDiagnostics,
   fetchStartupHealth,
   normalizeInjectionSelection,
@@ -42,11 +44,19 @@ import {
 } from "./dashboard-shared";
 
 const CONTROLS_CACHE_PREFIX = "ocx.dash.controls.v1:";
+const OVERVIEW_CACHE_PREFIX = "ocx.dash.overview.v1:";
+const USAGE_CACHE_PREFIX = "ocx.dash.usage30d.v1:";
+const STARTUP_CACHE_PREFIX = "ocx.dash.startup.v1:";
 
 type CachedControls = {
   settings?: SettingsData | null;
   sidecar?: SidecarData | null;
   shadowCall?: ShadowCallData | null;
+};
+
+type CachedOverview = {
+  health: HealthData;
+  providers: ProviderInfo[];
 };
 
 function readCachedControls(apiBase: string): CachedControls | null {
@@ -71,15 +81,27 @@ export function useDashboardData(apiBase: string) {
   const [selectedSection, setSelectedSection] = useState<DashboardSection>(readDashboardSectionFromHash);
   const [modelQuery, setModelQuery] = useState("");
   const [expandedProviders, setExpandedProviders] = useState<Set<string>>(new Set());
-  const [health, setHealth] = useState<HealthData | null>(null);
-  const [startupHealth, setStartupHealth] = useState<StartupHealthStatus | null>(null);
-  const [providers, setProviders] = useState<ProviderInfo[]>([]);
-  const [models, setModels] = useState<ModelInfo[]>([]);
   const cachedControls = useMemo(() => readCachedControls(apiBase), [apiBase]);
+  const cachedOverview = useMemo(
+    () => readSessionListCache<CachedOverview>(`${OVERVIEW_CACHE_PREFIX}${apiBase}`),
+    [apiBase],
+  );
+  const cachedUsage = useMemo(
+    () => readSessionListCache<UsageSummary30d>(`${USAGE_CACHE_PREFIX}${apiBase}`),
+    [apiBase],
+  );
+  const cachedStartup = useMemo(
+    () => readSessionListCache<StartupHealthStatus>(`${STARTUP_CACHE_PREFIX}${apiBase}`),
+    [apiBase],
+  );
+  const [health, setHealth] = useState<HealthData | null>(() => cachedOverview?.health ?? null);
+  const [startupHealth, setStartupHealth] = useState<StartupHealthStatus | null>(() => cachedStartup);
+  const [providers, setProviders] = useState<ProviderInfo[]>(() => cachedOverview?.providers ?? []);
+  const [models, setModels] = useState<ModelInfo[]>([]);
   const [settings, setSettings] = useState<SettingsData | null>(() => cachedControls?.settings ?? null);
   const [sidecar, setSidecar] = useState<SidecarData | null>(() => cachedControls?.sidecar ?? null);
   const [shadowCall, setShadowCall] = useState<ShadowCallData | null>(() => cachedControls?.shadowCall ?? null);
-  const [usage30d, setUsage30d] = useState<UsageSummary30d | null>(null);
+  const [usage30d, setUsage30d] = useState<UsageSummary30d | null>(() => cachedUsage);
   const [sidecarSaving, setSidecarSaving] = useState(false);
   const [shadowCallSaving, setShadowCallSaving] = useState(false);
   const [modelsLoading, setModelsLoading] = useState(false);
@@ -145,7 +167,7 @@ export function useDashboardData(apiBase: string) {
     }
   }, []);
 
-  const startupHealthRef = useRef<StartupHealthStatus | null>(null);
+  const startupHealthRef = useRef<StartupHealthStatus | null>(cachedStartup);
   /** Bumped whenever the dedicated startup-health poll commits; core polls ignore older generations. */
   const startupHealthGenerationRef = useRef(0);
   const epochRefs = useRef<DashboardEpochRefs>({
@@ -164,17 +186,14 @@ export function useDashboardData(apiBase: string) {
     { pollMs: 30_000 },
   );
 
-  const corePoll = useKeyedClientResource(
-    `dashboard-core:${apiBase}`,
+  // Wave 1: status/uptime/providers must not wait on injection-model / usage.
+  const overviewPoll = useKeyedClientResource(
+    `dashboard-overview:${apiBase}`,
     [apiBase],
-    async (signal) => {
-      // Capture generation at fetch start so a newer probe can win at commit time.
-      const startupHealthGeneration = startupHealthGenerationRef.current;
-      const data = await fetchDashboardCore(apiBase, signal);
-      return { ...data, startupHealthGeneration };
-    },
+    (signal) => fetchDashboardOverview(apiBase, signal),
     { pollMs: 5000 },
   );
+  const overviewReady = health !== null || overviewPoll.data !== undefined;
 
   const controlsPoll = useKeyedClientResource(
     `dashboard-controls:${apiBase}`,
@@ -187,25 +206,33 @@ export function useDashboardData(apiBase: string) {
     { pollMs: 5000 },
   );
 
+  // Wave 2: heavier peers start after overview commits (or session seed) to cut contention.
+  const multiAgentPoll = useKeyedClientResource(
+    `dashboard-multi-agent:${apiBase}`,
+    [apiBase],
+    (signal) => fetchDashboardMultiAgent(apiBase, signal),
+    { pollMs: 5000, enabled: overviewReady },
+  );
+
   const usagePoll = useKeyedClientResource(
     `dashboard-usage:${apiBase}`,
     [apiBase],
     (signal) => fetchDashboardUsage(apiBase, signal),
-    { pollMs: 60_000 },
+    { pollMs: 60_000, enabled: overviewReady },
   );
 
   const diagnosticsPoll = useKeyedClientResource(
     `dashboard-diagnostics:${apiBase}`,
     [apiBase],
     (signal) => fetchProjectConfigDiagnostics(apiBase, signal),
-    { pollMs: PROJECT_CONFIG_DIAGNOSTICS_POLL_MS },
+    { pollMs: PROJECT_CONFIG_DIAGNOSTICS_POLL_MS, enabled: overviewReady },
   );
 
   const modelsPoll = useKeyedClientResource(
     `dashboard-models:${apiBase}`,
     [apiBase, error],
     (signal) => fetchDashboardModels(apiBase, signal),
-    { enabled: !error },
+    { enabled: overviewReady && !error },
   );
 
   /* eslint-disable react-hooks/set-state-in-effect -- mirror client-resource snapshots into mutable dashboard UI state that handlers also update */
@@ -214,14 +241,27 @@ export function useDashboardData(apiBase: string) {
       startupHealthGenerationRef.current += 1;
       setStartupHealth(startupHealthPoll.data);
       startupHealthRef.current = startupHealthPoll.data;
+      writeSessionListCache(`${STARTUP_CACHE_PREFIX}${apiBase}`, startupHealthPoll.data);
     }
-  }, [startupHealthPoll.data]);
+  }, [startupHealthPoll.data, apiBase]);
 
   useEffect(() => {
-    const data = corePoll.data;
+    const data = overviewPoll.data;
     if (!data) return;
-    if (data.health) setHealth(data.health);
+    if (data.health) {
+      setHealth(data.health);
+      writeSessionListCache(`${OVERVIEW_CACHE_PREFIX}${apiBase}`, {
+        health: data.health,
+        providers: data.providers,
+      });
+    }
     setProviders(data.providers);
+    setError(data.error);
+  }, [overviewPoll.data, apiBase]);
+
+  useEffect(() => {
+    const data = multiAgentPoll.data;
+    if (!data) return;
     setMaMode(data.maMode);
     setMaModeResolved(data.maModeResolved);
     if (data.injection) {
@@ -236,8 +276,7 @@ export function useDashboardData(apiBase: string) {
       setEffortCap(data.effortCaps.effortCap);
       setSubagentEffortCap(data.effortCaps.subagentEffortCap);
     }
-    setError(data.error);
-  }, [corePoll.data]);
+  }, [multiAgentPoll.data]);
 
   useEffect(() => {
     const data = controlsPoll.data;
@@ -252,6 +291,7 @@ export function useDashboardData(apiBase: string) {
       const merged = seedStartupHealthFromSettings(startupHealthRef.current, data.startupHealthSeed);
       setStartupHealth(merged);
       startupHealthRef.current = merged;
+      if (merged) writeSessionListCache(`${STARTUP_CACHE_PREFIX}${apiBase}`, merged);
     }
     if (data.sidecar) setSidecar(data.sidecar);
     if (data.shadowCall !== undefined) setShadowCall(data.shadowCall);
@@ -263,8 +303,11 @@ export function useDashboardData(apiBase: string) {
   }, [controlsPoll.data, apiBase]);
 
   useEffect(() => {
-    if (usagePoll.data !== undefined) setUsage30d(usagePoll.data);
-  }, [usagePoll.data]);
+    if (usagePoll.data !== undefined) {
+      setUsage30d(usagePoll.data);
+      writeSessionListCache(`${USAGE_CACHE_PREFIX}${apiBase}`, usagePoll.data);
+    }
+  }, [usagePoll.data, apiBase]);
 
   useEffect(() => {
     if (diagnosticsPoll.data) setProjectConfigWarnings(diagnosticsPoll.data);
@@ -566,7 +609,7 @@ export function useDashboardData(apiBase: string) {
     expandedProviders, setExpandedProviders,
     health, startupHealth, providers, models, settings, sidecar, shadowCall, usage30d,
     usageLoading: usagePoll.loading && !usage30d,
-    healthLoading: corePoll.loading && !health,
+    healthLoading: overviewPoll.loading && !health,
     sidecarSaving, shadowCallSaving, modelsLoading, settingsSaving, syncing,
     maMode, maModeResolved, maBusy, setMaHelpOpen, maHelpOpen,
     effortCapHelpOpen, setEffortCapHelpOpen, shadowCallHelpOpen, setShadowCallHelpOpen,

--- a/gui/src/pages/use-dashboard-data.ts
+++ b/gui/src/pages/use-dashboard-data.ts
@@ -95,10 +95,10 @@ export function useDashboardData(apiBase: string) {
     () => readSessionListCache<UsageSummary30d>(`${USAGE_CACHE_PREFIX}${apiBase}`),
     [apiBase],
   );
-  const cachedStartup = useMemo(
-    () => readSessionListCache<StartupHealthStatus>(`${STARTUP_CACHE_PREFIX}${apiBase}`),
-    [apiBase],
-  );
+  const cachedStartup = useMemo(() => {
+    const cached = readSessionListCache<StartupHealthStatus>(`${STARTUP_CACHE_PREFIX}${apiBase}`);
+    return cached === "error" ? null : cached;
+  }, [apiBase]);
   const cachedMaMode = useMemo(
     () => readSessionListCache<MaMode>(`${MA_MODE_CACHE_PREFIX}${apiBase}`),
     [apiBase],
@@ -269,7 +269,10 @@ export function useDashboardData(apiBase: string) {
       startupHealthGenerationRef.current += 1;
       setStartupHealth(startupHealthPoll.data);
       startupHealthRef.current = startupHealthPoll.data;
-      writeSessionListCache(`${STARTUP_CACHE_PREFIX}${apiBase}`, startupHealthPoll.data);
+      // Never persist hard errors — a cold SWR miss used to poison revisits.
+      if (startupHealthPoll.data !== "error") {
+        writeSessionListCache(`${STARTUP_CACHE_PREFIX}${apiBase}`, startupHealthPoll.data);
+      }
     }
   }, [startupHealthPoll.data, apiBase]);
 

--- a/gui/src/pages/use-dashboard-data.ts
+++ b/gui/src/pages/use-dashboard-data.ts
@@ -8,6 +8,7 @@ import {
 } from "../startup-health-ui";
 import {
   fetchDashboardCore,
+  fetchDashboardControls,
   fetchDashboardUsage,
   fetchDashboardModels,
   fetchProjectConfigDiagnostics,
@@ -40,6 +41,30 @@ import {
   useModalDialog,
 } from "./dashboard-shared";
 
+const CONTROLS_CACHE_PREFIX = "ocx.dash.controls.v1:";
+
+type CachedControls = {
+  settings?: SettingsData | null;
+  sidecar?: SidecarData | null;
+  shadowCall?: ShadowCallData | null;
+};
+
+function readCachedControls(apiBase: string): CachedControls | null {
+  try {
+    const raw = sessionStorage.getItem(`${CONTROLS_CACHE_PREFIX}${apiBase}`);
+    if (!raw) return null;
+    return JSON.parse(raw) as CachedControls;
+  } catch {
+    return null;
+  }
+}
+
+function writeCachedControls(apiBase: string, value: CachedControls) {
+  try {
+    sessionStorage.setItem(`${CONTROLS_CACHE_PREFIX}${apiBase}`, JSON.stringify(value));
+  } catch { /* private mode / quota */ }
+}
+
 export function useDashboardData(apiBase: string) {
   const { locale, t } = useI18n();
   // The hash is the source of truth for the active section (#dashboard, …).
@@ -50,9 +75,10 @@ export function useDashboardData(apiBase: string) {
   const [startupHealth, setStartupHealth] = useState<StartupHealthStatus | null>(null);
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [models, setModels] = useState<ModelInfo[]>([]);
-  const [settings, setSettings] = useState<SettingsData | null>(null);
-  const [sidecar, setSidecar] = useState<SidecarData | null>(null);
-  const [shadowCall, setShadowCall] = useState<ShadowCallData | null>(null);
+  const cachedControls = useMemo(() => readCachedControls(apiBase), [apiBase]);
+  const [settings, setSettings] = useState<SettingsData | null>(() => cachedControls?.settings ?? null);
+  const [sidecar, setSidecar] = useState<SidecarData | null>(() => cachedControls?.sidecar ?? null);
+  const [shadowCall, setShadowCall] = useState<ShadowCallData | null>(() => cachedControls?.shadowCall ?? null);
   const [usage30d, setUsage30d] = useState<UsageSummary30d | null>(null);
   const [sidecarSaving, setSidecarSaving] = useState(false);
   const [shadowCallSaving, setShadowCallSaving] = useState(false);
@@ -144,7 +170,18 @@ export function useDashboardData(apiBase: string) {
     async (signal) => {
       // Capture generation at fetch start so a newer probe can win at commit time.
       const startupHealthGeneration = startupHealthGenerationRef.current;
-      const data = await fetchDashboardCore(apiBase, signal, epochRefs);
+      const data = await fetchDashboardCore(apiBase, signal);
+      return { ...data, startupHealthGeneration };
+    },
+    { pollMs: 5000 },
+  );
+
+  const controlsPoll = useKeyedClientResource(
+    `dashboard-controls:${apiBase}`,
+    [apiBase],
+    async (signal) => {
+      const startupHealthGeneration = startupHealthGenerationRef.current;
+      const data = await fetchDashboardControls(apiBase, signal, epochRefs);
       return { ...data, startupHealthGeneration };
     },
     { pollMs: 5000 },
@@ -185,19 +222,6 @@ export function useDashboardData(apiBase: string) {
     if (!data) return;
     if (data.health) setHealth(data.health);
     setProviders(data.providers);
-    if (data.settings) setSettings(data.settings);
-    // Latest-wins: only seed from settings when no newer dedicated probe has committed
-    // while this core poll was in flight. Always merge against the live ref.
-    if (
-      data.startupHealthSeed !== undefined
-      && data.startupHealthGeneration === startupHealthGenerationRef.current
-    ) {
-      const merged = seedStartupHealthFromSettings(startupHealthRef.current, data.startupHealthSeed);
-      setStartupHealth(merged);
-      startupHealthRef.current = merged;
-    }
-    if (data.sidecar) setSidecar(data.sidecar);
-    if (data.shadowCall !== undefined) setShadowCall(data.shadowCall);
     setMaMode(data.maMode);
     setMaModeResolved(data.maModeResolved);
     if (data.injection) {
@@ -214,6 +238,29 @@ export function useDashboardData(apiBase: string) {
     }
     setError(data.error);
   }, [corePoll.data]);
+
+  useEffect(() => {
+    const data = controlsPoll.data;
+    if (!data) return;
+    if (data.settings) setSettings(data.settings);
+    // Latest-wins: only seed from settings when no newer dedicated probe has committed
+    // while this controls poll was in flight. Always merge against the live ref.
+    if (
+      data.startupHealthSeed !== undefined
+      && data.startupHealthGeneration === startupHealthGenerationRef.current
+    ) {
+      const merged = seedStartupHealthFromSettings(startupHealthRef.current, data.startupHealthSeed);
+      setStartupHealth(merged);
+      startupHealthRef.current = merged;
+    }
+    if (data.sidecar) setSidecar(data.sidecar);
+    if (data.shadowCall !== undefined) setShadowCall(data.shadowCall);
+    writeCachedControls(apiBase, {
+      settings: data.settings ?? undefined,
+      sidecar: data.sidecar ?? undefined,
+      shadowCall: data.shadowCall === undefined ? undefined : data.shadowCall,
+    });
+  }, [controlsPoll.data, apiBase]);
 
   useEffect(() => {
     if (usagePoll.data !== undefined) setUsage30d(usagePoll.data);
@@ -518,6 +565,8 @@ export function useDashboardData(apiBase: string) {
     modelQuery, setModelQuery,
     expandedProviders, setExpandedProviders,
     health, startupHealth, providers, models, settings, sidecar, shadowCall, usage30d,
+    usageLoading: usagePoll.loading && !usage30d,
+    healthLoading: corePoll.loading && !health,
     sidecarSaving, shadowCallSaving, modelsLoading, settingsSaving, syncing,
     maMode, maModeResolved, maBusy, setMaHelpOpen, maHelpOpen,
     effortCapHelpOpen, setEffortCapHelpOpen, shadowCallHelpOpen, setShadowCallHelpOpen,

--- a/gui/src/pages/use-dashboard-data.ts
+++ b/gui/src/pages/use-dashboard-data.ts
@@ -8,10 +8,12 @@ import {
   type StartupHealthStatus,
 } from "../startup-health-ui";
 import {
-  fetchDashboardControls,
+  fetchDashboardMaMode,
   fetchDashboardModels,
   fetchDashboardMultiAgent,
   fetchDashboardOverview,
+  fetchDashboardSettings,
+  fetchDashboardSidecars,
   fetchDashboardUsage,
   fetchProjectConfigDiagnostics,
   fetchStartupHealth,
@@ -47,6 +49,7 @@ const CONTROLS_CACHE_PREFIX = "ocx.dash.controls.v1:";
 const OVERVIEW_CACHE_PREFIX = "ocx.dash.overview.v1:";
 const USAGE_CACHE_PREFIX = "ocx.dash.usage30d.v1:";
 const STARTUP_CACHE_PREFIX = "ocx.dash.startup.v1:";
+const MA_MODE_CACHE_PREFIX = "ocx.dash.maMode.v1:";
 
 type CachedControls = {
   settings?: SettingsData | null;
@@ -58,6 +61,8 @@ type CachedOverview = {
   health: HealthData;
   providers: ProviderInfo[];
 };
+
+type MaMode = "v1" | "default" | "v2";
 
 function readCachedControls(apiBase: string): CachedControls | null {
   try {
@@ -94,6 +99,10 @@ export function useDashboardData(apiBase: string) {
     () => readSessionListCache<StartupHealthStatus>(`${STARTUP_CACHE_PREFIX}${apiBase}`),
     [apiBase],
   );
+  const cachedMaMode = useMemo(
+    () => readSessionListCache<MaMode>(`${MA_MODE_CACHE_PREFIX}${apiBase}`),
+    [apiBase],
+  );
   const [health, setHealth] = useState<HealthData | null>(() => cachedOverview?.health ?? null);
   const [startupHealth, setStartupHealth] = useState<StartupHealthStatus | null>(() => cachedStartup);
   const [providers, setProviders] = useState<ProviderInfo[]>(() => cachedOverview?.providers ?? []);
@@ -107,8 +116,8 @@ export function useDashboardData(apiBase: string) {
   const [modelsLoading, setModelsLoading] = useState(false);
   const [settingsSaving, setSettingsSaving] = useState(false);
   const [syncing, setSyncing] = useState(false);
-  const [maMode, setMaMode] = useState<"v1" | "default" | "v2">("default");
-  const [maModeResolved, setMaModeResolved] = useState(false);
+  const [maMode, setMaMode] = useState<MaMode>(() => cachedMaMode ?? "default");
+  const [maModeResolved, setMaModeResolved] = useState(() => cachedMaMode !== null);
   const [maBusy, setMaBusy] = useState(false);
   const [maHelpOpen, setMaHelpOpen] = useState(false);
   const [effortCapHelpOpen, setEffortCapHelpOpen] = useState(false);
@@ -195,12 +204,31 @@ export function useDashboardData(apiBase: string) {
   );
   const overviewReady = health !== null || overviewPoll.data !== undefined;
 
-  const controlsPoll = useKeyedClientResource(
-    `dashboard-controls:${apiBase}`,
+  // Preferences that are just config — never gate on overview or injection.
+  const maModePoll = useKeyedClientResource(
+    `dashboard-ma-mode:${apiBase}`,
+    [apiBase],
+    (signal) => fetchDashboardMaMode(apiBase, signal),
+    { pollMs: 5000 },
+  );
+
+  const sidecarPoll = useKeyedClientResource(
+    `dashboard-sidecars:${apiBase}`,
     [apiBase],
     async (signal) => {
       const startupHealthGeneration = startupHealthGenerationRef.current;
-      const data = await fetchDashboardControls(apiBase, signal, epochRefs);
+      const data = await fetchDashboardSidecars(apiBase, signal, epochRefs);
+      return { ...data, startupHealthGeneration };
+    },
+    { pollMs: 5000 },
+  );
+
+  const settingsPoll = useKeyedClientResource(
+    `dashboard-settings:${apiBase}`,
+    [apiBase],
+    async (signal) => {
+      const startupHealthGeneration = startupHealthGenerationRef.current;
+      const data = await fetchDashboardSettings(apiBase, signal, epochRefs);
       return { ...data, startupHealthGeneration };
     },
     { pollMs: 5000 },
@@ -260,10 +288,15 @@ export function useDashboardData(apiBase: string) {
   }, [overviewPoll.data, apiBase]);
 
   useEffect(() => {
+    if (maModePoll.data === undefined) return;
+    setMaMode(maModePoll.data.maMode);
+    setMaModeResolved(true);
+    writeSessionListCache(`${MA_MODE_CACHE_PREFIX}${apiBase}`, maModePoll.data.maMode);
+  }, [maModePoll.data, apiBase]);
+
+  useEffect(() => {
     const data = multiAgentPoll.data;
     if (!data) return;
-    setMaMode(data.maMode);
-    setMaModeResolved(data.maModeResolved);
     if (data.injection) {
       setMultiAgentGuidanceEnabled(data.injection.multiAgentGuidanceEnabled);
       setSyncCodexSubagentDefaults(data.injection.syncCodexSubagentDefaults);
@@ -279,11 +312,24 @@ export function useDashboardData(apiBase: string) {
   }, [multiAgentPoll.data]);
 
   useEffect(() => {
-    const data = controlsPoll.data;
+    const data = sidecarPoll.data;
+    if (!data) return;
+    setSidecar(data.sidecar);
+    setShadowCall(data.shadowCall);
+    const prev = readCachedControls(apiBase) ?? {};
+    writeCachedControls(apiBase, {
+      ...prev,
+      sidecar: data.sidecar,
+      shadowCall: data.shadowCall,
+    });
+  }, [sidecarPoll.data, apiBase]);
+
+  useEffect(() => {
+    const data = settingsPoll.data;
     if (!data) return;
     if (data.settings) setSettings(data.settings);
     // Latest-wins: only seed from settings when no newer dedicated probe has committed
-    // while this controls poll was in flight. Always merge against the live ref.
+    // while this settings poll was in flight. Always merge against the live ref.
     if (
       data.startupHealthSeed !== undefined
       && data.startupHealthGeneration === startupHealthGenerationRef.current
@@ -293,14 +339,12 @@ export function useDashboardData(apiBase: string) {
       startupHealthRef.current = merged;
       if (merged) writeSessionListCache(`${STARTUP_CACHE_PREFIX}${apiBase}`, merged);
     }
-    if (data.sidecar) setSidecar(data.sidecar);
-    if (data.shadowCall !== undefined) setShadowCall(data.shadowCall);
+    const prev = readCachedControls(apiBase) ?? {};
     writeCachedControls(apiBase, {
+      ...prev,
       settings: data.settings ?? undefined,
-      sidecar: data.sidecar ?? undefined,
-      shadowCall: data.shadowCall === undefined ? undefined : data.shadowCall,
     });
-  }, [controlsPoll.data, apiBase]);
+  }, [settingsPoll.data, apiBase]);
 
   useEffect(() => {
     if (usagePoll.data !== undefined) {
@@ -381,7 +425,15 @@ export function useDashboardData(apiBase: string) {
     }
     return out;
   }, [grouped, modelQuery]);
-  const sidecarModels = useMemo(() => sidecarModelOptions(models), [models]);
+  const sidecarModels = useMemo(() => {
+    const opts = sidecarModelOptions(models);
+    for (const id of [sidecar?.webSearch.model, sidecar?.vision.model]) {
+      if (id && !opts.some(option => option.value === id)) {
+        opts.unshift({ value: id, label: id });
+      }
+    }
+    return opts;
+  }, [models, sidecar]);
 
   const saveSidecar = async (patch: SidecarPatch) => {
     if (!sidecar || sidecarSaving) return;
@@ -400,6 +452,11 @@ export function useDashboardData(apiBase: string) {
       });
       const data = await requireJson<SidecarData>(res, "save failed");
       setSidecar({ webSearch: data.webSearch, vision: data.vision });
+      const prev = readCachedControls(apiBase) ?? {};
+      writeCachedControls(apiBase, {
+        ...prev,
+        sidecar: { webSearch: data.webSearch, vision: data.vision },
+      });
     } catch {
       setSidecar(previous);
     } finally {
@@ -439,7 +496,11 @@ export function useDashboardData(apiBase: string) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ multiAgentMode: mode }),
       });
-      if (r.ok) setMaMode(mode);
+      if (r.ok) {
+        setMaMode(mode);
+        setMaModeResolved(true);
+        writeSessionListCache(`${MA_MODE_CACHE_PREFIX}${apiBase}`, mode);
+      }
     } catch { /* ignore */ }
     finally { setMaBusy(false); }
   };

--- a/gui/src/pages/use-providers-fetch.ts
+++ b/gui/src/pages/use-providers-fetch.ts
@@ -32,16 +32,10 @@ export function useProvidersFetch({
 
   const fetchOauth = useCallback(async () => {
     try {
-      const provRes = await fetch(`${apiBase}/api/oauth/providers`);
-      const provData = await readJsonOrThrow<{ providers?: string[] }>(provRes);
-      const provs: string[] = provData?.providers ?? [];
-      setOauthProviders(provs);
-      const [oauthEntries, codexAccounts, codexActive] = await Promise.all([
-        Promise.all(provs.map(async p => {
-          const sRes = await fetch(`${apiBase}/api/oauth/status?provider=${p}`).catch(() => null);
-          const s = sRes ? (await readJsonIfOk<OAuthStatus>(sRes) ?? { loggedIn: false }) : { loggedIn: false };
-          return [p, s] as const;
-        })),
+      // Kick oauth provider list and Codex account probes in parallel — accounts do
+      // not depend on the oauth/providers response, so a serial await was pure latency.
+      const [provRes, codexAccounts, codexActive] = await Promise.all([
+        fetch(`${apiBase}/api/oauth/providers`),
         fetch(`${apiBase}/api/codex-auth/accounts`)
           .then(r => readJsonIfOk<{ accounts?: Array<{ id?: string; email?: string; isMain?: boolean; hasCredential?: boolean; needsReauth?: boolean }> }>(r))
           .catch(() => null),
@@ -49,6 +43,14 @@ export function useProvidersFetch({
           .then(r => readJsonIfOk<{ activeCodexAccountId?: string | null }>(r))
           .catch(() => null),
       ]);
+      const provData = await readJsonOrThrow<{ providers?: string[] }>(provRes);
+      const provs: string[] = provData?.providers ?? [];
+      setOauthProviders(provs);
+      const oauthEntries = await Promise.all(provs.map(async p => {
+        const sRes = await fetch(`${apiBase}/api/oauth/status?provider=${p}`).catch(() => null);
+        const s = sRes ? (await readJsonIfOk<OAuthStatus>(sRes) ?? { loggedIn: false }) : { loggedIn: false };
+        return [p, s] as const;
+      }));
       const next: Record<string, OAuthStatus> = Object.fromEntries(oauthEntries);
       const accounts = codexAccounts?.accounts ?? [];
       const main = accounts.find(a => a.isMain) ?? accounts[0];

--- a/gui/src/provider-workspace/catalog.ts
+++ b/gui/src/provider-workspace/catalog.ts
@@ -15,8 +15,8 @@
  *  7. hasApiKey === true             -> ready  (key-auth with credential present)
  *  8. everything else                -> needsSetup
  *
- * Live-auth overlay: `applyActiveAccountReauth` may demote ready → needs-setup
- * when the active account needs reauth (config binning rules above unchanged).
+ * Live-auth overlay: `applyActiveAccountReauth` tags ready providers that
+ * need reauth without moving them out of the ready section (avoids rail flash).
  *
  * Tiers (three-way, interview 2026-07-17): "accounts" (the canonical OpenAI forward
  * provider), "free" (free pricing), "paid" (everything else). Accounts wins
@@ -219,8 +219,9 @@ export function buildProviderWorkspace(
 
 /**
  * Live-auth overlay: when the active account for a provider needs reauth,
- * demote that provider from ready → needs-setup. Inactive-only reauth is
- * ignored (caller must only set true for the active account).
+ * tag that provider with `activeNeedsReauth` without moving it between
+ * ready/needs-setup. Config-based section membership stays stable on first
+ * paint so live discovery cannot flash a resort of the rail.
  */
 export function applyActiveAccountReauth(
   sections: WorkspaceSections,
@@ -233,18 +234,14 @@ export function applyActiveAccountReauth(
   );
   if (demote.size === 0) return sections;
 
-  const stillReady: WorkspaceItem[] = [];
-  const needsSetup = [...sections.needsSetup];
-  for (const item of sections.ready) {
-    if (demote.has(item.name)) {
-      const demoted: WorkspaceItem = { ...item, activeNeedsReauth: true };
-      delete demoted.tier;
-      needsSetup.push(demoted);
-    } else {
-      stillReady.push(item);
-    }
-  }
-  return { ready: stillReady, needsSetup, disabled: sections.disabled };
+  const tag = (items: WorkspaceItem[]): WorkspaceItem[] =>
+    items.map(item => (demote.has(item.name) ? { ...item, activeNeedsReauth: true } : item));
+
+  return {
+    ready: tag(sections.ready),
+    needsSetup: tag(sections.needsSetup),
+    disabled: sections.disabled,
+  };
 }
 
 /** Canonical status string for a single provider — config plus optional live-auth overlay. */

--- a/gui/src/provider-workspace/usage.ts
+++ b/gui/src/provider-workspace/usage.ts
@@ -150,17 +150,24 @@ export interface AttentionItem {
 
 /**
  * Derives the list of providers that require user attention:
- * - needsSetup with activeNeedsReauth → "Active account needs re-authentication"
+ * - any section row with activeNeedsReauth → "Active account needs re-authentication"
  * - other needsSetup providers → "Missing credentials" (or override)
  * - disabled providers that have an explicit override reason in `overrideReasons`
  *
- * Ready providers are never included.
+ * Ready providers without reauth are never included.
  */
 export function buildAttentionItems(
   sections: WorkspaceSections,
   overrideReasons: Record<string, string>,
 ): AttentionItem[] {
   const items: AttentionItem[] = [];
+  for (const p of sections.ready) {
+    if (!p.activeNeedsReauth) continue;
+    items.push({
+      name: p.name,
+      reason: overrideReasons[p.name] ?? "Active account needs re-authentication",
+    });
+  }
   for (const p of sections.needsSetup) {
     const reason = p.activeNeedsReauth
       ? (overrideReasons[p.name] ?? "Active account needs re-authentication")

--- a/gui/src/session-list-cache.ts
+++ b/gui/src/session-list-cache.ts
@@ -1,0 +1,30 @@
+/**
+ * SessionStorage helpers for non-secret GUI list/summary shapes (SWR seeds).
+ * Never store API keys, tokens, or credentials here — XSS can read sessionStorage.
+ */
+
+export function readSessionListCache<T>(key: string): T | null {
+  try {
+    const raw = sessionStorage.getItem(key);
+    if (!raw) return null;
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function writeSessionListCache(key: string, value: unknown): void {
+  try {
+    sessionStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    /* private mode / quota */
+  }
+}
+
+export function clearSessionListCache(key: string): void {
+  try {
+    sessionStorage.removeItem(key);
+  } catch {
+    /* ignore */
+  }
+}

--- a/gui/src/startup-health-ui.ts
+++ b/gui/src/startup-health-ui.ts
@@ -49,6 +49,15 @@ export function beginPollEpochs(refs: {
 
 export type StartupHealthStatus = "native" | "protected" | "at-risk" | "error";
 
+/**
+ * Map a startup-health API payload to the dashboard chip status.
+ *
+ * `diagnosticStale` means the server is still refreshing (SWR fallback / expired TTL).
+ * That is NOT a hard read failure — collapsing it to "error" shows the misleading
+ * "Could not read startup protection" chip whenever the 30s cache misses.
+ * Keep the payload status (the cache already forces at-risk for local-proxy routing
+ * when stale). Reserve "error" for fetchStartupHealth hard failures only.
+ */
 export function mapStartupHealthProbe(data: {
   status?: unknown;
   diagnosticStale?: unknown;
@@ -56,20 +65,22 @@ export function mapStartupHealthProbe(data: {
   const status = data.status;
   const valid = status === "native" || status === "protected" || status === "at-risk";
   if (!valid) return null;
-  return data.diagnosticStale === true ? "error" : status;
+  return status;
 }
 
 /**
- * Settings may only seed startup health while it is still unknown.
- * After `/api/startup-health` has produced a value, it stays authoritative.
+ * Settings may only seed startup health while it is still unknown or a hard error.
+ * After `/api/startup-health` has produced a real status, it stays authoritative.
  */
 export function seedStartupHealthFromSettings(
   previous: StartupHealthStatus | null,
   seeded: { status: "native" | "protected" | "at-risk"; diagnosticStale: boolean } | null | undefined,
 ): StartupHealthStatus | null {
-  if (previous !== null) return previous;
-  if (!seeded) return null;
-  return seeded.diagnosticStale ? "error" : seeded.status;
+  if (!seeded) return previous;
+  // A prior hard "error" (or unknown) may be replaced by a settings seed; a real
+  // status from the dedicated probe must not be overwritten.
+  if (previous !== null && previous !== "error") return previous;
+  return seeded.status;
 }
 
 /** Single owner cadence for project-config diagnostics (ms). */

--- a/gui/tests/dashboard-contracts.test.ts
+++ b/gui/tests/dashboard-contracts.test.ts
@@ -26,35 +26,36 @@ test("Dashboard usage polling cannot delay core health and settings", async () =
   const hook = await Bun.file(new URL("../src/pages/use-dashboard-data.ts", import.meta.url)).text();
   const overviewFnStart = core.indexOf("export async function fetchDashboardOverview");
   const usageFnStart = core.indexOf("export async function fetchDashboardUsage");
-  const controlsFnStart = core.indexOf("export async function fetchDashboardControls");
+  const sidecarsFnStart = core.indexOf("export async function fetchDashboardSidecars");
   expect(overviewFnStart).toBeGreaterThan(-1);
   expect(usageFnStart).toBeGreaterThan(-1);
-  expect(controlsFnStart).toBeGreaterThan(-1);
+  expect(sidecarsFnStart).toBeGreaterThan(-1);
   expect(core.slice(overviewFnStart, core.indexOf("export async function fetchDashboardMultiAgent"))).not.toContain("/api/usage?range=30d");
   expect(core.slice(overviewFnStart, core.indexOf("export async function fetchDashboardMultiAgent"))).not.toContain("/api/sidecar-settings");
   expect(core.slice(overviewFnStart, core.indexOf("export async function fetchDashboardMultiAgent"))).not.toContain("/api/shadow-call-settings");
-  expect(core.slice(controlsFnStart, overviewFnStart > controlsFnStart ? overviewFnStart : undefined)).toContain("/api/sidecar-settings");
+  expect(core.slice(sidecarsFnStart)).toContain("/api/sidecar-settings");
   expect(hook).toContain("dashboard-usage:${apiBase}");
-  expect(hook).toContain("dashboard-controls:${apiBase}");
+  expect(hook).toContain("dashboard-sidecars:${apiBase}");
   expect(hook).toContain("dashboard-overview:${apiBase}");
   expect(hook).toContain("fetchDashboardUsage(apiBase, signal)");
-  expect(hook).toContain("fetchDashboardControls");
+  expect(hook).toContain("fetchDashboardSidecars");
   expect(hook).toContain("fetchDashboardOverview");
   expect(hook).toMatch(/dashboard-usage:\$\{apiBase\}[\s\S]*pollMs: 60_000/);
 });
 
 test("Dashboard interactive controls load independently of health/providers", async () => {
   const core = await Bun.file(new URL("../src/pages/dashboard-core-poll.ts", import.meta.url)).text();
-  const controlsFnStart = core.indexOf("export async function fetchDashboardControls");
-  const overviewFnStart = core.indexOf("export async function fetchDashboardOverview");
-  expect(controlsFnStart).toBeGreaterThan(-1);
-  const controlsBody = core.slice(controlsFnStart, overviewFnStart > controlsFnStart ? overviewFnStart : undefined);
-  expect(controlsBody).toContain("/api/settings");
-  expect(controlsBody).toContain("/api/sidecar-settings");
-  expect(controlsBody).toContain("/api/shadow-call-settings");
-  expect(controlsBody).not.toContain("/healthz");
-  expect(controlsBody).not.toContain("/api/providers");
-  expect(controlsBody).not.toContain("/api/usage");
+  const sidecarsFnStart = core.indexOf("export async function fetchDashboardSidecars");
+  const settingsFnStart = core.indexOf("export async function fetchDashboardSettings");
+  expect(sidecarsFnStart).toBeGreaterThan(-1);
+  expect(settingsFnStart).toBeGreaterThan(-1);
+  const sidecarsBody = core.slice(sidecarsFnStart, settingsFnStart > sidecarsFnStart ? settingsFnStart : undefined);
+  expect(sidecarsBody).toContain("/api/sidecar-settings");
+  expect(sidecarsBody).toContain("/api/shadow-call-settings");
+  expect(sidecarsBody).not.toContain("/api/settings");
+  expect(sidecarsBody).not.toContain("/healthz");
+  expect(sidecarsBody).not.toContain("/api/providers");
+  expect(sidecarsBody).not.toContain("/api/usage");
 });
 
 test("Dashboard overview status widgets do not wait on injection-model", async () => {
@@ -74,6 +75,29 @@ test("Dashboard overview status widgets do not wait on injection-model", async (
   expect(hook).toContain("dashboard-overview:${apiBase}");
   expect(hook).toContain("dashboard-multi-agent:${apiBase}");
   expect(hook).toContain("enabled: overviewReady");
+});
+
+test("Dashboard MA mode and sidecars do not wait on settings or injection", async () => {
+  const core = await Bun.file(new URL("../src/pages/dashboard-core-poll.ts", import.meta.url)).text();
+  const hook = await Bun.file(new URL("../src/pages/use-dashboard-data.ts", import.meta.url)).text();
+  const maStart = core.indexOf("export async function fetchDashboardMaMode");
+  const sidecarsStart = core.indexOf("export async function fetchDashboardSidecars");
+  const settingsStart = core.indexOf("export async function fetchDashboardSettings");
+  const overviewStart = core.indexOf("export async function fetchDashboardOverview");
+  expect(maStart).toBeGreaterThan(-1);
+  expect(sidecarsStart).toBeGreaterThan(-1);
+  expect(settingsStart).toBeGreaterThan(-1);
+  const maBody = core.slice(maStart, overviewStart > maStart ? overviewStart : undefined);
+  const sidecarsBody = core.slice(sidecarsStart, settingsStart > sidecarsStart ? settingsStart : undefined);
+  expect(maBody).toContain("/api/v2");
+  expect(maBody).not.toContain("/api/injection-model");
+  expect(maBody).not.toContain("/api/settings");
+  expect(sidecarsBody).toContain("/api/sidecar-settings");
+  expect(sidecarsBody).not.toContain("/api/settings");
+  expect(hook).toContain("dashboard-ma-mode:${apiBase}");
+  expect(hook).toContain("dashboard-sidecars:${apiBase}");
+  expect(hook).toContain("dashboard-settings:${apiBase}");
+  expect(hook).not.toContain("dashboard-controls:${apiBase}");
 });
 
 test("Dashboard workspace pane is a labelled section, not a nested main landmark", async () => {

--- a/gui/tests/dashboard-contracts.test.ts
+++ b/gui/tests/dashboard-contracts.test.ts
@@ -26,12 +26,33 @@ test("Dashboard usage polling cannot delay core health and settings", async () =
   const hook = await Bun.file(new URL("../src/pages/use-dashboard-data.ts", import.meta.url)).text();
   const coreFnStart = core.indexOf("export async function fetchDashboardCore");
   const usageFnStart = core.indexOf("export async function fetchDashboardUsage");
+  const controlsFnStart = core.indexOf("export async function fetchDashboardControls");
   expect(coreFnStart).toBeGreaterThan(-1);
   expect(usageFnStart).toBeGreaterThan(-1);
+  expect(controlsFnStart).toBeGreaterThan(-1);
   expect(core.slice(coreFnStart)).not.toContain("/api/usage?range=30d");
+  expect(core.slice(coreFnStart)).not.toContain("/api/sidecar-settings");
+  expect(core.slice(coreFnStart)).not.toContain("/api/shadow-call-settings");
+  expect(core.slice(controlsFnStart, coreFnStart > controlsFnStart ? coreFnStart : undefined)).toContain("/api/sidecar-settings");
   expect(hook).toContain("dashboard-usage:${apiBase}");
+  expect(hook).toContain("dashboard-controls:${apiBase}");
   expect(hook).toContain("fetchDashboardUsage(apiBase, signal)");
+  expect(hook).toContain("fetchDashboardControls");
   expect(hook).toMatch(/dashboard-usage:\$\{apiBase\}[\s\S]*pollMs: 60_000/);
+});
+
+test("Dashboard interactive controls load independently of health/providers", async () => {
+  const core = await Bun.file(new URL("../src/pages/dashboard-core-poll.ts", import.meta.url)).text();
+  const controlsFnStart = core.indexOf("export async function fetchDashboardControls");
+  const coreFnStart = core.indexOf("export async function fetchDashboardCore");
+  expect(controlsFnStart).toBeGreaterThan(-1);
+  const controlsBody = core.slice(controlsFnStart, coreFnStart > controlsFnStart ? coreFnStart : undefined);
+  expect(controlsBody).toContain("/api/settings");
+  expect(controlsBody).toContain("/api/sidecar-settings");
+  expect(controlsBody).toContain("/api/shadow-call-settings");
+  expect(controlsBody).not.toContain("/healthz");
+  expect(controlsBody).not.toContain("/api/providers");
+  expect(controlsBody).not.toContain("/api/usage");
 });
 
 test("Dashboard workspace pane is a labelled section, not a nested main landmark", async () => {

--- a/gui/tests/dashboard-contracts.test.ts
+++ b/gui/tests/dashboard-contracts.test.ts
@@ -14,45 +14,66 @@ test("Dashboard wires a single project-config diagnostics owner outside the sett
   expect(core.match(/diagnostics\/project-config/g)?.length ?? 0).toBe(1);
   expect(hook).toContain("fetchProjectConfigDiagnostics");
   expect(hook).toContain("PROJECT_CONFIG_DIAGNOSTICS_POLL_MS");
-  // Core poll must not own the diagnostics endpoint.
-  const coreFnStart = core.indexOf("export async function fetchDashboardCore");
-  expect(coreFnStart).toBeGreaterThan(-1);
-  const coreBody = core.slice(coreFnStart);
-  expect(coreBody).not.toContain("diagnostics/project-config");
+  // Overview poll must not own the diagnostics endpoint.
+  const overviewFnStart = core.indexOf("export async function fetchDashboardOverview");
+  expect(overviewFnStart).toBeGreaterThan(-1);
+  const overviewBody = core.slice(overviewFnStart, core.indexOf("export async function fetchDashboardMultiAgent"));
+  expect(overviewBody).not.toContain("diagnostics/project-config");
 });
 
 test("Dashboard usage polling cannot delay core health and settings", async () => {
   const core = await Bun.file(new URL("../src/pages/dashboard-core-poll.ts", import.meta.url)).text();
   const hook = await Bun.file(new URL("../src/pages/use-dashboard-data.ts", import.meta.url)).text();
-  const coreFnStart = core.indexOf("export async function fetchDashboardCore");
+  const overviewFnStart = core.indexOf("export async function fetchDashboardOverview");
   const usageFnStart = core.indexOf("export async function fetchDashboardUsage");
   const controlsFnStart = core.indexOf("export async function fetchDashboardControls");
-  expect(coreFnStart).toBeGreaterThan(-1);
+  expect(overviewFnStart).toBeGreaterThan(-1);
   expect(usageFnStart).toBeGreaterThan(-1);
   expect(controlsFnStart).toBeGreaterThan(-1);
-  expect(core.slice(coreFnStart)).not.toContain("/api/usage?range=30d");
-  expect(core.slice(coreFnStart)).not.toContain("/api/sidecar-settings");
-  expect(core.slice(coreFnStart)).not.toContain("/api/shadow-call-settings");
-  expect(core.slice(controlsFnStart, coreFnStart > controlsFnStart ? coreFnStart : undefined)).toContain("/api/sidecar-settings");
+  expect(core.slice(overviewFnStart, core.indexOf("export async function fetchDashboardMultiAgent"))).not.toContain("/api/usage?range=30d");
+  expect(core.slice(overviewFnStart, core.indexOf("export async function fetchDashboardMultiAgent"))).not.toContain("/api/sidecar-settings");
+  expect(core.slice(overviewFnStart, core.indexOf("export async function fetchDashboardMultiAgent"))).not.toContain("/api/shadow-call-settings");
+  expect(core.slice(controlsFnStart, overviewFnStart > controlsFnStart ? overviewFnStart : undefined)).toContain("/api/sidecar-settings");
   expect(hook).toContain("dashboard-usage:${apiBase}");
   expect(hook).toContain("dashboard-controls:${apiBase}");
+  expect(hook).toContain("dashboard-overview:${apiBase}");
   expect(hook).toContain("fetchDashboardUsage(apiBase, signal)");
   expect(hook).toContain("fetchDashboardControls");
+  expect(hook).toContain("fetchDashboardOverview");
   expect(hook).toMatch(/dashboard-usage:\$\{apiBase\}[\s\S]*pollMs: 60_000/);
 });
 
 test("Dashboard interactive controls load independently of health/providers", async () => {
   const core = await Bun.file(new URL("../src/pages/dashboard-core-poll.ts", import.meta.url)).text();
   const controlsFnStart = core.indexOf("export async function fetchDashboardControls");
-  const coreFnStart = core.indexOf("export async function fetchDashboardCore");
+  const overviewFnStart = core.indexOf("export async function fetchDashboardOverview");
   expect(controlsFnStart).toBeGreaterThan(-1);
-  const controlsBody = core.slice(controlsFnStart, coreFnStart > controlsFnStart ? coreFnStart : undefined);
+  const controlsBody = core.slice(controlsFnStart, overviewFnStart > controlsFnStart ? overviewFnStart : undefined);
   expect(controlsBody).toContain("/api/settings");
   expect(controlsBody).toContain("/api/sidecar-settings");
   expect(controlsBody).toContain("/api/shadow-call-settings");
   expect(controlsBody).not.toContain("/healthz");
   expect(controlsBody).not.toContain("/api/providers");
   expect(controlsBody).not.toContain("/api/usage");
+});
+
+test("Dashboard overview status widgets do not wait on injection-model", async () => {
+  const core = await Bun.file(new URL("../src/pages/dashboard-core-poll.ts", import.meta.url)).text();
+  const hook = await Bun.file(new URL("../src/pages/use-dashboard-data.ts", import.meta.url)).text();
+  const overviewStart = core.indexOf("export async function fetchDashboardOverview");
+  const multiStart = core.indexOf("export async function fetchDashboardMultiAgent");
+  expect(overviewStart).toBeGreaterThan(-1);
+  expect(multiStart).toBeGreaterThan(overviewStart);
+  const overviewBody = core.slice(overviewStart, multiStart);
+  expect(overviewBody).toContain("/healthz");
+  expect(overviewBody).toContain("/api/providers");
+  expect(overviewBody).not.toContain("/api/injection-model");
+  expect(overviewBody).not.toContain("/api/v2");
+  expect(overviewBody).not.toContain("/api/effort-caps");
+  expect(core.slice(multiStart)).toContain("/api/injection-model");
+  expect(hook).toContain("dashboard-overview:${apiBase}");
+  expect(hook).toContain("dashboard-multi-agent:${apiBase}");
+  expect(hook).toContain("enabled: overviewReady");
 });
 
 test("Dashboard workspace pane is a labelled section, not a nested main landmark", async () => {
@@ -98,4 +119,22 @@ test("Dashboard sync surfaces native subagent default warnings", async () => {
   expect(sections).toContain("syncResult.nativeSubagentDefaultsWarning");
   expect(sections).toContain('"notice-warn"');
   expect(sections).toContain("<IconAlert />");
+});
+
+test("fetchStartupHealth does not map abort into a sticky error status", async () => {
+  const { fetchStartupHealth } = await import("../src/pages/dashboard-core-poll");
+  const controller = new AbortController();
+  controller.abort();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+    if (init?.signal?.aborted) {
+      throw new DOMException("The operation was aborted.", "AbortError");
+    }
+    return Response.json({ status: "protected", diagnosticStale: false });
+  }) as typeof fetch;
+  try {
+    await expect(fetchStartupHealth("http://test", controller.signal)).rejects.toMatchObject({ name: "AbortError" });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });

--- a/gui/tests/session-list-cache.test.ts
+++ b/gui/tests/session-list-cache.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import {
+  clearSessionListCache,
+  readSessionListCache,
+  writeSessionListCache,
+} from "../src/session-list-cache";
+
+const globals = ["document", "window", "navigator", "sessionStorage"] as const;
+let previousGlobals: Record<(typeof globals)[number], unknown>;
+let testWindow: Window;
+
+function install() {
+  previousGlobals = Object.fromEntries(globals.map(key => [key, Reflect.get(globalThis, key)])) as typeof previousGlobals;
+  testWindow = new Window({ url: "http://localhost/" });
+  Object.defineProperties(globalThis, {
+    document: { configurable: true, value: testWindow.document },
+    window: { configurable: true, value: testWindow },
+    navigator: { configurable: true, value: testWindow.navigator },
+    sessionStorage: { configurable: true, value: testWindow.sessionStorage },
+  });
+  sessionStorage.clear();
+}
+
+function restore() {
+  testWindow.close();
+  for (const key of globals) {
+    Object.defineProperty(globalThis, key, { configurable: true, value: previousGlobals[key] });
+  }
+}
+
+afterEach(restore);
+
+test("session list cache round-trips non-secret JSON shapes", () => {
+  install();
+  writeSessionListCache("ocx.test", { range: "30d", surface: "claude", n: 3 });
+  expect(readSessionListCache<{ range: string; surface: string; n: number }>("ocx.test")).toEqual({
+    range: "30d",
+    surface: "claude",
+    n: 3,
+  });
+  clearSessionListCache("ocx.test");
+  expect(readSessionListCache("ocx.test")).toBeNull();
+});
+
+test("session list cache returns null for corrupt JSON", () => {
+  install();
+  sessionStorage.setItem("ocx.bad", "{not-json");
+  expect(readSessionListCache("ocx.bad")).toBeNull();
+});

--- a/tests/provider-workspace-data.test.ts
+++ b/tests/provider-workspace-data.test.ts
@@ -55,15 +55,16 @@ function forwardProv(overrides: Partial<WorkspaceProvider> = {}): WorkspaceProvi
 }
 
 describe("applyActiveAccountReauth", () => {
-  test("demotes ready provider when active account needs reauth", () => {
+  test("tags ready provider when active account needs reauth without moving sections", () => {
     const sections = buildProviderWorkspace({
       anthropic: prov({ authMode: "oauth" }),
       keyed: prov({ authMode: "key", hasApiKey: true }),
     });
     expect(sections.ready.map(p => p.name)).toContain("anthropic");
     const next = applyActiveAccountReauth(sections, { anthropic: true });
-    expect(next.ready.map(p => p.name)).not.toContain("anthropic");
-    expect(next.needsSetup.map(p => p.name)).toContain("anthropic");
+    expect(next.ready.map(p => p.name)).toContain("anthropic");
+    expect(next.needsSetup.map(p => p.name)).not.toContain("anthropic");
+    expect(next.ready.find(p => p.name === "anthropic")?.activeNeedsReauth).toBe(true);
     expect(next.ready.map(p => p.name)).toContain("keyed");
   });
 
@@ -74,6 +75,7 @@ describe("applyActiveAccountReauth", () => {
     const next = applyActiveAccountReauth(sections, { anthropic: false });
     expect(next.ready.map(p => p.name)).toContain("anthropic");
     expect(next.needsSetup.map(p => p.name)).not.toContain("anthropic");
+    expect(next.ready.find(p => p.name === "anthropic")?.activeNeedsReauth).toBeUndefined();
   });
 
   test("does not move disabled providers", () => {
@@ -85,14 +87,14 @@ describe("applyActiveAccountReauth", () => {
     expect(next.needsSetup.map(p => p.name)).not.toContain("anthropic");
   });
 
-  test("demoted items carry activeNeedsReauth and binProviderStatus is needs-setup", () => {
+  test("tagged ready items keep section membership; binProviderStatus is needs-setup", () => {
     const sections = buildProviderWorkspace({
       anthropic: prov({ authMode: "oauth" }),
     });
     const next = applyActiveAccountReauth(sections, { anthropic: true });
-    const demoted = next.needsSetup.find(p => p.name === "anthropic");
-    expect(demoted?.activeNeedsReauth).toBe(true);
-    expect(binProviderStatus(demoted!)).toBe("needs-setup");
+    const tagged = next.ready.find(p => p.name === "anthropic");
+    expect(tagged?.activeNeedsReauth).toBe(true);
+    expect(binProviderStatus(tagged!)).toBe("needs-setup");
     expect(binProviderStatus(prov({ authMode: "oauth" }))).toBe("ready");
   });
 });
@@ -340,8 +342,8 @@ describe("usage: most-used and attention", () => {
     const sections = applyActiveAccountReauth(base, { anthropic: true });
     const items = buildAttentionItems(sections, {});
     expect(items).toEqual([
-      { name: "missing", reason: "Missing credentials" },
       { name: "anthropic", reason: "Active account needs re-authentication" },
+      { name: "missing", reason: "Missing credentials" },
     ]);
   });
 });

--- a/tests/startup-health-ui.test.ts
+++ b/tests/startup-health-ui.test.ts
@@ -26,16 +26,19 @@ describe("startup health UI decisions", () => {
     expect(settingsPollMayCommit(started, { request: 4, mutation: 2, mutationInFlight: true })).toBe(false);
   });
 
-  test("maps stale diagnostics to error and rejects invalid payloads", () => {
-    expect(mapStartupHealthProbe({ status: "protected", diagnosticStale: true })).toBe("error");
+  test("keeps payload status when diagnostics are stale and rejects invalid payloads", () => {
+    // diagnosticStale is SWR refresh, not a hard read failure — do not map to "error".
+    expect(mapStartupHealthProbe({ status: "protected", diagnosticStale: true })).toBe("protected");
+    expect(mapStartupHealthProbe({ status: "at-risk", diagnosticStale: true })).toBe("at-risk");
     expect(mapStartupHealthProbe({ status: "native", diagnosticStale: false })).toBe("native");
     expect(mapStartupHealthProbe({ status: "nope" })).toBeNull();
   });
 
-  test("settings may only seed while startup health is still unknown", () => {
+  test("settings may seed while unknown or hard-error, but not overwrite a real status", () => {
     expect(seedStartupHealthFromSettings(null, { status: "protected", diagnosticStale: false })).toBe("protected");
-    expect(seedStartupHealthFromSettings("error", { status: "protected", diagnosticStale: false })).toBe("error");
-    expect(seedStartupHealthFromSettings(null, { status: "at-risk", diagnosticStale: true })).toBe("error");
+    expect(seedStartupHealthFromSettings("error", { status: "protected", diagnosticStale: false })).toBe("protected");
+    expect(seedStartupHealthFromSettings(null, { status: "at-risk", diagnosticStale: true })).toBe("at-risk");
+    expect(seedStartupHealthFromSettings("at-risk", { status: "protected", diagnosticStale: false })).toBe("at-risk");
   });
 });
 


### PR DESCRIPTION
## Summary
- Dashboard: load settings/sidecar/shadow via a dedicated poll (not gated on slow health/usage); session cache for last-known; `aria-busy` on slow stats only
- Models: fetch shadow settings on mount so switch/dropdown work while catalog still loads
- Providers: keep rail order config-stable (no alpha→ready resort flash); prefetch catalog/usage; parallel oauth/accounts

Before/after notes: `devlog/gui-load-perf-hot-before-after.md`

## Test plan
- [ ] Dashboard: Shadow Call Intercept + sidecar/vision usable before tokens/uptime finish
- [ ] Models: shadow controls interactive during catalog load
- [ ] Providers: rail does not jump from alpha to ready/need-setup after discovery
- [ ] Add Provider catalog feels snappier on open
- [ ] `gui` lint + dashboard-contracts / provider-workspace-data tests

Part of GUI loading split (PERF-1). UI drafts: #607 #630 #629.