### PR TITLE
fix(providers): drop a removed provider's custom models (#1273)

### DIFF
--- a/src/cli/provider.ts
+++ b/src/cli/provider.ts
@@ -12,6 +12,7 @@ import { apiKeyTransportConfigError, hasOwnProvider, isValidProviderName, loadCo
 import { hasHelpFlag } from "./help";
 import { getProviderRegistryEntry, PROVIDER_REGISTRY } from "../providers/registry";
 import { providerConfigSeed } from "../providers/derive";
+import { dropProviderCustomModels } from "../providers/provider-id-rewrite";
 import type { OcxProviderConfig } from "../types";
 import { findLiveProxy } from "../server/proxy-liveness";
 import { syncModelsToCodex } from "../codex/sync";
@@ -302,6 +303,7 @@ function handleRemove(args: string[]): void {
   }
 
   delete config.providers[name];
+  const droppedCustomModels = dropProviderCustomModels(config, name);
   validateAndSave(config);
 
 
@@ -312,11 +314,16 @@ function handleRemove(args: string[]): void {
       remainingProviders: Object.keys(config.providers),
       defaultProvider: config.defaultProvider,
       needsSync: true,
+      ...(droppedCustomModels > 0 ? { droppedCustomModels } : {}),
     }, null, 2));
     return;
   }
 
   console.log(`✅ Provider "${name}" removed.`);
+  if (droppedCustomModels > 0) {
+    const plural = droppedCustomModels === 1 ? "model" : "models";
+    console.log(`   Also removed ${droppedCustomModels} custom ${plural} that belonged to it.`);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/providers/provider-id-rewrite.ts
+++ b/src/providers/provider-id-rewrite.ts
@@ -148,3 +148,32 @@ export function rewriteProviderReferences(config: OcxConfig, from: string, to: s
 
   return { changed, collisions };
 }
+
+/**
+ * Drop the custom-model rows that belonged to a provider being removed.
+ *
+ * The sibling of the rename pass above. `rewriteProviderReferences` already
+ * carries `customModels[].provider` across a rename, so the array tracks the
+ * provider lifecycle — but removal used to delete only `config.providers[name]`
+ * and leave the rows behind. Those orphans still reach `/api/models` and the
+ * generated Codex catalog, which key on the row rather than on provider
+ * existence, so they surface as models that resolve to nothing (#1273).
+ *
+ * Only the rows are touched: the `customModelCatalogMigration` marker records
+ * one-time ownership of pre-marker rows and must survive removal unchanged, or
+ * an older binary's view of that ownership silently changes.
+ *
+ * Returns the number of rows dropped so callers can report it.
+ */
+export function dropProviderCustomModels(config: OcxConfig, provider: string): number {
+  const existing = config.customModels;
+  if (!Array.isArray(existing) || existing.length === 0) return 0;
+  const kept = existing.filter(model => model.provider !== provider);
+  if (kept.length === existing.length) return 0;
+  // Match the add/remove routes: an emptied list is dropped rather than left as
+  // `[]`, so the `customModels` field is absent either way. Only that field —
+  // the `customModelCatalogMigration` marker is deliberately left in place.
+  if (kept.length > 0) config.customModels = kept;
+  else delete config.customModels;
+  return existing.length - kept.length;
+}

--- a/src/server/management/provider-routes.ts
+++ b/src/server/management/provider-routes.ts
@@ -615,13 +615,20 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
     const { saveConfigPreservingClaudeCode: save } = await import("../../config");
     if (fallbackDefault) config.defaultProvider = fallbackDefault;
     delete config.providers[name];
+    const { dropProviderCustomModels } = await import("../../providers/provider-id-rewrite");
+    const droppedCustomModels = dropProviderCustomModels(config, name);
     setProviderContextCap(config, name, false);
     save(config);
     reconcileLiveStateStores();
     const { clearModelCache: clearCache } = await import("../../codex/model-cache");
     clearCache(name);
     const catalogRefresh = await convergeCodexCatalog();
-    return jsonResponse({ success: true, ...(fallbackDefault ? { defaultProvider: fallbackDefault } : {}), catalogRefresh });
+    return jsonResponse({
+      success: true,
+      ...(fallbackDefault ? { defaultProvider: fallbackDefault } : {}),
+      ...(droppedCustomModels > 0 ? { droppedCustomModels } : {}),
+      catalogRefresh,
+    });
   }
 
   if (url.pathname === "/api/provider-context-caps" && req.method === "GET") {

--- a/tests/cli-provider.test.ts
+++ b/tests/cli-provider.test.ts
@@ -223,6 +223,45 @@ describe("ocx provider", () => {
     }
   });
 
