### PR TITLE
fix(catalog): strip non-Codex input_modalities like video

### DIFF
--- a/src/codex/catalog.ts
+++ b/src/codex/catalog.ts
@@ -1,6 +1,6 @@
 // AUTO-SPLIT facade: original catalog.ts body moved into ./catalog/* modules.
 // Public surface preserved exactly; importers keep using "src/codex/catalog".
-export { isMediaGenerationModelId, shouldExposeRoutedModel, readCodexCatalogPath, normalizeRoutedCatalogEntry, catalogModelSlug, filterSupportedNativeSlugs, catalogModelSupportsReasoningSummaries } from "./catalog/parsing";
+export { isMediaGenerationModelId, shouldExposeRoutedModel, readCodexCatalogPath, readCatalog, normalizeRoutedCatalogEntry, catalogModelSlug, filterSupportedNativeSlugs, catalogModelSupportsReasoningSummaries, sanitizeCodexInputModalities, repairCatalogInputModalities, CODEX_CATALOG_INPUT_MODALITIES, ensureStrictCatalogFields } from "./catalog/parsing";
 export type { CatalogModel, MultiAgentMode } from "./catalog/parsing";
 export { NATIVE_OPENAI_MODELS, nativeOpenAiContextWindow, disabledNativeSlugs, visibleNativeSlugs, nativeModelRows, applyNativeVisibility, upstreamNativeEntry, nativeOpenAiSlugs, listCatalogNativeSlugs } from "./catalog/metadata";
 export { isSpawnableCodexCandidate, codexExecInvocation, loadBundledCodexCatalog, materializeBundledCodexCatalog, loadCatalogTemplate } from "./catalog/bundled";

--- a/src/codex/catalog/bundled.ts
+++ b/src/codex/catalog/bundled.ts
@@ -31,7 +31,7 @@ import { redactSecretString } from "../../lib/redact";
 import upstreamModelsSnapshot from "../data/upstream-models.json";
 
 
-import { activeCodexModelsCachePath, catalogBackupPathFor, findNativeTemplate, isDefaultCatalogPath, legacyCatalogBackupPath, parseCatalogJson, readCatalog, readCatalogBackup, readCodexCatalogPath } from "./parsing";
+import { activeCodexModelsCachePath, catalogBackupPathFor, findNativeTemplate, isDefaultCatalogPath, legacyCatalogBackupPath, parseCatalogJson, readCatalog, readCatalogBackup, readCodexCatalogPath, repairCatalogInputModalities } from "./parsing";
 import type { RawCatalog, RawEntry } from "./parsing";
 import { codexExecInvocation, isSpawnableCodexCandidate } from "../exec-invocation";
 import { resolveAndPersistCodexRuntime } from "../runtime";
