### PR TITLE
fix(gui): prevent accidental Add Provider modal dismissal

### DIFF
--- a/gui/src/components/AddProviderModal.tsx
+++ b/gui/src/components/AddProviderModal.tsx
@@ -229,8 +229,12 @@ export default function AddProviderModal({
 
   return (
     <>
-    <div role="dialog" aria-modal="true" aria-label={t("modal.add")} className="modal-overlay" onClick={onClose}>
-      <div ref={dialogRef} className="modal-card" onClick={e => e.stopPropagation()}>
+    {/* The backdrop must not dismiss this modal: a stray click — or a text
+        selection drag that is released outside the card — would wipe every
+        field the user already filled in. Close only via the × button,
+        Escape, or a successful add. */}
+    <div role="dialog" aria-modal="true" aria-label={t("modal.add")} className="modal-overlay">
+      <div ref={dialogRef} className="modal-card">
         <div className="modal-head">
           <h3>{preset ? t("modal.addNamed", { label: preset.label }) : t("modal.add")}</h3>
           <button type="button" className="btn btn-ghost btn-icon" aria-label={t("common.close")} onClick={onClose}><IconX /></button>

--- a/gui/tests/add-provider-modal-backdrop.test.tsx
+++ b/gui/tests/add-provider-modal-backdrop.test.tsx
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act } from "react";
+import type { Root } from "react-dom/client";
+import { LanguageProvider } from "../src/i18n/provider";
+import AddProviderModal from "../src/components/AddProviderModal";
+
+/**
+ * The Add Provider modal collects a name, base URL, and API key before the
+ * user saves anything. Dismissing it on a backdrop click — or on a text
+ * selection drag that is released outside the card — unmounts the modal and
+ * wipes all of that input. The backdrop must therefore never close the
+ * modal; only the × button, Escape, and a successful add may.
+ */
+
+const globals = ["document", "window", "navigator", "localStorage", "IS_REACT_ACT_ENVIRONMENT"] as const;
+let previous: Record<(typeof globals)[number], unknown>;
+let win: Window;
+let host: HTMLElement;
+let root: Root | null = null;
+let originalFetch: typeof globalThis.fetch;
+let closeCalls: number;
+
+beforeEach(() => {
+  previous = Object.fromEntries(globals.map((k) => [k, Reflect.get(globalThis, k)])) as typeof previous;
+  originalFetch = globalThis.fetch;
+  win = new Window({ url: "http://localhost/" });
+  Object.defineProperty(win.navigator, "language", { configurable: true, value: "en-US" });
+  Object.defineProperties(globalThis, {
+    document: { configurable: true, value: win.document },
+    window: { configurable: true, value: win },
+    navigator: { configurable: true, value: win.navigator },
+    localStorage: { configurable: true, value: win.localStorage },
+  });
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+  closeCalls = 0;
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (input: RequestInfo | URL) => {
+      const url = new URL(String(input), "http://localhost");
+      if (url.pathname === "/api/oauth/providers") return Response.json({ providers: [] });
+      if (url.pathname === "/api/provider-presets") return Response.json({ providers: [] });
+      if (url.pathname === "/api/usage") return Response.json({ providers: [] });
+      return Response.json({});
+    },
+  });
+
+  host = win.document.createElement("div") as unknown as HTMLElement;
+  win.document.body.appendChild(host as never);
+});
+
+afterEach(async () => {
+  if (root) {
+    const current = root;
+    await act(async () => { current.unmount(); });
+    root = null;
+  }
+  for (const key of globals) {
+    Object.defineProperty(globalThis, key, { configurable: true, value: previous[key] });
+  }
+  Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
+  await win.happyDOM?.close?.();
+});
+
+async function mountModal() {
+  const { createRoot } = await import("react-dom/client");
+  await act(async () => {
+    root = createRoot(host);
+    root.render(
+      <LanguageProvider>
+        <AddProviderModal
+          apiBase=""
+          existingNames={[]}
+          initialCustom
+          onClose={() => { closeCalls += 1; }}
+          onAdded={() => {}}
+        />
+      </LanguageProvider>,
+    );
+  });
+  await act(async () => { await new Promise((r) => setTimeout(r, 40)); });
+}
+
+function overlay(): HTMLElement {
+  const el = host.querySelector<HTMLElement>(".modal-overlay");
+  expect(el).toBeTruthy();
+  return el!;
+}
+
+function nameInput(): HTMLInputElement {
+  const el = host.querySelector<HTMLInputElement>(".modal-card input.input");
+  expect(el).toBeTruthy();
+  return el!;
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(win.HTMLInputElement.prototype, "value")!.set!;
+  setter.call(input, value);
+  input.dispatchEvent(new win.Event("input", { bubbles: true }));
+}
+
+function click(target: HTMLElement) {
+  target.dispatchEvent(new win.MouseEvent("click", { bubbles: true }));
+}
+
+test("clicking the backdrop neither closes the modal nor discards entered form data", async () => {
+  await mountModal();
+
+  await act(async () => { setInputValue(nameInput(), "my-provider"); });
+  expect(nameInput().value).toBe("my-provider");
+
+  await act(async () => { click(overlay()); });
+
+  expect(closeCalls).toBe(0);
+  expect(host.querySelector(".modal-overlay")).toBeTruthy();
+  expect(nameInput().value).toBe("my-provider");
+});
+
+test("a text-selection drag released on the backdrop does not close the modal", async () => {
+  await mountModal();
+
+  await act(async () => { setInputValue(nameInput(), "sk-live-key-material"); });
+
+  // Press inside the input (starting a selection drag), release on the overlay.
+  await act(async () => {
+    nameInput().dispatchEvent(new win.MouseEvent("mousedown", { bubbles: true }));
+    overlay().dispatchEvent(new win.MouseEvent("mouseup", { bubbles: true }));
+    click(overlay());
+  });
+
+  expect(closeCalls).toBe(0);
+  expect(host.querySelector(".modal-overlay")).toBeTruthy();
+  expect(nameInput().value).toBe("sk-live-key-material");
+});
+
+test("the close button still closes the modal", async () => {
+  await mountModal();
+
+  const closeButton = host.querySelector<HTMLElement>(".modal-head button[aria-label='Close']");
+  expect(closeButton).toBeTruthy();
+  await act(async () => { click(closeButton!); });
+
+  expect(closeCalls).toBe(1);
+});
+
+test("Escape still closes the modal", async () => {
+  await mountModal();
+
+  await act(async () => {
+    win.dispatchEvent(new win.KeyboardEvent("keydown", { key: "Escape" }));
+  });
+
+  expect(closeCalls).toBe(1);
+});


