### PR TITLE
docs(devlog): record the layer-3 merge commit in the vision filter outcome

### DIFF
--- a/devlog/_fin/260809_vision_sidecar_model_filter/060_outcome.md
+++ b/devlog/_fin/260809_vision_sidecar_model_filter/060_outcome.md
@@ -6,7 +6,7 @@ Shipped. Three layers on `dev`, bottom-up, one PABCD cycle each.
 |---|---|---|---|
 | 1 — eligibility predicate | #1326 | `eebd9d48f` | `src/vision/eligibility.ts`, the devlog unit |
 | 2 — management API + write gate | #1327 | `d4758bc94` | options module, both routes, shared model resolver |
-| 3 — dashboard card | #1328 | (this unit's close) | filtered picker, backend provenance, card shell |
+| 3 — dashboard card | #1328 | `e96a81bed` | filtered picker, backend provenance, card shell |
 
 ## What the user asked for, and what answers it
 


### PR DESCRIPTION
## Summary

Closes the last loose end from the vision sidecar model filter stack (#1326 → #1327 → #1328).

The outcome doc was written and committed before layer 3 merged, so its merge-commit table carried `(this unit's close)` as a placeholder for the dashboard-card row. `050_stack_landing.md` asks each layer's merge commit to be recorded, so the closed unit was not fully auditable. This fills in `e96a81bed`.

One line in one markdown file. No code, no test, no behavior change — and no UI change, so there is nothing to screenshot.

## Verification

- `bun run typecheck` — exit 0
- `bun scripts/privacy-scan.ts` — Privacy scan passed
- `bun test` over the four vision suites (eligibility, sidecar-settings filter, reasoning contract, dashboard option helper) — 43 pass / 0 fail on the landed `dev` tip
- `bun test tests/repo-hygiene.test.ts` — 11 pass / 0 fail

## Checklist

- [x] Targets `dev`
- [x] Docs-only change, no user-facing behavior
- [x] Local checks green