### PR TITLE
test(catalog): pin the custom-provider reasoning-summary opt-in (#1100)

### DIFF
--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -2388,6 +2388,89 @@ describe("Codex catalog routed normalization", () => {
     expect(routed?.supports_reasoning_summaries).toBe(true);
   });
 
+  // #1100 (supersedes PR #1119): a routed row can advertise a full effort ladder
+  // while `supports_reasoning_summaries` is false, and Codex gates construction
+  // of the whole Responses `reasoning` object on that flag — so the Desktop
+  // picker offers an effort the wire never carries. The landed built-in
+  // coverage below ("built-in DeepSeek and GLM effort models opt into Codex
+  // reasoning propagation") pins the registry rows. These three pin the CUSTOM
+  // provider route, which the built-in tests cannot reach.
+  test("routed strip does not defeat an explicit custom-provider summary opt-in (#1100)", async () => {
+    const models = await gatherRoutedModels({
+      providers: {
+        ladder: {
+          adapter: "openai-responses",
+          baseUrl: "https://ladder.example.test/v1",
+          authMode: "key",
+          liveModels: false,
+          models: ["effort-model"],
+          modelReasoningEfforts: { "effort-model": ["low", "high", "max"] },
+          modelSupportsReasoningSummaries: { "effort-model": true },
+        },
+      },
+    });
+    // A template is required. buildCatalogEntries(null, ...) takes the fallback
+    // branch, which never runs the routed strip, so a null-template assertion
+    // cannot detect a reordering regression.
+    const entries = buildCatalogEntries(nativeTemplate(), [], models);
+    const routed = entries.find(e => e.slug === "ladder/effort-model");
+
+    expect((routed?.supported_reasoning_levels as { effort: string }[]).map(l => l.effort))
+      .toEqual(expect.arrayContaining(["low", "high", "max"]));
+    // The opt-in survives normalizeRoutedCatalogEntry's delete only because
+    // applyCatalogModelMetadata runs after it in buildCatalogEntries' routed
+    // branch (src/codex/catalog/sync.ts). Swap that order and every opted-in
+    // routed provider silently stops receiving reasoning.effort from Codex,
+    // while the picker keeps advertising the ladder.
+    expect(routed?.supports_reasoning_summaries).toBe(true);
+  });
+
+  test("custom routed rows without an opt-in stay conservative about summaries (#1100)", async () => {
+    const models = await gatherRoutedModels({
+      providers: {
+        plain: {
+          adapter: "openai-responses",
+          baseUrl: "https://plain.example.test/v1",
+          authMode: "key",
+          liveModels: false,
+          models: ["effort-model"],
+          modelReasoningEfforts: { "effort-model": ["low", "high", "max"] },
+        },
+      },
+    });
+    const entries = buildCatalogEntries(nativeTemplate(), [], models);
+    const routed = entries.find(e => e.slug === "plain/effort-model");
+
+    // Deliberate: we do not claim OpenAI-only summary delivery for an arbitrary
+    // endpoint just because it has an effort ladder. The supported remedy is the
+    // per-model opt-in asserted above. Pinned so flipping this default is always
+    // a deliberate decision rather than an accident.
+    expect(routed?.supports_reasoning_summaries).toBe(false);
+  });
+
+  test("the no-template fallback never applies the routed summary strip (#1100)", async () => {
+    const models = await gatherRoutedModels({
+      providers: {
+        ladder: {
+          adapter: "openai-responses",
+          baseUrl: "https://ladder.example.test/v1",
+          authMode: "key",
+          liveModels: false,
+          models: ["effort-model"],
+          modelReasoningEfforts: { "effort-model": ["low", "high", "max"] },
+          modelSupportsReasoningSummaries: { "effort-model": true },
+        },
+      },
+    });
+    // Pins the asymmetry itself: the fallback path skips
+    // normalizeRoutedCatalogEntry entirely, so this row is opt-in-true for a
+    // different reason than the template row above. Kept explicit so a future
+    // unification of the two construction paths is a visible change.
+    const routed = buildCatalogEntries(null, [], models).find(e => e.slug === "ladder/effort-model");
+    expect(routed?.supports_reasoning_summaries).toBe(true);
+  });
+
+
   test("built-in DeepSeek and GLM effort models opt into Codex reasoning propagation (#1100)", async () => {
     const expected = [
       { slug: "deepseek/deepseek-v4-flash", efforts: ["low", "high", "max", "ultra"] },


### PR DESCRIPTION
## Summary

Pins the custom-provider half of the #1100 reasoning-summary contract, so PR #1119 can be closed without losing regression coverage.

The landed #1100 tests cover the built-in registry rows. They do not reach the custom-provider route, where an explicit `modelSupportsReasoningSummaries` opt-in has to survive the routed strip. Both existing custom-provider tests call `buildCatalogEntries(null, ...)`, which takes the fallback branch and never runs `normalizeRoutedCatalogEntry` — so an ordering regression in the template path was invisible to every existing test.

That survival is ordering-dependent: `normalizeRoutedCatalogEntry` deletes the flag and `applyCatalogModelMetadata` restores it. Reverse them and every opted-in routed provider silently stops receiving `reasoning.effort` from Codex while the picker keeps advertising the ladder — the original #1100 symptom.

Three tests: the opt-in survives the template path, an absent opt-in stays conservative rather than claiming OpenAI-only summary delivery for an arbitrary endpoint, and the no-template fallback reaches the same answer by a different route (kept explicit so unifying the two construction paths is a visible change).

Supersedes the test portion of #1119, whose branch is ~1,800 commits behind `dev`. Authored originally there; preserved via `Co-authored-by`.

## Verification

- `bun test tests/codex-catalog.test.ts` — 132 pass / 0 fail
- `bun run typecheck` — clean
- Ablation: swapping `normalizeRoutedCatalogEntry` and `applyCatalogModelMetadata` fails the new opt-in test plus the landed built-in test (6 pass / 2 fail); reverting restores 8 pass / 0 fail

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for reasoning-effort metadata across routed custom providers.
  * Verified that explicit reasoning-summary settings are preserved when supported.
  * Confirmed conservative behavior when summary support is not explicitly enabled.
  * Covered fallback behavior when no template is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->