### PR TITLE
fix(oauth): reject superseded login credential commits

### DIFF
--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -322,6 +322,13 @@ export class OAuthReauthIdentityUnverifiedError extends Error {
   }
 }
 
+class OAuthLoginSupersededError extends Error {
+  constructor() {
+    super("OAuth login was superseded before credential persistence");
+    this.name = "OAuthLoginSupersededError";
+  }
+}
+
 /** Project arbitrary OAuth failures onto the small, stable public error vocabulary. */
 export function publicOAuthAuthenticationErrorMessage(error: unknown): string {
   if (error instanceof OAuthMutationBusyError) {
@@ -1096,6 +1103,7 @@ interface RunLoginDeps {
   settleKiroLoginTransaction?: typeof settleKiroLoginTransaction;
   removeAccount?: typeof removeAccount;
   setActiveAccount?: typeof setActiveAccount;
+  assertCurrentOwner?: () => void;
 }
 
 /** Roll back only accounts created by this forced login, preserving concurrent refreshes of others. */
@@ -1145,6 +1153,7 @@ export async function runLogin(
   const cred: OAuthCredentials = rawCred.source ? rawCred : { ...rawCred, source: "oauth" };
   const settleKiroTransaction = deps.settleKiroLoginTransaction ?? settleKiroLoginTransaction;
   try {
+    deps.assertCurrentOwner?.();
     // Validate the provider row before credential persistence. A namespace claimed during the
     // credential write is handled again below before the latest row is re-upserted.
     if (provider !== "chatgpt") {
@@ -1165,10 +1174,13 @@ export async function runLogin(
       if (!identityMatches) {
         throw new OAuthReauthIdentityMismatchError();
       }
-      await (deps.saveAccountCredential ?? saveAccountCredential)(provider, opts.reauthAccountId, cred);
+      await (deps.saveAccountCredential ?? saveAccountCredential)(provider, opts.reauthAccountId, cred, {
+        assertBeforePersist: deps.assertCurrentOwner,
+      });
     } else {
       await (deps.saveCredential ?? saveCredential)(provider, cred, {
         preserveIdentityless: opts?.forceLogin === true,
+        assertBeforePersist: deps.assertCurrentOwner,
       });
     }
     if (provider !== "chatgpt") {
@@ -1235,6 +1247,7 @@ export async function runLogin(
  */
 const loginState = new Map<string, { error?: string; done: boolean }>();
 const loginAbort = new Map<string, AbortController>();
+const kiroLoginSettling = new Set<string>();
 
 /** Pending paste for a login in progress: either a waiter or a stashed early submission. */
 interface ManualCodeSlot {
@@ -1403,13 +1416,14 @@ export async function startLoginFlow(
   const def = OAUTH_PROVIDERS[provider];
   if (!def) throw new UnsupportedOAuthProviderError(provider);
   const existing = loginState.get(provider);
-  if (existing && !existing.done) {
+  if ((existing && !existing.done) || (provider === "kiro" && kiroLoginSettling.has(provider))) {
     throw new Error(`A login for ${provider} is already in progress`);
   }
   clearManualCodeSlot(provider);
   loginState.set(provider, { done: false });
   const abort = new AbortController();
   loginAbort.set(provider, abort);
+  if (provider === "kiro") kiroLoginSettling.add(provider);
   return new Promise((resolve, reject) => {
     let urlResolved = false;
     const ctrl: OAuthController = {
@@ -1460,7 +1474,10 @@ export async function startLoginFlow(
     };
     // Background: runLogin persists the credential + provider entry to disk. The lifecycle hook
     // lets a long-lived server config adopt that settled state before clients observe done=true.
-    void runLogin(provider, ctrl, opts).then(
+    const assertCurrentOwner = (): void => {
+      if (loginAbort.get(provider) !== abort) throw new OAuthLoginSupersededError();
+    };
+    void runLogin(provider, ctrl, opts, { assertCurrentOwner }).then(
       () => settle(),
       (e: unknown) => settle(e),
     ).catch((e: unknown) => {
@@ -1471,6 +1488,8 @@ export async function startLoginFlow(
       const msg = publicOAuthAuthenticationErrorMessage(e);
       loginState.set(provider, { done: true, error: msg });
       if (!urlResolved) reject(e);
+    }).finally(() => {
+      if (provider === "kiro") kiroLoginSettling.delete(provider);
     });
   });
 }

--- a/src/oauth/store.ts
+++ b/src/oauth/store.ts
@@ -465,10 +465,11 @@ function serializeMutation<T>(work: () => Promise<T>, retainedValues: readonly u
   drainOAuthMutations();
   return result;
 }
-export function mutateStore<T>(fn:(store:AuthStore)=>T|Promise<T>, retainedValues: readonly unknown[] = [], options?: { waitMs?: number }):Promise<T>{return serializeMutation(async()=>{const guard=await createOAuthFileLock({path:getAuthStoreLockPath(),staleAfterMs:30000}).acquire();try{
+export function mutateStore<T>(fn:(store:AuthStore)=>T|Promise<T>, retainedValues: readonly unknown[] = [], options?: { waitMs?: number; assertBeforePersist?: () => void }):Promise<T>{return serializeMutation(async()=>{const guard=await createOAuthFileLock({path:getAuthStoreLockPath(),staleAfterMs:30000}).acquire();try{
     const { store, hadLegacy } = loadAuthStoreInternal();
     if (hadLegacy) backupLegacyOnce();
     const result = await fn(store);
+    options?.assertBeforePersist?.();
     persist(store);
     return result;
   }finally{guard.release();}}, retainedValues, options?.waitMs);
@@ -491,7 +492,7 @@ export function getCredential(provider: string): OAuthCredentials | null {
 export async function saveCredential(
   provider: string,
   cred: OAuthCredentials,
-  opts: { preserveIdentityless?: boolean } = {},
+  opts: { preserveIdentityless?: boolean; assertBeforePersist?: () => void } = {},
 ): Promise<void> {
   const safe = normalizeCredential(cred);
   if (!safe) return;
@@ -542,7 +543,7 @@ export async function saveCredential(
       set.accounts.push({ id, credential: safe, addedAt: Date.now() });
       set.activeAccountId = id;
     }
-  }, [provider, safe]);
+  }, [provider, safe], { assertBeforePersist: opts.assertBeforePersist });
 }
 
 /**
@@ -632,7 +633,12 @@ export function getAccountCredential(provider: string, accountId: string): OAuth
 }
 
 /** Persist a refreshed credential for a SPECIFIC account without touching activeAccountId. */
-export async function saveAccountCredential(provider: string, accountId: string, cred: OAuthCredentials): Promise<void> {
+export async function saveAccountCredential(
+  provider: string,
+  accountId: string,
+  cred: OAuthCredentials,
+  opts: { assertBeforePersist?: () => void } = {},
+): Promise<void> {
   const safe = normalizeCredential(cred);
   if (!safe) return;
   await mutateStore(store => {
@@ -640,7 +646,7 @@ export async function saveAccountCredential(provider: string, accountId: string,
     if (!account) return;
     account.credential = safe;
     delete account.needsReauth;
-  }, [provider, accountId, safe]);
+  }, [provider, accountId, safe], { assertBeforePersist: opts.assertBeforePersist });
 }
 
 export async function setActiveAccount(provider: string, accountId: string): Promise<boolean> {

--- a/tests/oauth-public-surface.test.ts
+++ b/tests/oauth-public-surface.test.ts
@@ -448,6 +448,113 @@ describe("legacy ChatGPT OAuth public-surface exclusion", () => {
     }
   });
 
+  test("a superseded OAuth flow cannot commit after its replacement owns the provider", async () => {
+    saveConfig(config());
+    const originalLogin = OAUTH_PROVIDERS.xai.login;
+    let loginCalls = 0;
+    OAUTH_PROVIDERS.xai.login = async (ctrl) => {
+      loginCalls += 1;
+      const call = loginCalls;
+      ctrl.onAuth({ url: `https://auth.example.test/${call}`, deviceCode: `flow-${call}` });
+      return {
+        access: `access-${call}`,
+        refresh: `refresh-${call}`,
+        accountId: `account-${call}`,
+        email: `account-${call}@example.test`,
+        expires: Date.now() + 60_000,
+      };
+    };
+
+    let releaseHead!: () => void;
+    let signalHeadStarted!: () => void;
+    const headStarted = new Promise<void>(resolve => { signalHeadStarted = resolve; });
+    const headGate = new Promise<void>(resolve => { releaseHead = resolve; });
+    const blockingMutation = oauthStore.mutateStore(async () => {
+      signalHeadStarted();
+      await headGate;
+    });
+
+    const waitForMutationCount = async (minimum: number): Promise<void> => {
+      for (let attempt = 0; attempt < 200; attempt += 1) {
+        if (oauthStore.oauthMutationTailSnapshot().active >= minimum) return;
+        await Bun.sleep(5);
+      }
+      throw new Error(`OAuth mutation queue did not reach ${minimum} active rows`);
+    };
+
+    try {
+      await headStarted;
+      await startLoginFlow("xai");
+      await waitForMutationCount(2);
+      expect(cancelLoginFlow("xai")).toBe(true);
+
+      await startLoginFlow("xai");
+      await waitForMutationCount(3);
+      releaseHead();
+      await blockingMutation;
+
+      const status = await waitForOAuthDone("xai");
+      expect(status).toMatchObject({ done: true, loggedIn: true });
+      expect(getCredential("xai")).toMatchObject({
+        access: "access-2",
+        accountId: "account-2",
+      });
+      expect(oauthStore.getAccountSet("xai")?.accounts.map(account => account.credential.accountId))
+        .toEqual(["account-2"]);
+    } finally {
+      releaseHead();
+      await blockingMutation.catch(() => {});
+      OAUTH_PROVIDERS.xai.login = originalLogin;
+      clearLoginState("xai");
+    }
+  });
+
+  test("Kiro does not start a replacement until the canceled external CLI flow settles", async () => {
+    saveConfig(config());
+    const originalLogin = OAUTH_PROVIDERS.kiro.login;
+    let loginCalls = 0;
+    OAUTH_PROVIDERS.kiro.login = async (ctrl) => {
+      loginCalls += 1;
+      const call = loginCalls;
+      ctrl.onAuth({ url: "", deviceCode: `kiro-flow-${call}` });
+      if (call === 1) {
+        await new Promise<never>((_, reject) => {
+          ctrl.signal.addEventListener("abort", () => reject(new Error("Kiro login cancelled")), { once: true });
+        });
+      }
+      return {
+        access: "kiro-replacement-access",
+        refresh: "kiro-replacement-refresh",
+        accountId: "kiro-replacement-account",
+        email: "kiro-replacement@example.test",
+        expires: Date.now() + 60_000,
+      };
+    };
+
+    try {
+      await startLoginFlow("kiro");
+      expect(cancelLoginFlow("kiro")).toBe(true);
+      await expect(startLoginFlow("kiro")).rejects.toThrow("A login for kiro is already in progress");
+
+      let replacement: Awaited<ReturnType<typeof startLoginFlow>> | undefined;
+      for (let attempt = 0; attempt < 200; attempt += 1) {
+        try {
+          replacement = await startLoginFlow("kiro");
+          break;
+        } catch (error) {
+          if (!(error instanceof Error) || !error.message.includes("already in progress")) throw error;
+          await Bun.sleep(5);
+        }
+      }
+      expect(replacement).toMatchObject({ deviceCode: "kiro-flow-2" });
+      expect(await waitForOAuthDone("kiro")).toMatchObject({ done: true, loggedIn: true });
+      expect(loginCalls).toBe(2);
+    } finally {
+      OAUTH_PROVIDERS.kiro.login = originalLogin;
+      clearLoginState("kiro");
+    }
+  });
+
   test("management OAuth safely reconciles live config after a late namespace claim", async () => {
     const liveConfig = config();
     liveConfig.hostname = "0.0.0.0";


### PR DESCRIPTION
## Summary

A cancelled login could still persist its credential after a newer flow had taken ownership of the provider, so the newer login's token was silently replaced by the one the user had already abandoned.

**Credit: @Ingwannu's #2053**, carried unchanged.

Ownership is checked at the **synchronous persist boundary** rather than before the work: `mutateStore` takes an `assertBeforePersist` hook that runs inside the file lock, after `fn(store)` and before `persist(store)`. An in-memory mutation from a superseded flow is discarded rather than written — the only placement that cannot lose the race, since the in-memory object is thrown away when persist is skipped.

Ownership is identity-checked against the flow's own `AbortController` (`loginAbort.get(provider) !== abort`), so a newer login *replacing the entry* is what invalidates the older one. Not a timestamp, not a flag either side could read stale.

Kiro replacements additionally wait for a cancelled CLI flow to finish rolling back before a new login may start.

## Verification

- **RED-first**: reverting `src/oauth/` fails 2 tests, including the ownership round-trip that queues a blocking `mutateStore`, starts flow 1, cancels it, starts flow 2, and proves only `access-2`/`account-2` is stored.
- `bun test --isolate tests` — 13,536 pass, 0 fail, 10 skip (855 files).
- `bun test --isolate tests/oauth-public-surface.test.ts tests/codex-auth-context.test.ts` — 61 pass, 0 fail.
- `bun run typecheck` — clean.
- `bun run privacy:scan` — passed.

## Two things a reviewer should check rather than take on faith

**The reauth path is wired but not covered.** #2053's description claims reauth coverage; the diff wires `saveAccountCredential(..., assertBeforePersist)` but adds no reauth-specific test. The wiring is correct as far as I can read it, and I did not add a test I could not make meaningfully fail — but it is untested, and I would rather say so than let the claim stand.

**`OAuthLoginSupersededError` is not in the public error allowlist**, so it projects to the generic auth-failure string. That is the safe direction (no internal detail leaks), but it means a user who hits this sees a generic message rather than "your earlier login was superseded".

**A never-finishing Kiro rollback blocks all replacements**, by design. That is a deliberate trade — better than racing — but it is a liveness property worth an explicit second opinion.

## Supersedes

Closes #2053 (@Ingwannu) once merged, with attribution.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No user-facing behavior beyond a cancelled login no longer overwriting a newer one.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. **This is a C4 credential-store change and MAINTAINERS.md mandates security review — please do not merge on my verification alone.** What I can attest: the assert runs inside the existing file lock so it cannot race, no credential value or account id is logged, the error projects through the existing public vocabulary, and the failure direction is refuse-to-persist rather than persist-and-hope. Privacy scan green.

Closes #2053


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented canceled or superseded OAuth login attempts from saving credentials.
  * Improved handling when replacing an active login flow, ensuring the latest attempt remains in control.
  * Added safeguards so Kiro login waits for a canceled external login process to finish before restarting.
* **Tests**
  * Added coverage for OAuth flow replacement, cancellation, and credential persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->