### PR TITLE
fix(lab): read per-model overrides in the report the way the runtime reads them

### DIFF
--- a/src/routing/compatibility/behavior.ts
+++ b/src/routing/compatibility/behavior.ts
@@ -53,7 +53,7 @@ function includesModel(list: string[] | undefined, modelId: string): boolean {
 }
 
 /**
- * Per-model override lookup for the report rows.
+ * Per-model override lookup for the nine family-aware report rows.
  *
  * Delegates to modelRecordValue so the report reads these maps the way the
  * runtime does -- own properties only, then the pre-colon family, then a
@@ -62,12 +62,35 @@ function includesModel(list: string[] | undefined, modelId: string): boolean {
  * differently-cased key, and walked the prototype chain, so a routed model id
  * of `constructor`/`toString` yielded an Object.prototype function. That last
  * one made buildBehaviorFingerprintV1 throw ("unsupported value type
- * function"), which resolvePassiveRouteSubjectId swallows -- the subject is
- * silently dropped, and the linker contract says implementations do not throw.
- * openai-responses.ts guards modelPreferHostedTools for the same reason.
+ * function"); the caller catches it (`src/routing/compatibility/subject.ts:125`)
+ * and returns no route, so the subject is silently dropped -- and the linker
+ * contract says implementations do not throw.
+ *
+ * Not every override map belongs here. `modelPreferHostedTools` and
+ * `modelOpenRouterRouting` are exact-own at runtime and go through
+ * `exactOwnValue` below; widening those to the family would be this same bug
+ * with the sign flipped.
  */
 function modelValue<T>(map: Record<string, T> | undefined, modelId: string): T | undefined {
   return modelRecordValue(map, modelId);
+}
+
+/**
+ * Exact, own-property lookup for the two maps the runtime resolves that way.
+ *
+ * `modelPreferHostedTools` and `modelOpenRouterRouting` are deliberately exact: the
+ * adapter reads the first through `hasOwnProperty`
+ * (`src/adapters/openai-responses.ts:1001`) and the second through `Object.hasOwn`
+ * (`src/providers/openrouter-routing.ts:89`), and the type documents the first as
+ * "Exact-model hosted tools" (`src/types.ts:1584`). Sending them through
+ * `modelRecordValue` would make the report say a `gpt-oss` entry applies to
+ * `gpt-oss:120b` when the adapter will never apply it -- the same divergence this
+ * file exists to remove, pointed the other way. A bare index is not the answer
+ * either: it walks the prototype chain, which is the bug `modelValue` just fixed.
+ * Neither existing primitive is right for these two, so this is the third one.
+ */
+function exactOwnValue<T>(map: Record<string, T> | undefined, modelId: string): T | undefined {
+  return map !== undefined && Object.hasOwn(map, modelId) ? map[modelId] : undefined;
 }
 
 const CREDENTIAL_HEADER = /(authorization|api[-_]?key|token|secret|credential|cookie)/i;
