### PR TITLE
fix(google): preserve and replay thought signatures across stream chunks and multi-tool turns (#2125)

### DIFF
--- a/src/adapters/google-antigravity-replay.ts
+++ b/src/adapters/google-antigravity-replay.ts
@@ -601,10 +601,15 @@ export function antigravityUsesReplayCache(model: string): boolean {
  * multi-step tool loop keeps EVERY prior call's signature, not just the latest part-index slot.
  * A signature on a standalone thought part is paired with the next functionCall in the same
  * array (#897); a call's own signature takes precedence and an unpaired one is dropped.
- * `parts` is the already-unwrapped `response.candidates[0].content.parts`.
- */
-export function observeAntigravityReplay(model: string, sessionId: string, parts: unknown[]): void {
-  if (!antigravityUsesReplayCache(model) || !Array.isArray(parts) || parts.length === 0) return;
+* `parts` is the already-unwrapped `response.candidates[0].content.parts`.
+*/
+export function observeAntigravityReplay(
+  model: string,
+  sessionId: string,
+  parts: unknown[],
+  carriedThoughtSig?: string,
+): string | undefined {
+  if (!antigravityUsesReplayCache(model) || !Array.isArray(parts) || parts.length === 0) return carriedThoughtSig;
   ensureReplaySnapshotLoaded();
   const now = Date.now();
   deleteExpiredReplaySessionsThrottled(now);
@@ -618,7 +623,7 @@ export function observeAntigravityReplay(model: string, sessionId: string, parts
     lastActiveAtMs: 0,
   };
   let inserted = false;
-  let pendingThoughtSig: string | undefined;
+  let pendingThoughtSig: string | undefined = carriedThoughtSig;
   for (const raw of parts) {
     if (!raw || typeof raw !== "object") continue;
     const part = raw as Record<string, unknown>;
@@ -632,7 +637,6 @@ export function observeAntigravityReplay(model: string, sessionId: string, parts
       continue;
     }
     const callSig = sig ?? pendingThoughtSig; // a signature on the call part itself wins
-    pendingThoughtSig = undefined;
     if (!callSig) continue;
     const ck = functionCallKey(fc.name, fc.args);
     if (!ck) continue; // only function-call signatures are replayable by identity
@@ -645,7 +649,7 @@ export function observeAntigravityReplay(model: string, sessionId: string, parts
     replayBytes += sizeBytes;
     inserted = true;
   }
-  if (!inserted) return;
+  if (!inserted) return pendingThoughtSig;
   // Charge the fixed outer key only when the session is actually stored.
   if (!existing) replayBytes += REPLAY_SESSION_KEY_BYTES;
   evictInnerCalls(entry);
@@ -659,7 +663,7 @@ export function observeAntigravityReplay(model: string, sessionId: string, parts
     } else {
       replayBytes -= REPLAY_SESSION_KEY_BYTES;
     }
-    return;
+    return pendingThoughtSig;
   }
   entry.expiresAtMs = now + REPLAY_TTL_MS;
   entry.lastActiveAtMs = now;
@@ -668,6 +672,7 @@ export function observeAntigravityReplay(model: string, sessionId: string, parts
   evictIfNeeded();
   enforceAppOwnedMemoryBudget();
   markReplayDirty();
+  return pendingThoughtSig;
 }
 
 /**

--- a/src/adapters/google-antigravity-replay.ts
+++ b/src/adapters/google-antigravity-replay.ts
@@ -599,10 +599,13 @@ export function antigravityUsesReplayCache(model: string): boolean {
  * Observe a parsed CCA chunk's `candidates[0].content.parts` and record thought signatures keyed by
  * the functionCall identity (name + args). Accumulates across the whole session so a sequential
  * multi-step tool loop keeps EVERY prior call's signature, not just the latest part-index slot.
- * A signature on a standalone thought part is paired with the next functionCall in the same
- * array (#897); a call's own signature takes precedence and an unpaired one is dropped.
-* `parts` is the already-unwrapped `response.candidates[0].content.parts`.
-*/
+ * A signature on a standalone thought part applies to the functionCall parts that follow it in
+ * the same array AND to later arrays of the same turn: streaming splits a thought part and its
+ * calls across SSE chunks, so `carriedThoughtSig` threads the still-unpaired signature from the
+ * previous chunk and the return value hands the remainder to the next one (#897, #2125). A call's
+ * own signature always takes precedence over a carried one.
+ * `parts` is the already-unwrapped `response.candidates[0].content.parts`.
+ */
 export function observeAntigravityReplay(
   model: string,
   sessionId: string,

--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -342,6 +342,7 @@ interface GoogleResponsePart {
   text?: string;
   thought?: boolean;
   thoughtSignature?: string;
+  thought_signature?: string;
   functionCall?: { name: string; args: unknown };
 }
 
@@ -352,8 +353,9 @@ interface GoogleResponsePart {
  */
 function googleToolCallMetadataFromPart(
   part: GoogleResponsePart,
+  fallbackSignature?: string,
 ): { providerMetadata: OcxProviderOpaqueToolCallMetadata } | undefined {
-  const signature = part.thoughtSignature;
+  const signature = part.thoughtSignature ?? part.thought_signature ?? fallbackSignature;
   if (!isLikelyRealThoughtSignature(signature)) return undefined;
   return { providerMetadata: { google: { thoughtSignature: signature } } };
 }
@@ -601,6 +603,7 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
       let lastFinishReason: string | undefined;
       let sawAnyFrame = false;
       let sawTerminalSignal = false;
+      let pendingStreamThoughtSig: string | undefined;
 
       const handleDataLine = async function* (line: string): AsyncGenerator<AdapterEvent, "continue" | "content" | "terminate"> {
         const payload = line.slice(5).trim();
@@ -697,10 +700,19 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
         const replaySession = provider.googleMode === "cloud-code-assist" ? antigravitySession : vertexReplaySession;
         if ((provider.googleMode === "cloud-code-assist" || provider.googleMode === "vertex")
           && parts && replayModel && replaySession) {
-          observeAntigravityReplay(replayModel, replaySession, parts as unknown[]);
+          pendingStreamThoughtSig = observeAntigravityReplay(
+            replayModel,
+            replaySession,
+            parts as unknown[],
+            pendingStreamThoughtSig,
+          );
         }
         if (parts) {
           for (const part of parts) {
+            const sig = part.thoughtSignature ?? part.thought_signature;
+            if (part.thought === true && sig && isLikelyRealThoughtSignature(sig)) {
+              pendingStreamThoughtSig = sig;
+            }
             const textEvent = googlePartTextEvent(part);
             if (textEvent) {
               emittedContentEvent = true;
@@ -729,7 +741,7 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
                 type: "tool_call_start",
                 id,
                 name: restoreGoogleToolName(part.functionCall.name),
-                ...googleToolCallMetadataFromPart(part),
+                ...googleToolCallMetadataFromPart(part, pendingStreamThoughtSig),
               };
               yield { type: "tool_call_delta", arguments: JSON.stringify(part.functionCall.args ?? {}) };
               yield { type: "tool_call_end" };
@@ -926,7 +938,12 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
           && replayModel && replaySession) {
           observeAntigravityReplay(replayModel, replaySession, candidates[0].content.parts as unknown[]);
         }
+        let pendingThoughtSig: string | undefined;
         for (const part of candidates[0].content.parts) {
+          const sig = part.thoughtSignature ?? part.thought_signature;
+          if (part.thought === true && sig && isLikelyRealThoughtSignature(sig)) {
+            pendingThoughtSig = sig;
+          }
           const textEvent = googlePartTextEvent(part);
           if (textEvent) events.push(textEvent);
           const inline = (part as { inlineData?: { mimeType?: string; data?: string } }).inlineData;
@@ -950,7 +967,7 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
               type: "tool_call_start",
               id,
               name: restoreGoogleToolName(part.functionCall.name),
-              ...googleToolCallMetadataFromPart(part),
+              ...googleToolCallMetadataFromPart(part, pendingThoughtSig),
             });
             events.push({ type: "tool_call_delta", arguments: JSON.stringify(part.functionCall.args ?? {}) });
             events.push({ type: "tool_call_end" });

--- a/tests/google-antigravity-replay.test.ts
+++ b/tests/google-antigravity-replay.test.ts
@@ -97,6 +97,33 @@ describe("antigravity reasoning-replay cache", () => {
     expect((contents[0].parts[0] as { thoughtSignature?: string }).thoughtSignature).toBe(SIG);
   });
 
+  test("a signature on a standalone thought part replays onto all subsequent functionCalls in the same turn", () => {
+    observeAntigravityReplay(MODEL, SESSION, [
+      { thought: true, thoughtSignature: SIG },
+      fcPart("get_x", { a: 1 }),
+      fcPart("get_y", { b: 2 }),
+    ]);
+    const contents = [{
+      role: "model",
+      parts: [
+        { functionCall: { name: "get_x", args: { a: 1 } } },
+        { functionCall: { name: "get_y", args: { b: 2 } } },
+      ],
+    }];
+    applyAntigravityReplay(MODEL, SESSION, contents);
+    expect((contents[0].parts[0] as { thoughtSignature?: string }).thoughtSignature).toBe(SIG);
+    expect((contents[0].parts[1] as { thoughtSignature?: string }).thoughtSignature).toBe(SIG);
+  });
+
+  test("carried thought signature across separate stream chunks pairs with subsequent functionCalls", () => {
+    const carried = observeAntigravityReplay(MODEL, SESSION, [{ thought: true, thought_signature: SIG }]);
+    expect(carried).toBe(SIG);
+    observeAntigravityReplay(MODEL, SESSION, [fcPart("get_x", { a: 1 })], carried);
+    const contents = [{ role: "model", parts: [{ functionCall: { name: "get_x", args: { a: 1 } } }] }];
+    applyAntigravityReplay(MODEL, SESSION, contents);
+    expect((contents[0].parts[0] as { thoughtSignature?: string }).thoughtSignature).toBe(SIG);
+  });
+
   test("a call's own signature wins over a preceding standalone thought signature", () => {
     observeAntigravityReplay(MODEL, SESSION, [
       { thought: true, thoughtSignature: "sig-standalone-aaaa" },

--- a/tests/google-signature-history-roundtrip.test.ts
+++ b/tests/google-signature-history-roundtrip.test.ts
@@ -132,6 +132,56 @@ describe("#1735 thought signature survives history replay", () => {
     expect(signatures).toEqual([SIGNATURE, SIGNATURE_B]);
   });
 
+  test("a standalone thought part's signature attaches to all subsequent functionCalls in non-streaming parse", async () => {
+    const adapter = createGoogleAdapter(provider);
+    await adapter.buildRequest(firstTurn());
+    const events = await adapter.parseResponse!(new Response(JSON.stringify(googleBody([
+      { text: "thinking...", thought: true, thoughtSignature: SIGNATURE },
+      { functionCall: { name: "shell_command", args: { command: "pwd" } } },
+      { functionCall: { name: "shell_command", args: { command: "ls" } } },
+    ]))));
+    const starts = events.filter((e: AdapterEvent) => e.type === "tool_call_start");
+    expect(starts.length).toBe(2);
+    expect("providerMetadata" in starts[0] ? starts[0].providerMetadata?.google?.thoughtSignature : undefined)
+      .toBe(SIGNATURE);
+    expect("providerMetadata" in starts[1] ? starts[1].providerMetadata?.google?.thoughtSignature : undefined)
+      .toBe(SIGNATURE);
+  });
+
+  test("streaming SSE chunks carry thought signature across chunk boundaries to function calls", async () => {
+    const adapter = createGoogleAdapter(provider);
+    await adapter.buildRequest(firstTurn());
+    const ssePayload = [
+      `data: ${JSON.stringify(googleBody([{ text: "thinking...", thought: true, thought_signature: SIGNATURE }]))}`,
+      "",
+      `data: ${JSON.stringify(googleBody([{ functionCall: { name: "shell_command", args: { command: "pwd" } } }]))}`,
+      "",
+      `data: ${JSON.stringify(googleBody([{ functionCall: { name: "shell_command", args: { command: "ls" } } }]))}`,
+      "",
+      "data: [DONE]",
+      "",
+    ].join("\n");
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(ssePayload));
+        controller.close();
+      },
+    });
+
+    const events: AdapterEvent[] = [];
+    for await (const event of adapter.parseStream(new Response(stream))) {
+      events.push(event);
+    }
+
+    const starts = events.filter((e: AdapterEvent) => e.type === "tool_call_start");
+    expect(starts.length).toBe(2);
+    expect("providerMetadata" in starts[0] ? starts[0].providerMetadata?.google?.thoughtSignature : undefined)
+      .toBe(SIGNATURE);
+    expect("providerMetadata" in starts[1] ? starts[1].providerMetadata?.google?.thoughtSignature : undefined)
+      .toBe(SIGNATURE);
+  });
+
   test("a signature replayed through Responses history reaches the rebuilt Google part", async () => {
     // No cache is warmed here: this is a cold process replaying client-supplied history.
     const parsed = parseRequestScoped({

--- a/tests/google-signature-history-roundtrip.test.ts
+++ b/tests/google-signature-history-roundtrip.test.ts
@@ -151,20 +151,20 @@ describe("#1735 thought signature survives history replay", () => {
   test("streaming SSE chunks carry thought signature across chunk boundaries to function calls", async () => {
     const adapter = createGoogleAdapter(provider);
     await adapter.buildRequest(firstTurn());
-    const ssePayload = [
-      `data: ${JSON.stringify(googleBody([{ text: "thinking...", thought: true, thought_signature: SIGNATURE }]))}`,
-      "",
-      `data: ${JSON.stringify(googleBody([{ functionCall: { name: "shell_command", args: { command: "pwd" } } }]))}`,
-      "",
-      `data: ${JSON.stringify(googleBody([{ functionCall: { name: "shell_command", args: { command: "ls" } } }]))}`,
-      "",
-      "data: [DONE]",
-      "",
-    ].join("\n");
+    // Each SSE frame arrives as its own transport chunk so the signature has to
+    // survive the chunk boundary between the thought part and the function calls.
+    const frames = [
+      `data: ${JSON.stringify(googleBody([{ text: "thinking...", thought: true, thought_signature: SIGNATURE }]))}\n\n`,
+      `data: ${JSON.stringify(googleBody([{ functionCall: { name: "shell_command", args: { command: "pwd" } } }]))}\n\n`,
+      `data: ${JSON.stringify(googleBody([{ functionCall: { name: "shell_command", args: { command: "ls" } } }]))}\n\n`,
+      // usageMetadata is the terminal signal; no [DONE] sentinel needed.
+      `data: ${JSON.stringify({ usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 2 } })}\n\n`,
+    ];
 
     const stream = new ReadableStream<Uint8Array>({
       start(controller) {
-        controller.enqueue(new TextEncoder().encode(ssePayload));
+        const encoder = new TextEncoder();
+        for (const frame of frames) controller.enqueue(encoder.encode(frame));
         controller.close();
       },
     });
@@ -174,6 +174,9 @@ describe("#1735 thought signature survives history replay", () => {
       events.push(event);
     }
 
+    // The turn completes cleanly: no error events, terminal done last.
+    expect(events.some((e: AdapterEvent) => e.type === "error")).toBe(false);
+    expect(events[events.length - 1]?.type).toBe("done");
     const starts = events.filter((e: AdapterEvent) => e.type === "tool_call_start");
     expect(starts.length).toBe(2);
     expect("providerMetadata" in starts[0] ? starts[0].providerMetadata?.google?.thoughtSignature : undefined)


### PR DESCRIPTION
## Summary

Closes #2125

Fixes HTTP 400 (`Function call is missing a thought_signature in functionCall parts`) errors on `google-antigravity` (Gemini reasoning models) during streaming and multi-turn tool execution:

1. **Cross-chunk SSE thought signature pairing**: In Gemini streaming mode, reasoning thought parts and subsequent `functionCall` parts often arrive in separate SSE chunks. `observeAntigravityReplay` now carries `pendingStreamThoughtSig` across chunks within the stream turn, and `googleToolCallMetadataFromPart` pairs the thought signature with all tool calls in that stream.
2. **Multi-tool turn persistence**: `observeAntigravityReplay` no longer resets `pendingThoughtSig` after the first tool call in a multi-call turn, so parallel/sequential tool calls (e.g. `default_api:exec` + `default_api:wait`) all keep the required `thought_signature`. A call's own signature still wins over the carried one.
3. **Snake_case `thought_signature` support**: `GoogleResponsePart` and `googleToolCallMetadataFromPart` now recognize both camelCase `thoughtSignature` and snake_case `thought_signature` from upstream chunks (the replay cache's `extractSignature` already read both; the parser did not).

The JSDoc on `observeAntigravityReplay` now documents the new contract (same-turn subsequent calls + carried across SSE chunks), per review.

## Verification

- `bun test tests/google-antigravity-replay.test.ts tests/google-signature-history-roundtrip.test.ts` — 78 pass, 0 fail (includes the hardened streaming test: separate transport chunks per SSE frame, no `[DONE]` sentinel, asserts no error events and a terminal `done`, per CodeRabbit).
- `bun run typecheck` — clean.
- `OCX_TEST_NO_QUEUE=1 bun run prepush` — green.
- **Live multi-turn tool loop on the local proxy (v2.26.0 + this patch, cockpit-tools-imported `google-antigravity` account, `gemini-3.7-flash`)**: 4 sequential turns replaying history as bare `function_call` items (no `extra_content` echoed, like real Codex clients) — all 200, every replayed call re-signed from the proxy store. A parallel two-`function_call` turn replayed on the next turn also returned 200. This is the exact failure shape from #2125 (positions 133/238/262) and it no longer reproduces locally.
- If a 400 still appears on a compaction/multi-agent path that strips `providerMetadata`, that is the named follow-up (Refs, issue stays open) — the replay cache keys on name+args there, and the call_id store only helps when the first emit carried a signature.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Gemini thought signatures in streamed and buffered responses.
  * Thought signatures now correctly carry across response chunks and apply to subsequent function calls.
  * Supports both camelCase and snake_case signature formats.
  * Preserves signatures during replay processing and early completion scenarios.

* **Tests**
  * Added coverage for signature propagation across calls, streams, and replayed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->