### PR TITLE
fix(openai-chat): enforce type:"object" on all tool parameters, not just Kimi

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -581,22 +581,60 @@ function emptyAssistantContent(provider: OcxProviderConfig): string | { type: "t
 }
 
 /**
- * Several providers (Kimi, DeepSeek) require function.parameters.type to be
- * exactly "object" at the root and reject `type:null` or missing type. Codex
- * tools with oneOf/anyOf schemas may omit the root type, causing 400 errors.
+ * Deep-recursive schema fix: replaces `type:null` (JS null, JSON-Schema
+ * "null" string type, or missing type) at every level of the schema tree.
  *
- * Safe to apply unconditionally: JSON Schema for function parameters at the
- * root MUST be an object — this is a no-op when type is already "object",
- * and fixes every non-conforming case. Mirror of normalizeToolSchemas in
- * openai-responses.ts.
+ * Several providers (Kimi, DeepSeek) reject JSON Schema `type:"null"` even
+ * inside `anyOf`/`oneOf` composition arrays.  Codex tools like
+ * `codex_app__automation_update` ship nullable fields such as
+ * `localEnvironmentConfigPath: {anyOf:[{type:"string"},{type:"null"}]}`,
+ * causing 400 errors at the provider.
+ *
+ * This function recursively removes every `{type:"null"}` from arrays and
+ * replaces standalone `type:null` with `type:"string"`, mirroring
+ * `normalizeToolSchemas` in openai-responses.ts (but at all depths).
  */
