### PR TITLE
fix(zai): complete GLM-5.3 coding metadata

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1977,7 +1977,11 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
   // 260710 GLM-5.2 context and path-specific ids: Tier-2 evidence in
   // devlog/_plan/260710_provider_hardening/002_research_cn.md.
   // 260814: glm-5.3 / glm-5.3[1m] added per docs.z.ai/devpack/latest-model, which lists them as
-  // Coding Plan ids on this same endpoint. Capabilities mirror 5.2 until Z.AI publishes tables.
+  // Coding Plan ids on this same endpoint.
+  // 260815: docs.z.ai/guides/llm/glm-5.3 now publishes the capability table (thinking, streaming,
+  // function calling, caching, structured output) and a 128K output budget, recorded here as the
+  // exact 131_072 every other source in this repo uses for that model. Coding Plan pricing stays
+  // unpublished, so no cost entry is asserted.
   {
     id: "zai", label: "Z.AI — GLM Coding Plan", baseUrl: "https://api.z.ai/api/coding/paas/v4", adapter: "openai-chat", authKind: "key",
     dashboardUrl: "https://z.ai/manage-apikey/apikey-list", defaultModel: "glm-5.3",
@@ -1988,6 +1992,8 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     modelSuffixBracketStrip: true,
     noVisionModels: ZAI_GLM_5X_MODELS,
     modelReasoningEfforts: ZAI_GLM_5X_REASONING_EFFORTS,
+    modelDefaultReasoningEfforts: Object.fromEntries(ZAI_GLM_53_MODELS.map(id => [id, "max"])),
+    modelMaxOutputTokens: Object.fromEntries(ZAI_GLM_53_MODELS.map(id => [id, 131_072])),
     modelSupportsReasoningSummaries: Object.fromEntries(ZAI_GLM_5X_MODELS.map(id => [id, true])),
     preserveReasoningContentModels: ZAI_GLM_5X_MODELS,
   },

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -360,7 +360,11 @@ describe("provider registry parity", () => {
       .filter(entry => entry.modelSuffixBracketStrip)
       .map(entry => entry.id);
     expect(zai?.modelContextWindows).toEqual({ "glm-5.3": 1_000_000, "glm-5.3[1m]": 1_000_000, "glm-5.2": 1_000_000, "glm-5.2[1m]": 1_000_000 });
+    expect(zai?.modelDefaultReasoningEfforts).toEqual({ "glm-5.3": "max", "glm-5.3[1m]": "max" });
+    expect(zai?.modelMaxOutputTokens).toEqual({ "glm-5.3": 131_072, "glm-5.3[1m]": 131_072 });
     expect(providerConfigSeed(zai!).modelSuffixBracketStrip).toBe(true);
+    expect(providerConfigSeed(zai!).modelDefaultReasoningEfforts?.["glm-5.3"]).toBe("max");
+    expect(deriveKeyLoginMap().zai.modelMaxOutputTokens?.["glm-5.3[1m]"]).toBe(131_072);
     // `zhipu-bigmodel-coding` opts in for the same reason `zai` does: it serves the same
     // bracketed GLM ids, and that vendor's OpenAI path returns 400 code 1211 for them.
     expect(optedInProviders).toEqual(["kimi", "zai", "zhipu-bigmodel-coding", "kimi-code"]);
@@ -375,7 +379,18 @@ describe("provider registry parity", () => {
         },
       },
     };
+    const routed53 = routeModel(config, "zai/glm-5.3");
+    expect(routed53.provider.modelDefaultReasoningEfforts?.["glm-5.3"]).toBe("max");
+    expect(routed53.provider.modelMaxOutputTokens?.["glm-5.3"]).toBe(131_072);
     expect(routeModel(config, "zai/glm-5.2[1m]").provider.modelSuffixBracketStrip).toBe(true);
+
+    const glm53Model = applyProviderConfigHints("zai", providerConfigSeed(zai!), {
+      provider: "zai",
+      id: "glm-5.3",
+    });
+    const glm53Entry = buildCatalogEntries(nativeTemplate(), [], [glm53Model])
+      .find(entry => entry.slug === "zai/glm-5.3");
+    expect(glm53Entry?.default_reasoning_level).toBe("max");
   });
 
   test("Anthropic API-key provider mirrors the OAuth entry's models on the key flow", () => {


### PR DESCRIPTION
## Summary

- set the documented default reasoning effort for `zai/glm-5.3` and `zai/glm-5.3[1m]` to `max`
- set the documented per-model maximum output to 128,000 tokens
- verify registry seeding, key-login derivation, routing, and catalog default metadata

## Scope

This change is limited to the Z.AI Coding Plan route. It does not infer GLM-5.3 availability or metadata for unrelated pay-as-you-go or aggregator endpoints.

## Validation

- `bun test tests/provider-registry-parity.test.ts` (37 passed)
- `bun run typecheck`
- `bun run privacy:scan`
- `git diff --check`

Fixes #1734


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - GLM-5.3 models, including the `[1m]` variant, now default to maximum reasoning effort.
  - Increased the maximum generated output to 131,072 tokens (128K).

- **Bug Fixes**
  - Provider routing and model catalog entries now consistently reflect the updated reasoning and output limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->