### PR TITLE
docs(devlog): correct the bug-PR disposition tally

### DIFF
--- a/devlog/_plan/260818_bug_pr_resolution/000_disposition_matrix.md
+++ b/devlog/_plan/260818_bug_pr_resolution/000_disposition_matrix.md
@@ -35,7 +35,7 @@ WP5 (closeout).
 | #1748 | REDESIGN-SMALL | — | outbound-only fake-IP proxy routing (avoid SSRF widening) |
 | #1725 | MERGE-SQUASH | — | warmup response bounds; threads resolved |
 
-Tally: MERGE 9 · MERGE-SQUASH 5 · REDESIGN-SMALL 6 · REDESIGN-LARGE-CLOSE 3 · CLOSE-STALE 1.
+Tally: MERGE 9 · MERGE-SQUASH 4 · REDESIGN-SMALL 7 · REDESIGN-LARGE-CLOSE 3 · CLOSE-STALE 1.
 
 ## Issue-closure rules for this campaign
 


### PR DESCRIPTION
## Summary

Plan-audit reviewer caught an arithmetic error in the matrix tally: rows are MERGE-SQUASH 4 / REDESIGN-SMALL 7, not 5/6. One-line correction.

## Verification
- docs-only

## Checklist
- [x] No code paths touched
- [x] No GUI change (no screenshot required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the disposition tally to reflect one fewer `MERGE-SQUASH` outcome and one additional `REDESIGN-SMALL` outcome.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->