### PR TITLE
docs(codex): the example contradicted the paragraph under it

### DIFF
--- a/docs-site/src/content/docs/guides/codex-integration.md
+++ b/docs-site/src/content/docs/guides/codex-integration.md
@@ -23,6 +23,7 @@ model_catalog_json = "/absolute/path/to/opencodex-catalog.json"
 # Auto-injected by opencodex
 openai_base_url = "http://127.0.0.1:10100/v1"
 
+# only when fastMode is set; unset adds no [features] table
 [features]
 fast_mode = true
 ```

--- a/docs-site/src/content/docs/ja/guides/codex-integration.md
+++ b/docs-site/src/content/docs/ja/guides/codex-integration.md
@@ -17,6 +17,7 @@ model_catalog_json = "/absolute/path/to/opencodex-catalog.json"
 # Auto-injected by opencodex
 openai_base_url = "http://127.0.0.1:10100/v1"
 
+# fastMode を設定した場合のみ。未設定なら [features] は作られません
 [features]
 fast_mode = true
 ```

--- a/docs-site/src/content/docs/ko/guides/codex-integration.md
+++ b/docs-site/src/content/docs/ko/guides/codex-integration.md
@@ -17,6 +17,7 @@ model_catalog_json = "/absolute/path/to/opencodex-catalog.json"
 # Auto-injected by opencodex
 openai_base_url = "http://127.0.0.1:10100/v1"
 
+# fastMode를 설정했을 때만 들어갑니다. 설정하지 않으면 [features] 자체가 생기지 않습니다
 [features]
 fast_mode = true
 ```

--- a/docs-site/src/content/docs/ru/guides/codex-integration.md
+++ b/docs-site/src/content/docs/ru/guides/codex-integration.md
@@ -24,6 +24,7 @@ model_catalog_json = "/absolute/path/to/opencodex-catalog.json"
 # Auto-injected by opencodex
 openai_base_url = "http://127.0.0.1:10100/v1"
 
+# только если fastMode задан; без него таблица [features] не создаётся
 [features]
 fast_mode = true
 ```

--- a/docs-site/src/content/docs/zh-cn/guides/codex-integration.md
+++ b/docs-site/src/content/docs/zh-cn/guides/codex-integration.md
@@ -23,6 +23,7 @@ model_catalog_json = "/absolute/path/to/opencodex-catalog.json"
 # Auto-injected by opencodex
 openai_base_url = "http://127.0.0.1:10100/v1"
 
+# 仅在设置了 fastMode 时写入；未设置则不会创建 [features] 表
 [features]
 fast_mode = true
 ```


### PR DESCRIPTION
## What

PR #1022 made `fast_mode` opt-in: unset now leaves the user's config alone and creates no `[features]` table. The guide says so — and two lines above it, the config example still shows that table unconditionally.

A reader following the example expects output they will not get.

## Change

One comment line above the block in each of the five locales, marking it conditional. No prose changes, no behavior claims altered.

```toml
# only when fastMode is set; unset adds no [features] table
[features]
fast_mode = true
```

Follow-up to #1022, found while verifying that PR against current `dev`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified in Codex integration guides that the `[features]` table and `fast_mode` setting are added only when `fastMode` is configured.
  * Documented that no `[features]` table is created when `fastMode` remains unset.
  * Updated the guidance across English, Japanese, Korean, Russian, and Simplified Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->