### PR TITLE
fix(lab): harden CL-10 strict JSON bounds

### DIFF
--- a/src/lab/public/strict-json.ts
+++ b/src/lab/public/strict-json.ts
@@ -1,5 +1,6 @@
 import { PublicEvidenceValidationError } from "./validate";
 
+const MAX_PUBLIC_JSON_BYTES = 2 * 1024 * 1024;
 const MAX_PUBLIC_JSON_DEPTH = 8;
 const MAX_PUBLIC_JSON_OBJECT_KEYS = 64;
 const MAX_PUBLIC_JSON_ARRAY_ELEMENTS = 512;
@@ -183,7 +184,14 @@ export function parseStrictPublicJson(
   bytes: Uint8Array,
   label = "public JSON",
   invalidCode = "public_json",
+  maxBytes = MAX_PUBLIC_JSON_BYTES,
 ): unknown {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) {
+    throw new PublicEvidenceValidationError(invalidCode, `${label} byte limit is invalid`);
+  }
+  if (bytes.byteLength > maxBytes) {
+    throw new PublicEvidenceValidationError(invalidCode, `${label} exceeds ${maxBytes} bytes`);
+  }
   const buffer = Buffer.from(bytes);
   const text = buffer.toString("utf8");
   if (!Buffer.from(text, "utf8").equals(buffer)) {

--- a/tests/lab-public-core-contract.test.ts
+++ b/tests/lab-public-core-contract.test.ts
@@ -112,6 +112,8 @@ describe("CL-10 public evidence core contract", () => {
       .toThrow(/array exceeds 512/i);
     const wide = `{${Array.from({ length: 65 }, (_, index) => `"k${index}":0`).join(",")}}`;
     expect(() => parseStrictPublicJson(Buffer.from(wide, "utf8"))).toThrow(/object exceeds 64/i);
+    expect(() => parseStrictPublicJson(Buffer.alloc((2 * 1024 * 1024) + 1, 0x20)))
+      .toThrow(/exceeds 2097152 bytes/i);
   });
 
   test("local signing rejects artifact bytes before creating publisher state", () => {


### PR DESCRIPTION
Fixes the review finding that the exported strict public JSON parser had no intrinsic total-input limit. Adds a 2 MiB parser-level default and a regression that rejects oversized input before decoding/materialization.