### PR TITLE
fix(ci): isolate storage policy tests from Linux shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,9 +206,12 @@ jobs:
   # The suite, split by file across four Linux runners.
   #
   # `bun test --shard=i/N` sorts test files by path and deals them round-robin,
-  # so the split is deterministic: shard 3 of 4 covers the same files on every
-  # run, and the four shards together cover the suite exactly once. Measured on
-  # this suite: 120 files per shard, union 480, no file in two shards.
+  # so the split is deterministic for the files that remain in this lane.
+  # Storage-policy API tests are deliberately excluded here and run in the
+  # dedicated `storage-policy` job below. Bun 1.3.14 can corrupt the Linux
+  # isolate/epoll state around that Worker-heavy harness; keeping it out of the
+  # general shards prevents one runtime failure from wedging ~150 unrelated
+  # files while preserving the same coverage in a fresh Bun process.
   #
   # Only the suite lives here. Typecheck, lint, build, and the scans run once in
   # `gates` rather than four times — they are fixed cost, and paying it per shard
@@ -261,7 +264,45 @@ jobs:
           bun run build
 
       - name: Test
-        run: bun test --isolate tests --shard=${{ matrix.shard }}/4
+        run: bun test --isolate tests --path-ignore-patterns 'tests/api-storage-policy*.test.ts' --shard=${{ matrix.shard }}/4
+
+  # Bun 1.3.14 has shown a Linux isolate/epoll race around the storage-policy
+  # harness. Keep the entire five-file family in one fresh process so a runtime
+  # failure is bounded to this job instead of poisoning a general test shard.
+  storage-policy:
+    name: storage policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: |
+          bun install --frozen-lockfile
+          cd gui
+          bun install --frozen-lockfile
+
+      - name: Build GUI
+        run: |
+          cd gui
+          bun run build
+
+      - name: Test storage policy API
+        run: |
+          bun test --isolate \
+            ./tests/api-storage-policy-already-running.test.ts \
+            ./tests/api-storage-policy-mutation-busy.test.ts \
+            ./tests/api-storage-policy-put-race.test.ts \
+            ./tests/api-storage-policy-run.test.ts \
+            ./tests/api-storage-policy.test.ts
 
   # Everything that is not the suite: type safety, privacy, lint, build, smoke.
   # One runner, once per push. Splitting these across the shards would repeat a
@@ -332,7 +373,7 @@ jobs:
   platform-macos:
     name: macos
     runs-on: macos-latest
-    # The unsharded control for the sharded lanes: the only place the whole
+    # The unsharded control for the sharded Linux lane: the only place the whole
     # suite runs in one pool, so it is the place that catches what sharding
     # hides. The flakes it keeps surfacing are timing, not logic, and the fix
     # is the tests, not a fourth lane.
@@ -592,7 +633,7 @@ jobs:
     # direct dependencies only, so a failing `select-windows-runner` would
     # otherwise reach this gate as nothing at all while its dependents report
     # `skipped` — which the gate is required to read as a deliberate skip.
-    needs: [changes, select-windows-runner, test, gates, platform-macos, platform-windows, keyring-smoke, npm-global-smoke]
+    needs: [changes, select-windows-runner, test, storage-policy, gates, platform-macos, platform-windows, keyring-smoke, npm-global-smoke]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/tests/zz-ci-storage-policy-isolation.test.ts
+++ b/tests/zz-ci-storage-policy-isolation.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test";
+
+type Step = {
+  name?: string;
+  run?: string;
+};
+
+type Job = {
+  "runs-on"?: string;
+  "timeout-minutes"?: number;
+  needs?: string[];
+  steps?: Step[];
+};
+
+test("Linux shards isolate the storage-policy API family into its own gated job", async () => {
+  const text = await Bun.file(
+    new URL("../.github/workflows/ci.yml", import.meta.url),
+  ).text();
+  const workflow = Bun.YAML.parse(text) as {
+    jobs?: Record<string, Job>;
+  };
+
+  const shardRun = workflow.jobs?.test?.steps?.find(step => step.name === "Test")?.run ?? "";
+  expect(shardRun).toContain(
+    "--path-ignore-patterns 'tests/api-storage-policy*.test.ts'",
+  );
+
+  const storageJob = workflow.jobs?.["storage-policy"];
+  expect(storageJob?.["runs-on"]).toBe("ubuntu-latest");
+  expect(storageJob?.["timeout-minutes"]).toBe(5);
+
+  const storageRun = storageJob?.steps?.find(
+    step => step.name === "Test storage policy API",
+  )?.run ?? "";
+  const dedicatedFiles = [
+    "tests/api-storage-policy-already-running.test.ts",
+    "tests/api-storage-policy-mutation-busy.test.ts",
+    "tests/api-storage-policy-put-race.test.ts",
+    "tests/api-storage-policy-run.test.ts",
+    "tests/api-storage-policy.test.ts",
+  ];
+
+  for (const file of dedicatedFiles) {
+    expect(storageRun).toContain(`./${file}`);
+  }
+  expect(storageRun).not.toContain("--shard");
+
+  expect(workflow.jobs?.ci?.needs).toContain("storage-policy");
+});

