### PR TITLE
fix(windows): preflight scheduler registration before teardown

### DIFF
--- a/docs-site/src/content/docs/reference/cli/lifecycle.md
+++ b/docs-site/src/content/docs/reference/cli/lifecycle.md
@@ -282,6 +282,13 @@ automatically. If that fallback cannot determine the token state, it retains the
 error. Foreign tasks and operations can never emit the automatic-elevation marker. Approve the
 dashboard UAC prompt or rerun `ocx service install` in an elevated PowerShell window.
 
+For a fresh install where the OpenCodex scheduler task is confirmed absent, UAC approval now
+happens before the installer stops any existing proxy. The task is registered without being run;
+only after registration succeeds does OpenCodex stop the old listener, publish the service assets,
+and start the scheduled task. Cancelling or denying UAC therefore leaves the working proxy and its
+Codex routing in place. Existing or conflicting scheduler registrations continue to fail closed
+rather than being deleted as an unsafe best-effort rollback.
+
 ### `ocx codex-shim <install|status|uninstall|remove>`
 
 Wrap a script-based `codex` launcher on PATH with a lightweight autostart script. Real `codex.exe`

--- a/src/server/startup-action-control.ts
+++ b/src/server/startup-action-control.ts
@@ -164,10 +164,17 @@ function runCliInstall(
   const cli = join(import.meta.dir, "..", "cli", "index.ts");
   const argv = [cli, ...startupInstallArgv(action, options)];
   return new Promise((resolve, reject) => {
+    const timeout = process.platform === "win32" && action === "install-service"
+      ? 0
+      : 60_000;
     execFile(bun, argv, {
       encoding: "utf8",
       env: process.env,
-      timeout: 60_000,
+      // A fresh Windows scheduler install now owns its UAC prompt inside this CLI
+      // transaction. Killing only the CLI at 60s can orphan its elevated schtasks child,
+      // which may register the task after the Dashboard has reported failure. Keep the
+      // async request/attempt lock alive until Windows returns approval or cancellation.
+      timeout,
       windowsHide: true,
       maxBuffer: 256 * 1024,
     }, (error, stdout, stderr) => {

--- a/src/service.ts
+++ b/src/service.ts
@@ -29,6 +29,7 @@ import {
   runWindowsElevated,
   toWindowsSchtasksError,
   WindowsElevationError,
+  WindowsSchtasksError,
   type ElevatedSchedulerOutcome,
   type ElevatedSchtasksCreateAndRunExecution,
   type ElevatedSchtasksCreateAndRunResult,
@@ -1506,6 +1507,11 @@ export function buildWindowsSchtasksCreateArgs(script = windowsServiceScriptPath
   return ["/create", "/tn", TASK, "/xml", xml, "/f"];
 }
 
+/** Build the fixed scheduler-create command from an explicit staged XML document. */
+export function buildWindowsSchtasksCreateArgsForXml(xml: string): string[] {
+  return ["/create", "/tn", TASK, "/xml", xml, "/f"];
+}
+
 /**
  * VBS launcher that starts the batch wrapper with a hidden window (style 0).
  * bWaitOnReturn=True keeps wscript.exe resident for the wrapper's lifetime so the
@@ -1821,6 +1827,84 @@ function writeWindowsSchedulerAssets(): void {
   // paths on some WSH/codepage combinations — same contract as the task XML below.
   writeServiceAssetWithRetry(windowsLauncherVbsPath(), `\uFEFF${buildWindowsLauncherVbs(script)}`, "utf16le");
   writeServiceAssetWithRetry(windowsTaskXmlPath(), `\uFEFF${buildWindowsTaskXml(script)}`, "utf16le");
+}
+
+function stageWindowsSchedulerRegistrationXml(): string {
+  if (!existsSync(getConfigDir())) mkdirSync(getConfigDir(), { recursive: true, mode: 0o700 });
+  const path = join(getConfigDir(), `.opencodex-service-task.${randomUUID()}.xml`);
+  // This document points at the canonical launcher but does not publish or rewrite that
+  // launcher. UAC can therefore be refused while the current proxy still owns its port.
+  writeServiceAssetWithRetry(
+    path,
+    `\uFEFF${buildWindowsTaskXml(windowsServiceScriptPath(), windowsLauncherVbsPath())}`,
+    "utf16le",
+  );
+  return path;
+}
+
+export interface FreshWindowsSchedulerRegistrationDeps {
+  create?: (args: string[]) => void;
+  elevate?: (args: string[]) => Promise<void>;
+  probe?: () => WindowsSchedulerTaskProbe;
+  queryXml?: () => string;
+  rollback?: () => Promise<string | null>;
+}
+
+export async function registerFreshWindowsSchedulerTask(
+  xmlPath: string,
+  deps: FreshWindowsSchedulerRegistrationDeps = {},
+): Promise<void> {
+  const args = buildWindowsSchtasksCreateArgsForXml(xmlPath);
+  try {
+    (deps.create ?? schtasks)(args);
+  } catch (error) {
+    if (
+      !(error instanceof WindowsSchtasksError)
+      || error.operation !== "create"
+      || error.reason !== "access-denied"
+    ) {
+      throw error;
+    }
+    // The elevated command is still the fixed trusted schtasks executable plus the
+    // owned create shape. It registers only; the task is not run until cleanup commits.
+    await (deps.elevate ?? elevateSchtasks)(args);
+  }
+
+  const rollbackTask = deps.rollback ?? (() => rollbackElevatedSchedulerTask(TASK));
+  const probe = (deps.probe ?? (() => probeWindowsSchedulerTask(TASK)))();
+  if (probe.status === "absent") {
+    throw new Error("Task Scheduler reported success, but the new registration is absent; no service cleanup was started.");
+  }
+  if (probe.status === "unknown") {
+    const rollback = await rollbackTask();
+    throw new Error(
+      `Task Scheduler registration was not verifiably present after create (${probe.detail}).`
+      + (rollback ? ` Cleanup also failed: ${rollback}` : " The unverified registration was rolled back."),
+    );
+  }
+
+  let registeredXml = "";
+  let queryDetail: string | null = null;
+  try {
+    registeredXml = (deps.queryXml ?? (() => querySchtasks(["/query", "/tn", TASK, "/xml"])))();
+  } catch (error) {
+    queryDetail = error instanceof Error ? error.message : String(error);
+  }
+  if (!registeredXml.trim()) {
+    const rollback = await rollbackTask();
+    throw new Error(
+      "Task Scheduler registration was created, but its live XML could not be verified."
+      + (queryDetail ? ` Query failed: ${queryDetail}` : " The query returned an empty document.")
+      + (rollback ? ` Cleanup also failed: ${rollback}` : " The unverified registration was rolled back."),
+    );
+  }
+  if (!windowsTaskRegistrationHealthy(registeredXml)) {
+    const rollback = await rollbackTask();
+    throw new Error(
+      "Task Scheduler registration was created but failed the OpenCodex action/trigger verification."
+      + (rollback ? ` Cleanup also failed: ${rollback}` : " The invalid registration was rolled back."),
+    );
+  }
 }
 
 function installWindows(): void {
@@ -2437,6 +2521,82 @@ export async function installServiceSafely(
   await install();
 }
 
+export interface FreshWindowsSchedulerInstallDeps {
+  stageRegistrationXml?: () => string;
+  register?: (xmlPath: string) => Promise<void>;
+  prepare?: () => Promise<void>;
+  publishAssets?: () => void;
+  runTask?: () => void;
+  writeState?: () => void;
+  rollbackTask?: () => Promise<string | null>;
+  removeStagedXml?: (xmlPath: string) => void;
+}
+
+/**
+ * Fresh Windows scheduler install with UAC before the destructive commit.
+ *
+ * The registration is created but never run before `prepare`: UAC cancellation and
+ * create failure therefore cannot stop the existing proxy or trigger its native-routing
+ * cleanup. This path is used only after Task Scheduler absence was proved, so rollback
+ * can delete the exact registration this attempt created without touching prior state.
+ */
+export async function installFreshWindowsSchedulerSafely(
+  deps: FreshWindowsSchedulerInstallDeps = {},
+): Promise<void> {
+  const stage = deps.stageRegistrationXml ?? stageWindowsSchedulerRegistrationXml;
+  const register = deps.register ?? registerFreshWindowsSchedulerTask;
+  const prepare = deps.prepare ?? (() => prepareServiceInstall("scheduler"));
+  const publishAssets = deps.publishAssets ?? writeWindowsSchedulerAssets;
+  const runTask = deps.runTask ?? startWindows;
+  const writeState = deps.writeState ?? (() => writeServiceInstallState("scheduler"));
+  const rollbackTask = deps.rollbackTask ?? (() => rollbackElevatedSchedulerTask(TASK));
+  const removeStagedXml = deps.removeStagedXml ?? ((path: string) => {
+    if (existsSync(path)) unlinkSync(path);
+  });
+
+  let stagedXml: string | null = null;
+  let registered = false;
+  let started = false;
+  try {
+    stagedXml = stage();
+    await register(stagedXml);
+    registered = true;
+
+    // The destructive boundary begins only after Task Scheduler accepted the definition.
+    await prepare();
+    publishAssets();
+    runTask();
+    started = true;
+    writeState();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    if (registered && !started) {
+      const rollback = await rollbackTask();
+      throw new Error(
+        `${detail}\n`
+        + (rollback
+          ? `The new Task Scheduler registration may remain: ${rollback}`
+          : "The new Task Scheduler registration was rolled back. The previous proxy/routing state was not assumed restored."),
+      );
+    }
+    if (started) {
+      throw new Error(
+        `${detail}\nThe scheduler task started, but install state was not published. `
+        + "The task was left in place; inspect `ocx service status` before retrying.",
+      );
+    }
+    throw error;
+  } finally {
+    if (stagedXml) {
+      try { removeStagedXml(stagedXml); } catch (error) {
+        console.error(
+          `⚠️  Failed to remove temporary Task Scheduler XML ${stagedXml}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+}
+
 /**
  * If a service is installed, stop it so the process manager doesn't respawn after `ocx stop`.
  * Returns true if a service was found and stopped.
@@ -2812,7 +2972,19 @@ export async function serviceCommand(...args: (string | undefined)[]): Promise<v
       // restart-loops on EADDRINUSE, and the old standalone process makes the install
       // verification report a false success.
       try {
-        await installServiceSafely(backend, ops.install);
+        if (process.platform === "win32" && backend === "scheduler") {
+          const scheduler = probeWindowsSchedulerTask(TASK);
+          if (scheduler.status === "unknown") {
+            throw new Error(`Task Scheduler state could not be verified before install: ${scheduler.detail}`);
+          }
+          if (scheduler.status === "absent") {
+            await installFreshWindowsSchedulerSafely();
+          } else {
+            await installServiceSafely(backend, ops.install);
+          }
+        } else {
+          await installServiceSafely(backend, ops.install);
+        }
       } catch (error) {
         console.error(`❌ Service install cleanup failed: ${error instanceof Error ? error.message : String(error)}`);
         process.exitCode = 1;

--- a/structure/05_gui-and-management-api.md
+++ b/structure/05_gui-and-management-api.md
@@ -197,6 +197,29 @@ the effective-token elevation probe may classify it as access denied only when t
 to be non-elevated. An unavailable probe remains `other` and cannot trigger UAC. Query, run, delete,
 native-service, file-write, and foreign task failures never use this fallback.
 
+For a fresh scheduler install whose task is proven absent, registration is the non-destructive
+first phase. OpenCodex writes a unique temporary XML definition and asks Task Scheduler to create
+the owned task without running it. Only after that succeeds may service-manager cleanup stop the
+existing proxy, publish the canonical scheduler assets, run the task, and write install state.
+UAC cancellation or create failure removes the temporary XML before any manager/proxy stop, so the
+working proxy's shutdown cleanup cannot strip Codex routing merely because elevation was refused.
+The Dashboard does not apply its ordinary 60-second child timeout to this Windows service command:
+killing only the CLI could orphan the already-launched elevated child, which might register a task
+after the UI reported failure. The asynchronous request and install-attempt lock remain pending
+until Windows returns approval or cancellation; other proxy requests keep running normally.
+Existing or conflicting registrations stay on the older fail-closed path because deleting or
+replacing them cannot be called a rollback without an exact prior-registration snapshot.
+
+```text
+[Decision Log]
+- 목적과 의도: Keep a refused fresh Windows service install from stopping a working proxy and removing managed Codex routing.
+- 기존 구현 및 제약 조건: The generic installer stopped service managers and the standalone proxy before the first scheduler create attempt; the Dashboard UAC path depended on assets produced by that already-destructive failure.
+- 검토한 주요 대안: Reject every non-elevated caller up front, restart and re-inject after failure, snapshot every runtime/config artifact for rollback, or separate registration approval from the destructive commit.
+- 선택한 방식: When scheduler absence is proven, create but do not run the owned registration from a temporary XML first; cleanup and canonical asset publication begin only after registration succeeds.
+- 다른 대안 대신 이 방식을 선택한 이유: An early rejection breaks Dashboard UAC, while a best-effort restart cannot prove that manager, proxy, and routing state were restored. The two-phase boundary makes denial/cancellation a real pre-commit failure.
+- 장점, 단점 및 영향: Fresh-install UAC failure preserves the live proxy and routing. Failures after registration remain explicit partial-install cases, and existing/conflicting scheduler recovery remains conservative until exact prior-state restoration is available.
+```
+
 ```text
 [Decision Log]
 - 목적과 의도: Make Windows scheduler installation recovery work on non-English systems without broadening the commands that may request UAC.

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -1,12 +1,13 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { saveConfig } from "../src/config";
 import { windowsEnvIndirectBatchValue } from "../src/lib/win-paths";
-import { assertServiceAuthEnvironment, assertServiceEnvironmentMatchesInstall, bakedServicePathsDiagnostic, confirmServiceServing, launchdListenPort, systemdListenPort, buildPlist, buildUnit, buildWindowsLauncherVbs, buildWindowsSchtasksCreateArgs, buildWindowsServiceScript, buildWindowsTaskXml, deriveWindowsServiceDiagnostic, installServiceSafely, launchctlLoadFailed, launchdJobMatchesPlist, normalizeServiceSubcommand, parseServiceInstallState, prepareServiceInstall, readWindowsSchedulerXmlState, repairService, resolveServiceListenPort, runLaunchctl, serviceLogPath, serviceStartableFromTray, serviceStatusReport, serviceRetryCommand, serviceStatusSummary, systemdNeedsDaemonReload, windowsListenPort, winswListenPort, startLaunchd, windowsTaskRegistrationHealthy } from "../src/service";
+import { assertServiceAuthEnvironment, assertServiceEnvironmentMatchesInstall, bakedServicePathsDiagnostic, confirmServiceServing, launchdListenPort, systemdListenPort, buildPlist, buildUnit, buildWindowsLauncherVbs, buildWindowsSchtasksCreateArgs, buildWindowsSchtasksCreateArgsForXml, buildWindowsServiceScript, buildWindowsTaskXml, deriveWindowsServiceDiagnostic, installFreshWindowsSchedulerSafely, installServiceSafely, launchctlLoadFailed, launchdJobMatchesPlist, normalizeServiceSubcommand, parseServiceInstallState, prepareServiceInstall, readWindowsSchedulerXmlState, registerFreshWindowsSchedulerTask, repairService, resolveServiceListenPort, runLaunchctl, serviceLogPath, serviceStartableFromTray, serviceStatusReport, serviceRetryCommand, serviceStatusSummary, systemdNeedsDaemonReload, windowsListenPort, winswListenPort, startLaunchd, windowsTaskRegistrationHealthy } from "../src/service";
 import type { ServiceDiagnostic } from "../src/service";
 import { buildWinswXml } from "../src/lib/winsw";
 import { serviceApiTokenFilePath } from "../src/lib/service-secrets";
+import { WindowsSchtasksError } from "../src/lib/windows-elevation";
 import type { OcxConfig } from "../src/types";
 
 const TEST_DIR = join(import.meta.dir, ".tmp-service-test");
@@ -662,6 +663,172 @@ describe("launchd service plist", () => {
 });
 
 describe("service lifecycle cleanup ordering", () => {
+  test("fresh registration elevates only the fixed create after a structured denial", async () => {
+    const calls: string[] = [];
+    const stagedXml = "C:\\Users\\x\\.opencodex\\attempt.xml";
+    const expectedArgs = buildWindowsSchtasksCreateArgsForXml(stagedXml);
+    await registerFreshWindowsSchedulerTask(stagedXml, {
+      create: args => {
+        calls.push(`create:${args.join(" ")}`);
+        throw new WindowsSchtasksError("create", "access-denied", "denied");
+      },
+      elevate: async args => { calls.push(`elevate:${args.join(" ")}`); },
+      probe: () => ({ status: "present", detail: "present" }),
+      queryXml: () => buildWindowsTaskXml(),
+      rollback: async () => { calls.push("rollback"); return null; },
+    });
+
+    expect(calls).toEqual([
+      `create:${expectedArgs.join(" ")}`,
+      `elevate:${expectedArgs.join(" ")}`,
+    ]);
+  });
+
+  test("fresh registration UAC denial returns before task probing or cleanup", async () => {
+    const calls: string[] = [];
+    await expect(registerFreshWindowsSchedulerTask("attempt.xml", {
+      create: () => {
+        calls.push("create");
+        throw new WindowsSchtasksError("create", "access-denied", "denied");
+      },
+      elevate: async () => { calls.push("elevate"); throw new Error("UAC cancelled"); },
+      probe: () => { calls.push("probe"); return { status: "present", detail: "present" }; },
+      queryXml: () => { calls.push("query"); return buildWindowsTaskXml(); },
+      rollback: async () => { calls.push("rollback"); return null; },
+    })).rejects.toThrow("UAC cancelled");
+
+    expect(calls).toEqual(["create", "elevate"]);
+  });
+
+  test("fresh registration never elevates an unstructured scheduler failure", async () => {
+    const calls: string[] = [];
+    await expect(registerFreshWindowsSchedulerTask("attempt.xml", {
+      create: () => { calls.push("create"); throw new Error("scheduler unavailable"); },
+      elevate: async () => { calls.push("elevate"); },
+      probe: () => { calls.push("probe"); return { status: "present", detail: "present" }; },
+      queryXml: () => buildWindowsTaskXml(),
+      rollback: async () => { calls.push("rollback"); return null; },
+    })).rejects.toThrow("scheduler unavailable");
+
+    expect(calls).toEqual(["create"]);
+  });
+
+  test("create success followed by proven absence does not request a pointless rollback UAC", async () => {
+    const calls: string[] = [];
+    await expect(registerFreshWindowsSchedulerTask("attempt.xml", {
+      create: () => { calls.push("create"); },
+      elevate: async () => { calls.push("elevate"); },
+      probe: () => { calls.push("probe"); return { status: "absent", detail: "absent" }; },
+      queryXml: () => { calls.push("query"); return buildWindowsTaskXml(); },
+      rollback: async () => { calls.push("rollback"); return null; },
+    })).rejects.toThrow(/registration is absent/);
+
+    expect(calls).toEqual(["create", "probe"]);
+  });
+
+  test("fresh registration requires the live Task Scheduler XML before cleanup can begin", async () => {
+    const calls: string[] = [];
+    await expect(registerFreshWindowsSchedulerTask("attempt.xml", {
+      create: () => { calls.push("create"); },
+      probe: () => { calls.push("probe"); return { status: "present", detail: "present" }; },
+      queryXml: () => { calls.push("query"); throw new Error("query denied"); },
+      rollback: async () => { calls.push("rollback"); return null; },
+    })).rejects.toThrow(/live XML could not be verified/);
+
+    expect(calls).toEqual(["create", "probe", "query", "rollback"]);
+  });
+
+  test("fresh Windows scheduler install gets registration approval before destructive cleanup", async () => {
+    const calls: string[] = [];
+    await installFreshWindowsSchedulerSafely({
+      stageRegistrationXml: () => { calls.push("stage"); return "attempt.xml"; },
+      register: async path => { calls.push(`register:${path}`); },
+      prepare: async () => { calls.push("prepare:stop-managers-and-proxy"); },
+      publishAssets: () => { calls.push("publish-assets"); },
+      runTask: () => { calls.push("run-task"); },
+      writeState: () => { calls.push("write-state"); },
+      rollbackTask: async () => { calls.push("rollback-task"); return null; },
+      removeStagedXml: path => { calls.push(`remove:${path}`); },
+    });
+
+    expect(calls).toEqual([
+      "stage",
+      "register:attempt.xml",
+      "prepare:stop-managers-and-proxy",
+      "publish-assets",
+      "run-task",
+      "write-state",
+      "remove:attempt.xml",
+    ]);
+  });
+
+  test("UAC cancellation removes only staged XML and never enters cleanup or asset publication", async () => {
+    const calls: string[] = [];
+    mkdirSync(TEST_DIR, { recursive: true });
+    const routingPath = join(TEST_DIR, "config.toml");
+    const routingBefore = 'openai_base_url = "http://127.0.0.1:10100/v1"\nmodel_catalog_json = "keep.json"\n';
+    writeFileSync(routingPath, routingBefore, "utf8");
+    await expect(installFreshWindowsSchedulerSafely({
+      stageRegistrationXml: () => { calls.push("stage"); return "attempt.xml"; },
+      register: async path => {
+        calls.push(`register:${path}`);
+        throw new Error("UAC prompt was cancelled");
+      },
+      prepare: async () => { calls.push("prepare"); },
+      publishAssets: () => { calls.push("publish-assets"); },
+      runTask: () => { calls.push("run-task"); },
+      writeState: () => { calls.push("write-state"); },
+      rollbackTask: async () => { calls.push("rollback-task"); return null; },
+      removeStagedXml: path => { calls.push(`remove:${path}`); },
+    })).rejects.toThrow("UAC prompt was cancelled");
+
+    expect(calls).toEqual([
+      "stage",
+      "register:attempt.xml",
+      "remove:attempt.xml",
+    ]);
+    expect(readFileSync(routingPath, "utf8")).toBe(routingBefore);
+  });
+
+  test("a pre-run commit failure rolls back only the newly-created registration", async () => {
+    const calls: string[] = [];
+    await expect(installFreshWindowsSchedulerSafely({
+      stageRegistrationXml: () => "attempt.xml",
+      register: async () => { calls.push("register"); },
+      prepare: async () => { calls.push("prepare"); throw new Error("standalone stop failed"); },
+      publishAssets: () => { calls.push("publish-assets"); },
+      runTask: () => { calls.push("run-task"); },
+      writeState: () => { calls.push("write-state"); },
+      rollbackTask: async () => { calls.push("rollback-task"); return null; },
+      removeStagedXml: () => { calls.push("remove-stage"); },
+    })).rejects.toThrow(/previous proxy\/routing state was not assumed restored/);
+
+    expect(calls).toEqual(["register", "prepare", "rollback-task", "remove-stage"]);
+  });
+
+  test("a state-write failure leaves the already-started task for explicit diagnosis", async () => {
+    const calls: string[] = [];
+    await expect(installFreshWindowsSchedulerSafely({
+      stageRegistrationXml: () => "attempt.xml",
+      register: async () => { calls.push("register"); },
+      prepare: async () => { calls.push("prepare"); },
+      publishAssets: () => { calls.push("publish-assets"); },
+      runTask: () => { calls.push("run-task"); },
+      writeState: () => { calls.push("write-state"); throw new Error("state write failed"); },
+      rollbackTask: async () => { calls.push("rollback-task"); return null; },
+      removeStagedXml: () => { calls.push("remove-stage"); },
+    })).rejects.toThrow(/task was left in place/);
+
+    expect(calls).toEqual([
+      "register",
+      "prepare",
+      "publish-assets",
+      "run-task",
+      "write-state",
+      "remove-stage",
+    ]);
+  });
+
   test("service install stops the recorded backend, requested backend, and standalone before loading assets", async () => {
     const calls: string[] = [];
     const managerOps = (backend: "scheduler" | "native") => ({
@@ -761,6 +928,16 @@ describe("service lifecycle cleanup ordering", () => {
     expect(assetsHelper).toContain("writeServiceAssetWithRetry(windowsTaskXmlPath()");
     // Retry helper tolerates transient Windows file locks from the just-ended task.
     expect(service).toContain('code !== "EBUSY" && code !== "EPERM" && code !== "EACCES"');
+  });
+
+  test("fresh Windows scheduler wiring selects the pre-registration transaction", async () => {
+    const service = await readText("src/service.ts");
+    const installCase = service.slice(service.indexOf('case "install":'), service.indexOf('case "start":'));
+    expect(installCase).toContain('scheduler.status === "absent"');
+    expect(installCase).toContain("await installFreshWindowsSchedulerSafely()");
+    expect(installCase.indexOf('scheduler.status === "absent"')).toBeLessThan(
+      installCase.indexOf("await installFreshWindowsSchedulerSafely()"),
+    );
   });
 
   test("Windows service uninstall verifies task deletion before removing assets", async () => {

--- a/tests/startup-action-control-elevation.test.ts
+++ b/tests/startup-action-control-elevation.test.ts
@@ -68,6 +68,24 @@ describe("startup install elevation retry", () => {
     });
   }
 
+  test("a CLI-completed two-phase scheduler install does not enter the legacy Dashboard finalizer", async () => {
+    execFileMock.mockImplementation((
+      _file: string,
+      _args: string[],
+      _options: unknown,
+      callback: (error: Error | null, stdout?: string, stderr?: string) => void,
+    ) => {
+      callback(null, "service installed", "");
+    });
+
+    await expect(runStartupInstallAction("install-service")).resolves.toEqual({
+      message: "Background service installed.",
+    });
+    expect(finalizeMock).not.toHaveBeenCalled();
+    expect(getStartupInstallState().status).toBe("idle");
+    expect((execFileMock.mock.calls[0]![2] as { timeout?: number }).timeout).toBe(0);
+  });
+
   test("retries only for structured schtasks /create access denied", async () => {
     failCli(`Windows access denied while running Task Scheduler.\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`);
 


### PR DESCRIPTION
## Summary

- Move fresh Windows Task Scheduler registration ahead of destructive service/proxy cleanup.
- Register but do not run the owned task from a unique temporary XML, then verify the live scheduler XML before stopping the current proxy or removing managed Codex routing.
- Roll back only the registration created by this attempt when the commit phase fails before task start; leave started partial state explicit for diagnosis.
- Keep existing or conflicting scheduler registrations on the conservative fail-closed path, and keep the Dashboard install request alive while Windows UAC is pending so an elevated child cannot be orphaned by the ordinary 60-second timeout.
- Document the two-phase lifecycle and its tradeoffs.

This fixes the real ordering regression reported in #1454: cancelling or denying UAC during a fresh scheduler install is now a pre-commit failure and leaves the working proxy/routing untouched.

Closes #1454

## Verification

- Exact base: `origin/dev` at `87e3ff9f6`.
- `taskset -c 0-1 nice -n 10 bun test` across 18 Windows service/UAC and adjacent CLI files: **406 pass, 0 fail**.
- `taskset -c 0-1 nice -n 10 bun run typecheck`: passed.
- `taskset -c 0-1 nice -n 10 bun run privacy:scan`: passed.
- `cd docs-site && bun install --frozen-lockfile`: no changes.
- `cd docs-site && taskset -c 0-1 nice -n 10 bun run build`: **221 pages built**.
- Full suite before the final upstream rebase: **10,947 pass, 11 skip, 1 fail**. The one failure, `Codex autostart shim > Unix shim exports persisted service API token before running Codex`, reproduces on clean `dev` and is unrelated to this Windows scheduler change. After rebasing, the exact-head focused suite, typecheck, privacy scan, and docs build above were rerun successfully.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Because this changes Windows elevation and service lifecycle boundaries, please keep the PR in draft until an independent maintainer completes the required security review and Windows smoke test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows service installation safety by registering and verifying the scheduler task before stopping an existing proxy or replacing service assets.
  * Cancelled or denied elevation now preserves the active proxy and routing.
  * Windows installation no longer times out during UAC approval or extended setup.
  * Failed registrations automatically roll back temporary changes and clean up staged files.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->