### PR TITLE
fix(codex): bind prompt journal recovery paths

### DIFF
--- a/src/codex/prompt-journal.ts
+++ b/src/codex/prompt-journal.ts
@@ -20,7 +20,7 @@
  * recovery sees a mismatch and overwrites their work with a stale image.
  */
 import { existsSync, mkdirSync, openSync, closeSync, fsyncSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 import { createHash, randomBytes } from "node:crypto";
 import { forgetEphemeralSecretPath, hardenSecretPath, windowsSecretAclApplies } from "../lib/windows-secret-acl";
 
@@ -210,14 +210,40 @@ export type RecoveryOutcome =
   | { ok: true; action: "none" | "committed" | "rolled-back" }
   | { ok: false; error: "recovery_required"; detail: string };
 
+export interface RecoveryTargets {
+  configPath: string;
+  storePath: string;
+}
+
+/** Lexical path identity only: never resolve an untrusted journal path through the filesystem. */
+export function sameRecoveryPath(
+  recordedPath: string,
+  expectedPath: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  const recorded = resolve(recordedPath);
+  const expected = resolve(expectedPath);
+  return platform === "win32"
+    ? recorded.toLowerCase() === expected.toLowerCase()
+    : recorded === expected;
+}
+
 /**
  * Run at service start and at every lock acquisition. Never from a read.
  *
  * A journal on disk means commit never happened, so the default is rollback.
  * The single exception is not a roll-forward: when BOTH targets already hold the
  * post-image the writes had finished and only the journal deletion was missing.
+ *
+ * The expected targets come from the active prompt-layer configuration, not
+ * from the journal. The envelope checksum detects accidental corruption, not a
+ * same-user forgery, so recovery binds the decoded record to those trusted
+ * paths before reading either target.
  */
-export function recoverIfNeeded(journalPath: string): RecoveryOutcome {
+export function recoverIfNeeded(
+  journalPath: string,
+  expectedTargets: RecoveryTargets,
+): RecoveryOutcome {
   const raw = readOrNull(journalPath);
   if (raw === null) return { ok: true, action: "none" };
 
@@ -230,11 +256,22 @@ export function recoverIfNeeded(journalPath: string): RecoveryOutcome {
     };
   }
 
-  const config = classify(readOrNull(record.configPath), record.preConfig, record.postConfig);
-  const store = classify(readOrNull(record.storePath), record.preStore, record.postStore);
+  if (
+    !sameRecoveryPath(record.configPath, expectedTargets.configPath)
+    || !sameRecoveryPath(record.storePath, expectedTargets.storePath)
+  ) {
+    return {
+      ok: false,
+      error: "recovery_required",
+      detail: `journal at ${journalPath} does not match the active prompt-layer paths; nothing was read from its targets`,
+    };
+  }
+
+  const config = classify(readOrNull(expectedTargets.configPath), record.preConfig, record.postConfig);
+  const store = classify(readOrNull(expectedTargets.storePath), record.preStore, record.postStore);
 
   if (config === "unknown" || store === "unknown") {
-    const which = config === "unknown" ? record.configPath : record.storePath;
+    const which = config === "unknown" ? expectedTargets.configPath : expectedTargets.storePath;
     return {
       ok: false,
       error: "recovery_required",
@@ -258,38 +295,38 @@ export function recoverIfNeeded(journalPath: string): RecoveryOutcome {
   // Revalidate each target immediately before its own restore: a target that
   // changed since the initial classification must not be overwritten.
   if (config === "post") {
-    if (classify(readOrNull(record.configPath), record.preConfig, record.postConfig) !== "post") {
+    if (classify(readOrNull(expectedTargets.configPath), record.preConfig, record.postConfig) !== "post") {
       return {
         ok: false,
         error: "recovery_required",
-        detail: `${record.configPath} changed after its first classification; refusing to overwrite it`,
+        detail: `${expectedTargets.configPath} changed after its first classification; refusing to overwrite it`,
       };
     }
     try {
-      restore(record.configPath, record.preConfigBytes);
+      restore(expectedTargets.configPath, record.preConfigBytes);
     } catch (error) {
       return {
         ok: false,
         error: "recovery_required",
-        detail: `rollback of ${record.configPath} failed mid-write: ${error instanceof Error ? error.message : String(error)}`,
+        detail: `rollback of ${expectedTargets.configPath} failed mid-write: ${error instanceof Error ? error.message : String(error)}`,
       };
     }
   }
   if (store === "post") {
-    if (classify(readOrNull(record.storePath), record.preStore, record.postStore) !== "post") {
+    if (classify(readOrNull(expectedTargets.storePath), record.preStore, record.postStore) !== "post") {
       return {
         ok: false,
         error: "recovery_required",
-        detail: `${record.storePath} changed after its first classification; refusing to overwrite it`,
+        detail: `${expectedTargets.storePath} changed after its first classification; refusing to overwrite it`,
       };
     }
     try {
-      restore(record.storePath, record.preStoreBytes);
+      restore(expectedTargets.storePath, record.preStoreBytes);
     } catch (error) {
       return {
         ok: false,
         error: "recovery_required",
-        detail: `rollback of ${record.storePath} failed mid-write: ${error instanceof Error ? error.message : String(error)}`,
+        detail: `rollback of ${expectedTargets.storePath} failed mid-write: ${error instanceof Error ? error.message : String(error)}`,
       };
     }
   }

--- a/src/codex/prompt-layers.ts
+++ b/src/codex/prompt-layers.ts
@@ -650,7 +650,7 @@ function commit(
   try {
     // 1. recovery first: a journal on disk means an earlier attempt never
     //    committed, and we must not stack a second transaction on top of it.
-    const recovered = recoverJournal(journalPath);
+    const recovered = recoverJournal(journalPath, { configPath, storePath });
     if (!recovered.ok) return { ok: false, error: "recovery_required", detail: recovered.detail };
 
     // 2. re-read and compare against the caller's edit base.

--- a/tests/codex-prompt-journal.test.ts
+++ b/tests/codex-prompt-journal.test.ts
@@ -17,6 +17,7 @@ import {
   encodeJournal,
   hashBytes,
   recoverIfNeeded,
+  sameRecoveryPath,
   type JournalRecord,
 } from "../src/codex/prompt-journal";
 import {
@@ -74,6 +75,13 @@ function read(path: string): string | null {
   return existsSync(path) ? readFileSync(path, "utf8") : null;
 }
 
+function recover(s: ReturnType<typeof scenario>) {
+  return recoverIfNeeded(s.journalPath, {
+    configPath: s.configPath,
+    storePath: s.storePath,
+  });
+}
+
 describe("envelope", () => {
   test("round-trips a record", () => {
     const record = { configPath: "/c", storePath: "/s" } as JournalRecord;
@@ -111,17 +119,32 @@ describe("classification", () => {
   });
 });
 
+describe("path binding", () => {
+  test("normalizes lexical segments without following the recorded path", () => {
+    expect(sameRecoveryPath("/tmp/ocx/a/../config.toml", "/tmp/ocx/config.toml", "linux")).toBe(true);
+  });
+
+  test("uses case-insensitive identity only on Windows", () => {
+    const mixed = "C:\\Users\\Alice\\.codex\\config.toml";
+    expect(sameRecoveryPath(mixed, mixed.toLowerCase(), "win32")).toBe(true);
+    expect(sameRecoveryPath(mixed, mixed.toLowerCase(), "linux")).toBe(false);
+  });
+});
+
 describe("recovery", () => {
   test("no journal is a no-op", () => {
     const dir = root();
-    expect(recoverIfNeeded(join(dir, "absent.journal"))).toEqual({ ok: true, action: "none" });
+    expect(recoverIfNeeded(join(dir, "absent.journal"), {
+      configPath: join(dir, "config.toml"),
+      storePath: join(dir, "opencodex-prompt.json"),
+    })).toEqual({ ok: true, action: "none" });
   });
 
   test("both targets at post-image: commit by deleting the journal", () => {
     // The writes finished; only step 6 was missing. This is the ONE case that
     // does not roll back, and it is not a roll-forward.
     const s = scenario({ config: "POST_C", store: "POST_S" });
-    expect(recoverIfNeeded(s.journalPath)).toEqual({ ok: true, action: "committed" });
+    expect(recover(s)).toEqual({ ok: true, action: "committed" });
     expect(read(s.configPath)).toBe("POST_C");
     expect(read(s.storePath)).toBe("POST_S");
     expect(existsSync(s.journalPath)).toBe(false);
@@ -131,7 +154,7 @@ describe("recovery", () => {
     // Crash after config.toml but before the store. A journal on disk means
     // commit never happened, so the transaction is undone.
     const s = scenario({ config: "POST_C", store: "PRE_S" });
-    expect(recoverIfNeeded(s.journalPath)).toEqual({ ok: true, action: "rolled-back" });
+    expect(recover(s)).toEqual({ ok: true, action: "rolled-back" });
     expect(read(s.configPath)).toBe("PRE_C");
     expect(read(s.storePath)).toBe("PRE_S");
     expect(existsSync(s.journalPath)).toBe(false);
@@ -139,7 +162,7 @@ describe("recovery", () => {
 
   test("nothing applied: leave both alone", () => {
     const s = scenario({ config: "PRE_C", store: "PRE_S" });
-    expect(recoverIfNeeded(s.journalPath).ok).toBe(true);
+    expect(recover(s).ok).toBe(true);
     expect(read(s.configPath)).toBe("PRE_C");
     expect(read(s.storePath)).toBe("PRE_S");
   });
@@ -148,7 +171,7 @@ describe("recovery", () => {
     // THE case this module exists for: crash, then Codex or the user edits
     // config.toml. Recovery must not overwrite it with a stale image.
     const s = scenario({ config: "SOMEONE ELSE WROTE THIS", store: "PRE_S" });
-    const result = recoverIfNeeded(s.journalPath);
+    const result = recover(s);
     expect(result.ok).toBe(false);
     expect(read(s.configPath)).toBe("SOMEONE ELSE WROTE THIS");
     expect(existsSync(s.journalPath)).toBe(true);
@@ -158,7 +181,7 @@ describe("recovery", () => {
     // One unknown target aborts the WHOLE recovery: we never repair one file
     // while the other carries a stranger's edit.
     const s = scenario({ config: "POST_C", store: "SOMEONE ELSE" });
-    expect(recoverIfNeeded(s.journalPath).ok).toBe(false);
+    expect(recover(s).ok).toBe(false);
     expect(read(s.configPath)).toBe("POST_C");
     expect(read(s.storePath)).toBe("SOMEONE ELSE");
   });
@@ -166,7 +189,7 @@ describe("recovery", () => {
   test("a corrupt journal is recovery_required, and nothing is written", () => {
     const s = scenario({ config: "POST_C", store: "PRE_S" });
     writeFileSync(s.journalPath, "ocx-journal-v1 deadbeef\n{\"configPath\":\"/x\"}", "utf8");
-    const result = recoverIfNeeded(s.journalPath);
+    const result = recover(s);
     expect(result.ok).toBe(false);
     expect(read(s.configPath)).toBe("POST_C");
     expect(read(s.storePath)).toBe("PRE_S");
@@ -177,7 +200,7 @@ describe("recovery", () => {
     const s = scenario({ config: "POST_C", store: "PRE_S" });
     const encoded = readFileSync(s.journalPath, "utf8");
     writeFileSync(s.journalPath, encoded.slice(0, encoded.length - 20), "utf8");
-    expect(recoverIfNeeded(s.journalPath).ok).toBe(false);
+    expect(recover(s).ok).toBe(false);
     expect(read(s.configPath)).toBe("POST_C");
   });
 
@@ -195,9 +218,37 @@ describe("recovery", () => {
       preConfigBytes: null, postConfigBytes: "POST_C",
       preStoreBytes: "PRE_S", postStoreBytes: "POST_S",
     }), "utf8");
-    expect(recoverIfNeeded(journalPath).ok).toBe(true);
+    expect(recoverIfNeeded(journalPath, { configPath, storePath }).ok).toBe(true);
     expect(existsSync(configPath)).toBe(false);
   });
+
+  for (const mismatchedTarget of ["configPath", "storePath"] as const) {
+    test(`a valid journal with a different ${mismatchedTarget} is rejected before recovery`, () => {
+      const s = scenario({ config: "PRE_C", store: "PRE_S" });
+      const attackerDir = root();
+      const attackerConfigPath = join(attackerDir, "config.toml");
+      const attackerStorePath = join(attackerDir, "opencodex-prompt.json");
+      writeFileSync(attackerConfigPath, "POST_C", "utf8");
+      writeFileSync(attackerStorePath, "PRE_S", "utf8");
+
+      const forgedRecord: JournalRecord = {
+        ...s.record,
+        configPath: mismatchedTarget === "configPath" ? attackerConfigPath : s.configPath,
+        storePath: mismatchedTarget === "storePath" ? attackerStorePath : s.storePath,
+      };
+      writeFileSync(s.journalPath, encodeJournal(forgedRecord), "utf8");
+
+      const result = recover(s);
+      expect(result).toMatchObject({ ok: false, error: "recovery_required" });
+      if (result.ok) throw new Error("forged journal unexpectedly recovered");
+      expect(result.detail).not.toContain(attackerDir);
+      expect(read(attackerConfigPath)).toBe("POST_C");
+      expect(read(attackerStorePath)).toBe("PRE_S");
+      expect(read(s.configPath)).toBe("PRE_C");
+      expect(read(s.storePath)).toBe("PRE_S");
+      expect(existsSync(s.journalPath)).toBe(true);
+    });
+  }
 });
 
 describe("durable write", () => {

--- a/tests/codex-prompt-layers-write.test.ts
+++ b/tests/codex-prompt-layers-write.test.ts
@@ -13,6 +13,11 @@ import {
   writeCustomLayers,
   type CustomLayer,
 } from "../src/codex/prompt-layers";
+import {
+  encodeJournal,
+  hashBytes,
+  type JournalRecord,
+} from "../src/codex/prompt-journal";
 
 const MARKER = "# Auto-injected by opencodex";
 const roots: string[] = [];
@@ -213,6 +218,34 @@ describe("transaction", () => {
     const result = setToggle("apps", false, snap.revision, paths);
     expect(result).toMatchObject({ ok: false, error: "recovery_required" });
     expect(read(paths.configPath)).toBe('model = "x"\n');
+  });
+
+  test("a forged journal cannot redirect recovery away from the active paths", () => {
+    const paths = fixture('model = "x"\n');
+    const attacker = fixture("ATTACKER_POST_CONFIG", "ATTACKER_PRE_STORE");
+    const journalPath = join(paths.root, "opencodex-prompt.journal");
+    const record: JournalRecord = {
+      configPath: attacker.configPath,
+      storePath: attacker.storePath,
+      preConfig: hashBytes("ATTACKER_PRE_CONFIG"),
+      postConfig: hashBytes("ATTACKER_POST_CONFIG"),
+      preStore: hashBytes("ATTACKER_PRE_STORE"),
+      postStore: hashBytes("ATTACKER_POST_STORE"),
+      preConfigBytes: "ATTACKER_PRE_CONFIG",
+      postConfigBytes: "ATTACKER_POST_CONFIG",
+      preStoreBytes: "ATTACKER_PRE_STORE",
+      postStoreBytes: "ATTACKER_POST_STORE",
+    };
+    writeFileSync(journalPath, encodeJournal(record), "utf8");
+
+    const before = readPromptLayers(paths);
+    const result = setToggle("apps", false, before.revision, paths);
+
+    expect(result).toMatchObject({ ok: false, error: "recovery_required" });
+    expect(read(paths.configPath)).toBe('model = "x"\n');
+    expect(read(attacker.configPath)).toBe("ATTACKER_POST_CONFIG");
+    expect(read(attacker.storePath)).toBe("ATTACKER_PRE_STORE");
+    expect(existsSync(journalPath)).toBe(true);
   });
 
   test("a held lock refuses a second writer", () => {


### PR DESCRIPTION
## Summary

- Bind decoded prompt-journal records to the config and store paths selected by the active prompt-layer runtime before reading either recorded target.
- Perform every recovery read, revalidation, restore, and diagnostic through those trusted runtime paths, so a checksum-valid journal cannot redirect rollback to another filesystem target.
- Preserve lexical Windows path identity and existing crash recovery while adding direct and public-callsite regressions for forged config/store paths.
- This is preventive filesystem-authority hardening for the currently dormant prompt-composer write surface; it does not add a new runtime route or claim journal authenticity.

## Verification

- `Bun 1.3.14: bun test --isolate tests/codex-prompt-journal.test.ts tests/codex-prompt-layers-write.test.ts` — 45 pass
- `Bun 1.4.0-canary.1: bun test --isolate tests/codex-prompt-journal.test.ts tests/codex-prompt-layers-write.test.ts` — 45 pass
- `bun x tsc --noEmit` — passed on Bun 1.3.14 and Bun 1.4
- `bun run privacy:scan` — passed on Bun 1.3.14 and Bun 1.4
- `git diff --check`
- Focused security and final diff reviews found no P0-P3 blocker.
- The full local suite was not duplicated; GitHub CI remains the cross-platform/full-suite authority.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
