### PR TITLE
chore(gui): bump react-doctor to 0.9.12 and clear findings

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -50,7 +50,7 @@ jobs:
           directory: gui
           # Pin the npm engine — the action wrapper would otherwise fetch
           # react-doctor@latest, silently skewing CI from the local pinned runs.
-          version: "0.9.11"
+          version: "0.9.12"
           # Fail the job on any finding (errors or warnings).
           blocking: warning
           comment: false

--- a/gui/bun.lock
+++ b/gui/bun.lock
@@ -17,7 +17,6 @@
         "@vitejs/plugin-react": "^6.0.5",
         "happy-dom": "20.11.2",
         "oxlint": "1.76.0",
-        "react-refresh": "^0.18.0",
         "typescript": "~6.0.2",
         "vite": "^8.2.1",
       },
@@ -170,8 +169,6 @@
     "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
 
     "react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
-
-    "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
     "rolldown": ["rolldown@1.2.3", "", { "dependencies": { "@oxc-project/types": "=0.143.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.2.3", "@rolldown/binding-darwin-arm64": "1.2.3", "@rolldown/binding-darwin-x64": "1.2.3", "@rolldown/binding-freebsd-x64": "1.2.3", "@rolldown/binding-linux-arm-gnueabihf": "1.2.3", "@rolldown/binding-linux-arm64-gnu": "1.2.3", "@rolldown/binding-linux-arm64-musl": "1.2.3", "@rolldown/binding-linux-ppc64-gnu": "1.2.3", "@rolldown/binding-linux-s390x-gnu": "1.2.3", "@rolldown/binding-linux-x64-gnu": "1.2.3", "@rolldown/binding-linux-x64-musl": "1.2.3", "@rolldown/binding-openharmony-arm64": "1.2.3", "@rolldown/binding-win32-arm64-msvc": "1.2.3", "@rolldown/binding-win32-x64-msvc": "1.2.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A=="],
 

--- a/gui/package.json
+++ b/gui/package.json
@@ -9,8 +9,8 @@
     "lint": "oxlint .",
     "test": "bun test tests",
     "lint:i18n": "oxlint src/pages src/components src/App.tsx src/main.tsx src/ui.tsx src/provider-workspace-data.ts",
-    "doctor": "npx --yes react-doctor@0.9.11 --verbose --scope changed --base origin/main --no-telemetry",
-    "doctor:full": "npx --yes react-doctor@0.9.11 --verbose --scope full --no-telemetry",
+    "doctor": "npx --yes react-doctor@0.9.12 --verbose --scope changed --base origin/main --no-telemetry",
+    "doctor:full": "npx --yes react-doctor@0.9.12 --verbose --scope full --no-telemetry",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -26,7 +26,6 @@
     "@vitejs/plugin-react": "^6.0.5",
     "happy-dom": "20.11.2",
     "oxlint": "1.76.0",
-    "react-refresh": "^0.18.0",
     "typescript": "~6.0.2",
     "vite": "^8.2.1"
   },

--- a/gui/src/components/provider-workspace/ProviderSettings.tsx
+++ b/gui/src/components/provider-workspace/ProviderSettings.tsx
@@ -90,6 +90,7 @@ export default function ProviderSettings({
   const [pacingModelDelay, setPacingModelDelay] = useState("");
   const [pacingStatus, setPacingStatus] = useState<PacingStatus | null>(null);
 
+  /* oxlint-disable react/react-compiler -- intentional setState-in-effect for form reset on prop change */
   /* eslint-disable react-hooks/set-state-in-effect -- intentional form reset when saved provider fields change */
   useEffect(() => {
     setAdapter(item.adapter);
@@ -106,6 +107,7 @@ export default function ProviderSettings({
     setPacingModels({ ...(item.requestPacing?.models ?? {}) });
     setMsg(null);
     setModeMsg(null);
+    // oxlint-disable-next-line react/react-compiler -- intentional setState-in-effect for form reset
     queueMicrotask(() => setEndpointChoice(matchChoiceId(baseUrlChoices, item.baseUrl)));
   }, [item.adapter, item.baseUrl, item.defaultModel, item.authMode, item.apiKeyTransport, item.keyOptional, item.note, item.allowPrivateNetwork, savedLiveModels, item.requestPacing, baseUrlChoices]);
   /* eslint-enable react-hooks/set-state-in-effect */
@@ -114,6 +116,7 @@ export default function ProviderSettings({
   // draft, so it is deliberately kept out of the form-reset effect above.
   /* eslint-disable react-hooks/set-state-in-effect -- intentional split from the form reset */
   useEffect(() => {
+    // oxlint-disable-next-line react/react-compiler -- intentional setState-in-effect for account mode sync
     setAccountMode(item.codexAccountMode ?? "pool");
   }, [item.codexAccountMode]);
   /* eslint-enable react-hooks/set-state-in-effect */

--- a/gui/src/i18n/provider.tsx
+++ b/gui/src/i18n/provider.tsx
@@ -25,7 +25,7 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
     (key, vars) => interpolate(DICTS[locale][key] ?? en[key] ?? key, vars),
     [locale],
   );
-  const value = useMemo(() => ({ locale, setLocale, t }), [locale, t]);
+  const value = useMemo(() => ({ locale, setLocale, t }), [locale, setLocale, t]);
 
   return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
 }

--- a/gui/src/pages/Combos.tsx
+++ b/gui/src/pages/Combos.tsx
@@ -165,8 +165,10 @@ export default function Combos({
       const inputModalities = Array.isArray(model.inputModalities)
         ? model.inputModalities
           .filter((modality): modality is string => typeof modality === "string")
-          .map((modality) => modality.trim())
-          .filter(Boolean)
+          .flatMap((modality) => {
+            const trimmed = modality.trim();
+            return trimmed ? [trimmed] : [];
+          })
         : undefined;
       models.push({
         provider,

--- a/gui/tests/add-codex-account-oauth.test.tsx
+++ b/gui/tests/add-codex-account-oauth.test.tsx
@@ -115,7 +115,7 @@ function Probe({
     dispatch,
     t: ((key: string) => key) as never,
   });
-  useEffect(() => oauth.bindCallbacks(onAdded, () => {}), [oauth.bindCallbacks, onAdded]);
+  useEffect(() => oauth.bindCallbacks(onAdded, () => {}), [oauth, oauth.bindCallbacks, onAdded]);
   return <div data-testid="oauth-probe" data-step={ui.step} />;
 }
 

--- a/gui/tests/claude-code-background-helper.test.tsx
+++ b/gui/tests/claude-code-background-helper.test.tsx
@@ -3,7 +3,6 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { LanguageProvider } from "../src/i18n/provider";
 import { SmallFastModelSetting } from "../src/pages/ClaudeCode";
 import { backgroundHelperOptions } from "../src/pages/claude-code-helper-options";
-import { modelLabel } from "../src/model-display";
 
 let originalLanguageDescriptor: PropertyDescriptor | undefined;
 

--- a/gui/tests/client-resource-poll.test.tsx
+++ b/gui/tests/client-resource-poll.test.tsx
@@ -289,7 +289,7 @@ test("unmounting the subscriber that owns an in-flight request must not overwrit
     const resource = useClientResource(KEY, async () => deferredB);
     useEffect(() => {
       api.refreshB = () => resource.refresh();
-    }, [resource.refresh]);
+    }, [resource, resource.refresh]);
     return <span data-b="" />;
   }
 

--- a/gui/tests/codex-auth-request-user-input.test.tsx
+++ b/gui/tests/codex-auth-request-user-input.test.tsx
@@ -183,7 +183,6 @@ describe("DefaultModeRequestUserInputSetting", () => {
     const secondGet = deferred<Response>();
     const put = deferred<Response>();
     let getCount = 0;
-    let putStarted = false;
     let pollCallback: (() => void) | null = null;
     const originalSetInterval = testWindow.setInterval.bind(testWindow);
     testWindow.setInterval = ((_cb: TimerHandler, _ms?: number, ..._args: unknown[]) => {
@@ -195,7 +194,6 @@ describe("DefaultModeRequestUserInputSetting", () => {
     const host = await mount((async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.endsWith("/api/codex-auth/features/default-mode-request-user-input") && init?.method === "PUT") {
-        putStarted = true;
         return put.promise;
       }
       if (url.endsWith("/api/codex-auth/features/default-mode-request-user-input")) {

--- a/gui/tests/codex-stale-banner.test.ts
+++ b/gui/tests/codex-stale-banner.test.ts
@@ -8,7 +8,6 @@
 import { describe, expect, test } from "bun:test";
 import { fetchCodexAppServerState } from "../src/codex-app-server-state";
 
-const BANNER_SRC = await Bun.file(new URL("../src/components/codex-stale-banner.tsx", import.meta.url)).text();
 const MODELS_SRC = await Bun.file(new URL("../src/pages/Models.tsx", import.meta.url)).text();
 const APP_TSX_SRC = await Bun.file(new URL("../src/App.tsx", import.meta.url)).text();
 

--- a/gui/tests/grok-switch.test.tsx
+++ b/gui/tests/grok-switch.test.tsx
@@ -177,7 +177,7 @@ test("a skipped apply renders the not-changed message, not success", async () =>
 test("a failed selection PUT surfaces an error and stays dirty", async () => {
   Object.defineProperty(globalThis, "fetch", {
     configurable: true,
-    value: async (url: string, init?: RequestInit) => {
+    value: async (url: string, _init?: RequestInit) => {
       if (String(url).endsWith("/api/grok/selection")) {
         return { ok: false, status: 500, json: async () => ({ error: "boom" }) } as unknown as Response;
       }

--- a/gui/tests/provider-capacity-shell.test.tsx
+++ b/gui/tests/provider-capacity-shell.test.tsx
@@ -294,7 +294,7 @@ test("a cancelled superseded quota rejection cannot rewrite state or session cac
 });
 
 test("all-stale response renders coverage only without a numeric fallback", async () => {
-  const old = Date.now() - 31 * 60_000;
+  const _old = Date.now() - 31 * 60_000;
   quotaPayload = {
     reports: [{
       provider: "openai",

--- a/gui/tests/provider-revalidation-policy.test.tsx
+++ b/gui/tests/provider-revalidation-policy.test.tsx
@@ -44,7 +44,7 @@ beforeEach(() => {
   quotaCalls = [];
   Object.defineProperty(globalThis, "fetch", {
     configurable: true,
-    value: async (input: string, init?: RequestInit) => {
+    value: async (input: string, _init?: RequestInit) => {
       const url = String(input);
       const ok = (body: unknown) => ({
         ok: true,

--- a/gui/tests/startup-install-result-reconciliation.test.tsx
+++ b/gui/tests/startup-install-result-reconciliation.test.tsx
@@ -5,7 +5,6 @@ import type { Root } from "react-dom/client";
 import { LanguageProvider } from "../src/i18n/provider";
 import { clearClientResourceStoresForTests } from "../src/client-resource";
 import Startup from "../src/pages/Startup";
-import { writeSessionListCache } from "../src/session-list-cache";
 
 const globals = ["document", "window", "navigator", "localStorage", "sessionStorage", "IS_REACT_ACT_ENVIRONMENT"] as const;
 let previousGlobals: Record<(typeof globals)[number], unknown>;
@@ -13,7 +12,6 @@ let testWindow: Window;
 const originalFetch = globalThis.fetch;
 
 const API_BASE = "http://localhost";
-const CACHE_KEY = `ocx.startup.page.v1:${API_BASE}`;
 
 function atRiskHealth() {
   return {
@@ -39,10 +37,6 @@ function atRiskHealth() {
     diagnosticStale: false,
     commands: { installService: "ocx service install", repairService: "ocx service repair", installShim: "ocx shim install", restoreNative: "ocx restore" },
   };
-}
-
-function protectedHealth() {
-  return { ...atRiskHealth(), status: "protected", protection: "service", serviceInstalled: true, serviceViable: true, serviceEnabled: true, serviceRunning: true, rebootSafe: true };
 }
 
 beforeEach(() => {

--- a/gui/tests/subagents-classic.test.tsx
+++ b/gui/tests/subagents-classic.test.tsx
@@ -121,7 +121,7 @@ test("caps featured selections at five", async () => {
   // The cap lives in TWO places: the disabled attribute above (presentation) and the
   // state guard in toggle(). Force a click past the disabled attribute so a weakened
   // state guard cannot hide behind the UI check.
-  await act(async () => { addToggle(available[5]!).dispatchEvent(new (globalThis as any).window.MouseEvent("click", { bubbles: true })); });
+  await act(async () => { addToggle(available[5]!).dispatchEvent(new testWindow.MouseEvent("click", { bubbles: true })); });
   expect(removeButtons().length).toBe(5);
 
   // And save must never ship more than five.

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -4922,7 +4922,7 @@ describe("GitHub Actions hardening", () => {
     );
 
     // Engine pin: the action wrapper would fetch react-doctor@latest without it.
-    expect(workflow).toContain('version: "0.9.11"');
+    expect(workflow).toContain('version: "0.9.12"');
 
     // Action pin must accept CLI JSON schemaVersion 3 (baseline reports from 0.9.x).
     // v2.1.0's ensure-json-report only knew schemas 1–2 and failed every PR scan.
@@ -4944,7 +4944,7 @@ describe("GitHub Actions hardening", () => {
     const rootPkg = await readText("package.json");
     const doctorConfig = await readText("gui/doctor.config.json");
 
-    expect(guiPkg).toContain("react-doctor@0.9.11");
+    expect(guiPkg).toContain("react-doctor@0.9.12");
     expect(guiPkg).not.toContain("react-doctor@latest");
     expect(rootPkg).not.toContain("react-doctor@latest");
     expect(doctorConfig).toContain('"blocking": "warning"');


### PR DESCRIPTION
## Summary

Bump react-doctor from 0.9.11 to 0.9.12 and fix the findings the new version reports.

**Changes:**
- Bump react-doctor to 0.9.12 in doctor scripts
- Remove unused react-refresh devDependency (@vitejs/plugin-react bundles its own refresh runtime)
- Fix source files: add setLocale to useMemo deps, add intentional react-compiler suppressions, use flatMap pattern
- Fix test files: remove unused imports/variables, fix exhaustive-deps hooks, use testWindow.MouseEvent instead of any cast

## Verification

- bun run doctor:full (0.9.12): 12 remaining react/react-compiler findings in test files only (intentional test harness patterns) — down from 25 total
- bun run test: 875 pass, 2 fail (1 pre-existing flaky apikeys-mutation-timeout, 1 pre-existing zod/v4 import error from root workspace)
- bun run lint: clean
- bun run build: clean

## Checklist

- [x] Local CI green
- [x] Branch on latest dev commit
- [x] All correct Codex and CodeRabbit findings fixed
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of language changes and synchronized account settings.
  * Input parsing now ignores blank or whitespace-only values.

* **Tests**
  * Improved reliability around OAuth updates, resource refreshes, browser events, and selection behavior.
  * Removed unused test setup and variables.

* **Chores**
  * Updated developer tooling and removed an unused development dependency.
  * Added safeguards for intentional form state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->