### PR TITLE
fix(oauth): normalize Antigravity refresh margin

### DIFF
--- a/src/oauth/google-antigravity.ts
+++ b/src/oauth/google-antigravity.ts
@@ -32,7 +32,8 @@ const SCOPES = [
 ];
 const CALLBACK_PORT = 51121;
 const CALLBACK_PATH = "/callback";
-const REFRESH_SKEW_MS = 50 * 60 * 1000; // refresh proactively ~50min before nominal 1h expiry
+// Keep provider-side margins small: the shared OAuth freshness gate applies an additional minute.
+const REFRESH_SKEW_MS = 5 * 60 * 1000;
 const REQUEST_TIMEOUT_MS = 30_000;
 const ONBOARD_ATTEMPTS = 5;
 const ONBOARD_POLL_MS = 2_000;

--- a/src/oauth/types.ts
+++ b/src/oauth/types.ts
@@ -13,7 +13,8 @@ export interface KiroOAuthMetadata {
 export type OAuthCredentials = {
   refresh: string;
   access: string;
-  expires: number; // epoch ms (already skew-adjusted by the provider flow)
+  /** Epoch ms after any small provider-specific early-refresh margin; the shared gate adds 1 minute. */
+  expires: number;
   email?: string;
   accountId?: string;
   source?: OAuthCredentialSource;

--- a/tests/google-antigravity-oauth.test.ts
+++ b/tests/google-antigravity-oauth.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { discoverAntigravityProject, refreshAntigravityToken } from "../src/oauth/google-antigravity";
 import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -84,15 +84,21 @@ describe("antigravity refresh", () => {
       if (url.includes(":loadCodeAssist")) return new Response(JSON.stringify({ cloudaicompanionProject: "proj-R" }), { status: 200 });
       return new Response("no", { status: 404 });
     });
-    const issuedAt = Date.now();
-    const cred = await refreshAntigravityToken("refresh-tok");
+    const issuedAt = 1_900_000_000_000;
+    const nowSpy = spyOn(Date, "now").mockReturnValue(issuedAt);
+    const cred = await (async () => {
+      try {
+        return await refreshAntigravityToken("refresh-tok");
+      } finally {
+        nowSpy.mockRestore();
+      }
+    })();
     expect(cred.access).toBe("fresh-access");
     expect(cred.refresh).toBe("refresh-tok");
     expect(cred.projectId).toBe("proj-R");
     // A one-hour Google token must retain roughly 55 minutes after the provider margin. The
     // previous 50-minute margin stored only ten minutes and caused repeated refreshes in use.
-    expect(cred.expires - issuedAt).toBeGreaterThanOrEqual(54 * 60 * 1000);
-    expect(cred.expires - issuedAt).toBeLessThanOrEqual(60 * 60 * 1000);
+    expect(cred.expires - issuedAt).toBe(55 * 60 * 1000);
   });
 
   test("refresh failure carries status only, not the response body", async () => {

--- a/tests/google-antigravity-oauth.test.ts
+++ b/tests/google-antigravity-oauth.test.ts
@@ -84,10 +84,15 @@ describe("antigravity refresh", () => {
       if (url.includes(":loadCodeAssist")) return new Response(JSON.stringify({ cloudaicompanionProject: "proj-R" }), { status: 200 });
       return new Response("no", { status: 404 });
     });
+    const issuedAt = Date.now();
     const cred = await refreshAntigravityToken("refresh-tok");
     expect(cred.access).toBe("fresh-access");
     expect(cred.refresh).toBe("refresh-tok");
     expect(cred.projectId).toBe("proj-R");
+    // A one-hour Google token must retain roughly 55 minutes after the provider margin. The
+    // previous 50-minute margin stored only ten minutes and caused repeated refreshes in use.
+    expect(cred.expires - issuedAt).toBeGreaterThanOrEqual(54 * 60 * 1000);
+    expect(cred.expires - issuedAt).toBeLessThanOrEqual(60 * 60 * 1000);
   });
 
   test("refresh failure carries status only, not the response body", async () => {


### PR DESCRIPTION
## What changed

- reduce the Antigravity provider refresh margin from 50 minutes to 5 minutes
- document that the shared OAuth freshness gate adds a further one-minute margin
- add a regression assertion for nominal one-hour token lifetime

## Why

A 50-minute provider margin stored only about ten minutes of a one-hour Google token lifetime, causing repeated refreshes during active use.

Closes #828

## Checks

- bun test tests/google-antigravity-oauth.test.ts
- bun x tsc --noEmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth token refresh timing to reduce unnecessary early refreshes.
  * Preserved refreshed tokens for closer to their full one-hour validity period.
* **Documentation**
  * Clarified token expiration timing and the refresh margins applied during authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->