### PR TITLE
fix(gui): render dashboard log timestamps in server timezone

### DIFF
--- a/gui/src/pages/Logs.tsx
+++ b/gui/src/pages/Logs.tsx
@@ -368,9 +368,10 @@ export default function Logs({ apiBase }: { apiBase: string }) {
     // failures flicker between the error banner, empty state, and stale table.
     if (!silent) setLoading(true);
     try {
-      const res = await fetch(`${apiBase}/api/logs`);
+      const res = await fetch(`${apiBase}/api/logs?limit=2000`);
       if (!res.ok) throw new Error(`${res.status} ${res.statusText}`.trim());
-      const next = await res.json() as LogEntry[];
+      const body = await res.json() as LogEntry[] | { logs?: LogEntry[] };
+      const next = Array.isArray(body) ? body : (body.logs ?? []);
       setLogs(next);
       writeSessionListCache(logsCacheKey(apiBase), next);
       setError(null);

--- a/gui/src/pages/Logs.tsx
+++ b/gui/src/pages/Logs.tsx
@@ -280,12 +280,12 @@ function statusColor(status: number): string {
   return "var(--amber)";
 }
 
-function formatLogTimestamp(ts: number, localeTag?: string): string {
-  return new Date(ts).toLocaleTimeString(localeTag);
+function formatLogTimestamp(ts: number, localeTag?: string, timeZone?: string): string {
+  return new Date(ts).toLocaleTimeString(localeTag, timeZone ? { timeZone } : undefined);
 }
 
-function formatLogDateTime(ts: number, localeTag?: string): string {
-  return new Date(ts).toLocaleString(localeTag);
+function formatLogDateTime(ts: number, localeTag?: string, timeZone?: string): string {
+  return new Date(ts).toLocaleString(localeTag, timeZone ? { timeZone } : undefined);
 }
 
 function modelTitle(log: LogEntry): string {
@@ -333,6 +333,7 @@ export default function Logs({ apiBase }: { apiBase: string }) {
   const { t, locale } = useI18n();
   const cachedLogs = readSessionListCache<LogEntry[]>(logsCacheKey(apiBase));
   const [logs, setLogs] = useState<LogEntry[]>(() => cachedLogs ?? []);
+  const [serverTimeZone, setServerTimeZone] = useState<string | undefined>();
   const [loading, setLoading] = useState(() => !(cachedLogs && cachedLogs.length > 0));
   const [error, setError] = useState<string | null>(null);
   const [autoRefresh, setAutoRefresh] = useState(true);
@@ -370,8 +371,11 @@ export default function Logs({ apiBase }: { apiBase: string }) {
     try {
       const res = await fetch(`${apiBase}/api/logs?limit=2000`);
       if (!res.ok) throw new Error(`${res.status} ${res.statusText}`.trim());
-      const body = await res.json() as LogEntry[] | { logs?: LogEntry[] };
+      const body = await res.json() as LogEntry[] | { logs?: LogEntry[]; timeZone?: string };
       const next = Array.isArray(body) ? body : (body.logs ?? []);
+      if (!Array.isArray(body) && typeof body.timeZone === "string" && body.timeZone.trim()) {
+        setServerTimeZone(body.timeZone.trim());
+      }
       setLogs(next);
       writeSessionListCache(logsCacheKey(apiBase), next);
       setError(null);
@@ -592,7 +596,7 @@ export default function Logs({ apiBase }: { apiBase: string }) {
                  data-index={virtualRow.index}
                  ref={rowVirtualizer.measureElement}
                >
-                 <td className="muted mono">{formatLogTimestamp(log.timestamp, localeTag)}</td>
+                 <td className="muted mono">{formatLogTimestamp(log.timestamp, localeTag, serverTimeZone)}</td>
                   <td className="num mono log-col-tokens" title={tokensTitle(log, t)}>
                     {(() => {
                       const tokenTotal = displayContextTokenTotal(log);
@@ -679,6 +683,7 @@ export default function Logs({ apiBase }: { apiBase: string }) {
           detailInfo={detailInfo}
           localeCode={locale}
           localeTag={localeTag}
+          serverTimeZone={serverTimeZone}
           t={t}
           onClose={() => setDetail(null)}
           onFilterConversation={id => {
@@ -704,12 +709,13 @@ function useModalDialog(open: boolean) {
 }
 
 function LogDetailDialog({
-  detail, detailInfo, localeCode, localeTag, t, onClose, onFilterConversation,
+  detail, detailInfo, localeCode, localeTag, serverTimeZone, t, onClose, onFilterConversation,
 }: {
   detail: LogEntry;
   detailInfo: ReturnType<typeof statusCodeInfo> | null;
   localeCode: string;
   localeTag?: string;
+  serverTimeZone?: string;
   t: TFn;
   onClose: () => void;
   onFilterConversation?: (conversationId: string) => void;
@@ -751,7 +757,7 @@ function LogDetailDialog({
         <section className="log-detail-section" aria-labelledby="log-detail-basic">
           <h4 id="log-detail-basic" className="log-detail-section-title">{t("logs.detail.section.basic")}</h4>
           <div className="log-detail-grid">
-            <span className="muted">{t("logs.col.time")}</span><span className="mono">{formatLogDateTime(detail.timestamp, localeTag)}</span>
+            <span className="muted">{t("logs.col.time")}</span><span className="mono">{formatLogDateTime(detail.timestamp, localeTag, serverTimeZone)}</span>
             <span className="muted">{t("logs.col.request")}</span>
             <span className="log-detail-request-row">
               <span className="mono log-detail-break">{detail.requestId ?? "\u2014"}</span>

--- a/src/server/management/config-routes.ts
+++ b/src/server/management/config-routes.ts
@@ -110,6 +110,7 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
       );
     }
     return jsonResponse({
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       codexAutoStart: codexAutoStartEnabled(config),
       port: config.port,
       hostname: config.hostname ?? "127.0.0.1",

--- a/src/server/management/logs-usage-routes.ts
+++ b/src/server/management/logs-usage-routes.ts
@@ -124,8 +124,13 @@ export async function handleLogsUsageRoutes(ctx: ManagementContext): Promise<Res
   const { req, url, config, deps, refreshCodexCatalogBestEffort, syncClaudeAgentDefsBestEffort } = ctx;
 
   if (url.pathname === "/api/logs" && req.method === "GET") {
-    const logs = filterRequestLogs(getRequestLogEntries(), url.searchParams);
-    return jsonResponse(logs.map(requestLogDto));
+    const all = getRequestLogEntries();
+    const logs = filterRequestLogs(all, url.searchParams);
+    return jsonResponse({
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      total: all.length,
+      logs: logs.map(requestLogDto),
+    });
   }
 
   if (url.pathname === "/api/debug" && req.method === "GET") {

--- a/src/server/request-log.ts
+++ b/src/server/request-log.ts
@@ -126,7 +126,7 @@ export interface RequestLogEntry {
 }
 
 const requestLog: RequestLogEntry[] = [];
-const MAX_LOG_SIZE = 200;
+const MAX_LOG_SIZE = 2000;
 let requestLogSeq = 0;
 /** True after hydrateRequestLogsFromDisk ran once in this process. */
 let requestLogsHydratedFromDisk = false;
@@ -759,6 +759,17 @@ export function filterRequestLogs(logs: RequestLogEntry[], params: URLSearchPara
   if (tailRaw) {
     const tail = Number.parseInt(tailRaw, 10);
     if (Number.isFinite(tail) && tail > 0) filtered = filtered.slice(-Math.min(tail, MAX_LOG_SIZE));
+  }
+  const offsetRaw = params.get("offset")?.trim();
+  const limitRaw = params.get("limit")?.trim();
+  if (limitRaw) {
+    const limit = Number.parseInt(limitRaw, 10);
+    const offset = offsetRaw ? Number.parseInt(offsetRaw, 10) : 0;
+    if (Number.isFinite(limit) && limit > 0) {
+      const capped = Math.min(limit, MAX_LOG_SIZE);
+      const start = Number.isFinite(offset) && offset > 0 ? offset : 0;
+      filtered = filtered.slice(start, start + capped);
+    }
   }
   return filtered;
 }

--- a/tests/helpers/logs-api.ts
+++ b/tests/helpers/logs-api.ts
@@ -1,0 +1,7 @@
+export function logsFromApiBody<T extends Record<string, unknown> = Record<string, unknown>>(body: unknown): T[] {
+  if (Array.isArray(body)) return body as T[];
+  if (body && typeof body === "object" && Array.isArray((body as { logs?: unknown }).logs)) {
+    return (body as { logs: T[] }).logs;
+  }
+  return [];
+}

--- a/tests/management-api-logs-metrics.test.ts
+++ b/tests/management-api-logs-metrics.test.ts
@@ -16,7 +16,10 @@ async function readLogs(): Promise<Array<Record<string, any>>> {
   const url = new URL("http://localhost/api/logs");
   const response = await handleManagementAPI(new Request(url), url, config);
   expect(response?.status).toBe(200);
-  return await response!.json() as Array<Record<string, any>>;
+  const body = await response!.json() as { logs?: Array<Record<string, any>>; timeZone?: string };
+  expect(typeof body.timeZone).toBe("string");
+  expect(body.timeZone!.length).toBeGreaterThan(0);
+  return body.logs ?? [];
 }
 
 function baseEntry(overrides: Partial<RequestLogEntry>): RequestLogEntry {

--- a/tests/openai-api-virtual-models.test.ts
+++ b/tests/openai-api-virtual-models.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { logsFromApiBody } from "./helpers/logs-api";
 import { managementHeaders } from "./helpers/management-auth";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -231,7 +232,8 @@ describe("OpenAI API compact transport", () => {
 
     const server = startServer(0);
     const readLogs = () => originalFetch(new URL("/api/logs", server.url), { headers: managementHeaders() })
-      .then(response => response.json()) as Promise<Array<Record<string, unknown>>>;
+      .then(response => response.json())
+      .then(body => logsFromApiBody(body));
     const readUsage = (): Array<Record<string, unknown>> => existsSync(usageLogPath())
       ? readFileSync(usageLogPath(), "utf8").trim().split("\n").filter(Boolean).map(line => JSON.parse(line) as Record<string, unknown>)
       : [];
@@ -399,7 +401,8 @@ describe("OpenAI API Pro transport identities", () => {
       ? readFileSync(usageLogPath(), "utf8").trim().split("\n").filter(Boolean).map(line => JSON.parse(line) as Record<string, unknown>)
       : [];
     const readLogs = () => originalFetch(new URL("/api/logs", server.url), { headers: managementHeaders() })
-      .then(response => response.json()) as Promise<Array<Record<string, unknown>>>;
+      .then(response => response.json())
+      .then(body => logsFromApiBody(body));
     const expectOnePersisted = async (
       beforeLogs: number,
       beforeUsage: number,

--- a/tests/openai-provider-option-e2e.test.ts
+++ b/tests/openai-provider-option-e2e.test.ts
@@ -1,3 +1,4 @@
+import { logsFromApiBody } from "./helpers/logs-api";
 import { describe, expect, test } from "bun:test";
 import { managementFetch as fetch } from "./helpers/management-auth";
 import { createHash } from "node:crypto";
@@ -486,7 +487,7 @@ describe("OpenAI provider-option integration spine", () => {
       expect((await put("/api/injection-model", { model: selected, effort: "high" })).status).toBe(200);
       expect(await local("/api/injection-model").then(response => response.json())).toMatchObject({ model: selected, effort: "high" });
 
-      const logs = await local("/api/logs").then(response => response.json()) as Array<Record<string, unknown>>;
+      const logs = logsFromApiBody(await local("/api/logs").then(response => response.json()));
       expect(logs.some(row => row.provider === "openai-p123abc"
         && row.requestedModel === "gpt-5.6-sol"
         && row.resolvedModel === "gpt-5.6-sol")).toBe(true);

--- a/tests/request-log.test.ts
+++ b/tests/request-log.test.ts
@@ -544,6 +544,12 @@ describe("request log metadata", () => {
     expect(combined.map(entry => entry.requestId)).toEqual(["c"]);
   });
 
+  test("filters logs by offset and limit", () => {
+    const logs = Array.from({ length: 5 }, (_, i) => log({ requestId: `r${i}`, provider: "openai", status: 200 }));
+    expect(filterRequestLogs(logs, new URLSearchParams("limit=2")).map(entry => entry.requestId)).toEqual(["r0", "r1"]);
+    expect(filterRequestLogs(logs, new URLSearchParams("offset=2&limit=2")).map(entry => entry.requestId)).toEqual(["r2", "r3"]);
+  });
+
   test("deferred JSON logging preserves response service tier before final log", async () => {
     const entries: RequestLogEntry[] = [];
     const logCtx = {
@@ -1250,7 +1256,7 @@ describe("request log restart hydrate", () => {
 
   test("hydrate keeps only the newest MAX_LOG_SIZE rows from a long usage.jsonl", () => {
     clearRequestLogsForTests();
-    const persisted: PersistedUsageEntry[] = Array.from({ length: 205 }, (_, i) => ({
+    const persisted: PersistedUsageEntry[] = Array.from({ length: 2005 }, (_, i) => ({
       requestId: `ocx-${i}`,
       timestamp: i,
       provider: "openai",
@@ -1259,10 +1265,10 @@ describe("request log restart hydrate", () => {
       durationMs: 1,
       usageStatus: "unreported" as const,
     }));
-    expect(hydrateRequestLogsFromDisk(() => persisted)).toBe(200);
+    expect(hydrateRequestLogsFromDisk(() => persisted)).toBe(2000);
     const ids = getRequestLogEntries().map(e => e.requestId);
     expect(ids[0]).toBe("ocx-5");
-    expect(ids.at(-1)).toBe("ocx-204");
+    expect(ids.at(-1)).toBe("ocx-2004");
   });
 
   test("hydrate swallows usage.jsonl read failures instead of crashing startup", () => {

--- a/tests/server-403-permission-e2e.test.ts
+++ b/tests/server-403-permission-e2e.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { logsFromApiBody } from "./helpers/logs-api";
 import { managementFetch as fetch } from "./helpers/management-auth";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -83,11 +84,7 @@ async function runUpstreamFailure(status: 401 | 403, body: unknown): Promise<{
     const payload = await response.json() as {
       error: { message?: string; type?: string; code?: string | null };
     };
-    const logs = await fetch(new URL("/api/logs?tail=1", proxy.url)).then(res => res.json()) as Array<{
-      status?: number;
-      errorCode?: string;
-      upstreamError?: string;
-    }>;
+    const logs = logsFromApiBody(await fetch(new URL("/api/logs?tail=1", proxy.url)).then(res => res.json()));
     return {
       path,
       responseStatus: response.status,

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { logsFromApiBody } from "./helpers/logs-api";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { request as httpRequest } from "node:http";
 import { tmpdir } from "node:os";
@@ -1620,7 +1621,7 @@ describe("server local API auth", () => {
       ws.close();
 
       expect(seenAuth).toEqual(["Bearer old-access-token", "Bearer new-access-token"]);
-      const logs = await fetch(new URL("/api/logs?tail=2", server.url), { headers: managementHeaders() }).then(r => r.json()) as Array<{ status: number }>;
+      const logs = logsFromApiBody(await fetch(new URL("/api/logs?tail=2", server.url), { headers: managementHeaders() }).then(r => r.json()));
       expect(logs.map(entry => entry.status)).toEqual([200, 200]);
     } finally {
       Date.now = originalNow;
@@ -1692,14 +1693,7 @@ describe("server local API auth", () => {
       await waitForTerminal();
       ws.close();
 
-      const logs = await fetch(new URL("/api/logs?tail=1", server.url), { headers: managementHeaders() }).then(r => r.json()) as Array<{
-        status: number;
-        terminalStatus?: string;
-        closeReason?: string;
-        usageStatus?: string;
-        totalTokens?: number;
-        usage?: { inputTokens: number; outputTokens: number; cachedInputTokens?: number };
-      }>;
+      const logs = logsFromApiBody(await fetch(new URL("/api/logs?tail=1", server.url), { headers: managementHeaders() }).then(r => r.json()));
       expect(logs.at(-1)).toMatchObject({
         status: 200,
         terminalStatus: "completed",
@@ -2210,7 +2204,7 @@ describe("server local API auth", () => {
         consecutiveFailures: 3,
         lastFailureStatus: 502,
       });
-      const logs = await fetch(new URL("/api/logs?tail=1", server.url), { headers: managementHeaders() }).then(r => r.json()) as Array<{ status: number; errorCode?: string; terminalStatus?: string; closeReason?: string }>;
+      const logs = logsFromApiBody(await fetch(new URL("/api/logs?tail=1", server.url), { headers: managementHeaders() }).then(r => r.json()));
       expect(logs.at(-1)).toMatchObject({
         status: 502,
         errorCode: "upstream_server_error",
@@ -2266,14 +2260,7 @@ describe("server local API auth", () => {
 
       expect(response.status).toBe(200);
       await response.text();
-      const logs = await fetch(new URL("/api/logs?tail=1", server.url), { headers: managementHeaders() }).then(r => r.json()) as Array<{
-        status: number;
-        terminalStatus?: string;
-        closeReason?: string;
-        usageStatus?: string;
-        totalTokens?: number;
-        usage?: { inputTokens: number; outputTokens: number; cachedInputTokens?: number; reasoningOutputTokens?: number };
-      }>;
+      const logs = logsFromApiBody(await fetch(new URL("/api/logs?tail=1", server.url), { headers: managementHeaders() }).then(r => r.json()));
       expect(logs.at(-1)).toMatchObject({
         status: 200,
         terminalStatus: "completed",

--- a/tests/server-combo-failover-e2e.test.ts
+++ b/tests/server-combo-failover-e2e.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, setDefaultTimeout, test } from "bun:test";
+import { logsFromApiBody } from "./helpers/logs-api";
 import { managementFetch as fetch, ManagementRequest as Request } from "./helpers/management-auth";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -286,7 +287,7 @@ async function postModelLogged(
 
 async function latestAttemptReceipts(config: OcxConfig) {
   const response = await management(config, "GET", "/api/logs?tail=1");
-  const logs = await response!.json() as Array<Record<string, unknown>>;
+  const logs = logsFromApiBody(await response!.json());
   const usage = readUsageEntries();
   return { log: logs[0]!, usage: usage.at(-1)! };
 }
@@ -493,7 +494,7 @@ describe("server combo failover 030 activation matrix", () => {
     clearRequestLogsForTests();
     expect(hydrateRequestLogsFromDisk()).toBe(1);
     const hydratedResponse = await management(config, "GET", "/api/logs?tail=1");
-    const hydrated = await hydratedResponse!.json() as Array<Record<string, unknown>>;
+    const hydrated = logsFromApiBody(await hydratedResponse!.json());
     expect(hydrated).toHaveLength(1);
     expectMappedReceipt(hydrated[0]!);
   });


### PR DESCRIPTION
## Summary
- Use server timeZone from the logs/settings APIs when formatting dashboard timestamps.

## Test plan
- [ ] Focused unit/regression tests for this change
- [ ] `bun run typecheck` / CI green

## Security
See research/security notes on #725 where applicable.

Fixes #725

Depends on the PR for #726 (log pagination /api/logs envelope).