### PR TITLE
fix(codex): distinguish exhausted quota from unknown

### DIFF
--- a/src/codex/quota.ts
+++ b/src/codex/quota.ts
@@ -50,7 +50,9 @@ const MONTHLY_WINDOW_MIN_MINUTES = MONTHLY_WINDOW_MIN_SECONDS / 60;
 
 const accountQuota = new Map<string, StoredAccountQuota>();
 
-export const CODEX_UNKNOWN_USAGE_SCORE = 100;
+// Valid upstream percentages are normalized to 0..100. Keep "unknown" outside that domain so an
+// actually exhausted account is still eligible for threshold rotation.
+export const CODEX_UNKNOWN_USAGE_SCORE = 101;
 export const CODEX_EXHAUSTED_USAGE_PERCENT = 100;
 
 export function isCodexQuotaExhausted(

--- a/tests/codex-routing.test.ts
+++ b/tests/codex-routing.test.ts
@@ -127,6 +127,8 @@ describe("codex routing", () => {
   test("usage score treats unknown quota conservatively", () => {
     expect(computeCodexUsageScore(null)).toBe(CODEX_UNKNOWN_USAGE_SCORE);
     expect(computeCodexUsageScore({})).toBe(CODEX_UNKNOWN_USAGE_SCORE);
+    expect(computeCodexUsageScore({ weeklyPercent: 100 })).toBe(100);
+    expect(CODEX_UNKNOWN_USAGE_SCORE).toBeGreaterThan(100);
   });
 
   test("bulk pause exhaustion requires an explicit 100% relevant window", () => {
@@ -144,6 +146,25 @@ describe("codex routing", () => {
     updateAccountQuota("a", 85);
     updateAccountQuota("b", 20);
     expect(resolveCodexAccountForThread("new-thread", config)).toBe("b");
+  });
+
+  test("known 100% weekly usage is exhausted, not unknown, and switches accounts", () => {
+    const config = makeConfig();
+    updateAccountQuota("a", 100);
+    updateAccountQuota("b", 20);
+    expect(resolveCodexAccountForThread("known-100-weekly", config)).toBe("b");
+  });
+
+  test("known 100% Go monthly usage follows threshold switching", () => {
+    const config = makeConfig({
+      codexAccounts: [
+        { id: "a", email: "a@test", plan: "go", isMain: false },
+        { id: "b", email: "b@test", plan: "go", isMain: false },
+      ],
+    });
+    updateAccountQuota("a", 1, undefined, 100);
+    updateAccountQuota("b", 99, undefined, 20);
+    expect(resolveCodexAccountForThread("known-100-go-monthly", config)).toBe("b");
   });
 
   test("missing OpenAI mode defaults to pool and rotates from hot main to a cool added account", () => {


### PR DESCRIPTION
## What changed

- move the unknown quota sentinel outside the valid 0..100 percentage domain
- keep a real 100% usage snapshot on the exhausted/threshold path
- cover weekly and Go monthly 100% rotation while preserving unknown behavior

## Why

The previous unknown sentinel collided with a valid exhausted value, so threshold routing retained an account at exactly 100% usage.

Closes #815

## Checks

- bun test tests/codex-routing.test.ts
- bun x tsc --noEmit