### PR TITLE
[Bug]: Preserve operator-owned static OAuth catalogs during reconciliation

### DIFF
--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -777,6 +777,11 @@ function migrateLegacyAntigravityStaticCatalog(config: OcxConfig): boolean {
   return true;
 }
 
+/** An explicit static catalog is operator-owned and must not be replaced by OAuth presets. */
+function isOperatorOwnedStaticCatalog(provider: OcxProviderConfig): boolean {
+  return provider.liveModels === false;
+}
+
 export function reconcileOAuthProviders(config: OcxConfig): boolean {
   let changed = migrateLegacyAntigravityStaticCatalog(config);
   for (const [name, prov] of Object.entries(config.providers)) {
@@ -788,6 +793,7 @@ export function reconcileOAuthProviders(config: OcxConfig): boolean {
       changed = true;
     }
     if (!def || prov.authMode !== "oauth") continue;
+    if (isOperatorOwnedStaticCatalog(prov)) continue;
     const preset = def.providerConfig;
     for (const field of OAUTH_RECONCILE_FIELDS) {
       if (JSON.stringify(prov[field]) === JSON.stringify(preset[field])) continue;

--- a/tests/oauth-provider-reconcile.test.ts
+++ b/tests/oauth-provider-reconcile.test.ts
@@ -116,6 +116,34 @@ describe("OAuth provider reconciliation", () => {
     expect(config.providers["google-antigravity"].liveModels).toBe(false);
   });
 
+  test("preserves operator-owned static OAuth catalog fields", () => {
+    const config = {
+      port: 10100,
+      defaultProvider: "command-code",
+      providers: {
+        "command-code": {
+          ...structuredClone(OAUTH_PROVIDERS["command-code"].providerConfig),
+          liveModels: false,
+          models: ["deepseek/deepseek-v4-flash", "xiaomi/mimo-v2.5-pro"],
+          modelContextWindows: {
+            "deepseek/deepseek-v4-flash": 1_000_000,
+            "xiaomi/mimo-v2.5-pro": 1_050_000,
+          },
+        },
+      },
+    } satisfies OcxConfig;
+
+    expect(reconcileOAuthProviders(config)).toBe(false);
+    expect(config.providers["command-code"].models).toEqual([
+      "deepseek/deepseek-v4-flash",
+      "xiaomi/mimo-v2.5-pro",
+    ]);
+    expect(config.providers["command-code"].modelContextWindows).toEqual({
+      "deepseek/deepseek-v4-flash": 1_000_000,
+      "xiaomi/mimo-v2.5-pro": 1_050_000,
+    });
+  });
+
   test("preserves explicit Antigravity live discovery when authMode is omitted or non-OAuth", () => {
     const home = mkdtempSync(join(tmpdir(), "ocx-antigravity-authmode-reconcile-"));
     homes.push(home);


### PR DESCRIPTION
## Summary

- Preserve provider model and capability metadata when an operator explicitly sets `liveModels: false`.
- Prevent OAuth startup reconciliation from replacing an operator-owned static catalog with the registry preset.
- Keep legacy Antigravity migration behavior unchanged.
- Add regression coverage for a customized Command Code static OAuth catalog.
- Fixes #1308.

## Verification

- `bun run test tests/oauth-provider-reconcile.test.ts` — 6 passed.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `git diff --check` — passed.
- The full `bun run test` suite was started through Nub and reached broad coverage, but was stopped after unrelated GUI dependency warnings for missing `react` packages in the checkout; the focused reconciliation test and all relevant reported tests passed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (not user-facing API; no docs change needed).
- [ ] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

## Contributor readiness

- [x] Local focused CI is green.
- [x] Branch is based on the latest available `dev` checkout.
- [x] All correct Codex and CodeRabbit findings are fixed.
- [x] Ready for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved operator-configured OAuth model catalogs during preset reconciliation.
  * Prevented static model settings and context-window mappings from being unintentionally modified.
  * Reconciliation now correctly reports no changes when these catalogs are already configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->