### PR TITLE
docs(governance): move @Wibias to former maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,11 @@
 # Default reviewers
-* @lidge-jun @Ingwannu @Wibias
+* @lidge-jun @Ingwannu
 
 # High-impact runtime behavior
-/src/adapters/ @lidge-jun @Ingwannu @Wibias
-/src/providers/ @lidge-jun @Ingwannu @Wibias
-/src/codex/ @lidge-jun @Ingwannu @Wibias
-/src/server/ @lidge-jun @Ingwannu @Wibias
+/src/adapters/ @lidge-jun @Ingwannu
+/src/providers/ @lidge-jun @Ingwannu
+/src/codex/ @lidge-jun @Ingwannu
+/src/server/ @lidge-jun @Ingwannu
 
 # Repository automation and release security
 /.github/ @lidge-jun @Ingwannu

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,13 +9,22 @@ review and merge policy.
 | --- | --- | --- |
 | [@lidge-jun](https://github.com/lidge-jun) | Project owner | Project direction, releases, repository administration, and final governance decisions |
 | [@Ingwannu](https://github.com/Ingwannu) | Maintainer | Issue and pull-request triage, `dev` integration, security review, and repository maintenance |
-| [@Wibias](https://github.com/Wibias) | Maintainer | Issue and pull-request triage, `dev` integration, and provider/CI maintenance |
 
 The table describes project responsibilities. Actual repository permissions remain controlled
 through GitHub repository settings.
 
 `dev` is the only integration line. The former `dev2-go` carry duty is retired;
 see [The retired `dev2-go` line](#the-retired-dev2-go-line).
+
+## Former maintainers
+
+| GitHub account | Project role | Period |
+| --- | --- | --- |
+| [@Wibias](https://github.com/Wibias) | Maintainer | 2026-07-27 – 2026-08-19 |
+
+Former maintainers keep contributor standing and are welcome to open issues and pull requests like
+anyone else. Authorship credit in git history, release notes, and code comments is not rewritten
+when a maintainer steps down.
 
 ## Review and merge policy
 
@@ -98,6 +107,24 @@ Adding or removing a maintainer requires:
 
 ### Change log
 
+- 2026-08-19 — [@Wibias](https://github.com/Wibias) stepped down as a maintainer
+  and is now a contributor. This follows his own decision to stop developing
+  opencodex; it is not a disciplinary action, and it was made with the owner's
+  agreement (requirement 1). Requirement 2 does not apply to a maintainer's own
+  resignation, which needs no second maintainer to ratify it. Requirement 3 is
+  met by this file and `.github/CODEOWNERS`, where the default-reviewer line
+  and the four runtime paths that listed him (`/src/adapters/`,
+  `/src/providers/`, `/src/codex/`, `/src/server/`) drop back to the two
+  remaining maintainers. Repository permission was reduced to read access at
+  the same time, so the roster and the GitHub settings agree again.
+
+  Nothing he authored is being unwound. His commits, the pull requests he
+  merged, the release-note attributions, and the code comments citing his
+  reviews stay exactly as they are, and the trust-lane gate derived from his
+  work in `.github/scripts/pr-sponsored-surface.cjs` keeps its attribution.
+  Returning to the maintainer table later would go through the same three
+  requirements that govern every addition.
+
 - 2026-07-27 — [@Wibias](https://github.com/Wibias) added as a maintainer.
   Requirement 1 (agreement from the project owner) is met: the owner requested
   the addition. **Requirement 2 (review by another current maintainer) was
@@ -105,10 +132,10 @@ Adding or removing a maintainer requires:
   carried the addition (`a2693c02`, `dc3a4ade`, `02bbd47a`) landed on `dev` as
   direct owner pushes with no associated pull request, so no second maintainer
   reviewed them. Requirement 3 is met by this file and `.github/CODEOWNERS`.
-  The addition is in effect regardless: @Wibias holds write access on the
-  repository and has been merging pull requests since 2026-07-26. This entry
-  records the gap rather than papering over it — a later maintainer change
-  should go through a reviewed pull request.
+  The addition took effect regardless: @Wibias held write access on the
+  repository and merged pull requests from 2026-07-26 until he stepped down on
+  2026-08-19. This entry records the gap rather than papering over it — a later
+  maintainer change should go through a reviewed pull request.
 
   Scope covers issue and pull-request triage, `dev` integration, and
   provider/CI maintenance. (This entry originally also described carrying


### PR DESCRIPTION
## Summary

- @Wibias stepped down from developing opencodex; repository permission is now read access. This
  moves the roster to match: he leaves the current-maintainers table and appears in a new
  **Former maintainers** section with his 2026-07-27 – 2026-08-19 term.
- `.github/CODEOWNERS` drops him from the default-reviewer line and the four high-impact runtime
  paths (`/src/adapters/`, `/src/providers/`, `/src/codex/`, `/src/server/`), so review routing
  no longer requests a review that cannot be given. The security-boundary blocks were already
  owner/maintainer-only and are untouched.
- A change-log entry records the step-down under the three requirements in `## Maintainer changes`,
  and the 2026-07-27 addition entry is put in the past tense so it no longer claims he currently
  holds write access.

Nothing he authored is unwound. Commits, merged pull requests, release-note attributions, and the
code comments citing his reviews stay exactly as they are, including the trust-lane gate derived
from his work in `.github/scripts/pr-sponsored-surface.cjs`.

## Verification

- `bun test tests/ci-workflows.test.ts tests/zz-pr-coderabbit-readiness-revalidation.test.ts` —
  137 pass, 0 fail. The readiness-ping assertions use an in-test `MAINTAINERS.md` fixture, so the
  live roster change does not move them.
- `node .github/scripts/pr-maintainers.test.cjs` — 5 pass, 0 fail. `parseMaintainerLogins` reads
  only the `## Current maintainers` section, so the new `## Former maintainers` table is correctly
  excluded from the ping list and the change-log mention stays excluded as before.
- `node .github/scripts/enforce-pr-target.test.cjs` — 0 fail.
- Documentation-only change to governance files; no runtime code touched.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated maintainer records to reflect a former maintainer’s resignation and historical contributions.
  * Clarified changes to repository access, ownership paths, and prior maintainer responsibilities.

* **Chores**
  * Updated code ownership assignments for core runtime areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->