### PR TITLE
fix(xai): merge root tool unions into one object schema

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -717,6 +717,23 @@ function expandXaiRootObjectSchemas(schema: unknown): Record<string, unknown>[] 
   return expanded.length > 0 ? expanded : undefined;
 }
 
+function mergeXaiPropertySchemas(values: unknown[]): unknown {
+  const unique: unknown[] = [];
+  const serialized = new Set<string>();
+  for (const value of values) {
+    const key = JSON.stringify(value);
+    if (serialized.has(key)) continue;
+    serialized.add(key);
+    unique.push(value);
+  }
+  return unique.length === 1 ? unique[0] : { anyOf: unique };
+}
+
+/**
+ * xAI rejects a function parameter schema whose root remains oneOf/anyOf, even when every branch
+ * is an object. Merge the union into one object root while preserving branch choices on each
+ * property. A field stays required only when every branch requires it.
+ */
 function normalizeXaiToolParameters(parameters: unknown): Record<string, unknown> | undefined {
   const variants = expandXaiRootObjectSchemas(parameters);
   if (!variants) return undefined;
@@ -725,7 +742,41 @@ function normalizeXaiToolParameters(parameters: unknown): Record<string, unknown
     ? parameters as Record<string, unknown>
     : {};
   const metadata = Object.fromEntries(Object.entries(root).filter(([key]) => key !== "oneOf" && key !== "anyOf" && key !== "type"));
-  return { ...metadata, oneOf: variants };
+  delete metadata.properties;
+  delete metadata.required;
+
+  const propertyValues = new Map<string, unknown[]>();
+  for (const variant of variants) {
+    if (!variant.properties || typeof variant.properties !== "object" || Array.isArray(variant.properties)) continue;
+    for (const [name, value] of Object.entries(variant.properties as Record<string, unknown>)) {
+      const values = propertyValues.get(name) ?? [];
+      values.push(value);
+      propertyValues.set(name, values);
+    }
+  }
+  const properties = Object.fromEntries(
+    [...propertyValues].map(([name, values]) => [name, mergeXaiPropertySchemas(values)]),
+  );
+
+  const requiredSets = variants.map(variant => new Set(
+    Array.isArray(variant.required)
+      ? variant.required.filter((item): item is string => typeof item === "string")
+      : [],
+  ));
+  const required = requiredSets.length === 0
+    ? []
+    : [...requiredSets[0]].filter(name => requiredSets.every(set => set.has(name)));
+  const additionalProperties = variants.every(variant => variant.additionalProperties === false)
+    ? false
+    : undefined;
+
+  return {
+    ...metadata,
+    type: "object",
+    properties,
+    ...(required.length > 0 ? { required } : {}),
+    ...(additionalProperties === false ? { additionalProperties } : {}),
+  };
 }
 
 function toolsToChatFormat(parsed: OcxParsedRequest, provider: OcxProviderConfig): unknown[] | undefined {

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -706,6 +706,122 @@ function stringRequiredFields(value: unknown): string[] {
     : [];
 }
 
+const XAI_UNSAFE_VARIANT_KEYS = [
+  "$ref",
+  "oneOf",
+  "anyOf",
+  "allOf",
+  "if",
+  "then",
+  "else",
+  "not",
+  "dependentRequired",
+  "dependentSchemas",
+  "patternProperties",
+  "unevaluatedProperties",
+] as const;
+
+function decodeJsonPointerToken(token: string): string {
+  return token.replace(/~1/g, "/").replace(/~0/g, "~");
+}
+
+function lookupLocalJsonPointer(root: unknown, ref: string): unknown {
+  if (ref === "#" || ref === "#/") return root;
+  if (!ref.startsWith("#/")) return undefined;
+  let current: unknown = root;
+  for (const token of ref.slice(2).split("/").map(decodeJsonPointerToken)) {
+    if (!isXaiObjectSchema(current) || !Object.hasOwn(current, token)) return undefined;
+    current = current[token];
+  }
+  return current;
+}
+
+/** Resolve local `#/` `$ref`s. Unresolvable or cyclic refs return undefined. */
+function resolveXaiSchemaRefs(
+  schema: unknown,
+  root: Record<string, unknown>,
+  stack: Set<string> = new Set(),
+): unknown | undefined {
+  if (!isXaiObjectSchema(schema)) return schema;
+  if (typeof schema.$ref === "string") {
+    const ref = schema.$ref;
+    if (stack.has(ref)) return undefined;
+    const target = lookupLocalJsonPointer(root, ref);
+    if (target === undefined) return undefined;
+    stack.add(ref);
+    const resolvedTarget = resolveXaiSchemaRefs(target, root, stack);
+    stack.delete(ref);
+    if (resolvedTarget === undefined) return undefined;
+    const rest: Record<string, unknown> = { ...schema };
+    delete rest.$ref;
+    if (Object.keys(rest).length === 0) return resolvedTarget;
+    const resolvedRest = resolveXaiSchemaRefs(rest, root, stack);
+    if (resolvedRest === undefined || !isXaiObjectSchema(resolvedTarget) || !isXaiObjectSchema(resolvedRest)) {
+      return undefined;
+    }
+    return composeXaiObjectSchemas(resolvedTarget, resolvedRest);
+  }
+
+  const resolved: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(schema)) {
+    if ((key === "oneOf" || key === "anyOf") && Array.isArray(value)) {
+      const items: unknown[] = [];
+      for (const item of value) {
+        const next = resolveXaiSchemaRefs(item, root, stack);
+        if (next === undefined) return undefined;
+        items.push(next);
+      }
+      resolved[key] = items;
+      continue;
+    }
+    if (key === "properties" && isXaiObjectSchema(value)) {
+      const properties: Record<string, unknown> = {};
+      for (const [name, property] of Object.entries(value)) {
+        const next = resolveXaiSchemaRefs(property, root, stack);
+        if (next === undefined) return undefined;
+        properties[name] = next;
+      }
+      resolved[key] = properties;
+      continue;
+    }
+    resolved[key] = value;
+  }
+  return resolved;
+}
+
+function xaiVariantIsConcreteObject(variant: Record<string, unknown>): boolean {
+  if (variant.type !== undefined && variant.type !== "object") return false;
+  return XAI_UNSAFE_VARIANT_KEYS.every(key => !(key in variant));
+}
+
+function xaiRequiredSetsMatch(variants: Record<string, unknown>[]): boolean {
+  const serialized = variants.map(variant => [...stringRequiredFields(variant.required)].sort().join("\0"));
+  return serialized.every(value => value === serialized[0]);
+}
+
+function mergeXaiAdditionalProperties(
+  variants: Record<string, unknown>[],
+): { ok: true; value?: unknown } | { ok: false } {
+  const values = variants.map(variant => variant.additionalProperties);
+  const explicit = values.filter(value => value !== undefined);
+  if (explicit.length === 0) return { ok: true };
+  if (explicit.length !== values.length) return { ok: false };
+  const hasFalse = explicit.some(value => value === false);
+  const permissive = explicit.filter(value => value !== false);
+  if (hasFalse && permissive.length > 0) return { ok: false };
+  if (hasFalse) return { ok: true, value: false };
+  const unique: unknown[] = [];
+  const seen = new Set<string>();
+  for (const value of permissive) {
+    const key = JSON.stringify(value);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(value);
+  }
+  if (unique.length !== 1) return { ok: false };
+  return { ok: true, value: unique[0] };
+}
+
 /** Compose root siblings into a branch so properties/required are not overwritten. */
 function composeXaiObjectSchemas(
   inherited: Record<string, unknown>,
@@ -767,19 +883,27 @@ function mergeXaiPropertySchemas(values: unknown[]): unknown {
 
 /**
  * xAI rejects a function parameter schema whose root remains oneOf/anyOf, even when every branch
- * is an object. Merge the union into one object root while preserving branch choices on each
- * property. A field stays required only when every branch requires it.
+ * is an object. Flatten only when the merge is lossless: local $refs resolve, every variant is a
+ * concrete object, required sets match, and additionalProperties does not change meaning.
+ * Otherwise omit the tool rather than emit a weaker schema.
  */
 function normalizeXaiToolParameters(parameters: unknown): Record<string, unknown> | undefined {
-  const variants = expandXaiRootObjectSchemas(parameters);
+  if (!isXaiObjectSchema(parameters)) return undefined;
+  const resolved = resolveXaiSchemaRefs(parameters, parameters);
+  if (!isXaiObjectSchema(resolved)) return undefined;
+  const variants = expandXaiRootObjectSchemas(resolved);
   if (!variants) return undefined;
-  if (variants.length === 1) return variants[0];
-  const root = parameters && typeof parameters === "object" && !Array.isArray(parameters)
-    ? parameters as Record<string, unknown>
-    : {};
-  const metadata = Object.fromEntries(Object.entries(root).filter(([key]) => key !== "oneOf" && key !== "anyOf" && key !== "type"));
+  if (variants.length === 1) {
+    return xaiVariantIsConcreteObject(variants[0]) ? variants[0] : undefined;
+  }
+  if (!variants.every(xaiVariantIsConcreteObject) || !xaiRequiredSetsMatch(variants)) return undefined;
+  const additionalProperties = mergeXaiAdditionalProperties(variants);
+  if (!additionalProperties.ok) return undefined;
+
+  const metadata = Object.fromEntries(Object.entries(resolved).filter(([key]) => key !== "oneOf" && key !== "anyOf" && key !== "type"));
   delete metadata.properties;
   delete metadata.required;
+  delete metadata.additionalProperties;
 
   const propertyValues = new Map<string, unknown[]>();
   for (const variant of variants) {
@@ -793,21 +917,14 @@ function normalizeXaiToolParameters(parameters: unknown): Record<string, unknown
   const properties = Object.fromEntries(
     [...propertyValues].map(([name, values]) => [name, mergeXaiPropertySchemas(values)]),
   );
-
-  const requiredSets = variants.map(variant => new Set(stringRequiredFields(variant.required)));
-  const required = requiredSets.length === 0
-    ? []
-    : [...requiredSets[0]].filter(name => requiredSets.every(set => set.has(name)));
-  const additionalProperties = variants.every(variant => variant.additionalProperties === false)
-    ? false
-    : undefined;
+  const required = stringRequiredFields(variants[0]?.required);
 
   return {
     ...metadata,
     type: "object",
     properties,
     ...(required.length > 0 ? { required } : {}),
-    ...(additionalProperties === false ? { additionalProperties } : {}),
+    ...("value" in additionalProperties ? { additionalProperties: additionalProperties.value } : {}),
   };
 }
 

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -797,16 +797,12 @@ function variantProperties(variant: Record<string, unknown>): Record<string, unk
 }
 
 /**
- * Independent per-property anyOf is lossless only when at most one property schema
- * differs. Two or more divergent properties can be correlated (kind+value, etc.).
- * A property present on only some closed (`additionalProperties: false`) variants
- * cannot be added to the others without widening the accepted set.
+ * Independent per-property anyOf is lossless only when every property name exists
+ * on every variant (absence is meaningful under xAI's default additionalProperties:
+ * false, and promoting a branch-local key also tightens explicit-true variants)
+ * and at most one of those shared properties has a conflicting schema.
  */
-function xaiPropertyMergeIsLossless(
-  variants: Record<string, unknown>[],
-  additionalProperties: { ok: true; value?: unknown },
-): boolean {
-  const closed = additionalProperties.value === false;
+function xaiPropertyMergeIsLossless(variants: Record<string, unknown>[]): boolean {
   const names = new Set<string>();
   const props = variants.map(variant => {
     const properties = variantProperties(variant);
@@ -815,8 +811,8 @@ function xaiPropertyMergeIsLossless(
   });
   let schemaConflicts = 0;
   for (const name of names) {
-    const values = props.map(property => property[name]).filter(value => value !== undefined);
-    if (values.length !== variants.length && closed) return false;
+    const values = props.map(property => property[name]);
+    if (values.some(value => value === undefined)) return false;
     if (values.some(value => JSON.stringify(value) !== JSON.stringify(values[0]))) schemaConflicts += 1;
   }
   return schemaConflicts <= 1;
@@ -913,8 +909,8 @@ function mergeXaiPropertySchemas(values: unknown[]): unknown {
  * The Grok CLI proxy rejects a function parameter schema whose root remains oneOf/anyOf.
  * Flatten only when the merge is lossless: local $refs resolve, every variant is a concrete
  * object whose keys we can preserve, required sets match, additionalProperties does not change
- * meaning, and at most one property schema differs (so per-property anyOf cannot hide
- * correlations). Otherwise omit the tool rather than emit a weaker schema.
+ * meaning, every property name exists on every variant, and at most one property schema
+ * differs. Otherwise omit the tool rather than emit a weaker schema.
  */
 function normalizeXaiToolParameters(parameters: unknown): Record<string, unknown> | undefined {
   if (!isXaiObjectSchema(parameters)) return undefined;
@@ -928,7 +924,7 @@ function normalizeXaiToolParameters(parameters: unknown): Record<string, unknown
   if (!variants.every(xaiVariantIsConcreteObject) || !xaiRequiredSetsMatch(variants)) return undefined;
   const additionalProperties = mergeXaiAdditionalProperties(variants);
   if (!additionalProperties.ok) return undefined;
-  if (!xaiPropertyMergeIsLossless(variants, additionalProperties)) return undefined;
+  if (!xaiPropertyMergeIsLossless(variants)) return undefined;
 
   const metadata = Object.fromEntries(Object.entries(resolved).filter(([key]) => key !== "oneOf" && key !== "anyOf" && key !== "type"));
   delete metadata.properties;

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -658,11 +658,11 @@ function shouldSanitizeZenToolParameters(provider: OcxProviderConfig): boolean {
     || baseUrl === "https://opencode.ai/zen/go/v1";
 }
 
-const XAI_SCHEMA_BASE_URLS = new Set(["api.x.ai", "cli-chat-proxy.grok.com"]);
-
 function isXaiSchemaTarget(provider: OcxProviderConfig): boolean {
   try {
-    return XAI_SCHEMA_BASE_URLS.has(new URL(provider.baseUrl).hostname);
+    // Public api.x.ai accepts native root object unions. Only the Grok CLI proxy
+    // 400s on a root oneOf/anyOf, so flattening/omitting is scoped to that host.
+    return new URL(provider.baseUrl).hostname === "cli-chat-proxy.grok.com";
   } catch {
     return false;
   }
@@ -706,20 +706,18 @@ function stringRequiredFields(value: unknown): string[] {
     : [];
 }
 
-const XAI_UNSAFE_VARIANT_KEYS = [
-  "$ref",
-  "oneOf",
-  "anyOf",
-  "allOf",
-  "if",
-  "then",
-  "else",
-  "not",
-  "dependentRequired",
-  "dependentSchemas",
-  "patternProperties",
-  "unevaluatedProperties",
-] as const;
+/** Variant keys the merger can keep. Anything else is refused, not silently dropped. */
+const XAI_VARIANT_MERGE_KEYS = new Set([
+  "type",
+  "properties",
+  "required",
+  "additionalProperties",
+  "description",
+  "title",
+  "$comment",
+  "$defs",
+  "definitions",
+]);
 
 function decodeJsonPointerToken(token: string): string {
   return token.replace(/~1/g, "/").replace(/~0/g, "~");
@@ -791,7 +789,37 @@ function resolveXaiSchemaRefs(
 
 function xaiVariantIsConcreteObject(variant: Record<string, unknown>): boolean {
   if (variant.type !== undefined && variant.type !== "object") return false;
-  return XAI_UNSAFE_VARIANT_KEYS.every(key => !(key in variant));
+  return Object.keys(variant).every(key => XAI_VARIANT_MERGE_KEYS.has(key));
+}
+
+function variantProperties(variant: Record<string, unknown>): Record<string, unknown> {
+  return isXaiObjectSchema(variant.properties) ? variant.properties : {};
+}
+
+/**
+ * Independent per-property anyOf is lossless only when at most one property schema
+ * differs. Two or more divergent properties can be correlated (kind+value, etc.).
+ * A property present on only some closed (`additionalProperties: false`) variants
+ * cannot be added to the others without widening the accepted set.
+ */
+function xaiPropertyMergeIsLossless(
+  variants: Record<string, unknown>[],
+  additionalProperties: { ok: true; value?: unknown },
+): boolean {
+  const closed = additionalProperties.value === false;
+  const names = new Set<string>();
+  const props = variants.map(variant => {
+    const properties = variantProperties(variant);
+    for (const name of Object.keys(properties)) names.add(name);
+    return properties;
+  });
+  let schemaConflicts = 0;
+  for (const name of names) {
+    const values = props.map(property => property[name]).filter(value => value !== undefined);
+    if (values.length !== variants.length && closed) return false;
+    if (values.some(value => JSON.stringify(value) !== JSON.stringify(values[0]))) schemaConflicts += 1;
+  }
+  return schemaConflicts <= 1;
 }
 
 function xaiRequiredSetsMatch(variants: Record<string, unknown>[]): boolean {
@@ -882,10 +910,11 @@ function mergeXaiPropertySchemas(values: unknown[]): unknown {
 }
 
 /**
- * xAI rejects a function parameter schema whose root remains oneOf/anyOf, even when every branch
- * is an object. Flatten only when the merge is lossless: local $refs resolve, every variant is a
- * concrete object, required sets match, and additionalProperties does not change meaning.
- * Otherwise omit the tool rather than emit a weaker schema.
+ * The Grok CLI proxy rejects a function parameter schema whose root remains oneOf/anyOf.
+ * Flatten only when the merge is lossless: local $refs resolve, every variant is a concrete
+ * object whose keys we can preserve, required sets match, additionalProperties does not change
+ * meaning, and at most one property schema differs (so per-property anyOf cannot hide
+ * correlations). Otherwise omit the tool rather than emit a weaker schema.
  */
 function normalizeXaiToolParameters(parameters: unknown): Record<string, unknown> | undefined {
   if (!isXaiObjectSchema(parameters)) return undefined;
@@ -899,6 +928,7 @@ function normalizeXaiToolParameters(parameters: unknown): Record<string, unknown
   if (!variants.every(xaiVariantIsConcreteObject) || !xaiRequiredSetsMatch(variants)) return undefined;
   const additionalProperties = mergeXaiAdditionalProperties(variants);
   if (!additionalProperties.ok) return undefined;
+  if (!xaiPropertyMergeIsLossless(variants, additionalProperties)) return undefined;
 
   const metadata = Object.fromEntries(Object.entries(resolved).filter(([key]) => key !== "oneOf" && key !== "anyOf" && key !== "type"));
   delete metadata.properties;

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -696,23 +696,59 @@ function ensureRootObjectType(parameters: unknown): Record<string, unknown> {
   return { ...obj, type: "object" };
 }
 
+function isXaiObjectSchema(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringRequiredFields(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+/** Compose root siblings into a branch so properties/required are not overwritten. */
+function composeXaiObjectSchemas(
+  inherited: Record<string, unknown>,
+  branch: Record<string, unknown>,
+): Record<string, unknown> {
+  const composed: Record<string, unknown> = { ...inherited, ...branch };
+  const inheritedProps = isXaiObjectSchema(inherited.properties) ? inherited.properties : undefined;
+  const branchProps = isXaiObjectSchema(branch.properties) ? branch.properties : undefined;
+  if (inheritedProps || branchProps) {
+    const properties: Record<string, unknown> = { ...(inheritedProps ?? {}) };
+    for (const [name, value] of Object.entries(branchProps ?? {})) {
+      const inheritedValue = inheritedProps?.[name];
+      properties[name] = inheritedValue !== undefined && JSON.stringify(inheritedValue) !== JSON.stringify(value)
+        ? { allOf: [inheritedValue, value] }
+        : value;
+    }
+    composed.properties = properties;
+  }
+  const required = [...new Set([
+    ...stringRequiredFields(inherited.required),
+    ...stringRequiredFields(branch.required),
+  ])];
+  if (required.length > 0) composed.required = required;
+  else delete composed.required;
+  return composed;
+}
+
 function expandXaiRootObjectSchemas(schema: unknown): Record<string, unknown>[] | undefined {
-  if (!schema || typeof schema !== "object" || Array.isArray(schema)) return undefined;
-  const obj = schema as Record<string, unknown>;
-  const compositionKey = ["oneOf", "anyOf"].find(key => Array.isArray(obj[key]));
+  if (!isXaiObjectSchema(schema)) return undefined;
+  const compositionKey = ["oneOf", "anyOf"].find(key => Array.isArray(schema[key]));
   if (!compositionKey) {
-    if (obj.type !== undefined && obj.type !== "object") return undefined;
-    return [{ ...obj, type: "object" }];
+    if (schema.type !== undefined && schema.type !== "object") return undefined;
+    return [{ ...schema, type: "object" }];
   }
 
-  const siblings = Object.fromEntries(Object.entries(obj).filter(([key]) => key !== compositionKey));
-  const branches = obj[compositionKey];
+  const siblings = Object.fromEntries(Object.entries(schema).filter(([key]) => key !== compositionKey));
+  const branches = schema[compositionKey];
   if (!Array.isArray(branches)) return undefined;
   const expanded: Record<string, unknown>[] = [];
   for (const branch of branches) {
     const variants = expandXaiRootObjectSchemas(branch);
     if (!variants) return undefined;
-    for (const variant of variants) expanded.push({ ...siblings, ...variant });
+    for (const variant of variants) expanded.push(composeXaiObjectSchemas(siblings, variant));
   }
   return expanded.length > 0 ? expanded : undefined;
 }
@@ -758,11 +794,7 @@ function normalizeXaiToolParameters(parameters: unknown): Record<string, unknown
     [...propertyValues].map(([name, values]) => [name, mergeXaiPropertySchemas(values)]),
   );
 
-  const requiredSets = variants.map(variant => new Set(
-    Array.isArray(variant.required)
-      ? variant.required.filter((item): item is string => typeof item === "string")
-      : [],
-  ));
+  const requiredSets = variants.map(variant => new Set(stringRequiredFields(variant.required)));
   const required = requiredSets.length === 0
     ? []
     : [...requiredSets[0]].filter(name => requiredSets.every(set => set.has(name)));

--- a/tests/xai-transport.test.ts
+++ b/tests/xai-transport.test.ts
@@ -111,9 +111,13 @@ describe("xAI auth-mode transport selection", () => {
     });
     const xaiParameters = (JSON.parse(request.body) as { tools: Array<{ function: { parameters: Record<string, unknown> } }> }).tools[0].function.parameters;
 
-    expect(xaiParameters.type).toBeUndefined();
-    expect(xaiParameters.oneOf).toHaveLength(3);
-    expect((xaiParameters.oneOf as Record<string, unknown>[]).every(branch => branch.type === "object")).toBe(true);
+    expect(xaiParameters.type).toBe("object");
+    expect(xaiParameters.oneOf).toBeUndefined();
+    expect(xaiParameters.anyOf).toBeUndefined();
+    expect(xaiParameters.properties).toEqual({
+      mode: { type: "string", enum: ["view"] },
+      path: { type: "string" },
+    });
     expect(xaiParameters.$defs).toEqual(schema.$defs);
 
     const otherRequest = createOpenAIChatAdapter({ ...provider("key"), baseUrl: "https://example.test/v1" }).buildRequest({
@@ -169,8 +173,9 @@ describe("xAI auth-mode transport selection", () => {
     const body = JSON.parse(request.body) as { tools: Array<{ function: { name: string; parameters: Record<string, unknown> } }> };
     const tool = body.tools.find(entry => entry.function.name === "automation_update");
 
-    expect(tool?.function.parameters.oneOf).toHaveLength(2);
-    expect((tool?.function.parameters.oneOf as Record<string, unknown>[]).every(branch => branch.type === "object")).toBe(true);
+    expect(tool?.function.parameters.type).toBe("object");
+    expect(tool?.function.parameters.oneOf).toBeUndefined();
+    expect(tool?.function.parameters.properties).toEqual({});
   });
 });
 

--- a/tests/xai-transport.test.ts
+++ b/tests/xai-transport.test.ts
@@ -127,14 +127,14 @@ describe("xAI auth-mode transport selection", () => {
     expect((JSON.parse(otherRequest.body) as { tools: Array<{ function: { parameters: unknown } }> }).tools[0].function.parameters).toEqual({ ...schema, type: "object" });
   });
 
-  test("preserves root properties and required across xAI union branches", () => {
+  test("preserves shared root properties when every xAI branch has the same required set", () => {
     const schema = {
       type: "object",
       properties: { token: { type: "string" } },
       required: ["token"],
       oneOf: [
-        { properties: { mode: { const: "path" }, path: { type: "string" } }, required: ["mode", "path"] },
-        { properties: { mode: { const: "url" }, url: { type: "string" } }, required: ["mode", "url"] },
+        { properties: { mode: { const: "path" } } },
+        { properties: { mode: { const: "url" } } },
       ],
     };
     const request = createOpenAIChatAdapter(provider("key")).buildRequest({
@@ -149,10 +149,92 @@ describe("xAI auth-mode transport selection", () => {
     expect(xaiParameters.properties).toEqual({
       token: { type: "string" },
       mode: { anyOf: [{ const: "path" }, { const: "url" }] },
+    });
+    expect(xaiParameters.required).toEqual(["token"]);
+  });
+
+  test("omits an xAI union whose branch required fields cannot be flattened", () => {
+    const schema = {
+      type: "object",
+      properties: { token: { type: "string" } },
+      required: ["token"],
+      oneOf: [
+        { properties: { mode: { const: "path" }, path: { type: "string" } }, required: ["mode", "path"] },
+        { properties: { mode: { const: "url" }, url: { type: "string" } }, required: ["mode", "url"] },
+      ],
+    };
+    const request = createOpenAIChatAdapter(provider("key")).buildRequest({
+      ...parsed(),
+      context: { messages: [], tools: [{ name: "automation_update", description: "Update", parameters: schema }] },
+    });
+    expect(JSON.parse(request.body).tools).toBeUndefined();
+  });
+
+  test("resolves local $ref variants before flattening an xAI union", () => {
+    const schema = {
+      $defs: {
+        path: { type: "object", properties: { mode: { const: "path" }, path: { type: "string" } } },
+        url: { type: "object", properties: { mode: { const: "url" }, url: { type: "string" } } },
+      },
+      oneOf: [{ $ref: "#/$defs/path" }, { $ref: "#/$defs/url" }],
+    };
+    const request = createOpenAIChatAdapter(provider("key")).buildRequest({
+      ...parsed(),
+      context: { messages: [], tools: [{ name: "automation_update", description: "Update", parameters: schema }] },
+    });
+    const xaiParameters = (JSON.parse(request.body) as { tools: Array<{ function: { parameters: Record<string, unknown> } }> }).tools[0].function.parameters;
+
+    expect(xaiParameters.type).toBe("object");
+    expect(xaiParameters.oneOf).toBeUndefined();
+    expect(xaiParameters.properties).toEqual({
+      mode: { anyOf: [{ const: "path" }, { const: "url" }] },
       path: { type: "string" },
       url: { type: "string" },
     });
-    expect(xaiParameters.required).toEqual(["token", "mode"]);
+    expect(xaiParameters.$defs).toEqual(schema.$defs);
+  });
+
+  test("omits an xAI $ref union that would collapse to an empty object", () => {
+    const schema = {
+      $defs: {
+        named: { type: "object", properties: { name: { type: "string" } }, required: ["name"] },
+      },
+      oneOf: [{ $ref: "#/$defs/named" }, { type: "object", properties: { id: { type: "number" } } }],
+    };
+    const request = createOpenAIChatAdapter(provider("key")).buildRequest({
+      ...parsed(),
+      context: { messages: [], tools: [{ name: "lookup", description: "Lookup", parameters: schema }] },
+    });
+    expect(JSON.parse(request.body).tools).toBeUndefined();
+  });
+
+  test("keeps additionalProperties: false only when every xAI variant is closed", () => {
+    const schema = {
+      oneOf: [
+        { type: "object", properties: { a: { type: "string" } }, additionalProperties: false },
+        { type: "object", properties: { b: { type: "string" } }, additionalProperties: false },
+      ],
+    };
+    const request = createOpenAIChatAdapter(provider("key")).buildRequest({
+      ...parsed(),
+      context: { messages: [], tools: [{ name: "closed", description: "Closed", parameters: schema }] },
+    });
+    const xaiParameters = (JSON.parse(request.body) as { tools: Array<{ function: { parameters: Record<string, unknown> } }> }).tools[0].function.parameters;
+    expect(xaiParameters.additionalProperties).toBe(false);
+  });
+
+  test("omits an xAI union that would tighten additionalProperties", () => {
+    const schema = {
+      oneOf: [
+        { type: "object", properties: { a: { type: "string" } }, additionalProperties: true },
+        { type: "object", properties: { b: { type: "string" } }, additionalProperties: false },
+      ],
+    };
+    const request = createOpenAIChatAdapter(provider("key")).buildRequest({
+      ...parsed(),
+      context: { messages: [], tools: [{ name: "mixed", description: "Mixed", parameters: schema }] },
+    });
+    expect(JSON.parse(request.body).tools).toBeUndefined();
   });
 
   test("non-xAI providers preserve nested nullable and annotation schema content", () => {

--- a/tests/xai-transport.test.ts
+++ b/tests/xai-transport.test.ts
@@ -127,6 +127,34 @@ describe("xAI auth-mode transport selection", () => {
     expect((JSON.parse(otherRequest.body) as { tools: Array<{ function: { parameters: unknown } }> }).tools[0].function.parameters).toEqual({ ...schema, type: "object" });
   });
 
+  test("preserves root properties and required across xAI union branches", () => {
+    const schema = {
+      type: "object",
+      properties: { token: { type: "string" } },
+      required: ["token"],
+      oneOf: [
+        { properties: { mode: { const: "path" }, path: { type: "string" } }, required: ["mode", "path"] },
+        { properties: { mode: { const: "url" }, url: { type: "string" } }, required: ["mode", "url"] },
+      ],
+    };
+    const request = createOpenAIChatAdapter(provider("key")).buildRequest({
+      ...parsed(),
+      context: { messages: [], tools: [{ name: "automation_update", description: "Update", parameters: schema }] },
+    });
+    const xaiParameters = (JSON.parse(request.body) as { tools: Array<{ function: { parameters: Record<string, unknown> } }> }).tools[0].function.parameters;
+
+    expect(xaiParameters.type).toBe("object");
+    expect(xaiParameters.oneOf).toBeUndefined();
+    expect(xaiParameters.anyOf).toBeUndefined();
+    expect(xaiParameters.properties).toEqual({
+      token: { type: "string" },
+      mode: { anyOf: [{ const: "path" }, { const: "url" }] },
+      path: { type: "string" },
+      url: { type: "string" },
+    });
+    expect(xaiParameters.required).toEqual(["token", "mode"]);
+  });
+
   test("non-xAI providers preserve nested nullable and annotation schema content", () => {
     const schema = {
       type: "object",

--- a/tests/xai-transport.test.ts
+++ b/tests/xai-transport.test.ts
@@ -32,6 +32,16 @@ function provider(authMode: "oauth" | "key"): OcxProviderConfig {
   };
 }
 
+function cliProvider(): OcxProviderConfig {
+  return {
+    adapter: "openai-chat",
+    baseUrl: XAI_GROK_CLI_BASE_URL,
+    authMode: "oauth",
+    apiKey: "oauth-token",
+    defaultModel: "grok-4.5",
+  };
+}
+
 function parsed(): OcxParsedRequest {
   return {
     modelId: "grok-4.5",
@@ -97,7 +107,7 @@ describe("xAI auth-mode transport selection", () => {
     });
   });
 
-  test("flattens nested root tool unions for xAI while other providers get a root object type", () => {
+  test("flattens nested root tool unions for the Grok CLI proxy while other providers keep a root object type", () => {
     const schema = {
       oneOf: [
         { type: "object", properties: { mode: { type: "string", enum: ["view"] } } },
@@ -105,7 +115,7 @@ describe("xAI auth-mode transport selection", () => {
       ],
       $defs: { shared: { type: "string" } },
     };
-    const request = createOpenAIChatAdapter(provider("key")).buildRequest({
+    const request = createOpenAIChatAdapter(cliProvider()).buildRequest({
       ...parsed(),
       context: { messages: [], tools: [{ name: "automation_update", description: "Update", parameters: schema }] },
     });
@@ -119,6 +129,12 @@ describe("xAI auth-mode transport selection", () => {
       path: { type: "string" },
     });
     expect(xaiParameters.$defs).toEqual(schema.$defs);
+
+    const apiRequest = createOpenAIChatAdapter(provider("key")).buildRequest({
+      ...parsed(),
+      context: { messages: [], tools: [{ name: "automation_update", description: "Update", parameters: schema }] },
+    });
+    expect((JSON.parse(apiRequest.body) as { tools: Array<{ function: { parameters: unknown } }> }).tools[0].function.parameters).toEqual({ ...schema, type: "object" });
 
     const otherRequest = createOpenAIChatAdapter({ ...provider("key"), baseUrl: "https://example.test/v1" }).buildRequest({
       ...parsed(),
@@ -137,7 +153,7 @@ describe("xAI auth-mode transport selection", () => {
         { properties: { mode: { const: "url" } } },
       ],
     };
-    const request = createOpenAIChatAdapter(provider("key")).buildRequest({
+    const request = createOpenAIChatAdapter(cliProvider()).buildRequest({
       ...parsed(),
       context: { messages: [], tools: [{ name: "automation_update", description: "Update", parameters: schema }] },
     });
@@ -163,11 +179,31 @@ describe("xAI auth-mode transport selection", () => {
         { properties: { mode: { const: "url" }, url: { type: "string" } }, required: ["mode", "url"] },
       ],
     };
-    const request = createOpenAIChatAdapter(provider("key")).buildRequest({
+    const request = createOpenAIChatAdapter(cliProvider()).buildRequest({
       ...parsed(),
       context: { messages: [], tools: [{ name: "automation_update", description: "Update", parameters: schema }] },
     });
     expect(JSON.parse(request.body).tools).toBeUndefined();
+  });
+
+  test("omits equal-required CLI unions whose property types are correlated", () => {
+    const schema = {
+      oneOf: [
+        { type: "object", properties: { kind: { const: "email" }, value: { type: "string" } }, required: ["kind", "value"] },
+        { type: "object", properties: { kind: { const: "sms" }, value: { type: "number" } }, required: ["kind", "value"] },
+      ],
+    };
+    const cli = createOpenAIChatAdapter(cliProvider()).buildRequest({
+      ...parsed(),
+      context: { messages: [], tools: [{ name: "contact", description: "Contact", parameters: schema }] },
+    });
+    expect(JSON.parse(cli.body).tools).toBeUndefined();
+
+    const api = createOpenAIChatAdapter(provider("key")).buildRequest({
+      ...parsed(),
+      context: { messages: [], tools: [{ name: "contact", description: "Contact", parameters: schema }] },
+    });
+    expect((JSON.parse(api.body) as { tools: Array<{ function: { parameters: unknown } }> }).tools[0].function.parameters).toEqual({ ...schema, type: "object" });
   });
 
   test("resolves local $ref variants before flattening an xAI union", () => {
@@ -178,7 +214,7 @@ describe("xAI auth-mode transport selection", () => {
       },
       oneOf: [{ $ref: "#/$defs/path" }, { $ref: "#/$defs/url" }],
     };
-    const request = createOpenAIChatAdapter(provider("key")).buildRequest({
+    const request = createOpenAIChatAdapter(cliProvider()).buildRequest({
       ...parsed(),
       context: { messages: [], tools: [{ name: "automation_update", description: "Update", parameters: schema }] },
     });
@@ -201,26 +237,41 @@ describe("xAI auth-mode transport selection", () => {
       },
       oneOf: [{ $ref: "#/$defs/named" }, { type: "object", properties: { id: { type: "number" } } }],
     };
-    const request = createOpenAIChatAdapter(provider("key")).buildRequest({
+    const request = createOpenAIChatAdapter(cliProvider()).buildRequest({
       ...parsed(),
       context: { messages: [], tools: [{ name: "lookup", description: "Lookup", parameters: schema }] },
     });
     expect(JSON.parse(request.body).tools).toBeUndefined();
   });
 
-  test("keeps additionalProperties: false only when every xAI variant is closed", () => {
+  test("omits a closed CLI union whose exclusive properties cannot be flattened", () => {
     const schema = {
       oneOf: [
         { type: "object", properties: { a: { type: "string" } }, additionalProperties: false },
         { type: "object", properties: { b: { type: "string" } }, additionalProperties: false },
       ],
     };
-    const request = createOpenAIChatAdapter(provider("key")).buildRequest({
+    const request = createOpenAIChatAdapter(cliProvider()).buildRequest({
+      ...parsed(),
+      context: { messages: [], tools: [{ name: "closed", description: "Closed", parameters: schema }] },
+    });
+    expect(JSON.parse(request.body).tools).toBeUndefined();
+  });
+
+  test("keeps additionalProperties: false when every closed CLI variant shares the same properties", () => {
+    const schema = {
+      oneOf: [
+        { type: "object", properties: { a: { const: "one" } }, additionalProperties: false },
+        { type: "object", properties: { a: { const: "two" } }, additionalProperties: false },
+      ],
+    };
+    const request = createOpenAIChatAdapter(cliProvider()).buildRequest({
       ...parsed(),
       context: { messages: [], tools: [{ name: "closed", description: "Closed", parameters: schema }] },
     });
     const xaiParameters = (JSON.parse(request.body) as { tools: Array<{ function: { parameters: Record<string, unknown> } }> }).tools[0].function.parameters;
     expect(xaiParameters.additionalProperties).toBe(false);
+    expect(xaiParameters.properties).toEqual({ a: { anyOf: [{ const: "one" }, { const: "two" }] } });
   });
 
   test("omits an xAI union that would tighten additionalProperties", () => {
@@ -230,9 +281,23 @@ describe("xAI auth-mode transport selection", () => {
         { type: "object", properties: { b: { type: "string" } }, additionalProperties: false },
       ],
     };
-    const request = createOpenAIChatAdapter(provider("key")).buildRequest({
+    const request = createOpenAIChatAdapter(cliProvider()).buildRequest({
       ...parsed(),
       context: { messages: [], tools: [{ name: "mixed", description: "Mixed", parameters: schema }] },
+    });
+    expect(JSON.parse(request.body).tools).toBeUndefined();
+  });
+
+  test("omits a CLI union that would drop branch-level minProperties", () => {
+    const schema = {
+      oneOf: [
+        { type: "object", properties: { a: { type: "string" } }, minProperties: 1 },
+        { type: "object", properties: { a: { type: "string" } } },
+      ],
+    };
+    const request = createOpenAIChatAdapter(cliProvider()).buildRequest({
+      ...parsed(),
+      context: { messages: [], tools: [{ name: "min", description: "Min", parameters: schema }] },
     });
     expect(JSON.parse(request.body).tools).toBeUndefined();
   });
@@ -253,7 +318,7 @@ describe("xAI auth-mode transport selection", () => {
   });
 
   test("omits an xAI tool whose root schema cannot be normalized safely", () => {
-    const request = createOpenAIChatAdapter(provider("key")).buildRequest({
+    const request = createOpenAIChatAdapter(cliProvider()).buildRequest({
       ...parsed(),
       context: { messages: [], tools: [{ name: "unsafe", description: "Unsafe", parameters: { oneOf: [{ type: "string" }] } }] },
     });
@@ -279,7 +344,7 @@ describe("xAI auth-mode transport selection", () => {
         { type: "message", role: "user", content: [{ type: "input_text", text: "continue" }] },
       ],
     });
-    const request = createOpenAIChatAdapter(provider("key")).buildRequest(parsedRequest);
+    const request = createOpenAIChatAdapter(cliProvider()).buildRequest(parsedRequest);
     const body = JSON.parse(request.body) as { tools: Array<{ function: { name: string; parameters: Record<string, unknown> } }> };
     const tool = body.tools.find(entry => entry.function.name === "automation_update");
 

--- a/tests/xai-transport.test.ts
+++ b/tests/xai-transport.test.ts
@@ -107,7 +107,7 @@ describe("xAI auth-mode transport selection", () => {
     });
   });
 
-  test("flattens nested root tool unions for the Grok CLI proxy while other providers keep a root object type", () => {
+  test("omits a CLI union whose properties are only on some branches; api.x.ai keeps the native union", () => {
     const schema = {
       oneOf: [
         { type: "object", properties: { mode: { type: "string", enum: ["view"] } } },
@@ -119,16 +119,7 @@ describe("xAI auth-mode transport selection", () => {
       ...parsed(),
       context: { messages: [], tools: [{ name: "automation_update", description: "Update", parameters: schema }] },
     });
-    const xaiParameters = (JSON.parse(request.body) as { tools: Array<{ function: { parameters: Record<string, unknown> } }> }).tools[0].function.parameters;
-
-    expect(xaiParameters.type).toBe("object");
-    expect(xaiParameters.oneOf).toBeUndefined();
-    expect(xaiParameters.anyOf).toBeUndefined();
-    expect(xaiParameters.properties).toEqual({
-      mode: { type: "string", enum: ["view"] },
-      path: { type: "string" },
-    });
-    expect(xaiParameters.$defs).toEqual(schema.$defs);
+    expect(JSON.parse(request.body).tools).toBeUndefined();
 
     const apiRequest = createOpenAIChatAdapter(provider("key")).buildRequest({
       ...parsed(),
@@ -141,6 +132,34 @@ describe("xAI auth-mode transport selection", () => {
       context: { messages: [], tools: [{ name: "automation_update", description: "Update", parameters: schema }] },
     });
     expect((JSON.parse(otherRequest.body) as { tools: Array<{ function: { parameters: unknown } }> }).tools[0].function.parameters).toEqual({ ...schema, type: "object" });
+  });
+
+  test("omits a CLI union with a branch-local property even when additionalProperties is omitted", () => {
+    const schema = {
+      oneOf: [
+        { type: "object", properties: { mode: { type: "string" } } },
+        { type: "object", properties: { path: { type: "string" } } },
+      ],
+    };
+    const request = createOpenAIChatAdapter(cliProvider()).buildRequest({
+      ...parsed(),
+      context: { messages: [], tools: [{ name: "local", description: "Local", parameters: schema }] },
+    });
+    expect(JSON.parse(request.body).tools).toBeUndefined();
+  });
+
+  test("omits a CLI union with a branch-local property even when additionalProperties is true", () => {
+    const schema = {
+      oneOf: [
+        { type: "object", properties: { a: { type: "string" } }, additionalProperties: true },
+        { type: "object", properties: { b: { type: "number" } }, additionalProperties: true },
+      ],
+    };
+    const request = createOpenAIChatAdapter(cliProvider()).buildRequest({
+      ...parsed(),
+      context: { messages: [], tools: [{ name: "open", description: "Open", parameters: schema }] },
+    });
+    expect(JSON.parse(request.body).tools).toBeUndefined();
   });
 
   test("preserves shared root properties when every xAI branch has the same required set", () => {
@@ -206,7 +225,7 @@ describe("xAI auth-mode transport selection", () => {
     expect((JSON.parse(api.body) as { tools: Array<{ function: { parameters: unknown } }> }).tools[0].function.parameters).toEqual({ ...schema, type: "object" });
   });
 
-  test("resolves local $ref variants before flattening an xAI union", () => {
+  test("omits a $ref union whose resolved properties are only on some branches", () => {
     const schema = {
       $defs: {
         path: { type: "object", properties: { mode: { const: "path" }, path: { type: "string" } } },
@@ -218,14 +237,26 @@ describe("xAI auth-mode transport selection", () => {
       ...parsed(),
       context: { messages: [], tools: [{ name: "automation_update", description: "Update", parameters: schema }] },
     });
-    const xaiParameters = (JSON.parse(request.body) as { tools: Array<{ function: { parameters: Record<string, unknown> } }> }).tools[0].function.parameters;
+    expect(JSON.parse(request.body).tools).toBeUndefined();
+  });
 
+  test("resolves local $ref variants and flattens when every property is shared", () => {
+    const schema = {
+      $defs: {
+        path: { type: "object", properties: { mode: { const: "path" } } },
+        url: { type: "object", properties: { mode: { const: "url" } } },
+      },
+      oneOf: [{ $ref: "#/$defs/path" }, { $ref: "#/$defs/url" }],
+    };
+    const request = createOpenAIChatAdapter(cliProvider()).buildRequest({
+      ...parsed(),
+      context: { messages: [], tools: [{ name: "automation_update", description: "Update", parameters: schema }] },
+    });
+    const xaiParameters = (JSON.parse(request.body) as { tools: Array<{ function: { parameters: Record<string, unknown> } }> }).tools[0].function.parameters;
     expect(xaiParameters.type).toBe("object");
     expect(xaiParameters.oneOf).toBeUndefined();
     expect(xaiParameters.properties).toEqual({
       mode: { anyOf: [{ const: "path" }, { const: "url" }] },
-      path: { type: "string" },
-      url: { type: "string" },
     });
     expect(xaiParameters.$defs).toEqual(schema.$defs);
   });


### PR DESCRIPTION
## Summary

xAI rejects function tool parameter schemas whose **root** is still `oneOf` / `anyOf`, even when every branch is an object (`tool parameter root must be an object`).

`expandXaiRootObjectSchemas` already flattens nested unions into object variants. `normalizeXaiToolParameters` then put those variants back under a root `oneOf`, which Grok still 400s.

This merges the expanded object branches into a single `type: "object"` root:

- properties are unioned; conflicting schemas become a nested `anyOf`
- a field is `required` only when every branch requires it
- `additionalProperties: false` is kept only when every branch has it

Tools that cannot be expanded to object branches are still omitted.

## Test plan

- [x] `bun test tests/xai-transport.test.ts` (25 pass), including:
  - nested root unions flatten to `type: "object"` with no root `oneOf`
  - later-turn `tool_search` history tools get the same object root
  - non-object root unions are omitted
- [ ] Live Grok request with a union-root tool (e.g. `codex_app__automation_update`) no longer 400s

Rebased onto current `main` (`v2.19.0`). The leftover `oneOf: variants` return is still present there.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with xAI tool schemas used by CLI chat transports.
  - Union-based parameter definitions are safely flattened when compatible, with merged properties and conflicting types preserved.
  - Required fields, additional-property restrictions, minimum property counts, and references are handled accurately.
  - Unsafe or unresolvable schemas are omitted rather than weakened.
  - Native unions remain supported for API-key transports.
  - Consistent handling applies to tools reconstructed from tool-search history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->