### PR TITLE
chore: clean orphaned GitHub Actions workflows

### DIFF
--- a/.github/workflows/cleanup-orphaned-workflows.yml
+++ b/.github/workflows/cleanup-orphaned-workflows.yml
@@ -1,0 +1,45 @@
+name: Clean orphaned workflow runs
+
+# GitHub keeps workflow identities in the Actions sidebar after a temporary
+# workflow file is removed. Once every run for that orphan is deleted, GitHub
+# can drop the stale workflow entry too.
+on:
+  schedule:
+    # Daily, offset from the hour to avoid the busiest scheduler window.
+    - cron: "47 5 * * *"
+  push:
+    branches: [main]
+    paths:
+      # The first promotion to main performs the initial backlog cleanup without
+      # exposing a branch-selectable workflow_dispatch with actions:write.
+      - ".github/workflows/cleanup-orphaned-workflows.yml"
+      - "scripts/ci/cleanup-orphaned-workflows.mjs"
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: cleanup-orphaned-workflows
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Delete orphaned workflow runs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout trusted default-branch code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Remove stale workflow histories
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun scripts/ci/cleanup-orphaned-workflows.mjs

--- a/.github/workflows/cleanup-orphaned-workflows.yml
+++ b/.github/workflows/cleanup-orphaned-workflows.yml
@@ -5,8 +5,8 @@ name: Clean orphaned workflow runs
 # can drop the stale workflow entry too.
 on:
   schedule:
-    # Daily, offset from the hour to avoid the busiest scheduler window.
-    - cron: "47 5 * * *"
+    # Daily at 06:00 UTC.
+    - cron: "0 6 * * *"
   push:
     branches: [main]
     paths:

--- a/.github/workflows/cleanup-orphaned-workflows.yml
+++ b/.github/workflows/cleanup-orphaned-workflows.yml
@@ -16,7 +16,7 @@ on:
       - "scripts/ci/cleanup-orphaned-workflows.mjs"
 
 permissions:
-  actions: write
+  actions: write # Required to delete orphaned workflow runs through the Actions API.
   contents: read
 
 concurrency:

--- a/.github/workflows/cleanup-orphaned-workflows.yml
+++ b/.github/workflows/cleanup-orphaned-workflows.yml
@@ -11,7 +11,7 @@ on:
     branches: [main]
     paths:
       # The first promotion to main performs the initial backlog cleanup without
-      # exposing a branch-selectable workflow_dispatch with actions:write.
+      # exposing a branch-selectable manual trigger with actions:write.
       - ".github/workflows/cleanup-orphaned-workflows.yml"
       - "scripts/ci/cleanup-orphaned-workflows.mjs"
 

