### PR TITLE
fix(catalog): preserve nested reasoning efforts

### DIFF
--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -923,7 +923,16 @@ export function catalogHintsFromModelsApiItem(providerName: string, item: Provid
       item.max_context_length,
     );
   const maxInputTokens = positiveSafeInteger(limits?.max_input_tokens, item.max_input_tokens);
-  const rawReasoningEfforts = capabilityRecord?.reasoning_effort ?? item.reasoning_efforts;
+  // Some OpenAI-compatible catalogs expose the selectable ladder under
+  // `reasoning_parameters.efforts` instead of the older `reasoning_efforts` key.
+  // Treat both as model metadata: otherwise a valid upstream capability disappears
+  // before client exporters (including omp) can advertise it.
+  const reasoningParameters = plainRecord(item.reasoning_parameters)
+    ?? plainRecord(metadata?.reasoning_parameters)
+    ?? plainRecord(capabilityRecord?.reasoning_parameters);
+  const rawReasoningEfforts = capabilityRecord?.reasoning_effort
+    ?? item.reasoning_efforts
+    ?? reasoningParameters?.efforts;
   const listedReasoningEfforts = normalizedStringList(rawReasoningEfforts, 8, 24);
   const reasoningEfforts = listedReasoningEfforts
     ? sanitizeCodexReasoningEfforts(listedReasoningEfforts)

--- a/tests/provider-model-discovery-contract.test.ts
+++ b/tests/provider-model-discovery-contract.test.ts
@@ -274,6 +274,13 @@ describe("registry-owned provider model discovery", () => {
     })).toEqual({});
   });
 
+  test("preserves nested reasoning_parameters effort ladders from OpenAI-compatible catalogs", () => {
+    expect(catalogHintsFromModelsApiItem("example", {
+      id: "reasoning-model",
+      reasoning_parameters: { efforts: ["low", "high", "max"] },
+    })).toEqual({ reasoningEfforts: ["low", "high", "max"] });
+  });
+
   test("drops untrusted metadata tokens containing control characters", () => {
     expect(catalogHintsFromModelsApiItem("example", {
       id: "controlled",


### PR DESCRIPTION
## Summary

- Preserve `reasoning_parameters.efforts` emitted by OpenAI-compatible `/models` endpoints.
- This fixes effort controls disappearing in downstream client exports such as Oh My Pi even when the upstream explicitly advertises a valid per-model ladder.

## Verification

- `bun test tests/provider-model-discovery-contract.test.ts`
- `bun run typecheck`
- `bun run test`
- `bun run privacy:scan`
- Live synthetic-provider verification: the advertised `low`, `high`, and `max` values now appear in `omp models`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (not needed for an internal metadata parser fix).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults; no credentials are stored or emitted.

<!-- pr-quality-readiness-checklist:start -->
- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model discovery now recognizes and preserves available reasoning-effort options from compatible catalogs.

* **Bug Fixes**
  * Improved handling of nested model metadata so reasoning capabilities are accurately surfaced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->