### PR TITLE
fix(update): preserve service repair on scan failure

### DIFF
--- a/src/update/job.ts
+++ b/src/update/job.ts
@@ -1134,8 +1134,16 @@ async function restartAfterUpdate(
         `Port ${port} still busy after ${Math.trunc(RESTART_PORT_RECLAIM_MS / 1000)}s; refusing to hop — reinstall may fail until the port is free.`
           + ` ${formatPortHolders(port, listPids, verifyOcx, preServiceAllow)}`,
       );
-      const liveAfter = listPids(port).filter(pid => pid !== process.pid && aliveFn(pid));
-      if (liveAfter.length === 0) {
+      const liveScan: ListenPidScan = io.scanListenPidsFn
+        ? io.scanListenPidsFn(port)
+        : io.listListenPidsFn
+          // Test seam: an injected list represents a successful scan.
+          ? { ok: true, pids: io.listListenPidsFn(port) }
+          : scanListenPids(port);
+      const liveAfter = liveScan.ok
+        ? liveScan.pids.filter(pid => pid !== process.pid && aliveFn(pid))
+        : null;
+      if (liveAfter !== null && liveAfter.length === 0) {
         // Non-elevated `service install` will UAC-fail anyway; skip straight to
         // the direct-start fallthrough instead of burning another minute on it.
         updateJob(job, {}, "Skipping service reinstall after reclaim timeout with no live holders; falling back to a direct proxy start.");

--- a/tests/update-job.test.ts
+++ b/tests/update-job.test.ts
@@ -448,6 +448,7 @@ describe("GUI update execution decisions", () => {
 
   test("service restart is not skipped when the listener scan fails", async () => {
     let serviceRuns = 0;
+    const serviceArgs: string[][] = [];
     const job: UpdateJobState = {
       id: "svc-scan-failure",
       status: "restarting",
@@ -460,6 +461,7 @@ describe("GUI update execution decisions", () => {
       restart: true,
       command: "",
       log: [],
+      releaseNotesUrl: "",
     };
     writeFileSync(updateJobPath(job.id), JSON.stringify(job));
     await restartAfterUpdateForTests(job, { port: 19997, hostname: "127.0.0.1" }, {
@@ -468,13 +470,16 @@ describe("GUI update execution decisions", () => {
       waitForPort: async () => false,
       listListenPidsFn: () => [],
       scanListenPidsFn: () => ({ ok: false, error: "listener tools unavailable" }),
-      runService: () => {
+      runService: (_job, _bin, args) => {
         serviceRuns += 1;
+        serviceArgs.push(args);
         return { status: 0 };
       },
+      spawnStart: () => {},
       probeProxy: async () => true,
     });
     expect(serviceRuns).toBe(1);
+    expect(serviceArgs[0]).toContain("repair");
     expect(readUpdateJob(job.id)?.log.some(line =>
       line.includes("Skipping service reinstall after reclaim timeout"),
     )).toBe(false);

--- a/tests/update-job.test.ts
+++ b/tests/update-job.test.ts
@@ -446,6 +446,40 @@ describe("GUI update execution decisions", () => {
     });
   });
 
+  test("service restart is not skipped when the listener scan fails", async () => {
+    let serviceRuns = 0;
+    const job: UpdateJobState = {
+      id: "svc-scan-failure",
+      status: "restarting",
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      currentVersion: "2.10.2",
+      latestVersion: "2.10.3",
+      channel: "latest",
+      installer: "npm",
+      restart: true,
+      command: "",
+      log: [],
+    };
+    writeFileSync(updateJobPath(job.id), JSON.stringify(job));
+    await restartAfterUpdateForTests(job, { port: 19997, hostname: "127.0.0.1" }, {
+      serviceInstalledFn: () => true,
+      serviceViableFn: () => true,
+      waitForPort: async () => false,
+      listListenPidsFn: () => [],
+      scanListenPidsFn: () => ({ ok: false, error: "listener tools unavailable" }),
+      runService: () => {
+        serviceRuns += 1;
+        return { status: 0 };
+      },
+      probeProxy: async () => true,
+    });
+    expect(serviceRuns).toBe(1);
+    expect(readUpdateJob(job.id)?.log.some(line =>
+      line.includes("Skipping service reinstall after reclaim timeout"),
+    )).toBe(false);
+  });
+
   test("proxy restart pins --port so post-update start does not hop to an ephemeral port", () => {
     const proxy = restartCommand(false, "npm", "/pkg/bin/ocx.mjs", 10100);
     expect(proxy.mode).toBe("proxy");

--- a/tests/update-job.test.ts
+++ b/tests/update-job.test.ts
@@ -463,7 +463,7 @@ describe("GUI update execution decisions", () => {
       log: [],
       releaseNotesUrl: "",
     };
-    writeFileSync(updateJobPath(job.id), JSON.stringify(job));
+    writeFileSync(updateJobPath(), JSON.stringify(job));
     await restartAfterUpdateForTests(job, { port: 19997, hostname: "127.0.0.1" }, {
       serviceInstalledFn: () => true,
       serviceViableFn: () => true,


### PR DESCRIPTION
## Summary

- Preserve the service-refresh path when the post-reclaim listener scan is inconclusive.
- Treat only a successful empty PID scan as proof that there are no live holders.
- Keep injected list-only test seams compatible by treating their result as a successful scan, and add a regression for unavailable listener tools.

## Verification

- Bun 1.3.14: `bun test tests/update-job.test.ts` — 54 passed.
- Bun 1.3.14: focused listener-scan regression — 1 passed.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `git diff --check HEAD^ HEAD` — passed.
- The previous exact head completed full GitHub CI successfully; subsequent review-only test refinements retained the same production patch.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] No documentation change is required for this recovery-path correction.
- [x] The branch is based on the latest `dev`.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service restarts when listener detection fails, preventing valid installations from being incorrectly skipped.
  * Enhanced reclaim handling by checking all available listeners before deciding whether a service can start.
  * Ensured repair actions continue when port waiting or listener scanning is unavailable.

* **Tests**
  * Added regression coverage for successful service restarts when listener scanning is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->