### PR TITLE
fix(providers): keep hand-edited context windows through a POST overwrite

### DIFF
--- a/devlog/_plan/260812_five_bug_fix_campaign/040_phase4_issue1409_context_window_overrides.md
+++ b/devlog/_plan/260812_five_bug_fix_campaign/040_phase4_issue1409_context_window_overrides.md
@@ -271,8 +271,11 @@ the untouched user key survives.
 
 ```bash
 bun x tsc --noEmit
-bun test tests/provider-routes*.test.ts tests/management*.test.ts tests/config*.test.ts
+bun test tests/management-provider-validation.test.ts tests/management*.test.ts tests/config*.test.ts
 ```
+
+(There is no `tests/provider-routes*.test.ts`; an unmatched glob aborts the run under zsh.
+The management-provider validation suite is where this path's coverage lives.)
 
 ## Delivery
 

--- a/src/server/management/provider-routes.ts
+++ b/src/server/management/provider-routes.ts
@@ -350,6 +350,12 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
     }
     // Catalog providers (e.g. ollama-cloud) carry a models + vision/reasoning classification the GUI
     // doesn't send — merge it in so the sidecars are gated correctly.
+    // Sample request ownership BEFORE enrichment. Enrichment fills absent fields from the
+    // registry seed, after which "the client omitted this" and "the registry supplied it" are
+    // indistinguishable — so a carry-over guard written as `prov.x === undefined` after this
+    // call can never fire.
+    const submittedContextWindow = Object.hasOwn(prov, "contextWindow");
+    const submittedModelContextWindows = Object.hasOwn(prov, "modelContextWindows");
     enrichProviderFromCatalog(name, prov);
     const { saveConfigPreservingClaudeCode: save } = await import("../../config");
     // Overwriting an existing provider must not drop its multi-key pool: carry it over, then
@@ -361,6 +367,23 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
     // erase hand-edited per-model prices from Logs/Usage estimates.
     const existingCosts = config.providers[name]?.modelCosts;
     if (existingCosts && !prov.modelCosts) prov.modelCosts = existingCosts;
+    // ...and to hand-edited context windows. `ProviderPayload` (gui/src/provider-payload.ts)
+    // has no member for either field, so the add/edit form structurally cannot send them:
+    // absence in the request means "not carried", never "the user deleted it". Deletion goes
+    // through PATCH with an explicit null (#1409).
+    const existing = config.providers[name];
+    if (!submittedContextWindow && existing?.contextWindow !== undefined) {
+      prov.contextWindow = existing.contextWindow;
+    }
+    if (existing?.modelContextWindows) {
+      // When the client did send a map, its keys win and the user's other keys survive. When
+      // it did not, the stored value is the user's map alone: merging the registry seed in
+      // would persist seed keys into user config as a side effect of an unrelated save, and
+      // router.ts already fills registry values beneath user entries at resolve time.
+      prov.modelContextWindows = submittedModelContextWindows
+        ? { ...existing.modelContextWindows, ...(prov.modelContextWindows ?? {}) }
+        : { ...existing.modelContextWindows };
+    }
     config.providers[name] = stripRegistryOnlyStaticHeaders(name, prov);
     if (body.setDefault === true) config.defaultProvider = name;
     save(config);

--- a/tests/management-provider-validation.test.ts
+++ b/tests/management-provider-validation.test.ts
@@ -427,6 +427,120 @@ describe("provider management validation", () => {
     }
   });
 
