### PR TITLE
fix(windows): trust ScheduledTasks module during elevation

### DIFF
--- a/src/lib/windows-elevation.ts
+++ b/src/lib/windows-elevation.ts
@@ -640,15 +640,21 @@ export function runWindowsElevatedScheduledTaskRegistration(
   xml: string,
 ): Promise<number> {
   const xmlBase64 = Buffer.from(xml, "utf16le").toString("base64");
+  const powerShellPath = windowsPowerShell();
+  const powerShellDirectory = powerShellPath.replace(/[\\/][^\\/]+$/, "");
+  const scheduledTasksModule = `${powerShellDirectory}\\Modules\\ScheduledTasks\\ScheduledTasks.psd1`;
   const inner = [
     `$taskName = ${psSingleQuote(taskName)}`,
     `$xmlBase64 = ${psSingleQuote(xmlBase64)}`,
     "$xml = [Text.Encoding]::Unicode.GetString([Convert]::FromBase64String($xmlBase64))",
-    "Register-ScheduledTask -TaskName $taskName -Xml $xml -Force -ErrorAction Stop | Out-Null",
+    `$module = Microsoft.PowerShell.Core\\Import-Module -Name ${psSingleQuote(scheduledTasksModule)} -PassThru -Force -ErrorAction Stop`,
+    "$registerTask = $module.ExportedCommands['Register-ScheduledTask']",
+    "if ($null -eq $registerTask) { throw 'Trusted ScheduledTasks module does not export Register-ScheduledTask.' }",
+    "& $registerTask -TaskName $taskName -Xml $xml -Force -ErrorAction Stop | Out-Null",
   ].join("; ");
   const encodedCommand = Buffer.from(inner, "utf16le").toString("base64");
   const script = [
-    `$p = Start-Process -FilePath ${psSingleQuote(windowsPowerShell())}`,
+    `$p = Start-Process -FilePath ${psSingleQuote(powerShellPath)}`,
     ` -ArgumentList ${psSingleQuote(buildWindowsElevatedArgumentList([
       "-NoProfile",
       "-NonInteractive",

--- a/tests/windows-elevation-spawn.test.ts
+++ b/tests/windows-elevation-spawn.test.ts
@@ -190,7 +190,16 @@ describe("runWindowsElevated spawn contract", () => {
     const match = /-EncodedCommand ([A-Za-z0-9+/=]+)/.exec(commandScript);
     expect(match).not.toBeNull();
     const elevatedScript = Buffer.from(match![1]!, "base64").toString("utf16le");
-    expect(elevatedScript).toContain("Register-ScheduledTask -TaskName $taskName -Xml $xml -Force");
+    expect(elevatedScript).toContain(
+      "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules\\ScheduledTasks\\ScheduledTasks.psd1",
+    );
+    expect(elevatedScript).toContain("Microsoft.PowerShell.Core\\Import-Module");
+    expect(elevatedScript).toContain("$module.ExportedCommands['Register-ScheduledTask']");
+    expect(elevatedScript).toContain(
+      "Trusted ScheduledTasks module does not export Register-ScheduledTask.",
+    );
+    expect(elevatedScript).toContain("& $registerTask -TaskName $taskName -Xml $xml -Force");
+    expect(elevatedScript.match(/\bRegister-ScheduledTask\b/g)).toHaveLength(2);
     expect(elevatedScript).toContain(Buffer.from(xml, "utf16le").toString("base64"));
     expect(commandScript).not.toContain("/xml");
     expect(commandScript).not.toContain("task.xml");


### PR DESCRIPTION
## Summary

- Import the Windows `ScheduledTasks` module from the absolute manifest beside the already trusted System32 Windows PowerShell executable.
- Invoke the module's exported `Register-ScheduledTask` command object and fail closed when the export is unavailable, instead of relying on inherited command/module lookup during elevation.
- Pin the elevated-script contract so any additional bare `Register-ScheduledTask` invocation fails the focused regression test.

## Verification

- Exact-head Bun 1.3.14: `tests/windows-elevation-spawn.test.ts` + `tests/ports.test.ts` — **62 pass, 0 fail, 208 assertions**.
- Exact-head `bun run typecheck`, `bun run privacy:scan`, and `git diff --check` — passed.
- Stable patch ID remains `3da4d08777d0e169590e0e093a70fa6cb17daa62`.
- The broader content-equivalent Windows elevation selection was previously validated on Bun 1.3.14 and Bun 1.4.0-canary.1: 51 pass, 170 assertions.
- Windows PowerShell 5.1 x64 absolute ScheduledTasks manifest smoke previously passed.
- Real UAC / Task Scheduler registration and Windows ARM64 were not exercised locally.
- The prior maintained macOS run failed the unchanged timing-sensitive `findAvailablePort retries the preferred port briefly before falling back` test. That exact test passes on this Windows exact head, but a clean maintained macOS job is still required before claiming cross-platform CI green.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and security when creating scheduled tasks through elevated PowerShell.
  * Ensured the required task-registration command is loaded from a trusted system module before use.
  * Added clearer error handling when the scheduled-task command is unavailable.

* **Tests**
  * Expanded coverage for module loading, command validation, and invocation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->