### PR TITLE
feat(command-code): enforce ZDR fail-closed and shorten picker labels to cc/

### DIFF
--- a/docs-site/src/content/docs/guides/providers.md
+++ b/docs-site/src/content/docs/guides/providers.md
@@ -321,7 +321,8 @@ the fixed Provider API host, preserves provider-native ids, and caps discovery a
 rows. `ocx login command-code` supports OAuth via browser sign-in (with optional local CLI credential
 import from `~/.commandcode/auth.json` for existing Command Code CLI users); the model catalog is
 account-scoped and comes from the authenticated discovery endpoint after login. Chat requests use the
-configured Bearer key. Create keys at
+configured Bearer key and always send `x-cmd-zdr: 1`. If the selected model has no ZDR-capable
+upstream, the resulting `422 cmd_zdr_no_providers` is returned without a non-ZDR retry. Create keys at
 [Command Code Studio](https://commandcode.ai/studio/).
 
 **SambaNova Cloud discovery.** The preset reads SambaNova Cloud's public `/v1/models` list from the fixed API

--- a/docs-site/src/content/docs/ko/guides/providers.md
+++ b/docs-site/src/content/docs/ko/guides/providers.md
@@ -240,7 +240,9 @@ Nscale service token은 [Nscale Console](https://console.nscale.com)에서 만�
 256개로 제한합니다. `ocx login command-code`는 브라우저 OAuth 로그인을 지원하며(기존 Command Code
 CLI 사용자는 `~/.commandcode/auth.json`의 로컬 CLI 자격 증명을 가져올 수 있음), 모델 카탈로그는
 계정 단위이며 로그인 후 인증된 discovery 엔드포인트에서 가져옵니다. 채팅 요청은 설정된 bearer
-키를 사용합니다. 키는 [Command Code Studio](https://commandcode.ai/studio/)에서 생성합니다.
+키와 `x-cmd-zdr: 1`을 항상 사용합니다. 선택한 모델에 ZDR 가능한 upstream이 없으면
+`422 cmd_zdr_no_providers`를 비-ZDR 재시도 없이 반환합니다. 키는
+[Command Code Studio](https://commandcode.ai/studio/)에서 생성합니다.
 
 **SambaNova Cloud 검색:** 프리셋은 고정 API 호스트의 SambaNova Cloud 공개 `/v1/models` 목록을 읽고, 프로바이더
 네이티브 ID를 보존하며 discovery를 128 KiB와 raw 행 128개로 제한합니다. 카탈로그에는 인증이 필요하지 않으므로

--- a/gui/src/provider-icons.ts
+++ b/gui/src/provider-icons.ts
@@ -150,21 +150,20 @@ export function isCatalogProviderId(provider: string): boolean {
   return CATALOG_PROVIDER_IDS.has(provider.toLowerCase());
 }
 
-/** Distinguishable lowercase-dash slug for a provider id (command-code -> commandcode-auth). */
+/** Display-only slug for a provider id. Command Code's two ids share the short `cc` label. */
 export function providerDisplaySlug(provider: string): string {
-  if (provider === "command-code") return "commandcode-auth";
-  if (provider === "commandcode") return "commandcode-api";
+  if (provider === "command-code" || provider === "commandcode") return "cc";
   return provider;
 }
 
 /**
  * Rewrite a `provider/model` route to a clearly distinguishable slug. Command Code's two
- * config ids differ by a single dash (`command-code` vs `commandcode`), so relabel them to
- * `commandcode-auth/...` and `commandcode-api/...` — the same lowercase-dash style the
- * opencode presets use (`opencode-free/mimo-v2.5`, `opencode-go/hy3`). Also collapse a
- * redundant `<provider>-<model>` prefix when the model id itself repeats the family
- * (`command-code/deepseek-deepseek-v4-flash` -> `commandcode-auth/deepseek-v4-flash`).
- * Every other provider keeps the raw route exactly as before.
+ * config ids differ by a single dash (`command-code` vs `commandcode`), and the full
+ * `commandcode-auth/...` / `commandcode-api/...` labels are long enough to truncate in the
+ * UI, so both are shortened to a display-only `cc/...` label. Also collapse a redundant
+ * `<provider>-<model>` prefix when the model id itself repeats the family
+ * (`command-code/deepseek-deepseek-v4-flash` -> `cc/deepseek-v4-flash`). Every other
+ * provider keeps the raw route exactly as before.
  */
 export function formatNamespacedModelId(namespaced: string, _t: TFn): string {
   const slash = namespaced.indexOf("/");
@@ -176,7 +175,7 @@ export function formatNamespacedModelId(namespaced: string, _t: TFn): string {
     // encoded as `<vendor>-<model>`; drop the duplicated `<vendor>-` prefix for display.
     const m = model.match(/^([a-z0-9]+)-([a-z0-9]+(?:-[a-z0-9]+)+)$/i);
     if (m && model.startsWith(`${m[1]}-${m[1]}-`)) model = model.slice(m[1]!.length + 1);
-    return `${provider === "command-code" ? "commandcode-auth" : "commandcode-api"}/${model}`;
+    return `cc/${model}`;
   }
   return namespaced;
 }

--- a/src/adapters/command-code.ts
+++ b/src/adapters/command-code.ts
@@ -21,6 +21,11 @@ const COMMAND_CODE_MODEL_ALIASES: Readonly<Record<string, string>> = {
   "glm-5.2": "zai-org/GLM-5.2",
 };
 
+/** Command Code privacy contract: every generation must use a ZDR-capable upstream or fail closed. */
+const COMMAND_CODE_ZDR_HEADER = "x-cmd-zdr";
+const COMMAND_CODE_ZDR_VALUE = "1";
+const COMMAND_CODE_ZDR_ERROR_CODE = "cmd_zdr_no_providers";
+
 /** Flatten tool-result content for the text-only wire output, keeping an `[image]` marker per image part in content order. */
 function toolResultText(content: string | OcxContentPart[]): string {
   if (typeof content === "string") return content;
@@ -285,6 +290,10 @@ function isReasoningEffortRejection(status: number, payload: string): boolean {
   return (status === 400 || status === 422) && /reasoning[_ -]?effort|unsupported effort|invalid effort/i.test(payload);
 }
 
+function isZdrUnavailableResponse(status: number, payload: string): boolean {
+  return status === 422 && payload.includes(COMMAND_CODE_ZDR_ERROR_CODE);
+}
+
 function requestWithoutReasoningEffort(request: AdapterRequest): AdapterRequest | undefined {
   try {
     const body = JSON.parse(request.body) as { params?: Record<string, unknown> };
@@ -367,6 +376,9 @@ export function createCommandCodeAdapter(provider: OcxProviderConfig): ProviderA
         "x-cli-environment": "production",
         "x-taste-learning": "false",
         "x-co-flag": "false",
+        // This is intentionally not configurable. Command Code must never receive a
+        // generation from this adapter unless its selected upstream guarantees ZDR.
+        [COMMAND_CODE_ZDR_HEADER]: COMMAND_CODE_ZDR_VALUE,
         "x-session-id": randomUUID(),
       };
       if (cwd) headers["x-project-slug"] = projectSlug(cwd);
@@ -390,6 +402,9 @@ export function createCommandCodeAdapter(provider: OcxProviderConfig): ProviderA
         if (!observed.displaySafe) return response;
         body = observed.text;
       } catch { return response; }
+      // A ZDR-capability failure is final. Check it before the compatibility retry so
+      // even an upstream message mentioning reasoning effort cannot trigger another call.
+      if (isZdrUnavailableResponse(response.status, body)) return response;
       if (!isReasoningEffortRejection(response.status, body)) return response;
       const modelId = (() => {
         try { return (JSON.parse(request.body) as { params?: { model?: unknown } }).params?.model; } catch { return undefined; }

--- a/src/codex/catalog/sync.ts
+++ b/src/codex/catalog/sync.ts
@@ -202,10 +202,11 @@ export function isExactComboCatalogModel(
 
 /**
  * Friendly Codex-picker label for a routed `provider/model` slug. Command Code's two config
- * ids differ by a single dash (`command-code` vs `commandcode`), so relabel them to the
- * lowercase-dash style the opencode presets use: `commandcode-auth/x` and `commandcode-api/x`.
- * The model-id portion also carries a redundant `<vendor>-` prefix (`deepseek-deepseek-v4-flash`)
- * that is dropped for display. All other providers keep the raw slug exactly as before.
+ * ids differ by a single dash (`command-code` vs `commandcode`), and the full
+ * `commandcode-auth/x` / `commandcode-api/x` labels are long enough to truncate in the
+ * picker, so both are shortened to a display-only `cc/x` label. The model-id portion also
+ * carries a redundant `<vendor>-` prefix (`deepseek-deepseek-v4-flash`) that is dropped for
+ * display. All other providers keep the raw slug exactly as before.
  */
 function routedDisplayName(slug: string): string {
   const slash = slug.indexOf("/");
@@ -215,7 +216,7 @@ function routedDisplayName(slug: string): string {
   if (provider === "command-code" || provider === "commandcode") {
     const m = model.match(/^([a-z0-9]+)-([a-z0-9]+(?:-[a-z0-9]+)+)$/i);
     if (m && model.startsWith(`${m[1]}-${m[1]}-`)) model = model.slice(m[1]!.length + 1);
-    return `${provider === "command-code" ? "commandcode-auth" : "commandcode-api"}/${model}`;
+    return `cc/${model}`;
   }
   return slug;
 }

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -756,9 +756,9 @@ describe("configured CatalogModel displayName -> catalog display_name", () => {
     const api = entries.find(e => e.slug === "commandcode/deepseek-deepseek-v4-pro");
 
     // Display-only relabel + redundant vendor-prefix drop: routing slugs stay untouched.
-    expect(auth?.display_name).toBe("commandcode-auth/deepseek-v4-flash");
+    expect(auth?.display_name).toBe("cc/deepseek-v4-flash");
     expect(auth?.slug).toBe("command-code/deepseek-deepseek-v4-flash");
-    expect(api?.display_name).toBe("commandcode-api/deepseek-v4-pro");
+    expect(api?.display_name).toBe("cc/deepseek-v4-pro");
     expect(api?.slug).toBe("commandcode/deepseek-deepseek-v4-pro");
   });
 

--- a/tests/command-code-provider.test.ts
+++ b/tests/command-code-provider.test.ts
@@ -145,6 +145,7 @@ describe("Command Code provider", () => {
     const body = JSON.parse(built.body);
     expect(built.url).toBe("https://api.commandcode.ai/alpha/generate");
     expect(built.headers.Authorization).toBe("Bearer secret-command-key");
+    expect(built.headers["x-cmd-zdr"]).toBe("1");
     expect(body.params).toMatchObject({ model: "deepseek/deepseek-v4-flash", reasoning_effort: "high", max_tokens: 100, stream: true });
     expect(body.params.tools[0]).toMatchObject({ name: "lookup" });
     expect(built.body).not.toContain("secret-command-key");
@@ -234,10 +235,14 @@ describe("Command Code provider", () => {
   });
 
   test("refreshes a stale official effort record only after a reasoning rejection and retries without it", async () => {
-    const requests: Array<{ url: string; body?: string }> = [];
+    const requests: Array<{ url: string; body?: string; zdr?: string }> = [];
     const fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       const href = String(url);
-      requests.push({ url: href, body: typeof init?.body === "string" ? init.body : undefined });
+      requests.push({
+        url: href,
+        body: typeof init?.body === "string" ? init.body : undefined,
+        zdr: new Headers(init?.headers).get("x-cmd-zdr") ?? undefined,
+      });
       if (href.includes("commandcode.ai/models/")) {
         return new Response("Reasoning efforts high are supported; no other reasoning settings.");
       }
@@ -252,6 +257,28 @@ describe("Command Code provider", () => {
     expect(commandCodeReasoningEfforts("deepseek/deepseek-v4-flash")).toEqual(["high"]);
     const generated = requests.filter(request => request.url.endsWith("/alpha/generate"));
     expect(JSON.parse(generated[1]!.body!).params).not.toHaveProperty("reasoning_effort");
+    expect(generated.map(request => request.zdr)).toEqual(["1", "1"]);
+  });
+
+  test("fails closed on a ZDR-capability 422 without retrying or consuming its body", async () => {
+    const upstreamBody = JSON.stringify({
+      error: {
+        code: "cmd_zdr_no_providers",
+        message: "No ZDR-capable providers available; invalid reasoning_effort cannot be served",
+      },
+    });
+    let calls = 0;
+    const fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      calls += 1;
+      expect(new Headers(init?.headers).get("x-cmd-zdr")).toBe("1");
+      return new Response(upstreamBody, { status: 422 });
+    }) as typeof globalThis.fetch;
+    const adapter = createCommandCodeAdapter({ ...provider, fetch } as OcxProviderConfig);
+    const request = await adapter.buildRequest(parsed());
+    const response = await adapter.fetchResponse!(request);
+    expect(calls).toBe(1);
+    expect(response.status).toBe(422);
+    expect(await response.text()).toBe(upstreamBody);
   });
 
   test("omits effort when the caller did not choose one", async () => {

--- a/tests/provider-workspace-data.test.ts
+++ b/tests/provider-workspace-data.test.ts
@@ -459,12 +459,12 @@ describe("provider-icons", () => {
   });
 
   test("namespaced model ids rewrite the Command Code provider prefix to a distinguishable slug", () => {
-    expect(formatNamespacedModelId("command-code/deepseek-v4-flash", englishT)).toBe("commandcode-auth/deepseek-v4-flash");
-    expect(formatNamespacedModelId("commandcode/deepseek-v4-flash", englishT)).toBe("commandcode-api/deepseek-v4-flash");
+    expect(formatNamespacedModelId("command-code/deepseek-v4-flash", englishT)).toBe("cc/deepseek-v4-flash");
+    expect(formatNamespacedModelId("commandcode/deepseek-v4-flash", englishT)).toBe("cc/deepseek-v4-flash");
     // Redundant vendor prefix in the encoded model id is dropped for display.
-    expect(formatNamespacedModelId("command-code/deepseek-deepseek-v4-flash", englishT)).toBe("commandcode-auth/deepseek-v4-flash");
-    expect(formatNamespacedModelId("commandcode/deepseek-deepseek-v4-pro", englishT)).toBe("commandcode-api/deepseek-v4-pro");
-    expect(formatNamespacedModelId("command-code/claude-fable-5", englishT)).toBe("commandcode-auth/claude-fable-5");
+    expect(formatNamespacedModelId("command-code/deepseek-deepseek-v4-flash", englishT)).toBe("cc/deepseek-v4-flash");
+    expect(formatNamespacedModelId("commandcode/deepseek-deepseek-v4-pro", englishT)).toBe("cc/deepseek-v4-pro");
+    expect(formatNamespacedModelId("command-code/claude-fable-5", englishT)).toBe("cc/claude-fable-5");
     // Other providers keep the raw route untouched.
     expect(formatNamespacedModelId("openai/gpt-5.5", englishT)).toBe("openai/gpt-5.5");
     expect(formatNamespacedModelId("my-custom/thing", englishT)).toBe("my-custom/thing");


### PR DESCRIPTION
## Summary

Two related changes for the Command Code provider:

1. **Enforce ZDR fail-closed on every generation.** The `command-code` adapter now always
   sends `x-cmd-zdr: 1` on `/alpha/generate` and treats a `422 cmd_zdr_no_providers`
   response as final: no non-ZDR retry, no reasoning-effort retry, no fallback. The header
   is intentionally not configurable. Documented in the en/ko provider guides and pinned
   with adapter tests (including a test that a ZDR-capability 422 is returned untouched
   after exactly one upstream call).

2. **Shorten Command Code picker labels to `cc/` (display-only).** The full
   `commandcode-auth/x` / `commandcode-api/x` labels truncate in the Codex model picker.
   Both Command Code config ids are relabeled to a display-only `cc/x` prefix in the
   catalog `display_name` and the dashboard model formatter. Routing slugs
   (`command-code/...`, `commandcode/...`) are untouched, so routing behavior is
   unchanged.

## Verification

- `bun run typecheck` — clean.
- `bun run test` — 9091 pass / 1 fail; the single failure
  (`native main profile scoped server admission`) is a timing-sensitive flake unrelated to
  this change and passes in isolation (`tests/native-profile-drain-server.test.ts`).
- Targeted `tests/codex-catalog.test.ts` + `tests/provider-workspace-data.test.ts` —
  167 pass.
- Catalog regenerated locally; Command Code entries now carry
  `display_name: "cc/<model>"` while slugs stay `command-code/<model>`.

UI impact is display-only label shortening (picker row text). No layout or interaction
changes; a picker screenshot will be attached once the app is restarted with the new
catalog.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (en/ko provider guides).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults
  (ZDR enforcement is fail-closed and non-configurable).

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
