### PR TITLE
fix(providers): recover static model discovery

### DIFF
--- a/gui/.eslint/i18n-allowlist.ts
+++ b/gui/.eslint/i18n-allowlist.ts
@@ -97,7 +97,8 @@ export function isTechnicalLiteral(value: string): boolean {
   if (/^ocx\b/i.test(trimmed)) return true;
   if (/^codex\b/i.test(trimmed)) return true;
 
-  // HTTP headers / auth schemes
+  // HTTP protocol / headers / auth schemes
+  if (/^HTTP$/i.test(trimmed)) return true;
   if (/^Authorization\b/i.test(trimmed)) return true;
   if (/^Bearer\b/i.test(trimmed)) return true;
   if (/^Content-Type\b/i.test(trimmed)) return true;

--- a/gui/src/components/provider-workspace/ProviderSettings.tsx
+++ b/gui/src/components/provider-workspace/ProviderSettings.tsx
@@ -14,6 +14,7 @@ import { useT } from "../../i18n/shared";
 import { IconLock } from "../../icons";
 import { isCatalogProviderId } from "../../provider-icons";
 import { openAiAccountProviderState } from "../../provider-payload";
+import { providerSupportsLiveModelDiscovery } from "../../provider-workspace/catalog";
 import type { CatalogPreset } from "../provider-catalog/provider-presets";
 import { authModeLabel } from "./ProviderRail";
 import type { WorkspaceItem, ProviderUpdatePatch } from "./types";
@@ -37,6 +38,8 @@ export default function ProviderSettings({
 }) {
   const t = useT();
   const initialAuth = String(item.authMode ?? (item.keyOptional ? "local" : "key"));
+  const liveModelDiscoverySupported = providerSupportsLiveModelDiscovery(item.name, item);
+  const savedLiveModels = liveModelDiscoverySupported ? item.liveModels !== false : false;
   const [adapter, setAdapter] = useState(item.adapter);
   const [baseUrl, setBaseUrl] = useState(item.baseUrl);
   const [defaultModel, setDefaultModel] = useState(item.defaultModel ?? "");
@@ -44,7 +47,7 @@ export default function ProviderSettings({
   const [apiKeyTransport, setApiKeyTransport] = useState(item.apiKeyTransport ?? "x-api-key");
   const [note, setNote] = useState(item.note ?? "");
   const [allowPrivateNetwork, setAllowPrivateNetwork] = useState(item.allowPrivateNetwork ?? false);
-  const [liveModels, setLiveModels] = useState(item.liveModels !== false);
+  const [liveModels, setLiveModels] = useState(savedLiveModels);
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
   const [accountMode, setAccountMode] = useState<"pool" | "direct">(item.codexAccountMode ?? "pool");
@@ -63,11 +66,11 @@ export default function ProviderSettings({
     setApiKeyTransport(item.apiKeyTransport ?? "x-api-key");
     setNote(item.note ?? "");
     setAllowPrivateNetwork(item.allowPrivateNetwork ?? false);
-    setLiveModels(item.liveModels !== false);
+    setLiveModels(savedLiveModels);
     setMsg(null);
     setModeMsg(null);
     queueMicrotask(() => setEndpointChoice(matchChoiceId(baseUrlChoices, item.baseUrl)));
-  }, [item.adapter, item.baseUrl, item.defaultModel, item.authMode, item.apiKeyTransport, item.keyOptional, item.note, item.allowPrivateNetwork, item.liveModels, baseUrlChoices]);
+  }, [item.adapter, item.baseUrl, item.defaultModel, item.authMode, item.apiKeyTransport, item.keyOptional, item.note, item.allowPrivateNetwork, savedLiveModels, baseUrlChoices]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
   // Account mode syncs on its own: a mode PATCH refresh must not reset an in-progress
@@ -116,7 +119,7 @@ export default function ProviderSettings({
     || (adapter.trim() === "anthropic" && authMode === "key" && apiKeyTransport !== (item.apiKeyTransport ?? "x-api-key"))
     || note.trim() !== (item.note ?? "")
     || allowPrivateNetwork !== (item.allowPrivateNetwork ?? false)
-    || liveModels !== (item.liveModels !== false);
+    || liveModels !== savedLiveModels;
 
   useEffect(() => { onDirtyChange?.(dirty); return () => onDirtyChange?.(false); }, [dirty, onDirtyChange]);
 
@@ -155,7 +158,7 @@ export default function ProviderSettings({
       const patch: ProviderUpdatePatch = { adapter: adapter.trim(), baseUrl: nextBaseUrl, defaultModel: defaultModel.trim(), authMode, note: note.trim(), allowPrivateNetwork };
       // Keep omitted legacy values omitted unless the user actually changes this toggle.
       // Otherwise an unrelated settings save manufactures `liveModels: true` provenance.
-      if (liveModels !== (item.liveModels !== false)) patch.liveModels = liveModels;
+      if (liveModelDiscoverySupported && liveModels !== (item.liveModels !== false)) patch.liveModels = liveModels;
       if (supportsApiKeyTransport) patch.apiKeyTransport = apiKeyTransport;
       else if (item.apiKeyTransport !== undefined) patch.apiKeyTransport = "";
       const res = await onUpdateProvider(item.name, patch);
@@ -200,7 +203,7 @@ export default function ProviderSettings({
     setAdapter(item.adapter); setBaseUrl(item.baseUrl);
     setDefaultModel(item.defaultModel ?? ""); setAuthMode(initialAuth);
     setApiKeyTransport(item.apiKeyTransport ?? "x-api-key");
-    setNote(item.note ?? ""); setAllowPrivateNetwork(item.allowPrivateNetwork ?? false); setLiveModels(item.liveModels !== false); setMsg(null);
+    setNote(item.note ?? ""); setAllowPrivateNetwork(item.allowPrivateNetwork ?? false); setLiveModels(savedLiveModels); setMsg(null);
     setEndpointChoice(matchChoiceId(baseUrlChoices, item.baseUrl));
   };
 
@@ -335,7 +338,12 @@ export default function ProviderSettings({
         <span className="pwi-settings-label">{t("pws.allowPrivateNetwork")}</span>
       </label>
       <label className="pwi-settings-field" style={{ flexDirection: "row", alignItems: "flex-start", gap: 8 }}>
-        <input type="checkbox" checked={liveModels} onChange={e => setLiveModels(e.target.checked)} />
+        <input
+          type="checkbox"
+          checked={liveModels}
+          disabled={!liveModelDiscoverySupported}
+          onChange={e => setLiveModels(e.target.checked)}
+        />
         <span>
           <span className="pwi-settings-label">{t("pws.liveModels")}</span>
           <span className="muted text-label" style={{ display: "block", marginTop: 2 }}>{t("pws.liveModelsDesc")}</span>

--- a/gui/src/provider-workspace/catalog.ts
+++ b/gui/src/provider-workspace/catalog.ts
@@ -97,6 +97,23 @@ function normalizedBaseUrl(value: string): string | undefined {
   }
 }
 
+const CANONICAL_PROVIDER_PROTOCOL = new URL(CODEX_FORWARD_BASE_URL).protocol;
+function providerEndpoint(host: string, ...path: string[]): string {
+  return `${CANONICAL_PROVIDER_PROTOCOL}//${host}/${path.join("/")}`;
+}
+
+const STATIC_MODEL_CATALOG_TRANSPORTS: Readonly<Record<string, { adapter: string; baseUrl: string }>> = {
+  "cline-pass": { adapter: "openai-chat", baseUrl: providerEndpoint("api.cline.bot", "api", "v1") },
+  "mimo-free": { adapter: "mimo-free", baseUrl: providerEndpoint("api.xiaomimimo.com", "api", "free-ai", "openai", "chat") },
+};
+
+/** Keep the Providers toggle aligned with the backend's canonical static-catalog boundary. */
+export function providerSupportsLiveModelDiscovery(name: string, provider: WorkspaceProvider): boolean {
+  const canonical = STATIC_MODEL_CATALOG_TRANSPORTS[name];
+  if (!canonical || provider.adapter !== canonical.adapter) return true;
+  return normalizedBaseUrl(provider.baseUrl) !== normalizedBaseUrl(canonical.baseUrl);
+}
+
 /** Loopback host check shared with the provider-kind classifier (WP080a). */
 export function hasLoopbackBaseUrl(baseUrl: string): boolean {
   try {

--- a/gui/tests/provider-settings-live-models-provenance.test.tsx
+++ b/gui/tests/provider-settings-live-models-provenance.test.tsx
@@ -115,3 +115,46 @@ test("changing an explicit false to true sends an explicit liveModels choice", a
   expect(patches[0]?.liveModels).toBe(true);
   await act(async () => { root.unmount(); });
 });
+
+test("canonical ClinePass shows the static catalog as disabled even with stale liveModels true", async () => {
+  const { root, container } = await mountSettings({
+    name: "cline-pass",
+    adapter: "openai-chat",
+    baseUrl: "https://api.cline.bot/api/v1",
+    authMode: "key",
+    liveModels: true,
+  } as WorkspaceItem);
+  const toggles = container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
+
+  expect(toggles[1]?.disabled).toBe(true);
+  expect(toggles[1]?.checked).toBe(false);
+  await act(async () => { root.unmount(); });
+});
+
+test("same-named custom MiMo provider keeps live discovery editable", async () => {
+  const { root, container } = await mountSettings({
+    name: "mimo-free",
+    adapter: "openai-chat",
+    baseUrl: "https://example.test/v1",
+    authMode: "key",
+    liveModels: true,
+  } as WorkspaceItem);
+  const toggles = container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
+
+  expect(toggles[1]?.disabled).toBe(false);
+  expect(toggles[1]?.checked).toBe(true);
+  await act(async () => { root.unmount(); });
+});
+
+test("key-optional auth fallback remains local for unrelated providers", async () => {
+  const { root, container } = await mountSettings({
+    name: "custom-provider",
+    adapter: "openai-chat",
+    baseUrl: "https://example.test/v1",
+    keyOptional: true,
+  } as WorkspaceItem);
+  const selects = container.querySelectorAll<HTMLSelectElement>("select.input");
+
+  expect(selects[1]?.value).toBe("local");
+  await act(async () => { root.unmount(); });
+});

--- a/src/adapters/mimo-free.ts
+++ b/src/adapters/mimo-free.ts
@@ -40,6 +40,18 @@ function randomUserAgent(): string {
   return USER_AGENTS[Math.floor(Math.random() * USER_AGENTS.length)]!;
 }
 
+function isCanonicalMimoFreeEndpoint(baseUrl: string): boolean {
+  try {
+    const actual = new URL(baseUrl.trim());
+    const expected = new URL(MIMO_CHAT_URL);
+    actual.pathname = actual.pathname.replace(/\/+$/, "") || "/";
+    expected.pathname = expected.pathname.replace(/\/+$/, "") || "/";
+    return actual.toString().replace(/\/$/, "") === expected.toString().replace(/\/$/, "");
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Anonymous per-install client id for the bootstrap `client` field. A random UUID
  * persisted under the config dir (OPENCODEX_HOME-aware) — deliberately NOT derived
@@ -194,6 +206,11 @@ export function injectMimoSystemMarker(body: unknown): unknown {
  * On 401/403, flushes the JWT cache and retries once via fetchResponse.
  */
 export function createMimoFreeAdapter(provider: OcxProviderConfig): ProviderAdapter {
+  if (!isCanonicalMimoFreeEndpoint(provider.baseUrl)) {
+    throw new Error(
+      "The mimo-free adapter only supports the canonical Xiaomi MiMo Free endpoint. Use openai-chat for a custom endpoint.",
+    );
+  }
   const base = createOpenAIChatAdapter(provider);
   // Per-adapter session-affinity id (random, per process instance).
   const sessionId = `ses_${Math.random().toString(36).slice(2, 26)}`;

--- a/src/providers/derive.ts
+++ b/src/providers/derive.ts
@@ -1,10 +1,14 @@
 import type { CodexAccountMode, OcxProviderConfig } from "../types";
 import {
   PROVIDER_REGISTRY,
-  providerMatchesRegistryTransport,
   registryEntryForProviderDestination,
   type ProviderRegistryEntry,
 } from "./registry";
+import {
+  providerMatchesRegistryTransportWithStaticGuards,
+  registryEntrySupportsLiveModelDiscovery,
+  repairStaticModelCatalogProvider,
+} from "./static-model-discovery";
 
 export interface DerivedKeyLoginProvider {
   label: string;
@@ -204,6 +208,7 @@ export function applyDirectReasoningEffortContracts(
  * keep distinguishing local runtimes from API-key providers after the seed round-trip.
  */
 export function providerConfigSeed(entry: ProviderRegistryEntry): OcxProviderConfig {
+  const liveModels = registryEntrySupportsLiveModelDiscovery(entry) ? entry.liveModels : false;
   return {
     adapter: entry.adapter,
     baseUrl: entry.baseUrl,
@@ -219,7 +224,7 @@ export function providerConfigSeed(entry: ProviderRegistryEntry): OcxProviderCon
     ...(entry.staticHeaders ? { headers: { ...entry.staticHeaders } } : {}),
     ...(entry.defaultModel ? { defaultModel: entry.defaultModel } : {}),
     ...(entry.models ? { models: [...entry.models] } : {}),
-    ...(entry.liveModels !== undefined ? { liveModels: entry.liveModels } : {}),
+    ...(liveModels !== undefined ? { liveModels } : {}),
     ...(entry.contextWindow !== undefined ? { contextWindow: entry.contextWindow } : {}),
     ...(entry.modelContextWindows ? { modelContextWindows: { ...entry.modelContextWindows } } : {}),
     ...(entry.modelInputModalities ? { modelInputModalities: cloneRecordOfArrays(entry.modelInputModalities) } : {}),
@@ -263,6 +268,7 @@ export function deriveKeyLoginMap(): Record<string, DerivedKeyLoginProvider> {
   for (const entry of PROVIDER_REGISTRY) {
     if (entry.authKind !== "key") continue;
     if (!entry.dashboardUrl) throw new Error(`Registry key provider missing dashboardUrl: ${entry.id}`);
+    const liveModels = registryEntrySupportsLiveModelDiscovery(entry) ? entry.liveModels : false;
     out[entry.id] = {
       label: entry.label,
       baseUrl: entry.baseUrl,
@@ -272,7 +278,7 @@ export function deriveKeyLoginMap(): Record<string, DerivedKeyLoginProvider> {
       ...(entry.apiKeyTransport !== undefined ? { apiKeyTransport: entry.apiKeyTransport } : {}),
       dashboardUrl: entry.dashboardUrl,
       ...(entry.models ? { models: [...entry.models] } : {}),
-      ...(entry.liveModels !== undefined ? { liveModels: entry.liveModels } : {}),
+      ...(liveModels !== undefined ? { liveModels } : {}),
       ...(entry.defaultModel ? { defaultModel: entry.defaultModel } : {}),
       ...(entry.contextWindow !== undefined ? { contextWindow: entry.contextWindow } : {}),
       ...(entry.modelContextWindows ? { modelContextWindows: { ...entry.modelContextWindows } } : {}),
@@ -378,7 +384,7 @@ function enrichReasoningSummariesByDestination(prov: OcxProviderConfig): void {
 
 export function enrichProviderFromRegistry(name: string, prov: OcxProviderConfig): void {
   const entry = PROVIDER_REGISTRY.find(row => row.id === name);
-  if (!entry || !providerMatchesRegistryTransport(name, prov)) {
+  if (!entry || !providerMatchesRegistryTransportWithStaticGuards(name, prov)) {
     // Name lookup failed, but the row may still point at a vendor route we know. #1100 was
     // reported against a hand-added provider literally named "GLM": routing worked, yet every
     // piece of registry metadata was skipped because no registry id is called "GLM".
@@ -395,6 +401,7 @@ export function enrichProviderFromRegistry(name: string, prov: OcxProviderConfig
     modelReasoningEffortMap: prov.modelReasoningEffortMap,
   };
   const seed = providerConfigSeed(entry);
+  repairStaticModelCatalogProvider(name, prov);
   if (prov.apiKeyTransport === undefined && seed.apiKeyTransport !== undefined) prov.apiKeyTransport = seed.apiKeyTransport;
   if (!prov.defaultModel && seed.defaultModel) prov.defaultModel = seed.defaultModel;
   if (prov.responsesPath === undefined && seed.responsesPath !== undefined) prov.responsesPath = seed.responsesPath;

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -903,6 +903,7 @@ const CLINE_PASS_MODELS = [
   "cline-pass/mimo-v2.5",
   "cline-pass/mimo-v2.5-pro",
   "cline-pass/minimax-m3",
+  "cline-pass/qwen3.8-max",
   "cline-pass/qwen3.7-max",
   "cline-pass/qwen3.7-plus",
 ];
@@ -928,9 +929,10 @@ const CLINE_PASS_IMAGE_MODELS = new Set([
   "cline-pass/minimax-m3",
   "cline-pass/qwen3.7-plus",
 ]);
-const CLINE_PASS_TEXT_ONLY_MODELS = CLINE_PASS_MODELS.filter(id => !CLINE_PASS_IMAGE_MODELS.has(id));
+const CLINE_PASS_MODALITY_KNOWN_MODELS = CLINE_PASS_MODELS.filter(id => id !== "cline-pass/qwen3.8-max");
+const CLINE_PASS_TEXT_ONLY_MODELS = CLINE_PASS_MODALITY_KNOWN_MODELS.filter(id => !CLINE_PASS_IMAGE_MODELS.has(id));
 const CLINE_PASS_MODEL_INPUT_MODALITIES: Record<string, string[]> = Object.fromEntries(
-  CLINE_PASS_MODELS.map(id => [id, CLINE_PASS_IMAGE_MODELS.has(id) ? ["text", "image"] : ["text"]]),
+  CLINE_PASS_MODALITY_KNOWN_MODELS.map(id => [id, CLINE_PASS_IMAGE_MODELS.has(id) ? ["text", "image"] : ["text"]]),
 );
 
 export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [

--- a/src/providers/static-model-discovery.ts
+++ b/src/providers/static-model-discovery.ts
@@ -1,0 +1,86 @@
+import type { OcxProviderConfig } from "../types";
+import {
+  getProviderRegistryEntry,
+  providerMatchesRegistryTransport,
+  type ProviderRegistryEntry,
+} from "./registry";
+
+const STATIC_MODEL_CATALOG_PROVIDER_IDS = new Set(["cline-pass", "mimo-free"]);
+
+function normalizedEndpoint(value: string): string {
+  const trimmed = value.trim();
+  try {
+    const parsed = new URL(trimmed);
+    parsed.pathname = parsed.pathname.replace(/\/+$/, "") || "/";
+    return parsed.toString().replace(/\/$/, "");
+  } catch {
+    return trimmed.replace(/\/+$/, "");
+  }
+}
+
+function exactRegistryTransportMatch(
+  entry: ProviderRegistryEntry,
+  provider: Pick<OcxProviderConfig, "baseUrl" | "adapter"> & Partial<Pick<OcxProviderConfig, "authMode">>,
+  options: { allowLegacyMimoLocal?: boolean } = {},
+): boolean {
+  if (entry.allowBaseUrlOverride || /\{[^}]*\}/.test(entry.baseUrl)) return false;
+  if (typeof provider.baseUrl !== "string" || provider.adapter !== entry.adapter) return false;
+  const legacyMimoLocal = options.allowLegacyMimoLocal === true
+    && entry.id === "mimo-free"
+    && provider.authMode === "local";
+  if (provider.authMode !== undefined && provider.authMode !== "key" && !legacyMimoLocal) return false;
+  return normalizedEndpoint(provider.baseUrl) === normalizedEndpoint(entry.baseUrl);
+}
+
+/** Registry policy for providers whose maintained model list is authoritative. */
+export function registryEntrySupportsLiveModelDiscovery(entry: ProviderRegistryEntry): boolean {
+  return !STATIC_MODEL_CATALOG_PROVIDER_IDS.has(entry.id);
+}
+
+/**
+ * Static-catalog authority is tied to canonical provider identity and exact transport.
+ * Renamed/custom rows stay operator-owned: Cline and ClinePass intentionally share a transport,
+ * so destination matching alone cannot safely identify a renamed ClinePass configuration.
+ */
+export function staticModelCatalogEntryForProvider(
+  name: string,
+  provider: OcxProviderConfig,
+): ProviderRegistryEntry | undefined {
+  const entry = getProviderRegistryEntry(name);
+  if (!entry || !STATIC_MODEL_CATALOG_PROVIDER_IDS.has(entry.id)) return undefined;
+  return exactRegistryTransportMatch(entry, provider, { allowLegacyMimoLocal: true })
+    ? entry
+    : undefined;
+}
+
+export function providerSupportsLiveModelDiscovery(name: string, provider: OcxProviderConfig): boolean {
+  return staticModelCatalogEntryForProvider(name, provider) === undefined;
+}
+
+/**
+ * MiMo Free predates collision preservation in the registry. Keep same-named custom rows out of
+ * registry ownership without broadening the generic transport matcher to other key providers.
+ */
+export function providerMatchesRegistryTransportWithStaticGuards(
+  name: string,
+  provider: Pick<OcxProviderConfig, "baseUrl" | "adapter"> & Partial<Pick<OcxProviderConfig, "authMode">>,
+): boolean {
+  if (name !== "mimo-free") return providerMatchesRegistryTransport(name, provider);
+  const entry = getProviderRegistryEntry(name);
+  return entry !== undefined
+    && exactRegistryTransportMatch(entry, provider, { allowLegacyMimoLocal: true });
+}
+
+/** Repair only registry-owned legacy state; operator-owned model lists stay untouched. */
+export function repairStaticModelCatalogProvider(name: string, provider: OcxProviderConfig): void {
+  const entry = staticModelCatalogEntryForProvider(name, provider);
+  if (!entry) return;
+  provider.liveModels = false;
+  if (
+    name === "mimo-free"
+    && entry.id === "mimo-free"
+    && (provider.authMode === undefined || provider.authMode === "local")
+  ) {
+    provider.authMode = "key";
+  }
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -11,8 +11,12 @@ import type { NormalizedComboConfig } from "./combos/types";
 import { hasOwnProvider, resolveEnvValue } from "./config";
 import { assertProviderDestinationAllowed } from "./lib/destination-policy";
 import { redactSecretString, redactUrlForLog } from "./lib/redact";
-import { PROVIDER_REGISTRY, providerCodexAccountMode, providerMatchesRegistryTransport } from "./providers/registry";
+import { PROVIDER_REGISTRY, providerCodexAccountMode } from "./providers/registry";
 import { applyDirectReasoningEffortContracts } from "./providers/derive";
+import {
+  providerMatchesRegistryTransportWithStaticGuards,
+  providerSupportsLiveModelDiscovery,
+} from "./providers/static-model-discovery";
 import {
   isCanonicalOpenAiForwardProvider,
   LEGACY_CHATGPT_PROVIDER_ID,
@@ -86,7 +90,7 @@ const MODEL_PROVIDER_PATTERNS: Array<{ providerNames: string[]; prefixes: string
 export function knownModelIdsForProvider(provName: string, prov: OcxProviderConfig): string[] {
   const ids = new Set<string>();
   for (const id of prov.models ?? []) ids.add(id);
-  const registry = providerMatchesRegistryTransport(provName, prov)
+  const registry = providerMatchesRegistryTransportWithStaticGuards(provName, prov)
     ? PROVIDER_REGISTRY.find(entry => entry.id === provName)
     : undefined;
   for (const id of registry?.models ?? []) ids.add(id);
@@ -249,20 +253,26 @@ function usableResolvedApiKey(apiKey: string | undefined): string | undefined {
 
 export function routedProviderConfig(providerName: string, provider: OcxProviderConfig): OcxProviderConfig {
   const registryEntry = PROVIDER_REGISTRY.find(entry => entry.id === providerName);
-  if (!registryEntry || !providerMatchesRegistryTransport(providerName, provider)) {
+  if (!registryEntry || !providerMatchesRegistryTransportWithStaticGuards(providerName, provider)) {
     assertProviderDestinationAllowed(providerName, provider);
     return { ...provider, apiKey: usableResolvedApiKey(provider.apiKey) };
   }
   const resolvedApiKey = usableResolvedApiKey(provider.apiKey);
+  const staticModelCatalog = !providerSupportsLiveModelDiscovery(providerName, provider);
+  const repairLegacyMimoFreeAuth = providerName === "mimo-free"
+    && staticModelCatalog
+    && (provider.authMode === undefined || provider.authMode === "local");
   const explicitKeyOverride = registryEntry.authKind === "oauth"
     && registryEntry.allowKeyAuthOverride === true
     && provider.authMode === "key"
     && resolvedApiKey !== undefined;
   const canonicalAuthMode = explicitKeyOverride
     ? "key"
-    : registryEntry.authKind === "forward" || registryEntry.authKind === "oauth"
-      ? registryEntry.authKind
-    : provider.authMode === "forward" ? undefined : provider.authMode;
+    : repairLegacyMimoFreeAuth
+      ? "key"
+      : registryEntry.authKind === "forward" || registryEntry.authKind === "oauth"
+        ? registryEntry.authKind
+        : provider.authMode === "forward" ? undefined : provider.authMode;
   const reasoningEffortMap = mergeRecord(registryEntry.reasoningEffortMap, provider.reasoningEffortMap);
   const modelReasoningEffortMap = mergeNestedRecord(registryEntry.modelReasoningEffortMap, provider.modelReasoningEffortMap);
   const modelReasoningEfforts = mergeStringArrayRecord(registryEntry.modelReasoningEfforts, provider.modelReasoningEfforts);
@@ -343,6 +353,7 @@ export function routedProviderConfig(providerName: string, provider: OcxProvider
       : {}),
     authMode: canonicalAuthMode,
     apiKey: resolvedApiKey,
+    ...(staticModelCatalog ? { liveModels: false } : {}),
     // Backfill the Google wire mode + Vertex project/location from the registry when the user
     // config omits them, so a minimal `google-vertex`/`google-antigravity` entry still routes
     // through the correct branch (CCA/Vertex) instead of falling back to AI Studio.

--- a/tests/cline-pass-provider.test.ts
+++ b/tests/cline-pass-provider.test.ts
@@ -18,6 +18,7 @@ const OFFICIAL_CLINE_PASS_MODELS = [
   "cline-pass/mimo-v2.5",
   "cline-pass/mimo-v2.5-pro",
   "cline-pass/minimax-m3",
+  "cline-pass/qwen3.8-max",
   "cline-pass/qwen3.7-max",
   "cline-pass/qwen3.7-plus",
 ];
@@ -76,6 +77,8 @@ describe("ClinePass provider", () => {
       "cline-pass/mimo-v2.5-pro",
       "cline-pass/qwen3.7-max",
     ]);
+    expect(entry?.modelContextWindows?.["cline-pass/qwen3.8-max"]).toBeUndefined();
+    expect(entry?.modelInputModalities?.["cline-pass/qwen3.8-max"]).toBeUndefined();
     expect(entry?.modelInputModalities?.["cline-pass/kimi-k3"]).toEqual(["text", "image"]);
     expect(entry?.modelInputModalities?.["cline-pass/glm-5.2"]).toEqual(["text"]);
     expect(KEY_LOGIN_PROVIDERS["cline-pass"]?.models).toEqual(OFFICIAL_CLINE_PASS_MODELS);

--- a/tests/mimo-free-provider.test.ts
+++ b/tests/mimo-free-provider.test.ts
@@ -36,10 +36,10 @@ describe("mimo-free provider registry", () => {
     expect(entry?.defaultModel).toBe("mimo-auto");
   });
 
-  test("providerConfigSeed propagates keyOptional and liveModels", () => {
+  test("providerConfigSeed preserves keyOptional and disables static live discovery", () => {
     const seed = providerConfigSeed(entry!);
     expect(seed.keyOptional).toBe(true);
-    expect(seed.liveModels).toBe(true);
+    expect(seed.liveModels).toBe(false);
   });
 
   test("is included in the key-login map", () => {

--- a/tests/provider-static-model-discovery.test.ts
+++ b/tests/provider-static-model-discovery.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import { createMimoFreeAdapter, MIMO_CHAT_URL } from "../src/adapters/mimo-free";
+import { enrichProviderFromRegistry, providerConfigSeed } from "../src/providers/derive";
+import { getProviderRegistryEntry } from "../src/providers/registry";
+import {
+  providerMatchesRegistryTransportWithStaticGuards,
+  providerSupportsLiveModelDiscovery,
+  registryEntrySupportsLiveModelDiscovery,
+} from "../src/providers/static-model-discovery";
+import { routedProviderConfig } from "../src/router";
+import type { OcxProviderConfig } from "../src/types";
+
+function provider(overrides: Partial<OcxProviderConfig>): OcxProviderConfig {
+  return {
+    adapter: "openai-chat",
+    baseUrl: "https://example.com/v1",
+    ...overrides,
+  };
+}
+
+describe("static provider model discovery policy", () => {
+  test("ClinePass and MiMo Free seeds are static without changing the registry catalog", () => {
+    for (const id of ["cline-pass", "mimo-free"] as const) {
+      const entry = getProviderRegistryEntry(id);
+      expect(entry).toBeDefined();
+      expect(registryEntrySupportsLiveModelDiscovery(entry!)).toBeFalse();
+      expect(providerConfigSeed(entry!).liveModels).toBeFalse();
+    }
+  });
+
+  test("stale canonical ClinePass discovery is disabled without replacing saved models", () => {
+    const savedModels = ["cline-pass/kimi-k3", "saved-selector"];
+    const config = provider({
+      adapter: "openai-chat",
+      baseUrl: "https://api.cline.bot/api/v1",
+      authMode: "key",
+      liveModels: true,
+      models: [...savedModels],
+    });
+
+    enrichProviderFromRegistry("cline-pass", config);
+    expect(config.liveModels).toBeFalse();
+    expect(config.models).toEqual(savedModels);
+
+    const routed = routedProviderConfig("cline-pass", provider({
+      adapter: "openai-chat",
+      baseUrl: "https://api.cline.bot/api/v1",
+      authMode: "key",
+      liveModels: true,
+      models: [...savedModels],
+    }));
+    expect(routed.liveModels).toBeFalse();
+    expect(routed.models).toEqual(savedModels);
+  });
+
+  test("the normal Cline API stays live even though it shares the ClinePass destination", () => {
+    const config = provider({
+      adapter: "openai-chat",
+      baseUrl: "https://api.cline.bot/api/v1",
+      authMode: "key",
+      liveModels: true,
+      defaultModel: "anthropic/claude-sonnet-4-6",
+    });
+
+    expect(providerSupportsLiveModelDiscovery("cline", config)).toBeTrue();
+    expect(providerSupportsLiveModelDiscovery("my-cline", config)).toBeTrue();
+  });
+
+  test("legacy canonical MiMo Free auth is repaired without replacing saved models", () => {
+    const config = provider({
+      adapter: "mimo-free",
+      baseUrl: MIMO_CHAT_URL,
+      authMode: "local",
+      liveModels: true,
+      models: ["mimo-auto", "saved-selector"],
+    });
+
+    enrichProviderFromRegistry("mimo-free", config);
+    expect(config.authMode).toBe("key");
+    expect(config.liveModels).toBeFalse();
+    expect(config.models).toEqual(["mimo-auto", "saved-selector"]);
+
+    const routed = routedProviderConfig("mimo-free", provider({
+      adapter: "mimo-free",
+      baseUrl: MIMO_CHAT_URL,
+      authMode: "local",
+      liveModels: true,
+      models: ["mimo-auto", "saved-selector"],
+    }));
+    expect(routed.authMode).toBe("key");
+    expect(routed.liveModels).toBeFalse();
+    expect(routed.models).toEqual(["mimo-auto", "saved-selector"]);
+  });
+
+  test("same-named custom MiMo Free rows are not claimed by the canonical preset", () => {
+    const custom = provider({
+      adapter: "openai-chat",
+      baseUrl: "https://example.com/v1",
+      authMode: "key",
+      liveModels: true,
+      models: ["custom-model"],
+    });
+
+    expect(providerMatchesRegistryTransportWithStaticGuards("mimo-free", custom)).toBeFalse();
+    const routed = routedProviderConfig("mimo-free", custom);
+    expect(routed.adapter).toBe("openai-chat");
+    expect(routed.baseUrl).toBe("https://example.com/v1");
+    expect(routed.liveModels).toBeTrue();
+    expect(routed.models).toEqual(["custom-model"]);
+  });
+
+  test("the bespoke MiMo Free adapter refuses a custom destination", () => {
+    expect(() => createMimoFreeAdapter(provider({
+      adapter: "mimo-free",
+      baseUrl: "https://example.com/v1",
+    }))).toThrow("only supports the canonical Xiaomi MiMo Free endpoint");
+  });
+});


### PR DESCRIPTION
## Summary

- make canonical ClinePass and MiMo Free use their maintained static model lists instead of probing unsupported model-list endpoints
- keep the current ClinePass catalogue intact, including the forward-looking `cline-pass/glm-5.3`, and add Cline's now-documented `cline-pass/qwen3.8-max` slug without inventing unverified context or vision metadata
- repair legacy canonical MiMo Free `authMode: local` or omitted auth to `key` at registry enrichment/routing time without replacing saved model selectors
- refuse custom destinations on the bespoke `mimo-free` adapter
- disable the Live Models toggle only for the exact canonical static-catalog transports
- preserve the existing key-optional auth fallback for every unrelated provider

## Reimplementation of #1639

This reimplements the useful discovery-recovery work from #1639 on current `dev` instead of replaying its stale commits.

Two deliberate differences follow Jun's review and the current code:

1. The old global ProviderSettings fallback change is not included. Unrelated `keyOptional` providers keep `item.authMode ?? (item.keyOptional ? "local" : "key")`.
2. The current `dev` ClinePass catalogue stays intact, including `cline-pass/glm-5.3`. The only catalogue refresh here is `cline-pass/qwen3.8-max`, which Cline now lists for ClinePass. Qwen3.8's context window and input modality remain unclassified because the ClinePass gateway does not document those capabilities yet.

Cline and ClinePass share the same API transport, so destination matching alone cannot safely classify renamed rows as ClinePass. Static-catalog authority is therefore limited to canonical provider id plus exact transport. Renamed/custom rows remain operator-owned.

## Tests

Added/extended regression coverage for:

- ClinePass and MiMo Free static seeds
- ClinePass `qwen3.8-max` catalogue presence while leaving undocumented context/vision metadata unset
- normal Cline remaining live despite the shared destination
- legacy MiMo auth and discovery repair while preserving saved models
- same-named custom MiMo rows remaining custom
- the MiMo bespoke adapter rejecting custom destinations
- canonical ClinePass showing a disabled static Live Models control
- same-named custom MiMo keeping the control editable
- unrelated key-optional providers retaining the `local` UI fallback

This environment could not execute a local checkout, so GitHub Actions is the execution gate for this draft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added static model catalogs for Cline Pass and MiMo Free, including the `qwen3.8-max` model.
  * Live model discovery is automatically disabled for supported static providers, while custom configurations retain it.
  * MiMo Free now validates its canonical endpoint and guides custom endpoints to the appropriate provider option.

* **Bug Fixes**
  * Corrected legacy authentication settings and stale discovery states.
  * Preserved saved models when live discovery is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->