### PR TITLE
fix(sse): treat a data frame that parses to a non-record as malformed (#1219)

### DIFF
--- a/src/adapters/anthropic.ts
+++ b/src/adapters/anthropic.ts
@@ -984,13 +984,21 @@ export function createAnthropicAdapter(provider: OcxProviderConfig, cacheRetenti
         const payload = record.data.trim();
         if (!payload) continue;
 
-        let data: Record<string, unknown>;
+        let parsed: unknown;
         try {
-          data = JSON.parse(payload) as Record<string, unknown>;
+          parsed = JSON.parse(payload);
         } catch {
           debugDroppedFrame("anthropic", payload);
           continue;
         }
+        // `JSON.parse("null")` returns null instead of throwing, so the catch above cannot cover
+        // it and the `data.type` read below crashed the stream. Drop a non-record frame the same
+        // way an unparseable one is dropped, so the message_stop check still governs the outcome.
+        if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+          debugDroppedFrame("anthropic", payload);
+          continue;
+        }
+        const data = parsed as Record<string, unknown>;
 
         switch (record.event || data.type) {
               case "message_start": {

--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -497,13 +497,23 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
         }
         let emittedContentEvent = false;
 
-        let chunk: Record<string, unknown>;
+        let parsed: unknown;
         try {
-          chunk = JSON.parse(payload);
+          parsed = JSON.parse(payload);
         } catch {
           yield { type: "error", message: "malformed upstream SSE data frame" };
           return "terminate";
         }
+        // `JSON.parse("null")` returns null rather than throwing, so the catch above cannot cover
+        // it and the `chunk.error` read below crashed the stream (see openai-chat.ts). Skip such a
+        // frame rather than terminating, for the reason given there: it is padding between real
+        // frames, not a broken stream. Deliberately returns BEFORE `sawAnyFrame`, so a stream made
+        // only of non-record frames still fails the terminal-signal check below instead of
+        // completing empty. An unparseable frame stays terminal.
+        if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+          return "continue";
+        }
+        const chunk = parsed as Record<string, unknown>;
         sawAnyFrame = true;
 
         // Inline provider error inside a 200 stream → terminal error (see openai-chat.ts).

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -958,13 +958,27 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
           return "terminate";
         }
 
-        let chunk: Record<string, unknown>;
+        let parsed: unknown;
         try {
-          chunk = JSON.parse(payload) as Record<string, unknown>;
+          parsed = JSON.parse(payload);
         } catch {
           yield { type: "error", message: "malformed upstream SSE data frame" };
           return "terminate";
         }
+        // Validate the shape instead of asserting it. `JSON.parse` yields a value, not necessarily
+        // an object — `JSON.parse("null")` returns null without throwing, so the catch above never
+        // sees it and the `chunk.error` read below crashed the stream mid-flight.
+        //
+        // Skip rather than terminate: `data: null` is emitted as a benign padding frame BETWEEN
+        // content deltas by real OpenAI-compatible routes (issue #1219), so failing here would
+        // discard the finish_reason chunk and [DONE] still in flight and turn a healthy response
+        // into a failed turn. Skipping cannot mask a genuinely broken stream — a stream carrying
+        // only such frames still sets neither finishReason nor sawUserFacingOutput and so trips
+        // the EOF truncation guard below. An unparseable frame stays terminal.
+        if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+          return "continue";
+        }
+        const chunk = parsed as Record<string, unknown>;
 
         // A 200/OK chat-completions stream may carry an inline provider error envelope
         // instead of a clean [DONE]. Surface it as a terminal error so the bridge emits a

