### PR TITLE
test(ci): bind the Windows shard assertion to an executable command (#1185)

### DIFF
--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -39,6 +39,15 @@ function count(text: string, fragment: string): number {
   return text.split(fragment).length - 1;
 }
 
+/** Match an executable shell line, not a fragment that could appear in echo or a comment. */
+function hasExactShellCommand(run: string | undefined, expected: string): boolean {
+  return (run ?? "")
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line.length > 0 && !line.startsWith("#"))
+    .includes(expected);
+}
+
 function expectSecureLinuxKeyringBootstrap(workflow: string): void {
   const smokeStep = workflow
     .split("- name: OS keyring create/read/delete smoke")[1]
@@ -164,7 +173,9 @@ describe("GitHub Actions hardening", () => {
     // the runner's disk and the suite passes against a tree that no longer
     // exists in git.
     const winSteps = (ci.jobs?.["platform-windows"] as { steps?: { if?: string; run?: string }[] })?.steps ?? [];
-    expect(winSteps.some(step => step.run?.includes(`--shard=\${{ matrix.shard }}/${windowsShards.length}`))).toBe(true);
+    const windowsTestCommand = `bun test --isolate tests --shard=\${{ matrix.shard }}/${windowsShards.length}`;
+    expect(hasExactShellCommand(`echo ${windowsTestCommand}`, windowsTestCommand)).toBe(false);
+    expect(winSteps.some(step => hasExactShellCommand(step.run, windowsTestCommand))).toBe(true);
     expect(winSteps.some(step => step.if === "runner.environment == 'self-hosted'"
       && step.run?.includes("git clean -xffd"))).toBe(true);
 

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -175,7 +175,13 @@ describe("GitHub Actions hardening", () => {
     const winSteps = (ci.jobs?.["platform-windows"] as { steps?: { if?: string; run?: string }[] })?.steps ?? [];
     const windowsTestCommand = `bun test --isolate tests --shard=\${{ matrix.shard }}/${windowsShards.length}`;
     expect(hasExactShellCommand(`echo ${windowsTestCommand}`, windowsTestCommand)).toBe(false);
-    expect(winSteps.some(step => hasExactShellCommand(step.run, windowsTestCommand))).toBe(true);
+    // Binding the assertion to an executable line is only half the guarantee: a
+    // step carrying the exact command still runs nothing under `if: false`, and
+    // the suite would stay green against a Windows leg that never tests. Require
+    // the matching step to be unconditional.
+    const windowsTestSteps = winSteps.filter(step => hasExactShellCommand(step.run, windowsTestCommand));
+    expect(windowsTestSteps.length).toBeGreaterThan(0);
+    expect(windowsTestSteps.every(step => step.if === undefined)).toBe(true);
     expect(winSteps.some(step => step.if === "runner.environment == 'self-hosted'"
       && step.run?.includes("git clean -xffd"))).toBe(true);
 


### PR DESCRIPTION
## Summary

Republishes @luvs01's #1185 on current `dev`. Their branch was 324 commits behind, so this is a maintainer rebase; the first commit is theirs via `Co-authored-by`.

The assertion that the Windows leg shards the suite used `.includes()` against the step's `run` text, so any occurrence of the command anywhere in the script satisfied it — inside an `echo`, or in a comment. A Windows job that printed the command instead of running it kept the suite green. `hasExactShellCommand` splits the script into lines, drops blanks and comments, and requires the command as a whole line; the negative assertion against `echo <command>` pins that so a future loosening back to substring matching fails here rather than silently.

**This PR adds one maintainer-authored commit that was not in #1185** (`test(ci): require the Windows test step to be unconditional`). Binding the assertion to an executable line closes the `echo` hole but not the neighbouring one: a step carrying the exact command still runs nothing under `if: false`, and the suite would stay green against a Windows leg that never tests. It is a separate commit rather than folded in, so the added coverage is not attributed to the contributor.

Supersedes #1185, which can be closed once this lands.

## Verification

Rebased onto `14e948525` and verified after the rebase:

- `bun run test` — **10009 pass / 7 skip / 0 fail** across 626 files
- `bun test tests/ci-workflows.test.ts` — 125 pass / 0 fail
- `bun run typecheck` — clean
- `bun run privacy:scan` — passed

Two ablations against `.github/workflows/ci.yml`, each restored afterwards. Both mutations neuter the Windows test leg, and **neither is caught by `dev` today**:

| Mutation to the Windows Test step | `dev` today | with this PR |
|---|---|---|
| `run: bun test …` → `run: echo bun test …` | 125 pass / 0 fail | 124 pass / **1 fail** |
| add `if: false`, command unchanged | 125 pass / 0 fail | 124 pass / **1 fail** |

The first is the contributor's assertion; the second is the maintainer commit.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (Test-only change; no user-facing behavior.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (No workflow file is modified — this tightens the test that inspects them. The ablations above were local and reverted.)

---

Note on #1185's red CI: its `Cross-platform CI` failure at `bff31d1e0` is not caused by that diff. The shard crashed while loading `tests/autostart-health.test.ts` with `EEXIST: file already exists, epoll_ctl` in a Bun `WriteStream`, followed by a collateral `Cannot call describe() after the test run has completed`. #1185 touches only `tests/ci-workflows.test.ts` and has no path to that file. Root cause of the Bun-level crash is unknown and not diagnosed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved continuous integration checks for Windows test execution.
  - Validation now confirms the required sharded test command is present, exact, and runs unconditionally.
  - Prevents misleading matches caused by commented or echoed command text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->