### PR TITLE
fix(routing): bound reasoning-effort trace hydration

### DIFF
--- a/src/routing/trace.ts
+++ b/src/routing/trace.ts
@@ -465,13 +465,20 @@ function parseCapability(raw: unknown, caps: ParseCaps): RouteCapabilityEvidence
   if (image !== undefined) out.image = image;
   const structuredOutput = unknownable(raw.structuredOutput);
   if (structuredOutput !== undefined) out.structuredOutput = structuredOutput;
-  if (Array.isArray(raw.reasoningEfforts)
-    && raw.reasoningEfforts.slice(0, 8).every((value): value is string => typeof value === "string")) {
-    if (raw.reasoningEfforts.some((value: unknown) => typeof value === "string"
+  const rawReasoningEfforts = Array.isArray(raw.reasoningEfforts)
+    ? raw.reasoningEfforts
+    : undefined;
+  const reasoningEfforts = rawReasoningEfforts
+    ? Array.from(
+      { length: Math.min(rawReasoningEfforts.length, 8) },
+      (_, index) => rawReasoningEfforts[index],
+    )
+    : undefined;
+  if (reasoningEfforts
+    && reasoningEfforts.every((value): value is string => typeof value === "string")) {
+    if (reasoningEfforts.some((value: unknown) => typeof value === "string"
       && value.length > MAX_TRACE_STRING)) caps.strings = true;
-    out.reasoningEfforts = raw.reasoningEfforts
-      .slice(0, 8)
-      .map(value => value.slice(0, MAX_TRACE_STRING));
+    out.reasoningEfforts = reasoningEfforts.map(value => value.slice(0, MAX_TRACE_STRING));
   }
   if (raw.serviceTier === "unknown") {
     out.serviceTier = "unknown";

--- a/tests/route-decision-trace.test.ts
+++ b/tests/route-decision-trace.test.ts
@@ -226,7 +226,7 @@ describe("route decision traces (RI-01)", () => {
   test("normalization only inspects retained reasoning efforts", () => {
     const reasoningEfforts = Array.from({ length: 1_000_000 }) as unknown[];
     reasoningEfforts.fill("medium", 0, 8);
-    Object.defineProperty(reasoningEfforts, reasoningEfforts.length - 1, {
+    Object.defineProperty(reasoningEfforts, 8, {
       get: () => { throw new Error("reasoning effort outside the retained range was inspected"); },
     });
     const raw = {
@@ -271,8 +271,11 @@ describe("route decision traces (RI-01)", () => {
       selected: { candidateIndex: 0, provider: "a", model: "m1", reason: "policy" },
     };
 
-    expect(normalizeRouteDecisionTrace(raw)?.candidates[0]?.capability?.reasoningEfforts)
-      .toBeUndefined();
+    const normalized = normalizeRouteDecisionTrace(raw);
+    expect(normalized).not.toBeNull();
+    if (!normalized) throw new Error("trace normalization unexpectedly failed");
+    expect(normalized.candidates).toHaveLength(1);
+    expect(normalized.candidates[0]?.capability?.reasoningEfforts).toBeUndefined();
   });
 
   test("startup hydration reads trace-sized usage rows", () => {

--- a/tests/route-decision-trace.test.ts
+++ b/tests/route-decision-trace.test.ts
@@ -223,6 +223,58 @@ describe("route decision traces (RI-01)", () => {
     expect(trace.candidates.every(candidate => candidate.exclusions.length === MAX_EXCLUSIONS_PER_CANDIDATE)).toBe(true);
   });
 
+  test("normalization only inspects retained reasoning efforts", () => {
+    const reasoningEfforts = Array.from({ length: 1_000_000 }) as unknown[];
+    reasoningEfforts.fill("medium", 0, 8);
+    Object.defineProperty(reasoningEfforts, reasoningEfforts.length - 1, {
+      get: () => { throw new Error("reasoning effort outside the retained range was inspected"); },
+    });
+    const raw = {
+      version: 1,
+      decisionId: "abcdef012345",
+      createdAt: 1,
+      requestedModel: "a/m1",
+      routeKind: "policy",
+      requirements: [],
+      candidates: [{
+        provider: "a",
+        model: "m1",
+        eligible: true,
+        exclusions: [],
+        capability: { reasoningEfforts },
+      }],
+      selected: { candidateIndex: 0, provider: "a", model: "m1", reason: "policy" },
+    };
+
+    expect(normalizeRouteDecisionTrace(raw)?.candidates[0]?.capability?.reasoningEfforts)
+      .toEqual(Array.from({ length: 8 }, () => "medium"));
+  });
+
+  test("normalization rejects sparse retained reasoning efforts", () => {
+    const reasoningEfforts = Array(8) as unknown[];
+    reasoningEfforts[0] = "low";
+    reasoningEfforts[7] = "high";
+    const raw = {
+      version: 1,
+      decisionId: "abcdef012345",
+      createdAt: 1,
+      requestedModel: "a/m1",
+      routeKind: "policy",
+      requirements: [],
+      candidates: [{
+        provider: "a",
+        model: "m1",
+        eligible: true,
+        exclusions: [],
+        capability: { reasoningEfforts },
+      }],
+      selected: { candidateIndex: 0, provider: "a", model: "m1", reason: "policy" },
+    };
+
+    expect(normalizeRouteDecisionTrace(raw)?.candidates[0]?.capability?.reasoningEfforts)
+      .toBeUndefined();
+  });
+
   test("startup hydration reads trace-sized usage rows", () => {
     const trace = oversizedTrace();
     for (let index = 0; index < 20; index++) {

--- a/tests/route-decision-trace.test.ts
+++ b/tests/route-decision-trace.test.ts
@@ -226,6 +226,7 @@ describe("route decision traces (RI-01)", () => {
   test("normalization only inspects retained reasoning efforts", () => {
     const reasoningEfforts = Array.from({ length: 1_000_000 }) as unknown[];
     reasoningEfforts.fill("medium", 0, 8);
+    reasoningEfforts[0] = "x".repeat(MAX_TRACE_STRING + 1);
     Object.defineProperty(reasoningEfforts, 8, {
       get: () => { throw new Error("reasoning effort outside the retained range was inspected"); },
     });
@@ -246,8 +247,12 @@ describe("route decision traces (RI-01)", () => {
       selected: { candidateIndex: 0, provider: "a", model: "m1", reason: "policy" },
     };
 
-    expect(normalizeRouteDecisionTrace(raw)?.candidates[0]?.capability?.reasoningEfforts)
-      .toEqual(Array.from({ length: 8 }, () => "medium"));
+    const normalized = normalizeRouteDecisionTrace(raw);
+    expect(normalized).not.toBeNull();
+    if (!normalized) throw new Error("trace normalization unexpectedly failed");
+    expect(normalized.candidates[0]?.capability?.reasoningEfforts)
+      .toEqual(["x".repeat(MAX_TRACE_STRING), ...Array.from({ length: 7 }, () => "medium")]);
+    expect(normalized.truncated?.strings).toBe(true);
   });
 
   test("normalization rejects sparse retained reasoning efforts", () => {


### PR DESCRIPTION
## Summary

- inspect at most the first eight persisted `reasoningEfforts` values during route-trace hydration;
- materialize that retained prefix densely so sparse arrays are rejected instead of preserving holes;
- apply string-length checks and normalization only to the bounded retained prefix;
- add regressions for a million-entry array with a throwing discarded getter and for sparse retained input.

## Why

`parseCapability()` previously validated `raw.reasoningEfforts.slice(0, 8)` but then called `some()` on the original array before slicing again. A large hand-edited or persisted trace row could therefore force an unbounded scan even though the normalized trace retains only eight values.

A simple `slice()` replacement is not sufficient because JavaScript preserves sparse holes and `every()`/`map()` skip them. The bounded prefix is now copied through explicit indexed reads, producing `undefined` for a hole so validation fails closed.

## Verification

- Bun 1.3.14: `tests/route-decision-trace.test.ts` **22/22 passed**.
- Bun 1.4.0-canary.1 (`b22e0e6d0`): the same suite **22/22 passed**.
- `bun x tsc --noEmit`: passed.
- `bun scripts/privacy-scan.ts`: passed.
- `git diff --check`: passed.

## Checklist

- [x] Scope stays within trace hydration and its focused tests.
- [x] Oversized and sparse persisted input are both covered.
- [x] No routing selection or user-facing configuration semantics change.

Ready for review; upstream CI and maintainer review remain pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trace data normalization for reasoning effort values.
  * Limited processing to the first eight entries and consistently handled overly long strings.
  * Correctly handled sparse reasoning effort arrays without retaining invalid data.
  * Prevented inspection of entries beyond the retained limit, improving consistency and reliability.

* **Tests**
  * Added coverage for bounded processing, string truncation, and sparse array handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
