### PR TITLE
fix(openai-chat): accept SSE data fields without the optional space (#1170)

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -947,8 +947,14 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
       // Yields adapter events and returns "terminate" for a terminal frame ([DONE] / error) that
       // must end the stream, or "continue" otherwise. Mutates the closure's terminal-signal state.
       const handleDataLine = function* (line: string): Generator<AdapterEvent, "continue" | "terminate"> {
-        if (!line.startsWith("data: ")) return "continue";
-        const payload = line.slice(6).trim();
+        // SSE field syntax: the value may begin immediately after the colon; one optional
+        // leading space is stripped when present. Some OpenAI-compatible upstreams emit
+        // `data:{...}` / `data:[DONE]` without that space, and every frame was dropped.
+        if (!line.startsWith("data:")) return "continue";
+        const payload = line.slice(5).trim();
+        // A bare `data:` line carries nothing (heartbeat-style keep-alive on some gateways);
+        // it is not a malformed frame, just nothing to parse.
+        if (payload.length === 0) return "continue";
         if (payload === "[DONE]") {
           yield* flushToolCalls();
           const stopReason = stopReasonFor(finishReason);

--- a/tests/openai-chat-eof.test.ts
+++ b/tests/openai-chat-eof.test.ts
@@ -293,3 +293,49 @@ describe("openai-chat EOF mid tool call (#735)", () => {
     expect(events.at(-1)?.type).toBe("done");
   });
 });
+
+describe("openai-chat SSE data-field framing (#1170)", () => {
+  // The SSE spec strips at most one optional space after the colon, so `data:{...}` is a valid
+  // data field. Some OpenAI-compatible gateways emit that framing; the parser must accept it
+  // exactly like the spaced form.
+  test("unspaced data:{...} frames with a final finish_reason and no [DONE] complete", async () => {
+    const response = new Response([
+      'data:{"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}\n\n',
+      'data:{"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+      'data:{"id":"x","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}\n\n',
+    ].join(""));
+    const events = await collect(createOpenAIChatAdapter(provider).parseStream(response));
+    expect(events.find(e => e.type === "text_delta")).toMatchObject({ type: "text_delta", text: "hi" });
+    expect(events.at(-1)?.type).toBe("done");
+    expect(events.some(e => e.type === "error")).toBe(false);
+  });
+
+  test("unspaced data:[DONE] sentinel terminates the stream", async () => {
+    const response = new Response([
+      'data:{"choices":[{"delta":{"content":"hi"},"finish_reason":"stop"}]}\n\n',
+      "data:[DONE]\n\n",
+    ].join(""));
+    const events = await collect(createOpenAIChatAdapter(provider).parseStream(response));
+    expect(events.at(-1)?.type).toBe("done");
+    expect(events.some(e => e.type === "error")).toBe(false);
+  });
+
+  test("a bare data: line is ignored, not reported as a malformed frame", async () => {
+    const response = new Response([
+      "data:\n\n",
+      'data:{"choices":[{"delta":{"content":"hi"},"finish_reason":"stop"}]}\n\n',
+    ].join(""));
+    const events = await collect(createOpenAIChatAdapter(provider).parseStream(response));
+    expect(events.at(-1)?.type).toBe("done");
+    expect(events.some(e => e.type === "error")).toBe(false);
+  });
+
+  test("unspaced truncated stream with no terminal signal still fails closed", async () => {
+    const response = new Response(
+      'data:{"choices":[{"delta":{"reasoning_content":"thinking..."}}]}\n\n',
+    );
+    const events = await collect(createOpenAIChatAdapter(provider).parseStream(response));
+    expect(events.at(-1)?.type).toBe("error");
+    expect(events.some(e => e.type === "done")).toBe(false);
+  });
+});

--- a/tests/openai-chat-eof.test.ts
+++ b/tests/openai-chat-eof.test.ts
@@ -301,12 +301,15 @@ describe("openai-chat SSE data-field framing (#1170)", () => {
   test("unspaced data:{...} frames with a final finish_reason and no [DONE] complete", async () => {
     const response = new Response([
       'data:{"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}\n\n',
-      'data:{"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+      'data:{"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"length"}]}\n\n',
       'data:{"id":"x","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}\n\n',
     ].join(""));
     const events = await collect(createOpenAIChatAdapter(provider).parseStream(response));
     expect(events.find(e => e.type === "text_delta")).toMatchObject({ type: "text_delta", text: "hi" });
-    expect(events.at(-1)?.type).toBe("done");
+    // "length" maps to stopReason "max_tokens" ("stop" maps to none): the EOF fallback would
+    // emit done WITHOUT a stopReason, so this assertion only passes if the terminal
+    // finish_reason frame was actually parsed.
+    expect(events.at(-1)).toMatchObject({ type: "done", stopReason: "max_tokens" });
     expect(events.some(e => e.type === "error")).toBe(false);
   });
 

--- a/tests/openai-chat-eof.test.ts
+++ b/tests/openai-chat-eof.test.ts
@@ -311,10 +311,9 @@ describe("openai-chat SSE data-field framing (#1170)", () => {
   });
 
   test("unspaced data:[DONE] sentinel terminates the stream", async () => {
-    const response = new Response([
-      'data:{"choices":[{"delta":{"content":"hi"},"finish_reason":"stop"}]}\n\n',
-      "data:[DONE]\n\n",
-    ].join(""));
+    // Sentinel only: a preceding answer frame would let the finish_reason EOF fallback emit
+    // `done` even if unspaced [DONE] handling were broken, so this test must not carry one.
+    const response = new Response("data:[DONE]\n\n");
     const events = await collect(createOpenAIChatAdapter(provider).parseStream(response));
     expect(events.at(-1)?.type).toBe("done");
     expect(events.some(e => e.type === "error")).toBe(false);


### PR DESCRIPTION
## Summary

Closes #1170.

Some OpenAI-compatible gateways emit valid SSE data fields with no space after the colon (`data:{...}`, `data:[DONE]`). The OpenAI Chat stream parser only matched `data: ` (colon + space), so every frame — including the terminal `finish_reason` chunk — was silently dropped, and the turn failed with a false truncation error (`upstream stream ended without a terminal signal`).

Per the [WHATWG SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation), the field value may begin immediately after the colon; one optional leading space is stripped when present.

Change: `handleDataLine` in `src/adapters/openai-chat.ts` now matches the `data:` field name regardless of the following space and trims the payload. A bare `data:` line (heartbeat-style keep-alive on some gateways) carries no payload and is skipped rather than reported as a malformed frame. No other parser behavior changes: spaced framing, `[DONE]`, inline error envelopes, usage accounting, and the fail-closed truncation paths are all untouched.

Regression coverage (`tests/openai-chat-eof.test.ts`, new describe block):

1. Unspaced `data:{...}` frames with a final non-null `finish_reason` and no `[DONE]` complete (the exact framing from the issue report).
2. Unspaced `data:[DONE]` terminates the stream — driven by the sentinel frame alone, so the finish_reason EOF fallback cannot mask broken unspaced `[DONE]` handling (CodeRabbit review finding, addressed).
3. A bare `data:` line is ignored, not reported as a malformed frame.
4. A genuinely truncated unspaced stream (no `[DONE]`, no `finish_reason`, no answer text) still fails closed.

## Verification

- `bun run typecheck` — clean.
- `bun test tests/openai-chat-eof.test.ts` — 28/28 pass (4 new).
- Full `bun run test` on the rebased branch — 9569 tests; the only failing names are 11 `provider management validation` tests plus `two processes at the post-approval management seam serialize instead of interleaving`. The identical set fails on a pristine `origin/dev` worktree (eeae0088) without this change, so they are pre-existing environment-dependent failures unrelated to this PR. `tests/crash-guard.test.ts` timed out once under full-suite load and passes standalone on both this branch and baseline.
- CodeRabbit's one Minor finding (the `[DONE]` test could pass via the EOF fallback) was fixed in the follow-up commit; no other review findings are outstanding.
- Branch is rebased on the latest `dev` (0 commits behind at push time).

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
