### PR TITLE
fix(windows): preserve ARM64 ACL identity lookup

### DIFF
--- a/src/lib/windows-user-principal.ts
+++ b/src/lib/windows-user-principal.ts
@@ -20,11 +20,67 @@
  * would mean passing an absolute deadline through the runner interface.
  */
 
+import { existsSync } from "node:fs";
+import { win32 as windowsPath } from "node:path";
+
 import { resolveTrustedWindowsPowerShellExe } from "./windows-elevation";
 
 const SID_PATTERN = /^S-1-(?:\d+-)+\d+$/i;
 const SID_EXPRESSION =
   "[System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value";
+const DEFAULT_WINDOWS_ARM64_POWERSHELL = windowsPath.join(
+  "C:\\Windows\\System32",
+  "WindowsPowerShell",
+  "v1.0",
+  "powershell.exe",
+);
+
+type PrincipalExecutableResolution = Readonly<{
+  platform: NodeJS.Platform;
+  arch: string;
+  resolveTrusted: () => string;
+  pathExists: (path: string) => boolean;
+}>;
+
+/**
+ * Bun's Windows ARM64 build cannot currently execute the `bun:ffi` call used
+ * by the general System32 resolver. The ACL identity lookup has a narrower
+ * authority than the elevation helpers: it starts one non-elevated PowerShell
+ * command and accepts only a SID-shaped result. Keep its fallback equally
+ * narrow by using the fixed, OS-protected default installation path only.
+ *
+ * Environment and PATH lookup are deliberately absent. A Windows installation
+ * outside C:\\Windows keeps failing closed rather than executing a binary chosen
+ * by caller-controlled `SystemRoot`, `WINDIR`, or `PATH` values.
+ */
+function resolveWindowsPrincipalPowerShellExecutable(
+  resolution: PrincipalExecutableResolution = {
+    platform: process.platform,
+    arch: process.arch,
+    resolveTrusted: resolveTrustedWindowsPowerShellExe,
+    pathExists: existsSync,
+  },
+): string {
+  try {
+    return resolution.resolveTrusted();
+  } catch (error) {
+    if (
+      resolution.platform !== "win32" ||
+      resolution.arch !== "arm64" ||
+      !resolution.pathExists(DEFAULT_WINDOWS_ARM64_POWERSHELL)
+    ) {
+      throw error;
+    }
+    return DEFAULT_WINDOWS_ARM64_POWERSHELL;
+  }
+}
+
+/** Test-only dependency-injected view of the Windows ARM64 executable boundary. */
+export function resolveWindowsPrincipalPowerShellExecutableForTests(
+  resolution: PrincipalExecutableResolution,
+): string {
+  return resolveWindowsPrincipalPowerShellExecutable(resolution);
+}
 
 export interface WindowsPrincipalLookupResult {
   success: boolean;
@@ -52,7 +108,7 @@ const POWERSHELL_ARGS = [
 ] as const;
 
 function windowsPrincipalPowerShellCommand(): string[] {
-  return [resolveTrustedWindowsPowerShellExe(), ...POWERSHELL_ARGS];
+  return [resolveWindowsPrincipalPowerShellExecutable(), ...POWERSHELL_ARGS];
 }
 
 /** Test-only readback of the exact trusted executable and static arguments. */

--- a/structure/02_config-and-codex-home.md
+++ b/structure/02_config-and-codex-home.md
@@ -81,6 +81,22 @@ the recorded service ownership.
 sequence number) to avoid collisions when concurrent writers (e.g. `ocx stop` and the proxy's own
 shutdown handler) both restore Codex config simultaneously. The temp is renamed atomically into place.
 
+Windows secret-file hardening resolves the effective token SID through an absolute, trusted
+PowerShell path before granting the owner and removing inherited broad ACL entries. The normal
+path obtains System32 from `GetSystemDirectoryW`. Windows ARM64 Bun builds that cannot execute
+`bun:ffi` use a narrower ACL-only fallback to the fixed protected default installation path
+`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`. The fallback never applies to UAC or
+Task Scheduler launch, never consults environment variables or `PATH`, and fails closed when the
+fixed executable is absent.
+
+[Decision Log]
+- 목적과 의도: Preserve required Windows ACL hardening on the bundled Windows ARM64 runtime without weakening executable trust.
+- 기존 구현 및 제약 조건: The effective-SID query depended on the shared `GetSystemDirectoryW` FFI resolver; Bun 1.3.14 Windows ARM64 has no working `bun:ffi`, so config mutation reached `EACLIDENTITY` before PowerShell could start.
+- 검토한 주요 대안: Restore `USERDOMAIN\\USERNAME`; trust `SystemRoot`, `WINDIR`, or `PATH`; weaken required ACL writes; broaden the shared elevation resolver; or add a fixed-path fallback only for the non-elevated SID query.
+- 선택한 방식: Keep FFI authoritative, then allow only Windows ARM64 to use the existing default `C:\Windows\System32` PowerShell binary for the SID query when that exact file exists.
+- 다른 대안 대신 이 방식을 선택한 이유: Names and environment paths are caller-controlled, required secret writes must not silently skip ACLs, and elevation has a larger authority boundary that should remain FFI-only.
+- 장점, 단점 및 영향: Default Windows ARM64 installations can start and harden secrets; non-default Windows roots continue to fail closed until Bun exposes a trustworthy native system-directory API without FFI.
+
 Response-state loading performs a bounded recovery pass for interrupted snapshot writes. It only
 matches regular files named `responses-state.json.ocx.<pid>.<sequence>.tmp`, waits at least 15
 minutes, and skips the current or any live PID. Eligible files are truncated before unlinking so a

