### PR TITLE
ci: classify Bun epoll faults as runtime crashes

### DIFF
--- a/scripts/ci/run-bun-test-batches.sh
+++ b/scripts/ci/run-bun-test-batches.sh
@@ -67,6 +67,16 @@ is_bun_runtime_crash() {
       ;;
   esac
 
+  # Bun 1.3.14 can surface a Linux epoll registration failure as exit 1,
+  # even though the failure comes from Bun's internal WriteStream setup rather
+  # than a test assertion. Treat only that narrow runtime signature as a crash.
+  if (( status == 1 )) \
+    && grep -Fq '# Unhandled error between tests' "$log_file" \
+    && grep -Fq 'error: EEXIST: file already exists, epoll_ctl' "$log_file" \
+    && grep -Fq 'at new WriteStream (internal:fs/streams:' "$log_file"; then
+    return 0
+  fi
+
   grep -Eqi \
     'oh no: Bun has crashed|Segmentation fault at address|Illegal instruction|Bus error|Aborted \(core dumped\)' \
     "$log_file"


### PR DESCRIPTION
## Summary

- Classify Bun 1.3.14's Linux `EEXIST: file already exists, epoll_ctl` failure from internal `WriteStream` setup as a Bun runtime crash even when Bun exits with status 1.
- Route that narrow signature through the singleton recovery path added in #1469 instead of treating it as an assertion/test failure and aborting the shard.
- Keep ordinary exit-1 assertion failures fail-fast. The new detector requires the Bun "Unhandled error between tests" marker, the exact `epoll_ctl` error, and an `internal:fs/streams` `WriteStream` frame.

This addresses the runtime failure seen in the Linux test shard for #1457, where the existing #1469 fallback was skipped because the Bun runtime fault exited with status 1.

## Verification

- `bash -n scripts/ci/run-bun-test-batches.sh` — pass.
- Replayed the exact captured failure log against the classifier: current `dev` detector does not classify the exit-1 `epoll_ctl` fault as runtime; patched detector does.
- End-to-end fake-Bun probe against the full batch helper:
  - exact internal `epoll_ctl` runtime signature on a two-file batch -> classified as runtime, singleton recovery runs, both singleton processes pass, helper exits 0;
  - ordinary assertion failure with exit 1 -> no singleton retry, helper exits 1;
  - `EEXIST ... epoll_ctl` without Bun's internal `WriteStream` frame -> no singleton retry, helper exits 1.
- Reconstructed the pre-change script byte-for-byte and verified its Git blob SHA matched `dev` (`6031deb91f78ca7d93f087719c5c460ec9f9ee95`) before applying the 10-line patch.
- Full `bun run typecheck` / `bun run test` were not executable in the current tool environment because it does not have a Bun binary. Repository CI should provide the Bun-native validation.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. No user-facing behavior changed, so no docs update is needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. This changes only failure classification in the bounded CI test helper; it does not change credentials, permissions, workflows, or external inputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Bun runtime crashes by requiring specific crash indicators in test logs.
  * Reduced the risk of incorrectly classifying unrelated status-1 test failures as runtime crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->