### PR TITLE
[WRONG BRANCH] release: v2.26.0-preview.20260819

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitkyc08/opencodex",
-  "version": "2.25.0-preview.20260818",
+  "version": "2.26.0-preview.20260819",
   "description": "Universal provider proxy for OpenAI Codex & Claude Code — use any LLM with Codex CLI/App/SDK and Claude Code",
   "type": "module",
   "main": "./bin/package-main.mjs",


### PR DESCRIPTION
Version bump for the 2.26.0 preview train (ruleset requires a PR; preflight already green: 13398 pass / 0 fail, typecheck, privacy scan on this exact tree).