### PR TITLE
fix(cli): preserve service command exit failures

### DIFF
--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -21,7 +21,6 @@ import { restoreNativeCodexAsync } from "../codex/inject";
 import { stripGrokConfig } from "../grok/inject";
 import { afterCatalogWriteHandleAppServers } from "../codex/app-server-processes";
 import { normalizeUpdateChannel, runGuiUpdateWorker } from "../update/job";
-import { serviceCommand } from "../service";
 
 export interface CliDispatchDeps {
   args: string[];
@@ -45,6 +44,7 @@ export interface CliDispatchDeps {
   handleStatus: () => Promise<void>;
   handleRecoverHistory: () => Promise<void>;
   handleReady: (args: ReadyArgs) => Promise<number>;
+  serviceCommand: (...args: string[]) => Promise<void>;
 }
 
 type CommandRunner = (deps: CliDispatchDeps) => Promise<number>;
@@ -261,8 +261,11 @@ const commandRunners: Record<string, CommandRunner> = {
     return 0;
   },
   service: async deps => {
-    await serviceCommand(...deps.args.slice(1));
-    return 0;
+    process.exitCode = 0;
+    await deps.serviceCommand(...deps.args.slice(1));
+    // serviceCommand uses process.exitCode for recoverable install/stop failures
+    // that must finish cleanup before the single top-level process.exit runs.
+    return Number(process.exitCode ?? 0);
   },
   tray: async deps => {
     const { windowsTrayCommand } = await import("../tray/windows");

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -941,4 +941,5 @@ process.exit(await dispatchCommand(head, {
   handleStatus,
   handleRecoverHistory,
   handleReady,
+  serviceCommand,
 }));

--- a/tests/cli-dispatch.test.ts
+++ b/tests/cli-dispatch.test.ts
@@ -76,4 +76,45 @@ describe("dispatchCommand exit codes", () => {
       expect(await dispatchCommand(head, fakeDeps), `${name} must be unknown`).toBe(1);
     }
   });
+
+  test("forwards service arguments and preserves handler exit codes", async () => {
+    const previousExitCode = process.exitCode;
+    try {
+      process.exitCode = 7;
+      const successCalls: string[][] = [];
+      const successDeps = {
+        ...fakeDeps,
+        args: ["service", "install", "--scheduler"],
+        serviceCommand: async (...args: string[]) => {
+          successCalls.push(args);
+        },
+      };
+
+      expect(await dispatchCommand(
+        { kind: "command", command: "service", args: successDeps.args },
+        successDeps,
+      )).toBe(0);
+      expect(successCalls).toEqual([["install", "--scheduler"]]);
+
+      for (const expected of [1, 2]) {
+        const calls: string[][] = [];
+        const deps = {
+          ...fakeDeps,
+          args: ["service", "install", "--scheduler"],
+          serviceCommand: async (...args: string[]) => {
+            calls.push(args);
+            process.exitCode = expected;
+          },
+        };
+
+        expect(await dispatchCommand(
+          { kind: "command", command: "service", args: deps.args },
+          deps,
+        )).toBe(expected);
+        expect(calls).toEqual([["install", "--scheduler"]]);
+      }
+    } finally {
+      process.exitCode = previousExitCode ?? 0;
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- Inject the service command into CLI dispatch like the other entrypoint-owned handlers.
- Preserve nonzero `process.exitCode` values set by recoverable service install or stop failures instead of returning success from the dispatcher.
- Add focused coverage for exact subcommand forwarding and exit codes 0, 1, and 2.

## Verification

- Base: `dev` at `a1e5192b75edbf6dcacae51a30912fab93906f87`; exact head: `5dcbcae5defcc278ffa8fcb00d5e03870b4cb6f4`.
- Bun 1.3.14: `tests/cli-dispatch.test.ts` — 9 pass, 0 fail; typecheck passed.
- Bun 1.4.0 canary: `tests/cli-dispatch.test.ts` — 9 pass, 0 fail; typecheck passed.
- `bun run privacy:scan` and `git diff --check` passed.
- Independent scoped review found no P0-P2 issue. Exact-head maintained CI is still required.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. No command surface, configuration, or API behavior changed; this corrects the existing exit-status contract.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Service command failures now return the correct exit codes instead of always reporting success.
  * Service command arguments are forwarded correctly.
  * Previous process exit codes are restored after command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->