### PR TITLE
fix(codex): classify detail-scoped workspace denials

### DIFF
--- a/src/codex/quota-rejection.ts
+++ b/src/codex/quota-rejection.ts
@@ -71,15 +71,29 @@ async function denialFromResponse(
   }
 }
 
-/** Own-property `code` lookup at the top level or under `error`. No coercion, no accessors. */
+function ownStringField(container: Record<string, unknown>, field: string): string | undefined {
+  const descriptor = Object.getOwnPropertyDescriptor(container, field);
+  return descriptor && "value" in descriptor && typeof descriptor.value === "string"
+    ? descriptor.value
+    : undefined;
+}
+
+/** Own-property `code` lookup at the top level or under `error` / `detail`. No coercion or accessors. */
 function structuredDenialCode(payload: unknown): string | undefined {
   if (payload === null || typeof payload !== "object" || Array.isArray(payload)) return undefined;
-  const direct = (payload as Record<string, unknown>).code;
-  if (typeof direct === "string") return direct;
-  const error = (payload as Record<string, unknown>).error;
-  if (error === null || typeof error !== "object" || Array.isArray(error)) return undefined;
-  const nested = (error as Record<string, unknown>).code;
-  return typeof nested === "string" ? nested : undefined;
+  const record = payload as Record<string, unknown>;
+  const direct = ownStringField(record, "code");
+  if (direct !== undefined) return direct;
+
+  for (const field of ["error", "detail"] as const) {
+    const descriptor = Object.getOwnPropertyDescriptor(record, field);
+    if (!descriptor || !("value" in descriptor)) continue;
+    const nested = descriptor.value;
+    if (nested === null || typeof nested !== "object" || Array.isArray(nested)) continue;
+    const code = ownStringField(nested as Record<string, unknown>, "code");
+    if (code !== undefined) return code;
+  }
+  return undefined;
 }
 
 const RESET_ELIGIBLE_CODES: ReadonlySet<string> = new Set(RESET_ELIGIBLE_CODE_VALUES);

--- a/tests/codex-quota-rejection.test.ts
+++ b/tests/codex-quota-rejection.test.ts
@@ -26,10 +26,23 @@ describe("Codex pre-stream quota rejection classification", () => {
     }));
     expect(topLevel).toMatchObject({ kind: "permission-error", denial: "workspace" });
 
+    const detail = await classifyCodexPreStreamRejection(jsonPayload(403, {
+      detail: {
+        code: "codex_workspace_access_denied",
+        message: "workspace access denied",
+      },
+    }));
+    expect(detail).toMatchObject({ kind: "permission-error", denial: "workspace" });
+
     const entitlement = await classifyCodexPreStreamRejection(jsonRejection(403, {
       code: "codex_entitlement_missing",
     }));
     expect(entitlement).toMatchObject({ kind: "permission-error", denial: "entitlement" });
+
+    const detailEntitlement = await classifyCodexPreStreamRejection(jsonPayload(403, {
+      detail: { code: "entitlement_missing" },
+    }));
+    expect(detailEntitlement).toMatchObject({ kind: "permission-error", denial: "entitlement" });
   });
 
   test("a 403 without denial evidence stays an ordinary permission error (#1789)", async () => {
@@ -46,6 +59,11 @@ describe("Codex pre-stream quota rejection classification", () => {
 
     const malformed = await classifyCodexPreStreamRejection(new Response("{not json", { status: 403 }));
     expect(malformed.denial).toBeUndefined();
+
+    const invalidDetail = await classifyCodexPreStreamRejection(jsonPayload(403, {
+      detail: { code: 403 },
+    }));
+    expect(invalidDetail.denial).toBeUndefined();
   });
 
   test.each([


### PR DESCRIPTION
## Summary

- accept exact workspace and entitlement denial codes under an own object-valued `detail.code`
- keep extraction fail-closed for non-string, primitive, array, inherited, or accessor-backed values
- prevent valid K12 credentials from being marked `needs-reauth` for the observed denial envelope

Fixes the false credential-failure classification in #2046. The existing-thread workspace compatibility portion remains open for separate evidence-driven handling.

## Verification

- `taskset -c 0,1 bun test tests/codex-quota-rejection.test.ts tests/codex-routing.test.ts` — 166 passed
- `taskset -c 0,1 bun run typecheck`
- `taskset -c 0,1 bun run privacy:scan`
- Codex Security exact-range diff scan completed with full source coverage and no reportable findings

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No user-facing documentation change required.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of quota rejection responses with denial codes nested under additional response details.
  * Invalid or non-text denial values are now safely ignored, reducing incorrect rejection classifications.

* **Tests**
  * Added coverage for workspace and entitlement denial codes in nested response data.
  * Added validation for invalid denial-code formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->