### PR TITLE
fix(test): give the contended restore its real production wait budget

### DIFF
--- a/tests/codex-composed-acceptance.test.ts
+++ b/tests/codex-composed-acceptance.test.ts
@@ -477,7 +477,13 @@ describe("WP13 composed toggle acceptance", () => {
     `], { cwd: repoRoot, env: fx.env(), stdout: "pipe", stderr: "pipe" });
     fx.children.push(holder);
     await waitFor(() => existsSync(held) ? true : null, "history BEGIN IMMEDIATE");
-    const blocked = await fx.runCli(["restore", "--json"], fx.homeA, fx.userprofileA, 15_000);
+    // The contended restore deliberately waits out PRODUCTION's retry budget:
+    // a 5 s SQLite busy timeout per attempt, two attempts, plus the delay
+    // between them — ~11 s of intentional waiting before it can report `busy`.
+    // A 15 s watchdog left almost no margin and fired on a loaded macOS runner
+    // (dev CI run 31105071651). Give the wait its budget plus real headroom;
+    // the case's own 45 s test timeout still bounds it.
+    const blocked = await fx.runCli(["restore", "--json"], fx.homeA, fx.userprofileA, 30_000);
     expect(blocked.exitCode).toBe(1);
     const envelope = JSON.parse(blocked.stdout) as { success: boolean; artifacts: { history: { state: string; reason?: string } } };
     expect(envelope).toMatchObject({ success: false, artifacts: { history: { state: "failed", reason: "busy" } } });


### PR DESCRIPTION
## Summary

Restores `dev` to green. The composed-acceptance "Restore truth" case failed on the macOS shard of the post-merge `dev` run ([31105071651](https://github.com/lidge-jun/opencodex/actions/runs/31105071651)) after #1106 landed.

It is a watchdog-margin bug in the test, not a product regression. The case holds `state_5.sqlite` with `BEGIN IMMEDIATE` and then runs a real `ocx restore --json` child, which deliberately waits out **production's** retry budget before it may report `busy`: a 5 s SQLite busy timeout per attempt, two attempts (`HISTORY_RETRY_ATTEMPTS`), plus `HISTORY_RETRY_DELAY_MS` between them — roughly 11 s of intentional waiting. The CLI watchdog was set to 15 s, leaving under 4 s of headroom, which a loaded CI runner consumed. The watchdog now gets 30 s; the case's own 45 s test timeout still bounds it, and no production timing changed.

## Verification

- `bun test ./tests/codex-composed-acceptance.test.ts` — 6 pass / 0 fail (14.94 s locally; the contended case alone accounts for ~11 s of that by design).
- `bun x tsc --noEmit` — clean.
- Single-file change, tests only; no `src/` diff.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (not applicable — test-only timing margin).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults (no auth, credential, or workflow surface touched).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the timeout for the restore contention acceptance test to accommodate production retry delays.
  * Kept the test within its overall execution limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->