### PR TITLE
fix(tools): repair bare integers in string-declared tool arguments

### DIFF
--- a/src/lib/tool-argument-integers.ts
+++ b/src/lib/tool-argument-integers.ts
@@ -1,4 +1,7 @@
-// Schema-aware repair for integer tool arguments that arrive as floats (issue #1611).
+// Schema-aware repair for tool arguments whose serialized representation disagrees
+// with the declared schema in a way that has exactly one faithful reading.
+//
+// Case 1 — integer fields arriving as integral floats (issue #1611).
 //
 // Grok serializes integer tool-call arguments through a float representation, so
 // `yield_time_ms: 120000` leaves the provider as `120000.0`. Codex declares those
@@ -15,7 +18,23 @@
 //     `120000.0` has exactly one integer reading, so it is repaired;
 //   - `1.5` in an integer field is a genuine disagreement with the schema and is left
 //     alone so it still fails, rather than being truncated into a plausible lie.
-// Anything without a declared `integer` type is never touched.
+//
+// Case 2 — string fields arriving as bare integers (issue #1938).
+//
+// Cursor-served models emit `{"cell_id": 4}` where the schema declares
+// `{"type": "string"}`. Codex rejects the call before the tool runs (invalid type:
+// integer `4`, expected a string), and the model never self-corrects, so every such
+// call is a hard failure loop. A safely-integral JSON number in a string-declared
+// field has exactly one faithful string reading (`4` -> `"4"`), so it is repaired
+// under the same intent boundary:
+//   - only when the field declares `string` and no numeric type (a
+//     `["integer","string"]` union accepts the number as-is and is left alone);
+//   - a non-integral number (`4.5`) in a string field is a genuine disagreement and
+//     is left alone so it still fails;
+//   - beyond 2^53-1 the parsed value may differ from the serialized text, so the
+//     original bytes stay.
+//
+// Anything without a declared `integer`/`string` type is never touched.
 
 /** JSON Schema subset we need; provider tool schemas are untrusted input. */
 type SchemaNode = Record<string, unknown>;
@@ -31,6 +50,21 @@ function declaresInteger(schema: SchemaNode): boolean {
   const type = schema.type;
   if (type === "integer") return true;
   return Array.isArray(type) && type.includes("integer");
+}
+
+/** True when the node declares `string`, including `["string","null"]` unions. */
+function declaresString(schema: SchemaNode): boolean {
+  const type = schema.type;
+  if (type === "string") return true;
+  return Array.isArray(type) && type.includes("string");
+}
+
+/** True when the node accepts a JSON number (`integer` or `number`), so a numeric
+ * value is already schema-valid and must not be rewritten into a string. */
+function declaresNumeric(schema: SchemaNode): boolean {
+  const type = schema.type;
+  if (type === "integer" || type === "number") return true;
+  return Array.isArray(type) && (type.includes("integer") || type.includes("number"));
 }
 
 /**
@@ -91,8 +125,17 @@ function coerceValue(value: unknown, schema: SchemaNode | undefined, root: Schem
 
   if (typeof value === "number") {
     if (!resolved) return { value, changed: false };
-    const integerDeclared = declaresInteger(resolved)
-      || compositionBranches(resolved).some(declaresInteger);
+    const branches = compositionBranches(resolved);
+    const integerDeclared = declaresInteger(resolved) || branches.some(declaresInteger);
+    if (!integerDeclared && safelyIntegral(value)) {
+      // Issue #1938: a bare integer in a string-only field has exactly one faithful
+      // string reading. A field that also accepts a numeric type keeps the number.
+      const stringDeclared = declaresString(resolved) || branches.some(declaresString);
+      const numericDeclared = declaresNumeric(resolved) || branches.some(declaresNumeric);
+      if (stringDeclared && !numericDeclared) {
+        return { value: String(value), changed: true };
+      }
+    }
     // Not an integer field, already an integer, non-integral, or unrepresentable:
     // in every one of those cases the received value is the right thing to keep.
     if (!integerDeclared || !safelyIntegral(value)) return { value, changed: false };
@@ -141,8 +184,9 @@ export function coerceIntegerToolArguments(
   parameters: Record<string, unknown> | undefined,
 ): string {
   if (!parameters || !args) return args;
-  // Cheap reject: a payload with no fractional-looking number cannot need repair.
-  if (!/\d\.\d/.test(args)) return args;
+  // Cheap reject: a payload with no digit cannot need either repair (integral-float
+  // -> integer, or bare-integer -> string).
+  if (!/\d/.test(args)) return args;
   let parsed: unknown;
   try {
     parsed = JSON.parse(args);

--- a/tests/tool-argument-integers.test.ts
+++ b/tests/tool-argument-integers.test.ts
@@ -191,3 +191,71 @@ describe("#1611 wiring: bridge emits repaired arguments", () => {
     expect(done?.data.arguments).toBe('{"n":7.0}');
   });
 });
+
+/** The code-mode wait shape from the #1938 report: cell_id declared string. */
+const WAIT_SCHEMA = {
+  type: "object",
+  properties: {
+    cell_id: { type: "string" },
+    yield_time_ms: { type: "integer" },
+    max_tokens: { type: "integer" },
+    label: { type: ["string", "null"] },
+    loose: { type: ["integer", "string"] },
+  },
+};
+
+describe("bare-integer-for-string tool argument repair (#1938)", () => {
+  test("repairs the exact call cursor/gpt-5.6-sol emitted in the report", () => {
+    // invalid type: integer `4`, expected a string — 19/19 wait calls rejected
+    expect(coerceIntegerToolArguments('{"cell_id":4,"yield_time_ms":10000}', WAIT_SCHEMA))
+      .toBe('{"cell_id":"4","yield_time_ms":10000}');
+  });
+
+  test("repairs a string-or-null union field", () => {
+    expect(coerceIntegerToolArguments('{"label":12}', WAIT_SCHEMA))
+      .toBe('{"label":"12"}');
+  });
+
+  test("a union that also accepts a numeric type keeps the number", () => {
+    const clean = '{"loose":4}';
+    expect(coerceIntegerToolArguments(clean, WAIT_SCHEMA)).toBe(clean);
+  });
+
+  test("a non-integral number in a string field is not manufactured into a string", () => {
+    const clean = '{"cell_id":4.5}';
+    expect(coerceIntegerToolArguments(clean, WAIT_SCHEMA)).toBe(clean);
+  });
+
+  test("a value beyond 2^53-1 keeps its original bytes", () => {
+    const clean = '{"cell_id":18446744073709551615}';
+    expect(coerceIntegerToolArguments(clean, WAIT_SCHEMA)).toBe(clean);
+  });
+
+  test("a real string stays untouched and bytes are preserved", () => {
+    const clean = '{"cell_id":"4","yield_time_ms":10000}';
+    expect(coerceIntegerToolArguments(clean, WAIT_SCHEMA)).toBe(clean);
+  });
+
+  test("both repairs compose in one payload", () => {
+    expect(coerceIntegerToolArguments('{"cell_id":4,"yield_time_ms":120000.0}', WAIT_SCHEMA))
+      .toBe('{"cell_id":"4","yield_time_ms":120000}');
+  });
+
+  test("nested objects and arrays repair against their declared schemas", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        page: { type: "object", properties: { id: { type: "string" } } },
+        tags: { type: "array", items: { type: "string" } },
+      },
+    };
+    expect(coerceIntegerToolArguments('{"page":{"id":7},"tags":[1,2]}', schema))
+      .toBe('{"page":{"id":"7"},"tags":["1","2"]}');
+  });
+
+  test("an integer field arriving as an integer is never stringified", () => {
+    const clean = '{"yield_time_ms":10000}';
+    expect(coerceIntegerToolArguments(clean, WAIT_SCHEMA)).toBe(clean);
+  });
+});
+


