### PR TITLE
fix(oauth): harden generated account ids against collisions

### DIFF
--- a/src/oauth/store.ts
+++ b/src/oauth/store.ts
@@ -198,7 +198,7 @@ interface LockSnapshot { bytes: string; dev: number; ino: number; mtimeMs: numbe
 export interface OAuthFileLockOptions { path: string; waitTimeoutMs?: number; staleAfterMs?: number; pollMinMs?: number; pollMaxMs?: number; sleep?: (ms: number) => Promise<void>; now?: () => number; random?: () => number; beforeStaleUnlink?: () => void; beforeReleaseUnlink?: () => void; beforeFailedCreateUnlink?: () => void; writeMetadata?: (fd: number, bytes: string) => void }
 export interface OAuthFileLockGuard { readonly ownerId: string; release(): void }
 function errorCode(error: unknown): string | undefined { return error && typeof error === "object" && "code" in error ? String((error as { code?: unknown }).code) : undefined; }
-function snapshot(path: string): LockSnapshot { const bytes = readFileSync(path, "utf8"); const s = statSync(path); return { bytes, dev:s.dev, ino:s.ino,mtimeMs:s.mtimeMs,size:s.size }; }
+function snapshot(path: string): LockSnapshot { const bytes = readFileSync(path, "utf8"); const s = statSync(path); return { bytes, dev:s.dev, ino:s.ino, mtimeMs:s.mtimeMs, size:s.size }; }
 function sameSnapshot(a: LockSnapshot,b: LockSnapshot): boolean { return a.bytes===b.bytes&&a.dev===b.dev&&a.ino===b.ino&&a.mtimeMs===b.mtimeMs&&a.size===b.size; }
 function sameFd(a: LockSnapshot,b: ReturnType<typeof fstatSync>): boolean { return a.dev===b.dev&&a.ino===b.ino&&a.mtimeMs===b.mtimeMs&&a.size===b.size; }
 export function createOAuthFileLock(options: OAuthFileLockOptions): { acquire(): Promise<OAuthFileLockGuard> } {

--- a/src/oauth/store.ts
+++ b/src/oauth/store.ts
@@ -198,7 +198,7 @@ interface LockSnapshot { bytes: string; dev: number; ino: number; mtimeMs: numbe
 export interface OAuthFileLockOptions { path: string; waitTimeoutMs?: number; staleAfterMs?: number; pollMinMs?: number; pollMaxMs?: number; sleep?: (ms: number) => Promise<void>; now?: () => number; random?: () => number; beforeStaleUnlink?: () => void; beforeReleaseUnlink?: () => void; beforeFailedCreateUnlink?: () => void; writeMetadata?: (fd: number, bytes: string) => void }
 export interface OAuthFileLockGuard { readonly ownerId: string; release(): void }
 function errorCode(error: unknown): string | undefined { return error && typeof error === "object" && "code" in error ? String((error as { code?: unknown }).code) : undefined; }
-function snapshot(path: string): LockSnapshot { const bytes = readFileSync(path, "utf8"); const s = statSync(path); return { bytes, dev:s.dev, ino:s.ino, mtimeMs:s.mtimeMs, size:s.size }; }
+function snapshot(path: string): LockSnapshot { const bytes = readFileSync(path, "utf8"); const s = statSync(path); return { bytes, dev:s.dev, ino:s.ino,mtimeMs:s.mtimeMs,size:s.size }; }
 function sameSnapshot(a: LockSnapshot,b: LockSnapshot): boolean { return a.bytes===b.bytes&&a.dev===b.dev&&a.ino===b.ino&&a.mtimeMs===b.mtimeMs&&a.size===b.size; }
 function sameFd(a: LockSnapshot,b: ReturnType<typeof fstatSync>): boolean { return a.dev===b.dev&&a.ino===b.ino&&a.mtimeMs===b.mtimeMs&&a.size===b.size; }
 export function createOAuthFileLock(options: OAuthFileLockOptions): { acquire(): Promise<OAuthFileLockGuard> } {
@@ -286,15 +286,18 @@ function normalizeCredential(cred: unknown): OAuthCredentials | null {
 }
 
 /**
- * Stable short account id. MUST be deterministic for a given credential: legacy
- * single-credential stores are re-normalized on EVERY load without being persisted,
+ * Stable collision-resistant account id. MUST be deterministic for a given credential:
+ * legacy single-credential stores are re-normalized on EVERY load without being persisted,
  * so a time-salted id would differ between two loads (getAccountSet vs
  * getAccountCredential), surfacing as a spurious OAuthLoginRequiredError and making
  * refresh persists silently miss the account (rotated refresh token lost).
+ *
+ * Keep 128 bits of SHA-256 rather than the historical 32-bit prefix. Existing persisted
+ * account ids are read as-is; only newly-derived ids and legacy normalization use this width.
  */
 function newAccountId(cred: OAuthCredentials): string {
   const identity = cred.accountId ?? cred.email ?? cred.refresh;
-  return createHash("sha256").update(identity).digest("hex").slice(0, 8);
+  return createHash("sha256").update(identity).digest("hex").slice(0, 32);
 }
 
 function normalizeAccount(value: unknown): ProviderAccount | null {

--- a/tests/oauth-account-id-collision.test.ts
+++ b/tests/oauth-account-id-collision.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  resetHardenedStateForTests,
+  setIcaclsRunnerForTests,
+} from "../src/lib/windows-secret-acl";
+import {
+  getAccountSet,
+  getCredential,
+  saveCredential,
+} from "../src/oauth/store";
+
+const TEST_DIR = join(import.meta.dir, ".tmp-oauth-account-id-collision-test");
+let previousOpencodexHome: string | undefined;
+
+const COLLIDING_ACCOUNT_A = "account-collision-16138";
+const COLLIDING_ACCOUNT_B = "account-collision-28806";
+
+describe("OAuth account id collision hardening", () => {
+  beforeEach(() => {
+    previousOpencodexHome = process.env.OPENCODEX_HOME;
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    resetHardenedStateForTests();
+    setIcaclsRunnerForTests(() => ({
+      success: true,
+      exitCode: 0,
+      timedOut: false,
+      stdout: "",
+    }));
+  });
+
+  afterEach(() => {
+    setIcaclsRunnerForTests(null);
+    resetHardenedStateForTests();
+    if (previousOpencodexHome === undefined) delete process.env.OPENCODEX_HOME;
+    else process.env.OPENCODEX_HOME = previousOpencodexHome;
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  });
+
+  test("distinct identities that collide on the historical 32-bit prefix get distinct slots", async () => {
+    // sha256(account-collision-16138) and sha256(account-collision-28806) both
+    // start with da1e26d2. The historical 8-hex id therefore aliased these
+    // two accounts and made active-account lookup return the wrong credential.
+    await saveCredential("anthropic", {
+      access: "access-a",
+      refresh: "refresh-a",
+      expires: Date.now() + 3600_000,
+      accountId: COLLIDING_ACCOUNT_A,
+    });
+    await saveCredential("anthropic", {
+      access: "access-b",
+      refresh: "refresh-b",
+      expires: Date.now() + 3600_000,
+      accountId: COLLIDING_ACCOUNT_B,
+    });
+
+    const set = getAccountSet("anthropic");
+    expect(set).not.toBeNull();
+    expect(set!.accounts).toHaveLength(2);
+    expect(new Set(set!.accounts.map(account => account.id)).size).toBe(2);
+    expect(set!.accounts.every(account => account.id.length === 32)).toBe(true);
+    expect(getCredential("anthropic")?.accountId).toBe(COLLIDING_ACCOUNT_B);
+    expect(getCredential("anthropic")?.access).toBe("access-b");
+  });
+
+  test("existing persisted 32-bit account ids remain valid and are not rewritten", async () => {
+    const authPath = join(TEST_DIR, "auth.json");
+    writeFileSync(authPath, JSON.stringify({
+      anthropic: {
+        activeAccountId: "deadbeef",
+        accounts: [{
+          id: "deadbeef",
+          credential: {
+            access: "old-access",
+            refresh: "old-refresh",
+            expires: Date.now() + 3600_000,
+            accountId: "existing-account",
+          },
+        }],
+      },
+    }));
+
+    expect(getAccountSet("anthropic")?.activeAccountId).toBe("deadbeef");
+
+    await saveCredential("anthropic", {
+      access: "rotated-access",
+      refresh: "rotated-refresh",
+      expires: Date.now() + 7200_000,
+      accountId: "existing-account",
+    });
+
+    const set = getAccountSet("anthropic");
+    expect(set?.activeAccountId).toBe("deadbeef");
+    expect(set?.accounts[0]?.id).toBe("deadbeef");
+    expect(getCredential("anthropic")?.access).toBe("rotated-access");
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up security hardening for the OAuth multi-account store.

`newAccountId()` historically kept only 8 hex characters of SHA-256, giving generated account slots a 32-bit collision space. Two distinct identities could therefore receive the same persisted account id. Because `activeAccountId` and per-account mutations address slots by that id, a collision can make lookups or updates resolve the wrong account.

This PR:

- expands newly-derived OAuth account ids from 32 bits to 128 bits (`slice(0, 32)`)
- preserves existing persisted account ids exactly as stored, so there is no auth-store migration or forced relogin
- keeps legacy single-credential normalization deterministic across repeated loads
- adds a regression using two concrete identities whose SHA-256 digests share the historical `da1e26d2` 32-bit prefix
- verifies the colliding identities now receive distinct slots and the active credential resolves correctly
- verifies an existing persisted 8-character account id remains unchanged after credential rotation

## Security rationale

This is pre-existing hardening, separate from #1505. #1505's reasoning replay boundary also includes credential generation, so the old 32-bit slot id did not by itself cross that replay boundary. The wider issue is the OAuth store itself: duplicate generated slot ids can alias account selection and account-scoped mutations.

128 bits keeps the identifier deterministic where legacy normalization requires that property while making accidental or practical collision search infeasible for this use case.

## Scope

Only OAuth account-id derivation and focused regression coverage are changed. Existing stored ids remain backwards-compatible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the risk of OAuth account-ID collisions by using longer, more unique identifiers for newly created accounts.
  * Improved credential lookup when multiple accounts could previously share the same shortened identifier.
  * Preserved existing persisted account IDs, ensuring previously stored credentials remain compatible and can still be updated.

* **Tests**
  * Added coverage for collision handling, account selection, and backward compatibility with existing OAuth account data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->