### PR TITLE
fix(deps): pin nanoid to 3.3.18 so the release audit gate passes

### DIFF
--- a/gui/bun.lock
+++ b/gui/bun.lock
@@ -29,6 +29,7 @@
   },
   "overrides": {
     "brace-expansion": "5.0.9",
+    "nanoid": "3.3.18",
     "postcss": "8.5.18",
   },
   "packages": {
@@ -332,7 +333,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 

--- a/gui/package.json
+++ b/gui/package.json
@@ -36,6 +36,7 @@
   },
   "overrides": {
     "brace-expansion": "5.0.9",
+    "nanoid": "3.3.18",
     "postcss": "8.5.18"
   }
 }


### PR DESCRIPTION
## Summary

`bun run audit:high` began failing on two high advisories in `nanoid` below 3.3.16 — [GHSA-28wg-ghj8-5hjv](https://github.com/advisories/GHSA-28wg-ghj8-5hjv) and [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — reached through `vite → postcss → nanoid`.

The dependency itself has not changed. The advisories are new, which is why v2.10.2 shipped through this same gate before they published.

This blocks releases, not just CI: `scripts/release.ts` runs `audit:high` in its preflight, so no version can go out until the transitive copy is pinned. Found while promoting the current dev head.

## Why an override and not `bun update nanoid`

That was the first attempt and it is wrong in a way worth recording. It installs `nanoid@6` as a direct dependency while leaving `postcss` on its own `3.3.12` resolution — so the flagged copy stays exactly where it was, the audit still fails, and the tree gains a package nothing imports.

`postcss@8.5.18` asks for `^3.3.12`, so `3.3.18` satisfies it. The override reaches the transitive resolution that is actually flagged, and the lockfile confirms it: `"nanoid": ["nanoid@3.3.18", ...]`.

## Verification

- `bun run audit:high` — clean across both workspaces.
- `bun run typecheck` — clean.
- Frontend lint — clean.
- Frontend build — succeeded.

This is a lockfile and override pin only. No source file changed and no rendered surface exists to capture: zero paths under any `src` directory.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No user-facing behavior changed.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.