### PR TITLE
fix(providers): give Claude 4.6/4.7 their 1M context windows

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -214,7 +214,7 @@ export type ProviderConfigSeed = Pick<
 // 260710 context refresh: Tier-2 evidence in
 // devlog/_plan/260710_provider_hardening/001_research_frontier.md.
 const ANTHROPIC_MODELS = ["claude-fable-5", "claude-sonnet-5", "claude-opus-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"];
-const ANTHROPIC_MODEL_CONTEXT_WINDOWS: Record<string, number> = { "claude-sonnet-5": 1_000_000, "claude-fable-5": 1_000_000, "claude-opus-5": 1_000_000, "claude-opus-4-8": 1_000_000, "claude-haiku-4-5": 200_000 };
+const ANTHROPIC_MODEL_CONTEXT_WINDOWS: Record<string, number> = { "claude-sonnet-5": 1_000_000, "claude-fable-5": 1_000_000, "claude-opus-5": 1_000_000, "claude-opus-4-8": 1_000_000, "claude-opus-4-7": 1_000_000, "claude-opus-4-6": 1_000_000, "claude-sonnet-4-6": 1_000_000, "claude-haiku-4-5": 200_000 };
 
 const ZAI_GLM_52_MODELS = ["glm-5.2", "glm-5.2[1m]"];
 const ZAI_GLM_52_REASONING_EFFORTS = ["low", "medium", "high", "xhigh", "max"];

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -607,6 +607,13 @@ describe("provider registry parity", () => {
     expect(OAUTH_PROVIDERS.anthropic.providerConfig.models).toContain("claude-sonnet-5");
     expect(OAUTH_PROVIDERS.anthropic.providerConfig.models).toContain("claude-fable-5");
     expect(OAUTH_PROVIDERS.anthropic.providerConfig.modelContextWindows?.["claude-sonnet-5"]).toBe(1_000_000);
+    expect(OAUTH_PROVIDERS.anthropic.providerConfig.modelContextWindows?.["claude-opus-4-7"]).toBe(1_000_000);
+    expect(OAUTH_PROVIDERS.anthropic.providerConfig.modelContextWindows?.["claude-opus-4-6"]).toBe(1_000_000);
+    expect(OAUTH_PROVIDERS.anthropic.providerConfig.modelContextWindows?.["claude-sonnet-4-6"]).toBe(1_000_000);
+    // A missing window makes the model advertise max_input_tokens: null and lose its [1m] picker row.
+    for (const model of OAUTH_PROVIDERS.anthropic.providerConfig.models ?? []) {
+      expect(OAUTH_PROVIDERS.anthropic.providerConfig.modelContextWindows?.[model]).toBeGreaterThan(0);
+    }
     expect(OAUTH_PROVIDERS.xai.providerConfig.defaultModel).toBe("grok-4.5");
     expect(OAUTH_PROVIDERS.xai.providerConfig.liveModels).toBe(true);
     expect(OAUTH_PROVIDERS.xai.providerConfig.models).toContain("grok-4.5");


### PR DESCRIPTION
## Summary

- `ANTHROPIC_MODEL_CONTEXT_WINDOWS` omits `claude-opus-4-7`, `claude-opus-4-6`, and `claude-sonnet-4-6`, although all three ship in `ANTHROPIC_MODELS`. Anthropic documents all three at 1M.
- Without a window entry those models advertise `max_input_tokens: null`, `shouldMarkOneMillion()` rejects them on its `typeof window !== "number"` guard, and `buildAnthropicModelInfos()` never emits the `[1m]` picker row. Claude Code then accounts them at its 200k default, so the extra context is unreachable from the `/model` picker.
- `buildClaudeContextWindows()` skips them for the same reason, so they are also absent from `/api/claude-code` `contextWindows`.

Observed on 2.7.43 with an OAuth (Claude subscription) anthropic provider. `/v1/models` before:

```
claude-opus-4-6      claude-opus-4-6 (anthropic)       max_input=None
claude-opus-4-7      claude-opus-4-7 (anthropic)       max_input=None
claude-sonnet-4-6    claude-sonnet-4-6 (anthropic)     max_input=None
claude-opus-4-8      claude-opus-4-8 (anthropic)       max_input=1000000
claude-opus-4-8[1m]  claude-opus-4-8 (anthropic) · 1M  max_input=1000000
```

After, each of the three gains its `· 1M` row (24 advertised models to 27).

User config cannot work around this: `OAUTH_RECONCILE_FIELDS` includes `modelContextWindows`, so a hand-added entry in `providers.anthropic` is reconciled back to the registry value on the next `ocx start`.

The parity test also gains a roster-wide guard, so a future model added to `ANTHROPIC_MODELS` without a window fails instead of silently losing its `[1m]` row.

## Verification

- `bun run typecheck` — clean.
- `bun test tests/provider-registry-parity.test.ts` — 31 pass.
- New guard driven red first: with the registry map reverted it fails (30 pass / 1 fail), confirming it is not vacuous.
- `bun run privacy:scan` — passed.
- `bun run test` — 6420 pass / 6 skip / 8 fail / 5 errors. All 8 failures and 5 errors reproduce on unmodified `upstream/dev` in this environment: 3 in `tests/cli-help.test.ts` and `tests/service.test.ts` (service/CLI diagnostics), and 5 module-resolution errors from `gui/` React deps not installed locally. None touch this change; the four files nearest to it (`provider-registry-parity`, `claude-model-info`, `desktop-3p`, `oauth-provider-reconcile`) are 61 pass / 0 fail.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No user-facing docs describe this table.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (Static model metadata only.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Claude Opus 4.7, Opus 4.6, and Sonnet 4.6 with 1-million-token context windows.

* **Bug Fixes**
  * Improved model metadata validation to ensure supported Anthropic models report valid context-window limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->