### PR TITLE
fix(google): allow AI Studio bare Gemini Flash IDs

### DIFF
--- a/docs-site/src/content/docs/reference/configuration/providers.md
+++ b/docs-site/src/content/docs/reference/configuration/providers.md
@@ -122,7 +122,7 @@ differing backup and rewrites known legacy namespaced selected ids to bare ids.
 | `escapeBuiltinToolNames?` | `boolean` | Escape built-in tool names for Anthropic-compatible gateways and restore them in returned calls. |
 | `anthropicEofTolerance?` | `boolean` | Let an Anthropic-compatible gateway complete a stream that ends before `message_stop`, only when visible text or a complete JSON-object tool input was received. Off by default. |
 | `googleMode?` | `"ai-studio" \| "vertex" \| "cloud-code-assist"` | Google transport/auth mode. Default `ai-studio`. |
-| `directGeminiWireRenames?` | `boolean` | Google only. When `false`, the AI Studio (direct) path sends Gemini Flash ids to the wire unchanged instead of applying the `-tiered` suffix (`gemini-3.7-flash` -> `gemini-3.7-flash-tiered`). Defaults to the rename; set `false` when the configured upstream still serves the bare ids. |
+| `directGeminiWireRenames?` | `boolean` | Google only. This affects only direct AI Studio requests. When `false`, the AI Studio path sends Gemini Flash ids to the wire unchanged instead of applying the `-tiered` suffix (`gemini-3.7-flash` -> `gemini-3.7-flash-tiered`). Vertex preserves the requested model ID, and Cloud Code Assist routing is unchanged. Defaults to the rename; set `false` when the configured upstream still serves the bare ids. |
 | `project?` | `string` | Vertex or Antigravity Cloud Code Assist project id. |
 | `location?` | `string` | Vertex location; environment fallback is `GOOGLE_CLOUD_LOCATION`. |
 | `mcpServers?` | `Record<string, CursorMcpServerConfig>` | Cursor only: stdio or Streamable HTTP MCP servers. |

--- a/docs-site/src/content/docs/reference/configuration/providers.md
+++ b/docs-site/src/content/docs/reference/configuration/providers.md
@@ -122,7 +122,7 @@ differing backup and rewrites known legacy namespaced selected ids to bare ids.
 | `escapeBuiltinToolNames?` | `boolean` | Escape built-in tool names for Anthropic-compatible gateways and restore them in returned calls. |
 | `anthropicEofTolerance?` | `boolean` | Let an Anthropic-compatible gateway complete a stream that ends before `message_stop`, only when visible text or a complete JSON-object tool input was received. Off by default. |
 | `googleMode?` | `"ai-studio" \| "vertex" \| "cloud-code-assist"` | Google transport/auth mode. Default `ai-studio`. |
-| `directGeminiWireRenames?` | `boolean` | Google only. This affects only direct AI Studio requests. When `false`, the AI Studio path sends Gemini Flash ids to the wire unchanged instead of applying the `-tiered` suffix (`gemini-3.7-flash` -> `gemini-3.7-flash-tiered`). Vertex preserves the requested model ID, and Cloud Code Assist routing is unchanged. Defaults to the rename; set `false` when the configured upstream still serves the bare ids. |
+| `directGeminiWireRenames?` | `boolean` | Google only. Applies only to direct AI Studio requests. Omitted or `true` keeps the `-tiered` wire rename for Gemini Flash ids (`gemini-3.7-flash` -> `gemini-3.7-flash-tiered`); `false` sends the requested bare ids to the wire unchanged. Vertex preserves the requested model ID, and Cloud Code Assist routing is unchanged. Set `false` when the configured upstream still serves the bare ids. |
 | `project?` | `string` | Vertex or Antigravity Cloud Code Assist project id. |
 | `location?` | `string` | Vertex location; environment fallback is `GOOGLE_CLOUD_LOCATION`. |
 | `mcpServers?` | `Record<string, CursorMcpServerConfig>` | Cursor only: stdio or Streamable HTTP MCP servers. |

--- a/docs-site/src/content/docs/reference/configuration/providers.md
+++ b/docs-site/src/content/docs/reference/configuration/providers.md
@@ -122,6 +122,7 @@ differing backup and rewrites known legacy namespaced selected ids to bare ids.
 | `escapeBuiltinToolNames?` | `boolean` | Escape built-in tool names for Anthropic-compatible gateways and restore them in returned calls. |
 | `anthropicEofTolerance?` | `boolean` | Let an Anthropic-compatible gateway complete a stream that ends before `message_stop`, only when visible text or a complete JSON-object tool input was received. Off by default. |
 | `googleMode?` | `"ai-studio" \| "vertex" \| "cloud-code-assist"` | Google transport/auth mode. Default `ai-studio`. |
