### PR TITLE
fix(codex): rotate pool accounts on model capacity

### DIFF
--- a/docs-site/src/content/docs/reference/cli/providers-accounts.md
+++ b/docs-site/src/content/docs/reference/cli/providers-accounts.md
@@ -165,9 +165,10 @@ recovery may later select another eligible Pool account. Those recovery paths re
 usage-based switching is off. OpenCodex replays the conversation after an account change, but the
 provider-side prompt cache may be cold. Unknown providers or ids exit 1.
 Before substantive output, an upstream model-capacity rejection rotates through each eligible Pool
-account once without persisting a cooldown or changing the next request's eligible set. Exhaustion
-returns the first capacity error. Direct mode, exact account selectors, and failures after output do
-not rotate.
+account once without persisting a cooldown. A rejected account does not create or refresh thread
+affinity; only the account whose response is accepted becomes the thread binding. Exhaustion returns
+the first capacity error, and the next request starts with a fresh eligible set and no new affinity from
+the rejected attempts. Direct mode, exact account selectors, and failures after output do not rotate.
 On a **401/403**, App login clears that account's process-local affinity and requires reauthentication.
 On a **429**, opencodex honors `Retry-After`, starts the account cooldown, clears affinity, and may
 rotate the request to another eligible Pool account. These failure transitions remain active with

--- a/docs-site/src/content/docs/reference/cli/providers-accounts.md
+++ b/docs-site/src/content/docs/reference/cli/providers-accounts.md
@@ -164,6 +164,10 @@ Direct mode keeps using the caller-owned/native main credential. Usage-based pro
 recovery may later select another eligible Pool account. Those recovery paths remain active when
 usage-based switching is off. OpenCodex replays the conversation after an account change, but the
 provider-side prompt cache may be cold. Unknown providers or ids exit 1.
+Before substantive output, an upstream model-capacity rejection rotates through each eligible Pool
+account once without persisting a cooldown or changing the next request's eligible set. Exhaustion
+returns the first capacity error. Direct mode, exact account selectors, and failures after output do
+not rotate.
 On a **401/403**, App login clears that account's process-local affinity and requires reauthentication.
 On a **429**, opencodex honors `Retry-After`, starts the account cooldown, clears affinity, and may
 rotate the request to another eligible Pool account. These failure transitions remain active with

--- a/docs-site/src/content/docs/reference/configuration/providers.md
+++ b/docs-site/src/content/docs/reference/configuration/providers.md
@@ -150,6 +150,14 @@ alternate account in the same request, even when usage-based proactive switching
 changes preserve and replay the conversation context, but provider-side prompt-cache reuse across
 accounts is not guaranteed and the cache may need to warm again.
 
+Before any text, reasoning, tool call, or other model output reaches the client, a structured
+`server_is_overloaded` / `slow_down` model-capacity rejection (or the standard
+`Selected model is at capacity. Please try a different model.` response) tries each remaining
+eligible Pool account once. This exclusion is request-local: rejected capacity attempts do not write
+account cooldown, health, affinity, or active-selection state. If every account returns capacity, the first response
+is returned; the next request starts with a fresh eligible set. Direct mode and exact account
+selectors never use this rotation, and capacity after substantive output is never replayed.
+
 On a **401/403**, App login clears that account's process-local affinity and requires reauthentication.
 On a **429**, opencodex honors `Retry-After`, starts the account cooldown, clears affinity, and may
 rotate the request to another eligible Pool account. These failure transitions remain active with

--- a/docs-site/src/content/docs/reference/configuration/providers.md
+++ b/docs-site/src/content/docs/reference/configuration/providers.md
@@ -154,9 +154,11 @@ Before any text, reasoning, tool call, or other model output reaches the client,
 `server_is_overloaded` / `slow_down` model-capacity rejection (or the standard
 `Selected model is at capacity. Please try a different model.` response) tries each remaining
 eligible Pool account once. This exclusion is request-local: rejected capacity attempts do not write
-account cooldown, health, affinity, or active-selection state. If every account returns capacity, the first response
-is returned; the next request starts with a fresh eligible set. Direct mode and exact account
-selectors never use this rotation, and capacity after substantive output is never replayed.
+account cooldown or health. Thread affinity is not created or refreshed until a non-capacity response
+is accepted; after rotation, only the accepted account is bound. If every account returns capacity,
+the first response is returned and the next request starts with a fresh eligible set, without any new
+affinity from the rejected attempts. Direct mode and exact account selectors never use this rotation,
+and capacity after substantive output is never replayed.
 
 On a **401/403**, App login clears that account's process-local affinity and requires reauthentication.
 On a **429**, opencodex honors `Retry-After`, starts the account cooldown, clears affinity, and may

--- a/src/codex/auth-context.ts
+++ b/src/codex/auth-context.ts
@@ -21,6 +21,7 @@ import {
   tryAcquireCodexQuotaProbeLease,
   tryAcquireCodexQuotaScopeProbeLease,
   pickAlternateCodexAccount,
+  pickAlternateCodexAccountExcluding,
   resolveCodexAccountForThreadDetailed,
 } from "./routing";
 import type { CodexCooldownSource, CodexQuotaScope } from "./routing";
