### PR TITLE
feat(api): serve Codex catalog at GET /api/catalog

### DIFF
--- a/docs-site/src/content/docs/guides/codex-integration.md
+++ b/docs-site/src/content/docs/guides/codex-integration.md
@@ -201,6 +201,19 @@ Add a display name from the CLI (the proxy syncs the catalog right away when liv
 ocx models add deepseek deepseek-v4 --display-name "DeepSeek V4" --context-window 128000
 ```
 
+Remote Codex clients can fetch the same generated catalog over the management API (same
+admission token as other `/api/*` routes):
+
+```bash
+curl -fsS -H "x-opencodex-api-key: $OPENCODEX_ADMIN_AUTH_TOKEN" \
+  "https://proxy.example.com/api/catalog" > "${CODEX_HOME:-$HOME/.codex}/opencodex-catalog.json"
+ocx sync-cache
+```
+
+The response is the raw `opencodex-catalog.json` document (no provider credentials). When
+available, the `x-opencodex-codex-version` header reports the Codex runtime version on the
+server so clients can spot version skew.
+
 You can also set or edit it through the management API (`POST /api/custom-models`,
 `PUT /api/custom-models/<id>` with a `displayName` string) and the web dashboard. A `/` is rejected
 because it would collide with the routed-slug separator.

--- a/docs-site/src/content/docs/guides/codex-integration.md
+++ b/docs-site/src/content/docs/guides/codex-integration.md
@@ -205,8 +205,11 @@ Remote Codex clients can fetch the same generated catalog over the management AP
 admission token as other `/api/*` routes):
 
 ```bash
+dest="${CODEX_HOME:-$HOME/.codex}/opencodex-catalog.json"
+tmp="$(mktemp "${dest}.XXXXXX")"
 curl -fsS -H "x-opencodex-api-key: $OPENCODEX_ADMIN_AUTH_TOKEN" \
-  "https://proxy.example.com/api/catalog" > "${CODEX_HOME:-$HOME/.codex}/opencodex-catalog.json"
+  "https://proxy.example.com/api/catalog" > "$tmp" \
+  && mv "$tmp" "$dest"
 ocx sync-cache
 ```
 

--- a/src/codex/catalog.ts
+++ b/src/codex/catalog.ts
@@ -1,6 +1,6 @@
 // AUTO-SPLIT facade: original catalog.ts body moved into ./catalog/* modules.
 // Public surface preserved exactly; importers keep using "src/codex/catalog".
-export { isMediaGenerationModelId, shouldExposeRoutedModel, readCodexCatalogPath, normalizeRoutedCatalogEntry, catalogModelSlug, filterSupportedNativeSlugs, catalogModelSupportsReasoningSummaries } from "./catalog/parsing";
+export { isMediaGenerationModelId, shouldExposeRoutedModel, readCodexCatalogPath, readCatalog, normalizeRoutedCatalogEntry, catalogModelSlug, filterSupportedNativeSlugs, catalogModelSupportsReasoningSummaries } from "./catalog/parsing";
 export type { CatalogModel, MultiAgentMode } from "./catalog/parsing";
 export { NATIVE_OPENAI_MODELS, nativeOpenAiContextWindow, disabledNativeSlugs, visibleNativeSlugs, nativeModelRows, applyNativeVisibility, upstreamNativeEntry, nativeOpenAiSlugs, listCatalogNativeSlugs } from "./catalog/metadata";
 export { isSpawnableCodexCandidate, codexExecInvocation, loadBundledCodexCatalog, materializeBundledCodexCatalog, loadCatalogTemplate } from "./catalog/bundled";

--- a/src/server/management/model-routes.ts
+++ b/src/server/management/model-routes.ts
@@ -72,11 +72,9 @@ export async function handleModelRoutes(ctx: ManagementContext): Promise<Respons
       "Content-Type": "application/json",
       ...corsHeaders(req, config),
     };
-    try {
-      const { resolveCodexRuntime } = await import("../../codex/runtime");
-      const version = resolveCodexRuntime().runtime.version;
-      if (version) headers["x-opencodex-codex-version"] = version;
-    } catch { /* best-effort skew hint */ }
+    const { loadPersistedCodexRuntime } = await import("../../codex/runtime");
+    const version = loadPersistedCodexRuntime()?.selectedVersion;
+    if (version) headers["x-opencodex-codex-version"] = version;
     return new Response(JSON.stringify(catalog), { status: 200, headers });
   }
 

--- a/src/server/management/model-routes.ts
+++ b/src/server/management/model-routes.ts
@@ -54,7 +54,7 @@ import { drainAndShutdown } from "../lifecycle";
 import { filterRequestLogs, getRequestLogEntries, type RequestLogEntry } from "../request-log";
 import { estimateComboCost, estimateRequestCost, normalizeCostTokens, tokensPerSecond } from "../../usage/cost";
 import type { PersistedUsageAttempt } from "../../usage/log";
-import { isAllowedRequestOrigin, jsonResponse, providerManagementConfigError, publicProviderBaseUrl, safeConfigDTO } from "../auth-cors";
+import { isAllowedRequestOrigin, jsonResponse, providerManagementConfigError, publicProviderBaseUrl, safeConfigDTO, corsHeaders } from "../auth-cors";
 import { applySystemEnvToggle } from "../system-env";
 
 import { isPlainRecord, parseDebugLogQuery, tokPerSecondResult, unavailableCostReason, costResult, requestLogDto, stripRegistryOnlyStaticHeaders, fetchAllModels } from "./shared";