@@ -84,7 +107,7 @@ function nonCredentialHeaderDigest(
 }
 
 function effectiveOpenRouterRouting(effective: OcxProviderConfig, modelId: string) {
-  return effective.modelOpenRouterRouting?.[modelId] ?? effective.openRouterRouting;
+  return exactOwnValue(effective.modelOpenRouterRouting, modelId) ?? effective.openRouterRouting;
 }
 
 /**
@@ -199,7 +222,7 @@ export function resolveProductionBehaviorValues(
       effective.parallelToolCalls ?? (upstreamProtocol === "openai-chat"),
     ),
     "tools.hostedPreference": behaviorRow("provider_config", {
-      tools: modelValue(effective.modelPreferHostedTools, modelId) ?? [],
+      tools: exactOwnValue(effective.modelPreferHostedTools, modelId) ?? [],
     }),
     "tools.builtinNameEscaping": behaviorRow("provider_config", effective.escapeBuiltinToolNames === true),
     "cache.forwarding": behaviorRow("provider_config", effective.promptCacheKey === true),

--- a/src/routing/compatibility/behavior.ts
+++ b/src/routing/compatibility/behavior.ts
@@ -1,3 +1,4 @@
+import { modelRecordValue } from "../../reasoning-effort";
 import { modelInList } from "../../types";
 import type { OcxConfig, OcxProviderConfig } from "../../types";
 import { PROVIDER_REGISTRY } from "../../providers/registry";
@@ -51,8 +52,22 @@ function includesModel(list: string[] | undefined, modelId: string): boolean {
   return modelInList(list, modelId);
 }
 
+/**
+ * Per-model override lookup for the report rows.
+ *
+ * Delegates to modelRecordValue so the report reads these maps the way the
+ * runtime does -- own properties only, then the pre-colon family, then a
+ * case-folded key. A bare index disagreed on all three: it missed the
+ * `gpt-oss` entry ollama-cloud's `gpt-oss:120b` actually resolves, missed a
+ * differently-cased key, and walked the prototype chain, so a routed model id
+ * of `constructor`/`toString` yielded an Object.prototype function. That last
+ * one made buildBehaviorFingerprintV1 throw ("unsupported value type
+ * function"), which resolvePassiveRouteSubjectId swallows -- the subject is
+ * silently dropped, and the linker contract says implementations do not throw.
+ * openai-responses.ts guards modelPreferHostedTools for the same reason.
+ */
 function modelValue<T>(map: Record<string, T> | undefined, modelId: string): T | undefined {
-  return map?.[modelId];
+  return modelRecordValue(map, modelId);
 }
 
 const CREDENTIAL_HEADER = /(authorization|api[-_]?key|token|secret|credential|cookie)/i;

--- a/tests/routing-compatibility-model-matching.test.ts
+++ b/tests/routing-compatibility-model-matching.test.ts
@@ -8,6 +8,8 @@ import { describe, expect, test } from "bun:test";
 import { resolveProductionBehaviorValues } from "../src/routing/compatibility/behavior";
 import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
 import { buildBehaviorFingerprintV1 } from "../src/lab/subject/behavior-fingerprint";
+import { resolveOpenRouterRouting } from "../src/providers/openrouter-routing";
+import { modelRecordValue } from "../src/reasoning-effort";
 import type { OcxConfig, OcxParsedRequest, OcxProviderConfig } from "../src/types";
 
 // ollama-cloud ships `gpt-oss:120b` verbatim (src/providers/registry.ts) and the same
