### PR TITLE
[WRONG BRANCH] fix(cursor): accept trailing -fast Grok wire ids

### DIFF
--- a/src/adapters/cursor/discovery.ts
+++ b/src/adapters/cursor/discovery.ts
@@ -67,13 +67,28 @@ function stripCursorWirePrefix(id: string): string {
 /**
  * True when a configured Cursor base model should remain exposed after live GetUsableModels filtering.
  * Live ids are full effort-suffixed variants (`claude-4.6-opus-high`); base ids match exactly or by prefix.
+ *
+ * Fast families currently use a trailing mode marker after the effort tier
+ * (`grok-4.5-high-fast`) rather than the older `{base}-fast-{effort}` form
+ * (`grok-4.5-fast-high`). Accept both so live discovery does not drop Fast when
+ * Cursor only returns the trailing-fast wire ids.
  */
 export function isCursorModelAvailableForAccount(modelId: string, liveIds: readonly string[]): boolean {
   return liveIds.some(raw => {
     const id = stripCursorWirePrefix(raw);
     if (id === modelId) return true;
     const effortPrefix = `${modelId}-`;
-    return id.startsWith(effortPrefix) && CANONICAL_EFFORT_SUFFIXES.has(id.slice(effortPrefix.length));
+    if (id.startsWith(effortPrefix) && CANONICAL_EFFORT_SUFFIXES.has(id.slice(effortPrefix.length))) {
+      return true;
+    }
+    // `{stem}-fast` base ↔ `{stem}-{effort}-fast` wire (current Cursor GetUsableModels shape).
+    if (modelId.endsWith("-fast") && id.endsWith("-fast")) {
+      const stem = modelId.slice(0, -"-fast".length);
+      if (!id.startsWith(`${stem}-`)) return false;
+      const middle = id.slice(stem.length + 1, -"-fast".length);
+      return CANONICAL_EFFORT_SUFFIXES.has(middle);
+    }
+    return false;
   });
 }
 

--- a/src/adapters/cursor/effort-map.ts
+++ b/src/adapters/cursor/effort-map.ts
@@ -27,8 +27,9 @@ const CURSOR_MODEL_EFFORT_TIERS: Record<string, readonly string[]> = {
   "claude-opus-5": ["low", "medium", "high", "xhigh", "max"],
   "claude-sonnet-5": ["low", "medium", "high", "xhigh", "max"],
   "glm-5.2": ["high", "max"],
-  // GetUsableModels (2026-07-09) lists grok-4.5-{medium,high,xhigh} and grok-4.5-fast-{medium,high,xhigh};
-  // the bare "grok-4.5-fast" id was removed upstream and now returns not_found.
+  // GetUsableModels currently lists grok-4.5-{low,medium,high} and grok-4.5-{low,medium,high}-fast.
+  // Older snapshots used grok-4.5-fast-{medium,high,xhigh}; wire construction prefers the trailing
+  // `-fast` form (see cursorWireModelIdWithEffort). The bare "grok-4.5-fast" id still returns not_found.
   "grok-4.5": ["medium", "high", "xhigh"],
   "grok-4.5-fast": ["medium", "high", "xhigh"],
   "gpt-5.1": ["low", "high"],
@@ -109,4 +110,18 @@ export function cursorModelEffortLadder(baseModelId: string): string[] | undefin
 /** Base models known to carry a reasoning-effort suffix (everything else is sent bare). */
 export function cursorModelHasEffortTiers(baseModelId: string): boolean {
   return (CURSOR_MODEL_EFFORT_TIERS[baseModelId]?.length ?? 0) > 0;
+}
+
+/**
+ * Compose a Cursor wire model id from a Codex-facing base id and an effort tier.
+ *
+ * Fast families encode the mode after the effort (`grok-4.5-high-fast`). Non-fast
+ * reasoning models keep the historical `{base}-{effort}` shape (`claude-opus-4-8-high`).
+ */
+export function cursorWireModelIdWithEffort(baseModelId: string, effortSuffix: string): string {
+  if (baseModelId.endsWith("-fast")) {
+    const stem = baseModelId.slice(0, -"-fast".length);
+    return `${stem}-${effortSuffix}-fast`;
+  }
+  return `${baseModelId}-${effortSuffix}`;
 }

--- a/src/adapters/cursor/request-builder.ts
+++ b/src/adapters/cursor/request-builder.ts
@@ -10,7 +10,7 @@ import type {
 import { isAllowedToolChoice, namespacedToolName, toolChoiceAliases, type OcxTool, type OcxToolChoice } from "../../types";
 import type { CursorRequestMessage, CursorRunRequest } from "./types";
 import { cursorWireModelSelection, type CursorRoutingLevel } from "./discovery";
-import { cursorEffortSuffix } from "./effort-map";
+import { cursorEffortSuffix, cursorWireModelIdWithEffort } from "./effort-map";
 import {
   cursorMcpToolEncodedSize,
   cursorMcpToolsEncodedSize,
@@ -127,7 +127,7 @@ function normalizeCursorModelId(modelId: string, reasoning?: string): { modelId:
   const selection = cursorWireModelSelection(modelId);
   const id = selection.modelId;
   const suffix = cursorEffortSuffix(id, reasoning);
-  return { ...selection, modelId: suffix ? `${id}-${suffix}` : id };
+  return { ...selection, modelId: suffix ? cursorWireModelIdWithEffort(id, suffix) : id };
 }
 
 function contentPartToText(part: OcxContentPart | OcxAssistantContentPart): string | undefined {

--- a/tests/cursor-discovery.test.ts
+++ b/tests/cursor-discovery.test.ts
@@ -63,6 +63,11 @@ describe("Cursor discovery metadata", () => {
     // Issue #117: Cursor GetUsableModels may return ids with a `cursor-` wire prefix.
     expect(isCursorModelAvailableForAccount("grok-4.5", ["cursor-grok-4.5-high"])).toBe(true);
     expect(isCursorModelAvailableForAccount("grok-4.5-fast", ["cursor-grok-4.5-fast-medium"])).toBe(true);
+    // Current Cursor wire shape puts `-fast` after the effort tier (`grok-4.5-high-fast`).
+    expect(isCursorModelAvailableForAccount("grok-4.5-fast", ["cursor-grok-4.5-high-fast"])).toBe(true);
+    expect(isCursorModelAvailableForAccount("grok-4.5-fast", ["cursor-grok-4.5-medium-fast"])).toBe(true);
+    expect(isCursorModelAvailableForAccount("grok-4.5-fast", ["cursor-grok-4.5-high"])).toBe(false);
+    expect(isCursorModelAvailableForAccount("grok-4.5", ["cursor-grok-4.5-high-fast"])).toBe(false);
     expect(isCursorModelAvailableForAccount("gpt-5.4", ["cursor-gpt-5.4-high"])).toBe(true);
     // Prefixed sibling rejection: cursor- prefix must not bypass sibling-model checks.
     expect(isCursorModelAvailableForAccount("gpt-5.5", ["cursor-gpt-5.5-extra-high"])).toBe(false);

--- a/tests/cursor-effort-suffix.test.ts
+++ b/tests/cursor-effort-suffix.test.ts
@@ -60,10 +60,12 @@ describe("Cursor per-model reasoning-effort suffix", () => {
     expect(modelIdFor("cursor/glm-5.2", "max")).toBe("glm-5.2-max");
   });
 
-  test("grok-4.5-fast preserves its explicit code-backed tiers", () => {
-    expect(modelIdFor("cursor/grok-4.5-fast", "medium")).toBe("grok-4.5-fast-medium");
-    expect(modelIdFor("cursor/grok-4.5-fast", "high")).toBe("grok-4.5-fast-high");
-    expect(modelIdFor("cursor/grok-4.5-fast", "xhigh")).toBe("grok-4.5-fast-xhigh");
+  test("grok-4.5-fast uses trailing -fast after the effort tier on the wire", () => {
+    // Live GetUsableModels returns grok-4.5-{low,medium,high}-fast, not grok-4.5-fast-{effort}.
+    expect(modelIdFor("cursor/grok-4.5-fast", "medium")).toBe("grok-4.5-medium-fast");
+    expect(modelIdFor("cursor/grok-4.5-fast", "high")).toBe("grok-4.5-high-fast");
+    expect(modelIdFor("cursor/grok-4.5-fast", "xhigh")).toBe("grok-4.5-xhigh-fast");
+    expect(modelIdFor("cursor/grok-4.5", "high")).toBe("grok-4.5-high");
   });
 
   test("model ladders are deduped and sorted in canonical Codex order", () => {


### PR DESCRIPTION
## Summary
- Accept Cursor's current Grok Fast wire shape `{stem}-{effort}-fast` in live discovery (keep older `{stem}-fast-{effort}` too).
- Emit trailing-`-fast` wire ids when resolving `cursor/grok-4.5-fast` + reasoning effort.
- Add regression coverage from a live GetUsableModels snapshot.

Closes #731

## Why
Cursor accounts with Grok Fast unlocked were still filtered out of the Codex catalog because OpenCodex expected `grok-4.5-fast-high` while upstream returns `grok-4.5-high-fast`.

## Test plan
- [x] `bun test tests/cursor-discovery.test.ts tests/cursor-effort-suffix.test.ts`
- [x] `bun run typecheck`
- [x] Live protobuf snapshot: `grok-4.5-fast` availability flips to true; wire `grok-4.5-high-fast` present
- [ ] Maintainer: smoke `ocx sync` on a Cursor account with Grok Fast and pick `cursor/grok-4.5-fast`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Cursor model discovery for fast variants using alternate effort-tier naming.
  - Corrected model identifiers for reasoning-effort configurations, including `grok-4.5-fast`.
  - Prevented valid fast models from being incorrectly omitted when returned by Cursor.

- **Tests**
  - Added coverage for supported and mismatched Cursor model identifier formats.
  - Updated expectations for effort-tier model identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->