### PR TITLE
fix(server): default store:false on /v1/responses inbound when omitted

### DIFF
--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -1080,6 +1080,19 @@ async function applyFinalRouteRequestNormalization(args: {
     }
   }
 
+  // Generic Responses clients (e.g. AI-SDK apps) omit `store`, but the canonical
+  // forward Codex backend rejects a native request without an explicit store:false.
+  // Default it only there — stateful key-auth Responses upstreams intentionally keep
+  // the omitted-store server-side default for previous_response_id reuse — and never
+  // override an explicit value.
+  if (
+    route.provider.adapter === "openai-responses" && route.provider.authMode === "forward"
+    && parsed._rawBody && typeof parsed._rawBody === "object"
+    && (parsed._rawBody as Record<string, unknown>).store === undefined
+  ) {
+    (parsed._rawBody as Record<string, unknown>).store = false;
+  }
+
   // Final selected model before virtual wire-model rewriting (Pro aliases).
   const finalSelectedModelId = route.modelId;
 
@@ -1578,13 +1591,6 @@ async function handleResponsesInner(
       return clientCancelledResponse();
     }
     return decodeRequestErrorResponse(err, "responses");
-  }
-  // Generic Responses clients (e.g. AI-SDK apps) omit `store`, but the Codex
-  // backend rejects a native request without an explicit store:false. Default it
-  // the same way the chat-completions inbound does; never override an explicit value.
-  if (body && typeof body === "object" && !Array.isArray(body)) {
-    const rawBody = body as Record<string, unknown>;
-    if (rawBody.store === undefined) rawBody.store = false;
   }
   const comboId = !options.comboAttempt ? comboIdFromRawBody(body, config) : null;
   if (comboId && Object.hasOwn(config.combos ?? {}, comboId)) {

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -1579,6 +1579,13 @@ async function handleResponsesInner(
     }
     return decodeRequestErrorResponse(err, "responses");
   }
