### PR TITLE
docs(security): point reporters at the now-enabled private advisory form

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Report a security vulnerability (private)
+    url: https://github.com/lidge-jun/opencodex/security/advisories/new
+    about: Report undisclosed vulnerabilities privately to the maintainers. Do not open a public issue.
   - name: Security policy
     url: https://github.com/lidge-jun/opencodex/blob/main/SECURITY.md
     about: Read the supported-version and reporting guidance before sharing security-sensitive details.

--- a/README.md
+++ b/README.md
@@ -509,6 +509,9 @@ The public docs — install, providers, routing, sidecars, Codex integration, Co
 Maintainer source-of-truth notes live under [`structure/`](./structure). Historical investigations remain under [`docs/`](./docs).
 Contributor setup lives in [`CONTRIBUTING.md`](./CONTRIBUTING.md), and security reporting guidance
 lives in [`SECURITY.md`](./SECURITY.md).
+Report undisclosed vulnerabilities privately through
+[GitHub private vulnerability reporting](https://github.com/lidge-jun/opencodex/security/advisories/new),
+not a public issue.
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,13 +17,19 @@ or the latest published package before triage continues.
 
 Please avoid posting undisclosed vulnerabilities as public GitHub issues.
 
-- Prefer this repository's GitHub private vulnerability reporting or GitHub Security Advisory flow
-  when that option is available in the repository UI.
-- If no private reporting option is available, do not include exploit details, secrets, or live
-  targets in a public issue. Open a minimal issue that asks maintainers for a safe coordination path.
-- Include affected versions, reproduction steps, impact, and any required configuration details.
+Report privately through GitHub private vulnerability reporting, which is enabled on this
+repository:
 
-The project does not publish a dedicated private security email in this repository.
+**<https://github.com/lidge-jun/opencodex/security/advisories/new>**
+
+The same form is reachable from the repository's **Security** tab under **Report a vulnerability**.
+It is private between you and the maintainers, and it is the only channel this project offers for
+undisclosed vulnerabilities — there is no dedicated private security email.
+
+Include affected versions, reproduction steps, impact, and any required configuration details.
+
+If the form is ever unreachable for you, open a minimal public issue that asks maintainers for a
+safe coordination path. Do not include exploit details, secrets, or live targets in that issue.
 
 ## Response Expectations
 


### PR DESCRIPTION
## Summary

`SECURITY.md` described a private reporting path that did not exist, so a
reporter following it had no way to disclose privately.

The file told reporters to prefer "this repository's GitHub private
vulnerability reporting or GitHub Security Advisory flow **when that option is
available in the repository UI**", and then stated that the project publishes no
private security email. At the time, `GET /repos/lidge-jun/opencodex/private-vulnerability-reporting`
returned `{"enabled": false}` and the repository had zero published advisories,
so none of the named private channels resolved to anything. The only remaining
instruction was to open a public issue asking for a safe coordination path —
which is exactly what the policy opens by telling people not to do.

## Changes

Private vulnerability reporting has been enabled on the repository
(`{"enabled": true}`), and the advisory form now returns HTTP 200.

- `SECURITY.md` — replace the conditional wording with the direct advisory URL
  and the Security-tab location. The minimal-public-issue text stays, demoted
  from default to fallback for reporters who cannot reach the form.
- `.github/ISSUE_TEMPLATE/config.yml` — add the advisory form as the first
  contact link, above the security-policy link, so the chooser routes reporters
  to the private path before they can open an issue.
- `README.md` — name the private path where the docs section already points at
  `SECURITY.md`.

## Verification

- `https://github.com/lidge-jun/opencodex/security/advisories/new` → HTTP 200
- `gh api repos/lidge-jun/opencodex/private-vulnerability-reporting` → `{"enabled":true}`
- `.github/ISSUE_TEMPLATE/config.yml` parses; contact links resolve to
  `["Report a security vulnerability (private)", "Security policy", "Contributing guide"]`
- The pre-push hook ran `bun run test` to completion before this branch was
  pushed.

Docs-only; no runtime code touched.

## Follow-up

Dependabot security updates are currently `disabled` on the repository and
should be enabled separately.
