### PR TITLE
chore(release): require audited dispatch SHA

### DIFF
--- a/.github/scripts/release-dispatch-guard.cjs
+++ b/.github/scripts/release-dispatch-guard.cjs
@@ -1,0 +1,44 @@
+"use strict";
+
+const ALLOWED_RELEASE_REFS = new Set([
+  "refs/heads/main",
+  "refs/heads/preview",
+]);
+
+function validateReleaseDispatch({
+  eventName,
+  ref,
+  expectedSha,
+  actualSha,
+}) {
+  if (eventName !== "workflow_dispatch") {
+    return `Release must be triggered by workflow_dispatch; got ${eventName || "(empty)"}.`;
+  }
+
+  if (!ALLOWED_RELEASE_REFS.has(ref)) {
+    return `Release must run from main or preview; got ${ref || "(empty)"}.`;
+  }
+
+  if (!expectedSha) {
+    return "expected-sha is required; refusing to publish without an audited commit.";
+  }
+
+  if (!/^[0-9a-f]{40}$/.test(expectedSha)) {
+    return `expected-sha must be a full 40-character commit SHA; got ${expectedSha}.`;
+  }
+
+  if (actualSha !== expectedSha) {
+    return (
+      `branch moved after the release audit ` +
+      `(expected ${expectedSha}, got ${actualSha || "(empty)"}) — ` +
+      "refusing to publish an unaudited commit."
+    );
+  }
+
+  return null;
+}
+
+module.exports = {
+  ALLOWED_RELEASE_REFS,
+  validateReleaseDispatch,
+};

--- a/.github/scripts/release-dispatch-guard.test.cjs
+++ b/.github/scripts/release-dispatch-guard.test.cjs
@@ -1,0 +1,66 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { validateReleaseDispatch } = require("./release-dispatch-guard.cjs");
+
+const SHA = "0123456789abcdef0123456789abcdef01234567";
+const OTHER_SHA = "89abcdef0123456789abcdef0123456789abcdef";
+
+function validate(overrides = {}) {
+  return validateReleaseDispatch({
+    eventName: "workflow_dispatch",
+    ref: "refs/heads/main",
+    expectedSha: SHA,
+    actualSha: SHA,
+    ...overrides,
+  });
+}
+
+describe("release dispatch guard", () => {
+  it("accepts an exact audited SHA on main", () => {
+    assert.equal(validate(), null);
+  });
+
+  it("accepts an exact audited SHA on preview", () => {
+    assert.equal(
+      validate({ ref: "refs/heads/preview" }),
+      null,
+    );
+  });
+
+  it("rejects non-workflow_dispatch events", () => {
+    assert.match(
+      validate({ eventName: "push" }),
+      /must be triggered by workflow_dispatch/,
+    );
+  });
+
+  it("rejects release dispatches from unapproved refs", () => {
+    assert.match(
+      validate({ ref: "refs/heads/dev" }),
+      /must run from main or preview/,
+    );
+  });
+
+  it("requires expected-sha", () => {
+    assert.match(
+      validate({ expectedSha: "" }),
+      /expected-sha is required/,
+    );
+  });
+
+  it("requires a full 40-character commit SHA", () => {
+    assert.match(
+      validate({ expectedSha: "0123456" }),
+      /full 40-character commit SHA/,
+    );
+  });
+
+  it("rejects when the selected ref moved after audit", () => {
+    assert.match(
+      validate({ actualSha: OTHER_SHA }),
+      /branch moved after the release audit/,
+    );
+  });
+});

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ on:
         default: true
       expected-sha:
         description: "Immutable release commit this dispatch must publish (fail if the branch moved)"
-        required: false
+        required: true
         type: string
 
 permissions:
@@ -54,7 +54,8 @@ jobs:
           EXPECTED_SHA: ${{ inputs.expected-sha }}
         run: |
           if [ -z "$EXPECTED_SHA" ]; then
-            echo "::warning::no expected-sha supplied; publishing whatever the branch currently points at"
+            echo "::error::expected-sha is required; refusing to publish without an audited commit"
+            exit 1
           elif [ "$GITHUB_SHA" != "$EXPECTED_SHA" ]; then
             echo "::error::branch moved after the release audit (expected ${EXPECTED_SHA}, got ${GITHUB_SHA}) — refusing to publish an unaudited commit"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,20 +29,55 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write # create the matching GitHub Release + version tag after npm publish
-  actions: read # verify the release commit already passed Cross-platform CI
-  pull-requests: read # credit-takeovers looks up landing/source PR authors via gh api
-  id-token: write # OIDC auth for Trusted Publishing + automatic provenance attestation
+permissions: {}
 
 concurrency:
   group: release
   cancel-in-progress: false
 
 jobs:
