### PR TITLE
fix(cli): report model capabilities the way the runtime resolves them

### DIFF
--- a/src/cli/models.ts
+++ b/src/cli/models.ts
@@ -102,8 +102,11 @@ function collectModels(config: OcxConfig, providerFilter?: string): ModelEntry[]
       // proxy will not honour: `isModelTextOnly` matches noVisionModels with modelInList
       // and reads modelInputModalities with modelRecordValue, so a `gpt-oss` entry covers
       // `gpt-oss:120b`. A bare lookup reported that model as unclassified on every field.
+      // noVisionModels is checked first because `isModelTextOnly` returns true on that
+      // match before it ever reads modelInputModalities: a `gpt-oss` noVision entry beats
+      // an exact `gpt-oss:120b` entry that lists "image", and the proxy rejects the image.
       const noVision = modelInList(prov.noVisionModels, model);
-      const modalities = modelRecordValue(inputModalities, model) ?? (noVision ? ["text"] : null);
+      const modalities = noVision ? ["text"] : (modelRecordValue(inputModalities, model) ?? null);
       const efforts = modelRecordValue(reasoningEfforts, model) ?? prov.reasoningEfforts ?? null;
 
       entries.push({

--- a/src/cli/models.ts
+++ b/src/cli/models.ts
@@ -5,11 +5,11 @@ import { randomUUID } from "node:crypto";
 import { createInterface } from "node:readline/promises";
 import { syncModelsToCodex } from "../codex/sync";
 import { hasOwnProvider, isValidProviderName, loadConfig, saveConfig } from "../config";
-import { canonicalizeReasoningEfforts, isDeclaredReasoningEffort } from "../reasoning-effort";
+import { canonicalizeReasoningEfforts, isDeclaredReasoningEffort, modelRecordValue } from "../reasoning-effort";
 import { encodedModelIdCollides, routedSlug, slugEquals } from "../providers/slug-codec";
 import { knownModelIdsForProvider } from "../router";
 import { findLiveProxy } from "../server/proxy-liveness";
-import type { OcxConfig, OcxCustomModel } from "../types";
+import { modelInList, type OcxConfig, type OcxCustomModel } from "../types";
 
 const ADD_USAGE = "Usage: ocx models add <provider> <modelId> [--display-name <name>] [--context-window <tokens>] [--modalities text,image,audio] [--reasoning-efforts <none,minimal,low,medium,high,xhigh,max,ultra>] [--default-reasoning-effort <level>]";
 const REMOVE_USAGE = "Usage: ocx models remove <customId|provider/modelId> [--yes]";
@@ -98,15 +98,19 @@ function collectModels(config: OcxConfig, providerFilter?: string): ModelEntry[]
       if (seen.has(model)) return;
       seen.add(model);
 
-      const noVision = prov.noVisionModels?.includes(model);
-      const modalities = inputModalities[model] ?? (noVision ? ["text"] : null);
-      const efforts = reasoningEfforts[model] ?? prov.reasoningEfforts ?? null;
+      // Resolve exactly as the runtime does, or this command reports capabilities the
+      // proxy will not honour: `isModelTextOnly` matches noVisionModels with modelInList
+      // and reads modelInputModalities with modelRecordValue, so a `gpt-oss` entry covers
+      // `gpt-oss:120b`. A bare lookup reported that model as unclassified on every field.
+      const noVision = modelInList(prov.noVisionModels, model);
+      const modalities = modelRecordValue(inputModalities, model) ?? (noVision ? ["text"] : null);
+      const efforts = modelRecordValue(reasoningEfforts, model) ?? prov.reasoningEfforts ?? null;
 
       entries.push({
         provider: provName,
         model,
         isDefault,
-        contextWindow: contextWindows[model] ?? globalContext,
+        contextWindow: modelRecordValue(contextWindows, model) ?? globalContext,
         inputModalities: modalities,
         reasoningEfforts: efforts,
       });

--- a/tests/cli-models.test.ts
+++ b/tests/cli-models.test.ts
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { INTERNAL_DEADLINE_MS, SPAWN_BUDGET_MS } from "./helpers/test-budget";
+import { isModelTextOnly } from "../src/vision";
+import type { OcxProviderConfig } from "../src/types";
 
 const repoRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
 const cliPath = join(repoRoot, "src", "cli", "index.ts");
@@ -160,6 +162,67 @@ describe("ocx models richer metadata", () => {
       const modelB = parsed.models.find((m: { model: string }) => m.model === "model-b");
       expect(modelB.contextWindow).toBe(32000);
       expect(modelB.inputModalities).toEqual(["text"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a family entry classifies its tagged siblings, as the runtime does", () => {
+    // isModelTextOnly matches noVisionModels with modelInList and reads
+    // modelInputModalities with modelRecordValue, so a `gpt-oss` entry covers
+    // `gpt-oss:120b`. This command must not report a different answer.
+    const dir = mkdtempSync(join(tmpdir(), "ocx-models-family-"));
+    const provider = {
+      adapter: "openai-chat",
+      baseUrl: "http://localhost:8080/v1",
+      allowPrivateNetwork: true,
+      defaultModel: "gpt-oss:120b",
+      models: ["gpt-oss:120b"],
+      modelContextWindows: { "gpt-oss": 131000 },
+      noVisionModels: ["gpt-oss"],
+      modelReasoningEfforts: { "gpt-oss": ["low", "high"] },
+    };
+    writeFileSync(
+      join(dir, "config.json"),
+      JSON.stringify({ port: 10121, providers: { test: provider }, defaultProvider: "test" }),
+      "utf8",
+    );
+    try {
+      // Ground truth first: what the proxy itself will do with this config.
+      expect(isModelTextOnly(provider as unknown as OcxProviderConfig, "gpt-oss:120b")).toBe(true);
+
+      const result = runCli(["models", "--json"], { OPENCODEX_HOME: dir });
+      expect(result.status).toBe(0);
+      const row = JSON.parse(result.stdout).models
+        .find((m: { model: string }) => m.model === "gpt-oss:120b");
+      expect(row.inputModalities).toEqual(["text"]);
+      expect(row.contextWindow).toBe(131000);
+      expect(row.reasoningEfforts).toEqual(["low", "high"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("an exact entry still wins over the family entry", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ocx-models-exact-"));
+    const provider = {
+      adapter: "openai-chat",
+      baseUrl: "http://localhost:8080/v1",
+      allowPrivateNetwork: true,
+      defaultModel: "gpt-oss:20b",
+      models: ["gpt-oss:20b"],
+      modelContextWindows: { "gpt-oss": 131000, "gpt-oss:20b": 32000 },
+    };
+    writeFileSync(
+      join(dir, "config.json"),
+      JSON.stringify({ port: 10122, providers: { test: provider }, defaultProvider: "test" }),
+      "utf8",
+    );
+    try {
+      const result = runCli(["models", "--json"], { OPENCODEX_HOME: dir });
+      const row = JSON.parse(result.stdout).models
+        .find((m: { model: string }) => m.model === "gpt-oss:20b");
+      expect(row.contextWindow).toBe(32000);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/cli-models.test.ts
+++ b/tests/cli-models.test.ts
@@ -203,6 +203,39 @@ describe("ocx models richer metadata", () => {
     }
   });
 
+  test("a noVision family entry beats an exact modality entry, as the runtime does", () => {
+    // isModelTextOnly returns true on the noVisionModels match before it ever reads
+    // modelInputModalities, so an exact entry listing "image" does not grant vision.
+    // Reporting ["text", "image"] here would advertise support the proxy then rejects.
+    const dir = mkdtempSync(join(tmpdir(), "ocx-models-novision-"));
+    const provider = {
+      adapter: "openai-chat",
+      baseUrl: "http://localhost:8080/v1",
+      allowPrivateNetwork: true,
+      defaultModel: "gpt-oss:120b",
+      models: ["gpt-oss:120b"],
+      noVisionModels: ["gpt-oss"],
+      modelInputModalities: { "gpt-oss:120b": ["text", "image"] },
+    };
+    writeFileSync(
+      join(dir, "config.json"),
+      JSON.stringify({ port: 10123, providers: { test: provider }, defaultProvider: "test" }),
+      "utf8",
+    );
+    try {
+      // Ground truth first: the proxy treats this model as text-only.
+      expect(isModelTextOnly(provider as unknown as OcxProviderConfig, "gpt-oss:120b")).toBe(true);
+
+      const result = runCli(["models", "--json"], { OPENCODEX_HOME: dir });
+      expect(result.status).toBe(0);
+      const row = JSON.parse(result.stdout).models
+        .find((m: { model: string }) => m.model === "gpt-oss:120b");
+      expect(row.inputModalities).toEqual(["text"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("an exact entry still wins over the family entry", () => {
     const dir = mkdtempSync(join(tmpdir(), "ocx-models-exact-"));
     const provider = {


### PR DESCRIPTION
## Summary

`ocx models` builds each row with bare lookups:

```ts
const noVision = prov.noVisionModels?.includes(model);
const modalities = inputModalities[model] ?? (noVision ? ["text"] : null);
const efforts = reasoningEfforts[model] ?? prov.reasoningEfforts ?? null;
...
contextWindow: contextWindows[model] ?? globalContext,
```

The proxy resolves those same four fields through `modelInList` / `modelRecordValue`, both of which accept a family entry for a tagged id — `src/vision/index.ts:33-34` (`isModelTextOnly`), `src/reasoning-effort.ts:108`, `src/server/effort-policy.ts:122`, `src/codex/catalog/provider-fetch.ts:612`.

## Why it bites

```jsonc
{
  "models": ["gpt-oss:120b"],
  "modelContextWindows": { "gpt-oss": 131072 },
  "noVisionModels": ["gpt-oss"],
  "modelReasoningEfforts": { "gpt-oss": ["low", "high"] }
}
```

Measured on this branch's parent:

```
RUNTIME  isModelTextOnly = true
RUNTIME  context window  = 131072
RUNTIME  efforts         = ["low","high"]

ocx models --json
  {"model":"gpt-oss:120b","contextWindow":null,
   "inputModalities":null,"reasoningEfforts":null}
```

Every field comes back unclassified. A model the proxy **will** treat as text-only is listed with no modality restriction, so it reads as image-capable; a window the proxy honours reads as unset. This is the command operators use to check what a config actually did, and it disagreed with the proxy on a config the proxy honours in full.

After the change the row is `{"contextWindow":131072,"inputModalities":["text"],"reasoningEfforts":["low","high"]}` — identical to the runtime on all three.

## Verification

Two tests in `tests/cli-models.test.ts`, and I want to be precise about what each one is worth:

- **"a family entry classifies its tagged siblings, as the runtime does"** — the bug proof. It calls `isModelTextOnly` and asserts *that* first, so the command is pinned to the runtime's answer rather than to a second copy of the rule. Red without the src change (`16 pass, 1 fail`).
- **"an exact entry still wins over the family entry"** — passes on the old code too. It is a guard against the fix over-reaching, not evidence of the defect. Including it as proof would be overstating it.

Blast radius, run locally:

```
tests/cli-models.test.ts tests/vision-eligibility.test.ts
tests/codex-catalog.test.ts tests/input-admission.test.ts
-> 237 pass, 0 fail
```

`npx tsc --noEmit` — no errors.

Related: this is the same divergence class as #2042 and #2059, on the CLI surface.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model capability detection for routed and variant model names.
  * Ensured modality, reasoning effort, and context-window settings resolve correctly.
  * Exact model metadata now takes precedence over family-level defaults.
  * Family-level capabilities are correctly applied to tagged sibling models.
  * Improved no-vision classification when explicit modality settings are configured.
  * Updated capability resolution for model variants to provide more consistent CLI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->