@@ -227,6 +228,8 @@ export function shouldMarkAccountNeedsReauthForCodexAuthFailure(cause: unknown):
 
 export interface ResolveCodexAuthContextOptions {
   excludeAccountId?: string;
+  /** Request-local exclusion set for bounded multi-account recovery. */
+  excludeAccountIds?: ReadonlySet<string>;
   /** Resolve exactly this account without consulting or mutating Pool selection. */
   accountId?: string;
   /** Final native model selected for this request, used to select its quota group. */
@@ -253,7 +256,9 @@ export async function resolveCodexAuthContext(
 ): Promise<CodexAuthContext> {
   const writerGeneration = captureConfigGeneration();
   const fixedAccountId = options.accountId;
-  if (fixedAccountId !== undefined && options.excludeAccountId !== undefined) {
+  const hasExclusions = options.excludeAccountId !== undefined
+    || (options.excludeAccountIds?.size ?? 0) > 0;
+  if (fixedAccountId !== undefined && hasExclusions) {
     throw new Error("Codex auth context cannot select and exclude an account simultaneously");
   }
   // An explicit namespace binding is stronger than the provider's default mode. It must use the
@@ -284,15 +289,25 @@ export async function resolveCodexAuthContext(
     const threadId = headers.get("x-codex-parent-thread-id");
     const resolution = fixedAccountId !== undefined
       ? { status: "selected" as const, accountId: fixedAccountId }
-      : options.excludeAccountId
+      : hasExclusions
       ? (() => {
-          const selected = pickAlternateCodexAccount(
-            config,
-            options.excludeAccountId!,
-            Date.now(),
-            quotaScope,
-            selectionOptions,
-          );
+          const selected = options.excludeAccountIds
+            ? pickAlternateCodexAccountExcluding(
+              config,
+              options.excludeAccountIds,
+              [...options.excludeAccountIds].at(-1)!,
+              Date.now(),
+              quotaScope,
+              selectionOptions,
+              false,
+            )
+            : pickAlternateCodexAccount(
+              config,
+              options.excludeAccountId!,
+              Date.now(),
+              quotaScope,
+              selectionOptions,
+            );
           return selected
             ? { status: "selected" as const, accountId: selected }
             : { status: "none" as const };
@@ -309,7 +324,7 @@ export async function resolveCodexAuthContext(
       // temporary fence rather than misclassifying that credential as invalid.
       // A configured pool retry/exclusion that finds no alternate preserves its
       // ordinary pool-auth failure instead of being mislabeled as a main fence.
-      if (nativeMainTrafficBlocked && !options.excludeAccountId) {
+      if (nativeMainTrafficBlocked && !hasExclusions) {
         throw new CodexMainProfileDrainingError();
       }
       throw new CodexPoolAuthenticationError();

--- a/src/codex/auth-context.ts
+++ b/src/codex/auth-context.ts
@@ -22,6 +22,7 @@ import {
   tryAcquireCodexQuotaScopeProbeLease,
   pickAlternateCodexAccount,
   pickAlternateCodexAccountExcluding,
+  previewCodexAccountForRequestDetailed,
   resolveCodexAccountForThreadDetailed,
 } from "./routing";
 import type { CodexCooldownSource, CodexQuotaScope } from "./routing";
@@ -234,8 +235,8 @@ export interface ResolveCodexAuthContextOptions {
   accountId?: string;
   /** Final native model selected for this request, used to select its quota group. */
   modelId?: string;
-  /** Delay thread-affinity writes until the upstream response is accepted for relay. */
-  deferThreadAffinityCommit?: boolean;
+  /** Preview without selection-state writes until the upstream response is accepted. */
+  deferSelectionCommit?: boolean;
   /** Short reservation converted to turn ownership before native `__main__` token materialization. */
   beginCodexAccountSelection?: () => CodexAccountSelectionAdmission | undefined;
   /** Test-only native credential read seams. */
@@ -314,14 +315,9 @@ export async function resolveCodexAuthContext(
             ? { status: "selected" as const, accountId: selected }
             : { status: "none" as const };
         })()
-      : resolveCodexAccountForThreadDetailed(
-        threadId,
-        config,
-        Date.now(),
-        quotaScope,
-        selectionOptions,
-        options.deferThreadAffinityCommit !== true,
-      );
+      : options.deferSelectionCommit
+      ? previewCodexAccountForRequestDetailed(threadId, config, Date.now(), quotaScope, selectionOptions)
+      : resolveCodexAccountForThreadDetailed(threadId, config, Date.now(), quotaScope, selectionOptions);
     if (resolution.status === "expired") throw new CodexThreadAffinityExpiredError(resolution.accountId);
     const selected = resolution.status === "selected" ? resolution.accountId : null;
     if (!selected) {

--- a/src/codex/auth-context.ts
+++ b/src/codex/auth-context.ts
@@ -234,6 +234,8 @@ export interface ResolveCodexAuthContextOptions {
   accountId?: string;
   /** Final native model selected for this request, used to select its quota group. */
   modelId?: string;
+  /** Delay thread-affinity writes until the upstream response is accepted for relay. */
+  deferThreadAffinityCommit?: boolean;
   /** Short reservation converted to turn ownership before native `__main__` token materialization. */
   beginCodexAccountSelection?: () => CodexAccountSelectionAdmission | undefined;
   /** Test-only native credential read seams. */
@@ -312,7 +314,14 @@ export async function resolveCodexAuthContext(
             ? { status: "selected" as const, accountId: selected }
             : { status: "none" as const };
         })()
-      : resolveCodexAccountForThreadDetailed(threadId, config, Date.now(), quotaScope, selectionOptions);
+      : resolveCodexAccountForThreadDetailed(
+        threadId,
+        config,
+        Date.now(),
+        quotaScope,
+        selectionOptions,
+        options.deferThreadAffinityCommit !== true,
+      );
     if (resolution.status === "expired") throw new CodexThreadAffinityExpiredError(resolution.accountId);
     const selected = resolution.status === "selected" ? resolution.accountId : null;
     if (!selected) {

--- a/src/codex/pool-rotation.ts
+++ b/src/codex/pool-rotation.ts
@@ -210,6 +210,32 @@ export function peekRoundRobinAccount(
   return pickRoundRobinFromState(eligibleIds, stickyLimit, scratch, false);
 }
 
+/**
+ * Record the account whose response was actually accepted after a deferred pick.
+ * Completion order is authoritative: concurrent requests each contribute one
+ * smooth-weighted success for the account that served them.
+ */
+export function commitRoundRobinAccountSuccess(
+  poolKey: string,
+  eligibleIds: readonly string[],
+  accountId: string,
+  stickyLimit: number,
+): boolean {
+  if (!eligibleIds.includes(accountId)) return false;
+  const state = getOrCreateState(poolKey);
+  if (state.activeKey !== accountId) {
+    delete state.activeKey;
+    state.successes = 0;
+    const total = eligibleIds.length;
+    for (const id of eligibleIds) {
+      state.currentWeights.set(id, (state.currentWeights.get(id) ?? 0) + 1);
+    }
+    state.currentWeights.set(accountId, (state.currentWeights.get(accountId) ?? 0) - total);
+  }
+  notePoolRotationSuccess(poolKey, accountId, stickyLimit);
+  return true;
+}
+
 export function notePoolRotationSuccess(
   poolKey: string,
   accountId: string,

--- a/src/codex/routing.ts
+++ b/src/codex/routing.ts
@@ -900,16 +900,24 @@ function bindThreadAffinity(
   pruneLruThreadAffinities();
 }
 
+type CodexAccountExclusion = string | ReadonlySet<string> | undefined;
+
+function isExcludedCodexAccount(exclusion: CodexAccountExclusion, accountId: string): boolean {
+  return typeof exclusion === "string"
+    ? exclusion === accountId
+    : exclusion?.has(accountId) === true;
+}
+
 function getEligiblePoolAccounts(
   config: OcxConfig,
-  excludeId?: string,
+  exclusion?: CodexAccountExclusion,
   now = Date.now(),
   quotaScope?: CodexQuotaScope,
   selectionOptions?: CodexAccountUsabilityOptions,
 ): readonly string[] {
   const ids = (config.codexAccounts ?? [])
     .filter(account => isSelectableCodexPoolAccount(account)
-      && account.id !== excludeId
+      && !isExcludedCodexAccount(exclusion, account.id)
       && !isCodexAccountPaused(config, account.id)
       && !isAccountNeedsReauth(account.id))
     .filter(account => getCodexQuotaHealthSnapshot(account.id, quotaScope, now) === null)
@@ -919,7 +927,7 @@ function getEligiblePoolAccounts(
   // The main Codex account is not stored in config.codexAccounts; include it as a
   // first-class rotation candidate when its read-only token is usable (Option A).
   if (
-    excludeId !== MAIN_CODEX_ACCOUNT_ID
+    !isExcludedCodexAccount(exclusion, MAIN_CODEX_ACCOUNT_ID)
     && !isCodexAccountPaused(config, MAIN_CODEX_ACCOUNT_ID)
     && !isAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID)
     && getCodexQuotaHealthSnapshot(MAIN_CODEX_ACCOUNT_ID, quotaScope, now) === null
@@ -1152,20 +1160,47 @@ export function pickAlternateCodexAccount(
   quotaScope?: CodexQuotaScope,
   selectionOptions?: CodexAccountUsabilityOptions,
 ): string | null {
+  return pickAlternateCodexAccountExcluding(
+    config,
+    new Set([excludeId]),
+    excludeId,
+    now,
+    quotaScope,
+    selectionOptions,
+  );
+}
+
+/** Strategy-aware alternate that never revisits an account already tried by this request. */
+export function pickAlternateCodexAccountExcluding(
+  config: OcxConfig,
+  excludedIds: ReadonlySet<string>,
+  afterId: string,
+  now = Date.now(),
+  quotaScope?: CodexQuotaScope,
+  selectionOptions?: CodexAccountUsabilityOptions,
+  commitRoundRobin = true,
+): string | null {
   const strategy = normalizeAccountPoolStrategy(config.accountPoolStrategy);
   // The exclusion is passed into eligibility rather than post-filtered off its
   // result: when the excluded account is the only healthy member of the top
   // tier, the tier walk must be free to descend instead of selecting that tier
   // and then handing back an empty list.
   if (strategy === "round-robin") {
-    const eligible = getEligiblePoolAccounts(config, excludeId, now, quotaScope, selectionOptions);
-    return pickRoundRobinAccount(codexPoolKeyForScope(quotaScope), eligible, stickyLimitForConfig(config));
+    const eligible = getEligiblePoolAccounts(config, excludedIds, now, quotaScope, selectionOptions);
+    const poolKey = codexPoolKeyForScope(quotaScope);
+    const stickyLimit = stickyLimitForConfig(config);
+    return commitRoundRobin
+      ? pickRoundRobinAccount(poolKey, eligible, stickyLimit)
+      : peekRoundRobinAccount(poolKey, eligible, stickyLimit);
   }
   if (strategy === "fill-first") {
-    const eligible = getEligiblePoolAccounts(config, excludeId, now, quotaScope, selectionOptions);
-    return pickNextFillFirstCodexAccount(config, excludeId, eligible, now, selectionOptions);
+    const eligible = getEligiblePoolAccounts(config, excludedIds, now, quotaScope, selectionOptions);
+    return pickNextFillFirstCodexAccount(config, afterId, eligible, now, selectionOptions);
   }
-  return pickLowestUsageCodexAccount(config, excludeId, now, quotaScope, selectionOptions);
+  return pickLowestUsageAmong(
+    config,
+    getEligiblePoolAccounts(config, excludedIds, now, quotaScope, selectionOptions),
+  );
 }
 
 /** Effective active: automatic runtime cursor, else operator/persisted selection. */

--- a/src/codex/routing.ts
+++ b/src/codex/routing.ts
@@ -900,6 +900,17 @@ function bindThreadAffinity(
   pruneLruThreadAffinities();
 }
 
+/** Commit affinity only after a routed response is accepted for relay. */
+export function bindCodexThreadAffinityForAcceptedResponse(
+  threadId: string | null,
+  accountId: string,
+  modelId: string | undefined,
+  now = Date.now(),
+): void {
+  if (!threadId) return;
+  bindThreadAffinity(threadId, accountId, now, codexQuotaScopeForModel(modelId));
+}
+
 type CodexAccountExclusion = string | ReadonlySet<string> | undefined;
 
 function isExcludedCodexAccount(exclusion: CodexAccountExclusion, accountId: string): boolean {
@@ -1065,6 +1076,7 @@ function pickUnboundStrategyAccount(
   commit: boolean,
   quotaScope?: CodexQuotaScope,
   selectionOptions?: CodexAccountUsabilityOptions,
+  commitThreadAffinity = commit,
 ): string | null {
   const strategy = normalizeAccountPoolStrategy(config.accountPoolStrategy);
   if (strategy === "quota") return null;
@@ -1080,7 +1092,7 @@ function pickUnboundStrategyAccount(
     picked = pickRoundRobinAccount(poolKey, eligible, limit);
     if (!picked) return null;
     if (!isIndependentCodexQuotaScope(quotaScope)) rememberActiveCodexAccount(config, picked);
-    if (threadId) bindThreadAffinity(threadId, picked, now, quotaScope);
+    if (threadId && commitThreadAffinity) bindThreadAffinity(threadId, picked, now, quotaScope);
     notePoolRotationSuccess(poolKey, picked, limit);
     return picked;
   }
@@ -1090,7 +1102,7 @@ function pickUnboundStrategyAccount(
     if (!picked) return null;
     if (commit) {
       if (!isIndependentCodexQuotaScope(quotaScope)) rememberActiveCodexAccount(config, picked);
-      if (threadId) bindThreadAffinity(threadId, picked, now, quotaScope);
+      if (threadId && commitThreadAffinity) bindThreadAffinity(threadId, picked, now, quotaScope);
     }
     return picked;
   }
@@ -1506,6 +1518,7 @@ export function resolveCodexAccountForThreadDetailed(
   now = Date.now(),
   quotaScope?: CodexQuotaScope,
   selectionOptions?: CodexAccountUsabilityOptions,
+  commitThreadAffinity = true,
 ): CodexThreadResolution {
   // Retiring a spent manual pin is independent of affinity: an existing thread
   // keeps its account below, but the operator's tier ceiling must not silently
@@ -1526,7 +1539,7 @@ export function resolveCodexAccountForThreadDetailed(
       // (soft-avoid covers the first-hit case; this catches post-avoid residual streaks).
       && !shouldFailover(config, entry.accountId, now)
     ) {
-      entry.lastUsedAt = now;
+      if (commitThreadAffinity) entry.lastUsedAt = now;
       // Periodic quota re-eval: a long-lived bound thread must still switch when
       // it crosses autoSwitchThreshold and a strictly-cooler account exists.
       // Without this the reuse branch returns before applyQuotaAutoSwitch and the
@@ -1551,7 +1564,9 @@ export function resolveCodexAccountForThreadDetailed(
             const best = pickLowerUsageAccount(config, entry.accountId, usage, now, quotaScope, selectionOptions);
             if (best !== entry.accountId) {
               if (!isIndependentCodexQuotaScope(quotaScope)) setActiveCodexAccount(config, best);
-              bindThreadAffinity(threadId, best, now, quotaScope); // rebinds + resets clocks
+              if (commitThreadAffinity) {
+                bindThreadAffinity(threadId, best, now, quotaScope); // rebinds + resets clocks
+              }
               return { status: "selected", accountId: best };
             }
           }
@@ -1562,7 +1577,15 @@ export function resolveCodexAccountForThreadDetailed(
     deleteThreadAffinity(threadId, quotaScope);
   }
 
-  const strategyPick = pickUnboundStrategyAccount(config, threadId, now, true, quotaScope, selectionOptions);
+  const strategyPick = pickUnboundStrategyAccount(
+    config,
+    threadId,
+    now,
+    true,
+    quotaScope,
+    selectionOptions,
+    commitThreadAffinity,
+  );
   if (strategyPick) return { status: "selected", accountId: strategyPick };
 
   let active = getEffectiveActiveCodexAccountId(config);
@@ -1610,7 +1633,7 @@ export function resolveCodexAccountForThreadDetailed(
       ? { status: "selected", accountId: active }
       : { status: "none" };
   }
-  if (threadId) bindThreadAffinity(threadId, active, now, quotaScope);
+  if (threadId && commitThreadAffinity) bindThreadAffinity(threadId, active, now, quotaScope);
   return { status: "selected", accountId: active };
 }
 

--- a/src/codex/routing.ts
+++ b/src/codex/routing.ts
@@ -8,6 +8,7 @@ import { isCodexAccountUsable, type CodexAccountUsabilityOptions } from "./accou
 import { isAccountNeedsReauth, markAccountNeedsReauth } from "./account-runtime-state";
 import {
   POOL_KEY_CODEX,
+  commitRoundRobinAccountSuccess,
   normalizeAccountPoolStickyLimit,
   normalizeAccountPoolStrategy,
   notePoolRotationFailure,
@@ -900,19 +901,9 @@ function bindThreadAffinity(
   pruneLruThreadAffinities();
 }
 
-/** Commit affinity only after a routed response is accepted for relay. */
-export function bindCodexThreadAffinityForAcceptedResponse(
-  threadId: string | null,
-  accountId: string,
-  modelId: string | undefined,
-  now = Date.now(),
-): void {
-  if (!threadId) return;
-  bindThreadAffinity(threadId, accountId, now, codexQuotaScopeForModel(modelId));
-}
-
 type CodexAccountExclusion = string | ReadonlySet<string> | undefined;
 
+/** Match a single legacy exclusion or a request-local exclusion set. */
 function isExcludedCodexAccount(exclusion: CodexAccountExclusion, accountId: string): boolean {
   return typeof exclusion === "string"
     ? exclusion === accountId
@@ -1076,7 +1067,6 @@ function pickUnboundStrategyAccount(
   commit: boolean,
   quotaScope?: CodexQuotaScope,
   selectionOptions?: CodexAccountUsabilityOptions,
-  commitThreadAffinity = commit,
 ): string | null {
   const strategy = normalizeAccountPoolStrategy(config.accountPoolStrategy);
   if (strategy === "quota") return null;
@@ -1092,7 +1082,7 @@ function pickUnboundStrategyAccount(
     picked = pickRoundRobinAccount(poolKey, eligible, limit);
     if (!picked) return null;
     if (!isIndependentCodexQuotaScope(quotaScope)) rememberActiveCodexAccount(config, picked);
-    if (threadId && commitThreadAffinity) bindThreadAffinity(threadId, picked, now, quotaScope);
+    if (threadId) bindThreadAffinity(threadId, picked, now, quotaScope);
     notePoolRotationSuccess(poolKey, picked, limit);
     return picked;
   }
@@ -1102,7 +1092,7 @@ function pickUnboundStrategyAccount(
     if (!picked) return null;
     if (commit) {
       if (!isIndependentCodexQuotaScope(quotaScope)) rememberActiveCodexAccount(config, picked);
-      if (threadId && commitThreadAffinity) bindThreadAffinity(threadId, picked, now, quotaScope);
+      if (threadId) bindThreadAffinity(threadId, picked, now, quotaScope);
     }
     return picked;
   }
@@ -1512,13 +1502,86 @@ export function previewCodexAccountForRequest(
   return active;
 }
 
+/** Preview Pool selection; expired-affinity cleanup matches live resolve. */
+export function previewCodexAccountForRequestDetailed(
+  threadId: string | null,
+  config: OcxConfig,
+  now = Date.now(),
+  quotaScope?: CodexQuotaScope,
+  selectionOptions?: CodexAccountUsabilityOptions,
+): CodexThreadResolution {
+  const entry = threadId ? getThreadAffinity(threadId, quotaScope) : undefined;
+  if (entry && isThreadAffinityExpired(entry, now)) {
+    deleteThreadAffinity(threadId!, quotaScope);
+    return { status: "expired", accountId: entry.accountId };
+  }
+  const accountId = previewCodexAccountForRequest(threadId, config, now, quotaScope, selectionOptions);
+  return accountId ? { status: "selected", accountId } : { status: "none" };
+}
+
+/**
+ * Commit a deferred Pool selection exactly once, after its response is accepted.
+ * Capacity-rejected and unavailable attempts remain request-local exclusions.
+ */
+export function commitCodexAcceptedAccountSelection(
+  config: OcxConfig,
+  threadId: string | null,
+  accountId: string,
+  modelId: string | undefined,
+  excludedAccountIds: ReadonlySet<string>,
+  now = Date.now(),
+): void {
+  const quotaScope = codexQuotaScopeForModel(modelId);
+  if (!isCodexAccountSelectable(config, accountId, now, quotaScope)) return;
+  if (!isIndependentCodexQuotaScope(quotaScope)) releaseDrainedCodexAccountPin(config);
+
+  const existingAffinity = threadId ? getThreadAffinity(threadId, quotaScope) : undefined;
+  const reusedAffinity = existingAffinity?.accountId === accountId
+    && !isThreadAffinityExpired(existingAffinity, now)
+    && isThreadAffinityGenerationLive(existingAffinity)
+    && !shouldFailover(config, accountId, now);
+
+  const strategy = normalizeAccountPoolStrategy(config.accountPoolStrategy);
+  if (reusedAffinity) {
+    existingAffinity.lastUsedAt = now;
+    if (strategy === "quota") {
+      const threshold = config.autoSwitchThreshold ?? 80;
+      const usage = threshold > 0
+        ? computeCodexUsageScore(getAccountQuota(accountId), getPoolAccountPlan(config, accountId))
+        : 0;
+      const overThreshold = threshold > 0 && !isUnknownUsage(usage) && usage >= threshold;
+      if (overThreshold || now - existingAffinity.lastReevalAt >= CODEX_THREAD_AFFINITY_REEVAL_INTERVAL_MS) {
+        existingAffinity.lastReevalAt = now;
+      }
+    }
+    return;
+  }
+
+  if (strategy === "round-robin") {
+    const eligible = getEligiblePoolAccounts(config, excludedAccountIds, now, quotaScope);
+    const committed = commitRoundRobinAccountSuccess(
+      codexPoolKeyForScope(quotaScope),
+      eligible,
+      accountId,
+      stickyLimitForConfig(config),
+    );
+    if (!committed) return;
+    if (!isIndependentCodexQuotaScope(quotaScope)) rememberActiveCodexAccount(config, accountId);
+  } else if (strategy === "fill-first") {
+    if (!isIndependentCodexQuotaScope(quotaScope)) rememberActiveCodexAccount(config, accountId);
+  } else if (!isIndependentCodexQuotaScope(quotaScope)) {
+    setActiveCodexAccount(config, accountId);
+  }
+
+  if (threadId) bindThreadAffinity(threadId, accountId, now, quotaScope);
+}
+
 export function resolveCodexAccountForThreadDetailed(
   threadId: string | null,
   config: OcxConfig,
   now = Date.now(),
   quotaScope?: CodexQuotaScope,
   selectionOptions?: CodexAccountUsabilityOptions,
-  commitThreadAffinity = true,
 ): CodexThreadResolution {
   // Retiring a spent manual pin is independent of affinity: an existing thread
   // keeps its account below, but the operator's tier ceiling must not silently
@@ -1539,7 +1602,7 @@ export function resolveCodexAccountForThreadDetailed(
       // (soft-avoid covers the first-hit case; this catches post-avoid residual streaks).
       && !shouldFailover(config, entry.accountId, now)
     ) {
-      if (commitThreadAffinity) entry.lastUsedAt = now;
+      entry.lastUsedAt = now;
       // Periodic quota re-eval: a long-lived bound thread must still switch when
       // it crosses autoSwitchThreshold and a strictly-cooler account exists.
       // Without this the reuse branch returns before applyQuotaAutoSwitch and the
@@ -1564,9 +1627,7 @@ export function resolveCodexAccountForThreadDetailed(
             const best = pickLowerUsageAccount(config, entry.accountId, usage, now, quotaScope, selectionOptions);
             if (best !== entry.accountId) {
               if (!isIndependentCodexQuotaScope(quotaScope)) setActiveCodexAccount(config, best);
-              if (commitThreadAffinity) {
-                bindThreadAffinity(threadId, best, now, quotaScope); // rebinds + resets clocks
-              }
+              bindThreadAffinity(threadId, best, now, quotaScope); // rebinds + resets clocks
               return { status: "selected", accountId: best };
             }
           }
@@ -1577,15 +1638,7 @@ export function resolveCodexAccountForThreadDetailed(
     deleteThreadAffinity(threadId, quotaScope);
   }
 
-  const strategyPick = pickUnboundStrategyAccount(
-    config,
-    threadId,
-    now,
-    true,
-    quotaScope,
-    selectionOptions,
-    commitThreadAffinity,
-  );
+  const strategyPick = pickUnboundStrategyAccount(config, threadId, now, true, quotaScope, selectionOptions);
   if (strategyPick) return { status: "selected", accountId: strategyPick };
 
   let active = getEffectiveActiveCodexAccountId(config);
@@ -1633,7 +1686,7 @@ export function resolveCodexAccountForThreadDetailed(
       ? { status: "selected", accountId: active }
       : { status: "none" };
   }
-  if (threadId && commitThreadAffinity) bindThreadAffinity(threadId, active, now, quotaScope);
+  if (threadId) bindThreadAffinity(threadId, active, now, quotaScope);
   return { status: "selected", accountId: active };
 }
 

--- a/src/lib/upstream-retry.ts
+++ b/src/lib/upstream-retry.ts
@@ -244,6 +244,10 @@ export interface ResetRetryOptions {
 export interface TransientRetryOptions extends ResetRetryOptions {
   /** Test seam: per-attempt slow budget override (defaults to TRANSIENT_RETRY_SLOW_ATTEMPT_MS). */
   slowAttemptMs?: number;
+  /** Optional semantic gate run before retrying a transient HTTP response. */
+  prepareTransientRetry?: (
+    response: Response,
+  ) => Promise<{ response: Response; retry: boolean }> | { response: Response; retry: boolean };
 }
 
 export type UpstreamSendRecovery = "connection-reset" | "transient-5xx";
@@ -367,6 +371,11 @@ export async function fetchWithTransientRetry(
     if (res.ok || !isTransientUpstreamStatus(res.status)) return res;
     if (opts.abortSignal?.aborted) return res;
     if (Date.now() - attemptStart > slowAttemptMs) return res;
+    if (opts.prepareTransientRetry) {
+      const prepared = await opts.prepareTransientRetry(res);
+      res = prepared.response;
+      if (!prepared.retry) return res;
+    }
     console.warn(
       `[upstream-retry] transient ${res.status}${opts.label ? ` (${opts.label})` : ""} — retrying (${attempt + 2}/${attempts})`,
     );

--- a/src/server/responses/codex-capacity.ts
+++ b/src/server/responses/codex-capacity.ts
@@ -1,0 +1,267 @@
+import { readBoundedResponseBody } from "../../lib/bounded-body";
+import {
+  BoundedSseFrameBuffer,
+  joinSseFrameBytes,
+  MAX_CLIENT_SSE_FRAME_BYTES,
+} from "../sse-frame-buffer";
+import { sseDataPayload } from "../relay";
+
+export const CODEX_MODEL_CAPACITY_MESSAGE =
+  "Selected model is at capacity. Please try a different model.";
+
+const CAPACITY_CODES: ReadonlySet<string> = new Set([
+  "server_is_overloaded",
+  "slow_down",
+]);
+
+type JsonRecord = Record<string, unknown>;
+
+export type CodexCapacityInspection =
+  | { kind: "capacity"; response: Response }
+  | { kind: "pass"; response: Response };
+
+function record(value: unknown): JsonRecord | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as JsonRecord
+    : null;
+}
+
+function normalizeCapacityMessage(value: string): string {
+  return value.trim().replace(/\s+/gu, " ").toLocaleLowerCase("en-US");
+}
+
+function hasCapacitySignal(value: unknown): boolean {
+  if (typeof value === "string") return CAPACITY_CODES.has(value.trim().toLocaleLowerCase("en-US"));
+  const candidate = record(value);
+  if (!candidate) return false;
+  const code = typeof candidate.code === "string"
+    ? candidate.code.trim().toLocaleLowerCase("en-US")
+    : "";
+  if (CAPACITY_CODES.has(code)) return true;
+  const type = typeof candidate.type === "string"
+    ? candidate.type.trim().toLocaleLowerCase("en-US")
+    : "";
+  if (CAPACITY_CODES.has(type)) return true;
+  const message = typeof candidate.message === "string" ? candidate.message : "";
+  return normalizeCapacityMessage(message)
+    === normalizeCapacityMessage(CODEX_MODEL_CAPACITY_MESSAGE);
+}
+
+/** Exact structured capacity signals, plus the one standard message compatibility case. */
+export function isCodexCapacityPayload(payload: unknown): boolean {
+  const root = record(payload);
+  if (!root) return false;
+  const response = record(root.response);
+  return [
+    root,
+    root.error,
+    root.last_error,
+    response,
+    response?.error,
+    response?.last_error,
+  ].some(hasCapacitySignal);
+}
+
+function isFailedDocument(payload: unknown): boolean {
+  const root = record(payload);
+  if (!root) return false;
+  const response = record(root.response);
+  return root.type === "response.failed"
+    || root.type === "error"
+    || root.status === "failed"
+    || response?.status === "failed";
+}
+
+function parsePayload(payload: string | null): unknown | undefined {
+  if (!payload || payload === "[DONE]") return undefined;
+  try {
+    return JSON.parse(payload) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function isSafePreOutputLifecycle(payload: unknown): boolean {
+  const event = record(payload);
+  if (!event) return false;
+  return event.type === "response.created"
+    || event.type === "response.in_progress"
+    || event.type === "response.queued"
+    || event.type === "response.heartbeat";
+}
+
+function responseWithBody(response: Response, body: BodyInit | null): Response {
+  const headers = new Headers(response.headers);
+  headers.delete("content-length");
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function replayBufferedThenReader(
+  buffered: readonly Uint8Array[],
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  terminalError?: unknown,
+): ReadableStream<Uint8Array> {
+  let prefixIndex = 0;
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (prefixIndex < buffered.length) {
+        controller.enqueue(buffered[prefixIndex++]!);
+        return;
+      }
+      if (terminalError !== undefined) {
+        controller.error(terminalError);
+        return;
+      }
+      try {
+        const next = await reader.read();
+        if (next.done) controller.close();
+        else controller.enqueue(next.value);
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason).catch(() => undefined);
+    },
+  });
+}
+
+function passWithBufferedBody(
+  response: Response,
+  buffered: readonly Uint8Array[],
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  terminalError?: unknown,
+): CodexCapacityInspection {
+  return {
+    kind: "pass",
+    response: responseWithBody(response, replayBufferedThenReader(buffered, reader, terminalError)),
+  };
+}
+
+async function inspectSseCapacityBeforeOutput(
+  response: Response,
+  signal?: AbortSignal,
+): Promise<CodexCapacityInspection> {
+  const body = response.body;
+  if (!body) return { kind: "pass", response };
+  const reader = body.getReader();
+  const framer = new BoundedSseFrameBuffer(MAX_CLIENT_SSE_FRAME_BYTES);
+  const buffered: Uint8Array[] = [];
+  const completeFrameParts: Uint8Array[] = [];
+  const decoder = new TextDecoder();
+  let bufferedBytes = 0;
+  let frameBytes = 0;
+
+  try {
+    while (true) {
+      if (signal?.aborted) throw signal.reason;
+      let next: { done: boolean; value?: Uint8Array };
+      try {
+        next = await reader.read();
+      } catch (error) {
+        framer.dispose();
+        return passWithBufferedBody(response, buffered, reader, error);
+      }
+      if (next.done) {
+        framer.dispose();
+        return passWithBufferedBody(response, buffered, reader);
+      }
+      const chunk = next.value!;
+      buffered.push(chunk);
+      bufferedBytes += chunk.byteLength;
+
+      let frames: ReturnType<BoundedSseFrameBuffer["feed"]>;
+      try {
+        frames = framer.feed(chunk);
+      } catch {
+        framer.dispose();
+        return passWithBufferedBody(response, buffered, reader);
+      }
+
+      for (const frame of frames) {
+        completeFrameParts.push(frame.block, frame.delimiter);
+        frameBytes += frame.block.byteLength + frame.delimiter.byteLength;
+        if (frameBytes > MAX_CLIENT_SSE_FRAME_BYTES) {
+          framer.dispose();
+          return passWithBufferedBody(response, buffered, reader);
+        }
+        const payloadText = sseDataPayload(decoder.decode(frame.block));
+        if (payloadText === null) continue;
+        if (payloadText === "[DONE]") {
+          framer.dispose();
+          return passWithBufferedBody(response, buffered, reader);
+        }
+        const payload = parsePayload(payloadText);
+        if (isFailedDocument(payload)) {
+          if (isCodexCapacityPayload(payload)) {
+            framer.dispose();
+            void reader.cancel("Codex capacity retry").catch(() => undefined);
+            const capacityBytes = Uint8Array.from(joinSseFrameBytes(completeFrameParts));
+            return {
+              kind: "capacity",
+              response: responseWithBody(response, capacityBytes),
+            };
+          }
+          framer.dispose();
+          return passWithBufferedBody(response, buffered, reader);
+        }
+        if (!isSafePreOutputLifecycle(payload)) {
+          framer.dispose();
+          return passWithBufferedBody(response, buffered, reader);
+        }
+      }
+
+      if (bufferedBytes > MAX_CLIENT_SSE_FRAME_BYTES) {
+        framer.dispose();
+        return passWithBufferedBody(response, buffered, reader);
+      }
+    }
+  } catch (error) {
+    framer.dispose();
+    void reader.cancel(error).catch(() => undefined);
+    throw error;
+  }
+}
+
+/**
+ * Inspect a Codex response only while no substantive Responses event has been
+ * exposed. SSE lifecycle frames are held under the existing client-frame byte
+ * bound; any unknown or output-bearing event commits the attempt permanently.
+ */
+export async function inspectCodexCapacityBeforeOutput(
+  response: Response,
+  options: { streamRequested: boolean; signal?: AbortSignal },
+): Promise<CodexCapacityInspection> {
+  const contentType = response.headers.get("content-type")?.toLocaleLowerCase("en-US") ?? "";
+  const isEventStream = contentType.includes("text/event-stream")
+    || (response.ok && !!response.body && !contentType && options.streamRequested);
+  if (isEventStream) return inspectSseCapacityBeforeOutput(response, options.signal);
+  if (!response.ok
+    && response.status !== 402
+    && response.status !== 429
+    && response.status < 500) {
+    return { kind: "pass", response };
+  }
+
+  try {
+    const body = await readBoundedResponseBody(response.clone(), {
+      signal: options.signal,
+      fatalUtf8: true,
+    });
+    if (!body.displaySafe || body.truncated || !body.text.trim()) {
+      return { kind: "pass", response };
+    }
+    const payload = JSON.parse(body.text) as unknown;
+    const rebuilt = responseWithBody(response, body.text);
+    const capacity = isCodexCapacityPayload(payload)
+      && (!response.ok || isFailedDocument(payload));
+    return capacity ? { kind: "capacity", response: rebuilt } : { kind: "pass", response: rebuilt };
+  } catch {
+    if (options.signal?.aborted) throw options.signal.reason;
+    return { kind: "pass", response };
+  }
+}

--- a/src/server/responses/codex-capacity.ts
+++ b/src/server/responses/codex-capacity.ts
@@ -20,16 +20,19 @@ export type CodexCapacityInspection =
   | { kind: "capacity"; response: Response }
   | { kind: "pass"; response: Response };
 
+/** Narrow an unknown JSON value to a non-array object. */
 function record(value: unknown): JsonRecord | null {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? value as JsonRecord
     : null;
 }
 
+/** Normalize only whitespace and case for the exact-message compatibility check. */
 function normalizeCapacityMessage(value: string): string {
   return value.trim().replace(/\s+/gu, " ").toLocaleLowerCase("en-US");
 }
 
+/** Match one structured capacity signal or the exact standard message. */
 function hasCapacitySignal(value: unknown): boolean {
   if (typeof value === "string") return CAPACITY_CODES.has(value.trim().toLocaleLowerCase("en-US"));
   const candidate = record(value);
@@ -62,6 +65,7 @@ export function isCodexCapacityPayload(payload: unknown): boolean {
   ].some(hasCapacitySignal);
 }
 
+/** Return whether a Responses envelope represents a terminal failure. */
 function isFailedDocument(payload: unknown): boolean {
   const root = record(payload);
   if (!root) return false;
@@ -72,6 +76,7 @@ function isFailedDocument(payload: unknown): boolean {
     || response?.status === "failed";
 }
 
+/** Parse an SSE data payload without treating malformed bytes as retryable. */
 function parsePayload(payload: string | null): unknown | undefined {
   if (!payload || payload === "[DONE]") return undefined;
   try {
@@ -81,6 +86,7 @@ function parsePayload(payload: string | null): unknown | undefined {
   }
 }
 
+/** Allow only lifecycle events that cannot expose model output. */
 function isSafePreOutputLifecycle(payload: unknown): boolean {
   const event = record(payload);
   if (!event) return false;
@@ -90,6 +96,7 @@ function isSafePreOutputLifecycle(payload: unknown): boolean {
     || event.type === "response.heartbeat";
 }
 
+/** Rebuild a response while preserving status and non-length headers. */
 function responseWithBody(response: Response, body: BodyInit | null): Response {
   const headers = new Headers(response.headers);
   headers.delete("content-length");
@@ -100,6 +107,7 @@ function responseWithBody(response: Response, body: BodyInit | null): Response {
   });
 }
 
+/** Replay inspected bytes before resuming the untouched upstream reader. */
 function replayBufferedThenReader(
   buffered: readonly Uint8Array[],
   reader: ReadableStreamDefaultReader<Uint8Array>,
@@ -130,6 +138,7 @@ function replayBufferedThenReader(
   });
 }
 
+/** Return a committed attempt with every inspected byte restored. */
 function passWithBufferedBody(
   response: Response,
   buffered: readonly Uint8Array[],
@@ -142,6 +151,7 @@ function passWithBufferedBody(
   };
 }
 
+/** Inspect bounded lifecycle-only SSE frames until capacity or output commits the attempt. */
 async function inspectSseCapacityBeforeOutput(
   response: Response,
   signal?: AbortSignal,

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -82,7 +82,7 @@ import {
   type CodexAuthContext,
 } from "../../codex/auth-context";
 import {
-  bindCodexThreadAffinityForAcceptedResponse,
+  commitCodexAcceptedAccountSelection,
   computeQuotaCooldown,
   formatCodexProviderForLog,
   previewCodexAccountForRequest,
@@ -855,7 +855,7 @@ async function resolveResponsesCodexAuth(
       authCtx = await resolveCodexAuthContext(req.headers, config, route.codexAccountMode, {
         accountId: route.codexAccountId,
         modelId: route.modelId,
-        deferThreadAffinityCommit: route.codexAccountMode === "pool"
+        deferSelectionCommit: route.codexAccountMode === "pool"
           && route.codexAccountId === undefined,
         beginCodexAccountSelection: codexAccountSelectionForTurn(options.turnAdmissionLease),
       });
@@ -2106,10 +2106,12 @@ async function handleResponsesInner(
         });
         upstreamResponse = inspected.response;
         if (inspected.kind !== "capacity") {
-          bindCodexThreadAffinityForAcceptedResponse(
+          commitCodexAcceptedAccountSelection(
+            config,
             req.headers.get("x-codex-parent-thread-id"),
             authCtx.accountId,
             route.modelId,
+            excludedAccountIds,
           );
           if (firstCapacityAttempt) {
             await firstCapacityAttempt.response.body?.cancel().catch(() => undefined);

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -82,6 +82,7 @@ import {
   type CodexAuthContext,
 } from "../../codex/auth-context";
 import {
+  bindCodexThreadAffinityForAcceptedResponse,
   computeQuotaCooldown,
   formatCodexProviderForLog,
   previewCodexAccountForRequest,
@@ -854,6 +855,8 @@ async function resolveResponsesCodexAuth(
       authCtx = await resolveCodexAuthContext(req.headers, config, route.codexAccountMode, {
         accountId: route.codexAccountId,
         modelId: route.modelId,
+        deferThreadAffinityCommit: route.codexAccountMode === "pool"
+          && route.codexAccountId === undefined,
         beginCodexAccountSelection: codexAccountSelectionForTurn(options.turnAdmissionLease),
       });
       options.onCodexAuthContextResolved?.(authCtx);
@@ -2103,6 +2106,11 @@ async function handleResponsesInner(
         });
         upstreamResponse = inspected.response;
         if (inspected.kind !== "capacity") {
+          bindCodexThreadAffinityForAcceptedResponse(
+            req.headers.get("x-codex-parent-thread-id"),
+            authCtx.accountId,
+            route.modelId,
+          );
           if (firstCapacityAttempt) {
             await firstCapacityAttempt.response.body?.cancel().catch(() => undefined);
           }

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -2,6 +2,7 @@ import type { Server } from "bun";
 import { bridgeToResponsesSSE, buildResponseJSON, formatErrorResponse, type ResponsesTerminalStatus } from "../../bridge";
 import { formatPassthroughUpstreamError } from "./passthrough-error";
 import { describeUpstreamConnectFailure } from "./upstream-error";
+import { inspectCodexCapacityBeforeOutput } from "./codex-capacity";
 import {
   getConfigPath,
   multiAgentGuidanceEnabled,
@@ -344,6 +345,9 @@ interface CodexPoolAccountRetryArgs {
   connectMs: number;
   passthroughEstimate?: number;
   stream: boolean;
+  excludedAccountIds?: Set<string>;
+  recordRejectedOutcome?: boolean;
+  preserveRejectedResponse?: boolean;
 }
 
 type CodexPoolAccountRetryResult =
@@ -402,49 +406,64 @@ async function retryCodexPoolOnAlternateAccount(
   if (firstAuthCtx.fixedAccount) return { kind: "no-alternate" };
   const inboundWire = options.inboundWire ?? "responses";
   let retryAuthCtx: CodexAuthContext | undefined;
-  try {
-    retryAuthCtx = await resolveCodexAuthContext(
-      req.headers,
-      config,
-      "pool",
-      {
-        excludeAccountId: firstAuthCtx.accountId,
-        modelId: route.modelId,
-        beginCodexAccountSelection: codexAccountSelectionForTurn(options.turnAdmissionLease),
-      },
-    );
-  } catch (error) {
-    if (
-      !(error instanceof CodexPoolAuthenticationError)
-      && !(error instanceof CodexAuthContextError)
-      && !(error instanceof CodexAccountCooldownError)
-      && !(error instanceof CodexMainProfileDrainingError)
-    ) throw error;
+  while (!retryAuthCtx) {
+    try {
+      retryAuthCtx = await resolveCodexAuthContext(
+        req.headers,
+        config,
+        "pool",
+        {
+          ...(args.excludedAccountIds
+            ? { excludeAccountIds: args.excludedAccountIds }
+            : { excludeAccountId: firstAuthCtx.accountId }),
+          modelId: route.modelId,
+          beginCodexAccountSelection: codexAccountSelectionForTurn(options.turnAdmissionLease),
+        },
+      );
+    } catch (error) {
+      if (
+        args.excludedAccountIds
+        && (error instanceof CodexAuthContextError || error instanceof CodexAccountCooldownError)
+        && !args.excludedAccountIds.has(error.accountId)
+      ) {
+        args.excludedAccountIds.add(error.accountId);
+        continue;
+      }
+      if (
+        !(error instanceof CodexPoolAuthenticationError)
+        && !(error instanceof CodexAuthContextError)
+        && !(error instanceof CodexAccountCooldownError)
+        && !(error instanceof CodexMainProfileDrainingError)
+      ) throw error;
+      break;
+    }
   }
   if (retryAuthCtx?.kind !== "pool" && retryAuthCtx?.kind !== "main-pool") {
     return { kind: "no-alternate" };
   }
 
-  const quotaMeta = codexQuotaOutcomeMeta(firstResponse);
-  if (outcomeStatus === 429 || outcomeStatus === 402) {
-    const { applyAccountQuotaFromUpstreamHeaders } = await import("../../codex/auth-api");
-    applyAccountQuotaFromUpstreamHeaders(
-      firstAuthCtx.accountId,
-      firstResponse.headers,
-      firstAuthCtx.writerGeneration,
-    );
-  }
-  if (!shouldDeferCodexResetDerivedCooldown(firstResponse, options.deferCodexResetDerivedCooldown)) {
-    recordCodexUpstreamOutcome(config, firstAuthCtx.accountId, outcomeStatus, {
-      ...quotaMeta,
-      threadId: req.headers.get("x-codex-parent-thread-id"),
-      modelId: route.modelId,
-      probeLeaseId: codexProbeLeaseId(firstAuthCtx),
-      probeQuotaScope: codexProbeQuotaScope(firstAuthCtx),
-      writerGeneration: firstAuthCtx.writerGeneration,
-      // Retry already advanced the RR ring via excludeAccountId — reuse for promotion.
-      ...(retryAuthCtx.accountId ? { promoteAccountId: retryAuthCtx.accountId } : {}),
-    });
+  if (args.recordRejectedOutcome !== false) {
+    const quotaMeta = codexQuotaOutcomeMeta(firstResponse);
+    if (outcomeStatus === 429 || outcomeStatus === 402) {
+      const { applyAccountQuotaFromUpstreamHeaders } = await import("../../codex/auth-api");
+      applyAccountQuotaFromUpstreamHeaders(
+        firstAuthCtx.accountId,
+        firstResponse.headers,
+        firstAuthCtx.writerGeneration,
+      );
+    }
+    if (!shouldDeferCodexResetDerivedCooldown(firstResponse, options.deferCodexResetDerivedCooldown)) {
+      recordCodexUpstreamOutcome(config, firstAuthCtx.accountId, outcomeStatus, {
+        ...quotaMeta,
+        threadId: req.headers.get("x-codex-parent-thread-id"),
+        modelId: route.modelId,
+        probeLeaseId: codexProbeLeaseId(firstAuthCtx),
+        probeQuotaScope: codexProbeQuotaScope(firstAuthCtx),
+        writerGeneration: firstAuthCtx.writerGeneration,
+        // Retry already advanced the RR ring via exclusion — reuse for promotion.
+        ...(retryAuthCtx.accountId ? { promoteAccountId: retryAuthCtx.accountId } : {}),
+      });
+    }
   }
 
   const retryHeaders = headersForCodexAuthContext(req.headers, retryAuthCtx);
@@ -463,7 +482,9 @@ async function retryCodexPoolOnAlternateAccount(
   });
   recordAdapterReasoning(logCtx, request);
 
-  await firstResponse.body?.cancel().catch(() => undefined);
+  if (args.preserveRejectedResponse !== true) {
+    await firstResponse.body?.cancel().catch(() => undefined);
+  }
   options.onCodexAuthContextResolved?.(retryAuthCtx);
   route.provider = retryProvider;
   logCtx.provider = formatCodexProviderForLog(
@@ -1961,6 +1982,21 @@ async function handleResponsesInner(
         : describeUpstreamConnectFailure(err, connectMs);
       return formatErrorResponse(502, "upstream_error", msg);
     };
+    const passthroughTransientRetryOptions = {
+      abortSignal: upstream.signal,
+      label: safeHostLabel(request.url),
+      ...(usesCodexForwardPoolAuth(authCtx, route.provider) && !authCtx.fixedAccount
+        ? {
+          prepareTransientRetry: async (response: Response) => {
+            const inspected = await inspectCodexCapacityBeforeOutput(response, {
+              streamRequested: parsed.stream,
+              signal: options.abortSignal,
+            });
+            return { response: inspected.response, retry: inspected.kind !== "capacity" };
+          },
+        }
+        : {}),
+    };
     try {
       // Transient-5xx pre-stream retry (devlog/_plan/260716_claudecode_hardening/010):
       // the ChatGPT backend emits transient 502/520s that an immediate retry absorbs.
@@ -1981,7 +2017,7 @@ async function handleResponsesInner(
               return res;
             });
         },
-        { abortSignal: upstream.signal, label: safeHostLabel(request.url) },
+        passthroughTransientRetryOptions,
       );
     } catch (err) {
       return transportFailureResponse(err);
@@ -2040,14 +2076,97 @@ async function handleResponsesInner(
                 return res;
               });
           },
-          { abortSignal: upstream.signal, label: safeHostLabel(request.url) },
+          passthroughTransientRetryOptions,
         );
       } catch (err) {
         return transportFailureResponse(err);
       }
     }
 
+    let capacityRetryExhausted = false;
     if (usesCodexForwardPoolAuth(authCtx, route.provider) && !authCtx.fixedAccount) {
+      const excludedAccountIds = new Set<string>();
+      let firstCapacityAttempt: {
+        response: Response;
+        authCtx: Extract<CodexAuthContext, { kind: "pool" | "main-pool" }>;
+        request: typeof request;
+        provider: OcxProviderConfig;
+        selectedForwardHeaders: Headers;
+        logProvider: string;
+        subagentFallbackAccountId: string | null;
+      } | undefined;
+
+      while (true) {
+        const inspected = await inspectCodexCapacityBeforeOutput(upstreamResponse, {
+          streamRequested: parsed.stream,
+          signal: options.abortSignal,
+        });
+        upstreamResponse = inspected.response;
+        if (inspected.kind !== "capacity") {
+          if (firstCapacityAttempt) {
+            await firstCapacityAttempt.response.body?.cancel().catch(() => undefined);
+          }
+          break;
+        }
+
+        excludedAccountIds.add(authCtx.accountId);
+        firstCapacityAttempt ??= {
+          response: upstreamResponse,
+          authCtx,
+          request,
+          provider: route.provider,
+          selectedForwardHeaders,
+          logProvider: logCtx.provider,
+          subagentFallbackAccountId,
+        };
+        const retry = await retryCodexPoolOnAlternateAccount({
+          req,
+          config,
+          route,
+          parsed,
+          logCtx,
+          options,
+          firstAuthCtx: authCtx,
+          firstResponse: upstreamResponse,
+          outcomeStatus: 503,
+          upstream,
+          connectMs,
+          passthroughEstimate,
+          stream: parsed.stream,
+          excludedAccountIds,
+          recordRejectedOutcome: false,
+          preserveRejectedResponse: upstreamResponse === firstCapacityAttempt.response,
+        });
+        if (retry.kind === "transport") {
+          await firstCapacityAttempt.response.body?.cancel().catch(() => undefined);
+          authCtx = retry.authCtx;
+          return transportFailureResponse(retry.error);
+        }
+        if (retry.kind === "no-alternate") {
+          if (upstreamResponse !== firstCapacityAttempt.response) {
+            await upstreamResponse.body?.cancel().catch(() => undefined);
+          }
+          authCtx = firstCapacityAttempt.authCtx;
+          request = firstCapacityAttempt.request;
+          route.provider = firstCapacityAttempt.provider;
+          selectedForwardHeaders = firstCapacityAttempt.selectedForwardHeaders;
+          logCtx.provider = firstCapacityAttempt.logProvider;
+          subagentFallbackAccountId = firstCapacityAttempt.subagentFallbackAccountId;
+          upstreamResponse = firstCapacityAttempt.response;
+          options.onCodexAuthContextResolved?.(authCtx);
+          capacityRetryExhausted = true;
+          break;
+        }
+
+        authCtx = retry.authCtx;
+        request = retry.request;
+        upstreamResponse = retry.upstreamResponse;
+        selectedForwardHeaders = retry.selectedForwardHeaders;
+        subagentFallbackAccountId = retry.authCtx.accountId;
+      }
+    }
+
+    if (!capacityRetryExhausted && usesCodexForwardPoolAuth(authCtx, route.provider) && !authCtx.fixedAccount) {
       let poolRetryOutcome: number | undefined;
       if (await shouldRetryCodexPoolAccountModel400(
         upstreamResponse,
@@ -2102,17 +2221,19 @@ async function handleResponsesInner(
     const passthroughCt = headers.get("content-type")?.toLowerCase();
     const isEventStream = passthroughCt?.includes("text/event-stream")
       || (upstreamResponse.ok && !!upstreamResponse.body && !passthroughCt && parsed.stream);
-    const terminalRecorder = codexForwardTerminalOutcomeRecorder(
-      config,
-      authCtx,
-      route.provider,
-      route.modelId,
-      logCtx,
-      req.headers.get("x-codex-parent-thread-id"),
-    );
+    const terminalRecorder = capacityRetryExhausted
+      ? undefined
+      : codexForwardTerminalOutcomeRecorder(
+        config,
+        authCtx,
+        route.provider,
+        route.modelId,
+        logCtx,
+        req.headers.get("x-codex-parent-thread-id"),
+      );
     const terminalBodyWillRecord = !!terminalRecorder && upstreamResponse.ok && isEventStream;
     // Capture quota from upstream response for multi-account tracking
-   if (usesCodexForwardPoolAuth(authCtx, route.provider)) {
+   if (!capacityRetryExhausted && usesCodexForwardPoolAuth(authCtx, route.provider)) {
       // primary was the 5h window; it now carries weekly data for GPT plans.
       // Prefer primary when present, fall back to secondary for compatibility.
       const quotaMeta = codexQuotaOutcomeMeta(upstreamResponse);

--- a/structure/08_openai-provider-tiers.md
+++ b/structure/08_openai-provider-tiers.md
@@ -23,6 +23,13 @@ An explicit `Retry-After` or an unclassified quota 429 is account-wide. A reset-
 the shared native group (including GPT-5.6 Terra/Luna). This allows a same-account combo to test an
 independent quota without allowing fallbacks that share the exhausted quota.
 
+Model-capacity rejection is a different recovery class. Before substantive Responses output, exact
+structured `server_is_overloaded` / `slow_down` signals and the standard model-capacity sentence
+exclude the current account only for that request, then try each remaining eligible Pool account
+once. Rejected capacity attempts write no cooldown, health, affinity, or active-account state. Exhaustion returns the
+first rejection, and the next request starts with no capacity exclusions. Direct and exact-account
+routes never rotate, and a committed output event makes the attempt non-replayable.
+
 `pausedCodexAccountIds` is a persisted Pool eligibility boundary. A paused added account or the
 stable `__main__` alias remains visible for maintenance and quota reads, but is excluded from new
 affinity, quota rotation, cooldown probes, transient failover, and manual activation. In-flight

--- a/structure/08_openai-provider-tiers.md
+++ b/structure/08_openai-provider-tiers.md
@@ -26,9 +26,10 @@ independent quota without allowing fallbacks that share the exhausted quota.
 Model-capacity rejection is a different recovery class. Before substantive Responses output, exact
 structured `server_is_overloaded` / `slow_down` signals and the standard model-capacity sentence
 exclude the current account only for that request, then try each remaining eligible Pool account
-once. Rejected capacity attempts write no cooldown, health, affinity, or active-account state. Exhaustion returns the
-first rejection, and the next request starts with no capacity exclusions. Direct and exact-account
-routes never rotate, and a committed output event makes the attempt non-replayable.
+once. Rejected capacity attempts write no cooldown or health, and thread affinity is committed only
+for the account whose non-capacity response is accepted. Exhaustion returns the first rejection; the
+next request starts with no capacity exclusions and no new affinity from the rejected attempts. Direct
+and exact-account routes never rotate, and a committed output event makes the attempt non-replayable.
 
 `pausedCodexAccountIds` is a persisted Pool eligibility boundary. A paused added account or the
 stable `__main__` alias remains visible for maintenance and quota reads, but is excluded from new

--- a/tests/codex-capacity-retry.test.ts
+++ b/tests/codex-capacity-retry.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CODEX_MODEL_CAPACITY_MESSAGE,
+  inspectCodexCapacityBeforeOutput,
+  isCodexCapacityPayload,
+} from "../src/server/responses/codex-capacity";
+
+function sseResponse(chunks: readonly string[]): Response {
+  const encoder = new TextEncoder();
+  return new Response(new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  }), { headers: { "content-type": "text/event-stream" } });
+}
+
+describe("Codex model-capacity classification", () => {
+  test("accepts structured code/type and only the exact standard message", () => {
+    expect(isCodexCapacityPayload({ error: { code: "server_is_overloaded" } })).toBe(true);
+    expect(isCodexCapacityPayload({ error: { type: "slow_down" } })).toBe(true);
+    expect(isCodexCapacityPayload({ error: { message: CODEX_MODEL_CAPACITY_MESSAGE } })).toBe(true);
+    expect(isCodexCapacityPayload({
+      error: { message: `${CODEX_MODEL_CAPACITY_MESSAGE} retry later` },
+    })).toBe(false);
+    expect(isCodexCapacityPayload({ error: { message: "model unavailable" } })).toBe(false);
+  });
+
+  test("recognizes a fragmented SSE error after lifecycle-only frames", async () => {
+    const source = [
+      'event: response.created\ndata: {"type":"response.created"}\n\n',
+      'event: error\ndata: {"type":"error","error":{"message":"Selected model is at ',
+      'capacity. Please try a different model."}}\n\n',
+    ];
+    const inspected = await inspectCodexCapacityBeforeOutput(sseResponse(source), {
+      streamRequested: true,
+    });
+    expect(inspected.kind).toBe("capacity");
+    expect(await inspected.response.text()).toBe(source.join(""));
+  });
+
+  test("any substantive event commits the stream and forbids capacity replay", async () => {
+    const source = [
+      'event: response.output_item.added\ndata: {"type":"response.output_item.added","item":{"type":"function_call"}}\n\n',
+      `event: response.failed\ndata: ${JSON.stringify({
+        type: "response.failed",
+        response: {
+          status: "failed",
+          error: { code: "server_is_overloaded", message: "busy" },
+        },
+      })}\n\n`,
+    ].join("");
+    const inspected = await inspectCodexCapacityBeforeOutput(sseResponse([source]), {
+      streamRequested: true,
+    });
+    expect(inspected.kind).toBe("pass");
+    expect(await inspected.response.text()).toBe(source);
+  });
+
+  test("non-capacity transient response stays byte-for-byte readable", async () => {
+    const body = JSON.stringify({ error: { code: "upstream_server_error", message: "gateway reset" } });
+    const inspected = await inspectCodexCapacityBeforeOutput(new Response(body, {
+      status: 502,
+      statusText: "Bad Gateway",
+      headers: { "content-type": "application/json", "x-origin": "kept" },
+    }), { streamRequested: false });
+    expect(inspected.kind).toBe("pass");
+    expect(inspected.response.status).toBe(502);
+    expect(inspected.response.statusText).toBe("Bad Gateway");
+    expect(inspected.response.headers.get("x-origin")).toBe("kept");
+    expect(await inspected.response.text()).toBe(body);
+  });
+});

--- a/tests/codex-pool-rotation.test.ts
+++ b/tests/codex-pool-rotation.test.ts
@@ -1,4 +1,5 @@
 import {
+  commitRoundRobinAccountSuccess,
   clearPoolRotationState,
   DEFAULT_ACCOUNT_PRIORITY,
   normalizeAccountPriority,
@@ -307,6 +308,13 @@ describe("pickRoundRobinAccount", () => {
     const peekAfter = peekRoundRobinAccount("codex", ids, 1);
     expect(peekAfter).not.toBe(picked);
     expect(pickRoundRobinAccount("codex", ids, 1)).toBe(peekAfter);
+  });
+
+  test("deferred commit advances from the accepted account, not a rejected preview", () => {
+    const ids = ["a", "b", "c"];
+    expect(peekRoundRobinAccount("codex", ids, 1)).toBe("a");
+    expect(commitRoundRobinAccountSuccess("codex", ["b", "c"], "b", 1)).toBe(true);
+    expect(peekRoundRobinAccount("codex", ids, 1)).toBe("c");
   });
 });
 

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -135,6 +135,7 @@ afterEach(() => {
   clearThreadAccountMap();
   clearAccountNeedsReauth("pool-a");
   clearAccountNeedsReauth("pool-b");
+  clearAccountNeedsReauth("pool-c");
   clearAccountQuota();
   if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
 });
@@ -145,6 +146,52 @@ function unsupportedModelBody(model = POOL_RETRY_MODEL): string {
   return JSON.stringify({
     detail: `The '${model}' model is not supported when using Codex with a ChatGPT account.`,
   });
+}
+
+const CAPACITY_MESSAGE = "Selected model is at capacity. Please try a different model.";
+
+function capacityErrorBody(
+  code: "server_is_overloaded" | "slow_down" | undefined = undefined,
+  message = CAPACITY_MESSAGE,
+): string {
+  return JSON.stringify({
+    error: {
+      type: "server_error",
+      ...(code ? { code } : {}),
+      message,
+    },
+  });
+}
+
+function capacityFailedSse(
+  code: "server_is_overloaded" | "slow_down" | undefined = undefined,
+  message = CAPACITY_MESSAGE,
+): string {
+  const error = {
+    type: "server_error",
+    ...(code ? { code } : {}),
+    message,
+  };
+  return [
+    'event: response.created\ndata: {"type":"response.created","response":{"id":"capacity-attempt","status":"in_progress"}}\n\n',
+    `event: response.failed\ndata: ${JSON.stringify({
+      type: "response.failed",
+      response: { status: "failed", error, last_error: error },
+    })}\n\n`,
+  ].join("");
+}
+
+function capacityErrorSse(
+  code: "server_is_overloaded" | "slow_down" | undefined = undefined,
+  message = CAPACITY_MESSAGE,
+): string {
+  return [
+    'event: response.created\ndata: {"type":"response.created","response":{"id":"capacity-attempt","status":"in_progress"}}\n\n',
+    `event: error\ndata: ${JSON.stringify({
+      type: "error",
+      error: { ...(code ? { code } : {}), message },
+    })}\n\n`,
+  ].join("");
 }
 
 type PoolRetryHarness = {
@@ -183,6 +230,7 @@ async function startPoolRetryHarness(
   reply: (accountId: string, request: Request) => Response | Promise<Response>,
   options: {
     secondAccount?: boolean;
+    thirdAccount?: boolean;
     streamMode?: "legacy-tee" | "eager-relay";
     accountMode?: "direct" | "pool";
     activeAccountId?: string;
@@ -205,6 +253,7 @@ async function startPoolRetryHarness(
   clearRequestLogsForTests();
   clearAccountNeedsReauth("pool-a");
   clearAccountNeedsReauth("pool-b");
+  clearAccountNeedsReauth("pool-c");
   // The registry is process-global and survives a harness teardown. WS-REBIND-01
   // asserts exact per-account socket counts, so a socket leaked by any earlier test
   // in this file shifts its snapshots and fails it in milliseconds — which reads as
@@ -225,6 +274,7 @@ async function startPoolRetryHarness(
   const redirectedFetch = globalThis.fetch;
 
   const secondAccount = options.secondAccount ?? true;
+  const thirdAccount = options.thirdAccount ?? false;
   const config = {
     port: 0,
     defaultProvider: "openai",
@@ -242,6 +292,9 @@ async function startPoolRetryHarness(
       { id: "pool-a", email: "pool-a@example.test", isMain: false, chatgptAccountId: "acct-pool-a" },
       ...(secondAccount
         ? [{ id: "pool-b", email: "pool-b@example.test", isMain: false, chatgptAccountId: "acct-pool-b" }]
+        : []),
+      ...(thirdAccount
+        ? [{ id: "pool-c", email: "pool-c@example.test", isMain: false, chatgptAccountId: "acct-pool-c" }]
         : []),
     ],
     activeCodexAccountId: options.activeAccountId ?? "pool-a",
@@ -271,6 +324,17 @@ async function startPoolRetryHarness(
       });
     }
     updateAccountQuota("pool-b", 20);
+  }
+  if (thirdAccount) {
+    if (!options.omitCredentialAccountIds?.includes("pool-c")) {
+      saveCodexAccountCredential("pool-c", {
+        accessToken: "pool-c-token",
+        refreshToken: "pool-c-refresh",
+        expiresAt: Date.now() + 10 * 60_000,
+        chatgptAccountId: "acct-pool-c",
+      });
+    }
+    updateAccountQuota("pool-c", 30);
   }
   for (const accountId of options.reauthAccountIds ?? []) markAccountNeedsReauth(accountId);
 
@@ -2257,6 +2321,162 @@ describe("server local API auth", () => {
       await stopPoolRetryHarness(harness);
     }
   }, { timeout: SERVER_BUDGET_MS });
+
+  test("capacity rejection rotates through every eligible pool account once", async () => {
+    const harness = await startPoolRetryHarness(accountId => {
+      if (accountId === "acct-pool-a") {
+        return new Response(capacityErrorBody(undefined), {
+          status: 502,
+          headers: { "content-type": "application/json", "x-capacity-attempt": "a" },
+        });
+      }
+      if (accountId === "acct-pool-b") {
+        return new Response(capacityErrorBody("server_is_overloaded", "busy"), {
+          status: 503,
+          headers: { "content-type": "application/json", "x-capacity-attempt": "b" },
+        });
+      }
+      return Response.json({ id: "capacity-rotation-success", status: "completed", output: [] });
+    }, { thirdAccount: true });
+    try {
+      const response = await harness.request();
+      expect(response.status).toBe(200);
+      const responseText = await response.text();
+      expect(responseText).toContain("capacity-rotation-success");
+      expect(harness.dispatches).toEqual(["acct-pool-a", "acct-pool-b", "acct-pool-c"]);
+      expect(getCodexUpstreamHealth("pool-a")).toBeNull();
+      expect(getCodexUpstreamHealth("pool-b")).toBeNull();
+    } finally {
+      await stopPoolRetryHarness(harness);
+    }
+  });
+
+  test("capacity rotation skips an unavailable intermediate account", async () => {
+    const harness = await startPoolRetryHarness(accountId => accountId === "acct-pool-a"
+      ? new Response(capacityErrorBody("server_is_overloaded"), {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      })
+      : Response.json({ id: "available-c", status: "completed", output: [] }), {
+      thirdAccount: true,
+      omitCredentialAccountIds: ["pool-b"],
+    });
+    try {
+      const response = await harness.request();
+      expect(response.status).toBe(200);
+      expect(await response.text()).toContain("available-c");
+      expect(harness.dispatches).toEqual(["acct-pool-a", "acct-pool-c"]);
+      expect(getCodexUpstreamHealth("pool-a")).toBeNull();
+      expect(getCodexUpstreamHealth("pool-b")).toBeNull();
+    } finally {
+      await stopPoolRetryHarness(harness);
+    }
+  });
+
+  test("capacity exhaustion preserves the first error and resets on the next request", async () => {
+    let requestOrdinal = 0;
+    const harness = await startPoolRetryHarness(accountId => {
+      if (accountId === "acct-pool-a") requestOrdinal += 1;
+      if (requestOrdinal === 2 && accountId === "acct-pool-a") {
+        return Response.json({ id: "fresh-request-success", status: "completed", output: [] });
+      }
+      const attempt = accountId === "acct-pool-a" ? "a" : "b";
+      return new Response(capacityErrorBody("slow_down", `capacity-${attempt}`), {
+        status: 502,
+        statusText: `Capacity ${attempt.toUpperCase()}`,
+        headers: { "content-type": "application/json", "x-capacity-attempt": attempt },
+      });
+    });
+    try {
+      const exhausted = await harness.request();
+      expect(exhausted.status).toBe(502);
+      expect(exhausted.headers.get("x-capacity-attempt")).toBe("a");
+      expect(await exhausted.text()).toContain("capacity-a");
+      expect(harness.dispatches).toEqual(["acct-pool-a", "acct-pool-b"]);
+      expect(getCodexUpstreamHealth("pool-a")).toBeNull();
+      expect(getCodexUpstreamHealth("pool-b")).toBeNull();
+
+      const fresh = await harness.request();
+      expect(fresh.status).toBe(200);
+      const freshText = await fresh.text();
+      expect(freshText).toContain("fresh-request-success");
+      expect(harness.dispatches).toEqual(["acct-pool-a", "acct-pool-b", "acct-pool-a"]);
+    } finally {
+      await stopPoolRetryHarness(harness);
+    }
+  });
+
+  test("SSE capacity failure rotates only before substantive output", async () => {
+    const preOutput = await startPoolRetryHarness(accountId => accountId === "acct-pool-a"
+      ? new Response(capacityErrorSse(undefined), {
+        headers: { "content-type": "text/event-stream" },
+      })
+      : new Response(
+        'event: response.completed\ndata: {"type":"response.completed","response":{"id":"from-b","status":"completed","output":[]}}\n\n',
+        { headers: { "content-type": "text/event-stream" } },
+      ));
+    try {
+      const text = await (await preOutput.request({ stream: true })).text();
+      expect(preOutput.dispatches).toEqual(["acct-pool-a", "acct-pool-b"]);
+      expect(text).toContain('"id":"from-b"');
+      expect(text).not.toContain("capacity-attempt");
+    } finally {
+      await stopPoolRetryHarness(preOutput);
+    }
+
+    const postOutput = await startPoolRetryHarness(() => new Response([
+      'event: response.created\ndata: {"type":"response.created","response":{"id":"committed","status":"in_progress"}}\n\n',
+      'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"visible"}\n\n',
+      capacityFailedSse("server_is_overloaded", "busy"),
+    ].join(""), { headers: { "content-type": "text/event-stream" } }));
+    try {
+      const text = await (await postOutput.request({ stream: true })).text();
+      expect(postOutput.dispatches).toEqual(["acct-pool-a"]);
+      expect(text).toContain('"delta":"visible"');
+      expect(text).toContain("response.failed");
+    } finally {
+      await stopPoolRetryHarness(postOutput);
+    }
+  });
+
+  test("Direct mode never rotates a capacity rejection", async () => {
+    const harness = await startPoolRetryHarness(() => new Response(capacityErrorBody("server_is_overloaded"), {
+      status: 409,
+      headers: { "content-type": "application/json" },
+    }), { accountMode: "direct" });
+    try {
+      const response = await harness.request();
+      expect(response.status).toBe(409);
+      expect(harness.dispatches).toEqual(["missing"]);
+    } finally {
+      await stopPoolRetryHarness(harness);
+    }
+  });
+
+  test("exact account selector never rotates a capacity rejection", async () => {
+    const body = capacityErrorBody("server_is_overloaded");
+    const harness = await startPoolRetryHarness(() => new Response(body, {
+      status: 409,
+      headers: { "content-type": "application/json", "x-exact-response": "original" },
+    }), {
+      accountMode: "direct",
+      activeAccountId: "pool-b",
+      accountNamespaces: { side: "pool-a" },
+    });
+    try {
+      const response = await harness.request({
+        model: `side/${POOL_RETRY_MODEL}`,
+        callerBearer: false,
+      });
+      expect(response.status).toBe(409);
+      expect(response.headers.get("x-exact-response")).toBe("original");
+      expect(await response.text()).toBe(body);
+      expect(harness.dispatches).toEqual(["acct-pool-a"]);
+      expect(loadConfig().activeCodexAccountId).toBe("pool-b");
+    } finally {
+      await stopPoolRetryHarness(harness);
+    }
+  });
 
   test("#584: pre-stream 429 retries once on another eligible pool account", async () => {
     const harness = await startPoolRetryHarness(accountId => accountId === "acct-pool-a"

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -40,6 +40,7 @@ import { fakeChatGptJwt } from "./helpers/fake-chatgpt-jwt";
 import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
 import { configuredAdminToken } from "../src/lib/admin-secrets";
 import { SYSTEM_RESTART_CAPABILITY_VERSION } from "../src/lib/system-restart-contract";
+import { CODEX_MODEL_CAPACITY_MESSAGE } from "../src/server/responses/codex-capacity";
 
 const previousApiToken = process.env.OPENCODEX_API_AUTH_TOKEN;
 const previousOpencodexHome = process.env.OPENCODEX_HOME;
@@ -148,11 +149,9 @@ function unsupportedModelBody(model = POOL_RETRY_MODEL): string {
   });
 }
 
-const CAPACITY_MESSAGE = "Selected model is at capacity. Please try a different model.";
-
 function capacityErrorBody(
   code: "server_is_overloaded" | "slow_down" | undefined = undefined,
-  message = CAPACITY_MESSAGE,
+  message = CODEX_MODEL_CAPACITY_MESSAGE,
 ): string {
   return JSON.stringify({
     error: {
@@ -165,7 +164,7 @@ function capacityErrorBody(
 
 function capacityFailedSse(
   code: "server_is_overloaded" | "slow_down" | undefined = undefined,
-  message = CAPACITY_MESSAGE,
+  message = CODEX_MODEL_CAPACITY_MESSAGE,
 ): string {
   const error = {
     type: "server_error",
@@ -183,7 +182,7 @@ function capacityFailedSse(
 
 function capacityErrorSse(
   code: "server_is_overloaded" | "slow_down" | undefined = undefined,
-  message = CAPACITY_MESSAGE,
+  message = CODEX_MODEL_CAPACITY_MESSAGE,
 ): string {
   return [
     'event: response.created\ndata: {"type":"response.created","response":{"id":"capacity-attempt","status":"in_progress"}}\n\n',

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -203,6 +203,7 @@ type PoolRetryHarness = {
     model?: string;
     path?: "/v1/responses" | "/v1/responses/compact";
     callerBearer?: boolean;
+    threadId?: string;
   }) => Promise<Response>;
   restoreFetch: () => void;
   server: ReturnType<typeof startServer>;
@@ -353,11 +354,13 @@ async function startPoolRetryHarness(
       model = POOL_RETRY_MODEL,
       path = "/v1/responses",
       callerBearer = true,
+      threadId,
     } = {}) => originalGlobalFetch(new URL(path, server.url), {
       method: "POST",
       headers: {
         "content-type": "application/json",
         ...(callerBearer ? { authorization: "Bearer inbound-token" } : {}),
+        ...(threadId ? { "x-codex-parent-thread-id": threadId } : {}),
       },
       body: JSON.stringify({ model, input: path.endsWith("/compact") ? [] : "hello", stream }),
       signal,
@@ -2368,6 +2371,29 @@ describe("server local API auth", () => {
       expect(harness.dispatches).toEqual(["acct-pool-a", "acct-pool-c"]);
       expect(getCodexUpstreamHealth("pool-a")).toBeNull();
       expect(getCodexUpstreamHealth("pool-b")).toBeNull();
+    } finally {
+      await stopPoolRetryHarness(harness);
+    }
+  });
+
+  test("capacity rotation binds thread affinity only to the accepted account", async () => {
+    const harness = await startPoolRetryHarness(accountId => accountId === "acct-pool-a"
+      ? new Response(capacityErrorBody("server_is_overloaded"), {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      })
+      : Response.json({ id: "accepted-b", status: "completed", output: [] }));
+    try {
+      const first = await harness.request({ threadId: "capacity-thread" });
+      expect(first.status).toBe(200);
+      expect(await first.text()).toContain("accepted-b");
+      expect(harness.dispatches).toEqual(["acct-pool-a", "acct-pool-b"]);
+
+      const second = await harness.request({ threadId: "capacity-thread" });
+      expect(second.status).toBe(200);
+      expect(await second.text()).toContain("accepted-b");
+      expect(harness.dispatches).toEqual(["acct-pool-a", "acct-pool-b", "acct-pool-b"]);
+      expect(getCodexUpstreamHealth("pool-a")).toBeNull();
     } finally {
       await stopPoolRetryHarness(harness);
     }

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -13,10 +13,12 @@ import {
   CODEX_THREAD_AFFINITY_IDLE_TTL_MS,
   clearCodexUpstreamHealth,
   clearThreadAccountMap,
+  getEffectiveActiveCodexAccountId,
   getCodexUpstreamHealth,
   isCodexAccountSoftAvoided,
   recordCodexUpstreamOutcome,
 } from "../src/codex/routing";
+import { clearPoolRotationState, POOL_KEY_CODEX } from "../src/codex/pool-rotation";
 import { loadConfig, saveConfig } from "../src/config";
 import { clearUpstreamHostHealth, getUpstreamHostHealth, recordUpstreamHostFailure, upstreamHostHealthKey } from "../src/codex/upstream-host-health";
 import { deriveProviderPresets } from "../src/providers/derive";
@@ -242,6 +244,8 @@ async function startPoolRetryHarness(
     pausedAccountIds?: string[];
     reauthAccountIds?: string[];
     omitCredentialAccountIds?: string[];
+    accountPoolStrategy?: "quota" | "round-robin" | "fill-first";
+    accountPoolStickyLimit?: number;
   } = {},
 ): Promise<PoolRetryHarness> {
   await removeTestDirBestEffort(TEST_DIR);
@@ -249,6 +253,7 @@ async function startPoolRetryHarness(
   process.env.OPENCODEX_HOME = TEST_DIR;
   clearCodexUpstreamHealth();
   clearThreadAccountMap();
+  clearPoolRotationState(POOL_KEY_CODEX);
   clearAccountQuota();
   clearRequestLogsForTests();
   clearAccountNeedsReauth("pool-a");
@@ -298,6 +303,8 @@ async function startPoolRetryHarness(
         : []),
     ],
     activeCodexAccountId: options.activeAccountId ?? "pool-a",
+    ...(options.accountPoolStrategy ? { accountPoolStrategy: options.accountPoolStrategy } : {}),
+    ...(options.accountPoolStickyLimit ? { accountPoolStickyLimit: options.accountPoolStickyLimit } : {}),
     ...(options.accountNamespaces ? { codexAccountNamespaces: options.accountNamespaces } : {}),
     ...(options.pausedAccountIds ? { pausedCodexAccountIds: options.pausedAccountIds } : {}),
     ...(options.visionSidecarModel ? { visionSidecar: { model: options.visionSidecarModel } } : {}),
@@ -2393,6 +2400,41 @@ describe("server local API auth", () => {
       expect(await second.text()).toContain("accepted-b");
       expect(harness.dispatches).toEqual(["acct-pool-a", "acct-pool-b", "acct-pool-b"]);
       expect(getCodexUpstreamHealth("pool-a")).toBeNull();
+    } finally {
+      await stopPoolRetryHarness(harness);
+    }
+  });
+
+  test("capacity rotation commits round-robin state only for the accepted account", async () => {
+    const harness = await startPoolRetryHarness(accountId => accountId === "acct-pool-a"
+      ? new Response(capacityErrorBody("server_is_overloaded"), {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      })
+      : Response.json({ id: `accepted-${accountId}`, status: "completed", output: [] }), {
+      thirdAccount: true,
+      accountPoolStrategy: "round-robin",
+      accountPoolStickyLimit: 1,
+    });
+    try {
+      const first = await harness.request({ threadId: "rr-capacity-thread" });
+      expect(first.status).toBe(200);
+      expect(harness.dispatches).toEqual(["acct-pool-a", "acct-pool-b"]);
+      expect(getEffectiveActiveCodexAccountId(harness.config)).toBe("pool-b");
+
+      const sameThread = await harness.request({ threadId: "rr-capacity-thread" });
+      expect(sameThread.status).toBe(200);
+      expect(harness.dispatches).toEqual(["acct-pool-a", "acct-pool-b", "acct-pool-b"]);
+
+      const nextThread = await harness.request({ threadId: "rr-next-thread" });
+      expect(nextThread.status).toBe(200);
+      expect(harness.dispatches).toEqual([
+        "acct-pool-a",
+        "acct-pool-b",
+        "acct-pool-b",
+        "acct-pool-c",
+      ]);
+      expect(getEffectiveActiveCodexAccountId(harness.config)).toBe("pool-c");
     } finally {
       await stopPoolRetryHarness(harness);
     }

--- a/tests/upstream-transient-retry.test.ts
+++ b/tests/upstream-transient-retry.test.ts
@@ -44,6 +44,25 @@ describe("fetchWithTransientRetry", () => {
     expect(res.status).toBe(400);
   });
 
+  test("semantic gate can preserve a rebuilt transient response without retrying", async () => {
+    let calls = 0;
+    const rebuilt = new Response("capacity", { status: 502, headers: { "x-prepared": "yes" } });
+    const res = await fetchWithTransientRetry(async () => {
+      calls++;
+      return bodyResponse(502);
+    }, {
+      slowAttemptMs: 60_000,
+      prepareTransientRetry: async response => {
+        expect(response.status).toBe(502);
+        return { response: rebuilt, retry: false };
+      },
+    });
+    expect(calls).toBe(1);
+    expect(res).toBe(rebuilt);
+    expect(res.headers.get("x-prepared")).toBe("yes");
+    expect(await res.text()).toBe("capacity");
+  });
+
   test("honors Retry-After header for the backoff delay", async () => {
     let calls = 0;
     const started = Date.now();


### PR DESCRIPTION
## Summary

- Rotate a pre-output Codex Pool request through each eligible account once when OpenAI reports model capacity via `server_is_overloaded`, `slow_down`, or the exact standard capacity message.
- Keep exclusions request-local: rejected accounts do not receive a durable cooldown, health update, active-account promotion, or thread-affinity write, and the next request starts a fresh selection pass.
- Preserve the first capacity response when all accounts are exhausted, and never replay Direct mode, exact-account routes, or an SSE attempt after substantive output has been committed.
- Prefer structured error codes. Exact message matching is a deliberately bounded compatibility heuristic for the observed unstructured upstream response.

## Verification

- `bun run typecheck`
- `bun test tests/codex-capacity-retry.test.ts tests/upstream-transient-retry.test.ts` (12 passed)
- `bun test tests/server-auth.test.ts -t "capacity|stalled 400"` (7 passed)
- `bun run privacy:scan`
- `cd docs-site && bun install --frozen-lockfile && bun run build` (221 pages built)
- `bun run prepush` reached 10,022 passed / 7 skipped / 22 failed. The failures are one local-server `ECONNRESET` cluster in management/data-plane auth and attribution tests; the same failure class reproduces from a clean upstream worktree at the pre-change SHA under Bun 1.3.14.

## Review focus

- Please explicitly review the auth/account-selection boundary: request-local exclusions must not weaken exact-account binding or write rejected capacity attempts into durable account health.
- Please verify the output-commit boundary in `codex-capacity.ts`: only lifecycle-only SSE frames may be replayed; an unknown or output-bearing event permanently commits the attempt.

## Draft readiness

- [x] Focused local validation is green.
- [x] Rebased onto the latest `dev` before publication.
- [ ] All actionable Codex/CodeRabbit findings are resolved.
- [ ] Maintainer security review is complete and the PR is ready to leave draft.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [ ] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pool requests now automatically try each eligible account once when capacity is rejected before output begins.
  * Capacity failures are detected across standard and streaming responses.
  * Rotation skips unavailable accounts, binds the thread to the accepted account, and preserves the initial capacity error if all accounts are exhausted.
  * Direct requests, exact-account selections, and failures after output begins are not retried.

* **Documentation**
  * Added guidance describing account rotation behavior and applicable limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->