### PR TITLE
fix(codex): stop the background main refresh from retracting a reauth quarantine (#327)

### DIFF
--- a/src/codex/auth-api.ts
+++ b/src/codex/auth-api.ts
@@ -644,12 +644,13 @@ async function retryMainAccountInfoIfIdentityChanged(
   requestAccountId: string | null,
   retriesRemaining: number,
   nativeMainLease: AdmissionLease,
+  explicitRefresh: boolean,
 ): Promise<MainAccountInfoFetchResult | null> {
   const currentAccountId = getMainChatgptAccountId();
   if (currentAccountId === null || currentAccountId === requestAccountId) return null;
   reconcileMainCodexAccountRuntimeState();
   return retriesRemaining > 0
-    ? fetchMainAccountInfoWhileOwned(true, retriesRemaining - 1, nativeMainLease)
+    ? fetchMainAccountInfoWhileOwned(true, retriesRemaining - 1, nativeMainLease, explicitRefresh)
     : { info: EMPTY_MAIN_ACCOUNT_INFO, credentialChecked: true, hasCredential: true };
 }
 
@@ -696,6 +697,13 @@ async function fetchMainAccountInfoWhileOwned(
   forceRefresh: boolean,
   retriesRemaining: number,
   nativeMainLease: AdmissionLease,
+  /**
+   * Whether the *caller* asked for this refresh. `forceRefresh` also means "bypass the
+   * cache", and `retryMainAccountInfoIfIdentityChanged` re-enters with it set purely to
+   * re-read after the identity changed. Keeping the two apart stops that retry from
+   * promoting a background poll into operator intent below.
+   */
+  explicitRefresh: boolean = forceRefresh,
 ): Promise<MainAccountInfoFetchResult> {
   const writerGeneration = captureConfigGeneration();
   reconcileMainCodexAccountRuntimeState();
@@ -724,7 +732,7 @@ async function fetchMainAccountInfoWhileOwned(
     });
     if (!resp.ok) {
       const terminalAuthFailure = await isTerminalMainAuthResponse(resp, isMainAccountTokenVerifiablyLive());
-      const retried = await retryMainAccountInfoIfIdentityChanged(requestAccountId, retriesRemaining, nativeMainLease);
+      const retried = await retryMainAccountInfoIfIdentityChanged(requestAccountId, retriesRemaining, nativeMainLease, explicitRefresh);
       if (retried) return retried;
       if (terminalAuthFailure) {
         clearMainAccountInfoCache();
@@ -733,7 +741,7 @@ async function fetchMainAccountInfoWhileOwned(
       return { info: EMPTY_MAIN_ACCOUNT_INFO, credentialChecked: true, hasCredential: true };
     }
     const data = (await resp.json()) as WhamUsageResponse;
-    const retried = await retryMainAccountInfoIfIdentityChanged(requestAccountId, retriesRemaining, nativeMainLease);
+    const retried = await retryMainAccountInfoIfIdentityChanged(requestAccountId, retriesRemaining, nativeMainLease, explicitRefresh);
     if (retried) return retried;
     const plan = nonEmptyPlan(data.plan_type) ?? nonEmptyPlan(cached?.plan) ?? nonEmptyPlan(getMainAccountPlan());
     const quota = parseUsageQuota({ ...data, ...(plan ? { plan_type: plan } : {}) });
@@ -754,7 +762,7 @@ async function fetchMainAccountInfoWhileOwned(
     // never settled and the dashboard kept showing nothing — the symptom #327 reported.
     // An explicit refresh is an operator asking to re-evaluate, normally right after
     // signing in again, so it stays authoritative.
-    if (forceRefresh) clearAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID);
+    if (explicitRefresh) clearAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID);
     // Mirror main quota + plan into the shared stores so the rotation engine can
     // score and auto-switch the main account exactly like a pool account (Option A).
     setMainAccountPlan(result.plan);
@@ -769,7 +777,7 @@ async function fetchMainAccountInfoWhileOwned(
       ...(freshResetCredits !== undefined ? { freshResetCredits } : {}),
     };
   } catch {
-    const retried = await retryMainAccountInfoIfIdentityChanged(requestAccountId, retriesRemaining, nativeMainLease);
+    const retried = await retryMainAccountInfoIfIdentityChanged(requestAccountId, retriesRemaining, nativeMainLease, explicitRefresh);
     return retried ?? { info: EMPTY_MAIN_ACCOUNT_INFO, credentialChecked: true, hasCredential: true };
   }
 }

--- a/src/codex/auth-api.ts
+++ b/src/codex/auth-api.ts
@@ -745,7 +745,16 @@ async function fetchMainAccountInfoWhileOwned(
       ts: Date.now(),
     };
     setMainAccountInfoCache(result);