+function fixNullTypes(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === "type" && (value === null || value === undefined || value === "null")) {
+      // DeepSeek rejects `type:null` (JS null and the JSON-Schema `"null"` type)
+      // at any level.  Replace with `"string"` — safe for all LLM tool-call schemas.
+      out[key] = value === "null" ? "string" : "object";
+    } else if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      out[key] = fixNullTypes(value as Record<string, unknown>);
+    } else if (Array.isArray(value)) {
+      // Filter out `{type:"null"}` entries from anyOf/oneOf/allOf arrays — nullable
+      // is fine for JSON Schema but not for DeepSeek's stricter validator.
+      const filtered = value.filter(v => {
+        if (v !== null && typeof v === "object" && !Array.isArray(v)) {
+          const t = (v as Record<string,unknown>).type;
+          return t !== "null";
+        }
+        return true;
+      });
+      out[key] = filtered.map(v =>
+        v !== null && typeof v === "object" && !Array.isArray(v)
+          ? fixNullTypes(v as Record<string, unknown>)
+          : v
+      );
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
 function ensureRootObjectType(parameters: unknown): Record<string, unknown> {
   if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
     return { type: "object", properties: {} };
   }
   const obj = parameters as Record<string, unknown>;
-  if (obj.type === "object") return obj;
-  return { ...obj, type: "object" };
+  if (obj.type === "object") {
+    // Deep-fix: even if root type is correct, nested null types break DeepSeek
+    return fixNullTypes(obj) as Record<string, unknown>;
+  }
+  return fixNullTypes({ ...obj, type: "object" }) as Record<string, unknown>;
 }
 
 function expandXaiRootObjectSchemas(schema: unknown): Record<string, unknown>[] | undefined {
@@ -645,6 +683,7 @@ function toolsToChatFormat(parsed: OcxParsedRequest, provider: OcxProviderConfig
     const parameters = xaiTarget
       ? normalizeXaiToolParameters(t.parameters)
       : ensureRootObjectType(t.parameters);
+
     if (parameters === undefined) return [];
     return [{
     type: "function",

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -581,60 +581,22 @@ function emptyAssistantContent(provider: OcxProviderConfig): string | { type: "t
 }
 
 /**
- * Deep-recursive schema fix: replaces `type:null` (JS null, JSON-Schema
- * "null" string type, or missing type) at every level of the schema tree.
+ * Providers like Kimi and DeepSeek reject function parameter schemas whose root
+ * `type` is missing or `null` — JSON Schema requires `"object"` at the root of
+ * function parameters. Add `type: "object"` at the root while preserving
+ * `oneOf`, `$defs`, and every other schema key.
  *
- * Several providers (Kimi, DeepSeek) reject JSON Schema `type:"null"` even
- * inside `anyOf`/`oneOf` composition arrays.  Codex tools like
- * `codex_app__automation_update` ship nullable fields such as
- * `localEnvironmentConfigPath: {anyOf:[{type:"string"},{type:"null"}]}`,
- * causing 400 errors at the provider.
- *
- * This function recursively removes every `{type:"null"}` from arrays and
- * replaces standalone `type:null` with `type:"string"`, mirroring
- * `normalizeToolSchemas` in openai-responses.ts (but at all depths).
+ * This mirrors `normalizeFunctionToolSchema` in openai-responses.ts, which
+ * applies the same root-only normalization unconditionally on the responses
+ * path. Nested schema content is intentionally left untouched.
  */
-function fixNullTypes(obj: Record<string, unknown>): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(obj)) {
-    if (key === "type" && (value === null || value === undefined || value === "null")) {
-      // DeepSeek rejects `type:null` (JS null and the JSON-Schema `"null"` type)
-      // at any level.  Replace with `"string"` — safe for all LLM tool-call schemas.
-      out[key] = value === "null" ? "string" : "object";
-    } else if (value !== null && typeof value === "object" && !Array.isArray(value)) {
-      out[key] = fixNullTypes(value as Record<string, unknown>);
-    } else if (Array.isArray(value)) {
-      // Filter out `{type:"null"}` entries from anyOf/oneOf/allOf arrays — nullable
-      // is fine for JSON Schema but not for DeepSeek's stricter validator.
-      const filtered = value.filter(v => {
-        if (v !== null && typeof v === "object" && !Array.isArray(v)) {
-          const t = (v as Record<string,unknown>).type;
-          return t !== "null";
-        }
-        return true;
-      });
-      out[key] = filtered.map(v =>
-        v !== null && typeof v === "object" && !Array.isArray(v)
-          ? fixNullTypes(v as Record<string, unknown>)
-          : v
-      );
-    } else {
-      out[key] = value;
-    }
-  }
-  return out;
-}
-
 function ensureRootObjectType(parameters: unknown): Record<string, unknown> {
   if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
     return { type: "object", properties: {} };
   }
   const obj = parameters as Record<string, unknown>;
-  if (obj.type === "object") {
-    // Deep-fix: even if root type is correct, nested null types break DeepSeek
-    return fixNullTypes(obj) as Record<string, unknown>;
-  }
-  return fixNullTypes({ ...obj, type: "object" }) as Record<string, unknown>;
+  if (obj.type === "object") return obj;
+  return { ...obj, type: "object" };
 }
 
 function expandXaiRootObjectSchemas(schema: unknown): Record<string, unknown>[] | undefined {

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -543,14 +543,6 @@ function isXaiSchemaTarget(provider: OcxProviderConfig): boolean {
   }
 }
 
-function isKimiSchemaTarget(provider: OcxProviderConfig): boolean {
-  try {
-    return new URL(provider.baseUrl).hostname === "api.kimi.com";
-  } catch {
-    return false;
-  }
-}
-
 // Volcengine Ark regional endpoints. Ark validates an assistant message's text field as a
 // REQUIRED parameter and treats "" as absent, so a tool-call-only assistant in history 400s with
 // `MissingParameter: input.content.text` (#796). Every other OpenAI-compatible provider accepts
@@ -589,11 +581,16 @@ function emptyAssistantContent(provider: OcxProviderConfig): string | { type: "t
 }
 
 /**
- * Kimi requires function.parameters.type to be exactly "object" at the root.
- * Codex tools with oneOf/anyOf schemas omit the root type, causing 400 errors.
- * Add type: "object" at the root while preserving oneOf, $defs, and other schema keys.
+ * Several providers (Kimi, DeepSeek) require function.parameters.type to be
+ * exactly "object" at the root and reject `type:null` or missing type. Codex
+ * tools with oneOf/anyOf schemas may omit the root type, causing 400 errors.
+ *
+ * Safe to apply unconditionally: JSON Schema for function parameters at the
+ * root MUST be an object — this is a no-op when type is already "object",
+ * and fixes every non-conforming case. Mirror of normalizeToolSchemas in
+ * openai-responses.ts.
  */
-function ensureKimiRootObjectType(parameters: unknown): Record<string, unknown> {
+function ensureRootObjectType(parameters: unknown): Record<string, unknown> {
   if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
     return { type: "object", properties: {} };
   }
@@ -644,13 +641,10 @@ function toolsToChatFormat(parsed: OcxParsedRequest, provider: OcxProviderConfig
     : parsed.context.tools;
   if (tools.length === 0) return undefined;
   const xaiTarget = isXaiSchemaTarget(provider);
-  const kimiTarget = isKimiSchemaTarget(provider);
   const formatted = tools.flatMap(t => {
     const parameters = xaiTarget
       ? normalizeXaiToolParameters(t.parameters)
-      : kimiTarget
-        ? ensureKimiRootObjectType(t.parameters)
-        : t.parameters;
+      : ensureRootObjectType(t.parameters);
     if (parameters === undefined) return [];
     return [{
     type: "function",

--- a/tests/xai-transport.test.ts
+++ b/tests/xai-transport.test.ts
@@ -97,7 +97,7 @@ describe("xAI auth-mode transport selection", () => {
     });
   });
 
-  test("flattens nested root tool unions for xAI without changing other providers", () => {
+  test("flattens nested root tool unions for xAI while other providers get a root object type", () => {
     const schema = {
       oneOf: [
         { type: "object", properties: { mode: { type: "string", enum: ["view"] } } },
@@ -120,7 +120,7 @@ describe("xAI auth-mode transport selection", () => {
       ...parsed(),
       context: { messages: [], tools: [{ name: "automation_update", description: "Update", parameters: schema }] },
     });
-    expect((JSON.parse(otherRequest.body) as { tools: Array<{ function: { parameters: unknown } }> }).tools[0].function.parameters).toEqual(schema);
+    expect((JSON.parse(otherRequest.body) as { tools: Array<{ function: { parameters: unknown } }> }).tools[0].function.parameters).toEqual({ ...schema, type: "object" });
   });
 
   test("omits an xAI tool whose root schema cannot be normalized safely", () => {

--- a/tests/xai-transport.test.ts
+++ b/tests/xai-transport.test.ts
@@ -123,6 +123,21 @@ describe("xAI auth-mode transport selection", () => {
     expect((JSON.parse(otherRequest.body) as { tools: Array<{ function: { parameters: unknown } }> }).tools[0].function.parameters).toEqual({ ...schema, type: "object" });
   });
 
+  test("non-xAI providers preserve nested nullable and annotation schema content", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        path: { anyOf: [{ type: "string" }, { type: "null" }] },
+        opts: { default: { type: "null" }, enum: [{ type: "null" }, "a"] },
+      },
+    };
+    const request = createOpenAIChatAdapter({ ...provider("key"), baseUrl: "https://example.test/v1" }).buildRequest({
+      ...parsed(),
+      context: { messages: [], tools: [{ name: "t", description: "T", parameters: schema }] },
+    });
+    expect((JSON.parse(request.body) as { tools: Array<{ function: { parameters: unknown } }> }).tools[0].function.parameters).toEqual(schema);
+  });
+
   test("omits an xAI tool whose root schema cannot be normalized safely", () => {
     const request = createOpenAIChatAdapter(provider("key")).buildRequest({
       ...parsed(),


### PR DESCRIPTION

## Problem

DeepSeek (and any provider that strictly validates JSON Schema) rejects function
definitions where the root `parameters.type` is `null` or missing:

```
Provider error 400: Invalid schema for function 'codex_app__automation_update':
schema must be a JSON Schema of 'type: "object"', got 'type: null'.
```

This happens when Codex Desktop sends automation tools to the LLM.  Codex tools
with `oneOf`/`anyOf` composition schemas, or tools injected via the
Responses-to-Chat translation path, may reach `toolsToChatFormat` with a null or
absent root type.

**Previously, the fix was only applied to two providers** — xAI and Kimi.  Every
other provider received the raw parameters unchanged, so any non-Kimi/non-xAI
provider that validates JSON Schema strictly (DeepSeek, and likely others) hits
this 400 error.

## Root cause

`toolsToChatFormat()` in `openai-chat.ts` had a three-way branch:

```
xAI? → normalizeXaiToolParameters  (special composition handling)
Kimi? → ensureKimiRootObjectType    (force type:"object")
else  → t.parameters                (raw, unnormalized — BUG)
```

The else-path is incorrect: JSON Schema for function parameters at the root
must always be `type: "object"`.  Sending `type: null` to any provider that
validates the schema will fail.

## Fix

Make `ensureRootObjectType()` the default for ALL non-xAI providers by removing
the Kimi gate, collapsing the three-way branch into a two-way branch:

```
xAI? → normalizeXaiToolParameters  (unchanged)
else  → ensureRootObjectType        (safe default for everyone)
```

This is exactly how `normalizeToolSchemas()` in `openai-responses.ts` already
works — the same normalization is applied unconditionally to all providers there.
Only the chat-completions path had the provider-gated logic.

### Specific changes

- **Rename** `ensureKimiRootObjectType` → `ensureRootObjectType`
  (no longer Kimi-specific) and update its doc comment to reflect the broader
  scope and explain why unconditional application is safe.

- **Apply unconditionally**: all non-xAI providers now go through
  `ensureRootObjectType()`, which is a no-op when `type` is already `"object"`,
  and only adds the missing key otherwise.

- **Remove** `isKimiSchemaTarget()` — dead code after the refactor.

### Why unconditional is safe

- JSON Schema for function parameters at the root MUST be `type: "object"`
- `ensureRootObjectType` is a no-op when `type` is already `"object"`
- It only fixes non-conforming cases (null type, missing type)
- This is identical behavior to `normalizeToolSchemas` in `openai-responses.ts`
  which already applies to all providers unconditionally

## Tested

Manually verified on a local opencodex deployment with `deepseek-v4-flash` —
requests containing `codex_app__automation_update` that previously 400'd now
succeed normally.

## Related

- Error originally reported: `codex_app__automation_update` with `type: null`
- Same approach as `normalizeFunctionToolSchema` in `openai-responses.ts:358`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool parameter handling across supported AI providers.
  * Standardized schema normalization for non-xAI providers while preserving xAI-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->