### PR TITLE
fix(codex): fence native reads for foreign service-home ownership

### DIFF
--- a/src/codex/native-profile-startup.ts
+++ b/src/codex/native-profile-startup.ts
@@ -20,8 +20,15 @@ export type NativeMainStartupGateSnapshot =
   | { status: "ready"; homeId: string | null }
   | {
       status: "blocked";
-      homeId: string;
-      reason: "recovery-pending" | "manual-recovery" | "owner-conflict" | "owner-unavailable" | "stage-cleanup-required";
+      homeId: string | null;
+      reason:
+        | "foreign-ownership"
+        | "ownership-unknown"
+        | "recovery-pending"
+        | "manual-recovery"
+        | "owner-conflict"
+        | "owner-unavailable"
+        | "stage-cleanup-required";
     };
 
 export interface NativeMainStartupGateDeps {
@@ -42,6 +49,10 @@ export interface NativeMainStartupLifecycle {
 let epoch = 0;
 let snapshot: NativeMainStartupGateSnapshot = { status: "ready", homeId: null };
 let settled: Promise<NativeMainStartupGateSnapshot> = Promise.resolve(snapshot);
+export type NativeMainServiceOwnershipBlockReason =
+  | "foreign-ownership"
+  | "ownership-unknown";
+const serviceOwnershipRefs = new Map<NativeMainServiceOwnershipBlockReason, number>();
 interface StartupEntry {
   homeId: string;
   refs: number;
@@ -295,6 +306,37 @@ export function startNativeMainStartupLifecycle(
   };
 }
 
+function activeServiceOwnershipBlockReason(): NativeMainServiceOwnershipBlockReason | null {
+  if ((serviceOwnershipRefs.get("foreign-ownership") ?? 0) > 0) return "foreign-ownership";
+  if ((serviceOwnershipRefs.get("ownership-unknown") ?? 0) > 0) return "ownership-unknown";
+  return null;
+}
+
+function serviceOwnershipSnapshot(
+  reason: NativeMainServiceOwnershipBlockReason,
+): NativeMainStartupGateSnapshot {
+  return { status: "blocked", homeId: null, reason };
+}
+
+/** Close native-main admission without resolving or creating any CODEX_HOME artifacts. */
+export function blockNativeMainStartupForUnownedServiceHome(
+  reason: NativeMainServiceOwnershipBlockReason,
+): NativeMainStartupLifecycle {
+  serviceOwnershipRefs.set(reason, (serviceOwnershipRefs.get(reason) ?? 0) + 1);
+  let released = false;
+  return {
+    homeId: null,
+    settled: Promise.resolve(serviceOwnershipSnapshot(reason)),
+    async release() {
+      if (released) return;
+      released = true;
+      const remaining = Math.max(0, (serviceOwnershipRefs.get(reason) ?? 0) - 1);
+      if (remaining === 0) serviceOwnershipRefs.delete(reason);
+      else serviceOwnershipRefs.set(reason, remaining);
+    },
+  };
+}
+
 export function bindNativeMainStartupLifecycle(server: object, lifecycle: NativeMainStartupLifecycle): void {
   serverLifecycles.set(server, lifecycle);
 }
@@ -307,7 +349,7 @@ export async function releaseNativeMainStartupLifecycle(server: object): Promise
 }
 
 export function isNativeMainTrafficBlocked(): boolean {
-  return snapshot.status === "blocked";
+  return activeServiceOwnershipBlockReason() !== null || snapshot.status === "blocked";
 }
 
 /**
@@ -340,9 +382,13 @@ export function completeNativeMainRecovery(homeId: string): boolean {
 }
 
 export function nativeMainStartupGateSnapshot(): NativeMainStartupGateSnapshot {
+  const reason = activeServiceOwnershipBlockReason();
+  if (reason) return serviceOwnershipSnapshot(reason);
   return { ...snapshot };
 }
 
 export function waitForNativeMainStartupGate(): Promise<NativeMainStartupGateSnapshot> {
+  const reason = activeServiceOwnershipBlockReason();
+  if (reason) return Promise.resolve(serviceOwnershipSnapshot(reason));
   return settled;
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -24,7 +24,10 @@ import { withCatalogWriteSerialization } from "../codex/catalog-write-serializat
 import { invalidateCodexModelsCacheWithPermit } from "../codex/catalog/sync";
 import { getCodexHome } from "../codex/paths";
 import { shouldSyncCodexOnStart } from "../codex/desired-state";
-import { inspectNativeCodexOwnership } from "../integrations/native/ownership-preflight";
+import {
+  inspectNativeCodexOwnership,
+  type OwnershipInspection,
+} from "../integrations/native/ownership-preflight";
 import { registerCodexCooldownRecoveryProbeWorker } from "../codex/auth-api";
 import {
   reconcileLiveStateStores,
@@ -169,6 +172,7 @@ import { buildDesktop3pRegistry } from "../claude/desktop-3p";
 import { runClaudeAuthModeMigration } from "../claude/auth-mode-migration";
 import {
   bindNativeMainStartupLifecycle,
+  blockNativeMainStartupForUnownedServiceHome,
   releaseNativeMainStartupLifecycle,
   startNativeMainStartupLifecycle,
   type NativeMainStartupGateDeps,
@@ -433,12 +437,25 @@ export interface StartServerDeps {
   managementApi?: ManagementApiDeps;
   /** Test-only native-main recovery dependencies; production constructs the normal manager. */
   nativeMainStartup?: NativeMainStartupGateDeps;
+  /** Test-only ownership evidence; production inspects the installed service state. */
+  inspectNativeCodexOwnership?: typeof inspectNativeCodexOwnership;
   /** Test-only seam for an upstream that cannot complete its WebSocket close handshake. */
   liveSidebandWebSocketFactory?: LiveSidebandWebSocketFactory;
   /** Test-only seam; production derives a fresh local-attestation secret per process. */
   localAttestationSecret?: string;
   /** Optional readiness gate; a fresh pending gate is created when omitted. */
   readinessGate?: ReadinessGate;
+}
+
+function inspectStartupOwnership(deps: StartServerDeps): OwnershipInspection {
+  try {
+    return (deps.inspectNativeCodexOwnership ?? inspectNativeCodexOwnership)();
+  } catch {
+    return {
+      ownership: "unknown",
+      reason: "service-home ownership inspection failed",
+    };
+  }
 }
 
 /*
@@ -505,21 +522,28 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
       if (migrated) saveConfig(config);
     }
   }
+  // Resolve unattended service-home authority before any Codex lock, cache, owner,
+  // journal, or credential path. Both positive foreign evidence and an unprovable
+  // ownership state are non-authority.
+  startupCacheInvalidationWrote = false;
+  const startupCacheOwnership = inspectStartupOwnership(deps);
   // Startup cache invalidation is best-effort and must never block the server from
   // serving. It now takes K so it cannot race a convergence commit, but both the
   // home resolution and the acquisition can fail on a machine with no Codex home —
   // `getCodexHome()` THROWS when CODEX_HOME names a missing directory, which would
   // otherwise turn "no Codex installed" into "proxy will not start".
-  try {
-    const startupCodexHome = getCodexHome();
-    // #1046: record whether this actually rewrote the cache. `handleStart` ORs this
-    // with the later startup sync and warns ONCE about stale app-servers; warning
-    // here instead would read a catalog mtime the sync is about to move.
-    const outcome = withCatalogWriteSerialization(startupCodexHome, permit =>
-      invalidateCodexModelsCacheWithPermit(permit, startupCodexHome));
-    // A refused permit is not a write; only a completed run that returned true is.
-    startupCacheInvalidationWrote = outcome.kind === "completed" && outcome.value === true;
-  } catch { /* no readable Codex home: nothing to invalidate */ }
+  if (startupCacheOwnership.ownership === "owned") {
+    try {
+      const startupCodexHome = getCodexHome();
+      // #1046: record whether this actually rewrote the cache. `handleStart` ORs this
+      // with the later startup sync and warns ONCE about stale app-servers; warning
+      // here instead would read a catalog mtime the sync is about to move.
+      const outcome = withCatalogWriteSerialization(startupCodexHome, permit =>
+        invalidateCodexModelsCacheWithPermit(permit, startupCodexHome));
+      // A refused permit is not a write; only a completed run that returned true is.
+      startupCacheInvalidationWrote = outcome.kind === "completed" && outcome.value === true;
+    } catch { /* no readable Codex home: nothing to invalidate */ }
+  }
   // Arm the `claudeCode` hand-edit guard (devlog 260726_claude_auth_auto/040 H1) BEFORE
   // the server can serve a request, and AFTER the startup migrations above — those run
   // against a config nobody else holds and are the documented exception to the save
