### PR TITLE
test(ci): accept the Copilot permission in the issue-quality workflow pin

### DIFF
--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -4142,7 +4142,7 @@ describe("GitHub Actions hardening", () => {
 
     // Job-scoped permissions only (no top-level issues:write; no actions:write).
     expect(workflow).toMatch(
-      /jobs:\s*\n\s*translate:[\s\S]*?permissions:\s*\n(?:\s*#.*\n)*\s*contents: read\s*\n(?:\s*#.*\n)*\s*issues: write\s*\n(?:\s*#.*\n)*\s*models: read/,
+      /jobs:\s*\n\s*translate:[\s\S]*?permissions:\s*\n(?:\s*#.*\n)*\s*contents: read\s*\n(?:\s*#.*\n)*\s*issues: write\s*\n(?:\s*#.*\n)*\s*(?:copilot-requests: write|models: read)/,
     );
     const translateJob = workflow.split(/\n {2}translate:\n/)[1]!.split(/\n {2}[a-zA-Z]/)[0]!;
     expect(translateJob).not.toMatch(/actions:\s*write/);


### PR DESCRIPTION
## Fix the issue-quality CI test pinning the pre-Copilot permission

The `translate` job in `.github/workflows/enforce-issue-quality.yml` migrated from the `actions/ai-inference` action (which needed `models: read`) to the GitHub Copilot CLI (which needs `copilot-requests: write`) in `3a7a72d8` (migrate issue automation to Copilot). The regression test in `tests/ci-workflows.test.ts` was not updated and still pins `models: read`, so the `test 1/4` CI job fails on every PR against current `dev`.

### Change

The test's real guard is that the `translate` job stays **job-scoped** — no top-level `issues: write`, no `actions: write`. The permission-name pin is secondary, so the assertion now accepts either the legacy `models: read` or the current `copilot-requests: write`, keeping the job-scoped guard intact.

```diff
-      /jobs:\s*\n\s*translate:[\s\S]*?permissions:\s*\n(?:\s*#.*\n)*\s*contents: read\s*\n(?:\s*#.*\n)*\s*issues: write\s*\n(?:\s*#.*\n)*\s*models: read/,
+      /jobs:\s*\n\s*translate:[\s\S]*?permissions:\s*\n(?:\s*#.*\n)*\s*contents: read\s*\n(?:\s*#.*\n)*\s*issues: write\s*\n(?:\s*#.*\n)*\s*(?:copilot-requests: write|models: read)/,
```

### Verification

- `tests/ci-workflows.test.ts` — all 113 tests pass (was 1 fail on the head).
- `bun run typecheck` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated workflow validation to support the newly available permission option for issue translation, while preserving existing required permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->