### PR TITLE
perf(gui): progressive dashboard paint and Startup safety CLS

### DIFF
--- a/docs-site/src/content/docs/reference/cli.md
+++ b/docs-site/src/content/docs/reference/cli.md
@@ -429,6 +429,7 @@ Windows **Task Scheduler**) that auto-starts on login and auto-restarts on crash
 | `start` | Start an installed service. |
 | `stop` | Stop the service and restore native Codex. |
 | `status` | Report whether the service is running. |
+| `repair` | Refresh installed service assets without re-registering (no Task Scheduler UAC). |
 | `uninstall` | Remove the service and restore native Codex. |
 | `remove` | Alias of `uninstall`. |
 
@@ -436,6 +437,7 @@ Windows **Task Scheduler**) that auto-starts on login and auto-restarts on crash
 ocx service
 ocx service install
 ocx service status
+ocx service repair
 ocx service uninstall
 ```
 

--- a/gui/src/components/provider-catalog/ProviderCatalog.tsx
+++ b/gui/src/components/provider-catalog/ProviderCatalog.tsx
@@ -62,13 +62,19 @@ export default function ProviderCatalog({
 
   const catalog = useMemo(() => presets.filter(p => p.id !== "custom"), [presets]);
 
-  /** Usage-ranked order: requests desc, then label (050a sortPresets is the no-usage fallback). */
-  const ranked = useMemo(() => catalog.toSorted((a, b) => {
-    const ra = usageRank[a.id] ?? 0;
-    const rb = usageRank[b.id] ?? 0;
-    if (rb !== ra) return rb - ra;
-    return a.label.localeCompare(b.label, undefined, { sensitivity: "base" }) || a.id.localeCompare(b.id);
-  }), [catalog, usageRank]);
+  /** Usage-ranked order only after usage arrives; until then keep stable label order
+   * so a slow /api/usage (~5s cold) cannot flash a catalog resort. */
+  const ranked = useMemo(() => {
+    const hasUsage = Object.keys(usageRank).length > 0;
+    return catalog.toSorted((a, b) => {
+      if (hasUsage) {
+        const ra = usageRank[a.id] ?? 0;
+        const rb = usageRank[b.id] ?? 0;
+        if (rb !== ra) return rb - ra;
+      }
+      return a.label.localeCompare(b.label, undefined, { sensitivity: "base" }) || a.id.localeCompare(b.id);
+    });
+  }, [catalog, usageRank]);
 
   const buckets = useMemo(() => bucketPresets(ranked), [ranked]);
   const tierList = buckets[tier];

--- a/gui/src/components/provider-workspace/ProviderAuthPanel.tsx
+++ b/gui/src/components/provider-workspace/ProviderAuthPanel.tsx
@@ -28,9 +28,11 @@ import type { AccountLoadState, OAuthAccountRow, ApiKeyRow, LoginHint, ProviderA
 
 const DOCTOR_CMD = "ocx doctor";
 const QUOTA_ENRICH_RESERVE_MS = 4_000;
+const EMPTY_OAUTH_ACCOUNTS: OAuthAccountRow[] = [];
+const EMPTY_API_KEYS: ApiKeyRow[] = [];
 
 export default function ProviderAuthPanel({
-  item, apiBase, oauth, accounts = [], keys = [], accountLoadState = "ready",
+  item, apiBase, oauth, accounts = EMPTY_OAUTH_ACCOUNTS, keys = EMPTY_API_KEYS, accountLoadState = "ready",
   switchingAccountId = null, busy = false, loginHint, authHandlers, onCodexActiveNeedsReauthChange,
   codexController,
 }: {

--- a/gui/src/components/provider-workspace/ProviderAuthPanel.tsx
+++ b/gui/src/components/provider-workspace/ProviderAuthPanel.tsx
@@ -3,7 +3,7 @@
  * embedding for the workspace Settings tab (WP091). Consumes WP040+WP060
  * handlers via props-down; no internal auth machinery.
  */
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useT } from "../../i18n/shared";
 import { IconLock, IconTrash } from "../../icons";
 import type { WorkspaceItem } from "../../provider-workspace/catalog";
@@ -27,6 +27,7 @@ import type { CodexAccountPoolController } from "../../hooks/useCodexAccountPool
 import type { AccountLoadState, OAuthAccountRow, ApiKeyRow, LoginHint, ProviderAuthHandlers } from "./types";
 
 const DOCTOR_CMD = "ocx doctor";
+const QUOTA_ENRICH_RESERVE_MS = 4_000;
 
 export default function ProviderAuthPanel({
   item, apiBase, oauth, accounts = [], keys = [], accountLoadState = "ready",
@@ -51,8 +52,26 @@ export default function ProviderAuthPanel({
   const [addingKey, setAddingKey] = useState(false);
   const [newKey, setNewKey] = useState("");
   const [keyBusy, setKeyBusy] = useState(false);
+  const [reserveQuotaSlots, setReserveQuotaSlots] = useState(false);
   const deviceCodeCopy = useCopyFeedback<string>();
   const doctorCopy = useCopyFeedback<string>();
+
+  // Soft &quota=1 enrichment lands after the local account list. Reserve stacked
+  // bar height briefly so bars don't shove rows when WHAM returns.
+  useEffect(() => {
+    if (accounts.length === 0) {
+      setReserveQuotaSlots(false);
+      return;
+    }
+    const needsFill = accounts.some(a => a.quota == null && !a.quotaUnavailable);
+    if (!needsFill) {
+      setReserveQuotaSlots(false);
+      return;
+    }
+    setReserveQuotaSlots(true);
+    const timer = window.setTimeout(() => setReserveQuotaSlots(false), QUOTA_ENRICH_RESERVE_MS);
+    return () => window.clearTimeout(timer);
+  }, [accounts]);
 
   const surface = providerAuthSurface({ ...item, hasApiKey: item.hasApiKey || keys.length > 0 });
   const isOauth = surface === "oauth-accounts";
@@ -222,7 +241,7 @@ export default function ProviderAuthPanel({
                       </button>
                     )}
                     {showDoctor && (
-                      <button type="button" className="btn btn-ghost btn-sm" onClick={copyDoctor}>
+                      <button type="button" className="btn btn-ghost btn-sm codex-auth-action-btn" onClick={copyDoctor}>
                         <span aria-live="polite">{doctorCopyButtonLabel(t, doctorCopy.outcomeFor(account.id))}</span>
                       </button>
                     )}
@@ -238,13 +257,19 @@ export default function ProviderAuthPanel({
                       <IconTrash style={{ width: 13, height: 13 }} aria-hidden="true" />
                     </button>
                     </div>
-                    {(account.quota || account.quotaUnavailable) && (
+                    {(account.quota != null || account.quotaUnavailable || (reserveQuotaSlots && account.quota == null)) && (
                       <div className="pwi-auth-acct-quota">
-                        {account.quota && (
-                          <QuotaBars quota={account.quota} plan={null} threshold={80} t={t} layout="stacked" />
-                        )}
-                        {account.quotaUnavailable && (
+                        {account.quotaUnavailable ? (
                           <p className="muted pwi-auth-acct-quota-stale">{t("pws.accountQuotaUnavailable")}</p>
+                        ) : (
+                          <QuotaBars
+                            quota={account.quota ?? null}
+                            plan={null}
+                            threshold={80}
+                            t={t}
+                            layout="stacked"
+                            pending={account.quota == null}
+                          />
                         )}
                       </div>
                     )}

--- a/gui/src/components/provider-workspace/ProviderOverviewDashboard.tsx
+++ b/gui/src/components/provider-workspace/ProviderOverviewDashboard.tsx
@@ -51,10 +51,12 @@ export default function ProviderOverviewDashboard({
 
   const attention = useMemo(() => buildAttentionItems(sections, {}), [sections]);
   const attentionCount = attention.length;
-  const reauthCount = useMemo(
-    () => [...sections.ready, ...sections.needsSetup].filter(p => p.activeNeedsReauth).length,
+  const readyReauthCount = useMemo(
+    () => sections.ready.filter(p => p.activeNeedsReauth).length,
     [sections],
   );
+  const readyCount = sections.ready.length - readyReauthCount;
+  const needsAttentionCount = sections.needsSetup.length + readyReauthCount;
 
   /* Rate-limit rows: urgency first (highest utilisation), then name */
   const quotaProviders = useMemo(() => {
@@ -100,10 +102,10 @@ export default function ProviderOverviewDashboard({
       </div>
 
       <div className="pws-dashboard-summary">
-        <SummaryCard count={sections.ready.length} label={t("pws.status.ready")} tone="ok" />
+        <SummaryCard count={readyCount} label={t("pws.status.ready")} tone="ok" />
         <SummaryCard
-          count={sections.needsSetup.length}
-          label={reauthCount > 0 ? t("pws.status.needsAttention") : t("pws.status.needsSetup")}
+          count={needsAttentionCount}
+          label={readyReauthCount > 0 ? t("pws.status.needsAttention") : t("pws.status.needsSetup")}
           tone="warn"
         />
         <SummaryCard count={sections.disabled.length} label={t("prov.disabledBadge")} tone="muted" />

--- a/gui/src/components/provider-workspace/ProviderOverviewDashboard.tsx
+++ b/gui/src/components/provider-workspace/ProviderOverviewDashboard.tsx
@@ -26,12 +26,16 @@ export default function ProviderOverviewDashboard({
   sections,
   quotaReports,
   usageTotals,
+  usageLoading = false,
+  quotasLoading = false,
   onSelectProvider,
   onEditConfig,
 }: {
   sections: WorkspaceSections;
   quotaReports: Record<string, ProviderQuotaReportView>;
   usageTotals: Record<string, ProviderUsageTotals>;
+  usageLoading?: boolean;
+  quotasLoading?: boolean;
   onSelectProvider: (name: string) => void;
   onEditConfig?: () => void;
 }) {
@@ -48,7 +52,7 @@ export default function ProviderOverviewDashboard({
   const attention = useMemo(() => buildAttentionItems(sections, {}), [sections]);
   const attentionCount = attention.length;
   const reauthCount = useMemo(
-    () => sections.needsSetup.filter(p => p.activeNeedsReauth).length,
+    () => [...sections.ready, ...sections.needsSetup].filter(p => p.activeNeedsReauth).length,
     [sections],
   );
 
@@ -132,9 +136,13 @@ export default function ProviderOverviewDashboard({
       )}
 
       <div className="pws-dashboard-columns">
-        {quotaProviders.length > 0 && (
-          <section className="pws-dashboard-section" aria-label={t("pws.dashboard.rateLimits")}>
-            <h3 className="pws-dashboard-section-title">{t("pws.dashboard.rateLimits")}</h3>
+        <section
+          className="pws-dashboard-section pws-dashboard-section--rate-limits"
+          aria-label={t("pws.dashboard.rateLimits")}
+          aria-busy={quotasLoading || undefined}
+        >
+          <h3 className="pws-dashboard-section-title">{t("pws.dashboard.rateLimits")}</h3>
+          {quotaProviders.length > 0 ? (
             <div className="pws-dashboard-rows">
               {quotaProviders.map(({ item, report }) => (
                 <button
@@ -157,17 +165,39 @@ export default function ProviderOverviewDashboard({
                       threshold={80}
                       t={t}
                       layout="stacked"
+                      pending={quotasLoading && !report.quota}
                     />
                   </div>
                 </button>
               ))}
             </div>
-          </section>
-        )}
+          ) : quotasLoading ? (
+            <div className="pws-dashboard-rows pws-dashboard-rows--pending" aria-hidden="true">
+              {Array.from({ length: 3 }, (_, index) => (
+                <div key={index} className="pws-dashboard-row pws-dashboard-row--skeleton">
+                  <span className="pws-dashboard-row-icon pws-skel" />
+                  <div className="pws-dashboard-row-info">
+                    <span className="pws-skel pws-skel--name" />
+                    <span className="pws-skel pws-skel--meta" />
+                  </div>
+                  <div className="pws-dashboard-row-bars">
+                    <QuotaBars quota={null} threshold={80} t={t} layout="stacked" pending />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="muted pws-dashboard-empty">{t("pws.dashboard.noRateLimits")}</p>
+          )}
+        </section>
 
-        {mostUsed.length > 0 ? (
-          <section className="pws-dashboard-section" aria-label={t("pws.dashboard.recentlyUsed")}>
-            <h3 className="pws-dashboard-section-title">{t("pws.dashboard.recentlyUsed")}</h3>
+        <section
+          className="pws-dashboard-section pws-dashboard-section--recent"
+          aria-label={t("pws.dashboard.recentlyUsed")}
+          aria-busy={usageLoading || undefined}
+        >
+          <h3 className="pws-dashboard-section-title">{t("pws.dashboard.recentlyUsed")}</h3>
+          {mostUsed.length > 0 ? (
             <div className="pws-dashboard-rows">
               {mostUsed.map(provider => (
                 <button
@@ -185,13 +215,20 @@ export default function ProviderOverviewDashboard({
                 </button>
               ))}
             </div>
-          </section>
-        ) : (
-          <section className="pws-dashboard-section" aria-label={t("pws.dashboard.recentlyUsed")}>
-            <h3 className="pws-dashboard-section-title">{t("pws.dashboard.recentlyUsed")}</h3>
-            <p className="muted">{t("pws.dashboard.noUsage")}</p>
-          </section>
-        )}
+          ) : usageLoading ? (
+            <div className="pws-dashboard-rows pws-dashboard-rows--pending" aria-hidden="true">
+              {Array.from({ length: 3 }, (_, index) => (
+                <div key={index} className="pws-dashboard-row pws-dashboard-row--skeleton">
+                  <span className="pws-dashboard-row-icon pws-skel" />
+                  <span className="pws-skel pws-skel--name" />
+                  <span className="pws-skel pws-skel--count" />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="muted pws-dashboard-empty">{t("pws.dashboard.noUsage")}</p>
+          )}
+        </section>
       </div>
     </div>
   );

--- a/gui/src/components/provider-workspace/ProviderRail.tsx
+++ b/gui/src/components/provider-workspace/ProviderRail.tsx
@@ -110,11 +110,9 @@ export function RailRow({ item, selected, tabbable, modelCount, isDefault, showC
             <span className="pwi-rail-badge pwi-rail-badge--free" title={t("pws.freeTitle")}>{t("modal.badge.free")}</span>
           ) : null}
         </span>
-        {secondaryLabel && (
-          <span className="providers-workspace-rail-secondary" title={secondaryLabel}>
-            {secondaryLabel}
-          </span>
-        )}
+        <span className="providers-workspace-rail-secondary" title={secondaryLabel || undefined}>
+          {secondaryLabel || "\u00a0"}
+        </span>
       </span>
       <span className="providers-workspace-rail-trail">
         {isDefault && (

--- a/gui/src/components/provider-workspace/ProviderWorkspaceShell.tsx
+++ b/gui/src/components/provider-workspace/ProviderWorkspaceShell.tsx
@@ -20,6 +20,7 @@ import {
 } from "../../provider-workspace/catalog";
 import { providerKind } from "../../provider-workspace/kind";
 import { readJsonIfOk, readJsonOrThrow } from "../../fetch-json";
+import { readSessionListCache, writeSessionListCache } from "../../session-list-cache";
 import { countAvailableModels, parseAvailableModels, parseLiveModelCounts, parseSelectedModels, type ProviderAvailableModels, type ProviderLiveModelCounts, type ProviderModelCounts, type ProviderSelectedModels } from "../../provider-workspace/usage";
 import type { ProviderQuotaReportView } from "../../provider-workspace/report";
 import { formatProviderDisplayName } from "../../provider-icons";
@@ -105,9 +106,18 @@ export default function ProviderWorkspaceShell({
   const [selectedModels, setSelectedModels] = useState<ProviderSelectedModels>({});
   const [modelsLoading, setModelsLoading] = useState(false);
   const [modelsLoadFailed, setModelsLoadFailed] = useState(false);
-  const [usageTotals, setUsageTotals] = useState<Record<string, ProviderUsageTotals>>({});
-  const [usageModels, setUsageModels] = useState<Record<string, ProviderModelUsageRow[]>>({});
-  const [quotaReports, setQuotaReports] = useState<Record<string, ProviderQuotaReportView>>({});
+  const quotasCacheKey = `ocx.providers.quotas.v1:${apiBase}`;
+  const usageCacheKey = `ocx.providers.usage.v1:${apiBase}`;
+  const cachedQuotas = readSessionListCache<Record<string, ProviderQuotaReportView>>(quotasCacheKey);
+  const cachedUsage = readSessionListCache<{
+    totals: Record<string, ProviderUsageTotals>;
+    models: Record<string, ProviderModelUsageRow[]>;
+  }>(usageCacheKey);
+  const [usageTotals, setUsageTotals] = useState<Record<string, ProviderUsageTotals>>(() => cachedUsage?.totals ?? {});
+  const [usageModels, setUsageModels] = useState<Record<string, ProviderModelUsageRow[]>>(() => cachedUsage?.models ?? {});
+  const [quotaReports, setQuotaReports] = useState<Record<string, ProviderQuotaReportView>>(() => cachedQuotas ?? {});
+  const [usageLoading, setUsageLoading] = useState(() => !cachedUsage);
+  const [quotasLoading, setQuotasLoading] = useState(() => !cachedQuotas);
   const [modelsLoadEpoch, setModelsLoadEpoch] = useState(0);
   const filterWrapRef = useRef<HTMLDivElement>(null);
 
@@ -152,64 +162,81 @@ export default function ProviderWorkspaceShell({
 
   useEffect(() => {
     let cancelled = false;
-    fetch(`${apiBase}/api/usage?range=30d`)
-      .then(r => readJsonIfOk<{
-        providers?: Array<{ provider: string; requests: number; totalTokens?: number }>;
-        models?: Array<{ provider: string; model: string; resolvedModel?: string; requests: number; totalTokens: number; inputTokens: number; outputTokens: number; shareRatio: number; estimatedCostUsd?: number }>;
-      }>(r))
-      .then((data) => {
-        if (cancelled || !data) return;
-        const byProvider: Record<string, ProviderUsageTotals> = {};
-        for (const p of data.providers ?? []) byProvider[p.provider] = { requests: p.requests, totalTokens: p.totalTokens };
-        setUsageTotals(byProvider);
-        // Group model rows by provider
-        const byProviderModels: Record<string, ProviderModelUsageRow[]> = {};
-        for (const m of data.models ?? []) {
-          const key = m.provider;
-          if (!byProviderModels[key]) byProviderModels[key] = [];
-          byProviderModels[key].push({
-            model: m.model,
-            ...(m.resolvedModel ? { resolvedModel: m.resolvedModel } : {}),
-            requests: m.requests,
-            totalTokens: m.totalTokens,
-            inputTokens: m.inputTokens,
-            outputTokens: m.outputTokens,
-            shareRatio: m.shareRatio,
-            ...(m.estimatedCostUsd !== undefined ? { estimatedCostUsd: m.estimatedCostUsd } : {}),
-          });
-        }
-        setUsageModels(byProviderModels);
-      })
-      .catch(() => {});
-    return () => { cancelled = true; };
-  }, [apiBase]);
+    const timeout = window.setTimeout(() => {
+      // Keep last-good paint when sessionStorage already seeded — don't flash loading skeletons.
+      if (!cachedUsage) setUsageLoading(true);
+      void fetch(`${apiBase}/api/usage?range=30d`)
+        .then(r => readJsonIfOk<{
+          providers?: Array<{ provider: string; requests: number; totalTokens?: number }>;
+          models?: Array<{ provider: string; model: string; resolvedModel?: string; requests: number; totalTokens: number; inputTokens: number; outputTokens: number; shareRatio: number; estimatedCostUsd?: number }>;
+        }>(r))
+        .then((data) => {
+          if (cancelled || !data) return;
+          const byProvider: Record<string, ProviderUsageTotals> = {};
+          for (const p of data.providers ?? []) byProvider[p.provider] = { requests: p.requests, totalTokens: p.totalTokens };
+          setUsageTotals(byProvider);
+          // Group model rows by provider
+          const byProviderModels: Record<string, ProviderModelUsageRow[]> = {};
+          for (const m of data.models ?? []) {
+            const key = m.provider;
+            if (!byProviderModels[key]) byProviderModels[key] = [];
+            byProviderModels[key].push({
+              model: m.model,
+              ...(m.resolvedModel ? { resolvedModel: m.resolvedModel } : {}),
+              requests: m.requests,
+              totalTokens: m.totalTokens,
+              inputTokens: m.inputTokens,
+              outputTokens: m.outputTokens,
+              shareRatio: m.shareRatio,
+              ...(m.estimatedCostUsd !== undefined ? { estimatedCostUsd: m.estimatedCostUsd } : {}),
+            });
+          }
+          setUsageModels(byProviderModels);
+          writeSessionListCache(usageCacheKey, { totals: byProvider, models: byProviderModels });
+        })
+        .catch(() => {})
+        .finally(() => { if (!cancelled) setUsageLoading(false); });
+    }, 0);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeout);
+    };
+  }, [apiBase, usageCacheKey]);
 
   useEffect(() => {
     let cancelled = false;
-    fetch(`${apiBase}/api/provider-quotas`)
-      .then(r => readJsonIfOk<{ reports?: Array<{ provider: string; label?: string; source?: string; updatedAt?: number; quota?: unknown }> }>(r))
-      .then((data) => {
-        if (cancelled || !data) return;
-        // Merge so a partial/failed probe cannot wipe a previously good provider row.
-        setQuotaReports(prev => {
-          const next = { ...prev };
-          for (const report of data.reports ?? []) {
-            if (!report?.provider) continue;
-            next[report.provider] = {
-              label: report.label,
-              source: report.source,
-              updatedAt: typeof report.updatedAt === "number" ? report.updatedAt : Date.now(),
-              quota: report.quota,
-            };
-          }
-          return next;
-        });
-      })
-      .catch(() => { /* keep last-good */ });
-    return () => { cancelled = true; };
+    const timeout = window.setTimeout(() => {
+      if (!cachedQuotas) setQuotasLoading(true);
+      void fetch(`${apiBase}/api/provider-quotas`)
+        .then(r => readJsonIfOk<{ reports?: Array<{ provider: string; label?: string; source?: string; updatedAt?: number; quota?: unknown }> }>(r))
+        .then((data) => {
+          if (cancelled || !data) return;
+          // Merge so a partial/failed probe cannot wipe a previously good provider row.
+          setQuotaReports(prev => {
+            const next = { ...prev };
+            for (const report of data.reports ?? []) {
+              if (!report?.provider) continue;
+              next[report.provider] = {
+                label: report.label,
+                source: report.source,
+                updatedAt: typeof report.updatedAt === "number" ? report.updatedAt : Date.now(),
+                quota: report.quota,
+              };
+            }
+            writeSessionListCache(quotasCacheKey, next);
+            return next;
+          });
+        })
+        .catch(() => { /* keep last-good */ })
+        .finally(() => { if (!cancelled) setQuotasLoading(false); });
+    }, 0);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeout);
+    };
     // Key on active-account identity (not the reauth boolean map) so switching between two
     // healthy accounts still re-reads /api/provider-quotas for the Usage/overview bars.
-  }, [apiBase, quotaRefreshKey]);
+  }, [apiBase, quotaRefreshKey, quotasCacheKey]);
 
   useEffect(() => {
     if (!filterOpen) return;
@@ -509,15 +536,17 @@ export default function ProviderWorkspaceShell({
               </button>
             </div>
           )
-        ) : allItems.length > 0 ? (
+        ) : (
           <ProviderOverviewDashboard
             sections={sections}
             quotaReports={quotaReports}
             usageTotals={usageTotals}
+            usageLoading={usageLoading}
+            quotasLoading={quotasLoading}
             onSelectProvider={(name) => onSelect(name)}
             onEditConfig={onEditConfig}
           />
-        ) : null}
+        )}
         </main>
       </div>
     </div>

--- a/gui/src/components/provider-workspace/ProviderWorkspaceShell.tsx
+++ b/gui/src/components/provider-workspace/ProviderWorkspaceShell.tsx
@@ -108,16 +108,17 @@ export default function ProviderWorkspaceShell({
   const [modelsLoadFailed, setModelsLoadFailed] = useState(false);
   const quotasCacheKey = `ocx.providers.quotas.v1:${apiBase}`;
   const usageCacheKey = `ocx.providers.usage.v1:${apiBase}`;
-  const cachedQuotas = readSessionListCache<Record<string, ProviderQuotaReportView>>(quotasCacheKey);
-  const cachedUsage = readSessionListCache<{
-    totals: Record<string, ProviderUsageTotals>;
-    models: Record<string, ProviderModelUsageRow[]>;
-  }>(usageCacheKey);
-  const [usageTotals, setUsageTotals] = useState<Record<string, ProviderUsageTotals>>(() => cachedUsage?.totals ?? {});
-  const [usageModels, setUsageModels] = useState<Record<string, ProviderModelUsageRow[]>>(() => cachedUsage?.models ?? {});
-  const [quotaReports, setQuotaReports] = useState<Record<string, ProviderQuotaReportView>>(() => cachedQuotas ?? {});
-  const [usageLoading, setUsageLoading] = useState(() => !cachedUsage);
-  const [quotasLoading, setQuotasLoading] = useState(() => !cachedQuotas);
+  const [usageTotals, setUsageTotals] = useState<Record<string, ProviderUsageTotals>>(() => (
+    readSessionListCache<{ totals: Record<string, ProviderUsageTotals> }>(usageCacheKey)?.totals ?? {}
+  ));
+  const [usageModels, setUsageModels] = useState<Record<string, ProviderModelUsageRow[]>>(() => (
+    readSessionListCache<{ models: Record<string, ProviderModelUsageRow[]> }>(usageCacheKey)?.models ?? {}
+  ));
+  const [quotaReports, setQuotaReports] = useState<Record<string, ProviderQuotaReportView>>(() => (
+    readSessionListCache<Record<string, ProviderQuotaReportView>>(quotasCacheKey) ?? {}
+  ));
+  const [usageLoading, setUsageLoading] = useState(() => !readSessionListCache(usageCacheKey));
+  const [quotasLoading, setQuotasLoading] = useState(() => !readSessionListCache(quotasCacheKey));
   const [modelsLoadEpoch, setModelsLoadEpoch] = useState(0);
   const filterWrapRef = useRef<HTMLDivElement>(null);
 
@@ -164,7 +165,9 @@ export default function ProviderWorkspaceShell({
     let cancelled = false;
     const timeout = window.setTimeout(() => {
       // Keep last-good paint when sessionStorage already seeded — don't flash loading skeletons.
-      if (!cachedUsage) setUsageLoading(true);
+      // Read inside the effect (keyed by usageCacheKey) so the seed check stays correct without
+      // closing over an unstable cachedUsage render value.
+      if (!readSessionListCache(usageCacheKey)) setUsageLoading(true);
       void fetch(`${apiBase}/api/usage?range=30d`)
         .then(r => readJsonIfOk<{
           providers?: Array<{ provider: string; requests: number; totalTokens?: number }>;
@@ -206,7 +209,7 @@ export default function ProviderWorkspaceShell({
   useEffect(() => {
     let cancelled = false;
     const timeout = window.setTimeout(() => {
-      if (!cachedQuotas) setQuotasLoading(true);
+      if (!readSessionListCache(quotasCacheKey)) setQuotasLoading(true);
       void fetch(`${apiBase}/api/provider-quotas`)
         .then(r => readJsonIfOk<{ reports?: Array<{ provider: string; label?: string; source?: string; updatedAt?: number; quota?: unknown }> }>(r))
         .then((data) => {

--- a/gui/src/pages/Providers.tsx
+++ b/gui/src/pages/Providers.tsx
@@ -11,6 +11,8 @@ import { formatProviderDisplayName } from "../provider-icons";
 import { useProviderAccountPools } from "../hooks/useProviderAccountPools";
 import { useCodexAccountPool } from "../hooks/useCodexAccountPool";
 import { useJsonConfigEditor } from "../hooks/useJsonConfigEditor";
+import { useKeyedClientResource } from "../client-resource";
+import { readSessionListCache } from "../session-list-cache";
 import type { ProvidersConfig } from "./providers-shared";
 import { useProvidersOAuth } from "./use-providers-oauth";
 import { useProvidersCrud } from "./use-providers-crud";
@@ -20,7 +22,10 @@ import { buildAccountLoginStatus, buildAddModalAccountRows } from "./providers-p
 
 export default function Providers({ apiBase }: { apiBase: string }) {
   const t = useT();
-  const [config, setConfig] = useState<ProvidersConfig | null>(null);
+  const configCacheKey = `ocx.providers.config.v1:${apiBase}`;
+  const [config, setConfig] = useState<ProvidersConfig | null>(
+    () => readSessionListCache<ProvidersConfig>(configCacheKey),
+  );
   const [adding, setAdding] = useState(false);
   const [status, setStatus] = useState("");
   const [statusOk, setStatusOk] = useState(false);
@@ -50,8 +55,35 @@ export default function Providers({ apiBase }: { apiBase: string }) {
   useEffect(() => { aliveRef.current = true; return () => { aliveRef.current = false; }; }, []);
   // Providers hash sync is owned by App (passive replaceHash / deliberate navigateHash).
 
+  // Warm the Add Provider catalog cache while the page is open so opening the
+  // modal does not wait on a cold /api/provider-presets round-trip (~same key as
+  // AddProviderModal). Prefetch usage too so the catalog does not paint alpha then
+  // re-rank when the slow usage probe (~5s cold) finally returns.
+  useKeyedClientResource(
+    `add-provider-presets:${apiBase}`,
+    [apiBase],
+    async (signal) => {
+      const res = await fetch(`${apiBase}/api/provider-presets`, { signal });
+      if (!res.ok) throw new Error(String(res.status));
+      const data = await res.json() as { providers?: unknown[] };
+      return Array.isArray(data.providers) && data.providers.length > 0 ? data.providers : null;
+    },
+  );
+  useKeyedClientResource(
+    `add-provider-usage:${apiBase}`,
+    [apiBase],
+    async (signal) => {
+      const res = await fetch(`${apiBase}/api/usage?range=30d`, { signal });
+      if (!res.ok) return {} as Record<string, number>;
+      const data = await res.json() as { providers?: Array<{ provider: string; requests: number }> };
+      const rank: Record<string, number> = {};
+      for (const row of data.providers ?? []) rank[row.provider] = row.requests;
+      return rank;
+    },
+  );
   const { fetchConfig, fetchOauth, fetchProviderQuotas } = useProvidersFetch({
     apiBase, t, setConfig, setOauthProviders, setOauthStatus, setQuotaReports, notify,
+    configCacheKey,
   });
 
   // WP3: one Codex account controller for the whole Providers page, shared by the
@@ -62,9 +94,30 @@ export default function Providers({ apiBase }: { apiBase: string }) {
   // accounts/active pair this page used to poll on its own 30s timer.
   const codexActiveNeedsReauth = codexPool.activeNeedsReauth;
 
+  // Derive openai login status from the shared Codex controller (no duplicate /accounts).
+  const oauthStatusWithCodex = useMemo(() => {
+    const accounts = codexPool.accounts;
+    if (accounts.length === 0 && codexPool.loadState === "loading") return oauthStatus;
+    const main = accounts.find(a => a.isMain) ?? accounts[0];
+    const mainIsReal = !!main && !!main.email && main.email !== "Codex App login";
+    const poolLoggedIn = accounts.some(a => !a.isMain && (a.hasCredential || a.email));
+    const codexLoggedIn = mainIsReal || poolLoggedIn;
+    const codexEmail = mainIsReal
+      ? main?.email
+      : (accounts.find(a => !a.isMain && a.email)?.email ?? undefined);
+    return {
+      ...oauthStatus,
+      openai: {
+        loggedIn: codexLoggedIn,
+        ...(codexEmail ? { email: codexEmail } : {}),
+        ...(codexActiveNeedsReauth ? { needsReauth: true } : {}),
+      },
+    };
+  }, [oauthStatus, codexPool.accounts, codexPool.loadState, codexActiveNeedsReauth]);
+
   const pools = useProviderAccountPools({
     apiBase, t: t as unknown as Parameters<typeof useProviderAccountPools>[0]["t"],
-    config, oauthStatus, aliveRef,
+    config, oauthStatus: oauthStatusWithCodex, aliveRef,
     notify,
     fetchConfig, fetchOauth, fetchProviderQuotas, codexActiveNeedsReauth,
   });
@@ -96,12 +149,12 @@ export default function Providers({ apiBase }: { apiBase: string }) {
     const timeout = window.setTimeout(() => {
       void fetchConfig();
       void fetchOauth();
-      void fetchProviderQuotas();
+      // Quotas: workspace shell owns /api/provider-quotas — do not double-fetch on mount.
     }, 0);
     return () => {
       window.clearTimeout(timeout);
     };
-  }, [fetchConfig, fetchOauth, fetchProviderQuotas]);
+  }, [fetchConfig, fetchOauth]);
 
   const bumpModelsRefresh = () => setModelsRefreshToken(n => n + 1);
 
@@ -133,13 +186,20 @@ export default function Providers({ apiBase }: { apiBase: string }) {
         </div>
         {status
           ? <Notice tone="err">{status}</Notice>
-          : <div className="muted">{t("prov.loadingConfig")}</div>}
+          : (
+            <div className="providers-workspace providers-workspace--boot" aria-busy="true">
+              <div className="providers-workspace-rail providers-workspace-rail--boot" aria-hidden="true" />
+              <div className="providers-workspace-main">
+                <p className="muted"><span className="spin" aria-hidden="true" /> {t("prov.loadingConfig")}</p>
+              </div>
+            </div>
+          )}
       </>
     );
   }
 
   const addModalAccountRows = buildAddModalAccountRows(config, oauthProviders);
-  const accountLoginStatus = buildAccountLoginStatus(config, oauthStatus);
+  const accountLoginStatus = buildAccountLoginStatus(config, oauthStatusWithCodex);
   const isForwardProvider = (name: string) => config.providers[name]?.authMode === "forward";
 
   const onAccountLogin = async (provider: string) => {

--- a/gui/src/pages/Startup.tsx
+++ b/gui/src/pages/Startup.tsx
@@ -132,10 +132,6 @@ export default function Startup({ apiBase }: { apiBase: string }) {
       const [settings, trayResult] = await Promise.all([settingsPromise, trayPromise]);
       if (signal?.aborted || generation !== loadGenerationRef.current) return;
 
-      const notice = deriveCodexRuntimeNotice(settings?.codexRuntime, t, next.platform);
-      setCodexRuntimeWarning(notice.warning);
-      setCodexRuntimeFix(notice.fix);
-      setRuntimeNoticePending(false);
       const nextTray = next.platform === "win32" ? trayResult.tray : null;
       if (next.platform === "win32") {
         setTray(nextTray);
@@ -145,13 +141,28 @@ export default function Startup({ apiBase }: { apiBase: string }) {
         setTrayError(false);
       }
       setTrayLoading(false);
+      setRuntimeNoticePending(false);
 
-      writeSessionListCache(cacheKey, {
-        data: next,
-        warning: notice.warning,
-        fix: notice.fix,
-        tray: nextTray,
-      } satisfies StartupPageCache);
+      if (settings) {
+        const notice = deriveCodexRuntimeNotice(settings.codexRuntime, t, next.platform);
+        setCodexRuntimeWarning(notice.warning);
+        setCodexRuntimeFix(notice.fix);
+        writeSessionListCache(cacheKey, {
+          data: next,
+          warning: notice.warning,
+          fix: notice.fix,
+          tray: nextTray,
+        } satisfies StartupPageCache);
+      } else {
+        // Settings fetch failure: keep the last-good runtime notice in UI + cache.
+        const prev = readSessionListCache<StartupPageCache>(cacheKey);
+        writeSessionListCache(cacheKey, {
+          data: next,
+          warning: prev?.warning ?? null,
+          fix: prev?.fix ?? null,
+          tray: nextTray,
+        } satisfies StartupPageCache);
+      }
     } catch {
       if (signal?.aborted || generation !== loadGenerationRef.current) return;
       setFailed(true);
@@ -289,6 +300,7 @@ export default function Startup({ apiBase }: { apiBase: string }) {
           <StartupDetailsSection
             data={data}
             failed={failed}
+            loading={loading}
             installBusy={installBusy}
             installResult={installResult}
             onInstall={(action, opts) => { void runInstallAction(action, opts); }}

--- a/gui/src/pages/Startup.tsx
+++ b/gui/src/pages/Startup.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { IconRefresh } from "../icons";
-import { useI18n } from "../i18n/shared";
+import { type TFn, useI18n } from "../i18n/shared";
+import { readSessionListCache, writeSessionListCache } from "../session-list-cache";
 import { EmptyState } from "../ui";
 import {
   StartupDetailsSection,
@@ -15,110 +16,156 @@ import {
   type TrayStatusData,
 } from "./startup-shared";
 
+type CodexRuntimeSettings = {
+  version?: string | null;
+  newerAvailable?: { path?: string; version?: string | null } | null;
+  catalogClamp?: { active?: boolean; removedEfforts?: string[]; runtimeVersion?: string | null };
+};
+
+type StartupPageCache = {
+  data: StartupHealthData;
+  warning: string | null;
+  fix: string | null;
+  tray: TrayStatusData | null;
+};
+
+const STARTUP_PAGE_CACHE_PREFIX = "ocx.startup.page.v1:";
+
+function shellChain(commands: string[], platform: string | undefined): string {
+  // Windows PowerShell 5.x rejects bash `&&`; `;` works in PowerShell and cmd.
+  const sep = platform === "win32" ? "; " : " && ";
+  return commands.join(sep);
+}
+
+function deriveCodexRuntimeNotice(
+  runtime: CodexRuntimeSettings | undefined,
+  t: TFn,
+  platform?: string,
+): { warning: string | null; fix: string | null } {
+  if (!runtime) return { warning: null, fix: null };
+  const clampActive = Boolean(runtime.catalogClamp?.active);
+  const newer = Boolean(runtime.newerAvailable);
+  const version = (clampActive
+    ? runtime.catalogClamp?.runtimeVersion
+    : runtime.version) ?? runtime.version ?? "unknown";
+  const efforts = (runtime.catalogClamp?.removedEfforts ?? []).join(", ");
+  const doctorSync = shellChain(["ocx doctor --fix-codex-runtime", "ocx sync"], platform);
+  if (clampActive) {
+    return {
+      warning: efforts
+        ? t("startup.codexRuntime.clampHiddenWithEfforts", { version, efforts })
+        : t("startup.codexRuntime.clampHidden", { version }),
+      fix: newer ? doctorSync : "ocx sync",
+    };
+  }
+  if (newer) {
+    return {
+      warning: t("startup.codexRuntime.olderBinary", { version }),
+      fix: doctorSync,
+    };
+  }
+  return { warning: null, fix: null };
+}
+
 export default function Startup({ apiBase }: { apiBase: string }) {
   const { t } = useI18n();
-  const [data, setData] = useState<StartupHealthData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [failed, setFailed] = useState(false);
+  const cacheKey = `${STARTUP_PAGE_CACHE_PREFIX}${apiBase}`;
+  const cached = useMemo(() => readSessionListCache<StartupPageCache>(cacheKey), [cacheKey]);
+
+  const [data, setData] = useState<StartupHealthData | null>(() => cached?.data ?? null);
+  const [loading, setLoading] = useState(() => !cached?.data);
+  const [failed, setFailed] = useState(() => Boolean(cached?.data?.diagnosticStale));
   const [copied, setCopied] = useState<string | null>(null);
-  const [tray, setTray] = useState<TrayStatusData | null>(null);
-  const [trayLoading, setTrayLoading] = useState(true);
+  const [tray, setTray] = useState<TrayStatusData | null>(() => cached?.tray ?? null);
+  const [trayLoading, setTrayLoading] = useState(() => !cached?.data);
   const [trayBusy, setTrayBusy] = useState(false);
   const [trayError, setTrayError] = useState(false);
   const [installBusy, setInstallBusy] = useState<StartupInstallAction | null>(null);
-  const [installResult, setInstallResult] = useState<{ kind: "success" | "error"; action: StartupInstallAction; detail?: string } | null>(null);
-  const [codexRuntimeWarning, setCodexRuntimeWarning] = useState<string | null>(null);
-  const [codexRuntimeFix, setCodexRuntimeFix] = useState<string | null>(null);
+  const [installResult, setInstallResult] = useState<{ kind: "success" | "error"; action: StartupInstallAction; repair?: boolean; detail?: string } | null>(null);
+  const [codexRuntimeWarning, setCodexRuntimeWarning] = useState<string | null>(() => cached?.warning ?? null);
+  const [codexRuntimeFix, setCodexRuntimeFix] = useState<string | null>(() => cached?.fix ?? null);
+  /** True while settings (runtime notice) are still in flight — reserves notice slot height. */
+  const [runtimeNoticePending, setRuntimeNoticePending] = useState(() => !cached?.data);
   const loadGenerationRef = useRef(0);
+  const paintedRef = useRef(Boolean(cached?.data));
 
   const refresh = useCallback(async (signal?: AbortSignal) => {
     const generation = ++loadGenerationRef.current;
+    const keepSecondary = paintedRef.current;
     setLoading(true);
-    setTrayLoading(true);
+    // Keep prior notice/tray visible on revalidation; only reserve empty slots on first paint.
+    if (!keepSecondary) {
+      setTrayLoading(true);
+      setRuntimeNoticePending(true);
+    }
     try {
+      // Kick settings off immediately so it overlaps the health round-trip.
+      const settingsPromise = fetch(`${apiBase}/api/settings`, { signal })
+        .then(async (settingsRes) => {
+          if (!settingsRes.ok) return null;
+          return await settingsRes.json() as { codexRuntime?: CodexRuntimeSettings };
+        })
+        .catch(() => null);
+
       const res = await fetch(`${apiBase}/api/startup-health`, { signal });
       if (!res.ok) throw new Error("fetch failed");
       const next = await res.json() as StartupHealthData;
       if (signal?.aborted || generation !== loadGenerationRef.current) return;
+
+      // Paint hero/details/recovery as soon as health arrives.
       setData(next);
+      paintedRef.current = true;
       setFailed(next.diagnosticStale);
-      try {
-        const settingsRes = await fetch(`${apiBase}/api/settings`, { signal });
-        if (settingsRes.ok) {
-          const settings = await settingsRes.json() as {
-            codexRuntime?: {
-              version?: string | null;
-              newerAvailable?: { path?: string; version?: string | null } | null;
-              catalogClamp?: { active?: boolean; removedEfforts?: string[]; runtimeVersion?: string | null };
-            };
-          };
-          if (!signal?.aborted && generation === loadGenerationRef.current) {
-            const runtime = settings.codexRuntime;
-            const clampActive = Boolean(runtime?.catalogClamp?.active);
-            const newer = Boolean(runtime?.newerAvailable);
-            const version = (clampActive
-              ? runtime?.catalogClamp?.runtimeVersion
-              : runtime?.version) ?? runtime?.version ?? "unknown";
-            const efforts = (runtime?.catalogClamp?.removedEfforts ?? []).join(", ");
-            if (clampActive) {
-              setCodexRuntimeWarning(
-                efforts
-                  ? t("startup.codexRuntime.clampHiddenWithEfforts", { version, efforts })
-                  : t("startup.codexRuntime.clampHidden", { version }),
-              );
-            } else if (newer) {
-              setCodexRuntimeWarning(t("startup.codexRuntime.olderBinary", { version }));
-            } else {
-              setCodexRuntimeWarning(null);
-            }
-            setCodexRuntimeFix(
-              newer
-                ? "ocx doctor --fix-codex-runtime && ocx sync"
-                : clampActive
-                  ? "ocx sync"
-                  : null,
-            );
-          }
-        } else if (!signal?.aborted && generation === loadGenerationRef.current) {
-          setCodexRuntimeWarning(null);
-          setCodexRuntimeFix(null);
-        }
-      } catch {
-        if (!signal?.aborted && generation === loadGenerationRef.current) {
-          setCodexRuntimeWarning(null);
-          setCodexRuntimeFix(null);
-        }
-      }
+      setLoading(false);
+
+      const trayPromise = next.platform === "win32"
+        ? fetch(`${apiBase}/api/windows-tray`, { signal })
+          .then(async (trayRes) => {
+            if (!trayRes.ok) throw new Error("tray status failed");
+            const trayNext = await trayRes.json() as unknown;
+            if (!isTrayStatusData(trayNext)) throw new Error("invalid tray status");
+            return { tray: trayNext, error: false as const };
+          })
+          .catch(() => ({ tray: null, error: true as const }))
+        : Promise.resolve({ tray: null, error: false as const });
+
+      const [settings, trayResult] = await Promise.all([settingsPromise, trayPromise]);
+      if (signal?.aborted || generation !== loadGenerationRef.current) return;
+
+      const notice = deriveCodexRuntimeNotice(settings?.codexRuntime, t, next.platform);
+      setCodexRuntimeWarning(notice.warning);
+      setCodexRuntimeFix(notice.fix);
+      setRuntimeNoticePending(false);
+      const nextTray = next.platform === "win32" ? trayResult.tray : null;
       if (next.platform === "win32") {
+        setTray(nextTray);
+        setTrayError(trayResult.error);
+      } else {
+        setTray(null);
         setTrayError(false);
-        try {
-          const trayRes = await fetch(`${apiBase}/api/windows-tray`, { signal });
-          if (!trayRes.ok) throw new Error("tray status failed");
-          const trayNext = await trayRes.json() as unknown;
-          if (!isTrayStatusData(trayNext)) throw new Error("invalid tray status");
-          if (!signal?.aborted && generation === loadGenerationRef.current) {
-            setTray(trayNext);
-            setTrayError(false);
-          }
-        } catch {
-          if (!signal?.aborted && generation === loadGenerationRef.current) {
-            setTray(null);
-            setTrayError(true);
-          }
-        }
       }
+      setTrayLoading(false);
+
+      writeSessionListCache(cacheKey, {
+        data: next,
+        warning: notice.warning,
+        fix: notice.fix,
+        tray: nextTray,
+      } satisfies StartupPageCache);
     } catch {
       if (signal?.aborted || generation !== loadGenerationRef.current) return;
       setFailed(true);
-      setTray(null);
-      setTrayError(true);
-    } finally {
-      if (generation === loadGenerationRef.current) {
-        setTrayLoading(false);
-        setLoading(false);
+      if (!keepSecondary) {
+        setTray(null);
+        setTrayError(true);
+        setCodexRuntimeWarning(null);
+        setCodexRuntimeFix(null);
       }
+      setRuntimeNoticePending(false);
+      setTrayLoading(false);
+      setLoading(false);
     }
-  }, [apiBase, t]);
+  }, [apiBase, cacheKey, t]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -170,23 +217,23 @@ export default function Startup({ apiBase }: { apiBase: string }) {
     }
   };
 
-  const runInstallAction = async (action: StartupInstallAction) => {
+  const runInstallAction = async (action: StartupInstallAction, opts?: { repair?: boolean }) => {
     setInstallBusy(action);
     setInstallResult(null);
     try {
       const res = await fetch(`${apiBase}/api/startup-action`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ action }),
+        body: JSON.stringify({ action, repair: opts?.repair === true }),
       });
       if (!res.ok) {
         const body = await res.json().catch(() => null) as { error?: unknown } | null;
         throw new Error(typeof body?.error === "string" ? body.error : "installation failed");
       }
-      setInstallResult({ kind: "success", action });
+      setInstallResult({ kind: "success", action, repair: opts?.repair === true });
       await refresh();
     } catch (error) {
-      setInstallResult({ kind: "error", action, detail: error instanceof Error ? error.message : String(error) });
+      setInstallResult({ kind: "error", action, repair: opts?.repair === true, detail: error instanceof Error ? error.message : String(error) });
     } finally {
       setInstallBusy(null);
     }
@@ -199,9 +246,12 @@ export default function Startup({ apiBase }: { apiBase: string }) {
           <h2>{t("startup.title")}</h2>
           <p className="page-sub startup-page-sub">{t("startup.subtitle")}</p>
         </div>
-        <button type="button" className="btn btn-ghost btn-sm" onClick={() => void refresh()} disabled={loading}>
-          <IconRefresh /> {t("startup.refresh")}
-        </button>
+        <div className="startup-page-head-actions">
+          <a className="btn btn-ghost btn-sm" href="#dashboard">{t("startup.backToDashboard")}</a>
+          <button type="button" className="btn btn-ghost btn-sm" onClick={() => void refresh()} disabled={loading}>
+            <IconRefresh /> {t("startup.refresh")}
+          </button>
+        </div>
       </div>
 
       {loading && !data ? (
@@ -210,17 +260,28 @@ export default function Startup({ apiBase }: { apiBase: string }) {
         <EmptyState title={t("startup.error")} />
       ) : data ? (
         <>
-          {failed && <div className="notice notice-warn" role="alert">{t("startup.staleData")}</div>}
-          {codexRuntimeWarning && (
-            <div className="notice notice-warn" role="status">
-              <p>{codexRuntimeWarning}</p>
-              {codexRuntimeFix && (
-                <p>
-                  <button type="button" className="btn btn-ghost btn-sm" onClick={() => void copyCommand(codexRuntimeFix)}>
-                    {copied === codexRuntimeFix ? t("startup.copied") : t("startup.copy")}
-                  </button>
-                  <code style={{ marginLeft: "0.5rem" }}>{codexRuntimeFix}</code>
-                </p>
+          {failed && (
+            <div className="notice notice-warn startup-page-notice" role="alert">
+              {t("startup.staleData")}
+            </div>
+          )}
+          {(runtimeNoticePending || codexRuntimeWarning) && (
+            <div
+              className={`startup-runtime-notice-slot${runtimeNoticePending && !codexRuntimeWarning ? " startup-runtime-notice-slot--pending" : ""}`}
+              aria-hidden={runtimeNoticePending && !codexRuntimeWarning ? true : undefined}
+            >
+              {codexRuntimeWarning && (
+                <div className="notice notice-warn startup-page-notice startup-runtime-notice" role="status">
+                  <p className="startup-runtime-notice__text">{codexRuntimeWarning}</p>
+                  {codexRuntimeFix && (
+                    <div className="startup-runtime-notice__fix">
+                      <code>{codexRuntimeFix}</code>
+                      <button type="button" className="btn btn-ghost btn-sm" onClick={() => void copyCommand(codexRuntimeFix)}>
+                        {copied === codexRuntimeFix ? t("startup.copied") : t("startup.copy")}
+                      </button>
+                    </div>
+                  )}
+                </div>
               )}
             </div>
           )}
@@ -230,7 +291,7 @@ export default function Startup({ apiBase }: { apiBase: string }) {
             failed={failed}
             installBusy={installBusy}
             installResult={installResult}
-            onInstall={(action) => { void runInstallAction(action); }}
+            onInstall={(action, opts) => { void runInstallAction(action, opts); }}
           />
           {data.platform === "win32" && (
             <StartupTraySection

--- a/gui/src/pages/dashboard-core-poll.ts
+++ b/gui/src/pages/dashboard-core-poll.ts
@@ -62,11 +62,16 @@ export type DashboardMultiAgentPoll = {
 /** Sidecar + shadow only — must not wait on /api/settings (startup-health). */
 export type DashboardSidecarPoll = {
   sidecar: SidecarData;
-  shadowCall: ShadowCallData | null;
+  /**
+   * `null` = authoritative endpoint failure (clear UI).
+   * `undefined` = lost poll authority (epoch gate) — do not commit.
+   */
+  shadowCall: ShadowCallData | null | undefined;
 };
 
 export type DashboardSettingsPoll = {
-  settings: SettingsData | null;
+  /** Absent when the poll lost authority — callers must keep prior settings/cache. */
+  settings: SettingsData | undefined;
   startupHealthSeed: SettingsData["startupHealth"] | null | undefined;
 };
 
@@ -149,7 +154,7 @@ export async function fetchDashboardSidecars(
   ]);
 
   const sidecar = await requireJson<SidecarData>(scRes);
-  let shadowCall: ShadowCallData | null = null;
+  let shadowCall: ShadowCallData | null | undefined = undefined;
   try {
     if (shRes.ok) {
       const nextShadow = await shRes.json() as ShadowCallData;
@@ -163,6 +168,15 @@ export async function fetchDashboardSidecars(
       )) {
         shadowCall = nextShadow;
       }
+    } else if (settingsPollMayCommit(
+      { request: shadowRequestEpoch, mutation: shadowMutationEpoch },
+      {
+        request: epochs.shadowCallRequestEpochRef.current,
+        mutation: epochs.shadowCallMutationEpochRef.current,
+        mutationInFlight: epochs.shadowCallMutationInFlightRef.current,
+      },
+    )) {
+      shadowCall = null;
     }
   } catch {
     if (settingsPollMayCommit(
@@ -191,7 +205,7 @@ export async function fetchDashboardSettings(
 
   const sRes = await fetch(`${apiBase}/api/settings`, { signal });
   const nextSettings = await requireJson<SettingsData>(sRes);
-  let settings: SettingsData | null = null;
+  let settings: SettingsData | undefined = undefined;
   let startupHealthSeed: SettingsData["startupHealth"] | null | undefined = undefined;
   if (settingsPollMayCommit(
     { request: settingsRequestEpoch, mutation: settingsMutationEpoch },

--- a/gui/src/pages/dashboard-core-poll.ts
+++ b/gui/src/pages/dashboard-core-poll.ts
@@ -1,5 +1,6 @@
 import { readJsonIfOk } from "../fetch-json";
 import {
+  beginPollEpoch,
   settingsPollMayCommit,
   mapStartupHealthProbe,
   type StartupHealthStatus,
@@ -145,8 +146,10 @@ export async function fetchDashboardSidecars(
   epochs: DashboardEpochRefs,
 ): Promise<DashboardSidecarPoll> {
   // Only bump shadow epochs — settings has its own poll and must not be invalidated here.
-  const shadowRequestEpoch = ++epochs.shadowCallRequestEpochRef.current;
-  const shadowMutationEpoch = epochs.shadowCallMutationEpochRef.current;
+  const { request: shadowRequestEpoch, mutation: shadowMutationEpoch } = beginPollEpoch(
+    epochs.shadowCallRequestEpochRef,
+    epochs.shadowCallMutationEpochRef,
+  );
 
   const [scRes, shRes] = await Promise.all([
     fetch(`${apiBase}/api/sidecar-settings`, { signal }),
@@ -200,8 +203,10 @@ export async function fetchDashboardSettings(
   signal: AbortSignal,
   epochs: DashboardEpochRefs,
 ): Promise<DashboardSettingsPoll> {
-  const settingsRequestEpoch = ++epochs.settingsRequestEpochRef.current;
-  const settingsMutationEpoch = epochs.settingsMutationEpochRef.current;
+  const { request: settingsRequestEpoch, mutation: settingsMutationEpoch } = beginPollEpoch(
+    epochs.settingsRequestEpochRef,
+    epochs.settingsMutationEpochRef,
+  );
 
   const sRes = await fetch(`${apiBase}/api/settings`, { signal });
   const nextSettings = await requireJson<SettingsData>(sRes);

--- a/gui/src/pages/dashboard-core-poll.ts
+++ b/gui/src/pages/dashboard-core-poll.ts
@@ -1,7 +1,6 @@
 import { readJsonIfOk } from "../fetch-json";
 import {
   settingsPollMayCommit,
-  beginPollEpochs,
   mapStartupHealthProbe,
   type StartupHealthStatus,
 } from "../startup-health-ui";
@@ -47,20 +46,32 @@ export type EffortCapPoll = {
   subagentEffortCap: string;
 };
 
-export type DashboardCorePoll = {
+export type DashboardOverviewPoll = {
   health: HealthData | null;
   providers: ProviderInfo[];
-  settings: SettingsData | null;
-  /** Settings-derived seed payload; merge against latest startup-health at commit time. */
-  startupHealthSeed: SettingsData["startupHealth"] | null | undefined;
-  sidecar: SidecarData | null;
-  shadowCall: ShadowCallData | null | undefined;
-  maMode: "v1" | "default" | "v2";
-  maModeResolved: boolean;
+  error: boolean;
+};
+
+/** Multi-agent extras — slower peers must not gate status/uptime/provider counts. */
+export type DashboardMultiAgentPoll = {
   /** Absent when the optional endpoint failed — callers must keep prior UI state. */
   injection: InjectionPoll | undefined;
   effortCaps: EffortCapPoll | undefined;
-  error: boolean;
+};
+
+/** Sidecar + shadow only — must not wait on /api/settings (startup-health). */
+export type DashboardSidecarPoll = {
+  sidecar: SidecarData;
+  shadowCall: ShadowCallData | null;
+};
+
+export type DashboardSettingsPoll = {
+  settings: SettingsData | null;
+  startupHealthSeed: SettingsData["startupHealth"] | null | undefined;
+};
+
+export type DashboardMaModePoll = {
+  maMode: "v1" | "default" | "v2";
 };
 
 export type DashboardEpochRefs = {
@@ -72,6 +83,11 @@ export type DashboardEpochRefs = {
   shadowCallMutationInFlightRef: { current: boolean };
 };
 
+function isAbortError(error: unknown, signal: AbortSignal): boolean {
+  if (signal.aborted) return true;
+  return error instanceof Error && error.name === "AbortError";
+}
+
 export async function fetchStartupHealth(apiBase: string, signal: AbortSignal): Promise<StartupHealthStatus> {
   try {
     const response = await fetch(`${apiBase}/api/startup-health`, { signal });
@@ -80,7 +96,11 @@ export async function fetchStartupHealth(apiBase: string, signal: AbortSignal): 
     const mapped = mapStartupHealthProbe(data);
     if (!mapped) throw new Error("invalid startup health response");
     return mapped;
-  } catch {
+  } catch (error) {
+    // Aborts must propagate so client-resource can discard the generation.
+    // Swallowing them as "error" briefly shows "Could not read startup protection"
+    // after refresh / remount races.
+    if (isAbortError(error, signal)) throw error;
     return "error";
   }
 }
@@ -113,79 +133,26 @@ export async function fetchDashboardUsage(apiBase: string, signal: AbortSignal):
   return requireJson<UsageSummary30d>(response);
 }
 
-export async function fetchDashboardCore(
+/** Web-search / vision sidecar + shadow-call — config reads, typically sub-10ms. */
+export async function fetchDashboardSidecars(
   apiBase: string,
   signal: AbortSignal,
   epochs: DashboardEpochRefs,
-): Promise<DashboardCorePoll> {
-  const epochSnapshot = beginPollEpochs({
-    settingsRequest: epochs.settingsRequestEpochRef,
-    settingsMutation: epochs.settingsMutationEpochRef,
-    shadowRequest: epochs.shadowCallRequestEpochRef,
-    shadowMutation: epochs.shadowCallMutationEpochRef,
-  });
-  const settingsRequestEpoch = epochSnapshot.settings.request;
-  const settingsMutationEpoch = epochSnapshot.settings.mutation;
-  const shadowRequestEpoch = epochSnapshot.shadow.request;
-  const shadowMutationEpoch = epochSnapshot.shadow.mutation;
+): Promise<DashboardSidecarPoll> {
+  // Only bump shadow epochs — settings has its own poll and must not be invalidated here.
+  const shadowRequestEpoch = ++epochs.shadowCallRequestEpochRef.current;
+  const shadowMutationEpoch = epochs.shadowCallMutationEpochRef.current;
 
-  const empty: DashboardCorePoll = {
-    health: null,
-    providers: [],
-    settings: null,
-    startupHealthSeed: undefined,
-    sidecar: null,
-    shadowCall: undefined,
-    maMode: "default",
-    maModeResolved: true,
-    injection: undefined,
-    effortCaps: undefined,
-    error: true,
-  };
+  const [scRes, shRes] = await Promise.all([
+    fetch(`${apiBase}/api/sidecar-settings`, { signal }),
+    fetch(`${apiBase}/api/shadow-call-settings`, { signal }),
+  ]);
 
+  const sidecar = await requireJson<SidecarData>(scRes);
+  let shadowCall: ShadowCallData | null = null;
   try {
-    const [hRes, pRes, sRes, scRes, shRes] = await Promise.all([
-      fetch(`${apiBase}/healthz`, { signal }),
-      fetch(`${apiBase}/api/providers`, { signal }),
-      fetch(`${apiBase}/api/settings`, { signal }),
-      fetch(`${apiBase}/api/sidecar-settings`, { signal }),
-      fetch(`${apiBase}/api/shadow-call-settings`, { signal }),
-    ]);
-
-    const health = await requireJson<HealthData>(hRes);
-    const providers = await requireJson<ProviderInfo[]>(pRes);
-    const nextSettings = await requireJson<SettingsData>(sRes);
-    let settings: SettingsData | null = null;
-    let startupHealthSeed: SettingsData["startupHealth"] | null | undefined = undefined;
-    if (settingsPollMayCommit(
-      { request: settingsRequestEpoch, mutation: settingsMutationEpoch },
-      {
-        request: epochs.settingsRequestEpochRef.current,
-        mutation: epochs.settingsMutationEpochRef.current,
-        mutationInFlight: epochs.settingsMutationInFlightRef.current,
-      },
-    )) {
-      settings = nextSettings;
-      startupHealthSeed = nextSettings.startupHealth;
-    }
-
-    const sidecar = await requireJson<SidecarData>(scRes);
-    let shadowCall: ShadowCallData | null | undefined = undefined;
-    try {
-      if (shRes.ok) {
-        const nextShadow = await shRes.json() as ShadowCallData;
-        if (settingsPollMayCommit(
-          { request: shadowRequestEpoch, mutation: shadowMutationEpoch },
-          {
-            request: epochs.shadowCallRequestEpochRef.current,
-            mutation: epochs.shadowCallMutationEpochRef.current,
-            mutationInFlight: epochs.shadowCallMutationInFlightRef.current,
-          },
-        )) {
-          shadowCall = nextShadow;
-        }
-      }
-    } catch {
+    if (shRes.ok) {
+      const nextShadow = await shRes.json() as ShadowCallData;
       if (settingsPollMayCommit(
         { request: shadowRequestEpoch, mutation: shadowMutationEpoch },
         {
@@ -194,64 +161,123 @@ export async function fetchDashboardCore(
           mutationInFlight: epochs.shadowCallMutationInFlightRef.current,
         },
       )) {
-        shadowCall = null;
+        shadowCall = nextShadow;
       }
     }
-
-    let maMode: "v1" | "default" | "v2" = "default";
-    let maModeResolved = false;
-    try {
-      const v2Res = await fetch(`${apiBase}/api/v2`, { signal });
-      if (v2Res.ok) {
-        const v2Data = await v2Res.json();
-        if (v2Data.multiAgentMode === "v1" || v2Data.multiAgentMode === "v2") maMode = v2Data.multiAgentMode;
-        else maMode = "default";
-      }
-    } catch { /* old server */ }
-    finally { maModeResolved = true; }
-
-    let injection: InjectionPoll | undefined;
-    try {
-      const imRes = await fetch(`${apiBase}/api/injection-model`, { signal });
-      if (imRes.ok) {
-        const imData = await imRes.json() as InjectionSelectionResponse & {
-          efforts?: string[];
-          available?: InjectionPoll["injectionAvailable"];
-        };
-        injection = {
-          ...normalizeInjectionSelection(imData),
-          injectionEfforts: imData.efforts ?? [],
-          injectionAvailable: imData.available ?? [],
-        };
-      }
-    } catch { /* old server / malformed — keep prior UI state */ }
-
-    let effortCaps: EffortCapPoll | undefined;
-    try {
-      const ecRes = await fetch(`${apiBase}/api/effort-caps`, { signal });
-      if (ecRes.ok) {
-        const ecData = await ecRes.json() as { effortCap?: string | null; subagentEffortCap?: string | null };
-        effortCaps = {
-          effortCap: ecData.effortCap ?? "",
-          subagentEffortCap: ecData.subagentEffortCap ?? "",
-        };
-      }
-    } catch { /* old server */ }
-
-    return {
-      health,
-      providers,
-      settings,
-      startupHealthSeed,
-      sidecar,
-      shadowCall,
-      maMode,
-      maModeResolved,
-      injection,
-      effortCaps,
-      error: false,
-    };
   } catch {
-    return empty;
+    if (settingsPollMayCommit(
+      { request: shadowRequestEpoch, mutation: shadowMutationEpoch },
+      {
+        request: epochs.shadowCallRequestEpochRef.current,
+        mutation: epochs.shadowCallMutationEpochRef.current,
+        mutationInFlight: epochs.shadowCallMutationInFlightRef.current,
+      },
+    )) {
+      shadowCall = null;
+    }
   }
+
+  return { sidecar, shadowCall };
+}
+
+/** Codex auto-start + startup-health seed — can be slower because settings embeds startup probe. */
+export async function fetchDashboardSettings(
+  apiBase: string,
+  signal: AbortSignal,
+  epochs: DashboardEpochRefs,
+): Promise<DashboardSettingsPoll> {
+  const settingsRequestEpoch = ++epochs.settingsRequestEpochRef.current;
+  const settingsMutationEpoch = epochs.settingsMutationEpochRef.current;
+
+  const sRes = await fetch(`${apiBase}/api/settings`, { signal });
+  const nextSettings = await requireJson<SettingsData>(sRes);
+  let settings: SettingsData | null = null;
+  let startupHealthSeed: SettingsData["startupHealth"] | null | undefined = undefined;
+  if (settingsPollMayCommit(
+    { request: settingsRequestEpoch, mutation: settingsMutationEpoch },
+    {
+      request: epochs.settingsRequestEpochRef.current,
+      mutation: epochs.settingsMutationEpochRef.current,
+      mutationInFlight: epochs.settingsMutationInFlightRef.current,
+    },
+  )) {
+    settings = nextSettings;
+    startupHealthSeed = nextSettings.startupHealth;
+  }
+
+  return { settings, startupHealthSeed };
+}
+
+/** Multi-agent mode toggle only — must not wait on injection-model / effort-caps. */
+export async function fetchDashboardMaMode(
+  apiBase: string,
+  signal: AbortSignal,
+): Promise<DashboardMaModePoll> {
+  try {
+    const v2Res = await fetch(`${apiBase}/api/v2`, { signal });
+    if (!v2Res.ok) return { maMode: "default" };
+    const v2Data = await v2Res.json() as { multiAgentMode?: unknown };
+    if (v2Data.multiAgentMode === "v1" || v2Data.multiAgentMode === "v2") {
+      return { maMode: v2Data.multiAgentMode };
+    }
+    return { maMode: "default" };
+  } catch (error) {
+    if (isAbortError(error, signal)) throw error;
+    return { maMode: "default" };
+  }
+}
+
+export async function fetchDashboardOverview(
+  apiBase: string,
+  signal: AbortSignal,
+): Promise<DashboardOverviewPoll> {
+  try {
+    const [hRes, pRes] = await Promise.all([
+      fetch(`${apiBase}/healthz`, { signal }),
+      fetch(`${apiBase}/api/providers`, { signal }),
+    ]);
+    const health = await requireJson<HealthData>(hRes);
+    const providers = await requireJson<ProviderInfo[]>(pRes);
+    return { health, providers, error: false };
+  } catch {
+    return { health: null, providers: [], error: true };
+  }
+}
+
+export async function fetchDashboardMultiAgent(
+  apiBase: string,
+  signal: AbortSignal,
+): Promise<DashboardMultiAgentPoll> {
+  const [imRes, ecRes] = await Promise.all([
+    fetch(`${apiBase}/api/injection-model`, { signal }).catch(() => null),
+    fetch(`${apiBase}/api/effort-caps`, { signal }).catch(() => null),
+  ]);
+
+  let injection: InjectionPoll | undefined;
+  try {
+    if (imRes?.ok) {
+      const imData = await imRes.json() as InjectionSelectionResponse & {
+        efforts?: string[];
+        available?: InjectionPoll["injectionAvailable"];
+      };
+      injection = {
+        ...normalizeInjectionSelection(imData),
+        injectionEfforts: imData.efforts ?? [],
+        injectionAvailable: imData.available ?? [],
+      };
+    }
+  } catch { /* old server / malformed — keep prior UI state */ }
+
+  let effortCaps: EffortCapPoll | undefined;
+  try {
+    if (ecRes?.ok) {
+      const ecData = await ecRes.json() as { effortCap?: string | null; subagentEffortCap?: string | null };
+      effortCaps = {
+        effortCap: ecData.effortCap ?? "",
+        subagentEffortCap: ecData.subagentEffortCap ?? "",
+      };
+    }
+  } catch { /* old server */ }
+
+  return { injection, effortCaps };
 }

--- a/gui/src/pages/dashboard-overview-head.tsx
+++ b/gui/src/pages/dashboard-overview-head.tsx
@@ -11,6 +11,8 @@ export function DashboardOverviewHead({
   health,
   providers,
   usage30d,
+  usageLoading,
+  healthLoading,
   startupHealth,
   projectConfigWarnings,
   maMode,
@@ -19,7 +21,7 @@ export function DashboardOverviewHead({
   maHelpOpen,
   setMaHelpOpen,
   switchMaMode,
-}: Pick<Dash, "locale" | "health" | "providers" | "usage30d" | "startupHealth" | "projectConfigWarnings" | "maMode" | "maBusy" | "maHelpTriggerRef" | "maHelpOpen" | "setMaHelpOpen" | "switchMaMode">) {
+}: Pick<Dash, "locale" | "health" | "providers" | "usage30d" | "usageLoading" | "healthLoading" | "startupHealth" | "projectConfigWarnings" | "maMode" | "maBusy" | "maHelpTriggerRef" | "maHelpOpen" | "setMaHelpOpen" | "switchMaMode">) {
   const t = useT();
   const online = health?.status === "ok";
 
@@ -61,16 +63,16 @@ export function DashboardOverviewHead({
               </div>
             </div>
           </div>
-          <div className="stat">
+          <div className="stat" aria-busy={healthLoading || undefined}>
             <div className="label">{t("dash.status")}</div>
             <div className="value" style={{ display: "flex", alignItems: "center", gap: 9, color: online ? "var(--green)" : "var(--red)" }}>
               <span className={`dot ${online ? "dot-green" : "dot-red"}`} />{online ? t("dash.online") : t("dash.offline")}
             </div>
           </div>
-          <div className="stat"><div className="label">{t("dash.version")}</div><div className="value mono">{health?.version ?? "—"}</div></div>
-          <div className="stat"><div className="label">{t("dash.uptime")}</div><div className="value mono">{health ? formatUptime(health.uptime, locale) : "—"}</div></div>
-          <div className="stat"><div className="label">{t("dash.providers")}</div><div className="value">{providers.length}</div></div>
-          <div className="stat">
+          <div className="stat" aria-busy={healthLoading || undefined}><div className="label">{t("dash.version")}</div><div className="value mono">{health?.version ?? "—"}</div></div>
+          <div className="stat" aria-busy={healthLoading || undefined}><div className="label">{t("dash.uptime")}</div><div className="value mono">{health ? formatUptime(health.uptime, locale) : "—"}</div></div>
+          <div className="stat" aria-busy={healthLoading || undefined}><div className="label">{t("dash.providers")}</div><div className="value">{providers.length}</div></div>
+          <div className="stat" aria-busy={usageLoading || undefined}>
             <div className="label">{t("dash.tokens30d")}</div>
             <div className="value mono">{usage30d && usage30d.summary.requests > 0 ? formatTokens(usage30d.summary.totalTokens, locale) : "—"}</div>
             <div className="muted text-label dash-stat-coverage">

--- a/gui/src/pages/dashboard-overview-sections.tsx
+++ b/gui/src/pages/dashboard-overview-sections.tsx
@@ -249,7 +249,7 @@ export function DashboardSidecarPanels({ d }: { d: Dash }) {
       </div>
 
       <div className="dash-sidecar-grid">
-        <div className="panel dash-sidecar-card">
+        <div className="panel dash-sidecar-card" aria-busy={!sidecar || undefined}>
           <div className="dash-sidecar-card__row">
             <div className="font-semibold">{t("dash.webSearchSidecar")}</div>
             <Select
@@ -263,7 +263,7 @@ export function DashboardSidecarPanels({ d }: { d: Dash }) {
           <div className="muted setting-hint">{t("dash.webSearchSidecarHint")}</div>
         </div>
 
-        <div className="panel dash-sidecar-card">
+        <div className="panel dash-sidecar-card" aria-busy={!sidecar || undefined}>
           <div className="dash-sidecar-card__row">
             <div className="font-semibold">{t("dash.visionSidecar")}</div>
             <Select
@@ -278,7 +278,7 @@ export function DashboardSidecarPanels({ d }: { d: Dash }) {
         </div>
       </div>
 
-      <div className="panel">
+      <div className="panel" aria-busy={!shadowCall || undefined}>
         <div className="spread" style={{ alignItems: "center" }}>
           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
             <span className="font-semibold">{t("dash.shadowCallIntercept")}</span>

--- a/gui/src/pages/startup-sections.tsx
+++ b/gui/src/pages/startup-sections.tsx
@@ -84,10 +84,12 @@ export function StartupDetailsSection({
   data: StartupHealthData;
   failed: boolean;
   installBusy: StartupInstallAction | null;
-  installResult: { kind: "success" | "error"; action: StartupInstallAction; detail?: string } | null;
-  onInstall: (action: StartupInstallAction) => void;
+  installResult: { kind: "success" | "error"; action: StartupInstallAction; repair?: boolean; detail?: string } | null;
+  onInstall: (action: StartupInstallAction, opts?: { repair?: boolean }) => void;
 }) {
   const { t } = useI18n();
+  const serviceNeedsRepair = data.serviceSupported && data.serviceInstalled && !data.serviceViable;
+  const shimNeedsRepair = data.shimInstalled && !data.shimHealthy;
 
   return (
     <section className="panel startup-details">
@@ -108,6 +110,11 @@ export function StartupDetailsSection({
               {t(installBusy === "install-service" ? "startup.installing" : "startup.install")}
             </button>
           )}
+          {serviceNeedsRepair && (
+            <button type="button" className="btn btn-primary btn-sm" aria-label={`${t("startup.service")} - ${t("startup.repair")}`} disabled={installBusy !== null || failed} onClick={() => onInstall("install-service", { repair: true })}>
+              {t(installBusy === "install-service" ? "startup.repairing" : "startup.repair")}
+            </button>
+          )}
         </div>
       </div>
       <div className="startup-detail-row">
@@ -125,12 +132,19 @@ export function StartupDetailsSection({
               {t(installBusy === "install-shim" ? "startup.installing" : "startup.install")}
             </button>
           )}
+          {shimNeedsRepair && (
+            <button type="button" className="btn btn-primary btn-sm" aria-label={`${t("startup.shim")} - ${t("startup.repair")}`} disabled={installBusy !== null || failed} onClick={() => onInstall("install-shim", { repair: true })}>
+              {t(installBusy === "install-shim" ? "startup.repairing" : "startup.repair")}
+            </button>
+          )}
         </div>
       </div>
       {installResult && (
         <div className={`notice ${installResult.kind === "success" ? "notice-ok" : "notice-warn"} startup-action-notice`} role="status" aria-live="polite">
           {installResult.kind === "success"
-            ? t(installResult.action === "install-service" ? "startup.serviceInstalled" : "startup.shimInstalled")
+            ? installResult.action === "install-service"
+              ? t(installResult.repair ? "startup.serviceRepaired" : "startup.serviceInstalled")
+              : t(installResult.repair ? "startup.shimRepaired" : "startup.shimInstalled")
             : `${t("startup.installFailed")} ${installResult.detail ?? ""}`}
         </div>
       )}
@@ -189,7 +203,9 @@ export function StartupTraySection({
           }}>{t("startup.tray.uninstall")}</button>
         )}
       </div>
-      {(trayError || tray?.stale) && <div className="notice notice-warn" role="alert">{t("startup.tray.error")}</div>}
+      {(trayError || tray?.stale) && (
+        <div className="notice notice-warn startup-tray-error" role="alert">{t("startup.tray.error")}</div>
+      )}
     </section>
   );
 }

--- a/gui/src/pages/startup-sections.tsx
+++ b/gui/src/pages/startup-sections.tsx
@@ -77,19 +77,23 @@ export function StartupHeroSection({
 export function StartupDetailsSection({
   data,
   failed,
+  loading = false,
   installBusy,
   installResult,
   onInstall,
 }: {
   data: StartupHealthData;
   failed: boolean;
+  loading?: boolean;
   installBusy: StartupInstallAction | null;
   installResult: { kind: "success" | "error"; action: StartupInstallAction; repair?: boolean; detail?: string } | null;
   onInstall: (action: StartupInstallAction, opts?: { repair?: boolean }) => void;
 }) {
   const { t } = useI18n();
-  const serviceNeedsRepair = data.serviceSupported && data.serviceInstalled && !data.serviceViable;
+  // Repair only rewrites stale assets — conflict/disabled need uninstall/reinstall, not repair.
+  const serviceNeedsRepair = data.serviceSupported && data.serviceInstalled && data.serviceStale && !data.serviceConflict;
   const shimNeedsRepair = data.shimInstalled && !data.shimHealthy;
+  const actionsDisabled = installBusy !== null || failed || loading;
 
   return (
     <section className="panel startup-details">
@@ -106,12 +110,12 @@ export function StartupDetailsSection({
             no={t(data.serviceConflict ? "startup.conflict" : data.serviceStale ? "startup.stale" : data.serviceInstalled ? "startup.unhealthy" : data.serviceSupported ? "startup.notInstalled" : "startup.unsupported")}
           />
           {data.serviceSupported && !data.serviceInstalled && (
-            <button type="button" className="btn btn-primary btn-sm" aria-label={`${t("startup.service")} - ${t("startup.install")}`} disabled={installBusy !== null || failed} onClick={() => onInstall("install-service")}>
+            <button type="button" className="btn btn-primary btn-sm" aria-label={`${t("startup.service")} - ${t("startup.install")}`} disabled={actionsDisabled} onClick={() => onInstall("install-service")}>
               {t(installBusy === "install-service" ? "startup.installing" : "startup.install")}
             </button>
           )}
           {serviceNeedsRepair && (
-            <button type="button" className="btn btn-primary btn-sm" aria-label={`${t("startup.service")} - ${t("startup.repair")}`} disabled={installBusy !== null || failed} onClick={() => onInstall("install-service", { repair: true })}>
+            <button type="button" className="btn btn-primary btn-sm" aria-label={`${t("startup.service")} - ${t("startup.repair")}`} disabled={actionsDisabled} onClick={() => onInstall("install-service", { repair: true })}>
               {t(installBusy === "install-service" ? "startup.repairing" : "startup.repair")}
             </button>
           )}
@@ -128,12 +132,12 @@ export function StartupDetailsSection({
               : "startup.notInstalled")}
           />
           {!data.shimInstalled && (
-            <button type="button" className="btn btn-primary btn-sm" aria-label={`${t("startup.shim")} - ${t("startup.install")}`} disabled={installBusy !== null || failed} onClick={() => onInstall("install-shim")}>
+            <button type="button" className="btn btn-primary btn-sm" aria-label={`${t("startup.shim")} - ${t("startup.install")}`} disabled={actionsDisabled} onClick={() => onInstall("install-shim")}>
               {t(installBusy === "install-shim" ? "startup.installing" : "startup.install")}
             </button>
           )}
           {shimNeedsRepair && (
-            <button type="button" className="btn btn-primary btn-sm" aria-label={`${t("startup.shim")} - ${t("startup.repair")}`} disabled={installBusy !== null || failed} onClick={() => onInstall("install-shim", { repair: true })}>
+            <button type="button" className="btn btn-primary btn-sm" aria-label={`${t("startup.shim")} - ${t("startup.repair")}`} disabled={actionsDisabled} onClick={() => onInstall("install-shim", { repair: true })}>
               {t(installBusy === "install-shim" ? "startup.repairing" : "startup.repair")}
             </button>
           )}

--- a/gui/src/pages/use-dashboard-data.ts
+++ b/gui/src/pages/use-dashboard-data.ts
@@ -1,15 +1,20 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useKeyedClientResource } from "../client-resource";
 import { useI18n } from "../i18n/shared";
+import { readSessionListCache, writeSessionListCache } from "../session-list-cache";
 import {
   PROJECT_CONFIG_DIAGNOSTICS_POLL_MS,
   seedStartupHealthFromSettings,
   type StartupHealthStatus,
 } from "../startup-health-ui";
 import {
-  fetchDashboardCore,
-  fetchDashboardUsage,
+  fetchDashboardMaMode,
   fetchDashboardModels,
+  fetchDashboardMultiAgent,
+  fetchDashboardOverview,
+  fetchDashboardSettings,
+  fetchDashboardSidecars,
+  fetchDashboardUsage,
   fetchProjectConfigDiagnostics,
   fetchStartupHealth,
   normalizeInjectionSelection,
@@ -40,27 +45,79 @@ import {
   useModalDialog,
 } from "./dashboard-shared";
 
+const CONTROLS_CACHE_PREFIX = "ocx.dash.controls.v1:";
+const OVERVIEW_CACHE_PREFIX = "ocx.dash.overview.v1:";
+const USAGE_CACHE_PREFIX = "ocx.dash.usage30d.v1:";
+const STARTUP_CACHE_PREFIX = "ocx.dash.startup.v1:";
+const MA_MODE_CACHE_PREFIX = "ocx.dash.maMode.v1:";
+
+type CachedControls = {
+  settings?: SettingsData | null;
+  sidecar?: SidecarData | null;
+  shadowCall?: ShadowCallData | null;
+};
+
+type CachedOverview = {
+  health: HealthData;
+  providers: ProviderInfo[];
+};
+
+type MaMode = "v1" | "default" | "v2";
+
+function readCachedControls(apiBase: string): CachedControls | null {
+  try {
+    const raw = sessionStorage.getItem(`${CONTROLS_CACHE_PREFIX}${apiBase}`);
+    if (!raw) return null;
+    return JSON.parse(raw) as CachedControls;
+  } catch {
+    return null;
+  }
+}
+
+function writeCachedControls(apiBase: string, value: CachedControls) {
+  try {
+    sessionStorage.setItem(`${CONTROLS_CACHE_PREFIX}${apiBase}`, JSON.stringify(value));
+  } catch { /* private mode / quota */ }
+}
+
 export function useDashboardData(apiBase: string) {
   const { locale, t } = useI18n();
   // The hash is the source of truth for the active section (#dashboard, …).
   const [selectedSection, setSelectedSection] = useState<DashboardSection>(readDashboardSectionFromHash);
   const [modelQuery, setModelQuery] = useState("");
   const [expandedProviders, setExpandedProviders] = useState<Set<string>>(new Set());
-  const [health, setHealth] = useState<HealthData | null>(null);
-  const [startupHealth, setStartupHealth] = useState<StartupHealthStatus | null>(null);
-  const [providers, setProviders] = useState<ProviderInfo[]>([]);
+  const cachedControls = useMemo(() => readCachedControls(apiBase), [apiBase]);
+  const cachedOverview = useMemo(
+    () => readSessionListCache<CachedOverview>(`${OVERVIEW_CACHE_PREFIX}${apiBase}`),
+    [apiBase],
+  );
+  const cachedUsage = useMemo(
+    () => readSessionListCache<UsageSummary30d>(`${USAGE_CACHE_PREFIX}${apiBase}`),
+    [apiBase],
+  );
+  const cachedStartup = useMemo(() => {
+    const cached = readSessionListCache<StartupHealthStatus>(`${STARTUP_CACHE_PREFIX}${apiBase}`);
+    return cached === "error" ? null : cached;
+  }, [apiBase]);
+  const cachedMaMode = useMemo(
+    () => readSessionListCache<MaMode>(`${MA_MODE_CACHE_PREFIX}${apiBase}`),
+    [apiBase],
+  );
+  const [health, setHealth] = useState<HealthData | null>(() => cachedOverview?.health ?? null);
+  const [startupHealth, setStartupHealth] = useState<StartupHealthStatus | null>(() => cachedStartup);
+  const [providers, setProviders] = useState<ProviderInfo[]>(() => cachedOverview?.providers ?? []);
   const [models, setModels] = useState<ModelInfo[]>([]);
-  const [settings, setSettings] = useState<SettingsData | null>(null);
-  const [sidecar, setSidecar] = useState<SidecarData | null>(null);
-  const [shadowCall, setShadowCall] = useState<ShadowCallData | null>(null);
-  const [usage30d, setUsage30d] = useState<UsageSummary30d | null>(null);
+  const [settings, setSettings] = useState<SettingsData | null>(() => cachedControls?.settings ?? null);
+  const [sidecar, setSidecar] = useState<SidecarData | null>(() => cachedControls?.sidecar ?? null);
+  const [shadowCall, setShadowCall] = useState<ShadowCallData | null>(() => cachedControls?.shadowCall ?? null);
+  const [usage30d, setUsage30d] = useState<UsageSummary30d | null>(() => cachedUsage);
   const [sidecarSaving, setSidecarSaving] = useState(false);
   const [shadowCallSaving, setShadowCallSaving] = useState(false);
   const [modelsLoading, setModelsLoading] = useState(false);
   const [settingsSaving, setSettingsSaving] = useState(false);
   const [syncing, setSyncing] = useState(false);
-  const [maMode, setMaMode] = useState<"v1" | "default" | "v2">("default");
-  const [maModeResolved, setMaModeResolved] = useState(false);
+  const [maMode, setMaMode] = useState<MaMode>(() => cachedMaMode ?? "default");
+  const [maModeResolved, setMaModeResolved] = useState(() => cachedMaMode !== null);
   const [maBusy, setMaBusy] = useState(false);
   const [maHelpOpen, setMaHelpOpen] = useState(false);
   const [effortCapHelpOpen, setEffortCapHelpOpen] = useState(false);
@@ -119,7 +176,7 @@ export function useDashboardData(apiBase: string) {
     }
   }, []);
 
-  const startupHealthRef = useRef<StartupHealthStatus | null>(null);
+  const startupHealthRef = useRef<StartupHealthStatus | null>(cachedStartup);
   /** Bumped whenever the dedicated startup-health poll commits; core polls ignore older generations. */
   const startupHealthGenerationRef = useRef(0);
   const epochRefs = useRef<DashboardEpochRefs>({
@@ -138,37 +195,72 @@ export function useDashboardData(apiBase: string) {
     { pollMs: 30_000 },
   );
 
-  const corePoll = useKeyedClientResource(
-    `dashboard-core:${apiBase}`,
+  // Wave 1: status/uptime/providers must not wait on injection-model / usage.
+  const overviewPoll = useKeyedClientResource(
+    `dashboard-overview:${apiBase}`,
+    [apiBase],
+    (signal) => fetchDashboardOverview(apiBase, signal),
+    { pollMs: 5000 },
+  );
+  const overviewReady = health !== null || overviewPoll.data !== undefined;
+
+  // Preferences that are just config — never gate on overview or injection.
+  const maModePoll = useKeyedClientResource(
+    `dashboard-ma-mode:${apiBase}`,
+    [apiBase],
+    (signal) => fetchDashboardMaMode(apiBase, signal),
+    { pollMs: 5000 },
+  );
+
+  const sidecarPoll = useKeyedClientResource(
+    `dashboard-sidecars:${apiBase}`,
     [apiBase],
     async (signal) => {
-      // Capture generation at fetch start so a newer probe can win at commit time.
       const startupHealthGeneration = startupHealthGenerationRef.current;
-      const data = await fetchDashboardCore(apiBase, signal, epochRefs);
+      const data = await fetchDashboardSidecars(apiBase, signal, epochRefs);
       return { ...data, startupHealthGeneration };
     },
     { pollMs: 5000 },
+  );
+
+  const settingsPoll = useKeyedClientResource(
+    `dashboard-settings:${apiBase}`,
+    [apiBase],
+    async (signal) => {
+      const startupHealthGeneration = startupHealthGenerationRef.current;
+      const data = await fetchDashboardSettings(apiBase, signal, epochRefs);
+      return { ...data, startupHealthGeneration };
+    },
+    { pollMs: 5000 },
+  );
+
+  // Wave 2: heavier peers start after overview commits (or session seed) to cut contention.
+  const multiAgentPoll = useKeyedClientResource(
+    `dashboard-multi-agent:${apiBase}`,
+    [apiBase],
+    (signal) => fetchDashboardMultiAgent(apiBase, signal),
+    { pollMs: 5000, enabled: overviewReady },
   );
 
   const usagePoll = useKeyedClientResource(
     `dashboard-usage:${apiBase}`,
     [apiBase],
     (signal) => fetchDashboardUsage(apiBase, signal),
-    { pollMs: 60_000 },
+    { pollMs: 60_000, enabled: overviewReady },
   );
 
   const diagnosticsPoll = useKeyedClientResource(
     `dashboard-diagnostics:${apiBase}`,
     [apiBase],
     (signal) => fetchProjectConfigDiagnostics(apiBase, signal),
-    { pollMs: PROJECT_CONFIG_DIAGNOSTICS_POLL_MS },
+    { pollMs: PROJECT_CONFIG_DIAGNOSTICS_POLL_MS, enabled: overviewReady },
   );
 
   const modelsPoll = useKeyedClientResource(
     `dashboard-models:${apiBase}`,
     [apiBase, error],
     (signal) => fetchDashboardModels(apiBase, signal),
-    { enabled: !error },
+    { enabled: overviewReady && !error },
   );
 
   /* eslint-disable react-hooks/set-state-in-effect -- mirror client-resource snapshots into mutable dashboard UI state that handlers also update */
@@ -177,29 +269,37 @@ export function useDashboardData(apiBase: string) {
       startupHealthGenerationRef.current += 1;
       setStartupHealth(startupHealthPoll.data);
       startupHealthRef.current = startupHealthPoll.data;
+      // Never persist hard errors — a cold SWR miss used to poison revisits.
+      if (startupHealthPoll.data !== "error") {
+        writeSessionListCache(`${STARTUP_CACHE_PREFIX}${apiBase}`, startupHealthPoll.data);
+      }
     }
-  }, [startupHealthPoll.data]);
+  }, [startupHealthPoll.data, apiBase]);
 
   useEffect(() => {
-    const data = corePoll.data;
+    const data = overviewPoll.data;
     if (!data) return;
-    if (data.health) setHealth(data.health);
-    setProviders(data.providers);
-    if (data.settings) setSettings(data.settings);
-    // Latest-wins: only seed from settings when no newer dedicated probe has committed
-    // while this core poll was in flight. Always merge against the live ref.
-    if (
-      data.startupHealthSeed !== undefined
-      && data.startupHealthGeneration === startupHealthGenerationRef.current
-    ) {
-      const merged = seedStartupHealthFromSettings(startupHealthRef.current, data.startupHealthSeed);
-      setStartupHealth(merged);
-      startupHealthRef.current = merged;
+    if (data.health) {
+      setHealth(data.health);
+      writeSessionListCache(`${OVERVIEW_CACHE_PREFIX}${apiBase}`, {
+        health: data.health,
+        providers: data.providers,
+      });
     }
-    if (data.sidecar) setSidecar(data.sidecar);
-    if (data.shadowCall !== undefined) setShadowCall(data.shadowCall);
-    setMaMode(data.maMode);
-    setMaModeResolved(data.maModeResolved);
+    setProviders(data.providers);
+    setError(data.error);
+  }, [overviewPoll.data, apiBase]);
+
+  useEffect(() => {
+    if (maModePoll.data === undefined) return;
+    setMaMode(maModePoll.data.maMode);
+    setMaModeResolved(true);
+    writeSessionListCache(`${MA_MODE_CACHE_PREFIX}${apiBase}`, maModePoll.data.maMode);
+  }, [maModePoll.data, apiBase]);
+
+  useEffect(() => {
+    const data = multiAgentPoll.data;
+    if (!data) return;
     if (data.injection) {
       setMultiAgentGuidanceEnabled(data.injection.multiAgentGuidanceEnabled);
       setSyncCodexSubagentDefaults(data.injection.syncCodexSubagentDefaults);
@@ -212,12 +312,49 @@ export function useDashboardData(apiBase: string) {
       setEffortCap(data.effortCaps.effortCap);
       setSubagentEffortCap(data.effortCaps.subagentEffortCap);
     }
-    setError(data.error);
-  }, [corePoll.data]);
+  }, [multiAgentPoll.data]);
 
   useEffect(() => {
-    if (usagePoll.data !== undefined) setUsage30d(usagePoll.data);
-  }, [usagePoll.data]);
+    const data = sidecarPoll.data;
+    if (!data) return;
+    setSidecar(data.sidecar);
+    setShadowCall(data.shadowCall);
+    const prev = readCachedControls(apiBase) ?? {};
+    writeCachedControls(apiBase, {
+      ...prev,
+      sidecar: data.sidecar,
+      shadowCall: data.shadowCall,
+    });
+  }, [sidecarPoll.data, apiBase]);
+
+  useEffect(() => {
+    const data = settingsPoll.data;
+    if (!data) return;
+    if (data.settings) setSettings(data.settings);
+    // Latest-wins: only seed from settings when no newer dedicated probe has committed
+    // while this settings poll was in flight. Always merge against the live ref.
+    if (
+      data.startupHealthSeed !== undefined
+      && data.startupHealthGeneration === startupHealthGenerationRef.current
+    ) {
+      const merged = seedStartupHealthFromSettings(startupHealthRef.current, data.startupHealthSeed);
+      setStartupHealth(merged);
+      startupHealthRef.current = merged;
+      if (merged) writeSessionListCache(`${STARTUP_CACHE_PREFIX}${apiBase}`, merged);
+    }
+    const prev = readCachedControls(apiBase) ?? {};
+    writeCachedControls(apiBase, {
+      ...prev,
+      settings: data.settings ?? undefined,
+    });
+  }, [settingsPoll.data, apiBase]);
+
+  useEffect(() => {
+    if (usagePoll.data !== undefined) {
+      setUsage30d(usagePoll.data);
+      writeSessionListCache(`${USAGE_CACHE_PREFIX}${apiBase}`, usagePoll.data);
+    }
+  }, [usagePoll.data, apiBase]);
 
   useEffect(() => {
     if (diagnosticsPoll.data) setProjectConfigWarnings(diagnosticsPoll.data);
@@ -291,7 +428,15 @@ export function useDashboardData(apiBase: string) {
     }
     return out;
   }, [grouped, modelQuery]);
-  const sidecarModels = useMemo(() => sidecarModelOptions(models), [models]);
+  const sidecarModels = useMemo(() => {
+    const opts = sidecarModelOptions(models);
+    for (const id of [sidecar?.webSearch.model, sidecar?.vision.model]) {
+      if (id && !opts.some(option => option.value === id)) {
+        opts.unshift({ value: id, label: id });
+      }
+    }
+    return opts;
+  }, [models, sidecar]);
 
   const saveSidecar = async (patch: SidecarPatch) => {
     if (!sidecar || sidecarSaving) return;
@@ -310,6 +455,11 @@ export function useDashboardData(apiBase: string) {
       });
       const data = await requireJson<SidecarData>(res, "save failed");
       setSidecar({ webSearch: data.webSearch, vision: data.vision });
+      const prev = readCachedControls(apiBase) ?? {};
+      writeCachedControls(apiBase, {
+        ...prev,
+        sidecar: { webSearch: data.webSearch, vision: data.vision },
+      });
     } catch {
       setSidecar(previous);
     } finally {
@@ -349,7 +499,11 @@ export function useDashboardData(apiBase: string) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ multiAgentMode: mode }),
       });
-      if (r.ok) setMaMode(mode);
+      if (r.ok) {
+        setMaMode(mode);
+        setMaModeResolved(true);
+        writeSessionListCache(`${MA_MODE_CACHE_PREFIX}${apiBase}`, mode);
+      }
     } catch { /* ignore */ }
     finally { setMaBusy(false); }
   };
@@ -518,6 +672,8 @@ export function useDashboardData(apiBase: string) {
     modelQuery, setModelQuery,
     expandedProviders, setExpandedProviders,
     health, startupHealth, providers, models, settings, sidecar, shadowCall, usage30d,
+    usageLoading: usagePoll.loading && !usage30d,
+    healthLoading: overviewPoll.loading && !health,
     sidecarSaving, shadowCallSaving, modelsLoading, settingsSaving, syncing,
     maMode, maModeResolved, maBusy, setMaHelpOpen, maHelpOpen,
     effortCapHelpOpen, setEffortCapHelpOpen, shadowCallHelpOpen, setShadowCallHelpOpen,

--- a/gui/src/pages/use-dashboard-data.ts
+++ b/gui/src/pages/use-dashboard-data.ts
@@ -108,7 +108,6 @@ export function useDashboardData(apiBase: string) {
   const [settingsSaving, setSettingsSaving] = useState(false);
   const [syncing, setSyncing] = useState(false);
   const [maMode, setMaMode] = useState<MaMode>(() => cachedMaMode ?? "default");
-  const [maModeResolved, setMaModeResolved] = useState(() => cachedMaMode !== null);
   const [maBusy, setMaBusy] = useState(false);
   const [maHelpOpen, setMaHelpOpen] = useState(false);
   const [effortCapHelpOpen, setEffortCapHelpOpen] = useState(false);
@@ -284,9 +283,12 @@ export function useDashboardData(apiBase: string) {
   useEffect(() => {
     if (maModePoll.data === undefined) return;
     setMaMode(maModePoll.data.maMode);
-    setMaModeResolved(true);
     writeSessionListCache(`${MA_MODE_CACHE_PREFIX}${apiBase}`, maModePoll.data.maMode);
   }, [maModePoll.data, apiBase]);
+
+  // Derived — avoids setState-on-prop-change for the resolved flag. Cache / poll / optimistic
+  // save (which writes the same cache key) all count as resolved for MA UI.
+  const maModeResolved = maModePoll.data !== undefined || cachedMaMode !== null;
 
   useEffect(() => {
     const data = multiAgentPoll.data;
@@ -494,7 +496,6 @@ export function useDashboardData(apiBase: string) {
       });
       if (r.ok) {
         setMaMode(mode);
-        setMaModeResolved(true);
         writeSessionListCache(`${MA_MODE_CACHE_PREFIX}${apiBase}`, mode);
       }
     } catch { /* ignore */ }

--- a/gui/src/pages/use-dashboard-data.ts
+++ b/gui/src/pages/use-dashboard-data.ts
@@ -64,20 +64,8 @@ type CachedOverview = {
 
 type MaMode = "v1" | "default" | "v2";
 
-function readCachedControls(apiBase: string): CachedControls | null {
-  try {
-    const raw = sessionStorage.getItem(`${CONTROLS_CACHE_PREFIX}${apiBase}`);
-    if (!raw) return null;
-    return JSON.parse(raw) as CachedControls;
-  } catch {
-    return null;
-  }
-}
-
-function writeCachedControls(apiBase: string, value: CachedControls) {
-  try {
-    sessionStorage.setItem(`${CONTROLS_CACHE_PREFIX}${apiBase}`, JSON.stringify(value));
-  } catch { /* private mode / quota */ }
+function controlsCacheKey(apiBase: string): string {
+  return `${CONTROLS_CACHE_PREFIX}${apiBase}`;
 }
 
 export function useDashboardData(apiBase: string) {
@@ -86,7 +74,10 @@ export function useDashboardData(apiBase: string) {
   const [selectedSection, setSelectedSection] = useState<DashboardSection>(readDashboardSectionFromHash);
   const [modelQuery, setModelQuery] = useState("");
   const [expandedProviders, setExpandedProviders] = useState<Set<string>>(new Set());
-  const cachedControls = useMemo(() => readCachedControls(apiBase), [apiBase]);
+  const cachedControls = useMemo(
+    () => readSessionListCache<CachedControls>(controlsCacheKey(apiBase)),
+    [apiBase],
+  );
   const cachedOverview = useMemo(
     () => readSessionListCache<CachedOverview>(`${OVERVIEW_CACHE_PREFIX}${apiBase}`),
     [apiBase],
@@ -281,12 +272,12 @@ export function useDashboardData(apiBase: string) {
     if (!data) return;
     if (data.health) {
       setHealth(data.health);
+      setProviders(data.providers);
       writeSessionListCache(`${OVERVIEW_CACHE_PREFIX}${apiBase}`, {
         health: data.health,
         providers: data.providers,
       });
     }
-    setProviders(data.providers);
     setError(data.error);
   }, [overviewPoll.data, apiBase]);
 
@@ -318,19 +309,19 @@ export function useDashboardData(apiBase: string) {
     const data = sidecarPoll.data;
     if (!data) return;
     setSidecar(data.sidecar);
-    setShadowCall(data.shadowCall);
-    const prev = readCachedControls(apiBase) ?? {};
-    writeCachedControls(apiBase, {
+    if (data.shadowCall !== undefined) setShadowCall(data.shadowCall);
+    const prev = readSessionListCache<CachedControls>(controlsCacheKey(apiBase)) ?? {};
+    writeSessionListCache(controlsCacheKey(apiBase), {
       ...prev,
       sidecar: data.sidecar,
-      shadowCall: data.shadowCall,
+      ...(data.shadowCall !== undefined ? { shadowCall: data.shadowCall } : {}),
     });
   }, [sidecarPoll.data, apiBase]);
 
   useEffect(() => {
     const data = settingsPoll.data;
     if (!data) return;
-    if (data.settings) setSettings(data.settings);
+    if (data.settings !== undefined) setSettings(data.settings);
     // Latest-wins: only seed from settings when no newer dedicated probe has committed
     // while this settings poll was in flight. Always merge against the live ref.
     if (
@@ -342,11 +333,13 @@ export function useDashboardData(apiBase: string) {
       startupHealthRef.current = merged;
       if (merged) writeSessionListCache(`${STARTUP_CACHE_PREFIX}${apiBase}`, merged);
     }
-    const prev = readCachedControls(apiBase) ?? {};
-    writeCachedControls(apiBase, {
-      ...prev,
-      settings: data.settings ?? undefined,
-    });
+    if (data.settings !== undefined) {
+      const prev = readSessionListCache<CachedControls>(controlsCacheKey(apiBase)) ?? {};
+      writeSessionListCache(controlsCacheKey(apiBase), {
+        ...prev,
+        settings: data.settings,
+      });
+    }
   }, [settingsPoll.data, apiBase]);
 
   useEffect(() => {
@@ -455,8 +448,8 @@ export function useDashboardData(apiBase: string) {
       });
       const data = await requireJson<SidecarData>(res, "save failed");
       setSidecar({ webSearch: data.webSearch, vision: data.vision });
-      const prev = readCachedControls(apiBase) ?? {};
-      writeCachedControls(apiBase, {
+      const prev = readSessionListCache<CachedControls>(controlsCacheKey(apiBase)) ?? {};
+      writeSessionListCache(controlsCacheKey(apiBase), {
         ...prev,
         sidecar: { webSearch: data.webSearch, vision: data.vision },
       });

--- a/gui/src/pages/use-providers-fetch.ts
+++ b/gui/src/pages/use-providers-fetch.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import type { TFn } from "../i18n/shared";
 import { readJsonIfOk, readJsonOrThrow } from "../fetch-json";
+import { writeSessionListCache } from "../session-list-cache";
 import type { OAuthStatus, ProviderQuotaReport, ProvidersConfig } from "./providers-shared";
 
 export function useProvidersFetch({
@@ -11,6 +12,7 @@ export function useProvidersFetch({
   setOauthStatus,
   setQuotaReports,
   notify,
+  configCacheKey,
 }: {
   apiBase: string;
   t: TFn;
@@ -19,56 +21,33 @@ export function useProvidersFetch({
   setOauthStatus: React.Dispatch<React.SetStateAction<Record<string, OAuthStatus>>>;
   setQuotaReports: React.Dispatch<React.SetStateAction<Record<string, ProviderQuotaReport>>>;
   notify: (msg: string, ok: boolean) => void;
+  /** Session seed key for instant Providers shell paint (no secrets — hasApiKey flags only). */
+  configCacheKey?: string;
 }) {
   const fetchConfig = useCallback(async () => {
     try {
       const res = await fetch(`${apiBase}/api/config`);
       const data = await readJsonOrThrow<ProvidersConfig>(res);
       setConfig(data ?? null);
+      if (configCacheKey && data) writeSessionListCache(configCacheKey, data);
     } catch {
       notify(t("prov.loadConfigFail"), false);
     }
-  }, [apiBase, notify, setConfig, t]);
+  }, [apiBase, configCacheKey, notify, setConfig, t]);
 
   const fetchOauth = useCallback(async () => {
     try {
+      // Codex openai status is owned by useCodexAccountPool — do not duplicate /accounts.
       const provRes = await fetch(`${apiBase}/api/oauth/providers`);
       const provData = await readJsonOrThrow<{ providers?: string[] }>(provRes);
       const provs: string[] = provData?.providers ?? [];
       setOauthProviders(provs);
-      const [oauthEntries, codexAccounts, codexActive] = await Promise.all([
-        Promise.all(provs.map(async p => {
-          const sRes = await fetch(`${apiBase}/api/oauth/status?provider=${p}`).catch(() => null);
-          const s = sRes ? (await readJsonIfOk<OAuthStatus>(sRes) ?? { loggedIn: false }) : { loggedIn: false };
-          return [p, s] as const;
-        })),
-        fetch(`${apiBase}/api/codex-auth/accounts`)
-          .then(r => readJsonIfOk<{ accounts?: Array<{ id?: string; email?: string; isMain?: boolean; hasCredential?: boolean; needsReauth?: boolean }> }>(r))
-          .catch(() => null),
-        fetch(`${apiBase}/api/codex-auth/active`)
-          .then(r => readJsonIfOk<{ activeCodexAccountId?: string | null }>(r))
-          .catch(() => null),
-      ]);
-      const next: Record<string, OAuthStatus> = Object.fromEntries(oauthEntries);
-      const accounts = codexAccounts?.accounts ?? [];
-      const main = accounts.find(a => a.isMain) ?? accounts[0];
-      const mainIsReal = !!main && !!main.email && main.email !== "Codex App login";
-      const poolLoggedIn = accounts.some(a => !a.isMain && (a.hasCredential || a.email));
-      const codexLoggedIn = mainIsReal || poolLoggedIn;
-      const codexEmail = mainIsReal ? main.email : (accounts.find(a => !a.isMain && a.email)?.email ?? undefined);
-      const activeId = codexActive?.activeCodexAccountId ?? null;
-      const activePoolAccount = activeId && activeId !== "__main__"
-        ? accounts.find(a => a.id === activeId)
-        : null;
-      const codexNeedsReauth = activePoolAccount
-        ? Boolean(activePoolAccount.needsReauth)
-        : Boolean(main?.needsReauth);
-      next.openai = {
-        loggedIn: codexLoggedIn,
-        email: codexEmail,
-        ...(codexNeedsReauth ? { needsReauth: true } : {}),
-      };
-      setOauthStatus(next);
+      const oauthEntries = await Promise.all(provs.map(async p => {
+        const sRes = await fetch(`${apiBase}/api/oauth/status?provider=${p}`).catch(() => null);
+        const s = sRes ? (await readJsonIfOk<OAuthStatus>(sRes) ?? { loggedIn: false }) : { loggedIn: false };
+        return [p, s] as const;
+      }));
+      setOauthStatus(Object.fromEntries(oauthEntries));
     } catch { /* ignore */ }
   }, [apiBase, setOauthProviders, setOauthStatus]);
 

--- a/gui/src/pages/use-providers-fetch.ts
+++ b/gui/src/pages/use-providers-fetch.ts
@@ -43,7 +43,7 @@ export function useProvidersFetch({
       const provs: string[] = provData?.providers ?? [];
       setOauthProviders(provs);
       const oauthEntries = await Promise.all(provs.map(async p => {
-        const sRes = await fetch(`${apiBase}/api/oauth/status?provider=${p}`).catch(() => null);
+        const sRes = await fetch(`${apiBase}/api/oauth/status?provider=${encodeURIComponent(p)}`).catch(() => null);
         const s = sRes ? (await readJsonIfOk<OAuthStatus>(sRes) ?? { loggedIn: false }) : { loggedIn: false };
         return [p, s] as const;
       }));

--- a/gui/src/provider-workspace/catalog.ts
+++ b/gui/src/provider-workspace/catalog.ts
@@ -15,8 +15,8 @@
  *  7. hasApiKey === true             -> ready  (key-auth with credential present)
  *  8. everything else                -> needsSetup
  *
- * Live-auth overlay: `applyActiveAccountReauth` may demote ready → needs-setup
- * when the active account needs reauth (config binning rules above unchanged).
+ * Live-auth overlay: `applyActiveAccountReauth` tags ready providers that
+ * need reauth without moving them out of the ready section (avoids rail flash).
  *
  * Tiers (three-way, interview 2026-07-17): "accounts" (the canonical OpenAI forward
  * provider), "free" (free pricing), "paid" (everything else). Accounts wins
@@ -219,8 +219,9 @@ export function buildProviderWorkspace(
 
 /**
  * Live-auth overlay: when the active account for a provider needs reauth,
- * demote that provider from ready → needs-setup. Inactive-only reauth is
- * ignored (caller must only set true for the active account).
+ * tag that provider with `activeNeedsReauth` without moving it between
+ * ready/needs-setup. Config-based section membership stays stable on first
+ * paint so live discovery cannot flash a resort of the rail.
  */
 export function applyActiveAccountReauth(
   sections: WorkspaceSections,
@@ -233,18 +234,14 @@ export function applyActiveAccountReauth(
   );
   if (demote.size === 0) return sections;
 
-  const stillReady: WorkspaceItem[] = [];
-  const needsSetup = [...sections.needsSetup];
-  for (const item of sections.ready) {
-    if (demote.has(item.name)) {
-      const demoted: WorkspaceItem = { ...item, activeNeedsReauth: true };
-      delete demoted.tier;
-      needsSetup.push(demoted);
-    } else {
-      stillReady.push(item);
-    }
-  }
-  return { ready: stillReady, needsSetup, disabled: sections.disabled };
+  const tag = (items: WorkspaceItem[]): WorkspaceItem[] =>
+    items.map(item => (demote.has(item.name) ? { ...item, activeNeedsReauth: true } : item));
+
+  return {
+    ready: tag(sections.ready),
+    needsSetup: tag(sections.needsSetup),
+    disabled: sections.disabled,
+  };
 }
 
 /** Canonical status string for a single provider — config plus optional live-auth overlay. */

--- a/gui/src/provider-workspace/usage.ts
+++ b/gui/src/provider-workspace/usage.ts
@@ -150,17 +150,24 @@ export interface AttentionItem {
 
 /**
  * Derives the list of providers that require user attention:
- * - needsSetup with activeNeedsReauth → "Active account needs re-authentication"
+ * - any section row with activeNeedsReauth → "Active account needs re-authentication"
  * - other needsSetup providers → "Missing credentials" (or override)
  * - disabled providers that have an explicit override reason in `overrideReasons`
  *
- * Ready providers are never included.
+ * Ready providers without reauth are never included.
  */
 export function buildAttentionItems(
   sections: WorkspaceSections,
   overrideReasons: Record<string, string>,
 ): AttentionItem[] {
   const items: AttentionItem[] = [];
+  for (const p of sections.ready) {
+    if (!p.activeNeedsReauth) continue;
+    items.push({
+      name: p.name,
+      reason: overrideReasons[p.name] ?? "Active account needs re-authentication",
+    });
+  }
   for (const p of sections.needsSetup) {
     const reason = p.activeNeedsReauth
       ? (overrideReasons[p.name] ?? "Active account needs re-authentication")

--- a/gui/src/startup-health-ui.ts
+++ b/gui/src/startup-health-ui.ts
@@ -25,7 +25,18 @@ export function settingsPollMayCommit(
     && started.mutation === current.mutation;
 }
 
-/** Snapshot + bump request epochs before issuing any poll fetches. */
+/** Snapshot + bump one request epoch before issuing a poll fetch. */
+export function beginPollEpoch(
+  request: { current: number },
+  mutation: { current: number },
+): SettingsPollEpoch {
+  return {
+    request: ++request.current,
+    mutation: mutation.current,
+  };
+}
+
+/** Snapshot + bump request epochs before issuing paired settings/shadow poll fetches. */
 export function beginPollEpochs(refs: {
   settingsRequest: { current: number };
   settingsMutation: { current: number };
@@ -36,14 +47,8 @@ export function beginPollEpochs(refs: {
   shadow: SettingsPollEpoch;
 } {
   return {
-    settings: {
-      request: ++refs.settingsRequest.current,
-      mutation: refs.settingsMutation.current,
-    },
-    shadow: {
-      request: ++refs.shadowRequest.current,
-      mutation: refs.shadowMutation.current,
-    },
+    settings: beginPollEpoch(refs.settingsRequest, refs.settingsMutation),
+    shadow: beginPollEpoch(refs.shadowRequest, refs.shadowMutation),
   };
 }
 

--- a/gui/src/startup-health-ui.ts
+++ b/gui/src/startup-health-ui.ts
@@ -49,6 +49,15 @@ export function beginPollEpochs(refs: {
 
 export type StartupHealthStatus = "native" | "protected" | "at-risk" | "error";
 
+/**
+ * Map a startup-health API payload to the dashboard chip status.
+ *
+ * `diagnosticStale` means the server is still refreshing (SWR fallback / expired TTL).
+ * That is NOT a hard read failure — collapsing it to "error" shows the misleading
+ * "Could not read startup protection" chip whenever the 30s cache misses.
+ * Keep the payload status (the cache already forces at-risk for local-proxy routing
+ * when stale). Reserve "error" for fetchStartupHealth hard failures only.
+ */
 export function mapStartupHealthProbe(data: {
   status?: unknown;
   diagnosticStale?: unknown;
@@ -56,20 +65,22 @@ export function mapStartupHealthProbe(data: {
   const status = data.status;
   const valid = status === "native" || status === "protected" || status === "at-risk";
   if (!valid) return null;
-  return data.diagnosticStale === true ? "error" : status;
+  return status;
 }
 
 /**
- * Settings may only seed startup health while it is still unknown.
- * After `/api/startup-health` has produced a value, it stays authoritative.
+ * Settings may only seed startup health while it is still unknown or a hard error.
+ * After `/api/startup-health` has produced a real status, it stays authoritative.
  */
 export function seedStartupHealthFromSettings(
   previous: StartupHealthStatus | null,
   seeded: { status: "native" | "protected" | "at-risk"; diagnosticStale: boolean } | null | undefined,
 ): StartupHealthStatus | null {
-  if (previous !== null) return previous;
-  if (!seeded) return null;
-  return seeded.diagnosticStale ? "error" : seeded.status;
+  if (!seeded) return previous;
+  // A prior hard "error" (or unknown) may be replaced by a settings seed; a real
+  // status from the dedicated probe must not be overwritten.
+  if (previous !== null && previous !== "error") return previous;
+  return seeded.status;
 }
 
 /** Single owner cadence for project-config diagnostics (ms). */

--- a/gui/src/styles-dashboard-workspace.css
+++ b/gui/src/styles-dashboard-workspace.css
@@ -28,6 +28,8 @@
 .dashboard-workspace-main .tbl-wrap {
   max-height: 520px;
   overflow-y: auto;
+  /* Inset table from border+surface so cells aren't flush to the frame. */
+  padding: var(--space-2);
 }
 
 .dashboard-workspace-main .tbl thead th {

--- a/gui/src/styles-dashboard-workspace.css
+++ b/gui/src/styles-dashboard-workspace.css
@@ -28,8 +28,8 @@
 .dashboard-workspace-main .tbl-wrap {
   max-height: 520px;
   overflow-y: auto;
-  /* Inset table from border+surface so cells aren't flush to the frame. */
-  padding: var(--space-2);
+  /* Side/bottom inset only — top padding on a sticky scrollport leaks rows above thead. */
+  padding: 0 var(--space-2) var(--space-2);
 }
 
 .dashboard-workspace-main .tbl thead th {

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -16,6 +16,11 @@
 @import "./styles-combos-workspace.css";
 @import "./styles-models-workspace.css";
 @import "./styles-dashboard-workspace.css";
+@import "./styles-storage-workspace.css";
+@import "./styles-subagents-workspace.css";
+@import "./styles-usage-workspace.css";
+@import "./styles-claudecode-workspace.css";
+@import "./styles-apikeys-workspace.css";
 
 :root {
   /* default: follow the OS; [data-theme] below pins color-scheme so light-dark() obeys it */
@@ -61,6 +66,9 @@
   --space-10: 40px;
   --space-12: 48px;
   --space-16: 64px;
+
+  /* Comfortable measure for prose (notices, hints, page intros) — not data tables. */
+  --prose-measure: 70ch;
 
   --radius-2xs: 4px;
   --radius: 12px;
@@ -176,6 +184,11 @@ a:hover { text-decoration-color: var(--text); }
 
 code { font-family: var(--font-code); font-size: var(--text-label); }
 .mono { font-family: var(--font-code); font-variant-numeric: tabular-nums; }
+.model-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
 
 h1, h2, h3, h4 { margin: 0; font-weight: var(--weight-semibold); letter-spacing: 0; line-height: var(--leading-tight); }
 
@@ -188,6 +201,12 @@ h1, h2, h3, h4 { margin: 0; font-weight: var(--weight-semibold); letter-spacing:
 .text-caption { font-size: var(--text-caption) !important; line-height: var(--leading-ui); }
 .text-label { font-size: var(--text-label) !important; line-height: var(--leading-ui); }
 .text-control { font-size: var(--text-control) !important; line-height: var(--leading-ui); }
+
+/* Paragraph hints/intros — measure only <p>, not toolbar spans. */
+p.muted.text-label,
+p.muted.text-control {
+  max-width: var(--prose-measure);
+}
 .text-body { font-size: var(--text-body) !important; line-height: var(--leading-body); }
 .text-subtitle { font-size: var(--text-subtitle) !important; line-height: var(--leading-tight); }
 .text-title { font-size: var(--text-title) !important; line-height: var(--leading-tight); }
@@ -265,7 +284,7 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
 .nav-entry { display: flex; align-items: center; min-width: 0; border-radius: var(--radius-sm); }
 .nav-entry .nav-item { flex: 1 1 auto; min-width: 0; }
 .nav-entry-claude {
-  padding-right: 2px;
+  padding-right: 4px;
   transition: background var(--motion-fast), color var(--motion-fast);
 }
 .nav-entry-claude:hover,
@@ -273,31 +292,12 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
 .nav-entry-claude .nav-item,
 .nav-entry-claude .nav-item:hover,
 .nav-entry-claude .nav-item.active { width: auto; background: transparent; }
+/* Use the standard flex Switch (not an absolute track/knob overlay) so the
+   knob stays vertically centered with the Claude label. */
 .nav-entry-claude .switch {
-  position: relative;
-  width: 44px;
-  height: 36px;
-  padding: 0;
-  border-color: transparent;
-  background: transparent;
+  margin-inline: 2px 4px;
 }
-.nav-entry-claude .switch::before {
-  content: "";
-  position: absolute;
-  top: 10px;
-  left: 8px;
-  width: 28px;
-  height: 16px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-pill);
-  background: var(--raised);
-  transition: background var(--motion-normal), border-color var(--motion-normal);
-}
-.nav-entry-claude .switch.on { border-color: transparent; background: transparent; }
-.nav-entry-claude .switch.on::before { border-color: var(--toggle-on-bg); background: var(--toggle-on-bg); }
-.nav-entry-claude .switch .knob { position: absolute; top: 13px; left: 11px; z-index: 1; width: 10px; height: 10px; }
-.nav-entry-claude .switch.on .knob { transform: translateX(12px); }
-.nav-entry-claude .switch:focus-visible { outline: 2px solid var(--accent-ring); outline-offset: 0; }
+.nav-entry-claude .switch:focus-visible { outline: 2px solid var(--accent-ring); outline-offset: 2px; }
 
 .sidebar-foot { margin-top: auto; padding-top: 12px; display: flex; flex-direction: column; gap: 2px; }
 
@@ -364,12 +364,11 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
 /* ---- page header ---- */
 .page-head { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 6px; }
 .page-head h2 { font-size: var(--text-title); }
-.page-sub { color: var(--muted); font-size: var(--text-body); margin: 4px 0 22px; max-width: 70ch; }
+.page-sub { color: var(--muted); font-size: var(--text-body); margin: 4px 0 22px; max-width: var(--prose-measure); }
 
-/* Page-level underline tabs (Logs & Debug). Distinct from pill .segmented filters. */
-/* Shared by Logs and Dashboard. Tabs never wrap: the strip scrolls horizontally so a
-   narrow viewport cannot push them onto a second row or squash their labels (Q7). */
-.page-tabs { display: flex; flex-wrap: nowrap; gap: 2px; border-bottom: 1px solid var(--border); margin: 2px 0 14px; overflow-x: auto; scrollbar-width: thin; }
+/* Page-level underline tabs (Logs & Debug / Dashboard). Distinct from pill .segmented filters. */
+/* Let the row take the height it needs — no horizontal scrollbar on a short tab strip. */
+.page-tabs { display: flex; flex-wrap: wrap; gap: 2px; border-bottom: 1px solid var(--border); margin: 2px 0 14px; overflow: visible; }
 .page-tab { flex: 0 0 auto; white-space: nowrap; appearance: none; background: none; border: none; border-bottom: 2px solid transparent; margin-bottom: -1px; padding: 8px 12px; color: var(--muted); cursor: pointer; font: inherit; font-size: var(--text-control); }
 .page-tab:hover { color: var(--text); }
 .page-tab--active { color: var(--text); border-bottom-color: var(--accent); font-weight: var(--weight-semibold); }
@@ -384,8 +383,113 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
   border-radius: var(--radius-xs);
   padding: 1px 4px;
 }
-.api-endpoints { display: grid; gap: 10px; margin-top: 8px; }
-.api-endpoints > div { display: grid; gap: 4px; }
+.api-endpoints {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px 12px;
+  margin-top: 8px;
+}
+.api-endpoints > div {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 4px;
+  min-width: 0;
+}
+.api-endpoints > div > .muted {
+  flex: 0 0 auto;
+  line-height: 1.3;
+}
+.api-endpoints .ocx-tooltip,
+.api-endpoints .api-endpoint-url-btn {
+  display: block !important;
+  position: relative;
+  width: 100%;
+  max-width: 100%;
+  text-align: left;
+  z-index: 1;
+  appearance: none;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+.api-endpoints .ocx-tooltip:focus-within,
+.api-endpoints .ocx-tooltip:hover,
+.api-endpoints .api-endpoint-url-btn:focus-within,
+.api-endpoints .api-endpoint-url-btn:hover {
+  z-index: 5;
+}
+.api-endpoints .api-endpoint-url {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: none;
+}
+.api-endpoints .api-endpoint-url-btn:hover .api-endpoint-url,
+.api-endpoints .api-endpoint-url-btn:focus-visible .api-endpoint-url {
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+}
+.api-example-copy-btn,
+.ocx-tooltip.api-example-copy-btn {
+  display: block;
+  position: relative;
+  width: 100%;
+  max-width: 100%;
+  appearance: none;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  z-index: 1;
+  align-items: stretch;
+}
+.api-example-copy-btn:hover,
+.api-example-copy-btn:focus-within,
+.ocx-tooltip.api-example-copy-btn:hover,
+.ocx-tooltip.api-example-copy-btn:focus-within {
+  z-index: 5;
+}
+.api-example-copy-btn .api-example-pre {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  /* Keep events so the <pre> can scroll; clicks still bubble to the copy wrapper. */
+  pointer-events: auto;
+}
+.api-example-copy-btn:hover .api-example-pre,
+.api-example-copy-btn:focus-visible .api-example-pre {
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+}/* Fixed portal tip — escapes overflow:hidden panels/columns. */
+.ocx-tooltip-bubble.api-copy-tip-fixed {
+  position: fixed;
+  z-index: var(--z-popover, 40);
+  top: 0;
+  left: 0;
+  bottom: auto;
+  right: auto;
+  transform: translate(-50%, -100%);
+  pointer-events: none;
+  width: max-content;
+  max-width: min(320px, 90vw);
+  white-space: nowrap;
+}
+@media (max-width: 720px) {
+  .api-endpoints { grid-template-columns: minmax(0, 1fr); }
+}
 .api-auth-list { display: grid; gap: 8px; margin: 0; padding-left: 1.1rem; }
 .api-auth-list li { color: var(--muted); font-size: var(--text-label); }
 .api-model-actions { display: inline-flex; align-items: center; gap: 6px; flex-wrap: wrap; }
@@ -400,6 +504,7 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
   font: inherit; font-size: var(--text-control); font-weight: var(--weight-medium); line-height: var(--leading-ui); cursor: pointer;
   border: 1px solid transparent; transition: background var(--motion-fast), border-color var(--motion-fast), opacity var(--motion-fast); white-space: nowrap;
 }
+a.btn, a.btn:hover { text-decoration: none; }
 .btn svg { width: 15px; height: 15px; }
 .btn:disabled { opacity: 0.55; cursor: default; }
 .btn-primary { background: var(--accent); color: var(--accent-ink); }
@@ -438,6 +543,20 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
 .api-panel { display: flex; flex-direction: column; gap: 10px; overflow: hidden; }
 .api-panel .panel-title { margin: 0; }
 .api-panel .muted { margin: 0; }
+.api-panel-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+}
+.api-panel-head .panel-title {
+  min-width: 0;
+}
+.api-panel-head .muted {
+  flex: 0 0 auto;
+  text-align: right;
+}
 .api-form-row { display: flex; align-items: center; gap: 8px; min-width: 0; }
 .api-form-row .input { flex: 1; min-width: 0; }
 .api-code {
@@ -604,7 +723,38 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
 .tbl tbody tr:last-child td { border-bottom: none; }
 .tbl tbody tr:hover td { background: var(--hover); }
 .tbl .num { text-align: right; font-family: var(--font-code); font-variant-numeric: tabular-nums; }
-.tbl-wrap { border: 1px solid var(--border); border-radius: var(--radius); overflow-x: auto; background: var(--surface); }
+.tbl-wrap {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow-x: auto;
+  background: var(--surface);
+  /* Inset table from border+surface — shared by all table shells. */
+  padding: var(--space-3);
+}
+/* Cap the external model catalog so long lists scroll inside the panel.
+   Flat scroller — no nested tbl-wrap card. */
+.api-models-scroll {
+  margin-top: 0.75rem;
+  min-height: 0;
+  max-height: min(360px, 50vh);
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+.api-models-scroll thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--panel, var(--raised));
+}
+.api-models-panel {
+  min-height: 0;
+}
+.awi-overview-right .api-models-panel > .input,
+.awi-overview-right .api-models-panel > .api-panel-head,
+.awi-overview-right .api-models-panel > .muted {
+  flex: 0 0 auto;
+}
+/* Models panel sizing (incl. desktop fill) lives in styles-apikeys-workspace.css. */
 
 /* ---- inputs ---- */
 .input, textarea.input {
@@ -737,7 +887,7 @@ select.input { appearance: none; }
 .faint { color: var(--faint); }
 .row { display: flex; align-items: center; gap: 10px; }
 .spread { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
-.setting-hint { font-size: var(--text-control); line-height: var(--leading-body); margin-top: 3px; }
+.setting-hint { font-size: var(--text-control); line-height: var(--leading-body); margin-top: 3px; max-width: var(--prose-measure); }
 .stack { display: flex; flex-direction: column; }
 .chip { font-family: var(--font-code); font-size: var(--text-label); line-height: var(--leading-ui); background: var(--raised); border: 1px solid var(--border); padding: 1px 7px; border-radius: var(--radius-xs); color: var(--text); }
 
@@ -745,10 +895,21 @@ select.input { appearance: none; }
 .empty svg { width: 30px; height: 30px; color: var(--faint); margin-bottom: 12px; }
 .empty .title { color: var(--text); font-weight: var(--weight-semibold); margin-bottom: 6px; }
 
-.notice { font-size: var(--text-control); line-height: var(--leading-body); padding: 9px 12px; border-radius: var(--radius-sm); margin-bottom: 14px; display: flex; align-items: center; gap: 8px; }
+.notice { font-size: var(--text-control); line-height: var(--leading-body); padding: 9px 12px; border-radius: var(--radius-sm); margin-bottom: 14px; display: flex; align-items: center; gap: 8px; max-width: var(--prose-measure); }
 .notice svg { width: 15px; height: 15px; flex-shrink: 0; }
-.notice-ok { background: var(--green-soft); color: var(--green); }
-.notice-err { background: var(--red-soft); color: var(--red); }
+/* Tone pairs: ink is a shade of the tint (not gray-on-color), AA on both themes. */
+.notice-ok {
+  background: light-dark(#ecfdf5, color-mix(in oklab, var(--green) 18%, var(--surface)));
+  color: light-dark(#065f46, #d1fae5);
+  border: 1px solid color-mix(in srgb, var(--green) 32%, transparent);
+}
+.notice-ok svg { color: var(--green); }
+.notice-err {
+  background: light-dark(#fef2f2, color-mix(in oklab, var(--red) 18%, var(--surface)));
+  color: light-dark(#991b1b, #fee2e2);
+  border: 1px solid color-mix(in srgb, var(--red) 32%, transparent);
+}
+.notice-err svg { color: var(--red); }
 
 .h-section { font-size: var(--text-control); font-weight: var(--weight-semibold); line-height: var(--leading-ui); color: var(--text); margin: 30px 0 12px; display: flex; align-items: center; gap: 8px; }
 .h-section .count { color: var(--muted); font-weight: var(--weight-medium); font-family: var(--font-code); font-size: var(--text-label); }
@@ -789,7 +950,22 @@ dialog.modal-overlay {
 dialog.modal-overlay::backdrop {
   background: transparent;
 }
-.modal-card { position: relative; z-index: 1; background: color-mix(in oklab, canvas 92%, transparent); backdrop-filter: blur(20px) saturate(1.4); -webkit-backdrop-filter: blur(20px) saturate(1.4); border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 20px; width: 100%; max-width: 520px; box-shadow: 0 8px 32px rgb(0 0 0 / 0.18); max-height: 84vh; overflow-y: auto; }
+.modal-card {
+  position: relative;
+  z-index: 1;
+  background: color-mix(in oklab, canvas 92%, transparent);
+  backdrop-filter: blur(20px) saturate(1.4);
+  -webkit-backdrop-filter: blur(20px) saturate(1.4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  width: 100%;
+  max-width: 520px;
+  /* Tight elevation with border — avoid hairline + wide soft blur (AI tell). */
+  box-shadow: var(--shadow-sm);
+  max-height: 84vh;
+  overflow-y: auto;
+}
 .modal-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
 .modal-head h3 { font-size: var(--text-subtitle); }
 
@@ -817,6 +993,97 @@ dialog.modal-overlay::backdrop {
 .section-label { font-size: var(--text-label); color: var(--muted); font-weight: var(--weight-medium); white-space: nowrap; }
 .sep-line { flex: 1; height: 1px; background: var(--border); }
 .quota-compact { padding: 2px 16px 12px; display: grid; gap: 4px; }
+/* Fixed slot so pending skeleton and real bars occupy the same vertical space.
+   Sized for two compact rows — a 1-bar plan must not shrink the card under settings. */
+.codex-account-quota-slot {
+  min-height: 58px;
+  box-sizing: border-box;
+}
+/* Display:contents so main/section/empty keep the same margins as the ready tree. */
+.codex-auth-load-skeleton {
+  display: contents;
+}
+.codex-auth-load-skeleton__main {
+  border-color: var(--border);
+}
+.codex-auth-load-skeleton__line {
+  display: inline-block;
+  height: 0.9em;
+  border-radius: 4px;
+  vertical-align: middle;
+  background: linear-gradient(90deg, var(--raised) 0%, var(--surface) 50%, var(--raised) 100%);
+  background-size: 200% 100%;
+  animation: codex-auth-skeleton-shimmer 1.2s ease-in-out infinite;
+}
+.codex-auth-load-skeleton__line--sub {
+  width: 12rem;
+  position: absolute;
+  left: 16px;
+  top: 0.35em;
+}
+.codex-auth-load-skeleton__main .card-sub {
+  position: relative;
+  min-height: calc(var(--leading-body) * 1em + 10px);
+}
+.codex-auth-load-skeleton__strut {
+  visibility: hidden;
+  display: inline-block;
+  white-space: nowrap;
+}.codex-auth-load-skeleton__empty {
+  /* Same .empty padding (56px) as the ready "no accounts" box (~141px). */
+  pointer-events: none;
+}
+.codex-auth-pool-empty {
+  /* Keep .empty's 56px padding — that is the measured ready height (~141px). */
+  box-sizing: border-box;
+}
+.openai-account-mode-banner__desc {
+  margin: 6px 0 0;
+  padding-left: 0;
+  padding-right: 0;
+}
+.openai-account-mode-banner__desc--pending {
+  visibility: hidden;
+  min-height: 1.35em;
+}
+.openai-account-mode-banner__badge-slot {
+  min-width: 4.5rem;
+  justify-content: center;
+}
+.openai-account-mode-banner__badge-slot--pending {
+  visibility: hidden;
+}.codex-ticket-badge-slot {
+  visibility: hidden;
+  pointer-events: none;
+  min-width: 2.25rem;
+  justify-content: center;
+}
+/* Pending skeletons must fit the same 58px slot as ready bars — otherwise main shrinks. */
+.quota-compact--pending {
+  height: 58px;
+  min-height: 58px;
+  max-height: 58px;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+.quota-compact--pending .quota-row--skeleton {
+  min-height: 0;
+  height: 18px;
+}
+.quota-skel {
+  display: block;
+  height: 8px;
+  border-radius: var(--radius-2xs);
+  background: linear-gradient(90deg, var(--raised) 0%, var(--surface) 50%, var(--raised) 100%);
+  background-size: 200% 100%;
+  animation: codex-auth-skeleton-shimmer 1.2s ease-in-out infinite;
+}
+.quota-skel--label { width: 28px; }
+.quota-skel--reset { width: 34px; }
+.quota-skel--day { width: 36px; }
+.quota-skel--time { width: 34px; }
+.quota-skel--bar { width: 100%; height: 5px; align-self: center; }
+.quota-skel--val { width: 28px; justify-self: end; }
 .quota-row { display: grid; grid-template-columns: minmax(34px, max-content) 34px minmax(34px, 44px) minmax(38px, 42px) minmax(58px, 1fr) minmax(30px, max-content); align-items: center; gap: 8px; min-width: 0; }
 .quota-label { font-size: var(--text-caption); color: var(--muted); font-weight: var(--weight-semibold); }
 .quota-val { font-size: var(--text-caption); font-family: var(--font-code); color: var(--text); text-align: right; }
@@ -825,6 +1092,10 @@ dialog.modal-overlay::backdrop {
 .quota-reset-time { font-size: var(--text-caption); color: var(--muted); white-space: nowrap; }
 .quota-reset-time { font-family: var(--font-code); }
 .bar { height: 5px; background: var(--raised); border-radius: var(--radius-2xs); overflow: hidden; min-width: 0; }
+<<<<<<< HEAD
+=======
+/* Full-width fill scaled on X — avoids layout thrash from animating width. */
+>>>>>>> 6cbe980c (perf(gui): progressive dashboard paint and Startup safety CLS)
 .bar-fill {
   height: 100%;
   width: 100%;
@@ -863,16 +1134,263 @@ dialog.modal-overlay::backdrop {
 .codex-auto-switch-controls > .toggle { margin-left: auto; }
 .codex-auto-switch-threshold { display: flex; flex-direction: column; align-items: flex-start; margin: 0; }
 .codex-auto-switch-threshold .field-label { margin-bottom: 4px; white-space: nowrap; }
-.codex-auto-switch-input-wrap { display: flex; align-items: center; gap: 6px; }
+/* Combined number field: value (+ optional unit) + inbound stepper share one border. */
+.codex-auto-switch-input-wrap {
+  display: inline-flex;
+  align-items: stretch;
+  gap: 0;
+  /* Stay compact inside grid/flex parents (grid blockifies inline-flex and would stretch). */
+  width: max-content;
+  max-width: 100%;
+  min-height: 32px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  overflow: hidden;
+}
+.codex-auto-switch-input-wrap:focus-within {
+  border-color: var(--accent-ring);
+  box-shadow: 0 0 0 1px var(--accent-ring);
+}
+.codex-auto-switch-input-wrap .input,
+.codex-auto-switch-input-wrap .codex-auto-switch-input {
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  height: auto;
+  min-height: 0;
+  align-self: stretch;
+}
+.codex-auto-switch-input-wrap .input:focus {
+  border-color: transparent;
+  box-shadow: none;
+}
 .codex-auto-switch-input { width: 84px; text-align: right; font-variant-numeric: tabular-nums; }
 .codex-auto-switch-input[readonly] { cursor: progress; opacity: 0.7; }
-.codex-auto-switch-unit { color: var(--muted); font-size: var(--text-control); }
+/* Hide native number spinners — we use .ocx-stepper chevrons instead. */
+.codex-auto-switch-input::-webkit-outer-spin-button,
+.codex-auto-switch-input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+.codex-auto-switch-input[type="number"] { appearance: textfield; -moz-appearance: textfield; }
+.codex-auto-switch-unit {
+  display: inline-flex;
+  align-items: center;
+  padding-right: 8px;
+  color: var(--muted);
+  font-size: var(--text-control);
+  flex: 0 0 auto;
+}
 .codex-auto-switch-feedback { flex: 1 0 100%; margin-top: -8px; color: var(--muted); font-size: var(--text-label); line-height: var(--leading-body); text-align: right; }
 .codex-auto-switch-feedback.is-error { color: var(--red); }
-.notice-warn { font-size: var(--text-label); line-height: var(--leading-body); padding: 8px 10px; border-radius: var(--radius-sm); background: var(--amber-soft); color: var(--amber); display: flex; align-items: center; gap: 6px; margin-bottom: 12px; }
-.notice-warn svg { width: 14px; height: 14px; flex-shrink: 0; }
+
+.ocx-stepper {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 0 0 auto;
+}
+.ocx-stepper__btn {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 16px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-2xs);
+  background: var(--raised);
+  color: var(--muted);
+  cursor: pointer;
+}
+.ocx-stepper__btn:hover:not(:disabled) { color: var(--text); border-color: var(--faint); }
+.ocx-stepper__btn:disabled { opacity: 0.45; cursor: not-allowed; }
+.ocx-stepper__btn:focus-visible { outline: 2px solid var(--accent-ring); outline-offset: 1px; }
+.ocx-stepper__btn svg { display: block; }
+
+/* Stepper flush inside the shared input chrome (inbound, not floating outside). */
+.codex-auto-switch-input-wrap .ocx-stepper {
+  gap: 0;
+  border-left: 1px solid var(--border);
+  align-self: stretch;
+}
+.codex-auto-switch-input-wrap .ocx-stepper__btn {
+  flex: 1 1 0;
+  width: 26px;
+  height: auto;
+  min-height: 0;
+  border: none;
+  border-radius: 0;
+  background: var(--raised);
+}
+.codex-auto-switch-input-wrap .ocx-stepper__btn + .ocx-stepper__btn {
+  border-top: 1px solid var(--border);
+}
+.codex-auto-switch-input-wrap .ocx-stepper__btn:hover:not(:disabled) {
+  background: var(--surface);
+  border-color: transparent;
+}
+.codex-auto-switch-input-wrap .ocx-stepper__btn:focus-visible {
+  outline-offset: -2px;
+  z-index: 1;
+}
+
+.codex-auth-page-head { align-items: flex-start; }
+.codex-auth-page-head__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+/* Account actions (pause / copy doctor / pause-exhausted): clearer hover than plain
+   btn-ghost on card surface — same raised-hover + faint border as icon/list cues. */
+.codex-auth-action-btn:hover:not(:disabled) {
+  background: var(--raised-hover);
+  border-color: var(--faint);
+  color: var(--text);
+}
+.codex-auth-action-btn.btn-primary:hover:not(:disabled) {
+  background: var(--accent-hover);
+  border-color: transparent;
+  color: var(--accent-ink);
+}
+.codex-auth-action-btn:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 1px;
+}
+.codex-auth-page-head__feedback {
+  min-width: 8rem;
+  max-width: 18rem;
+  min-height: calc(var(--leading-body) * 1em);
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  text-align: right;
+  font-size: var(--text-label);
+  line-height: var(--leading-body);
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.codex-auth-page-head__feedback.is-ok { color: var(--green); }
+.codex-auth-page-head__feedback.is-err { color: var(--red); }
+.codex-auth-pause-label {
+  display: inline-block;
+  text-align: center;
+}
+@keyframes codex-auth-skeleton-shimmer {
+  0% { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}
+
+.account-pool-strategy-card {
+  margin-top: 16px;
+  /* Match .card-row inset — .card itself has no padding; .card-sub expects 16px inset. */
+  padding: 14px 16px;
+  display: grid;
+  gap: 8px;
+}
+.account-pool-strategy-card > strong { display: block; margin: 0; }
+.account-pool-strategy-card > .card-sub,
+.account-pool-strategy-controls > .card-sub,
+.account-pool-strategy-controls .field .card-sub {
+  /* Already inside the padded card — don't double-indent like account-card subs. */
+  margin: 0;
+  padding: 0;
+}
+.account-pool-strategy-card__retry { justify-self: start; }
+.account-pool-strategy-card__error { color: var(--danger, #c44); }
+.account-pool-strategy-controls { margin: 0; display: grid; gap: 8px; }
+.account-pool-strategy-controls .field { display: grid; gap: 6px; margin: 0; }
+.account-pool-strategy-controls .field-label { margin-bottom: 0; }
+.account-pool-strategy-controls .custom-select { width: 100%; max-width: 100%; }
+.account-pool-strategy-controls .select-trigger {
+  width: 100%;
+  max-width: 100%;
+  justify-content: space-between;
+  border-radius: var(--radius-sm);
+}
+.account-pool-strategy-controls .select-trigger > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.api-active-keys-skeleton {
+  min-height: 96px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius);
+  background: linear-gradient(90deg, var(--raised) 0%, var(--surface) 50%, var(--raised) 100%);
+  background-size: 200% 100%;
+  animation: codex-auth-skeleton-shimmer 1.2s ease-in-out infinite;
+}
+.notice-warn {
+  font-size: var(--text-label);
+  line-height: var(--leading-body);
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  background: light-dark(#fffbeb, color-mix(in oklab, var(--amber) 20%, var(--surface)));
+  color: light-dark(#92400e, #fef3c7);
+  border: 1px solid color-mix(in srgb, var(--amber) 32%, transparent);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 12px;
+  max-width: var(--prose-measure);
+}
+.notice-warn svg { width: 14px; height: 14px; flex-shrink: 0; color: var(--amber); }
+
+.startup-runtime-notice__text,
+.startup-runtime-notice__fix code {
+  color: inherit;
+}
 
 .startup-page-sub { margin-bottom: 0; }
+.startup-page-head-actions { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+.startup-runtime-notice-slot {
+  margin-bottom: 12px;
+  min-height: 52px;
+}
+.startup-runtime-notice-slot--pending {
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--amber-soft) 45%, transparent);
+}
+.startup-runtime-notice-slot .startup-runtime-notice { margin-bottom: 0; }
+/* Match hero/panels: beat .notice / .notice-warn 70ch prose measure. */
+.notice.notice-warn.startup-page-notice {
+  max-width: none;
+  width: 100%;
+  box-sizing: border-box;
+}
+/* Message above, command+copy below. */
+.notice.notice-warn.startup-runtime-notice {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+}
+.startup-runtime-notice__text {
+  margin: 0;
+  max-width: none;
+}
+.startup-runtime-notice__fix {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+}
+.startup-runtime-notice__fix code {
+  margin: 0;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+.startup-runtime-notice__fix .btn {
+  flex: 0 0 auto;
+}
 .startup-hero { display: flex; gap: 16px; align-items: flex-start; margin-bottom: 16px; }
 .startup-hero--safe { border-color: color-mix(in srgb, var(--green) 34%, var(--border)); background: color-mix(in srgb, var(--green-soft) 64%, var(--surface)); }
 .startup-hero--risk { border-color: color-mix(in srgb, var(--amber) 40%, var(--border)); background: color-mix(in srgb, var(--amber-soft) 72%, var(--surface)); }
@@ -880,7 +1398,7 @@ dialog.modal-overlay::backdrop {
 .startup-hero-icon { width: 42px; height: 42px; border-radius: var(--radius); display: grid; place-items: center; background: var(--raised); flex: 0 0 auto; }
 .startup-hero-icon svg { width: 21px; height: 21px; }
 .startup-hero-copy h3 { margin: 10px 0 4px; font-size: var(--text-title); }
-.startup-hero-copy p { margin: 0; color: var(--muted); line-height: var(--leading-body); }
+.startup-hero-copy p { margin: 0; color: var(--muted); line-height: var(--leading-body); max-width: var(--prose-measure); }
 .startup-state-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 16px; }
 .startup-state-grid .value { font-size: var(--text-subtitle); }
 .startup-details, .startup-actions { margin-bottom: 16px; }
@@ -889,8 +1407,9 @@ dialog.modal-overlay::backdrop {
 .startup-detail-row > div { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
 .startup-detail-row > .startup-detail-actions { flex-direction: row; align-items: center; justify-content: flex-end; flex: 0 0 auto; gap: 8px; }
 .startup-detail-row span:not(.badge) { color: var(--muted); font-size: var(--text-label); line-height: var(--leading-body); }
-.startup-actions > .muted { margin: -4px 0 14px; font-size: var(--text-control); }
-.startup-tray-buttons { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 16px; }
+.startup-actions > .muted { margin: -4px 0 14px; font-size: var(--text-control); max-width: var(--prose-measure); }
+.startup-tray-buttons { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 16px; min-height: 36px; }
+.startup-tray-error { margin-top: 12px; }
 .startup-command-list { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); overflow: hidden; }
 .startup-command-row { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 12px; }
 .startup-command-row + .startup-command-row { border-top: 1px solid var(--border-soft); }
@@ -904,7 +1423,7 @@ dialog.modal-overlay::backdrop {
   .startup-detail-row { align-items: flex-start; }
   .startup-detail-row > .startup-detail-actions { flex-direction: column; align-items: flex-end; }
 }
-.modal-desc { font-size: var(--text-control); line-height: var(--leading-body); color: var(--muted); margin-bottom: 14px; }
+.modal-desc { font-size: var(--text-control); line-height: var(--leading-body); color: var(--muted); margin-bottom: 14px; max-width: var(--prose-measure); }
 .modal-actions { display: flex; gap: 8px; margin-top: 16px; }
 .modal-actions .btn { flex: 1; }
 
@@ -919,13 +1438,102 @@ dialog.modal-overlay::backdrop {
 table.logs-table { min-width: 960px; }
 .log-col-rate { min-width: 7ch; white-space: nowrap; }
 .log-col-cost { min-width: 10ch; white-space: nowrap; }
-.log-status-cell { display: inline-flex; flex-direction: column; align-items: flex-start; gap: 2px; min-width: 7ch; line-height: var(--leading-tight); }
+.log-status-cell { display: inline-flex; flex-direction: column; align-items: flex-start; gap: var(--space-0-5); min-width: 7ch; line-height: var(--leading-tight); }
 .log-detail-btn {
   background: none; border: none; padding: 0; cursor: pointer;
   color: var(--accent-hover); font: inherit; font-size: var(--text-caption); text-decoration: underline;
   white-space: nowrap;
 }
-.log-detail-grid { display: grid; grid-template-columns: max-content minmax(0, 1fr); gap: 6px 14px; font-size: var(--text-control); }
+
+/* Logs page layout rhythm — keep spacing in CSS so virtualized rows don't flood inline px. */
+.logs-auto-refresh {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+}
+
+.logs-toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+.logs-segmented {
+  display: inline-flex;
+  border-radius: var(--radius-pill);
+  background: var(--surface-soft, var(--raised));
+  padding: var(--space-1);
+  gap: var(--space-1);
+}
+
+.logs-segmented .btn {
+  border-radius: var(--radius-pill);
+  min-width: 64px;
+  padding: var(--space-1-5) var(--space-3);
+  border: none;
+}
+
+.logs-filter-field {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.logs-filter-field .input {
+  min-width: 220px;
+  max-width: 360px;
+}
+
+.logs-conversation-totals {
+  margin-bottom: var(--space-3);
+}
+
+.logs-table-wrap {
+  overflow-y: auto;
+  max-height: calc(100vh - 260px);
+}
+
+.logs-table thead {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--surface);
+}
+
+.logs-virtual-spacer {
+  padding: 0;
+  border: 0;
+}
+
+.logs-stack-end {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--space-0-5);
+}
+
+.logs-stack-start {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-0-5);
+}
+
+.logs-model-cell {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.logs-detail-info {
+  margin-left: var(--space-2);
+}
+
+.log-detail-grid { display: grid; grid-template-columns: max-content minmax(0, 1fr); gap: var(--space-2) var(--space-3); font-size: var(--text-control); }
 .log-detail-break { word-break: break-all; }
 .log-detail-card { max-width: 760px; }
 .log-detail-section { padding: 14px 0; border-top: 1px solid var(--border-soft); }
@@ -1172,7 +1780,7 @@ button.prov-account-row.active { cursor: default; }
 .heatmap-legend .heatmap-cell { width: 10px; height: 10px; }
 .heatmap-tip { position: fixed; z-index: 10; transform: translate(-50%, -100%) translateY(-8px); pointer-events: none;
   background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 6px 10px;
-  box-shadow: 0 6px 20px rgba(0,0,0,0.35); white-space: nowrap; font-size: var(--text-label); }
+  box-shadow: var(--shadow-sm); white-space: nowrap; font-size: var(--text-label); }
 .heatmap-tip-date { font-weight: var(--weight-semibold); color: var(--text); margin-bottom: 2px; }
 .heatmap-tip-val { color: var(--text); font-variant-numeric: tabular-nums; }
 .heatmap-tip-req { font-size: var(--text-caption); }
@@ -1183,14 +1791,26 @@ button.prov-account-row.active { cursor: default; }
 .daybars { display: grid; grid-template-columns: repeat(7, 1fr); gap: 10px; align-items: end; height: 180px; padding-top: 8px; }
 .daybar { position: relative; display: flex; flex-direction: column; align-items: center; gap: 6px; height: 100%; justify-content: flex-end; }
 .daybar-track { width: 100%; max-width: 48px; flex: 1; display: flex; align-items: flex-end; background: var(--border); border-radius: var(--radius-xs); overflow: hidden; }
-.daybar-stack { width: 100%; display: flex; flex-direction: column-reverse; border-radius: var(--radius-xs) var(--radius-xs) 0 0; overflow: hidden; min-height: 2px; transition: height var(--motion-normal) ease; }
+/* Full-height stack scaled on Y — avoids layout thrash from animating height. */
+.daybar-stack {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column-reverse;
+  border-radius: var(--radius-xs) var(--radius-xs) 0 0;
+  overflow: hidden;
+  min-height: 2px;
+  transform: scaleY(var(--daybar-scale, 0));
+  transform-origin: bottom center;
+  transition: transform var(--motion-normal) ease;
+}
 .daybar-seg { width: 100%; min-height: 1px; }
 .daybar-count { font-size: var(--text-label); font-weight: var(--weight-semibold); color: var(--text); }
 .daybar-label { font-size: var(--text-caption); white-space: nowrap; }
 .daybar:hover .daybar-track { outline: 1px solid var(--border); }
 .daybar-tip { position: absolute; bottom: calc(100% + 6px); left: 50%; transform: translateX(-50%); z-index: 5;
   background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 8px 10px;
-  min-width: 160px; box-shadow: 0 6px 20px rgba(0,0,0,0.35); pointer-events: none; }
+  min-width: 160px; box-shadow: var(--shadow-sm); pointer-events: none; }
 .daybar-tip-date { font-size: var(--text-label); font-weight: var(--weight-semibold); color: var(--text); margin-bottom: 6px; white-space: nowrap; }
 .daybar-tip-row { display: flex; align-items: center; gap: 8px; font-size: var(--text-label); line-height: var(--leading-relaxed); }
 .daybar-tip-swatch { width: 10px; height: 10px; border-radius: var(--radius-2xs); flex-shrink: 0; }
@@ -1310,8 +1930,8 @@ button.prov-account-row.active { cursor: default; }
 .claude-profile-bar {
   position: sticky; top: 12px; z-index: 8; display: flex; align-items: center; justify-content: space-between;
   gap: 12px; margin: 18px 0 16px; padding: 10px 12px; border: 1px solid var(--border);
-  border-radius: var(--radius); background: var(--glass-panel); backdrop-filter: var(--glass-blur);
-  -webkit-backdrop-filter: var(--glass-blur); box-shadow: var(--shadow-sm);
+  border-radius: var(--radius); background: var(--surface);
+  box-shadow: var(--shadow-sm);
 }
 .claude-dirty { color: var(--muted); font-size: 12.5px; font-weight: 550; }
 .claude-dirty.active { color: var(--amber); }
@@ -1338,8 +1958,16 @@ button.prov-account-row.active { cursor: default; }
 .ocx-group-name { font-size: 14px; font-weight: 600; }
 .ocx-group-count { flex-shrink: 0; color: var(--muted); font-size: 11.5px; }
 .ocx-chevron { flex-shrink: 0; align-self: center; color: var(--muted); transition: transform var(--motion-fast); }
+.claude-model-names { display: flex; flex: 1; min-width: 0; flex-direction: column; gap: 1px; }
+.claude-model-names strong { display: block; overflow: hidden; color: var(--text); font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
+.claude-model-names code {
+  display: block; overflow: hidden; color: var(--text); font-family: var(--font-code);
+  font-weight: var(--weight-semibold); font-size: var(--text-control); letter-spacing: 0;
+  text-overflow: ellipsis; white-space: nowrap;
+}
 .claude-lane-default {
-  min-width: 0; overflow: hidden; color: var(--faint); font-size: 11px;
+  min-width: 0; overflow: hidden; color: var(--faint);
+  font-family: var(--font-code); font-size: 11px; font-weight: var(--weight-semibold);
   text-overflow: ellipsis; white-space: nowrap;
 }
 .claude-default-radio { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); font-size: 11.5px; cursor: pointer; }
@@ -1348,7 +1976,7 @@ button.prov-account-row.active { cursor: default; }
 .claude-lane-models { display: flex; flex-direction: column; gap: 9px; min-height: 104px; padding: 10px; }
 /* Lane density controls: a filter that only appears once a lane is long enough to need one,
    and a pager for the tail. Same idiom as the Models page so the two dense surfaces match. */
-.claude-lane-search { width: calc(100% - 20px); margin: 0 10px; min-height: 32px; font-size: 12.5px; }
+.claude-lane-search { width: calc(100% - 20px); margin: 10px 10px 0; min-height: 32px; font-size: 12.5px; }
 .claude-lane-more { align-self: stretch; justify-content: center; }
 
 /* Grok page: read-only status for the managed fence in ~/.grok/config.toml. */
@@ -1382,9 +2010,6 @@ button.prov-account-row.active { cursor: default; }
   border: 0; background: transparent; color: inherit; cursor: pointer; text-align: left;
 }
 .claude-model-summary:hover { background: var(--hover); }
-.claude-model-names { display: flex; flex: 1; min-width: 0; flex-direction: column; gap: 1px; }
-.claude-model-names strong { display: block; overflow: hidden; color: var(--text); font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
-.claude-model-names code { display: block; overflow: hidden; color: var(--muted); font-size: 10.5px; text-overflow: ellipsis; white-space: nowrap; }
 .claude-model-context { flex-shrink: 0; color: var(--muted); font-size: 11px; }
 .claude-model-context-unknown { color: var(--faint); font-style: italic; }
 .claude-row-default { flex-shrink: 0; color: var(--green); font-size: 10.5px; font-weight: 600; }

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -16,11 +16,6 @@
 @import "./styles-combos-workspace.css";
 @import "./styles-models-workspace.css";
 @import "./styles-dashboard-workspace.css";
-@import "./styles-storage-workspace.css";
-@import "./styles-subagents-workspace.css";
-@import "./styles-usage-workspace.css";
-@import "./styles-claudecode-workspace.css";
-@import "./styles-apikeys-workspace.css";
 
 :root {
   /* default: follow the OS; [data-theme] below pins color-scheme so light-dark() obeys it */
@@ -1092,10 +1087,7 @@ dialog.modal-overlay::backdrop {
 .quota-reset-time { font-size: var(--text-caption); color: var(--muted); white-space: nowrap; }
 .quota-reset-time { font-family: var(--font-code); }
 .bar { height: 5px; background: var(--raised); border-radius: var(--radius-2xs); overflow: hidden; min-width: 0; }
-<<<<<<< HEAD
-=======
 /* Full-width fill scaled on X — avoids layout thrash from animating width. */
->>>>>>> 6cbe980c (perf(gui): progressive dashboard paint and Startup safety CLS)
 .bar-fill {
   height: 100%;
   width: 100%;
@@ -1386,7 +1378,6 @@ dialog.modal-overlay::backdrop {
   flex: 1 1 auto;
   min-width: 0;
   overflow-wrap: anywhere;
-  word-break: break-word;
 }
 .startup-runtime-notice__fix .btn {
   flex: 0 0 auto;

--- a/gui/src/styles/provider-overview-dashboard.css
+++ b/gui/src/styles/provider-overview-dashboard.css
@@ -187,6 +187,62 @@
   grid-column: 1 / -1;
   padding-left: 30px;
   padding-top: 1px;
+  min-height: 64px;
+}
+
+.pws-dashboard-section--rate-limits,
+.pws-dashboard-section--recent {
+  min-height: 180px;
+}
+
+.pws-dashboard-empty {
+  margin: 8px 0 0;
+  min-height: 3rem;
+}
+
+.pws-dashboard-row--skeleton {
+  pointer-events: none;
+  cursor: default;
+}
+
+.pws-skel {
+  display: block;
+  border-radius: var(--radius-2xs, 4px);
+  background: linear-gradient(90deg, var(--raised, #eee) 0%, var(--surface, #f7f7f7) 50%, var(--raised, #eee) 100%);
+  background-size: 200% 100%;
+  animation: codex-auth-skeleton-shimmer 1.2s ease-in-out infinite;
+}
+
+.pws-dashboard-row-icon.pws-skel {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+}
+
+.pws-skel--name {
+  width: 7rem;
+  height: 0.85rem;
+}
+
+.pws-skel--meta {
+  width: 5rem;
+  height: 0.7rem;
+  margin-top: 4px;
+}
+
+.pws-skel--count {
+  width: 4rem;
+  height: 0.75rem;
+  margin-left: auto;
+}
+
+.providers-workspace--boot {
+  min-height: 600px;
+}
+
+.providers-workspace-rail--boot {
+  min-height: 600px;
+  opacity: 0.35;
 }
 
 /* Narrow main pane / mobile: stack columns */

--- a/gui/src/styles/provider-workspace-shell.css
+++ b/gui/src/styles/provider-workspace-shell.css
@@ -342,6 +342,7 @@
 
 .providers-workspace-rail-secondary {
   min-width: 0;
+  min-height: 1.15em;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -669,7 +670,7 @@
   font-size: 0.85rem;
   color: inherit;
   cursor: pointer;
-  min-height: 48px;
+  min-height: 62px;
   transition: border-color 0.15s;
 }
 
@@ -687,7 +688,7 @@
   color: inherit;
   background: var(--bg);
   resize: vertical;
-  min-height: 48px;
+  min-height: 62px;
 }
 
 .pws-notes-textarea:focus {

--- a/gui/src/ui.tsx
+++ b/gui/src/ui.tsx
@@ -25,12 +25,12 @@ export function Notice({ tone, children }: { tone: "ok" | "err"; children: React
 
 export interface SelectOption { value: string; label: React.ReactNode }
 
-export function Select({ value, options, onChange, disabled, label, style, align, placement, dropdownStyle, portal = true, id }: {
-  value: string;
+export function Select({ value, options, onChange, disabled, label, id, style, align, placement, dropdownStyle, portal = true }: {  value: string;
   options: SelectOption[];
   onChange: (value: string) => void;
   disabled?: boolean;
   label?: string;
+  id?: string;
   style?: CSSProperties;
   align?: "left" | "right";
   placement?: "below" | "right";

--- a/gui/tests/collapse-store.test.ts
+++ b/gui/tests/collapse-store.test.ts
@@ -75,11 +75,11 @@ test("toggleInSet adds and removes without mutating its input", () => {
   expect(original.has("opus")).toBe(true);
 });
 
-test("only empty families fold by default", () => {
+test("every family folds by default", () => {
   expect([...defaultCollapsedFamilies({ opus: 23, fable: 0, sonnet: 0, haiku: 0 })].toSorted())
-    .toEqual(["fable", "haiku", "sonnet"]);
-  // Once a user fills another family it must stop folding — a fixed list would be wrong here.
+    .toEqual(["fable", "haiku", "opus", "sonnet"]);
   expect([...defaultCollapsedFamilies({ opus: 12, fable: 0, sonnet: 4, haiku: 0 })].toSorted())
-    .toEqual(["fable", "haiku"]);
-  expect(defaultCollapsedFamilies({ opus: 1, fable: 1, sonnet: 1, haiku: 1 }).size).toBe(0);
+    .toEqual(["fable", "haiku", "opus", "sonnet"]);
+  expect([...defaultCollapsedFamilies({ opus: 1, fable: 1, sonnet: 1, haiku: 1 })].toSorted())
+    .toEqual(["fable", "haiku", "opus", "sonnet"]);
 });

--- a/gui/tests/collapse-store.test.ts
+++ b/gui/tests/collapse-store.test.ts
@@ -75,11 +75,11 @@ test("toggleInSet adds and removes without mutating its input", () => {
   expect(original.has("opus")).toBe(true);
 });
 
-test("every family folds by default", () => {
+test("empty families fold by default", () => {
   expect([...defaultCollapsedFamilies({ opus: 23, fable: 0, sonnet: 0, haiku: 0 })].toSorted())
-    .toEqual(["fable", "haiku", "opus", "sonnet"]);
+    .toEqual(["fable", "haiku", "sonnet"]);
   expect([...defaultCollapsedFamilies({ opus: 12, fable: 0, sonnet: 4, haiku: 0 })].toSorted())
-    .toEqual(["fable", "haiku", "opus", "sonnet"]);
+    .toEqual(["fable", "haiku"]);
   expect([...defaultCollapsedFamilies({ opus: 1, fable: 1, sonnet: 1, haiku: 1 })].toSorted())
-    .toEqual(["fable", "haiku", "opus", "sonnet"]);
+    .toEqual([]);
 });

--- a/gui/tests/dashboard-contracts.test.ts
+++ b/gui/tests/dashboard-contracts.test.ts
@@ -14,24 +14,90 @@ test("Dashboard wires a single project-config diagnostics owner outside the sett
   expect(core.match(/diagnostics\/project-config/g)?.length ?? 0).toBe(1);
   expect(hook).toContain("fetchProjectConfigDiagnostics");
   expect(hook).toContain("PROJECT_CONFIG_DIAGNOSTICS_POLL_MS");
-  // Core poll must not own the diagnostics endpoint.
-  const coreFnStart = core.indexOf("export async function fetchDashboardCore");
-  expect(coreFnStart).toBeGreaterThan(-1);
-  const coreBody = core.slice(coreFnStart);
-  expect(coreBody).not.toContain("diagnostics/project-config");
+  // Overview poll must not own the diagnostics endpoint.
+  const overviewFnStart = core.indexOf("export async function fetchDashboardOverview");
+  expect(overviewFnStart).toBeGreaterThan(-1);
+  const overviewBody = core.slice(overviewFnStart, core.indexOf("export async function fetchDashboardMultiAgent"));
+  expect(overviewBody).not.toContain("diagnostics/project-config");
 });
 
 test("Dashboard usage polling cannot delay core health and settings", async () => {
   const core = await Bun.file(new URL("../src/pages/dashboard-core-poll.ts", import.meta.url)).text();
   const hook = await Bun.file(new URL("../src/pages/use-dashboard-data.ts", import.meta.url)).text();
-  const coreFnStart = core.indexOf("export async function fetchDashboardCore");
+  const overviewFnStart = core.indexOf("export async function fetchDashboardOverview");
   const usageFnStart = core.indexOf("export async function fetchDashboardUsage");
-  expect(coreFnStart).toBeGreaterThan(-1);
+  const sidecarsFnStart = core.indexOf("export async function fetchDashboardSidecars");
+  expect(overviewFnStart).toBeGreaterThan(-1);
   expect(usageFnStart).toBeGreaterThan(-1);
-  expect(core.slice(coreFnStart)).not.toContain("/api/usage?range=30d");
+  expect(sidecarsFnStart).toBeGreaterThan(-1);
+  expect(core.slice(overviewFnStart, core.indexOf("export async function fetchDashboardMultiAgent"))).not.toContain("/api/usage?range=30d");
+  expect(core.slice(overviewFnStart, core.indexOf("export async function fetchDashboardMultiAgent"))).not.toContain("/api/sidecar-settings");
+  expect(core.slice(overviewFnStart, core.indexOf("export async function fetchDashboardMultiAgent"))).not.toContain("/api/shadow-call-settings");
+  expect(core.slice(sidecarsFnStart)).toContain("/api/sidecar-settings");
   expect(hook).toContain("dashboard-usage:${apiBase}");
+  expect(hook).toContain("dashboard-sidecars:${apiBase}");
+  expect(hook).toContain("dashboard-overview:${apiBase}");
   expect(hook).toContain("fetchDashboardUsage(apiBase, signal)");
+  expect(hook).toContain("fetchDashboardSidecars");
+  expect(hook).toContain("fetchDashboardOverview");
   expect(hook).toMatch(/dashboard-usage:\$\{apiBase\}[\s\S]*pollMs: 60_000/);
+});
+
+test("Dashboard interactive controls load independently of health/providers", async () => {
+  const core = await Bun.file(new URL("../src/pages/dashboard-core-poll.ts", import.meta.url)).text();
+  const sidecarsFnStart = core.indexOf("export async function fetchDashboardSidecars");
+  const settingsFnStart = core.indexOf("export async function fetchDashboardSettings");
+  expect(sidecarsFnStart).toBeGreaterThan(-1);
+  expect(settingsFnStart).toBeGreaterThan(-1);
+  const sidecarsBody = core.slice(sidecarsFnStart, settingsFnStart > sidecarsFnStart ? settingsFnStart : undefined);
+  expect(sidecarsBody).toContain("/api/sidecar-settings");
+  expect(sidecarsBody).toContain("/api/shadow-call-settings");
+  expect(sidecarsBody).not.toContain("/api/settings");
+  expect(sidecarsBody).not.toContain("/healthz");
+  expect(sidecarsBody).not.toContain("/api/providers");
+  expect(sidecarsBody).not.toContain("/api/usage");
+});
+
+test("Dashboard overview status widgets do not wait on injection-model", async () => {
+  const core = await Bun.file(new URL("../src/pages/dashboard-core-poll.ts", import.meta.url)).text();
+  const hook = await Bun.file(new URL("../src/pages/use-dashboard-data.ts", import.meta.url)).text();
+  const overviewStart = core.indexOf("export async function fetchDashboardOverview");
+  const multiStart = core.indexOf("export async function fetchDashboardMultiAgent");
+  expect(overviewStart).toBeGreaterThan(-1);
+  expect(multiStart).toBeGreaterThan(overviewStart);
+  const overviewBody = core.slice(overviewStart, multiStart);
+  expect(overviewBody).toContain("/healthz");
+  expect(overviewBody).toContain("/api/providers");
+  expect(overviewBody).not.toContain("/api/injection-model");
+  expect(overviewBody).not.toContain("/api/v2");
+  expect(overviewBody).not.toContain("/api/effort-caps");
+  expect(core.slice(multiStart)).toContain("/api/injection-model");
+  expect(hook).toContain("dashboard-overview:${apiBase}");
+  expect(hook).toContain("dashboard-multi-agent:${apiBase}");
+  expect(hook).toContain("enabled: overviewReady");
+});
+
+test("Dashboard MA mode and sidecars do not wait on settings or injection", async () => {
+  const core = await Bun.file(new URL("../src/pages/dashboard-core-poll.ts", import.meta.url)).text();
+  const hook = await Bun.file(new URL("../src/pages/use-dashboard-data.ts", import.meta.url)).text();
+  const maStart = core.indexOf("export async function fetchDashboardMaMode");
+  const sidecarsStart = core.indexOf("export async function fetchDashboardSidecars");
+  const settingsStart = core.indexOf("export async function fetchDashboardSettings");
+  const overviewStart = core.indexOf("export async function fetchDashboardOverview");
+  expect(maStart).toBeGreaterThan(-1);
+  expect(sidecarsStart).toBeGreaterThan(-1);
+  expect(settingsStart).toBeGreaterThan(-1);
+  const maBody = core.slice(maStart, overviewStart > maStart ? overviewStart : undefined);
+  const sidecarsBody = core.slice(sidecarsStart, settingsStart > sidecarsStart ? settingsStart : undefined);
+  expect(maBody).toContain("/api/v2");
+  expect(maBody).not.toContain("/api/injection-model");
+  expect(maBody).not.toContain("/api/settings");
+  expect(sidecarsBody).toContain("/api/sidecar-settings");
+  expect(sidecarsBody).not.toContain("/api/settings");
+  expect(hook).toContain("dashboard-ma-mode:${apiBase}");
+  expect(hook).toContain("dashboard-sidecars:${apiBase}");
+  expect(hook).toContain("dashboard-settings:${apiBase}");
+  expect(hook).not.toContain("dashboard-controls:${apiBase}");
 });
 
 test("Dashboard workspace pane is a labelled section, not a nested main landmark", async () => {
@@ -77,4 +143,22 @@ test("Dashboard sync surfaces native subagent default warnings", async () => {
   expect(sections).toContain("syncResult.nativeSubagentDefaultsWarning");
   expect(sections).toContain('"notice-warn"');
   expect(sections).toContain("<IconAlert />");
+});
+
+test("fetchStartupHealth does not map abort into a sticky error status", async () => {
+  const { fetchStartupHealth } = await import("../src/pages/dashboard-core-poll");
+  const controller = new AbortController();
+  controller.abort();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+    if (init?.signal?.aborted) {
+      throw new DOMException("The operation was aborted.", "AbortError");
+    }
+    return Response.json({ status: "protected", diagnosticStale: false });
+  }) as typeof fetch;
+  try {
+    await expect(fetchStartupHealth("http://test", controller.signal)).rejects.toMatchObject({ name: "AbortError" });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });

--- a/gui/tests/dashboard-contracts.test.ts
+++ b/gui/tests/dashboard-contracts.test.ts
@@ -1,10 +1,23 @@
 import { expect, test } from "bun:test";
 import { en } from "../src/i18n/en";
 import { normalizeInjectionSelection } from "../src/pages/dashboard-core-poll";
-import { PROJECT_CONFIG_DIAGNOSTICS_POLL_MS } from "../src/startup-health-ui";
+import { PROJECT_CONFIG_DIAGNOSTICS_POLL_MS, beginPollEpoch, beginPollEpochs } from "../src/startup-health-ui";
 
 test("project-config diagnostics poll cadence is owned by the shared constant", () => {
   expect(PROJECT_CONFIG_DIAGNOSTICS_POLL_MS).toBe(30_000);
+});
+
+test("dashboard poll epochs share beginPollEpoch", () => {
+  const refs = {
+    settingsRequest: { current: 0 },
+    settingsMutation: { current: 2 },
+    shadowRequest: { current: 0 },
+    shadowMutation: { current: 4 },
+  };
+  const paired = beginPollEpochs(refs);
+  expect(paired.settings).toEqual({ request: 1, mutation: 2 });
+  expect(paired.shadow).toEqual({ request: 1, mutation: 4 });
+  expect(beginPollEpoch(refs.settingsRequest, refs.settingsMutation)).toEqual({ request: 2, mutation: 2 });
 });
 
 test("Dashboard wires a single project-config diagnostics owner outside the settings poll", async () => {

--- a/src/server/management/config-routes.ts
+++ b/src/server/management/config-routes.ts
@@ -229,11 +229,11 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
 
   if (url.pathname === "/api/sync" && req.method === "POST") {
     const { syncModelsToCodex } = await import("../../codex/sync");
+    const { attachStaleAppServerHint } = await import("../../codex/app-server-processes");
     const result = await syncModelsToCodex(undefined, config, null);
     return jsonResponse({
-      ...result,
+      ...attachStaleAppServerHint(result),
       ...(result.ok ? {} : { error: result.message }),
-      staleAppServerHint: "If Codex App still shows an older model list, restart its long-lived app-server process after sync.",
     }, result.ok ? 200 : 500);
   }
 

--- a/src/server/management/config-routes.ts
+++ b/src/server/management/config-routes.ts
@@ -140,16 +140,20 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
   }
 
   if (url.pathname === "/api/startup-action" && req.method === "POST") {
-    let body: { action?: unknown };
+    let body: { action?: unknown; repair?: unknown };
     try { body = await req.json(); } catch { return jsonResponse({ error: "invalid JSON body" }, 400); }
     if (!body || !["install-service", "install-shim"].includes(String(body.action))) {
       return jsonResponse({ error: "action must be install-service or install-shim" }, 400);
     }
+    if (body.repair !== undefined && typeof body.repair !== "boolean") {
+      return jsonResponse({ error: "repair must be a boolean when provided" }, 400);
+    }
     try {
       const action = body.action as StartupInstallAction;
-      const result = await (deps.runStartupInstallAction ?? runStartupInstallAction)(action);
+      const repair = body.repair === true;
+      const result = await (deps.runStartupInstallAction ?? runStartupInstallAction)(action, { repair });
       invalidateStartupHealthCache();
-      return jsonResponse({ ok: true, action, message: result.message });
+      return jsonResponse({ ok: true, action, repair, message: result.message });
     } catch (error) {
       return jsonResponse({ error: error instanceof Error ? error.message : String(error) }, 500);
     }
@@ -225,13 +229,11 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
 
   if (url.pathname === "/api/sync" && req.method === "POST") {
     const { syncModelsToCodex } = await import("../../codex/sync");
-    const { attachStaleAppServerHint } = await import("../../codex/app-server-processes");
     const result = await syncModelsToCodex(undefined, config, null);
-    // Hint only after a real catalog/cache write — never enumerate processes here
-    // (WMIC/PowerShell would block Bun's event loop on every dashboard sync).
     return jsonResponse({
-      ...attachStaleAppServerHint(result),
+      ...result,
       ...(result.ok ? {} : { error: result.message }),
+      staleAppServerHint: "If Codex App still shows an older model list, restart its long-lived app-server process after sync.",
     }, result.ok ? 200 : 500);
   }
 

--- a/src/server/management/context.ts
+++ b/src/server/management/context.ts
@@ -7,7 +7,10 @@ export interface ManagementApiDeps {
   clearThreadAccountMap?: () => void;
   clearProviderQuotaCache?: () => void;
   primeCodexPoolQuotas?: (config: OcxConfig, reason: string) => Promise<void> | void;
-  runStartupInstallAction?: (action: StartupInstallAction) => Promise<{ message: string }>;
+  runStartupInstallAction?: (
+    action: StartupInstallAction,
+    options?: { repair?: boolean },
+  ) => Promise<{ message: string }>;
 }
 
 

--- a/src/server/startup-action-control.ts
+++ b/src/server/startup-action-control.ts
@@ -106,10 +106,14 @@ export function resetStartupInstallStateForTests(): void {
   installState = { status: "idle" };
 }
 
-export function startupInstallArgv(action: StartupInstallAction): string[] {
-  return action === "install-service"
-    ? ["service", "install"]
-    : ["codex-shim", "install"];
+export function startupInstallArgv(
+  action: StartupInstallAction,
+  options?: { repair?: boolean },
+): string[] {
+  if (action === "install-service") {
+    return options?.repair ? ["service", "repair"] : ["service", "install"];
+  }
+  return ["codex-shim", "install"];
 }
 
 export interface CliInstallFailure {
@@ -152,10 +156,13 @@ export function installFailureDetail(stdout: string, stderr: string, error: Erro
   return classifyCliInstallFailure(stdout, stderr, error).detail;
 }
 
-function runCliInstall(action: StartupInstallAction): Promise<{ stdout: string; stderr: string }> {
+function runCliInstall(
+  action: StartupInstallAction,
+  options?: { repair?: boolean },
+): Promise<{ stdout: string; stderr: string }> {
   const bun = durableBunPath();
   const cli = join(import.meta.dir, "..", "cli", "index.ts");
-  const argv = [cli, ...startupInstallArgv(action)];
+  const argv = [cli, ...startupInstallArgv(action, options)];
   return new Promise((resolve, reject) => {
     execFile(bun, argv, {
       encoding: "utf8",
@@ -219,29 +226,37 @@ function applyReconciliationOutcome(
 /**
  * Execute the existing fixed CLI installer outside the proxy event loop.
  *
+ * Repair mode (`options.repair`) runs `ocx service repair` — asset rewrite + restart
+ * without Task Scheduler re-registration, so it must not enter the UAC elevation path.
+ *
  * After an elevation request timeout the lock becomes `indeterminate` until the
  * original elevated transaction completes and is reconciled. A process restart
  * clears this in-memory lock — callers must then inspect Task Scheduler reality
  * (see evaluateSchedulerInstallRestartReconciliation) before installing again.
  */
-export function runStartupInstallAction(action: StartupInstallAction): Promise<{ message: string }> {
+export function runStartupInstallAction(
+  action: StartupInstallAction,
+  options?: { repair?: boolean },
+): Promise<{ message: string }> {
   const busy = rejectIfBusy(action);
   if (busy) return Promise.reject(busy);
 
+  const repair = options?.repair === true;
   const attemptId = randomUUID();
   const startedAt = Date.now();
   installState = { status: "running", action, attemptId, startedAt };
 
   const operation = (async () => {
     try {
-      await runCliInstall(action);
+      await runCliInstall(action, { repair });
     } catch (error) {
       const code = installFailureCode(error);
       const detail = error instanceof Error ? error.message : String(error);
-      // Elevate only for a structured Task Scheduler /create access denial — never for
-      // WinSW removal, asset writes, or generic permission errors.
+      // Elevate only for fresh install + structured Task Scheduler /create access denial —
+      // never for repair, WinSW removal, asset writes, or generic permission errors.
       if (
-        action === "install-service"
+        !repair
+        && action === "install-service"
         && process.platform === "win32"
         && (code === WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER
           || isWindowsSchtasksCreateAccessDenied(detail))
@@ -276,10 +291,11 @@ export function runStartupInstallAction(action: StartupInstallAction): Promise<{
         throw error;
       }
     }
+    if (action === "install-service") {
+      return { message: repair ? "Background service repaired." : "Background service installed." };
+    }
     return {
-      message: action === "install-service"
-        ? "Background service installed."
-        : "Codex launcher shim installed.",
+      message: repair ? "Codex launcher shim repaired." : "Codex launcher shim installed.",
     };
   })();
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -944,6 +944,8 @@ function taskXmlString(value: string): string {
  * RunLevel check. Schema default is LeastPrivilege (omitted on export). Elevated
  * `schtasks /create` often rewrites the registered task to HighestAvailable even when
  * the source XML asked for LeastPrivilege — still InteractiveToken / same user.
+ * Keep accepting HighestAvailable here: rejecting it would false-fail healthy elevated
+ * installs, and windowsTaskRegistrationHealthy tests encode that contract.
  */
 function taskXmlRunLevelAcceptable(principal: string): boolean {
   if (taskXmlHasPrefixedTag(principal, "RunLevel")) return false;
@@ -1298,9 +1300,12 @@ export interface RepairServiceDeps {
   stopScheduler?: () => void;
   startScheduler?: () => void;
   writeSchedulerState?: () => void;
+  writeNativeState?: () => void;
   repairNative?: () => void | Promise<void>;
   repairLaunchd?: () => void;
   repairSystemd?: () => void;
+  /** Test seam — defaults to process.platform so Linux CI cannot hit real installSystemd. */
+  platform?: NodeJS.Platform;
 }
 
 /**
@@ -1312,6 +1317,7 @@ export interface RepairServiceDeps {
  */
 export async function repairService(deps: RepairServiceDeps = {}): Promise<void> {
   const diagnose = deps.diagnose ?? diagnoseService;
+  const platform = deps.platform ?? process.platform;
   const diag = diagnose();
   if (!diag.supported) {
     throw new Error(`Background service is unsupported (${diag.summary}).`);
@@ -1329,9 +1335,10 @@ export async function repairService(deps: RepairServiceDeps = {}): Promise<void>
   (deps.assertEnv ?? assertServiceEnvironmentMatchesInstall)();
   (deps.assertAuth ?? assertServiceAuthEnvironment)();
 
-  if (process.platform === "win32") {
+  if (platform === "win32") {
     if (diag.backend === "native") {
       await (deps.repairNative ?? (() => installWinswService(defaultWinswEntry(import.meta.dir))))();
+      (deps.writeNativeState ?? (() => writeServiceInstallState("native")))();
       return;
     }
     try { (deps.stopScheduler ?? stopWindows)(); } catch { /* not running */ }
@@ -1340,15 +1347,15 @@ export async function repairService(deps: RepairServiceDeps = {}): Promise<void>
     (deps.writeSchedulerState ?? (() => writeServiceInstallState("scheduler")))();
     return;
   }
-  if (process.platform === "darwin") {
+  if (platform === "darwin") {
     (deps.repairLaunchd ?? installLaunchd)();
     return;
   }
-  if (process.platform === "linux") {
+  if (platform === "linux") {
     (deps.repairSystemd ?? installSystemd)();
     return;
   }
-  throw new Error(`Background service repair is unsupported on ${process.platform}.`);
+  throw new Error(`Background service repair is unsupported on ${platform}.`);
 }
 
 /**

--- a/src/service.ts
+++ b/src/service.ts
@@ -355,8 +355,41 @@ function sh(cmd: string): string {
   return execSync(cmd, { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }).trim();
 }
 
+/**
+ * Decode schtasks stdout. `/query /xml` emits UTF-16LE (often with BOM) because the
+ * registered task document is UTF-16; reading that as UTF-8 makes every health check
+ * fail ("registration present but unhealthy") and rolls back a successful elevated create.
+ */
+export function decodeSchtasksOutput(buffer: Buffer): string {
+  if (buffer.length === 0) return "";
+  const bomUtf16Le = buffer.length >= 2 && buffer[0] === 0xff && buffer[1] === 0xfe;
+  const bomUtf16Be = buffer.length >= 2 && buffer[0] === 0xfe && buffer[1] === 0xff;
+  const looksUtf16Le = buffer.length >= 4
+    && buffer[1] === 0x00
+    && buffer[3] === 0x00
+    && buffer[0] !== 0x00;
+  if (bomUtf16Le || looksUtf16Le) {
+    return buffer.toString("utf16le").replace(/^\uFEFF/, "").trim();
+  }
+  if (bomUtf16Be) {
+    // Swap pairs then decode as utf16le.
+    const swapped = Buffer.alloc(buffer.length - 2);
+    for (let i = 2; i + 1 < buffer.length; i += 2) {
+      swapped[i - 2] = buffer[i + 1]!;
+      swapped[i - 1] = buffer[i]!;
+    }
+    return swapped.toString("utf16le").trim();
+  }
+  return buffer.toString("utf8").replace(/^\uFEFF/, "").trim();
+}
+
 function runFile(file: string, args: string[]): string {
-  return execFileSync(file, args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], windowsHide: true }).trim();
+  const buffer = execFileSync(file, args, {
+    encoding: "buffer",
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  }) as Buffer;
+  return decodeSchtasksOutput(buffer);
 }
 
 function windowsSchtasks(): string {
@@ -487,7 +520,9 @@ export function evaluateWindowsSchedulerInstallVerification(inputs: {
       : !assetsHealthy
         ? "Required scheduler service assets are missing."
         : !registrationHealthy
-          ? "Task Scheduler registration is present but unhealthy."
+          ? (inputs.xml.trim()
+            ? "Task Scheduler registration is present but unhealthy."
+            : "Task Scheduler task is present but its XML could not be read.")
           : nativeStatusUnknown
             ? "The Task Scheduler task was created, but OpenCodex could not verify that the native WinSW service is absent."
             : "ok";
@@ -506,9 +541,18 @@ export function evaluateWindowsSchedulerInstallVerification(inputs: {
 /** Conflict-free postcondition check for an elevated scheduler install. */
 export function verifyWindowsSchedulerInstall(taskName = TASK): WindowsSchedulerInstallVerification {
   const taskInstalled = windowsSchedulerTaskInstalled(taskName);
-  const xml = taskInstalled ? (() => {
-    try { return querySchtasks(["/query", "/tn", taskName, "/xml"]); } catch { return ""; }
-  })() : "";
+  let xml = "";
+  if (taskInstalled) {
+    try { xml = querySchtasks(["/query", "/tn", taskName, "/xml"]); } catch { xml = ""; }
+  }
+  // After elevated create, non-elevated `/query /xml` can fail or return empty while the
+  // task is still listed. Fall back to the on-disk document we registered.
+  if (taskInstalled && !xml.trim()) {
+    const diskPath = windowsTaskXmlPath();
+    if (existsSync(diskPath)) {
+      try { xml = decodeSchtasksOutput(readFileSync(diskPath)); } catch { /* keep empty */ }
+    }
+  }
   return evaluateWindowsSchedulerInstallVerification({
     taskInstalled,
     xml,
@@ -896,6 +940,20 @@ function taskXmlString(value: string): string {
     .replace(/'/g, "&apos;");
 }
 
+/**
+ * RunLevel check. Schema default is LeastPrivilege (omitted on export). Elevated
+ * `schtasks /create` often rewrites the registered task to HighestAvailable even when
+ * the source XML asked for LeastPrivilege — still InteractiveToken / same user.
+ */
+function taskXmlRunLevelAcceptable(principal: string): boolean {
+  if (taskXmlHasPrefixedTag(principal, "RunLevel")) return false;
+  const count = taskXmlElementCount(principal, "RunLevel");
+  if (count === 0) return true;
+  if (count > 1) return false;
+  const value = new RegExp(`<RunLevel(?:\\s[^>]*?)?>\\s*([^<]*?)\\s*<\\/RunLevel>`, "i").exec(principal)?.[1]?.trim().toLowerCase();
+  return value === "leastprivilege" || value === "highestavailable";
+}
+
 export function buildWindowsServiceScript(entry = cliEntry(), port = resolveServiceListenPort()): string {
   const { bun, cli } = entry;
   const bunRuntime = durableBunRuntime();
@@ -1077,7 +1135,7 @@ function taskXmlDecodedValueEquals(xml: string, tag: string, expected: string): 
   // `[^<]*` refuses nested markup, so a decoy inside a child element cannot match.
   const value = new RegExp(`<${tag}(?:\\s[^>]*?)?>([^<]*)<\\/${tag}>`, "i").exec(xml)?.[1];
   if (value === undefined) return false;
-  return taskXmlDecodeEntities(value).trim() === expected.trim();
+  return taskXmlDecodeEntities(value).trim().toLowerCase() === expected.trim().toLowerCase();
 }
 
 function taskXmlOptionalValueEquals(xml: string, tag: string, expected: string): boolean {
@@ -1113,13 +1171,14 @@ export function windowsTaskRegistrationHealthy(
   return taskXmlElementCount(triggers, "LogonTrigger") > 0
     && taskXmlOptionalValueEquals(trigger, "Enabled", "true")
     && /<LogonType>\s*InteractiveToken\s*<\/LogonType>/i.test(principal)
-    && taskXmlOptionalValueEquals(principal, "RunLevel", "LeastPrivilege")
+    && taskXmlRunLevelAcceptable(principal)
     && taskXmlOptionalValueEquals(settings, "Enabled", "true")
     && /<MultipleInstancesPolicy>\s*IgnoreNew\s*<\/MultipleInstancesPolicy>/i.test(settings)
     && /<ExecutionTimeLimit>\s*PT0S\s*<\/ExecutionTimeLimit>/i.test(settings)
     // Compare decoded VALUES, not encodings: Task Scheduler canonicalizes the
     // quotes we wrote as `&quot;` back to literal `"` on export, so an escaped
     // needle never matched and a healthy task read as permanently stale (#608).
