### PR TITLE
fix(update): stage global-style so dependencies land inside the package

### DIFF
--- a/src/update/transactional-install.mjs
+++ b/src/update/transactional-install.mjs
@@ -154,7 +154,16 @@ export function transactionalNpmUpdate({
   const rename = deps.rename ?? renameSync;
   const scopeDir = dirname(packageDir);
   const stageRoot = join(scopeDir, stampedName(".ocx-staging"));
-  const stagedPackage = join(stageRoot, "node_modules", ...pkgName.split("/"));
+  // GLOBAL-style staging (-g --prefix): npm nests the package's dependencies INSIDE the
+  // package dir, exactly like the live global tree this stage will replace. A local-style
+  // install would hoist bun/zod to stageRoot/node_modules — siblings that the swap would
+  // leave behind, shipping a dependency-less live tree (release-audit blocker).
+  // Layout: <stageRoot>/lib/node_modules/<pkg> on POSIX, <stageRoot>/node_modules/<pkg>
+  // on Windows.
+  const stagedCandidates = [
+    join(stageRoot, "lib", "node_modules", ...pkgName.split("/")),
+    join(stageRoot, "node_modules", ...pkgName.split("/")),
+  ];
 
   // D1: stage to the side. --prefix keeps npm entirely inside stageRoot; the live tree
   // and the npm bin shims are untouched until the swap. A failure HERE (mkdir EACCES,
@@ -167,10 +176,15 @@ export function transactionalNpmUpdate({
   }
   const spec = pkgName + "@" + (targetVersion || tag);
   log("Staging " + spec + " into " + stageRoot);
-  const install = runNpm(["install", "--prefix", stageRoot, "--no-audit", "--no-fund", spec]);
+  const install = runNpm(["install", "-g", "--prefix", stageRoot, "--no-audit", "--no-fund", spec]);
   if (install.status !== 0) {
     try { rmSync(stageRoot, { recursive: true, force: true }); } catch { /* best effort */ }
     return { ok: false, phase: "stage", error: "npm staging install failed (" + (install.status ?? "?") + ")" };
+  }
+  const stagedPackage = stagedCandidates.find(dir => existsSync(join(dir, "package.json")));
+  if (!stagedPackage) {
+    try { rmSync(stageRoot, { recursive: true, force: true }); } catch { /* best effort */ }
+    return { ok: false, phase: "verify", error: "staged package directory not found under " + stageRoot };
   }
 
   // D2: verify INSIDE the stage. Live is still untouched on any failure here.

--- a/tests/update-transactional.test.ts
+++ b/tests/update-transactional.test.ts
@@ -36,13 +36,14 @@ function liveVersion(packageDir: string): string | undefined {
   }
 }
 
-/** npm stub that materializes a staged tree under the --prefix root. */
+/** npm stub that materializes a GLOBAL-style staged tree (deps nested inside the package). */
 function stagingNpm(version: string, opts: { fail?: boolean; truncate?: boolean } = {}) {
   return (args: string[]) => {
     if (opts.fail) return { status: 1 };
     const prefixIndex = args.indexOf("--prefix");
     const stageRoot = args[prefixIndex + 1]!;
-    const staged = join(stageRoot, "node_modules", ...PKG.split("/"));
+    // Mirror npm -g layout on POSIX: <prefix>/lib/node_modules/<pkg>.
+    const staged = join(stageRoot, "lib", "node_modules", ...PKG.split("/"));
     writeTree(staged, version);
     if (opts.truncate) rmSync(join(staged, "bin", "ocx.mjs"));
     return { status: 0 };


### PR DESCRIPTION
## Summary

Release-regression-audit blocker for the 2.26.0 train: `transactionalNpmUpdate` (#2079) staged with a **local-style** `npm install --prefix`, which hoists the package's dependencies (`bun`, `zod`, ...) to `stageRoot/node_modules` — siblings of the package. The swap then moved only the package directory, shipping a dependency-less live tree, so every post-upgrade `ocx update` failed manifest verification (`sentinel dependency missing`).

Staging now uses **global-style** `npm install -g --prefix`: npm nests dependencies inside the package exactly like the live global tree this stage replaces. The staged path is resolved across both layouts (POSIX `lib/node_modules/<pkg>`, Windows `node_modules/<pkg>`).

## Verification

- Real-registry end-to-end: seeded a live tree from `@bitkyc08/opencodex@2.25.0`, ran `transactionalNpmUpdate` against the actual npm registry — `{ ok: true, phase: "done" }`, post-swap live verifies, `node_modules/zod` present **inside** the package.
- `bun test tests/update-transactional.test.ts` — 9 pass / 0 fail (stub updated to the global layout).

## Checklist

- [x] Root cause (hoisting) reproduced and closed with a real-registry proof
- [x] Both platform layouts handled