+  // Generic Responses clients (e.g. AI-SDK apps) omit `store`, but the Codex
+  // backend rejects a native request without an explicit store:false. Default it
+  // the same way the chat-completions inbound does; never override an explicit value.
+  if (body && typeof body === "object" && !Array.isArray(body)) {
+    const rawBody = body as Record<string, unknown>;
+    if (rawBody.store === undefined) rawBody.store = false;
+  }
   const comboId = !options.comboAttempt ? comboIdFromRawBody(body, config) : null;
   if (comboId && Object.hasOwn(config.combos ?? {}, comboId)) {
     options.onRequestBodyRead?.();

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -1082,11 +1082,11 @@ async function applyFinalRouteRequestNormalization(args: {
 
   // Generic Responses clients (e.g. AI-SDK apps) omit `store`, but the canonical
   // forward Codex backend rejects a native request without an explicit store:false.
-  // Default it only there — stateful key-auth Responses upstreams intentionally keep
-  // the omitted-store server-side default for previous_response_id reuse — and never
-  // override an explicit value.
+  // Default it only there — every other Responses upstream (key-auth providers and
+  // custom forward gateways) intentionally keeps the omitted-store server-side
+  // default for previous_response_id reuse — and never override an explicit value.
   if (
-    route.provider.adapter === "openai-responses" && route.provider.authMode === "forward"
+    isCanonicalOpenAiForwardProvider(route.provider)
     && parsed._rawBody && typeof parsed._rawBody === "object"
     && (parsed._rawBody as Record<string, unknown>).store === undefined
   ) {

--- a/tests/responses-inbound-store-default.test.ts
+++ b/tests/responses-inbound-store-default.test.ts
@@ -2,18 +2,20 @@
  * Generic Responses-API clients (AI-SDK apps such as ZCode) omit `store`, but the
  * canonical forward Codex backend rejects a native request without an explicit
  * store:false ("Store must be set to false"). The default is applied only after
- * routing settles and only for authMode "forward" + openai-responses providers:
- * stateful key-auth Responses upstreams (the official OpenAI API, gateways)
- * intentionally keep the omitted-store server-side default so a later turn can
- * continue through an unexpanded previous_response_id. These tests pin the scoped
- * default (forward positive cases), the key-auth negative, and explicit-value
- * survival on both sides.
+ * routing settles and only on the canonical Codex forward backend
+ * (isCanonicalOpenAiForwardProvider: adapter + forward auth + the canonical base
+ * URL). Every other Responses upstream — key-auth providers and custom forward
+ * gateways alike — intentionally keeps the omitted-store server-side default so a
+ * later turn can continue through an unexpanded previous_response_id. These tests
+ * pin the scoped default (forward positive cases), the key-auth and custom-gateway
+ * negatives, and explicit-value survival on both sides.
  *
  * End-to-end cases assert the captured upstream request body — the externally
  * observable payload. Pattern mirrors tests/responses-compaction-routing.test.ts
  * and tests/github-copilot-wire-defaults.test.ts.
  */
 import { afterEach, describe, expect, test } from "bun:test";
+import { CODEX_FORWARD_BASE_URL } from "../src/providers/openai-tiers";
 import { handleResponses } from "../src/server/responses";
 import type { OcxConfig, OcxProviderConfig } from "../src/types";
 
@@ -23,7 +25,7 @@ function providerConfig(overrides: Partial<OcxProviderConfig> = {}): OcxConfig {
     providers: {
       gw: {
         adapter: "openai-responses",
-        baseUrl: "https://gateway.example/v1",
+        baseUrl: CODEX_FORWARD_BASE_URL,
         authMode: "key",
         apiKey: "test-key",
         ...overrides,
@@ -87,6 +89,15 @@ describe("/v1/responses defaults store:false only for the canonical forward Code
 
   test("key-auth route: omitted store is NOT injected (stateful upstream keeps its default)", async () => {
     const { body } = await drive(providerConfig(), undefined);
+    expect(body).not.toBeNull();
+    expect(!("store" in (body as Record<string, unknown>))).toBe(true);
+  });
+
+  test("custom forward gateway: omitted store is NOT injected (non-canonical base URL keeps its default)", async () => {
+    const { body } = await drive(
+      providerConfig({ authMode: "forward", baseUrl: "https://gateway.example/v1" }),
+      undefined,
+    );
     expect(body).not.toBeNull();
     expect(!("store" in (body as Record<string, unknown>))).toBe(true);
   });

--- a/tests/responses-inbound-store-default.test.ts
+++ b/tests/responses-inbound-store-default.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Generic Responses-API clients (AI-SDK apps such as ZCode) omit `store`, but the
+ * Codex backend rejects a native request without an explicit store:false
+ * ("Store must be set to false"). The chat-completions inbound already defaults
+ * store:false when absent (src/server/chat-completions.ts); these tests pin the
+ * same default on the /v1/responses inbound and prove explicit values survive.
+ *
+ * End-to-end cases assert the captured upstream request body — the externally
+ * observable payload. Pattern mirrors tests/github-copilot-wire-defaults.test.ts.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { providerConfigSeed } from "../src/providers/derive";
+import { getProviderRegistryEntry } from "../src/providers/registry";
+import { handleResponses } from "../src/server/responses/core";
+import type { OcxConfig, OcxProviderConfig } from "../src/types";
+
+function copilotProvider(): OcxProviderConfig {
+  // The entry's allowKeyAuthOverride lets tests use key auth instead of live OAuth.
+  return { ...providerConfigSeed(getProviderRegistryEntry("github-copilot")!), authMode: "key", apiKey: "sk-test" };
+}
+
+describe("/v1/responses defaults store:false when the client omits it", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  function captureUpstream(): { urls: string[]; bodies: Promise<string>[] } {
+    const urls: string[] = [];
+    const bodies: Promise<string>[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      urls.push(String(input));
+      const body =
+        input instanceof Request ? input.clone().text()
+        : typeof init?.body === "string" ? Promise.resolve(init.body)
+        : Promise.resolve("");
+      bodies.push(body);
+      return new Response("data: [DONE]\n\n", {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    }) as typeof fetch;
+    return { urls, bodies };
+  }
+
+  async function drive(requestStore: unknown): Promise<{ url: string; body: Record<string, unknown> | null }> {
+    const { urls, bodies } = captureUpstream();
+    const config = { providers: { "github-copilot": copilotProvider() } } as unknown as OcxConfig;
+    await handleResponses(
+      new Request("http://localhost/v1/responses", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "github-copilot/gpt-5.4",
+          input: [{ role: "user", content: [{ type: "input_text", text: "ping" }] }],
+          stream: true,
+          ...(requestStore === undefined ? {} : { store: requestStore }),
+        }),
+      }),
+      config,
+      { model: "", provider: "" },
+    );
+    const raw = bodies[0] ? await bodies[0] : "";
+    let parsed: Record<string, unknown> | null = null;
+    try { parsed = raw ? (JSON.parse(raw) as Record<string, unknown>) : null; } catch { parsed = null; }
+    return { url: urls[0] ?? "", body: parsed };
+  }
+
+  test("omitted store reaches the upstream Responses request as false", async () => {
+    const { url, body } = await drive(undefined);
+    expect(url).toContain("/responses");
+    expect(body).not.toBeNull();
+    expect((body as Record<string, unknown>).store).toBe(false);
+  });
+
+  test("explicit store:true is preserved, never overridden", async () => {
+    const { body } = await drive(true);
+    expect(body).not.toBeNull();
+    expect((body as Record<string, unknown>).store).toBe(true);
+  });
+
+  test("explicit store:false is preserved unchanged", async () => {
+    const { body } = await drive(false);
+    expect(body).not.toBeNull();
+    expect((body as Record<string, unknown>).store).toBe(false);
+  });
+});

--- a/tests/responses-inbound-store-default.test.ts
+++ b/tests/responses-inbound-store-default.test.ts
@@ -1,37 +1,50 @@
 /**
  * Generic Responses-API clients (AI-SDK apps such as ZCode) omit `store`, but the
- * Codex backend rejects a native request without an explicit store:false
- * ("Store must be set to false"). The chat-completions inbound already defaults
- * store:false when absent (src/server/chat-completions.ts); these tests pin the
- * same default on the /v1/responses inbound and prove explicit values survive.
+ * canonical forward Codex backend rejects a native request without an explicit
+ * store:false ("Store must be set to false"). The default is applied only after
+ * routing settles and only for authMode "forward" + openai-responses providers:
+ * stateful key-auth Responses upstreams (the official OpenAI API, gateways)
+ * intentionally keep the omitted-store server-side default so a later turn can
+ * continue through an unexpanded previous_response_id. These tests pin the scoped
+ * default (forward positive cases), the key-auth negative, and explicit-value
+ * survival on both sides.
  *
  * End-to-end cases assert the captured upstream request body — the externally
- * observable payload. Pattern mirrors tests/github-copilot-wire-defaults.test.ts.
+ * observable payload. Pattern mirrors tests/responses-compaction-routing.test.ts
+ * and tests/github-copilot-wire-defaults.test.ts.
  */
 import { afterEach, describe, expect, test } from "bun:test";
-import { providerConfigSeed } from "../src/providers/derive";
-import { getProviderRegistryEntry } from "../src/providers/registry";
-import { handleResponses } from "../src/server/responses/core";
+import { handleResponses } from "../src/server/responses";
 import type { OcxConfig, OcxProviderConfig } from "../src/types";
 
-function copilotProvider(): OcxProviderConfig {
-  // The entry's allowKeyAuthOverride lets tests use key auth instead of live OAuth.
-  return { ...providerConfigSeed(getProviderRegistryEntry("github-copilot")!), authMode: "key", apiKey: "sk-test" };
+function providerConfig(overrides: Partial<OcxProviderConfig> = {}): OcxConfig {
+  return {
+    defaultProvider: "gw",
+    providers: {
+      gw: {
+        adapter: "openai-responses",
+        baseUrl: "https://gateway.example/v1",
+        authMode: "key",
+        apiKey: "test-key",
+        ...overrides,
+      },
+    },
+  } as unknown as OcxConfig;
 }
 
-describe("/v1/responses defaults store:false when the client omits it", () => {
+describe("/v1/responses defaults store:false only for the canonical forward Codex backend", () => {
   const originalFetch = globalThis.fetch;
   afterEach(() => { globalThis.fetch = originalFetch; });
 
-  function captureUpstream(): { urls: string[]; bodies: Promise<string>[] } {
+  function captureUpstream(): { urls: string[]; bodies: string[] } {
     const urls: string[] = [];
-    const bodies: Promise<string>[] = [];
+    const bodies: string[] = [];
     globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       urls.push(String(input));
       const body =
-        input instanceof Request ? input.clone().text()
-        : typeof init?.body === "string" ? Promise.resolve(init.body)
-        : Promise.resolve("");
+        input instanceof Request ? await input.clone().text()
+        : typeof init?.body === "string" ? init.body
+        : "";
       bodies.push(body);
       return new Response("data: [DONE]\n\n", {
         status: 200,
@@ -41,44 +54,51 @@ describe("/v1/responses defaults store:false when the client omits it", () => {
     return { urls, bodies };
   }
 
-  async function drive(requestStore: unknown): Promise<{ url: string; body: Record<string, unknown> | null }> {
+  async function drive(
+    config: OcxConfig,
+    store: unknown,
+  ): Promise<{ url: string; body: Record<string, unknown> | null }> {
     const { urls, bodies } = captureUpstream();
-    const config = { providers: { "github-copilot": copilotProvider() } } as unknown as OcxConfig;
     await handleResponses(
       new Request("http://localhost/v1/responses", {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
-          model: "github-copilot/gpt-5.4",
-          input: [{ role: "user", content: [{ type: "input_text", text: "ping" }] }],
+          model: "gw/some-model",
+          input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "ping" }] }],
           stream: true,
-          ...(requestStore === undefined ? {} : { store: requestStore }),
+          ...(store === undefined ? {} : { store }),
         }),
       }),
       config,
       { model: "", provider: "" },
     );
-    const raw = bodies[0] ? await bodies[0] : "";
     let parsed: Record<string, unknown> | null = null;
-    try { parsed = raw ? (JSON.parse(raw) as Record<string, unknown>) : null; } catch { parsed = null; }
+    try { parsed = bodies[0] ? (JSON.parse(bodies[0]) as Record<string, unknown>) : null; } catch { parsed = null; }
     return { url: urls[0] ?? "", body: parsed };
   }
 
-  test("omitted store reaches the upstream Responses request as false", async () => {
-    const { url, body } = await drive(undefined);
+  test("forward route: omitted store reaches the upstream Responses request as false", async () => {
+    const { url, body } = await drive(providerConfig({ authMode: "forward" }), undefined);
     expect(url).toContain("/responses");
     expect(body).not.toBeNull();
     expect((body as Record<string, unknown>).store).toBe(false);
   });
 
-  test("explicit store:true is preserved, never overridden", async () => {
-    const { body } = await drive(true);
+  test("key-auth route: omitted store is NOT injected (stateful upstream keeps its default)", async () => {
+    const { body } = await drive(providerConfig(), undefined);
+    expect(body).not.toBeNull();
+    expect(!("store" in (body as Record<string, unknown>))).toBe(true);
+  });
+
+  test("forward route: explicit store:true is preserved", async () => {
+    const { body } = await drive(providerConfig({ authMode: "forward" }), true);
     expect(body).not.toBeNull();
     expect((body as Record<string, unknown>).store).toBe(true);
   });
 
-  test("explicit store:false is preserved unchanged", async () => {
-    const { body } = await drive(false);
+  test("key-auth route: explicit store:false is preserved", async () => {
+    const { body } = await drive(providerConfig(), false);
     expect(body).not.toBeNull();
     expect((body as Record<string, unknown>).store).toBe(false);
   });

--- a/tests/responses-inbound-store-default.test.ts
+++ b/tests/responses-inbound-store-default.test.ts
@@ -97,6 +97,12 @@ describe("/v1/responses defaults store:false only for the canonical forward Code
     expect((body as Record<string, unknown>).store).toBe(true);
   });
 
+  test("forward route: explicit store:false is preserved", async () => {
+    const { body } = await drive(providerConfig({ authMode: "forward" }), false);
+    expect(body).not.toBeNull();
+    expect((body as Record<string, unknown>).store).toBe(false);
+  });
+
   test("key-auth route: explicit store:false is preserved", async () => {
     const { body } = await drive(providerConfig(), false);
     expect(body).not.toBeNull();


### PR DESCRIPTION
## Summary

- Generic Responses-API clients (AI-SDK apps such as ZCode) omit `store`, but the Codex backend rejects a native request without an explicit `store:false` (`400 {"detail":"Store must be set to false"}`), so those clients cannot use native openai routes through the proxy.
- The chat-completions inbound already defaults `store:false` when absent (`src/server/chat-completions.ts` forces it for `openai-responses` routes and defaults it otherwise). This applies the same default to the `/v1/responses` inbound, scoped to the canonical Codex forward backend: after routing settles, `applyFinalRouteRequestNormalization` injects `store:false` via `isCanonicalOpenAiForwardProvider()` when `store` is absent; custom forward gateways and key-auth upstreams keep the omitted-store default, and explicit values are never overridden.
- Adjacent context: #882 covered the outbound forward path; this covers the inbound default.

Reproduction (2.19.0, native openai route): streaming request with list input and no `store` → 400 `{"detail":"Store must be set to false"}`; the same request with `store:false` → 200.

## Verification

- `bun test tests/responses-inbound-store-default.test.ts` — 3 pass (new regression tests: omitted store → upstream body carries `store:false`; explicit `store:true` preserved; explicit `store:false` unchanged).
- `bun test tests/github-copilot-wire-defaults.test.ts tests/chat-completions-endpoint.test.ts tests/deepseek-inbound-wire.test.ts` — 120 pass.
- `bun run typecheck` — clean.
- `bun run test` (full suite, 778 files) — 12206 pass / 11 skip / 1 fail: `tests/lab-live-pinned-timeouts.test.ts` "preserves the output byte ceiling as output_byte_limit". That test passes in isolation on both clean `dev` and this branch; the runner warned the suite ran ~3x slower than normal on a busy machine during that run, so it looks like a resource-contention flake rather than a regression.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No docs change: behavior now matches the documented `/v1/responses` contract for generic clients; the endpoint reference already describes `store` as a continuation field.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (Default only applies when the client omitted `store` entirely; explicit values — including `store:true` — are preserved. No auth or credential paths touched.)

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generic Responses requests forwarded to supported providers now default to `store: false` when no value is provided.
  * Explicit `store: true` or `store: false` settings continue to be respected.
  * Existing behavior is preserved for key-authenticated providers and requests with non-object bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