### PR DESCRIPTION
## Summary

**Problem.** The Web Dashboard "Add provider" modal closed whenever the user clicked the modal-overlay backdrop. Two common accidents triggered it: (1) a stray click outside the modal, and (2) drag-selecting text inside an input/textarea where the pointer slides outside the card before release — the resulting click lands on the overlay. Either way the modal unmounted and every field already filled in (provider name, Base URL, API key, default model) was silently discarded.

**Root cause.** `AddProviderModal` wired the overlay directly to dismissal:

```tsx
<div className="modal-overlay" onClick={onClose}>
  <div className="modal-card" onClick={e => e.stopPropagation()}>
```

Because a text-selection drag that starts inside the card and ends on the backdrop still dispatches a `click` whose target is the overlay, `stopPropagation` inside the card cannot protect against it — the click never propagates *through* the card, so this pattern makes backdrop dismissal and drag-release dismissal inseparable.

**Fix.** Remove `onClick={onClose}` from the overlay in `gui/src/components/AddProviderModal.tsx` (and the now-dead `stopPropagation` on the card). The backdrop no longer dismisses the modal at all, which eliminates both failure modes without any event-guessing heuristics. All explicit close paths are preserved: the × button (`aria-label` Close), Escape (the existing `keydown` listener), and the existing close-on-successful-add via `onAdded`. The provider-add flow and all other business logic are untouched; the nested OAuth ToS warning modal is a separate component (`OAuthTosWarningModal`, a native `<dialog>` with its own backdrop-dismiss button) and is unaffected — Escape while it is pending was already gated on `!oauthTosPending`.

No new modal framework, no unrelated refactoring, no version bump.

**Regression tests.** New `gui/tests/add-provider-modal-backdrop.test.tsx` (happy-dom, following the existing `add-provider-oauth-url-leak.test.tsx` harness):

1. opens the modal, types into the provider-name input, clicks the backdrop → modal stays open and the entered value is preserved;
2. simulates a selection drag — `mousedown` inside the input, `mouseup` + `click` on the overlay → modal stays open, input preserved;
3. the × close button still closes the modal;
4. Escape still closes the modal.

Both backdrop tests fail on the pre-fix code (verified by stashing the component change: 2 fail / 2 pass) and pass with the fix.

## Verification

- `cd gui && bun test tests` — 764 pass, 0 fail, 137 files (~39s), including the 4 new regression tests
- `cd gui && bun run lint` — clean, no findings
- `cd gui && bun run build` — Vite build succeeds (`✓ built in 622ms`)
- `bun run typecheck` (repo root, `tsc --noEmit` strict) — clean
- `bun run privacy:scan` — "Privacy scan passed"
- `bun run doctor:gui` (React Doctor, `--base origin/main`) — "No issues found!"
- Real-browser check (headless Chromium against a locally started proxy serving the built GUI): filled name/Base URL/API key, clicked the backdrop, then performed a text-selection drag from inside the name input released on the backdrop — the modal stayed open with all input intact in both cases:

![Add Provider modal still open with form data intact after a backdrop click and a selection drag released on the backdrop](https://raw.githubusercontent.com/Anoyou/opencodex/pr-assets/add-provider-modal-backdrop/assets/add-provider-modal-after-backdrop-click.png)

- `bun run test` (repo root suite): 10990 pass / 60 fail / 8 skip. The 60 failures are pre-existing on a pristine `dev` checkout of this machine (verified by stashing this change and re-running, e.g. `tests/lab-fabric-task.test.ts` and `tests/lab-live-probe.test.ts` fail identically without this PR); they are environment-dependent lab/live-probe harness tests unrelated to `gui/`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup. (2 files: the one-line behavioral fix plus its regression test)
- [x] Docs or release notes were updated when needed. (No user-facing docs change: the modal simply stops dismissing on backdrop click; no configuration, setup, or documented behavior is affected)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (No auth, credential, workflow, release-automation, or dependency surfaces touched)

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The Add Provider modal no longer closes accidentally when clicking the backdrop or selecting text.
  - Modal data remains intact during these interactions.
  - The modal can still be closed using the close button or Escape key, and closes after a successful provider addition.

- **Tests**
  - Added coverage for modal interaction and dismissal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
