### PR TITLE
fix(anthropic): forward structured output schemas

### DIFF
--- a/docs-site/src/content/docs/reference/adapters.md
+++ b/docs-site/src/content/docs/reference/adapters.md
@@ -80,13 +80,14 @@ of the HTTP retry loop.
   output headroom, and **drops `temperature`/`top_p`** when thinking is enabled (Anthropic forbids
   them there).
 - **Structured output:** Responses `text.format` and Chat Completions `response_format` requests
-  with `type: "json_schema"` become Anthropic `output_config.format`. The adapter mirrors the
-  Anthropic TypeScript SDK's supported JSON Schema subset: unsupported constraints are moved into
-  `description` as model guidance, `oneOf` becomes `anyOf`, and object schemas receive
-  `additionalProperties: false`. A root `$ref` retains its adjacent `$defs` so the local reference
-  remains resolvable. OpenAI envelope fields such as schema `name`, envelope `description`, and
-  `strict` are not part of the Anthropic wire format. JSON object mode without a schema has no
-  Anthropic equivalent and is not translated.
+  with `type: "json_schema"` become Anthropic `output_config.format`. The format merges into an
+  existing adaptive-thinking output configuration, preserving a compatible `output_config.effort`.
+  The adapter mirrors the Anthropic TypeScript SDK's supported JSON Schema subset: unsupported
+  constraints are moved into `description` as model guidance, `oneOf` becomes `anyOf`, and object
+  schemas receive `additionalProperties: false`. A root `$ref` retains its adjacent `$defs` so the
+  local reference remains resolvable. OpenAI envelope fields such as schema `name`, envelope
+  `description`, and `strict` are not part of the Anthropic wire format. JSON object mode without a
+  schema has no Anthropic equivalent and is not translated.
 - Always sends `anthropic-version: 2023-06-01`. Streams `content_block_delta` (`text_delta`,
   `thinking_delta`, compatible `reasoning_delta`, `input_json_delta`). The SSE decoder preserves
   event state across fetch chunks and accepts a terminal `message_stop` without a trailing newline.

--- a/docs-site/src/content/docs/reference/adapters.md
+++ b/docs-site/src/content/docs/reference/adapters.md
@@ -79,6 +79,14 @@ of the HTTP retry loop.
   maps reasoning effort to a budget (minimal 1024 … max 32000), then computes a safe `max_tokens` with
   output headroom, and **drops `temperature`/`top_p`** when thinking is enabled (Anthropic forbids
   them there).
+- **Structured output:** Responses `text.format` and Chat Completions `response_format` requests
+  with `type: "json_schema"` become Anthropic `output_config.format`. The adapter mirrors the
+  Anthropic TypeScript SDK's supported JSON Schema subset: unsupported constraints are moved into
+  `description` as model guidance, `oneOf` becomes `anyOf`, and object schemas receive
+  `additionalProperties: false`. A root `$ref` retains its adjacent `$defs` so the local reference
+  remains resolvable. OpenAI envelope fields such as schema `name`, envelope `description`, and
+  `strict` are not part of the Anthropic wire format. JSON object mode without a schema has no
+  Anthropic equivalent and is not translated.
 - Always sends `anthropic-version: 2023-06-01`. Streams `content_block_delta` (`text_delta`,
   `thinking_delta`, compatible `reasoning_delta`, `input_json_delta`). The SSE decoder preserves
   event state across fetch chunks and accepts a terminal `message_stop` without a trailing newline.

--- a/docs-site/src/content/docs/reference/adapters.md
+++ b/docs-site/src/content/docs/reference/adapters.md
@@ -82,6 +82,7 @@ of the HTTP retry loop.
 - **Structured output:** Responses `text.format` and Chat Completions `response_format` requests
   with `type: "json_schema"` become Anthropic `output_config.format`. The format merges into an
   existing adaptive-thinking output configuration, preserving a compatible `output_config.effort`.
+  Routed Anthropic Messages requests preserve the same format through stored-OAuth translation.
   The adapter mirrors the Anthropic TypeScript SDK's supported JSON Schema subset: unsupported
   constraints are moved into `description` as model guidance, `oneOf` becomes `anyOf`, and object
   schemas receive `additionalProperties: false`. A root `$ref` retains its adjacent `$defs` so the

--- a/src/adapters/anthropic-output-schema.ts
+++ b/src/adapters/anthropic-output-schema.ts
@@ -44,15 +44,18 @@ function normalizeSchema(schema: Record<string, unknown>): Record<string, unknow
   }
 
   const type = take(schema, "type");
