### PR TITLE
fix(openai-responses): mirror web_search_call query into queries

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -137,6 +137,26 @@ function stripItemIdsWhenUnstored(body: unknown): unknown {
 }
 
 /**
+ * Replayed web_search_call actions carry a singular `query`, but DeepSeek's Responses route
+ * requires `queries` and 400s without it (#930). Add the plural next to the singular. Key path
+ * only: forward mode keeps the hosted shape.
+ */
+function normalizeWebSearchCallActions(body: unknown): unknown {
+  if (!isPlainObject(body) || !Array.isArray(body.input)) return body;
+
+  let changed = false;
+  const input = body.input.map(item => {
+    if (!isPlainObject(item) || item.type !== "web_search_call") return item;
+    const action = item.action;
+    if (!isPlainObject(action) || typeof action.query !== "string" || action.queries !== undefined) return item;
+    changed = true;
+    return { ...item, action: { ...action, queries: [action.query] } };
+  });
+
+  return changed ? { ...body, input } : body;
+}
+
+/**
  * Replace proxy-minted compaction items (`encrypted_content` starting with `ocx1:`) with plain
  * user messages before forwarding to the ChatGPT backend. Our envelope is transparent base64, not
  * OpenAI encryption — the native backend cannot decrypt it and would reject the request. Real
@@ -1140,6 +1160,7 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
           parsed._openAiVirtualSelectedModelId,
         );
         outBody = normalizeImageGenClientTools(outBody);
+        outBody = normalizeWebSearchCallActions(outBody);
       }
       if (forward || parsed._previousResponseInputExpanded === true) {
         outBody = repairOversizedReplayCallIds(outBody);

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -104,6 +104,59 @@ describe("DeepSeek Responses endpoint contract", () => {
   });
 });
 
+/** Issue #930: DeepSeek's Responses route requires `queries` on replayed web_search_call actions. */
+describe("web_search_call action replay (#930)", () => {
+  const keyProvider = {
+    adapter: "openai-responses",
+    baseUrl: "https://api.deepseek.com",
+    authMode: "key" as const,
+    apiKey: "sk-test",
+    responsesPath: "/responses",
+  };
+  const forwardProvider = {
+    adapter: "openai-responses",
+    baseUrl: "https://chatgpt.example/backend-api/codex",
+    authMode: "forward" as const,
+  };
+
+  function forwardedInput(provider: typeof keyProvider | typeof forwardProvider, input: unknown[]): Record<string, unknown>[] {
+    const request = createResponsesPassthroughAdapter(provider).buildRequest({
+      modelId: "deepseek-v4-flash",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: { model: "deepseek-v4-flash", stream: true, input },
+    }, { headers: new Headers({ authorization: "Bearer t" }) }) as { body: string };
+    return (JSON.parse(request.body) as { input: Record<string, unknown>[] }).input;
+  }
+
+  test("the key path adds queries next to the recorded singular query", () => {
+    const input = forwardedInput(keyProvider, [
+      { type: "web_search_call", id: "ws_x", status: "completed", action: { type: "search", query: "test" } },
+    ]);
+    expect(input[0].action).toEqual({ type: "search", query: "test", queries: ["test"] });
+  });
+
+  test("forward mode keeps the hosted shape", () => {
+    const input = forwardedInput(forwardProvider, [
+      { type: "web_search_call", id: "ws_x", status: "completed", action: { type: "search", query: "test" } },
+    ]);
+    expect(input[0].action).toEqual({ type: "search", query: "test" });
+  });
+
+  test("existing queries, actionless calls, and other items pass through untouched", () => {
+    const ready = { type: "search", queries: ["a", "b"] };
+    const input = forwardedInput(keyProvider, [
+      { type: "web_search_call", id: "ws_a", status: "completed", action: ready },
+      { type: "web_search_call", id: "ws_b", status: "completed" },
+      { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+    ]);
+    expect(input[0].action).toEqual(ready);
+    expect("action" in input[1]).toBe(false);
+    expect(input[2].type).toBe("message");
+  });
+});
+
 describe("OpenAI Responses passthrough sanitization", () => {
   test("normalizes top-level function schemas in the serialized raw body (#745)", () => {
     const validParameters = {


### PR DESCRIPTION
## Summary

Fixes #930. Replayed `web_search_call` history carries a singular `action.query`, but DeepSeek's Responses route requires `queries`, so one web search made every later turn in the conversation fail with 400. The key path now adds `queries` next to the singular; forward mode is untouched.

## Verification

- New tests in `tests/openai-responses-passthrough.test.ts`: the mirror, forward mode staying untouched, and pass-through of everything else.
- `bun run test`, `typecheck`, `lint:gui`, `privacy:scan`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with DeepSeek for replayed web search actions.
  * Preserved existing hosted search request formats and unrelated input data.

* **Tests**
  * Added regression coverage for search actions with singular or multiple query fields, actionless calls, and forward-mode requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->