### PR TITLE
feat(quota): support GLM coding plan quota on z.ai and bigmodel.cn

### DIFF
--- a/docs-site/src/content/docs/guides/providers.md
+++ b/docs-site/src/content/docs/guides/providers.md
@@ -585,3 +585,15 @@ does not follow redirects. The response's rolling, weekly, and monthly `percent`
 already-consumed utilization: rolling maps to the 5-hour bar, while weekly and monthly keep
 their matching bars. OpenCodex does not reconstruct dollar caps from local usage logs, and a
 provider using a non-canonical `baseUrl` is never sent the key for this probe.
+
+**Z.AI GLM Coding Plan quota.** The `zai`, `glm`, `glm-cn`, and `zhipu-bigmodel-coding`
+presets read `GET /api/monitor/usage/quota/limit` with the configured key as a Bearer token
+and do not follow redirects. The probe runs against the region the provider points at:
+`api.z.ai` (bare or `/api/coding/paas/v4`) or `open.bigmodel.cn` (bare,
+`/api/coding/paas/v4`, or the OpenAI Responses endpoint `/api/v1`). The response's `limits`
+rows fill the utilization bars: `TOKENS_LIMIT` / `CREDIT_LIMIT` rows with `unit` 3 /
+`number` 5 fill the 5-hour bar and `unit` 6 / `number` 1 the weekly bar, while
+`TIME_LIMIT` rows fill the monthly MCP bar. The v2 coding-plan protocol reports the
+monthly MCP row; the newer protocol does not, so the monthly bar renders only when that
+row is present. A provider using a non-canonical `baseUrl` is never sent the key for this
+probe.

