### PR TITLE
fix(test): isolate usage-log fixtures from the real OpenCodex home

### DIFF
--- a/tests/management-api-logs-metrics.test.ts
+++ b/tests/management-api-logs-metrics.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { handleManagementAPI } from "../src/server/management-api";
+import { usageLogPath } from "../src/usage/log";
 import {
   addRequestLog,
   clearRequestLogsForTests,
@@ -173,6 +174,34 @@ describe("GET /api/logs display metrics", () => {
     }));
     const [dto] = await readLogs();
     expect(dto!.displayMetrics.cost).toEqual({ kind: "unavailable", reason: "invalid_cache_breakdown" });
+  });
+
+  test("fixture usage rows land in the scratch home, never the default location", () => {
+    // Pins the safety property this file's isolation exists for: addRequestLog
+    // persists to usage.jsonl, so if the scratch-home hook is ever dropped (or a
+    // future test logs before it runs), a bare `bun test <file>` from outside the
+    // repo writes fixture rows into the developer's real ~/.opencodex log.
+    const requestId = "safety-pin-usage-log-target";
+    addRequestLog(baseEntry({ requestId }));
+
+    const resolvedTarget = usageLogPath();
+    expect(resolvedTarget).toBe(join(testDir, "usage.jsonl"));
+    expect(readFileSync(resolvedTarget, "utf-8")).toContain(requestId);
+
+    // The default location (what the resolver returns with no OPENCODEX_HOME
+    // override) must never be the write target for this suite.
+    const previousHome = process.env.OPENCODEX_HOME;
+    delete process.env.OPENCODEX_HOME;
+    try {
+      const defaultTarget = usageLogPath();
+      expect(defaultTarget).not.toBe(resolvedTarget);
+      if (existsSync(defaultTarget)) {
+        expect(readFileSync(defaultTarget, "utf-8")).not.toContain(requestId);
+      }
+    } finally {
+      if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+      else process.env.OPENCODEX_HOME = previousHome;
+    }
   });
 });
 import { ManagementRequest as Request } from "./helpers/management-auth";

--- a/tests/management-api-logs-metrics.test.ts
+++ b/tests/management-api-logs-metrics.test.ts
@@ -1,4 +1,7 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { handleManagementAPI } from "../src/server/management-api";
 import {
   addRequestLog,
@@ -10,7 +13,24 @@ import type { OcxConfig } from "../src/types";
 
 const config = { providers: [] } as unknown as OcxConfig;
 
-afterEach(() => clearRequestLogsForTests());
+let testDir = "";
+let previousHome: string | undefined;
+
+beforeEach(() => {
+  // addRequestLog persists to usage.jsonl; without a scratch OPENCODEX_HOME a bare
+  // `bun test <file>` run from outside the repo (no bunfig preload) writes these
+  // fixture rows into the real ~/.opencodex log and poisons the GUI Usage page.
+  previousHome = process.env.OPENCODEX_HOME;
+  testDir = mkdtempSync(join(tmpdir(), "ocx-logs-metrics-"));
+  process.env.OPENCODEX_HOME = testDir;
+});
+
+afterEach(() => {
+  clearRequestLogsForTests();
+  if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = previousHome;
+  if (testDir) rmSync(testDir, { recursive: true, force: true });
+});
 
 async function readLogs(): Promise<Array<Record<string, any>>> {
   const url = new URL("http://localhost/api/logs");


### PR DESCRIPTION
## Summary

- `tests/management-api-logs-metrics.test.ts` exercises `GET /api/logs` display metrics through `addRequestLog`, which persists every row to `usage.jsonl`. Unlike its sibling suites that also persist (`usage-failure-persistence.test.ts`, `api-key-attribution.test.ts`), it did not redirect `OPENCODEX_HOME` itself and relied entirely on the `bunfig.toml` preload (`tests/preload.ts`).
- The preload only loads when Bun discovers `bunfig.toml` from the current directory. Running `bun test <absolute path>` from outside the repo (agent/IDE pattern) skips it, and the fixture rows (`ok-a`/`ok-b`/`fail`, `no-such-model`, `unpriced-model`, `combo/my-combo`, ...) are appended to the developer's real `~/.opencodex/usage.jsonl`. The dashboard Usage page then renders never-used models with real token counts.
- This change adds a per-test scratch `OPENCODEX_HOME` (mkdtemp, restored and cleaned in `afterEach`), matching the established pattern in the two sibling suites.

## Reproduction before the fix

```console
$ cd ~ && bun test /path/to/repo/tests/management-api-logs-metrics.test.ts
$ rg '"requestId":"ok-a"' ~/.opencodex/usage.jsonl   # fixture row now in the real log
```

## Verification

- Reproduced against a scratch `OPENCODEX_HOME`: 11 fixture rows were written before the fix.
- After the fix, the same foreign-cwd invocation leaves the real `usage.jsonl` untouched.
- `bun run typecheck` and `bun run privacy:scan` pass.
- Focused suites (usage-summary, usage-log, request-log, usage-cost, management-api-logs-metrics) pass: 147 tests; this file is 9/9 in the full suite.
- Full suite on this branch is green except 10 `management-provider-validation.test.ts` cases that fail only in this dev environment because `chatgpt.com` resolves to a non-global address (write-time DNS/SSRF gate returns 400); upstream CI for `dev` is green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by using temporary configuration directories for each test.
  * Added cleanup and environment restoration after tests complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I fixed all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

