### PR TITLE
fix(service): preserve rollback before startup tier migration

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,7 +1,7 @@
 import * as readline from "node:readline";
-import { constants as fsConstants, copyFileSync, existsSync, readFileSync, unlinkSync } from "node:fs";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { injectCodexConfig } from "../codex/inject";
-import { classifyOpenAiTierBackup, getConfigPath, getDefaultConfig, isValidProviderName, saveConfig } from "../config";
+import { classifyOpenAiTierBackup, getConfigPath, getDefaultConfig, isValidProviderName, preserveOpenAiTierRollbackSnapshot, saveConfig } from "../config";
 import { enrichProviderFromCatalog } from "../oauth/key-providers";
 import { deriveInitProviders } from "../providers/derive";
 import type { OcxConfig, OcxProviderConfig } from "../types";
@@ -80,21 +80,8 @@ export function cleanupOpenAiTierBackupAfterInit(configPath = getConfigPath()): 
       unlinkSync(backup);
       return;
     }
-    // Publish the preserved snapshot with a no-replace copy (COPYFILE_EXCL) so a
-    // destination collision (frozen/rolled-back clock, pre-created file) can never
-    // silently overwrite another rollback snapshot; retry with a sequence suffix.
-    for (let attempt = 0; attempt < 16; attempt++) {
-      const preserved = `${configPath}.pre-openai-tiers-v1-rollback.${Date.now()}${attempt ? `-${attempt}` : ""}.bak`;
-      try {
-        copyFileSync(backup, preserved, fsConstants.COPYFILE_EXCL);
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "EEXIST") continue;
-        throw error;
-      }
-      unlinkSync(backup);
-      console.warn(`⚠️  Kept your pre-migration config rollback snapshot at ${preserved}`);
-      return;
-    }
+    const preserved = preserveOpenAiTierRollbackSnapshot(configPath);
+    console.warn(`⚠️  Kept your pre-migration config rollback snapshot at ${preserved}`);
   } catch { /* cleanup is best-effort; never block init on backup housekeeping */ }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { chmodSync, copyFileSync, existsSync, linkSync, lstatSync, mkdirSync, readFileSync, realpathSync, renameSync, truncateSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, constants as fsConstants, copyFileSync, existsSync, linkSync, lstatSync, mkdirSync, readFileSync, realpathSync, renameSync, truncateSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { Database } from "bun:sqlite";
@@ -373,7 +373,21 @@ export class OpenAiTierBackupRollbackError extends Error {
 }
 
 export class OpenAiTierBackupCollisionError extends Error {
-  constructor() { super("Existing OpenAI tier backup differs from the current config"); this.name = "OpenAiTierBackupCollisionError"; }
+  readonly configPath?: string;
+  constructor(configPath?: string) {
+    super("Existing OpenAI tier backup differs from the current config");
+    this.name = "OpenAiTierBackupCollisionError";
+    this.configPath = configPath;
+  }
+}
+
+export class OpenAiTierRollbackPreserveError extends Error {
+  readonly code?: "missing" | "not-rollback" | "mismatch" | "exhausted";
+  constructor(message: string, options?: ErrorOptions & { code?: OpenAiTierRollbackPreserveError["code"] }) {
+    super(message, options);
+    this.name = "OpenAiTierRollbackPreserveError";
+    this.code = options?.code;
+  }
 }
 
 export class OpenAiTierBackupSecretResidualError extends Error {
@@ -461,7 +475,7 @@ export function backupConfigBeforeOpenAiTierMigration(
       // point would be surprising and potentially destructive.
       const backupBytes = io.read(backup);
       if (classifyOpenAiTierBackup(backupBytes) === "rollback") {
-        throw new OpenAiTierBackupCollisionError();
+        throw new OpenAiTierBackupCollisionError(source);
       }
       console.warn("[openai-provider-migration] Replacing stale pre-migration backup (post-migration config was rewritten since last migration).");
       io.unlink(backup);
@@ -516,7 +530,7 @@ export function backupConfigBeforeOpenAiTierMigration(
     } catch (cause) {
       if (!isAlreadyExistsError(cause)) throw cause;
       const winner = io.read(backup);
-      if (!sameBytes(original, winner)) throw new OpenAiTierBackupCollisionError();
+      if (!sameBytes(original, winner)) throw new OpenAiTierBackupCollisionError(source);
       scrubUnpublishedTemp();
       return "reused";
     }
@@ -550,6 +564,67 @@ export function backupConfigBeforeOpenAiTierMigration(
     }
     throw cause;
   }
+}
+
+export interface OpenAiTierRollbackPreserveIO {
+  exists(path: string): boolean;
+  read(path: string): Uint8Array;
+  copyExclusive(source: string, destination: string): void;
+  unlink(path: string): void;
+}
+
+const DEFAULT_ROLLBACK_PRESERVE_IO: OpenAiTierRollbackPreserveIO = {
+  exists: existsSync,
+  read: target => readFileSync(target),
+  copyExclusive: (source, destination) => {
+    copyFileSync(source, destination, fsConstants.COPYFILE_EXCL);
+  },
+  unlink: unlinkSync,
+};
+
+const OPENAI_TIER_ROLLBACK_PRESERVE_ATTEMPTS = 16;
+
+/**
+ * Copy a rollback-classified `.pre-openai-tiers-v2.bak` to a unique
+ * `.pre-openai-tiers-v1-rollback.<timestamp>[suffix].bak` path, then unlink the
+ * blocking v2 name. The original bytes are copied with no-replace publication;
+ * the v2 path is removed only after the copy is verified. Shared by startup
+ * migration recovery and `ocx init` cleanup so the two paths cannot drift.
+ */
+export function preserveOpenAiTierRollbackSnapshot(
+  configPath = getConfigPath(),
+  io: OpenAiTierRollbackPreserveIO = DEFAULT_ROLLBACK_PRESERVE_IO,
+): string {
+  const backup = `${configPath}.pre-openai-tiers-v2.bak`;
+  if (!io.exists(backup)) {
+    throw new OpenAiTierRollbackPreserveError("OpenAI tier rollback backup is missing", { code: "missing" });
+  }
+  const original = io.read(backup);
+  if (classifyOpenAiTierBackup(original) !== "rollback") {
+    throw new OpenAiTierRollbackPreserveError("OpenAI tier backup is not a rollback snapshot", { code: "not-rollback" });
+  }
+  for (let attempt = 0; attempt < OPENAI_TIER_ROLLBACK_PRESERVE_ATTEMPTS; attempt++) {
+    const preserved = `${configPath}.pre-openai-tiers-v1-rollback.${Date.now()}${attempt ? `-${attempt}` : ""}.bak`;
+    try {
+      io.copyExclusive(backup, preserved);
+    } catch (error) {
+      if (isAlreadyExistsError(error)) continue;
+      throw error;
+    }
+    let copied: Uint8Array;
+    try {
+      copied = io.read(preserved);
+    } catch (error) {
+      throw new OpenAiTierRollbackPreserveError("Failed to read preserved rollback snapshot", { cause: error, code: "mismatch" });
+    }
+    if (!sameBytes(original, copied)) {
+      try { io.unlink(preserved); } catch { /* keep the original backup; incomplete copy is best-effort */ }
+      throw new OpenAiTierRollbackPreserveError("Preserved rollback snapshot does not match source bytes", { code: "mismatch" });
+    }
+    io.unlink(backup);
+    return preserved;
+  }
+  throw new OpenAiTierRollbackPreserveError("Unable to find a unique rollback snapshot path", { code: "exhausted" });
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -382,7 +382,7 @@ export class OpenAiTierBackupCollisionError extends Error {
 }
 
 export class OpenAiTierRollbackPreserveError extends Error {
-  readonly code?: "missing" | "not-rollback" | "mismatch" | "exhausted";
+  readonly code?: "missing" | "not-rollback" | "mismatch" | "exhausted" | "changed";
   constructor(message: string, options?: ErrorOptions & { code?: OpenAiTierRollbackPreserveError["code"] }) {
     super(message, options);
     this.name = "OpenAiTierRollbackPreserveError";
@@ -570,6 +570,7 @@ export interface OpenAiTierRollbackPreserveIO {
   exists(path: string): boolean;
   read(path: string): Uint8Array;
   copyExclusive(source: string, destination: string): void;
+  harden(path: string): void;
   unlink(path: string): void;
 }
 
@@ -579,6 +580,13 @@ const DEFAULT_ROLLBACK_PRESERVE_IO: OpenAiTierRollbackPreserveIO = {
   copyExclusive: (source, destination) => {
     copyFileSync(source, destination, fsConstants.COPYFILE_EXCL);
   },
+  harden: target => {
+    try { chmodSync(target, 0o600); } catch { /* platform may ignore chmod */ }
+    // Same Windows ACL path as v2 migration backup: required:false so a wedged
+    // icacls on CI temp volumes cannot abort start, but the secret-path helper
+    // still runs. CopyFile does not copy the source DACL.
+    if (process.platform === "win32") hardenSecretPath(target, { required: false });
+  },
   unlink: unlinkSync,
 };
 
@@ -587,8 +595,9 @@ const OPENAI_TIER_ROLLBACK_PRESERVE_ATTEMPTS = 16;
 /**
  * Copy a rollback-classified `.pre-openai-tiers-v2.bak` to a unique
  * `.pre-openai-tiers-v1-rollback.<timestamp>[suffix].bak` path, then unlink the
- * blocking v2 name. The original bytes are copied with no-replace publication;
- * the v2 path is removed only after the copy is verified. Shared by startup
+ * blocking v2 name. Order is copy → verify bytes → harden → re-read source →
+ * unlink source. The v2 path is removed only after the copy is verified, the
+ * destination is hardened, and the source still matches. Shared by startup
  * migration recovery and `ocx init` cleanup so the two paths cannot drift.
  */
 export function preserveOpenAiTierRollbackSnapshot(
@@ -615,11 +624,22 @@ export function preserveOpenAiTierRollbackSnapshot(
     try {
       copied = io.read(preserved);
     } catch (error) {
+      try { io.unlink(preserved); } catch { /* unverified copy cleanup is best-effort; never unlink the source */ }
       throw new OpenAiTierRollbackPreserveError("Failed to read preserved rollback snapshot", { cause: error, code: "mismatch" });
     }
     if (!sameBytes(original, copied)) {
       try { io.unlink(preserved); } catch { /* keep the original backup; incomplete copy is best-effort */ }
       throw new OpenAiTierRollbackPreserveError("Preserved rollback snapshot does not match source bytes", { code: "mismatch" });
+    }
+    io.harden(preserved);
+    let sourceNow: Uint8Array;
+    try {
+      sourceNow = io.read(backup);
+    } catch (error) {
+      throw new OpenAiTierRollbackPreserveError("Failed to re-read OpenAI tier rollback backup before unlink", { cause: error, code: "changed" });
+    }
+    if (!sameBytes(copied, sourceNow)) {
+      throw new OpenAiTierRollbackPreserveError("OpenAI tier rollback backup changed after it was copied", { code: "changed" });
     }
     io.unlink(backup);
     return preserved;

--- a/src/providers/openai-tier-startup.ts
+++ b/src/providers/openai-tier-startup.ts
@@ -1,4 +1,10 @@
-import { backupConfigBeforeOpenAiTierMigration, saveConfig } from "../config";
+import {
+  backupConfigBeforeOpenAiTierMigration,
+  OpenAiTierBackupCollisionError,
+  OpenAiTierRollbackPreserveError,
+  preserveOpenAiTierRollbackSnapshot,
+  saveConfig,
+} from "../config";
 import type { OcxConfig } from "../types";
 import { projectOpenAiTierMigration } from "./openai-tiers";
 
@@ -6,6 +12,23 @@ export interface OpenAiTierStartupDeps {
   project: typeof projectOpenAiTierMigration;
   backup: () => void;
   save: (config: OcxConfig) => void;
+  preserveRollback?: (error: OpenAiTierBackupCollisionError) => void;
+}
+
+function defaultPreserveRollback(error: OpenAiTierBackupCollisionError): void {
+  if (!error.configPath) throw error;
+  try {
+    const preserved = preserveOpenAiTierRollbackSnapshot(error.configPath);
+    console.warn(`[openai-provider-migration] Preserved rollback snapshot at ${preserved}`);
+  } catch (cause) {
+    if (
+      cause instanceof OpenAiTierRollbackPreserveError
+      && (cause.code === "missing" || cause.code === "not-rollback")
+    ) {
+      throw error;
+    }
+    throw cause;
+  }
 }
 
 const DEFAULT_DEPS: OpenAiTierStartupDeps = {
@@ -20,7 +43,13 @@ export function runOpenAiTierStartupMigration(
 ): OcxConfig {
   const projection = deps.project(config);
   if (!projection.changed) return projection.config;
-  deps.backup();
+  try {
+    deps.backup();
+  } catch (error) {
+    if (!(error instanceof OpenAiTierBackupCollisionError)) throw error;
+    (deps.preserveRollback ?? defaultPreserveRollback)(error);
+    deps.backup();
+  }
   deps.save(projection.config);
   for (const warning of projection.warnings) console.warn(`[openai-provider-migration] ${warning}`);
   return projection.config;

--- a/structure/08_openai-provider-tiers.md
+++ b/structure/08_openai-provider-tiers.md
@@ -96,10 +96,11 @@ shipped v1 shape; the next startup re-migrates to the same marker-2 bytes.
 
 A pre-existing snapshot that differs from the current config is classified before anything is written
 (`src/config.ts` `classifyOpenAiTierBackup`): a snapshot that parses as a valid pre-migration (v1)
-config is a user-intentional rollback point and blocks migration; a snapshot that is unparseable or
-already tier-v2 is stale and is replaced with a warning. The distinction matters because silently
-discarding a rollback point is destructive, while preserving a stale one would block every later
-migration.
+config is a user-intentional rollback point and is copied to a unique
+`config.json.pre-openai-tiers-v1-rollback.<timestamp>.bak` path before startup retries the v2
+migration backup; a snapshot that is unparseable or already tier-v2 is stale and is replaced with a
+warning. The distinction matters because silently discarding a rollback point is destructive, while
+preserving a stale one would block every later migration.
 
 ## Model and wire identity
 

--- a/tests/init-backup-cleanup.test.ts
+++ b/tests/init-backup-cleanup.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSy
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { cleanupOpenAiTierBackupAfterInit } from "../src/cli/init";
-import { classifyOpenAiTierBackup } from "../src/config";
+import { classifyOpenAiTierBackup, OpenAiTierRollbackPreserveError, preserveOpenAiTierRollbackSnapshot } from "../src/config";
 
 describe("cleanupOpenAiTierBackupAfterInit", () => {
   const dirs: string[] = [];
@@ -87,5 +87,44 @@ describe("cleanupOpenAiTierBackupAfterInit", () => {
     expect(classifyOpenAiTierBackup(enc("garbage"))).toBe("stale");
     expect(classifyOpenAiTierBackup(enc(JSON.stringify({ openaiProviderTierVersion: 1 })))).toBe("rollback");
     expect(classifyOpenAiTierBackup(enc(JSON.stringify({})))).toBe("rollback");
+  });
+
+  test("preserveOpenAiTierRollbackSnapshot copy failure keeps the v2 backup", () => {
+    const dir = makeDir();
+    const configPath = join(dir, "config.json");
+    const backup = `${configPath}.pre-openai-tiers-v2.bak`;
+    const v1 = JSON.stringify({ openaiProviderTierVersion: 1, port: 10100, defaultProvider: "openai", providers: {} });
+    writeFileSync(backup, v1);
+    expect(() => preserveOpenAiTierRollbackSnapshot(configPath, {
+      exists: existsSync,
+      read: path => readFileSync(path),
+      copyExclusive: () => { throw new Error("copy failed"); },
+      unlink: () => { throw new Error("unlink must not run"); },
+    })).toThrow("copy failed");
+    expect(readFileSync(backup, "utf8")).toBe(v1);
+    expect(readdirSync(dir).filter(name => name.includes("pre-openai-tiers-v1-rollback"))).toEqual([]);
+  });
+
+  test("preserveOpenAiTierRollbackSnapshot does not overwrite occupied destinations and keeps source on exhaustion", () => {
+    const dir = makeDir();
+    const configPath = join(dir, "config.json");
+    const backup = `${configPath}.pre-openai-tiers-v2.bak`;
+    const v1 = JSON.stringify({ openaiProviderTierVersion: 1, port: 10100, defaultProvider: "openai", providers: {} });
+    writeFileSync(backup, v1);
+    const now = Date.now();
+    writeFileSync(`${configPath}.pre-openai-tiers-v1-rollback.${now}.bak`, "occupied");
+    for (let attempt = 1; attempt < 16; attempt++) {
+      writeFileSync(`${configPath}.pre-openai-tiers-v1-rollback.${now}-${attempt}.bak`, "occupied");
+    }
+    const realNow = Date.now;
+    Date.now = () => now;
+    try {
+      expect(() => preserveOpenAiTierRollbackSnapshot(configPath)).toThrow(OpenAiTierRollbackPreserveError);
+    } finally {
+      Date.now = realNow;
+    }
+    expect(readFileSync(backup, "utf8")).toBe(v1);
+    expect(readFileSync(`${configPath}.pre-openai-tiers-v1-rollback.${now}.bak`, "utf8")).toBe("occupied");
+    expect(readFileSync(`${configPath}.pre-openai-tiers-v1-rollback.${now}-1.bak`, "utf8")).toBe("occupied");
   });
 });

--- a/tests/init-backup-cleanup.test.ts
+++ b/tests/init-backup-cleanup.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { constants as fsConstants, copyFileSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { cleanupOpenAiTierBackupAfterInit } from "../src/cli/init";
@@ -99,6 +99,7 @@ describe("cleanupOpenAiTierBackupAfterInit", () => {
       exists: existsSync,
       read: path => readFileSync(path),
       copyExclusive: () => { throw new Error("copy failed"); },
+      harden: () => { throw new Error("harden must not run"); },
       unlink: () => { throw new Error("unlink must not run"); },
     })).toThrow("copy failed");
     expect(readFileSync(backup, "utf8")).toBe(v1);
@@ -126,5 +127,100 @@ describe("cleanupOpenAiTierBackupAfterInit", () => {
     expect(readFileSync(backup, "utf8")).toBe(v1);
     expect(readFileSync(`${configPath}.pre-openai-tiers-v1-rollback.${now}.bak`, "utf8")).toBe("occupied");
     expect(readFileSync(`${configPath}.pre-openai-tiers-v1-rollback.${now}-1.bak`, "utf8")).toBe("occupied");
+  });
+
+  test("preserveOpenAiTierRollbackSnapshot hardens before unlinking the source", () => {
+    const dir = makeDir();
+    const configPath = join(dir, "config.json");
+    const backup = `${configPath}.pre-openai-tiers-v2.bak`;
+    const v1 = JSON.stringify({ openaiProviderTierVersion: 1, port: 10100, defaultProvider: "openai", providers: {} });
+    writeFileSync(backup, v1);
+    const calls: string[] = [];
+    const preserved = preserveOpenAiTierRollbackSnapshot(configPath, {
+      exists: existsSync,
+      read: path => {
+        calls.push(path === backup ? "read-source" : "read-preserved");
+        return readFileSync(path);
+      },
+      copyExclusive: (source, destination) => {
+        calls.push("copy");
+        copyFileSync(source, destination, fsConstants.COPYFILE_EXCL);
+      },
+      harden: path => { calls.push(`harden:${path}`); },
+      unlink: path => {
+        calls.push(path === backup ? "unlink-source" : "unlink-other");
+        if (path !== backup) throw new Error("only the source backup may be unlinked after a verified copy");
+        unlinkSync(path);
+      },
+    });
+    expect(calls).toEqual(["read-source", "copy", "read-preserved", `harden:${preserved}`, "read-source", "unlink-source"]);
+    expect(existsSync(backup)).toBe(false);
+    expect(readFileSync(preserved, "utf8")).toBe(v1);
+  });
+
+  test("preserveOpenAiTierRollbackSnapshot harden failure keeps the v2 backup", () => {
+    const dir = makeDir();
+    const configPath = join(dir, "config.json");
+    const backup = `${configPath}.pre-openai-tiers-v2.bak`;
+    const v1 = JSON.stringify({ openaiProviderTierVersion: 1, port: 10100, defaultProvider: "openai", providers: {} });
+    writeFileSync(backup, v1);
+    expect(() => preserveOpenAiTierRollbackSnapshot(configPath, {
+      exists: existsSync,
+      read: path => readFileSync(path),
+      copyExclusive: (source, destination) => { copyFileSync(source, destination, fsConstants.COPYFILE_EXCL); },
+      harden: () => { throw new Error("harden failed"); },
+      unlink: () => { throw new Error("unlink must not run"); },
+    })).toThrow("harden failed");
+    expect(readFileSync(backup, "utf8")).toBe(v1);
+  });
+
+  test("preserveOpenAiTierRollbackSnapshot does not unlink a source that changed after copy", () => {
+    const dir = makeDir();
+    const configPath = join(dir, "config.json");
+    const backup = `${configPath}.pre-openai-tiers-v2.bak`;
+    const bytesA = JSON.stringify({ openaiProviderTierVersion: 1, defaultProvider: "openai-multi", providers: {} });
+    const bytesB = JSON.stringify({ openaiProviderTierVersion: 1, defaultProvider: "openai", providers: {} });
+    writeFileSync(backup, bytesA);
+    expect(() => preserveOpenAiTierRollbackSnapshot(configPath, {
+      exists: existsSync,
+      read: path => readFileSync(path),
+      copyExclusive: (source, destination) => {
+        copyFileSync(source, destination, fsConstants.COPYFILE_EXCL);
+        writeFileSync(source, bytesB);
+      },
+      harden: () => {},
+      unlink: () => { throw new Error("unlink must not run"); },
+    })).toThrow(OpenAiTierRollbackPreserveError);
+    expect(readFileSync(backup, "utf8")).toBe(bytesB);
+    const preserved = readdirSync(dir).filter(name => name.includes("pre-openai-tiers-v1-rollback"));
+    expect(preserved).toHaveLength(1);
+    expect(readFileSync(join(dir, preserved[0]!), "utf8")).toBe(bytesA);
+  });
+
+  test("preserveOpenAiTierRollbackSnapshot removes an unverified copy when read(preserved) fails", () => {
+    const dir = makeDir();
+    const configPath = join(dir, "config.json");
+    const backup = `${configPath}.pre-openai-tiers-v2.bak`;
+    const v1 = JSON.stringify({ openaiProviderTierVersion: 1, port: 10100, defaultProvider: "openai", providers: {} });
+    writeFileSync(backup, v1);
+    const unlinks: string[] = [];
+    expect(() => preserveOpenAiTierRollbackSnapshot(configPath, {
+      exists: existsSync,
+      read: path => {
+        if (path.includes("pre-openai-tiers-v1-rollback")) throw new Error("read preserved failed");
+        return readFileSync(path);
+      },
+      copyExclusive: (source, destination) => { copyFileSync(source, destination, fsConstants.COPYFILE_EXCL); },
+      harden: () => { throw new Error("harden must not run"); },
+      unlink: path => {
+        unlinks.push(path);
+        if (path === backup) throw new Error("source unlink must not run");
+        unlinkSync(path);
+      },
+    })).toThrow("Failed to read preserved rollback snapshot");
+    expect(readFileSync(backup, "utf8")).toBe(v1);
+    expect(unlinks).toHaveLength(1);
+    expect(unlinks[0]!.includes("pre-openai-tiers-v1-rollback")).toBe(true);
+    expect(readdirSync(dir).filter(name => name.includes("pre-openai-tiers-v1-rollback"))).toEqual([]);
   });
 });

--- a/tests/openai-provider-option-startup.test.ts
+++ b/tests/openai-provider-option-startup.test.ts
@@ -23,7 +23,10 @@ import {
   OpenAiTierBackupCollisionError,
   OpenAiTierBackupRollbackError,
   OpenAiTierBackupSecretResidualError,
+  OpenAiTierRollbackPreserveError,
+  preserveOpenAiTierRollbackSnapshot,
   type OpenAiTierBackupIO,
+  type OpenAiTierRollbackPreserveIO,
 } from "../src/config";
 import { runOpenAiTierStartupMigration } from "../src/providers/openai-tier-startup";
 import { OpenAiTierMigrationCollisionError, projectOpenAiTierMigration } from "../src/providers/openai-tiers";
@@ -228,6 +231,57 @@ describe("OpenAI provider option startup coordinator", () => {
       backup: () => {},
       save: () => { throw new Error("disk full"); },
     })).toThrow("disk full");
+  });
+
+  test("rollback collision preserves the snapshot then retries backup once before save (#1599)", () => {
+    const calls: string[] = [];
+    let backups = 0;
+    const projected = { ...config, openaiProviderTierVersion: 2 as const };
+    const result = runOpenAiTierStartupMigration(config, {
+      project: () => ({ config: projected, changed: true, resolvedMode: "pool", warnings: [] }),
+      backup: () => {
+        calls.push("backup");
+        backups += 1;
+        if (backups === 1) throw new OpenAiTierBackupCollisionError();
+      },
+      preserveRollback: () => { calls.push("preserve"); },
+      save: () => { calls.push("save"); },
+    });
+    expect(calls).toEqual(["backup", "preserve", "backup", "save"]);
+    expect(result).toBe(projected);
+  });
+
+  test("rollback preserve failure leaves the original backup and does not save (#1599)", () => {
+    const calls: string[] = [];
+    expect(() => runOpenAiTierStartupMigration(config, {
+      project: () => ({ config: { ...config, openaiProviderTierVersion: 2 }, changed: true, resolvedMode: "pool", warnings: [] }),
+      backup: () => { calls.push("backup"); throw new OpenAiTierBackupCollisionError(); },
+      preserveRollback: () => { calls.push("preserve"); throw new Error("preserve failed"); },
+      save: () => { calls.push("save"); },
+    })).toThrow("preserve failed");
+    expect(calls).toEqual(["backup", "preserve"]);
+  });
+
+  test("non-collision backup errors are not retried (#1599)", () => {
+    const calls: string[] = [];
+    expect(() => runOpenAiTierStartupMigration(config, {
+      project: () => ({ config: { ...config }, changed: true, resolvedMode: "pool", warnings: [] }),
+      backup: () => { calls.push("backup"); throw new OpenAiTierBackupCleanupError(); },
+      preserveRollback: () => { calls.push("preserve"); },
+      save: () => { calls.push("save"); },
+    })).toThrow(OpenAiTierBackupCleanupError);
+    expect(calls).toEqual(["backup"]);
+  });
+
+  test("rollback collision retries backup only once (#1599)", () => {
+    const calls: string[] = [];
+    expect(() => runOpenAiTierStartupMigration(config, {
+      project: () => ({ config: { ...config, openaiProviderTierVersion: 2 }, changed: true, resolvedMode: "pool", warnings: [] }),
+      backup: () => { calls.push("backup"); throw new OpenAiTierBackupCollisionError(); },
+      preserveRollback: () => { calls.push("preserve"); },
+      save: () => { calls.push("save"); },
+    })).toThrow(OpenAiTierBackupCollisionError);
+    expect(calls).toEqual(["backup", "preserve", "backup"]);
   });
 
   test("absent original file produces a no-op backup", () => {
@@ -500,6 +554,160 @@ describe("OpenAI provider option startup coordinator", () => {
       expect([...state.files.keys()].filter(path => path.endsWith(".tmp"))).toEqual([]);
       const expectedPrefix = stage === "read" ? ["read:/virtual/config.json"] : ["read:/virtual/config.json", expect.stringContaining("create:")];
       expect(state.calls.slice(0, expectedPrefix.length)).toEqual(expectedPrefix);
+    }
+  });
+
+  test("startup migration preserves a rollback-classified v2 backup then continues (#1599)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ocx-1599-startup-"));
+    try {
+      const configPath = join(dir, "config.json");
+      const v2Backup = `${configPath}.pre-openai-tiers-v2.bak`;
+      const currentConfig: OcxConfig = {
+        port: 10100,
+        defaultProvider: "kimi",
+        providers: { kimi: { adapter: "openai-chat", baseUrl: "https://api.moonshot.cn/v1" } },
+      };
+      const currentBytes = `${JSON.stringify(currentConfig, null, 2)}\n`;
+      const rollbackBytes = `${JSON.stringify({
+        openaiProviderTierVersion: 1,
+        defaultProvider: "openai-multi",
+        providers: { "openai-multi": { adapter: "openai-responses", baseUrl: "https://chatgpt.com/backend-api/codex", authMode: "forward" } },
+      }, null, 2)}\n`;
+      writeFileSync(configPath, currentBytes);
+      writeFileSync(v2Backup, rollbackBytes);
+
+      expect(projectOpenAiTierMigration(currentConfig).changed).toBe(true);
+      expect(currentConfig).not.toHaveProperty("openaiProviderTierVersion");
+
+      const result = runOpenAiTierStartupMigration(currentConfig, {
+        project: projectOpenAiTierMigration,
+        backup: () => backupConfigBeforeOpenAiTierMigration(configPath),
+        save: value => { writeFileSync(configPath, `${JSON.stringify(value, null, 2)}\n`); },
+      });
+
+      expect(result.openaiProviderTierVersion).toBe(2);
+      expect(result.defaultProvider).toBe("kimi");
+      expect(readFileSync(configPath, "utf8")).toContain('"openaiProviderTierVersion": 2');
+      expect(readFileSync(v2Backup, "utf8")).toBe(currentBytes);
+      const preserved = readdirSync(dir).filter(name => name.includes("pre-openai-tiers-v1-rollback"));
+      expect(preserved).toHaveLength(1);
+      expect(readFileSync(join(dir, preserved[0]!), "utf8")).toBe(rollbackBytes);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("startup migration does not overwrite an occupied rollback destination (#1599)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ocx-1599-collide-"));
+    const now = Date.now();
+    const realNow = Date.now;
+    Date.now = () => now;
+    try {
+      const configPath = join(dir, "config.json");
+      const v2Backup = `${configPath}.pre-openai-tiers-v2.bak`;
+      const occupied = `${configPath}.pre-openai-tiers-v1-rollback.${now}.bak`;
+      const currentConfig: OcxConfig = {
+        port: 10100,
+        defaultProvider: "kimi",
+        providers: { kimi: { adapter: "openai-chat", baseUrl: "https://api.moonshot.cn/v1" } },
+      };
+      const currentBytes = `${JSON.stringify(currentConfig, null, 2)}\n`;
+      const rollbackBytes = JSON.stringify({ openaiProviderTierVersion: 1, defaultProvider: "openai-multi", providers: {} });
+      writeFileSync(configPath, currentBytes);
+      writeFileSync(v2Backup, rollbackBytes);
+      writeFileSync(occupied, "existing rollback");
+
+      runOpenAiTierStartupMigration(currentConfig, {
+        project: projectOpenAiTierMigration,
+        backup: () => backupConfigBeforeOpenAiTierMigration(configPath),
+        save: value => { writeFileSync(configPath, `${JSON.stringify(value, null, 2)}\n`); },
+      });
+
+      expect(readFileSync(occupied, "utf8")).toBe("existing rollback");
+      expect(readFileSync(v2Backup, "utf8")).toBe(currentBytes);
+      const preserved = readdirSync(dir)
+        .filter(name => name.includes("pre-openai-tiers-v1-rollback") && join(dir, name) !== occupied);
+      expect(preserved).toHaveLength(1);
+      expect(readFileSync(join(dir, preserved[0]!), "utf8")).toBe(rollbackBytes);
+    } finally {
+      Date.now = realNow;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("unchanged projection does not touch rollback or v2 backups (#1599)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ocx-1599-unchanged-"));
+    try {
+      const configPath = join(dir, "config.json");
+      const v2Backup = `${configPath}.pre-openai-tiers-v2.bak`;
+      const rollbackName = `${configPath}.pre-openai-tiers-v1-rollback.keep.bak`;
+      writeFileSync(configPath, "current");
+      writeFileSync(v2Backup, "v2-backup");
+      writeFileSync(rollbackName, "rollback");
+      const marked = { ...config, openaiProviderTierVersion: 2 as const };
+      const result = runOpenAiTierStartupMigration(marked, {
+        project: () => ({ config: marked, changed: false, resolvedMode: "pool", warnings: [] }),
+        backup: () => backupConfigBeforeOpenAiTierMigration(configPath),
+        save: () => { writeFileSync(configPath, "migrated"); },
+      });
+      expect(result).toBe(marked);
+      expect(readFileSync(configPath, "utf8")).toBe("current");
+      expect(readFileSync(v2Backup, "utf8")).toBe("v2-backup");
+      expect(readFileSync(rollbackName, "utf8")).toBe("rollback");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("startup leaves the v2 backup and does not save when rollback copy fails (#1599)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ocx-1599-copyfail-"));
+    try {
+      const configPath = join(dir, "config.json");
+      const v2Backup = `${configPath}.pre-openai-tiers-v2.bak`;
+      const currentConfig: OcxConfig = {
+        port: 10100,
+        defaultProvider: "kimi",
+        providers: { kimi: { adapter: "openai-chat", baseUrl: "https://api.moonshot.cn/v1" } },
+      };
+      const currentBytes = `${JSON.stringify(currentConfig, null, 2)}\n`;
+      const rollbackBytes = JSON.stringify({ openaiProviderTierVersion: 1, defaultProvider: "openai-multi", providers: {} });
+      writeFileSync(configPath, currentBytes);
+      writeFileSync(v2Backup, rollbackBytes);
+      const failingIo: OpenAiTierRollbackPreserveIO = {
+        exists: existsSync,
+        read: path => readFileSync(path),
+        copyExclusive: () => { throw new Error("copy failed"); },
+        unlink: unlinkSync,
+      };
+
+      expect(() => runOpenAiTierStartupMigration(currentConfig, {
+        project: projectOpenAiTierMigration,
+        backup: () => backupConfigBeforeOpenAiTierMigration(configPath),
+        preserveRollback: () => { preserveOpenAiTierRollbackSnapshot(configPath, failingIo); },
+        save: () => { throw new Error("save must not run"); },
+      })).toThrow("copy failed");
+
+      expect(readFileSync(v2Backup, "utf8")).toBe(rollbackBytes);
+      expect(readFileSync(configPath, "utf8")).toBe(currentBytes);
+      expect(readdirSync(dir).filter(name => name.includes("pre-openai-tiers-v1-rollback"))).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("preserveOpenAiTierRollbackSnapshot rejects stale backups without deleting them (#1599)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ocx-1599-stale-"));
+    try {
+      const configPath = join(dir, "config.json");
+      const v2Backup = `${configPath}.pre-openai-tiers-v2.bak`;
+      const stale = JSON.stringify({ openaiProviderTierVersion: 2, providers: {} });
+      writeFileSync(configPath, "current");
+      writeFileSync(v2Backup, stale);
+      expect(() => preserveOpenAiTierRollbackSnapshot(configPath)).toThrow(OpenAiTierRollbackPreserveError);
+      expect(readFileSync(v2Backup, "utf8")).toBe(stale);
+      expect(readdirSync(dir).filter(name => name.includes("pre-openai-tiers-v1-rollback"))).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/tests/openai-provider-option-startup.test.ts
+++ b/tests/openai-provider-option-startup.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
   chmodSync,
+  constants as fsConstants,
+  copyFileSync,
   existsSync,
   linkSync,
   mkdtempSync,
@@ -677,6 +679,7 @@ describe("OpenAI provider option startup coordinator", () => {
         exists: existsSync,
         read: path => readFileSync(path),
         copyExclusive: () => { throw new Error("copy failed"); },
+        harden: () => { throw new Error("harden must not run"); },
         unlink: unlinkSync,
       };
 
@@ -705,6 +708,146 @@ describe("OpenAI provider option startup coordinator", () => {
       writeFileSync(v2Backup, stale);
       expect(() => preserveOpenAiTierRollbackSnapshot(configPath)).toThrow(OpenAiTierRollbackPreserveError);
       expect(readFileSync(v2Backup, "utf8")).toBe(stale);
+      expect(readdirSync(dir).filter(name => name.includes("pre-openai-tiers-v1-rollback"))).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("startup does not save when rollback harden fails before source unlink (#1599)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ocx-1599-hardenfail-"));
+    try {
+      const configPath = join(dir, "config.json");
+      const v2Backup = `${configPath}.pre-openai-tiers-v2.bak`;
+      const currentConfig: OcxConfig = {
+        port: 10100,
+        defaultProvider: "kimi",
+        providers: { kimi: { adapter: "openai-chat", baseUrl: "https://api.moonshot.cn/v1" } },
+      };
+      const currentBytes = `${JSON.stringify(currentConfig, null, 2)}\n`;
+      const rollbackBytes = JSON.stringify({ openaiProviderTierVersion: 1, defaultProvider: "openai-multi", providers: {} });
+      writeFileSync(configPath, currentBytes);
+      writeFileSync(v2Backup, rollbackBytes);
+      const calls: string[] = [];
+      const failingIo: OpenAiTierRollbackPreserveIO = {
+        exists: existsSync,
+        read: path => readFileSync(path),
+        copyExclusive: (source, destination) => {
+          calls.push("copy");
+          copyFileSync(source, destination, fsConstants.COPYFILE_EXCL);
+        },
+        harden: () => { calls.push("harden"); throw new Error("harden failed"); },
+        unlink: path => {
+          calls.push(`unlink:${path}`);
+          if (path === v2Backup) throw new Error("source unlink must not run");
+          unlinkSync(path);
+        },
+      };
+
+      expect(() => runOpenAiTierStartupMigration(currentConfig, {
+        project: projectOpenAiTierMigration,
+        backup: () => backupConfigBeforeOpenAiTierMigration(configPath),
+        preserveRollback: () => { preserveOpenAiTierRollbackSnapshot(configPath, failingIo); },
+        save: () => { calls.push("save"); },
+      })).toThrow("harden failed");
+
+      expect(calls).toEqual(["copy", "harden"]);
+      expect(readFileSync(v2Backup, "utf8")).toBe(rollbackBytes);
+      expect(readFileSync(configPath, "utf8")).toBe(currentBytes);
+      expect(calls.includes("save")).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("startup does not save when the rollback source changes after copy (#1599)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ocx-1599-srcchange-"));
+    try {
+      const configPath = join(dir, "config.json");
+      const v2Backup = `${configPath}.pre-openai-tiers-v2.bak`;
+      const currentConfig: OcxConfig = {
+        port: 10100,
+        defaultProvider: "kimi",
+        providers: { kimi: { adapter: "openai-chat", baseUrl: "https://api.moonshot.cn/v1" } },
+      };
+      const currentBytes = `${JSON.stringify(currentConfig, null, 2)}\n`;
+      const bytesA = JSON.stringify({ openaiProviderTierVersion: 1, defaultProvider: "openai-multi", providers: {} });
+      const bytesB = JSON.stringify({ openaiProviderTierVersion: 1, defaultProvider: "openai", providers: {} });
+      writeFileSync(configPath, currentBytes);
+      writeFileSync(v2Backup, bytesA);
+      const saves: number[] = [];
+      const changingIo: OpenAiTierRollbackPreserveIO = {
+        exists: existsSync,
+        read: path => readFileSync(path),
+        copyExclusive: (source, destination) => {
+          copyFileSync(source, destination, fsConstants.COPYFILE_EXCL);
+          writeFileSync(source, bytesB);
+        },
+        harden: () => {},
+        unlink: () => { throw new Error("source unlink must not run"); },
+      };
+
+      expect(() => runOpenAiTierStartupMigration(currentConfig, {
+        project: projectOpenAiTierMigration,
+        backup: () => backupConfigBeforeOpenAiTierMigration(configPath),
+        preserveRollback: () => { preserveOpenAiTierRollbackSnapshot(configPath, changingIo); },
+        save: () => { saves.push(1); },
+      })).toThrow(OpenAiTierRollbackPreserveError);
+
+      expect(saves).toEqual([]);
+      expect(readFileSync(v2Backup, "utf8")).toBe(bytesB);
+      expect(readFileSync(configPath, "utf8")).toBe(currentBytes);
+      const preserved = readdirSync(dir).filter(name => name.includes("pre-openai-tiers-v1-rollback"));
+      expect(preserved).toHaveLength(1);
+      expect(readFileSync(join(dir, preserved[0]!), "utf8")).toBe(bytesA);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("startup does not save when read(preserved) fails and still keeps the source (#1599)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ocx-1599-readfail-"));
+    try {
+      const configPath = join(dir, "config.json");
+      const v2Backup = `${configPath}.pre-openai-tiers-v2.bak`;
+      const currentConfig: OcxConfig = {
+        port: 10100,
+        defaultProvider: "kimi",
+        providers: { kimi: { adapter: "openai-chat", baseUrl: "https://api.moonshot.cn/v1" } },
+      };
+      const currentBytes = `${JSON.stringify(currentConfig, null, 2)}\n`;
+      const rollbackBytes = JSON.stringify({ openaiProviderTierVersion: 1, defaultProvider: "openai-multi", providers: {} });
+      writeFileSync(configPath, currentBytes);
+      writeFileSync(v2Backup, rollbackBytes);
+      const unlinks: string[] = [];
+      const saves: number[] = [];
+      const failingIo: OpenAiTierRollbackPreserveIO = {
+        exists: existsSync,
+        read: path => {
+          if (path.includes("pre-openai-tiers-v1-rollback")) throw new Error("read preserved failed");
+          return readFileSync(path);
+        },
+        copyExclusive: (source, destination) => { copyFileSync(source, destination, fsConstants.COPYFILE_EXCL); },
+        harden: () => { throw new Error("harden must not run"); },
+        unlink: path => {
+          unlinks.push(path);
+          if (path === v2Backup) throw new Error("source unlink must not run");
+          unlinkSync(path);
+        },
+      };
+
+      expect(() => runOpenAiTierStartupMigration(currentConfig, {
+        project: projectOpenAiTierMigration,
+        backup: () => backupConfigBeforeOpenAiTierMigration(configPath),
+        preserveRollback: () => { preserveOpenAiTierRollbackSnapshot(configPath, failingIo); },
+        save: () => { saves.push(1); },
+      })).toThrow("Failed to read preserved rollback snapshot");
+
+      expect(saves).toEqual([]);
+      expect(unlinks).toHaveLength(1);
+      expect(unlinks[0]!.includes("pre-openai-tiers-v1-rollback")).toBe(true);
+      expect(readFileSync(v2Backup, "utf8")).toBe(rollbackBytes);
+      expect(readFileSync(configPath, "utf8")).toBe(currentBytes);
       expect(readdirSync(dir).filter(name => name.includes("pre-openai-tiers-v1-rollback"))).toEqual([]);
     } finally {
       rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Closes #1599.

Startup used to throw `OpenAiTierBackupCollisionError` when current `config.json` still needed OpenAI tier migration and `config.json.pre-openai-tiers-v2.bak` was a legitimate pre-migration rollback snapshot (`openaiProviderTierVersion !== 2`). That abort happens before the proxy binds, so a macOS LaunchAgent with KeepAlive crash-loops while `ocx service status` still reports the job as installed.

Root cause: `backupConfigBeforeOpenAiTierMigration()` correctly refuses to overwrite a rollback-classified backup, but `runOpenAiTierStartupMigration()` treated that collision as fatal. `ocx init` already had preserve-then-unlink cleanup; `ocx start` / launchd did not.

Fix sequence on this specific collision only:

1. Copy the rollback snapshot to a unique `config.json.pre-openai-tiers-v1-rollback.<timestamp>[suffix].bak` with no-replace publication (`COPYFILE_EXCL`). Occupied destinations are not overwritten; a bounded suffix retry picks a free name.
2. Verify the preserved bytes match the source, and only then unlink the blocking `.pre-openai-tiers-v2.bak`.
3. Retry the v2 migration backup once against the current config.
4. Save the migrated config.

If rollback preservation fails, the original v2 backup stays in place, migrated config is not saved, and startup still fails closed. Other backup errors are not swallowed or retried. The no-collision path remains `project -> backup -> save`. Unchanged projections still touch no backup files. `classifyOpenAiTierBackup()` rollback detection is unchanged.

`preserveOpenAiTierRollbackSnapshot()` lives in `src/config.ts` so startup does not import `src/cli/init.ts`. `cleanupOpenAiTierBackupAfterInit()` keeps init's best-effort semantics but reuses that primitive.

The one-paragraph update in `structure/08_openai-provider-tiers.md` is required because that file previously said a rollback snapshot "blocks migration", which would be a false invariant after this change.

## Verification

Red-then-green: the #1599 tests were added first against unfixed `upstream/dev` (`2cdbf66a2`). `bun test tests/openai-provider-option-startup.test.ts` failed 4 tests / 26 pass, including:

- `startup migration preserves a rollback-classified v2 backup then continues (#1599)` at `src/config.ts:464` → `src/providers/openai-tier-startup.ts:23`
- `rollback collision preserves the snapshot then retries backup once before save (#1599)`

After the fix:

- `bun test tests/openai-provider-option-startup.test.ts tests/init-backup-cleanup.test.ts` — 41 pass, 0 fail, ~5.35s, exit 0
- `bun test tests/openai-provider-option-startup.test.ts tests/init-backup-cleanup.test.ts tests/openai-provider-option-migration.test.ts tests/openai-provider-option-e2e.test.ts tests/openai-provider-option-tooling.test.ts tests/openai-provider-option.test.ts` — 85 pass, 0 fail, 19.00s, exit 0
- `bun run typecheck` — exit 0
- `bun run privacy:scan` — passed
- `git diff --check` — clean

Local verification was on Windows. macOS launchd KeepAlive behavior has **not** been verified on a real Mac. Cross-platform coverage depends on repository CI. The full `bun run test` suite has **not** been claimed as passed on this head.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
