### PR TITLE
fix(google): anchor the CCA session id on the client thread id (#1297)

### DIFF
--- a/src/adapters/google-antigravity-wire.ts
+++ b/src/adapters/google-antigravity-wire.ts
@@ -51,16 +51,48 @@ function firstUserText(parsed: OcxParsedRequest): string | undefined {
  * 0x7FFFFFFFFFFFFFFF, prefixed with "-". Falls back to a random "-<digits>" id when there is no text.
  */
 export function antigravitySessionId(parsed: OcxParsedRequest): string {
-  // Anchored on the first user message text: this is the one value that stays STABLE across every
-  // turn of a conversation, which the replay cache requires (it observes signatures on turn N's
-  // response and re-injects them on turn N+1's request, so both turns must map to the same id).
-  // Cross-conversation collisions (two threads opening with identical text) are made harmless by
-  // the replay cache keying signatures on functionCall identity (name+args), not on this id alone.
-  const text = firstUserText(parsed);
+  // The id must be IDENTICAL on turn N and turn N+1: the replay cache observes thought signatures
+  // on turn N's response and re-injects them on turn N+1's request, so a changing id loses the
+  // association entirely. (A *shared* id does not — signatures are keyed on functionCall identity,
+  // name+args, so cross-conversation collisions stay harmless. Instability is the failure mode.)
+  //
+  // First-user text does not guarantee that. It is stable only while the first user message
+  // survives verbatim in what this adapter sees, and Codex compacts, summarises, and trims long
+  // histories — at which point the anchor changes mid-conversation (#1295's sibling, #1297).
+  //
+  // `_clientThreadId` is Codex's own thread identity from `x-codex-parent-thread-id`. It survives
+  // compaction because it does not depend on message content, which is the property first-user
+  // text fails to provide. Deliberately NOT `promptCacheKey`: that is arbitrary Responses input
+  // and is explicitly shared across conversations for some clients
+  // (`adapters/cursor/request-builder.ts`), so it identifies a cache cohort, not a conversation.
+  //
+  // What is NOT claimed: that Google treats this id as anything but opaque, or that upstream
+  // signatures are not session-bound. Only the local association is verified here.
+  //
+  // Clients that send no thread header keep the text anchor and its instability; this is a scoped
+  // repair, not a universal one.
+  const text = clientThreadAnchor(parsed) ?? firstUserText(parsed);
   if (!text) return `-${Math.floor(Math.random() * 9e18).toString()}`;
   const digest = createHash("sha256").update(text, "utf8").digest();
   const masked = digest.readBigUInt64BE(0) & 0x7fffffffffffffffn;
   return `-${masked.toString()}`;
+}
+
+/**
+ * Codex's stable client thread id, prefixed before hashing so it does not collide with a first
+ * user message equal to the bare thread id.
+ *
+ * This is a prefix, not full domain separation: a textless-anchor request whose first message is
+ * literally `codex-thread:<id>` still hashes the same preimage. Tagging BOTH anchor classes would
+ * separate them completely, but it would also change every existing text-derived id — a
+ * Google-visible wire value for live conversations — which is a larger blast radius than the
+ * collision it removes. A collision is harmless here anyway: the replay cache keys signatures on
+ * functionCall identity (name+args), so a shared id does not misattribute them. Instability, not
+ * collision, is the failure mode this function exists to prevent.
+ */
+function clientThreadAnchor(parsed: OcxParsedRequest): string | undefined {
+  const threadId = parsed._clientThreadId?.trim();
+  return threadId ? `codex-thread:${threadId}` : undefined;
 }
 
 /** A Gemini content part as it appears in an Antigravity request body. */

--- a/tests/google-antigravity-wire.test.ts
+++ b/tests/google-antigravity-wire.test.ts
@@ -204,6 +204,86 @@ describe("antigravity CCA envelope", () => {
     expect(antigravitySessionId(parsed("a"))).not.toBe(antigravitySessionId(parsed("b")));
   });
 
+  // #1297. The id must be identical on consecutive turns or the replay cache stops
+  // finding thought signatures. First-user text only holds while that message
+  // survives verbatim, and Codex compacts long histories.
+  function threaded(text: string, threadId?: string): OcxParsedRequest {
+    const base = parsed(text) as OcxParsedRequest & { _clientThreadId?: string };
+    if (threadId) base._clientThreadId = threadId;
+    return base;
+  }
+
+  test("#1297: one thread keeps one session id after history compaction changes the first message", () => {
+    // Turn N and turn N+1 of the same conversation, where the client has dropped
+    // or summarised the earliest user message between them.
+    expect(antigravitySessionId(threaded("original first message", "thread-a")))
+      .toBe(antigravitySessionId(threaded("summary of earlier turns", "thread-a")));
+  });
+
+  test("#1297: distinct threads do not collide even with identical text", () => {
+    expect(antigravitySessionId(threaded("hi", "thread-a")))
+      .not.toBe(antigravitySessionId(threaded("hi", "thread-b")));
+  });
+
+  test("#1297: promptCacheKey does not influence the id", () => {
+    // Deliberately not the anchor: it is arbitrary Responses input and is shared
+    // across conversations for some clients, so it identifies a cache cohort.
+    const withKey = threaded("same text", "thread-a") as OcxParsedRequest;
+    (withKey.options as Record<string, unknown>).promptCacheKey = "cohort-1";
+    const otherKey = threaded("same text", "thread-a") as OcxParsedRequest;
+    (otherKey.options as Record<string, unknown>).promptCacheKey = "cohort-2";
+    expect(antigravitySessionId(withKey)).toBe(antigravitySessionId(otherKey));
+  });
+
+  test("#1297: the prefix separates a thread id from the bare same text", () => {
+    // Scope of the guarantee, stated exactly: prefixing stops the RAW-EQUAL case.
+    expect(antigravitySessionId(threaded("thread-a", undefined)))
+      .not.toBe(antigravitySessionId(threaded("anything", "thread-a")));
+    // It is not full domain separation — a first message that is literally the
+    // prefixed form still shares the preimage. Asserted rather than hidden,
+    // because tagging the text anchor too would change every existing
+    // Google-visible id for live conversations. Harmless here: signatures are
+    // keyed on functionCall identity, so a shared id misattributes nothing.
+    expect(antigravitySessionId(threaded("codex-thread:thread-a", undefined)))
+      .toBe(antigravitySessionId(threaded("anything", "thread-a")));
+  });
+
+  test("#1297: clients without the thread header keep the text anchor", () => {
+    // A scoped repair, not a universal one — this behaviour is unchanged.
+    expect(antigravitySessionId(threaded("same", undefined)))
+      .toBe(antigravitySessionId(threaded("same", undefined)));
+    expect(antigravitySessionId(threaded("a", undefined)))
+      .not.toBe(antigravitySessionId(threaded("b", undefined)));
+  });
+
+  test("#1297: the wire id shape is unchanged", () => {
+    // It is sent to Google as `request.sessionId`, so the format must not move:
+    // "-" followed by a masked uint63.
+    for (const id of [
+      antigravitySessionId(threaded("text only", undefined)),
+      antigravitySessionId(threaded("text", "thread-a")),
+    ]) {
+      expect(id).toMatch(/^-\d+$/);
+      expect(BigInt(id.slice(1))).toBeLessThanOrEqual(0x7fffffffffffffffn);
+    }
+  });
+
+  test("#1297: the built CCA envelope carries the stable sessionId across turns", async () => {
+    // The helper tests above prove the derivation; this one proves the value
+    // actually reaches `request.sessionId` on the wire, which is what Google
+    // sees and what the CCA replay path is keyed by.
+    const adapter = createGoogleAdapter(provider);
+    const turnOne = JSON.parse((await adapter.buildRequest(threaded("original first message", "thread-a"))).body);
+    const turnTwo = JSON.parse((await adapter.buildRequest(threaded("summary of earlier turns", "thread-a"))).body);
+
+    expect(turnOne.request.sessionId).toBe(antigravitySessionId(threaded("original first message", "thread-a")));
+    expect(turnTwo.request.sessionId).toBe(turnOne.request.sessionId);
+
+    // A different thread must still land on a different session.
+    const other = JSON.parse((await adapter.buildRequest(threaded("original first message", "thread-b"))).body);
+    expect(other.request.sessionId).not.toBe(turnOne.request.sessionId);
+  });
+
   test("claude-on-antigravity forces toolConfig.functionCallingConfig.mode=VALIDATED", async () => {
     const claudeProvider = { ...provider } as OcxProviderConfig;
     const withTools = {


### PR DESCRIPTION
## Summary

Fixes #1297. `antigravitySessionId` derived the Cloud Code Assist session id from a hash of the first user message text, while its own comment states the invariant it must satisfy: the id has to be identical on turn N and turn N+1, because the replay cache observes thought signatures on one response and re-injects them on the next request.

First-user text does not provide that. It is stable only while the first user message survives verbatim in what the adapter sees, and Codex compacts, summarises, and trims long histories — at which point the anchor changes mid-conversation and cached signatures stop being found. The textless fallback is worse by construction: a fresh random id every turn.

`_clientThreadId` (from `x-codex-parent-thread-id`) does not depend on message content, so compaction cannot move it.

### Scope, stated up front

- **A client that sends no thread header keeps the text anchor and its instability.** This is a scoped repair, not a universal one.
- **Nothing here claims Google treats the id as more than opaque**, or that upstream signatures are not session-bound. Only the local association is verified; there is no live CCA compatibility evidence in this PR.
- **Deploying this changes the Google-visible `sessionId` for conversations already in flight**, since a live conversation switches anchor on its next turn.

### Two deliberate choices worth reading

**Not `promptCacheKey`.** It is arbitrary Responses input (`responses/schema.ts` accepts any string) and is explicitly shared across conversations for some clients — `adapters/cursor/request-builder.ts` warns against using it as a conversation id, and Claude Desktop cohorts are shared by design. It identifies a cache cohort, not a conversation. `vertexReplaySessionId` (`adapters/google.ts:56`) does use it, under a comment saying it prefers a stable thread key; **that is an analogous open defect, not a precedent**, and it is recorded on the issue rather than changed here.

**The prefix is not full domain separation.** `codex-thread:<id>` separates a thread id from a first message equal to the *bare* id, but a first message that is literally `codex-thread:thread-a` still shares the preimage. The test asserts that rather than hiding it. Tagging the text anchor as well would separate them completely — and would change every existing text-derived id, a Google-visible value for live conversations, which is a larger blast radius than the collision it removes. A collision is harmless here in any case: signatures are keyed on `functionCall` identity (name + args), so a shared id misattributes nothing. **Instability, not collision, is the failure mode this function exists to prevent** — a shared id still finds the association; a changed id loses it.

## Verification

- `bun run test` — **10040 pass / 7 skip / 0 fail** across 627 files
- `bun test tests/google-antigravity-wire.test.ts` — 47 pass / 0 fail
- `bun run typecheck` — clean
- `bun run privacy:scan` — passed
- Ablation: reverting only `src/adapters/google-antigravity-wire.ts` fails **4** tests

Seven tests, one property each:

| Test | Property |
|---|---|
| compaction | one thread keeps one id when the first message changes |
| collision | distinct threads differ on identical text |
| envelope | `request.sessionId` in the **built CCA body** is stable across turns and differs per thread |
| cohort | `promptCacheKey` does not influence the id |
| prefix | separates the bare-equal case, and the residual case is asserted, not hidden |
| fallback | clients without the header behave exactly as before |
| shape | `/^-\d+$/` and `<= 0x7fffffffffffffff` |

The envelope test is separate from the helper tests on purpose: the changed value goes on the wire to Google, so proving the derivation is not the same as proving it reaches `request.sessionId`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No documented behavior changes; the wire id format is unchanged.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. The id is a masked hash — the raw thread id is never sent, and no credential or account identifier is touched or logged.

---

Reported by @brunoflma, who stated plainly that this was a mechanism-level finding rather than a captured failure, and pointed at the invariant the code documents for itself. That honesty about evidence level is what made it straightforward to confirm by reading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation session stability across multiple turns, including when conversation history is compacted.
  * Separate conversations now maintain distinct sessions more reliably.
  * Preserved compatibility with existing text-based session behavior when no stable conversation identifier is available.
  * Improved consistency when passing session information through requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->