### PR TITLE
fix(server): restrict plaintext sideband overrides to numeric loopback

### DIFF
--- a/src/server/live.ts
+++ b/src/server/live.ts
@@ -207,8 +207,12 @@ export function parseLiveSidebandTarget(pathname: string, searchParams: URLSearc
  */
 function isLoopbackHost(hostname: string): boolean {
   const lower = hostname.toLowerCase();
+  const ipv4 = lower.split(".");
+  const ipv4Loopback = ipv4.length === 4
+    && ipv4[0] === "127"
+    && ipv4.every(part => /^\d{1,3}$/.test(part) && Number(part) <= 255);
   return lower === "localhost" || lower.endsWith(".localhost")
-    || lower === "127.0.0.1" || lower.startsWith("127.")
+    || ipv4Loopback
     || lower === "::1" || lower === "[::1]";
 }
 

--- a/tests/server-live.test.ts
+++ b/tests/server-live.test.ts
@@ -629,6 +629,7 @@ test("sideband URL policy: override precedence, normalization, and fail-closed b
   // Scheme rewrite: https -> wss; loopback http -> ws (the dev case the knob exists for).
   expect(buildLiveSidebandUpstreamWsUrl(frameless, "http://localhost:8080/v1")).toBe("ws://localhost:8080/v1/live/rtc_1");
   expect(buildLiveSidebandUpstreamWsUrl(frameless, "http://127.0.0.1:8080")).toBe("ws://127.0.0.1:8080/v1/live/rtc_1");
+  expect(buildLiveSidebandUpstreamWsUrl(frameless, "http://127.0.0.2:8080")).toBe("ws://127.0.0.2:8080/v1/live/rtc_1");
 
   // Fail-closed bounds: malformed, remote plaintext, userinfo, and non-http(s)
   // schemes all return the canonical root — a compromised or accidental override
@@ -637,6 +638,9 @@ test("sideband URL policy: override precedence, normalization, and fail-closed b
     "not a url",
     "http://realtime.example.test/v1",
     "ws://realtime.example.test/v1",
+    "http://127.256.0.1/v1",
+    "http://127.evil.example/v1",
+    "http://127.0.0.1.evil.example/v1",
     "https://user:pass@realtime.example.test/v1",
     "ftp://realtime.example.test/v1",
     "   ",


### PR DESCRIPTION
## Summary

- restrict plaintext Realtime sideband overrides to numeric IPv4 addresses in the 127.0.0.0/8 range;
- preserve localhost and IPv6 loopback handling;
- reject DNS names that merely begin with `127.` and fall back to the canonical secure Realtime endpoint;
- add positive and negative regression coverage for the hostname boundary.

## Why

The plaintext development exception used `hostname.startsWith("127.")`. A configured URL such as `http://127.evil.example/v1` therefore passed the loopback check even though it names a remote DNS host. The resulting sideband connection is created with the resolved upstream authorization headers and transparently relays Realtime frames.

This override is deliberately configuration-file-only and has no management API or GUI write surface, so the practical precondition is trusted local configuration. The fix nevertheless restores the documented invariant that plaintext `http/ws` is accepted only for loopback destinations.

## Verification

- Bun 1.3.14: `tests/server-live.test.ts` **27/27 passed**.
- Bun 1.4.0-canary.1 (`b22e0e6d0`): the same file **27/27 passed**.
- `bun x tsc --noEmit`: passed.
- `bun scripts/privacy-scan.ts`: passed.
- `git diff --check`: passed.

## Security boundary

The change narrows a credential-destination check. It does not add a new configuration or network surface. Plaintext remains available for numeric 127/8, localhost, and IPv6 loopback development endpoints; all other plaintext hostnames fail closed to `wss://api.openai.com/v1`.

## Checklist

- [x] Numeric IPv4 loopback compatibility is covered.
- [x] Deceptive `127.*` DNS names are rejected.
- [x] Existing sideband relay and readiness tests remain green.

Ready for review; upstream CI and the repository-required maintainer security review for credential-destination changes remain pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loopback address validation to accept only valid IPv4 loopback addresses.
  * Prevented hostname-like and out-of-range values from being incorrectly accepted.
  * Preserved support for `localhost`, `.localhost`, and IPv6 loopback addresses.
  * Expanded validation coverage for additional loopback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
