### PR TITLE
fix(cline-pass): stop DeepSeek V4 tool replay loops

### DIFF
--- a/src/adapters/cline-pass-deepseek-v4-tool-replay.ts
+++ b/src/adapters/cline-pass-deepseek-v4-tool-replay.ts
@@ -1,0 +1,69 @@
+import type { ProviderAdapter } from "./base";
+
+const CLINE_PASS_DEEPSEEK_V4_MODELS = new Set([
+  "cline-pass/deepseek-v4-flash",
+  "cline-pass/deepseek-v4-pro",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function isClinePassDeepSeekV4Model(modelId: string): boolean {
+  return CLINE_PASS_DEEPSEEK_V4_MODELS.has(modelId);
+}
+
+/**
+ * DeepSeek V4 can copy historical pre-tool narration back into the next turn and
+ * eventually degenerate into text-only "I'll call the tool" loops. For the two
+ * affected ClinePass models, replay historical assistant tool turns as the
+ * structured call only. Normal assistant messages, tool results, and separate
+ * reasoning metadata remain untouched.
+ */
+export function stripClinePassDeepSeekV4ToolReplayNarration(
+  body: string,
+  modelId: string,
+): string {
+  if (!isClinePassDeepSeekV4Model(modelId)) return body;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return body;
+  }
+  if (!isRecord(parsed) || !Array.isArray(parsed.messages)) return body;
+
+  let changed = false;
+  const messages = parsed.messages.map(message => {
+    if (!isRecord(message) || message.role !== "assistant") return message;
+    const toolCalls = message.tool_calls;
+    if (!Array.isArray(toolCalls) || toolCalls.length === 0) return message;
+    if (message.content === "") return message;
+
+    changed = true;
+    return { ...message, content: "" };
+  });
+
+  return changed ? JSON.stringify({ ...parsed, messages }) : body;
+}
+
+/**
+ * Apply the ClinePass DeepSeek V4 replay compatibility policy after the ordinary
+ * OpenAI-chat request has been serialized. The adapter's response parsing and all
+ * non-target request behavior stay identical.
+ */
+export function withClinePassDeepSeekV4ToolReplayCompatibility(
+  adapter: ProviderAdapter,
+): ProviderAdapter {
+  return {
+    ...adapter,
+    async buildRequest(parsed, incoming) {
+      const request = await adapter.buildRequest(parsed, incoming);
+      if (!isClinePassDeepSeekV4Model(parsed.modelId)) return request;
+
+      const body = stripClinePassDeepSeekV4ToolReplayNarration(request.body, parsed.modelId);
+      return body === request.body ? request : { ...request, body };
+    },
+  };
+}

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -1,6 +1,7 @@
 import { createAnthropicAdapter } from "./anthropic";
 import { createAzureAdapter } from "./azure";
 import type { ProviderAdapter } from "./base";
+import { withClinePassDeepSeekV4ToolReplayCompatibility } from "./cline-pass-deepseek-v4-tool-replay";
 import { createCommandCodeAdapter } from "./command-code";
 import { createCursorAdapter } from "./cursor";
 import { createGoogleAdapter } from "./google";
@@ -57,7 +58,8 @@ export const ADAPTER_REGISTRY = {
   "openai-chat": {
     wire: "openai-chat",
     mutation: "codex-owned",
-    create: (provider: OcxProviderConfig, _context: AdapterFactoryContext) => createOpenAIChatAdapter(provider),
+    create: (provider: OcxProviderConfig, _context: AdapterFactoryContext) =>
+      withClinePassDeepSeekV4ToolReplayCompatibility(createOpenAIChatAdapter(provider)),
   },
   anthropic: {
     wire: "anthropic",

--- a/tests/cline-pass-deepseek-v4-tool-replay.test.ts
+++ b/tests/cline-pass-deepseek-v4-tool-replay.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+import { createRegisteredAdapter } from "../src/adapters/registry";
+import {
+  stripClinePassDeepSeekV4ToolReplayNarration,
+} from "../src/adapters/cline-pass-deepseek-v4-tool-replay";
+import type { OcxParsedRequest, OcxProviderConfig } from "../src/types";
+import { createTestTranslatorBudget } from "./helpers/translator-budget";
+
+const TARGET_MODELS = [
+  "cline-pass/deepseek-v4-flash",
+  "cline-pass/deepseek-v4-pro",
+] as const;
+
+const provider = {
+  adapter: "openai-chat",
+  baseUrl: "https://api.cline.bot/api/v1",
+  authMode: "key",
+  apiKey: "test-key",
+} satisfies OcxProviderConfig;
+
+function parsedWithHybridToolTurn(modelId: string): OcxParsedRequest {
+  return {
+    modelId,
+    stream: true,
+    options: {},
+    context: {
+      tools: [{
+        name: "exec",
+        description: "Execute a command",
+        parameters: {
+          type: "object",
+          properties: { command: { type: "string" } },
+          required: ["command"],
+          additionalProperties: false,
+        },
+      }],
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "I should inspect the repository first." },
+            { type: "text", text: "Let me run that now." },
+            {
+              type: "toolCall",
+              id: "call_exec_1",
+              name: "exec",
+              arguments: { command: "git status --short" },
+            },
+          ],
+          timestamp: 1,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call_exec_1",
+          toolName: "exec",
+          content: "clean",
+          isError: false,
+          timestamp: 2,
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "The repository is clean." }],
+          timestamp: 3,
+        },
+        {
+          role: "user",
+          content: "Continue.",
+          timestamp: 4,
+        },
+      ],
+    },
+  };
+}
+
+async function outboundMessages(modelId: string): Promise<Array<Record<string, unknown>>> {
+  const adapter = createRegisteredAdapter(provider);
+  const request = await adapter.buildRequest(parsedWithHybridToolTurn(modelId), {
+    headers: new Headers(),
+    translatorBudget: createTestTranslatorBudget(),
+  });
+  const body = JSON.parse(request.body) as { messages?: Array<Record<string, unknown>> };
+  return body.messages ?? [];
+}
+
+describe("ClinePass DeepSeek V4 tool-call history replay", () => {
+  test.each(TARGET_MODELS)("strips historical assistant narration for %s while preserving the tool call", async modelId => {
+    const messages = await outboundMessages(modelId);
+    const toolTurn = messages.find(message => Array.isArray(message.tool_calls));
+
+    expect(toolTurn).toBeDefined();
+    expect(toolTurn?.content).toBe("");
+    expect(toolTurn?.tool_calls).toEqual([{
+      id: "call_exec_1",
+      type: "function",
+      function: {
+        name: "exec",
+        arguments: JSON.stringify({ command: "git status --short" }),
+      },
+    }]);
+
+    const toolResult = messages.find(message => message.role === "tool");
+    expect(toolResult?.tool_call_id).toBe("call_exec_1");
+    expect(toolResult?.content).toBe("clean");
+
+    const finalAssistant = messages.find(message => message.role === "assistant" && message.content === "The repository is clean.");
+    expect(finalAssistant).toBeDefined();
+  });
+
+  test("leaves hybrid assistant content unchanged for non-target models", async () => {
+    const messages = await outboundMessages("cline-pass/not-deepseek-v4");
+    const toolTurn = messages.find(message => Array.isArray(message.tool_calls));
+
+    expect(toolTurn?.content).toContain("I should inspect the repository first.");
+    expect(toolTurn?.content).toContain("Let me run that now.");
+  });
+
+  test("keeps reasoning metadata when stripping a target tool turn", () => {
+    const input = JSON.stringify({
+      messages: [{
+        role: "assistant",
+        content: "Let me call the tool.",
+        reasoning_content: "private reasoning",
+        tool_calls: [{
+          id: "call_1",
+          type: "function",
+          function: { name: "exec", arguments: "{}" },
+        }],
+      }],
+    });
+
+    const output = stripClinePassDeepSeekV4ToolReplayNarration(
+      input,
+      "cline-pass/deepseek-v4-flash",
+    );
+    const body = JSON.parse(output) as { messages: Array<Record<string, unknown>> };
+
+    expect(body.messages[0]?.content).toBe("");
+    expect(body.messages[0]?.reasoning_content).toBe("private reasoning");
+    expect(body.messages[0]?.tool_calls).toEqual([{
+      id: "call_1",
+      type: "function",
+      function: { name: "exec", arguments: "{}" },
+    }]);
+  });
+});

