### PR TITLE
fix(router): pin Codex auto review to OpenAI

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -306,8 +306,13 @@ export class NoEnabledOpenAiProviderError extends Error {
   }
 }
 
+// Codex uses a small number of control-plane model ids that are not part of the public GPT/o
+// naming families. Keep this exact: a broad `codex-*` rule could capture a third-party model.
+const CODEX_INTERNAL_OPENAI_MODELS = new Set(["codex-auto-review"]);
+
 function isBareOpenAiFamilyModel(modelId: string): boolean {
-  return !modelId.includes("/") && /^(?:gpt-|o1-|o3-|o4-)/.test(modelId);
+  return !modelId.includes("/")
+    && (/^(?:gpt-|o1-|o3-|o4-)/.test(modelId) || CODEX_INTERNAL_OPENAI_MODELS.has(modelId));
 }
 
 function routeResult(providerName: string, provider: OcxProviderConfig, modelId: string): RouteResult {

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -139,12 +139,22 @@ describe("routeModel registry effort defaults", () => {
       },
     };
     expect(routeModel(base, "gpt-5.5")).toMatchObject({ providerName: "openai", codexAccountMode: "pool" });
+    expect(routeModel(base, "codex-auto-review")).toMatchObject({
+      providerName: "openai",
+      modelId: "codex-auto-review",
+      codexAccountMode: "pool",
+    });
+    expect(routeModel(base, "codex-third-party-model")).toMatchObject({
+      providerName: "openai-apikey",
+      modelId: "codex-third-party-model",
+    });
     expect(routeModel({ ...base, providers: { ...base.providers, openai: { ...forward, codexAccountMode: "direct" } } }, "gpt-5.5"))
       .toMatchObject({ providerName: "openai", codexAccountMode: "direct" });
     expect(() => routeModel({ ...base, providers: { ...base.providers, openai: { ...forward, disabled: true } } }, "gpt-5.5"))
       .toThrow(/requires the canonical openai provider/);
     const unavailable = { ...base, providers: { "openai-proxy": base.providers["openai-proxy"] } };
     expect(() => routeModel(unavailable, "gpt-5.5")).toThrow(/ocx provider add openai/);
+    expect(() => routeModel(unavailable, "codex-auto-review")).toThrow(NoEnabledOpenAiProviderError);
   });
 
   test("rejects legacy chatgpt namespaces even when configured", () => {

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -148,6 +148,26 @@ describe("routeModel registry effort defaults", () => {
       providerName: "openai-apikey",
       modelId: "codex-third-party-model",
     });
+    const withDeepSeekDefault: OcxConfig = {
+      ...base,
+      defaultProvider: "deepseek",
+      providers: {
+        ...base.providers,
+        deepseek: {
+          adapter: "openai-chat",
+          baseUrl: "https://api.deepseek.com/v1",
+          defaultModel: "deepseek-chat",
+        },
+      },
+    };
+    expect(routeModel(withDeepSeekDefault, "codex-auto-review")).toMatchObject({
+      providerName: "openai",
+      modelId: "codex-auto-review",
+    });
+    expect(routeModel(withDeepSeekDefault, "codex-third-party-model")).toMatchObject({
+      providerName: "deepseek",
+      modelId: "codex-third-party-model",
+    });
     expect(routeModel({ ...base, providers: { ...base.providers, openai: { ...forward, codexAccountMode: "direct" } } }, "gpt-5.5"))
       .toMatchObject({ providerName: "openai", codexAccountMode: "direct" });
     expect(() => routeModel({ ...base, providers: { ...base.providers, openai: { ...forward, disabled: true } } }, "gpt-5.5"))


### PR DESCRIPTION
## What changed

- recognize codex-auto-review as an exact Codex internal model id
- route it only through the canonical enabled openai provider
- fail closed when canonical OpenAI is unavailable
- keep unknown codex-* third-party ids on the normal routing path

## Why

The internal approval model did not match the public GPT/o family prefixes and could be sent to an unrelated default provider.

Closes #816

## Checks

- bun test tests/router.test.ts
- bun x tsc --noEmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routing for supported bare OpenAI-family model IDs, including Codex models.
  * Preserved correct handling for third-party Codex models and slash-qualified model IDs.
  * Added clearer error handling when no OpenAI provider is available.

* **Tests**
  * Added coverage for Codex routing, provider selection, and unavailable-provider scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->