### PR TITLE
[WRONG BRANCH] feat: add OpenCode Go quota usage

### DIFF
--- a/tests/provider-quota-opencode-go.test.ts
+++ b/tests/provider-quota-opencode-go.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { clearProviderQuotaCache, fetchProviderQuotaReports } from "../src/providers/quota";
+import type { OcxConfig } from "../src/types";
+
+const originalFetch = globalThis.fetch;
+
+function openCodeGoConfig(): OcxConfig {
+  return {
+    defaultProvider: "opencode-go",
+    providers: {
+      "opencode-go": {
+        adapter: "openai-chat",
+        authMode: "key",
+        baseUrl: "https://opencode.ai/zen/v1",
+        apiKey: "opencode-go-secret",
+      },
+    },
+  } as OcxConfig;
+}
+
+beforeEach(() => {
+  clearProviderQuotaCache();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  clearProviderQuotaCache();
+});
+
+describe("OpenCode Go provider quota", () => {
+  test("maps rolling, weekly, and monthly usage from the Go usage endpoint", async () => {
+    const seen: Array<{ url: string; authorization: string | null; redirect?: RequestRedirect }> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const headers = new Headers(init?.headers);
+      seen.push({ url, authorization: headers.get("authorization"), redirect: init?.redirect });
+      if (url !== "https://opencode.ai/zen/go/v1/usage") {
+        return new Response("not found", { status: 404 });
+      }
+      return new Response(JSON.stringify({
+        usage: {
+          rolling: { percent: 12, resetsAt: "2026-08-12T18:00:00Z" },
+          weekly: { percent: 8, resetsAt: "2026-08-17T00:00:00Z" },
+          monthly: { percent: 35, resetsAt: "2026-09-01T00:00:00Z" },
+        },
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+
+    const result = await fetchProviderQuotaReports(openCodeGoConfig(), true);
+
+    expect(seen).toEqual([{
+      url: "https://opencode.ai/zen/go/v1/usage",
+      authorization: "Bearer opencode-go-secret",
+      redirect: "error",
+    }]);
+    expect(result.reports).toHaveLength(1);
+    expect(result.reports[0]?.provider).toBe("opencode-go");
+    expect(result.reports[0]?.source).toBe("opencode-go:usage");
+    expect(result.reports[0]?.quota).toEqual({
+      fiveHourPercent: 12,
+      fiveHourResetAt: Date.parse("2026-08-12T18:00:00Z"),
+      weeklyPercent: 8,
+      weeklyResetAt: Date.parse("2026-08-17T00:00:00Z"),
+      monthlyPercent: 35,
+      monthlyResetAt: Date.parse("2026-09-01T00:00:00Z"),
+      updatedAt: expect.any(Number),
+    });
+    expect(JSON.stringify(result)).not.toContain("opencode-go-secret");
+  });
+});


### PR DESCRIPTION
## Summary

- query OpenCode Go usage from `GET /zen/go/v1/usage`
- map the rolling 5-hour, weekly, and monthly percentages and reset times into provider quota
- authenticate with the configured `OPENCODE_API_KEY` bearer without exposing it in quota responses

## Test plan

- provider quota test for the Go usage endpoint, bearer auth, all three windows, reset timestamps, and credential redaction


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for OpenCode Go quota reporting.
  * Verified quota periods, reset times, report metadata, request authorization, endpoint behavior, and secret redaction.
  * Ensured test isolation by resetting cached quota state and network mocks between tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
