### PR TITLE
test(ci): bind Windows shard assertion to executable command

### DIFF
--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -39,6 +39,15 @@ function count(text: string, fragment: string): number {
   return text.split(fragment).length - 1;
 }
 
+/** Match an executable shell line, not a fragment that could appear in echo or a comment. */
+function hasExactShellCommand(run: string | undefined, expected: string): boolean {
+  return (run ?? "")
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line.length > 0 && !line.startsWith("#"))
+    .includes(expected);
+}
+
 function expectSecureLinuxKeyringBootstrap(workflow: string): void {
   const smokeStep = workflow
     .split("- name: OS keyring create/read/delete smoke")[1]
@@ -164,7 +173,9 @@ describe("GitHub Actions hardening", () => {
     // the runner's disk and the suite passes against a tree that no longer
     // exists in git.
     const winSteps = (ci.jobs?.["platform-windows"] as { steps?: { if?: string; run?: string }[] })?.steps ?? [];
-    expect(winSteps.some(step => step.run?.includes(`--shard=\${{ matrix.shard }}/${windowsShards.length}`))).toBe(true);
+    const windowsTestCommand = `bun test --isolate tests --shard=\${{ matrix.shard }}/${windowsShards.length}`;
+    expect(hasExactShellCommand(`echo ${windowsTestCommand}`, windowsTestCommand)).toBe(false);
+    expect(winSteps.some(step => hasExactShellCommand(step.run, windowsTestCommand))).toBe(true);
     expect(winSteps.some(step => step.if === "runner.environment == 'self-hosted'"
       && step.run?.includes("git clean -xffd"))).toBe(true);
 


### PR DESCRIPTION
## Summary

- require the Windows workflow step to execute the complete sharded root-test command;
- compare normalized shell lines instead of accepting independent substrings;
- prove that an `echo` containing the same text does not satisfy the assertion.

## Why

The existing test pinned only the shard fragment. Requiring both fragments with independent `.includes()` checks still accepts a no-op such as `echo bun test --isolate tests --shard=...`.

This assertion now matches the exact executable command line used by the current workflow and derives the divisor from the parsed Windows shard matrix.

## Verification

- Bun 1.3.14: `tests/ci-workflows.test.ts` **122/122 passed**.
- Bun 1.4.0-canary.1 (`b22e0e6d0`): the same suite **122/122 passed**.
- `bun x tsc --noEmit`: passed.
- `bun scripts/privacy-scan.ts`: passed.
- `git diff --check`: passed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (Test-only contract pin.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of Windows CI workflow commands.
  * Added checks to ensure exact executable commands are detected while ignoring comments and blank lines.
  * Prevented false positives from matching text embedded in `echo` statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->