### PR TITLE
perf: route ChatGPT Codex upstream turns over responses_websockets

### DIFF
--- a/src/server/responses/fetch-helpers.ts
+++ b/src/server/responses/fetch-helpers.ts
@@ -1,4 +1,5 @@
 import type { Server } from "bun";
+import { codexWsUpstreamFetch, shouldUseCodexWsUpstream } from "./ws-upstream";
 import { bridgeToResponsesSSE, buildResponseJSON, formatErrorResponse, type ResponsesTerminalStatus } from "../../bridge";
 import {
   getConfigPath,
@@ -131,7 +132,17 @@ export function safeOriginLabel(url: string): string {
 
 
 export function providerFetch(provider: OcxProviderConfig): typeof globalThis.fetch {
-  return (provider as OcxProviderConfig & { fetch?: typeof globalThis.fetch }).fetch ?? globalThis.fetch;
+  const base = (provider as OcxProviderConfig & { fetch?: typeof globalThis.fetch }).fetch ?? globalThis.fetch;
+  // ChatGPT Codex backend: streaming turns ride the responses_websockets
+  // transport (measured ~3s faster TTFT than the SSE POST queue); everything
+  // else keeps the provider's HTTP fetch. See ws-upstream.ts for the details.
+  const wrapped = (input: Parameters<typeof globalThis.fetch>[0], init?: RequestInit) => {
+    if (typeof input === "string" && init && shouldUseCodexWsUpstream(input, init)) {
+      return codexWsUpstreamFetch(input, init, base);
+    }
+    return base(input, init);
+  };
+  return wrapped as typeof globalThis.fetch;
 }
 
 

--- a/src/server/responses/ws-upstream.ts
+++ b/src/server/responses/ws-upstream.ts
@@ -1,0 +1,199 @@
+// Upstream WebSocket transport for the ChatGPT Codex backend.
+//
+// Why this exists: the Codex backend serves the responses_websockets path from
+// a measurably faster queue than the plain SSE POST path. Measured 2026-08-12
+// KST (same account, same payload, strictly sequential): gpt-5.6-luna TTFT p50
+// ~1.0s over WS vs ~3.9s over SSE. Codex CLI itself defaults to the WS
+// transport; opencodex previously always POSTed SSE, which is where its extra
+// 2-3s of TTFT came from.
+//
+// The wrapper only swaps the transport. It dials wss:// with the same headers,
+// sends the JSON body as a single `response.create` frame, and re-encodes the
+// returned event frames as an SSE byte stream, so every downstream consumer
+// (passthrough relay, adapter parsers, usage sniffing) is unchanged.
+
+const CODEX_RESPONSES_HTTP_URL = "https://chatgpt.com/backend-api/codex/responses";
+const CODEX_RESPONSES_WS_URL = "wss://chatgpt.com/backend-api/codex/responses";
+const WS_BETA = "responses_websockets=2026-02-06";
+// If the 101 never arrives (network black hole), give SSE a chance well before
+// the caller's connect timeout (default 200s) would fire.
+const UPGRADE_DEADLINE_MS = 10_000;
+
+export function shouldUseCodexWsUpstream(url: string, init?: RequestInit): boolean {
+  if (url !== CODEX_RESPONSES_HTTP_URL) return false;
+  if ((init?.method ?? "GET").toUpperCase() !== "POST") return false;
+  const body = init?.body;
+  if (typeof body !== "string") return false;
+  // Only root-level stream:true selects WS: JSON-mode calls keep the HTTP path
+  // because the WS path only speaks the event protocol, and a nested
+  // {"metadata":{"stream":true}} must not flip the transport. Parsing (not
+  // substring matching) also keeps whitespace-formatted bodies routable.
+  try {
+    const parsed = JSON.parse(body) as unknown;
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      && (parsed as Record<string, unknown>).stream === true;
+  } catch {
+    return false;
+  }
+}
+
+export function codexWsUpstreamFetch(
+  url: string,
+  init: RequestInit,
+  sseFallback: typeof globalThis.fetch,
+): Promise<Response> {
+  const signal = init.signal ?? undefined;
+  if (signal?.aborted) {
+    return Promise.reject(signal.reason ?? new DOMException("The operation was aborted.", "AbortError"));
+  }
+
+  let frameText: string;
+  try {
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    // The WS create frame is implicitly streaming; the backend rejects the
+    // HTTP-only `stream` flag inside a frame.
+    delete body.stream;
+    frameText = JSON.stringify({ ...body, type: "response.create" });
+  } catch {
+    return sseFallback(url, init);
+  }
+
+  const headers: Record<string, string> = {};
+  new Headers(init.headers ?? {}).forEach((value, key) => {
+    // HTTP-body framing headers do not apply to a WS handshake.
+    if (key === "content-type" || key === "content-length" || key === "accept" || key === "accept-encoding") return;
+    headers[key] = value;
+  });
+  headers["openai-beta"] = headers["openai-beta"]
+    ? headers["openai-beta"].includes("responses_websockets")
+      ? headers["openai-beta"]
+      : `${headers["openai-beta"]}, ${WS_BETA}`
+    : WS_BETA;
+  // A genuine caller `originator` is already in these headers via the forward
+  // set. Never fabricate one here: pool/forward traffic must not impersonate
+  // Codex CLI, per the metadata-integrity contract. (The backend's fast lane
+  // keys on WS + originator, so callers without the tag simply keep their own
+  // provenance and scheduling.)
+
+  return new Promise<Response>((resolve, reject) => {
+    let ws: WebSocket;
+    try {
+      // Bun accepts per-handshake headers; the DOM lib types only list protocol arrays.
+      ws = new WebSocket(CODEX_RESPONSES_WS_URL, { headers } as unknown as string[]);
+    } catch {
+      resolve(sseFallback(url, init));
+      return;
+    }
+
+    let opened = false;
+    let settledPreOpen = false;
+    let terminal = false;
+    let controller: ReadableStreamDefaultController<Uint8Array> | null = null;
+    const encoder = new TextEncoder();
+
+    const upgradeTimer = setTimeout(() => {
+      if (opened || settledPreOpen) return;
+      settledPreOpen = true;
+      try { ws.close(); } catch { /* already closing */ }
+      resolve(sseFallback(url, init));
+    }, UPGRADE_DEADLINE_MS);
+
+    const onAbort = () => {
+      if (!opened) {
+        if (settledPreOpen) return;
+        // Settle BEFORE close(): the close handler treats a pre-open close as
+        // an upgrade rejection and would dial the SSE fallback for a request
+        // the caller just cancelled.
+        settledPreOpen = true;
+        clearTimeout(upgradeTimer);
+        try { ws.close(); } catch { /* already closing */ }
+        reject(signal?.reason ?? new DOMException("The operation was aborted.", "AbortError"));
+        return;
+      }
+      try { ws.close(); } catch { /* already closing */ }
+      if (controller && !terminal) {
+        terminal = true;
+        // Mirror an aborted fetch: the body read rejects with the abort reason.
+        try { controller.error(signal?.reason ?? new DOMException("The operation was aborted.", "AbortError")); } catch { /* stream already done */ }
+      }
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+
+    ws.addEventListener("open", () => {
+      if (settledPreOpen) return;
+      clearTimeout(upgradeTimer);
+      try {
+        ws.send(frameText);
+      } catch {
+        // send() throwing means the frame never left, so no upstream turn
+        // started and the SSE resend cannot double-generate. Falling back
+        // (instead of erroring a synthetic 200 body) keeps the pre-stream
+        // HTTP error/refresh/failover machinery in charge.
+        settledPreOpen = true;
+        try { ws.close(); } catch { /* already closing */ }
+        resolve(sseFallback(url, init));
+        return;
+      }
+      opened = true;
+      const stream = new ReadableStream<Uint8Array>({
+        start(c) { controller = c; },
+        cancel() { try { ws.close(); } catch { /* already closing */ } },
+      });
+      resolve(new Response(stream, {
+        status: 200,
+        // The 101 response headers (x-codex-*-reset-at quota hints) are not
+        // exposed by Bun's WebSocket; the periodic quota poller covers those.
+        headers: { "content-type": "text/event-stream; charset=utf-8" },
+      }));
+    });
+
+    ws.addEventListener("message", (event) => {
+      if (!controller || terminal) return;
+      const text = typeof event.data === "string" ? event.data : "";
+      if (!text) return;
+      let type: unknown;
+      try { type = (JSON.parse(text) as { type?: unknown }).type; } catch { return; }
+      if (typeof type !== "string") return;
+      // Relay only the event surface the SSE path produces today. WS-only
+      // frames (codex.rate_limits, responsesapi.websocket_timing) are dropped
+      // so downstream clients see exactly the stream shape they always got.
+      if (!type.startsWith("response.") && type !== "error") return;
+      try {
+        controller.enqueue(encoder.encode(`event: ${type}\ndata: ${text}\n\n`));
+      } catch {
+        return;
+      }
+      if (type === "response.completed" || type === "response.failed" || type === "response.incomplete" || type === "error") {
+        terminal = true;
+        try { controller.close(); } catch { /* already closed */ }
+        try { ws.close(); } catch { /* already closing */ }
+      }
+    });
+
+    ws.addEventListener("close", () => {
+      signal?.removeEventListener("abort", onAbort);
+      if (!opened) {
+        if (settledPreOpen) return;
+        settledPreOpen = true;
+        clearTimeout(upgradeTimer);
+        // Upgrade rejected (401/403/429/5xx). Retry over plain SSE so the real
+        // HTTP status reaches the existing refresh/rotation handlers. No turn
+        // started upstream, so the resend cannot double-generate.
+        resolve(sseFallback(url, init));
+        return;
+      }
+      if (controller && !terminal) {
+        terminal = true;
+        // Connection dropped before a Responses terminal event. A clean EOF
+        // here would reach clients with no response.completed/failed at all —
+        // relaySseWithFailedTail() only synthesizes a failed terminal when the
+        // body read THROWS. Error the stream like a reset TCP socket.
+        try { controller.error(new Error("codex websocket closed before a Responses terminal event")); } catch { /* stream already done */ }
+      }
+    });
+
+    ws.addEventListener("error", () => {
+      /* Bun always follows error with close; the close handler settles. */
+    });
+  });
+}

--- a/tests/ws-upstream.test.ts
+++ b/tests/ws-upstream.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { providerFetch } from "../src/server/responses/fetch-helpers";
+import { codexWsUpstreamFetch, shouldUseCodexWsUpstream } from "../src/server/responses/ws-upstream";
+import type { OcxProviderConfig } from "../src/types";
+
+const CODEX_URL = "https://chatgpt.com/backend-api/codex/responses";
+
+function streamingInit(body: Record<string, unknown> = {}): RequestInit {
+  return {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: "Bearer test" },
+    body: JSON.stringify({ model: "gpt-5.6-luna", stream: true, ...body }),
+  };
+}
+
+describe("shouldUseCodexWsUpstream", () => {
+  test("matches only streaming POSTs to the Codex backend", () => {
+    expect(shouldUseCodexWsUpstream(CODEX_URL, streamingInit())).toBe(true);
+    // Non-streaming turns keep HTTP: the WS path only speaks the event protocol.
+    expect(shouldUseCodexWsUpstream(CODEX_URL, {
+      method: "POST",
+      body: JSON.stringify({ model: "gpt-5.6-luna" }),
+    })).toBe(false);
+    expect(shouldUseCodexWsUpstream(CODEX_URL, { method: "GET" })).toBe(false);
+    expect(shouldUseCodexWsUpstream("https://api.openai.com/v1/responses", streamingInit())).toBe(false);
+    // Body must be the adapter's serialized string, not a stream.
+    expect(shouldUseCodexWsUpstream(CODEX_URL, { method: "POST", body: new Blob(["x"]) as unknown as string })).toBe(false);
+  });
+
+  test("requires a ROOT-level stream flag, not a serialized substring", () => {
+    // Nested stream:true must not flip the transport.
+    expect(shouldUseCodexWsUpstream(CODEX_URL, {
+      method: "POST",
+      body: JSON.stringify({ model: "gpt-5.6-luna", metadata: { stream: true } }),
+    })).toBe(false);
+    // Whitespace-formatted JSON still routes.
+    expect(shouldUseCodexWsUpstream(CODEX_URL, {
+      method: "POST",
+      body: "{\n  \"model\": \"gpt-5.6-luna\",\n  \"stream\" : true\n}",
+    })).toBe(true);
+    // Non-boolean stream values stay on HTTP.
+    expect(shouldUseCodexWsUpstream(CODEX_URL, {
+      method: "POST",
+      body: JSON.stringify({ stream: "true" }),
+    })).toBe(false);
+    // Malformed JSON stays on HTTP.
+    expect(shouldUseCodexWsUpstream(CODEX_URL, { method: "POST", body: "{\"stream\":true" })).toBe(false);
+  });
+});
+
+type Listener = (event: unknown) => void;
+
+/** Minimal scriptable stand-in for Bun's WebSocket. */
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  static script: (ws: FakeWebSocket) => void = () => {};
+  url: string;
+  sent: string[] = [];
+  closed = false;
+  listeners = new Map<string, Listener[]>();
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+    queueMicrotask(() => FakeWebSocket.script(this));
+  }
+
+  addEventListener(type: string, listener: Listener) {
+    const list = this.listeners.get(type) ?? [];
+    list.push(listener);
+    this.listeners.set(type, list);
+  }
+
+  emit(type: string, event: unknown = {}) {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    this.emit("close", {});
+  }
+}
+
+const RealWebSocket = globalThis.WebSocket;
+
+afterEach(() => {
+  globalThis.WebSocket = RealWebSocket;
+  FakeWebSocket.instances = [];
+  FakeWebSocket.script = () => {};
+});
+
+function installFake(script: (ws: FakeWebSocket) => void) {
+  FakeWebSocket.script = script;
+  globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+}
+
+describe("providerFetch routing", () => {
+  test("routes eligible Codex streaming turns to WS and everything else to the base fetch", async () => {
+    installFake(ws => {
+      ws.emit("open", {});
+      ws.emit("message", { data: JSON.stringify({ type: "response.completed", response: {} }) });
+    });
+    const baseCalls: string[] = [];
+    const sentinel = new Response("base");
+    const provider = {
+      fetch: (async (input: unknown) => {
+        baseCalls.push(String(input));
+        return sentinel.clone();
+      }) as unknown as typeof fetch,
+    } as unknown as OcxProviderConfig;
+    const wrapped = providerFetch(provider);
+
+    // Eligible: WS adapter serves it, base fetch untouched.
+    const wsResponse = await wrapped(CODEX_URL, streamingInit());
+    expect(wsResponse.headers.get("content-type")).toContain("text/event-stream");
+    expect(baseCalls).toHaveLength(0);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    // Non-streaming body: base fetch.
+    await wrapped(CODEX_URL, { method: "POST", body: JSON.stringify({ model: "m" }) });
+    // Different host: base fetch.
+    await wrapped("https://api.openai.com/v1/responses", streamingInit());
+    // Request-object input: base fetch (WS path only handles string URLs).
+    await wrapped(new Request(CODEX_URL, streamingInit() as RequestInit));
+    expect(baseCalls).toHaveLength(3);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+});
+
+describe("codexWsUpstreamFetch", () => {
+  test("relays event frames as an SSE response and sends one response.create frame", async () => {
+    installFake(ws => {
+      ws.emit("open", {});
+      ws.emit("message", { data: JSON.stringify({ type: "codex.rate_limits", limits: {} }) });
+      ws.emit("message", { data: JSON.stringify({ type: "response.created", response: { id: "r1" } }) });
+      ws.emit("message", { data: JSON.stringify({ type: "response.output_text.delta", delta: "hi" }) });
+      ws.emit("message", { data: JSON.stringify({ type: "response.completed", response: { id: "r1" } }) });
+    });
+    const fallback = () => { throw new Error("fallback must not run"); };
+    const response = await codexWsUpstreamFetch(CODEX_URL, streamingInit(), fallback as unknown as typeof fetch);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    const text = await response.text();
+    // WS-only frames are dropped so clients see the exact SSE surface they always got.
+    expect(text).not.toContain("codex.rate_limits");
+    expect(text).toContain("event: response.created");
+    expect(text).toContain('data: {"type":"response.output_text.delta","delta":"hi"}');
+    expect(text).toContain("event: response.completed");
+
+    const ws = FakeWebSocket.instances[0];
+    expect(ws.url).toBe("wss://chatgpt.com/backend-api/codex/responses");
+    expect(ws.sent).toHaveLength(1);
+    const frame = JSON.parse(ws.sent[0]) as Record<string, unknown>;
+    expect(frame.type).toBe("response.create");
+    // The HTTP-only stream flag must not reach the WS create frame.
+    expect("stream" in frame).toBe(false);
+    expect(ws.closed).toBe(true);
+  });
+
+  test("a request body with a top-level type field cannot override the frame discriminator", async () => {
+    installFake(ws => {
+      ws.emit("open", {});
+      ws.emit("message", { data: JSON.stringify({ type: "response.completed", response: {} }) });
+    });
+    await codexWsUpstreamFetch(CODEX_URL, streamingInit({ type: "evil.frame" }), (() => {
+      throw new Error("fallback must not run");
+    }) as unknown as typeof fetch);
+    const frame = JSON.parse(FakeWebSocket.instances[0].sent[0]) as Record<string, unknown>;
+    expect(frame.type).toBe("response.create");
+  });
+
+  test("falls back to the HTTP fetch when the upgrade is rejected before open", async () => {
+    installFake(ws => ws.close());
+    const sentinel = new Response("sse-fallback", { status: 429 });
+    let fallbackCalls = 0;
+    const fallback = (async () => {
+      fallbackCalls += 1;
+      return sentinel;
+    }) as unknown as typeof fetch;
+    const response = await codexWsUpstreamFetch(CODEX_URL, streamingInit(), fallback);
+    // The real HTTP status must reach the existing refresh/rotation handlers.
+    expect(response).toBe(sentinel);
+    expect(fallbackCalls).toBe(1);
+  });
+
+  test("falls back to the HTTP fetch when the frame send throws", async () => {
+    installFake(ws => {
+      ws.send = () => { throw new Error("socket write failed"); };
+      ws.emit("open", {});
+    });
+    const sentinel = new Response("sse-after-send-failure", { status: 200 });
+    let fallbackCalls = 0;
+    const fallback = (async () => {
+      fallbackCalls += 1;
+      return sentinel;
+    }) as unknown as typeof fetch;
+    // The frame never left the client, so no upstream turn started and the SSE
+    // resend is safe; a synthetic 200 with an errored body would bypass the
+    // pre-stream HTTP error/refresh/failover machinery.
+    const response = await codexWsUpstreamFetch(CODEX_URL, streamingInit(), fallback);
+    expect(response).toBe(sentinel);
+    expect(fallbackCalls).toBe(1);
+    expect(FakeWebSocket.instances[0].closed).toBe(true);
+  });
+
+  test("errors the stream when the socket drops before a Responses terminal event", async () => {
+    installFake(ws => {
+      ws.emit("open", {});
+      ws.emit("message", { data: JSON.stringify({ type: "response.created", response: { id: "r1" } }) });
+      ws.close();
+    });
+    const fallback = () => { throw new Error("fallback must not run after open"); };
+    const response = await codexWsUpstreamFetch(CODEX_URL, streamingInit(), fallback as unknown as typeof fetch);
+    // A clean EOF here would let a terminal-less stream reach clients:
+    // relaySseWithFailedTail() only synthesizes response.failed when the body
+    // read throws. The read must therefore reject, like a reset TCP socket.
+    await expect(response.text()).rejects.toThrow("closed before a Responses terminal event");
+  });
+
+  test("a mid-stream drop surfaces as a synthesized failed terminal through the passthrough relay", async () => {
+    const { relaySseWithFailedTail } = await import("../src/server/relay");
+    installFake(ws => {
+      ws.emit("open", {});
+      ws.emit("message", { data: JSON.stringify({ type: "response.created", response: { id: "r1" } }) });
+      ws.emit("message", { data: JSON.stringify({ type: "response.output_text.delta", delta: "partial" }) });
+      // Drop on a later tick: controller.error() discards chunks still queued,
+      // so a synchronous close would erase frames a real client had already
+      // received over the wire.
+      setTimeout(() => ws.close(), 10);
+    });
+    const response = await codexWsUpstreamFetch(CODEX_URL, streamingInit(), (() => {
+      throw new Error("fallback must not run after open");
+    }) as unknown as typeof fetch);
+    const relayed = relaySseWithFailedTail(response.body!, new AbortController());
+    const text = await new Response(relayed).text();
+    expect(text).toContain("event: response.created");
+    // The relay converts the erroring read into a failed terminal + [DONE], so
+    // no client ever sees a terminal-less stream.
+    expect(text).toContain("event: response.failed");
+    expect(text).toContain("data: [DONE]");
+  });
+
+  test("preserves caller headers on the handshake without fabricating an originator", async () => {
+    const seen: Record<string, string>[] = [];
+    FakeWebSocket.script = ws => {
+      ws.emit("open", {});
+      ws.emit("message", { data: JSON.stringify({ type: "response.completed", response: {} }) });
+    };
+    class HeaderCapturingWebSocket extends FakeWebSocket {
+      constructor(url: string, options?: { headers?: Record<string, string> }) {
+        super(url);
+        seen.push(options?.headers ?? {});
+      }
+    }
+    globalThis.WebSocket = HeaderCapturingWebSocket as unknown as typeof WebSocket;
+    const fallback = (() => { throw new Error("fallback must not run"); }) as unknown as typeof fetch;
+
+    await codexWsUpstreamFetch(CODEX_URL, streamingInit(), fallback);
+    // Without a caller originator none is invented: pool/forward traffic must
+    // not impersonate Codex CLI (metadata-integrity contract).
+    expect(seen[0].originator).toBeUndefined();
+    expect(seen[0]["openai-beta"]).toContain("responses_websockets");
+    expect(seen[0].authorization).toBe("Bearer test");
+    // HTTP body-framing headers do not belong on a WS handshake.
+    expect(seen[0]["content-type"]).toBeUndefined();
+
+    // A genuine caller originator is forwarded verbatim.
+    await codexWsUpstreamFetch(CODEX_URL, {
+      ...streamingInit(),
+      headers: { ...streamingInit().headers as Record<string, string>, originator: "codex_cli_rs" },
+    }, fallback);
+    expect(seen[1].originator).toBe("codex_cli_rs");
+  });
+
+  test("aborting before open rejects like an aborted fetch", async () => {
+    installFake(() => { /* never opens */ });
+    const controller = new AbortController();
+    const promise = codexWsUpstreamFetch(CODEX_URL, { ...streamingInit(), signal: controller.signal }, (() => {
+      throw new Error("fallback must not run");
+    }) as unknown as typeof fetch);
+    controller.abort();
+    await expect(promise).rejects.toThrow();
+  });
+});

--- a/tests/ws-upstream.test.ts
+++ b/tests/ws-upstream.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, jest, test } from "bun:test";
 import { providerFetch } from "../src/server/responses/fetch-helpers";
 import { codexWsUpstreamFetch, shouldUseCodexWsUpstream } from "../src/server/responses/ws-upstream";
 import type { OcxProviderConfig } from "../src/types";
@@ -187,6 +187,30 @@ describe("codexWsUpstreamFetch", () => {
     // The real HTTP status must reach the existing refresh/rotation handlers.
     expect(response).toBe(sentinel);
     expect(fallbackCalls).toBe(1);
+  });
+
+  test("falls back to the HTTP fetch when the upgrade deadline elapses without open or close", async () => {
+    jest.useFakeTimers();
+    try {
+      installFake(() => { /* handshake never settles */ });
+      const sentinel = new Response("sse-timeout-fallback", { status: 200 });
+      let fallbackCalls = 0;
+      const fallback = (async () => {
+        fallbackCalls += 1;
+        return sentinel;
+      }) as unknown as typeof fetch;
+
+      const responsePromise = codexWsUpstreamFetch(CODEX_URL, streamingInit(), fallback);
+      expect(FakeWebSocket.instances).toHaveLength(1);
+      jest.advanceTimersByTime(10_000);
+      const response = await responsePromise;
+
+      expect(response).toBe(sentinel);
+      expect(fallbackCalls).toBe(1);
+      expect(FakeWebSocket.instances[0].closed).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   test("falls back to the HTTP fetch when the frame send throws", async () => {


### PR DESCRIPTION
> Maintainer-rebased replacement for #1487 from @kargnas. The contributor fork could not accept the rebased Git object through the GitHub integration after branch synchronization, so this upstream branch preserves the exact reviewed change on current `dev`.

## Problem

Requests proxied through opencodex to the ChatGPT Codex backend consistently showed **2–3s worse TTFT** than the same requests made by Codex CLI directly — even with the same account, same payload, and strictly sequential execution.

Root cause: Codex CLI talks to `chatgpt.com/backend-api/codex/responses` over the **`responses_websockets`** transport, while opencodex always POSTs SSE. The backend serves the WS path from a measurably faster queue.

## Measurements (2026-08-12, same account, same payload, sequential, alternating order)

| transport | gpt-5.6-luna TTFT p50 | mean |
|---|---|---|
| WS (`responses_websockets`) | **1037 ms** | 1212 ms |
| SSE (POST, `stream:true`) | **3897 ms** | 3686 ms |

Event timeline shows the gap is upstream scheduling, not transfer: both paths reach `response.created` in ~0.5s, but SSE then waits 2.4–4.0s before `response.output_item.added` (WS: 0.8–1.3s).

Ruled out: HTTP/2 vs 1.1 (no change), `OpenAI-Beta: responses_websockets` header on the SSE POST (no change), `session_id`/`prompt_cache_key` (no change), warmup effects (no decay over sequential repeats), account differences (A/B with identical account).

A second finding: the fast lane keys on **WS + `originator` tag**, not the transport alone — 60KB turns run ~1.5s with `originator: codex_cli_rs` vs ~4.6s without. The patch defaults the header for callers that don't send one (Codex CLI always does).

## Change

- New `src/server/responses/ws-upstream.ts`: for streaming POSTs to the Codex backend, dial `wss://` with the same headers, send the JSON body as a single `response.create` frame, and re-encode returned event frames as an SSE byte stream — so the passthrough relay, adapter parsers, and usage sniffing are all unchanged.
- `providerFetch()` in `fetch-helpers.ts` wraps the provider fetch with this transport swap. Everything that isn't a Codex-backend streaming turn keeps the exact HTTP path.
- Fallbacks: upgrade rejected (401/403/429/5xx) → retry over plain SSE so the real HTTP status reaches the existing refresh/rotation handlers; no 101 within 10s → SSE; frame-send failure → stream error into the caller's normal transport-retry path. WS-only frames (`codex.rate_limits`, `responsesapi.websocket_timing`) are dropped so clients see exactly the stream shape they always got.

## After patching (local proxy vs direct Codex CLI)

| target | Luna TTFT p50 | Terra TTFT p50 |
|---|---|---|
| codex CLI direct (WS) | 1196 ms | 1426 ms |
| opencodex **before** | 4385–4705 ms | 2951–4431 ms |
| opencodex **after** | **1424 ms** | **1577 ms** |

Also verified: tool-call round-trips (function_call arguments relay), 630KB / 900KB / 1.26MB / 1.5MB input frames, `context_length_exceeded` and `server_is_overloaded` error relay, and ~600 live requests through the patched proxy with no new failure modes.

## Known trade-off

Bun's `WebSocket` does not expose the 101 response headers, so `x-codex-*-reset-at` quota hints are not visible on this path. The periodic quota poller still covers quota tracking. If there's a preferred way to surface those, happy to adjust.

Related: #1217 (stream-stage timing) would make this kind of transport gap visible in the dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebSocket-based streaming for eligible Codex responses.
  * Converts WebSocket messages into the existing streaming response format.
  * Preserves HTTP streaming when requests are ineligible or WebSocket connectivity is unavailable.
  * Supports request cancellation and clean stream termination.

* **Bug Fixes**
  * Improved resilience with fallback handling for invalid requests, connection failures, and upgrade timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->