### PR TITLE
fix(scripts): release helper rejects channel-backwards versions

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -154,6 +154,65 @@ async function githubReleaseExists(tagName: string): Promise<boolean> {
   process.exit(1);
 }
 
+/** Order two semver strings per the semver.org rules (numeric identifiers numerically,
+ * numeric < alphanumeric prerelease, prerelease < release). Returns negative/0/positive. */
+export function compareReleaseVersions(left: string, right: string): number {
+  const parse = (value: string) => {
+    const [main, ...preParts] = value.split("-");
+    const nums = (main ?? "").split(".").map(part => Number(part));
+    return { nums, pre: preParts.length ? preParts.join("-").split(".") : null };
+  };
+  const a = parse(left);
+  const b = parse(right);
+  for (let i = 0; i < 3; i += 1) {
+    const delta = (a.nums[i] ?? 0) - (b.nums[i] ?? 0);
+    if (delta !== 0) return delta;
+  }
+  if (a.pre === null && b.pre === null) return 0;
+  if (a.pre === null) return 1;
+  if (b.pre === null) return -1;
+  const len = Math.max(a.pre.length, b.pre.length);
+  for (let i = 0; i < len; i += 1) {
+    const x = a.pre[i];
+    const y = b.pre[i];
+    if (x === undefined) return -1;
+    if (y === undefined) return 1;
+    const xn = /^\d+$/.test(x) ? Number(x) : null;
+    const yn = /^\d+$/.test(y) ? Number(y) : null;
+    if (xn !== null && yn !== null && xn !== yn) return xn - yn;
+    if (xn !== null && yn === null) return -1;
+    if (xn === null && yn !== null) return 1;
+    if (xn === null && yn === null && x !== y) return x < y ? -1 : 1;
+  }
+  return 0;
+}
+
+/** The proposed version must move its npm channel FORWARD: an unused-but-obsolete
+ * target (e.g. cut from a dev branch whose version line trails main) would otherwise
+ * pass the unused-version check and publish a regression over the channel tip. */
+async function assertChannelVersionMovesForward(packageName: string, version: string, channel: string): Promise<void> {
+  const result = await runQuiet(["npm", "view", packageName, "dist-tags", "--json"]);
+  if (result.exitCode !== 0) {
+    console.error(`✗ failed to read npm dist-tags for ${packageName}`);
+    if (result.stderr) console.error(result.stderr);
+    process.exit(1);
+  }
+  let distTags: Record<string, string>;
+  try {
+    distTags = JSON.parse(result.stdout) as Record<string, string>;
+  } catch {
+    console.error(`✗ npm dist-tags response for ${packageName} was not JSON`);
+    process.exit(1);
+  }
+  const current = distTags[channel];
+  if (!current) return; // channel not published yet — nothing to regress
+  if (compareReleaseVersions(version, current) <= 0) {
+    console.error(`✗ release version ${version} does not move the '${channel}' channel forward (current: ${current}).`);
+    console.error("Reconcile the version line first: dev's package.json may trail the latest release; pick a version strictly newer than the channel tip.");
+    process.exit(1);
+  }
+}
+
 async function assertUnusedReleaseVersion(packageName: string, version: string): Promise<void> {
   const releaseTag = `v${version}`;
   const [npmUsed, tagSha, releaseUsed] = await Promise.all([
@@ -298,6 +357,7 @@ if ((await capture(["git", "status", "--porcelain"])).trim()) { console.error("�
 const packageName = await readPackageName();
 console.log(`→ release metadata preflight (${packageName}@${version})`);
 await assertUnusedReleaseVersion(packageName, version);
+await assertChannelVersionMovesForward(packageName, version, tag);
 console.log("→ dependency audit");
 await runLoud(["bun", "run", "audit:high"]);
 console.log("→ typecheck");

--- a/tests/release-helper.test.ts
+++ b/tests/release-helper.test.ts
@@ -18,6 +18,8 @@ interface LoggedCall {
 
 interface ReleaseScenario {
   branch?: string;
+  npmLatest?: string;
+  npmPreview?: string;
   headSha?: string;
   remoteHeadSha?: string;
   privacyExitCode?: number;
@@ -104,6 +106,14 @@ process.exit(1);
 
 const args = process.argv.slice(2);
 appendFileSync(process.env.FAKE_RELEASE_LOG, JSON.stringify({ name: "npm", args }) + "\\n");
+
+if (args[0] === "view" && args.includes("dist-tags")) {
+  process.stdout.write(JSON.stringify({
+    latest: process.env.FAKE_NPM_LATEST ?? "0.0.1",
+    preview: process.env.FAKE_NPM_PREVIEW ?? "0.0.1-preview.0",
+  }) + "\\n");
+  process.exit(0);
+}
 
 if (args[0] === "view") {
   console.error("npm ERR! code E404");
@@ -216,6 +226,8 @@ function runRelease(version: string, scenario: ReleaseScenario = {}) {
       FAKE_BUN_TSC_EXIT_CODE: String(scenario.typecheckExitCode ?? 0),
       FAKE_BUN_TEST_EXIT_CODE: String(scenario.testExitCode ?? 0),
       FAKE_BUN_PRIVACY_EXIT_CODE: String(scenario.privacyExitCode ?? 0),
+      ...(scenario.npmLatest ? { FAKE_NPM_LATEST: scenario.npmLatest } : {}),
+      ...(scenario.npmPreview ? { FAKE_NPM_PREVIEW: scenario.npmPreview } : {}),
     },
     encoding: "utf8",
   });
@@ -253,6 +265,28 @@ describe("release helper", () => {
     expect(privacyIndex).toBeGreaterThan(testIndex);
     expect(versionIndex).toBeGreaterThan(privacyIndex);
     expect(dispatchIndex).toBeGreaterThan(versionIndex);
+  });
+
+  test("an obsolete version that would move latest backwards aborts before the bump", () => {
+    const { calls, result } = runRelease("9.9.8", { npmLatest: "9.9.9" });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr ?? "").toContain("does not move the 'latest' channel forward");
+    expect(findCallIndex(calls, "npm", call => call.args[0] === "version")).toBe(-1);
+    expect(findCallIndex(calls, "git", call => call.args[0] === "commit")).toBe(-1);
+  });
+
+  test("a version newer than the channel tip passes the forward guard", () => {
+    const { calls, result } = runRelease("9.9.10", { npmLatest: "9.9.9" });
+
+    expect(`${result.status}\n${result.stderr ?? ""}`.trim()).toBe("0");
+    expect(findCallIndex(calls, "npm", call => call.args.join(" ") === "version 9.9.10 --no-git-tag-version")).toBeGreaterThanOrEqual(0);
+  });
+
+  test("preview releases compare against the preview channel, not latest", () => {
+    const { result } = runRelease("9.9.9-preview.2", { branch: "preview", npmLatest: "10.0.0", npmPreview: "9.9.9-preview.1" });
+
+    expect(`${result.status}\n${result.stderr ?? ""}`.trim()).toBe("0");
   });
 
   test("failed privacy scan aborts before version bump, commit, and push", () => {


### PR DESCRIPTION
## Summary
 
Release-prep hardening found by the 260815 readiness audit: dev's version line (2.18.0) trails npm latest (2.19.0, released from main). The release helper's preflight only verified the proposed version was *unused* - an obsolete-but-unused target could pass preflight and move a dist-tag backwards. This adds a channel-forward guard: read npm dist-tags, require the proposed version to be strictly newer than the channel tip (semver-ordered; preview channel compares against preview). Fail-closed on npm read errors, matching the existing checks.
 
## Verification
 
- bun test tests/release-helper.test.ts: all green incl. 3 new shimmed tests (obsolete-version abort, newer-version pass, preview-channel comparison).
- bun x tsc --noEmit: green.
 
## Checklist
 
- [x] Targets dev
- [x] No runtime surface; release tooling only
- [x] Security-relevant automation change reviewed (no token handling; npm view is read-only)
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release checks now prevent publishing versions older than the currently published version.
  * Preview releases are compared against the appropriate preview channel version.
  * Release validation handles unavailable channels, command failures, and invalid responses more safely.

* **Tests**
  * Added coverage for rejected backward releases and accepted forward releases across release channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->