### PR TITLE
fix(openai-chat): forward caller-selected service tier

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -744,6 +744,10 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
         messages,
         stream: parsed.stream,
       };
+      // Preserve a caller-selected service tier for OpenAI-compatible chat gateways. The
+      // request pipeline deliberately does not inject fast mode for this adapter, but dropping
+      // an explicit value here makes the Responses parser's serviceTier projection ineffective.
+      if (parsed.options.serviceTier !== undefined) body.service_tier = parsed.options.serviceTier;
       if (modelInList(provider.reasoningSplitModels, parsed.modelId)) body.reasoning_split = true;
       const maxTokens = resolveMaxTokens(provider, parsed);
       const openRouterRouting = resolveOpenRouterRouting(provider, parsed.modelId);

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -747,7 +747,15 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
       // Preserve a caller-selected service tier for OpenAI-compatible chat gateways. The
       // request pipeline deliberately does not inject fast mode for this adapter, but dropping
       // an explicit value here makes the Responses parser's serviceTier projection ineffective.
-      if (parsed.options.serviceTier !== undefined) body.service_tier = parsed.options.serviceTier;
+      //
+      // Opt-in, like `prompt_cache_key` directly below: `service_tier` is an OpenAI-specific
+      // extension and 66 registry providers share this adapter, several of which reject
+      // unknown body fields. Forwarding unconditionally would turn a caller-supplied
+      // `service_tier` into an upstream 400 on those routes. `supportsServiceTier` is the
+      // Responses-wire flag (applyServiceTierGate) and deliberately does not gate this path.
+      if (provider.chatServiceTier && parsed.options.serviceTier !== undefined) {
+        body.service_tier = parsed.options.serviceTier;
+      }
       if (modelInList(provider.reasoningSplitModels, parsed.modelId)) body.reasoning_split = true;
       const maxTokens = resolveMaxTokens(provider, parsed);
       const openRouterRouting = resolveOpenRouterRouting(provider, parsed.modelId);

--- a/src/providers/derive.ts
+++ b/src/providers/derive.ts
@@ -239,6 +239,7 @@ export function providerConfigSeed(entry: ProviderRegistryEntry): OcxProviderCon
     ...(entry.noPenaltyModels ? { noPenaltyModels: [...entry.noPenaltyModels] } : {}),
     ...(entry.parallelToolCalls !== undefined ? { parallelToolCalls: entry.parallelToolCalls } : {}),
     ...(entry.promptCacheKey !== undefined ? { promptCacheKey: entry.promptCacheKey } : {}),
