### PR TITLE
fix(gui): keep brand colors on usage source icons in dark mode

### DIFF
--- a/gui/src/pages/Usage.tsx
+++ b/gui/src/pages/Usage.tsx
@@ -235,7 +235,7 @@ function UsageFilters({
                 <img className="usage-source-mark" src="/provider-icons/claude-color.svg" alt="" aria-hidden="true" />
               )}
               {choice === "grok" && (
-                <img className="usage-source-mark" src="/provider-icons/grok.svg" alt="" aria-hidden="true" />
+                <img className="usage-source-mark usage-source-mark--mono" src="/provider-icons/grok.svg" alt="" aria-hidden="true" />
               )}
               <span className={choice === "all" ? "usage-source-label" : "usage-source-label usage-source-label-collapsible"}>
                 {label}

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -2083,10 +2083,12 @@ button.prov-account-row.active { cursor: default; }
 .usage-segmented-btn { display: inline-flex; align-items: center; justify-content: center; gap: 6px; border: none; background: transparent; color: var(--muted); padding: 4px 12px; border-radius: var(--radius-pill); cursor: pointer; font: inherit; white-space: nowrap; }
 .usage-segmented-btn.active { background: var(--raised); color: var(--text); font-weight: var(--weight-semibold); }
 .usage-source-mark { width: var(--icon-sm); height: var(--icon-sm); flex: 0 0 auto; object-fit: contain; }
-:root[data-theme="dark"] .usage-source-mark { filter: invert(1); }
+/* Only monochrome source marks (Grok) are inverted for dark themes. Brand-colored
+   marks (Claude, Codex/OpenAI) must keep their brand color; inverting shifts the hue. */
+:root[data-theme="dark"] .usage-source-mark--mono { filter: invert(1); }
 
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .usage-source-mark { filter: invert(1); }
+  :root:not([data-theme="light"]) .usage-source-mark--mono { filter: invert(1); }
 }
 
 @media (max-width: 760px) {

--- a/gui/tests/usage-layout.test.ts
+++ b/gui/tests/usage-layout.test.ts
@@ -142,3 +142,24 @@ test("Usage renders Available history and a persistent qualification when histor
     }
   }
 });
+
+test("Usage source marks keep brand colors and invert only the monochrome Grok mark", async () => {
+  const page = await Bun.file(new URL("../src/pages/Usage.tsx", import.meta.url)).text();
+  const css = await Bun.file(new URL("../src/styles.css", import.meta.url)).text();
+
+  // Claude and Codex ship brand-colored SVGs and must not carry the mono modifier.
+  expect(page).toContain('src="/provider-icons/claude-color.svg"');
+  expect(page).not.toContain('usage-source-mark usage-source-mark--mono" src="/provider-icons/claude-color.svg"');
+  expect(page).toContain('src="/provider-icons/openai.svg"');
+  expect(page).not.toContain('usage-source-mark usage-source-mark--mono" src="/provider-icons/openai.svg"');
+
+  // Grok ships a black monochrome mark: it is the only one that needs dark-theme inversion.
+  expect(page).toContain('usage-source-mark usage-source-mark--mono" src="/provider-icons/grok.svg"');
+
+  // Dark-theme inversion must be scoped to the mono modifier so brand hues survive.
+  expect(css).toContain(':root[data-theme="dark"] .usage-source-mark--mono { filter: invert(1); }');
+  expect(css).not.toContain(':root[data-theme="dark"] .usage-source-mark { filter: invert(1); }');
+  // The OS dark-mode (prefers-color-scheme) path must keep the same scoping.
+  expect(css).toContain(':root:not([data-theme="light"]) .usage-source-mark--mono { filter: invert(1); }');
+  expect(css).not.toContain(':root:not([data-theme="light"]) .usage-source-mark { filter: invert(1); }');
+});


### PR DESCRIPTION
## Summary

- Usage page surface filter icons now render with correct colors in dark mode: brand-colored marks (Claude, Codex/OpenAI) keep their brand hue, while the monochrome Grok mark keeps the dark-theme invert that makes it visible on the dark surface.
- Previously the blanket dark-mode `filter: invert(1)` applied to every `.usage-source-mark`, which inverted the brand-colored Claude and Codex/OpenAI SVGs and shifted their brand hues (Claude orange → cyan, OpenAI green → pink).

## Validation

- `bun test tests/usage-layout.test.ts tests/usage-grok-filter.test.ts` (gui) — 8 pass, 0 fail
- `bun run test` (gui) — 677 pass, 0 fail
- `bun run typecheck` — pass
- `bun run lint` (gui) — pass
- Added regression test asserting Claude and Codex keep their color SVGs and only the monochrome Grok mark is inverted, covering both explicit dark-theme and OS prefers-color-scheme selector paths.

## Review notes

- The fix scopes the invert to a `usage-source-mark--mono` modifier on the Grok mark only; Claude ships `claude-color.svg` and Codex/OpenAI ships the brand-green `openai.svg`, neither of which should be inverted.

Fixes #1252


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected provider icons in usage views so brand-colored marks retain their colors across themes.
  * Updated the Grok icon to use appropriate monochrome styling and dark-theme inversion.

* **Tests**
  * Added coverage to verify provider icon assets and theme-specific styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->