### PR TITLE
fix(security): allow TLS terminator Origin scheme skew for management

### DIFF
--- a/src/server/auth-cors.ts
+++ b/src/server/auth-cors.ts
@@ -89,6 +89,11 @@ function isExtraAllowedOrigin(origin: string, cfg: OcxConfig): boolean {
   });
 }
 
+function normalizedPort(url: URL): string {
+  if (url.port) return url.port;
+  return url.protocol === "https:" ? "443" : "80";
+}
+
 /** True when Origin and the process-derived origin share a host across http/https (TLS terminator). */
 function sameManagementHost(origin: string, requestOrigin: string): boolean {
   try {
@@ -98,8 +103,14 @@ function sameManagementHost(origin: string, requestOrigin: string): boolean {
     if (right.protocol !== "http:" && right.protocol !== "https:") return false;
     if (left.hostname.toLowerCase() !== right.hostname.toLowerCase()) return false;
     // Same scheme with unequal origins means a port (or rare URL) mismatch — keep fail-closed.
+    if (left.protocol === right.protocol) return false;
     // Cross-scheme only: browser https Origin vs process http Host behind a TLS terminator.
-    return left.protocol !== right.protocol;
+    if (left.protocol !== "https:" || right.protocol !== "http:") return false;
+    const leftPort = normalizedPort(left);
+    const rightPort = normalizedPort(right);
+    // Public https:443 in front of an internal http listener on :80 is the common terminator shape.
+    if (leftPort === rightPort) return true;
+    return leftPort === "443" && rightPort === "80";
   } catch {
     return false;
   }

--- a/src/server/auth-cors.ts
+++ b/src/server/auth-cors.ts
@@ -70,22 +70,39 @@ export function isSameOriginAsRequest(req: Request, origin: string): boolean {
 }
 
 export function isAllowedRequestOrigin(req: Request, config: OcxConfig): boolean {
-  function isExtraAllowedOrigin(origin: string, cfg: OcxConfig): boolean {
-    if (!cfg.corsAllowOrigins?.length) return false;
-    return cfg.corsAllowOrigins.some(allowed => {
-      try {
-        return new URL(allowed).origin === new URL(origin).origin;
-      } catch {
-        return allowed === origin;
-      }
-    });
-  }
   const origin = req.headers.get("Origin");
   if (!isApiAuthRequired(config)) {
     if (!isLoopbackRequestHost(req.headers.get("Host"))) return false;
     return !origin || isLoopbackOriginValue(origin) || isExtraAllowedOrigin(origin, config);
   }
   return !origin || isLoopbackOriginValue(origin) || isSameOriginAsRequest(req, origin) || isExtraAllowedOrigin(origin, config);
+}
+
+function isExtraAllowedOrigin(origin: string, cfg: OcxConfig): boolean {
+  if (!cfg.corsAllowOrigins?.length) return false;
+  return cfg.corsAllowOrigins.some(allowed => {
+    try {
+      return new URL(allowed).origin === new URL(origin).origin;
+    } catch {
+      return allowed === origin;
+    }
+  });
+}
+
+/** True when Origin and the process-derived origin share a host across http/https (TLS terminator). */
+function sameManagementHost(origin: string, requestOrigin: string): boolean {
+  try {
+    const left = new URL(origin);
+    const right = new URL(requestOrigin);
+    if (left.protocol !== "http:" && left.protocol !== "https:") return false;
+    if (right.protocol !== "http:" && right.protocol !== "https:") return false;
+    if (left.hostname.toLowerCase() !== right.hostname.toLowerCase()) return false;
+    // Same scheme with unequal origins means a port (or rare URL) mismatch — keep fail-closed.
+    // Cross-scheme only: browser https Origin vs process http Host behind a TLS terminator.
+    return left.protocol !== right.protocol;
+  } catch {
+    return false;
+  }
 }
 
 export function managementRequestOrigin(req: Request, config: OcxConfig): string | null {
@@ -106,7 +123,14 @@ export function isAllowedManagementOrigin(req: Request, config: OcxConfig): bool
   const requestOrigin = managementRequestOrigin(req, config);
   if (!requestOrigin) return false;
   const origin = req.headers.get("Origin");
-  return !origin || origin === requestOrigin;
+  if (!origin) return true;
+  if (origin === requestOrigin) return true;
+  // Explicit operator allowlist (documented reverse-proxy deployments).
+  if (isExtraAllowedOrigin(origin, config)) return true;
+  // TLS-terminating reverse proxy: browser sends https://host while the process sees http://host.
+  // Hostname match is enough; credentials still required by requireManagementAuth.
+  if (sameManagementHost(origin, requestOrigin)) return true;
+  return false;
 }
 
 export function browserSecurityHeaders(): Record<string, string> {

--- a/src/server/auth-cors.ts
+++ b/src/server/auth-cors.ts
@@ -89,33 +89,6 @@ function isExtraAllowedOrigin(origin: string, cfg: OcxConfig): boolean {
   });
 }
 
-function normalizedPort(url: URL): string {
-  if (url.port) return url.port;
-  return url.protocol === "https:" ? "443" : "80";
-}
-
-/** True when Origin and the process-derived origin share a host across http/https (TLS terminator). */
-function sameManagementHost(origin: string, requestOrigin: string): boolean {
-  try {
-    const left = new URL(origin);
-    const right = new URL(requestOrigin);
-    if (left.protocol !== "http:" && left.protocol !== "https:") return false;
-    if (right.protocol !== "http:" && right.protocol !== "https:") return false;
-    if (left.hostname.toLowerCase() !== right.hostname.toLowerCase()) return false;
-    // Same scheme with unequal origins means a port (or rare URL) mismatch — keep fail-closed.
-    if (left.protocol === right.protocol) return false;
-    // Cross-scheme only: browser https Origin vs process http Host behind a TLS terminator.
-    if (left.protocol !== "https:" || right.protocol !== "http:") return false;
-    const leftPort = normalizedPort(left);
-    const rightPort = normalizedPort(right);
-    // Public https:443 in front of an internal http listener on :80 is the common terminator shape.
-    if (leftPort === rightPort) return true;
-    return leftPort === "443" && rightPort === "80";
-  } catch {
-    return false;
-  }
-}
-
 export function managementRequestOrigin(req: Request, config: OcxConfig): string | null {
   const host = req.headers.get("Host");
   const parsedHost = parseHttpHost(host);
@@ -134,14 +107,9 @@ export function isAllowedManagementOrigin(req: Request, config: OcxConfig): bool
   const requestOrigin = managementRequestOrigin(req, config);
   if (!requestOrigin) return false;
   const origin = req.headers.get("Origin");
-  if (!origin) return true;
-  if (origin === requestOrigin) return true;
-  // Explicit operator allowlist (documented reverse-proxy deployments).
-  if (isExtraAllowedOrigin(origin, config)) return true;
-  // TLS-terminating reverse proxy: browser sends https://host while the process sees http://host.
-  // Hostname match is enough; credentials still required by requireManagementAuth.
-  if (sameManagementHost(origin, requestOrigin)) return true;
-  return false;
+  // Exact match against the process-derived origin, or an operator-listed corsAllowOrigins
+  // entry (covers TLS-terminator https://… when the process observes http://…).
+  return !origin || origin === requestOrigin || isExtraAllowedOrigin(origin, config);
 }
 
 export function browserSecurityHeaders(): Record<string, string> {

--- a/tests/management-origin-tls.test.ts
+++ b/tests/management-origin-tls.test.ts
@@ -45,6 +45,17 @@ describe("management origin behind TLS termination (#760)", () => {
     expect(isAllowedManagementOrigin(req, config({ hostname: "127.0.0.1" }))).toBe(false);
   });
 
+  test("rejects cross-scheme Origins on a different public port", () => {
+    const req = new Request("http://proxy.example.com/api/config", {
+      method: "GET",
+      headers: {
+        Host: "proxy.example.com",
+        Origin: "https://proxy.example.com:4443",
+      },
+    });
+    expect(isAllowedManagementOrigin(req, config({ hostname: "0.0.0.0" }))).toBe(false);
+  });
+
   test("honours corsAllowOrigins for an explicit external origin", () => {
     const req = new Request("http://127.0.0.1:10100/api/v2", {
       method: "PUT",

--- a/tests/management-origin-tls.test.ts
+++ b/tests/management-origin-tls.test.ts
@@ -12,7 +12,7 @@ function config(partial: Partial<OcxConfig> = {}): OcxConfig {
 }
 
 describe("management origin behind TLS termination (#760)", () => {
-  test("allows https Origin when the process sees http with the same Host", () => {
+  test("does not auto-admit https Origin when Host is http without corsAllowOrigins", () => {
     const req = new Request("http://127.0.0.1:10100/api/v2", {
       method: "PUT",
       headers: {
@@ -20,7 +20,33 @@ describe("management origin behind TLS termination (#760)", () => {
         Origin: "https://proxy.example.com",
       },
     });
-    expect(isAllowedManagementOrigin(req, config())).toBe(true);
+    expect(isAllowedManagementOrigin(req, config())).toBe(false);
+  });
+
+  test("admits https Origin listed in corsAllowOrigins on a remote bind", () => {
+    const req = new Request("http://127.0.0.1:10100/api/v2", {
+      method: "PUT",
+      headers: {
+        Host: "proxy.example.com",
+        Origin: "https://proxy.example.com",
+      },
+    });
+    expect(isAllowedManagementOrigin(req, config({
+      corsAllowOrigins: ["https://proxy.example.com"],
+    }))).toBe(true);
+  });
+
+  test("admits OPTIONS preflight for an allowlisted https Origin", () => {
+    const req = new Request("http://127.0.0.1:10100/api/v2", {
+      method: "OPTIONS",
+      headers: {
+        Host: "proxy.example.com",
+        Origin: "https://proxy.example.com",
+      },
+    });
+    expect(isAllowedManagementOrigin(req, config({
+      corsAllowOrigins: ["https://proxy.example.com"],
+    }))).toBe(true);
   });
 
   test("still rejects a different Origin host", () => {
@@ -31,7 +57,9 @@ describe("management origin behind TLS termination (#760)", () => {
         Origin: "https://evil.example.com",
       },
     });
-    expect(isAllowedManagementOrigin(req, config())).toBe(false);
+    expect(isAllowedManagementOrigin(req, config({
+      corsAllowOrigins: ["https://proxy.example.com"],
+    }))).toBe(false);
   });
 
   test("still rejects same-scheme cross-port Origins", () => {
@@ -45,7 +73,7 @@ describe("management origin behind TLS termination (#760)", () => {
     expect(isAllowedManagementOrigin(req, config({ hostname: "127.0.0.1" }))).toBe(false);
   });
 
-  test("rejects cross-scheme Origins on a different public port", () => {
+  test("rejects allowlisted host on a different public port", () => {
     const req = new Request("http://proxy.example.com/api/config", {
       method: "GET",
       headers: {
@@ -53,7 +81,10 @@ describe("management origin behind TLS termination (#760)", () => {
         Origin: "https://proxy.example.com:4443",
       },
     });
-    expect(isAllowedManagementOrigin(req, config({ hostname: "0.0.0.0" }))).toBe(false);
+    expect(isAllowedManagementOrigin(req, config({
+      hostname: "0.0.0.0",
+      corsAllowOrigins: ["https://proxy.example.com"],
+    }))).toBe(false);
   });
 
   test("honours corsAllowOrigins for an explicit external origin", () => {

--- a/tests/management-origin-tls.test.ts
+++ b/tests/management-origin-tls.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { isAllowedManagementOrigin } from "../src/server/auth-cors";
+import type { OcxConfig } from "../src/types";
+
+function config(partial: Partial<OcxConfig> = {}): OcxConfig {
+  return {
+    port: 10100,
+    hostname: "0.0.0.0",
+    providers: {},
+    ...partial,
+  } as OcxConfig;
+}
+
+describe("management origin behind TLS termination (#760)", () => {
+  test("allows https Origin when the process sees http with the same Host", () => {
+    const req = new Request("http://127.0.0.1:10100/api/v2", {
+      method: "PUT",
+      headers: {
+        Host: "proxy.example.com",
+        Origin: "https://proxy.example.com",
+      },
+    });
+    expect(isAllowedManagementOrigin(req, config())).toBe(true);
+  });
+
+  test("still rejects a different Origin host", () => {
+    const req = new Request("http://127.0.0.1:10100/api/v2", {
+      method: "PUT",
+      headers: {
+        Host: "proxy.example.com",
+        Origin: "https://evil.example.com",
+      },
+    });
+    expect(isAllowedManagementOrigin(req, config())).toBe(false);
+  });
+
+  test("still rejects same-scheme cross-port Origins", () => {
+    const req = new Request("http://127.0.0.1:10100/api/config", {
+      method: "GET",
+      headers: {
+        Host: "127.0.0.1:10100",
+        Origin: "http://127.0.0.1:65534",
+      },
+    });
+    expect(isAllowedManagementOrigin(req, config({ hostname: "127.0.0.1" }))).toBe(false);
+  });
+
+  test("honours corsAllowOrigins for an explicit external origin", () => {
+    const req = new Request("http://127.0.0.1:10100/api/v2", {
+      method: "PUT",
+      headers: {
+        Host: "internal.example.com",
+        Origin: "https://dashboard.example.com",
+      },
+    });
+    expect(isAllowedManagementOrigin(req, config({
+      corsAllowOrigins: ["https://dashboard.example.com"],
+    }))).toBe(true);
+  });
+});

--- a/tests/storage-cleanup.test.ts
+++ b/tests/storage-cleanup.test.ts
@@ -458,6 +458,8 @@ describe("executeArchivedCleanup", () => {
     expect(existsSync(join(home, ".trash", "77", "rollout-old.jsonl"))).toBe(false);
   });
 
+  // Windows CI: permanent cleanup + spawn/dynamic-tool SQLite work can exceed Bun's
+  // default 5s under runner load (timed out at 5.5s on PR #779).
   test("deletes spawn edges with parent_thread_id/child_thread_id and cascades dynamic tools", () => {
     home = buildHome({ withSpawnEdges: true, withDynamicTools: true });
     // Delete both sides of the edge together so referenced_history does not fire.
@@ -467,7 +469,7 @@ describe("executeArchivedCleanup", () => {
     expect(db.query("SELECT COUNT(*) AS n FROM thread_spawn_edges").get() as { n: number }).toEqual({ n: 0 });
     expect(db.query("SELECT COUNT(*) AS n FROM thread_dynamic_tools").get() as { n: number }).toEqual({ n: 0 });
     db.close();
-  });
+  }, { timeout: STORE_BUDGET_MS });
 
   test("rejects candidates still referenced by a live spawn edge", () => {
     home = buildHome({ withSpawnEdges: true });


### PR DESCRIPTION
## Summary
Fixes #760

Allows TLS terminator Origin scheme skew for management API requests.

## Security
Credential-aware / corsAllowOrigins; session origin+CSRF unchanged.

## Test plan
- [ ] CI green
- [ ] Management origin/TLS regression tests