### PR TITLE
fix(providers): add official opencode client User-Agent to opencode-free

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -2435,6 +2435,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     note: "No key needed — public desktop tier. OpenCode currently advertises about 200 Big Pickle/free-model requests per 5 hours. The same Zen gateway can also short-window rate-limit free models at roughly 15-20 requests/minute, and may return generic 429s without Retry-After (opencodex synthesizes backoff only when that header is omitted). Free models are discovered live from Zen. Data use: per OpenCode's Zen docs (https://opencode.ai/docs/zen/), prompts sent to free models may be retained and used for training/improvement — do not send confidential material through this provider.",
     dashboardUrl: "https://opencode.ai",
     staticHeaders: {
+      "User-Agent": "opencode",
       "x-opencode-client": "desktop",
     },
     modelReasoningEfforts: Object.fromEntries(OPENCODE_FREE_DEEPSEEK_MODELS.map(id => [id, deepseekThinkingEffortsFor(id)])),

--- a/tests/management-provider-validation.test.ts
+++ b/tests/management-provider-validation.test.ts
@@ -2888,11 +2888,11 @@ describe("provider management validation", () => {
     };
 
     // Clearing user-managed headers must not delete the registry-owned static
-    // metadata (opencode-free's x-opencode-client marker) the transport relies on.
+    // metadata (opencode-free's User-Agent and x-opencode-client markers) the transport relies on.
     expect((await patch("opencode-free", { headers: null }))?.status).toBe(200);
-    expect(liveConfig.providers["opencode-free"].headers).toEqual({ "x-opencode-client": "desktop" });
+    expect(liveConfig.providers["opencode-free"].headers).toEqual({ "User-Agent": "opencode", "x-opencode-client": "desktop" });
     const saved = JSON.parse(readFileSync(join(TEST_DIR, "config.json"), "utf8")) as OcxConfig;
-    expect(saved.providers["opencode-free"]?.headers).toEqual({ "x-opencode-client": "desktop" });
+    expect(saved.providers["opencode-free"]?.headers).toEqual({ "User-Agent": "opencode", "x-opencode-client": "desktop" });
   });
   test("concurrent provider PATCHes merge different headers", async () => {
     if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });

--- a/tests/opencode-free-provider.test.ts
+++ b/tests/opencode-free-provider.test.ts
@@ -29,12 +29,14 @@ describe("opencode-free provider", () => {
 
   test("static headers include only the public client marker", () => {
     expect(entry?.staticHeaders?.["Authorization"]).toBeUndefined();
+    expect(entry?.staticHeaders?.["User-Agent"]).toBe("opencode");
     expect(entry?.staticHeaders?.["x-opencode-client"]).toBe("desktop");
   });
 
   test("providerConfigSeed propagates static headers", () => {
     const seed = providerConfigSeed(entry!);
     expect(seed.headers?.["Authorization"]).toBeUndefined();
+    expect(seed.headers?.["User-Agent"]).toBe("opencode");
     expect(seed.headers?.["x-opencode-client"]).toBe("desktop");
     expect(seed.keyOptional).toBe(true);
     expect(seed.liveModels).toBe(true);
@@ -55,6 +57,7 @@ describe("opencode-free provider", () => {
     const req = adapter.buildRequest(minimalRequest());
     const headers = req.headers as Record<string, string>;
     expect(headers["Authorization"]).toBeUndefined();
+    expect(headers["User-Agent"]).toBe("opencode");
     expect(headers["x-opencode-client"]).toBe("desktop");
     expect(req.url).toBe("https://opencode.ai/zen/v1/chat/completions");
   });


### PR DESCRIPTION
### Problem
Requests to OpenCode Free (`https://opencode.ai/zen/v1/chat/completions`) currently fail with `429 Too Many Requests` / `FreeUsageLimitError`:
```json
{"type":"error","error":{"type":"FreeUsageLimitError","message":"Error from provider (Console): Rate limit exceeded. Please try again later."}}
```
This occurs because the OpenCode API gateway rejects requests carrying generic/browser `User-Agent` strings alongside `x-opencode-client: desktop`, requiring the official client `User-Agent` prefix (`opencode`) used by the official `@opencode-ai/desktop` and CLI applications.

### Solution
Add the canonical `User-Agent: opencode` header to `staticHeaders` for `opencode-free` in `src/providers/registry.ts`, while preserving the existing desktop client identity (`x-opencode-client: desktop`) and avoiding fragile CLI-specific version strings or unnecessary project headers:
- `User-Agent`: `opencode` (matches the root client family `opencode/${version}` from `@opencode-ai/desktop` bundle `out/main/chunks/node-4IhTfWZ9.js`)
- `x-opencode-client`: `desktop` (preserves the desktop tier identity and documentation consistency)

### Verification
- Decompiled and inspected `@opencode-ai/desktop` (v1.18.18) app bundle (`USER_AGENT = "opencode/" + InstallationVersion`).
- Tested live against `https://opencode.ai/zen/v1/chat/completions` across header variations:
  - `User-Agent: opencode` + `x-opencode-client: desktop` -> `200 OK`
  - generic User-Agent + `x-opencode-client: desktop` -> `429 FreeUsageLimitError`
- `bun test tests/opencode-free-provider.test.ts` passes.
- `bun test tests/management-provider-validation.test.ts` passes.
- `bun run typecheck` (`tsc --noEmit`) passes cleanly.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added the `User-Agent: opencode` header to requests made through the OpenCode Free provider.
  * Ensured provider-managed headers are preserved when clearing or updating configuration.
  * Improved consistency of headers across configured and unauthenticated requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->