--- a/scripts/ci/cleanup-orphaned-workflows.mjs
+++ b/scripts/ci/cleanup-orphaned-workflows.mjs
@@ -1,0 +1,243 @@
+const API_ROOT = "https://api.github.com";
+const LOCAL_WORKFLOW_PREFIX = ".github/workflows/";
+const DEFAULT_MAX_DELETIONS = 500;
+
+function encodePath(path) {
+  return path.split("/").map(encodeURIComponent).join("/");
+}
+
+function parseRepository(repository) {
+  if (typeof repository !== "string") {
+    throw new Error("GITHUB_REPOSITORY is required");
+  }
+  const [owner, repo, ...rest] = repository.split("/");
+  if (!owner || !repo || rest.length > 0) {
+    throw new Error(`GITHUB_REPOSITORY must be owner/repo, got ${JSON.stringify(repository)}`);
+  }
+  return { owner, repo };
+}
+
+class GitHubHttpError extends Error {
+  constructor(status, method, path, body) {
+    const detail = body.trim();
+    super(`${method} ${path} failed with HTTP ${status}${detail ? `: ${detail}` : ""}`);
+    this.name = "GitHubHttpError";
+    this.status = status;
+  }
+}
+
+function httpError(status, method, path, body) {
+  return new GitHubHttpError(status, method, path, body);
+}
+
+export function createGitHubClient({ token, fetchImpl = fetch, apiRoot = API_ROOT }) {
+  const headers = {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+
+  async function request(path, init = {}) {
+    const method = init.method ?? "GET";
+    const response = await fetchImpl(`${apiRoot}${path}`, {
+      ...init,
+      headers: { ...headers, ...(init.headers ?? {}) },
+    });
+
+    if (!response.ok) {
+      throw httpError(response.status, method, path, await response.text());
+    }
+
+    if (response.status === 204) return undefined;
+    return await response.json();
+  }
+
+  async function exists(path) {
+    const response = await fetchImpl(`${apiRoot}${path}`, { headers });
+    if (response.status === 404) return false;
+    if (!response.ok) {
+      throw httpError(response.status, "GET", path, await response.text());
+    }
+    return true;
+  }
+
+  async function paginate(path, key) {
+    const all = [];
+    for (let page = 1; ; page += 1) {
+      const separator = path.includes("?") ? "&" : "?";
+      const data = await request(`${path}${separator}per_page=100&page=${page}`);
+      const items = data?.[key];
+      if (!Array.isArray(items)) {
+        throw new Error(`GET ${path} did not return an array at ${key}`);
+      }
+      all.push(...items);
+      if (items.length < 100) return all;
+    }
+  }
+
+  return { request, exists, paginate };
+}
+
+async function workflowExistsOnLiveHeadBranch({ client, owner, repo, defaultBranch, workflow, runs, log }) {
+  const heads = new Map();
+  for (const run of runs) {
+    const fullName = run.head_repository?.full_name;
+    const branch = run.head_branch;
+    if (typeof fullName !== "string" || typeof branch !== "string" || !branch) continue;
+    if (fullName === `${owner}/${repo}` && branch === defaultBranch) continue;
+    heads.set(`${fullName}\0${branch}`, { fullName, branch });
+  }
+
+  for (const { fullName, branch } of heads.values()) {
+    const [headOwner, headRepo, ...rest] = fullName.split("/");
+    if (!headOwner || !headRepo || rest.length > 0) {
+      throw new Error(`Workflow run returned invalid head_repository.full_name: ${JSON.stringify(fullName)}`);
+    }
+
+    const exists = await client.exists(
+      `/repos/${encodeURIComponent(headOwner)}/${encodeURIComponent(headRepo)}`
+      + `/contents/${encodePath(workflow.path)}?ref=${encodeURIComponent(branch)}`,
+    );
+    if (exists) {
+      log(`Preserving ${workflow.name} (${workflow.path}): branch ${fullName}:${branch} still contains it.`);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export async function cleanupOrphanedWorkflowRuns({
+  token,
+  repository,
+  fetchImpl = fetch,
+  apiRoot = API_ROOT,
+  maxDeletions = DEFAULT_MAX_DELETIONS,
+  log = console.log,
+}) {
+  if (!token) throw new Error("GITHUB_TOKEN is required");
+  if (!Number.isInteger(maxDeletions) || maxDeletions < 1) {
+    throw new Error(`maxDeletions must be a positive integer, got ${maxDeletions}`);
+  }
+
+  const { owner, repo } = parseRepository(repository);
+  const client = createGitHubClient({ token, fetchImpl, apiRoot });
+
+  const repositoryData = await client.request(`/repos/${owner}/${repo}`);
+  const defaultBranch = repositoryData.default_branch;
+  if (!defaultBranch) throw new Error("Repository response did not include default_branch");
+
+  const defaultWorkflowEntries = await client.request(
+    `/repos/${owner}/${repo}/contents/.github/workflows?ref=${encodeURIComponent(defaultBranch)}`,
+  );
+  if (!Array.isArray(defaultWorkflowEntries)) {
+    throw new Error("Default branch .github/workflows response was not a directory listing");
+  }
+
+  const activePaths = new Set(
+    defaultWorkflowEntries
+      .filter(entry => entry?.type === "file" && typeof entry.path === "string")
+      .map(entry => entry.path),
+  );
+
+  const workflows = await client.paginate(`/repos/${owner}/${repo}/actions/workflows`, "workflows");
+  const candidates = workflows.filter(workflow =>
+    typeof workflow?.path === "string"
+    && workflow.path.startsWith(LOCAL_WORKFLOW_PREFIX)
+    && !activePaths.has(workflow.path),
+  );
+
+  log(
+    `Found ${workflows.length} workflow records, ${activePaths.size} active default-branch workflow files, `
+    + `and ${candidates.length} orphan candidates.`,
+  );
+
+  // Preflight every candidate before the first destructive call. If any read or
+  // head-branch lookup fails, the run stops without deleting anything based on an
+  // incomplete view of repository state.
+  const cleanupPlans = [];
+  for (const workflow of candidates) {
+    const runs = await client.paginate(
+      `/repos/${owner}/${repo}/actions/workflows/${workflow.id}/runs`,
+      "workflow_runs",
+    );
+
+    const inProgress = runs.filter(run => run.status !== "completed");
+    if (inProgress.length > 0) {
+      log(`Preserving ${workflow.name} (${workflow.path}): ${inProgress.length} run(s) are not completed.`);
+      continue;
+    }
+
+    if (await workflowExistsOnLiveHeadBranch({
+      client,
+      owner,
+      repo,
+      defaultBranch,
+      workflow,
+      runs,
+      log,
+    })) {
+      continue;
+    }
+
+    cleanupPlans.push({ workflow, runs });
+  }
+
+  // Prefer clearing small workflow histories first so the sidebar loses as many
+  // orphan workflow identities as possible when the per-run safety cap is hit.
+  cleanupPlans.sort((a, b) => a.runs.length - b.runs.length || a.workflow.id - b.workflow.id);
+
+  const plannedRuns = cleanupPlans.reduce((sum, plan) => sum + plan.runs.length, 0);
+  log(`Preflight approved ${cleanupPlans.length} orphan workflow(s) containing ${plannedRuns} run(s).`);
+
+  let deletedRuns = 0;
+  let capped = false;
+  const failures = [];
+
+  outer: for (const { workflow, runs } of cleanupPlans) {
+    for (const run of runs) {
+      if (deletedRuns >= maxDeletions) {
+        capped = true;
+        break outer;
+      }
+
+      try {
+        await client.request(`/repos/${owner}/${repo}/actions/runs/${run.id}`, { method: "DELETE" });
+        deletedRuns += 1;
+      } catch (error) {
+        if (error instanceof GitHubHttpError && error.status === 404) {
+          log(`Run ${run.id} for ${workflow.name} disappeared before deletion; continuing.`);
+          continue;
+        }
+        failures.push(`${workflow.name} run ${run.id}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  }
+
+  if (capped) {
+    log(`Stopped after ${maxDeletions} deletions; remaining approved runs will be handled by the next daily run.`);
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`Failed to delete ${failures.length} workflow run(s):\n${failures.join("\n")}`);
+  }
+
+  const summary = {
+    totalWorkflowRecords: workflows.length,
+    activeWorkflowFiles: activePaths.size,
+    orphanCandidates: candidates.length,
+    approvedWorkflows: cleanupPlans.length,
+    plannedRuns,
+    deletedRuns,
+    capped,
+  };
+  log(`Cleanup complete: ${JSON.stringify(summary)}`);
+  return summary;
+}
+
+if (import.meta.main) {
+  await cleanupOrphanedWorkflowRuns({
+    token: process.env.GITHUB_TOKEN,
+    repository: process.env.GITHUB_REPOSITORY,
+  });
+}

--- a/tests/cleanup-orphaned-workflows.test.ts
+++ b/tests/cleanup-orphaned-workflows.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, test } from "bun:test";
+import { cleanupOrphanedWorkflowRuns } from "../scripts/ci/cleanup-orphaned-workflows.mjs";
+
+interface MockRoute {
+  method?: string;
+  path: string;
+  status?: number;
+  body?: unknown;
+}
+
+function mockFetch(routes: MockRoute[], calls: string[]) {
+  return async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = new URL(typeof input === "string" ? input : input instanceof URL ? input : input.url);
+    const method = init?.method ?? "GET";
+    const key = `${method} ${url.pathname}${url.search}`;
+    calls.push(key);
+
+    const index = routes.findIndex(route =>
+      (route.method ?? "GET") === method
+      && route.path === `${url.pathname}${url.search}`,
+    );
+    if (index < 0) return new Response(`Unexpected request: ${key}`, { status: 500 });
+
+    const [route] = routes.splice(index, 1);
+    const status = route!.status ?? 200;
+    if (status === 204) return new Response(null, { status });
+    return Response.json(route!.body ?? {}, { status });
+  };
+}
+
+function baseRoutes(extra: MockRoute[]): MockRoute[] {
+  return [
+    { path: "/repos/lidge-jun/opencodex", body: { default_branch: "main" } },
+    {
+      path: "/repos/lidge-jun/opencodex/contents/.github/workflows?ref=main",
+      body: [
+        { type: "file", path: ".github/workflows/ci.yml" },
+        { type: "file", path: ".github/workflows/cleanup-orphaned-workflows.yml" },
+      ],
+    },
+    ...extra,
+  ];
+}
+
+describe("orphaned GitHub Actions cleanup", () => {
+  test("workflow is default-branch-only, least-privilege, bounded, and pinned", async () => {
+    const text = await Bun.file(
+      new URL("../.github/workflows/cleanup-orphaned-workflows.yml", import.meta.url),
+    ).text();
+    const workflow = Bun.YAML.parse(text) as {
+      on?: Record<string, unknown>;
+      permissions?: Record<string, string>;
+      jobs?: Record<string, {
+        "timeout-minutes"?: number;
+        steps?: Array<{ uses?: string; run?: string }>;
+      }>;
+    };
+
+    expect(Object.keys(workflow.on ?? {}).sort()).toEqual(["push", "schedule"]);
+    expect(workflow.permissions).toEqual({
+      actions: "write",
+      contents: "read",
+    });
+    expect(workflow.jobs?.cleanup?.["timeout-minutes"]).toBe(10);
+
+    const steps = workflow.jobs?.cleanup?.steps ?? [];
+    expect(steps.some(step =>
+      step.uses === "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+    )).toBe(true);
+    expect(steps.some(step =>
+      step.uses === "oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6"
+    )).toBe(true);
+    expect(steps.some(step =>
+      step.run === "bun scripts/ci/cleanup-orphaned-workflows.mjs"
+    )).toBe(true);
+    expect(text).not.toContain("workflow_dispatch");
+    expect(text).not.toMatch(/uses:\s+\S+@(?:v\d+|main|master)\b/);
+  });
+
+  test("deletes runs only for local workflows absent from the default branch", async () => {
+    const calls: string[] = [];
+    const routes = baseRoutes([
+      {
+        path: "/repos/lidge-jun/opencodex/actions/workflows?per_page=100&page=1",
+        body: {
+          workflows: [
+            { id: 1, name: "CI", path: ".github/workflows/ci.yml" },
+            { id: 2, name: "Temporary rebase", path: ".github/workflows/tmp-rebase.yml" },
+            { id: 3, name: "Dependabot", path: "dynamic/dependabot/dependabot-updates" },
+          ],
+        },
+      },
+      {
+        path: "/repos/lidge-jun/opencodex/actions/workflows/2/runs?per_page=100&page=1",
+        body: { workflow_runs: [{ id: 201, status: "completed", pull_requests: [] }] },
+      },
+      { method: "DELETE", path: "/repos/lidge-jun/opencodex/actions/runs/201", status: 204 },
+    ]);
+
+    const result = await cleanupOrphanedWorkflowRuns({
+      token: "test-token",
+      repository: "lidge-jun/opencodex",
+      fetchImpl: mockFetch(routes, calls) as typeof fetch,
+      log: () => {},
+    });
+
+    expect(result.orphanCandidates).toBe(1);
+    expect(result.deletedRuns).toBe(1);
+    expect(calls.some(call => call.includes("dynamic/dependabot"))).toBe(false);
+    expect(routes).toHaveLength(0);
+  });
+
+  test("preserves an orphan while a live run head branch still contains its workflow file", async () => {
+    const calls: string[] = [];
+    const routes = baseRoutes([
+      {
+        path: "/repos/lidge-jun/opencodex/actions/workflows?per_page=100&page=1",
+        body: {
+          workflows: [{ id: 2, name: "Temporary PR check", path: ".github/workflows/tmp-pr.yml" }],
+        },
+      },
+      {
+        path: "/repos/lidge-jun/opencodex/actions/workflows/2/runs?per_page=100&page=1",
+        body: {
+          workflow_runs: [{
+            id: 202,
+            status: "completed",
+            pull_requests: [],
+            head_branch: "agent/pr-77",
+            head_repository: { full_name: "lidge-jun/opencodex" },
+          }],
+        },
+      },
+      {
+        path: "/repos/lidge-jun/opencodex/contents/.github/workflows/tmp-pr.yml?ref=agent%2Fpr-77",
+        body: { type: "file", path: ".github/workflows/tmp-pr.yml" },
+      },
+    ]);
+
+    const result = await cleanupOrphanedWorkflowRuns({
+      token: "test-token",
+      repository: "lidge-jun/opencodex",
+      fetchImpl: mockFetch(routes, calls) as typeof fetch,
+      log: () => {},
+    });
+
+    expect(result.approvedWorkflows).toBe(0);
+    expect(result.deletedRuns).toBe(0);
+    expect(calls.some(call => call.startsWith("DELETE "))).toBe(false);
+    expect(routes).toHaveLength(0);
+  });
+
+  test("cleans an orphan after its run head branch no longer contains the workflow file", async () => {
+    const calls: string[] = [];
+    const routes = baseRoutes([
+      {
+        path: "/repos/lidge-jun/opencodex/actions/workflows?per_page=100&page=1",
+        body: {
+          workflows: [{ id: 2, name: "Temporary PR check", path: ".github/workflows/tmp-pr.yml" }],
+        },
+      },
+      {
+        path: "/repos/lidge-jun/opencodex/actions/workflows/2/runs?per_page=100&page=1",
+        body: {
+          workflow_runs: [{
+            id: 202,
+            status: "completed",
+            pull_requests: [],
+            head_branch: "agent/pr-77",
+            head_repository: { full_name: "lidge-jun/opencodex" },
+          }],
+        },
+      },
+      {
+        path: "/repos/lidge-jun/opencodex/contents/.github/workflows/tmp-pr.yml?ref=agent%2Fpr-77",
+        status: 404,
+        body: { message: "Not Found" },
+      },
+      { method: "DELETE", path: "/repos/lidge-jun/opencodex/actions/runs/202", status: 204 },
+    ]);
+
+    const result = await cleanupOrphanedWorkflowRuns({
+      token: "test-token",
+      repository: "lidge-jun/opencodex",
+      fetchImpl: mockFetch(routes, calls) as typeof fetch,
+      log: () => {},
+    });
+
+    expect(result.approvedWorkflows).toBe(1);
+    expect(result.deletedRuns).toBe(1);
+    expect(routes).toHaveLength(0);
+  });
+
+  test("does not delete anything when an orphan still has a non-completed run", async () => {
+    const calls: string[] = [];
+    const routes = baseRoutes([
+      {
+        path: "/repos/lidge-jun/opencodex/actions/workflows?per_page=100&page=1",
+        body: {
+          workflows: [{ id: 2, name: "Temporary PR check", path: ".github/workflows/tmp-pr.yml" }],
+        },
+      },
+      {
+        path: "/repos/lidge-jun/opencodex/actions/workflows/2/runs?per_page=100&page=1",
+        body: { workflow_runs: [{ id: 203, status: "in_progress", pull_requests: [] }] },
+      },
+    ]);
+
+    const result = await cleanupOrphanedWorkflowRuns({
+      token: "test-token",
+      repository: "lidge-jun/opencodex",
+      fetchImpl: mockFetch(routes, calls) as typeof fetch,
+      log: () => {},
+    });
+
+    expect(result.approvedWorkflows).toBe(0);
+    expect(result.deletedRuns).toBe(0);
+    expect(calls.some(call => call.startsWith("DELETE "))).toBe(false);
+    expect(routes).toHaveLength(0);
+  });
+
+  test("preflights every candidate before issuing the first delete", async () => {
+    const calls: string[] = [];
+    const routes = baseRoutes([
+      {
+        path: "/repos/lidge-jun/opencodex/actions/workflows?per_page=100&page=1",
+        body: {
+          workflows: [
+            { id: 2, name: "Old temp A", path: ".github/workflows/tmp-a.yml" },
+            { id: 3, name: "Old temp B", path: ".github/workflows/tmp-b.yml" },
+          ],
+        },
+      },
+      {
+        path: "/repos/lidge-jun/opencodex/actions/workflows/2/runs?per_page=100&page=1",
+        body: { workflow_runs: [{ id: 204, status: "completed", pull_requests: [] }] },
+      },
+      {
+        path: "/repos/lidge-jun/opencodex/actions/workflows/3/runs?per_page=100&page=1",
+        status: 503,
+        body: { message: "Service Unavailable" },
+      },
+    ]);
+
+    await expect(cleanupOrphanedWorkflowRuns({
+      token: "test-token",
+      repository: "lidge-jun/opencodex",
+      fetchImpl: mockFetch(routes, calls) as typeof fetch,
+      log: () => {},
+    })).rejects.toThrow("HTTP 503");
+
+    expect(calls.some(call => call.startsWith("DELETE "))).toBe(false);
+  });
+
+  test("caps deletion volume and prefers clearing smaller histories first", async () => {
+    const calls: string[] = [];
+    const routes = baseRoutes([
+      {
+        path: "/repos/lidge-jun/opencodex/actions/workflows?per_page=100&page=1",
+        body: {
+          workflows: [
+            { id: 2, name: "Large temp", path: ".github/workflows/tmp-large.yml" },
+            { id: 3, name: "Small temp", path: ".github/workflows/tmp-small.yml" },
+          ],
+        },
+      },
+      {
+        path: "/repos/lidge-jun/opencodex/actions/workflows/2/runs?per_page=100&page=1",
+        body: {
+          workflow_runs: [
+            { id: 205, status: "completed", pull_requests: [] },
+            { id: 206, status: "completed", pull_requests: [] },
+          ],
+        },
+      },
+      {
+        path: "/repos/lidge-jun/opencodex/actions/workflows/3/runs?per_page=100&page=1",
+        body: { workflow_runs: [{ id: 207, status: "completed", pull_requests: [] }] },
+      },
+      { method: "DELETE", path: "/repos/lidge-jun/opencodex/actions/runs/207", status: 204 },
+    ]);
+
+    const result = await cleanupOrphanedWorkflowRuns({
+      token: "test-token",
+      repository: "lidge-jun/opencodex",
+      fetchImpl: mockFetch(routes, calls) as typeof fetch,
+      maxDeletions: 1,
+      log: () => {},
+    });
+
+    expect(result.deletedRuns).toBe(1);
+    expect(result.capped).toBe(true);
+    expect(calls.at(-1)).toBe("DELETE /repos/lidge-jun/opencodex/actions/runs/207");
+    expect(routes).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What changed

- add a permanent `Clean orphaned workflow runs` maintenance workflow
- run it daily at 06:00 UTC from the default branch
- also run it when the cleanup workflow/script first lands on `main`, so the existing backlog is cleaned without a branch-selectable manual trigger
- detect repository workflow records whose `.github/workflows/*` file no longer exists on the default branch
- ignore GitHub-managed `dynamic/*` workflows such as Dependabot and Copilot
- preserve any orphan whose run is still in progress
- preserve any orphan whose workflow file still exists on a current head branch that produced one of its runs
- preflight every candidate before issuing the first delete
- cap deletions at 500 runs per execution and prefer clearing smaller histories first
- add focused tests for active workflows, GitHub-managed workflows, live temporary branches, dead temporary branches, non-completed runs, fail-closed preflight, immutable action pins, least privilege, and the deletion cap

## Why

GitHub Actions currently retains many workflow identities from temporary PR/maintenance workflows after their YAML files are removed. The Actions sidebar therefore keeps accumulating one-off entries such as temporary rebases and maintainer transplant workflows.

Deleting the orphaned workflow runs lets GitHub drop those stale workflow identities while keeping real repository automation intact.

## Safety

The cleanup is deliberately conservative:

1. only paths under `.github/workflows/` are candidates
2. the path must be absent from the repository default branch
3. every run must already be completed
4. if a current run head branch still contains that workflow file, the workflow is preserved
5. all candidate state is read before any destructive API call
6. unexpected API/read failures abort instead of guessing
7. the token only gets `actions: write` and `contents: read`

This branch-presence check matters because existing temporary PR workflows were sometimes triggered by `push` and therefore have an empty `pull_requests` array.

## Validation

- `node --check scripts/ci/cleanup-orphaned-workflows.mjs`
- workflow YAML parsed successfully
- mocked live-head scenario preserves the workflow and performs no delete
- mocked dead-head scenario deletes the orphaned run
- repository CI is running on the latest head

The workflow becomes active only when this change is promoted to the repository default branch (`main`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated daily cleanup of orphaned GitHub Actions workflow runs.
  * Runs automatically when the cleanup configuration or script changes.
  * Preserves active runs and workflows still present on branches.
  * Supports configurable deletion limits, prioritizes smaller histories, and reports cleanup results.
* **Tests**
  * Added comprehensive coverage for workflow detection, safety checks, deletion limits, error handling, and prioritization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->