### PR TITLE
fix(provider): clamp Xiaomi MiMo public reasoning tiers

### DIFF
--- a/docs-site/src/content/docs/guides/providers.md
+++ b/docs-site/src/content/docs/guides/providers.md
@@ -291,6 +291,7 @@ free-experimentation model.
 | SiliconFlow | `https://api.siliconflow.cn/v1` |
 | Volcengine Ark · Coding Plan · Agent Plan | `https://ark.cn-beijing.volces.com/api/v3` · `https://ark.cn-beijing.volces.com/api/coding/v3` · `https://ark.cn-beijing.volces.com/api/plan/v3` |
 | Xiaomi MiMo | `https://api.xiaomimimo.com/anthropic` |
+| Xiaomi MiMo (OpenAI Chat) | `https://api.xiaomimimo.com/v1` |
 | Kilo | `https://api.kilo.ai/api/gateway` |
 | GitLab Duo | `https://cloud.gitlab.com/ai/v1/proxy/openai/v1` |
 | Cloudflare AI Gateway | `https://gateway.ai.cloudflare.com/v1/{account-id}/{gateway}/anthropic` |

--- a/docs-site/src/content/docs/ja/guides/providers.md
+++ b/docs-site/src/content/docs/ja/guides/providers.md
@@ -218,6 +218,7 @@ Cline IDE/CLI のみで API からは使えません。`minimax/minimax-m2.5` �
 | SiliconFlow | `https://api.siliconflow.cn/v1` |
 | Volcengine Ark · Coding Plan · Agent Plan | `https://ark.cn-beijing.volces.com/api/v3` · `https://ark.cn-beijing.volces.com/api/coding/v3` · `https://ark.cn-beijing.volces.com/api/plan/v3` |
 | Xiaomi MiMo | `https://api.xiaomimimo.com/anthropic` |
+| Xiaomi MiMo (OpenAI Chat) | `https://api.xiaomimimo.com/v1` |
 | Kilo | `https://api.kilo.ai/api/gateway` |
 | GitLab Duo | `https://cloud.gitlab.com/ai/v1/proxy/openai/v1` |
 | Cloudflare AI Gateway | `https://gateway.ai.cloudflare.com/v1/{account-id}/{gateway}/anthropic` |

--- a/docs-site/src/content/docs/ko/guides/providers.md
+++ b/docs-site/src/content/docs/ko/guides/providers.md
@@ -218,6 +218,7 @@ Cline IDE/CLI에서만 제공되며 API로는 사용할 수 없습니다. `minim
 | SiliconFlow | `https://api.siliconflow.cn/v1` |
 | Volcengine Ark · Coding Plan · Agent Plan | `https://ark.cn-beijing.volces.com/api/v3` · `https://ark.cn-beijing.volces.com/api/coding/v3` · `https://ark.cn-beijing.volces.com/api/plan/v3` |
 | Xiaomi MiMo | `https://api.xiaomimimo.com/anthropic` |
+| Xiaomi MiMo (OpenAI Chat) | `https://api.xiaomimimo.com/v1` |
 | Kilo | `https://api.kilo.ai/api/gateway` |
 | GitLab Duo | `https://cloud.gitlab.com/ai/v1/proxy/openai/v1` |
 | Cloudflare AI Gateway | `https://gateway.ai.cloudflare.com/v1/{account-id}/{gateway}/anthropic` |

--- a/docs-site/src/content/docs/ru/guides/providers.md
+++ b/docs-site/src/content/docs/ru/guides/providers.md
@@ -229,6 +229,7 @@ opencodex поставляется с 79 встроенными пресетам
 | SiliconFlow | `https://api.siliconflow.cn/v1` |
 | Volcengine Ark · Coding Plan · Agent Plan | `https://ark.cn-beijing.volces.com/api/v3` · `https://ark.cn-beijing.volces.com/api/coding/v3` · `https://ark.cn-beijing.volces.com/api/plan/v3` |
 | Xiaomi MiMo | `https://api.xiaomimimo.com/anthropic` |
