### PR TITLE
fix(codex): keep unreadable shim checks advisory

### DIFF
--- a/src/cli/codex-shim-readiness.ts
+++ b/src/cli/codex-shim-readiness.ts
@@ -60,9 +60,16 @@ export function codexShimReadinessWarnings(
 
 export function collectCodexShimReadinessWarnings(): string[] {
   const config = loadConfig();
+  let externalProvider: string | null = null;
+  try {
+    externalProvider = currentExternalCodexModelProvider();
+  } catch {
+    // Routing readiness is advisory; getCodexRoutingKind() already reports an
+    // unreadable config as unknown, so preserve that warning instead of failing.
+  }
   return codexShimReadinessWarnings({
     routingKind: getCodexRoutingKind(),
-    externalProvider: currentExternalCodexModelProvider(),
+    externalProvider,
     processProxyEnvPresent: PROXY_ENV_KEYS.some(key => Boolean(process.env[key]?.trim())),
     configuredProxyResolved: Boolean(resolveEnvValue(config.proxy)?.trim()),
   });

--- a/tests/codex-shim-readiness.test.ts
+++ b/tests/codex-shim-readiness.test.ts
@@ -8,7 +8,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { delimiter, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { codexShimReadinessWarnings } from "../src/cli/codex-shim-readiness";
 
@@ -137,6 +137,43 @@ describe("Codex shim install readiness", () => {
       expect(result.stderr).toContain("config.proxy");
       expect(`${result.stdout}\n${result.stderr}`).not.toContain(proxyUrl);
       expect(`${result.stdout}\n${result.stderr}`).not.toContain("user:secret");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps install advisory when the Codex config cannot be read", () => {
+    const root = mkdtempSync(join(tmpdir(), "ocx-shim-unreadable-config-"));
+    const codexHome = join(root, "codex-home");
+    const opencodexHome = join(root, "opencodex-home");
+    const binDir = join(root, "bin");
+    mkdirSync(codexHome);
+    mkdirSync(opencodexHome);
+    mkdirSync(binDir);
+    try {
+      mkdirSync(join(codexHome, "config.toml"));
+      const codex = join(binDir, process.platform === "win32" ? "codex.cmd" : "codex");
+      writeFileSync(
+        codex,
+        process.platform === "win32" ? "@echo off\r\nexit /b 0\r\n" : "#!/bin/sh\nexit 0\n",
+        "utf8",
+      );
+      if (process.platform !== "win32") chmodSync(codex, 0o755);
+
+      const result = spawnSync(process.execPath, [cliPath, "codex-shim", "install"], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          CODEX_HOME: codexHome,
+          OPENCODEX_HOME: opencodexHome,
+          PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
+        },
+        encoding: "utf8",
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toStartWith("⚠️  Codex autostart shim installed");
+      expect(result.stderr).toContain("Codex routing could not be verified");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- Keep the post-install Codex shim readiness check advisory when the Codex config cannot be read or changes between existence and read checks.
- Reuse the existing `getCodexRoutingKind()` fallback so the install succeeds and emits the generic routing-verification warning instead of failing after the shim has already been written.
- Add a cross-platform end-to-end regression with `config.toml` represented by an unreadable directory and platform-appropriate Codex launchers.

## Verification

- `bun test tests/codex-shim-readiness.test.ts` — 6 passed, 0 failed.
- `bun run typecheck`
- `bun run privacy:scan`
- `git diff --check`
- Independent focused diff review: no P0-P3 findings.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No documentation change is needed for this failure-path fix.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->