### PR TITLE
fix(update): allow stable updates from older previews

### DIFF
--- a/src/update/notify.ts
+++ b/src/update/notify.ts
@@ -92,7 +92,7 @@ function gt(a: number[], b: number[]): boolean {
 export function isNewer(latest: string, current: string, channel: Channel): boolean {
   if (channel === "latest") {
     const l = parseStable(latest);
-    const c = parseStable(current);
+    const c = parseStable(current) ?? parsePreview(current)?.slice(0, 3);
     if (!l || !c) return false;
     return gt(l, c);
   }

--- a/tests/update-job.test.ts
+++ b/tests/update-job.test.ts
@@ -85,6 +85,24 @@ describe("GUI update check", () => {
     expect(result.canUpdate).toBe(false);
     expect(result.reason).toBe("already_latest");
   });
+
+  test("offers a stable update from an older preview but not the same base", () => {
+    const olderPreview = checkForUpdate("latest", {
+      currentVersion: () => "2.8.2-preview.20260731",
+      detectInstall: () => "npm",
+      latestVersion: () => "2.9.1",
+    });
+    expect(olderPreview.updateAvailable).toBe(true);
+    expect(olderPreview.canUpdate).toBe(true);
+
+    const sameBasePreview = checkForUpdate("latest", {
+      currentVersion: () => "2.9.1-preview.20260731",
+      detectInstall: () => "npm",
+      latestVersion: () => "2.9.1",
+    });
+    expect(sameBasePreview.updateAvailable).toBe(false);
+    expect(sameBasePreview.canUpdate).toBe(false);
+  });
 });
 
 describe("GUI update execution decisions", () => {

--- a/tests/update-notify.test.ts
+++ b/tests/update-notify.test.ts
@@ -38,6 +38,10 @@ describe("isNewer — latest channel", () => {
   test("prereleases are ignored on the stable channel", () => {
     expect(isNewer("2.7.0-preview.1", "2.6.4", "latest")).toBe(false);
   });
+  test("stable releases compare against a preview current by its base version", () => {
+    expect(isNewer("2.9.1", "2.8.2-preview.20260731", "latest")).toBe(true);
+    expect(isNewer("2.9.1", "2.9.1-preview.20260731", "latest")).toBe(false);
+  });
 });
 
 describe("isNewer — preview channel", () => {


### PR DESCRIPTION
## Summary

- Compare an installed preview by its `major.minor.patch` core when the selected update channel is `latest`.
- Keep the latest-channel target strict: a preview registry target is still never accepted as a stable update.
- Cover both the comparator and the GUI/API update-check result that controls one-click availability.

## Problem

An older preview install such as `2.8.2-preview.20260731` cannot be parsed by the stable-only current-version branch. With npm `latest` at `2.9.1`, `isNewer()` therefore returns `false`, and the dashboard incorrectly reports `already_latest` and disables one-click update.

## Behavior

- `latest=2.9.1`, `current=2.8.2-preview.20260731`: update available.
- `latest=2.9.1`, `current=2.9.1-preview.20260731`: no update, preserving the existing core-version comparison policy.
- A preview value in the `latest` target remains rejected.

## Verification

- `bun test tests/update-notify.test.ts tests/update-job.test.ts`: 60 passed, 0 failed, 152 assertions.
- `bun run typecheck`: passed.
- `bun run privacy:scan`: passed.
- `git diff --check upstream/dev...HEAD`: passed.

No documentation change is included because this restores the documented existing update-channel behavior rather than adding a new user-facing option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update checks for preview versions, allowing older previews to detect newer stable releases.
  * Prevented update notifications when a preview already matches the stable release’s base version.

* **Tests**
  * Added coverage for preview-to-stable update detection and matching-version behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->