### PR TITLE
feat(vision): filter sidecar describers by real image-input capability

### DIFF
--- a/devlog/_plan/260809_vision_sidecar_model_filter/000_plan.md
+++ b/devlog/_plan/260809_vision_sidecar_model_filter/000_plan.md
@@ -1,0 +1,154 @@
+# 260809 — vision sidecar model eligibility filter
+
+Base: `origin/dev@632743269`, worktree `/Users/jun/.codex/worktrees/34b7/opencodex`.
+Cycle: docs-first. This unit writes the roadmap; no production code lands in this
+work-phase.
+
+## Objective
+
+The dashboard's Vision sidecar model picker currently offers **every** model whose
+provider is `openai` or `anthropic`, with no regard for whether that model can
+actually accept an image. Users have been asking for more models, and the honest
+answer has two halves:
+
+1. The picker is simultaneously **too wide** (it lists models that cannot see) and
+   **too narrow** (it hard-codes two provider names instead of asking about
+   capability).
+2. The sidecar has exactly two executors — the OpenAI Responses forward path
+   (`src/vision/describe.ts`) and the Anthropic Messages path
+   (`src/vision/anthropic-describe.ts`). A model that is not reachable by one of
+   those two wire protocols cannot be a vision sidecar today no matter what the
+   picker shows.
+
+So the deliverable is a real **vision-capability filter** on both sides, plus a
+guaranteed baseline entry per side, plus a dashboard card that shows the allowed
+list in the compact delegation-panel form factor.
+
+## Constraints
+
+- The proxy is Bun-native TypeScript; `bun run typecheck` and `bun run test` gate
+  every layer.
+- `src/vision/reasoning.ts` already owns effort normalization. The filter must not
+  duplicate or contradict `normalizeVisionReasoningForModel`.
+- The GUI must not be the only gate: `PUT /api/sidecar-settings` has to reject an
+  ineligible vision model itself (`PLAN-BYPASS-NAMED-01` below).
+- No change to routing, provider registry semantics, or the web-search sidecar's
+  behavior. Shared plumbing may be extracted, but web-search's option list keeps
+  its current contents in this unit.
+
+## The trap that shapes the whole design
+
+`applyProviderConfigHints` (`src/codex/catalog/provider-fetch.ts:574-582`) **adds**
+`"image"` to a model's `inputModalities` when the model is listed in
+`provider.noVisionModels`. That is deliberate: `noVisionModels` marks models the
+PROXY describes images for, and the Codex app gates attachments client-side on
+`input_modalities`, so a text-only entry would block the image before the sidecar
+could ever run.
+
+The consequence for this unit is load-bearing: **catalog `inputModalities` is not a
+truthful vision-capability signal.** A model that is in `noVisionModels` advertises
+`["text","image"]` precisely *because* it is blind. Filtering on `inputModalities`
+alone would let a blind model be chosen as the describer for other blind models.
+
+Therefore eligibility is a conjunction:
+
+```
+eligible(model) = advertisesImageInput(model) AND NOT isSidecarConsumer(model)
+```
+
+where `isSidecarConsumer` is `modelInList(provider.noVisionModels, id)` — the same
+predicate `planVisionSidecar` uses to decide a model needs describing.
+
+## Work-phase map (dependency-ordered, PHASE-SPLIT-01)
+
+| # | Doc | Phase | Consumes |
+|---|-----|-------|----------|
+| 0 | this unit | roadmap | — |
+| 1 | `010_vision_eligibility_core.md` | eligibility predicate + baselines in `src/vision/eligibility.ts` | catalog metadata accessors |
+| 2 | `020_management_api_allowed_models.md` | `/api/sidecar-settings` exposes the allowed list and rejects ineligible writes | phase 1's predicate |
+| 3 | `030_dashboard_vision_card.md` | dashboard card restyle + server-provided options | phase 2's payload |
+| 4 | `040_stack_publication.md` | branch cascade, push, stacked PRs | phases 1-3 |
+
+Each phase closes with something independently verifiable: phase 1 with unit tests
+over the predicate, phase 2 with route tests over both the 200 and the 400 path,
+phase 3 with `lint:gui` + `build:gui` + a read-back screenshot, phase 4 with
+`gh pr view` base refs.
+
+## Verifiers (PLAN-VERIFIER-REAL-01)
+
+Run before this plan was written, from the worktree root:
+
+| Command | Exit | Reads this unit's target? |
+|---|---|---|
+| `bun run typecheck` | 0 | yes — `tsconfig.json` compiles `src/**` and `gui/src/**`, which is where every phase writes |
+| `bun run test` | 0 | yes — `tests/*.test.ts` is a flat glob over the whole directory, so a new `tests/vision-eligibility.test.ts` is picked up without configuration |
+| `bun run lint:gui` | 0 | yes for phase 3 only — `gui/eslint.config.js` lints `gui/src/**`; it does **not** observe `src/**`, so it is not a gate for phases 1-2 |
+| `bun run build:gui` | 0 | yes for phase 3 — Vite builds `gui/src` into `gui/dist` |
+| `bun run privacy:scan` | 0 | partially — it scans the repo including `devlog/`, so it observes these documents, but it asserts nothing about the filter's behavior |
+
+`bun run lint:gui` does **not** observe `src/vision/*`; phase 1 and 2 acceptance
+rows are covered by `typecheck` + `test`, not by lint.
+
+## Field chain (PLAN-FIELD-CHAIN-01)
+
+The unit adds one field to a wire payload — `visionModels` on the
+`/api/sidecar-settings` GET response — and one derived value, the eligibility
+boolean. Its chain:
+
+| Stage | Location | Note |
+|---|---|---|
+| creation | `visionEligibleModelOptions()` in `src/vision/eligibility.ts` (NEW) | derives from `listManagementModelRows` output plus config |
+| serialization | `src/server/management/config-routes.ts` GET **and PUT** `/api/sidecar-settings` | both response bodies, so an optimistic update and a refetch cannot disagree |
+| deserialization | `SidecarData` in `gui/src/pages/dashboard-shared.ts` | new optional `visionModels?: SidecarModelOption[]` — optional so a stale GUI against a new server, or a new GUI against a cached response, degrades to the old client-side list rather than rendering an empty picker |
+| consumers | `use-dashboard-data.ts`: NEW `visionModels` memo + three field-by-field writes in `saveSidecar` (optimistic `next`, success `setSidecar`, session cache) and the hook's return object; `dashboard-overview-sections.tsx` (the vision `Select`) | the existing `sidecarModels` memo stays as-is and keeps serving web-search — `N/A` for it by design. The poll effect assigns `data.sidecar` wholesale, so it needs no edit; `CachedControls.sidecar` is typed `SidecarData`, so the optional field flows without a type change |
+| validation | `PUT /api/sidecar-settings` in the same file, and the `visionSidecar` branch of `PUT /api/claude-code` in `agent-settings-routes.ts` | rejects a **provably blind** `vision.model` with 400; an unknown id is allowed |
+
+No enum gains a value in this unit, so the enum-consumer sweep is `N/A`.
+
+## Bypass (PLAN-BYPASS-NAMED-01)
+
+| Field | Value |
+|---|---|
+| tier | E4 — server-side request validation |
+| executing surface | `PUT /api/sidecar-settings` in `src/server/management/config-routes.ts`, plus the Claude Code vision override in `src/server/management/agent-settings-routes.ts` |
+| known bypass | editing `~/.opencodex/config.json` by hand and restarting; the config loader does not re-validate `visionSidecar.model` |
+| residual risk | a hand-edited blind model stays configured and the sidecar produces useless descriptions; it fails at request time, not at write time |
+| wording downgrade | yes, and deliberately. The gate rejects only models **positively known** to be unable to see. It is enforcement against a *proven-blind* selection and no barrier at all against an *unknown* one |
+| final layer | none. `planVisionSidecar` stays permissive by design, so an operator can still point at a model the catalog has never heard of |
+
+**The gate and the picker are not the same set** (audit round 1, blocker 1). The
+picker suggests; the gate forbids. Deriving one from the other would reject every
+unknown id — including `custom-vision`, which
+`tests/vision-reasoning-contract.test.ts:148-151` asserts must still save with
+`providers: {}`. The rule is therefore:
+
+```
+picker option  ⇐  eligible AND reachable by an executor AND known to some source
+PUT rejection  ⇐  modelAcceptsImageInput(...) === false     (never on undefined)
+```
+
+## Scope boundary: the Claude Code override (audit round 1, blocker 5)
+
+Claude Code carries its own vision sidecar override
+(`gui/src/pages/claude-code-sections.tsx:154-205`, persisted through
+`PUT /api/claude-code`). Two halves, decided separately:
+
+- **Server: in scope.** The eligibility gate covers every route that sets a vision
+  describer, so `agent-settings-routes.ts` gets the same rejection. A second
+  unguarded write path would make the first gate decorative.
+- **GUI: out of scope.** That surface is a freeform `<input>` with a `<datalist>`
+  of suggestions, not a constrained picker. Narrowing a deliberately freeform
+  field is a different product decision and is not smuggled into this unit.
+
+Requirement 2 ("both sides show only allowed models") is therefore read as: both
+*backend families* (OpenAI and Anthropic) inside the dashboard vision picker —
+which is the control the request was anchored on.
+
+## Out of scope
+
+- A third sidecar executor (e.g. a Gemini or xAI vision path). Adding a provider
+  family here would change routing surface, not just the picker, and belongs to its
+  own unit.
+- Changing which models `noVisionModels` contains.
+- Web-search sidecar option filtering.
+- Merging the resulting PR stack. Publication is authorized; merging is not.

--- a/devlog/_plan/260809_vision_sidecar_model_filter/001_capability_signal_inventory.md
+++ b/devlog/_plan/260809_vision_sidecar_model_filter/001_capability_signal_inventory.md
@@ -1,0 +1,103 @@
+# 001 — where a model's image capability actually comes from
+
+Research doc. No diffs here; the diffs live in the decade docs.
+
+## The four sources, in the order the runtime consults them
+
+1. **Native pinned metadata** — `src/codex/catalog/metadata.ts:117`
+   `nativeInputModalities(slug)` reads `src/codex/data/upstream-models.json`.
+   Verified contents for the seven supported native slugs:
+
+   ```
+   gpt-5.6-sol   ["text","image"]
+   gpt-5.6-terra ["text","image"]
+   gpt-5.6-luna  ["text","image"]
+   gpt-5.5       ["text","image"]
+   gpt-5.4       ["text","image"]
+   gpt-5.4-mini  ["text","image"]
+   gpt-5.3-codex-spark  (absent from snapshot → falls back to ["text","image"])
+   ```
+
+   So **every** native OpenAI slug is image-capable. The native side of the picker
+   is not where over-listing happens.
+
+2. **Generated vendor metadata** — `src/generated/model-metadata.ts`, `DATA` rows
+   whose 4th column is a comma-joined modality string. `getModelMetadata(provider,
+   id)` and `getModelMetadataCaseInsensitive` return `input?: ("text"|"image"|"video")[]`.
+   Every `anthropic` row in that table carries `text,image`, including
+   `claude-haiku-4-5` and `claude-haiku-4-5-20251001`.
+
+3. **Live catalog rows** — `CatalogModel.inputModalities`, populated by
+   `catalogHintsFromModelsApiItem` (`provider-fetch.ts:938`) from the provider's
+   own `/models` payload, then post-processed by `applyProviderConfigHints`.
+
+4. **Operator config** — `provider.modelInputModalities[id]`, which
+   `configuredInputModalities` treats as the base before the `noVisionModels`
+   augmentation.
+
+## Live evidence from this machine
+
+`GET /api/models` (admin token, port 10100) returned 11 providers. The two the
+picker currently sources from:
+
+```
+openai     7 rows, inputModalities: absent on every row
+anthropic 11 rows, inputModalities: absent on every row
+```
+
+That absence is the second load-bearing fact. `listManagementModelRows`
+(`src/server/management/model-rows.ts:45-54`) builds native rows by hand and never
+attaches `inputModalities`; anthropic rows come through `dedupedRouted` from the
+catalog, where the anthropic provider's `/models` response also omits it.
+
+**A naive `row.inputModalities?.includes("image")` filter would therefore empty the
+picker completely.** Unknown must not be read as zero. The predicate has to fall
+back to pinned/generated metadata before concluding a model cannot see, and when
+all four sources are silent it must stay permissive.
+
+## The inverted signal
+
+`applyProviderConfigHints` (`provider-fetch.ts:574-582`) appends `"image"` to a
+model listed in `provider.noVisionModels`. `tests/catalog-vision-sidecar-modalities.test.ts`
+asserts exactly this: `glm-5.2`, a text-only model, comes out as
+`["text","image"]`.
+
+`noVisionModels` is also the trigger for the sidecar itself —
+`planVisionSidecar` (`src/vision/index.ts:237`) returns undefined unless
+`modelInList(provider.noVisionModels, modelId)`. One list, two opposite meanings
+depending on which side of the sidecar you stand on.
+
+Consequence for the predicate: membership in `noVisionModels` is a **hard
+disqualifier** for being a describer, and it must be checked before the modality
+list, because the modality list was rewritten by that very membership.
+
+## Which models a sidecar can actually reach
+
+`planVisionSidecar` has exactly two branches:
+
+- `backend === "anthropic"` → `describeImageAnthropic`, which requires an enabled
+  `adapter: "anthropic"`, `authMode: "oauth"` provider with a non-reauth active
+  account (`findAnthropicVisionProvider`, `src/vision/index.ts:171`).
+- `backend === "openai"` → `describeImage` against
+  `${forwardProvider.baseUrl}/responses`, requiring a resolved OpenAI forward
+  sidecar (ChatGPT login).
+
+There is no third executor. A `xai/grok-4.5` row, image-capable though it is,
+has no code path that would describe an image today. Eligibility must therefore be
+scoped to the two backend families, not opened to every image-capable row in the
+catalog — otherwise the picker would offer selections that silently produce no
+plan at all.
+
+That is the honest answer to "can we allow other models?": **within the two
+supported wire protocols, yes — and the current filter is the wrong shape.
+Outside them, not without a new executor**, which this unit scopes out.
+
+## Baseline requirement
+
+The user requires `gpt-5.6-luna` to always appear when the GPT side is enabled and
+a haiku model to always appear when Claude is registered. Both are image-capable by
+the tables above, so the baselines are not exceptions to the capability rule — they
+are a **presence** guarantee against an empty or unfetched catalog, which the live
+evidence above shows is a real state (`/api/models` can be cold, and
+`fetchAllModels` can return nothing while a provider is cooling down after a fetch
+failure).

