### PR TITLE
fix(adapters): reject malformed nested response shapes

### DIFF
--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -577,15 +577,32 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
           pendingUsage = usageFromGemini(usageMeta);
           sawTerminalSignal = true;
         }
-        const candidates = root.candidates as { content?: { parts?: unknown[] }; finishReason?: string }[] | undefined;
-        if (!candidates?.length) return "continue";
+        const rawCandidates = root.candidates;
+        if (rawCandidates === undefined) return "continue";
+        if (!Array.isArray(rawCandidates)) {
+          yield { type: "error", message: "google response contained invalid candidates" };
+          return "terminate";
+        }
+        if (rawCandidates.length === 0) return "continue";
+        const rawCandidate = rawCandidates[0];
+        if (rawCandidate === null || typeof rawCandidate !== "object" || Array.isArray(rawCandidate)) {
+          // Unlike a root `data: null` keepalive, this is a claimed response candidate. Treat it
+          // as terminal protocol corruption so the turn cannot complete after silently losing
+          // a candidate or tool call (#1325).
+          yield { type: "error", message: "google response contained invalid candidates" };
+          return "terminate";
+        }
+        const candidate = rawCandidate as {
+          content?: { parts?: unknown[] };
+          finishReason?: string;
+        };
 
-        if (typeof candidates[0].finishReason === "string" && candidates[0].finishReason) {
-          lastFinishReason = candidates[0].finishReason;
+        if (typeof candidate.finishReason === "string" && candidate.finishReason) {
+          lastFinishReason = candidate.finishReason;
           sawTerminalSignal = true;
         }
 
-        const parts = candidates[0].content?.parts as { text?: string; functionCall?: { name: string; args: unknown } }[] | undefined;
+        const parts = candidate.content?.parts as { text?: string; functionCall?: { name: string; args: unknown } }[] | undefined;
         // Record Gemini thought signatures for the next stateless tool-result turn. Vertex and
         // Antigravity use separate model namespaces so opaque provider state cannot cross routes.
         const replayModel = provider.googleMode === "cloud-code-assist" ? antigravityModel : vertexReplayModel;

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -163,6 +163,18 @@ function invalidChoicesEvent(usage?: OcxUsage): Extract<AdapterEvent, { type: "e
   };
 }
 
