### PR TITLE
test(service): pin the file mode on POSIX only, not on Windows

### DIFF
--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -2178,7 +2178,15 @@ describe("service serving confirmation", () => {
 describe("service definitions are not world-readable", () => {
   const modeOf = (path: string): string => (statSync(path).mode & 0o777).toString(8);
 
-  test("a freshly written definition is owner-only", () => {
+  // Windows does not implement POSIX permission bits — Bun reports 0666 for an ordinary
+  // file regardless of what `mode` asked for, and the real boundary there is the NTFS ACL
+  // applied by hardenSecretPath. Asserting the octal on Windows tests the emulation layer
+  // rather than the security property, so these three pin the POSIX half only. The Windows
+  // half is covered by the credential-detection tests below, which decide whether that ACL
+  // is applied strictly.
+  const posixOnly = process.platform === "win32" ? test.skip : test;
+
+  posixOnly("a freshly written definition is owner-only", () => {
     const dir = mkdtempSync(join(tmpdir(), "ocx-service-mode-"));
     try {
       const path = join(dir, "unit");
@@ -2192,7 +2200,7 @@ describe("service definitions are not world-readable", () => {
     }
   });
 
-  test("an install over a loose definition from an older version tightens it", () => {
+  posixOnly("an install over a loose definition from an older version tightens it", () => {
     // `mode` applies only on creation, so a reinstall would otherwise leave 0644 standing.
     const dir = mkdtempSync(join(tmpdir(), "ocx-service-mode-"));
     try {
@@ -2208,7 +2216,7 @@ describe("service definitions are not world-readable", () => {
     }
   });
 
-  test("utf16le scheduler assets take the same mode", () => {
+  posixOnly("utf16le scheduler assets take the same mode", () => {
     const dir = mkdtempSync(join(tmpdir(), "ocx-service-mode-"));
     try {
       const path = join(dir, "task.xml");


### PR DESCRIPTION
## Summary

The Windows CI shard reported three of my own tests as failures, and they were genuinely wrong: **Bun on Windows returns `0666` from `statSync` for an ordinary file** regardless of what `mode` the write asked for, because Windows does not implement POSIX permission bits. The assertion was testing the emulation layer rather than the security property.

The real boundary on Windows is the NTFS ACL, applied by `hardenSecretPath` — and that is already covered by the credential-detection tests, which decide whether the ACL is required or best-effort. That is the question that actually matters there.

So these three skip on `win32` and keep asserting the octal everywhere the octal means something.

## What this does not fix, stated plainly

Three of the 25 Windows shard-4 failures were mine. **The other 22 are not, and this PR does not touch them.**

Evidence, since "pre-existing" is easy to claim and easy to get wrong:

- Run [32147924436](https://github.com/lidge-jun/opencodex/actions/runs/32147924436) on `e446607c8` (2026-08-18) already failed **3 of 4 Windows shards**, before any of the recent stack landed.
- The failures there and now overlap on the same suites: `Codex Log Guard lock`, `Codex Log Guard protection management API`, `CodeRabbit protection regressions`, and the reclaim/compact families.
- None of those files appear in `git diff origin/main...origin/dev --name-only` — not `tests/api-codex-log-guard-compact.test.ts`, not `tests/cli-codex-log-guard-protection.test.ts`, not `tests/codex-composed-acceptance.test.ts`.
- Shard 2's failure is not a test result at all: `panic(thread): Internal assertion failure` — a Bun runtime crash, which the workflow already has a signature list for on the macOS leg.

So the Windows leg is red for reasons that predate this work and live in SQLite/Log-Guard territory. Worth a deliberate decision rather than discovering it at promotion time.

## Verification

```
bun test tests/service.test.ts        135 pass / 0 fail
bun x tsc --noEmit                    exit 0
```

The Windows shard is the check that matters for this one, since the whole point is behavior that only differs there.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated file-permission tests to skip on Windows, where permission mode bits behave differently.
  * Continued validating owner-only permissions for service definition files on supported POSIX systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->