### PR TITLE
fix(oauth): continue manual flow when callback port is occupied

### DIFF
--- a/docs-site/src/content/docs/reference/configuration/server.md
+++ b/docs-site/src/content/docs/reference/configuration/server.md
@@ -122,10 +122,11 @@ port too:
 ssh -L 20100:localhost:10100 -L 1455:localhost:1455 you@remote
 ```
 
-If a registered callback port is already in use and the login surface offers manual input, the flow
-still returns the provider authorization URL. Complete the provider login, then copy the full failed
-callback URL from the browser address bar and paste it into OpenCodex. The URL is validated against
-the pending flow's state and PKCE session. Callers without manual input still fail closed.
+If a registered callback port is already in use and the login surface offers manual input, OpenCodex
+keeps the registered redirect URI and still returns the provider authorization URL. Complete the
+provider login, then paste the final redirect URL from the browser address bar or the authorization
+code into OpenCodex. The pending flow preserves state and PKCE validation. Callers without manual
+input still fail closed.
 
 :::caution[Forwarded loopback is unauthenticated]
 Plain `ssh -L` listens on your local loopback and is safe for the default unauthenticated bind. Do not

--- a/docs-site/src/content/docs/reference/configuration/server.md
+++ b/docs-site/src/content/docs/reference/configuration/server.md
@@ -122,6 +122,11 @@ port too:
 ssh -L 20100:localhost:10100 -L 1455:localhost:1455 you@remote
 ```
 
+If a registered callback port is already in use and the login surface offers manual input, the flow
+still returns the provider authorization URL. Complete the provider login, then copy the full failed
+callback URL from the browser address bar and paste it into OpenCodex. The URL is validated against
+the pending flow's state and PKCE session. Callers without manual input still fail closed.
+
 :::caution[Forwarded loopback is unauthenticated]
 Plain `ssh -L` listens on your local loopback and is safe for the default unauthenticated bind. Do not
 use `ssh -g -L`, broad container publishing, or forwarding modes that expose the client side on

--- a/src/oauth/callback-server.ts
+++ b/src/oauth/callback-server.ts
@@ -5,7 +5,7 @@
  * Change vs source: the success/error page is an inline HTML constant. opencodex's GUI polls
  * GET /api/oauth/status, so it does not need OAuth state injected into the callback page.
  *
- * Handles: port allocation (preferred → random fallback), callback server, CSRF state,
+ * Handles: port allocation (preferred → random/manual-only fallback), callback server, CSRF state,
  * manual-input race, 300s timeout. Providers implement generateAuthUrl() + exchangeToken().
  */
 import { isAddrInUse } from "../server/ports";
@@ -131,8 +131,14 @@ export abstract class OAuthCallbackFlow {
       }
       const redirectUri = `http://${this.callbackHostname}:${this.preferredPort}${this.callbackPath}`;
       return { servers, redirectUri };