+    // Case-insensitive: elevated `schtasks /create` may rewrite System32 casing.
     && taskXmlDecodedValueEquals(action, "Command", wscript)
     && taskXmlDecodedValueEquals(action, "Arguments", `/b /nologo "${launcher}"`);
 }
@@ -1192,10 +1251,23 @@ function writeServiceAssetWithRetry(path: string, content: string, encoding: "ut
   }
 }
 
-function installWindows(): void {
-  recordOwnedConfigPath(getConfigDir(), serviceStatePath());
+/**
+ * Rewrite on-disk scheduler assets (script/VBS/XML) without re-registering the task.
+ * Used by fresh install (before schtasks /create) and by repair (no elevation).
+ */
+function writeWindowsSchedulerAssets(): void {
   if (!existsSync(getConfigDir())) mkdirSync(getConfigDir(), { recursive: true });
   writeServiceApiTokenFile();
+  const script = windowsServiceScriptPath();
+  writeServiceAssetWithRetry(script, buildWindowsServiceScript(), "utf8");
+  // UTF-16LE + BOM: a BOM-less UTF-8 VBS mis-decodes non-ASCII (e.g. Korean) profile
+  // paths on some WSH/codepage combinations — same contract as the task XML below.
+  writeServiceAssetWithRetry(windowsLauncherVbsPath(), `\uFEFF${buildWindowsLauncherVbs(script)}`, "utf16le");
+  writeServiceAssetWithRetry(windowsTaskXmlPath(), `\uFEFF${buildWindowsTaskXml(script)}`, "utf16le");
+}
+
+function installWindows(): void {
+  recordOwnedConfigPath(getConfigDir(), serviceStatePath());
   // Transactional backend switch: installing the scheduler backend removes a native
   // service first — two live managers would both respawn the proxy (conflict).
   if (statusWinswRaw() !== "nonexistent") {
@@ -1212,15 +1284,71 @@ function installWindows(): void {
   // End a running task BEFORE rewriting the assets it is executing — cmd.exe reading the
   // script mid-rewrite runs a torn batch file, and its open handle can fail the write.
   try { stopWindows(); } catch { /* not running */ }
-  const script = windowsServiceScriptPath();
-  writeServiceAssetWithRetry(script, buildWindowsServiceScript(), "utf8");
-  // UTF-16LE + BOM: a BOM-less UTF-8 VBS mis-decodes non-ASCII (e.g. Korean) profile
-  // paths on some WSH/codepage combinations — same contract as the task XML below.
-  writeServiceAssetWithRetry(windowsLauncherVbsPath(), `\uFEFF${buildWindowsLauncherVbs(script)}`, "utf16le");
-  writeServiceAssetWithRetry(windowsTaskXmlPath(), `\uFEFF${buildWindowsTaskXml(script)}`, "utf16le");
-  schtasks(buildWindowsSchtasksCreateArgs(script));
+  writeWindowsSchedulerAssets();
+  schtasks(buildWindowsSchtasksCreateArgs(windowsServiceScriptPath()));
   schtasks(["/run", "/tn", TASK]);
   writeServiceInstallState("scheduler");
+}
+
+export interface RepairServiceDeps {
+  diagnose?: () => ServiceDiagnostic;
+  assertEnv?: () => void;
+  assertAuth?: () => void;
+  writeSchedulerAssets?: () => void;
+  stopScheduler?: () => void;
+  startScheduler?: () => void;
+  writeSchedulerState?: () => void;
+  repairNative?: () => void | Promise<void>;
+  repairLaunchd?: () => void;
+  repairSystemd?: () => void;
+}
+
+/**
+ * Repair an already-installed background service without Task Scheduler re-registration.
+ *
+ * Windows scheduler: rewrite assets + stop/start — no `schtasks /create`, no UAC.
+ * Windows native: WinSW asset rewrite + restart (skips `install /p` when present).
+ * macOS/Linux: re-run the user-level install/reload path.
+ */
+export async function repairService(deps: RepairServiceDeps = {}): Promise<void> {
+  const diagnose = deps.diagnose ?? diagnoseService;
+  const diag = diagnose();
+  if (!diag.supported) {
+    throw new Error(`Background service is unsupported (${diag.summary}).`);
+  }
+  if (diag.conflict) {
+    throw new Error(
+      "Cannot repair while Task Scheduler and native WinSW are both present. "
+        + "Run 'ocx service uninstall' then reinstall one backend with 'ocx service install'.",
+    );
+  }
+  if (!diag.installed) {
+    throw new Error("Background service is not installed. Run 'ocx service install' first.");
+  }
+
+  (deps.assertEnv ?? assertServiceEnvironmentMatchesInstall)();
+  (deps.assertAuth ?? assertServiceAuthEnvironment)();
+
+  if (process.platform === "win32") {
+    if (diag.backend === "native") {
+      await (deps.repairNative ?? (() => installWinswService(defaultWinswEntry(import.meta.dir))))();
+      return;
+    }
+    try { (deps.stopScheduler ?? stopWindows)(); } catch { /* not running */ }
+    (deps.writeSchedulerAssets ?? writeWindowsSchedulerAssets)();
+    (deps.startScheduler ?? startWindows)();
+    (deps.writeSchedulerState ?? (() => writeServiceInstallState("scheduler")))();
+    return;
+  }
+  if (process.platform === "darwin") {
+    (deps.repairLaunchd ?? installLaunchd)();
+    return;
+  }
+  if (process.platform === "linux") {
+    (deps.repairSystemd ?? installSystemd)();
+    return;
+  }
+  throw new Error(`Background service repair is unsupported on ${process.platform}.`);
 }
 
 /**
@@ -1712,6 +1840,13 @@ export async function serviceCommand(...args: (string | undefined)[]): Promise<v
     console.error("--native (WinSW) is Windows-only.");
     process.exit(1);
   }
+  if (command === "repair") {
+    assertServiceEnvironmentMatchesInstall();
+    assertServiceAuthEnvironment();
+    await repairService();
+    console.log("✅ opencodex background service repaired (assets refreshed, no Task Scheduler re-registration).");
+    return;
+  }
   // Non-install subcommands follow the backend recorded at install time (state v2).
   const backend: ServiceBackend = parsed.backend ?? (process.platform === "win32" ? readServiceBackend() : "scheduler");
   const ops = platformOps(backend);
@@ -1789,8 +1924,9 @@ export async function serviceCommand(...args: (string | undefined)[]): Promise<v
       console.log("✅ service uninstalled.");
       break;
     default:
-      console.error("Usage: ocx service [install|start|stop|status|uninstall|remove] [--native|--scheduler]");
+      console.error("Usage: ocx service [install|repair|start|stop|status|uninstall|remove] [--native|--scheduler]");
       console.error("       With no subcommand, installs/updates and starts the background service.");
+      console.error("       repair: refresh assets and restart an already-installed service (no admin re-prompt).");
       console.error("       --native (Windows only): register a real SCM service via WinSW instead of Task Scheduler.");
       process.exit(1);
   }

--- a/tests/provider-workspace-data.test.ts
+++ b/tests/provider-workspace-data.test.ts
@@ -55,15 +55,16 @@ function forwardProv(overrides: Partial<WorkspaceProvider> = {}): WorkspaceProvi
 }
 
 describe("applyActiveAccountReauth", () => {
-  test("demotes ready provider when active account needs reauth", () => {
+  test("tags ready provider when active account needs reauth without moving sections", () => {
     const sections = buildProviderWorkspace({
       anthropic: prov({ authMode: "oauth" }),
       keyed: prov({ authMode: "key", hasApiKey: true }),
     });
     expect(sections.ready.map(p => p.name)).toContain("anthropic");
     const next = applyActiveAccountReauth(sections, { anthropic: true });
-    expect(next.ready.map(p => p.name)).not.toContain("anthropic");
-    expect(next.needsSetup.map(p => p.name)).toContain("anthropic");
+    expect(next.ready.map(p => p.name)).toContain("anthropic");
+    expect(next.needsSetup.map(p => p.name)).not.toContain("anthropic");
+    expect(next.ready.find(p => p.name === "anthropic")?.activeNeedsReauth).toBe(true);
     expect(next.ready.map(p => p.name)).toContain("keyed");
   });
 
@@ -74,6 +75,7 @@ describe("applyActiveAccountReauth", () => {
     const next = applyActiveAccountReauth(sections, { anthropic: false });
     expect(next.ready.map(p => p.name)).toContain("anthropic");
     expect(next.needsSetup.map(p => p.name)).not.toContain("anthropic");
+    expect(next.ready.find(p => p.name === "anthropic")?.activeNeedsReauth).toBeUndefined();
   });
 
   test("does not move disabled providers", () => {
@@ -85,14 +87,14 @@ describe("applyActiveAccountReauth", () => {
     expect(next.needsSetup.map(p => p.name)).not.toContain("anthropic");
   });
 
-  test("demoted items carry activeNeedsReauth and binProviderStatus is needs-setup", () => {
+  test("tagged ready items keep section membership; binProviderStatus is needs-setup", () => {
     const sections = buildProviderWorkspace({
       anthropic: prov({ authMode: "oauth" }),
     });
     const next = applyActiveAccountReauth(sections, { anthropic: true });
-    const demoted = next.needsSetup.find(p => p.name === "anthropic");
-    expect(demoted?.activeNeedsReauth).toBe(true);
-    expect(binProviderStatus(demoted!)).toBe("needs-setup");
+    const tagged = next.ready.find(p => p.name === "anthropic");
+    expect(tagged?.activeNeedsReauth).toBe(true);
+    expect(binProviderStatus(tagged!)).toBe("needs-setup");
     expect(binProviderStatus(prov({ authMode: "oauth" }))).toBe("ready");
   });
 });
@@ -340,8 +342,8 @@ describe("usage: most-used and attention", () => {
     const sections = applyActiveAccountReauth(base, { anthropic: true });
     const items = buildAttentionItems(sections, {});
     expect(items).toEqual([
-      { name: "missing", reason: "Missing credentials" },
       { name: "anthropic", reason: "Active account needs re-authentication" },
+      { name: "missing", reason: "Missing credentials" },
     ]);
   });
 });

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { saveConfig } from "../src/config";
 import { windowsEnvIndirectBatchValue } from "../src/lib/win-paths";
-import { assertServiceAuthEnvironment, assertServiceEnvironmentMatchesInstall, bakedServicePathsDiagnostic, buildPlist, buildUnit, buildWindowsLauncherVbs, buildWindowsSchtasksCreateArgs, buildWindowsServiceScript, buildWindowsTaskXml, deriveWindowsServiceDiagnostic, normalizeServiceSubcommand, parseServiceInstallState, readWindowsSchedulerXmlState, resolveServiceListenPort, serviceLogPath, serviceStartableFromTray, serviceStatusSummary, windowsTaskRegistrationHealthy } from "../src/service";
+import { assertServiceAuthEnvironment, assertServiceEnvironmentMatchesInstall, bakedServicePathsDiagnostic, buildPlist, buildUnit, buildWindowsLauncherVbs, buildWindowsSchtasksCreateArgs, buildWindowsServiceScript, buildWindowsTaskXml, deriveWindowsServiceDiagnostic, normalizeServiceSubcommand, parseServiceInstallState, readWindowsSchedulerXmlState, repairService, resolveServiceListenPort, serviceLogPath, serviceStartableFromTray, serviceStatusSummary, windowsTaskRegistrationHealthy } from "../src/service";
 import { serviceApiTokenFilePath } from "../src/lib/service-secrets";
 import type { OcxConfig } from "../src/types";
 
@@ -245,7 +245,7 @@ describe("Windows service task", () => {
     for (const mutated of [
       xml.replace("<LogonTrigger>", "<BootTrigger>"),
       xml.replace("InteractiveToken", "Password"),
-      xml.replace("LeastPrivilege", "HighestAvailable"),
+      xml.replace("LeastPrivilege", "InvalidLevel"),
       xml.replace("IgnoreNew", "Parallel"),
       xml.replace(wscript, "C:\\Windows\\System32\\cmd.exe"),
       xml.replace(launcher, "C:\\Temp\\foreign.vbs"),
@@ -284,7 +284,7 @@ describe("Windows service task", () => {
     const xml = buildWindowsTaskXml("ignored.cmd", launcher)
       .replace(/<Command>.*?<\/Command>/, `<Command>${wscript}</Command>`);
     // We write `&quot;`; Task Scheduler hands the same value back with literal
-    // quotes. Comparing encodings made a healthy task read as stale forever.
+    // quotes. Comparing encodings made a healthy task read as permanently stale.
     const canonical = xml.replace(
       `<Arguments>/b /nologo &quot;${launcher}&quot;</Arguments>`,
       `<Arguments>/b /nologo "${launcher}"</Arguments>`,
@@ -338,6 +338,19 @@ describe("Windows service task", () => {
     ] as const) {
       expect(windowsTaskRegistrationHealthy(mutated, wscript, launcher), reason).toBe(false);
     }
+  });
+
+  test("accepts elevated-create rewrites (HighestAvailable, path casing, raw quotes)", () => {
+    const wscript = "C:\\Windows\\System32\\wscript.exe";
+    const launcher = "C:\\Users\\Test\\.opencodex\\service-launcher.vbs";
+    const xml = buildWindowsTaskXml("ignored.cmd", launcher)
+      .replace(/<Command>.*?<\/Command>/, `<Command>C:\\WINDOWS\\System32\\wscript.exe</Command>`)
+      .replace("<RunLevel>LeastPrivilege</RunLevel>", "<RunLevel>HighestAvailable</RunLevel>")
+      .replace(
+        `<Arguments>/b /nologo &quot;${launcher}&quot;</Arguments>`,
+        `<Arguments>/b /nologo "${launcher}"</Arguments>`,
+      );
+    expect(windowsTaskRegistrationHealthy(xml, wscript, launcher)).toBe(true);
   });
 
   test("rejects explicit unsafe values even though defaults may be omitted", () => {
@@ -610,17 +623,23 @@ describe("service lifecycle cleanup ordering", () => {
 
   test("Windows service install ends the running task before rewriting its assets, with write retry", async () => {
     const service = await readText("src/service.ts");
-    const installWindows = service.slice(service.indexOf("function installWindows()"), service.indexOf("function startWindows()"));
+    const assetsHelper = service.slice(
+      service.indexOf("function writeWindowsSchedulerAssets()"),
+      service.indexOf("function installWindows()"),
+    );
+    const installWindows = service.slice(service.indexOf("function installWindows()"), service.indexOf("async function installWindowsNative()"));
 
     const stopAt = installWindows.indexOf("stopWindows();");
-    const scriptWriteAt = installWindows.indexOf("writeServiceAssetWithRetry(script");
-    const xmlWriteAt = installWindows.indexOf("writeServiceAssetWithRetry(windowsTaskXmlPath()");
+    const assetsAt = installWindows.indexOf("writeWindowsSchedulerAssets();");
+    const createAt = installWindows.indexOf("buildWindowsSchtasksCreateArgs");
     expect(stopAt).toBeGreaterThan(-1);
-    expect(scriptWriteAt).toBeGreaterThan(-1);
-    expect(xmlWriteAt).toBeGreaterThan(-1);
-    expect(stopAt).toBeLessThan(scriptWriteAt);
-    expect(scriptWriteAt).toBeLessThan(xmlWriteAt);
+    expect(assetsAt).toBeGreaterThan(-1);
+    expect(createAt).toBeGreaterThan(-1);
+    expect(stopAt).toBeLessThan(assetsAt);
+    expect(assetsAt).toBeLessThan(createAt);
     expect(installWindows).not.toContain("writeFileSync(script");
+    expect(assetsHelper).toContain("writeServiceAssetWithRetry(script");
+    expect(assetsHelper).toContain("writeServiceAssetWithRetry(windowsTaskXmlPath()");
     // Retry helper tolerates transient Windows file locks from the just-ended task.
     expect(service).toContain('code !== "EBUSY" && code !== "EPERM" && code !== "EACCES"');
   });
@@ -771,5 +790,63 @@ describe("service diagnostics", () => {
 
     expect(statusCase).toContain("Diagnostics:");
     expect(statusCase).toContain("serviceDiagnosticsSummary()");
+  });
+});
+
+describe("service repair", () => {
+  const baseDiag = {
+    supported: true,
+    installed: true,
+    enabled: true,
+    running: true,
+    viable: false,
+    startable: true,
+    stale: true,
+    conflict: false,
+    backend: "scheduler" as const,
+    summary: "stale",
+  };
+
+  test("scheduler repair rewrites assets and restarts without schtasks create", async () => {
+    const calls: string[] = [];
+    await repairService({
+      diagnose: () => baseDiag,
+      assertEnv: () => { calls.push("env"); },
+      assertAuth: () => { calls.push("auth"); },
+      stopScheduler: () => { calls.push("stop"); },
+      writeSchedulerAssets: () => { calls.push("assets"); },
+      startScheduler: () => { calls.push("start"); },
+      writeSchedulerState: () => { calls.push("state"); },
+      repairNative: async () => { calls.push("native"); },
+    });
+    expect(calls).toEqual(["env", "auth", "stop", "assets", "start", "state"]);
+  });
+
+  test("repair rejects when nothing is installed", async () => {
+    await expect(repairService({
+      diagnose: () => ({ ...baseDiag, installed: false, backend: null, summary: "not installed" }),
+      writeSchedulerAssets: () => { throw new Error("should not write"); },
+    })).rejects.toThrow(/not installed/i);
+  });
+
+  test("repair rejects conflict without touching assets", async () => {
+    let wrote = false;
+    await expect(repairService({
+      diagnose: () => ({ ...baseDiag, conflict: true, summary: "CONFLICT" }),
+      writeSchedulerAssets: () => { wrote = true; },
+    })).rejects.toThrow(/both present/i);
+    expect(wrote).toBe(false);
+  });
+
+  test("native repair uses the WinSW repair path", async () => {
+    const calls: string[] = [];
+    await repairService({
+      diagnose: () => ({ ...baseDiag, backend: "native" }),
+      assertEnv: () => {},
+      assertAuth: () => {},
+      repairNative: async () => { calls.push("native"); },
+      writeSchedulerAssets: () => { calls.push("scheduler"); },
+    });
+    expect(calls).toEqual(["native"]);
   });
 });

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -810,6 +810,7 @@ describe("service repair", () => {
   test("scheduler repair rewrites assets and restarts without schtasks create", async () => {
     const calls: string[] = [];
     await repairService({
+      platform: "win32",
       diagnose: () => baseDiag,
       assertEnv: () => { calls.push("env"); },
       assertAuth: () => { calls.push("auth"); },
@@ -818,35 +819,43 @@ describe("service repair", () => {
       startScheduler: () => { calls.push("start"); },
       writeSchedulerState: () => { calls.push("state"); },
       repairNative: async () => { calls.push("native"); },
+      repairSystemd: () => { calls.push("systemd"); },
     });
     expect(calls).toEqual(["env", "auth", "stop", "assets", "start", "state"]);
   });
 
   test("repair rejects when nothing is installed", async () => {
     await expect(repairService({
+      platform: "win32",
       diagnose: () => ({ ...baseDiag, installed: false, backend: null, summary: "not installed" }),
       writeSchedulerAssets: () => { throw new Error("should not write"); },
+      repairSystemd: () => { throw new Error("should not install systemd"); },
     })).rejects.toThrow(/not installed/i);
   });
 
   test("repair rejects conflict without touching assets", async () => {
     let wrote = false;
     await expect(repairService({
+      platform: "win32",
       diagnose: () => ({ ...baseDiag, conflict: true, summary: "CONFLICT" }),
       writeSchedulerAssets: () => { wrote = true; },
+      repairSystemd: () => { throw new Error("should not install systemd"); },
     })).rejects.toThrow(/both present/i);
     expect(wrote).toBe(false);
   });
 
-  test("native repair uses the WinSW repair path", async () => {
+  test("native repair uses the WinSW repair path and refreshes install state", async () => {
     const calls: string[] = [];
     await repairService({
+      platform: "win32",
       diagnose: () => ({ ...baseDiag, backend: "native" }),
       assertEnv: () => {},
       assertAuth: () => {},
       repairNative: async () => { calls.push("native"); },
+      writeNativeState: () => { calls.push("native-state"); },
       writeSchedulerAssets: () => { calls.push("scheduler"); },
+      repairSystemd: () => { calls.push("systemd"); },
     });
-    expect(calls).toEqual(["native"]);
+    expect(calls).toEqual(["native", "native-state"]);
   });
 });

--- a/tests/startup-action-control-elevation.test.ts
+++ b/tests/startup-action-control-elevation.test.ts
@@ -149,6 +149,17 @@ describe("startup install elevation retry", () => {
     expect(finalizeMock).not.toHaveBeenCalled();
   });
 
+  test("does not elevate service repair even with create-access-denied marker", async () => {
+    failCli(`Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`);
+    await expect(runStartupInstallAction("install-service", { repair: true })).rejects.toThrow(
+      WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER,
+    );
+    expect(finalizeMock).not.toHaveBeenCalled();
+    expect(execFileMock).toHaveBeenCalled();
+    const argv = execFileMock.mock.calls[0]![1] as string[];
+    expect(argv.slice(-2)).toEqual(["service", "repair"]);
+  });
+
   test("does not elevate on non-Windows platforms", async () => {
     Object.defineProperty(process, "platform", { value: "linux" });
     failCli(`Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`);

--- a/tests/startup-action-control.test.ts
+++ b/tests/startup-action-control.test.ts
@@ -8,25 +8,45 @@ const config = { port: 10100, providers: {}, defaultProvider: "openai", codexAut
 describe("startup install actions", () => {
   test("maps the allowlisted actions to fixed CLI argv", () => {
     expect(startupInstallArgv("install-service")).toEqual(["service", "install"]);
+    expect(startupInstallArgv("install-service", { repair: true })).toEqual(["service", "repair"]);
     expect(startupInstallArgv("install-shim")).toEqual(["codex-shim", "install"]);
+    expect(startupInstallArgv("install-shim", { repair: true })).toEqual(["codex-shim", "install"]);
   });
 
   test("management API dispatches an allowlisted install action", async () => {
-    const calls: StartupInstallAction[] = [];
+    const calls: Array<{ action: StartupInstallAction; repair?: boolean }> = [];
     const url = new URL("http://localhost/api/startup-action");
     const response = await handleManagementAPI(new Request(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ action: "install-service" }),
     }), url, config, {
-      runStartupInstallAction: async action => {
-        calls.push(action);
+      runStartupInstallAction: async (action, options) => {
+        calls.push({ action, repair: options?.repair });
         return { message: "installed" };
       },
     });
     expect(response?.status).toBe(200);
-    expect(await response!.json()).toEqual({ ok: true, action: "install-service", message: "installed" });
-    expect(calls).toEqual(["install-service"]);
+    expect(await response!.json()).toEqual({ ok: true, action: "install-service", repair: false, message: "installed" });
+    expect(calls).toEqual([{ action: "install-service", repair: false }]);
+  });
+
+  test("management API forwards repair mode for service actions", async () => {
+    const calls: Array<{ action: StartupInstallAction; repair?: boolean }> = [];
+    const url = new URL("http://localhost/api/startup-action");
+    const response = await handleManagementAPI(new Request(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "install-service", repair: true }),
+    }), url, config, {
+      runStartupInstallAction: async (action, options) => {
+        calls.push({ action, repair: options?.repair });
+        return { message: "repaired" };
+      },
+    });
+    expect(response?.status).toBe(200);
+    expect(await response!.json()).toEqual({ ok: true, action: "install-service", repair: true, message: "repaired" });
+    expect(calls).toEqual([{ action: "install-service", repair: true }]);
   });
 
   test("rejects unknown actions before invoking the installer", async () => {

--- a/tests/startup-health-ui.test.ts
+++ b/tests/startup-health-ui.test.ts
@@ -26,16 +26,19 @@ describe("startup health UI decisions", () => {
     expect(settingsPollMayCommit(started, { request: 4, mutation: 2, mutationInFlight: true })).toBe(false);
   });
 
-  test("maps stale diagnostics to error and rejects invalid payloads", () => {
-    expect(mapStartupHealthProbe({ status: "protected", diagnosticStale: true })).toBe("error");
+  test("keeps payload status when diagnostics are stale and rejects invalid payloads", () => {
+    // diagnosticStale is SWR refresh, not a hard read failure — do not map to "error".
+    expect(mapStartupHealthProbe({ status: "protected", diagnosticStale: true })).toBe("protected");
+    expect(mapStartupHealthProbe({ status: "at-risk", diagnosticStale: true })).toBe("at-risk");
     expect(mapStartupHealthProbe({ status: "native", diagnosticStale: false })).toBe("native");
     expect(mapStartupHealthProbe({ status: "nope" })).toBeNull();
   });
 
-  test("settings may only seed while startup health is still unknown", () => {
+  test("settings may seed while unknown or hard-error, but not overwrite a real status", () => {
     expect(seedStartupHealthFromSettings(null, { status: "protected", diagnosticStale: false })).toBe("protected");
-    expect(seedStartupHealthFromSettings("error", { status: "protected", diagnosticStale: false })).toBe("error");
-    expect(seedStartupHealthFromSettings(null, { status: "at-risk", diagnosticStale: true })).toBe("error");
+    expect(seedStartupHealthFromSettings("error", { status: "protected", diagnosticStale: false })).toBe("protected");
+    expect(seedStartupHealthFromSettings(null, { status: "at-risk", diagnosticStale: true })).toBe("at-risk");
+    expect(seedStartupHealthFromSettings("at-risk", { status: "protected", diagnosticStale: false })).toBe("at-risk");
   });
 });
 

--- a/tests/windows-scheduler-install-verification.test.ts
+++ b/tests/windows-scheduler-install-verification.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   buildWindowsTaskXml,
+  decodeSchtasksOutput,
   evaluateWindowsSchedulerInstallVerification,
   probeWindowsSchedulerTask,
   setQuerySchtasksForTests,
@@ -11,6 +12,30 @@ import {
 
 afterEach(() => {
   setQuerySchtasksForTests(null);
+});
+
+describe("decodeSchtasksOutput", () => {
+  test("decodes UTF-16LE BOM XML that would fail as UTF-8", () => {
+    const xml = buildWindowsTaskXml(
+      "C:\\Users\\x\\.opencodex\\opencodex-service.cmd",
+      "C:\\Users\\x\\.opencodex\\opencodex-service-launcher.vbs",
+    );
+    const utf16 = Buffer.from(`\uFEFF${xml}`, "utf16le");
+    const decoded = decodeSchtasksOutput(utf16);
+    expect(decoded.startsWith("<?xml")).toBe(true);
+    expect(windowsTaskRegistrationHealthy(
+      decoded,
+      "C:\\WINDOWS\\System32\\wscript.exe",
+      "C:\\Users\\x\\.opencodex\\opencodex-service-launcher.vbs",
+    )).toBe(true);
+    // Sanity: the historical utf8 mis-decode is unhealthy.
+    expect(windowsTaskRegistrationHealthy(utf16.toString("utf8"))).toBe(false);
+  });
+
+  test("keeps plain UTF-8 schtasks text listings intact", () => {
+    const text = "Folder: \\\nTaskName: opencodex-proxy";
+    expect(decodeSchtasksOutput(Buffer.from(text, "utf8"))).toBe(text);
+  });
 });
 
 describe("windowsSchedulerCsvIncludesTask", () => {


### PR DESCRIPTION
## Summary
- Progressive dashboard paint: overview before injection/usage; MA mode and sidecars without waiting on settings
- Session list cache for non-secret page seeds; Startup safety CLS (reserved chrome, stale-data notice width, Repair)
- Provider workspace / service startup-action polish tied to those paths

## Stack
1. https://github.com/lidge-jun/opencodex/pull/738 — catalog cold-load
2. https://github.com/lidge-jun/opencodex/pull/739 — Codex pool hydration
3. **This PR** (base: `stack/gui-codex-pool-hydration`) — https://github.com/lidge-jun/opencodex/pull/740
4. https://github.com/lidge-jun/opencodex/pull/741 — Dense workspaces

## Test plan
- [ ] `bun test gui/tests/dashboard-contracts.test.ts gui/tests/session-list-cache.test.ts tests/startup-health-ui.test.ts tests/service.test.ts`
- [ ] Dashboard paints status/providers before slow usage/injection
- [ ] Startup does not flash empty loader / misaligned stale banner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup service and shim repair actions, including a new service repair command.
  * Added clearer startup warnings, stale-data alerts, and navigation back to the dashboard.
  * Added loading indicators, skeleton states, and empty states across dashboard and provider views.
* **Bug Fixes**
  * Preserved provider placement while highlighting accounts requiring reauthentication.
  * Improved quota and usage loading, caching, and partial-data handling.
  * Improved Windows scheduler detection and compatibility with varied output formats.
* **Style**
  * Refined dashboard layouts, spacing, tables, buttons, and responsive behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->