### PR TITLE
fix(cli): emit login start URL before polling under non-TTY

### DIFF
--- a/src/cli/account-api.ts
+++ b/src/cli/account-api.ts
@@ -46,6 +46,8 @@ export interface AccountDeps {
   loadConfigImpl?: () => OcxConfig;
   stdinImpl?: AccountStdin;
   stdinTimeoutMs?: number;
+  /** Test injection for synchronous stdout writes (login start URL). */
+  stdoutImpl?: (chunk: string) => void;
   /** Test/platform injection for the official Codex login in a restricted staging home. */
   spawnCodexLoginImpl?: (codexHome: string) => NativeMainLoginChild;
   /** Legacy test seam. Production always uses the spawned child handle above. */

--- a/src/cli/account-auth.ts
+++ b/src/cli/account-auth.ts
@@ -1,3 +1,4 @@
+import { writeSync } from "node:fs";
 import {
   CliUsageError,
   printData,
@@ -31,6 +32,30 @@ interface LoginStart {
   flowId?: string;
   instructions?: string;
   deviceCode?: string;
+}
+
+/** Synchronous fallback for `stdoutImpl`; reaches a pipe immediately. */
+function writeSyncStdout(chunk: string): void {
+  writeSync(1, chunk);
+}
+
+/**
+ * Announce the login start before the polling loop holds the process open.
+ *
+ * `console.log` to a non-TTY stdout can stay buffered for minutes on some
+ * platforms, so `ocx account login` piped or redirected to a file appeared to
+ * hang instead of showing the authorization URL (issue #1007). Writing fd 1
+ * synchronously delivers the URL to the user before the first poll.
+ */
+function printLoginStart(start: LoginStart, deps: RuntimeApiDeps): void {
+  const lines: string[] = [];
+  if (start.url) lines.push(`Open this URL to sign in:\n${start.url}`);
+  if (start.instructions) lines.push(start.instructions);
+  if (start.flowId) lines.push(`Flow: ${start.flowId}`);
+  if (start.deviceCode) lines.push(`Device code: ${start.deviceCode}`);
+  if (lines.length === 0) return;
+  const write = deps.stdoutImpl ?? writeSyncStdout;
+  write(`${lines.join("\n")}\n`);
 }
 
 /** `-` means "read it from stdin", the documented way to pass a code silently. */
@@ -81,11 +106,7 @@ async function login(argv: string[], deps: RuntimeApiDeps): Promise<void> {
       method: "POST",
       body: JSON.stringify({ ...(id ? { id } : {}), ...(reauth ? { reauth: true } : {}) }),
     }, deps);
-    if (!wantsJson) {
-      if (start.url) console.log(`Open this URL to sign in:\n${start.url}`);
-      if (start.instructions) console.log(start.instructions);
-      if (start.flowId) console.log(`Flow: ${start.flowId}`);
-    }
+    if (!wantsJson) printLoginStart(start, deps);
     if (code && start.flowId) {
       await runtimeRequest("/api/codex-auth/login/code", {
         method: "POST",
@@ -119,11 +140,7 @@ async function login(argv: string[], deps: RuntimeApiDeps): Promise<void> {
     method: "POST",
     body: JSON.stringify({ provider, addAccount: !reauth, ...(reauth && id ? { accountId: id, reauth: true } : {}) }),
   }, deps);
-  if (!wantsJson) {
-    if (start.url) console.log(`Open this URL to sign in:\n${start.url}`);
-    if (start.instructions) console.log(start.instructions);
-    if (start.deviceCode) console.log(`Device code: ${start.deviceCode}`);
-  }
+  if (!wantsJson) printLoginStart(start, deps);
   if (code) {
     await runtimeRequest("/api/oauth/login/code", {
       method: "POST",

--- a/src/cli/runtime-api.ts
+++ b/src/cli/runtime-api.ts
@@ -20,6 +20,11 @@ export interface RuntimeApiDeps {
   /** Test injection for commands that read a secret from stdin instead of argv. */
   stdinImpl?: CliStdin;
   stdinTimeoutMs?: number;
+  /**
+   * Test injection for output that must reach the user before a long-running
+   * command holds the process open (for example, the login start URL).
+   */
+  stdoutImpl?: (chunk: string) => void;
 }
 
 export class CliUsageError extends Error {

--- a/tests/cli-account.test.ts
+++ b/tests/cli-account.test.ts
@@ -44,6 +44,7 @@ let codexAccounts: Array<Record<string, unknown>> = [];
 let oauthAccounts: Array<Record<string, unknown>> = [];
 let oauthActiveId: string | null = "acct_1";
 let oauthLoginStatus: Record<string, unknown> = { loggedIn: false };
+let codexLoginStatus: Record<string, unknown> = { status: "pending" };
 let keyEntries: Array<Record<string, unknown>> = [];
 let keyActiveId: string | null = "key_1";
 let logs: string[] = [];
@@ -290,6 +291,10 @@ async function mockManagementApi(req: Request): Promise<Response> {
     return json(oauthLoginStatus);
   }
 
+  if (req.method === "GET" && url.pathname === "/api/codex-auth/login-status") {
+    return json(codexLoginStatus);
+  }
+
   return json({ error: `unhandled mock endpoint: ${req.method} ${url.pathname}` }, 404);
 }
 
@@ -354,6 +359,7 @@ beforeEach(() => {
   ];
   oauthActiveId = "acct_1";
   oauthLoginStatus = { loggedIn: false };
+  codexLoginStatus = { status: "pending" };
   keyEntries = [{
     id: "key_1",
     label: "personal",
@@ -1279,6 +1285,58 @@ describe("ocx account CLI (issue #180 matrix)", () => {
       expect(requests.some(request => request.path === "/api/oauth/login/code")).toBe(false);
     });
 
+  });
+
+  describe("login announces the start URL before polling (issue #1007)", () => {
+    test("OAuth login writes the URL synchronously even when stdout is not a TTY", async () => {
+      oauthLoginStatus = { loggedIn: false };
+      const chunks: string[] = [];
+      let seenBeforeFirstPoll = false;
+      let polls = 0;
+      const sleepSpy = spyOn(Bun, "sleep").mockImplementation(async () => {
+        polls += 1;
+        if (polls === 1) seenBeforeFirstPoll = chunks.join("").includes("https://auth.example/authorize");
+      });
+      try {
+        const result = await run(
+          ["login", "anthropic"],
+          { ...defaultDeps(), stdoutImpl: (chunk: string) => chunks.push(chunk) },
+        );
+
+        expect(result.code).toBe(2);
+        expect(result.stderr).toContain("login timed out");
+        expect(seenBeforeFirstPoll).toBe(true);
+        expect(chunks.join("")).toContain("Open this URL to sign in:\nhttps://auth.example/authorize");
+        expect(chunks.join("")).toContain("Sign in, then paste the redirect URL.");
+      } finally {
+        sleepSpy.mockRestore();
+      }
+    });
+
+    test("Codex login writes the URL and flow id before the first poll", async () => {
+      codexLoginStatus = { status: "done", email: "j***@example.com" };
+      const chunks: string[] = [];
+      let seenBeforeFirstPoll = false;
+      let polls = 0;
+      const sleepSpy = spyOn(Bun, "sleep").mockImplementation(async () => {
+        polls += 1;
+        if (polls === 1) seenBeforeFirstPoll = chunks.join("").includes("https://auth.example/authorize");
+      });
+      try {
+        const result = await run(
+          ["login", "openai"],
+          { ...defaultDeps(), stdoutImpl: (chunk: string) => chunks.push(chunk) },
+        );
+
+        expect(result.code).toBe(0);
+        expect(result.stdout).toContain("Logged in as j***@example.com.");
+        expect(seenBeforeFirstPoll).toBe(true);
+        expect(chunks.join("")).toContain("Open this URL to sign in:\nhttps://auth.example/authorize");
+        expect(chunks.join("")).toContain("Flow: flow-mock");
+      } finally {
+        sleepSpy.mockRestore();
+      }
+    });
   });
 
   test("39: a login error wins over a retained OAuth credential", async () => {


### PR DESCRIPTION
## Summary

Fixes #1007.

`ocx account login` printed the authorization URL with `console.log`, which stays buffered when stdout is not a TTY (piped or redirected). Because the command then enters its polling loop, the URL did not reach the user until the process flushed, which made the manual redirect-URL flow look hung under non-TTY stdout.

The login-start announcement (URL, instructions, flow id / device code) is now written synchronously to stdout fd 1 before the first poll. Output text and `--json` behavior are unchanged. The writer is injectable (`stdoutImpl`), so the ordering is covered by an in-process regression test.

## Verification

- `bun test tests/cli-account.test.ts` — 65 pass, 0 fail; includes two new regression tests asserting the URL is emitted before the first poll for both OAuth and Codex logins.
- `bun run typecheck` — pass
- `bun run lint:gui` — pass
- `bun run privacy:scan` — pass
- `bun run doctor:gui:if-changed` — skip (no `gui/` changes)
- `bun run test` — 8202 pass / 6 skip / 16 fail on this machine. All 16 failures reproduce identically on unmodified `dev` HEAD (Windows `EBUSY` file-lock in the e2e isolated-home helper plus 5s timeouts while the machine was heavily loaded; the suite itself reported taking 2347s vs its normal ~210s), i.e. pre-existing environmental failures unrelated to this change.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No docs change needed: same output text and flags as before; this only fixes when the URL reaches the user.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (Output content is unchanged — the same URL/flow id/device code, just flushed earlier. No credential is written to stdout, and the `--json` path is unchanged.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Login instructions and authorization URLs now appear immediately, including when output is piped or redirected.
  * Improved Codex and OAuth login flows with clearer device-code and flow information.
  * Login status handling now behaves consistently during timeouts and successful authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->