-    clearAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID);
+    // Only an explicit refresh may retract a reauth quarantine. A 200 from
+    // /wham/usage proves the token authenticates to the usage endpoint; it does not
+    // prove the account can serve Responses traffic, which is a different backend path
+    // and still answers 403 for a workspace the token may no longer select (#327).
+    // Letting the background poll clear the flag put such an account straight back into
+    // rotation: the next request failed the same way and re-marked it, so needsReauth
+    // never settled and the dashboard kept showing nothing — the symptom #327 reported.
+    // An explicit refresh is an operator asking to re-evaluate, normally right after
+    // signing in again, so it stays authoritative.
+    if (forceRefresh) clearAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID);
     // Mirror main quota + plan into the shared stores so the rotation engine can
     // score and auto-switch the main account exactly like a pool account (Option A).
     setMainAccountPlan(result.plan);

--- a/tests/codex-auth-api.test.ts
+++ b/tests/codex-auth-api.test.ts
@@ -13,7 +13,7 @@ import {
   handleCodexAuthAPI, updateAccountQuota, getAccountQuota,
   checkAccountIdCollision, getMainChatgptAccountId,
   markAccountNeedsReauth, isAccountNeedsReauth, clearAccountNeedsReauth, clearAccountQuota,
-  clearMainAccountInfoCache, maskEmail,
+  clearMainAccountInfoCache, maskEmail, fetchMainAccountInfo,
   clearCodexQuotaPrimeState, primeCodexPoolQuotas, seedCodexAuthAdmissionForTests,
   type CodexAuthAccountDto,
   listCodexAuthAccounts,
@@ -855,6 +855,40 @@ describe("codex-auth API", () => {
     const data = await resp!.json() as { accounts: Array<{ id: string; needsReauth?: boolean }> };
 
     expect(data.accounts.find(account => account.id === MAIN_CODEX_ACCOUNT_ID)?.needsReauth).toBe(false);
+    expect(isAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID)).toBe(false);
+  });
+
+  test("a background main account refresh does not retract a reauth quarantine (#327)", async () => {
+    // #327's own repro: the token is valid, but its workspace can no longer be
+    // selected, so Responses traffic answers 403 and quarantines the account.
+    // /wham/usage is a different backend path and keeps answering 200 for that same
+    // token, so the periodic refresh must not read its own 200 as proof the account
+    // can serve traffic again — doing so returned the account to rotation, the next
+    // request failed identically and re-marked it, and needsReauth never settled.
+    writeFileSync(join(TEST_CODEX_HOME, "auth.json"), JSON.stringify({
+      tokens: { access_token: "live-main", account_id: "acct-main" },
+    }));
+    markAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID);
+    clearMainAccountInfoCache();
+    let usageCalls = 0;
+    globalThis.fetch = (async () => {
+      usageCalls += 1;
+      return Response.json({
+        email: "main@example.test",
+        plan_type: "pro",
+        rate_limit: { primary_window: { used_percent: 10, reset_at: 1783000000 } },
+      });
+    }) as typeof fetch;
+
+    expect((await fetchMainAccountInfo(false)).email).toBe("main@example.test");
+    // The probe really ran and really succeeded — the quarantine survives it anyway.
+    expect(usageCalls).toBe(1);
+    expect(isAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID)).toBe(true);
+
+    // An explicit refresh is an operator asking to re-evaluate, so it stays
+    // authoritative and still clears the flag (the test above pins that direction).
+    clearMainAccountInfoCache();
+    expect((await fetchMainAccountInfo(true)).email).toBe("main@example.test");
     expect(isAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID)).toBe(false);
   });
 

--- a/tests/codex-auth-api.test.ts
+++ b/tests/codex-auth-api.test.ts
@@ -892,6 +892,43 @@ describe("codex-auth API", () => {
     expect(isAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID)).toBe(false);
   });
 
