### PR TITLE
fix(codex): retry the native-main ACL timeout once, fail closed otherwise

### DIFF
--- a/src/codex/native-main-lock-file.ts
+++ b/src/codex/native-main-lock-file.ts
@@ -140,12 +140,16 @@ export function assertStableLockFile(path: string, handle: StableLockFile): void
 export async function hardenStableLockFile(
   path: string,
   platform: NodeJS.Platform = process.platform,
+  options: { retryTimedOutOnce?: boolean } = {},
 ): Promise<void> {
   if (platform === "win32") {
     // Best-effort here: POSIX modes are not authoritative on NTFS, and the
     // required ACL hardening below is what actually decides.
     try { chmodSync(path, 0o600); } catch { /* ACL below is authoritative. */ }
-    await hardenSecretPathAsync(path, { required: true });
+    await hardenSecretPathAsync(path, {
+      required: true,
+      retryTimedOutOnce: options.retryTimedOutOnce,
+    });
     return;
   }
   // On POSIX the mode IS the mechanism, so a failure may not be swallowed.

--- a/src/codex/native-main-owner.ts
+++ b/src/codex/native-main-owner.ts
@@ -53,6 +53,7 @@ interface OwnerEntry {
   timer?: ReturnType<typeof setTimeout>;
   drive?: Promise<void>;
   activeOperations: Set<Promise<unknown>>;
+  aclTimeoutRetryUsed: boolean;
   closing: boolean;
 }
 
@@ -149,8 +150,13 @@ async function prepareOwnerDatabase(entry: OwnerEntry): Promise<void> {
     // here still exercises the host's branch, and the production default — the
     // thing that actually hardens the owner's lock file — stays unproved. An
     // audit replaced this fallback with a no-op and 91 tests stayed green.
-    await (entry.options.hardenPath
-      ?? ((target: string) => hardenStableLockFile(target, entry.options.platform)))(entry.lockPath);
+    if (entry.options.hardenPath) {
+      await entry.options.hardenPath(entry.lockPath);
+    } else {
+      await hardenStableLockFile(entry.lockPath, entry.options.platform, {
+        retryTimedOutOnce: entry.aclTimeoutRetryUsed,
+      });
+    }
     assertStableLockFile(entry.lockPath, file);
     entry.file = file;
     file = undefined;
@@ -196,6 +202,13 @@ async function drive(entry: OwnerEntry, generation: number): Promise<void> {
       scheduleRetry(entry, generation);
       return;
     }
+    if (errorCode(error) === "ETIMEDOUT" && !entry.aclTimeoutRetryUsed) {
+      entry.aclTimeoutRetryUsed = true;
+      // A timeout is neither ownership contention nor a permanent ACL denial.
+      // Stay fail-closed in `acquiring` and spend exactly one fresh-budget retry.
+      scheduleRetry(entry, generation);
+      return;
+    }
     publish(entry, { status: "unavailable", homeId: entry.context.homeId, reason: "lock-unavailable" });
   }
 }
@@ -222,6 +235,7 @@ function entryFor(context: NativeProfileContext, options: NativeMainOwnerOptions
     snapshot: { status: "acquiring", homeId: context.homeId },
     listeners: new Set(),
     activeOperations: new Set(),
+    aclTimeoutRetryUsed: false,
     prepared: false,
     closing: false,
   };
@@ -239,7 +253,7 @@ export function retainNativeMainOwner(
     throw new NativeProfileError("NATIVE_MAIN_OWNER_BUSY", "Native-main ownership is closing.", 503, true);
   }
   entry.refs += 1;
