### PR TITLE
fix: normalize tool function schemas to always have root type: "object"

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -354,6 +354,61 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
   return !!v && typeof v === "object" && !Array.isArray(v);
 }
 
+/**
+ * Ensure every function tool exposes a valid object JSON Schema at its
+ * `parameters` root. Strict validators (e.g. DeepSeek) reject schemas whose
+ * root `type` is `null`, missing, or non-`"object"` with HTTP 400.
+ *
+ * Codex tools such as `codex_app__automation_update` arrive without a
+ * `parameters` field, which would otherwise serialize to a schema lacking the
+ * root `type`. Walks both top-level `tools` and Responses Lite
+ * `additional_tools[].tools`. Namespace grouping is flattened by earlier strip
+ * steps, so any function tool seen here is already top-level.
+ */
+function normalizeToolSchemas(body: unknown): unknown {
+  if (!isPlainObject(body)) return body;
+
+  const fixFunctionParams = (tool: unknown): unknown => {
+    if (!isPlainObject(tool) || tool.type !== "function") return tool;
+    const params = isPlainObject(tool.parameters) ? { ...tool.parameters } : {};
+    let changed = false;
+    if (params.type !== "object") { params.type = "object"; changed = true; }
+    if (!isPlainObject(params.properties)) { params.properties = {}; changed = true; }
+    return changed ? { ...tool, parameters: params } : tool;
+  };
+
+  let changed = false;
+
+  // Top-level tools array.
+  if (Array.isArray(body.tools)) {
+    const tools = body.tools.map((t) => {
+      const fixed = fixFunctionParams(t);
+      if (fixed !== t) changed = true;
+      return fixed;
+    });
+    if (changed) body = { ...body, tools };
+  }
+
+  // Responses Lite `additional_tools` items embed their own tools arrays.
+  if (Array.isArray(body.input)) {
+    let inputChanged = false;
+    const input = body.input.map((item) => {
+      if (!isPlainObject(item) || item.type !== "additional_tools" || !Array.isArray(item.tools)) return item;
+      let innerChanged = false;
+      const innerTools = item.tools.map((t) => {
+        const fixed = fixFunctionParams(t);
+        if (fixed !== t) innerChanged = true;
+        return fixed;
+      });
+      if (innerChanged) { inputChanged = true; return { ...item, tools: innerTools }; }
+      return item;
+    });
+    if (inputChanged) { changed = true; body = { ...body, input }; }
+  }
+
+  return body;
+}
+
 const MAX_RESPONSES_CALL_ID_LENGTH = 64;
 const REPAIRED_CALL_ID_PREFIX = "call_ocx_";
 const REPAIRED_CALL_ID_DIGEST_LENGTH = MAX_RESPONSES_CALL_ID_LENGTH - REPAIRED_CALL_ID_PREFIX.length;
@@ -938,7 +993,7 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
       if (parsed._compactionRequest === true && !isCanonicalOpenAiForwardProvider(provider)) {
         outBody = buildRoutedCompactionBody(outBody);
       }
