### PR TITLE
docs: carry needs-go-port policy onto dig2-go (#672)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,9 +55,21 @@ non-trivial change. CI runs these on Linux, Windows, and macOS.
 - `main` — release branch. It only moves by maintainer-controlled promotion
   from `dev` (releases, docs deploys). Do not open feature PRs against `main`.
 - `preview` — prerelease train (`x.y.z-preview.*` versions).
-- `dev2-go` — temporary maintainer-owned Go rewrite track running in parallel
-  with the TypeScript `preview` train. It intentionally has no standing pull
-  request into `dev`; do not merge or rebase it without maintainer direction.
+
+### Transition to `dev2-go`
+
+The project is moving its primary runtime to the Go native port, so `dev2-go`
+has to keep receiving everything that lands on `dev`. Pull requests against
+`dev` stay welcome and unchanged — the extra work belongs to the maintainer who
+merges them.
+
+A merge into `dev` does not finish the task. The merging maintainer also
+rebases that work onto `dev2-go`, ports whatever needs a Go counterpart under
+`go/`, and merges the port. The item is done only when both lines carry the
+change. If a change has no Go counterpart, say so in the merge or tracking
+issue; if the port has to wait, open a `needs-go-port` tracking issue against
+`dev2-go` naming the source commits before closing out the `dev` merge.
+[`MAINTAINERS.md`](./MAINTAINERS.md) holds the authoritative wording.
 
 The Claude Desktop integration formerly carried on the `claudedesktop` branch is
 now fully merged into `dev`, and that branch has been retired. Desktop work

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -23,6 +23,27 @@ through GitHub repository settings.
   distinguish scoped Go port work from anything else aimed at `dev2-go`, so
   that boundary is enforced in review: redirect an out-of-scope pull request to
   `dev` rather than treating the automation's silence as approval.
+- **Transition to `dev2-go` (current phase).** The project is moving its
+  primary runtime to the Go native port, so `dev2-go` has to keep receiving
+  everything that lands on `dev`. Contributors still open pull requests against
+  `dev`, and that stays allowed — the extra work is the maintainer's, not
+  theirs. A merge into `dev` is therefore not the end of the task. The
+  maintainer who merges it also rebases that work onto `dev2-go`, ports
+  whatever needs a Go counterpart under `go/`, and merges the port. The item is
+  finished only when both lines carry the change.
+  - Do the rebase and the port in the same session as the merge. A `dev` merge
+    left unported is the failure mode this rule exists to prevent: `dev2-go`
+    silently falls behind, and the divergence surfaces later as a conflict
+    nobody has context for.
+  - When a change genuinely has no Go counterpart — docs, TypeScript-only
+    paths the port does not cover yet, GUI-only work — record that decision in
+    the merge or the tracking issue. An unexplained missing port is
+    indistinguishable from a forgotten one.
+  - If the port cannot be completed immediately (a blocking dependency, a
+    subsystem the port has not reached), open a tracking issue against
+    `dev2-go` before closing out the `dev` merge, label it `needs-go-port`,
+    and name the source commits. That label is the durable signal that a
+    deferred port is intentional, not forgotten.
 - A pull request requires approval from at least one maintainer and successful required CI checks
   before merge.
 - Authors do not approve their own pull requests.


### PR DESCRIPTION
## Summary
- Carries #672 onto `dev2-go`.
- Also brings the Transition section from `dev` that was missing on this line (so `needs-go-port` has a place to live). Drops the obsolete duplicate `dev2-go` bullet in AGENTS.

## Go port
None — docs/policy only. Decision: leave.

## Test plan
- [x] Conflicts resolved; Transition + `needs-go-port` present on both files