-  if (!entry.drive && !entry.database && !entry.timer) {
+  if (!entry.drive && !entry.database && !entry.timer && entry.snapshot.status !== "unavailable") {
     const generation = entry.generation;
     entry.drive = drive(entry, generation).finally(() => {
       if (entry.generation === generation) entry.drive = undefined;

--- a/src/lib/windows-secret-acl.ts
+++ b/src/lib/windows-secret-acl.ts
@@ -34,8 +34,12 @@ import { env, platform } from "node:process";
 
 const hardenedDirectories = new Map<string, HardenedIdentity>();
 const hardenedPaths = new Map<string, HardenedIdentity>();
-/** Paths whose harden TIMED OUT this process: do not re-stall every loadConfig on them. */
-const timedOutPaths = new Set<string>();
+/**
+ * Paths whose harden TIMED OUT this process: do not re-stall every loadConfig on them.
+ * `false` means one explicitly authorized recovery attempt remains; `true` means
+ * that attempt was consumed. Ordinary callers never consume it.
+ */
+const timedOutPaths = new Map<string, boolean>();
 
 /**
  * The memo value: `object:freshness` for a file a harden was actually attributed
@@ -212,6 +216,12 @@ export interface HardenOptions {
    * Must NOT be a parent directory — directory ACLs are not authoritative for new files.
    */
   timeoutMemoKey?: string;
+  /**
+   * Consume the one recovery attempt for a previously timed-out memo key.
+   * Only a caller that owns its own single-flight and bounded retry policy should
+   * set this. It never clears or bypasses an already-consumed timeout memo.
+   */
+  retryTimedOutOnce?: boolean;
 }
 
 /**
@@ -524,6 +534,50 @@ function isTimeoutError(error: unknown): boolean {
     && String((error as NodeJS.ErrnoException).code) === "ETIMEDOUT";
 }
 
+/** Preserve only the bounded machine-readable cause on a sanitized public error. */
+function sanitizedAclError(diagnostics: string, cause: unknown): NodeJS.ErrnoException {
+  const error = new Error(diagnostics) as NodeJS.ErrnoException;
+  const code = cause && typeof cause === "object" && "code" in cause
+    ? String((cause as { code?: unknown }).code)
+    : "";
+  if (code === "ETIMEDOUT" || code === "EICACLS" || code === "EACCES" || code === "EPERM") {
+    error.code = code;
+  }
+  return error;
+}
+
+function previousTimeoutError(retryConsumed: boolean): NodeJS.ErrnoException {
+  if (retryConsumed) {
+    const error = new Error(
+      "ACL hardening skipped — the previous timeout recovery was already consumed",
+    ) as NodeJS.ErrnoException;
+    error.code = "EACLRETRYEXHAUSTED";
+    return error;
+  }
+  return sanitizedAclError(
+    "ACL hardening skipped — previous attempt timed out",
+    Object.assign(new Error("timeout"), { code: "ETIMEDOUT" }),
+  );
+}
+
+/** Consume, but never reset, the single explicit recovery attempt for this key. */
+function timeoutMemoErrorIfBlocked(
+  memoKey: string,
+  opts: HardenOptions,
+): NodeJS.ErrnoException | null {
+  const retryConsumed = timedOutPaths.get(memoKey);
+  if (retryConsumed === undefined) return null;
+  if (opts.retryTimedOutOnce && retryConsumed === false) {
+    timedOutPaths.set(memoKey, true);
+    return null;
+  }
+  return previousTimeoutError(retryConsumed);
+}
+
+function recordTimeout(memoKey: string): void {
+  if (!timedOutPaths.has(memoKey)) timedOutPaths.set(memoKey, false);
+}
+
 /**
  * Diagnostic-only post-timeout probe (never promotes to ok:true — a clean /findsid
  * does not prove inheritance was disabled or the user grant ran; only a fully
@@ -588,10 +642,10 @@ function hardenEntry(
   if (effectivePlatform() !== "win32") return { ok: true };
   if (memoSatisfied(cache, targetPath)) return { ok: true };
   const memoKey = timeoutMemoKey(targetPath, opts);
-  if (timedOutPaths.has(memoKey)) {
-    const diagnostics = "ACL hardening skipped — previous attempt timed out";
-    if (opts.required) throw new Error(diagnostics);
-    return { ok: false, diagnostics };
+  const timeoutMemoError = timeoutMemoErrorIfBlocked(memoKey, opts);
+  if (timeoutMemoError) {
+    if (opts.required) throw timeoutMemoError;
+    return { ok: false, diagnostics: timeoutMemoError.message };
   }
 
   const deadline = nowFn() + resolveHardenDeadlineMs();
@@ -606,6 +660,7 @@ function hardenEntry(
         if (opts.required) throw new Error(SUBSTITUTED_DIAGNOSTIC);
         return { ok: false, diagnostics: SUBSTITUTED_DIAGNOSTIC };
       }
+      timedOutPaths.delete(memoKey);
       return { ok: true };
     } catch (err) {
       // A substitution is not a transient icacls stall; do not spend the retry on it.
@@ -617,14 +672,14 @@ function hardenEntry(
 
   const diagnostics = sanitizeDiagnostics(lastErr);
   if (isTimeoutError(lastErr)) {
-    timedOutPaths.add(memoKey);
+    recordTimeout(memoKey);
     const state = describeAclStateAfterTimeout(targetPath, deadline);
     const annotated = `${diagnostics}; ${state}`;
-    if (opts.required) throw new Error(annotated);
+    if (opts.required) throw sanitizedAclError(annotated, lastErr);
     console.warn(`[opencodex] ${annotated} — continuing without NTFS ACL harden`);
     return { ok: false, diagnostics: annotated };
   }
-  if (opts.required) throw new Error(diagnostics);
+  if (opts.required) throw sanitizedAclError(diagnostics, lastErr);
   return { ok: false, diagnostics };
 }
 
@@ -639,10 +694,10 @@ async function hardenEntryAsync(
   if (effectivePlatform() !== "win32") return { ok: true };
   if (memoSatisfied(cache, targetPath)) return { ok: true };
   const memoKey = timeoutMemoKey(targetPath, opts);
-  if (timedOutPaths.has(memoKey)) {
-    const diagnostics = "ACL hardening skipped — previous attempt timed out";
-    if (opts.required) throw new Error(diagnostics);
-    return { ok: false, diagnostics };
+  const timeoutMemoError = timeoutMemoErrorIfBlocked(memoKey, opts);
+  if (timeoutMemoError) {
+    if (opts.required) throw timeoutMemoError;
+    return { ok: false, diagnostics: timeoutMemoError.message };
   }
 
   const deadline = nowFn() + resolveHardenDeadlineMs();
@@ -656,6 +711,7 @@ async function hardenEntryAsync(
         if (opts.required) throw new Error(SUBSTITUTED_DIAGNOSTIC);
         return { ok: false, diagnostics: SUBSTITUTED_DIAGNOSTIC };
       }
+      timedOutPaths.delete(memoKey);
       return { ok: true };
     } catch (err) {
       if (err instanceof Error && err.message === SUBSTITUTED_DIAGNOSTIC) throw err;
@@ -666,14 +722,14 @@ async function hardenEntryAsync(
 
   const diagnostics = sanitizeDiagnostics(lastErr);
   if (isTimeoutError(lastErr)) {
-    timedOutPaths.add(memoKey);
+    recordTimeout(memoKey);
     const state = await describeAclStateAfterTimeoutAsync(targetPath, deadline);
     const annotated = `${diagnostics}; ${state}`;
-    if (opts.required) throw new Error(annotated);
+    if (opts.required) throw sanitizedAclError(annotated, lastErr);
     console.warn(`[opencodex] ${annotated} — continuing without NTFS ACL harden`);
     return { ok: false, diagnostics: annotated };
   }
-  if (opts.required) throw new Error(diagnostics);
+  if (opts.required) throw sanitizedAclError(diagnostics, lastErr);
   return { ok: false, diagnostics };
 }
 

--- a/tests/native-main-owner-lifetime.test.ts
+++ b/tests/native-main-owner-lifetime.test.ts
@@ -252,6 +252,84 @@ function isContended(event: Event): boolean {
 }
 
 describe("native-main process owner lease", () => {
+  test("one coded ACL timeout retries once before ownership becomes held", async () => {
+    const f = fixture("acl-timeout-recovery");
+    let attempts = 0;
+    const trace: string[] = [];
+    const owner = retainNativeMainOwner(f.manager.context, {
+      retryMs: 10,
+      hardenPath: async () => {
+        attempts += 1;
+        if (attempts === 1) throw Object.assign(new Error("transient"), { code: "ETIMEDOUT" });
+      },
+    });
+    const unsubscribe = owner.subscribe(snapshot => { trace.push(snapshot.status); });
+    try {
+      await waitUntil(() => owner.snapshot().status === "held" ? true : null);
+      expect(attempts).toBe(2);
+      expect(trace).toEqual(["acquiring", "held"]);
+    } finally {
+      unsubscribe();
+      await owner.release();
+    }
+  });
+
+  test("a second coded ACL timeout becomes terminal and a release cancels a pending retry", async () => {
+    const f = fixture("acl-timeout-terminal");
+    let attempts = 0;
+    const trace: string[] = [];
+    const owner = retainNativeMainOwner(f.manager.context, {
+      retryMs: 10,
+      hardenPath: async () => {
+        attempts += 1;
+        throw Object.assign(new Error("transient"), { code: "ETIMEDOUT" });
+      },
+    });
+    const unsubscribe = owner.subscribe(snapshot => { trace.push(snapshot.status); });
+    try {
+      await waitUntil(() => owner.snapshot().status === "unavailable" ? true : null);
+      await Bun.sleep(50);
+      expect(attempts).toBe(2);
+      expect(trace).toEqual(["acquiring", "unavailable"]);
+    } finally {
+      unsubscribe();
+      await owner.release();
+    }
+
+    const f2 = fixture("acl-timeout-release");
+    let releasedAttempts = 0;
+    const releasing = retainNativeMainOwner(f2.manager.context, {
+      retryMs: 100,
+      hardenPath: async () => {
+        releasedAttempts += 1;
+        throw Object.assign(new Error("transient"), { code: "ETIMEDOUT" });
+      },
+    });
+    await waitUntil(() => releasedAttempts === 1 ? true : null);
+    await releasing.release();
+    await Bun.sleep(150);
+    expect(releasedAttempts).toBe(1);
+  });
+
+  test("an ETIMEDOUT-looking message without the code remains a permanent failure", async () => {
+    const f = fixture("acl-timeout-message-only");
+    let attempts = 0;
+    const owner = retainNativeMainOwner(f.manager.context, {
+      retryMs: 10,
+      hardenPath: async () => {
+        attempts += 1;
+        throw new Error("ETIMEDOUT in untrusted prose");
+      },
+    });
+    try {
+      await waitUntil(() => owner.snapshot().status === "unavailable" ? true : null);
+      await Bun.sleep(50);
+      expect(attempts).toBe(1);
+    } finally {
+      await owner.release();
+    }
+  });
+
   test("same-process references retain one owner and do not deadlock the transaction lock", async () => {
     const f = fixture();
     const first = retainNativeMainOwner(f.manager.context, { retryMs: 10, hardenPath: async () => {} });

--- a/tests/windows-secret-acl.test.ts
+++ b/tests/windows-secret-acl.test.ts
@@ -576,7 +576,15 @@ describe("async hardenSecretPath (issue #612)", () => {
 
   test("async permission failure still throws on required paths", async () => {
     setAsyncIcaclsRunnerForTests(async () => denied);
-    await expect(hardenSecretPathAsync(secretFile(), { required: true })).rejects.toThrow(/EICACLS/);
+    let caught: unknown;
+    try {
+      await hardenSecretPathAsync(secretFile(), { required: true });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as NodeJS.ErrnoException).code).toBe("EICACLS");
+    expect((caught as Error).message).toMatch(/EICACLS/);
   });
 
   test("timeoutMemoKey shares the timeout cache across distinct temp paths", async () => {
@@ -596,6 +604,66 @@ describe("async hardenSecretPath (issue #612)", () => {
     });
     await expect(hardenSecretPathAsync(tempB, { required: true, timeoutMemoKey: dest })).rejects.toThrow(/skipped/);
     expect(calls).toBe(0); // destination-keyed memo; not a parent-directory shortcut
+  });
+
+  test("a required timeout preserves ETIMEDOUT and one explicit recovery gets a fresh budget", async () => {
+    const target = secretFile("one-time-recovery.json");
+    let now = 0;
+    let grantCalls = 0;
+    setNowForTests(() => now);
+    setAsyncIcaclsRunnerForTests(async args => {
+      if (args.includes("/grant:r")) grantCalls += 1;
+      if (grantCalls === 1) {
+        now = 5_000; // exhaust the first call's entire budget
+        return timeout;
+      }
+      return ok;
+    });
+
+    let first: unknown;
+    try {
+      await hardenSecretPathAsync(target, { required: true });
+    } catch (error) {
+      first = error;
+    }
+    expect((first as NodeJS.ErrnoException).code).toBe("ETIMEDOUT");
+    expect((first as Error).message).not.toContain(target);
+    expect(timedOutSecretPathCountForTests()).toBe(1);
+
+    await expect(hardenSecretPathAsync(target, {
+      required: true,
+      retryTimedOutOnce: true,
+    })).resolves.toEqual({ ok: true });
+    expect(grantCalls).toBe(2);
+    expect(timedOutSecretPathCountForTests()).toBe(0);
+  });
+
+  test("the explicit timeout recovery cannot be consumed more than once", async () => {
+    const target = secretFile("consumed-recovery.json");
+    let now = 0;
+    let grantCalls = 0;
+    setNowForTests(() => now);
+    setAsyncIcaclsRunnerForTests(async args => {
+      if (args.includes("/grant:r")) grantCalls += 1;
+      now += 5_000;
+      return timeout;
+    });
+
+    await expect(hardenSecretPathAsync(target, { required: true })).rejects.toMatchObject({
+      code: "ETIMEDOUT",
+    });
+    await expect(hardenSecretPathAsync(target, {
+      required: true,
+      retryTimedOutOnce: true,
+    })).rejects.toMatchObject({ code: "ETIMEDOUT" });
+    const callsAfterRecovery = grantCalls;
+    await expect(hardenSecretPathAsync(target, {
+      required: true,
+      retryTimedOutOnce: true,
+    })).rejects.toMatchObject({ code: "EACLRETRYEXHAUSTED" });
+    expect(grantCalls).toBe(callsAfterRecovery);
+    expect(grantCalls).toBe(2);
+    expect(timedOutSecretPathCountForTests()).toBe(1);
   });
 
   test("optional timeout memo does not poison a later required harden of the same path", () => {
@@ -1093,7 +1161,12 @@ describe("hardenStableLockFile — the production call edge, not just the primit
     const lockPath = join(testDir, "coordinator-posix.sqlite");
     writeFileSync(lockPath, "x", "utf8");
     chmodSync(lockPath, 0o644);
-    expect(statSync(lockPath).mode & 0o777).toBe(0o644);
+    // Windows does not expose POSIX mode bits faithfully even when this test
+    // forces the caller's platform branch to Linux. Keep the real mode proof on
+    // POSIX hosts; on Windows this case still proves no ACL command is invoked.
+    if (process.platform !== "win32") {
+      expect(statSync(lockPath).mode & 0o777).toBe(0o644);
+    }
 
     let calls = 0;
     setAsyncIcaclsRunnerForTests(async () => {
@@ -1102,7 +1175,9 @@ describe("hardenStableLockFile — the production call edge, not just the primit
     });
     try {
       await hardenStableLockFile(lockPath, "linux");
-      expect(statSync(lockPath).mode & 0o777).toBe(0o600);
+      if (process.platform !== "win32") {
+        expect(statSync(lockPath).mode & 0o777).toBe(0o600);
+      }
       expect(calls).toBe(0);
     } finally {
       setAsyncIcaclsRunnerForTests(null);
@@ -1141,6 +1216,7 @@ describe("the production default hardener is reached, with the resolved platform
     run: (codexHome: string) => Promise<void>,
     onGrant: () => void = () => {},
     gate?: Promise<void>,
+    resultFor?: (args: string[]) => IcaclsResult | Promise<IcaclsResult>,
   ): Promise<string[][]> => {
     const seen: string[][] = [];
     setPlatformForTests("win32");
@@ -1152,7 +1228,9 @@ describe("the production default hardener is reached, with the resolved platform
       // A deferred runner lets a test observe the window WHILE hardening is in
       // flight, which is the only way to assert nothing was published early.
       if (gate) await gate;
-      return { success: true, exitCode: 0, timedOut: false, stdout: "" };
+      return resultFor
+        ? await resultFor(args)
+        : { success: true, exitCode: 0, timedOut: false, stdout: "" };
     });
     const codexHome = mkdtempSync(join(tmpdir(), "ocx-default-harden-"));
     try {
@@ -1236,6 +1314,49 @@ describe("the production default hardener is reached, with the resolved platform
     }, () => {}, aclBlocked);
     expect(seen.some(args => args.includes("/grant:r"))).toBe(true);
     expect(seen.every(args => args[0] === expected)).toBe(true);
+  });
+
+  test("the production owner default consumes one timeout memo and then acquires", async () => {
+    resetHardenedStateForTests();
+    let now = 0;
+    let grantAttempts = 0;
+    const trace: string[] = [];
+    let expected = "";
+    setNowForTests(() => now);
+    try {
+      const seen = await forcedWindows(async codexHome => {
+        expected = join(codexHome, NATIVE_MAIN_OWNER_DB);
+        const owner = retainNativeMainOwner(
+          { codexHome } as never,
+          { platform: "win32", retryMs: 10 },
+        );
+        const unsubscribe = owner.subscribe(snapshot => { trace.push(snapshot.status); });
+        try {
+          const deadline = Date.now() + 5_000;
+          while (owner.snapshot().status === "acquiring" && Date.now() < deadline) {
+            await Bun.sleep(10);
+          }
+          expect(owner.snapshot()).toMatchObject({ status: "held" });
+        } finally {
+          unsubscribe();
+          await owner.release();
+        }
+      }, () => {}, undefined, args => {
+        if (args.includes("/grant:r")) {
+          grantAttempts += 1;
+          if (grantAttempts === 1) {
+            now = 5_000;
+            return { success: false, exitCode: null, timedOut: true, stdout: "" };
+          }
+        }
+        return { success: true, exitCode: 0, timedOut: false, stdout: "" };
+      });
+      expect(trace).toEqual(["acquiring", "held"]);
+      expect(grantAttempts).toBe(2);
+      expect(seen.every(args => args[0] === expected)).toBe(true);
+    } finally {
+      setNowForTests(null);
+    }
   });
 });
 
@@ -1324,6 +1445,7 @@ describe("a required hardening failure stops the operation it protects", () => {
     await forcedWindowsFailure(async codexHome => {
       expected = join(codexHome, NATIVE_MAIN_OWNER_DB);
       const owner = retainNativeMainOwner({ codexHome } as never, { platform: "win32", retryMs: 10 });
+      let second: ReturnType<typeof retainNativeMainOwner> | undefined;
       const trace: string[] = [];
       const unsubscribe = owner.subscribe(snapshot => { trace.push(snapshot.status); });
       try {
@@ -1353,8 +1475,13 @@ describe("a required hardening failure stops the operation it protects", () => {
         expect(hardenAttempts).toBe(1);
         // Exactly one attempt, against exactly the owner's own database.
         expect(targets).toEqual([expected]);
+        second = retainNativeMainOwner({ codexHome } as never, { platform: "win32", retryMs: 10 });
+        await Bun.sleep(60);
+        expect(second.snapshot()).toMatchObject({ status: "unavailable" });
+        expect(hardenAttempts).toBe(1);
       } finally {
         unsubscribe();
+        if (second) await second.release();
         await owner.release();
       }
     }, args => { hardenAttempts += 1; targets.push(args[0]!); });


### PR DESCRIPTION
## Summary

Separates "the Windows ACL call timed out" from "the ACL was refused" on the native-main owner path, and retries once for the former.

Previously a transient ACL stall was indistinguishable from a permanent denial, so a slow call could permanently fence the native-main owner. `src/lib/windows-secret-acl.ts` now returns a coded error taxonomy, `src/codex/native-main-owner.ts` retries exactly once on the timeout class, and `src/codex/native-main-lock-file.ts` propagates the coded failure.

**The fail-closed property is preserved.** A refused ACL still denies — the retry applies only to the timeout class. That distinction is load-bearing because this path guards a physical credential: a retry that swallowed a denial would be a security regression, and the tests pin that it does not.

### Attribution

This is **@luvs01's** work from #1130, cherry-picked with their authorship intact. #1130 stays open for them. The coded-error approach is the right shape for this — it makes the recoverable case explicit rather than widening the catch.

Stack 3 of the 260806 attribution campaign, stacked on #1134. Planning unit: `devlog/_plan/260806_stacked_bug_campaign/`.

## Verification

- `bun test tests/windows-secret-acl.test.ts tests/native-main-owner-lifetime.test.ts` — 166 pass, 0 fail
- `bun run typecheck` — exit 0
- `bun run privacy:scan` — passed
- Full `bun run test` via the repository prepush gate — passed

**Platform limitation stated honestly:** verification ran on macOS, so the Windows ACL boundary is exercised through injection rather than natively. The tests cover the permanent-error, timeout, and retry-exhaustion classes; they do not prove real Windows ACL behavior. A Windows CI leg is the check that would.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.
