### PR TITLE
feat(providers): add Baseten to the free provider directory

### DIFF
--- a/src/providers/free-directory.ts
+++ b/src/providers/free-directory.ts
@@ -18,7 +18,7 @@ export const FREE_PROVIDER_ACCESS_GROUPS = {
   ],
   "recurring-credit": ["bytez", "nous-research"],
   "signup-credit": [
-    "agentrouter", "ai21", "baichuan", "deepinfra", "deepseek", "doubao", "fireworks", "freemodel-dev", "glm-cn",
+    "agentrouter", "ai21", "baichuan", "baseten", "deepinfra", "deepseek", "doubao", "fireworks", "freemodel-dev", "glm-cn",
     "hyperbolic", "longcat", "monsterapi", "nebius", "novita", "nscale", "nvidia", "predibase", "publicai", "qoder",
     "scaleway", "sensenova", "stepfun", "together", "vertex",
   ],
@@ -119,6 +119,9 @@ const CONNECTABLE: Record<string, ConnectableOverride> = {
   agentrouter: { baseUrl: "https://agentrouter.org", dashboardUrl: "https://agentrouter.org", adapter: "anthropic", authKind: "key", supportLevel: "experimental", verification: "primary", modelsUrl: "https://agentrouter.org/v1/models", lastVerified: LAST_VERIFIED, discovery: "live", liveModels: true },
   ai21: openAi("https://api.ai21.com/studio/v1", "https://studio.ai21.com/account/api-key", { supportLevel: "supported", verification: "official", documentationUrl: "https://docs.ai21.com/reference/models" }),
   baichuan: openAi("https://api.baichuan-ai.com/v1", "https://platform.baichuan-ai.com/console/apikey", { verification: "official" }),
+  // Verified end-to-end 2026-07-30: /v1/models returns the OpenAI-shaped live catalog (13 models),
+  // and a chat completion against moonshotai/Kimi-K3 returned a standard chat.completion payload.
+  baseten: openAi("https://inference.baseten.co/v1", "https://app.baseten.co/settings/api_keys", { supportLevel: "supported", verification: "official", documentationUrl: "https://docs.baseten.co/inference/model-apis/overview", modelsUrl: "https://inference.baseten.co/v1/models", lastVerified: "2026-07-30" }),
   deepinfra: openAi("https://api.deepinfra.com/v1/openai", "https://deepinfra.com/dash/api_keys", { supportLevel: "supported", verification: "official", documentationUrl: "https://deepinfra.com/docs/openai_api" }),
   deepseek: openAi("https://api.deepseek.com", "https://platform.deepseek.com/api_keys", { supportLevel: "supported", verification: "official", documentationUrl: "https://api-docs.deepseek.com/api/list-models" }),
   doubao: openAi("https://ark.cn-beijing.volces.com/api/v3", "https://console.volcengine.com/ark/region:ark+cn-beijing/apiKey", { verification: "official" }),


### PR DESCRIPTION
## Summary

- Add Baseten Model APIs to the free provider directory under `signup-credit`
  (new accounts receive free credits per the pricing FAQ) as a connectable
  OpenAI-compatible entry: `https://inference.baseten.co/v1`, key auth, live
  model discovery via `/v1/models`.
- Marked `supported` + `official` with `lastVerified: 2026-07-30` after
  verifying both endpoints live.

## Verification

- `GET /v1/models` with an API key → 200, OpenAI-shaped catalog (13 models).
- `POST /v1/chat/completions` (`moonshotai/Kimi-K3`, `max_tokens: 1`) → 200,
  standard `chat.completion` payload.
- `bun x tsc --noEmit`
- `bun test tests/provider-registry-parity.test.ts` (31 pass)
- `bun test tests/provider-live-models.test.ts tests/opencode-free-provider.test.ts tests/mimo-free-provider.test.ts` (41 pass)

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded signup-credit access to additional providers.
  * Added Baseten as a connectable provider, including setup details and documentation links.
  * Verified Baseten connectivity and chat completion support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->