### PR TITLE
fix(antigravity): drop synthetic x-goog-api-client header on onboarding

### DIFF
--- a/src/adapters/client-fingerprint.ts
+++ b/src/adapters/client-fingerprint.ts
@@ -45,8 +45,6 @@ export function claudeCodeSessionId(token: string | undefined): string {
 export const ANTIGRAVITY_IDE_VERSION = "2.5.5";
 const ANTIGRAVITY_IDE_CLIENT_NAME = "aidev_client";
 const ANTIGRAVITY_IDE_PLATFORM = "windows/amd64";
-/** Secondary Google API client UA the Antigravity client library reports. */
-export const ANTIGRAVITY_GOOG_API_CLIENT_UA = "google-api-nodejs-client/10.3.0";
 
 /**
  * The real Antigravity IDE User-Agent, e.g.

--- a/src/oauth/google-antigravity.ts
+++ b/src/oauth/google-antigravity.ts
@@ -12,7 +12,7 @@
 import { OAuthCallbackFlow, type OAuthCallbackFlowOptions } from "./callback-server";
 import { generatePKCE } from "./pkce";
 import type { OAuthController, OAuthCredentials } from "./types";
-import { antigravityUserAgent, ANTIGRAVITY_GOOG_API_CLIENT_UA } from "../adapters/client-fingerprint";
+import { ANTIGRAVITY_IDE_VERSION, antigravityUserAgent } from "../adapters/client-fingerprint";
 
 const CLIENT_ID = process.env.GOOGLE_ANTIGRAVITY_CLIENT_ID
   || "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com";
@@ -110,8 +110,8 @@ async function onboardProject(accessToken: string, signal?: AbortSignal): Promis
     if (signal?.aborted) throw signal.reason ?? new Error("Antigravity onboarding aborted");
     const response = await fetch(`${DAILY_API}/${API_VERSION}:onboardUser`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${accessToken}`, Accept: "*/*", "Content-Type": "application/json", "User-Agent": antigravityUserAgent(), "x-goog-api-client": ANTIGRAVITY_GOOG_API_CLIENT_UA },
-      body: JSON.stringify({ tier_id: "free-tier", metadata: { ide_type: "ANTIGRAVITY", ide_name: "antigravity", ide_version: antigravityUserAgent() } }),
+      headers: { Authorization: `Bearer ${accessToken}`, Accept: "*/*", "Content-Type": "application/json", "User-Agent": antigravityUserAgent() },
+      body: JSON.stringify({ tier_id: "free-tier", metadata: { ide_type: "ANTIGRAVITY", ide_name: "antigravity", ide_version: ANTIGRAVITY_IDE_VERSION } }),
       signal: requestSignal(signal),
     });
     if (!response.ok) {

--- a/tests/client-fingerprint.test.ts
+++ b/tests/client-fingerprint.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
   ANTIGRAVITY_IDE_VERSION,
-  ANTIGRAVITY_GOOG_API_CLIENT_UA,
   CLAUDE_CODE_HEADERS,
   antigravityUserAgent,
   claudeCodeSessionId,
@@ -40,10 +39,6 @@ describe("client fingerprint — helpers", () => {
       if (prev === undefined) delete process.env.GOOGLE_ANTIGRAVITY_USER_AGENT;
       else process.env.GOOGLE_ANTIGRAVITY_USER_AGENT = prev;
     }
-  });
-
-  test("secondary google api client UA is pinned", async () => {
-    expect(ANTIGRAVITY_GOOG_API_CLIENT_UA).toMatch(/^google-api-nodejs-client\/[\d.]+$/);
   });
 
   test("claude session id is a stable v4-shaped uuid per token", async () => {

--- a/tests/google-antigravity-oauth.test.ts
+++ b/tests/google-antigravity-oauth.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { ANTIGRAVITY_IDE_VERSION } from "../src/adapters/client-fingerprint";
 import { discoverAntigravityProject, refreshAntigravityToken } from "../src/oauth/google-antigravity";
 import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -37,7 +38,14 @@ describe("antigravity project discovery", () => {
 
   test("falls back to onboardUser poll loop (not-done then done)", async () => {
     let onboardCalls = 0;
-    routeFetch((url) => {
+    routeFetch((url, init) => {
+      if (url.includes(":onboardUser")) {
+        const headers = (init?.headers ?? {}) as Record<string, string>;
+        expect(headers["x-goog-api-client"]).toBeUndefined();
+        expect(headers["User-Agent"]).toMatch(/^antigravity\/ide\//);
+        const body = JSON.parse(String(init?.body ?? "{}"));
+        expect(body.metadata?.ide_version).toBe(ANTIGRAVITY_IDE_VERSION);
+      }
       if (url.includes(":loadCodeAssist")) return new Response(JSON.stringify({}), { status: 200 }); // no project
       if (url.includes(":onboardUser")) {
         onboardCalls++;


### PR DESCRIPTION
## Summary

Remove synthetic `x-goog-api-client` header from Antigravity `onboardUser` requests and pass `ANTIGRAVITY_IDE_VERSION` for `metadata.ide_version`.

## Context & Evidence

Following discussion in #1836:
- Decompilation of Antigravity IDE 2.5.5 (`language_server_macos_arm` 126MB Go1.26.5) confirms that `x-goog-api-client` is never sent on the wire.
  - 0 ADRP hits across all `SetHTTPHeaders` variants (`IDE`, `CLI`, `Hub`, `Standalone`, `Stubby`).
  - The single raw string occurrence at `0x24ea019` is part of a `generationConfig.x-goog-api-client` descriptor, not a header.
- `metadata.ide_version` in `onboardUser` is aligned to `ANTIGRAVITY_IDE_VERSION` (`2.5.5`), separating it from the `User-Agent` header.
- Removed obsolete `ANTIGRAVITY_GOOG_API_CLIENT_UA` export and associated test.

## Verification

- `bun test tests/client-fingerprint.test.ts tests/google-antigravity-oauth.test.ts tests/google-antigravity-wire.test.ts` (**73 passed, 0 failed**)
- `bun run typecheck` (passed with **0 errors**)

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->