### PR TITLE
test(ws-upstream): hold the eager-relay marker to the win32 rule, not to a constant

### DIFF
--- a/tests/ws-upstream.test.ts
+++ b/tests/ws-upstream.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, jest, test } from "bun:test";
 import { providerFetch } from "../src/server/responses/fetch-helpers";
 import { handleResponses } from "../src/server/responses";
 import { isEagerRelaySseResponse } from "../src/server/relay";
+import { isWin32EagerRewrite } from "../src/lib/bun-stream-caps";
+import { createResponsesFieldBackfillBlockRewrite } from "../src/server/responses/responses-field-backfill";
 import {
   bunSupportsBoundedCodexWsRelay,
   codexWsUpstreamFetch as rawCodexWsUpstreamFetch,
@@ -16,6 +18,17 @@ import type { OcxConfig } from "../src/types";
 
 const CODEX_URL = "https://chatgpt.com/backend-api/codex/responses";
 const BOUNDED_WS_RUNTIME = "1.4.0";
+
+// #864 keeps win32 rewrite traffic out of the tee()+JS-pull chain, so
+// `isWin32EagerRewrite(platform, needsClientRewrite)` sends it through the eager
+// single-reader relay instead. Since the annotations backfill became an
+// unconditional block rewrite (5a75e57f, `createResponsesFieldBackfillBlockRewrite()`),
+// `needsClientRewrite` is true for every Responses stream — so on win32 the eager
+// relay marker is set no matter which upstream transport was chosen. Cases below
+// that are about *not* taking the WebSocket path assert that directly through
+// `FakeWebSocket.instances`; they hold the marker to this rule rather than to a
+// constant that only held before the backfill landed.
+const EAGER_RELAY_FORCED_BY_PLATFORM = isWin32EagerRewrite(process.platform, true);
 
 function shouldUseCodexWsUpstream(url: string, init?: RequestInit): boolean {
   return rawShouldUseCodexWsUpstream(url, init, BOUNDED_WS_RUNTIME);
@@ -288,7 +301,7 @@ describe("handleResponses Codex WS relay selection", () => {
     });
 
     expect(FakeWebSocket.instances).toHaveLength(1);
-    expect(isEagerRelaySseResponse(response)).toBe(false);
+    expect(isEagerRelaySseResponse(response)).toBe(EAGER_RELAY_FORCED_BY_PLATFORM);
     expect(await response.text()).toContain("response.completed");
   });
 
@@ -330,10 +343,31 @@ describe("handleResponses Codex WS relay selection", () => {
       const response = await handleResponses(request(), forwardConfig(), { model: "", provider: "" });
 
       expect(FakeWebSocket.instances).toHaveLength(0);
-      expect(isEagerRelaySseResponse(response)).toBe(false);
+      expect(isEagerRelaySseResponse(response)).toBe(EAGER_RELAY_FORCED_BY_PLATFORM);
       expect(await response.text()).toContain("response.completed");
     },
   );