--- a/tests/zz-ci-storage-policy-isolation.test.ts
+++ b/tests/zz-ci-storage-policy-isolation.test.ts
@@ -40,9 +40,15 @@ test("Linux shards isolate the storage-policy API family into its own gated job"
     "tests/api-storage-policy.test.ts",
   ];
 
-  for (const file of dedicatedFiles) {
-    expect(storageRun).toContain(`./${file}`);
-  }
+  // Extract all test file paths from the run command
+  const testPathPattern = /\.\/tests\/[a-z0-9-]+\.test\.ts/g;
+  const actualFiles = (storageRun.match(testPathPattern) || [])
+    .map(path => path.slice(2)) // Remove leading "./"
+    .sort();
+
+  const expectedFiles = [...dedicatedFiles].sort();
+  expect(actualFiles).toEqual(expectedFiles);
+
   expect(storageRun).not.toContain("--shard");
 
   expect(workflow.jobs?.ci?.needs).toContain("storage-policy");


### PR DESCRIPTION
## Summary

- exclude the five `api-storage-policy*` suites from the general four-way Linux `bun test --isolate` shards
- run that entire storage-policy family in a dedicated Ubuntu job with a fresh Bun 1.3.14 process and a 5-minute job bound
- make the aggregate `ci` check depend on the dedicated storage-policy job, so its failure can never be hidden behind a green aggregate check
- add a structural regression test that pins the quarantine pattern, exact dedicated file set, unsharded execution, timeout, runner, and aggregate-gate dependency
- leave the macOS full-suite control and dispatch-only Windows shards unchanged

## Why

Linux shard 3 has repeatedly hit Bun 1.3.14 runtime corruption around the storage-policy boundary:

```text
error: EEXIST: file already exists, epoll_ctl
at new WriteStream (internal:fs/streams:244:58)
```

After that unhandled runtime error Bun reports follow-on lifecycle errors such as `Cannot call beforeEach() after the test run has completed`, continues running in a corrupted state, and can then stop making progress until GitHub Actions kills the 15-minute shard.

The same `dev` suite can pass on another run, so this is not a deterministic product-test failure. It is an isolate/runtime race whose blast radius is currently an entire ~150-file shard.

The storage-policy tests are already structured as a coherent Bun-isolation family: the Worker-spawning cases are split one-per-file, with the non-Worker GET/PUT companion beside them. This PR keeps that family together in a clean process instead of allowing a Bun runtime failure there to poison unrelated tests.

## Behavior after this change

General Linux shards run:

```text
bun test --isolate tests --path-ignore-patterns 'tests/api-storage-policy*.test.ts' --shard=N/4
```

The dedicated job separately runs these exact files without sharding:

- `tests/api-storage-policy-already-running.test.ts`
- `tests/api-storage-policy-mutation-busy.test.ts`
- `tests/api-storage-policy-put-race.test.ts`
- `tests/api-storage-policy-run.test.ts`
- `tests/api-storage-policy.test.ts`

If Bun still wedges on that harness, the failure is isolated to a 5-minute job instead of consuming and corrupting a general 15-minute shard.

## Scope

This is intentionally separate from #1179. That PR hardens Worker reclaim and bounds the later Claude probe child process; this PR contains the remaining nondeterministic Bun isolate failure at the CI topology level rather than adding more sleeps or increasing timeouts.

## Validation

- branch rebased onto latest `dev` before PR creation
- structural regression test pins the dedicated lane and aggregate gate
- full Cross-platform CI is the runtime verification for whether shard 3 remains healthy while the storage-policy family runs independently


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Added a dedicated storage-policy test job with its own setup and isolated execution.
  * Updated Linux test sharding to prevent storage-policy tests from running in parallel.
  * The overall CI check now requires the dedicated storage-policy job to pass.
  * Added automated validation to ensure the workflow maintains this test isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->