### PR TITLE
test(omp): close final #1109 path-contract review gap

### DIFF
--- a/tests/omp-path-contract.test.ts
+++ b/tests/omp-path-contract.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ompModelsConfigPath } from "../src/clients/config-export";
+
+function withTempHome(run: (home: string) => void): void {
+  const home = mkdtempSync(join(tmpdir(), "opencodex-omp-home-"));
+  try {
+    run(home);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+describe("OMP path contract regressions", () => {
+  test("PI_CONFIG_DIR remains home-relative for slash- and tilde-prefixed values", () => {
+    withTempHome(home => {
+      for (const value of ["/custom-omp", "~/.custom-omp"]) {
+        expect(ompModelsConfigPath({ PI_CONFIG_DIR: value } as NodeJS.ProcessEnv, home)).toBe(
+          join(home, value, "agent", "models.yml"),
+        );
+      }
+    });
+  });
+
+  test("a named profile ignores PI_CODING_AGENT_DIR", () => {
+    withTempHome(home => {
+      const configDir = "custom-omp";
+
+      expect(ompModelsConfigPath({
+        OMP_PROFILE: "work",
+        PI_CONFIG_DIR: configDir,
+        PI_CODING_AGENT_DIR: join(home, "wrong-agent"),
+      } as NodeJS.ProcessEnv, home)).toBe(
+        join(home, configDir, "profiles", "work", "agent", "models.yml"),
+      );
+    });
+  });
+});


### PR DESCRIPTION
Maintainer follow-up for #1109. #1109 is merged; this PR now contains only focused OMP path-contract regression coverage on top of current `dev`.

Current scope:
- slash- and tilde-prefixed `PI_CONFIG_DIR` values stay home-relative under OMP's `path.join(home, value)` contract
- named profiles ignore `PI_CODING_AGENT_DIR`
- tests use unique temporary home directories so legacy `models.yaml` files or parallel runs cannot affect the result

No production behavior changes. Merge only after fresh current-head CI is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for resolving configuration paths relative to the home directory.
  * Added coverage ensuring configured paths take priority when selecting named profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->