### PR TITLE
fix(routing): resolve capability evidence the way the resolver resolves it

### DIFF
--- a/src/routing/capability.ts
+++ b/src/routing/capability.ts
@@ -21,6 +21,7 @@ import {
   nativeReasoningEfforts,
 } from "../codex/catalog/metadata";
 import { readCatalog, readCodexCatalogPath } from "../codex/catalog/parsing";
+import { modelRecordValue } from "../reasoning-effort";
 import { statSync } from "node:fs";
 import type { RouteCapabilityEvidence } from "./trace";
 
@@ -159,9 +160,14 @@ export function candidateCapabilityEvidence(
   const catalogRow = cachedCatalogModels().find(model => model.provider === providerName && model.id === modelId);
   const isNative = providerName === OPENAI_CODEX_PROVIDER_ID && !modelId.includes("/");
 
-  const rawContextWindow = provider?.modelContextWindows?.[modelId]
+  // `modelRecordValue`, not a bare lookup: every runtime reader of these three maps
+  // resolves them that way, so a `gpt-oss` entry covers `gpt-oss:120b`. Reading raw
+  // made the evidence disagree with the resolver it claims to describe — and for the
+  // window it did not even degrade to unknown, it fell through to the provider-wide
+  // value, which is a definite wrong answer rather than an absent one.
+  const rawContextWindow = modelRecordValue(provider?.modelContextWindows, modelId)
     ?? provider?.contextWindow
-    ?? registryEntry?.modelContextWindows?.[modelId]
+    ?? modelRecordValue(registryEntry?.modelContextWindows, modelId)
     ?? catalogRow?.contextWindow
     ?? (isNative ? nativeOpenAiContextWindow(modelId, nativeContextLimits(config)) : undefined);
   // Native rows go through the accessor (raise-to-ceiling + opt-in). Routed rows keep
@@ -170,8 +176,8 @@ export function candidateCapabilityEvidence(
     ? (nativeOpenAiContextWindow(modelId, nativeContextLimits(config)) ?? rawContextWindow)
     : rawContextWindow;
 
-  const modalities = provider?.modelInputModalities?.[modelId]
-    ?? registryEntry?.modelInputModalities?.[modelId]
+  const modalities = modelRecordValue(provider?.modelInputModalities, modelId)
+    ?? modelRecordValue(registryEntry?.modelInputModalities, modelId)
     ?? catalogRow?.inputModalities
     ?? (isNative ? nativeInputModalities(modelId) : undefined);
   const image = Array.isArray(modalities)
@@ -196,8 +202,8 @@ export function candidateCapabilityEvidence(
     || provider?.parallelToolCalls === true
     || undefined;
 
-  const reasoningEfforts = provider?.modelReasoningEfforts?.[modelId]
-    ?? registryEntry?.modelReasoningEfforts?.[modelId]
+  const reasoningEfforts = modelRecordValue(provider?.modelReasoningEfforts, modelId)
+    ?? modelRecordValue(registryEntry?.modelReasoningEfforts, modelId)
     ?? (isNative ? nativeReasoningEfforts(modelId) : undefined);
 
   const tierSupport = provider

--- a/src/routing/capability.ts
+++ b/src/routing/capability.ts
@@ -10,7 +10,7 @@
  * how that affects eligibility.
  */
 
-import type { OcxConfig } from "../types";
+import { modelInList, type OcxConfig } from "../types";
 import { isCanonicalOpenAiForwardProvider, OPENAI_CODEX_PROVIDER_ID } from "../providers/openai-tiers";
 import { serviceTierSupportForModel } from "../providers/service-tier";
 import { PROVIDER_REGISTRY } from "../providers/registry";
@@ -176,10 +176,21 @@ export function candidateCapabilityEvidence(
     ? (nativeOpenAiContextWindow(modelId, nativeContextLimits(config)) ?? rawContextWindow)
     : rawContextWindow;
 
-  const modalities = modelRecordValue(provider?.modelInputModalities, modelId)
-    ?? modelRecordValue(registryEntry?.modelInputModalities, modelId)
-    ?? catalogRow?.inputModalities
-    ?? (isNative ? nativeInputModalities(modelId) : undefined);
+  // `noVisionModels` is checked before the modality chain because that is the order
+  // `isModelTextOnly` uses: it matches the no-vision list and returns true before it
+  // ever reads `modelInputModalities` (`src/vision/index.ts:32`). So a `gpt-oss`
+  // no-vision entry beats an exact `gpt-oss:120b` entry that lists "image", and
+  // deriving `image` from the modality chain alone reported vision on a model the
+  // runtime refuses it for. That matters more here than on the CLI surface fixed in
+  // #2086: routing *acts* on this evidence, so it would select the candidate for image
+  // work that execution then rejects.
+  const noVision = modelInList(provider?.noVisionModels, modelId);
+  const modalities = noVision
+    ? ["text"]
+    : (modelRecordValue(provider?.modelInputModalities, modelId)
+      ?? modelRecordValue(registryEntry?.modelInputModalities, modelId)
+      ?? catalogRow?.inputModalities
+      ?? (isNative ? nativeInputModalities(modelId) : undefined));
   const image = Array.isArray(modalities)
     ? modalities.includes("image")
     : undefined;

--- a/tests/routing-capability-model-matching.test.ts
+++ b/tests/routing-capability-model-matching.test.ts
@@ -49,14 +49,16 @@ describe("candidateCapabilityEvidence model matching", () => {
   });
 
   test("the window does not fall through to the provider-wide value", () => {
-    // The specific regression: 8_000 here is not "unknown", it is a definite answer
-    // belonging to a different model, and routing would act on it.
+    // The specific regression: the provider-wide 8_000 is not "unknown", it is a
+    // definite answer belonging to a different model, and routing would act on it.
+    // Asserted as the exact expected number rather than `not.toBe(8_000)`, which
+    // would also pass for `undefined` or any other wrong value.
     const evidence = candidateCapabilityEvidence(
       configFor(providerWithFamilyEntries()),
       "custom",
       "gpt-oss:120b",
     );
-    expect(evidence.contextWindow).not.toBe(8_000);
+    expect(evidence.contextWindow).toBe(131_072);
   });
 
   test("an exact entry still wins over the family entry", () => {
@@ -98,6 +100,39 @@ describe("candidateCapabilityEvidence model matching", () => {
     expect(evidence.contextWindow).toBe(registryEntry.modelContextWindows![family]);
     expect(evidence.image).toBe(registryEntry.modelInputModalities![family].includes("image"));
     expect(evidence.reasoningEfforts).toEqual(registryEntry.modelReasoningEfforts![family]);
+  });
+
+  test("noVisionModels beats an exact modality entry, as isModelTextOnly does", () => {
+    // `isModelTextOnly` matches the no-vision list and returns true before it ever
+    // reads `modelInputModalities`, so the `gpt-oss` no-vision entry wins over an
+    // exact `gpt-oss:120b` entry listing "image". Evidence that disagrees here is
+    // worse than a wrong window: routing selects the candidate for image work and
+    // execution then refuses it.
+    const provider = {
+      ...providerWithFamilyEntries(),
+      noVisionModels: ["gpt-oss"],
+      modelInputModalities: { "gpt-oss:120b": ["text", "image"] },
+    } as unknown as OcxProviderConfig;
+
+    // Ground truth first: the resolver this evidence claims to describe says text-only.
+    expect(isModelTextOnly(provider, "gpt-oss:120b")).toBe(true);
+
+    const evidence = candidateCapabilityEvidence(configFor(provider), "custom", "gpt-oss:120b");
+    expect(evidence.image).toBe(false);
+  });
+
+  test("a model outside noVisionModels keeps its declared image modality", () => {
+    // The negative half: the no-vision check must not spread to models the list does
+    // not cover, or the fix would trade a false positive for a false negative.
+    const provider = {
+      ...providerWithFamilyEntries(),
+      models: ["gpt-oss:120b", "llava:13b"],
+      noVisionModels: ["gpt-oss"],
+      modelInputModalities: { "llava:13b": ["text", "image"] },
+    } as unknown as OcxProviderConfig;
+
+    expect(isModelTextOnly(provider, "llava:13b")).toBe(false);
+    expect(candidateCapabilityEvidence(configFor(provider), "custom", "llava:13b").image).toBe(true);
   });
 
   test("a prototype-shaped model id resolves nothing", () => {

--- a/tests/routing-capability-model-matching.test.ts
+++ b/tests/routing-capability-model-matching.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { candidateCapabilityEvidence } from "../src/routing/capability";
+import { PROVIDER_REGISTRY } from "../src/providers/registry";
 import { modelRecordValue } from "../src/reasoning-effort";
 import { isModelTextOnly } from "../src/vision";
 import type { OcxConfig, OcxProviderConfig } from "../src/types";
@@ -75,6 +76,28 @@ describe("candidateCapabilityEvidence model matching", () => {
     );
     expect(evidence.contextWindow).toBe(8_000);
     expect(evidence.reasoningEfforts).toBeUndefined();
+  });
+
+  test("a registry entry covers its tagged siblings with no provider configured", () => {
+    // The three registry lookups (capability.ts lines 170/180/206) are a separate branch
+    // from the configured-provider ones above: they are only reached when the provider is
+    // absent from the config, which every other case here supplies.
+    const registryEntry = PROVIDER_REGISTRY.find(entry => entry.id === "xai");
+    if (!registryEntry) throw new Error("fixture drift: no `xai` entry in PROVIDER_REGISTRY");
+
+    // Pin the fixture's shape rather than its values, so registry churn does not turn
+    // into a false failure here while real drift still does.
+    const family = "grok-4.6";
+    expect(registryEntry.modelContextWindows?.[family]).toBeNumber();
+    expect(registryEntry.modelInputModalities?.[family]).toBeArray();
+    expect(registryEntry.modelReasoningEfforts?.[family]).toBeArray();
+
+    const emptyConfig = { providers: {} } as unknown as OcxConfig;
+    const evidence = candidateCapabilityEvidence(emptyConfig, "xai", `${family}:latest`);
+
+    expect(evidence.contextWindow).toBe(registryEntry.modelContextWindows![family]);
+    expect(evidence.image).toBe(registryEntry.modelInputModalities![family].includes("image"));
+    expect(evidence.reasoningEfforts).toEqual(registryEntry.modelReasoningEfforts![family]);
   });
 
   test("a prototype-shaped model id resolves nothing", () => {

--- a/tests/routing-capability-model-matching.test.ts
+++ b/tests/routing-capability-model-matching.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { candidateCapabilityEvidence } from "../src/routing/capability";
+import { modelRecordValue } from "../src/reasoning-effort";
+import { isModelTextOnly } from "../src/vision";
+import type { OcxConfig, OcxProviderConfig } from "../src/types";
+
+/**
+ * `candidateCapabilityEvidence` describes what the resolver will do with a candidate,
+ * so it has to match the resolver. Every runtime reader of `modelContextWindows`,
+ * `modelInputModalities` and `modelReasoningEfforts` goes through `modelRecordValue`
+ * (`src/reasoning-effort.ts:108`, `src/server/effort-policy.ts:122`,
+ * `src/vision/index.ts:34`, `src/codex/catalog/provider-fetch.ts:612`), which accepts a
+ * family entry for a tagged id. This file pins the evidence to that same rule.
+ *
+ * The window matters most: a bare lookup did not degrade to unknown there, it fell
+ * through to the provider-wide `contextWindow` — a definite wrong answer, which the
+ * module's own "unknown is not zero" contract is written to avoid.
+ */
+
+function providerWithFamilyEntries(): OcxProviderConfig {
+  return {
+    adapter: "openai-chat",
+    baseUrl: "https://example.test/v1",
+    contextWindow: 8_000,
+    models: ["gpt-oss:120b"],
+    modelContextWindows: { "gpt-oss": 131_072 },
+    modelInputModalities: { "gpt-oss": ["text"] },
+    modelReasoningEfforts: { "gpt-oss": ["low", "high"] },
+  } as unknown as OcxProviderConfig;
+}
+
+function configFor(provider: OcxProviderConfig): OcxConfig {
+  return { providers: { custom: provider } } as unknown as OcxConfig;
+}
+
+describe("candidateCapabilityEvidence model matching", () => {
+  test("a family entry covers its tagged siblings, as the resolver does", () => {
+    const provider = providerWithFamilyEntries();
+
+    // Ground truth first: what the runtime itself resolves off this config.
+    expect(modelRecordValue(provider.modelContextWindows, "gpt-oss:120b")).toBe(131_072);
+    expect(isModelTextOnly(provider, "gpt-oss:120b")).toBe(true);
+
+    const evidence = candidateCapabilityEvidence(configFor(provider), "custom", "gpt-oss:120b");
+    expect(evidence.contextWindow).toBe(131_072);
+    expect(evidence.image).toBe(false);
+    expect(evidence.reasoningEfforts).toEqual(["low", "high"]);
+  });
+
+  test("the window does not fall through to the provider-wide value", () => {
+    // The specific regression: 8_000 here is not "unknown", it is a definite answer
+    // belonging to a different model, and routing would act on it.
+    const evidence = candidateCapabilityEvidence(
+      configFor(providerWithFamilyEntries()),
+      "custom",
+      "gpt-oss:120b",
+    );
+    expect(evidence.contextWindow).not.toBe(8_000);
+  });
+
+  test("an exact entry still wins over the family entry", () => {
+    const provider = {
+      ...providerWithFamilyEntries(),
+      modelContextWindows: { "gpt-oss": 131_072, "gpt-oss:20b": 32_000 },
+    } as unknown as OcxProviderConfig;
+    expect(candidateCapabilityEvidence(configFor(provider), "custom", "gpt-oss:20b").contextWindow)
+      .toBe(32_000);
+  });
+
+  test("an unrelated model still falls back to the provider-wide window", () => {
+    const evidence = candidateCapabilityEvidence(
+      configFor(providerWithFamilyEntries()),
+      "custom",
+      "some-other-model",
+    );
+    expect(evidence.contextWindow).toBe(8_000);
+    expect(evidence.reasoningEfforts).toBeUndefined();
+  });
+
+  test("a prototype-shaped model id resolves nothing", () => {
+    // modelRecordValue uses hasOwnProperty; a bare lookup would return Object.prototype
+    // members here and hand routing a function as evidence.
+    for (const modelId of ["constructor", "toString", "valueOf", "hasOwnProperty"]) {
+      const evidence = candidateCapabilityEvidence(
+        configFor(providerWithFamilyEntries()),
+        "custom",
+        modelId,
+      );
+      expect(evidence.contextWindow).toBe(8_000);
+      expect(evidence.reasoningEfforts).toBeUndefined();
+      expect(evidence.image).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`candidateCapabilityEvidence` describes what the resolver will do with a candidate, and routing acts on it. It read three per-model maps with bare lookups:

```ts
const rawContextWindow = provider?.modelContextWindows?.[modelId] ?? provider?.contextWindow ?? ...
const modalities       = provider?.modelInputModalities?.[modelId] ?? ...
const reasoningEfforts = provider?.modelReasoningEfforts?.[modelId] ?? ...
```

Every runtime reader of those maps goes through `modelRecordValue`, which accepts a family entry for a tagged id — `src/reasoning-effort.ts:108`, `src/server/effort-policy.ts:122`, `src/vision/index.ts:34`, `src/codex/catalog/provider-fetch.ts:612`.

## Why it bites

```jsonc
{
  "contextWindow": 8000,
  "modelContextWindows":   { "gpt-oss": 131072 },
  "modelInputModalities":  { "gpt-oss": ["text"] },
  "modelReasoningEfforts": { "gpt-oss": ["low", "high"] }
}
```

Measured on this branch's parent, for `gpt-oss:120b`:

```
runtime    window 131072 · isModelTextOnly true · efforts ["low","high"]
evidence   {"contextWindow":8000,"tools":true,"serviceTier":"unsupported",...}
```

The **window is the serious one**. It did not degrade to unknown — it fell through to the provider-wide `contextWindow`, so routing weighed the candidate with a definite value belonging to a different model. That is the failure mode this module's own contract is written against:

> "Unknown is not zero": any dimension without canonical evidence stays `undefined` (unknown) and the profile's `unknownEvidence` policy decides how that affects eligibility.

`image` and `reasoningEfforts` merely went absent, which at least reads honestly as unknown.

There is a second, smaller thing the same change fixes: a bare lookup answers for prototype-shaped ids, so a model named `constructor` resolved `Object.prototype.constructor` as its evidence. `modelRecordValue` uses `hasOwnProperty`, so it now resolves nothing.

After the change the evidence is `{"contextWindow":131072,"image":false,"reasoningEfforts":["low","high"],...}` — matching the runtime on all three.

## Verification

Eight tests in a new `tests/routing-capability-model-matching.test.ts`. Reverting only the `src` change gives **5 fail / 3 pass**:

```
(fail) a family entry covers its tagged siblings, as the resolver does
(fail) the window does not fall through to the provider-wide value
(fail) a registry entry covers its tagged siblings with no provider configured
(fail) noVisionModels beats an exact modality entry, as isModelTextOnly does
(fail) a prototype-shaped model id resolves nothing
```

The three that pass on the old code are deliberate and are **not** evidence of the defect: exact-entry-beats-family, unrelated-model-still-falls-back, and a-model-outside-`noVisionModels`-keeps-its-image-modality. Each guards the fix from over-reaching in one direction.

Two tests assert ground truth before asserting evidence — `modelRecordValue(...)` and `isModelTextOnly(...)` are pinned first, so the file is tied to the resolver's own answer rather than to a second copy of the rule.

Blast radius, run locally on the rebased branch:

```
routing-capability-model-matching · routing-capability-catalog · route-explainability
service-tier-capability · fastwire-characterization-routing
routing-compatibility-model-matching · catalog-vision-sidecar-modalities
routing-policy-fallback
-> 93 pass, 0 fail
```

Full `bun run test`: one unrelated failure, `CL-03 ... preserves the output byte ceiling as output_byte_limit` in `tests/lab-live-pinned-timeouts.test.ts`. It passes 3/3 in isolation. That file's default `firstByteTimeoutMs` is 30 ms, so under full-suite CPU contention the first-byte timeout fires before 16 bytes accumulate — a timing race. The file imports only `lib/lab-live-pinned-sender`, nothing this PR touches. Flagging it rather than quietly calling the run green.

`bun run typecheck` — exit 0.

Related: same divergence class as #2042, #2059 and #2086, on the routing-evidence surface.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model capability detection for context windows, supported input types, and reasoning settings.
  * Model families and tagged variants are matched more reliably, with exact model settings taking priority.
  * Text-only model configuration now takes precedence when determining vision support.
  * Prevented unrelated or specially named models from being incorrectly treated as supported capabilities.
* **Tests**
  * Added coverage for family matching, exact-model precedence, provider and registry fallbacks, vision exclusions, and invalid model identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

