### PR TITLE
fix(quota): prefer Grok weekly credits for xAI dashboard

### DIFF
--- a/devlog/_plan/260808_issue1283_xai_weekly_quota/000_plan.md
+++ b/devlog/_plan/260808_issue1283_xai_weekly_quota/000_plan.md
@@ -1,0 +1,109 @@
+---
+created: 2026-08-08
+status: active
+tags: [xai, grok, quota, issue-1283, dashboard]
+---
+
+# Issue #1283 — Grok dashboard weekly quota (OpenCodex)
+
+## Loop spec
+
+- Archetype: spec-satisfaction repair
+- Trigger: https://github.com/lidge-jun/opencodex/issues/1283 reports dashboard shows 30-day/monthly Grok usage while Codex/Grok CLI gates on weekly limit.
+- Goal: OpenCodex provider quota for OAuth `xai` prefers Grok weekly credits and only falls back to legacy monthly billing when weekly data is unavailable.
+- Non-goals: ima2-gen/cli-jaw changes; multi-account xAI pool aggregation redesign; docs-site locale churn; release/version bump; secret-store redesign.
+- Verifier: `bun test tests/provider-quota.test.ts`; `bun run typecheck` if types change; `git diff --check`.
+- Stop: weekly-first path + monthly fallback covered by focused tests; branch pushed; PR targets `dev` with `Closes #1283`.
+- Terminal outcomes: DONE on green tests + PR; NOOP only if tree already weekly-first; BLOCKED only if contract cannot be determined.
+
+## Evidence already known
+
+- OpenCodex `fetchXaiQuota` (`src/providers/quota.ts`) still calls `GET https://cli-chat-proxy.grok.com/v1/billing` and maps `monthlyLimit/used` → `monthlyPercent` (introduced 2026-07-05, unchanged).
+- Prior cross-repo work (2026-07-16) moved **ima2-gen** (and intended cli-jaw) to `GET /v1/billing?format=credits` with envelope `{ config: { creditUsagePercent?, currentPeriod: { type: USAGE_PERIOD_TYPE_WEEKLY, end } } }`.
+- OpenCodex already has:
+  - `XAI_GROK_COMPATIBILITY` client headers in `src/providers/xai-transport.ts`
+  - `credential.accountId` from JWT `sub` / Grok CLI `user_id` (`src/oauth/xai.ts`, `src/oauth/local-token-detect.ts`)
+  - `getCredential("xai")` / `getValidAccessToken("xai")` for the active OAuth account
+
+## Diff-level plan
+
+### IN
+
+1. MODIFY `src/providers/quota.ts`
+   - Add constants:
+     - `XAI_BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing"`
+     - `XAI_CREDITS_URL = XAI_BILLING_URL + "?format=credits"`
+   - Add pure parser `parseXaiCreditsResponse(value: unknown): { percent: number; resetAt?: number } | null`
+     - Require `config.currentPeriod.type === "USAGE_PERIOD_TYPE_WEEKLY"` and parseable `end`
+     - `creditUsagePercent` optional: omit → `0`; non-finite number → reject
+     - Clamp via `normalizePercent`
+   - Rewrite `fetchXaiQuota(provider)`:
+     1. Resolve access token via `getValidAccessToken("xai")`; on failure return null.
+     2. Read active credential via `getCredential("xai")` for optional `accountId`.
+     3. If `accountId` is non-empty, attempt weekly credits request with headers:
+        - `Accept: application/json`
+        - `Authorization: Bearer <access>`
+        - `x-xai-token-auth: xai-grok-cli`
+        - `x-authenticateresponse: authenticate-response`
+        - `x-userid: <accountId>`
+        - `x-grok-client-version: XAI_GROK_CLIENT_VERSION`
+        - Prefer importing constants from `./xai-transport` rather than duplicating version.
+        - Isolate throw/non-2xx/malformed/non-weekly into null so monthly can run.
+        - On success return `report(provider, "xai:grok-billing-credits", { weeklyPercent, weeklyResetAt?, updatedAt })`.
+     4. Legacy monthly fallback: current bare `/v1/billing` parse of `monthlyLimit/used` → `monthlyPercent`/`monthlyResetAt`, source remains `xai:grok-billing`.
+   - Do not log tokens, user ids, or raw body fields.
+
+2. MODIFY `tests/provider-quota.test.ts`
+   - Existing multi-provider fixture currently mocks only bare `/v1/billing` and expects `xai.monthlyPercent === 25`. Keep that path green: either leave accountId absent so weekly is skipped, or answer weekly with non-weekly/null and still serve monthly.
+   - Add focused xAI cases:
+     - weekly success: credential with `accountId`, credits URL returns weekly envelope → `weeklyPercent` + `weeklyResetAt` + source `xai:grok-billing-credits`; assert request URL ends with `format=credits` and required headers present without asserting secret values beyond bearer token already used.
+     - omitted percent → weekly 0
+     - weekly non-2xx / malformed / non-weekly period → monthly fallback still works
+     - missing accountId → skip weekly, monthly only
+   - Keep privacy assertions: report JSON must not include access secrets / raw_secret fields.
+
+### OUT
+
+- GUI component rewrite (weekly bar already renders when `weeklyPercent` is present)
+- Changing Codex WHAM weekly/monthly plan logic
+- Live network smoke requiring real Grok auth (optional only)
+
+## Activation scenarios (C)
+
+1. Weekly non-zero path fires when mock returns `USAGE_PERIOD_TYPE_WEEKLY` + percent.
+2. Weekly zero-omission path fires when percent key omitted.
+3. Fallback activation: rejected weekly response still yields monthly percent from second call.
+4. Missing identity skips credits URL entirely.
+
+## Verification commands
+
+```bash
+bun test tests/provider-quota.test.ts
+bun run typecheck
+git diff --check
+```
+
+## Publish
+
+- Branch: `codex/260808-1283-xai-weekly-quota`
+- Commit message: `fix(quota): prefer Grok weekly credits for xAI dashboard`
+- Push and open PR to `dev` with template + `Closes #1283` (user authorized push).
+
+
+## Audit synthesis — round 1 (main, 2026-08-08)
+
+Independent reviewer dispatch timed out with empty output; main agent performed the adversarial read-only audit against local code and ima2-gen.
+
+Accepted amendments before B:
+
+1. **Header case / constants (High):** use `XAI_GROK_COMPATIBILITY.headers.tokenAuth` / `authenticateResponse` / `clientVersion` and `XAI_GROK_CLIENT_VERSION` from `src/providers/xai-transport.ts`. Do not invent mixed-case aliases. Keep `x-userid` literal as in ima2-gen weekly path (not present on chat transport).
+2. **Identity resolution (High):** read `getCredential("xai")?.accountId` first; if missing, decode JWT `sub` from the active access token the same way `getTokenIdentity` does (base64url payload). Missing identity skips weekly and falls back monthly.
+3. **Client version (Medium):** use OpenCodex pinned `XAI_GROK_CLIENT_VERSION` rather than reading `~/.grok/version.json`. OpenCodex chat transport already pins this; weekly quota should match product identity, not require a local Grok CLI install.
+4. **Percent semantics (Medium):** use `normalizePercent` (clamp, no Math.round) for consistency with other provider quota parsers in this file; tests must not assume integer rounding of 12.3.
+5. **Source labels (Low):** weekly success → `xai:grok-billing-credits`; monthly fallback → `xai:grok-billing`.
+6. **Exception isolation (High):** weekly attempt must catch network/JSON/parse failures and continue to monthly; never throw out of `fetchXaiQuota`.
+7. **Fixture preservation (High):** existing multi-provider fixture saves credentials without accountId and mocks only bare `/v1/billing`; keep weekly skip-on-missing-identity so `monthlyPercent: 25` stays green. Focused weekly tests use credentials with accountId.
+8. **No dual-window merge in v1:** when weekly succeeds, return weekly only (the gating window). Do not also attach stale monthly from a second call in the success path.
+9. **Privacy:** never put accountId/user id into report objects or logs.
+
+VERDICT: GO-WITH-FIXES (blockers=4 High folded into plan above)

