### PR TITLE
fix(admission): resolve the per-model window the way the catalog does

### DIFF
--- a/src/server/responses/input-admission.ts
+++ b/src/server/responses/input-admission.ts
@@ -13,6 +13,7 @@
 import { nativeOpenAiContextWindow, nativeOpenAiMaxInputTokens, type NativeContextLimitsInput } from "../../codex/catalog/metadata";
 import { estimateTokens } from "../../lib/token-estimate";
 import { isCanonicalOpenAiForwardProvider, OPENAI_CODEX_PROVIDER_ID } from "../../providers/openai-tiers";
+import { modelRecordValue } from "../../reasoning-effort";
 import type { OcxContentPart, OcxParsedRequest, OcxProviderConfig } from "../../types";
 
 /**
@@ -133,7 +134,11 @@ export function resolveInputCeiling(
   // config here so this stays pure: no filesystem, no catalog, no registry scan.
   nativeContextCap?: NativeContextLimitsInput,
 ): number | null {
-  const configured = positive(provider.modelContextWindows?.[modelId]) ?? positive(provider.contextWindow);
+  // `modelRecordValue`, not a bare lookup: the catalog resolves these same two maps that
+  // way, so a `gpt-oss` entry covers `gpt-oss:120b`. Reading raw here made the gate fall
+  // back to the provider-wide window and refuse turns the model can plainly hold.
+  const configured = positive(modelRecordValue(provider.modelContextWindows, modelId))
+    ?? positive(provider.contextWindow);
 
   // The canonical `openai` registry entry declares no context fields, so without this the
   // gate would be inert on the default Codex route. All three clauses are load-bearing: a
@@ -156,7 +161,7 @@ export function resolveInputCeiling(
 
   const window = canonicalNativeBare ? native : configured;
   // modelMaxInputTokens is an input-only cap, so it can only tighten the window.
-  const configuredMaxInput = positive(provider.modelMaxInputTokens?.[modelId]);
+  const configuredMaxInput = positive(modelRecordValue(provider.modelMaxInputTokens, modelId));
   const limits = [window, configuredMaxInput, nativeMaxInput].filter((v): v is number => v !== null);
   return limits.length === 0 ? null : Math.min(...limits);
 }

--- a/tests/input-admission.test.ts
+++ b/tests/input-admission.test.ts
@@ -5,6 +5,7 @@ import {
   estimateInputTokens,
   resolveInputCeiling,
 } from "../src/server/responses/input-admission";
+import { modelRecordValue } from "../src/reasoning-effort";
 import type { OcxMessage, OcxParsedRequest, OcxProviderConfig, OcxTool } from "../src/types";
 
 const CANONICAL_NATIVE: OcxProviderConfig = {
@@ -90,6 +91,42 @@ describe("resolveInputCeiling", () => {
   test("an explicit user window still wins over native metadata", () => {
     const pinned: OcxProviderConfig = { ...CANONICAL_NATIVE, modelContextWindows: { "gpt-5.6-sol": 50_000 } };
     expect(resolveInputCeiling(pinned, "openai", "gpt-5.6-sol")).toBe(50_000);
+  });
+
+  test("a family entry covers its tagged siblings, like the catalog", () => {
+    // The catalog resolves modelContextWindows through modelRecordValue, so it advertises
+    // 131_072 for gpt-oss:120b off this config. A bare lookup here resolved nothing and
+    // fell back to contextWindow, leaving the gate refusing turns the model can hold.
+    const provider: OcxProviderConfig = {
+      adapter: "openai-chat",
+      baseUrl: "https://example.test/v1",
+      contextWindow: 8_000,
+      modelContextWindows: { "gpt-oss": 131_072 },
+    };
+    expect(modelRecordValue(provider.modelContextWindows, "gpt-oss:120b")).toBe(131_072);
+    expect(resolveInputCeiling(provider, "custom", "gpt-oss:120b")).toBe(131_072);
+    // An id with no tag and no entry still falls back to the provider-wide window.
+    expect(resolveInputCeiling(provider, "custom", "other")).toBe(8_000);
+  });
+
+  test("an exact entry still beats the family entry", () => {
+    const provider: OcxProviderConfig = {
+      adapter: "openai-chat",
+      baseUrl: "https://example.test/v1",
+      modelContextWindows: { "gpt-oss": 131_072, "gpt-oss:20b": 32_000 },
+    };
+    expect(resolveInputCeiling(provider, "custom", "gpt-oss:20b")).toBe(32_000);
+    expect(resolveInputCeiling(provider, "custom", "gpt-oss:120b")).toBe(131_072);
+  });
+
+  test("a family modelMaxInputTokens tightens its tagged siblings", () => {
+    const provider: OcxProviderConfig = {
+      adapter: "openai-chat",
+      baseUrl: "https://example.test/v1",
+      modelContextWindows: { "gpt-oss": 131_072 },
+      modelMaxInputTokens: { "gpt-oss": 40_000 },
+    };
+    expect(resolveInputCeiling(provider, "custom", "gpt-oss:120b")).toBe(40_000);
   });
 });
 


### PR DESCRIPTION
## Summary

`resolveInputCeiling` reads two per-model maps with a bare lookup:

```ts
const configured = positive(provider.modelContextWindows?.[modelId]) ?? positive(provider.contextWindow);
...
const configuredMaxInput = positive(provider.modelMaxInputTokens?.[modelId]);
```

The catalog resolves those same two maps through `modelRecordValue` (`src/codex/catalog/provider-fetch.ts:612`), which also accepts a family entry for a tagged id — the documented behaviour for `gpt-oss` covering `gpt-oss:120b`.

## Why it bites

Config:

```jsonc
{ "contextWindow": 8000, "modelContextWindows": { "gpt-oss": 131072 } }
```

Request to `gpt-oss:120b`:

| | value |
|---|---|
| what the catalog advertises | **131 072** |
| what admission used as the ceiling | **8 000** |

The bare lookup misses `gpt-oss:120b`, so `configured` falls through to the provider-wide `contextWindow` — a window that belongs to a different model — and the gate refuses turns the routed model can plainly hold. A ~50k-token turn is rejected pre-dispatch against a 131k model.

That inverts this module's own stated contract:

> Deliberately narrow. This is not a context manager and not a compaction trigger: it catches the pathological case and stays out of the way otherwise. **Every uncertainty resolves toward admitting.**

`modelMaxInputTokens` has the mirror of the same bug: a family cap silently never applies to the tagged sibling it was written for. That one fails open, so it is a missed cap rather than a wrong refusal — but it is the same divergence.

## Fix

Both lookups go through `modelRecordValue`. Nothing else changes; an id that already resolved exactly resolves to the same value, and `modelRecordValue` is pure, so the module stays free of filesystem, catalog and registry reads (the existing "touches no filesystem" test still passes).

## Verification

Three new tests in `tests/input-admission.test.ts`. Reverting only the `src` change turns **exactly those three red** and nothing else:

```
(fail) resolveInputCeiling > a family entry covers its tagged siblings, like the catalog
(fail) resolveInputCeiling > an exact entry still beats the family entry
(fail) resolveInputCeiling > a family modelMaxInputTokens tightens its tagged siblings
 19 pass, 3 fail
```

with the fix: `22 pass, 0 fail`.

The first test asserts `modelRecordValue(...)` — the catalog's own answer — *before* asserting the ceiling, so the two cannot drift apart again without the test noticing.

Blast radius, run locally:

```
tests/input-admission.test.ts tests/codex-catalog.test.ts tests/cli-models.test.ts
tests/routing-compatibility-model-matching.test.ts tests/openai-chat-hardening.test.ts
tests/anthropic-hardening.test.ts
-> 293 pass, 0 fail
```

`npx tsc --noEmit` — no errors.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved input limit handling for model families and specific model variants.
  - Context-window and maximum-input-token limits are now resolved correctly, including model-specific overrides.
  - Prevents valid requests from being incorrectly rejected or limits from being applied inaccurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->