### PR TITLE
fix(quota): ignore Command Code epoch-zero reset timestamps

### DIFF
--- a/src/providers/quota.ts
+++ b/src/providers/quota.ts
@@ -242,7 +242,7 @@ function normalizeResetAt(value: unknown): number | undefined {
     const trimmed = value.trim();
     // Cursor Connect RPC returns billingCycleEnd as a unix-ms decimal string ("1771077734000").
     // Date.parse treats that as invalid; numeric epoch strings must be handled explicitly.
-    if (/^\d+(\.\d+)?$/.test(trimmed)) {
+    if (/^[+-]?\d+(\.\d+)?$/.test(trimmed)) {
       const numeric = Number(trimmed);
       return epochMillis(numeric);
     }

--- a/src/providers/quota.ts
+++ b/src/providers/quota.ts
@@ -237,19 +237,25 @@ function providerLabel(providerId: string): string {
 }
 
 function normalizeResetAt(value: unknown): number | undefined {
-  if (typeof value === "number" && Number.isFinite(value)) return value > 10_000_000_000 ? value : value * 1000;
+  if (typeof value === "number" && Number.isFinite(value)) return epochMillis(value);
   if (typeof value === "string" && value.trim()) {
     const trimmed = value.trim();
     // Cursor Connect RPC returns billingCycleEnd as a unix-ms decimal string ("1771077734000").
     // Date.parse treats that as invalid; numeric epoch strings must be handled explicitly.
     if (/^\d+(\.\d+)?$/.test(trimmed)) {
       const numeric = Number(trimmed);
-      if (Number.isFinite(numeric)) return numeric > 10_000_000_000 ? numeric : numeric * 1000;
+      return epochMillis(numeric);
     }
     const parsed = Date.parse(trimmed);
-    return Number.isFinite(parsed) ? parsed : undefined;
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
   }
   return undefined;
+}
+
+/** Unix 0 / negative values are sentinels, not reset clocks (Command Code fiveHour.resetAt: 0). */
+function epochMillis(value: number): number | undefined {
+  if (!Number.isFinite(value) || value <= 0) return undefined;
+  return value > 10_000_000_000 ? value : value * 1000;
 }
 
 function toFiniteNumber(value: unknown): number | undefined {

--- a/tests/command-code-quota.test.ts
+++ b/tests/command-code-quota.test.ts
@@ -121,12 +121,47 @@ describe("Command Code provider quota", () => {
   test("omits a zero Command Code window reset instead of treating it as the Unix epoch", async () => {
     globalThis.fetch = (async (input: RequestInfo | URL) => {
       const url = String(input);
-      if (url.includes("/alpha/whoami") || url.includes("/alpha/billing/subscriptions") || url.includes("/alpha/usage/summary")) {
+      if (url === "https://api.commandcode.ai/alpha/whoami"
+        || url === "https://api.commandcode.ai/alpha/billing/subscriptions"
+        || url === "https://api.commandcode.ai/alpha/usage/summary") {
         return new Response("down", { status: 500 });
+      }
+      if (url !== "https://api.commandcode.ai/alpha/billing/credits") {
+        throw new Error(`unexpected Command Code quota probe: ${url}`);
       }
       return new Response(JSON.stringify({
         windowLimits: {
           fiveHour: { cap: 14, used: 0, resetAt: 0 },
+          weekly: { cap: 35, used: 34.9522404823, resetAt: 1_787_184_801_319 },
+        },
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+
+    const result = await fetchProviderQuotaReports(commandCodeConfig(), true);
+
+    expect(result.reports[0]?.quota).toEqual({
+      fiveHourPercent: 0,
+      weeklyPercent: 99.86354423514285,
+      weeklyResetAt: 1_787_184_801_319,
+      updatedAt: expect.any(Number),
+    });
+    expect(result.reports[0]?.quota).not.toHaveProperty("fiveHourResetAt");
+  });
+
+  test("omits a signed numeric Command Code window reset instead of Date.parse-ing it", async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "https://api.commandcode.ai/alpha/whoami"
+        || url === "https://api.commandcode.ai/alpha/billing/subscriptions"
+        || url === "https://api.commandcode.ai/alpha/usage/summary") {
+        return new Response("down", { status: 500 });
+      }
+      if (url !== "https://api.commandcode.ai/alpha/billing/credits") {
+        throw new Error(`unexpected Command Code quota probe: ${url}`);
+      }
+      return new Response(JSON.stringify({
+        windowLimits: {
+          fiveHour: { cap: 14, used: 0, resetAt: "-1" },
           weekly: { cap: 35, used: 34.9522404823, resetAt: 1_787_184_801_319 },
         },
       }), { status: 200, headers: { "content-type": "application/json" } });

--- a/tests/command-code-quota.test.ts
+++ b/tests/command-code-quota.test.ts
@@ -118,6 +118,31 @@ describe("Command Code provider quota", () => {
     expect(JSON.stringify(result)).not.toContain("commandcode-secret");
   });
 
+  test("omits a zero Command Code window reset instead of treating it as the Unix epoch", async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/alpha/whoami") || url.includes("/alpha/billing/subscriptions") || url.includes("/alpha/usage/summary")) {
+        return new Response("down", { status: 500 });
+      }
+      return new Response(JSON.stringify({
+        windowLimits: {
+          fiveHour: { cap: 14, used: 0, resetAt: 0 },
+          weekly: { cap: 35, used: 34.9522404823, resetAt: 1_787_184_801_319 },
+        },
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+
+    const result = await fetchProviderQuotaReports(commandCodeConfig(), true);
+
+    expect(result.reports[0]?.quota).toEqual({
+      fiveHourPercent: 0,
+      weeklyPercent: 99.86354423514285,
+      weeklyResetAt: 1_787_184_801_319,
+      updatedAt: expect.any(Number),
+    });
+    expect(result.reports[0]?.quota).not.toHaveProperty("fiveHourResetAt");
+  });
+
   test("keeps rolling windows when whoami and usage summary fail", async () => {
     const seen: string[] = [];
     globalThis.fetch = (async (input: RequestInfo | URL) => {


### PR DESCRIPTION
## Summary

- Command Code's unused 5-hour window sends `resetAt: 0` as a sentinel, not a clock.
- OpenCodex treated that `0` as Unix seconds, so the provider overview showed **Resets 31 Dec 1969, 17:00** while the weekly window still formatted correctly.
- `normalizeResetAt()` now drops non-positive timestamps, so the 5-hour bar still reports `0%` used but no longer invents an epoch reset date.
- Signed numeric sentinels such as `"-1"` now go through `epochMillis` instead of `Date.parse`, which otherwise produces a historical date.

## Verification

- Watched `bun test tests/command-code-quota.test.ts -t "omits a zero Command Code window reset"` fail first with `fiveHourResetAt: 0`.
- Watched `bun test tests/command-code-quota.test.ts -t "omits a signed numeric Command Code window reset"` fail first with `fiveHourResetAt: 978307200000` from `Date.parse("-1")`.
- After the follow-up: `bun test tests/command-code-quota.test.ts tests/provider-quota.test.ts tests/opencode-go-quota.test.ts` — 112 pass, 0 fail.
- `bun run typecheck` — clean.
- `bun run privacy:scan` — passed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected quota reset times so valid numeric timestamps display accurately.
  * Prevented zero and negative reset values from appearing as invalid dates or Unix epoch timestamps.
  * Improved handling of date-based reset values.

* **Tests**
  * Added regression coverage for valid, zero, and signed numeric quota reset values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->