### PR TITLE
fix(service): compare Task Scheduler Arguments after XML decode

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -1050,6 +1050,29 @@ function taskXmlOptionalValueEquals(xml: string, tag: string, expected: string):
   return value?.trim().toLowerCase() === expected.toLowerCase();
 }
 
+function taskXmlDecodeEntities(value: string): string {
+  return value
+    .replace(/&quot;/g, "\"")
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+/**
+ * Exact element-text match after one-pass decoding of XML's five predefined entities.
+ * Task Scheduler exports element text unescaped (`"`), while we emit `&quot;` (#608).
+ * Rejects zero/multiple occurrences and nested markup (no `<` inside the value).
+ */
+function taskXmlElementTextEquals(xml: string, tag: string, expectedDecoded: string): boolean {
+  if (taskXmlHasPrefixedTag(xml, tag)) return false;
+  const count = taskXmlElementCount(xml, tag);
+  if (count !== 1) return false;
+  const raw = new RegExp(`<${tag}(?:\\s[^>]*?)?>\\s*([^<]*?)\\s*<\\/${tag}>`, "i").exec(xml)?.[1];
+  if (raw === undefined || raw.includes("<")) return false;
+  return taskXmlDecodeEntities(raw) === expectedDecoded;
+}
+
 /** Validate the security/lifecycle-critical fields of the registered scheduler task. */
 export function windowsTaskRegistrationHealthy(
   xml: string,
@@ -1076,8 +1099,8 @@ export function windowsTaskRegistrationHealthy(
     && taskXmlOptionalValueEquals(settings, "Enabled", "true")
     && /<MultipleInstancesPolicy>\s*IgnoreNew\s*<\/MultipleInstancesPolicy>/i.test(settings)
     && /<ExecutionTimeLimit>\s*PT0S\s*<\/ExecutionTimeLimit>/i.test(settings)
-    && action.includes(`<Command>${taskXmlString(wscript)}</Command>`)
-    && action.includes(`<Arguments>${taskXmlString(`/b /nologo "${launcher}"`)}</Arguments>`);
+    && taskXmlElementTextEquals(action, "Command", wscript)
+    && taskXmlElementTextEquals(action, "Arguments", `/b /nologo "${launcher}"`);
 }
 
 export interface WindowsSchedulerXmlState {

--- a/src/service.ts
+++ b/src/service.ts
@@ -1070,7 +1070,7 @@ function taskXmlElementTextEquals(xml: string, tag: string, expectedDecoded: str
   if (count !== 1) return false;
   const raw = new RegExp(`<${tag}(?:\\s[^>]*?)?>\\s*([^<]*?)\\s*<\\/${tag}>`, "i").exec(xml)?.[1];
   if (raw === undefined || raw.includes("<")) return false;
-  return taskXmlDecodeEntities(raw) === expectedDecoded;
+  return taskXmlDecodeEntities(raw).trim() === expectedDecoded.trim();
 }
 
 /** Validate the security/lifecycle-critical fields of the registered scheduler task. */

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -237,6 +237,21 @@ describe("Windows service task", () => {
     expect(xml).not.toContain("<Command>C:\\Users\\a&amp;b\\.opencodex\\opencodex-service.cmd</Command>");
   });
 
+  test("accepts Task Scheduler Arguments with unescaped quotes (#608)", () => {
+    const wscript = "C:\\Windows\\System32\\wscript.exe";
+    const launcher = "C:\\Users\\Test\\.opencodex\\service-launcher.vbs";
+    const xml = buildWindowsTaskXml("ignored.cmd", launcher)
+      .replace(/<Command>.*?<\/Command>/, `<Command>${wscript}</Command>`)
+      // Windows exports element text unescaped — literal " not &quot;
+      .replace(
+        `<Arguments>/b /nologo &quot;${launcher}&quot;</Arguments>`,
+        `<Arguments>/b /nologo "${launcher}"</Arguments>`,
+      );
+    expect(xml).toContain(`<Arguments>/b /nologo "${launcher}"</Arguments>`);
+    expect(xml).not.toContain("&quot;");
+    expect(windowsTaskRegistrationHealthy(xml, wscript, launcher)).toBe(true);
+  });
+
   test("validates the registered scheduler action, trigger, principal, and settings", () => {
     const wscript = "C:\\Windows\\System32\\wscript.exe";
     const launcher = "C:\\Users\\Test\\.opencodex\\service-launcher.vbs";


### PR DESCRIPTION
## Summary
- Compare `<Arguments>`/`<Command>` by decoding XML entities once, matching Windows Task Scheduler's unescaped export (distinct from #432).
- Keeps nested-markup / multi-element rejection.

## Test plan
- [x] `bun test tests/service.test.ts -t '#608'`
- [ ] CI green

Closes #608