### PR TITLE
fix(service): keep an absolute POSIX sqlite home literal in POSIX service files

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -9,7 +9,7 @@ import { execFileSync, execSync, spawnSync } from "node:child_process";
 import { findLiveProxy, proxyIdentityAt, SERVICE_STOP_LIVENESS } from "./server/proxy-liveness";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { dirname, join, resolve, win32 } from "node:path";
+import { dirname, join, posix, resolve, win32 } from "node:path";
 import { expandUserPath, getConfigDir, readPid, removePid, removeRuntimePort, verifyPidIdentity } from "./config";
 import { loadConfig } from "./config";
 import { restoreNativeCodex, restoreNativeCodexAsync } from "./codex/inject";
@@ -113,12 +113,19 @@ function currentCodexSqliteHomeAbsolute(target: "native" | "windows" = "native")
   const raw = process.env.CODEX_SQLITE_HOME?.trim();
   if (!raw) return undefined;
   const expanded = expandUserPath(raw);
-  // Windows service artifacts can be rendered by cross-platform tests and
-  // repair tooling. Preserve an already-absolute drive/UNC path instead of
-  // anchoring it beneath the current POSIX worktree.
-  return target === "windows" && win32.isAbsolute(expanded)
-    ? win32.normalize(expanded)
-    : resolve(expanded);
+  // Service artifacts can be rendered by cross-platform tests and repair tooling, so an
+  // already-absolute path for the TARGET platform is preserved rather than re-anchored
+  // against the writing host. `resolve()` is host-relative in both directions: on a POSIX
+  // host it turns `C:\data` into `<cwd>/C:\data`, and on a Windows host it turns `/tmp/x`
+  // into `D:\tmp\x` — neither is a path the target can use. A relative value still resolves,
+  // because a service unit has no meaningful working directory.
+  //
+  // CODEX_HOME and OPENCODEX_HOME are carried through literally, so without this the same
+  // generated file disagreed with itself about two variables holding the same kind of value.
+  if (target === "windows") {
+    return win32.isAbsolute(expanded) ? win32.normalize(expanded) : resolve(expanded);
+  }
+  return posix.isAbsolute(expanded) ? posix.normalize(expanded) : resolve(expanded);
 }
 
 function currentOpenCodexHome(): string {

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join, posix, win32 } from "node:path";
 import * as serviceModule from "../src/service";
 import { saveConfig } from "../src/config";
 import { windowsEnvIndirectBatchValue } from "../src/lib/win-paths";
@@ -695,8 +695,24 @@ describe("launchd service plist", () => {
       process.env.CODEX_SQLITE_HOME = "relative-sqlite-home";
       const plist = buildPlist();
 
-      expect(plist).toContain("<key>CODEX_SQLITE_HOME</key>");
-      expect(plist).not.toContain("<string>relative-sqlite-home</string>");
+      // Assert the emitted value is actually absolute. Rejecting only the raw string would
+      // stay green for any other non-absolute transform, which is the whole thing this test
+      // exists to catch. The two artifact formats differ, so each is extracted on its own
+      // terms: launchd is XML, systemd is a quoted Environment= line.
+      const plistValue = /<key>CODEX_SQLITE_HOME<\/key>\s*<string>([^<]*)<\/string>/.exec(plist)?.[1];
+      expect(plistValue).toBeDefined();
+      expect(
+        isAbsolute(plistValue!) || posix.isAbsolute(plistValue!) || win32.isAbsolute(plistValue!),
+      ).toBe(true);
+      expect(plistValue!.endsWith("relative-sqlite-home")).toBe(true);
+
+      const unit = buildUnit();
+      const unitValue = /Environment="CODEX_SQLITE_HOME=([^"]*)"/.exec(unit)?.[1];
+      expect(unitValue).toBeDefined();
+      expect(
+        isAbsolute(unitValue!) || posix.isAbsolute(unitValue!) || win32.isAbsolute(unitValue!),
+      ).toBe(true);
+      expect(unitValue!.endsWith("relative-sqlite-home")).toBe(true);
     } finally {
       if (inherited === undefined) delete process.env.CODEX_SQLITE_HOME;
       else process.env.CODEX_SQLITE_HOME = inherited;

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -663,6 +663,45 @@ describe("launchd service plist", () => {
       else process.env.OPENCODEX_API_AUTH_TOKEN = oldApiAuthToken;
     }
   });
