### PR TITLE
fix(integrations): fail closed on invalid OMP YAML removal

### DIFF
--- a/src/integrations/omp-yaml-source.ts
+++ b/src/integrations/omp-yaml-source.ts
@@ -200,7 +200,12 @@ export function patchOmpYamlSource(
 
   let patched = `${text.slice(0, startOffset)}${text.slice(endOffset)}`;
   if (mutation.removeEmptyProviders) {
-    const remaining = Bun.YAML.parse(patched) as { providers?: unknown } | null;
+    let remaining: { providers?: unknown } | null;
+    try {
+      remaining = Bun.YAML.parse(patched) as { providers?: unknown } | null;
+    } catch {
+      return null;
+    }
     if (remaining && Object.hasOwn(remaining, "providers")) {
       const provider = remaining.providers;
       const empty = provider === null || (

--- a/tests/integrations-writer.test.ts
+++ b/tests/integrations-writer.test.ts
@@ -459,6 +459,23 @@ describe("OMP source preservation", () => {
     if (!result.ok) expect(result.reason).toBe("unsafe");
     expect(readFileSync(configPath, "utf8")).toBe(edited);
   });
+
+  test("refuses disable when removing the managed block would break a YAML alias", () => {
+    const configPath = installOmp();
+    expect(applyIntegration(input({ clientId: "omp" })).ok).toBe(true);
+    const edited = readFileSync(configPath, "utf8")
+      .replace("    baseUrl:", "    baseUrl: &opencodex_url")
+      .concat("settings:\n  inheritedBase: *opencodex_url\n");
+    expect(edited).toContain("    baseUrl: &opencodex_url");
+    writeFileSync(configPath, edited);
+
+    const journalBefore = store.listOperations("omp");
+    const result = disableIntegration(input({ clientId: "omp" }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("unsafe");
+    expect(readFileSync(configPath, "utf8")).toBe(edited);
+    expect(store.listOperations("omp")).toEqual(journalBefore);
+  });
 });
 
 describe("restore", () => {

--- a/tests/management-integration-routes.test.ts
+++ b/tests/management-integration-routes.test.ts
@@ -113,6 +113,13 @@ function installHermes(): string {
   return spec.configPath(routeEnv, home);
 }
 
+function installOmp(): string {
+  const spec = INTEGRATION_CLIENTS.omp;
+  const dir = spec.detectDir(routeEnv, home);
+  mkdirSync(dir, { recursive: true });
+  return spec.configPath(routeEnv, home);
+}
+
 function hermesConfigPath(): string {
   return INTEGRATION_CLIENTS.hermes.configPath(routeEnv, home);
 }
@@ -412,6 +419,29 @@ function bookkeeping(): Pick<IntegrationIO, "appendJournal" | "putRecord" | "dro
 }
 
 describe("refusals", () => {
+  test("invalid OMP alias removal returns unsafe without changing bytes or journal", async () => {
+    const configPath = installOmp();
+    expect((await put("omp", true)).status).toBe(200);
+    const edited = readFileSync(configPath, "utf8")
+      .replace("    baseUrl:", "    baseUrl: &opencodex_url")
+      .concat("settings:\n  inheritedBase: *opencodex_url\n");
+    expect(edited).toContain("    baseUrl: &opencodex_url");
+    writeFileSync(configPath, edited);
+    const journalBefore = store.listOperations("omp");
+
+    const response = await put("omp", false);
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      error: "integration config is unsafe",
+      code: "integration_unsafe",
+      clientId: "omp",
+      state: "unsafe",
+      reason: "unsafe",
+    });
+    expect(readFileSync(configPath, "utf8")).toBe(edited);
+    expect(store.listOperations("omp")).toEqual(journalBefore);
+  });
+
   test("conflict rejects disable without changing a managed-field edit", async () => {
     const configPath = installHermes();
     expect((await put("hermes", true)).status).toBe(200);


### PR DESCRIPTION
## Summary

- Catch parse failures in the intermediate YAML produced while removing `providers.opencodex`, returning the patcher's unsafe sentinel instead of letting the parser exception escape.
- Preserve the original config bytes and journal when a managed YAML anchor is still referenced by an external alias.
- Add writer and management-route regressions proving disable is refused as HTTP 409 `integration_unsafe` rather than surfacing as an internal error.

The failure is intentionally conservative: if removing the managed block would leave invalid YAML, OpenCodex declines the mutation and leaves unrelated source formatting and history untouched.

## Verification

- Base: `dev` at `a1e5192b75edbf6dcacae51a30912fab93906f87`; exact head: `1e0d08a5bb86a91e301d9e78a9ff2c6b55d7536b`.
- Bun 1.3.14: `bun test --isolate --timeout 60000 tests/integrations-writer.test.ts tests/management-integration-routes.test.ts` — 59 pass, 0 fail.
- Bun 1.4.0-canary.1: the same focused command — 59 pass, 0 fail.
- The strengthened management-route regression passed separately on both runtimes after switching to full journal equality.
- `bun run typecheck` passed on both runtimes.
- `bun run privacy:scan` and `git diff --check` passed.
- Independent scoped correctness review found no actionable P0-P2 issue. Exact-head maintained full CI is still required.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. This restores the existing fail-closed integration contract and changes no command or configuration surface.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. The patch only converts a parser exception into the existing conservative refusal path and writes no new data.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Safely handles YAML parsing errors when disabling an integration.
* Prevents removal of managed YAML configuration when user-defined aliases could make the change unsafe.
* Preserves configuration files and journal entries when an unsafe update is refused.
* Returns an appropriate conflict response when disabling an integration cannot be completed safely.

## Tests

* Added coverage for unsafe YAML anchors and aliases during integration disablement.
* Added verification of the appropriate conflict response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->