### PR TITLE
fix(gui): close logs detail dialog on outside click

### DIFF
--- a/gui/src/pages/Logs.tsx
+++ b/gui/src/pages/Logs.tsx
@@ -891,7 +891,8 @@ function LogDetailDialog({
       aria-labelledby="log-detail-title"
       onCancel={e => { e.preventDefault(); onClose(); }}
     >
-      <div className="modal-card log-detail-card">
+      <button type="button" className="modal-backdrop-dismiss" aria-label={t("common.close")} tabIndex={-1} onClick={onClose} />
+      <div className="modal-card log-detail-card" onClick={event => event.stopPropagation()} role="document">
         <div className="modal-head">
           <h3 id="log-detail-title">
             <span className="mono" style={{ color: statusColor(detail.status) }}>{detail.status}</span>

--- a/gui/tests/logs-auto-refresh.test.tsx
+++ b/gui/tests/logs-auto-refresh.test.tsx
@@ -453,3 +453,26 @@ test("Logs: attempt details render exact reasoning wire values without legacy pl
 
   await act(async () => { root.unmount(); });
 });
+
+test("Logs: backdrop dismiss closes the detail dialog", async () => {
+  globalThis.fetch = (async (input) => {
+    if (!String(input).includes("/api/logs")) return new Response(null, { status: 404 });
+    return jsonResponse([sampleLog]);
+  }) as typeof fetch;
+
+  const { root, container } = await mountLogs();
+  await flushMicrotasks();
+
+  const detailBtn = container.querySelector<HTMLButtonElement>(".log-detail-btn")!;
+  await act(async () => { detailBtn.click(); });
+  expect(container.querySelector("dialog")).not.toBeNull();
+
+  const backdrop = container.querySelector<HTMLButtonElement>(".modal-backdrop-dismiss")!;
+  expect(backdrop).not.toBeNull();
+  expect(backdrop.tabIndex).toBe(-1);
+
+  await act(async () => { backdrop.click(); });
+  expect(container.querySelector("dialog")).toBeNull();
+
+  await act(async () => { root.unmount(); });
+});

--- a/gui/tests/logs-auto-refresh.test.tsx
+++ b/gui/tests/logs-auto-refresh.test.tsx
@@ -454,7 +454,7 @@ test("Logs: attempt details render exact reasoning wire values without legacy pl
   await act(async () => { root.unmount(); });
 });
 
-test("Logs: backdrop dismiss closes the detail dialog", async () => {
+test("Logs: inside-card clicks keep the detail dialog open; backdrop dismiss closes it", async () => {
   globalThis.fetch = (async (input) => {
     if (!String(input).includes("/api/logs")) return new Response(null, { status: 404 });
     return jsonResponse([sampleLog]);
@@ -465,6 +465,11 @@ test("Logs: backdrop dismiss closes the detail dialog", async () => {
 
   const detailBtn = container.querySelector<HTMLButtonElement>(".log-detail-btn")!;
   await act(async () => { detailBtn.click(); });
+  expect(container.querySelector("dialog")).not.toBeNull();
+
+  const card = container.querySelector<HTMLElement>(".log-detail-card")!;
+  expect(card).not.toBeNull();
+  await act(async () => { card.click(); });
   expect(container.querySelector("dialog")).not.toBeNull();
 
   const backdrop = container.querySelector<HTMLButtonElement>(".modal-backdrop-dismiss")!;


### PR DESCRIPTION
## Summary
- Add backdrop dismiss to the logs Details dialog so clicking outside the modal closes it
- Use the same modal-backdrop-dismiss pattern as other native dialog modals in the GUI

## Test plan
- [ ] Open Logs, click Details on a log entry
- [ ] Click outside the dialog and confirm it closes
- [ ] Confirm Escape and the X button still close the dialog
- [ ] Confirm clicks inside the dialog do not dismiss it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log detail dialogs so clicking inside the dialog no longer unintentionally dismisses it.
  * Added a backdrop-dismiss option for easier dialog closure.
  * Improved keyboard navigation by excluding the backdrop-dismiss button from the tab order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->