### PR TITLE
fix(cursor): expose Grok 4.6 xhigh thinking

### DIFF
--- a/src/adapters/cursor/effort-map.ts
+++ b/src/adapters/cursor/effort-map.ts
@@ -35,10 +35,9 @@ const CURSOR_MODEL_EFFORT_TIERS: Record<string, readonly string[]> = {
   // cursor-grok-4.5-{low,medium,high}-fast. The bare Fast id returns not_found.
   "grok-4.5": ["low", "medium", "high"],
   "grok-4.5-fast": ["low", "medium", "high"],
-  // 260813 preemptive: grok-4.6 tiers mirrored from grok-4.5 ahead of Cursor's lineup update,
-  // so the suffix/wire handling is already correct the day the slugs appear.
-  "grok-4.6": ["low", "medium", "high"],
-  "grok-4.6-fast": ["low", "medium", "high"],
+  // Cursor Agent CLI lists low, medium, high, and xhigh for Grok 4.6.
+  "grok-4.6": ["low", "medium", "high", "xhigh"],
+  "grok-4.6-fast": ["low", "medium", "high", "xhigh"],
   "gpt-5.1": ["low", "high"],
   "gpt-5.1-codex-max": ["low", "medium", "high", "xhigh"],
   "gpt-5.1-codex-mini": ["low", "high"],

--- a/tests/cursor-effort-suffix.test.ts
+++ b/tests/cursor-effort-suffix.test.ts
@@ -135,6 +135,13 @@ describe("Cursor per-model reasoning-effort suffix", () => {
     }
   });
 
+  test("grok-4.6 exposes Cursor's xhigh tier", () => {
+    expect(modelIdFor("cursor/grok-4.6", "low")).toBe("cursor-grok-4.6-low");
+    expect(modelIdFor("cursor/grok-4.6", "high")).toBe("cursor-grok-4.6-high");
+    expect(modelIdFor("cursor/grok-4.6", "xhigh")).toBe("cursor-grok-4.6-xhigh");
+    expect(cursorModelEffortLadder("grok-4.6")).toEqual(["low", "medium", "high", "xhigh"]);
+  });
+
   test("kimi-k3 maps to its live effort-suffixed variants", () => {
     expect(modelIdFor("cursor/kimi-k3", "low")).toBe("kimi-k3-low");
     expect(modelIdFor("cursor/kimi-k3", "medium")).toBe("kimi-k3-high");


### PR DESCRIPTION
## Summary

- Extend the existing Cursor Grok 4.6 effort ladder with the `xhigh` tier advertised by the Cursor Agent CLI.
- Map `cursor/grok-4.6[effort=xhigh]` to Cursor wire model `cursor-grok-4.6-xhigh`.
- Add a regression test for the wire ID and the Codex-facing picker ladder.

This intentionally complements, rather than duplicates, #1547, which verifies the existing low/medium/high Grok 4.6 support.

## Verification

- `bun test tests/cursor-effort-suffix.test.ts tests/cursor-discovery.test.ts` — 21 passed
- `bun run typecheck` — passed
- Live local OpenCodex probe through authenticated Cursor: `cursor/grok-4.6` returned HTTP 200 for `low`, `high`, and `xhigh`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. No public docs change: this only adds an advertised picker tier.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. No auth or transport behavior changed.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
