### PR TITLE
fix(oauth): guard local token expiry parsing against NaN

### DIFF
--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -1180,18 +1180,15 @@ export function getLoginStatus(provider: string): { loggedIn: boolean; email?: s
     expiresAt: a.credential.expires,
   }));
 
-  // A stored credential only counts as "logged in" when it is confirmed usable:
-  // not marked for re-auth and carrying a finite, positive, still-future expiry.
-  // Unknown (0/NaN) or expired expiries mean refresh validation is required.
-  const active = set?.accounts.find(a => a.id === set.activeAccountId);
-  const activeUsable = active
-    ? Number.isFinite(active.credential.expires)
-      && active.credential.expires > 0
-      && active.credential.expires > Date.now()
-    : false;
-  const activeNeedsReauth = active?.needsReauth === true;
+  // A stored credential counts as "logged in" when it exists and is not marked for
+  // re-authentication. An expired access token with a valid refresh token is still
+  // logged in: request resolution refreshes expired/near-expiry credentials lazily.
+  // Invalid/unknown local-import expiries are handled at parse/adoption time
+  // (local-token-detect.ts), never by over-reporting login state here.
+  const activeNeedsReauth = set?.accounts
+    .find(a => a.id === set.activeAccountId)?.needsReauth === true;
   return {
-    loggedIn: !!cred && activeUsable && !activeNeedsReauth,
+    loggedIn: !!cred && !activeNeedsReauth,
     email: maskEmail(cred?.email) ?? undefined,
     source: cred?.source,
     error: st?.error,

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -1180,17 +1180,18 @@ export function getLoginStatus(provider: string): { loggedIn: boolean; email?: s
     expiresAt: a.credential.expires,
   }));
 
-  // A stored credential only counts as "logged in" when it is still usable: not marked for
-  // re-auth and not already expired (or unknown-expiry, which needs refresh validation).
+  // A stored credential only counts as "logged in" when it is confirmed usable:
+  // not marked for re-auth and carrying a finite, positive, still-future expiry.
+  // Unknown (0/NaN) or expired expiries mean refresh validation is required.
   const active = set?.accounts.find(a => a.id === set.activeAccountId);
-  const activeExpired = active
+  const activeUsable = active
     ? Number.isFinite(active.credential.expires)
       && active.credential.expires > 0
-      && active.credential.expires <= Date.now()
+      && active.credential.expires > Date.now()
     : false;
   const activeNeedsReauth = active?.needsReauth === true;
   return {
-    loggedIn: !!cred && !activeNeedsReauth && !activeExpired,
+    loggedIn: !!cred && activeUsable && !activeNeedsReauth,
     email: maskEmail(cred?.email) ?? undefined,
     source: cred?.source,
     error: st?.error,

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -1179,8 +1179,18 @@ export function getLoginStatus(provider: string): { loggedIn: boolean; email?: s
     ...(a.needsReauth ? { needsReauth: true } : {}),
     expiresAt: a.credential.expires,
   }));
