### PR TITLE
fix(chat): retain admission lease through native streams

### DIFF
--- a/src/server/chat-native.ts
+++ b/src/server/chat-native.ts
@@ -7,6 +7,7 @@ import {
   isChatCompletionsStreamError,
 } from "../chat/outbound";
 import { classifyError, CYBER_POLICY_ERROR_CODE, isCyberPolicyCode } from "../lib/errors";
+import type { AdmissionLease } from "../lib/admission";
 import { readBoundedResponseBody } from "../lib/bounded-body";
 import { redactSecretString } from "../lib/redact";
 import { resolveClientRetryAfter } from "../lib/retry-after";
@@ -39,6 +40,7 @@ import {
   type RequestLogContext,
 } from "./request-log";
 import { jsonCompletionSse, nativeChatSse, structuredError, usageFromChat } from "./chat-native-sse";
+import { registerTurn, unregisterTurn } from "./lifecycle";
 
 type Rec = Record<string, unknown>;
 
@@ -78,7 +80,7 @@ interface HandleNativeChatOptions {
   req: Request;
   config: OcxConfig;
   logCtx: RequestLogContext;
-  logIds?: { requestId: string; start: number };
+  logIds?: { requestId: string; start: number; turnAdmissionLease?: AdmissionLease };
   route: RouteResult;
   chatBody: Rec;
   requestedModel: string;
@@ -122,6 +124,21 @@ export async function handleNativeChatCompletions(options: HandleNativeChatOptio
 
   const upstream = new AbortController();
   const cleanupAbort = linkAbortSignal(upstream, req.signal);
+  // nativeChatSse already owns the translated stream's async pull/cancel path.
+  // Bind the lease to that same controller and its terminal callbacks instead
+  // of adding another trackStreamLifetime wrapper (unsafe on bundled Bun#32111).
+  let streamTurnRegistered = false;
+  const transferTurnToStream = () => {
+    const lease = logIds?.turnAdmissionLease;
+    if (!lease || typeof (lease as { bindAbortController?: unknown }).bindAbortController !== "function") return;
+    registerTurn(upstream, lease);
+    streamTurnRegistered = true;
+  };
+  const releaseStreamTurn = () => {
+    if (!streamTurnRegistered) return;
+    streamTurnRegistered = false;
+    unregisterTurn(upstream);
+  };
   const connectMs = config.connectTimeoutMs ?? 200_000;
   let activeProvider: OcxProviderConfig = route.provider;
   let activeAdapter: ProviderAdapter = createOpenAIChatAdapter(activeProvider);
@@ -276,6 +293,7 @@ export async function handleNativeChatCompletions(options: HandleNativeChatOptio
 
   const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
   if (contentType.includes("text/event-stream") && response.body) {
+    if (requestedStream) transferTurnToStream();
     const stream = nativeChatSse(response.body, {
       requestedModel,
       translatorBudget,
@@ -287,13 +305,21 @@ export async function handleNativeChatCompletions(options: HandleNativeChatOptio
       },
       ...(requestedStream ? {
         onTerminal: (status: number, message?: string) => {
-          cleanupAbort();
-          finishLog(status, message, "terminal");
+          try {
+            cleanupAbort();
+            finishLog(status, message, "terminal");
+          } finally {
+            releaseStreamTurn();
+          }
         },
         onCancel: () => {
-          cleanupAbort();
-          upstream.abort();
-          finishLog(499, undefined, "client_cancel");
+          try {
+            cleanupAbort();
+            upstream.abort();
+            finishLog(499, undefined, "client_cancel");
+          } finally {
+            releaseStreamTurn();
+          }
         },
       } : {}),
     });

--- a/tests/chat-completions-endpoint.test.ts
+++ b/tests/chat-completions-endpoint.test.ts
@@ -19,8 +19,11 @@ import {
 } from "../src/providers/request-pacing";
 import {
   acquireNativeMainProfileDrain,
+  activeRegistryMetrics,
+  getActiveTurnCount,
   getNativeMainProfileRequestCount,
   resetLifecycleDrainStateForTests,
+  tryAdmitTurn,
 } from "../src/server/lifecycle";
 import {
   blockNativeMainRecovery,
@@ -638,6 +641,53 @@ test("POST /v1/chat/completions forwards response_format to routed openai-chat",
   }
 });
 
+test("native Chat SSE holds its active-turn lease until terminal completion", async () => {
+  const encoder = new TextEncoder();
+  let upstreamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+  const upstream = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(new ReadableStream<Uint8Array>({
+        start(controller) {
+          upstreamController = controller;
+          controller.enqueue(encoder.encode(
+            `data: ${JSON.stringify({ choices: [{ index: 0, delta: { role: "assistant", content: "held" } }] })}\n\n`,
+          ));
+        },
+      }), { headers: { "Content-Type": "text/event-stream" } });
+    },
+  });
+  saveConfig(mockConfig(`${upstream.url.toString().replace(/\/$/, "")}/v1`));
+  const server = startServer(0);
+  const before = getActiveTurnCount();
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  try {
+    const response = await fetch(new URL("/v1/chat/completions", server.url), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "mock/test-model",
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(response.status).toBe(200);
+    reader = response.body!.getReader();
+    expect((await reader.read()).done).toBe(false);
+    expect(getActiveTurnCount()).toBe(before + 1);
+
+    upstreamController!.enqueue(encoder.encode("data: [DONE]\n\n"));
+    try { upstreamController!.close(); } catch { /* parser may cancel after terminal */ }
+    while (!(await reader.read()).done) { /* drain terminal frames */ }
+    reader = undefined;
+    expect(getActiveTurnCount()).toBe(before);
+  } finally {
+    await reader?.cancel();
+    await server.stop(true);
+    await upstream.stop(true);
+  }
+});
+
 test("POST /v1/responses carries text.format onto the routed chat wire", async () => {
   const { server: upstream, captured } = mockChatUpstreamCapturing();
   saveConfig(mockConfig(`${upstream.url.toString().replace(/\/$/, "")}/v1`));
@@ -1097,6 +1147,7 @@ test("chat-native streaming accepts CRLF events split across transport chunks", 
 });
 
 test("chat-native streaming rejects an unterminated SSE event", async () => {
+  const before = getActiveTurnCount();
   const upstream = Bun.serve({
     port: 0,
     fetch() {
@@ -1117,6 +1168,7 @@ test("chat-native streaming rejects an unterminated SSE event", async () => {
     expect(response.status).toBe(200);
     expect(text).toContain('"code":"upstream_sse_unterminated"');
     expect(text).not.toContain("data: [DONE]");
+    expect(getActiveTurnCount()).toBe(before);
   } finally {
     await server.stop(true);
     upstream.stop(true);
@@ -1254,6 +1306,60 @@ test("chat-native client cancellation cancels the upstream stream and logs 499",
   let markCancelled!: () => void;
   const cancelled = new Promise<void>(resolve => { markCancelled = resolve; });
   const encoder = new TextEncoder();
+  const releaseMisses = activeRegistryMetrics().activeTurns.releaseMisses;
+  const before = getActiveTurnCount();
+  const lease = tryAdmitTurn();
+  if (!lease) throw new Error("failed to admit native Chat cancellation test turn");
+  globalThis.fetch = (async () => new Response(new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode('data: {"choices":[{"index":0,"delta":{"content":"held"}}]}\n\n'));
+        },
+        cancel() {
+          markCancelled();
+        },
+      }), { headers: { "content-type": "text/event-stream" } })) as typeof fetch;
+  try {
+    const request = new Request("http://localhost/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "mock/test-model", stream: true, messages: [{ role: "user", content: "hi" }] }),
+    });
+    const logCtx = {} as Parameters<typeof handleChatCompletions>[2];
+    const response = await handleChatCompletions(
+      request,
+      mockConfig("https://provider.example/v1"),
+      logCtx,
+      { requestId: "chat-cancel", start: Date.now(), turnAdmissionLease: lease },
+    );
+    const reader = response.body!.getReader();
+    expect((await reader.read()).done).toBe(false);
+    expect(lease.isTransferred()).toBe(true);
+    expect(getActiveTurnCount()).toBe(before + 1);
+    const cancelOutcome = await Promise.race([
+      Promise.all([reader.cancel("client done"), cancelled]).then(() => "cancelled" as const),
+      Bun.sleep(2_000).then(() => "timeout" as const),
+    ]);
+    expect(cancelOutcome).toBe("cancelled");
+    expect(getRequestLogEntries().at(-1)?.status).toBe(499);
+    expect(getActiveTurnCount()).toBe(before);
+    expect(activeRegistryMetrics().activeTurns.releaseMisses).toBe(releaseMisses);
+  } finally {
+    lease.release();
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("chat-native request abort releases its active-turn lease and logs 499", async () => {
+  const { clearRequestLogsForTests, getRequestLogEntries } = await import("../src/server/request-log");
+  const { handleChatCompletions } = await import("../src/server/chat-completions");
+  clearRequestLogsForTests();
+  let markCancelled!: () => void;
+  const cancelled = new Promise<void>(resolve => { markCancelled = resolve; });
+  const encoder = new TextEncoder();
+  const releaseMisses = activeRegistryMetrics().activeTurns.releaseMisses;
+  const before = getActiveTurnCount();
+  const lease = tryAdmitTurn();
+  if (!lease) throw new Error("failed to admit native Chat request-abort test turn");
   globalThis.fetch = (async () => new Response(new ReadableStream<Uint8Array>({
         start(controller) {
           controller.enqueue(encoder.encode('data: {"choices":[{"index":0,"delta":{"content":"held"}}]}\n\n'));
@@ -1270,19 +1376,55 @@ test("chat-native client cancellation cancels the upstream stream and logs 499",
       body: JSON.stringify({ model: "mock/test-model", stream: true, messages: [{ role: "user", content: "hi" }] }),
       signal: clientAbort.signal,
     });
-    const logCtx = {} as Parameters<typeof handleChatCompletions>[2];
     const response = await handleChatCompletions(
       request,
       mockConfig("https://provider.example/v1"),
-      logCtx,
-      { requestId: "chat-cancel", start: Date.now() },
+      {} as Parameters<typeof handleChatCompletions>[2],
+      { requestId: "chat-request-abort", start: Date.now(), turnAdmissionLease: lease },
     );
     const reader = response.body!.getReader();
     expect((await reader.read()).done).toBe(false);
+    expect(lease.isTransferred()).toBe(true);
+    expect(getActiveTurnCount()).toBe(before + 1);
+
+    const nextRead = reader.read();
     clientAbort.abort("client done");
-    expect((await reader.read()).done).toBe(true);
-    await cancelled;
+    const abortOutcome = await Promise.race([
+      Promise.all([nextRead, cancelled]).then(([read]) => ({ kind: "cancelled" as const, read })),
+      Bun.sleep(2_000).then(() => ({ kind: "timeout" as const })),
+    ]);
+    expect(abortOutcome.kind).toBe("cancelled");
+    if (abortOutcome.kind === "cancelled") expect(abortOutcome.read.done).toBe(true);
     expect(getRequestLogEntries().at(-1)?.status).toBe(499);
+    expect(getActiveTurnCount()).toBe(before);
+    expect(activeRegistryMetrics().activeTurns.releaseMisses).toBe(releaseMisses);
+  } finally {
+    lease.release();
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("chat-native direct streaming without an admission lease does not record a release miss", async () => {
+  const { handleChatCompletions } = await import("../src/server/chat-completions");
+  const releaseMisses = activeRegistryMetrics().activeTurns.releaseMisses;
+  globalThis.fetch = (async () => new Response(
+    'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n',
+    { headers: { "content-type": "text/event-stream" } },
+  )) as typeof fetch;
+  try {
+    const request = new Request("http://localhost/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "mock/test-model", stream: true, messages: [{ role: "user", content: "hi" }] }),
+    });
+    const response = await handleChatCompletions(
+      request,
+      mockConfig("https://provider.example/v1"),
+      {} as Parameters<typeof handleChatCompletions>[2],
+      { requestId: "chat-no-lease", start: Date.now() },
+    );
+    expect(await response.text()).toContain("data: [DONE]");
+    expect(activeRegistryMetrics().activeTurns.releaseMisses).toBe(releaseMisses);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -1512,7 +1654,7 @@ test("chat-native skips optional main enrichment while routed work survives drai
     upstream.stop(true);
     resetLifecycleDrainStateForTests();
   }
-});
+}, 15_000);
 
 test("POST /v1/chat/completions finalizes native passthrough request logs", async () => {
   const { clearRequestLogsForTests, getRequestLogEntries } = await import("../src/server/request-log");


### PR DESCRIPTION
## Summary

- Keep the native Chat active-turn admission lease alive for the full lifetime of a streamed SSE response.
- Release the lease on terminal output, malformed/truncated streams, request abort, client cancellation, or shutdown.
- Integrate release into the existing native Chat SSE parser instead of adding another async-pull wrapper on bundled Bun 1.3.14.

Exact base: `9830ab1c26014a5d6c4a4ec2b4d4b1802d4e0c79`  
Exact head: `fce54f5f9b9ef570352fcde31f9484eaaad73c3b`

## Why

`/v1/chat/completions` already acquires an active-turn lease before routing. Native Chat streaming previously returned the downstream body without transferring that lease, so the outer handler released admission as soon as it returned while the stream and upstream work were still active. Long-lived native streams could therefore fall out of the 256-turn admission cap.

This change transfers the lease only for requested native upstream SSE. The existing parser owns terminal and cancellation callbacks, so it can release the transferred lease without adding a second stream wrapper. The bounded JSON fallback remains unchanged because its upstream model response is already fully terminal before the handler returns.

Related: #820

## Behavior and compatibility

- Authentication and origin checks still run before admission and provider work.
- Normal `[DONE]`, provider terminal events, malformed/truncated SSE, request abort, reader cancellation, and shutdown all release exactly once.
- Direct/internal calls without an admission lease remain supported and do not increment release-miss metrics.
- Non-streaming and completed JSON-to-SSE fallback behavior is unchanged.
- No request, credential, account-routing, logging, or provider wire contract changes.

## Verification

- Bun 1.3.14: `tests/chat-completions-endpoint.test.ts` — 78 pass, 0 fail, 260 assertions.
- Bun 1.4.0-canary.1: same file — 78 pass, 0 fail, 260 assertions.
- `tsc --noEmit` — pass on both runtimes.
- `scripts/privacy-scan.ts` — pass on both runtimes.
- `git diff --check` — pass.
- Independent correctness, test-contract, and security reviews — CLEAN, no P0-P2 findings.
- Codex Security diff scan `87177ad2-03f0-4017-b864-b51d05f32960` — 0 findings.
- Stable patch ID across the dependency-only rebase: `eaf2fb19483b2f159480add368d2c7f2bba31cf1`.

The full repository suite is not claimed green; maintained exact-head CI is still required.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for streamed chat responses by correctly managing active requests through completion, cancellation, and connection aborts.
  * Prevented lingering request activity after interrupted streams, helping maintain consistent service behavior.
  * Added safeguards for chat requests handled without an admission lease.
* **Tests**
  * Expanded coverage for streaming completion, cancellation, request aborts, and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->