### PR TITLE
chore(governance): tighten security code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,12 @@
 
 # Repository automation and release security
 /.github/ @lidge-jun @Ingwannu
+/.coderabbit.yaml @lidge-jun @Ingwannu
+/.npmignore @lidge-jun @Ingwannu
+/bunfig.toml @lidge-jun @Ingwannu
 /scripts/release.ts @lidge-jun @Ingwannu
+/scripts/release-notes.ts @lidge-jun @Ingwannu
+/scripts/prepare-package.ts @lidge-jun @Ingwannu
 /package.json @lidge-jun @Ingwannu
 /bun.lock @lidge-jun @Ingwannu
 
@@ -18,6 +23,9 @@
 /src/codex/auth-context.ts @lidge-jun @Ingwannu
 /src/server/auth-cors.ts @lidge-jun @Ingwannu
 /src/server/management-api.ts @lidge-jun @Ingwannu
+/src/lib/admin-secrets.ts @lidge-jun @Ingwannu
+/src/lib/service-secrets.ts @lidge-jun @Ingwannu
+/src/server/management-auth.ts @lidge-jun @Ingwannu
 
 # Governance and security policy
 /AGENTS.md @lidge-jun @Ingwannu


### PR DESCRIPTION
## Summary

- explicitly assign release and package-assembly configuration to the existing security/release CODEOWNERS
- explicitly assign admin, service-token, and management-authentication surfaces to the existing auth/security CODEOWNERS
- leave the repository-wide default ownership unchanged

## Why

Several security-sensitive files currently inherit only the repository-wide default CODEOWNERS rule even though closely related release, authentication, and governance files already use the narrower `@lidge-jun @Ingwannu` ownership boundary.

This change makes that boundary explicit for:

- CodeRabbit configuration
- npm package inclusion rules
- Bun repository configuration
- release-note generation and package preparation
- admin-token and service-token handling
- management API authentication

These files can materially affect review automation, published package contents, release metadata, or credential/authentication behavior, so changes to them should receive the same focused ownership as the surrounding security-sensitive surfaces.

## Impact

This changes ownership/review metadata only.

It does not change runtime behavior, release behavior, credentials, CI execution, or repository ruleset enforcement.

## Review

Ready for review.

@lidge-jun @Ingwannu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership coverage for automation, release, authentication, and management secret files.
  * Assigned designated reviewers for changes to these files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->