### PR TITLE
fix(ci): bind maintainer sponsorship to the reviewed head

### DIFF
--- a/.github/scripts/pr-sponsored-surface.cjs
+++ b/.github/scripts/pr-sponsored-surface.cjs
@@ -26,6 +26,14 @@ const RESTRICTED_PREFIXES = [
   "src/oauth/",
 ];
 
+const HEAD_SPECIFIC_APPROVAL_LABELS = [
+  "test-exception-approved",
+  "suppression-approved",
+  "generated-change-approved",
+  "dependency-change-approved",
+  "maintainer-sponsored",
+];
+
 const RESTRICTED_FILES = new Set([
   // Release and packaging automation executed by the release workflow.
   "scripts/release.ts",
@@ -63,6 +71,10 @@ function hasSponsorship(labels) {
   );
 }
 
+function headSpecificApprovalLabelsForAction(action) {
+  return action === "synchronize" ? HEAD_SPECIFIC_APPROVAL_LABELS : [];
+}
+
 /**
  * @returns {{ code: string, paths: string[] }[]} empty when the pull request may proceed
  */
@@ -80,8 +92,10 @@ function assessSponsoredSurface({
 }
 
 module.exports = {
+  HEAD_SPECIFIC_APPROVAL_LABELS,
   RESTRICTED_FILES,
   RESTRICTED_PREFIXES,
   assessSponsoredSurface,
+  headSpecificApprovalLabelsForAction,
   isRestrictedPath,
 };

--- a/.github/scripts/pr-sponsored-surface.test.cjs
+++ b/.github/scripts/pr-sponsored-surface.test.cjs
@@ -2,7 +2,31 @@
 
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
-const { assessSponsoredSurface, isRestrictedPath } = require("./pr-sponsored-surface.cjs");
+const {
+  HEAD_SPECIFIC_APPROVAL_LABELS,
+  assessSponsoredSurface,
+  headSpecificApprovalLabelsForAction,
+  isRestrictedPath,
+} = require("./pr-sponsored-surface.cjs");
+
+describe("head-specific approvals", () => {
+  it("keeps the exact set of labels that must be invalidated by a new head", () => {
+    assert.deepEqual(HEAD_SPECIFIC_APPROVAL_LABELS, [
+      "test-exception-approved",
+      "suppression-approved",
+      "generated-change-approved",
+      "dependency-change-approved",
+      "maintainer-sponsored",
+    ]);
+  });
+
+  it("invalidates them only when a synchronize event changes the reviewed head", () => {
+    assert.equal(headSpecificApprovalLabelsForAction("synchronize"), HEAD_SPECIFIC_APPROVAL_LABELS);
+    for (const action of ["opened", "reopened", "labeled", "unlabeled"]) {
+      assert.deepEqual(headSpecificApprovalLabelsForAction(action), [], action);
+    }
+  });
+});
 
 describe("isRestrictedPath", () => {
   it("covers auth, workflow, release, and dependency surfaces", () => {

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -43,7 +43,7 @@ jobs:
             const { assessHygiene } = require(
               path.join(process.cwd(), ".github", "scripts", "pr-hygiene.cjs"),
             );
-            const { assessSponsoredSurface } = require(
+            const { assessSponsoredSurface, headSpecificApprovalLabelsForAction } = require(
               path.join(process.cwd(), ".github", "scripts", "pr-sponsored-surface.cjs"),
             );
             const {
@@ -90,24 +90,14 @@ jobs:
             // Exception approvals are head-specific: a new commit invalidates
             // them, so a contributor cannot obtain one narrow exception and
             // then push unreviewed violations under the same label.
-            if (context.payload.action === "synchronize") {
-              for (const name of [
-                "test-exception-approved",
-                "suppression-approved",
-                "generated-change-approved",
-                "dependency-change-approved",
-              ]) {
-                if (labels.has(name)) {
-                  await github.rest.issues.removeLabel({
-                    owner, repo, issue_number: pull_number, name,
-                  });
-                  labels.delete(name);
-                }
+            for (const name of headSpecificApprovalLabelsForAction(context.payload.action)) {
+              if (labels.has(name)) {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: pull_number, name,
+                });
+                labels.delete(name);
               }
             }
-            // Sponsorship is head-independent: it is about which surfaces the
-            // change touches, not about the state of a particular revision, so
-            // it is NOT cleared by the synchronize sweep above.
             const failures = [
               ...assessHygiene({ files, labels: [...labels] }),
               ...assessSponsoredSurface({

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,9 @@ A ready-for-review PR is the author's claim that the change is complete, underst
 - Authentication, workflow, release automation, and dependency-installation
   surfaces need a maintainer to sponsor the change (`maintainer-sponsored`)
   before merge. Those are the places where a bad merge is expensive and hard to
-  unwind, which is why they are the only pre-approved surfaces here.
+  unwind, which is why they are the only pre-approved surfaces here. Sponsorship
+  is bound to the reviewed commit: pushing another commit clears the label, and
+  a maintainer reapplies it only after reviewing the new head.
 - A PR that stalls with unresolved review feedback may be closed, with the reason
   stated. A closed PR can be reopened once the stated reason is resolved, or
   replaced with a clean one.

--- a/docs-site/src/content/docs/contributing/pr-quality.md
+++ b/docs-site/src/content/docs/contributing/pr-quality.md
@@ -110,7 +110,9 @@ Authentication, credential handling, GitHub Actions workflows, release
 automation, and dependency installation need a maintainer to sponsor the change
 (`maintainer-sponsored`) before it merges. A bad merge on those surfaces is
 expensive and hard to unwind, which is why they are the only surfaces gated this
-way. Everything else is open.
+way. The sponsorship is bound to the reviewed commit. Pushing another commit
+clears the label, and a maintainer reapplies it only after reviewing the new
+head. Everything else is open.
 
 ## When a pull request is closed
 


### PR DESCRIPTION
## Summary

- make `maintainer-sponsored` a head-specific approval, alongside the four existing exception labels;
- centralize the exact five-label set and invalidate it only when a `synchronize` event changes the PR head;
- keep sponsorship intact for label, reopen, and other events that do not change the reviewed revision;
- document that a maintainer must review the new head and reapply sponsorship after any pushed commit.

## Why

The hygiene workflow currently treats `maintainer-sponsored` as PR-wide. Once applied, later commits retain the label even if they add or alter authentication, credential, GitHub Actions, release, or dependency-installation code.

That label is also the workflow's automated evidence that the restricted surface received the maintainer security review required before merge. Keeping it across a head change therefore separates the approval from the revision it was meant to attest. This does not create an automatic merge path—normal review and CI still apply—but it can make an old review appear current in a repository where these controls are enforced by convention.

The other four approval labels are already cleared on `synchronize`. This change gives sponsorship the same revision-bound lifecycle while preserving it on events that do not modify the head.

## Verification

- `node --test .github/scripts/pr-sponsored-surface.test.cjs`: **9/9 passed**.
- `node --test .github/scripts/pr-hygiene.test.cjs`: **21/21 passed**.
- Bun 1.3.14: `tests/ci-workflows.test.ts` **122/122 passed**.
- Bun 1.4.0-canary.1 (`b22e0e6d0`): the same file **122/122 passed**.
- `bun x tsc --noEmit`: passed.
- `bun scripts/privacy-scan.ts`: passed.
- `git diff --check`: passed.

## Security boundary

The workflow remains `pull_request_target` and continues to execute trusted default-branch code only. It does not check out PR-head content, expand token permissions, or add a write endpoint. The sole additional mutation is removing an existing approval label after a head-changing event; a maintainer can reapply it after reviewing that revision.

As with the existing hygiene policy, the live behavior changes only after this workflow reaches the repository default branch.

## Checklist

- [x] The exact five head-specific labels are regression-tested.
- [x] `synchronize` invalidates sponsorship.
- [x] Non-head-changing events preserve sponsorship.
- [x] Contributor documentation explains re-review and reapplication.

Draft pending upstream CI and the repository-required maintainer security review for GitHub Actions changes.