+});
+
+describe("eager-relay marker preconditions", () => {
+  test("the client rewrite chain is never empty, so win32 always takes the eager path", () => {
+    // This is the coupling that silently changed the two cases above.
+    // `createResponsesFieldBackfillBlockRewrite()` is added to `blockRewrites`
+    // unconditionally and returns a rewrite rather than `undefined`, so
+    // `needsClientRewrite` in `handleResponses` is a constant `true`. Combined with
+    // the win32 rule that makes the eager relay the only safe path for rewrite
+    // traffic, every Responses stream on Windows is marked. If either half changes,
+    // this fails here rather than in an assertion that looks like it is about
+    // WebSocket selection.
+    expect(typeof createResponsesFieldBackfillBlockRewrite()).toBe("function");
+
+    expect(isWin32EagerRewrite("win32", true)).toBe(true);
+    expect(isWin32EagerRewrite("win32", false)).toBe(false);
+    expect(isWin32EagerRewrite("darwin", true)).toBe(false);
+    expect(isWin32EagerRewrite("linux", true)).toBe(false);
+
+    expect(EAGER_RELAY_FORCED_BY_PLATFORM).toBe(process.platform === "win32");
+  });
 });
 
 describe("codexWsUpstreamFetch", () => {

--- a/tests/ws-upstream.test.ts
+++ b/tests/ws-upstream.test.ts
@@ -3,7 +3,6 @@ import { providerFetch } from "../src/server/responses/fetch-helpers";
 import { handleResponses } from "../src/server/responses";
 import { isEagerRelaySseResponse } from "../src/server/relay";
 import { isWin32EagerRewrite } from "../src/lib/bun-stream-caps";
-import { createResponsesFieldBackfillBlockRewrite } from "../src/server/responses/responses-field-backfill";
 import {
   bunSupportsBoundedCodexWsRelay,
   codexWsUpstreamFetch as rawCodexWsUpstreamFetch,
@@ -347,20 +346,59 @@ describe("handleResponses Codex WS relay selection", () => {
       expect(await response.text()).toContain("response.completed");
     },
   );
+
+  // The two cases above assert the marker against `EAGER_RELAY_FORCED_BY_PLATFORM`,
+  // which is only the right expectation while `needsClientRewrite` is genuinely
+  // `true`. Rather than assert that through the rewrite factory — which would stay
+  // green if `handleResponses` stopped registering it — this drives a real Responses
+  // stream through the handler and reads the rewrite's own effect off the client
+  // bytes. `createResponsesFieldBackfillBlockRewrite()` is the unconditional entry in
+  // `blockRewrites`, so observing its transformation is what proves
+  // `clientBlockRewrite !== undefined`, hence `needsClientRewrite === true`.
+  test("the registered rewrite chain transforms the client stream, so needsClientRewrite is true", async () => {
+    const upstreamEvent = {
+      type: "response.completed",
+      response: {
+        id: "r-backfill",
+        status: "completed",
+        // Deliberately spec-non-compliant: `annotations` is required on
+        // `output_text` and this upstream omits it. Only the backfill rewrite
+        // puts it back.
+        output: [{
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "hi" }],
+        }],
+      },
+    };
+    globalThis.fetch = (async () => new Response(
+      `event: response.completed\ndata: ${JSON.stringify(upstreamEvent)}\n\n`,
+      { status: 200, headers: { "content-type": "text/event-stream" } },
+    )) as typeof fetch;
+
+    const response = await handleResponses(request(), forwardConfig(), { model: "", provider: "" });
+    const text = await response.text();
+
+    const payload = text
+      .split("\n")
+      .filter(line => line.startsWith("data: ") && line !== "data: [DONE]")
+      .map(line => JSON.parse(line.slice("data: ".length)))
+      .find(event => event.type === "response.completed");
+
+    expect(payload).toBeDefined();
+    // Absent on the wire, present to the client: the chain ran.
+    expect(payload.response.output[0].content[0]).toHaveProperty("annotations");
+    expect(payload.response.output[0].content[0].annotations).toEqual([]);
+
+    // And with the chain proven non-empty, the marker is exactly the win32 rule.
+    expect(isEagerRelaySseResponse(response)).toBe(EAGER_RELAY_FORCED_BY_PLATFORM);
+  });
 });
 