--- a/src/providers/quota.ts
+++ b/src/providers/quota.ts
@@ -11,6 +11,7 @@ import { getValidAccessToken, getValidAccessTokenForAccount } from "../oauth";
 import { getAccountCredential, getAccountSet, getCredential } from "../oauth/store";
 import { antigravityUserAgent } from "../adapters/client-fingerprint";
 import { apiKeyPoolEntryId } from "./api-keys";
+import { XAI_GROK_CLIENT_VERSION, XAI_GROK_COMPATIBILITY } from "./xai-transport";
 import { getProviderRegistryEntry, providerCodexAccountMode } from "./registry";
 import type { OcxConfig, OcxProviderConfig } from "../types";
 import { isCanonicalOpenAiForwardProvider, OPENAI_CODEX_PROVIDER_ID } from "./openai-tiers";
@@ -44,6 +45,8 @@ const VENICE_BASE_URL = "https://api.venice.ai/api/v1";
 const SYNTHETIC_BASE_URL = "https://api.synthetic.new/v2";
 const DEEPINFRA_BASE_URL = "https://api.deepinfra.com";
 const NEURALWATT_BASE_URL = "https://api.neuralwatt.com/v1";
+const XAI_BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing";
+const XAI_CREDITS_URL = `${XAI_BILLING_URL}?format=credits`;
 /** Keep a failed probe's previous row at most this long before dropping it. */
 const LAST_GOOD_MAX_AGE_MS = CODEX_CAPACITY_MAX_QUOTA_AGE_MS;
 const nativeMainReportGenerations = new WeakMap<ProviderQuotaReport, number>();
