### PR TITLE
fix(lab): isolate CL-01 harness failures from negative-control passes

### DIFF
--- a/src/lab/conformance/negative-controls.ts
+++ b/src/lab/conformance/negative-controls.ts
@@ -50,11 +50,15 @@ export const NEGATIVE_CONTROL_FIXTURES: Array<{
   },
   {
     id: "negative.tool-result-order",
-    defect: "invalid tool-result ordering",
+    defect: "invalid tool-result correlation after chat-history repair",
     mutate: (c) => ({
       ...c,
       id: "negative.tool-result-order",
-      assertions: [{ id: "result", operator: "tool_result_correlates", selector: "/upstream/requests", expected: { call: "/client/response/toolCalls/0/id", result: "/upstream/requests/1/json/messages/1/tool_call_id" }, required: true }],
+      // Chat history hardening closes the unmatched call with a synthetic result, then
+      // re-emits the orphan result behind a synthetic assistant call. Inspect the actual
+      // supplied result at the end of that repaired pair rather than the synthetic close,
+      // otherwise the negative control accidentally validates the repair and passes.
+      assertions: [{ id: "result", operator: "tool_result_correlates", selector: "/upstream/requests", expected: { call: "/client/response/toolCalls/0/id", result: "/upstream/requests/1/json/messages/3/tool_call_id" }, required: true }],
       fixture: {
         ...c.fixture,
         bytesUtf8: JSON.stringify({

--- a/src/lab/conformance/runner.ts
+++ b/src/lab/conformance/runner.ts
@@ -1,6 +1,6 @@
 import { discoverScenarios, loadCaseAuthority } from "./manifest";
 import { runScenario } from "./executor";
-import { buildNegativeControls } from "./negative-controls";
+import { baseCaseForNegativeControl, buildNegativeControls } from "./negative-controls";
 import type { CaseRecord, ScenarioRunResult } from "./types";
 import { CL01_SUITES } from "./types";
 
@@ -43,7 +43,10 @@ export async function runNegativeControls(
   if (scenarios.length === 0) throw new Error("harness_failure: no negative controls discovered");
   const results: ScenarioRunResult[] = [];
   for (const scenario of scenarios) {
-    results.push(await execute(scenario));
+    const baseCase = baseCaseForNegativeControl(scenario.id, authority.cases);
+    const executionScenario = baseCase ? { ...scenario, id: baseCase.id } : scenario;
+    const result = await execute(executionScenario);
+    results.push({ ...result, scenarioId: scenario.id });
   }
   const rejected = results.filter((r) => (
     !r.passed

--- a/src/lab/conformance/runner.ts
+++ b/src/lab/conformance/runner.ts
@@ -1,7 +1,7 @@
 import { discoverScenarios, loadCaseAuthority } from "./manifest";
 import { runScenario } from "./executor";
 import { buildNegativeControls } from "./negative-controls";
-import type { ScenarioRunResult } from "./types";
+import type { CaseRecord, ScenarioRunResult } from "./types";
 import { CL01_SUITES } from "./types";
 
 export interface ConformanceRunSummary {
@@ -19,6 +19,8 @@ export interface NegativeControlRunSummary extends ConformanceRunSummary {
   rejected: number;
 }
 
+type ScenarioRunner = (caseRecord: CaseRecord) => Promise<ScenarioRunResult>;
+
 export async function runConformanceSuite(
   suites: readonly string[] = CL01_SUITES,
 ): Promise<ConformanceRunSummary> {
@@ -33,15 +35,21 @@ export async function runConformanceSuite(
   return { total: results.length, passed, failed: results.length - passed, results };
 }
 
-export async function runNegativeControls(): Promise<NegativeControlRunSummary> {
+export async function runNegativeControls(
+  execute: ScenarioRunner = runScenario,
+): Promise<NegativeControlRunSummary> {
   const authority = loadCaseAuthority();
   const scenarios = buildNegativeControls(discoverScenarios(authority));
   if (scenarios.length === 0) throw new Error("harness_failure: no negative controls discovered");
   const results: ScenarioRunResult[] = [];
   for (const scenario of scenarios) {
-    results.push(await runScenario(scenario));
+    results.push(await execute(scenario));
   }
-  const rejected = results.filter((r) => !r.passed).length;
+  const rejected = results.filter((r) => (
+    !r.passed
+    && r.classification === "protocol_failure"
+    && r.secondaryCode === "deterministic_assertion"
+  )).length;
   return {
     total: results.length,
     passed: rejected,

--- a/tests/lab-conformance-runner-failures.test.ts
+++ b/tests/lab-conformance-runner-failures.test.ts
@@ -3,6 +3,21 @@ import { runScenario } from "../src/lab/conformance/executor";
 import { NEGATIVE_CONTROL_FIXTURES } from "../src/lab/conformance/negative-controls";
 import { runNegativeControls } from "../src/lab/conformance/runner";
 
+function unexpectedNegativeControlResults(
+  results: Awaited<ReturnType<typeof runNegativeControls>>["results"],
+): string[] {
+  return results
+    .filter((result) => (
+      result.passed
+      || result.classification !== "protocol_failure"
+      || result.secondaryCode !== "deterministic_assertion"
+    ))
+    .map((result) => (
+      `${result.scenarioId}: ${result.classification}/${result.secondaryCode ?? "none"}`
+      + (result.diagnostics.length > 0 ? ` ${result.diagnostics.join(";")}` : "")
+    ));
+}
+
 describe("CL-01 negative-control failure accounting", () => {
   test("does not count harness failures as rejected negative controls", async () => {
     let injected = false;
@@ -24,19 +39,15 @@ describe("CL-01 negative-control failure accounting", () => {
     expect(summary.rejected).toBe(summary.total - 1);
     expect(summary.passed).toBe(summary.rejected);
     expect(summary.failed).toBe(1);
-    expect(summary.results.some((result) => result.classification === "harness_failure")).toBe(true);
+    expect(summary.results.filter((result) => result.classification === "harness_failure")).toHaveLength(1);
   }, 120000);
 
   test("counts deterministic protocol failures as rejected negative controls", async () => {
     const summary = await runNegativeControls();
 
     expect(summary.total).toBe(NEGATIVE_CONTROL_FIXTURES.length);
+    expect(unexpectedNegativeControlResults(summary.results)).toEqual([]);
     expect(summary.rejected).toBe(summary.total);
     expect(summary.failed).toBe(0);
-    for (const result of summary.results) {
-      expect(result.passed).toBe(false);
-      expect(result.classification).toBe("protocol_failure");
-      expect(result.secondaryCode).toBe("deterministic_assertion");
-    }
   }, 120000);
 });

--- a/tests/lab-conformance-runner-failures.test.ts
+++ b/tests/lab-conformance-runner-failures.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { runScenario } from "../src/lab/conformance/executor";
+import { NEGATIVE_CONTROL_FIXTURES } from "../src/lab/conformance/negative-controls";
+import { runNegativeControls } from "../src/lab/conformance/runner";
+
+describe("CL-01 negative-control failure accounting", () => {
+  test("does not count harness failures as rejected negative controls", async () => {
+    let injected = false;
+    const summary = await runNegativeControls(async (scenario) => {
+      const result = await runScenario(scenario);
+      if (injected) return result;
+      injected = true;
+      return {
+        ...result,
+        passed: false,
+        classification: "harness_failure",
+        secondaryCode: "execution_error",
+        assertionResults: [],
+        diagnostics: ["synthetic harness failure"],
+      };
+    });
+
+    expect(summary.total).toBe(NEGATIVE_CONTROL_FIXTURES.length);
+    expect(summary.rejected).toBe(summary.total - 1);
+    expect(summary.passed).toBe(summary.rejected);
+    expect(summary.failed).toBe(1);
+    expect(summary.results.some((result) => result.classification === "harness_failure")).toBe(true);
+  }, 120000);
+
+  test("counts deterministic protocol failures as rejected negative controls", async () => {
+    const summary = await runNegativeControls();
+
+    expect(summary.total).toBe(NEGATIVE_CONTROL_FIXTURES.length);
+    expect(summary.rejected).toBe(summary.total);
+    expect(summary.failed).toBe(0);
+    for (const result of summary.results) {
+      expect(result.passed).toBe(false);
+      expect(result.classification).toBe("protocol_failure");
+      expect(result.secondaryCode).toBe("deterministic_assertion");
+    }
+  }, 120000);
+});


### PR DESCRIPTION
## Summary

- Follow up on #1320 and fix CL-01 negative-control accounting so internal harness failures cannot be counted as successful negative-control rejections.
- Count a negative control as rejected only when it fails with `protocol_failure` / `deterministic_assertion`.
- Preserve each `negative.*` reporting ID while executing the mutated case under its canonical base scenario ID. This fixes adapter-vector negative controls that were previously routed to `unsupported adapter_vector scenario ...` and misclassified as `harness_failure`.
- Fix `negative.tool-result-order` so it checks the actual mismatched tool result after OpenAI Chat history repair instead of the synthetic repair result, making the control a real deterministic rejection.
- Add regression coverage that injects a `harness_failure` and verifies it is reported as failed rather than rejected, plus coverage that all built-in negative controls are deterministic protocol failures.
- Keep the follow-up limited to reproducible CL-01 harness issues. No workflow, dependency, database, environment, or documentation changes are included.

## Verification

- The first CI run exposed adapter-vector negative controls executing under their renamed `negative.*` IDs instead of their base scenario IDs. The implementation now separates execution identity from reporting identity.
- The second CI run exposed `negative.tool-result-order` as `inconclusive` because Chat history repair masked the intended defect. The control now inspects the actual orphan result after repair.
- Current head: `1c59fb18d307266548d376d2fdc9064bd954f01c`.
- Compared with `dev`: 5 commits ahead, 0 behind.
- Diff is limited to `src/lab/conformance/runner.ts`, `src/lab/conformance/negative-controls.ts`, and `tests/lab-conformance-runner-failures.test.ts`.
- All four sharded test jobs are green, including the previously failing CL-01 regression coverage.
- Gates, typecheck, npm-global checks on Ubuntu/macOS/Windows, storage/API checks, keyring checks, and React Doctor are green.
- The broad macOS job is still running; no current-head CI job has failed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. No docs change is needed for this internal correctness fix.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. No security-sensitive surface is changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved negative-control result classification so deterministic protocol violations are correctly identified as rejected controls.
  * Prevented harness or execution failures from being miscounted as rejected controls.
  * Corrected validation for invalid tool-result ordering after chat-history repair.

* **Tests**
  * Added coverage for negative-control failure accounting and rejection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->