### PR TITLE
fix(xai): preserve Claude tools with root $schema

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -1156,7 +1156,11 @@ function normalizeXaiToolParameters(parameters: unknown): Record<string, unknown
   if (!isXaiObjectSchema(parameters)) return undefined;
   const resolved = resolveXaiSchemaRefs(parameters, parameters);
   if (!isXaiObjectSchema(resolved)) return undefined;
-  const variants = expandXaiRootObjectSchemas(resolved);
+
+  const normalizedRoot = { ...resolved };
+  delete normalizedRoot.$schema;
+
+  const variants = expandXaiRootObjectSchemas(normalizedRoot);
   if (!variants) return undefined;
   if (variants.length === 1) {
     return xaiVariantIsConcreteObject(variants[0]) ? variants[0] : undefined;
@@ -1166,7 +1170,7 @@ function normalizeXaiToolParameters(parameters: unknown): Record<string, unknown
   if (!additionalProperties.ok) return undefined;
   if (!xaiPropertyMergeIsLossless(variants)) return undefined;
 
-  const metadata = Object.fromEntries(Object.entries(resolved).filter(([key]) => key !== "oneOf" && key !== "anyOf" && key !== "type"));
+  const metadata = Object.fromEntries(Object.entries(normalizedRoot).filter(([key]) => key !== "oneOf" && key !== "anyOf" && key !== "type"));
   delete metadata.properties;
   delete metadata.required;
   delete metadata.additionalProperties;
@@ -1180,6 +1184,7 @@ function normalizeXaiToolParameters(parameters: unknown): Record<string, unknown
       propertyValues.set(name, values);
     }
   }
+
   const properties = Object.fromEntries(
     [...propertyValues].map(([name, values]) => [name, mergeXaiPropertySchemas(values)]),
   );

--- a/tests/xai-tool-schema.test.ts
+++ b/tests/xai-tool-schema.test.ts
@@ -1,8 +1,23 @@
 import { describe, expect, test } from "bun:test";
-import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
-import type { OcxParsedRequest, OcxTool } from "../src/types";
+import {
+  createOpenAIChatAdapter as createOpenAIChatAdapterProduction,
+} from "../src/adapters/openai-chat";
+import type {
+  OcxParsedRequest,
+  OcxTool,
+} from "../src/types";
+import { withTestTranslatorBudget } from "./helpers/translator-budget";
 
