### PR TITLE
fix(gui): clear a stale install failure once that action succeeded (#1245)

### DIFF
--- a/gui/src/pages/Startup.tsx
+++ b/gui/src/pages/Startup.tsx
@@ -81,7 +81,7 @@ export default function Startup({ apiBase }: { apiBase: string }) {
   const [trayBusy, setTrayBusy] = useState(false);
   const [trayError, setTrayError] = useState(false);
   const [installBusy, setInstallBusy] = useState<StartupInstallAction | null>(null);
-  const [installResult, setInstallResult] = useState<{ kind: "success" | "error"; action: StartupInstallAction; repair?: boolean; detail?: string } | null>(null);
+  const [installResult, setInstallResult] = useState<{ kind: "success" | "error"; action: StartupInstallAction; repair?: boolean; detail?: string; forLocalRouting?: boolean } | null>(null);
   const [codexRuntimeWarning, setCodexRuntimeWarning] = useState<string | null>(() => cached?.warning ?? null);
   const [codexRuntimeFix, setCodexRuntimeFix] = useState<string | null>(() => cached?.fix ?? null);
   /** True while settings (runtime notice) are still in flight — reserves notice slot height. */
@@ -107,6 +107,29 @@ export default function Startup({ apiBase }: { apiBase: string }) {
       const res = await fetch(`${apiBase}/api/startup-health`, { signal });
       if (!res.ok) throw new Error("fetch failed");
       const next = await res.json() as StartupHealthData;
+      // #1245: a failed install notice is a claim about ONE attempt, not about the
+      // current state. Once health independently shows that attempt's goal is met —
+      // the user may well have reached it another way — the notice contradicts what
+      // the same page is showing and must yield.
+      //
+      // Scoped per action deliberately. `status` is overall restart safety, so a
+      // machine protected by the service would otherwise erase a failed SHIM
+      // install, which is still true and still actionable. Each action clears only
+      // against the health field it was trying to change; restoring native routing
+      // retires both, since neither install is outstanding then.
+      setInstallResult(current => {
+        if (current?.kind !== "error") return current;
+        // Native routing retires an install that existed to protect a local
+        // routing dependency. It does not retire an optional shim a native
+        // machine can still install — that button is still on the page.
+        if (next.status === "native" && current.forLocalRouting === true) return null;
+        const satisfied = current.action === "install-service"
+          // serviceViable, not installed-and-running: a stale or conflicting
+          // service can be both while the page still reports it unhealthy.
+          ? next.serviceViable
+          : next.shimInstalled && next.shimHealthy;
+        return satisfied ? null : current;
+      });
       paintedRef.current = true;
       const prevCache = readSessionListCache<StartupPageCache>(cacheKey);
       writeSessionListCache(cacheKey, {
@@ -247,7 +270,11 @@ export default function Startup({ apiBase }: { apiBase: string }) {
       setInstallResult({ kind: "success", action, repair: opts?.repair === true });
       refresh();
     } catch (error) {
-      setInstallResult({ kind: "error", action, repair: opts?.repair === true, detail: error instanceof Error ? error.message : String(error) });
+      // #1245: remember whether this attempt was made while startup depended on
+      // local routing. A later switch to native retires an install that existed to
+      // protect that dependency, but says nothing about an optional shim a native
+      // machine can still choose to install.
+      setInstallResult({ kind: "error", action, repair: opts?.repair === true, detail: error instanceof Error ? error.message : String(error), forLocalRouting: data?.localRoutingDependency === true });
     } finally {
       setInstallBusy(null);
     }

--- a/gui/tests/startup-install-result-reconciliation.test.tsx
+++ b/gui/tests/startup-install-result-reconciliation.test.tsx
@@ -1,0 +1,259 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act } from "react";
+import type { Root } from "react-dom/client";
+import { LanguageProvider } from "../src/i18n/provider";
+import { clearClientResourceStoresForTests } from "../src/client-resource";
+import Startup from "../src/pages/Startup";
+import { writeSessionListCache } from "../src/session-list-cache";
+
+const globals = ["document", "window", "navigator", "localStorage", "sessionStorage", "IS_REACT_ACT_ENVIRONMENT"] as const;
+let previousGlobals: Record<(typeof globals)[number], unknown>;
+let testWindow: Window;
+const originalFetch = globalThis.fetch;
+
+const API_BASE = "http://localhost";
+const CACHE_KEY = `ocx.startup.page.v1:${API_BASE}`;
+
+function atRiskHealth() {
+  return {
+    status: "at-risk",
+    routingKind: "opencodex-local",
+    routingInjected: true,
+    localRoutingDependency: true,
+    autostartEnabled: false,
+    rebootSafe: false,
+    protection: "none",
+    serviceInstalled: false,
+    serviceViable: false,
+    serviceEnabled: false,
+    serviceRunning: false,
+    serviceStale: false,
+    serviceConflict: false,
+    serviceSupported: true,
+    shimInstalled: false,
+    shimHealthy: false,
+    shimCoverage: "none",
+    platform: "darwin",
+    recommendedCommand: "ocx service install",
+    diagnosticStale: false,
+    commands: { installService: "ocx service install", repairService: "ocx service repair", installShim: "ocx shim install", restoreNative: "ocx restore" },
+  };
+}
+
+function protectedHealth() {
+  return { ...atRiskHealth(), status: "protected", protection: "service", serviceInstalled: true, serviceViable: true, serviceEnabled: true, serviceRunning: true, rebootSafe: true };
+}
+
+beforeEach(() => {
+  clearClientResourceStoresForTests();
+  previousGlobals = Object.fromEntries(globals.map(key => [key, Reflect.get(globalThis, key)])) as typeof previousGlobals;
+  testWindow = new Window({ url: "http://localhost/" });
+  Object.defineProperties(globalThis, {
+    document: { configurable: true, value: testWindow.document },
+    window: { configurable: true, value: testWindow.window },
+    navigator: { configurable: true, value: testWindow.navigator },
+    localStorage: { configurable: true, value: testWindow.localStorage },
+    sessionStorage: { configurable: true, value: testWindow.sessionStorage },
+  });
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  testWindow.sessionStorage.clear();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  clearClientResourceStoresForTests();
+  testWindow.close();
+  for (const key of globals) {
+    Object.defineProperty(globalThis, key, { configurable: true, value: previousGlobals[key] });
+  }
+});
+
+// #1245: a failed install notice is a claim about one attempt. If the user then
+// reaches that attempt's goal another way -- the CLI, the service manager, a retry
+// the page did not initiate -- the refresh reports success while the stale failure
+// keeps claiming otherwise, with no way to dismiss it.
+//
+// The clearing is scoped per action on purpose, and the second test pins that:
+// `status` is overall restart safety, so a machine protected by the service must
+// NOT erase a failed shim install, which is still true and still actionable.
+
+// The two install buttons both read "Install"; only their aria-label
+// distinguishes service from shim. Match the accessible name so a copy change
+// cannot silently retarget the click.
+function accessibleName(el: Element): string {
+  return el.getAttribute("aria-label") ?? el.textContent ?? "";
+}
+
+function clickTarget(pattern: RegExp): HTMLButtonElement {
+  const button = [...container().querySelectorAll("button")]
+    .find(b => pattern.test(accessibleName(b)));
+  if (!button) {
+    const names = [...container().querySelectorAll("button")].map(accessibleName);
+    throw new Error(`no button matching ${pattern}; saw: ${JSON.stringify(names)}`);
+  }
+  return button as unknown as HTMLButtonElement;
+}
+
+let containerEl: HTMLElement | null = null;
+function container(): HTMLElement {
+  if (!containerEl) throw new Error("container not mounted");
+  return containerEl;
+}
+
+async function mount(health: () => Record<string, unknown>, onAction: () => Response) {
+  const { createRoot } = await import("react-dom/client");
+  containerEl = document.createElement("div");
+  document.body.append(containerEl);
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("/api/settings")) return Response.json({ codexRuntime: {} });
+    if (url.includes("/api/startup-action")) return onAction();
+    if (url.includes("/api/startup-health")) return Response.json(health());
+    return new Response(null, { status: 404 });
+  }) as typeof fetch;
+
+  let root!: Root;
+  await act(async () => {
+    root = createRoot(containerEl!);
+    root.render(<LanguageProvider><Startup apiBase={API_BASE} /></LanguageProvider>);
+  });
+  await settle();
+  return root;
+}
+
+// Drain the microtask queue and any zero-delay timers React scheduled, without
+// betting on a fixed wall-clock duration.
+async function settle() {
+  for (let i = 0; i < 8; i++) {
+    await act(async () => { await new Promise<void>(r => testWindow.setTimeout(r, 0)); });
+  }
+}
+
+test("a failed service install clears once the service is independently running (#1245)", async () => {
+  let health = atRiskHealth();
+  const root = await mount(() => health, () => Response.json({ error: "service install failed" }, { status: 500 }));
+
+  await act(async () => {
+    clickTarget(/service.*install/i).dispatchEvent(new testWindow.Event("click", { bubbles: true }));
+  });
+  await settle();
+  expect(container().textContent).toContain("service install failed");
+
+  // The service comes up by some other route; the page refreshes.
+  health = { ...atRiskHealth(), status: "protected", protection: "service", serviceInstalled: true, serviceViable: true, serviceEnabled: true, serviceRunning: true, rebootSafe: true };
+  await act(async () => {
+    clickTarget(/refresh/i).dispatchEvent(new testWindow.Event("click", { bubbles: true }));
+  });
+  await settle();
+
+  expect(container().textContent).not.toContain("service install failed");
+
+  await act(async () => { root.unmount(); });
+  containerEl!.remove();
+  containerEl = null;
+});
+
+test("a failed shim install survives a refresh that only proves the service is healthy (#1245)", async () => {
+  let health = atRiskHealth();
+  const root = await mount(() => health, () => Response.json({ error: "shim install failed" }, { status: 500 }));
+
+  await act(async () => {
+    clickTarget(/shim.*install/i).dispatchEvent(new testWindow.Event("click", { bubbles: true }));
+  });
+  await settle();
+  expect(container().textContent).toContain("shim install failed");
+
+  // Restart safety is now covered BY THE SERVICE. The shim is still not installed,
+  // so the shim failure is still true — clearing it here would hide a real problem
+  // behind an unrelated success.
+  health = { ...atRiskHealth(), status: "protected", protection: "service", serviceInstalled: true, serviceViable: true, serviceEnabled: true, serviceRunning: true, rebootSafe: true };
+  await act(async () => {
+    clickTarget(/refresh/i).dispatchEvent(new testWindow.Event("click", { bubbles: true }));
+  });
+  await settle();
+
+  expect(container().textContent).toContain("shim install failed");
+
+  await act(async () => { root.unmount(); });
+  containerEl!.remove();
+  containerEl = null;
+});
+
+test("a failed service repair survives a refresh where the service is still stale (#1245)", async () => {
+  let health = { ...atRiskHealth(), serviceInstalled: true, serviceRunning: true, serviceStale: true, serviceViable: false };
+  const root = await mount(() => health, () => Response.json({ error: "service repair failed" }, { status: 500 }));
+
+  await act(async () => {
+    clickTarget(/service.*repair/i).dispatchEvent(new testWindow.Event("click", { bubbles: true }));
+  });
+  await settle();
+  expect(container().textContent).toContain("service repair failed");
+
+  // A stale or conflicting service can be installed AND running while the page
+  // still reports it unhealthy. Installed-and-running is therefore not proof the
+  // repair worked; serviceViable is what the UI itself treats as healthy.
+  health = { ...health, serviceInstalled: true, serviceRunning: true, serviceStale: true, serviceViable: false };
+  await act(async () => {
+    clickTarget(/refresh/i).dispatchEvent(new testWindow.Event("click", { bubbles: true }));
+  });
+  await settle();
+
+  expect(container().textContent).toContain("service repair failed");
+
+  await act(async () => { root.unmount(); });
+  containerEl!.remove();
+  containerEl = null;
+});
+
+test("a failed shim install on an already-native machine survives a native refresh (#1245)", async () => {
+  // Native routing means no local routing dependency to protect, but the shim
+  // Install button is still offered, so a failed optional shim install is still
+  // true. Clearing on `native` alone would hide it.
+  const nativeHealth = () => ({ ...atRiskHealth(), status: "native", routingKind: "native", routingInjected: false, localRoutingDependency: false, protection: "none", rebootSafe: true });
+  const root = await mount(nativeHealth, () => Response.json({ error: "shim install failed" }, { status: 500 }));
+
+  await act(async () => {
+    clickTarget(/shim.*install/i).dispatchEvent(new testWindow.Event("click", { bubbles: true }));
+  });
+  await settle();
+  expect(container().textContent).toContain("shim install failed");
+
+  await act(async () => {
+    clickTarget(/refresh/i).dispatchEvent(new testWindow.Event("click", { bubbles: true }));
+  });
+  await settle();
+
+  expect(container().textContent).toContain("shim install failed");
+
+  await act(async () => { root.unmount(); });
+  containerEl!.remove();
+  containerEl = null;
+});
+
+test("a failed install clears when the user restores native routing instead (#1245)", async () => {
+  // The positive side of the routing-provenance branch. The attempt was made
+  // while startup depended on the local proxy; restoring native routing removes
+  // that dependency, so the install it was protecting is no longer outstanding
+  // and its failure notice is obsolete.
+  let health = atRiskHealth();
+  const root = await mount(() => health, () => Response.json({ error: "service install failed" }, { status: 500 }));
+
+  await act(async () => {
+    clickTarget(/service.*install/i).dispatchEvent(new testWindow.Event("click", { bubbles: true }));
+  });
+  await settle();
+  expect(container().textContent).toContain("service install failed");
+
+  health = { ...atRiskHealth(), status: "native", routingKind: "native", routingInjected: false, localRoutingDependency: false, protection: "none", rebootSafe: true };
+  await act(async () => {
+    clickTarget(/refresh/i).dispatchEvent(new testWindow.Event("click", { bubbles: true }));
+  });
+  await settle();
+
+  expect(container().textContent).not.toContain("service install failed");
+
+  await act(async () => { root.unmount(); });
+  containerEl!.remove();
+  containerEl = null;
+});


### PR DESCRIPTION
## Summary

The Startup Safety page kept showing "Installation failed" after startup protection was already in place. A user who hit a failing install and then fixed it another way — the CLI, the service manager, a retry the page did not initiate — saw "Restart protected" and "Installation failed" at the same time, with no way to dismiss the contradiction.

`installResult` was only reset when the page itself started an action, so a refresh replaced the health data underneath a notice describing a past attempt.

`fetchStartup` now retires a failed notice only when health independently shows that attempt's goal is met. Three conditions, each added after reproducing a case where a looser rule hid something true:

- **per action, not overall status** — a machine protected by the service must not erase a failed shim install, which is still true and actionable
- **`serviceViable`, not installed-and-running** — a stale or conflicting service can be both while the page reports it unhealthy, so a failed repair would vanish while the UI still said "Stale"
- **native routing retires only installs made under a local routing dependency**, recorded on the error at action time; a native machine is still offered the shim button, so an optional shim failure there stands

Success notices are left alone — those are the receipt for an action the user just ran.

Closes #1245.

### GUI change

Before — a failed install, then the service comes up another way. Both messages on screen:

![before](https://raw.githubusercontent.com/lidge-jun/opencodex/pr-assets-1245-startup-stale/1245-before.png)

After — the stale failure is gone, and the shim correctly still reads "Not installed":

![after](https://raw.githubusercontent.com/lidge-jun/opencodex/pr-assets-1245-startup-stale/1245-after.png)

## Verification

- `bun test tests` (gui) — 684 pass / 0 fail
- `bun run lint:gui` — clean
- `bun run typecheck` — clean
- Five regressions drive the real page through button clicks and fetch responses: two assert clearing, three assert survival. Every branch has a test that goes red when that branch is deleted or widened.
- Screenshots above are a live render against a stubbed startup-health API, driven through the page's own Install and Refresh buttons.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup install error handling during health refreshes.
  * Resolved failed installation notices when the related service or routing condition is restored.
  * Preserved unrelated or still-relevant failure notices instead of clearing them prematurely.

* **Tests**
  * Added coverage for service recovery, routing changes, stale failures, and native routing restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->