### PR TITLE
[WRONG BRANCH] release: v2.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitkyc08/opencodex",
-  "version": "2.25.0",
+  "version": "2.26.0",
   "description": "Universal provider proxy for OpenAI Codex & Claude Code — use any LLM with Codex CLI/App/SDK and Claude Code",
   "type": "module",
   "main": "./bin/package-main.mjs",


### PR DESCRIPTION
Version bump for the 2.26.0 stable release (main ruleset requires a PR). Source tree identical to the published 2.26.0-preview.20260819 (release run 32211336930); preflight was green on that tree (13398 pass / 0 fail, typecheck, privacy).