@@ -63,6 +63,22 @@ import type { ManagementContext } from "./context";
 
 export async function handleModelRoutes(ctx: ManagementContext): Promise<Response | null> {
   const { req, url, config, deps, refreshCodexCatalogBestEffort, syncClaudeAgentDefsBestEffort } = ctx;
+
+  if (url.pathname === "/api/catalog" && req.method === "GET") {
+    const { readCatalog, readCodexCatalogPath } = await import("../../codex/catalog");
+    const catalog = readCatalog(readCodexCatalogPath());
+    if (!catalog) return jsonResponse({ error: "catalog not found" }, 404, req, config);
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      ...corsHeaders(req, config),
+    };
+    try {
+      const { resolveCodexRuntime } = await import("../../codex/runtime");
+      const version = resolveCodexRuntime().runtime.version;
+      if (version) headers["x-opencodex-codex-version"] = version;
+    } catch { /* best-effort skew hint */ }
+    return new Response(JSON.stringify(catalog), { status: 200, headers });
+  }
 
   if (url.pathname === "/api/models" && req.method === "GET") {
     const models = await fetchAllModels(config);

--- a/tests/api-catalog-route.test.ts
+++ b/tests/api-catalog-route.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "bun:test";
+import { isAllowedManagementOrigin } from "../src/server/auth-cors";
+import type { OcxConfig } from "../src/types";
+
+// Smoke: route module exports stay importable; full e2e covered elsewhere once landed with auth harness.
+describe("GET /api/catalog route (#709)", () => {
+  test("model-routes module loads", async () => {
+    const mod = await import("../src/server/management/model-routes");
+    expect(typeof mod.handleModelRoutes).toBe("function");
+  });
+});

--- a/tests/api-catalog-route.test.ts
+++ b/tests/api-catalog-route.test.ts
@@ -1,11 +1,77 @@
-import { describe, expect, test } from "bun:test";
-import { isAllowedManagementOrigin } from "../src/server/auth-cors";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { handleManagementAPI } from "../src/server/management-api";
+import { loadConfig, saveConfig } from "../src/config";
+import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+import { ManagementRequest, managementHeaders } from "./helpers/management-auth";
 import type { OcxConfig } from "../src/types";
 
-// Smoke: route module exports stay importable; full e2e covered elsewhere once landed with auth harness.
+const TEST_DIR = join(import.meta.dir, `.tmp-api-catalog-route-${process.pid}`);
+const previousOpencodexHome = process.env.OPENCODEX_HOME;
+let isolatedCodexHome: IsolatedCodexHome | null = null;
+
+beforeEach(() => {
+  if (previousOpencodexHome === undefined) mkdirSync(TEST_DIR, { recursive: true });
+  process.env.OPENCODEX_HOME = TEST_DIR;
+  isolatedCodexHome = null;
+  saveConfig({
+    port: 10100,
+    hostname: "127.0.0.1",
+    defaultProvider: "mock",
+    providers: {
+      mock: { adapter: "openai-chat", baseUrl: "http://127.0.0.1:1/v1", apiKey: "k", allowPrivateNetwork: true, models: ["test-model"] },
+    },
+  } as OcxConfig);
+});
+
+afterEach(() => {
+  isolatedCodexHome?.restore();
+  isolatedCodexHome = null;
+  if (previousOpencodexHome === undefined) {
+    delete process.env.OPENCODEX_HOME;
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  } else {
+    process.env.OPENCODEX_HOME = previousOpencodexHome;
+  }
+});
+
 describe("GET /api/catalog route (#709)", () => {
-  test("model-routes module loads", async () => {
-    const mod = await import("../src/server/management/model-routes");
-    expect(typeof mod.handleModelRoutes).toBe("function");
+  test("returns the on-disk catalog and omits sync runtime probes for version hint", async () => {
+    isolatedCodexHome = installIsolatedCodexHome("ocx-api-catalog-");
+    const catalog = {
+      models: [{
+        slug: "mock/test-model",
+        display_name: "Mock Test",
+        description: "fixture",
+        priority: 1,
+        visibility: "list",
+        base_instructions: "You are a helpful coding assistant.",
+        input_modalities: ["text"],
+      }],
+    };
+    writeFileSync(join(isolatedCodexHome.path, "opencodex-catalog.json"), JSON.stringify(catalog));
+
+    const url = new URL("http://localhost/api/catalog");
+    const response = await handleManagementAPI(
+      new ManagementRequest(url, { headers: managementHeaders() }),
+      url,
+      loadConfig(),
+    );
+    expect(response?.status).toBe(200);
+    expect(await response!.json()).toEqual(catalog);
+    expect(response!.headers.get("x-opencodex-codex-version")).toBeNull();
+  });
+
+  test("returns 404 when the catalog file is missing", async () => {
+    isolatedCodexHome = installIsolatedCodexHome("ocx-api-catalog-missing-");
+    const url = new URL("http://localhost/api/catalog");
+    const response = await handleManagementAPI(
+      new ManagementRequest(url, { headers: managementHeaders() }),
+      url,
+      loadConfig(),
+    );
+    expect(response?.status).toBe(404);
+    expect(await response!.json()).toEqual({ error: "catalog not found" });
   });
 });


### PR DESCRIPTION
## Summary
- Expose Codex model catalog via GET /api/catalog on the management API.
- Document catalog endpoint in Codex integration guide.

Fixes #709

## Test plan
- [ ] Focused server/management tests and manual GET /api/catalog

## Security
- none