### PR TITLE
fix(web-search): carry queries on a single-query search so strict parsers accept the replay

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -473,6 +473,33 @@ function toolOutputText(output: unknown): string {
  *   reasoning chain is intact and must be preserved.
  * Runs on every forward request; with intact pairs it returns the original reference.
  */
+/**
+ * Backfill `queries` on a replayed single-query `web_search_call`.
+ *
+ * `webSearchAction()` in the bridge now emits both keys, but that only helps items
+ * created after the fix. A conversation that already recorded
+ * `{type:"search", query:"..."}` replays that stored item on every subsequent turn, and
+ * DeepSeek's native Responses parser requires `queries` — so upgrading alone leaves
+ * those threads permanently 400ing with `missing field 'queries'` (#930).
+ *
+ * Runs on every Responses request, on both `input` items and the `action` nested inside
+ * them. Returns the original reference when nothing needs repair, so the common path
+ * allocates nothing.
+ */
+function backfillWebSearchQueries(body: unknown): unknown {
+  if (!isPlainObject(body) || !Array.isArray(body.input)) return body;
+  let changed = false;
+  const input = body.input.map(item => {
+    if (!isPlainObject(item) || item.type !== "web_search_call") return item;
+    const action = item.action;
+    if (!isPlainObject(action) || action.type !== "search") return item;
+    if (typeof action.query !== "string" || Array.isArray(action.queries)) return item;
+    changed = true;
+    return { ...item, action: { ...action, queries: [action.query] } };
+  });
+  return changed ? { ...body, input } : body;
+}
+
 function repairOrphanedInputItems(body: unknown, dropReasoning: boolean): unknown {
   if (!isPlainObject(body) || !Array.isArray(body.input)) return body;
   const input = body.input;
@@ -1145,6 +1172,10 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
         outBody = repairOversizedReplayCallIds(outBody);
       }
       outBody = stripUnsupportedReasoningSummaryDelivery(outBody, parsed.modelId);
+      // Repair stored history from before the bridge emitted both keys: a conversation
+      // that already recorded a single-query web_search_call replays it every turn, and
+      // a strict parser rejects the whole request over it (#930).
+      outBody = backfillWebSearchQueries(outBody);
       // Same predicate as the routedCompaction gate in handleResponses(): an
       // authMode check would let a noncanonical custom forward provider skip this
       // rewrite while the server still routes it as a summarizer turn (#422).

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -120,8 +120,24 @@ export { adapterFailureFromMessage } from "./lib/errors";
  * is absent and `queries.len() > 1`. So a single query → `{ query }`; multiple → `{ queries }` with
  * no singular `query`, so Codex shows the native plural ellipsis. Empty → `{ query: "" }`.
  */
+/**
+ * Single query carries BOTH keys; a batch carries only `queries`.
+ *
+ * codex-rs reads singular `query`, and renders the batch form as "<first> ..." only when
+ * `query` is ABSENT and `queries.len() > 1` — so adding `query` to a batch would collapse
+ * that display. The plural case stays clean for exactly that reason.
+ *
+ * The single case is different. DeepSeek's native Responses parser makes `queries` a
+ * required field, so a replayed one-term `web_search_call` — carried in the history of
+ * every subsequent turn — fails deserialization with `missing field 'queries'` and 400s
+ * the rest of the conversation (#930). Adding `queries: [query]` satisfies the strict
+ * parser while leaving `query` in place, so native single-query rendering is unchanged.
+ */
 function webSearchAction(queries: string[]): Record<string, unknown> {
-  if (queries.length <= 1) return { type: "search", query: queries[0] ?? "" };
+  if (queries.length <= 1) {
+    const query = queries[0] ?? "";
+    return { type: "search", query, queries: [query] };
+  }
   return { type: "search", queries };
 }
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -115,23 +115,22 @@ function adapterFailureFromEvent(event: Extract<AdapterEvent, { type: "error" }>
 export { adapterFailureFromMessage } from "./lib/errors";
 
 /**
- * Build the native `WebSearchAction::Search` payload from the queries that ran. codex-rs prefers a
- * non-empty `query` over `queries` for the cell label, and only renders "<first> ..." when `query`
- * is absent and `queries.len() > 1`. So a single query → `{ query }`; multiple → `{ queries }` with
- * no singular `query`, so Codex shows the native plural ellipsis. Empty → `{ query: "" }`.
- */
-/**
- * Single query carries BOTH keys; a batch carries only `queries`.
+ * Build the native `WebSearchAction::Search` payload from the queries that ran.
  *
- * codex-rs reads singular `query`, and renders the batch form as "<first> ..." only when
- * `query` is ABSENT and `queries.len() > 1` — so adding `query` to a batch would collapse
- * that display. The plural case stays clean for exactly that reason.
+ * Single query → `{ query, queries: [query] }`. Batch → `{ queries }` with NO singular
+ * `query`. Empty → `{ query: "", queries: [""] }`.
  *
- * The single case is different. DeepSeek's native Responses parser makes `queries` a
- * required field, so a replayed one-term `web_search_call` — carried in the history of
- * every subsequent turn — fails deserialization with `missing field 'queries'` and 400s
- * the rest of the conversation (#930). Adding `queries: [query]` satisfies the strict
- * parser while leaving `query` in place, so native single-query rendering is unchanged.
+ * The asymmetry is load-bearing in both directions. codex-rs prefers a non-empty `query`
+ * for the cell label and renders "<first> ..." only when `query` is ABSENT and
+ * `queries.len() > 1`, so adding `query` to a batch would collapse the plural ellipsis.
+ * Meanwhile DeepSeek's native Responses parser makes `queries` a required field, so a
+ * replayed one-term `web_search_call` — carried in the history of every subsequent turn
+ * — fails deserialization with `missing field 'queries'` and 400s the rest of the
+ * conversation (#930). Carrying both keys in the single case satisfies the strict parser
+ * without changing what codex-rs displays.
+ *
+ * This fixes items created from here on. History recorded before it is repaired at the
+ * replay boundary by `backfillWebSearchQueries()` in the Responses adapter.
  */
 function webSearchAction(queries: string[]): Record<string, unknown> {
   if (queries.length <= 1) {

--- a/tests/bridge.test.ts
+++ b/tests/bridge.test.ts
@@ -882,7 +882,9 @@ describe("Responses bridge web_search_call native item", () => {
     expect((addedItem.id as string).startsWith("ws_")).toBe(true);
     expect(doneItem.id).toBe(addedItem.id);
     expect(doneItem.status).toBe("completed");
-    expect(doneItem.action).toEqual({ type: "search", query: "current docs" });
+    // Both shapes: codex-rs reads `query`, and DeepSeek's native Responses parser
+    // requires `queries` when the item is replayed in later turns (#930).
+    expect(doneItem.action).toEqual({ type: "search", query: "current docs", queries: ["current docs"] });
 
     const completed = frames.find(f => f.event === "response.completed")?.data.response as Record<string, unknown>;
     const output = completed.output as Record<string, unknown>[];
@@ -918,6 +920,36 @@ describe("Responses bridge web_search_call native item", () => {
     // Native renders "<first> ..." only when `query` is absent and queries.len() > 1.
     expect(action).toEqual({ type: "search", queries: ["rust async", "tokio runtime"] });
     expect(action.query).toBeUndefined();
+  });
+
+  test("a single-query search also carries queries so strict parsers accept the replay (#930)", () => {
+    // DeepSeek's native Responses parser requires `queries`. Without it, the replayed
+    // web_search_call in every later turn of the conversation fails deserialization with
+    // `missing field 'queries'` and 400s the whole thread.
+    const json = buildResponseJSON([
+      { type: "web_search_call_begin", id: "ws_930" },
+      { type: "web_search_call_end", id: "ws_930", queries: ["deepseek responses"] },
+      { type: "text_delta", text: "answer" },
+      { type: "done" },
+    ], "routed/model");
+
+    const action = (json.output as Record<string, unknown>[])[0].action as Record<string, unknown>;
+    expect(action.queries).toEqual(["deepseek responses"]);
+    // `query` stays present: codex-rs reads it, and the single-query rendering depends
+    // on it, so this is additive rather than a swap.
+    expect(action.query).toBe("deepseek responses");
+  });
+
+  test("an empty-query search still carries a queries array (#930)", () => {
+    const json = buildResponseJSON([
+      { type: "web_search_call_begin", id: "ws_931" },
+      { type: "web_search_call_end", id: "ws_931", queries: [] },
+      { type: "done" },
+    ], "routed/model");
+
+    const action = (json.output as Record<string, unknown>[])[0].action as Record<string, unknown>;
+    expect(action.queries).toEqual([""]);
+    expect(action.query).toBe("");
   });
 
   test("streaming: web_search_call_end sources attach as url_citation annotations on the next message", async () => {

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -309,6 +309,37 @@ describe("OpenAI Responses passthrough sanitization", () => {
     expect(input[0]).not.toHaveProperty("id");
   });
 
+  test("backfills queries on a replayed single-query web_search_call (#930)", () => {
+    // The bridge fix only helps items created after it. A conversation that already
+    // recorded {type:"search", query:"..."} replays that stored item every turn, and
+    // DeepSeek's parser rejects the whole request over it — so upgrading alone would
+    // leave those threads permanently broken.
+    const adapter = createResponsesPassthroughAdapter(provider);
+    const request = adapter.buildRequest({
+      modelId: "provider-model",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: {
+        model: "provider-model",
+        input: [
+          { type: "web_search_call", id: "ws_legacy", status: "completed", action: { type: "search", query: "legacy" } },
+          { type: "web_search_call", id: "ws_batch", status: "completed", action: { type: "search", queries: ["a", "b"] } },
+          { type: "web_search_call", id: "ws_other", status: "completed", action: { type: "open_page", url: "https://example.test" } },
+        ],
+      },
+    }, meta);
+    const input = (JSON.parse(request.body) as { input: Array<{ action: Record<string, unknown> }> }).input;
+
+    // Repaired: singular query gains the array the strict parser requires.
+    expect(input[0].action).toEqual({ type: "search", query: "legacy", queries: ["legacy"] });
+    // Untouched: a batch already satisfies the parser, and adding `query` would collapse
+    // the native plural rendering.
+    expect(input[1].action).toEqual({ type: "search", queries: ["a", "b"] });
+    // Untouched: not a search action.
+    expect(input[2].action).toEqual({ type: "open_page", url: "https://example.test" });
+  });
+
   test("strips invalid type-specific ids from serialized input items", () => {
     const adapter = createResponsesPassthroughAdapter(provider);
     const encryptedContent = "opaque-openai-encrypted-content";


### PR DESCRIPTION
Closes #930. Reported by @Hzzz7, whose minimal repro pinned it exactly.

A one-term web search emitted `action: {type: "search", query: "..."}`. That matches the Responses schema and is what codex-rs reads, but DeepSeek's native Responses parser makes `queries` a required field. Since the `web_search_call` lands in conversation history, every subsequent turn replays it and 400s with `missing field 'queries'` — one search poisons the rest of the thread, which is why the reporter saw *every* following turn fail rather than just the search turn.

## The fix, and the part that constrains it

The single-query case now carries both keys. `query` stays because codex-rs reads it and the single-query rendering depends on it; `queries: [query]` is what the strict parser wants. Additive, not a swap.

The batch case deliberately does **not** gain `query`. There is an existing test asserting `action.query` is undefined for a batch, with the reason recorded next to it: codex-rs renders the plural form as `"<first> ..."` only when `query` is absent and `queries.len() > 1`. Adding `query` there would collapse that display, so the plural branch is unchanged and that test stands exactly as it was.

That asymmetry is the whole design — it would have been easier to emit both keys everywhere, and it would have broken the batched-search UI.

## Evidence

- Two regressions: the single-query case and the empty-query edge (`queries: []` → `query: ""`, `queries: [""]`).
- **Ablation**: reverting `src/bridge.ts` with the tests kept fails 3 of the 55 bridge tests — the two new ones plus the existing single-query assertion.
- `bun run test`: 7589 pass / 0 fail across 504 files
- `bun x tsc --noEmit` exit 0, `bun run privacy:scan` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web search requests to consistently include query details for single-query searches.
  * Replayed single-query searches now retain their query list for consistent display and processing.
  * Empty searches are normalized consistently.
  * Multi-query searches continue to use the existing format without changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review round

An adversarial review returned FAIL on one blocker, and it was the right call: **the first commit only fixed newly created items.**

A conversation that already recorded `{type:"search", query:"..."}` replays that stored item on every subsequent turn. Upgrading opencodex would not have repaired those threads — they would keep 400ing, which is exactly the symptom the issue reports. The reviewer built a diagnostic request and confirmed the legacy action was forwarded unchanged.

`backfillWebSearchQueries()` now runs at the replay boundary in the Responses adapter: a `web_search_call` whose action is `{type:"search", query:"..."}` with no `queries` gains `queries: [query]` on the way out. A batch is untouched (adding `query` there would collapse the plural ellipsis), a non-search action is untouched, and the function returns the original reference when nothing needs repair.

Also folded the two stacked JSDoc blocks above `webSearchAction()` into one — the first still described the pre-fix contract and contradicted the second.

The review also verified the parts I could not confirm from here: OpenAI's current schema carries optional `query` and optional `queries` on the same object with no exclusivity, the official Node SDK models both independently, and codex-rs has a round-trip fixture containing both — so the dual-field single case is safe on OpenAI-facing paths. No consumer in `src/` or the GUI branches on key *presence*; the only reader is `src/claude/outbound.ts:138`, which is unaffected.

Updated: 3 regressions, `bun run test` 7590 pass / 0 fail, and a second ablation — reverting the adapter alone fails exactly the replay-boundary test.