--- a/tests/windows-user-principal.test.ts
+++ b/tests/windows-user-principal.test.ts
@@ -4,6 +4,7 @@ import {
   resetWindowsPrincipalForTests,
   resolveCurrentWindowsPrincipal,
   resolveCurrentWindowsPrincipalAsync,
+  resolveWindowsPrincipalPowerShellExecutableForTests,
   setAsyncWindowsPrincipalRunnerForTests,
   setWindowsPrincipalRunnerForTests,
   windowsPrincipalPowerShellCommandForTests,
@@ -38,6 +39,67 @@ describe("Windows effective ACL principal", () => {
       "-Command",
       "[System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value",
     ]);
+  });
+
+  test("Windows ARM64 uses only the fixed default PowerShell path when FFI resolution is unavailable", () => {
+    const lookupError = new Error("bun:ffi unavailable");
+    const previousSystemRoot = process.env.SystemRoot;
+    const previousWindir = process.env.WINDIR;
+    const previousPath = process.env.PATH;
+    process.env.SystemRoot = "C:\\attacker-controlled";
+    process.env.WINDIR = "D:\\attacker-controlled";
+    process.env.PATH = "E:\\attacker-controlled";
+    try {
+      let observedPath = "";
+      const resolved = resolveWindowsPrincipalPowerShellExecutableForTests({
+        platform: "win32",
+        arch: "arm64",
+        resolveTrusted: () => { throw lookupError; },
+        pathExists: path => {
+          observedPath = path;
+          return true;
+        },
+      });
+      expect(observedPath).toBe("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe");
+      expect(resolved).toBe(observedPath);
+      expect(resolved).not.toContain("attacker-controlled");
+    } finally {
+      if (previousSystemRoot === undefined) delete process.env.SystemRoot;
+      else process.env.SystemRoot = previousSystemRoot;
+      if (previousWindir === undefined) delete process.env.WINDIR;
+      else process.env.WINDIR = previousWindir;
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+    }
+  });
+
+  test("the ARM64 fallback never broadens to x64, non-Windows, or a missing fixed executable", () => {
+    const lookupError = new Error("trusted resolver failed");
+    const resolve = (platform: NodeJS.Platform, arch: string, present: boolean) =>
+      resolveWindowsPrincipalPowerShellExecutableForTests({
+        platform,
+        arch,
+        resolveTrusted: () => { throw lookupError; },
+        pathExists: () => present,
+      });
+
+    expect(() => resolve("win32", "x64", true)).toThrow(lookupError);
+    expect(() => resolve("linux", "arm64", true)).toThrow(lookupError);
+    expect(() => resolve("win32", "arm64", false)).toThrow(lookupError);
+  });
+
+  test("a successful trusted resolver always wins without probing the ARM64 fallback", () => {
+    let fallbackProbes = 0;
+    expect(resolveWindowsPrincipalPowerShellExecutableForTests({
+      platform: "win32",
+      arch: "arm64",
+      resolveTrusted: () => "D:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+      pathExists: () => {
+        fallbackProbes += 1;
+        return true;
+      },
+    })).toBe("D:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe");
+    expect(fallbackProbes).toBe(0);
   });
 
   test("the default trusted runner resolves the real token on Windows", () => {


### PR DESCRIPTION
## Summary

- Preserve required secret-file ACL hardening on Windows ARM64 when Bun 1.3.14 cannot load the `bun:ffi` System32 resolver.
- Keep `GetSystemDirectoryW` authoritative on supported runtimes, then permit only the non-elevated SID lookup on `win32/arm64` to use the fixed protected default PowerShell path when that exact file exists.
- Keep environment-derived paths and account names outside the trust boundary, leave UAC and Task Scheduler resolution unchanged, and fail closed for non-default Windows roots.
- Add regression coverage for the ARM64 selection boundary, hostile environment values, unsupported platforms/architectures, missing files, and primary-resolver precedence.
- Document the decision and tradeoff in the config/Codex-home architecture note.

Root cause: the effective-SID query resolved PowerShell through `GetSystemDirectoryW` via `bun:ffi`. Bun 1.3.14 on Windows ARM64 cannot provide that FFI call, so the required ACL path surfaced `EACLIDENTITY` before PowerShell started.

Closes #1449

## Verification

- `taskset -c 0,1 nice -n 10 bun test tests/windows-user-principal.test.ts tests/windows-secret-acl.test.ts tests/windows-elevation.test.ts tests/windows-elevation-spawn.test.ts tests/windows-popup-fix.test.ts` — 238 pass, 0 fail on exact PR head.
- `taskset -c 0,1 nice -n 10 bun run typecheck` — passed on exact PR head.
- `taskset -c 0,1 nice -n 10 bun run privacy:scan` — passed on exact PR head.
- `git diff --check` — passed.
- The first CPU-limited full-suite run completed with 10,778 pass, 10 skip, and 9 unrelated failures/errors. Six occurred before the GUI dependency install step; the two reported image/bridge failures passed when rerun in isolation. The remaining `codex-shim` failure reproduces in an untouched test path because the fixture reads the process runtime token instead of `local-secret`; neither its implementation nor test differs from `dev` in this PR.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.
