### PR TITLE
fix(quota): identify OpenCode Go by where it routes, not what it is named

### DIFF
--- a/src/providers/quota.ts
+++ b/src/providers/quota.ts
@@ -13,7 +13,7 @@ import { getAccountCredential, getAccountSet, getCredential } from "../oauth/sto
 import { antigravityUserAgent } from "../adapters/client-fingerprint";
 import { apiKeyPoolEntryId } from "./api-keys";
 import { XAI_GROK_CLIENT_VERSION, XAI_GROK_COMPATIBILITY } from "./xai-transport";
-import { getProviderRegistryEntry, providerCodexAccountMode } from "./registry";
+import { getProviderRegistryEntry, providerCodexAccountMode, registryEntryForProviderDestination } from "./registry";
 import type { OcxConfig, OcxProviderConfig } from "../types";
 import { isCanonicalOpenAiForwardProvider, OPENAI_CODEX_PROVIDER_ID } from "./openai-tiers";
 import {
@@ -2084,7 +2084,14 @@ async function maybeFetchProviderQuota(
       && isCanonicalCommandCodeBaseUrl(provider.baseUrl)) {
       return fetchCommandCodeQuota(name, provider);
     }
-    if ((provider.authMode ?? "key") === "key" && name === "opencode-go") {
+    // Identify OpenCode Go by where it routes, not by what the row is called. Multi-account
+    // setups keep the same destination under names like `opencode-go-2` (#1924), and those rows
+    // silently had no quota panel and no `ocx provider quota --json` report while the literal
+    // name was the gate. `registryEntryForProviderDestination` is the existing predicate for
+    // exactly this question: normalized endpoint + adapter + key auth, so a canonical URL behind
+    // a different adapter is still not OpenCode Go. The defensive URL check inside
+    // `fetchOpenCodeGoQuota` stays — sending a key anywhere must not depend on this gate.
+    if ((provider.authMode ?? "key") === "key" && registryEntryForProviderDestination(provider)?.id === "opencode-go") {
       return fetchOpenCodeGoQuota(name, provider);
     }
     if ((provider.authMode ?? "key") === "key" && isCanonicalA6apiBaseUrl(provider.baseUrl)) {

--- a/tests/opencode-go-quota.test.ts
+++ b/tests/opencode-go-quota.test.ts
@@ -87,4 +87,61 @@ describe("OpenCode Go provider quota", () => {
     expect(fetchCalls).toBe(0);
     expect(result.reports).toEqual([]);
   });
+
+  // #1924: a multi-account setup points several rows at the same OpenCode Go endpoint under
+  // names the registry has never heard of. Gating dispatch on the literal name `opencode-go`
+  // meant those rows had no dashboard quota panel and no `ocx provider quota --json` report,
+  // even though each one holds a working key for the same upstream.
+  test("a canonical sibling row under any name is probed and reported", async () => {
+    const bearers: string[] = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string> | undefined;
+      if (headers?.Authorization) bearers.push(headers.Authorization);
+      return new Response(JSON.stringify({
+        usage: { rolling: { status: "ok", percent: 12, resetsAt: "2026-08-12T20:00:00.000Z" } },
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+
+    const config = openCodeGoConfig();
+    config.providers["opencode-go-2"] = {
+      adapter: "openai-chat",
+      authMode: "key",
+      baseUrl: "https://opencode.ai/zen/go/v1",
+      // Kept under the privacy scanner's bearer-token length floor: a longer fixture reads as
+      // a real credential to `privacy:scan` even inside a test.
+      apiKey: "sibling-secret",
+    };
+
+    const result = await fetchProviderQuotaReports(config, true);
+
+    expect(result.reports.map(report => report.provider).sort()).toEqual(["opencode-go", "opencode-go-2"]);
+    expect(bearers.sort()).toEqual(["Bearer opencode-go-secret", "Bearer sibling-secret"]);
+    expect(JSON.stringify(result)).not.toContain("sibling-secret");
+  });
+
+  // The distinction between "routes to the OpenCode Go endpoint" and "is the OpenCode Go
+  // provider": a bare URL match would probe this row, but a different adapter speaks a
+  // different protocol to that host and is not the provider whose quota shape we parse.
+  test("a canonical URL behind a different adapter is not OpenCode Go", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls += 1;
+      return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+
+    const result = await fetchProviderQuotaReports({
+      defaultProvider: "not-really-go",
+      providers: {
+        "not-really-go": {
+          adapter: "anthropic",
+          authMode: "key",
+          baseUrl: "https://opencode.ai/zen/go/v1",
+          apiKey: "unrelated-secret",
+        },
+      },
+    } as OcxConfig, true);
+
+    expect(fetchCalls).toBe(0);
+    expect(result.reports).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

Absorbs #2027 by @yzxcj797. Stack layer 4 — base is `codex/absorb-agentrouter-language-framing` (#2162), not `dev`.

**The defect (#1924).** A multi-account setup points several provider rows at the same OpenCode Go endpoint under names the registry has never heard of — `opencode-go-2` through `-5`. Quota dispatch gated on the literal name `"opencode-go"` (`src/providers/quota.ts`), so those rows had no dashboard quota panel and no report in `ocx provider quota --refresh --json`, even though each holds a working key for the same upstream.

Worth naming: identity was already answered *inconsistently* here. Dispatch asked "what is this row called"; the credential-safety check inside `fetchOpenCodeGoQuota` asked "where does it actually route". The second question is the right one.

**The correction on top of #2027.** The original swaps the name for a base-URL comparison. That fixes the reported symptom but does not check the adapter, so a row pointing at the canonical URL through a *different* adapter would be probed — a different protocol to that host, and not the provider whose quota shape we parse.

This uses `registryEntryForProviderDestination`, which this repository already uses for renamed fixed-key rows (`opencode-zen-rate-limit.ts`, `derive.ts`): normalized endpoint + adapter + key auth.

**Rejected alternative, recorded.** `providerMatchesRegistryTransport("opencode-go", provider)` would need `preserveCustomDestination: true` on the registry entry, which also changes *routing* for a same-named custom row. That may be worth doing on its own merits; it is not something a quota fix should do as a side effect.

The defensive canonical-URL check inside `fetchOpenCodeGoQuota` stays. Whether an API key may be sent to a host must not depend on the dispatch gate above it being correct.

No `package.json` change — the version bump in #2027 was inherited from its branch point and was the entire reason GitHub marked it `CONFLICTING`.

Closes #2027. Fixes #1924.

## Verification

- `bun run typecheck` — clean.
- `bun test --isolate tests/opencode-go-quota.test.ts` — 4 pass / 0 fail.
- **RED-first.** Reverting only `src/providers/quota.ts` fails exactly the sibling-row test (3 pass / 1 fail). The wrong-adapter test stays green on unpatched `dev` because `dev` probes nothing but the literal name — which is what makes it a guard against the URL-only predicate rather than a restatement of the fix.
- `bun run test` at the stack tip — **13562 pass / 10 skip / 0 fail** across 857 files.
- `bun run privacy:scan` — passed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

The test asserts the sibling's key never appears in the serialized report.

---

**Stack** (bottom to top): #2134 → #2160 → #2162 → **this** → openai-chat padding repeats
