### PR TITLE
fix(issue-quality): bound reproduction matching cost

### DIFF
--- a/.github/scripts/issue-quality-core.cjs
+++ b/.github/scripts/issue-quality-core.cjs
@@ -1134,10 +1134,8 @@ const REPRO_PATH_RE = new RegExp([
     "~?/[\\w.@-]+(?:/[\\w.@-]+)+",
     "[A-Za-z]:\\\\(?:[\\w.@-]+\\\\)+[\\w.@-]+",
     "~?/[\\w.@-]+/[\\w.@-]+\\.(?:json|yaml|yml|toml|conf|log|env|txt|ts|js|tsx|jsx|sh|ps1|py)",
-    "[\\w.@-]+\\.(?:json|yaml|yml|toml|conf|log|env)\\b",
-].join("|"));
-const ACTIONABLE_REPRO_RE = new RegExp(
-  [REPRO_COMMAND_RE.source, REPRO_FAILURE_RE.source, REPRO_PATH_RE.source].join("|"),
+    "(?:^|[^\\w.@-])[\\w.@-]+\\.(?:json|yaml|yml|toml|conf|log|env)\\b",
+].join("|"),
   "i",
 );
 
@@ -1151,9 +1149,18 @@ const EMPTY_FENCE_RE = /^[ \t]{0,3}(?:```+|~~~+)\s*\n\s*\n[ \t]{0,3}(?:```+|~~~+
  * count as actionable when their body contains non-whitespace content.
  */
 function hasActionableReproductionDetail(text) {
+  if (typeof text !== "string") return false;
+  // Avoid Markdown cleanup and path matching when the raw input cannot contain
+  // actionable syntax. Fences remain eligible through their ` / ~ sigils.
+  if (!/[./\\`~]/.test(text) && !REPRO_COMMAND_RE.test(text) && !REPRO_FAILURE_RE.test(text)) {
+    return false;
+  }
   const c = clean(text);
   if (!c) return false;
-  if (ACTIONABLE_REPRO_RE.test(c)) return true;
+  if (REPRO_COMMAND_RE.test(c) || REPRO_FAILURE_RE.test(c)) return true;
+  // A boundary-anchored filename avoids retrying the same long token from each
+  // successive character while preserving case-insensitive extension matches.
+  if (/[./\\]/.test(c) && REPRO_PATH_RE.test(c)) return true;
   // Fenced blocks: only count when the body has non-whitespace content.
   if (/```|~~~/.test(c)) {
     const parts = stripFencedActionableContent(c);

--- a/.github/scripts/issue-quality.test.cjs
+++ b/.github/scripts/issue-quality.test.cjs
@@ -713,6 +713,13 @@ describe("validateIssue - feature", () => {
     assert.equal(hasActionableReproductionDetail("```\nSIGSEGV at 0x0000\n```"), true);
   });
 
+  it("bounds long non-matching reproduction path tokens", () => {
+    const startedAt = performance.now();
+    assert.equal(hasActionableReproductionDetail(`${"a".repeat(60_000)}.unknown`), false);
+    assert.ok(performance.now() - startedAt < 500, "actionable reproduction check took too long");
+    assert.equal(hasActionableReproductionDetail("CONFIG.JSON"), true);
+  });
+
   it("rejects fenced placeholder-only examples", () => {
     const fencedPlaceholders = [
       "```\nN/A\n```",


### PR DESCRIPTION
## Summary

- Move the reproduction matcher hardening into the current `.github/scripts/issue-quality-core.cjs` source of truth.
- Anchor the bare-filename alternative at a token boundary so a long unsupported extension is not retried from every successive character.
- Split command, failure, and path checks behind a cheap raw-input syntax gate while preserving fenced examples and case-insensitive path extensions.
- Add a 60,000-character near-miss regression plus uppercase-extension compatibility coverage.

On the same local Node runtime, the focused near-miss dropped from about 3.07 seconds before the change to about 7 milliseconds after it.

## Verification

- `node --test .github/scripts/issue-quality*.test.cjs` — 119 passed, 0 failed.
- `bun run typecheck`
- `bun run privacy:scan`
- `git diff --check`
- Independent focused security review found no actionable P0–P3 findings.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were not needed for this internal repository-automation hardening.
- [x] Security-sensitive changes were explicitly reviewed for regex complexity, input semantics, and workflow trust boundaries.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue reproduction-detail detection to avoid recognizing embedded or invalid filename fragments.
  * Added support for uppercase configuration filenames.
  * Improved handling of long, unrecognized path-like text for more reliable and responsive validation.

* **Tests**
  * Added regression coverage for filename matching and bounded processing time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->