### PR TITLE
fix(codex): treat a bare WHAM 401 as transient only for a verifiably live token (lands #1932)

### DIFF
--- a/src/codex/auth-api.ts
+++ b/src/codex/auth-api.ts
@@ -83,7 +83,7 @@ export {
   updateAccountQuota,
 } from "./quota";
 import { extractAccountId } from "../oauth/chatgpt";
-import { getMainAccountPlan, MAIN_CODEX_ACCOUNT_ID, setMainAccountPlan } from "./main-account";
+import { getMainAccountPlan, isMainAccountTokenVerifiablyLive, MAIN_CODEX_ACCOUNT_ID, setMainAccountPlan } from "./main-account";
 import { captureConfigGeneration, registerStateSweepAfterTick } from "../lib/state-store-sweeper";
 import { reconcileLiveStateStores } from "../lib/state-store-registrations";
 import {
@@ -566,12 +566,31 @@ const MAIN_TERMINAL_AUTH_CODES = new Set([
   "invalid_refresh_token",
 ]);
 
-async function isTerminalMainAuthResponse(resp: Response): Promise<boolean> {
-  if (resp.status === 401) return true;
+/**
+ * A WHAM 401 is not itself proof the local credential died. Upstream edges can
+ * transiently reject a still-valid access token (region/anti-abuse/rotation
+ * races), and fail-closing on every bare 401 makes a healthy main account flip
+ * needs-reauth on the next GUI quota poll. Only treat the response as terminal
+ * when the body carries a known terminal code or the local access token is not
+ * verifiably live (`accessTokenLive`). Liveness must be strict: a JWT whose
+ * `exp` cannot be decoded is NOT live — an undecodable token that vouched for
+ * itself would make a real 401 permanently transient.
+ */
+async function isTerminalMainAuthResponse(resp: Response, accessTokenLive: boolean): Promise<boolean> {
+  if (resp.status === 401) {
+    if (!accessTokenLive) return true;
+    const code = await readMainAuthErrorCode(resp);
+    return typeof code === "string" && MAIN_TERMINAL_AUTH_CODES.has(code);
+  }
   if (resp.status !== 403) return false;
+  const code = await readMainAuthErrorCode(resp);
+  return typeof code === "string" && MAIN_TERMINAL_AUTH_CODES.has(code);
+}
+
+async function readMainAuthErrorCode(resp: Response): Promise<unknown> {
   try {
     const body = await readBoundedResponseBody(resp, { totalTimeoutMs: 1_000, inactivityTimeoutMs: 1_000 });
-    if (!body.displaySafe) return false;
+    if (!body.displaySafe) return undefined;
     const parsed = JSON.parse(body.text) as {
       detail?: { code?: unknown } | string;
       error?: { code?: unknown } | string;
@@ -582,9 +601,9 @@ async function isTerminalMainAuthResponse(resp: Response): Promise<boolean> {
       : typeof parsed.error === "object" && parsed.error !== null
         ? parsed.error.code
         : parsed.code;
-    return typeof code === "string" && MAIN_TERMINAL_AUTH_CODES.has(code);
+    return code;
   } catch {
-    return false;
+    return undefined;
   }
 }
 
@@ -704,7 +723,7 @@ async function fetchMainAccountInfoWhileOwned(
       signal: AbortSignal.timeout(8000),
     });
     if (!resp.ok) {
-      const terminalAuthFailure = await isTerminalMainAuthResponse(resp);
+      const terminalAuthFailure = await isTerminalMainAuthResponse(resp, isMainAccountTokenVerifiablyLive());
       const retried = await retryMainAccountInfoIfIdentityChanged(requestAccountId, retriesRemaining, nativeMainLease);
       if (retried) return retried;
       if (terminalAuthFailure) {

--- a/src/codex/main-account.ts
+++ b/src/codex/main-account.ts
@@ -49,3 +49,20 @@ export function isMainAccountTokenLive(now = Date.now()): boolean {
   const exp = typeof payload?.exp === "number" ? payload.exp * 1000 : undefined;
   return exp === undefined || exp > now;
 }
+
+/**
+ * Strict liveness for auth-terminality decisions: true only when the access-token JWT
+ * carries a decodable `exp` that is still in the future.
+ *
+ * Unlike {@link isMainAccountTokenLive}, an undecodable `exp` counts as NOT live here.
+ * This gate decides whether a bare WHAM 401 is downgraded to a transient failure; if an
+ * undecodable token could vouch for itself, a genuinely dead credential would keep every
+ * 401 "transient" and needsReauth could never flip.
+ */
+export function isMainAccountTokenVerifiablyLive(now = Date.now()): boolean {
+  const tokens = readCodexTokens();
+  if (!tokens?.access_token) return false;
+  const payload = decodeJwtPayload(tokens.access_token);
+  const exp = typeof payload?.exp === "number" ? payload.exp * 1000 : undefined;
+  return exp !== undefined && exp > now;
+}

--- a/tests/codex-auth-api.test.ts
+++ b/tests/codex-auth-api.test.ts
@@ -80,6 +80,11 @@ let previousCodexHome: string | undefined;
 let previousManualImportEnv: string | undefined;
 let previousFetch: typeof fetch;
 
+function jwtWithExp(exp: number): string {
+  const enc = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return enc({ alg: "RS256", typ: "JWT" }) + "." + enc({ exp }) + ".sig";
+}
+
 function makeConfig(overrides: Partial<OcxConfig> = {}): OcxConfig {
   return {
     port: 10100,
@@ -742,7 +747,9 @@ describe("codex-auth API", () => {
     expect(main?.needsReauth).toBe(true);
   });
 
-  test("main account 401 marks needsReauth and exposes it in the DTO (#327)", async () => {
+  test("main account 401 with an undecodable-exp token is terminal and marks needsReauth (#327, #1932)", async () => {
+    // "expired-main" is not a decodable JWT, so its exp cannot vouch for liveness.
+    // Undecodable exp must fail toward reauth: only a decodable future exp counts as live.
     writeFileSync(join(TEST_CODEX_HOME, "auth.json"), JSON.stringify({
       tokens: { access_token: "expired-main", account_id: "acct-main" },
     }));
@@ -755,6 +762,54 @@ describe("codex-auth API", () => {
 
     expect(main).toMatchObject({ hasCredential: true, needsReauth: true });
     expect(isAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID)).toBe(true);
+  });
+
+  test("bare main account 401 with a verifiably live token is transient, not reauth (#1932)", async () => {
+    writeFileSync(join(TEST_CODEX_HOME, "auth.json"), JSON.stringify({
+      tokens: { access_token: jwtWithExp(Math.floor(Date.now() / 1000) + 3600), account_id: "acct-main" },
+    }));
+    globalThis.fetch = (async () => new Response("", { status: 401 })) as typeof fetch;
+
+    const req = new Request("http://localhost/api/codex-auth/accounts?refresh=1");
+    const resp = await handleCodexAuthAPI(req, new URL(req.url), makeConfig());
+    const data = await resp!.json() as { accounts: Array<{ id: string; hasCredential: boolean; needsReauth?: boolean }> };
+    const main = data.accounts.find(account => account.id === MAIN_CODEX_ACCOUNT_ID);
+
+    expect(main).toMatchObject({ hasCredential: true, needsReauth: false });
+    expect(isAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID)).toBe(false);
+  });
+
+  test("main account 401 with a live token but terminal body code is still terminal (#1932)", async () => {
+    writeFileSync(join(TEST_CODEX_HOME, "auth.json"), JSON.stringify({
+      tokens: { access_token: jwtWithExp(Math.floor(Date.now() / 1000) + 3600), account_id: "acct-main" },
+    }));
+    globalThis.fetch = (async () => Response.json(
+      { detail: { code: "invalid_refresh_token" } },
+      { status: 401 },
+    )) as typeof fetch;
+
+    const req = new Request("http://localhost/api/codex-auth/accounts?refresh=1");
+    const resp = await handleCodexAuthAPI(req, new URL(req.url), makeConfig());
+    const data = await resp!.json() as { accounts: Array<{ id: string; needsReauth?: boolean }> };
+
+    expect(data.accounts.find(account => account.id === MAIN_CODEX_ACCOUNT_ID)?.needsReauth).toBe(true);
+    expect(isAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID)).toBe(true);
+    clearAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID);
+  });
+
+  test("main account 401 with an expired access token is terminal (#1932)", async () => {
+    writeFileSync(join(TEST_CODEX_HOME, "auth.json"), JSON.stringify({
+      tokens: { access_token: jwtWithExp(1), account_id: "acct-main" },
+    }));
+    globalThis.fetch = (async () => new Response("", { status: 401 })) as typeof fetch;
+
+    const req = new Request("http://localhost/api/codex-auth/accounts?refresh=1");
+    const resp = await handleCodexAuthAPI(req, new URL(req.url), makeConfig());
+    const data = await resp!.json() as { accounts: Array<{ id: string; needsReauth?: boolean }> };
+
+    expect(data.accounts.find(account => account.id === MAIN_CODEX_ACCOUNT_ID)?.needsReauth).toBe(true);
+    expect(isAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID)).toBe(true);
+    clearAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID);
   });
 
   test("main account invalid-workspace 403 is terminal but a generic 403 is not (#327)", async () => {


### PR DESCRIPTION
## Summary

Lands contributor PR #1932's idea with the audit-required tightening: a bare WHAM 401 is transient only when the main token is VERIFIABLY live — `exp` must decode AND be in the future. An undecodable exp fails toward reauth (the original gate would have made every bare 401 permanently transient on a dead credential). Terminal body codes stay terminal even on a live token.

## Verification

- codex-auth-api suite: 186/0 (adds undecodable-exp→terminal, live-token transient, terminal-body, expired-exp cases)
- `tsc --noEmit` clean; today's plan-provenance code undisturbed

## Checklist

- [x] Regression tests included
- [x] Typecheck green
- [x] No GUI change (no screenshot required)