### PR TITLE
fix(codex): persist account deletion before cleanup

### DIFF
--- a/src/codex/account-lifecycle.ts
+++ b/src/codex/account-lifecycle.ts
@@ -1,5 +1,10 @@
-import { existsSync } from "node:fs";
-import { getConfigPath, saveConfigPreservingClaudeCode, withConfigMutationLockSync } from "../config";
+import { existsSync, readFileSync } from "node:fs";
+import {
+  atomicWriteFile,
+  getConfigPath,
+  saveConfigPreservingClaudeCode,
+  withConfigMutationLockSync,
+} from "../config";
 import { removeCodexAccountCredential } from "./account-store";
 import { clearAccountNeedsReauth } from "./account-runtime-state";
 import { getMainChatgptAccountId } from "./auth-collision";
@@ -19,6 +24,13 @@ export class CodexAccountDeleteCleanupError extends Error {
   constructor() {
     super("Account deletion was saved, but local credential cleanup did not complete. Retry removal.");
     this.name = "CodexAccountDeleteCleanupError";
+  }
+}
+
+export class CodexAccountDeleteRollbackError extends Error {
+  constructor() {
+    super("Account deletion failed and the previous config could not be restored. Restart before retrying.");
+    this.name = "CodexAccountDeleteRollbackError";
   }
 }
 
@@ -85,14 +97,23 @@ function restoreRuntimeConfig(target: OcxConfig, snapshot: OcxConfig): void {
   Object.assign(target, snapshot);
 }
 