--- a/tests/cline-pass-deepseek-v4-tool-replay.test.ts
+++ b/tests/cline-pass-deepseek-v4-tool-replay.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
 import { createRegisteredAdapter } from "../src/adapters/registry";
 import {
   stripClinePassDeepSeekV4ToolReplayNarration,
@@ -72,12 +73,16 @@ function parsedWithHybridToolTurn(modelId: string): OcxParsedRequest {
   };
 }
 
-async function outboundMessages(modelId: string): Promise<Array<Record<string, unknown>>> {
-  const adapter = createRegisteredAdapter(provider);
-  const request = await adapter.buildRequest(parsedWithHybridToolTurn(modelId), {
+function incoming() {
+  return {
     headers: new Headers(),
     translatorBudget: createTestTranslatorBudget(),
-  });
+  };
+}
+
+async function outboundMessages(modelId: string): Promise<Array<Record<string, unknown>>> {
+  const adapter = createRegisteredAdapter(provider);
+  const request = await adapter.buildRequest(parsedWithHybridToolTurn(modelId), incoming());
   const body = JSON.parse(request.body) as { messages?: Array<Record<string, unknown>> };
   return body.messages ?? [];
 }
@@ -106,12 +111,12 @@ describe("ClinePass DeepSeek V4 tool-call history replay", () => {
     expect(finalAssistant).toBeDefined();
   });
 
-  test("leaves hybrid assistant content unchanged for non-target models", async () => {
-    const messages = await outboundMessages("cline-pass/not-deepseek-v4");
-    const toolTurn = messages.find(message => Array.isArray(message.tool_calls));
+  test("leaves non-target OpenAI-chat requests byte-identical", async () => {
+    const parsed = parsedWithHybridToolTurn("cline-pass/not-deepseek-v4");
+    const plainRequest = await createOpenAIChatAdapter(provider).buildRequest(parsed, incoming());
+    const wrappedRequest = await createRegisteredAdapter(provider).buildRequest(parsed, incoming());
 
-    expect(toolTurn?.content).toContain("I should inspect the repository first.");
-    expect(toolTurn?.content).toContain("Let me run that now.");
+    expect(wrappedRequest.body).toBe(plainRequest.body);
   });
 
   test("keeps reasoning metadata when stripping a target tool turn", () => {


### PR DESCRIPTION
## Summary

Fixes a reproducible ClinePass DeepSeek V4 failure mode where long tool-using sessions can degrade into repeated textual tool intent (for example, repeatedly saying it will run/call a tool) without emitting the corresponding structured tool call.

The fix is intentionally narrow: for `cline-pass/deepseek-v4-flash` and `cline-pass/deepseek-v4-pro`, historical OpenAI-chat assistant messages that already contain `tool_calls` are replayed with empty `content`. The structured tool call, its arguments/id, tool result, and any separate `reasoning_content` remain intact. Normal assistant/final-answer messages are unchanged, and non-target models are unchanged.

## Investigation / tracing

This came from a live investigation against `api.cline.bot` using a long-running Codex/OpenCodex session that reliably reproduced the issue.

What the tracing established:

- The repeated narration was genuine upstream DeepSeek output. The OpenAI-chat adapter received text deltas before any structured tool-call boundary; OpenCodex was not converting an initial structured call into prose.
- Tool-call/result history itself stayed structurally sound throughout the failing sessions: call and result counts matched, with zero unmatched calls, orphan results, or duplicate call/result IDs.
- A separate web-search-sidecar buffering behavior made some bad turns appear as delayed output bursts. Enabling live routed-model output made the deltas visible immediately, but did **not** remove the DeepSeek loop. That streaming behavior is intentionally not changed by this PR.
- Canonical OpenCodex history contained assistant thinking blocks that ClinePass Chat Completions did not replay as `reasoning_content`. A controlled reasoning-replay A/B restored the real thinking blocks exactly; the loop still reproduced. Reasoning replay is therefore not part of this fix.
- The decisive A/B removed historical assistant prose only from messages that also carried a structured tool call. The same already-poisoned long session immediately returned to normal structured tool calling.

### Flash validation

On the same 400+ message session that had already exhibited the loop, tool-call history changed from large assistant prose + `exec` to effectively empty assistant content + the same `exec` call. Subsequent turns repeatedly emitted structured `exec` calls instead of the previous hundreds/thousands of repetitive text deltas.

A long `finishReason: "stop"` turn remained possible when the model was actually giving a coherent final answer; subsequent turns returned to structured tools normally. This distinguishes normal long answers from the pathological tool-intent loop.

### Pro validation

The same policy was then exercised with `cline-pass/deepseek-v4-pro` in an even larger accumulated session:

- roughly 678 -> 708 messages during the captured run
- 318+ -> 333+ historical tool calls/results
- zero unmatched/orphan/duplicate tool-call IDs
- repeated structured `exec` calls after the policy was applied
- most tool turns emitted only an empty/tiny text delta before the structured call; a few emitted small amounts of prose (for example 8 deltas / 130 bytes or 10 deltas / 164 bytes) and then crossed into the proper tool boundary
- no recurrence of the old hundreds/thousands-of-deltas textual tool-intent loop in the validation run

Some Pro turns had high time-to-first-token latency, but once output began they crossed into the structured call normally. That latency is separate from this failure mode.

## Implementation

- Add a narrowly scoped ClinePass DeepSeek V4 OpenAI-chat replay compatibility wrapper.
- Target only:
  - `cline-pass/deepseek-v4-flash`
  - `cline-pass/deepseek-v4-pro`
- On historical assistant messages with non-empty `tool_calls`, replace only `content` with `""`.
- Preserve all other message fields, including `reasoning_content` when present.
- Leave ordinary assistant messages, tool results, and all non-target models unchanged.

## Regression coverage

The added tests verify that:

- Flash strips historical assistant narration on a tool-call turn while preserving the exact structured call and result.
- Pro does the same.
- A non-target ClinePass model keeps its hybrid assistant content unchanged.
- Normal assistant/final-answer text remains present for the target models.
- Separate `reasoning_content` survives the strip unchanged.

## Non-goals

This PR deliberately does **not** include the temporary provider tracing used during diagnosis, the reasoning-replay experiment, or any change to web-search sidecar buffering / `streamRoutedModelOutput` behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for supported DeepSeek V4 models when replaying conversations with tool calls.
  * Assistant narration is now removed where necessary while preserving tool calls, tool results, reasoning data, and later responses.
  * Requests for unsupported models or already-compatible content remain unchanged.
* **Tests**
  * Added coverage for tool-call replay, preserved conversation data, and unchanged behavior for other models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->