### PR TITLE
docs(providers): document OpenCode Go quota probe

### DIFF
--- a/docs-site/src/content/docs/guides/providers.md
+++ b/docs-site/src/content/docs/guides/providers.md
@@ -564,6 +564,13 @@ The bars show how much of a window (5-hour, weekly, monthly, or
 provider-specific) is already consumed.
 
 Providers with a live probe: OpenAI/Codex, Anthropic, xAI, Cursor, Kimi,
-Google Antigravity, OpenRouter, DeepSeek, ClinePass, Z.AI, MiniMax,
+Google Antigravity, OpenCode Go, OpenRouter, DeepSeek, ClinePass, Z.AI, MiniMax,
 Moonshot, Venice, Synthetic, DeepInfra, Neuralwatt, Command Code, and any a6api-backed
 custom provider.
+
+**OpenCode Go quota.** The canonical `opencode-go` preset reads
+`GET https://opencode.ai/zen/go/v1/usage` with the configured key as a Bearer token and
+does not follow redirects. The response's rolling, weekly, and monthly `percent` values are
+already-consumed utilization: rolling maps to the 5-hour bar, while weekly and monthly keep
+their matching bars. OpenCodex does not reconstruct dollar caps from local usage logs, and a
+provider using a non-canonical `baseUrl` is never sent the key for this probe.


### PR DESCRIPTION
## Summary

- list OpenCode Go among providers with a live quota probe
- document the canonical `GET /zen/go/v1/usage` destination and Bearer/redirect behavior
- clarify that rolling, weekly, and monthly percentages are used utilization, not reconstructed dollar caps
- state that non-canonical base URLs never receive the probe key

Fixes #1598.

## Verification

- `cd docs-site && taskset -c 0,1 bun install --frozen-lockfile`
- `cd docs-site && taskset -c 0,1 bun run build` — 385 pages built
- `git diff --check`

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added OpenCode Go as a supported provider.
  * Documented rate-limit monitoring, usage metrics, authentication, redirects, and canonical endpoint requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->