+  test("an identity-change retry does not upgrade a background refresh into an explicit one (#327)", async () => {
+    // `retryMainAccountInfoIfIdentityChanged` re-enters with forceRefresh=true so it can
+    // re-read past a now-stale cache. That argument must not double as operator intent:
+    // a background poll that crosses an identity change would otherwise come back with
+    // the authority to retract a quarantine it was never allowed to touch.
+    writeFileSync(join(TEST_CODEX_HOME, "auth.json"), JSON.stringify({
+      tokens: { access_token: "live-main", account_id: "acct-before" },
+    }));
+    clearMainAccountInfoCache();
+    let usageCalls = 0;
+    globalThis.fetch = (async () => {
+      usageCalls += 1;
+      if (usageCalls === 1) {
+        // Identity changes on disk mid-probe. The retry's purge legitimately drops the
+        // *previous* identity's runtime state — that is not what this test is about.
+        writeFileSync(join(TEST_CODEX_HOME, "auth.json"), JSON.stringify({
+          tokens: { access_token: "live-main", account_id: "acct-after" },
+        }));
+      } else {
+        // Real traffic quarantines the *new* identity while the retry probe is in
+        // flight, exactly as recordCodexUpstreamOutcome does on a 401/403.
+        markAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID);
+      }
+      return Response.json({
+        email: "main@example.test",
+        plan_type: "pro",
+        rate_limit: { primary_window: { used_percent: 10, reset_at: 1783000000 } },
+      });
+    }) as typeof fetch;
+
+    await fetchMainAccountInfo(false);
+
+    // The retry really fired — otherwise this proves nothing about the retry path.
+    expect(usageCalls).toBeGreaterThan(1);
+    expect(isAccountNeedsReauth(MAIN_CODEX_ACCOUNT_ID)).toBe(true);
+  });
+
   test("BUG-R327: main account exposes and updates needsReauth from WHAM auth responses", async () => {
     writeFileSync(join(TEST_CODEX_HOME, "auth.json"), JSON.stringify({
       tokens: {


### PR DESCRIPTION
## Problem

`tests/server-auth.test.ts > OpenAI option auth matrix keeps direct, pool, and API credentials independent` fails **reproducibly** on a clean `dev` tree — 78 pass / 1 fail, on win32, on every run. It is not load-dependent.

Narrowing it to the `reauth` iteration of the `["expired", "reauth", "cooldown"]` loop:

```
[state, status]
-   "reauth", 401
+   "reauth", 200
```

The account is marked `needsReauth`, and the request that must be refused with 401 is served instead.

## Root cause

Instrumenting the flag store shows the mark landing and then being erased milliseconds later:

```
[PROBE] mark id=__main__ writerGen=18 lastRecon=18 live=__main__ dropped=false
[PROBE] CLEAR __main__
    at clearAccountNeedsReauth (src/codex/account-runtime-state.ts:37)
    at fetchMainAccountInfoWhileOwned (src/codex/auth-api.ts:748)
    at async withNativeMainSharedClaim (src/codex/native-main-claim.ts:143)
```

`fetchMainAccountInfoWhileOwned` cleared `needsReauth` for `__main__` on **every** successful `/wham/usage` response, background refreshes included.

That is a stronger conclusion than the test alone. A 200 from `/wham/usage` proves the token authenticates to the *usage* endpoint. It does not prove the account can serve Responses traffic — a different backend path, which still answers **403 when the token's workspace can no longer be selected**. That is precisely the condition #327 was filed about:

> `~/.codex/auth.json`을 무효한 ChatGPT 토큰으로 만듭니다. (재현에 사용한 상태: 토큰에 박힌 workspace가 더 이상 선택 불가여서 upstream …)

So in production, with `codexAccountMode: pool` where `__main__` joins rotation:

1. Responses traffic 403s → `recordCodexUpstreamOutcome` takes the `outcomeClass === "credential"` branch and quarantines the account (`routing.ts`, *"401/403 quarantines the account for reauth"*).
2. The next background `/wham/usage` refresh returns 200 and silently retracts that quarantine.
3. `__main__` is a rotation candidate again, the next request fails identically, re-marks it — and step 2 wipes it again.

`needsReauth` therefore never settles, so the dashboard keeps showing nothing wrong. **That is the exact symptom #327 reported**, re-introduced through its own recovery path.

## Fix

One line: gate the clear on `forceRefresh`.

An explicit refresh (`?refresh=1` from the dashboard, `fetchMainAccountInfo(true)`) is an operator asking to re-evaluate, normally right after signing in again, so it stays authoritative — #327's recovery is unchanged, and its test still passes untouched. A background poll no longer counts as authentication evidence. Sign-in and account-add continue to clear unconditionally through `account-lifecycle`.

I deliberately did **not** simply delete the clear (which also turns `server-auth` green): that would regress #327's recovery. Two other designs were tried and measured first — a generation guard, and tagging marks with their origin — and both were discarded, the generation guard because the race happens inside a single generation (`writerGen=18`, `lastRecon=18`), the origin tagging because it broke `"successful main account refresh clears a prior needsReauth mark (#327)"`. `forceRefresh` is the axis that separates the two existing contracts cleanly.

## Verification — win32, on this exact rebased head

```
bun run typecheck                        exit 0
bun test tests/server-auth.test.ts        79 pass / 0 fail   (was 78 / 1)
bun test tests/codex-auth-api.test.ts    191 pass / 0 fail
```

10 adjacent auth / routing / oauth suites — `codex-routing`, `codex-auth-context`, `codex-main-rotation`, `oauth-health`, `oauth-reauth-bind`, `codex-account-delete-atomicity`, `cli-status-oauth-health`, `doctor-oauth`, `issue-452-empty-503`, `management-provider-validation` — **325 pass / 0 fail**.

**Mutation-checked.** Restoring the unconditional clear:

| suite | result |
|---|---|
| `codex-auth-api` | 1 fail — the new regression test |
| `server-auth` | 1 fail — OpenAI option auth matrix |

The new test asserts the probe genuinely ran (`usageCalls === 1`) and genuinely succeeded before checking the quarantine survived, so it cannot pass by accident of the probe being skipped.

## Note on scope

This is the only reproducible failure on clean `dev` on my machine. The other reddening I have seen in full-suite runs is load-dependent and reddens a different subset each run; none of it is touched here.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Background account refreshes no longer incorrectly clear a required reauthentication status.
  * Explicit refreshes continue to clear the reauthentication status after a successful account check.
  * Account identity changes now preserve the correct reauthentication state during automatic retries and account checks.

* **Tests**
  * Added coverage for background and explicit account refresh behavior, including identity-change retry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