+function restorePersistedConfig(configPath: string, previousBytes: string): void {
+  try {
+    if (readFileSync(configPath, "utf8") === previousBytes) return;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  atomicWriteFile(configPath, previousBytes);
+}
+
 /**
  * Delete a stored account while retaining its selector binding.
  *
  * When the runtime config is backed by an existing config.json, commit the config deletion before
- * credentials or runtime state are destroyed. Pure in-memory callers intentionally remain
- * side-effect free because they have no durable account row to protect. The whole sequence shares
- * the config mutation coordinator so a cooperating writer cannot re-add a persisted account
- * between the durable config commit and credential cleanup.
+ * credentials or runtime state are destroyed. Transient callers intentionally skip durable config
+ * persistence because they have no durable account row to protect. The whole sequence shares the
+ * config mutation coordinator so a cooperating writer cannot re-add a persisted account between
+ * the durable config commit and credential cleanup.
  *
  * Returns true when a picker-visible row disappeared and the catalog must converge.
  */
@@ -100,7 +121,9 @@ export function deleteCodexAccount(runtimeConfig: OcxConfig, accountId: string):
   let cleanupFailed = false;
   const pickerVisibilityChanged = withConfigMutationLockSync(() => {
     const previousConfig = structuredClone(runtimeConfig);
-    const hasPersistedConfig = existsSync(getConfigPath());
+    const configPath = getConfigPath();
+    const hasPersistedConfig = existsSync(configPath);
+    const previousPersistedConfig = hasPersistedConfig ? readFileSync(configPath, "utf8") : undefined;
     const hadStoredAccount = (runtimeConfig.codexAccounts ?? [])
       .some(account => !account.isMain && account.id === accountId);
     const hadVisiblePickerBinding = hadStoredAccount
@@ -115,13 +138,18 @@ export function deleteCodexAccount(runtimeConfig: OcxConfig, accountId: string):
     clearCodexAccountPin(runtimeConfig, accountId);
     if (runtimeConfig.activeCodexAccountId === accountId) runtimeConfig.activeCodexAccountId = undefined;
 
-    if (hasPersistedConfig) {
+    if (previousPersistedConfig !== undefined) {
       try {
         // Persist first for durable configs. Destructive cleanup below must never run for a
         // deletion that failed to commit. Transient configs intentionally skip this write.
         saveConfigPreservingClaudeCode(runtimeConfig);
       } catch (error) {
         restoreRuntimeConfig(runtimeConfig, previousConfig);
+        try {
+          restorePersistedConfig(configPath, previousPersistedConfig);
+        } catch {
+          throw new CodexAccountDeleteRollbackError();
+        }
         throw error;
       }
     }

--- a/src/codex/account-lifecycle.ts
+++ b/src/codex/account-lifecycle.ts
@@ -1,4 +1,5 @@
-import { saveConfigPreservingClaudeCode, withConfigMutationLockSync } from "../config";
+import { existsSync } from "node:fs";
+import { getConfigPath, saveConfigPreservingClaudeCode, withConfigMutationLockSync } from "../config";
 import { removeCodexAccountCredential } from "./account-store";
 import { clearAccountNeedsReauth } from "./account-runtime-state";
 import { getMainChatgptAccountId } from "./auth-collision";
@@ -87,10 +88,11 @@ function restoreRuntimeConfig(target: OcxConfig, snapshot: OcxConfig): void {
 /**
  * Delete a stored account while retaining its selector binding.
  *
- * Config deletion is committed before credentials or runtime state are destroyed. This prevents a
- * failed config write from leaving a still-configured account with a tombstoned credential. The
- * whole sequence shares the config mutation coordinator so a cooperating writer cannot re-add the
- * account between the durable config commit and credential cleanup.
+ * When the runtime config is backed by an existing config.json, commit the config deletion before
+ * credentials or runtime state are destroyed. Pure in-memory callers intentionally remain
+ * side-effect free because they have no durable account row to protect. The whole sequence shares
+ * the config mutation coordinator so a cooperating writer cannot re-add a persisted account
+ * between the durable config commit and credential cleanup.
  *
  * Returns true when a picker-visible row disappeared and the catalog must converge.
  */
@@ -98,6 +100,7 @@ export function deleteCodexAccount(runtimeConfig: OcxConfig, accountId: string):
   let cleanupFailed = false;
   const pickerVisibilityChanged = withConfigMutationLockSync(() => {
     const previousConfig = structuredClone(runtimeConfig);
+    const hasPersistedConfig = existsSync(getConfigPath());
     const hadStoredAccount = (runtimeConfig.codexAccounts ?? [])
       .some(account => !account.isMain && account.id === accountId);
     const hadVisiblePickerBinding = hadStoredAccount
@@ -112,13 +115,15 @@ export function deleteCodexAccount(runtimeConfig: OcxConfig, accountId: string):
     clearCodexAccountPin(runtimeConfig, accountId);
     if (runtimeConfig.activeCodexAccountId === accountId) runtimeConfig.activeCodexAccountId = undefined;
 
-    try {
-      // Persist first. Destructive cleanup below must never run for a deletion that did not become
-      // durable. The auth API's existing follow-up save is intentionally idempotent.
-      saveConfigPreservingClaudeCode(runtimeConfig);
-    } catch (error) {
-      restoreRuntimeConfig(runtimeConfig, previousConfig);
-      throw error;
+    if (hasPersistedConfig) {
+      try {
+        // Persist first for durable configs. Destructive cleanup below must never run for a
+        // deletion that failed to commit. Transient configs intentionally skip this write.
+        saveConfigPreservingClaudeCode(runtimeConfig);
+      } catch (error) {
+        restoreRuntimeConfig(runtimeConfig, previousConfig);
+        throw error;
+      }
     }
 
     try {

--- a/src/codex/account-lifecycle.ts
+++ b/src/codex/account-lifecycle.ts
@@ -1,3 +1,4 @@
+import { saveConfigPreservingClaudeCode, withConfigMutationLockSync } from "../config";
 import { removeCodexAccountCredential } from "./account-store";
 import { clearAccountNeedsReauth } from "./account-runtime-state";
 import { getMainChatgptAccountId } from "./auth-collision";
@@ -12,6 +13,13 @@ import { codexAccountNamespaceEntries, codexAccountPickerEnabled } from "./accou
 import type { OcxConfig } from "../types";
 
 let observedMainChatgptAccountId: string | undefined;
+
+export class CodexAccountDeleteCleanupError extends Error {
+  constructor() {
+    super("Account deletion was saved, but local credential cleanup did not complete. Retry removal.");
+    this.name = "CodexAccountDeleteCleanupError";
+  }
+}
 
 export function purgeCodexAccountRuntimeState(accountId: string): void {
   clearAccountNeedsReauth(accountId);
@@ -71,25 +79,61 @@ export function resetMainCodexAccountIdentityTrackingForTests(): void {
   clearMainAccountCredentialPresence();
 }
 
+function restoreRuntimeConfig(target: OcxConfig, snapshot: OcxConfig): void {
+  for (const key of Object.keys(target) as Array<keyof OcxConfig>) delete target[key];
+  Object.assign(target, snapshot);
+}
+
 /**
  * Delete a stored account while retaining its selector binding.
+ *
+ * Config deletion is committed before credentials or runtime state are destroyed. This prevents a
+ * failed config write from leaving a still-configured account with a tombstoned credential. The
+ * whole sequence shares the config mutation coordinator so a cooperating writer cannot re-add the
+ * account between the durable config commit and credential cleanup.
+ *
  * Returns true when a picker-visible row disappeared and the catalog must converge.
  */
 export function deleteCodexAccount(runtimeConfig: OcxConfig, accountId: string): boolean {
-  const hadStoredAccount = (runtimeConfig.codexAccounts ?? [])
-    .some(account => !account.isMain && account.id === accountId);
-  const hadVisiblePickerBinding = hadStoredAccount
-    && codexAccountPickerEnabled(runtimeConfig)
-    && codexAccountNamespaceEntries(runtimeConfig)
-      .some(([, boundAccountId]) => boundAccountId === accountId);
-  removeCodexAccountCredential(accountId);
-  runtimeConfig.codexAccounts = (runtimeConfig.codexAccounts ?? [])
-    .filter(account => account.isMain || account.id !== accountId);
-  forgetCodexAccountPause(runtimeConfig, accountId);
-  forgetCodexAccountPriority(runtimeConfig, accountId);
-  clearCodexAccountPin(runtimeConfig, accountId);
-  if (runtimeConfig.activeCodexAccountId === accountId) runtimeConfig.activeCodexAccountId = undefined;
-  purgeCodexAccountRuntimeState(accountId);
-  invalidateCodexWebSocketsForAccount(accountId);
-  return hadVisiblePickerBinding;
+  let cleanupFailed = false;
+  const pickerVisibilityChanged = withConfigMutationLockSync(() => {
+    const previousConfig = structuredClone(runtimeConfig);
+    const hadStoredAccount = (runtimeConfig.codexAccounts ?? [])
+      .some(account => !account.isMain && account.id === accountId);
+    const hadVisiblePickerBinding = hadStoredAccount
+      && codexAccountPickerEnabled(runtimeConfig)
+      && codexAccountNamespaceEntries(runtimeConfig)
+        .some(([, boundAccountId]) => boundAccountId === accountId);
+
+    runtimeConfig.codexAccounts = (runtimeConfig.codexAccounts ?? [])
+      .filter(account => account.isMain || account.id !== accountId);
+    forgetCodexAccountPause(runtimeConfig, accountId);
+    forgetCodexAccountPriority(runtimeConfig, accountId);
+    clearCodexAccountPin(runtimeConfig, accountId);
+    if (runtimeConfig.activeCodexAccountId === accountId) runtimeConfig.activeCodexAccountId = undefined;
+
+    try {
+      // Persist first. Destructive cleanup below must never run for a deletion that did not become
+      // durable. The auth API's existing follow-up save is intentionally idempotent.
+      saveConfigPreservingClaudeCode(runtimeConfig);
+    } catch (error) {
+      restoreRuntimeConfig(runtimeConfig, previousConfig);
+      throw error;
+    }
+
+    try {
+      removeCodexAccountCredential(accountId);
+      purgeCodexAccountRuntimeState(accountId);
+      invalidateCodexWebSocketsForAccount(accountId);
+    } catch {
+      // Do not throw through the mutation coordinator after config.json committed: that would roll
+      // back only the SQLite generation transaction, not the already-atomic file replacement.
+      cleanupFailed = true;
+    }
+
+    return hadVisiblePickerBinding;
+  });
+
+  if (cleanupFailed) throw new CodexAccountDeleteCleanupError();
+  return pickerVisibilityChanged;
 }

--- a/tests/codex-account-delete-atomicity.test.ts
+++ b/tests/codex-account-delete-atomicity.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import * as accountStoreModule from "../src/codex/account-store";
 import {
@@ -18,7 +18,7 @@ import {
   getAccountQuota,
   updateAccountQuota,
 } from "../src/codex/quota";
-import { loadConfig, saveConfig } from "../src/config";
+import { getConfigPath, loadConfig, saveConfig } from "../src/config";
 import * as configModule from "../src/config";
 import type { OcxConfig } from "../src/types";
 
@@ -87,6 +87,7 @@ describe("Codex account delete persistence ordering", () => {
   test("a failure after durable config replacement restores the prior config", () => {
     const config = seededConfig();
     const before = structuredClone(config);
+    const beforeBytes = readFileSync(getConfigPath(), "utf8");
     const realSave = configModule.saveConfigPreservingClaudeCode;
     const saveSpy = spyOn(configModule, "saveConfigPreservingClaudeCode")
       .mockImplementation(candidate => {
@@ -98,6 +99,7 @@ describe("Codex account delete persistence ordering", () => {
       expect(() => deleteCodexAccount(config, ACCOUNT_ID)).toThrow("forced post-write failure");
 
       expect(config).toEqual(before);
+      expect(readFileSync(getConfigPath(), "utf8")).toBe(beforeBytes);
       expect(loadConfig().codexAccounts?.some(account => account.id === ACCOUNT_ID)).toBe(true);
       expect(getCodexAccountCredential(ACCOUNT_ID)).not.toBeNull();
       expect(isAccountNeedsReauth(ACCOUNT_ID)).toBe(true);

--- a/tests/codex-account-delete-atomicity.test.ts
+++ b/tests/codex-account-delete-atomicity.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import * as accountStoreModule from "../src/codex/account-store";
+import {
+  getCodexAccountCredential,
+  saveCodexAccountCredential,
+} from "../src/codex/account-store";
+import {
+  CodexAccountDeleteCleanupError,
+  deleteCodexAccount,
+} from "../src/codex/account-lifecycle";
+import {
+  isAccountNeedsReauth,
+  markAccountNeedsReauth,
+} from "../src/codex/account-runtime-state";
+import {
+  getAccountQuota,
+  updateAccountQuota,
+} from "../src/codex/quota";
+import { loadConfig, saveConfig } from "../src/config";
+import * as configModule from "../src/config";
+import type { OcxConfig } from "../src/types";
+
+const TEST_DIR = join(import.meta.dir, ".tmp-codex-account-delete-atomicity");
+const ACCOUNT_ID = "delete-atomicity";
+let previousHome: string | undefined;
+
+function seededConfig(): OcxConfig {
+  const config = loadConfig();
+  config.codexAccounts = [{
+    id: ACCOUNT_ID,
+    email: "delete-atomicity@example.test",
+    isMain: false,
+  }];
+  config.codexAccountNamespaces = { stable: ACCOUNT_ID };
+  config.codexAccountPickerEnabled = true;
+  config.pausedCodexAccountIds = [ACCOUNT_ID];
+  config.codexAccountPriorities = { [ACCOUNT_ID]: 7 };
+  config.activeCodexAccountPinned = ACCOUNT_ID;
+  config.activeCodexAccountId = ACCOUNT_ID;
+  saveConfig(config);
+  saveCodexAccountCredential(ACCOUNT_ID, {
+    accessToken: "delete-access",
+    refreshToken: "delete-refresh",
+    expiresAt: Date.now() + 60_000,
+    chatgptAccountId: "delete-chatgpt-id",
+  });
+  markAccountNeedsReauth(ACCOUNT_ID);
+  updateAccountQuota(ACCOUNT_ID, 42);
+  return config;
+}
+
+beforeEach(() => {
+  previousHome = process.env.OPENCODEX_HOME;
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  mkdirSync(TEST_DIR, { recursive: true });
+  process.env.OPENCODEX_HOME = TEST_DIR;
+});
+
+afterEach(() => {
+  if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = previousHome;
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+});
+
+describe("Codex account delete persistence ordering", () => {
+  test("a config persistence failure leaves the account and destructive state intact", () => {
+    const config = seededConfig();
+    const before = structuredClone(config);
+    const saveSpy = spyOn(configModule, "saveConfigPreservingClaudeCode")
+      .mockImplementation(() => { throw new Error("forced config write failure"); });
+
+    try {
+      expect(() => deleteCodexAccount(config, ACCOUNT_ID)).toThrow("forced config write failure");
+
+      expect(config).toEqual(before);
+      expect(loadConfig().codexAccounts?.some(account => account.id === ACCOUNT_ID)).toBe(true);
+      expect(getCodexAccountCredential(ACCOUNT_ID)).not.toBeNull();
+      expect(isAccountNeedsReauth(ACCOUNT_ID)).toBe(true);
+      expect(getAccountQuota(ACCOUNT_ID)).not.toBeNull();
+    } finally {
+      saveSpy.mockRestore();
+    }
+  });
+
+  test("the durable config deletion happens before credential and runtime cleanup", () => {
+    const config = seededConfig();
+    const realSave = configModule.saveConfigPreservingClaudeCode;
+    const saveSpy = spyOn(configModule, "saveConfigPreservingClaudeCode")
+      .mockImplementation(candidate => {
+        expect(getCodexAccountCredential(ACCOUNT_ID)).not.toBeNull();
+        expect(isAccountNeedsReauth(ACCOUNT_ID)).toBe(true);
+        expect(getAccountQuota(ACCOUNT_ID)).not.toBeNull();
+        realSave(candidate);
+      });
+
+    try {
+      expect(deleteCodexAccount(config, ACCOUNT_ID)).toBe(true);
+    } finally {
+      saveSpy.mockRestore();
+    }
+
+    const persisted = loadConfig();
+    expect(persisted.codexAccounts?.some(account => account.id === ACCOUNT_ID)).toBe(false);
+    expect(persisted.codexAccountNamespaces).toEqual({ stable: ACCOUNT_ID });
+    expect(config.codexAccounts?.some(account => account.id === ACCOUNT_ID)).toBe(false);
+    expect(config.pausedCodexAccountIds).toBeUndefined();
+    expect(config.codexAccountPriorities).toBeUndefined();
+    expect(config.activeCodexAccountPinned).toBeUndefined();
+    expect(config.activeCodexAccountId).toBeUndefined();
+    expect(getCodexAccountCredential(ACCOUNT_ID)).toBeNull();
+    expect(isAccountNeedsReauth(ACCOUNT_ID)).toBe(false);
+    expect(getAccountQuota(ACCOUNT_ID)).toBeNull();
+  });
+
+  test("a cleanup failure keeps the deletion durable and exposes only a fixed recovery error", () => {
+    const config = seededConfig();
+    const removeSpy = spyOn(accountStoreModule, "removeCodexAccountCredential")
+      .mockImplementation(() => {
+        throw new Error("private cleanup detail /private/codex-accounts.json Bearer secret-token");
+      });
+
+    try {
+      let thrown: unknown;
+      try {
+        deleteCodexAccount(config, ACCOUNT_ID);
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeInstanceOf(CodexAccountDeleteCleanupError);
+      expect(String((thrown as Error).message)).toBe(
+        "Account deletion was saved, but local credential cleanup did not complete. Retry removal.",
+      );
+      expect(String((thrown as Error).message)).not.toContain("private");
+      expect(String((thrown as Error).message)).not.toContain("secret-token");
+      expect(loadConfig().codexAccounts?.some(account => account.id === ACCOUNT_ID)).toBe(false);
+      expect(config.codexAccounts?.some(account => account.id === ACCOUNT_ID)).toBe(false);
+      expect(getCodexAccountCredential(ACCOUNT_ID)).not.toBeNull();
+    } finally {
+      removeSpy.mockRestore();
+    }
+
+    // The route is retry-safe even after the durable row is gone: a second delete can finish the
+    // tombstone/runtime cleanup without recreating the account or selector mapping.
+    expect(deleteCodexAccount(config, ACCOUNT_ID)).toBe(false);
+    expect(getCodexAccountCredential(ACCOUNT_ID)).toBeNull();
+    expect(loadConfig().codexAccountNamespaces).toEqual({ stable: ACCOUNT_ID });
+  });
+});

--- a/tests/codex-account-delete-atomicity.test.ts
+++ b/tests/codex-account-delete-atomicity.test.ts
@@ -84,6 +84,29 @@ describe("Codex account delete persistence ordering", () => {
     }
   });
 
+  test("a failure after durable config replacement restores the prior config", () => {
+    const config = seededConfig();
+    const before = structuredClone(config);
+    const realSave = configModule.saveConfigPreservingClaudeCode;
+    const saveSpy = spyOn(configModule, "saveConfigPreservingClaudeCode")
+      .mockImplementation(candidate => {
+        realSave(candidate);
+        throw new Error("forced post-write failure");
+      });
+
+    try {
+      expect(() => deleteCodexAccount(config, ACCOUNT_ID)).toThrow("forced post-write failure");
+
+      expect(config).toEqual(before);
+      expect(loadConfig().codexAccounts?.some(account => account.id === ACCOUNT_ID)).toBe(true);
+      expect(getCodexAccountCredential(ACCOUNT_ID)).not.toBeNull();
+      expect(isAccountNeedsReauth(ACCOUNT_ID)).toBe(true);
+      expect(getAccountQuota(ACCOUNT_ID)).not.toBeNull();
+    } finally {
+      saveSpy.mockRestore();
+    }
+  });
+
   test("the durable config deletion happens before credential and runtime cleanup", () => {
     const config = seededConfig();
     const realSave = configModule.saveConfigPreservingClaudeCode;


### PR DESCRIPTION
## Summary

- Persist Codex account removal in `config.json` before destructive credential/runtime cleanup.
- Keep the whole delete sequence under the shared config mutation coordinator so cooperating writers cannot re-add the account between config commit and cleanup.
- Restore the in-memory config snapshot when config persistence fails, so a failed delete leaves the account, credential, pin/pause/priority state, and runtime health intact.
- Convert post-commit cleanup failures to a fixed recovery error without reflecting credential-store paths or secret-bearing error details.
- Keep retained account-selector mappings unchanged so exact routes continue to fail closed and a later re-add can recover the same selector.

## Root cause

`deleteCodexAccount()` tombstoned the credential and purged runtime state before the caller persisted the config mutation. If `saveConfigPreservingClaudeCode()` then failed, the durable config could still contain the account while its credential was already tombstoned and its live state had been cleared.

## Tests

Added `tests/codex-account-delete-atomicity.test.ts` covering:

- config persistence failure leaves the configured account and destructive state intact;
- successful deletion commits config before credential/runtime cleanup;
- cleanup failure keeps the config deletion durable, exposes only a fixed privacy-safe recovery error, and remains retry-safe.

## Notes

This is the separate non-blocking hardening follow-up identified while reviewing #1303. It is intentionally scoped to account-delete persistence ordering and does not change the account-picker feature itself.

CI should run the repository validation for this branch; no local checkout was available in this session to run Bun tests before publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account deletion reliability by saving configuration changes before removing credentials and runtime data.
  * Failed configuration saves now preserve the account and its associated state.
  * Cleanup failures now provide a clear recovery error while keeping the deletion safely recorded.
  * Account deletion cleanup can be retried safely after an interrupted operation.

* **Tests**
  * Added coverage for deletion ordering, rollback behavior, failure handling, and retry-safe cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->