--- a/devlog/_plan/260809_vision_sidecar_model_filter/002_audit_synthesis.md
+++ b/devlog/_plan/260809_vision_sidecar_model_filter/002_audit_synthesis.md
@@ -1,0 +1,138 @@
+# 002 — A-phase audit synthesis (round 1)
+
+Reviewer: independent subagent on `xai/grok-4.5`, high effort, read-only.
+Verdict: `GO-WITH-FIXES (blockers=5)`.
+
+Every blocker below was **re-verified by the main agent against the tree** before
+being accepted; none was taken on the reviewer's word.
+
+## Root-cause synthesis
+
+Blockers 1 and 2 are one defect, not two. I wrote the write-gate as *"reject what
+is not in the picker"* while writing the bypass table as *"an operator may point
+at a model the catalog does not know about"*. Those cannot both hold: an unknown
+id is absent from the option list by construction, so the gate would reject
+exactly the case the bypass table promises to allow.
+
+The correct rule follows from the tri-state the predicate already returns:
+
+```
+option list  = eligible AND reachable AND known   (a suggestion — may be narrow)
+write gate   = reject only when modelAcceptsImageInput(...) === false  (a proof of harm)
+```
+
+`undefined` (nothing knows) belongs on the permissive side of the gate and the
+conservative side of the list. Conflating "not suggested" with "forbidden" is the
+error; the fix is to stop deriving the gate from the list.
+
+Blockers 3, 4, 6, 8 are all under-specification of a real call site — I named a
+behavior and left the implementer to find the writes. Blocker 5 is a scope claim
+I made too broadly.
+
+## Accept / rebut
+
+| # | Sev | Finding | Decision | Verification I ran |
+|---|-----|---------|----------|--------------------|
+| 1 | Critical | PUT 400 would reject unknown ids and break an existing contract test | **ACCEPT** | `tests/vision-reasoning-contract.test.ts:148-151` really does assert `putVision(custom, { model: "custom-vision" })` → 200 with `providers: {}`. My gate would have turned that red. |
+| 2 | High | GET grandfathers the configured model, PUT does not | **ACCEPT** | Same root cause as 1; fixed by the same rule change. |
+| 3 | High | `saveSidecar` drops `visionModels` on the success path | **ACCEPT** | `use-dashboard-data.ts:480-485`: `setSidecar({ webSearch: data.webSearch, vision: data.vision })` and the cache write both enumerate fields explicitly, so a new field is silently dropped. Three write sites, not one. |
+| 4 | High | `config.providers.openai && !disabled` is not this repo's "OpenAI side enabled" | **ACCEPT** | `listOpenAiForwardSidecarCandidates` (`src/providers/openai-sidecar.ts:55-70`) additionally requires `isCanonicalOpenAiForwardProvider` (`openai-tiers.ts:32-36`): `openai-responses` + `forward` + canonical base URL. My predicate was strictly broader and asymmetric with the Anthropic side. |
+| 5 | High | Requirement 2 ignores the Claude Code vision override | **ACCEPT IN PART** | `gui/src/pages/claude-code-sections.tsx:154-205` is a freeform `<input>` with a `<datalist>`, not a picker, and `agent-settings-routes.ts:1002-1014` only type-checks `model`. I accept the **server** half (the gate must cover every route that sets a vision describer) and rebut the **GUI** half (a freeform text input is deliberately freeform; narrowing its suggestions is a different product decision). Recorded as an explicit scope statement, not silence. |
+| 6 | Medium | Card does not really adopt the delegation form factor | **ACCEPT** | `dash-delegation-summary` is applied to the *panel* at line 102; my draft put it on an inner row where `.dash-sidecar-card__row` already supplies the same flex rules. Redundant, and it would not match. |
+| 7 | Medium | Wrong seam named for route tests | **ACCEPT** | The real seam is `handleManagementAPI` + `tests/helpers/management-auth`, demonstrated by `tests/vision-reasoning-contract.test.ts:12-31`. `model-routes.ts` documents a `deps.saveConfigPreservingClaudeCode` injection that the sidecar route does not use — it calls the bare import at line 469. |
+| 8 | Medium | Compact CSS rule proposed in the wrong file | **ACCEPT** | The `min-width: clamp(10rem, 24vw, 11.5rem)` it must override lives in `styles-dashboard-workspace.css:104-110`, not `styles.css`. |
+| 9 | Low | Stale line citations | **ACCEPT** | Re-pinned below. |
+| 10 | Low | docs-site / CLI consumers omitted | **ACCEPT** | `src/cli/agent.ts` writes through the same PUT, so it inherits the corrected gate for free; `docs-site/src/content/docs/guides/sidecars.md` needs a sentence (SOT-SYNC-01, phase 2's C). |
+
+Reviewer claims I **rebut**: none outright. The one partial rebuttal (5) is scoped,
+not dismissed.
+
+Reviewer claims I independently confirmed as *correct in my favor*: the
+`:last-child` selector is robust (`Select` renders sibling `.custom-select` roots),
+and the delegation panel itself needs no change because it already maps efforts to
+raw values (`dashboard-overview-sections.tsx:119-122`). So comment 2's "여기처럼"
+is a pattern reference, not a request to edit that panel.
+
+## Amendments applied
+
+1. `010` — `visionEligibleModelOptions` unchanged, but the doc now states the
+   list/gate asymmetry explicitly and adds a test asserting the tri-state.
+2. `020` — the 400 guard is rewritten to fire only on
+   `modelAcceptsImageInput(...) === false`; `enabledVisionBackends` now uses
+   `listOpenAiForwardSidecarCandidates`; the same guard is applied to the Claude
+   Code vision override route; the seam is named correctly; a docs-site sync line
+   is added; two tests are added (unknown id keeps 200, Claude Code route rejects).
+3. `030` — the card becomes `panel dash-delegation-summary`; all three
+   `visionModels` write sites are enumerated; the CSS rule moves to
+   `styles-dashboard-workspace.css`.
+4. `000` — bypass table restated so the enforcement claim matches the code, and
+   the Claude Code scope boundary is written down.
+
+## Re-pinned anchors
+
+| Symbol | Real location |
+|---|---|
+| `planVisionSidecar` | `src/vision/index.ts:231` (its `modelInList` guard at 238) |
+| `findAnthropicVisionProvider` | `src/vision/index.ts:172` |
+| vision card markup | `gui/src/pages/dashboard-overview-sections.tsx:288-311` |
+| delegation panel | `gui/src/pages/dashboard-overview-sections.tsx:102-104` |
+| delegation raw effort labels | `gui/src/pages/dashboard-overview-sections.tsx:119-122` |
+| sidecar select min-width | `gui/src/styles-dashboard-workspace.css:104-110` |
+| `saveConfigPreservingClaudeCode` call in PUT | `src/server/management/config-routes.ts:469` |
+
+Confirmed accurate as originally written: `provider-fetch.ts:574-582`,
+`config-routes.ts:380-393`, reasoning enum check `422-423`, `model-rows.ts:45-54`,
+`use-dashboard-data.ts:454-462`.
+
+# Round 2
+
+Same reviewer, re-audit of the amended documents. Verdict:
+`GO-WITH-FIXES (blockers=1)`. Eight of nine prior findings confirmed **CLOSED**,
+including the reviewer walking the `custom-vision` input through the amended
+predicate step by step and reaching `undefined` (so the contract test stays
+green), and confirming `.dash-delegation-controls .custom-select:last-child`
+touches no other surface (`dash-delegation-controls` has exactly two users, and
+the delegation panel's last child is a `<button>`).
+
+## N1 (High) — ACCEPTED, and it was a real defect
+
+Two halves, both verified by me before accepting:
+
+1. **The fenced JSX still shipped the old structure** while the prose above it
+   described the new one. An implementer executing the fence verbatim would have
+   re-applied blocker 6. The fence is now rewritten to match.
+2. **The dual-class panel would not have produced a row.**
+   `.dash-sidecar-card` declares `flex-direction: column`
+   (`gui/src/styles-dashboard-workspace.css:84-89`) and `.dash-delegation-summary`
+   (`gui/src/styles.css:2245-2250`) sets `display/align-items/justify-content/gap`
+   but **never** `flex-direction`. Different properties do not compete, so import
+   order is irrelevant — column would simply have survived. My "confirm in render
+   grounding" hedge was wrong: this was decidable statically, and I should have
+   decided it. Fixed by dropping `dash-sidecar-card` from the vision panel and
+   adding `.dash-vision-card { min-width: 0; }` for the only property the grid
+   cell actually needed.
+
+## N2 (Medium) — ACCEPTED as an explicit product decision, not a silent residual
+
+A proven-blind configured model stays visible in GET but is rejected on re-save.
+Documented in `020` case 2 with the reasoning: effort-only edits bypass the model
+guard, and hiding the configured id would show a different model than the one the
+config actually names.
+
+## N3 (Low) — ACCEPTED
+
+`visionCandidateRows` is now written out as concrete code so layer 2 is
+copy-paste complete.
+
+## Stale crumbs — both fixed
+
+`000`'s field-chain row still named only the `sidecarModels` memo and a single
+serialization site; it now names the `visionModels` memo, all three `saveSidecar`
+writes, both serialization sites, and the second validation route.
+
+## My own measurement, added to 020
+
+I enumerated what the synthesized fallback candidate can reject: exactly
+`codex-mini-latest`, `gpt-4`, `o3-mini` on the openai side and nothing on the
+anthropic side. All three are genuinely blind, so there is no false-positive
+surface.

--- a/devlog/_plan/260809_vision_sidecar_model_filter/010_vision_eligibility_core.md
+++ b/devlog/_plan/260809_vision_sidecar_model_filter/010_vision_eligibility_core.md
@@ -1,0 +1,257 @@
+# 010 — phase 1: vision eligibility core
+
+Layer 1 of the stack. Branch `codex/260809-vision-eligibility-core`, base
+`origin/dev`.
+
+Thesis: **one predicate decides which models may describe an image, and it lives
+next to the sidecar that uses it.**
+
+## Files
+
+| Path | Action |
+|---|---|
+| `src/vision/eligibility.ts` | NEW |
+| `src/vision/index.ts` | MODIFY (re-export only) |
+| `tests/vision-eligibility.test.ts` | NEW |
+
+No GUI and no route changes in this layer — it must stand alone as "the predicate
+plus its proof".
+
+## NEW `src/vision/eligibility.ts`
+
+```ts
+/**
+ * Which models may serve AS the vision sidecar (the describer), as opposed to the
+ * models the sidecar describes FOR.
+ *
+ * Two rules make this non-obvious, and both are load-bearing:
+ *
+ * 1. `provider.noVisionModels` marks models the proxy describes images for, and
+ *    `applyProviderConfigHints` deliberately ADDS "image" to their advertised
+ *    input modalities so the Codex app does not block the attachment client-side.
+ *    A blind model therefore advertises image input. Membership in that list is a
+ *    hard disqualifier here, checked BEFORE the modality list it rewrote.
+ * 2. Catalog rows frequently omit `inputModalities` entirely (the live
+ *    `/api/models` response carries none for either openai or anthropic rows).
+ *    Unknown is not zero: when no source can speak, the model stays eligible
+ *    rather than silently vanishing from the picker.
+ */
+import { modelInList, type OcxConfig } from "../types";
+import { getModelMetadataCaseInsensitive, resolveMetadataProvider } from "../generated/model-metadata";
+import { nativeInputModalities } from "../codex/catalog/metadata";
+import { SUPPORTED_NATIVE_OPENAI_SLUGS } from "../codex/catalog/native-models";
+
+/** The two wire protocols `planVisionSidecar` can actually dispatch to. */
+export type VisionSidecarBackend = "openai" | "anthropic";
+
+/** Guaranteed entry per backend: cheap, image-capable, and present in every deployment. */
+export const BASELINE_VISION_MODELS: Record<VisionSidecarBackend, string> = {
+  openai: "gpt-5.6-luna",
+  anthropic: "claude-haiku-4-5",
+};
+
+export interface VisionCandidateModel {
+  provider: string;
+  id: string;
+  inputModalities?: string[];
+  native?: boolean;
+}
+
+export interface VisionModelOption {
+  value: string;
+  label: string;
+  backend: VisionSidecarBackend;
+  /** True when the row is a guaranteed baseline rather than a catalog discovery. */
+  baseline?: boolean;
+}
+
+function advertisesImageInput(modalities: readonly string[] | undefined): boolean | undefined {
+  if (!modalities || modalities.length === 0) return undefined;
+  return modalities.includes("image");
+}
+
+/** Vendor-table modalities for a routed row, or undefined when the table has no opinion. */
+function metadataImageInput(provider: string, modelId: string): boolean | undefined {
+  const resolved = resolveMetadataProvider(provider) ?? provider;
+  const meta = getModelMetadataCaseInsensitive(resolved, modelId);
+  return advertisesImageInput(meta?.input);
+}
+
+/**
+ * Is this model listed as one the sidecar describes FOR? Such a model cannot be
+ * the describer, and its advertised modalities are untrustworthy.
+ */
+export function isVisionSidecarConsumer(config: Pick<OcxConfig, "providers">, providerName: string, modelId: string): boolean {
+  const provider = config.providers?.[providerName];
+  return provider ? modelInList(provider.noVisionModels, modelId) : false;
+}
+
+/**
+ * Can this model accept an image on the wire? Sources are consulted in descending
+ * trustworthiness; the first that speaks wins. `undefined` means nothing knows,
+ * which callers treat as eligible.
+ */
+export function modelAcceptsImageInput(
+  config: Pick<OcxConfig, "providers">,
+  candidate: VisionCandidateModel,
+): boolean | undefined {
+  if (isVisionSidecarConsumer(config, candidate.provider, candidate.id)) return false;
+  if (candidate.native || SUPPORTED_NATIVE_OPENAI_SLUGS.has(candidate.id)) {
+    return advertisesImageInput(nativeInputModalities(candidate.id)) ?? true;
+  }
+  const fromRow = advertisesImageInput(candidate.inputModalities);
+  if (fromRow !== undefined) return fromRow;
+  return metadataImageInput(candidate.provider, candidate.id);
+}
+
+/** Eligible = not a sidecar consumer, and not positively known to be text-only. */
+export function isVisionEligibleModel(
+  config: Pick<OcxConfig, "providers">,
+  candidate: VisionCandidateModel,
+): boolean {
+  return modelAcceptsImageInput(config, candidate) !== false;
+}
+
+/** Which backend would describe through this row, or undefined when neither can. */
+export function visionBackendForCandidate(
+  config: Pick<OcxConfig, "providers">,
+  candidate: VisionCandidateModel,
+): VisionSidecarBackend | undefined {
+  if (candidate.native || candidate.provider === "openai") return "openai";
+  const adapter = config.providers?.[candidate.provider]?.adapter;
+  if (adapter === "anthropic") return "anthropic";
+  return undefined;
+}
+
+/**
+ * The picker's option list: every eligible row reachable by one of the two
+ * executors, plus each enabled side's baseline, de-duplicated and stably ordered
+ * (openai side first, baselines first within a side).
+ */
+export function visionEligibleModelOptions(
+  config: Pick<OcxConfig, "providers">,
+  candidates: readonly VisionCandidateModel[],
+  enabledBackends: readonly VisionSidecarBackend[],
+): VisionModelOption[] {
+  const enabled = new Set(enabledBackends);
+  const byValue = new Map<string, VisionModelOption>();
+
+  for (const backend of ["openai", "anthropic"] as const) {
+    if (!enabled.has(backend)) continue;
+    const id = BASELINE_VISION_MODELS[backend];
+    byValue.set(id, { value: id, label: id, backend, baseline: true });
+  }
+  for (const candidate of candidates) {
+    const backend = visionBackendForCandidate(config, candidate);
+    if (!backend || !enabled.has(backend)) continue;
+    if (!isVisionEligibleModel(config, candidate)) continue;
+    if (byValue.has(candidate.id)) continue;
+    byValue.set(candidate.id, { value: candidate.id, label: candidate.id, backend });
+  }
+
+  const order = (option: VisionModelOption) =>
+    (option.backend === "openai" ? 0 : 2) + (option.baseline ? 0 : 1);
+  return [...byValue.values()].sort((a, b) => order(a) - order(b) || a.value.localeCompare(b.value));
+}
+```
+
+### The suggestion list and the write gate are different questions
+
+`visionEligibleModelOptions` answers *"what should the picker suggest?"* and is
+deliberately narrow: it emits only rows an executor can reach and some source has
+heard of. `modelAcceptsImageInput` answers *"can we prove this model cannot
+see?"* and is the ONLY input to phase 2's rejection.
+
+Absence from the option list must never imply rejection (audit round 1,
+blocker 1). An unknown id like `custom-vision` is absent from the list yet returns
+`undefined` — not `false` — from the predicate, and
+`tests/vision-reasoning-contract.test.ts:148-151` requires it to keep saving.
+Never let a caller derive the gate from the list.
+
+### Which backends are "enabled"
+
+The caller supplies `enabledBackends`; this module does not read credentials.
+That keeps the predicate pure and testable, and it keeps credential inspection in
+`src/vision/index.ts`, which already owns `findAnthropicVisionProvider`. Phase 2
+computes the set as:
+
+- `"anthropic"` when `findAnthropicVisionProvider(config)` returns a provider;
+- `"openai"` when `listOpenAiForwardSidecarCandidates(config).length > 0`.
+
+**Not** "a non-disabled `openai` provider exists" (audit round 1, blocker 4). The
+OpenAI describer posts to `${forwardProvider.baseUrl}/responses` with forwarded
+ChatGPT headers, and `listOpenAiForwardSidecarCandidates`
+(`src/providers/openai-sidecar.ts:55-70`) is the function that decides whether such
+a provider exists: it additionally requires `isCanonicalOpenAiForwardProvider`
+(`src/providers/openai-tiers.ts:32-36`) — adapter `openai-responses`, authMode
+`forward` (an omitted authMode normalizes to forward), and the canonical base URL.
+A mis-shaped `openai` row would otherwise light up the OpenAI side and offer a
+baseline that cannot run, and it would be asymmetric with the Anthropic side,
+which already checks a usable credential.
+
+## MODIFY `src/vision/index.ts`
+
+Add one re-export block after the two existing `export {...} from` lines
+(currently lines 15-16), so importers have a single entry point:
+
+```ts
+ export { describeImage } from "./describe";
+ export { describeImageAnthropic, parseAnthropicVisionSSE } from "./anthropic-describe";
++export {
++  BASELINE_VISION_MODELS,
++  isVisionEligibleModel,
++  isVisionSidecarConsumer,
++  modelAcceptsImageInput,
++  visionBackendForCandidate,
++  visionEligibleModelOptions,
++} from "./eligibility";
++export type { VisionCandidateModel, VisionModelOption, VisionSidecarBackend } from "./eligibility";
+```
+
+`planVisionSidecar` is **not** changed. An operator who hand-configures an exotic
+model keeps working; the filter governs the picker and the API, not the runtime
+dispatch (see the bypass table in `000_plan.md`).
+
+## NEW `tests/vision-eligibility.test.ts`
+
+Cases, each one an assertion the plan owes:
+
+1. **text-only exclusion (activation evidence).** Candidate
+   `{ provider: "openrouter", id: "openai/gpt-5.4-mini" }` — the generated table
+   marks it `"text"` — asserts `isVisionEligibleModel` is `false`. Paired with
+   `{ provider: "anthropic", id: "claude-haiku-4-5" }` asserting `true`, so the
+   test proves discrimination, not blanket rejection.
+2. **`noVisionModels` inversion.** Config with
+   `providers["opencode-go"].noVisionModels = ["glm-5.2"]` and a candidate whose
+   `inputModalities` is `["text","image"]` (exactly what
+   `applyProviderConfigHints` produces) asserts `false`. This is the case a naive
+   modality filter gets wrong.
+3. **unknown stays eligible.** Two sub-cases, because "unknown" and "silent row"
+   are different states:
+   - `{ provider: "anthropic", id: "claude-opus-4-6" }` with no
+     `inputModalities` asserts `true` — the row is silent but the generated
+     table answers `["text","image"]` (verified). This is the live
+     `/api/models` shape.
+   - `{ provider: "anthropic", id: "claude-future-9" }`, absent from every
+     table, asserts `true` via the `undefined → eligible` fallback, and
+     `modelAcceptsImageInput` returns `undefined` for it. Assert the tri-state
+     directly here, otherwise cases 3a and 3b are indistinguishable and the
+     fallback branch is never actually driven.
+4. **native slugs.** Each of the seven `NATIVE_OPENAI_MODELS` asserts `true`.
+5. **baseline presence, openai side.** `visionEligibleModelOptions(config, [],
+   ["openai"])` contains `gpt-5.6-luna` and no anthropic entry.
+6. **baseline presence, anthropic side.** Same with `["anthropic"]` contains
+   `claude-haiku-4-5` and no openai entry.
+7. **baseline is not duplicated** when the catalog also lists it.
+8. **backend routing.** A `cursor`-provider row returns `undefined` from
+   `visionBackendForCandidate` and is therefore absent from the options even
+   though it is image-capable — the "no third executor" rule made testable.
+
+## Acceptance
+
+| Row | Verifier | Covered? |
+|---|---|---|
+| predicate correctness | `bun test tests/vision-eligibility.test.ts` | yes |
+| no type regressions | `bun run typecheck` | yes |
+| no existing-suite breakage | `bun run test` | yes |
+| GUI unaffected | — | `N/A`, this layer touches no `gui/` file |

--- a/devlog/_plan/260809_vision_sidecar_model_filter/020_management_api_allowed_models.md
+++ b/devlog/_plan/260809_vision_sidecar_model_filter/020_management_api_allowed_models.md
@@ -1,0 +1,246 @@
+# 020 — phase 2: management API exposes the allowed list and refuses the rest
+
+Layer 2 of the stack. Branch `codex/260809-vision-sidecar-api`, base
+`codex/260809-vision-eligibility-core`.
+
+Thesis: **the server publishes which models it recommends, and refuses to persist
+one it can prove is blind.** Without this layer the GUI filter is cosmetic —
+anything with the admin token could write a blind model into
+`visionSidecar.model`.
+
+Two sets, never conflated (audit round 1, blockers 1-2):
+
+| | Question | Source | Effect of `undefined` |
+|---|---|---|---|
+| suggestion list | what should the picker offer? | `visionEligibleModelOptions` | excluded (list stays tidy) |
+| write gate | can we prove this is blind? | `modelAcceptsImageInput(...) === false` | **allowed** (never rejected) |
+
+Rejecting on "absent from the list" would break
+`tests/vision-reasoning-contract.test.ts:148-151`, which requires
+`{ model: "custom-vision" }` to save with HTTP 200 against `providers: {}`.
+
+## Files
+
+| Path | Action |
+|---|---|
+| `src/server/management/config-routes.ts` | MODIFY (GET + PUT `/api/sidecar-settings`) |
+| `src/server/management/agent-settings-routes.ts` | MODIFY (Claude Code vision override write) |
+| `docs-site/src/content/docs/guides/sidecars.md` | MODIFY (SOT-SYNC-01: document the gate) |
+| `tests/sidecar-settings-vision-filter.test.ts` | NEW |
+
+`model-rows.ts` is **not** modified: `listManagementModelRows` already returns
+`provider`, `id`, `native`, and (where known) `inputModalities`, which is exactly
+`VisionCandidateModel`. Reusing it keeps the picker and the Models tab sourced
+from one list.
+
+## Imports to add (`config-routes.ts`, alongside the existing line 56 import)
+
+```ts
+ import { normalizeVisionReasoningForModel } from "../../vision/reasoning";
++import { findAnthropicVisionProvider } from "../../vision";
++import { modelAcceptsImageInput, visionEligibleModelOptions, type VisionSidecarBackend } from "../../vision/eligibility";
++import { listOpenAiForwardSidecarCandidates } from "../../providers/openai-sidecar";
++import { listManagementModelRows } from "./model-rows";
+```
+
+`listManagementModelRows` is async and hits `gatherRoutedModels`, which can be
+slow or cooling down after a fetch failure. Both new call sites therefore wrap it
+and degrade to `[]` on throw — a catalog outage must not 500 the settings route
+nor reject a write. With `[]` the option list is exactly the baselines, which is
+the intended floor.
+
+## Helper, added near the top of the module
+
+```ts
+/** Backends whose executor could actually run: openai forward, anthropic OAuth. */
+function enabledVisionBackends(config: OcxConfig): VisionSidecarBackend[] {
+  const backends: VisionSidecarBackend[] = [];
+  // The OpenAI describer needs a CANONICAL ChatGPT forward provider, not merely a
+  // provider keyed "openai" — same predicate the runtime sidecar resolver uses.
+  if (listOpenAiForwardSidecarCandidates(config).length > 0) backends.push("openai");
+  if (findAnthropicVisionProvider(config)) backends.push("anthropic");
+  // Neither side resolvable (fresh install, no login): fall back to both so the
+  // picker is populated rather than empty, matching the permissive-unknown rule.
+  return backends.length > 0 ? backends : ["openai", "anthropic"];
+}
+
+async function visionModelOptionsFor(config: OcxConfig) {
+  let rows: Awaited<ReturnType<typeof listManagementModelRows>> = [];
+  try { rows = await listManagementModelRows(config); } catch { rows = []; }
+  return visionEligibleModelOptions(
+    config,
+    rows.filter(row => row.disabled !== true).map(row => ({
+      provider: row.provider,
+      id: row.id,
+      ...(row.inputModalities ? { inputModalities: row.inputModalities } : {}),
+      ...(row.native ? { native: true } : {}),
+    })),
+    enabledVisionBackends(config),
+  );
+}
+```
+
+## GET `/api/sidecar-settings` (current body at lines 380-393)
+
+```ts
+   if (url.pathname === "/api/sidecar-settings" && req.method === "GET") {
+     const ws = config.webSearchSidecar ?? {};
+     const vs = config.visionSidecar ?? {};
+     const visionModel = vs.model || "gpt-5.4-mini";
+     const visionReasoning = normalizeVisionReasoningForModel(visionModel, vs.reasoning) ?? "low";
++    const visionModels = await visionModelOptionsFor(config);
++    // A model the operator already configured stays selectable even if it is no
++    // longer eligible; dropping it would silently re-point their sidecar.
++    if (!visionModels.some(option => option.value === visionModel)) {
++      visionModels.unshift({ value: visionModel, label: visionModel, backend: vs.backend ?? "openai" });
++    }
+     return jsonResponse({
+       webSearch: { model: ws.model ?? "gpt-5.6-luna", backend: ws.backend },
+       vision: {
+         model: visionModel,
+         backend: vs.backend,
+         reasoning: visionReasoning,
+         maxDescriptionsPerTurn: vs.maxDescriptionsPerTurn,
+       },
++      visionModels,
+     });
+   }
+```
+
+The same `visionModels` block is appended to the PUT response body (the second
+serialization site, currently at lines 470-483), so an optimistic GUI update and a
+refetch cannot disagree about the option list.
+
+## PUT validation
+
+Inserted after the existing `vision.reasoning` enum check (lines 422-423), before
+the normalization block and well before `saveConfigPreservingClaudeCode(config)`
+at line 469, so a rejected write mutates nothing:
+
+```ts
++    // Reject ONLY a model we can prove is blind. An id nothing knows about stays
++    // allowed: the operator may be ahead of our catalog, and the runtime never
++    // required catalog membership (`tests/vision-reasoning-contract.test.ts`
++    // pins `custom-vision` → 200).
++    if (body.vision && typeof body.vision.model === "string" && body.vision.model !== "") {
++      const requested = body.vision.model;
++      const row = (await visionCandidateRows(config)).find(candidate => candidate.id === requested);
++      const accepts = modelAcceptsImageInput(config, row ?? { provider: body.vision.backend === "anthropic" ? "anthropic" : "openai", id: requested });
++      if (accepts === false) {
++        return jsonResponse({
++          error: `vision.model "${requested}" cannot describe images: it has no image input support, or it is a model the vision sidecar describes FOR.`,
++          allowed: (await visionModelOptionsFor(config)).map(option => option.value),
++        }, 400);
++      }
++    }
+```
+
+Empty string keeps its existing meaning — clear the override, fall back to
+`gpt-5.4-mini` — so it bypasses the check by design.
+
+`visionCandidateRows(config)` is the shared row loader the gate and the list both
+read, so they can never disagree about what exists (audit round 2, N3):
+
+```ts
+async function visionCandidateRows(config: OcxConfig): Promise<VisionCandidateModel[]> {
+  let rows: Awaited<ReturnType<typeof listManagementModelRows>> = [];
+  // A catalog outage must not 500 the settings route nor reject a write; with []
+  // the option list degrades to the baselines, which is the intended floor.
+  try { rows = await listManagementModelRows(config); } catch { rows = []; }
+  return rows.filter(row => row.disabled !== true).map(row => ({
+    provider: row.provider,
+    id: row.id,
+    ...(row.inputModalities ? { inputModalities: row.inputModalities } : {}),
+    ...(row.native ? { native: true } : {}),
+  }));
+}
+
+async function visionModelOptionsFor(config: OcxConfig) {
+  return visionEligibleModelOptions(config, await visionCandidateRows(config), enabledVisionBackends(config));
+}
+```
+
+(The `visionModelOptionsFor` body shown earlier is superseded by this pair.)
+
+### What the synthesized fallback candidate can and cannot reject
+
+When the requested id matches no row, the gate synthesizes
+`{ provider: <anthropic if that backend was named, else openai>, id }`. Measured
+against `src/generated/model-metadata.ts`, that can only ever reject three ids —
+`codex-mini-latest`, `gpt-4`, `o3-mini` (the openai table's only text-only rows;
+the anthropic table has none). All three genuinely cannot see, so the rejection is
+correct rather than overreach. Every other unmatched id resolves to `undefined`
+and is allowed.
+
+## The second write path: Claude Code's vision override
+
+`PUT /api/claude-code` sets `claudeCode.visionSidecar.model` and today only
+type-checks it (`src/server/management/agent-settings-routes.ts:1002-1014`). A gate
+on one route and not the other is decorative, so the same
+`accepts === false` rejection is applied there for the `visionSidecar` field of
+that loop. `webSearchSidecar` is untouched — it has no vision requirement.
+
+The Claude Code **GUI** stays freeform: it is an `<input>` + `<datalist>`
+(`gui/src/pages/claude-code-sections.tsx:154-205`), not a constrained picker, and
+narrowing it is out of scope per `000_plan.md`.
+
+## Wire-shape note
+
+`visionModels` is a top-level sibling of `vision`, not a member of it, because
+`SidecarSetting` is shared with `webSearch` and shipping a vision-only array
+inside it would give the web-search half a field it can never populate.
+
+## NEW `tests/sidecar-settings-vision-filter.test.ts`
+
+Driven through `handleManagementAPI` with an in-memory `OcxConfig`, exactly as
+`tests/vision-reasoning-contract.test.ts:12-31` does (`getVision`/`putVision`
+helpers plus `ManagementRequest` from `tests/helpers/management-auth`). That is the
+real seam — the sidecar PUT calls the bare `saveConfigPreservingClaudeCode` import
+at line 469, so it does **not** use `model-routes.ts`'s `deps` injection. Where a
+"did not persist" assertion is needed, assert on the in-memory config object
+(which the handler mutates in place) and, if a stronger claim is wanted, use
+`spyOn(configModule, "saveConfigPreservingClaudeCode")` as
+`tests/codex-account-delete-atomicity.test.ts:71-73` does.
+
+1. **GET returns the allowed list** containing `gpt-5.6-luna`.
+2. **GET keeps a configured-but-ineligible model selectable** — set
+   `visionSidecar.model` to a text-only id, assert it is present in
+   `visionModels` and still returned as `vision.model`.
+
+   This grandfather is **display-only, and asymmetric on purpose** (audit round 2,
+   N2): the operator can see what is configured and can change the effort
+   (`visionReasoningPatch` sends `{ vision: { reasoning } }` only,
+   `gui/src/pages/dashboard-shared.ts:157-159`, so it never trips the model gate),
+   but re-submitting that same proven-blind id is rejected. Hiding it instead
+   would leave the picker showing some *other* model while the config still names
+   this one, which is the worse lie. Case 3 below pins the rejection; this case
+   pins the visibility.
+3. **PUT rejects an ineligible model with 400 (activation evidence)** — body
+   `{ vision: { model: "<text-only id>" } }` asserts status 400, an `allowed`
+   array in the body, and that `config.visionSidecar?.model` is **unchanged**. The
+   unchanged assertion is the one that proves rejection happened before mutation
+   rather than after.
+4. **PUT accepts an eligible model** — `claude-haiku-4-5` asserts 200 and a
+   persisted config.
+5. **PUT with `model: ""` still clears** — asserts 200, proving the guard did not
+   capture the clear path.
+6. **catalog failure degrades to baselines** — stub the model source to throw and
+   assert GET still returns 200 with the baseline entries.
+7. **PUT keeps an UNKNOWN id (regression guard for blocker 1)** —
+   `{ model: "custom-vision" }` against `providers: {}` asserts 200 and a persisted
+   value, mirroring `tests/vision-reasoning-contract.test.ts:148-151`. Without this
+   case the over-strict gate could be reintroduced silently.
+8. **PUT /api/claude-code rejects a provably blind vision override** with 400,
+   and accepts an unknown one.
+
+## Acceptance
+
+| Row | Verifier | Covered? |
+|---|---|---|
+| allowed list on the wire | `bun test tests/sidecar-settings-vision-filter.test.ts` | yes |
+| 400 on ineligible write | same file, case 3 | yes |
+| unknown id still accepted | same file, case 7 + `bun test tests/vision-reasoning-contract.test.ts` | yes |
+| second write path gated | same file, case 8 | yes |
+| no regression in existing sidecar routes | `bun run test` | yes |
+| types | `bun run typecheck` | yes |
+| GUI consumption | — | `N/A` until phase 3 |

--- a/devlog/_plan/260809_vision_sidecar_model_filter/030_dashboard_vision_card.md
+++ b/devlog/_plan/260809_vision_sidecar_model_filter/030_dashboard_vision_card.md
@@ -1,0 +1,265 @@
+# 030 — phase 3: the dashboard vision card
+
+Layer 3 of the stack. Branch `codex/260809-vision-sidecar-card`, base
+`codex/260809-vision-sidecar-api`.
+
+Thesis: **the card shows only what the server allows, in the delegation panel's
+form factor, with the effort select reading its raw wire values.**
+
+Two review comments drive this layer:
+
+- comment 1, on the vision card: "여기 프런트 양식을 위의 서브에이전트 위임 처럼
+  만들게 해주고" — adopt the delegation panel's layout.
+- comment 2, on the delegation panel: "여기처럼 i18n 하지말고 추론창은 컴팩트하게"
+  — the delegation panel's effort control shows a bare `high`, and the vision card
+  should match that instead of rendering `낮음`.
+
+Comment 2 is anchored ON the delegation panel but is a **pattern reference**, not
+a request to change it: that panel already maps efforts to raw values
+(`dashboard-overview-sections.tsx:119-122`, `injectionEfforts.map(e => ({ value: e,
+label: e }))`). Verified in audit round 1 — the delegation panel needs no edit.
+
+## Files
+
+| Path | Action |
+|---|---|
+| `gui/src/pages/dashboard-shared.ts` | MODIFY (types + option helper) |
+| `gui/src/pages/use-dashboard-data.ts` | MODIFY (prefer server list) |
+| `gui/src/pages/dashboard-overview-sections.tsx` | MODIFY (card markup) |
+| `gui/src/styles-dashboard-workspace.css` | MODIFY (compact-select + copy-block rules) |
+| `gui/src/i18n/vision-reasoning-labels.ts` | DELETE if no importer remains |
+
+## `dashboard-shared.ts`
+
+```ts
+ export interface SidecarSetting { backend?: SidecarBackend; model: string; reasoning?: VisionReasoning }
+-export interface SidecarData { webSearch: SidecarSetting; vision: SidecarSetting }
++export interface VisionModelOption { value: string; label: string; backend: SidecarBackend; baseline?: boolean }
++export interface SidecarData {
++  webSearch: SidecarSetting;
++  vision: SidecarSetting;
++  /** Server-computed eligible describers. Optional: an older server omits it and
++   *  the client falls back to the legacy provider-name list rather than showing
++   *  an empty picker. */
++  visionModels?: VisionModelOption[];
++}
+```
+
+and a selector that encodes the fallback once:
+
+```ts
+/** Server list when present, else the legacy openai+anthropic list. */
+export function visionModelOptions(
+  serverOptions: VisionModelOption[] | undefined,
+  models: ModelInfo[],
+  current: string | undefined,
+): Array<{ value: string; label: string }> {
+  const options = serverOptions && serverOptions.length > 0
+    ? serverOptions.map(option => ({ value: option.value, label: option.label }))
+    : sidecarModelOptions(models);
+  if (current && !options.some(option => option.value === current)) {
+    options.unshift({ value: current, label: current });
+  }
+  return options;
+}
+```
+
+`sidecarModelOptions` stays exactly as it is — web-search still uses it, and this
+unit does not change the web-search picker.
+
+## `use-dashboard-data.ts`
+
+The existing `sidecarModels` memo (lines 454-462) keeps serving web-search. Add a
+sibling and export it from the hook's return object next to `sidecarModels`:
+
+```ts
++  const visionModels = useMemo(
++    () => visionModelOptions(sidecar?.visionModels, models, sidecar?.vision.model),
++    [sidecar?.visionModels, models, sidecar?.vision.model],
++  );
+```
+
+`saveSidecar` enumerates fields explicitly at **three** write sites, so a new
+field is silently dropped unless all three are edited (audit round 1, blocker 3):
+
+1. the optimistic `next` object (lines 467-470) — add
+   `...(sidecar.visionModels ? { visionModels: sidecar.visionModels } : {})` so the
+   picker does not blank for the in-flight frame;
+2. the success writeback (line 480) — `setSidecar` currently names only
+   `webSearch` and `vision`; it must also carry `data.visionModels`, otherwise
+   every successful save falls back to the legacy openai+anthropic list until the
+   next poll, undoing requirement 2 on the exact interaction the user performs;
+3. the session cache write (line 484) — same two named fields, same fix, or a
+   reload serves a list-less snapshot.
+
+Also add `visionModels` to the hook's returned object next to `sidecarModels`, or
+the card cannot read it. The polling path (lines 333-343) assigns `data.sidecar`
+wholesale and needs no change.
+
+## `dashboard-overview-sections.tsx`
+
+Replace the vision branch of `DashboardSidecarPanels` (lines 288-311). Before —
+a `dash-sidecar-card` whose title, two selects, and hint stack vertically. After —
+the delegation shape.
+
+**The form factor is the panel, not an inner row** (audit round 1, blocker 6).
+`DashboardInjectionPanel` puts `dash-delegation-summary` on the panel itself
+(line 102); `.dash-sidecar-card__row` already carries the same flex rules
+(`styles-dashboard-workspace.css:91-98`), so adding the class there would be
+redundant and would not reproduce the shape. The edit below therefore:
+
+- makes the panel `className="panel dash-delegation-summary dash-vision-card"`.
+  **`dash-sidecar-card` is dropped from the vision panel, not combined with it**
+  (audit round 2, N1). Keeping both would silently produce a COLUMN panel:
+  `.dash-sidecar-card` declares `flex-direction: column`
+  (`styles-dashboard-workspace.css:84-89`) and `.dash-delegation-summary`
+  (`styles.css:2245-2250`) never resets that property, so the two classes do not
+  compete — column simply survives, regardless of import order. A new
+  `.dash-vision-card { min-width: 0; }` supplies the only thing the grid cell
+  actually needed from the old class;
+- drops the inner `dash-sidecar-card__row` wrapper entirely;
+- moves the hint into a left copy block `<div className="dash-sidecar-copy">`
+  holding the title and `dash.visionSidecarHint`, since the panel is now a row
+  and the old trailing hint would land beside the controls. The trailing
+  `<div className="muted setting-hint">` after the row is deleted in the same
+  edit.
+
+The web-search card is deliberately left alone: the request was anchored on the
+vision card, and restyling both would exceed the comment's scope.
+
+```tsx
+-        <div className="panel dash-sidecar-card" aria-busy={!sidecar || undefined}>
+-          <div className="dash-sidecar-card__row">
+-            <div className="font-semibold">{t("dash.visionSidecar")}</div>
+-            <div className="dash-delegation-controls">
+-              <Select
+-                value={visionModel}
+-                options={sidecarModels}
+-                onChange={model => { /* unchanged */ }}
+-                disabled={!sidecar || sidecarSaving}
+-                label={t("dash.sidecarModel")}
+-              />
+-              <Select
+-                value={visionReasoning}
+-                options={visionReasoningOptionsFor(visionLadder, visionReasoning)
+-                  .map(value => ({ value, label: visionReasoningLabel(locale, value) }))}
+-                onChange={reasoning => { /* unchanged */ }}
+-                disabled={!sidecar || sidecarSaving}
+-                label={`${t("dash.visionSidecar")} — ${t("dash.injectionEffortLabel")}`}
+-              />
+-            </div>
+-          </div>
+-          <div className="muted setting-hint">{t("dash.visionSidecarHint")}</div>
+-        </div>
++        {/* Same shell as DashboardInjectionPanel: the PANEL is the flex row. */}
++        <div className="panel dash-delegation-summary dash-vision-card" aria-busy={!sidecar || undefined}>
++          <div className="dash-sidecar-copy">
++            <div className="font-semibold">{t("dash.visionSidecar")}</div>
++            <div className="muted setting-hint">{t("dash.visionSidecarHint")}</div>
++          </div>
++          <div className="dash-delegation-controls">
++            <Select
++              value={visionModel}
++              options={visionModels}
++              onChange={model => { /* unchanged */ }}
++              disabled={!sidecar || sidecarSaving}
++              label={t("dash.sidecarModel")}
++            />
++            <Select
++              value={visionReasoning}
++              // Raw wire value (low…max), matching the delegation panel's bare `high`.
++              options={visionReasoningOptionsFor(visionLadder, visionReasoning)
++                .map(value => ({ value, label: value }))}
++              onChange={reasoning => { /* unchanged */ }}
++              disabled={!sidecar || sidecarSaving}
++              align="right"
++              label={`${t("dash.visionSidecar")} — ${t("dash.injectionEffortLabel")}`}
++            />
++          </div>
++        </div>
+```
+
+The wrapping `<Select>` keeps its `label` prop: that is the accessible name, not
+visible text, so dropping the localized *option* labels does not make the control
+anonymous to a screen reader. The visible option text becomes the wire value,
+which is what comment 2 asks for.
+
+Destructuring changes at the top of the component: `visionModels` in,
+`sidecarModels` retained for the web-search card, and `locale` removed once
+`visionReasoningLabel` is gone. Drop the now-unused imports
+(`visionReasoningLabel`) in the same edit or `lint:gui` fails on
+`no-unused-vars`.
+
+### Effort select width
+
+`.dash-sidecar-card__row .custom-select`
+(`gui/src/styles-dashboard-workspace.css:104-110`) forces
+`min-width: clamp(10rem, 24vw, 11.5rem)`, which is what makes the effort control
+as wide as the model control. Add the narrower rule **immediately after it in
+that same file**, not in `styles.css` (audit round 1, blocker 8) — the override
+belongs beside the rule it overrides:
+
+```css
+/* The effort control holds one short wire value (low…max); it must not inherit
+   the model select's reserved width. */
+.dash-delegation-controls .custom-select:last-child {
+  min-width: 6.5rem;
+  max-width: 9rem;
+}
+```
+
+`:last-child` is sound: `Select` renders each control as a sibling
+`.custom-select` root, so the effort select really is the last child of
+`.dash-delegation-controls`. The same selector also reaches the delegation
+panel's controls, whose last child is a `<button>` and therefore does not match —
+verify both cards during render grounding.
+
+Add alongside it, mirroring `.dash-sync-copy` (`styles.css:684-687`):
+
+```css
+.dash-sidecar-copy { min-width: 0; flex: 1 1 auto; }
+```
+
+and the replacement for the class the vision panel no longer wears:
+
+```css
+/* The vision panel is a delegation-style ROW, so it must not inherit
+   .dash-sidecar-card's flex-direction: column. It only ever needed min-width. */
+.dash-vision-card { min-width: 0; }
+```
+
+## i18n cleanup
+
+`visionReasoningLabel` has one importer today (`dashboard-overview-sections.tsx`).
+After this edit, grep for it; if zero importers remain, delete
+`gui/src/i18n/vision-reasoning-labels.ts` and its tests. If any other surface
+(e.g. Claude Code overrides) imports it, keep the file and only stop using it
+here — a shared helper is not this unit's to remove.
+
+The `dash.visionSidecar` / `dash.visionSidecarHint` / `dash.sidecarModel` keys
+stay localized. Comment 2 is about the effort *values*, not the card's prose;
+deleting the Korean card title would be a scope overreach and would regress five
+other locales.
+
+## Render grounding (C-RENDER-GROUNDING-01)
+
+This layer changes layout, so C is not complete on `lint:gui` alone:
+
+1. `bun run build:gui`
+2. serve the built dashboard (or point the running proxy at it) and open
+   `#dashboard` at 1280x720
+3. screenshot the overview and **read the screenshot back**, confirming: the
+   vision card's title sits left with both controls right; the effort select is
+   visibly narrower than the model select; the effort select reads `low` (not
+   `낮음`); the model dropdown lists only eligible ids.
+4. persist the screenshot into this unit's `evidence/` directory.
+
+## Acceptance
+
+| Row | Verifier | Covered? |
+|---|---|---|
+| filtered options reach the picker | `bun run test` (shared-helper unit test) | yes |
+| no lint regressions | `bun run lint:gui` | yes |
+| bundle builds | `bun run build:gui` | yes |
+| layout + non-localized effort + compact width | screenshot read-back | yes — human/visual, not a gate |
+| types | `bun run typecheck` | yes |

--- a/devlog/_plan/260809_vision_sidecar_model_filter/040_stack_publication.md
+++ b/devlog/_plan/260809_vision_sidecar_model_filter/040_stack_publication.md
@@ -1,0 +1,72 @@
+# 040 — phase 4: publish the stack
+
+No production code. This phase turns the three landed layers into three reviewable
+pull requests.
+
+## The chain
+
+```
+codex/260809-vision-sidecar-card   → PR #3 (base: codex/260809-vision-sidecar-api)
+codex/260809-vision-sidecar-api    → PR #2 (base: codex/260809-vision-eligibility-core)
+codex/260809-vision-eligibility-core → PR #1 (base: dev)
+──────────────────────────────────── dev
+```
+
+Three layers, inside the 2-4 range `DEV-STACK-01` recommends. Each is separately
+mergeable: the predicate is inert without a caller, the API layer is a real
+server-side guard with or without the GUI, and the GUI layer degrades to the legacy
+list against an older server (`visionModels` is optional by design).
+
+## Sequence
+
+1. Confirm the worktree is on `origin/dev` and clean; never touch the `dev`
+   branch checked out in `/Users/jun/Developer/new/700_projects/opencodex`.
+2. Create each branch from the tip of the one below and commit that layer's files
+   only. Keep the devlog unit on layer 1 so the plan lands with the foundation.
+3. `git push -u origin <branch>` per layer, bottom-up.
+4. `gh pr create --base <branch below> --head <branch>` per layer. Pass `--base`
+   explicitly on every one: omitted, `gh` falls back to `branch.<name>.gh-merge-base`
+   or the repository default branch, which would silently retarget a layer at trunk.
+5. `gh pr view <n> --json baseRefName,headRefName,isDraft` per PR as the evidence
+   this phase owes.
+
+## PR bodies
+
+Every PR fills `.github/PULL_REQUEST_TEMPLATE.md` — Summary, Verification,
+Checklist — because `enforce-target` rejects thin or malformed descriptions.
+The GUI layer's description **must** embed a screenshot: the gate requires one from
+any PR whose title or description mentions `gui`.
+
+Each body also carries the stack map (`DEV-STACK-03`):
+
+```markdown
+**Stack** (merge bottom-up):
+| # | PR | Layer | Review focus |
+|---|----|-------|--------------|
+| 3 | #c | dashboard vision card | layout, non-localized effort values |
+| 2 | #b | management API | the 400 gate and the allowed-list payload |
+| 1 | #a | vision eligibility core ← you are here | the predicate and its inversion cases |
+```
+
+## Cascade rule
+
+If review changes a lower layer, rebase upward with
+`git rebase --update-refs`, re-push with `--force-with-lease` (never bare
+`--force`), then verify per `DEV-STACK-02`: `git log --oneline <lower>..<upper>`
+shows only the upper layer's own commits, and each PR's base ref still names the
+branch below. Review state is assumed stale after any cascade.
+
+## Authorization boundary
+
+Push and PR creation are authorized for this unit. **Merging is not** — not the
+bottom PR, not auto-merge, not a queue bypass. Merging is a separate decision that
+stays with the user (`DEV-STACK-04`, `DEV-GIT-PUSH-01`).
+
+## Acceptance
+
+| Row | Verifier | Covered? |
+|---|---|---|
+| three branches exist with the right ancestry | `git log --oneline <lower>..<upper>` | yes |
+| three PRs open with correct bases | `gh pr view --json baseRefName,headRefName` | yes |
+| bodies satisfy the template | `enforce-target` on the PR | yes, once CI runs |
+| nothing merged | `gh pr view --json state` shows OPEN | yes |

--- a/src/vision/eligibility.ts
+++ b/src/vision/eligibility.ts
@@ -29,7 +29,11 @@ import { enrichProviderFromRegistry } from "../providers/derive";
 /** The two wire protocols `planVisionSidecar` can actually dispatch to. */
 export type VisionSidecarBackend = "openai" | "anthropic";
 
-/** Guaranteed entry per backend: cheap, image-capable, and present in every deployment. */
+/**
+ * Default entry per backend: cheap, image-capable, and present in every deployment. Offered
+ * whenever its side is enabled, and withheld only when that provider explicitly lists it as a
+ * model the sidecar describes FOR — never merely because a metadata table stayed silent.
+ */
 export const BASELINE_VISION_MODELS: Record<VisionSidecarBackend, string> = {
   openai: "gpt-5.6-luna",
   anthropic: "claude-haiku-4-5",
@@ -149,17 +153,18 @@ export function visionBackendForCandidate(
   anthropicProviderName?: string,
 ): VisionSidecarBackend | undefined {
   if (candidate.native || candidate.provider === "openai") return "openai";
-  // The runtime dispatches through one OAuth Anthropic provider, never every provider that
-  // happens to speak the Messages wire. Without a resolved executor, retain the canonical row
-  // so a fresh install's permissive fallback still has a useful suggestion.
-  if (anthropicProviderName !== undefined) {
-    return candidate.provider === anthropicProviderName ? "anthropic" : undefined;
-  }
-  // Unresolved executor: the canonical name alone is not enough, because a row may be named
-  // "anthropic" while speaking another wire. The adapter still has to agree.
-  if (candidate.provider !== "anthropic") return undefined;
-  const adapter = config.providers?.anthropic?.adapter;
-  return adapter === undefined || adapter === "anthropic" ? "anthropic" : undefined;
+  // The runtime dispatches through exactly ONE Anthropic provider — the enabled OAuth row
+  // with a healthy active account that `findAnthropicVisionProvider` picks. Speaking the
+  // Messages wire is not enough: a key-auth row of the same adapter is unreachable, and an
+  // option that cannot be dispatched is worse than a missing one, because selecting it fails
+  // at describe time rather than at pick time.
+  //
+  // So the executor's name is REQUIRED for an Anthropic suggestion. When the caller has no
+  // executor to name, no catalog row qualifies; the side's baseline is added separately and
+  // keeps the picker populated. Narrowing here never widens the write gate, which is a
+  // different predicate (`modelAcceptsImageInput`) and still treats unknown as allowed.
+  if (anthropicProviderName === undefined) return undefined;
+  return candidate.provider === anthropicProviderName ? "anthropic" : undefined;
 }
 
 function baselineCandidate(
@@ -177,9 +182,11 @@ function baselineCandidate(
 
 /**
  * The picker's option list: every eligible row reachable by one of the two
- * executors, plus each enabled side's baseline, de-duplicated and stably ordered
- * (openai side first, baselines first within a side). Anthropic rows must belong
- * to the selected OAuth executor when its name is known.
+ * executors, plus each enabled side's baseline unless that baseline is explicitly
+ * excluded, de-duplicated and stably ordered (openai side first, baselines first
+ * within a side). Anthropic rows must belong to the OAuth provider that would
+ * actually execute them, so `anthropicProviderName` is what makes that side's
+ * catalog rows eligible at all.
  *
  * This is the SUGGESTION list (narrow): it emits only rows an executor can reach
  * and some source has heard of. It is deliberately NOT the same set as the write

--- a/src/vision/eligibility.ts
+++ b/src/vision/eligibility.ts
@@ -2,22 +2,29 @@
  * Which models may serve AS the vision sidecar (the describer), as opposed to the
  * models the sidecar describes FOR.
  *
- * Two rules make this non-obvious, and both are load-bearing:
+ * Three rules make this non-obvious, and all are load-bearing:
  *
  * 1. `provider.noVisionModels` marks models the proxy describes images for, and
  *    `applyProviderConfigHints` deliberately ADDS "image" to their advertised
  *    input modalities so the Codex app does not block the attachment client-side.
  *    A blind model therefore advertises image input. Membership in that list is a
  *    hard disqualifier here, checked BEFORE the modality list it rewrote.
- * 2. Catalog rows frequently omit `inputModalities` entirely (the live
+ * 2. The catalog enriches configured providers from the registry before it
+ *    applies that rule. Eligibility must use the same effective provider policy,
+ *    including a `noVisionModels` list learned after the config was persisted.
+ * 3. Catalog rows frequently omit `inputModalities` entirely (the live
  *    `/api/models` response carries none for either openai or anthropic rows).
  *    Unknown is not zero: when no source can speak, the model stays eligible
  *    rather than silently vanishing from the picker.
+ *    Native OpenAI metadata is likewise authoritative only for a native row or
+ *    the canonical OpenAI provider; a routed row with the same id owns its own
+ *    explicit modalities.
  */
-import { modelInList, type OcxConfig } from "../types";
+import { modelInList, type OcxConfig, type OcxProviderConfig } from "../types";
 import { getModelMetadataCaseInsensitive, resolveMetadataProvider } from "../generated/model-metadata";
 import { nativeInputModalities } from "../codex/catalog/metadata";
 import { SUPPORTED_NATIVE_OPENAI_SLUGS } from "../codex/catalog/native-models";
+import { enrichProviderFromRegistry } from "../providers/derive";
 
 /** The two wire protocols `planVisionSidecar` can actually dispatch to. */
 export type VisionSidecarBackend = "openai" | "anthropic";
@@ -43,6 +50,8 @@ export interface VisionModelOption {
   baseline?: boolean;
 }
 
+type EnrichedProviderCache = Map<string, OcxProviderConfig>;
+
 function advertisesImageInput(modalities: readonly string[] | undefined): boolean | undefined {
   if (!modalities || modalities.length === 0) return undefined;
   return modalities.includes("image");
@@ -56,12 +65,39 @@ function metadataImageInput(provider: string, modelId: string): boolean | undefi
 }
 
 /**
+ * Mirrors the catalog's registry enrichment without mutating saved configuration. The picker
+ * checks many rows from one provider, so its caller shares this small call-local cache.
+ */
+function enrichedProviderForVision(
+  config: Pick<OcxConfig, "providers">,
+  providerName: string,
+  cache: EnrichedProviderCache,
+): OcxProviderConfig | undefined {
+  const cached = cache.get(providerName);
+  if (cached) return cached;
+  const configured = config.providers?.[providerName];
+  if (!configured) return undefined;
+  const enriched = structuredClone(configured);
+  enrichProviderFromRegistry(providerName, enriched);
+  cache.set(providerName, enriched);
+  return enriched;
+}
+
+function isVisionSidecarConsumerWithCache(
+  config: Pick<OcxConfig, "providers">,
+  providerName: string,
+  modelId: string,
+  cache: EnrichedProviderCache,
+): boolean {
+  return modelInList(enrichedProviderForVision(config, providerName, cache)?.noVisionModels, modelId);
+}
+
+/**
  * Is this model listed as one the sidecar describes FOR? Such a model cannot be
  * the describer, and its advertised modalities are untrustworthy.
  */
 export function isVisionSidecarConsumer(config: Pick<OcxConfig, "providers">, providerName: string, modelId: string): boolean {
-  const provider = config.providers?.[providerName];
-  return provider ? modelInList(provider.noVisionModels, modelId) : false;
+  return isVisionSidecarConsumerWithCache(config, providerName, modelId, new Map());
 }
 
 /**
@@ -73,8 +109,16 @@ export function modelAcceptsImageInput(
   config: Pick<OcxConfig, "providers">,
   candidate: VisionCandidateModel,
 ): boolean | undefined {
-  if (isVisionSidecarConsumer(config, candidate.provider, candidate.id)) return false;
-  if (candidate.native || SUPPORTED_NATIVE_OPENAI_SLUGS.has(candidate.id)) {
+  return modelAcceptsImageInputWithCache(config, candidate, new Map());
+}
+
+function modelAcceptsImageInputWithCache(
+  config: Pick<OcxConfig, "providers">,
+  candidate: VisionCandidateModel,
+  cache: EnrichedProviderCache,
+): boolean | undefined {
+  if (isVisionSidecarConsumerWithCache(config, candidate.provider, candidate.id, cache)) return false;
+  if (candidate.native === true || (candidate.provider === "openai" && SUPPORTED_NATIVE_OPENAI_SLUGS.has(candidate.id))) {
     return advertisesImageInput(nativeInputModalities(candidate.id)) ?? true;
   }
   const fromRow = advertisesImageInput(candidate.inputModalities);
@@ -87,24 +131,55 @@ export function isVisionEligibleModel(
   config: Pick<OcxConfig, "providers">,
   candidate: VisionCandidateModel,
 ): boolean {
-  return modelAcceptsImageInput(config, candidate) !== false;
+  return isVisionEligibleModelWithCache(config, candidate, new Map());
 }
 
-/** Which backend would describe through this row, or undefined when neither can. */
+function isVisionEligibleModelWithCache(
+  config: Pick<OcxConfig, "providers">,
+  candidate: VisionCandidateModel,
+  cache: EnrichedProviderCache,
+): boolean {
+  return modelAcceptsImageInputWithCache(config, candidate, cache) !== false;
+}
+
+/** Which executor can describe through this row, or undefined when neither can. */
 export function visionBackendForCandidate(
   config: Pick<OcxConfig, "providers">,
   candidate: VisionCandidateModel,
+  anthropicProviderName?: string,
 ): VisionSidecarBackend | undefined {
   if (candidate.native || candidate.provider === "openai") return "openai";
-  const adapter = config.providers?.[candidate.provider]?.adapter;
-  if (adapter === "anthropic") return "anthropic";
-  return undefined;
+  // The runtime dispatches through one OAuth Anthropic provider, never every provider that
+  // happens to speak the Messages wire. Without a resolved executor, retain the canonical row
+  // so a fresh install's permissive fallback still has a useful suggestion.
+  if (anthropicProviderName !== undefined) {
+    return candidate.provider === anthropicProviderName ? "anthropic" : undefined;
+  }
+  // Unresolved executor: the canonical name alone is not enough, because a row may be named
+  // "anthropic" while speaking another wire. The adapter still has to agree.
+  if (candidate.provider !== "anthropic") return undefined;
+  const adapter = config.providers?.anthropic?.adapter;
+  return adapter === undefined || adapter === "anthropic" ? "anthropic" : undefined;
+}
+
+function baselineCandidate(
+  backend: VisionSidecarBackend,
+  anthropicProviderName: string | undefined,
+): VisionCandidateModel {
+  return {
+    provider: backend === "openai" ? "openai" : anthropicProviderName ?? "anthropic",
+    id: BASELINE_VISION_MODELS[backend],
+    // Both baselines are known image-capable. This makes their only exclusion path the
+    // provider's explicit consumer list, never a silent or stale metadata table.
+    inputModalities: ["text", "image"],
+  };
 }
 
 /**
  * The picker's option list: every eligible row reachable by one of the two
  * executors, plus each enabled side's baseline, de-duplicated and stably ordered
- * (openai side first, baselines first within a side).
+ * (openai side first, baselines first within a side). Anthropic rows must belong
+ * to the selected OAuth executor when its name is known.
  *
  * This is the SUGGESTION list (narrow): it emits only rows an executor can reach
  * and some source has heard of. It is deliberately NOT the same set as the write
@@ -120,19 +195,23 @@ export function visionEligibleModelOptions(
   config: Pick<OcxConfig, "providers">,
   candidates: readonly VisionCandidateModel[],
   enabledBackends: readonly VisionSidecarBackend[],
+  anthropicProviderName?: string,
 ): VisionModelOption[] {
   const enabled = new Set(enabledBackends);
   const byValue = new Map<string, VisionModelOption>();
+  const enrichedProviders: EnrichedProviderCache = new Map();
 
   for (const backend of ["openai", "anthropic"] as const) {
     if (!enabled.has(backend)) continue;
-    const id = BASELINE_VISION_MODELS[backend];
+    const candidate = baselineCandidate(backend, anthropicProviderName);
+    if (!isVisionEligibleModelWithCache(config, candidate, enrichedProviders)) continue;
+    const id = candidate.id;
     byValue.set(id, { value: id, label: id, backend, baseline: true });
   }
   for (const candidate of candidates) {
-    const backend = visionBackendForCandidate(config, candidate);
+    const backend = visionBackendForCandidate(config, candidate, anthropicProviderName);
     if (!backend || !enabled.has(backend)) continue;
-    if (!isVisionEligibleModel(config, candidate)) continue;
+    if (!isVisionEligibleModelWithCache(config, candidate, enrichedProviders)) continue;
     if (byValue.has(candidate.id)) continue;
     byValue.set(candidate.id, { value: candidate.id, label: candidate.id, backend });
   }

--- a/src/vision/eligibility.ts
+++ b/src/vision/eligibility.ts
@@ -1,0 +1,143 @@
+/**
+ * Which models may serve AS the vision sidecar (the describer), as opposed to the
+ * models the sidecar describes FOR.
+ *
+ * Two rules make this non-obvious, and both are load-bearing:
+ *
+ * 1. `provider.noVisionModels` marks models the proxy describes images for, and
+ *    `applyProviderConfigHints` deliberately ADDS "image" to their advertised
+ *    input modalities so the Codex app does not block the attachment client-side.
+ *    A blind model therefore advertises image input. Membership in that list is a
+ *    hard disqualifier here, checked BEFORE the modality list it rewrote.
+ * 2. Catalog rows frequently omit `inputModalities` entirely (the live
+ *    `/api/models` response carries none for either openai or anthropic rows).
+ *    Unknown is not zero: when no source can speak, the model stays eligible
+ *    rather than silently vanishing from the picker.
+ */
+import { modelInList, type OcxConfig } from "../types";
+import { getModelMetadataCaseInsensitive, resolveMetadataProvider } from "../generated/model-metadata";
+import { nativeInputModalities } from "../codex/catalog/metadata";
+import { SUPPORTED_NATIVE_OPENAI_SLUGS } from "../codex/catalog/native-models";
+
+/** The two wire protocols `planVisionSidecar` can actually dispatch to. */
+export type VisionSidecarBackend = "openai" | "anthropic";
+
+/** Guaranteed entry per backend: cheap, image-capable, and present in every deployment. */
+export const BASELINE_VISION_MODELS: Record<VisionSidecarBackend, string> = {
+  openai: "gpt-5.6-luna",
+  anthropic: "claude-haiku-4-5",
+};
+
+export interface VisionCandidateModel {
+  provider: string;
+  id: string;
+  inputModalities?: string[];
+  native?: boolean;
+}
+
+export interface VisionModelOption {
+  value: string;
+  label: string;
+  backend: VisionSidecarBackend;
+  /** True when the row is a guaranteed baseline rather than a catalog discovery. */
+  baseline?: boolean;
+}
+
+function advertisesImageInput(modalities: readonly string[] | undefined): boolean | undefined {
+  if (!modalities || modalities.length === 0) return undefined;
+  return modalities.includes("image");
+}
+
+/** Vendor-table modalities for a routed row, or undefined when the table has no opinion. */
+function metadataImageInput(provider: string, modelId: string): boolean | undefined {
+  const resolved = resolveMetadataProvider(provider) ?? provider;
+  const meta = getModelMetadataCaseInsensitive(resolved, modelId);
+  return advertisesImageInput(meta?.input);
+}
+
+/**
+ * Is this model listed as one the sidecar describes FOR? Such a model cannot be
+ * the describer, and its advertised modalities are untrustworthy.
+ */
+export function isVisionSidecarConsumer(config: Pick<OcxConfig, "providers">, providerName: string, modelId: string): boolean {
+  const provider = config.providers?.[providerName];
+  return provider ? modelInList(provider.noVisionModels, modelId) : false;
+}
+
+/**
+ * Can this model accept an image on the wire? Sources are consulted in descending
+ * trustworthiness; the first that speaks wins. `undefined` means nothing knows,
+ * which callers treat as eligible.
+ */
+export function modelAcceptsImageInput(
+  config: Pick<OcxConfig, "providers">,
+  candidate: VisionCandidateModel,
+): boolean | undefined {
+  if (isVisionSidecarConsumer(config, candidate.provider, candidate.id)) return false;
+  if (candidate.native || SUPPORTED_NATIVE_OPENAI_SLUGS.has(candidate.id)) {
+    return advertisesImageInput(nativeInputModalities(candidate.id)) ?? true;
+  }
+  const fromRow = advertisesImageInput(candidate.inputModalities);
+  if (fromRow !== undefined) return fromRow;
+  return metadataImageInput(candidate.provider, candidate.id);
+}
+
+/** Eligible = not a sidecar consumer, and not positively known to be text-only. */
+export function isVisionEligibleModel(
+  config: Pick<OcxConfig, "providers">,
+  candidate: VisionCandidateModel,
+): boolean {
+  return modelAcceptsImageInput(config, candidate) !== false;
+}
+
+/** Which backend would describe through this row, or undefined when neither can. */
+export function visionBackendForCandidate(
+  config: Pick<OcxConfig, "providers">,
+  candidate: VisionCandidateModel,
+): VisionSidecarBackend | undefined {
+  if (candidate.native || candidate.provider === "openai") return "openai";
+  const adapter = config.providers?.[candidate.provider]?.adapter;
+  if (adapter === "anthropic") return "anthropic";
+  return undefined;
+}
+
+/**
+ * The picker's option list: every eligible row reachable by one of the two
+ * executors, plus each enabled side's baseline, de-duplicated and stably ordered
+ * (openai side first, baselines first within a side).
+ *
+ * This is the SUGGESTION list (narrow): it emits only rows an executor can reach
+ * and some source has heard of. It is deliberately NOT the same set as the write
+ * gate. `modelAcceptsImageInput` answers "can we prove this model cannot see?"
+ * and is the only input to rejection. Absence from this list must never imply
+ * rejection — an unknown id stays eligible via the undefined → eligible fallback.
+ *
+ * De-duplication is by BARE model id, first eligible row wins. Two providers of
+ * the same adapter family can expose the same id; they resolve to the same
+ * backend, and only `value` reaches the client, so first-wins costs nothing.
+ */
+export function visionEligibleModelOptions(
+  config: Pick<OcxConfig, "providers">,
+  candidates: readonly VisionCandidateModel[],
+  enabledBackends: readonly VisionSidecarBackend[],
+): VisionModelOption[] {
+  const enabled = new Set(enabledBackends);
+  const byValue = new Map<string, VisionModelOption>();
+
+  for (const backend of ["openai", "anthropic"] as const) {
+    if (!enabled.has(backend)) continue;
+    const id = BASELINE_VISION_MODELS[backend];
+    byValue.set(id, { value: id, label: id, backend, baseline: true });
+  }
+  for (const candidate of candidates) {
+    const backend = visionBackendForCandidate(config, candidate);
+    if (!backend || !enabled.has(backend)) continue;
+    if (!isVisionEligibleModel(config, candidate)) continue;
+    if (byValue.has(candidate.id)) continue;
+    byValue.set(candidate.id, { value: candidate.id, label: candidate.id, backend });
+  }
+
+  const order = (option: VisionModelOption) =>
+    (option.backend === "openai" ? 0 : 2) + (option.baseline ? 0 : 1);
+  return [...byValue.values()].sort((a, b) => order(a) - order(b) || a.value.localeCompare(b.value));
+}

--- a/src/vision/index.ts
+++ b/src/vision/index.ts
@@ -14,6 +14,15 @@ import type { TranslatorBudget } from "../lib/translator-budget";
 
 export { describeImage } from "./describe";
 export { describeImageAnthropic, parseAnthropicVisionSSE } from "./anthropic-describe";
+export {
+  BASELINE_VISION_MODELS,
+  isVisionEligibleModel,
+  isVisionSidecarConsumer,
+  modelAcceptsImageInput,
+  visionBackendForCandidate,
+  visionEligibleModelOptions,
+} from "./eligibility";
+export type { VisionCandidateModel, VisionModelOption, VisionSidecarBackend } from "./eligibility";
 
 const DEFAULT_VISION_MODEL = "gpt-5.4-mini";
 const DEFAULT_ANTHROPIC_VISION_MODEL = "claude-sonnet-5";

--- a/tests/vision-eligibility.test.ts
+++ b/tests/vision-eligibility.test.ts
@@ -164,6 +164,25 @@ describe("vision eligibility core", () => {
     expect(options.map(option => option.value)).not.toContain("umans-coder");
   });
 
+  test("12b. with no resolvable Anthropic executor, no Anthropic catalog row is offered", () => {
+    // `findAnthropicVisionProvider` requires an enabled OAuth row with a healthy account, so a
+    // key-auth canonical provider dispatches nothing. Offering its rows would surface an option
+    // that only fails later, at describe time. The baseline still keeps the side populated.
+    const config = configWithProviders({
+      anthropic: {
+        adapter: "anthropic",
+        authMode: "key",
+        baseUrl: "https://api.anthropic.com",
+      },
+    });
+    const options = visionEligibleModelOptions(
+      config,
+      [{ provider: "anthropic", id: "claude-key-only", inputModalities: ["text", "image"] }],
+      ["anthropic"],
+    );
+    expect(options.map(option => option.value)).toEqual([BASELINE_VISION_MODELS.anthropic]);
+  });
+
   test("13. a baseline listed as blind is dropped without removing the other backend baseline", () => {
     const config = configWithProviders({
       openai: {

--- a/tests/vision-eligibility.test.ts
+++ b/tests/vision-eligibility.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from "bun:test";
+import { NATIVE_OPENAI_MODELS } from "../src/codex/catalog/native-models";
+import type { OcxConfig } from "../src/types";
+import {
+  BASELINE_VISION_MODELS,
+  isVisionEligibleModel,
+  modelAcceptsImageInput,
+  visionBackendForCandidate,
+  visionEligibleModelOptions,
+  type VisionCandidateModel,
+} from "../src/vision/eligibility";
+
+const emptyConfig: Pick<OcxConfig, "providers"> = { providers: {} };
+
+function configWithProviders(providers: NonNullable<OcxConfig["providers"]>): Pick<OcxConfig, "providers"> {
+  return { providers };
+}
+
+describe("vision eligibility core", () => {
+  test("1. text-only exclusion discriminates against image-capable rows", () => {
+    // openrouter / openai/gpt-5.4-mini is text-only in generated metadata.
+    expect(
+      isVisionEligibleModel(emptyConfig, {
+        provider: "openrouter",
+        id: "openai/gpt-5.4-mini",
+      }),
+    ).toBe(false);
+
+    // anthropic / claude-haiku-4-5 is text+image — proves discrimination, not blanket rejection.
+    expect(
+      isVisionEligibleModel(emptyConfig, {
+        provider: "anthropic",
+        id: "claude-haiku-4-5",
+      }),
+    ).toBe(true);
+  });
+
+  test("2. noVisionModels is a hard disqualifier even when modalities advertise image", () => {
+    // applyProviderConfigHints rewrites noVisionModels rows to advertise image input.
+    // Membership must disqualify the describer BEFORE that rewritten modality list is trusted.
+    const config = configWithProviders({
+      "opencode-go": {
+        adapter: "openai-chat",
+        baseUrl: "https://opencode.ai/zen/go/v1",
+        noVisionModels: ["glm-5.2"],
+      },
+    });
+    const candidate: VisionCandidateModel = {
+      provider: "opencode-go",
+      id: "glm-5.2",
+      inputModalities: ["text", "image"],
+    };
+    expect(isVisionEligibleModel(config, candidate)).toBe(false);
+    expect(modelAcceptsImageInput(config, candidate)).toBe(false);
+  });
+
+  test("3a. silent catalog rows fall back to generated metadata (live /api/models shape)", () => {
+    // anthropic / claude-opus-4-6 carries ["text","image"] in the generated table, but live
+    // /api/models rows omit inputModalities entirely.
+    expect(
+      isVisionEligibleModel(emptyConfig, {
+        provider: "anthropic",
+        id: "claude-opus-4-6",
+      }),
+    ).toBe(true);
+  });
+
+  test("3b. completely unknown models stay eligible via the undefined tri-state", () => {
+    const candidate: VisionCandidateModel = {
+      provider: "anthropic",
+      id: "claude-future-9",
+    };
+    // Assert the tri-state directly — cases 3a and 3b would otherwise be indistinguishable
+    // and the fallback branch would never actually be driven.
+    expect(modelAcceptsImageInput(emptyConfig, candidate)).toBeUndefined();
+    expect(isVisionEligibleModel(emptyConfig, candidate)).toBe(true);
+  });
+
+  test("4. every native OpenAI slug is vision-eligible", () => {
+    // Deliberately not pinned to a count: an 8th native slug shipping is not a
+    // regression in this predicate, and a length assertion would fail for the
+    // wrong reason.
+    expect(NATIVE_OPENAI_MODELS.length).toBeGreaterThan(0);
+    for (const id of NATIVE_OPENAI_MODELS) {
+      expect(
+        isVisionEligibleModel(emptyConfig, {
+          provider: "openai",
+          id,
+          native: true,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  test("9. the exact candidate shapes the management write gate will synthesize", () => {
+    // WP2's PUT guard falls back to `{ provider: openai|anthropic, id }` when no
+    // catalog row matches. These three cases pin that path, because collapsing
+    // undefined into false here would silently start rejecting models the runtime
+    // has always accepted (tests/vision-reasoning-contract.test.ts:149-152 pins
+    // `custom-vision` at HTTP 200).
+    expect(modelAcceptsImageInput(emptyConfig, { provider: "openai", id: "custom-vision" })).toBeUndefined();
+    // The openai table's only text-only rows are codex-mini-latest, gpt-4, o3-mini;
+    // these are the sole ids the synthesized fallback can legitimately reject.
+    expect(modelAcceptsImageInput(emptyConfig, { provider: "openai", id: "o3-mini" })).toBe(false);
+    expect(modelAcceptsImageInput(emptyConfig, { provider: "anthropic", id: "claude-haiku-4-5" })).toBe(true);
+  });
+
+  test("10. a suffixed variant of a blind model is disqualified too", () => {
+    // modelInList (src/types.ts:208-213) matches the pre-colon prefix, so a
+    // `:extended` variant of a noVisionModels entry is still a sidecar consumer.
+    // Without this, a blind model could re-enter the picker under a suffix.
+    const config = configWithProviders({
+      "opencode-go": {
+        adapter: "openai-chat",
+        baseUrl: "https://opencode.ai/zen/go/v1",
+        noVisionModels: ["glm-5.2"],
+      },
+    });
+    expect(modelAcceptsImageInput(config, {
+      provider: "opencode-go",
+      id: "glm-5.2:extended",
+      inputModalities: ["text", "image"],
+    })).toBe(false);
+  });
+
+  test("5. openai baseline is present when that side is enabled", () => {
+    const options = visionEligibleModelOptions(emptyConfig, [], ["openai"]);
+    expect(options.map((o) => o.value)).toEqual([BASELINE_VISION_MODELS.openai]);
+    expect(options.every((o) => o.backend === "openai")).toBe(true);
+    expect(options.some((o) => o.backend === "anthropic")).toBe(false);
+  });
+
+  test("6. anthropic baseline is present when that side is enabled", () => {
+    const options = visionEligibleModelOptions(emptyConfig, [], ["anthropic"]);
+    expect(options.map((o) => o.value)).toEqual([BASELINE_VISION_MODELS.anthropic]);
+    expect(options.every((o) => o.backend === "anthropic")).toBe(true);
+    expect(options.some((o) => o.backend === "openai")).toBe(false);
+  });
+
+  test("7. baseline is not duplicated when the catalog also lists it", () => {
+    const config = configWithProviders({
+      anthropic: {
+        adapter: "anthropic",
+        baseUrl: "https://api.anthropic.com",
+      },
+    });
+    const options = visionEligibleModelOptions(
+      config,
+      [
+        {
+          provider: "anthropic",
+          id: BASELINE_VISION_MODELS.anthropic,
+          inputModalities: ["text", "image"],
+        },
+      ],
+      ["anthropic"],
+    );
+    const matches = options.filter((o) => o.value === BASELINE_VISION_MODELS.anthropic);
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.baseline).toBe(true);
+  });
+
+  test("8. backend routing excludes image-capable rows with no executor", () => {
+    // cursor has no vision sidecar executor — backend is undefined and the row is absent
+    // from the options list even when it is image-capable.
+    const config = configWithProviders({
+      cursor: {
+        adapter: "openai-chat",
+        baseUrl: "https://api2.cursor.sh",
+      },
+    });
+    const candidate: VisionCandidateModel = {
+      provider: "cursor",
+      id: "cursor-vision-capable",
+      inputModalities: ["text", "image"],
+    };
+    expect(visionBackendForCandidate(config, candidate)).toBeUndefined();
+    expect(isVisionEligibleModel(config, candidate)).toBe(true);
+    const options = visionEligibleModelOptions(config, [candidate], ["openai", "anthropic"]);
+    expect(options.some((o) => o.value === candidate.id)).toBe(false);
+    // baselines still appear for the enabled backends
+    expect(options.map((o) => o.value)).toEqual([
+      BASELINE_VISION_MODELS.openai,
+      BASELINE_VISION_MODELS.anthropic,
+    ]);
+  });
+});

--- a/tests/vision-eligibility.test.ts
+++ b/tests/vision-eligibility.test.ts
@@ -123,6 +123,72 @@ describe("vision eligibility core", () => {
     })).toBe(false);
   });
 
+  test("11. registry-backed noVisionModels still disqualifies a persisted provider row", () => {
+    // Catalog enrichment adds this registry list before it adds image to the row. A config
+    // saved before Umans gained the classification must reach the same enrichment here.
+    const config = configWithProviders({
+      umans: {
+        adapter: "anthropic",
+        baseUrl: "https://api.code.umans.ai",
+      },
+    });
+    expect(modelAcceptsImageInput(config, {
+      provider: "umans",
+      id: "umans-glm-5.2",
+      inputModalities: ["text", "image"],
+    })).toBe(false);
+  });
+
+  test("12. only the selected Anthropic OAuth provider contributes Anthropic options", () => {
+    const config = configWithProviders({
+      anthropic: {
+        adapter: "anthropic",
+        authMode: "oauth",
+        baseUrl: "https://api.anthropic.com",
+      },
+      umans: {
+        adapter: "anthropic",
+        baseUrl: "https://api.code.umans.ai",
+      },
+    });
+    const options = visionEligibleModelOptions(
+      config,
+      [
+        { provider: "anthropic", id: "claude-oauth-vision", inputModalities: ["text", "image"] },
+        { provider: "umans", id: "umans-coder", inputModalities: ["text", "image"] },
+      ],
+      ["anthropic"],
+      "anthropic",
+    );
+    expect(options.map(option => option.value)).toContain("claude-oauth-vision");
+    expect(options.map(option => option.value)).not.toContain("umans-coder");
+  });
+
+  test("13. a baseline listed as blind is dropped without removing the other backend baseline", () => {
+    const config = configWithProviders({
+      openai: {
+        adapter: "openai-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        noVisionModels: [BASELINE_VISION_MODELS.openai],
+      },
+      anthropic: {
+        adapter: "anthropic",
+        baseUrl: "https://api.anthropic.com",
+      },
+    });
+    expect(visionEligibleModelOptions(config, [], ["openai", "anthropic"], "anthropic").map(option => option.value)).toEqual([
+      BASELINE_VISION_MODELS.anthropic,
+    ]);
+  });
+
+  test("14. a non-native row's explicit text-only modality wins over a colliding native slug", () => {
+    expect(modelAcceptsImageInput(emptyConfig, {
+      provider: "custom-openai-compatible",
+      id: "gpt-5.4-mini",
+      inputModalities: ["text"],
+    })).toBe(false);
+  });
+
   test("5. openai baseline is present when that side is enabled", () => {
     const options = visionEligibleModelOptions(emptyConfig, [], ["openai"]);
     expect(options.map((o) => o.value)).toEqual([BASELINE_VISION_MODELS.openai]);


### PR DESCRIPTION
## Summary

The Vision sidecar model picker offered every model whose provider was `openai` or `anthropic`. That is simultaneously too wide — it lists models that cannot see — and too narrow, because it asks about a provider name instead of a capability. Users have been asking for more models; this is the foundation that lets the answer be "any model that can actually accept an image".

This layer adds `src/vision/eligibility.ts` and nothing else. It has no caller yet; the management API and the dashboard consume it in the PRs above.

Two rules make the predicate non-obvious, and both are load-bearing:

- **`provider.noVisionModels` inverts the modality signal.** That list marks models the proxy describes images *for*, and `applyProviderConfigHints` deliberately **adds** `"image"` to their advertised `inputModalities` so the Codex app does not block the attachment client-side before the sidecar can run. A blind model therefore advertises image input. Membership in that list is a hard disqualifier, checked **before** the modality list it rewrote.
- **Unknown is not zero.** Catalog rows routinely omit `inputModalities` entirely — the live `/api/models` response carries none for either `openai` or `anthropic` rows. So `modelAcceptsImageInput` is a tri-state, and `undefined` stays eligible. Collapsing it to `false` would have emptied the picker completely.

`visionEligibleModelOptions` is the **suggestion list** and is deliberately not the same set as the write gate that lands in the next PR: absence from it must never imply rejection. `gpt-5.6-luna` and `claude-haiku-4-5` are guaranteed per enabled backend so a cold or failed catalog still offers a usable describer.

## Verification

- `bun run typecheck` — exit 0
- `bun test tests/vision-eligibility.test.ts` — 11 pass, 0 fail
- `bun run test` (full suite) — 10146 pass, 0 fail, 632 files
- Red ablations proving the tests are not vacuous, each reverted afterwards:
  - removing the `isVisionSidecarConsumer` early return → 1 fail (the inversion guard is genuinely exercised)
  - replacing the metadata fallback with `undefined` → 1 fail (the fallback branch is genuinely exercised)

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

---

**Stack** (merge bottom-up):

| # | PR | Layer | Review focus |
|---|----|-------|--------------|
| 3 | dashboard vision card | dashboard | layout, non-localized effort values |
| 2 | management API | server | the 400 gate and the allowed-list payload |
| 1 | vision eligibility core ← you are here | predicate | the inversion case and the tri-state |

Review this PR's diff only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added vision sidecar model eligibility filtering for OpenAI and Anthropic providers.
  - Model options now prioritize baseline models, exclude models already used by sidecars, and remove duplicates.
  - Added image-capability detection using available provider and model metadata.
  - Unknown model capabilities remain selectable when eligibility cannot be confirmed.
  - Added backend-aware routing for eligible vision models.

- **Documentation**
  - Added a phased roadmap for management APIs, dashboard integration, validation, fallback behavior, and rollout verification.

- **Tests**
  - Added coverage for modality detection, overrides, metadata fallbacks, baselines, deduplication, and backend routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->