### PR TITLE
fix(cursor): reuse Connect conversations from session_id

### DIFF
--- a/src/server/request-log-conversation.ts
+++ b/src/server/request-log-conversation.ts
@@ -61,6 +61,13 @@ export function sessionIdHeaderFromRequest(headers: Headers): string | null {
   return headers.get("session_id") ?? headers.get("session-id");
 }
 
+/** Cursor conversation reuse: Codex parent thread, then Responses session headers. */
+export function clientThreadIdFromResponsesHeaders(headers: Headers): string | undefined {
+  return headers.get("x-codex-parent-thread-id")?.trim()
+    || sessionIdHeaderFromRequest(headers)?.trim()
+    || undefined;
+}
+
 export function conversationIdFromResponsesRequest(input: {
   clientThreadId?: string;
   sessionIdHeader?: string | null;

--- a/src/server/request-log-conversation.ts
+++ b/src/server/request-log-conversation.ts
@@ -58,14 +58,21 @@ export function matchesLogConversationId(
  * parent thread header > session_id / session-id > thread-id > cursor conversation id.
  */
 export function sessionIdHeaderFromRequest(headers: Headers): string | null {
-  return headers.get("session_id") ?? headers.get("session-id");
+  return firstNonEmptyHeader(headers, "session_id", "session-id");
 }
 
 /** Cursor conversation reuse: Codex parent thread, then Responses session headers. */
 export function clientThreadIdFromResponsesHeaders(headers: Headers): string | undefined {
-  return headers.get("x-codex-parent-thread-id")?.trim()
-    || sessionIdHeaderFromRequest(headers)?.trim()
+  return firstNonEmptyHeader(headers, "x-codex-parent-thread-id", "session_id", "session-id")
     || undefined;
+}
+
+function firstNonEmptyHeader(headers: Headers, ...names: string[]): string | null {
+  for (const name of names) {
+    const value = headers.get(name)?.trim();
+    if (value) return value;
+  }
+  return null;
 }
 
 export function conversationIdFromResponsesRequest(input: {

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -1247,6 +1247,7 @@ export async function handleComboResponses(
   config: OcxConfig,
   logCtx: RequestLogContext,
   options: HandleResponsesOptions,
+  inboundClientThreadId = clientThreadIdFromResponsesHeaders(req.headers),
 ): Promise<Response> {
   const requestedModel = typeof (rawBody as { model?: unknown } | null)?.model === "string"
     ? (rawBody as { model: string }).model
@@ -1264,7 +1265,7 @@ export async function handleComboResponses(
   // Expand previous_response_id before image policy and child dispatch so a
   // continuation that only references prior images still fails closed when
   // imageInput is disabled (and so targets see the full replayed input).
-  const body = expandPreviousResponseInput(rawBody);
+  const body = expandPreviousResponseInput(rawBody, inboundClientThreadId);
   if (previousResponseReplayFailure(body)) {
     return formatErrorResponse(
       400,
@@ -1642,6 +1643,7 @@ async function handleResponsesInner(
     }
     return decodeRequestErrorResponse(err, "responses");
   }
+  const inboundClientThreadId = clientThreadIdFromResponsesHeaders(req.headers);
   const comboId = !options.comboAttempt ? comboIdFromRawBody(body, config) : null;
   if (comboId && Object.hasOwn(config.combos ?? {}, comboId)) {
     options.onRequestBodyRead?.();
@@ -1650,12 +1652,11 @@ async function handleResponsesInner(
       // The original request body was accepted above. Combo children are synthetic
       // replays and must not repeat the caller-owned timeout transition.
       onRequestBodyRead: undefined,
-    });
+    }, inboundClientThreadId);
   }
   let unreadableEncryptedAgentTask = hasUnreadableEncryptedAgentTask(
     (body as { input?: unknown } | undefined)?.input,
   );
-  const inboundClientThreadId = clientThreadIdFromResponsesHeaders(req.headers);
   const originalBody = body;
   body = expandPreviousResponseInput(body, inboundClientThreadId);
   if (previousResponseScopeMismatch(body)) {

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -173,6 +173,7 @@ import {
   type RequestLogContext,
 } from "../request-log";
 import {
+  clientThreadIdFromResponsesHeaders,
   conversationIdFromResponsesRequest,
   normalizeLogConversationId,
   sessionIdHeaderFromRequest,
@@ -1654,7 +1655,7 @@ async function handleResponsesInner(
   let unreadableEncryptedAgentTask = hasUnreadableEncryptedAgentTask(
     (body as { input?: unknown } | undefined)?.input,
   );
-  const inboundClientThreadId = req.headers.get("x-codex-parent-thread-id")?.trim() || undefined;
+  const inboundClientThreadId = clientThreadIdFromResponsesHeaders(req.headers);
   const originalBody = body;
   body = expandPreviousResponseInput(body, inboundClientThreadId);
   if (previousResponseScopeMismatch(body)) {

--- a/tests/request-log-conversation.test.ts
+++ b/tests/request-log-conversation.test.ts
@@ -69,8 +69,13 @@ describe("sessionIdHeaderFromRequest", () => {
       session_id: "underscore",
       "session-id": "hyphen",
     }))).toBe("underscore");
+    expect(sessionIdHeaderFromRequest(new Headers({
+      session_id: "   ",
+      "session-id": "hyphen",
+    }))).toBe("hyphen");
   });
 });
+
 describe("clientThreadIdFromResponsesHeaders", () => {
   test("prefers Codex parent thread over session_id", () => {
     expect(clientThreadIdFromResponsesHeaders(new Headers({
@@ -83,6 +88,13 @@ describe("clientThreadIdFromResponsesHeaders", () => {
     expect(clientThreadIdFromResponsesHeaders(new Headers({
       session_id: "gjc-session",
     }))).toBe("gjc-session");
+  });
+
+  test("falls back to session-id when session_id is blank", () => {
+    expect(clientThreadIdFromResponsesHeaders(new Headers({
+      session_id: "   ",
+      "session-id": "hyphen-session",
+    }))).toBe("hyphen-session");
   });
 });
 

--- a/tests/request-log-conversation.test.ts
+++ b/tests/request-log-conversation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import {
+  clientThreadIdFromResponsesHeaders,
   conversationIdFromClaudeCacheKey,
   conversationIdFromClaudeMetadata,
   conversationIdFromResponsesRequest,
@@ -68,6 +69,20 @@ describe("sessionIdHeaderFromRequest", () => {
       session_id: "underscore",
       "session-id": "hyphen",
     }))).toBe("underscore");
+  });
+});
+describe("clientThreadIdFromResponsesHeaders", () => {
+  test("prefers Codex parent thread over session_id", () => {
+    expect(clientThreadIdFromResponsesHeaders(new Headers({
+      "x-codex-parent-thread-id": "parent",
+      session_id: "session",
+    }))).toBe("parent");
+  });
+
+  test("falls back to session_id so store:false clients reuse Cursor conversations", () => {
+    expect(clientThreadIdFromResponsesHeaders(new Headers({
+      session_id: "gjc-session",
+    }))).toBe("gjc-session");
   });
 });
 


### PR DESCRIPTION
## Summary

- Cursor Connect conversation reuse currently keys only on `x-codex-parent-thread-id`.
- `store:false` Responses clients such as GJC never send that header or `previous_response_id`, so every turn minted a new `cursor_*` conversation.
- Cursor Connect then burst-rejected `claude-fable-5` (`resource_exhausted` / `rate_limit_exceeded`) even though monthly quota was almost unused.
- Fall back to `session_id` / `session-id` for the same `_clientThreadId` so one client session stays on one Cursor conversation. Codex parent-thread still wins when present.
- Blank `session_id` no longer masks a real `session-id`. Combo continuations expand `previous_response_id` with the same inbound thread key.
- `prompt_cache_key` is still not used as a conversation key. The Responses path does not synthesize `session_id` from `prompt_cache_key`; that happens only on the Claude-messages native route.

## Verification

- `bun test tests/request-log-conversation.test.ts tests/combos.test.ts tests/responses-state.test.ts` — 151 pass, 0 fail.
- Live check against a patched OCX: three continued GJC turns on `cursor/claude-fable-5` reused one conversation id (`530f3b0f…`) with HTTP 200 and no 429.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation and session identification from request headers.
  * Prioritizes the Codex parent-thread identifier and reliably falls back to available session identifiers.
  * Ignores blank or whitespace-only header values to prevent incorrect conversation associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->