### PR TITLE
fix(cursor): teach code-mode nested-helper contract in tool guidance

### DIFF
--- a/src/adapters/cursor/tool-definitions.ts
+++ b/src/adapters/cursor/tool-definitions.ts
@@ -191,6 +191,38 @@ export function isCursorWaitTool(tool: Pick<OcxTool, "namespace" | "name">): boo
   return isCursorResponsesProvider(tool.namespace) && tool.name === CODEX_WAIT_TOOL;
 }
 
+/**
+ * True for Codex's unified-exec "code mode" tool: a freeform `exec` whose body is JavaScript
+ * evaluated in a V8 isolate, not a shell command string.
+ */
+export function isCursorCodeModeExecTool(
+  tool: Pick<OcxTool, "namespace" | "name" | "freeform">,
+): boolean {
+  return isCursorResponsesProvider(tool.namespace)
+    && tool.name === CODEX_UNIFIED_EXEC_TOOL
+    && tool.freeform === true;
+}
+
+/**
+ * Codex code mode advertises ONE freeform `exec` tool and no bare shell bridge. Shell, file
+ * edits, and MCP calls are reachable only as nested `tools.<name>(...)` helpers described inside
+ * that tool's own description, so a flat catalog scan cannot see them.
+ *
+ * This matters because the shell-bridge guidance below is written for a flat catalog. Emitting
+ * "call \`exec_command\`" into a code-mode turn names a top-level tool that does not exist: the
+ * model calls it, gets nothing back, and burns turns rediscovering the real contract from error
+ * messages (empty output until \`text()\` is called, \`require is not defined\` because the isolate
+ * is not Node, \`apply_patch\` rejected because it too is only a nested helper here).
+ */
+export function cursorRequestUsesCodeMode(
+  tools: readonly Pick<OcxTool, "namespace" | "name" | "freeform">[] | undefined,
+  toolChoice?: OcxRequestOptions["toolChoice"],
+): boolean {
+  const catalog = tools ?? [];
+  const visible = catalog.filter(tool => cursorToolAllowedByChoice(tool, toolChoice, catalog));
+  return visible.some(isCursorCodeModeExecTool) && !visible.some(isBareCodexShellBridgeTool);
+}
+
 /** @deprecated Prefer isBareCodexShellBridgeTool; kept for older call sites/tests. */
 function isBareCodexExecCommandTool(tool: Pick<OcxTool, "namespace" | "name">): boolean {
   return isBareCodexShellBridgeTool(tool);
@@ -554,6 +586,7 @@ export function buildCursorToolGuidanceSystemNote(
   const listedNames = quotedNames(wireNames);
   const shellBridgeNames = wireNames.filter(isCodexShellBridgeToolName);
   const hasBareExec = shellBridgeNames.length > 0;
+  const codeMode = cursorRequestUsesCodeMode(tools, toolChoice);
   const shellBridgeLabel = quotedNames(shellBridgeNames.length > 0 ? shellBridgeNames : [...CODEX_SHELL_BRIDGE_TOOL_NAMES]);
   const hasApplyPatch = cursorRequestAdvertisesApplyPatch(tools, toolChoice);
   const structuredEditNames = tools
@@ -571,6 +604,14 @@ export function buildCursorToolGuidanceSystemNote(
     "Use the current tool catalog as ground truth and call only those exact names with their listed argument keys.",
     unavailableNeighborNames.length > 0
       ? `This turn does not expose neighboring-agent tool names ${quotedNames(unavailableNeighborNames)}; do not call or suggest them unless the catalog lists them.`
+      : undefined,
+    // Code mode: the ONLY callable tool is freeform `exec`, and shell/edit/MCP live inside it as
+    // nested helpers. Without this the model probes for a top-level shell tool that is not there.
+    codeMode
+      ? `\`${CODEX_UNIFIED_EXEC_TOOL}\` is Codex code mode: its body is JavaScript evaluated in a V8 isolate, not a shell command and not Node. Shell, file edits, and MCP are nested helpers called INSIDE that body as \`await tools.<name>(...)\`, for example \`await tools.exec_command({cmd: \"ls\"})\`. Read the tool description for the exact nested helpers this turn provides; they are not separate top-level tools, so do not call \`exec_command\`, \`shell_command\`, or \`apply_patch\` at the top level here.`
+      : undefined,
+    codeMode
+      ? "In code mode the isolate returns nothing on its own: call `text(...)` (or `notify(...)`) on any value you need to see, or the call completes with empty output. There is no `require`, no `module`, and no filesystem or network globals; reach the host only through the nested helpers."
       : undefined,
     hasBareExec
       ? `${shellBridgeLabel} is the Codex Responses shell bridge for this turn, exposed through Cursor's tool protocol; it is not an external MCP server tool. \`shell_command\` and \`exec_command\` are aliases of the same bridge.`

--- a/tests/cursor-tool-definitions.test.ts
+++ b/tests/cursor-tool-definitions.test.ts
@@ -9,6 +9,8 @@ import {
   buildCursorToolGuidanceSystemNote,
   CURSOR_EXEC_COMMAND_INPUT_SCHEMA,
   cursorRequestAdvertisesApplyPatch,
+  cursorRequestUsesCodeMode,
+  isCursorCodeModeExecTool,
   cursorToolArgNormalizeSchema,
   cursorToolInputSchema,
   cursorToolWireName,
@@ -409,5 +411,57 @@ describe("Cursor tool definitions", () => {
 
     expect(allowedNote).toContain("`mcp__fs__write_file`");
     expect(allowedNote).not.toContain("`mcp__fs__read_file`");
+  });
+});
+
+describe("Cursor code mode tool guidance", () => {
+  const codeModeExec = (): OcxTool => ({
+    name: "exec",
+    description: "Run JavaScript code to orchestrate tool calls. Nested tools are available on the global `tools` object.",
+    parameters: {},
+    freeform: true,
+  });
+
+  test("detects code mode only when freeform exec has no bare shell bridge", () => {
+    expect(cursorRequestUsesCodeMode([codeModeExec()])).toBe(true);
+    expect(isCursorCodeModeExecTool(codeModeExec())).toBe(true);
+
+    // A non-freeform `exec` is not code mode.
+    expect(cursorRequestUsesCodeMode([{ name: "exec", description: "Run", parameters: {} }])).toBe(false);
+    // A bare shell bridge alongside it means the flat-catalog guidance still applies.
+    expect(cursorRequestUsesCodeMode([codeModeExec(), { name: "exec_command", description: "Run", parameters: {} }])).toBe(false);
+    expect(cursorRequestUsesCodeMode([{ name: "exec_command", description: "Run", parameters: {} }])).toBe(false);
+    expect(cursorRequestUsesCodeMode(undefined)).toBe(false);
+    // Tool choice that hides exec also hides code mode.
+    expect(cursorRequestUsesCodeMode([codeModeExec(), { name: "read_file", namespace: "mcp__fs", description: "R", parameters: {} }], { name: "read_file" })).toBe(false);
+  });
+
+  test("teaches the nested-helper contract instead of a top-level shell bridge", () => {
+    const note = buildCursorToolGuidanceSystemNote([codeModeExec()]);
+    expect(note).toBeDefined();
+    if (!note) throw new Error("Expected Cursor tool guidance note");
+
+    expect(note).toContain("is Codex code mode");
+    expect(note).toContain("V8 isolate");
+    expect(note).toContain("await tools.<name>(...)");
+    expect(note).toContain("await tools.exec_command({cmd: " + "\"" + "ls" + "\"" + "})");
+    expect(note).toContain("text(...)");
+    expect(note).toContain("There is no `require`");
+
+    // The flat-catalog shell-bridge guidance must NOT appear: naming a top-level
+    // `exec_command` in code mode sends the model after a tool that does not exist.
+    expect(note).not.toContain("is the Codex Responses shell bridge for this turn");
+    expect(note).not.toContain("mcp_opencodex-responses_shell_command");
+    expect(note).not.toContain("For file read/search/listing, use");
+  });
+
+  test("keeps flat-catalog shell-bridge guidance when a bare bridge is advertised", () => {
+    const note = buildCursorToolGuidanceSystemNote([{ name: "exec_command", description: "Run", parameters: {} }]);
+    expect(note).toBeDefined();
+    if (!note) throw new Error("Expected Cursor tool guidance note");
+
+    expect(note).toContain("is the Codex Responses shell bridge for this turn");
+    expect(note).not.toContain("is Codex code mode");
+    expect(note).not.toContain("V8 isolate");
   });
 });


### PR DESCRIPTION
## Problem

Codex "code mode" advertises a single freeform `exec` tool whose body is JavaScript evaluated in a V8 isolate. Shell, file edits, and MCP are reachable only as nested `await tools.<name>(...)` helpers described inside that tool's own description, so a flat catalog scan cannot see them.

`buildCursorToolGuidanceSystemNote` assumed a flat catalog and injected shell-bridge guidance naming a top-level `exec_command` / `shell_command`. On a code-mode turn those top-level tools do not exist, so the model calls a tool that is not there, gets nothing back, and spends several turns rediscovering the real contract from error messages:

- `exec_command` at top level returns nothing
- empty output until `text()` is called
- `require is not defined` (the isolate is not Node)
- `apply_patch` rejected, because it too is only a nested helper here

The shared `adapters/tool-catalog-nudge.ts` already documents this hazard for `apply_patch`:

> under Codex code mode it is reachable as a nested `tools.apply_patch(...)` helper ... so a flat catalog check cannot see it

The Cursor adapter keeps its own sibling copy of that guidance and never received the equivalent handling.

## Fix

Detect code mode and emit the correct contract instead of the flat-catalog shell-bridge text.

- `isCursorCodeModeExecTool`: freeform `exec` on the Responses provider.
- `cursorRequestUsesCodeMode`: a visible code-mode `exec` **and** no bare shell bridge, evaluated after `toolChoice` filtering so a pinned choice that hides `exec` also disables the branch.
- Two guidance lines describing the nested-helper contract, the V8 isolate, and the `text()` output requirement.

Turns that advertise a bare `exec_command` / `shell_command` are unchanged: the existing shell-bridge, PowerShell, alias, and anti-false-block guidance still applies. The two paths are mutually exclusive by construction.

## Tests

Three cases in `tests/cursor-tool-definitions.test.ts`:

1. detection is true only for freeform `exec` with no bare bridge (covers non-freeform `exec`, bridge present, undefined tools, and a tool-choice pin)
2. code-mode guidance teaches the nested contract and omits the shell-bridge lines
3. a bare bridge still gets the flat-catalog guidance and none of the code-mode text

Verified the coverage is real: stubbing the detection to `false` fails case 2, and restoring it passes.

```
bun run typecheck                     clean
bun test tests/cursor-*.test.ts       236 pass, 0 fail (7 files)
bun run privacy:scan                  passed
```

Rebased onto current `dev` (`e1769b5e2`).

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for detecting Cursor’s Codex code mode.
  - Guidance now explains how to use nested tools within JavaScript execution, including output helpers.
  - Prevents conflicting instructions for shell, patch, and MCP calls in code mode.

- **Bug Fixes**
  - Preserved existing guidance for standard catalogs with direct shell access.

- **Tests**
  - Added coverage for code-mode detection, tool selection, and guidance behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->