### PR TITLE
fix(proxy): intercept all shadow source models regardless of request_kind (#1684)

### DIFF
--- a/src/lib/shadow-call.ts
+++ b/src/lib/shadow-call.ts
@@ -32,23 +32,15 @@ export function isShadowSourceModel(modelId: string, configured?: unknown): bool
 /**
  * Decide whether a matching source model should use the opt-in intercept.
  *
- * Codex 0.145.0+ identifies normal user turns and maintenance requests in
- * x-codex-turn-metadata. Only an explicit normal turn bypasses interception;
- * missing or unrecognized metadata retains the legacy opt-in prefix behavior.
+ * Before Codex 0.147.0 this checked x-codex-turn-metadata and exempted
+ * request_kind "turn". Codex 0.147.0 can label background helper calls as
+ * "turn", causing them to bypass the intercept (#1684). The fix is to
+ * intercept every configured shadow source model unconditionally — the model
+ * slug alone is a sufficient signal.
  */
 export function shouldInterceptShadowCall(
   modelId: string,
   configured: unknown,
-  headers: Headers,
 ): boolean {
-  if (!isShadowSourceModel(modelId, configured)) return false;
-  const rawMetadata = headers.get("x-codex-turn-metadata");
-  if (rawMetadata === null) return true;
-
-  try {
-    const parsed = JSON.parse(rawMetadata) as { request_kind?: unknown };
-    return parsed?.request_kind !== "turn";
-  } catch {
-    return true;
-  }
+  return isShadowSourceModel(modelId, configured);
 }

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -1582,7 +1582,6 @@ async function handleResponsesInner(
   if (_sci?.enabled && _sci.model && shouldInterceptShadowCall(
     parsed.modelId,
     _sci.sourceModels,
-    req.headers,
   )) {
     const _sciOriginal = parsed.modelId;
     parsed.modelId = _sci.model;

--- a/src/types.ts
+++ b/src/types.ts
@@ -756,11 +756,11 @@ export interface OcxConfig {
    */
   customModelCatalogMigration?: unknown;
   /**
-   * Shadow call intercept: redirect Codex's hard-coded helper calls (title generation,
-   * commit messages, skill orchestration) to a user-chosen model. Default intercepted
-   * source models: gpt-5.4-mini (older clients) and gpt-5.6-luna (Codex 0.145.0+).
-   * Opt-in; disabled by default. Matching maintenance/helper requests are forced to low.
-   * Normal Codex turns identified by request_kind=turn are never rewritten.
+  * Shadow call intercept: redirect Codex's hard-coded helper calls (title generation,
+  * commit messages, skill orchestration) to a user-chosen model. Default intercepted
+  * source models: gpt-5.4-mini (older clients) and gpt-5.6-luna (Codex 0.145.0+).
+  * Opt-in; disabled by default. Matching maintenance/helper requests are forced to low.
+   * All requests for configured shadow source models are intercepted unconditionally.
    */
   shadowCallIntercept?: {
     /** When true, requests for known shadow/helper source models are rewritten to the configured model. */

--- a/tests/responses-shadow-intercept.test.ts
+++ b/tests/responses-shadow-intercept.test.ts
@@ -58,38 +58,19 @@ describe("isShadowSourceModel", () => {
 });
 
 describe("shouldInterceptShadowCall", () => {
-  const metadata = (requestKind: string) => new Headers({
-    "x-codex-turn-metadata": JSON.stringify({ request_kind: requestKind }),
+  test("intercepts every shadow source model unconditionally (#1684)", () => {
+    expect(shouldInterceptShadowCall("gpt-5.6-luna", undefined)).toBe(true);
+    expect(shouldInterceptShadowCall("gpt-5.6-luna-2026-08", undefined)).toBe(true);
   });
 
-  test("intercepts recognized maintenance kinds but not normal turns", () => {
-    expect(shouldInterceptShadowCall("gpt-5.6-luna", undefined, metadata("memory"))).toBe(true);
-    expect(shouldInterceptShadowCall("gpt-5.6-luna", undefined, metadata("compaction"))).toBe(true);
-    expect(shouldInterceptShadowCall("gpt-5.6-luna", undefined, metadata("prewarm"))).toBe(true);
-    expect(shouldInterceptShadowCall("gpt-5.6-luna", undefined, metadata("turn"))).toBe(false);
+  test("does not intercept non-source models", () => {
+    expect(shouldInterceptShadowCall("gpt-5.6-terra", undefined)).toBe(false);
+    expect(shouldInterceptShadowCall("gpt-5.5", undefined)).toBe(false);
   });
 
-  test("keeps legacy matching for headerless, malformed, and unrecognized metadata", () => {
-    expect(shouldInterceptShadowCall("gpt-5.6-luna", undefined, new Headers())).toBe(true);
-    expect(shouldInterceptShadowCall(
-      "gpt-5.6-luna",
-      undefined,
-      new Headers({ "x-codex-turn-metadata": "{" }),
-    )).toBe(true);
-    expect(shouldInterceptShadowCall(
-      "gpt-5.6-luna",
-      undefined,
-      new Headers({ "x-codex-turn-metadata": "{}" }),
-    )).toBe(true);
-    expect(shouldInterceptShadowCall("gpt-5.6-luna", undefined, metadata("future-kind"))).toBe(true);
-  });
-
-  test("uses case-insensitive Headers lookup and still excludes non-source models", () => {
-    const headers = new Headers({
-      "X-CoDeX-TuRn-MeTaDaTa": JSON.stringify({ request_kind: "turn" }),
-    });
-    expect(shouldInterceptShadowCall("gpt-5.6-luna", undefined, headers)).toBe(false);
-    expect(shouldInterceptShadowCall("gpt-5.6-terra", undefined, metadata("memory"))).toBe(false);
+  test("respects configured sourceModels override", () => {
+    expect(shouldInterceptShadowCall("custom-helper-v2", ["custom-helper"])).toBe(true);
+    expect(shouldInterceptShadowCall("gpt-5.6-luna", ["custom-helper"])).toBe(false);
   });
 });
 
@@ -147,17 +128,20 @@ describe("shadow call intercept request path (issue #311)", () => {
     expect(effort).toBe("low");
   });
 
-  test("does not rewrite a foreground gpt-5.6-luna turn", async () => {
-    let sawFetch = false;
-    globalThis.fetch = (async () => {
-      sawFetch = true;
-      return new Response(JSON.stringify({ error: { message: "unreachable" } }), { status: 500 });
+  test("rewrites a gpt-5.6-luna turn request too (#1684)", async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    globalThis.fetch = (async (_url: unknown, init?: RequestInit) => {
+      bodies.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+      return new Response(JSON.stringify({
+        choices: [{ message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      }), { status: 200, headers: { "content-type": "application/json" } });
     }) as typeof fetch;
 
-    const response = await post(interceptConfig(), "gpt-5.6-luna", "turn");
+    await post(interceptConfig(), "gpt-5.6-luna", "turn");
 
-    expect(sawFetch).toBe(false);
-    expect(response.status).toBe(404);
+    expect(bodies.length).toBe(1);
+    expect(String(bodies[0]?.model ?? "")).toContain("grok-4.5");
   });
 
   test("leaves gpt-5.6-terra requests unrewritten", async () => {


### PR DESCRIPTION
## Summary

Codex 0.147.0 can mark background Luna helper calls with
`request_kind: "turn"` in the `x-codex-turn-metadata` header.
The previous `shouldInterceptShadowCall()` exempted requests with
`request_kind === "turn"` from interception, causing these helper
calls to bypass the proxy and reach OpenAI directly (issue #1684).

This PR simplifies `shouldInterceptShadowCall()` to delegate
entirely to `isShadowSourceModel()` — the model slug alone is a
sufficient signal. The `x-codex-turn-metadata` header is no longer
consulted for shadow call interception decisions.

### Changes

- **src/lib/shadow-call.ts** — removed the `headers` parameter
  and metadata parsing from `shouldInterceptShadowCall()`;
  it now returns `isShadowSourceModel(modelId, configured)`
  unconditionally.
- **src/server/responses/core.ts** — removed the `req.headers`
  argument from the `shouldInterceptShadowCall()` call site.
- **src/types.ts** — updated the JSDoc comment on
  `shadowCallIntercept` to reflect the new unconditional behavior.
- **tests/responses-shadow-intercept.test.ts** — updated unit and
  integration tests: the "turn" metadata test now expects
  interception (returning true), and a new integration test
  confirms that `gpt-5.6-luna` requests with `request_kind: "turn"`
  are correctly rewritten to the configured model.

Closes #1684

## Verification

- `bun test tests/responses-shadow-intercept.test.ts` — 15/15 pass
- `bun run typecheck` — clean, no errors

## Checklist

- [x] Focused tests pass
- [x] Typecheck passes
- [x] No unrelated changes
