### PR TITLE
fix(responses): drop legacy cache retention for GPT-5.6

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -1505,7 +1505,9 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
       }
       if (forward) {
         outBody = stripUnsupportedForwardParams(outBody);
-        outBody = stripDeprecatedPromptCacheRetention(outBody, parsed.modelId);
+        if (isCanonicalOpenAiForwardProvider(provider)) {
+          outBody = stripDeprecatedPromptCacheRetention(outBody, parsed.modelId);
+        }
       } else {
         outBody = preferConfiguredHostedTools(
           outBody,

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -1505,6 +1505,7 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
       }
       if (forward) {
         outBody = stripUnsupportedForwardParams(outBody);
+        outBody = stripDeprecatedPromptCacheRetention(outBody, parsed.modelId);
       } else {
         outBody = preferConfiguredHostedTools(
           outBody,
@@ -1536,7 +1537,6 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
         outBody = rewritten.body;
         convertedRoutedCustomToolNames = rewritten.names;
       }
-      outBody = stripDeprecatedPromptCacheRetention(outBody, parsed.modelId);
       const sanitizedBody = normalizeToolSchemas(stripSparkCompatibility(stripUnsupportedReasoningParams(stripItemIdsWhenUnstored(stripInvalidItemIds(stripUnsupportedHostedTools(sanitizeReasoningInputContent(scrubOcxCompactionItems(outBody), { preserveRawReasoningContent: provider.preserveResponsesReasoningContent === true })))))));
       const finalBody = stripDisabledReasoningSummaries(
         normalizeConfiguredReasoningSummaryDelivery(sanitizedBody, provider, parsed.modelId),

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -186,6 +186,20 @@ function stripUnsupportedReasoningParams(body: unknown): unknown {
 }
 
 /**
+ * GPT-5.6 replaced the legacy 24-hour retention field with `prompt_cache_options.ttl`.
+ * Do not translate `24h` to the new field: GPT-5.6 currently accepts a different TTL contract,
+ * and implicit caching remains available when the caller did not send the replacement options.
+ */
+function stripDeprecatedPromptCacheRetention(body: unknown, modelId: unknown): unknown {
+  if (!isPlainObject(body)) return body;
+  if (typeof modelId !== "string") return body;
+  if (modelId !== "gpt-5.6" && !modelId.startsWith("gpt-5.6-")) return body;
+  if (!Object.hasOwn(body, "prompt_cache_retention")) return body;
+  const { prompt_cache_retention: _retention, ...rest } = body;
+  return rest;
+}
+
+/**
  * A false model capability prevents Codex from emitting summary fields after the catalog refresh.
  * Strip them here as well so an already-running client with a stale catalog cannot keep sending an
  * upstream-rejected `reasoning_summary_delivery` value (issue #323).
@@ -1522,6 +1536,7 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
         outBody = rewritten.body;
         convertedRoutedCustomToolNames = rewritten.names;
       }
+      outBody = stripDeprecatedPromptCacheRetention(outBody, parsed.modelId);
       const sanitizedBody = normalizeToolSchemas(stripSparkCompatibility(stripUnsupportedReasoningParams(stripItemIdsWhenUnstored(stripInvalidItemIds(stripUnsupportedHostedTools(sanitizeReasoningInputContent(scrubOcxCompactionItems(outBody), { preserveRawReasoningContent: provider.preserveResponsesReasoningContent === true })))))));
       const finalBody = stripDisabledReasoningSummaries(
         normalizeConfiguredReasoningSummaryDelivery(sanitizedBody, provider, parsed.modelId),

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -2091,6 +2091,29 @@ describe("OpenAI Responses forward-mode unsupported param stripping", () => {
 
     expect(body.prompt_cache_retention).toBe("24h");
   });
+
+  test("noncanonical forward endpoints preserve GPT-5.6 prompt_cache_retention", () => {
+    const adapter = createResponsesPassthroughAdapter({
+      adapter: "openai-responses",
+      baseUrl: "https://provider.example/v1",
+      authMode: "forward",
+      headers: { authorization: "Bearer provider-static" },
+    });
+    const request = adapter.buildRequest({
+      modelId: "gpt-5.6-sol",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: {
+        model: "gpt-5.6-sol",
+        input: "hi",
+        prompt_cache_retention: "24h",
+      },
+    }, { headers: new Headers() });
+    const body = JSON.parse(request.body) as { prompt_cache_retention?: string };
+
+    expect(body.prompt_cache_retention).toBe("24h");
+  });
 });
 
 describe("openaiResponsesUrl", () => {

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -822,6 +822,57 @@ describe("OpenAI Responses passthrough sanitization", () => {
     expect(body.prompt_cache_retention).toBe("24h");
   });
 
+  test.each([
+    "gpt-5.6",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+  ])("drops deprecated prompt_cache_retention for %s without inventing replacement options", modelId => {
+    const adapter = createResponsesPassthroughAdapter(provider);
+    const request = adapter.buildRequest({
+      modelId,
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: {
+        model: modelId,
+        input: "hi",
+        prompt_cache_retention: "24h",
+      },
+    }, { headers: new Headers({ authorization: "Bearer token" }) });
+    const body = JSON.parse(request.body) as {
+      prompt_cache_retention?: string;
+      prompt_cache_options?: unknown;
+    };
+
+    expect(body.prompt_cache_retention).toBeUndefined();
+    expect(body.prompt_cache_options).toBeUndefined();
+  });
+
+  test("preserves caller prompt_cache_options while dropping GPT-5.6 legacy retention", () => {
+    const adapter = createResponsesPassthroughAdapter(provider);
+    const promptCacheOptions = { mode: "explicit", ttl: "30m" };
+    const request = adapter.buildRequest({
+      modelId: "gpt-5.6-sol",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: {
+        model: "gpt-5.6-sol",
+        input: "hi",
+        prompt_cache_retention: "24h",
+        prompt_cache_options: promptCacheOptions,
+      },
+    }, { headers: new Headers({ authorization: "Bearer token" }) });
+    const body = JSON.parse(request.body) as {
+      prompt_cache_retention?: string;
+      prompt_cache_options?: unknown;
+    };
+
+    expect(body.prompt_cache_retention).toBeUndefined();
+    expect(body.prompt_cache_options).toEqual(promptCacheOptions);
+  });
+
   const expandedRawBody = {
     model: "gpt-5.5",
     previous_response_id: "resp_1",

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -2068,6 +2068,29 @@ describe("OpenAI Responses forward-mode unsupported param stripping", () => {
     expect(body.max_output_tokens).toBe(32000);
     expect(body.metadata).toEqual({ user_id: "u-1" });
   });
+
+  test("key-auth custom endpoints preserve GPT-5.6 prompt_cache_retention", () => {
+    const adapter = createResponsesPassthroughAdapter({
+      adapter: "openai-responses",
+      baseUrl: "https://api.openai.example/v1",
+      authMode: "key",
+      apiKey: "sk-test",
+    });
+    const request = adapter.buildRequest({
+      modelId: "gpt-5.6-sol",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: {
+        model: "gpt-5.6-sol",
+        input: "hi",
+        prompt_cache_retention: "24h",
+      },
+    }, { headers: new Headers() });
+    const body = JSON.parse(request.body) as { prompt_cache_retention?: string };
+
+    expect(body.prompt_cache_retention).toBe("24h");
+  });
 });
 
 describe("openaiResponsesUrl", () => {


### PR DESCRIPTION
## Summary

- Strip deprecated `prompt_cache_retention` from GPT-5.6 family Responses requests only on the ChatGPT forward-auth path.
- Keep API-key and custom OpenAI-compatible `openai-responses` passthroughs out of scope, preserving their caller-provided `prompt_cache_retention` unchanged.
- Preserve legacy retention passthrough for older models and preserve caller-provided `prompt_cache_options` without synthesizing a replacement TTL.
- Add focused coverage for the GPT-5.6 alias, Sol, Terra, Luna, legacy GPT-5.5 behavior, API-key custom endpoints, noncanonical forward endpoints, and pre-existing passthrough fixtures.
- Follow the current [OpenAI GPT-5.6 migration guidance](https://developers.openai.com/api/docs/guides/latest-model), which replaces `prompt_cache_retention` with `prompt_cache_options.ttl` while retaining implicit caching when options are omitted.

## Verification

- `bun test tests/openai-responses-passthrough.test.ts tests/anthropic-thinking-signature.test.ts` — 90 pass, 0 fail
- `bun run typecheck` — passed
- `bun run privacy:scan` — passed
- CI-equivalent fresh-process general shards plus the storage-policy job, with all proxy environment variables removed — 13,409 pass, 10 skipped, 0 fail across 851 files
- Dedicated `api-usage` job, matching `.github/workflows/ci.yml` isolation — 24 pass, 0 fail
- Combined coverage — all 852 test files, 13,433 pass, 10 skipped, 0 fail
- `git diff --check` — passed

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. No user configuration or workflow changed, so no docs update is required.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with GPT-5.6 and its variants by removing the deprecated prompt cache retention setting from requests.
  * Preserved supported prompt cache options provided by callers.
  * Kept existing behavior unchanged for other models and unaffected requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
