### PR TITLE
fix(windows): hide npm launcher proxy child

### DIFF
--- a/bin/ocx.mjs
+++ b/bin/ocx.mjs
@@ -481,6 +481,10 @@ const launchContext = JSON.stringify({
 });
 const child = spawn(bun, [cliPath, `${NODE_LAUNCH_PROOF_PREFIX}${launchProof}`, ...process.argv.slice(2)], {
   stdio: "inherit",
+  // A headless Windows parent (Task Scheduler, dashboard restart, shortcut) has no
+  // console to inherit. Without this flag Windows allocates a visible console for
+  // the long-running Bun child, and closing that window kills the proxy (#1236).
+  windowsHide: true,
   env: {
     ...process.env,
     [NODE_LAUNCH_CONTEXT_ENV]: launchContext,

--- a/tests/ocx-launcher-source.test.ts
+++ b/tests/ocx-launcher-source.test.ts
@@ -36,6 +36,17 @@ describe("ocx.mjs npm launcher (source invariants)", () => {
     expect(runtimeSource).toContain('export const BUN_RUNTIME_SOURCE_ENV = "OCX_BUN_RUNTIME_SOURCE";');
   });
 
+  test("the long-running Bun child stays hidden under a headless Windows launcher (#1236)", () => {
+    const spawnStart = source.indexOf("const child = spawn(bun, [cliPath");
+    expect(spawnStart).toBeGreaterThanOrEqual(0);
+    const spawnCall = source.slice(spawnStart, source.indexOf("});", spawnStart));
+
+    // Scope this to the final Node-to-Bun launch. Other helper spawns already hide
+    // their windows, but they do not cover the child that owns the proxy lifetime.
+    expect(spawnCall).toContain('stdio: "inherit"');
+    expect(spawnCall).toContain("windowsHide: true");
+  });
+
   test("Windows npm spawns use the trusted absolute invocation without shell lookup", () => {
     expect(source).toContain("const latestInvocation = npmInvocation(");
     expect(source).toContain("const installInvocation = npmInvocation(");


### PR DESCRIPTION
## Summary

* Set `windowsHide: true` on the final Node-to-Bun npm launcher spawn.
* Prevent headless Windows starts and restarts from allocating a visible, closable console for the long-running proxy child.
* Add a source-scoped regression for the exact Bun child spawn boundary.

Closes lidge-jun/opencodex#1236

## Verification

* `taskset -c 0-1 bun test tests/ocx-launcher-source.test.ts tests/ocx-launcher-runtime.test.ts tests/shutdown-launcher.test.ts` — 13 passed and 2 platform skips.
* `taskset -c 0-1 bun run typecheck` — passed.
* `taskset -c 0-1 bun run privacy:scan` — passed.
* The launcher integration checks cover signal forwarding, proxy teardown, and Codex config restoration after the spawn-option change.

## Checklist

- [X] Scope stays focused and avoids unrelated cleanup.
- [X] Docs or release notes were updated when needed.
- [X] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented an unnecessary console window from appearing when launching the application headlessly on Windows.
  * Preserved standard input, output, and error stream behavior for the long-running process.
* **Tests**
  * Added coverage to verify the Windows launch behavior and inherited console streams.