### PR TITLE
docs(devlog): record the Wave 5C Cursor outcome

### DIFF
--- a/devlog/_plan/260817_wave5_execution/070_wave5c_cursor.md
+++ b/devlog/_plan/260817_wave5_execution/070_wave5c_cursor.md
@@ -68,3 +68,29 @@ its CI could be judged. For #1900 the fork run was approved, waited to `complete
 
 `#1866` needs no decision here: it is an issue with no PR, and the structured Computer Use
 payload it describes is a design task rather than a merge.
+## WP7 outcome
+
+| PR | Outcome | Evidence |
+|----|---------|----------|
+| #1900 | merged | `2b12521ee` — CI success 01:12:10Z, merged 01:15:18Z |
+| #1895 | merged via #1951 | its blocking review finding fixed on top of its commits |
+| #1951 | merged | `93e521c80` — CI success 01:33:45Z, merged 01:37:50Z |
+| #1953 | merged | `9eb3a101a` — CI success 01:57:51Z, merged 01:59:12Z |
+| #1887 | **held** | must migrate five items into #1896 first; closing it as superseded would delete the catalog-derived guard |
+| #1896 | **held** | needs #1887's `cursorNativeExecUsesCodeModeBridge` before it can be canonical |
+| #1903 | **held** | conflicts alone on `dev`; needs an author rebase, and is a ~32-file review surface |
+| #1866 | **not started** | no PR exists; explicitly scoped out of #1900 |
+
+**The defect I introduced and the audit caught.** #1951 fixed #1895's blocker — code mode is
+decided from `freeform` metadata rather than the name `exec` — but my port of the shell-bridge
+predicate dropped the Cursor original's `!tool.namespace` requirement. A namespaced MCP tool
+(`mcp__docker__exec_command`) then cancelled code mode on a genuine code-mode turn, silently
+stripping the guidance. It failed *safe* — generic rather than false guidance — which is exactly
+why nothing caught it, and why an audit that runs the predicate against adversarial catalogs
+beats one that reads it. Fixed in #1953, driven red first.
+
+A second reviewer then probed ten catalog shapes — empty-string namespace, non-boolean truthy
+`freeform`, mixed namespaced and bare bridges — and found no remaining misclassification. Worth
+recording one behavior it judged correct: when `tool_choice` forces `exec`, a catalog holding
+both a freeform `exec` and a bare `exec_command` still classifies as code mode, because the
+bridge is filtered out of visibility first. Naming an unreachable tool would be the worse answer.

--- a/devlog/_plan/260817_wave5_execution/080_wave5d_antigravity.md
+++ b/devlog/_plan/260817_wave5_execution/080_wave5d_antigravity.md
@@ -1,5 +1,11 @@
 # WP8 — Wave 5D: Antigravity fingerprint and discovery
 
+> **Read the two correction sections below before the original text.** The order and the
+> #1836 disposition in this header were both overturned during execution: the real order is
+> `#1891 → #1897 → #1889` for merge-cleanliness but **`#1889` must land first** for
+> correctness, and #1836 was already closed. The original text is left standing as the record
+> of what changed.
+
 ```
 #1889 → #1891 → #1897   (then close #1836 as superseded)
 ```

--- a/devlog/_plan/260817_wave5_execution/090_wave6_closeout.md
+++ b/devlog/_plan/260817_wave5_execution/090_wave6_closeout.md
@@ -76,3 +76,31 @@ of them:
 
 Neither is affected by the close-on-dev-merge decision: both are blocked *before* merge, so the
 policy that governs when a merged fix closes its issue never reaches them.
+## WP9 gate result
+
+Run on the promotion candidate (local `dev`, 6 commits ahead of `origin/dev` at the time):
+
+| Gate | Result |
+|------|--------|
+| `bun test --isolate tests` | **12805 pass, 10 skip, 0 fail**, 159382 expect() calls across 826 files (452s) |
+| `bun run typecheck` | clean |
+| `bun run privacy:scan` | passed |
+
+### What actually closed, under the close-on-dev-merge decision
+
+| Closed | Landed via |
+|--------|-----------|
+| #1894 | #1739 through PR #1921 |
+| #1843 | #1860, already released in v2.24.0 |
+| #1899 | superseded by the ordering assertion in PR #1923 |
+
+Everything else stayed open, and none of it for release-timing reasons — which is the point
+worth making about the policy change. It removed a gate that was never what held these back.
+
+### Promotion state
+
+`dev` carries nine merged PRs from this campaign. `preview` and `main` are both behind it, and
+`dev`'s own hosted CI has no completed green run on its current head — the runs at `2b12521ee`
+and `aca3c0241` were both cancelled by supersession as later merges landed. The local full
+suite above is the evidence that exists; a hosted run on the exact promotion head is the
+evidence that does not, and promotion should carry that distinction rather than bury it.


### PR DESCRIPTION
## Summary

Devlog-only. Records the Wave 5C Cursor phase: three PRs landed, four held.

The part worth reading is a defect I introduced and an audit caught.

#1951 fixed #1895's blocking review finding — code mode is now decided from `freeform` tool
metadata rather than from the name `exec`, so a structured `exec`, or an `exec` beside a shell
bridge, is no longer told it takes JavaScript. But my port of the shell-bridge predicate dropped
the Cursor original's `!tool.namespace` requirement. A namespaced MCP tool
(`mcp__docker__exec_command`) then cancelled code mode on a genuine code-mode turn, silently
stripping the guidance.

It failed **safe** — generic guidance rather than false guidance — which is exactly why nothing
caught it, and why an audit that *runs* the predicate against adversarial catalogs beats one that
reads it. #1953 restores the guard, driven red first; a second reviewer then probed ten catalog
shapes (empty-string namespace, non-boolean truthy `freeform`, mixed namespaced and bare bridges)
and found no remaining misclassification.

**#1887 is no longer being closed as superseded.** The plan said to consolidate it into #1896 and
drop it. That would have deleted `cursorNativeExecUsesCodeModeBridge`, which derives bridge names
from the advertised catalog — while #1896's `codeModeBridgeGuidance` hardcodes them on a boolean.
That is the same defect #1895 exists to remove, so the consolidation is now a **migration** with
five named items on both PRs.

Also corrected: my explanation of the simulated merge conflict. I wrote that #1887 conflicts
because of #1896; isolation shows it needs #1900 **and** #1895 together, and lands in
`tool-definitions.ts`.

## Verification

- `bun test` across `tool-catalog-nudge`, `cursor-tool-definitions`, `cursor-hardening`, `responses-parser` — **103 pass, 0 fail**.
- `bun run typecheck` — passed.
- All three merges are ancestors of `origin/dev`, each merged only after its CI reported `completed/success` on the exact head.

## Checklist

- [x] Tests added or updated — n/a, devlog only
- [x] Docs updated
- [x] No credentials, request bodies, or account identifiers logged
- [x] Targets `dev`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project execution records with the latest work-item outcomes and merge sequencing requirements.
  * Documented a correction to tool cancellation behavior and confirmed additional catalog checks found no remaining misclassification.
  * Added gate results covering tests, type checks, privacy scans, issue closure decisions, and promotion status.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->