--- a/src/providers/quota.ts
+++ b/src/providers/quota.ts
@@ -704,11 +704,12 @@ export function parseZaiQuotaLimits(data: Record<string, unknown> | null): Provi
     if (percent === undefined) continue;
     if (row.type === "TOKENS_LIMIT" || row.type === "CREDIT_LIMIT") {
       const unit = toFiniteNumber(row.unit);
-      if (unit === 3) {
+      const number = toFiniteNumber(row.number);
+      if (unit === 3 && number === 5) {
         quota.fiveHourPercent = percent;
         if (resetAt !== undefined) quota.fiveHourResetAt = resetAt;
         windows += 1;
-      } else if (unit === 6) {
+      } else if (unit === 6 && number === 1) {
         quota.weeklyPercent = percent;
         if (resetAt !== undefined) quota.weeklyResetAt = resetAt;
         windows += 1;
@@ -782,7 +783,9 @@ async function fetchZaiQuota(provider: string, config: OcxProviderConfig): Promi
   const body = asRecord(await readQuotaJson(response));
   if (!body || body.success === false) return null;
   const data = asRecord(body.data) ?? body;
-  const quota = parseZaiQuotaLimits(data) ?? parseZaiQuotaLegacyFields(data);
+  const quota = Array.isArray(data?.limits)
+    ? parseZaiQuotaLimits(data)
+    : parseZaiQuotaLegacyFields(data);
   return quota ? report(provider, "zai:quota-limit", quota) : null;
 }
 

--- a/src/providers/quota.ts
+++ b/src/providers/quota.ts
@@ -50,6 +50,7 @@ const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 const DEEPSEEK_BASE_URL = "https://api.deepseek.com";
 const CLINE_BASE_URL = "https://api.cline.bot";
 const ZAI_BASE_URL = "https://api.z.ai";
+const ZAI_CN_BASE_URL = "https://open.bigmodel.cn";
 const MINIMAX_REMAINS_URL = "https://www.minimax.io/v1/token_plan/remains";
 const MOONSHOT_BASE_URL = "https://api.moonshot.ai/v1";
 const VENICE_BASE_URL = "https://api.venice.ai/api/v1";
@@ -343,7 +344,12 @@ function isCanonicalClineBaseUrl(baseUrl: string): boolean {
 
 function isCanonicalZaiBaseUrl(baseUrl: string): boolean {
   const normalized = normalizedBaseUrl(baseUrl);
-  return normalized === ZAI_BASE_URL || normalized === `${ZAI_BASE_URL}/api/coding/paas/v4`;
+  return normalized === ZAI_BASE_URL
+    || normalized === `${ZAI_BASE_URL}/api/coding/paas/v4`
+    || normalized === ZAI_CN_BASE_URL
+    || normalized === `${ZAI_CN_BASE_URL}/api/coding/paas/v4`
+    // BigModel serves the same GLM Coding Plan on the OpenAI Responses wire at /api/v1.
+    || normalized === `${ZAI_CN_BASE_URL}/api/v1`;
 }
 
 function isCanonicalMinimaxBaseUrl(baseUrl: string): boolean {
@@ -669,34 +675,66 @@ async function fetchClineQuota(provider: string, config: OcxProviderConfig): Pro
 
 /**
  * Z.AI GLM Coding Plan `GET /api/monitor/usage/quota/limit` — the coding-plan
- * subscription's 5-hour token cycle, weekly quota, and monthly MCP usage.
- * Authenticates with the API key as a Bearer token per Z.AI's API reference.
+ * limits arrive as a `limits` array of `TOKENS_LIMIT` (newer plans call the
+ * same rows `CREDIT_LIMIT`) and `TIME_LIMIT` rows. `TOKENS_LIMIT`/`CREDIT_LIMIT`
+ * rows carry the window length as `unit`/`number`: unit 3 is hours (number 5 →
+ * the rolling five-hour window), unit 6 is weeks (number 1 → the weekly
+ * window). `TIME_LIMIT` rows are the monthly MCP tool budget (Web Search / Web
+ * Reader / Zread). Every row's `percentage` is the consumed share (falling
+ * back to `currentValue`/`usage` when absent) and `nextResetTime` (unix ms)
+ * the window reset.
  */
-async function fetchZaiQuota(provider: string, config: OcxProviderConfig): Promise<ProviderQuotaProbeResult> {
-  if (!isCanonicalZaiBaseUrl(config.baseUrl)) return null;
-  const apiKey = resolveEnvValue(config.apiKey)?.trim();
-  if (!apiKey) return null;
-  const response = await fetch(`${ZAI_BASE_URL}/api/monitor/usage/quota/limit`, {
-    headers: { Accept: "application/json", Authorization: `Bearer ${apiKey}` },
-    redirect: "error",
-    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-  });
-  if (!response.ok) {
-    return response.status >= 400 && response.status < 500 && response.status !== 408 && response.status !== 429
-      ? TERMINAL_QUOTA_FAILURE
-      : null;
+export function parseZaiQuotaLimits(data: Record<string, unknown> | null): ProviderQuota | null {
+  const limits = Array.isArray(data?.limits) ? data.limits as unknown[] : null;
+  if (!limits) return null;
+  const quota: ProviderQuota = { updatedAt: Date.now() };
+  let windows = 0;
+  for (const raw of limits) {
+    const row = asRecord(raw);
+    if (!row) continue;
+    const resetAt = normalizeResetAt(row.nextResetTime);
+    let percent = normalizePercent(row.percentage);
+    if (percent === undefined) {
+      const used = toFiniteNumber(row.currentValue);
+      const total = toFiniteNumber(row.usage);
+      if (used !== undefined && total !== undefined && total > 0) {
+        percent = normalizePercent((used / total) * 100);
+      }
+    }
+    if (percent === undefined) continue;
+    if (row.type === "TOKENS_LIMIT" || row.type === "CREDIT_LIMIT") {
+      const unit = toFiniteNumber(row.unit);
+      if (unit === 3) {
+        quota.fiveHourPercent = percent;
+        if (resetAt !== undefined) quota.fiveHourResetAt = resetAt;
+        windows += 1;
+      } else if (unit === 6) {
+        quota.weeklyPercent = percent;
+        if (resetAt !== undefined) quota.weeklyResetAt = resetAt;
+        windows += 1;
+      }
+    } else if (row.type === "TIME_LIMIT") {
+      quota.monthlyPercent = percent;
+      if (resetAt !== undefined) quota.monthlyResetAt = resetAt;
+      windows += 1;
+    }
   }
-  const body = asRecord(await readQuotaJson(response));
-  if (!body || body.success === false) return null;
-  const data = asRecord(body.data) ?? body;
-  // The plugin renders a 5h token window, a weekly window, and a monthly MCP
-  // window. Look for percent fields with window identifiers.
+  return windows > 0 ? quota : null;
+}
+
+/**
+ * Legacy Z.AI payload shape: percent fields with window identifiers directly on
+ * the data object (optionally nested under `quota`). Kept as a fallback so
+ * older responses keep rendering when the `limits` array is absent.
+ */
+function parseZaiQuotaLegacyFields(data: Record<string, unknown> | null): ProviderQuota | null {
+  if (!data) return null;
   const quota: ProviderQuota = { updatedAt: Date.now() };
   let windows = 0;
   const percentAt = (key: string): number | undefined => {
-    const value = normalizePercent(data?.[key]);
+    const value = normalizePercent(data[key]);
     if (value !== undefined) return value;
-    const nested = asRecord(data?.quota);
+    const nested = asRecord(data.quota);
     return nested ? normalizePercent(nested[key]) : undefined;
   };
   const fiveHour = percentAt("fiveHourPercent") ?? percentAt("fiveHourUsage") ?? percentAt("fiveHourUsed");
@@ -714,7 +752,38 @@ async function fetchZaiQuota(provider: string, config: OcxProviderConfig): Promi
     quota.monthlyPercent = monthly;
     windows += 1;
   }
-  return windows > 0 ? report(provider, "zai:quota-limit", quota) : null;
+  return windows > 0 ? quota : null;
+}
+
+/**
+ * Fetches the Z.AI GLM Coding Plan quota — on whichever region the provider
+ * points at (api.z.ai or open.bigmodel.cn). Authenticates with the API key as
+ * a Bearer token per Z.AI's API reference. The `limits` array shape is
+ * preferred; older field-name payloads fall back to the legacy parser.
+ */
+async function fetchZaiQuota(provider: string, config: OcxProviderConfig): Promise<ProviderQuotaProbeResult> {
+  if (!isCanonicalZaiBaseUrl(config.baseUrl)) return null;
+  const apiKey = resolveEnvValue(config.apiKey)?.trim();
+  if (!apiKey) return null;
+  const normalized = normalizedBaseUrl(config.baseUrl);
+  const monitorHost = normalized === ZAI_BASE_URL || normalized === `${ZAI_BASE_URL}/api/coding/paas/v4`
+    ? ZAI_BASE_URL
+    : ZAI_CN_BASE_URL;
+  const response = await fetch(`${monitorHost}/api/monitor/usage/quota/limit`, {
+    headers: { Accept: "application/json", Authorization: `Bearer ${apiKey}` },
+    redirect: "error",
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    return response.status >= 400 && response.status < 500 && response.status !== 408 && response.status !== 429
+      ? TERMINAL_QUOTA_FAILURE
+      : null;
+  }
+  const body = asRecord(await readQuotaJson(response));
+  if (!body || body.success === false) return null;
+  const data = asRecord(body.data) ?? body;
+  const quota = parseZaiQuotaLimits(data) ?? parseZaiQuotaLegacyFields(data);
+  return quota ? report(provider, "zai:quota-limit", quota) : null;
 }
 
 /**
@@ -2106,7 +2175,8 @@ async function maybeFetchProviderQuota(
     if ((provider.authMode ?? "key") === "key" && name === "cline-pass") {
       return fetchClineQuota(name, provider);
     }
-    if ((provider.authMode ?? "key") === "key" && name === "zai") {
+    if ((provider.authMode ?? "key") === "key"
+      && (name === "zai" || name === "glm" || name === "glm-cn" || name === "zhipu-bigmodel-coding")) {
       return fetchZaiQuota(name, provider);
     }
     if ((provider.authMode ?? "key") === "key" && (name === "minimax" || name === "minimax-cn")) {

--- a/tests/provider-quota.test.ts
+++ b/tests/provider-quota.test.ts
@@ -883,6 +883,79 @@ describe("fetchProviderQuotaReports", () => {
       seen.push({ url, authorization: headers?.Authorization, redirect: init?.redirect });
       return new Response(JSON.stringify({
         success: true,
+        data: {
+          limits: [
+            { type: "TOKENS_LIMIT", unit: 3, number: 5, percentage: 40.5, currentValue: 405, usage: 1000, nextResetTime: 1789000000000 },
+            { type: "TOKENS_LIMIT", unit: 6, number: 1, percentage: 52, nextResetTime: 1789600000000 },
+            { type: "TIME_LIMIT", percentage: 12.3, nextResetTime: 1789000000000 },
+          ],
+        },
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await fetchProviderQuotaReports(keyQuotaConfig("zai", "https://api.z.ai"), true);
+
+    expect(result.reports).toHaveLength(1);
+    expect(result.reports[0]?.source).toBe("zai:quota-limit");
+    expect(result.reports[0]?.quota).toMatchObject({
+      fiveHourPercent: 40.5,
+      fiveHourResetAt: 1789000000000,
+      weeklyPercent: 52,
+      weeklyResetAt: 1789600000000,
+      monthlyPercent: 12.3,
+      monthlyResetAt: 1789000000000,
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.url).toBe("https://api.z.ai/api/monitor/usage/quota/limit");
+    expect(seen[0]?.authorization).toBe("Bearer zai-secret");
+    expect(seen[0]?.redirect).toBe("error");
+  });
+
+  test("Z.AI quota probes the BigModel region from the provider's own host", async () => {
+    const seen: Array<{ url: string; authorization?: string; redirect?: RequestRedirect }> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const headers = init?.headers as Record<string, string> | undefined;
+      seen.push({ url, authorization: headers?.Authorization, redirect: init?.redirect });
+      // Weekly row omits `percentage`: the fallback derives it from currentValue/usage.
+      return new Response(JSON.stringify({
+        success: true,
+        data: {
+          limits: [
+            { type: "CREDIT_LIMIT", unit: 3, number: 5, percentage: 20, currentValue: 200, usage: 1000, nextResetTime: 1789000000000 },
+            { type: "TOKENS_LIMIT", unit: 6, number: 1, currentValue: 156, usage: 300, nextResetTime: 1789600000000 },
+            { type: "TIME_LIMIT", percentage: 7.5, nextResetTime: 1789000000000 },
+          ],
+        },
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await fetchProviderQuotaReports(
+      keyQuotaConfig("zhipu-bigmodel-coding", "https://open.bigmodel.cn/api/coding/paas/v4"),
+      true,
+    );
+
+    expect(result.reports).toHaveLength(1);
+    expect(result.reports[0]?.source).toBe("zai:quota-limit");
+    expect(result.reports[0]?.quota).toMatchObject({
+      fiveHourPercent: 20,
+      weeklyPercent: 52,
+      monthlyPercent: 7.5,
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.url).toBe("https://open.bigmodel.cn/api/monitor/usage/quota/limit");
+    expect(seen[0]?.authorization).toBe("Bearer zhipu-bigmodel-coding-secret");
+    expect(seen[0]?.redirect).toBe("error");
+  });
+
+  test("Z.AI quota falls back to legacy field-name payloads", async () => {
+    const seen: Array<{ url: string; authorization?: string }> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const headers = init?.headers as Record<string, string> | undefined;
+      seen.push({ url, authorization: headers?.Authorization });
+      return new Response(JSON.stringify({
+        success: true,
         data: { fiveHourPercent: 40.5, weeklyPercent: 52, monthlyMCPUsage: 12.3 },
       }), { status: 200 });
     }) as typeof fetch;
@@ -898,8 +971,41 @@ describe("fetchProviderQuotaReports", () => {
     });
     expect(seen).toHaveLength(1);
     expect(seen[0]?.url).toBe("https://api.z.ai/api/monitor/usage/quota/limit");
-    expect(seen[0]?.authorization).toBe("Bearer zai-secret");
-    expect(seen[0]?.redirect).toBe("error");
+  });
+
+  test("Z.AI quota probes the BigModel Responses endpoint at /api/v1", async () => {
+    const seen: Array<{ url: string; authorization?: string }> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const headers = init?.headers as Record<string, string> | undefined;
+      seen.push({ url, authorization: headers?.Authorization });
+      return new Response(JSON.stringify({
+        success: true,
+        data: {
+          limits: [
+            { type: "TOKENS_LIMIT", unit: 3, number: 5, percentage: 30, currentValue: 300, usage: 1000, nextResetTime: 1789000000000 },
+            { type: "TOKENS_LIMIT", unit: 6, number: 1, percentage: 60, nextResetTime: 1789600000000 },
+            { type: "TIME_LIMIT", percentage: 9.5, nextResetTime: 1789000000000 },
+          ],
+        },
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await fetchProviderQuotaReports(
+      keyQuotaConfig("zhipu-bigmodel-coding", "https://open.bigmodel.cn/api/v1"),
+      true,
+    );
+
+    expect(result.reports).toHaveLength(1);
+    expect(result.reports[0]?.source).toBe("zai:quota-limit");
+    expect(result.reports[0]?.quota).toMatchObject({
+      fiveHourPercent: 30,
+      weeklyPercent: 60,
+      monthlyPercent: 9.5,
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.url).toBe("https://open.bigmodel.cn/api/monitor/usage/quota/limit");
+    expect(seen[0]?.authorization).toBe("Bearer zhipu-bigmodel-coding-secret");
   });
 
   test("Z.AI quota treats an unsuccessful payload as a no-report", async () => {
@@ -921,6 +1027,22 @@ describe("fetchProviderQuotaReports", () => {
 
     const result = await fetchProviderQuotaReports(
       keyQuotaConfig("zai", "https://attacker.example/api/coding/paas/v4"),
+      true,
+    );
+
+    expect(result.reports).toEqual([]);
+    expect(seen).toEqual([]);
+  });
+
+  test("Z.AI quota never probes the BigModel pay-as-you-go endpoint", async () => {
+    const seen: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      seen.push(String(input));
+      return new Response("unexpected", { status: 500 });
+    }) as typeof fetch;
+
+    const result = await fetchProviderQuotaReports(
+      keyQuotaConfig("zhipu-bigmodel", "https://open.bigmodel.cn/api/paas/v4"),
       true,
     );
 

--- a/tests/provider-quota.test.ts
+++ b/tests/provider-quota.test.ts
@@ -593,11 +593,11 @@ describe("fetchProviderQuotaReports", () => {
     expect(rejectedRefresh.reports).toEqual([]);
   });
 
-  function keyQuotaConfig(name: string, baseUrl: string): OcxConfig {
+  function keyQuotaConfig(name: string, baseUrl: string, apiKey = `${name}-secret`): OcxConfig {
     return {
       defaultProvider: name,
       providers: {
-        [name]: { adapter: "openai-chat", authMode: "key", baseUrl, apiKey: `${name}-secret` },
+        [name]: { adapter: "openai-chat", authMode: "key", baseUrl, apiKey },
       },
     } as OcxConfig;
   }
@@ -931,7 +931,7 @@ describe("fetchProviderQuotaReports", () => {
     }) as typeof fetch;
 
     const result = await fetchProviderQuotaReports(
-      keyQuotaConfig("zhipu-bigmodel-coding", "https://open.bigmodel.cn/api/coding/paas/v4"),
+      keyQuotaConfig("zhipu-bigmodel-coding", "https://open.bigmodel.cn/api/coding/paas/v4", "zai-secret"),
       true,
     );
 
@@ -944,7 +944,7 @@ describe("fetchProviderQuotaReports", () => {
     });
     expect(seen).toHaveLength(1);
     expect(seen[0]?.url).toBe("https://open.bigmodel.cn/api/monitor/usage/quota/limit");
-    expect(seen[0]?.authorization).toBe("Bearer zhipu-bigmodel-coding-secret");
+    expect(seen[0]?.authorization).toBe("Bearer zai-secret");
     expect(seen[0]?.redirect).toBe("error");
   });
 
@@ -992,7 +992,7 @@ describe("fetchProviderQuotaReports", () => {
     }) as typeof fetch;
 
     const result = await fetchProviderQuotaReports(
-      keyQuotaConfig("zhipu-bigmodel-coding", "https://open.bigmodel.cn/api/v1"),
+      keyQuotaConfig("zhipu-bigmodel-coding", "https://open.bigmodel.cn/api/v1", "zai-secret"),
       true,
     );
 
@@ -1005,7 +1005,7 @@ describe("fetchProviderQuotaReports", () => {
     });
     expect(seen).toHaveLength(1);
     expect(seen[0]?.url).toBe("https://open.bigmodel.cn/api/monitor/usage/quota/limit");
-    expect(seen[0]?.authorization).toBe("Bearer zhipu-bigmodel-coding-secret");
+    expect(seen[0]?.authorization).toBe("Bearer zai-secret");
   });
 
   test("Z.AI quota treats an unsuccessful payload as a no-report", async () => {

--- a/tests/provider-quota.test.ts
+++ b/tests/provider-quota.test.ts
@@ -1081,6 +1081,56 @@ describe("fetchProviderQuotaReports", () => {
     expect(result.reports).toEqual([]);
   });
 
+  test("Z.AI quota renders a real v2 coding-plan response (monthly MCP TIME_LIMIT)", async () => {
+    // Sanitized live response captured from the /api/monitor/usage/quota/limit probe
+    // (level=max, v2 protocol): the TIME_LIMIT row is the 30-day MCP tool budget
+    // (search-prime / web-reader / zread), independent of the token windows.
+    const v2Response = {
+      limits: [
+        { type: "TIME_LIMIT", unit: 5, number: 1, usage: 4000, currentValue: 0, remaining: 4000, percentage: 0, nextResetTime: 1788073095998,
+          usageDetails: [{ modelCode: "search-prime", usage: 0 }, { modelCode: "web-reader", usage: 0 }, { modelCode: "zread", usage: 0 }] },
+        { type: "TOKENS_LIMIT", unit: 3, number: 5, percentage: 100, nextResetTime: 1787056863927 },
+        { type: "TOKENS_LIMIT", unit: 6, number: 1, percentage: 20, nextResetTime: 1787641095989 },
+      ],
+      level: "max",
+    };
+    globalThis.fetch = (async () => new Response(JSON.stringify({ success: true, data: v2Response }), { status: 200 })) as typeof fetch;
+
+    const result = await fetchProviderQuotaReports(keyQuotaConfig("zai", "https://api.z.ai/api/coding/paas/v4"), true);
+
+    expect(result.reports).toHaveLength(1);
+    expect(result.reports[0]?.quota).toMatchObject({
+      fiveHourPercent: 100,
+      fiveHourResetAt: 1787056863927,
+      weeklyPercent: 20,
+      weeklyResetAt: 1787641095989,
+      monthlyPercent: 0,
+      monthlyResetAt: 1788073095998,
+    });
+  });
+
+  test("Z.AI quota renders a real new-protocol response without the monthly MCP row", async () => {
+    // Sanitized live response (level=pro, newer protocol): CREDIT_LIMIT rows only,
+    // no TIME_LIMIT row — the monthly MCP bar must not render.
+    const newProtocolResponse = {
+      limits: [
+        { type: "CREDIT_LIMIT", unit: 3, number: 5, usage: 12000, currentValue: 0, remaining: 12000, percentage: 0 },
+        { type: "CREDIT_LIMIT", unit: 6, number: 1, usage: 60000, currentValue: 0, remaining: 60000, percentage: 0, nextResetTime: 1787649214999 },
+      ],
+      level: "pro",
+    };
+    globalThis.fetch = (async () => new Response(JSON.stringify({ success: true, data: newProtocolResponse }), { status: 200 })) as typeof fetch;
+
+    const result = await fetchProviderQuotaReports(keyQuotaConfig("zai", "https://api.z.ai/api/coding/paas/v4"), true);
+
+    expect(result.reports).toHaveLength(1);
+    expect(result.reports[0]?.quota).toMatchObject({
+      fiveHourPercent: 0,
+      weeklyPercent: 0,
+    });
+    expect(result.reports[0]?.quota.monthlyPercent).toBeUndefined();
+  });
+
   test("MiniMax quota drops the row when the API omits the plan total after having it", async () => {
     // A valid row (with total) exists; a later valid response omitting the
     // total is a DELIBERATE contract change — the stale row must be dropped

--- a/tests/provider-quota.test.ts
+++ b/tests/provider-quota.test.ts
@@ -1042,12 +1042,43 @@ describe("fetchProviderQuotaReports", () => {
     }) as typeof fetch;
 
     const result = await fetchProviderQuotaReports(
-      keyQuotaConfig("zhipu-bigmodel", "https://open.bigmodel.cn/api/paas/v4"),
+      keyQuotaConfig("zhipu-bigmodel-coding", "https://open.bigmodel.cn/api/paas/v4"),
       true,
     );
 
     expect(result.reports).toEqual([]);
     expect(seen).toEqual([]);
+  });
+
+  test("Z.AI quota ignores token rows whose window length does not match", async () => {
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      success: true,
+      data: {
+        limits: [
+          { type: "TOKENS_LIMIT", unit: 3, number: 2, percentage: 40, nextResetTime: 1789000000000 },
+          { type: "TOKENS_LIMIT", unit: 6, number: 2, percentage: 52, nextResetTime: 1789600000000 },
+          { type: "TIME_LIMIT", percentage: 12.3, nextResetTime: 1789000000000 },
+        ],
+      },
+    }), { status: 200 })) as typeof fetch;
+
+    const result = await fetchProviderQuotaReports(keyQuotaConfig("zai", "https://api.z.ai/api/coding/paas/v4"), true);
+
+    expect(result.reports).toHaveLength(1);
+    expect(result.reports[0]?.quota).toMatchObject({ monthlyPercent: 12.3 });
+    expect(result.reports[0]?.quota.fiveHourPercent).toBeUndefined();
+    expect(result.reports[0]?.quota.weeklyPercent).toBeUndefined();
+  });
+
+  test("Z.AI quota does not fall back to legacy fields when limits is present but empty", async () => {
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      success: true,
+      data: { limits: [], fiveHourPercent: 40.5, weeklyPercent: 52, monthlyMCPUsage: 12.3 },
+    }), { status: 200 })) as typeof fetch;
+
+    const result = await fetchProviderQuotaReports(keyQuotaConfig("zai", "https://api.z.ai/api/coding/paas/v4"), true);
+
+    expect(result.reports).toEqual([]);
   });
 
   test("MiniMax quota drops the row when the API omits the plan total after having it", async () => {


### PR DESCRIPTION
## Summary

Adds GLM Coding Plan quota probing for the `zai` provider family across both Z.AI regions:

- Probes `/api/monitor/usage/quota/limit` with the API key as a Bearer token on both `api.z.ai` and `open.bigmodel.cn`, including the OpenAI Responses endpoint `https://open.bigmodel.cn/api/v1`.
- Parses the `limits` array: `TOKENS_LIMIT`/`CREDIT_LIMIT` rows with `unit` 3 / `number` 5 map to the five-hour window and `unit` 6 / `number` 1 to the weekly window; `TIME_LIMIT` rows map to the monthly MCP tool budget.
- Falls back to the legacy field-name payload shape (`fiveHourPercent`, `weeklyPercent`, `monthlyMCPUsage`, …) only when the `limits` array is absent.
- Dispatches quota probing for `zai`, `glm`, `glm-cn`, and `zhipu-bigmodel-coding`; the pay-as-you-go `/api/paas/v4` route never probes.
- Documented in the providers guide (`docs-site/src/content/docs/guides/providers.md`).

## Evidence: real `limits` responses (sanitized, from the live probe)

The v2 coding-plan protocol reports the monthly MCP budget as a `TIME_LIMIT` row; the newer protocol does not. The fixtures in `tests/provider-quota.test.ts` are captured from these live responses, not invented:

**v2 protocol (`level: max`)** — carries the monthly MCP `TIME_LIMIT` row:

```json
{ "limits": [
    { "type": "TIME_LIMIT", "unit": 5, "number": 1, "usage": 4000, "currentValue": 0, "remaining": 4000, "percentage": 0, "nextResetTime": 1788073095998,
      "usageDetails": [ { "modelCode": "search-prime", "usage": 0 }, { "modelCode": "web-reader", "usage": 0 }, { "modelCode": "zread", "usage": 0 } ] },
    { "type": "TOKENS_LIMIT", "unit": 3, "number": 5, "percentage": 100, "nextResetTime": 1787056863927 },
    { "type": "TOKENS_LIMIT", "unit": 6, "number": 1, "percentage": 20, "nextResetTime": 1787641095989 }
  ], "level": "max" }
```

**Newer protocol (`level: pro`)** — `CREDIT_LIMIT` token rows only, no monthly MCP row:

```json
{ "limits": [
    { "type": "CREDIT_LIMIT", "unit": 3, "number": 5, "usage": 12000, "currentValue": 0, "remaining": 12000, "percentage": 0 },
    { "type": "CREDIT_LIMIT", "unit": 6, "number": 1, "usage": 60000, "currentValue": 0, "remaining": 60000, "percentage": 0, "nextResetTime": 1787649214999 }
  ], "level": "pro" }
```

The `TIME_LIMIT` row's `usageDetails` (search-prime / web-reader / zread) is the 30-day MCP tool budget the dashboard renders as the monthly bar; the newer protocol omits the row, so the monthly bar renders only when present.

## Verification

- `bun run typecheck` passes.
- `bun test tests/provider-quota.test.ts` — 105 tests pass, including probe tests for both regions, the `/api/v1` Responses endpoint, the real v2/new-protocol fixtures, the legacy fallback, and non-canonical base-URL guards (the key never leaves its own host).
- `bun run privacy:scan` passes.
- Branch rebased onto current `dev` (0 commits behind).

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Z.AI GLM Coding Plan quota monitoring for regional BigModel endpoints.
  - Supports modern token, credit, and time-based quota windows with reset times and percentage fallbacks.
  - Retains compatibility with legacy quota responses and supports additional provider aliases.

- **Documentation**
  - Added setup guidance, supported presets, regional endpoints, authentication behavior, and quota display mappings for Z.AI monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->