-function parsedRequest(tool: OcxTool): Parameters<ReturnType<typeof createOpenAIChatAdapter>["buildRequest"]>[0] {
+const createOpenAIChatAdapter = (
+  ...args: Parameters<typeof createOpenAIChatAdapterProduction>
+) =>
+  withTestTranslatorBudget(
+    createOpenAIChatAdapterProduction(...args),
+  );
+
+function parsedRequest(
+  tool: OcxTool,
+): OcxParsedRequest {
   return {
     modelId: "grok-4.6",
     context: {
@@ -17,7 +32,7 @@ function parsedRequest(tool: OcxTool): Parameters<ReturnType<typeof createOpenAI
     },
     stream: true,
     options: {},
-  } as never;
+  };
 }
 
 function xaiAdapter() {
@@ -29,7 +44,7 @@ function xaiAdapter() {
 }
 
 describe("xAI Grok CLI tool schema normalization", () => {
-  test("keeps Claude Code tools with a root $schema", () => {
+  test("keeps Claude Code tools with a root $schema", async () => {
     const tool: OcxTool = {
       name: "Bash",
       description: "Execute a shell command",
@@ -46,9 +61,11 @@ describe("xAI Grok CLI tool schema normalization", () => {
       },
     };
 
-    const body = JSON.parse(
-      xaiAdapter().buildRequest(parsedRequest(tool)).body,
-    ) as {
+    const request = await xaiAdapter().buildRequest(
+      parsedRequest(tool),
+    );
+
+    const body = JSON.parse(request.body) as {
       tools?: Array<{
         type: string;
         function: {
@@ -70,12 +87,15 @@ describe("xAI Grok CLI tool schema normalization", () => {
       required: ["command"],
       additionalProperties: false,
     });
-    expect(body.tools?.[0]?.function.parameters).not.toHaveProperty("$schema");
+    expect(
+      body.tools?.[0]?.function.parameters,
+    ).not.toHaveProperty("$schema");
   });
 
-  test("does not reintroduce $schema when flattening a root union", () => {
+  test("does not reintroduce $schema when flattening a root union", async () => {
     const tool: OcxTool = {
       name: "Bash",
+      description: "Execute a shell command",
       parameters: {
         $schema: "https://json-schema.org/draft/2020-12/schema",
         oneOf: [
@@ -104,9 +124,11 @@ describe("xAI Grok CLI tool schema normalization", () => {
       },
     };
 
-    const body = JSON.parse(
-      xaiAdapter().buildRequest(parsedRequest(tool)).body,
-    ) as {
+    const request = await xaiAdapter().buildRequest(
+      parsedRequest(tool),
+    );
+
+    const body = JSON.parse(request.body) as {
       tools?: Array<{
         function: {
           parameters: Record<string, unknown>;
@@ -115,7 +137,11 @@ describe("xAI Grok CLI tool schema normalization", () => {
     };
 
     expect(body.tools).toHaveLength(1);
-    expect(body.tools?.[0]?.function.parameters).not.toHaveProperty("$schema");
-    expect(body.tools?.[0]?.function.parameters).not.toHaveProperty("oneOf");
+    expect(
+      body.tools?.[0]?.function.parameters,
+    ).not.toHaveProperty("$schema");
+    expect(
+      body.tools?.[0]?.function.parameters,
+    ).not.toHaveProperty("oneOf");
   });
 });

--- a/tests/xai-tool-schema.test.ts
+++ b/tests/xai-tool-schema.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
+import type { OcxParsedRequest, OcxTool } from "../src/types";
+
+function parsedRequest(tool: OcxTool): Parameters<ReturnType<typeof createOpenAIChatAdapter>["buildRequest"]>[0] {
+  return {
+    modelId: "grok-4.6",
+    context: {
+      messages: [
+        {
+          role: "user",
+          content: "run the command",
+          timestamp: 0,
+        },
+      ],
+      tools: [tool],
+    },
+    stream: true,
+    options: {},
+  } as never;
+}
+
+function xaiAdapter() {
+  return createOpenAIChatAdapter({
+    adapter: "openai-chat",
+    baseUrl: "https://cli-chat-proxy.grok.com/v1",
+    apiKey: "k",
+  });
+}
+
+describe("xAI Grok CLI tool schema normalization", () => {
+  test("keeps Claude Code tools with a root $schema", () => {
+    const tool: OcxTool = {
+      name: "Bash",
+      description: "Execute a shell command",
+      parameters: {
+        $schema: "https://json-schema.org/draft/2020-12/schema",
+        type: "object",
+        properties: {
+          command: {
+            type: "string",
+          },
+        },
+        required: ["command"],
+        additionalProperties: false,
+      },
+    };
+
+    const body = JSON.parse(
+      xaiAdapter().buildRequest(parsedRequest(tool)).body,
+    ) as {
+      tools?: Array<{
+        type: string;
+        function: {
+          name: string;
+          parameters: Record<string, unknown>;
+        };
+      }>;
+    };
+
+    expect(body.tools).toHaveLength(1);
+    expect(body.tools?.[0]?.function.name).toBe("Bash");
+    expect(body.tools?.[0]?.function.parameters).toEqual({
+      type: "object",
+      properties: {
+        command: {
+          type: "string",
+        },
+      },
+      required: ["command"],
+      additionalProperties: false,
+    });
+    expect(body.tools?.[0]?.function.parameters).not.toHaveProperty("$schema");
+  });
+
+  test("does not reintroduce $schema when flattening a root union", () => {
+    const tool: OcxTool = {
+      name: "Bash",
+      parameters: {
+        $schema: "https://json-schema.org/draft/2020-12/schema",
+        oneOf: [
+          {
+            type: "object",
+            properties: {
+              command: {
+                type: "string",
+              },
+            },
+            required: ["command"],
+            additionalProperties: false,
+          },
+          {
+            type: "object",
+            properties: {
+              command: {
+                type: "string",
+                minLength: 1,
+              },
+            },
+            required: ["command"],
+            additionalProperties: false,
+          },
+        ],
+      },
+    };
+
+    const body = JSON.parse(
+      xaiAdapter().buildRequest(parsedRequest(tool)).body,
+    ) as {
+      tools?: Array<{
+        function: {
+          parameters: Record<string, unknown>;
+        };
+      }>;
+    };
+
+    expect(body.tools).toHaveLength(1);
+    expect(body.tools?.[0]?.function.parameters).not.toHaveProperty("$schema");
+    expect(body.tools?.[0]?.function.parameters).not.toHaveProperty("oneOf");
+  });
+});

--- a/tests/xai-tool-schema.test.ts
+++ b/tests/xai-tool-schema.test.ts
@@ -137,11 +137,18 @@ describe("xAI Grok CLI tool schema normalization", () => {
     };
 
     expect(body.tools).toHaveLength(1);
-    expect(
-      body.tools?.[0]?.function.parameters,
-    ).not.toHaveProperty("$schema");
-    expect(
-      body.tools?.[0]?.function.parameters,
-    ).not.toHaveProperty("oneOf");
+    expect(body.tools?.[0]?.function.parameters).toEqual({
+    type: "object",
+    properties: {
+        command: {
+        anyOf: [
+            { type: "string" },
+            { type: "string", minLength: 1 },
+        ],
+        },
+    },
+    required: ["command"],
+    additionalProperties: false,
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Strip the root `$schema` keyword before normalizing tool parameter schemas for the xAI Grok CLI proxy.
- Claude Code includes `$schema` in its tool definitions. The xAI schema normalizer treated that root keyword as unsupported and dropped otherwise valid tools.
- Before this fix, a Claude Code request with 69 declared tools was translated to 69 internal tools but serialized to 0 xAI tools, preventing Bash and other client tools from being called.
- Preserve the existing conservative behavior for genuinely unsupported xAI tool schemas.
- Claude Code Auto Mode classifier routing is outside the scope of this change.

## Verification

- `bun test tests/xai-tool-schema.test.ts`
- `bun run typecheck`
- `bun run test`
- `bun run privacy:scan`
- Verified the regression test fails without the `$schema` normalization fix and passes with it.
- Verified end-to-end with Claude Code 2.1.235 and xAI Grok 4.6:
  - Claude Code declared 69 tools.
  - OpenCodex preserved all 69 tools in the xAI request.
  - Grok emitted a `Bash` tool call.
  - Bash executed `python3 -c 'import secrets; print(secrets.token_hex(8))'` successfully and returned a 16-character hex value.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the internal `$schema` field from normalized xAI tool parameters.
  * Improved compatibility for tools using root-level schema unions while preserving tool names and parameter structure.

* **Tests**
  * Added coverage for standard tool schemas and root-level `oneOf` configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->