### PR TITLE
fix(google): allow opting out of the direct Gemini -tiered wire rename

### DIFF
--- a/docs-site/src/content/docs/reference/configuration/providers.md
+++ b/docs-site/src/content/docs/reference/configuration/providers.md
@@ -121,6 +121,7 @@ differing backup and rewrites known legacy namespaced selected ids to bare ids.
 | `escapeBuiltinToolNames?` | `boolean` | Escape built-in tool names for Anthropic-compatible gateways and restore them in returned calls. |
 | `anthropicEofTolerance?` | `boolean` | Let an Anthropic-compatible gateway complete a stream that ends before `message_stop`, only when visible text or a complete JSON-object tool input was received. Off by default. |
 | `googleMode?` | `"ai-studio" \| "vertex" \| "cloud-code-assist"` | Google transport/auth mode. Default `ai-studio`. |
+| `directGeminiWireRenames?` | `boolean` | Google only. When `false`, the AI Studio (direct) path sends Gemini Flash ids to the wire unchanged instead of applying the `-tiered` suffix (`gemini-3.7-flash` -> `gemini-3.7-flash-tiered`). Defaults to the rename; set `false` when the configured upstream still serves the bare ids. |
 | `project?` | `string` | Vertex or Antigravity Cloud Code Assist project id. |
 | `location?` | `string` | Vertex location; environment fallback is `GOOGLE_CLOUD_LOCATION`. |
 | `mcpServers?` | `Record<string, CursorMcpServerConfig>` | Cursor only: stdio or Streamable HTTP MCP servers. |

--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -370,7 +370,9 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
             parsed.modelId,
             mapReasoningEffort(provider, parsed.modelId, parsed.options.reasoning),
           ).wireModelId
-        : resolveDirectGeminiWireModelId(parsed.modelId, provider.directGeminiWireRenames !== false);
+        : provider.googleMode === "vertex"
+          ? parsed.modelId
+          : resolveDirectGeminiWireModelId(parsed.modelId, provider.directGeminiWireRenames !== false);
       const { systemInstruction, contents } = messagesToGeminiFormat(parsed, routedModelId);
       const tools = toolsToGeminiFormat(parsed);
 

--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -46,19 +46,17 @@ const GOOGLE_BREVITY_INSTRUCTION = [
 ].join("\n");
 
 /**
- * Google renamed the current Gemini Flash generations on the Generative Language API,
- * appending a `-tiered` suffix (`gemini-3.7-flash` -> `gemini-3.7-flash-tiered`). The
- * old `gemini-3.7-flash` path 404s, so a saved config or registry entry naming the base
- * id must be resolved here before it reaches the URL. The user-facing id is deliberately
- * left alone: the picker, the catalog, the usage log and the price overlays all stay
- * keyed on the base id, and only the wire path learns the new spelling.
+ * Some Google direct deployments expose current Gemini Flash generations with a `-tiered`
+ * wire suffix (`gemini-3.7-flash` -> `gemini-3.7-flash-tiered`). Keep the picker-visible id
+ * stable and make the mapping configurable for deployments that still serve the bare id.
  */
 const GEMINI_DIRECT_WIRE_RENAMES: Record<string, string> = {
   "gemini-3.7-flash": "gemini-3.7-flash-tiered",
   "gemini-3.6-flash": "gemini-3.6-flash-tiered",
 };
 