+| `directGeminiWireRenames?` | `boolean` | Google only. When `false`, the AI Studio (direct) path sends Gemini Flash ids to the wire unchanged instead of applying the `-tiered` suffix (`gemini-3.7-flash` -> `gemini-3.7-flash-tiered`). Defaults to the rename; set `false` when the configured upstream still serves the bare ids. |
 | `project?` | `string` | Vertex or Antigravity Cloud Code Assist project id. |
 | `location?` | `string` | Vertex location; environment fallback is `GOOGLE_CLOUD_LOCATION`. |
 | `mcpServers?` | `Record<string, CursorMcpServerConfig>` | Cursor only: stdio or Streamable HTTP MCP servers. |

--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -394,7 +394,9 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
             parsed.modelId,
             mapReasoningEffort(provider, parsed.modelId, parsed.options.reasoning),
           ).wireModelId
-        : resolveDirectGeminiWireModelId(parsed.modelId, provider.directGeminiWireRenames !== false);
+        : provider.googleMode === "vertex"
+          ? parsed.modelId
+          : resolveDirectGeminiWireModelId(parsed.modelId, provider.directGeminiWireRenames !== false);
       const { systemInstruction, contents } = messagesToGeminiFormat(parsed, routedModelId);
       const tools = toolsToGeminiFormat(parsed);
 

--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -143,10 +143,7 @@ function geminiToolResultText(content: string | OcxContentPart[]): string {
   return hasContent ? contentPartsToText(content) : GEMINI_EMPTY_TOOL_OUTPUT_PLACEHOLDER;
 }
 
-function messagesToGeminiFormat(
-  parsed: OcxParsedRequest,
-  routedModelId = parsed.modelId,
-): { systemInstruction?: unknown; contents: unknown[] } {
+function messagesToGeminiFormat(parsed: OcxParsedRequest): { systemInstruction?: unknown; contents: unknown[] } {
   // Neutralize Codex's GPT-5 identity line (Gemini/Antigravity share this path) so a routed model
   // never misreports as GPT-5/OpenAI, and never leaks the proxy identity upstream.
   const toolCatalogNudge = buildNonOpenAIToolCatalogNudgeForTools(parsed.context.tools, parsed.options.toolChoice);
@@ -154,7 +151,7 @@ function messagesToGeminiFormat(
     ...(parsed.context.systemPrompt ?? []),
     ...(toolCatalogNudge ? [toolCatalogNudge] : []),
     GOOGLE_BREVITY_INSTRUCTION,
-  ].join("\n\n"), routedModelId);
+  ].join("\n\n"), parsed.modelId);
   const systemInstruction = { parts: [{ text: systemText }] };
 
   const contents: unknown[] = [];
@@ -397,7 +394,9 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
         : provider.googleMode === "vertex"
           ? parsed.modelId
           : resolveDirectGeminiWireModelId(parsed.modelId, provider.directGeminiWireRenames !== false);
-      const { systemInstruction, contents } = messagesToGeminiFormat(parsed, routedModelId);
+      // System identity names the public model id (parsed.modelId) so the model never
+      // self-reports as its -tiered wire spelling; routedModelId is only the wire id in the URL.
+      const { systemInstruction, contents } = messagesToGeminiFormat(parsed);
       const tools = toolsToGeminiFormat(parsed);
 
       const body: Record<string, unknown> = { contents };

--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -48,19 +48,17 @@ const GOOGLE_BREVITY_INSTRUCTION = [
 ].join("\n");
 
 /**
- * Google renamed the current Gemini Flash generations on the Generative Language API,
- * appending a `-tiered` suffix (`gemini-3.7-flash` -> `gemini-3.7-flash-tiered`). The
- * old `gemini-3.7-flash` path 404s, so a saved config or registry entry naming the base
- * id must be resolved here before it reaches the URL. The user-facing id is deliberately
- * left alone: the picker, the catalog, the usage log and the price overlays all stay
- * keyed on the base id, and only the wire path learns the new spelling.
+ * Some Google direct deployments expose current Gemini Flash generations with a `-tiered`
+ * wire suffix (`gemini-3.7-flash` -> `gemini-3.7-flash-tiered`). Keep the picker-visible id
+ * stable and make the mapping configurable for deployments that still serve the bare id.
  */
 const GEMINI_DIRECT_WIRE_RENAMES: Record<string, string> = {
   "gemini-3.7-flash": "gemini-3.7-flash-tiered",
   "gemini-3.6-flash": "gemini-3.6-flash-tiered",
 };
 