@@ -136,5 +138,63 @@ describe("a prototype-shaped model id resolves to no override", () => {
     expect(() => buildBehaviorFingerprintV1(overrideValues("constructor"))).not.toThrow();
     expect(buildBehaviorFingerprintV1(overrideValues("constructor")))
       .toBe(buildBehaviorFingerprintV1(overrideValues("toString")));
+  });
+});
+
+// Not every override map is family-aware, and the two that are not must stay that way.
+// The adapter reads `modelPreferHostedTools` through `hasOwnProperty`
+// (`src/adapters/openai-responses.ts:1001`) and `resolveOpenRouterRouting` reads
+// `modelOpenRouterRouting` through `Object.hasOwn` (`src/providers/openrouter-routing.ts:89`);
+// the type calls the first "Exact-model hosted tools" (`src/types.ts:1584`). Sending
+// these through modelRecordValue would be the divergence above with the sign flipped:
+// the report would claim an override applies that the adapter will never apply.
+const EXACT_ONLY: OcxProviderConfig = {
+  adapter: "openai-responses",
+  baseUrl: "https://openrouter.ai/api/v1",
+  apiKey: "sk-test",
+  authMode: "key",
+  modelPreferHostedTools: { "gpt-oss": ["image_generation"] },
+  modelOpenRouterRouting: { "gpt-oss": { order: ["fireworks"] } },
+} as unknown as OcxProviderConfig;
+
+const exactConfig = { providers: { "ollama-cloud": EXACT_ONLY } } as unknown as OcxConfig;
+
+const exactValues = (modelId: string) =>
+  resolveProductionBehaviorValues(exactConfig, "ollama-cloud", modelId, EXACT_ONLY, "salt")!;
+
+describe("exact-own override maps must not spread to the family", () => {
+  test("the runtime really does not apply the bare-family entry to the :tag model (ground truth)", () => {
+    // openRouter routing is resolvable directly, so this half is executable rather than cited.
+    expect(resolveOpenRouterRouting(EXACT_ONLY, "gpt-oss")).toEqual({ order: ["fireworks"] });
+    expect(resolveOpenRouterRouting(EXACT_ONLY, MODEL)).toBeUndefined();
+
+    // And the divergence is real rather than theoretical: the family-aware primitive
+    // resolves the entry that the adapter's own-property guard does not see.
+    expect(modelRecordValue(EXACT_ONLY.modelPreferHostedTools, MODEL)).toEqual(["image_generation"]);
+    expect(Object.hasOwn(EXACT_ONLY.modelPreferHostedTools!, MODEL)).toBe(false);
+  });
+
+  test("report agrees: the :tag model gets no hosted-tool preference", () => {
+    expect(exactValues(MODEL)["tools.hostedPreference"]!.value).toEqual({ tools: [] });
+  });
+
+  test("report agrees: the :tag model gets no openrouter routing", () => {
+    expect(exactValues(MODEL)["openrouter.order"]!.value).toEqual([]);
+  });
+
+  test("an exact key still resolves on both maps (control)", () => {
+    const v = exactValues("gpt-oss");
+    expect(v["tools.hostedPreference"]!.value).toEqual({ tools: ["image_generation"] });
+    expect(v["openrouter.order"]!.value).toEqual(["fireworks"]);
+  });
+
+  test("a prototype-shaped id resolves neither map", () => {
+    // The bare index this replaced walked the prototype chain here too, so these two
+    // maps had the original bug and must not simply inherit the family-aware fix.
+    for (const modelId of ["constructor", "toString", "valueOf"]) {
+      const v = exactValues(modelId);
+      expect(v["tools.hostedPreference"]!.value).toEqual({ tools: [] });
+      expect(v["openrouter.order"]!.value).toEqual([]);
+    }
   });
 });

--- a/tests/routing-compatibility-model-matching.test.ts
+++ b/tests/routing-compatibility-model-matching.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, test } from "bun:test";
 import { resolveProductionBehaviorValues } from "../src/routing/compatibility/behavior";
 import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
+import { buildBehaviorFingerprintV1 } from "../src/lab/subject/behavior-fingerprint";
 import type { OcxConfig, OcxParsedRequest, OcxProviderConfig } from "../src/types";
 
 // ollama-cloud ships `gpt-oss:120b` verbatim (src/providers/registry.ts) and the same
