### PR TITLE
fix(ci): harden Bun isolate worker teardown and probe timeouts

### DIFF
--- a/src/storage/worker-lifecycle.ts
+++ b/src/storage/worker-lifecycle.ts
@@ -11,10 +11,9 @@
  * time (so we cannot miss `self.close()` / early exit), stays in `liveWorkers`
  * until that close settles, and `drainStorageWorkers()` joins every in-flight
  * terminate. Spawns are serialized through `withStorageWorkerSpawnGate` so the
- * next Worker cannot be created until prior threads have exited. On Windows and
- * macOS, a post-close settle covers the OS join gap Bun does not expose
- * (Windows unbalanced join panic; macOS Silicon balanced-count segfault under
- * `bun test --isolate`).
+ * next Worker cannot be created until prior threads have exited. A post-close
+ * settle covers the OS/runtime join gap Bun does not expose on Windows, macOS,
+ * and Linux (including Bun 1.3.14 isolate crashes and Linux `epoll_ctl` reuse).
  */
 
 import { createAdmissionGate, type AdmissionMetrics, type AdmissionReservation } from "../lib/admission";
@@ -52,15 +51,15 @@ let spawnCancelEpoch = 0;
 /**
  * OS-join gap after the `close` event on platforms where Bun's Worker reclaim
  * races the isolate/file boundary (not a CI job-timeout bump).
- * Windows GHA at 250ms and 750ms still left `workers_spawned(N)
- * workers_terminated(N-1)` panics under isolate (seen mid
- * `storage-mutation-race` with 11/10). 1500ms covers deferred reclaim under
- * stacked policy/restore workers. Darwin uses 250ms.
+ * Windows GHA at 250ms and 750ms still left `workers_spawned(N)`
+ * `workers_terminated(N-1)` panics under isolate, so Windows keeps 1500ms.
+ * Darwin and Linux use a shorter settle for the balanced-count/epoll reclaim
+ * window seen on Bun 1.3.14.
  */
-const WORKER_OS_JOIN_MS = process.platform === "win32" ? 1_500 : 250;
-
-function needsWorkerOsJoinSettle(): boolean {
-  return process.platform === "win32" || process.platform === "darwin";
+export function storageWorkerOsJoinSettleMs(platform = process.platform): number {
+  if (platform === "win32") return 1_500;
+  if (platform === "darwin" || platform === "linux") return 250;
+  return 0;
 }
 
 /** Invalidate spawn callbacks still waiting on the gate (reset / server drain). */
@@ -181,9 +180,10 @@ export function terminateStorageWorker(worker: Worker, timeoutMs = 5_000): Promi
       // only forces `closed`, it does not prove the OS thread has exited.
       // Callers that catch and continue (e.g. drainAndShutdown) still need
       // that gap before the next isolate reclaim or server.stop.
-      if (needsWorkerOsJoinSettle()) {
+      const settleMs = storageWorkerOsJoinSettleMs();
+      if (settleMs > 0) {
         await Bun.sleep(0);
-        await Bun.sleep(WORKER_OS_JOIN_MS);
+        await Bun.sleep(settleMs);
       }
       if (timedOut) {
         throw new Error(`storage worker did not exit within ${timeoutMs}ms`);

--- a/tests/claude-dotenv-provenance-transport.test.ts
+++ b/tests/claude-dotenv-provenance-transport.test.ts
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
+const PROBE_TIMEOUT_MS = 3_000;
+
 /**
  * Project dotenv can write environment variables before OpenCodex evaluates,
  * but it cannot add the random proof argument emitted by the plain-Node npm
@@ -35,7 +37,13 @@ describe("Node launcher context transport", () => {
     delete env.OCX_PRE_BUN_ANTHROPIC_ENV;
     if (contextEnv === undefined) delete env.OCX_NODE_LAUNCH_CONTEXT;
     else env.OCX_NODE_LAUNCH_CONTEXT = contextEnv;
-    const result = spawnSync(process.execPath, [probe, ...args], { encoding: "utf8", env });
+    const result = spawnSync(process.execPath, [probe, ...args], {
+      encoding: "utf8",
+      env,
+      timeout: PROBE_TIMEOUT_MS,
+      killSignal: "SIGKILL",
+    });
+    if (result.error) throw result.error;
     expect(result.status).toBe(0);
     return JSON.parse(result.stdout) as {
       context: { anthropicEnvSlots: string[] } | null;

--- a/tests/storage-worker-os-join-settle.test.ts
+++ b/tests/storage-worker-os-join-settle.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "bun:test";
+import { storageWorkerOsJoinSettleMs } from "../src/storage/worker-lifecycle";
+
+test("storage worker OS-join settle covers every Bun 1.3.14 isolate platform", () => {
+  expect(storageWorkerOsJoinSettleMs("win32")).toBe(1_500);
+  expect(storageWorkerOsJoinSettleMs("darwin")).toBe(250);
+  expect(storageWorkerOsJoinSettleMs("linux")).toBe(250);
+  expect(storageWorkerOsJoinSettleMs("freebsd")).toBe(0);
+});


### PR DESCRIPTION
## Summary

- extend the storage Worker post-close OS-join settle to Linux, where Bun 1.3.14 is also showing isolate/reclaim failures
- keep the longer 1.5s Windows settle while using a 250ms reclaim window on Linux/macOS
- add a regression test that pins the per-platform settle policy
- bound the synchronous Claude launcher-context probe with a 3s timeout and hard kill so a wedged child cannot consume the entire CI job

## Failure observed

Linux shard `test 3/4` repeatedly fails under Bun 1.3.14 with two linked symptoms:

1. `tests/api-storage-policy-already-running.test.ts` hits an unhandled Bun runtime failure while creating a stream around Worker activity:

```text
error: EEXIST: file already exists, epoll_ctl
at new WriteStream (internal:fs/streams:244:58)
```

Bun then reports test-runner corruption (`Cannot call beforeEach() after the test run has completed`) but continues into later files.

2. Once the corrupted shard reaches `tests/claude-dotenv-provenance-transport.test.ts`, its unbounded `spawnSync()` child can wedge. The log shows `killed 1 dangling process`, followed by no progress until the 15-minute job timeout.

The repository already documents Bun 1.3.14 Worker-reclaim crashes on Ubuntu, but `worker-lifecycle.ts` only applied its post-close OS-join settle on Windows/macOS. This PR closes that Linux gap and independently makes the Claude subprocess fail boundedly instead of hanging the whole shard.

## Test coverage

- new pure regression test covers Windows/macOS/Linux settle values
- existing Claude transport tests continue exercising the real child-process path, now with a bounded subprocess lifetime
- full cross-platform CI should verify whether the repeated Linux `test 3/4` hang is eliminated

## Scope

This is intentionally separate from #1175; it changes only CI/runtime hardening for the pre-existing Bun isolate failure and subprocess hang.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker shutdown timing across Windows, macOS, Linux, and other platforms.
  * Added support for Linux and Bun 1.3.14 behavior during worker termination.

* **Tests**
  * Added coverage for platform-specific shutdown delays.
  * Improved child-process test reliability with probe timeouts and explicit termination handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->