+function invalidToolCallsEvent(usage?: OcxUsage): Extract<AdapterEvent, { type: "error" }> {
+  return {
+    type: "error",
+    message: "upstream response contained invalid tool calls",
+    ...(usage !== undefined ? { usage } : {}),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 function developerSystemText(message: OcxMessage): string | undefined {
   if (message.role !== "developer") return undefined;
   if (typeof message.content === "string") return message.content;
@@ -916,9 +928,23 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
             yield { type: "text_delta", text: delta.content };
           }
 
-          const toolCalls = delta.tool_calls as { index?: number; id?: string; function?: { name?: string; arguments?: string } }[] | undefined;
-          if (toolCalls) {
-            for (const tc of toolCalls) {
+          const rawToolCalls = delta.tool_calls;
+          if (rawToolCalls !== undefined) {
+            // A claimed tool-call payload is not benign padding. Dropping it can leave the
+            // matching result permanently orphaned, so malformed nested shapes fail closed
+            // through the adapter error channel instead of escaping as TypeError (#1325).
+            if (!Array.isArray(rawToolCalls)) {
+              return yield* terminateWithError(invalidToolCallsEvent(pendingUsage));
+            }
+            for (const rawToolCall of rawToolCalls) {
+              if (!isRecord(rawToolCall)) {
+                return yield* terminateWithError(invalidToolCallsEvent(pendingUsage));
+              }
+              const tc = rawToolCall as {
+                index?: number;
+                id?: string;
+                function?: { name?: string; arguments?: string };
+              };
               const key = typeof tc.index === "number"
                 ? `i:${tc.index}`
                 : tc.id
@@ -1073,11 +1099,21 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
         const reasoningText = reasoningTextFrom(msg);
         if (reasoningText !== undefined) events.push({ type: "reasoning_raw_delta", text: reasoningText });
         if (typeof msg.content === "string") events.push({ type: "text_delta", text: msg.content });
-        const toolCalls = msg.tool_calls as { id: string; function: { name: string; arguments: string } }[] | undefined;
-        if (toolCalls) {
-          for (const tc of toolCalls) {
-            events.push({ type: "tool_call_start", id: tc.id, name: tc.function.name });
-            events.push({ type: "tool_call_delta", arguments: tc.function.arguments });
+        const rawToolCalls = msg.tool_calls;
+        if (rawToolCalls !== undefined) {
+          if (!Array.isArray(rawToolCalls)) return [invalidToolCallsEvent(usage)];
+          for (const rawToolCall of rawToolCalls) {
+            if (!isRecord(rawToolCall) || !isRecord(rawToolCall.function)) {
+              return [invalidToolCallsEvent(usage)];
+            }
+            const id = rawToolCall.id;
+            const name = rawToolCall.function.name;
+            const args = rawToolCall.function.arguments;
+            if (typeof id !== "string" || typeof name !== "string" || typeof args !== "string") {
+              return [invalidToolCallsEvent(usage)];
+            }
+            events.push({ type: "tool_call_start", id, name });
+            events.push({ type: "tool_call_delta", arguments: args });
             events.push({ type: "tool_call_end" });
           }
         }

--- a/tests/google-hardening.test.ts
+++ b/tests/google-hardening.test.ts
@@ -115,6 +115,18 @@ describe("google provider hardening", () => {
     expect(events.some(event => event.type === "done")).toBe(false);
   });
 
+  test("a malformed nested candidate is a terminal stream error", async () => {
+    const events = await collect(createGoogleAdapter(provider()).parseStream(
+      sseResponse([{ candidates: [null] }, { candidates: [{ finishReason: "STOP" }] }]),
+    ));
+
+    expect(events).toEqual([{
+      type: "error",
+      message: "google response contained invalid candidates",
+    }]);
+    expect(events.some(event => event.type === "done")).toBe(false);
+  });
+
   test("EOF residual data frame without a trailing newline is parsed", async () => {
     const events = await collect(createGoogleAdapter(provider()).parseStream(
       new Response('data:{"candidates":[{"content":{"parts":[{"text":"final"}]},"finishReason":"STOP"}]}', {

--- a/tests/openai-chat-hardening.test.ts
+++ b/tests/openai-chat-hardening.test.ts
@@ -116,6 +116,25 @@ describe("openai-chat non-stream response hardening", () => {
 
     expect(events).toEqual([{ type: "error", message: "upstream response contained invalid choices" }]);
   });
+
+  test("rejects malformed nested tool calls without throwing", async () => {
+    const adapter = createOpenAIChatAdapter(provider());
+    for (const toolCalls of [
+      { unexpected: true },
+      [null],
+      [{ id: "call_missing_function" }],
+    ]) {
+      const events = await adapter.parseResponse!(new Response(JSON.stringify({
+        choices: [{ message: { role: "assistant", tool_calls: toolCalls } }],
+        usage: { prompt_tokens: 7, completion_tokens: 2 },
+      })));
+      expect(events).toEqual([{
+        type: "error",
+        message: "upstream response contained invalid tool calls",
+        usage: { inputTokens: 7, outputTokens: 2 },
+      }]);
+    }
+  });
 });
 
 describe("openai-chat stream response hardening", () => {
@@ -159,6 +178,26 @@ describe("openai-chat stream response hardening", () => {
 
     expect(events.at(-1)).toEqual({ type: "error", message: "malformed upstream SSE data frame" });
     expect(events.some(event => event.type === "done")).toBe(false);
+  });
+
+  test("malformed nested streaming tool calls are terminal errors", async () => {
+    const adapter = createOpenAIChatAdapter(provider());
+    for (const toolCalls of [{ unexpected: true }, [null]]) {
+      const response = new Response([
+        `data: ${JSON.stringify({
+          choices: [{ delta: { tool_calls: toolCalls } }],
+          usage: { prompt_tokens: 7, completion_tokens: 2 },
+        })}\n\n`,
+        "data: [DONE]\n\n",
+      ].join(""));
+
+      const events = await collect(adapter.parseStream(response));
+      expect(events).toEqual([{
+        type: "error",
+        message: "upstream response contained invalid tool calls",
+        usage: { inputTokens: 7, outputTokens: 2 },
+      }]);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

* Reject malformed nested Google candidate and OpenAI Chat tool-call shapes through the adapter error channel.
* Keep root `data: null` padding behavior unchanged while failing closed once an upstream claims a candidate or tool call.
* Preserve non-stream usage accounting and prevent raw JavaScript `TypeError` exceptions from escaping the adapter.

## Verification

* `taskset -c 0-1 bun run typecheck` — passed on the rebased exact head.
* `taskset -c 0-1 bun test tests/openai-chat-hardening.test.ts tests/google-hardening.test.ts tests/openai-chat-parallel-stream.test.ts tests/google-vertex-stream.test.ts` — 83 passed, 0 failed on the rebased exact head.
* Full pre-rebase suite — 10,130 passed, 10 skipped, 1 unrelated existing local-environment failure in `tests/codex-shim.test.ts` (`Unix shim exports persisted service API token before running Codex`); that failure reproduces in isolation and does not touch adapter code.
* `git diff --check origin/dev...HEAD` — passed.

## Decision Log

* 목적과 의도: Prevent malformed nested upstream response structures from silently losing tool calls or crashing the request with an implementation-level exception.
* 기존 구현 및 제약 조건: Root null SSE padding is intentionally tolerated, but nested `candidates: [null]`, object-shaped `tool_calls`, null tool calls, and missing tool functions were trusted through casts.
* 검토한 주요 대안: Ignore malformed entries, coerce them into empty values, or terminate the adapter turn with a structured error.
* 선택한 방식: Preserve benign root padding and fail closed only after an upstream claims a malformed candidate or tool-call structure.
* 다른 대안 대신 이 방식을 선택한 이유: Ignoring or coercing a claimed tool call can orphan its matching result and allow a false successful completion; a structured adapter error is deterministic and observable.
* 장점, 단점 및 영향: Valid provider responses are unchanged and malformed turns no longer leak raw `TypeError`; malformed providers now receive a terminal error instead of best-effort continuation.

## Checklist

- [X] Scope stays focused and avoids unrelated cleanup.
- [X] Docs or release notes were updated when needed. No public configuration or API contract changed, so no docs update is needed.
- [X] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. This patch changes response validation only and does not touch credentials or routing authority.

Closes lidge-jun/opencodex#1325

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed Google response candidates by returning clear terminal errors instead of silently skipping invalid data.
  * Added validation for malformed tool-call payloads in OpenAI Chat responses, preventing runtime errors and reporting adapter errors consistently.
  * Preserved usage-token metadata when invalid tool-call data is encountered.
* **Tests**
  * Added coverage for malformed Google candidates and OpenAI tool-call payloads in streaming and non-streaming responses.