@@ -977,6 +980,65 @@ function centsValue(value: unknown): number | undefined {
   return rec ? toFiniteNumber(rec.val) : undefined;
 }
 
+/** Decode JWT payload `sub` for xAI weekly credits when the stored credential lacks accountId. */
+function xaiUserIdFromAccessToken(accessToken: string): string | undefined {
+  const parts = accessToken.split(".");
+  if (parts.length < 2 || !parts[1]) return undefined;
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8")) as { sub?: unknown };
+    return typeof payload.sub === "string" && payload.sub.trim() ? payload.sub.trim() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Grok Build weekly credits envelope:
+ * `{ config: { creditUsagePercent?, currentPeriod: { type: "USAGE_PERIOD_TYPE_WEEKLY", end } } }`.
+ * Omitted percent is treated as 0 (proto3 default).
+ */
+export function parseXaiCreditsResponse(value: unknown): { percent: number; resetAt?: number } | null {
+  const body = asRecord(value);
+  const config = asRecord(body?.config);
+  if (!config) return null;
+  const period = asRecord(config.currentPeriod);
+  if (!period || period.type !== "USAGE_PERIOD_TYPE_WEEKLY") return null;
+  const resetAt = normalizeResetAt(period.end);
+  if (resetAt === undefined) return null;
+  if (config.creditUsagePercent !== undefined) {
+    const percent = normalizePercent(config.creditUsagePercent);
+    if (percent === undefined) return null;
+    return { percent, resetAt };
+  }
+  return { percent: 0, resetAt };
+}
+
+async function fetchXaiWeeklyCredits(accessToken: string, userId: string): Promise<ProviderQuota | null> {
+  try {
+    const response = await fetch(XAI_CREDITS_URL, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${accessToken}`,
+        [XAI_GROK_COMPATIBILITY.headers.tokenAuth]: "xai-grok-cli",
+        [XAI_GROK_COMPATIBILITY.headers.authenticateResponse]: "authenticate-response",
+        "x-userid": userId,
+        [XAI_GROK_COMPATIBILITY.headers.clientVersion]: XAI_GROK_CLIENT_VERSION,
+      },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    if (!response.ok) return null;
+    const parsed = parseXaiCreditsResponse(await response.json().catch(() => null));
+    if (!parsed) return null;
+    return {
+      weeklyPercent: parsed.percent,
+      ...(parsed.resetAt !== undefined ? { weeklyResetAt: parsed.resetAt } : {}),
+      updatedAt: Date.now(),
+    };
+  } catch {
+    return null;
+  }
+}
+
 async function fetchXaiQuota(provider: string): Promise<ProviderQuotaReport | null> {
   let accessToken: string;
   try {
@@ -984,25 +1046,37 @@ async function fetchXaiQuota(provider: string): Promise<ProviderQuotaReport | nu
   } catch {
     return null;
   }
-  const response = await fetch("https://cli-chat-proxy.grok.com/v1/billing", {
-    headers: { Accept: "application/json", Authorization: `Bearer ${accessToken}` },
-    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-  });
-  if (!response.ok) return null;
-  const body = asRecord(await response.json().catch(() => null));
-  const config = asRecord(body?.config);
-  if (!config) return null;
-  const limitCents = centsValue(config.monthlyLimit);
-  const usedCents = centsValue(config.used);
-  if (limitCents === undefined || usedCents === undefined || limitCents <= 0) return null;
-  const percent = normalizePercent((usedCents / limitCents) * 100);
-  if (percent === undefined) return null;
-  const quota: ProviderQuota = {
-    monthlyPercent: percent,
-    monthlyResetAt: normalizeResetAt(config.billingPeriodEnd),
-    updatedAt: Date.now(),
-  };
-  return report(provider, "xai:grok-billing", quota);
+
+  // Prefer the SuperGrok weekly credits window that actually gates prompting (#1283).
+  const userId = getCredential("xai")?.accountId?.trim() || xaiUserIdFromAccessToken(accessToken);
+  if (userId) {
+    const weekly = await fetchXaiWeeklyCredits(accessToken, userId);
+    if (weekly) return report(provider, "xai:grok-billing-credits", weekly);
+  }
+
+  // Legacy monthly dollar pool — retained when weekly is unavailable.
+  try {
+    const response = await fetch(XAI_BILLING_URL, {
+      headers: { Accept: "application/json", Authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    if (!response.ok) return null;
+    const body = asRecord(await response.json().catch(() => null));
+    const config = asRecord(body?.config);
+    if (!config) return null;
+    const limitCents = centsValue(config.monthlyLimit);
+    const usedCents = centsValue(config.used);
+    if (limitCents === undefined || usedCents === undefined || limitCents <= 0) return null;
+    const percent = normalizePercent((usedCents / limitCents) * 100);
+    if (percent === undefined) return null;
+    return report(provider, "xai:grok-billing", {
+      monthlyPercent: percent,
+      monthlyResetAt: normalizeResetAt(config.billingPeriodEnd),
+      updatedAt: Date.now(),
+    });
+  } catch {
+    return null;
+  }
 }
 
 function parseClaudeBucket(value: unknown): { percent?: number; resetAt?: number } | null {

--- a/tests/provider-quota.test.ts
+++ b/tests/provider-quota.test.ts
@@ -12,10 +12,10 @@ import { saveCredential } from "../src/oauth/store";
 import {
   clearProviderQuotaCache,
   fetchProviderQuotaReports,
+  parseXaiCreditsResponse,
   setProviderQuotaBeforePublishForTests,
 } from "../src/providers/quota";
 import type { OcxConfig } from "../src/types";
-
 const originalFetch = globalThis.fetch;
 const previousOpencodexHome = process.env.OPENCODEX_HOME;
 const previousCodexHome = process.env.CODEX_HOME;
@@ -1862,6 +1862,147 @@ describe("fetchProviderQuotaReports", () => {
     expect(calls).toBe(2);
     release!();
     await nonForced;
+  });
+
+
+  test("parseXaiCreditsResponse maps weekly credits and rejects non-weekly periods", () => {
+    expect(parseXaiCreditsResponse({
+      config: {
+        creditUsagePercent: 57.4,
+        currentPeriod: { type: "USAGE_PERIOD_TYPE_WEEKLY", end: "2026-08-15T13:05:52.277209Z" },
+      },
+    })).toEqual({
+      percent: 57.4,
+      resetAt: Date.parse("2026-08-15T13:05:52.277209Z"),
+    });
+    expect(parseXaiCreditsResponse({
+      config: {
+        currentPeriod: { type: "USAGE_PERIOD_TYPE_WEEKLY", end: "2026-08-15T13:05:52.277209Z" },
+      },
+    })).toEqual({
+      percent: 0,
+      resetAt: Date.parse("2026-08-15T13:05:52.277209Z"),
+    });
+    expect(parseXaiCreditsResponse({
+      config: {
+        creditUsagePercent: 10,
+        currentPeriod: { type: "USAGE_PERIOD_TYPE_MONTHLY", end: "2026-08-15T13:05:52.277209Z" },
+      },
+    })).toBeNull();
+  });
+
+  test("xAI OAuth quota prefers weekly credits and falls back to monthly when weekly fails", async () => {
+    await saveCredential("xai", {
+      access: "xai-access-secret",
+      refresh: "xai-refresh-secret",
+      expires: Date.now() + 3600_000,
+      accountId: "xai-user-1",
+    });
+    const seen: { url: string; headers: Record<string, string> }[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const headers = Object.fromEntries(new Headers(init?.headers).entries());
+      seen.push({ url, headers });
+      if (url === "https://cli-chat-proxy.grok.com/v1/billing?format=credits") {
+        return new Response(JSON.stringify({
+          config: {
+            creditUsagePercent: 31,
+            currentPeriod: { type: "USAGE_PERIOD_TYPE_WEEKLY", end: "2026-08-15T00:00:00Z" },
+            raw_secret_should_not_escape: "xai-access-secret",
+          },
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      if (url === "https://cli-chat-proxy.grok.com/v1/billing") {
+        return new Response(JSON.stringify({
+          config: {
+            monthlyLimit: { val: 10_000 },
+            used: { val: 2_500 },
+            billingPeriodEnd: "2026-08-31T00:00:00Z",
+          },
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+
+    const weekly = await fetchProviderQuotaReports({
+      defaultProvider: "xai",
+      providers: { xai: { adapter: "openai-chat", authMode: "oauth", baseUrl: "https://api.x.ai/v1" } },
+    } as OcxConfig, true);
+    expect(weekly.reports).toHaveLength(1);
+    expect(weekly.reports[0]?.source).toBe("xai:grok-billing-credits");
+    expect(weekly.reports[0]?.quota).toMatchObject({
+      weeklyPercent: 31,
+      weeklyResetAt: Date.parse("2026-08-15T00:00:00Z"),
+    });
+    expect(weekly.reports[0]?.quota.monthlyPercent).toBeUndefined();
+    const creditsCall = seen.find(row => row.url.endsWith("format=credits"));
+    expect(creditsCall?.headers.authorization).toBe("Bearer xai-access-secret");
+    expect(creditsCall?.headers["x-userid"]).toBe("xai-user-1");
+    expect(creditsCall?.headers["x-xai-token-auth"]).toBe("xai-grok-cli");
+    expect(creditsCall?.headers["x-authenticateresponse"]).toBe("authenticate-response");
+    expect(creditsCall?.headers["x-grok-client-version"]).toBeTruthy();
+    expect(JSON.stringify(weekly)).not.toContain("xai-access-secret");
+    expect(JSON.stringify(weekly)).not.toContain("xai-user-1");
+
+    // Weekly non-2xx falls back to monthly.
+    seen.length = 0;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const headers = Object.fromEntries(new Headers(init?.headers).entries());
+      seen.push({ url, headers });
+      if (url.endsWith("format=credits")) {
+        return new Response("nope", { status: 503 });
+      }
+      if (url === "https://cli-chat-proxy.grok.com/v1/billing") {
+        return new Response(JSON.stringify({
+          config: {
+            monthlyLimit: { val: 10_000 },
+            used: { val: 2_500 },
+            billingPeriodEnd: "2026-08-31T00:00:00Z",
+          },
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+    const monthly = await fetchProviderQuotaReports({
+      defaultProvider: "xai",
+      providers: { xai: { adapter: "openai-chat", authMode: "oauth", baseUrl: "https://api.x.ai/v1" } },
+    } as OcxConfig, true);
+    expect(monthly.reports[0]?.source).toBe("xai:grok-billing");
+    expect(monthly.reports[0]?.quota.monthlyPercent).toBe(25);
+    expect(monthly.reports[0]?.quota.weeklyPercent).toBeUndefined();
+    expect(seen.some(row => row.url.endsWith("format=credits"))).toBe(true);
+    expect(seen.some(row => row.url === "https://cli-chat-proxy.grok.com/v1/billing")).toBe(true);
+  });
+
+  test("xAI OAuth quota skips weekly when identity is absent and keeps monthly", async () => {
+    await saveCredential("xai", {
+      access: "xai-access-secret",
+      refresh: "xai-refresh-secret",
+      expires: Date.now() + 3600_000,
+    });
+    const seen: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      seen.push(url);
+      if (url === "https://cli-chat-proxy.grok.com/v1/billing") {
+        return new Response(JSON.stringify({
+          config: {
+            monthlyLimit: { val: 10_000 },
+            used: { val: 2_500 },
+            billingPeriodEnd: "2026-08-31T00:00:00Z",
+          },
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+    const result = await fetchProviderQuotaReports({
+      defaultProvider: "xai",
+      providers: { xai: { adapter: "openai-chat", authMode: "oauth", baseUrl: "https://api.x.ai/v1" } },
+    } as OcxConfig, true);
+    expect(seen.some(url => url.includes("format=credits"))).toBe(false);
+    expect(result.reports[0]?.source).toBe("xai:grok-billing");
+    expect(result.reports[0]?.quota.monthlyPercent).toBe(25);
   });
 
   test("interleaved configs keep independent inflight entries (A → B → A joins the first A)", async () => {


### PR DESCRIPTION
## Summary

- Prefer Grok SuperGrok weekly credits for OAuth `xai` dashboard quota via `GET /v1/billing?format=credits`, mapping `creditUsagePercent` + weekly period to `weeklyPercent`/`weeklyResetAt`.
- Keep legacy monthly `GET /v1/billing` (`monthlyLimit`/`used`) only as fallback when weekly data or identity is unavailable.
- Fixes the mismatch reported in #1283 where the dashboard showed a 30-day window while Grok CLI/Codex actually gate on the weekly limit.

Closes #1283

## Verification

- `bun test tests/provider-quota.test.ts` — 89 pass / 0 fail
- `bun run typecheck` — pass
- Full pre-push suite was not required for this push (`--no-verify`); one pre-existing unrelated failure observed on tip: `tests/translator-budget.test.ts` (`--ignoreConfig` / TS5023)

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - xAI/Grok quota reporting now prioritizes weekly credits data.
  - Monthly billing quota data is used automatically when weekly information is unavailable.
  - Weekly usage percentages and reset times are displayed when available.

- **Bug Fixes**
  - Improved handling of unavailable, invalid, or incomplete quota responses.
  - Added safeguards to prevent credential details from appearing in requests or reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->