@@ -70,5 +71,70 @@ describe("behavior report must agree with the wire the adapter actually builds",
     const v = resolveProductionBehaviorValues(config, "ollama-cloud", "glm-5.3", effective, "salt")!;
     expect(v["sampling.omitTemperature"]!.value).toBe(false);
     expect(v["reasoning.budgetMode"]!.value).toBe(false);
+  });
+});
+
+// The list-shaped options above are one half of the report. The other half is the
+// per-model override maps, which the runtime reads through modelRecordValue: own
+// properties, then the pre-colon family, then a case-folded key.
+
+const OVERRIDES: OcxProviderConfig = {
+  adapter: "openai-chat",
+  baseUrl: "https://ollama.com/v1",
+  apiKey: "sk-test",
+  authMode: "key",
+  modelMaxOutputTokens: { "gpt-oss": 1234 },
+  modelContextWindows: { "GPT-OSS": 55_555 },
+};
+
+const overrideConfig = { providers: { "ollama-cloud": OVERRIDES } } as unknown as OcxConfig;
+
+const overrideValues = (modelId: string) =>
+  resolveProductionBehaviorValues(overrideConfig, "ollama-cloud", modelId, OVERRIDES, "salt")!;
+
+describe("behavior report reads per-model overrides the way the runtime does", () => {
+  test("the adapter really applies the bare-family override to the :tag model (ground truth)", () => {
+    const parsed: OcxParsedRequest = {
+      modelId: MODEL,
+      context: { messages: [{ role: "user", content: "hi", timestamp: 0 }] },
+      stream: false,
+      options: {},
+    };
+    const body = JSON.parse(createOpenAIChatAdapter(OVERRIDES).buildRequest(parsed).body as string);
+    expect(body.max_tokens).toBe(1234);
+  });
+
+  test("report agrees: limits.maxOutputTokens for the :tag model", () => {
+    expect(overrideValues(MODEL)["limits.maxOutputTokens"]!.value).toBe(1234);
+  });
+
+  test("a case-folded key still resolves", () => {
+    expect(overrideValues("gpt-oss")["limits.contextWindow"]!.value).toBe(55_555);
+  });
+
+  test("an unrelated model gets no override (control)", () => {
+    expect(overrideValues("glm-5.3")["limits.maxOutputTokens"]!.value).toBeNull();
+  });
+});
+
+// Model ids are operator-controlled, so one can collide with Object.prototype.
+// openai-responses.ts already guards modelPreferHostedTools for exactly this.
+describe("a prototype-shaped model id resolves to no override", () => {
+  test.each(["constructor", "toString", "valueOf", "hasOwnProperty"])(
+    "%s yields null rather than an inherited function",
+    (modelId) => {
+      const v = overrideValues(modelId);
+      expect(v["limits.contextWindow"]!.value).toBeNull();
+      expect(v["limits.maxOutputTokens"]!.value).toBeNull();
+      expect(typeof v["modalities.input"]!.value).not.toBe("function");
+    },
+  );
+
+  test("so the behavior fingerprint stays computable", () => {
+    // jcsStringify rejects a function, and resolvePassiveRouteSubjectId swallows the
+    // throw -- the subject would silently never link.
+    expect(() => buildBehaviorFingerprintV1(overrideValues("constructor"))).not.toThrow();
+    expect(buildBehaviorFingerprintV1(overrideValues("constructor")))
+      .toBe(buildBehaviorFingerprintV1(overrideValues("toString")));
   });
 });


### PR DESCRIPTION
## Summary

#2059 fixed the list-shaped half of the behavior report. The **per-model override maps** are the other half, and they had the same shape of bug plus one more.

`modelValue` was a bare index:

```ts
function modelValue<T>(map: Record<string, T> | undefined, modelId: string): T | undefined {
  return map?.[modelId];
}
```

The runtime reads these maps through `modelRecordValue` (`src/reasoning-effort.ts:73`), which checks **own properties**, then the **pre-colon family**, then a **case-folded** key. Nine of the ten maps the report reads go through it at runtime — `modelContextWindows`, `modelMaxInputTokens`, `modelMaxOutputTokens`, `modelInputModalities`, `modelReasoningEfforts`, `modelDefaultReasoningEfforts`, `modelReasoningEffortMap`, `modelSupportsReasoningSummaries`, `modelReasoningSummaryDelivery`. The tenth, `modelPreferHostedTools`, is read in `openai-responses.ts` with its own explicit `hasOwnProperty` guard.

## The three disagreements

**1. Pre-colon family.** ollama-cloud serves `gpt-oss:120b`. With `modelMaxOutputTokens: {"gpt-oss": 1234}`:

| | value |
|---|---|
| wire the adapter builds | `max_tokens: 1234` |
| report `limits.maxOutputTokens` | `null` |

**2. Case folding.** A differently-cased key resolves at runtime and did not in the report.

**3. Prototype chain — this one is not just wrong data.**

Model ids are operator-controlled, so one can be `constructor` or `toString`. The bare index then returned an `Object.prototype` function:

```
report limits.contextWindow for 'constructor' = function Object() { [native code] }
```

`jcsStringify` rejects a function, so `buildBehaviorFingerprintV1` threw `unsupported value type function`, and `resolvePassiveRouteSubjectId` swallows the throw — **the subject silently never links** and Lab loses that traffic with no diagnostic. The linker's contract states an implementation is *"synchronous, free of side effects with respect to the request, and non-throwing"*; the try/catch is described there as belonging to the mechanism so the guarantee is not restated by callers — a backstop, not a licence. `openai-responses.ts:996-1001` already guards `modelPreferHostedTools` against exactly this, and says why in a comment.

