### PR TITLE
test(native-profile): bound hosted macOS busy-probe case

### DIFF
--- a/tests/native-profile-manager.test.ts
+++ b/tests/native-profile-manager.test.ts
@@ -1069,6 +1069,10 @@ describe("native main profile transactions", () => {
     ]);
   }, 10_000);
 
+  // This rollback case uses the same encrypted-vault and SQLite setup as the
+  // transaction test above. Hosted macOS can complete the product recovery
+  // successfully after Bun's 5 s default, so the harness must not become the
+  // shorter deadline.
   test("a read-back mismatch restores the exact source and removes the journal", async () => {
     const f = await enrolledFixture();
     const authPath = f.manager.context.authPath;
@@ -1087,7 +1091,7 @@ describe("native main profile transactions", () => {
     expect(readFileSync(join(f.codexHome, "auth.json"), "utf8")).toBe(f.source);
     expect((await failing.doctor()).recoveryPending).toBe(false);
     expect((await failing.list()).activeProfileId).toBe(f.sourceProfile.id);
-  });
+  }, 10_000);
 
   test("rollback verification failure retains the encrypted recovery journal and never claims success", async () => {
     const f = await enrolledFixture();

--- a/tests/native-profile-manager.test.ts
+++ b/tests/native-profile-manager.test.ts
@@ -1113,6 +1113,10 @@ describe("native main profile transactions", () => {
     expect(journal).not.toContain("opaque-refresh-target");
   });
 
+  // The rejection is immediate once the injected process probe runs, but the
+  // shared enrollment fixture still performs encrypted-vault and SQLite setup.
+  // Hosted macOS can push that setup past Bun's 5 s default under full-suite
+  // load, so keep the harness budget above the manager's own lock deadline.
   test("normal switch rejects a busy native Codex process before publishing any transaction file", async () => {
     const f = await enrolledFixture();
     const blocked = new NativeProfileManager({
@@ -1126,7 +1130,7 @@ describe("native main profile transactions", () => {
     expect(readFileSync(blocked.context.authPath, "utf8")).toBe(f.source);
     expect(existsSync(blocked.context.journalPath)).toBe(false);
     expect((await blocked.list()).activeProfileId).toBe(f.sourceProfile.id);
-  });
+  }, 10_000);
 
   test("vault-write failure after auth replacement restores exact source and removes the journal", async () => {
     const f = await enrolledFixture();


### PR DESCRIPTION
## Summary

- give the deterministic busy-process rejection case its own 10-second Bun harness budget
- document why hosted macOS full-suite setup can cross the default deadline
- leave the product's SQLite lock deadline and `CODEX_BUSY` behavior unchanged

Closes #1563

## Verification

```bash
# repeated five times under the requested 2-core limit
taskset -c 0,1 bun test --isolate tests/native-profile-manager.test.ts --test-name-pattern 'normal switch rejects a busy native Codex process'
bun run typecheck
bun run privacy:scan
git diff --check
```

Focused result: 5/5 passes. Typecheck and privacy scan are green.

## Checklist

- [x] The change is limited to the flaky test harness budget.
- [x] The product timeout and runtime behavior are unchanged.
- [x] The hosted-macOS reason is recorded next to the test.
- [x] No GUI or wording surface changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Increased rollback and busy-process test timeouts to 10 seconds for more reliable test execution.
  * Added comments explaining the timeout rationale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->