### PR TITLE
fix(routing): define hard cost-cap behavior when cost evidence is unknown

### DIFF
--- a/src/routing/evaluator.ts
+++ b/src/routing/evaluator.ts
@@ -304,14 +304,25 @@ export function evaluatePolicyProfile(
     const excludedByUnknown = unknown && profile.unknownEvidence.capability === "exclude";
     const costLimit = profile.limits.maxEstimatedCostUsd;
     const estimatedCost = evidence.cost?.estimatedUsd;
+    const costEstimateKnown = typeof estimatedCost === "number" && Number.isFinite(estimatedCost);
     const overCostLimit = costLimit !== undefined
-      && typeof estimatedCost === "number"
-      && Number.isFinite(estimatedCost)
-      && estimatedCost > costLimit;
+      && costEstimateKnown
+      && estimatedCost! > costLimit;
     if (overCostLimit) {
       exclusions.push({ code: "cost-limit", detail: "maxEstimatedCostUsd" });
     }
-    let eligible = !unsatisfied && !excludedByUnknown && !overCostLimit;
+    // A cap can only be *proven* satisfied when the estimate is known. The live
+    // routing path often has no usage evidence yet, so the default stays
+    // "allow" to preserve the documented dry-run contract; operators who need a
+    // genuine hard ceiling opt into "exclude". The distinct exclusion code lets
+    // a trace distinguish "known above the cap" from "cost is unknown".
+    const unknownCostBlocked = costLimit !== undefined
+      && !costEstimateKnown
+      && profile.limits.onUnknownCost === "exclude";
+    if (unknownCostBlocked) {
+      exclusions.push({ code: "cost-limit-unknown", detail: "maxEstimatedCostUsd" });
+    }
+    let eligible = !unsatisfied && !excludedByUnknown && !overCostLimit && !unknownCostBlocked;
 
     // Health scoring (RI-06): live hard cooldown is authoritative and
     // excludes; unknown health follows the profile's unknownEvidence policy;

--- a/src/routing/profile.ts
+++ b/src/routing/profile.ts
@@ -9,6 +9,7 @@ import type {
   OcxConfig,
   OcxRoutingProfileConfig,
   OcxRoutingUnknownEvidenceMode,
+  OcxRoutingUnknownCostCapMode,
 } from "../types";
 import { codexAccountNamespaceEntries } from "../codex/account-namespaces";
 import { listComboIds, resolveComboId } from "../combos";
@@ -60,7 +61,7 @@ export interface NormalizedRoutingProfile {
   candidates: Array<{ provider: string; model: string }>;
   require: NormalizedRoutingProfileRequirements;
   optimize: { latency: number; health: number; cost: number; quota: number };
-  limits: { maxEstimatedCostUsd?: number };
+  limits: { maxEstimatedCostUsd?: number; onUnknownCost?: OcxRoutingUnknownCostCapMode };
   unknownEvidence: Record<"capability" | "health" | "quota" | "cost", OcxRoutingUnknownEvidenceMode>;
   revision: string;
 }
@@ -317,6 +318,11 @@ export function routingProfileIssues(
           || limits.maxEstimatedCostUsd < 0)) {
         issues.push({ path: ["limits", "maxEstimatedCostUsd"], message: "maxEstimatedCostUsd must be a non-negative number" });
       }
+      if (limits.onUnknownCost !== undefined
+        && limits.onUnknownCost !== "allow"
+        && limits.onUnknownCost !== "exclude") {
+        issues.push({ path: ["limits", "onUnknownCost"], message: 'onUnknownCost must be "allow" or "exclude"' });
+      }
     }
   }
 
