### PR TITLE
docs(devlog): record the Wave 3/4 final outcome and the review-binding gap

### DIFF
--- a/devlog/_plan/260816_wave34_closeout/120_outcome.md
+++ b/devlog/_plan/260816_wave34_closeout/120_outcome.md
@@ -141,3 +141,81 @@ the generated-metadata sync check). No regression.
 Every merge had exact-head CI green apart from the macOS job, which is queued rather than
 failing — the same pattern recorded in the first pass.
 
+
+---
+
+# Final outcome — Wave 3/4 closeout
+
+## Issue disposition against the objective
+
+| Issue | State | Evidence |
+|---|---|---|
+| `#1686` | CLOSED | `#1853` + `#1861` on dev |
+| `#1802` | CLOSED | `73440d4bb` |
+| `#1835` | CLOSED | `73440d4bb` |
+| `#1798` | CLOSED | `#1862` on dev |
+| `#1789` | CLOSED | `73440d4bb` |
+| `#1791` | CLOSED | `#1863` on dev |
+| `#1784` | CLOSED | `73440d4bb` |
+| `#1834` | CLOSED | `73440d4bb` |
+| `#1830` | CLOSED | `0313716c2` |
+| `#1524` | CLOSED | `#1864` on dev |
+| `#1049` | OPEN — deferred | corrected plan in `101` |
+| `#1795` | OPEN — NEEDS_HUMAN | `130`, evidence requested on the issue |
+
+Contributor PRs named in the objective: `#1829` and `#1831` are CI-green but stay draft until their
+authors complete the review-readiness checklist, which is an author attestation a maintainer must
+not tick for them. `#1836` is blocked on live wire evidence — it reverts a UA that `875bb70c3`
+introduced specifically to un-gate `gemini-3.7-flash`, and binary-default analysis does not refute
+a backend 404 observation. Review posted on each.
+
+## The finding worth keeping
+
+`#1524` shipped a hop-eligible code that never fired, and then a reorder that still did not fire.
+The emitter path was the real defect: `formatErrorResponse` runs `classifyError`, whose
+"context window" remap rewrote the proxy's own `input_admission_refused` code before it could reach
+the decision. The refusal message necessarily contains that phrase — it is what the refusal is
+about — so the remap was guaranteed to fire on exactly the case it broke.
+
+That survived two rounds of review because the regression test hand-built an envelope the proxy
+does not emit. A green test proved a shape that never reaches production.
+
+**Ablation discipline is what caught it, and also what nearly missed it.** The first ablation
+disabled only the structured-code arm and still passed, because a `message.includes` fallback
+caught the case. An ablation that does not fail has not proven the mechanism it was aimed at — the
+honest version disables one factor at a time and confirms each fails alone.
+
+## Verification
+
+Remote Linux suite (`ssh lidge`, `bun test --isolate tests`), verified against the exact head each
+time by reading `git log --oneline -1` on the remote first:
+
+| Head | pass | skip | fail |
+|---|---|---|---|
+| `798ecbfb7` | 12684 | 15 | 16 |
+| `acfedae0a` (`#1861`) | 12687 | 15 | 16 |
+| `6cd5b04b3` (`#1862`) | 12687 | 15 | 16 |
+| `bc6019bae` (`#1864`) | 12695 | 15 | 16 |
+
+The 16 failures are identical in every run and are `bun`-not-on-PATH harness cases:
+`doctor-gui-if-changed` (5), `lint-gui-if-changed` (3), the two-process lock group (6), the
+generated-metadata sync check, and the translator-budget typecheck. No regression.
+
+One process note: an early `#1864` run showed two extra failures purely because the branch point
+predated `#1791`. Rebasing and re-running at the true head cleared them. Always verify the remote
+checkout before reading a suite result as evidence.
+
+## Process gap recorded
+
+`REVIEW-BINDING-01` could not be satisfied in this runtime. `review-observer.js` records a verdict
+only for a subagent whose payload carries `agent_type === "explorer"`, but this runtime's
+`spawn_agent` has no `agent_type` parameter at all. Two plan-audit rounds ended with correctly
+formatted `LAUNCH`/`VERDICT` signoffs and both stayed `in_flight`, so `A→B` was unreachable rather
+than merely unattempted.
+
+The cycle was closed with `orchestrate reset` instead. Hand-editing `goalplan.json` to inject a
+verdict was available and deliberately not done: that is precisely the self-attestation the
+observer exists to prevent. Logged to `.codexclaw/friction.jsonl`; the real fix belongs in
+codexclaw, either widening the matcher or accepting a launch-id-bearing signoff from any subagent
+type.
+


