### PR TITLE
fix: recognize Codex Team plans in pool capacity

### DIFF
--- a/src/providers/codex-capacity.ts
+++ b/src/providers/codex-capacity.ts
@@ -2,6 +2,7 @@ import { codexPlanKey, codexPlanValue } from "../codex/plan";
 
 export const CODEX_CONFIGURED_CAPACITY_WEIGHTS = {
   plus: 1,
+  team: 1,
   business: 1,
   prolite: 5,
   pro: 20,

--- a/tests/provider-capacity.test.ts
+++ b/tests/provider-capacity.test.ts
@@ -58,6 +58,20 @@ describe("configured-weight Codex pool capacity", () => {
     });
   });
 
+  test("an all-Team pool has complete configured-weight coverage", () => {
+    const result = aggregateCodexPoolCapacity([
+      account("team", 20, { isMain: true, active: true }),
+      account("team", 60),
+    ], NOW);
+    expect(result.quota?.weeklyPercent).toBe(40);
+    expect(result.aggregation).toMatchObject({
+      includedAccounts: 2,
+      excludedAccounts: 0,
+      unknownPlanAccounts: 0,
+      incomplete: false,
+    });
+  });
+
   test("same-time resets group partial consumed capacity and expose only recovery percent", () => {
     const result = aggregateCodexPoolCapacity([
       account("pro", 25, { weeklyResetAt: NOW + 10_000 }),

--- a/tests/provider-capacity.test.ts
+++ b/tests/provider-capacity.test.ts
@@ -44,6 +44,20 @@ describe("configured-weight Codex pool capacity", () => {
     expect(aggregateCodexPoolCapacity(rows(9), NOW).quota?.weeklyPercent).toBeCloseTo(39.33333333, 8);
   });
 
+  test("legacy Team and Business plans share configured weight", () => {
+    const result = aggregateCodexPoolCapacity([
+      account("team", 20, { isMain: true, active: true }),
+      account("business", 60),
+    ], NOW);
+    expect(result.quota?.weeklyPercent).toBe(40);
+    expect(result.aggregation).toMatchObject({
+      includedAccounts: 2,
+      excludedAccounts: 0,
+      unknownPlanAccounts: 0,
+      incomplete: false,
+    });
+  });
+
   test("same-time resets group partial consumed capacity and expose only recovery percent", () => {
     const result = aggregateCodexPoolCapacity([
       account("pro", 25, { weeklyResetAt: NOW + 10_000 }),
@@ -66,7 +80,7 @@ describe("configured-weight Codex pool capacity", () => {
   test("unknown, missing, paused, and reauth rows are excluded with incomplete coverage", () => {
     const result = aggregateCodexPoolCapacity([
       account("pro", 10, { active: true, isMain: true }),
-      account("team", 50),
+      account("future-plan", 50),
       account("plus", undefined),
       account("prolite", 20, { paused: true }),
       account("business", 30, { needsReauth: true }),
@@ -109,7 +123,7 @@ describe("configured-weight Codex pool capacity", () => {
     ], NOW);
     expect(expired.aggregation?.weekly).not.toHaveProperty("nextRecoveryAt");
     const fallback = aggregateCodexPoolCapacity([
-      account("team", 70, { active: true, isMain: true }),
+      account("future-plan", 70, { active: true, isMain: true }),
       account("go", 80),
     ], NOW);
     expect(fallback.aggregation).toMatchObject({
@@ -209,7 +223,7 @@ describe("configured-weight Codex pool capacity", () => {
     const stale = account("pro", 90);
     stale.quota = { ...stale.quota!, updatedAt: NOW - CODEX_CAPACITY_MAX_QUOTA_AGE_MS - 1 };
     const result = aggregateCodexPoolCapacity([
-      account("team", 10, { active: true, isMain: true }),
+      account("future-plan", 10, { active: true, isMain: true }),
       account("plus", undefined),
       account("prolite", 20, { paused: true }),
       account("business", 30, { needsReauth: true }),


### PR DESCRIPTION
## Summary

- Treat the upstream `team` plan identifier as the Business-tier configured capacity weight.
- Keep unrecognized future plan identifiers excluded from pool estimates.
- Add a focused regression covering mixed Team and Business capacity aggregation.

Closes #1442

## Verification

- `bun test tests/provider-capacity.test.ts` — 14 passed, 0 failed.
- `PATH=/Users/terrytan/.nvm/versions/node/v24.3.0/bin:$PATH bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `PATH=/Users/terrytan/.nvm/versions/node/v24.3.0/bin:$PATH bun run test` — 10,813 passed, 7 skipped, 0 failed.
- `git diff --check` — passed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. Existing unknown-plan documentation remains accurate; no documentation change is needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for Team plan accounts in capacity weighting.
  * Team and Business plans now use the same configured capacity weighting.

* **Bug Fixes**
  * Improved handling of unsupported or future plan types during capacity aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