## Change

Two lookups, because the ten maps are not one contract.

`modelValue` delegates to `modelRecordValue` for the **nine family-aware maps**, so the report cannot disagree with the runtime on any of them at once.

A new `exactOwnValue` serves the two that are deliberately **exact-own** at runtime: `modelPreferHostedTools`, read through `hasOwnProperty` at `src/adapters/openai-responses.ts:1001` and documented as "Exact-model hosted tools" at `src/types.ts:1584`, and `modelOpenRouterRouting`, read through `Object.hasOwn` at `src/providers/openrouter-routing.ts:89`.

Family-resolving those two would be this PR's own divergence with the sign flipped — the report claiming an override applies that the adapter will never apply. A bare index is not the alternative either: it walks the prototype chain, which is the defect being fixed. `modelOpenRouterRouting` at `behavior.ts:87` *was* still a bare read, so it carried that bug untouched by the first commit.

Measured, first 16 hex of the behavior fingerprint, with `modelPreferHostedTools: {"gpt-oss": ["image_generation"]}` and `modelOpenRouterRouting: {"gpt-oss": {order: ["fireworks"]}}` present:

| `gpt-oss:120b` | fingerprint | |
|---|---|---|
| both maps sent through `modelRecordValue` | `96a2ad0adbcae1de` | a different subject, from an override the adapter never applies |
| both maps through `exactOwnValue` | `5c992edff35bd7e9` | unchanged, and equal to the no-hosted-tools config |

## Blast radius, measured

Same config, before and after, first 16 hex of the behavior fingerprint:

| model | dev | this branch | |
|---|---|---|---|
| `gpt-oss:120b` | `54154e19bd2c8ee4` | `5c992edff35bd7e9` | was missing the 1234 override |
| `gpt-oss` | `5c992edff35bd7e9` | `180a84b2d837619d` | was missing the case-folded 55555 |
| `glm-5.3` | `54154e19bd2c8ee4` | `54154e19bd2c8ee4` | unchanged |
| `constructor` | **THROW** | `54154e19bd2c8ee4` | now computable |

Re-measured on the rebased head; the exact-own split does not move any of these, because none of those configs carries a hosted-tools or OpenRouter-routing override.

Only subjects whose overrides were being missed move, so `resolverVersion` stays at `2` for the same reason as #2059 — say the word if you would rather draw a generation boundary.

## Tests

Extends `tests/routing-compatibility-model-matching.test.ts` from #2059, same pattern: assert the wire the adapter really builds, then hold the report to it. Prototype-shaped ids get their own cases, including one asserting the fingerprint stays computable and that two such ids hash alike.

The exact-own group adds five more. Their ground truth is executable rather than cited: `resolveOpenRouterRouting` is exported, and it returns the entry for the exact key and `undefined` for the tagged sibling.

Whole file, 21 tests, against current `dev`: **13 pass / 8 fail**. Against this branch's first commit — i.e. with both exact-own maps wrongly family-resolved — the two "report agrees" cases go red instead. Both numbers matter: the first shows the original defect, the second shows the correction to it.

## Verification

Rebased onto `7a2d13a74`; the branch was 31 commits behind.

```
bun run typecheck                                          exit 0
bun test tests/routing-compatibility-model-matching.test.ts
                                                           21 pass / 0 fail
  same file with src reverted to dev:                      13 pass / 8 fail
bun test <compatibility, openrouter-routing, fastwire-observability,
          lab-live-review-regressions>                     116 pass / 0 fail
```

Not the full suite: this is a Windows machine and `bun run test` panics partway through on Bun 1.3.14 (`index out of bounds: index 0, len 0`), so a result from it would be a truncated log. The batch ran through `scripts/test.ts` so each file keeps its isolated home.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved per-model configuration matching for model names and families, including case-insensitive matches.
  * Prevented inherited or unsupported values from affecting routing, hosted-tool preferences, and compatibility fingerprints.

* **Tests**
  * Added coverage for model-family matching, case variations, unrelated models, prototype-shaped model IDs, and fingerprint generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

