### PR TITLE
fix(config): rebase stale live saves

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -2717,6 +2717,12 @@ export function websocketsEnabled(config: Pick<OcxConfig, "websockets">): boolea
  * against, or a later stale save would masquerade as "our own change".
  */
 const claudeCodeBaseline = new WeakMap<OcxConfig, unknown>();
+/**
+ * Full live-config baseline used to rebase unrelated cooperating writes. The
+ * Claude subtree and the bound listener fields remain on their dedicated
+ * reconciliation paths below.
+ */
+const liveConfigBaseline = new WeakMap<OcxConfig, OcxConfig>();
 
 /**
  * The live config retains the address of the socket Bun actually opened, while
@@ -2734,6 +2740,7 @@ const persistedLiveServerBinding = new WeakMap<OcxConfig, PersistedServerBinding
  * save, which is the case the guard exists for.
  */
 export function armClaudeCodeBaseline(config: OcxConfig): void {
+  liveConfigBaseline.set(config, structuredClone(config));
   claudeCodeBaseline.set(config, structuredClone(config.claudeCode));
 }
 
@@ -2781,6 +2788,54 @@ function cloneConfigValue(value: ConfigMergeValue): ConfigMergeValue {
   return value === MISSING_CONFIG_VALUE ? value : structuredClone(value);
 }
 