+| Xiaomi MiMo (OpenAI Chat) | `https://api.xiaomimimo.com/v1` |
 | Kilo | `https://api.kilo.ai/api/gateway` |
 | GitLab Duo | `https://cloud.gitlab.com/ai/v1/proxy/openai/v1` |
 | Cloudflare AI Gateway | `https://gateway.ai.cloudflare.com/v1/{account-id}/{gateway}/anthropic` |

--- a/docs-site/src/content/docs/zh-cn/guides/providers.md
+++ b/docs-site/src/content/docs/zh-cn/guides/providers.md
@@ -206,6 +206,7 @@ Cline IDE/CLI 中提供，不能通过 API 使用；`minimax/minimax-m2.5` 是�
 | SiliconFlow | `https://api.siliconflow.cn/v1` |
 | 火山方舟 · Coding Plan · Agent Plan | `https://ark.cn-beijing.volces.com/api/v3` · `https://ark.cn-beijing.volces.com/api/coding/v3` · `https://ark.cn-beijing.volces.com/api/plan/v3` |
 | Xiaomi MiMo | `https://api.xiaomimimo.com/anthropic` |
+| Xiaomi MiMo (OpenAI Chat) | `https://api.xiaomimimo.com/v1` |
 | Kilo | `https://api.kilo.ai/api/gateway` |
 | GitLab Duo | `https://cloud.gitlab.com/ai/v1/proxy/openai/v1` |
 | Cloudflare AI Gateway | `https://gateway.ai.cloudflare.com/v1/{account-id}/{gateway}/anthropic` |

--- a/docs-site/src/content/docs/zh-tw/guides/providers.md
+++ b/docs-site/src/content/docs/zh-tw/guides/providers.md
@@ -272,6 +272,7 @@ IDE／CLI，不透過 API；`minimax/minimax-m2.5` 是文件列出的 API 免費
 | SiliconFlow | `https://api.siliconflow.cn/v1` |
 | Volcengine Ark · Coding Plan · Agent Plan | `https://ark.cn-beijing.volces.com/api/v3` · `https://ark.cn-beijing.volces.com/api/coding/v3` · `https://ark.cn-beijing.volces.com/api/plan/v3` |
 | Xiaomi MiMo | `https://api.xiaomimimo.com/anthropic` |
+| Xiaomi MiMo (OpenAI Chat) | `https://api.xiaomimimo.com/v1` |
 | Kilo | `https://api.kilo.ai/api/gateway` |
 | GitLab Duo | `https://cloud.gitlab.com/ai/v1/proxy/openai/v1` |
 | Cloudflare AI Gateway | `https://gateway.ai.cloudflare.com/v1/{account-id}/{gateway}/anthropic` |

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -2323,6 +2323,24 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     noVisionModels: OPENCODE_ZEN_TEXT_ONLY_MODELS,
   },
   { id: "xiaomi", label: "Xiaomi MiMo", baseUrl: "https://api.xiaomimimo.com/anthropic", adapter: "anthropic", authKind: "key", dashboardUrl: "https://xiaomimimo.com", defaultModel: "mimo-v2.5-pro" },
