### PR TITLE
feat(windows): count atomic-replace retries so the envelope can be argued from evidence

### DIFF
--- a/src/claude/agents-inject.ts
+++ b/src/claude/agents-inject.ts
@@ -236,7 +236,7 @@ export function syncClaudeAgentDefs(defs: readonly ClaudeAgentDef[], configDir =
       } catch { /* does not exist: ours to create */ }
       const tmp = `${target}.tmp-${process.pid}`;
       writeFileSync(tmp, renderAgentDef(def), { encoding: "utf8", mode: 0o644 });
-      renameAtomicFile(tmp, target);
+      renameAtomicFile(tmp, target, undefined, "claude-agents");
       written.push(def.file);
     }
     return written;

--- a/src/codex/prompt-journal.ts
+++ b/src/codex/prompt-journal.ts
@@ -83,7 +83,7 @@ export function durableWrite(path: string, content: string): void {
     // Windows can refuse the replace with EBUSY/EPERM/EACCES while a scanner
     // still holds the target; the shared helper retries that briefly. Losing
     // this publish breaks journal restore, so it should not fail on a blink.
-    renameAtomicFile(tmp, path);
+    renameAtomicFile(tmp, path, undefined, "prompt-journal");
     // The temp is renamed away: proven absent — release its ACL memos.
     forgetEphemeralSecretPath(tmp);
     fsyncDir(path);

--- a/src/lab/automation/config-persistence.ts
+++ b/src/lab/automation/config-persistence.ts
@@ -217,7 +217,7 @@ function writeConfigUnlocked(
     if (configCommitFaultForTests === "before_publish") {
       throw new LabAutomationError("synthetic automation config commit failure", "invalid_state");
     }
-    renameAtomicFile(tmp, path);
+    renameAtomicFile(tmp, path, undefined, "lab-automation");
     return normalized;
   } finally {
     if (fd !== null) closeSync(fd);

--- a/src/lab/automation/persistence.ts
+++ b/src/lab/automation/persistence.ts
@@ -125,7 +125,7 @@ function atomicWriteJson(path: string, payload: unknown): void {
   const tmp = join(dir, `.${basename(path)}.${process.pid}.${Date.now()}.tmp`);
   const text = JSON.stringify(payload);
   writeFileSync(tmp, text, { encoding: "utf8", mode: 0o600 });
-  renameAtomicFile(tmp, path);
+  renameAtomicFile(tmp, path, undefined, "lab-automation");
 }
 
 function basename(path: string): string {

--- a/src/lab/ledger/purge.ts
+++ b/src/lab/ledger/purge.ts
@@ -79,7 +79,7 @@ function atomicRewriteLedger(ledgerPath: string, events: LabEvent[]): void {
     } finally {
       closeSync(fd);
     }
-    renameAtomicFile(tmpPath, ledgerPath);
+    renameAtomicFile(tmpPath, ledgerPath, undefined, "lab-ledger");
     renamed = true;
   } catch (err) {
     if (!renamed) {

--- a/src/lib/config-ownership.ts
+++ b/src/lib/config-ownership.ts
@@ -235,7 +235,7 @@ function writeManifest(configDir: string, manifest: ConfigUninstallManifest): vo
     // Same Windows sharing-violation tolerance the config writer has: a
     // scanner holding the manifest must not turn uninstall bookkeeping into a
     // hard failure.
-    renameAtomicFile(temp, path);
+    renameAtomicFile(temp, path, undefined, "config-ownership");
   } catch (error) {
     try { unlinkSync(temp); } catch { /* best effort */ }
     throw error;

--- a/src/lib/windows-atomic-replace.ts
+++ b/src/lib/windows-atomic-replace.ts
@@ -19,6 +19,71 @@
 
 import { renameSync } from "node:fs";
 
+/**
+ * Which durable publisher retried. A closed union on purpose: the value is a
+ * label in a diagnostic surface, and a path-derived string could carry a
+ * username. The type is the enforcement — a path cannot be passed here without
+ * failing typecheck. (`privacy:scan` reads file text and cannot see a runtime
+ * value, so it is a backstop for the response body, not the guard.)
+ */
+export type ReplacePublisher =
+  | "config"
+  | "prompt-journal"
+  | "config-ownership"
+  | "claude-agents"
+  | "lab-automation"
+  | "lab-ledger"
+  | "storage-cleanup"
+  | "tray";
+
+/** The Windows error codes this module treats as a momentary hold. */
+export type ReplaceRetryCode = "EBUSY" | "EPERM" | "EACCES";
+
+export interface ReplaceRetryCounts {
+  /** Replaces that hit this code and were retried. */
+  retried: number;
+  /** Replaces that exhausted every retry and threw. */
+  exhausted: number;
+}
+
+/**
+ * Keyed by publisher AND code. The code is the diagnostic half: EBUSY from a
+ * scanner, EACCES from a permissions problem and EPERM from a lock are three
+ * different stories, and collapsing them would leave the counters unable to
+ * answer the question they exist for.
+ */
+const counters = new Map<string, ReplaceRetryCounts>();
+
+function counterKey(publisher: ReplacePublisher, code: ReplaceRetryCode): string {
+  return `${publisher}:${code}`;
+}
+
+function bump(
+  publisher: ReplacePublisher,
+  code: ReplaceRetryCode,
+  field: keyof ReplaceRetryCounts,
+): void {
+  const key = counterKey(publisher, code);
+  const current = counters.get(key) ?? { retried: 0, exhausted: 0 };
+  current[field] += 1;
+  counters.set(key, current);
+}
+
+/**
+ * Process-lifetime snapshot, keyed `publisher:CODE`. These reset on restart,
+ * which is fine: the question they answer is "does this ever fire at all", not
+ * "how often per hour".
+ */
+export function readWindowsReplaceRetryCounters(): Record<string, ReplaceRetryCounts> {
+  const out: Record<string, ReplaceRetryCounts> = {};
+  for (const [key, counts] of counters) out[key] = { ...counts };
+  return out;
+}
+
+/** Test-only: the counters are module state and cases must not leak into each other. */
+export function resetWindowsReplaceRetryCountersForTests(): void {
+  counters.clear();
+}
 export interface AtomicRenameIO {
   platform: NodeJS.Platform;
   rename: (source: string, destination: string) => void;
@@ -27,11 +92,17 @@ export interface AtomicRenameIO {
 
 const MAX_RETRIES = 2;
 
-/** Windows sharing violations only. Any other error is the caller's to see, immediately. */
-function isTransientWindowsReplaceError(platform: NodeJS.Platform, error: unknown): boolean {
-  if (platform !== "win32") return false;
+/**
+ * Windows sharing violations only, returning the code so the caller can record
+ * which one. Any other error is the caller's to see, immediately.
+ */
+function transientWindowsReplaceCode(
+  platform: NodeJS.Platform,
+  error: unknown,
+): ReplaceRetryCode | null {
+  if (platform !== "win32") return null;
   const code = (error as NodeJS.ErrnoException).code;
-  return code === "EBUSY" || code === "EPERM" || code === "EACCES";
+  return code === "EBUSY" || code === "EPERM" || code === "EACCES" ? code : null;
 }
 
 export function renameAtomicFile(
@@ -42,27 +113,42 @@ export function renameAtomicFile(
     rename: renameSync,
     sleep: Bun.sleepSync,
   },
+  publisher: ReplacePublisher = "config",
 ): void {
   for (let attempt = 0; ; attempt += 1) {
     try {
       io.rename(source, destination);
       return;
     } catch (error) {
-      if (!isTransientWindowsReplaceError(io.platform, error)) throw error;
-      if (attempt >= MAX_RETRIES) throw error;
+      const code = transientWindowsReplaceCode(io.platform, error);
+      if (!code) throw error;
+      if (attempt >= MAX_RETRIES) {
+        bump(publisher, code, "exhausted");
+        throw error;
+      }
+      bump(publisher, code, "retried");
       io.sleep(25 * (attempt + 1));
     }
   }
 }
 
-export async function renameAtomicFileAsync(source: string, destination: string): Promise<void> {
+export async function renameAtomicFileAsync(
+  source: string,
+  destination: string,
+  publisher: ReplacePublisher = "config",
+): Promise<void> {
   for (let attempt = 0; ; attempt += 1) {
     try {
       renameSync(source, destination);
       return;
     } catch (error) {
-      if (!isTransientWindowsReplaceError(process.platform, error)) throw error;
-      if (attempt >= MAX_RETRIES) throw error;
+      const code = transientWindowsReplaceCode(process.platform, error);
+      if (!code) throw error;
+      if (attempt >= MAX_RETRIES) {
+        bump(publisher, code, "exhausted");
+        throw error;
+      }
+      bump(publisher, code, "retried");
       await Bun.sleep(25 * (attempt + 1));
     }
   }

--- a/src/server/management/system-routes.ts
+++ b/src/server/management/system-routes.ts
@@ -27,6 +27,7 @@ import { getActiveTurnCount, isDraining } from "../lifecycle";
 import { getActiveMemoryWatchdog, observedMemoryCounter } from "../memory-watchdog";
 import { responseStateMetrics } from "../../responses/state";
 import { appOwnedBytesSnapshot } from "../../lib/app-owned-memory";
+import { readWindowsReplaceRetryCounters } from "../../lib/windows-atomic-replace";
 import {
   SYSTEM_RESTART_EXPECTED_PID_HEADER,
   parseExpectedSystemRestartPid,
@@ -115,6 +116,20 @@ export async function handleSystemRoutes(ctx: ManagementContext): Promise<Respon
     });
   }
 
+  /**
+   * Windows atomic-replace retry counters.
+   *
+   * A sibling route rather than a field on /api/system/memory: that payload is
+   * memory-shaped, and appending unrelated filesystem counters to it makes both
+   * harder to consume.
+   *
+   * Keys are `publisher:CODE` where publisher is a closed union
+   * (ReplacePublisher) and never a path — a path could carry a username. The
+   * type is what enforces that; a text scan cannot see a runtime value.
+   */
+  if (url.pathname === "/api/system/windows-replace-retries" && req.method === "GET") {
+    return jsonResponse({ counters: readWindowsReplaceRetryCounters() });
+  }
   if (url.pathname === "/api/system/restart" && req.method === "POST") {
     const expectedPid = parseExpectedSystemRestartPid(
       req.headers.get(SYSTEM_RESTART_EXPECTED_PID_HEADER),

--- a/src/storage/cleanup.ts
+++ b/src/storage/cleanup.ts
@@ -1091,7 +1091,7 @@ function writeSatelliteBackup(
     throw new Error("test_fail_satellite_backup_replace");
   }
   try {
-    renameAtomicFile(tmp, dest);
+    renameAtomicFile(tmp, dest, undefined, "storage-cleanup");
   } catch (error) {
     try { unlinkSync(tmp); } catch { /* */ }
     throw error;
@@ -2435,7 +2435,7 @@ function writeRestorePending(
     throw new Error("test_fail_pending_rename");
   }
   try {
-    renameAtomicFile(tmp, dest);
+    renameAtomicFile(tmp, dest, undefined, "storage-cleanup");
   } catch (error) {
     try { unlinkSync(tmp); } catch { /* */ }
     throw error;

--- a/src/tray/windows.ts
+++ b/src/tray/windows.ts
@@ -243,7 +243,7 @@ export function replaceWindowsTrayOwnedFile(
       const hardened = hardenSecretPath(target, { required: true, timeoutMemoKey: path });
       if (!hardened.ok) throw new Error("Windows tray ACL hardening did not complete; refusing to persist executable state.");
     },
-    rename: renameAtomicFile,
+    rename: (source, destination) => renameAtomicFile(source, destination, undefined, "tray"),
     unlink: unlinkSync,
   },
 ): void {

--- a/tests/system-routes.test.ts
+++ b/tests/system-routes.test.ts
@@ -1,0 +1,165 @@
+/**
+ * GET /api/system/windows-replace-retries.
+ *
+ * The Windows atomic replace retries EBUSY/EPERM/EACCES twice, about 75ms of
+ * tolerance in total. Both plan audits wanted that envelope widened; neither
+ * could show it failing in the field. These counters exist to answer that with
+ * evidence instead of intuition, so the endpoint's whole job is to report
+ * whether the retry path ever fires, and under which error.
+ *
+ * Scope note: the counters are process-local. A CI assertion that they stay
+ * zero across the suite would need a finalizer that aggregates many short-lived
+ * sharded processes, which does not exist. This file covers the route.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { handleManagementAPI } from "../src/server/management-api";
+import {
+  readWindowsReplaceRetryCounters,
+  renameAtomicFile,
+  resetWindowsReplaceRetryCountersForTests,
+  type ReplacePublisher,
+} from "../src/lib/windows-atomic-replace";
+import type { OcxConfig } from "../src/types";
+
+function config(): OcxConfig {
+  return {
+    port: 10100,
+    defaultProvider: "openai",
+    providers: {
+      openai: {
+        adapter: "openai-chat",
+        baseUrl: "https://api.example.test/v1",
+        apiKey: "sk-secret-value",
+        defaultModel: "gpt-test",
+      },
+    },
+  } as unknown as OcxConfig;
+}
+
+const url = "http://127.0.0.1:10100/api/system/windows-replace-retries";
+const get = (method = "GET") =>
+  new Request(url, { method, headers: { Host: "127.0.0.1:10100" } });
+
+/** A rename that fails `failures` times with `code`, then succeeds. */
+function flakyIo(failures: number, code = "EBUSY", platform: NodeJS.Platform = "win32") {
+  let seen = 0;
+  return {
+    platform,
+    rename: () => {
+      if (seen++ < failures) {
+        const error = new Error(code) as NodeJS.ErrnoException;
+        error.code = code;
+        throw error;
+      }
+    },
+    sleep: () => {},
+  };
+}
+
+afterEach(() => {
+  resetWindowsReplaceRetryCountersForTests();
+});
+
+describe("windows replace retry counters", () => {
+  test("a clean replace records nothing", () => {
+    renameAtomicFile("a", "b", flakyIo(0), "config");
+    expect(readWindowsReplaceRetryCounters()).toEqual({});
+  });
+
+  test("a transient sharing violation is counted under its own code", () => {
+    renameAtomicFile("a", "b", flakyIo(1, "EBUSY"), "prompt-journal");
+    expect(readWindowsReplaceRetryCounters()).toEqual({
+      "prompt-journal:EBUSY": { retried: 1, exhausted: 0 },
+    });
+  });
+
+  test("the three codes stay distinguishable", () => {
+    // EBUSY from a scanner, EACCES from permissions and EPERM from a lock are
+    // three different stories. Collapsing them would leave the counters unable
+    // to answer the question they exist for.
+    renameAtomicFile("a", "b", flakyIo(1, "EBUSY"), "config");
+    renameAtomicFile("a", "b", flakyIo(1, "EPERM"), "config");
+    renameAtomicFile("a", "b", flakyIo(1, "EACCES"), "config");
+    expect(readWindowsReplaceRetryCounters()).toEqual({
+      "config:EBUSY": { retried: 1, exhausted: 0 },
+      "config:EPERM": { retried: 1, exhausted: 0 },
+      "config:EACCES": { retried: 1, exhausted: 0 },
+    });
+  });
+
+  test("exhausting the envelope rethrows and is counted separately", () => {
+    expect(() => renameAtomicFile("a", "b", flakyIo(99), "config-ownership")).toThrow();
+    // Two retries then the throw: the envelope is 2, not unbounded.
+    expect(readWindowsReplaceRetryCounters()).toEqual({
+      "config-ownership:EBUSY": { retried: 2, exhausted: 1 },
+    });
+  });
+
+  test("a non-Windows error is not retried and not counted", () => {
+    expect(() => renameAtomicFile("a", "b", flakyIo(99, "ENOENT"), "config")).toThrow();
+    expect(readWindowsReplaceRetryCounters()).toEqual({});
+  });
+
+  test("POSIX never retries even on a matching code", () => {
+    expect(() => renameAtomicFile("a", "b", flakyIo(99, "EBUSY", "linux"), "config")).toThrow();
+    expect(readWindowsReplaceRetryCounters()).toEqual({});
+  });
+
+  test("publisher labels are a closed set, so a path can never become a key", () => {
+    // The union is the privacy enforcement: privacy:scan reads file text and
+    // cannot tell that a runtime string came from a path. If this list ever
+    // grows, it grows deliberately and in review.
+    const publishers: ReplacePublisher[] = [
+      "config",
+      "prompt-journal",
+      "config-ownership",
+      "claude-agents",
+      "lab-automation",
+      "lab-ledger",
+      "storage-cleanup",
+      "tray",
+    ];
+    for (const publisher of publishers) renameAtomicFile("a", "b", flakyIo(1), publisher);
+    expect(Object.keys(readWindowsReplaceRetryCounters()).sort()).toEqual([
+      "claude-agents:EBUSY",
+      "config-ownership:EBUSY",
+      "config:EBUSY",
+      "lab-automation:EBUSY",
+      "lab-ledger:EBUSY",
+      "prompt-journal:EBUSY",
+      "storage-cleanup:EBUSY",
+      "tray:EBUSY",
+    ]);
+    // @ts-expect-error a path is not a ReplacePublisher
+    renameAtomicFile("a", "b", flakyIo(0), "C:\\Users\\someone\\.opencodex");
+  });
+});
+
+describe("GET /api/system/windows-replace-retries", () => {
+  test("reports the snapshot", async () => {
+    renameAtomicFile("a", "b", flakyIo(1, "EACCES"), "config");
+    const res = await handleManagementAPI(get(), new URL(url), config());
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(200);
+    const body = await res!.json() as { counters: Record<string, { retried: number; exhausted: number }> };
+    expect(body.counters).toEqual({ "config:EACCES": { retried: 1, exhausted: 0 } });
+  });
+
+  test("an empty snapshot is an empty object, not an error", async () => {
+    const res = await handleManagementAPI(get(), new URL(url), config());
+    expect(res!.status).toBe(200);
+    expect(await res!.json()).toEqual({ counters: {} });
+  });
+
+  test("the route does not answer non-GET methods", async () => {
+    for (const method of ["POST", "PUT", "DELETE"]) {
+      const res = await handleManagementAPI(get(method), new URL(url), config());
+      // Unmatched by this route: either no management route claims it, or a
+      // different handler answers. Either way it must not return the snapshot.
+      if (res !== null && res.status === 200) {
+        expect(await res.json()).not.toHaveProperty("counters");
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Both plan audits wanted the 75ms retry envelope widened. Neither could show it failing in the field, and one explicitly declined to raise its severity for exactly that reason. Counting is the honest next step: if these stay at zero across a release the envelope is fine, and if they do not, the change cites numbers.
- Counters live beside the retry loop, keyed by which publisher retried, with separate `retried` and `exhausted` totals. Exposed as `GET /api/system/windows-replace-retries` — a **sibling** of `/api/system/memory` rather than a field on it, because that payload is memory-shaped and appending filesystem counters would make both harder to consume.
- The publisher label is a closed union (`ReplacePublisher`), and **that union is the privacy enforcement, not `privacy:scan`**. The scanner reads file text (`scripts/privacy-scan.ts:187`) and cannot tell that a runtime string came from a path — a path could carry a username. A closed union makes the same mistake a typecheck failure instead, which the new test pins with `@ts-expect-error`.
- Scope note, stated because the plan originally overreached here: these counters are **process-local**. Asserting they stay zero across the Windows suite would need a finalizer aggregating many short-lived sharded processes, which does not exist. Evidence comes from local runs and voluntary bug reports.
- `tests/system-routes.test.ts` is new; `handleSystemRoutes` coverage previously lived scattered in `memory-watchdog.test.ts` and `codex-restart-route.test.ts`.

Last of a stacked chain implementing `devlog/_plan/260817_windows_stability_program/` (phase `031`). Targets #1946; retarget to `dev` once the parents land.

## Verification

- `bun test tests/system-routes.test.ts` — 9 pass
- `bun run typecheck` — clean
- `bun run privacy:scan` — passed

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.