### PR TITLE
docs(agents): instruct agents to use issue and PR templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,27 @@ bun run build:gui      # Vite GUI build
 Run `bun run typecheck` and `bun run test` before proposing or approving any
 non-trivial change. CI runs these on Linux, Windows, and macOS.
 
+## Issues and pull requests (agents)
+
+Agent-created issues and PRs must use the repository templates. The gates
+below enforce them, so a freeform or mismatched submission is rejected rather
+than nudged.
+
+- **Creating an issue:** open it through the template chooser and use the
+  matching form in `.github/ISSUE_TEMPLATE/` — `bug_report.yml` (Bug report),
+  `feature_request.yml` (Feature proposal), `documentation.yml`
+  (Documentation), or `provider_compatibility.yml` (Provider or API
+  compatibility). Keep the form's section headings exactly as generated;
+  `enforce-issue-quality` validates the headings and closes untemplated or
+  mislabeled issues (`.github/ISSUE_TEMPLATE/config.yml` disables blank
+  issues, so there is no freeform fallback).
+- **Opening a pull request:** fill every section of
+  `.github/PULL_REQUEST_TEMPLATE.md` (Summary, Verification, Checklist).
+  `enforce-target` rejects empty, thin, or malformed descriptions, and a PR
+  whose title or description mentions `gui` must include a screenshot of the
+  UI change in the description. When the PR resolves an issue, add
+  `Closes #<number>` so merging updates the tracker automatically.
+
 ## Branch policy
 
 - `dev` — the single integration branch and the target for every pull request.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,9 @@ than nudged.
   `enforce-target` rejects empty, thin, or malformed descriptions, and a PR
   whose title or description mentions `gui` must include a screenshot of the
   UI change in the description. When the PR resolves an issue, add
-  `Closes #<number>` so merging updates the tracker automatically.
+  `Closes #<number>` to link it. GitHub auto-closes the linked issue only
+  when the PR merges into the default branch (`main`); PRs here target
+  `dev`, so close the issue manually once the change is on `dev`.
 
 ## Branch policy
 


### PR DESCRIPTION
## Summary

Adds a short "Issues and pull requests (agents)" section to `AGENTS.md` so
agent-created contributions use the repository templates:

- **Issues:** the matching form in `.github/ISSUE_TEMPLATE/` (Bug report /
  Feature proposal / Documentation / Provider or API compatibility), keeping
  the generated section headings — `enforce-issue-quality` validates the
  headings and closes untemplated issues, and `config.yml` disables blank
  issues so there is no freeform fallback.
- **PRs:** every section of `.github/PULL_REQUEST_TEMPLATE.md` (Summary,
  Verification, Checklist) — `enforce-target` rejects empty, thin, or
  malformed descriptions and GUI PRs require a screenshot; `Closes #<number>`
  linking guidance, with the auto-close limitation stated (GitHub closes the
  linked issue only on default-branch merges, so dev-targeted PRs require a
  manual close once the change is on `dev`).

Docs-only change; no runtime, GUI, or test-path impact. Content is grounded
in the repository's actual CI gates (`.github/workflows/enforce-issue-quality.yml`,
`enforce-pr-target.yml`) and current template files.

## Verification

- `git diff` reviewed: 21 added lines, confined to `AGENTS.md`.
- Nothing in the build, typecheck, or test path reads `AGENTS.md`;
  `bun run typecheck` / `bun run test` were green on the dev HEAD this branch
  was cut from (`91da63fd7`) and are unaffected by a docs-only edit.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (N/A — documentation only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for creating GitHub issues and pull requests.
  * Documented required templates, headings, sections, screenshots, and issue-closing references.
  * Clarified that changes targeting the development branch may require manual issue closure after merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->