### PR TITLE
fix(claude): separate reasoning summary parts in streamed thinking

### DIFF
--- a/src/claude/outbound.ts
+++ b/src/claude/outbound.ts
@@ -187,6 +187,8 @@ interface OpenBlock {
   argsBufBytes?: number;
   webSearchArgsEmitted?: boolean;
   callId?: string;
+  /** Last reasoning part identity (item + summary/content index) seen by this thinking block. */
+  reasoningPartKey?: string;
 }
 
 /** Streaming: Responses SSE bytes -> Anthropic Messages SSE bytes. */
@@ -353,6 +355,21 @@ export function responsesSseToAnthropicSse(
           case "response.reasoning_text.delta": {
             if (typeof data.delta !== "string" || data.delta.length === 0) break;
             ensureBlock("thinking");
+            // The JSON path joins reasoning summary/content parts with "\n\n"
+            // (responsesJsonToAnthropicMessage); mirror that at part and item boundaries
+            // so multi-part summaries do not glue into one run-on paragraph. Frames
+            // without part indices produce a constant key and never get a separator.
+            const slot = eventName === "response.reasoning_summary_text.delta"
+              ? `s${String(data.summary_index)}`
+              : `c${String(data.content_index)}`;
+            const partKey = `${String(data.item_id)}:${slot}`;
+            if (open!.reasoningPartKey !== undefined && open!.reasoningPartKey !== partKey) {
+              emit("content_block_delta", {
+                type: "content_block_delta", index: open!.index,
+                delta: { type: "thinking_delta", thinking: "\n\n" },
+              });
+            }
+            open!.reasoningPartKey = partKey;
             emit("content_block_delta", {
               type: "content_block_delta", index: open!.index,
               delta: { type: "thinking_delta", thinking: data.delta },

--- a/tests/claude-outbound.test.ts
+++ b/tests/claude-outbound.test.ts
@@ -207,6 +207,58 @@ describe("claude outbound SSE", () => {
     expect(startIndexes).toEqual([0, 1, 2]);
   });
 
+  test("multi-part reasoning summaries keep the JSON path's part separator", async () => {
+    const upstream = [
+      sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+      sse("response.output_item.added", { output_index: 0, item: { type: "reasoning", id: "rs_1" } }),
+      sse("response.reasoning_summary_part.added", { item_id: "rs_1", output_index: 0, summary_index: 0, part: { type: "summary_text", text: "" } }),
+      sse("response.reasoning_summary_text.delta", { item_id: "rs_1", output_index: 0, summary_index: 0, delta: "**A**\n\nOne." }),
+      sse("response.reasoning_summary_part.added", { item_id: "rs_1", output_index: 0, summary_index: 1, part: { type: "summary_text", text: "" } }),
+      sse("response.reasoning_summary_text.delta", { item_id: "rs_1", output_index: 0, summary_index: 1, delta: "**B**\n\nTwo." }),
+      sse("response.output_item.done", { output_index: 0, item: { type: "reasoning", id: "rs_1" } }),
+      sse("response.output_item.added", { output_index: 1, item: { type: "reasoning", id: "rs_2" } }),
+      sse("response.reasoning_summary_text.delta", { item_id: "rs_2", output_index: 1, summary_index: 0, delta: "Three." }),
+      sse("response.completed", { response: { status: "completed", usage: { input_tokens: 1, output_tokens: 1 } } }),
+    ].join("");
+    const msg = await collectAnthropicMessage(responsesSseToAnthropicSse(streamFrom(upstream), "m"), "m") as Record<string, any>;
+    // Parts within an item are separated; a new reasoning item opens its own block.
+    const thinkingBlocks = msg.content.filter((b: Record<string, unknown>) => b.type === "thinking");
+    expect(thinkingBlocks.map((b: Record<string, unknown>) => b.thinking)).toEqual([
+      "**A**\n\nOne.\n\n**B**\n\nTwo.",
+      "Three.",
+    ]);
+
+    // Parity: the non-streaming translator joins the same summary parts identically.
+    const json = responsesJsonToAnthropicMessage({
+      id: "resp_1",
+      status: "completed",
+      output: [{ type: "reasoning", id: "rs_1", summary: [{ type: "summary_text", text: "**A**\n\nOne." }, { type: "summary_text", text: "**B**\n\nTwo." }] }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    }, "m") as Record<string, any>;
+    const jsonThinking = json.content.find((b: Record<string, unknown>) => b.type === "thinking");
+    expect(jsonThinking.thinking).toBe("**A**\n\nOne.\n\n**B**\n\nTwo.");
+  });
+
+  test("same-part deltas and index-free reasoning frames never get a separator", async () => {
+    const samePart = [
+      sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+      sse("response.reasoning_summary_text.delta", { item_id: "rs_1", output_index: 0, summary_index: 0, delta: "Hel" }),
+      sse("response.reasoning_summary_text.delta", { item_id: "rs_1", output_index: 0, summary_index: 0, delta: "lo" }),
+      sse("response.completed", { response: { status: "completed", usage: { input_tokens: 1, output_tokens: 1 } } }),
+    ].join("");
+    const msg1 = await collectAnthropicMessage(responsesSseToAnthropicSse(streamFrom(samePart), "m"), "m") as Record<string, any>;
+    expect(msg1.content.find((b: Record<string, unknown>) => b.type === "thinking").thinking).toBe("Hello");
+
+    const indexFree = [
+      sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+      sse("response.reasoning_text.delta", { delta: "A" }),
+      sse("response.reasoning_text.delta", { delta: "B" }),
+      sse("response.completed", { response: { status: "completed", usage: { input_tokens: 1, output_tokens: 1 } } }),
+    ].join("");
+    const msg2 = await collectAnthropicMessage(responsesSseToAnthropicSse(streamFrom(indexFree), "m"), "m") as Record<string, any>;
+    expect(msg2.content.find((b: Record<string, unknown>) => b.type === "thinking").thinking).toBe("AB");
+  });
+
   test("data-only Responses frames infer event names from payload types", async () => {
     const upstream = [
       dataOnlySse({ type: "response.created", response: { id: "resp_data_only", status: "in_progress" } }),

--- a/tests/claude-outbound.test.ts
+++ b/tests/claude-outbound.test.ts
@@ -259,6 +259,17 @@ describe("claude outbound SSE", () => {
     expect(msg2.content.find((b: Record<string, unknown>) => b.type === "thinking").thinking).toBe("AB");
   });
 
+  test("indexed reasoning content parts get the separator too", async () => {
+    const indexedContent = [
+      sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+      sse("response.reasoning_text.delta", { item_id: "rs_1", output_index: 0, content_index: 0, delta: "A" }),
+      sse("response.reasoning_text.delta", { item_id: "rs_1", output_index: 0, content_index: 1, delta: "B" }),
+      sse("response.completed", { response: { status: "completed", usage: { input_tokens: 1, output_tokens: 1 } } }),
+    ].join("");
+    const msg = await collectAnthropicMessage(responsesSseToAnthropicSse(streamFrom(indexedContent), "m"), "m") as Record<string, any>;
+    expect(msg.content.find((b: Record<string, unknown>) => b.type === "thinking").thinking).toBe("A\n\nB");
+  });
+
   test("data-only Responses frames infer event names from payload types", async () => {
     const upstream = [
       dataOnlySse({ type: "response.created", response: { id: "resp_data_only", status: "in_progress" } }),


### PR DESCRIPTION
## Summary

On the native ChatGPT backend the upstream Responses stream is translated straight into Anthropic SSE. Reasoning summaries arrive there in parts, each its own paragraph with a bold headline. The streaming translator folded every part into one thinking block with no separator, so thinking text rendered as run-on lines like "wants X.**Planning the fix**". The non-streaming translator in the same file already joins parts with a blank line. The stream now tracks part identity on the delta frames and emits the same blank-line separator at part boundaries. Frames without part indices keep a constant key and behave as before, and a new reasoning item still opens its own block.

## Verification

- Two new tests in `tests/claude-outbound.test.ts`: multi-part summaries match the JSON path's joined text, and same-part or index-free deltas never get a separator.
- Repro harness: streamed, collected, and JSON-path thinking text are now identical for the same upstream frames.
- `bun run test`, `typecheck`, `lint:gui`, `privacy:scan`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streamed reasoning display by clearly separating distinct summary sections.
  * Preserved continuous text when updates belong to the same section or lack section indicators.
  * Aligned streaming and non-streaming reasoning output for consistent results.

* **Tests**
  * Added coverage for multiple reasoning sections and streaming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->