### PR TITLE
fix(ci): preserve code while normalizing issue media

### DIFF
--- a/.github/scripts/issue-quality-core.cjs
+++ b/.github/scripts/issue-quality-core.cjs
@@ -66,45 +66,78 @@ function isPlaceholderOnlyValue(raw) {
  */
 function stripMediaTokens(text) {
   if (typeof text !== "string") return "";
-  // Indented code lines render as literal code in GitHub Markdown. Protect
-  // them first so neither the HTML nor the Markdown media stripper can
-  // remove example syntax; restore the lines afterwards.
+  // Fenced and indented code render literally in GitHub Markdown. Protect
+  // them first so neither media stripper can remove example syntax. The
+  // protector deliberately leaves indented children of an unindented HTML
+  // media block visible: those lines are HTML children, not Markdown code.
   const protectedText = protectIndentedCodeLines(text);
   const markdownStripped = stripMarkdownImages(stripHtmlMedia(protectedText.text));
   const referenceStripped = stripReferenceImages(markdownStripped);
-  return restoreIndentedCodeLines(referenceStripped, protectedText.lines);
+  return restoreIndentedCodeLines(referenceStripped, protectedText);
 }
 
 /**
- * Replace every indented code line (4+ leading spaces or a tab) with a
- * placeholder of equal length so media stripping cannot touch it. Returns the
- * masked text plus the original lines for restoration.
+ * Replace fenced code and indented code outside HTML media blocks with opaque
+ * tokens. Restoration is token-based rather than line-position-based because
+ * stripping a multiline media block may collapse or remove lines.
  */
 function protectIndentedCodeLines(text) {
   const lines = [];
+  let markerPrefix = "\u0000OCX_ISSUE_CODE_";
+  while (text.includes(markerPrefix)) markerPrefix += "_";
+  let mediaDepth = 0;
+  let fence = null;
+
+  const mask = (line) => {
+    const index = lines.push(line) - 1;
+    return `${markerPrefix}${index}\u0000`;
+  };
+
   const masked = text.split("\n").map((line) => {
-    if (/^(?: {4,}|\t)/.test(line)) {
-      lines.push(line);
-      return "\u0000" + line.replace(/[^\n]/g, " ").slice(1);
+    if (fence) {
+      const closing = new RegExp(`^ {0,3}${fence.char}{${fence.length},}[ \\t]*$`);
+      if (closing.test(line)) fence = null;
+      return mask(line);
     }
-    lines.push(null);
+
+    const fenceStart = line.match(/^ {0,3}(`{3,}|~{3,})/);
+    if (fenceStart) {
+      fence = { char: fenceStart[1][0], length: fenceStart[1].length };
+      return mask(line);
+    }
+
+    // Four-space/tab lines inside an active unindented HTML media block are
+    // child markup or fallback text. Treating them as code would keep an
+    // otherwise media-only <picture>/<video> block alive.
+    if (mediaDepth === 0 && /^(?: {4,}|\t)/.test(line)) {
+      return mask(line);
+    }
+
+    mediaDepth = Math.max(0, mediaDepth + htmlMediaDepthDelta(line));
     return line;
   });
-  return { text: masked.join("\n"), lines };
+  return { text: masked.join("\n"), lines, markerPrefix };
 }
 
 /**
- * Restore masked indented-code lines from their original content. Placeholder
- * lines are identified by the leading \u0000 marker and matched positionally.
+ * Count opening/closing block-media tags on one line. Self-closing tags do not
+ * create a block. This small scanner is only for deciding whether indentation
+ * belongs to HTML; stripHtmlMedia remains the authority for removing media.
  */
-function restoreIndentedCodeLines(text, lines) {
-  const out = text.split("\n").map((line, i) => {
-    if (lines[i] !== null && line.startsWith("\u0000")) {
-      return lines[i];
-    }
-    return line;
-  });
-  return out.join("\n");
+function htmlMediaDepthDelta(line) {
+  let delta = 0;
+  for (const match of line.matchAll(/<(\/)?(picture|video|audio)\b[^>]*>/gi)) {
+    if (match[1]) delta -= 1;
+    else if (!/\/\s*>$/.test(match[0])) delta += 1;
+  }
+  return delta;
+}
+
+/** Restore protected code from ordered tokens, independent of line count. */
+function restoreIndentedCodeLines(text, protection) {
+  const escapedPrefix = protection.markerPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const token = new RegExp(`${escapedPrefix}(\\d+)\\u0000`, "g");
+  return text.replace(token, (_match, rawIndex) => protection.lines[Number(rawIndex)] ?? "");
 }
 
 /**
@@ -131,7 +164,9 @@ function stripHtmlMedia(text) {
         .replace(/<[^>]+>/g, " ")
         .replace(/[\s_*~`]+/g, " ")
         .trim();
-      return innerStripped.length === 0 ? " " : match;
+      // GitHub's generated placeholders remain empty even when wrapped as
+      // fallback text inside a media element. Real captions remain intact.
+      return innerStripped.length === 0 || isPlaceholderOnlyValue(innerStripped) ? " " : match;
     },
   );
   return s;

--- a/.github/scripts/issue-quality.test.cjs
+++ b/.github/scripts/issue-quality.test.cjs
@@ -396,12 +396,45 @@ describe("validateIssue - feature", () => {
       false,
     );
     assert.equal(isMediaOnly('<picture><source srcset="x.webp"><img src="x.png"></picture>'), true);
+    assert.equal(isMediaOnly('<video>No response</video>'), true);
+    assert.equal(isMediaOnly('<audio> _No response_ </audio>'), true);
+    assert.equal(clean('<video>No response</video>'), "");
+    assert.equal(
+      isMediaOnly('<picture>\n    <source srcset="x.webp">\n    <img src="x.png">\n</picture>'),
+      true,
+    );
+    assert.equal(
+      isMediaOnly('<video>\n    <source src="clip.mp4">\n    Real fallback caption\n</video>'),
+      false,
+    );
     assert.equal(isMediaOnly('<video src="clip.mp4"></video>'), true);
     assert.equal(isMediaOnly('<img src="x.png" />\nCaption text'), false);
     assert.equal(isMediaOnly("Some real description."), false);
     assert.equal(stripMediaTokens('<img src="x.png" />').trim(), "");
     assert.equal(stripMediaTokens('![alt](url "title")').trim(), "");
     assert.equal(stripMediaTokens('before ![alt](url) after').replace(/\s+/g, " ").trim(), "before after");
+
+    const fencedMediaExample = [
+      "```html",
+      "<video>No response</video>",
+      "```",
+    ].join("\n");
+    assert.equal(stripMediaTokens(fencedMediaExample), fencedMediaExample);
+    assert.equal(isMediaOnly(fencedMediaExample), false);
+
+    const protectedAroundMedia = [
+      "    ![before](url)",
+      "<video>",
+      '    <source src="clip.mp4">',
+      "</video>",
+      "    ![after](url)",
+    ].join("\n");
+    const strippedAroundMedia = stripMediaTokens(protectedAroundMedia);
+    assert.ok(strippedAroundMedia.includes("    ![before](url)"));
+    assert.ok(strippedAroundMedia.includes("    ![after](url)"));
+    assert.equal(strippedAroundMedia.includes("<video>"), false);
+    assert.equal(strippedAroundMedia.includes("<source"), false);
+    assert.equal(strippedAroundMedia.includes("\u0000"), false);
   });
 
   it("accepts a concise but actionable feature", () => {


### PR DESCRIPTION
## Summary

* treat exact placeholder fallback text inside HTML media as empty
* preserve fenced and indented code with ordered restoration tokens
* avoid positional restoration after multiline media stripping changes line count

## Root cause

The issue-quality normalizer protected every indented line before it identified HTML media blocks. Indented `<source>` and `<img>` children were therefore preserved as Markdown code, keeping otherwise media-only blocks substantive. Restoration also depended on original line indexes even though stripping a multiline media block can remove lines. Separately, placeholder fallback text such as `<video>No response</video>` was treated as a real caption.

The fix distinguishes indented children of an active HTML media block from literal Markdown code, protects fenced and indented examples with collision-resistant ordered tokens, and restores those tokens independently of line count. Only exact placeholder fallback values are removed; real captions remain substantive.

## Validation

* `node --test .github/scripts/issue-quality.test.cjs` — 112 passed
* related issue-quality / PR-quality / target-enforcement tests — 211 passed
* `bun run typecheck` — passed
* `bun run privacy:scan` — passed
* `git diff --check` — passed

Closes lidge-jun/opencodex#1196

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of media markup in issue content, including nested picture, audio, and video elements.
  * Removes media blocks with placeholder-only fallback text while preserving meaningful captions and prose.
  * Correctly preserves fenced and indented code examples, including media-like markup.
  * Prevents formatting artifacts when content is processed.