### PR TITLE
fix(openai-chat): ignore empty data: frames; tighten unspaced [DONE] test

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -951,6 +951,9 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
         const rawPayload = sseFieldValue(line, "data");
         if (rawPayload === null) return "continue";
         const payload = rawPayload.trim();
+        // A bare `data:` line carries nothing (heartbeat-style keep-alive on some gateways);
+        // it is not a malformed frame, just nothing to parse.
+        if (payload.length === 0) return "continue";
         if (payload === "[DONE]") {
           yield* flushToolCalls();
           const stopReason = stopReasonFor(finishReason);

--- a/tests/sse-unspaced-data-fields.test.ts
+++ b/tests/sse-unspaced-data-fields.test.ts
@@ -112,12 +112,23 @@ describe("openai-chat adapter (#1170)", () => {
   });
 
   test("accepts an unspaced [DONE] sentinel", async () => {
-    const response = new Response([
-      'data:{"choices":[{"delta":{"content":"hi"}}]}\n\n',
-      "data:[DONE]\n\n",
-    ].join(""));
+    // Sentinel only: a preceding answer frame would let the finish-less EOF fallback emit
+    // `done` even if unspaced [DONE] handling were broken, so this test must not carry one.
+    const response = new Response("data:[DONE]\n\n");
     const events = await collect(createOpenAIChatAdapter(provider).parseStream(response));
     expect(events.at(-1)?.type).toBe("done");
+    expect(events.some(e => e.type === "error")).toBe(false);
+  });
+
+  test("a bare data: line is ignored, not reported as a malformed frame", async () => {
+    const response = new Response([
+      "data:\n\n",
+      'data:{"choices":[{"delta":{"content":"hi"},"finish_reason":"stop"}]}\n\n',
+    ].join(""));
+    const events = await collect(createOpenAIChatAdapter(provider).parseStream(response));
+    expect(events.find(e => e.type === "text_delta")).toMatchObject({ type: "text_delta", text: "hi" });
+    expect(events.at(-1)?.type).toBe("done");
+    expect(events.some(e => e.type === "error")).toBe(false);
   });
 
   test("still handles the spaced form identically", async () => {


### PR DESCRIPTION
## Summary

Small follow-up to #1194, carrying forward the two pieces of the superseded #1188 that the maintainer review called out as worth keeping (see the closing comment on #1188):

1. **Ignore empty `data:` frames in the OpenAI Chat adapter.** `sseFieldValue` (from #1194) correctly yields an empty value for a bare `data:` line, but `handleDataLine` then falls into `JSON.parse("")` and terminates the stream with `malformed upstream SSE data frame`. Some gateways emit bare `data:` lines as heartbeat keep-alives; they now short-circuit as nothing-to-parse, matching the tolerant behavior of the other SSE call sites (`claude-messages.ts`, `chat/outbound.ts`, which `catch { continue }`).
2. **Tighten the unspaced `[DONE]` regression test to sentinel-only.** The merged `accepts an unspaced [DONE] sentinel` test carries a preceding answer frame, so the finish-less EOF fallback would emit `done` even if unspaced `[DONE]` parsing regressed. The test now drives the parser with the `data:[DONE]` frame alone, so it fails unless the sentinel is actually recognized (this is the same weakness CodeRabbit flagged on #1188).

No other parser behavior changes.

## Verification

- `bun x tsc --noEmit` — clean.
- `bun test tests/sse-unspaced-data-fields.test.ts tests/openai-chat-eof.test.ts` — 41/41 pass (1 new test, 1 tightened).
- `bun run privacy:scan` — passed.
- Rebased onto the current integration head per maintainer review (`517f4460`, 0 commits behind at push time). Diff remains the same two files.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming responses by safely ignoring empty server-sent event frames.
  * Prevented malformed-frame errors when receiving blank `data:` messages.
  * Ensured valid streamed content and completion signals continue to work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