+
+  // A stored credential only counts as "logged in" when it is still usable: not marked for
+  // re-auth and not already expired (or unknown-expiry, which needs refresh validation).
+  const active = set?.accounts.find(a => a.id === set.activeAccountId);
+  const activeExpired = active
+    ? Number.isFinite(active.credential.expires)
+      && active.credential.expires > 0
+      && active.credential.expires <= Date.now()
+    : false;
+  const activeNeedsReauth = active?.needsReauth === true;
   return {
-    loggedIn: !!cred,
+    loggedIn: !!cred && !activeNeedsReauth && !activeExpired,
     email: maskEmail(cred?.email) ?? undefined,
     source: cred?.source,
     error: st?.error,

--- a/src/oauth/local-token-detect.ts
+++ b/src/oauth/local-token-detect.ts
@@ -24,7 +24,10 @@ export function detectGrokCliToken(): OAuthCredentials | null {
 
     const accessToken = entry.key as string;
     const refreshToken = entry.refresh_token as string;
-    const expiresAt = entry.expires_at ? new Date(entry.expires_at as string).getTime() : 0;
+    const parsedExpiresAt = entry.expires_at ? new Date(entry.expires_at as string).getTime() : 0;
+    // Guard against unparseable/NaN expiries: a non-finite value must never be treated as
+    // "valid forever". Unknown → 0, which forces the refresh-validation path downstream.
+    const expiresAt = Number.isFinite(parsedExpiresAt) ? parsedExpiresAt : 0;
 
     return {
       refresh: refreshToken,
@@ -55,6 +58,9 @@ export function shouldAdoptGrokGeneration(
   now = Date.now(),
   refreshSkewMs = 60_000,
 ): boolean {
+  // A non-finite disk expiry means we cannot reason about the generation: the credential is
+  // either garbage or unknown. Treat it as requiring refresh validation, never as an upgrade.
+  if (!Number.isFinite(disk.expires)) return false;
   if (disk.expires <= now + refreshSkewMs) return false;
   const bothExpiriesExist = stored.expires > 0 && disk.expires > 0;
   if (bothExpiriesExist) return disk.expires >= stored.expires;
@@ -108,7 +114,10 @@ export function parseClaudeOauthPayload(raw: string): OAuthCredentials | null {
     const data = JSON.parse(raw) as { claudeAiOauth?: { accessToken?: string; refreshToken?: string; expiresAt?: number } };
     const o = data.claudeAiOauth;
     if (!o?.accessToken || !o?.refreshToken) return null;
-    return { access: o.accessToken, refresh: o.refreshToken, expires: o.expiresAt ?? 0, source: "local-cli" };
+    // Number.isFinite guard: a string/NaN expiresAt must not flow into downstream time
+    // comparisons as a "valid forever" value. Unknown → 0 (refresh-validation path).
+    const expires = typeof o.expiresAt === "number" && Number.isFinite(o.expiresAt) ? o.expiresAt : 0;
+    return { access: o.accessToken, refresh: o.refreshToken, expires, source: "local-cli" };
   } catch {
     return null;
   }

--- a/tests/local-token-detect.test.ts
+++ b/tests/local-token-detect.test.ts
@@ -2,14 +2,21 @@ import { afterEach, beforeAll, afterAll, describe, expect, test } from "bun:test
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { parseClaudeOauthPayload, readClaudeCredentialsFile } from "../src/oauth/local-token-detect";
+import {
+  detectGrokCliToken,
+  parseClaudeOauthPayload,
+  readClaudeCredentialsFile,
+  shouldAdoptGrokGeneration,
+} from "../src/oauth/local-token-detect";
 
 let tmp: string;
 let prevConfigDir: string | undefined;
+let prevHome: string | undefined;
 
 beforeAll(() => {
   tmp = mkdtempSync(join(tmpdir(), "ocx-claude-detect-"));
   prevConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  prevHome = process.env.HOME;
 });
 
 afterAll(() => {
@@ -19,6 +26,8 @@ afterAll(() => {
 afterEach(() => {
   if (prevConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
   else process.env.CLAUDE_CONFIG_DIR = prevConfigDir;
+  if (prevHome === undefined) delete process.env.HOME;
+  else process.env.HOME = prevHome;
 });
 
 describe("Claude Code credentials file fallback (Linux/Windows)", () => {
@@ -43,5 +52,84 @@ describe("Claude Code credentials file fallback (Linux/Windows)", () => {
   test("parse rejects payloads without both tokens", () => {
     expect(parseClaudeOauthPayload(JSON.stringify({ claudeAiOauth: { accessToken: "only" } }))).toBeNull();
     expect(parseClaudeOauthPayload("not json")).toBeNull();
+  });
+});
+
+describe("invalid expiry handling (NaN guard)", () => {
+  test("parseClaudeOauthPayload coerces a string expiresAt to unknown (0) instead of NaN", () => {
+    const raw = JSON.stringify({ claudeAiOauth: { accessToken: "at-1", refreshToken: "rt-1", expiresAt: "garbage" } });
+    const creds = parseClaudeOauthPayload(raw);
+    expect(creds).not.toBeNull();
+    expect(creds!.expires).toBe(0);
+    expect(Number.isFinite(creds!.expires)).toBe(true);
+  });
+
+  test("parseClaudeOauthPayload coerces a non-finite expiresAt to unknown (0)", () => {
+    const raw = JSON.stringify({ claudeAiOauth: { accessToken: "at-1", refreshToken: "rt-1", expiresAt: NaN } });
+    const creds = parseClaudeOauthPayload(raw);
+    expect(creds).not.toBeNull();
+    expect(creds!.expires).toBe(0);
+  });
+
+  test("detectGrokCliToken coerces an unparseable expires_at to unknown (0) instead of NaN", () => {
+    const grokHome = join(tmp, "grok-home");
+    mkdirSync(join(grokHome, ".grok"), { recursive: true });
+    writeFileSync(join(grokHome, ".grok", "auth.json"), JSON.stringify({
+      "https://auth.x.ai::1": {
+        key: "xai-stub-access",
+        refresh_token: "xai-stub-refresh",
+        expires_at: "not-a-date",
+      },
+    }));
+    process.env.HOME = grokHome;
+
+    const creds = detectGrokCliToken();
+    expect(creds).not.toBeNull();
+    expect(creds!.expires).toBe(0);
+    expect(Number.isFinite(creds!.expires)).toBe(true);
+  });
+
+  test("detectGrokCliToken passes through a parseable future expires_at", () => {
+    const grokHome = join(tmp, "grok-home-future");
+    mkdirSync(join(grokHome, ".grok"), { recursive: true });
+    const future = new Date(Date.now() + 3600_000).toISOString();
+    writeFileSync(join(grokHome, ".grok", "auth.json"), JSON.stringify({
+      "https://auth.x.ai::1": {
+        key: "xai-stub-access",
+        refresh_token: "xai-stub-refresh",
+        expires_at: future,
+      },
+    }));
+    process.env.HOME = grokHome;
+
+    const creds = detectGrokCliToken();
+    expect(creds).not.toBeNull();
+    expect(creds!.expires).toBeGreaterThan(Date.now());
+  });
+
+  test("detectGrokCliToken returns null when auth.json is absent", () => {
+    process.env.HOME = join(tmp, "grok-home-missing");
+    expect(detectGrokCliToken()).toBeNull();
+  });
+});
+
+describe("shouldAdoptGrokGeneration with NaN/unknown expiries", () => {
+  const stored = { refresh: "stored-refresh", access: "stored-access", expires: Date.now() + 3600_000 };
+
+  test("never adopts a disk credential with a non-finite expiry", () => {
+    expect(shouldAdoptGrokGeneration(stored, { ...stored, expires: Number.NaN }, Date.now(), 60_000)).toBe(false);
+  });
+
+  test("rejects an unknown (0) disk expiry as requiring refresh", () => {
+    expect(shouldAdoptGrokGeneration(stored, { ...stored, expires: 0 }, Date.now(), 60_000)).toBe(false);
+  });
+
+  test("rejects an already-expired disk credential", () => {
+    expect(shouldAdoptGrokGeneration(stored, { ...stored, expires: Date.now() - 60_000 }, Date.now(), 60_000)).toBe(false);
+  });
+
+  test("adopts a newer valid disk credential", () => {
+    const disk = { ...stored, expires: Date.now() + 7200_000 };
+    expect(shouldAdoptGrokGeneration(stored, disk, Date.now(), 60_000)).toBe(true);
   });
 });

--- a/tests/oauth-refresh.test.ts
+++ b/tests/oauth-refresh.test.ts
@@ -380,6 +380,24 @@ describe("oauth refresh hardening", () => {
     expect(getCredential("xai")?.source).toBe("local-cli");
   });
 
+  test("malformed Grok generation is not adopted and falls through to refresh-resolution", async () => {
+    await saveCredential("xai", {
+      access: "xai-old", refresh: "rt-old", expires: Date.now() - 1, accountId: "user-1", source: "local-cli",
+    });
+    // Disk auth.json carries an unparseable expires_at; before the NaN guard this
+    // generation was adopted as authoritative and never refreshed.
+    seedGrokAuth({
+      key: "xai-disk", refresh_token: "rt-disk", expires_at: "not-a-date", user_id: "user-1",
+    });
+    const mock = mockXaiRefreshFetch();
+
+    await expect(getValidAccessToken("xai")).resolves.toBe("xai-fresh");
+    expect(mock.discoveryCount()).toBe(1);
+    expect(mock.tokenCount()).toBe(1);
+    expect(new URLSearchParams(mock.tokenBodies[0]).get("refresh_token")).toBe("rt-old");
+    expect(getCredential("xai")?.source).toBe("oauth");
+  });
+
   test("newer-expiry Grok access token is adopted when refresh generation is unchanged", async () => {
     const mock = mockRefreshFetch([new Response("unexpected", { status: 500 })]);
     await saveCredential("xai", {

--- a/tests/oauth-status-privacy.test.ts
+++ b/tests/oauth-status-privacy.test.ts
@@ -96,7 +96,7 @@ describe("OAuth status privacy", () => {
     expect(JSON.stringify(status)).not.toContain("oauth<script>");
   });
 
-  test("getLoginStatus reports not logged in for an expired credential", async () => {
+  test("getLoginStatus stays logged in for an expired-but-refreshable credential", async () => {
     await saveCredential("xai", {
       access: "access-token",
       refresh: "refresh-token",
@@ -106,10 +106,14 @@ describe("OAuth status privacy", () => {
       source: "local-cli",
     });
 
-    expect(getLoginStatus("xai").loggedIn).toBe(false);
+    // Expired access token with a valid refresh token is still a logged-in account:
+    // request resolution refreshes it lazily. Only needsReauth is authoritative.
+    const status = getLoginStatus("xai");
+    expect(status.loggedIn).toBe(true);
+    expect(status.accounts?.[0]?.needsReauth).toBeUndefined();
   });
 
-  test("getLoginStatus reports not logged in for an unknown (0) credential expiry", async () => {
+  test("getLoginStatus stays logged in for an unknown (0) credential expiry", async () => {
     writeFileSync(join(TEST_DIR, "auth.json"), JSON.stringify({
       xai: {
         access: "access-token",
@@ -118,19 +122,15 @@ describe("OAuth status privacy", () => {
       },
     }), "utf8");
 
-    expect(getLoginStatus("xai").loggedIn).toBe(false);
+    expect(getLoginStatus("xai").loggedIn).toBe(true);
   });
 
-  test("getLoginStatus reports not logged in for a non-finite credential expiry", async () => {
-    writeFileSync(join(TEST_DIR, "auth.json"), JSON.stringify({
-      xai: {
-        access: "access-token",
-        refresh: "refresh-token",
-        expires: NaN,
-      },
-    }), "utf8");
+  test("getLoginStatus stays logged in for a non-finite credential expiry", async () => {
+    // JSON.stringify cannot carry NaN/Infinity, but a hand-written auth.json with an
+    // out-of-range numeric expiry parses to Infinity — the realistic corrupt shape.
+    writeFileSync(join(TEST_DIR, "auth.json"), '{"xai":{"access":"access-token","refresh":"refresh-token","expires":1e999}}', "utf8");
 
-    expect(getLoginStatus("xai").loggedIn).toBe(false);
+    expect(getLoginStatus("xai").loggedIn).toBe(true);
   });
 
   test("getLoginStatus reports not logged in for a needsReauth account", async () => {

--- a/tests/oauth-status-privacy.test.ts
+++ b/tests/oauth-status-privacy.test.ts
@@ -109,6 +109,18 @@ describe("OAuth status privacy", () => {
     expect(getLoginStatus("xai").loggedIn).toBe(false);
   });
 
+  test("getLoginStatus reports not logged in for an unknown (0) credential expiry", async () => {
+    writeFileSync(join(TEST_DIR, "auth.json"), JSON.stringify({
+      xai: {
+        access: "access-token",
+        refresh: "refresh-token",
+        expires: 0,
+      },
+    }), "utf8");
+
+    expect(getLoginStatus("xai").loggedIn).toBe(false);
+  });
+
   test("getLoginStatus reports not logged in for a non-finite credential expiry", async () => {
     writeFileSync(join(TEST_DIR, "auth.json"), JSON.stringify({
       xai: {

--- a/tests/oauth-status-privacy.test.ts
+++ b/tests/oauth-status-privacy.test.ts
@@ -96,6 +96,46 @@ describe("OAuth status privacy", () => {
     expect(JSON.stringify(status)).not.toContain("oauth<script>");
   });
 
+  test("getLoginStatus reports not logged in for an expired credential", async () => {
+    await saveCredential("xai", {
+      access: "access-token",
+      refresh: "refresh-token",
+      expires: Date.now() - 60_000,
+      email: "person@example.test",
+      accountId: "acct-xai",
+      source: "local-cli",
+    });
+
+    expect(getLoginStatus("xai").loggedIn).toBe(false);
+  });
+
+  test("getLoginStatus reports not logged in for a non-finite credential expiry", async () => {
+    writeFileSync(join(TEST_DIR, "auth.json"), JSON.stringify({
+      xai: {
+        access: "access-token",
+        refresh: "refresh-token",
+        expires: NaN,
+      },
+    }), "utf8");
+
+    expect(getLoginStatus("xai").loggedIn).toBe(false);
+  });
+
+  test("getLoginStatus reports not logged in for a needsReauth account", async () => {
+    await saveCredential("xai", {
+      access: "access-token",
+      refresh: "refresh-token",
+      expires: Date.now() + 3600_000,
+      accountId: "acct-xai",
+      source: "local-cli",
+    });
+    const { markAccountNeedsReauth, getAccountSet } = await import("../src/oauth/store");
+    await markAccountNeedsReauth("xai", getAccountSet("xai")!.activeAccountId, true);
+
+    expect(getLoginStatus("xai").loggedIn).toBe(false);
+    expect(getLoginStatus("xai").accounts?.[0]?.needsReauth).toBe(true);
+  });
+
   test("stale credentials for removed OAuth providers fail as unsupported provider config", async () => {
     await saveCredential("removed-provider", {
       access: "access-token",


### PR DESCRIPTION
## Summary

Fixes [#1366](https://github.com/lidge-jun/opencodex/issues/1366): an imported local CLI credential (Grok `~/.grok/auth.json` or Claude `.credentials.json`) whose `expires_at` is invalid/unparseable (e.g. `"not-a-date"`, `NaN`, epoch-garbage like `1970-01-22`) was **treated as valid and never refreshed**, and `ocx status` showed **`✓ logged in`** for it.

## Root cause

`src/oauth/local-token-detect.ts` — `new Date(entry.expires_at as string).getTime()` returns `NaN` for unparseable strings. Downstream comparisons then misbehave:

- `shouldAdoptGrokGeneration()`: `disk.expires <= now + refreshSkewMs` is **always `false`** for `NaN` (passes the expiry gate); `bothExpiriesExist` is `false` because `NaN > 0` is `false`, so it falls through to `return true` — the garbage credential is **adopted** as the authoritative generation (`authoritative()` in `src/oauth/index.ts`), and the refresh path never re-validates it.
- `getLoginStatus()` reported `loggedIn: !!cred` (credential exists), ignoring `needsReauth` — the CLI "OAuth logins" section printed `✓ logged in` for reauth-required credentials.

## Changes

1. **`src/oauth/local-token-detect.ts`** — `detectGrokCliToken()`: `Number.isFinite` guard on the parsed `expires_at`; non-finite → `0` (unknown → forces the refresh-validation path downstream instead of "valid forever").
2. **`src/oauth/local-token-detect.ts`** — `shouldAdoptGrokGeneration()`: explicit `!Number.isFinite(disk.expires) → false` (defense-in-depth; a garbage disk credential is never adopted as an upgrade).
3. **`src/oauth/local-token-detect.ts`** — `parseClaudeOauthPayload()`: `Number.isFinite` guard on `expiresAt` (strings/NaN → `0`).
4. **`src/oauth/index.ts`** — `getLoginStatus()`: `loggedIn = !!cred && !needsReauth`. `needsReauth` is the authoritative login-failure signal; an expired-but-refreshable access token stays logged in per the lazy-refresh contract (request resolution refreshes it on demand). Invalid/unknown local-import expiries are handled solely at parse/adoption time (points 1–3), never by over-reporting login state.

## Tests

- `tests/local-token-detect.test.ts`: +9 tests (string/NaN `expiresAt` → `0`; `detectGrokCliToken` with unparseable/future `expires_at`; `shouldAdoptGrokGeneration` with NaN/0/expired/newer-valid disk expiry).
- `tests/oauth-status-privacy.test.ts`: +4 tests — expired / unknown-0 / non-finite (`1e999`) expiries **stay logged in** (lazy-refresh contract); `needsReauth` reports not logged in.
- `tests/oauth-refresh.test.ts`: +1 lifecycle regression — stored `local-cli` xAI credential + malformed disk `expires_at: "not-a-date"` → generation not adopted, refresh resolves with the stored refresh token (1 discovery + 1 token exchange), detaches to `source: "oauth"`.

Verification (head `9468a57b`, rebased onto `dev` 0757b10e):
- Targeted: 51/51 pass
- OAuth suite (`tests/oauth-*` + local-token + cli-status + login-summary): **174/174 pass**
- `bun x tsc --noEmit` → clean
- Full suite runs on CI (ubuntu/macos/windows)

Fixes #1366

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Login status now remains active for expired credentials that can be refreshed automatically.
  * Accounts requiring reauthentication are correctly reported as logged out.
  * Invalid or non-finite credential expiration values are handled safely.
  * Malformed stored credentials no longer prevent successful OAuth refreshes.

* **Tests**
  * Added coverage for credential expiration, refresh behavior, reauthentication, and local token detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->