+  test("provider remove drops that provider's custom models (#1273)", () => {
+    const { dir } = freshConfig({
+      providers: {
+        openai: { adapter: "openai-responses", baseUrl: "https://chatgpt.com/backend-api/codex", authMode: "forward" },
+        huggingface: { adapter: "openai-chat", baseUrl: "https://api.hf.test/v1", apiKey: "k" },
+      },
+      customModels: [
+        { id: "keep-1", provider: "openai", modelId: "kept-model" },
+        { id: "drop-1", provider: "huggingface", modelId: "DeepSeek-V4-Flash-0731" },
+      ],
+      // Seeded so the assertion below proves removal does not rewrite one-time
+      // ownership: an older binary must keep seeing the same legacy slugs.
+      customModelCatalogMigration: {
+        version: 1,
+        legacyOwnedSlugs: ["huggingface/DeepSeek-V4-Flash-0731", "openai/kept-model"],
+      },
+    });
+    try {
+      const result = runCli(["provider", "remove", "huggingface", "--json"], { OPENCODEX_HOME: dir });
+      expect(result.status).toBe(0);
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        action: "removed",
+        provider: "huggingface",
+        droppedCustomModels: 1,
+      });
+
+      const config = readConfig(dir);
+      expect(config.customModels).toEqual([
+        { id: "keep-1", provider: "openai", modelId: "kept-model" },
+      ]);
+      expect(config.customModelCatalogMigration).toEqual({
+        version: 1,
+        legacyOwnedSlugs: ["huggingface/DeepSeek-V4-Flash-0731", "openai/kept-model"],
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("provider remove rejects default provider", () => {
     const { dir } = freshConfig();
     try {

--- a/tests/management-provider-validation.test.ts
+++ b/tests/management-provider-validation.test.ts
@@ -1072,6 +1072,69 @@ describe("provider management validation", () => {
     }
   });
 
+  test("provider deletion removes that provider's custom models (#1273)", async () => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    saveConfig({
+      port: 0,
+      defaultProvider: "test-openai",
+      providers: {
+        "test-openai": {
+          adapter: "openai-chat",
+          baseUrl: "https://api.example.test/v1",
+          apiKey: "sk-secret-value",
+        },
+        removable: {
+          adapter: "openai-chat",
+          baseUrl: "https://api.removable.test/v1",
+          apiKey: "sk-removable",
+        },
+      },
+      customModels: [
+        { id: "keep-1", provider: "test-openai", modelId: "kept-model" },
+        { id: "drop-1", provider: "removable", modelId: "ghost-model" },
+      ],
+      // Seeded so the assertion below covers the real persistence path, not just
+      // the helper: `projectCustomModelCatalogMigration` runs inside the save and
+      // must carry this marker through a provider delete unchanged.
+      customModelCatalogMigration: {
+        version: 1,
+        legacyOwnedSlugs: ["removable/ghost-model", "test-openai/kept-model"],
+      },
+    } as unknown as Parameters<typeof saveConfig>[0]);
+
+    const server = startServer(0);
+    try {
+      const response = await fetch(new URL("/api/providers?name=removable", server.url), {
+        method: "DELETE",
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ success: true, droppedCustomModels: 1 });
+
+      // The dashboard model page reads this route; a surviving row here is the
+      // ghost model users see pointing at a provider that no longer exists.
+      const customModels = await fetch(new URL("/api/custom-models", server.url));
+      expect(await customModels.json()).toEqual([
+        { id: "keep-1", provider: "test-openai", modelId: "kept-model" },
+      ]);
+
+      const persisted = JSON.parse(readFileSync(join(TEST_DIR, "config.json"), "utf8")) as {
+        customModels?: unknown;
+        customModelCatalogMigration?: unknown;
+      };
+      expect(persisted.customModels).toEqual([
+        { id: "keep-1", provider: "test-openai", modelId: "kept-model" },
+      ]);
+      expect(persisted.customModelCatalogMigration).toEqual({
+        version: 1,
+        legacyOwnedSlugs: ["removable/ghost-model", "test-openai/kept-model"],
+      });
+    } finally {
+      await server.stop(true);
+    }
+  });
+
   test("provider management switches the default and reassigns it when removed", async () => {
     if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
     mkdirSync(TEST_DIR, { recursive: true });

--- a/tests/provider-id-rewrite.test.ts
+++ b/tests/provider-id-rewrite.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { comboConfigError } from "../src/combos";
 import { providerContextCap } from "../src/providers/context-cap";
-import { rewriteProviderReferences } from "../src/providers/provider-id-rewrite";
+import { dropProviderCustomModels, rewriteProviderReferences } from "../src/providers/provider-id-rewrite";
 import type { OcxConfig, OcxProviderConfig } from "../src/types";
 
 const FROM = "alibaba-token-plan";
@@ -130,4 +130,82 @@ test("does not touch providers[*].selectedModels", () => {
   } as unknown as OcxConfig;
   expect(rewriteProviderReferences(config, FROM, TO).changed).toBe(0);
   expect(config.providers.openrouter!.selectedModels).toEqual([`${FROM}/qwen3.7-max`]);
+});
+
+// ---------------------------------------------------------------------------
+// dropProviderCustomModels — the removal sibling of the rename pass (#1273)
+// ---------------------------------------------------------------------------
+
+function customModelsConfig(models: Array<{ id: string; provider: string; modelId: string }>): OcxConfig {
+  return {
+    providers: {
+      huggingface: { adapter: "openai-chat" },
+      "agnes-ai": { adapter: "openai-chat" },
+    },
+    customModels: models,
+  } as unknown as OcxConfig;
+}
+
+test("removal drops only the departing provider's custom models", () => {
+  const config = customModelsConfig([
+    { id: "a", provider: "agnes-ai", modelId: "agnes-2.5-flash" },
+    { id: "b", provider: "huggingface", modelId: "DeepSeek-V4-Flash-0731" },
+    { id: "c", provider: "huggingface", modelId: "another-model" },
+  ]);
+
+  expect(dropProviderCustomModels(config, "huggingface")).toBe(2);
+  expect(config.customModels).toEqual([
+    { id: "a", provider: "agnes-ai", modelId: "agnes-2.5-flash" },
+  ] as OcxConfig["customModels"]);
+});
+
+test("removing the last custom model deletes the key rather than leaving []", () => {
+  // The add/remove routes drop an emptied list, so the `customModels` field is
+  // absent either way. Only that field: the `customModelCatalogMigration`
+  // marker is deliberately preserved, so the two configs are not identical.
+  const config = customModelsConfig([
+    { id: "b", provider: "huggingface", modelId: "DeepSeek-V4-Flash-0731" },
+  ]);
+
+  expect(dropProviderCustomModels(config, "huggingface")).toBe(1);
+  expect(Object.hasOwn(config, "customModels")).toBe(false);
+});
+
+test("a provider with no custom models is a no-op that leaves the array identical", () => {
+  const rows = [{ id: "a", provider: "agnes-ai", modelId: "agnes-2.5-flash" }];
+  const config = customModelsConfig(rows);
+  const before = config.customModels;
+
+  expect(dropProviderCustomModels(config, "huggingface")).toBe(0);
+  // Same reference, not merely a deep-equal copy: an untouched save must not
+  // look like a mutation to anything comparing identity.
+  expect(config.customModels).toBe(before);
+});
+
+test("an absent customModels key is left absent", () => {
+  const config = { providers: { huggingface: { adapter: "openai-chat" } } } as unknown as OcxConfig;
+  expect(dropProviderCustomModels(config, "huggingface")).toBe(0);
+  expect(Object.hasOwn(config, "customModels")).toBe(false);
+});
+
+test("removal leaves the custom-model ownership marker untouched", () => {
+  // legacyOwnedSlugs records one-time ownership of pre-marker rows. Rewriting it
+  // here would change an older binary's view of what it may delete, which the
+  // migration module explicitly warns against.
+  const config = customModelsConfig([
+    { id: "a", provider: "agnes-ai", modelId: "agnes-2.5-flash" },
+    { id: "b", provider: "huggingface", modelId: "DeepSeek-V4-Flash-0731" },
+  ]);
+  const marker = {
+    version: 1,
+    legacyOwnedSlugs: ["agnes-ai/agnes-2.5-flash", "huggingface/DeepSeek-V4-Flash-0731"],
+  };
+  (config as unknown as Record<string, unknown>).customModelCatalogMigration = marker;
+
+  dropProviderCustomModels(config, "huggingface");
+
+  expect((config as unknown as Record<string, unknown>).customModelCatalogMigration).toEqual({
+    version: 1,
+    legacyOwnedSlugs: ["agnes-ai/agnes-2.5-flash", "huggingface/DeepSeek-V4-Flash-0731"],
+  });
 });


### PR DESCRIPTION
## Summary

Partial fix for #1273 — the first of the two defects in that report. **It does not close the issue**; see "What this does not fix" below.

Removing a provider deleted only `config.providers[name]`. Its rows in `config.customModels` stayed behind, and neither consumer filters them: `/api/models` lists every row (`src/server/management/model-rows.ts`) and the generated Codex catalog emits every row keyed by slug (`src/codex/catalog/provider-fetch.ts`). The dashboard kept advertising models that resolved to a provider which no longer existed.

This is an inconsistency rather than a missing feature. Provider **rename** already maintains the array — `rewriteProviderReferences` rewrites `customModels[].provider` alongside combo targets and Claude tier maps — so the array is meant to track the provider lifecycle, and one of the two sibling operations simply did not. `dropProviderCustomModels` is placed directly beside the rename pass so the two stay visible to each other.

Both removal paths call it and report the count: `ocx provider remove` prints it and adds `droppedCustomModels` to `--json`; the management `DELETE /api/providers` returns the same field.

Two deliberate details:

- An emptied list drops the `customModels` field rather than leaving `[]`, matching the add/remove routes.
- The `customModelCatalogMigration` marker is **preserved unchanged**. It records one-time ownership of pre-marker rows, and rewriting it would change an older binary's view of what it may delete — the migration module warns against exactly that. Both integration tests assert the marker survives in the persisted `config.json`.

## What this does not fix

The second defect in #1273 remains open: a stale in-memory config re-persisting deleted rows through a whole-document write. `saveConfigPreservingClaudeCode` reconciles `claudeCode` and the live server binding against its pre-write disk read, but not `customModels`, so a process holding a pre-deletion config resurrects the rows.

That needs a reconciliation design of its own, keyed on the immutable `OcxCustomModel.id` rather than on `routedSlug` (which is an encoding — both `provider` and `modelId` are mutable, so a renamed row reads as a delete plus an insert). It also has to cover `providers` itself, since the same stale write resurrects the provider record. Diagnosis and the writer-path inventory are recorded on the issue.

## Verification

- `bun run test` — **10009 pass / 7 skip / 0 fail** across 626 files
- `bun test tests/provider-id-rewrite.test.ts tests/management-provider-validation.test.ts` — 62 pass / 0 fail
- `bun test tests/cli-provider.test.ts` — 30 pass / 0 fail
- `bun run typecheck` — clean
- `bun run privacy:scan` — passed

Each path proved independently, since a combined ablation would only have proved one of them:

- reverting **only** `src/server/management/provider-routes.ts` → 61 pass / 1 fail, failing the new management API test
- reverting **only** `src/cli/provider.ts` → 29 pass / 1 fail, failing the new CLI test, which spawns the real `ocx provider remove` and reads the persisted config

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No documented behavior changes; the new `droppedCustomModels` field is additive and reported only when non-zero.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (No credential, auth, or workflow surface is touched; the change filters one config array.)

---

Reported by @gdxnpy, whose reproduction included a before/after config diff showing the cooperating save path itself was healthy — that detail is what made the second defect findable rather than "settings sometimes revert".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removing a provider now also removes its associated custom models.
  - Custom models belonging to other providers remain unchanged.
  - Migration metadata is preserved during provider removal.

- **CLI & API**
  - Provider deletion results report the number of removed custom models.
  - JSON and human-readable output use appropriate count formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->