### PR TITLE
fix(oauth): guard expires_in parsing against NaN across token responses

### DIFF
--- a/src/codex/account-store.ts
+++ b/src/codex/account-store.ts
@@ -491,11 +491,15 @@ export async function getValidCodexToken(id: string): Promise<CodexTokenResult> 
       throw new TokenRefreshError(reason, `Codex token refresh failed (${reason}); reauthenticate the account.`);
     }
     const data = (await res.json()) as { access_token: string; refresh_token?: string; expires_in: number };
+    // Guard against a missing/non-finite expires_in (malformed upstream response):
+    // a NaN expiry would never compare as expired and would block refresh forever.
+    const expiresIn =
+      typeof data.expires_in === "number" && Number.isFinite(data.expires_in) ? data.expires_in : 3600;
 
     const updated: CodexAccountCredentials = {
       accessToken: data.access_token,
       refreshToken: data.refresh_token ?? lockedCred.refreshToken,
-      expiresAt: Date.now() + data.expires_in * 1000,
+      expiresAt: Date.now() + expiresIn * 1000,
       chatgptAccountId: lockedCred.chatgptAccountId,
     };
     if (!saveCodexAccountCredentialIfGeneration(id, startGeneration, updated)) {

--- a/src/codex/account-store.ts
+++ b/src/codex/account-store.ts
@@ -491,10 +491,13 @@ export async function getValidCodexToken(id: string): Promise<CodexTokenResult> 
       throw new TokenRefreshError(reason, `Codex token refresh failed (${reason}); reauthenticate the account.`);
     }
     const data = (await res.json()) as { access_token: string; refresh_token?: string; expires_in: number };
-    // Guard against a missing/non-finite expires_in (malformed upstream response):
-    // a NaN expiry would never compare as expired and would block refresh forever.
+    // Guard against a missing/non-finite/negative expires_in (malformed upstream
+    // response): a NaN expiry would never compare as expired, and a negative
+    // duration would stamp an already-past expiry — both block refresh semantics.
     const expiresIn =
-      typeof data.expires_in === "number" && Number.isFinite(data.expires_in) ? data.expires_in : 3600;
+      typeof data.expires_in === "number" && Number.isFinite(data.expires_in) && data.expires_in >= 0
+        ? data.expires_in
+        : 3600;
     // The computed timestamp itself must stay finite: Number.MAX_VALUE passes
     // Number.isFinite but overflows to Infinity once multiplied by 1000.
     const expiresAt = Date.now() + expiresIn * 1000;

--- a/src/codex/account-store.ts
+++ b/src/codex/account-store.ts
@@ -495,11 +495,15 @@ export async function getValidCodexToken(id: string): Promise<CodexTokenResult> 
     // a NaN expiry would never compare as expired and would block refresh forever.
     const expiresIn =
       typeof data.expires_in === "number" && Number.isFinite(data.expires_in) ? data.expires_in : 3600;
