### PR TITLE
fix(antigravity): discover live tiered models from CCA

### DIFF
--- a/src/providers/antigravity-models.ts
+++ b/src/providers/antigravity-models.ts
@@ -69,9 +69,13 @@ function pickerModelIdForDiscoveredWireId(
   wireId: string,
   available: ReadonlyMap<string, Record<string, unknown>>,
 ): string {
-  const explicitPickerId = ANTIGRAVITY_PICKER_MODEL_BY_WIRE_ID[wireId];
+  const explicitPickerId = Object.hasOwn(ANTIGRAVITY_PICKER_MODEL_BY_WIRE_ID, wireId)
+    ? ANTIGRAVITY_PICKER_MODEL_BY_WIRE_ID[wireId]
+    : undefined;
   if (explicitPickerId) {
-    const requiredWireIds = ANTIGRAVITY_WIRE_IDS_BY_PICKER_MODEL[explicitPickerId] ?? [];
+    const requiredWireIds = Object.hasOwn(ANTIGRAVITY_WIRE_IDS_BY_PICKER_MODEL, explicitPickerId)
+      ? ANTIGRAVITY_WIRE_IDS_BY_PICKER_MODEL[explicitPickerId] ?? []
+      : [];
     if (requiredWireIds.every(id => available.has(id))) return explicitPickerId;
   }
 
@@ -257,6 +261,7 @@ export function parseAntigravityAvailableModels(
       if (!Array.isArray(modelIds)) return null;
       for (const id of modelIds) {
         if (!isValidModelDiscoveryModelId(id)
+          || !Object.hasOwn(models, id)
           || !antigravityRecord(models[id])
           || ids.length >= limit) return null;
         ids.push(id);
@@ -277,6 +282,7 @@ export function parseAntigravityAvailableModels(
   if (Array.isArray(flashTieredIds)) {
     for (const id of flashTieredIds) {
       if (!isValidModelDiscoveryModelId(id)
+        || !Object.hasOwn(models, id)
         || !antigravityRecord(models[id])
         || ids.length >= limit) return null;
       ids.push(id);
@@ -289,7 +295,10 @@ export function parseAntigravityAvailableModels(
     if (!info || available.has(wireId)) continue;
     // Legacy compatibility aliases are deliberately routed to newer wire ids for saved
     // selections. They are not safe as independently discovered picker rows.
-    if (ANTIGRAVITY_MODEL_ALIASES[wireId] && ANTIGRAVITY_MODEL_ALIASES[wireId] !== wireId) continue;
+    const alias = Object.hasOwn(ANTIGRAVITY_MODEL_ALIASES, wireId)
+      ? ANTIGRAVITY_MODEL_ALIASES[wireId]
+      : undefined;
+    if (alias && alias !== wireId) continue;
     available.set(wireId, info);
   }
 
@@ -309,7 +318,9 @@ export function parseAntigravityAvailableModels(
 }
 
 export function resolveAntigravityWireModelId(modelId: string): string {
-  return ANTIGRAVITY_MODEL_ALIASES[modelId] ?? modelId;
+  return Object.hasOwn(ANTIGRAVITY_MODEL_ALIASES, modelId)
+    ? ANTIGRAVITY_MODEL_ALIASES[modelId]
+    : modelId;
 }
 
 /**
@@ -323,7 +334,7 @@ export function isAntigravitySuffixModelId(modelId: string): boolean {
 
 /** The reasoning tier a retired Flash id used to encode, if it is one. */
 export function retiredAntigravityFlashTier(modelId: string): string | undefined {
-  return RETIRED_FLASH_TIERS[modelId];
+  return Object.hasOwn(RETIRED_FLASH_TIERS, modelId) ? RETIRED_FLASH_TIERS[modelId] : undefined;
 }
 
 /**
@@ -343,7 +354,7 @@ export function resolveAntigravityEffortWireModel(
   // Rule 0: retired Flash id — Google has taken the wire id offline, so route to the
   // current generation and carry the tier the retired id encoded. This runs BEFORE the
   // suffix check because those ids are aliases, and rule 1 would drop the tier.
-  const retiredTier = RETIRED_FLASH_TIERS[modelId];
+  const retiredTier = retiredAntigravityFlashTier(modelId);
   if (retiredTier) {
     return {
       wireModelId: GEMINI_FLASH_CURRENT,

--- a/src/providers/antigravity-models.ts
+++ b/src/providers/antigravity-models.ts
@@ -41,14 +41,6 @@ const RETIRED_FLASH_TIERS: Record<string, string> = {
   "gemini-3-flash-agent": "high",
 };
 
-// Current agy releases expose the 3.7 effort tiers as separate discovery rows even though
-// runtime requests use the single `gemini-3.7-flash` wire id plus `thinkingLevel`.
-const GEMINI_FLASH_DISCOVERY_TIER_IDS = [
-  "gemini-3.7-flash-low",
-  "gemini-3.7-flash-medium",
-  "gemini-3.7-flash-high",
-] as const;
-
 const ANTIGRAVITY_WIRE_MODELS = [
   "gemini-3.7-flash",
   "gemini-3.1-pro-low",
@@ -60,7 +52,6 @@ const ANTIGRAVITY_WIRE_MODELS = [
 ];
 
 const ANTIGRAVITY_PICKER_MODEL_BY_WIRE_ID: Record<string, string> = {
-  ...Object.fromEntries(GEMINI_FLASH_DISCOVERY_TIER_IDS.map(id => [id, GEMINI_FLASH_CURRENT])),
   "gemini-3.1-pro-low": "gemini-3.1-pro",
   "gemini-pro-agent": "gemini-3.1-pro",
 };
@@ -71,6 +62,33 @@ const ANTIGRAVITY_WIRE_IDS_BY_PICKER_MODEL: Record<string, string[]> = Object.en
   (out[pickerId] ??= []).push(wireId);
   return out;
 }, {});
+
+const ANTIGRAVITY_DISCOVERY_EFFORTS = ["low", "medium", "high"] as const;
+
+function pickerModelIdForDiscoveredWireId(
+  wireId: string,
+  available: ReadonlyMap<string, Record<string, unknown>>,
+): string {
+  const explicitPickerId = ANTIGRAVITY_PICKER_MODEL_BY_WIRE_ID[wireId];
+  if (explicitPickerId) {
+    const requiredWireIds = ANTIGRAVITY_WIRE_IDS_BY_PICKER_MODEL[explicitPickerId] ?? [];
+    if (requiredWireIds.every(id => available.has(id))) return explicitPickerId;
+  }
+
+  // CCA uses a single `-tiered` row for models whose effort levels ride on the
+  // request's thinkingLevel field. Keep this generic so new tiered models do not
+  // require another provider-specific ID mapping.
+  if (wireId.endsWith("-tiered")) return wireId.slice(0, -"-tiered".length);
+
+  const effortMatch = /^(.*)-(low|medium|high)$/.exec(wireId);
+  if (effortMatch) {
+    const baseId = effortMatch[1]!;
+    if (ANTIGRAVITY_DISCOVERY_EFFORTS.every(effort => available.has(`${baseId}-${effort}`))) {
+      return baseId;
+    }
+  }
+  return wireId;
+}
 
 // ── Effort ladders per collapsed base model ──
 // Gemini models: effort → wire model suffix (official agy UI pattern).
@@ -244,6 +262,18 @@ export function parseAntigravityAvailableModels(
     if (ids.length >= limit) return null;
     ids.push("gemini-3.1-flash-image");
   }
+  // Newer CCA responses identify tiered Flash models through this index instead of
+  // adding their synthetic wire ids to agentModelSorts.
+  const tieredModelIds = antigravityRecord(body.tieredModelIds);
+  const flashTieredIds = tieredModelIds?.flash;
+  if (Array.isArray(flashTieredIds)) {
+    for (const id of flashTieredIds) {
+      if (!isValidModelDiscoveryModelId(id)
+        || !antigravityRecord(models[id])
+        || ids.length >= limit) return null;
+      ids.push(id);
+    }
+  }
 
   const available = new Map<string, Record<string, unknown>>();
   for (const wireId of ids) {
@@ -258,10 +288,7 @@ export function parseAntigravityAvailableModels(
   const out: AntigravityAvailableModel[] = [];
   const seen = new Set<string>();
   for (const [wireId, info] of available) {
-    const pickerId = ANTIGRAVITY_PICKER_MODEL_BY_WIRE_ID[wireId];
-    const completePickerSet = pickerId !== undefined
-      && ANTIGRAVITY_WIRE_IDS_BY_PICKER_MODEL[pickerId]!.every(id => available.has(id));
-    const id = completePickerSet ? pickerId! : wireId;
+    const id = pickerModelIdForDiscoveredWireId(wireId, available);
     if (seen.has(id)) continue;
     seen.add(id);
     out.push({

--- a/src/providers/antigravity-models.ts
+++ b/src/providers/antigravity-models.ts
@@ -78,12 +78,16 @@ function pickerModelIdForDiscoveredWireId(
   // CCA uses a single `-tiered` row for models whose effort levels ride on the
   // request's thinkingLevel field. Keep this generic so new tiered models do not
   // require another provider-specific ID mapping.
-  if (wireId.endsWith("-tiered")) return wireId.slice(0, -"-tiered".length);
+  if (wireId.endsWith("-tiered")) {
+    const baseId = wireId.slice(0, -"-tiered".length);
+    if (isValidModelDiscoveryModelId(baseId)) return baseId;
+  }
 
   const effortMatch = /^(.*)-(low|medium|high)$/.exec(wireId);
   if (effortMatch) {
     const baseId = effortMatch[1]!;
-    if (ANTIGRAVITY_DISCOVERY_EFFORTS.every(effort => available.has(`${baseId}-${effort}`))) {
+    if (isValidModelDiscoveryModelId(baseId)
+      && ANTIGRAVITY_DISCOVERY_EFFORTS.every(effort => available.has(`${baseId}-${effort}`))) {
       return baseId;
     }
   }

--- a/src/providers/antigravity-models.ts
+++ b/src/providers/antigravity-models.ts
@@ -6,8 +6,8 @@ import { isValidModelDiscoveryModelId, MODEL_DISCOVERY_MAX_MODELS } from "./mode
 // CLI resolves labels against. The ids below separate CCA wire ids, collapsed picker entries,
 // and hidden compatibility aliases for saved selections. The CCA envelope's `model` field must
 // receive the wire id (for example "Gemini 3.1 Pro (High)" => gemini-pro-agent), while the
-// picker exposes collapsed base models only when CCA returns every known tier; otherwise each
-// returned wire id remains visible so an unavailable tier cannot be selected.
+// picker exposes collapsed known base models only when CCA returns every known tier; unknown
+// returned wire ids remain visible so they stay directly routable.
 
 // ── Wire IDs (what CCA :fetchAvailableModels returns) ──
 
@@ -80,13 +80,13 @@ function pickerModelIdForDiscoveredWireId(
   // require another provider-specific ID mapping.
   if (wireId.endsWith("-tiered")) {
     const baseId = wireId.slice(0, -"-tiered".length);
-    if (isValidModelDiscoveryModelId(baseId)) return baseId;
+    if (isKnownAntigravityPickerModelId(baseId)) return baseId;
   }
 
   const effortMatch = /^(.*)-(low|medium|high)$/.exec(wireId);
   if (effortMatch) {
     const baseId = effortMatch[1]!;
-    if (isValidModelDiscoveryModelId(baseId)
+    if (isKnownAntigravityPickerModelId(baseId)
       && ANTIGRAVITY_DISCOVERY_EFFORTS.every(effort => available.has(`${baseId}-${effort}`))) {
       return baseId;
     }
@@ -171,6 +171,10 @@ export const ANTIGRAVITY_MODELS = [
   "claude-opus-4-6-thinking",
   "gpt-oss-120b-medium",
 ];
+
+function isKnownAntigravityPickerModelId(value: string): boolean {
+  return isValidModelDiscoveryModelId(value) && ANTIGRAVITY_MODELS.includes(value);
+}
 
 // Context windows from the upstream `:fetchAvailableModels` maxTokens per model.
 const ANTIGRAVITY_WIRE_MODEL_CONTEXT_WINDOWS: Record<string, number> = {

--- a/src/providers/antigravity-models.ts
+++ b/src/providers/antigravity-models.ts
@@ -41,6 +41,14 @@ const RETIRED_FLASH_TIERS: Record<string, string> = {
   "gemini-3-flash-agent": "high",
 };
 
+// Current agy releases expose the 3.7 effort tiers as separate discovery rows even though
+// runtime requests use the single `gemini-3.7-flash` wire id plus `thinkingLevel`.
+const GEMINI_FLASH_DISCOVERY_TIER_IDS = [
+  "gemini-3.7-flash-low",
+  "gemini-3.7-flash-medium",
+  "gemini-3.7-flash-high",
+] as const;
+
 const ANTIGRAVITY_WIRE_MODELS = [
   "gemini-3.7-flash",
   "gemini-3.1-pro-low",
@@ -52,6 +60,7 @@ const ANTIGRAVITY_WIRE_MODELS = [
 ];
 
 const ANTIGRAVITY_PICKER_MODEL_BY_WIRE_ID: Record<string, string> = {
+  ...Object.fromEntries(GEMINI_FLASH_DISCOVERY_TIER_IDS.map(id => [id, GEMINI_FLASH_CURRENT])),
   "gemini-3.1-pro-low": "gemini-3.1-pro",
   "gemini-pro-agent": "gemini-3.1-pro",
 };

--- a/tests/google-antigravity-wire.test.ts
+++ b/tests/google-antigravity-wire.test.ts
@@ -130,17 +130,24 @@ describe("antigravity CCA envelope", () => {
     });
 
     expect(parseAntigravityAvailableModels(payload([
-      "gemini-3.7-flash-low",
-      "gemini-3.7-flash-medium",
-      "gemini-3.7-flash-high",
-    ]))?.map(model => model.id)).toEqual(["gemini-3.7-flash"]);
+      "future-flash-low",
+      "future-flash-medium",
+      "future-flash-high",
+    ]))?.map(model => model.id)).toEqual(["future-flash"]);
     expect(parseAntigravityAvailableModels(payload([
-      "gemini-3.7-flash-low",
-      "gemini-3.7-flash-high",
+      "future-flash-low",
+      "future-flash-high",
     ]))?.map(model => model.id)).toEqual([
-      "gemini-3.7-flash-low",
-      "gemini-3.7-flash-high",
+      "future-flash-low",
+      "future-flash-high",
     ]);
+    expect(parseAntigravityAvailableModels({
+      models: {
+        "future-flash-tiered": { maxTokens: 1_048_576 },
+      },
+      agentModelSorts: [{ groups: [{ modelIds: [] }] }],
+      tieredModelIds: { flash: ["future-flash-tiered"] },
+    })?.map(model => model.id)).toEqual(["future-flash"]);
     expect(parseAntigravityAvailableModels(payload([
       "gemini-3.1-pro-low",
       "gemini-pro-agent",

--- a/tests/google-antigravity-wire.test.ts
+++ b/tests/google-antigravity-wire.test.ts
@@ -130,6 +130,18 @@ describe("antigravity CCA envelope", () => {
     });
 
     expect(parseAntigravityAvailableModels(payload([
+      "gemini-3.7-flash-low",
+      "gemini-3.7-flash-medium",
+      "gemini-3.7-flash-high",
+    ]))?.map(model => model.id)).toEqual(["gemini-3.7-flash"]);
+    expect(parseAntigravityAvailableModels(payload([
+      "gemini-3.7-flash-low",
+      "gemini-3.7-flash-high",
+    ]))?.map(model => model.id)).toEqual([
+      "gemini-3.7-flash-low",
+      "gemini-3.7-flash-high",
+    ]);
+    expect(parseAntigravityAvailableModels(payload([
       "gemini-3.1-pro-low",
       "gemini-pro-agent",
     ]))?.map(model => model.id)).toEqual(["gemini-3.1-pro"]);

--- a/tests/google-antigravity-wire.test.ts
+++ b/tests/google-antigravity-wire.test.ts
@@ -130,10 +130,19 @@ describe("antigravity CCA envelope", () => {
     });
 
     expect(parseAntigravityAvailableModels(payload([
+      "gemini-3.7-flash-low",
+      "gemini-3.7-flash-medium",
+      "gemini-3.7-flash-high",
+    ]))?.map(model => model.id)).toEqual(["gemini-3.7-flash"]);
+    expect(parseAntigravityAvailableModels(payload([
       "future-flash-low",
       "future-flash-medium",
       "future-flash-high",
-    ]))?.map(model => model.id)).toEqual(["future-flash"]);
+    ]))?.map(model => model.id)).toEqual([
+      "future-flash-low",
+      "future-flash-medium",
+      "future-flash-high",
+    ]);
     expect(parseAntigravityAvailableModels(payload([
       "future-flash-low",
       "future-flash-high",
@@ -147,7 +156,14 @@ describe("antigravity CCA envelope", () => {
       },
       agentModelSorts: [{ groups: [{ modelIds: [] }] }],
       tieredModelIds: { flash: ["future-flash-tiered"] },
-    })?.map(model => model.id)).toEqual(["future-flash"]);
+    })?.map(model => model.id)).toEqual(["future-flash-tiered"]);
+    expect(parseAntigravityAvailableModels({
+      models: {
+        "gemini-3.7-flash-tiered": { maxTokens: 1_048_576 },
+      },
+      agentModelSorts: [{ groups: [{ modelIds: [] }] }],
+      tieredModelIds: { flash: ["gemini-3.7-flash-tiered"] },
+    })?.map(model => model.id)).toEqual(["gemini-3.7-flash"]);
     expect(parseAntigravityAvailableModels({
       models: { "-tiered": { maxTokens: 1_048_576 } },
       agentModelSorts: [{ groups: [{ modelIds: ["-tiered"] }] }],
@@ -166,6 +182,15 @@ describe("antigravity CCA envelope", () => {
     ]))?.map(model => model.id)).toEqual([
       "gemini-3.1-pro-low",
     ]);
+  });
+
+  test("keeps unknown discovered tier IDs directly routable", async () => {
+    for (const modelId of ["future-flash-tiered", "future-flash-low"]) {
+      const req = await createGoogleAdapter(effortProvider).buildRequest(parsedWithEffort(modelId, "high"));
+      const env = JSON.parse(req.body);
+      expect(env.model).toBe(modelId);
+      expect(env.request.generationConfig?.thinkingConfig).toBeUndefined();
+    }
   });
 
   test("rejects malformed and oversized CCA agent-model lists", () => {

--- a/tests/google-antigravity-wire.test.ts
+++ b/tests/google-antigravity-wire.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createGoogleAdapter as createGoogleAdapterProduction } from "../src/adapters/google";
 import { antigravitySessionId, isLikelyRealThoughtSignature } from "../src/adapters/google-antigravity-wire";
-import { ANTIGRAVITY_MODELS, ANTIGRAVITY_MODEL_EFFORTS, canonicalAntigravityUsageModel, parseAntigravityAvailableModels } from "../src/providers/antigravity-models";
+import { ANTIGRAVITY_MODELS, ANTIGRAVITY_MODEL_EFFORTS, canonicalAntigravityUsageModel, parseAntigravityAvailableModels, resolveAntigravityEffortWireModel, resolveAntigravityWireModelId } from "../src/providers/antigravity-models";
 import { MODEL_DISCOVERY_MAX_MODEL_ID_LENGTH, MODEL_DISCOVERY_MAX_MODELS } from "../src/providers/model-discovery";
 import type { AdapterEvent, OcxParsedRequest, OcxProviderConfig } from "../src/types";
 import { withTestTranslatorBudget } from "./helpers/translator-budget";
@@ -191,6 +191,24 @@ describe("antigravity CCA envelope", () => {
       expect(env.model).toBe(modelId);
       expect(env.request.generationConfig?.thinkingConfig).toBeUndefined();
     }
+  });
+
+  test("ignores inherited CCA model and alias properties", () => {
+    const inheritedModels = Object.create(null) as Record<string, unknown>;
+    Object.defineProperty(inheritedModels, "__proto__", {
+      value: { maxTokens: 1_048_576 },
+      enumerable: true,
+    });
+    const models = Object.create(inheritedModels);
+
+    expect(parseAntigravityAvailableModels({
+      models,
+      agentModelSorts: [{ groups: [{ modelIds: ["__proto__"] }] }],
+    })).toBeNull();
+    expect(resolveAntigravityWireModelId("__proto__")).toBe("__proto__");
+    expect(resolveAntigravityEffortWireModel("__proto__", "high")).toEqual({
+      wireModelId: "__proto__",
+    });
   });
 
   test("rejects malformed and oversized CCA agent-model lists", () => {

--- a/tests/google-antigravity-wire.test.ts
+++ b/tests/google-antigravity-wire.test.ts
@@ -148,6 +148,15 @@ describe("antigravity CCA envelope", () => {
       agentModelSorts: [{ groups: [{ modelIds: [] }] }],
       tieredModelIds: { flash: ["future-flash-tiered"] },
     })?.map(model => model.id)).toEqual(["future-flash"]);
+    expect(parseAntigravityAvailableModels({
+      models: { "-tiered": { maxTokens: 1_048_576 } },
+      agentModelSorts: [{ groups: [{ modelIds: ["-tiered"] }] }],
+    })?.map(model => model.id)).toEqual(["-tiered"]);
+    expect(parseAntigravityAvailableModels(payload([
+      "-low",
+      "-medium",
+      "-high",
+    ]))?.map(model => model.id)).toEqual(["-low", "-medium", "-high"]);
     expect(parseAntigravityAvailableModels(payload([
       "gemini-3.1-pro-low",
       "gemini-pro-agent",

--- a/tests/google-models-listing.test.ts
+++ b/tests/google-models-listing.test.ts
@@ -88,6 +88,10 @@ describe("Antigravity live model discovery", () => {
         models: {
           "gemini-3.1-pro-low": { maxTokens: 1_048_576, supportsImages: true, supportsThinking: true, thinkingBudget: 1000 },
           "gemini-3.7-flash-tiered": { maxTokens: 1_048_576, supportsImages: true, supportsThinking: true, thinkingBudget: 10000 },
+          "future-flash-tiered": { maxTokens: 1_048_576, supportsImages: true, supportsThinking: true, thinkingBudget: 10000 },
+          "future-flash-low": { maxTokens: 1_048_576, supportsImages: true, supportsThinking: true, thinkingBudget: 10000 },
+          "future-flash-medium": { maxTokens: 1_048_576, supportsImages: true, supportsThinking: true, thinkingBudget: 10000 },
+          "future-flash-high": { maxTokens: 1_048_576, supportsImages: true, supportsThinking: true, thinkingBudget: 10000 },
           "future-agent-model": { maxTokens: 333_333, supportsImages: false, supportsThinking: true, thinkingBudget: 7777 },
           "gemini-3.1-flash-image": { maxTokens: 555_555, supportsImages: true },
           "non-agent-command-model": { maxTokens: 222_222 },
@@ -95,8 +99,9 @@ describe("Antigravity live model discovery", () => {
         },
         agentModelSorts: [{ groups: [{ modelIds: [
           "future-agent-model", "gemini-3.1-pro-low",
+          "future-flash-low", "future-flash-medium", "future-flash-high",
         ] }] }],
-        tieredModelIds: { flash: ["gemini-3.7-flash-tiered"] },
+        tieredModelIds: { flash: ["gemini-3.7-flash-tiered", "future-flash-tiered"] },
         imageGenerationModelIds: ["gemini-3.1-flash-image"],
         tabModelIds: ["tab-only-model"],
         commandModelIds: ["non-agent-command-model"],
@@ -121,6 +126,10 @@ describe("Antigravity live model discovery", () => {
       expect(JSON.parse(String(seen[0]?.init?.body))).toEqual({ project: "configured-project" });
       expect(live.map(model => model.id).sort()).toEqual([
         "future-agent-model",
+        "future-flash-high",
+        "future-flash-low",
+        "future-flash-medium",
+        "future-flash-tiered",
         "gemini-3.1-flash-image",
         "gemini-3.1-pro-low",
         "gemini-3.7-flash",

--- a/tests/google-models-listing.test.ts
+++ b/tests/google-models-listing.test.ts
@@ -87,15 +87,16 @@ describe("Antigravity live model discovery", () => {
       return Response.json({
         models: {
           "gemini-3.1-pro-low": { maxTokens: 1_048_576, supportsImages: true, supportsThinking: true, thinkingBudget: 1000 },
-          "gemini-3.7-flash": { maxTokens: 1_048_576, supportsImages: true, supportsThinking: true, thinkingBudget: 10000 },
+          "gemini-3.7-flash-tiered": { maxTokens: 1_048_576, supportsImages: true, supportsThinking: true, thinkingBudget: 10000 },
           "future-agent-model": { maxTokens: 333_333, supportsImages: false, supportsThinking: true, thinkingBudget: 7777 },
           "gemini-3.1-flash-image": { maxTokens: 555_555, supportsImages: true },
           "non-agent-command-model": { maxTokens: 222_222 },
           "tab-only-model": { maxTokens: 32_768 },
         },
         agentModelSorts: [{ groups: [{ modelIds: [
-          "future-agent-model", "gemini-3.1-pro-low", "gemini-3.7-flash",
+          "future-agent-model", "gemini-3.1-pro-low",
         ] }] }],
+        tieredModelIds: { flash: ["gemini-3.7-flash-tiered"] },
         imageGenerationModelIds: ["gemini-3.1-flash-image"],
         tabModelIds: ["tab-only-model"],
         commandModelIds: ["non-agent-command-model"],


### PR DESCRIPTION
## Summary

- Make Antigravity model discovery follow the live CCA catalog instead of a hardcoded model allowlist.
- Keep the existing agent model index, add tiered Flash rows from the protocol's `tieredModelIds.flash` index, and collapse known tiered/complete effort rows into their picker model id while preserving unknown live wire IDs so future models remain directly routable.
- No future model ID needs a source-code update: new models returned by the live agent/tiered indexes flow through the existing catalog and metadata pipeline.
- Root cause: current CCA responses put Gemini 3.7 in `models` plus `tieredModelIds.flash` while omitting its synthetic row from `agentModelSorts`; the old parser ignored that index.

## Verification

- `./node_modules/.bin/bun test tests/google-antigravity-wire.test.ts tests/google-models-listing.test.ts tests/gemini-37-flash-migration.test.ts`
- `./node_modules/.bin/bun run typecheck`
- `./node_modules/.bin/bun run privacy:scan`
- `git diff --check`
- Latest review finding fixed in commit `a261a4aef`: CCA catalog and Antigravity mapping lookups now require own properties, and the `__proto__` regression confirms inherited entries cannot be discovered or resolved.
- Real live discovery using the worktree code (`loadConfig()` + `gatherRoutedModels()` with the current Antigravity OAuth account). The live CCA request returned HTTP 200 and the final provider rows included `gemini-3.7-flash` with a 1,048,576-token context window and text/image input.
- `agy models` independently returned Gemini 3.7 Flash low/medium/high rows for the same account.

Focused tests passed (91 tests, 0 failures); typecheck and privacy scan passed. The earlier full-suite attempt was not a reliable gate in this worktree: it hit unrelated existing 5-second timeouts, lacked GUI dependencies (`react`), and Bun 1.3.14 later crashed with a segmentation fault after about 711 seconds.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed; this is a provider discovery compatibility fix with no new configuration surface.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults; no credential handling was changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovering tiered Antigravity models and presenting complete effort-tier sets as a single base model.
  * Added support for Flash model listings provided through tiered discovery data.
  * Added support for newer and previously unknown tiered model identifiers.

* **Bug Fixes**
  * Incomplete effort-tier sets continue to display individual model variants.
  * Preserved models with empty or nonstandard suffixes.
  * Improved model discovery, routing, and naming consistency.
  * Prevented unrecognized model identifiers from being altered during routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->