### PR TITLE
fix(release): never publish an empty changelog (commit-based fallback)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -459,12 +459,15 @@ jobs:
             # exactly that, 0 of 36 commits PR-associated. Fall back to the commit log so a
             # release can never publish an empty changelog.
             # The renderer only keeps entries carrying a PR number, so the fallback
-            # travels in its own channel (--commit-fallback) and is emitted only when
-            # the PR pipeline produced no category sections at all.
-            if ! bun scripts/release-notes.ts has-meaningful "$delta_file" \
-              && ! bun scripts/release-notes.ts has-meaningful "$carried_file"; then
+            # travels in its own channel (--commit-fallback). The decision depends on
+            # THIS range's PR delta only: carried preview notes cover the pre-preview
+            # span, so gating on them too would silently drop every post-preview
+            # direct commit. The renderer decides whether to emit the channel.
+            if ! bun scripts/release-notes.ts has-meaningful "$delta_file"; then
               commit_log_file="$(mktemp)"
-              git log --format='%H%x1f%s%x1f%an' "${notes_range_start}..${GITHUB_SHA}" > "$commit_log_file"
+              # NUL-delimited: Git forbids NUL in commit content, so neither a crafted
+              # subject nor an author name can forge a field boundary.
+              git log -z --format='%H%x00%s%x00%an' "${notes_range_start}..${GITHUB_SHA}" > "$commit_log_file"
               bun scripts/release-notes.ts commit-fallback "$commit_log_file" > "$commit_fallback_file"
               if bun scripts/release-notes.ts has-meaningful "$commit_fallback_file"; then
                 echo "::notice::generate-notes returned no PR categories for ${notes_range_start}..${release_tag}; using the commit-based changelog fallback"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -374,8 +374,10 @@ jobs:
           notes_file="$(mktemp)"
           carried_file="$(mktemp)"
           delta_file="$(mktemp)"
+          commit_fallback_file="$(mktemp)"
           : > "$carried_file"
           : > "$delta_file"
+          : > "$commit_fallback_file"
 
           # Stable releases after matching previews: aggregate every matching preview
           # changelog (oldest→newest; each preview body is incremental), then only
@@ -449,6 +451,28 @@ jobs:
             pr_notes="$(gh api "${generate_notes_api[@]}" --jq '.body')"
             # Drop generate-notes' trailing compare link; we re-append it after the commit list.
             printf '%s\n' "$pr_notes" | sed '/^\*\*Full Changelog\*\*:/d' > "$delta_file"
+
+            # generate-notes counts MERGED PULL REQUESTS in the tag range. Work that lands
+            # as direct commits on the integration branch (or via PRs based on `dev` rather
+            # than this release branch) leaves that range with nothing to aggregate, and the
+            # body collapses to the npm line plus a compare link — v2.17.0..v2.18.2 shipped
+            # exactly that, 0 of 36 commits PR-associated. Fall back to the commit log so a
+            # release can never publish an empty changelog.
+            # The renderer only keeps entries carrying a PR number, so the fallback
+            # travels in its own channel (--commit-fallback) and is emitted only when
+            # the PR pipeline produced no category sections at all.
+            if ! bun scripts/release-notes.ts has-meaningful "$delta_file" \
+              && ! bun scripts/release-notes.ts has-meaningful "$carried_file"; then
+              commit_log_file="$(mktemp)"
+              git log --format='%H%x1f%s%x1f%an' "${notes_range_start}..${GITHUB_SHA}" > "$commit_log_file"
+              bun scripts/release-notes.ts commit-fallback "$commit_log_file" > "$commit_fallback_file"
+              if bun scripts/release-notes.ts has-meaningful "$commit_fallback_file"; then
+                echo "::notice::generate-notes returned no PR categories for ${notes_range_start}..${release_tag}; using the commit-based changelog fallback"
+              else
+                : > "$commit_fallback_file"
+                echo "::notice::No PR categories and no eligible commits in ${notes_range_start}..${release_tag}; release notes stay minimal"
+              fi
+            fi
           else
             # First release on this channel: never call generate-notes without previous_tag_name.
             # GitHub would baseline the newest repo tag, which may belong to the other channel.
@@ -476,6 +500,7 @@ jobs:
             --npm-metadata "$npm_metadata"
             --carried "$carried_file"
             --delta "$delta_file"
