### PR TITLE
fix(providers): keep Antigravity catalog static

### DIFF
--- a/docs-site/src/content/docs/guides/providers.md
+++ b/docs-site/src/content/docs/guides/providers.md
@@ -86,7 +86,7 @@ ocx logout <provider>
 | `anthropic` | `anthropic` | `https://api.anthropic.com` | Claude models; live model list fetched from `/v1/models`. |
 | `kimi` | `openai-chat` | `https://api.kimi.com/coding/v1` | Kimi K2.7/K2.6/K2.5 coding models. |
 | `kiro` | `kiro` | `https://runtime.us-east-1.kiro.dev` | Initial login imports the installed, signed-in `kiro-cli` session (on Unix, install with `curl -fsSL https://cli.kiro.dev/install | bash`; on Windows PowerShell, use `irm 'https://cli.kiro.dev/install.ps1' | iex`; then run `kiro-cli login`). **Add account** logs `kiro-cli` out, starts a fresh browser login that switches the account used by `kiro-cli`, and stores account-scoped profile metadata. Existing OpenCodex accounts are preserved, and cancellation or failure restores the previous `kiro-cli` session. |
-| `google-antigravity` | `google` | `https://daily-cloudcode-pa.googleapis.com` | Google OAuth over the Cloud Code Assist wire. |
+| `google-antigravity` | `google` | `https://daily-cloudcode-pa.googleapis.com` | Google OAuth over the Cloud Code Assist wire. Uses the maintained six-model static catalog because CCA does not expose the generic `/models` endpoint. |
 | `cursor` | `cursor` | `https://api2.cursor.sh` | Experimental PKCE login, live HTTP/2 transport, and account-filtered model discovery. |
 | `github-copilot` | `openai-chat` | `https://api.githubcopilot.com` | Experimental. GitHub device flow + `copilot_internal` exchange (VS Code OAuth client). Requires an active Copilot subscription; not an official third-party API. |
 

--- a/docs-site/src/content/docs/ja/guides/providers.md
+++ b/docs-site/src/content/docs/ja/guides/providers.md
@@ -83,7 +83,7 @@ ocx logout <provider>
 | `anthropic` | `anthropic` | `https://api.anthropic.com` | Claude モデル; ライブモデル一覧は `/v1/models` から取得。 |
 | `kimi` | `openai-chat` | `https://api.kimi.com/coding/v1` | Kimi K2.7/K2.6/K2.5 コーディングモデル。 |
 | `kiro` | `kiro` | `https://runtime.us-east-1.kiro.dev` | 初回ログインは、インストール済みでサインインした `kiro-cli` セッションを取り込みます（Unix では `curl -fsSL https://cli.kiro.dev/install | bash`、Windows PowerShell では `irm 'https://cli.kiro.dev/install.ps1' | iex` でインストールしてから `kiro-cli login` を実行）。**アカウントを追加**は `kiro-cli` をログアウトして新しいブラウザログインを開始し、`kiro-cli` 自体のアカウントを切り替えてアカウント別プロファイルメタデータを保存します。既存の OpenCodex アカウントは保持され、キャンセルまたは失敗時には以前の `kiro-cli` セッションが復元されます。 |
-| `google-antigravity` | `google` | `https://daily-cloudcode-pa.googleapis.com` | Google OAuth を Cloud Code Assist wire で使用。 |
+| `google-antigravity` | `google` | `https://daily-cloudcode-pa.googleapis.com` | Google OAuth を Cloud Code Assist wire で使用。CCA は汎用 `/models` エンドポイントを公開しないため、管理された 6 モデルの静的カタログを使用します。 |
 | `cursor` | `cursor` | `https://api2.cursor.sh` | 実験的 PKCE ログイン、HTTP/2 トランスポート、アカウント別モデル探索をサポート。 |
 | `github-copilot` | `openai-chat` | `https://api.githubcopilot.com` | 実験的。GitHub デバイスフロー + `copilot_internal` 交換（VS Code OAuth クライアント）。有効な Copilot サブスクリプションが必要で、公式のサードパーティ API ではありません。 |
 

--- a/docs-site/src/content/docs/ko/guides/providers.md
+++ b/docs-site/src/content/docs/ko/guides/providers.md
@@ -83,7 +83,7 @@ ocx logout <provider>
 | `anthropic` | `anthropic` | `https://api.anthropic.com` | Claude 모델; 실시간 모델 목록은 `/v1/models`에서 가져옵니다. |
 | `kimi` | `openai-chat` | `https://api.kimi.com/coding/v1` | Kimi K2.7/K2.6/K2.5 코딩 모델. |
 | `kiro` | `kiro` | `https://runtime.us-east-1.kiro.dev` | 최초 로그인은 설치하고 로그인한 `kiro-cli` 세션을 가져옵니다(Unix에서는 `curl -fsSL https://cli.kiro.dev/install | bash`, Windows PowerShell에서는 `irm 'https://cli.kiro.dev/install.ps1' | iex`로 설치한 뒤 `kiro-cli login` 실행). **계정 추가**는 `kiro-cli`에서 로그아웃한 뒤 새 브라우저 로그인을 시작하여 `kiro-cli` 자체의 계정을 전환하고, 계정별 프로필 메타데이터를 저장합니다. 기존 OpenCodex 계정은 유지되며, 취소되거나 실패하면 이전 `kiro-cli` 세션을 복원합니다. |
-| `google-antigravity` | `google` | `https://daily-cloudcode-pa.googleapis.com` | Google OAuth를 Cloud Code Assist wire로 사용합니다. |
+| `google-antigravity` | `google` | `https://daily-cloudcode-pa.googleapis.com` | Google OAuth를 Cloud Code Assist wire로 사용합니다. CCA가 범용 `/models` 엔드포인트를 제공하지 않으므로 유지 관리되는 6개 모델 정적 카탈로그를 사용합니다. |
 | `cursor` | `cursor` | `https://api2.cursor.sh` | 실험적 PKCE 로그인, HTTP/2 전송, 계정별 모델 탐색을 지원합니다. |
 | `github-copilot` | `openai-chat` | `https://api.githubcopilot.com` | 실험적. GitHub 디바이스 플로우 + `copilot_internal` 교환(VS Code OAuth 클라이언트). 활성 Copilot 구독 필요; 공식 서드파티 API가 아닙니다. |
 

--- a/docs-site/src/content/docs/ru/guides/providers.md
+++ b/docs-site/src/content/docs/ru/guides/providers.md
@@ -89,7 +89,7 @@ ocx logout <provider>
 | `anthropic` | `anthropic` | `https://api.anthropic.com` | Модели Claude; актуальный список моделей загружается из `/v1/models`. |
 | `kimi` | `openai-chat` | `https://api.kimi.com/coding/v1` | Модели Kimi K2.7/K2.6/K2.5 для кодинга. |
 | `kiro` | `kiro` | `https://runtime.us-east-1.kiro.dev` | Первый вход импортирует существующую сессию после установки Kiro CLI (в Unix: `curl -fsSL https://cli.kiro.dev/install | bash`; в Windows PowerShell: `irm 'https://cli.kiro.dev/install.ps1' | iex`; затем выполните `kiro-cli login`). **Добавить аккаунт** выполняет выход из `kiro-cli`, запускает новый вход через браузер, переключает аккаунт самого `kiro-cli` и сохраняет метаданные профиля отдельно для каждого аккаунта. Существующие аккаунты OpenCodex сохраняются; при отмене или сбое восстанавливается предыдущая сессия `kiro-cli`. |
-| `google-antigravity` | `google` | `https://daily-cloudcode-pa.googleapis.com` | Google OAuth поверх протокола Cloud Code Assist. |
+| `google-antigravity` | `google` | `https://daily-cloudcode-pa.googleapis.com` | Google OAuth поверх протокола Cloud Code Assist. Используется поддерживаемый статический каталог из шести моделей, поскольку CCA не предоставляет общий эндпоинт `/models`. |
 | `cursor` | `cursor` | `https://api2.cursor.sh` | Экспериментальный PKCE-вход, живой транспорт HTTP/2 и обнаружение моделей с фильтрацией по аккаунту. |
 | `github-copilot` | `openai-chat` | `https://api.githubcopilot.com` | Экспериментально. Device flow GitHub + обмен `copilot_internal` (OAuth-клиент VS Code). Требуется активная подписка Copilot; это не официальный сторонний API. |
 

--- a/docs-site/src/content/docs/zh-cn/guides/providers.md
+++ b/docs-site/src/content/docs/zh-cn/guides/providers.md
@@ -77,7 +77,7 @@ ocx logout <provider>
 | `anthropic` | `anthropic` | `https://api.anthropic.com` | Claude 模型；实时模型列表从 `/v1/models` 获取。 |
 | `kimi` | `openai-chat` | `https://api.kimi.com/coding/v1` | Kimi K2.7/K2.6/K2.5 编程模型。 |
 | `kiro` | `kiro` | `https://runtime.us-east-1.kiro.dev` | 首次登录会导入已安装并已登录的 Kiro CLI 会话（Unix 使用 `curl -fsSL https://cli.kiro.dev/install | bash`；Windows PowerShell 使用 `irm 'https://cli.kiro.dev/install.ps1' | iex`；然后运行 `kiro-cli login`）。**添加账户**会先退出 `kiro-cli`，再启动新的浏览器登录，从而切换 `kiro-cli` 自身使用的账户，并保存账户范围的配置文件元数据。现有 OpenCodex 账户会保留；如果取消或失败，则恢复之前的 `kiro-cli` 会话。 |
