### PR TITLE
feat(terminal-guard): opt-in no-tool-call continuation guard for openai-chat providers

### DIFF
--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -3578,9 +3578,13 @@ async function handleResponsesInner(
 
   cancelBodyOnAbort(upstreamResponse.body, upstream.signal);
 
-  // Anthropic-only: one bounded internal continuation re-ask for clean end_turn turns that
-  // announced an edit without emitting a tool call.
-  const terminalGuardEnabled = activeAdapter.name === "anthropic" && !options.comboAttempt && !routedCompaction;
+  // One bounded internal continuation re-ask for clean end_turn turns that announced an edit
+  // without emitting a tool call. Anthropic gets this by default; openai-chat providers opt in
+  // per-provider via `terminalContinuationGuard` (the heuristic was tuned on Anthropic turns,
+  // so it stays off for the shared openai-chat adapter unless a provider enables it).
+  const terminalGuardEnabled = (activeAdapter.name === "anthropic"
+      || (activeAdapter.name === "openai-chat" && route.provider.terminalContinuationGuard === true))
+    && !options.comboAttempt && !routedCompaction;
   /**
    * One bounded internal re-ask for Anthropic end_turn-without-tool-call turns. Replays the
    * continuation on a 429 with the same-key retry budget (hoisted per request), then falls

--- a/src/server/responses/terminal-guard.ts
+++ b/src/server/responses/terminal-guard.ts
@@ -195,7 +195,7 @@ export async function* guardTerminalEventStream(options: GuardedEventStreamOptio
     for await (const event of source) {
       if (event.type === "done") {
         terminalSeen = true;
-        const analysis = options.adapterName === "anthropic"
+        const analysis = (options.adapterName === "anthropic" || options.adapterName === "openai-chat")
           ? analyzeTerminalTurn(parsed, seen)
           : { decision: "pass" as const };
         const normalStop = event.stopReason !== "max_tokens" && event.stopReason !== "content_filter";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1451,6 +1451,18 @@ export interface OcxProviderConfig {
    */
   parallelToolCalls?: boolean;
   /**
+   * Opt-in: extend the no-tool-call terminal continuation guard to this provider's
+   * `openai-chat` routed turns. The guard (originally Anthropic-only, see
+   * devlog/_fin/260706_previous-response-id-400) issues one bounded internal re-ask when a
+   * model announces work but ends the turn without emitting a tool call. Self-hosted
+   * OpenAI-compatible gateways (GLM/Kimi-family, etc.) hit the same premature-completion
+   * pattern, but the heuristic that decides a "suspicious no-tool stop" was tuned on
+   * Anthropic turns, so it stays OFF by default for the many registry providers that share
+   * the `openai-chat` adapter. Enable only for a provider whose models are known to stop
+   * mid-work; non-`openai-chat` adapters ignore this flag.
+   */
+  terminalContinuationGuard?: boolean;
+  /**
    * Opt-in: forward `prompt_cache_key` to the upstream `/chat/completions` body.
    * OpenAI-specific extension; strict backends (Groq, Cerebras, etc.) reject unknown
    * fields. Default off; only enable for providers that document this parameter.

--- a/tests/terminal-guard-server.test.ts
+++ b/tests/terminal-guard-server.test.ts
@@ -37,6 +37,27 @@ const continuationTurn = [
   'event: message_stop\ndata: {"type":"message_stop"}\n\n',
 ].join("");
 
+/** Build an OpenAI Chat Completions SSE response from raw frames. */
+function chatSse(body: string): Response {
+  return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+// A clean end-of-turn with only assistant text and no tool call — the suspicious
+// no-tool completion the guard is meant to re-ask (mirrors firstTurn for openai-chat).
+const chatFirstTurn = [
+  'data: {"choices":[{"delta":{"content":"我接下来会修改相关文件。"}}]}\n\n',
+  'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+  "data: [DONE]\n\n",
+].join("");
+
+// The continuation turn emits the tool call the model should have produced.
+const chatContinuationTurn = [
+  'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"exec_command","arguments":""}}]}}]}\n\n',
+  'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}"}}]}}]}\n\n',
+  'data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}\n\n',
+  "data: [DONE]\n\n",
+].join("");
+
 describe("server terminal guard integration", () => {
   let originalFetch: typeof fetch;
   let calls: number;
@@ -316,5 +337,87 @@ describe("server terminal guard integration", () => {
     expect(text).toContain("response.completed");
     expect(text).not.toContain("upstream_stall_timeout");
   }, 5_000);
+
+  test("openai-chat provider without terminalContinuationGuard does not re-ask", async () => {
+    const chatConfig = {
+      port: 0,
+      defaultProvider: "glm-gw",
+      providers: {
+        "glm-gw": {
+          adapter: "openai-chat",
+          baseUrl: "https://example.test/v1",
+          apiKey: "key",
+          defaultModel: "glm-5.2",
+          models: ["glm-5.2"],
+        },
+      },
+    } as unknown as OcxConfig;
+    let sends = 0;
+    globalThis.fetch = (async () => {
+      sends += 1;
+      return chatSse(chatFirstTurn);
+    }) as typeof fetch;
+
+    const response = await handleResponses(new Request("http://localhost/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "glm-gw/glm-5.2",
+        input: "请检查这个问题并修复代码",
+        stream: true,
+        tools: [{ type: "function", name: "exec_command", description: "run a command", parameters: { type: "object" } }],
+      }),
+    }), chatConfig, { model: "", provider: "" });
+
+    const text = await response.text();
+    expect(response.status).toBe(200);
+    // Guard is opt-in for openai-chat: no continuation, so exactly one upstream call.
+    expect(sends).toBe(1);
+    expect(text).toContain("response.completed");
+  });
+
+  test("openai-chat provider with terminalContinuationGuard re-asks once and forwards the tool call", async () => {
+    const chatConfig = {
+      port: 0,
+      defaultProvider: "glm-gw",
+      providers: {
+        "glm-gw": {
+          adapter: "openai-chat",
+          baseUrl: "https://example.test/v1",
+          apiKey: "key",
+          defaultModel: "glm-5.2",
+          models: ["glm-5.2"],
+          terminalContinuationGuard: true,
+        },
+      },
+    } as unknown as OcxConfig;
+    let sends = 0;
+    const bodies: Record<string, unknown>[] = [];
+    globalThis.fetch = (async (_input, init) => {
+      sends += 1;
+      bodies.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+      return chatSse(sends === 1 ? chatFirstTurn : chatContinuationTurn);
+    }) as typeof fetch;
+
+    const response = await handleResponses(new Request("http://localhost/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "glm-gw/glm-5.2",
+        input: "请检查这个问题并修复代码",
+        stream: true,
+        tools: [{ type: "function", name: "exec_command", description: "run a command", parameters: { type: "object" } }],
+      }),
+    }), chatConfig, { model: "", provider: "" });
+
+    const text = await response.text();
+    expect(response.status).toBe(200);
+    // Opted-in openai-chat provider: one bounded continuation, so two upstream calls.
+    expect(sends).toBe(2);
+    expect(text).toContain("response.completed");
+    expect(text).toContain("exec_command");
+    const messages = bodies[1]?.messages as Array<{ role?: string; content?: unknown }>;
+    expect(messages.some(m => m.role === "developer" || m.role === "system")).toBe(true);
+  });
 
 });

