### PR TITLE
chore: ignore leftover test temp files, not only directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,12 @@ devlog/**/security-advisory-draft*
 .worktrees/
 
 # Test-generated artifacts
-tests/.tmp-*/
+# Trailing slash matched directories only, but the same tests also leave plain
+# files behind when a run dies mid-write -- and on Windows those can stay locked
+# by an exiting child, so they cannot simply be deleted. An unignorable leftover
+# blocks the release preflight's clean-tree check for work that has nothing to do
+# with it, so ignore both shapes.
+tests/.tmp-*
 .claude/
 
 # Retired Go native-runtime experiment. `go/` is not part of the build, the


### PR DESCRIPTION
## Summary

`tests/.tmp-*/` matched directories only. The same tests also leave plain files behind when a run dies mid-write, and on Windows an exiting child can still hold one open, so it cannot be deleted either. The result is an unignorable leftover that fails the release preflight's clean-tree check for work that has nothing to do with it.

Match both shapes: `tests/.tmp-*`.

## Verification

- `git status --porcelain` is clean with the two stranded `tests/.tmp-codex-config-generation-*` files present.
- No test or build path reads `.gitignore`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cleanup handling for temporary files created by interrupted tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->