### PR TITLE
fix(openai-chat): strip Responses-only encrypted tool annotation

### DIFF
--- a/src/adapters/anthropic.ts
+++ b/src/adapters/anthropic.ts
@@ -19,6 +19,7 @@ import { parseDataUrl } from "./image";
 import { enforceAnthropicImageLimits } from "./anthropic-image-guard";
 import { normalizeAnthropicImages } from "./anthropic-image-normalize";
 import { normalizeAnthropicOutputSchema } from "./anthropic-output-schema";
+import { stripResponsesOnlyEncryptedMarker } from "./responses-tool-schema";
 import { identifyRoutedModel } from "./identity";
 import { redactSecretString } from "../lib/redact";
 import { CLAUDE_CODE_HEADERS, claudeCodeSessionId } from "./client-fingerprint";
@@ -721,35 +722,8 @@ function toolsToAnthropicFormat(parsed: OcxParsedRequest, toolNames: { toWire: (
   return converted;
 }
 
-// Codex multi-agent v2 stamps a Responses-only `encrypted: true` marker on
-// collaboration tool schemas (openai/codex 5f4d06ef; issue #85). It is an
-// annotation for the ChatGPT backend only. Anthropic input_schema is strict
-// JSON Schema; strip the marker defensively everywhere it can appear as a
-// schema keyword, while preserving properties literally named "encrypted".
-const ENCRYPTED_MARKER_NAME_BAG_KEYS = new Set(["properties", "patternProperties", "$defs", "definitions"]);
-const ENCRYPTED_MARKER_LITERAL_VALUE_KEYS = new Set(["const", "default", "enum", "examples"]);
-
-function stripEncryptedMarker(node: unknown, inNameBag = false): unknown {
-  if (Array.isArray(node)) return node.map(item => stripEncryptedMarker(item));
-  if (!node || typeof node !== "object") return node;
-
-  const out: Record<string, unknown> = {};
-
-  for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
-    if (inNameBag) {
-      out[key] = stripEncryptedMarker(value);
-    } else if (key !== "encrypted") {
-      out[key] = ENCRYPTED_MARKER_LITERAL_VALUE_KEYS.has(key)
-        ? value
-        : stripEncryptedMarker(value, ENCRYPTED_MARKER_NAME_BAG_KEYS.has(key));
-    }
-  }
-
-  return out;
-}
-
 function normalizeAnthropicInputSchema(schema: unknown): Record<string, unknown> {
-  const stripped = stripEncryptedMarker(schema);
+  const stripped = stripResponsesOnlyEncryptedMarker(schema);
   const obj = stripped && typeof stripped === "object" && !Array.isArray(stripped)
     ? stripped as Record<string, unknown>
     : {};

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -14,6 +14,7 @@ import { buildNonOpenAIToolCatalogNudgeForTools, shouldInjectNonOpenAIToolCatalo
 import { openRouterProviderPayload, resolveOpenRouterRouting } from "../providers/openrouter-routing";
 import { canSerializeServiceTierForChatModel } from "../providers/service-tier";
 import { openaiChatCompletionsUrl } from "./openai-chat-url";
+import { stripResponsesOnlyEncryptedMarker } from "./responses-tool-schema";
 import {
   isTranslatorBudgetExceededError,
   retainTranslatedEventBatch,
@@ -1077,9 +1078,9 @@ function toolsToChatFormat(parsed: OcxParsedRequest, provider: OcxProviderConfig
   if (tools.length === 0) return undefined;
   const xaiTarget = isXaiSchemaTarget(provider);
   const formatted = tools.flatMap(t => {
-    const parameters = xaiTarget
+    const parameters = stripResponsesOnlyEncryptedMarker(xaiTarget
       ? normalizeXaiToolParameters(t.parameters)
-      : ensureRootObjectType(t.parameters);
+      : ensureRootObjectType(t.parameters));
 
     if (parameters === undefined) return [];
     return [{

--- a/src/adapters/responses-tool-schema.ts
+++ b/src/adapters/responses-tool-schema.ts
@@ -1,0 +1,34 @@
+// Codex multi-agent v2 stamps a Responses-only `encrypted: true` marker on
+// collaboration tool schemas (openai/codex 5f4d06ef; issue #85). It is an
+// annotation for the ChatGPT backend only, so translated provider schemas must
+// drop it without removing properties or definitions literally named `encrypted`.
+const ENCRYPTED_MARKER_NAME_BAG_KEYS = new Set([
+  "properties",
+  "patternProperties",
+  "$defs",
+  "definitions",
+  "dependencies",
+  "dependentSchemas",
+  "dependentRequired",
+]);
+const ENCRYPTED_MARKER_LITERAL_VALUE_KEYS = new Set(["const", "default", "enum", "examples"]);
+
+export function stripResponsesOnlyEncryptedMarker(node: unknown, inNameBag = false): unknown {
+  if (Array.isArray(node)) return node.map(item => stripResponsesOnlyEncryptedMarker(item));
+  if (!node || typeof node !== "object") return node;
+
+  // A schema name may be `__proto__`; a null-prototype record keeps it as data.
+  const out: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+
+  for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+    if (inNameBag) {
+      out[key] = stripResponsesOnlyEncryptedMarker(value);
+    } else if (key !== "encrypted") {
+      out[key] = ENCRYPTED_MARKER_LITERAL_VALUE_KEYS.has(key)
+        ? value
+        : stripResponsesOnlyEncryptedMarker(value, ENCRYPTED_MARKER_NAME_BAG_KEYS.has(key));
+    }
+  }
+
+  return out;
+}

--- a/tests/openai-chat-hardening.test.ts
+++ b/tests/openai-chat-hardening.test.ts
@@ -59,6 +59,81 @@ function routedProvider(name: "litellm" | "ollama", apiKey?: string): OcxProvide
   return routeModel(config, `${name}/test-model`).provider;
 }
 
+describe("openai-chat request hardening", () => {
+  test("strips Responses-only encrypted annotations without changing schema names or literal values", () => {
+    const parameters = {
+      type: "object",
+      properties: {
+        encrypted: { type: "boolean", description: "A legitimate tool argument name" },
+        message: { type: "string", encrypted: true },
+        nested: {
+          type: "object",
+          properties: { value: { type: "string", encrypted: false } },
+        },
+        literalData: {
+          type: "object",
+          const: { encrypted: true },
+          default: { encrypted: false },
+          enum: [{ encrypted: true }],
+          examples: [{ encrypted: false }],
+        },
+      },
+      patternProperties: { encrypted: { type: "string", encrypted: true } },
+      $defs: { encrypted: { type: "number", encrypted: true } },
+      definitions: { encrypted: { type: "integer", encrypted: false } },
+      dependencies: { encrypted: ["message"], other: { type: "object", encrypted: true } },
+      dependentSchemas: { encrypted: { type: "string", encrypted: true } },
+      dependentRequired: { encrypted: ["message"] },
+      propertiesWithSpecialName: { type: "object", properties: { ["__proto__"]: { type: "string", encrypted: true } } },
+      required: ["message", "encrypted"],
+    };
+    const before = structuredClone(parameters);
+    const request = createOpenAIChatAdapter(provider()).buildRequest({
+      ...parsed(),
+      context: {
+        messages: [{ role: "user", content: "delegate", timestamp: 0 }],
+        tools: [{
+          name: "spawn_agent",
+          namespace: "collaboration",
+          description: "Spawn a child agent",
+          parameters,
+        }],
+      },
+    });
+    const body = JSON.parse(request.body) as {
+      tools: Array<{ function: { parameters: Record<string, unknown> } }>;
+    };
+
+    expect(body.tools[0].function.parameters).toEqual({
+      type: "object",
+      properties: {
+        encrypted: { type: "boolean", description: "A legitimate tool argument name" },
+        message: { type: "string" },
+        nested: {
+          type: "object",
+          properties: { value: { type: "string" } },
+        },
+        literalData: {
+          type: "object",
+          const: { encrypted: true },
+          default: { encrypted: false },
+          enum: [{ encrypted: true }],
+          examples: [{ encrypted: false }],
+        },
+      },
+      patternProperties: { encrypted: { type: "string" } },
+      $defs: { encrypted: { type: "number" } },
+      definitions: { encrypted: { type: "integer" } },
+      dependencies: { encrypted: ["message"], other: { type: "object" } },
+      dependentSchemas: { encrypted: { type: "string" } },
+      dependentRequired: { encrypted: ["message"] },
+      propertiesWithSpecialName: { type: "object", properties: { ["__proto__"]: { type: "string" } } },
+      required: ["message", "encrypted"],
+    });
+    expect(parameters).toEqual(before);
+  });
+});
+
 describe("openai-chat non-stream response hardening", () => {
   test("surfaces an upstream error envelope message", async () => {
     const adapter = createOpenAIChatAdapter(provider());


### PR DESCRIPTION
## Summary

- Fixes #1774: strip the Responses-only `encrypted` schema annotation when the generic `openai-chat` adapter translates tools to Chat Completions.
- Extracts the existing Anthropic marker sanitizer into a shared adapter helper so translated Chat and Anthropic schemas remove the marker consistently while preserving required fields, literal values, and schema names such as `encrypted` and `__proto__`.
- Leaves the native `openai-responses` passthrough unchanged.
- Adds a behavior-contract regression covering nested annotations, schema name maps, JSON Schema dependency maps, literal-value keywords, prototype-like names, and input non-mutation.

The root cause is protocol translation: `encrypted: true` is private Responses metadata, but it was serialized into Chat Completions tool parameters. For the affected V2 collaboration request, the upstream then returned empty `spawn_agent` arguments; the required `message` field was absent and no child agent was created.

I am happy to prepare/continue the PR review and follow-up fixes.

## Verification

- `bun test tests/openai-chat-hardening.test.ts tests/anthropic-tool-schema.test.ts` — 59 passed, 0 failed.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `bun run test` — attempted on the final commit; 12,357 passed, 8 skipped, 18 failed in unrelated existing provider-management/concurrency tests (the focused adapter tests and typecheck remain green).
- `git diff --check origin/dev...HEAD` — passed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed; this is an internal adapter compatibility fix with no new user-facing configuration.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults; this change does not touch those paths.

Closes #1774

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
