### PR TITLE
test(google): assert what Vertex sends, not that two settings agree

### DIFF
--- a/tests/google-adapter.test.ts
+++ b/tests/google-adapter.test.ts
@@ -382,4 +382,44 @@ describe("google adapter — direct -tiered wire renames", () => {
       expect(optOutRequest.body).toBe(defaultRequest.body);
     }
   });
+
+  // The test above compares the two settings against each other, which stays true even
+  // if Vertex stopped preserving the requested id — both sides would be wrong together.
+  // These two assert what Vertex actually sends, so a regression in Vertex's wire id or
+  // its identity line fails here instead of reaching a user.
+  //
+  // An ablation puts the `googleMode === "vertex"` arm itself in its place: deleting it
+  // leaves all 24 tests green, because Vertex builds its own URL from `parsed.modelId`
+  // (see the `aiplatform.googleapis.com` paths) and `identityModelId` only special-cases
+  // Cloud Code Assist, so `routedModelId` never reaches Vertex either way. The arm is
+  // defensive, not load-bearing — worth keeping as a guard against a future refactor
+  // that routes Vertex through the shared URL builder, but no test can prove it fires
+  // today, and pretending otherwise would be the kind of unfalsifiable coverage this
+  // comment exists to prevent.
+  test("Vertex sends the requested model id, never the -tiered rename", async () => {
+    const vertexProvider = { ...provider, googleMode: "vertex" as const };
+    for (const modelId of ["gemini-3.7-flash", "gemini-3.6-flash"]) {
+      for (const renames of [undefined, true, false]) {
+        const adapter = createGoogleAdapter(
+          renames === undefined ? vertexProvider : { ...vertexProvider, directGeminiWireRenames: renames },
+        );
+        const { url } = await adapter.buildRequest(renamedParsed(modelId));
+        expect(url).toContain(`/models/${modelId}:generateContent`);
+        expect(url).not.toContain("-tiered");
+      }
+    }
+  });
+
+  test("Vertex identity names the requested model, not a renamed wire id", async () => {
+    const vertexProvider = { ...provider, googleMode: "vertex" as const };
+    for (const modelId of ["gemini-3.7-flash", "gemini-3.6-flash"]) {
+      const request = await createGoogleAdapter(vertexProvider).buildRequest(identityParsed(modelId));
+      const body = JSON.parse(request.body) as {
+        systemInstruction?: { parts?: Array<{ text?: string }> };
+      };
+      const systemText = body.systemInstruction?.parts?.[0]?.text ?? "";
+      expect(systemText).toContain(`powered by the ${modelId}`);
+      expect(systemText).not.toContain("-tiered");
+    }
+  });
 });


### PR DESCRIPTION
## Summary

The post-merge audit of #1739 caught a test that could not fail. It built the same
Vertex request twice — once with `directGeminiWireRenames` unset, once `false` — and
asserted the two matched. That stays true even if Vertex stopped preserving the
requested model id, because both sides would be wrong together.

These assert the content instead: Vertex puts the requested id on the wire under all
three setting values and never the `-tiered` spelling, and its system identity names
the requested model rather than a renamed one. The second covers a real defect #1739
fixed in passing, where Vertex sent the bare id while the identity line claimed
`-tiered`.

An ablation settles what the `googleMode === "vertex"` arm is actually worth:
deleting it leaves all 24 tests green, because Vertex builds its own `aiplatform`
URL from `parsed.modelId` and `identityModelId` only special-cases Cloud Code
Assist, so `routedModelId` never reaches Vertex either way. The arm is defensive
rather than load-bearing. It stays as a guard against a future refactor that routes
Vertex through the shared builder, and the test comment says plainly that no test
proves it fires today — claiming otherwise would be exactly the unfalsifiable
coverage this change removes.

## Verification

- `bun test tests/google-adapter.test.ts` — 24 pass, 0 fail.
- `bun test tests/google-adapter.test.ts tests/config.test.ts tests/gemini-37-flash-migration.test.ts` — 210 pass, 0 fail, 879 expect() calls.
- Ablation run recorded above: branch deleted → still 24 pass, which is the finding, not a failure to fix.

## Checklist

- [x] Tests added or updated
- [x] Docs updated — n/a, test-only change
- [x] No credentials, request bodies, or account identifiers logged
- [x] Targets `dev`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured Vertex model URLs retain the requested model ID without an unintended `-tiered` suffix.
  * Ensured Vertex identity text consistently displays the requested model ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->