+  // #1409: the add/edit form's payload type has no member for contextWindow or
+  // modelContextWindows, so an overwrite arrives without them. Registry enrichment then fills
+  // the absent fields from the seed and the stored row loses the user's values — for
+  // opencode-go the seed is exactly {"kimi-k3": 262144}, which is what the reporter found in
+  // place of their deepseek-v4-flash override.
+  describe("provider POST overwrite preserves hand-edited context windows (#1409)", () => {
+    async function seedProvider(url: URL, extra: Record<string, unknown>): Promise<Response> {
+      return fetch(new URL("/api/providers", url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "opencode-go",
+          provider: { adapter: "openai-chat", baseUrl: "https://opencode.ai/zen/go/v1", apiKey: "k", ...extra },
+        }),
+      });
+    }
+
+    function freshHome(): void {
+      if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+      mkdirSync(TEST_DIR, { recursive: true });
+      process.env.OPENCODEX_HOME = TEST_DIR;
+      saveConfig(config("127.0.0.1"));
+    }
+
+    test("an omitted modelContextWindows keeps the user's map, without registry seed keys", async () => {
+      freshHome();
+      const server = startServer(0);
+      try {
+        expect((await seedProvider(server.url, { modelContextWindows: { "deepseek-v4-flash": 900000 } })).status).toBe(200);
+        expect((await seedProvider(server.url, {})).status).toBe(200);
+
+        // The user's key survives, and the registry seed is NOT persisted into user config:
+        // router.ts fills registry values beneath user entries at resolve time, so writing
+        // them here would be a side effect of an unrelated save.
+        expect(loadConfig().providers["opencode-go"]?.modelContextWindows).toEqual({ "deepseek-v4-flash": 900000 });
+      } finally {
+        await server.stop(true);
+      }
+    });
+
+    test("a submitted modelContextWindows updates that key and keeps the others", async () => {
+      freshHome();
+      const server = startServer(0);
+      try {
+        expect((await seedProvider(server.url, { modelContextWindows: { "deepseek-v4-flash": 900000 } })).status).toBe(200);
+        expect((await seedProvider(server.url, { modelContextWindows: { "kimi-k3": 300000 } })).status).toBe(200);
+
+        expect(loadConfig().providers["opencode-go"]?.modelContextWindows)
+          .toEqual({ "deepseek-v4-flash": 900000, "kimi-k3": 300000 });
+      } finally {
+        await server.stop(true);
+      }
+    });
+
+    test("an omitted contextWindow keeps the user's scalar", async () => {
+      freshHome();
+      const server = startServer(0);
+      try {
+        expect((await seedProvider(server.url, { contextWindow: 777000 })).status).toBe(200);
+        expect((await seedProvider(server.url, {})).status).toBe(200);
+
+        expect(loadConfig().providers["opencode-go"]?.contextWindow).toBe(777000);
+      } finally {
+        await server.stop(true);
+      }
+    });
+
+    test("a submitted contextWindow still wins", async () => {
+      freshHome();
+      const server = startServer(0);
+      try {
+        expect((await seedProvider(server.url, { contextWindow: 777000 })).status).toBe(200);
+        expect((await seedProvider(server.url, { contextWindow: 512000 })).status).toBe(200);
+
+        expect(loadConfig().providers["opencode-go"]?.contextWindow).toBe(512000);
+      } finally {
+        await server.stop(true);
+      }
+    });
+
+    test("a brand-new provider still receives the registry seed", async () => {
+      freshHome();
+      const server = startServer(0);
+      try {
+        expect((await seedProvider(server.url, {})).status).toBe(200);
+
+        // No prior row exists, so enrichment is authoritative and the seed must land.
+        expect(loadConfig().providers["opencode-go"]?.modelContextWindows).toBeDefined();
+      } finally {
+        await server.stop(true);
+      }
+    });
+
+    test("PATCH can still delete a key with an explicit null", async () => {
+      freshHome();
+      const server = startServer(0);
+      try {
+        expect((await seedProvider(server.url, { modelContextWindows: { "deepseek-v4-flash": 900000 } })).status).toBe(200);
+
+        const patch = await fetch(new URL("/api/providers?name=opencode-go", server.url), {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ modelContextWindows: { "deepseek-v4-flash": null } }),
+        });
+        expect(patch.status).toBe(200);
+
+        // Deletion is an explicit null through PATCH, which the POST carry-over must not undo.
+        expect(loadConfig().providers["opencode-go"]?.modelContextWindows?.["deepseek-v4-flash"]).toBeUndefined();
+      } finally {
+        await server.stop(true);
+      }
+    });
+  });
+
   test("provider management accepts modelCosts on the canonical openai provider", async () => {
     if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
     mkdirSync(TEST_DIR, { recursive: true });


### PR DESCRIPTION
## Summary

`POST /api/providers` loses hand-edited context windows when it overwrites an existing provider.

`ProviderPayload` (`gui/src/provider-payload.ts`) has no member for `contextWindow` or `modelContextWindows`, so the dashboard's add/edit form structurally cannot send them. On an overwrite those fields are therefore absent, `enrichProviderFromCatalog` → `enrichProviderFromRegistry` fills them from the registry seed, and the stored row becomes the seed. For `opencode-go` the seed is exactly `{"kimi-k3": 262144}` — which is what #1409 reports finding in place of a hand-edited `{"deepseek-v4-flash": 900000}`.

The fix follows the precedent already in this function: `apiKeyPool` and `modelCosts` are carried across the same path, with the same rationale — the form does not send them, so absence must not mean deletion. These two fields are the same class of user-owned data and were simply never added to the list.

Two details that matter for review:

- **Ownership is sampled before enrichment.** After `enrichProviderFromCatalog` runs, "the client omitted this field" and "the registry supplied it" are indistinguishable, so a carry-over guard written as `prov.x === undefined` afterwards can never fire. An earlier draft had exactly that bug and its test would have stayed red.
- **When the client omits the map, the stored value is the user's map alone.** Merging the registry seed in would persist seed keys into user config as a side effect of an unrelated save, and `router.ts` already fills registry values *beneath* user entries at resolve time via `mergeRecordFill`.

Deletion is unaffected: it goes through PATCH with an explicit `null`, which the carry-over must not undo, and that is covered by a test.

## Why this does not carry `Closes #1409`

The confirmed reproduction is a **duplicate-name POST through the Add Provider modal**. The dashboard's ordinary editing surfaces use PATCH (`gui/src/pages/use-providers-crud.ts`), and `Models.tsx` sends `modelContextWindows` over PATCH, which merges per key and already preserves unmentioned entries.

The reporter's sequence was an upgrade, a daemon restart, and a later unrelated full-config write. That points at the stale whole-document writer tracked in #1273, and nothing here rules it in or out. So this PR fixes a real, demonstrated data-loss defect on its own merits, and #1409 gets a comment describing what was confirmed rather than a closure it has not earned.

## Verification

On a Linux runner (Bun 1.3.14):

- `bun x tsc --noEmit` — exit 0
- `bun test tests/management-provider-validation.test.ts` — 60 pass, 0 fail
- 60-file provider/config/management sweep — 1023 pass, 0 fail

Red-before evidence: with only the test diff applied to unmodified `dev`, 3 of the new tests fail.

New coverage: an omitted map keeps the user's map **and** does not gain registry seed keys; a submitted map updates that key while other user keys survive; an omitted scalar `contextWindow` is preserved; a submitted scalar still wins; a brand-new provider still receives the registry seed (no regression in enrichment); and PATCH can still delete a key with an explicit null.

This touches a management write boundary, so it wants the security review `src/AGENTS.md` asks for — no auth, credential, or transport behavior changes, but the persisted-config write path does.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Refs #1409, #1273


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved existing provider context-window settings when updates omit those fields.
  - Correctly merged submitted per-model context-window values during provider updates.
  - Prevented registry defaults from being saved as user-configured settings.
  - New providers still receive appropriate registry defaults.
  - Explicitly clearing model-specific settings continues to work as expected.

- **Tests**
  - Added regression coverage for provider creation, updates, merging, preservation, and clearing of context-window settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->