### PR TITLE
fix(cli): check live proxy before journal recovery

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -222,7 +222,6 @@ async function handleStart(options: { block?: boolean } = {}) {
   const serviceToken = loadServiceTokenFromFile(process.env);
   if (serviceToken) process.env.OPENCODEX_API_AUTH_TOKEN = serviceToken;
   const requestedPort = parsePortOption();
-  if (!currentExternalCodexModelProvider()) reconcileJournal();
   const existingPid = readPid();
   if (existingPid) {
     const live = await findLiveProxy();
@@ -232,6 +231,10 @@ async function handleStart(options: { block?: boolean } = {}) {
     }
     removePid(existingPid);
   }
+  // A losing concurrent start must not restore the active proxy's Codex config.
+  // Establish that the PID-file owner is stale before reconciling a dead journal;
+  // a healthy owner exits above without changing integration state (#1230).
+  if (!currentExternalCodexModelProvider()) reconcileJournal();
 
   // Interactive-only update prompt. Must run BEFORE we bind a port / write a
   // PID: choosing "Update now" installs globally and exits, so we never want a

--- a/tests/cli-start-journal-order.test.ts
+++ b/tests/cli-start-journal-order.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const source = readFileSync(join(import.meta.dir, "..", "src", "cli", "index.ts"), "utf8");
+
+function handleStartSource(): string {
+  const start = source.indexOf("async function handleStart(");
+  const end = source.indexOf("async function handleEnsure(", start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe("handleStart journal ownership ordering (#1230)", () => {
+  test("a healthy PID-file proxy is detected before journal reconciliation", () => {
+    const handleStart = handleStartSource();
+    const readPid = handleStart.indexOf("const existingPid = readPid();");
+    const findLive = handleStart.indexOf("const live = await findLiveProxy();", readPid);
+    const healthyExit = handleStart.indexOf("process.exit(1);", findLive);
+    const removeStalePid = handleStart.indexOf("removePid(existingPid);", healthyExit);
+    const reconcile = handleStart.indexOf("reconcileJournal();", removeStalePid);
+    const updatePrompt = handleStart.indexOf("await maybeShowUpdatePrompt();", reconcile);
+
+    expect(readPid).toBeGreaterThanOrEqual(0);
+    expect(findLive).toBeGreaterThan(readPid);
+    expect(healthyExit).toBeGreaterThan(findLive);
+    expect(removeStalePid).toBeGreaterThan(healthyExit);
+    expect(reconcile).toBeGreaterThan(removeStalePid);
+    expect(updatePrompt).toBeGreaterThan(reconcile);
+  });
+});


### PR DESCRIPTION
## Summary

* Check the PID-file owner and the live proxy before reconciling a stale Codex journal during `ocx start`.
* Exit without mutating Codex integration state when another healthy OpenCodex proxy already owns the start lifecycle.
* Keep stale-PID cleanup and journal recovery in place for genuine replacement starts.
* Add an ordering regression that pins the ownership check ahead of journal recovery.

Closes lidge-jun/opencodex#1230

## Verification

* `taskset -c 0-1 bun test tests/cli-start-journal-order.test.ts tests/codex-journal.test.ts tests/proxy-liveness.test.ts tests/stale-state-purge.test.ts` — 105 passed.
* `taskset -c 0-1 bun run typecheck` — passed.
* `taskset -c 0-1 bun run privacy:scan` — passed.
* `taskset -c 0-1 bun run test` — 9,765 passed and 10 skipped; the local all-suite run also retained unrelated baseline/environment failures in the Codex shim token fixture, Live sideband close timing, and GUI dependency setup. The focused lifecycle suites above are green; exact-head CI remains authoritative.

## Checklist

- [X] Scope stays focused and avoids unrelated cleanup.
- [X] Docs or release notes were updated when needed.
- [X] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup handling when another healthy proxy is already running.
  * Prevented competing startup attempts from modifying the active proxy’s configuration.
  * Correctly removes stale process state before reconciling startup data.
* **Tests**
  * Added coverage to verify the expected startup sequence and proxy detection behavior.