-function resolveDirectGeminiWireModelId(modelId: string): string {
+function resolveDirectGeminiWireModelId(modelId: string, applyRenames: boolean): string {
+  if (!applyRenames) return modelId;
   return Object.hasOwn(GEMINI_DIRECT_WIRE_RENAMES, modelId)
     ? GEMINI_DIRECT_WIRE_RENAMES[modelId]!
     : modelId;
@@ -396,7 +394,7 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
             parsed.modelId,
             mapReasoningEffort(provider, parsed.modelId, parsed.options.reasoning),
           ).wireModelId
-        : resolveDirectGeminiWireModelId(parsed.modelId);
+        : resolveDirectGeminiWireModelId(parsed.modelId, provider.directGeminiWireRenames !== false);
       const { systemInstruction, contents } = messagesToGeminiFormat(parsed, routedModelId);
       const tools = toolsToGeminiFormat(parsed);
 

--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -143,7 +143,10 @@ function geminiToolResultText(content: string | OcxContentPart[]): string {
   return hasContent ? contentPartsToText(content) : GEMINI_EMPTY_TOOL_OUTPUT_PLACEHOLDER;
 }
 
-function messagesToGeminiFormat(parsed: OcxParsedRequest): { systemInstruction?: unknown; contents: unknown[] } {
+function messagesToGeminiFormat(
+  parsed: OcxParsedRequest,
+  identityModelId: string,
+): { systemInstruction?: unknown; contents: unknown[] } {
   // Neutralize Codex's GPT-5 identity line (Gemini/Antigravity share this path) so a routed model
   // never misreports as GPT-5/OpenAI, and never leaks the proxy identity upstream.
   const toolCatalogNudge = buildNonOpenAIToolCatalogNudgeForTools(parsed.context.tools, parsed.options.toolChoice);
@@ -151,7 +154,7 @@ function messagesToGeminiFormat(parsed: OcxParsedRequest): { systemInstruction?:
     ...(parsed.context.systemPrompt ?? []),
     ...(toolCatalogNudge ? [toolCatalogNudge] : []),
     GOOGLE_BREVITY_INSTRUCTION,
-  ].join("\n\n"), parsed.modelId);
+  ].join("\n\n"), identityModelId);
   const systemInstruction = { parts: [{ text: systemText }] };
 
   const contents: unknown[] = [];
@@ -394,9 +397,9 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
         : provider.googleMode === "vertex"
           ? parsed.modelId
           : resolveDirectGeminiWireModelId(parsed.modelId, provider.directGeminiWireRenames !== false);
-      // System identity names the public model id (parsed.modelId) so the model never
-      // self-reports as its -tiered wire spelling; routedModelId is only the wire id in the URL.
-      const { systemInstruction, contents } = messagesToGeminiFormat(parsed);
+      // AI Studio's `-tiered` spelling is wire-only; CCA aliases may migrate to another generation.
+      const identityModelId = provider.googleMode === "cloud-code-assist" ? routedModelId : parsed.modelId;
+      const { systemInstruction, contents } = messagesToGeminiFormat(parsed, identityModelId);
       const tools = toolsToGeminiFormat(parsed);
 
       const body: Record<string, unknown> = { contents };

