### PR TITLE
fix(windows): keep catalog discovery off request event loop

### DIFF
--- a/docs-site/src/content/docs/guides/sub-agent-surface.md
+++ b/docs-site/src/content/docs/guides/sub-agent-surface.md
@@ -260,7 +260,7 @@ separately by `ocx doctor`. `stale` clears only after every detected Codex app-s
 the final catalog write; it does not necessarily clear `unknown`.
 
 On Windows, this advisory check uses asynchronous PowerShell/CIM discovery on the v2 request path.
-Concurrent cold checks share one in-flight discovery and successful results are cached briefly. A
+Concurrent cold checks share one in-flight discovery and results are cached briefly. A
 slow or failing CIM query can delay or suppress only OpenCodex-authored model guidance; it does not
 block the Bun event loop, `/healthz`, or unrelated proxy traffic. Explicit CLI/service lifecycle
 operations retain the synchronous, fail-closed process collector because they may signal processes.

--- a/docs-site/src/content/docs/guides/sub-agent-surface.md
+++ b/docs-site/src/content/docs/guides/sub-agent-surface.md
@@ -259,6 +259,12 @@ timestamp, an unreadable process start time, or a failed process enumeration —
 separately by `ocx doctor`. `stale` clears only after every detected Codex app-server starts after
 the final catalog write; it does not necessarily clear `unknown`.
 
+On Windows, this advisory check uses asynchronous PowerShell/CIM discovery on the v2 request path.
+Concurrent cold checks share one in-flight discovery and successful results are cached briefly. A
+slow or failing CIM query can delay or suppress only OpenCodex-authored model guidance; it does not
+block the Bun event loop, `/healthz`, or unrelated proxy traffic. Explicit CLI/service lifecycle
+operations retain the synchronous, fail-closed process collector because they may signal processes.
+
 Only a real change counts. A sync whose result is byte-identical to the catalog already on disk
 leaves the file untouched, so restarting the proxy or re-syncing an unchanged model set does not
 make a running Codex look stale.

--- a/docs-site/src/content/docs/guides/sub-agent-surface.md
+++ b/docs-site/src/content/docs/guides/sub-agent-surface.md
@@ -260,7 +260,8 @@ separately by `ocx doctor`. `stale` clears only after every detected Codex app-s
 the final catalog write; it does not necessarily clear `unknown`.
 
 On Windows, this advisory check uses asynchronous PowerShell/CIM discovery on the v2 request path.
-Concurrent cold checks share one in-flight discovery and results are cached briefly. A
+Concurrent cold checks share one in-flight discovery. Observed states are cached for five seconds;
+an `unknown` failure is cached for only 250 milliseconds so a transient CIM error retries quickly. A
 slow or failing CIM query can delay or suppress only OpenCodex-authored model guidance; it does not
 block the Bun event loop, `/healthz`, or unrelated proxy traffic. Explicit CLI/service lifecycle
 operations retain the synchronous, fail-closed process collector because they may signal processes.

--- a/src/codex/app-server-processes.ts
+++ b/src/codex/app-server-processes.ts
@@ -450,12 +450,32 @@ export function listWindowsSnapshots(runPowerShell?: (psCommand: string) => stri
   return parseWindowsSnapshotOutput(output);
 }
 
