### PR TITLE
fix(launcher): honor OPENCODEX_BUN_PATH

### DIFF
--- a/bin/ocx.mjs
+++ b/bin/ocx.mjs
@@ -292,13 +292,22 @@ function bunBinDir() {
 // the ~450-byte stub in place, which is NOT executable (ENOEXEC). A size gate
 // cleanly distinguishes the stub from a real binary on every platform.
 const REAL_BUN_MIN_BYTES = 1_000_000;
+const BUN_OVERRIDE_ENV = "OPENCODEX_BUN_PATH";
+
+function isRealBunBinary(path) {
+  try {
+    return existsSync(path) && statSync(path).size >= REAL_BUN_MIN_BYTES;
+  } catch {
+    return false;
+  }
+}
 
 function findBunBinary(bunDir) {
   // The npm `bun` package ships the binary as bin/bun.exe on every platform;
   // probe bin/bun too for forward compatibility.
   for (const name of ["bun.exe", "bun"]) {
     const p = join(bunDir, "bin", name);
-    if (existsSync(p) && statSync(p).size >= REAL_BUN_MIN_BYTES) return p;
+    if (isRealBunBinary(p)) return p;
   }
   return null;
 }
@@ -317,6 +326,11 @@ function fail(msg) {
 }
 
 function resolveBun() {
+  // Keep direct npm-launcher starts aligned with durable service/shim installs:
+  // a valid explicit runtime must win even when the bundled dependency exists.
+  const override = process.env[BUN_OVERRIDE_ENV]?.trim();
+  if (override && isRealBunBinary(override)) return override;
+
   let bunDir;
   try {
     bunDir = bunBinDir();

--- a/bin/ocx.mjs
+++ b/bin/ocx.mjs
@@ -290,7 +290,9 @@ function bunBinDir() {
 // The `bun` package ships a tiny ASCII placeholder at bin/bun.exe until its
 // postinstall downloads the real ~60MB binary. --ignore-scripts / pnpm leave
 // the ~450-byte stub in place, which is NOT executable (ENOEXEC). A size gate
-// cleanly distinguishes the stub from a real binary on every platform.
+// cleanly distinguishes the stub from a real binary on every platform. Keep
+// this Node-safe copy aligned with src/lib/bun-runtime.ts: the launcher cannot
+// import Bun-native TypeScript until after it has resolved a Bun executable.
 const REAL_BUN_MIN_BYTES = 1_000_000;
 const BUN_OVERRIDE_ENV = "OPENCODEX_BUN_PATH";
 
@@ -329,7 +331,13 @@ function resolveBun() {
   // Keep direct npm-launcher starts aligned with durable service/shim installs:
   // a valid explicit runtime must win even when the bundled dependency exists.
   const override = process.env[BUN_OVERRIDE_ENV]?.trim();
-  if (override && isRealBunBinary(override)) return override;
+  if (override) {
+    const overridePath = resolve(override);
+    if (isRealBunBinary(overridePath)) return overridePath;
+    console.error(
+      `opencodex: ${BUN_OVERRIDE_ENV} is missing, unreadable, or not a complete Bun binary; falling back to the bundled runtime.`,
+    );
+  }
 
   let bunDir;
   try {

--- a/bin/ocx.mjs
+++ b/bin/ocx.mjs
@@ -10,10 +10,11 @@
  */
 import { spawn, spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { isRealBunBinary } from "../src/lib/bun-binary-validator.mjs";
 import { npmInvocation } from "../src/update/npm-invocation.mjs";
 import { handoffWindowsTrayForUpdate, planWindowsTrayUpdate } from "../src/update/tray-update-plan.mjs";
 
@@ -287,22 +288,7 @@ function bunBinDir() {
   return dirname(require.resolve("bun/package.json"));
 }
 
-// The `bun` package ships a tiny ASCII placeholder at bin/bun.exe until its
-// postinstall downloads the real ~60MB binary. --ignore-scripts / pnpm leave
-// the ~450-byte stub in place, which is NOT executable (ENOEXEC). A size gate
-// cleanly distinguishes the stub from a real binary on every platform. Keep
-// this Node-safe copy aligned with src/lib/bun-runtime.ts: the launcher cannot
-// import Bun-native TypeScript until after it has resolved a Bun executable.
-const REAL_BUN_MIN_BYTES = 1_000_000;
 const BUN_OVERRIDE_ENV = "OPENCODEX_BUN_PATH";
-
-function isRealBunBinary(path) {
-  try {
-    return existsSync(path) && statSync(path).size >= REAL_BUN_MIN_BYTES;
-  } catch {
-    return false;
-  }
-}
 
 function findBunBinary(bunDir) {
   // The npm `bun` package ships the binary as bin/bun.exe on every platform;

--- a/src/lib/bun-binary-validator.d.mts
+++ b/src/lib/bun-binary-validator.d.mts
@@ -1,0 +1,3 @@
+export declare const REAL_BUN_MIN_BYTES: number;
+
+export declare function isRealBunBinary(path: string): boolean;

--- a/src/lib/bun-binary-validator.mjs
+++ b/src/lib/bun-binary-validator.mjs
@@ -1,0 +1,18 @@
+import { existsSync, statSync } from "node:fs";
+
+// The `bun` package leaves a tiny ASCII placeholder at bin/bun.exe until its
+// postinstall downloads the real ~60MB binary. Keep the threshold and the
+// false-on-filesystem-error contract shared by the Node launcher and Bun code.
+export const REAL_BUN_MIN_BYTES = 1_000_000;
+
+/**
+ * @param {string} path
+ * @returns {boolean}
+ */
+export function isRealBunBinary(path) {
+  try {
+    return existsSync(path) && statSync(path).size >= REAL_BUN_MIN_BYTES;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/bun-runtime.ts
+++ b/src/lib/bun-runtime.ts
@@ -11,7 +11,7 @@
  * back to `process.execPath` (which is itself Bun when run via `bun src/cli/index.ts`).
  */
 import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { isRealBunBinary } from "./bun-binary-validator.mjs";
 
 export { isRealBunBinary };
@@ -48,7 +48,8 @@ export function bundledBunPath(): string | null {
 export function overrideBunPath(): string | null {
   const value = process.env[BUN_OVERRIDE_ENV]?.trim();
   if (!value) return null;
-  return isRealBunBinary(value) ? value : null;
+  const resolved = resolve(value);
+  return isRealBunBinary(resolved) ? resolved : null;
 }
 
 export function durableBunRuntime(): DurableBunRuntime {

--- a/src/lib/bun-runtime.ts
+++ b/src/lib/bun-runtime.ts
@@ -11,15 +11,13 @@
  * back to `process.execPath` (which is itself Bun when run via `bun src/cli/index.ts`).
  */
 import { createRequire } from "node:module";
-import { existsSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { isRealBunBinary } from "./bun-binary-validator.mjs";
+
+export { isRealBunBinary };
 
 const require = createRequire(import.meta.url);
 
-// The `bun` package leaves a tiny ASCII placeholder at bin/bun.exe until its
-// postinstall downloads the real ~60MB binary; reject the stub by size so we
-// never bake a non-executable path into durable artifacts.
-const REAL_BUN_MIN_BYTES = 1_000_000;
 const BUN_OVERRIDE_ENV = "OPENCODEX_BUN_PATH";
 
 export type DurableBunRuntime = {
@@ -27,19 +25,6 @@ export type DurableBunRuntime = {
   source: "override" | "bundled" | "process";
   overrideEnv: typeof BUN_OVERRIDE_ENV;
 };
-
-/**
- * True only for a real, downloaded Bun binary — not the ~450-byte ASCII
- * placeholder stub left by `--ignore-scripts` / pnpm. A size gate cleanly
- * separates the two on every platform (real binary is tens of MB).
- */
-export function isRealBunBinary(path: string): boolean {
-  try {
-    return existsSync(path) && statSync(path).size >= REAL_BUN_MIN_BYTES;
-  } catch {
-    return false;
-  }
-}
 
 /**
  * Absolute path to the bundled Bun binary, or null if the `bun` dependency is

--- a/tests/bun-runtime.test.ts
+++ b/tests/bun-runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterAll } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { isRealBunBinary, bundledBunPath, durableBunPath, durableBunRuntime, overrideBunPath } from "../src/lib/bun-runtime";
@@ -58,6 +58,31 @@ describe("bundledBunPath / durableBunPath", () => {
     expect(durableBunPath()).toBe(real);
     if (previousOverride === undefined) delete process.env.OPENCODEX_BUN_PATH;
     else process.env.OPENCODEX_BUN_PATH = previousOverride;
+  });
+
+  it("resolves a relative override against the launcher cwd", () => {
+    const launcherCwd = join(tmp, "launcher-cwd");
+    const real = join(launcherCwd, "relative-bun.exe");
+    const previousCwd = process.cwd();
+    const inheritedOverride = process.env.OPENCODEX_BUN_PATH;
+    mkdirSync(launcherCwd, { recursive: true });
+    writeFileSync(real, Buffer.alloc(1_000_000));
+
+    try {
+      process.chdir(launcherCwd);
+      process.env.OPENCODEX_BUN_PATH = "  relative-bun.exe  ";
+      expect(overrideBunPath()).toBe(real);
+      expect(durableBunRuntime()).toEqual({
+        path: real,
+        source: "override",
+        overrideEnv: "OPENCODEX_BUN_PATH",
+      });
+      expect(durableBunPath()).toBe(real);
+    } finally {
+      process.chdir(previousCwd);
+      if (inheritedOverride === undefined) delete process.env.OPENCODEX_BUN_PATH;
+      else process.env.OPENCODEX_BUN_PATH = inheritedOverride;
+    }
   });
 
   it("resolves the installed bundled bun binary (dev has the bun dep)", () => {

--- a/tests/bun-runtime.test.ts
+++ b/tests/bun-runtime.test.ts
@@ -69,11 +69,18 @@ describe("bundledBunPath / durableBunPath", () => {
   });
 
   it("durableBunPath returns the bundled path when present, else process.execPath", () => {
-    const bundled = bundledBunPath();
-    const durable = durableBunPath();
-    expect(typeof durable).toBe("string");
-    expect(durable.length).toBeGreaterThan(0);
-    if (bundled) expect(durable).toBe(bundled);
-    else expect(durable).toBe(process.execPath);
+    const inheritedOverride = process.env.OPENCODEX_BUN_PATH;
+    delete process.env.OPENCODEX_BUN_PATH;
+    try {
+      const bundled = bundledBunPath();
+      const durable = durableBunPath();
+      expect(typeof durable).toBe("string");
+      expect(durable.length).toBeGreaterThan(0);
+      if (bundled) expect(durable).toBe(bundled);
+      else expect(durable).toBe(process.execPath);
+    } finally {
+      if (inheritedOverride === undefined) delete process.env.OPENCODEX_BUN_PATH;
+      else process.env.OPENCODEX_BUN_PATH = inheritedOverride;
+    }
   });
 });

--- a/tests/ocx-launcher-runtime.test.ts
+++ b/tests/ocx-launcher-runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
-import { copyFileSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -128,6 +128,33 @@ function sameProcess(actual: WindowsProcessIdentity | null, expected: WindowsPro
     && sameWindowsPath(actual.executablePath, expected.executablePath);
 }
 
+function captureWindowsProcessIdentity(pid: number): WindowsProcessIdentity {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      const identity = windowsProcessIdentity(pid);
+      if (identity) return identity;
+    } catch (error) {
+      lastError = error;
+    }
+    Bun.sleepSync(100);
+  }
+  throw new Error(`could not capture process identity for PID ${pid}: ${String(lastError ?? "process not found")}`);
+}
+
+function inspectWindowsProcessIdentity(pid: number): WindowsProcessIdentity | null {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      return windowsProcessIdentity(pid);
+    } catch (error) {
+      lastError = error;
+      Bun.sleepSync(100);
+    }
+  }
+  throw lastError;
+}
+
 function removeTree(path: string): void {
   // Windows can retain the copied executable's image handle briefly after
   // taskkill returns. Retry only transient fixture-cleanup errors, with a cap.
@@ -153,15 +180,19 @@ async function effectiveRuntime(override: string): Promise<string> {
   const opencodexHome = join(root, "opencodex");
   const codexHome = join(root, "codex");
   const grokHome = join(root, "grok");
-  mkdirSync(opencodexHome, { recursive: true });
-  mkdirSync(codexHome, { recursive: true });
-  mkdirSync(grokHome, { recursive: true });
-
-  const port = await freePort();
+  let port: number | null = null;
   let launcher: ChildProcess | null = null;
+  let launcherPid: number | null = null;
   let ownedLauncher: WindowsProcessIdentity | null = null;
   let ownedProxy: WindowsProcessIdentity | null = null;
+  let runtimePath: string | undefined;
+  let hasPrimaryError = false;
+  let primaryError: unknown;
   try {
+    mkdirSync(opencodexHome, { recursive: true });
+    mkdirSync(codexHome, { recursive: true });
+    mkdirSync(grokHome, { recursive: true });
+    port = await freePort();
     launcher = spawn("node", [BIN_OCX, "start", "--port", String(port)], {
       stdio: "ignore",
       windowsHide: true,
@@ -176,8 +207,8 @@ async function effectiveRuntime(override: string): Promise<string> {
       },
     });
     if (!launcher.pid) throw new Error("Node launcher has no process id");
-    ownedLauncher = windowsProcessIdentity(launcher.pid);
-    if (!ownedLauncher) throw new Error("could not capture Node launcher process identity");
+    launcherPid = launcher.pid;
+    ownedLauncher = captureWindowsProcessIdentity(launcherPid);
 
     const health = await waitForHealth(port, 25_000, launcher);
     if (!health) throw new Error("proxy did not become healthy");
@@ -186,33 +217,149 @@ async function effectiveRuntime(override: string): Promise<string> {
       throw new Error("health PID is not the spawned Node launcher's direct Bun child");
     }
     ownedProxy = identity;
-    return identity.executablePath;
-  } finally {
-    // Both identities were captured from processes this test spawned. Re-query
-    // before each kill so a reused PID can never become a cleanup target.
-    const cleanupErrors: string[] = [];
-    for (const [label, identity] of [
-      ["launcher", ownedLauncher],
-      ["proxy", ownedProxy],
-    ] as const) {
-      if (!identity || !sameProcess(windowsProcessIdentity(identity.pid), identity)) continue;
-      try {
-        killProxy(identity.pid);
-      } catch (error) {
-        cleanupErrors.push(`${label} cleanup failed: ${String(error)}`);
+    runtimePath = identity.executablePath;
+  } catch (error) {
+    hasPrimaryError = true;
+    primaryError = error;
+  }
+
+  const cleanupErrors: string[] = [];
+  let launcherTreeStopped = false;
+
+  // Prefer the creation-time/path identity. If the initial CIM capture failed,
+  // the live ChildProcess handle and its PID are still positive ownership of
+  // this test's launcher, so terminate that exact process tree as a fallback.
+  if (ownedLauncher) {
+    try {
+      if (sameProcess(inspectWindowsProcessIdentity(ownedLauncher.pid), ownedLauncher)) {
+        killProxy(ownedLauncher.pid);
+        launcherTreeStopped = true;
       }
-      if (sameProcess(windowsProcessIdentity(identity.pid), identity)) {
+    } catch (error) {
+      cleanupErrors.push(`launcher cleanup failed: ${String(error)}`);
+    }
+  }
+  if (!launcherTreeStopped && launcher && launcherPid && launcher.exitCode === null && launcher.signalCode === null) {
+    try {
+      killProxy(launcherPid);
+      launcherTreeStopped = true;
+    } catch (error) {
+      cleanupErrors.push(`launcher tree fallback failed: ${String(error)}`);
+    }
+  }
+
+  // The launcher tree kill normally removes the Bun child. Retain the
+  // identity-verified proxy fallback in case the launcher exited first.
+  if (ownedProxy) {
+    try {
+      if (sameProcess(inspectWindowsProcessIdentity(ownedProxy.pid), ownedProxy)) {
+        killProxy(ownedProxy.pid);
+      }
+    } catch (error) {
+      cleanupErrors.push(`proxy cleanup failed: ${String(error)}`);
+    }
+  }
+
+  // Inspection failures are reported, but never prevent the remaining
+  // process checks or fixture cleanup from running.
+  for (const [label, identity] of [
+    ["launcher", ownedLauncher],
+    ["proxy", ownedProxy],
+  ] as const) {
+    if (!identity) continue;
+    try {
+      if (sameProcess(inspectWindowsProcessIdentity(identity.pid), identity)) {
         cleanupErrors.push(`owned ${label} PID ${identity.pid} remained after bounded cleanup`);
       }
-    }
-    try {
-      removeTree(root);
     } catch (error) {
-      cleanupErrors.push(`fixture cleanup failed: ${String(error)}`);
+      cleanupErrors.push(`${label} cleanup verification failed: ${String(error)}`);
     }
-    if (cleanupErrors.length > 0) throw new Error(cleanupErrors.join("; "));
   }
+  if (port !== null) {
+    const lingeringProxy = await healthAt(port);
+    if (lingeringProxy) {
+      cleanupErrors.push(`OpenCodex proxy PID ${lingeringProxy.pid} remained on owned port ${port}`);
+    }
+  }
+  try {
+    removeTree(root);
+  } catch (error) {
+    cleanupErrors.push(`fixture cleanup failed: ${String(error)}`);
+  }
+
+  if (hasPrimaryError) {
+    if (cleanupErrors.length > 0) console.error(`additional cleanup errors: ${cleanupErrors.join("; ")}`);
+    throw primaryError;
+  }
+  if (cleanupErrors.length > 0) throw new Error(cleanupErrors.join("; "));
+  if (!runtimePath) throw new Error("proxy runtime path was not captured");
+  return runtimePath;
 }
+
+function isolatedLauncherEnv(root: string, override: string): NodeJS.ProcessEnv {
+  const opencodexHome = join(root, "opencodex");
+  const codexHome = join(root, "codex");
+  const grokHome = join(root, "grok");
+  mkdirSync(opencodexHome, { recursive: true });
+  mkdirSync(codexHome, { recursive: true });
+  mkdirSync(grokHome, { recursive: true });
+  return {
+    ...process.env,
+    HOME: root,
+    USERPROFILE: root,
+    OPENCODEX_HOME: opencodexHome,
+    CODEX_HOME: codexHome,
+    GROK_HOME: grokHome,
+    OPENCODEX_BUN_PATH: override,
+  };
+}
+
+describe.skipIf(!nodeAvailable)("ocx npm launcher relative Bun override", () => {
+  test("resolves a valid bare relative override before spawning", () => {
+    const root = mkdtempSync(join(tmpdir(), "ocx-launcher-relative-"));
+    try {
+      const overrideName = `custom-bun${process.platform === "win32" ? ".exe" : ""}`;
+      const override = join(root, overrideName);
+      copyFileSync(process.execPath, override);
+      chmodSync(override, 0o755);
+
+      const result = spawnSync("node", [BIN_OCX, "--version"], {
+        cwd: root,
+        encoding: "utf8",
+        timeout: 30_000,
+        windowsHide: true,
+        env: isolatedLauncherEnv(root, overrideName),
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).not.toContain("OPENCODEX_BUN_PATH is missing");
+    } finally {
+      removeTree(root);
+    }
+  }, 60_000);
+
+  test("warns without exposing the rejected override path before bundled fallback", () => {
+    const root = mkdtempSync(join(tmpdir(), "ocx-launcher-invalid-"));
+    try {
+      const overrideName = `stub-bun${process.platform === "win32" ? ".exe" : ""}`;
+      writeFileSync(join(root, overrideName), "not a Bun executable", "utf8");
+
+      const result = spawnSync("node", [BIN_OCX, "--version"], {
+        cwd: root,
+        encoding: "utf8",
+        timeout: 30_000,
+        windowsHide: true,
+        env: isolatedLauncherEnv(root, overrideName),
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toContain("OPENCODEX_BUN_PATH is missing, unreadable, or not a complete Bun binary");
+      expect(result.stderr).not.toContain(root);
+    } finally {
+      removeTree(root);
+    }
+  }, 60_000);
+});
 
 describe.skipIf(!runnable)("ocx npm launcher effective Bun runtime", () => {
   test("uses a valid OPENCODEX_BUN_PATH for the actual proxy process", async () => {

--- a/tests/ocx-launcher-runtime.test.ts
+++ b/tests/ocx-launcher-runtime.test.ts
@@ -177,9 +177,6 @@ function removeTree(path: string): void {
 
 async function effectiveRuntime(override: string): Promise<string> {
   const root = mkdtempSync(join(tmpdir(), "ocx-launcher-runtime-"));
-  const opencodexHome = join(root, "opencodex");
-  const codexHome = join(root, "codex");
-  const grokHome = join(root, "grok");
   let port: number | null = null;
   let launcher: ChildProcess | null = null;
   let launcherPid: number | null = null;
@@ -189,22 +186,11 @@ async function effectiveRuntime(override: string): Promise<string> {
   let hasPrimaryError = false;
   let primaryError: unknown;
   try {
-    mkdirSync(opencodexHome, { recursive: true });
-    mkdirSync(codexHome, { recursive: true });
-    mkdirSync(grokHome, { recursive: true });
     port = await freePort();
     launcher = spawn("node", [BIN_OCX, "start", "--port", String(port)], {
       stdio: "ignore",
       windowsHide: true,
-      env: {
-        ...process.env,
-        HOME: root,
-        USERPROFILE: root,
-        OPENCODEX_HOME: opencodexHome,
-        CODEX_HOME: codexHome,
-        GROK_HOME: grokHome,
-        OPENCODEX_BUN_PATH: override,
-      },
+      env: isolatedLauncherEnv(root, override),
     });
     if (!launcher.pid) throw new Error("Node launcher has no process id");
     launcherPid = launcher.pid;

--- a/tests/ocx-launcher-runtime.test.ts
+++ b/tests/ocx-launcher-runtime.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, test } from "bun:test";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { copyFileSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { bundledBunPath } from "../src/lib/bun-runtime";
+import { killProxy } from "../src/lib/process-control";
+
+const BIN_OCX = join(import.meta.dir, "..", "bin", "ocx.mjs");
+const nodeAvailable = spawnSync("node", ["--version"], {
+  stdio: "ignore",
+  windowsHide: true,
+}).status === 0;
+const runnable = process.platform === "win32" && nodeAvailable;
+
+type Health = {
+  status: string;
+  service: string;
+  pid: number;
+  port: number;
+};
+
+type WindowsProcessIdentity = {
+  pid: number;
+  parentPid: number;
+  executablePath: string;
+  creationDate: string;
+};
+
+function freePort(): Promise<number> {
+  return new Promise((resolvePort, reject) => {
+    const server = createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close(() => (port ? resolvePort(port) : reject(new Error("no port"))));
+    });
+  });
+}
+
+async function healthAt(port: number): Promise<Health | null> {
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/healthz`, {
+      signal: AbortSignal.timeout(800),
+    });
+    if (!response.ok) return null;
+    const body = await response.json() as Health;
+    return body?.status === "ok"
+      && body.service === "opencodex"
+      && Number.isSafeInteger(body.pid)
+      && body.pid > 0
+      && body.port === port
+      ? body
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function waitForHealth(
+  port: number,
+  deadlineMs: number,
+  launcher: ChildProcess,
+): Promise<Health | null> {
+  const deadline = Date.now() + deadlineMs;
+  while (Date.now() < deadline) {
+    if (launcher.exitCode !== null) return null;
+    const health = await healthAt(port);
+    if (health) return health;
+    await Bun.sleep(200);
+  }
+  return null;
+}
+
+function windowsProcessIdentity(pid: number): WindowsProcessIdentity | null {
+  const result = spawnSync(
+    "powershell.exe",
+    [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      `[Console]::OutputEncoding=[System.Text.Encoding]::UTF8; $p = Get-CimInstance Win32_Process -Filter \"ProcessId = ${pid}\"; if ($null -ne $p) { $p | Select-Object ProcessId, ParentProcessId, ExecutablePath, CreationDate | ConvertTo-Json -Compress }`,
+    ],
+    { encoding: "utf8", timeout: 10_000, windowsHide: true },
+  );
+  if (result.status !== 0) throw new Error(`could not inspect process identity: ${result.stderr.trim()}`);
+  if (!result.stdout.trim()) return null;
+  const value = JSON.parse(result.stdout) as {
+    ProcessId?: number;
+    ParentProcessId?: number;
+    ExecutablePath?: string;
+    CreationDate?: string;
+  };
+  if (
+    !Number.isSafeInteger(value.ProcessId)
+    || !Number.isSafeInteger(value.ParentProcessId)
+    || typeof value.ExecutablePath !== "string"
+    || typeof value.CreationDate !== "string"
+  ) {
+    throw new Error("process identity response was incomplete");
+  }
+  return {
+    pid: value.ProcessId!,
+    parentPid: value.ParentProcessId!,
+    executablePath: value.ExecutablePath,
+    creationDate: value.CreationDate,
+  };
+}
+
+function canonicalWindowsPath(path: string): string {
+  try {
+    return realpathSync.native(path).toLowerCase();
+  } catch {
+    return resolve(path).toLowerCase();
+  }
+}
+
+function sameWindowsPath(actual: string, expected: string): boolean {
+  return canonicalWindowsPath(actual) === canonicalWindowsPath(expected);
+}
+
+function sameProcess(actual: WindowsProcessIdentity | null, expected: WindowsProcessIdentity): boolean {
+  return actual !== null
+    && actual.pid === expected.pid
+    && actual.creationDate === expected.creationDate
+    && sameWindowsPath(actual.executablePath, expected.executablePath);
+}
+
+function removeTree(path: string): void {
+  // Windows can retain the copied executable's image handle briefly after
+  // taskkill returns. Retry only transient fixture-cleanup errors, with a cap.
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      rmSync(path, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      const code = error && typeof error === "object" && "code" in error
+        ? String(error.code)
+        : "";
+      if (!new Set(["EPERM", "EBUSY", "ENOTEMPTY"]).has(code)) throw error;
+      lastError = error;
+      Bun.sleepSync(200);
+    }
+  }
+  throw lastError;
+}
+
+async function effectiveRuntime(override: string): Promise<string> {
+  const root = mkdtempSync(join(tmpdir(), "ocx-launcher-runtime-"));
+  const opencodexHome = join(root, "opencodex");
+  const codexHome = join(root, "codex");
+  const grokHome = join(root, "grok");
+  mkdirSync(opencodexHome, { recursive: true });
+  mkdirSync(codexHome, { recursive: true });
+  mkdirSync(grokHome, { recursive: true });
+
+  const port = await freePort();
+  let launcher: ChildProcess | null = null;
+  let ownedLauncher: WindowsProcessIdentity | null = null;
+  let ownedProxy: WindowsProcessIdentity | null = null;
+  try {
+    launcher = spawn("node", [BIN_OCX, "start", "--port", String(port)], {
+      stdio: "ignore",
+      windowsHide: true,
+      env: {
+        ...process.env,
+        HOME: root,
+        USERPROFILE: root,
+        OPENCODEX_HOME: opencodexHome,
+        CODEX_HOME: codexHome,
+        GROK_HOME: grokHome,
+        OPENCODEX_BUN_PATH: override,
+      },
+    });
+    if (!launcher.pid) throw new Error("Node launcher has no process id");
+    ownedLauncher = windowsProcessIdentity(launcher.pid);
+    if (!ownedLauncher) throw new Error("could not capture Node launcher process identity");
+
+    const health = await waitForHealth(port, 25_000, launcher);
+    if (!health) throw new Error("proxy did not become healthy");
+    const identity = windowsProcessIdentity(health.pid);
+    if (!identity || identity.parentPid !== launcher.pid) {
+      throw new Error("health PID is not the spawned Node launcher's direct Bun child");
+    }
+    ownedProxy = identity;
+    return identity.executablePath;
+  } finally {
+    // Both identities were captured from processes this test spawned. Re-query
+    // before each kill so a reused PID can never become a cleanup target.
+    const cleanupErrors: string[] = [];
+    for (const [label, identity] of [
+      ["launcher", ownedLauncher],
+      ["proxy", ownedProxy],
+    ] as const) {
+      if (!identity || !sameProcess(windowsProcessIdentity(identity.pid), identity)) continue;
+      try {
+        killProxy(identity.pid);
+      } catch (error) {
+        cleanupErrors.push(`${label} cleanup failed: ${String(error)}`);
+      }
+      if (sameProcess(windowsProcessIdentity(identity.pid), identity)) {
+        cleanupErrors.push(`owned ${label} PID ${identity.pid} remained after bounded cleanup`);
+      }
+    }
+    try {
+      removeTree(root);
+    } catch (error) {
+      cleanupErrors.push(`fixture cleanup failed: ${String(error)}`);
+    }
+    if (cleanupErrors.length > 0) throw new Error(cleanupErrors.join("; "));
+  }
+}
+
+describe.skipIf(!runnable)("ocx npm launcher effective Bun runtime", () => {
+  test("uses a valid OPENCODEX_BUN_PATH for the actual proxy process", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ocx-launcher-runtime-copy-"));
+    try {
+      const override = join(root, "override-bun.exe");
+      copyFileSync(process.execPath, override);
+      expect(sameWindowsPath(await effectiveRuntime(override), override)).toBe(true);
+    } finally {
+      removeTree(root);
+    }
+  }, 120_000);
+
+  test("falls back to bundled Bun for a sub-1MB override stub", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ocx-launcher-runtime-stub-"));
+    try {
+      const stub = join(root, "stub-bun.exe");
+      writeFileSync(stub, "not a Bun executable", "utf8");
+      const bundled = bundledBunPath();
+      expect(bundled).not.toBeNull();
+      expect(sameWindowsPath(await effectiveRuntime(stub), bundled!)).toBe(true);
+    } finally {
+      removeTree(root);
+    }
+  }, 120_000);
+});

--- a/tests/ocx-launcher-source.test.ts
+++ b/tests/ocx-launcher-source.test.ts
@@ -37,18 +37,28 @@ describe("ocx.mjs npm launcher (source invariants)", () => {
 
   test("valid Bun overrides are selected before the bundled runtime", () => {
     expect(source).toContain('const BUN_OVERRIDE_ENV = "OPENCODEX_BUN_PATH";');
-    expect(source).toContain("if (override && isRealBunBinary(override)) return override;");
+    expect(source).toContain("const overridePath = resolve(override);");
+    expect(source).toContain("if (isRealBunBinary(overridePath)) return overridePath;");
 
     const resolveStart = source.indexOf("function resolveBun() {");
     const overrideCheck = source.indexOf("process.env[BUN_OVERRIDE_ENV]?.trim()", resolveStart);
+    const overrideResolve = source.indexOf("resolve(override)", overrideCheck);
     const bundledLookup = source.indexOf("bunDir = bunBinDir()", resolveStart);
     expect(resolveStart).toBeGreaterThanOrEqual(0);
     expect(overrideCheck).toBeGreaterThan(resolveStart);
-    expect(bundledLookup).toBeGreaterThan(overrideCheck);
+    expect(overrideResolve).toBeGreaterThan(overrideCheck);
+    expect(bundledLookup).toBeGreaterThan(overrideResolve);
   });
 
-  test("invalid Bun overrides fall back without throwing", () => {
+  test("invalid Bun overrides warn safely and fall back without throwing", () => {
     expect(source).toContain("function isRealBunBinary(path) {");
     expect(source).toMatch(/function isRealBunBinary\(path\) \{[\s\S]*?try \{[\s\S]*?statSync\(path\)[\s\S]*?catch \{[\s\S]*?return false;/);
+    expect(source).toContain("is missing, unreadable, or not a complete Bun binary; falling back to the bundled runtime.");
+    expect(source).not.toContain('${override} is missing, unreadable');
+  });
+
+  test("documents why the Node launcher keeps a synchronized validator copy", () => {
+    expect(source).toContain("this Node-safe copy aligned with src/lib/bun-runtime.ts");
+    expect(source).toContain("cannot\n// import Bun-native TypeScript until after it has resolved a Bun executable");
   });
 });

--- a/tests/ocx-launcher-source.test.ts
+++ b/tests/ocx-launcher-source.test.ts
@@ -7,6 +7,11 @@ import { join } from "node:path";
  * cannot be imported by tests. Guard its Windows-critical invariants at the source level.
  */
 const source = readFileSync(join(import.meta.dir, "..", "bin", "ocx.mjs"), "utf8");
+const runtimeSource = readFileSync(join(import.meta.dir, "..", "src", "lib", "bun-runtime.ts"), "utf8");
+const validatorSource = readFileSync(
+  join(import.meta.dir, "..", "src", "lib", "bun-binary-validator.mjs"),
+  "utf8",
+);
 
 describe("ocx.mjs npm launcher (source invariants)", () => {
   test("Windows npm spawns use the trusted absolute invocation without shell lookup", () => {
@@ -51,14 +56,16 @@ describe("ocx.mjs npm launcher (source invariants)", () => {
   });
 
   test("invalid Bun overrides warn safely and fall back without throwing", () => {
-    expect(source).toContain("function isRealBunBinary(path) {");
-    expect(source).toMatch(/function isRealBunBinary\(path\) \{[\s\S]*?try \{[\s\S]*?statSync\(path\)[\s\S]*?catch \{[\s\S]*?return false;/);
+    expect(source).toContain('import { isRealBunBinary } from "../src/lib/bun-binary-validator.mjs";');
     expect(source).toContain("is missing, unreadable, or not a complete Bun binary; falling back to the bundled runtime.");
     expect(source).not.toContain('${override} is missing, unreadable');
   });
 
-  test("documents why the Node launcher keeps a synchronized validator copy", () => {
-    expect(source).toContain("this Node-safe copy aligned with src/lib/bun-runtime.ts");
-    expect(source).toContain("cannot\n// import Bun-native TypeScript until after it has resolved a Bun executable");
+  test("shares the Node-safe Bun binary validator across both runtime paths", () => {
+    expect(source).toContain('import { isRealBunBinary } from "../src/lib/bun-binary-validator.mjs";');
+    expect(runtimeSource).toContain('import { isRealBunBinary } from "./bun-binary-validator.mjs";');
+    expect(runtimeSource).toContain("export { isRealBunBinary };");
+    expect(validatorSource).toContain("export const REAL_BUN_MIN_BYTES = 1_000_000;");
+    expect(validatorSource).toMatch(/export function isRealBunBinary\(path\) \{[\s\S]*?try \{[\s\S]*?statSync\(path\)[\s\S]*?catch \{[\s\S]*?return false;/);
   });
 });

--- a/tests/ocx-launcher-source.test.ts
+++ b/tests/ocx-launcher-source.test.ts
@@ -34,4 +34,21 @@ describe("ocx.mjs npm launcher (source invariants)", () => {
     // The marker must be computed from the launcher's OWN env, before Bun's dotenv load.
     expect(source).toContain("typeof process.env[name] === \"string\" && process.env[name] !== \"\"");
   });
+
+  test("valid Bun overrides are selected before the bundled runtime", () => {
+    expect(source).toContain('const BUN_OVERRIDE_ENV = "OPENCODEX_BUN_PATH";');
+    expect(source).toContain("if (override && isRealBunBinary(override)) return override;");
+
+    const resolveStart = source.indexOf("function resolveBun() {");
+    const overrideCheck = source.indexOf("process.env[BUN_OVERRIDE_ENV]?.trim()", resolveStart);
+    const bundledLookup = source.indexOf("bunDir = bunBinDir()", resolveStart);
+    expect(resolveStart).toBeGreaterThanOrEqual(0);
+    expect(overrideCheck).toBeGreaterThan(resolveStart);
+    expect(bundledLookup).toBeGreaterThan(overrideCheck);
+  });
+
+  test("invalid Bun overrides fall back without throwing", () => {
+    expect(source).toContain("function isRealBunBinary(path) {");
+    expect(source).toMatch(/function isRealBunBinary\(path\) \{[\s\S]*?try \{[\s\S]*?statSync\(path\)[\s\S]*?catch \{[\s\S]*?return false;/);
+  });
 });


### PR DESCRIPTION
## Summary

- Resolve a valid `OPENCODEX_BUN_PATH` to an absolute path and prefer it before the npm launcher probes bundled Bun.
- Warn without exposing the configured path when an override is missing, unreadable, or incomplete, then retain the bundled-runtime fallback.
- Share the Bun binary size validator through a Node-safe `.mjs` module used by both the npm launcher and Bun runtime code.
- Add cross-platform bare-relative/fallback coverage plus a Windows behavioral regression that checks the healthy proxy process's actual executable path and bounded cleanup.

Fixes #721.

## Why

Durable service and Codex-shim artifacts already use `durableBunRuntime()`, which gives a valid explicit override priority. The npm launcher maintained a separate resolver that only considered bundled Bun. Cold `ocx gui` / direct starts—and the detached direct-start fallback after a service refresh failure—could therefore downgrade the effective proxy runtime to the bundled version.

The launcher now applies the same validation contract as the shared resolver before it touches the bundled dependency. Both launch paths import one Node-safe binary validator, avoiding threshold or error-handling drift.

## Behavioral regression

Cross-platform launcher tests invoke `node bin/ocx.mjs --version` with bare relative overrides and verify both absolute resolution and a path-redacted invalid-override warning. The Windows test launches `node bin/ocx.mjs start` on isolated homes and free ports, then verifies the actual health PID through CIM:

- valid copied Bun override → the proxy `ExecutablePath` is the override
- sub-1MB override stub → the proxy `ExecutablePath` is bundled Bun

Cleanup records the spawned launcher PID immediately, retries CIM identity capture, uses the still-live owned child as a bounded tree-cleanup fallback, preserves the primary test failure, probes the owned port for a lingering OpenCodex proxy, and confirms owned processes and fixtures are gone. The runtime and relative-path tests share one isolated launcher environment builder.

## Verification

- `node --check bin/ocx.mjs`
- `node --check src/lib/bun-binary-validator.mjs`
- Focused suite: **23 passed, 0 failed on each runtime**
  - bundled Bun `1.3.14 (0d9b296a)`
  - configured Bun `1.4.0-canary.1 (b22e0e6d0)`
  - test files: `tests/ocx-launcher-source.test.ts`, `tests/ocx-launcher-runtime.test.ts`, `tests/bun-runtime.test.ts`, `tests/install-scripts.test.ts`
- `bun x tsc --noEmit`: passed on both runtimes
- `bun scripts/privacy-scan.ts`: passed on both runtimes
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json`: shared validator implementation, declaration, and launcher are included
- GUI doctor gate: skipped as expected because no `gui/` files changed
- Independent review of the initial review-fix delta: all five initial live threads addressed, no blocking concerns

### Full-suite context

A CI-like monolithic Windows run was attempted with the repository's Bun 1.3.14 and a 20-minute command budget. Bun itself hit an internal assertion and crashed after 83.4 seconds while the suite was still in `api-storage-policy.test.ts`, before reaching the changed launcher tests. This is recorded as a runtime crash, not a passing run or a test assertion failure. A post-crash audit found no worktree-linked Node/Bun survivors and no recent launcher fixtures.

Current `dev` has a green cross-platform CI baseline. Cross-platform CI for this PR still requires repository approval.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No update needed: this restores the already documented override semantics.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (This reuses an existing explicit runtime override and does not touch auth or credentials.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit Bun runtime override via `OPENCODEX_BUN_PATH`, including support for relative paths.

* **Bug Fixes**
  * Bun override paths are validated as real binaries before use; invalid values now emit a clearer message and safely fall back to the bundled runtime.
  * Improved Windows runtime selection consistency.

* **Tests**
  * Expanded coverage for override validation, relative override handling, fallback behavior, and Windows runtime effectiveness with health/identity verification and resilient cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
