### PR TITLE
fix(test): sanitize both shim recursion-guard variables

### DIFF
--- a/devlog/_plan/260817_wave5_execution/080_wave5d_antigravity.md
+++ b/devlog/_plan/260817_wave5_execution/080_wave5d_antigravity.md
@@ -217,3 +217,32 @@ That is also the honest answer to "is the sponsorship refusal over-cautious": I 
 because reviewing *someone else's* auth change is the maintainer act the label records — but a
 one-line auth fix I wrote and verified myself is exactly the case where a maintainer sponsors
 their own work, so it ships.
+### #1891 landed after all
+
+The hold expired four minutes after I wrote it. The gate bot marked #1891 `review-ready` at
+02:10:50Z — the author rebased onto `9eb3a101a` and ticked all four boxes — so the checklist
+block described above and in my PR comments was accurate when posted and false shortly after.
+
+Merged as `5c66ad205`, verified as an ancestor of `origin/dev`. No file overlap with #1955
+(`src/adapters/` vs `src/oauth/`), so nothing conflicted.
+
+Wave 5D final state: **#1897 and #1891 and the #1955 fix landed; #1889 alone remains**, blocked
+on maintainer sponsorship of an auth surface.
+
+### Full-suite result and the one failure
+
+`bun test --isolate tests` on the merged tree: **12805 pass, 10 skip, 1 fail** across 826 files.
+
+The failure is `Codex autostart shim > Unix shim permits a real Codex process to start a new
+child invocation`, failing with `status 126` — permission denied on exec. It is **environmental
+and pre-existing**, established three ways rather than assumed:
+
+1. it reproduces solo, so it is not cross-test interference;
+2. it fails identically at the campaign baseline `1208bd25c`, which predates every change in
+   this campaign;
+3. all four `test 1/4..4/4` shards passed in the dev CI run for `9eb3a101a`.
+
+The test writes a shim into a temp directory, `chmod 0755`s it, and `spawnSync`s it. 126 is the
+shell's "found but not executable" — this sandbox blocks execution from that path. Recording it
+rather than skipping it: the right fix is an environment note, not a test change, and it is
+outside this campaign's scope.

--- a/devlog/_plan/260817_wave5_execution/080_wave5d_antigravity.md
+++ b/devlog/_plan/260817_wave5_execution/080_wave5d_antigravity.md
@@ -242,7 +242,23 @@ and pre-existing**, established three ways rather than assumed:
    this campaign;
 3. all four `test 1/4..4/4` shards passed in the dev CI run for `9eb3a101a`.
 
-The test writes a shim into a temp directory, `chmod 0755`s it, and `spawnSync`s it. 126 is the
-shell's "found but not executable" — this sandbox blocks execution from that path. Recording it
-rather than skipping it: the right fix is an environment note, not a test change, and it is
-outside this campaign's scope.
+**Correction — I had the mechanism wrong, and a reviewer traced the real one.** I wrote that 126
+was the shell's "found but not executable" and that this sandbox blocks execution from a temp
+path. Neither is true: a `chmod 755` script in `mktemp -d` runs fine here, and `/var/folders` is
+not mounted `noexec`.
+
+126 is **opencodex's own recursion-guard sentinel**. This shell exports
+`OCX_SHIM_ACTIVE_DEPTH=1` and `OCX_SHIM_ACTIVE_PID`, because the session itself was launched
+through an installed Codex shim. The test deleted only the pid, so the outer shim started at
+depth 1 instead of 0, the child re-entry reached depth 2, and the guard fired with its
+launcher-loop message — the shim behaving exactly as designed, on a test that meant to start
+from a clean slate. CI is green because CI has no shimmed ancestor, which is what made the
+failure look environmental rather than under-sanitized.
+
+So the fix is a one-line test change, not an environment note: `delete env.OCX_SHIM_ACTIVE_DEPTH`
+beside the existing pid deletion. Left alone it stays red for every developer running the suite
+under an installed shim. Fixed here; the suite is now **12806 pass, 0 fail** locally.
+
+Worth keeping as the lesson: "environmental" was the right disposition and the wrong
+explanation, and a plausible-sounding mechanism in a durable devlog is exactly what misleads
+whoever hits this next.

--- a/tests/codex-shim.test.ts
+++ b/tests/codex-shim.test.ts
@@ -1043,7 +1043,14 @@ printf '%s\\n' child-codex
       chmodSync(realCodexPath, 0o755);
       chmodSync(shimPath, 0o755);
       const env = { ...process.env, OCX_SHIM_BYPASS: "1" };
+      // Both recursion-guard variables, not just the pid. A developer running this suite from a
+      // shell that was itself launched through an installed shim inherits
+      // OCX_SHIM_ACTIVE_DEPTH=1, so the outer shim starts at depth 1, the child re-entry lands on
+      // depth 2, and the guard exits 126 with the launcher-loop message — the shim behaving
+      // exactly as designed, on a test that meant to start from a clean slate. CI never sees it
+      // because CI has no shimmed ancestor, which is what made this look environmental.
       delete env.OCX_SHIM_ACTIVE_PID;
+      delete env.OCX_SHIM_ACTIVE_DEPTH;
 
       const result = spawnSync(shimPath, ["--help"], {
         encoding: "utf8",


### PR DESCRIPTION
## Summary

One test fix plus the Wave 5D record.

**The test fix.** `tests/codex-shim.test.ts` deleted `OCX_SHIM_ACTIVE_PID` from the child
environment but inherited `OCX_SHIM_ACTIVE_DEPTH` from the parent. Anyone running the suite from
a shell that was itself launched through an installed Codex shim carries `DEPTH=1`, so the outer
shim starts at depth 1 rather than 0, the child re-entry lands on depth 2, and the recursion
guard exits 126 with its launcher-loop message.

The shim was behaving exactly as designed. The test was starting from a slate it believed was
clean. CI never sees it because CI has no shimmed ancestor — which is precisely what made it look
like a machine quirk rather than an under-sanitized test.

Production code already does the right thing here: `probeUnixShimInstall` deletes `PID`, `DEPTH`
and `PROBE_ACTIVE` before spawning its probe. This brings the test in line with the runtime's own
practice.

I first recorded the cause as "the sandbox blocks execution from a temp path." That was wrong —
a `chmod 755` script in `mktemp -d` runs fine, and `/var/folders` is not `noexec` — and a reviewer
traced the real mechanism. The devlog carries the correction, because a plausible-sounding wrong
explanation in a durable record is worse than none.

**Wave 5D record.** #1897 had already merged and #1836 was already closed before the phase ran.
#1891 landed (`5c66ad205`) once its author rebased and ticked its checklist. #1889 remains blocked
on maintainer sponsorship of `src/oauth/` — a label that records a security review, so not one an
agent should apply to unblock a merge.

## Verification

- `bun test tests/codex-shim.test.ts` — **69 pass, 0 fail** (was 68/1).
- Full suite on the merged tree before this fix: 12805 pass, 10 skip, 1 fail — that one failure.
- Pre-existing confirmed three ways: reproduces solo, fails identically at the campaign baseline `1208bd25c`, and all four shards pass in dev CI run `32090176020`.

## Checklist

- [x] Tests added or updated
- [x] Docs updated — devlog records the outcome and the corrected mechanism
- [x] No credentials, request bodies, or account identifiers logged
- [x] Targets `dev`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Unix shim test that could incorrectly report launcher recursion when inherited environment settings were present.
  * Improved test isolation by clearing recursion-guard state before child-process execution.

* **Tests**
  * Updated full-suite results: 12,806 tests passing, 10 skipped, with no failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->