-      const sanitizedBody = stripSparkCompatibility(stripUnsupportedReasoningParams(stripItemIdsWhenUnstored(stripInvalidItemIds(stripUnsupportedHostedTools(sanitizeReasoningInputContent(scrubOcxCompactionItems(outBody)))))));
+      const sanitizedBody = normalizeToolSchemas(stripSparkCompatibility(stripUnsupportedReasoningParams(stripItemIdsWhenUnstored(stripInvalidItemIds(stripUnsupportedHostedTools(sanitizeReasoningInputContent(scrubOcxCompactionItems(outBody))))))));
       return {
         url,
         method: "POST",

--- a/src/responses/parser.ts
+++ b/src/responses/parser.ts
@@ -137,11 +137,24 @@ function allowedToolName(tool: unknown): string | undefined {
 function buildTools(tools: unknown[] | undefined): OcxTool[] | undefined {
   if (!tools) return undefined;
   const out: OcxTool[] = [];
+  // Some tool definitions (e.g. Codex `codex_app__automation_update`) arrive
+  // without a `parameters` field or with `parameters: null`. When serialized,
+  // that produces a JSON Schema whose root `type` is `null` (or missing).
+  // Strict validators reject such schemas with HTTP 400
+  // ("schema must be a JSON Schema of 'type: \"object\"', got 'type: null'").
+  // Coerce every function tool's `parameters` to a valid object-schema root
+  // so all downstream adapters pass through cleanly.
+  const normalizeParameters = (raw: unknown): Record<string, unknown> => {
+    const p = isObj(raw) ? { ...raw } : {};
+    if (p.type !== "object") p.type = "object";
+    if (!isObj(p.properties)) p.properties = {};
+    return p;
+  };
   const pushFn = (t: Record<string, unknown>, namespace?: string) => {
     const tool: OcxTool = {
       name: t.name as string,
       description: (t.description as string) ?? "",
-      parameters: (t.parameters ?? {}) as Record<string, unknown>,
+      parameters: normalizeParameters(t.parameters),
     };
     if (t.strict !== undefined) tool.strict = t.strict as boolean;
     if (namespace) tool.namespace = namespace;


### PR DESCRIPTION
## Problem

Some provider APIs (notably DeepSeek) strictly validate JSON Schema in function tool definitions and reject requests where the root `type` is `null` or missing with HTTP 400:

```
Invalid schema for function 'codex_app__automation_update':
schema must be a JSON Schema of 'type: "object"', got 'type: null'.
```

This occurs because Codex injects tools like `codex_app__automation_update` without a `parameters` field. When opencodex forwards the request, the serialized schema has `type: null` (or no `type` at all) at its root.

OpenAI and most other providers tolerate this, but stricter validators reject it. The same issue has been reported across multiple proxy projects:
- cc-switch: [8+ issues](https://github.com/farion1231/cc-switch/issues?q=is%3Aissue+type%3Anull+deepseek) tracking the same root cause
- openclaw: [#106277](https://github.com/openclaw/openclaw/issues/106277)

## Root Cause

Two forwarding paths in opencodex can pass through a broken tool schema:

1. **Adapter translation path**: `buildTools()` in `parser.ts` uses `(t.parameters ?? {})` — when `parameters` is null/absent, the resulting object has no root `type`.
2. **Passthrough path** (used by `wire_api=responses` providers like DeepSeek): `createResponsesPassthroughAdapter` serializes `_rawBody` verbatim. The raw body contains the same broken tool schemas directly.

## Fix

### 1. `src/responses/parser.ts` — `buildTools()`
Added `normalizeParameters()` helper that ensures every function tool's `parameters` is a valid JSON Schema object with `type: "object"` and a `properties` key. Covers the adapter translation path (Anthropic, Gemini, Cursor, etc.).

### 2. `src/adapters/openai-responses.ts` — passthrough adapter
Added `normalizeToolSchemas()` function that walks both top-level `body.tools` and Responses Lite `additional_tools[].tools`, fixing any function tool whose parameters schema is invalid. Inserted into the sanitization chain at the outermost position so it runs regardless of which strip functions are active.

Both changes are idempotent — already-valid schemas pass through unchanged. Tools that are not `type: "function"` are not touched.

## Testing

- [x] `bun build` syntax check on both files
- [x] `bun x tsc --noEmit` typecheck passes
- [x] Unit-tested with edge cases: no `parameters`, `parameters: null`, `type: null`, already-valid schemas, nested `additional_tools`, non-function tool types
- [x] Verified live with DeepSeek (`deepseek-v4-pro` via `wire_api=responses`) — the 400 error is resolved

## Notes

This is a defensive normalization — the output is a valid JSON Schema regardless of what the upstream tool definition provides. The change is minimal (70 lines added across 2 files) and does not alter any existing behavior for already-valid schemas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with strict JSON schema validation for function tools.
  * Automatically fills in missing or invalid tool parameter definitions with a valid object schema.
  * Prevents requests from being rejected when tool parameters are missing, null, or incorrectly structured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->