### PR TITLE
docs(codex): explain deferred tool search troubleshooting

### DIFF
--- a/docs-site/src/content/docs/guides/codex-integration.md
+++ b/docs-site/src/content/docs/guides/codex-integration.md
@@ -279,6 +279,45 @@ enabled, also pass `x-opencodex-api-key` from `OPENCODEX_API_AUTH_TOKEN`, matchi
 provider form above. To let OpenCodex inject routing directly, first switch Codex back to its
 built-in `openai` provider and remove any user-owned root `openai_base_url`, then rerun `ocx start`.
 
+### Deferred `tool_search` troubleshooting
+
+`tool_search` is a client-executed Codex discovery tool for loading deferred MCP/app tools. It is
+not an OpenCodex feature flag, and an upstream `tool_choice: "auto"` value does not create or enable
+it. OpenCodex can relay the tool only when Codex already included a declaration like this in the
+incoming Responses request:
+
+```json
+{
+  "tools": [
+    { "type": "tool_search", "description": "Load deferred tools" }
+  ]
+}
+```
+
+For routed chat/local models, OpenCodex exposes that declaration as a normal function named
+`tool_search`. If the model calls it, OpenCodex converts the call back to a Responses
+`tool_search_call`; Codex executes the search and supplies the resulting tool definitions in a
+later `tool_search_output`. Definitions loaded that way are then available on the next model turn.
+
+Check the failure boundary before changing provider settings:
+
+1. **No `type: "tool_search"` in the incoming request:** the active Codex client/session did not
+   advertise deferred discovery. OpenCodex cannot invent the tool. Update/restart Codex and verify
+   the client's MCP/app configuration and feature availability.
+2. **The incoming declaration exists, but no `tool_search` function reaches the routed request:**
+   capture only the redacted tool-type/name list and open an OpenCodex bug. Never attach the bearer,
+   account id, conversation input, full headers, or complete request body.
+3. **The routed request contains `tool_search`, but the local model never calls it:** the relay is
+   working. Use a model/template with reliable function calling and instructions that explicitly
+   tell it to search for a needed deferred tool. LM Studio's `tool_choice: "auto"` permits tool use;
+   it does not force the model to call this function.
+4. **A call is emitted repeatedly or loaded tools never become usable:** capture the redacted
+   `tool_search_call` / `tool_search_output` item types and call ids. OpenCodex preserves both in
+   history so the model should see the completed search instead of issuing it forever.
+
+See [The parser and bridge](/reference/architecture/#the-parser) for the wire mapping. There is no
+provider-level setting that can compensate for a missing client declaration.
+
 ### Catalog troubleshooting
 
 If a model is missing from Codex, or the catalog order/visibility looks wrong, check in order:

--- a/docs-site/src/content/docs/guides/codex-integration.md
+++ b/docs-site/src/content/docs/guides/codex-integration.md
@@ -279,12 +279,16 @@ enabled, also pass `x-opencodex-api-key` from `OPENCODEX_API_AUTH_TOKEN`, matchi
 provider form above. To let OpenCodex inject routing directly, first switch Codex back to its
 built-in `openai` provider and remove any user-owned root `openai_base_url`, then rerun `ocx start`.
 
-### Deferred `tool_search` troubleshooting
+### Explicit `tool_search` troubleshooting
 
-`tool_search` is a client-executed Codex discovery tool for loading deferred MCP/app tools. It is
-not an OpenCodex feature flag, and an upstream `tool_choice: "auto"` value does not create or enable
-it. OpenCodex can relay the tool only when Codex already included a declaration like this in the
-incoming Responses request:
+Routed local tooling has two distinct discovery paths. In normal routed code mode, Codex can expose
+deferred MCP/app tools through the official `exec` tool's `tools` global and `ALL_TOOLS`; that path
+does not require the model to see or call `tool_search`.
+
+Separately, `tool_search` is a client-executed Codex discovery surface. It is not an OpenCodex
+feature flag, and an upstream `tool_choice: "auto"` value does not create or enable it. OpenCodex can
+relay the explicit surface only when Codex already included a declaration like this in the incoming
+Responses request:
 
 ```json
 {
@@ -302,21 +306,23 @@ later `tool_search_output`. Definitions loaded that way are then available on th
 Check the failure boundary before changing provider settings:
 
 1. **No `type: "tool_search"` in the incoming request:** the active Codex client/session did not
-   advertise deferred discovery. OpenCodex cannot invent the tool. Update/restart Codex and verify
-   the client's MCP/app configuration and feature availability.
+   advertise the explicit `tool_search` surface. OpenCodex cannot invent that declaration. This
+   does not mean normal code-mode tools are unavailable: check whether the routed model can use
+   `exec` and discover the needed nested tool through `tools` / `ALL_TOOLS` first.
 2. **The incoming declaration exists, but no `tool_search` function reaches the routed request:**
    capture only the redacted tool-type/name list and open an OpenCodex bug. Never attach the bearer,
    account id, conversation input, full headers, or complete request body.
 3. **The routed request contains `tool_search`, but the local model never calls it:** the relay is
    working. Use a model/template with reliable function calling and instructions that explicitly
-   tell it to search for a needed deferred tool. LM Studio's `tool_choice: "auto"` permits tool use;
+   tell it to search for a deferred tool it needs. LM Studio's `tool_choice: "auto"` permits tool use;
    it does not force the model to call this function.
 4. **A call is emitted repeatedly or loaded tools never become usable:** capture the redacted
    `tool_search_call` / `tool_search_output` item types and call ids. OpenCodex preserves both in
    history so the model should see the completed search instead of issuing it forever.
 
-See [The parser and bridge](/reference/architecture/#the-parser) for the wire mapping. There is no
-provider-level setting that can compensate for a missing client declaration.
+See [The parser and bridge](/reference/architecture/#the-parser) for the explicit wire mapping.
+There is no provider-level setting that can add a missing `tool_search` declaration; ordinary
+code-mode discovery remains a separate path.
 
 ### Catalog troubleshooting
 


### PR DESCRIPTION
## Summary

- explain that `tool_search` must be declared by the Codex client and is not enabled by `tool_choice: "auto"`
- document the Responses declaration, routed function mapping, `tool_search_call`, and later `tool_search_output` continuation
- provide a privacy-safe checklist that distinguishes missing client advertisement, relay loss, and local-model tool-use behavior

Closes #1872.

## Verification

- `cd docs-site && bun install --frozen-lockfile`
- `cd docs-site && nice -n 10 bun run build`
- `git diff --check`

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for Codex integrations using `tool_search`.
  * Clarified the difference between standard routed tool discovery and client-declared searches.
  * Documented required declarations, request and response mapping, and diagnostic steps for missing or unused searches.
  * Added guidance on redacting sensitive information and preserving search history during troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->