### PR TITLE
fix(quota): keep the sub-day burst window instead of discarding it

### DIFF
--- a/src/cli/account-api.ts
+++ b/src/cli/account-api.ts
@@ -145,6 +145,10 @@ export interface CodexQuotaDto {
   monthlyPercent?: number;
   weeklyResetAt?: number;
   monthlyResetAt?: number;
+  /** Sub-day burst window, when upstream declares one (#1791). */
+  shortPercent?: number;
+  shortResetAt?: number;
+  shortWindowSeconds?: number;
 }
 
 export interface ProviderQuotaWindowDto {
@@ -183,7 +187,7 @@ interface CodexAccountDto {
 function projectQuota(quota: CodexQuotaDto | null | undefined): CodexQuotaDto | null {
   if (!quota) return null;
   const projected: CodexQuotaDto = {};
-  for (const key of ["weeklyPercent", "monthlyPercent", "weeklyResetAt", "monthlyResetAt"] as const) {
+  for (const key of ["weeklyPercent", "monthlyPercent", "weeklyResetAt", "monthlyResetAt", "shortPercent", "shortResetAt", "shortWindowSeconds"] as const) {
     if (typeof quota[key] === "number" && Number.isFinite(quota[key])) projected[key] = quota[key];
   }
   return projected;

--- a/src/codex/auth-api.ts
+++ b/src/codex/auth-api.ts
@@ -217,6 +217,11 @@ function quotaForPlan<T extends Omit<StoredAccountQuota, "updatedAt"> | StoredAc
   return {
     ...(quota.monthlyPercent !== undefined ? { monthlyPercent: quota.monthlyPercent } : {}),
     ...(quota.monthlyResetAt !== undefined ? { monthlyResetAt: quota.monthlyResetAt } : {}),
+    // A 30-day plan can still carry a burst window, and it blocks the account on its own.
+    // Dropping it here would show a healthy card for an account upstream is refusing (#1791).
+    ...(quota.shortPercent !== undefined ? { shortPercent: quota.shortPercent } : {}),
+    ...(quota.shortResetAt !== undefined ? { shortResetAt: quota.shortResetAt } : {}),
+    ...(quota.shortWindowSeconds !== undefined ? { shortWindowSeconds: quota.shortWindowSeconds } : {}),
     ...(quota.resetCredits !== undefined ? { resetCredits: quota.resetCredits } : {}),
     ...("updatedAt" in quota ? { updatedAt: quota.updatedAt } : {}),
   } as T;

--- a/src/codex/quota.ts
+++ b/src/codex/quota.ts
@@ -9,6 +9,20 @@ export type StoredAccountQuota = {
   monthlyPercent?: number;
   weeklyResetAt?: number;
   monthlyResetAt?: number;
+  /**
+   * A sub-day burst window, when upstream declares one (#1791).
+   *
+   * K12 and similar plans enforce a rolling 5-hour limit ALONGSIDE the weekly one.
+   * Not folding it into `weeklyPercent` stopped the mislabeling, but dropping it
+   * entirely hides a limit that genuinely blocks the account: a 429 at 100% here is
+   * real even while the weekly quota is untouched.
+   *
+   * `shortWindowSeconds` is retained because the duration is the only thing that makes
+   * this window self-describing; the slot it arrived in is not stable across plans.
+   */
+  shortPercent?: number;
+  shortResetAt?: number;
+  shortWindowSeconds?: number;
   resetCredits?: number;
   /**
    * True when `monthlyPercent` came from an explicitly-monthly PRIMARY window —
@@ -85,13 +99,16 @@ export const CODEX_UNKNOWN_USAGE_SCORE = 101;
 export const CODEX_EXHAUSTED_USAGE_PERCENT = 100;
 
 export function isCodexQuotaExhausted(
-  quota: Pick<StoredAccountQuota, "weeklyPercent" | "monthlyPercent"> | null,
+  quota: Pick<StoredAccountQuota, "weeklyPercent" | "monthlyPercent" | "shortPercent"> | null,
   plan?: unknown,
 ): boolean {
   if (!quota) return false;
+  // The burst window counts on EVERY plan. It is upstream-enforced independently, so an
+  // account at 100% there is blocked regardless of which longer window governs its plan;
+  // omitting it would route traffic straight into a 429 (#1791).
   const values = codexQuotaWindowForPlan(plan) === "monthly"
-    ? [quota.monthlyPercent]
-    : [quota.weeklyPercent, quota.monthlyPercent];
+    ? [quota.monthlyPercent, quota.shortPercent]
+    : [quota.weeklyPercent, quota.monthlyPercent, quota.shortPercent];
   return values.some(value => typeof value === "number"
     && Number.isFinite(value)
     && value >= CODEX_EXHAUSTED_USAGE_PERCENT);
@@ -117,7 +134,7 @@ export function codexQuotaWindowForPlan(plan?: unknown): "monthly" | "weekly" {
 }
 
 export function isCompleteCodexQuotaRecoverySnapshot(
-  quota: Pick<StoredAccountQuota, "weeklyPercent" | "monthlyPercent" | "monthlyIsPrimaryWindow"> | null,
+  quota: Pick<StoredAccountQuota, "weeklyPercent" | "monthlyPercent" | "monthlyIsPrimaryWindow" | "shortPercent"> | null,
   plan?: unknown,
 ): boolean {
   if (!quota || isCodexQuotaExhausted(quota, plan)) return false;
@@ -494,6 +511,14 @@ export function parseUsageQuota(data: WhamUsageResponse): Omit<StoredAccountQuot
   const primaryIsShort = isExplicitShortWindow(primaryWindow);
   const weeklyCandidatePercent = primaryIsShort ? undefined : primaryPercent;
   const weeklyCandidateResetAt = primaryIsShort ? undefined : primaryResetAt;
+  // Keep the burst reading instead of dropping it on the floor: it is a real limit, and
+  // the account is blocked when it fills even though the weekly window is fine (#1791).
+  if (primaryIsShort && primaryPercent !== undefined) {
+    quota.shortPercent = primaryPercent;
+    if (primaryResetAt !== undefined) quota.shortResetAt = primaryResetAt;
+    const seconds = primaryWindow?.limit_window_seconds;
+    if (typeof seconds === "number" && Number.isFinite(seconds)) quota.shortWindowSeconds = seconds;
+  }
   const weeklyPercent = primaryIsMonthly ? secondaryPercent : weeklyCandidatePercent ?? secondaryPercent;
   const weeklyResetAt = primaryIsMonthly
     ? secondaryResetAt

--- a/tests/codex-routing.test.ts
+++ b/tests/codex-routing.test.ts
@@ -1251,6 +1251,39 @@ describe("codex routing", () => {
     })).toMatchObject({ weeklyPercent: 20, weeklyResetAt: 2 });
   });
 
+  test("a sub-day primary window is KEPT as its own burst window (#1791)", () => {
+    // Not masquerading as weekly was only half the fix. The 5-hour reading is a real
+    // upstream-enforced limit -- the issue reports it at 99% remaining alongside a
+    // separate weekly limit -- so discarding it hides a window that genuinely gates
+    // the account. Both windows must survive parsing with independent resets.
+    expect(parseUsageQuota({
+      plan_type: "k12",
+      rate_limit: {
+        primary_window: { used_percent: 1, reset_at: 2000000000, limit_window_seconds: 18000 },
+        secondary_window: { used_percent: 0, reset_at: 2000586800, limit_window_seconds: 604800 },
+      },
+    })).toMatchObject({
+      shortPercent: 1,
+      shortResetAt: 2000000000,
+      shortWindowSeconds: 18000,
+      weeklyPercent: 0,
+      weeklyResetAt: 2000586800,
+    });
+  });
+
+  test("an exhausted burst window takes the account out of rotation (#1791)", () => {
+    // Upstream enforces the 5-hour window independently, so an account at 100% there is
+    // genuinely blocked even while its weekly quota is untouched. Reporting it as usable
+    // would route traffic straight into a 429.
+    const quota = parseUsageQuota({
+      plan_type: "k12",
+      rate_limit: {
+        primary_window: { used_percent: 100, reset_at: 2000000000, limit_window_seconds: 18000 },
+        secondary_window: { used_percent: 10, reset_at: 2000586800, limit_window_seconds: 604800 },
+      },
+    });
+    expect(isCodexQuotaExhausted(quota, "k12")).toBe(true);
+  });
   test("a primary window with no declared duration is still treated as weekly (#1791)", () => {
     // Older payloads omit limit_window_seconds entirely. Guessing there would reclassify
     // every legacy account, so an undeclared duration keeps the historical behavior.


### PR DESCRIPTION
## Summary

Completes #1791.

The earlier fix stopped a 5-hour primary window from being written into `weeklyPercent`, so the dashboard no longer labels a 5-hour bar as "Week". But it achieved that by **discarding** the reading. The issue reports both windows as live upstream limits — 5-hour at 99% remaining, weekly at 100% — so a K12 account could sit at 100% of its 5-hour quota while opencodex showed a healthy weekly bar and kept routing into a guaranteed 429.

This stores it instead. `shortPercent` / `shortResetAt` / `shortWindowSeconds` carry the burst window with its own reset, **next to** the weekly one rather than instead of it.

| Behavior | Before | After |
|---|---|---|
| 5h window labeled "Week" | yes (original bug) | no |
| 5h reading retained | no (dropped) | yes, with its own reset |
| 5h at 100% blocks the account | no | yes, on every plan |
| Cooldown clears while 5h is full | yes | no |
| 5h visible in dashboard / CLI | no | yes |

Exhaustion counts the burst window on **every** plan, including 30-day-only ones: upstream enforces it independently of whichever longer window governs the plan, so an account full here is blocked regardless of the weekly or monthly reading. The same field flows into `isCompleteCodexQuotaRecoverySnapshot`, so a cooldown cannot clear while the burst window is still full, and through the dashboard and CLI DTOs so the limit that is actually holding a user is visible.

The **duration** is retained rather than the slot the window arrived in: the slot is not stable across plans, and the duration is the only thing that makes the window self-describing. A payload that omits `limit_window_seconds` is unchanged — legacy accounts keep today's classification rather than having a duration invented for them.

## Verification

- Two new cases in `tests/codex-routing.test.ts` use the sanitized K12 payload from the issue verbatim (18000s primary at 1%, 604800s secondary at 0%): both windows survive with independent resets, and a full burst window marks the account exhausted.
- **Driven red**: disabling the capture reproduces the discarded reading exactly — both new tests fail, the three existing #1791 tests still pass. The new tests are not vacuous, and they do not merely restate the old ones.
- `bun x tsc --noEmit` — clean.
- `bun test --isolate tests/codex-routing.test.ts tests/codex-cooldown-recovery.test.ts tests/rate-limit-reset-credits.test.ts tests/codex-auth-api.test.ts` — 358 pass, 0 fail.

## Checklist

- [x] Targets `dev`
- [x] Focused regression tests added next to the existing quota tests
- [x] Driven red before being accepted as evidence
- [x] `bun x tsc --noEmit` clean
- [x] Backward compatible — cached quota documents without the new fields behave exactly as today
- [ ] Docs update — not required; no user-facing interface changed beyond an additional quota window becoming visible

## Design note

The plan doc for this unit proposed replacing `StoredAccountQuota` with a generic `windows[]` array plus a `governing` flag. That is a field-chain migration across `quota.ts`, `auth-api.ts`, `routing.ts`, the CLI DTOs, the main-account cache, and capacity projection, plus a v1→v2 on-disk format change — and it is not what the issue needs. The defect is one discarded window, and adding it as an explicit field fixes the reported behavior without a persisted-format migration that could lose quota state on upgrade. The generic-array refactor stays available if a future payload actually carries more windows than the three fixed upstream slots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for short-window quota tracking, including usage percentage, reset time, and window duration.
  * Short-window usage is now included when determining whether an account has exhausted its quota.
  * Quota data preserves burst-window details separately from weekly and monthly limits.

* **Bug Fixes**
  * Corrected quota handling so short-window usage and recovery information are no longer omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->