### PR TITLE
test(codex-convergence): update route inventory for #1541's attested reload call

### DIFF
--- a/tests/codex-convergence-contract.test.ts
+++ b/tests/codex-convergence-contract.test.ts
@@ -324,9 +324,9 @@ test("the total lazy adapter preserves a persisted-success route when factory co
   });
 });
 
-test("the route inventory contains exactly the specified 6 + 6 + 2 + 2 convergence calls", () => {
+test("the route inventory contains exactly the specified 7 + 6 + 2 + 2 convergence calls", () => {
   const counts = Object.fromEntries([
-    ["provider-routes.ts", 6],
+    ["provider-routes.ts", 7],
     ["model-routes.ts", 6],
     ["combo-routes.ts", 2],
     ["agent-settings-routes.ts", 2],
@@ -338,7 +338,7 @@ test("the route inventory contains exactly the specified 6 + 6 + 2 + 2 convergen
     return [file, count];
   }));
   expect(counts).toEqual({
-    "provider-routes.ts": 6,
+    "provider-routes.ts": 7,
     "model-routes.ts": 6,
     "combo-routes.ts": 2,
     "agent-settings-routes.ts": 2,


### PR DESCRIPTION
## Problem

`dev` CI is currently red for every open PR: #1541 (`fb4f2fe99`) added a seventh `await convergeCodexCatalog()` to `src/server/management/provider-routes.ts` in the new attested credential-free provider-reload route, but `tests/codex-convergence-contract.test.ts` ("route inventory contains exactly the specified 6 + 6 + 2 + 2 convergence calls") still expects 6. See the analysis on #1500 where the failure surfaced on the merge ref, and @Wibias's confirmation that the stale inventory contract should be repaired on `dev` before merging.

## Fix

Update the inventory contract to the actual call set: expected count for `provider-routes.ts` 6 → 7 in both the map and the final `toEqual`, and the test title to `7 + 6 + 2 + 2`. The seventh call is legitimate — the attested reload route converges the catalog after clearing provider caches, same as every sibling route — so the contract is updated rather than the call removed.

## Tests

`bun test tests/codex-convergence-contract.test.ts` — 12 pass / 0 fail on this branch (`dev` @ `6c5f94a13` + this commit).

Unblocks #1500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated route inventory validation to reflect the current number of convergence calls and expected route totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->