+  validate-dispatch:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout trusted dispatch guard
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          path: trusted-dispatch
+
+      - name: Validate release dispatch
+        env:
+          EXPECTED_SHA: ${{ inputs.expected-sha }}
+        run: |
+          node - <<'NODE'
+          const { validateReleaseDispatch } = require(
+            "./trusted-dispatch/.github/scripts/release-dispatch-guard.cjs",
+          );
+
+          const failure = validateReleaseDispatch({
+            eventName: process.env.GITHUB_EVENT_NAME,
+            ref: process.env.GITHUB_REF,
+            expectedSha: process.env.EXPECTED_SHA,
+            actualSha: process.env.GITHUB_SHA,
+          });
+
+          if (failure) {
+            console.error(`::error::${failure}`);
+            process.exit(1);
+          }
+          NODE
   publish:
+    needs: validate-dispatch
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
+      actions: read
+      pull-requests: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -557,17 +557,36 @@ describe("GitHub Actions hardening", () => {
     const workflow = await readText(".github/workflows/release.yml");
     const release = Bun.YAML.parse(workflow) as {
       permissions?: Record<string, string>;
-      jobs?: { publish?: { "runs-on"?: string } };
+      jobs?: {
+        "validate-dispatch"?: {
+          "runs-on"?: string;
+          permissions?: Record<string, string>;
+        };
+        publish?: {
+          "runs-on"?: string;
+          needs?: string;
+          permissions?: Record<string, string>;
+        };
+      };
     };
-
-    // Least privilege + never cancel a publish mid-flight.
-    expect(release.permissions).toEqual({
+    
+    // Keep the workflow unprivileged by default. Dispatch validation gets only
+    // read access; write + OIDC permissions exist only on the gated publish job.
+    expect(release.permissions).toEqual({});
+    
+    expect(release.jobs?.["validate-dispatch"]?.["runs-on"]).toBe("ubuntu-latest");
+    expect(release.jobs?.["validate-dispatch"]?.permissions).toEqual({
+      contents: "read",
+    });
+    
+    expect(release.jobs?.publish?.needs).toBe("validate-dispatch");
+    expect(release.jobs?.publish?.["runs-on"]).toBe("ubuntu-latest");
+    expect(release.jobs?.publish?.permissions).toEqual({
       contents: "write",
       actions: "read",
       "pull-requests": "read",
       "id-token": "write",
     });
-    expect(release.jobs?.publish?.["runs-on"]).toBe("ubuntu-latest");
     expect(workflow).toContain("actions: read");
     expect(workflow).toContain("pull-requests: read");
     expect(workflow).toContain("id-token: write");


### PR DESCRIPTION
## Summary

- require `expected-sha` for every manual Release workflow dispatch
- fail closed if the supplied SHA is missing, malformed, or no longer matches the selected release ref
- validate manual release dispatches against trusted guard code loaded from the repository default branch
- allow releases only from `main` and `preview`
- run dispatch validation in a separate read-only job before the privileged publish job can start
- scope GitHub write and OIDC permissions to the publish job instead of granting them workflow-wide
- add focused tests for the release dispatch guard

## Why

The Release workflow is designed to publish an explicitly reviewed and audited commit, but the previous workflow still had two trust gaps.

First, `expected-sha` was optional. A manually dispatched release without it could continue by publishing whatever commit the selected branch currently pointed at.

Second, branch/ref validation happened only after the selected dispatch ref had already been checked out and repository code had begun executing. Since `workflow_dispatch` can be started against a selected branch, that meant release-ref code could run before the workflow had established that the dispatch came from an approved release branch.

This change makes the release path fail closed.

A new `validate-dispatch` job:

- has only `contents: read`
- checks out the dispatch guard explicitly from the repository default branch
- requires the event to be `workflow_dispatch`
- permits only `refs/heads/main` and `refs/heads/preview`
- requires a full 40-character `expected-sha`
- requires `GITHUB_SHA` to exactly match that audited SHA

Only after that validation succeeds can the `publish` job start.

The write-capable permissions required for GitHub release creation and npm Trusted Publishing are now scoped specifically to `publish`, rather than being granted to every job in the workflow.

## Impact

Normal releases through `bun scripts/release.ts` remain compatible because the helper already:

- runs only from `main` or `preview`
- waits for CI before dispatch
- verifies the live remote branch head before dispatch
- supplies `expected-sha=${releaseSha}`

Intentional behavior changes:

- manual releases without `expected-sha` are rejected
- short or malformed SHAs are rejected
- dispatches from branches other than `main` or `preview` are rejected
- the privileged publish job cannot begin unless trusted dispatch validation succeeds

No npm publishing semantics, release channel mapping, or `main`/`preview` release support are removed.

## Validation

Added focused tests covering:

- valid `main` dispatch
- valid `preview` dispatch
- non-`workflow_dispatch` events
- unapproved refs such as `dev`
- missing `expected-sha`
- non-full commit SHAs
- branch movement after audit

CodeRabbit's two security findings covering dispatch trust ordering and trusted guard invocation are now resolved.

## Review

Ready for review.

@lidge-jun @Ingwannu