### PR TITLE
fix(providers): correct Qwen3.8 reasoning levels

### DIFF
--- a/docs-site/src/content/docs/reference/architecture.md
+++ b/docs-site/src/content/docs/reference/architecture.md
@@ -166,6 +166,12 @@ upstream providers may support only a smaller subset or require a real alias. Th
 - Resolves per-model and per-provider `reasoningEffortMap` overrides for custom wire mappings.
 - Drops the effort entirely for models listed in `noReasoningModels`.
 
+Qwen3.8-Max is an explicit direct-effort exception to the older Qwen3.x budget contract. Alibaba
+Token Plan records its upstream-supported ladder as `low`, `medium`, and `xhigh` (the default), and
+sends the effective value as `reasoning_effort`; Codex-only compatibility tops are clamped to
+`xhigh` on the wire. Runtime registry enrichment repairs older persisted preset metadata that still
+classifies this model as a `thinking_budget` model.
+
 ## Core types
 
 The internal model lives in `types.ts`: `OcxParsedRequest`, `OcxContext`, the `OcxMessage` union,

--- a/docs-site/src/content/docs/zh-cn/reference/architecture.md
+++ b/docs-site/src/content/docs/zh-cn/reference/architecture.md
@@ -157,6 +157,11 @@ Codex context compaction 同样适用于路由模型。`server/responses/compact
 - 解析模型级和 provider 级 `reasoningEffortMap` override，用于自定义 wire 映射。
 - 对 `noReasoningModels` 中的模型完全移除 effort。
 
+Qwen3.8-Max 是旧版 Qwen3.x budget 契约之外、明确使用直接 effort 的例外。Alibaba Token
+Plan 把其上游支持等级记录为 `low`、`medium` 和 `xhigh`（默认值），并通过
+`reasoning_effort` 发送最终值；仅供 Codex 兼容的顶档在发送时会限制为 `xhigh`。运行时的
+注册表补全会修复仍把该模型归类为 `thinking_budget` 模型的旧版持久化预设元数据。
+
 ## 核心类型
 
 内部模型位于 `types.ts`：`OcxParsedRequest`、`OcxContext`、`OcxMessage` 联合类型、

--- a/src/providers/derive.ts
+++ b/src/providers/derive.ts
@@ -109,6 +109,67 @@ function cloneNestedRecord(input: Record<string, Record<string, string>>): Recor
   return Object.fromEntries(Object.entries(input).map(([key, value]) => [key, { ...value }]));
 }
 
+function omitFoldedModelKeys<T>(
+  record: Record<string, T> | undefined,
+  foldedModels: ReadonlySet<string>,
+): Record<string, T> | undefined {
+  if (!record) return undefined;
+  const next = Object.fromEntries(
+    Object.entries(record).filter(([model]) => !foldedModels.has(model.toLowerCase())),
+  ) as Record<string, T>;
+  return Object.keys(next).length > 0 ? next : undefined;
+}
+
+/**
+ * Apply a registry-owned direct `reasoning_effort` contract after user/seed metadata is merged.
+ *
+ * Provider presets are persisted with capability metadata, so an existing config can retain an
+ * obsolete thinking-budget classification after the registry learns that a model has a native
+ * effort field. The registry opts only verified model contracts into this repair; providers that
+ * do not resolve through the matching registry entry keep their user-supplied classification.
+ */
+export function applyDirectReasoningEffortContracts(
+  entry: ProviderRegistryEntry,
+  prov: OcxProviderConfig,
+): void {
+  const models = entry.directReasoningEffortModels;
+  if (!models || models.length === 0) return;
+
+  const direct = new Set(models.map(model => model.toLowerCase()));
+  const keepNonDirect = (model: string): boolean => !direct.has(model.toLowerCase());
+
+  prov.thinkingBudgetModels = prov.thinkingBudgetModels?.filter(keepNonDirect);
+  prov.thinkingToggleModels = prov.thinkingToggleModels?.filter(keepNonDirect);
+  prov.modelReasoningEfforts = omitFoldedModelKeys(prov.modelReasoningEfforts, direct);
+  prov.modelDefaultReasoningEfforts = omitFoldedModelKeys(prov.modelDefaultReasoningEfforts, direct);
+  prov.modelReasoningEffortMap = omitFoldedModelKeys(prov.modelReasoningEffortMap, direct);
+
+  for (const model of models) {
+    const efforts = entry.modelReasoningEfforts?.[model];
+    if (efforts) {
+      prov.modelReasoningEfforts = {
+        ...(prov.modelReasoningEfforts ?? {}),
+        [model]: [...efforts],
+      };
+    }
+
+    const defaultEffort = entry.modelDefaultReasoningEfforts?.[model];
+    if (defaultEffort) {
+      prov.modelDefaultReasoningEfforts = {
+        ...(prov.modelDefaultReasoningEfforts ?? {}),
+        [model]: defaultEffort,
+      };
+    }
+
+    // An explicit empty model map masks any provider-wide aliases. Without it, a stale global
+    // mapping such as xhigh -> max would win before the verified direct ladder can clamp it.
+    prov.modelReasoningEffortMap = {
+      ...(prov.modelReasoningEffortMap ?? {}),
+      [model]: {},
+    };
+  }
+}
+
 /**
  * Build the provider config a registry entry contributes when a preset is materialized.
  * The registry auth kind is preserved verbatim (including `"local"`) so fail-closed gates
@@ -353,6 +414,7 @@ export function enrichProviderFromRegistry(name: string, prov: OcxProviderConfig
   if (prov.freeTier === undefined && seed.freeTier !== undefined) prov.freeTier = seed.freeTier;
   if (prov.modelSuffixBracketStrip === undefined && seed.modelSuffixBracketStrip !== undefined) prov.modelSuffixBracketStrip = seed.modelSuffixBracketStrip;
   if (!prov.headers && seed.headers) prov.headers = { ...seed.headers };
+  applyDirectReasoningEffortContracts(entry, prov);
 }
 
 export function deriveFeaturedProviderIds(): string[] {

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -209,6 +209,12 @@ export interface ProviderRegistryEntry {
   modelDefaultReasoningEfforts?: Record<string, string>;
   reasoningEffortMap?: Record<string, string>;
   modelReasoningEffortMap?: Record<string, Record<string, string>>;
+  /**
+   * Registry-authoritative models that send OpenAI's direct `reasoning_effort` field.
+   * Runtime enrichment uses this to repair stale preset metadata that still classifies a model
+   * as a thinking-budget/toggle model. This is registry-only and is never persisted as user config.
+   */
+  directReasoningEffortModels?: string[];
   reasoningWireFormat?: OcxProviderConfig["reasoningWireFormat"];
   noVisionModels?: string[];
   noReasoningModels?: string[];
@@ -344,6 +350,9 @@ const ZHIPU_BIGMODEL_INPUT_MODALITIES: Record<string, string[]> = {
 };
 const ZHIPU_BIGMODEL_THINKING_TOGGLE_MODELS = ["glm-4.6", "glm-4.7", "glm-5", "glm-5.1"];
 const THINKING_BUDGET_EFFORTS = ["low", "medium", "high", "xhigh", "max"];
+// Qwen3.8-Max is the first Qwen3.x model with official direct `reasoning_effort` support.
+// Evidence: https://qwen.ai/blog?id=qwen3.8
+const QWEN38_REASONING_EFFORTS = ["low", "medium", "xhigh"];
 const THINKING_BUDGET_MODELS = [
   "qwen3.5-397b", "qwen3.6-35b",
   "qwen3.5-plus", "qwen3.6-plus", "qwen3.7-max", "qwen3.7-plus",
@@ -1899,11 +1908,14 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     },
     modelReasoningEfforts: {
       ...Object.fromEntries(ALIBABA_TOKEN_PLAN_QWEN_MODELS.map(id => [id, THINKING_BUDGET_EFFORTS])),
+      "qwen3.8-max": QWEN38_REASONING_EFFORTS,
       "glm-5.2": ZAI_GLM_52_REASONING_EFFORTS,
       "deepseek-v4-pro": deepseekThinkingEffortsFor("deepseek-v4-pro"),
     },
+    modelDefaultReasoningEfforts: { "qwen3.8-max": "xhigh" },
     modelReasoningEffortMap: { "deepseek-v4-pro": deepseekReasoningMapFor("deepseek-v4-pro") },
-    thinkingBudgetModels: ALIBABA_TOKEN_PLAN_QWEN_MODELS,
+    directReasoningEffortModels: ["qwen3.8-max"],
+    thinkingBudgetModels: ALIBABA_TOKEN_PLAN_QWEN_MODELS.filter(id => id !== "qwen3.8-max"),
     preserveReasoningContentModels: ["glm-5.2", "deepseek-v4-pro", "qwen3.8-max", "qwen3.7-max", "qwen3.7-plus", "qwen3.6-flash"],
     noVisionModels: ["glm-5.2", "deepseek-v4-pro"],
   },
@@ -1932,7 +1944,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     },
     modelReasoningEfforts: {
       ...Object.fromEntries(ALIBABA_INTL_TOKEN_PLAN_QWEN_MODELS.map(id => [id, THINKING_BUDGET_EFFORTS])),
-      "qwen3.8-max": ["low", "high", "xhigh"],
+      "qwen3.8-max": QWEN38_REASONING_EFFORTS,
       "glm-5.2": ZAI_GLM_52_REASONING_EFFORTS,
       "deepseek-v4-pro": deepseekThinkingEffortsFor("deepseek-v4-pro"),
       "deepseek-v4-flash": deepseekThinkingEffortsFor("deepseek-v4-flash"),
@@ -1941,7 +1953,8 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
       "deepseek-v4-pro": deepseekReasoningMapFor("deepseek-v4-pro"),
       "deepseek-v4-flash": deepseekReasoningMapFor("deepseek-v4-flash"),
     },
-    thinkingBudgetModels: ALIBABA_INTL_TOKEN_PLAN_QWEN_MODELS,
+    directReasoningEffortModels: ["qwen3.8-max"],
+    thinkingBudgetModels: ALIBABA_INTL_TOKEN_PLAN_QWEN_MODELS.filter(id => id !== "qwen3.8-max"),
     preserveReasoningContentModels: ["glm-5.2", "deepseek-v4-pro", "deepseek-v4-flash", "qwen3.8-max", "qwen3.7-max", "qwen3.7-plus", "qwen3.6-plus", "qwen3.6-flash"],
     noVisionModels: ["deepseek-v4-pro", "deepseek-v4-flash", "deepseek-v3.2", "glm-5.2", "glm-5.1", "glm-5", "MiniMax-M2.5"],
     noReasoningModels: ["kimi-k2.7-code", "kimi-k2.6", "kimi-k2.5", "deepseek-v3.2", "glm-5.1", "glm-5", "MiniMax-M2.5"],

--- a/src/router.ts
+++ b/src/router.ts
@@ -12,6 +12,7 @@ import { hasOwnProvider, resolveEnvValue } from "./config";
 import { assertProviderDestinationAllowed } from "./lib/destination-policy";
 import { redactSecretString, redactUrlForLog } from "./lib/redact";
 import { PROVIDER_REGISTRY, providerCodexAccountMode, providerMatchesRegistryTransport } from "./providers/registry";
+import { applyDirectReasoningEffortContracts } from "./providers/derive";
 import {
   isCanonicalOpenAiForwardProvider,
   LEGACY_CHATGPT_PROVIDER_ID,
@@ -300,7 +301,7 @@ function routedProviderConfig(providerName: string, provider: OcxProviderConfig)
   if (userBaseUrlIsResolved) warnIfBaseUrlDiscarded(providerName, userBaseUrl, baseUrl);
   assertProviderDestinationAllowed(providerName, { baseUrl, allowPrivateNetwork: provider.allowPrivateNetwork });
 
-  return {
+  const resolved: OcxProviderConfig = {
     ...provider,
     adapter: registryEntry.adapter,
     baseUrl,
@@ -372,6 +373,8 @@ function routedProviderConfig(providerName: string, provider: OcxProviderConfig)
     ...(thinkingToggleModels ? { thinkingToggleModels } : {}),
     ...(thinkingBudgetModels ? { thinkingBudgetModels } : {}),
   };
+  applyDirectReasoningEffortContracts(registryEntry, resolved);
+  return resolved;
 }
 
 function activeProviderEntries(config: OcxConfig): [string, OcxProviderConfig][] {

--- a/tests/alibaba-intl-token-plan.test.ts
+++ b/tests/alibaba-intl-token-plan.test.ts
@@ -11,7 +11,7 @@ import {
   matchBaseUrlChoice,
 } from "../src/providers/base-url-choices";
 import { PROVIDER_REGISTRY } from "../src/providers/registry";
-import { deriveProviderPresets } from "../src/providers/derive";
+import { deriveProviderPresets, enrichProviderFromRegistry } from "../src/providers/derive";
 
 const CHOICES = [...ALIBABA_INTL_BASE_URL_CHOICES];
 
@@ -56,7 +56,10 @@ describe("alibaba-token-plan-intl registry entry", () => {
 
   test("qwen3.8-max reasoning efforts", () => {
     const entry = PROVIDER_REGISTRY.find(e => e.id === "alibaba-token-plan-intl");
-    expect(entry!.modelReasoningEfforts?.["qwen3.8-max"]).toEqual(["low", "high", "xhigh"]);
+    expect(entry!.modelReasoningEfforts?.["qwen3.8-max"]).toEqual(["low", "medium", "xhigh"]);
+    expect(entry!.directReasoningEffortModels).toEqual(["qwen3.8-max"]);
+    expect(entry!.thinkingBudgetModels).not.toContain("qwen3.8-max");
+    expect(entry!.thinkingBudgetModels).toContain("qwen3.7-max");
   });
 
   test("qwen3.8-max default reasoning effort is xhigh", () => {
@@ -86,12 +89,34 @@ describe("alibaba-token-plan-intl registry entry", () => {
     }
     // The intl entry additionally carries the effort ladder.
     const intl = PROVIDER_REGISTRY.find(e => e.id === "alibaba-token-plan-intl")!;
-    expect(intl.modelReasoningEfforts?.["qwen3.8-max"]).toEqual(["low", "high", "xhigh"]);
+    expect(intl.modelReasoningEfforts?.["qwen3.8-max"]).toEqual(["low", "medium", "xhigh"]);
     expect(intl.modelDefaultReasoningEfforts?.["qwen3.8-max"]).toBe("xhigh");
     // Only the Beijing entry defaults to this model; intl deliberately defaults to
     // qwen3.7-max. That predates this rename and is left alone — renaming an id is not
     // a licence to change which model a provider selects by default.
     expect(PROVIDER_REGISTRY.find(e => e.id === "alibaba-token-plan")!.defaultModel).toBe("qwen3.8-max");
+  });
+
+  test("registry enrichment repairs a persisted pre-release Qwen3.8 contract", () => {
+    const provider = {
+      adapter: "openai-chat",
+      baseUrl: ALIBABA_INTL_TOKEN_PLAN_BASE_URL,
+      modelReasoningEfforts: { "QWEN3.8-MAX": ["low", "high", "xhigh"] },
+      modelDefaultReasoningEfforts: { "QWEN3.8-MAX": "high" },
+      reasoningEffortMap: { xhigh: "max" },
+      modelReasoningEffortMap: { "QWEN3.8-MAX": { medium: "high" } },
+      thinkingBudgetModels: ["QWEN3.8-MAX", "qwen3.7-max"],
+    };
+
+    enrichProviderFromRegistry("alibaba-token-plan-intl", provider);
+
+    expect(provider.modelReasoningEfforts["qwen3.8-max"]).toEqual(["low", "medium", "xhigh"]);
+    expect(provider.modelReasoningEfforts["QWEN3.8-MAX"]).toBeUndefined();
+    expect(provider.modelDefaultReasoningEfforts["qwen3.8-max"]).toBe("xhigh");
+    expect(provider.modelDefaultReasoningEfforts["QWEN3.8-MAX"]).toBeUndefined();
+    expect(provider.modelReasoningEffortMap?.["qwen3.8-max"]).toEqual({});
+    expect(provider.modelReasoningEffortMap?.["QWEN3.8-MAX"]).toBeUndefined();
+    expect(provider.thinkingBudgetModels).toEqual(["qwen3.7-max"]);
   });
 
   test("non-reasoning models are marked", () => {

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -290,8 +290,9 @@ describe("provider registry parity", () => {
         "qwen3.7-max": ["text", "image"],
       },
       modelReasoningEfforts: {
-        "qwen3.8-max": ["low", "medium", "high", "xhigh", "max"],
+        "qwen3.8-max": ["low", "medium", "xhigh"],
       },
+      modelDefaultReasoningEfforts: { "qwen3.8-max": "xhigh" },
       modelContextWindows: {
         "qwen3.8-max": 983_616,
         "qwen3.7-max": 1_000_000,
@@ -300,8 +301,12 @@ describe("provider registry parity", () => {
       noVisionModels: ["glm-5.2", "deepseek-v4-pro"],
       preserveReasoningContentModels: expect.arrayContaining(["qwen3.8-max", "qwen3.7-max", "qwen3.7-plus"]),
     });
+    expect(PROVIDER_REGISTRY.find(entry => entry.id === "alibaba-token-plan")?.directReasoningEffortModels)
+      .toEqual(["qwen3.8-max"]);
     expect(KEY_LOGIN_PROVIDERS["alibaba-token-plan"].thinkingBudgetModels)
-      .toContain("qwen3.8-max");
+      .not.toContain("qwen3.8-max");
+    expect(KEY_LOGIN_PROVIDERS["alibaba-token-plan"].thinkingBudgetModels)
+      .toContain("qwen3.7-max");
   });
 
   test("aggregator defaults and Neuralwatt seeds match the audited live catalogs", () => {

--- a/tests/reasoning-effort.test.ts
+++ b/tests/reasoning-effort.test.ts
@@ -562,7 +562,7 @@ describe("thinking-toggle models (260707)", () => {
   });
 });
 
-describe("thinking-budget models (260709)", () => {
+describe("Qwen reasoning wire contracts", () => {
   const budgetProvider: OcxProviderConfig = {
     adapter: "openai-chat",
     baseUrl: "https://api.neuralwatt.com/v1",
@@ -628,7 +628,7 @@ describe("thinking-budget models (260709)", () => {
     expect(body).not.toHaveProperty("reasoning_effort");
   });
 
-  test("Alibaba Token Plan routes Qwen3.8 Max Preview with the Qwen thinking budget contract", () => {
+  test("Alibaba Token Plan repairs stale Qwen3.8 metadata and sends direct reasoning_effort", () => {
     const config = {
       port: 10100,
       defaultProvider: "alibaba-token-plan",
@@ -637,18 +637,44 @@ describe("thinking-budget models (260709)", () => {
           adapter: "openai-chat",
           baseUrl: "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
           apiKey: "k",
+          // Simulate a provider row persisted before Qwen3.8 documented its native effort field.
+          thinkingBudgetModels: ["QWEN3.8-MAX", "qwen3.7-max"],
+          modelReasoningEfforts: { "QWEN3.8-MAX": ["low", "medium", "high", "xhigh", "max"] },
+          modelDefaultReasoningEfforts: { "QWEN3.8-MAX": "medium" },
+          reasoningEffortMap: { xhigh: "max" },
+          modelReasoningEffortMap: { "QWEN3.8-MAX": { medium: "high" } },
         },
       },
     } as unknown as OcxConfig;
     const route = routeModel(config, "alibaba-token-plan/qwen3.8-max");
 
     expect(route.provider.modelInputModalities?.[route.modelId]).toEqual(["text", "image"]);
-    expect(route.provider.thinkingBudgetModels).toContain(route.modelId);
-    expect(route.provider.modelReasoningEfforts?.[route.modelId]).toEqual(["low", "medium", "high", "xhigh", "max"]);
+    expect(route.provider.thinkingBudgetModels).not.toContain(route.modelId);
+    expect(route.provider.thinkingBudgetModels).toContain("qwen3.7-max");
+    expect(route.provider.modelReasoningEfforts?.[route.modelId]).toEqual(["low", "medium", "xhigh"]);
+    expect(route.provider.modelReasoningEfforts?.["QWEN3.8-MAX"]).toBeUndefined();
+    expect(route.provider.modelDefaultReasoningEfforts?.[route.modelId]).toBe("xhigh");
+    expect(route.provider.modelDefaultReasoningEfforts?.["QWEN3.8-MAX"]).toBeUndefined();
+    expect(route.provider.modelReasoningEffortMap?.[route.modelId]).toEqual({});
+    expect(route.provider.modelReasoningEffortMap?.["QWEN3.8-MAX"]).toBeUndefined();
 
-    const body = buildBody(route.provider, route.modelId, { reasoning: "max", maxOutputTokens: 65536 });
-    expect(body).toMatchObject({ model: "qwen3.8-max", thinking_budget: 65536 });
-    expect(body).not.toHaveProperty("reasoning_effort");
+    const request = buildChatRequest(route.provider, route.modelId, { reasoning: "xhigh", maxOutputTokens: 65536 });
+    const body = JSON.parse(request.body) as Record<string, unknown>;
+    expect(body).toMatchObject({ model: "qwen3.8-max", reasoning_effort: "xhigh" });
+    expect(body).not.toHaveProperty("thinking_budget");
+    expect(request.reasoningLog).toEqual({
+      effectiveEffort: "xhigh",
+      wireField: "reasoning_effort",
+      wireValue: "xhigh",
+    });
+
+    // Codex may advertise its synthetic compatibility tops; neither may leak an unsupported value.
+    const maxBody = buildBody(route.provider, route.modelId, { reasoning: "max" });
+    expect(maxBody.reasoning_effort).toBe("xhigh");
+    expect(maxBody).not.toHaveProperty("thinking_budget");
+
+    // A client with the old, already-cached high rung degrades to the nearest lower real tier.
+    expect(buildBody(route.provider, route.modelId, { reasoning: "high" }).reasoning_effort).toBe("medium");
   });
 
   test("opencode-go Qwen models are no longer pinned to the Anthropic wire", () => {


### PR DESCRIPTION
## Summary

- Correct Alibaba Token Plan's Qwen3.8-Max reasoning ladder to the officially documented `low`, `medium`, and `xhigh` levels, with `xhigh` as the default.
- Route Qwen3.8-Max through the direct `reasoning_effort` field instead of the legacy Qwen `thinking_budget` contract in both Beijing and international presets.
- Repair stale persisted preset metadata at registry enrichment and routing time, including case-insensitive model keys and provider-wide aliases that could otherwise leak unsupported `high` or `max` values.
- Update the English and Simplified Chinese architecture references with the direct-effort exception.

The previous registry data classified Qwen3.8-Max like older Qwen3.x budget models. International metadata also exposed `high` while omitting the supported `medium` tier. Existing provider rows persist capability metadata, so correcting only the registry seed would leave upgraded installations on the stale wire contract.

This change makes new and existing Alibaba Token Plan configurations follow the [Qwen3.8-Max documentation](https://qwen.ai/blog?id=qwen3.8). Codex compatibility levels above the upstream ladder clamp to `xhigh` rather than reaching the provider as unsupported values.

## Verification

- `bun test tests/reasoning-effort.test.ts tests/alibaba-intl-token-plan.test.ts tests/provider-registry-parity.test.ts` — 89 passed, 0 failed.
- `bun run test` — 10,132 passed, 7 skipped, 0 failed across 631 files.
- `bun run typecheck`
- `bun run privacy:scan`
- `cd docs-site && bun run build`
- `git diff --check`

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
