### PR TITLE
fix(openai-chat): let opted-out providers pin parallel_tool_calls:false

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -968,8 +968,11 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
         if (provider.parallelToolCalls === false) {
           // NIM documents the Boolean defaulting to false and kimi rejects true; pin the
           // wire bit so Codex cannot opt in via request.options. Other opted-out providers
-          // omit the field so strict OpenAI-compatible hosts never see an unsupported knob.
-          if (provider.baseUrl === "https://integrate.api.nvidia.com/v1") {
+          // omit the field by default so strict OpenAI-compatible hosts never see an
+          // unsupported knob, but a self-hosted gateway that DOES honor the field and keeps
+          // emitting parallel calls without it can opt in via pinParallelToolCallsFalse.
+          if (provider.baseUrl === "https://integrate.api.nvidia.com/v1"
+              || provider.pinParallelToolCallsFalse === true) {
             body.parallel_tool_calls = false;
           }
         } else if (provider.parallelToolCalls === true) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1451,6 +1451,16 @@ export interface OcxProviderConfig {
    */
   parallelToolCalls?: boolean;
   /**
+   * Opt-in: when `parallelToolCalls` is `false`, actually send `parallel_tool_calls: false`
+   * on the `/chat/completions` wire for this provider. By default an opted-out provider only
+   * OMITS the field (strict OpenAI-compatible hosts reject unknown knobs), and the NVIDIA NIM
+   * baseUrl is the sole built-in exception that pins the wire bit. Some self-hosted gateways
+   * (Kimi/GLM-family, vLLM, etc.) do honor `parallel_tool_calls` and keep emitting concurrent
+   * tool calls unless it is present; enable this to pin the bit without hardcoding their URL.
+   * No effect unless `parallelToolCalls === false`; ignored by non-`openai-chat` adapters.
+   */
+  pinParallelToolCallsFalse?: boolean;
+  /**
    * Opt-in: forward `prompt_cache_key` to the upstream `/chat/completions` body.
    * OpenAI-specific extension; strict backends (Groq, Cerebras, etc.) reject unknown
    * fields. Default off; only enable for providers that document this parameter.

--- a/tests/parallel-tool-calls-optin.test.ts
+++ b/tests/parallel-tool-calls-optin.test.ts
@@ -42,6 +42,24 @@ describe("parallel tool calls provider opt-in (request body)", () => {
     const body = JSON.parse(adapter.buildRequest(parsedRequest({ parallelToolCalls: true })).body) as Record<string, unknown>;
     expect(body).not.toHaveProperty("parallel_tool_calls");
   });
+
+  test("pinParallelToolCallsFalse pins the wire bit for an opted-out non-NVIDIA provider", () => {
+    const adapter = createOpenAIChatAdapter({ adapter: "openai-chat", baseUrl: "https://llm.example.internal/v1", apiKey: "k", parallelToolCalls: false, pinParallelToolCallsFalse: true });
+    const body = JSON.parse(adapter.buildRequest(parsedRequest()).body) as Record<string, unknown>;
+    expect(body.parallel_tool_calls).toBe(false);
+  });
+
+  test("pinParallelToolCallsFalse keeps sending false even under a permissive request bit", () => {
+    const adapter = createOpenAIChatAdapter({ adapter: "openai-chat", baseUrl: "https://llm.example.internal/v1", apiKey: "k", parallelToolCalls: false, pinParallelToolCallsFalse: true });
+    const body = JSON.parse(adapter.buildRequest(parsedRequest({ parallelToolCalls: true })).body) as Record<string, unknown>;
+    expect(body.parallel_tool_calls).toBe(false);
+  });
+
+  test("pinParallelToolCallsFalse has no effect without parallelToolCalls:false", () => {
+    const adapter = createOpenAIChatAdapter({ adapter: "openai-chat", baseUrl: "https://llm.example.internal/v1", apiKey: "k", pinParallelToolCallsFalse: true });
+    const body = JSON.parse(adapter.buildRequest(parsedRequest()).body) as Record<string, unknown>;
+    expect(body).not.toHaveProperty("parallel_tool_calls");
+  });
 });
 
 describe("stale persisted config backfill (router)", () => {


### PR DESCRIPTION
## What

Add an opt-in provider flag `pinParallelToolCallsFalse` so an opted-out
`openai-chat` provider can actually send `parallel_tool_calls: false` on the
wire, instead of silently omitting it.

Fixes #1650.

## Why

In `src/adapters/openai-chat.ts`, when `provider.parallelToolCalls === false` the
wire bit `parallel_tool_calls: false` is only emitted for the NVIDIA NIM
`baseUrl`. Every other opted-out provider omits the field entirely. For strict
OpenAI-compatible hosts that reject unknown fields this omit-by-default is
correct. But self-hosted gateways in the Kimi/GLM family (and vLLM-style
backends) *do* honor `parallel_tool_calls` and, without it, keep emitting
multiple concurrent tool calls in a single streamed turn -- which the Responses
translator then has to reject. `parallelToolCalls: false` looks like the opt-out
for this, but today it is a no-op for those providers.

## Design / why opt-in

The omit-by-default behavior is deliberate and covered by existing tests
(`tests/parallel-tool-calls-optin.test.ts`: a `false` provider must NOT emit the
field). Sending `parallel_tool_calls: false` unconditionally would break those
strict hosts, so the wire bit stays gated:

- NVIDIA NIM baseUrl: unchanged (still pinned).
- Any other provider: pinned only when it sets `pinParallelToolCallsFalse: true`.
- No effect unless `parallelToolCalls === false`.

Default behavior for every existing provider is unchanged.

## Changes

- `src/types.ts`: add documented optional `pinParallelToolCallsFalse?: boolean` to `OcxProviderConfig`.
- `src/adapters/openai-chat.ts`: OR the new flag into the existing NVIDIA-baseUrl condition that pins the wire bit.
- `tests/parallel-tool-calls-optin.test.ts`: cover pinned-false emits the bit, keeps emitting under a permissive request bit, and is a no-op without `parallelToolCalls:false`.

## Testing

- `bun x tsc --noEmit` clean on top of `dev`.
- `bun test` for `parallel-tool-calls-optin`, `openai-chat-hardening`, `openai-chat-parallel-stream`, `chat-completions-endpoint`: 126 pass, 0 fail (includes 3 new cases). Existing omit-by-default assertions still pass.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider configuration to explicitly send `parallel_tool_calls: false` when parallel tool calls are disabled.
  * Supports overriding permissive request-level settings when this option is enabled.

* **Bug Fixes**
  * Improved consistency of parallel tool-call settings across supported providers.
  * Providers without the opt-in configuration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