+
+  // A POSIX unit must carry the literal POSIX path no matter which host writes it. The two
+  // cases above are where this actually bites: on a Windows host `resolve("/tmp/x")` anchors
+  // to the current drive and the generated file said `D:\tmp\codex-sqlite-home`, while
+  // CODEX_HOME beside it kept `/tmp/codex-home`. The same file disagreed with itself about two
+  // variables holding the same kind of value. This states the rule directly so the intent
+  // survives; on a POSIX host `resolve()` is identity here, so only Windows can catch it.
+  test("carries an absolute POSIX sqlite home into POSIX units without host anchoring", () => {
+    const inherited = process.env.CODEX_SQLITE_HOME;
+    try {
+      process.env.CODEX_SQLITE_HOME = "/var/lib/opencodex/codex-sqlite";
+
+      expect(buildPlist()).toContain(
+        "<key>CODEX_SQLITE_HOME</key><string>/var/lib/opencodex/codex-sqlite</string>",
+      );
+      expect(buildUnit()).toContain(
+        'Environment="CODEX_SQLITE_HOME=/var/lib/opencodex/codex-sqlite"',
+      );
+    } finally {
+      if (inherited === undefined) delete process.env.CODEX_SQLITE_HOME;
+      else process.env.CODEX_SQLITE_HOME = inherited;
+    }
+  });
+
+  // The relative case is why the resolve() is there at all: a service unit has no meaningful
+  // working directory, so a relative home must still be made absolute.
+  test("still absolutizes a relative sqlite home", () => {
+    const inherited = process.env.CODEX_SQLITE_HOME;
+    try {
+      process.env.CODEX_SQLITE_HOME = "relative-sqlite-home";
+      const plist = buildPlist();
+
+      expect(plist).toContain("<key>CODEX_SQLITE_HOME</key>");
+      expect(plist).not.toContain("<string>relative-sqlite-home</string>");
+    } finally {
+      if (inherited === undefined) delete process.env.CODEX_SQLITE_HOME;
+      else process.env.CODEX_SQLITE_HOME = inherited;
+    }
+  });
 });
 
 describe("service lifecycle cleanup ordering", () => {


### PR DESCRIPTION
## Summary

Closes #1786.

You asked which of two readings was right and said you could not distinguish them from outside. It is the first one: **the generator normalizes `CODEX_SQLITE_HOME` and should not.** The asymmetry you pointed at is the whole tell, and it is real rather than a test artifact.

`currentCodexSqliteHomeAbsolute` ends in `resolve()`. That is host-relative in both directions — on a Windows host it anchors `/tmp/x` to the current drive (`D:\tmp\x`), and on a POSIX host it would turn `C:\data` into `<cwd>/C:\data`. Neither is a path the target host can use. `CODEX_HOME` and `OPENCODEX_HOME` beside it are carried through literally, which is why one generated file ended up disagreeing with itself about two variables holding the same kind of value.

The interesting part is that the code already contains this exact argument, one branch up:

```ts
// Windows service artifacts can be rendered by cross-platform tests and
// repair tooling. Preserve an already-absolute drive/UNC path instead of
// anchoring it beneath the current POSIX worktree.
return target === "windows" && win32.isAbsolute(expanded)
  ? win32.normalize(expanded)
  : resolve(expanded);
```

So the rule was already established for Windows artifacts rendered on a POSIX host. It just had no counterpart for POSIX artifacts rendered on a Windows host. This adds the mirror, and keeps the `resolve()` for the relative case — which is why it is there at all, since a service unit has no meaningful working directory.

Your second reading — pin or skip the tests on Windows — would also have turned the suite green, and I think it is the wrong trade. It would leave a real cross-host defect in place and convert a true signal into a permanently skipped case, which is the same thing you said you did not want to keep tolerating.

## Verification

Windows 11, `dev` at `7612e4c4f`:

- `bun test tests/service.test.ts` — **119 pass / 2 fail → 123 pass / 0 fail**. The two named in your report both pass now.
- `bun run typecheck` — clean.
- `bun test tests/service-*.test.ts tests/winsw.test.ts tests/windows-*.test.ts` and the wider service/platform suites — no change.

New coverage in `tests/service.test.ts`:

- an absolute POSIX `CODEX_SQLITE_HOME` reaches both the launchd plist and the systemd unit literally;
- a **relative** value is still absolutized, pinning the behaviour the `resolve()` exists for so this does not regress into "never normalize".

The first was driven red against the unfixed resolver and fails alongside the two you reported. The second passes either way by design — it guards what the change deliberately preserves.

One caveat worth stating plainly, since it explains the whole history: **this can only fail on a Windows host.** On POSIX, `resolve()` of an absolute POSIX path is identity, so the new assertion passes trivially there. That is exactly why the defect survived CI, and why your report was the only way it was going to surface.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup. One resolver branch in `src/service.ts` plus its regression coverage; no other call site or platform path is touched.
- [x] Docs or release notes were updated when needed. No user-facing configuration or documented behaviour changes — a correctly generated unit is what the documentation already describes.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. No credential, auth, or workflow surface is involved. The change narrows a path transform and cannot widen what a service file exposes; the API-token indirection in these artifacts is untouched, and the existing assertions that the token never appears inline still pass.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `CODEX_SQLITE_HOME` paths when generating cross-platform service configurations.
  * Windows and POSIX absolute paths are now preserved correctly, while relative paths continue resolving against the host environment.
  * Service artifacts now retain the intended target-platform paths.

* **Tests**
  * Added coverage for launchd and systemd configurations across absolute and relative path scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