-  const anyOf = take(schema, "anyOf");
-  const oneOf = take(schema, "oneOf");
-  const allOf = take(schema, "allOf");
+  const anyOf = schema.anyOf;
+  const oneOf = schema.oneOf;
+  const allOf = schema.allOf;
 
   if (Array.isArray(anyOf)) {
+    take(schema, "anyOf");
     normalized.anyOf = anyOf.map(normalizeSubschema);
   } else if (Array.isArray(oneOf)) {
+    take(schema, "oneOf");
     normalized.anyOf = oneOf.map(normalizeSubschema);
   } else if (Array.isArray(allOf)) {
+    take(schema, "allOf");
     normalized.allOf = allOf.map(normalizeSubschema);
   } else {
     if (type === undefined) {

--- a/src/adapters/anthropic-output-schema.ts
+++ b/src/adapters/anthropic-output-schema.ts
@@ -1,0 +1,119 @@
+const SUPPORTED_STRING_FORMATS = new Set([
+  "date-time",
+  "time",
+  "date",
+  "duration",
+  "email",
+  "hostname",
+  "uri",
+  "ipv4",
+  "ipv6",
+  "uuid",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function take(schema: Record<string, unknown>, key: string): unknown {
+  const value = schema[key];
+  delete schema[key];
+  return value;
+}
+
+function normalizeSubschema(value: unknown): unknown {
+  return isRecord(value) ? normalizeSchema(value) : value;
+}
+
+function normalizeSchema(schema: Record<string, unknown>): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {};
+
+  const ref = take(schema, "$ref");
+  if (ref !== undefined) {
+    return { $ref: ref };
+  }
+
+  const defs = take(schema, "$defs");
+  if (isRecord(defs)) {
+    normalized.$defs = Object.fromEntries(
+      Object.entries(defs).map(([name, definition]) => [name, normalizeSubschema(definition)]),
+    );
+  }
+
+  const type = take(schema, "type");
+  const anyOf = take(schema, "anyOf");
+  const oneOf = take(schema, "oneOf");
+  const allOf = take(schema, "allOf");
+
+  if (Array.isArray(anyOf)) {
+    normalized.anyOf = anyOf.map(normalizeSubschema);
+  } else if (Array.isArray(oneOf)) {
+    normalized.anyOf = oneOf.map(normalizeSubschema);
+  } else if (Array.isArray(allOf)) {
+    normalized.allOf = allOf.map(normalizeSubschema);
+  } else if (type !== undefined) {
+    normalized.type = type;
+  }
+
+  const description = take(schema, "description");
+  if (description !== undefined) {
+    normalized.description = description;
+  }
+
+  const title = take(schema, "title");
+  if (title !== undefined) {
+    normalized.title = title;
+  }
+
+  if (type === "object") {
+    const properties = take(schema, "properties");
+    normalized.properties = isRecord(properties)
+      ? Object.fromEntries(
+          Object.entries(properties).map(([name, property]) => [name, normalizeSubschema(property)]),
+        )
+      : {};
+    take(schema, "additionalProperties");
+    normalized.additionalProperties = false;
+
+    const required = take(schema, "required");
+    if (required !== undefined) {
+      normalized.required = required;
+    }
+  } else if (type === "string") {
+    const format = take(schema, "format");
+    if (typeof format === "string" && SUPPORTED_STRING_FORMATS.has(format)) {
+      normalized.format = format;
+    } else if (format !== undefined) {
+      schema.format = format;
+    }
+  } else if (type === "array") {
+    const items = take(schema, "items");
+    if (items !== undefined) {
+      normalized.items = normalizeSubschema(items);
+    }
+
+    const minItems = take(schema, "minItems");
+    if (minItems === 0 || minItems === 1) {
+      normalized.minItems = minItems;
+    } else if (minItems !== undefined) {
+      schema.minItems = minItems;
+    }
+  }
+
+  const unsupported = Object.entries(schema);
+  if (unsupported.length > 0) {
+    const existingDescription =
+      typeof normalized.description === "string" ? `${normalized.description}\n\n` : "";
+    normalized.description = `${existingDescription}{${unsupported
+      .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
+      .join(", ")}}`;
+  }
+
+  return normalized;
+}
+
+export function normalizeAnthropicOutputSchema(
+  schema: Record<string, unknown>,
+): Record<string, unknown> {
+  return normalizeSchema(structuredClone(schema));
+}

--- a/src/adapters/anthropic-output-schema.ts
+++ b/src/adapters/anthropic-output-schema.ts
@@ -126,3 +126,12 @@ export function normalizeAnthropicOutputSchema(
 ): Record<string, unknown> {
   return normalizeSchema(structuredClone(schema));
 }
+
+export function isAnthropicOutputSchema(schema: Record<string, unknown>): boolean {
+  try {
+    normalizeAnthropicOutputSchema(schema);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/adapters/anthropic-output-schema.ts
+++ b/src/adapters/anthropic-output-schema.ts
@@ -1,4 +1,4 @@
-// Mirrors Anthropic SDK's transformJSONSchema semantics with local unknown narrowing:
+// Based on Anthropic SDK's transformJSONSchema, preserving root $defs required by root $ref:
 // https://github.com/anthropics/anthropic-sdk-typescript/blob/main/src/lib/transform-json-schema.ts
 const SUPPORTED_STRING_FORMATS = new Set([
   "date-time",
@@ -30,16 +30,17 @@ function normalizeSubschema(value: unknown): unknown {
 function normalizeSchema(schema: Record<string, unknown>): Record<string, unknown> {
   const normalized: Record<string, unknown> = {};
 
-  const ref = take(schema, "$ref");
-  if (ref !== undefined) {
-    return { $ref: ref };
-  }
-
   const defs = take(schema, "$defs");
   if (isRecord(defs)) {
     normalized.$defs = Object.fromEntries(
       Object.entries(defs).map(([name, definition]) => [name, normalizeSubschema(definition)]),
     );
+  }
+
+  const ref = take(schema, "$ref");
+  if (ref !== undefined) {
+    normalized.$ref = ref;
+    return normalized;
   }
 
   const type = take(schema, "type");

--- a/src/adapters/anthropic-output-schema.ts
+++ b/src/adapters/anthropic-output-schema.ts
@@ -1,3 +1,5 @@
+// Mirrors Anthropic SDK's transformJSONSchema semantics with local unknown narrowing:
+// https://github.com/anthropics/anthropic-sdk-typescript/blob/main/src/lib/transform-json-schema.ts
 const SUPPORTED_STRING_FORMATS = new Set([
   "date-time",
   "time",
@@ -51,7 +53,10 @@ function normalizeSchema(schema: Record<string, unknown>): Record<string, unknow
     normalized.anyOf = oneOf.map(normalizeSubschema);
   } else if (Array.isArray(allOf)) {
     normalized.allOf = allOf.map(normalizeSubschema);
-  } else if (type !== undefined) {
+  } else {
+    if (type === undefined) {
+      throw new Error("JSON schema must have a type defined if anyOf/oneOf/allOf are not used");
+    }
     normalized.type = type;
   }
 

--- a/src/adapters/anthropic.ts
+++ b/src/adapters/anthropic.ts
@@ -18,6 +18,7 @@ import { ANTHROPIC_OAUTH_BETA, CLAUDE_CODE_SYSTEM_INSTRUCTION, applyClaudeToolPr
 import { parseDataUrl } from "./image";
 import { enforceAnthropicImageLimits } from "./anthropic-image-guard";
 import { normalizeAnthropicImages } from "./anthropic-image-normalize";
+import { normalizeAnthropicOutputSchema } from "./anthropic-output-schema";
 import { identifyRoutedModel } from "./identity";
 import { redactSecretString } from "../lib/redact";
 import { CLAUDE_CODE_HEADERS, claudeCodeSessionId } from "./client-fingerprint";
@@ -896,6 +897,20 @@ export function createAnthropicAdapter(provider: OcxProviderConfig, cacheRetenti
         // Extended thinking disallows temperature != 1 and top_p — drop both or the API 400s.
         delete body.temperature;
         delete body.top_p;
+      }
+
+      const textFormat = parsed.options.textFormat;
+      if (textFormat?.type === "json_schema" && textFormat.schema) {
+        const outputConfig = body.output_config;
+        body.output_config = {
+          ...(outputConfig && typeof outputConfig === "object" && !Array.isArray(outputConfig)
+            ? outputConfig
+            : {}),
+          format: {
+            type: "json_schema",
+            schema: normalizeAnthropicOutputSchema(textFormat.schema),
+          },
+        };
       }
 
       if (parsed.options.toolChoice && (tools || parsed.options.toolChoice === "none")) {

--- a/src/claude/inbound.ts
+++ b/src/claude/inbound.ts
@@ -78,7 +78,7 @@ function formatFromOutputConfig(outputConfig: unknown): Rec | undefined {
     || !isRec(format.schema)
     || !isAnthropicOutputSchema(format.schema)
   ) return undefined;
-  return { type: "json_schema", schema: format.schema };
+  return { type: "json_schema", name: "response", schema: format.schema };
 }
 
 function systemToInstructions(system: unknown): string | undefined {

--- a/src/claude/inbound.ts
+++ b/src/claude/inbound.ts
@@ -69,6 +69,13 @@ export function effortFromOutputConfig(outputConfig: unknown): string | undefine
   return typeof effort === "string" && OUTPUT_CONFIG_EFFORTS.has(effort) ? effort : undefined;
 }
 
+function formatFromOutputConfig(outputConfig: unknown): Rec | undefined {
+  if (!isRec(outputConfig) || !isRec(outputConfig.format)) return undefined;
+  const format = outputConfig.format;
+  if (format.type !== "json_schema" || !isRec(format.schema)) return undefined;
+  return { type: "json_schema", schema: format.schema };
+}
+
 function systemToInstructions(system: unknown): string | undefined {
   if (typeof system === "string") return system.length > 0 ? system : undefined;
   if (Array.isArray(system)) {
@@ -467,6 +474,8 @@ export function anthropicToResponsesTranslation(raw: unknown, cc?: OcxClaudeCode
   if (Array.isArray(raw.stop_sequences) && raw.stop_sequences.length > 0) {
     body.stop = raw.stop_sequences.filter((s): s is string => typeof s === "string");
   }
+  const outputConfigFormat = formatFromOutputConfig(raw.output_config);
+  if (outputConfigFormat) body.text = { format: outputConfigFormat };
   let cacheKeySource: ClaudeCacheKeySource = null;
   if (isRec(raw.metadata) && typeof raw.metadata.user_id === "string") {
     body.user = raw.metadata.user_id;

--- a/src/claude/inbound.ts
+++ b/src/claude/inbound.ts
@@ -10,6 +10,7 @@
  *  - top_k is accepted and silently dropped (no Responses equivalent, CCR parity).
  */
 import type { OcxClaudeCodeConfig } from "../types";
+import { isAnthropicOutputSchema } from "../adapters/anthropic-output-schema";
 import { resolveAlias } from "./alias";
 import { stripOneMillionMarker } from "./context-windows";
 import { resolveDesktop3pAlias } from "./desktop-3p";
@@ -72,7 +73,11 @@ export function effortFromOutputConfig(outputConfig: unknown): string | undefine
 function formatFromOutputConfig(outputConfig: unknown): Rec | undefined {
   if (!isRec(outputConfig) || !isRec(outputConfig.format)) return undefined;
   const format = outputConfig.format;
-  if (format.type !== "json_schema" || !isRec(format.schema)) return undefined;
+  if (
+    format.type !== "json_schema"
+    || !isRec(format.schema)
+    || !isAnthropicOutputSchema(format.schema)
+  ) return undefined;
   return { type: "json_schema", schema: format.schema };
 }
 

--- a/src/server/claude-messages.ts
+++ b/src/server/claude-messages.ts
@@ -605,7 +605,10 @@ async function handleClaudeMessagesWithBudget(
       return await anthropicNativePassthrough(req, config, logCtx, logIds, anthropicBody, "/v1/messages");
     }
     if (isRec(anthropicBody) && effortOverride) {
-      anthropicBody.output_config = { effort: effortOverride };
+      anthropicBody.output_config = {
+        ...(isRec(anthropicBody.output_config) ? anthropicBody.output_config : {}),
+        effort: effortOverride,
+      };
       delete anthropicBody.thinking;
     }
     const translation = anthropicToResponsesTranslation(anthropicBody, config.claudeCode);

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -589,6 +589,8 @@ family shared by unrelated upstreams.
 The Anthropic adapter lowers Responses `text.format` and Chat Completions `response_format` JSON
 Schema requests to `output_config.format`. The local transform follows Anthropic's TypeScript SDK
 subset so upstream rejects neither OpenAI-only envelope fields nor unsupported schema constraints.
+The adapter merges `format` into an existing adaptive-thinking `output_config` rather than replacing
+it, so a compatible `output_config.effort` remains alongside the structured-output format.
 Unsupported constraints remain in `description` as model guidance instead of disappearing. Root
 `$defs` stay beside a root `$ref`, intentionally differing from the current SDK transform's early
 `$ref` return so local references remain resolvable.
@@ -597,7 +599,7 @@ Unsupported constraints remain in `description` as model guidance instead of dis
 - 목적과 의도: Preserve schema-constrained output when OpenAI-shaped Responses or Chat Completions requests route to Anthropic Messages.
 - 기존 구현 및 제약 조건: The parser retained the requested schema, but the Anthropic adapter dropped it; forwarding the OpenAI schema unchanged fails when it includes constraints outside Anthropic's supported subset.
 - 검토한 주요 대안: Keep tool-call emulation; forward the raw schema; depend on the full Anthropic SDK; maintain a local compatibility transform based on the SDK.
-- 선택한 방식: Emit Anthropic `output_config.format`, mirror the SDK transform locally with strict `unknown` narrowing, move unsupported constraints into descriptions, and preserve root `$defs` before returning a root `$ref`.
+- 선택한 방식: Merge Anthropic `output_config.format` into compatible adaptive-thinking configuration, mirror the SDK transform locally with strict `unknown` narrowing, move unsupported constraints into descriptions, and preserve root `$defs` before returning a root `$ref`.
 - 다른 대안 대신 이 방식을 선택한 이유: Native structured output avoids synthetic tools, raw forwarding produces upstream 400s, and importing the full SDK only for a small wire transform would duplicate the adapter's direct HTTP ownership.
 - 장점, 단점 및 영향: Both OpenAI-shaped input surfaces gain native Anthropic schema enforcement and unsupported intent remains visible to the model; the copied subset must track upstream SDK changes, description-carried constraints are guidance rather than hard validation, and the root-reference fix is an intentional divergence to keep definitions reachable.
 

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -591,6 +591,8 @@ Schema requests to `output_config.format`. The local transform follows Anthropic
 subset so upstream rejects neither OpenAI-only envelope fields nor unsupported schema constraints.
 The adapter merges `format` into an existing adaptive-thinking `output_config` rather than replacing
 it, so a compatible `output_config.effort` remains alongside the structured-output format.
+Routed Anthropic Messages input carries `output_config.format` through internal `text.format`, so
+stored-OAuth requests regain the same native format when the Anthropic adapter rebuilds the wire body.
 Unsupported constraints remain in `description` as model guidance instead of disappearing. Root
 `$defs` stay beside a root `$ref`, intentionally differing from the current SDK transform's early
 `$ref` return so local references remain resolvable.

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -584,6 +584,23 @@ family shared by unrelated upstreams.
 - 다른 대안 대신 이 방식을 선택한 이유: Global or heuristic rules regress supported providers and make custom gateway names part of the wire contract.
 - 장점, 단점 및 영향: Compatible siblings retain schema enforcement and explicitly incompatible models avoid the upstream 400; operators must classify each unsupported model they route.
 
+## Anthropic structured-output compatibility
+
+The Anthropic adapter lowers Responses `text.format` and Chat Completions `response_format` JSON
+Schema requests to `output_config.format`. The local transform follows Anthropic's TypeScript SDK
+subset so upstream rejects neither OpenAI-only envelope fields nor unsupported schema constraints.
+Unsupported constraints remain in `description` as model guidance instead of disappearing. Root
+`$defs` stay beside a root `$ref`, intentionally differing from the current SDK transform's early
+`$ref` return so local references remain resolvable.
+
+[Decision Log]
+- 목적과 의도: Preserve schema-constrained output when OpenAI-shaped Responses or Chat Completions requests route to Anthropic Messages.
+- 기존 구현 및 제약 조건: The parser retained the requested schema, but the Anthropic adapter dropped it; forwarding the OpenAI schema unchanged fails when it includes constraints outside Anthropic's supported subset.
+- 검토한 주요 대안: Keep tool-call emulation; forward the raw schema; depend on the full Anthropic SDK; maintain a local compatibility transform based on the SDK.
+- 선택한 방식: Emit Anthropic `output_config.format`, mirror the SDK transform locally with strict `unknown` narrowing, move unsupported constraints into descriptions, and preserve root `$defs` before returning a root `$ref`.
+- 다른 대안 대신 이 방식을 선택한 이유: Native structured output avoids synthetic tools, raw forwarding produces upstream 400s, and importing the full SDK only for a small wire transform would duplicate the adapter's direct HTTP ownership.
+- 장점, 단점 및 영향: Both OpenAI-shaped input surfaces gain native Anthropic schema enforcement and unsupported intent remains visible to the model; the copied subset must track upstream SDK changes, description-carried constraints are guidance rather than hard validation, and the root-reference fix is an intentional divergence to keep definitions reachable.
+
 ## Reasoning display parity (hideThinkingSummary)
 
 `hideThinkingSummary` (request reasoning summary absent/"none" — the routed catalog default) is

--- a/tests/anthropic-reasoning.test.ts
+++ b/tests/anthropic-reasoning.test.ts
@@ -69,6 +69,55 @@ describe("anthropic extended-thinking gate", () => {
     expect(b.output_config).toEqual({ effort: "low" });
   });
 
+  test("forwards Responses JSON Schema output format to Anthropic", async () => {
+    const schema = {
+      type: "object",
+      properties: { score: { type: "integer", minimum: 1, maximum: 10 } },
+      required: ["score"],
+      additionalProperties: false,
+    };
+    const b = await bodyOf(parseRequest({
+      model: "claude-sonnet-5",
+      input: [{ role: "user", content: [{ type: "input_text", text: "score this" }] }],
+      text: { format: { type: "json_schema", name: "score", schema, strict: true } },
+    }));
+
+    expect(b.output_config).toEqual({
+      format: {
+        type: "json_schema",
+        schema: {
+          ...schema,
+          properties: {
+            score: {
+              type: "integer",
+              description: "{minimum: 1, maximum: 10}",
+            },
+          },
+        },
+      },
+    });
+  });
+
+  test("merges JSON Schema output format with adaptive thinking effort", async () => {
+    const schema = {
+      type: "object",
+      properties: { summary: { type: "string" } },
+      required: ["summary"],
+      additionalProperties: false,
+    };
+    const b = await bodyOf(parseRequest({
+      model: "claude-sonnet-5",
+      input: [{ role: "user", content: [{ type: "input_text", text: "summarize this" }] }],
+      reasoning: { effort: "high" },
+      text: { format: { type: "json_schema", name: "summary", schema, strict: true } },
+    }));
+
+    expect(b.output_config).toEqual({
+      effort: "high",
+      format: { type: "json_schema", schema },
+    });
+  });
+
   test("adaptive-thinking model resizes max_tokens for high effort (issue #246)", async () => {
     const b = await bodyOf(parsed("max", {}, "claude-fable-5"));
     // Exact regression: effort=max budget is 32000; adaptive ceiling adds OUTPUT_HEADROOM (8192)

--- a/tests/anthropic-reasoning.test.ts
+++ b/tests/anthropic-reasoning.test.ts
@@ -20,8 +20,8 @@ function parsed(reasoning?: string, extraOpts: Record<string, unknown> = {}, mod
   } as unknown as OcxParsedRequest;
 }
 
-async function bodyOf(p: OcxParsedRequest): Promise<Record<string, unknown>> {
-  const { body } = await createAnthropicAdapter(provider).buildRequest(p);
+async function bodyOf(p: OcxParsedRequest, configuredProvider = provider): Promise<Record<string, unknown>> {
+  const { body } = await createAnthropicAdapter(configuredProvider).buildRequest(p);
   return JSON.parse(typeof body === "string" ? body : JSON.stringify(body)) as Record<string, unknown>;
 }
 
@@ -374,6 +374,37 @@ describe("anthropic extended-thinking gate", () => {
     expect(JSON.stringify(messages)).not.toContain("rs_other_provider");
     expect(JSON.stringify(messages)).not.toContain("signature");
     expect(messages).toEqual([{ role: "user", content: "continue on anthropic" }]);
+  });
+});
+
+describe("Anthropic Messages stored-OAuth round trip", () => {
+  test("Messages structured output survives the stored OAuth round trip", async () => {
+    const schema = {
+      type: "object",
+      properties: { answer: { type: "string" } },
+      required: ["answer"],
+      additionalProperties: false,
+    };
+    const inbound = anthropicToResponsesBody({
+      model: "claude-sonnet-5",
+      max_tokens: 256,
+      messages: [{ role: "user", content: "Return JSON" }],
+      thinking: { type: "adaptive" },
+      output_config: {
+        effort: "high",
+        format: { type: "json_schema", schema },
+      },
+    });
+
+    const body = await bodyOf(parseRequest(inbound), {
+      ...provider,
+      authMode: "oauth",
+    });
+
+    expect(body.output_config).toEqual({
+      effort: "high",
+      format: { type: "json_schema", schema },
+    });
   });
 });
 

--- a/tests/anthropic-reasoning.test.ts
+++ b/tests/anthropic-reasoning.test.ts
@@ -118,6 +118,18 @@ describe("anthropic extended-thinking gate", () => {
     });
   });
 
+  test("rejects a JSON Schema without a type or composition keyword", async () => {
+    const request = parseRequest({
+      model: "claude-sonnet-5",
+      input: [{ role: "user", content: [{ type: "input_text", text: "summarize this" }] }],
+      text: { format: { type: "json_schema", name: "summary", schema: { description: "summary" } } },
+    });
+
+    await expect(bodyOf(request)).rejects.toThrow(
+      "JSON schema must have a type defined if anyOf/oneOf/allOf are not used",
+    );
+  });
+
   test("adaptive-thinking model resizes max_tokens for high effort (issue #246)", async () => {
     const b = await bodyOf(parsed("max", {}, "claude-fable-5"));
     // Exact regression: effort=max budget is 32000; adaptive ceiling adds OUTPUT_HEADROOM (8192)

--- a/tests/anthropic-reasoning.test.ts
+++ b/tests/anthropic-reasoning.test.ts
@@ -98,6 +98,29 @@ describe("anthropic extended-thinking gate", () => {
     });
   });
 
+  test("preserves root definitions used by a root JSON Schema reference", async () => {
+    const schema = {
+      $ref: "#/$defs/answer",
+      $defs: {
+        answer: {
+          type: "object",
+          properties: { ok: { type: "boolean" } },
+          required: ["ok"],
+          additionalProperties: false,
+        },
+      },
+    };
+    const b = await bodyOf(parseRequest({
+      model: "claude-sonnet-5",
+      input: [{ role: "user", content: [{ type: "input_text", text: "answer this" }] }],
+      text: { format: { type: "json_schema", name: "answer", schema } },
+    }));
+
+    expect(b.output_config).toEqual({
+      format: { type: "json_schema", schema },
+    });
+  });
+
   test("merges JSON Schema output format with adaptive thinking effort", async () => {
     const schema = {
       type: "object",

--- a/tests/anthropic-reasoning.test.ts
+++ b/tests/anthropic-reasoning.test.ts
@@ -142,6 +142,36 @@ describe("anthropic extended-thinking gate", () => {
     });
   });
 
+  test("preserves unselected composition keywords as model guidance", async () => {
+    const oneOf = [{ type: "number", minimum: 0 }];
+    const allOf = [{ type: "string", minLength: 1 }];
+    const b = await bodyOf(parseRequest({
+      model: "claude-sonnet-5",
+      input: [{ role: "user", content: [{ type: "input_text", text: "answer this" }] }],
+      text: {
+        format: {
+          type: "json_schema",
+          name: "answer",
+          schema: {
+            anyOf: [{ type: "boolean" }],
+            oneOf,
+            allOf,
+          },
+        },
+      },
+    }));
+
+    expect(b.output_config).toEqual({
+      format: {
+        type: "json_schema",
+        schema: {
+          anyOf: [{ type: "boolean" }],
+          description: `{oneOf: ${JSON.stringify(oneOf)}, allOf: ${JSON.stringify(allOf)}}`,
+        },
+      },
+    });
+  });
+
   test("translates Chat Completions JSON Schema output to Anthropic", async () => {
     const schema = {
       type: "object",

--- a/tests/anthropic-reasoning.test.ts
+++ b/tests/anthropic-reasoning.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { createAnthropicAdapter as createAnthropicAdapterProduction } from "../src/adapters/anthropic";
+import { chatCompletionsToResponsesBody } from "../src/chat/inbound";
 import { parseRequest } from "../src/responses/parser";
 import { anthropicToResponsesBody } from "../src/claude/inbound";
 import type { OcxParsedRequest, OcxProviderConfig } from "../src/types";
@@ -134,6 +135,36 @@ describe("anthropic extended-thinking gate", () => {
       reasoning: { effort: "high" },
       text: { format: { type: "json_schema", name: "summary", schema, strict: true } },
     }));
+
+    expect(b.output_config).toEqual({
+      effort: "high",
+      format: { type: "json_schema", schema },
+    });
+  });
+
+  test("translates Chat Completions JSON Schema output to Anthropic", async () => {
+    const schema = {
+      type: "object",
+      properties: { summary: { type: "string" } },
+      required: ["summary"],
+      additionalProperties: false,
+    };
+    const responsesBody = chatCompletionsToResponsesBody({
+      model: "claude-sonnet-5",
+      messages: [{ role: "user", content: "summarize this" }],
+      reasoning_effort: "high",
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "summary",
+          description: "One summary object.",
+          schema,
+          strict: true,
+        },
+      },
+    });
+
+    const b = await bodyOf(parseRequest(responsesBody));
 
     expect(b.output_config).toEqual({
       effort: "high",

--- a/tests/claude-inbound.test.ts
+++ b/tests/claude-inbound.test.ts
@@ -159,6 +159,31 @@ describe("claude inbound translation", () => {
     expect(parseRequest(body).options.textFormat).toEqual({ type: "json_schema", schema });
   });
 
+  test("structured output rejects unsupported schemas and preserves root references", () => {
+    const base = {
+      model: "claude-sonnet-5",
+      max_tokens: 256,
+      messages: [{ role: "user", content: "Return JSON" }],
+    };
+    const invalid = anthropicToResponsesBody({
+      ...base,
+      output_config: {
+        format: { type: "json_schema", schema: { description: "answer" } },
+      },
+    });
+    const refSchema = {
+      $defs: { answer: { type: "object", properties: { value: { type: "string" } } } },
+      $ref: "#/$defs/answer",
+    };
+    const referenced = anthropicToResponsesBody({
+      ...base,
+      output_config: { format: { type: "json_schema", schema: refSchema } },
+    });
+
+    expect(invalid.text).toBeUndefined();
+    expect(referenced.text).toEqual({ format: { type: "json_schema", schema: refSchema } });
+  });
+
   test("tool_choice any/tool/none", () => {
     const base = { model: "m", max_tokens: 10, messages: [{ role: "user", content: "hi" }] };
     expect((anthropicToResponsesBody({ ...base, tool_choice: { type: "any" } }) as any).tool_choice).toBe("required");

--- a/tests/claude-inbound.test.ts
+++ b/tests/claude-inbound.test.ts
@@ -141,6 +141,24 @@ describe("claude inbound translation", () => {
     }))).toEqual({ summary: "auto" });
   });
 
+  test("structured output maps output_config.format to text.format", () => {
+    const schema = {
+      type: "object",
+      properties: { answer: { type: "string" } },
+      required: ["answer"],
+      additionalProperties: false,
+    };
+    const body = anthropicToResponsesBody({
+      model: "claude-sonnet-5",
+      max_tokens: 256,
+      messages: [{ role: "user", content: "Return JSON" }],
+      output_config: { format: { type: "json_schema", schema } },
+    });
+
+    expect(body.text).toEqual({ format: { type: "json_schema", schema } });
+    expect(parseRequest(body).options.textFormat).toEqual({ type: "json_schema", schema });
+  });
+
   test("tool_choice any/tool/none", () => {
     const base = { model: "m", max_tokens: 10, messages: [{ role: "user", content: "hi" }] };
     expect((anthropicToResponsesBody({ ...base, tool_choice: { type: "any" } }) as any).tool_choice).toBe("required");

--- a/tests/claude-inbound.test.ts
+++ b/tests/claude-inbound.test.ts
@@ -155,8 +155,8 @@ describe("claude inbound translation", () => {
       output_config: { format: { type: "json_schema", schema } },
     });
 
-    expect(body.text).toEqual({ format: { type: "json_schema", schema } });
-    expect(parseRequest(body).options.textFormat).toEqual({ type: "json_schema", schema });
+    expect(body.text).toEqual({ format: { type: "json_schema", name: "response", schema } });
+    expect(parseRequest(body).options.textFormat).toEqual({ type: "json_schema", name: "response", schema });
   });
 
   test("structured output rejects unsupported schemas and preserves root references", () => {
@@ -181,7 +181,9 @@ describe("claude inbound translation", () => {
     });
 
     expect(invalid.text).toBeUndefined();
-    expect(referenced.text).toEqual({ format: { type: "json_schema", schema: refSchema } });
+    expect(referenced.text).toEqual({
+      format: { type: "json_schema", name: "response", schema: refSchema },
+    });
   });
 
   test("tool_choice any/tool/none", () => {

--- a/tests/claude-messages-endpoint.test.ts
+++ b/tests/claude-messages-endpoint.test.ts
@@ -1361,6 +1361,69 @@ test("generated agent effort directive restores exact xhigh and max after Claude
   }
 });
 
+test("generated agent effort directive preserves routed Anthropic structured output", async () => {
+  const captured: Array<Record<string, unknown>> = [];
+  const upstream = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      captured.push(await req.json() as Record<string, unknown>);
+      return new Response([
+        'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_test","type":"message","role":"assistant","model":"claude-sonnet-5","content":[],"stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n',
+        'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+        'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{\\"answer\\":\\"ok\\"}"}}\n\n',
+        'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+        'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}\n\n',
+        'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+      ].join(""), { headers: { "content-type": "text/event-stream" } });
+    },
+  });
+  saveConfig({
+    port: 0,
+    defaultProvider: "mock-anthropic",
+    providers: {
+      "mock-anthropic": {
+        adapter: "anthropic",
+        baseUrl: upstream.url.toString().replace(/\/$/, ""),
+        apiKey: "test-key",
+        allowPrivateNetwork: true,
+      },
+    },
+  } as OcxConfig);
+  const server = startServer(0);
+  const schema = {
+    type: "object",
+    properties: { answer: { type: "string" } },
+    required: ["answer"],
+    additionalProperties: false,
+  };
+  try {
+    const response = await postMessages(server.url.toString(), {
+      model: "claude-haiku-4-5",
+      max_tokens: 32000,
+      stream: true,
+      system: [
+        { type: "text", text: "<!-- ocx-route: claude-ocx-mock-anthropic--claude-sonnet-5 -->" },
+        { type: "text", text: "<!-- ocx-effort: max -->" },
+      ],
+      thinking: { type: "enabled", budget_tokens: 31999 },
+      output_config: {
+        format: { type: "json_schema", schema },
+      },
+      messages: [{ role: "user", content: "Return JSON" }],
+    });
+    expect(response.status).toBe(200);
+    await response.text();
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.output_config).toEqual({
+      effort: "max",
+      format: { type: "json_schema", schema },
+    });
+  } finally {
+    await server.stop(true);
+    upstream.stop(true);
+  }
+});
+
 test("unknown-ladder routes keep the requested effort (no false stripping)", async () => {
   const { server: upstream, captured } = mockChatUpstreamCapturing();
   saveConfig(mockConfig(`${upstream.url.toString().replace(/\/$/, "")}/v1`));


### PR DESCRIPTION
## Summary

- Forward Responses and Chat Completions JSON Schema output formats through the Anthropic adapter as `output_config.format`.
- Normalize JSON Schema to Anthropic's supported structured-output subset while preserving unsupported constraints in descriptions.
- Preserve root `$defs` beside a root `$ref`, merge structured-output configuration with adaptive-thinking `output_config.effort`, and round-trip Messages structured output through stored OAuth.
- Document the Anthropic compatibility transform, limitations, and maintenance decision.

## Verification

- Rebased onto current `dev@4fed8d3f`.
- `bun test tests/anthropic-reasoning.test.ts tests/claude-inbound.test.ts tests/claude-messages-endpoint.test.ts tests/responses-parser.test.ts tests/responses-parser-malformed-content.test.ts tests/chat-completions-endpoint.test.ts tests/responses-compaction.test.ts tests/responses-compaction-routing.test.ts` (269 passed; 2 optional-main enrichment tests fail identically on current `dev` and are unrelated to structured output)
- `bun test tests/api-storage-policy-put-race.test.ts` (1 passed)
- `bun run typecheck`
- `bun run privacy:scan`
- `git diff --check upstream/dev...HEAD`
- `cd docs-site && bun install --frozen-lockfile && bun run build`
- Live AI SDK v7 `Output.object` request through the patched server on port 10101 using `anthropic/claude-sonnet-5`
- The previous exact-head Cross-platform CI run passed all Linux shards, the unsharded macOS suite, gates, keyring, storage-policy, API-usage, and npm-global jobs; the rebased head is awaiting maintainer approval for the fork workflow
- The unsharded local Windows suite remains affected by the repository's known Windows-only failures and Bun 1.3.14 panics; the related focused suites are green apart from the two current-`dev` optional-main enrichment failures noted above

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured JSON Schema output support for Anthropic requests.
  * Translated compatible OpenAI-style structured-output settings for Anthropic and Responses APIs.
  * Preserved schema references, definitions, compositions, nested structures, and supported constraints.
  * Retained output configuration when adding schema formatting, including adaptive reasoning and routed requests.

* **Bug Fixes**
  * Invalid or unsupported schemas are safely rejected or omitted.
  * Preserved structured-output settings when applying effort overrides.

* **Documentation**
  * Documented structured-output compatibility and schema normalization behavior.

* **Tests**
  * Expanded coverage for schema forwarding, translation, routing, and adaptive reasoning compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