### PR DESCRIPTION
## Summary

Devlog-only. Closes out `devlog/_plan/260816_wave34_closeout/` with the final issue disposition, the remote suite numbers per merged head, and two findings worth keeping.

**Issue disposition against the Wave 3/4 objective:**

| Issue | State |
|---|---|
| #1686, #1802, #1835, #1798, #1789, #1791, #1784, #1834, #1830, #1524 | CLOSED |
| #1049 | OPEN — deferred with a corrected plan |
| #1795 | OPEN — NEEDS_HUMAN, evidence requested |

**The #1524 finding.** The hop-eligible code never fired, and reordering it still did not fire. `formatErrorResponse` runs `classifyError`, whose "context window" remap rewrote the proxy's own `input_admission_refused` code before the decision could see it — and the refusal message necessarily contains that phrase, so the remap was guaranteed to fire on exactly the case it broke. It survived earlier review because the regression test hand-built an envelope the proxy does not emit: a green test proving a shape that never reaches production.

**The ablation lesson.** The first ablation disabled only the structured-code arm and still passed, because a `message.includes` fallback caught the case. An ablation that does not fail has not proven the mechanism it was aimed at.

**A process gap, recorded honestly.** `REVIEW-BINDING-01` is unreachable in the Codex desktop runtime: `review-observer.js` records a verdict only for a subagent whose payload carries `agent_type === "explorer"`, but this runtime's `spawn_agent` has no `agent_type` parameter at all. Two plan-audit rounds ended with correctly formatted `LAUNCH`/`VERDICT` signoffs and both stayed `in_flight`, so `A→B` was unreachable rather than merely unattempted. The cycle was closed with `orchestrate reset` rather than by hand-editing `goalplan.json`, which would have been the exact self-attestation the observer exists to prevent. Also logged to `.codexclaw/friction.jsonl`.

## Verification

Nothing in the build, typecheck, or test path reads from `devlog/`. `privacy:scan` does, and these documents contain no credentials, tokens, account identifiers, or home paths.

Remote Linux suite numbers recorded in the doc, each verified against the exact head by reading `git log --oneline -1` on the remote first:

| Head | pass | skip | fail |
|---|---|---|---|
| `798ecbfb7` | 12684 | 15 | 16 |
| `acfedae0a` (#1861) | 12687 | 15 | 16 |
| `6cd5b04b3` (#1862) | 12687 | 15 | 16 |
| `bc6019bae` (#1864) | 12695 | 15 | 16 |

The 16 failures are identical in every run and are `bun`-not-on-PATH harness cases. No regression.

## Checklist

- [x] Targets `dev`
- [x] Documentation only — no `src/`, `tests/`, or `gui/` changes
- [x] No security or pre-disclosure material
- [ ] Tests — not applicable
- [ ] Docs-site update — not applicable; `devlog/` is maintainer-facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Wave 3/4 closeout summary covering issue dispositions, contributor pull request status, and verification outcomes.
  * Documented classification and remapping findings, including ablation results and exact-head verification.
  * Recorded process gaps related to unavailable agent-type support and incomplete review-observer verdicts.
  * Consolidated final outcomes and follow-up context for improved project traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->