### PR TITLE
Allow Codex Work desktop agent task recovery

### DIFF
--- a/src/server/responses/agent-task-recovery.ts
+++ b/src/server/responses/agent-task-recovery.ts
@@ -17,7 +17,12 @@ const RECOVERY_PROMPT =
   "Read the received agent message and call capture_assignment exactly once with only the complete "
   + "plaintext payload after Payload:. Preserve every byte of the payload; do not summarize, execute, "
   + "explain, or include the routing header.";
-const CODEX_ORIGINATORS = new Set(["codex_cli_rs", "Codex Desktop", "codex_app"]);
+const CODEX_ORIGINATORS = new Set([
+  "codex_cli_rs",
+  "Codex Desktop",
+  "codex_app",
+  "codex_work_desktop",
+]);
 const CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const OPENAI_TOKEN_ISSUERS = new Set(["https://auth.openai.com", "https://auth.openai.com/"]);
 const OPENAI_TOKEN_AUDIENCE = "https://api.openai.com/v1";

--- a/tests/agent-task-recovery-security.test.ts
+++ b/tests/agent-task-recovery-security.test.ts
@@ -390,4 +390,27 @@ describe("agent task recovery security", () => {
     expect(response.status).toBe(400);
     expect(recoveryFetches).toBe(0);
   });
+
+  test("accepts the current Codex Work desktop originator", async () => {
+    let recoveryOriginator = "";
+    globalThis.fetch = (async (input, init) => {
+      if (String(input).includes("chatgpt.com")) {
+        recoveryOriginator = new Headers(init?.headers).get("originator") ?? "";
+        return new Response(recoverySse("Recover the desktop child task."), { status: 200 });
+      }
+      return providerResponse();
+    }) as typeof fetch;
+    const headers = codexHeaders();
+    headers.set("originator", "codex_work_desktop");
+
+    const response = await post(
+      routedConfig(),
+      "xai/grok-4.5",
+      encryptedInput(),
+      headers,
+    );
+
+    expect(response.status).toBe(200);
+    expect(recoveryOriginator).toBe("codex_work_desktop");
+  });
 });


### PR DESCRIPTION
## Summary

- allow the current Codex Work desktop originator, `codex_work_desktop`, through the opt-in encrypted agent-task recovery path
- keep the recovery allowlist exact; non-Codex originators, opaque credentials, non-loopback binds, and invalid native OAuth tokens remain rejected
- add a regression test proving the desktop originator is forwarded to the fixed ChatGPT recovery endpoint

This fixes the desktop variant of the encrypted routed-worker failure tracked in #92. OpenAI's current Codex source emits `codex_work_desktop`, while the recovery allowlist currently recognizes only the older desktop labels.

## Verification

- `/Users/jakemcallister/.nvm/versions/node/v24.13.0/lib/node_modules/@bitkyc08/opencodex/node_modules/bun/bin/bun.exe test tests/agent-task-recovery-security.test.ts` — 13 passed
- `/Users/jakemcallister/.nvm/versions/node/v24.13.0/lib/node_modules/@bitkyc08/opencodex/node_modules/bun/bin/bun.exe run typecheck` — passed
- live local proxy check: the desktop request advanced from the encrypted V2 rejection into configured provider routing; Gemini 3.7 Flash then completed a direct Antigravity request successfully

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. No user-facing configuration changes.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for task recovery requests originating from the Codex desktop app.
  * Preserves the origin information when forwarding recovered tasks to ChatGPT.
* **Tests**
  * Added security coverage confirming desktop-originated recovery requests are accepted and handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->