### PR TITLE
docs: follow up Command Code quota review

### DIFF
--- a/docs-site/src/content/docs/fr/guides/providers.md
+++ b/docs-site/src/content/docs/fr/guides/providers.md
@@ -391,7 +391,9 @@ fixe de l'API Provider, préserve les identifiants natifs du fournisseur et limi
 256 lignes brutes. `ocx login command-code` prend en charge OAuth par connexion dans le navigateur, avec
 importation facultative des identifiants locaux depuis `~/.commandcode/auth.json` pour les utilisateurs de la
 CLI Command Code. Le catalogue, propre au compte, provient du point de terminaison de découverte authentifié
-après la connexion. Les requêtes de chat utilisent la clé Bearer configurée. Créez des clés dans
+après la connexion. Les requêtes de chat du préréglage Provider-API `commandcode` utilisent la clé Bearer active
+configurée ; le préréglage OAuth `command-code` utilise le jeton Bearer du compte enregistré pour la découverte
+authentifiée et les requêtes de chat. Créez des clés Provider-API dans
 [Command Code Studio](https://commandcode.ai/studio/).
 
 **Quota Command Code.** Le tableau de bord et `ocx account refresh` sondent les fenêtres
@@ -607,4 +609,4 @@ au fournisseur.
 
 Les fournisseurs qui disposent d'une sonde en direct sont OpenAI/Codex, Anthropic, xAI, Cursor, Kimi,
 Google Antigravity, OpenRouter, DeepSeek, ClinePass, Z.AI, MiniMax, Moonshot, Venice, Synthetic, DeepInfra,
-Neuralwatt, ainsi que tout fournisseur personnalisé reposant sur a6api.
+Neuralwatt, Command Code, ainsi que tout fournisseur personnalisé reposant sur a6api.

--- a/docs-site/src/content/docs/guides/providers.md
+++ b/docs-site/src/content/docs/guides/providers.md
@@ -363,9 +363,10 @@ key from the subscription overview in the [Vultr Console](https://my.vultr.com).
 the fixed Provider API host, preserves provider-native ids, and caps discovery at 256 KiB and 256 raw
 rows. `ocx login command-code` supports OAuth via browser sign-in (with optional local CLI credential
 import from `~/.commandcode/auth.json` for existing Command Code CLI users); the model catalog is
-account-scoped and comes from the authenticated discovery endpoint after login. Chat requests use the
-configured Bearer key. Create keys at
-[Command Code Studio](https://commandcode.ai/studio/).
+account-scoped and comes from the authenticated discovery endpoint after login. The Provider-API
+preset (`commandcode`) uses the active configured Bearer key for chat requests; the OAuth preset
+(`command-code`) uses the stored account bearer for authenticated discovery and chat. Create
+Provider-API keys at [Command Code Studio](https://commandcode.ai/studio/).
 
 **Command Code quota.** The dashboard and `ocx account refresh` probe Command Code's
 `/alpha/billing/credits` windows (5-hour and weekly) on the canonical
@@ -564,5 +565,5 @@ provider-specific) is already consumed.
 
 Providers with a live probe: OpenAI/Codex, Anthropic, xAI, Cursor, Kimi,
 Google Antigravity, OpenRouter, DeepSeek, ClinePass, Z.AI, MiniMax,
-Moonshot, Venice, Synthetic, DeepInfra, Neuralwatt, and any a6api-backed
+Moonshot, Venice, Synthetic, DeepInfra, Neuralwatt, Command Code, and any a6api-backed
 custom provider.


### PR DESCRIPTION
## Summary

Follow-up to #1761 for the remaining Command Code quota documentation cleanup:

- clarify `commandcode` Provider-API key auth vs `command-code` OAuth bearer behavior in the English and French provider docs
- add Command Code to the English and French live quota-probe summaries
- intentionally do **not** duplicate the `/alpha/usage/summary` failure regression: the final #1761 already contains the stronger version of that test

## Rebase / scope

#1761 is merged. This branch has been rebuilt directly on current `dev` rather than merging the old stacked history, which avoids reintroducing the parent PR through a parallel commit lineage.

Current diff against `dev` is exactly two files:

- `docs-site/src/content/docs/guides/providers.md`
- `docs-site/src/content/docs/fr/guides/providers.md`

## Verification

- branch is 1 commit ahead / 0 behind current `dev`
- GitHub reports the PR mergeable
- the older stacked copy of `tests/command-code-quota.test.ts` was dropped because `dev` already has the newer regression from #1761