--- a/src/web-search/parse.ts
+++ b/src/web-search/parse.ts
@@ -155,11 +155,23 @@ export async function parseSidecarSSE(response: Response): Promise<WebSearchResu
 
   const handle = (payload: string): void => {
     if (!payload || payload === "[DONE]") return;
-    let data: Record<string, unknown>;
-    try { data = JSON.parse(payload) as Record<string, unknown>; } catch {
-      console.warn(`[web-search-parse] malformed SSE JSON (${payload.length} chars): ${payload.slice(0, 120)}`);
+    // Neither warning below copies the frame's content. An upstream SSE payload can carry model
+    // output or credential material, and a malformed frame is exactly the case where the content
+    // is least trustworthy. Length plus a classification separates the two failure modes in a log
+    // without reproducing anything from the wire.
+    let parsed: unknown;
+    try { parsed = JSON.parse(payload); } catch {
+      console.warn(`[web-search-parse] malformed SSE JSON (${payload.length} chars)`);
       return;
     }
+    // `JSON.parse("null")` returns null rather than throwing, so the catch above cannot cover it
+    // and the `data.type` read below threw out of parseSidecarSSE.
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      const shape = Array.isArray(parsed) ? "array" : parsed === null ? "null" : typeof parsed;
+      console.warn(`[web-search-parse] non-record SSE JSON frame (${payload.length} chars, ${shape})`);
+      return;
+    }
+    const data = parsed as Record<string, unknown>;
     const type = data.type as string | undefined;
     if (type === "response.output_text.delta" && typeof data.delta === "string") {
       acc.deltaText += data.delta;

--- a/tests/sse-null-data-frame.test.ts
+++ b/tests/sse-null-data-frame.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { createAnthropicAdapter as createAnthropicAdapterProduction } from "../src/adapters/anthropic";
+import { createGoogleAdapter as createGoogleAdapterProduction } from "../src/adapters/google";
+import { createOpenAIChatAdapter as createOpenAIChatAdapterProduction } from "../src/adapters/openai-chat";
+import type { AdapterEvent, OcxProviderConfig } from "../src/types";
+import { parseSidecarSSE } from "../src/web-search/parse";
+import { withTestTranslatorBudget } from "./helpers/translator-budget";
+
+// `JSON.parse` returns a value, not necessarily an object: `JSON.parse("null")` is `null` and
+// never throws, so a `try/catch` around the parse cannot see it. Every payload below is
+// syntactically valid JSON that does NOT deserialize to a record, which is the input class that
+// walked past the malformed-frame guard and reached a property access on the parse result.
+//
+// Only `null` actually crashed — property access on a number, string, boolean or array is legal
+// in JS and quietly yields `undefined`, so those frames were silently accepted as empty ones.
+// Both are wrong for the same reason, so they are asserted together.
+const NON_RECORD_PAYLOADS = ["null", "42", '"text"', "true", "[]"] as const;
+
+// The syntactically-invalid control. It was already handled correctly before this fix; every
+// assertion below is written as parity against it so the test states the actual requirement —
+// a valid-JSON non-record frame is treated exactly like an unparseable one — rather than
+// re-encoding each adapter's terminal message and drifting when those messages change.
+const INVALID_JSON_PAYLOAD = "{not json}";
+
+// A token distinctive enough that finding it anywhere in a log line proves the frame's content
+// was copied there. Used by the web-search warning-hygiene tests below.
+const MARKER = "ocx-marker-4f21b7a9-do-not-log";
+
+const createOpenAIChatAdapter = (...args: Parameters<typeof createOpenAIChatAdapterProduction>) =>
+  withTestTranslatorBudget(createOpenAIChatAdapterProduction(...args));
+const createGoogleAdapter = (...args: Parameters<typeof createGoogleAdapterProduction>) =>
+  withTestTranslatorBudget(createGoogleAdapterProduction(...args));
+const createAnthropicAdapter = (...args: Parameters<typeof createAnthropicAdapterProduction>) =>
+  withTestTranslatorBudget(createAnthropicAdapterProduction(...args));
+
+function sse(payload: string): Response {
+  return new Response(`data: ${payload}\n\n`, {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+async function collect(stream: AsyncGenerator<AdapterEvent>): Promise<AdapterEvent[]> {
+  const events: AdapterEvent[] = [];
+  for await (const event of stream) events.push(event);
+  return events;
+}
+
+function chatText(events: AdapterEvent[]): string {
+  return events.flatMap(event => (event.type === "text_delta" ? [event.text] : [])).join("");
+}
+
+// The reporter's captured stream from issue #1219, with the middle frame substituted. The point
+// of the shape is that the frame under test sits BETWEEN content deltas and the terminal frames,
+// so a parser that stops on it throws away an answer that has already fully arrived.
+function healthyChatStream(midFrame: string): Response {
+  return new Response([
+    'data: {"choices":[{"delta":{"content":"P"},"finish_reason":null,"index":0}],"usage":null}\n\n',
+    'data: {"choices":[{"delta":{"content":"ONG"},"finish_reason":null,"index":0}],"usage":null}\n\n',
+    `data: ${midFrame}\n\n`,
+    'data: {"choices":[{"delta":{},"finish_reason":"stop","index":0}],"usage":null}\n\n',
+    "data: [DONE]\n\n",
+  ].join(""), { headers: { "content-type": "text/event-stream" } });
+}
+
+// Same idea on the Gemini wire: the terminal signal is the trailing `finishReason`, so the frame
+// under test has to be skipped for the turn to reach it.
+function healthyGoogleStream(midFrame: string): Response {
+  return new Response([
+    'data: {"candidates":[{"content":{"parts":[{"text":"P"}]}}]}\n\n',
+    `data: ${midFrame}\n\n`,
+    'data: {"candidates":[{"content":{"parts":[{"text":"ONG"}]},"finishReason":"STOP"}]}\n\n',
+  ].join(""), { headers: { "content-type": "text/event-stream" } });
+}
+
+const openAIChatProvider = {
+  adapter: "openai-chat",
+  baseUrl: "https://example.test/v1",
+  apiKey: "sk-test",
+  authMode: "key",
+} as OcxProviderConfig;
+
+const googleProvider = {
+  adapter: "google",
+  baseUrl: "https://generativelanguage.googleapis.com",
+  apiKey: "google-test-key",
+  authMode: "key",
+} as OcxProviderConfig;
+
+const anthropicProvider = {
+  adapter: "anthropic",
+  baseUrl: "https://example.test",
+  apiKey: "key",
+} as OcxProviderConfig;
+
+describe("SSE data frames that parse to a non-record", () => {
+  describe("openai-chat adapter", () => {
+    // The shape the reporter actually captured (issue #1219): `data: null` is a benign padding
+    // frame BETWEEN content deltas, with the finish chunk and [DONE] arriving right after it.
+    // Terminating here discarded a completed answer — they measured the full text arriving and
+    // the turn failing anyway. Skipping is what makes the reported provider work.
+    test.each(NON_RECORD_PAYLOADS)("a mid-stream `data: %s` is skipped and the turn completes", async payload => {
+      const events = await collect(createOpenAIChatAdapter(openAIChatProvider).parseStream(healthyChatStream(payload)));
+
+      expect(events.at(-1)?.type).toBe("done");
+      expect(events.some(event => event.type === "error")).toBe(false);
+      expect(chatText(events)).toBe("PONG");
+    });
+
+    // Skipping must not become a silent success. A stream carrying nothing but non-record frames
+    // sets neither finishReason nor sawUserFacingOutput, so the EOF terminal-signal guard fires.
+    test.each(NON_RECORD_PAYLOADS)("a stream of only `data: %s` frames still fails closed", async payload => {
+      const events = await collect(createOpenAIChatAdapter(openAIChatProvider).parseStream(sse(payload)));
+
+      expect(events.at(-1)?.type).toBe("error");
+      expect(events.some(event => event.type === "done")).toBe(false);
+    });
+
+    // The two classes must stay distinguishable: unparseable JSON is still terminal at the frame,
+    // where a valid-JSON non-record is not. Asserted at the same position in the same stream so
+    // the only variable is the payload.
+    test("an unparseable frame stays terminal where a non-record frame does not", async () => {
+      const withInvalid = await collect(
+        createOpenAIChatAdapter(openAIChatProvider).parseStream(healthyChatStream(INVALID_JSON_PAYLOAD)));
+      expect(withInvalid.at(-1)).toEqual({ type: "error", message: "malformed upstream SSE data frame" });
+      expect(withInvalid.some(event => event.type === "done")).toBe(false);
+
+      const withNonRecord = await collect(
+        createOpenAIChatAdapter(openAIChatProvider).parseStream(healthyChatStream("null")));
+      expect(withNonRecord.at(-1)?.type).toBe("done");
+    });
+  });
+
+  describe("google adapter", () => {
+    test.each(NON_RECORD_PAYLOADS)("a mid-stream `data: %s` is skipped and the turn completes", async payload => {
+      const events = await collect(createGoogleAdapter(googleProvider).parseStream(healthyGoogleStream(payload)));
+
+      expect(events.at(-1)?.type).toBe("done");
+      expect(events.some(event => event.type === "error")).toBe(false);
+      expect(chatText(events)).toBe("PONG");
+    });
+
+    // The guard returns before `sawAnyFrame = true`, so an all-non-record stream is still an
+    // empty one as far as the terminal-signal check is concerned.
+    test.each(NON_RECORD_PAYLOADS)("a stream of only `data: %s` frames still fails closed", async payload => {
+      const events = await collect(createGoogleAdapter(googleProvider).parseStream(sse(payload)));
+
+      expect(events.at(-1)?.type).toBe("error");
+      expect(events.some(event => event.type === "done")).toBe(false);
+    });
+
+    test("an unparseable frame stays terminal where a non-record frame does not", async () => {
+      const withInvalid = await collect(
+        createGoogleAdapter(googleProvider).parseStream(healthyGoogleStream(INVALID_JSON_PAYLOAD)));
+      expect(withInvalid.at(-1)).toEqual({ type: "error", message: "malformed upstream SSE data frame" });
+      expect(withInvalid.some(event => event.type === "done")).toBe(false);
+
+      const withNonRecord = await collect(
+        createGoogleAdapter(googleProvider).parseStream(healthyGoogleStream("null")));
+      expect(withNonRecord.at(-1)?.type).toBe("done");
+    });
+  });
+
+  describe("anthropic adapter", () => {
+    // The anthropic parser drops an unparseable frame and keeps reading rather than terminating,
+    // so parity here means "dropped the same way" — the stream still fails closed at EOF because
+    // no `message_stop` arrived, which is the pre-existing truncation guard doing its job.
+    test.each(NON_RECORD_PAYLOADS)("`data: %s` is dropped, not thrown", async payload => {
+      const control = await collect(createAnthropicAdapter(anthropicProvider).parseStream(sse(INVALID_JSON_PAYLOAD)));
+      const events = await collect(createAnthropicAdapter(anthropicProvider).parseStream(sse(payload)));
+
+      expect(events).toEqual(control);
+      expect(events.some(event => event.type === "done")).toBe(false);
+    });
+
+    test("a non-record frame does not stop a later well-formed frame from being read", async () => {
+      const response = new Response([
+        "data: null\n\n",
+        "event: message_start\n",
+        'data: {"type":"message_start","message":{"usage":{"input_tokens":3,"output_tokens":1}}}\n\n',
+        "event: content_block_start\n",
+        'data: {"type":"content_block_start","content_block":{"type":"text","text":""}}\n\n',
+        "event: content_block_delta\n",
+        'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"hi"}}\n\n',
+        "event: message_stop\n",
+        'data: {"type":"message_stop"}\n\n',
+      ].join(""), { headers: { "content-type": "text/event-stream" } });
+
+      const events = await collect(createAnthropicAdapter(anthropicProvider).parseStream(response));
+
+      expect(events.some(event => event.type === "text_delta")).toBe(true);
+      expect(events.at(-1)?.type).toBe("done");
+    });
+  });
+
+  describe("web-search sidecar parser", () => {
+    test.each(NON_RECORD_PAYLOADS)("`data: %s` is ignored, not thrown", async payload => {
+      const control = await parseSidecarSSE(sse(INVALID_JSON_PAYLOAD));
+      const result = await parseSidecarSSE(sse(payload));
+
+      expect(result).toEqual(control);
+    });
+
+    // An upstream SSE payload can carry model output or credential material, and a frame that
+    // failed to parse is the least trustworthy content there is. Both warning paths — unparseable
+    // and valid-but-not-a-record — must report the frame without reproducing it.
+    test.each([
+      ["unparseable", `{${MARKER}`],
+      ["non-record", `"${MARKER}"`],
+    ])("the %s warning reports the frame without copying its content", async (_label, payload) => {
+      const warn = spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        await parseSidecarSSE(sse(payload));
+
+        // The warning has to actually fire, or the marker assertion below passes vacuously.
+        expect(warn).toHaveBeenCalled();
+        const logged = warn.mock.calls.flat().map(String).join("\n");
+        expect(logged).not.toContain(MARKER);
+        expect(logged).toContain("[web-search-parse]");
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    test("a non-record frame does not discard the answer that follows it", async () => {
+      const response = new Response([
+        "data: null\n\n",
+        'data: {"type":"response.output_text.done","text":"answer"}\n\n',
+      ].join(""), { headers: { "content-type": "text/event-stream" } });
+
+      const result = await parseSidecarSSE(response);
+
+      expect(result.text).toBe("answer");
+    });
+  });
+});


### PR DESCRIPTION
Closes lidge-jun/opencodex#1219

## Problem

`JSON.parse` returns a *value*, not necessarily an object. `JSON.parse("null")` returns `null` without throwing, so a `try/catch` wrapped around the parse cannot see it. Four SSE frame parsers cast the result straight to `Record<string, unknown>` and dereference it on the next line, so a syntactically valid `data: null` frame walks past the malformed-frame guard and crashes the parser mid-stream.

You observed it through the web-search loop on `adapter: openai-chat`, where upstream instability makes odd frames frequent, but nothing about it is provider-specific or web-search-specific — it reaches any streamed request.

<!-- linear:table-colwidths:200,200,200,200 -->
| File | Unguarded parse | Crashing access | Existing guard it escapes |
| -- | -- | -- | -- |
| `src/adapters/openai-chat.ts` | `:961` | `chunk.error` `:970` | `yield` malformed frame + terminate |
| `src/adapters/google.ts` | `:502` | `chunk.error` `:510` | `yield` malformed frame + terminate |
| `src/adapters/anthropic.ts` | `:989` | `data.type` `:995` | `debugDroppedFrame` + `continue` |
| `src/web-search/parse.ts` | `:157` | `data.type` `:161` | `console.warn` + `return` |

**The fourth row is not in the report.** The issue names three adapters. `src/web-search/parse.ts` has the identical defect, and it sits directly in the web-search path you were actually running — `parseSidecarSSE` wraps its read loop in `try`/`finally` with no `catch`, so the `TypeError` escapes the function. Fixing only the three reported sites would have left your own code path broken.

**Two failure modes, not one.** Property access on a non-null primitive is legal in JS, so only `null` actually throws:

<!-- linear:table-colwidths:266,266,266 -->
| `data:` payload | `typeof` | Behaviour before this PR |
| -- | -- | -- |
| `null` | `object` | **throws** — `null is not an object` |
| `42` / `"text"` / `true` | number / string / boolean | no throw; silently accepted as an empty frame |
| `[]` | `object` (array) | no throw; silently accepted as an empty frame |

The crash is the reported bug. The silent acceptance is the same defect one step milder: a malformed frame is treated as a well-formed frame carrying nothing, so it is neither surfaced nor counted. Both are fixed by validating the shape rather than asserting it — which is what your proposed patch does, so this follows it.

**Audit of the remaining SSE parsers — no other site is affected.** Eight further data-frame parsers were checked; all parse into `unknown` and gate on a local record predicate before any dereference, so they were already correct:

`src/chat/outbound.ts:510` and `:678` (`isRec`), `src/claude/outbound.ts:624` and `:869` (`isRec`), `src/server/claude-messages.ts:177` (`isRec`), `src/web-search/anthropic-executor.ts:78` (`isRec`), `src/vision/anthropic-describe.ts:63` (`isRecord`), `src/adapters/openai-responses.ts:1220` (`isPlainObject`).

## Fix

**Validate the parse result instead of asserting it**, at all four sites. The guard is written against the shape (`null`, non-object, array) rather than against `null` alone, so the silent-empty case is closed together with the crash.

**Each site keeps its own existing malformed-frame handling** rather than acquiring a new one — this PR changes what counts as malformed, not what happens next:

* `src/adapters/openai-chat.ts`, `src/adapters/google.ts` — emit the existing `malformed upstream SSE data frame` error and terminate, exactly as the invalid-JSON path does.
* `src/adapters/anthropic.ts` — `debugDroppedFrame` and `continue`, so the pre-existing `message_stop` truncation check still decides the stream's outcome.
* `src/web-search/parse.ts` — warn and skip the frame.

The guard uses the shape-check form already present in these files (the `wrapped` checks in `src/adapters/google.ts`, the `rawChoice` check in `src/adapters/openai-chat.ts`), so no new helper or import is introduced.

## Tests

New `tests/sse-null-data-frame.test.ts` — 25 tests, covering all four production sites against all five non-record payloads (`null`, `42`, `"text"`, `true`, `[]`).

Assertions are written as **parity against the syntactically-invalid control** (`{not json}`) rather than by re-encoding each parser's terminal message. That states the actual requirement — a valid-JSON non-record frame is handled exactly like an unparseable one — and does not drift when those messages change. The control also proves the pre-existing guard still works, so a regression breaking both would not pass silently.

Beyond the shape matrix:

* a non-record frame followed by `data: [DONE]` stays terminal on `openai-chat` and does not become a clean completion;
* a non-record frame on `anthropic` does not prevent a later well-formed frame from being read through to `done`;
* a non-record frame in the web-search sidecar does not discard the answer that follows it.

Verification on this branch (all runs via `bun scripts/test.ts`, i.e. `--isolate` plus the isolated `CODEX_HOME`/`OPENCODEX_HOME` environment):

* **new file 25/25 pass** — and **17 of the 25 fail on** `dev` **without the production change**, so the coverage is proven to bite rather than merely to pass;
* **1103 pass / 0 fail across 61 files** — every SSE, streaming, adapter, web-search, vision and chat/claude endpoint suite in the tree, i.e. the full blast radius of these four files;
* `bun x tsc --noEmit` — output byte-identical to a stashed clean-`dev` control (both exit 2 on one pre-existing `@napi-rs/keyring` module-resolution error local to my machine);
* `bun scripts/privacy-scan.ts` — passed.

**On the Windows leg.** This was developed on Windows, where the suite is known-red — lidge-jun/opencodex#1059 tracks \~207 pre-existing failures and the leg is dispatch-only. Rather than report that as noise, I controlled the affected area directly: the 74 `codex-*` and `cli-*` files that contain every failure were run on this branch and on a stashed clean `dev`.

```
branch:     115 failing tests
clean dev:  115 failing tests
diff:       identical — same tests, both sides
```

So this change adds no failure to the known-red set, and none of those files is reachable from the four it touches.

## Notes

**One behavioural change beyond the crash fix.** On `openai-chat` and `google`, a `data:` frame carrying a non-null non-record (`42`, `"text"`, `true`, `[]`) is now reported as a malformed frame and terminates the stream, where before it was silently ignored. This is deliberate — such a frame is not valid in either wire format, and silently continuing is how a broken stream reaches the truncation guard with a misleading cause. `anthropic` and the web-search sidecar keep their non-terminal handling, so nothing that previously completed a turn now fails.

**No payload content is added to any log.** The new `src/web-search/parse.ts` branch reports only the frame length and its JSON shape (`null` / `array` / `number` / …), not a slice of the payload. The pre-existing invalid-JSON warning one line above still logs `payload.slice(0, 120)`; that line is untouched, but the new path deliberately does not copy the pattern.

**Overlap with** lidge-jun/opencodex#1194**.** That PR changes the `data:` field-prefix handling in `src/adapters/openai-chat.ts` and `src/web-search/parse.ts`, among others. The changes are adjacent but disjoint — lidge-jun/opencodex#1194 decides *which lines become payloads*, this PR decides *what a parsed payload must look like*. Whichever lands first, the other is a trivial rebase; happy to rebase onto lidge-jun/opencodex#1194 if you would rather take them in that order.

**The reporter also asked for a** `debugProviderDiagnostic` **on the malformed-frame path**, noting the failure leaves no server-side trace. That is deliberately not in this PR — it is a diagnostics change with its own shape (which channel, at what level, and whether frame content may be recorded), and it should not ride along with a crash fix. Happy to take it as a follow-up, or to leave it to @brunoflma who raised it.

## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [X] All CI tests are green on my local testing.
- [X] I pushed my PR to the latest dev commit.
- [X] I resolved all correct Codex and CodeRabbit findings.
- [X] My PR is ready for review.

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming response handling when event data is null, a primitive value, or an array.
  * Prevented malformed or unexpected streaming frames from causing crashes.
  * Ensured invalid frames are safely logged and handled consistently across AI and search integrations.
* **Tests**
  * Added coverage for malformed and unexpected streaming payloads.
  * Verified subsequent valid events continue processing.
  * Confirmed diagnostic warnings do not expose event payload contents.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
