### PR TITLE
fix(responses): promote deferred tools in routed passthrough

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -400,6 +400,112 @@ function normalizeToolSchemas(body: unknown): unknown {
   return normalizedBody;
 }
 
+function activateDeferredTool(tool: Record<string, unknown>): Record<string, unknown> {
+  const { defer_loading: _, ...activeTool } = tool;
+  if (tool.type !== "namespace" || !Array.isArray(tool.tools)) return activeTool;
+  return {
+    ...activeTool,
+    tools: tool.tools.map(inner => isPlainObject(inner) ? activateDeferredTool(inner) : inner),
+  };
+}
+
+function mergeLoadedTools(declaredTools: unknown[], loadedTools: unknown[]): unknown[] {
+  const merged = [...declaredTools];
+  let changed = false;
+
+  for (const candidate of loadedTools) {
+    if (!isPlainObject(candidate) || typeof candidate.name !== "string") continue;
+    const loaded = activateDeferredTool(candidate);
+    if (loaded.type === "namespace" && Array.isArray(loaded.tools)) {
+      const namespaceIndex = merged.findIndex(tool =>
+        isPlainObject(tool) && tool.type === "namespace" && tool.name === loaded.name
+      );
+      if (namespaceIndex < 0) {
+        merged.push(loaded);
+        changed = true;
+        continue;
+      }
+
+      const namespace = merged[namespaceIndex];
+      if (!isPlainObject(namespace)) continue;
+      const namespaceTools = Array.isArray(namespace.tools) ? namespace.tools : [];
+      const nextNamespaceTools = [...namespaceTools];
+      let namespaceChanged = "defer_loading" in namespace;
+      for (const tool of loaded.tools) {
+        if (!isPlainObject(tool) || typeof tool.name !== "string") continue;
+        const declaredIndex = nextNamespaceTools.findIndex(declared =>
+          isPlainObject(declared) && declared.name === tool.name
+        );
+        if (declaredIndex < 0) {
+          nextNamespaceTools.push(tool);
+          namespaceChanged = true;
+          continue;
+        }
+        const declared = nextNamespaceTools[declaredIndex];
+        if (isPlainObject(declared) && "defer_loading" in declared) {
+          nextNamespaceTools[declaredIndex] = activateDeferredTool(declared);
+          namespaceChanged = true;
+        }
+      }
+      if (!namespaceChanged) continue;
+      const { defer_loading: _, ...activeNamespace } = namespace;
+      merged[namespaceIndex] = { ...activeNamespace, tools: nextNamespaceTools };
+      changed = true;
+      continue;
+    }
+
+    const declaredIndex = merged.findIndex(tool =>
+      isPlainObject(tool) && tool.type !== "namespace" && tool.name === loaded.name
+    );
+    if (declaredIndex < 0) {
+      merged.push(loaded);
+      changed = true;
+    } else {
+      const declared = merged[declaredIndex];
+      if (isPlainObject(declared) && "defer_loading" in declared) {
+        merged[declaredIndex] = activateDeferredTool(declared);
+        changed = true;
+      }
+    }
+  }
+
+  return changed ? merged : declaredTools;
+}
+
+/**
+ * Client-executed tool search only changes Codex's parsed tool context. Routed passthrough keeps
+ * serializing the raw request, so activate those returned definitions for upstreams that do not
+ * implement the native deferred-loading handshake themselves.
+ */
+function promoteClientLoadedTools(body: unknown): unknown {
+  if (!isPlainObject(body) || !Array.isArray(body.input)) return body;
+
+  const loadedTools = body.input.flatMap(item =>
+    isPlainObject(item) && item.type === "tool_search_output" && Array.isArray(item.tools)
+      ? item.tools
+      : []
+  );
+  if (loadedTools.length === 0) return body;
+
+  if (Array.isArray(body.tools)) {
+    const tools = mergeLoadedTools(body.tools, loadedTools);
+    return tools === body.tools ? body : { ...body, tools };
+  }
+
+  const additionalToolsIndex = body.input.findIndex(item =>
+    isPlainObject(item) && item.type === "additional_tools" && Array.isArray(item.tools)
+  );
+  if (additionalToolsIndex < 0) return { ...body, tools: mergeLoadedTools([], loadedTools) };
+
+  const additionalTools = body.input[additionalToolsIndex];
+  if (!isPlainObject(additionalTools) || !Array.isArray(additionalTools.tools)) return body;
+  const tools = mergeLoadedTools(additionalTools.tools, loadedTools);
+  if (tools === additionalTools.tools) return body;
+  const input = [...body.input];
+  input[additionalToolsIndex] = { ...additionalTools, tools };
+  return { ...body, input };
+}
+
 const MAX_RESPONSES_CALL_ID_LENGTH = 64;
 const REPAIRED_CALL_ID_PREFIX = "call_ocx_";
 const REPAIRED_CALL_ID_DIGEST_LENGTH = MAX_RESPONSES_CALL_ID_LENGTH - REPAIRED_CALL_ID_PREFIX.length;
