### PR TITLE
fix(windows): grant secret ACLs to effective token SID

### DIFF
--- a/src/lib/windows-secret-acl.ts
+++ b/src/lib/windows-secret-acl.ts
@@ -31,6 +31,10 @@
 
 import { existsSync, statSync } from "node:fs";
 import { env, platform } from "node:process";
+import {
+  resolveCurrentWindowsPrincipal,
+  resolveCurrentWindowsPrincipalAsync,
+} from "./windows-user-principal";
 
 const hardenedDirectories = new Map<string, HardenedIdentity>();
 const hardenedPaths = new Map<string, HardenedIdentity>();
@@ -393,18 +397,23 @@ function icaclsError(step: string, result: IcaclsResult): NodeJS.ErrnoException 
   return err;
 }
 
-/**
- * Return the current Windows username from the environment.
- * Falls back to USERDOMAIN\USERNAME if USERNAME alone is ambiguous.
- * The value is used directly in icacls arguments, so it must be present.
- */
-function currentWindowsUser(): string | undefined {
-  const username = env["USERNAME"];
-  const domain = env["USERDOMAIN"];
-  if (!username) return undefined;
-  // USERDOMAIN is the machine/domain name; USERNAME is the account name.
-  // icacls accepts "DOMAIN\User" or just "User" for local accounts.
-  return domain ? `${domain}\\${username}` : username;
+// POSIX CI deliberately drives the Windows ACL branch through platformOverride.
+// The synthetic SID exists only for that test seam; production Windows always
+// resolves the effective token and never falls back to USERDOMAIN/USERNAME.
+const FORCED_NON_WINDOWS_TEST_PRINCIPAL = "*S-1-5-21-1-2-3-1001";
+
+function currentWindowsPrincipal(deadline: number): string {
+  if (platformOverride === "win32" && platform !== "win32") {
+    return FORCED_NON_WINDOWS_TEST_PRINCIPAL;
+  }
+  return resolveCurrentWindowsPrincipal(deadline - nowFn());
+}
+
+async function currentWindowsPrincipalAsync(deadline: number): Promise<string> {
+  if (platformOverride === "win32" && platform !== "win32") {
+    return FORCED_NON_WINDOWS_TEST_PRINCIPAL;
+  }
+  return resolveCurrentWindowsPrincipalAsync(deadline - nowFn());
 }
 
 /**
@@ -424,10 +433,7 @@ function grantAce(user: string, directory: boolean): string {
 }
 
 function runIcacls(targetPath: string, directory: boolean, deadline: number): void {
-  const user = currentWindowsUser();
-  if (!user) {
-    throw new Error("Cannot determine current Windows user for ACL hardening");
-  }
+  const principal = currentWindowsPrincipal(deadline);
 
   // The deadline is owned by hardenEntry (total budget incl. retry + verification).
   const run = (step: string, args: string[]): IcaclsResult => {
@@ -444,7 +450,7 @@ function runIcacls(targetPath: string, directory: boolean, deadline: number): vo
 
   // Step 1: grant current user full control BEFORE any destructive ACL change.
   // If this fails, inheritance is untouched and the writer keeps inherited access.
-  runOrThrow("/grant:r", [targetPath, "/grant:r", grantAce(user, directory)]);
+  runOrThrow("/grant:r", [targetPath, "/grant:r", grantAce(principal, directory)]);
 
   // Step 2: disable inheritance and remove inherited ACEs. The explicit owner ACE
   // from step 1 survives this transition, so a later failure still leaves cleanup access.
@@ -473,10 +479,7 @@ function runIcacls(targetPath: string, directory: boolean, deadline: number): vo
 
 /** Async counterpart of runIcacls — same step order and timeout/error classification (#612). */
 async function runIcaclsAsync(targetPath: string, directory: boolean, deadline: number): Promise<void> {
-  const user = currentWindowsUser();
-  if (!user) {
-    throw new Error("Cannot determine current Windows user for ACL hardening");
-  }
+  const principal = await currentWindowsPrincipalAsync(deadline);
 
   const run = async (step: string, args: string[]): Promise<IcaclsResult> => {
     const remaining = deadline - nowFn();
@@ -490,7 +493,7 @@ async function runIcaclsAsync(targetPath: string, directory: boolean, deadline: 
     if (!result.success) throw icaclsError(step, result);
   };
 
-  await runOrThrow("/grant:r", [targetPath, "/grant:r", grantAce(user, directory)]);
+  await runOrThrow("/grant:r", [targetPath, "/grant:r", grantAce(principal, directory)]);
   await runOrThrow("/inheritance:r", [targetPath, "/inheritance:r"]);
 
   const removal = await run("/remove:g", [targetPath, "/remove:g", ...BROAD_SIDS]);
@@ -524,6 +527,8 @@ function sanitizeDiagnostics(error: unknown): string {
       return `ACL hardening failed (${code}) — permission denied running icacls`;
     case "EICACLS":
       return "ACL hardening failed (EICACLS) — icacls command error; filesystem may not support per-user NTFS ACLs";
+    case "EACLIDENTITY":
+      return "ACL hardening failed (EACLIDENTITY) — the effective Windows account SID could not be resolved";
     default:
       return `ACL hardening failed${code ? ` (${code})` : ""} — filesystem may not support per-user NTFS ACLs`;
   }

--- a/src/lib/windows-user-principal.ts
+++ b/src/lib/windows-user-principal.ts
@@ -1,0 +1,215 @@
+/**
+ * Resolve the effective Windows token to the locale-independent SID form that
+ * icacls accepts ("*S-1-..."). Environment values such as USERDOMAIN are not
+ * an authority for the current token: on workgroup machines USERDOMAIN may be
+ * the literal WORKGROUP even though the account belongs to the local computer.
+ */
+
+import { resolveTrustedWindowsPowerShellExe } from "./windows-elevation";
+
+const SID_PATTERN = /^S-1-(?:\d+-)+\d+$/i;
+const SID_EXPRESSION =
+  "[System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value";
+
+export interface WindowsPrincipalLookupResult {
+  success: boolean;
+  exitCode: number | null;
+  timedOut: boolean;
+  stdout: string;
+}
+
+export type WindowsPrincipalRunner = (
+  timeoutMs: number,
+) => WindowsPrincipalLookupResult;
+
+export type AsyncWindowsPrincipalRunner = (
+  timeoutMs: number,
+) => Promise<WindowsPrincipalLookupResult>;
+
+const POWERSHELL_ARGS = [
+  "-NoLogo",
+  "-NoProfile",
+  "-NonInteractive",
+  "-WindowStyle",
+  "Hidden",
+  "-Command",
+  SID_EXPRESSION,
+] as const;
+
+function windowsPrincipalPowerShellCommand(): string[] {
+  return [resolveTrustedWindowsPowerShellExe(), ...POWERSHELL_ARGS];
+}
+
+/** Test-only readback of the exact trusted executable and static arguments. */
+export function windowsPrincipalPowerShellCommandForTests(): string[] {
+  return windowsPrincipalPowerShellCommand();
+}
+
+function defaultWindowsPrincipalRunner(timeoutMs: number): WindowsPrincipalLookupResult {
+  const result = Bun.spawnSync(windowsPrincipalPowerShellCommand(), {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "ignore",
+    timeout: Math.max(1, timeoutMs),
+    windowsHide: true,
+  });
+  return {
+    success: result.success,
+    exitCode: result.exitCode,
+    timedOut: result.exitedDueToTimeout ?? false,
+    stdout: result.stdout ? result.stdout.toString() : "",
+  };
+}
+
+async function defaultAsyncWindowsPrincipalRunner(
+  timeoutMs: number,
+): Promise<WindowsPrincipalLookupResult> {
+  const proc = Bun.spawn(windowsPrincipalPowerShellCommand(), {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "ignore",
+    windowsHide: true,
+  });
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    try { proc.kill(); } catch { /* already exited */ }
+  }, Math.max(1, timeoutMs));
+  let exitCode: number | null = null;
+  try {
+    exitCode = await proc.exited;
+  } finally {
+    clearTimeout(timer);
+  }
+  const stdout = proc.stdout
+    ? await new Response(proc.stdout).text().catch(() => "")
+    : "";
+  return {
+    success: !timedOut && exitCode === 0,
+    exitCode: timedOut ? null : exitCode,
+    timedOut,
+    stdout,
+  };
+}
+
+let principalRunner: WindowsPrincipalRunner = defaultWindowsPrincipalRunner;
+let asyncPrincipalRunner: AsyncWindowsPrincipalRunner = defaultAsyncWindowsPrincipalRunner;
+let cachedPrincipal: string | null = null;
+let asyncLookupInFlight: Promise<string> | null = null;
+
+function identityError(reason: string): NodeJS.ErrnoException {
+  const error = new Error(`Windows effective-account SID lookup ${reason}`) as NodeJS.ErrnoException;
+  // Keep identity lookup failures distinct from icacls timeouts. In particular,
+  // they must not populate windows-secret-acl's destination timeout memo.
+  error.code = "EACLIDENTITY";
+  return error;
+}
+
+function principalFromResult(result: WindowsPrincipalLookupResult): string {
+  if (!result.success) {
+    throw identityError(result.timedOut
+      ? "timed out"
+      : `exited ${result.exitCode ?? "null"}`);
+  }
+  const sid = result.stdout.trim();
+  if (!SID_PATTERN.test(sid)) {
+    throw identityError(sid ? "returned an invalid SID" : "returned an empty SID");
+  }
+  return `*${sid.toUpperCase()}`;
+}
+
+/** Resolve and process-cache the effective token SID for synchronous ACL paths. */
+export function resolveCurrentWindowsPrincipal(timeoutMs: number): string {
+  if (cachedPrincipal) return cachedPrincipal;
+  if (timeoutMs <= 0) throw identityError("had no remaining deadline");
+  let result: WindowsPrincipalLookupResult;
+  try {
+    result = principalRunner(timeoutMs);
+  } catch {
+    throw identityError("could not start");
+  }
+  const principal = principalFromResult(result);
+  cachedPrincipal = principal;
+  return principal;
+}
+
+async function waitForExistingLookup(
+  lookup: Promise<string>,
+  timeoutMs: number,
+): Promise<string> {
+  if (timeoutMs <= 0) throw identityError("had no remaining deadline");
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      lookup,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(identityError("timed out while awaiting the shared lookup")),
+          Math.max(1, timeoutMs),
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Async counterpart. Concurrent callers share one owned child lookup; a later
+ * caller may exhaust its own budget without cancelling the lookup owned by the
+ * first caller. The first caller owns that child and its process timeout; a
+ * later, longer budget deliberately does not extend an already-running child.
+ */
+export async function resolveCurrentWindowsPrincipalAsync(timeoutMs: number): Promise<string> {
+  if (cachedPrincipal) return cachedPrincipal;
+  if (asyncLookupInFlight) return waitForExistingLookup(asyncLookupInFlight, timeoutMs);
+  if (timeoutMs <= 0) throw identityError("had no remaining deadline");
+
+  const lookup = (async (): Promise<string> => {
+    let result: WindowsPrincipalLookupResult;
+    try {
+      result = await asyncPrincipalRunner(timeoutMs);
+    } catch {
+      throw identityError("could not start");
+    }
+    const principal = principalFromResult(result);
+    cachedPrincipal = principal;
+    return principal;
+  })();
+  asyncLookupInFlight = lookup;
+  try {
+    return await lookup;
+  } finally {
+    if (asyncLookupInFlight === lookup) asyncLookupInFlight = null;
+  }
+}
+
+/** Test seam: replace the sync resolver process and clear its successful cache. */
+export function setWindowsPrincipalRunnerForTests(
+  runner: WindowsPrincipalRunner | null,
+): void {
+  if (asyncLookupInFlight) {
+    throw new Error("Cannot replace the Windows principal runner while a lookup is in flight.");
+  }
+  principalRunner = runner ?? defaultWindowsPrincipalRunner;
+  cachedPrincipal = null;
+}
+
+/** Test seam: replace the async resolver process and clear its successful cache. */
+export function setAsyncWindowsPrincipalRunnerForTests(
+  runner: AsyncWindowsPrincipalRunner | null,
+): void {
+  if (asyncLookupInFlight) {
+    throw new Error("Cannot replace the Windows principal runner while a lookup is in flight.");
+  }
+  asyncPrincipalRunner = runner ?? defaultAsyncWindowsPrincipalRunner;
+  cachedPrincipal = null;
+}
+
+/** Test seam: clear only process-local principal state. */
+export function resetWindowsPrincipalForTests(): void {
+  if (asyncLookupInFlight) {
+    throw new Error("Cannot reset the Windows principal while a lookup is in flight.");
+  }
+  cachedPrincipal = null;
+}

--- a/tests/windows-secret-acl.test.ts
+++ b/tests/windows-secret-acl.test.ts
@@ -36,6 +36,10 @@ import { atomicWriteFile } from "../src/config";
 import { hardenStableLockFile } from "../src/codex/native-main-lock-file";
 import { nativeMainClaimPath, withNativeMainSharedClaim } from "../src/codex/native-main-claim";
 import { NATIVE_MAIN_OWNER_DB, retainNativeMainOwner } from "../src/codex/native-main-owner";
+import {
+  resetWindowsPrincipalForTests,
+  setWindowsPrincipalRunnerForTests,
+} from "../src/lib/windows-user-principal";
 
 let testDir = "";
 
@@ -113,6 +117,77 @@ describe("hardenSecretPath – required mode (required: true)", () => {
 
     expect(result.ok).toBe(true);
     expect(existsSync(filePath)).toBe(false);
+  });
+});
+
+describe("effective Windows principal integration", () => {
+  test("the owner grant uses a numeric SID even when USERDOMAIN says WORKGROUP", () => {
+    const filePath = join(testDir, "workgroup-secret.json");
+    writeFileSync(filePath, "data", "utf-8");
+    const oldDomain = process.env.USERDOMAIN;
+    const oldUser = process.env.USERNAME;
+    process.env.USERDOMAIN = "WORKGROUP";
+    process.env.USERNAME = "not-authoritative";
+    resetHardenedStateForTests();
+    setPlatformForTests("win32");
+    const seen: string[][] = [];
+    setIcaclsRunnerForTests(args => {
+      seen.push(args);
+      return { success: true, exitCode: 0, timedOut: false, stdout: "" };
+    });
+    try {
+      expect(hardenSecretPath(filePath, { required: true })).toEqual({ ok: true });
+      const grant = seen.find(args => args.includes("/grant:r"));
+      expect(grant).toBeDefined();
+      expect(grant![2]).toMatch(/^\*S-1-(?:\d+-)+\d+:\(F\)$/i);
+      expect(grant![2]).not.toContain("WORKGROUP");
+    } finally {
+      setIcaclsRunnerForTests(null);
+      setPlatformForTests(null);
+      resetHardenedStateForTests();
+      if (oldDomain === undefined) delete process.env.USERDOMAIN;
+      else process.env.USERDOMAIN = oldDomain;
+      if (oldUser === undefined) delete process.env.USERNAME;
+      else process.env.USERNAME = oldUser;
+    }
+  });
+
+  test("identity lookup failure is fail-closed but never memoized as an icacls timeout", () => {
+    if (process.platform !== "win32") return;
+    const requiredPath = join(testDir, "identity-required.json");
+    const optionalPath = join(testDir, "identity-optional.json");
+    writeFileSync(requiredPath, "required", "utf-8");
+    writeFileSync(optionalPath, "optional", "utf-8");
+    let identityCalls = 0;
+    let icaclsCalls = 0;
+    setWindowsPrincipalRunnerForTests(() => {
+      identityCalls += 1;
+      return { success: false, exitCode: null, timedOut: true, stdout: "" };
+    });
+    setIcaclsRunnerForTests(() => {
+      icaclsCalls += 1;
+      return { success: true, exitCode: 0, timedOut: false, stdout: "" };
+    });
+    resetHardenedStateForTests();
+    setPlatformForTests("win32");
+    try {
+      expect(() => hardenSecretPath(requiredPath, { required: true }))
+        .toThrow(/EACLIDENTITY/);
+      expect(hardenSecretPath(optionalPath, { required: false })).toEqual({
+        ok: false,
+        diagnostics:
+          "ACL hardening failed (EACLIDENTITY) — the effective Windows account SID could not be resolved",
+      });
+      expect(identityCalls).toBe(2);
+      expect(icaclsCalls).toBe(0);
+      expect(timedOutSecretPathCountForTests()).toBe(0);
+    } finally {
+      setIcaclsRunnerForTests(null);
+      setPlatformForTests(null);
+      resetHardenedStateForTests();
+      setWindowsPrincipalRunnerForTests(null);
+      resetWindowsPrincipalForTests();
+    }
   });
 });
 

