### PR TITLE
fix(service): fail closed on systemctl probe errors

### DIFF
--- a/src/service-manager-probe.ts
+++ b/src/service-manager-probe.ts
@@ -63,6 +63,8 @@ export interface ProbeRunner {
     stderr: string;
     timedOut: boolean;
     spawnFailed: boolean;
+    /** Structured spawn failure provenance; stderr is not a safe discriminator. */
+    spawnErrorCode?: string;
   };
 }
 
@@ -84,13 +86,16 @@ export const defaultProbeRunner: ProbeRunner = (file, args) => {
     windowsHide: true,
     timeout: SERVICE_PROBE_TIMEOUT_MS,
   });
+  const spawnErrorCode = (result.error as NodeJS.ErrnoException | undefined)?.code;
+  const timedOut = spawnErrorCode === "ETIMEDOUT" || result.signal !== null;
   return {
     status: result.status,
     stdout: String(result.stdout ?? ""),
     stderr: String(result.stderr ?? ""),
-    // `signal` is SIGTERM when the timeout fired; a spawn failure sets `error`.
-    timedOut: result.signal !== null && result.error === undefined,
-    spawnFailed: result.error !== undefined,
+    // Node-compatible spawnSync reports a timeout through both `error` and SIGTERM.
+    timedOut,
+    spawnFailed: result.error !== undefined && !timedOut,
+    spawnErrorCode,
   };
 };
 
@@ -251,6 +256,41 @@ function systemdProperty(out: string, key: string): string | null {
   return null;
 }
 
+function inspectSystemdDefinition(
+  definitionPath: string,
+  registration: "present" | "absent",
+): ServiceManagerInstallation {
+  const definition = artifactPresence(definitionPath);
+  if (definition === "absent") {
+    return registration === "absent"
+      ? { kind: "absent" }
+      : unknown("systemd knows this unit but its file is missing");
+  }
+  if (definition === "unreadable") {
+    return unknown("the systemd unit path exists but could not be inspected");
+  }
+
+  let body: string;
+  try {
+    body = readFileSync(definitionPath, "utf-8");
+  } catch {
+    return unknown("the systemd unit exists but could not be read");
+  }
+
+  return {
+    kind: "present",
+    claims: [{
+      backend: "systemd",
+      definitionPath,
+      homes: {
+        codexHome: unitEnvValue(body, "CODEX_HOME"),
+        opencodexHome: unitEnvValue(body, "OPENCODEX_HOME"),
+      },
+      registration,
+    }],
+  };
+}
+
 function inspectSystemd(deps: Required<Pick<ProbeDeps, "run" | "home">>): ServiceManagerInstallation {
   const definitionPath = join(deps.home, ".config", "systemd", "user", `${TASK}.service`);
 
@@ -264,8 +304,17 @@ function inspectSystemd(deps: Required<Pick<ProbeDeps, "run" | "home">>): Servic
     "--user", "show", TASK,
     "-p", "LoadState", "-p", "ActiveState", "-p", "FragmentPath", "-p", "NeedDaemonReload",
   ]);
-  if (shown.spawnFailed) return { kind: "absent" };
   if (shown.timedOut) return unknown("systemctl could not be asked: timed out");
