### PR TITLE
fix(cli): flush the login authorization URL synchronously under non-TTY stdout (#1007)

### DIFF
--- a/src/cli/account-auth.ts
+++ b/src/cli/account-auth.ts
@@ -11,6 +11,23 @@ import {
   type CliStdin,
   type RuntimeApiDeps,
 } from "./runtime-api";
+import { writeSync } from "node:fs";
+
+/**
+ * Write the whole block to fd 1 synchronously (#1007). `console.log` can
+ * buffer behind a pipe, which hid the authorization URL for the entire
+ * polling window under non-TTY stdout. A partial write loops; a zero-byte
+ * write is a hard failure, never silent progress.
+ */
+function writeStdoutFully(text: string): void {
+  const bytes = Buffer.from(text, "utf8");
+  let offset = 0;
+  while (offset < bytes.length) {
+    const written = writeSync(1, bytes, offset, bytes.length - offset);
+    if (written <= 0) throw new CliUsageError("failed to write login instructions to stdout");
+    offset += written;
+  }
+}
 
 const USAGE = `Usage:
   ocx account login <provider> [--id <account-id>] [--reauth] [--code -] [--no-wait] [--json]
@@ -82,9 +99,14 @@ async function login(argv: string[], deps: RuntimeApiDeps): Promise<void> {
       body: JSON.stringify({ ...(id ? { id } : {}), ...(reauth ? { reauth: true } : {}) }),
     }, deps);
     if (!wantsJson) {
-      if (start.url) console.log(`Open this URL to sign in:\n${start.url}`);
-      if (start.instructions) console.log(start.instructions);
-      if (start.flowId) console.log(`Flow: ${start.flowId}`);
+      // One atomic pre-poll block, flushed synchronously so a piped parent
+      // reads the URL before the polling window starts (#1007).
+      const block = [
+        start.url ? `Open this URL to sign in:\n${start.url}` : "",
+        start.instructions ?? "",
+        start.flowId ? `Flow: ${start.flowId}` : "",
+      ].filter(line => line !== "").join("\n");
+      if (block) writeStdoutFully(`${block}\n`);
     }
     if (code && start.flowId) {
       await runtimeRequest("/api/codex-auth/login/code", {
@@ -120,9 +142,12 @@ async function login(argv: string[], deps: RuntimeApiDeps): Promise<void> {
     body: JSON.stringify({ provider, addAccount: !reauth, ...(reauth && id ? { accountId: id, reauth: true } : {}) }),
   }, deps);
   if (!wantsJson) {
-    if (start.url) console.log(`Open this URL to sign in:\n${start.url}`);
-    if (start.instructions) console.log(start.instructions);
-    if (start.deviceCode) console.log(`Device code: ${start.deviceCode}`);
+    const block = [
+      start.url ? `Open this URL to sign in:\n${start.url}` : "",
+      start.instructions ?? "",
+      start.deviceCode ? `Device code: ${start.deviceCode}` : "",
+    ].filter(line => line !== "").join("\n");
+    if (block) writeStdoutFully(`${block}\n`);
   }
   if (code) {
     await runtimeRequest("/api/oauth/login/code", {

--- a/tests/cli-account.test.ts
+++ b/tests/cli-account.test.ts
@@ -303,6 +303,37 @@ function stdinFrom(value: string, isTTY = false): AccountStdin {
   return input;
 }
 
+test("the login URL reaches piped stdout before the polling window (#1007)", async () => {
+  const child = Bun.spawn({
+    cmd: [process.execPath, "run", new URL("./helpers/account-login-pipe-child.ts", import.meta.url).pathname],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  try {
+    // Read incrementally with a sub-second deadline: the URL block must
+    // arrive while the child is still polling (still authenticating).
+    const reader = child.stdout.getReader();
+    const deadline = AbortSignal.timeout(5_000);
+    let received = "";
+    while (!received.includes("auth.example/authorize")) {
+      const { value, done } = await Promise.race([
+        reader.read(),
+        Bun.sleep(5_000).then(() => ({ value: undefined, done: true }) as const),
+      ]);
+      if (done) break;
+      if (value) received += new TextDecoder().decode(value);
+    }
+    expect(received).toContain("https://auth.example/authorize?flow=pipe-test");
+    expect(received).toContain("Flow: flow-pipe");
+    // The child is STILL authenticating (the whole point of the flush).
+    expect(child.exitCode).toBeNull();
+    void deadline;
+  } finally {
+    child.kill();
+    await child.exited.catch(() => {});
+  }
+}, 15_000);
+
 async function run(args: string[], deps: AccountDeps = defaultDeps()): Promise<CommandResult> {
   logs.length = 0;
   errors.length = 0;

--- a/tests/helpers/account-login-pipe-child.ts
+++ b/tests/helpers/account-login-pipe-child.ts
@@ -1,0 +1,35 @@
+/**
+ * Pipe-regression child for #1007: runs the REAL account login handler
+ * against a mock management API whose login-status never resolves, so the
+ * parent can prove the authorization URL reaches a piped stdout while the
+ * child is still polling.
+ */
+import { cmdAccount, type AccountDeps } from "../../src/cli/account";
+
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port: 0,
+  async fetch(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+    if (req.method === "POST" && url.pathname === "/api/codex-auth/login") {
+      return Response.json({
+        url: "https://auth.example/authorize?flow=pipe-test",
+        instructions: "Finish sign-in in your browser.",
+        flowId: "flow-pipe",
+      });
+    }
+    if (url.pathname === "/api/codex-auth/login-status") {
+      // Never resolves: the child keeps polling for the whole window.
+      return Response.json({ status: "pending" });
+    }
+    return Response.json({ error: "unhandled" }, 404);
+  },
+});
+
+const deps: AccountDeps = {
+  baseUrl: `http://127.0.0.1:${server.port}`,
+  loadConfigImpl: () => ({ providers: {} }) as ReturnType<NonNullable<AccountDeps["loadConfigImpl"]>>,
+};
+
+await cmdAccount(["login", "openai"], deps);
+server.stop(true);


### PR DESCRIPTION
Bug-stack campaign lane (`devlog/_plan/260805_bug_stack_campaign/080`). Fixes #1007.

`console.log` can buffer behind a pipe, hiding the authorization URL for the entire polling window. The pre-poll block (URL + instructions + flow id) now goes out as one atomic synchronous fd-1 write with partial-write looping and zero-progress failure.

- Pipe-based regression: a spawned child running the real handler against a never-resolving status mock proves the URL is readable while the child is still authenticating. `--json` mode untouched; TTY ordering preserved.
- `bun run typecheck` 0 errors; `bun run privacy:scan` pass; tests/cli-account 64/64; full suite on ssh lidge 8314/0 (campaign tree).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account login output when running in piped or redirected terminals.
  * Login URLs, instructions, and flow identifiers now appear together before authentication polling begins.
  * Prevented incomplete or missing login information caused by partial output writes.

* **Tests**
  * Added coverage verifying login details are emitted correctly while authentication remains in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->