+    // The computed timestamp itself must stay finite: Number.MAX_VALUE passes
+    // Number.isFinite but overflows to Infinity once multiplied by 1000.
+    const expiresAt = Date.now() + expiresIn * 1000;
+    const safeExpiresAt = Number.isFinite(expiresAt) ? expiresAt : Date.now() + 3600 * 1000;
 
     const updated: CodexAccountCredentials = {
       accessToken: data.access_token,
       refreshToken: data.refresh_token ?? lockedCred.refreshToken,
-      expiresAt: Date.now() + expiresIn * 1000,
+      expiresAt: safeExpiresAt,
       chatgptAccountId: lockedCred.chatgptAccountId,
     };
     if (!saveCodexAccountCredentialIfGeneration(id, startGeneration, updated)) {

--- a/src/oauth/anthropic.ts
+++ b/src/oauth/anthropic.ts
@@ -85,10 +85,14 @@ function credsFrom(data: AnthropicTokenResponse, refreshFallback?: string): OAut
   // a NaN expiry would never compare as expired and would block refresh forever.
   const expiresIn =
     typeof data.expires_in === "number" && Number.isFinite(data.expires_in) ? data.expires_in : 3600;
+  // The computed timestamp itself must stay finite: Number.MAX_VALUE passes
+  // Number.isFinite but overflows to Infinity once multiplied by 1000.
+  const computedExpires = Date.now() + expiresIn * 1000 - 5 * 60 * 1000;
+  const expires = Number.isFinite(computedExpires) ? computedExpires : Date.now() + 3600 * 1000 - 5 * 60 * 1000;
   return {
     refresh: data.refresh_token || refreshFallback || "",
     access: data.access_token,
-    expires: Date.now() + expiresIn * 1000 - 5 * 60 * 1000,
+    expires,
     accountId: typeof accountUuid === "string" && accountUuid.length > 0 ? accountUuid : undefined,
     email: typeof email === "string" && email.length > 0 ? email : undefined,
   };

--- a/src/oauth/anthropic.ts
+++ b/src/oauth/anthropic.ts
@@ -81,10 +81,13 @@ function parseTokenResponse(responseBody: string): AnthropicTokenResponse {
 function credsFrom(data: AnthropicTokenResponse, refreshFallback?: string): OAuthCredentials {
   const accountUuid = data.account?.uuid;
   const email = data.account?.email_address;
-  // Guard against a missing/non-finite expires_in (malformed upstream response):
-  // a NaN expiry would never compare as expired and would block refresh forever.
+  // Guard against a missing/non-finite/negative expires_in (malformed upstream
+  // response): a NaN expiry would never compare as expired, and a negative
+  // duration would stamp an already-past expiry — both block refresh semantics.
   const expiresIn =
-    typeof data.expires_in === "number" && Number.isFinite(data.expires_in) ? data.expires_in : 3600;
+    typeof data.expires_in === "number" && Number.isFinite(data.expires_in) && data.expires_in >= 0
+      ? data.expires_in
+      : 3600;
   // The computed timestamp itself must stay finite: Number.MAX_VALUE passes
   // Number.isFinite but overflows to Infinity once multiplied by 1000.
   const computedExpires = Date.now() + expiresIn * 1000 - 5 * 60 * 1000;

--- a/src/oauth/anthropic.ts
+++ b/src/oauth/anthropic.ts
@@ -81,10 +81,14 @@ function parseTokenResponse(responseBody: string): AnthropicTokenResponse {
 function credsFrom(data: AnthropicTokenResponse, refreshFallback?: string): OAuthCredentials {
   const accountUuid = data.account?.uuid;
   const email = data.account?.email_address;
+  // Guard against a missing/non-finite expires_in (malformed upstream response):
+  // a NaN expiry would never compare as expired and would block refresh forever.
+  const expiresIn =
+    typeof data.expires_in === "number" && Number.isFinite(data.expires_in) ? data.expires_in : 3600;
   return {
     refresh: data.refresh_token || refreshFallback || "",
     access: data.access_token,
-    expires: Date.now() + data.expires_in * 1000 - 5 * 60 * 1000,
+    expires: Date.now() + expiresIn * 1000 - 5 * 60 * 1000,
     accountId: typeof accountUuid === "string" && accountUuid.length > 0 ? accountUuid : undefined,
     email: typeof email === "string" && email.length > 0 ? email : undefined,
   };

--- a/src/oauth/chatgpt.ts
+++ b/src/oauth/chatgpt.ts
@@ -53,10 +53,14 @@ function credsFromToken(data: Record<string, unknown>): OAuthCredentials {
   // produce a NaN expiry that never compares as expired (refresh blocked forever).
   const expiresIn =
     typeof data.expires_in === "number" && Number.isFinite(data.expires_in) ? data.expires_in : 3600;
+  // The computed timestamp itself must stay finite: Number.MAX_VALUE passes
+  // Number.isFinite but overflows to Infinity once multiplied by 1000.
+  const computedExpires = Date.now() + expiresIn * 1000;
+  const expires = Number.isFinite(computedExpires) ? computedExpires : Date.now() + 3600 * 1000;
   return {
     access: accessToken,
     refresh: (data.refresh_token as string) ?? "",
-    expires: Date.now() + expiresIn * 1000,
+    expires,
     accountId: extractAccountId(idToken, accessToken),
     email: extractEmail(idToken, accessToken),
   };

--- a/src/oauth/chatgpt.ts
+++ b/src/oauth/chatgpt.ts
@@ -50,9 +50,12 @@ function credsFromToken(data: Record<string, unknown>): OAuthCredentials {
   const idToken = typeof data.id_token === "string" ? data.id_token : undefined;
   const accessToken = data.access_token as string;
   // ?? only guards null/undefined; NaN or a string expires_in would otherwise
-  // produce a NaN expiry that never compares as expired (refresh blocked forever).
+  // produce a NaN expiry that never compares as expired, and a negative duration
+  // would stamp an already-past expiry — both block refresh semantics.
   const expiresIn =
-    typeof data.expires_in === "number" && Number.isFinite(data.expires_in) ? data.expires_in : 3600;
+    typeof data.expires_in === "number" && Number.isFinite(data.expires_in) && data.expires_in >= 0
+      ? data.expires_in
+      : 3600;
   // The computed timestamp itself must stay finite: Number.MAX_VALUE passes
   // Number.isFinite but overflows to Infinity once multiplied by 1000.
   const computedExpires = Date.now() + expiresIn * 1000;

--- a/src/oauth/chatgpt.ts
+++ b/src/oauth/chatgpt.ts
@@ -49,10 +49,14 @@ export function extractEmail(idToken?: string, accessToken?: string): string | u
 function credsFromToken(data: Record<string, unknown>): OAuthCredentials {
   const idToken = typeof data.id_token === "string" ? data.id_token : undefined;
   const accessToken = data.access_token as string;
+  // ?? only guards null/undefined; NaN or a string expires_in would otherwise
+  // produce a NaN expiry that never compares as expired (refresh blocked forever).
+  const expiresIn =
+    typeof data.expires_in === "number" && Number.isFinite(data.expires_in) ? data.expires_in : 3600;
   return {
     access: accessToken,
     refresh: (data.refresh_token as string) ?? "",
-    expires: Date.now() + ((data.expires_in as number) ?? 3600) * 1000,
+    expires: Date.now() + expiresIn * 1000,
     accountId: extractAccountId(idToken, accessToken),
     email: extractEmail(idToken, accessToken),
   };

--- a/src/oauth/kimi.ts
+++ b/src/oauth/kimi.ts
@@ -153,9 +153,15 @@ async function requestDeviceAuthorization(): Promise<{
 function parseTokenPayload(payload: TokenResponse, refreshFallback?: string): OAuthCredentials {
   // Number.isFinite is required here: typeof NaN === "number", so the type check
   // alone would let a NaN expires_in through and produce a never-refreshing expiry.
+  // Negative durations would stamp an already-past expiry — also malformed.
   // The computed timestamp itself must also stay finite: Number.MAX_VALUE passes
   // Number.isFinite but overflows to Infinity once multiplied by 1000.
-  if (!payload.access_token || typeof payload.expires_in !== "number" || !Number.isFinite(payload.expires_in)) {
+  if (
+    !payload.access_token
+    || typeof payload.expires_in !== "number"
+    || !Number.isFinite(payload.expires_in)
+    || payload.expires_in < 0
+  ) {
     throw new Error("Kimi token response missing required fields");
   }
   const expires = Date.now() + payload.expires_in * 1000 - OAUTH_EXPIRY_SKEW_MS;

--- a/src/oauth/kimi.ts
+++ b/src/oauth/kimi.ts
@@ -153,7 +153,13 @@ async function requestDeviceAuthorization(): Promise<{
 function parseTokenPayload(payload: TokenResponse, refreshFallback?: string): OAuthCredentials {
   // Number.isFinite is required here: typeof NaN === "number", so the type check
   // alone would let a NaN expires_in through and produce a never-refreshing expiry.
+  // The computed timestamp itself must also stay finite: Number.MAX_VALUE passes
+  // Number.isFinite but overflows to Infinity once multiplied by 1000.
   if (!payload.access_token || typeof payload.expires_in !== "number" || !Number.isFinite(payload.expires_in)) {
+    throw new Error("Kimi token response missing required fields");
+  }
+  const expires = Date.now() + payload.expires_in * 1000 - OAUTH_EXPIRY_SKEW_MS;
+  if (!Number.isFinite(expires)) {
     throw new Error("Kimi token response missing required fields");
   }
   const refresh = payload.refresh_token ?? refreshFallback;
@@ -162,7 +168,7 @@ function parseTokenPayload(payload: TokenResponse, refreshFallback?: string): OA
   return {
     access: payload.access_token,
     refresh,
-    expires: Date.now() + payload.expires_in * 1000 - OAUTH_EXPIRY_SKEW_MS,
+    expires,
     ...identity,
   };
 }

--- a/src/oauth/kimi.ts
+++ b/src/oauth/kimi.ts
@@ -151,7 +151,9 @@ async function requestDeviceAuthorization(): Promise<{
 }
 
 function parseTokenPayload(payload: TokenResponse, refreshFallback?: string): OAuthCredentials {
-  if (!payload.access_token || typeof payload.expires_in !== "number") {
+  // Number.isFinite is required here: typeof NaN === "number", so the type check
+  // alone would let a NaN expires_in through and produce a never-refreshing expiry.
+  if (!payload.access_token || typeof payload.expires_in !== "number" || !Number.isFinite(payload.expires_in)) {
     throw new Error("Kimi token response missing required fields");
   }
   const refresh = payload.refresh_token ?? refreshFallback;

--- a/tests/anthropic-hardening.test.ts
+++ b/tests/anthropic-hardening.test.ts
@@ -56,6 +56,19 @@ describe("anthropic provider hardening", () => {
     expect(cred.expires).toBeGreaterThan(Date.now());
   });
 
+  test("refresh with an overflowing expires_in falls back to a finite default expiry", async () => {
+    globalThis.fetch = (async () => new Response(
+      // Number.MAX_VALUE passes Number.isFinite but overflows to Infinity when
+      // multiplied by 1000 — the computed expiry must still be guarded.
+      '{"access_token":"at","refresh_token":"rt","expires_in":1.7976931348623157e308}',
+      { status: 200 },
+    )) as typeof fetch;
+
+    const cred = await refreshAnthropicToken("secret");
+    expect(Number.isFinite(cred.expires)).toBe(true);
+    expect(cred.expires).toBeGreaterThan(Date.now());
+  });
+
   test("key mode rejects a blank API key", async () => {
     const adapter = createAnthropicAdapter(provider({ apiKey: "   " }));
 

--- a/tests/anthropic-hardening.test.ts
+++ b/tests/anthropic-hardening.test.ts
@@ -43,6 +43,19 @@ describe("anthropic provider hardening", () => {
     await expect(refreshAnthropicToken("secret")).rejects.toMatchObject({ httpStatus: 503, oauthError: undefined });
   });
 
+  test("refresh with a non-finite expires_in falls back to a finite default expiry", async () => {
+    globalThis.fetch = (async () => new Response(
+      // JSON.stringify would turn Infinity into null; hand-write 1e999 so JSON.parse
+      // yields Infinity, which would previously produce expires: NaN (never refreshing).
+      '{"access_token":"at","refresh_token":"rt","expires_in":1e999}',
+      { status: 200 },
+    )) as typeof fetch;
+
+    const cred = await refreshAnthropicToken("secret");
+    expect(Number.isFinite(cred.expires)).toBe(true);
+    expect(cred.expires).toBeGreaterThan(Date.now());
+  });
+
   test("key mode rejects a blank API key", async () => {
     const adapter = createAnthropicAdapter(provider({ apiKey: "   " }));
 

--- a/tests/anthropic-hardening.test.ts
+++ b/tests/anthropic-hardening.test.ts
@@ -43,7 +43,7 @@ describe("anthropic provider hardening", () => {
     await expect(refreshAnthropicToken("secret")).rejects.toMatchObject({ httpStatus: 503, oauthError: undefined });
   });
 
-  test("refresh with a non-finite expires_in falls back to a finite default expiry", async () => {
+  test("refresh with a non-finite expires_in falls back to the 3600s default (3300s after skew)", async () => {
     globalThis.fetch = (async () => new Response(
       // JSON.stringify would turn Infinity into null; hand-write 1e999 so JSON.parse
       // yields Infinity, which would previously produce expires: NaN (never refreshing).
@@ -51,12 +51,15 @@ describe("anthropic provider hardening", () => {
       { status: 200 },
     )) as typeof fetch;
 
+    const before = Date.now();
     const cred = await refreshAnthropicToken("secret");
     expect(Number.isFinite(cred.expires)).toBe(true);
-    expect(cred.expires).toBeGreaterThan(Date.now());
+    expect(cred.expires).toBeGreaterThan(before);
+    // 3600s default minus the 5-minute refresh skew.
+    expect(Math.abs(cred.expires - (before + 3300 * 1000))).toBeLessThan(30_000);
   });
 
-  test("refresh with an overflowing expires_in falls back to a finite default expiry", async () => {
+  test("refresh with an overflowing expires_in falls back to the 3600s default (3300s after skew)", async () => {
     globalThis.fetch = (async () => new Response(
       // Number.MAX_VALUE passes Number.isFinite but overflows to Infinity when
       // multiplied by 1000 — the computed expiry must still be guarded.
@@ -64,9 +67,24 @@ describe("anthropic provider hardening", () => {
       { status: 200 },
     )) as typeof fetch;
 
+    const before = Date.now();
     const cred = await refreshAnthropicToken("secret");
     expect(Number.isFinite(cred.expires)).toBe(true);
-    expect(cred.expires).toBeGreaterThan(Date.now());
+    expect(cred.expires).toBeGreaterThan(before);
+    expect(Math.abs(cred.expires - (before + 3300 * 1000))).toBeLessThan(30_000);
+  });
+
+  test("refresh with a negative expires_in falls back to the 3600s default (3300s after skew)", async () => {
+    globalThis.fetch = (async () => new Response(
+      JSON.stringify({ access_token: "at", refresh_token: "rt", expires_in: -1 }),
+      { status: 200 },
+    )) as typeof fetch;
+
+    const before = Date.now();
+    const cred = await refreshAnthropicToken("secret");
+    expect(Number.isFinite(cred.expires)).toBe(true);
+    expect(cred.expires).toBeGreaterThan(before);
+    expect(Math.abs(cred.expires - (before + 3300 * 1000))).toBeLessThan(30_000);
   });
 
   test("key mode rejects a blank API key", async () => {

--- a/tests/chatgpt-token-expiry.test.ts
+++ b/tests/chatgpt-token-expiry.test.ts
@@ -28,4 +28,17 @@ describe("ChatGPT OAuth token response parsing", () => {
     expect(Number.isFinite(cred.expires)).toBe(true);
     expect(cred.expires).toBeGreaterThan(Date.now());
   });
+
+  test("refresh with an overflowing expires_in falls back to a finite default expiry", async () => {
+    globalThis.fetch = (async () => new Response(
+      // Number.MAX_VALUE passes Number.isFinite but overflows to Infinity when
+      // multiplied by 1000 — the computed expiry must still be guarded.
+      '{"access_token":"at","refresh_token":"rt","expires_in":1.7976931348623157e308}',
+      { status: 200 },
+    )) as typeof fetch;
+
+    const cred = await refreshChatGPTToken("secret");
+    expect(Number.isFinite(cred.expires)).toBe(true);
+    expect(cred.expires).toBeGreaterThan(Date.now());
+  });
 });

--- a/tests/chatgpt-token-expiry.test.ts
+++ b/tests/chatgpt-token-expiry.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { refreshChatGPTToken } from "../src/oauth/chatgpt";
+
+const originalFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = originalFetch; });
+
+describe("ChatGPT OAuth token response parsing", () => {
+  test("refresh with a non-finite expires_in falls back to a finite default expiry", async () => {
+    globalThis.fetch = (async () => new Response(
+      // JSON.stringify would turn Infinity into null; hand-write 1e999 so JSON.parse
+      // yields Infinity, which ?? 3600 alone would let through (NaN expiry, never refreshing).
+      '{"access_token":"at","refresh_token":"rt","expires_in":1e999}',
+      { status: 200 },
+    )) as typeof fetch;
+
+    const cred = await refreshChatGPTToken("secret");
+    expect(Number.isFinite(cred.expires)).toBe(true);
+    expect(cred.expires).toBeGreaterThan(Date.now());
+  });
+
+  test("refresh with a string expires_in falls back to a finite default expiry", async () => {
+    globalThis.fetch = (async () => new Response(
+      JSON.stringify({ access_token: "at", refresh_token: "rt", expires_in: "garbage" }),
+      { status: 200 },
+    )) as typeof fetch;
+
+    const cred = await refreshChatGPTToken("secret");
+    expect(Number.isFinite(cred.expires)).toBe(true);
+    expect(cred.expires).toBeGreaterThan(Date.now());
+  });
+});

--- a/tests/chatgpt-token-expiry.test.ts
+++ b/tests/chatgpt-token-expiry.test.ts
@@ -4,8 +4,11 @@ import { refreshChatGPTToken } from "../src/oauth/chatgpt";
 const originalFetch = globalThis.fetch;
 afterEach(() => { globalThis.fetch = originalFetch; });
 
+const FALLBACK_MS = 3600 * 1000;
+const TOLERANCE_MS = 30_000;
+
 describe("ChatGPT OAuth token response parsing", () => {
-  test("refresh with a non-finite expires_in falls back to a finite default expiry", async () => {
+  test("refresh with a non-finite expires_in falls back to the 3600s default", async () => {
     globalThis.fetch = (async () => new Response(
       // JSON.stringify would turn Infinity into null; hand-write 1e999 so JSON.parse
       // yields Infinity, which ?? 3600 alone would let through (NaN expiry, never refreshing).
@@ -13,23 +16,27 @@ describe("ChatGPT OAuth token response parsing", () => {
       { status: 200 },
     )) as typeof fetch;
 
+    const before = Date.now();
     const cred = await refreshChatGPTToken("secret");
     expect(Number.isFinite(cred.expires)).toBe(true);
-    expect(cred.expires).toBeGreaterThan(Date.now());
+    expect(cred.expires).toBeGreaterThan(before);
+    expect(Math.abs(cred.expires - (before + FALLBACK_MS))).toBeLessThan(TOLERANCE_MS);
   });
 
-  test("refresh with a string expires_in falls back to a finite default expiry", async () => {
+  test("refresh with a string expires_in falls back to the 3600s default", async () => {
     globalThis.fetch = (async () => new Response(
       JSON.stringify({ access_token: "at", refresh_token: "rt", expires_in: "garbage" }),
       { status: 200 },
     )) as typeof fetch;
 
+    const before = Date.now();
     const cred = await refreshChatGPTToken("secret");
     expect(Number.isFinite(cred.expires)).toBe(true);
-    expect(cred.expires).toBeGreaterThan(Date.now());
+    expect(cred.expires).toBeGreaterThan(before);
+    expect(Math.abs(cred.expires - (before + FALLBACK_MS))).toBeLessThan(TOLERANCE_MS);
   });
 
-  test("refresh with an overflowing expires_in falls back to a finite default expiry", async () => {
+  test("refresh with an overflowing expires_in falls back to the 3600s default", async () => {
     globalThis.fetch = (async () => new Response(
       // Number.MAX_VALUE passes Number.isFinite but overflows to Infinity when
       // multiplied by 1000 — the computed expiry must still be guarded.
@@ -37,8 +44,23 @@ describe("ChatGPT OAuth token response parsing", () => {
       { status: 200 },
     )) as typeof fetch;
 
+    const before = Date.now();
     const cred = await refreshChatGPTToken("secret");
     expect(Number.isFinite(cred.expires)).toBe(true);
-    expect(cred.expires).toBeGreaterThan(Date.now());
+    expect(cred.expires).toBeGreaterThan(before);
+    expect(Math.abs(cred.expires - (before + FALLBACK_MS))).toBeLessThan(TOLERANCE_MS);
+  });
+
+  test("refresh with a negative expires_in falls back to the 3600s default", async () => {
+    globalThis.fetch = (async () => new Response(
+      JSON.stringify({ access_token: "at", refresh_token: "rt", expires_in: -1 }),
+      { status: 200 },
+    )) as typeof fetch;
+
+    const before = Date.now();
+    const cred = await refreshChatGPTToken("secret");
+    expect(Number.isFinite(cred.expires)).toBe(true);
+    expect(cred.expires).toBeGreaterThan(before);
+    expect(Math.abs(cred.expires - (before + FALLBACK_MS))).toBeLessThan(TOLERANCE_MS);
   });
 });

--- a/tests/codex-account-store.test.ts
+++ b/tests/codex-account-store.test.ts
@@ -261,7 +261,7 @@ describe("codex-account-store CRUD", () => {
     }
   });
 
-  test("refresh with a non-finite expires_in falls back to a finite default expiry", async () => {
+  test("refresh with a non-finite expires_in falls back to the 3600s default", async () => {
     const {
       getCodexAccountCredential,
       getValidCodexToken,
@@ -277,16 +277,18 @@ describe("codex-account-store CRUD", () => {
     )) as typeof fetch;
 
     try {
+      const before = Date.now();
       await getValidCodexToken("refresh-bad-expiry");
       const stored = getCodexAccountCredential("refresh-bad-expiry")!;
       expect(Number.isFinite(stored.expiresAt)).toBe(true);
-      expect(stored.expiresAt).toBeGreaterThan(Date.now());
+      expect(stored.expiresAt).toBeGreaterThan(before);
+      expect(Math.abs(stored.expiresAt - (before + 3600 * 1000))).toBeLessThan(30_000);
     } finally {
       globalThis.fetch = originalFetch;
     }
   });
 
-  test("refresh with an overflowing expires_in falls back to a finite default expiry", async () => {
+  test("refresh with an overflowing expires_in falls back to the 3600s default", async () => {
     const {
       getCodexAccountCredential,
       getValidCodexToken,
@@ -302,10 +304,37 @@ describe("codex-account-store CRUD", () => {
     )) as typeof fetch;
 
     try {
+      const before = Date.now();
       await getValidCodexToken("refresh-overflow-expiry");
       const stored = getCodexAccountCredential("refresh-overflow-expiry")!;
       expect(Number.isFinite(stored.expiresAt)).toBe(true);
-      expect(stored.expiresAt).toBeGreaterThan(Date.now());
+      expect(stored.expiresAt).toBeGreaterThan(before);
+      expect(Math.abs(stored.expiresAt - (before + 3600 * 1000))).toBeLessThan(30_000);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("refresh with a negative expires_in falls back to the 3600s default", async () => {
+    const {
+      getCodexAccountCredential,
+      getValidCodexToken,
+      saveCodexAccountCredential,
+    } = await import("../src/codex/account-store");
+    saveCodexAccountCredential("refresh-negative-expiry", { accessToken: "old", refreshToken: "old-r", expiresAt: 0, chatgptAccountId: "acc" });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(
+      JSON.stringify({ access_token: "new", refresh_token: "new-r", expires_in: -1 }),
+      { status: 200 },
+    )) as typeof fetch;
+
+    try {
+      const before = Date.now();
+      await getValidCodexToken("refresh-negative-expiry");
+      const stored = getCodexAccountCredential("refresh-negative-expiry")!;
+      expect(Number.isFinite(stored.expiresAt)).toBe(true);
+      expect(stored.expiresAt).toBeGreaterThan(before);
+      expect(Math.abs(stored.expiresAt - (before + 3600 * 1000))).toBeLessThan(30_000);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/tests/codex-account-store.test.ts
+++ b/tests/codex-account-store.test.ts
@@ -286,6 +286,31 @@ describe("codex-account-store CRUD", () => {
     }
   });
 
+  test("refresh with an overflowing expires_in falls back to a finite default expiry", async () => {
+    const {
+      getCodexAccountCredential,
+      getValidCodexToken,
+      saveCodexAccountCredential,
+    } = await import("../src/codex/account-store");
+    saveCodexAccountCredential("refresh-overflow-expiry", { accessToken: "old", refreshToken: "old-r", expiresAt: 0, chatgptAccountId: "acc" });
+    const originalFetch = globalThis.fetch;
+    // Number.MAX_VALUE passes Number.isFinite but overflows to Infinity when
+    // multiplied by 1000 — the computed expiresAt must still be guarded.
+    globalThis.fetch = (async () => new Response(
+      '{"access_token":"new","refresh_token":"new-r","expires_in":1.7976931348623157e308}',
+      { status: 200 },
+    )) as typeof fetch;
+
+    try {
+      await getValidCodexToken("refresh-overflow-expiry");
+      const stored = getCodexAccountCredential("refresh-overflow-expiry")!;
+      expect(Number.isFinite(stored.expiresAt)).toBe(true);
+      expect(stored.expiresAt).toBeGreaterThan(Date.now());
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("refresh waits behind file lock and reuses credential refreshed by another process", async () => {
     const {
       getValidCodexToken,

--- a/tests/codex-account-store.test.ts
+++ b/tests/codex-account-store.test.ts
@@ -261,6 +261,31 @@ describe("codex-account-store CRUD", () => {
     }
   });
 
+  test("refresh with a non-finite expires_in falls back to a finite default expiry", async () => {
+    const {
+      getCodexAccountCredential,
+      getValidCodexToken,
+      saveCodexAccountCredential,
+    } = await import("../src/codex/account-store");
+    saveCodexAccountCredential("refresh-bad-expiry", { accessToken: "old", refreshToken: "old-r", expiresAt: 0, chatgptAccountId: "acc" });
+    const originalFetch = globalThis.fetch;
+    // JSON.stringify turns NaN into null; hand-write 1e999 so JSON.parse yields Infinity,
+    // the realistic corrupt shape that would previously produce expiresAt: NaN.
+    globalThis.fetch = (async () => new Response(
+      '{"access_token":"new","refresh_token":"new-r","expires_in":1e999}',
+      { status: 200 },
+    )) as typeof fetch;
+
+    try {
+      await getValidCodexToken("refresh-bad-expiry");
+      const stored = getCodexAccountCredential("refresh-bad-expiry")!;
+      expect(Number.isFinite(stored.expiresAt)).toBe(true);
+      expect(stored.expiresAt).toBeGreaterThan(Date.now());
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("refresh waits behind file lock and reuses credential refreshed by another process", async () => {
     const {
       getValidCodexToken,

--- a/tests/kimi-oauth-identity.test.ts
+++ b/tests/kimi-oauth-identity.test.ts
@@ -75,6 +75,17 @@ describe("Kimi token-response wiring (production parseTokenPayload path)", () =>
     expect(cred.accountId).toBe("wired-user");
     expect(cred.email).toBe(["w", String.fromCharCode(64), "kimi.example"].join(""));
   });
+
+  test("refreshKimiToken rejects a non-finite expires_in (would otherwise yield NaN expiry)", async () => {
+    globalThis.fetch = (async () => new Response(
+      // JSON.stringify would turn Infinity into null; hand-write 1e999 so JSON.parse
+      // yields Infinity, which typeof === "number" alone would let through.
+      `{"access_token":"at","refresh_token":"rt","expires_in":1e999}`,
+      { status: 200 },
+    )) as typeof fetch;
+
+    await expect(refreshKimiToken("old-refresh")).rejects.toThrow("missing required fields");
+  });
 });
 
 describe("Kimi multiauth via saveCredential", () => {

--- a/tests/kimi-oauth-identity.test.ts
+++ b/tests/kimi-oauth-identity.test.ts
@@ -97,6 +97,15 @@ describe("Kimi token-response wiring (production parseTokenPayload path)", () =>
 
     await expect(refreshKimiToken("old-refresh")).rejects.toThrow("missing required fields");
   });
+
+  test("refreshKimiToken rejects a negative expires_in (already-past expiry)", async () => {
+    globalThis.fetch = (async () => new Response(
+      JSON.stringify({ access_token: "at", refresh_token: "rt", expires_in: -1 }),
+      { status: 200 },
+    )) as typeof fetch;
+
+    await expect(refreshKimiToken("old-refresh")).rejects.toThrow("missing required fields");
+  });
 });
 
 describe("Kimi multiauth via saveCredential", () => {

--- a/tests/kimi-oauth-identity.test.ts
+++ b/tests/kimi-oauth-identity.test.ts
@@ -86,6 +86,17 @@ describe("Kimi token-response wiring (production parseTokenPayload path)", () =>
 
     await expect(refreshKimiToken("old-refresh")).rejects.toThrow("missing required fields");
   });
+
+  test("refreshKimiToken rejects an overflowing expires_in (finite input, Infinity expiry)", async () => {
+    globalThis.fetch = (async () => new Response(
+      // Number.MAX_VALUE passes Number.isFinite but overflows to Infinity when
+      // multiplied by 1000 — the computed expiry must be rejected as malformed.
+      `{"access_token":"at","refresh_token":"rt","expires_in":1.7976931348623157e308}`,
+      { status: 200 },
+    )) as typeof fetch;
+
+    await expect(refreshKimiToken("old-refresh")).rejects.toThrow("missing required fields");
+  });
 });
 
 describe("Kimi multiauth via saveCredential", () => {


### PR DESCRIPTION
## Summary

Fixes [#1417](https://github.com/lidge-jun/opencodex/issues/1417): OAuth token responses with an invalid `expires_in` (missing, `NaN`, string, negative, or numeric-overflowing) produce a **`NaN`/`Infinity`/past expiry** in stored credentials. `NaN <= x` is always false and `Infinity` never expires, so such credentials break the refresh loop. This is the token-response counterpart of the already-merged [#1369](https://github.com/lidge-jun/opencodex/pull/1369) fix — same data-quality class, remaining at the upstream parse sites.

## Root cause

- `src/oauth/anthropic.ts` — `Date.now() + data.expires_in * 1000` — missing `expires_in` → `undefined * 1000` = `NaN`
- `src/oauth/kimi.ts` — `typeof !== "number"` check lets `NaN` through (`typeof NaN === "number"`)
- `src/oauth/chatgpt.ts` — `?? 3600` only guards `null`/`undefined`; `NaN` or a numeric string passes through
- `src/codex/account-store.ts` — no validation at all

Additional failure modes found in review:
- **Overflow (CodeRabbit Major):** a finite-but-huge `expires_in` (e.g. `Number.MAX_VALUE`) passes `Number.isFinite` but overflows to `Infinity` once multiplied by 1000 — the *computed* expiry must also be guarded.
- **Negative (maintainer review):** a finite negative `expires_in` produces a finite already-past expiry, silently bypassing the malformed-response fallback.

## Changes

All four sites now require `typeof === "number" && Number.isFinite(...) && >= 0` (falling back to a 3600s default so the credential stays refreshable), **plus a guard on the computed expiry timestamp**:

1. **`src/oauth/anthropic.ts`** — `credsFrom()`: non-finite/negative/overflowing → 3600s default.
2. **`src/oauth/kimi.ts`** — `parseTokenPayload()`: non-finite, negative, or overflowing `expires_in` rejected as malformed.
3. **`src/oauth/chatgpt.ts`** — `credsFromToken()`: non-finite/negative/overflowing → 3600s default.
4. **`src/codex/account-store.ts`** — refresh path: non-finite/negative/overflowing → 3600s default.

Per the lazy-refresh contract established in #1369, this change only guards at parse/adoption time — it does not touch `getLoginStatus` or expiry comparison logic.

## Tests

- `tests/chatgpt-token-expiry.test.ts` (new): non-finite, string, overflowing, and negative `expires_in` all fall back to **exactly ~3600s** (tolerance 30s)
- `tests/anthropic-hardening.test.ts`: non-finite, overflowing, and negative → **~3300s** (3600s minus the 5-minute skew)
- `tests/codex-account-store.test.ts`: non-finite, overflowing, and negative → persisted `expiresAt` **~3600s**
- `tests/kimi-oauth-identity.test.ts`: non-finite, overflowing, and negative `expires_in` all rejected

Verification (head `355b69e5`, rebased onto `dev` 9c051342):
- Targeted: 55/55 pass
- OAuth + anthropic + account-store suite: **414/414 pass**
- `bun x tsc --noEmit` → clean
- hygiene: **passed** (maintainer-sponsored applied)
- **cross-platform CI: green** (confirmed by maintainer review on exact head)
- `mergeable_state`: clean

Fixes #1417

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->