@@ -658,10 +682,15 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
   // CODEX_HOME. When the user has disabled the Codex integration, starting the
   // proxy must not manufacture those Codex artifacts merely to serve other
   // clients; no Codex request can use this lifecycle in that state.
-  const nativeOwnership = inspectNativeCodexOwnership();
+  // Re-probe here instead of trusting the earlier cache decision: startup work
+  // between the two sites must not widen the service-install race.
+  const nativeOwnership = inspectStartupOwnership(deps);
   const nativeMainLifecycle: NativeMainStartupLifecycle = shouldSyncCodexOnStart(config)
-    && nativeOwnership.ownership !== "foreign"
-    ? startNativeMainStartupLifecycle(deps.nativeMainStartup)
+    ? nativeOwnership.ownership === "owned"
+      ? startNativeMainStartupLifecycle(deps.nativeMainStartup)
+      : blockNativeMainStartupForUnownedServiceHome(
+        nativeOwnership.ownership === "foreign" ? "foreign-ownership" : "ownership-unknown",
+      )
     : {
       homeId: null,
       settled: Promise.resolve({ status: "ready", homeId: null }),

--- a/tests/codex-composed-acceptance.test.ts
+++ b/tests/codex-composed-acceptance.test.ts
@@ -194,7 +194,9 @@ class Fixture {
       server.process.exited,
       new Promise<never>((_, reject) => setTimeout(() => reject(new Error("server shutdown watchdog")), 10_000)),
     ]);
