### PR TITLE
chore(deps): bump @bufbuild/protobuf to 2.14.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@bitkyc08/opencodex",
       "dependencies": {
-        "@bufbuild/protobuf": "^2.13.0",
+        "@bufbuild/protobuf": "^2.14.0",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@napi-rs/keyring": "1.3.0",
         "bun": "1.3.14",
@@ -27,7 +27,7 @@
     "ip-address": "^10.4.0",
   },
   "packages": {
-    "@bufbuild/protobuf": ["@bufbuild/protobuf@2.13.0", "", {}, "sha512-acq7c49vxfm1ggJ95P70TX7ABDM0vxr1SYD3BB0o0jnBLB4OAqeHyKuN+cD3w80gXEDQ2zxHpR6CUeA+O/aU9g=="],
+    "@bufbuild/protobuf": ["@bufbuild/protobuf@2.14.0", "", {}, "sha512-C3UGsiCwSprE2NKIIFA3hCDlpXTMCAXRZuEVp88L1GY36Y41+rYL5fryE+nOFhp4p4JPQvdV8PQ4DWgHgeTE+w=="],
 
     "@hono/node-server": ["@hono/node-server@2.1.0", "", { "peerDependencies": { "hono": "^4" } }, "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg=="],
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "setup:hooks": "bun scripts/setup-hooks.ts"
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^2.13.0",
+    "@bufbuild/protobuf": "^2.14.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@napi-rs/keyring": "1.3.0",
     "bun": "1.3.14",


### PR DESCRIPTION
## Summary

- Bump `@bufbuild/protobuf` from 2.13.0 to 2.14.0 in the root workspace.

## Verification

- `bun install` regenerates the lockfile cleanly (protobuf only).
- `bun run typecheck` passes.
- `bun run test`: every executed test passed. NOTE: the Bun test runner panics
  at teardown on this Windows machine (`Internal assertion failure`,
  `bun.report/1.3.14`), reproducing identically on pristine `dev` with no
  changes — pre-existing, unrelated to this bump.
- `bun audit` clean.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the protobuf library dependency to a newer version, incorporating the latest available improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->