### PR TITLE
fix(antigravity): drop the synthetic x-goog-api-client onboarding header (lands #1889)

### DIFF
--- a/src/adapters/client-fingerprint.ts
+++ b/src/adapters/client-fingerprint.ts
@@ -45,8 +45,6 @@ export function claudeCodeSessionId(token: string | undefined): string {
 export const ANTIGRAVITY_IDE_VERSION = "2.5.5";
 const ANTIGRAVITY_IDE_CLIENT_NAME = "aidev_client";
 const ANTIGRAVITY_IDE_PLATFORM = "windows/amd64";
-/** Secondary Google API client UA the Antigravity client library reports. */
-export const ANTIGRAVITY_GOOG_API_CLIENT_UA = "google-api-nodejs-client/10.3.0";
 
 /**
  * Real Antigravity IDE User-Agent format, decompiled from 2.5.5 Go LS (`setHeaders` @ `0x1018fbe00`):

--- a/src/oauth/google-antigravity.ts
+++ b/src/oauth/google-antigravity.ts
@@ -12,7 +12,7 @@
 import { OAuthCallbackFlow, type OAuthCallbackFlowOptions } from "./callback-server";
 import { generatePKCE } from "./pkce";
 import type { OAuthController, OAuthCredentials } from "./types";
-import { antigravityUserAgent, ANTIGRAVITY_GOOG_API_CLIENT_UA, ANTIGRAVITY_IDE_VERSION } from "../adapters/client-fingerprint";
+import { antigravityUserAgent, ANTIGRAVITY_IDE_VERSION } from "../adapters/client-fingerprint";
 
 const CLIENT_ID = process.env.GOOGLE_ANTIGRAVITY_CLIENT_ID
   || "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com";
@@ -110,7 +110,7 @@ async function onboardProject(accessToken: string, signal?: AbortSignal): Promis
     if (signal?.aborted) throw signal.reason ?? new Error("Antigravity onboarding aborted");
     const response = await fetch(`${DAILY_API}/${API_VERSION}:onboardUser`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${accessToken}`, Accept: "*/*", "Content-Type": "application/json", "User-Agent": antigravityUserAgent(), "x-goog-api-client": ANTIGRAVITY_GOOG_API_CLIENT_UA },
+      headers: { Authorization: `Bearer ${accessToken}`, Accept: "*/*", "Content-Type": "application/json", "User-Agent": antigravityUserAgent() },
       // `ide_version` is a version, not a User-Agent. `antigravityUserAgent()` returns the whole
       // header — `antigravity/ide/2.5.5 (aidev_client; os_type=...; arch=...)` — so onboarding was
       // sending a parenthesized UA string in a field the real client fills with `2.5.5`. It is a

--- a/tests/client-fingerprint.test.ts
+++ b/tests/client-fingerprint.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
   ANTIGRAVITY_IDE_VERSION,
-  ANTIGRAVITY_GOOG_API_CLIENT_UA,
   CLAUDE_CODE_HEADERS,
   antigravityUserAgent,
   claudeCodeSessionId,
@@ -54,10 +53,6 @@ describe("client fingerprint — helpers", () => {
       if (prevGoogle === undefined) delete process.env.GOOGLE_ANTIGRAVITY_USER_AGENT;
       else process.env.GOOGLE_ANTIGRAVITY_USER_AGENT = prevGoogle;
     }
-  });
-
-  test("secondary google api client UA is pinned", async () => {
-    expect(ANTIGRAVITY_GOOG_API_CLIENT_UA).toMatch(/^google-api-nodejs-client\/[\d.]+$/);
   });
 
   test("claude session id is a stable v4-shaped uuid per token", async () => {

--- a/tests/google-antigravity-oauth.test.ts
+++ b/tests/google-antigravity-oauth.test.ts
@@ -38,7 +38,14 @@ describe("antigravity project discovery", () => {
 
   test("falls back to onboardUser poll loop (not-done then done)", async () => {
     let onboardCalls = 0;
-    routeFetch((url) => {
+    routeFetch((url, init) => {
+      if (url.includes(":onboardUser")) {
+        // #1889: the synthetic x-goog-api-client header is dropped from onboarding — the real
+        // Antigravity client does not send it, so emitting it was a fingerprint mismatch.
+        const headers = (init?.headers ?? {}) as Record<string, string>;
+        expect(headers["x-goog-api-client"]).toBeUndefined();
+        expect(headers["User-Agent"]).toMatch(/^antigravity\/ide\//);
+      }
       if (url.includes(":loadCodeAssist")) return new Response(JSON.stringify({}), { status: 200 }); // no project
       if (url.includes(":onboardUser")) {
         onboardCalls++;

--- a/tests/google-antigravity-wire.test.ts
+++ b/tests/google-antigravity-wire.test.ts
@@ -63,7 +63,7 @@ describe("antigravity CCA envelope", () => {
     );
     // The literal "antigravity" giveaway UA must no longer be sent.
     expect(req.headers["User-Agent"]).not.toBe("antigravity");
-    // x-goog-api-client is NOT sent on runtime requests (CLIProxyAPI only uses it during onboarding).
+    // x-goog-api-client is never sent — not on runtime requests, and (since #1889) not on onboarding either.
     expect(req.headers["x-goog-api-client"]).toBeUndefined();
     // sessionId lives only at request.sessionId (no top-level / snake_case duplicate).
     expect(env.request.sessionId).toMatch(/^-/);


### PR DESCRIPTION
## Summary

Re-applies the remaining half of contributor PR #1889 (its `ide_version` half already landed): the synthetic `x-goog-api-client` header is removed from the Antigravity onboarding fetch, the orphaned UA constant retired, and the PR's header assertions ported onto the current test shape.

## Verification

- client-fingerprint + google-antigravity-oauth + google-antigravity-wire suites: 75/0
- `tsc --noEmit` clean

## Checklist

- [x] Regression assertions ported from the original PR
- [x] Typecheck green
- [x] No GUI change (no screenshot required)