### PR TITLE
fix(codex): preserve auto-compaction limit on inject

### DIFF
--- a/src/codex/inject.ts
+++ b/src/codex/inject.ts
@@ -296,10 +296,10 @@ function stripExistingModelProvider(content: string): string {
 }
 
 /**
- * Drop ROOT-level `model_context_window` / `model_auto_compact_token_limit` overrides (keys before
- * the first table header). Codex treats these root keys as a global override that wins over the
- * per-model catalog values, so a stale `model_context_window = 1000000` makes every model (e.g.
- * gpt-5.5) report a 1M window. Stripping them on (re)injection lets the catalog drive context size.
+ * Drop ROOT-level `model_context_window` overrides (keys before the first table header). Codex
+ * treats this root key as a global override that wins over the per-model catalog values, so a stale
+ * `model_context_window = 1000000` makes every model (e.g. gpt-5.5) report a 1M window. User-owned
+ * compaction limits do not alter the advertised context window and must survive reinjection.
  */
 export function stripRootContextWindowOverrides(content: string): string {
   const lines = content.split("\n");
@@ -307,7 +307,7 @@ export function stripRootContextWindowOverrides(content: string): string {
   return lines
     .filter((line, i) => {
       const isRoot = firstTable === -1 || i < firstTable;
-      return !isRoot || !/^\s*model_(?:context_window|auto_compact_token_limit)\s*=/.test(line);
+      return !isRoot || !/^\s*model_context_window\s*=/.test(line);
     })
     .join("\n");
 }

--- a/tests/codex-inject.test.ts
+++ b/tests/codex-inject.test.ts
@@ -60,6 +60,7 @@ describe("Codex config injection", () => {
       'model_provider = "opencodex"',
       "model_context_window = 1000000",
       "model_auto_compact_token_limit = 900000",
+      'model_auto_compact_token_limit_scope = "total"',
       'model = "gpt-5.5"',
       "",
       "[model_providers.opencodex]",
@@ -68,9 +69,10 @@ describe("Codex config injection", () => {
       "",
     ].join("\n"));
 
-    // Root-level overrides (before the first table header) are removed.
+    // Only the stale root context-window override is removed. Compaction is a user-owned limit.
     expect(cleaned).not.toMatch(/^model_context_window = 1000000$/m);
-    expect(cleaned).not.toMatch(/^model_auto_compact_token_limit = 900000$/m);
+    expect(cleaned).toContain("model_auto_compact_token_limit = 900000");
+    expect(cleaned).toContain('model_auto_compact_token_limit_scope = "total"');
     // Non-context-window root keys are untouched.
     expect(cleaned).toContain('model_provider = "opencodex"');
     expect(cleaned).toContain('model = "gpt-5.5"');


### PR DESCRIPTION
## What changed

- strip only the stale root model_context_window override during OpenCodex injection
- preserve the user-owned model_auto_compact_token_limit and scope
- cover root and nested config behavior in the injection regression test

## Why

The cleanup helper was broader than its context-window purpose and silently removed a valid user compaction threshold on every reinjection.

Closes #817

## Checks

- bun test tests/codex-inject.test.ts
- bun x tsc --noEmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved root-level automatic compaction token limits when cleaning up stale context-window settings.
  * Continued removing only outdated root-level context-window overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->