--- a/tests/windows-user-principal.test.ts
+++ b/tests/windows-user-principal.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  resetWindowsPrincipalForTests,
+  resolveCurrentWindowsPrincipal,
+  resolveCurrentWindowsPrincipalAsync,
+  setAsyncWindowsPrincipalRunnerForTests,
+  setWindowsPrincipalRunnerForTests,
+  windowsPrincipalPowerShellCommandForTests,
+} from "../src/lib/windows-user-principal";
+import { setTrustedWindowsElevationExecutablesForTests } from "../src/lib/windows-elevation";
+
+const ok = (stdout = "S-1-5-21-111-222-333-1001\r\n") => ({
+  success: true,
+  exitCode: 0,
+  timedOut: false,
+  stdout,
+});
+
+afterEach(() => {
+  setWindowsPrincipalRunnerForTests(null);
+  setAsyncWindowsPrincipalRunnerForTests(null);
+  setTrustedWindowsElevationExecutablesForTests(null);
+  resetWindowsPrincipalForTests();
+});
+
+describe("Windows effective ACL principal", () => {
+  test("builds a hidden non-interactive command from the trusted PowerShell path", () => {
+    const trusted = "C:\\trusted-system32\\WindowsPowerShell\\v1.0\\powershell.exe";
+    setTrustedWindowsElevationExecutablesForTests({ powershell: trusted });
+    expect(windowsPrincipalPowerShellCommandForTests()).toEqual([
+      trusted,
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-WindowStyle",
+      "Hidden",
+      "-Command",
+      "[System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value",
+    ]);
+  });
+
+  test("the default trusted runner resolves the real token on Windows", () => {
+    if (process.platform !== "win32") return;
+    expect(resolveCurrentWindowsPrincipal(5_000)).toMatch(/^\*S-1-(?:\d+-)+\d+$/i);
+  });
+
+  test("the default trusted async runner settles and resolves the real token on Windows", async () => {
+    if (process.platform !== "win32") return;
+    expect(await resolveCurrentWindowsPrincipalAsync(5_000))
+      .toMatch(/^\*S-1-(?:\d+-)+\d+$/i);
+  });
+
+  test("uses the token SID and normalizes it for icacls, independent of WORKGROUP env", () => {
+    const oldDomain = process.env.USERDOMAIN;
+    const oldUser = process.env.USERNAME;
+    process.env.USERDOMAIN = "WORKGROUP";
+    process.env.USERNAME = "not-the-token-authority";
+    setWindowsPrincipalRunnerForTests(() => ok());
+    try {
+      expect(resolveCurrentWindowsPrincipal(1_000)).toBe("*S-1-5-21-111-222-333-1001");
+    } finally {
+      if (oldDomain === undefined) delete process.env.USERDOMAIN;
+      else process.env.USERDOMAIN = oldDomain;
+      if (oldUser === undefined) delete process.env.USERNAME;
+      else process.env.USERNAME = oldUser;
+    }
+  });
+
+  test("caches only a successful lookup", () => {
+    let calls = 0;
+    setWindowsPrincipalRunnerForTests(() => {
+      calls += 1;
+      return ok();
+    });
+    expect(resolveCurrentWindowsPrincipal(1_000)).toMatch(/^\*S-1-/);
+    expect(resolveCurrentWindowsPrincipal(1_000)).toMatch(/^\*S-1-/);
+    expect(calls).toBe(1);
+  });
+
+  test("invalid output fails closed and is retried rather than cached", () => {
+    let calls = 0;
+    setWindowsPrincipalRunnerForTests(() => {
+      calls += 1;
+      return ok("WORKGROUP\\user\n");
+    });
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        resolveCurrentWindowsPrincipal(1_000);
+        throw new Error("expected identity refusal");
+      } catch (error) {
+        expect((error as NodeJS.ErrnoException).code).toBe("EACLIDENTITY");
+      }
+    }
+    expect(calls).toBe(2);
+  });
+
+  test("a resolver timeout stays EACLIDENTITY rather than entering the icacls timeout class", () => {
+    setWindowsPrincipalRunnerForTests(() => ({
+      success: false,
+      exitCode: null,
+      timedOut: true,
+      stdout: "",
+    }));
+    try {
+      resolveCurrentWindowsPrincipal(1_000);
+      throw new Error("expected identity refusal");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("EACLIDENTITY");
+    }
+  });
+
+  test("concurrent async callers share one owned lookup", async () => {
+    let calls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    setAsyncWindowsPrincipalRunnerForTests(async () => {
+      calls += 1;
+      await gate;
+      return ok();
+    });
+
+    const first = resolveCurrentWindowsPrincipalAsync(2_000);
+    const second = resolveCurrentWindowsPrincipalAsync(2_000);
+    await Bun.sleep(0);
+    expect(calls).toBe(1);
+    release();
+    await expect(first).resolves.toBe("*S-1-5-21-111-222-333-1001");
+    await expect(second).resolves.toBe("*S-1-5-21-111-222-333-1001");
+  });
+});


