### PR TITLE
fix(codex): ignore process-local symbol tags in catalog config identity

### DIFF
--- a/src/codex/catalog-admission.ts
+++ b/src/codex/catalog-admission.ts
@@ -79,9 +79,11 @@ function canonicalConfigEncoding(value: unknown, ancestors = new Set<object>()):
   }
 
   if (ancestors.has(value)) throw new TypeError("Catalog config identity cannot encode a cyclic graph.");
-  if (Object.getOwnPropertySymbols(value).length > 0) {
-    throw new TypeError("Catalog config identity cannot encode symbol keys.");
-  }
+  // Symbol keys are process-local metadata (e.g. the user-cost-overlay
+  // preservation-owner tag) that JSON.stringify omits and no persist path
+  // writes. They must not change the durable config identity, so encoding
+  // proceeds over the enumerable string-keyed properties below (Object.keys
+  // already ignores symbols). Symbol VALUES are still refused above.
   ancestors.add(value);
   try {
     if (Array.isArray(value)) {

--- a/tests/codex-catalog-admission.test.ts
+++ b/tests/codex-catalog-admission.test.ts
@@ -184,6 +184,25 @@ test("binds opaque config identity to the exact reference, generation, and snaps
   expect(mutated.generation).toEqual(first.generation);
 });
 
+test("ignores process-local symbol tags when binding the config snapshot identity", () => {
+  saveConfig(config());
+  const plainIdentity = captureCatalogAdmissionSnapshot(config(20200)).configIdentity;
+
+  const tagged = config(20200);
+  Object.defineProperty(tagged, Symbol("opencodex.user-cost-overlay-preservation-owner"), {
+    value: { refs: 1, config: tagged, ownedProviders: Object.keys(tagged.providers ?? {}) },
+    enumerable: true,
+    configurable: true,
+  });
+  const taggedIdentity = captureCatalogAdmissionSnapshot(tagged).configIdentity;
+
+  // The tag is process-local metadata: JSON.stringify omits it and no persist
+  // path writes it, so it must not change the durable snapshot identity. The
+  // reference identity stays per-object, matching the untagged contract.
+  expect(taggedIdentity.snapshotIdentity).toBe(plainIdentity.snapshotIdentity);
+  expect(taggedIdentity.referenceIdentity).not.toBe(plainIdentity.referenceIdentity);
+});
+
 test("rejects missing home, required, and conditional evidence keys structurally", () => {
   expect(STRUCTURALLY_INVALID_EVIDENCE_ASSIGNABILITY).toEqual([false, false, false]);
 });


### PR DESCRIPTION
## Summary

Every management-triggered catalog convergence fails on a live ocx service with
a masked `{status:"failed", reason:"disk", phase:"gather"}` response. The root
cause is a collision between two newer subsystems:

- The user-cost-overlay reconciler attaches an **enumerable Symbol** to the
  live config object (`PRESERVATION_OWNER_STATE`, attached by
  `registerPreservedProviderOwner`) so object spreads carry the owner tag.
- `canonicalConfigEncoding` (catalog admission identity) deliberately refuses
  **any** object with symbol keys: `Cannot encode symbol keys`. That throw is
  caught by the management convergence adapter and (before #1784's
  classification fix) projected to a non-retryable `failed/disk/gather`.

Symbol keys are process-local metadata: `JSON.stringify` omits them and no
persist path writes them, so they must not influence the durable config
identity. This change encodes enumerable **string-keyed** properties only
(`Object.keys` already ignores symbols), while still refusing symbol *values*,
accessor properties, cycles, and non-finite numbers.

## Test plan

- `bun run typecheck` — clean.
- `bun test tests/codex-catalog-admission.test.ts tests/codex-management-convergence.test.ts tests/codex-convergence-contract.test.ts tests/user-cost-overlay-live-reconcile.test.ts` — 112/112 pass.
- Added regression: a config tagged with the preservation-owner symbol keeps
  the same `snapshotIdentity` as its untagged equivalent, and the reference
  identity stays per-object.
- Reproduced the original failure end-to-end outside the suite: attaching the
  symbol makes `captureCatalogAdmissionSnapshot` throw; after the fix it
  captures and the management convergence commits.

Two unrelated pre-existing failures in
`tests/codex-retained-root-serialization.test.ts` (network-dependent provider
discovery in child processes) reproduce on clean `dev` in this environment.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Catalog configurations with enumerable symbol metadata are now accepted without affecting their durable identity.
  * String-keyed configuration properties continue to determine identity, while symbol values remain unsupported.

* **Tests**
  * Added coverage confirming symbol metadata does not alter a configuration’s durable snapshot identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->