### PR TITLE
fix(usage): bound startup hydration tail reads

### DIFF
--- a/src/usage/log.ts
+++ b/src/usage/log.ts
@@ -420,6 +420,7 @@ export type UsageLogRevision = {
 
 let usageReadCacheStats = { fullReads: 0, tailReads: 0, parsedLines: 0 };
 const MANAGEMENT_USAGE_MAX_READ_BYTES = 64 * 1024 * 1024;
+const RECENT_USAGE_MAX_READ_BYTES = 64 * 1024 * 1024;
 const MANAGEMENT_USAGE_READ_CHUNK_BYTES = 1024 * 1024;
 const MANAGEMENT_USAGE_MAX_ENTRIES = 500_000;
 const MANAGEMENT_USAGE_FLIGHT_STALE_MS = 30_000;
@@ -655,10 +656,10 @@ export function readRecentUsageEntries(limit: number): PersistedUsageEntry[] {
     fd = openSync(path, "r");
     const size = fstatSync(fd).size;
     if (size <= 0) return [];
-    // Trace-sized rows (up to MAX_TRACE_BYTES, RI-01) need a larger per-row
-    // budget than the pre-trace ledger; keep expanding until the window covers
-    // the file start or the whole file so a restart never hydrates nothing.
-    let windowBytes = Math.min(size, Math.max(64 * 1024, Math.ceil(limit) * 20 * 1024));
+    // Trace-sized rows need a larger per-row budget than the pre-trace ledger,
+    // but startup hydration must never grow into an unbounded whole-file read.
+    const maxWindowBytes = Math.min(size, RECENT_USAGE_MAX_READ_BYTES);
+    let windowBytes = Math.min(maxWindowBytes, Math.max(64 * 1024, Math.ceil(limit) * 20 * 1024));
     while (true) {
       const start = Math.max(0, size - windowBytes);
       const buf = Buffer.alloc(size - start);
@@ -667,8 +668,8 @@ export function readRecentUsageEntries(limit: number): PersistedUsageEntry[] {
       if (start > 0) {
         const nl = text.indexOf("\n");
         if (nl < 0) {
-          if (start === 0) break;
-          windowBytes = Math.min(size, windowBytes * 4);
+          if (start === 0 || windowBytes >= maxWindowBytes) break;
+          windowBytes = Math.min(maxWindowBytes, windowBytes * 4);
           continue;
         }
         text = text.slice(nl + 1);
@@ -678,9 +679,8 @@ export function readRecentUsageEntries(limit: number): PersistedUsageEntry[] {
       // or partial lines are filtered out during parsing and we always return the
       // most recent N valid rows (not N physical lines minus corrupt ones).
       const entries = parseUsageLines(lines);
-      if (entries.length >= limit || start === 0 || windowBytes >= size) return entries.slice(-limit);
-      if (windowBytes >= size) break;
-      windowBytes = Math.min(size, windowBytes * 4);
+      if (entries.length >= limit || start === 0 || windowBytes >= maxWindowBytes) return entries.slice(-limit);
+      windowBytes = Math.min(maxWindowBytes, windowBytes * 4);
     }
     return [];
   } catch {

--- a/tests/usage-log.test.ts
+++ b/tests/usage-log.test.ts
@@ -783,4 +783,18 @@ describe("usage log", () => {
     expect(readRecentUsageEntries(0)).toEqual([]);
     expect(readRecentUsageEntries(-1)).toEqual([]);
   });
+
+  test("readRecentUsageEntries does not expand beyond its bounded tail window", () => {
+    const path = usageLogPath();
+    const fd = openSync(path, "w");
+    try {
+      const older = Buffer.from(`${persistedLine("outside-tail")}\n`);
+      writeSync(fd, older, 0, older.byteLength, 0);
+      truncateSync(fd, 64 * 1024 * 1024 + older.byteLength + 1);
+    } finally {
+      closeSync(fd);
+    }
+
+    expect(readRecentUsageEntries(1)).toEqual([]);
+  }, STORE_BUDGET_MS);
 });


### PR DESCRIPTION
## Summary

- cap `readRecentUsageEntries()` startup hydration at a 64 MiB tail window;
- preserve the existing adaptive growth within that bound;
- stop cleanly when the bounded tail contains no complete line instead of expanding to the whole file;
- add a sparse oversized-ledger regression proving rows outside the bounded tail are not allocated or parsed.

## Why

`readRecentUsageEntries()` starts with a small tail window and multiplies it until enough valid rows are found. Before this change, the upper bound was the full `usage.jsonl` size. A large or malformed persisted row could therefore make every startup allocate and parse the complete ledger even though the caller only requests a small recent set.

The management/history paths already use separately bounded readers. Startup hydration should have the same finite-memory property.

## Behavior

The reader still returns the newest valid entries that fit inside the retained window and still expands for trace-sized rows. It now stops at 64 MiB. If that bounded tail contains no newline, the function returns an empty recent set rather than attempting a whole-file read. The append-only ledger itself is not modified.

## Verification

- Bun 1.3.14: `tests/usage-log.test.ts` **30/30 passed**.
- Bun 1.4.0-canary.1 (`b22e0e6d0`): the same suite **30/30 passed**.
- `bun x tsc --noEmit`: passed.
- `bun scripts/privacy-scan.ts`: passed.
- `git diff --check`: passed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Tests cover the bounded behavior and existing usage-log semantics.
- [x] No credential, routing, or user-facing configuration contract changes.

Ready for review; upstream CI and maintainer review remain pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup usage-log loading by limiting reads to a 64 MiB window.
  * Ensures the newest usage entries are returned without scanning excessively large logs.

* **Tests**
  * Added regression coverage for bounded reads when older data exists beyond the limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