-    expect(exitCode).toBe(0);
+    // Bun reports a forced SIGTERM as 128 + 15 on Windows; POSIX children may
+    // run the CLI shutdown handler and exit cleanly instead.
+    expect(exitCode === 0 || (process.platform === "win32" && exitCode === 143)).toBe(true);
   }
 
   async request(runtime: RuntimeRecord, path: string, init: RequestInit = {}): Promise<{ status: number; body: Record<string, unknown> }> {
@@ -350,7 +352,33 @@ describe("WP13 composed toggle acceptance", () => {
   /** RED: omit `admitCodexWrite` ownership refusal; start/ensure/P19 create a coordinator or native artifact. */
   test("D-reduced: foreign service-home evidence refuses real CLI and HTTP writers before artifacts", async () => {
     const fx = fixture();
-    fx.writeConfig();
+    fx.writeConfig({
+      defaultProvider: "openai",
+      providers: {
+        openai: {
+          adapter: "openai-responses",
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+          authMode: "forward",
+          codexAccountMode: "pool",
+        },
+      },
+      codexAccounts: [],
+      activeCodexAccountId: "__main__",
+      autoSwitchThreshold: 0,
+    });
+    const expiredPayload = Buffer.from(JSON.stringify({
+      exp: Math.floor(Date.now() / 1000) - 60,
+    })).toString("base64url");
+    writeFileSync(join(fx.codex, "auth.json"), JSON.stringify({
+      tokens: {
+        access_token: `header.${expiredPayload}.signature`,
+        account_id: "foreign-main-account",
+      },
+    }));
+    writeFileSync(join(fx.codex, "opencodex-catalog.json"), JSON.stringify({
+      models: [{ slug: "foreign-sentinel" }],
+    }));
+    writeFileSync(join(fx.codex, "models_cache.json"), "foreign-cache-sentinel\n");
     writeFileSync(join(fx.ocx, "service-state.json"), JSON.stringify({
       version: 2,
       codexHome: join(fx.root, "foreign-codex"),
@@ -360,6 +388,11 @@ describe("WP13 composed toggle acceptance", () => {
     const before = manifest(fx.codex);
     const server = await fx.start();
     try {
+      const nativeRead = await fx.request(server.runtime, "/v1/responses", {
+        method: "POST",
+        body: JSON.stringify({ model: "openai/gpt-test", input: "foreign owner", stream: false }),
+      });
+      expect(nativeRead.status).toBe(503);
       const ensure = await fx.runCli(["ensure"]);
       expect(ensure.exitCode).toBe(0);
       const sync = await fx.request(server.runtime, "/api/sync", { method: "POST" });
@@ -367,6 +400,51 @@ describe("WP13 composed toggle acceptance", () => {
       expect(String(sync.body.message ?? sync.body.error)).toMatch(/Refusing|service|ownership/i);
       const restore = await fx.runCli(["restore"]);
       expect(restore.exitCode).toBe(1);
+      expect(manifest(fx.codex)).toEqual(before);
+      expect(fx.lockAllowlist.some(existsSync)).toBe(false);
+    } finally {
+      await fx.stop(server);
+    }
+  }, 45_000);
+
+  test("D-unknown: unprovable service-home ownership refuses native reads and cache writes", async () => {
+    const fx = fixture();
+    fx.writeConfig({
+      defaultProvider: "openai",
+      providers: {
+        openai: {
+          adapter: "openai-responses",
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+          authMode: "forward",
+          codexAccountMode: "pool",
+        },
+      },
+      codexAccounts: [],
+      activeCodexAccountId: "__main__",
+      autoSwitchThreshold: 0,
+    });
+    writeFileSync(join(fx.codex, "auth.json"), JSON.stringify({
+      tokens: {
+        access_token: "opaque-main-token",
+        account_id: "unknown-main-account",
+      },
+    }));
+    writeFileSync(join(fx.codex, "opencodex-catalog.json"), JSON.stringify({
+      models: [{ slug: "unknown-sentinel" }],
+    }));
+    writeFileSync(join(fx.codex, "models_cache.json"), "unknown-cache-sentinel\n");
+    writeFileSync(join(fx.ocx, "service-state.json"), "{malformed-service-state\n");
+    const before = manifest(fx.codex);
+    const server = await fx.start();
+    try {
+      const nativeRead = await fx.request(server.runtime, "/v1/responses", {
+        method: "POST",
+        body: JSON.stringify({ model: "openai/gpt-test", input: "unknown owner", stream: false }),
+      });
+      expect(nativeRead.status).toBe(503);
+      const sync = await fx.request(server.runtime, "/api/sync", { method: "POST" });
+      expect(sync.status).toBe(409);
+      expect(String(sync.body.message ?? sync.body.error)).toMatch(/ownership|proven|read|malformed/i);
       expect(manifest(fx.codex)).toEqual(before);
       expect(fx.lockAllowlist.some(existsSync)).toBe(false);
     } finally {

--- a/tests/helpers/native-profile-startup-child.ts
+++ b/tests/helpers/native-profile-startup-child.ts
@@ -58,6 +58,10 @@ globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promis
 }) as typeof fetch;
 
 const server = startServer(0, {
+  inspectNativeCodexOwnership: () => ({
+    ownership: "owned",
+    reason: "native startup test fixture",
+  }),
   nativeMainStartup: {
     manager,
     beforeRecovery: async () => {

--- a/tests/native-profile-startup.test.ts
+++ b/tests/native-profile-startup.test.ts
@@ -30,6 +30,7 @@ import type {
 } from "../src/codex/native-profile-types";
 import type { OcxConfig } from "../src/types";
 import {
+  blockNativeMainStartupForUnownedServiceHome,
   initializeNativeMainStartupGate,
   isNativeMainTrafficBlocked,
   nativeMainStartupGateSnapshot,
@@ -286,6 +287,48 @@ const recoverable: Array<{ phase: Phase; observation: Observation; active: "sour
 ];
 
 describe("native-main startup journal gate", () => {
+  test("unowned service homes close native-main admission without starting ownership", async () => {
+    const foreign = blockNativeMainStartupForUnownedServiceHome("foreign-ownership");
+    const unknown = blockNativeMainStartupForUnownedServiceHome("ownership-unknown");
+    try {
+      expect(nativeMainStartupGateSnapshot()).toEqual({
+        status: "blocked",
+        homeId: null,
+        reason: "foreign-ownership",
+      });
+      expect(isNativeMainTrafficBlocked()).toBe(true);
+      expect(tryClaimNativeMainProfileForTurn()).toBe(false);
+      expect(tryAcquireNativeMainProfileClaim()).toBeNull();
+      expect(getNativeMainProfileRequestCount()).toBe(0);
+
+      expect(await initializeNativeMainStartupGate({
+        manager: { context: { homeId: "competing-owned-home" } } as unknown as NativeProfileManager,
+        probeRecoveryState: () => "none",
+      })).toEqual({ status: "ready", homeId: "competing-owned-home" });
+      expect(nativeMainStartupGateSnapshot()).toEqual({
+        status: "blocked",
+        homeId: null,
+        reason: "foreign-ownership",
+      });
+
+      await foreign.release();
+      expect(isNativeMainTrafficBlocked()).toBe(true);
+      expect(nativeMainStartupGateSnapshot()).toEqual({
+        status: "blocked",
+        homeId: null,
+        reason: "ownership-unknown",
+      });
+      await foreign.release();
+      expect(isNativeMainTrafficBlocked()).toBe(true);
+      await unknown.release();
+      expect(isNativeMainTrafficBlocked()).toBe(false);
+      expect(nativeMainStartupGateSnapshot()).toEqual({ status: "ready", homeId: "competing-owned-home" });
+    } finally {
+      await foreign.release();
+      await unknown.release();
+    }
+  });
+
   test("combined turn and standalone claims reject retained recovery before native-main reads", async () => {
     const homeId = "home-combined-admission";
     resetLifecycleDrainStateForTests();


### PR DESCRIPTION
## Summary

- fail closed for both foreign and unprovable (`unknown`) service-home ownership before native-main credential admission
- gate startup cache invalidation before catalog, lock, or CODEX_HOME mutations, then re-check ownership immediately before selecting the native startup lifecycle
- keep the service-ownership fence process-wide, reason-aware, reference-counted, and safe under duplicate release
- add real-server regression coverage proving native requests and sync are rejected while auth, catalog, cache, and coordinator-lock bytes remain unchanged

Before this change, `startServer()` returned a dummy ready lifecycle only for `ownership === "foreign"`. An `unknown` ownership result could still enter the native startup lifecycle, and startup cache invalidation ran before the ownership boundary was applied.

The blocked lifecycle now contributes a process-wide service-ownership fence without inspecting, resolving, or creating native Codex artifacts. Owned startup behavior and Pool-account behavior remain unchanged.

## Verification

- Bun 1.4.0-canary.1: `bun test --isolate --timeout 30000 tests/native-profile-startup.test.ts` — 13 passed, 0 failed, 162 expects
- Bun 1.3.14: `bun test --isolate --timeout 30000 tests/native-profile-startup.test.ts` — 13 passed, 0 failed, 162 expects
- Bun 1.4.0-canary.1: focused foreign/unknown real-server regressions — 2 passed, 0 failed, 16 expects
- Bun 1.3.14: focused foreign/unknown real-server regressions — 2 passed, 0 failed, 16 expects
- Bun 1.4.0-canary.1: `bun x --package typescript@7.0.2 tsc --noEmit` — passed
- Bun 1.3.14: `bun x --package typescript@7.0.2 tsc --noEmit` — passed
- Bun 1.4.0-canary.1: `bun run privacy:scan` — passed
- `git diff --check HEAD^..HEAD` — passed

The full repository suite was not rerun locally: an earlier monolithic Windows run hit unrelated live-service/runtime teardown failures. The affected focused suites above were rerun cleanly on both supported test runtimes.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. This is an internal startup/admission correction with no user-facing configuration or API change.
- [x] Security-sensitive changes were reviewed for credential access, lifecycle races, and fail-closed behavior.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
