### PR TITLE
fix(windows): stop the service wrapper killer using the argv Bun rejects

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -2358,7 +2358,10 @@ function killWindowsServiceWrapperProcesses(): void {
       "} | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }",
     ].join(" ");
     spawnSync(resolveTrustedWindowsPowerShellExe(), [
-      "-NoProfile", "-NoLogo", "-NonInteractive", "-WindowStyle", "Hidden",
+      // No `-WindowStyle Hidden` here: Bun 1.3.14 can fail that direct CLI pair
+      // before the command runs (#1589). `windowsHide` below is what actually
+      // suppresses the console window, and it is sufficient.
+      "-NoProfile", "-NoLogo", "-NonInteractive",
       "-Command", ps,
     ], { stdio: "ignore", timeout: 5000, windowsHide: true });
   } catch { /* best-effort */ }

--- a/tests/windows-popup-fix.test.ts
+++ b/tests/windows-popup-fix.test.ts
@@ -9,6 +9,8 @@
  * and under a bounded timeout so a hung child cannot wedge those paths.
  */
 import { afterEach, describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 
 import { readProcessStartMsBatch } from "../src/codex/app-server-processes";
 import {
@@ -83,5 +85,49 @@ describe("Windows process-lookup popup fix (#1278)", () => {
     } else {
       expect(startedAtMs).toBeNull();
     }
+  });
+});
+
+describe("no direct PowerShell argv carries the Bun-incompatible window flag (#1589)", () => {
+  // src/codex/user-identity.ts records the invariant in prose: PowerShell's
+  // `-WindowStyle Hidden` CLI pair can fail under Bun 1.3.14 before the command
+  // runs, and process-level `windowsHide` is what actually suppresses the window.
+  // The prose held for the file that carried it and drifted everywhere else, so
+  // this sweeps the whole runtime instead of one file.
+  //
+  // Only the ARGV form is forbidden. Passing `-WindowStyle Hidden` inside a
+  // PowerShell script string (`Start-Process ... -WindowStyle Hidden`) is a
+  // different construct that Bun never parses, and six legitimate call sites
+  // rely on it.
+  const runtimeFiles = (dir: string): string[] => {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) out.push(...runtimeFiles(full));
+      else if (entry.name.endsWith(".ts")) out.push(full);
+    }
+    return out;
+  };
+
+  // "-WindowStyle" and "Hidden" as adjacent quoted argv elements, in either
+  // quote style, tolerating whitespace or a line break between them.
+  const FORBIDDEN_ARGV = /["']-WindowStyle["']\s*,\s*["']Hidden["']/;
+
+  const srcRoot = join(import.meta.dir, "..", "src");
+
+  test("no src/**/*.ts passes -WindowStyle Hidden as an argv pair", () => {
+    const offenders = runtimeFiles(srcRoot)
+      .filter(file => FORBIDDEN_ARGV.test(readFileSync(file, "utf8")))
+      .map(file => file.slice(srcRoot.length + 1).replaceAll("\\", "/"));
+    expect(offenders).toEqual([]);
+  });
+
+  test("the pattern accepts the script-string form and rejects the argv form", () => {
+    // Guard the guard: if this ever stops discriminating, the sweep above is
+    // either vacuous or about to fail six correct call sites.
+    expect(FORBIDDEN_ARGV.test('"-NonInteractive", "-WindowStyle", "Hidden",')).toBe(true);
+    expect(FORBIDDEN_ARGV.test("'-WindowStyle', 'Hidden'")).toBe(true);
+    expect(FORBIDDEN_ARGV.test('" -Verb RunAs -WindowStyle Hidden -PassThru -Wait;"')).toBe(false);
+    expect(FORBIDDEN_ARGV.test('"$startInfo.WindowStyle = [System.Diagnostics.ProcessWindowStyle]::Hidden"')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- `src/service.ts` spawned PowerShell with `"-WindowStyle", "Hidden"` as argv elements. `src/codex/user-identity.ts:222-224` already forbids exactly that: Bun 1.3.14 can fail the direct CLI pair before the command runs (#1589), and the process-level `windowsHide` flag is what actually suppresses the window.
- The call is not decorative. `stopServiceIfInstalled()` uses it because `schtasks /end` can leave the `wscript.exe`/`cmd.exe` wrapper alive to respawn the proxy, and it ignores `spawnSync`'s exit status. Under #1589 wrapper termination silently does nothing, so `ocx stop`, restart and update report success without sticking.
- The invariant survived as prose plus a single-file assertion. `tests/windows-deploy-close-regressions.test.ts:43` pins the argv only for `src/update/job.ts` (the variable is bound at line 13), so `service.ts` was never covered. Replaced with a sweep over every `src/**/*.ts`, which found exactly one offender.
- The sweep matches the **argv form only**. Six call sites legitimately pass `-WindowStyle Hidden` inside a PowerShell script string handed to `Start-Process` (`windows-elevation.ts` 622/660/687/736, `tray/windows.ts:489`, `update/job.ts:574`); Bun never parses those. A second test pins that discrimination in both directions so the sweep cannot quietly become vacuous or start failing correct code.

First of a stacked chain implementing `devlog/_plan/260817_windows_stability_program/` (phase `010`). This one targets `dev`.

## Verification

- Driven red first: the sweep reported `["service.ts"]` before the fix.
- `bun test tests/windows-popup-fix.test.ts` — 7 pass
- `bun test tests/service.test.ts tests/windows-deploy-close-regressions.test.ts` — 131 pass
- `bun run typecheck` — clean

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows service cleanup to prevent unwanted PowerShell compatibility issues.
  * Console windows remain hidden during background cleanup operations.

* **Tests**
  * Added regression coverage to ensure incompatible PowerShell arguments are not used directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->