### PR TITLE
fix(codex): honor tri-state fastMode in Codex config injection

### DIFF
--- a/docs-site/src/content/docs/guides/codex-integration.md
+++ b/docs-site/src/content/docs/guides/codex-integration.md
@@ -27,6 +27,10 @@ openai_base_url = "http://127.0.0.1:10100/v1"
 fast_mode = true
 ```
 
+The injected `fast_mode` follows the tri-state `fastMode` setting: `true` writes `fast_mode = true`,
+`false` writes `fast_mode = false`, and unset leaves an existing `fast_mode` untouched without
+adding a `[features]` table.
+
 The proxy listens on port `10100` by default and serves `POST /v1/responses`,
 `POST /v1/responses/compact`, `POST /v1/images/generations`, `POST /v1/images/edits`,
 `GET /v1/models`, `GET /healthz`, and the `/api/*` management surface.

--- a/docs-site/src/content/docs/ja/guides/codex-integration.md
+++ b/docs-site/src/content/docs/ja/guides/codex-integration.md
@@ -21,6 +21,10 @@ openai_base_url = "http://127.0.0.1:10100/v1"
 fast_mode = true
 ```
 
+注入される `fast_mode` は三値の `fastMode` 設定に従います。`true` は `fast_mode = true` を書き込み、
+`false` は `fast_mode = false` を書き込み、未設定の場合は既存の `fast_mode` を変更せずに
+`[features]` テーブルも追加しません。
+
 プロキシはデフォルトでポート `10100` をリッスンし、`POST /v1/responses`、`POST /v1/responses/compact`、`POST /v1/images/generations`、`POST /v1/images/edits`、`GET /v1/models`、`GET /healthz`、および `/api/*` 管理サーフェスを提供します。
 
 ### 組み込みの画像生成 (`image_gen`)

--- a/docs-site/src/content/docs/ko/guides/codex-integration.md
+++ b/docs-site/src/content/docs/ko/guides/codex-integration.md
@@ -21,6 +21,10 @@ openai_base_url = "http://127.0.0.1:10100/v1"
 fast_mode = true
 ```
 
+주입되는 `fast_mode`는 3-상태 `fastMode` 설정을 따릅니다. `true`면 `fast_mode = true`를 쓰고,
+`false`면 `fast_mode = false`를 쓰며, 설정하지 않으면 기존 `fast_mode`를 그대로 두고
+`[features]` 테이블도 추가하지 않습니다.
+
 프록시는 기본적으로 포트 `10100`에서 듣고 `POST /v1/responses`, `POST /v1/responses/compact`, `POST /v1/images/generations`, `POST /v1/images/edits`, `GET /v1/models`, `GET /healthz`, 그리고 `/api/*` 관리 표면을 제공합니다.
 
 ### 내장 이미지 생성 (`image_gen`)

--- a/docs-site/src/content/docs/ru/guides/codex-integration.md
+++ b/docs-site/src/content/docs/ru/guides/codex-integration.md
@@ -28,6 +28,10 @@ openai_base_url = "http://127.0.0.1:10100/v1"
 fast_mode = true
 ```
 
+Инжектируемый `fast_mode` следует трёхзначной настройке `fastMode`: `true` записывает
+`fast_mode = true`, `false` — `fast_mode = false`, а при отсутствии настройки существующий
+`fast_mode` сохраняется без изменений, и таблица `[features]` не добавляется.
+
 Прокси по умолчанию слушает порт `10100` и обслуживает `POST /v1/responses`,
 `POST /v1/responses/compact`, `POST /v1/images/generations`, `POST /v1/images/edits`,
 `GET /v1/models`, `GET /healthz` и management surface `/api/*`.

--- a/docs-site/src/content/docs/zh-cn/guides/codex-integration.md
+++ b/docs-site/src/content/docs/zh-cn/guides/codex-integration.md
@@ -27,6 +27,9 @@ openai_base_url = "http://127.0.0.1:10100/v1"
 fast_mode = true
 ```
 
+注入的 `fast_mode` 遵循三态 `fastMode` 配置：`true` 写入 `fast_mode = true`，`false` 写入
+`fast_mode = false`，未设置时保留用户已有的 `fast_mode` 且不添加 `[features]` 表。
+
 proxy 默认监听 `10100` 端口，并提供 `POST /v1/responses`、`POST /v1/responses/compact`、
 `POST /v1/images/generations`、`POST /v1/images/edits`、`GET /v1/models`、`GET /healthz`，
 以及 `/api/*` 管理面。

--- a/src/codex/inject.ts
+++ b/src/codex/inject.ts
@@ -397,25 +397,32 @@ function normalizeServiceTier(content: string): string {
   return content.replace(/^(\s*service_tier\s*=\s*)["']priority["']\s*$/gm, '$1"fast"');
 }
 
-function ensureFastModeFeature(content: string): string {
+function ensureFastModeFeature(content: string, fastMode?: boolean): string {
+  // Tri-state fast mode (see OcxConfig.fastMode): true forces `fast_mode = true`,
+  // false forces `fast_mode = false`, and undefined leaves the user's config
+  // untouched (no [features] table is added and an existing fast_mode line is
+  // preserved as-is).
   const lines = content.split("\n");
   const featuresStart = lines.findIndex(line => line.trim() === "[features]");
   if (featuresStart === -1) {
-    return content.trimEnd() + "\n\n[features]\nfast_mode = true\n";
+    if (fastMode === undefined) return content;
+    return content.trimEnd() + "\n\n[features]\nfast_mode = " + (fastMode ? "true" : "false") + "\n";
   }
 
   const nextTable = lines.findIndex((line, index) => index > featuresStart && /^\s*\[/.test(line));
   const featuresEnd = nextTable === -1 ? lines.length : nextTable;
   for (let i = featuresStart + 1; i < featuresEnd; i++) {
     if (/^\s*fast_mode\s*=/.test(lines[i])) {
-      lines[i] = lines[i].replace(/^(\s*)fast_mode\s*=.*$/, "$1fast_mode = true");
+      if (fastMode === undefined) return lines.join("\n");
+      lines[i] = lines[i].replace(/^(\s*)fast_mode\s*=.*$/, `$1fast_mode = ${fastMode ? "true" : "false"}`);
       return lines.join("\n");
     }
   }
 
+  if (fastMode === undefined) return lines.join("\n");
   let insertAt = featuresEnd;
   while (insertAt > featuresStart + 1 && lines[insertAt - 1].trim() === "") insertAt--;
-  lines.splice(insertAt, 0, "fast_mode = true");
+  lines.splice(insertAt, 0, `fast_mode = ${fastMode ? "true" : "false"}`);
   return lines.join("\n");
 }
 
@@ -433,7 +440,7 @@ function stripOpencodexCatalogPath(content: string): string {
     .join("\n");
 }
 
-export function buildProfileFile(port: number, catalogPath?: string | null, supportsWebsockets = false, includeApiAuthHeader = false, hostname?: string): string {
+export function buildProfileFile(port: number, catalogPath?: string | null, supportsWebsockets = false, includeApiAuthHeader = false, hostname?: string, fastMode = true): string {
   const host = providerBaseHost(hostname);
   // Design B (loopback): the reference/fallback file documents the root override form.
   // Non-loopback keeps the legacy provider-table shape (built-in provider cannot carry
@@ -446,7 +453,7 @@ export function buildProfileFile(port: number, catalogPath?: string | null, supp
       buildOpenaiBaseUrlLine(port, hostname),
     ];
     if (catalogPath) lines.push(`model_catalog_json = ${tomlString(catalogPath)}`);
-    lines.push("", "[features]", "fast_mode = true", "");
+    lines.push("", "[features]", `fast_mode = ${fastMode ? "true" : "false"}`, "");
     return lines.join("\n");
   }
   const lines = [
@@ -455,7 +462,7 @@ export function buildProfileFile(port: number, catalogPath?: string | null, supp
     'model_provider = "opencodex"',
   ];
   if (catalogPath) lines.push(`model_catalog_json = ${tomlString(catalogPath)}`);
-  lines.push("", "[features]", "fast_mode = true");
+  lines.push("", "[features]", `fast_mode = ${fastMode ? "true" : "false"}`);
   lines.push(buildProviderTableBlock(port, supportsWebsockets, includeApiAuthHeader, hostname).trimEnd(), "");
   return lines.join("\n");
 }
@@ -542,7 +549,7 @@ export async function injectCodexConfig(port: number, config?: OcxConfig, option
   content = stripExistingModelProvider(content);
   content = stripRootContextWindowOverrides(content);
   content = normalizeServiceTier(content);
-  content = ensureFastModeFeature(content);
+  content = ensureFastModeFeature(content, config?.fastMode);
 
   const catalogPath = chooseCatalogPathForInjection(content, options.catalogPath);
   content = catalogPath ? setRootModelCatalogPath(content, catalogPath) : stripOpencodexCatalogPath(content);
@@ -590,7 +597,7 @@ export async function injectCodexConfig(port: number, config?: OcxConfig, option
     managedDefaultsMessage = `  ⚠️ ${nativeSubagentDefaultsWarning}\n`;
   }
 
-  const profileContent = buildProfileFile(port, catalogPath, websocketsEnabled(config ?? {}), legacyMode, config?.hostname);
+  const profileContent = buildProfileFile(port, catalogPath, websocketsEnabled(config ?? {}), legacyMode, config?.hostname, config?.fastMode);
   content = applyEol(content, eol);
   atomicWriteFile(CODEX_CONFIG_PATH, content);
   atomicWriteFile(CODEX_PROFILE_PATH, profileContent);

--- a/src/codex/inject.ts
+++ b/src/codex/inject.ts
@@ -401,9 +401,12 @@ function ensureFastModeFeature(content: string, fastMode?: boolean): string {
   // Tri-state fast mode (see OcxConfig.fastMode): true forces `fast_mode = true`,
   // false forces `fast_mode = false`, and undefined leaves the user's config
   // untouched (no [features] table is added and an existing fast_mode line is
-  // preserved as-is).
+  // preserved as-is). Table and key matching accept the valid TOML spellings
+  // `[features] # comment`, `["features"]` / `['features']`, and quoted keys.
   const lines = content.split("\n");
-  const featuresStart = lines.findIndex(line => line.trim() === "[features]");
+  const featuresHeader = /^\s*\[(["']?)\s*features\s*\1\]\s*(?:#.*)?$/;
+  const fastModeKey = /^\s*(?:"fast_mode"|'fast_mode'|fast_mode)\s*=/;
+  const featuresStart = lines.findIndex(line => featuresHeader.test(line));
   if (featuresStart === -1) {
     if (fastMode === undefined) return content;
     return content.trimEnd() + "\n\n[features]\nfast_mode = " + (fastMode ? "true" : "false") + "\n";
@@ -412,9 +415,9 @@ function ensureFastModeFeature(content: string, fastMode?: boolean): string {
   const nextTable = lines.findIndex((line, index) => index > featuresStart && /^\s*\[/.test(line));
   const featuresEnd = nextTable === -1 ? lines.length : nextTable;
   for (let i = featuresStart + 1; i < featuresEnd; i++) {
-    if (/^\s*fast_mode\s*=/.test(lines[i])) {
+    if (fastModeKey.test(lines[i])) {
       if (fastMode === undefined) return lines.join("\n");
-      lines[i] = lines[i].replace(/^(\s*)fast_mode\s*=.*$/, `$1fast_mode = ${fastMode ? "true" : "false"}`);
+      lines[i] = lines[i].replace(/^(\s*)(?:"fast_mode"|'fast_mode'|fast_mode)\s*=.*$/, `$1fast_mode = ${fastMode ? "true" : "false"}`);
       return lines.join("\n");
     }
   }
@@ -440,7 +443,7 @@ function stripOpencodexCatalogPath(content: string): string {
     .join("\n");
 }
 
-export function buildProfileFile(port: number, catalogPath?: string | null, supportsWebsockets = false, includeApiAuthHeader = false, hostname?: string, fastMode = true): string {
+export function buildProfileFile(port: number, catalogPath?: string | null, supportsWebsockets = false, includeApiAuthHeader = false, hostname?: string, fastMode?: boolean): string {
   const host = providerBaseHost(hostname);
   // Design B (loopback): the reference/fallback file documents the root override form.
   // Non-loopback keeps the legacy provider-table shape (built-in provider cannot carry
@@ -453,7 +456,7 @@ export function buildProfileFile(port: number, catalogPath?: string | null, supp
       buildOpenaiBaseUrlLine(port, hostname),
     ];
     if (catalogPath) lines.push(`model_catalog_json = ${tomlString(catalogPath)}`);
-    lines.push("", "[features]", `fast_mode = ${fastMode ? "true" : "false"}`, "");
+    if (fastMode !== undefined) lines.push("", "[features]", `fast_mode = ${fastMode ? "true" : "false"}`, "");
     return lines.join("\n");
   }
   const lines = [
@@ -462,7 +465,7 @@ export function buildProfileFile(port: number, catalogPath?: string | null, supp
     'model_provider = "opencodex"',
   ];
   if (catalogPath) lines.push(`model_catalog_json = ${tomlString(catalogPath)}`);
-  lines.push("", "[features]", `fast_mode = ${fastMode ? "true" : "false"}`);
+  if (fastMode !== undefined) lines.push("", "[features]", `fast_mode = ${fastMode ? "true" : "false"}`);
   lines.push(buildProviderTableBlock(port, supportsWebsockets, includeApiAuthHeader, hostname).trimEnd(), "");
   return lines.join("\n");
 }

--- a/tests/codex-inject-integration.test.ts
+++ b/tests/codex-inject-integration.test.ts
@@ -100,6 +100,59 @@ describe("injectCodexConfig integration (Design B)", () => {
     expect(second).toBe(first);
   });
 
+  test("fastMode=false forces fast_mode=false in both config and profile", () => {
+    writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.5"\n', "utf8");
+
+    const r = runInject(codexHome, ocxHome, JSON.stringify({ fastMode: false }));
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout).success).toBe(true);
+
+    const config = readFileSync(join(codexHome, "config.toml"), "utf8");
+    expect(config).toContain("[features]");
+    expect(config).toContain("fast_mode = false");
+    expect(config).not.toContain("fast_mode = true");
+
+    const profile = readFileSync(join(codexHome, "opencodex.config.toml"), "utf8");
+    expect(profile).toContain("fast_mode = false");
+    expect(profile).not.toContain("fast_mode = true");
+  });
+
+  test("fastMode=true adds fast_mode=true to a config without a [features] table", () => {
+    writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.5"\n', "utf8");
+
+    const r = runInject(codexHome, ocxHome, JSON.stringify({ fastMode: true }));
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout).success).toBe(true);
+
+    const config = readFileSync(join(codexHome, "config.toml"), "utf8");
+    expect(config).toContain("[features]");
+    expect(config).toContain("fast_mode = true");
+  });
+
+  test("fastMode unset preserves the user's existing fast_mode setting", () => {
+    writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.5"\n\n[features]\nfast_mode = false\n', "utf8");
+
+    const r = runInject(codexHome, ocxHome);
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout).success).toBe(true);
+
+    const config = readFileSync(join(codexHome, "config.toml"), "utf8");
+    expect(config).toContain("fast_mode = false");
+    expect(config).not.toContain("fast_mode = true");
+  });
+
+  test("fastMode unset does not add a [features] table to a config that lacks one", () => {
+    writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.5"\n', "utf8");
+
+    const r = runInject(codexHome, ocxHome);
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout).success).toBe(true);
+
+    const config = readFileSync(join(codexHome, "config.toml"), "utf8");
+    expect(config).not.toContain("[features]");
+    expect(config).not.toContain("fast_mode");
+  });
+
   test("opt-in injects native subagent defaults, removes them when disabled, and restores the native config", () => {
     const original = [
       'model = "gpt-5.5"',

--- a/tests/codex-inject-integration.test.ts
+++ b/tests/codex-inject-integration.test.ts
@@ -127,6 +127,9 @@ describe("injectCodexConfig integration (Design B)", () => {
     const config = readFileSync(join(codexHome, "config.toml"), "utf8");
     expect(config).toContain("[features]");
     expect(config).toContain("fast_mode = true");
+
+    const profile = readFileSync(join(codexHome, "opencodex.config.toml"), "utf8");
+    expect(profile).toContain("fast_mode = true");
   });
 
   test("fastMode unset preserves the user's existing fast_mode setting", () => {
@@ -139,6 +142,9 @@ describe("injectCodexConfig integration (Design B)", () => {
     const config = readFileSync(join(codexHome, "config.toml"), "utf8");
     expect(config).toContain("fast_mode = false");
     expect(config).not.toContain("fast_mode = true");
+
+    const profile = readFileSync(join(codexHome, "opencodex.config.toml"), "utf8");
+    expect(profile).not.toContain("fast_mode");
   });
 
   test("fastMode unset does not add a [features] table to a config that lacks one", () => {
@@ -151,6 +157,66 @@ describe("injectCodexConfig integration (Design B)", () => {
     const config = readFileSync(join(codexHome, "config.toml"), "utf8");
     expect(config).not.toContain("[features]");
     expect(config).not.toContain("fast_mode");
+
+    const profile = readFileSync(join(codexHome, "opencodex.config.toml"), "utf8");
+    expect(profile).not.toContain("fast_mode");
+  });
+
+  test("fastMode=false updates a commented [features] header without duplicating the table", () => {
+    writeFileSync(join(codexHome, "config.toml"), [
+      'model = "gpt-5.5"',
+      "",
+      "[features] # user comment",
+      "fast_mode = true",
+      "",
+    ].join("\n"), "utf8");
+
+    const r = runInject(codexHome, ocxHome, JSON.stringify({ fastMode: false }));
+    expect(r.status).toBe(0);
+
+    const config = readFileSync(join(codexHome, "config.toml"), "utf8");
+    expect(config).toContain("fast_mode = false");
+    expect(config).not.toContain("fast_mode = true");
+    expect(() => Bun.TOML.parse(config)).not.toThrow();
+    expect(Bun.TOML.parse(config).features.fast_mode).toBe(false);
+  });
+
+  test("fastMode=false updates a quoted [\"features\"] header without duplicating the table", () => {
+    writeFileSync(join(codexHome, "config.toml"), [
+      'model = "gpt-5.5"',
+      "",
+      '["features"]',
+      "fast_mode = true",
+      "",
+    ].join("\n"), "utf8");
+
+    const r = runInject(codexHome, ocxHome, JSON.stringify({ fastMode: false }));
+    expect(r.status).toBe(0);
+
+    const config = readFileSync(join(codexHome, "config.toml"), "utf8");
+    expect(config).toContain("fast_mode = false");
+    expect(config).not.toContain("fast_mode = true");
+    expect(() => Bun.TOML.parse(config)).not.toThrow();
+    expect(Bun.TOML.parse(config).features.fast_mode).toBe(false);
+  });
+
+  test("fastMode=false updates a quoted \"fast_mode\" key", () => {
+    writeFileSync(join(codexHome, "config.toml"), [
+      'model = "gpt-5.5"',
+      "",
+      "[features]",
+      '"fast_mode" = true',
+      "",
+    ].join("\n"), "utf8");
+
+    const r = runInject(codexHome, ocxHome, JSON.stringify({ fastMode: false }));
+    expect(r.status).toBe(0);
+
+    const config = readFileSync(join(codexHome, "config.toml"), "utf8");
+    expect(config).toContain("fast_mode = false");
+    expect(config).not.toContain("fast_mode = true");
+    expect(() => Bun.TOML.parse(config)).not.toThrow();
+    expect(Bun.TOML.parse(config).features.fast_mode).toBe(false);
   });
 
   test("opt-in injects native subagent defaults, removes them when disabled, and restores the native config", () => {

--- a/tests/codex-inject.test.ts
+++ b/tests/codex-inject.test.ts
@@ -139,7 +139,18 @@ describe("Codex config injection", () => {
     expect(profile).not.toContain('model_provider = "opencodex"');
     expect(profile).not.toContain("[model_providers.opencodex]");
     expect(profile).not.toContain("model_catalog_json");
-    expect(profile).toContain("fast_mode = true");
+  });
+
+  test("fallback profile does not force fast_mode when fastMode is unset", () => {
+    expect(buildProfileFile(10100, null)).not.toContain("fast_mode");
+    expect(buildProfileFile(10100, null, false, true, "192.168.1.20")).not.toContain("fast_mode");
+  });
+
+  test("fallback profile mirrors an explicit fastMode=true override", () => {
+    const loopback = buildProfileFile(10100, null, false, false, undefined, true);
+
+    expect(loopback).toContain("fast_mode = true");
+    expect(loopback).not.toContain("fast_mode = false");
   });
 
   test("fallback profile mirrors an explicit fastMode=false override", () => {

--- a/tests/codex-inject.test.ts
+++ b/tests/codex-inject.test.ts
@@ -142,6 +142,17 @@ describe("Codex config injection", () => {
     expect(profile).toContain("fast_mode = true");
   });
 
+  test("fallback profile mirrors an explicit fastMode=false override", () => {
+    const loopback = buildProfileFile(10100, null, false, false, undefined, false);
+
+    expect(loopback).toContain("fast_mode = false");
+    expect(loopback).not.toContain("fast_mode = true");
+
+    const legacy = buildProfileFile(10100, null, false, true, "192.168.1.20", false);
+    expect(legacy).toContain("fast_mode = false");
+    expect(legacy).not.toContain("fast_mode = true");
+  });
+
   test("non-loopback fallback profile keeps the legacy provider-table shape with the injected host", () => {
     const profile = buildProfileFile(10100, null, false, true, "192.168.1.20");
 


### PR DESCRIPTION
## Summary

`injectCodexConfig()` unconditionally forced `[features] fast_mode = true` into `~/.codex/config.toml` on every `ocx init` / `ocx start` / `ocx sync`, even when the user's `fastMode` setting said otherwise. This made the client-side injection contradict the wire path (which already honors the tri-state `fastMode`: `true` injects `service_tier: priority`, `false` strips it, unset is passthrough).

The injection now follows the same tri-state semantics:

- `fastMode: true` → writes `fast_mode = true` (unchanged behavior)
- `fastMode: false` → writes `fast_mode = false`, consistent with the wire strip
- `fastMode` unset → preserves the user's existing `fast_mode` and no longer creates a `[features]` table in configs that never had one (fast becomes opt-in)

The fallback profile (`opencodex.config.toml`) mirrors the flag, and omits `fast_mode` entirely when unset.

## Verification

- `bun run typecheck` — clean
- `bun test --isolate tests/codex-inject.test.ts tests/codex-inject-integration.test.ts tests/service-tier-capability.test.ts tests/codex-v2-gate.test.ts` — 143 pass, 0 fail
- New unit + integration regression tests cover all three states (`fastMode` true / false / unset), including configs with and without an existing `[features]` table.

Note: the full local suite has unrelated environment-dependent failures in this workspace (server port binding under the sandbox, load flakes); the touched files and all injection tests pass.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (integration guide, all five locales).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Closes #1021


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Codex fast mode now supports explicitly enabled, disabled, or unset states.
  * Unset fast mode preserves existing settings and avoids creating unnecessary configuration sections.
  * Explicit settings are consistently applied across generated profiles.
  * Existing quoted or commented configuration formats are handled without creating duplicate settings.

* **Documentation**
  * Updated Codex integration guidance in English, Japanese, Korean, Russian, and Simplified Chinese.

* **Tests**
  * Added coverage for enabled, disabled, unset, and fallback profile scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->