### PR TITLE
fix(responses): clear stripped service tier from logs

### DIFF
--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -988,6 +988,10 @@ async function applyFinalRouteRequestNormalization(args: {
     parsed.options.serviceTier = tier;
   }
   applyServiceTierGate(route.provider, parsed._rawBody, parsed.options);
+  if (route.provider.adapter === "openai-responses" && route.provider.supportsServiceTier === false) {
+    logCtx.requestedServiceTier = undefined;
+    logCtx.requestedSpeedLabel = undefined;
+  }
 
   {
     const guidance = await multiAgentGuidanceText(parsed, {

--- a/tests/service-tier-capability.test.ts
+++ b/tests/service-tier-capability.test.ts
@@ -9,6 +9,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { providerConfigSeed, enrichProviderFromRegistry } from "../src/providers/derive";
 import { getProviderRegistryEntry } from "../src/providers/registry";
+import type { RequestLogContext } from "../src/server/request-log";
 import { applyServiceTierGate, handleResponses } from "../src/server/responses/core";
 import type { OcxConfig, OcxProviderConfig } from "../src/types";
 
@@ -125,6 +126,30 @@ describe("the gate fires on the live handleResponses path", () => {
   test("DeepSeek strips a caller-supplied service_tier", async () => {
     const body = await drive("deepseek", deepseekProvider(), "deepseek-v4-flash", { service_tier: "priority" });
     expect("service_tier" in body).toBe(false);
+  });
+
+  test("DeepSeek clears a stripped caller tier from request logging", async () => {
+    const { bodies } = captureBody();
+    const logCtx: RequestLogContext = { model: "", provider: "" };
+    await handleResponses(
+      new Request("http://localhost/v1/responses", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "deepseek/deepseek-v4-flash",
+          input: "ping",
+          stream: true,
+          service_tier: "priority",
+        }),
+      }),
+      { providers: { deepseek: deepseekProvider() } } as unknown as OcxConfig,
+      logCtx,
+      {},
+    );
+
+    expect("service_tier" in (bodies[0] ?? {})).toBe(false);
+    expect(logCtx.requestedServiceTier).toBeUndefined();
+    expect(logCtx.requestedSpeedLabel).toBeUndefined();
   });
 
   test("canonical OpenAI keeps fast-mode injection and removal", async () => {

--- a/tests/service-tier-capability.test.ts
+++ b/tests/service-tier-capability.test.ts
@@ -147,7 +147,9 @@ describe("the gate fires on the live handleResponses path", () => {
       {},
     );
 
-    expect("service_tier" in (bodies[0] ?? {})).toBe(false);
+    const upstreamBody = bodies[0];
+    expect(upstreamBody).toBeDefined();
+    expect("service_tier" in upstreamBody!).toBe(false);
     expect(logCtx.requestedServiceTier).toBeUndefined();
     expect(logCtx.requestedSpeedLabel).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

- Clear `requestedServiceTier` and its speed label after the final provider capability gate strips an unsupported `service_tier`.
- Add a live DeepSeek regression proving the upstream body and request-log context agree.
- Preserve configured-tier provenance and the tri-state behavior for supported and unclassified providers.

The request log captured caller tier metadata before final route normalization. DeepSeek and Volcengine correctly removed the unsupported wire field later, but the earlier log metadata still described the request as Fast/priority.

## Verification

- `bun test tests/service-tier-capability.test.ts` — 13 passed.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `git diff --check` — passed.
- Independent two-file review found no diff-introduced P0-P3 issues.
- The previous exact head completed full GitHub CI successfully; this update only rebases the same patch onto the latest `dev`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected request handling for providers that do not support service tiers.
  * Service-tier settings are now consistently removed from outgoing requests and request logs when unsupported.
* **Tests**
  * Added regression coverage to verify service-tier data is cleared across the request flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->