### PR TITLE
test(codex): add isolated pool failover canary

### DIFF
--- a/openspec/changes/harden-codex-pool-canary/.openspec.yaml
+++ b/openspec/changes/harden-codex-pool-canary/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/harden-codex-pool-canary/README.md
+++ b/openspec/changes/harden-codex-pool-canary/README.md
@@ -1,0 +1,3 @@
+# harden-codex-pool-canary
+
+Add an isolated regression canary for Codex account-pool failover and memory-safety boundaries.

--- a/openspec/changes/harden-codex-pool-canary/design.md
+++ b/openspec/changes/harden-codex-pool-canary/design.md
@@ -1,0 +1,27 @@
+## Context
+
+The existing persistent proxy on port 10123 has real shared account credentials and active requests. It is not a safe surface for deliberately provoking quota failures or changing account selection. Existing unit tests cover individual pool decisions but do not bind the Responses retry path, alternate credential selection, thread affinity, and state bounds in one disposable scenario.
+
+## Decision
+
+Adopt the existing Bun test runtime and Responses handler rather than starting a second long-lived proxy or using a real provider. The canary will create only synthetic account records in a test-owned temporary `OPENCODEX_HOME`, mock the outbound fetch boundary, and make a first pre-stream 429 response followed by a successful non-streaming Responses JSON response from an alternate synthetic account. A test-only start seam suppresses the otherwise fire-and-forget startup quota prime; synthetic fresh quota snapshots keep the request-path lazy prime dormant; and test cleanup awaits the server lifecycle drain before restoring the environment or removing temporary homes.
+
+The canary will assert:
+
+1. exactly one alternate-account retry occurs after the quota failure;
+2. a health request remains successful before and after the turn;
+3. the failing account is excluded from the continued thread route while the alternate account is retained;
+4. routing state reaches but does not exceed the documented affinity-entry bound, keeps a recent affinity sticky, and rebinds an evicted oldest thread after a selection change; and
+5. no bearer or credential reaches assertions, test output, or a public runtime endpoint.
+
+If the existing module lacks a safe way to observe the affinity count, add an explicitly test-only export in `src/codex/routing.ts`. Do not add an unbounded diagnostic endpoint or persist canary state.
+
+## Failure and rollback proof
+
+The first upstream response is a local synthetic 429. The required recovery proof is the alternate-account successful non-streaming Responses JSON response with the original service still health-checkable. All test state is created beneath the test fixture root and removed by test cleanup; no recovery action is needed for 10123 because it is not involved.
+
+## Non-goals
+
+- No use, copying, refresh, login, pause, or selection of the real Codex account pool.
+- No real provider traffic, quota consumption, service installation, restart, or port-10123 operation.
+- No change to production pool strategy or memory-watchdog thresholds.

--- a/openspec/changes/harden-codex-pool-canary/proposal.md
+++ b/openspec/changes/harden-codex-pool-canary/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The Codex account pool has component-level rotation and failure tests, but no one isolated canary proves that a real Responses turn can move from a synthetic quota-rejected account to an alternate account while preserving service availability and bounded account-affinity state. The live audit also showed that RSS alone is not enough to diagnose retained application state.
+
+## What Changes
+
+- Add a deterministic, local-only Codex pool canary covering a pre-stream quota rejection followed by one alternate-account success.
+- Add test-only routing-state observation needed to assert the documented thread-affinity bound without exposing account identifiers through a runtime API.
+- Exercise the canary under many synthetic thread ids and assert that the pool state remains bounded and the HTTP surface stays healthy.
+
+## Capabilities
+
+### New Capabilities
+
+- `codex-pool-canary-safety`: Deterministic isolated verification of Codex pool failover, continuity, and bounded affinity state.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- `src/codex/routing.ts` test-only state observation and `src/server/index.ts` test-only startup-prime suppression, if required by the canary.
+- A focused Bun regression test under `tests/`.
+- No provider configuration, credential-store format, management API, dashboard behavior, or production service changes.

