### PR TITLE
fix(logs): record the configured shadow prefix, not the caller's model string

### DIFF
--- a/src/lib/shadow-call.ts
+++ b/src/lib/shadow-call.ts
@@ -30,6 +30,21 @@ export function isShadowSourceModel(modelId: string, configured?: unknown): bool
 }
 
 /**
+ * The configured source prefix this model matched, or undefined.
+ *
+ * Callers that RECORD the intercepted model must record this rather than the caller's raw
+ * `modelId`. Matching is by prefix, so `gpt-5.6-luna` plus arbitrary trailing text still
+ * intercepts — and the raw string is caller-controlled, reaches `usage.jsonl` and `/api/logs`,
+ * and only passes a pattern-based redactor on the way. A credential family that redactor does
+ * not recognize survives verbatim. Returning the operator-configured prefix keeps the log
+ * field inside a set the operator chose, so no caller string is ever persisted.
+ */
+export function shadowSourceModelPrefix(modelId: string, configured?: unknown): string | undefined {
+  if (modelId.includes("/")) return undefined;
+  return shadowSourceModels(configured).find(prefix => modelId.startsWith(prefix));
+}
+
+/**
  * Decide whether a matching source model should use the opt-in intercept.
  *
  * Before Codex 0.147.0 this checked x-codex-turn-metadata and exempted

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -315,7 +315,7 @@ export function sidecarOutcomeRecorder(
 
 
 
-import { isShadowSourceModel, shouldInterceptShadowCall } from "../../lib/shadow-call";
+import { isShadowSourceModel, shadowSourceModelPrefix, shouldInterceptShadowCall } from "../../lib/shadow-call";
 
 export { DEFAULT_SHADOW_SOURCE_MODELS, isShadowSourceModel, shadowSourceModels } from "../../lib/shadow-call";
 
@@ -1921,7 +1921,14 @@ async function handleResponsesInner(
     if (parsed._rawBody && typeof parsed._rawBody === "object") {
       (parsed._rawBody as Record<string, unknown>).reasoning = { effort: "low" };
     }
-    logCtx.shadowCallRewrittenFrom = sanitizeLogMetadataString(_sciOriginal);
+    // Record the operator-configured prefix that matched, NOT the caller's raw model string.
+    // Matching is by prefix, so a caller can append arbitrary text and still intercept; that
+    // raw value would then land in usage.jsonl and /api/logs behind a pattern-based redactor
+    // that does not recognize every credential family. The prefix is a value the operator
+    // configured, so no caller-controlled string is persisted.
+    logCtx.shadowCallRewrittenFrom = sanitizeLogMetadataString(
+      shadowSourceModelPrefix(_sciOriginal, _sci.sourceModels),
+    );
     // Helpers must not resume/append into the parent thread's Cursor conversation.
     parsed._cursorIsolateConversation = true;
   }

--- a/tests/responses-shadow-intercept.test.ts
+++ b/tests/responses-shadow-intercept.test.ts
@@ -152,6 +152,41 @@ describe("shadow call intercept request path (issue #311)", () => {
     expect(logCtx.shadowCallRewrittenFrom).toBe("gpt-5.6-luna");
   });
 
+  // The intercept matches by PREFIX, so a caller can append anything and still be intercepted.
+  // The recorded marker is persisted to usage.jsonl and served from /api/logs, and the runtime
+  // redactor is pattern-based: a credential family it does not recognize would survive verbatim.
+  // Recording the operator-configured prefix instead of the caller's raw string removes the
+  // class, rather than adding one more pattern to a deny-list.
+  test("the recorded marker is the configured prefix, never the caller's raw model string", async () => {
+    const logCtx: RequestLogContext = { model: "", provider: "" };
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      choices: [{ message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    }), { status: 200, headers: { "content-type": "application/json" } })) as typeof fetch;
+
+    // A Google-shaped key: the runtime redactor has no rule for this family, and the newline
+    // is stripped before redaction runs, so the old code persisted this string intact.
+    const smuggled = "gpt-5.6-luna\nAIzaSyA1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6";
+    await post(interceptConfig(), smuggled, "turn", logCtx);
+
+    expect(logCtx.shadowCallRewrittenFrom).toBe("gpt-5.6-luna");
+    expect(logCtx.shadowCallRewrittenFrom ?? "").not.toContain("AIza");
+  });
+
+  test("a configured non-default prefix is recorded as itself", async () => {
+    const logCtx: RequestLogContext = { model: "", provider: "" };
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      choices: [{ message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    }), { status: 200, headers: { "content-type": "application/json" } })) as typeof fetch;
+
+    const config = interceptConfig();
+    config.shadowCallIntercept = { enabled: true, model: "grok-4.5", sourceModels: ["gpt-5.4-mini"] };
+    await post(config, "gpt-5.4-mini-2024-07-18", "turn", logCtx);
+
+    expect(logCtx.shadowCallRewrittenFrom).toBe("gpt-5.4-mini");
+  });
+
   test("leaves gpt-5.6-terra requests unrewritten", async () => {
     let sawFetch = false;
     globalThis.fetch = (async () => {


### PR DESCRIPTION
## Summary

Release audit of `origin/main..origin/dev` found a credential-leak path in the shadow-call logging that landed in this range. This is the fix.

**The defect.** The shadow-call intercept matches by *prefix*, so a caller can send `gpt-5.6-luna` followed by arbitrary text and still be intercepted. The whole raw string was then recorded as `shadowCallRewrittenFrom`, which is persisted to `usage.jsonl` and served from `/api/logs`.

The sanitizer on that path is not sufficient protection, for two independent reasons — both verified against the shipped code:

```
"gpt-5.6-luna\nBearer sk-abc123def456ghi789jkl"  ->  "gpt-5.6-lunaBearer [REDACTED]"
"gpt-5.6-luna\nAIzaSyA1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6"  ->  unchanged, key intact
```

1. Control characters are stripped *before* redaction runs, so the newline that separated the marker from the credential is gone by the time the `Bearer` rule looks for a word boundary.
2. The runtime redactor is a deny-list. An `AIza`-shaped Google key has no rule at all and survives verbatim into the log file.

**The fix.** Record the operator-configured prefix that matched, not the caller's string. `shadowSourceModelPrefix()` returns the entry from `sourceModels` that produced the match, so the field can only ever hold a value the operator configured. That removes the class rather than adding one more pattern to a deny-list — which is the right shape here, because the next unrecognized credential family would reopen it.

## Verification

- **RED-first.** Reverting only `src/lib/shadow-call.ts` and `src/server/responses/core.ts` fails exactly the two new tests (15 pass / 2 fail). The first pins the `AIza` smuggling case; the second pins that a non-default configured prefix is recorded as itself, so the fix cannot degrade into a hardcoded string.
- `bun x tsc --noEmit` — exit 0 (on `ssh lidge`).
- `bun test --isolate tests/responses-shadow-intercept.test.ts` — 17 pass / 0 fail.
- `bun run test` on `ssh lidge` — **13713 pass / 15 skip / 0 fail** across 866 files.
- `bun run privacy:scan` — passed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

This *is* the security-sensitive change: it narrows what can reach a persisted log field. No credential is logged by the new code, and the field's value set is now bounded by operator configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security & Privacy**
  - Shadow-call logs now record only the configured source-model prefix instead of the full caller-provided model identifier.
  - Prevents credential-like or otherwise sensitive content appended to model IDs from being persisted.

- **Bug Fixes**
  - Improved handling of custom source-model prefixes and routed model identifiers.

- **Tests**
  - Added regression coverage for sanitized logging and custom prefix configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->