### PR TITLE
fix(responses): preserve unified exec input contract

### DIFF
--- a/src/responses/custom-tool-compat.ts
+++ b/src/responses/custom-tool-compat.ts
@@ -70,6 +70,9 @@ function rewriteForUpstream(
       || isPlainObject(value.format)
       || isPlainObject(value.parameters);
     if (!isDefinition) return { ...rest, type: "function" };
+    const inputDescription = value.name === "exec"
+      ? "JavaScript source for unified exec. Use await tools.exec_command(...) for shell commands and text(...) to return textual output; do not provide a bare shell command."
+      : "Raw input for this client-executed custom tool.";
     return {
       ...rest,
       type: "function",
@@ -78,7 +81,7 @@ function rewriteForUpstream(
         properties: {
           input: {
             type: "string",
-            description: "Raw input for this client-executed custom tool.",
+            description: inputDescription,
           },
         },
         required: ["input"],

--- a/tests/custom-tool-compat.test.ts
+++ b/tests/custom-tool-compat.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { rewriteRoutedCustomToolsForUpstream } from "../src/responses/custom-tool-compat";
+
+function convertedInputDescription(name: string): string | undefined {
+  const result = rewriteRoutedCustomToolsForUpstream({
+    tools: [{ type: "custom", name, description: "client tool", format: { type: "text" } }],
+  });
+  const body = result.body as {
+    tools?: Array<{
+      parameters?: { properties?: { input?: { description?: string } } };
+    }>;
+  };
+  return body.tools?.[0]?.parameters?.properties?.input?.description;
+}
+
+describe("routed custom-tool compatibility", () => {
+  test("converted exec preserves the JavaScript input contract", () => {
+    const description = convertedInputDescription("exec");
+    expect(description).toContain("JavaScript");
+    expect(description).toContain("tools.exec_command");
+    expect(description).toContain("text(...)");
+    expect(description).toContain("do not provide a bare shell command");
+  });
+
+  test("other converted custom tools keep the generic raw-input contract", () => {
+    expect(convertedInputDescription("review_patch"))
+      .toBe("Raw input for this client-executed custom tool.");
+  });
+});


### PR DESCRIPTION
## Summary

- preserve the JavaScript input contract when the Responses compatibility layer converts the unified `exec` custom tool into a function tool
- explicitly direct models to use `tools.exec_command(...)` for shell commands and `text(...)` for textual output
- keep the existing generic raw-input description for every other converted custom tool

## Scope

This PR fixes the confirmed shared conversion defect from #1730. It intentionally does not add a hostname/model-specific `tool_choice: required` policy for Camel because that upstream-specific behavior still needs current raw-response evidence.

## Validation

- `bun test tests/custom-tool-compat.test.ts tests/openai-responses-passthrough.test.ts` (70 passed)
- `bun run typecheck`
- `bun run privacy:scan`
- `git diff --check`

Refs #1730


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved guidance for the `exec` tool, including JavaScript execution, command execution, and `text(...)` usage.
  * Other custom tools continue to use their standard raw-input guidance.

* **Bug Fixes**
  * Improved compatibility when routing custom tools by providing tool-specific input descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->