### PR TITLE
test(update): re-pin launcher invariants to the transactional install contract

### DIFF
--- a/devlog/_plan/260819_triage_execution/030_outcome.md
+++ b/devlog/_plan/260819_triage_execution/030_outcome.md
@@ -1,0 +1,41 @@
+# 030 — Campaign outcome (260819 triage execution)
+
+## Merged (12 PRs, all --squash --admin after sol-medium review lanes)
+
+| PR | SHA | scope |
+|---|---|---|
+| #2055 | 2648ffa87 | detail.code workspace denial classification (partial #2046) |
+| #2061 | 82b882903 | provider sub-table strip crash fix (scratch 84/0+tsc) |
+| #2066 | 963699845 | Claude-on-Antigravity continue nudge (closes #2065) |
+| #2045 | 0161a66d9 | NO_PROXY fake-IP boundary (follow-up note posted) |
+| #2042 | c472ad0f3 | structured-output opt-out exact-ID |
+| #2059 | bd3aa3192 | Lab gate reporting = adapter matching (follow-up note) |
+| #2044 | bca251c16 | Cursor text-part tool results (blocker disproved) |
+| #1903 | fd85c8238 | Cursor HTTP/1.1 transport (Ingwannu-approved head) |
+| #2057 | abaa75a60 | OpenCode Go quota probe docs |
+| #2076 | 59964ad77 | OUR #2073 fix: env_key injector contract |
+| #2078 | 11e03eb44 | OUR #1926 fix: tsig credential scope + barrier (C4 sec review) |
+| #2079 | 1ad131acb | OUR #1942/#1849 fix: transactional update (adversarial review) |
+
+## Downgraded to needs-work (BLOCK verdicts honored, evidence comments)
+
+- #2056 (fail-open shortPercent routing, 5335838673), #2053 (missing reauth
+  regression test, 5335919807), #2075 (modelInList vs #2042 + FastWire parity,
+  5335950781), #2072 (assumed-tier billing, 5335998291), #2068 (quota->catalog
+  peer fail-open, 5335998403).
+
+## Closed
+
+- PRs: #1498 (stale/dont-merge); #1885 already closed upstream of us.
+- Issues: #2065 #2073 #1926 #1942 #1849 (by merges), #2064 (fixed-on-dev RCA,
+  020 doc), #2046 partial-status comment (thread-switch half open).
+
+## Gates
+
+- Push CI: intermediate merge runs cancelled by supersession (concurrency);
+  full success 59964ad77 mid-train; decisive run on final head 1ad131acb
+  (32204396229). Windows dispatch leg remains known-red pre-campaign (not a
+  gate).
+- lidge: tsc + isolate suite + privacy on 1ad131acb in ~/.wp9-final
+  (/tmp/wp9-{tsc,suite,privacy}.log).
+

--- a/tests/ocx-launcher-source.test.ts
+++ b/tests/ocx-launcher-source.test.ts
@@ -51,7 +51,10 @@ describe("ocx.mjs npm launcher (source invariants)", () => {
     expect(source).toContain("const latestInvocation = npmInvocation(");
     expect(source).toContain("const installInvocation = npmInvocation(");
     expect(source).toContain("spawnSync(latestInvocation.file, latestInvocation.args");
-    expect(source).toContain("spawnSync(installInvocation.file, installInvocation.args");
+    // #1942: the staged install spawns through the same hardened npmInvocation resolver
+    // inside the transactional runNpm callback.
+    expect(source).toContain("const invocation = npmInvocation(args);");
+    expect(source).toContain("spawnSync(invocation.file, invocation.args");
     expect(source).not.toContain("shell: true");
     expect(source).not.toContain('"npm.cmd"');
   });

--- a/tests/update-stop-first.test.ts
+++ b/tests/update-stop-first.test.ts
@@ -57,7 +57,9 @@ describe("update stops the running proxy before replacing files", () => {
   test("npm launcher update path stops via its own launcher path before npm install", () => {
     expect(launcherSource).toContain('spawnSync(process.execPath, [launcher, "stop"]');
     const stopAt = launcherSource.indexOf('[launcher, "stop"]');
-    const installAt = launcherSource.indexOf("spawnSync(installInvocation.file, installInvocation.args");
+    // #1942: the destructive step is now the transactional staged update, not a direct
+    // global npm install. The stop must still precede it.
+    const installAt = launcherSource.indexOf("transactionalNpmUpdate({");
     expect(stopAt).toBeGreaterThan(-1);
     expect(installAt).toBeGreaterThan(-1);
     expect(stopAt).toBeLessThan(installAt);
@@ -114,7 +116,7 @@ describe("update stops the running proxy before replacing files", () => {
     expect(launcherSource).toContain('name.startsWith("codex-history-backup-") && name.endsWith(".json")');
     expect(launcherSource).toContain("if (historyRestoreIncomplete())");
     const warnAt = launcherSource.indexOf("Codex resume history was NOT restored");
-    const installAt = launcherSource.indexOf("spawnSync(installInvocation.file, installInvocation.args");
+    const installAt = launcherSource.indexOf("transactionalNpmUpdate({");
     expect(warnAt).toBeGreaterThan(-1);
     expect(installAt).toBeGreaterThan(-1);
     expect(warnAt).toBeLessThan(installAt);


### PR DESCRIPTION
## Summary

Fix-forward for the red dev-head CI (run 32204396229) introduced by #2079: three source-invariant tests anchored on the removed direct `npm install -g` spawn line. The invariants themselves still hold on the new transactional path — the proxy stop precedes the destructive step, the history-restore warning precedes it, and every npm spawn resolves through the hardened `npmInvocation` — so the pins now anchor on `transactionalNpmUpdate({` and the `runNpm` callback's `spawnSync(invocation.file, invocation.args`.

## Verification

- `bun test tests/update-stop-first.test.ts tests/ocx-launcher-source.test.ts tests/update-transactional.test.ts` — 30 pass / 0 fail (was 3 fail on dev head)
- `bun test tests/update-job.test.ts tests/install-scripts.test.ts` — 63 pass / 0 fail (adjacent pins unaffected)

## Checklist

- [x] Test-only change
- [x] No behavior modification