-function resolveDirectGeminiWireModelId(modelId: string): string {
+function resolveDirectGeminiWireModelId(modelId: string, applyRenames: boolean): string {
+  if (!applyRenames) return modelId;
   return Object.hasOwn(GEMINI_DIRECT_WIRE_RENAMES, modelId)
     ? GEMINI_DIRECT_WIRE_RENAMES[modelId]!
     : modelId;
@@ -372,7 +370,7 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
             parsed.modelId,
             mapReasoningEffort(provider, parsed.modelId, parsed.options.reasoning),
           ).wireModelId
-        : resolveDirectGeminiWireModelId(parsed.modelId);
+        : resolveDirectGeminiWireModelId(parsed.modelId, provider.directGeminiWireRenames !== false);
       const { systemInstruction, contents } = messagesToGeminiFormat(parsed, routedModelId);
       const tools = toolsToGeminiFormat(parsed);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -734,6 +734,7 @@ const providerConfigSchema = z.object({
   modelSupportsServiceTier: z.record(z.string().min(1), z.boolean()).optional(),
   preserveResponsesReasoningContent: z.boolean().optional(),
   allowPrivateNetwork: z.boolean().optional(),
+  directGeminiWireRenames: z.boolean().optional(),
   noStructuredOutputModels: z.array(z.string().min(1))
     .transform(normalizeNonBlankStringArray)
     .optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1353,6 +1353,13 @@ export interface OcxProviderConfig {
    * link-local, or unique-local upstreams. Metadata endpoints remain blocked.
    */
   allowPrivateNetwork?: boolean;
+  /**
+   * Google only. When `false`, the AI Studio (direct) path sends Gemini Flash ids
+   * unchanged to the wire instead of applying the `-tiered` suffix (`gemini-3.7-flash`
+   * -> `gemini-3.7-flash-tiered`). Set this to `false` when the configured upstream still
+   * serves the bare ids. Absent (default) keeps the rename.
+   */
+  directGeminiWireRenames?: boolean;
   /** Keep provider settings on disk but exclude it from routing and model/catalog listings. */
   disabled?: boolean;
   /**

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -789,6 +789,38 @@ describe("opencodex config defaults", () => {
     expect(readConfigDiagnostics().error).toContain("responsesSnapshotRepair");
   });
 
+  test("direct Gemini wire rename opt-out is a boolean and round-trips", () => {
+    const base = {
+      port: 12345,
+      providers: {
+        google: {
+          adapter: "google",
+          baseUrl: "https://generativelanguage.googleapis.com",
+        },
+      },
+      defaultProvider: "google",
+    };
+    writeConfig({
+      ...base,
+      providers: {
+        google: { ...base.providers.google, directGeminiWireRenames: false },
+      },
+    });
+    const config = loadConfig();
+    expect(config.providers.google.directGeminiWireRenames).toBe(false);
+    saveConfig(config);
+    expect(loadConfig().providers.google.directGeminiWireRenames).toBe(false);
+
+    writeConfig({
+      ...base,
+      providers: {
+        google: { ...base.providers.google, directGeminiWireRenames: "false" },
+      },
+    });
+    expect(readConfigDiagnostics().source).toBe("fallback");
+    expect(readConfigDiagnostics().error).toContain("directGeminiWireRenames");
+  });
+
   test("accepts a relative responsesPath", () => {
     writeResponsesPathConfig("/responses");
 

--- a/tests/google-adapter.test.ts
+++ b/tests/google-adapter.test.ts
@@ -278,3 +278,29 @@ describe("google adapter — tool_choice on the wire", () => {
     });
   });
 });
+
+describe("google adapter — direct -tiered wire renames", () => {
+  function renamedParsed(modelId: string): OcxParsedRequest {
+    return {
+      modelId,
+      stream: false,
+      options: {},
+      context: { messages: [{ role: "user", content: "hi" }], tools: [] },
+    } as unknown as OcxParsedRequest;
+  }
+
+  test("default maps the picker id to the -tiered wire id", async () => {
+    for (const modelId of ["gemini-3.7-flash", "gemini-3.6-flash"]) {
+      const { url } = await createGoogleAdapter(provider).buildRequest(renamedParsed(modelId));
+      expect(url).toContain(`/v1beta/models/${modelId}-tiered:generateContent`);
+    }
+  });
+
+  test("directGeminiWireRenames: false keeps the bare wire id", async () => {
+    const adapter = createGoogleAdapter({ ...provider, directGeminiWireRenames: false });
+    for (const modelId of ["gemini-3.7-flash", "gemini-3.6-flash"]) {
+      const { url } = await adapter.buildRequest(renamedParsed(modelId));
+      expect(url).toContain(`/v1beta/models/${modelId}:generateContent`);
+    }
+  });
+});

--- a/tests/google-adapter.test.ts
+++ b/tests/google-adapter.test.ts
@@ -303,4 +303,16 @@ describe("google adapter — direct -tiered wire renames", () => {
       expect(url).toContain(`/v1beta/models/${modelId}:generateContent`);
     }
   });
+
+  test("directGeminiWireRenames does not affect Vertex requests", async () => {
+    const vertexProvider = { ...provider, googleMode: "vertex" as const };
+    for (const modelId of ["gemini-3.7-flash", "gemini-3.6-flash"]) {
+      const parsed = renamedParsed(modelId);
+      const defaultRequest = await createGoogleAdapter(vertexProvider).buildRequest(parsed);
+      const optOutRequest = await createGoogleAdapter({ ...vertexProvider, directGeminiWireRenames: false })
+        .buildRequest(parsed);
+      expect(optOutRequest.url).toBe(defaultRequest.url);
+      expect(optOutRequest.body).toBe(defaultRequest.body);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Google's Generative Language API renamed current Gemini Flash generations on the wire with a `-tiered` suffix (`gemini-3.7-flash` -> `gemini-3.7-flash-tiered`, `gemini-3.6-flash` -> `gemini-3.6-flash-tiered`), and opencodex applies that rename by default in the AI Studio (direct) path. Some AI Studio deployments/keys still serve the bare ids and return `404 NOT_FOUND` (`models/gemini-3.7-flash-tiered is not found for API version v1beta`) for every renamed request.

This PR adds a per-provider opt-out: `directGeminiWireRenames: false` keeps the picker-visible id stable while sending the bare id on the wire. Default behavior (rename applied) is unchanged; Vertex requests are unaffected.

## Verification

- `bun run typecheck` passes.
- `bun test tests/google-adapter.test.ts tests/config.test.ts` passes (159 tests, including new coverage for the opt-out round-trip and the Vertex exclusion).
- Live check against `generativelanguage.googleapis.com/v1beta/models` confirmed the affected account serves bare ids only; with the opt-out set, the request reaches `models/gemini-3.7-flash:generateContent` and succeeds.

## Checklist

- [ ] Scope stays focused and avoids unrelated cleanup.
- [ ] Docs or release notes were updated when needed (providers.md documents the new setting).
- [ ] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
