### PR TITLE
[WRONG BRANCH] release: v2.24.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitkyc08/opencodex",
-  "version": "2.24.1",
+  "version": "2.24.2",
   "description": "Universal provider proxy for OpenAI Codex & Claude Code — use any LLM with Codex CLI/App/SDK and Claude Code",
   "type": "module",
   "main": "./bin/package-main.mjs",


### PR DESCRIPTION
## Summary

Release v2.24.2 — the Windows suite work from #1881, promoted through `dev` (#1908, #1910).

Notable production fixes in this release:

- `user-identity.ts` resolves LocalAppData via `SHGetKnownFolderPath` instead of the .NET wrapper that follows `USERPROFILE` and returns an empty string, which had been refusing every Codex coordinator lookup on affected Windows setups.
- `injected-marker.ts` decodes TOML string escapes, so a Windows path recorded in the journal round-trips and restore can recognize its own catalog (#1798).
- `lab/projection/rebuild.ts` finalizes prepared statements before closing, so a Compatibility Lab rebuild can replace its own file on Windows.
- Identity lookups are memoized per process: ~510ms to ~1ms per coordinator path resolution.

## Verification

- Full Bun suite on Windows: 806/806 files, 0 failures (run in batches; `bun test --isolate ./tests/` panics near the end of an 806-file run after every test has passed — a Bun memory limit, not a suite failure).
- `bun x tsc --noEmit` and `bun run privacy:scan` green.
- CI fully green on #1881 before promotion.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 2.24.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->