### PR TITLE
fix(codex): strip app-rewritten provider sub-tables so the provider never survives nameless

### DIFF
--- a/src/codex/inject.ts
+++ b/src/codex/inject.ts
@@ -1104,8 +1104,11 @@ export async function injectCodexConfig(
  * `[model_providers.opencodex_backup]`-style tables out of scope.
  */
 function isOcxProviderHeaderLine(trimmedLine: string): boolean {
+  // Root form matched by regex, not equality: TOML v1.0 allows a trailing comment
+  // (`[model_providers.opencodex] # comment`), and an exact compare would miss that form.
+  // The sub-table prefix check already tolerates trailing comments by construction.
   return (
-    trimmedLine === "[model_providers.opencodex]" ||
+    /^\[model_providers\.opencodex\]\s*(?:#.*)?$/.test(trimmedLine) ||
     trimmedLine.startsWith("[model_providers.opencodex.")
   );
 }

--- a/src/codex/inject.ts
+++ b/src/codex/inject.ts
@@ -735,7 +735,7 @@ export async function injectCodexConfig(
   // Design B form FIRST: removeOcxSection also keys on the marker line, so a root-level
   // marker + openai_base_url pair must be gone before it scans or it would swallow root keys.
   content = stripInjectedOpenaiBaseUrl(content);
-  if (content.includes("[model_providers.opencodex]")) {
+  if (hasOcxProviderTable(content)) {
     content = removeOcxSection(content);
   }
   content = removeProfileSection(content);
@@ -1095,6 +1095,27 @@ export async function injectCodexConfig(
   };
 }
 
+/**
+ * Sub-table headers like `[model_providers.opencodex.env_http_headers]` appear when a Codex app
+ * config rewrite re-serializes the provider's inline `env_http_headers` table. They define the
+ * same `model_providers.opencodex` provider, so cleanup must remove them too — otherwise the
+ * provider survives with no `name` and Codex rejects the whole config
+ * ("provider name must not be empty"). The dot terminator keeps a user's
+ * `[model_providers.opencodex_backup]`-style tables out of scope.
+ */
+function isOcxProviderHeaderLine(trimmedLine: string): boolean {
+  return (
+    trimmedLine === "[model_providers.opencodex]" ||
+    trimmedLine.startsWith("[model_providers.opencodex.")
+  );
+}
+
+function hasOcxProviderTable(content: string): boolean {
+  return content
+    .split("\n")
+    .some((line) => isOcxProviderHeaderLine(line.trim()));
+}
+
 function removeOcxSection(content: string): string {
   const lines = content.split("\n");
   const filtered: string[] = [];
@@ -1102,18 +1123,16 @@ function removeOcxSection(content: string): string {
   for (const line of lines) {
     if (
       line.includes(OCX_SECTION_MARKER) ||
-      line.trim() === "[model_providers.opencodex]"
+      isOcxProviderHeaderLine(line.trim())
     ) {
       inOcxSection = true;
       continue;
     }
     if (inOcxSection) {
-      // End the injected section at the next table header that ISN'T our own — exact match so a
-      // user's "[model_providers.opencodex_backup]" (or similar) is preserved, not swallowed.
-      if (
-        /^\s*\[/.test(line) &&
-        line.trim() !== "[model_providers.opencodex]"
-      ) {
+      // End the injected section at the next table header that ISN'T our own. Exact match on the
+      // provider name (plus our own sub-tables) so a user's
+      // "[model_providers.opencodex_backup]" (or similar) is preserved, not swallowed.
+      if (/^\s*\[/.test(line) && !isOcxProviderHeaderLine(line.trim())) {
         inOcxSection = false;
         filtered.push(line);
       }
@@ -1153,7 +1172,7 @@ function stripOpencodexConfigResult(
     || (journaledBaseUrl !== null && rootTomlString(out, "openai_base_url") === journaledBaseUrl);
   out = stripInjectedOpenaiBaseUrl(out); // before removeOcxSection — it keys on the marker line too
   out = stripJournaledOpenaiBaseUrl(out, journaledBaseUrl);
-  if (out.includes("[model_providers.opencodex]")) {
+  if (hasOcxProviderTable(out)) {
     out = removeOcxSection(out);
   }
   out = removeProfileSection(out);
@@ -1182,7 +1201,7 @@ export function stripOpencodexConfig(content: string): string {
 
 function hasOpencodexRouting(content: string): boolean {
   return (
-    content.includes("[model_providers.opencodex]") ||
+    hasOcxProviderTable(content) ||
     /^\s*model_provider\s*=\s*"opencodex"/m.test(content) ||
     hasInjectedOpenaiBaseUrl(content)
   );

--- a/tests/codex-inject.test.ts
+++ b/tests/codex-inject.test.ts
@@ -431,6 +431,36 @@ describe("Design B openai_base_url injection", () => {
     expect(stripped).toContain("[model_providers.opencodex_backup]");
     expect(stripped).toContain('name = "user backup"');
   });
+
+  test("a trailing comment on the root provider header is still recognized (TOML allows `[table] # comment`)", () => {
+    const commented = [
+      'model = "gpt-5.5"',
+      "",
+      "[model_providers.opencodex] # managed provider",
+      'name = "OpenCodex Proxy"',
+      'base_url = "http://127.0.0.1:10100/v1"',
+      "",
+    ].join("\n");
+    const stripped = stripOpencodexConfig(commented);
+
+    expect(stripped).not.toContain("model_providers.opencodex");
+    expect(stripped).not.toContain("OpenCodex Proxy");
+    expect(stripped).toContain('model = "gpt-5.5"');
+  });
+
+  test("a trailing comment on the sub-table header is still recognized", () => {
+    const commented = [
+      'model = "gpt-5.5"',
+      "",
+      "[model_providers.opencodex.env_http_headers] # managed sub-table",
+      '"x-opencodex-api-key" = "OPENCODEX_API_AUTH_TOKEN"',
+      "",
+    ].join("\n");
+    const stripped = stripOpencodexConfig(commented);
+
+    expect(stripped).not.toContain("opencodex");
+    expect(stripped).toContain('model = "gpt-5.5"');
+  });
 });
 
 describe("EOL boundary helpers (Windows CRLF configs)", () => {

--- a/tests/codex-inject.test.ts
+++ b/tests/codex-inject.test.ts
@@ -365,6 +365,72 @@ describe("Design B openai_base_url injection", () => {
     expect(stripped).not.toContain("[model_providers.opencodex]");
     expect(stripped).toContain('model = "gpt-5.5"');
   });
+
+  test("app-rewritten env_http_headers sub-table strips fully: no nameless provider survives", () => {
+    // A Codex app config rewrite re-serializes the provider's inline env_http_headers table
+    // into a separate [model_providers.opencodex.env_http_headers] sub-table. Cleanup must
+    // remove the provider table AND its sub-table, or the provider survives with no `name`
+    // and Codex rejects the whole config ("provider name must not be empty").
+    const rewritten = [
+      'model = "gpt-5.5"',
+      "",
+      "[model_providers.opencodex]",
+      'name = "OpenCodex Proxy"',
+      'base_url = "http://127.0.0.1:10100/v1"',
+      'wire_api = "responses"',
+      "",
+      "[model_providers.opencodex.env_http_headers]",
+      '"x-opencodex-api-key" = "OPENCODEX_API_AUTH_TOKEN"',
+      "",
+      "[agents]",
+      "max_concurrent_threads_per_session = 8",
+      "",
+    ].join("\n");
+    const stripped = stripOpencodexConfig(rewritten);
+
+    expect(stripped).not.toContain("opencodex");
+    expect(stripped).toContain("[agents]");
+    expect(stripped).toContain('model = "gpt-5.5"');
+  });
+
+  test("an orphaned env_http_headers sub-table alone is removed (recurrence breaker)", () => {
+    // Once the main table is gone, only the sub-table header defines the provider. The old
+    // exact-match guards never matched that form, so the orphan was journaled as baseline and
+    // re-persisted on every inject/restore cycle while Codex kept failing on startup.
+    const orphan = [
+      'model = "gpt-5.5"',
+      "",
+      "[agents]",
+      "max_concurrent_threads_per_session = 8",
+      "",
+      "[model_providers.opencodex.env_http_headers]",
+      '"x-opencodex-api-key" = "OPENCODEX_API_AUTH_TOKEN"',
+      '"CF-Access-Client-Id" = "CF_ACCESS_CLIENT_ID"',
+      "",
+    ].join("\n");
+    const stripped = stripOpencodexConfig(orphan);
+
+    expect(stripped).not.toContain("opencodex");
+    expect(stripped).not.toContain("CF-Access-Client-Id");
+    expect(stripped).toContain('model = "gpt-5.5"');
+    expect(stripped).toContain("[agents]");
+  });
+
+  test("a user's similarly named provider table is preserved while opencodex sub-tables strip", () => {
+    const content = [
+      "[model_providers.opencodex.env_http_headers]",
+      '"x-opencodex-api-key" = "OPENCODEX_API_AUTH_TOKEN"',
+      "",
+      "[model_providers.opencodex_backup]",
+      'name = "user backup"',
+      "",
+    ].join("\n");
+    const stripped = stripOpencodexConfig(content);
+
+    expect(stripped).not.toContain("env_http_headers");
+    expect(stripped).toContain("[model_providers.opencodex_backup]");
+    expect(stripped).toContain('name = "user backup"');
+  });
 });
 
 describe("EOL boundary helpers (Windows CRLF configs)", () => {


### PR DESCRIPTION
## Summary

Observed in the wild on v2.25.0 (macOS Codex App + ocx daemon): every new Codex chat fails with

```
invalid configuration: model_providers.opencodex: provider name must not be empty
```

Root cause chain:

1. User config carries `[model_providers.opencodex]` with `name`/`base_url`/`wire_api` and an inline `env_http_headers = { ... }` table.
2. A Codex app config rewrite re-serializes that inline table into a separate `[model_providers.opencodex.env_http_headers]` sub-table (the same app-rewrite behavior already documented around `stripOpencodexConfigResult`, e.g. the #1798 comment).
3. On the next inject/restore, `removeOcxSection()` removes the main table but ends its removal scope at "the next table header" — and the sub-table header is one — so the sub-table survives. `model_providers.opencodex` now exists with only `env_http_headers` and no `name`, and Codex rejects the whole config on startup.
4. All cleanup guards (`injectCodexConfig`, `stripOpencodexConfigResult`, `hasOpencodexRouting`) match the exact string `"[model_providers.opencodex]"`, which never matches the sub-table form. The orphan is journaled as the baseline and re-persisted on every inject/restore cycle, so the breakage recurs until the sub-table is removed by hand.

Fix: recognize `[model_providers.opencodex.*]` sub-table headers in `removeOcxSection()` and in the three cleanup guards, so the main table and its sub-tables are removed together. A user's own similarly named table (`[model_providers.opencodex_backup]`) stays out of scope because the match requires the `opencodex.` dot boundary. No behavior changes for configs without the sub-table form.

## Test plan

- `bun run typecheck` — clean (no output).
- `bun test tests/codex-inject.test.ts` — **34 pass / 0 fail**, including three new regression tests:
  - full app-rewritten form (main table + sub-table) strips completely;
  - an orphaned `env_http_headers` sub-table alone is removed (the recurrence breaker);
  - a user's `[model_providers.opencodex_backup]` table is preserved.
- Full suite `bun run test`: 13,334 tests / 846 files, **81 fail — all pre-existing on unmodified `dev` (bcc77c0) in this environment**. Verified by running the 14 failing files on both trees: identical results (`262 pass / 81 fail` on patched `76906a3` and on stashed clean dev). The suite also ran ~3× slower than the runner's own idle expectation (606s vs ~210s note printed by `scripts/test.ts`), consistent with machine load; failures cluster in lab/e2e/auth suites, none in codex config injection.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


## Review readiness checklist

- [x] All CI tests are green on my local testing. (`bun run typecheck` clean; `bun test tests/codex-inject.test.ts` 34/34; full suite failures proven pre-existing on unmodified dev with zero delta — see Test plan)
- [x] I pushed my PR to the latest dev commit. (based on dev `bcc77c0`, verified still head at push time)
- [x] I resolved all correct Codex and CodeRabbit findings. (none raised so far — CodeRabbit skipped review while in draft; will address any that appear)
- [x] My PR is ready for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup and restoration of OpenCodex configuration sections, including nested tables and sections with trailing comments.
  - Preserved similarly named user configuration tables, such as backup sections.
  - Improved detection when routing or injecting OpenCodex configuration.

- **Tests**
  - Added regression coverage for rewritten and orphaned configuration sections.
  - Verified unrelated user tables remain intact, including similarly named tables and commented headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

