### PR TITLE
[WRONG BRANCH] release: v2.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitkyc08/opencodex",
-  "version": "2.24.2",
+  "version": "2.25.0",
   "description": "Universal provider proxy for OpenAI Codex & Claude Code — use any LLM with Codex CLI/App/SDK and Claude Code",
   "type": "module",
   "main": "./bin/package-main.mjs",


### PR DESCRIPTION
## Summary

Version bump for the stable channel release `2.25.0`.

Bumps `package.json` only. The code is the RC promoted in #2001
(`314f3edbf30333b64e63ec96b4e7349d2c7d2406`).

Cut as a minor rather than a patch: the externally observable behaviour of a failed turn
changed. A turn that previously came back `completed` with a vanished tool call now
reports `failed` with a truncation error, and an unrequested CANCEL is now a typed
transport failure instead of a silent return.

## Verification

Gates were run against the RC tree in a dedicated clean worktree:

- `bun x tsc --noEmit` — exit 0
- `bun run privacy:scan` — Privacy scan passed
- `bun run audit:high` — No vulnerabilities found (root and gui)
- `bun test --isolate tests` — 12875 pass, 10 skip, 0 fail

The Release workflow independently requires a successful push-event Cross-platform CI run
and a successful Service lifecycle run at this merge commit before it will publish.

## Checklist

- [x] Version moves the latest channel forward (npm latest is 2.24.2)
- [x] Tag `v2.25.0` is unused
- [x] Only `package.json` changes
- [x] Preview released from the same RC



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application release version to 2.25.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->