### PR TITLE
fix(release): fail closed on unparseable channel versions (#1753 follow-up)

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -157,10 +157,15 @@ async function githubReleaseExists(tagName: string): Promise<boolean> {
 /** Order two semver strings per the semver.org rules (numeric identifiers numerically,
  * numeric < alphanumeric prerelease, prerelease < release). Returns negative/0/positive. */
 export function compareReleaseVersions(left: string, right: string): number {
+  // SemVer 2.0.0: build metadata (+...) is valid and ignored for precedence, but
+  // anything else unparseable must fail CLOSED. Number() on a garbage core used to
+  // yield NaN, and NaN comparisons made the forward guard pass any candidate.
+  const SEMVER = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
   const parse = (value: string) => {
-    const [main, ...preParts] = value.split("-");
-    const nums = (main ?? "").split(".").map(part => Number(part));
-    return { nums, pre: preParts.length ? preParts.join("-").split(".") : null };
+    const match = SEMVER.exec(value.trim());
+    if (!match) throw new Error(`unparseable release version: ${JSON.stringify(value)}`);
+    const nums = [Number(match[1]), Number(match[2]), Number(match[3])];
+    return { nums, pre: match[4] ? match[4].split(".") : null };
   };
   const a = parse(left);
   const b = parse(right);
@@ -206,7 +211,14 @@ async function assertChannelVersionMovesForward(packageName: string, version: st
   }
   const current = distTags[channel];
   if (!current) return; // channel not published yet — nothing to regress
-  if (compareReleaseVersions(version, current) <= 0) {
+  let forward: number;
+  try {
+    forward = compareReleaseVersions(version, current);
+  } catch (err) {
+    console.error(`✗ cannot compare release versions (candidate ${version}, channel tip ${JSON.stringify(current)}): ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+  if (forward <= 0) {
     console.error(`✗ release version ${version} does not move the '${channel}' channel forward (current: ${current}).`);
     console.error("Reconcile the version line first: dev's package.json may trail the latest release; pick a version strictly newer than the channel tip.");
     process.exit(1);

--- a/tests/release-helper.test.ts
+++ b/tests/release-helper.test.ts
@@ -396,4 +396,24 @@ describe("release helper", () => {
     // And the launcher must still be the thing it reaches for.
     expect(withoutComments).toContain("commandInvocation");
   });
+
+  // #1753 review follow-up: build metadata on the channel tip is valid semver
+  // and compares by precedence only; an unparseable tip must fail CLOSED
+  // (Number() on a garbage core used to yield NaN and pass any candidate).
+  test("channel tip with build metadata compares by precedence, not NaN", () => {
+    const { result } = runRelease("2.19.4", { npmLatest: "2.19.3+build.1" });
+    expect(`${result.status}\n${result.stderr ?? ""}`.trim()).toBe("0");
+  });
+
+  test("channel tip equal after stripping build metadata does not move forward", () => {
+    const { result } = runRelease("2.19.3", { npmLatest: "2.19.3+build.1" });
+    expect(result.status).toBe(1);
+    expect(result.stderr ?? "").toContain("does not move");
+  });
+
+  test("unparseable channel tip fails closed", () => {
+    const { result } = runRelease("2.19.4", { npmLatest: "not-a-version" });
+    expect(result.status).toBe(1);
+    expect(result.stderr ?? "").toContain("cannot compare release versions");
+  });
 });


### PR DESCRIPTION
## Summary\n\nFollow-up to the unresolved #1753 review finding (SemVer build metadata): 'compareReleaseVersions' parsed version cores with Number(), so a channel tip like 2.19.3+build.1 produced NaN and the forward guard ('does this candidate move the channel forward?') silently failed open. Now: strict SemVer 2.0.0 parsing (build metadata accepted but ignored for precedence), throw on unparseable input, and the caller exits 1 (fail closed).\n\n## Verification\n\n- tests/release-helper.test.ts: 13 pass / 0 fail, including three new regression cases — build-metadata tip compares by precedence, equal-after-strip is not forward, unparseable tip fails closed.\n- bun x tsc --noEmit green.\n\n## Checklist\n\n- [x] Targets dev\n- [x] Release-automation change — flagged for security review per MAINTAINERS.md\n- [x] Regression tests included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release version validation for SemVer 2.0.0 formats.
  * Build metadata is now accepted while correctly ignored when comparing precedence.
  * Invalid or non-forward release versions now fail with clear error messages instead of producing unreliable results.

* **Tests**
  * Added coverage for build metadata, equal versions, and malformed channel versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->