-async function listWindowsSnapshotsAsync(): Promise<ProcessSnapshot[]> {
-  const output = await execFileTextAsync(resolveTrustedWindowsPowerShellExe(), [
+/**
+ * Exec seam for the async enumeration. Without it the default request path is
+ * untestable off Windows: `resolveTrustedWindowsPowerShellExe()` fails immediately, so a
+ * synchronous and an asynchronous implementation are indistinguishable from a test — which
+ * is exactly how a test asserting "yields to the event loop" stayed green after the async
+ * call was reverted to `execFileSync`. Overriding this lets a test drive the real default
+ * wiring and observe whether the event loop keeps running during enumeration.
+ */
+let windowsSnapshotExecAsync: (command: string, timeoutMs: number) => Promise<string> =
+  (command, timeoutMs) => execFileTextAsync(resolveTrustedWindowsPowerShellExe(), [
     "-NoProfile", "-NoLogo", "-NonInteractive",
     "-Command",
-    windowsSnapshotPowerShellCommand(),
-  ], 8_000);
+    command,
+  ], timeoutMs);
+
+/** Test-only: swap the async enumeration exec. Returns a restore function. */
+export function setWindowsSnapshotExecAsyncForTest(
+  exec: (command: string, timeoutMs: number) => Promise<string>,
+): () => void {
+  const previous = windowsSnapshotExecAsync;
+  windowsSnapshotExecAsync = exec;
+  return () => { windowsSnapshotExecAsync = previous; };
+}
+
+async function listWindowsSnapshotsAsync(): Promise<ProcessSnapshot[]> {
+  const output = await windowsSnapshotExecAsync(windowsSnapshotPowerShellCommand(), 8_000);
   return parseWindowsSnapshotOutput(output);
 }
 

--- a/src/codex/app-server-processes.ts
+++ b/src/codex/app-server-processes.ts
@@ -919,7 +919,12 @@ export async function collectCodexAppServerCatalogStateForRequest(
   return flight.promise;
 }
 
-/** Test hook: drop the memoized catalog state. */
+/**
+ * Drop memoized catalog state after a relevant catalog/cache write and before
+ * the post-write state read. Advancing the generation prevents an older
+ * in-flight Windows CIM refresh from publishing its pre-write result after the
+ * write has completed.
+ */
 export function resetCodexAppServerCatalogStateCache(): void {
   catalogStateCache = null;
   requestCatalogStateGeneration += 1;

--- a/src/codex/app-server-processes.ts
+++ b/src/codex/app-server-processes.ts
@@ -900,9 +900,25 @@ export async function collectCodexAppServerCatalogStateForRequest(
   }));
   let flight: RequestCatalogStateFlight;
   const promise = pending.then(status => {
-    // A catalog write can invalidate while slow CIM is still running. Never
-    // let that pre-write result repopulate the post-write cache.
-    if (requestCatalogStateGeneration === generation && requestCatalogStateFlight === flight) {
+    // A catalog write can invalidate while slow CIM is still running. The result
+    // describes the PRE-write world, so it must neither repopulate the post-write
+    // cache nor reach the caller.
+    //
+    // Suppressing only the cache write is not enough. The awaiting request still
+    // received `fresh`, and `fresh` is the one state that authorizes positive
+    // guidance (`src/server/responses/collaboration.ts:279-280` returns null for
+    // `stale`/`unknown` but describes the catalog for `fresh`). So the request
+    // would advertise the newly written disk catalog to an app-server whose
+    // in-memory copy the write just made stale — a wrong answer, which is worse
+    // than the slow answer this whole change exists to fix.
+    //
+    // Degrade to `unknown` instead: it is the honest description of what an
+    // invalidated observation knows, and the guidance path already treats it as
+    // "say nothing positive".
+    if (requestCatalogStateGeneration !== generation) {
+      return { state: "unknown" as const, processes: [], catalogMtimeMs: null };
+    }
+    if (requestCatalogStateFlight === flight) {
       requestCatalogStateCache = {
         generation,
         identity,

--- a/src/codex/app-server-processes.ts
+++ b/src/codex/app-server-processes.ts
@@ -450,32 +450,12 @@ export function listWindowsSnapshots(runPowerShell?: (psCommand: string) => stri
   return parseWindowsSnapshotOutput(output);
 }
 
-/**
- * Exec seam for the async enumeration. Without it the default request path is
- * untestable off Windows: `resolveTrustedWindowsPowerShellExe()` fails immediately, so a
- * synchronous and an asynchronous implementation are indistinguishable from a test — which
- * is exactly how a test asserting "yields to the event loop" stayed green after the async
- * call was reverted to `execFileSync`. Overriding this lets a test drive the real default
- * wiring and observe whether the event loop keeps running during enumeration.
- */
-let windowsSnapshotExecAsync: (command: string, timeoutMs: number) => Promise<string> =
-  (command, timeoutMs) => execFileTextAsync(resolveTrustedWindowsPowerShellExe(), [
+async function listWindowsSnapshotsAsync(): Promise<ProcessSnapshot[]> {
+  const output = await execFileTextAsync(resolveTrustedWindowsPowerShellExe(), [
     "-NoProfile", "-NoLogo", "-NonInteractive",
     "-Command",
-    command,
-  ], timeoutMs);
-
-/** Test-only: swap the async enumeration exec. Returns a restore function. */
-export function setWindowsSnapshotExecAsyncForTest(
-  exec: (command: string, timeoutMs: number) => Promise<string>,
-): () => void {
-  const previous = windowsSnapshotExecAsync;
-  windowsSnapshotExecAsync = exec;
-  return () => { windowsSnapshotExecAsync = previous; };
-}
-
-async function listWindowsSnapshotsAsync(): Promise<ProcessSnapshot[]> {
-  const output = await windowsSnapshotExecAsync(windowsSnapshotPowerShellCommand(), 8_000);
+    windowsSnapshotPowerShellCommand(),
+  ], 8_000);
   return parseWindowsSnapshotOutput(output);
 }
 

--- a/src/codex/app-server-processes.ts
+++ b/src/codex/app-server-processes.ts
@@ -7,7 +7,7 @@
  * Never match broad `*codex*` patterns that hit unrelated tools such as
  * `hermes-codex-bridge-mcp`.
  */
-import { execFileSync } from "node:child_process";
+import { execFile, execFileSync, type ExecFileException } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { isProcessAlive, waitForExit } from "../lib/process-control";
 import {
@@ -98,7 +98,28 @@ export interface CodexAppServerProcessIo {
   waitExit?: (pid: number, timeoutMs: number) => boolean;
   now?: () => number;
   readStartMs?: (pid: number) => number | null;
+  /** Async process-list seam used by the request-path Windows collector. */
+  listSnapshotsAsync?: () => Promise<ProcessSnapshot[]>;
+  /** Async batch start-time seam used by the request-path Windows collector. */
+  readStartMsBatchAsync?: (pids: readonly number[]) => Promise<Map<number, number | null>>;
   catalogMtimeMs?: () => number | null;
+}
+
+function execFileTextAsync(
+  file: string,
+  args: readonly string[],
+  timeoutMs: number,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(file, [...args], {
+      encoding: "utf-8",
+      timeout: timeoutMs,
+      windowsHide: true,
+    }, (error: ExecFileException | null, stdout: string) => {
+      if (error) reject(error);
+      else resolve(stdout);
+    });
+  });
 }
 
 /** Split a process command line into argv-like tokens (handles simple quotes). */
@@ -375,7 +396,7 @@ export function parseWindowsSnapshotOutput(output: string): ProcessSnapshot[] {
   return out;
 }
 
-export function listWindowsSnapshots(runPowerShell?: (psCommand: string) => string): ProcessSnapshot[] {
+function windowsSnapshotPowerShellCommand(): string {
   // Newlines keep -Command as a real script (space-joined statements need ';').
   // Double-quoted format string so `t expands to a real tab.
   // Codex candidates only: basename token codex / codex.exe / codex.cmd /
@@ -384,7 +405,7 @@ export function listWindowsSnapshots(runPowerShell?: (psCommand: string) => stri
   // path with "opencodex".
   const basenameMatch = powerShellSingleQuotedIgnoreCaseMatch(WINDOWS_CODEX_BASENAME_CANDIDATE_RE.source);
   const codeModeMatch = powerShellSingleQuotedIgnoreCaseMatch(WINDOWS_CODEX_CODE_MODE_HOST_CANDIDATE_RE.source);
-  const psCommand = [
+  return [
     "$ErrorActionPreference='SilentlyContinue'",
     "$me=[System.Security.Principal.WindowsIdentity]::GetCurrent().Name",
     // -ErrorAction Stop plus the outer try is what makes a TOP-LEVEL query failure
@@ -412,9 +433,13 @@ export function listWindowsSnapshots(runPowerShell?: (psCommand: string) => stri
     "}",
     "} catch { \"__OCX_ENUM_INCOMPLETE__\" }",
   ].join("\n");
+}
+
+export function listWindowsSnapshots(runPowerShell?: (psCommand: string) => string): ProcessSnapshot[] {
   // Top-level exec failure propagates (see listDarwinSnapshots note). The
   // executable resolves from the trusted System32 directory (never PATH), and
   // windowsHide keeps the enumeration console-less on desktop sessions (#1278).
+  const psCommand = windowsSnapshotPowerShellCommand();
   const output = runPowerShell
     ? runPowerShell(psCommand)
     : execFileSync(resolveTrustedWindowsPowerShellExe(), [
@@ -422,6 +447,15 @@ export function listWindowsSnapshots(runPowerShell?: (psCommand: string) => stri
       "-Command",
       psCommand,
     ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"], timeout: 8_000, windowsHide: true });
+  return parseWindowsSnapshotOutput(output);
+}
+
+async function listWindowsSnapshotsAsync(): Promise<ProcessSnapshot[]> {
+  const output = await execFileTextAsync(resolveTrustedWindowsPowerShellExe(), [
+    "-NoProfile", "-NoLogo", "-NonInteractive",
+    "-Command",
+    windowsSnapshotPowerShellCommand(),
+  ], 8_000);
   return parseWindowsSnapshotOutput(output);
 }
 
@@ -533,6 +567,41 @@ export function readProcessStartMs(pid: number, platform: NodeJS.Platform = proc
   return readLinuxProcStartMs(pid);
 }
 
+function windowsProcessStartPowerShellCommand(pids: readonly number[]): string {
+  const filter = pids.map(pid => `ProcessId=${pid}`).join(" OR ");
+  return `Get-CimInstance Win32_Process -Filter "${filter}" | ForEach-Object { "$($_.ProcessId)\t$($_.CreationDate.ToUniversalTime().ToString("o"))" }`;
+}
+
+function parseWindowsProcessStartTimes(
+  stdout: string,
+  pids: readonly number[],
+): Map<number, number | null> {
+  const byPid = new Map<number, number>();
+  for (const line of stdout.split(/\r?\n/)) {
+    const tab = line.indexOf("\t");
+    if (tab <= 0) continue;
+    const pid = Number(line.slice(0, tab));
+    const parsed = Date.parse(line.slice(tab + 1).trim());
+    if (Number.isSafeInteger(pid) && Number.isFinite(parsed)) byPid.set(pid, parsed);
+  }
+  return new Map(pids.map(pid => [pid, byPid.get(pid) ?? null]));
+}
+
+async function readWindowsProcessStartMsBatchAsync(
+  pids: readonly number[],
+): Promise<Map<number, number | null>> {
+  try {
+    const stdout = await execFileTextAsync(resolveTrustedWindowsPowerShellExe(), [
+      "-NoProfile", "-NoLogo", "-NonInteractive",
+      "-Command",
+      windowsProcessStartPowerShellCommand(pids),
+    ], 5_000);
+    return parseWindowsProcessStartTimes(stdout, pids);
+  } catch {
+    return new Map(pids.map(pid => [pid, null]));
+  }
+}
+
 /**
  * Start times for many pids in ONE platform call where possible, so the
  * staleness check does not serialize per-process ps/PowerShell invocations
@@ -568,22 +637,12 @@ export function readProcessStartMsBatch(
   }
   if (platform === "win32") {
     try {
-      const filter = pids.map(pid => `ProcessId=${pid}`).join(" OR ");
       const stdout = execFileSync(resolveTrustedWindowsPowerShellExe(), [
         "-NoProfile", "-NoLogo", "-NonInteractive",
         "-Command",
-        `Get-CimInstance Win32_Process -Filter "${filter}" | ForEach-Object { "$($_.ProcessId)\t$($_.CreationDate.ToUniversalTime().ToString("o"))" }`,
+        windowsProcessStartPowerShellCommand(pids),
       ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"], timeout: 5_000, windowsHide: true });
-      const byPid = new Map<number, number>();
-      for (const line of stdout.split(/\r?\n/)) {
-        const tab = line.indexOf("\t");
-        if (tab <= 0) continue;
-        const pid = Number(line.slice(0, tab));
-        const parsed = Date.parse(line.slice(tab + 1).trim());
-        if (Number.isSafeInteger(pid) && Number.isFinite(parsed)) byPid.set(pid, parsed);
-      }
-      for (const pid of pids) out.set(pid, byPid.get(pid) ?? null);
-      return out;
+      return parseWindowsProcessStartTimes(stdout, pids);
     } catch {
       for (const pid of pids) out.set(pid, null);
       return out;
@@ -610,9 +669,65 @@ function defaultCatalogMtimeMs(): number | null {
   }
 }
 
+function codexAppServerProcessesFromSnapshots(
+  snapshots: readonly ProcessSnapshot[],
+): CodexAppServerProcess[] {
+  const processes: CodexAppServerProcess[] = [];
+  const seen = new Set<number>();
+  for (const snapshot of snapshots) {
+    if (seen.has(snapshot.pid)) continue;
+    if (!isCodexAppServerCommandLine(snapshot.commandLine, snapshot.executable)) continue;
+    seen.add(snapshot.pid);
+    processes.push({ pid: snapshot.pid, commandLine: snapshot.commandLine });
+  }
+  return processes;
+}
+
+function catalogStatusFromProcesses(
+  processes: readonly CodexAppServerProcess[],
+  catalogMtimeMs: number | null,
+  starts: ReadonlyMap<number, number | null>,
+): CodexAppServerCatalogStatus {
+  const withStarts = processes.map(proc => ({
+    pid: proc.pid,
+    startedAtMs: starts.get(proc.pid) ?? null,
+  }));
+  if (catalogMtimeMs === null || withStarts.some(proc => proc.startedAtMs === null)) {
+    return { state: "unknown", processes: withStarts, catalogMtimeMs };
+  }
+  // `<=` is deliberate: coarse clocks (ps lstart is second-granularity) can
+  // report equal values when the catalog actually changed after startup.
+  const stale = withStarts.some(proc => proc.startedAtMs! <= catalogMtimeMs);
+  return { state: stale ? "stale" : "fresh", processes: withStarts, catalogMtimeMs };
+}
+
 // Short TTL: process listing + stat run once per window even under per-turn
 // guidance calls (#857).
 let catalogStateCache: { atMs: number; status: CodexAppServerCatalogStatus } | null = null;
+interface RequestCatalogStateIdentity {
+  platform: NodeJS.Platform;
+  listSnapshots?: CodexAppServerProcessIo["listSnapshots"];
+  listSnapshotsAsync?: CodexAppServerProcessIo["listSnapshotsAsync"];
+  readStartMs?: CodexAppServerProcessIo["readStartMs"];
+  readStartMsBatchAsync?: CodexAppServerProcessIo["readStartMsBatchAsync"];
+  catalogMtimeMs?: CodexAppServerProcessIo["catalogMtimeMs"];
+  now?: CodexAppServerProcessIo["now"];
+}
+
+interface RequestCatalogStateFlight {
+  generation: number;
+  identity: RequestCatalogStateIdentity;
+  promise: Promise<CodexAppServerCatalogStatus>;
+}
+
+let requestCatalogStateGeneration = 0;
+let requestCatalogStateCache: {
+  generation: number;
+  identity: RequestCatalogStateIdentity;
+  atMs: number;
+  status: CodexAppServerCatalogStatus;
+} | null = null;
+let requestCatalogStateFlight: RequestCatalogStateFlight | null = null;
 const CATALOG_STATE_TTL_MS = 5_000;
 /**
  * `unknown` is a failure to observe, not an observation, so it gets a much shorter
@@ -625,6 +740,19 @@ const CATALOG_STATE_UNKNOWN_TTL_MS = 250;
 
 export function catalogStateTtlMs(state: CodexAppServerCatalogState): number {
   return state === "unknown" ? CATALOG_STATE_UNKNOWN_TTL_MS : CATALOG_STATE_TTL_MS;
+}
+
+function sameRequestCatalogStateIdentity(
+  left: RequestCatalogStateIdentity,
+  right: RequestCatalogStateIdentity,
+): boolean {
+  return left.platform === right.platform
+    && left.listSnapshots === right.listSnapshots
+    && left.listSnapshotsAsync === right.listSnapshotsAsync
+    && left.readStartMs === right.readStartMs
+    && left.readStartMsBatchAsync === right.readStartMsBatchAsync
+    && left.catalogMtimeMs === right.catalogMtimeMs
+    && left.now === right.now;
 }
 
 /**
@@ -676,33 +804,17 @@ export function collectCodexAppServerCatalogState(
       snapshots = [];
       enumerationFailed = true;
     }
-    const processes: CodexAppServerProcess[] = [];
-    const seen = new Set<number>();
-    for (const snapshot of snapshots) {
-      if (seen.has(snapshot.pid)) continue;
-      if (!isCodexAppServerCommandLine(snapshot.commandLine, snapshot.executable)) continue;
-      seen.add(snapshot.pid);
-      processes.push({ pid: snapshot.pid, commandLine: snapshot.commandLine });
-    }
+    const processes = codexAppServerProcessesFromSnapshots(snapshots);
     if (processes.length === 0) {
       return enumerationFailed
         ? { state: "unknown", processes: [], catalogMtimeMs: null }
         : { state: "not_running", processes: [], catalogMtimeMs: null };
     }
     const catalogMtimeMs = (io.catalogMtimeMs ?? defaultCatalogMtimeMs)();
-    const withStarts = io.readStartMs
-      ? processes.map(proc => ({ pid: proc.pid, startedAtMs: io.readStartMs!(proc.pid) }))
-      : (() => {
-        const batch = readProcessStartMsBatch(processes.map(proc => proc.pid), platform);
-        return processes.map(proc => ({ pid: proc.pid, startedAtMs: batch.get(proc.pid) ?? null }));
-      })();
-    if (catalogMtimeMs === null || withStarts.some(proc => proc.startedAtMs === null)) {
-      return { state: "unknown", processes: withStarts, catalogMtimeMs };
-    }
-    // `<=` is deliberate: coarse clocks (ps lstart is second-granularity) can
-    // report equal values when the catalog actually changed after startup.
-    const stale = withStarts.some(proc => proc.startedAtMs! <= catalogMtimeMs);
-    return { state: stale ? "stale" : "fresh", processes: withStarts, catalogMtimeMs };
+    const starts = io.readStartMs
+      ? new Map(processes.map(proc => [proc.pid, io.readStartMs!(proc.pid)] as const))
+      : readProcessStartMsBatch(processes.map(proc => proc.pid), platform);
+    return catalogStatusFromProcesses(processes, catalogMtimeMs, starts);
   };
   const status = compute();
   if (fullyDefault) {
@@ -711,9 +823,108 @@ export function collectCodexAppServerCatalogState(
   return status;
 }
 
+/**
+ * Request-path catalog state collector.
+ *
+ * [Decision Log]
+ * - 목적과 의도: keep Windows CIM discovery from blocking Bun's event loop while v2 guidance is built.
+ * - 기존 구현 및 제약 조건: CLI/service operations still need the synchronous, fail-closed collector; the request path needs only advisory state.
+ * - 검토한 주요 대안: remove stale-catalog guidance, move all process work to workers, or add a Windows-only async boundary.
+ * - 선택한 방식: retain the synchronous API and use async PowerShell plus an identity-scoped in-flight refresh, short cache, and invalidation generation only for Windows requests.
+ * - 다른 대안 대신 이 방식을 선택한 이유: it fixes unrelated `/healthz` starvation without widening the process-matching or restart contract.
+ * - 장점, 단점 및 영향: concurrent turns share one CIM walk, invalidated pre-write results cannot repopulate the cache, and the event loop stays responsive; a cold v2 turn can still await the bounded advisory probe.
+ */
+export async function collectCodexAppServerCatalogStateForRequest(
+  io: CodexAppServerProcessIo = {},
+): Promise<CodexAppServerCatalogStatus> {
+  const platform = io.platform ?? process.platform;
+  if (platform !== "win32") return collectCodexAppServerCatalogState(io);
+
+  const now = (io.now ?? Date.now)();
+  const generation = requestCatalogStateGeneration;
+  const identity: RequestCatalogStateIdentity = {
+    platform,
+    listSnapshots: io.listSnapshots,
+    listSnapshotsAsync: io.listSnapshotsAsync,
+    readStartMs: io.readStartMs,
+    readStartMsBatchAsync: io.readStartMsBatchAsync,
+    catalogMtimeMs: io.catalogMtimeMs,
+    now: io.now,
+  };
+  if (requestCatalogStateCache
+    && requestCatalogStateCache.generation === generation
+    && sameRequestCatalogStateIdentity(requestCatalogStateCache.identity, identity)
+    && now - requestCatalogStateCache.atMs < CATALOG_STATE_TTL_MS) {
+    return requestCatalogStateCache.status;
+  }
+  if (requestCatalogStateFlight
+    && requestCatalogStateFlight.generation === generation
+    && sameRequestCatalogStateIdentity(requestCatalogStateFlight.identity, identity)) {
+    return requestCatalogStateFlight.promise;
+  }
+
+  const refresh = async (): Promise<CodexAppServerCatalogStatus> => {
+    let snapshots: ProcessSnapshot[];
+    try {
+      snapshots = io.listSnapshotsAsync
+        ? await io.listSnapshotsAsync()
+        : io.listSnapshots
+          ? io.listSnapshots()
+          : await listWindowsSnapshotsAsync();
+    } catch {
+      return { state: "unknown", processes: [], catalogMtimeMs: null };
+    }
+    const processes = codexAppServerProcessesFromSnapshots(snapshots);
+    if (processes.length === 0) {
+      return { state: "not_running", processes: [], catalogMtimeMs: null };
+    }
+    let catalogMtimeMs: number | null;
+    try {
+      catalogMtimeMs = (io.catalogMtimeMs ?? defaultCatalogMtimeMs)();
+    } catch {
+      catalogMtimeMs = null;
+    }
+    const pids = processes.map(proc => proc.pid);
+    const starts = io.readStartMsBatchAsync
+      ? await io.readStartMsBatchAsync(pids)
+      : io.readStartMs
+        ? new Map(pids.map(pid => [pid, io.readStartMs!(pid)] as const))
+        : await readWindowsProcessStartMsBatchAsync(pids);
+    return catalogStatusFromProcesses(processes, catalogMtimeMs, starts);
+  };
+
+  const pending = refresh().catch(() => ({
+    state: "unknown" as const,
+    processes: [],
+    catalogMtimeMs: null,
+  }));
+  let flight: RequestCatalogStateFlight;
+  const promise = pending.then(status => {
+    // A catalog write can invalidate while slow CIM is still running. Never
+    // let that pre-write result repopulate the post-write cache.
+    if (requestCatalogStateGeneration === generation && requestCatalogStateFlight === flight) {
+      requestCatalogStateCache = {
+        generation,
+        identity,
+        atMs: (io.now ?? Date.now)(),
+        status,
+      };
+    }
+    return status;
+  }).finally(() => {
+    if (requestCatalogStateFlight === flight) requestCatalogStateFlight = null;
+  });
+  flight = { generation, identity, promise };
+  requestCatalogStateFlight = flight;
+  return flight.promise;
+}
+
 /** Test hook: drop the memoized catalog state. */
 export function resetCodexAppServerCatalogStateCache(): void {
   catalogStateCache = null;
+  requestCatalogStateGeneration += 1;
+  requestCatalogStateCache = null;
+  requestCatalogStateFlight = null;
 }
 
 export interface RestartCodexAppServersResult {

--- a/src/codex/app-server-processes.ts
+++ b/src/codex/app-server-processes.ts
@@ -854,7 +854,7 @@ export async function collectCodexAppServerCatalogStateForRequest(
   if (requestCatalogStateCache
     && requestCatalogStateCache.generation === generation
     && sameRequestCatalogStateIdentity(requestCatalogStateCache.identity, identity)
-    && now - requestCatalogStateCache.atMs < CATALOG_STATE_TTL_MS) {
+    && now - requestCatalogStateCache.atMs < catalogStateTtlMs(requestCatalogStateCache.status.state)) {
     return requestCatalogStateCache.status;
   }
   if (requestCatalogStateFlight

--- a/src/server/responses/collaboration.ts
+++ b/src/server/responses/collaboration.ts
@@ -197,7 +197,8 @@ export interface MultiAgentGuidanceDeps {
     configuredModels: readonly string[],
     surface: SpawnAgentSurface,
   ) => EffectiveSubagentRoster | Promise<EffectiveSubagentRoster>;
-  collectCatalogState?: () => { state: "fresh" | "stale" | "not_running" | "unknown" };
+  collectCatalogState?: () => { state: "fresh" | "stale" | "not_running" | "unknown" }
+    | Promise<{ state: "fresh" | "stale" | "not_running" | "unknown" }>;
 }
 
 async function defaultCollectCatalogState(): Promise<{ state: "fresh" | "stale" | "not_running" | "unknown" }> {
@@ -207,8 +208,8 @@ async function defaultCollectCatalogState(): Promise<{ state: "fresh" | "stale" 
   if (override === "fresh" || override === "stale" || override === "not_running" || override === "unknown") {
     return { state: override };
   }
-  const { collectCodexAppServerCatalogState } = await import("../../codex/app-server-processes");
-  return collectCodexAppServerCatalogState();
+  const { collectCodexAppServerCatalogStateForRequest } = await import("../../codex/app-server-processes");
+  return collectCodexAppServerCatalogStateForRequest();
 }
 
 

--- a/structure/03_catalog-and-subagents.md
+++ b/structure/03_catalog-and-subagents.md
@@ -59,6 +59,16 @@ deleting, or editing a provider's shape clears that per-provider cache; a disabl
 deliberately does not, because a disabled provider is already excluded from the catalog gather
 instead. Codex's own `models_cache.json` is a different cache, invalidated by catalog refresh.
 
+### Windows request-path catalog-state discovery
+
+[Decision Log]
+- 목적과 의도: Prevent Windows PowerShell/CIM process discovery from blocking Bun's event loop while v2 sub-agent guidance is assembled.
+- 기존 구현 및 제약 조건: The stale-catalog check is advisory on the request path, but CLI/service lifecycle operations use the same process evidence before warning or terminating narrowly matched app-servers.
+- 검토한 주요 대안: Remove stale-catalog guidance, move every platform collector into workers, or isolate only the Windows request path behind asynchronous child processes.
+- 선택한 방식: Keep the synchronous fail-closed collector for explicit lifecycle operations; v2 requests use asynchronous trusted-System32 PowerShell, one identity-scoped in-flight refresh, and the existing short cache. Cache invalidation advances a generation so a pre-write CIM result cannot repopulate post-write state.
+- 다른 대안 대신 이 방식을 선택한 이유: This preserves process ownership and matching invariants while preventing a slow CIM query from starving `/healthz` and unrelated proxy traffic.
+- 장점, 단점 및 영향: Concurrent v2 turns do not multiply CIM walks and the event loop remains responsive. A cold request can still await the bounded advisory check, and collection failure suppresses OpenCodex-authored model guidance as `unknown`.
+
 ## Startup readiness
 
 Each `startServer` invocation owns a private, one-shot readiness gate created before the listener

--- a/tests/codex-app-server-processes.test.ts
+++ b/tests/codex-app-server-processes.test.ts
@@ -161,6 +161,33 @@ describe("collectCodexAppServerCatalogState (#857)", () => {
     resetCodexAppServerCatalogStateCache();
   });
 
+  test("Windows request collection briefly caches failed CIM enumeration (#1852)", async () => {
+    resetCodexAppServerCatalogStateCache();
+    let calls = 0;
+    let now = 1_000;
+    const io = {
+      platform: "win32" as const,
+      now: () => now,
+      listSnapshotsAsync: async () => {
+        calls += 1;
+        throw new Error("windows_enum_incomplete");
+      },
+      catalogMtimeMs: () => 1_000,
+    };
+
+    await expect(collectCodexAppServerCatalogStateForRequest(io)).resolves.toMatchObject({
+      state: "unknown",
+    });
+    now += 10;
+    await expect(collectCodexAppServerCatalogStateForRequest(io)).resolves.toMatchObject({
+      state: "unknown",
+    });
+    // Failure is advisory and fail-closed, but caching it briefly prevents a
+    // broken CIM provider from spawning one PowerShell process per request.
+    expect(calls).toBe(1);
+    resetCodexAppServerCatalogStateCache();
+  });
+
   test("unrelated processes never enter the comparison", () => {
     const status = collectCodexAppServerCatalogState({
       listSnapshots: () => [

--- a/tests/codex-app-server-processes.test.ts
+++ b/tests/codex-app-server-processes.test.ts
@@ -185,6 +185,12 @@ describe("collectCodexAppServerCatalogState (#857)", () => {
     // Failure is advisory and fail-closed, but caching it briefly prevents a
     // broken CIM provider from spawning one PowerShell process per request.
     expect(calls).toBe(1);
+
+    now += 241;
+    await expect(collectCodexAppServerCatalogStateForRequest(io)).resolves.toMatchObject({
+      state: "unknown",
+    });
+    expect(calls).toBe(2);
     resetCodexAppServerCatalogStateCache();
   });
 

--- a/tests/codex-app-server-processes.test.ts
+++ b/tests/codex-app-server-processes.test.ts
@@ -24,7 +24,32 @@ import {
 } from "../src/codex/app-server-processes";
 
 describe("collectCodexAppServerCatalogState (#857)", () => {
-  const APP_SERVER_CMD = "/usr/local/bin/codex app-server";
+const APP_SERVER_CMD = "/usr/local/bin/codex app-server";
+
+/**
+ * A stand-in for powershell.exe that stalls, prints `line`, and exits.
+ *
+ * Platform-shaped on purpose: `execFile` launches its target directly with no shell, so a
+ * POSIX `.sh` script is not an executable on Windows — and Windows is the platform this
+ * whole fix exists for, with its own CI shard running this suite. On Windows the fake is a
+ * `.cmd` invoked through `cmd.exe`; elsewhere it is a shell script.
+ */
+function writeStallingFakePowerShell(dir: string, line: string): string {
+  if (process.platform === "win32") {
+    const cmd = join(dir, "fake-powershell.cmd");
+    writeFileSync(cmd, [
+      "@echo off",
+      // ~200ms without depending on timeout.exe, which refuses a redirected stdin.
+      "ping -n 1 -w 200 192.0.2.1 >nul 2>&1",
+      `echo ${line.replace(/\t/g, "\t")}`,
+    ].join("\r\n"));
+    return cmd;
+  }
+  const sh = join(dir, "fake-powershell.sh");
+  writeFileSync(sh, ["#!/bin/sh", "sleep 0.2", `printf '%s\\n' '${line}'`].join("\n"));
+  chmodSync(sh, 0o755);
+  return sh;
+}
 
   test("not_running when no app-server process exists", () => {
     const status = collectCodexAppServerCatalogState({
@@ -110,45 +135,64 @@ describe("collectCodexAppServerCatalogState (#857)", () => {
   test("the default Windows request path keeps the event loop alive through both PowerShell calls (#1852)", async () => {
     resetCodexAppServerCatalogStateCache();
     const dir = mkdtempSync(join(tmpdir(), "ocx-ps-fake-"));
-    const fake = join(dir, "powershell.sh");
-    // Ignores its arguments and stalls, then prints one enumeration row. Both the
-    // snapshot call and the start-time call land here; each sleeps, so a synchronous
-    // runner blocks twice.
-    writeFileSync(fake, [
-      "#!/bin/sh",
-      "sleep 0.2",
-      `printf '%s\\t%s\\t%s\\n' 42 '${APP_SERVER_CMD}' 'CONTOSO\\\\jun'`,
-    ].join("\n"));
-    chmodSync(fake, 0o755);
+    const fake = writeStallingFakePowerShell(dir, `42\t${APP_SERVER_CMD}\tCONTOSO\\jun`);
     setTrustedWindowsElevationExecutablesForTests({ powershell: fake });
 
-    let ticks = 0;
+    // Phase signal instead of a timer count. A callback tally has to pick a threshold
+    // between "sync" and "async" observations, and `setInterval` makes no catch-up
+    // guarantee — on a loaded runner a correct implementation can dip under any midpoint.
+    // This asks a binary question instead: did event-loop work make progress WHILE the
+    // child was running? A synchronous exec parks the loop, so the flag stays false no
+    // matter how slow or fast the machine is.
+    let loopRanDuringExec = false;
+    const beat = setInterval(() => { loopRanDuringExec = true; }, 5);
     let status: Awaited<ReturnType<typeof collectCodexAppServerCatalogStateForRequest>>;
-    const timer = setInterval(() => { ticks += 1; }, 10);
     try {
       status = await collectCodexAppServerCatalogStateForRequest({
         platform: "win32",
         catalogMtimeMs: () => 1_000,
+        // Only the enumeration is exercised here; the start-time half has its own test.
+        readStartMsBatchAsync: async pids => new Map(pids.map(pid => [pid, 2_000])),
       });
     } finally {
-      clearInterval(timer);
+      clearInterval(beat);
       setTrustedWindowsElevationExecutablesForTests(null);
       rmSync(dir, { recursive: true, force: true });
       resetCodexAppServerCatalogStateCache();
     }
 
-    // Assert the fake was actually parsed. Without this the test passes on
-    // "not_running" — which is what a failed exec also produces — so a broken
-    // enumeration would look identical to a fast one.
+    // Without this a failed exec ("not_running") would look identical to a fast one.
     expect(status.processes.map(proc => proc.pid)).toEqual([42]);
+    expect(loopRanDuringExec).toBe(true);
+  });
 
-    // The fake stalls ~200ms per call against a 10ms timer, and the request path makes
-    // TWO calls (enumeration, then start-time discovery). Measured on this repo:
-    // async default ~42 ticks, synchronous default ~19. The gap is real but not total —
-    // Bun's execFileSync still lets a few timers through — so the threshold sits between
-    // the two measurements rather than at zero. Isolated probe for the same runtime:
-    // execFileSync("sleep 0.3") admits 1 tick against a 10ms timer.
-    expect(ticks).toBeGreaterThan(28);
+  // The request path makes TWO PowerShell calls. The test above injects
+  // `readStartMsBatchAsync` so it isolates the first one — which means reverting the
+  // SECOND to a synchronous read slips past it. That second call is up to five seconds of
+  // blocking when an app-server exists, so it needs its own oracle.
+  test("the default Windows start-time discovery keeps the event loop alive (#1852)", async () => {
+    resetCodexAppServerCatalogStateCache();
+    const dir = mkdtempSync(join(tmpdir(), "ocx-ps-start-"));
+    const fake = writeStallingFakePowerShell(dir, `42\t${APP_SERVER_CMD}\tCONTOSO\\jun`);
+    setTrustedWindowsElevationExecutablesForTests({ powershell: fake });
+
+    let loopRanDuringExec = false;
+    const beat = setInterval(() => { loopRanDuringExec = true; }, 5);
+    try {
+      // No readStartMsBatchAsync override: the default start-time path must run for real.
+      await collectCodexAppServerCatalogStateForRequest({
+        platform: "win32",
+        listSnapshotsAsync: async () => [{ pid: 42, commandLine: APP_SERVER_CMD }],
+        catalogMtimeMs: () => 1_000,
+      });
+    } finally {
+      clearInterval(beat);
+      setTrustedWindowsElevationExecutablesForTests(null);
+      rmSync(dir, { recursive: true, force: true });
+      resetCodexAppServerCatalogStateCache();
+    }
+
+    expect(loopRanDuringExec).toBe(true);
   });
 
   test("Windows request collection shares one in-flight refresh and its short cache (#1852)", async () => {

--- a/tests/codex-app-server-processes.test.ts
+++ b/tests/codex-app-server-processes.test.ts
@@ -8,6 +8,7 @@ import {
   attachStaleAppServerHint,
   catalogStateTtlMs,
   collectCodexAppServerCatalogState,
+  collectCodexAppServerCatalogStateForRequest,
   formatStaleCodexAppServerWarning,
   isCodexAppServerCommandLine,
   isWindowsCodexCandidateCommandLine,
@@ -72,6 +73,92 @@ describe("collectCodexAppServerCatalogState (#857)", () => {
       catalogMtimeMs: () => null,
     });
     expect(noCatalog.state).toBe("unknown");
+  });
+
+  test("Windows request collection yields to the event loop while CIM enumeration is slow (#1852)", async () => {
+    let releaseSnapshots: ((snapshots: Array<{ pid: number; commandLine: string }>) => void) | undefined;
+    const snapshots = new Promise<Array<{ pid: number; commandLine: string }>>(resolve => {
+      releaseSnapshots = resolve;
+    });
+    const collection = collectCodexAppServerCatalogStateForRequest({
+      platform: "win32",
+      listSnapshotsAsync: () => snapshots,
+      readStartMsBatchAsync: async pids => new Map(pids.map(pid => [pid, 2_000])),
+      catalogMtimeMs: () => 1_000,
+    });
+
+    const first = await Promise.race([
+      collection.then(() => "collection"),
+      new Promise<"timer">(resolve => setTimeout(() => resolve("timer"), 10)),
+    ]);
+    expect(first).toBe("timer");
+
+    releaseSnapshots?.([{ pid: 42, commandLine: APP_SERVER_CMD }]);
+    await expect(collection).resolves.toMatchObject({ state: "fresh" });
+  });
+
+  test("Windows request collection shares one in-flight refresh and its short cache (#1852)", async () => {
+    resetCodexAppServerCatalogStateCache();
+    let calls = 0;
+    let now = 1_000;
+    const io = {
+      platform: "win32" as const,
+      now: () => now,
+      listSnapshotsAsync: async () => {
+        calls += 1;
+        await Bun.sleep(10);
+        return [{ pid: 42, commandLine: APP_SERVER_CMD }];
+      },
+      readStartMsBatchAsync: async (pids: readonly number[]) => new Map(pids.map(pid => [pid, 2_000])),
+      catalogMtimeMs: () => 1_000,
+    };
+
+    const [first, joined] = await Promise.all([
+      collectCodexAppServerCatalogStateForRequest(io),
+      collectCodexAppServerCatalogStateForRequest(io),
+    ]);
+    expect(first.state).toBe("fresh");
+    expect(joined).toBe(first);
+    expect(calls).toBe(1);
+
+    now += 4_999;
+    expect((await collectCodexAppServerCatalogStateForRequest(io)).state).toBe("fresh");
+    expect(calls).toBe(1);
+
+    now += 2;
+    expect((await collectCodexAppServerCatalogStateForRequest(io)).state).toBe("fresh");
+    expect(calls).toBe(2);
+    resetCodexAppServerCatalogStateCache();
+  });
+
+  test("cache invalidation cannot be undone by an older in-flight Windows refresh (#1852)", async () => {
+    resetCodexAppServerCatalogStateCache();
+    let calls = 0;
+    let releaseFirst: ((snapshots: Array<{ pid: number; commandLine: string }>) => void) | undefined;
+    const firstSnapshots = new Promise<Array<{ pid: number; commandLine: string }>>(resolve => {
+      releaseFirst = resolve;
+    });
+    const io = {
+      platform: "win32" as const,
+      listSnapshotsAsync: async () => {
+        calls += 1;
+        if (calls === 1) return firstSnapshots;
+        return [];
+      },
+      readStartMsBatchAsync: async (pids: readonly number[]) => new Map(pids.map(pid => [pid, 2_000])),
+      catalogMtimeMs: () => 1_000,
+    };
+
+    const staleFlight = collectCodexAppServerCatalogStateForRequest(io);
+    resetCodexAppServerCatalogStateCache();
+    releaseFirst?.([{ pid: 42, commandLine: APP_SERVER_CMD }]);
+    await expect(staleFlight).resolves.toMatchObject({ state: "fresh" });
+
+    await expect(collectCodexAppServerCatalogStateForRequest(io)).resolves.toMatchObject({
+      state: "not_running",
+    });
+    expect(calls).toBe(2);
+    resetCodexAppServerCatalogStateCache();
   });
 
   test("unrelated processes never enter the comparison", () => {

--- a/tests/codex-app-server-processes.test.ts
+++ b/tests/codex-app-server-processes.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { spawn } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setTrustedWindowsElevationExecutablesForTests } from "../src/lib/windows-elevation";
 import {
@@ -17,7 +18,6 @@ import {
   parseWindowsSnapshotOutput,
   resetCodexAppServerCatalogStateCache,
   restartCodexAppServers,
-  setWindowsSnapshotExecAsyncForTest,
   STALE_CODEX_APP_SERVER_HINT,
   warnIfStaleCodexAppServersAfterStartupWrite,
   WINDOWS_CODEX_BASENAME_CANDIDATE_RE,
@@ -102,33 +102,53 @@ describe("collectCodexAppServerCatalogState (#857)", () => {
   // production default is async: reverting the default to `execFileSync` leaves every
   // assertion in it passing. It describes the intended design without guarding it.
   //
-  // This one drives the DEFAULT wiring — no `listSnapshotsAsync` override — through the
-  // exec seam, so a synchronous enumeration is observable as what it actually is: a
-  // blocked event loop. That is the defect #1852 reported.
-  test("the default Windows request enumeration does not block the event loop (#1852)", async () => {
+  // The one below guards it. It replaces the *executable* rather than the code under
+  // test, so BOTH default PowerShell calls — process enumeration and start-time
+  // discovery — run for real through their production wiring. A synchronous
+  // implementation parks the event loop for the script's whole duration; an
+  // asynchronous one does not. That difference is the entire content of #1852.
+  test("the default Windows request path keeps the event loop alive through both PowerShell calls (#1852)", async () => {
     resetCodexAppServerCatalogStateCache();
-    const restore = setWindowsSnapshotExecAsyncForTest(async () => {
-      // Stand in for a slow CIM walk. A synchronous implementation spends this time
-      // inside execFileSync with the loop parked; an async one leaves it running.
-      await new Promise(resolve => setTimeout(resolve, 30));
-      return `42\t${APP_SERVER_CMD}\tCONTOSO\\jun`;
-    });
+    const dir = mkdtempSync(join(tmpdir(), "ocx-ps-fake-"));
+    const fake = join(dir, "powershell.sh");
+    // Ignores its arguments and stalls, then prints one enumeration row. Both the
+    // snapshot call and the start-time call land here; each sleeps, so a synchronous
+    // runner blocks twice.
+    writeFileSync(fake, [
+      "#!/bin/sh",
+      "sleep 0.2",
+      `printf '%s\\t%s\\t%s\\n' 42 '${APP_SERVER_CMD}' 'CONTOSO\\\\jun'`,
+    ].join("\n"));
+    chmodSync(fake, 0o755);
+    setTrustedWindowsElevationExecutablesForTests({ powershell: fake });
+
+    let ticks = 0;
+    let status: Awaited<ReturnType<typeof collectCodexAppServerCatalogStateForRequest>>;
+    const timer = setInterval(() => { ticks += 1; }, 10);
     try {
-      let ticks = 0;
-      const timer = setInterval(() => { ticks += 1; }, 5);
-      const status = await collectCodexAppServerCatalogStateForRequest({
+      status = await collectCodexAppServerCatalogStateForRequest({
         platform: "win32",
-        readStartMsBatchAsync: async pids => new Map(pids.map(pid => [pid, 2_000])),
         catalogMtimeMs: () => 1_000,
       });
-      clearInterval(timer);
-      expect(status.state).toBe("fresh");
-      // The whole point of the fix: other work ran while enumeration was in flight.
-      expect(ticks).toBeGreaterThan(0);
     } finally {
-      restore();
+      clearInterval(timer);
+      setTrustedWindowsElevationExecutablesForTests(null);
+      rmSync(dir, { recursive: true, force: true });
       resetCodexAppServerCatalogStateCache();
     }
+
+    // Assert the fake was actually parsed. Without this the test passes on
+    // "not_running" — which is what a failed exec also produces — so a broken
+    // enumeration would look identical to a fast one.
+    expect(status.processes.map(proc => proc.pid)).toEqual([42]);
+
+    // The fake stalls ~200ms per call against a 10ms timer, and the request path makes
+    // TWO calls (enumeration, then start-time discovery). Measured on this repo:
+    // async default ~42 ticks, synchronous default ~19. The gap is real but not total —
+    // Bun's execFileSync still lets a few timers through — so the threshold sits between
+    // the two measurements rather than at zero. Isolated probe for the same runtime:
+    // execFileSync("sleep 0.3") admits 1 tick against a 10ms timer.
+    expect(ticks).toBeGreaterThan(28);
   });
 
   test("Windows request collection shares one in-flight refresh and its short cache (#1852)", async () => {

--- a/tests/codex-app-server-processes.test.ts
+++ b/tests/codex-app-server-processes.test.ts
@@ -17,6 +17,7 @@ import {
   parseWindowsSnapshotOutput,
   resetCodexAppServerCatalogStateCache,
   restartCodexAppServers,
+  setWindowsSnapshotExecAsyncForTest,
   STALE_CODEX_APP_SERVER_HINT,
   warnIfStaleCodexAppServersAfterStartupWrite,
   WINDOWS_CODEX_BASENAME_CANDIDATE_RE,
@@ -95,6 +96,39 @@ describe("collectCodexAppServerCatalogState (#857)", () => {
 
     releaseSnapshots?.([{ pid: 42, commandLine: APP_SERVER_CMD }]);
     await expect(collection).resolves.toMatchObject({ state: "fresh" });
+  });
+
+  // The test above injects an ALREADY-async seam, so it stays green whether or not the
+  // production default is async: reverting the default to `execFileSync` leaves every
+  // assertion in it passing. It describes the intended design without guarding it.
+  //
+  // This one drives the DEFAULT wiring — no `listSnapshotsAsync` override — through the
+  // exec seam, so a synchronous enumeration is observable as what it actually is: a
+  // blocked event loop. That is the defect #1852 reported.
+  test("the default Windows request enumeration does not block the event loop (#1852)", async () => {
+    resetCodexAppServerCatalogStateCache();
+    const restore = setWindowsSnapshotExecAsyncForTest(async () => {
+      // Stand in for a slow CIM walk. A synchronous implementation spends this time
+      // inside execFileSync with the loop parked; an async one leaves it running.
+      await new Promise(resolve => setTimeout(resolve, 30));
+      return `42\t${APP_SERVER_CMD}\tCONTOSO\\jun`;
+    });
+    try {
+      let ticks = 0;
+      const timer = setInterval(() => { ticks += 1; }, 5);
+      const status = await collectCodexAppServerCatalogStateForRequest({
+        platform: "win32",
+        readStartMsBatchAsync: async pids => new Map(pids.map(pid => [pid, 2_000])),
+        catalogMtimeMs: () => 1_000,
+      });
+      clearInterval(timer);
+      expect(status.state).toBe("fresh");
+      // The whole point of the fix: other work ran while enumeration was in flight.
+      expect(ticks).toBeGreaterThan(0);
+    } finally {
+      restore();
+      resetCodexAppServerCatalogStateCache();
+    }
   });
 
   test("Windows request collection shares one in-flight refresh and its short cache (#1852)", async () => {

--- a/tests/codex-app-server-processes.test.ts
+++ b/tests/codex-app-server-processes.test.ts
@@ -152,10 +152,48 @@ describe("collectCodexAppServerCatalogState (#857)", () => {
     const staleFlight = collectCodexAppServerCatalogStateForRequest(io);
     resetCodexAppServerCatalogStateCache();
     releaseFirst?.([{ pid: 42, commandLine: APP_SERVER_CMD }]);
-    await expect(staleFlight).resolves.toMatchObject({ state: "fresh" });
+    // The awaiting request must NOT receive the pre-write `fresh`. It was true
+    // before the invalidating write and is false after it, and `fresh` is the one
+    // state that authorizes positive model guidance — so handing it back trades the
+    // original hang for a wrong answer. `unknown` is what an invalidated
+    // observation actually knows, and the guidance path already stays silent on it.
+    await expect(staleFlight).resolves.toMatchObject({ state: "unknown" });
 
     await expect(collectCodexAppServerCatalogStateForRequest(io)).resolves.toMatchObject({
       state: "not_running",
+    });
+    expect(calls).toBe(2);
+    resetCodexAppServerCatalogStateCache();
+  });
+
+  test("an invalidated in-flight refresh does not poison the next request (#1852)", async () => {
+    // Companion to the case above: degrading the obsolete result to `unknown` must
+    // not also suppress the NEXT observation, which is made after the write and is
+    // therefore the one the caller should trust.
+    resetCodexAppServerCatalogStateCache();
+    let calls = 0;
+    let releaseFirst: ((snapshots: Array<{ pid: number; commandLine: string }>) => void) | undefined;
+    const firstSnapshots = new Promise<Array<{ pid: number; commandLine: string }>>(resolve => {
+      releaseFirst = resolve;
+    });
+    const io = {
+      platform: "win32" as const,
+      listSnapshotsAsync: async () => {
+        calls += 1;
+        if (calls === 1) return firstSnapshots;
+        return [{ pid: 43, commandLine: APP_SERVER_CMD }];
+      },
+      readStartMsBatchAsync: async (pids: readonly number[]) => new Map(pids.map(pid => [pid, 2_000])),
+      catalogMtimeMs: () => 1_000,
+    };
+
+    const obsolete = collectCodexAppServerCatalogStateForRequest(io);
+    resetCodexAppServerCatalogStateCache();
+    releaseFirst?.([{ pid: 42, commandLine: APP_SERVER_CMD }]);
+    await expect(obsolete).resolves.toMatchObject({ state: "unknown" });
+
+    await expect(collectCodexAppServerCatalogStateForRequest(io)).resolves.toMatchObject({
+      state: "fresh",
     });
     expect(calls).toBe(2);
     resetCodexAppServerCatalogStateCache();

--- a/tests/multi-agent-compat.test.ts
+++ b/tests/multi-agent-compat.test.ts
@@ -129,7 +129,7 @@ describe("multiAgentGuidanceText", () => {
 
     for (const state of ["stale", "unknown"] as const) {
       const text = await multiAgentGuidanceText(parsed, options, {
-        collectCatalogState: () => ({ state }),
+        collectCatalogState: async () => ({ state }),
       });
       // #1395: withhold OpenCodex's disk-derived claims, but do not prohibit
       // options the active spawn_agent tool advertises — the global catalog

--- a/tests/multi-agent-compat.test.ts
+++ b/tests/multi-agent-compat.test.ts
@@ -136,9 +136,15 @@ describe("multiAgentGuidanceText", () => {
     // a stalling fake stands in for a slow CIM walk. The async request collector leaves
     // the loop free; the synchronous collector parks it.
     const fakeDir = mkdtempSync(join(tmpdir(), "ocx-collab-ps-"));
-    const fake = join(fakeDir, "powershell.sh");
-    writeFileSync(fake, ["#!/bin/sh", "sleep 0.2", "printf ''"].join("\n"));
-    chmodSync(fake, 0o755);
+    // Platform-shaped: execFile takes no shell, so a POSIX script is not executable on
+    // Windows — the platform this fix targets, whose CI shard runs this suite.
+    const fake = join(fakeDir, process.platform === "win32" ? "fake-powershell.cmd" : "fake-powershell.sh");
+    if (process.platform === "win32") {
+      writeFileSync(fake, ["@echo off", "ping -n 1 -w 200 192.0.2.1 >nul 2>&1"].join("\r\n"));
+    } else {
+      writeFileSync(fake, ["#!/bin/sh", "sleep 0.2", "printf ''"].join("\n"));
+      chmodSync(fake, 0o755);
+    }
     setTrustedWindowsElevationExecutablesForTests({ powershell: fake });
     const realPlatform = Object.getOwnPropertyDescriptor(process, "platform")!;
     Object.defineProperty(process, "platform", { value: "win32", configurable: true });
@@ -149,12 +155,17 @@ describe("multiAgentGuidanceText", () => {
     // real default path.
     delete process.env.OPENCODEX_APP_SERVER_CATALOG_STATE_OVERRIDE;
 
-    let ticks = 0;
-    const timer = setInterval(() => { ticks += 1; }, 10);
+    // Phase signal rather than a tick count: a threshold between "sync" and "async"
+    // observations has to guess how many timer callbacks a loaded runner will deliver,
+    // and setInterval promises no catch-up. This asks the binary question instead — did
+    // any event-loop work run WHILE the child was alive? A synchronous exec parks the
+    // loop, so the flag cannot flip regardless of machine speed.
+    let loopRanDuringExec = false;
+    const beat = setInterval(() => { loopRanDuringExec = true; }, 5);
     try {
       await multiAgentGuidanceText(parsed, { injectionModel: "anthropic/claude-sonnet-5" });
     } finally {
-      clearInterval(timer);
+      clearInterval(beat);
       Object.defineProperty(process, "platform", realPlatform);
       setTrustedWindowsElevationExecutablesForTests(null);
       rmSync(fakeDir, { recursive: true, force: true });
@@ -162,11 +173,7 @@ describe("multiAgentGuidanceText", () => {
       process.env.OPENCODEX_APP_SERVER_CATALOG_STATE_OVERRIDE = "fresh";
     }
 
-    // Measured on this repo against the stalling fake: the async request collector admits
-    // ~23 ticks, the synchronous collector admits 0 — it parks the loop for the whole
-    // enumeration. Any positive count proves the async wiring; the margin to 8 is
-    // generous enough that a loaded CI box cannot flake it.
-    expect(ticks).toBeGreaterThan(8);
+    expect(loopRanDuringExec).toBe(true);
   });
 
   test("v2 guidance suppresses positive model claims while the app-server catalog is stale or unknown (#857)", async () => {

--- a/tests/multi-agent-compat.test.ts
+++ b/tests/multi-agent-compat.test.ts
@@ -4,14 +4,15 @@
  * the Proactive delegation prompt when they arrive with the synthetic top tier.
  */
 import { afterAll, afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { injectDeveloperMessage, multiAgentGuidanceText, sanitizeEncryptedContentInPlace } from "../src/server/responses";
 import { parseRequest } from "../src/responses/parser";
 import type { OcxParsedRequest } from "../src/types";
 import { CODEX_ACCOUNT_BOUND_CATALOG_KIND, effectiveSubagentRoster } from "../src/codex/catalog";
-import { collectCodexAppServerCatalogState } from "../src/codex/app-server-processes";
+import { collectCodexAppServerCatalogState, resetCodexAppServerCatalogStateCache } from "../src/codex/app-server-processes";
+import { setTrustedWindowsElevationExecutablesForTests } from "../src/lib/windows-elevation";
 import { clearDebugSettings, setDebugSettings } from "../src/lib/debug-settings";
 import {
   getInjectionDebugLogEntries,
@@ -116,6 +117,56 @@ describe("multiAgentGuidanceText", () => {
     codexHomeFixture(V2_OFF);
     expect(await multiAgentGuidanceText(parsedFixture({ reasoning: "max", tools: [{ name: "spawn_agent" }] }))).toBeNull();
     expect(await multiAgentGuidanceText(parsedFixture({ reasoning: "max", tools: [{ name: "shell" }] }))).toBeNull();
+  });
+
+  // Every catalog-state test in this file injects `collectCatalogState`, which means none
+  // of them observes which collector the DEFAULT path picks. Rewiring the v2 boundary back
+  // to the synchronous collector left this whole suite green — the regression #1852 exists
+  // to prevent would have shipped unnoticed. This pins the default wiring itself.
+  test("the v2 default catalog path uses the request collector, not the synchronous one (#1852)", async () => {
+    const dir = codexHomeFixture(V2_ON);
+    catalogFixture(dir, [{
+      slug: "anthropic/claude-sonnet-5",
+      efforts: ["low", "medium", "high", "xhigh"],
+    }]);
+    const parsed = parsedFixture({ reasoning: "medium", tools: [{ name: "spawn_agent" }] });
+
+    // Force the default dependency by passing NO collectCatalogState, and make the
+    // underlying process enumeration observable through the trusted-executable seam:
+    // a stalling fake stands in for a slow CIM walk. The async request collector leaves
+    // the loop free; the synchronous collector parks it.
+    const fakeDir = mkdtempSync(join(tmpdir(), "ocx-collab-ps-"));
+    const fake = join(fakeDir, "powershell.sh");
+    writeFileSync(fake, ["#!/bin/sh", "sleep 0.2", "printf ''"].join("\n"));
+    chmodSync(fake, 0o755);
+    setTrustedWindowsElevationExecutablesForTests({ powershell: fake });
+    const realPlatform = Object.getOwnPropertyDescriptor(process, "platform")!;
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    resetCodexAppServerCatalogStateCache();
+    // This suite sets a hermetic state override at module load so the host's real
+    // app-server cannot leak in. That override short-circuits before any collector runs,
+    // so it has to come off for exactly this test — which is the one test that needs the
+    // real default path.
+    delete process.env.OPENCODEX_APP_SERVER_CATALOG_STATE_OVERRIDE;
+
+    let ticks = 0;
+    const timer = setInterval(() => { ticks += 1; }, 10);
+    try {
+      await multiAgentGuidanceText(parsed, { injectionModel: "anthropic/claude-sonnet-5" });
+    } finally {
+      clearInterval(timer);
+      Object.defineProperty(process, "platform", realPlatform);
+      setTrustedWindowsElevationExecutablesForTests(null);
+      rmSync(fakeDir, { recursive: true, force: true });
+      resetCodexAppServerCatalogStateCache();
+      process.env.OPENCODEX_APP_SERVER_CATALOG_STATE_OVERRIDE = "fresh";
+    }
+
+    // Measured on this repo against the stalling fake: the async request collector admits
+    // ~23 ticks, the synchronous collector admits 0 — it parks the loop for the whole
+    // enumeration. Any positive count proves the async wiring; the margin to 8 is
+    // generous enough that a loaded CI box cannot flake it.
+    expect(ticks).toBeGreaterThan(8);
   });
 
   test("v2 guidance suppresses positive model claims while the app-server catalog is stale or unknown (#857)", async () => {


### PR DESCRIPTION
## Summary

- move Windows PowerShell/CIM app-server enumeration off Bun's request event loop for v2 guidance;
- keep the existing synchronous fail-closed collector for explicit CLI/service lifecycle operations;
- share concurrent request probes by collection identity and cache the advisory result for five seconds;
- generation-guard invalidation so a pre-write CIM flight cannot repopulate post-write catalog state;
- document the request/lifecycle split and add event-loop, single-flight, TTL, and invalidation regressions.

Closes #1852

## Why this boundary

The stale-catalog observation is advisory on the v2 request path, but the same process evidence is also used by explicit lifecycle operations. Replacing the synchronous API globally would widen a process-control boundary. This PR therefore adds a Windows-only asynchronous request collector while preserving the existing matching, owner verification, trusted System32 PowerShell resolution, and synchronous lifecycle behavior.

## Verification

- `bun test tests/codex-app-server-processes.test.ts tests/multi-agent-compat.test.ts` — 88 pass, 1 platform skip, 0 fail.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `cd docs-site && bun install --frozen-lockfile && bun run build` — 385 pages built successfully.
- `git diff --check` — passed.
- Full suite attempted with CPU limits: 12,620 pass, 15 skip, 10 fail, 7 errors across 12,645 tests. The run took 944.69 seconds on a busy six-core host. The observed failures were outside this diff:
  - `lab-live-pinned-timeouts` and `bridge-lifecycle` timing cases passed when rerun alone on both this head and clean `origin/dev` (18/18 each);
  - `codex-shim` reproduced identically on this head and clean `origin/dev` because this host's installed service token overrides the fixture's `local-secret` (68 pass, 1 baseline failure);
  - the remaining errors were worktree GUI dependency-resolution failures from the initial root-only `node_modules` link, not files changed here.

## dev2-go

No Go counterpart exists for this change: Codex app-server process discovery and v2 guidance assembly remain in the TypeScript control plane on the Go transition line. This PR does not change the Go native data path.

## Review notes

This is self-authored maintainer work, so I will not approve or merge it myself. Exact-head cross-platform CI and another maintainer review are required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved Windows request handling by moving advisory process checks off the main event loop.
  * Added brief caching and shared in-progress checks to reduce repeated system queries.

* **Reliability**
  * Slow or failed Windows checks no longer block health checks or unrelated proxy traffic.
  * Prevented outdated process information from replacing newer results.
  * Preserved fail-closed behavior for CLI and service lifecycle operations.

* **Documentation**
  * Documented Windows process-discovery, caching, and advisory-check behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->