### PR TITLE
feat(routing): use pool-aware quota evidence for policy profiles

### DIFF
--- a/src/routing/quota.ts
+++ b/src/routing/quota.ts
@@ -24,11 +24,8 @@ import type { RouteQuotaEvidence } from "./trace";
 export interface QuotaEvidenceInput {
   provider: string;
   model: string;
-  /** Opaque account reference for per-account quota sources. */
   accountRef?: string;
-  /** Codex pool account id (provider "openai"). */
   codexAccountId?: string;
-  /** The account's plan (provider "openai"); selects the governing quota window. */
   codexAccountPlan?: string;
 }
 
@@ -40,16 +37,15 @@ export interface CodexPoolQuotaAccount {
 function codexAccountQuotaEvidence(accountId: string, plan?: string): RouteQuotaEvidence {
   const quota = getAccountQuota(accountId);
   if (!quota) return { known: false };
-
-  // Go/Free accounts report a 30-day window only; weekly windows gate
-  // everything else. `codexQuotaWindowForPlan` is the single shared rule
-  // (parser, exhaustion, recovery), so select the plan-specific bars here too.
   const monthly = codexQuotaWindowForPlan(plan) === "monthly";
   const percents = [
     ...(monthly ? [] : [quota.weeklyPercent]),
     quota.monthlyPercent,
   ].filter((value): value is number => typeof value === "number" && Number.isFinite(value));
   const maxPercent = percents.length > 0 ? Math.max(...percents) : undefined;
+  // Credits-only snapshots prove neither usage nor exhaustion. Unknown must not
+  // become healthy capacity merely because a cache row exists.
+  if (maxPercent === undefined) return { known: false };
   const resets = [
     ...(monthly ? [] : [quota.weeklyResetAt]),
     quota.monthlyResetAt,
@@ -57,32 +53,21 @@ function codexAccountQuotaEvidence(accountId: string, plan?: string): RouteQuota
     .filter(value => value > Date.now());
   return {
     known: true,
-    ...(maxPercent !== undefined
-      ? { headroom: Math.max(0, Math.min(1, 1 - maxPercent / 100)) }
-      : {}),
+    headroom: Math.max(0, Math.min(1, 1 - maxPercent / 100)),
     exhausted: isCodexQuotaExhausted(quota, plan),
     ...(resets.length > 0 ? { resetAtMs: Math.min(...resets) } : {}),
     source: "codex-pool",
   };
 }
 
-/**
- * Provider-level quota evidence for a Codex account pool. A policy profile
- * chooses provider/model, while the existing pool remains authoritative for
- * the physical account. Therefore the provider is usable when ANY known pool
- * account has headroom. Unknown accounts prevent a known-exhausted verdict:
- * unknown capacity is not zero capacity.
- */
 export function codexPoolQuotaEvidence(accounts: readonly CodexPoolQuotaAccount[]): RouteQuotaEvidence {
   if (accounts.length === 0) return { known: false };
   const evidence = accounts.map(account => codexAccountQuotaEvidence(account.accountId, account.plan));
   const known = evidence.filter(item => item.known);
   if (known.length === 0) return { known: false };
-
   const usable = known.filter(item => item.exhausted !== true);
   if (usable.length > 0) {
-    const headrooms = usable
-      .map(item => item.headroom)
+    const headrooms = usable.map(item => item.headroom)
       .filter((value): value is number => typeof value === "number" && Number.isFinite(value));
     return {
       known: true,
@@ -91,13 +76,8 @@ export function codexPoolQuotaEvidence(accounts: readonly CodexPoolQuotaAccount[
       source: "codex-pool",
     };
   }
-
-  // At least one account has no quota evidence. The pool may still be usable,
-  // so fail open as unknown rather than excluding the provider as exhausted.
   if (known.length < evidence.length) return { known: false };
-
-  const resets = known
-    .map(item => item.resetAtMs)
+  const resets = known.map(item => item.resetAtMs)
     .filter((value): value is number => typeof value === "number" && Number.isFinite(value));
   return {
     known: true,
@@ -108,16 +88,11 @@ export function codexPoolQuotaEvidence(accounts: readonly CodexPoolQuotaAccount[
   };
 }
 
-/**
- * Assemble quota evidence from canonical local caches only (no network).
- * Unknown dimensions stay unknown - never zero.
- */
 export function quotaEvidenceForCandidate(input: QuotaEvidenceInput): RouteQuotaEvidence {
   if (input.provider === "openai" && input.codexAccountId) {
-    // The live routing/profile assembly path includes the selected account's
-    // plan. At that boundary the candidate represents the whole Codex pool,
-    // not that one active account, so aggregate the reconciled quota cache.
-    // Caller-supplied dry-run account evidence omits the plan and remains exact.
+    // listAccountQuotas() is the reconciled quota snapshot: config-generation
+    // reconciliation prunes removed accounts. Other eligibility dimensions
+    // (pause/reauth/cooldown/soft-avoid) remain health/pool-selector concerns.
     if (input.codexAccountPlan !== undefined) {
       const pool = [...listAccountQuotas()].map(([accountId]) => ({
         accountId,
@@ -131,10 +106,6 @@ export function quotaEvidenceForCandidate(input: QuotaEvidenceInput): RouteQuota
   if (input.provider === "anthropic" && input.accountRef) {
     const quota = getCachedProviderAccountQuota("anthropic", input.accountRef);
     if (quota) {
-      // Anthropic per-family buckets (e.g. Opus / Sonnet) are stricter than the
-      // broad account windows: fold the candidate model's matching bucket into
-      // headroom and exhaustion so a model-specific overage is not hidden by
-      // a healthy aggregate window.
       const family = anthropicFamilyWindow(input.model, quota.customWindows ?? []);
       const percents = [quota.fiveHourPercent, quota.weeklyPercent, quota.monthlyPercent, family?.percent]
         .filter((value): value is number => typeof value === "number" && Number.isFinite(value));
@@ -144,25 +115,16 @@ export function quotaEvidenceForCandidate(input: QuotaEvidenceInput): RouteQuota
         .filter(value => value > Date.now());
       return {
         known: true,
-        ...(maxPercent !== undefined
-          ? { headroom: Math.max(0, Math.min(1, 1 - maxPercent / 100)) }
-          : {}),
+        ...(maxPercent !== undefined ? { headroom: Math.max(0, Math.min(1, 1 - maxPercent / 100)) } : {}),
         exhausted: maxPercent !== undefined && maxPercent >= 100,
         ...(resets.length > 0 ? { resetAtMs: Math.min(...resets) } : {}),
         source: "provider-report",
       };
     }
   }
-
   return { known: false };
 }
 
-/**
- * Match the candidate model to an Anthropic per-family quota window. Window
- * labels from the provider probe are "Opus" / "Sonnet"; model ids carry the
- * family as a segment (e.g. `claude-opus-...`, `claude-sonnet-...`). Returns
- * undefined when no family window is cached or no label matches.
- */
 function anthropicFamilyWindow(
   model: string,
   windows: Array<{ label: string; percent?: number; resetAt?: number }>,
@@ -170,18 +132,11 @@ function anthropicFamilyWindow(
   const normalized = model.toLowerCase();
   for (const window of windows) {
     const family = window.label.trim().toLowerCase();
-    if (family && normalized.includes(family)) {
-      return window;
-    }
+    if (family && normalized.includes(family)) return window;
   }
   return undefined;
 }
 
-/**
- * Deterministic quota score in [0,1]: larger available headroom scores
- * higher; exhausted evidence scores 0. Unknown evidence returns null so the
- * caller can apply the profile's unknownEvidence policy.
- */
 export function quotaScore(evidence: RouteQuotaEvidence | undefined): number | null {
   if (!evidence || !evidence.known) return null;
   if (evidence.exhausted === true) return 0;

--- a/src/routing/quota.ts
+++ b/src/routing/quota.ts
@@ -12,7 +12,12 @@
  * carries an account reference (dry-run/evaluate), never invented.
  */
 
-import { codexQuotaWindowForPlan, getAccountQuota, isCodexQuotaExhausted } from "../codex/quota";
+import {
+  codexQuotaWindowForPlan,
+  getAccountQuota,
+  isCodexQuotaExhausted,
+  listAccountQuotas,
+} from "../codex/quota";
 import { getCachedProviderAccountQuota } from "../providers/quota";
 import type { RouteQuotaEvidence } from "./trace";
 
@@ -27,39 +32,100 @@ export interface QuotaEvidenceInput {
   codexAccountPlan?: string;
 }
 
+export interface CodexPoolQuotaAccount {
+  accountId: string;
+  plan?: string;
+}
+
+function codexAccountQuotaEvidence(accountId: string, plan?: string): RouteQuotaEvidence {
+  const quota = getAccountQuota(accountId);
+  if (!quota) return { known: false };
+
+  // Go/Free accounts report a 30-day window only; weekly windows gate
+  // everything else. `codexQuotaWindowForPlan` is the single shared rule
+  // (parser, exhaustion, recovery), so select the plan-specific bars here too.
+  const monthly = codexQuotaWindowForPlan(plan) === "monthly";
+  const percents = [
+    ...(monthly ? [] : [quota.weeklyPercent]),
+    quota.monthlyPercent,
+  ].filter((value): value is number => typeof value === "number" && Number.isFinite(value));
+  const maxPercent = percents.length > 0 ? Math.max(...percents) : undefined;
+  const resets = [
+    ...(monthly ? [] : [quota.weeklyResetAt]),
+    quota.monthlyResetAt,
+  ].filter((value): value is number => typeof value === "number" && Number.isFinite(value))
+    .filter(value => value > Date.now());
+  return {
+    known: true,
+    ...(maxPercent !== undefined
+      ? { headroom: Math.max(0, Math.min(1, 1 - maxPercent / 100)) }
+      : {}),
+    exhausted: isCodexQuotaExhausted(quota, plan),
+    ...(resets.length > 0 ? { resetAtMs: Math.min(...resets) } : {}),
+    source: "codex-pool",
+  };
+}
+
+/**
+ * Provider-level quota evidence for a Codex account pool. A policy profile
+ * chooses provider/model, while the existing pool remains authoritative for
+ * the physical account. Therefore the provider is usable when ANY known pool
+ * account has headroom. Unknown accounts prevent a known-exhausted verdict:
+ * unknown capacity is not zero capacity.
+ */
+export function codexPoolQuotaEvidence(accounts: readonly CodexPoolQuotaAccount[]): RouteQuotaEvidence {
+  if (accounts.length === 0) return { known: false };
+  const evidence = accounts.map(account => codexAccountQuotaEvidence(account.accountId, account.plan));
+  const known = evidence.filter(item => item.known);
+  if (known.length === 0) return { known: false };
+
+  const usable = known.filter(item => item.exhausted !== true);
+  if (usable.length > 0) {
+    const headrooms = usable
+      .map(item => item.headroom)
+      .filter((value): value is number => typeof value === "number" && Number.isFinite(value));
+    return {
+      known: true,
+      exhausted: false,
+      ...(headrooms.length > 0 ? { headroom: Math.max(...headrooms) } : {}),
+      source: "codex-pool",
+    };
+  }
+
+  // At least one account has no quota evidence. The pool may still be usable,
+  // so fail open as unknown rather than excluding the provider as exhausted.
+  if (known.length < evidence.length) return { known: false };
+
+  const resets = known
+    .map(item => item.resetAtMs)
+    .filter((value): value is number => typeof value === "number" && Number.isFinite(value));
+  return {
+    known: true,
+    exhausted: true,
+    headroom: 0,
+    ...(resets.length > 0 ? { resetAtMs: Math.min(...resets) } : {}),
+    source: "codex-pool",
+  };
+}
+
 /**
  * Assemble quota evidence from canonical local caches only (no network).
  * Unknown dimensions stay unknown - never zero.
  */
 export function quotaEvidenceForCandidate(input: QuotaEvidenceInput): RouteQuotaEvidence {
   if (input.provider === "openai" && input.codexAccountId) {
-    const quota = getAccountQuota(input.codexAccountId);
-    if (quota) {
-      // Go/Free accounts report a 30-day window only; weekly windows gate
-      // everything else. `codexQuotaWindowForPlan` is the single shared rule
-      // (parser, exhaustion, recovery), so select the plan-specific bars here
-      // too instead of always combining weekly + monthly.
-      const monthly = codexQuotaWindowForPlan(input.codexAccountPlan) === "monthly";
-      const percents = [
-        ...(monthly ? [] : [quota.weeklyPercent]),
-        quota.monthlyPercent,
-      ].filter((value): value is number => typeof value === "number" && Number.isFinite(value));
-      const maxPercent = percents.length > 0 ? Math.max(...percents) : undefined;
-      const resets = [
-        ...(monthly ? [] : [quota.weeklyResetAt]),
-        quota.monthlyResetAt,
-      ].filter((value): value is number => typeof value === "number" && Number.isFinite(value))
-        .filter(value => value > Date.now());
-      return {
-        known: true,
-        ...(maxPercent !== undefined
-          ? { headroom: Math.max(0, Math.min(1, 1 - maxPercent / 100)) }
-          : {}),
-        exhausted: isCodexQuotaExhausted(quota, input.codexAccountPlan),
-        ...(resets.length > 0 ? { resetAtMs: Math.min(...resets) } : {}),
-        source: "codex-pool",
-      };
+    // The live routing/profile assembly path includes the selected account's
+    // plan. At that boundary the candidate represents the whole Codex pool,
+    // not that one active account, so aggregate the reconciled quota cache.
+    // Caller-supplied dry-run account evidence omits the plan and remains exact.
+    if (input.codexAccountPlan !== undefined) {
+      const pool = [...listAccountQuotas()].map(([accountId]) => ({
+        accountId,
+        ...(accountId === input.codexAccountId ? { plan: input.codexAccountPlan } : {}),
+      }));
+      if (pool.length > 1) return codexPoolQuotaEvidence(pool);
     }
+    return codexAccountQuotaEvidence(input.codexAccountId, input.codexAccountPlan);
   }
 
   if (input.provider === "anthropic" && input.accountRef) {

--- a/tests/routing-policy-pool-quota.test.ts
+++ b/tests/routing-policy-pool-quota.test.ts
@@ -9,44 +9,30 @@ describe("Codex pool quota evidence for routing policies", () => {
   test("uses the best known usable headroom instead of only one active account", () => {
     setAccountQuotaFromParsed("low", { weeklyPercent: 95 });
     setAccountQuotaFromParsed("healthy", { weeklyPercent: 20 });
-
     expect(codexPoolQuotaEvidence([
       { accountId: "low", plan: "plus" },
       { accountId: "healthy", plan: "plus" },
-    ])).toMatchObject({
-      known: true,
-      exhausted: false,
-      headroom: 0.8,
-      source: "codex-pool",
-    });
+    ])).toMatchObject({ known: true, exhausted: false, headroom: 0.8, source: "codex-pool" });
   });
 
   test("the live policy evidence path aggregates the reconciled pool", () => {
     setAccountQuotaFromParsed("active", { weeklyPercent: 96 });
     setAccountQuotaFromParsed("alternate", { weeklyPercent: 25 });
-
     expect(quotaEvidenceForCandidate({
       provider: "openai",
       model: "gpt-5.6",
       codexAccountId: "active",
       codexAccountPlan: "plus",
-    })).toMatchObject({
-      known: true,
-      exhausted: false,
-      headroom: 0.75,
-      source: "codex-pool",
-    });
+    })).toMatchObject({ known: true, exhausted: false, headroom: 0.75, source: "codex-pool" });
   });
 
   test("reports exhausted only when every pool account is known exhausted", () => {
     setAccountQuotaFromParsed("a", { weeklyPercent: 100, weeklyResetAt: Date.now() + 60_000 });
     setAccountQuotaFromParsed("b", { weeklyPercent: 100, weeklyResetAt: Date.now() + 120_000 });
-
     const evidence = codexPoolQuotaEvidence([
       { accountId: "a", plan: "plus" },
       { accountId: "b", plan: "plus" },
     ]);
-
     expect(evidence.known).toBe(true);
     expect(evidence.exhausted).toBe(true);
     expect(evidence.headroom).toBe(0);
@@ -55,10 +41,18 @@ describe("Codex pool quota evidence for routing policies", () => {
 
   test("does not call a partially unknown pool exhausted", () => {
     setAccountQuotaFromParsed("known-exhausted", { weeklyPercent: 100 });
-
     expect(codexPoolQuotaEvidence([
       { accountId: "known-exhausted", plan: "plus" },
       { accountId: "unknown", plan: "plus" },
+    ])).toEqual({ known: false });
+  });
+
+  test("credits-only cached evidence stays unknown", () => {
+    setAccountQuotaFromParsed("known-exhausted", { weeklyPercent: 100 });
+    setAccountQuotaFromParsed("credits-only", { resetCredits: 7 });
+    expect(codexPoolQuotaEvidence([
+      { accountId: "known-exhausted", plan: "plus" },
+      { accountId: "credits-only", plan: "plus" },
     ])).toEqual({ known: false });
   });
 });

--- a/tests/routing-policy-pool-quota.test.ts
+++ b/tests/routing-policy-pool-quota.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
 import { clearAccountQuota, setAccountQuotaFromParsed } from "../src/codex/quota";
-import { codexPoolQuotaEvidence } from "../src/routing/quota";
+import { codexPoolQuotaEvidence, quotaEvidenceForCandidate } from "../src/routing/quota";
 
 afterEach(() => clearAccountQuota());
 
@@ -17,6 +17,23 @@ describe("Codex pool quota evidence for routing policies", () => {
       known: true,
       exhausted: false,
       headroom: 0.8,
+      source: "codex-pool",
+    });
+  });
+
+  test("the live policy evidence path aggregates the reconciled pool", () => {
+    setAccountQuotaFromParsed("active", { weeklyPercent: 96 });
+    setAccountQuotaFromParsed("alternate", { weeklyPercent: 25 });
+
+    expect(quotaEvidenceForCandidate({
+      provider: "openai",
+      model: "gpt-5.6",
+      codexAccountId: "active",
+      codexAccountPlan: "plus",
+    })).toMatchObject({
+      known: true,
+      exhausted: false,
+      headroom: 0.75,
       source: "codex-pool",
     });
   });

--- a/tests/routing-policy-pool-quota.test.ts
+++ b/tests/routing-policy-pool-quota.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { clearAccountQuota, setAccountQuotaFromParsed } from "../src/codex/quota";
+import { codexPoolQuotaEvidence } from "../src/routing/quota";
+
+afterEach(() => clearAccountQuota());
+
+describe("Codex pool quota evidence for routing policies", () => {
+  test("uses the best known usable headroom instead of only one active account", () => {
+    setAccountQuotaFromParsed("low", { weeklyPercent: 95 });
+    setAccountQuotaFromParsed("healthy", { weeklyPercent: 20 });
+
+    expect(codexPoolQuotaEvidence([
+      { accountId: "low", plan: "plus" },
+      { accountId: "healthy", plan: "plus" },
+    ])).toMatchObject({
+      known: true,
+      exhausted: false,
+      headroom: 0.8,
+      source: "codex-pool",
+    });
+  });
+
+  test("reports exhausted only when every pool account is known exhausted", () => {
+    setAccountQuotaFromParsed("a", { weeklyPercent: 100, weeklyResetAt: Date.now() + 60_000 });
+    setAccountQuotaFromParsed("b", { weeklyPercent: 100, weeklyResetAt: Date.now() + 120_000 });
+
+    const evidence = codexPoolQuotaEvidence([
+      { accountId: "a", plan: "plus" },
+      { accountId: "b", plan: "plus" },
+    ]);
+
+    expect(evidence.known).toBe(true);
+    expect(evidence.exhausted).toBe(true);
+    expect(evidence.headroom).toBe(0);
+    expect(evidence.resetAtMs).toBeDefined();
+  });
+
+  test("does not call a partially unknown pool exhausted", () => {
+    setAccountQuotaFromParsed("known-exhausted", { weeklyPercent: 100 });
+
+    expect(codexPoolQuotaEvidence([
+      { accountId: "known-exhausted", plan: "plus" },
+      { accountId: "unknown", plan: "plus" },
+    ])).toEqual({ known: false });
+  });
+});


### PR DESCRIPTION
## Summary

Use Codex pool capacity when scoring an OpenAI policy candidate instead of treating the currently active account as the whole provider.

Expected semantics:
- use the best known usable quota headroom across the live pool
- mark the pool exhausted only when every relevant account is known exhausted
- if all known accounts are exhausted but another account is unknown, keep pool quota unknown rather than falsely excluding it
- keep account identities out of route traces
- keep the existing account pool responsible for the physical account choice
- share the same evidence helper between live routing and profile dry-runs

## TDD state

The first commit intentionally adds failing tests for the missing pool aggregation helper. Implementation follows after the red state is confirmed.

## Scope

- quota evidence only; Codex pool health is already pool-aware on current `dev`
- no routing-profile schema changes
- no account-pool strategy changes
- exact account selectors remain unchanged

Base inspected: `dev` at `3ad5bb6bd3f76f6879d84b78ea39edd3e01ec296`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Codex pool quota evaluation across multiple accounts.
  * Plans now apply the appropriate quota windows for each account.
  * Routing can report available pool headroom when at least one account remains usable.
  * Preserves unknown quota status when account data is unavailable.
  * Retains account-level evaluation when pool aggregation is not applicable.
* **Bug Fixes**
  * Improved quota handling for exhausted pools, reset times, and partially unavailable account information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->