### PR TITLE
fix(providers): allow baseUrl override for Anthropic Claude provider

### DIFF
--- a/src/lib/destination-policy.ts
+++ b/src/lib/destination-policy.ts
@@ -131,6 +131,44 @@ function registryAllowsPrivateNetwork(name: string): boolean {
 }
 
 /**
+ * OAuth registry entries that opt into `allowBaseUrlOverride` send bearer credentials to a
+ * user-configured endpoint (review findings, PR #2109 / PR #2110): a cleartext `http:`
+ * override would expose the OAuth token on the wire. `https:` is therefore required for
+ * every non-local destination. Loopback/localhost/private relays keep working over
+ * `http:` because they already sit behind the explicit `allowPrivateNetwork` opt-in
+ * enforced by {@link providerDestinationConfigError}. Keyed/local providers (Ollama,
+ * vLLM, LM Studio, LiteLLM, Moonshot, Qwen, Alibaba) are untouched: they are not
+ * `authKind: "oauth"`, so this check never fires for them.
+ */
+function registrySendsOAuthToOverriddenBaseUrl(name: string): boolean {
+  const entry = getProviderRegistryEntry(name);
+  return entry?.authKind === "oauth" && entry.allowBaseUrlOverride === true;
+}
+
+export function providerSecureTransportConfigError(
+  name: string,
+  provider: Pick<OcxProviderConfig, "baseUrl" | "allowPrivateNetwork">,
+): string | null {
+  if (!registrySendsOAuthToOverriddenBaseUrl(name)) return null;
+  // An explicit allowPrivateNetwork opt-in is the documented "intentionally local/self-hosted"
+  // contract; a named local relay (http://relay.corp.internal) stays reachable through it.
+  if (providerAllowsPrivateNetwork(name, provider)) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(provider.baseUrl.trim());
+  } catch {
+    return null; // invalid URLs are providerBaseUrlConfigError's concern
+  }
+  if (parsed.protocol !== "http:") return null;
+  const assessment = assessDestination(provider.baseUrl);
+  if (!assessment) return null;
+  if (assessment.kind === "localhost" || assessment.kind === "loopback" || assessment.kind === "private") {
+    return null; // local relays; the private-network gate below still applies
+  }
+  return "baseUrl must use https: this provider sends OAuth credentials to its endpoint, and http is allowed only for loopback/private relays";
+}
+
+/**
  * Whether a provider may reach loopback/private addresses.
  *
  * Two sources, and both have to be consulted at every boundary: the operator's explicit
@@ -150,6 +188,8 @@ export function providerAllowsPrivateNetwork(
 }
 
 export function providerDestinationConfigError(name: string, provider: Pick<OcxProviderConfig, "baseUrl" | "allowPrivateNetwork">): string | null {
+  const secureTransportError = providerSecureTransportConfigError(name, provider);
+  if (secureTransportError) return secureTransportError;
   const assessment = assessDestination(provider.baseUrl);
   if (!assessment) return null;
   if (assessment.kind === "public" || assessment.kind === "hostname") return null;
@@ -331,3 +371,4 @@ export async function resolvePublicAddresses(
 export async function assertUrlResolvesPublic(url: string): Promise<void> {
   await resolvePublicAddresses(url);
 }
+

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1083,6 +1083,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     adapter: "anthropic",
     baseUrl: "https://api.anthropic.com",
     authKind: "oauth",
+    allowBaseUrlOverride: true,
     featured: true,
     oauthId: "anthropic",
     jawcodeBundle: "anthropic",

--- a/tests/anthropic-baseurl-override.test.ts
+++ b/tests/anthropic-baseurl-override.test.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "bun:test";
+import { routeModel } from "../src/router";
+import { providerDestinationConfigError } from "../src/lib/destination-policy";
+import type { OcxConfig, OcxProviderConfig } from "../src/types";
+
+/**
+ * Regression coverage for the allowBaseUrlOverride opt-in on the anthropic
+ * registry entry.
+ *
+ * Before the opt-in, the pinned registry endpoint silently outranked a saved
+ * baseUrl and the router emitted the discarded-baseUrl diagnostic (see
+ * tests/router-discarded-baseurl-warning.test.ts, which now pins google as
+ * its fixture). Users routing Claude traffic through a local relay or an
+ * enterprise gateway therefore could not redirect the provider at all. These
+ * tests pin the new contract: a resolved user baseUrl wins, no warning fires,
+ * and the registry endpoint remains the default seeded value.
+ */
+const PROVIDER = "anthropic";
+const REGISTRY_BASE_URL = "https://api.anthropic.com";
+const MODEL = PROVIDER + "/claude-sonnet-5";
+
+function configFor(provider: OcxProviderConfig): OcxConfig {
+  return {
+    port: 10100,
+    defaultProvider: PROVIDER,
+    providers: { [PROVIDER]: provider },
+  };
+}
+
+function routeCapturingWarnings(config: OcxConfig): { baseUrl: string; warnings: string[] } {
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(" ")); };
+  try {
+    const route = routeModel(config, MODEL);
+    return { baseUrl: route.provider.baseUrl, warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
+test("anthropic honors a configured baseUrl override", () => {
+  const { baseUrl, warnings } = routeCapturingWarnings(configFor({
+    adapter: "anthropic",
+    baseUrl: "https://claude-relay.example.test",
+  } as OcxProviderConfig));
+
+  expect(baseUrl).toBe("https://claude-relay.example.test");
+  // The override is applied, so the discarded-baseUrl diagnostic must not fire.
+  expect(warnings).toHaveLength(0);
+});
+
+test("anthropic keeps the registry endpoint when the seeded baseUrl is unchanged", () => {
+  // providerConfigSeed copies the registry baseUrl into every saved config, so the
+  // no-override case reaches the router as a config whose baseUrl equals the registry URL.
+  const { baseUrl, warnings } = routeCapturingWarnings(configFor({
+    adapter: "anthropic",
+    baseUrl: REGISTRY_BASE_URL,
+  } as OcxProviderConfig));
+
+  expect(baseUrl).toBe(REGISTRY_BASE_URL);
+  expect(warnings).toHaveLength(0);
+});
+
+test("anthropic requires a resolved baseUrl once override is enabled", () => {
+  // allowBaseUrlOverride providers fail closed on a missing baseUrl instead of silently
+  // re-pinning the registry endpoint; the seed guarantees real configs always carry one.
+  expect(() => routeModel(configFor({
+    adapter: "anthropic",
+  } as OcxProviderConfig), MODEL)).toThrow(/Invalid baseUrl/);
+});
+
+test("anthropic rejects an unresolved template baseUrl override", () => {
+  expect(() => routeModel(configFor({
+    adapter: "anthropic",
+    baseUrl: "https://{region}.example.test",
+  } as OcxProviderConfig), MODEL)).toThrow(/Invalid baseUrl/);
+});
+
+/**
+ * Security regression (CodeRabbit, PR #2109): anthropic is an OAuth provider, so an
+ * allowBaseUrlOverride endpoint receives bearer credentials. A cleartext http override to a
+ * non-local destination must be rejected on BOTH enforcement paths: routing (normal requests,
+ * via assertProviderDestinationAllowed) and providerDestinationConfigError, the shared gate
+ * that config validation and the model-discovery outbound layer (providerGet/providerPost in
+ * src/lib/provider-outbound.ts) consult before any fetch.
+ */
+test("anthropic rejects a cleartext http override on the routing path", () => {
+  expect(() => routeModel(configFor({
+    adapter: "anthropic",
+    baseUrl: "http://claude-relay.example.test",
+  } as OcxProviderConfig), MODEL)).toThrow(/https/);
+});
+
+test("anthropic rejects a cleartext http override on the discovery/config gate", () => {
+  expect(providerDestinationConfigError(PROVIDER, {
+    baseUrl: "http://claude-relay.example.test",
+  } as OcxProviderConfig)).toMatch(/https/);
+  // The https form of the same destination stays accepted.
+  expect(providerDestinationConfigError(PROVIDER, {
+    baseUrl: "https://claude-relay.example.test",
+  } as OcxProviderConfig)).toBeNull();
+});
+
+test("anthropic keeps http for an explicitly local relay", () => {
+  // Loopback and allowPrivateNetwork opt-ins are the documented local-transport escape
+  // hatch; the https requirement must not break a localhost proxy.
+  const { baseUrl, warnings } = routeCapturingWarnings(configFor({
+    adapter: "anthropic",
+    baseUrl: "http://127.0.0.1:8787",
+    allowPrivateNetwork: true,
+  } as OcxProviderConfig));
+
+  expect(baseUrl).toBe("http://127.0.0.1:8787");
+  expect(warnings).toHaveLength(0);
+});
+

--- a/tests/provider-model-discovery-contract.test.ts
+++ b/tests/provider-model-discovery-contract.test.ts
@@ -172,15 +172,15 @@ describe("registry-owned provider model discovery", () => {
       authMode: "oauth",
     };
 
-    await withRegistryDiscovery("anthropic", { path: "catalog" }, () => {
-      const relative = buildModelsRequest(staleConfig, "oauth-token", "anthropic");
-      expect(relative.url).toBe("https://api.anthropic.com/catalog");
+    await withRegistryDiscovery("kimi", { path: "catalog" }, () => {
+      const relative = buildModelsRequest(staleConfig, "oauth-token", "kimi");
+      expect(relative.url).toBe("https://api.kimi.com/coding/v1/catalog");
       expect(relative.headers.Authorization).toBe("Bearer oauth-token");
     });
 
-    await withRegistryDiscovery("anthropic", { maxModels: 25 }, () => {
-      const defaultEndpoint = buildModelsRequest(staleConfig, "oauth-token", "anthropic");
-      expect(defaultEndpoint.url).toBe("https://api.anthropic.com/v1/models?limit=1000");
+    await withRegistryDiscovery("kimi", { maxModels: 25 }, () => {
+      const defaultEndpoint = buildModelsRequest(staleConfig, "oauth-token", "kimi");
+      expect(defaultEndpoint.url).toBe("https://api.kimi.com/coding/v1/models");
     });
   });
 
@@ -604,3 +604,4 @@ describe("same-named custom provider preservation", () => {
     });
   });
 });
+

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -563,7 +563,7 @@ describe("provider registry parity", () => {
   test("base URL override permission is registry-only and limited to opted-in providers", () => {
     const optedIn = PROVIDER_REGISTRY.filter(entry => entry.allowBaseUrlOverride);
 
-    expect(optedIn.map(entry => entry.id)).toEqual(["ollama", "vllm", "lm-studio", "moonshot", "qwen-cloud", "alibaba", "alibaba-token-plan-intl", "litellm"]);
+    expect(optedIn.map(entry => entry.id)).toEqual(["anthropic", "ollama", "vllm", "lm-studio", "moonshot", "qwen-cloud", "alibaba", "alibaba-token-plan-intl", "litellm"]);
     for (const entry of optedIn) {
       expect(providerConfigSeed(entry)).not.toHaveProperty("allowBaseUrlOverride");
     }

--- a/tests/router-discarded-baseurl-warning.test.ts
+++ b/tests/router-discarded-baseurl-warning.test.ts
@@ -7,12 +7,12 @@ import type { OcxConfig, OcxProviderConfig } from "../src/types";
  * asserted in tests/router-template-baseurl.test.ts; these tests cover the diagnostic that
  * tells the user it happened, so a wrong-region URL stops surfacing as a bare 401.
  *
- * `anthropic` is the pinned fixture: a fixed remote registry endpoint, no `allowBaseUrlOverride`.
+ * `google` is the pinned fixture: a fixed remote registry endpoint, no `allowBaseUrlOverride`.
  * Warnings dedupe per (provider, discarded URL, effective URL), so each test uses a distinct
  * discarded URL and the suite stays order-independent.
  */
-const PINNED_PROVIDER = "anthropic";
-const PINNED_REGISTRY_BASE_URL = "https://api.anthropic.com";
+const PINNED_PROVIDER = "google";
+const PINNED_REGISTRY_BASE_URL = "https://generativelanguage.googleapis.com";
 
 function configFor(providerName: string, provider: OcxProviderConfig): OcxConfig {
   return {
@@ -37,8 +37,8 @@ function routeCapturingWarnings(config: OcxConfig, model: string, times = 1): st
 
 function routePinned(baseUrl: unknown, times = 1): string[] {
   return routeCapturingWarnings(
-    configFor(PINNED_PROVIDER, { adapter: "anthropic", baseUrl } as OcxProviderConfig),
-    `${PINNED_PROVIDER}/claude-sonnet-5`,
+    configFor(PINNED_PROVIDER, { adapter: "google", baseUrl } as OcxProviderConfig),
+    `${PINNED_PROVIDER}/gemini-3-pro`,
     times,
   );
 }
@@ -57,13 +57,13 @@ test("warns when a pinned provider discards a configured baseUrl", () => {
 
 test("routing is unchanged by the warning", () => {
   const config = configFor(PINNED_PROVIDER, {
-    adapter: "anthropic",
+    adapter: "google",
     baseUrl: "https://routing-unchanged.example.test/v1",
   });
   const originalWarn = console.warn;
   console.warn = () => {};
   try {
-    expect(routeModel(config, `${PINNED_PROVIDER}/claude-sonnet-5`).provider.baseUrl)
+    expect(routeModel(config, `${PINNED_PROVIDER}/gemini-3-pro`).provider.baseUrl)
       .toBe(PINNED_REGISTRY_BASE_URL);
   } finally {
     console.warn = originalWarn;
@@ -221,3 +221,4 @@ for (const { label, id, adapter, baseUrl } of [
     expect(routeModel(config, `${id}/model`).provider.baseUrl).toBe(baseUrl);
   });
 }
+

--- a/tests/router-template-baseurl.test.ts
+++ b/tests/router-template-baseurl.test.ts
@@ -56,7 +56,7 @@ for (const { id, registryBaseUrl } of OVERRIDE_PROVIDERS) {
 
 for (const { id, registryBaseUrl, adapter } of [
   { id: "ollama-cloud", registryBaseUrl: "https://ollama.com/v1", adapter: "openai-chat" },
-  { id: "anthropic", registryBaseUrl: "https://api.anthropic.com", adapter: "anthropic" },
+  { id: "google", registryBaseUrl: "https://generativelanguage.googleapis.com", adapter: "google" },
 ] as const) {
   test(`${id} keeps its fixed remote registry endpoint authoritative`, () => {
     const config = configFor(id, {
@@ -100,3 +100,4 @@ for (const { id, adapter, registryTemplate, resolvedBaseUrl } of [
     expect(routeModel(config, `${id}/model`).provider.baseUrl).toBe(registryTemplate);
   });
 }
+


### PR DESCRIPTION
## Problem

When a stale `baseUrl` is saved in `config.json` for the `anthropic` provider (e.g. a local proxy like `http://127.0.0.1:...` left over from a different account/setup), ocx prints a warning on every run:

```
config.json provider "anthropic": configured baseUrl ... is ignored because this provider's endpoint is fixed at https://api.anthropic.com/.
```

There is currently no supported way to intentionally point this provider at a compatible proxy endpoint, and the warning cannot be silenced without hand-editing config.

## Fix

Set `allowBaseUrlOverride: true` on the `anthropic` provider entry in `src/providers/registry.ts`, consistent with other providers that already support endpoint overrides (alibaba, ollama, vllm, lm-studio, ...). The default `baseUrl` is unchanged; behavior is identical unless the user explicitly configures an override.

## Security hardening (review follow-up)

Because `anthropic` is an OAuth provider, an override endpoint receives bearer credentials. Per the CodeRabbit and maintainer review, this PR now also adds `providerSecureTransportConfigError` to `src/lib/destination-policy.ts`: OAuth registry entries that opt into `allowBaseUrlOverride` require `https:`, and cleartext `http:` is accepted only for loopback/localhost/private relays behind the existing `allowPrivateNetwork` opt-in. The check runs inside `providerDestinationConfigError`, so routing, config validation, and the outbound model-discovery layer all enforce it. Keyed/local providers are untouched.

Review follow-ups also included here:
- `tests/router-discarded-baseurl-warning.test.ts`: only the pinned fixture moves to `google`; the unrelated alibaba/ollama/custom cases keep `adapter: "openai-chat"` (maintainer finding).
- `tests/router-template-baseurl.test.ts`: fixed-endpoint fixture moves anthropic→google.
- `tests/provider-model-discovery-contract.test.ts`: fixed-OAuth discovery pinning fixture moves anthropic→kimi.
- `tests/anthropic-baseurl-override.test.ts`: regression tests for the https requirement on the routing path, the shared discovery/config gate, and the local-relay escape hatch.

Companion PR for the same issue on the Google Antigravity provider is #2110; it carries the same shared-policy commit so either merge order works.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Anthropic OAuth connections can now use custom base URLs, including compatible routing services and local relays.
* **Bug Fixes**
  * Added secure transport protections for overridden OAuth endpoints.
  * Non-local HTTP destinations are rejected unless explicitly permitted, while localhost and private-network relay scenarios remain supported.
  * Improved validation and warnings for missing, unresolved, or discarded base URL configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->