### PR DESCRIPTION
## Summary

- resolve the effective Windows token SID instead of constructing the ACL owner from `USERDOMAIN\\USERNAME`;
- pass the validated numeric principal to `icacls` as `*S-1-...:(F)`;
- use trusted System32 PowerShell with hidden, non-interactive sync and async runners bounded by the existing ACL deadline;
- process-cache only a successful lookup and keep identity lookup failures separate from `icacls` timeouts;
- add WORKGROUP, failure-propagation, cache, async-deduplication, and real Windows token regression coverage.

Fixes #1149.

## Why

On workgroup Windows hosts, `USERDOMAIN` may be the literal `WORKGROUP` while the effective token belongs to `COMPUTER\\user`. The previous `currentWindowsUser()` therefore asked `icacls` to grant an unmappable `WORKGROUP\\user` principal and received exit code 52. Required ACL hardening then failed closed even though NTFS and the effective account were valid.

The token SID is locale-independent and is already the authority used by the Codex coordinator identity work from #998. This PR extracts a low-level ACL-specific resolver rather than importing the higher-level coordinator module.

This is independent of #1130/#1135: those handle one retry after an ACL timeout; this fixes principal construction before `icacls` can succeed.

## Security boundary

- PowerShell is resolved from the trusted Windows system directory through `GetSystemDirectoryW`; PATH and `SystemRoot` do not select it.
- Both runners use `windowsHide: true`, `-WindowStyle Hidden`, `-NonInteractive`, and `-NoProfile`.
- Only strict `S-1-...` output is accepted; raw output, paths, and account identifiers are not included in diagnostics.
- Lookup failure is `EACLIDENTITY`, not `ETIMEDOUT`, so it cannot poison the destination ACL timeout memo.
- Failed and invalid lookups are not cached. Concurrent async callers share one owned lookup.