-    } catch {
+    } catch (error) {
       if (this.redirectUri) {
+        // Fixed OAuth redirect URIs cannot move to a random port. Remote dashboards can
+        // still complete the same state/PKCE flow by pasting the final redirect URL or
+        // authorization code, so do not make a local listener a prerequisite for that path.
+        if (this.ctrl.onManualCodeInput && isAddrInUse(error)) {
+          return { servers: [], redirectUri: this.redirectUri };
+        }
         throw new Error(
           `OAuth callback port ${this.preferredPort} unavailable; cannot fall back to a random port when redirectUri is set`,
         );

--- a/structure/05_gui-and-management-api.md
+++ b/structure/05_gui-and-management-api.md
@@ -276,6 +276,11 @@ OAuth polling API: submit request, waiting-for-login completion, and terminal su
 `aria-live` status message that the code was accepted, and surface repeated `login-status` polling
 network failures as a visible warning instead of silently looking idle again.
 
+Fixed provider redirect URIs keep their registered port. If that port is already in use, a login
+controller with `onManualCodeInput` enters manual-only mode: it must still publish the authorization
+URL and accept the final redirect URL or code through the same state/PKCE session. A controller
+without manual input must fail closed; it must not silently move a fixed redirect URI to another port.
+
 The account-targeting control reads the effective flag from `GET /api/settings`; it must not infer
 state from the redacted config DTO or expose selector mappings. It renders no actionable off switch
 before hydration, serializes rapid clicks, rejects stale poll results that started before a mutation,

--- a/tests/oauth-callback-server.test.ts
+++ b/tests/oauth-callback-server.test.ts
@@ -12,6 +12,21 @@ class TestFlow extends OAuthCallbackFlow {
   }
 }
 
+class ManualFallbackFlow extends OAuthCallbackFlow {
+  generated?: { state: string; redirectUri: string };
+  exchanged?: { code: string; state: string; redirectUri: string };
+
+  async generateAuthUrl(state: string, redirectUri: string): Promise<{ url: string }> {
+    this.generated = { state, redirectUri };
+    return { url: `https://example.test/auth?state=${state}` };
+  }
+
+  async exchangeToken(code: string, state: string, redirectUri: string): Promise<OAuthCredentials> {
+    this.exchanged = { code, state, redirectUri };
+    return { access: "access", refresh: "refresh", expires: Date.now() + 60_000 };
+  }
+}
+
 const ctrl: OAuthController = {};
 
 describe("OAuth callback server defaults", () => {
@@ -31,5 +46,74 @@ describe("OAuth callback server defaults", () => {
     });
 
     expect(flow.callbackBindHostname).toBe("127.0.0.1");
+  });
+
+  test("continues with manual input when an exact redirect port is unavailable", async () => {
+    const blocker = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      reusePort: false,
+      fetch: () => new Response("occupied"),
+    });
+    const redirectUri = `http://127.0.0.1:${blocker.port}/callback`;
+    let authUrl = "";
+    const flow = new ManualFallbackFlow(
+      {
+        onAuth: ({ url }) => {
+          authUrl = url;
+        },
+        onManualCodeInput: async () => "manual-code",
+      },
+      {
+        preferredPort: blocker.port,
+        callbackPath: "/callback",
+        callbackHostname: "127.0.0.1",
+        callbackBindHostname: "127.0.0.1",
+        redirectUri,
+      },
+    );
+
+    try {
+      const credential = await flow.login();
+
+      expect(authUrl).toStartWith("https://example.test/auth?state=");
+      expect(flow.generated?.redirectUri).toBe(redirectUri);
+      expect(flow.exchanged).toEqual({
+        code: "manual-code",
+        state: flow.generated?.state,
+        redirectUri,
+      });
+      expect(credential.access).toBe("access");
+    } finally {
+      blocker.stop(true);
+    }
+  });
+
+  test("fails closed when an exact redirect port is unavailable without manual input", async () => {
+    const blocker = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      reusePort: false,
+      fetch: () => new Response("occupied"),
+    });
+    const redirectUri = `http://127.0.0.1:${blocker.port}/callback`;
+    const flow = new TestFlow(
+      {},
+      {
+        preferredPort: blocker.port,
+        callbackPath: "/callback",
+        callbackHostname: "127.0.0.1",
+        callbackBindHostname: "127.0.0.1",
+        redirectUri,
+      },
+    );
+
+    try {
+      await expect(flow.login()).rejects.toThrow(
+        `OAuth callback port ${blocker.port} unavailable; cannot fall back to a random port when redirectUri is set`,
+      );
+    } finally {
+      blocker.stop(true);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Continue an exact-redirect OAuth flow without a local callback listener when the bind fails with `EADDRINUSE` and the controller provides manual callback input.
- Preserve the registered redirect URI and the existing state/PKCE validation; callers without manual input still fail closed.
- Document the remote-login behavior and its security boundary.

This fixes remote account login when Windows/WSL reserves the provider's fixed callback port (for ChatGPT, `localhost:1455`). The authorization URL can now be returned and the final redirect URL or authorization code can be pasted into the same pending flow.

## Verification

- `bun test tests/oauth-callback-server.test.ts tests/oauth-callback-binds.test.ts tests/oauth-manual-code.test.ts` — 18 passed.
- `bun test tests/codex-auth-api.test.ts` — 198 passed.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- Live deployment on OpenCodex 2.12.0: port 1455 still returned `EADDRINUSE`, while the account-login surface returned the provider authorization URL and manual redirect/code input. The verification flow was cancelled before provider login or token exchange.
- `bun run test` — 10,816 passed, 8 skipped, 78 failed in unrelated management-auth, Lab, provider-management, and usage-attribution suites. A clean detached `origin/dev` worktree reproduced the representative `tests/server-management-auth.test.ts` baseline (12 passed, 10 failed with the same 503 responses).

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added manual recovery for provider sign-in when the configured callback port is unavailable.
  - Users can open the authorization link and submit the resulting callback URL or code when manual input is supported.
  - Callback details are validated against the active sign-in session.
  - Fixed callback ports are preserved during manual recovery.

- **Bug Fixes**
  - Sign-in now fails safely when manual recovery is unavailable instead of switching to an unintended port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->