### PR TITLE
fix(server): bound client-facing SSE frame retention

### DIFF
--- a/docs-site/src/content/docs/ja/reference/proxy-formats.md
+++ b/docs-site/src/content/docs/ja/reference/proxy-formats.md
@@ -53,6 +53,8 @@ provider events → internal adapter events → client dialect
 
 `stream: false` を指定するか、`stream` を指定しないと、同じアダプター イベントが 1 つの Responses JSON オブジェクトに収集されます。どちらの形式でも、選択したモデル、出力項目、端末の状態、使用状況が保存されます。
 
+クライアント向け Responses SSE フレームは、SSE ブロック区切りの前の生バイトで測って 1 フレームあたり 4 MiB に制限されます。HTTP では、区切りなしでこの上限を超えたアップストリーム フレームは、合成 `response.failed` イベントと続く `data: [DONE]` でフェイルクローズします。Responses WebSocket ブリッジでは、同じ条件で 502 `websocket_protocol_error` を送信し、アップストリーム リーダーをキャンセルします。完全な Responses 終端フレームがすでに到着している場合はそれが優先され、その後のサイズ超過または不正なバイトは、完了したターンをトランスポート障害に置き換えず破棄されます。
+
 すべての端末応答使用状況オブジェクトには、プロバイダーが詳細を報告しなかった場合でも、両方の詳細オブジェクトが含まれます。
 
 ```json

--- a/docs-site/src/content/docs/ko/reference/proxy-formats.md
+++ b/docs-site/src/content/docs/ko/reference/proxy-formats.md
@@ -63,6 +63,8 @@ deltas, 그리고 정확히 하나의 종료 `response.completed`, `response.fai
 `stream: false`이거나 `stream`이 없으면, 같은 adapter 이벤트가 하나의 Responses JSON 객체로 수집됩니다.
 두 형식 모두 선택한 모델, output item, 종료 상태, usage를 보존합니다.
 
+클라이언트로 전달되는 Responses SSE 프레임은 SSE 블록 구분자 앞의 원시 바이트 기준으로 프레임당 4 MiB로 제한됩니다. HTTP에서는 구분자 없이 이 한도를 초과한 업스트림 프레임을 합성 `response.failed` 이벤트와 이어지는 `data: [DONE]`으로 fail closed 처리합니다. Responses WebSocket 브리지에서는 같은 조건에서 502 `websocket_protocol_error`를 보내고 업스트림 reader를 취소합니다. 완전한 Responses 종료 프레임이 이미 수신된 경우에는 그 종료가 우선하며, 이후의 과도한 크기 또는 잘못된 바이트는 완료된 턴을 전송 오류로 바꾸지 않고 버립니다.
+
 모든 종료 Responses usage 객체에는 제공자가 해당 세부 정보를 보고하지 않았더라도 두 상세 객체가 모두
 포함됩니다.
 

--- a/docs-site/src/content/docs/reference/proxy-formats.md
+++ b/docs-site/src/content/docs/reference/proxy-formats.md
@@ -65,6 +65,13 @@ With `stream: true`, the response is `text/event-stream`. The bridge emits Respo
 With `stream: false` or no `stream`, the same adapter events are collected into one Responses JSON
 object. Both forms preserve the selected model, output items, terminal status, and usage.
 
+Client-facing Responses SSE frames are limited to 4 MiB per frame, measured in raw bytes before the
+SSE block delimiter. On HTTP, an unterminated upstream frame that exceeds the limit fails closed
+with a synthetic `response.failed` event followed by `data: [DONE]`. On the Responses WebSocket
+bridge, the same condition emits a 502 `websocket_protocol_error` and cancels the upstream reader.
+A complete Responses terminal frame is authoritative: oversized or malformed trailing bytes after
+that terminal are dropped rather than replacing the completed turn with a transport failure.
+
 Every terminal Responses usage object includes both detail objects, even when the provider did not
 report those details:
 

--- a/docs-site/src/content/docs/ru/reference/proxy-formats.md
+++ b/docs-site/src/content/docs/ru/reference/proxy-formats.md
@@ -67,6 +67,8 @@ Translated-adapter'ы обрабатывают только известные �
 При `stream: false` или при отсутствии `stream` те же события адаптера собираются в один JSON
 Responses. Обе формы сохраняют выбранную модель, output item'ы, terminal status и usage.
 
+Клиентские frame'ы Responses SSE ограничены 4 MiB на frame, считая сырые байты до разделителя SSE-блока. В HTTP незавершённый upstream-frame, превысивший этот предел, завершается fail-closed синтетическим событием `response.failed`, после которого идёт `data: [DONE]`. В мосте Responses WebSocket то же условие даёт 502 `websocket_protocol_error` и отменяет upstream-reader. Если полноценный terminal-frame Responses уже получен, он остаётся авторитетным: слишком большие или некорректные байты после него отбрасываются и не заменяют завершённый ход транспортной ошибкой.
+
 Каждый terminal usage-объект Responses всегда включает оба detail-объекта, даже если провайдер их
 не сообщил:
 

--- a/docs-site/src/content/docs/zh-cn/reference/proxy-formats.md
+++ b/docs-site/src/content/docs/zh-cn/reference/proxy-formats.md
@@ -62,6 +62,8 @@ Responses 表示是这座桥的中心。原生兼容的路由可以跳过部分�
 当 `stream: false` 或未提供 `stream` 时，同样的适配器事件会被收集为一个 Responses JSON
 对象。两种形式都会保留所选模型、输出项、终止状态和 usage。
 
