### PR TITLE
docs(structure): scope canonical Fast injection to the bridged Chat path

### DIFF
--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -660,9 +660,10 @@ normalization, credential and provider headers, capability-specific fields, and 
 messages (including `name` and separate `system`/`developer` entries), Chat token controls,
 sampling/logprob fields, caller identity/metadata, and caller stream options retain their wire
 shape. For streams, caller `stream_options` are merged with mandatory `include_usage: true`. On
-classified Fast-capable routes, canonical Fast follows the resolved Fast policy and does not require
-`chatServiceTier`; foreign caller tiers still require `chatServiceTier: true`, as does every caller
-tier on an unclassified Chat route. `parallel_tool_calls` is emitted only for providers opted into
+the native passthrough there is no canonical Fast injection and no wire mapping: every caller
+`service_tier` — canonical or foreign — is forwarded raw and only under `chatServiceTier: true`,
+and `fastMode` injects nothing here. Resolved-Fast-policy injection applies only to routes that
+take the Chat -> Responses -> Chat bridge below. `parallel_tool_calls` is emitted only for providers opted into
 parallel tools (or pinned false by the existing provider opt-out contract).
 Combo/policy routes and requests that need Responses-only hosted tools, continuation, background,
 or storage semantics retain the existing Chat -> Responses -> Chat bridge.


### PR DESCRIPTION
## Summary

Campaign wp9 docs-drift fix (the release-readiness follow-up item). structure/04's native Chat passthrough paragraph claimed canonical Fast follows the resolved Fast policy without chatServiceTier. The code does not do that on the native path: chat-native.ts has no tier wiring — tier resolution lives only in the Responses pipeline feeding adapter buildRequest, which the passthrough bypasses. On the native path every caller service_tier is forwarded raw and only under chatServiceTier: true, and fastMode injects nothing (openai-chat.ts:121, chat-native.ts:54-72; adversarial verification recorded in devlog/_plan/260818_bug_pr_resolution/040).

Docs-only: one paragraph in structure/04_transports-and-sidecars.md.

## Verification

- git show --stat: 1 file changed (structure/04_transports-and-sidecars.md), docs-only
- Claim verified by adversarial plan-audit subagent with file:line citations (r6/F2)

## Checklist

- [x] Docs-only, no runtime change
- [x] Matches code behavior with citations
- [x] No dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Native Chat Completions requests now preserve caller-supplied service tier values when supported.
  * Fast mode no longer alters native Chat Completions passthrough requests.
  * Automatic Fast-policy handling remains limited to the Chat-to-Responses-to-Chat conversion flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->