### PR TITLE
fix(cli): default IS_SANDBOX=1 for root ocx claude launches (#1688)

### DIFF
--- a/src/cli/claude.ts
+++ b/src/cli/claude.ts
@@ -33,6 +33,8 @@ export type ClaudeEnvDeps = {
   authDetect?: Omit<Partial<AuthDetectDeps>, "env" | "ownTokens">;
   /** Test seam; production uses the authenticated Node-launcher context. */
   preBunAnthropicSlots?: readonly AnthropicParentEnvSlot[] | null;
+  /** Test seam for root detection; production reads process.getuid(). */
+  getuid?: (() => number) | null;
 };
 
 function isClaudeLoopbackHostname(hostname: string): boolean {
@@ -237,6 +239,15 @@ export function buildClaudeEnv(
   // authoritative >=1M window (Claude Code then accounts 1M, compaction preserved).
   for (const [name, value] of Object.entries(effectiveModelEnv(config.claudeCode, contextWindows, auto))) {
     setDefault(name, value);
+  }
+  // Root bypass guard (Claude Code 2.1.205+): the CLI refuses --dangerously-skip-permissions
+  // when uid==0 unless it believes it runs inside a sandbox. Servers are commonly root, so
+  // treat the proxy-launched session as one — opt out by exporting IS_SANDBOX=0 yourself.
+  const getuidFn = deps.getuid !== undefined
+    ? deps.getuid
+    : (typeof process.getuid === "function" ? () => process.getuid!() : null);
+  if (getuidFn && getuidFn() === 0) {
+    setDefault("IS_SANDBOX", "1");
   }
   return env;
 }

--- a/tests/claude-cli.test.ts
+++ b/tests/claude-cli.test.ts
@@ -228,6 +228,28 @@ describe("ocx claude env assembly", () => {
     expect(env.ANTHROPIC_SMALL_FAST_MODEL).toBeUndefined();
   });
 
+  test("root launch (uid==0) defaults IS_SANDBOX=1 for Claude Code 2.1.205+ permission bypass guard (#1688)", () => {
+    const envRoot = buildClaudeEnv(cfg({ claudeCode: {} }), 10100, {}, {}, {
+      getuid: () => 0,
+      ...AUTH_PRESENT,
+    });
+    expect(envRoot.IS_SANDBOX).toBe("1");
+
+    const envNonRoot = buildClaudeEnv(cfg({ claudeCode: {} }), 10100, {}, {}, {
+      getuid: () => 1000,
+      ...AUTH_PRESENT,
+    });
+    expect(envNonRoot.IS_SANDBOX).toBeUndefined();
+
+    const envUserOptOut = buildClaudeEnv(cfg({ claudeCode: {} }), 10100, {
+      IS_SANDBOX: "0",
+    }, {}, {
+      getuid: () => 0,
+      ...AUTH_PRESENT,
+    });
+    expect(envUserOptOut.IS_SANDBOX).toBe("0");
+  });
+
 });
 
 describe("ocx claude Windows launch (devlog 260715_cross_platform_audit/020)", () => {


### PR DESCRIPTION
## Summary
- Sets \`IS_SANDBOX="1"\` by default in \`buildClaudeEnv\` when \`ocx claude\` runs with root privileges (\`process.getuid() === 0\`).
- Fixes #1688 where Claude Code 2.1.205+ refuses \`--dangerously-skip-permissions\` under root/sudo environments (typical VPS deployments) with \`--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons\` unless \`IS_SANDBOX\` is set.
- Respects explicit user overrides: \`setDefault\` semantics ensure that if a user exports \`IS_SANDBOX=0\`, that value is preserved.
- Adds test seam \`getuid\` to \`ClaudeEnvDeps\` for cross-platform deterministic testability.
- Adds unit tests in \`tests/claude-cli.test.ts\` verifying root defaults to \`IS_SANDBOX=1\`, non-root leaves it unset, and explicit user exports are honored.

## Test plan
- Run \`bun test tests/claude-cli.test.ts\` (all 22 tests passed).
- Run \`bun test tests/claude-inbound.test.ts tests/claude-auth-detect.test.ts tests/claude-auth-mode.test.ts tests/claude-desktop-cli.test.ts\` (all 95 tests passed).
- Run \`bun run typecheck\` (0 errors).
- Run \`bun run privacy:scan\` (passed).

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude Code launches now automatically enable sandbox mode when run with root privileges.
  * Users can explicitly override this behavior by setting the sandbox option.

* **Bug Fixes**
  * Improved permission-bypass behavior for root-launched Claude Code sessions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->