+            --commit-fallback "$commit_fallback_file"
             --out "$notes_file"
             --compare-to "$release_tag"
             --repository "$GITHUB_REPOSITORY"

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -332,13 +332,9 @@ export function extractCommitBulletSections(body: string): string {
 }
 
 /**
- * Parse `git log -z --format=%H%x00%s%x00%an` output into commits.
- *
- * Records are NUL-delimited and fields are NUL-separated. Git forbids NUL in
- * commit content, so — unlike the unit separator, which Git happily accepts in
- * both subjects and author names — no field value can forge a boundary. Every
- * record is read as exactly three fields; anything longer is a malformed record
- * and is skipped rather than silently reinterpreted.
+ * Merge several already-rendered commit-bullet bodies into one set of category
+ * sections, preserving order within a category and de-duplicating identical
+ * bullets. Concatenating the bodies directly would repeat a shared heading.
  */
 export function mergeCommitBulletSections(bodies: string[]): string {
   const buckets = new Map<string, string[]>();
@@ -376,6 +372,14 @@ export function mergeCommitBulletSections(bodies: string[]): string {
   return merged.join("\n\n").trim();
 }
 
+/**
+ * Parse `git log -z --format=%H%x00%s%x00%an` output into commits.
+ *
+ * Records and fields are NUL-separated. Git forbids NUL in commit content, so
+ * — unlike the unit separator, which Git accepts in both subjects and author
+ * names — no field value can forge a boundary. Every record is read as exactly
+ * three fields.
+ */
 export function parseCommitLog(raw: string): ReleaseNoteCommit[] {
   const commits: ReleaseNoteCommit[] = [];
   const fields = raw.split("\u0000");

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -10,6 +10,7 @@
  *   bun scripts/release-notes.ts matching-preview-tags <version>
  *   bun scripts/release-notes.ts previous-release-tag <version>
  *   bun scripts/release-notes.ts has-meaningful [body-file]
+ *   bun scripts/release-notes.ts commit-fallback [commit-log-file]
  *   bun scripts/release-notes.ts credit-takeovers --repo <owner/name> --in <file> --out <file>
  *   bun scripts/release-notes.ts render --npm-metadata ... --out ... [--carried ...] [--delta ...] [--compare-from ...] [--compare-to ...] [--repository ...]
  *   bun scripts/release-notes.ts polish --in <file> --out <file> [--model ...] [--base-url ...]
@@ -175,6 +176,104 @@ export function isEmptyGeneratedNotes(body: string): boolean {
  */
 export function hasMeaningfulCarriedNotes(stripped: string): boolean {
   return !isEmptyGeneratedNotes(stripped);
+}
+
+/**
+ * A single commit considered for the commit-based changelog fallback.
+ * `sha` is the full or short hash; `subject` is the commit subject line.
+ */
+export type ReleaseNoteCommit = {
+  sha: string;
+  subject: string;
+  author: string;
+};
+
+/** Category order shared by the PR renderer and the commit fallback. */
+const RENDER_CATEGORY_ORDER = ["New Features", "Bug Fixes", "Documentation", "Chores", "Other Changes"];
+
+/** Conventional-commit type -> release.yml category title. */
+const COMMIT_TYPE_CATEGORY: Record<string, string> = {
+  feat: "New Features",
+  fix: "Bug Fixes",
+  perf: "Bug Fixes",
+  docs: "Documentation",
+  chore: "Chores",
+  build: "Chores",
+  ci: "Chores",
+  refactor: "Chores",
+  style: "Chores",
+  test: "Chores",
+};
+
+/**
+ * Commits that are release plumbing rather than shipped work. A merge commit's
+ * content is already represented by the commits it brings in, and a `release:`
+ * bump is the release itself.
+ */
+export function isReleasePlumbingCommit(subject: string): boolean {
+  const text = subject.trim();
+  if (/^Merge\s/i.test(text)) return true;
+  if (/^release:\s/i.test(text)) return true;
+  return false;
+}
+
+/**
+ * Render commits as a generate-notes-shaped body so the existing category
+ * parser/renderer can consume them unchanged.
+ *
+ * Why this exists: `releases/generate-notes` aggregates MERGED PULL REQUESTS
+ * against the compared tag range. When work lands as direct commits on the
+ * integration branch (or through PRs whose base is `dev` rather than the
+ * release branch), that range contains no PRs the API will count and the body
+ * collapses to the npm line plus a compare link — v2.17.0..v2.18.2 had 0 of 36
+ * commits associated with a main-merged PR, and both releases shipped an empty
+ * changelog. The fallback keeps the release body honest regardless of how the
+ * work reached the branch.
+ *
+ * Commits carry no PR number, so the synthetic entries use `#0` — a sentinel
+ * the renderer never prints as a link because these are emitted as plain
+ * bullets under their category heading.
+ */
+export function renderCommitFallbackNotes(commits: ReleaseNoteCommit[]): string {
+  const buckets = new Map<string, string[]>();
+  for (const commit of commits) {
+    const subject = commit.subject.trim();
+    if (!subject) continue;
+    if (isReleasePlumbingCommit(subject)) continue;
+    const match = /^([a-zA-Z]+)(?:\(([^)]*)\))?!?:\s*(.+)$/.exec(subject);
+    const type = match?.[1]?.toLowerCase();
+    const scope = match?.[2]?.trim();
+    const summary = (match?.[3] ?? subject).trim();
+    const category = (type && COMMIT_TYPE_CATEGORY[type]) ?? "Other Changes";
+    const shortSha = commit.sha.trim().slice(0, 9);
+    const scopePrefix = scope ? `${scope}: ` : "";
+    const author = commit.author.trim();
+    const credit = author ? ` @${author}` : "";
+    const line = `- ${scopePrefix}${summary} (${shortSha})${credit}`;
+    const existing = buckets.get(category);
+    if (existing) existing.push(line);
+    else buckets.set(category, [line]);
+  }
+  if (buckets.size === 0) return "";
+  const parts: string[] = [];
+  for (const title of RENDER_CATEGORY_ORDER) {
+    const lines = buckets.get(title);
+    if (!lines || lines.length === 0) continue;
+    parts.push([`## ${title}`, "", ...lines].join("\n"));
+  }
+  return parts.join("\n\n").replace(/\n+$/, "") + "\n";
+}
+
+/** Parse `git log --format=%H%x1f%s%x1f%an` output into commits. */
+export function parseCommitLog(raw: string): ReleaseNoteCommit[] {
+  const commits: ReleaseNoteCommit[] = [];
+  for (const line of raw.replace(/\r\n/g, "\n").split("\n")) {
+    if (!line.trim()) continue;
+    const [sha, subject, author] = line.split("\u001f");
+    if (!sha || !subject) continue;
+    commits.push({ sha, subject, author: author ?? "" });
+  }
+  return commits;
 }
 
 export function hasNonWhitespace(text: string): boolean {
@@ -425,8 +524,6 @@ export function groupPrsByScope(prs: ReleaseNotePr[]): Array<{ scope: string | n
   return groups;
 }
 
-const RENDER_CATEGORY_ORDER = ["New Features", "Bug Fixes", "Documentation", "Chores", "Other Changes"];
-
 /**
  * Render OpenAI-Codex-style release notes from the generate-notes pieces:
  * H2 category sections with scope-grouped, prefix-free summary bullets, then a
@@ -439,6 +536,12 @@ export function renderReleaseNotes(input: {
   npmMetadata: string;
   carriedPreviewNotes?: string;
   deltaPrNotes?: string;
+  /**
+   * Pre-rendered category sections for commit-based entries (no PR numbers).
+   * Used only when the PR pipeline yields nothing, so a release body can never
+   * collapse to the npm line plus a compare link.
+   */
+  commitFallbackNotes?: string;
   compareFrom?: string | null;
   compareTo?: string;
   repository?: string;
@@ -493,6 +596,12 @@ export function renderReleaseNotes(input: {
     }
     parts.push(lines.join("\n"));
   }
+
+  // Commit fallback: only when the PR pipeline produced no category content at
+  // all. Its sections are already rendered, so they are appended verbatim.
+  const renderedAnyPrSection = parts.length > (npmMetadata ? 1 : 0);
+  const commitFallback = (input.commitFallbackNotes ?? "").trim();
+  if (!renderedAnyPrSection && commitFallback) parts.push(commitFallback);
 
   const allPrs = [...categories.values()].flat().sort((a, b) => a.number - b.number);
   const from = input.compareFrom?.trim();
@@ -734,6 +843,13 @@ async function main(argv: string[]): Promise<void> {
     process.exit(hasMeaningfulCarriedNotes(stripped) ? 0 : 1);
   }
 
+  if (cmd === "commit-fallback") {
+    // stdin: `git log --format=%H%x1f%s%x1f%an <range>` output.
+    const rendered = renderCommitFallbackNotes(parseCommitLog(await readStdinOrFile(rest[0])));
+    process.stdout.write(rendered);
+    return;
+  }
+
   if (cmd === "join-carried") {
     let out: string | undefined;
     const files: string[] = [];
@@ -888,6 +1004,7 @@ async function main(argv: string[]): Promise<void> {
       "out",
       "carried",
       "delta",
+      "commit-fallback",
       "compare-from",
       "compare-to",
       "repository",
@@ -909,6 +1026,7 @@ async function main(argv: string[]): Promise<void> {
       npmMetadata,
       carriedPreviewNotes: await readOptional("carried"),
       deltaPrNotes: await readOptional("delta"),
+      commitFallbackNotes: await readOptional("commit-fallback"),
       compareFrom: args.get("compare-from") ?? null,
       compareTo: args.get("compare-to"),
       repository: args.get("repository"),
@@ -972,6 +1090,7 @@ async function main(argv: string[]): Promise<void> {
 Usage:
   bun scripts/release-notes.ts strip-carried [body-file]
   bun scripts/release-notes.ts has-meaningful [body-file]
+  bun scripts/release-notes.ts commit-fallback [commit-log-file]
   bun scripts/release-notes.ts join-carried --out <file> <part-file>...
   bun scripts/release-notes.ts matching-preview-tag <version>   # tags on stdin
   bun scripts/release-notes.ts matching-preview-tags <version>  # tags on stdin, oldest→newest

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -213,8 +213,29 @@ const COMMIT_TYPE_CATEGORY: Record<string, string> = {
 export function isReleasePlumbingCommit(subject: string): boolean {
   const text = subject.trim();
   if (/^Merge\s/i.test(text)) return true;
-  if (/^release:\s/i.test(text)) return true;
+  // Real two-parent merges in this repo also use a `merge:` conventional prefix.
+  if (/^merge(?:\([^)]*\))?!?:\s/i.test(text)) return true;
+  if (/^release(?:\([^)]*\))?!?:\s/i.test(text)) return true;
   return false;
+}
+
+/**
+ * Neutralize Markdown and mention syntax from untrusted commit text before it
+ * lands in a release body. Commit subjects and author names are attacker- or
+ * accident-controlled: a bare `@name` renders as a real GitHub mention (and
+ * notifies that account), and backticks/brackets can restructure the notes.
+ */
+export function sanitizeCommitText(text: string): string {
+  return text
+    .replace(/\r?\n/g, " ")
+    // Strip the ASCII unit separator so a subject can never forge a log field.
+    .replace(/\u001f/g, " ")
+    .replace(/[`<>|]/g, "")
+    .replace(/([[\]])/g, "\\$1")
+    // `@name` -> `@\u200bname`: reads identically, never notifies.
+    .replace(/@(?=[A-Za-z0-9_-])/g, "@\u200b")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 /**
@@ -242,14 +263,21 @@ export function renderCommitFallbackNotes(commits: ReleaseNoteCommit[]): string 
     if (isReleasePlumbingCommit(subject)) continue;
     const match = /^([a-zA-Z]+)(?:\(([^)]*)\))?!?:\s*(.+)$/.exec(subject);
     const type = match?.[1]?.toLowerCase();
-    const scope = match?.[2]?.trim();
-    const summary = (match?.[3] ?? subject).trim();
+    const scope = sanitizeCommitText(match?.[2] ?? "");
+    const summary = sanitizeCommitText(match?.[3] ?? subject);
+    if (!summary) continue;
     const category = (type && COMMIT_TYPE_CATEGORY[type]) ?? "Other Changes";
-    const shortSha = commit.sha.trim().slice(0, 9);
+    // Hex-only short hash: a crafted `sha` field can never inject markup.
+    const shortSha = /^[0-9a-f]{7,40}$/i.test(commit.sha.trim())
+      ? commit.sha.trim().slice(0, 9)
+      : "";
     const scopePrefix = scope ? `${scope}: ` : "";
-    const author = commit.author.trim();
-    const credit = author ? ` @${author}` : "";
-    const line = `- ${scopePrefix}${summary} (${shortSha})${credit}`;
+    // `%an` is a free-form Git display name, not a GitHub login, so it is
+    // rendered as plain text rather than an @mention that would notify a
+    // same-named (or non-existent) account.
+    const author = sanitizeCommitText(commit.author).replace(/^@\u200b/, "");
+    const trailer = [shortSha, author].filter(Boolean).join(", ");
+    const line = trailer ? `- ${scopePrefix}${summary} (${trailer})` : `- ${scopePrefix}${summary}`;
     const existing = buckets.get(category);
     if (existing) existing.push(line);
     else buckets.set(category, [line]);
@@ -264,14 +292,64 @@ export function renderCommitFallbackNotes(commits: ReleaseNoteCommit[]): string 
   return parts.join("\n\n").replace(/\n+$/, "") + "\n";
 }
 
-/** Parse `git log --format=%H%x1f%s%x1f%an` output into commits. */
+/**
+ * Extract commit-style category sections (bullets with no `(#N)` reference)
+ * from an already-rendered body.
+ *
+ * A preview release whose notes came from the commit fallback carries bullets
+ * like `- gui: fix a thing (abc1234, Name)`. Those are meaningful prose, so the
+ * workflow keeps them as carried notes and skips regenerating a fallback — but
+ * the PR renderer only retains entries carrying a PR number, so without this
+ * the stable release would silently collapse back to the npm-line stub.
+ */
+export function extractCommitBulletSections(body: string): string {
+  const out: string[] = [];
+  let current: { title: string; lines: string[] } | null = null;
+  const flush = (): void => {
+    if (current && current.lines.length > 0) {
+      out.push([`## ${current.title}`, "", ...current.lines].join("\n"));
+    }
+    current = null;
+  };
+  for (const rawLine of body.replace(/\r\n/g, "\n").split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("<!--")) continue;
+    if (line.startsWith("## ") || line.startsWith("### ")) {
+      flush();
+      const title = line.replace(/^#{2,3}\s+/, "").trim();
+      if (!SCAFFOLD_HEADINGS.has(title)) current = { title, lines: [] };
+      continue;
+    }
+    if (!current) continue;
+    if (!line.startsWith("- ")) continue;
+    // Anything carrying a PR reference belongs to the PR pipeline, not here.
+    if (/\(#\d+(?:\s*,\s*#\d+)*\)\s*$/.test(line)) continue;
+    if (/^-\s+#\d+\s/.test(line)) continue;
+    current.lines.push(line);
+  }
+  flush();
+  return out.join("\n\n").replace(/\n+$/, "") + (out.length > 0 ? "\n" : "");
+}
+
+/**
+ * Parse `git log --format=%H%x1f%s%x1f%an` output into commits.
+ *
+ * Fields are split from the LEFT for the hash and from the RIGHT for the
+ * author, so a subject containing the separator byte cannot shift the author
+ * field (the subject keeps the remainder). `sanitizeCommitText` strips any
+ * stray separator at render time.
+ */
 export function parseCommitLog(raw: string): ReleaseNoteCommit[] {
   const commits: ReleaseNoteCommit[] = [];
   for (const line of raw.replace(/\r\n/g, "\n").split("\n")) {
     if (!line.trim()) continue;
-    const [sha, subject, author] = line.split("\u001f");
-    if (!sha || !subject) continue;
-    commits.push({ sha, subject, author: author ?? "" });
+    const parts = line.split("\u001f");
+    if (parts.length < 2) continue;
+    const sha = parts[0]!;
+    const author = parts.length >= 3 ? parts[parts.length - 1]! : "";
+    const subject = (parts.length >= 3 ? parts.slice(1, -1).join("\u001f") : parts[1]!);
+    if (!sha.trim() || !subject.trim()) continue;
+    commits.push({ sha, subject, author });
   }
   return commits;
 }
@@ -600,8 +678,13 @@ export function renderReleaseNotes(input: {
   // Commit fallback: only when the PR pipeline produced no category content at
   // all. Its sections are already rendered, so they are appended verbatim.
   const renderedAnyPrSection = parts.length > (npmMetadata ? 1 : 0);
-  const commitFallback = (input.commitFallbackNotes ?? "").trim();
-  if (!renderedAnyPrSection && commitFallback) parts.push(commitFallback);
+  if (!renderedAnyPrSection) {
+    // Carried commit bullets first (older preview work), then this range's own.
+    const carriedCommitSections = extractCommitBulletSections(input.carriedPreviewNotes ?? "").trim();
+    const commitFallback = (input.commitFallbackNotes ?? "").trim();
+    const merged = [carriedCommitSections, commitFallback].filter(Boolean).join("\n\n");
+    if (merged) parts.push(merged);
+  }
 
   const allPrs = [...categories.values()].flat().sort((a, b) => a.number - b.number);
   const from = input.compareFrom?.trim();

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -340,6 +340,42 @@ export function extractCommitBulletSections(body: string): string {
  * record is read as exactly three fields; anything longer is a malformed record
  * and is skipped rather than silently reinterpreted.
  */
+export function mergeCommitBulletSections(bodies: string[]): string {
+  const buckets = new Map<string, string[]>();
+  const seen = new Set<string>();
+  for (const body of bodies) {
+    let current: string | null = null;
+    for (const rawLine of (body ?? "").replace(/\r\n/g, "\n").split("\n")) {
+      const line = rawLine.trim();
+      if (!line) continue;
+      if (line.startsWith("## ") || line.startsWith("### ")) {
+        current = line.replace(/^#{2,3}\s+/, "").trim();
+        if (!buckets.has(current)) buckets.set(current, []);
+        continue;
+      }
+      if (!current || !line.startsWith("- ")) continue;
+      const key = `${current}\u0000${line}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      buckets.get(current)!.push(line);
+    }
+  }
+  const titles = [...buckets.keys()].sort((x, y) => {
+    const ix = RENDER_CATEGORY_ORDER.indexOf(x);
+    const iy = RENDER_CATEGORY_ORDER.indexOf(y);
+    const rx = ix === -1 ? RENDER_CATEGORY_ORDER.length : ix;
+    const ry = iy === -1 ? RENDER_CATEGORY_ORDER.length : iy;
+    return rx - ry;
+  });
+  const merged: string[] = [];
+  for (const title of titles) {
+    const lines = buckets.get(title)!;
+    if (lines.length === 0) continue;
+    merged.push([`## ${title}`, "", ...lines].join("\n"));
+  }
+  return merged.join("\n\n").trim();
+}
+
 export function parseCommitLog(raw: string): ReleaseNoteCommit[] {
   const commits: ReleaseNoteCommit[] = [];
   const fields = raw.split("\u0000");
@@ -681,9 +717,12 @@ export function renderReleaseNotes(input: {
   const renderedAnyPrSection = parts.length > (npmMetadata ? 1 : 0);
   if (!renderedAnyPrSection) {
     // Carried commit bullets first (older preview work), then this range's own.
-    const carriedCommitSections = extractCommitBulletSections(input.carriedPreviewNotes ?? "").trim();
-    const commitFallback = (input.commitFallbackNotes ?? "").trim();
-    const merged = [carriedCommitSections, commitFallback].filter(Boolean).join("\n\n");
+    // They are merged BY CATEGORY: concatenating two rendered bodies would emit
+    // `## Bug Fixes` twice when both halves touched the same category.
+    const merged = mergeCommitBulletSections([
+      extractCommitBulletSections(input.carriedPreviewNotes ?? ""),
+      input.commitFallbackNotes ?? "",
+    ]);
     if (merged) parts.push(merged);
   }
 

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -229,9 +229,9 @@ export function sanitizeCommitText(text: string): string {
   return text
     .replace(/\r?\n/g, " ")
     // Strip the ASCII unit separator so a subject can never forge a log field.
-    .replace(/\u001f/g, " ")
-    .replace(/[`<>|]/g, "")
-    .replace(/([[\]])/g, "\\$1")
+    .replace(/[\u0000\u001f]/g, " ")
+    // Escape rather than delete: `Map<K, V> | CLI` must stay readable.
+    .replace(/([`<>|[\]\\])/g, "\\$1")
     // `@name` -> `@\u200bname`: reads identically, never notifies.
     .replace(/@(?=[A-Za-z0-9_-])/g, "@\u200b")
     .replace(/\s+/g, " ")
@@ -332,23 +332,24 @@ export function extractCommitBulletSections(body: string): string {
 }
 
 /**
- * Parse `git log --format=%H%x1f%s%x1f%an` output into commits.
+ * Parse `git log -z --format=%H%x00%s%x00%an` output into commits.
  *
- * Fields are split from the LEFT for the hash and from the RIGHT for the
- * author, so a subject containing the separator byte cannot shift the author
- * field (the subject keeps the remainder). `sanitizeCommitText` strips any
- * stray separator at render time.
+ * Records are NUL-delimited and fields are NUL-separated. Git forbids NUL in
+ * commit content, so — unlike the unit separator, which Git happily accepts in
+ * both subjects and author names — no field value can forge a boundary. Every
+ * record is read as exactly three fields; anything longer is a malformed record
+ * and is skipped rather than silently reinterpreted.
  */
 export function parseCommitLog(raw: string): ReleaseNoteCommit[] {
   const commits: ReleaseNoteCommit[] = [];
-  for (const line of raw.replace(/\r\n/g, "\n").split("\n")) {
-    if (!line.trim()) continue;
-    const parts = line.split("\u001f");
-    if (parts.length < 2) continue;
-    const sha = parts[0]!;
-    const author = parts.length >= 3 ? parts[parts.length - 1]! : "";
-    const subject = (parts.length >= 3 ? parts.slice(1, -1).join("\u001f") : parts[1]!);
-    if (!sha.trim() || !subject.trim()) continue;
+  const fields = raw.split("\u0000");
+  // Trailing separator from `git log -z` leaves an empty final element.
+  if (fields.length > 0 && fields[fields.length - 1]!.trim() === "") fields.pop();
+  for (let i = 0; i + 2 < fields.length + 1; i += 3) {
+    const sha = (fields[i] ?? "").replace(/^\n+/, "").trim();
+    const subject = fields[i + 1] ?? "";
+    const author = fields[i + 2] ?? "";
+    if (!sha || !subject.trim()) continue;
     commits.push({ sha, subject, author });
   }
   return commits;

--- a/tests/release-notes.test.ts
+++ b/tests/release-notes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   cleanPrTitle,
   extractChangelogPrNumbers,
+  extractCommitBulletSections,
   extractPrNumbers,
   hasMeaningfulCarriedNotes,
   isReleasePlumbingCommit,
@@ -15,6 +16,7 @@ import {
   parseTakeoverSourcePr,
   previousReleaseNotesTag,
   renderCommitFallbackNotes,
+  sanitizeCommitText,
   renderReleaseNotes,
   rewriteTakeoverCredits,
   selectNewestCarriedPreviewTag,
@@ -37,6 +39,103 @@ describe("matchingPreviewTag", () => {
   test("returns null for preview versions and when no match exists", () => {
     expect(matchingPreviewTag("2.7.39-preview.1", ["v2.7.39-preview.1"])).toBeNull();
     expect(matchingPreviewTag("2.7.41", ["v2.7.40-preview.20260725"])).toBeNull();
+  });
+});
+
+describe("commit fallback: untrusted-input and carry hardening", () => {
+  const log = (s: string) => parseCommitLog(s);
+
+  test("git author display names never render as GitHub mentions", () => {
+    // %an is a free-form display name; "@Abhishek" would notify an unrelated account.
+    const out = renderCommitFallbackNotes(log("aaaaaaaaaaaa1fix(x): a fixAbhishek Sharma"));
+    expect(out).toContain("Abhishek Sharma");
+    expect(out).not.toMatch(/@Abhishek/);
+  });
+
+  test("mentions inside commit subjects are neutralized but stay readable", () => {
+    const out = renderCommitFallbackNotes(log("aaaaaaaaaaaa1fix(x): thanks @octocatdev"));
+    expect(out).not.toMatch(/@octocat/);
+    expect(out).toContain("octocat");
+  });
+
+  test("markdown metacharacters cannot restructure the release body", () => {
+    const subject = "fix(x): drop " + String.fromCharCode(96) + "code" + String.fromCharCode(96) + " and <b>tags</b>";
+    const out = renderCommitFallbackNotes(log("aaaaaaaaaaaa1" + subject + "dev"));
+    expect(out).not.toContain(String.fromCharCode(96));
+    expect(out).not.toContain("<b>");
+  });
+
+  test("sanitizeCommitText collapses newlines and strips the separator byte", () => {
+    expect(sanitizeCommitText("a\nb")).toBe("a b");
+    expect(sanitizeCommitText("a" + String.fromCharCode(31) + "b")).toBe("a b");
+  });
+
+  test("a separator byte inside a subject cannot shift the author field", () => {
+    const commits = log("aaaaaaaaaaaa1subjectwith seprealauthor");
+    expect(commits).toHaveLength(1);
+    expect(commits[0]!.author).toBe("realauthor");
+    expect(commits[0]!.subject).toContain("subject");
+    expect(commits[0]!.subject).toContain("with sep");
+  });
+
+  test("a non-hex sha is dropped rather than rendered", () => {
+    const out = renderCommitFallbackNotes([{ sha: "not-a-sha](evil)", subject: "fix(x): y", author: "dev" }]);
+    expect(out).not.toContain("evil");
+    expect(out).toContain("- x: y");
+  });
+
+  test("conventional merge: commits are plumbing too", () => {
+    expect(isReleasePlumbingCommit("merge: bring dev into main")).toBe(true);
+    expect(isReleasePlumbingCommit("merge(dev): sync")).toBe(true);
+    expect(renderCommitFallbackNotes(log("aaaaaaaaaaaa1merge: bring dev into maindev"))).toBe("");
+  });
+
+  test("preview fallback notes survive the carry into a stable release", () => {
+    // Guards the blocker: a preview body built by the fallback is "meaningful",
+    // so the workflow carries it and skips regenerating — and the PR renderer
+    // would otherwise discard every non-PR bullet, collapsing back to the stub.
+    const previewBody = "## Bug Fixes\n\n- gui: fix a thing (abc1234, Some Name)\n";
+    const rendered = renderReleaseNotes({
+      npmMetadata: "npm line.",
+      carriedPreviewNotes: previewBody,
+      deltaPrNotes: "",
+      compareFrom: "v1.0.0",
+      compareTo: "v1.1.0",
+      repository: "o/n",
+    });
+    expect(rendered).toContain("## Bug Fixes");
+    expect(rendered).toContain("gui: fix a thing (abc1234, Some Name)");
+  });
+
+  test("extractCommitBulletSections keeps only PR-free bullets", () => {
+    const body = [
+      "## Bug Fixes",
+      "",
+      "- gui: commit style (abc1234, Name)",
+      "- pr style (#42)",
+      "",
+      "## Changelog",
+      "",
+      "- #42 pr style @dev",
+    ].join("\n");
+    const out = extractCommitBulletSections(body);
+    expect(out).toContain("gui: commit style");
+    expect(out).not.toContain("#42");
+    expect(out).not.toContain("Changelog");
+  });
+
+  test("carried PR sections still win over carried commit bullets", () => {
+    const previewBody = "## Bug Fixes\n\n- real pr work (#7)\n\n## Changelog\n\n- #7 real pr work @dev\n";
+    const rendered = renderReleaseNotes({
+      npmMetadata: "npm line.",
+      carriedPreviewNotes: previewBody,
+      commitFallbackNotes: "## Chores\n\n- noise: should not appear (abc1234, Name)\n",
+      compareFrom: "v1.0.0",
+      compareTo: "v1.1.0",
+      repository: "o/n",
+    });
+    expect(rendered).toContain("#7");
+    expect(rendered).not.toContain("should not appear");
   });
 });
 
@@ -727,13 +826,13 @@ describe("commit-based changelog fallback", () => {
   test("conventional prefixes map onto the release.yml categories", () => {
     const out = renderCommitFallbackNotes(parseCommitLog(log));
     expect(out).toContain("## New Features");
-    expect(out).toContain("- gui: add a quota badge (aaaaaaaaa) @alice");
+    expect(out).toContain("- gui: add a quota badge (aaaaaaaaa, alice)");
     expect(out).toContain("## Bug Fixes");
-    expect(out).toContain("- codex: stop a launcher crash (#1625) (bbbbbbbbb) @bob");
+    expect(out).toContain("- codex: stop a launcher crash (#1625) (bbbbbbbbb, bob)");
     expect(out).toContain("## Documentation");
     expect(out).toContain("## Chores");
     expect(out).toContain("## Other Changes");
-    expect(out).toContain("- just a bare subject (eeeeeeeee) @eve");
+    expect(out).toContain("- just a bare subject (eeeeeeeee, eve)");
   });
 
   test("categories render in the canonical order", () => {

--- a/tests/release-notes.test.ts
+++ b/tests/release-notes.test.ts
@@ -4,14 +4,17 @@ import {
   extractChangelogPrNumbers,
   extractPrNumbers,
   hasMeaningfulCarriedNotes,
+  isReleasePlumbingCommit,
   isPolishBaseUrlAllowed,
   joinCarriedPreviewNotes,
   matchingPreviewTag,
   matchingPreviewTags,
+  parseCommitLog,
   parseGeneratedNotes,
   parseSectionHeadings,
   parseTakeoverSourcePr,
   previousReleaseNotesTag,
+  renderCommitFallbackNotes,
   renderReleaseNotes,
   rewriteTakeoverCredits,
   selectNewestCarriedPreviewTag,
@@ -694,5 +697,110 @@ describe("polish validation", () => {
     const errors = validatePolishedSections(out, [653, 744, 853], ["New Features", "Bug Fixes"]);
     expect(errors).toContain("missing headings: Bug Fixes");
     expect(errors).toContain("unexpected headings: Internal");
+  });
+});
+
+describe("commit-based changelog fallback", () => {
+  const log = [
+    "aaaaaaaaaaaa1\u001ffeat(gui): add a quota badge\u001falice",
+    "bbbbbbbbbbbb2\u001ffix(codex): stop a launcher crash (#1625)\u001fbob",
+    "cccccccccccc3\u001fdocs(devlog): record the release train\u001fcarol",
+    "dddddddddddd4\u001fchore(ci): prune stale workflows\u001fdave",
+    "eeeeeeeeeeee5\u001fjust a bare subject\u001feve",
+    "ffffffffffff6\u001fMerge dev into main: v9.9.9 release\u001fmallory",
+    "gggggggggggg7\u001frelease: v9.9.9\u001ftrent",
+  ].join("\n");
+
+  test("parseCommitLog reads the unit-separated git log format", () => {
+    const commits = parseCommitLog(log);
+    expect(commits).toHaveLength(7);
+    expect(commits[0]).toEqual({ sha: "aaaaaaaaaaaa1", subject: "feat(gui): add a quota badge", author: "alice" });
+  });
+
+  test("parseCommitLog ignores blank and malformed lines", () => {
+    expect(parseCommitLog("")).toEqual([]);
+    expect(parseCommitLog("\n\n")).toEqual([]);
+    // A hash with no subject carries no changelog value.
+    expect(parseCommitLog("abc123")).toEqual([]);
+  });
+
+  test("conventional prefixes map onto the release.yml categories", () => {
+    const out = renderCommitFallbackNotes(parseCommitLog(log));
+    expect(out).toContain("## New Features");
+    expect(out).toContain("- gui: add a quota badge (aaaaaaaaa) @alice");
+    expect(out).toContain("## Bug Fixes");
+    expect(out).toContain("- codex: stop a launcher crash (#1625) (bbbbbbbbb) @bob");
+    expect(out).toContain("## Documentation");
+    expect(out).toContain("## Chores");
+    expect(out).toContain("## Other Changes");
+    expect(out).toContain("- just a bare subject (eeeeeeeee) @eve");
+  });
+
+  test("categories render in the canonical order", () => {
+    const out = renderCommitFallbackNotes(parseCommitLog(log));
+    const order = ["## New Features", "## Bug Fixes", "## Documentation", "## Chores", "## Other Changes"]
+      .map(heading => out.indexOf(heading));
+    expect(order).toEqual([...order].sort((a, b) => a - b));
+    expect(order.every(index => index >= 0)).toBe(true);
+  });
+
+  test("merge commits and release bumps are excluded", () => {
+    const out = renderCommitFallbackNotes(parseCommitLog(log));
+    expect(out).not.toContain("Merge dev into main");
+    expect(out).not.toContain("release: v9.9.9");
+    expect(isReleasePlumbingCommit("Merge pull request #1 from x/y")).toBe(true);
+    expect(isReleasePlumbingCommit("release: v2.20.0")).toBe(true);
+    expect(isReleasePlumbingCommit("fix(codex): a real fix")).toBe(false);
+  });
+
+  test("a range with only plumbing commits renders nothing, so the caller keeps minimal notes", () => {
+    const plumbingOnly = [
+      "ffffffffffff6\u001fMerge dev into main: v9.9.9 release\u001fmallory",
+      "gggggggggggg7\u001frelease: v9.9.9\u001ftrent",
+    ].join("\n");
+    const out = renderCommitFallbackNotes(parseCommitLog(plumbingOnly));
+    expect(out).toBe("");
+    expect(hasMeaningfulCarriedNotes(out)).toBe(false);
+  });
+
+  test("no commits at all renders nothing", () => {
+    expect(renderCommitFallbackNotes([])).toBe("");
+  });
+
+  test("real PR sections win; the commit fallback is not appended alongside them", () => {
+    const rendered = renderReleaseNotes({
+      npmMetadata: "npm line.",
+      deltaPrNotes: "## Bug Fixes\n\n* fix a thing by @dev in https://github.com/o/n/pull/42\n",
+      commitFallbackNotes: renderCommitFallbackNotes(parseCommitLog(log)),
+      compareFrom: "v9.9.8",
+      compareTo: "v9.9.9",
+      repository: "owner/name",
+    });
+    expect(rendered).toContain("#42");
+    expect(rendered).not.toContain("@alice");
+    expect(rendered).not.toContain("aaaaaaaaa");
+  });
+
+  test("the fallback output is meaningful, which is the workflow's switch condition", () => {
+    // The workflow calls has-meaningful on the generate-notes body; when that is
+    // empty it renders the commit fallback and checks the same predicate again.
+    const emptyGenerateNotes = "<!-- Release notes generated using configuration in .github/release.yml at v9.9.9 -->\n\n\n";
+    expect(hasMeaningfulCarriedNotes(emptyGenerateNotes)).toBe(false);
+    expect(hasMeaningfulCarriedNotes(renderCommitFallbackNotes(parseCommitLog(log)))).toBe(true);
+  });
+
+  test("fallback sections flow through the real renderer into a non-empty body", () => {
+    // The whole point: an empty generate-notes delta must still produce a body
+    // with categorized content rather than the npm line plus a compare link.
+    const rendered = renderReleaseNotes({
+      npmMetadata: "Published to npm as \`pkg@9.9.9\` with dist-tag \`latest\`.",
+      commitFallbackNotes: renderCommitFallbackNotes(parseCommitLog(log)),
+      compareFrom: "v9.9.8",
+      compareTo: "v9.9.9",
+      repository: "owner/name",
+    });
+    expect(rendered).toContain("## New Features");
+    expect(rendered).toContain("## Bug Fixes");
+    expect(rendered.length).toBeGreaterThan(400);
   });
 });

--- a/tests/release-notes.test.ts
+++ b/tests/release-notes.test.ts
@@ -47,20 +47,20 @@ describe("commit fallback: untrusted-input and carry hardening", () => {
 
   test("git author display names never render as GitHub mentions", () => {
     // %an is a free-form display name; "@Abhishek" would notify an unrelated account.
-    const out = renderCommitFallbackNotes(log("aaaaaaaaaaaa1fix(x): a fixAbhishek Sharma"));
+    const out = renderCommitFallbackNotes(log("aaaaaaaaaaaa1\u0000fix(x): a fix\u0000Abhishek Sharma"));
     expect(out).toContain("Abhishek Sharma");
     expect(out).not.toMatch(/@Abhishek/);
   });
 
   test("mentions inside commit subjects are neutralized but stay readable", () => {
-    const out = renderCommitFallbackNotes(log("aaaaaaaaaaaa1fix(x): thanks @octocatdev"));
+    const out = renderCommitFallbackNotes(log("aaaaaaaaaaaa1\u0000fix(x): thanks @octocat\u0000dev"));
     expect(out).not.toMatch(/@octocat/);
     expect(out).toContain("octocat");
   });
 
   test("markdown metacharacters cannot restructure the release body", () => {
     const subject = "fix(x): drop " + String.fromCharCode(96) + "code" + String.fromCharCode(96) + " and <b>tags</b>";
-    const out = renderCommitFallbackNotes(log("aaaaaaaaaaaa1" + subject + "dev"));
+    const out = renderCommitFallbackNotes(log("aaaaaaaaaaaa1\\u001f" + subject + "\\u001fdev"));
     expect(out).not.toContain(String.fromCharCode(96));
     expect(out).not.toContain("<b>");
   });
@@ -70,12 +70,14 @@ describe("commit fallback: untrusted-input and carry hardening", () => {
     expect(sanitizeCommitText("a" + String.fromCharCode(31) + "b")).toBe("a b");
   });
 
-  test("a separator byte inside a subject cannot shift the author field", () => {
-    const commits = log("aaaaaaaaaaaa1subjectwith seprealauthor");
+  test("a unit separator in subject OR author cannot forge a field boundary", () => {
+    // Git accepts U+001F in both subjects and author names, so the old framing
+    // was ambiguous in both directions; NUL cannot appear in commit content.
+    const commits = log("aaaaaaaaaaaa1\u0000subject\u001fwith sep\u0000Mallory\u001fInjected");
     expect(commits).toHaveLength(1);
-    expect(commits[0]!.author).toBe("realauthor");
-    expect(commits[0]!.subject).toContain("subject");
-    expect(commits[0]!.subject).toContain("with sep");
+    expect(commits[0]!.subject).toBe("subject\u001fwith sep");
+    expect(commits[0]!.author).toBe("Mallory\u001fInjected");
+    expect(renderCommitFallbackNotes(commits)).not.toContain("\u001f");
   });
 
   test("a non-hex sha is dropped rather than rendered", () => {
@@ -87,7 +89,7 @@ describe("commit fallback: untrusted-input and carry hardening", () => {
   test("conventional merge: commits are plumbing too", () => {
     expect(isReleasePlumbingCommit("merge: bring dev into main")).toBe(true);
     expect(isReleasePlumbingCommit("merge(dev): sync")).toBe(true);
-    expect(renderCommitFallbackNotes(log("aaaaaaaaaaaa1merge: bring dev into maindev"))).toBe("");
+    expect(renderCommitFallbackNotes(log("aaaaaaaaaaaa1\\u001fmerge: bring dev into main\\u001fdev"))).toBe("");
   });
 
   test("preview fallback notes survive the carry into a stable release", () => {
@@ -801,16 +803,16 @@ describe("polish validation", () => {
 
 describe("commit-based changelog fallback", () => {
   const log = [
-    "aaaaaaaaaaaa1\u001ffeat(gui): add a quota badge\u001falice",
-    "bbbbbbbbbbbb2\u001ffix(codex): stop a launcher crash (#1625)\u001fbob",
-    "cccccccccccc3\u001fdocs(devlog): record the release train\u001fcarol",
-    "dddddddddddd4\u001fchore(ci): prune stale workflows\u001fdave",
-    "eeeeeeeeeeee5\u001fjust a bare subject\u001feve",
-    "ffffffffffff6\u001fMerge dev into main: v9.9.9 release\u001fmallory",
-    "gggggggggggg7\u001frelease: v9.9.9\u001ftrent",
-  ].join("\n");
+    "aaaaaaaaaaaa1\u0000feat(gui): add a quota badge\u0000alice",
+    "bbbbbbbbbbbb2\u0000fix(codex): stop a launcher crash (#1625)\u0000bob",
+    "cccccccccccc3\u0000docs(devlog): record the release train\u0000carol",
+    "dddddddddddd4\u0000chore(ci): prune stale workflows\u0000dave",
+    "eeeeeeeeeeee5\u0000just a bare subject\u0000eve",
+    "ffffffffffff6\u0000Merge dev into main: v9.9.9 release\u0000mallory",
+    "gggggggggggg7\u0000release: v9.9.9\u0000trent",
+  ].join("\u0000");
 
-  test("parseCommitLog reads the unit-separated git log format", () => {
+  test("parseCommitLog reads the NUL-separated git log format", () => {
     const commits = parseCommitLog(log);
     expect(commits).toHaveLength(7);
     expect(commits[0]).toEqual({ sha: "aaaaaaaaaaaa1", subject: "feat(gui): add a quota badge", author: "alice" });
@@ -854,9 +856,9 @@ describe("commit-based changelog fallback", () => {
 
   test("a range with only plumbing commits renders nothing, so the caller keeps minimal notes", () => {
     const plumbingOnly = [
-      "ffffffffffff6\u001fMerge dev into main: v9.9.9 release\u001fmallory",
-      "gggggggggggg7\u001frelease: v9.9.9\u001ftrent",
-    ].join("\n");
+      "ffffffffffff6\u0000Merge dev into main: v9.9.9 release\u0000mallory",
+      "gggggggggggg7\u0000release: v9.9.9\u0000trent",
+    ].join("\u0000");
     const out = renderCommitFallbackNotes(parseCommitLog(plumbingOnly));
     expect(out).toBe("");
     expect(hasMeaningfulCarriedNotes(out)).toBe(false);

--- a/tests/release-notes.test.ts
+++ b/tests/release-notes.test.ts
@@ -3,6 +3,7 @@ import {
   cleanPrTitle,
   extractChangelogPrNumbers,
   extractCommitBulletSections,
+  mergeCommitBulletSections,
   extractPrNumbers,
   hasMeaningfulCarriedNotes,
   isReleasePlumbingCommit,
@@ -60,9 +61,14 @@ describe("commit fallback: untrusted-input and carry hardening", () => {
 
   test("markdown metacharacters cannot restructure the release body", () => {
     const subject = "fix(x): drop " + String.fromCharCode(96) + "code" + String.fromCharCode(96) + " and <b>tags</b>";
-    const out = renderCommitFallbackNotes(log("aaaaaaaaaaaa1\\u001f" + subject + "\\u001fdev"));
-    expect(out).not.toContain(String.fromCharCode(96));
-    expect(out).not.toContain("<b>");
+    const NUL = String.fromCharCode(0);
+    const out = renderCommitFallbackNotes(log("aaaaaaaaaaaa1" + NUL + subject + NUL + "dev"));
+    // Non-vacuous: the entry must actually render.
+    expect(out).toContain("drop");
+    // Escaped, not deleted: technical text survives but cannot restructure the body.
+    expect(out).toContain("\\" + String.fromCharCode(96) + "code");
+    expect(out).toContain("\\<b\\>");
+    expect(out).not.toMatch(/(^|[^\\])<b>/);
   });
 
   test("sanitizeCommitText collapses newlines and strips the separator byte", () => {
@@ -89,7 +95,10 @@ describe("commit fallback: untrusted-input and carry hardening", () => {
   test("conventional merge: commits are plumbing too", () => {
     expect(isReleasePlumbingCommit("merge: bring dev into main")).toBe(true);
     expect(isReleasePlumbingCommit("merge(dev): sync")).toBe(true);
-    expect(renderCommitFallbackNotes(log("aaaaaaaaaaaa1\\u001fmerge: bring dev into main\\u001fdev"))).toBe("");
+    const NUL = String.fromCharCode(0);
+    // Non-vacuous: an ordinary commit in the same shape does render.
+    expect(renderCommitFallbackNotes(log("aaaaaaaaaaaa1" + NUL + "fix(x): real" + NUL + "dev"))).toContain("real");
+    expect(renderCommitFallbackNotes(log("aaaaaaaaaaaa1" + NUL + "merge: bring dev into main" + NUL + "dev"))).toBe("");
   });
 
   test("preview fallback notes survive the carry into a stable release", () => {
@@ -124,6 +133,30 @@ describe("commit fallback: untrusted-input and carry hardening", () => {
     expect(out).toContain("gui: commit style");
     expect(out).not.toContain("#42");
     expect(out).not.toContain("Changelog");
+  });
+
+  test("carried and current fallback bullets merge under one heading per category", () => {
+    const rendered = renderReleaseNotes({
+      npmMetadata: "npm line.",
+      carriedPreviewNotes: "## Bug Fixes\n\n- carried one (aaa1234, N)\n",
+      commitFallbackNotes: "## Bug Fixes\n\n- current one (bbb1234, M)\n\n## Chores\n\n- chore one (ccc1234, O)\n",
+      compareFrom: "v1.0.0",
+      compareTo: "v1.1.0",
+      repository: "o/n",
+    });
+    expect(rendered).toContain("carried one");
+    expect(rendered).toContain("current one");
+    expect(rendered).toContain("chore one");
+    expect((rendered.match(/## Bug Fixes/g) ?? [])).toHaveLength(1);
+  });
+
+  test("mergeCommitBulletSections drops duplicate bullets", () => {
+    const merged = mergeCommitBulletSections([
+      "## Bug Fixes\n\n- same (aaa1234, N)\n",
+      "## Bug Fixes\n\n- same (aaa1234, N)\n- other (bbb1234, M)\n",
+    ]);
+    expect((merged.match(/- same/g) ?? [])).toHaveLength(1);
+    expect(merged).toContain("- other");
   });
 
   test("carried PR sections still win over carried commit bullets", () => {


### PR DESCRIPTION
## Summary

Release bodies for v2.18.2 and v2.19.0 shipped as a 169-character stub - just the npm line and a compare link. Root cause: the releases/generate-notes API aggregates MERGED PULL REQUESTS over the compared tag range, and recent ranges have almost none, because work lands as direct commits on dev (or through PRs based on dev rather than the release branch). Measured on the live repo: v2.17.0..v2.18.2 = 0 of 36 commits PR-associated, v2.18.2..v2.19.0 = 2 of 21.

This adds a commit-based fallback: when the PR delta yields no categories, the workflow renders the commit log instead, categorized by conventional-commit prefix, excluding merge and release-bump commits. Replaying the real v2.18.2..v2.19.0 range turns the 169-char stub into a 1.8 KB categorized changelog.

Hardening folded in from three adversarial review rounds:

- The commit log is NUL-framed (git log -z); Git forbids NUL in commit content, while U+001F is legal in both subjects and author names and could otherwise forge a field boundary.
- Commit text is sanitized: the git author field is a free-form display name, so a contributor named e.g. "Abhishek Sharma" previously rendered as a live at-mention. Authors now render as plain text in a (sha, Name) trailer, and Markdown metacharacters are backslash-escaped rather than deleted so technical text stays readable.
- Fallback generation depends on this range's PR delta only. Gating on carried notes too would silently drop every post-preview direct commit.
- Carried commit bullets survive the preview to stable carry, and carried plus current sections merge by category so a shared heading is not emitted twice.

## Verification

- bun test tests/release-notes.test.ts: 70 pass / 0 fail (16 new regression tests).
- Remote full gates on ssh lidge @ cfee2d2c9: 12371 pass / 11 skip / 0 fail (12382 tests, 786 files); typecheck, privacy:scan, lint:gui green.
- End-to-end replay against the real empty range reproduces the failure and the fix.

## Checklist

- [x] Targets dev
- [x] Release-automation change - flagged for maintainer security review per MAINTAINERS.md
- [x] Regression tests included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release notes now include eligible commit-based entries when no meaningful pull request categories are available.
  * Commit entries are organized into familiar release categories and merged with carried-forward notes.
* **Improvements**
  * Duplicate entries are removed, release-plumbing changes are excluded, and commit text is cleaned for readability.
  * Pull request release notes continue to take precedence when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->