### PR TITLE
chore(proxy): update MCP SDK and protobuf, clear hono advisories

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@bitkyc08/opencodex",
       "dependencies": {
-        "@bufbuild/protobuf": "^2.12.0",
+        "@bufbuild/protobuf": "^2.13.0",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@napi-rs/keyring": "1.3.0",
         "bun": "1.3.14",
@@ -21,13 +21,15 @@
     "bun",
   ],
   "overrides": {
+    "@hono/node-server": "2.1.0",
     "fast-uri": "^3.1.5",
+    "hono": "4.13.1",
     "ip-address": "^10.4.0",
   },
   "packages": {
-    "@bufbuild/protobuf": ["@bufbuild/protobuf@2.12.1", "", {}, "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg=="],
+    "@bufbuild/protobuf": ["@bufbuild/protobuf@2.13.0", "", {}, "sha512-acq7c49vxfm1ggJ95P70TX7ABDM0vxr1SYD3BB0o0jnBLB4OAqeHyKuN+cD3w80gXEDQ2zxHpR6CUeA+O/aU9g=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+    "@hono/node-server": ["@hono/node-server@2.1.0", "", { "peerDependencies": { "hono": "^4" } }, "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
 
@@ -173,7 +175,7 @@
 
     "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
-    "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
+    "hono": ["hono@4.13.1", "", {}, "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "setup:hooks": "bun scripts/setup-hooks.ts"
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^2.12.0",
+    "@bufbuild/protobuf": "^2.13.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@napi-rs/keyring": "1.3.0",
     "bun": "1.3.14",
@@ -70,7 +70,9 @@
     "typescript": "5.9.3"
   },
   "overrides": {
+    "@hono/node-server": "2.1.0",
     "fast-uri": "^3.1.5",
+    "hono": "4.13.1",
     "ip-address": "^10.4.0"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

- Bump @modelcontextprotocol/sdk 1.29.0 → 1.30.0 — carries the `@hono/node-server` dependency-range widening past GHSA-frvp-7c67-39w9, stricter Content-Type validation, SSE keep-alive + timer-lifecycle fixes, Zod 3.25 method-literal support, and a stdio buffer limit.
- Bump @bufbuild/protobuf 2.12.1 → 2.13.0 — Protobuf Text Format support, erasable enum syntax, `readMaxBytes` option for `sizeDelimitedDecode`.
- Pin overrides to clear the remaining `bun audit` findings in the MCP SDK dependency tree: `@hono/node-server` 2.1.0 (GHSA-frvp-7c67-39w9) and `hono` 4.13.1 (GHSA-8j4g-w8fx-2239, GHSA-f23p-vx2j-j53r, GHSA-79qm-7rj5-m7r9, GHSA-54fx-42gc-7vw4).
- No application code changes; the diff is `package.json` + `bun.lock` only.

## Validation

- `bun run typecheck` — pass
- `bun audit` — pass, 0 vulnerabilities after overrides
- `bun install --frozen-lockfile --dry-run` — pass, lockfile consistent
- Full `bun run test` cannot complete on this Windows host: Bun 1.3.14 crashes mid-suite (documented in `ci.yml` — the repo avoids hosted-Windows full-suite runs for this reason) and 7 `codex-native-residue` tests fail from a Windows account-lookup environment issue. Both reproduce identically on the clean `dev` base (56 pass / 2 skip / 7 fail in that file on base and head alike). CI runs the suite on Linux shards and is the authoritative test gate.

## Review notes

- The MCP SDK widened `@hono/node-server` to `^1.19.9 || ^2.0.5`, but bun resolves the 1.x line to 1.19.14 which is still below the advisory fix `<2.0.5`; the override forces 2.1.0 (same for `hono`, where `^4.11.4` resolves below the fixed 4.12.34).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supporting packages to newer versions.
  * Added server runtime packages to improve compatibility and deployment support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->