### PR TITLE
test(gui): update client inventory assertions for mcode (#1744 follow-up)

### DIFF
--- a/gui/tests/client-config-panel.test.tsx
+++ b/gui/tests/client-config-panel.test.tsx
@@ -170,9 +170,10 @@ function rowButton(container: HTMLElement, name: string, label: string): HTMLBut
     .find(el => el.textContent?.trim() === label)!;
 }
 
-test("the API download surface includes DSH as the eighth client", () => {
-  expect(CLIENTS).toEqual(["opencode", "pi", "omp", "hermes", "openclaw", "kimi", "gajae", "dsh"]);
+test("the API download surface includes DSH and MiniMax Code as clients", () => {
+  expect(CLIENTS).toEqual(["opencode", "pi", "omp", "hermes", "openclaw", "kimi", "gajae", "dsh", "mcode"]);
   expect(CLIENT_LABEL_KEYS.dsh).toBe("api.clientConfig.clientDsh");
+  expect(CLIENT_LABEL_KEYS.mcode).toBe("api.clientConfig.clientMcode");
 });
 
 test("each row fetches its own client and its dialog renders that client's exact bytes", async () => {

--- a/gui/tests/integrations-api.test.ts
+++ b/gui/tests/integrations-api.test.ts
@@ -18,7 +18,7 @@ const originalFetch = globalThis.fetch;
 
 test("DSH is a file integration client", () => {
   expect(FILE_INTEGRATION_CLIENTS).toEqual([
-    "opencode", "pi", "omp", "hermes", "openclaw", "kimi", "gajae", "dsh",
+    "opencode", "pi", "omp", "hermes", "openclaw", "kimi", "gajae", "dsh", "mcode",
   ]);
 });
 

--- a/gui/tests/integrations-overview-rows.test.ts
+++ b/gui/tests/integrations-overview-rows.test.ts
@@ -178,8 +178,9 @@ test("every client counts toward the summary, not just the file clients", () => 
 
 test("an unsettled file list renders unknown rows instead of dropping them", () => {
   const built = buildOverviewRows(sources({ clients: [], clientsSettled: false }));
-  expect(built.rows).toHaveLength(12);
+  expect(built.rows).toHaveLength(13);
   expect(rowById(built, "omp").state).toBe("unknown");
+  expect(rowById(built, "mcode").state).toBe("unknown");
   expect(rowById(built, "kimi").state).toBe("unknown");
   expect(rowById(built, "dsh")).toMatchObject({
     hash: "integrations/dsh",

--- a/gui/tests/locale-parity.test.ts
+++ b/gui/tests/locale-parity.test.ts
@@ -108,6 +108,8 @@ const ZH_TW_KEEP_ENGLISH: ReadonlySet<string> = new Set([
   "integrations.tab.kimi",
   "integrations.tab.gajae",
   "integrations.tab.dsh",
+  "integrations.tab.mcode",
+  "api.clientConfig.clientMcode",
   "integrations.codex.title",
   // Provider proper nouns kept in English
   "provider.name.commandCodeAuth",


### PR DESCRIPTION
## Summary\n\nFixes the 4 red GUI gate tests on dev after #1744: MiniMax Code (mcode) legitimately became the ninth integration client, and the hardcoded client-inventory assertions (integrations-api, client-config-panel, integrations-overview-rows) plus the zh-TW locale-parity allowlist needed to catch up. Test-only change; no product code touched. zh-TW keeps the product proper noun in English, matching the Kimi Code precedent.\n\n## Verification\n\n- cd gui && bun test --isolate tests: 854 pass / 0 fail (146 files) on this branch — previously 4 fail on dev.\n\n## Checklist\n\n- [x] Targets dev\n- [x] Test-only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration coverage to include the MiniMax Code client.
  * Expanded client configuration and integration overview checks for the newly supported client.
  * Added localization parity coverage for MiniMax Code labels in Traditional Chinese.
  * Updated expected integration counts and handling for clients whose connection status is not yet known.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->