+面向客户端的 Responses SSE 帧按 SSE 块分隔符之前的原始字节计算，每帧限制为 4 MiB。对于 HTTP，未终止的上游帧一旦超过该限制，会以合成的 `response.failed` 事件并随后发送 `data: [DONE]` 的方式 fail closed。对于 Responses WebSocket 桥，相同情况会发送 502 `websocket_protocol_error` 并取消上游 reader。已经完整到达的 Responses 终止帧具有优先权；其后的超大或格式错误字节会被丢弃，而不会把已经完成的轮次替换为传输失败。
+
 每个终止的 Responses usage 对象都包含两个 detail 对象，即使提供方没有报告这些细节：
 
 ```json

--- a/src/server/relay.ts
+++ b/src/server/relay.ts
@@ -619,17 +619,6 @@ function delimiterLengthAt(
   return byteAt(index + 3) === 10 ? 4 : 0;
 }
 
-function joinedBytes(slices: readonly Uint8Array[], byteLength: number): Uint8Array {
-  if (slices.length === 1 && slices[0]!.byteLength === byteLength) return slices[0]!;
-  const joined = new Uint8Array(byteLength);
-  let offset = 0;
-  for (const slice of slices) {
-    joined.set(slice, offset);
-    offset += slice.byteLength;
-  }
-  return joined;
-}
-
 /**
  * Per-chunk SSE inspection state machine shared by consumeForInspection,
  * consumeForResponseLogMetadata, and the eager bounded relay (relay-eager.ts).
@@ -650,8 +639,8 @@ export function createSseInspector(handlers: SseInspectorHandlers): SseInspector
   let reported = false;
   let sawTerminal = false;
   let disposed = false;
-  let delimiterTail = new Uint8Array(0);
-  let candidateSlices: Uint8Array[] = [];
+  let delimiterTail: Uint8Array = new Uint8Array(0);
+  let candidate: Uint8Array = new Uint8Array(0);
   let candidateBytes = 0;
   let discardingOversizedFrame = false;
   const reportFirstOutput = createFirstOutputReporter(handlers.onFirstOutput);
@@ -665,7 +654,7 @@ export function createSseInspector(handlers: SseInspectorHandlers): SseInspector
 
   const clearFrameState = (): void => {
     delimiterTail = new Uint8Array(0);
-    candidateSlices = [];
+    candidate = new Uint8Array(0);
     candidateBytes = 0;
     discardingOversizedFrame = false;
   };
@@ -685,6 +674,30 @@ export function createSseInspector(handlers: SseInspectorHandlers): SseInspector
     firstResponseId = undefined;
   };
 
+  const ensureCandidateCapacity = (requiredBytes: number): void => {
+    if (candidate.byteLength >= requiredBytes) return;
+    let capacity = candidate.byteLength === 0
+      ? Math.min(MAX_INSPECTION_SSE_FRAME_BYTES, Math.max(requiredBytes, 4096))
+      : candidate.byteLength;
+    while (capacity < requiredBytes) {
+      capacity = Math.min(
+        MAX_INSPECTION_SSE_FRAME_BYTES,
+        Math.max(requiredBytes, capacity * 2),
+      );
+    }
+    const grown = new Uint8Array(capacity);
+    if (candidateBytes > 0) grown.set(candidate.subarray(0, candidateBytes));
+    candidate = grown;
+  };
+
+  const takeCandidate = (): Uint8Array => {
+    if (candidateBytes === 0) return new Uint8Array(0);
+    const frame = candidate.slice(0, candidateBytes);
+    candidate = new Uint8Array(0);
+    candidateBytes = 0;
+    return frame;
+  };
+
   const retainCandidateSlice = (slice: Uint8Array): void => {
     if (slice.byteLength === 0 || discardingOversizedFrame) return;
     const nextBytes = candidateBytes + slice.byteLength;
@@ -693,7 +706,7 @@ export function createSseInspector(handlers: SseInspectorHandlers): SseInspector
       Math.min(nextBytes, MAX_INSPECTION_SSE_FRAME_BYTES),
     );
     if (nextBytes > MAX_INSPECTION_SSE_FRAME_BYTES) {
-      candidateSlices = [];
+      candidate = new Uint8Array(0);
       candidateBytes = 0;
       discardingOversizedFrame = true;
       inspectionCounters.frameCapOverflows += 1;
@@ -703,10 +716,8 @@ export function createSseInspector(handlers: SseInspectorHandlers): SseInspector
       reconstructionTainted = true;
       return;
     }
-    // `subarray()` aliases the upstream chunk's backing buffer. Copy only the
-    // live candidate bytes so a tiny trailing frame cannot pin a multi-MiB
-    // chunk whose preceding frames have already been consumed.
-    candidateSlices.push(slice.slice());
+    ensureCandidateCapacity(nextBytes);
+    candidate.set(slice, candidateBytes);
     candidateBytes = nextBytes;
   };
 
@@ -842,9 +853,7 @@ export function createSseInspector(handlers: SseInspectorHandlers): SseInspector
       return;
     }
     const sourceBytes = candidateBytes;
-    const frame = joinedBytes(candidateSlices, sourceBytes);
-    candidateSlices = [];
-    candidateBytes = 0;
+    const frame = takeCandidate();
     if (reported && !handlers.onCompletedResponse) return;
     const decoded = decoder!.decode(frame);
     scanPayload(sseDataPayload(decoded), sourceBytes);
@@ -901,7 +910,7 @@ export function createSseInspector(handlers: SseInspectorHandlers): SseInspector
         delimiterTail = new Uint8Array(0);
         if (!discardingOversizedFrame && candidateBytes > 0 && !reported) {
           const sourceBytes = candidateBytes;
-          const decoded = decoder!.decode(joinedBytes(candidateSlices, sourceBytes));
+          const decoded = decoder!.decode(takeCandidate());
           scanPayload(decoded.trim() ? sseDataPayload(decoded) : null, sourceBytes);
         }
       } finally {

--- a/src/server/relay.ts
+++ b/src/server/relay.ts
@@ -11,11 +11,16 @@ import {
   type RequestLogContext,
   type RequestLogEntry,
 } from "./request-log";
+import {
+  BoundedSseFrameBuffer,
+  joinSseFrameBytes,
+  MAX_CLIENT_SSE_FRAME_BYTES,
+} from "./sse-frame-buffer";
 
 const nativePassthroughSseResponses = new WeakSet<Response>();
 const eagerRelaySseResponses = new WeakSet<Response>();
 
-export const MAX_INSPECTION_SSE_FRAME_BYTES = 4 * 1024 * 1024;
+export const MAX_INSPECTION_SSE_FRAME_BYTES = MAX_CLIENT_SSE_FRAME_BYTES;
 export const MAX_COMPLETED_OUTPUT_ITEMS = 256;
 export const MAX_COMPLETED_OUTPUT_ITEM_SOURCE_BYTES = 8 * 1024 * 1024;
 export const MAX_TAIL_ERROR_MESSAGE_CHARS = 512;
@@ -104,30 +109,29 @@ export type SseTerminalOutputBoundary = {
 
 /**
  * Frame-aware client output boundary shared by both native Responses relays.
- * It buffers only the current incomplete SSE block, forwards complete blocks
- * through the first Responses terminal, and drops every later block/byte.
+ * It buffers only the current incomplete SSE block under the same hard byte
+ * cap as inspection, forwards complete blocks through the first Responses
+ * terminal, and drops every later block/byte.
  */
 export function createSseTerminalOutputBoundary(): SseTerminalOutputBoundary {
-  let decoder: TextDecoder | null = new TextDecoder();
-  const encoder = new TextEncoder();
-  let buffer = "";
+  const decoder = new TextDecoder();
+  const framer = new BoundedSseFrameBuffer(MAX_INSPECTION_SSE_FRAME_BYTES);
   let terminal = false;
   let done = false;
   let disposed = false;
 
-  const process = (flush: boolean): Uint8Array => {
-    if (disposed || terminal) return new Uint8Array(0);
-    let output = "";
+  const processFrames = (
+    frames: ReturnType<BoundedSseFrameBuffer["feed"]>,
+  ): Uint8Array => {
+    if (disposed || terminal || frames.length === 0) return new Uint8Array(0);
+    const output: Uint8Array[] = [];
     let responsesTerminal = false;
-    for (;;) {
-      const next = nextSseBlock(buffer);
-      if (!next) break;
-      buffer = next.rest;
-      const payload = sseDataPayload(next.block);
-      if (!responsesTerminal) output += next.block + next.delimiter;
+    for (const frame of frames) {
+      const payload = sseDataPayload(decoder.decode(frame.block));
+      if (!responsesTerminal) output.push(frame.block, frame.delimiter);
       if (payload === "[DONE]") {
         done = true;
-        if (responsesTerminal) output += next.block + next.delimiter;
+        if (responsesTerminal) output.push(frame.block, frame.delimiter);
         continue;
       }
       if (!responsesTerminal && payload && terminalStatusFromSsePayload(payload)) {
@@ -136,33 +140,26 @@ export function createSseTerminalOutputBoundary(): SseTerminalOutputBoundary {
     }
     if (responsesTerminal) {
       terminal = true;
-      buffer = "";
+      framer.dispose();
     }
-    if (flush && !terminal && buffer.length > 0) {
-      output += buffer;
-      buffer = "";
-    }
-    return encoder.encode(output);
+    return joinSseFrameBytes(output);
   };
 
   return {
     feed(chunk) {
       if (disposed || terminal) return new Uint8Array(0);
-      buffer += decoder!.decode(chunk, { stream: true });
-      return process(false);
+      return processFrames(framer.feed(chunk));
     },
     finish() {
       if (disposed || terminal) return new Uint8Array(0);
-      buffer += decoder!.decode();
-      return process(true);
+      return framer.finish();
     },
     terminalSeen: () => terminal,
     doneSeen: () => done,
     dispose() {
       if (disposed) return;
       disposed = true;
-      decoder = null;
-      buffer = "";
+      framer.dispose();
     },
   };
 }

--- a/src/server/relay.ts
+++ b/src/server/relay.ts
@@ -227,7 +227,7 @@ export function relaySseWithFailedTail(
           if (result !== "buffered") return;
         }
       } catch (err) {
-        let partial = new Uint8Array(0);
+        let partial: Uint8Array = new Uint8Array(0);
         try {
           partial = terminalBoundary.finish();
         } catch {

--- a/src/server/relay.ts
+++ b/src/server/relay.ts
@@ -128,10 +128,13 @@ export function createSseTerminalOutputBoundary(): SseTerminalOutputBoundary {
     let responsesTerminal = false;
     for (const frame of frames) {
       const payload = sseDataPayload(decoder.decode(frame.block));
-      if (!responsesTerminal) output.push(frame.block, frame.delimiter);
-      if (payload === "[DONE]") {
+      const isDone = payload === "[DONE]";
+      // Preserve every frame through the first Responses terminal. A [DONE]
+      // frame is also preserved when it immediately follows that terminal in
+      // the same upstream chunk; every later non-DONE frame is dropped.
+      if (!responsesTerminal || isDone) output.push(frame.block, frame.delimiter);
+      if (isDone) {
         done = true;
-        if (responsesTerminal) output.push(frame.block, frame.delimiter);
         continue;
       }
       if (!responsesTerminal && payload && terminalStatusFromSsePayload(payload)) {
@@ -224,7 +227,14 @@ export function relaySseWithFailedTail(
           if (result !== "buffered") return;
         }
       } catch (err) {
-        const partial = terminalBoundary.finish();
+        let partial = new Uint8Array(0);
+        try {
+          partial = terminalBoundary.finish();
+        } catch {
+          // A near-cap ambiguous delimiter tail may itself overflow at EOF.
+          // Preserve the original read/framing failure and continue emitting
+          // the bounded failed tail instead of letting cleanup throw again.
+        }
         terminalBoundary.dispose();
         if (closed) return;
         const payload = buildFailedTailPayload(err);

--- a/src/server/sse-frame-buffer.ts
+++ b/src/server/sse-frame-buffer.ts
@@ -1,0 +1,191 @@
+export const MAX_CLIENT_SSE_FRAME_BYTES = 4 * 1024 * 1024;
+
+export class SseFrameTooLargeError extends Error {
+  readonly maxBytes: number;
+
+  constructor(maxBytes: number) {
+    super(`upstream SSE frame exceeded ${maxBytes} bytes`);
+    this.name = "SseFrameTooLargeError";
+    this.maxBytes = maxBytes;
+  }
+}
+
+export type BoundedSseFrame = {
+  block: Uint8Array;
+  delimiter: Uint8Array;
+};
+
+function delimiterLengthAt(
+  index: number,
+  length: number,
+  byteAt: (index: number) => number,
+): number | 0 | undefined {
+  const first = byteAt(index);
+  if (first === 10) {
+    if (index + 1 >= length) return undefined;
+    const second = byteAt(index + 1);
+    if (second === 10) return 2;
+    if (second !== 13) return 0;
+    if (index + 2 >= length) return undefined;
+    return byteAt(index + 2) === 10 ? 3 : 0;
+  }
+  if (first !== 13) return 0;
+  if (index + 1 >= length) return undefined;
+  if (byteAt(index + 1) !== 10) return 0;
+  if (index + 2 >= length) return undefined;
+  const third = byteAt(index + 2);
+  if (third === 10) return 3;
+  if (third !== 13) return 0;
+  if (index + 3 >= length) return undefined;
+  return byteAt(index + 3) === 10 ? 4 : 0;
+}
+
+function joinSlices(slices: readonly Uint8Array[], byteLength: number): Uint8Array {
+  if (byteLength === 0) return new Uint8Array(0);
+  if (slices.length === 1 && slices[0]!.byteLength === byteLength) return slices[0]!;
+  const joined = new Uint8Array(byteLength);
+  let offset = 0;
+  for (const slice of slices) {
+    joined.set(slice, offset);
+    offset += slice.byteLength;
+  }
+  return joined;
+}
+
+function copyRange(
+  start: number,
+  end: number,
+  tailLength: number,
+  previousTail: Uint8Array,
+  chunk: Uint8Array,
+): Uint8Array {
+  const out = new Uint8Array(end - start);
+  for (let index = start; index < end; index += 1) {
+    out[index - start] = index < tailLength
+      ? previousTail[index]!
+      : chunk[index - tailLength]!;
+  }
+  return out;
+}
+
+/**
+ * Byte-bounded SSE block framer for client-facing protocol paths.
+ *
+ * The delimiter scanner works on raw bytes, so fragmented UTF-8 cannot change
+ * accounting and a hostile upstream cannot grow an unterminated JS string
+ * without limit. Complete blocks are returned without their delimiter; the
+ * exact delimiter bytes are returned separately so callers can relay bytes
+ * unchanged.
+ */
+export class BoundedSseFrameBuffer {
+  private readonly maxFrameBytes: number;
+  private delimiterTail = new Uint8Array(0);
+  private candidateSlices: Uint8Array[] = [];
+  private candidateBytes = 0;
+  private disposed = false;
+
+  constructor(maxFrameBytes = MAX_CLIENT_SSE_FRAME_BYTES) {
+    if (!Number.isSafeInteger(maxFrameBytes) || maxFrameBytes <= 0) {
+      throw new RangeError("maxFrameBytes must be a positive safe integer");
+    }
+    this.maxFrameBytes = maxFrameBytes;
+  }
+
+  private clear(): void {
+    this.delimiterTail = new Uint8Array(0);
+    this.candidateSlices = [];
+    this.candidateBytes = 0;
+  }
+
+  private retain(slice: Uint8Array): void {
+    if (slice.byteLength === 0) return;
+    const nextBytes = this.candidateBytes + slice.byteLength;
+    if (nextBytes > this.maxFrameBytes) {
+      this.clear();
+      this.disposed = true;
+      throw new SseFrameTooLargeError(this.maxFrameBytes);
+    }
+    // Never retain a view into an arbitrarily larger fetch chunk.
+    this.candidateSlices.push(slice.slice());
+    this.candidateBytes = nextBytes;
+  }
+
+  feed(chunk: Uint8Array): BoundedSseFrame[] {
+    if (this.disposed) return [];
+    if (chunk.byteLength === 0) return [];
+
+    const frames: BoundedSseFrame[] = [];
+    const previousTail = this.delimiterTail;
+    this.delimiterTail = new Uint8Array(0);
+    const tailLength = previousTail.byteLength;
+    const totalLength = tailLength + chunk.byteLength;
+    const byteAt = (index: number): number => index < tailLength
+      ? previousTail[index]!
+      : chunk[index - tailLength]!;
+    const retainRange = (start: number, end: number): void => {
+      if (end <= start) return;
+      if (start < tailLength) {
+        this.retain(previousTail.subarray(start, Math.min(end, tailLength)));
+      }
+      if (end > tailLength) {
+        this.retain(chunk.subarray(Math.max(0, start - tailLength), end - tailLength));
+      }
+    };
+
+    let index = 0;
+    let retainedThrough = 0;
+    while (index < totalLength) {
+      const delimiterLength = delimiterLengthAt(index, totalLength, byteAt);
+      if (delimiterLength === undefined) break;
+      if (delimiterLength > 0) {
+        retainRange(retainedThrough, index);
+        const block = joinSlices(this.candidateSlices, this.candidateBytes);
+        this.candidateSlices = [];
+        this.candidateBytes = 0;
+        const delimiter = copyRange(
+          index,
+          index + delimiterLength,
+          tailLength,
+          previousTail,
+          chunk,
+        );
+        frames.push({ block, delimiter });
+        index += delimiterLength;
+        retainedThrough = index;
+        continue;
+      }
+      index += 1;
+    }
+
+    retainRange(retainedThrough, index);
+    if (index < totalLength) {
+      this.delimiterTail = copyRange(index, totalLength, tailLength, previousTail, chunk);
+    }
+    return frames;
+  }
+
+  /** Return the final unterminated block bytes and release all retained state. */
+  finish(): Uint8Array {
+    if (this.disposed) return new Uint8Array(0);
+    try {
+      this.retain(this.delimiterTail);
+      this.delimiterTail = new Uint8Array(0);
+      return joinSlices(this.candidateSlices, this.candidateBytes);
+    } finally {
+      this.clear();
+      this.disposed = true;
+    }
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.clear();
+    this.disposed = true;
+  }
+}
+
+export function joinSseFrameBytes(parts: readonly Uint8Array[]): Uint8Array {
+  let byteLength = 0;
+  for (const part of parts) byteLength += part.byteLength;
+  return joinSlices(parts, byteLength);
+}

--- a/src/server/sse-frame-buffer.ts
+++ b/src/server/sse-frame-buffer.ts
@@ -88,6 +88,34 @@ function copyRange(
 }
 
 /**
+ * True when a complete SSE block already commits a Responses terminal event.
+ *
+ * Framing errors in bytes *after* such a block must not retroactively turn an
+ * already-completed/failed/incomplete model turn into a transport failure. This
+ * helper is used only on the exceptional path, so decoding/JSON parsing has no
+ * cost on ordinary framing.
+ */
+function isResponsesTerminalFrame(block: Uint8Array): boolean {
+  const data: string[] = [];
+  for (const line of new TextDecoder().decode(block).split(/\r?\n/)) {
+    if (!line.startsWith("data:")) continue;
+    const value = line.slice(5);
+    data.push(value.startsWith(" ") ? value.slice(1) : value);
+  }
+  if (data.length === 0) return false;
+  const payload = data.join("\n");
+  if (payload === "[DONE]") return false;
+  try {
+    const parsed = JSON.parse(payload) as { type?: unknown };
+    return parsed.type === "response.completed"
+      || parsed.type === "response.failed"
+      || parsed.type === "response.incomplete";
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Byte-bounded SSE block framer for client-facing protocol paths.
  *
  * The delimiter scanner works on raw bytes, so fragmented UTF-8 cannot change
@@ -186,33 +214,47 @@ export class BoundedSseFrameBuffer {
       }
     };
 
-    let index = 0;
-    let retainedThrough = 0;
-    while (index < totalLength) {
-      const delimiterLength = delimiterLengthAt(index, totalLength, byteAt);
-      if (delimiterLength === undefined) break;
-      if (delimiterLength > 0) {
-        if (frames.length >= this.maxFramesPerFeed) {
-          this.clear();
-          this.disposed = true;
-          throw new SseFrameCountLimitError(this.maxFramesPerFeed);
+    try {
+      let index = 0;
+      let retainedThrough = 0;
+      while (index < totalLength) {
+        const delimiterLength = delimiterLengthAt(index, totalLength, byteAt);
+        if (delimiterLength === undefined) break;
+        if (delimiterLength > 0) {
+          if (frames.length >= this.maxFramesPerFeed) {
+            this.clear();
+            this.disposed = true;
+            throw new SseFrameCountLimitError(this.maxFramesPerFeed);
+          }
+          retainRange(retainedThrough, index);
+          const block = this.takeCandidate();
+          const delimiter = delimiterBytesAt(index, delimiterLength, byteAt);
+          frames.push({ block, delimiter });
+          index += delimiterLength;
+          retainedThrough = index;
+          continue;
         }
-        retainRange(retainedThrough, index);
-        const block = this.takeCandidate();
-        const delimiter = delimiterBytesAt(index, delimiterLength, byteAt);
-        frames.push({ block, delimiter });
-        index += delimiterLength;
-        retainedThrough = index;
-        continue;
+        index += 1;
       }
-      index += 1;
-    }
 
-    retainRange(retainedThrough, index);
-    if (index < totalLength) {
-      this.delimiterTail = copyRange(index, totalLength, tailLength, previousTail, chunk);
+      retainRange(retainedThrough, index);
+      if (index < totalLength) {
+        this.delimiterTail = copyRange(index, totalLength, tailLength, previousTail, chunk);
+      }
+      return frames;
+    } catch (err) {
+      const framingError = err instanceof SseFrameTooLargeError
+        || err instanceof SseFrameCountLimitError;
+      if (framingError && frames.some(frame => isResponsesTerminalFrame(frame.block))) {
+        // A terminal frame is the Responses protocol boundary. Ignore malformed
+        // or oversized bytes that occur later in the same upstream chunk rather
+        // than retroactively replacing the committed terminal with a 502.
+        this.clear();
+        this.disposed = true;
+        return frames;
+      }
+      throw err;
     }
-    return frames;
   }
 
   /** Return the final unterminated block bytes and release all retained state. */

--- a/src/server/sse-frame-buffer.ts
+++ b/src/server/sse-frame-buffer.ts
@@ -1,5 +1,10 @@
 export const MAX_CLIENT_SSE_FRAME_BYTES = 4 * 1024 * 1024;
 
+const LF_LF = Uint8Array.of(10, 10);
+const LF_CR_LF = Uint8Array.of(10, 13, 10);
+const CR_LF_LF = Uint8Array.of(13, 10, 10);
+const CR_LF_CR_LF = Uint8Array.of(13, 10, 13, 10);
+
 export class SseFrameTooLargeError extends Error {
   readonly maxBytes: number;
 
@@ -10,16 +15,32 @@ export class SseFrameTooLargeError extends Error {
   }
 }
 
+export class SseFrameCountLimitError extends Error {
+  readonly maxFrames: number;
+
+  constructor(maxFrames: number) {
+    super(`upstream SSE chunk exceeded ${maxFrames} frame limit`);
+    this.name = "SseFrameCountLimitError";
+    this.maxFrames = maxFrames;
+  }
+}
+
 export type BoundedSseFrame = {
   block: Uint8Array;
   delimiter: Uint8Array;
 };
 
+/**
+ * Classify the bytes at `index` as an SSE block delimiter.
+ *
+ * Returns the delimiter length in bytes, `0` when `index` does not start a
+ * delimiter, and `undefined` when more bytes are required to decide.
+ */
 function delimiterLengthAt(
   index: number,
   length: number,
   byteAt: (index: number) => number,
-): number | 0 | undefined {
+): number | undefined {
   const first = byteAt(index);
   if (first === 10) {
     if (index + 1 >= length) return undefined;
@@ -38,6 +59,16 @@ function delimiterLengthAt(
   if (third !== 13) return 0;
   if (index + 3 >= length) return undefined;
   return byteAt(index + 3) === 10 ? 4 : 0;
+}
+
+function delimiterBytesAt(
+  index: number,
+  delimiterLength: number,
+  byteAt: (index: number) => number,
+): Uint8Array {
+  if (delimiterLength === 2) return LF_LF;
+  if (delimiterLength === 4) return CR_LF_CR_LF;
+  return byteAt(index) === 10 ? LF_CR_LF : CR_LF_LF;
 }
 
 function copyRange(
@@ -68,6 +99,7 @@ function copyRange(
  */
 export class BoundedSseFrameBuffer {
   private readonly maxFrameBytes: number;
+  private readonly maxFramesPerFeed: number;
   private delimiterTail: Uint8Array = new Uint8Array(0);
   private candidate: Uint8Array = new Uint8Array(0);
   private candidateBytes = 0;
@@ -78,6 +110,10 @@ export class BoundedSseFrameBuffer {
       throw new RangeError("maxFrameBytes must be a positive safe integer");
     }
     this.maxFrameBytes = maxFrameBytes;
+    // Delimiter-only input otherwise creates an object-amplification path that
+    // is independent of candidate bytes. Keep frame count proportional to the
+    // configured byte budget while leaving ample room for real Responses events.
+    this.maxFramesPerFeed = Math.max(1, Math.ceil(maxFrameBytes / 1024));
   }
 
   private clear(): void {
@@ -88,6 +124,9 @@ export class BoundedSseFrameBuffer {
 
   private ensureCapacity(requiredBytes: number): void {
     if (this.candidate.byteLength >= requiredBytes) return;
+    if (requiredBytes > this.maxFrameBytes) {
+      throw new SseFrameTooLargeError(this.maxFrameBytes);
+    }
     let capacity = this.candidate.byteLength === 0
       ? Math.min(this.maxFrameBytes, Math.max(requiredBytes, 4096))
       : this.candidate.byteLength;
@@ -117,6 +156,9 @@ export class BoundedSseFrameBuffer {
   private takeCandidate(): Uint8Array {
     if (this.candidateBytes === 0) return new Uint8Array(0);
     const block = this.candidate.slice(0, this.candidateBytes);
+    // Release the working allocation after each complete frame. This avoids
+    // retaining a rare multi-MiB frame allocation for the rest of a long-lived
+    // stream; normal small-frame allocation remains bounded by feed's frame cap.
     this.candidate = new Uint8Array(0);
     this.candidateBytes = 0;
     return block;
@@ -150,15 +192,14 @@ export class BoundedSseFrameBuffer {
       const delimiterLength = delimiterLengthAt(index, totalLength, byteAt);
       if (delimiterLength === undefined) break;
       if (delimiterLength > 0) {
+        if (frames.length >= this.maxFramesPerFeed) {
+          this.clear();
+          this.disposed = true;
+          throw new SseFrameCountLimitError(this.maxFramesPerFeed);
+        }
         retainRange(retainedThrough, index);
         const block = this.takeCandidate();
-        const delimiter = copyRange(
-          index,
-          index + delimiterLength,
-          tailLength,
-          previousTail,
-          chunk,
-        );
+        const delimiter = delimiterBytesAt(index, delimiterLength, byteAt);
         frames.push({ block, delimiter });
         index += delimiterLength;
         retainedThrough = index;

--- a/src/server/sse-frame-buffer.ts
+++ b/src/server/sse-frame-buffer.ts
@@ -40,18 +40,6 @@ function delimiterLengthAt(
   return byteAt(index + 3) === 10 ? 4 : 0;
 }
 
-function joinSlices(slices: readonly Uint8Array[], byteLength: number): Uint8Array {
-  if (byteLength === 0) return new Uint8Array(0);
-  if (slices.length === 1 && slices[0]!.byteLength === byteLength) return slices[0]!;
-  const joined = new Uint8Array(byteLength);
-  let offset = 0;
-  for (const slice of slices) {
-    joined.set(slice, offset);
-    offset += slice.byteLength;
-  }
-  return joined;
-}
-
 function copyRange(
   start: number,
   end: number,
@@ -73,14 +61,15 @@ function copyRange(
  *
  * The delimiter scanner works on raw bytes, so fragmented UTF-8 cannot change
  * accounting and a hostile upstream cannot grow an unterminated JS string
- * without limit. Complete blocks are returned without their delimiter; the
- * exact delimiter bytes are returned separately so callers can relay bytes
- * unchanged.
+ * without limit. Candidate bytes live in one geometrically grown buffer rather
+ * than one allocation per upstream chunk, bounding both bytes and object count.
+ * Complete blocks are returned without their delimiter; the exact delimiter
+ * bytes are returned separately so callers can relay bytes unchanged.
  */
 export class BoundedSseFrameBuffer {
   private readonly maxFrameBytes: number;
   private delimiterTail: Uint8Array = new Uint8Array(0);
-  private candidateSlices: Uint8Array[] = [];
+  private candidate: Uint8Array = new Uint8Array(0);
   private candidateBytes = 0;
   private disposed = false;
 
@@ -93,8 +82,23 @@ export class BoundedSseFrameBuffer {
 
   private clear(): void {
     this.delimiterTail = new Uint8Array(0);
-    this.candidateSlices = [];
+    this.candidate = new Uint8Array(0);
     this.candidateBytes = 0;
+  }
+
+  private ensureCapacity(requiredBytes: number): void {
+    if (this.candidate.byteLength >= requiredBytes) return;
+    let capacity = this.candidate.byteLength === 0
+      ? Math.min(this.maxFrameBytes, Math.max(requiredBytes, 4096))
+      : this.candidate.byteLength;
+    while (capacity < requiredBytes) {
+      capacity = Math.min(this.maxFrameBytes, Math.max(requiredBytes, capacity * 2));
+    }
+    const grown = new Uint8Array(capacity);
+    if (this.candidateBytes > 0) {
+      grown.set(this.candidate.subarray(0, this.candidateBytes));
+    }
+    this.candidate = grown;
   }
 
   private retain(slice: Uint8Array): void {
@@ -105,9 +109,17 @@ export class BoundedSseFrameBuffer {
       this.disposed = true;
       throw new SseFrameTooLargeError(this.maxFrameBytes);
     }
-    // Never retain a view into an arbitrarily larger fetch chunk.
-    this.candidateSlices.push(slice.slice());
+    this.ensureCapacity(nextBytes);
+    this.candidate.set(slice, this.candidateBytes);
     this.candidateBytes = nextBytes;
+  }
+
+  private takeCandidate(): Uint8Array {
+    if (this.candidateBytes === 0) return new Uint8Array(0);
+    const block = this.candidate.slice(0, this.candidateBytes);
+    this.candidate = new Uint8Array(0);
+    this.candidateBytes = 0;
+    return block;
   }
 
   feed(chunk: Uint8Array): BoundedSseFrame[] {
@@ -139,9 +151,7 @@ export class BoundedSseFrameBuffer {
       if (delimiterLength === undefined) break;
       if (delimiterLength > 0) {
         retainRange(retainedThrough, index);
-        const block = joinSlices(this.candidateSlices, this.candidateBytes);
-        this.candidateSlices = [];
-        this.candidateBytes = 0;
+        const block = this.takeCandidate();
         const delimiter = copyRange(
           index,
           index + delimiterLength,
@@ -170,7 +180,7 @@ export class BoundedSseFrameBuffer {
     try {
       this.retain(this.delimiterTail);
       this.delimiterTail = new Uint8Array(0);
-      return joinSlices(this.candidateSlices, this.candidateBytes);
+      return this.takeCandidate();
     } finally {
       this.clear();
       this.disposed = true;
@@ -187,5 +197,13 @@ export class BoundedSseFrameBuffer {
 export function joinSseFrameBytes(parts: readonly Uint8Array[]): Uint8Array {
   let byteLength = 0;
   for (const part of parts) byteLength += part.byteLength;
-  return joinSlices(parts, byteLength);
+  if (byteLength === 0) return new Uint8Array(0);
+  if (parts.length === 1 && parts[0]!.byteLength === byteLength) return parts[0]!;
+  const joined = new Uint8Array(byteLength);
+  let offset = 0;
+  for (const part of parts) {
+    joined.set(part, offset);
+    offset += part.byteLength;
+  }
+  return joined;
 }

--- a/src/server/sse-frame-buffer.ts
+++ b/src/server/sse-frame-buffer.ts
@@ -79,7 +79,7 @@ function copyRange(
  */
 export class BoundedSseFrameBuffer {
   private readonly maxFrameBytes: number;
-  private delimiterTail = new Uint8Array(0);
+  private delimiterTail: Uint8Array = new Uint8Array(0);
   private candidateSlices: Uint8Array[] = [];
   private candidateBytes = 0;
   private disposed = false;

--- a/src/server/ws-bridge.ts
+++ b/src/server/ws-bridge.ts
@@ -316,7 +316,7 @@ export function sendResponsesJsonAsEvents(
     ? response.status
     : "completed";
   for (const frame of responsesJsonEventSequence(response)) {
-    sendObservedFrame(ws ? frame : frame);
+    sendObservedFrame(frame);
   }
   onTerminal?.(finalStatus);
 }

--- a/src/server/ws-bridge.ts
+++ b/src/server/ws-bridge.ts
@@ -274,12 +274,25 @@ export async function pumpResponsesSseToWebSocket(
     }
   } catch (err) {
     framer.dispose();
-    if (!terminalSeen && isCurrent() && ws.readyState === OPEN) {
-      if (!(err instanceof WsSendDroppedError)) reportTerminal("incomplete");
-      sendProtocolError(ws, 502, err instanceof Error ? err.message : String(err));
+    if (!terminalSeen
+      && isCurrent()
+      && ws.readyState === OPEN
+      && !(err instanceof WsSendDroppedError)) {
+      reportTerminal("incomplete");
+      try {
+        sendProtocolError(ws, 502, err instanceof Error ? err.message : String(err));
+      } catch (sendErr) {
+        // If delivery is already dropped, there is no useful error frame left
+        // to send. Swallow only that expected transport signal; other failures
+        // still surface to the caller after the upstream reader is released.
+        if (!(sendErr instanceof WsSendDroppedError)) throw sendErr;
+      }
     }
   } finally {
     framer.dispose();
+    // Framing errors can occur while the upstream body is still live. Always
+    // release the reader, even when terminal/send paths already cancelled it.
+    void reader.cancel().catch(() => {});
     if (ws.data.cancel === cancel) ws.data.cancel = undefined;
   }
 }
@@ -303,7 +316,7 @@ export function sendResponsesJsonAsEvents(
     ? response.status
     : "completed";
   for (const frame of responsesJsonEventSequence(response)) {
-    sendObservedFrame(frame);
+    sendObservedFrame(ws ? frame : frame);
   }
   onTerminal?.(finalStatus);
 }

--- a/src/server/ws-bridge.ts
+++ b/src/server/ws-bridge.ts
@@ -6,6 +6,7 @@ import { headersForCodexAuthContext } from "../codex/auth-context";
 import type { ResponsesTerminalStatus } from "../bridge";
 import type { DataPlaneAdmission } from "./auth-cors";
 import type { AdmissionLease, AdmissionReservation } from "../lib/admission";
+import { BoundedSseFrameBuffer } from "./sse-frame-buffer";
 
 const OPEN = 1;
 type ResponsesTerminalReporter = (status: ResponsesTerminalStatus) => void;
@@ -163,15 +164,6 @@ function parseSseBlock(block: string): string | null {
   return data.length > 0 ? data.join("\n") : null;
 }
 
-function nextSseBlock(buffer: string): { block: string; rest: string } | null {
-  const match = buffer.match(/\r?\n\r?\n/);
-  if (!match || match.index === undefined) return null;
-  return {
-    block: buffer.slice(0, match.index),
-    rest: buffer.slice(match.index + match[0].length),
-  };
-}
-
 function payloadType(payload: string): string | null {
   try {
     const json = JSON.parse(payload) as { type?: unknown };
@@ -231,7 +223,7 @@ export async function pumpResponsesSseToWebSocket(
   ws.data.cancel = cancel;
 
   const decoder = new TextDecoder();
-  let buffer = "";
+  const framer = new BoundedSseFrameBuffer();
   let terminalSeen = false;
 
   const handlePayload = (payload: string): boolean => {
@@ -266,17 +258,14 @@ export async function pumpResponsesSseToWebSocket(
     while (!terminalSeen) {
       const { done, value } = await reader.read();
       if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      let next: { block: string; rest: string } | null;
-      while ((next = nextSseBlock(buffer))) {
-        buffer = next.rest;
-        const payload = parseSseBlock(next.block);
+      for (const frame of framer.feed(value)) {
+        const payload = parseSseBlock(decoder.decode(frame.block));
         if (payload && handlePayload(payload)) break;
       }
     }
-    buffer += decoder.decode();
-    if (!terminalSeen && buffer.trim()) {
-      const payload = parseSseBlock(buffer);
+    const tail = framer.finish();
+    if (!terminalSeen && tail.byteLength > 0) {
+      const payload = parseSseBlock(decoder.decode(tail));
       if (payload) handlePayload(payload);
     }
     if (!terminalSeen && isCurrent() && !clientCancelled) {
@@ -284,11 +273,13 @@ export async function pumpResponsesSseToWebSocket(
       sendProtocolError(ws, 502, "Upstream stream ended before response terminal event");
     }
   } catch (err) {
+    framer.dispose();
     if (!terminalSeen && isCurrent() && ws.readyState === OPEN) {
       if (!(err instanceof WsSendDroppedError)) reportTerminal("incomplete");
       sendProtocolError(ws, 502, err instanceof Error ? err.message : String(err));
     }
   } finally {
+    framer.dispose();
     if (ws.data.cancel === cancel) ws.data.cancel = undefined;
   }
 }

--- a/src/server/ws-bridge.ts
+++ b/src/server/ws-bridge.ts
@@ -274,6 +274,7 @@ export async function pumpResponsesSseToWebSocket(
     }
   } catch (err) {
     framer.dispose();
+    if (err instanceof WsSendDroppedError) throw err;
     if (!terminalSeen
       && isCurrent()
       && ws.readyState === OPEN

--- a/tests/sse-client-frame-bounds.test.ts
+++ b/tests/sse-client-frame-bounds.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import type { ServerWebSocket } from "bun";
+import {
+  BoundedSseFrameBuffer,
+  MAX_CLIENT_SSE_FRAME_BYTES,
+  SseFrameTooLargeError,
+} from "../src/server/sse-frame-buffer";
+import { relaySseWithFailedTail } from "../src/server/relay";
+import { pumpResponsesSseToWebSocket, type WsData } from "../src/server/ws-bridge";
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+function streamFromChunks(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  let index = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (index < chunks.length) controller.enqueue(chunks[index++]!);
+      else controller.close();
+    },
+  });
+}
+
+describe("client-facing SSE frame bounds", () => {
+  test("the byte framer accepts the exact cap and preserves a split delimiter", () => {
+    const framer = new BoundedSseFrameBuffer(8);
+
+    expect(framer.feed(enc.encode("1234"))).toEqual([]);
+    expect(framer.feed(enc.encode("5678\n"))).toEqual([]);
+    const frames = framer.feed(enc.encode("\n"));
+
+    expect(frames).toHaveLength(1);
+    expect(dec.decode(frames[0]!.block)).toBe("12345678");
+    expect(dec.decode(frames[0]!.delimiter)).toBe("\n\n");
+    expect(framer.finish().byteLength).toBe(0);
+  });
+
+  test("the byte framer rejects cap + 1 without retaining an oversized tail", () => {
+    const framer = new BoundedSseFrameBuffer(8);
+
+    expect(() => framer.feed(enc.encode("123456789"))).toThrow(SseFrameTooLargeError);
+    expect(framer.finish().byteLength).toBe(0);
+  });
+
+  test("fragmented multibyte UTF-8 is decoded only after the complete frame arrives", () => {
+    const text = 'data: {"type":"response.created","label":"€"}';
+    const bytes = enc.encode(text);
+    const euro = enc.encode("€");
+    const euroStart = bytes.findIndex((value, index) => (
+      value === euro[0]
+      && bytes[index + 1] === euro[1]
+      && bytes[index + 2] === euro[2]
+    ));
+    expect(euroStart).toBeGreaterThan(0);
+
+    const framer = new BoundedSseFrameBuffer(1024);
+    expect(framer.feed(bytes.slice(0, euroStart + 1))).toEqual([]);
+    const frames = framer.feed(enc.encode(`${dec.decode(bytes.slice(euroStart + 1))}\n\n`));
+
+    expect(frames).toHaveLength(1);
+    expect(dec.decode(frames[0]!.block)).toBe(text);
+  });
+
+  test("HTTP native relay fails closed instead of retaining an oversized unterminated frame", async () => {
+    const upstream = new AbortController();
+    const oversized = new Uint8Array(MAX_CLIENT_SSE_FRAME_BYTES + 1);
+    oversized.fill(120);
+    const relayed = relaySseWithFailedTail(streamFromChunks([oversized]), upstream);
+
+    const text = await new Response(relayed).text();
+
+    expect(text.length).toBeLessThan(2048);
+    expect(text).toContain("response.failed");
+    expect(text).toContain(`upstream SSE frame exceeded ${MAX_CLIENT_SSE_FRAME_BYTES} bytes`);
+    expect(text).toContain("data: [DONE]");
+    expect(upstream.signal.aborted).toBe(true);
+  });
+
+  test("WebSocket pump emits one bounded protocol error for an oversized unterminated frame", async () => {
+    const sent: string[] = [];
+    const terminals: string[] = [];
+    const ws = {
+      readyState: 1,
+      data: {} as WsData,
+      send(message: string) {
+        sent.push(message);
+        return 1;
+      },
+    } as unknown as ServerWebSocket<WsData>;
+    const oversized = new Uint8Array(MAX_CLIENT_SSE_FRAME_BYTES + 1);
+    oversized.fill(120);
+
+    await pumpResponsesSseToWebSocket(ws, streamFromChunks([oversized]), {
+      onTerminal: status => terminals.push(status),
+    });
+
+    expect(terminals).toEqual(["incomplete"]);
+    expect(sent).toHaveLength(1);
+    const error = JSON.parse(sent[0]!) as {
+      type?: string;
+      status?: number;
+      error?: { code?: string; message?: string };
+    };
+    expect(error.type).toBe("error");
+    expect(error.status).toBe(502);
+    expect(error.error?.code).toBe("websocket_protocol_error");
+    expect(error.error?.message).toBe(
+      `upstream SSE frame exceeded ${MAX_CLIENT_SSE_FRAME_BYTES} bytes`,
+    );
+    expect(ws.data.cancel).toBeUndefined();
+  });
+});

--- a/tests/sse-client-frame-bounds.test.ts
+++ b/tests/sse-client-frame-bounds.test.ts
@@ -55,7 +55,12 @@ describe("client-facing SSE frame bounds", () => {
 
     const framer = new BoundedSseFrameBuffer(1024);
     expect(framer.feed(bytes.slice(0, euroStart + 1))).toEqual([]);
-    const frames = framer.feed(enc.encode(`${dec.decode(bytes.slice(euroStart + 1))}\n\n`));
+    const remainder = bytes.slice(euroStart + 1);
+    const delimiter = enc.encode("\n\n");
+    const secondChunk = new Uint8Array(remainder.byteLength + delimiter.byteLength);
+    secondChunk.set(remainder, 0);
+    secondChunk.set(delimiter, remainder.byteLength);
+    const frames = framer.feed(secondChunk);
 
     expect(frames).toHaveLength(1);
     expect(dec.decode(frames[0]!.block)).toBe(text);

--- a/tests/sse-client-frame-bounds.test.ts
+++ b/tests/sse-client-frame-bounds.test.ts
@@ -3,6 +3,7 @@ import type { ServerWebSocket } from "bun";
 import {
   BoundedSseFrameBuffer,
   MAX_CLIENT_SSE_FRAME_BYTES,
+  SseFrameCountLimitError,
   SseFrameTooLargeError,
 } from "../src/server/sse-frame-buffer";
 import { relaySseWithFailedTail } from "../src/server/relay";
@@ -39,6 +40,13 @@ describe("client-facing SSE frame bounds", () => {
     const framer = new BoundedSseFrameBuffer(8);
 
     expect(() => framer.feed(enc.encode("123456789"))).toThrow(SseFrameTooLargeError);
+    expect(framer.finish().byteLength).toBe(0);
+  });
+
+  test("delimiter-only input cannot amplify one chunk into unbounded frame objects", () => {
+    const framer = new BoundedSseFrameBuffer(4096);
+
+    expect(() => framer.feed(enc.encode("\n\n".repeat(5)))).toThrow(SseFrameCountLimitError);
     expect(framer.finish().byteLength).toBe(0);
   });
 
@@ -81,9 +89,37 @@ describe("client-facing SSE frame bounds", () => {
     expect(upstream.signal.aborted).toBe(true);
   });
 
-  test("WebSocket pump emits one bounded protocol error for an oversized unterminated frame", async () => {
+  test("HTTP failed-tail cleanup preserves the original failure when finish also overflows", async () => {
+    const upstream = new AbortController();
+    const nearCapWithAmbiguousTail = new Uint8Array(MAX_CLIENT_SSE_FRAME_BYTES + 1);
+    nearCapWithAmbiguousTail.fill(120, 0, MAX_CLIENT_SSE_FRAME_BYTES);
+    nearCapWithAmbiguousTail[MAX_CLIENT_SSE_FRAME_BYTES] = 10;
+    let reads = 0;
+    const source = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        reads += 1;
+        if (reads === 1) {
+          controller.enqueue(nearCapWithAmbiguousTail);
+          return;
+        }
+        controller.error(new Error("socket reset after partial frame"));
+      },
+    });
+    const relayed = relaySseWithFailedTail(source, upstream);
+
+    const text = await new Response(relayed).text();
+
+    expect(text.length).toBeLessThan(2048);
+    expect(text).toContain("response.failed");
+    expect(text).toContain("socket reset after partial frame");
+    expect(text).toContain("data: [DONE]");
+    expect(upstream.signal.aborted).toBe(true);
+  });
+
+  test("WebSocket pump emits one bounded protocol error and cancels upstream on overflow", async () => {
     const sent: string[] = [];
     const terminals: string[] = [];
+    let sourceCancelled = false;
     const ws = {
       readyState: 1,
       data: {} as WsData,
@@ -94,8 +130,16 @@ describe("client-facing SSE frame bounds", () => {
     } as unknown as ServerWebSocket<WsData>;
     const oversized = new Uint8Array(MAX_CLIENT_SSE_FRAME_BYTES + 1);
     oversized.fill(120);
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(oversized);
+      },
+      cancel() {
+        sourceCancelled = true;
+      },
+    });
 
-    await pumpResponsesSseToWebSocket(ws, streamFromChunks([oversized]), {
+    await pumpResponsesSseToWebSocket(ws, source, {
       onTerminal: status => terminals.push(status),
     });
 
@@ -112,6 +156,34 @@ describe("client-facing SSE frame bounds", () => {
     expect(error.error?.message).toBe(
       `upstream SSE frame exceeded ${MAX_CLIENT_SSE_FRAME_BYTES} bytes`,
     );
+    expect(sourceCancelled).toBe(true);
+    expect(ws.data.cancel).toBeUndefined();
+  });
+
+  test("WebSocket send drops do not trigger a second failing protocol-error send", async () => {
+    let sourceCancelled = false;
+    let sendCalls = 0;
+    const ws = {
+      readyState: 1,
+      data: {} as WsData,
+      send() {
+        sendCalls += 1;
+        return 0;
+      },
+    } as unknown as ServerWebSocket<WsData>;
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(enc.encode('data: {"type":"response.created"}\n\n'));
+      },
+      cancel() {
+        sourceCancelled = true;
+      },
+    });
+
+    await expect(pumpResponsesSseToWebSocket(ws, source)).resolves.toBeUndefined();
+
+    expect(sendCalls).toBe(1);
+    expect(sourceCancelled).toBe(true);
     expect(ws.data.cancel).toBeUndefined();
   });
 });

--- a/tests/sse-client-frame-bounds.test.ts
+++ b/tests/sse-client-frame-bounds.test.ts
@@ -180,7 +180,7 @@ describe("client-facing SSE frame bounds", () => {
       },
     });
 
-    await expect(pumpResponsesSseToWebSocket(ws, source)).resolves.toBeUndefined();
+    await expect(pumpResponsesSseToWebSocket(ws, source)).rejects.toThrow("websocket send dropped");
 
     expect(sendCalls).toBe(1);
     expect(sourceCancelled).toBe(true);

--- a/tests/sse-client-frame-bounds.test.ts
+++ b/tests/sse-client-frame-bounds.test.ts
@@ -22,6 +22,17 @@ function streamFromChunks(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
   });
 }
 
+function concatBytes(...chunks: Uint8Array[]): Uint8Array {
+  const total = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+  const joined = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    joined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return joined;
+}
+
 describe("client-facing SSE frame bounds", () => {
   test("the byte framer accepts the exact cap and preserves a split delimiter", () => {
     const framer = new BoundedSseFrameBuffer(8);
@@ -40,6 +51,19 @@ describe("client-facing SSE frame bounds", () => {
     const framer = new BoundedSseFrameBuffer(8);
 
     expect(() => framer.feed(enc.encode("123456789"))).toThrow(SseFrameTooLargeError);
+    expect(framer.finish().byteLength).toBe(0);
+  });
+
+  test("the byte framer preserves a committed Responses terminal before trailing overflow", () => {
+    const terminal = enc.encode('data: {"type":"response.completed"}\n\n');
+    const oversizedTail = new Uint8Array(65);
+    oversizedTail.fill(120);
+    const framer = new BoundedSseFrameBuffer(64);
+
+    const frames = framer.feed(concatBytes(terminal, oversizedTail));
+
+    expect(frames).toHaveLength(1);
+    expect(dec.decode(frames[0]!.block)).toBe('data: {"type":"response.completed"}');
     expect(framer.finish().byteLength).toBe(0);
   });
 
@@ -87,6 +111,25 @@ describe("client-facing SSE frame bounds", () => {
     expect(text).toContain(`upstream SSE frame exceeded ${MAX_CLIENT_SSE_FRAME_BYTES} bytes`);
     expect(text).toContain("data: [DONE]");
     expect(upstream.signal.aborted).toBe(true);
+  });
+
+  test("HTTP relay honours a completed frame before oversized trailing bytes in the same chunk", async () => {
+    const terminal = enc.encode(
+      'event: response.completed\ndata: {"type":"response.completed","response":{"id":"r1"}}\n\n',
+    );
+    const oversizedTail = new Uint8Array(MAX_CLIENT_SSE_FRAME_BYTES + 1);
+    oversizedTail.fill(120);
+    const relayed = relaySseWithFailedTail(
+      streamFromChunks([concatBytes(terminal, oversizedTail)]),
+      new AbortController(),
+    );
+
+    const text = await new Response(relayed).text();
+
+    expect(text).toContain('"type":"response.completed"');
+    expect(text).toContain("data: [DONE]");
+    expect(text).not.toContain('"type":"response.failed"');
+    expect(text).not.toContain("upstream SSE frame exceeded");
   });
 
   test("HTTP failed-tail cleanup preserves the original failure when finish also overflows", async () => {
@@ -156,6 +199,43 @@ describe("client-facing SSE frame bounds", () => {
     expect(error.error?.message).toBe(
       `upstream SSE frame exceeded ${MAX_CLIENT_SSE_FRAME_BYTES} bytes`,
     );
+    expect(sourceCancelled).toBe(true);
+    expect(ws.data.cancel).toBeUndefined();
+  });
+
+  test("WebSocket pump honours a completed frame before oversized trailing bytes in the same chunk", async () => {
+    const sent: string[] = [];
+    const terminals: string[] = [];
+    let sourceCancelled = false;
+    const ws = {
+      readyState: 1,
+      data: {} as WsData,
+      send(message: string) {
+        sent.push(message);
+        return 1;
+      },
+    } as unknown as ServerWebSocket<WsData>;
+    const terminal = enc.encode(
+      'event: response.completed\ndata: {"type":"response.completed","response":{"id":"r1"}}\n\n',
+    );
+    const oversizedTail = new Uint8Array(MAX_CLIENT_SSE_FRAME_BYTES + 1);
+    oversizedTail.fill(120);
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(concatBytes(terminal, oversizedTail));
+      },
+      cancel() {
+        sourceCancelled = true;
+      },
+    });
+
+    await pumpResponsesSseToWebSocket(ws, source, {
+      onTerminal: status => terminals.push(status),
+    });
+
+    expect(terminals).toEqual(["completed"]);
+    expect(sent).toHaveLength(1);
+    expect(JSON.parse(sent[0]!).type).toBe("response.completed");
     expect(sourceCancelled).toBe(true);
     expect(ws.data.cancel).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

Maintainer follow-up from the full audit of #1095.

#1095's DeepSeek-specific terminal-repair state machine is no longer the right implementation: `dev` already restored progressive DeepSeek Responses streaming in `0b8e608c06a4a81ba676019ee99b10b6e201dcd1` by relying on the existing terminal-event boundary instead of synthesizing delayed success.

During the takeover review, that replacement path exposed one independent availability/security gap: client-facing HTTP and WebSocket SSE framing could retain an arbitrarily large unterminated upstream frame.

This PR:
- adds a raw-byte `BoundedSseFrameBuffer` with a 4 MiB hard per-frame cap;
- applies it to the HTTP Responses terminal boundary;
- applies it to the Responses WebSocket SSE pump;
- preserves complete frame bytes and split SSE delimiters exactly;
- clears retained state before throwing on overflow so failure tails cannot echo the oversized frame;
- preserves an already-committed Responses terminal if oversized trailing bytes arrive in the same upstream chunk;
- cancels the upstream WebSocket reader on every pump exit, including framing failures;
- documents the 4 MiB client-facing frame limit and failure semantics in the English proxy reference and synchronized ja/ko/ru/zh-cn references;
- adds regression coverage for exact-cap acceptance, cap+1 rejection, fragmented UTF-8, HTTP fail-closed behaviour, terminal-before-overflow behaviour, and WebSocket protocol-error/cancellation behaviour.

## Security / resource rationale

A malicious or broken upstream could previously keep sending bytes without an SSE frame delimiter and grow the client-output buffer without a hard bound. Inspection already had a 4 MiB frame cap, but the output fanout did not. This aligns the client-facing paths with that existing memory envelope.

The frame-count guard also prevents delimiter-only input from amplifying a bounded byte chunk into an unbounded number of frame objects. Candidate storage is intentionally released after each completed frame rather than reused, so a rare multi-MiB frame cannot pin its peak allocation for the rest of a long-lived response.

## Relation to #1095

- Superseding functional fix already on `dev`: `0b8e608c06a4a81ba676019ee99b10b6e201dcd1`.
- This PR contains the additional hardening found while reviewing #1095 for bugs, leaks, edge cases, and security.
- #1095 remains rejected/closed rather than merging its larger timer-based state machine.

## Verification

- Focused frame-bound regressions cover raw-byte limits, fragmented delimiters/UTF-8, failed-tail cleanup, same-chunk terminal + overflow ordering, WebSocket send-drop handling, and upstream cancellation.
- All CodeRabbit and Codex inline findings have been verified against the current implementation, fixed where valid, or explicitly closed where the retention/allocation trade-off is intentional.
- Final merge gate: React Doctor and Cross-platform CI must be green on the final head.