### PR TITLE
fix(chat): keep the structured-output opt-out exact on the native chat wire

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -116,7 +116,11 @@ export function buildOpenAIChatPassthroughRequest(
     delete body.presence_penalty;
     delete body.frequency_penalty;
   }
-  if (modelInList(provider.noStructuredOutputModels, modelId)) delete body.response_format;
+  // Exact match, unlike the gates above: `noStructuredOutputModels` is documented as
+  // "only an exact requested-model match omits the field" (#1424), and the Responses
+  // ingress enforces exactly that. A prefix match here would strip response_format from
+  // `<listed>:<tag>` siblings the operator never opted out, silently returning prose.
+  if (provider.noStructuredOutputModels?.includes(modelId)) delete body.response_format;
 
   if (provider.chatServiceTier && rawBody.service_tier !== undefined) {
     body.service_tier = rawBody.service_tier;

--- a/tests/openai-chat-hardening.test.ts
+++ b/tests/openai-chat-hardening.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { createOpenAIChatAdapter as createOpenAIChatAdapterProduction } from "../src/adapters/openai-chat";
+import { buildOpenAIChatPassthroughRequest, createOpenAIChatAdapter as createOpenAIChatAdapterProduction } from "../src/adapters/openai-chat";
 import { stripResponsesOnlyEncryptedMarker } from "../src/adapters/responses-tool-schema";
 import { getDebugLogEntries, resetDebugLogBufferForTests } from "../src/lib/debug-log-buffer";
 import { resetDebugSettingsForTests } from "../src/lib/debug-settings";
@@ -790,6 +790,38 @@ describe("openai-chat response_format emission", () => {
     expect(bodyOf(colonVariant).response_format).toEqual({
       type: "json_schema",
       json_schema: { name: "answer", schema: { type: "object" }, strict: true },
+    });
+  });
+
+  // The native Chat ingress reads the same provider option and must draw the same
+  // boundary. It used to match through modelInList, so a `<listed>:<tag>` sibling
+  // lost response_format on this wire while keeping it on Responses.
+  describe("native chat passthrough draws the same exact boundary", () => {
+    const passthrough = (modelId: string, noStructuredOutputModels: string[]) =>
+      JSON.parse(buildOpenAIChatPassthroughRequest(
+        provider({ noStructuredOutputModels }),
+        { messages: [{ role: "user", content: "hi" }], response_format: { type: "json_object" } },
+        modelId,
+        false,
+      ).body as string) as Record<string, unknown>;
+
+    test("omits response_format for the exact listed id", () => {
+      expect(passthrough("test-model", ["test-model"]).response_format).toBeUndefined();
+    });
+
+    test("keeps response_format for a :tag sibling the operator never listed", () => {
+      expect(passthrough("test-model:structured", ["test-model"]).response_format)
+        .toEqual({ type: "json_object" });
+    });
+
+    test("listing the full :tag id opts that id out", () => {
+      expect(passthrough("test-model:structured", ["test-model:structured"]).response_format)
+        .toBeUndefined();
+    });
+
+    test("leaves an unrelated model untouched", () => {
+      expect(passthrough("supported-model", ["test-model"]).response_format)
+        .toEqual({ type: "json_object" });
     });
   });
 });


### PR DESCRIPTION
## Summary

`noStructuredOutputModels` is documented — in `reference/configuration/providers.md` and its fr/ja/ko/ru/tr/zh-cn translations — as:

> **Exact** model IDs whose `openai-chat` endpoint rejects `response_format`. **Only an exact requested-model match omits the field**; structured-output translation stays enabled for every other `openai-chat` model.

The Responses ingress enforces that, and `tests/openai-chat-hardening.test.ts` already pins a `:tag` sibling **keeping** the field there.

The native Chat passthrough (`buildOpenAIChatPassthroughRequest`, added in #1467) matched through `modelInList` instead, which additionally matches the pre-colon prefix:

```ts
export function modelInList(list, modelId) {
  if (list.includes(modelId)) return true;
  const colon = modelId.indexOf(":");
  return colon > 0 && list.includes(modelId.slice(0, colon));   // <- prefix
}
```

## Why it bites

`ollama-cloud` ships tagged ids verbatim — `gpt-oss:120b`, `qwen3-coder:480b`, `qwen3.5:397b`, `gemma4:31b` (`src/providers/registry.ts`). With

```json
{ "noStructuredOutputModels": ["gpt-oss"] }
```

a request for `gpt-oss:120b` lost `response_format` on `/v1/chat/completions` but kept it on `/v1/responses`. Same provider, same config key, same upstream — the answer depended on which client API the caller used, and on the chat wire **the caller asked for JSON and silently got prose**, on a model the operator never opted out.

That is precisely the failure #1424 named when it chose the exact boundary: a wider match *"would silently return prose for siblings that support JSON Schema."*

## Change

One gate, exact-matched, matching the Responses side. The neighbouring gates keep `modelInList` deliberately — `noVisionModels` is documented as *"matching tolerates an Ollama `:size` tag"*, this option is documented the other way — so the comment now records why this one differs.

No documentation change: the docs already describe the behaviour this restores.

## Tests

Four cases in the existing `openai-chat response_format emission` describe, placed directly after the Responses-side assertions so the two ingresses read as a pair:

| case | expected |
|---|---|
| exact listed id | omits `response_format` |
| `:tag` sibling, only the base listed | **keeps** it |
| full `:tag` id listed | omits it |
| unrelated model | keeps it |

The `:tag` sibling case fails on current `dev` and passes with this change.

## Verification

Run on the exact head of this branch:

```
bun run typecheck                                     clean

bun test tests/openai-chat-hardening.test.ts          54 pass / 0 fail
  (same file on unpatched dev: 53 pass / 1 fail — the new :tag sibling case)

bun scripts/test.ts <24 test files touching openai-chat,
  response_format, noStructuredOutputModels, passthrough>
                                                      414 pass / 0 fail
```

I did not run the full suite: this is a Windows machine and `bun run test` panics partway through on Bun 1.3.14 (`index out of bounds: index 0, len 0`), so a result from it would be a truncated log rather than a result. The batches above were run through `scripts/test.ts` so each file keeps its isolated home.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected structured-output handling for OpenAI Chat passthrough requests.
  - Response formatting is now disabled only for explicitly listed model IDs.
  - Related model variants retain response formatting unless their complete IDs are also excluded.

- **Tests**
  - Added coverage for exact model matching, suffixed variants, and unrelated models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

> **What box 1 covers here.** Ticked at the request of @Ingwannu ([review comment](https://github.com/lidge-jun/opencodex/pull/2042#issuecomment-5329202199)), who verified this exact head independently. To keep the record exact: "green on my local testing" means everything listed under **Verification** above ran green on this exact head — typecheck, the new tests, the same tests against unpatched `dev` to prove they fail there, and a batch of the surrounding suite. It does **not** mean I ran the full suite: this is a Windows machine, `bun run test` panics partway through on Bun 1.3.14 (`index out of bounds: index 0, len 0`), and the Windows baseline on clean `dev` is not green either (#1059). The exact-head CI gate is the authority on the full suite, which is what marking this Ready hands it.



