### PR TITLE
fix(auth): prioritize exact accountId during credential import

### DIFF
--- a/src/oauth/store.ts
+++ b/src/oauth/store.ts
@@ -541,15 +541,7 @@ export async function upsertCredentialByIdentity(
   }
   return await mutateStore(store => {
     const set = store[provider];
-    const matches = (account: ProviderAccount): boolean => {
-      if (safe.accountId) {
-        if (account.credential.accountId) return account.credential.accountId === safe.accountId;
-        return Boolean(
-          safe.email
-          && account.credential.email
-          && account.credential.email.toLowerCase() === safe.email.toLowerCase(),
-        );
-      }
+    const matchesEmailOnly = (account: ProviderAccount): boolean => {
       if (account.credential.accountId) return false;
       return Boolean(
         safe.email
@@ -557,7 +549,10 @@ export async function upsertCredentialByIdentity(
         && account.credential.email.toLowerCase() === safe.email.toLowerCase(),
       );
     };
-    const existing = set?.accounts.find(matches);
+    const existing = safe.accountId
+      ? set?.accounts.find(account => account.credential.accountId === safe.accountId)
+        ?? set?.accounts.find(matchesEmailOnly)
+      : set?.accounts.find(matchesEmailOnly);
     if (existing && set) {
       existing.credential = safe;
       delete existing.needsReauth;

--- a/tests/account-import.test.ts
+++ b/tests/account-import.test.ts
@@ -422,6 +422,62 @@ describe("Cockpit account-import atomic identity upsert", () => {
     expect(JSON.parse(readFileSync(join(testHome, "auth.json"), "utf8"))[ACCOUNT_IMPORT_PROVIDER].accounts).toHaveLength(1);
   });
 
+  test("prefers an exact accountId row over an earlier email-only legacy row", async () => {
+    testHome = mkdtempSync(join(tmpdir(), "ocx-account-import-store-"));
+    process.env.OPENCODEX_HOME = testHome;
+    const authPath = join(testHome, "auth.json");
+    writeFileSync(authPath, JSON.stringify({
+      [ACCOUNT_IMPORT_PROVIDER]: {
+        activeAccountId: "legacy-email-row",
+        accounts: [
+          {
+            id: "legacy-email-row",
+            credential: {
+              access: "access-legacy",
+              refresh: "refresh-legacy",
+              expires: 1,
+              email: "shared@example.com",
+              projectId: "project-legacy",
+            },
+            addedAt: 1,
+          },
+          {
+            id: "stable-subject-row",
+            credential: {
+              access: "access-stable",
+              refresh: "refresh-stable",
+              expires: 1,
+              email: "shared@example.com",
+              accountId: "google-subject-1",
+              projectId: "project-stable",
+            },
+            addedAt: 2,
+          },
+        ],
+      },
+    }), { mode: 0o600 });
+
+    expect(await upsertCredentialByIdentity(ACCOUNT_IMPORT_PROVIDER, {
+      access: "access-updated",
+      refresh: "refresh-updated",
+      expires: 2,
+      email: "SHARED@example.com",
+      accountId: "google-subject-1",
+      projectId: "project-updated",
+    })).toBe("updated");
+
+    const set = getAccountSet(ACCOUNT_IMPORT_PROVIDER);
+    expect(set?.accounts).toHaveLength(2);
+    expect(set?.activeAccountId).toBe("legacy-email-row");
+    const legacyCredential = set?.accounts.find(account => account.id === "legacy-email-row")?.credential;
+    expect(legacyCredential?.access).toBe("access-legacy");
+    expect(legacyCredential?.accountId).toBeUndefined();
+    expect(set?.accounts.find(account => account.id === "stable-subject-row")?.credential)
+      .toMatchObject({ access: "access-updated", accountId: "google-subject-1" });
+    expect(set?.accounts.filter(account => account.credential.accountId === "google-subject-1"))
+      .toHaveLength(1);
+  });
+
   test("does not overwrite a stable accountId row from an incoming email-only credential", async () => {
     testHome = mkdtempSync(join(tmpdir(), "ocx-account-import-store-"));
     process.env.OPENCODEX_HOME = testHome;


### PR DESCRIPTION
## Summary

- Search the complete stored account set for an exact verified `accountId` before considering a legacy email-only migration row.
- Preserve legacy migration only when no stable identity match exists, and keep incoming email-only credentials from overwriting stable-ID rows.
- Add a mixed-state regression proving an earlier legacy row cannot take an update intended for a later exact-ID row, while the existing active selection remains unchanged.

The previous single-pass predicate performed email fallback while scanning each row. An earlier email-only row could therefore win before a later exact `accountId` row was examined, leaving the stable row stale and creating duplicate stable identities after the update.

## Verification

- Base: `dev` at `a1e5192b75edbf6dcacae51a30912fab93906f87`; exact head: `b525150e6f40af7579d68d0c2ff762d02dde414f`.
- Bun 1.3.14: `bun test --isolate tests/account-import.test.ts` — 19 pass, 0 fail.
- Bun 1.4.0-canary.1: the same focused command — 19 pass, 0 fail.
- `bun run typecheck` passed on both runtimes.
- `bun run privacy:scan` and `git diff --check` passed.
- Independent scoped security/correctness review found no actionable P0-P2 issue. Exact-head maintained full CI and maintainer security review are still required.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. This restores the existing credential-import identity contract and adds no user-facing command or configuration.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. Independent scoped review found no actionable P0-P2 issue; maintainer security review and sponsorship remain required.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account import handling when legacy email-only records and stable account identities coexist.
  * Re-importing an existing identity now updates the correct account without creating duplicates or altering the active account.

* **Tests**
  * Added coverage for atomic identity updates and preservation of legacy account records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->