### PR TITLE
fix(codex): retain quota cooldown after account retry

### DIFF
--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -435,7 +435,11 @@ async function retryCodexPoolOnAlternateAccount(
       firstAuthCtx.writerGeneration,
     );
   }
-  if (!shouldDeferCodexResetDerivedCooldown(firstResponse, options.deferCodexResetDerivedCooldown)) {
+  const deferFirstOutcome = shouldDeferCodexResetDerivedCooldown(
+    firstResponse,
+    options.deferCodexResetDerivedCooldown,
+  );
+  const recordFirstOutcome = (): void => {
     recordCodexUpstreamOutcome(config, firstAuthCtx.accountId, outcomeStatus, {
       ...quotaMeta,
       threadId: req.headers.get("x-codex-parent-thread-id"),
@@ -446,8 +450,10 @@ async function retryCodexPoolOnAlternateAccount(
       // Retry already advanced the RR ring via excludeAccountId — reuse for promotion.
       ...(retryAuthCtx.accountId ? { promoteAccountId: retryAuthCtx.accountId } : {}),
     });
-  }
-
+  };
+  // Only a combo reset-derived outcome is deferred. Retry-After, defaults, and
+  // ordinary requests must block the first account before the alternate send.
+  if (!deferFirstOutcome) recordFirstOutcome();
   const retryHeaders = headersForCodexAuthContext(req.headers, retryAuthCtx);
   const retryProvider = applyCodexAuthContextToProvider(
     stripCodexRuntimeProviderFields(route.provider),
@@ -474,8 +480,9 @@ async function retryCodexPoolOnAlternateAccount(
   );
 
   noteAttemptSend(logCtx.activeAttempt, passthroughEstimate);
+  let upstreamResponse: Response;
   try {
-    const upstreamResponse = await fetchWithHeaderTimeout(
+    upstreamResponse = await fetchWithHeaderTimeout(
       request.url,
       {
         method: request.method,
@@ -490,26 +497,33 @@ async function retryCodexPoolOnAlternateAccount(
       // dead-host rejection after the credential was seen (#914).
       route.provider.authMode === "forward",
     );
-    // A real HTTP response proves the host was reached (#914).
-    const retryHostKey = upstreamHostHealthKey(route.providerName, safeOriginLabel(request.url));
-    if (normalizeUpstreamHostCircuitThreshold(config.upstreamHostCircuitThreshold) > 0) {
-      resetUpstreamHostHealth(retryHostKey, null);
-    } else {
-      resetUpstreamHostHealth(retryHostKey);
-    }
-    return {
-      kind: "retried",
-      authCtx: retryAuthCtx,
-      request,
-      upstreamResponse,
-      selectedForwardHeaders: retryHeaders,
-    };
   } catch (error) {
     // Attribute the transport failure to the alternate account (already selected).
     return { kind: "transport", error, authCtx: retryAuthCtx };
   } finally {
     request.releaseBodyObservation?.();
   }
+  // A real HTTP response proves the host was reached (#914).
+  const retryHostKey = upstreamHostHealthKey(route.providerName, safeOriginLabel(request.url));
+  if (normalizeUpstreamHostCircuitThreshold(config.upstreamHostCircuitThreshold) > 0) {
+    resetUpstreamHostHealth(retryHostKey, null);
+  } else {
+    resetUpstreamHostHealth(retryHostKey);
+  }
+  if (deferFirstOutcome && upstreamResponse.ok) {
+    // Deferral keeps the first account eligible for a later combo model while an
+    // alternate attempt is still fallible. Commit its quota outcome only once the
+    // alternate account returns a successful HTTP response; otherwise the combo may
+    // still need the first account for its next target.
+    recordFirstOutcome();
+  }
+  return {
+    kind: "retried",
+    authCtx: retryAuthCtx,
+    request,
+    upstreamResponse,
+    selectedForwardHeaders: retryHeaders,
+  };
 }
 
 

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -13,6 +13,7 @@ import {
   CODEX_THREAD_AFFINITY_IDLE_TTL_MS,
   clearCodexUpstreamHealth,
   clearThreadAccountMap,
+  getCodexQuotaHealthSnapshot,
   getCodexUpstreamHealth,
   isCodexAccountSoftAvoided,
   recordCodexUpstreamOutcome,
@@ -194,6 +195,7 @@ async function startPoolRetryHarness(
     pausedAccountIds?: string[];
     reauthAccountIds?: string[];
     omitCredentialAccountIds?: string[];
+    combos?: OcxConfig["combos"];
   } = {},
 ): Promise<PoolRetryHarness> {
   await removeTestDirBestEffort(TEST_DIR);
@@ -250,6 +252,7 @@ async function startPoolRetryHarness(
     ...(options.visionSidecarModel ? { visionSidecar: { model: options.visionSidecarModel } } : {}),
     ...(options.websockets ? { websockets: true } : {}),
     ...(options.streamMode ? { streamMode: options.streamMode } : {}),
+    ...(options.combos ? { combos: options.combos } : {}),
   } as OcxConfig;
   saveConfig(config);
   if (!options.omitCredentialAccountIds?.includes("pool-a")) {
@@ -2317,6 +2320,111 @@ describe("server local API auth", () => {
       await stopPoolRetryHarness(harness);
     }
   });
+
+  test("#584: Retry-After cools the first account even when its account retry fails", async () => {
+    const harness = await startPoolRetryHarness(accountId => accountId === "acct-pool-a"
+      ? new Response(JSON.stringify({ error: { message: "rate limited" } }), {
+        status: 429,
+        headers: { "content-type": "application/json", "retry-after": "60" },
+      })
+      : new Response(JSON.stringify({ error: { message: "upstream unavailable" } }), {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      }));
+    try {
+      const response = await harness.request();
+      expect(response.status).toBe(503);
+      expect(harness.dispatches).toEqual(["acct-pool-a", "acct-pool-b"]);
+      expect(getCodexUpstreamHealth("pool-a")).toMatchObject({
+        cooldownUntil: expect.any(Number),
+        cooldownSource: "retry-after",
+      });
+    } finally {
+      await stopPoolRetryHarness(harness);
+    }
+  }, { timeout: SERVER_BUDGET_MS });
+
+  test("combo reset deferral still cools the first account when its account retry succeeds", async () => {
+    const harness = await startPoolRetryHarness(
+      accountId => accountId === "acct-pool-a"
+        ? new Response(JSON.stringify({ error: { message: "rate limited" } }), {
+          status: 429,
+          headers: {
+            "content-type": "application/json",
+            "x-codex-primary-reset-at": String(Math.floor(Date.now() / 1000) + 3600),
+          },
+        })
+        : Response.json({ id: "combo-account-retry-success", status: "completed", output: [] }),
+      {
+        combos: {
+          quota: {
+            strategy: "failover",
+            targets: [
+              { provider: "openai", model: POOL_RETRY_MODEL },
+              { provider: "openai", model: `${POOL_RETRY_MODEL}-fallback` },
+            ],
+          },
+        },
+      },
+    );
+    try {
+      const response = await harness.request({ model: "combo/quota" });
+      expect(response.status).toBe(200);
+      expect((await response.json() as { id: string }).id).toBe("combo-account-retry-success");
+      expect(harness.dispatches).toEqual(["acct-pool-a", "acct-pool-b"]);
+      expect(getCodexQuotaHealthSnapshot("pool-a", "shared")).toMatchObject({
+        cooldownUntil: expect.any(Number),
+        cooldownSource: "reset-derived",
+        quotaScope: "shared",
+      });
+      expect(loadConfig().activeCodexAccountId).toBe("pool-b");
+    } finally {
+      await stopPoolRetryHarness(harness);
+    }
+  }, { timeout: SERVER_BUDGET_MS });
+
+  test("combo reset deferral preserves the first account when its account retry also fails", async () => {
+    const harness = await startPoolRetryHarness(
+      async (accountId, request) => {
+        const body = await request.json() as { model?: string };
+        if (body.model === `${POOL_RETRY_MODEL}-fallback`) {
+          return Response.json({ id: "combo-later-model-success", status: "completed", output: [] });
+        }
+        if (accountId === "acct-pool-a") {
+          return new Response(JSON.stringify({ error: { message: "rate limited" } }), {
+            status: 429,
+            headers: {
+              "content-type": "application/json",
+              "x-codex-primary-reset-at": String(Math.floor(Date.now() / 1000) + 3600),
+            },
+          });
+        }
+        return new Response(JSON.stringify({ error: { message: "retry later" } }), {
+          status: 429,
+          headers: { "content-type": "application/json", "retry-after": "60" },
+        });
+      },
+      {
+        combos: {
+          quota: {
+            strategy: "failover",
+            targets: [
+              { provider: "openai", model: POOL_RETRY_MODEL },
+              { provider: "openai", model: `${POOL_RETRY_MODEL}-fallback` },
+            ],
+          },
+        },
+      },
+    );
+    try {
+      const response = await harness.request({ model: "combo/quota" });
+      expect(response.status).toBe(200);
+      expect((await response.json() as { id: string }).id).toBe("combo-later-model-success");
+      expect(harness.dispatches).toEqual(["acct-pool-a", "acct-pool-b", "acct-pool-a"]);
+    } finally {
+      await stopPoolRetryHarness(harness);
+    }
+  }, { timeout: SERVER_BUDGET_MS });
 
   test("#584: pre-stream 429 with one eligible account preserves the original 429", async () => {
     const body = JSON.stringify({ error: { message: "rate limited" } });

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -2335,10 +2335,11 @@ describe("server local API auth", () => {
       const response = await harness.request();
       expect(response.status).toBe(503);
       expect(harness.dispatches).toEqual(["acct-pool-a", "acct-pool-b"]);
-      expect(getCodexUpstreamHealth("pool-a")).toMatchObject({
-        cooldownUntil: expect.any(Number),
+      const health = getCodexUpstreamHealth("pool-a");
+      expect(health).toMatchObject({
         cooldownSource: "retry-after",
       });
+      expect(health?.cooldownUntil).toBeGreaterThan(Date.now());
     } finally {
       await stopPoolRetryHarness(harness);
     }

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -2422,6 +2422,7 @@ describe("server local API auth", () => {
       expect(response.status).toBe(200);
       expect((await response.json() as { id: string }).id).toBe("combo-later-model-success");
       expect(harness.dispatches).toEqual(["acct-pool-a", "acct-pool-b", "acct-pool-a"]);
+      expect(getCodexQuotaHealthSnapshot("pool-a", "shared")).toBeNull();
     } finally {
       await stopPoolRetryHarness(harness);
     }


### PR DESCRIPTION
## Summary

- Retain the first Codex pool account's quota outcome when a successful alternate-account retry follows a reset-derived combo deferral.
- Keep that first account eligible for a later combo model when the alternate retry also fails.
- Preserve the existing fail-closed behavior for ordinary and explicit `Retry-After` cooldowns, which are still recorded before the alternate send.

The combo deferral was designed to let a later model target reuse the same account, but it also suppressed the first account's quota outcome after another account had successfully served the request. That could leave an exhausted account active or thread-affined and send the next request back to it.

## Verification

- Bun 1.3.14: focused account-retry/combo regressions — 3 passed, 0 failed.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `git diff --check` — passed.
- Independent focused review found no actionable P0-P3 findings.
- A full `tests/server-auth.test.ts` pass before the final focused refinement reported 71 passed and one transient existing timeout; that timeout passed alone on both this branch and clean `dev`.
- The full repository suite was attempted once, but Bun 1.3.14 panicked after 1,208 seconds amid unrelated Windows identity/history/catalog failures, so no changed-path failure was observed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No user-facing command or configuration contract changed.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry handling when alternate account requests fail or encounter rate limits.
  * Preserved cooldown and quota information after unsuccessful retries.
  * Ensured successful retries correctly update service health and quota status.
  * Improved failover so requests can continue to later models after repeated rate limits.
  * Prevented transport failures from incorrectly recording quota outcomes.

* **Tests**
  * Added coverage for retry cooldown persistence, quota resets, and multi-model failover scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->