### PR TITLE
fix(cli): doctor warns on empty provider apiKey env refs

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -307,11 +307,45 @@ export type ConfiguredProxyDiagnostic = {
   detail: string;
 };
 
-function envReferenceName(value: string): string | null {
+export function envReferenceName(value: string): string | null {
   const braced = value.match(/^\$\{(\w+)\}$/);
   if (braced) return braced[1]!;
   const bare = value.match(/^\$(\w+)$/);
   return bare ? bare[1]! : null;
+}
+
+export type ProviderApiKeyDiagnostic = {
+  provider: string;
+  envName: string;
+  detail: string;
+};
+
+/** Warn when a key-auth provider's apiKey env reference resolves empty in this process. */
+export function collectProviderApiKeyDiagnostics(
+  providers: Record<string, { authMode?: string; apiKey?: string }> = readConfigDiagnostics().config.providers ?? {},
+  env: EnvMap = process.env,
+): ProviderApiKeyDiagnostic[] {
+  const resolveInEnv = (value: string): string | undefined => {
+    const name = envReferenceName(value);
+    if (!name) return value;
+    return env[name];
+  };
+  const rows: ProviderApiKeyDiagnostic[] = [];
+  for (const [provider, config] of Object.entries(providers)) {
+    if (config.authMode !== "key") continue;
+    const raw = typeof config.apiKey === "string" ? config.apiKey.trim() : "";
+    if (!raw) continue;
+    const envName = envReferenceName(raw);
+    if (!envName) continue;
+    const resolved = resolveInEnv(raw);
+    if (resolved?.trim()) continue;
+    rows.push({
+      provider,
+      envName,
+      detail: `provider ${provider}: env reference ${envName} is unset or empty in this process`,
+    });
+  }
+  return rows;
 }
 
 export function collectConfiguredProxy(): ConfiguredProxyDiagnostic {
@@ -742,6 +776,16 @@ export async function runDoctor(args: string[] = []): Promise<void> {
   console.log("\nConfigured proxy (value hidden)");
   console.log(`  ${configuredProxy.present ? "set    " : "unset  "} ${configuredProxy.key} (${configuredProxy.source}; ${configuredProxy.detail})`);
 
+  const providerApiKeys = collectProviderApiKeyDiagnostics(doctorConfig.providers);
+  console.log("\nProvider API keys (value hidden)");
+  if (providerApiKeys.length === 0) {
+    console.log("  ok     no empty env-referenced provider keys detected in this process");
+  } else {
+    for (const row of providerApiKeys) {
+      console.log(`  !!     ${row.detail}`);
+    }
+  }
+
   console.log("\nRunning proxy process proxy env (presence only)");
   if (runningProxyEnv.status === "not_running") {
     console.log("  --     no running ocx proxy process found");
@@ -825,6 +869,9 @@ export async function runDoctor(args: string[] = []): Promise<void> {
     serviceViable: startup.serviceViable,
   });
   if (proxyDown) hints.push(proxyDown);
+  for (const row of providerApiKeys) {
+    hints.push(`${row.detail}. Set ${row.envName} in the shell that starts the proxy, or store a literal key in config (value hidden here).`);
+  }
   const anyDrvfs = paths.some(p => detectFsType(p.path, mounts).isDrvfs || detectFsType(p.path, mounts).isMntDrive);
   const noProxy = currentProxyEnv.every(p => !p.present) && !configuredProxy.present;
   if (!startup.rebootSafe) {

--- a/tests/doctor-provider-apikey.test.ts
+++ b/tests/doctor-provider-apikey.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { collectProviderApiKeyDiagnostics } from "../src/cli/doctor";
+
+describe("doctor provider apiKey env diagnostics (#762)", () => {
+  test("warns when a key-auth env reference resolves empty without printing secrets", () => {
+    const rows = collectProviderApiKeyDiagnostics({
+      openrouter: {
+        authMode: "key",
+        apiKey: "${OPENROUTER_API_KEY}",
+      },
+    }, {});
+    expect(rows).toEqual([{
+      provider: "openrouter",
+      envName: "OPENROUTER_API_KEY",
+      detail: "provider openrouter: env reference OPENROUTER_API_KEY is unset or empty in this process",
+    }]);
+  });
+
+  test("passes when the referenced env var is set", () => {
+    const rows = collectProviderApiKeyDiagnostics({
+      openrouter: {
+        authMode: "key",
+        apiKey: "${OPENROUTER_API_KEY}",
+      },
+    }, { OPENROUTER_API_KEY: "secret-value" });
+    expect(rows).toEqual([]);
+  });
+
+  test("ignores literal keys and non-key providers", () => {
+    const rows = collectProviderApiKeyDiagnostics({
+      openrouter: { authMode: "key", apiKey: "sk-live-not-an-env-ref" },
+      openai: { authMode: "forward", apiKey: "${SHOULD_NOT_MATTER}" },
+    }, {});
+    expect(rows).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Surface unresolved ${ENV} provider apiKey references in ocx doctor before inference fails.

## Test plan
- [ ] Focused unit/regression tests for this change
- [ ] `bun run typecheck` / CI green

## Security
See research/security notes on #762 where applicable.

Fixes #762