### PR TITLE
fix(openai-chat): tolerate non-string padding repeats on resolved stream tool calls

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -1628,20 +1628,9 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
               // name or arguments value fails closed through the #1325 channel here rather
               // than escaping later as a TypeError from string handling at flush time.
               const rawFunction = (rawToolCall as { function?: unknown }).function;
-              if (rawFunction !== undefined && rawFunction !== null) {
-                if (!isRecord(rawFunction)) {
-                  logInvalidToolCalls("stream", rawToolCalls);
-                  return yield* terminateWithError(invalidToolCallsEvent(rawToolCalls, "stream", pendingUsage));
-                }
-                const rawName = rawFunction.name;
-                const rawArguments = rawFunction.arguments;
-                // Some OpenAI-compatible streamers repeat already-sent fields as null on
-                // continuation deltas. Treat only null/undefined as absent; every other
-                // non-string value still fails closed before entering the accumulator.
-                if (isInvalidStreamStringField(rawName) || isInvalidStreamStringField(rawArguments)) {
-                  logInvalidToolCalls("stream", rawToolCalls);
-                  return yield* terminateWithError(invalidToolCallsEvent(rawToolCalls, "stream", pendingUsage));
-                }
+              if (rawFunction !== undefined && rawFunction !== null && !isRecord(rawFunction)) {
+                logInvalidToolCalls("stream", rawToolCalls);
+                return yield* terminateWithError(invalidToolCallsEvent(rawToolCalls, "stream", pendingUsage));
               }
               if (isInvalidStreamStringField(tc.id)) {
                 logInvalidToolCalls("stream", rawToolCalls);
@@ -1660,14 +1649,34 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
                 budget.openCall(call.key);
               }
               if (tc.id && !call.id) call.id = tc.id;
-              if (tc.function?.name && !call.name) call.name = tc.function.name;
-              if (tc.function?.arguments) {
+              // #1731 generalization: some gateways repeat the function envelope on
+              // continuation deltas with wrong JSON types (an object `name` observed from
+              // opencode.ai/zen) instead of null. Once the pending call carries its
+              // canonical name, a non-string repeat adds nothing — ignore it, and let only
+              // string fragments reach the accumulator. A non-string value while the call is
+              // still unnamed fails closed (#1531): it was the field's only chance to be
+              // established, and nothing else can name or parameterize the call.
+              const fnRecord = isRecord(rawFunction) ? rawFunction : undefined;
+              const hasCanonicalName = typeof call.name === "string" && call.name.trim().length > 0;
+              if (isInvalidStreamStringField(fnRecord?.name) && !hasCanonicalName) {
+                logInvalidToolCalls("stream", rawToolCalls);
+                return yield* terminateWithError(invalidToolCallsEvent(rawToolCalls, "stream", pendingUsage));
+              }
+              if (isInvalidStreamStringField(fnRecord?.arguments) && !hasCanonicalName) {
+                logInvalidToolCalls("stream", rawToolCalls);
+                return yield* terminateWithError(invalidToolCallsEvent(rawToolCalls, "stream", pendingUsage));
+              }
+              if (typeof tc.function?.name === "string" && !hasCanonicalName) call.name = tc.function.name;
+              // Only string fragments enter the accumulator: an accepted non-string repeat
+              // (padding, guarded above) must not concatenate "[object Object]" into args.
+              const argsDelta = typeof tc.function?.arguments === "string" ? tc.function.arguments : "";
+              if (argsDelta) {
                 const previousBytes = call.argsBytes;
-                const nextBytes = previousBytes + budgetEncoder.encode(tc.function.arguments).byteLength;
+                const nextBytes = previousBytes + budgetEncoder.encode(argsDelta).byteLength;
                 const scope = { kind: "tool_args" as const, callId: call.key };
                 const reservation = budget.reserveTransient(nextBytes, scope);
                 try {
-                  call.args += tc.function.arguments;
+                  call.args += argsDelta;
                   reservation.commitRetained();
                   budget.releaseRetained(previousBytes, scope);
                   call.argsBytes = nextBytes;

--- a/tests/openai-chat-hardening.test.ts
+++ b/tests/openai-chat-hardening.test.ts
@@ -476,6 +476,111 @@ describe("openai-chat stream response hardening", () => {
     expect(lines).toContain('"callIndex":1');
     expect(lines).not.toContain('"tool_call_function_name_invalid"');
   });
+
+  test("non-string repeated name/arguments on a resolved call are padding, not terminal", async () => {
+    // opencode.ai/zen continuation deltas: the first chunk carries id+name; later repeats
+    // can arrive with wrong JSON types (object name) instead of the null #1731 describes.
+    const adapter = createOpenAIChatAdapter(provider());
+    const response = new Response([
+      `data: ${JSON.stringify({ choices: [{ delta: { tool_calls: [{
+        index: 0,
+        id: "chatcmpl-tool-abc",
+        type: "function",
+        function: { name: "terminal", arguments: "" },
+      }] } }] })}\n\n`,
+      `data: ${JSON.stringify({ choices: [{ delta: { tool_calls: [{
+        index: 0,
+        id: null,
+        type: null,
+        function: { name: { unexpected: true }, arguments: { no: "string" } },
+      }] } }] })}\n\n`,
+      `data: ${JSON.stringify({ choices: [{ delta: { tool_calls: [{
+        index: 0,
+        id: null,
+        type: null,
+        function: { name: null, arguments: "{\"command\":\"ls\"}" },
+      }] } }] })}\n\n`,
+      `data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: "tool_calls" }], usage: { prompt_tokens: 7, completion_tokens: 3 } })}\n\n`,
+      "data: [DONE]\n\n",
+    ].join(""));
+
+    const events = await collect(adapter.parseStream(response));
+    expect(events).toEqual([
+      { type: "tool_call_start", id: "chatcmpl-tool-abc", name: "terminal" },
+      { type: "tool_call_delta", arguments: '{"command":"ls"}' },
+      { type: "tool_call_end" },
+      { type: "done", usage: { inputTokens: 7, outputTokens: 3 } },
+    ]);
+  });
+
+  test("non-string name on a call without its canonical value still fails closed", async () => {
+    const adapter = createOpenAIChatAdapter(provider());
+    const response = new Response([
+      `data: ${JSON.stringify({ choices: [{ delta: { tool_calls: [{
+        index: 0,
+        id: "chatcmpl-tool-abc",
+        type: "function",
+        function: { name: { unexpected: true }, arguments: "" },
+      }] } }] })}\n\n`,
+      "data: [DONE]\n\n",
+    ].join(""));
+
+    const events = await collect(adapter.parseStream(response));
+    expect(events).toEqual([{
+      type: "error",
+      status: 502,
+      errorType: "upstream_error",
+      message: "upstream response contained invalid tool calls (tool_call_function_name_invalid; callIndex=0; valueType=object)",
+    }]);
+  });
+
+  test("non-string arguments on a call that has accumulated nothing still fails closed", async () => {
+    const adapter = createOpenAIChatAdapter(provider());
+    const response = new Response([
+      `data: ${JSON.stringify({ choices: [{ delta: { tool_calls: [{
+        index: 0,
+        id: "chatcmpl-tool-abc",
+        type: "function",
+        function: { name: "terminal", arguments: { command: "ls" } },
+      }] } }] })}\n\n`,
+      "data: [DONE]\n\n",
+    ].join(""));
+
+    const events = await collect(adapter.parseStream(response));
+    expect(events).toEqual([{
+      type: "error",
+      status: 502,
+      errorType: "upstream_error",
+      message: "upstream response contained invalid tool calls (tool_call_function_arguments_invalid; callIndex=0; valueType=object)",
+    }]);
+  });
+
+  test("whitespace-only initial name followed by non-string delta fails closed", async () => {
+    const adapter = createOpenAIChatAdapter(provider());
+    const response = new Response([
+      `data: ${JSON.stringify({ choices: [{ delta: { tool_calls: [{
+        index: 0,
+        id: "chatcmpl-tool-abc",
+        type: "function",
+        function: { name: "   ", arguments: "" },
+      }] } }] })}\n\n`,
+      `data: ${JSON.stringify({ choices: [{ delta: { tool_calls: [{
+        index: 0,
+        id: null,
+        type: null,
+        function: { name: { unexpected: true }, arguments: { no: "string" } },
+      }] } }] })}\n\n`,
+      "data: [DONE]\n\n",
+    ].join(""));
+
+    const events = await collect(adapter.parseStream(response));
+    expect(events).toEqual([{
+      type: "error",
+      status: 502,
+      errorType: "upstream_error",
+      message: "upstream response contained invalid tool calls (tool_call_function_name_invalid; callIndex=0; valueType=object)",
+    }]);
+  });
 });
 
 describe("openai-chat credential hardening", () => {


### PR DESCRIPTION
### Problem
Some OpenAI-compatible providers/gateways (e.g. `opencode.ai/zen/go/v1` streaming `deepseek-v4-flash`) emit the function envelope on continuation deltas with non-string values (such as an empty/unexpected object in `delta.tool_calls[i].function.name` or `arguments`) rather than repeating `null` as handled in #1731.

Because `isInvalidStreamStringField` is checked unconditionally at the top of the loop, these malformed continuation repeats cause the entire stream to terminate immediately via `invalidToolCallsEvent` (HTTP 400 `upstream response contained invalid tool calls`), even when the tool call has already received its canonical name and arguments from earlier chunks.

### Solution
Generalize the padding tolerance logic established in #1731:
1. Validate `rawFunction` type defensively while retaining the fast-fail check for non-record structures.
2. Check `isInvalidStreamStringField` for `name` and `arguments` only when the accumulator does not yet hold the canonical value for that call:
   - If the call is already named, a non-string `name` repeat is safely ignored as stream padding.
   - If the call is still unnamed / unparameterized, non-string values continue to fail-closed immediately (#1531).
3. Ensure only genuine `string` deltas reach `call.args` accumulation so non-string repeats cannot pollute arguments.

### Verification
- Added 3 regression test cases in `tests/openai-chat-hardening.test.ts`:
  - `non-string repeated name/arguments on a resolved call are padding, not terminal` (passes)
  - `non-string name on a call without its canonical value still fails closed` (passes)
  - `non-string arguments on a call that has accumulated nothing still fails closed` (passes)
- `bun test tests/openai-chat-hardening.test.ts` passes (57/57).
- `bun test tests/openai-chat-stream.test.ts tests/openai-chat-parallel-stream.test.ts tests/openai-chat-eof.test.ts` passes (59/59).
- `bun run typecheck` (`tsc --noEmit`) passes cleanly.
- Verified against live failing deepseek-v4-flash stream trace (returns `200 OK` with complete tool call payload).

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streamed tool calls with malformed or repeated metadata.
  * Prevented invalid argument values from being incorrectly converted into text.
  * Ensured incomplete or invalid tool calls fail with clear upstream errors.

* **Tests**
  * Added coverage for malformed tool-call names, arguments, and continuation data.
  * Verified valid established calls can complete despite harmless padding data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->