### PR TITLE
chore(typescript): bump to TypeScript 7.0.2 (native port)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@types/bun": "1.3.14",
-        "typescript": "5.9.3",
+        "typescript": "7.0.2",
       },
     },
   },
@@ -94,6 +94,46 @@
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -265,7 +305,7 @@
 
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@types/bun": "1.3.14",
-    "typescript": "5.9.3"
+    "typescript": "7.0.2"
   },
   "overrides": {
     "@hono/node-server": "2.1.0",

--- a/src/adapters/cursor/native-exec-common.ts
+++ b/src/adapters/cursor/native-exec-common.ts
@@ -15,14 +15,18 @@ export function clientBytes(message: Parameters<typeof create<typeof AgentClient
   return toBinary(AgentClientMessageSchema, create(AgentClientMessageSchema, message));
 }
 
-export function execBytes(execMsg: ExecServerMessage, messageCase: ExecClientMessage["message"]["case"], value: unknown): Uint8Array {
+export function execBytes<K extends ExecClientMessage["message"]["case"]>(
+  execMsg: ExecServerMessage,
+  messageCase: K,
+  value: Extract<ExecClientMessage["message"], { case: K }>["value"],
+): Uint8Array {
   return clientBytes({
     message: {
       case: "execClientMessage",
       value: create(ExecClientMessageSchema, {
         id: execMsg.id,
         execId: execMsg.execId,
-        message: { case: messageCase, value: value as never },
+        message: { case: messageCase, value } as ExecClientMessage["message"],
       }),
     },
   });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -204,6 +204,22 @@ function releaseLiveSidebandAdmission(ws: ServerWebSocket<WsData>): void {
   ws.data.liveTurnAdmissionLease = undefined;
 }
 
+/**
+ * Send one live-sideband frame to the upstream socket.
+ *
+ * Bun's `WebSocket.send` accepts `string | Blob | BufferSource`, but the DOM-lib
+ * `Buffer` can be backed by a `SharedArrayBuffer`, which `BufferSource` rejects.
+ * `Uint8Array.from` copies into a fresh `ArrayBuffer`-backed view, so a frame
+ * arriving from `node:buffer` still round-trips byte-for-byte.
+ */
+function sendUpstreamFrame(upstream: WebSocket, frame: string | Buffer): void {
+  if (typeof frame === "string") {
+    upstream.send(frame);
+    return;
+  }
+  upstream.send(Uint8Array.from(frame));
+}
+
 function finalizeLiveSideband(ws: ServerWebSocket<WsData>, upstream?: WebSocket): void {
   if (upstream && ws.data.liveUpstream !== upstream) return;
   if (ws.data.liveCloseFallback !== undefined) {
@@ -236,7 +252,10 @@ function armLiveSidebandCloseFallback(ws: ServerWebSocket<WsData>, upstream: Web
     // close event. That is still an observed CLOSED transport and is safe to
     // finalize. CONNECTING/CLOSING peers keep the lease so profile switching
     // fails at its own bounded drain deadline instead of racing live traffic.
-    if (upstream.readyState === WebSocket.CLOSED) finalizeLiveSideband(ws, upstream);
+    // The earlier CLOSED check narrowed `readyState` to 0|1|2 in the type
+    // system, but the socket can still transition to CLOSED (3) before this
+    // fallback fires; the cast keeps the runtime-identical check.
+    if ((upstream.readyState as number) === 3) finalizeLiveSideband(ws, upstream);
   }, LIVE_SIDEBAND_CLOSE_FALLBACK_MS);
 }
 
@@ -246,7 +265,9 @@ function closeLiveSideband(ws: ServerWebSocket<WsData>, code = 1000, reason = ""
   ws.data.livePending = undefined;
   ws.data.cancel = undefined;
   const upstream = ws.data.liveUpstream;
-  if (!upstream || upstream.readyState === WebSocket.CLOSED) {
+  // Bun's `WebSocket` type narrows `readyState` to 0|1|2 even though the DOM
+  // constant CLOSED is 3; the numeric literal is the runtime-identical check.
+  if (!upstream || upstream.readyState === 3) {
     finalizeLiveSideband(ws, upstream);
   } else {
     // The sideband holds a native-main admission lease. Do not release it just
@@ -299,7 +320,7 @@ function attachLiveSidebandUpstream(
     ws.data.livePending = undefined;
     for (const frame of pending) {
       try {
-        upstream.send(frame);
+        sendUpstreamFrame(upstream, frame);
       } catch {
         closeLiveSideband(ws, 1011, "upstream send failed");
         return;
@@ -1312,7 +1333,7 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
             return;
           }
           try {
-            upstream.send(raw);
+            sendUpstreamFrame(upstream, raw);
           } catch {
             closeLiveSideband(ws, 1011, "upstream send failed");
           }

--- a/tests/cursor-native-exec-common.test.ts
+++ b/tests/cursor-native-exec-common.test.ts
@@ -1,0 +1,81 @@
+import { create, fromBinary } from "@bufbuild/protobuf";
+import { describe, expect, test } from "bun:test";
+import { execBytes } from "../src/adapters/cursor/native-exec-common";
+import {
+  AgentClientMessageSchema,
+  DiagnosticsErrorSchema,
+  DiagnosticsResultSchema,
+  ExecServerMessageSchema,
+  McpResultSchema,
+  McpSuccessSchema,
+  RequestContextSuccessSchema,
+  RequestContextResultSchema,
+  RequestContextSchema,
+} from "../src/adapters/cursor/gen/agent_pb";
+
+function execServerMessage(message: Parameters<typeof create<typeof ExecServerMessageSchema>>[1]["message"]) {
+  return create(ExecServerMessageSchema, { id: 7, execId: "exec-test", message });
+}
+
+describe("execBytes serialization (TS 7 generic signature)", () => {
+  test("mcpResult round-trips the typed value", () => {
+    const bytes = execBytes(
+      execServerMessage({ case: "mcpArgs", value: create(McpResultSchema, {}) }),
+      "mcpResult",
+      create(McpResultSchema, {
+        result: { case: "success", value: create(McpSuccessSchema, { isError: false, content: [] }) },
+      }),
+    );
+
+    const decoded = fromBinary(AgentClientMessageSchema, bytes);
+    expect(decoded.message.case).toBe("execClientMessage");
+    expect(decoded.message.value.message.case).toBe("mcpResult");
+    expect(decoded.message.value.message.value.result.case).toBe("success");
+  });
+
+  test("requestContextResult round-trips the typed value", () => {
+    const bytes = execBytes(
+      execServerMessage({ case: "requestContextArgs", value: create(RequestContextResultSchema, {}) }),
+      "requestContextResult",
+      create(RequestContextResultSchema, {
+        result: {
+          case: "success",
+          value: create(RequestContextSuccessSchema, {
+            requestContext: create(RequestContextSchema, {
+              tools: [{
+                name: "fs_read",
+                providerIdentifier: "opencodex",
+                toolName: "fs_read",
+                description: "read a file",
+                inputSchema: new Uint8Array(),
+              }],
+            }),
+          }),
+        },
+      }),
+    );
+
+    const decoded = fromBinary(AgentClientMessageSchema, bytes);
+    expect(decoded.message.case).toBe("execClientMessage");
+    expect(decoded.message.value.message.case).toBe("requestContextResult");
+    expect(decoded.message.value.message.value.result.case).toBe("success");
+    expect(decoded.message.value.message.value.result.value.requestContext.tools[0].name).toBe("fs_read");
+  });
+
+  test("diagnosticsResult round-trips an error result", () => {
+    const bytes = execBytes(
+      execServerMessage({ case: "diagnosticsArgs", value: create(DiagnosticsResultSchema, {}) }),
+      "diagnosticsResult",
+      create(DiagnosticsResultSchema, {
+        result: {
+          case: "error",
+          value: create(DiagnosticsErrorSchema, { path: "/tmp/x", error: "unsupported" }),
+        },
+      }),
+    );
+
+    const decoded = fromBinary(AgentClientMessageSchema, bytes);
+    expect(decoded.message.case).toBe("execClientMessage");
+    expect(decoded.message.value.message.case).toBe("diagnosticsResult");
+  });
+});

--- a/tests/install-scripts.test.ts
+++ b/tests/install-scripts.test.ts
@@ -29,7 +29,7 @@ describe("install scripts", () => {
     expect(pkg.exports?.["."]?.bun).toBe("./src/index.ts");
     expect(pkg.exports?.["."]?.default).toBe("./bin/package-main.mjs");
     expect(pkg.dependencies?.zod).toBe("4.4.3");
-    expect(pkg.devDependencies?.typescript).toBe("5.9.3");
+    expect(pkg.devDependencies?.typescript).toBe("7.0.2");
     expect(pkg.devDependencies?.["@types/bun"]).toBe("1.3.14");
     expect(pkg.scripts?.dev).toBe("bun run src/cli/index.ts start");
     expect(pkg.scripts?.["dev:proxy"]).toBe("bun run src/cli/index.ts start");

--- a/tests/translator-budget.test.ts
+++ b/tests/translator-budget.test.ts
@@ -248,6 +248,9 @@ test("production adapter contract rejects omitted translator budgets at typechec
   const base = [
     "x", "tsc", "--noEmit", "--target", "ESNext", "--module", "ESNext",
     "--moduleResolution", "bundler", "--types", "bun-types", "--strict", "--skipLibCheck",
+    // TypeScript 7 refuses to run with files on the command line while a
+    // tsconfig.json is present (TS5112); the fixture is checked standalone.
+    "--ignoreConfig",
   ];
   const invalid = Bun.spawnSync(["bun", ...base, "tests/fixtures/translator-budget-required.invalid.ts"]);
   expect(invalid.exitCode).not.toBe(0);


### PR DESCRIPTION
## Summary

- Bump the root devDependency `typescript` 5.9.3 → 7.0.2 — the Go-based native port (8-12x faster full builds).
- Fix the three type-level strictness differences TS 7 surfaces in the proxy runtime:
  - `native-exec-common.ts`: make `execBytes` generic over the message case so the value type is checked consistently (removes the `as never` escape hatch).
  - `server/index.ts`: new `sendUpstreamFrame` helper copies `Buffer` frames into an `ArrayBuffer`-backed `Uint8Array` before `WebSocket.send` (Bun's `BufferSource` rejects `SharedArrayBuffer`-backed buffers); the live-sideband frame sends now use it.
  - `server/index.ts`: `readyState` CLOSED checks use the numeric literal 3 (with explanatory comments) where Bun's type narrows `readyState` to 0|1|2.
- No runtime behavior changes; the fixes are type-system-only accommodations.
- GUI stays on TS ~6.0.2 (typescript-eslint's `<6.1.0` peer bound); TS 7 support there waits on typescript-eslint 9.x.

## Validation

- `bun run typecheck` — pass (TS 7.0.2)
- `bun audit` — pass, 0 vulnerabilities
- `bun test` focused (cursor native exec + websocket live transport) — pass, 115 tests / 0 fail
- Full suite runs on CI (Linux shards); the Windows-local Bun crash is a documented pre-existing environment issue

## Review notes

- `execBytes` is called from native-exec.ts and native-exec-tools.ts with `create(SomeSchema, {...})` values; the generic signature type-checks each call site exactly.
- The `readyState` numeric-literal comparisons are runtime-identical to `WebSocket.CLOSED` (which is 3).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of binary live updates to ensure frames are transmitted reliably.
  * Preserved text-based live updates while improving connection close-state handling.
  * Strengthened command message validation and serialization for more reliable execution.
  * Improved handling of success, metadata, and diagnostic responses.

* **Compatibility**
  * Improved support for environments with stricter WebSocket type definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->