### PR TITLE
Merge main into dev: v2.24.2 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitkyc08/opencodex",
-  "version": "2.24.1",
+  "version": "2.24.2",
   "description": "Universal provider proxy for OpenAI Codex & Claude Code — use any LLM with Codex CLI/App/SDK and Claude Code",
   "type": "module",
   "main": "./bin/package-main.mjs",


### PR DESCRIPTION
## Summary

Brings the v2.24.2 release commit back to the integration branches, so the version line on `dev`/`preview` matches what is published.

Only `package.json` differs (2.24.1 to 2.24.2). Without this the next branch cut from `dev` reopens the same version delta on every promotion.

## Verification

- Diff is `package.json` alone, one line.
- npm `latest` is `@bitkyc08/opencodex@2.24.2`, published from `474584bcd` on `main`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application to version 2.24.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->