### PR TITLE
docs(devlog): close the GUI loading/performance delivery record

### DIFF
--- a/devlog/_plan/260816_gui_loading_performance/050_delivery_record.md
+++ b/devlog/_plan/260816_gui_loading_performance/050_delivery_record.md
@@ -75,5 +75,34 @@ project owner's admin merge (pre-authorized by the user for this campaign) is
 the path used.
 
 - #1854 merged at 2026-08-16T17:15:18Z as `e2ef24ad6`.
-- Remaining layers merge in order once their own checks are green, retargeting
-  each child to `dev` after its parent lands.
+- #1855 merged at 2026-08-16T17:39:13Z as `14c643bcd`.
+- #1856 merged at 2026-08-16T17:47:45Z as `cc9087c64`.
+- #1857 merged at 2026-08-16T17:52:02Z as `9c5eb1e38`.
+
+Each child was retargeted to `dev` after its parent landed, and `dev` moved twice
+more mid-flight (#1861, #1862, #1863), which cost two further cascades of the
+remaining layers.
+
+## Delivery verification (binding round r8, PASS)
+
+An independent reviewer confirmed against `origin/dev`:
+
+- all four merge commits are ancestors of `dev`, in stack order, each with final
+  base `dev` and state MERGED;
+- every layer's substance survived both rebases — the deadline race
+  (`RESOURCE_TIMEOUT`, `timedOut`, `DEFAULT_REQUEST_DEADLINE_MS`), the bucket
+  scheduler (`pollBuckets`, `syncBucketTimer`, `bucketShouldRun`), the freshness
+  fields, the tri-state re-bootstrap with its watchdog, `visibility-poll.ts`, the
+  cache envelope, and all six new test files;
+- no commit landing after the stack tip touches any of the four GUI files;
+- `dev` GUI suite 924 pass / 0 fail, `tsc --noEmit` exit 0, `privacy:scan` green,
+  and all eight plan docs present with their D addenda.
+
+One wording note from the review: `api.ts` holds no direct `AbortController` — the
+bounded-fetch helper owns that composition and `api.ts` calls it. Refactor, not a
+lost change.
+
+## Terminal outcome
+
+DONE. The infinite-loading wedge is fixed at both of its causes, hidden tabs cost
+nothing, and a tab revisit inside the freshness window issues no requests at all.


### PR DESCRIPTION
## Summary

Closes the delivery record for the GUI loading/performance campaign (`devlog/_plan/260816_gui_loading_performance/050_delivery_record.md`). Documentation only — no code.

The four-layer stack (#1854 → #1855 → #1856 → #1857) is now fully merged into `dev`, so this fills in the parts the record could not state while the merges were still in flight: the merge commits and timestamps for all four layers, the two extra rebase cascades that `dev` moving mid-flight forced, and the independent delivery verification (all four merge commits ancestors of `dev` in stack order, every layer's substance intact across both rebases, no later merge touching the GUI files, `dev` GUI suite green).

## Verification

- `bun run privacy:scan` → green (the gate that actually reads `devlog/`)
- No code paths touched: nothing in the build, typecheck, or test path reads from `devlog/`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated delivery records with a clearer history of completed changes and integration milestones.
  * Added verification details covering retained functionality, ancestry checks, test results, and plan documentation.
  * Documented final review clarifications and successful delivery validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->