@@ -1297,6 +1403,9 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
       // rewrite while the server still routes it as a summarizer turn (#422).
       if (parsed._compactionRequest === true && !isCanonicalOpenAiForwardProvider(provider)) {
         outBody = buildRoutedCompactionBody(outBody);
+      }
+      if (!isCanonicalOpenAiForwardProvider(provider)) {
+        outBody = promoteClientLoadedTools(outBody);
       }
       if (provider.authMode !== "forward") {
         outBody = rewriteRoutedCustomToolsForUpstream(outBody).body;

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -239,6 +239,162 @@ describe("DeepSeek Responses endpoint contract", () => {
 });
 
 describe("OpenAI Responses passthrough sanitization", () => {
+  const deferredToolBody = {
+    model: "routed-model",
+    input: [
+      {
+        type: "tool_search_call",
+        call_id: "call_search",
+        execution: "client",
+        arguments: { query: "deferred read" },
+      },
+      {
+        type: "tool_search_output",
+        call_id: "call_search",
+        status: "completed",
+        execution: "client",
+        tools: [{
+          type: "namespace",
+          name: "workspace",
+          description: "Workspace tools",
+          tools: [{
+            type: "function",
+            name: "deferred_read",
+            description: "Read deferred data",
+            strict: false,
+            defer_loading: true,
+            parameters: {
+              type: "object",
+              properties: { id: { type: "string" } },
+              required: ["id"],
+              additionalProperties: false,
+            },
+          }, {
+            type: "function",
+            name: "declared_deferred_read",
+            description: "Read declared deferred data",
+            defer_loading: true,
+            parameters: { type: "object", properties: {}, additionalProperties: false },
+          }],
+        }],
+      },
+    ],
+    tools: [
+      {
+        type: "namespace",
+        name: "workspace",
+        description: "Workspace tools",
+        tools: [{
+          type: "function",
+          name: "upfront_read",
+          description: "Read upfront data",
+          parameters: { type: "object", properties: {}, additionalProperties: false },
+        }, {
+          type: "function",
+          name: "declared_deferred_read",
+          description: "Read declared deferred data",
+          defer_loading: true,
+          parameters: { type: "object", properties: {}, additionalProperties: false },
+        }],
+      },
+      {
+        type: "tool_search",
+        execution: "client",
+        description: "Search deferred tools",
+        parameters: {
+          type: "object",
+          properties: { query: { type: "string" } },
+          required: ["query"],
+          additionalProperties: false,
+        },
+      },
+    ],
+  };
+
+  test("routed passthrough promotes tool-search results into the active namespace", () => {
+    const adapter = createResponsesPassthroughAdapter({
+      adapter: "openai-responses",
+      baseUrl: "https://provider.example/v1",
+      authMode: "key",
+      apiKey: "test-key",
+    });
+    const body = JSON.parse(adapter.buildRequest({
+      modelId: deferredToolBody.model,
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: deferredToolBody,
+    }, { headers: new Headers() }).body) as {
+      tools: Array<{
+        type: string;
+        name?: string;
+        tools?: Array<{ name: string; defer_loading?: boolean }>;
+      }>;
+    };
+
+    const namespace = body.tools.find(tool => tool.type === "namespace" && tool.name === "workspace");
+    expect(namespace?.tools?.map(tool => tool.name)).toEqual([
+      "upfront_read",
+      "declared_deferred_read",
+      "deferred_read",
+    ]);
+    expect(namespace?.tools?.find(tool => tool.name === "declared_deferred_read"))
+      .not.toHaveProperty("defer_loading");
+    expect(namespace?.tools?.find(tool => tool.name === "deferred_read"))
+      .not.toHaveProperty("defer_loading");
+  });
+
+  test("canonical forward passthrough leaves tool-search loading to the native backend", () => {
+    const body = JSON.parse(createResponsesPassthroughAdapter(provider).buildRequest({
+      modelId: deferredToolBody.model,
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: deferredToolBody,
+    }, { headers: new Headers({ authorization: "Bearer test" }) }).body) as { tools: unknown[] };
+
+    expect(body.tools).toEqual(deferredToolBody.tools);
+  });
+
+  test("routed passthrough promotes tool-search results into Responses Lite additional tools", () => {
+    const adapter = createResponsesPassthroughAdapter({
+      adapter: "openai-responses",
+      baseUrl: "https://provider.example/v1",
+      authMode: "key",
+      apiKey: "test-key",
+    });
+    const { tools, ...bodyWithoutTools } = deferredToolBody;
+    const rawBody = {
+      ...bodyWithoutTools,
+      input: [
+        ...bodyWithoutTools.input,
+        { type: "additional_tools", role: "developer", tools },
+      ],
+    };
+    const body = JSON.parse(adapter.buildRequest({
+      modelId: rawBody.model,
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: rawBody,
+    }, { headers: new Headers() }).body) as {
+      tools?: unknown[];
+      input: Array<{
+        type: string;
+        tools?: Array<{ type: string; name?: string; tools?: Array<{ name: string }> }>;
+      }>;
+    };
+
+    expect(body.tools).toBeUndefined();
+    const additionalTools = body.input.find(item => item.type === "additional_tools")?.tools;
+    const namespace = additionalTools?.find(tool => tool.type === "namespace" && tool.name === "workspace");
+    expect(namespace?.tools?.map(tool => tool.name)).toEqual([
+      "upfront_read",
+      "declared_deferred_read",
+      "deferred_read",
+    ]);
+  });
+
   test("normalizes top-level function schemas in the serialized raw body (#745)", () => {
     const validParameters = {
       type: "object",


### PR DESCRIPTION
## Summary

- Promote tool definitions returned by client-executed `tool_search` before forwarding noncanonical Responses passthrough requests.
- Merge loaded namespace tools into either top-level `tools` or Responses Lite `additional_tools`, activate returned deferred declarations without duplicating existing names, and preserve canonical forward behavior.

## Verification

- `bun test tests/openai-responses-passthrough.test.ts` (68 pass)
- `bun run typecheck`
- `bun run privacy:scan`
- `git diff --check`
- `bun run test` was also exercised outside the restricted sandbox; unrelated timing-sensitive shim and WebSocket tests did not complete cleanly, while the focused passthrough suite stayed green.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No user-facing configuration change.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
