### PR TITLE
test(storage): give the policy suite an explicit harness budget

### DIFF
--- a/tests/storage-policy.test.ts
+++ b/tests/storage-policy.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { Database } from "bun:sqlite";
 import {
   existsSync,
@@ -30,6 +30,15 @@ import {
   type CleanupResult,
   type ExecuteCleanupOptions,
 } from "../src/storage/cleanup";
+
+// seedHome() writes real files plus a sqlite fixture for every case it backs.
+// On a slow windows-latest runner those cases land at 6-8s against bun's 5s
+// default and fail deterministically (issue #727, run 30507689929) while a
+// faster runner passes the same code — locally the whole file is 144ms. The
+// sibling storage-cleanup suite already carries { timeout: 20_000 } /
+// { timeout: 30_000 } per case for exactly this reason; one file-level budget
+// covers every seedHome site here.
+setDefaultTimeout(30_000);
 
 const OLD = new Date("2026-01-01T00:00:00Z");
 const MID = new Date("2026-02-01T00:00:00Z");


### PR DESCRIPTION
Closes #727.

## What breaks

`tests/storage-policy.test.ts` inherits bun's 5s default harness timeout. Its
`seedHome()` helper writes real files plus a sqlite fixture for every case it
backs — 15 call sites — and on a slow `windows-latest` runner those cases land at
6-8s and fail. Run [30507689929](https://github.com/lidge-jun/opencodex/actions/runs/30507689929)
failed five of them, then failed the same set again after a `--failed` rerun, so
it reproduces rather than flakes. Locally the whole file is 22 pass in ~100ms.

Every failure sat between 6s and 8s against a 5s ceiling: these are timeouts,
not assertion failures, and nothing indicates the selection logic is wrong.

## What changes

One file, `setDefaultTimeout(30_000)` plus a comment naming the cause and the
run id. That is the same budget the sibling `tests/storage-cleanup.test.ts`
already gives its seeding-heavy cases — `{ timeout: 20_000 }` at 14 sites and
`{ timeout: 30_000 }` at 5, with a comment saying seeding "trips bun's default
5s harness timeout". A file-level call covers all 15 `seedHome` sites here
without touching each case, and `setDefaultTimeout(30_000)` is already the
convention in `grok-management-api`, `codex-history-provider`,
`claude-management-api`, `server-combo-failover-e2e` and
`subagent-fallback-handle-responses`.

No `src/` change. No workflow change — the job-level ceiling was already raised
to 20 minutes in #717, and this is the per-test budget underneath it.

## Verification

Mechanism proven in isolation first, under CI's `--isolate` mode: a 6s case with
no budget fails with `this test timed out after 5000ms`; the identical case with
`setDefaultTimeout` passes at 6005ms. Same failure shape as #727.

- `bun x tsc --noEmit` — exit 0
- `bun test --isolate tests/storage-policy.test.ts` — 22 pass, 0 fail, 91 expect() calls

Windows behaviour is what CI has to confirm; the local run only proves the
change is inert on a fast filesystem.

## Follow-up, not in scope

Windows pays roughly 2.5x for this suite versus ubuntu. Raising budgets hides
the margin, it does not close the gap. The suspect is `bun test --isolate` in
`ci.yml` (per-test process isolation is expensive on Windows), which is a
reliability tradeoff and an owner call, not something to fold into a timeout fix.
Making `seedHome` cheaper is the other candidate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the default test timeout to improve reliability on slower environments.
  * Reduced intermittent failures during filesystem and database setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->