### PR TITLE
test: replace hardcoded old username with generic user in test fixture

### DIFF
--- a/tests/upstream-http-error.test.ts
+++ b/tests/upstream-http-error.test.ts
@@ -7,11 +7,11 @@ import {
 describe("sanitizeUpstreamErrorText", () => {
   test("redacts secrets and absolute paths", () => {
     const text = sanitizeUpstreamErrorText(
-      "Authorization: Bearer secret-token at /Users/example/private.json and C:\\Users\\JK\\secret.txt",
+      "Authorization: Bearer secret-token at /Users/example/private.json and C:\\Users\\user\\secret.txt",
     );
     expect(text).not.toContain("secret-token");
     expect(text).not.toContain("/Users/example/private.json");
-    expect(text).not.toContain("C:\\Users\\JK\\secret.txt");
+    expect(text).not.toContain("C:\\Users\\user\\secret.txt");
   });
 });
 


### PR DESCRIPTION
Replaces the old hardcoded username `JK` with a generic `user` in the test fixture path. Only affects `tests/upstream-http-error.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated sanitization test data to cover an alternative Windows absolute path.
  * Confirmed that sensitive values and Unix and Windows file paths remain properly redacted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->