+    ...(entry.chatServiceTier !== undefined ? { chatServiceTier: entry.chatServiceTier } : {}),
     ...(entry.responsesPath !== undefined ? { responsesPath: entry.responsesPath } : {}),
     ...(entry.statelessResponses !== undefined ? { statelessResponses: entry.statelessResponses } : {}),
     ...(entry.requiresAdjacentResponsesToolResults !== undefined
@@ -419,6 +420,7 @@ export function enrichProviderFromRegistry(name: string, prov: OcxProviderConfig
   if (!prov.noPenaltyModels && seed.noPenaltyModels) prov.noPenaltyModels = [...seed.noPenaltyModels];
   if (prov.parallelToolCalls === undefined && seed.parallelToolCalls !== undefined) prov.parallelToolCalls = seed.parallelToolCalls;
   if (prov.promptCacheKey === undefined && seed.promptCacheKey !== undefined) prov.promptCacheKey = seed.promptCacheKey;
+  if (prov.chatServiceTier === undefined && seed.chatServiceTier !== undefined) prov.chatServiceTier = seed.chatServiceTier;
   // Fill-only: a hand-edited path must survive, and a config saved before the registry
   // learned this route still gets backfilled.
   if (prov.responsesPath === undefined && seed.responsesPath !== undefined) prov.responsesPath = seed.responsesPath;

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -237,6 +237,12 @@ export interface ProviderRegistryEntry {
   parallelToolCalls?: boolean;
   /** Opt this provider into forwarding prompt_cache_key (OpenAI-specific; strict backends reject it). */
   promptCacheKey?: boolean;
+  /**
+   * Opt-in: forward `service_tier` on the `/chat/completions` wire. Same hazard as
+   * `promptCacheKey` — an OpenAI-specific extension that strict gateways reject. Distinct from
+   * `supportsServiceTier`, which governs the Responses wire.
+   */
+  chatServiceTier?: boolean;
   autoToolChoiceOnlyModels?: string[];
   preserveReasoningContentModels?: string[];
   requiresReasoningPlaceholderModels?: string[];

--- a/src/router.ts
+++ b/src/router.ts
@@ -350,6 +350,7 @@ export function routedProviderConfig(providerName: string, provider: OcxProvider
     // opt-in, while an explicit user `false` keeps overriding registry `true`.
     ...(provider.parallelToolCalls === undefined && registryEntry.parallelToolCalls !== undefined ? { parallelToolCalls: registryEntry.parallelToolCalls } : {}),
     ...(provider.promptCacheKey === undefined && registryEntry.promptCacheKey !== undefined ? { promptCacheKey: registryEntry.promptCacheKey } : {}),
+    ...(provider.chatServiceTier === undefined && registryEntry.chatServiceTier !== undefined ? { chatServiceTier: registryEntry.chatServiceTier } : {}),
     ...(provider.reasoningWireFormat === undefined && registryEntry.reasoningWireFormat !== undefined
       ? { reasoningWireFormat: registryEntry.reasoningWireFormat }
       : {}),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1439,6 +1439,15 @@ export interface OcxProviderConfig {
    */
   promptCacheKey?: boolean;
   /**
+   * Opt-in: forward `service_tier` to the upstream `/chat/completions` body.
+   * OpenAI-specific extension with the same hazard as `promptCacheKey` — strict backends
+   * reject unknown fields, and 66 registry providers share the `openai-chat` adapter, so a
+   * caller-supplied `service_tier` would otherwise turn working requests into upstream 400s.
+   * `supportsServiceTier` is the Responses-wire flag and does not apply here.
+   * Default off; only enable for providers that document this parameter on the chat wire.
+   */
+  chatServiceTier?: boolean;
+  /**
    * Provider-local passthrough SSE repair for broken openai-responses gateways that reuse exact
    * placeholder message/reasoning ids or omit the terminal id after a stable added event.
    * Disabled by default; function_call ids and call_id pairing are never rewritten.

--- a/tests/openai-chat-hardening.test.ts
+++ b/tests/openai-chat-hardening.test.ts
@@ -302,14 +302,35 @@ describe("openai-chat credential hardening", () => {
     expect(body).not.toHaveProperty("prompt_cache_key");
   });
 
-  test("preserves a caller-supplied service tier for the outbound chat body", () => {
-    const adapter = createOpenAIChatAdapter(provider());
+  test("preserves a caller-supplied service tier when the provider opts in", () => {
+    const adapter = createOpenAIChatAdapter(provider({ chatServiceTier: true }));
     const req = parsed();
     req.options.serviceTier = "priority";
 
     const body = JSON.parse(adapter.buildRequest(req).body);
 
     expect(body.service_tier).toBe("priority");
+  });
+
+  // `service_tier` is an OpenAI-specific extension and this adapter serves 66 registry
+  // providers, several of which reject unknown body fields. Forwarding it by default would
+  // turn a caller-supplied tier into an upstream 400 on those routes, so absence of the
+  // opt-in must mean the field is dropped — the same contract `prompt_cache_key` uses.
+  test("drops a caller-supplied service tier when the provider has not opted in", () => {
+    for (const p of [provider(), provider({ chatServiceTier: false })]) {
+      const req = parsed();
+      req.options.serviceTier = "priority";
+
+      const body = JSON.parse(createOpenAIChatAdapter(p).buildRequest(req).body);
+
+      expect(body).not.toHaveProperty("service_tier");
+    }
+  });
+
+  test("an opted-in provider without a caller tier still sends no service_tier", () => {
+    const body = JSON.parse(createOpenAIChatAdapter(provider({ chatServiceTier: true })).buildRequest(parsed()).body);
+
+    expect(body).not.toHaveProperty("service_tier");
   });
 
   test("canonical Kimi Coding Plan routes forward Codex prompt_cache_key", () => {

--- a/tests/openai-chat-hardening.test.ts
+++ b/tests/openai-chat-hardening.test.ts
@@ -302,6 +302,16 @@ describe("openai-chat credential hardening", () => {
     expect(body).not.toHaveProperty("prompt_cache_key");
   });
 
+  test("preserves a caller-supplied service tier for the outbound chat body", () => {
+    const adapter = createOpenAIChatAdapter(provider());
+    const req = parsed();
+    req.options.serviceTier = "priority";
+
+    const body = JSON.parse(adapter.buildRequest(req).body);
+
+    expect(body.service_tier).toBe("priority");
+  });
+
   test("canonical Kimi Coding Plan routes forward Codex prompt_cache_key", () => {
     for (const [providerName, authMode] of [
       ["kimi", "oauth"],


### PR DESCRIPTION
## Summary

- Preserve an explicit `parsed.options.serviceTier` value when serializing OpenAI-compatible Chat Completions requests.
- Add a regression test covering `service_tier: "priority"` on the outbound `/chat/completions` body.
- This fixes the request-path half of #1504; routed catalog capability publication remains tracked separately by #1436.
- Rebased onto current `dev@cbbfdd8773e68a5dc2391ddeb32f33a225373c1a`; current head: `ab72f5441e1b`.

Refs #1504
Refs #1436

## Verification

- `bun test --isolate --max-concurrency 1 tests/openai-chat-hardening.test.ts tests/service-tier-capability.test.ts` — 50 passed, 0 failed, 84 assertions.
- `bun run typecheck` — passed on the rebased head.
- `bun run privacy:scan` — passed.
- `git diff --check` — passed.
- A repository-wide `bun run test` result is not claimed; the suite contains current baseline/environment failures unrelated to this narrow serializer change.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed; this is an internal request serialization fix.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.
- [x] Local CI is green.
- [x] Branch is on the latest `dev` commit.
- [x] Correct Codex and CodeRabbit findings are fixed.
- [x] Ready-for-review confirmation is present.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for forwarding the requested service tier for compatible chat providers.
  - Provider configurations can now enable or disable service-tier handling independently.

- **Bug Fixes**
  - Service-tier settings are now correctly inherited when not explicitly configured.
  - The service tier is omitted when unsupported, disabled, or not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

**Maintainer note (checklist reset by the follow-up push).** Re-ticked against fresh evidence at `197c82ae9`, not carried over: `bun x tsc --noEmit` exit 0 and `tests/openai-chat-hardening.test.ts` 39 pass / 0 fail on a Linux runner (Bun 1.3.14); branch rebased onto `dev@d03755ee9`; the one review finding (unconditional `service_tier` forwarding across 66 openai-chat providers) is fixed by the `chatServiceTier` opt-in in the follow-up commit.
