### PR TITLE
fix(codex): pin Darwin process utility path

### DIFF
--- a/src/codex/app-server-processes.ts
+++ b/src/codex/app-server-processes.ts
@@ -272,12 +272,12 @@ function listDarwinSnapshots(uid: number | undefined): ProcessSnapshot[] {
   // Top-level exec failure propagates: callers decide their own safe default
   // (restart flow → treat as none; staleness check → unknown, never "fresh").
   const output = uid !== undefined
-    ? execFileSync("ps", ["-u", String(uid), "-o", "pid=,command="], {
+    ? execFileSync("/bin/ps", ["-u", String(uid), "-o", "pid=,command="], {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 5_000,
     })
-    : execFileSync("ps", ["-axo", "pid=,uid=,command="], {
+    : execFileSync("/bin/ps", ["-axo", "pid=,uid=,command="], {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 5_000,
@@ -444,7 +444,7 @@ function readLinuxProcStartMs(pid: number): number | null {
 /** `ps` lstart → epoch ms, or null (macOS). */
 function readDarwinProcStartMs(pid: number): number | null {
   try {
-    const out = execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+    const out = execFileSync("/bin/ps", ["-o", "lstart=", "-p", String(pid)], {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 4_000,
@@ -493,7 +493,7 @@ export function readProcessStartMsBatch(
   if (pids.length === 0) return out;
   if (platform === "darwin") {
     try {
-      const stdout = execFileSync("ps", ["-o", "pid=,lstart=", "-p", pids.join(",")], {
+      const stdout = execFileSync("/bin/ps", ["-o", "pid=,lstart=", "-p", pids.join(",")], {
         encoding: "utf-8",
         stdio: ["ignore", "pipe", "ignore"],
         timeout: 3_000,

--- a/tests/codex-app-server-processes.test.ts
+++ b/tests/codex-app-server-processes.test.ts
@@ -429,6 +429,18 @@ describe("CLI /api sync wiring for stale app-servers (#476)", () => {
   });
 });
 
+describe("process utility invocation source guards", () => {
+  const processSource = readFileSync(
+    join(import.meta.dir, "..", "src", "codex", "app-server-processes.ts"),
+    "utf8",
+  );
+
+  test("pins every Darwin ps invocation to the system binary", () => {
+    expect(processSource.match(/execFileSync\(\s*["']\/bin\/ps["']/g) ?? []).toHaveLength(4);
+    expect(processSource).not.toMatch(/execFileSync\(\s*["']ps["']/);
+  });
+});
+
 describe("Windows Win32_Process owner enumeration (#476)", () => {
   const processSource = readFileSync(
     join(import.meta.dir, "..", "src", "codex", "app-server-processes.ts"),


### PR DESCRIPTION
## Summary

- Pin every macOS Codex app-server process discovery and start-time probe to the system `/bin/ps` binary instead of resolving `ps` through `PATH`.
- Preserve the existing arguments, timeouts, parsing, and fail-closed behavior.
- Add a source guard that requires exactly four pinned Darwin call sites and rejects any bare `execFileSync("ps", ...)` invocation.

This prevents a modified local `PATH` from substituting another executable during Codex app-server synchronization and staleness checks.

## Verification

- `bun test tests/codex-app-server-processes.test.ts` — 31 passed, 0 failed on Bun 1.3.14.
- `bun run typecheck`
- `bun run privacy:scan`
- `git diff --check`
- Independent final diff review found no actionable P0–P3 findings.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were not needed for this internal process-launch hardening.
- [ ] Security-sensitive changes require explicit maintainer review before merge.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process detection on Darwin systems by using a reliable system path when invoking process utilities.

* **Tests**
  * Added regression coverage to ensure process checks consistently use the correct system command path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->