### PR TITLE
fix(routing): let fallback skip a candidate the request cannot fit

### DIFF
--- a/src/combos/failover.ts
+++ b/src/combos/failover.ts
@@ -124,6 +124,16 @@ export function comboFailureDecision(
   if (["origin_rejected", "context_length_exceeded", "invalid_request_error"].includes(error.code ?? "")) {
     return "stop";
   }
+  // A local input-admission refusal (#1524) says "this candidate cannot fit the request",
+  // not "the request is impossible". Hopping is exactly right: the next candidate may have a
+  // larger context window. Read it from the structured code OR the body text, because the
+  // generic classifier maps 413 to its own code and would otherwise swallow this signal.
+  // Upstream `context_length_exceeded` above still stops.
+  if (options?.code === "input_admission_refused"
+    || error.code === "input_admission_refused"
+    || message.includes("input_admission_refused")) {
+    return "hop";
+  }
   if ([401, 403, 404, 408, 429].includes(status) || status >= 500) return "hop";
   if ([
     "permission_denied",

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -1969,9 +1969,14 @@ async function handleResponsesInner(
   if (parsed._compactionRequest !== true) {
     const inputAdmission = checkInputAdmission(parsed, route.provider, route.providerName, parsed.modelId);
     if (!inputAdmission.admitted) {
+      // #1524: this is a LOCAL preflight refusal, not an upstream verdict. A policy or combo
+      // fallback must be able to skip this candidate and try one whose context window fits,
+      // instead of treating the first incompatible candidate as the end of the chain. The
+      // distinct code is what lets the fallback layer tell the two apart -- an upstream
+      // `context_length_exceeded` still stops, because retrying it elsewhere is guesswork.
       return formatErrorResponse(
         413,
-        "request_too_large",
+        "input_admission_refused",
         `Estimated input (~${inputAdmission.estimatedTokens} tokens) is far past the context window `
           + `of ${parsed.modelId} (${inputAdmission.ceiling} tokens). Start a new session or choose a `
           + `model with a larger context window.`,

--- a/tests/combos.test.ts
+++ b/tests/combos.test.ts
@@ -357,6 +357,14 @@ describe("combo failure policy and advancement", () => {
     expect(comboFailureDecision(409, "conflict")).toBe("stop");
     expect(comboFailureDecision(499, "client cancelled")).toBe("stop");
     expect(comboFailureDecision(422, "invalid_api_key")).toBe("hop");
+    // #1524: a LOCAL input-admission refusal means "this candidate cannot fit the request",
+    // not "the request is impossible". The next candidate may have a larger context window,
+    // so the chain must continue instead of ending at the first incompatible target.
+    expect(comboFailureDecision(413, '{"code":"input_admission_refused"}')).toBe("hop");
+    // An UPSTREAM context verdict still stops: retrying that elsewhere is guesswork, and a
+    // generic 413 with no structured code keeps its existing conservative handling.
+    expect(comboFailureDecision(400, "context_length_exceeded")).toBe("stop");
+    expect(comboFailureDecision(413, "request too large")).toBe("stop");
   });
 
   test("failure clears the active sticky target without adding a success", () => {


### PR DESCRIPTION
## Summary

An oversized request was never silently sent — `checkInputAdmission` (`src/server/responses/input-admission.ts:159`) already refuses it before any upstream I/O, and it runs on every concrete retry. The defect #1524 describes is what happens *next*: that local 413 was classified `request_too_large`, which `comboFailureDecision` treats as `stop`, so the **first** candidate whose context window was too small ended the fallback chain. A larger-window candidate sitting behind it was never tried.

The local preflight refusal now carries its own code, `input_admission_refused`, and that code is hop-eligible. The distinction is the point:

- `input_admission_refused` is *our* verdict about *this* candidate, so another candidate may well fit.
- Upstream `context_length_exceeded`, and a generic 413 with no structured code, still stop — retrying those elsewhere is guesswork.

The code is read from the structured field, the classified error, and the body text, because the generic classifier maps 413 to its own code and would otherwise swallow the signal on the text path.

Nothing here truncates history or drops images to force a fit; an incompatible candidate is skipped, not squeezed.

**Scope note.** This is the half of #1524 that is provably wrong today and safe to fix now. The broader "re-evaluate every fallback candidate against fresh request evidence" work needs a model-independent context estimate threaded into `PolicyRequestEvidence` (which currently leaves request size unknown) and has to reconcile evaluator exact-fit semantics with `ADMISSION_TOLERANCE = 2.5`; that design is written up in `devlog/_plan/260816_wave34_closeout/090_1524_capability_preflight.md` and is not in this PR.

Refs #1524.

## Verification

- `bun test tests/combos.test.ts` — 37 pass / 0 fail, including a new case pinning that `input_admission_refused` hops while upstream `context_length_exceeded` and a bare 413 still stop. Driven red with the branch disabled.
- `bun test tests/policy-execution.test.ts tests/routing-profile.test.ts` — green.
- `bun x tsc --noEmit` — clean.

## Checklist

- [x] Focused regression test added near the existing failover tests
- [x] Typecheck clean
- [x] Targets `dev`
- [x] No user-facing config surface added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of requests rejected before processing due to input limits, allowing eligible failover behavior.
  * Distinguished local input-admission refusals from upstream context-length errors.
  * Preserved terminal handling for upstream context-length and generic request-size errors.
  * Maintained the existing HTTP 413 response and explanatory message for locally rejected requests.

* **Tests**
  * Added coverage for local refusals, upstream context-limit errors, and generic 413 responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->