--- a/openspec/changes/harden-codex-pool-canary/specs/codex-pool-canary-safety/spec.md
+++ b/openspec/changes/harden-codex-pool-canary/specs/codex-pool-canary-safety/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Isolated alternate-account recovery canary
+
+The repository SHALL provide a deterministic Bun test that uses only task-owned temporary state and a mocked outbound transport to exercise a Codex Pool Responses request whose first synthetic account receives a pre-stream quota failure and whose alternate synthetic account succeeds.
+
+#### Scenario: Quota rejection recovers through one alternate account
+
+- **WHEN** a synthetic Pool request receives a pre-stream 429 from its initially selected account
+- **THEN** the canary SHALL verify exactly one retry using a different synthetic account and a successful client-facing response
+
+#### Scenario: Canary does not require external credentials or traffic
+
+- **WHEN** the canary executes
+- **THEN** it SHALL not access real provider credentials, contact a non-localhost upstream, or modify a persistent OpenCodex or Codex home
+
+#### Scenario: Canary cleanup contains process-global work
+
+- **WHEN** the canary server exits
+- **THEN** the test SHALL await lifecycle shutdown and reset only test-owned watchdog, sweeper, startup-prime, and retained-memory state before restoring its environment or deleting temporary homes; it SHALL also keep the request-path lazy quota prime dormant
+
+### Requirement: Bounded Codex thread-affinity observation
+
+The Codex routing module SHALL expose a test-only affinity entry count so the isolated canary can assert the documented bound without serializing account identities or adding a runtime management endpoint.
+
+#### Scenario: Distinct synthetic threads remain bounded
+
+- **WHEN** the canary resolves more distinct synthetic thread ids than the affinity capacity
+- **THEN** the observed entry count SHALL equal `CODEX_THREAD_AFFINITY_MAX_ENTRIES`, a recent affinity SHALL remain sticky, and an evicted oldest thread SHALL be rebound after the active selection changes
+
+#### Scenario: Test observation contains no account identifiers
+
+- **WHEN** a test reads the affinity observation
+- **THEN** it SHALL receive only a numeric count and no thread id, account id, credential, or quota value

--- a/openspec/changes/harden-codex-pool-canary/tasks.md
+++ b/openspec/changes/harden-codex-pool-canary/tasks.md
@@ -1,0 +1,11 @@
+## 1. Isolated canary
+
+- [x] 1.1 Add a RED deterministic canary for synthetic 429-to-alternate-account recovery and bounded affinity state.
+- [x] 1.2 Add the minimum test-only affinity-count observation required by the canary.
+- [x] 1.3 Make the canary pass without changing persistent configuration or public runtime behavior.
+
+## 2. Verification
+
+- [x] 2.1 Run the focused pool, Responses, and memory-watchdog regressions plus typecheck and privacy scan.
+- [x] 2.2 Run the isolated canary as the real-surface success and failure proof; verify task-owned cleanup and that port 10123 remains untouched.
+- [x] 2.3 Perform the required High-risk independent change/domain review before any delivery claim.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/src/codex/routing.ts
+++ b/src/codex/routing.ts
@@ -836,6 +836,11 @@ function threadAffinityEntryCount(): number {
   return count;
 }
 
