### PR TITLE
docs(devlog): final Wave 5 campaign record, including its own errors

### DIFF
--- a/devlog/_plan/260817_wave5_execution/090_wave6_closeout.md
+++ b/devlog/_plan/260817_wave5_execution/090_wave6_closeout.md
@@ -243,12 +243,22 @@ targeting the default branch. Every campaign PR targets `dev`, so none of them c
 CodeQL feedback at all — verified: `refs/pull/1959/head` and `refs/pull/1963/head` have analyses
 because they target `main`, while the `preview`-targeting pair have zero.
 
-The actual root cause is duller and more useful: **`dev` is scanned on push, and nobody read
-the result.** It carries 84 open alerts against `main`'s 71. The finding was observable on the
-integration branch from the moment #1897 merged until promotion, and no step in this campaign
-ever looked. CodeQL is structurally absent from the `dev` PR flow *and* the post-merge alert
-list is not part of anyone's gate — those are two different holes, and I named neither the
-first time.
+**Second attempt, also wrong.** I then wrote that `dev` is scanned on push and nobody read the
+result. Both halves are false: `dev`'s most recent analysis is `02abe0afa` from 2026-08-15,
+default setup runs on a *weekly* schedule, and `0be660a2e` is not an ancestor of that commit —
+so the code was never in a `dev` scan at all. Its 84 alerts are stale, not current, which is the
+opposite of what I claimed they showed. Alert #87's only instances are `refs/heads/main` and
+`refs/pull/1959/head`. "Nobody read it" described a page that never displayed it.
+
+**The actual missed signal, third time.** `github-advanced-security[bot]` posted the finding as
+an inline review comment on **#1959** at `src/providers/antigravity-models.ts:273` at
+**02:38:08Z**. #1963 promoted at **02:55:04Z**. It was sitting on a promotion PR, in the review
+thread, for **17 minutes** before the code reached `main` — and I was actively editing that PR's
+description during the window. Not a coverage gap. I did not look at the review comments on a
+PR I was in the middle of rewriting.
+
+Three explanations for one mistake, the first two of which blamed infrastructure. The third is
+the one that is true and the least comfortable.
 
 Severity in context: the input is a configured `baseUrl`, so exploitation needs a hostile or
 careless config rather than attacker-controlled traffic. Worth fixing, not urgent. Separately,
@@ -267,7 +277,7 @@ edge cases (empty string, all-slashes, no trailing slash, interior slashes).
 
 **The root cause is a process one and belongs in the record.** #1897 merged on local focused
 tests plus `tsc`. That substitutes for CI on the axis it covers — behavior — and silently skips
-the axis it does not: static analysis. Waiting for full CI would have surfaced this before it
+the axis it does not: static analysis. ~~Waiting for full CI would have surfaced this before it~~
 reached `main`. The instruction for this run was to stop waiting on per-PR CI and gate once at
 the end, which is a reasonable trade for speed; the honest accounting is that it traded away
 exactly this class of finding, and the end-gate I ran (`bun test`, `typecheck`, `privacy:scan`)


### PR DESCRIPTION
## Summary

Final record for the Wave 5 campaign. Devlog-only.

Most of this document is a list of things I got wrong and how they were caught, which is the
part worth keeping. The campaign ran nine PABCD work-phases with an independent adversarial
review at each gate, and the reviews found more than I did.

### The corrections that mattered

- **#1891 was on the promotion head while three artifacts said it was excluded.** I had held it,
  it merged afterwards, and my record described my decision rather than the branch.
- **A campaign PR introduced a high-severity CodeQL alert** — `js/polynomial-redos` via #1897 —
  and I told an approver "nothing in this campaign introduced them."
- **Three wrong PR counts**, then a claim to have stopped counting while the count was still in
  the document.
- **The `ide_version` fix was #1955, not #1957** — I credited a documentation-only PR.
- **Three different root causes** for the missed alert. The first two blamed infrastructure. The
  third is true: the bot posted it as an inline review comment on #1959 at 02:38:08Z, promotion
  happened at 02:55:04Z, and I was editing that PR's description during the seventeen minutes
  in between without reading its review thread.

### What the campaign actually changed

Wave 5A–5D landed on `dev` and reached `main`: the Gemini wire-id opt-out, the Windows
fail-closed process query, destination-scoped signature replay, ordered writer-hardening
assertions, Cursor transport gates, Antigravity discovery, and more. Two issues closed, both
with ancestry evidence. Ten stayed open, none for release-timing reasons.

Three PRs were deliberately held rather than landed — **#1889** and **#1888** need
`maintainer-sponsored`, which is the record that a security review happened rather than a label
an agent should apply to unblock itself, and **#1903** needs a rebase.

## Verification

- `bun test --isolate tests` — 12805 pass, 10 skip, 0 fail across 826 files.
- `bun run typecheck` clean, `bun run privacy:scan` passed.
- Every claim in this document was re-verified by an independent reviewer; the ones that failed
  verification are recorded as failures rather than removed.

## Checklist

- [x] Tests added or updated — n/a, devlog only
- [x] Docs updated
- [x] No credentials, request bodies, or account identifiers logged
- [x] Targets `dev`
