### PR TITLE
fix(service): align WSL Codex home ownership

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -285,11 +285,12 @@ export function serviceEnvironmentOwnedHere(): boolean {
 export function assertServiceEnvironmentMatchesInstall(): void {
   const state = readServiceInstallState();
   if (!state) return;
+  const actualCodexHome = currentCodexHome();
   const expected = normalizePathForCompare(state.codexHome);
-  const actual = normalizePathForCompare(currentCodexHome());
+  const actual = normalizePathForCompare(actualCodexHome);
   if (expected !== actual) {
     throw new ServiceOwnershipError(
-      `Service was installed with CODEX_HOME=${state.codexHome}, but current CODEX_HOME=${currentCodexHome()}. ` +
+      `Service was installed with CODEX_HOME=${state.codexHome}, but current CODEX_HOME=${actualCodexHome}. ` +
         "Run the service command from the same Codex home so native Codex restore updates the correct config.",
     );
   }

--- a/src/service.ts
+++ b/src/service.ts
@@ -14,7 +14,7 @@ import { expandUserPath, getConfigDir, readPid, removePid, removeRuntimePort, ve
 import { loadConfig } from "./config";
 import { restoreNativeCodex, restoreNativeCodexAsync } from "./codex/inject";
 import { stripGrokConfig } from "./grok/inject";
-import { isWslRuntime } from "./codex/home";
+import { isWslRuntime, resolveCodexHomeDir, type CodexHomeDeps } from "./codex/home";
 import { BUN_RUNTIME_PATH_ENV, BUN_RUNTIME_SOURCE_ENV, durableBunRuntime } from "./lib/bun-runtime";
 import type { BunRuntimeSource } from "./lib/bun-runtime";
 import { isProcessAlive, stopProxy } from "./lib/process-control";
@@ -94,9 +94,11 @@ function serviceStatePaths(): string[] {
   return paths;
 }
 
-function currentCodexHome(): string {
-  const raw = process.env.CODEX_HOME?.trim();
-  return raw ? resolve(expandUserPath(raw)) : join(homedir(), ".codex");
+function currentCodexHome(deps: CodexHomeDeps = {}): string {
+  // Service ownership must identify the same home as the runtime. In WSL an
+  // unset CODEX_HOME can resolve to the single Windows Desktop home rather than
+  // Linux ~/.codex; recording the fallback here creates a false foreign owner.
+  return resolveCodexHomeDir(deps);
 }
 
 function currentOpenCodexHome(): string {
@@ -218,8 +220,8 @@ export function inspectServiceStateEvidence(
 }
 
 /** The homes this process is actually using, for comparison against a claim. */
-export function currentServiceHomes(): { codexHome: string; opencodexHome: string } {
-  return { codexHome: currentCodexHome(), opencodexHome: currentOpenCodexHome() };
+export function currentServiceHomes(deps: CodexHomeDeps = {}): { codexHome: string; opencodexHome: string } {
+  return { codexHome: currentCodexHome(deps), opencodexHome: currentOpenCodexHome() };
 }
 
 export function serviceHomeMatches(a: string, b: string): boolean {

--- a/structure/02_config-and-codex-home.md
+++ b/structure/02_config-and-codex-home.md
@@ -20,6 +20,20 @@ $CODEX_HOME/.opencodex-native-main-profiles/
 Never assume macOS-only paths. Windows, service installs, and app-launched Codex can all depend on
 the resolved `CODEX_HOME`.
 
+Service install-state ownership uses this same resolver. In WSL, an unset `CODEX_HOME` may resolve
+to the single discoverable Windows Desktop home; recording Linux `~/.codex` instead would make a
+later repair or uninstall look foreign even though the service and runtime were started from the
+same environment. An explicit `CODEX_HOME` remains authoritative, and existing foreign ownership
+records are never migrated implicitly.
+
+[Decision Log]
+- 목적과 의도: Keep service ownership metadata aligned with the Codex home the proxy actually uses.
+- 기존 구현 및 제약 조건: The runtime performed narrow WSL Windows-home discovery, while service state used `CODEX_HOME || ~/.codex`.
+- 검토한 주요 대안: Bake `CODEX_HOME` into every service, migrate old state automatically, or reuse the runtime resolver.
+- 선택한 방식: Resolve service install and comparison state through the existing runtime Codex-home resolver.
+- 다른 대안 대신 이 방식을 선택한 이유: It preserves explicit overrides and the existing WSL ambiguity rules without rewriting user environment or foreign state.
+- 장점, 단점 및 영향: New installs and same-environment repairs agree with runtime targeting; genuinely foreign or ambiguous state remains fail-closed.
+
 Native-main profile ownership is bound to the real `CODEX_HOME`, not to an OpenCodex instance.
 Its encrypted vault, transaction journal, recovery marker, and referenced quarantine files live in
 the owner-only `.opencodex-native-main-profiles` directory. The unchanged

--- a/tests/codex-home-wsl.test.ts
+++ b/tests/codex-home-wsl.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { wslAutomountRoot, listWslWindowsCodexHomes } from "../src/codex/home";
 import { isWindowsInteropDir } from "../src/codex/shim";
+import { currentServiceHomes } from "../src/service";
 
 describe("wsl.conf automount root", () => {
   test("defaults to /mnt when wsl.conf is absent or silent", () => {
@@ -42,5 +43,24 @@ describe("wsl.conf automount root", () => {
     });
     expect(seen[0]).toBe("/win/c/Users");
     expect(homes).toEqual(["/win/c/Users/example/.codex"]);
+  });
+
+  test("service ownership uses the same discovered Windows Codex home as the runtime", () => {
+    const usersRoot = ["/mnt/c", "Users"].join("/");
+    const windowsCodexHome = [usersRoot, "windows-user", ".codex"].join("/");
+    const homes = currentServiceHomes({
+      env: { WSL_DISTRO_NAME: "Ubuntu" },
+      platform: "linux",
+      homedir: () => "/home/example",
+      usersRoot,
+      existsSync: (path: string) => path === usersRoot
+        || path === `${windowsCodexHome}/config.toml`,
+      readdirSync: () => ["windows-user"],
+      statSync: (() => ({ isDirectory: () => true })) as never,
+      realpathSync: (path: string) => path,
+    });
+
+    expect(homes.codexHome).toBe(windowsCodexHome);
+    expect(homes.codexHome).not.toBe("/home/example/.codex");
   });
 });


### PR DESCRIPTION
## Summary

- resolve service install-state ownership through the same Codex-home resolver used by the runtime
- preserve explicit `CODEX_HOME` authority while allowing the existing narrow WSL single-Windows-home discovery when it is unset
- keep ambiguous or genuinely foreign service state fail-closed and document the ownership decision

## Root cause

The runtime already used the WSL-aware `resolveCodexHomeDir()`, but service ownership independently recorded `CODEX_HOME || ~/.codex`. In a Windows Desktop + WSL layout with one discoverable Windows Codex home, the service could therefore record Linux `~/.codex` while the proxy actually used the Windows home. Later repair or uninstall then looked foreign even in the same environment.

## User impact

New service installs and same-environment ownership checks now agree with runtime Codex-home targeting. The patch does not migrate or take over existing foreign service state.

## Verification

- `bun test tests/codex-home-wsl.test.ts tests/service.test.ts`: 106 passed, 0 failed
- focused WSL regression rerun: 5 passed, 0 failed
- `bun run typecheck`: passed
- `bun run privacy:scan`: passed
- `git diff --check`: passed
- full-suite rerun was not repeated after the same clean-`origin/dev` host showed the documented service-token inheritance failure and the CPU-limited suite showed unrelated endpoint admission timeouts; exact-head GitHub CI remains required before readiness

Closes #1400


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service ownership now consistently uses the resolved Codex home, including Windows Codex locations when running under WSL.
  * Explicit Codex home paths remain honored without being automatically migrated.

* **Documentation**
  * Added guidance and decision notes describing Codex home resolution and service ownership behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->