### PR TITLE
fix(vertex): scope replay by client thread

### DIFF
--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -54,8 +54,8 @@ function resolveVertexApiKey(optKey?: string): string | undefined {
 /** Prefer Codex's stable opaque thread key; retain the existing deterministic fallback for clients
  * that omit it. The replay store hashes this value and never retains the raw session identifier. */
 function vertexReplaySessionId(parsed: OcxParsedRequest): string {
-  const promptCacheKey = parsed.options.promptCacheKey?.trim();
-  return promptCacheKey || antigravitySessionId(parsed);
+  const threadId = parsed._clientThreadId?.trim();
+  return threadId || antigravitySessionId(parsed);
 }
 
 /**

--- a/tests/google-vertex-thought-signature.test.ts
+++ b/tests/google-vertex-thought-signature.test.ts
@@ -55,6 +55,16 @@ const continuation = () => request([
   },
 ], false);
 
+function scopedReplayRequest(
+  parsed: OcxParsedRequest,
+  threadId: string | undefined,
+  promptCacheKey: string | undefined,
+): OcxParsedRequest {
+  if (threadId !== undefined) parsed._clientThreadId = threadId;
+  if (promptCacheKey !== undefined) parsed.options.promptCacheKey = promptCacheKey;
+  return parsed;
+}
+
 function vertexResponseBody(): Record<string, unknown> {
   return {
     candidates: [{
@@ -104,6 +114,34 @@ describe("Vertex thought-signature continuation (#1254)", () => {
     expect(events.some(event => event.type === "tool_call_start")).toBe(true);
 
     const followup = await createGoogleAdapter(provider).buildRequest(continuation());
+    expect(replayedFunctionCall(followup.body as string).thoughtSignature).toBe(SIGNATURE);
+  });
+
+  test("#1312: shared prompt cache keys cannot cross client-thread replay namespaces", async () => {
+    const first = scopedReplayRequest(firstTurn(false), "thread-a", "shared-cache-cohort");
+    const firstAdapter = createGoogleAdapter(provider);
+    await firstAdapter.buildRequest(first);
+    await firstAdapter.parseResponse!(new Response(JSON.stringify(vertexResponseBody())));
+
+    const otherThread = await createGoogleAdapter(provider).buildRequest(
+      scopedReplayRequest(continuation(), "thread-b", "shared-cache-cohort"),
+    );
+    expect(replayedFunctionCall(otherThread.body as string).thoughtSignature).toBeUndefined();
+
+    const originalThread = await createGoogleAdapter(provider).buildRequest(
+      scopedReplayRequest(continuation(), "thread-a", "different-cache-cohort"),
+    );
+    expect(replayedFunctionCall(originalThread.body as string).thoughtSignature).toBe(SIGNATURE);
+  });
+
+  test("#1312: threadless clients keep deterministic replay regardless of prompt cache key", async () => {
+    const firstAdapter = createGoogleAdapter(provider);
+    await firstAdapter.buildRequest(scopedReplayRequest(firstTurn(false), undefined, "cohort-a"));
+    await firstAdapter.parseResponse!(new Response(JSON.stringify(vertexResponseBody())));
+
+    const followup = await createGoogleAdapter(provider).buildRequest(
+      scopedReplayRequest(continuation(), undefined, "cohort-b"),
+    );
     expect(replayedFunctionCall(followup.body as string).thoughtSignature).toBe(SIGNATURE);
   });
 


### PR DESCRIPTION
## Summary

* Scope Vertex thought-signature replay to Codex's stable client thread identifier instead of the potentially shared prompt-cache key.
* Preserve the deterministic fallback for clients that do not send a thread identifier.
* Add regressions proving shared cache cohorts cannot replay signatures across threads while same-thread continuation still works.

Closes lidge-jun/opencodex#1312

## Verification

* `taskset -c 0-1 bun run typecheck`
* `taskset -c 0-1 bun test tests/antigravity-static-catalog.test.ts tests/google-adapter.test.ts tests/google-antigravity-oauth.test.ts tests/google-antigravity-replay.test.ts tests/google-antigravity-wire.test.ts tests/google-empty-content.test.ts tests/google-hardening.test.ts tests/google-models-listing.test.ts tests/google-tool-schema.test.ts tests/google-vertex-http.test.ts tests/google-vertex-stream.test.ts tests/google-vertex-thought-signature.test.ts tests/google-wire-compiler.test.ts tests/vertex-catalog.test.ts` (227 pass, 0 fail)
* `git diff --check origin/dev...HEAD`

## Checklist

- [X] Scope stays focused and avoids unrelated cleanup.
- [X] Docs or release notes were updated when needed. No documentation change is needed because this restores the existing per-thread replay contract.
- [X] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. No credential or raw thread identifier is persisted; the replay store continues to hash the namespace key.

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vertex replay session handling by prioritizing the client thread identifier when available.
  * Prevented replay signatures from being incorrectly shared across separate client threads.
  * Preserved deterministic replay behavior for requests without a client thread identifier.