### PR TITLE
fix(command-code): guard own-property model lookups

### DIFF
--- a/src/adapters/command-code.ts
+++ b/src/adapters/command-code.ts
@@ -21,6 +21,10 @@ const COMMAND_CODE_MODEL_ALIASES: Readonly<Record<string, string>> = {
   "glm-5.2": "zai-org/GLM-5.2",
 };
 
+function canonicalCommandCodeModelId(modelId: string): string {
+  return Object.hasOwn(COMMAND_CODE_MODEL_ALIASES, modelId) ? COMMAND_CODE_MODEL_ALIASES[modelId]! : modelId;
+}
+
 /** Flatten tool-result content for the text-only wire output, keeping an `[image]` marker per image part in content order. */
 function toolResultText(content: string | OcxContentPart[]): string {
   if (typeof content === "string") return content;
@@ -318,7 +322,7 @@ function supportedCommandCodeEffort(provider: OcxProviderConfig, modelId: string
   // Compatibility ids (deepseek-v4-flash / glm-5.2) must resolve to their canonical
   // Command Code id before the effort lookup, or legacy requests silently lose the
   // reasoning effort because the official table is keyed by the canonical ids.
-  const canonicalId = COMMAND_CODE_MODEL_ALIASES[modelId] ?? modelId;
+  const canonicalId = canonicalCommandCodeModelId(modelId);
   const supported = commandCodeReasoningEfforts(canonicalId) ?? configuredReasoningEfforts(provider, canonicalId);
   if (!supported) return undefined;
   // Command Code's official profiles describe xhigh and ultra as the CLI labels that map to
@@ -347,7 +351,7 @@ export function createCommandCodeAdapter(provider: OcxProviderConfig): ProviderA
         config: await commandCodeConfig(cwd), memory: "", taste: null, skills: null,
         permissionMode: "standard", mode: "agent",
         params: {
-          model: COMMAND_CODE_MODEL_ALIASES[parsed.modelId] ?? parsed.modelId,
+          model: canonicalCommandCodeModelId(parsed.modelId),
           messages: wireMessages(parsed.context.messages),
           tools: wireTools(tools),
           system,

--- a/src/providers/command-code-efforts.ts
+++ b/src/providers/command-code-efforts.ts
@@ -31,7 +31,8 @@ function keyFor(modelId: string): string {
 
 export function commandCodeReasoningEfforts(modelId: string): readonly string[] | undefined {
   const key = keyFor(modelId);
-  return refreshedEfforts.get(key) ?? COMMAND_CODE_MODEL_REASONING_EFFORTS[key];
+  return refreshedEfforts.get(key)
+    ?? (Object.hasOwn(COMMAND_CODE_MODEL_REASONING_EFFORTS, key) ? COMMAND_CODE_MODEL_REASONING_EFFORTS[key] : undefined);
 }
 
 function parsedProfileEfforts(page: string): string[] | undefined {
@@ -59,7 +60,9 @@ export async function refreshCommandCodeReasoningEfforts(
   fetchFn: typeof globalThis.fetch = globalThis.fetch,
 ): Promise<readonly string[] | undefined> {
   const key = keyFor(modelId);
-  const profile = COMMAND_CODE_MODEL_EFFORTS[key as keyof typeof COMMAND_CODE_MODEL_EFFORTS];
+  const profile = Object.hasOwn(COMMAND_CODE_MODEL_EFFORTS, key)
+    ? COMMAND_CODE_MODEL_EFFORTS[key as keyof typeof COMMAND_CODE_MODEL_EFFORTS]
+    : undefined;
   if (!profile) return undefined;
   try {
     const response = await fetchFn(profile.profileUrl, {

--- a/tests/command-code-provider.test.ts
+++ b/tests/command-code-provider.test.ts
@@ -214,6 +214,15 @@ describe("Command Code provider", () => {
     expect(JSON.parse(legacy.body).params.reasoning_effort).toBe("high");
   });
 
+  test("treats prototype property names as literal model ids", async () => {
+    for (const modelId of ["__proto__", "constructor", "toString"]) {
+      const built = await builtRequest(parsed(modelId));
+      const params = JSON.parse(built.body).params;
+      expect(params.model).toBe(modelId);
+      expect(params).not.toHaveProperty("reasoning_effort");
+    }
+  });
+
   test("filters tool declarations when tool_choice disables tools", async () => {
     const built = await builtRequest({ ...parsed(), options: { toolChoice: "none" } });
     expect(JSON.parse(built.body).params.tools).toEqual([]);


### PR DESCRIPTION
## Summary

- resolve legacy Command Code model aliases only from own table entries;
- reject inherited object properties when reading static and refreshed reasoning-effort profiles;
- cover `__proto__`, `constructor`, and `toString` as literal provider model IDs.

## Why

These tables are ordinary JavaScript objects. Direct bracket lookup can read properties inherited from `Object.prototype`, so a provider model ID with one of those names may be replaced, treated as a profile object, or throw instead of passing through literally.

The patch keeps the existing tables and compatibility aliases; it only makes the lookup boundary explicit with `Object.hasOwn`.

## Verification

- Bun 1.3.14: `tests/command-code-provider.test.ts` **23/23 passed, 58 assertions**.
- Bun 1.4.0-canary.1 (`5f65d3785`): the same suite **23/23 passed, 58 assertions**.
- `bun x tsc --noEmit`: passed.
- `bun scripts/privacy-scan.ts`: passed.
- `git diff --check`: passed.
- Full-suite boundary: a full-suite attempt on the prior patch-equivalent head assertion-crashed in the unrelated `tests/api-storage-policy-run.test.ts` under Bun 1.3.14. An A-B-A single-file comparison produced branch crash / clean-dev pass / branch pass, so this PR does not claim a green full-suite result.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No user-facing behavior or configuration changed.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when selecting Command Code models by consistently recognizing supported model aliases.
  * Prevented prototype-property names from being mistaken for valid models or receiving unintended reasoning settings.
  * Ensured outbound requests use the correct canonical model identifier.

* **Tests**
  * Added coverage for model IDs that match inherited property names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