--- a/src/config.ts
+++ b/src/config.ts
@@ -741,6 +741,7 @@ const providerConfigSchema = z.object({
   upstreamHttpVersion: z.enum(UPSTREAM_HTTP_VERSION_VALUES)
     .nullish()
     .transform(value => value ?? undefined),
+  directGeminiWireRenames: z.boolean().optional(),
   noStructuredOutputModels: z.array(z.string().min(1))
     .transform(normalizeNonBlankStringArray)
     .optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1392,8 +1392,9 @@ export interface OcxProviderConfig {
    * HTTP/2 streaming responses (issue #1668). "http1.1" / "h1" forces HTTP/1.1,
    * "http2" / "h2" forces HTTP/2. Absent or "auto" keeps Bun's default negotiation
    * (current behavior unchanged). Only meaningful for https: base URLs.
-   */
+  */
   upstreamHttpVersion?: UpstreamHttpVersion;
+  /**
    * Google only. When `false`, the AI Studio (direct) path sends Gemini Flash ids
    * unchanged to the wire instead of applying the `-tiered` suffix (`gemini-3.7-flash`
    * -> `gemini-3.7-flash-tiered`). Set this to `false` when the configured upstream still

--- a/src/types.ts
+++ b/src/types.ts
@@ -1394,6 +1394,12 @@ export interface OcxProviderConfig {
    * (current behavior unchanged). Only meaningful for https: base URLs.
    */
   upstreamHttpVersion?: UpstreamHttpVersion;
+   * Google only. When `false`, the AI Studio (direct) path sends Gemini Flash ids
+   * unchanged to the wire instead of applying the `-tiered` suffix (`gemini-3.7-flash`
+   * -> `gemini-3.7-flash-tiered`). Set this to `false` when the configured upstream still
+   * serves the bare ids. Absent (default) keeps the rename.
+   */
+  directGeminiWireRenames?: boolean;
   /** Keep provider settings on disk but exclude it from routing and model/catalog listings. */
   disabled?: boolean;
   /**

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -814,6 +814,38 @@ describe("opencodex config defaults", () => {
     expect(readConfigDiagnostics().error).toContain("responsesSnapshotRepair");
   });
 
+  test("direct Gemini wire rename opt-out is a boolean and round-trips", () => {
+    const base = {
+      port: 12345,
+      providers: {
+        google: {
+          adapter: "google",
+          baseUrl: "https://generativelanguage.googleapis.com",
+        },
+      },
+      defaultProvider: "google",
+    };
+    writeConfig({
+      ...base,
+      providers: {
+        google: { ...base.providers.google, directGeminiWireRenames: false },
+      },
+    });
+    const config = loadConfig();
+    expect(config.providers.google.directGeminiWireRenames).toBe(false);
+    saveConfig(config);
+    expect(loadConfig().providers.google.directGeminiWireRenames).toBe(false);
+
+    writeConfig({
+      ...base,
+      providers: {
+        google: { ...base.providers.google, directGeminiWireRenames: "false" },
+      },
+    });
+    expect(readConfigDiagnostics().source).toBe("fallback");
+    expect(readConfigDiagnostics().error).toContain("directGeminiWireRenames");
+  });
+
   test("accepts a relative responsesPath", () => {
     writeResponsesPathConfig("/responses");
 

--- a/tests/google-adapter.test.ts
+++ b/tests/google-adapter.test.ts
@@ -278,3 +278,29 @@ describe("google adapter — tool_choice on the wire", () => {
     });
   });
 });
+
+describe("google adapter — direct -tiered wire renames", () => {
+  function renamedParsed(modelId: string): OcxParsedRequest {
+    return {
+      modelId,
+      stream: false,
+      options: {},
+      context: { messages: [{ role: "user", content: "hi" }], tools: [] },
+    } as unknown as OcxParsedRequest;
+  }
+
+  test("default maps the picker id to the -tiered wire id", async () => {
+    for (const modelId of ["gemini-3.7-flash", "gemini-3.6-flash"]) {
+      const { url } = await createGoogleAdapter(provider).buildRequest(renamedParsed(modelId));
+      expect(url).toContain(`/v1beta/models/${modelId}-tiered:generateContent`);
+    }
+  });
+
+  test("directGeminiWireRenames: false keeps the bare wire id", async () => {
+    const adapter = createGoogleAdapter({ ...provider, directGeminiWireRenames: false });
+    for (const modelId of ["gemini-3.7-flash", "gemini-3.6-flash"]) {
+      const { url } = await adapter.buildRequest(renamedParsed(modelId));
+      expect(url).toContain(`/v1beta/models/${modelId}:generateContent`);
+    }
+  });
+});

--- a/tests/google-adapter.test.ts
+++ b/tests/google-adapter.test.ts
@@ -304,6 +304,34 @@ describe("google adapter — direct -tiered wire renames", () => {
     }
   });
 
+  test("directGeminiWireRenames: true still maps to the -tiered wire id", async () => {
+    const adapter = createGoogleAdapter({ ...provider, directGeminiWireRenames: true });
+    for (const modelId of ["gemini-3.7-flash", "gemini-3.6-flash"]) {
+      const { url } = await adapter.buildRequest(renamedParsed(modelId));
+      expect(url).toContain(`/v1beta/models/${modelId}-tiered:generateContent`);
+    }
+  });
+
+  test("directGeminiWireRenames does not affect Cloud Code Assist requests", async () => {
+    const ccaProvider = {
+      ...provider,
+      googleMode: "cloud-code-assist",
+      baseUrl: "https://daily-cloudcode-pa.googleapis.com",
+      project: "proj-123",
+    } as const;
+    for (const modelId of ["gemini-3.7-flash", "gemini-3.6-flash"]) {
+      const parsed = renamedParsed(modelId);
+      const defaultRequest = await createGoogleAdapter(ccaProvider).buildRequest(parsed);
+      const optOutRequest = await createGoogleAdapter({ ...ccaProvider, directGeminiWireRenames: false })
+        .buildRequest(parsed);
+      expect(optOutRequest.url).toBe(defaultRequest.url);
+      // The envelope's requestId/sessionId are minted per request; compare the wire model only.
+      const defaultModel = JSON.parse(defaultRequest.body).model as string;
+      const optOutModel = JSON.parse(optOutRequest.body).model as string;
+      expect(optOutModel).toBe(defaultModel);
+    }
+  });
+
   test("directGeminiWireRenames does not affect Vertex requests", async () => {
     const vertexProvider = { ...provider, googleMode: "vertex" as const };
     for (const modelId of ["gemini-3.7-flash", "gemini-3.6-flash"]) {

--- a/tests/google-adapter.test.ts
+++ b/tests/google-adapter.test.ts
@@ -303,4 +303,16 @@ describe("google adapter — direct -tiered wire renames", () => {
       expect(url).toContain(`/v1beta/models/${modelId}:generateContent`);
     }
   });
+
+  test("directGeminiWireRenames does not affect Vertex requests", async () => {
+    const vertexProvider = { ...provider, googleMode: "vertex" as const };
+    for (const modelId of ["gemini-3.7-flash", "gemini-3.6-flash"]) {
+      const parsed = renamedParsed(modelId);
+      const defaultRequest = await createGoogleAdapter(vertexProvider).buildRequest(parsed);
+      const optOutRequest = await createGoogleAdapter({ ...vertexProvider, directGeminiWireRenames: false })
+        .buildRequest(parsed);
+      expect(optOutRequest.url).toBe(defaultRequest.url);
+      expect(optOutRequest.body).toBe(defaultRequest.body);
+    }
+  });
 });

--- a/tests/google-adapter.test.ts
+++ b/tests/google-adapter.test.ts
@@ -352,6 +352,25 @@ describe("google adapter — direct -tiered wire renames", () => {
     }
   });
 
+  test("Cloud Code Assist identity follows a migrated wire model", async () => {
+    const ccaProvider = {
+      ...provider,
+      googleMode: "cloud-code-assist",
+      baseUrl: "https://daily-cloudcode-pa.googleapis.com",
+      project: "proj-123",
+    } as const;
+    const request = await createGoogleAdapter(ccaProvider).buildRequest(identityParsed("gemini-3.6-flash"));
+    const envelope = JSON.parse(request.body) as {
+      model: string;
+      request: { systemInstruction?: { parts?: Array<{ text?: string }> } };
+    };
+    const systemText = envelope.request.systemInstruction?.parts?.[0]?.text ?? "";
+
+    expect(envelope.model).toBe("gemini-3.7-flash-tiered");
+    expect(systemText).toContain("powered by the gemini-3.7-flash-tiered");
+    expect(systemText).not.toContain("powered by the gemini-3.6-flash.");
+  });
+
   test("directGeminiWireRenames does not affect Vertex requests", async () => {
     const vertexProvider = { ...provider, googleMode: "vertex" as const };
     for (const modelId of ["gemini-3.7-flash", "gemini-3.6-flash"]) {

--- a/tests/google-adapter.test.ts
+++ b/tests/google-adapter.test.ts
@@ -289,6 +289,19 @@ describe("google adapter — direct -tiered wire renames", () => {
     } as unknown as OcxParsedRequest;
   }
 
+  function identityParsed(modelId: string): OcxParsedRequest {
+    return {
+      modelId,
+      stream: false,
+      options: {},
+      context: {
+        systemPrompt: ["You are Codex, a coding agent based on GPT-5."],
+        messages: [{ role: "user", content: "hi" }],
+        tools: [],
+      },
+    } as unknown as OcxParsedRequest;
+  }
+
   test("default maps the picker id to the -tiered wire id", async () => {
     for (const modelId of ["gemini-3.7-flash", "gemini-3.6-flash"]) {
       const { url } = await createGoogleAdapter(provider).buildRequest(renamedParsed(modelId));
@@ -307,8 +320,15 @@ describe("google adapter — direct -tiered wire renames", () => {
   test("directGeminiWireRenames: true still maps to the -tiered wire id", async () => {
     const adapter = createGoogleAdapter({ ...provider, directGeminiWireRenames: true });
     for (const modelId of ["gemini-3.7-flash", "gemini-3.6-flash"]) {
-      const { url } = await adapter.buildRequest(renamedParsed(modelId));
+      const request = await adapter.buildRequest(identityParsed(modelId));
+      const { url } = request;
       expect(url).toContain(`/v1beta/models/${modelId}-tiered:generateContent`);
+      const body = JSON.parse(request.body) as {
+        systemInstruction?: { parts?: Array<{ text?: string }> };
+      };
+      const systemText = body.systemInstruction?.parts?.[0]?.text ?? "";
+      expect(systemText).toContain(`powered by the ${modelId}`);
+      expect(systemText).not.toContain(`${modelId}-tiered`);
     }
   });
 


### PR DESCRIPTION
## Summary

- **Observed problem:** With an affected Google AI Studio configuration, selecting `gemini-3.7-flash` made opencodex send `gemini-3.7-flash-tiered` on the wire. The upstream returned HTTP 404 before generation, so Codex Desktop appeared to receive no model response.
- **Observed evidence:** On 2026-08-15, the configured AI Studio key returned HTTP 200 for bare `gemini-3.7-flash` and `gemini-3.6-flash`, HTTP 404 for both `-tiered` ids, and `ListModels` contained no `-tiered` model. This is an observed deployment compatibility difference, not a claim that every Google account behaves the same way.
- Add provider-level `directGeminiWireRenames: false` for affected AI Studio providers. The default remains the existing `-tiered` mapping, so installations where `-tiered` works retain their behavior.
- Scope the setting to AI Studio direct requests: Vertex retains its requested model identity and Cloud Code Assist routing remains unchanged.
- This is an explicit operator setting, not automatic 404 fallback or model discovery. After a release containing this PR, add it to the affected Google provider entry in `config.json` and restart the proxy.
- Add focused adapter and config regression coverage for Gemini 3.6/3.7, including a persisted `false` round-trip, and document the setting.
- Rebased onto the current `dev` head (2026-08-17, `8f7a22ff7`) and resolved the `src/config.ts` / `src/types.ts` conflict without dropping either `upstreamHttpVersion` or `directGeminiWireRenames`; branch is 0 commits behind.
- Review feedback is addressed on the rebased head: the complete boolean contract is documented; direct AI Studio identity uses the public model id; and the rebased equivalent of `e4d83f6e6` preserves the resolved routed identity for Cloud Code Assist aliases, including the retired `gemini-3.6-flash` → `gemini-3.7-flash-tiered` migration regression.

## Verification

- `bun run typecheck` — passed on current head.
- `bun run privacy:scan` — passed on current head.
- `bun test tests/google-adapter.test.ts tests/google-antigravity-wire.test.ts tests/config.test.ts` — 223 passed, 0 failed, 905 assertions on the rebased head.
- `cd docs-site && bun run build` — passed (385 pages).
- `git diff --check` — passed.
- Monolithic `bun run test` did not produce a green local result on this host: one run hit an unrelated fixed-5-second catalog-sync timeout that passed alone in 2.95 seconds; later runs were terminated by the host with SIGKILL/exit 137 before the final summary.
- Memory-safe sharded reruns produced complete `0 fail` summaries for 812 of 814 test files. The two remaining unrelated files (`tests/integrations-invariants.test.ts` and `tests/opencode-cli.test.ts`) were also terminated with exit 137 before their summaries while the host had about 386 MiB of free pages. The local-CI checkbox therefore remains unchecked.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Google provider setting to control Gemini Flash model ID renaming for direct AI Studio requests.
  * By default, model IDs retain the existing `-tiered` suffix behavior; setting the option to `false` preserves original IDs.
  * Vertex and Cloud Code Assist request behavior remains unchanged.

* **Bug Fixes**
  * System identity now uses the public model name for AI Studio and Vertex, and the resolved routed model for Cloud Code Assist.
  * Invalid setting values produce configuration diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