-describe("eager-relay marker preconditions", () => {
-  test("the client rewrite chain is never empty, so win32 always takes the eager path", () => {
-    // This is the coupling that silently changed the two cases above.
-    // `createResponsesFieldBackfillBlockRewrite()` is added to `blockRewrites`
-    // unconditionally and returns a rewrite rather than `undefined`, so
-    // `needsClientRewrite` in `handleResponses` is a constant `true`. Combined with
-    // the win32 rule that makes the eager relay the only safe path for rewrite
-    // traffic, every Responses stream on Windows is marked. If either half changes,
-    // this fails here rather than in an assertion that looks like it is about
-    // WebSocket selection.
-    expect(typeof createResponsesFieldBackfillBlockRewrite()).toBe("function");
-
+describe("isWin32EagerRewrite", () => {
+  test("marks rewrite traffic on win32 only", () => {
+    // #864 is a win32-only Bun sink defect, so the rule must not widen to other
+    // platforms, and must not fire when there is nothing to rewrite.
     expect(isWin32EagerRewrite("win32", true)).toBe(true);
     expect(isWin32EagerRewrite("win32", false)).toBe(false);
     expect(isWin32EagerRewrite("darwin", true)).toBe(false);


### PR DESCRIPTION
## Summary

Two cases in `tests/ws-upstream.test.ts` fail on Windows and have since `5a75e57f`:

```
(fail) handleResponses Codex WS relay selection > an HTTP fallback remains on the configured legacy tee path
(fail) handleResponses Codex WS relay selection > an older runtime stays on HTTP SSE without opening a WebSocket
```

Both assert `isEagerRelaySseResponse(response)` is `false` and get `true`. **The source behaviour is correct; the assertions are stale.** This is a test-only change.

## Where it starts

Both bisect endpoints were run rather than assumed — I got this wrong once already by treating "the test name did not appear in a log" as "the test passed", so the endpoints here are measured:

```
dec332c49   23 pass / 0 fail
5a75e57ff   21 pass / 2 fail    fix(grok): switch to Responses backend and backfill required annotations
```

## Why it happens

`5a75e57f` adds `createResponsesFieldBackfillBlockRewrite()` to `blockRewrites` **unconditionally**, and the factory returns an `SseBlockRewrite`, never `undefined`. So the chain is never empty and `needsClientRewrite` in `handleResponses` is now a constant `true`.

`isWin32EagerRewrite` is `platform === "win32" && needsClientRewrite` (`src/lib/bun-stream-caps.ts:126`), so on Windows every Responses stream now takes the eager single-reader relay.

That is exactly what #864 asks for — win32 rewrite traffic must never enter the `tee()`+JS-pull chain, and now *all* traffic is rewrite traffic. Nothing to fix in `src`.

Instrumented the gate to confirm the mechanism rather than deduce it:

```
[EAGER] {"forceCodexWsEagerRelay":false,"useEagerRelay":null,"win32EagerRewrite":true,
         "needsClientRewrite":true,"platform":"win32","blockRewrites":1}
```

`forceCodexWsEagerRelay` is `false` — the WebSocket path was correctly *not* chosen. The marker is set by the win32 rewrite rule alone.

## Change

Both cases are about the **WebSocket path not being taken**, and both already assert that directly through `FakeWebSocket.instances` (1 opened then closed for the HTTP fallback, 0 for the older runtime). The `isEagerRelaySseResponse(...)` assertion was a second-order signal that stopped tracking WS selection on win32.

It now follows the documented rule instead of a constant:

```ts
const EAGER_RELAY_FORCED_BY_PLATFORM = isWin32EagerRewrite(process.platform, true);
```

so it stays honest on every platform rather than encoding a pre-backfill world.

Adds one precondition case pinning the coupling itself — the rewrite chain being non-empty, and the platform rule — so if either half moves, it fails somewhere that names the real cause instead of inside a WebSocket assertion.

## Verification

```
bun test tests/ws-upstream.test.ts                          24 pass / 0 fail   (was 21 pass / 2 fail)
bun test ws-upstream, responses-field-backfill,
         responses-snapshot-repair-server,
         subagent-fallback-handle-responses                 58 pass / 3 skip / 0 fail
bun run typecheck                                           exit 0
```

The new precondition case is mutation-checked rather than merely green: forcing `isWin32EagerRewrite` to return `false` turns it red.

I am on `bun 1.3.14`, which `tests/ws-upstream.test.ts:42` pins as *not* supporting the bounded relay, so the second case is one a newer-bun CI may `skipIf` past — which is likely why this has stayed unnoticed. The first case injects `BOUNDED_WS_RUNTIME` explicitly and is runtime-independent.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->



## Full-suite context

The repo-wide `bun run test` on this branch is **not** clean on Windows, and none of it is this change:

- `tests/server-auth.test.ts > OpenAI option auth matrix keeps direct, pool, and API credentials independent` fails **reproducibly** — twice in a row on a tree checked out wholesale to `origin/dev`, with this branch's only file reverted. Pre-existing, and separate from the failures fixed here.
- `CodeRabbit protection regressions`, `fixture-dir-uniqueness`, and two `#584` pool-retry cases failed in the full run and pass in isolation. They are load-dependent; each full-suite run on this machine reddens a different subset.

`tests/ws-upstream.test.ts` — the file this PR touches — is **25 pass / 0 fail** on win32 at the rebased head `7bfcec404` (base `caf20353f`, 0 behind), and no longer appears in the full-run failures at all. The first checklist box is ticked against that scope; the two items above are pre-existing on clean `dev` and are not claimed as green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded WebSocket relay coverage for platform-specific rewrite behavior.
  - Added validation for rewrite-driven client transformations and eager relay selection on Windows.
  - Updated HTTP fallback and older-runtime checks to verify platform-derived relay markers.
  - Added coverage confirming the derived eager-relay marker remains consistent across supported runtime scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