+type IndexedCustomModels = {
+  order: string[];
+  byId: Map<string, Record<string, unknown>>;
+};
+
+function indexCustomModels(value: ConfigMergeValue): IndexedCustomModels | null {
+  if (!Array.isArray(value)) return null;
+  const order: string[] = [];
+  const byId = new Map<string, Record<string, unknown>>();
+  for (const item of value) {
+    if (!isPlainConfigRecord(item) || typeof item.id !== "string" || item.id.length === 0 || byId.has(item.id)) {
+      return null;
+    }
+    order.push(item.id);
+    byId.set(item.id, item);
+  }
+  return { order, byId };
+}
+
+/**
+ * Merge custom-model rows by their stable id instead of treating the array as
+ * one opaque value. A row changed only on disk is adopted, a row changed only
+ * in the live config is retained, and disjoint edits to the same row recurse
+ * through the normal three-way object merge.
+ */
+function reconcileCustomModels(
+  baseline: ConfigMergeValue,
+  live: ConfigMergeValue,
+  persisted: ConfigMergeValue,
+): ConfigMergeValue | null {
+  const baselineRows = indexCustomModels(baseline);
+  const liveRows = indexCustomModels(live);
+  const persistedRows = indexCustomModels(persisted);
+  if (!baselineRows || !liveRows || !persistedRows) return null;
+
+  const order = [...liveRows.order, ...persistedRows.order.filter(id => !liveRows.byId.has(id))];
+  const merged: Array<Record<string, unknown>> = [];
+  for (const id of order) {
+    const row = reconcileConfigValue(
+      baselineRows.byId.get(id) ?? MISSING_CONFIG_VALUE,
+      liveRows.byId.get(id) ?? MISSING_CONFIG_VALUE,
+      persistedRows.byId.get(id) ?? MISSING_CONFIG_VALUE,
+    );
+    if (row !== MISSING_CONFIG_VALUE) merged.push(row as Record<string, unknown>);
+  }
+  return merged;
+}
+
 function reconcileConfigRecord(
   live: Record<string, unknown>,
   baseline: Record<string, unknown>,
@@ -2790,11 +2845,13 @@ function reconcileConfigRecord(
   const keys = new Set([...Object.keys(baseline), ...Object.keys(live), ...Object.keys(persisted)]);
   for (const key of keys) {
     if (skippedKeys?.has(key)) continue;
-    const merged = reconcileConfigValue(
-      ownConfigValue(baseline, key),
-      ownConfigValue(live, key),
-      ownConfigValue(persisted, key),
-    );
+    const baselineValue = ownConfigValue(baseline, key);
+    const liveValue = ownConfigValue(live, key);
+    const persistedValue = ownConfigValue(persisted, key);
+    const merged = key === "customModels"
+      ? reconcileCustomModels(baselineValue, liveValue, persistedValue)
+        ?? reconcileConfigValue(baselineValue, liveValue, persistedValue)
+      : reconcileConfigValue(baselineValue, liveValue, persistedValue);
     if (merged === MISSING_CONFIG_VALUE) delete live[key];
     else live[key] = merged;
   }
@@ -2920,13 +2977,12 @@ function readPersistedServerBinding(
  *
  * Conflict policy, chosen deliberately:
  * - disk changed, we did not → their hand edit wins;
- * - disk changed AND we changed → our change wins and the baseline rebases, so the
- *   user's next edit starts from the new value (a three-way merge is out of scope);
+ * - disk changed AND we changed → disjoint fields are merged, while a same-leaf
+ *   conflict keeps the live value;
  * - file missing/unreadable → save what we have, no throw.
  *
- * Scope residual: only `claudeCode` is reconciled. A hand edit to `providers` is still
- * clobbered — recorded and asserted in tests so it cannot drift into an assumed
- * guarantee.
+ * Custom-model rows are merged by their stable `id`, preserving independent
+ * edits and deletions across stale whole-config saves.
  */
 export function saveConfigPreservingClaudeCode(config: OcxConfig): void {
   withConfigMutationLockSync(() => {
@@ -2934,6 +2990,18 @@ export function saveConfigPreservingClaudeCode(config: OcxConfig): void {
     // One authoritative pre-write read feeds both the live-config reconciliation and
     // custom-model deletion migration. A second read could observe different bytes.
     const onDisk = readRawConfigJson();
+    const baseline = liveConfigBaseline.get(config);
+    if (baseline && onDisk !== undefined) {
+      const persistedDiagnostics = configDiagnosticsFromRaw(JSON.stringify(onDisk));
+      if (persistedDiagnostics.source === "file") {
+        reconcileConfigRecord(
+          config as unknown as Record<string, unknown>,
+          baseline as unknown as Record<string, unknown>,
+          persistedDiagnostics.config as unknown as Record<string, unknown>,
+          new Set(["hostname", "port", "claudeCode"]),
+        );
+      }
+    }
     if (claudeCodeBaseline.has(config)) {
       if (onDisk !== undefined) {
         const baseline = claudeCodeBaseline.get(config);
@@ -2964,6 +3032,9 @@ export function saveConfigPreservingClaudeCode(config: OcxConfig): void {
     adoptCustomModelCatalogMigration(config, projectedConfig);
     if (claudeCodeBaseline.has(config)) {
       claudeCodeBaseline.set(config, structuredClone(config.claudeCode));
+    }
+    if (liveConfigBaseline.has(config)) {
+      liveConfigBaseline.set(config, structuredClone(config));
     }
   });
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -2041,6 +2041,10 @@ export function loadConfig(): OcxConfig {
 /** Refresh the user cost-overlay registry from `config` and return it unchanged. */
 function withRefreshedCostOverlays(config: OcxConfig): OcxConfig {
   refreshUserCostOverlays(config);
+  // Every config loaded from a real or default snapshot carries provenance into
+  // the common whole-document write boundary. This covers CLI, management, and
+  // embedded callers without relying on server startup to arm one special path.
+  rememberConfigWriteBaseline(config);
   return config;
 }
 
@@ -2597,14 +2601,38 @@ function persistConfigUnlocked(config: OcxConfig): boolean {
   return true;
 }
 
+function persistWholeConfigDocument(config: OcxConfig): void {
+  const onDisk = readRawConfigJson();
+  const projected = projectCustomModelCatalogMigration(onDisk, config);
+  if (persistConfigUnlocked(projected)) bumpGenerationForCooperatingConfigWrite();
+  adoptCustomModelCatalogMigration(config, projected);
+}
+
+/**
+ * Persist a startup migration before the live server baseline is armed.
+ * Startup-only changes run before requests can arrive and intentionally retain
+ * the historical replace-document semantics; the guarded writers below cover
+ * every later live-config mutation.
+ */
+export function saveConfigDuringStartup(config: OcxConfig): void {
+  assertNotRealHomeUnderTest(getConfigDir());
+  withConfigMutationLockSync(() => {
+    const hadBaseline = liveConfigBaseline.has(config);
+    persistWholeConfigDocument(config);
+    if (hadBaseline) rememberConfigWriteBaseline(config);
+  });
+}
+
 /** Persist `config` to config.json under the config-mutation lock. */
 export function saveConfig(config: OcxConfig): void {
   // Keep the real-home assertion ahead of even lock-directory preparation.
   assertNotRealHomeUnderTest(getConfigDir());
   withConfigMutationLockSync(() => {
-    const projected = projectCustomModelCatalogMigration(readRawConfigJson(), config);
-    if (persistConfigUnlocked(projected)) bumpGenerationForCooperatingConfigWrite();
-    adoptCustomModelCatalogMigration(config, projected);
+    const hadBaseline = liveConfigBaseline.has(config);
+    const onDisk = readRawConfigJson();
+    reconcileLoadedConfigBeforeWrite(config, onDisk);
+    persistWholeConfigDocument(config);
+    if (hadBaseline) rememberConfigWriteBaseline(config);
   });
 }
 
@@ -2735,13 +2763,17 @@ type PersistedServerBinding = Pick<OcxConfig, "port" | "hostname">;
 const persistedLiveServerBinding = new WeakMap<OcxConfig, PersistedServerBinding>();
 
 /**
- * Arm the baseline for a long-lived config. MANDATORY at `startServer`, not lazy on
- * first save — arming lazily would lose exactly the hand edit made before that first
- * save, which is the case the guard exists for.
+ * Refresh the live-server baseline after startup-only migrations. `loadConfig()` already
+ * records provenance for every ordinary writer; this explicit arm keeps the long-lived
+ * server baseline scoped to the post-migration snapshot before requests can arrive.
  */
 export function armClaudeCodeBaseline(config: OcxConfig): void {
   liveConfigBaseline.set(config, structuredClone(config));
   claudeCodeBaseline.set(config, structuredClone(config.claudeCode));
+}
+
+function rememberConfigWriteBaseline(config: OcxConfig): void {
+  liveConfigBaseline.set(config, structuredClone(config));
 }
 
 /** Test seam only: is this instance armed? */
@@ -2773,6 +2805,22 @@ function deepEqual(a: unknown, b: unknown): boolean {
 
 const MISSING_CONFIG_VALUE = Symbol("missing-config-value");
 type ConfigMergeValue = unknown | typeof MISSING_CONFIG_VALUE;
+
+/**
+ * A loaded config was changed after another writer committed a different value.
+ * Whole-document persistence cannot safely choose a winner for this case, so
+ * the write is rejected before the atomic rename and the caller can retry from
+ * a fresh snapshot.
+ */
+export class ConfigWriteConflictError extends Error {
+  readonly code = "CONFIG_WRITE_CONFLICT";
+
+  constructor(readonly paths: readonly string[]) {
+    const location = paths.length > 0 ? paths.join(", ") : "config.json";
+    super(`config.json changed concurrently at ${location}; refusing to overwrite the newer disk state`);
+    this.name = "ConfigWriteConflictError";
+  }
+}
 
 function isPlainConfigRecord(value: ConfigMergeValue): value is Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
@@ -2817,7 +2865,8 @@ function reconcileCustomModels(
   baseline: ConfigMergeValue,
   live: ConfigMergeValue,
   persisted: ConfigMergeValue,
-): ConfigMergeValue | null {
+  path: string,
+): ConfigMergeResult | null {
   const baselineRows = indexCustomModels(baseline);
   const liveRows = indexCustomModels(live);
   const persistedRows = indexCustomModels(persisted);
@@ -2825,15 +2874,129 @@ function reconcileCustomModels(
 
   const order = [...liveRows.order, ...persistedRows.order.filter(id => !liveRows.byId.has(id))];
   const merged: Array<Record<string, unknown>> = [];
+  const conflicts: string[] = [];
   for (const id of order) {
-    const row = reconcileConfigValue(
+    const row = mergeConfigValue(
       baselineRows.byId.get(id) ?? MISSING_CONFIG_VALUE,
       liveRows.byId.get(id) ?? MISSING_CONFIG_VALUE,
       persistedRows.byId.get(id) ?? MISSING_CONFIG_VALUE,
+      path,
     );
-    if (row !== MISSING_CONFIG_VALUE) merged.push(row as Record<string, unknown>);
+    if (row.value !== MISSING_CONFIG_VALUE) merged.push(row.value as Record<string, unknown>);
+    conflicts.push(...row.conflicts);
   }
-  return merged;
+  return { value: merged, conflicts };
+}
+
+type ConfigMergeResult = {
+  value: ConfigMergeValue;
+  conflicts: string[];
+};
+
+function configPath(parent: string, key: string): string {
+  return parent.length > 0 ? `${parent}.${key}` : key;
+}
+
+function mergeConfigRecord(
+  baseline: Record<string, unknown>,
+  live: Record<string, unknown>,
+  persisted: Record<string, unknown>,
+  skippedKeys?: ReadonlySet<string>,
+  path = "",
+): ConfigMergeResult {
+  const keys = new Set([...Object.keys(baseline), ...Object.keys(live), ...Object.keys(persisted)]);
+  const merged: Record<string, unknown> = {};
+  const conflicts: string[] = [];
+  for (const key of keys) {
+    if (skippedKeys?.has(key)) {
+      const liveValue = ownConfigValue(live, key);
+      if (liveValue !== MISSING_CONFIG_VALUE) merged[key] = cloneConfigValue(liveValue);
+      continue;
+    }
+    const baselineValue = ownConfigValue(baseline, key);
+    const liveValue = ownConfigValue(live, key);
+    const persistedValue = ownConfigValue(persisted, key);
+    const result = key === "customModels"
+      ? reconcileCustomModels(baselineValue, liveValue, persistedValue, configPath(path, key))
+        ?? mergeConfigValue(baselineValue, liveValue, persistedValue, configPath(path, key))
+      : mergeConfigValue(baselineValue, liveValue, persistedValue, configPath(path, key));
+    if (result.value !== MISSING_CONFIG_VALUE) merged[key] = result.value;
+    conflicts.push(...result.conflicts);
+  }
+  return { value: merged, conflicts };
+}
+
+function mergeConfigValue(
+  baseline: ConfigMergeValue,
+  live: ConfigMergeValue,
+  persisted: ConfigMergeValue,
+  path: string,
+): ConfigMergeResult {
+  const liveChanged = !deepEqual(live, baseline);
+  const persistedChanged = !deepEqual(persisted, baseline);
+
+  if (!liveChanged) {
+    if (isPlainConfigRecord(live) && isPlainConfigRecord(persisted)) {
+      return mergeConfigRecord(
+        isPlainConfigRecord(baseline) ? baseline : {},
+        live,
+        persisted,
+        undefined,
+        path,
+      );
+    }
+    return { value: cloneConfigValue(persisted), conflicts: [] };
+  }
+
+  if (!persistedChanged) return { value: cloneConfigValue(live), conflicts: [] };
+
+  // Both writers reached the same value, so there is no ambiguity even though
+  // both values differ from the baseline.
+  if (deepEqual(live, persisted)) return { value: cloneConfigValue(live), conflicts: [] };
+
+  if (isPlainConfigRecord(live)
+    && isPlainConfigRecord(persisted)
+    && (baseline === MISSING_CONFIG_VALUE || isPlainConfigRecord(baseline))) {
+    return mergeConfigRecord(
+      isPlainConfigRecord(baseline) ? baseline : {},
+      live,
+      persisted,
+      undefined,
+      path,
+    );
+  }
+
+  // A deletion versus an edit, scalar disagreement, or opaque-array
+  // disagreement has no safe automatic winner. Keep the pending live value in
+  // the result for OAuth reconciliation, while guarded saves reject it before
+  // applying the result or touching disk.
+  return { value: cloneConfigValue(live), conflicts: [path || "config.json"] };
+}
+
+function applyMergedConfigValue(target: Record<string, unknown>, key: string, value: ConfigMergeValue): void {
+  if (value === MISSING_CONFIG_VALUE) {
+    delete target[key];
+    return;
+  }
+  const current = target[key];
+  if (isPlainConfigRecord(current) && isPlainConfigRecord(value)) {
+    applyMergedConfigRecord(current, value);
+    return;
+  }
+  if (Array.isArray(current) && Array.isArray(value)) {
+    current.splice(0, current.length, ...structuredClone(value));
+    return;
+  }
+  target[key] = structuredClone(value);
+}
+
+function applyMergedConfigRecord(target: Record<string, unknown>, merged: Record<string, unknown>): void {
+  for (const key of Object.keys(target)) {
+    if (!Object.hasOwn(merged, key)) delete target[key];
+  }
+  for (const [key, value] of Object.entries(merged)) {
+    applyMergedConfigValue(target, key, value);
+  }
 }
 
 function reconcileConfigRecord(
@@ -2841,60 +3004,12 @@ function reconcileConfigRecord(
   baseline: Record<string, unknown>,
   persisted: Record<string, unknown>,
   skippedKeys?: ReadonlySet<string>,
-): void {
-  const keys = new Set([...Object.keys(baseline), ...Object.keys(live), ...Object.keys(persisted)]);
-  for (const key of keys) {
-    if (skippedKeys?.has(key)) continue;
-    const baselineValue = ownConfigValue(baseline, key);
-    const liveValue = ownConfigValue(live, key);
-    const persistedValue = ownConfigValue(persisted, key);
-    const merged = key === "customModels"
-      ? reconcileCustomModels(baselineValue, liveValue, persistedValue)
-        ?? reconcileConfigValue(baselineValue, liveValue, persistedValue)
-      : reconcileConfigValue(baselineValue, liveValue, persistedValue);
-    if (merged === MISSING_CONFIG_VALUE) delete live[key];
-    else live[key] = merged;
-  }
+): string[] {
+  const result = mergeConfigRecord(baseline, live, persisted, skippedKeys);
+  applyMergedConfigRecord(live, result.value as Record<string, unknown>);
+  return result.conflicts;
 }
 
-function reconcileConfigValue(
-  baseline: ConfigMergeValue,
-  live: ConfigMergeValue,
-  persisted: ConfigMergeValue,
-): ConfigMergeValue {
-  const liveChanged = !deepEqual(live, baseline);
-  const persistedChanged = !deepEqual(persisted, baseline);
-
-  if (!liveChanged) {
-    if (live !== MISSING_CONFIG_VALUE && Array.isArray(live) && Array.isArray(persisted)) {
-      live.splice(0, live.length, ...structuredClone(persisted));
-      return live;
-    }
-    if (isPlainConfigRecord(live) && isPlainConfigRecord(persisted)) {
-      reconcileConfigRecord(
-        live,
-        isPlainConfigRecord(baseline) ? baseline : {},
-        persisted,
-      );
-      return live;
-    }
-    return cloneConfigValue(persisted);
-  }
-
-  if (!persistedChanged) return live;
-
-  if (isPlainConfigRecord(live)
-    && isPlainConfigRecord(persisted)
-    && (baseline === MISSING_CONFIG_VALUE || isPlainConfigRecord(baseline))) {
-    reconcileConfigRecord(
-      live,
-      isPlainConfigRecord(baseline) ? baseline : {},
-      persisted,
-    );
-  }
-  // Same-leaf conflicts prefer the pending live management mutation.
-  return live;
-}
 
 /**
  * Reconcile an async OAuth disk commit into the shared live config without erasing
@@ -2928,6 +3043,11 @@ export function reconcileLiveConfigFromDisk(config: OcxConfig, persistedBaseline
     if (persisted.claudeCode === undefined) delete config.claudeCode;
     else config.claudeCode = structuredClone(persisted.claudeCode);
     claudeCodeBaseline.set(config, structuredClone(config.claudeCode));
+    const writeBaseline = liveConfigBaseline.get(config);
+    if (writeBaseline) {
+      if (persisted.claudeCode === undefined) delete writeBaseline.claudeCode;
+      else writeBaseline.claudeCode = structuredClone(persisted.claudeCode);
+    }
   }
   // The reconciliation may have adopted a providers.<name>.modelCosts edit made
   // by a cooperating process while the OAuth login was pending; keep the overlay
@@ -2948,6 +3068,33 @@ function readRawConfigJson(): Record<string, unknown> | undefined {
     // Unreadable or corrupt: behave exactly as before. Never fail a save over protection.
     return undefined;
   }
+}
+
+/**
+ * Rebase a config loaded earlier onto the authoritative disk snapshot before
+ * any whole-document serializer projects migrations or provider overlays.
+ * Missing provenance is deliberate for callers that construct a config from
+ * scratch; those callers retain the historical replace-document behaviour.
+ */
+function reconcileLoadedConfigBeforeWrite(
+  config: OcxConfig,
+  onDisk: Record<string, unknown> | undefined,
+  skippedKeys?: ReadonlySet<string>,
+): void {
+  const baseline = liveConfigBaseline.get(config);
+  if (!baseline || onDisk === undefined) return;
+
+  const persistedDiagnostics = configDiagnosticsFromRaw(JSON.stringify(onDisk));
+  if (persistedDiagnostics.source !== "file") return;
+
+  const result = mergeConfigRecord(
+    baseline as unknown as Record<string, unknown>,
+    config as unknown as Record<string, unknown>,
+    persistedDiagnostics.config as unknown as Record<string, unknown>,
+    skippedKeys,
+  );
+  if (result.conflicts.length > 0) throw new ConfigWriteConflictError(result.conflicts);
+  applyMergedConfigRecord(config as unknown as Record<string, unknown>, result.value as Record<string, unknown>);
 }
 
 /**
@@ -2977,12 +3124,12 @@ function readPersistedServerBinding(
  *
  * Conflict policy, chosen deliberately:
  * - disk changed, we did not → their hand edit wins;
- * - disk changed AND we changed → disjoint fields are merged, while a same-leaf
- *   conflict keeps the live value;
+ * - disk changed AND we changed → disjoint fields are merged;
+ * - a same-leaf or delete/edit conflict throws before the disk write;
  * - file missing/unreadable → save what we have, no throw.
  *
- * Custom-model rows are merged by their stable `id`, preserving independent
- * edits and deletions across stale whole-config saves.
+ * Custom-model rows are merged by their stable `id`, preserving independent edits
+ * while rejecting delete/edit conflicts.
  */
 export function saveConfigPreservingClaudeCode(config: OcxConfig): void {
   withConfigMutationLockSync(() => {
@@ -2990,18 +3137,7 @@ export function saveConfigPreservingClaudeCode(config: OcxConfig): void {
     // One authoritative pre-write read feeds both the live-config reconciliation and
     // custom-model deletion migration. A second read could observe different bytes.
     const onDisk = readRawConfigJson();
-    const baseline = liveConfigBaseline.get(config);
-    if (baseline && onDisk !== undefined) {
-      const persistedDiagnostics = configDiagnosticsFromRaw(JSON.stringify(onDisk));
-      if (persistedDiagnostics.source === "file") {
-        reconcileConfigRecord(
-          config as unknown as Record<string, unknown>,
-          baseline as unknown as Record<string, unknown>,
-          persistedDiagnostics.config as unknown as Record<string, unknown>,
-          new Set(["hostname", "port", "claudeCode"]),
-        );
-      }
-    }
+    reconcileLoadedConfigBeforeWrite(config, onDisk, new Set(["hostname", "port"]));
     if (claudeCodeBaseline.has(config)) {
       if (onDisk !== undefined) {
         const baseline = claudeCodeBaseline.get(config);
@@ -3034,7 +3170,7 @@ export function saveConfigPreservingClaudeCode(config: OcxConfig): void {
       claudeCodeBaseline.set(config, structuredClone(config.claudeCode));
     }
     if (liveConfigBaseline.has(config)) {
-      liveConfigBaseline.set(config, structuredClone(config));
+      rememberConfigWriteBaseline(config);
     }
   });
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -15,7 +15,7 @@ import {
   applyProxyEnv,
   armClaudeCodeBaseline,
   loadConfig,
-  saveConfig,
+  saveConfigDuringStartup,
   websocketsEnabled,
 } from "../config";
 import { reconcileOAuthProviders } from "../oauth";
@@ -473,13 +473,13 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
   // even [], is left alone so GUI removals persist.
   if (config.subagentModels === undefined) {
     config.subagentModels = [...DEFAULT_SUBAGENT_MODELS];
-    saveConfig(config);
+    saveConfigDuringStartup(config);
   }
   // authMode migration (devlog 260726_claude_auth_auto/015): before "auto" existed,
   // choosing Subscription DELETED the key, so a pre-upgrade block with no authMode is
   // indistinguishable from "never chose". Pin those to subscription once so an upgrade
   // never silently moves a deliberate subscriber onto proxy.
-  if (runClaudeAuthModeMigration(config)) saveConfig(config);
+  if (runClaudeAuthModeMigration(config)) saveConfigDuringStartup(config);
   // Sidecar model migration (KST 2026-07-10 06:00 = UTC 2026-07-09 21:00): auto-migrate the old
   // gpt-5.4-mini default to gpt-5.6-luna for both search and vision sidecars. Only touches configs
   // still on the old default — explicit user choices are preserved.
@@ -495,7 +495,7 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
         config.visionSidecar = { ...config.visionSidecar, model: "gpt-5.6-luna" };
         migrated = true;
       }
-      if (migrated) saveConfig(config);
+      if (migrated) saveConfigDuringStartup(config);
     }
   }
   // Startup cache invalidation is best-effort and must never block the server from

--- a/structure/02_config-and-codex-home.md
+++ b/structure/02_config-and-codex-home.md
@@ -120,6 +120,17 @@ are consumed incrementally and at most 512 stale files are attempted per process
 
 ## Config surface
 
+[Decision Log]
+- Purpose and intent: Prevent a stale whole-config writer from resurrecting a provider, custom-model row, or another newer disk edit.
+- Existing implementation and constraints: `loadConfig()` returns a normalized snapshot, while CLI, management, request-path, and embedded writers may hold that object until a later save. The config mutation lock serializes cooperating writers but cannot identify a stale in-memory document by itself.
+- Baseline provenance: Every config returned by `loadConfig()` carries a private, per-object baseline. `armClaudeCodeBaseline()` refreshes that same baseline after startup-only migrations, before the server accepts requests. Config objects constructed from scratch have no provenance and retain replace-document semantics; they cannot claim that an omitted field was unchanged.
+- Recursive object semantics: A field changed only on disk is adopted; a field changed only in memory is retained; disjoint nested edits are merged. A same-leaf disagreement, or an edit on one side versus deletion on the other, is an explicit `CONFIG_WRITE_CONFLICT` and aborts before the atomic rename. An unreadable or malformed disk snapshot keeps the existing fail-open save behavior because there is no trustworthy merge input.
+- Stable-id array handling: `customModels` is treated as a keyed collection by `OcxCustomModel.id`, not by mutable provider/model slugs. Rows are merged recursively, independent row additions and edits survive, and a delete/edit collision is rejected. Array ordering follows live rows first, then disk-only rows; ordering alone is not a conflict.
+- Deletion and tombstones: A deletion with no competing edit is retained, including provider-map deletions and custom-model row deletions. There is no durable tombstone: the baseline plus the authoritative disk snapshot supplies the deletion evidence for one guarded write, and the successful save refreshes the baseline.
+- Covered writers: `saveConfig()` and `saveConfigPreservingClaudeCode()` share the rebase boundary, so loaded configs used by CLI, management, request-path, OAuth, routing, storage, and embedded callers receive the same protection. `mutatePersistedConfig()` remains field-scoped and independently revalidates its exact disk bytes. `saveConfigDuringStartup()` is the explicit pre-arm exception for startup migrations; scratch configs created without `loadConfig()` also retain replace-document semantics.
+- Chosen approach and alternatives: The common boundary was chosen over migrating every whole-document caller to field-scoped `mutatePersistedConfig()` because it closes the shared stale-document seam with one reviewable policy while preserving existing in-memory writer APIs. Field-scoped migrations remain preferable for new narrowly-owned mutations; the whole-document boundary rejects ambiguity rather than silently inventing ownership.
+- Benefits, drawbacks, and impact: Independent edits no longer disappear or resurrect deleted state, and ambiguous writes become visible retryable failures. A caller must reload after a conflict, and a caller that constructs a partial config without provenance still owns the replace-document risk.
+
 `src/types.ts` is the shape and `src/config.ts` is the loader; neither is reproduced here. What
 matters for maintainers is which groups exist and who resolves them:
 

--- a/tests/config-save-boundary.test.ts
+++ b/tests/config-save-boundary.test.ts
@@ -8,8 +8,8 @@ import { join } from "node:path";
  * config, so ONE bare call on a live config re-clobbers a hand-edited `claudeCode` and
  * silently undoes the guard.
  *
- * Startup migrations are the documented exception: they run before the server serves
- * requests, against a config nobody else holds.
+ * Startup migrations are the documented exception: they use the explicit startup saver
+ * before the server serves requests, against a config nobody else holds.
  */
 
 const SRC = join(import.meta.dir, "..", "src");
@@ -67,9 +67,9 @@ test("startServer arms the baseline before it can serve a request", () => {
   expect(start).toBeGreaterThan(-1);
   const armIndex = text.indexOf("armClaudeCodeBaseline(config)", start);
   expect(armIndex).toBeGreaterThan(-1);
-  // Every bare save inside startServer is a startup migration and must precede arming.
+  // Every startup-only save inside startServer is explicit and must precede arming.
   const body = text.slice(start, armIndex);
   const after = text.slice(armIndex, text.indexOf("\n}\n", armIndex));
-  expect(bareSaveConfigCalls(body).length).toBeGreaterThan(0);
+  expect(body.match(/(?<![A-Za-z])saveConfigDuringStartup\s*\(/g)?.length ?? 0).toBeGreaterThan(0);
   expect(bareSaveConfigCalls(after)).toEqual([]);
 });

--- a/tests/config-user-edits.test.ts
+++ b/tests/config-user-edits.test.ts
@@ -16,13 +16,16 @@ import {
 } from "../src/config";
 import { legacyCustomModelCatalogSlugs } from "../src/codex/custom-model-catalog-migration";
 import { rateLimitRetryPolicyFor } from "../src/providers/key-failover";
-import { activeUserCostOverlays, refreshUserCostOverlays } from "../src/usage/user-cost-overlays";
+import {
+  activeUserCostOverlays,
+  refreshUserCostOverlays,
+  resetPreservedDiskOnlyProvidersForTests,
+} from "../src/usage/user-cost-overlays";
 import type { OcxConfig } from "../src/types";
 
 /**
- * A user hand-edits `config.json` while the proxy runs. `saveConfig` serializes the
- * WHOLE object, so ANY later service-time save rewrites `claudeCode` from memory and
- * the edit vanishes with no visible cause (#488, devlog 260726_claude_auth_auto/040 H1).
+ * A user or cooperating process can edit config.json while the proxy runs.
+ * Guarded saves rebase disjoint live changes onto that newer disk snapshot.
  */
 
 let home: string;
@@ -618,16 +621,44 @@ test("an unarmed config saves without reconciliation", () => {
   expect((diskConfig().claudeCode as Record<string, unknown>).authMode).toBe("subscription");
 });
 
-// DOCUMENTED RESIDUAL, asserted so it cannot drift into an assumed guarantee: only the
-// `claudeCode` subtree is reconciled. A hand edit to `providers` is still lost.
-test("a providers hand edit is NOT preserved", () => {
+test("a provider deletion from a newer disk snapshot survives an unrelated live save", () => {
   const live = loadConfig();
+  live.providers.extra = {
+    adapter: "openai-chat",
+    baseUrl: "http://127.0.0.1:2/v1",
+    allowPrivateNetwork: true,
+  };
+  saveConfig(live);
   armClaudeCodeBaseline(live);
-  writeDiskConfig({ providers: { handEdited: { adapter: "openai-chat", baseUrl: "http://127.0.0.1:2/v1", allowPrivateNetwork: true } } });
+  resetPreservedDiskOnlyProvidersForTests();
+  writeDiskConfig({ providers: { test: live.providers.test } });
 
   live.port = 10103;
+  live.disabledModels = ["test/one"];
   saveConfigPreservingClaudeCode(live);
   expect(Object.keys(diskConfig().providers as Record<string, unknown>)).toEqual(["test"]);
+  expect(diskConfig().disabledModels).toEqual(["test/one"]);
+});
+
+test("independent custom-model edits survive a guarded stale save", () => {
+  const live = loadConfig();
+  live.customModels = [customModel("one"), customModel("two")];
+  saveConfig(live);
+  armClaudeCodeBaseline(live);
+
+  live.customModels![0]!.modelId = "live-one";
+  writeDiskConfig({
+    customModels: [
+      customModel("one"),
+      { ...customModel("two"), modelId: "disk-two" },
+    ],
+  });
+  saveConfigPreservingClaudeCode(live);
+
+  expect(diskConfig().customModels).toEqual([
+    { ...customModel("one"), modelId: "live-one" },
+    { ...customModel("two"), modelId: "disk-two" },
+  ]);
 });
 
 test("upstreamHostCircuitThreshold live writes accept only integer values from 0 through 20", () => {

--- a/tests/config-user-edits.test.ts
+++ b/tests/config-user-edits.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  ConfigWriteConflictError,
   armClaudeCodeBaseline,
   getConfigPath,
   getDefaultConfig,
@@ -504,21 +505,22 @@ test("a 429 key rotation does not clobber the hand edit", async () => {
   expect((diskConfig().claudeCode as Record<string, unknown>).authMode).toBe("proxy");
 });
 
-// Both sides changed: ours wins and the baseline rebases, so the NEXT edit starts fresh.
-test("our own change wins a conflict and rebases the baseline", () => {
+// Different leaves in the same object can merge: disk owns authMode, while the live
+// writer owns its independent systemEnv edit. A later hand edit starts from that merge.
+test("disjoint nested edits merge and rebase the baseline", () => {
   const live = loadConfig();
   armClaudeCodeBaseline(live);
   writeDiskConfig({ claudeCode: { authMode: "proxy" } });
   live.claudeCode = { authMode: "subscription", systemEnv: true };
 
   saveConfigPreservingClaudeCode(live);
-  expect((diskConfig().claudeCode as Record<string, unknown>).authMode).toBe("subscription");
+  expect(diskConfig().claudeCode).toEqual({ authMode: "proxy", systemEnv: true });
 
-  // Rebased: a fresh hand edit on top of OUR value is preserved by the next save.
-  writeDiskConfig({ claudeCode: { authMode: "proxy", systemEnv: true } });
+  // Rebased: a fresh hand edit on top of the merged value is preserved by the next save.
+  writeDiskConfig({ claudeCode: { authMode: "proxy", systemEnv: false } });
   live.port = 10102;
   saveConfigPreservingClaudeCode(live);
-  expect((diskConfig().claudeCode as Record<string, unknown>).authMode).toBe("proxy");
+  expect(diskConfig().claudeCode).toEqual({ authMode: "proxy", systemEnv: false });
 });
 
 test("OAuth reconciliation keeps a pending live Claude subtree authoritative", () => {
@@ -539,7 +541,7 @@ test("OAuth reconciliation keeps a pending live Claude subtree authoritative", (
   expect(live.contextCapValue).toBe(240_000);
 
   saveConfigPreservingClaudeCode(live);
-  expect(diskConfig().claudeCode).toEqual({ authMode: "subscription", systemEnv: true });
+  expect(diskConfig().claudeCode).toEqual({ authMode: "proxy", systemEnv: true });
   expect(diskConfig().disabledModels).toEqual(["pending/model"]);
   expect(diskConfig().contextCapValue).toBe(240_000);
 });
@@ -611,14 +613,48 @@ test("an unreadable config file never fails the save", () => {
   expect((diskConfig().claudeCode as Record<string, unknown>).authMode).toBe("proxy");
 });
 
-// An UNARMED config (a short-lived CLI load) behaves exactly like the old saveConfig.
-test("an unarmed config saves without reconciliation", () => {
+test("an independently loaded config rebases a non-server save", () => {
+  const stale = loadConfig();
+  const otherWriter = loadConfig();
+  otherWriter.disabledModels = ["disk/model"];
+  saveConfig(otherWriter);
+
+  stale.contextCapValue = 240_000;
+  saveConfig(stale);
+
+  expect(diskConfig().disabledModels).toEqual(["disk/model"]);
+  expect(diskConfig().contextCapValue).toBe(240_000);
+});
+
+test("a same-leaf edit conflict refuses to overwrite newer disk state", () => {
   const live = loadConfig();
   writeDiskConfig({ claudeCode: { authMode: "proxy" } });
 
-  live.claudeCode = { authMode: "subscription" };
-  saveConfigPreservingClaudeCode(live);
-  expect((diskConfig().claudeCode as Record<string, unknown>).authMode).toBe("subscription");
+  live.claudeCode = { authMode: "auto" };
+  expect(() => saveConfigPreservingClaudeCode(live)).toThrow(ConfigWriteConflictError);
+  expect((diskConfig().claudeCode as Record<string, unknown>).authMode).toBe("proxy");
+});
+
+test("a provider deletion versus live edit conflict refuses the stale save", () => {
+  const live = loadConfig();
+  const original = structuredClone(live.providers.test);
+  writeDiskConfig({ defaultProvider: "alt", providers: { alt: original } });
+  live.providers.test!.baseUrl = "http://127.0.0.1:2/v1";
+
+  expect(() => saveConfig(live)).toThrow(ConfigWriteConflictError);
+  expect(diskConfig().providers).toEqual({ alt: original });
+});
+
+test("a custom-model deletion versus live edit conflict refuses the stale save", () => {
+  const live = loadConfig();
+  live.customModels = [customModel("one"), customModel("two")];
+  saveConfig(live);
+
+  writeDiskConfig({ customModels: [customModel("one")] });
+  live.customModels![1]!.modelId = "edited-after-delete";
+
+  expect(() => saveConfig(live)).toThrow(ConfigWriteConflictError);
+  expect(diskConfig().customModels).toEqual([customModel("one")]);
 });
 
 test("a provider deletion from a newer disk snapshot survives an unrelated live save", () => {

--- a/tests/user-cost-overlay-provider-delete.test.ts
+++ b/tests/user-cost-overlay-provider-delete.test.ts
@@ -113,7 +113,7 @@ describe("provider deletion with disk-only preservation", () => {
     // Successful deletion converges every active owner so a third, older projection
     // that still had beta cannot recreate it on a later unrelated save.
     expect(liveConfigC.providers.beta).toBeUndefined();
-    liveConfigC.providers.acme!.models = ["model-x", "model-c"];
+    liveConfigC.disabledModels = ["acme/model-c"];
     saveConfig(liveConfigC);
     persisted = JSON.parse(readFileSync(getConfigPath(), "utf8")) as OcxConfig;
     expect(persisted.providers.beta).toBeUndefined();


### PR DESCRIPTION
## Summary

- Fixes the stale whole-config writer boundary for #1273.
- Records a private per-object baseline at `loadConfig()`, so CLI, management, request-path, OAuth, routing, storage, and embedded writers can rebase independently loaded snapshots.
- Merges disjoint nested fields recursively and merges `customModels` by stable `OcxCustomModel.id`; provider/custom-model delete-vs-edit and same-leaf conflicts fail visibly with `CONFIG_WRITE_CONFLICT` before the atomic write.
- Keeps startup migrations explicit through `saveConfigDuringStartup()` before the live baseline is armed.
- Closes #1273.

## Verification

- `bun test tests/config-user-edits.test.ts tests/config-save-boundary.test.ts tests/config-mutation-lock.test.ts tests/user-cost-overlay-provider-delete.test.ts tests/user-cost-overlay-live-reconcile.test.ts tests/oauth-public-surface.test.ts` — 67 passed.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `git diff --check` — passed.
- `bun run test` was started after the rebase but did not produce a final result within the bounded local run and was stopped; no full-suite-green claim is made. The key-login live-update test is also environment-dependent here because the Umans hostname resolves to a benchmark address and the existing route rejects it with HTTP 400.
- Added the architecture Decision Log to `structure/02_config-and-codex-home.md`; no GUI or user-facing docs change is required.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [ ] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.
- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->