### PR TITLE
[WRONG BRANCH] Fix localhost link formatting in README.zh-CN.md

### DIFF
--- a/readme/README.zh-CN.md
+++ b/readme/README.zh-CN.md
@@ -81,7 +81,7 @@ npm install -g @bitkyc08/opencodex   # Node 18+；自动捆绑 Bun 运行时
 ocx start                            # 或使用 `ocx service` 在后台运行
 ```
 
-打开 **http://localhost:10100**，在 Web 仪表板中完成所有配置：添加 provider（40 多个内置
+打开 **[http://localhost:10100](http://localhost:10100)**，在 Web 仪表板中完成所有配置：添加 provider（40 多个内置
 provider，或任意 OpenAI 兼容端点）、选择模型并管理账户。随时运行 `ocx gui` 可重新打开仪表板。
 
 ### 面向代理


### PR DESCRIPTION
## Summary

- Updated `readme/README.zh-CN.md` to format `http://localhost:10100` as an explicit Markdown link.
- This makes it easier for users to open the Web dashboard directly.

## Verification

- Verified that the link renders correctly in GitHub's Markdown preview.
- Verified that the link points to `http://localhost:10100`.
- This is a documentation-only change, so no code tests were run.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Documentation was updated as needed.
- [x] No security-sensitive code, configuration, or credentials were changed.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
