### PR TITLE
fix(openai-chat): tolerate null tool-call padding

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -975,10 +975,11 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
           }
 
           const rawToolCalls = delta.tool_calls;
-          if (rawToolCalls !== undefined) {
-            // A claimed tool-call payload is not benign padding. Dropping it can leave the
+          if (rawToolCalls !== undefined && rawToolCalls !== null) {
+            // A non-null claimed tool-call payload is not benign padding. Dropping it can leave the
             // matching result permanently orphaned, so malformed nested shapes fail closed
-            // through the adapter error channel instead of escaping as TypeError (#1325).
+            // through the adapter error channel instead of escaping as TypeError (#1325). Null is
+            // tolerated as absent because OpenAI-compatible providers may emit it as stream padding.
             if (!Array.isArray(rawToolCalls)) {
               return yield* terminateWithError(invalidToolCallsEvent(pendingUsage));
             }
@@ -1146,7 +1147,7 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
         if (reasoningText !== undefined) events.push({ type: "reasoning_raw_delta", text: reasoningText });
         if (typeof msg.content === "string") events.push({ type: "text_delta", text: msg.content });
         const rawToolCalls = msg.tool_calls;
-        if (rawToolCalls !== undefined) {
+        if (rawToolCalls !== undefined && rawToolCalls !== null) {
           if (!Array.isArray(rawToolCalls)) return [invalidToolCallsEvent(usage)];
           for (const rawToolCall of rawToolCalls) {
             if (!isRecord(rawToolCall) || !isRecord(rawToolCall.function)) {

--- a/tests/openai-chat-hardening.test.ts
+++ b/tests/openai-chat-hardening.test.ts
@@ -117,6 +117,19 @@ describe("openai-chat non-stream response hardening", () => {
     expect(events).toEqual([{ type: "error", message: "upstream response contained invalid choices" }]);
   });
 
+  test("treats null tool calls as absent", async () => {
+    const adapter = createOpenAIChatAdapter(provider());
+    const events = await adapter.parseResponse!(new Response(JSON.stringify({
+      choices: [{ message: { role: "assistant", content: "ok", tool_calls: null } }],
+      usage: { prompt_tokens: 7, completion_tokens: 2 },
+    })));
+
+    expect(events).toEqual([
+      { type: "text_delta", text: "ok" },
+      { type: "done", usage: { inputTokens: 7, outputTokens: 2 } },
+    ]);
+  });
+
   test("rejects malformed nested tool calls without throwing", async () => {
     const adapter = createOpenAIChatAdapter(provider());
     for (const toolCalls of [
@@ -178,6 +191,21 @@ describe("openai-chat stream response hardening", () => {
 
     expect(events.at(-1)).toEqual({ type: "error", message: "malformed upstream SSE data frame" });
     expect(events.some(event => event.type === "done")).toBe(false);
+  });
+
+  test("treats null streaming tool calls as padding", async () => {
+    const adapter = createOpenAIChatAdapter(provider());
+    const response = new Response([
+      'data: {"choices":[{"delta":{"content":"ok","tool_calls":null}}]}\n\n',
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":2}}\n\n',
+      "data: [DONE]\n\n",
+    ].join(""));
+
+    const events = await collect(adapter.parseStream(response));
+    expect(events).toEqual([
+      { type: "text_delta", text: "ok" },
+      { type: "done", usage: { inputTokens: 7, outputTokens: 2 } },
+    ]);
   });
 
   test("malformed nested streaming tool calls are terminal errors", async () => {


### PR DESCRIPTION
## Summary

- Treat explicit `tool_calls: null` as an absent optional field in streamed and buffered OpenAI-compatible responses.
- Preserve the fail-closed validation introduced for malformed non-null containers and entries in #1325.
- Add focused regression coverage for both response modes.

This restores compatibility with providers that use `null` as padding when no tool call is present, without accepting malformed claimed tool-call payloads.

## Verification

- `bun test tests/openai-chat-hardening.test.ts`
- `bun run typecheck`
- `bun run test`
- `bun run privacy:scan`

No documentation change is needed because this is an internal adapter compatibility correction with no configuration or public API change.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of OpenAI chat responses where tool-call data is `null`.
  * Text output and completion usage are now preserved without unnecessary errors.
  * Malformed, non-null tool-call data continues to be reported appropriately.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->