+  // Xiaomi's public OpenAI-compatible endpoint is a distinct transport from both the Anthropic
+  // preset above and the paid token-plan host below. Keep a separate fixed-destination contract
+  // so existing custom providers are never retargeted while the official route receives the
+  // strict reasoning ladder its validator enforces (#1483).
+  {
+    id: "xiaomi-mimo",
+    label: "Xiaomi MiMo (OpenAI Chat)",
+    baseUrl: "https://api.xiaomimimo.com/v1",
+    adapter: "openai-chat",
+    authKind: "key",
+    dashboardUrl: "https://platform.xiaomimimo.com/console/balance",
+    defaultModel: "mimo-v2.5",
+    models: ["mimo-v2.5"],
+    reasoningEfforts: ["low", "medium", "high"],
+    reasoningEffortMap: { xhigh: "high", max: "high", ultra: "high" },
+    preserveCustomDestination: true,
+    note: "Official Xiaomi MiMo OpenAI-compatible Chat endpoint. The upstream validator accepts reasoning_effort none/low/medium/high; higher Codex tiers are clamped to high.",
+  },
   { id: "kilo", label: "Kilo", baseUrl: "https://api.kilo.ai/api/gateway", adapter: "openai-chat", authKind: "key", dashboardUrl: "https://kilo.ai" },
   {
     id: "mimo-free",

--- a/structure/03_catalog-and-subagents.md
+++ b/structure/03_catalog-and-subagents.md
@@ -158,6 +158,21 @@ wire-clamps ultra/max to each model's real top rung (e.g. gpt-5.5 ultra → xhig
 the request, and they never raise it.
 
 [Decision Log]
+- 목적과 의도: Xiaomi MiMo의 공식 OpenAI Chat endpoint가 실제로 받지 않는 `max`/
+  `ultra` reasoning tier를 catalog에 노출하지 않도록 한다.
+- 기존 구현 및 제약 조건: `xiaomi`는 Anthropic endpoint, `mimo`는 token-plan endpoint를
+  소유하며, 공식 `https://api.xiaomimimo.com/v1`은 generic custom provider로 처리됐다.
+- 검토한 주요 대안: 기존 `xiaomi`/`mimo` contract를 확장하기, 모든 custom provider의 ladder를
+  일괄 축소하기, 공식 public endpoint만을 별도 registry row로 소유하기.
+- 선택한 방식: `xiaomi-mimo`를 고정 목적지의 `openai-chat` preset으로 등록하고
+  `low`/`medium`/`high`만 노출하며 높은 direct request는 `high`로 clamp한다.
+- 다른 대안 대신 이 방식을 선택한 이유: 서로 다른 auth/wire/host를 하나의 preset으로
+  합치지 않으면서 upstream error로 확인된 계약만 적용할 수 있다.
+- 장점, 단점 및 영향: 공식 endpoint에서 안전한 picker/wire 계약을 제공하고,
+  `preserveCustomDestination`으로 같은 이름의 다른 host/key를 보호한다. 대신 새 preset 표면을
+  문서와 registry parity에서 함께 유지해야 한다.
+
+[Decision Log]
 - 목적과 의도: bare `defaultModel` selectors that route into third-party providers must keep their
   adapter-owned effort ladder; only true ChatGPT-native requests should receive the mock-max repair.
 - 기존 구현 및 제약 조건: `nativeEffortClamp` already needed the original request id because

--- a/tests/mimo-token-plan-provider.test.ts
+++ b/tests/mimo-token-plan-provider.test.ts
@@ -1,8 +1,73 @@
 import { describe, expect, test } from "bun:test";
+import { applyProviderConfigHints } from "../src/codex/catalog";
 import { KEY_LOGIN_PROVIDERS } from "../src/oauth/key-providers";
 import { PROVIDER_REGISTRY } from "../src/providers/registry";
+import { mapReasoningEffort } from "../src/reasoning-effort";
 import { routeModel } from "../src/router";
 import type { OcxConfig } from "../src/types";
+
+describe("Xiaomi MiMo public OpenAI Chat endpoint (#1483)", () => {
+  const baseUrl = "https://api.xiaomimimo.com/v1";
+  const entry = PROVIDER_REGISTRY.find(row => row.id === "xiaomi-mimo");
+
+  test("owns the official destination and advertises only its validated ladder", () => {
+    expect(entry).toMatchObject({
+      adapter: "openai-chat",
+      baseUrl,
+      dashboardUrl: "https://platform.xiaomimimo.com/console/balance",
+      defaultModel: "mimo-v2.5",
+      models: ["mimo-v2.5"],
+      preserveCustomDestination: true,
+      reasoningEfforts: ["low", "medium", "high"],
+    });
+    expect(KEY_LOGIN_PROVIDERS["xiaomi-mimo"]?.baseUrl).toBe(baseUrl);
+
+    const config: OcxConfig = {
+      port: 10100,
+      defaultProvider: "xiaomi-mimo",
+      providers: {
+        "xiaomi-mimo": {
+          adapter: "openai-chat",
+          baseUrl,
+          authMode: "key",
+          apiKey: "test-key",
+          liveModels: true,
+        },
+      },
+    };
+    const route = routeModel(config, "xiaomi-mimo/mimo-v2.5");
+    const catalogModel = applyProviderConfigHints("xiaomi-mimo", route.provider, {
+      provider: "xiaomi-mimo",
+      id: route.modelId,
+    });
+
+    expect(catalogModel.reasoningEfforts).toEqual(["low", "medium", "high"]);
+    for (const tier of ["xhigh", "max", "ultra"]) {
+      expect(mapReasoningEffort(route.provider, route.modelId, tier)).toBe("high");
+    }
+  });
+
+  test("does not claim a same-named provider at another destination", () => {
+    const config: OcxConfig = {
+      port: 10100,
+      defaultProvider: "xiaomi-mimo",
+      providers: {
+        "xiaomi-mimo": {
+          adapter: "openai-chat",
+          baseUrl: "https://private.example/v1",
+          authMode: "key",
+          apiKey: "private-key",
+        },
+      },
+    };
+
+    const route = routeModel(config, "xiaomi-mimo/mimo-v2.5");
+    expect(route.provider.baseUrl).toBe("https://private.example/v1");
+    expect(route.provider.apiKey).toBe("private-key");
+    expect(route.provider.reasoningEfforts).toBeUndefined();
+    expect(route.provider.reasoningEffortMap).toBeUndefined();
+  });
+});
 
 describe("Xiaomi MiMo token plan (#1158)", () => {
   const entry = PROVIDER_REGISTRY.find(row => row.id === "mimo");

--- a/tests/mimo-token-plan-provider.test.ts
+++ b/tests/mimo-token-plan-provider.test.ts
@@ -118,4 +118,107 @@ describe("Xiaomi MiMo token plan (#1158)", () => {
     // The registry's effort clamp must not be applied to a row we do not own either.
     expect(route.provider.reasoningEfforts).toBeUndefined();
   });
+
+  // A user reasoningEffortMap CAN still lift a tier, and that is the shipped contract rather
+  // than an oversight: `healMappedTiers` treats a wire map as authoritative evidence of the
+  // tiers the upstream can emit and merges its Codex values into the ladder, which is what lets
+  // a stale persisted ladder recover a newly documented tier without rewriting user config
+  // (see "stale reasoning-ladder self-heal" in tests/reasoning-effort.test.ts).
+  //
+  // So the registry clamp protects the DEFAULT route, not a user who has deliberately written a
+  // conflicting map. This test records that boundary so the next reader does not mistake the
+  // clamp for an enforcement the code does not implement.
+  test("a user reasoningEffortMap deliberately overrides the registry clamp", () => {
+    const config: OcxConfig = {
+      port: 10100,
+      defaultProvider: "xiaomi-mimo",
+      providers: {
+        "xiaomi-mimo": {
+          adapter: "openai-chat",
+          baseUrl: "https://api.xiaomimimo.com/v1",
+          apiKey: "k",
+          authMode: "key",
+          // Conflicts with the registry clamp on purpose.
+          reasoningEffortMap: { max: "max", ultra: "ultra" },
+        },
+      },
+    };
+
+    const route = routeModel(config, "xiaomi-mimo/mimo-v2.5");
+    // The stored ladder is untouched — healing happens at lookup time, not on the config.
+    expect(route.provider.reasoningEfforts).toEqual(["low", "medium", "high"]);
+    // ...but `configuredReasoningEfforts` merges the user map's Codex values in, so `max`
+    // becomes a supported tier for resolution and the alias resolves to itself.
+    expect(mapReasoningEffort(route.provider, "mimo-v2.5", "max")).toBe("max");
+
+    // `ultra` still normalizes to `max` at the codex-rs boundary rather than reaching the wire.
+    expect(mapReasoningEffort(route.provider, "mimo-v2.5", "ultra")).toBe("max");
+
+    // Tiers inside the registry ladder are untouched.
+    expect(mapReasoningEffort(route.provider, "mimo-v2.5", "low")).toBe("low");
+    expect(mapReasoningEffort(route.provider, "mimo-v2.5", "medium")).toBe("medium");
+  });
+
+  // The case the clamp actually governs: no user map, so the registry ladder is authoritative
+  // and a direct max/ultra/xhigh request lands on `high` instead of reproducing the #1483 400.
+  test("without a conflicting user map the registry clamp holds", () => {
+    const config: OcxConfig = {
+      port: 10100,
+      defaultProvider: "xiaomi-mimo",
+      providers: {
+        "xiaomi-mimo": {
+          adapter: "openai-chat",
+          baseUrl: "https://api.xiaomimimo.com/v1",
+          apiKey: "k",
+          authMode: "key",
+        },
+      },
+    };
+
+    const route = routeModel(config, "xiaomi-mimo/mimo-v2.5");
+    expect(route.provider.reasoningEfforts).toEqual(["low", "medium", "high"]);
+    for (const tier of ["max", "ultra", "xhigh"]) {
+      expect(mapReasoningEffort(route.provider, "mimo-v2.5", tier)).toBe("high");
+    }
+    expect(mapReasoningEffort(route.provider, "mimo-v2.5", "low")).toBe("low");
+  });
+
+  test("an alias that lands inside the ladder still resolves through the map", () => {
+    const config: OcxConfig = {
+      port: 10100,
+      defaultProvider: "custom-alias",
+      providers: {
+        "custom-alias": {
+          adapter: "openai-chat",
+          baseUrl: "https://alias.example/v1",
+          apiKey: "k",
+          authMode: "key",
+          reasoningEfforts: ["low", "medium", "high"],
+          reasoningEffortMap: { max: "medium" },
+        },
+      },
+    };
+
+    const route = routeModel(config, "custom-alias/some-model");
+    expect(mapReasoningEffort(route.provider, "some-model", "max")).toBe("medium");
+  });
+
+  test("a provider without a configured ladder keeps its alias verbatim", () => {
+    const config: OcxConfig = {
+      port: 10100,
+      defaultProvider: "no-ladder",
+      providers: {
+        "no-ladder": {
+          adapter: "openai-chat",
+          baseUrl: "https://noladder.example/v1",
+          apiKey: "k",
+          authMode: "key",
+          reasoningEffortMap: { max: "turbo" },
+        },
+      },
+    };
+
+    const route = routeModel(config, "no-ladder/some-model");
+    expect(mapReasoningEffort(route.provider, "some-model", "max")).toBe("turbo");
+  });
 });

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -35,7 +35,7 @@ const EXPECTED_KEY_PROVIDER_IDS = [
   "huggingface", "nvidia", "venice", "zai", "zhipu-bigmodel", "zhipu-bigmodel-coding", "nanogpt", "synthetic", "siliconflow", "qwen-cloud", "tencent-coding-plan",
   "volcengine", "volcengine-coding-plan", "volcengine-agent-plan", "qianfan", "alibaba", "alibaba-token-plan", "alibaba-token-plan-intl", "parallel", "zenmux", "litellm", "ollama-cloud", "mistral",
   "minimax", "minimax-cn", "kimi-code", "opencode-zen", "vercel-ai-gateway",
-  "opencode-free", "xiaomi", "kilo", "mimo-free", "mimo", "cloudflare-ai-gateway", "cloudflare-workers-ai", "gitlab-duo",
+  "opencode-free", "xiaomi", "xiaomi-mimo", "kilo", "mimo-free", "mimo", "cloudflare-ai-gateway", "cloudflare-workers-ai", "gitlab-duo",
 ];
 
 describe("provider registry parity", () => {


### PR DESCRIPTION
## Summary

- add a fixed-destination `xiaomi-mimo` preset for Xiaomi's official OpenAI-compatible Chat endpoint
- expose only the upstream-validated `low`, `medium`, and `high` reasoning tiers
- clamp direct `xhigh`, `max`, and `ultra` requests to `high`
- preserve same-named custom providers that point at another destination
- document the separate public Chat transport and its registry ownership decision

## Root cause and impact

`https://api.xiaomimimo.com/v1` had no registry-owned transport contract. A custom provider named `xiaomi-mimo` therefore kept the generic routed-model ladder and could advertise/send `max` even though the MiMo endpoint rejects every reasoning value above `high`.

The new preset is intentionally separate from the existing Xiaomi Anthropic and MiMo token-plan entries because those routes use different hosts and transport contracts. `preserveCustomDestination` prevents the preset from retargeting an existing custom key when a same-named row points somewhere else.

This PR does not normalize the separately reported malformed `delta.tool_calls` failure. The shared parser remains fail-closed until a redacted failing frame identifies the actual nested shape; guessing there could silently drop or mis-bind a tool call.

Refs #1483.

## Provider evidence

Verified from Xiaomi's primary sources on 2026-08-11:

- Official OpenAI-compatible Chat reference: https://platform.xiaomimimo.com/docs/en-US/api/chat/openai-api documents `POST https://api.xiaomimimo.com/v1/chat/completions` and API-key/Bearer authentication.
- Service terms: https://mimo.mi.com/docs/terms/user-agreement identify `Xiaomi Technologies Singapore Pte. Ltd.` as the API service operator outside mainland China; the agreement was updated 2026-07-07.
- Privacy terms: https://mimo.mi.com/docs/terms/privacy-policy identify Xiaomi Technology Netherlands B.V. and Xiaomi Technologies Singapore Pte. Ltd.; the policy was updated 2026-03-17.
- Aggregator authorization: not applicable. This preset sends a user key to Xiaomi's first-party endpoint for Xiaomi's own MiMo model; it does not resell or route third-party models.
- OpenCodex maintenance owner: `@Ingwannu`. Endpoint/auth/catalog breakage should be reported in the OpenCodex issue tracker and will be rechecked against the primary sources above.
- The preset does not declare live model discovery, so no authenticated `GET /v1/models` contract is claimed.

## Verification

- `bun test tests/mimo-token-plan-provider.test.ts tests/provider-registry-parity.test.ts` — 41 passed
- `bun test tests/provider-workspace-rail.test.ts` — 6 passed after installing the GUI workspace dependencies
- `bun run typecheck` — passed
- `bun run privacy:scan` — passed
- `cd docs-site && bun install --frozen-lockfile && bun run build` — 265 pages built
- `bun run test` — 11,047 passed, 11 skipped, 2 failed across 681 files; the failures were the live service-token environment collision in `codex-shim.test.ts` and a loaded-runner stall deadline in `bridge-lifecycle.test.ts`
- `env -u OPENCODEX_API_AUTH_TOKEN bun test tests/codex-shim.test.ts tests/bridge-lifecycle.test.ts` — both failed files passed in isolation, 82/82
- `git diff --check` — passed

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

## Scope notes

- Targets `dev` only.
- No GUI behavior or text-only product change.
- No authentication or credential flow change.
- No speculative malformed-tool-call repair.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Xiaomi MiMo as an OpenAI-compatible provider at `https://api.xiaomimimo.com/v1`.
  * Added support for the `mimo-v2.5` model with low, medium, and high reasoning levels.
  * Added handling for unsupported higher reasoning requests while preserving custom provider settings.

* **Documentation**
  * Updated provider catalogs in English, Japanese, Korean, Russian, Simplified Chinese, and Traditional Chinese.
  * Documented Xiaomi MiMo configuration and reasoning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->