### PR TITLE
fix(responses): give the bounded JSON read a first-byte deadline distinct from inter-chunk inactivity (#1065)

### DIFF
--- a/src/lib/bounded-body.ts
+++ b/src/lib/bounded-body.ts
@@ -23,6 +23,8 @@ export interface BoundedBodyOptions {
 	totalTimeoutMs?: number;
 	/** Deadline between non-empty raw chunks. Exposed for focused tests. */
 	inactivityTimeoutMs?: number;
+	/** Deadline for the first non-empty raw chunk. Defaults to inactivityTimeoutMs. */
+	firstByteTimeoutMs?: number;
 }
 
 export interface BoundedBodyResult {
@@ -129,7 +131,7 @@ export async function readBoundedResponseBody(
 	let cancelReason: unknown;
 	const total = timeoutPromise(options.totalTimeoutMs ?? BOUNDED_BODY_TIMEOUT_MS, TOTAL_TIMEOUT);
 	let inactivity = timeoutPromise(
-		options.inactivityTimeoutMs ?? BOUNDED_BODY_TIMEOUT_MS,
+		options.firstByteTimeoutMs ?? options.inactivityTimeoutMs ?? BOUNDED_BODY_TIMEOUT_MS,
 		INACTIVITY_TIMEOUT,
 	);
 

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -747,10 +747,18 @@ const UNREADABLE_ENCRYPTED_AGENT_TASK_MESSAGE =
 // branch of the passthrough return path). 32 MiB matches the continuation snapshot read
 // bound and is far above any legitimate non-streaming completion, including base64 image
 // payloads. The stall deadlines only govern the body transfer — generation time before
-// the response headers is untouched.
+// the response headers is untouched. Generation after early/chunked headers but before
+// the first body byte previously used the 30-second inactivity deadline; this call site
+// gives it the full body deadline instead.
 const MAX_UPSTREAM_JSON_BODY_BYTES = 32 * 1024 * 1024;
 const UPSTREAM_JSON_BODY_TOTAL_TIMEOUT_MS = 180_000;
 const UPSTREAM_JSON_BODY_INACTIVITY_TIMEOUT_MS = 30_000;
+export const UPSTREAM_JSON_BODY_READ_OPTIONS = {
+  maxBytes: MAX_UPSTREAM_JSON_BODY_BYTES,
+  totalTimeoutMs: UPSTREAM_JSON_BODY_TOTAL_TIMEOUT_MS,
+  inactivityTimeoutMs: UPSTREAM_JSON_BODY_INACTIVITY_TIMEOUT_MS,
+  firstByteTimeoutMs: UPSTREAM_JSON_BODY_TOTAL_TIMEOUT_MS,
+};
 
 function unreadableEncryptedAgentTaskResponse(): Response {
   return new Response(
@@ -2226,11 +2234,7 @@ async function handleResponsesInner(
       // without limit. This path is no longer rare — WebSocket turns for models whose
       // streaming terminal event is unreliable are deliberately answered with bounded JSON.
       // Oversize and stall deadlines both fail closed; a partial body is never parsed.
-      const bounded = await readBoundedResponseBody(upstreamResponse, {
-        maxBytes: MAX_UPSTREAM_JSON_BODY_BYTES,
-        totalTimeoutMs: UPSTREAM_JSON_BODY_TOTAL_TIMEOUT_MS,
-        inactivityTimeoutMs: UPSTREAM_JSON_BODY_INACTIVITY_TIMEOUT_MS,
-      });
+      const bounded = await readBoundedResponseBody(upstreamResponse, UPSTREAM_JSON_BODY_READ_OPTIONS);
       if (bounded.oversized) {
         return formatErrorResponse(502, "upstream_error", "upstream JSON response exceeded the safe body limit");
       }

--- a/tests/bounded-body.test.ts
+++ b/tests/bounded-body.test.ts
@@ -4,6 +4,7 @@ import {
 	boundedBodyBufferGrowthsForTests,
 	readBoundedResponseBody,
 } from "../src/lib/bounded-body";
+import { UPSTREAM_JSON_BODY_READ_OPTIONS } from "../src/server/responses/core";
 
 const encoder = new TextEncoder();
 
@@ -18,6 +19,11 @@ function responseFromChunks(...chunks: Uint8Array[]): Response {
 }
 
 describe("readBoundedResponseBody", () => {
+	test("the bounded JSON caller allows a full total deadline for its first byte", () => {
+		expect(UPSTREAM_JSON_BODY_READ_OPTIONS.firstByteTimeoutMs)
+			.toBe(UPSTREAM_JSON_BODY_READ_OPTIONS.totalTimeoutMs);
+	});
+
 	test("reads multiple chunks and flushes split UTF-8", async () => {
 		const bytes = encoder.encode("alpha 한글 🌍");
 		const response = responseFromChunks(bytes.subarray(0, 8), bytes.subarray(8, 11), bytes.subarray(11));
@@ -50,6 +56,83 @@ describe("readBoundedResponseBody", () => {
 		expect(result.inactivityTimedOut).toBe(true);
 		expect(result.totalTimedOut).toBe(false);
 		expect(cancelled).toBe(true);
+	});
+
+	test("allows the first byte to arrive after the inter-chunk inactivity deadline", async () => {
+		const response = new Response(new ReadableStream<Uint8Array>({
+			start(controller) {
+				setTimeout(() => {
+					controller.enqueue(encoder.encode("first byte"));
+					controller.close();
+				}, 30);
+			},
+		}));
+
+		const result = await readBoundedResponseBody(response, {
+			totalTimeoutMs: 100,
+			inactivityTimeoutMs: 15,
+			firstByteTimeoutMs: 60,
+		});
+
+		expect(result.text).toBe("first byte");
+		expect(result.truncated).toBe(false);
+		expect(result.inactivityTimedOut).toBe(false);
+	});
+
+	test("times out when the first byte misses its dedicated deadline", async () => {
+		const response = new Response(new ReadableStream<Uint8Array>({}));
+
+		const result = await readBoundedResponseBody(response, {
+			totalTimeoutMs: 100,
+			inactivityTimeoutMs: 60,
+			firstByteTimeoutMs: 15,
+		});
+
+		expect(result.inactivityTimedOut).toBe(true);
+		expect(result.totalTimedOut).toBe(false);
+	});
+
+	test("keeps the inter-chunk inactivity deadline after the first byte", async () => {
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const response = new Response(new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode("first"));
+				timer = setTimeout(() => controller.enqueue(encoder.encode("late")), 30);
+			},
+			cancel() {
+				if (timer) clearTimeout(timer);
+			},
+		}));
+
+		const result = await readBoundedResponseBody(response, {
+			totalTimeoutMs: 100,
+			inactivityTimeoutMs: 15,
+			firstByteTimeoutMs: 60,
+		});
+
+		expect(result.text).toBe("first");
+		expect(result.truncated).toBe(true);
+		expect(result.inactivityTimedOut).toBe(true);
+	});
+
+	test("uses the inactivity deadline for the first byte by default", async () => {
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const response = new Response(new ReadableStream<Uint8Array>({
+			start(controller) {
+				timer = setTimeout(() => controller.enqueue(encoder.encode("late")), 30);
+			},
+			cancel() {
+				if (timer) clearTimeout(timer);
+			},
+		}));
+
+		const result = await readBoundedResponseBody(response, {
+			totalTimeoutMs: 100,
+			inactivityTimeoutMs: 15,
+		});
+
+		expect(result.inactivityTimedOut).toBe(true);
+		expect(result.totalTimedOut).toBe(false);
 	});
 
 	test("a partial body followed by silence times out and flushes UTF-8", async () => {


### PR DESCRIPTION
## Summary

- Fixes #1065: DeepSeek V4 Flash requests intermittently died with a local `502 upstream JSON response stalled before completing` after ~30.5s. Root cause: `readBoundedResponseBody` armed its 30s inactivity timer at reader creation — **before the first body byte**. A thinking model that flushes chunked headers promptly but computes >30s before emitting its first JSON byte was indistinguishable from a stalled upstream. Every `deepseek-v4-flash` turn takes this bounded JSON path because the registry deliberately pins `modelResponsesUpstreamStreaming: false` for it (#875 terminal-event unreliability), so slow-thinking turns at `high`/`max` effort crossed the window and failed locally.
- `BoundedBodyOptions` gains `firstByteTimeoutMs`, defaulting to `inactivityTimeoutMs` so **every existing caller is behavior-identical** (web-search loop, images loop, upstream-http-error, kiro-retry, auth-api, quota-rejection, and the other two core call sites). Only the bounded JSON upstream read opts in, passing the existing 180s total budget as the first-byte allowance — the total wall-clock deadline still bounds a genuinely dead upstream, and the 30s inter-chunk stall protection is unchanged once bytes flow.
- The options are exported as a named policy const so a regression test pins the call-site wiring, and the timeout comment now explains the early-header/late-first-byte case instead of implying pre-header generation was the only wait.
- Resource tradeoff (recorded in the devlog unit): a header-only stall can now hold a turn slot for up to 180s instead of 30s; buffer memory stays bounded (64 KiB initial buffer × 256 active-turn cap ≈ 16 MiB worst case).

## Verification

- `bun run typecheck` — clean.
- `bun test tests/bounded-body.test.ts` — 21 pass, 0 fail (new: first byte delayed past inactivity but under first-byte deadline completes; no first byte before the deadline still fails closed; on-time first byte with a later inter-chunk stall still times out; defaulted option behaves identically to today; call-site policy pin asserting `firstByteTimeoutMs === totalTimeoutMs` for the bounded JSON read).
- Red ablation recorded: the delayed-first-byte test fails without the fix (`Expected: "first byte" / Received: "" — 0 pass, 1 fail`).
- Smoke: `bun test tests/responses-shadow-intercept.test.ts` — 14 pass, 0 fail.
- `bun run privacy:scan` — passed.

Closes #1065.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (Behavior is internal reliability; the devlog unit carries the RCA and design.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (Fail-closed semantics preserved; all bounds still enforced.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of slow upstream responses by applying a dedicated timeout for receiving the first byte.
  * Continued enforcing inactivity limits between subsequent response chunks.
  * Standardized timeout behavior for non-streaming JSON responses, reducing delays when upstream services do not respond promptly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->