### PR TITLE
fix(tray): isolate Windows tray host from proxy sockets

### DIFF
--- a/src/tray/windows.ts
+++ b/src/tray/windows.ts
@@ -414,17 +414,43 @@ function assertWindows(): void {
   if (process.platform !== "win32") throw new Error(`The opencodex tray is Windows-only (current platform: ${process.platform}).`);
 }
 
-function spawnTray(state: WindowsTrayEntry): void {
-  const child = spawn(state.bun, [state.cli, "__tray-host"], {
-    detached: true,
+const DETACHED_TRAY_HOST_LAUNCHER = [
+  "$startInfo = New-Object System.Diagnostics.ProcessStartInfo",
+  "$startInfo.FileName = $env:OCX_TRAY_HOST_BUN",
+  "$startInfo.Arguments = $env:OCX_TRAY_HOST_ARGS",
+  "$startInfo.UseShellExecute = $true",
+  "$startInfo.WindowStyle = [System.Diagnostics.ProcessWindowStyle]::Hidden",
+  "$child = [System.Diagnostics.Process]::Start($startInfo)",
+  "if ($null -eq $child) { throw 'Windows tray host did not start.' }",
+  "$child.Dispose()",
+].join("; ");
+
+const DETACHED_TRAY_HOST_LAUNCHER_B64 = Buffer.from(DETACHED_TRAY_HOST_LAUNCHER, "utf16le").toString("base64");
+
+export function launchWindowsTrayHost(state: WindowsTrayEntry): void {
+  const bun = safePath(state.bun);
+  const cli = safePath(state.cli);
+  execFileSync(windowsPowerShellPath(), [
+    "-NoLogo",
+    "-NoProfile",
+    "-NonInteractive",
+    "-EncodedCommand",
+    DETACHED_TRAY_HOST_LAUNCHER_B64,
+  ], {
     stdio: "ignore",
     windowsHide: true,
+    timeout: 15_000,
     env: {
       ...process.env,
+      OCX_TRAY_HOST_BUN: bun,
+      OCX_TRAY_HOST_ARGS: `${quoteRunValue(cli)} __tray-host`,
       OCX_TRAY_ENTRY_B64: Buffer.from(JSON.stringify(state), "utf8").toString("base64"),
     },
   });
-  child.unref();
+}
+
+function spawnTray(state: WindowsTrayEntry): void {
+  launchWindowsTrayHost(state);
 }
 
 function parseTrayHostEntry(): WindowsTrayEntry {
@@ -443,6 +469,8 @@ export async function runWindowsTrayHost(): Promise<void> {
   assertWindows();
   const entry = parseTrayHostEntry();
   delete process.env.OCX_TRAY_ENTRY_B64;
+  delete process.env.OCX_TRAY_HOST_BUN;
+  delete process.env.OCX_TRAY_HOST_ARGS;
   const child = spawn(windowsPowerShellPath(), windowsTrayProcessArgs(entry, "Run", process.pid), {
     stdio: "ignore",
     windowsHide: true,

--- a/tests/helpers/windows-tray-inheritance-child.ts
+++ b/tests/helpers/windows-tray-inheritance-child.ts
@@ -1,0 +1,7 @@
+import { writeFileSync } from "node:fs";
+
+const pidPath = process.env.OCX_TRAY_TEST_PID_FILE;
+if (!pidPath) throw new Error("Missing OCX_TRAY_TEST_PID_FILE.");
+
+writeFileSync(pidPath, String(process.pid));
+await Bun.sleep(30_000);

--- a/tests/windows-tray.test.ts
+++ b/tests/windows-tray.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, readFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   buildWindowsTrayRunCommand,
+  launchWindowsTrayHost,
   parseWindowsTrayRunValue,
   readWindowsTrayRunValueWithAsyncRunner,
   readWindowsTrayRunValueWithRunner,
@@ -195,7 +197,7 @@ describe("Windows tray packaging and command safety", () => {
     const source = readFileSync(join(import.meta.dir, "..", "src", "tray", "windows-tray.ps1"), "utf8");
     expect(typescript).not.toContain("\u0000");
     expect(typescript).toContain("OCX_TRAY_ENTRY_B64");
-    expect(typescript).toContain('detached: true');
+    expect(typescript).toContain("$startInfo.UseShellExecute = $true");
     expect(source).toContain("System.Threading.Mutex");
     expect(source).toContain("System.Threading.EventWaitHandle");
     expect(source).toContain("GetFullPath");
@@ -210,6 +212,57 @@ describe("Windows tray packaging and command safety", () => {
     expect(source).not.toContain("Invoke-Expression");
     expect(source).not.toContain("taskkill");
     expect(source).not.toContain("Stop-Process");
+  });
+
+  test("launches the detached tray host without retaining the proxy listen socket", async () => {
+    if (process.platform !== "win32") return;
+    const directory = mkdtempSync(join(tmpdir(), "ocx-tray-inheritance-"));
+    const pidPath = join(directory, "child.pid");
+    const childPath = join(directory, "child & %TEMP% 테스트.ts");
+    copyFileSync(join(import.meta.dir, "helpers", "windows-tray-inheritance-child.ts"), childPath);
+    const previousPidPath = process.env.OCX_TRAY_TEST_PID_FILE;
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () => new Response("ok"),
+    });
+    const port = server.port;
+    let childPid = 0;
+    let replacement: ReturnType<typeof Bun.serve> | undefined;
+
+    try {
+      process.env.OCX_TRAY_TEST_PID_FILE = pidPath;
+      launchWindowsTrayHost({
+        ...entry,
+        bun: process.execPath,
+        cli: childPath,
+      });
+      for (let attempt = 0; attempt < 100 && !existsSync(pidPath); attempt += 1) {
+        await Bun.sleep(25);
+      }
+      expect(existsSync(pidPath)).toBe(true);
+      childPid = Number(readFileSync(pidPath, "utf8"));
+      expect(Number.isSafeInteger(childPid) && childPid > 0).toBe(true);
+      expect(() => process.kill(childPid, 0)).not.toThrow();
+
+      await server.stop(true);
+      replacement = Bun.serve({
+        hostname: "127.0.0.1",
+        port,
+        fetch: () => new Response("replacement"),
+      });
+      expect(replacement.port).toBe(port);
+      expect(() => process.kill(childPid, 0)).not.toThrow();
+    } finally {
+      if (previousPidPath === undefined) delete process.env.OCX_TRAY_TEST_PID_FILE;
+      else process.env.OCX_TRAY_TEST_PID_FILE = previousPidPath;
+      if (replacement) await replacement.stop(true);
+      await server.stop(true);
+      if (childPid > 0) {
+        try { process.kill(childPid); } catch { /* exact test child already exited */ }
+      }
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 
   test("ships branded multi-size Windows tray icons", () => {


### PR DESCRIPTION
## Summary

- Launch the long-lived Windows tray host through a short `ProcessStartInfo.UseShellExecute=true` PowerShell broker instead of spawning it directly from the live Bun proxy process tree.
- Keep executable and CLI paths out of the PowerShell command text: the encoded launcher is constant, paths are validated with the existing `safePath` rules, and values are passed through environment variables.
- Add a Windows regression test that keeps the tray child alive, stops the originating Bun listener, and proves that the same port can be rebound immediately. The fixture also covers Unicode paths and paths containing `&` and `%TEMP%`.

Fixes #733.

## Root cause and scope

On Windows, Bun 1.3.14 and the tested Bun 1.4 canary can pass an inheritable proxy listen socket through the current `proxy -> tray action -> detached tray host` process lineage. The old proxy can then exit while the long-lived tray host keeps the socket handle open, leaving the prior port unavailable.

This change isolates only the long-lived tray host. It does not change tray registration, registry ownership rules, UAC/elevation behavior, heartbeat semantics, or the tray host's command-line contract. The existing heartbeat remains the authority for whether startup succeeded.

The relevant upstream Bun handle-list work (oven-sh/bun#33160) is currently open and not suitable as a released dependency, so this PR keeps the workaround local and removable.

## Verification

- Bun 1.3.14 focused tray/restart tests: 40 passed.
- Bun 1.4.0-canary.1 focused tray/restart tests: 40 passed.
- The new real-socket regression passed independently on both runtimes and verifies that the child remains alive after the original port is rebound.
- `bun run typecheck`: passed on Bun 1.3.14 and Bun 1.4.0-canary.1.
- `bun run privacy:scan`: passed.
- `git diff --check`: passed.
- The full suite reached a 304-second local limit before producing a final result. The exact descendant process chain belonging to that run was identified by worktree, command line, parent PID, and start time, then terminated and confirmed absent; this is not reported as a full-suite pass.

## Draft status

This remains a draft pending an explicit review of the ShellExecute/environment boundary, AppLocker or EDR compatibility, and a final Windows full-suite run. Those checks are intentionally deferred rather than treated as complete here.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (none required for this internal Windows launch-path fix).
- [ ] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.