### PR TITLE
fix(claude): accept data-only Responses SSE (#700)

### DIFF
--- a/src/claude/outbound.ts
+++ b/src/claude/outbound.ts
@@ -453,12 +453,15 @@ export function responsesSseToAnthropicSse(
                 if (line.startsWith("event: ")) eventName = line.slice(7).trim();
                 else if (line.startsWith("data: ")) dataLine += line.slice(6);
               }
-              if (!eventName || !dataLine) continue;
+              if (!dataLine) continue;
               let data: unknown;
               try { data = JSON.parse(dataLine); } catch { continue; }
               if (!isRec(data)) continue;
-              if (terminated) continue;
-              handleFrame(eventName, data);
+              // Responses-compatible gateways may omit the optional SSE event field
+              // while retaining the event name in the JSON payload's required type.
+              const resolvedEventName = eventName || (typeof data.type === "string" ? data.type : "");
+              if (!resolvedEventName || terminated) continue;
+              handleFrame(resolvedEventName, data);
             }
           }
           // EOF without a terminal frame is a TRUNCATION, not success (devlog 100:

--- a/tests/claude-outbound.test.ts
+++ b/tests/claude-outbound.test.ts
@@ -13,6 +13,12 @@ function sse(name: string, data: Record<string, unknown>): string {
   return `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`;
 }
 
