### PR TITLE
fix(test): the 504 this test looked for was in a random id

### DIFF
--- a/tests/images/loop.test.ts
+++ b/tests/images/loop.test.ts
@@ -251,10 +251,27 @@ describe("runWithImageBridge", () => {
 
   test("retry wait longer than connectTimeoutMs restarts the header deadline (no 504)", async () => {
     let sends = 0;
+    const attemptSignals: (AbortSignal | undefined)[] = [];
+    const abortedAtFetch: boolean[] = [];
     const retryingAdapter: ProviderAdapter = {
       ...mockAdapter,
-      fetchResponse: async () => {
+      fetchResponse: async (_request, ctx) => {
         sends += 1;
+        // Captured AT FETCH TIME. Checking `aborted` later would observe the
+        // deadline expiring naturally after the body was consumed, which says
+        // nothing about whether the replay started with a live budget.
+        attemptSignals.push(ctx?.abortSignal);
+        abortedAtFetch.push(ctx?.abortSignal?.aborted ?? true);
+        /*
+         * Honor the deadline the bridge handed us.
+         *
+         * Without this the mock answers 200 no matter what, so the deadline
+         * could be left armed across the backoff and the test would still pass.
+         * That is not hypothetical: removing BOTH the pre-wait `clear()` and the
+         * post-wait re-arm in src/images/loop.ts left this test green, which
+         * means the regression it is named after was never actually guarded.
+         */
+        ctx?.abortSignal?.throwIfAborted();
         if (sends === 1) {
           return new Response(JSON.stringify({ error: { message: "rate limited" } }), {
             status: 429,
@@ -272,12 +289,41 @@ describe("runWithImageBridge", () => {
       connectTimeoutMs: 100,
       retryOn429Policy: { enabled: true, attempts: 1, intervalMs: 150, maxIntervalMs: 60_000, respectRetryAfter: false },
     });
+    /*
+     * Status first, and before the body is consumed. A header deadline that
+     * expires on the FIRST iteration is answered eagerly with an HTTP 504 and a
+     * JSON body — there is no SSE stream yet — so a stream-only assertion cannot
+     * see it.
+     */
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+
     const sse = await response.text();
     // The deliberate backoff must not consume the response-header deadline: a fresh deadline is
     // armed after the wait, so the replay gets a new connect budget instead of a 504.
     expect(sends).toBe(2);
     expect(sse).toContain("recovered");
-    expect(sse).not.toContain("504");
+    /*
+     * Terminal events, not a substring search for "504".
+     *
+     * The old assertion was `expect(sse).not.toContain("504")`, which searched
+     * the whole stream — including the random 32-hex response id. Roughly one id
+     * in 137 contains "504", so with two ids in a stream this reddened about 1
+     * run in 69 for no reason at all (measured: 1 failure in 37 local runs).
+     * It was also unable to detect a REAL 504, whose JSON body carries a timeout
+     * message rather than the number.
+     */
+    expect(sse).toContain("event: response.completed");
+    expect(sse).not.toContain("event: response.failed");
+    /*
+     * And the mechanism itself: the replay must get a NEW deadline, not the
+     * disarmed remains of the first one. Identity is the only way to see the
+     * difference, since a cleared deadline and a fresh deadline both fail to
+     * expire.
+     */
+    expect(attemptSignals).toHaveLength(2);
+    expect(attemptSignals[1]).not.toBe(attemptSignals[0]);
+    expect(abortedAtFetch).toEqual([false, false]);
   }, 5_000);
 
   test("retryOn429 budget is shared across iterations (per request, not per round)", async () => {


### PR DESCRIPTION
## The failure

`dev` CI went red on run [30967162304](https://github.com/lidge-jun/opencodex/actions/runs/30967162304) with a single failing test:

```
(fail) runWithImageBridge > retry wait longer than connectTimeoutMs restarts the header deadline (no 504)
error: expect(received).not.toContain(expected)
```

The assertion was `expect(sse).not.toContain("504")`, and the stream it rejected looked like this:

```
"id":"resp_612a6504e8ea4cf095d0f02d4f828c80"
             ^^^
```

That stream carried `recovered`, ended in `response.completed`, and contained no failure frame. The only `504` anywhere in it was three characters of a random identifier.

About one 32-hex id in 137 contains `504`, and a stream carries two of them, so this reddened roughly one run in 69 for no reason. Reproduced locally: **1 failure in 37 runs**, which matches.

## The larger half

The flake is not the interesting part. Removing the deadline re-arm that this test is *named after* left it green:

| Mutation in `src/images/loop.ts` | Old assertion | New assertion |
|---|---|---|
| drop the post-wait re-arm | passes | **fails** |
| drop the pre-wait `clear()` | passes | passes (see below) |
| drop both — the real cumulative-deadline regression | passes | **fails** |

Two reasons it could not work. The mock adapter ignored `ctx.abortSignal` and answered `200` no matter what the deadline said. And a genuine first-iteration timeout is answered eagerly with an HTTP 504 whose JSON body does not contain the number `504` at all — so even a real one would have slipped past a substring search.

So the regression this test exists to prevent was never actually guarded.

## The change

`tests/images/loop.test.ts` only. No production code.

- the mock now calls `ctx.abortSignal?.throwIfAborted()`, so the deadline means something
- `expect(response.status).toBe(200)` plus the content type, checked **before** the body is consumed, because an eager 504 never produces a stream to inspect
- terminal events by name (`event: response.completed` present, `event: response.failed` absent) instead of a substring hunt
- signal identity captured **at fetch time**, which is the only way to tell a fresh deadline from the disarmed remains of the old one — neither expires, so nothing else distinguishes them

`tests/web-search.test.ts` has a test of the same name proving the same thing, and it was already written this way. It passed in the same CI run.

## What is deliberately not claimed

Dropping only the pre-wait `clear()` still passes. That call guards a race between a stale expiry and the client-cancel path, which this test does not exercise. Saying it is covered would be the same kind of overclaim this PR is fixing, so it is left unclaimed and noted in the commit message.

## Verification

- remote Linux suite: **8412 pass / 0 fail / 10 skip** across 540 files
- `bun x tsc --noEmit`: clean
- the fixed test: **30 consecutive runs, 0 failures** (it fails about 1 in 37 before)
- mutation results in the table above, each restored to a clean tree afterwards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened coverage for connection retries and timeout handling.
  * Added validation that each retry receives a fresh, active timeout signal.
  * Improved checks for response status, streaming headers, terminal events, and successful retry completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->