## Verification

Post-rebase at `6d04574d`:

- Bun 1.3.14: principal + affected ACL suites **166/166 passed**.
- Bun 1.4.0-canary.1 (`b22e0e6d0`): the same suites **166/166 passed**.
- `tests/server-management-auth.test.ts` exceeded its fixed 5-second per-test cap on this host. The unchanged `dev` baseline reproduced the same six timeouts plus one unrelated unhandled assertion, while this branch had no patch-specific correctness failure. This result is reported as baseline timing instability, not as a pass.
- `bun x tsc --noEmit`: passed on both runtimes.
- `bun scripts/privacy-scan.ts`: passed.
- `git diff --check`: passed.
- Frontend-only lint and doctor gates do not apply because no frontend files changed.
- Independent read-only review found no remaining P0/P1 issue after trusted-executable and identity-failure coverage were added.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No user-facing configuration or command changed.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Draft pending upstream CI and the repository-required human maintainer security review.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows access-control handling by identifying the effective account directly, rather than relying on potentially misleading environment values.
  * Added safer failure handling when account identity cannot be resolved, including clearer diagnostics and prevention of unintended permission changes.
  * Improved consistency and reliability for both synchronous and asynchronous permission operations.

* **Tests**
  * Added coverage for identity resolution, caching, timeouts, invalid results, and concurrent lookups.
  * Added integration tests verifying correct permissions and fail-safe behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->