### PR TITLE
fix(responses): drop the retired prompt_cache_retention for gpt-5.6

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -186,6 +186,28 @@ function stripUnsupportedReasoningParams(body: unknown): unknown {
 }
 
 /**
+ * GPT-5.6 replaced the legacy 24-hour retention field with `prompt_cache_options.ttl`, and the
+ * ChatGPT backend 400s the whole request when the retired field is present (issue #2092).
+ *
+ * The retired field is NOT translated to the replacement: 5.6 carries a different TTL contract,
+ * and implicit caching still applies when the caller sent no replacement options. Inventing a
+ * value here would silently change a caching decision the caller never made.
+ *
+ * Deliberately narrow on both axes, because a wider strip is a behavior change rather than a fix:
+ * only the gpt-5.6 family (an older model may still honor the field), and only on the canonical
+ * ChatGPT backend, which is the deployment that rejects it. Matching is exact-or-dashed-prefix so
+ * a future `gpt-5.60` is not swept up by a bare `startsWith`.
+ */
+function stripDeprecatedPromptCacheRetention(body: unknown, modelId: unknown): unknown {
+  if (!isPlainObject(body)) return body;
+  if (typeof modelId !== "string") return body;
+  if (modelId !== "gpt-5.6" && !modelId.startsWith("gpt-5.6-")) return body;
+  if (!Object.hasOwn(body, "prompt_cache_retention")) return body;
+  const { prompt_cache_retention: _retention, ...rest } = body;
+  return rest;
+}
+
+/**
  * A false model capability prevents Codex from emitting summary fields after the catalog refresh.
  * Strip them here as well so an already-running client with a stale catalog cannot keep sending an
  * upstream-rejected `reasoning_summary_delivery` value (issue #323).
@@ -1491,6 +1513,11 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
       }
       if (forward) {
         outBody = stripUnsupportedForwardParams(outBody);
+        // Only the canonical ChatGPT backend rejects the retired field; a self-hosted or
+        // third-party forward gateway may still accept it, so this must not be widened.
+        if (isCanonicalOpenAiForwardProvider(provider)) {
+          outBody = stripDeprecatedPromptCacheRetention(outBody, parsed.modelId);
+        }
       } else {
         outBody = preferConfiguredHostedTools(
           outBody,

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -822,6 +822,92 @@ describe("OpenAI Responses passthrough sanitization", () => {
     expect(body.prompt_cache_retention).toBe("24h");
   });
 
+  /**
+   * Issue #2092: the ChatGPT backend 400s a gpt-5.6 request that still carries the retired
+   * `prompt_cache_retention`. The strip is deliberately narrow, and these cases pin the
+   * narrowness itself — a wider strip passes the first block and fails the second.
+   */
+  test.each(["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"])(
+    "drops the retired prompt_cache_retention for %s without inventing replacement options",
+    modelId => {
+      const adapter = createResponsesPassthroughAdapter(provider);
+      const request = adapter.buildRequest({
+        modelId,
+        context: { messages: [] },
+        stream: true,
+        options: {},
+        _rawBody: { model: modelId, input: "hi", prompt_cache_retention: "24h" },
+      }, { headers: new Headers({ authorization: "Bearer token" }) });
+      const body = JSON.parse(request.body) as {
+        prompt_cache_retention?: string;
+        prompt_cache_options?: unknown;
+      };
+
+      expect(body.prompt_cache_retention).toBeUndefined();
+      // Translating "24h" into the replacement field would invent a caching decision the
+      // caller never made, so absence must stay absence.
+      expect(body.prompt_cache_options).toBeUndefined();
+    },
+  );
+
+  test("keeps caller-sent prompt_cache_options while dropping the retired retention", () => {
+    const adapter = createResponsesPassthroughAdapter(provider);
+    const request = adapter.buildRequest({
+      modelId: "gpt-5.6-sol",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: {
+        model: "gpt-5.6-sol",
+        input: "hi",
+        prompt_cache_retention: "24h",
+        prompt_cache_options: { ttl: "30m" },
+      },
+    }, { headers: new Headers({ authorization: "Bearer token" }) });
+    const body = JSON.parse(request.body) as {
+      prompt_cache_retention?: string;
+      prompt_cache_options?: { ttl?: string };
+    };
+
+    expect(body.prompt_cache_retention).toBeUndefined();
+    expect(body.prompt_cache_options).toEqual({ ttl: "30m" });
+  });
+
+  test("a near-miss model id is not swept up by the gpt-5.6 family match", () => {
+    const adapter = createResponsesPassthroughAdapter(provider);
+    const request = adapter.buildRequest({
+      modelId: "gpt-5.60",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: { model: "gpt-5.60", input: "hi", prompt_cache_retention: "24h" },
+    }, { headers: new Headers({ authorization: "Bearer token" }) });
+    const body = JSON.parse(request.body) as { prompt_cache_retention?: string };
+
+    // A bare startsWith("gpt-5.6") would strip here and silently change an unrelated model.
+    expect(body.prompt_cache_retention).toBe("24h");
+  });
+
+  test("a noncanonical forward gateway keeps the field even for gpt-5.6", () => {
+    const adapter = createResponsesPassthroughAdapter({
+      adapter: "openai-responses",
+      baseUrl: "https://gateway.example/v1",
+      authMode: "forward" as const,
+    });
+    const request = adapter.buildRequest({
+      modelId: "gpt-5.6-sol",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: { model: "gpt-5.6-sol", input: "hi", prompt_cache_retention: "24h" },
+    }, { headers: new Headers({ authorization: "Bearer token" }) });
+    const body = JSON.parse(request.body) as { prompt_cache_retention?: string };
+
+    // Only the canonical ChatGPT backend is known to reject it. Stripping everywhere would be
+    // a behavior change for deployments that still honor the field.
+    expect(body.prompt_cache_retention).toBe("24h");
+  });
+
   const expandedRawBody = {
     model: "gpt-5.5",
     previous_response_id: "resp_1",


### PR DESCRIPTION
## Summary

The ChatGPT backend rejects a `gpt-5.6` request that still carries `prompt_cache_retention` with `400 Unsupported parameter` (#2092, reproduced 3/3 by the reporter: field present → 400, field omitted → 200). GPT-5.6 replaced it with `prompt_cache_options.ttl`.

This strips the retired field on the canonical ChatGPT forward path, for the `gpt-5.6` family only.

**Credit:** the implementation is @lilinxiong's from #2102, which had the right contract of the three proposals. @yzxcj797's #2099 contributed the `Fixes #2092` link and the repro-shaped fixture. @luvs01's #2091 raised the same defect.

### Why the narrowness is the fix

Two deliberate limits, each pinned by a test that a wider strip would fail:

- **Model:** exact `gpt-5.6` or a dashed `gpt-5.6-*` prefix. A bare `startsWith("gpt-5.6")` also matches a future `gpt-5.60`, silently changing an unrelated model.
- **Backend:** canonical ChatGPT forward only. A self-hosted or third-party forward gateway may still honor the field; the issue reporter explicitly withdrew the broader "never send it anywhere" claim, and `tests/openai-responses-passthrough.test.ts:807` already pins that a gpt-5.5 forward request keeps it.

The retired value is **not** translated into `prompt_cache_options`. 5.6 carries a different TTL contract and implicit caching still applies when the caller sent no replacement options, so synthesizing one would change a caching decision the caller never made.

## Verification

- Extended `tests/openai-responses-passthrough.test.ts`, driven **RED** first: reverting only the adapter change fails 5 of the new tests. The two narrowness guards (`gpt-5.60`, noncanonical gateway) stay green in both directions, which is what proves they are guards rather than restatements.
- `bun test --isolate tests` — 13,537 pass, 0 fail, 10 skip (855 files).
- `bun test --isolate tests/openai-responses-passthrough.test.ts` — 75 pass, 0 fail.
- `bun run typecheck` — clean.
- `bun run privacy:scan` — passed.

## Supersedes

Once this lands, #2102, #2099, and #2091 are all resolved by it. I will close them with attribution rather than leaving three open PRs for one defect.

Note: #2092's intermittent 400s on bodies that already lacked the field are **not** addressed here and remain open — that is a separate backend/retry question, and widening the strip would not fix it.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No user-facing documented behavior: a request that previously 400'd now succeeds.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (Removes one request field on one backend; no auth, credential, or workflow surface touched. Privacy scan green.)

Closes #2092


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated requests for the `gpt-5.6` model family to omit the retired prompt cache retention setting when using the canonical OpenAI backend.
  * Preserves replacement prompt cache options provided by callers.
  * Keeps existing behavior for other models and compatible third-party gateways.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->