### PR TITLE
fix(windows): preserve scheduled-task elevation launcher arguments

### DIFF
--- a/src/lib/windows-elevation.ts
+++ b/src/lib/windows-elevation.ts
@@ -648,12 +648,12 @@ export function runWindowsElevatedScheduledTaskRegistration(
       "-EncodedCommand",
       encodedCommand,
     ]))}`,
-    " -Verb RunAs -WindowStyle Hidden -PassThru -Wait",
+    " -Verb RunAs -WindowStyle Hidden -PassThru -Wait;",
     `if ($null -eq $p) { exit ${OCX_ELEVATED_UAC_CANCELLED} }`,
-    "$null = $p.Handle",
+    "$null = $p.Handle;",
     `if ($null -eq $p.ExitCode) { exit ${OCX_ELEVATED_PROTOCOL_FAILED} }`,
     "exit $p.ExitCode",
-  ].join("; ");
+  ].join("");
 
   return startPowerShellCommand(script).completion.then(result => result.exitCode);
 }

--- a/tests/windows-elevation-spawn.test.ts
+++ b/tests/windows-elevation-spawn.test.ts
@@ -120,6 +120,50 @@ describe("runWindowsElevated spawn contract", () => {
     await expect(runWindowsElevated("schtasks.exe", ["/create"])).resolves.toBe(1);
   });
 
+  test("keeps scheduled-task elevation arguments in one Start-Process statement", async () => {
+    let commandScript = "";
+    setWindowsElevationSpawnForTests(((
+      _cmd: string,
+      args: ReadonlyArray<string>,
+    ) => {
+      commandScript = String(args[args.length - 1] ?? "");
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter & { setEncoding?: (enc: string) => void };
+        stderr: EventEmitter & { setEncoding?: (enc: string) => void };
+        kill: ReturnType<typeof mock>;
+      };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.stdout.setEncoding = () => undefined;
+      child.stderr.setEncoding = () => undefined;
+      child.kill = mock(() => true);
+      queueMicrotask(() => child.emit("close", 0, null));
+      return child as never;
+    }) as never);
+
+    await expect(runWindowsElevatedScheduledTaskRegistration(
+      "opencodex-proxy",
+      "<Task />",
+    )).resolves.toBe(0);
+
+    const startProcessIndex = commandScript.indexOf("Start-Process");
+    const filePathIndex = commandScript.indexOf(" -FilePath ");
+    const argumentListIndex = commandScript.indexOf(" -ArgumentList ");
+    const verbIndex = commandScript.indexOf(" -Verb RunAs ");
+    const waitIndex = commandScript.indexOf(" -Wait");
+    const firstTerminator = commandScript.indexOf(";");
+
+    expect(startProcessIndex).toBeGreaterThanOrEqual(0);
+    expect(filePathIndex).toBeGreaterThan(startProcessIndex);
+    expect(argumentListIndex).toBeGreaterThan(filePathIndex);
+    expect(verbIndex).toBeGreaterThan(argumentListIndex);
+    expect(waitIndex).toBeGreaterThan(verbIndex);
+    expect(firstTerminator).toBeGreaterThan(waitIndex);
+    expect(commandScript.match(/Start-Process/g)).toHaveLength(1);
+    expect(commandScript).not.toMatch(/powershell\.exe';\s+-ArgumentList/i);
+    expect(commandScript).not.toMatch(/-ArgumentList\s+'[^']*';\s+-Verb RunAs/);
+  });
+
   test("scheduled-task registration embeds immutable XML bytes instead of a file path", async () => {
     let commandScript = "";
     setWindowsElevationSpawnForTests(((


### PR DESCRIPTION
## Summary

- Keep `-FilePath`, `-ArgumentList`, and `-Verb RunAs` in one `Start-Process` statement for elevated scheduled-task registration.
- Add a focused regression test that fails when the outer PowerShell launcher is split before its elevation arguments.
- Preserve trusted System32 PowerShell resolution, immutable encoded XML transport, UAC cancellation, and elevated exit-code protocol behavior.

Closes #1843

## Verification

- Final HEAD: `b58ac6a7a75fff452aecfe3bfd760d19b4711af3`.
- Current `dev`: `02da6cc9099db02873d6a38894af9b73d11f9f18`.
- `bun test tests/windows-elevation-spawn.test.ts` — 52 pass, 0 fail, 175 assertions on final HEAD with Bun 1.3.14 on Windows 11.
- `bun test --isolate tests/provider-workspace-data.test.ts` — 48 pass, 0 fail, 180 assertions after the clean CI-equivalent GUI bootstrap.
- Clean local readiness gate — `bun run prepush` passed with exit code 0 on exact final HEAD under Ubuntu 24.04 / WSL2 with Bun 1.3.14, after installing both root and GUI frozen dependencies and building `gui/dist`, matching the repository CI bootstrap. Full result: 12,714 pass, 15 skip, 0 fail, 159,070 assertions.
- `bun run typecheck` — passed on final HEAD.
- `bun run privacy:scan` — passed on final HEAD.
- `git diff --check upstream/dev...HEAD` — passed on final HEAD.
- Windows PowerShell 5.1 exit-protocol check — child exit code 7 and missing-ExitCode protocol code 13 both propagated correctly on final HEAD.
- Windows 11 non-elevated service-install smoke — not run: an existing user-owned `opencodex-proxy` task is installed and running on port 10100, so the fresh-install path could not be exercised without deleting the user's task.
- UAC cancellation smoke — not run for the same existing-task safety reason.

No documentation change was required because this restores the already documented Windows elevation behavior.

## Checklist
- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
