### PR TITLE
Expose web search sidecar enabled status

### DIFF
--- a/src/server/management/config-routes.ts
+++ b/src/server/management/config-routes.ts
@@ -592,6 +592,7 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
     const webSearchCandidates = await webSearchCandidateRows(config);
     return jsonResponse({
       webSearch: {
+        enabled: ws.enabled !== false,
         model: ws.model ?? "gpt-5.6-luna",
         backend: ws.backend,
         streamRoutedModelOutput: ws.streamRoutedModelOutput === true,
@@ -830,6 +831,7 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
     return jsonResponse({
       ok: true,
       webSearch: {
+        enabled: ws.enabled !== false,
         model: ws.model ?? "gpt-5.6-luna",
         backend: ws.backend,
         streamRoutedModelOutput: ws.streamRoutedModelOutput === true,

--- a/tests/sidecar-settings-vision-controls.test.ts
+++ b/tests/sidecar-settings-vision-controls.test.ts
@@ -221,6 +221,18 @@ describe("sidecar-settings remaining vision controls", () => {
     expect(config.visionSidecar).toEqual({ ...FULL_VISION, enabled: false });
   });
 
+  test("GET and PUT expose the effective web-search enabled state", async () => {
+    const unset = await getSidecarSettings(emptyConfig());
+    expect((await unset.json() as { webSearch: { enabled: boolean } }).webSearch.enabled).toBe(true);
+
+    const config = emptyConfig({ webSearchSidecar: { enabled: false } });
+    const disabled = await getSidecarSettings(config);
+    expect((await disabled.json() as { webSearch: { enabled: boolean } }).webSearch.enabled).toBe(false);
+
+    const response = await putSidecarSettings(config, { webSearch: { streamRoutedModelOutput: true } });
+    expect((await response.json() as { webSearch: { enabled: boolean } }).webSearch.enabled).toBe(false);
+  });
+
   test("timeoutMs validation reuses the runtime bounds rather than a second contract", async () => {
     expect(resolveVisionTimeoutMs(undefined)).toBe(DEFAULT_VISION_TIMEOUT_MS);
     expect(resolveVisionTimeoutMs(MIN_VISION_TIMEOUT_MS)).toBe(MIN_VISION_TIMEOUT_MS);


### PR DESCRIPTION
## Summary

- expose the effective `webSearchSidecar.enabled` value in GET sidecar settings
- preserve and return that state after partial PUT updates
- add focused coverage for default-enabled and explicitly-disabled configurations

## Validation

- `bun test tests/sidecar-settings-vision-controls.test.ts` (8 pass)
- `bun run typecheck`
- `git diff --check`

This only changes management status serialization; provider routing and OpenAI passthrough are untouched.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Web-search settings responses now clearly indicate whether web search is enabled or disabled.

- **Bug Fixes**
  - Preserved the disabled web-search state when updating other web-search settings.
  - Web search now defaults to enabled when no explicit configuration is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->