@@ -219,6 +219,7 @@ export function loadCatalogForSync(path: string): RawCatalog | null {
   const bundled = isDefaultCatalogPath(path) ? loadBundledCodexCatalog() : null;
   if (bundled) return JSON.parse(JSON.stringify(bundled)) as RawCatalog;
   const catalog = readCatalog(path);
+  if (catalog) repairCatalogInputModalities(catalog);
   if (catalog && findNativeTemplate(catalog)) return catalog;
   return readCatalog(catalogBackupPathFor(path))
     ?? (isDefaultCatalogPath(path) ? readCatalog(legacyCatalogBackupPath()) : null)

--- a/src/codex/catalog/parsing.ts
+++ b/src/codex/catalog/parsing.ts
@@ -228,6 +228,42 @@ export function normalizeServiceTiers(entry: RawEntry): RawEntry {
   return entry;
 }
 
+/** Codex catalog parser accepts only these input modality enum values. */
+export const CODEX_CATALOG_INPUT_MODALITIES = ["text", "image", "audio"] as const;
+
+export type CodexCatalogInputModality = typeof CODEX_CATALOG_INPUT_MODALITIES[number];
+
+const CODEX_CATALOG_INPUT_MODALITY_SET = new Set<string>(CODEX_CATALOG_INPUT_MODALITIES);
+
+/** Strip out-of-enum modalities (e.g. provider-advertised `video`) before Codex reads the catalog. */
+export function sanitizeCodexInputModalities(modalities: unknown): CodexCatalogInputModality[] {
+  if (!Array.isArray(modalities)) return ["text"];
+  const out: CodexCatalogInputModality[] = [];
+  for (const value of modalities) {
+    if (typeof value !== "string") continue;
+    const normalized = value.trim().toLowerCase();
+    if (!CODEX_CATALOG_INPUT_MODALITY_SET.has(normalized)) continue;
+    const modality = normalized as CodexCatalogInputModality;
+    if (!out.includes(modality)) out.push(modality);
+  }
+  return out.length > 0 ? out : ["text"];
+}
+
+/** Repair poisoned on-disk catalog rows so sync can rewrite a Codex-parseable file. */
+export function repairCatalogInputModalities(catalog: RawCatalog): boolean {
+  let changed = false;
+  for (const entry of catalog.models ?? []) {
+    if (!Array.isArray(entry.input_modalities)) continue;
+    const sanitized = sanitizeCodexInputModalities(entry.input_modalities);
+    const previous = entry.input_modalities as unknown[];
+    if (JSON.stringify(sanitized) !== JSON.stringify(previous)) {
+      entry.input_modalities = sanitized;
+      changed = true;
+    }
+  }
+  return changed;
+}
+
 export function ensureAutoCompactTokenLimit(entry: RawEntry): RawEntry {
   if (
     typeof entry.context_window === "number"
@@ -271,7 +307,9 @@ export function ensureStrictCatalogFields(
   if (typeof entry.supports_parallel_tool_calls !== "boolean") entry.supports_parallel_tool_calls = true;
   if (typeof entry.supports_image_detail_original !== "boolean") entry.supports_image_detail_original = false;
   if (!Array.isArray(entry.experimental_supported_tools)) entry.experimental_supported_tools = [];
-  if (!Array.isArray(entry.input_modalities) && !options.preserveExactInputModalities) {
+  if (Array.isArray(entry.input_modalities)) {
+    entry.input_modalities = sanitizeCodexInputModalities(entry.input_modalities);
+  } else if (!options.preserveExactInputModalities) {
     entry.input_modalities = ["text"];
   }
   const contextWindow = typeof entry.context_window === "number" && entry.context_window > 0 ? entry.context_window : 128000;

--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -324,7 +324,7 @@ function modelInputModalities(
       ?? capabilityRecord?.input_modalities,
     8,
     24,
-  )?.filter(value => value === "text" || value === "image" || value === "audio" || value === "video");
+  )?.filter(value => value === "text" || value === "image" || value === "audio");
   if (explicit && explicit.length > 0) return explicit;
   if (capabilityRecord?.vision === false) return ["text"];
   if (capabilityRecord?.vision === true || capabilities?.some(value => value === "vision" || value === "image-input")) {

--- a/tests/catalog-input-modality-enum.test.ts
+++ b/tests/catalog-input-modality-enum.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildCatalogEntries,
+  ensureStrictCatalogFields,
+  mergeCatalogEntriesForSync,
+  repairCatalogInputModalities,
+  resetCatalogRuntimeStateForTests,
+  sanitizeCodexInputModalities,
+  syncCatalogModels,
+} from "../src/codex/catalog";
+import { catalogHintsFromModelsApiItem } from "../src/codex/catalog/provider-fetch";
+import { handleManagementAPI } from "../src/server/management-api";
+import type { OcxConfig } from "../src/types";
+
+const previousCodexHome = process.env.CODEX_HOME;
+
+afterEach(() => {
+  resetCatalogRuntimeStateForTests();
+  if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+  else process.env.CODEX_HOME = previousCodexHome;
+});
+
+describe("Codex catalog input_modalities enum", () => {
+  test("sanitizeCodexInputModalities drops video and keeps text|image|audio", () => {
+    expect(sanitizeCodexInputModalities(["text", "video", "image", "audio", "video"])).toEqual(["text", "image", "audio"]);
+    expect(sanitizeCodexInputModalities(["video"])).toEqual(["text"]);
+    expect(sanitizeCodexInputModalities(undefined)).toEqual(["text"]);
+  });
+
+  test("ensureStrictCatalogFields strips video even when preserveExactInputModalities is true", () => {
+    const entry = ensureStrictCatalogFields({
+      slug: "combo/test-alias",
+      input_modalities: ["text", "video", "image"],
+    }, { preserveExactInputModalities: true, isRouted: true });
+    expect(entry.input_modalities).toEqual(["text", "image"]);
+  });
+
+  test("provider model discovery metadata never advertises video to the catalog builder", () => {
+    const hints = catalogHintsFromModelsApiItem("zenmux", {
+      id: "meta-muse-spark-1.1",
+      input_modalities: ["text", "image", "video"],
+    });
+    expect(hints.inputModalities).toEqual(["text", "image"]);
+  });
+
+  test("mergeCatalogEntriesForSync repairs poisoned on-disk modalities", () => {
+    const merged = mergeCatalogEntriesForSync(
+      [{
+        slug: "fakeprov/poisoned",
+        input_modalities: ["text", "video"],
+        visibility: "list",
+        priority: 5,
+      }],
+      [],
+      new Map(),
+      [],
+      false,
+    );
+    expect(merged[0]?.input_modalities).toEqual(["text"]);
+  });
+
+  test("syncCatalogModels rewrites a poisoned catalog file to Codex-safe modalities", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ocx-catalog-enum-"));
+    process.env.CODEX_HOME = dir;
+    const catalogPath = join(dir, "opencodex-catalog.json");
+    writeFileSync(catalogPath, JSON.stringify({
+      models: [{
+        slug: "gpt-5.5",
+        display_name: "gpt-5.5",
+        description: "native",
+        priority: 1,
+        visibility: "list",
+        base_instructions: "You are a helpful coding assistant.",
+        input_modalities: ["text", "video"],
+      }, {
+        slug: "fakeprov/routed",
+        display_name: "fakeprov/routed",
+        description: "routed",
+        priority: 5,
+        visibility: "list",
+        base_instructions: "You are a helpful coding assistant.",
+        input_modalities: ["text", "video", "image"],
+      }],
+    }, null, 2) + "\n");
+    writeFileSync(join(dir, "config.toml"), `model_catalog_json = "${catalogPath.replace(/\\/g, "/")}"\n`);
+
+    const config: OcxConfig = {
+      port: 10100,
+      defaultProvider: "fakeprov",
+      providers: {
+        fakeprov: {
+          adapter: "openai-chat",
+          baseUrl: "https://api.example.test/v1",
+          liveModels: false,
+          models: ["routed"],
+          fetch: (() => { throw new Error("unexpected fetch"); }) as typeof fetch,
+        },
+      },
+    };
+
+    await syncCatalogModels(config);
+    const written = JSON.parse(readFileSync(catalogPath, "utf8")) as { models: Array<{ slug?: string; input_modalities?: string[] }> };
+    for (const entry of written.models) {
+      expect(entry.input_modalities?.includes("video")).toBe(false);
+      expect(entry.input_modalities?.every(value => value === "text" || value === "image" || value === "audio")).toBe(true);
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("GET /api/catalog", () => {
+  test("returns the on-disk catalog under management auth without secrets", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ocx-catalog-api-"));
+    process.env.CODEX_HOME = dir;
+    const catalogPath = join(dir, "opencodex-catalog.json");
+    writeFileSync(catalogPath, JSON.stringify({
+      models: [{
+        slug: "gpt-5.5",
+        display_name: "gpt-5.5",
+        description: "native",
+        priority: 1,
+        visibility: "list",
+        base_instructions: "You are a helpful coding assistant.",
+        input_modalities: ["text", "image"],
+      }],
+    }, null, 2) + "\n");
+    writeFileSync(join(dir, "config.toml"), `model_catalog_json = "${catalogPath.replace(/\\/g, "/")}"\n`);
+
+    const url = new URL("http://127.0.0.1/api/catalog");
+    const response = await handleManagementAPI(
+      new Request(url, { headers: { Host: "127.0.0.1" } }),
+      url,
+      { port: 10100, hostname: "127.0.0.1" },
+    );
+    expect(response?.status).toBe(200);
+    const body = await response!.json() as { models: Array<{ slug?: string }> };
+    expect(body.models.some(entry => entry.slug === "gpt-5.5")).toBe(true);
+    expect(JSON.stringify(body)).not.toMatch(/api[_-]?key|sk-[a-z0-9]/i);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("catalog builder choke point", () => {
+  test("buildCatalogEntries never serializes video into input_modalities", () => {
+    const entries = buildCatalogEntries(null, [], [{
+      provider: "fakeprov",
+      id: "video-model",
+      inputModalities: ["text", "video", "image"],
+    }], [], false);
+    const routed = entries.find(entry => entry.slug === "fakeprov/video-model");
+    expect(routed?.input_modalities).toEqual(["text", "image"]);
+  });
+
+  test("repairCatalogInputModalities reports and fixes poisoned rows", () => {
+    const catalog = { models: [{ slug: "x/y", input_modalities: ["text", "video"] }] };
+    expect(repairCatalogInputModalities(catalog)).toBe(true);
+    expect(catalog.models[0]?.input_modalities).toEqual(["text"]);
+    expect(repairCatalogInputModalities(catalog)).toBe(false);
+  });
+});

--- a/tests/catalog-input-modality-enum.test.ts
+++ b/tests/catalog-input-modality-enum.test.ts
@@ -111,37 +111,6 @@ describe("Codex catalog input_modalities enum", () => {
   });
 });
 
-describe("GET /api/catalog", () => {
-  test("returns the on-disk catalog under management auth without secrets", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "ocx-catalog-api-"));
-    process.env.CODEX_HOME = dir;
-    const catalogPath = join(dir, "opencodex-catalog.json");
-    writeFileSync(catalogPath, JSON.stringify({
-      models: [{
-        slug: "gpt-5.5",
-        display_name: "gpt-5.5",
-        description: "native",
-        priority: 1,
-        visibility: "list",
-        base_instructions: "You are a helpful coding assistant.",
-        input_modalities: ["text", "image"],
-      }],
-    }, null, 2) + "\n");
-    writeFileSync(join(dir, "config.toml"), `model_catalog_json = "${catalogPath.replace(/\\/g, "/")}"\n`);
-
-    const url = new URL("http://127.0.0.1/api/catalog");
-    const response = await handleManagementAPI(
-      new Request(url, { headers: { Host: "127.0.0.1" } }),
-      url,
-      { port: 10100, hostname: "127.0.0.1" },
-    );
-    expect(response?.status).toBe(200);
-    const body = await response!.json() as { models: Array<{ slug?: string }> };
-    expect(body.models.some(entry => entry.slug === "gpt-5.5")).toBe(true);
-    expect(JSON.stringify(body)).not.toMatch(/api[_-]?key|sk-[a-z0-9]/i);
-    rmSync(dir, { recursive: true, force: true });
-  });
-});
 
 describe("catalog builder choke point", () => {
   test("buildCatalogEntries never serializes video into input_modalities", () => {


### PR DESCRIPTION
## Summary
- Sanitize provider video modalities so Codex catalog JSON cannot reject the whole file.

## Test plan
- [ ] Focused unit/regression tests for this change
- [ ] `bun run typecheck` / CI green

## Security
See research/security notes on #759 where applicable.

Fixes #759