### PR TITLE
fix(google): append continue nudge for Claude-on-Antigravity prefill

### DIFF
--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -498,6 +498,17 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
           } else {
             sanitizeAntigravityClaudeSignatures(contents);
           }
+          // Claude-on-Antigravity rejects assistant-tail (model-tail in Gemini terms) histories
+          // as prefill: "This model does not support assistant message prefill. The conversation
+          // must end with a user message." Context compaction, previous_response_id expansion,
+          // and interrupted-turn replay can all produce a model-tail history. Append a user
+          // "(continue)" nudge, mirroring the anthropic adapter's tail guard (src/adapters/anthropic.ts).
+          if (/claude/i.test(wireModelId)) {
+            const last = contents.length > 0 ? contents[contents.length - 1] as { role?: string } : undefined;
+            if (!last || last.role === "model") {
+              contents.push({ role: "user", parts: [{ text: "(continue)" }] });
+            }
+          }
         }
         const envelope = {
           model: wireModelId,

--- a/tests/google-claude-prefill-guard.test.ts
+++ b/tests/google-claude-prefill-guard.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { createGoogleAdapter as createGoogleAdapterProduction } from "../src/adapters/google";
+import type { OcxMessage, OcxParsedRequest, OcxProviderConfig } from "../src/types";
+import { withTestTranslatorBudget } from "./helpers/translator-budget";
+
+const createGoogleAdapter = (...args: Parameters<typeof createGoogleAdapterProduction>) =>
+  withTestTranslatorBudget(createGoogleAdapterProduction(...args));
+
+const provider = {
+  adapter: "google",
+  baseUrl: "https://daily-cloudcode-pa.googleapis.com",
+  googleMode: "cloud-code-assist",
+  project: "proj-123",
+  apiKey: "ya29.token",
+} as OcxProviderConfig;
+
+function parsed(messages: OcxMessage[], modelId = "claude-opus-4-6-thinking"): OcxParsedRequest {
+  return {
+    modelId,
+    stream: false,
+    options: {},
+    context: { messages, systemPrompt: [], tools: [] },
+  } as unknown as OcxParsedRequest;
+}
+
+async function envelopeContents(p: OcxParsedRequest): Promise<{ role: string; parts: unknown[] }[]> {
+  const { body } = await createGoogleAdapter(provider).buildRequest(p);
+  const envelope = JSON.parse(body);
+  return envelope.request.contents;
+}
+
+describe("google claude prefill guard", () => {
+  test("appends a user continue nudge when CCA Claude context ends with model turn", async () => {
+    const contents = await envelopeContents(parsed([
+      { role: "user", content: "start", timestamp: 0 },
+      { role: "assistant", content: [{ type: "text", text: "partial answer" }], model: "claude", timestamp: 0 },
+    ]));
+
+    expect(contents.at(-1)).toEqual({ role: "user", parts: [{ text: "(continue)" }] });
+  });
+
+  test("leaves context ending with user unchanged", async () => {
+    const contents = await envelopeContents(parsed([
+      { role: "assistant", content: [{ type: "text", text: "answer" }], model: "claude", timestamp: 0 },
+      { role: "user", content: "follow up", timestamp: 0 },
+    ]));
+
+    expect(contents.at(-1)!.role).toBe("user");
+    expect(JSON.stringify(contents.at(-1))).not.toContain("(continue)");
+  });
+
+  test("appends nudge when CCA Claude context is empty", async () => {
+    const contents = await envelopeContents(parsed([]));
+
+    expect(contents.at(-1)).toEqual({ role: "user", parts: [{ text: "(continue)" }] });
+  });
+
+  test("does not append nudge after tool result (tool result maps to user role)", async () => {
+    const contents = await envelopeContents(parsed([
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read_file", arguments: { path: "README.md" } }],
+        model: "claude",
+        timestamp: 0,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read_file",
+        content: "contents",
+        isError: false,
+        timestamp: 0,
+      },
+    ] as OcxMessage[]));
+
+    // toolResult maps to role:"user" in Gemini format, so no nudge needed
+    expect(contents.at(-1)!.role).toBe("user");
+    expect(JSON.stringify(contents.at(-1))).not.toContain("(continue)");
+  });
+
+  test("does not append nudge for non-Claude models on Antigravity", async () => {
+    const contents = await envelopeContents(parsed([
+      { role: "user", content: "start", timestamp: 0 },
+      { role: "assistant", content: [{ type: "text", text: "answer" }], model: "gemini", timestamp: 0 },
+    ], "gemini-3.7-flash"));
+
+    // Gemini natively accepts model-tail; no nudge
+    expect(contents.at(-1)!.role).toBe("model");
+    expect(JSON.stringify(contents)).not.toContain("(continue)");
+  });
+});


### PR DESCRIPTION
## Summary

- Claude-on-Antigravity rejects a history that ends on a model turn as assistant prefill (`The conversation must end with a user message`).
- Context compaction, `previous_response_id` expansion, and interrupted-turn replay can all produce that shape.
- The Anthropic adapter already appends a user `(continue)` nudge (`src/adapters/anthropic.ts`). This applies the same guard on the CCA Claude path only, in Gemini wire format (`role: "user", parts: [{ text: "(continue)" }]`).
- Gemini-native Antigravity models are unchanged. User-tailed and tool-result-tailed histories are unchanged.

Closes #2065

Related: #1916 already contains a broader `stripTrailingClaudePrefill` change, but that PR is draft, hygiene-blocked, and conflicted. This PR keeps only the prefill guard and does not take the pop-the-last-model-turn approach.

## Verification

- `bun test tests/google-claude-prefill-guard.test.ts` — 5 pass
- `bun test tests/google-adapter.test.ts tests/google-antigravity-wire.test.ts tests/google-hardening.test.ts tests/google-claude-prefill-guard.test.ts tests/anthropic-tail-guard.test.ts` — 86 pass
- `bun run typecheck` — pass
- `bun run privacy:scan` — pass
- `bun run test` — 9848 pass, 8 skip, 1 unrelated flake in `tests/native-profile-drain-server.test.ts` (reproduced green in isolation)
- Live CCA request with `google-antigravity/claude-opus-4-6-thinking` and an assistant-tail history returned HTTP 200

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude request handling when conversation context is empty or ends with an assistant response.
  * Prevented unnecessary continuation prompts for supported user or tool-result contexts and non-Claude models.

* **Tests**
  * Added coverage for Claude continuation behavior across empty, assistant, user, tool-result, and non-Claude request scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->