### PR TITLE
fix(images): preserve bodyless responses with size headers

### DIFF
--- a/src/server/images.ts
+++ b/src/server/images.ts
@@ -84,6 +84,9 @@ export async function readImageResponseBytes(
     cancelUnlockedResponseBody(response, signal.reason);
     throw signal.reason;
   }
+  if (response.body === null) {
+    return { bytes: new Uint8Array(0), oversized: false };
+  }
 
   const maxBytes = options.maxBytes ?? IMAGES_RESPONSE_MAX_BYTES;
   const contentLength = response.headers.get("content-length");

--- a/tests/server-images.test.ts
+++ b/tests/server-images.test.ts
@@ -783,7 +783,10 @@ test("relays a bodyless upstream image status without synthesizing a body", asyn
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const requestUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
     if (new URL(requestUrl).hostname === "chatgpt.com") {
-      return new Response(null, { status: 204 });
+      return new Response(null, {
+        status: 204,
+        headers: { "content-length": String(IMAGES_RESPONSE_MAX_BYTES + 1) },
+      });
     }
     return originalFetch(input, init);
   }) as typeof fetch;


### PR DESCRIPTION
## Summary

- Treat a response with no body as zero bytes before evaluating its Content-Length metadata.
- Preserve bodyless image relay statuses such as 204 even when an upstream sends an oversized or stale Content-Length header.
- Extend the live image relay regression so this header cannot turn a bodyless response into a synthetic 502.

Follow-up to https://github.com/lidge-jun/opencodex/pull/1346#discussion_r3745763840.

## Verification

- Bun 1.3.14: `bun test tests/server-images.test.ts` — 63 passed.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `git diff --check HEAD^ HEAD` — passed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed; none are required for this internal response-body correction.
- [x] Security-sensitive changes were reviewed for untrusted upstream metadata and fail-closed behavior.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of image responses with no body.
  * Prevented empty responses with oversized declared content lengths from being incorrectly treated as oversized image data.
  * Preserved expected behavior for successful empty responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->