### PR TITLE
fix(lab): report the model gates the way the adapters actually match them

### DIFF
--- a/src/routing/compatibility/behavior.ts
+++ b/src/routing/compatibility/behavior.ts
@@ -1,3 +1,4 @@
+import { modelInList } from "../../types";
 import type { OcxConfig, OcxProviderConfig } from "../../types";
 import { PROVIDER_REGISTRY } from "../../providers/registry";
 import { fastPolicyForModel, serviceTierSupportForModel } from "../../providers/service-tier";
@@ -37,8 +38,17 @@ function behaviorRow(source: LabBehaviorSource, value: unknown) {
   return { source, value };
 }
 
+/**
+ * Membership for the provider's `no*Models`-style lists.
+ *
+ * Delegates to modelInList so the report matches the wire: every runtime gate these
+ * rows describe (openai-chat's sampling/reasoning/tool-choice gates, reasoning-effort's
+ * noReasoningModels) matches through modelInList, which also accepts a bare entry for a
+ * tagged id. ollama-cloud serves `gpt-oss:120b` and lists the bare `gpt-oss`, so an
+ * exact-only check here reported "temperature is sent" on a request that omits it.
+ */
 function includesModel(list: string[] | undefined, modelId: string): boolean {
-  return Array.isArray(list) && list.includes(modelId);
+  return modelInList(list, modelId);
 }
 
 function modelValue<T>(map: Record<string, T> | undefined, modelId: string): T | undefined {

--- a/tests/routing-compatibility-model-matching.test.ts
+++ b/tests/routing-compatibility-model-matching.test.ts
@@ -1,0 +1,74 @@
+/**
+ * The compatibility behavior report is documented as "authoritative effective values
+ * emitted by the production route/model/adapter resolver", and its hash keys Lab
+ * evidence. These cases hold it to that: for one routed model they assert the wire the
+ * adapter actually builds, then assert the report describes that same wire.
+ */
+import { describe, expect, test } from "bun:test";
+import { resolveProductionBehaviorValues } from "../src/routing/compatibility/behavior";
+import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
+import type { OcxConfig, OcxParsedRequest, OcxProviderConfig } from "../src/types";
+
+// ollama-cloud ships `gpt-oss:120b` verbatim (src/providers/registry.ts) and the same
+// registry row lists the bare `gpt-oss` in noVisionModels, i.e. the bare-prefix form is
+// the documented, intended way to write these lists.
+const MODEL = "gpt-oss:120b";
+
+const effective: OcxProviderConfig = {
+  adapter: "openai-chat",
+  baseUrl: "https://ollama.com/v1",
+  apiKey: "sk-test",
+  authMode: "key",
+  noTemperatureModels: ["gpt-oss"],
+  noTopPModels: ["gpt-oss"],
+  noPenaltyModels: ["gpt-oss"],
+  thinkingBudgetModels: ["gpt-oss"],
+  autoToolChoiceOnlyModels: ["gpt-oss"],
+};
+
+const config = { providers: { "ollama-cloud": effective } } as unknown as OcxConfig;
+
+const values = () =>
+  resolveProductionBehaviorValues(config, "ollama-cloud", MODEL, effective, "salt")!;
+
+function wire(): Record<string, unknown> {
+  const parsed: OcxParsedRequest = {
+    modelId: MODEL,
+    context: { messages: [{ role: "user", content: "hi", timestamp: 0 }] },
+    stream: false,
+    options: { temperature: 0.5, topP: 0.9, presencePenalty: 0.2, frequencyPenalty: 0.2 },
+  };
+  return JSON.parse(createOpenAIChatAdapter(effective).buildRequest(parsed).body as string);
+}
+
+describe("behavior report must agree with the wire the adapter actually builds", () => {
+  test("adapter really does omit these for the :tag model (ground truth)", () => {
+    const body = wire();
+    expect(body.temperature).toBeUndefined();
+    expect(body.top_p).toBeUndefined();
+    expect(body.presence_penalty).toBeUndefined();
+    expect(body.frequency_penalty).toBeUndefined();
+  });
+
+  test("report agrees: sampling.omitTemperature", () => {
+    expect(values()["sampling.omitTemperature"]!.value).toBe(true);
+  });
+  test("report agrees: sampling.omitTopP", () => {
+    expect(values()["sampling.omitTopP"]!.value).toBe(true);
+  });
+  test("report agrees: sampling.omitPenalties", () => {
+    expect(values()["sampling.omitPenalties"]!.value).toBe(true);
+  });
+  test("report agrees: reasoning.budgetMode", () => {
+    expect(values()["reasoning.budgetMode"]!.value).toBe(true);
+  });
+  test("report agrees: tools.choiceRestrictions", () => {
+    expect(values()["tools.choiceRestrictions"]!.value).toEqual(["auto"]);
+  });
+
+  test("an unlisted model reports false (control)", () => {
+    const v = resolveProductionBehaviorValues(config, "ollama-cloud", "glm-5.3", effective, "salt")!;
+    expect(v["sampling.omitTemperature"]!.value).toBe(false);
+    expect(v["reasoning.budgetMode"]!.value).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`resolveProductionBehaviorValues` is documented as *"authoritative effective values emitted by the production route/model/adapter resolver"*, and `buildBehaviorFingerprintV1` hashes it into the behavior fingerprint that keys Lab evidence.

Ten of its rows are membership tests over the provider's `no*Models`-style lists, and they went through a local helper:

```ts
function includesModel(list: string[] | undefined, modelId: string): boolean {
  return Array.isArray(list) && list.includes(modelId);
}
```

Every runtime gate those rows describe matches through `modelInList` instead, which also accepts a bare entry for a tagged id:

| row | runtime gate |
|---|---|
| `sampling.omitTemperature` / `omitTopP` / `omitPenalties` | `openai-chat.ts` 113–115, 1326, 1329, 1398, 1401 |
| `reasoning.supported` | `reasoning-effort.ts:107` |
| `reasoning.replayMode.preserveContent` / `.placeholder` | `openai-chat.ts` 691, 700, 714, 760, 774–775 |
| `reasoning.splitMode` / `toggleMode` / `budgetMode` | `openai-chat.ts` 1315, 1370, 1380 |
| `tools.choiceRestrictions` | `openai-chat.ts:1321` |

All ten use `modelInList`. The report used exact match for all ten.

## Why it bites

`ollama-cloud` serves tagged ids verbatim — `gpt-oss:120b`, `qwen3-coder:480b`, `qwen3.5:397b`, `gemma4:31b` — and **the same registry row** writes the bare `gpt-oss` into `noVisionModels`, so the bare-prefix form is how these lists are meant to be written.

With `noTemperatureModels: ["gpt-oss"]`, for `gpt-oss:120b`:

- the adapter **omits** `temperature` from the upstream request
- the report says `sampling.omitTemperature: false`

The authoritative record contradicts the wire, and that contradiction is hashed into the fingerprint Lab uses to link observations.

## Blast radius, measured

Same config, before and after, first 16 hex of the behavior fingerprint:

| model | dev | this branch | |
|---|---|---|---|
| `gpt-oss:120b` | `54154e19bd2c8ee4` | `45a73577c5c257f9` | changed — it was wrong |
| `gpt-oss` | `45a73577c5c257f9` | `45a73577c5c257f9` | unchanged |
| `glm-5.3` | `54154e19bd2c8ee4` | `54154e19bd2c8ee4` | unchanged |

Read the first row against the third: on `dev`, a model whose sampling gates **were** applied hashed identically to one where they were **not**. It now hashes with `gpt-oss`, the id it actually behaves like.

### On `resolverVersion`

#1956 established the rule — *"adding hashed keys without it silently made new fingerprints incomparable to recorded ones"*. I left `resolverVersion` at `2` on purpose: unlike a key addition, this only moves subjects that were being described incorrectly, and the table above shows unaffected subjects keep their fingerprint, so their recorded evidence stays linkable. If you would rather draw a clean generation boundary anyway, say so and I will bump it in this PR.

## Tests

`tests/routing-compatibility-model-matching.test.ts`. The first case asserts the wire the adapter really builds for the tagged model; the rest hold the report to that same wire, so the two cannot drift apart silently. A control asserts an unlisted model still reports `false`.

The five report cases fail on current `dev` (2 pass / 5 fail) and pass here (7 / 0).

## Verification

Run on the exact head of this branch:

```
bun run typecheck                                    clean

bun test tests/routing-compatibility-model-matching.test.ts
                                                     7 pass / 0 fail
  same file with src reverted to dev:                2 pass / 5 fail

bun scripts/test.ts <22 test files touching compatibility,
  behaviorValues, passive-route-linker, lab, fastwire>
                                                     856 pass / 6 skip / 0 fail
```

I did not run the full suite: this is a Windows machine and `bun run test` panics partway through on Bun 1.3.14 (`index out of bounds: index 0, len 0`), so a result from it would be a truncated log rather than a result. The batch above went through `scripts/test.ts` so each file keeps its isolated home.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider exclusion matching so tagged model IDs are correctly recognized when their base model is listed.
  * Updated compatibility reporting for `gpt-oss:120b`, including accurate handling of supported request options and restrictions.

* **Tests**
  * Added coverage for model matching and compatibility behavior, including unlisted models and request field handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

> **What box 1 covers here.** Ticked on the same reading @Ingwannu applied to #2042 — the box gates triggering the full exact-head CI, not a claim to have run CI itself. To keep the record exact: "green on my local testing" means everything listed under **Verification** above ran green on this exact head — typecheck, the new tests, the same tests against unpatched `dev` to prove they fail there, and a batch of the surrounding suite. It does **not** mean I ran the full suite: this is a Windows machine, `bun run test` panics partway through on Bun 1.3.14 (`index out of bounds: index 0, len 0`), and the Windows baseline on clean `dev` is not green either (#1059). The exact-head CI gate is the authority on the full suite, which is what marking this Ready hands it.