@@ -401,6 +407,9 @@ export function normalizeRoutingProfile(id: string, raw: OcxRoutingProfileConfig
     limits: {
       ...(raw.limits?.maxEstimatedCostUsd !== undefined
         ? { maxEstimatedCostUsd: raw.limits.maxEstimatedCostUsd }
+        : {}),
+      ...(raw.limits?.onUnknownCost !== undefined
+        ? { onUnknownCost: raw.limits.onUnknownCost }
         : {}),
     },
     unknownEvidence: normalizedUnknownEvidence(raw),

--- a/src/types.ts
+++ b/src/types.ts
@@ -955,9 +955,23 @@ export interface OcxRoutingProfileOptimize {
   quota?: number;
 }
 
+/**
+ * Policy for the hard cost ceiling when a candidate has no finite cost
+ * estimate. `"allow"` (default) preserves the documented dry-run contract:
+ * the cap only excludes evidence known to exceed it. `"exclude"` makes the
+ * ceiling fail-closed, so a candidate that cannot be proven under the cap is
+ * ineligible.
+ */
+export type OcxRoutingUnknownCostCapMode = "allow" | "exclude";
+
 export interface OcxRoutingProfileLimits {
   /** Hard per-request estimated-cost ceiling in USD. */
   maxEstimatedCostUsd?: number;
+  /**
+   * How `maxEstimatedCostUsd` behaves when the estimate is unknown.
+   * Defaults to `"allow"`; opt in to `"exclude"` for a true hard ceiling.
+   */
+  onUnknownCost?: OcxRoutingUnknownCostCapMode;
 }
 
 export interface OcxRoutingProfileUnknownEvidence {

--- a/tests/cost-cap-unknown-evidence.test.ts
+++ b/tests/cost-cap-unknown-evidence.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Reproduction for issue #1181 — "Routing: define hard cost-cap behavior when
+ * runtime cost evidence is unknown".
+ *
+ * The hard ceiling `limits.maxEstimatedCostUsd` is documented as a hard
+ * per-request cap. In the live routing path it never fires, because
+ * `router.ts` assembles cost evidence WITHOUT usage:
+ *
+ *   costEvidenceForCandidate({ provider, model, limitUsd })   // no `usage`
+ *
+ * `costEvidenceForCandidate` then returns `{ limitUsd, incomplete: true }`
+ * with no `estimatedUsd`, and the evaluator's cap check
+ * (evaluator.ts:307-310) requires `typeof estimatedCost === "number"`, so an
+ * unknown estimate silently passes a cap the operator configured as hard.
+ *
+ * The existing test in cost-scoring.test.ts only exercises the cap with
+ * `usage: USAGE` supplied — i.e. on a code path production never takes.
+ *
+ * These tests pin both sides of `limits.onUnknownCost`:
+ *   - the default `"allow"`, which preserves the documented dry-run contract
+ *     and lets an unprovable candidate through, and
+ *   - the opt-in `"exclude"`, which makes the ceiling genuinely hard and
+ *     reports the distinct `cost-limit-unknown` exclusion.
+ *
+ * The first case was originally written as a failing reproduction before the
+ * evaluator change landed; it is retained to keep the fail-open default
+ * asserted rather than assumed.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { costEvidenceForCandidate } from "../src/routing/cost";
+import { evaluatePolicyProfile } from "../src/routing/evaluator";
+import type { OcxConfig } from "../src/types";
+
+let testDir = "";
+let previousHome: string | undefined;
+
+beforeEach(() => {
+  previousHome = process.env.OPENCODEX_HOME;
+  testDir = mkdtempSync(join(tmpdir(), "ocx-cost-cap-"));
+  process.env.OPENCODEX_HOME = testDir;
+});
+
+afterEach(() => {
+  if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = previousHome;
+  if (testDir) rmSync(testDir, { recursive: true, force: true });
+});
+
+/** Mirrors the live routing path: a cap is configured, usage is NOT available. */
+function configWithCap(capUsd: number, overrides: Record<string, unknown> = {}): OcxConfig {
+  return {
+    port: 10100,
+    defaultProvider: "anthropic",
+    providers: {
+      anthropic: {
+        adapter: "anthropic",
+        baseUrl: "https://api.anthropic.com/v1",
+        apiKey: "kan",
+        models: ["claude-opus-5"],
+      },
+    },
+    routingProfiles: {
+      cost: {
+        candidates: [{ provider: "anthropic", model: "claude-opus-5" }],
+        optimize: { cost: 0.8 },
+        limits: { maxEstimatedCostUsd: capUsd },
+        unknownEvidence: { capability: "allow", health: "allow", quota: "allow", cost: "allow" },
+        ...overrides,
+      },
+    },
+  } as OcxConfig;
+}
+
+describe("issue #1181 — hard cost cap under unknown evidence", () => {
+  test("default allow: live-path evidence carries no estimate, so the cap does not fire", async () => {
+    // Exactly how router.ts:515-519 builds it — no `usage` argument.
+    const evidence = costEvidenceForCandidate({
+      provider: "anthropic",
+      model: "claude-opus-5",
+      limitUsd: 0.000001, // an absurdly low cap; nothing should realistically pass
+    });
+
+    // The evidence is explicitly unknown, and correctly so.
+    expect(evidence.estimatedUsd).toBeUndefined();
+    expect(evidence.incomplete).toBe(true);
+    expect(evidence.limitUsd).toBe(0.000001);
+
+    const result = evaluatePolicyProfile(configWithCap(0.000001), "cost", {}, [
+      {
+        provider: "anthropic",
+        model: "claude-opus-5",
+        capability: { contextWindow: 200000 },
+        cost: evidence,
+      },
+    ]);
+
+    // Current behaviour: the candidate is eligible and selected despite a cap
+    // of $0.000001. No `cost-limit` exclusion is recorded, and nothing in the
+    // trace distinguishes "known below cap" from "cost unknown".
+    expect(result.candidates[0]!.eligible).toBe(true);
+    expect(
+      result.candidates[0]!.exclusions.some(e => e.code === "cost-limit"),
+    ).toBe(false);
+    expect(result.selectedIndex).toBe(0);
+  });
+
+  test("opt-in exclude: fail-closed cap excludes unknown-cost candidates", async () => {
+    const evidence = costEvidenceForCandidate({
+      provider: "anthropic",
+      model: "claude-opus-5",
+      limitUsd: 0.000001,
+    });
+
+    // Proposed opt-in policy: limits.onUnknownCost = "exclude".
+    const result = evaluatePolicyProfile(
+      configWithCap(0.000001, { limits: { maxEstimatedCostUsd: 0.000001, onUnknownCost: "exclude" } }),
+      "cost",
+      {},
+      [
+        {
+          provider: "anthropic",
+          model: "claude-opus-5",
+          capability: { contextWindow: 200000 },
+          cost: evidence,
+        },
+      ],
+    );
+
+    expect(result.candidates[0]!.eligible).toBe(false);
+    // Distinct code so operators can tell "over a known cap" from "cost unknown".
+    expect(
+      result.candidates[0]!.exclusions.some(e => e.code === "cost-limit-unknown"),
+    ).toBe(true);
+    expect(result.selectedIndex).toBeNull();
+  });
+
+  test("cap policy and unknownEvidence.cost are distinct mechanisms", async () => {
+    // unknownEvidence.cost governs SCORING of an unknown-cost candidate;
+    // limits.onUnknownCost governs whether the hard CEILING applies to it.
+    // They must produce distinct exclusion codes so a trace stays diagnosable.
+    const evidence = costEvidenceForCandidate({
+      provider: "anthropic",
+      model: "claude-opus-5",
+      limitUsd: 0.000001,
+    });
+
+    const scoringExcluded = evaluatePolicyProfile(
+      configWithCap(0.000001, {
+        unknownEvidence: { capability: "allow", health: "allow", quota: "allow", cost: "exclude" },
+      }),
+      "cost",
+      {},
+      [{ provider: "anthropic", model: "claude-opus-5", capability: { contextWindow: 200000 }, cost: evidence }],
+    );
+
+    const codes = scoringExcluded.candidates[0]!.exclusions.map(e => e.code);
+    expect(codes).toContain("unknown-price");
+    expect(codes).not.toContain("cost-limit-unknown");
+    expect(scoringExcluded.candidates[0]!.eligible).toBe(false);
+  });
+
+  test("no cap configured — onUnknownCost is inert", async () => {
+    const evidence = costEvidenceForCandidate({ provider: "anthropic", model: "claude-opus-5" });
+    const noCap = {
+      port: 10100,
+      defaultProvider: "anthropic",
+      providers: {
+        anthropic: { adapter: "anthropic", baseUrl: "https://api.anthropic.com/v1", apiKey: "kan", models: ["claude-opus-5"] },
+      },
+      routingProfiles: {
+        cost: {
+          candidates: [{ provider: "anthropic", model: "claude-opus-5" }],
+          optimize: { cost: 0.8 },
+          limits: { onUnknownCost: "exclude" }, // no maxEstimatedCostUsd
+          unknownEvidence: { capability: "allow", health: "allow", quota: "allow", cost: "allow" },
+        },
+      },
+    } as unknown as OcxConfig;
+
+    const result = evaluatePolicyProfile(noCap, "cost", {}, [
+      { provider: "anthropic", model: "claude-opus-5", capability: { contextWindow: 200000 }, cost: evidence },
+    ]);
+
+    // Without a ceiling there is nothing to fail closed against.
+    expect(result.candidates[0]!.eligible).toBe(true);
+    expect(
+      result.candidates[0]!.exclusions.some(e => e.code === "cost-limit-unknown"),
+    ).toBe(false);
+  });
+
+  test("default stays allow — the documented contract is unchanged", async () => {
+    const evidence = costEvidenceForCandidate({
+      provider: "anthropic",
+      model: "claude-opus-5",
+      limitUsd: 0.000001,
+    });
+
+    // No onUnknownCost configured → must behave exactly as today (fail-open),
+    // so existing deployments do not lose every live route on upgrade.
+    const result = evaluatePolicyProfile(configWithCap(0.000001), "cost", {}, [
+      {
+        provider: "anthropic",
+        model: "claude-opus-5",
+        capability: { contextWindow: 200000 },
+        cost: evidence,
+      },
+    ]);
+
+    expect(result.candidates[0]!.eligible).toBe(true);
+    expect(result.selectedIndex).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #1181.

## Summary

`limits.maxEstimatedCostUsd` is documented as a hard per-request ceiling, but it never fires on the live routing path.

`evaluatePolicyProfile` only excludes a candidate when the estimate is a finite number (`src/routing/evaluator.ts`):

```ts
const overCostLimit = costLimit !== undefined
  && typeof estimatedCost === "number"   // an unknown estimate passes silently
  && Number.isFinite(estimatedCost)
  && estimatedCost > costLimit;
```

…while `routeModel` assembles cost evidence **without** usage (`src/router.ts`):

```ts
cost: costEvidenceForCandidate({
  provider: candidate.provider,
  model: candidate.model,
  limitUsd: profile.limits.maxEstimatedCostUsd,   // no `usage`
}),
```

`costEvidenceForCandidate` correctly returns `{ limitUsd, incomplete: true }` with no `estimatedUsd`, so on the live path the estimate is *always* unknown and any candidate passes a cap the operator configured as hard. The existing coverage passes only because it supplies `usage` directly — exercising a path production does not take.

As #1181 notes, failing closed unconditionally is not safe either: with usage unwired it would reject every live candidate whenever a cap is set, and it would silently change the documented dry-run contract.

This adds an explicit, opt-in policy instead:

```jsonc
{
  "limits": {
    "maxEstimatedCostUsd": 0.25,
    "onUnknownCost": "exclude"   // "allow" (default) | "exclude"
  }
}
```

- **`"allow"` (default)** — preserves current behaviour and the documented contract exactly. No existing deployment changes on upgrade.
- **`"exclude"`** — the ceiling becomes genuinely hard: a candidate whose cost cannot be *proven* under the cap is ineligible.

Unknown-cost exclusions emit a distinct **`cost-limit-unknown`** code, so a trace distinguishes *known above the cap* from *cost is unknown* — the operator-facing distinction the issue asks for.

Kept deliberately separate from `unknownEvidence.cost`, which governs how an unknown-cost candidate is **scored** rather than whether the **ceiling** applies. A test asserts the two mechanisms stay distinguishable.

| File | Change |
|---|---|
| `src/types.ts` | `OcxRoutingUnknownCostCapMode`; `onUnknownCost` on `OcxRoutingProfileLimits` |
| `src/routing/profile.ts` | Validation (`"allow"` / `"exclude"`) + normalization |
| `src/routing/evaluator.ts` | Cap policy under unknown evidence; `cost-limit-unknown` exclusion |
| `tests/cost-cap-unknown-evidence.test.ts` | New — 5 cases |

## Verification

The defect was reproduced with a failing test **before** the fix: with a `$0.000001` cap and live-path evidence (no usage), the candidate was still eligible and selected.

Commands run against the `dev` base:

```
bun test tests/cost-cap-unknown-evidence.test.ts     → 5 pass, 0 fail
bun test tests/cost-scoring.test.ts \
         tests/routing-profile.test.ts               → 27 pass, 0 fail
bun x tsc --noEmit                                   → clean
bun scripts/test.ts                                  → 10134 pass, 7 skip, 0 fail
```

New test cases:

1. **Repro** — live-path evidence carries no estimate, so the hard cap never fires (documents current behaviour)
2. **Fail-closed** — `onUnknownCost: "exclude"` excludes the candidate and emits `cost-limit-unknown`
3. **Default unchanged** — with no `onUnknownCost`, behaviour is identical to today
4. **Mechanism distinctness** — `unknownEvidence.cost: "exclude"` emits `unknown-price`, *not* `cost-limit-unknown`
5. **Inert without a cap** — `onUnknownCost` has no effect when `maxEstimatedCostUsd` is unset

Coverage on touched files: `src/routing/profile.ts` 89.8% lines; every added line in `src/routing/evaluator.ts` covered. This change is server-side routing logic only; no front-end surface is touched, so no screenshot applies.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. — The new field is documented via JSDoc on `OcxRoutingProfileLimits` and its validation message. Happy to add a docs entry if you point me at the right file.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. — No secrets or auth touched. The default is deliberately `"allow"` so an upgrade cannot silently make every live candidate ineligible; the stricter behaviour is opt-in.

## Notes for review

- Default is unchanged, so this is additive and non-breaking.
- Wiring real usage into the live routing path is deliberately **not** attempted here — that is the larger change #1181 warns about, and it is separable from defining the policy.
- Happy to rename `onUnknownCost`, or fold it into `unknownEvidence`, if you would prefer a single mechanism. I kept them separate because they answer different questions.


---

Supersedes #1344, which was opened against `main` by mistake and closed. This one targets `dev`, is rebased onto the current `dev` head (`025c3791`), and addresses the CodeRabbit finding from that PR — the test docblock and two test names no longer describe the exclusion case as "fails until fixed", since the evaluator change ships in this PR.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable handling for candidates with unknown cost estimates when a maximum cost is configured.
  * Unknown costs are allowed by default, with an option to exclude them.
  * Added distinct cost-limit reporting for candidates excluded due to unknown costs.

* **Bug Fixes**
  * Known costs continue to be excluded when they exceed the configured maximum.
  * Existing behavior remains unchanged when no cost cap is configured.

* **Tests**
  * Added coverage for default behavior, opt-in exclusion, and related cost-evidence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->