### PR TITLE
fix(catalog): ingest llama.cpp multimodal and dual-envelope metadata

### DIFF
--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -990,6 +990,11 @@ function modelInputModalities(
   if (capabilityRecord?.vision === false) return ["text"];
   if (capabilityRecord?.vision === true || capabilities?.some(value => (
     value === "vision" || value === "image-input" || value === "image_input"
+    // llama.cpp and Ollama-compatible servers report vision as "multimodal" —
+    // it is the only image signal those servers emit (#1797). Mapped to the
+    // closed `text|image` enum rather than passed through: an out-of-enum
+    // modality makes Codex reject the entire catalog file.
+    || value === "multimodal"
   ))) {
     return ["text", "image"];
   }

--- a/src/providers/model-discovery.ts
+++ b/src/providers/model-discovery.ts
@@ -349,10 +349,18 @@ export function extractModelEnvelopeRows(
  *    admitted once a same-id sibling provided it. Enrichment may change what is
  *    KNOWN about a model, never WHICH models are published.
  * 2. Only the capability keys #1797 needs are copied. A blanket "fill every
- *    absent key" made a key the untrusted `models[]` array could reach into any
- *    field the pipeline consumes.
+ *    absent key" made the untrusted `models[]` array a way into any field the
+ *    pipeline consumes.
+ *
+ *    The list deliberately EXCLUDES `supported_features` and `features`, even
+ *    though both are capability-shaped: they are the two keys real provider
+ *    filters test (`registry.ts:1591` requires `supported_features` to contain
+ *    "tools"; `registry.ts:1883` tests `features.tool_use`). Ordering already
+ *    prevents a sibling from flipping an admission verdict, but a key that is
+ *    both enrichable and filter-relevant is one refactor away from becoming a
+ *    bypass again. #1797 does not need them.
  */
-const SIBLING_ENRICHABLE_KEYS = new Set(["capabilities", "features", "supported_features", "modalities", "input_modalities"]);
+const SIBLING_ENRICHABLE_KEYS = new Set(["capabilities", "modalities", "input_modalities"]);
 
 type SiblingIndex = Map<string, Record<string, unknown> | null>;
 

--- a/src/providers/model-discovery.ts
+++ b/src/providers/model-discovery.ts
@@ -332,23 +332,36 @@ export function extractModelEnvelopeRows(
 
 /** Validate, bound, deduplicate, and declaratively filter OpenAI `{data:[...]}` or top-level arrays (Together `#617`). */
 /**
- * Enrich `data[]` rows with metadata a sibling `models[]` array carries for the
- * SAME model id (#1797).
+ * Metadata a sibling `models[]` array may contribute to an ALREADY-ADMITTED
+ * `data[]` row (#1797).
  *
- * Deliberately conservative, because `models` is exactly the key catalog
- * discovery refuses to trust as a source of models:
- * - membership is decided entirely by `data[]`; a sibling-only entry is dropped,
- * - matching is exact id equality (`id`, or Ollama's `model`/`name`), never fuzzy,
- * - an ambiguous id appearing twice in the sibling array is skipped rather than guessed,
- * - only keys ABSENT from the `data[]` row are filled, so `data[]` always wins,
- * - the sibling array is bounded by the same limit as the primary envelope.
+ * llama.cpp serves a dual-envelope body: an Ollama-style `models[]` array
+ * carrying `capabilities` alongside the OpenAI-style `data[]` array carrying
+ * `meta`, so the two halves of one model's metadata never meet and a server
+ * that truthfully advertises "multimodal" produced an image-blind row.
+ *
+ * Two boundaries make this safe, and both were added after review found the
+ * first attempt unsound:
+ *
+ * 1. It runs AFTER admission filtering. Enriching first let a sibling supply
+ *    the exact field a provider filter requires — reproduced against the real
+ *    Chutes policy, where a row lacking `supported_features: ["tools"]` was
+ *    admitted once a same-id sibling provided it. Enrichment may change what is
+ *    KNOWN about a model, never WHICH models are published.
+ * 2. Only the capability keys #1797 needs are copied. A blanket "fill every
+ *    absent key" made a key the untrusted `models[]` array could reach into any
+ *    field the pipeline consumes.
  */
-function mergeSiblingModelMetadata(value: unknown, data: unknown[], limit: number): unknown[] {
+const SIBLING_ENRICHABLE_KEYS = new Set(["capabilities", "features", "supported_features", "modalities", "input_modalities"]);
+
+type SiblingIndex = Map<string, Record<string, unknown> | null>;
+
+function buildSiblingIndex(value: unknown, limit: number): SiblingIndex | null {
   const record = plainObject(value);
   const sibling = record?.models;
-  if (!Array.isArray(sibling) || sibling.length === 0 || sibling.length > limit) return data;
+  if (!Array.isArray(sibling) || sibling.length === 0 || sibling.length > limit) return null;
 
-  const byId = new Map<string, Record<string, unknown> | null>();
+  const byId: SiblingIndex = new Map();
   for (const raw of sibling) {
     const entry = plainObject(raw);
     if (!entry) continue;
@@ -360,19 +373,19 @@ function mergeSiblingModelMetadata(value: unknown, data: unknown[], limit: numbe
       byId.set(id, byId.has(id) && byId.get(id) !== entry ? null : entry);
     }
   }
-  if (byId.size === 0) return data;
+  return byId.size > 0 ? byId : null;
+}
 
-  return data.map(raw => {
-    const row = plainObject(raw);
-    if (!row || typeof row.id !== "string") return raw;
-    const extra = byId.get(row.id);
-    if (!extra) return raw;
-    const merged: Record<string, unknown> = { ...row };
-    for (const [key, val] of Object.entries(extra)) {
-      if (!(key in merged)) merged[key] = val;
-    }
-    return merged;
-  });
+function enrichAdmittedModel(item: ProviderModelsApiItem, siblings: SiblingIndex): ProviderModelsApiItem {
+  const extra = siblings.get(item.id);
+  if (!extra) return item;
+  let merged: Record<string, unknown> | null = null;
+  for (const key of SIBLING_ENRICHABLE_KEYS) {
+    if (!(key in extra) || key in item) continue;
+    merged ??= { ...(item as Record<string, unknown>) };
+    merged[key] = extra[key];
+  }
+  return (merged ?? item) as ProviderModelsApiItem;
 }
 
 function plainObject(value: unknown): Record<string, unknown> | null {
@@ -380,13 +393,13 @@ function plainObject(value: unknown): Record<string, unknown> | null {
     ? value as Record<string, unknown>
     : null;
 }
-
 export function extractProviderModelItems(
   value: unknown,
   discovery: ResolvedProviderModelDiscovery,
 ): ProviderModelItemsResult {
   const limit = positiveIntegerAtMost(discovery.maxModels, MODEL_DISCOVERY_MAX_MODELS);
   let data: unknown[];
+  let siblings: SiblingIndex | null = null;
   if (Array.isArray(value)) {
     // Together-style top-level /models arrays. Catalog discovery must not treat a stray
     // `models` key on openai-chat responses as valid — only `data` envelopes or top-level arrays.
@@ -396,18 +409,7 @@ export function extractProviderModelItems(
     const envelope = extractModelEnvelopeRows(value, discovery.maxModels, ["data"]);
     if (!envelope.ok) return envelope;
     data = envelope.rows;
-    // llama.cpp serves a dual-envelope body: an Ollama-style `models[]` array
-    // carrying `capabilities` alongside the OpenAI-style `data[]` array carrying
-    // `meta`. The two halves of one model's metadata therefore never meet, and a
-    // server that truthfully advertises "multimodal" still produced an
-    // image-blind row (#1797).
-    //
-    // The existing refusal to trust a stray `models` key stays intact: this does
-    // NOT add `models` as an envelope source, and a row present only there is
-    // still ignored. It enriches a row `data[]` ALREADY published, matching on
-    // exact id, and fills only keys the `data[]` row does not define — so an
-    // authoritative `data[]` entry can never be overridden.
-    data = mergeSiblingModelMetadata(value, data, limit);
+    siblings = buildSiblingIndex(value, limit);
   }
 
   const items: ProviderModelsApiItem[] = [];
@@ -425,9 +427,15 @@ export function extractProviderModelItems(
       if (!isValidModelDiscoveryModelId(finalId)) continue;
     }
     const item = finalId === id ? raw as ProviderModelsApiItem : { ...(raw as ProviderModelsApiItem), id: finalId };
+    // Admission is decided on the ORIGINAL `data[]` row, before any sibling
+    // enrichment. Merging first let a `models[]` entry supply the very field a
+    // provider filter requires — reproduced against the real Chutes policy,
+    // where a row lacking `supported_features: ["tools"]` was admitted once a
+    // same-id sibling provided it. Enrichment must never change WHICH models
+    // are published, only what is known about an already-admitted one.
     if (!providerModelMatchesDiscoveryFilter(item, discovery.spec?.filter) || seen.has(finalId)) continue;
     seen.add(finalId);
-    items.push(item);
+    items.push(siblings ? enrichAdmittedModel(item, siblings) : item);
   }
   return { ok: true, items, rawCount: data.length };
 }

--- a/src/providers/model-discovery.ts
+++ b/src/providers/model-discovery.ts
@@ -331,6 +331,56 @@ export function extractModelEnvelopeRows(
 }
 
 /** Validate, bound, deduplicate, and declaratively filter OpenAI `{data:[...]}` or top-level arrays (Together `#617`). */
+/**
+ * Enrich `data[]` rows with metadata a sibling `models[]` array carries for the
+ * SAME model id (#1797).
+ *
+ * Deliberately conservative, because `models` is exactly the key catalog
+ * discovery refuses to trust as a source of models:
+ * - membership is decided entirely by `data[]`; a sibling-only entry is dropped,
+ * - matching is exact id equality (`id`, or Ollama's `model`/`name`), never fuzzy,
+ * - an ambiguous id appearing twice in the sibling array is skipped rather than guessed,
+ * - only keys ABSENT from the `data[]` row are filled, so `data[]` always wins,
+ * - the sibling array is bounded by the same limit as the primary envelope.
+ */
+function mergeSiblingModelMetadata(value: unknown, data: unknown[], limit: number): unknown[] {
+  const record = plainObject(value);
+  const sibling = record?.models;
+  if (!Array.isArray(sibling) || sibling.length === 0 || sibling.length > limit) return data;
+
+  const byId = new Map<string, Record<string, unknown> | null>();
+  for (const raw of sibling) {
+    const entry = plainObject(raw);
+    if (!entry) continue;
+    for (const key of ["id", "model", "name"]) {
+      const id = entry[key];
+      if (typeof id !== "string" || id.length === 0) continue;
+      // `null` marks an ambiguous id: two sibling entries claim it, so neither
+      // can be attributed with confidence and both are ignored.
+      byId.set(id, byId.has(id) && byId.get(id) !== entry ? null : entry);
+    }
+  }
+  if (byId.size === 0) return data;
+
+  return data.map(raw => {
+    const row = plainObject(raw);
+    if (!row || typeof row.id !== "string") return raw;
+    const extra = byId.get(row.id);
+    if (!extra) return raw;
+    const merged: Record<string, unknown> = { ...row };
+    for (const [key, val] of Object.entries(extra)) {
+      if (!(key in merged)) merged[key] = val;
+    }
+    return merged;
+  });
+}
+
+function plainObject(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
 export function extractProviderModelItems(
   value: unknown,
   discovery: ResolvedProviderModelDiscovery,
@@ -346,6 +396,18 @@ export function extractProviderModelItems(
     const envelope = extractModelEnvelopeRows(value, discovery.maxModels, ["data"]);
     if (!envelope.ok) return envelope;
     data = envelope.rows;
+    // llama.cpp serves a dual-envelope body: an Ollama-style `models[]` array
+    // carrying `capabilities` alongside the OpenAI-style `data[]` array carrying
+    // `meta`. The two halves of one model's metadata therefore never meet, and a
+    // server that truthfully advertises "multimodal" still produced an
+    // image-blind row (#1797).
+    //
+    // The existing refusal to trust a stray `models` key stays intact: this does
+    // NOT add `models` as an envelope source, and a row present only there is
+    // still ignored. It enriches a row `data[]` ALREADY published, matching on
+    // exact id, and fills only keys the `data[]` row does not define — so an
+    // authoritative `data[]` entry can never be overridden.
+    data = mergeSiblingModelMetadata(value, data, limit);
   }
 
   const items: ProviderModelsApiItem[] = [];

--- a/tests/catalog-llamacpp-capabilities.test.ts
+++ b/tests/catalog-llamacpp-capabilities.test.ts
@@ -109,4 +109,33 @@ describe("llama.cpp served context ingestion (#1797)", () => {
     const items = (extracted as { ok: true; items: Array<Record<string, unknown>> }).items;
     expect(items[0]!.context_length).toBeUndefined();
   });
+  test("sibling metadata cannot admit a model the provider filter rejects", () => {
+    // Enrichment used to run BEFORE admission filtering, so a models[] entry
+    // could supply the exact field a filter required. Reproduced against the
+    // real Chutes policy: a row without supported_features:["tools"] was
+    // admitted once a same-id sibling provided it. Enrichment may change what
+    // is KNOWN about a model, never WHICH models are published.
+    const extracted = extractProviderModelItems({
+      models: [{ id: "not-proven-tool-capable", supported_features: ["tools"] }],
+      data: [{ id: "not-proven-tool-capable" }],
+    }, {
+      maxModels: 100,
+      spec: { filter: { allOf: [{ path: ["supported_features"], containsAny: ["tools"] }] } },
+    } as never);
+
+    const items = (extracted as { ok: true; items: Array<Record<string, unknown>> }).items;
+    expect(items).toEqual([]);
+  });
+
+  test("only capability keys are enriched, not arbitrary fields", () => {
+    // A blanket fill-every-absent-key made the untrusted models[] array a way
+    // into any field the pipeline consumes.
+    const extracted = extractProviderModelItems({
+      models: [{ id: "m", context_length: 999, owned_by: "hostile" }],
+      data: [{ id: "m" }],
+    }, { maxModels: 100 } as never);
+
+    const items = (extracted as { ok: true; items: Array<Record<string, unknown>> }).items;
+    expect(items[0]).toEqual({ id: "m" });
+  });
 });

--- a/tests/catalog-llamacpp-capabilities.test.ts
+++ b/tests/catalog-llamacpp-capabilities.test.ts
@@ -62,9 +62,10 @@ describe("llama.cpp served context ingestion (#1797)", () => {
     expect(hints.contextWindow).toBe(32768);
   });
 
-  test("the dual-envelope body yields context but still no image evidence", () => {
-    // Characterization of the KNOWN remaining gap in #1797, so the follow-up fix
-    // has a live witness and a test to flip rather than a prose claim.
+  test("the dual-envelope body now yields BOTH context and image evidence", () => {
+    // Was a characterization of the #1797 gap: the multimodal token lived in
+    // models[] while discovery read only data[], so the row stayed image-blind.
+    // Both halves are now joined on exact id, and multimodal maps to image.
     const extracted = extractProviderModelItems(VERBATIM_LLAMACPP_BODY, {
       maxModels: 100,
     } as never);
@@ -74,7 +75,38 @@ describe("llama.cpp served context ingestion (#1797)", () => {
 
     const hints = catalogHintsFromModelsApiItem("lidge", items[0] as never);
     expect(hints.contextWindow).toBe(262144);
-    // The "multimodal" token was discarded with models[]; unknown, never false.
-    expect(hints.inputModalities).toBeUndefined();
+    expect(hints.inputModalities).toEqual(["text", "image"]);
+  });
+
+  test("a data[] value is never overridden by its sibling", () => {
+    // models[] is exactly the key discovery refuses to trust as a source of
+    // models. Enrichment fills only ABSENT keys, so an authoritative data[]
+    // entry always wins.
+    const extracted = extractProviderModelItems({
+      models: [{ id: "m", context_length: 999 }],
+      data: [{ id: "m", context_length: 111 }],
+    }, { maxModels: 100 } as never);
+    const items = (extracted as { ok: true; items: Array<Record<string, unknown>> }).items;
+    expect(items[0]!.context_length).toBe(111);
+  });
+
+  test("a model present only in the sibling array is still ignored", () => {
+    // Membership is decided entirely by data[]; the conservative boundary that
+    // refuses a stray models key is preserved.
+    const extracted = extractProviderModelItems({
+      models: [{ id: "ghost" }],
+      data: [{ id: "real" }],
+    }, { maxModels: 100 } as never);
+    const items = (extracted as { ok: true; items: Array<Record<string, unknown>> }).items;
+    expect(items.map(i => i.id)).toEqual(["real"]);
+  });
+
+  test("an ambiguous sibling id is skipped rather than guessed", () => {
+    const extracted = extractProviderModelItems({
+      models: [{ id: "m", context_length: 999 }, { id: "m", context_length: 555 }],
+      data: [{ id: "m" }],
+    }, { maxModels: 100 } as never);
+    const items = (extracted as { ok: true; items: Array<Record<string, unknown>> }).items;
+    expect(items[0]!.context_length).toBeUndefined();
   });
 });

--- a/tests/catalog-llamacpp-capabilities.test.ts
+++ b/tests/catalog-llamacpp-capabilities.test.ts
@@ -3,16 +3,17 @@ import { catalogHintsFromModelsApiItem } from "../src/codex/catalog/provider-fet
 import { extractProviderModelItems } from "../src/providers/model-discovery";
 
 /**
- * Regression coverage for the context half of #1797.
+ * Regression coverage for #1797 (llama.cpp dual-envelope metadata).
  *
- * A llama.cpp server reports its served context under `meta.n_ctx`, which was in
- * none of the recognized context fields, so a correct local server produced no
- * context evidence at all.
+ * A llama.cpp server splits one model across two arrays: an Ollama-style
+ * `models[]` carrying `capabilities` and an OpenAI-style `data[]` carrying
+ * `meta`. Discovery reads only `data[]`, so the served context (`meta.n_ctx`)
+ * and the image signal (`multimodal`) never met and a correct server produced
+ * a context-unknown, image-blind row.
  *
- * The image half of #1797 is NOT fixed here and is characterized below: the
- * `multimodal` token lives in the Ollama-style `models[]` array while discovery
- * deliberately reads only `data[]`, and even a merged item would stay
- * image-unknown because `multimodal` is not a recognized capability string.
+ * Both halves now resolve. The tests below also pin the boundary that makes
+ * the join safe: admission is decided on the original `data[]` row before any
+ * enrichment, and only capability keys are copied.
  */
 
 const VERBATIM_LLAMACPP_BODY = {


### PR DESCRIPTION
## Summary

Closes #1797 — the two halves #1799 deliberately deferred.

A llama.cpp server splits one model's metadata across two arrays: an Ollama-style `models[]` carrying `capabilities`, and an OpenAI-style `data[]` carrying `meta`. Discovery reads only `data[]` (deliberately — a stray `models` key must not be trusted as a source of models), so the served context and the image signal never met. A server that truthfully advertised multimodality still produced a context-unknown, image-blind row.

Two changes:

1. **`multimodal` is recognized as an image signal.** llama.cpp and Ollama-compatible servers emit it instead of `vision`/`image-input`. It is mapped to the closed `text|image` enum rather than passed through, because an out-of-enum modality makes Codex reject the entire catalog file.

2. **An admitted `data[]` row is enriched from a same-id sibling `models[]` entry.**

The conservative boundary that refuses a stray `models` key is preserved, and review hardened it twice:

- **Admission is decided on the original `data[]` row, before any enrichment.** The first attempt merged first, which let a sibling supply the exact field a provider filter required — reproduced against the real Chutes policy, where a row lacking `supported_features: ["tools"]` was admitted once a same-id sibling provided it. Enrichment may change what is *known* about a model, never *which* models are published.
- **Only `capabilities`, `modalities`, `input_modalities` are copied.** `supported_features` and `features` are deliberately excluded despite being capability-shaped: they are the two keys real filters test ([registry.ts:1591](https://github.com/lidge-jun/opencodex/blob/dev/src/providers/registry.ts#L1591), [:1883](https://github.com/lidge-jun/opencodex/blob/dev/src/providers/registry.ts#L1883)). Ordering already prevents a bypass, but a key that is both enrichable and filter-relevant is one refactor away from becoming one, and #1797 does not need them.
- Membership stays with `data[]`; a sibling-only entry is dropped. Matching is exact id equality (`id`, or Ollama's `model`/`name`), never fuzzy. An id claimed twice in the sibling array is skipped rather than guessed. The sibling array is bounded by the same limit as the primary envelope.

## Verification

End to end on the verbatim payload from the reporting server:

```
{"id":"qwen3.8-27b-nvfp4","provider":"llama","owned_by":"llamacpp",
 "contextWindow":262144,"inputModalities":["text","image"],
 "capabilities":["completion","multimodal"]}
```

Independent audit (gpt-5.6-sol explorer) returned FAIL on the first attempt for the admission bypass, then **PASS** after the fix. It re-ran its own Chutes reproduction and attacked every allowlisted key:

```
CHUTES  withoutSibling -> items: []   withSibling -> items: []
ALLOWLIST_FILTER_ATTACK=capabilities       items: []
ALLOWLIST_FILTER_ATTACK=features           items: []
ALLOWLIST_FILTER_ATTACK=supported_features items: []
ALLOWLIST_FILTER_ATTACK=modalities         items: []
ALLOWLIST_FILTER_ATTACK=input_modalities   items: []
```

Prototype pollution, non-object siblings, oversized/deeply-nested siblings, cross-key id collisions, and hostile modality injection were all probed and produced no further defect. Raw modality tokens cannot leak: `provider-fetch.ts` filters to `text|image|audio`, maps `multimodal`, and `catalog/parsing.ts` filters again before serialization.

Commands, run on an isolated Linux checkout at the exact head:

- `bun x tsc --noEmit` — exit 0
- `bun run test tests/catalog-llamacpp-capabilities.test.ts tests/routing-capability-catalog.test.ts tests/core-lab-boundary.test.ts` — 32 pass / 0 fail
- Auditor's broader run at the previous head — 317 pass / 0 fail across 9 files

Both new admission-boundary regressions fail without the source change (activation exit 1).

The test that previously characterized this gap is flipped, and three guards pin the boundary: `data[]` wins a conflict, sibling-only rows stay ignored, ambiguous ids are skipped.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved model discovery for multimodal models, including image-input support.
  * Enriched model listings with compatible capability, modality, and input information when available.

* **Bug Fixes**
  * Improved handling of duplicate, ambiguous, or filtered model entries.
  * Preserved existing filtering and prioritization rules when combining model metadata.

* **Tests**
  * Added coverage for image-capable models, metadata precedence, ambiguous identifiers, and provider filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->