### PR TITLE
fix: finish passthrough SSE after terminal events

### DIFF
--- a/src/server/relay.ts
+++ b/src/server/relay.ts
@@ -517,11 +517,14 @@ export function relaySseWithHeartbeat(
   if (!body) return null;
   const reader = body.getReader();
   const decoder = new TextDecoder();
-  const heartbeat = new TextEncoder().encode(": opencodex keepalive\n\n");
+  const encoder = new TextEncoder();
+  const heartbeat = encoder.encode(": opencodex keepalive\n\n");
+  const doneSentinel = encoder.encode("data: [DONE]\n\n");
   let timer: ReturnType<typeof setInterval> | undefined;
   let closed = false;
   let clientCancelled = false;
   let terminalReported = false;
+  let doneSeen = false;
   let buffer = "";
 
   const reportTerminal = (status: ResponsesTerminalStatus) => {
@@ -532,6 +535,10 @@ export function relaySseWithHeartbeat(
 
   const inspectPayload = (payload: string | null) => {
     if (!payload) return;
+    if (payload === "[DONE]") {
+      doneSeen = true;
+      return;
+    }
     const status = terminalStatusFromSsePayload(payload);
     if (status) reportTerminal(status);
   };
@@ -571,6 +578,10 @@ export function relaySseWithHeartbeat(
         if (done) {
           buffer += decoder.decode();
           if (buffer.trim()) inspectPayload(sseDataPayload(buffer));
+          if (terminalReported && !doneSeen) {
+            controller.enqueue(doneSentinel);
+            doneSeen = true;
+          }
           if (!terminalReported && !clientCancelled) reportTerminal("incomplete");
           cleanup();
           controller.close();
@@ -578,6 +589,13 @@ export function relaySseWithHeartbeat(
         }
         inspectChunk(value);
         controller.enqueue(value);
+        if (terminalReported && !doneSeen) {
+          controller.enqueue(doneSentinel);
+          doneSeen = true;
+          cleanup();
+          controller.close();
+          reader.cancel("Responses terminal event received").catch(() => {});
+        }
       } catch (err) {
         if (!clientCancelled) reportTerminal("incomplete");
         cleanup();

--- a/tests/passthrough-abort.test.ts
+++ b/tests/passthrough-abort.test.ts
@@ -221,6 +221,21 @@ describe("passthrough relayWithAbort (RC2, passthrough path)", () => {
     expect(terminals).toEqual(["completed"]);
   });
 
+  test("SSE passthrough appends DONE after a terminal payload without upstream DONE", async () => {
+    const enc = new TextEncoder();
+    const ac = new AbortController();
+    const terminals: string[] = [];
+    const relayed = relaySseWithHeartbeat(streamFromChunks([
+      enc.encode('event: response.completed\ndata: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n'),
+    ]), ac, 15_000, status => terminals.push(status))!;
+
+    const raw = await readAll(relayed);
+
+    expect(raw).toContain('event: response.completed\ndata: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n');
+    expect(raw).toEndWith("data: [DONE]\n\n");
+    expect(terminals).toEqual(["completed"]);
+  });
+
   test("SSE passthrough treats DONE without a terminal as incomplete", async () => {
     const enc = new TextEncoder();
     const ac = new AbortController();


### PR DESCRIPTION
## Problem

When a provider (e.g. DeepSeek Flash v4) ends a Responses passthrough stream with a terminal event such as `response.completed` / `response.failed` / `response.incomplete` but does not send `data: [DONE]`, the relay keeps the client SSE stream open indefinitely. The client shows the assistant "thinking" forever and never receives the final response.

## Fix

In `src/server/relay.ts`, after forwarding a terminal event, emit `[DONE]` and close the client stream so the client can finalize the turn.

## Tests

- Added `tests/passthrough-abort.test.ts` coverage for a stream that ends with `response.completed` and no `[DONE]`.
- `bun test tests/passthrough-abort.test.ts` passes.
- Related relay tests and `bun run typecheck` pass.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I fixed all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming response handling when terminal events omit the expected completion marker.
  * Ensured clients receive a consistent completion signal and connection closure after a response finishes.

* **Tests**
  * Added coverage confirming terminal events are preserved and the completion marker is appended when missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->