### PR TITLE
docs: require needs-go-port for deferred Go ports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,8 @@ A merge into `dev` does not finish the task. The merging maintainer also
 rebases that work onto `dev2-go`, ports whatever needs a Go counterpart under
 `go/`, and merges the port. The item is done only when both lines carry the
 change. If a change has no Go counterpart, say so in the merge or tracking
-issue; if the port has to wait, open a tracking issue against `dev2-go` naming
-the source commits before closing out the `dev` merge.
+issue; if the port has to wait, open a `needs-go-port` tracking issue against
+`dev2-go` naming the source commits before closing out the `dev` merge.
 [`MAINTAINERS.md`](./MAINTAINERS.md) holds the authoritative wording.
 
 The Claude Desktop integration formerly carried on the `claudedesktop` branch is

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -45,7 +45,9 @@ rule is written out under [Review and merge policy](#review-and-merge-policy).
     indistinguishable from a forgotten one.
   - If the port cannot be completed immediately (a blocking dependency, a
     subsystem the port has not reached), open a tracking issue against
-    `dev2-go` before closing out the `dev` merge, and name the source commits.
+    `dev2-go` before closing out the `dev` merge, label it `needs-go-port`,
+    and name the source commits. That label is the durable signal that a
+    deferred port is intentional, not forgotten.
 - A pull request requires approval from at least one maintainer and successful required CI checks
   before merge.
 - Authors do not approve their own pull requests.


### PR DESCRIPTION
## Summary
- Lock the `needs-go-port` label into `MAINTAINERS.md` for deferred Go ports during the Transition phase.
- Mirror the label name in the `AGENTS.md` Transition summary (authoritative wording stays in MAINTAINERS).

Existing rule already required a tracking issue against `dev2-go` naming source commits; this makes the durable triage signal part of policy.

## Test plan
- [ ] Read the Transition bullets in MAINTAINERS + AGENTS for consistency
- [ ] Confirm label `needs-go-port` still exists on the repo