### PR TITLE
fix(tools): support namespaced custom tool aliases

### DIFF
--- a/src/adapters/anthropic.ts
+++ b/src/adapters/anthropic.ts
@@ -743,7 +743,7 @@ function toolsToAnthropicFormat(parsed: OcxParsedRequest, toolNames: { toWire: (
     ? new Set(parsed.options.toolChoice.allowedTools)
     : undefined;
   const tools = allowed
-    ? parsed.context.tools.filter(t => toolAllowedByChoice(t, allowed))
+    ? parsed.context.tools.filter(t => toolAllowedByChoice(t, allowed, parsed.context.tools))
     : parsed.context.tools;
   if (tools.length === 0) return undefined;
   const converted = tools.map(t => ({

--- a/src/adapters/command-code.ts
+++ b/src/adapters/command-code.ts
@@ -3,7 +3,7 @@ import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { opendir } from "node:fs/promises";
 import type { AdapterEvent, OcxContentPart, OcxMessage, OcxParsedRequest, OcxProviderConfig, OcxTool, OcxUsage } from "../types";
-import { isAllowedToolChoice, namespacedToolName, resolveToolChoiceWireName, toolAllowedByChoice, toolChoiceAliases } from "../types";
+import { isAllowedToolChoice, namespacedToolName, resolveToolChoiceWireName, toolAllowedByChoice } from "../types";
 import type { AdapterFetchContext, AdapterRequest, ProviderAdapter } from "./base";
 import type { TranslatorBudget } from "../lib/translator-budget";
 import { readBoundedResponseBody } from "../lib/bounded-body";
@@ -157,10 +157,11 @@ function visibleTools(parsed: OcxParsedRequest): OcxTool[] {
   const tools = parsed.context.tools ?? [];
   if (isAllowedToolChoice(choice)) {
     const allowed = new Set(choice.allowedTools);
-    return tools.filter(tool => toolAllowedByChoice(tool, allowed));
+    return tools.filter(tool => toolAllowedByChoice(tool, allowed, tools));
   }
   if (choice && typeof choice !== "string") {
-    return tools.filter(tool => toolChoiceAliases(tool).includes(choice.name));
+    const selected = resolveToolChoiceWireName(tools, choice.name);
+    return tools.filter(tool => namespacedToolName(tool.namespace, tool.name) === selected);
   }
   return tools;
 }

--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -255,7 +255,7 @@ function toolsToGeminiFormat(parsed: OcxParsedRequest): unknown[] | undefined {
     ? new Set(parsed.options.toolChoice.allowedTools)
     : undefined;
   const tools = allowed
-    ? parsed.context.tools.filter(t => toolAllowedByChoice(t, allowed))
+    ? parsed.context.tools.filter(t => toolAllowedByChoice(t, allowed, parsed.context.tools))
     : parsed.context.tools;
   if (tools.length === 0) return undefined;
   return [{

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -1192,7 +1192,7 @@ function normalizeXaiToolParameters(parameters: unknown): Record<string, unknown
 
 function toolsToChatFormat(parsed: OcxParsedRequest, provider: OcxProviderConfig): unknown[] | undefined {
   if (!parsed.context.tools || parsed.context.tools.length === 0) return undefined;
-  const tools = parsed.context.tools.filter(toolChoiceToolPredicate(parsed.options.toolChoice));
+  const tools = parsed.context.tools.filter(toolChoiceToolPredicate(parsed.options.toolChoice, parsed.context.tools));
   if (tools.length === 0) return undefined;
   const xaiTarget = isXaiSchemaTarget(provider);
   const formatted = tools.flatMap(t => {

--- a/src/adapters/tool-catalog-nudge.ts
+++ b/src/adapters/tool-catalog-nudge.ts
@@ -135,7 +135,7 @@ export function buildNonOpenAIToolCatalogNudgeForTools(
   toolChoice?: OcxRequestOptions["toolChoice"],
   toWireName: (tool: Pick<OcxTool, "namespace" | "name">) => string = tool => namespacedToolName(tool.namespace, tool.name),
 ): string | undefined {
-  const visible = tools?.filter(toolChoiceToolPredicate(toolChoice));
+  const visible = tools?.filter(toolChoiceToolPredicate(toolChoice, tools));
   const visibleNames = visible?.map(toWireName);
   // Decide code mode from the tool OBJECTS, while the `freeform` flag still exists — reducing
   // to wire names first throws away the only thing that distinguishes Codex's JavaScript

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -166,7 +166,7 @@ export type ResponsesTerminalStatus = "completed" | "failed" | "incomplete";
 export function bridgeToResponsesSSE(
   events: AsyncIterable<AdapterEvent>,
   modelId: string,
-  toolNsMap?: Map<string, { namespace: string; name: string }>,
+  toolNsMap?: Map<string, { namespace: string; name: string; freeform?: true }>,
   freeformToolNames?: Set<string>,
   toolSearchToolNames?: Set<string>,
   onCancel?: () => void,
@@ -1049,7 +1049,9 @@ export function bridgeToResponsesSSE(
               }
               const ns = mapped?.namespace;
               const toolSearch = toolSearchToolNames?.has(realName) ?? false;
-              const freeform = !toolSearch && (freeformToolNames?.has(realName) ?? false);
+              const freeform = !toolSearch && (mapped
+                ? mapped.freeform === true
+                : (freeformToolNames?.has(realName) ?? false));
               const itemId = `${toolSearch ? "tsc" : freeform ? "ctc" : "fc"}_${uuid()}`;
               const item = toolSearch
                 ? { type: "tool_search_call", id: itemId, call_id: event.id, execution: "client", arguments: {}, status: "in_progress" }
@@ -1439,7 +1441,7 @@ function buildResponseJSONWithBudget(
   modelId: string,
   options?: {
     hideThinkingSummary?: boolean;
-    toolNsMap?: Map<string, { namespace: string; name: string }>;
+    toolNsMap?: Map<string, { namespace: string; name: string; freeform?: true }>;
     /** Request-visible tool names. When present, an upstream call outside this set fails closed. */
     declaredToolNames?: ReadonlySet<string>;
     /** Declared parameter schema per tool name; repairs integral-float integer args (#1611). */
@@ -1620,7 +1622,9 @@ function buildResponseJSONWithBudget(
     const realName = mapped?.name ?? currentToolCallName;
     const ns = mapped?.namespace;
     const toolSearch = options?.toolSearchToolNames?.has(realName) ?? false;
-    const freeform = !toolSearch && (options?.freeformToolNames?.has(realName) ?? false);
+    const freeform = !toolSearch && (mapped
+      ? mapped.freeform === true
+      : (options?.freeformToolNames?.has(realName) ?? false));
     // #1611: same integral-float repair as the streaming path. Keyed by the wire name
     // the request declared, which is the pre-namespace-mapping `currentToolCallName`.
     const coercedArgs = coerceIntegerToolArguments(
@@ -1784,7 +1788,9 @@ function buildResponseJSONWithBudget(
           const mapped = options?.toolNsMap?.get(currentToolCallName);
           const realName = mapped?.name ?? currentToolCallName;
           const toolSearch = options?.toolSearchToolNames?.has(realName) ?? false;
-          const freeform = !toolSearch && (options?.freeformToolNames?.has(realName) ?? false);
+          const freeform = !toolSearch && (mapped
+            ? mapped.freeform === true
+            : (options?.freeformToolNames?.has(realName) ?? false));
           if (!freeform && !toolSearch) {
             flushToolCall("incomplete");
             errorEvent = {

--- a/src/images/loop.ts
+++ b/src/images/loop.ts
@@ -676,13 +676,20 @@ export async function runWithImageBridge(deps: ImageBridgeDeps): Promise<Respons
     }
   }
 
-  const toolNsMap = new Map<string, { namespace: string; name: string }>();
+  const toolNsMap = new Map<string, { namespace: string; name: string; freeform?: true }>();
   const freeform = new Set<string>();
   const toolSearch = new Set<string>();
-  const toolAllowed = toolChoiceToolPredicate(parsed.options.toolChoice);
-  for (const t of parsed.context.tools ?? []) {
+  const requestedTools = parsed.context.tools ?? [];
+  const toolAllowed = toolChoiceToolPredicate(parsed.options.toolChoice, requestedTools);
+  for (const t of requestedTools) {
     if (!toolAllowed(t)) continue;
-    if (t.namespace) toolNsMap.set(namespacedToolName(t.namespace, t.name), { namespace: t.namespace, name: t.name });
+    if (t.namespace) {
+      toolNsMap.set(namespacedToolName(t.namespace, t.name), {
+        namespace: t.namespace,
+        name: t.name,
+        ...(t.freeform ? { freeform: true } : {}),
+      });
+    }
     if (t.freeform) freeform.add(t.name);
     if (t.toolSearch) toolSearch.add(t.name);
   }

--- a/src/responses/parser.ts
+++ b/src/responses/parser.ts
@@ -328,6 +328,35 @@ function attachPendingReasoningToCallOwner(
 
 const REASONING_EFFORTS = new Set(["none", "minimal", "low", "medium", "high", "xhigh", "max"]);
 
+/**
+ * Namespace a custom tool was declared under, by its bare name.
+ *
+ * A `custom_tool_call` echoed back by the client carries only the bare name — the bridge
+ * emits `{"type":"custom_tool_call","name":"exec"}` even when the tool was declared as
+ * `mcp__functions__exec`. Without this lookup the namespace is lost on the return trip,
+ * and the adapters replay history through `namespacedToolName(namespace, name)`, which
+ * then produces a bare `exec` the provider may not have. Ordinary `function_call` items
+ * do not need this: they carry `namespace` on the wire.
+ */
+function customToolNamespaces(tools: unknown): Map<string, string> {
+  const out = new Map<string, string>();
+  if (!Array.isArray(tools)) return out;
+  for (const spec of tools) {
+    if (!isObj(spec) || spec.type !== "namespace" || !Array.isArray(spec.tools)) continue;
+    const namespace = typeof spec.name === "string" ? spec.name : undefined;
+    // Codex 0.147 groups ordinary client tools under the reserved `functions` namespace and
+    // buildTools deliberately flattens those without a namespace. Mirror that here, or the
+    // reconstruction would invent a namespace the request never advertised.
+    if (!namespace || namespace === "functions") continue;
+    for (const inner of spec.tools) {
+      if (!isObj(inner) || inner.type !== "custom" || typeof inner.name !== "string") continue;
+      // Ambiguous bare names are already rejected upstream, so first declaration wins.
+      if (!out.has(inner.name)) out.set(inner.name, namespace);
+    }
+  }
+  return out;
+}
+
 export function parseRequest(
   body: unknown,
   parseOptions?: { replayCacheScope?: OcxReasoningReplayScopeRef },
@@ -341,6 +370,9 @@ export function parseRequest(
   const data = parsed.data;
   const now = Date.now();
   const messages: OcxMessage[] = [];
+  // Built before the item loop: a custom_tool_call echoed back in `input` needs the
+  // namespace from the request's own tool catalog to survive the round trip.
+  const customToolNamespacesByName = customToolNamespaces(data.tools);
   const systemPrompt: string[] = [];
   // Responses reasoning siblings belong to the following assistant, including across call items.
   // Keep them off the message list until that assistant arrives; turn boundaries clear the array.
@@ -574,10 +606,15 @@ export function parseRequest(
       if (effectiveType === "custom_tool_call") {
         const call = item as { id?: string; call_id: string; name: string; input: string };
         const remembered = typeof call.call_id === "string" ? replayThoughtSignatureMetadata(call.call_id, replayCacheScope) : undefined;
+        // Reconstruct the namespace the request declared this tool under. The wire item
+        // carries only the bare name, so without this the round trip loses it and adapters
+        // replay the call as an unnamespaced tool the provider may not expose.
+        const customNamespace = customToolNamespacesByName.get(call.name);
         const toolCall: OcxToolCall = {
           type: "toolCall", id: call.call_id, name: call.name,
           arguments: { input: call.input ?? "" },
           customWireName: call.name,
+          ...(customNamespace ? { namespace: customNamespace } : {}),
           ...(remembered ? { providerMetadata: remembered } : {}),
         };
         assistantHolderWithReasoning().content.push(toolCall);

--- a/src/responses/parser.ts
+++ b/src/responses/parser.ts
@@ -11,7 +11,7 @@ import type {
   OcxToolCall,
   OcxReasoningReplayScopeRef,
 } from "../types";
-import { namespacedToolName } from "../types";
+import { namespacedToolName, toolChoiceCandidates } from "../types";
 import { responsesRequestSchema } from "./schema";
 import { providerMetadataFromResponsesFunctionCall } from "./provider-opaque-metadata";
 import { lookupReplayThoughtSignature } from "./thought-signature-replay";
@@ -691,6 +691,15 @@ export function parseRequest(
   const declaredTools = buildTools(data.tools as unknown[] | undefined) ?? [];
   const loadedTools = buildTools(loadedToolSpecs) ?? [];
   const loadedToolNames = new Set(loadedTools.map(t => namespacedToolName(t.namespace, t.name)));
+  const wireOwners = new Map<string, OcxTool>();
+  for (const tool of [...declaredTools, ...loadedTools]) {
+    const wireName = namespacedToolName(tool.namespace, tool.name);
+    const previous = wireOwners.get(wireName);
+    if (previous && (previous.namespace !== tool.namespace || previous.name !== tool.name || previous.freeform !== tool.freeform || previous.toolSearch !== tool.toolSearch)) {
+      throw new Error(`ambiguous tool catalog: multiple logical tools map to wire name ${wireName}`);
+    }
+    wireOwners.set(wireName, tool);
+  }
   const seenTools = new Set<string>();
   const mergedTools = [...declaredTools, ...loadedTools]
     .filter(t => {
@@ -716,6 +725,14 @@ export function parseRequest(
     options.stopSequences = typeof data.stop === "string" ? [data.stop] : data.stop;
   }
   const tc = mapToolChoice(data.tool_choice);
+  if (tc && typeof tc === "object") {
+    const selectors = "allowedTools" in tc ? tc.allowedTools : [tc.name];
+    for (const selector of selectors) {
+      if (toolChoiceCandidates(mergedTools, selector).length > 1) {
+        throw new Error(`ambiguous tool_choice name: ${selector}`);
+      }
+    }
+  }
   if (tc !== undefined) options.toolChoice = tc;
   if (data.parallel_tool_calls !== undefined) options.parallelToolCalls = data.parallel_tool_calls;
   // Upstream codex-rs converts "ultra" to "max" at the inference boundary (core/src/client.rs

--- a/src/responses/parser.ts
+++ b/src/responses/parser.ts
@@ -203,7 +203,7 @@ function buildTools(tools: unknown[] | undefined): OcxTool[] | undefined {
       const ns = typeof t.name === "string" && !builtinFunctions ? t.name : undefined;
       for (const inner of t.tools as unknown[]) {
         if (isObj(inner) && inner.type === "function" && typeof inner.name === "string") pushFn(inner, ns);
-        else if (builtinFunctions && isObj(inner) && inner.type === "custom" && typeof inner.name === "string") pushCustom(inner);
+        else if (isObj(inner) && inner.type === "custom" && typeof inner.name === "string") pushCustom(inner, ns);
       }
     }
     else if (t.type === "custom" && typeof t.name === "string") {

--- a/src/server/responses/collaboration.ts
+++ b/src/server/responses/collaboration.ts
@@ -101,22 +101,23 @@ import type { TranslatorBudget } from "../../lib/translator-budget";
 
 
 export function buildToolBridgeMaps(parsed: OcxParsedRequest, budget?: TranslatorBudget): {
-  toolNsMap: Map<string, { namespace: string; name: string }>;
+  toolNsMap: Map<string, { namespace: string; name: string; freeform?: true }>;
   declaredToolNames: Set<string>;
   /** Declared parameter schema per request-visible tool name (#1611 integer repair). */
   toolParameterSchemas: Map<string, Record<string, unknown>>;
   freeformToolNames: Set<string>;
   toolSearchToolNames: Set<string>;
 } {
-  const toolNsMap = new Map<string, { namespace: string; name: string }>();
+  const toolNsMap = new Map<string, { namespace: string; name: string; freeform?: true }>();
   const declaredToolNames = new Set<string>();
   const toolParameterSchemas = new Map<string, Record<string, unknown>>();
   const freeformToolNames = new Set<string>();
   const toolSearchToolNames = new Set<string>();
-  const toolAllowed = toolChoiceToolPredicate(parsed.options.toolChoice);
-  for (const t of parsed.context.tools ?? []) {
+  const requestedTools = parsed.context.tools ?? [];
+  const toolAllowed = toolChoiceToolPredicate(parsed.options.toolChoice, requestedTools);
+  const authorizedTools = requestedTools.filter(toolAllowed);
+  for (const t of authorizedTools) {
     // Upstream output is untrusted: only restore calls for tools the caller authorized.
-    if (!toolAllowed(t)) continue;
     const wireName = namespacedToolName(t.namespace, t.name);
     budget?.chargeRetained(new TextEncoder().encode(wireName).byteLength, { kind: "retained_collectors" });
     declaredToolNames.add(wireName);
@@ -125,7 +126,7 @@ export function buildToolBridgeMaps(parsed: OcxParsedRequest, budget?: Translato
     if (t.parameters && typeof t.parameters === "object") toolParameterSchemas.set(wireName, t.parameters);
     if (t.namespace) {
       budget?.chargeRetained(new TextEncoder().encode(JSON.stringify([wireName, t.namespace, t.name])).byteLength, { kind: "retained_collectors" });
-      toolNsMap.set(wireName, { namespace: t.namespace, name: t.name });
+      toolNsMap.set(wireName, { namespace: t.namespace, name: t.name, ...(t.freeform ? { freeform: true } : {}) });
     }
     if (t.freeform) {
       budget?.chargeRetained(new TextEncoder().encode(t.name).byteLength, { kind: "retained_collectors" });
@@ -134,6 +135,29 @@ export function buildToolBridgeMaps(parsed: OcxParsedRequest, budget?: Translato
     if (t.toolSearch) {
       budget?.chargeRetained(new TextEncoder().encode(t.name).byteLength, { kind: "retained_collectors" });
       toolSearchToolNames.add(t.name);
+    }
+  }
+  // Some routed providers echo a bare tool_choice selector instead of the flattened catalog
+  // name. Accept only selectors the client actually sent and only when the full request catalog
+  // contains one tool with that logical name.
+  const choice = parsed.options.toolChoice;
+  const bareChoiceNames = new Set(
+    choice && typeof choice === "object"
+      ? ("allowedTools" in choice ? choice.allowedTools : [choice.name])
+      : [],
+  );
+  const bareNameCounts = new Map<string, number>();
+  for (const t of requestedTools) {
+    bareNameCounts.set(t.name, (bareNameCounts.get(t.name) ?? 0) + 1);
+  }
+  for (const t of authorizedTools) {
+    if (!t.namespace || !bareChoiceNames.has(t.name) || bareNameCounts.get(t.name) !== 1 || declaredToolNames.has(t.name)) continue;
+    budget?.chargeRetained(new TextEncoder().encode(t.name).byteLength, { kind: "retained_collectors" });
+    declaredToolNames.add(t.name);
+    budget?.chargeRetained(new TextEncoder().encode(JSON.stringify([t.name, t.namespace, t.name])).byteLength, { kind: "retained_collectors" });
+    toolNsMap.set(t.name, { namespace: t.namespace, name: t.name, ...(t.freeform ? { freeform: true } : {}) });
+    if (t.parameters && typeof t.parameters === "object") {
+      toolParameterSchemas.set(t.name, t.parameters);
     }
   }
   return { toolNsMap, declaredToolNames, toolParameterSchemas, freeformToolNames, toolSearchToolNames };

--- a/src/types.ts
+++ b/src/types.ts
@@ -246,13 +246,39 @@ export function toolChoiceAliases(tool: Pick<OcxTool, "namespace" | "name">): st
   return tool.namespace ? [wireName, `${tool.namespace}.${tool.name}`] : [wireName];
 }
 
-export function toolAllowedByChoice(tool: Pick<OcxTool, "namespace" | "name">, allowedTools: ReadonlySet<string>): boolean {
-  return toolChoiceAliases(tool).some(name => allowedTools.has(name));
+function uniqueBareToolMatch(
+  tools: readonly Pick<OcxTool, "namespace" | "name">[] | undefined,
+  name: string,
+): Pick<OcxTool, "namespace" | "name"> | undefined {
+  if (!tools) return undefined;
+  const matches = tools.filter(tool => tool.name === name);
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
+/**
+ * Newer Codex clients can select a tool nested in a namespace by its bare name. Resolve that
+ * shorthand only when the request contains one tool with the logical name, so an ambiguous name
+ * cannot authorize a tool from an unintended namespace.
+ */
+export function toolAllowedByChoice(
+  tool: Pick<OcxTool, "namespace" | "name">,
+  allowedTools: ReadonlySet<string>,
+  tools?: readonly Pick<OcxTool, "namespace" | "name">[],
+): boolean {
+  if (toolChoiceAliases(tool).some(name => allowedTools.has(name))) return true;
+  if (!tool.namespace || !allowedTools.has(tool.name)) return false;
+  const match = uniqueBareToolMatch(tools, tool.name);
+  return match?.namespace === tool.namespace && match.name === tool.name;
 }
 
 export function resolveToolChoiceWireName(tools: readonly Pick<OcxTool, "namespace" | "name">[] | undefined, name: string): string {
-  const match = tools?.find(tool => toolChoiceAliases(tool).includes(name));
-  return match ? namespacedToolName(match.namespace, match.name) : name;
+  const exactMatches = tools?.filter(tool => toolChoiceAliases(tool).includes(name)) ?? [];
+  if (exactMatches.length === 1) {
+    const match = exactMatches[0];
+    return namespacedToolName(match.namespace, match.name);
+  }
+  const bareMatch = uniqueBareToolMatch(tools, name);
+  return bareMatch ? namespacedToolName(bareMatch.namespace, bareMatch.name) : name;
 }
 
 /**
@@ -281,14 +307,17 @@ export function isAllowedToolChoice(value: OcxToolChoice | undefined): value is 
 /** Compile the request's tool-choice policy into a reusable advertisement/restoration predicate. */
 export function toolChoiceToolPredicate(
   choice: OcxToolChoice | undefined,
+  tools?: readonly Pick<OcxTool, "namespace" | "name">[],
 ): (tool: Pick<OcxTool, "namespace" | "name">) => boolean {
   if (!choice || choice === "auto" || choice === "required") return () => true;
   if (choice === "none") return () => false;
   if (isAllowedToolChoice(choice)) {
     const allowed = new Set(choice.allowedTools);
-    return tool => toolAllowedByChoice(tool, allowed);
+    return tool => toolAllowedByChoice(tool, allowed, tools);
   }
-  return tool => toolChoiceAliases(tool).includes(choice.name);
+  if (!tools) return tool => toolChoiceAliases(tool).includes(choice.name);
+  const selected = resolveToolChoiceWireName(tools, choice.name);
+  return tool => namespacedToolName(tool.namespace, tool.name) === selected;
 }
 
 export interface OcxRequestOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -246,13 +246,29 @@ export function toolChoiceAliases(tool: Pick<OcxTool, "namespace" | "name">): st
   return tool.namespace ? [wireName, `${tool.namespace}.${tool.name}`] : [wireName];
 }
 
-function uniqueBareToolMatch(
+function sameToolIdentity(
+  left: Pick<OcxTool, "namespace" | "name">,
+  right: Pick<OcxTool, "namespace" | "name">,
+): boolean {
+  return left.namespace === right.namespace && left.name === right.name;
+}
+
+/**
+ * All tools that could be selected by one client-facing name. Bare logical names are included
+ * here because they are a compatibility selector for namespaced tools, while wire and dotted
+ * aliases come from `toolChoiceAliases`. A selector with more than one candidate is invalid.
+ */
+export function toolChoiceCandidates(
   tools: readonly Pick<OcxTool, "namespace" | "name">[] | undefined,
   name: string,
-): Pick<OcxTool, "namespace" | "name"> | undefined {
-  if (!tools) return undefined;
-  const matches = tools.filter(tool => tool.name === name);
-  return matches.length === 1 ? matches[0] : undefined;
+): Pick<OcxTool, "namespace" | "name">[] {
+  if (!tools) return [];
+  const candidates: Pick<OcxTool, "namespace" | "name">[] = [];
+  for (const tool of tools) {
+    if (tool.name !== name && !toolChoiceAliases(tool).includes(name)) continue;
+    if (!candidates.some(candidate => sameToolIdentity(candidate, tool))) candidates.push(tool);
+  }
+  return candidates;
 }
 
 /**
@@ -265,20 +281,24 @@ export function toolAllowedByChoice(
   allowedTools: ReadonlySet<string>,
   tools?: readonly Pick<OcxTool, "namespace" | "name">[],
 ): boolean {
-  if (toolChoiceAliases(tool).some(name => allowedTools.has(name))) return true;
-  if (!tool.namespace || !allowedTools.has(tool.name)) return false;
-  const match = uniqueBareToolMatch(tools, tool.name);
-  return match?.namespace === tool.namespace && match.name === tool.name;
+  if (!tools) return toolChoiceAliases(tool).some(name => allowedTools.has(name));
+  for (const name of [...toolChoiceAliases(tool), tool.name]) {
+    if (!allowedTools.has(name)) continue;
+    const candidates = toolChoiceCandidates(tools, name);
+    if (candidates.length === 1 && sameToolIdentity(candidates[0], tool)) return true;
+  }
+  return false;
 }
 
 export function resolveToolChoiceWireName(tools: readonly Pick<OcxTool, "namespace" | "name">[] | undefined, name: string): string {
-  const exactMatches = tools?.filter(tool => toolChoiceAliases(tool).includes(name)) ?? [];
-  if (exactMatches.length === 1) {
-    const match = exactMatches[0];
+  const candidates = toolChoiceCandidates(tools, name);
+  if (candidates.length === 1) {
+    const match = candidates[0];
     return namespacedToolName(match.namespace, match.name);
   }
-  const bareMatch = uniqueBareToolMatch(tools, name);
-  return bareMatch ? namespacedToolName(bareMatch.namespace, bareMatch.name) : name;
+  // Keep unknown/ambiguous names unchanged for callers that only serialize a selector. The
+  // catalog-aware predicate rejects them, and parseRequest rejects ambiguous request selectors.
+  return name;
 }
 
 /**
@@ -316,8 +336,8 @@ export function toolChoiceToolPredicate(
     return tool => toolAllowedByChoice(tool, allowed, tools);
   }
   if (!tools) return tool => toolChoiceAliases(tool).includes(choice.name);
-  const selected = resolveToolChoiceWireName(tools, choice.name);
-  return tool => namespacedToolName(tool.namespace, tool.name) === selected;
+  const candidates = toolChoiceCandidates(tools, choice.name);
+  return tool => candidates.length === 1 && sameToolIdentity(candidates[0], tool);
 }
 
 export interface OcxRequestOptions {

--- a/src/web-search/loop.ts
+++ b/src/web-search/loop.ts
@@ -741,13 +741,20 @@ export async function runWithWebSearch(deps: WebSearchLoopDeps): Promise<Respons
     throw e;
   }
 
-  const toolNsMap = new Map<string, { namespace: string; name: string }>();
+  const toolNsMap = new Map<string, { namespace: string; name: string; freeform?: true }>();
   const freeform = new Set<string>();
   const toolSearch = new Set<string>();
-  const toolAllowed = toolChoiceToolPredicate(parsed.options.toolChoice);
-  for (const t of parsed.context.tools ?? []) {
+  const requestedTools = parsed.context.tools ?? [];
+  const toolAllowed = toolChoiceToolPredicate(parsed.options.toolChoice, requestedTools);
+  for (const t of requestedTools) {
     if (!toolAllowed(t)) continue;
-    if (t.namespace) toolNsMap.set(namespacedToolName(t.namespace, t.name), { namespace: t.namespace, name: t.name });
+    if (t.namespace) {
+      toolNsMap.set(namespacedToolName(t.namespace, t.name), {
+        namespace: t.namespace,
+        name: t.name,
+        ...(t.freeform ? { freeform: true } : {}),
+      });
+    }
     if (t.freeform) freeform.add(t.name);
     if (t.toolSearch) toolSearch.add(t.name);
   }

--- a/tests/adapter-tool-conformance.test.ts
+++ b/tests/adapter-tool-conformance.test.ts
@@ -100,6 +100,26 @@ function freeformParsed(wire: AdapterWire): OcxParsedRequest {
   }), wire);
 }
 
+function namespacedCollisionParsed(wire: AdapterWire): OcxParsedRequest {
+  return prepareForWire(parseRequest({
+    model: WIRE_MODELS[wire],
+    input: "Run the requested tool.",
+    stream: true,
+    tools: [
+      {
+        type: "namespace",
+        name: "mcp__custom",
+        tools: [{ type: "custom", name: "exec", description: "Freeform execution." }],
+      },
+      {
+        type: "namespace",
+        name: "mcp__remote",
+        tools: [{ type: "function", name: "exec", description: "Structured execution.", parameters: { type: "object", properties: {} } }],
+      },
+    ],
+  }), wire);
+}
+
 function toolChoiceParsed(wire: AdapterWire, toolChoice?: "none"): OcxParsedRequest {
   return prepareForWire(parseRequest({
     model: WIRE_MODELS[wire],
@@ -428,6 +448,79 @@ describe("registry-derived routed tool conformance", () => {
         continue;
       }
       expect(await restoredStreamInput(adapterId, contract.wire), adapterId).toBe(PATCH);
+    }
+  });
+
+  test("every buffered adapter preserves same-name tools from different namespaces", async () => {
+    for (const [adapterId] of adapterDefinitions()) {
+      const contract = effectiveAdapterContract(adapterId);
+      if (contract.wire === "openai-responses" || contract.wire === "cursor") {
+        // Native Responses passthrough and Cursor's protobuf transport do not use the routed
+        // adapter tool declaration surface exercised by this registry-wide check.
+        continue;
+      }
+      const body = await outbound(adapterId, namespacedCollisionParsed(contract.wire));
+      const names = advertisedToolNames(contract.wire, body).filter(name => name.includes("exec"));
+      expect(new Set(names).size, adapterId).toBe(2);
+    }
+  });
+
+  test("every routed adapter fails closed for an ambiguous bare selector", async () => {
+    for (const [adapterId] of adapterDefinitions()) {
+      const contract = effectiveAdapterContract(adapterId);
+      if (contract.wire === "openai-responses" || contract.wire === "cursor") continue;
+      const parsed = namespacedCollisionParsed(contract.wire);
+      // parseRequest rejects this shape for real inbound traffic; keeping the policy mutation here
+      // also proves each adapter remains fail-closed when a caller reaches it with a prebuilt AST.
+      parsed.options.toolChoice = { allowedTools: ["exec"], mode: "required" };
+      if (contract.wire === "kiro") {
+        await expect(outbound(adapterId, parsed)).rejects.toThrow("Kiro supports only automatic tool choice or tool_choice:none");
+        continue;
+      }
+      const body = await outbound(adapterId, parsed);
+      expect(advertisedToolNames(contract.wire, body), adapterId).toHaveLength(0);
+    }
+  });
+
+  test("every streaming adapter restores namespaced custom/function collisions distinctly", async () => {
+    for (const [adapterId] of adapterDefinitions()) {
+      const contract = effectiveAdapterContract(adapterId);
+      const driver = TOOL_WIRE_DRIVERS[contract.wire];
+      if (!driver.streamingToolCall || !driver.extractWireToolName) {
+        expect(["openai-responses", "cursor"]).toContain(contract.wire);
+        continue;
+      }
+
+      const parsed = namespacedCollisionParsed(contract.wire);
+      const body = await outbound(adapterId, parsed);
+      const maps = buildToolBridgeMaps(parsed);
+      const cases = [
+        { logicalName: "mcp__custom__exec", type: "custom_tool_call" },
+        { logicalName: "mcp__remote__exec", namespace: "mcp__remote", type: "function_call" },
+      ] as const;
+      for (const testCase of cases) {
+        const wireName = driver.extractWireToolName(body, testCase.logicalName);
+        const bridged = bridgeToResponsesSSE(
+          createRegisteredAdapter(providerFixture(adapterId, contract.wire)).parseStream(
+            driver.streamingToolCall(wireName, JSON.stringify({ input: "ok" })),
+            createTestTranslatorBudget(),
+          ),
+          parsed.modelId,
+          maps.toolNsMap,
+          maps.freeformToolNames,
+          maps.toolSearchToolNames,
+          undefined,
+          2_000,
+          { declaredToolNames: maps.declaredToolNames },
+        );
+        const frames = parseResponsesFrames(await new Response(bridged).text());
+        const item = frames.find(frame => frame.event === "response.output_item.added")?.data.item as Record<string, unknown> | undefined;
+        expect(item, `${adapterId}:${testCase.logicalName}`).toMatchObject({
+          type: testCase.type,
+          name: "exec",
+          ...(testCase.namespace ? { namespace: testCase.namespace } : {}),
+        });
+      }
     }
   });
 

--- a/tests/command-code-provider.test.ts
+++ b/tests/command-code-provider.test.ts
@@ -392,7 +392,7 @@ describe("Command Code provider", () => {
     expect(JSON.parse(built.body).params.tools).toEqual([]);
   });
 
-  test("matches a forced namespaced tool choice by dot alias", async () => {
+  test("matches a forced namespaced tool choice by dot or unique bare alias", async () => {
     const namespacedParsed = {
       ...parsed(),
       context: {
@@ -404,6 +404,12 @@ describe("Command Code provider", () => {
     const built = await builtRequest(namespacedParsed);
     const tools = JSON.parse(built.body).params.tools;
     expect(tools).toEqual([{ name: "functions__exec_command", description: "exec", input_schema: { type: "object" } }]);
+
+    const bareBuilt = await builtRequest({
+      ...namespacedParsed,
+      options: { toolChoice: { name: "exec_command" } },
+    });
+    expect(JSON.parse(bareBuilt.body).params.tools).toEqual(tools);
   });
 
   test("refreshes a stale official effort record only after a reasoning rejection and retries without it", async () => {

--- a/tests/helpers/responses-conformance.ts
+++ b/tests/helpers/responses-conformance.ts
@@ -72,7 +72,7 @@ const isToolItem = (item: Record<string, unknown>): boolean =>
   String(item.type ?? "").includes("call");
 
 type BridgeMaps = [
-  toolNsMap?: Map<string, { namespace: string; name: string }>,
+  toolNsMap?: Map<string, { namespace: string; name: string; freeform?: true }>,
   freeformToolNames?: Set<string>,
   toolSearchToolNames?: Set<string>,
 ];

--- a/tests/reasoning-effort.test.ts
+++ b/tests/reasoning-effort.test.ts
@@ -487,6 +487,32 @@ describe("provider-specific reasoning effort mapping", () => {
     expect(body.tool_choice).toBe("required");
   });
 
+  test("OpenAI-compatible chat accepts a bare allowed_tools name for a unique namespace tool", () => {
+    const provider: OcxProviderConfig = {
+      adapter: "openai-chat",
+      baseUrl: "https://api.umans.ai/v1",
+    };
+
+    const req = createOpenAIChatAdapter(provider).buildRequest({
+      modelId: "umans-kimi-k2.7",
+      context: {
+        messages: [{ role: "user", content: "run it", timestamp: 0 }],
+        tools: [{
+          namespace: "functions",
+          name: "exec",
+          description: "Run a command",
+          parameters: { type: "object", properties: { input: { type: "string" } }, required: ["input"] },
+        }],
+      },
+      stream: false,
+      options: { toolChoice: { allowedTools: ["exec"], mode: "required" } },
+    });
+    const body = JSON.parse(req.body as string) as { tools: Array<{ function: { name: string } }>; tool_choice: string };
+
+    expect(body.tools.map(t => t.function.name)).toEqual(["functions__exec"]);
+    expect(body.tool_choice).toBe("required");
+  });
+
   test("named namespaced tool_choice resolves to the chat wire name", async () => {
     const provider: OcxProviderConfig = {
       adapter: "openai-chat",
@@ -548,6 +574,34 @@ describe("provider-specific reasoning effort mapping", () => {
     const body = JSON.parse(req.body as string) as { tools: Array<{ name: string }>; tool_choice: { type: string } };
 
     expect(body.tools.map(t => t.name)).toEqual(["functions__exec_command"]);
+    expect(body.tool_choice).toEqual({ type: "any" });
+  });
+
+  test("Anthropic accepts a bare allowed_tools name for a unique namespace tool", async () => {
+    const provider: OcxProviderConfig = {
+      adapter: "anthropic",
+      baseUrl: "https://api.anthropic.com/v1",
+      apiKey: "test-key",
+    };
+
+    const req = await createAnthropicAdapter(provider).buildRequest({
+      modelId: "claude-sonnet",
+      context: {
+        messages: [{ role: "user", content: "run it", timestamp: 0 }],
+        tools: [{
+          namespace: "functions",
+          name: "exec",
+          description: "Run a command",
+          parameters: { type: "object", properties: { input: { type: "string" } }, required: ["input"] },
+          freeform: true,
+        }],
+      },
+      stream: false,
+      options: { toolChoice: { allowedTools: ["exec"], mode: "required" } },
+    });
+    const body = JSON.parse(req.body as string) as { tools: Array<{ name: string }>; tool_choice: { type: string } };
+
+    expect(body.tools.map(t => t.name)).toEqual(["functions__exec"]);
     expect(body.tool_choice).toEqual({ type: "any" });
   });
 

--- a/tests/responses-parser.test.ts
+++ b/tests/responses-parser.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { buildResponseJSON } from "../src/bridge";
 import { parseRequest } from "../src/responses/parser";
 import { buildToolBridgeMaps } from "../src/server/responses";
 
@@ -188,6 +189,106 @@ describe("Responses parser", () => {
     expect([...maps.declaredToolNames]).toEqual([]);
     expect([...maps.freeformToolNames]).toEqual([]);
     expect([...maps.toolSearchToolNames]).toEqual([]);
+  });
+
+  test("accepts a unique bare selector for a namespaced custom tool and rejects ambiguity", () => {
+    const parsed = parseRequest({
+      model: "claude-opus-5",
+      input: "run it",
+      tools: [{
+        type: "namespace",
+        name: "functions",
+        tools: [{ type: "custom", name: "exec", description: "Run a command" }],
+      }],
+      tool_choice: {
+        type: "allowed_tools",
+        mode: "required",
+        tools: [{ type: "custom", name: "exec" }],
+      },
+    });
+
+    let maps = buildToolBridgeMaps(parsed);
+    expect([...maps.toolNsMap]).toEqual([
+      ["functions__exec", { namespace: "functions", name: "exec", freeform: true }],
+      ["exec", { namespace: "functions", name: "exec", freeform: true }],
+    ]);
+    expect([...maps.declaredToolNames]).toEqual(["functions__exec", "exec"]);
+    expect([...maps.freeformToolNames]).toEqual(["exec"]);
+
+    const bridged = buildResponseJSON([
+      { type: "tool_call_start", id: "call_exec", name: "exec" },
+      { type: "tool_call_delta", arguments: '{"input":"pwd"}' },
+      { type: "tool_call_end" },
+      { type: "done" },
+    ], "claude-opus-5", maps);
+    expect(bridged.status).toBe("completed");
+    expect((bridged.output as Record<string, unknown>[])[0]).toMatchObject({
+      type: "custom_tool_call",
+      call_id: "call_exec",
+      name: "exec",
+      input: "pwd",
+      status: "completed",
+    });
+
+    parsed.options.toolChoice = { name: "exec" };
+    maps = buildToolBridgeMaps(parsed);
+    expect([...maps.toolNsMap.keys()]).toEqual(["functions__exec", "exec"]);
+
+    const ambiguous = parseRequest({
+      model: "claude-opus-5",
+      input: "run it",
+      tools: [{
+        type: "namespace",
+        name: "functions",
+        tools: [{ type: "custom", name: "exec" }],
+      }, {
+        type: "namespace",
+        name: "other",
+        tools: [{ type: "custom", name: "exec" }],
+      }],
+      tool_choice: {
+        type: "allowed_tools",
+        mode: "required",
+        tools: [{ type: "custom", name: "exec" }],
+      },
+    });
+
+    const ambiguousMaps = buildToolBridgeMaps(ambiguous);
+    expect([...ambiguousMaps.declaredToolNames]).toEqual([]);
+    expect([...ambiguousMaps.toolNsMap]).toEqual([]);
+
+    const mixedKinds = parseRequest({
+      model: "claude-opus-5",
+      input: "run it",
+      tools: [{
+        type: "namespace",
+        name: "functions",
+        tools: [{ type: "custom", name: "exec" }],
+      }, {
+        type: "namespace",
+        name: "mcp__remote",
+        tools: [{ type: "function", name: "exec", parameters: { type: "object" } }],
+      }],
+    });
+    const mixedMaps = buildToolBridgeMaps(mixedKinds);
+    const customCall = buildResponseJSON([
+      { type: "tool_call_start", id: "call_custom", name: "functions__exec" },
+      { type: "tool_call_delta", arguments: '{"input":"pwd"}' },
+      { type: "tool_call_end" },
+      { type: "done" },
+    ], "claude-opus-5", mixedMaps);
+    const functionCall = buildResponseJSON([
+      { type: "tool_call_start", id: "call_function", name: "mcp__remote__exec" },
+      { type: "tool_call_delta", arguments: "{}" },
+      { type: "tool_call_end" },
+      { type: "done" },
+    ], "claude-opus-5", mixedMaps);
+    expect((customCall.output as Record<string, unknown>[])[0]?.type).toBe("custom_tool_call");
+    expect((functionCall.output as Record<string, unknown>[])[0]).toMatchObject({
+      type: "function_call",
+      name: "exec",
+      namespace: "mcp__remote",
+    });
   });
 
   test("maps hosted allowed_tools entries to their synthetic routed tool names", () => {

--- a/tests/responses-parser.test.ts
+++ b/tests/responses-parser.test.ts
@@ -197,7 +197,7 @@ describe("Responses parser", () => {
       input: "run it",
       tools: [{
         type: "namespace",
-        name: "functions",
+        name: "mcp__functions",
         tools: [{ type: "custom", name: "exec", description: "Run a command" }],
       }],
       tool_choice: {
@@ -209,10 +209,10 @@ describe("Responses parser", () => {
 
     let maps = buildToolBridgeMaps(parsed);
     expect([...maps.toolNsMap]).toEqual([
-      ["functions__exec", { namespace: "functions", name: "exec", freeform: true }],
-      ["exec", { namespace: "functions", name: "exec", freeform: true }],
+      ["mcp__functions__exec", { namespace: "mcp__functions", name: "exec", freeform: true }],
+      ["exec", { namespace: "mcp__functions", name: "exec", freeform: true }],
     ]);
-    expect([...maps.declaredToolNames]).toEqual(["functions__exec", "exec"]);
+    expect([...maps.declaredToolNames]).toEqual(["mcp__functions__exec", "exec"]);
     expect([...maps.freeformToolNames]).toEqual(["exec"]);
 
     const bridged = buildResponseJSON([
@@ -232,14 +232,14 @@ describe("Responses parser", () => {
 
     parsed.options.toolChoice = { name: "exec" };
     maps = buildToolBridgeMaps(parsed);
-    expect([...maps.toolNsMap.keys()]).toEqual(["functions__exec", "exec"]);
+    expect([...maps.toolNsMap.keys()]).toEqual(["mcp__functions__exec", "exec"]);
 
-    const ambiguous = parseRequest({
+    expect(() => parseRequest({
       model: "claude-opus-5",
       input: "run it",
       tools: [{
         type: "namespace",
-        name: "functions",
+        name: "mcp__functions",
         tools: [{ type: "custom", name: "exec" }],
       }, {
         type: "namespace",
@@ -251,18 +251,14 @@ describe("Responses parser", () => {
         mode: "required",
         tools: [{ type: "custom", name: "exec" }],
       },
-    });
-
-    const ambiguousMaps = buildToolBridgeMaps(ambiguous);
-    expect([...ambiguousMaps.declaredToolNames]).toEqual([]);
-    expect([...ambiguousMaps.toolNsMap]).toEqual([]);
+    })).toThrow("ambiguous tool_choice name: exec");
 
     const mixedKinds = parseRequest({
       model: "claude-opus-5",
       input: "run it",
       tools: [{
         type: "namespace",
-        name: "functions",
+        name: "mcp__functions",
         tools: [{ type: "custom", name: "exec" }],
       }, {
         type: "namespace",
@@ -272,7 +268,7 @@ describe("Responses parser", () => {
     });
     const mixedMaps = buildToolBridgeMaps(mixedKinds);
     const customCall = buildResponseJSON([
-      { type: "tool_call_start", id: "call_custom", name: "functions__exec" },
+      { type: "tool_call_start", id: "call_custom", name: "mcp__functions__exec" },
       { type: "tool_call_delta", arguments: '{"input":"pwd"}' },
       { type: "tool_call_end" },
       { type: "done" },
@@ -305,6 +301,37 @@ describe("Responses parser", () => {
 
     expect(parsed._webSearch).toEqual({ type: "web_search", search_context_size: "medium" });
     expect(parsed.options.toolChoice).toEqual({ allowedTools: ["web_search"], mode: "required" });
+  });
+
+  test("rejects wire-name collisions instead of dropping one logical tool", () => {
+    expect(() => parseRequest({
+      model: "gpt-5.5",
+      input: "run it",
+      tools: [
+        {
+          type: "namespace",
+          name: "foo",
+          tools: [{ type: "function", name: "bar", parameters: { type: "object" } }],
+        },
+        { type: "function", name: "foo__bar", parameters: { type: "object" } },
+      ],
+    })).toThrow("ambiguous tool catalog: multiple logical tools map to wire name foo__bar");
+  });
+
+  test("rejects a dotted alias that also names a flat tool", () => {
+    expect(() => parseRequest({
+      model: "gpt-5.5",
+      input: "run it",
+      tools: [
+        {
+          type: "namespace",
+          name: "foo",
+          tools: [{ type: "function", name: "bar", parameters: { type: "object" } }],
+        },
+        { type: "function", name: "foo.bar", parameters: { type: "object" } },
+      ],
+      tool_choice: { type: "function", name: "foo.bar" },
+    })).toThrow("ambiguous tool_choice name: foo.bar");
   });
 
   test("maps type-only hosted image_generation tool_choice to required image_gen", () => {

--- a/tests/responses-parser.test.ts
+++ b/tests/responses-parser.test.ts
@@ -606,4 +606,57 @@ describe("codex-rs compat surface (260707)", () => {
     expect(parseRequest({ model: "p/m", input: "hi", reasoning: { effort: "banana" } }).options.reasoning).toBeUndefined();
     expect(() => parseRequest({ model: "p/m", input: "hi", reasoning: { effort: null } })).toThrow();
   });
+
+  test("a replayed custom_tool_call recovers the namespace it was declared under", () => {
+    // The round trip loses it otherwise. The bridge emits a client-facing custom call with
+    // only the BARE name — `{"type":"custom_tool_call","name":"exec"}` even for a tool
+    // declared as `mcp__functions__exec`. On the next request the adapters replay tool
+    // history through `namespacedToolName(namespace, name)`, so a missing namespace makes
+    // the replayed call target a bare `exec` the provider may not expose.
+    //
+    // `function_call` items do not need this: they carry `namespace` on the wire.
+    const parsed = parseRequest({
+      model: "p/m",
+      tools: [{
+        type: "namespace",
+        name: "mcp__tools",
+        tools: [{ type: "custom", name: "exec", description: "run", format: { type: "text" } }],
+      }],
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "go" }] },
+        { type: "custom_tool_call", call_id: "call_1", name: "exec", input: "ls" },
+      ],
+    });
+
+    const assistant = parsed.context.messages.find(msg => msg.role === "assistant");
+    const call = (assistant?.content as Array<{ type: string; name?: string; namespace?: string }> | undefined)
+      ?.find(part => part.type === "toolCall");
+    expect(call?.name).toBe("exec");
+    expect(call?.namespace).toBe("mcp__tools");
+  });
+
+  test("a replayed custom_tool_call under the reserved functions namespace stays bare", () => {
+    // Companion guard. Codex 0.147 groups ordinary client tools under `functions`, and
+    // buildTools deliberately flattens those WITHOUT a namespace. Reconstructing one here
+    // would invent a namespace the request never advertised and break the reverse mapping
+    // in the other direction.
+    const parsed = parseRequest({
+      model: "p/m",
+      tools: [{
+        type: "namespace",
+        name: "functions",
+        tools: [{ type: "custom", name: "apply_patch", description: "patch", format: { type: "text" } }],
+      }],
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "go" }] },
+        { type: "custom_tool_call", call_id: "call_2", name: "apply_patch", input: "*** Begin Patch" },
+      ],
+    });
+
+    const assistant = parsed.context.messages.find(msg => msg.role === "assistant");
+    const call = (assistant?.content as Array<{ type: string; name?: string; namespace?: string }> | undefined)
+      ?.find(part => part.type === "toolCall");
+    expect(call?.name).toBe("apply_patch");
+    expect(call?.namespace).toBeUndefined();
+  });
 });

--- a/tests/responses-tool-conformance.test.ts
+++ b/tests/responses-tool-conformance.test.ts
@@ -172,18 +172,24 @@ describe("Responses tool-kind discrimination", () => {
     expect(parsed.context.tools ?? []).toEqual([]);
   });
 
-  it("CURRENT BEHAVIOR: a non-function child inside a namespace disappears", () => {
+  it("preserves custom namespace children while unknown child kinds still disappear", () => {
     const parsed = parseRequest(request([], [
       {
         type: "namespace",
         name: "ns",
         tools: [
           { type: "function", name: "kept", parameters: { type: "object", properties: {} } },
-          { type: "custom", name: "dropped" },
+          { type: "custom", name: "freeform" },
+          { type: "computer_use_preview", name: "dropped" },
         ],
       },
     ]));
-    expect(toolNames(parsed)).toEqual(["kept"]);
+    expect(toolNames(parsed)).toEqual(["kept", "freeform"]);
+    expect(parsed.context.tools?.[1]).toMatchObject({
+      name: "freeform",
+      namespace: "ns",
+      freeform: true,
+    });
   });
 });
 
@@ -384,6 +390,33 @@ describe("streaming and non-streaming tool parity", () => {
       "tool_search_call",
       "function_call",
     ]);
+  });
+
+  it("keeps namespaced custom and function tools distinct when their logical names collide", async () => {
+    const collidingNsMap = new Map<string, { namespace: string; name: string; freeform?: true }>([
+      ["functions__exec", { namespace: "functions", name: "exec", freeform: true }],
+      ["mcp__remote__exec", { namespace: "mcp__remote", name: "exec" }],
+    ]);
+    const events: AdapterEvent[] = [
+      { type: "tool_call_start", id: "call_custom", name: "functions__exec" },
+      { type: "tool_call_delta", arguments: '{"input":"pwd"}' },
+      { type: "tool_call_end" },
+      { type: "tool_call_start", id: "call_function", name: "mcp__remote__exec" },
+      { type: "tool_call_delta", arguments: "{}" },
+      { type: "tool_call_end" },
+      { type: "done" },
+    ];
+
+    const view = await streamedView(events, MODEL, collidingNsMap, new Set(["exec"]));
+    const json = jsonToolItems(events, MODEL, {
+      toolNsMap: collidingNsMap,
+      freeformToolNames: new Set(["exec"]),
+    });
+
+    expect(view.incremental).toEqual(view.snapshot);
+    expect(view.snapshot).toEqual(json);
+    expect(view.snapshot.map(item => item.type)).toEqual(["custom_tool_call", "function_call"]);
+    expect(view.snapshot[1]).toMatchObject({ name: "exec", namespace: "mcp__remote" });
   });
 
   it("emits the exact custom input fragments on the streamed path only", async () => {

--- a/tests/tool-catalog-nudge.test.ts
+++ b/tests/tool-catalog-nudge.test.ts
@@ -196,6 +196,18 @@ describe("non-OpenAI tool catalog nudge", () => {
     expect(note).not.toContain("`exec_command`,");
   });
 
+  test("keeps a uniquely named namespace tool visible when allowed_tools uses its bare name", () => {
+    const tools: OcxTool[] = [
+      { name: "exec", namespace: "functions", description: "Run", parameters: {} },
+      { name: "read_file", namespace: "mcp__fs", description: "Read", parameters: {} },
+    ];
+
+    const note = buildNonOpenAIToolCatalogNudgeForTools(tools, { mode: "required", allowedTools: ["exec"] });
+
+    expect(note).toContain("`functions__exec`");
+    expect(note).not.toContain("`mcp__fs__read_file`");
+  });
+
   test("skips OpenAI and ChatGPT hosts", () => {
     expect(shouldInjectNonOpenAIToolCatalogNudge({ baseUrl: "https://api.openai.com/v1" })).toBe(false);
     expect(shouldInjectNonOpenAIToolCatalogNudge({ baseUrl: "https://chatgpt.com/backend-api/codex" })).toBe(false);


### PR DESCRIPTION
## Summary

- Preserve `custom` tools nested inside Responses namespace declarations and lower them through each routed adapter with their flattened wire name.
- Resolve a bare namespaced `tool_choice` only when the logical name is unique in the complete request catalog, then restore that exact alias as a custom tool call.
- Carry tool kind per wire alias across streaming, buffered, image, and web-search bridges so same-named custom and function tools remain distinct while undeclared or ambiguous calls still fail closed.
- Reject wire-name and dotted-alias collisions instead of silently dropping one logical tool.
- No user-facing configuration or documentation contract changes.

## Verification

- Rebased onto `upstream/dev` `bcc77c0398cf565b9d00d10ef9bce8029b9e5be0`; current PR head is `1259c798b`.
- Focused parser, tool-conformance, adapter-conformance, reasoning, command-code, and tool-catalog tests: `158 pass`, `0 fail`.
- `./node_modules/.bin/bun run typecheck`
- `./node_modules/.bin/bun run privacy:scan`
- `git diff --check`
- Full `./node_modules/.bin/bun run test`: `13322 pass`, `15 skip`, `4 fail` across 846 files. The failures are unrelated to this change: the configured-catalog EACCES case cannot simulate unreadable files when run as root; the competing-OFF Codex sync race reproduces on the current dev baseline; and two timing-sensitive tests failed only during the heavily loaded 22-minute suite.
- Isolated follow-up runs passed `lab-live-pinned-timeouts.test.ts` and `codex-inject-write-lock.test.ts`; the native-residue file has only the expected root EACCES failure.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tool selection for namespaced tools, including uniquely identifiable bare names.
  - Prevented ambiguous tool names and wire-name collisions from being selected incorrectly.
  - Preserved namespaces and freeform metadata across tool calls, streaming responses, and replayed interactions.
  - Ensured custom and function tools with identical names remain distinct.
- **Tests**
  - Added coverage for namespaced tool selection, collisions, filtering, streaming, and response parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->