### PR DESCRIPTION
## Summary

A JSON integer emitted where the tool schema declares `string` passed through the bridge untouched, so Codex rejected the call before the tool ran (`invalid type: integer 4, expected a string`). In the #1938 report this made code-mode `wait` unusable through `cursor/gpt-5.6-sol`: 19/19 calls rejected across three sessions, with the model never self-correcting — a hard failure loop, same shape as #1611.

This extends the existing schema-aware repair in `src/lib/tool-argument-integers.ts` to the mirror case:

- a safely-integral JSON number in a **string-only** declared field is re-serialized as its single faithful string reading (`4` → `"4"`), including `["string","null"]` unions;
- a union that also accepts a numeric type (`["integer","string"]`) keeps the number — it is already schema-valid;
- a non-integral number (`4.5`) in a string field is left alone so it still fails honestly;
- values beyond 2^53-1 keep their original bytes (parsed value may differ from serialized text);
- unaffected payloads keep their exact bytes (function returns the original string when nothing changed).

Both repairs compose in one payload (`{"cell_id":4,"yield_time_ms":120000.0}` → `{"cell_id":"4","yield_time_ms":120000}`), and both bridge call sites get the behavior for free since they already run `coerceIntegerToolArguments`.

Closes #1938

## Verification

- `bun test tests/tool-argument-integers.test.ts` — 24 pass / 0 fail (9 new #1938 regression tests: the exact `cell_id` reproduction, string-or-null union, numeric-union preservation, non-integral rejection, 2^53 boundary, byte preservation, composed repair, nested object/array schemas, integer-field non-stringification)
- `bun test tests/tool-argument-integers.test.ts tests/bridge-lifecycle.test.ts` — 39 pass / 0 fail
- `bun x tsc --noEmit` — clean

## Checklist

- [x] Focused regression tests added next to the existing #1611 suite
- [x] Typecheck green
- [x] No user-facing docs change needed (transparent wire repair, same contract as #1611)
- [x] No GUI change (no screenshot required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool arguments with safely integral numeric values are now correctly converted to strings when required by the schema.
  * Preserved numeric values for numeric fields, non-integral values, unsafe integers, and existing strings.
  * Improved handling for nullable fields, nested objects, arrays, and combined string/integer repairs.

* **Tests**
  * Added coverage for numeric-to-string conversion and related edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->