### PR TITLE
fix(claude): keep a marker for tool_result document blocks

### DIFF
--- a/src/claude/inbound.ts
+++ b/src/claude/inbound.ts
@@ -106,6 +106,10 @@ function toolResultOutput(block: Rec): string | Rec[] {
       } else if (item.type === "image") {
         const img = imageBlockToInputImage(item);
         if (img) out.push(img);
+      } else if (item.type === "document") {
+        // Same marker as the user-message document case below: the model should see the
+        // attachment happened instead of an empty tool output.
+        out.push({ type: "input_text", text: `[document${typeof item.title === "string" ? `: ${item.title}` : ""}]` });
       }
     }
     if (isError) out.unshift({ type: "input_text", text: "[tool error]" });

--- a/tests/claude-inbound.test.ts
+++ b/tests/claude-inbound.test.ts
@@ -175,6 +175,41 @@ describe("claude inbound translation", () => {
     expect(() => parseRequest(body)).not.toThrow();
   });
 
+  test("tool_result document blocks surface the attachment marker", () => {
+    const body = anthropicToResponsesBody({
+      model: "m", max_tokens: 10,
+      messages: [
+        { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "Read", input: {} }] },
+        {
+          role: "user",
+          content: [{
+            type: "tool_result", tool_use_id: "t1",
+            content: [
+              { type: "text", text: "3 pages" },
+              { type: "document", source: { type: "base64", media_type: "application/pdf", data: "aWc=" }, title: "report.pdf" },
+            ],
+          }],
+        },
+        { role: "assistant", content: [{ type: "tool_use", id: "t2", name: "Read", input: {} }] },
+        {
+          role: "user",
+          content: [{
+            type: "tool_result", tool_use_id: "t2",
+            content: [{ type: "document", source: { type: "base64", media_type: "application/pdf", data: "aWc=" } }],
+          }],
+        },
+      ],
+    }) as any;
+    expect(body.input[1].output).toEqual([
+      { type: "input_text", text: "3 pages" },
+      { type: "input_text", text: "[document: report.pdf]" },
+    ]);
+    // An untitled document still leaves a marker rather than the empty output that
+    // read as "the tool returned nothing".
+    expect(body.input[3].output).toEqual([{ type: "input_text", text: "[document]" }]);
+    expect(() => parseRequest(body)).not.toThrow();
+  });
+
   test("modelMap: exact, date-stripped, passthrough", () => {
     const cc = { modelMap: { "claude-sonnet-4-5": "gemini/gemini-3-flash", "claude-opus-4": "xai/grok-4" } };
     expect(resolveInboundModel("claude-sonnet-4-5", cc)).toBe("gemini/gemini-3-flash");


### PR DESCRIPTION
## Summary

When a tool result contains a `document` block, the inbound translation dropped it and routed providers received an empty tool output, so the model concluded the tool returned nothing. A document in a plain user message already gets a `[document: title]` marker; the tool-result path now emits the same marker.

## Verification

- New test in `tests/claude-inbound.test.ts`: titled, untitled, and mixed text plus document results.
- Reproduced against a mock upstream: the tool message arrived as `""` before the fix and `[document]` after.
- `bun run test`, `typecheck`, `lint:gui`, `privacy:scan`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Document attachments in tool results are now represented correctly instead of producing empty output.
  * Document titles are preserved when available; untitled documents use a clear placeholder.

* **Tests**
  * Added coverage to verify document handling, text preservation, and parseable tool results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->