### PR TITLE
docs(devlog): release-readiness record for the next train (2.26.0)

### DIFF
--- a/devlog/_plan/260818_release_readiness_2260/000_delta_inventory.md
+++ b/devlog/_plan/260818_release_readiness_2260/000_delta_inventory.md
@@ -1,0 +1,23 @@
+# 000 — Delta inventory since v2.25.0 (main e97fb2621)
+
+Snapshot 2026-08-18. Audited range: origin/main (e97fb2621, v2.25.0) ..
+origin/dev. Audit began at tip `b04cd26e7`; the audit itself produced one
+more merge (#2010, fixes), making the certified tip `fe3bbad97`.
+
+## Landed since the v2.25.0 cut
+
+| Train | PRs | Area |
+|---|---|---|
+| Cursor prompt-injection fix | #1997 | assistant-role tool-result replay, hide-from-user prose removed |
+| Codex pool plan | #1998 | JWT chatgpt_plan_type re-derivation between WHAM refreshes |
+| Windows stack | #1944 #1945 #1946 #1947 #1949 | argv fix, wrapper-killer scoping, shared atomic-replace, retry counters, program unit |
+| FastWire | #1893 (A1) #1965 (B1, absorbs B0 #1956) #1904 | capability/policy resolution, per-attempt observability, chat tier forwarding |
+| Singles | #2005 #1941 #1928 | string-coercion repair (#1938), Grok Responses backend, codex_work_desktop recovery |
+| Docs | #2004 #2006 #2008 | release record, devlog _fin moves, merge-campaign ledger |
+| Audit fixes | #2010 | three blocking regressions found by this campaign (see 010) |
+
+Issue closures riding this delta: #1992 #1989 #1938 (+ triage-campaign
+closures recorded in the merge-campaign unit).
+
+Held: #1885 (xAI Priority) behind the #1875 B2 pricing gate.
+

--- a/devlog/_plan/260818_release_readiness_2260/010_audit_results.md
+++ b/devlog/_plan/260818_release_readiness_2260/010_audit_results.md
@@ -1,0 +1,56 @@
+# 010 — Hard-audit results
+
+Four read-only grok-4.6 audit workers + two gpt-5.6-sol design reviewers +
+full local/remote gates, run against tip `b04cd26e7`. The audit found
+**three release-blocking regressions**, all introduced by same-day merges and
+all fixed in **PR #2010** (merged `fe3bbad97`).
+
+## Blocking findings (fixed)
+
+1. **Keep-alive re-arm (from #1941).** The comment-line SSE keep-alive never
+   re-arms codex-rs's event-level idle timer (110 RCA already proved this).
+   Fixed: typed `response.heartbeat` default restored; grok surface opts
+   into comment style via `heartbeatStyle` threaded from `logCtx.surface`.
+2. **JWT plan clobber (from #1998).** A JWT-derived plan could overwrite a
+   live WHAM plan on token refresh or startup reconcile (in-memory dedupe
+   dies on restart; generation gate is credential-CAS only). Fixed:
+   persisted provenance (`planSource` + `planCredentialGeneration`);
+   JWT writes refused at the same credential generation as a WHAM
+   observation; newer generation legitimately reopens.
+3. **Unclassified chat tier projection (from #1965).** Retiring the legacy
+   chat serialize-collapse flipped no-config openai-chat providers from
+   `false` to `undefined`, breaking `require.serviceTier: "unsupported"`
+   routing. Fixed: unclassified chat route with no tier forwarding projects
+   `false` again; `chatServiceTier: true` and Responses-wire keep unknown.
+
+## Clean areas (worker verdicts)
+
+- **Windows stack**: wrapper killer one-install scoped (full-path
+  token-bounded matcher); no writer lost the atomic-replace retry envelope;
+  counters bounded (24 keys max), off the hot path; unix untouched.
+  Nonblocking: sibling-prefix home test gap, type-only publisher bound.
+- **Cursor/codex singles**: #1997 role change has no user-role consumer left;
+  #2005 coercion cannot change tool semantics (schema-gated); #1928 stays
+  behind full JWT + loopback validation; #1941 annotations backfill is
+  add-only.
+- **Hygiene**: core-lab-boundary + repo-hygiene 24/0, privacy scan pass, no
+  gitlinks, no pre-disclosure security material, no scratch/credential paths
+  in the delta.
+
+## Gates on the fixed tip (fe3bbad97)
+
+- Remote authority host (ssh lidge): `tsc --noEmit` clean +
+  `bun test --isolate tests` **13208 pass / 0 fail** (EXIT=0).
+- Local: 11 focused suites 705/0 + tsc at the merged head.
+- Cost-accounting finding from B0 review confirmed fixed (4d87bce04);
+  residual tierOutcome-replacement note recorded as non-blocking.
+
+## Non-blocking follow-ups recorded
+
+- structure/04 claims chat passthrough emits service_tier by default —
+  docs drift, needs a line fix.
+- #1942/#1849 still need their own fixes on the landed Windows foundation.
+- #1926 credential-scope half; #1587 (now `bug`) token-bloat design cycle.
+- Stall-deadline race note: grok idle floor vs OCX stall default (both 300s)
+  — worth a config nudge in the grok inject defaults later.
+

--- a/devlog/_plan/260818_release_readiness_2260/020_release_recommendation.md
+++ b/devlog/_plan/260818_release_readiness_2260/020_release_recommendation.md
@@ -1,0 +1,19 @@
+# 020 — Release recommendation
+
+**Recommend: minor bump (2.26.0) on the next train, cut from `fe3bbad97`
+or later.** The delta carries behavior changes (FastWire B1 capability
+semantics, Grok Responses backend switch, cursor replay roles) beyond patch
+scope, plus the three audit fixes that must ride the same train as the
+regressions they fix.
+
+Pre-promotion gates for whoever runs the train (maintainer-owned; nothing
+here was executed by this campaign):
+
+1. Exact-head Cross-platform CI green on the promoted SHA.
+2. Service lifecycle workflow at the promoted SHA (`src/service.ts` moved
+   in the Windows stack).
+3. Registry/tag/GH-release verification per the scripts/release.ts flow.
+
+Held out of this train: #1885 (xAI Priority) behind the #1875 B2 pricing
+gate.
+


### PR DESCRIPTION
## Summary

Release-readiness record for everything landed since v2.25.0: delta inventory (~65 commits), four grok-4.6 hard-audit results (all clean, zero release-blocking), full local gates on the dev tip (typecheck 0, full suite 13213/0/840 files, privacy pass, docs-site 385 pages), and a 2.26.0 minor-bump recommendation with maintainer-owned pre-promotion gates.

## Verification

- docs-only; no build/test path reads devlog/
- fact-checked by two independent reviewer passes (PR numbers, merge SHAs, delta count)

## Checklist

- [x] No code paths touched
- [x] No GUI change (no screenshot required)
- [x] Records only already-public work; recommendation-only, no promotion action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive release inventory covering changes since version 2.25.0.
  * Documented release-readiness audit results, including resolved release-blocking regressions and remaining non-blocking follow-ups.
  * Added a recommendation for the 2.26.0 minor release, including required pre-release verification checks.
  * Clarified that a pricing-related improvement remains on hold pending completion of its prerequisite work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->