+  if (shown.spawnFailed) {
+    if (shown.spawnErrorCode === "ENOENT") {
+      // systemd-less containers are usable only when no unit definition remains.
+      return inspectSystemdDefinition(definitionPath, "absent");
+    }
+    const errorCode = shown.spawnErrorCode && /^[A-Z0-9_]{1,32}$/.test(shown.spawnErrorCode)
+      ? shown.spawnErrorCode
+      : "unknown error";
+    return unknown(`systemctl could not be spawned (${errorCode})`);
+  }
   if (shown.status !== 0) {
     // A missing unit still exits ZERO and says not-found; a non-zero status means
     // the question never reached the bus.
@@ -285,32 +334,7 @@ function inspectSystemd(deps: Required<Pick<ProbeDeps, "run" | "home">>): Servic
 
   const registration: "present" | "absent" =
     loadState === "not-found" && activeState === "inactive" && !fragmentPath ? "absent" : "present";
-
-  if (artifactPresence(definitionPath) === "absent") {
-    return registration === "absent"
-      ? { kind: "absent" }
-      : unknown("systemd knows this unit but its file is missing");
-  }
-
-  let body: string;
-  try {
-    body = readFileSync(definitionPath, "utf-8");
-  } catch (error) {
-    return unknown(`the systemd unit exists but could not be read: ${String(error)}`);
-  }
-
-  return {
-    kind: "present",
-    claims: [{
-      backend: "systemd",
-      definitionPath,
-      homes: {
-        codexHome: unitEnvValue(body, "CODEX_HOME"),
-        opencodexHome: unitEnvValue(body, "OPENCODEX_HOME"),
-      },
-      registration,
-    }],
-  };
+  return inspectSystemdDefinition(definitionPath, registration);
 }
 
 /**

--- a/tests/service-probe-docker.test.ts
+++ b/tests/service-probe-docker.test.ts
@@ -1,27 +1,152 @@
 import { expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  defaultProbeRunner,
   inspectServiceManagerInstallation,
   type ProbeRunner,
 } from "../src/service-manager-probe";
+import { inspectNativeCodexOwnership } from "../src/integrations/native/ownership-preflight";
 
-test("Linux reports systemd absent when systemctl cannot be spawned", () => {
-  const home = mkdtempSync(join(tmpdir(), "ocx-probe-docker-"));
-  const run: ProbeRunner = () => ({
+function failedSystemctl(
+  spawnErrorCode: string | undefined,
+  timedOut = false,
+): ProbeRunner {
+  return () => ({
     status: null,
     stdout: "",
-    stderr: "spawn systemctl ENOENT",
-    timedOut: false,
-    spawnFailed: true,
+    stderr: spawnErrorCode ? `spawn systemctl ${spawnErrorCode}` : "spawn systemctl failed",
+    timedOut,
+    spawnFailed: !timedOut,
+    spawnErrorCode,
   });
+}
+
+test("Linux reports systemd absent when systemctl is missing and no unit exists", () => {
+  const home = mkdtempSync(join(tmpdir(), "ocx-probe-docker-"));
 
   try {
-    expect(inspectServiceManagerInstallation({ run, platform: "linux", home })).toEqual({
+    expect(inspectServiceManagerInstallation({
+      run: failedSystemctl("ENOENT"),
+      platform: "linux",
+      home,
+    })).toEqual({
       kind: "absent",
     });
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("the default probe preserves a missing executable's structured error code", () => {
+  const home = mkdtempSync(join(tmpdir(), "ocx-probe-runner-"));
+  try {
+    expect(defaultProbeRunner(join(home, "missing-systemctl"), [])).toMatchObject({
+      timedOut: false,
+      spawnFailed: true,
+      spawnErrorCode: "ENOENT",
+    });
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("the default probe classifies a spawnSync timeout as a timeout", () => {
+  const result = defaultProbeRunner(process.execPath, ["-e", "await Bun.sleep(10_000)"]);
+  expect(result.timedOut).toBe(true);
+  expect(result.spawnFailed).toBe(false);
+});
+
+test.each([
+  ["ETIMEDOUT", "ETIMEDOUT", true],
+  ["EACCES", "EACCES", false],
+  ["missing-code", undefined, false],
+] as const)("Linux does not treat a %s systemctl failure as absent", (_label, spawnErrorCode, timedOut) => {
+  const home = mkdtempSync(join(tmpdir(), "ocx-probe-failure-"));
+  try {
+    expect(inspectServiceManagerInstallation({
+      run: failedSystemctl(spawnErrorCode, timedOut),
+      platform: "linux",
+      home,
+    }).kind).toBe("unknown");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("Linux ownership remains unknown when systemctl cannot be executed", () => {
+  const home = mkdtempSync(join(tmpdir(), "ocx-probe-ownership-"));
+  const codexHome = join(home, ".codex");
+  const opencodexHome = join(home, ".opencodex");
+  try {
+    const result = inspectNativeCodexOwnership({
+      run: failedSystemctl("EACCES"),
+      platform: "linux",
+      home,
+      statePaths: [],
+      currentHomes: { codexHome, opencodexHome },
+    });
+    expect(result.ownership).toBe("unknown");
+    expect(result.reason).toContain("EACCES");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("a staged unit remains visible when systemctl is missing", () => {
+  const home = mkdtempSync(join(tmpdir(), "ocx-probe-staged-"));
+  const codexHome = join(home, ".codex");
+  const opencodexHome = join(home, ".opencodex");
+  const definitionPath = join(home, ".config", "systemd", "user", "opencodex-proxy.service");
+  mkdirSync(join(home, ".config", "systemd", "user"), { recursive: true });
+  writeFileSync(definitionPath, [
+    "[Service]",
+    `Environment=\"CODEX_HOME=${codexHome}\"`,
+    `Environment=\"OPENCODEX_HOME=${opencodexHome}\"`,
+  ].join("\n"));
+
+  try {
+    expect(inspectServiceManagerInstallation({
+      run: failedSystemctl("ENOENT"),
+      platform: "linux",
+      home,
+    })).toEqual({
+      kind: "present",
+      claims: [{
+        backend: "systemd",
+        definitionPath,
+        homes: { codexHome, opencodexHome },
+        registration: "absent",
+      }],
+    });
+
+    const ownership = inspectNativeCodexOwnership({
+      run: failedSystemctl("ENOENT"),
+      platform: "linux",
+      home,
+      statePaths: [],
+      currentHomes: { codexHome, opencodexHome },
+    });
+    expect(ownership.ownership).toBe("unknown");
+    expect(ownership.reason).toContain("no service state file");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("an unreadable staged unit is unknown when systemctl is missing", () => {
+  const home = mkdtempSync(join(tmpdir(), "ocx-probe-unreadable-"));
+  const definitionPath = join(home, ".config", "systemd", "user", "opencodex-proxy.service");
+  mkdirSync(definitionPath, { recursive: true });
+
+  try {
+    expect(inspectServiceManagerInstallation({
+      run: failedSystemctl("ENOENT"),
+      platform: "linux",
+      home,
+    }).kind).toBe("unknown");
   } finally {
     rmSync(home, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- Keep the Linux `systemctl` ownership probe fail-closed when process startup times out, is denied, or fails for an unknown reason.
- Preserve the systemd-less container behavior from #1612 only for structured `ENOENT` with no user unit definition.
- Inspect a staged user unit even when `systemctl` is unavailable, so existing and foreign ownership claims remain visible to native-write preflight.

Exact base: `aa9df919a524ac6bf53888779b9144471a2a4769`  
Exact head: `efe90982a70e188283d3e5554c22539dfb3fa1f7`

`spawnSync` timeouts can report both a termination signal and `error.code=ETIMEDOUT`. Treating any spawn error as “systemd absent” can let an unprovable manager state pass ownership checks. This change preserves the structured error code, distinguishes only `ENOENT` from other startup failures, and reuses the normal unit-definition parser for the `ENOENT` fallback.

## Verification

- exact-head Bun 1.3.14 `tests/service-probe-docker.test.ts` — 9 pass, 0 fail, 13 assertions
- exact-head `bun run typecheck`, `bun run privacy:scan`, and `git diff --check` — passed
- broader content-equivalent validation previously passed on Bun 1.3.14 and Bun 1.4 canary: 67 pass, 1 platform skip, 160 assertions
- stable patch ID remains `5104bc2ba6cf3fc3d90261443379f6d8d40a5f91`
- two independent correctness/contract reviews and the Codex Security scan found no P0-P2 issue
- maintained exact-head Cross-platform CI and React Doctor remain separate merge gates

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No public configuration or CLI contract changes.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved service detection when system tools are missing, unavailable, or fail unexpectedly.
  - Distinguishes timeouts, missing executables, unreadable service definitions, and other startup failures.
  - Preserves more specific error details while presenting sanitized results.
  - Improves detection of installed service definitions even when the related command cannot run.
- **Tests**
  - Added coverage for Docker and systemd probing failures, timeouts, ownership detection, and staged or unreadable service definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->