-| `google-antigravity` | `google` | `https://daily-cloudcode-pa.googleapis.com` | 通过 Cloud Code Assist 协议使用 Google OAuth。 |
+| `google-antigravity` | `google` | `https://daily-cloudcode-pa.googleapis.com` | 通过 Cloud Code Assist 协议使用 Google OAuth。由于 CCA 不提供通用 `/models` 端点，因此使用维护中的六模型静态目录。 |
 | `cursor` | `cursor` | `https://api2.cursor.sh` | 实验性 PKCE 登录、HTTP/2 传输和按账号筛选的模型发现。 |
 | `github-copilot` | `openai-chat` | `https://api.githubcopilot.com` | 实验性。GitHub 设备流 + `copilot_internal` 交换（VS Code OAuth 客户端）。需要有效的 Copilot 订阅；不是官方第三方 API。 |
 

--- a/gui/src/components/provider-workspace/ProviderDetails.tsx
+++ b/gui/src/components/provider-workspace/ProviderDetails.tsx
@@ -98,6 +98,14 @@ export default function ProviderDetails({
   const free = useMemo(() => isFreeProvider(item), [item]);
   const local = useMemo(() => isLocalProvider(item), [item]);
   const authSurface = useMemo(() => providerAuthSurface(item), [item]);
+  const connectionIdentity = JSON.stringify([
+    codexController?.activeId ?? "",
+    accounts?.find(account => account.active)?.id ?? "",
+    keys?.find(entry => entry.active)?.id ?? "",
+    oauth?.loggedIn === undefined ? "" : String(oauth.loggedIn),
+    oauth?.needsReauth === undefined ? "" : String(oauth.needsReauth),
+    oauthEmail ?? "",
+  ]);
   const tabs = useMemo<{ id: Tab; label: string }[]>(() => [
     { id: "overview", label: t("pws.tab.overview") },
     { id: "models", label: t("pws.tab.models") },
@@ -230,6 +238,8 @@ export default function ProviderDetails({
               />
             ) : undefined}
             item={item}
+            apiBase={apiBase}
+            connectionIdentity={connectionIdentity}
             usageTotals={usageTotals}
             quotaReport={quotaReport}
             oauthEmail={oauthEmail}

--- a/gui/src/components/provider-workspace/ProviderOverview.tsx
+++ b/gui/src/components/provider-workspace/ProviderOverview.tsx
@@ -3,6 +3,7 @@
  * (STATS + Notes). Phase 030 of workspace design parity.
  */
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { readJsonOrThrow } from "../../fetch-json";
 import { useT, useI18n } from "../../i18n/shared";
 import { IconAlert, IconCheck } from "../../icons";
 import { binProviderStatus, type WorkspaceItem } from "../../provider-workspace/catalog";
@@ -12,8 +13,24 @@ import type { ProviderUsageTotals } from "./types";
 import { authModeLabel } from "./ProviderRail";
 import type { ProviderUpdatePatch } from "./types";
 
+type ConnectionTestResult = {
+  applicable?: boolean;
+  ok?: boolean;
+  latencyMs?: number;
+  reason?: string;
+  message?: string;
+  error?: string;
+};
+
+type ConnectionTestState = {
+  key: string;
+  testing: boolean;
+  result: ConnectionTestResult | null;
+};
+
 export default function ProviderOverview({
   item, usageTotals, quotaReport, oauthEmail,
+  apiBase, connectionIdentity,
   onEditSettings, onViewUsage, onUpdateProvider,
   onReauthenticate, onCancelLogin, reauthBusy = false,
   accountPanel,
@@ -22,6 +39,9 @@ export default function ProviderOverview({
   usageTotals?: ProviderUsageTotals;
   quotaReport?: ProviderQuotaReportView;
   oauthEmail?: string;
+  apiBase?: string;
+  /** Opaque active credential identity used only to invalidate stale probe results. */
+  connectionIdentity?: string;
   onEditSettings?: () => void;
   onViewUsage?: () => void;
   onUpdateProvider?: (name: string, patch: ProviderUpdatePatch) => Promise<{ ok: boolean; error?: string }>;
@@ -48,6 +68,81 @@ export default function ProviderOverview({
   const requests = usageTotals?.requests;
   const tokens = usageTotals?.totalTokens;
   const quota = accountQuotaFromReport(quotaReport);
+  const connectionProbeKey = JSON.stringify([
+    apiBase ?? null,
+    item.name,
+    item.adapter,
+    item.baseUrl,
+    item.authMode ?? null,
+    item.apiKeyTransport ?? null,
+    item.liveModels ?? null,
+    item.disabled === true,
+    item.hasApiKey === true,
+    item.hasHeaders === true,
+    item.allowPrivateNetwork === true,
+    item.keyOptional === true,
+    item.activeNeedsReauth === true,
+    connectionIdentity ?? null,
+  ]);
+  const [connectionTest, setConnectionTest] = useState<ConnectionTestState | null>(null);
+  const connectionAbortRef = useRef<{ key: string; controller: AbortController } | null>(null);
+  const testingConnection = connectionTest?.key === connectionProbeKey && connectionTest.testing;
+  const connectionResult = connectionTest?.key === connectionProbeKey ? connectionTest.result : null;
+
+  useEffect(() => {
+    return () => {
+      if (connectionAbortRef.current?.key === connectionProbeKey) {
+        connectionAbortRef.current.controller.abort();
+        connectionAbortRef.current = null;
+      }
+    };
+  }, [connectionProbeKey]);
+
+  const testConnection = useCallback(async () => {
+    if (!apiBase) return;
+    connectionAbortRef.current?.controller.abort();
+    const controller = new AbortController();
+    connectionAbortRef.current = { key: connectionProbeKey, controller };
+    setConnectionTest({ key: connectionProbeKey, testing: true, result: null });
+    try {
+      const response = await fetch(`${apiBase}/api/providers/test?name=${encodeURIComponent(item.name)}`, {
+        method: "POST",
+        signal: controller.signal,
+      });
+      const result = await readJsonOrThrow<ConnectionTestResult>(response, t("pws.connectionFailed"));
+      if (!result) throw new Error(t("pws.connectionFailed"));
+      if (!controller.signal.aborted) {
+        setConnectionTest({ key: connectionProbeKey, testing: false, result });
+      }
+    } catch (error) {
+      if (!controller.signal.aborted) {
+        setConnectionTest({
+          key: connectionProbeKey,
+          testing: false,
+          result: {
+            applicable: true,
+            ok: false,
+            error: error instanceof Error ? error.message : t("pws.connectionFailed"),
+          },
+        });
+      }
+    } finally {
+      if (connectionAbortRef.current?.controller === controller) {
+        connectionAbortRef.current = null;
+      }
+    }
+  }, [apiBase, connectionProbeKey, item.name, t]);
+
+  const connectionState = connectionResult?.applicable === false
+    ? "not-applicable"
+    : connectionResult?.ok === true
+      ? "ok"
+      : "failed";
+  const connectionText = connectionResult?.applicable === false
+    ? t("pws.connectionNotApplicable")
+    : connectionResult?.ok === true
+      ? (connectionResult.message || t("pws.connectionOk"))
+      : (connectionResult?.error || t("pws.connectionFailed"));
   return (
     <div className="pws-overview-layout">
       <div className="pws-overview-main">
@@ -82,6 +177,27 @@ export default function ProviderOverview({
             </div>
           )}
         </dl>
+        {apiBase && (
+          <div className="row" style={{ marginTop: 12, alignItems: "center" }}>
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              disabled={testingConnection}
+              onClick={() => void testConnection()}
+            >
+              {testingConnection ? t("pws.testing") : t("pws.testConnection")}
+            </button>
+            {connectionResult && (
+              <span
+                role="status"
+                className={connectionState === "ok" ? "pws-status-ok" : connectionState === "failed" ? "pws-status-warn" : "muted"}
+                data-connection-test-state={connectionState}
+              >
+                {connectionText}
+              </span>
+            )}
+          </div>
+        )}
         {onEditSettings && (
           <button type="button" className="link-btn pws-edit-settings-link" onClick={onEditSettings}>
             {t("pws.editSettings")}

--- a/gui/src/components/provider-workspace/ProviderSettings.tsx
+++ b/gui/src/components/provider-workspace/ProviderSettings.tsx
@@ -135,7 +135,10 @@ export default function ProviderSettings({
     setSaving(true);
     setMsg(null);
     try {
-      const patch: ProviderUpdatePatch = { adapter: adapter.trim(), baseUrl: nextBaseUrl, defaultModel: defaultModel.trim(), authMode, note: note.trim(), allowPrivateNetwork, liveModels };
+      const patch: ProviderUpdatePatch = { adapter: adapter.trim(), baseUrl: nextBaseUrl, defaultModel: defaultModel.trim(), authMode, note: note.trim(), allowPrivateNetwork };
+      // Keep omitted legacy values omitted unless the user actually changes this toggle.
+      // Otherwise an unrelated settings save manufactures `liveModels: true` provenance.
+      if (liveModels !== (item.liveModels !== false)) patch.liveModels = liveModels;
       if (supportsApiKeyTransport) patch.apiKeyTransport = apiKeyTransport;
       else if (item.apiKeyTransport !== undefined) patch.apiKeyTransport = "";
       const res = await onUpdateProvider(item.name, patch);

--- a/gui/src/i18n/de.ts
+++ b/gui/src/i18n/de.ts
@@ -1384,6 +1384,7 @@ export const de: Record<TKey, string> = {
   "pws.testing": "Teste…",
   "pws.connectionOk": "Verbindung OK",
   "pws.connectionFailed": "Verbindung fehlgeschlagen",
+  "pws.connectionNotApplicable": "Nicht zutreffend — dieser Anbieter verwendet einen statischen Modellkatalog.",
   "pws.editSettings": "Einstellungen bearbeiten",
   "pws.viewUsage": "Detaillierte Nutzung anzeigen",
   "pws.allSystemsOk": "Alle Systeme betriebsbereit",

--- a/gui/src/i18n/en.ts
+++ b/gui/src/i18n/en.ts
@@ -1058,6 +1058,7 @@ export const en = {
   "pws.testing": "Testing…",
   "pws.connectionOk": "Connection OK",
   "pws.connectionFailed": "Connection failed",
+  "pws.connectionNotApplicable": "Not applicable — this provider uses a static model catalog.",
   "pws.editSettings": "Edit settings",
   "pws.viewUsage": "View detailed usage",
   "pws.allSystemsOk": "All systems operational",

--- a/gui/src/i18n/ja.ts
+++ b/gui/src/i18n/ja.ts
@@ -1008,6 +1008,7 @@ export const ja: Record<TKey, string> = {
   "pws.testing": "テスト中…",
   "pws.connectionOk": "接続 OK",
   "pws.connectionFailed": "接続失敗",
+  "pws.connectionNotApplicable": "対象外 — このプロバイダーは静的モデルカタログを使用します。",
   "pws.editSettings": "設定を編集",
   "pws.viewUsage": "詳細な使用量を表示",
   "pws.allSystemsOk": "すべてのシステムが稼働中",

--- a/gui/src/i18n/ko.ts
+++ b/gui/src/i18n/ko.ts
@@ -1411,6 +1411,7 @@ export const ko: Record<TKey, string> = {
   "pws.testing": "테스트 중…",
   "pws.connectionOk": "연결 성공",
   "pws.connectionFailed": "연결 실패",
+  "pws.connectionNotApplicable": "해당 없음 — 이 프로바이더는 정적 모델 카탈로그를 사용합니다.",
   "pws.editSettings": "설정 편집",
   "pws.viewUsage": "사용량 상세 보기",
   "pws.allSystemsOk": "모든 시스템 정상",

--- a/gui/src/i18n/ru.ts
+++ b/gui/src/i18n/ru.ts
@@ -1050,6 +1050,7 @@ export const ru: Record<TKey, string> = {
   "pws.testing": "Проверка…",
   "pws.connectionOk": "Подключение успешно",
   "pws.connectionFailed": "Ошибка подключения",
+  "pws.connectionNotApplicable": "Не применимо — этот провайдер использует статический каталог моделей.",
   "pws.editSettings": "Изменить настройки",
   "pws.viewUsage": "Подробнее об использовании",
   "pws.allSystemsOk": "Все системы работают штатно",

--- a/gui/src/i18n/zh.ts
+++ b/gui/src/i18n/zh.ts
@@ -1404,6 +1404,7 @@ export const zh: Record<TKey, string> = {
   "pws.testing": "测试中…",
   "pws.connectionOk": "连接成功",
   "pws.connectionFailed": "连接失败",
+  "pws.connectionNotApplicable": "不适用 — 此提供方使用静态模型目录。",
   "pws.editSettings": "编辑设置",
   "pws.viewUsage": "查看详细用量",
   "pws.allSystemsOk": "所有系统正常运行",

--- a/gui/tests/provider-overview-notes-save.test.tsx
+++ b/gui/tests/provider-overview-notes-save.test.tsx
@@ -9,6 +9,7 @@ import type { WorkspaceItem } from "../src/provider-workspace/catalog";
 const globals = ["document", "window", "navigator", "localStorage", "IS_REACT_ACT_ENVIRONMENT"] as const;
 let previousGlobals: Record<(typeof globals)[number], unknown>;
 let testWindow: Window;
+const originalFetch = globalThis.fetch;
 
 beforeEach(() => {
   previousGlobals = Object.fromEntries(globals.map(key => [key, Reflect.get(globalThis, key)])) as typeof previousGlobals;
@@ -24,6 +25,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  globalThis.fetch = originalFetch;
   testWindow.close();
   for (const key of globals) {
     Object.defineProperty(globalThis, key, { configurable: true, value: previousGlobals[key] });
@@ -46,6 +48,8 @@ async function flush(): Promise<void> {
 async function mountOverview(
   onUpdateProvider: (name: string, patch: { note?: string }) => Promise<{ ok: boolean; error?: string }>,
   providerItem = item,
+  apiBase?: string,
+  connectionIdentity?: string,
 ): Promise<{ root: Root; container: HTMLElement }> {
   const container = document.createElement("div");
   document.body.append(container);
@@ -55,7 +59,12 @@ async function mountOverview(
     root = createRoot(container);
     root.render(
       <LanguageProvider>
-        <ProviderOverview item={providerItem} onUpdateProvider={onUpdateProvider} />
+        <ProviderOverview
+          item={providerItem}
+          apiBase={apiBase}
+          connectionIdentity={connectionIdentity}
+          onUpdateProvider={onUpdateProvider}
+        />
       </LanguageProvider>,
     );
   });
@@ -138,6 +147,126 @@ test("notes save closes editor only after an acknowledged success", async () => 
 
   expect(container.querySelector(".pws-notes-textarea")).toBeNull();
   expect(container.querySelector(".pws-notes-display")?.textContent).toContain("existing note");
+
+  await act(async () => { root.unmount(); });
+});
+
+test("static catalog connection test renders as not applicable instead of failed", async () => {
+  let requests = 0;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    requests += 1;
+    expect(String(input)).toBe("http://localhost/api/providers/test?name=google-antigravity");
+    expect(init?.method).toBe("POST");
+    return Response.json({ applicable: false, reason: "static_catalog", latencyMs: 0 });
+  }) as typeof fetch;
+  const antigravity = {
+    name: "google-antigravity",
+    adapter: "google",
+    baseUrl: "https://daily-cloudcode-pa.googleapis.com",
+    authMode: "oauth",
+    liveModels: false,
+  } as WorkspaceItem;
+
+  const { root, container } = await mountOverview(async () => ({ ok: true }), antigravity, "http://localhost");
+  const button = [...container.querySelectorAll<HTMLButtonElement>("button")]
+    .find(candidate => candidate.textContent?.includes("Test connection"));
+  expect(button).toBeTruthy();
+
+  await act(async () => {
+    button!.click();
+    await flush();
+  });
+
+  const result = container.querySelector<HTMLElement>('[data-connection-test-state="not-applicable"]');
+  expect(requests).toBe(1);
+  expect(result?.textContent).toContain("Not applicable");
+  expect(result?.classList.contains("pws-status-warn")).toBe(false);
+  expect(container.textContent).not.toContain("Connection failed");
+
+  await act(async () => { root.unmount(); });
+});
+
+test("same-provider config changes clear a rendered connection result", async () => {
+  globalThis.fetch = (async () => Response.json({
+    ok: true,
+    latencyMs: 4,
+    message: "Connected",
+  })) as typeof fetch;
+  const update = async () => ({ ok: true as const });
+  const { root, container } = await mountOverview(update, item, "http://localhost", "key:key-a");
+  const button = [...container.querySelectorAll<HTMLButtonElement>("button")]
+    .find(candidate => candidate.textContent?.includes("Test connection"))!;
+
+  await act(async () => {
+    button.click();
+    await flush();
+  });
+  expect(container.querySelector('[data-connection-test-state="ok"]')).toBeTruthy();
+
+  await act(async () => {
+    root.render(
+      <LanguageProvider>
+        <ProviderOverview
+          item={{ ...item, disabled: true }}
+          apiBase="http://localhost"
+          connectionIdentity="key:key-a"
+          onUpdateProvider={update}
+        />
+      </LanguageProvider>,
+    );
+    await flush();
+  });
+
+  expect(container.querySelector("[data-connection-test-state]")).toBeNull();
+  expect(container.textContent).not.toContain("Connected");
+
+  await act(async () => { root.unmount(); });
+});
+
+test("same-provider auth identity changes abort and ignore an in-flight result", async () => {
+  let resolveFetch!: (response: Response) => void;
+  let signal: AbortSignal | null = null;
+  globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+    signal = init?.signal ?? null;
+    return await new Promise<Response>(resolve => {
+      resolveFetch = resolve;
+    });
+  }) as typeof fetch;
+  const update = async () => ({ ok: true as const });
+  const { root, container } = await mountOverview(update, item, "http://localhost", "key:key-a");
+  const button = [...container.querySelectorAll<HTMLButtonElement>("button")]
+    .find(candidate => candidate.textContent?.includes("Test connection"))!;
+
+  await act(async () => {
+    button.click();
+    await Promise.resolve();
+  });
+  expect(button.disabled).toBe(true);
+
+  await act(async () => {
+    root.render(
+      <LanguageProvider>
+        <ProviderOverview
+          item={item}
+          apiBase="http://localhost"
+          connectionIdentity="key:key-b"
+          onUpdateProvider={update}
+        />
+      </LanguageProvider>,
+    );
+    await flush();
+  });
+
+  expect(signal?.aborted).toBe(true);
+  expect(container.querySelector("[data-connection-test-state]")).toBeNull();
+  expect(container.querySelector<HTMLButtonElement>("button")?.disabled).toBe(false);
+
+  await act(async () => {
+    resolveFetch(Response.json({ ok: true, latencyMs: 4, message: "Old result" }));
+    await flush();
+  });
+  expect(container.querySelector("[data-connection-test-state]")).toBeNull();
+  expect(container.textContent).not.toContain("Old result");
 
   await act(async () => { root.unmount(); });
 });

--- a/gui/tests/provider-settings-live-models-provenance.test.tsx
+++ b/gui/tests/provider-settings-live-models-provenance.test.tsx
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act } from "react";
+import type { Root } from "react-dom/client";
+import ProviderSettings from "../src/components/provider-workspace/ProviderSettings";
+import type { ProviderUpdatePatch } from "../src/components/provider-workspace/types";
+import { LanguageProvider } from "../src/i18n/provider";
+import type { WorkspaceItem } from "../src/provider-workspace/catalog";
+
+const globals = ["document", "window", "navigator", "localStorage", "IS_REACT_ACT_ENVIRONMENT"] as const;
+let previousGlobals: Record<(typeof globals)[number], unknown>;
+let testWindow: Window;
+
+beforeEach(() => {
+  previousGlobals = Object.fromEntries(globals.map(key => [key, Reflect.get(globalThis, key)])) as typeof previousGlobals;
+  testWindow = new Window({ url: "http://localhost/#providers/workspace" });
+  Object.defineProperty(testWindow.navigator, "language", { configurable: true, value: "en-US" });
+  Object.defineProperties(globalThis, {
+    document: { configurable: true, value: testWindow.document },
+    window: { configurable: true, value: testWindow },
+    navigator: { configurable: true, value: testWindow.navigator },
+    localStorage: { configurable: true, value: testWindow.localStorage },
+  });
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(() => {
+  testWindow.close();
+  for (const key of globals) {
+    Object.defineProperty(globalThis, key, { configurable: true, value: previousGlobals[key] });
+  }
+});
+
+function provider(liveModels?: boolean): WorkspaceItem {
+  return {
+    name: "custom-provider",
+    adapter: "openai-chat",
+    baseUrl: "https://example.test/v1",
+    authMode: "key",
+    note: "before",
+    ...(liveModels === undefined ? {} : { liveModels }),
+  } as WorkspaceItem;
+}
+
+async function mountSettings(item: WorkspaceItem): Promise<{
+  root: Root;
+  container: HTMLElement;
+  patches: ProviderUpdatePatch[];
+}> {
+  const patches: ProviderUpdatePatch[] = [];
+  const container = document.createElement("div");
+  document.body.append(container);
+  const { createRoot } = await import("react-dom/client");
+  let root!: Root;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <LanguageProvider>
+        <ProviderSettings
+          item={item}
+          onUpdateProvider={async (_name, patch) => {
+            patches.push(patch);
+            return { ok: true };
+          }}
+        />
+      </LanguageProvider>,
+    );
+  });
+  return { root, container, patches };
+}
+
+async function save(container: HTMLElement): Promise<void> {
+  const button = container.querySelector<HTMLButtonElement>(".pwi-settings-sticky-bar .btn-primary");
+  expect(button).toBeTruthy();
+  await act(async () => {
+    button!.click();
+    await Promise.resolve();
+  });
+}
+
+test("an unrelated settings save does not materialize an omitted liveModels value", async () => {
+  const { root, container, patches } = await mountSettings(provider());
+  const note = container.querySelector<HTMLTextAreaElement>(".pwi-settings-textarea")!;
+
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(testWindow.HTMLTextAreaElement.prototype, "value")!
+      .set!.call(note, "after");
+    note.dispatchEvent(new testWindow.Event("input", { bubbles: true }));
+  });
+  await save(container);
+
+  expect(patches).toHaveLength(1);
+  expect(Object.hasOwn(patches[0]!, "liveModels")).toBe(false);
+  await act(async () => { root.unmount(); });
+});
+
+test("changing an omitted effective true to false sends an explicit liveModels choice", async () => {
+  const { root, container, patches } = await mountSettings(provider());
+  const toggles = container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
+
+  await act(async () => { toggles[1]!.click(); });
+  await save(container);
+
+  expect(patches[0]?.liveModels).toBe(false);
+  await act(async () => { root.unmount(); });
+});
+
+test("changing an explicit false to true sends an explicit liveModels choice", async () => {
+  const { root, container, patches } = await mountSettings(provider(false));
+  const toggles = container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
+
+  await act(async () => { toggles[1]!.click(); });
+  await save(container);
+
+  expect(patches[0]?.liveModels).toBe(true);
+  await act(async () => { root.unmount(); });
+});

--- a/src/cli/provider-runtime.ts
+++ b/src/cli/provider-runtime.ts
@@ -69,6 +69,13 @@ async function testProvider(argv: string[], deps: RuntimeApiDeps): Promise<void>
   const result = await runtimeRequest<Record<string, unknown>>(`/api/providers/test?name=${encodeURIComponent(name)}`, {
     method: "POST",
   }, deps);
+  if (result.applicable === false) {
+    printData(result, wantsJson, [
+      `${name}: not applicable`,
+      "Static catalog; no live model-discovery endpoint to test.",
+    ]);
+    return;
+  }
   const ok = result.ok === true;
   printData(result, wantsJson, [
     `${name}: ${ok ? "connected" : "failed"}`,

--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -407,7 +407,6 @@ function boundedOwnedBy(value: unknown): string | undefined {
 
 export async function fetchProviderModels(name: string, prov: OcxProviderConfig, ttlMs: number, contextCap?: number): Promise<CatalogModel[]> {
   if (prov.authMode === "forward") return []; // ChatGPT backend has no /models
-  const apiKey = await resolveModelsAuthToken(name, prov);
   const seedVertexDefault = prov.adapter === "google"
     && prov.googleMode === "vertex"
     && (prov.models?.length ?? 0) === 0
@@ -418,6 +417,13 @@ export async function fetchProviderModels(name: string, prov: OcxProviderConfig,
     provider: name,
     ...catalogHintsFromProviderConfig(name, prov, id, contextCap),
   }));
+  // Static catalogs never need an OAuth refresh or an upstream model request. Clear any
+  // discovery failure left by an older live configuration even when the account is logged out.
+  if (prov.liveModels === false) {
+    clearProviderDiscoveryStatus(name);
+    return configured;
+  }
+  const apiKey = await resolveModelsAuthToken(name, prov);
   // A configured default is a real callable selector and must remain discoverable when a
   // compatible provider's live /models request fails (issue #308). Keep this separate from the
   // explicit static list: `liveModels: false` + empty `models[]` intentionally publishes zero
@@ -436,10 +442,6 @@ export async function fetchProviderModels(name: string, prov: OcxProviderConfig,
       : models
   );
   if (prov.adapter === "cursor") {
-    if (prov.liveModels === false) {
-      clearProviderDiscoveryStatus(name);
-      return configured;
-    }
     if (!apiKey) return configured;
     // Cursor uses a bespoke GetUsableModels RPC (not /models), returning the full effort-suffixed
     // variants this PLAN can use. Keep the base-model UX (the request builder appends the effort
@@ -472,10 +474,6 @@ export async function fetchProviderModels(name: string, prov: OcxProviderConfig,
     // No usable token (logged out, or account marked needsReauth). Still surface the
     // configured static catalog so the GUI Models tab / rail counts are not empty —
     // matching Cursor's !apiKey → configured degradation and fetch-failure fallback.
-    return configured;
-  }
-  if (prov.liveModels === false) {
-    clearProviderDiscoveryStatus(name);
     return configured;
   }
   const fresh = getFreshCached(name, ttlMs);

--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -98,7 +98,9 @@ function stableJson(value: unknown): string {
 function providerCatalogFingerprint(name: string, prov: OcxProviderConfig): Record<string, unknown> {
   return {
     n: name,
-    live: prov.liveModels !== false,
+    // Preserve the persisted tri-state. Registry enrichment may turn an omitted value into
+    // `false` while an explicit `true` stays live, so those callers must not share a flight.
+    live: prov.liveModels ?? null,
     base: prov.baseUrl ?? "",
     adapter: prov.adapter ?? "",
     models: [...(prov.models ?? [])].sort(),

--- a/src/config.ts
+++ b/src/config.ts
@@ -760,6 +760,9 @@ const configSchema = z.object({
   providers: z.record(z.string(), providerConfigSchema),
   defaultProvider: z.string().min(1).default("openai"),
   openaiProviderTierVersion: z.union([z.literal(1), z.literal(2)]).optional(),
+  // Invalid hand edits must not discard an otherwise usable config. Treat them as
+  // pre-migration so startup can safely re-run the one-time normalization.
+  googleAntigravityStaticCatalogVersion: z.literal(1).optional().catch(undefined),
   providerContextCaps: z.record(z.string(), z.number().int().positive()).optional(),
   contextCapValue: z.number().int().positive().optional(),
   multiAgentGuidanceEnabled: z.boolean().optional(),
@@ -1457,9 +1460,20 @@ function appOwnedMemoryBudgetError(value: unknown): string | null {
   return null;
 }
 
+function googleAntigravityStaticCatalogVersionError(value: unknown): string | null {
+  const raw = rawConfigRecord(value);
+  if (!raw || !Object.hasOwn(raw, "googleAntigravityStaticCatalogVersion")) return null;
+  const version = raw.googleAntigravityStaticCatalogVersion;
+  if (version === undefined || version === 1) return null;
+  return "schema_invalid: googleAntigravityStaticCatalogVersion: must be 1 or omitted";
+}
+
 /** Validate an in-memory config candidate without touching disk. Used by headless CLI import/set. */
 export function validateConfigCandidate(value: unknown): { ok: true; config: OcxConfig } | { ok: false; error: string } {
-  const boundaryError = blankHostnameError(value) ?? claudeSubagentEffortError(value) ?? appOwnedMemoryBudgetError(value);
+  const boundaryError = blankHostnameError(value)
+    ?? claudeSubagentEffortError(value)
+    ?? appOwnedMemoryBudgetError(value)
+    ?? googleAntigravityStaticCatalogVersionError(value);
   if (boundaryError) return { ok: false, error: boundaryError };
   const result = configSchema.safeParse(value);
   if (result.success) return { ok: true, config: normalizeApiKeyIds(result.data as OcxConfig) };

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -659,10 +659,22 @@ const OAUTH_RECONCILE_FIELDS: (keyof OcxProviderConfig)[] = [
   "preserveReasoningContentModels",
 ];
 
+const GOOGLE_ANTIGRAVITY_PROVIDER = "google-antigravity";
+const GOOGLE_ANTIGRAVITY_STATIC_CATALOG_VERSION = 1 as const;
+
 export function reconcileOAuthProviders(config: OcxConfig): boolean {
   let changed = false;
+  const migrateAntigravityStaticCatalog =
+    config.googleAntigravityStaticCatalogVersion !== GOOGLE_ANTIGRAVITY_STATIC_CATALOG_VERSION;
   for (const [name, prov] of Object.entries(config.providers)) {
     const def = OAUTH_PROVIDERS[name];
+    // Normalize the canonical row before the OAuth-only reconciliation guard. Legacy GUI
+    // saves can carry an omitted or non-OAuth authMode, and stamping the migration marker
+    // while skipping such a row would make its materialized `true` look user-authored later.
+    if (name === GOOGLE_ANTIGRAVITY_PROVIDER && migrateAntigravityStaticCatalog && prov.liveModels !== false) {
+      prov.liveModels = false;
+      changed = true;
+    }
     if (!def || prov.authMode !== "oauth") continue;
     const preset = def.providerConfig;
     for (const field of OAUTH_RECONCILE_FIELDS) {
@@ -674,6 +686,9 @@ export function reconcileOAuthProviders(config: OcxConfig): boolean {
       }
       changed = true;
     }
+    // Before this marker existed, the GUI materialized an omitted `liveModels` as `true`
+    // on any settings save. The pre-guard normalization above resets that legacy state
+    // once; choices made after this migration are preserved by the version boundary.
     if (prov.liveModels === undefined && preset.liveModels !== undefined) {
       prov.liveModels = preset.liveModels;
       changed = true;
@@ -683,6 +698,10 @@ export function reconcileOAuthProviders(config: OcxConfig): boolean {
       prov.defaultModel = preset.defaultModel;
       changed = true;
     }
+  }
+  if (migrateAntigravityStaticCatalog) {
+    config.googleAntigravityStaticCatalogVersion = GOOGLE_ANTIGRAVITY_STATIC_CATALOG_VERSION;
+    changed = true;
   }
   if (changed) saveConfig(config);
   return changed;
@@ -745,8 +764,14 @@ export function upsertOAuthProvider(config: OcxConfig, provider: string): void {
   const existing = config.providers[provider];
   const next: OcxProviderConfig = { ...def.providerConfig };
   // `liveModels` is a user-facing provider toggle. A registry default seeds new rows, but an
-  // explicit choice must survive re-login and the post-credential latest-config upsert.
-  if (typeof existing?.liveModels === "boolean") next.liveModels = existing.liveModels;
+  // explicit post-migration choice must survive re-login and the latest-config upsert. A
+  // pre-marker Antigravity `true` may have been materialized by the old GUI, so it is reset
+  // once instead of being misclassified as user provenance.
+  const preserveExistingLiveModels = provider !== GOOGLE_ANTIGRAVITY_PROVIDER
+    || config.googleAntigravityStaticCatalogVersion === GOOGLE_ANTIGRAVITY_STATIC_CATALOG_VERSION;
+  if (preserveExistingLiveModels && typeof existing?.liveModels === "boolean") {
+    next.liveModels = existing.liveModels;
+  }
   if (existing && getProviderRegistryEntry(provider)?.allowKeyAuthOverride === true) {
     // Shared sanitizeApiKeyValue trim / no-CRLF checks from api-key pool writes.
     let storedApiKey = sanitizeApiKeyValue(existing.apiKey);
@@ -770,6 +795,9 @@ export function upsertOAuthProvider(config: OcxConfig, provider: string): void {
     }
   }
   config.providers[provider] = next;
+  if (provider === GOOGLE_ANTIGRAVITY_PROVIDER) {
+    config.googleAntigravityStaticCatalogVersion = GOOGLE_ANTIGRAVITY_STATIC_CATALOG_VERSION;
+  }
 }
 
 interface RunLoginDeps {

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -629,8 +629,9 @@ export function buildModelsRequest(prov: OcxProviderConfig, apiKey: string | und
  * configs on the next `ocx start`, instead of only fresh installs. The live `/models` fetch stays
  * the primary source; this keeps the static fallback (and models-not-in-/models) current.
  *
- * Only touches providers that are registry-managed AND still `authMode: "oauth"`, and only the
- * preset fields (never apiKey/baseUrl/user toggles). Persists + returns true when anything changed.
+ * Only touches providers that are registry-managed AND still `authMode: "oauth"`. Preset fields
+ * are refreshed, while the registry's `liveModels` default is filled only when the user has no
+ * explicit toggle. Persists + returns true when anything changed.
  */
 function cloneProviderField(value: unknown): unknown {
   if (Array.isArray(value)) return [...value];
@@ -671,6 +672,10 @@ export function reconcileOAuthProviders(config: OcxConfig): boolean {
       } else {
         delete prov[field];
       }
+      changed = true;
+    }
+    if (prov.liveModels === undefined && preset.liveModels !== undefined) {
+      prov.liveModels = preset.liveModels;
       changed = true;
     }
     // Heal a defaultModel that no longer exists in the refreshed list (e.g. a deprecated snapshot).
@@ -739,6 +744,9 @@ export function upsertOAuthProvider(config: OcxConfig, provider: string): void {
   if (namespaceCollision) throw new Error(namespaceCollision);
   const existing = config.providers[provider];
   const next: OcxProviderConfig = { ...def.providerConfig };
+  // `liveModels` is a user-facing provider toggle. A registry default seeds new rows, but an
+  // explicit choice must survive re-login and the post-credential latest-config upsert.
+  if (typeof existing?.liveModels === "boolean") next.liveModels = existing.liveModels;
   if (existing && getProviderRegistryEntry(provider)?.allowKeyAuthOverride === true) {
     // Shared sanitizeApiKeyValue trim / no-CRLF checks from api-key pool writes.
     let storedApiKey = sanitizeApiKeyValue(existing.apiKey);

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -630,8 +630,10 @@ export function buildModelsRequest(prov: OcxProviderConfig, apiKey: string | und
  * the primary source; this keeps the static fallback (and models-not-in-/models) current.
  *
  * Only touches providers that are registry-managed AND still `authMode: "oauth"`. Preset fields
- * are refreshed, while the registry's `liveModels` default is filled only when the user has no
- * explicit toggle. Persists + returns true when anything changed.
+ * are refreshed, while the registry's `liveModels` default is normally filled only when no value
+ * is stored. Antigravity has one versioned exception below because its old GUI-generated `true`
+ * cannot be distinguished from a hand-written pre-migration `true`. Persists + returns true when
+ * anything changed.
  */
 function cloneProviderField(value: unknown): unknown {
   if (Array.isArray(value)) return [...value];
@@ -668,9 +670,11 @@ export function reconcileOAuthProviders(config: OcxConfig): boolean {
     config.googleAntigravityStaticCatalogVersion !== GOOGLE_ANTIGRAVITY_STATIC_CATALOG_VERSION;
   for (const [name, prov] of Object.entries(config.providers)) {
     const def = OAUTH_PROVIDERS[name];
-    // Normalize the canonical row before the OAuth-only reconciliation guard. Legacy GUI
-    // saves can carry an omitted or non-OAuth authMode, and stamping the migration marker
-    // while skipping such a row would make its materialized `true` look user-authored later.
+    // Normalize the canonical row before the OAuth-only reconciliation guard. The old GUI and a
+    // manual edit both persist the same bare `true`, with no source metadata, so every ambiguous
+    // pre-marker value is reset once. A deliberate live-discovery choice can be re-enabled after
+    // the marker and is then preserved. Do this before the guard so omitted/non-OAuth authMode
+    // rows do not get stamped without actually receiving the new static default.
     if (name === GOOGLE_ANTIGRAVITY_PROVIDER && migrateAntigravityStaticCatalog && prov.liveModels !== false) {
       prov.liveModels = false;
       changed = true;
@@ -686,9 +690,9 @@ export function reconcileOAuthProviders(config: OcxConfig): boolean {
       }
       changed = true;
     }
-    // Before this marker existed, the GUI materialized an omitted `liveModels` as `true`
-    // on any settings save. The pre-guard normalization above resets that legacy state
-    // once; choices made after this migration are preserved by the version boundary.
+    // Before this marker existed, the GUI materialized an omitted `liveModels` as `true` on any
+    // settings save. Since persisted values have no provenance, the pre-guard normalization above
+    // intentionally resets all pre-marker `true` values once. Later choices are version-bounded.
     if (prov.liveModels === undefined && preset.liveModels !== undefined) {
       prov.liveModels = preset.liveModels;
       changed = true;
@@ -764,9 +768,9 @@ export function upsertOAuthProvider(config: OcxConfig, provider: string): void {
   const existing = config.providers[provider];
   const next: OcxProviderConfig = { ...def.providerConfig };
   // `liveModels` is a user-facing provider toggle. A registry default seeds new rows, but an
-  // explicit post-migration choice must survive re-login and the latest-config upsert. A
-  // pre-marker Antigravity `true` may have been materialized by the old GUI, so it is reset
-  // once instead of being misclassified as user provenance.
+  // explicit post-migration choice must survive re-login and the latest-config upsert. Old GUI
+  // saves and manual edits left identical pre-marker `true` values, so that ambiguous state is
+  // reset once; users who deliberately forced discovery can re-enable it after migration.
   const preserveExistingLiveModels = provider !== GOOGLE_ANTIGRAVITY_PROVIDER
     || config.googleAntigravityStaticCatalogVersion === GOOGLE_ANTIGRAVITY_STATIC_CATALOG_VERSION;
   if (preserveExistingLiveModels && typeof existing?.liveModels === "boolean") {

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -679,7 +679,12 @@ export function reconcileOAuthProviders(config: OcxConfig): boolean {
       prov.liveModels = false;
       changed = true;
     }
-    if (!def || prov.authMode !== "oauth") continue;
+    // During the one-time Antigravity static-catalog migration, also refresh preset catalog
+    // fields when authMode is omitted or non-oauth. Otherwise liveModels flips to static while
+    // a stale models[] remains the published catalog forever.
+    const migrateAntigravityCatalogFields =
+      name === GOOGLE_ANTIGRAVITY_PROVIDER && migrateAntigravityStaticCatalog;
+    if (!def || (prov.authMode !== "oauth" && !migrateAntigravityCatalogFields)) continue;
     const preset = def.providerConfig;
     for (const field of OAUTH_RECONCILE_FIELDS) {
       if (JSON.stringify(prov[field]) === JSON.stringify(preset[field])) continue;

--- a/src/server/management/provider-routes.ts
+++ b/src/server/management/provider-routes.ts
@@ -365,7 +365,10 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
       });
     }
     if (prov.liveModels === false) {
-      return jsonResponse({ ok: false, latencyMs: 0, error: "static catalog only — upstream not verified" });
+      // A static catalog has no live discovery endpoint to test. This is neither
+      // positive connectivity evidence nor an outage, and it must stay before
+      // credential resolution/network access for providers such as Antigravity.
+      return jsonResponse({ applicable: false, reason: "static_catalog", latencyMs: 0 });
     }
     const { resolveModelsAuthToken, buildModelsRequest } = await import("../../oauth");
     const apiKey = await resolveModelsAuthToken(name, prov);

--- a/src/types.ts
+++ b/src/types.ts
@@ -536,6 +536,8 @@ export interface OcxConfig {
   defaultProvider: string;
   /** OpenAI provider-contract migration marker (v2 = single `openai` provider with account mode). */
   openaiProviderTierVersion?: 1 | 2;
+  /** One-time migration marker for Antigravity's static catalog default. */
+  googleAntigravityStaticCatalogVersion?: 1;
   /** Claude Code inbound + launcher settings. */
   claudeCode?: OcxClaudeCodeConfig;
   /**

--- a/tests/cli-headless-parity.test.ts
+++ b/tests/cli-headless-parity.test.ts
@@ -111,6 +111,18 @@ describe("headless GUI parity CLI", () => {
     }]);
   });
 
+  test("provider test treats a static catalog as neutral", async () => {
+    const runtime = fakeRuntime(() => ({ applicable: false, reason: "static_catalog", latencyMs: 0 }));
+    const code = await handleProviderRuntimeCommand("test", ["google-antigravity", "--json"], runtime.deps);
+    expect(code).toBe(0);
+    expect(process.exitCode).not.toBe(1);
+    expect(runtime.requests).toEqual([{
+      path: "/api/providers/test?name=google-antigravity",
+      method: "POST",
+      body: null,
+    }]);
+  });
+
   test("model context all maps to the atomic GUI endpoint", async () => {
     const runtime = fakeRuntime();
     const code = await handleModelsRuntimeCommand("context", ["all", "on", "--json"], runtime.deps);

--- a/tests/codex-account-store.test.ts
+++ b/tests/codex-account-store.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, beforeEach, afterEach, spyOn } from "bun:test";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, rmSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { setIcaclsRunnerForTests } from "../src/lib/windows-secret-acl";
 
 const TEST_DIR = join(import.meta.dir, ".tmp-codex-accounts-test");
 const ACCOUNTS_PATH = join(TEST_DIR, "codex-accounts.json");
@@ -17,6 +18,10 @@ function refreshLockPathForToken(refreshToken: string): string {
 
 describe("codex-account-store CRUD", () => {
   beforeEach(() => {
+    // These exercises cover credential-store contention, not Windows ACL behavior.
+    // Avoid spawning icacls for every fixture write; its lingering handle makes
+    // the fixed fixture directory flaky under `bun test --isolate` on Windows.
+    setIcaclsRunnerForTests(() => ({ success: true, exitCode: 0, timedOut: false, stdout: "" }));
     process.env.OPENCODEX_HOME = TEST_DIR;
     if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
     mkdirSync(TEST_DIR, { recursive: true });
@@ -25,6 +30,7 @@ describe("codex-account-store CRUD", () => {
   afterEach(() => {
     delete process.env.OPENCODEX_HOME;
     if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    setIcaclsRunnerForTests(null);
   });
 
   test("save and load credential round-trip", async () => {

--- a/tests/codex-account-store.test.ts
+++ b/tests/codex-account-store.test.ts
@@ -28,9 +28,9 @@ describe("codex-account-store CRUD", () => {
   });
 
   afterEach(() => {
+    setIcaclsRunnerForTests(null);
     delete process.env.OPENCODEX_HOME;
     if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
-    setIcaclsRunnerForTests(null);
   });
 
   test("save and load credential round-trip", async () => {

--- a/tests/codex-auth-context.test.ts
+++ b/tests/codex-auth-context.test.ts
@@ -46,12 +46,17 @@ import {
   recordCodexUpstreamOutcome,
 } from "../src/codex/routing";
 import type { OcxConfig, OcxProviderConfig } from "../src/types";
+import { setIcaclsRunnerForTests } from "../src/lib/windows-secret-acl";
 
 let testDir: string;
 let previousOpencodexHome: string | undefined;
 let previousCodexHome: string | undefined;
 
 beforeEach(() => {
+  // This suite validates refresh admission and auth-context outcomes. Real icacls
+  // processes are covered elsewhere and can retain temp-dir handles long enough
+  // to obscure those assertions under Windows isolated-test load.
+  setIcaclsRunnerForTests(() => ({ success: true, exitCode: 0, timedOut: false, stdout: "" }));
   testDir = mkdtempSync(join(tmpdir(), "ocx-auth-ctx-"));
   previousOpencodexHome = process.env.OPENCODEX_HOME;
   process.env.OPENCODEX_HOME = testDir;
@@ -69,6 +74,7 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(testDir, { recursive: true, force: true });
+  setIcaclsRunnerForTests(null);
   clearThreadAccountMap();
   clearCodexUpstreamHealth();
   clearAccountQuota();

--- a/tests/codex-auth-context.test.ts
+++ b/tests/codex-auth-context.test.ts
@@ -73,8 +73,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  rmSync(testDir, { recursive: true, force: true });
   setIcaclsRunnerForTests(null);
+  rmSync(testDir, { recursive: true, force: true });
   clearThreadAccountMap();
   clearCodexUpstreamHealth();
   clearAccountQuota();

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -25,6 +25,7 @@ import type { OcxConfig } from "../src/types";
 import type { NormalizedComboConfig } from "../src/combos/types";
 import { enrichProviderFromRegistry } from "../src/providers/derive";
 import { handleManagementAPI } from "../src/server/management-api";
+import { OAUTH_PROVIDERS } from "../src/oauth";
 
 const originalFetch = globalThis.fetch;
 
@@ -1267,6 +1268,42 @@ describe("Codex catalog routed normalization", () => {
       globalThis.fetch = originalFetch;
       clearModelCache("static-provider");
     }
+  });
+
+  test("Google Antigravity uses its static registry catalog and suppresses stale discovery (#723)", async () => {
+    const providerName = "google-antigravity";
+    const provider = structuredClone(OAUTH_PROVIDERS[providerName].providerConfig);
+    const config = {
+      port: 10100,
+      defaultProvider: providerName,
+      providers: { [providerName]: provider },
+    } as OcxConfig;
+    let fetchCalls = 0;
+    globalThis.fetch = (() => {
+      fetchCalls += 1;
+      throw new Error("static Antigravity catalog must not call /models");
+    }) as typeof fetch;
+    markProviderDiscoveryFailed(providerName, { reason: "http", httpStatus: 404 });
+
+    const models = await gatherRoutedModels(config);
+    const ids = models.filter(model => model.provider === providerName).map(model => model.id).sort();
+
+    expect(fetchCalls).toBe(0);
+    expect(ids).toEqual([...(provider.models ?? [])].sort());
+    expect(ids).toHaveLength(6);
+    expect(getProviderDiscoveryStatus(providerName)).toBeUndefined();
+
+    markProviderDiscoveryFailed(providerName, { reason: "http", httpStatus: 404 });
+    const url = new URL("http://127.0.0.1/api/providers");
+    const response = await handleManagementAPI(new Request(url), url, config);
+    const rows = await response!.json() as Array<Record<string, unknown>>;
+    const row = rows.find(item => item.name === providerName);
+    expect(row).toMatchObject({
+      name: providerName,
+      liveModels: false,
+      models: provider.models,
+    });
+    expect(row).not.toHaveProperty("discovery");
   });
 
   test("failed discovery falls back to defaultModel when no static models are configured (#308)", async () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -150,6 +150,37 @@ describe("opencodex config defaults", () => {
     }
   });
 
+  test("Antigravity static-catalog migration marker is schema-safe but not default-injected", () => {
+    expect(getDefaultConfig().googleAntigravityStaticCatalogVersion).toBeUndefined();
+
+    writeConfig({
+      port: 12345,
+      defaultProvider: "custom",
+      googleAntigravityStaticCatalogVersion: 1,
+      providers: { custom: { adapter: "openai-chat", baseUrl: "https://example.test/v1" } },
+    });
+    expect(loadConfig().googleAntigravityStaticCatalogVersion).toBe(1);
+
+    writeConfig({
+      port: 12345,
+      defaultProvider: "custom",
+      googleAntigravityStaticCatalogVersion: 99,
+      providers: { custom: { adapter: "openai-chat", baseUrl: "https://example.test/v1" } },
+    });
+    const degraded = loadConfig();
+    expect(degraded.googleAntigravityStaticCatalogVersion).toBeUndefined();
+    expect(degraded.providers.custom.baseUrl).toBe("https://example.test/v1");
+    expect(backupNames()).toEqual([]);
+
+    expect(validateConfigCandidate({
+      ...getDefaultConfig(),
+      googleAntigravityStaticCatalogVersion: 99,
+    })).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("googleAntigravityStaticCatalogVersion"),
+    });
+  });
+
   test("Codex autostart can be disabled explicitly", () => {
     expect(codexAutoStartEnabled({ codexAutoStart: false })).toBe(false);
     expect(codexAutoStartEnabled({ codexAutoStart: true })).toBe(true);

--- a/tests/gather-routed-models-single-flight.test.ts
+++ b/tests/gather-routed-models-single-flight.test.ts
@@ -164,6 +164,40 @@ describe("gatherRoutedModels single-flight", () => {
     expect(a2).toEqual(a1);
   });
 
+  test("an omitted registry-static setting never shares a flight with explicit live discovery", async () => {
+    let fetchCount = 0;
+    globalThis.fetch = (async () => {
+      fetchCount += 1;
+      return new Response(JSON.stringify({ data: [{ id: "live-only" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const config = (liveModels?: true): OcxConfig => ({
+      port: 10100,
+      defaultProvider: "alibaba-token-plan",
+      providers: {
+        "alibaba-token-plan": {
+          adapter: "openai-chat",
+          baseUrl: "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+          apiKey: "test-key",
+          models: ["configured-static"],
+          ...(liveModels === undefined ? {} : { liveModels }),
+        },
+      },
+    });
+
+    const [registryStatic, explicitLive] = await Promise.all([
+      gatherRoutedModels(config()),
+      gatherRoutedModels(config(true)),
+    ]);
+
+    expect(fetchCount).toBe(1);
+    expect(registryStatic.map(model => model.id)).toEqual(["configured-static"]);
+    expect(explicitLive.map(model => model.id)).toEqual(["live-only"]);
+  });
+
   test("concurrent distinct keys keep flight-local combo omissions", async () => {
     globalThis.fetch = (async () =>
       new Response(JSON.stringify({ data: [{ id: "m1" }] }), {

--- a/tests/google-models-listing.test.ts
+++ b/tests/google-models-listing.test.ts
@@ -38,9 +38,10 @@ describe("buildModelsRequest google routing", () => {
     expect(headers["x-goog-api-key"]).toBe("gk-123");
   });
 
-  test("google-antigravity (oauth) keeps Authorization: Bearer via registry backfill", () => {
-    // A saved config may omit googleMode — the registry entry (cloud-code-assist) must win.
-    const prov = { adapter: "google", authMode: "oauth", baseUrl: "https://daily-cloudcode-pa.googleapis.com" } as OcxProviderConfig;
+  test("an explicit Antigravity live-discovery override keeps Authorization: Bearer", () => {
+    // Static discovery is the preset default. If a user explicitly opts into the generic probe,
+    // a saved config may still omit googleMode — the registry's cloud-code-assist mode must win.
+    const prov = { adapter: "google", authMode: "oauth", baseUrl: "https://daily-cloudcode-pa.googleapis.com", liveModels: true } as OcxProviderConfig;
     const { url, headers } = buildModelsRequest(prov, "oauth-token", "google-antigravity");
     expect(url).toBe("https://daily-cloudcode-pa.googleapis.com/models");
     expect(headers["Authorization"]).toBe("Bearer oauth-token");

--- a/tests/oauth-provider-reconcile.test.ts
+++ b/tests/oauth-provider-reconcile.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadConfig } from "../src/config";
-import { reconcileOAuthProviders } from "../src/oauth";
+import { OAUTH_PROVIDERS, reconcileOAuthProviders, upsertOAuthProvider } from "../src/oauth";
 import { getCredential, saveCredential } from "../src/oauth/store";
 import type { OcxConfig } from "../src/types";
 
@@ -61,6 +61,7 @@ describe("OAuth provider reconciliation", () => {
     expect(provider.models).not.toContain("gemini-3.6-flash-medium");
     expect(provider.models).not.toContain("gemini-3.6-flash-high");
     expect(provider.modelContextWindows?.["gemini-3.6-flash"]).toBe(1_048_576);
+    expect(provider.liveModels).toBe(false);
     expect(provider.project).toBe("config-project-sentinel");
     expect(provider.note).toBe("user-owned-note");
     expect(getCredential("google-antigravity")).toMatchObject({
@@ -71,6 +72,27 @@ describe("OAuth provider reconciliation", () => {
 
     const persisted = loadConfig();
     expect(persisted.providers["google-antigravity"]?.defaultModel).toBe("gemini-3.6-flash");
+    expect(persisted.providers["google-antigravity"]?.liveModels).toBe(false);
     expect(reconcileOAuthProviders(config)).toBe(false);
+  });
+
+  test("preserves an explicit Antigravity liveModels override during reconcile and re-login", () => {
+    const config = {
+      port: 10100,
+      defaultProvider: "google-antigravity",
+      providers: {
+        "google-antigravity": {
+          ...structuredClone(OAUTH_PROVIDERS["google-antigravity"].providerConfig),
+          liveModels: true,
+        },
+      },
+    } satisfies OcxConfig;
+
+    expect(reconcileOAuthProviders(config)).toBe(false);
+    expect(config.providers["google-antigravity"].liveModels).toBe(true);
+
+    upsertOAuthProvider(config, "google-antigravity");
+    expect(config.providers["google-antigravity"].liveModels).toBe(true);
+    expect(config.providers["google-antigravity"].models).toHaveLength(6);
   });
 });

--- a/tests/oauth-provider-reconcile.test.ts
+++ b/tests/oauth-provider-reconcile.test.ts
@@ -106,11 +106,14 @@ describe("OAuth provider reconciliation", () => {
     const home = mkdtempSync(join(tmpdir(), "ocx-antigravity-authmode-reconcile-"));
     homes.push(home);
     process.env.OPENCODEX_HOME = home;
+    const preset = OAUTH_PROVIDERS["google-antigravity"].providerConfig;
 
     for (const authMode of [undefined, "key"] as const) {
       const provider = {
-        ...structuredClone(OAUTH_PROVIDERS["google-antigravity"].providerConfig),
+        ...structuredClone(preset),
         liveModels: true,
+        defaultModel: "gemini-3.5-flash-low",
+        models: ["gemini-3.5-flash-low", "gemini-3.5-flash-high"],
       };
       if (authMode === undefined) delete provider.authMode;
       else provider.authMode = authMode;
@@ -122,7 +125,11 @@ describe("OAuth provider reconciliation", () => {
 
       expect(reconcileOAuthProviders(config)).toBe(true);
       expect(config.googleAntigravityStaticCatalogVersion).toBe(1);
-      expect(config.providers["google-antigravity"].liveModels).toBe(false);
+      const migrated = config.providers["google-antigravity"];
+      expect(migrated.liveModels).toBe(false);
+      expect(migrated.defaultModel).toBe(preset.defaultModel);
+      expect(migrated.models).toEqual(preset.models);
+      expect(migrated.authMode).toBe(authMode);
     }
   });
 

--- a/tests/oauth-provider-reconcile.test.ts
+++ b/tests/oauth-provider-reconcile.test.ts
@@ -41,6 +41,8 @@ describe("OAuth provider reconciliation", () => {
           modelContextWindows: { "gemini-3.5-flash-low": 1_048_576 },
           project: "config-project-sentinel",
           note: "user-owned-note",
+          // Older Provider Settings saves materialized this effective default.
+          liveModels: true,
         },
       },
     } satisfies OcxConfig;
@@ -62,6 +64,7 @@ describe("OAuth provider reconciliation", () => {
     expect(provider.models).not.toContain("gemini-3.6-flash-high");
     expect(provider.modelContextWindows?.["gemini-3.6-flash"]).toBe(1_048_576);
     expect(provider.liveModels).toBe(false);
+    expect(config.googleAntigravityStaticCatalogVersion).toBe(1);
     expect(provider.project).toBe("config-project-sentinel");
     expect(provider.note).toBe("user-owned-note");
     expect(getCredential("google-antigravity")).toMatchObject({
@@ -73,6 +76,7 @@ describe("OAuth provider reconciliation", () => {
     const persisted = loadConfig();
     expect(persisted.providers["google-antigravity"]?.defaultModel).toBe("gemini-3.6-flash");
     expect(persisted.providers["google-antigravity"]?.liveModels).toBe(false);
+    expect(persisted.googleAntigravityStaticCatalogVersion).toBe(1);
     expect(reconcileOAuthProviders(config)).toBe(false);
   });
 
@@ -80,6 +84,7 @@ describe("OAuth provider reconciliation", () => {
     const config = {
       port: 10100,
       defaultProvider: "google-antigravity",
+      googleAntigravityStaticCatalogVersion: 1,
       providers: {
         "google-antigravity": {
           ...structuredClone(OAUTH_PROVIDERS["google-antigravity"].providerConfig),
@@ -94,5 +99,55 @@ describe("OAuth provider reconciliation", () => {
     upsertOAuthProvider(config, "google-antigravity");
     expect(config.providers["google-antigravity"].liveModels).toBe(true);
     expect(config.providers["google-antigravity"].models).toHaveLength(6);
+  });
+
+  test("normalizes pre-marker Antigravity rows even when authMode is omitted or non-OAuth", () => {
+    const home = mkdtempSync(join(tmpdir(), "ocx-antigravity-authmode-reconcile-"));
+    homes.push(home);
+    process.env.OPENCODEX_HOME = home;
+
+    for (const authMode of [undefined, "key"] as const) {
+      const provider = {
+        ...structuredClone(OAUTH_PROVIDERS["google-antigravity"].providerConfig),
+        liveModels: true,
+      };
+      if (authMode === undefined) delete provider.authMode;
+      else provider.authMode = authMode;
+      const config = {
+        port: 10100,
+        defaultProvider: "google-antigravity",
+        providers: { "google-antigravity": provider },
+      } satisfies OcxConfig;
+
+      expect(reconcileOAuthProviders(config)).toBe(true);
+      expect(config.googleAntigravityStaticCatalogVersion).toBe(1);
+      expect(config.providers["google-antigravity"].liveModels).toBe(false);
+    }
+  });
+
+  test("seeds the static catalog during pre-marker re-login, then preserves later overrides", () => {
+    const config = {
+      port: 10100,
+      defaultProvider: "google-antigravity",
+      providers: {
+        "google-antigravity": {
+          ...structuredClone(OAUTH_PROVIDERS["google-antigravity"].providerConfig),
+          liveModels: true,
+        },
+      },
+    } satisfies OcxConfig;
+
+    upsertOAuthProvider(config, "google-antigravity");
+    expect(config.googleAntigravityStaticCatalogVersion).toBe(1);
+    expect(config.providers["google-antigravity"].liveModels).toBe(false);
+
+    config.providers["google-antigravity"].liveModels = true;
+    config.providers["google-antigravity"].authMode = "key";
+    upsertOAuthProvider(config, "google-antigravity");
+    expect(config.providers["google-antigravity"].liveModels).toBe(true);
+
+    config.providers["google-antigravity"].authMode = undefined;
+    upsertOAuthProvider(config, "google-antigravity");
+    expect(config.providers["google-antigravity"].liveModels).toBe(true);
   });
 });

--- a/tests/oauth-provider-reconcile.test.ts
+++ b/tests/oauth-provider-reconcile.test.ts
@@ -41,7 +41,8 @@ describe("OAuth provider reconciliation", () => {
           modelContextWindows: { "gemini-3.5-flash-low": 1_048_576 },
           project: "config-project-sentinel",
           note: "user-owned-note",
-          // Older Provider Settings saves materialized this effective default.
+          // This is deliberately ambiguous: old Provider Settings saves and manual edits
+          // persisted the same value, so the versioned migration normalizes both once.
           liveModels: true,
         },
       },
@@ -101,7 +102,7 @@ describe("OAuth provider reconciliation", () => {
     expect(config.providers["google-antigravity"].models).toHaveLength(6);
   });
 
-  test("normalizes pre-marker Antigravity rows even when authMode is omitted or non-OAuth", () => {
+  test("normalizes ambiguous pre-marker Antigravity rows even when authMode is omitted or non-OAuth", () => {
     const home = mkdtempSync(join(tmpdir(), "ocx-antigravity-authmode-reconcile-"));
     homes.push(home);
     process.env.OPENCODEX_HOME = home;
@@ -125,7 +126,7 @@ describe("OAuth provider reconciliation", () => {
     }
   });
 
-  test("seeds the static catalog during pre-marker re-login, then preserves later overrides", () => {
+  test("normalizes ambiguous pre-marker true during re-login, then preserves later overrides", () => {
     const config = {
       port: 10100,
       defaultProvider: "google-antigravity",

--- a/tests/provider-connection-test.test.ts
+++ b/tests/provider-connection-test.test.ts
@@ -4,6 +4,8 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { handleManagementAPI } from "../src/server/management-api";
 import { saveConfig } from "../src/config";
+import { OAUTH_PROVIDERS } from "../src/oauth";
+import { PROVIDER_REGISTRY } from "../src/providers/registry";
 import type { OcxConfig } from "../src/types";
 import { withRegistryDiscovery } from "./helpers/provider-registry-discovery";
 
@@ -94,6 +96,23 @@ describe("POST /api/providers/test (WP040 connectivity probe)", () => {
     const { body } = await probe(config, "staticprov");
     expect(body.ok).toBe(false);
     expect(String(body.error)).toContain("static catalog only");
+  });
+
+  test("Google Antigravity uses the static-only probe without network access (#723)", async () => {
+    let fetches = 0;
+    globalThis.fetch = (async () => {
+      fetches += 1;
+      throw new Error("static Antigravity catalog must not probe upstream");
+    }) as typeof fetch;
+    const config = baseConfig({
+      "google-antigravity": structuredClone(OAUTH_PROVIDERS["google-antigravity"].providerConfig),
+    });
+
+    const { body } = await probe(config, "google-antigravity");
+
+    expect(body.ok).toBe(false);
+    expect(String(body.error)).toContain("static catalog only");
+    expect(fetches).toBe(0);
   });
 
   test("a fake key gets the upstream rejection, not a catalog-presence pass", async () => {

--- a/tests/provider-connection-test.test.ts
+++ b/tests/provider-connection-test.test.ts
@@ -83,7 +83,7 @@ describe("POST /api/providers/test (WP040 connectivity probe)", () => {
     expect(fetches).toBe(0);
   });
 
-  test("static catalog cannot masquerade as a live connection", async () => {
+  test("static catalog reports a neutral non-applicable connection test", async () => {
     const config = baseConfig({
       staticprov: {
         adapter: "openai-chat",
@@ -94,11 +94,10 @@ describe("POST /api/providers/test (WP040 connectivity probe)", () => {
       },
     });
     const { body } = await probe(config, "staticprov");
-    expect(body.ok).toBe(false);
-    expect(String(body.error)).toContain("static catalog only");
+    expect(body).toEqual({ applicable: false, reason: "static_catalog", latencyMs: 0 });
   });
 
-  test("Google Antigravity uses the static-only probe without network access (#723)", async () => {
+  test("Google Antigravity reports not-applicable without credentials or network access (#723)", async () => {
     let fetches = 0;
     globalThis.fetch = (async () => {
       fetches += 1;
@@ -110,8 +109,7 @@ describe("POST /api/providers/test (WP040 connectivity probe)", () => {
 
     const { body } = await probe(config, "google-antigravity");
 
-    expect(body.ok).toBe(false);
-    expect(String(body.error)).toContain("static catalog only");
+    expect(body).toEqual({ applicable: false, reason: "static_catalog", latencyMs: 0 });
     expect(fetches).toBe(0);
   });
 

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -613,6 +613,10 @@ describe("provider registry parity", () => {
     expect(OAUTH_PROVIDERS.xai.providerConfig.modelContextWindows?.["grok-4.5"]).toBe(500_000);
     expect(OAUTH_PROVIDERS.xai.providerConfig.modelReasoningEfforts?.["grok-4.5"]).toEqual(["low", "medium", "high"]);
     expect(OAUTH_PROVIDERS.xai.providerConfig.noVisionModels).toContain("grok-build-0.1");
+    const antigravityRegistry = PROVIDER_REGISTRY.find(entry => entry.id === "google-antigravity");
+    expect(antigravityRegistry?.liveModels).toBe(false);
+    expect(providerConfigSeed(antigravityRegistry!).liveModels).toBe(false);
+    expect(OAUTH_PROVIDERS["google-antigravity"].providerConfig.liveModels).toBe(false);
     expect(OAUTH_PROVIDERS["google-antigravity"].providerConfig.defaultModel).toBe("gemini-3.6-flash");
     // Collapsed picker: base models only, no effort-suffix variants.
     expect(OAUTH_PROVIDERS["google-antigravity"].providerConfig.models).toContain("gemini-3.6-flash");


### PR DESCRIPTION
## Summary

- Complete the static-catalog behavior for the built-in `google-antigravity` preset already present on `dev`, so catalog reads, connection checks, settings, and OAuth reconciliation no longer issue or imply unsupported generic discovery.
- Migrate legacy Antigravity configs once. The old GUI and manual edits persisted the same bare `liveModels: true` with no source metadata, so every ambiguous pre-marker `true` is normalized once; users who deliberately forced discovery can re-enable it afterward, and later overrides persist through re-login.
- Make the provider settings UI send a sparse PATCH so saving an unrelated field does not silently materialize or change `liveModels`.
- Return static catalog rows and clear stale discovery failures before OAuth token resolution, so catalog reads neither refresh credentials nor touch the network.
- Keep omitted, explicit-live, and explicit-static provider settings distinct in the catalog single-flight key, preventing concurrent static and live gathers from sharing the wrong result.
- Return a neutral `not applicable` result for static-catalog connection checks before credential resolution or network access; render it neutrally in the dashboard and CLI, and invalidate stale probe state when provider configuration or active authentication changes.
- Add focused catalog, management API, connection-probe, migration, UI, and concurrency coverage, plus synchronized provider documentation in five locales.

Follow-up to #723. The registry flag itself is already on `dev` via `c4b83693d`; this PR carries the remaining reconciliation, settings, catalog-flight, GUI, CLI, test, and documentation work.

## Safety review

- This is a provider configuration and availability fix, not a security-vulnerability report.
- No inference, quota, OAuth endpoint, credential format, token destination, or authorization policy changes.
- Both catalog reads and static-catalog connection checks return before OAuth token resolution and are covered by zero-network-call regressions. The neutral response asserts no successful connectivity and cannot expose or forward credentials.
- Pre-marker `liveModels: true` provenance cannot be recovered from the stored config. The one-time reset is deliberate and version-bounded; a post-migration explicit `true` remains supported and retains the previous authenticated discovery behavior.
- A targeted auth-boundary and diff review checked credential exposure, unsafe defaults, migration provenance, and concurrent catalog isolation. No blocking security issue was found; a broader security scan was not warranted for this scope.

## Verification

Current head `fa6b3ef2` is rebased onto current `dev` (`33caf336`).

- `git range-diff` confirms that all five rebased commits are patch-equivalent to the reviewed series; the duplicate registry line already on `dev` is absent from the final PR diff.
- Bundled Bun `1.3.14 (0d9b296a)`: root provider/catalog/config regressions **289 passed, 0 failed**; rendered GUI regressions **8 passed, 0 failed**; typecheck and privacy scan passed.
- Configured Bun `1.4.0-canary.1 (b22e0e6d0)`: the same root **289/0** and GUI **8/0** suites passed; typecheck and privacy scan passed.
- GUI lint and production build passed; docs build produced **146 pages**; `git diff --check` passed.
- Cross-platform CI [30626272772](https://github.com/lidge-jun/opencodex/actions/runs/30626272772) is green on Ubuntu, macOS, Windows, and all three npm-global jobs. React Doctor, target enforcement, PR labeling, and CodeRabbit also passed.
- The explicit security approval remains associated with current head `fa6b3ef2`. The older functional `CHANGES_REQUESTED` review remains for the maintainer to dismiss or re-review; both maintainers are already requested reviewers, so no duplicate ping was added.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive boundaries were reviewed for secrets, auth, and unsafe defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an Antigravity migration marker to validate and control adoption of the static six-model catalog.

- **Bug Fixes**
  - OAuth provider reconciliation now consistently forces and persists the Antigravity static-catalog (`liveModels: false`) behavior, even after migrations and updates.
  - Provider settings saving no longer emits unrelated `liveModels` changes.

- **Documentation**
  - Updated the Providers guide (multiple languages) with clearer Antigravity static-catalog notes.

- **Tests**
  - Added/updated regression, connectivity, and reconciliation tests to ensure no live `/models` fetching and correct `liveModels` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->