### PR TITLE
fix(web-search): reject malformed forced-answer passes and silent completions (#1001)

### DIFF
--- a/src/web-search/loop.ts
+++ b/src/web-search/loop.ts
@@ -63,40 +63,68 @@ export function scanEventsForWebSearch(events: AdapterEvent[]): {
   calls: WebSearchCall[];
   passthrough: AdapterEvent[];
   hasRealToolCall: boolean;
+  hasMalformedToolCall: boolean;
 } {
   const calls: WebSearchCall[] = [];
   const passthrough: AdapterEvent[] = [];
   let hasRealToolCall = false;
-  let pending: { name: string; id: string; argsBuf: string; events: AdapterEvent[] } | null = null;
+  let hasMalformedToolCall = false;
+  let pending: { name: string; id: string; argsBuf: string; closed: boolean; events: AdapterEvent[] } | null = null;
+  const isBlank = (value: string): boolean => value.trim().length === 0;
   const flushPending = (): void => {
+    // A pending call that never saw tool_call_end is structurally malformed.
+    if (pending && !pending.closed) hasMalformedToolCall = true;
     if (pending && pending.name !== WEB_SEARCH_TOOL_NAME) {
       passthrough.push(...pending.events);
-      hasRealToolCall = true;
+      if (pending.closed && !isBlank(pending.id) && !isBlank(pending.name)) hasRealToolCall = true;
     }
     pending = null;
   };
   for (const e of events) {
     if (e.type === "tool_call_start") {
       flushPending();
-      pending = { name: e.name, id: e.id, argsBuf: "", events: [e] };
-    } else if (e.type === "tool_call_delta" && pending) {
-      pending.argsBuf += e.arguments;
-      pending.events.push(e);
-    } else if (e.type === "tool_call_end" && pending) {
-      pending.events.push(e);
-      if (pending.name === WEB_SEARCH_TOOL_NAME) {
-        calls.push({ id: pending.id, queries: parseQueries(pending.argsBuf) });
-      } else {
-        passthrough.push(...pending.events);
-        hasRealToolCall = true;
+      if (isBlank(e.id) || isBlank(e.name)) hasMalformedToolCall = true;
+      pending = { name: e.name, id: e.id, argsBuf: "", closed: false, events: [e] };
+    } else if (e.type === "tool_call_delta") {
+      // Orphan delta (no open call) is malformed.
+      if (!pending) hasMalformedToolCall = true;
+      else {
+        pending.argsBuf += e.arguments;
+        pending.events.push(e);
       }
-      pending = null;
+    } else if (e.type === "tool_call_end") {
+      // Orphan end (no open call) is malformed.
+      if (!pending) {
+        hasMalformedToolCall = true;
+      } else {
+        pending.events.push(e);
+        pending.closed = true;
+        if (pending.name === WEB_SEARCH_TOOL_NAME) {
+          calls.push({ id: pending.id, queries: parseQueries(pending.argsBuf) });
+        } else {
+          passthrough.push(...pending.events);
+          if (!isBlank(pending.id) && !isBlank(pending.name)) hasRealToolCall = true;
+        }
+        pending = null;
+      }
     } else {
       passthrough.push(e);
     }
   }
   flushPending();
-  return { calls, passthrough, hasRealToolCall };
+  return { calls, passthrough, hasRealToolCall, hasMalformedToolCall };
+}
+
+/**
+ * Visible final-answer text: a non-whitespace text_delta that is NOT commentary
+ * (#1001). Commentary streams early for progress and must not satisfy the
+ * forced-answer output check; thinking alone never counts either.
+ */
+export function hasVisibleAssistantText(events: AdapterEvent[]): boolean {
+  return events.some(event =>
+    event.type === "text_delta"
+    && event.phase !== "commentary"
+    && event.text.trim().length > 0);
 }
 
 async function* replay(events: AdapterEvent[]): AsyncGenerator<AdapterEvent> {
@@ -693,6 +721,18 @@ export async function runWithWebSearch(deps: WebSearchLoopDeps): Promise<Respons
           // calls reach Codex. forceAnswer also finalizes.
           const shouldLoop = split.calls.length > 0 && !split.hasRealToolCall && !forceAnswer;
           if (!shouldLoop) {
+            // #1001: a forced-answer pass that ends `done` must have produced
+            // usable output — never a malformed tool call, and never silence.
+            if (forceAnswer) {
+              // An unterminated call flushes AFTER the terminal event, so find
+              // the terminal rather than assuming it is last (#1001).
+              const terminalEvent = split.passthrough.find(event => event.type === "done");
+              if (terminalEvent?.type === "done"
+                && (split.hasMalformedToolCall
+                  || (!split.hasRealToolCall && !hasVisibleAssistantText(split.passthrough)))) {
+                throw new LoopError(502, "forced-answer pass produced no usable assistant output");
+              }
+            }
             if (executedSearchCount > 0) {
               const failedCount = failedQueries.size;
               console.warn(

--- a/tests/web-search.test.ts
+++ b/tests/web-search.test.ts
@@ -24,6 +24,100 @@ function runWithWebSearch(
   });
 }
 
+describe("issue #1001 — forced-answer passes must produce usable output", () => {
+  const webSearchFirstPass: AdapterEvent[] = [
+    { type: "tool_call_start", id: "ws1", name: "web_search" },
+    { type: "tool_call_delta", arguments: "{\"q\":\"docs\"}" },
+    { type: "tool_call_end" },
+    { type: "done" },
+  ];
+
+  function twoPassAdapter(secondPass: AdapterEvent[]): ProviderAdapter {
+    let pass = 0;
+    return {
+      name: "two-pass",
+      buildRequest: () => ({ url: "https://routed.test/v1", method: "POST", headers: {}, body: "{}" }),
+      fetchResponse: async () => new Response("wire", { status: 200 }),
+      async *parseStream() {
+        const events = pass++ === 0 ? webSearchFirstPass : secondPass;
+        for (const event of events) yield event;
+      },
+      async parseResponse() {
+        throw new Error("parseResponse must be unreachable");
+      },
+    };
+  }
+
+  async function drive(secondPass: AdapterEvent[]) {
+    const response = await runWithWebSearch({
+      parsed: parseRequest({ model: "routed/model", input: "hi", stream: true, tools: [{ type: "web_search" }] }),
+      adapter: twoPassAdapter(secondPass),
+      forwardProvider,
+      hostedTool: { type: "web_search" },
+      selectedForwardHeaders: new Headers({ authorization: "Bearer token" }),
+      settings: { model: "gpt-5.6-luna", reasoning: "low", timeoutMs: 30_000 },
+      maxSearches: 1,
+    });
+    return collectSse(response.body!);
+  }
+
+  test("a malformed forced-answer tool call (blank id/name) becomes response.failed, never completed", async () => {
+    const frames = await drive([
+      { type: "tool_call_start", id: "", name: "" },
+      { type: "tool_call_delta", arguments: "{\"x\":1}" },
+      { type: "tool_call_end" },
+      { type: "done" },
+    ]);
+    expect(frames.some(frame => frame.event === "response.failed")).toBe(true);
+    expect(frames.some(frame => frame.event === "response.completed")).toBe(false);
+  });
+
+  test("an unterminated tool call on the forced pass is malformed", async () => {
+    const frames = await drive([
+      { type: "tool_call_start", id: "c1", name: "shell" },
+      { type: "tool_call_delta", arguments: "{\"cmd\":\"ls\"" },
+      { type: "done" },
+    ]);
+    expect(frames.some(frame => frame.event === "response.failed")).toBe(true);
+    expect(frames.some(frame => frame.event === "response.completed")).toBe(false);
+  });
+
+  test("a forced pass with no text and no tool call becomes response.failed", async () => {
+    const frames = await drive([{ type: "done" }]);
+    expect(frames.some(frame => frame.event === "response.failed")).toBe(true);
+    expect(frames.some(frame => frame.event === "response.completed")).toBe(false);
+  });
+
+  test("commentary-only output does not satisfy the forced pass", async () => {
+    const frames = await drive([
+      { type: "text_delta", text: "thinking out loud", phase: "commentary" },
+      { type: "done" },
+    ]);
+    expect(frames.some(frame => frame.event === "response.failed")).toBe(true);
+    expect(frames.some(frame => frame.event === "response.completed")).toBe(false);
+  });
+
+  test("visible text on the forced pass completes normally", async () => {
+    const frames = await drive([
+      { type: "text_delta", text: "final answer" },
+      { type: "done" },
+    ]);
+    expect(frames.some(frame => frame.event === "response.completed")).toBe(true);
+    expect(frames.some(frame => frame.event === "response.failed")).toBe(false);
+  });
+
+  test("a valid closed non-web tool call without text is allowed to complete", async () => {
+    const frames = await drive([
+      { type: "tool_call_start", id: "call_1", name: "shell" },
+      { type: "tool_call_delta", arguments: "{\"cmd\":\"ls\"}" },
+      { type: "tool_call_end" },
+      { type: "done" },
+    ]);
+    expect(frames.some(frame => frame.event === "response.completed")).toBe(true);
+    expect(frames.some(frame => frame.event === "response.failed")).toBe(false);
+  });
+});
+
 const routedProvider: OcxProviderConfig = {
   adapter: "openai-chat",
   baseUrl: "https://example.test/v1",


### PR DESCRIPTION
Bug-stack campaign lane (`devlog/_plan/260805_bug_stack_campaign/090`). Fixes #1001.

The scanner judged any non-web_search name — including a blank one — a real tool call, and a forced-answer pass could complete with no assistant message at all.

- Structural validity: blank id/name, orphan delta/end, unterminated calls are malformed; `hasRealToolCall` only counts structurally complete non-web calls with nonblank identity (arguments stay bridge-owned — freeform tools unaffected).
- A forced-answer pass ending `done` with any malformed call, or with neither visible non-commentary text nor a valid real call, becomes an in-stream `response.failed` instead of a silent completion. `incomplete` semantics unchanged; no retry (explicit failure is bounded and allowed by the issue).
- tests/web-search 49/49 incl. the deterministic two-pass regression; `bun run typecheck` 0 errors; `bun run privacy:scan` pass; full suite on ssh lidge 8314/0 (campaign tree).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete or malformed web-search tool calls.
  * Prevented forced-answer responses from completing when tool calls are invalid or no usable assistant response is available.
  * Preserved successful completion for valid tool calls and visible answer content.

* **Tests**
  * Added regression coverage for malformed, incomplete, and valid forced-answer scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->