+function dataOnlySse(data: Record<string, unknown>): string {
+  return `data: ${JSON.stringify(data)}\n\n`;
+}
+
+const DONE_SSE = "data: [DONE]\n\n";
+
 function streamFrom(text: string): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
   return new ReadableStream({
@@ -97,6 +103,113 @@ describe("claude outbound SSE", () => {
     // monotonic block indexes
     const startIndexes = events.filter(e => e.name === "content_block_start").map(e => e.data.index);
     expect(startIndexes).toEqual([0, 1, 2]);
+  });
+
+  test("data-only Responses frames infer event names from payload types", async () => {
+    const upstream = [
+      dataOnlySse({ type: "response.created", response: { id: "resp_data_only", status: "in_progress" } }),
+      dataOnlySse({ type: "response.output_text.delta", delta: "data-only stream" }),
+      dataOnlySse({
+        type: "response.completed",
+        response: { status: "completed", usage: { input_tokens: 8, output_tokens: 2 } },
+      }),
+      DONE_SSE,
+    ].join("");
+
+    const events = await collectEvents(responsesSseToAnthropicSse(streamFrom(upstream), "m"));
+    expect(events.map(e => e.name)).toEqual([
+      "message_start", "ping",
+      "content_block_start", "content_block_delta", "content_block_stop",
+      "message_delta", "message_stop",
+    ]);
+    expect(events.find(e => e.name === "content_block_delta")!.data.delta).toEqual({
+      type: "text_delta",
+      text: "data-only stream",
+    });
+    expect(events.find(e => e.name === "message_delta")!.data).toMatchObject({
+      delta: { stop_reason: "end_turn" },
+      usage: { input_tokens: 8, output_tokens: 2 },
+    });
+  });
+
+  test("explicit and data-only Responses frames can interleave", async () => {
+    const upstream = [
+      sse("response.created", { response: { id: "resp_mixed", status: "in_progress" } }),
+      dataOnlySse({ type: "response.output_text.delta", delta: "mixed stream" }),
+      sse("response.completed", { response: { status: "completed" } }),
+      DONE_SSE,
+    ].join("");
+
+    const events = await collectEvents(responsesSseToAnthropicSse(streamFrom(upstream), "m"));
+    expect(events.find(e => e.name === "content_block_delta")!.data.delta).toEqual({
+      type: "text_delta",
+      text: "mixed stream",
+    });
+    expect(events.at(-1)!.name).toBe("message_stop");
+  });
+
+  test("data-only Responses frames survive non-streaming aggregation", async () => {
+    const upstream = [
+      dataOnlySse({ type: "response.output_text.delta", delta: "data-only message" }),
+      dataOnlySse({
+        type: "response.completed",
+        response: { status: "completed", usage: { input_tokens: 5, output_tokens: 3 } },
+      }),
+      DONE_SSE,
+    ].join("");
+
+    const anthropicSse = responsesSseToAnthropicSse(streamFrom(upstream), "m");
+    const message = await collectAnthropicMessage(anthropicSse, "m");
+    expect(message).toMatchObject({
+      type: "message",
+      role: "assistant",
+      content: [{ type: "text", text: "data-only message" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 5, output_tokens: 3 },
+    });
+  });
+
+  test("explicit event names override payload types and untyped data-only frames stay ignored", async () => {
+    const upstream = [
+      dataOnlySse({ delta: "must stay ignored" }),
+      sse("response.output_text.delta", { type: "response.ignored", delta: "visible" }),
+      sse("response.completed", {
+        type: "response.output_text.delta",
+        delta: "must not override the explicit terminal event",
+        response: { status: "completed" },
+      }),
+    ].join("");
+
+    const events = await collectEvents(responsesSseToAnthropicSse(streamFrom(upstream), "m"));
+    const textDeltas = events
+      .filter(e => e.name === "content_block_delta" && e.data.delta?.type === "text_delta")
+      .map(e => e.data.delta.text);
+    expect(textDeltas).toEqual(["visible"]);
+    expect(events.at(-1)!.name).toBe("message_stop");
+  });
+
+  test("data-only [DONE] without a Responses terminal frame still fails closed", async () => {
+    const upstream = [
+      dataOnlySse({ type: "response.output_text.delta", delta: "partial" }),
+      DONE_SSE,
+    ].join("");
+
+    const events = await collectEvents(responsesSseToAnthropicSse(streamFrom(upstream), "m"));
+    expect(events.some(e => e.name === "message_stop")).toBe(false);
+    expect(events.find(e => e.name === "content_block_delta")!.data.delta).toEqual({
+      type: "text_delta",
+      text: "partial",
+    });
+    expect(events.at(-1)).toMatchObject({
+      name: "error",
+      data: {
+        type: "error",
+        error: {
+          type: "overloaded_error",
+          message: "upstream stream ended before a terminal frame (truncated response)",
+        },
+      },
+    });
   });
 
   test("failed -> error event with taxonomy type", async () => {


### PR DESCRIPTION

Closes #700.

## Summary

- accept Responses-compatible data-only SSE records in the Claude Messages bridge by falling back
  to the parsed JSON payload's `type` when the optional SSE `event:` field is absent;
- preserve explicit event-name precedence and strict terminal-frame validation;
- add streaming, non-streaming, mixed-framing, precedence, ignored-frame, and truncation
  regressions.

## Problem

The Claude Messages bridge currently requires every upstream Responses SSE record to carry both an
`event:` line and a `data:` line before it parses the JSON:

```ts
if (!eventName || !dataLine) continue;
```

The provider in #700 emits valid data-only records whose Responses event type is in the JSON
payload:

```text
data: {"type":"response.output_text.delta",...}

data: {"type":"response.completed",...}

data: [DONE]
```

The HTML SSE standard permits data-only messages; `event:` is not required and the default event
type is `message`. Because the bridge drops these records before parsing them, it never observes
`response.completed`. Both Claude streaming and non-streaming requests consequently end as:

```text
upstream stream ended before a terminal frame (truncated response)
```

The two Claude response modes share this converter, so one parser gate causes both failures.

## Fix

Parse any record with a non-empty `data:` payload, then resolve its Responses event name as:

1. the explicit SSE `event:` value, when present; otherwise
2. the parsed JSON payload's string `type`.

The scope remains narrow:

- explicit `event:` values still take precedence over a conflicting payload `type`;
- untyped data-only JSON objects remain ignored;
- non-JSON sentinels such as `[DONE]` remain ignored;
- `response.completed`, `response.incomplete`, or `response.failed` is still required before EOF;
- cancellation, keepalive, terminal, error-taxonomy, image, and tool-call paths are unchanged.

This accepts the gateway's framing without weakening the existing fail-closed truncation contract.

## Tests

New regressions cover:

- a fully data-only Responses stream through Anthropic SSE output;
- data-only frames through non-streaming aggregation;
- explicit and data-only records interleaved in one stream;
- explicit event-name precedence over a conflicting payload type;
- ignoring untyped data-only records;
- `[DONE]` without a Responses terminal frame still producing a truncation error rather than
  `message_stop`.

Activation was verified before the source change: the streaming and non-streaming data-only tests
failed against the old gate, while the explicit-precedence control passed.

Final verification on commit `fcd3298f`:

- `bun test tests/claude-outbound.test.ts` — **30 passed, 0 failed**
- `bun test tests/claude-messages-endpoint.test.ts` — **26 passed, 0 failed**
- `bun run typecheck` — passed
- `bun run privacy:scan` — passed
- `git diff --check` — passed
- full isolated suite with Bun 1.3.14:
  `bun scripts/test.ts --max-concurrency 4 ./tests/` —
  **5,977 passed, 1 Windows-only skip, 0 failed across 429 files**

The bounded concurrency is a local WSL scheduling accommodation, not a test exclusion. At Bun's
default concurrency, two pre-existing deadline-sensitive tests intermittently starved under load;
the same tests passed 10/10 and 5/5 in isolated repetitions, and the complete lower-concurrency run
was clean.

## Notes

- No authentication, credential, logging, provider-routing, or workflow path changes.
- No live provider credential was used; the tests encode the redacted wire shape from #700.
- This is the TypeScript `dev` contribution. Any `dev2-go` port remains the maintainer's transition
  responsibility under the repository policy.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No user-facing configuration or API
  documentation changes are required.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming response handling for gateways that omit SSE event names.
  * Preserved text updates and message aggregation across mixed and data-only streams.
  * Added safer handling for untyped or incomplete terminal messages to prevent incorrect stream completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->