### PR TITLE
test(images): cover bodyless 304 content length

### DIFF
--- a/tests/server-images-bodyless-content-length.test.ts
+++ b/tests/server-images-bodyless-content-length.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test";
+import { IMAGES_RESPONSE_MAX_BYTES, readImageResponseBytes } from "../src/server/images";
+
+test("bodyless 304 ignores representation Content-Length when enforcing image response size", async () => {
+  const response = new Response(null, {
+    status: 304,
+    headers: { "content-length": String(IMAGES_RESPONSE_MAX_BYTES + 1) },
+  });
+
+  const observed = await readImageResponseBytes(response);
+
+  expect(observed.oversized).toBe(false);
+  expect(observed.bytes.byteLength).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Add a focused regression for a bodyless HTTP 304 response that carries a representation `Content-Length` larger than the image relay cap.
- Assert the bodyless response is treated as zero bytes and is not marked oversized.
- Follow up on the review nit from #1386 with the standards-valid case that originally motivated the fix.

## Why

#1386 correctly fixed bodyless responses before evaluating `Content-Length`, but its integration regression used `204 + Content-Length`. A 304 response is the standards-valid case where `Content-Length` can describe the selected representation while the response itself has no body.

## Scope

Test-only. No production behavior changes.

## Validation

- Branch is based on current `dev` after #1386 and #1387.
- Diff is one new 14-line test file only.
- GitHub CI will provide the executable validation because the local runtime in this session does not have Bun/GitHub CLI available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of bodyless `304` responses with oversized `Content-Length` headers.
  * These responses now correctly return zero bytes without being flagged as oversized.

* **Tests**
  * Added coverage to verify the corrected response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->