### PR TITLE
fix(dashboard): safely render prototype-named providers

### DIFF
--- a/gui/src/pages/use-dashboard-data.ts
+++ b/gui/src/pages/use-dashboard-data.ts
@@ -69,6 +69,16 @@ type CachedOverview = {
 
 type MaMode = "v1" | "default" | "v2";
 
+export function groupDashboardModels(models: ModelInfo[]): Array<[string, ModelInfo[]]> {
+  const groups = new Map<string, ModelInfo[]>();
+  for (const model of models) {
+    const rows = groups.get(model.provider);
+    if (rows) rows.push(model);
+    else groups.set(model.provider, [model]);
+  }
+  return [...groups.entries()].sort(([a], [b]) => a.localeCompare(b));
+}
+
 function controlsCacheKey(apiBase: string): string {
   return `${CONTROLS_CACHE_PREFIX}${apiBase}`;
 }
@@ -437,11 +447,7 @@ export function useDashboardData(apiBase: string) {
   }, [updatePoll.data]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
-  const grouped = useMemo(() => {
-    const g: Record<string, ModelInfo[]> = {};
-    for (const m of models) (g[m.provider] ??= []).push(m);
-    return Object.entries(g).sort(([a], [b]) => a.localeCompare(b));
-  }, [models]);
+  const grouped = useMemo(() => groupDashboardModels(models), [models]);
   const filteredGroups = useMemo(() => {
     const q = modelQuery.trim().toLowerCase();
     if (!q) return grouped;

--- a/gui/src/provider-icons.ts
+++ b/gui/src/provider-icons.ts
@@ -119,7 +119,8 @@ type ProviderIconHints = {
 };
 
 function providerIconAlias(provider: string): string | undefined {
-  return PROVIDER_ICON_ALIASES[provider.toLowerCase()];
+  const key = provider.toLowerCase();
+  return Object.hasOwn(PROVIDER_ICON_ALIASES, key) ? PROVIDER_ICON_ALIASES[key] : undefined;
 }
 
 /** Optional hints kept for call-site compatibility; resolution is name-based for now. */
@@ -132,9 +133,14 @@ export function providerIconSrc(provider: string, _hints?: ProviderIconHints): s
 /** Display label with proper brand casing when known; otherwise original name. */
 export function formatProviderDisplayName(provider: string, t: TFn): string {
   const key = provider.toLowerCase();
-  const displayNameKey = PROVIDER_DISPLAY_NAME_KEYS[key];
+  const displayNameKey = Object.hasOwn(PROVIDER_DISPLAY_NAME_KEYS, key)
+    ? PROVIDER_DISPLAY_NAME_KEYS[key]
+    : undefined;
   if (displayNameKey) return t(displayNameKey);
-  if (PROVIDER_DISPLAY_NAMES[key]) return PROVIDER_DISPLAY_NAMES[key]!;
+  const displayName = Object.hasOwn(PROVIDER_DISPLAY_NAMES, key)
+    ? PROVIDER_DISPLAY_NAMES[key]
+    : undefined;
+  if (displayName) return displayName;
   // Title-case simple ids like "my-provider" without mangling mixedCase custom names.
   if (provider === key && /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(provider)) {
     return provider

--- a/gui/tests/dashboard-model-grouping.test.ts
+++ b/gui/tests/dashboard-model-grouping.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test";
+import type { TFn } from "../src/i18n/shared";
+import { groupDashboardModels } from "../src/pages/use-dashboard-data";
+import { formatProviderDisplayName, providerIconSrc } from "../src/provider-icons";
+
+test("Dashboard groups models whose provider names match object prototype properties", () => {
+  const models = [
+    { id: "proto-model", provider: "__proto__" },
+    { id: "constructor-model", provider: "constructor" },
+    { id: "string-model", provider: "toString" },
+    { id: "second-proto-model", provider: "__proto__" },
+  ];
+
+  expect(groupDashboardModels(models)).toEqual([
+    ["__proto__", [models[0], models[3]]],
+    ["constructor", [models[1]]],
+    ["toString", [models[2]]],
+  ]);
+});
+
+test("provider display helpers ignore inherited object prototype properties", () => {
+  const t = ((key: string) => key) as TFn;
+  expect(formatProviderDisplayName("__proto__", t)).toBe("__proto__");
+  expect(formatProviderDisplayName("constructor", t)).toBe("Constructor");
+  expect(formatProviderDisplayName("toString", t)).toBe("toString");
+  expect(providerIconSrc("__proto__")).toBeUndefined();
+  expect(providerIconSrc("constructor")).toBeUndefined();
+  expect(providerIconSrc("toString")).toBeUndefined();
+});


### PR DESCRIPTION
## Summary

- Group dashboard models with a `Map` so provider IDs such as `__proto__`, `constructor`, and `toString` cannot collide with inherited object properties.
- Guard provider display-name and icon alias tables with own-property checks so those same valid custom provider IDs render through the normal fallback path.
- Add focused regressions for repeated prototype-named groups and their display/icon behavior.

## Verification

- `cd gui && bun test tests` — 709 passed, 0 failed.
- `cd gui && bun run lint`
- `cd gui && bun run build`
- `bun run privacy:scan`
- `git diff --check`
- Independent focused diff review: no P0-P3 findings.
- Browser render check with synthetic API fixtures:

![Dashboard model groups for prototype-named providers](https://raw.githubusercontent.com/luvs01/opencodex/ed3d6b26c5e6e9f464176326e2e9bee7af38e552/pr231-dashboard-model-grouping.png)

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No documentation change is needed for this bug fix.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard model grouping for provider names that overlap with built-in object properties.
  * Provider names and icons now fall back safely when no valid provider mapping exists.

* **Tests**
  * Added coverage for prototype-property provider names and safe provider display/icon handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->