### PR TITLE
fix(compact): report upstream usage for native compact turns

### DIFF
--- a/src/server/responses/compact.ts
+++ b/src/server/responses/compact.ts
@@ -506,6 +506,10 @@ export async function handleResponsesCompact(
     // Always record the real upstream status: a local buffering failure after a
     // 200 upstream response must not soft-avoid a healthy account or rotate a thread.
     recordCompactPoolOutcome(outcomeCtx, upstream.status, { retryAfter, resetAt });
+    // Lift usage and response metadata from the buffered upstream JSON into the
+    // request log; the routed branch gets the same through handleResponses. The
+    // synthetic buffer errors are not upstream bodies and stay uninspected.
+    if (buffered.ok) inspectResponseLogJson(logCtx, await buffered.clone().text());
     return buffered;
   }
 

--- a/src/server/responses/compact.ts
+++ b/src/server/responses/compact.ts
@@ -86,10 +86,10 @@ import { redactSecretString } from "../../lib/redact";
 import { readBoundedResponseBody } from "../../lib/bounded-body";
 import { supportedLadderFor } from "../effort-policy";
 import {
+  applyResponseLogMetadata,
   beginRequestAttempt,
   catalogModelSupportsServiceTier,
   finishRequestAttempt,
-  inspectResponseLogJson,
   noteAttemptSend,
   readConfiguredCodexServiceTier,
   requestLogSpeedLabel,
@@ -507,9 +507,16 @@ export async function handleResponsesCompact(
     // 200 upstream response must not soft-avoid a healthy account or rotate a thread.
     recordCompactPoolOutcome(outcomeCtx, upstream.status, { retryAfter, resetAt });
     // Lift usage and response metadata from the buffered upstream JSON into the
-    // request log; the routed branch gets the same through handleResponses. The
-    // synthetic buffer errors are not upstream bodies and stay uninspected.
-    if (buffered.ok) inspectResponseLogJson(logCtx, await buffered.clone().text());
+    // request log; the routed branch gets the same through handleResponses. Only
+    // the parsed fields are read: a compact body is replacement history derived
+    // from the conversation, so it must never reach the usage debug body sampler.
+    if (buffered.ok) {
+      try {
+        applyResponseLogMetadata(logCtx, JSON.parse(await buffered.clone().text()));
+      } catch {
+        /* body may not be JSON; usage stays unreported */
+      }
+    }
     return buffered;
   }
 

--- a/tests/responses-compaction-routing.test.ts
+++ b/tests/responses-compaction-routing.test.ts
@@ -182,15 +182,26 @@ describe("native compact usage reporting", () => {
     } as unknown as OcxConfig;
     globalThis.fetch = (async () => jsonResponse(completedPayload("native summary"))) as typeof fetch;
     const logCtx: RequestLogContext = { model: "", provider: "" };
-    const response = await handleResponsesCompact(
-      compactionRequest(baseCompactionBody({ model: "openai-apikey/gpt-5.5" })),
-      config,
-      logCtx,
-    );
+    const previousUsageDebug = process.env.OPENCODEX_USAGE_DEBUG;
+    process.env.OPENCODEX_USAGE_DEBUG = "1";
+    let response: Response;
+    try {
+      response = await handleResponsesCompact(
+        compactionRequest(baseCompactionBody({ model: "openai-apikey/gpt-5.5" })),
+        config,
+        logCtx,
+      );
+    } finally {
+      if (previousUsageDebug === undefined) delete process.env.OPENCODEX_USAGE_DEBUG;
+      else process.env.OPENCODEX_USAGE_DEBUG = previousUsageDebug;
+    }
     expect(response.status).toBe(200);
-    const body = await response.json() as { usage?: Record<string, unknown> };
-    expect(body.usage).toMatchObject({ input_tokens: 10, output_tokens: 5, total_tokens: 15 });
+    expect(await response.json()).toEqual(completedPayload("native summary"));
     expect(logCtx.usage).toMatchObject({ inputTokens: 10, outputTokens: 5, totalTokens: 15 });
+    // The compact body is replacement history; even with usage debug on it must
+    // never be sampled into the debug log.
+    expect(logCtx.usageDebugBodyKind).toBeUndefined();
+    expect(logCtx.usageDebugBodySample).toBeUndefined();
   });
 });
 

--- a/tests/responses-compaction-routing.test.ts
+++ b/tests/responses-compaction-routing.test.ts
@@ -25,6 +25,7 @@ import {
 } from "../src/codex/auth-context";
 import { supportsNativeResponsesCompactEndpoint } from "../src/providers/openai-tiers";
 import { acquireNativeMainProfileDrain, tryAdmitTurn } from "../src/server/lifecycle";
+import type { RequestLogContext } from "../src/server/request-log";
 import type { OcxConfig, OcxProviderConfig } from "../src/types";
 
 const originalFetch = globalThis.fetch;
@@ -163,6 +164,33 @@ describe("supportsNativeResponsesCompactEndpoint (#422)", () => {
       ...officialApi,
       baseUrl: "https://gateway.example/v1",
     })).toBe(false);
+  });
+});
+
+describe("native compact usage reporting", () => {
+  test("the buffered upstream body fills the request log usage and stays intact for the client", async () => {
+    const config = {
+      defaultProvider: "openai-apikey",
+      providers: {
+        "openai-apikey": {
+          adapter: "openai-responses",
+          baseUrl: "https://api.openai.com/v1",
+          authMode: "key",
+          apiKey: "sk-test",
+        },
+      },
+    } as unknown as OcxConfig;
+    globalThis.fetch = (async () => jsonResponse(completedPayload("native summary"))) as typeof fetch;
+    const logCtx: RequestLogContext = { model: "", provider: "" };
+    const response = await handleResponsesCompact(
+      compactionRequest(baseCompactionBody({ model: "openai-apikey/gpt-5.5" })),
+      config,
+      logCtx,
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json() as { usage?: Record<string, unknown> };
+    expect(body.usage).toMatchObject({ input_tokens: 10, output_tokens: 5, total_tokens: 15 });
+    expect(logCtx.usage).toMatchObject({ inputTokens: 10, outputTokens: 5, totalTokens: 15 });
   });
 });
 


### PR DESCRIPTION
## Summary

Native /v1/responses/compact turns buffer the upstream JSON and return it without reading the body, so every native compaction lands in /api/usage as unreported even though the response carries a full usage object. Compact turns are among the largest requests an account makes, so the undercount is biggest exactly where usage matters. The routed branch already reports through handleResponses. The native branch now inspects a clone of the buffered body with the existing inspectResponseLogJson helper, filling usage, resolved model, and service tier in the request log. The client body is unchanged and synthetic error responses are not inspected.

## Verification

- New test in `tests/responses-compaction-routing.test.ts`: a native compact turn fills the request log usage from the upstream body and the client still receives the body intact.
- `bun run test`, `typecheck`, `lint:gui`, `privacy:scan`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Native compact responses now preserve the upstream response body while correctly recording usage and response metadata in request logs.
  * Synthetic buffering errors are excluded from metadata inspection.
  * Non-JSON response bodies no longer report usage incorrectly.

* **Tests**
  * Added regression coverage to verify response delivery and usage tracking for compact responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->