+/** Test-only bounded-state observation; never serializes routing identities. */
+export function getCodexThreadAffinityEntryCountForTests(): number {
+  return threadAffinityEntryCount();
+}
+
 function isThreadAffinityExpired(entry: ThreadAffinityEntry, now: number): boolean {
   return now - entry.lastUsedAt > CODEX_THREAD_AFFINITY_IDLE_TTL_MS;
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -349,6 +349,8 @@ function attachLiveSidebandUpstream(
 export interface StartServerDeps {
   /** Test-only seam; production always initializes its own management credential state. */
   managementAuthState?: ManagementAuthState;
+  /** Test-only seam; production always starts best-effort Codex Pool quota priming. */
+  suppressStartupCodexQuotaPrime?: boolean;
   /** Test-only route dependencies, forwarded only after management admission succeeds. */
   managementApi?: ManagementApiDeps;
   /** Test-only native-main recovery dependencies; production constructs the normal manager. */
@@ -1284,7 +1286,8 @@ export function startServer(port?: number, deps: StartServerDeps = {}) {
   // listener, and a blocked network silently no-ops (see Phase 30 diagnostics).
   const openAiProvider = config.providers.openai;
   if (
-    openAiProvider
+    !deps.suppressStartupCodexQuotaPrime
+    && openAiProvider
     && openAiProvider.disabled !== true
     && isCanonicalOpenAiForwardProvider(openAiProvider)
     && providerCodexAccountMode("openai", openAiProvider) === "pool"

--- a/tests/codex-pool-isolated-canary.test.ts
+++ b/tests/codex-pool-isolated-canary.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { saveConfig } from "../src/config";
+import {
+  clearCodexCooldownRecoveryProbeState,
+  clearCodexQuotaPrimeState,
+} from "../src/codex/auth-api";
+import { saveCodexAccountCredential } from "../src/codex/account-store";
+import { clearAccountQuota, setAccountQuotaFromParsed } from "../src/codex/quota";
+import {
+  CODEX_THREAD_AFFINITY_MAX_ENTRIES,
+  clearCodexUpstreamHealth,
+  clearThreadAccountMap,
+  getCodexThreadAffinityEntryCountForTests,
+  resolveCodexAccountForThread,
+} from "../src/codex/routing";
+import { resetAppOwnedMemoryForTests } from "../src/lib/app-owned-memory";
+import { resetStateStoreSweeperForTests } from "../src/lib/state-store-sweeper";
+import { startServer } from "../src/server";
+import { resetLifecycleDrainStateForTests, drainAndShutdown } from "../src/server/lifecycle";
+import { getActiveMemoryWatchdog } from "../src/server/memory-watchdog";
+import type { OcxConfig } from "../src/types";
+import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+
+const originalFetch = globalThis.fetch;
+let testDir = "";
+let previousOpenCodexHome: string | undefined;
+let isolatedCodexHome: IsolatedCodexHome | null = null;
+let canaryServer: ReturnType<typeof startServer> | null = null;
+
+function resetCanaryProcessState(): void {
+  getActiveMemoryWatchdog()?.stop();
+  resetStateStoreSweeperForTests();
+  resetAppOwnedMemoryForTests();
+  clearCodexQuotaPrimeState();
+  clearCodexCooldownRecoveryProbeState();
+  resetLifecycleDrainStateForTests();
+}
+
+beforeEach(() => {
+  resetCanaryProcessState();
+  previousOpenCodexHome = process.env.OPENCODEX_HOME;
+  isolatedCodexHome = installIsolatedCodexHome("ocx-pool-canary-codex-");
+  testDir = mkdtempSync(join(tmpdir(), "ocx-pool-canary-"));
+  process.env.OPENCODEX_HOME = testDir;
+  clearThreadAccountMap();
+  clearCodexUpstreamHealth();
+  clearAccountQuota();
+});
+
+afterEach(async () => {
+  try {
+    if (canaryServer) {
+      const server = canaryServer;
+      canaryServer = null;
+      await drainAndShutdown(server, 5_000);
+    }
+  } finally {
+    resetCanaryProcessState();
+    globalThis.fetch = originalFetch;
+    clearThreadAccountMap();
+    clearCodexUpstreamHealth();
+    clearAccountQuota();
+    rmSync(testDir, { recursive: true, force: true });
+    isolatedCodexHome?.restore();
+    isolatedCodexHome = null;
+    if (previousOpenCodexHome === undefined) delete process.env.OPENCODEX_HOME;
+    else process.env.OPENCODEX_HOME = previousOpenCodexHome;
+  }
+});
+
+function poolConfig(): OcxConfig {
+  return {
+    port: 0,
+    defaultProvider: "openai",
+    activeCodexAccountId: "pool-a",
+    autoSwitchThreshold: 80,
+    providers: {
+      openai: {
+        adapter: "openai-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        authMode: "forward",
+        codexAccountMode: "pool",
+        liveModels: false,
+      },
+    },
+    codexAccounts: [
+      { id: "pool-a", email: "pool-a@example.test", isMain: false, chatgptAccountId: "pool-a-chatgpt" },
+      { id: "pool-b", email: "pool-b@example.test", isMain: false, chatgptAccountId: "pool-b-chatgpt" },
+    ],
+  } as OcxConfig;
+}
+
+function installSyntheticCredential(id: "pool-a" | "pool-b"): void {
+  saveCodexAccountCredential(id, {
+    accessToken: `${id}-access-token`,
+    refreshToken: `${id}-refresh-token`,
+    expiresAt: Date.now() + 60 * 60_000,
+    chatgptAccountId: `${id}-chatgpt`,
+  });
+  // Keep the request-path lazy quota primer dormant: it is intentionally
+  // fire-and-forget in production and therefore cannot outlive this canary's
+  // isolated server lifecycle.
+  setAccountQuotaFromParsed(id, { weeklyPercent: 0 });
+}
+
+test("isolated Pool canary retries a pre-stream quota rejection without losing HTTP availability", async () => {
+  const config = poolConfig();
+  installSyntheticCredential("pool-a");
+  installSyntheticCredential("pool-b");
+  saveConfig(config);
+
+  const attemptedAccounts: Array<"pool-a" | "pool-b"> = [];
+  globalThis.fetch = (async (input, init) => {
+    const url = input instanceof Request ? input.url : String(input);
+    if (!url.includes("chatgpt.com/backend-api/codex")) {
+      return Response.json({ data: [] });
+    }
+    const authorization = new Headers(init?.headers).get("authorization");
+    const account = authorization === "Bearer pool-a-access-token"
+      ? "pool-a"
+      : authorization === "Bearer pool-b-access-token"
+        ? "pool-b"
+        : null;
+    if (!account) throw new Error("unexpected synthetic account");
+    attemptedAccounts.push(account);
+    if (account === "pool-a") {
+      return new Response("quota exhausted", { status: 429, headers: { "retry-after": "60" } });
+    }
+    return Response.json({
+      id: "resp_pool_canary",
+      object: "response",
+      status: "completed",
+      model: "gpt-5.6-sol",
+      output: [],
+      usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+    });
+  }) as typeof fetch;
+
+  canaryServer = startServer(0, { suppressStartupCodexQuotaPrime: true });
+  const before = await originalFetch(new URL("/healthz", canaryServer.url));
+  expect(before.status).toBe(200);
+
+  const response = await originalFetch(new URL("/v1/responses", canaryServer.url), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-codex-parent-thread-id": "pool-canary-thread",
+    },
+    body: JSON.stringify({ model: "gpt-5.6-sol", input: "synthetic canary", stream: false }),
+  });
+
+  expect(response.status).toBe(200);
+  expect(attemptedAccounts).toEqual(["pool-a", "pool-b"]);
+  expect(resolveCodexAccountForThread("pool-canary-thread", config)).toBe("pool-b");
+
+  const after = await originalFetch(new URL("/healthz", canaryServer.url));
+  expect(after.status).toBe(200);
+});
+
+test("isolated Pool canary bounds synthetic thread affinity without exposing identities", () => {
+  const config = poolConfig();
+  installSyntheticCredential("pool-a");
+  installSyntheticCredential("pool-b");
+
+  for (let index = 0; index < CODEX_THREAD_AFFINITY_MAX_ENTRIES + 128; index += 1) {
+    expect(resolveCodexAccountForThread(`pool-canary-${index}`, config)).toBe("pool-a");
+  }
+
+  expect(getCodexThreadAffinityEntryCountForTests()).toBe(CODEX_THREAD_AFFINITY_MAX_ENTRIES);
+
+  const switchedConfig = { ...config, activeCodexAccountId: "pool-b" };
+  expect(resolveCodexAccountForThread(
+    `pool-canary-${CODEX_THREAD_AFFINITY_MAX_ENTRIES + 127}`,
+    switchedConfig,
+  )).toBe("pool-a");
+  expect(resolveCodexAccountForThread("pool-canary-0", switchedConfig)).toBe("pool-b");
+});


### PR DESCRIPTION
## Summary

- adds a deterministic, local-only Codex Pool canary for a pre-stream 429 followed by alternate-account success
- proves bounded thread affinity with LRU retention and rebinding coverage
- hardens test lifecycle cleanup so watchdog, state sweepers, quota persistence, and lazy/startup priming cannot outlive task-owned state

## Why

Existing component tests covered pool decisions but did not exercise the Responses retry path, alternate credential selection, HTTP availability, and bounded affinity state together without touching real accounts or the persistent proxy.

## Validation

- `bun test tests/codex-pool-isolated-canary.test.ts tests/codex-pool-rotation.test.ts tests/codex-main-rotation.test.ts tests/account-pool-management-api.test.ts tests/codex-auth-context.test.ts tests/codex-quota-prime.test.ts tests/memory-watchdog.test.ts`
- `bun run typecheck`
- `bun run privacy:scan`
- `openspec validate harden-codex-pool-canary --strict`
- `bun run test` — 8,481 pass, 0 fail (8 platform skips)

No persistent config, real credentials, provider traffic, or port 10123 service state is modified by the canary.