--- a/tests/terminal-guard.test.ts
+++ b/tests/terminal-guard.test.ts
@@ -212,6 +212,54 @@ describe("terminal guard", () => {
     expect(actual.filter(event => event.type === "done")).toHaveLength(1);
   });
 
+  test("guards an openai-chat stream (opted-in provider) with one continuation", async () => {
+    let continuations = 0;
+    const actual: AdapterEvent[] = [];
+    for await (const event of guardTerminalEventStream({
+      parsed: parsed("请检查这个问题并修复代码"),
+      firstEvents: (async function* () {
+        yield { type: "text_delta", text: "我接下来会修改相关文件。" } as AdapterEvent;
+        yield { type: "done", usage: { inputTokens: 10, outputTokens: 2 } } as AdapterEvent;
+      })(),
+      continuation: () => {
+        continuations += 1;
+        return (async function* () {
+          yield { type: "tool_call_start", id: "call_1", name: "exec_command" } as AdapterEvent;
+          yield { type: "tool_call_end" } as AdapterEvent;
+          yield { type: "done", usage: { inputTokens: 20, outputTokens: 3 } } as AdapterEvent;
+        })();
+      },
+      adapterName: "openai-chat",
+    })) actual.push(event);
+
+    expect(continuations).toBe(1);
+    expect(actual.some(event => event.type === "assistant_boundary")).toBe(true);
+    expect(actual.filter(event => event.type === "done")).toHaveLength(1);
+  });
+
+  test("does not guard adapters other than anthropic/openai-chat", async () => {
+    let continuations = 0;
+    const actual: AdapterEvent[] = [];
+    for await (const event of guardTerminalEventStream({
+      parsed: parsed("请检查这个问题并修复代码"),
+      firstEvents: (async function* () {
+        yield { type: "text_delta", text: "我接下来会修改相关文件。" } as AdapterEvent;
+        yield { type: "done", usage: { inputTokens: 10, outputTokens: 2 } } as AdapterEvent;
+      })(),
+      continuation: () => {
+        continuations += 1;
+        return (async function* () {
+          yield { type: "done" } as AdapterEvent;
+        })();
+      },
+      adapterName: "openai-responses",
+    })) actual.push(event);
+
+    expect(continuations).toBe(0);
+    expect(actual.some(event => event.type === "assistant_boundary")).toBe(false);
+    expect(actual.filter(event => event.type === "done")).toHaveLength(1);
+  });
+
   test("serializes the guarded boundary as separate assistant output items", () => {
     const response = buildResponseJSON([
       { type: "text_delta", text: "我接下来会修改。" },


### PR DESCRIPTION
## What

Extend the no-tool-call terminal continuation guard from the `anthropic` adapter to
`openai-chat` routed models, gated behind a new per-provider opt-in flag
`terminalContinuationGuard` (default off).

Fixes #1651.

## Why

The guard added in #394 issues one bounded internal re-ask when a model announces work
(an edit/plan) but ends the turn without emitting a tool call. It is currently wired to
the anthropic adapter only. Self-hosted OpenAI-compatible gateways (GLM / Kimi-family and
similar) routed through `openai-chat` hit the exact same premature-completion pattern and
stop mid-work, because they never reach `analyzeTerminalTurn`.

## Design / why opt-in

`analyzeTerminalTurn`'s suspicious-no-tool-stop heuristic (the `ACTIONABLE_REQUEST_RE` /
`PLAN_OR_COMPLETION_RE` / `WAITING_FOR_USER_RE` regexes) was tuned on Anthropic turns.
Its false-continue rate on other model families and non-English output is not yet
characterized. The `openai-chat` adapter is shared by many registry providers, so turning
the guard on globally there could inject unexpected continuations for existing users
(xAI, z.ai, etc.).

To keep this strictly do-no-harm, the guard is enabled only when a provider sets
`terminalContinuationGuard: true`. Anthropic behavior is unchanged; every other provider
is unchanged unless it explicitly opts in.

## Changes

- `src/types.ts`: add documented optional `terminalContinuationGuard?: boolean` to `OcxProviderConfig` (passthrough config bool, same pattern as `parallelToolCalls` / `promptCacheKey`).
- `src/server/responses/core.ts`: `terminalGuardEnabled` now also true for `openai-chat` when `route.provider.terminalContinuationGuard === true` (still excludes combo attempts and routed compaction).
- `src/server/responses/terminal-guard.ts`: `guardTerminalEventStream` runs `analyzeTerminalTurn` for `openai-chat` as well as `anthropic`; all other adapters still short-circuit to `pass`.
- `tests/terminal-guard.test.ts`: add coverage that an `openai-chat` stream gets exactly one continuation, and that an unrelated adapter (`openai-responses`) is never guarded.

## Not included

No change to `analyzeTerminalTurn`'s heuristics themselves. If maintainers later gain
confidence in the cross-family false-continue rate, flipping openai-chat to default-on
would be a separate follow-up.

## Testing

- `bun x tsc --noEmit` clean on top of `dev`.
- `bun test` for `terminal-guard`, `terminal-guard-server`, `anthropic-tail-guard`,
  `openai-chat-hardening`, `parallel-tool-calls-optin`, `cl01-openai-chat-review-regressions`:
  89 pass, 0 fail (includes the 2 new cases).

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional terminal continuation handling for OpenAI Chat providers.
  - Anthropic providers now support terminal stream analysis.
  - OpenAI Chat providers can enable bounded continuation behavior through a configuration setting.
- **Bug Fixes**
  - Prevented unintended continuation requests for providers where terminal guarding is not enabled.
  - Improved handling of terminal responses and tool calls across supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->