### PR TITLE
fix(lab): reject CL-04 invalid management read filters

### DIFF
--- a/src/server/management/lab-routes.ts
+++ b/src/server/management/lab-routes.ts
@@ -14,6 +14,7 @@
  */
 
 import {
+  ARTIFACT_CLASSES,
   EVIDENCE_LAYERS,
   EXECUTION_MODES,
   EVENT_KINDS,
@@ -323,9 +324,10 @@ export async function handleLabRoutes(ctx: ManagementContext): Promise<Response 
     const eventKind = parseEventKind(url.searchParams.get("eventKind"), ctx);
     if (eventKind instanceof Response) return eventKind;
     const excludedRaw = url.searchParams.get("excluded");
-    let excluded: boolean | undefined;
-    if (excludedRaw === "true") excluded = true;
-    else if (excludedRaw === "false") excluded = false;
+    if (excludedRaw !== null && excludedRaw !== "true" && excludedRaw !== "false") {
+      return errorResponse("invalid_excluded", "excluded must be true or false", 400, ctx);
+    }
+    const excluded = excludedRaw === "true" ? true : excludedRaw === "false" ? false : undefined;
     try {
       const page = queryLabEvents({
         eventKind,
@@ -366,6 +368,14 @@ export async function handleLabRoutes(ctx: ManagementContext): Promise<Response 
     const artifactClass = url.searchParams.get("artifactClass")?.trim() || undefined;
     if (statusRaw && !["present", "corrupt", "purged_unavailable"].includes(statusRaw)) {
       return errorResponse("invalid_status", "status must be present, corrupt, or purged_unavailable", 400, ctx);
+    }
+    if (artifactClass && !ARTIFACT_CLASSES.includes(artifactClass as (typeof ARTIFACT_CLASSES)[number])) {
+      return errorResponse(
+        "invalid_artifact_class",
+        "artifactClass must be a supported artifact class",
+        400,
+        ctx,
+      );
     }
     try {
       const page = queryLabArtifacts({

--- a/tests/lab-read-filter-validation.test.ts
+++ b/tests/lab-read-filter-validation.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import type { OcxConfig } from "../src/types";
+import { handleManagementAPI } from "../src/server/management-api";
+import { ManagementRequest } from "./helpers/management-auth";
+
+const config = { providers: {} } as OcxConfig;
+
+async function apiGet(path: string): Promise<Response> {
+  const req = new ManagementRequest(`http://127.0.0.1${path}`, { method: "GET" });
+  const response = await handleManagementAPI(req, new URL(req.url), config);
+  expect(response).not.toBeNull();
+  return response!;
+}
+
+describe("Compatibility Lab management read filter validation", () => {
+  test("rejects invalid excluded values instead of silently dropping the filter", async () => {
+    const response = await apiGet("/api/lab/events?excluded=maybe");
+    expect(response.status).toBe(400);
+    const body = await response.json() as { error: { code: string } };
+    expect(body.error.code).toBe("invalid_excluded");
+  });
+
+  test("rejects unsupported artifact classes instead of querying with arbitrary values", async () => {
+    const response = await apiGet("/api/lab/artifacts?artifactClass=not-real");
+    expect(response.status).toBe(400);
+    const body = await response.json() as { error: { code: string } };
+    expect(body.error.code).toBe("invalid_artifact_class");
+  });
+});


### PR DESCRIPTION
## Summary

- Reject invalid `excluded` values on `GET /api/lab/events` instead of silently dropping the filter and returning an unfiltered result.
- Reject unsupported `artifactClass` values on `GET /api/lab/artifacts` instead of accepting arbitrary strings as an `ArtifactClass`.
- Add focused regression tests for both invalid-filter cases.

This is a focused follow-up to the CL-04 read surfaces from #1378. The broader post-merge review findings were re-checked against current `dev`; only these two issues remained real, unfixed, and worth changing.

## Verification

- Compared `agent/cl04-read-filter-validation` against current `dev`: 2 commits, 2 changed files, branch is 0 commits behind `dev` at creation.
- Added `tests/lab-read-filter-validation.test.ts` covering both 400 responses and error codes.
- Local Bun execution was not available in this connector-only session, so the PR remains draft for repository CI validation.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. No docs change is needed because this corrects invalid-input handling rather than changing supported API behavior.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. No auth, credential, secret, or persistence boundary changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Management API event filters now reject invalid exclusion values with a clear error response.
  * Artifact queries now validate artifact classes and return an error for unsupported values.

* **Tests**
  * Added coverage for invalid event exclusion filters and unsupported artifact classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->