### PR TITLE
fix(gui): add Pool/Direct account mode switch to OpenAI provider settings

### DIFF
--- a/gui/src/components/provider-workspace/ProviderSettings.tsx
+++ b/gui/src/components/provider-workspace/ProviderSettings.tsx
@@ -50,8 +50,6 @@ export default function ProviderSettings({
   const [accountMode, setAccountMode] = useState<"pool" | "direct">(item.codexAccountMode ?? "pool");
   const [modeSaving, setModeSaving] = useState(false);
   const [modeMsg, setModeMsg] = useState<{ ok: boolean; text: string } | null>(null);
-  /** Set while the reset effect must keep the just-applied account-mode message. */
-  const modeSavedRef = useRef(false);
   const [baseUrlChoices, setBaseUrlChoices] = useState<CatalogPreset["baseUrlChoices"]>();
   const [choicesStatus, setChoicesStatus] = useState<ChoicesStatus>(apiBase ? "loading" : "idle");
   const [endpointChoice, setEndpointChoice] = useState(() => "custom");
@@ -66,12 +64,18 @@ export default function ProviderSettings({
     setNote(item.note ?? "");
     setAllowPrivateNetwork(item.allowPrivateNetwork ?? false);
     setLiveModels(item.liveModels !== false);
-    setAccountMode(item.codexAccountMode ?? "pool");
     setMsg(null);
-    if (!modeSavedRef.current) setModeMsg(null);
-    modeSavedRef.current = false;
+    setModeMsg(null);
     queueMicrotask(() => setEndpointChoice(matchChoiceId(baseUrlChoices, item.baseUrl)));
-  }, [item.adapter, item.baseUrl, item.defaultModel, item.authMode, item.apiKeyTransport, item.keyOptional, item.note, item.allowPrivateNetwork, item.liveModels, item.codexAccountMode, baseUrlChoices]);
+  }, [item.adapter, item.baseUrl, item.defaultModel, item.authMode, item.apiKeyTransport, item.keyOptional, item.note, item.allowPrivateNetwork, item.liveModels, baseUrlChoices]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  // Account mode syncs on its own: a mode PATCH refresh must not reset an in-progress
+  // draft, so it is deliberately kept out of the form-reset effect above.
+  /* eslint-disable react-hooks/set-state-in-effect -- intentional split from the form reset */
+  useEffect(() => {
+    setAccountMode(item.codexAccountMode ?? "pool");
+  }, [item.codexAccountMode]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
   useEffect(() => {
@@ -179,7 +183,6 @@ export default function ProviderSettings({
     try {
       const res = await onUpdateProvider("openai", { codexAccountMode: next });
       if (res.ok) {
-        modeSavedRef.current = true;
         setAccountMode(next);
         setModeMsg({ ok: true, text: t("pws.accountModeSaved") });
       } else {

--- a/gui/src/components/provider-workspace/ProviderSettings.tsx
+++ b/gui/src/components/provider-workspace/ProviderSettings.tsx
@@ -282,8 +282,19 @@ export default function ProviderSettings({
           <select
             className="input"
             value={accountMode}
-            disabled={modeSaving}
-            onChange={e => void applyAccountMode(e.target.value as "pool" | "direct")}
+            disabled={modeSaving || saving}
+            onChange={e => {
+              const next = e.target.value as "pool" | "direct";
+              if (next === accountMode) return;
+              // Flipping modes rebinds running threads and changes quota accounting,
+              // so the PATCH only fires after an explicit confirmation.
+              if (!window.confirm(t("pws.accountModeConfirm"))) {
+                // Keep the visible choice aligned with the applied mode.
+                e.target.value = accountMode;
+                return;
+              }
+              void applyAccountMode(next);
+            }}
           >
             <option value="pool">{t("codexAuth.accountModePool")}</option>
             <option value="direct">{t("codexAuth.accountModeDirect")}</option>
@@ -293,7 +304,10 @@ export default function ProviderSettings({
           </span>
           {modeSaving && <span className="muted text-label">{t("pws.accountSwitching")}</span>}
           {modeMsg && (
-            <span className={modeMsg.ok ? "pwi-settings-mode-msg pwi-settings-mode-msg--ok" : "pwi-settings-mode-msg pwi-settings-mode-msg--err"}>
+            <span
+              role={modeMsg.ok ? "status" : "alert"}
+              className={modeMsg.ok ? "pwi-settings-mode-msg pwi-settings-mode-msg--ok" : "pwi-settings-mode-msg pwi-settings-mode-msg--err"}
+            >
               {modeMsg.text}
             </span>
           )}
@@ -332,7 +346,11 @@ export default function ProviderSettings({
           </div>
         </div>
       )}
-      {msg && <div className={msg.ok ? "pwi-settings-msg pwi-settings-msg--ok" : "pwi-settings-msg pwi-settings-msg--err"}>{msg.text}</div>}
+      {msg && (
+        <div role={msg.ok ? "status" : "alert"} className={msg.ok ? "pwi-settings-msg pwi-settings-msg--ok" : "pwi-settings-msg pwi-settings-msg--err"}>
+          {msg.text}
+        </div>
+      )}
     </div>
   );
 }

--- a/gui/src/components/provider-workspace/ProviderSettings.tsx
+++ b/gui/src/components/provider-workspace/ProviderSettings.tsx
@@ -50,6 +50,8 @@ export default function ProviderSettings({
   const [accountMode, setAccountMode] = useState<"pool" | "direct">(item.codexAccountMode ?? "pool");
   const [modeSaving, setModeSaving] = useState(false);
   const [modeMsg, setModeMsg] = useState<{ ok: boolean; text: string } | null>(null);
+  /** Set while the reset effect must keep the just-applied account-mode message. */
+  const modeSavedRef = useRef(false);
   const [baseUrlChoices, setBaseUrlChoices] = useState<CatalogPreset["baseUrlChoices"]>();
   const [choicesStatus, setChoicesStatus] = useState<ChoicesStatus>(apiBase ? "loading" : "idle");
   const [endpointChoice, setEndpointChoice] = useState(() => "custom");
@@ -66,6 +68,8 @@ export default function ProviderSettings({
     setLiveModels(item.liveModels !== false);
     setAccountMode(item.codexAccountMode ?? "pool");
     setMsg(null);
+    if (!modeSavedRef.current) setModeMsg(null);
+    modeSavedRef.current = false;
     queueMicrotask(() => setEndpointChoice(matchChoiceId(baseUrlChoices, item.baseUrl)));
   }, [item.adapter, item.baseUrl, item.defaultModel, item.authMode, item.apiKeyTransport, item.keyOptional, item.note, item.allowPrivateNetwork, item.liveModels, item.codexAccountMode, baseUrlChoices]);
   /* eslint-enable react-hooks/set-state-in-effect */
@@ -173,7 +177,13 @@ export default function ProviderSettings({
     setModeMsg(null);
     try {
       const res = await onUpdateProvider("openai", { codexAccountMode: next });
-      setModeMsg(res.ok ? { ok: true, text: t("pws.accountModeSaved") } : { ok: false, text: res.error || t("pws.accountModeFailed") });
+      if (res.ok) {
+        modeSavedRef.current = true;
+        setAccountMode(next);
+        setModeMsg({ ok: true, text: t("pws.accountModeSaved") });
+      } else {
+        setModeMsg({ ok: false, text: res.error || t("pws.accountModeFailed") });
+      }
     } finally {
       setModeSaving(false);
     }

--- a/gui/src/components/provider-workspace/ProviderSettings.tsx
+++ b/gui/src/components/provider-workspace/ProviderSettings.tsx
@@ -13,6 +13,7 @@ import { readJsonIfOk } from "../../fetch-json";
 import { useT } from "../../i18n/shared";
 import { IconLock } from "../../icons";
 import { isCatalogProviderId } from "../../provider-icons";
+import { openAiAccountProviderState } from "../../provider-payload";
 import type { CatalogPreset } from "../provider-catalog/provider-presets";
 import { authModeLabel } from "./ProviderRail";
 import type { WorkspaceItem, ProviderUpdatePatch } from "./types";
@@ -46,6 +47,9 @@ export default function ProviderSettings({
   const [liveModels, setLiveModels] = useState(item.liveModels !== false);
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
+  const [accountMode, setAccountMode] = useState<"pool" | "direct">(item.codexAccountMode ?? "pool");
+  const [modeSaving, setModeSaving] = useState(false);
+  const [modeMsg, setModeMsg] = useState<{ ok: boolean; text: string } | null>(null);
   const [baseUrlChoices, setBaseUrlChoices] = useState<CatalogPreset["baseUrlChoices"]>();
   const [choicesStatus, setChoicesStatus] = useState<ChoicesStatus>(apiBase ? "loading" : "idle");
   const [endpointChoice, setEndpointChoice] = useState(() => "custom");
@@ -60,9 +64,10 @@ export default function ProviderSettings({
     setNote(item.note ?? "");
     setAllowPrivateNetwork(item.allowPrivateNetwork ?? false);
     setLiveModels(item.liveModels !== false);
+    setAccountMode(item.codexAccountMode ?? "pool");
     setMsg(null);
     queueMicrotask(() => setEndpointChoice(matchChoiceId(baseUrlChoices, item.baseUrl)));
-  }, [item.adapter, item.baseUrl, item.defaultModel, item.authMode, item.apiKeyTransport, item.keyOptional, item.note, item.allowPrivateNetwork, item.liveModels, baseUrlChoices]);
+  }, [item.adapter, item.baseUrl, item.defaultModel, item.authMode, item.apiKeyTransport, item.keyOptional, item.note, item.allowPrivateNetwork, item.liveModels, item.codexAccountMode, baseUrlChoices]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
   useEffect(() => {
@@ -122,6 +127,8 @@ export default function ProviderSettings({
   const isPreset = isCatalogProviderId(item.name);
   const hasEndpointPicker = choicesStatus === "ready" && !!(baseUrlChoices && baseUrlChoices.length > 0);
   const supportsApiKeyTransport = adapter.trim() === "anthropic" && authMode === "key";
+  const openAiState = item.name === "openai" ? openAiAccountProviderState(item) : "invalid";
+  const isCanonicalOpenAi = openAiState === "ready" || openAiState === "disabled";
   // Lock plain baseUrl for presets while loading or when there is no picker.
   // On fetch error, keep it editable so allowBaseUrlOverride providers are not trapped.
   const plainBaseUrlLocked = isPreset && choicesStatus !== "error";
@@ -158,6 +165,19 @@ export default function ProviderSettings({
     onRegisterSave(() => saveRef.current());
     return () => onRegisterSave(null);
   }, [onRegisterSave]);
+
+  const applyAccountMode = async (next: "pool" | "direct") => {
+    if (modeSaving || next === accountMode) return;
+    if (!onUpdateProvider) { setModeMsg({ ok: false, text: t("pws.updatesUnavailable") }); return; }
+    setModeSaving(true);
+    setModeMsg(null);
+    try {
+      const res = await onUpdateProvider("openai", { codexAccountMode: next });
+      setModeMsg(res.ok ? { ok: true, text: t("pws.accountModeSaved") } : { ok: false, text: res.error || t("pws.accountModeFailed") });
+    } finally {
+      setModeSaving(false);
+    }
+  };
 
   const discard = () => {
     setAdapter(item.adapter); setBaseUrl(item.baseUrl);
@@ -243,6 +263,29 @@ export default function ProviderSettings({
           </select>
         )}
       </label>
+      {isCanonicalOpenAi && (
+        <label className="pwi-settings-field">
+          <span className="pwi-settings-label">{t("codexAuth.accountModeTitle")}</span>
+          <select
+            className="input"
+            value={accountMode}
+            disabled={modeSaving}
+            onChange={e => void applyAccountMode(e.target.value as "pool" | "direct")}
+          >
+            <option value="pool">{t("codexAuth.accountModePool")}</option>
+            <option value="direct">{t("codexAuth.accountModeDirect")}</option>
+          </select>
+          <span className="pwi-settings-hint">
+            {accountMode === "direct" ? t("codexAuth.accountModeDirectDesc") : t("codexAuth.accountModePoolDesc")}
+          </span>
+          {modeSaving && <span className="muted text-label">{t("pws.accountSwitching")}</span>}
+          {modeMsg && (
+            <span className={modeMsg.ok ? "pwi-settings-mode-msg pwi-settings-mode-msg--ok" : "pwi-settings-mode-msg pwi-settings-mode-msg--err"}>
+              {modeMsg.text}
+            </span>
+          )}
+        </label>
+      )}
       {supportsApiKeyTransport && (
         <label className="pwi-settings-field">
           <span className="pwi-settings-label">{t("modal.apiKeyTransport")}</span>

--- a/gui/src/components/provider-workspace/ProviderSettings.tsx
+++ b/gui/src/components/provider-workspace/ProviderSettings.tsx
@@ -139,6 +139,7 @@ export default function ProviderSettings({
 
   const save = async (): Promise<boolean> => {
     if (!onUpdateProvider) { setMsg({ ok: false, text: t("pws.updatesUnavailable") }); return false; }
+    if (modeSaving) return false;
     const nextBaseUrl = hasEndpointPicker
       ? resolvedBaseUrlForChoice(baseUrlChoices, endpointChoice, baseUrl)
       : baseUrl.trim();
@@ -171,7 +172,7 @@ export default function ProviderSettings({
   }, [onRegisterSave]);
 
   const applyAccountMode = async (next: "pool" | "direct") => {
-    if (modeSaving || next === accountMode) return;
+    if (modeSaving || saving || next === accountMode) return;
     if (!onUpdateProvider) { setModeMsg({ ok: false, text: t("pws.updatesUnavailable") }); return; }
     setModeSaving(true);
     setModeMsg(null);
@@ -184,6 +185,8 @@ export default function ProviderSettings({
       } else {
         setModeMsg({ ok: false, text: res.error || t("pws.accountModeFailed") });
       }
+    } catch {
+      setModeMsg({ ok: false, text: t("pws.accountModeFailed") });
     } finally {
       setModeSaving(false);
     }
@@ -325,7 +328,7 @@ export default function ProviderSettings({
           <span className="muted">{t("pws.settingsUnsavedBar")}</span>
           <div className="pwi-settings-sticky-bar-actions">
             <button type="button" className="btn btn-ghost btn-sm" onClick={discard} disabled={saving}>{t("pws.discardSettings")}</button>
-            <button type="button" className="btn btn-primary btn-sm" onClick={() => void save()} disabled={saving}>{saving ? t("pws.saving") : t("pws.saveSettings")}</button>
+            <button type="button" className="btn btn-primary btn-sm" onClick={() => void save()} disabled={saving || modeSaving}>{saving ? t("pws.saving") : t("pws.saveSettings")}</button>
           </div>
         </div>
       )}

--- a/gui/src/components/provider-workspace/types.ts
+++ b/gui/src/components/provider-workspace/types.ts
@@ -98,4 +98,6 @@ export type ProviderUpdatePatch = {
   disabled?: boolean;
   allowPrivateNetwork?: boolean;
   liveModels?: boolean;
+  /** Dedicated field: the API PATCHes it alone for the canonical `openai` provider. */
+  codexAccountMode?: "direct" | "pool";
 };

--- a/gui/src/i18n/de.ts
+++ b/gui/src/i18n/de.ts
@@ -1464,6 +1464,8 @@ export const de: Record<TKey, string> = {
   "pws.saveSettings": "Speichern",
   "pws.saving": "Wird gespeichert…",
   "pws.settingsSaved": "Einstellungen gespeichert.",
+  "pws.accountModeSaved": "Kontomodus gespeichert.",
+  "pws.accountModeFailed": "Kontomodus konnte nicht gewechselt werden.",
   "pws.settingsUnsavedBar": "Es gibt ungespeicherte Änderungen.",
   "pws.unsavedLeaveBody": "Es gibt ungespeicherte Änderungen. Vor dem Verlassen speichern?",
   "pws.unsavedLeaveTitle": "Ungespeicherte Änderungen",

--- a/gui/src/i18n/de.ts
+++ b/gui/src/i18n/de.ts
@@ -1466,6 +1466,7 @@ export const de: Record<TKey, string> = {
   "pws.settingsSaved": "Einstellungen gespeichert.",
   "pws.accountModeSaved": "Kontomodus gespeichert.",
   "pws.accountModeFailed": "Kontomodus konnte nicht gewechselt werden.",
+  "pws.accountModeConfirm": "OpenAI-Kontomodus wechseln? Laufende Unterhaltungen werden dem anderen Kontosatz zugeordnet und die Quotennutzung wird unter dem neuen Modus erfasst.",
   "pws.settingsUnsavedBar": "Es gibt ungespeicherte Änderungen.",
   "pws.unsavedLeaveBody": "Es gibt ungespeicherte Änderungen. Vor dem Verlassen speichern?",
   "pws.unsavedLeaveTitle": "Ungespeicherte Änderungen",

--- a/gui/src/i18n/en.ts
+++ b/gui/src/i18n/en.ts
@@ -1040,6 +1040,8 @@ export const en = {
   "pws.saveSettings": "Save",
   "pws.saving": "Saving…",
   "pws.settingsSaved": "Settings saved.",
+  "pws.accountModeSaved": "Account mode saved.",
+  "pws.accountModeFailed": "Could not switch the account mode.",
   "pws.settingsUnsavedBar": "You have unsaved changes.",
   "pws.unsavedLeaveBody": "You have unsaved changes. Save them before leaving?",
   "pws.unsavedLeaveTitle": "Unsaved changes",

--- a/gui/src/i18n/en.ts
+++ b/gui/src/i18n/en.ts
@@ -1042,6 +1042,7 @@ export const en = {
   "pws.settingsSaved": "Settings saved.",
   "pws.accountModeSaved": "Account mode saved.",
   "pws.accountModeFailed": "Could not switch the account mode.",
+  "pws.accountModeConfirm": "Switch the OpenAI account mode? Running conversations will be reassigned to the other mode's account set, and quota usage will be tracked against the new mode.",
   "pws.settingsUnsavedBar": "You have unsaved changes.",
   "pws.unsavedLeaveBody": "You have unsaved changes. Save them before leaving?",
   "pws.unsavedLeaveTitle": "Unsaved changes",

--- a/gui/src/i18n/ja.ts
+++ b/gui/src/i18n/ja.ts
@@ -990,6 +990,8 @@ export const ja: Record<TKey, string> = {
   "pws.saveSettings": "保存",
   "pws.saving": "保存中…",
   "pws.settingsSaved": "設定を保存しました。",
+  "pws.accountModeSaved": "アカウントモードを保存しました。",
+  "pws.accountModeFailed": "アカウントモードを切り替えられませんでした。",
   "pws.settingsUnsavedBar": "未保存の変更があります。",
   "pws.unsavedLeaveBody": "未保存の変更があります。保存してから移動しますか?",
   "pws.unsavedLeaveTitle": "未保存の変更",

--- a/gui/src/i18n/ja.ts
+++ b/gui/src/i18n/ja.ts
@@ -992,6 +992,7 @@ export const ja: Record<TKey, string> = {
   "pws.settingsSaved": "設定を保存しました。",
   "pws.accountModeSaved": "アカウントモードを保存しました。",
   "pws.accountModeFailed": "アカウントモードを切り替えられませんでした。",
+  "pws.accountModeConfirm": "OpenAI のアカウントモードを切り替えますか？実行中の会話はもう一方のモードのアカウントセットに再割り当てされ、クォータ使用量は新しいモードで計上されます。",
   "pws.settingsUnsavedBar": "未保存の変更があります。",
   "pws.unsavedLeaveBody": "未保存の変更があります。保存してから移動しますか?",
   "pws.unsavedLeaveTitle": "未保存の変更",

--- a/gui/src/i18n/ko.ts
+++ b/gui/src/i18n/ko.ts
@@ -1493,6 +1493,7 @@ export const ko: Record<TKey, string> = {
   "pws.settingsSaved": "설정이 저장되었습니다.",
   "pws.accountModeSaved": "계정 모드가 저장되었습니다.",
   "pws.accountModeFailed": "계정 모드를 전환할 수 없습니다.",
+  "pws.accountModeConfirm": "OpenAI 계정 모드를 전환할까요? 실행 중인 대화가 다른 모드의 계정 세트로 다시 연결되며, 할당량 사용량은 새 모드로 집계됩니다.",
   "pws.settingsUnsavedBar": "저장하지 않은 변경사항이 있습니다.",
   "pws.unsavedLeaveBody": "저장하지 않은 변경사항이 있습니다. 나가기 전에 저장하시겠습니까?",
   "pws.unsavedLeaveTitle": "미저장 변경사항",

--- a/gui/src/i18n/ko.ts
+++ b/gui/src/i18n/ko.ts
@@ -1491,6 +1491,8 @@ export const ko: Record<TKey, string> = {
   "pws.saveSettings": "저장",
   "pws.saving": "저장 중…",
   "pws.settingsSaved": "설정이 저장되었습니다.",
+  "pws.accountModeSaved": "계정 모드가 저장되었습니다.",
+  "pws.accountModeFailed": "계정 모드를 전환할 수 없습니다.",
   "pws.settingsUnsavedBar": "저장하지 않은 변경사항이 있습니다.",
   "pws.unsavedLeaveBody": "저장하지 않은 변경사항이 있습니다. 나가기 전에 저장하시겠습니까?",
   "pws.unsavedLeaveTitle": "미저장 변경사항",

--- a/gui/src/i18n/ru.ts
+++ b/gui/src/i18n/ru.ts
@@ -1032,6 +1032,8 @@ export const ru: Record<TKey, string> = {
   "pws.saveSettings": "Сохранить",
   "pws.saving": "Сохранение…",
   "pws.settingsSaved": "Настройки сохранены.",
+  "pws.accountModeSaved": "Режим аккаунта сохранён.",
+  "pws.accountModeFailed": "Не удалось переключить режим аккаунта.",
   "pws.settingsUnsavedBar": "Есть несохранённые изменения.",
   "pws.unsavedLeaveBody": "Есть несохранённые изменения. Сохранить их перед переходом?",
   "pws.unsavedLeaveTitle": "Несохранённые изменения",

--- a/gui/src/i18n/ru.ts
+++ b/gui/src/i18n/ru.ts
@@ -1034,6 +1034,7 @@ export const ru: Record<TKey, string> = {
   "pws.settingsSaved": "Настройки сохранены.",
   "pws.accountModeSaved": "Режим аккаунта сохранён.",
   "pws.accountModeFailed": "Не удалось переключить режим аккаунта.",
+  "pws.accountModeConfirm": "Переключить режим аккаунта OpenAI? Текущие беседы будут перенаправлены на другой набор аккаунтов, а использование квоты будет учитываться в новом режиме.",
   "pws.settingsUnsavedBar": "Есть несохранённые изменения.",
   "pws.unsavedLeaveBody": "Есть несохранённые изменения. Сохранить их перед переходом?",
   "pws.unsavedLeaveTitle": "Несохранённые изменения",

--- a/gui/src/i18n/zh.ts
+++ b/gui/src/i18n/zh.ts
@@ -1486,6 +1486,7 @@ export const zh: Record<TKey, string> = {
   "pws.settingsSaved": "设置已保存。",
   "pws.accountModeSaved": "账户模式已保存。",
   "pws.accountModeFailed": "无法切换账户模式。",
+  "pws.accountModeConfirm": "切换 OpenAI 账户模式？正在进行的对话将重新分配到另一种模式的账户集合，配额用量将按新模式计入。",
   "pws.settingsUnsavedBar": "有未保存的更改。",
   "pws.unsavedLeaveBody": "有未保存的更改。离开前保存吗？",
   "pws.unsavedLeaveTitle": "未保存的更改",

--- a/gui/src/i18n/zh.ts
+++ b/gui/src/i18n/zh.ts
@@ -1484,6 +1484,8 @@ export const zh: Record<TKey, string> = {
   "pws.saveSettings": "保存",
   "pws.saving": "保存中…",
   "pws.settingsSaved": "设置已保存。",
+  "pws.accountModeSaved": "账户模式已保存。",
+  "pws.accountModeFailed": "无法切换账户模式。",
   "pws.settingsUnsavedBar": "有未保存的更改。",
   "pws.unsavedLeaveBody": "有未保存的更改。离开前保存吗？",
   "pws.unsavedLeaveTitle": "未保存的更改",

--- a/gui/src/pages/Providers.tsx
+++ b/gui/src/pages/Providers.tsx
@@ -181,6 +181,9 @@ export default function Providers({ apiBase }: { apiBase: string }) {
   const { removeProvider, confirmRemoveProvider, setProviderDisabled, setDefaultProvider, updateProvider } = useProvidersCrud({
     apiBase, t, removeBusyRef, workspaceSelected, setWorkspaceSelected, setRemoveConfirmName,
     notify, fetchConfig, fetchOauth, fetchProviderQuotas,
+    // Mode PATCHes clear quota caches and thread affinity; the shared controller
+    // must re-read /active (with quota) so both tabs show the post-switch state.
+    refreshCodexAccount: () => codexPool.load(true),
   });
 
   const requestLoginOAuth = (provider: string, addAccount = false) => {

--- a/gui/src/pages/use-providers-crud.ts
+++ b/gui/src/pages/use-providers-crud.ts
@@ -29,6 +29,7 @@ export function useProvidersCrud({
   fetchConfig,
   fetchOauth,
   fetchProviderQuotas,
+  refreshCodexAccount,
 }: {
   apiBase: string;
   t: TFn;
@@ -40,6 +41,8 @@ export function useProvidersCrud({
   fetchConfig: () => Promise<void>;
   fetchOauth: () => Promise<void>;
   fetchProviderQuotas: (refresh?: boolean) => Promise<void>;
+  /** Shared Codex account controller refresh (Providers.tsx passes codexPool.load). */
+  refreshCodexAccount?: () => Promise<unknown> | unknown;
 }) {
   const removeProvider = useCallback(async (name: string) => {
     setRemoveConfirmName(name);
@@ -103,11 +106,18 @@ export function useProvidersCrud({
       // Await refresh so callers (e.g. notes editor) only leave edit mode once
       // item.note reflects the saved value.
       await fetchConfig();
+      // A codexAccountMode PATCH clears quota caches and thread affinity server-side,
+      // so both dependent surfaces must refresh before the action reports success.
+      if (Object.hasOwn(patch, "codexAccountMode")) {
+        const refreshes: Promise<unknown>[] = [fetchProviderQuotas(true)];
+        if (refreshCodexAccount) refreshes.push(Promise.resolve(refreshCodexAccount()));
+        await Promise.all(refreshes);
+      }
       return { ok: true };
     } catch {
       return { ok: false, error: t("prov.networkError") };
     }
-  }, [apiBase, fetchConfig, t]);
+  }, [apiBase, fetchConfig, fetchProviderQuotas, refreshCodexAccount, t]);
 
   const setDefaultProvider = useCallback(async (name: string): Promise<boolean> => {
     try {

--- a/gui/src/provider-workspace/catalog.ts
+++ b/gui/src/provider-workspace/catalog.ts
@@ -45,6 +45,8 @@ export interface WorkspaceProvider {
   disabled?: boolean;
   note?: string;
   allowPrivateNetwork?: boolean;
+  /** Codex account routing mode for the canonical `openai` forward provider. */
+  codexAccountMode?: "direct" | "pool";
 }
 
 /** Three-way pricing/ownership tier for a ready provider row. */

--- a/gui/src/styles/provider-workspace-settings.css
+++ b/gui/src/styles/provider-workspace-settings.css
@@ -96,6 +96,9 @@
 }
 .pwi-settings-textarea:focus { border-color: var(--accent-ring); outline: none; }
 .pwi-settings-hint { font-size: var(--text-caption); color: var(--muted); line-height: 1.4; }
+.pwi-settings-mode-msg { font-size: var(--text-caption); line-height: 1.4; }
+.pwi-settings-mode-msg--ok  { color: var(--green); }
+.pwi-settings-mode-msg--err { color: var(--red); }
 
 .pwi-settings-sticky-bar {
   position: sticky; bottom: 0; z-index: 2;

--- a/gui/tests/provider-settings-account-mode.test.tsx
+++ b/gui/tests/provider-settings-account-mode.test.tsx
@@ -53,27 +53,34 @@ async function mountSettings(
   root: Root;
   container: HTMLElement;
   patches: ProviderUpdatePatch[];
+  rerender: (item: WorkspaceItem) => Promise<void>;
 }> {
   const patches: ProviderUpdatePatch[] = [];
   const container = document.createElement("div");
   document.body.append(container);
   const { createRoot } = await import("react-dom/client");
   let root!: Root;
+  const renderItem = (it: WorkspaceItem) => (
+    <LanguageProvider>
+      <ProviderSettings
+        item={it}
+        onUpdateProvider={async (name, patch) => {
+          patches.push(patch);
+          return onUpdateProvider ? onUpdateProvider(name, patch) : { ok: true };
+        }}
+      />
+    </LanguageProvider>
+  );
   await act(async () => {
     root = createRoot(container);
-    root.render(
-      <LanguageProvider>
-        <ProviderSettings
-          item={item}
-          onUpdateProvider={async (name, patch) => {
-            patches.push(patch);
-            return onUpdateProvider ? onUpdateProvider(name, patch) : { ok: true };
-          }}
-        />
-      </LanguageProvider>,
-    );
+    root.render(renderItem(item));
   });
-  return { root, container, patches };
+  return {
+    root,
+    container,
+    patches,
+    rerender: (it: WorkspaceItem) => act(async () => { root.render(renderItem(it)); }),
+  };
 }
 
 function modeSelect(container: HTMLElement): HTMLSelectElement {
@@ -172,5 +179,25 @@ test("the mode select is disabled while an ordinary settings save is in flight",
     await pending;
   });
   expect(modeSelect(container).disabled).toBe(false);
+  await act(async () => { root.unmount(); });
+});
+
+test("a mode-change config refresh does not wipe an unsaved draft", async () => {
+  const { root, container, rerender } = await mountSettings(openAiItem("pool"));
+  const note = container.querySelector<HTMLTextAreaElement>(".pwi-settings-textarea")!;
+
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(testWindow.HTMLTextAreaElement.prototype, "value")!
+      .set!.call(note, "draft");
+    note.dispatchEvent(new testWindow.Event("input", { bubbles: true }));
+  });
+  expect(container.querySelector(".pwi-settings-sticky-bar")).toBeTruthy();
+
+  // Simulate the config refresh that follows a successful mode PATCH.
+  await rerender(openAiItem("direct"));
+
+  expect(container.querySelector<HTMLTextAreaElement>(".pwi-settings-textarea")!.value).toBe("draft");
+  expect(container.querySelector(".pwi-settings-sticky-bar")).toBeTruthy();
+  expect(modeSelect(container).value).toBe("direct");
   await act(async () => { root.unmount(); });
 });

--- a/gui/tests/provider-settings-account-mode.test.tsx
+++ b/gui/tests/provider-settings-account-mode.test.tsx
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act } from "react";
+import type { Root } from "react-dom/client";
+import ProviderSettings from "../src/components/provider-workspace/ProviderSettings";
+import type { ProviderUpdatePatch } from "../src/components/provider-workspace/types";
+import { LanguageProvider } from "../src/i18n/provider";
+import type { WorkspaceItem } from "../src/provider-workspace/catalog";
+
+const globals = ["document", "window", "navigator", "localStorage", "IS_REACT_ACT_ENVIRONMENT"] as const;
+let previousGlobals: Record<(typeof globals)[number], unknown>;
+let testWindow: Window;
+
+beforeEach(() => {
+  previousGlobals = Object.fromEntries(globals.map(key => [key, Reflect.get(globalThis, key)])) as typeof previousGlobals;
+  testWindow = new Window({ url: "http://localhost/#providers/workspace" });
+  Object.defineProperty(testWindow.navigator, "language", { configurable: true, value: "en-US" });
+  Object.defineProperties(globalThis, {
+    document: { configurable: true, value: testWindow.document },
+    window: { configurable: true, value: testWindow },
+    navigator: { configurable: true, value: testWindow.navigator },
+    localStorage: { configurable: true, value: testWindow.localStorage },
+  });
+  setConfirm(true);
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(() => {
+  testWindow.close();
+  for (const key of globals) {
+    Object.defineProperty(globalThis, key, { configurable: true, value: previousGlobals[key] });
+  }
+});
+
+function setConfirm(result: boolean): void {
+  Object.defineProperty(testWindow, "confirm", { configurable: true, value: () => result });
+}
+
+function openAiItem(mode: "pool" | "direct" = "pool"): WorkspaceItem {
+  return {
+    name: "openai",
+    adapter: "openai-responses",
+    baseUrl: "https://chatgpt.com/backend-api/codex",
+    authMode: "forward",
+    codexAccountMode: mode,
+  } as WorkspaceItem;
+}
+
+async function mountSettings(
+  item: WorkspaceItem,
+  onUpdateProvider?: (name: string, patch: ProviderUpdatePatch) => Promise<{ ok: boolean; error?: string }>,
+): Promise<{
+  root: Root;
+  container: HTMLElement;
+  patches: ProviderUpdatePatch[];
+}> {
+  const patches: ProviderUpdatePatch[] = [];
+  const container = document.createElement("div");
+  document.body.append(container);
+  const { createRoot } = await import("react-dom/client");
+  let root!: Root;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <LanguageProvider>
+        <ProviderSettings
+          item={item}
+          onUpdateProvider={async (name, patch) => {
+            patches.push(patch);
+            return onUpdateProvider ? onUpdateProvider(name, patch) : { ok: true };
+          }}
+        />
+      </LanguageProvider>,
+    );
+  });
+  return { root, container, patches };
+}
+
+function modeSelect(container: HTMLElement): HTMLSelectElement {
+  const select = [...container.querySelectorAll<HTMLSelectElement>("select")]
+    .find(s => s.value === "pool" || s.value === "direct");
+  expect(select).toBeTruthy();
+  return select!;
+}
+
+async function chooseMode(select: HTMLSelectElement, value: string): Promise<void> {
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(testWindow.HTMLSelectElement.prototype, "value")!
+      .set!.call(select, value);
+    select.dispatchEvent(new testWindow.Event("change", { bubbles: true }));
+  });
+}
+
+test("a confirmed mode change sends the exact standalone codexAccountMode patch", async () => {
+  const { root, container, patches } = await mountSettings(openAiItem("pool"));
+  const select = modeSelect(container);
+
+  await chooseMode(select, "direct");
+
+  expect(patches).toEqual([{ codexAccountMode: "direct" }]);
+  expect(select.value).toBe("direct");
+  expect(container.querySelector('[role="status"]')?.textContent).toContain("Account mode saved.");
+  await act(async () => { root.unmount(); });
+});
+
+test("a cancelled confirmation sends no patch and snaps the select back", async () => {
+  const { root, container, patches } = await mountSettings(openAiItem("pool"));
+  const select = modeSelect(container);
+  setConfirm(false);
+
+  await chooseMode(select, "direct");
+
+  expect(patches).toHaveLength(0);
+  expect(select.value).toBe("pool");
+  await act(async () => { root.unmount(); });
+});
+
+test("a failed mode patch keeps the applied mode and announces the error", async () => {
+  const { root, container } = await mountSettings(openAiItem("pool"), async () => ({ ok: false, error: "mode rejected" }));
+  const select = modeSelect(container);
+
+  await chooseMode(select, "direct");
+
+  expect(select.value).toBe("pool");
+  const alert = container.querySelector('[role="alert"]');
+  expect(alert?.textContent).toContain("mode rejected");
+  await act(async () => { root.unmount(); });
+});
+
+test("the mode select is disabled while its own PATCH is in flight", async () => {
+  let resolvePatch!: (result: { ok: boolean }) => void;
+  const pending = new Promise<{ ok: boolean }>(resolve => {
+    resolvePatch = resolve;
+  });
+  const { root, container } = await mountSettings(openAiItem(), async () => pending);
+  const select = modeSelect(container);
+
+  await chooseMode(select, "direct");
+  expect(select.disabled).toBe(true);
+
+  await act(async () => {
+    resolvePatch({ ok: true });
+    await pending;
+  });
+  expect(select.disabled).toBe(false);
+  await act(async () => { root.unmount(); });
+});
+
+test("the mode select is disabled while an ordinary settings save is in flight", async () => {
+  let resolveSave!: (result: { ok: boolean; error?: string }) => void;
+  const pending = new Promise<{ ok: boolean; error?: string }>(resolve => {
+    resolveSave = resolve;
+  });
+  const { root, container } = await mountSettings(openAiItem(), async () => pending);
+  const note = container.querySelector<HTMLTextAreaElement>(".pwi-settings-textarea")!;
+
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(testWindow.HTMLTextAreaElement.prototype, "value")!
+      .set!.call(note, "changed");
+    note.dispatchEvent(new testWindow.Event("input", { bubbles: true }));
+  });
+  const saveButton = container.querySelector<HTMLButtonElement>(".pwi-settings-sticky-bar .btn-primary")!;
+  expect(saveButton).toBeTruthy();
+  await act(async () => {
+    saveButton!.click();
+    await Promise.resolve();
+  });
+
+  expect(modeSelect(container).disabled).toBe(true);
+  await act(async () => {
+    resolveSave({ ok: true });
+    await pending;
+  });
+  expect(modeSelect(container).disabled).toBe(false);
+  await act(async () => { root.unmount(); });
+});

--- a/gui/tests/use-providers-crud-update.test.tsx
+++ b/gui/tests/use-providers-crud-update.test.tsx
@@ -38,39 +38,7 @@ test("updateProvider awaits fetchConfig before returning success", async () => {
   const fetchConfig = mock(() => configPromise);
   globalThis.fetch = (async () => Response.json({ ok: true })) as typeof fetch;
 
-  const container = document.createElement("div");
-  document.body.append(container);
-  const { createRoot } = await import("react-dom/client");
-  let root!: Root;
-  let updateProvider!: (name: string, patch: ProviderUpdatePatch) => Promise<{ ok: boolean; error?: string }>;
-
-  function Harness() {
-    const removeBusyRef = useRef(false);
-    const crud = useProvidersCrud({
-      apiBase: "http://localhost:10100",
-      t: ((key: string) => key) as never,
-      removeBusyRef,
-      workspaceSelected: null,
-      setWorkspaceSelected: () => {},
-      setRemoveConfirmName: () => {},
-      notify: () => {},
-      fetchConfig,
-      fetchOauth: async () => {},
-      fetchProviderQuotas: async () => {},
-    });
-    const [ready, setReady] = useState(false);
-    useEffect(() => {
-      updateProvider = crud.updateProvider;
-      setReady(true);
-    }, [crud.updateProvider]);
-    return ready ? <div data-ready="1" /> : null;
-  }
-
-  await act(async () => {
-    root = createRoot(container);
-    root.render(<Harness />);
-  });
-  expect(container.querySelector("[data-ready]")).toBeTruthy();
+  const { root, updateProvider } = await mountCrud({ fetchConfig: fetchConfig as () => Promise<void> });
 
   let settled: { ok: boolean; error?: string } | undefined;
   const pending = updateProvider("openai", { note: "next" }).then(result => {
@@ -88,6 +56,116 @@ test("updateProvider awaits fetchConfig before returning success", async () => {
     await pending;
   });
   expect(settled).toEqual({ ok: true });
+
+  await act(async () => { root.unmount(); });
+});
+
+async function mountCrud(overrides: {
+  fetchConfig?: () => Promise<void>;
+  fetchProviderQuotas?: (refresh?: boolean) => Promise<void>;
+  refreshCodexAccount?: () => Promise<unknown>;
+} = {}) {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const { createRoot } = await import("react-dom/client");
+  let root!: Root;
+  let updateProvider!: (name: string, patch: ProviderUpdatePatch) => Promise<{ ok: boolean; error?: string }>;
+
+  function Harness() {
+    const removeBusyRef = useRef(false);
+    const crud = useProvidersCrud({
+      apiBase: "http://localhost:10100",
+      t: ((key: string) => key) as never,
+      removeBusyRef,
+      workspaceSelected: null,
+      setWorkspaceSelected: () => {},
+      setRemoveConfirmName: () => {},
+      notify: () => {},
+      fetchConfig: overrides.fetchConfig ?? (async () => {}),
+      fetchOauth: async () => {},
+      fetchProviderQuotas: overrides.fetchProviderQuotas ?? (async () => {}),
+      refreshCodexAccount: overrides.refreshCodexAccount,
+    });
+    const [ready, setReady] = useState(false);
+    useEffect(() => {
+      updateProvider = crud.updateProvider;
+      setReady(true);
+    }, [crud.updateProvider]);
+    return ready ? <div data-ready="1" /> : null;
+  }
+
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<Harness />);
+  });
+  expect(container.querySelector("[data-ready]")).toBeTruthy();
+  return { root, updateProvider };
+}
+
+test("a codexAccountMode patch sends the standalone body and awaits quota + Codex refreshes", async () => {
+  let resolveQuota!: () => void;
+  let resolveCodex!: () => void;
+  const quotaGate = new Promise<void>(resolve => {
+    resolveQuota = resolve;
+  });
+  const codexGate = new Promise<void>(resolve => {
+    resolveCodex = resolve;
+  });
+  const fetchProviderQuotas = mock(async (_refresh?: boolean) => { await quotaGate; });
+  const refreshCodexAccount = mock(async () => { await codexGate; });
+  let captured: { url: string; method?: string; body?: unknown } | null = null;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    captured = { url: String(input), method: init?.method, body: init?.body ? JSON.parse(String(init.body)) : undefined };
+    return Response.json({ ok: true });
+  }) as typeof fetch;
+
+  const { root, updateProvider } = await mountCrud({
+    fetchProviderQuotas: fetchProviderQuotas as (refresh?: boolean) => Promise<void>,
+    refreshCodexAccount: refreshCodexAccount as () => Promise<unknown>,
+  });
+
+  let settled: { ok: boolean; error?: string } | undefined;
+  const pending = updateProvider("openai", { codexAccountMode: "direct" }).then(result => {
+    settled = result;
+  });
+
+  await act(async () => {
+    await Promise.resolve();
+  });
+  expect(captured).toEqual({
+    url: "http://localhost:10100/api/providers?name=openai",
+    method: "PATCH",
+    body: { codexAccountMode: "direct" },
+  });
+  expect(fetchProviderQuotas).toHaveBeenCalledWith(true);
+  expect(refreshCodexAccount).toHaveBeenCalledTimes(1);
+  expect(settled).toBeUndefined();
+
+  await act(async () => {
+    resolveQuota();
+    resolveCodex();
+    await pending;
+  });
+  expect(settled).toEqual({ ok: true });
+
+  await act(async () => { root.unmount(); });
+});
+
+test("non-mode patches do not refresh quotas or the Codex controller", async () => {
+  const fetchProviderQuotas = mock(async () => {});
+  const refreshCodexAccount = mock(async () => {});
+  globalThis.fetch = (async () => Response.json({ ok: true })) as typeof fetch;
+
+  const { root, updateProvider } = await mountCrud({
+    fetchProviderQuotas: fetchProviderQuotas as (refresh?: boolean) => Promise<void>,
+    refreshCodexAccount: refreshCodexAccount as () => Promise<unknown>,
+  });
+
+  await act(async () => {
+    await updateProvider("openai", { note: "next" });
+  });
+  expect(fetchProviderQuotas).not.toHaveBeenCalled();
+  expect(refreshCodexAccount).not.toHaveBeenCalled();
 
   await act(async () => { root.unmount(); });
 });


### PR DESCRIPTION
## Summary

- Adds a Pool/Direct `codexAccountMode` selector to the Providers workspace Settings tab for the canonical OpenAI (Codex login) provider, so the dashboard no longer requires the JSON editor to change the account mode.
- The selector calls the existing dedicated `PATCH /api/providers?name=openai` endpoint with `codexAccountMode` alone, applies immediately, shows the description of the current mode, and refreshes the provider config so badges and the Codex Auth banner stay in sync.
- The control only renders for the canonical `openai` forward provider; other providers keep the existing settings form unchanged.

## Validation

- `bun run typecheck` — pass
- `bun run lint:gui` — pass
- `bun run build:gui` — pass
- `bun run privacy:scan` — pass
- React Doctor (changed files) — no issues
- `bun run test` — 7574 pass, 7 skip, 14 fail; the 14 failures are pre-existing Windows host-environment artifacts (symlink creation without Developer Mode, and a globally installed `codex.cmd`), all in files untouched by this diff; upstream `dev` CI is green on the same test set
- Browser E2E against an isolated proxy: switching Pool → Direct and Direct → Pool through the new selector persists on the server (`GET /api/providers`), the per-mode hint updates, and the save message appears. New copy uses existing `codexAuth.*` keys plus two new `pws.accountMode*` keys in all six locales.

## Review notes

- The mode applies immediately, matching the existing enable/disable toggle pattern on the provider header; the PATCH body never combines `codexAccountMode` with other fields, satisfying the endpoint's mutual-exclusion rule.

Fixes #586


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Direct and Pool account-mode options for supported OpenAI provider settings.
  * Added mode descriptions, availability indicators, and confirmation prompts.
  * Provider data and quotas refresh automatically after saving mode changes.

* **Bug Fixes**
  * Prevented conflicting edits while account-mode or general settings changes are being saved.
  * Failed mode changes now preserve the selected state and display an error.

* **Style**
  * Added distinct success and error styling for save messages.

* **Localization**
  * Added translated account-mode confirmation and save-status messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->