### PR TITLE
fix(claude): honor Desktop native model opt-out

### DIFF
--- a/src/server/management/native-integration-routes.ts
+++ b/src/server/management/native-integration-routes.ts
@@ -18,7 +18,7 @@
  * 011 (Claude Code), 012 (Grok).
  */
 import { loadConfig, readRuntimePort, saveConfigPreservingClaudeCode } from "../../config";
-import { filterCatalogVisibleModels, nativeOpenAiContextWindow, visibleNativeSlugs } from "../../codex/catalog";
+import { desktopVisibleNativeSlugs, filterCatalogVisibleModels, nativeOpenAiContextWindow, visibleNativeSlugs } from "../../codex/catalog";
 import { inspectDesktop3pConfigLibrary, removeDesktop3pStandardPivot, writeDesktop3pConfig } from "../../claude/desktop-3p";
 import { injectGrokConfig, stripGrokConfig, type GrokInjectModel } from "../../grok/inject";
 import { inspectGrokConfig } from "../../grok/inspect";
@@ -656,7 +656,7 @@ async function handleClaudeDesktopToggle(ctx: ManagementContext): Promise<Respon
       const runtime = (ctx.deps.readRuntimePort ?? readRuntimePort)(process.pid);
       const result = (ctx.deps.writeDesktop3pConfig ?? writeDesktop3pConfig)(
         runtime?.port ?? latest.port,
-        [...visibleNativeSlugs(latest)],
+        [...desktopVisibleNativeSlugs(latest)],
         routed,
         latest.apiKeys?.[0]?.key,
         "static",

--- a/tests/native-claude-desktop-toggle.test.ts
+++ b/tests/native-claude-desktop-toggle.test.ts
@@ -216,6 +216,23 @@ test("explicit enable re-reads desired state after catalog fetch and skips a con
   expect(writes).toBe(0);
 });
 
+test("explicit enable honors the Claude Desktop native-model opt-out", async () => {
+  const persisted = { ...config(), claudeCode: { desktopNativeModels: false } };
+  writeFileSync(join(root, "config.json"), JSON.stringify(persisted));
+  let nativeSlugs: string[] | undefined;
+
+  const result = await toggle(true, {
+    fetchAllModels: async () => [],
+    writeDesktop3pConfig: (_port, slugs) => {
+      nativeSlugs = slugs;
+      return { written: true, path: join(library, "new.json"), fingerprint: "fingerprint" };
+    },
+  });
+
+  expect(result.status).toBe(200);
+  expect(nativeSlugs).toEqual([]);
+});
+
 test("POST /apply enables from a stale OFF server snapshot instead of cancelling itself", async () => {
   // The regression: /apply persisted ON, then saved the WHOLE long-lived server
   // config — whose snapshot still said OFF — over that write, so its own


### PR DESCRIPTION
## Summary

- Make the native-integration Claude Desktop enable route use the same Desktop-specific native model visibility helper as the CLI, apply route, model list, and profile renderer.
- Preserve the existing default behavior while honoring an explicit `claudeCode.desktopNativeModels: false` opt-out.
- Add a focused regression that verifies the Desktop writer receives no native slugs after the persisted opt-out is reloaded.

Previously this one route used the generic native model list, so enabling Claude Desktop could re-add native entries that the user had explicitly disabled for Desktop.

## Verification

- `bun test tests/native-claude-desktop-toggle.test.ts` — 10 passed, 0 failed on Bun 1.3.14.
- `bun run typecheck`
- `bun run privacy:scan`
- `git diff --check`
- Independent final diff review found no actionable P0–P3 findings.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were not needed because this restores the existing Desktop opt-out contract.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Claude Desktop enablement now respects the setting that disables native models.
  * Only native integrations available for desktop are included during configuration.

* **Tests**
  * Added coverage to verify successful Claude Desktop activation without native model configuration when opted out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->