### PR TITLE
fix(guards): close the core/Lab directory bypass and the release dry-run dead end

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -380,15 +380,36 @@ console.log("→ privacy scan");
 await runLoud(["bun", "run", "privacy:scan"]);
 
 // 2. Bump package.json only; the workflow creates the version tag after npm publish.
-console.log(`→ bump package.json → ${version}`);
-await runLoud(["npm", "version", version, "--no-git-tag-version"]);
+//
+// A dry run bumps and pushes exactly like a real one, because the point of the dry run is to
+// exercise the workflow against the REAL release commit. That makes the second invocation
+// re-enter with package.json already at `version`, where `npm version <same>` exits
+// "Version not changed" — so the documented "re-run with --publish" path could never
+// complete. Treat an already-correct version as satisfied rather than as an error: the
+// bump is a desired end state, not an action that must happen every time.
+const currentVersion = JSON.parse(await Bun.file("package.json").text()).version as string;
+if (currentVersion === version) {
+  console.log(`→ package.json already at ${version}; leaving it alone`);
+} else {
+  console.log(`→ bump package.json → ${version}`);
+  await runLoud(["npm", "version", version, "--no-git-tag-version"]);
+}
 
-// 3. Commit + push the version bump.
-await runLoud(["git", "add", "package.json"]);
-await runLoud(["git", "commit", "-m", `release: v${version}`]);
+// 3. Commit + push the version bump — only if it is not already committed and pushed. On the
+// --publish re-run of a dry run there is nothing to commit, and `git commit` with an empty
+// index fails, which would strand the release just as surely as the bump did.
+const pendingBump = (await capture(["git", "status", "--porcelain", "package.json"])).trim() !== "";
+if (pendingBump) {
+  await runLoud(["git", "add", "package.json"]);
+  await runLoud(["git", "commit", "-m", `release: v${version}`]);
+}
 const releaseSha = await capture(["git", "rev-parse", "HEAD"]);
-console.log(`→ push origin ${branch}`);
-await runLoud(["git", "push", "origin", branch]);
+if (pendingBump) {
+  console.log(`→ push origin ${branch}`);
+  await runLoud(["git", "push", "origin", branch]);
+} else {
+  console.log(`→ release commit ${releaseSha.slice(0, 9)} already pushed; reusing it`);
+}
 
 // 4. Wait for the pushed release commit to pass CI, then dispatch the Release workflow.
 console.log(`→ wait for Cross-platform CI (${releaseSha})`);

--- a/tests/core-lab-boundary.test.ts
+++ b/tests/core-lab-boundary.test.ts
@@ -100,16 +100,29 @@ function firstLabPath(entry: string): string[] | null {
   return null;
 }
 
+/**
+ * Guard 1's predicate, defined ONCE so the test that claims to protect it actually calls it.
+ *
+ * It previously lived inline in the assertion while the self-test below re-declared its own
+ * copy of the regex — so the self-test proved a local literal behaved, not that the guard did.
+ * A copy cannot fail when the original drifts, which is the specific way a guard rots.
+ *
+ * The trailing-slash forms are not sufficient either: `src/lab/index.ts` exists, so
+ * `import("../lab")` resolves to the Lab entrypoint while matching none of them. The
+ * directory specifier is matched explicitly.
+ */
+export function namesLabDirectly(source: string): boolean {
+  return /^\s*(?:import|export)\s+(?!type\b)[^;]*?["'][^"']*\/lab(?:\/|["'])/m.test(source)
+    || /^\s*import\s+["'][^"']*\/lab(?:\/|["'])/m.test(source)
+    // A protected file may lazily reach Lab through a handler it imports, but must not
+    // name Lab itself -- not even dynamically, and not as a bare directory.
+    || /\bimport\s*\(\s*["'][^"']*\/lab(?:\/|["'])/.test(source);
+}
+
 describe("core / Compatibility Lab boundary", () => {
   // Guard 1: the obvious case, a direct import.
   test.each(PROTECTED)("%s has no direct src/lab import", file => {
-    const source = readFileSync(resolve(repoRoot, file), "utf8");
-    const direct = /^\s*(?:import|export)\s+(?!type\b)[^;]*?["'][^"']*\/lab\//m.test(source)
-      || /^\s*import\s+["'][^"']*\/lab\//m.test(source)
-      // A protected file may lazily reach Lab through a handler it imports, but must not
-      // name Lab itself -- not even dynamically.
-      || /\bimport\s*\(\s*["'][^"']*\/lab\//.test(source);
-    expect(direct).toBe(false);
+    expect(namesLabDirectly(readFileSync(resolve(repoRoot, file), "utf8"))).toBe(false);
   });
 
   // Guard 2: the case that actually caused this work. The original defect reached Lab
@@ -156,11 +169,18 @@ describe("boundary guard cannot be defeated", () => {
   // -- lazy loading is the remedy, not the defect. Guard 1 is what stops a protected file
   // from naming Lab dynamically, so the coverage moves there rather than disappearing.
   test("guard 1 forbids a direct dynamic Lab import in a protected file", () => {
-    const direct = (source: string) => /\bimport\s*\(\s*["'][^"']*\/lab\//.test(source);
-    expect(direct('void import("../lab/paths");')).toBe(true);
-    expect(direct('const m = await import("./management/lab-routes");')).toBe(false);
+    // Calls the SAME predicate the guard uses, so a drift in one cannot pass in the other.
+    expect(namesLabDirectly('void import("../lab/paths");')).toBe(true);
+    // A bare directory specifier resolves to src/lab/index.ts and must be caught too --
+    // matching only `/lab/` left this shape as a silent way through.
+    expect(namesLabDirectly('void import("../lab");')).toBe(true);
+    expect(namesLabDirectly('import "../lab";')).toBe(true);
+    expect(namesLabDirectly('import { x } from "../lab";')).toBe(true);
+    // A module whose NAME merely contains "lab" is not Lab.
+    expect(namesLabDirectly('const m = await import("./management/lab-routes");')).toBe(false);
+    expect(namesLabDirectly('import { x } from "./collaboration";')).toBe(false);
     for (const file of PROTECTED) {
-      expect(direct(readFileSync(resolve(repoRoot, file), "utf8"))).toBe(false);
+      expect(namesLabDirectly(readFileSync(resolve(repoRoot, file), "utf8"))).toBe(false);
     }
   });
 


### PR DESCRIPTION
## Summary

Two false-confidence defects found while auditing `main..dev` for release safety. Neither originated in that range — both are mechanisms the range is currently relying on to be safe.

**The core/Lab guard had a directory bypass.** It matched only specifiers containing `/lab/`. Since `src/lab/index.ts` exists, `import("../lab")` resolves to the Lab entrypoint while matching none of its three patterns:

```
source          : void import("../lab");
Guard 1 detects : false
```

Worse, the self-test that claims to protect the guard re-declared its own copy of the regex, so it proved a local literal behaved rather than that the guard did. A copy cannot fail when the original drifts — which is the specific way a guard rots while looking green. The predicate is now one shared function that both the guard and its self-test call, and it matches the bare directory specifier.

The current graph was and is clean: an independent walk from all three protected roots (192, 101, and 344 modules) found no Lab path, following dynamic edges too. This closes the hole before something uses it.

**The release helper's documented path could never complete.** A dry run bumps, commits, and pushes the version deliberately — the point is to exercise the workflow against the real release commit. So the `--publish` re-run it tells you to do hits `npm version <same-version>` and exits `Version not changed` before dispatching anything:

```
npm error Version not changed
exit 1
```

The bump and the push are now a desired end state rather than actions that must happen every time, so the second run reuses the release commit the first one made.

## Verification

- `bun run typecheck` — clean.
- `bun test --isolate tests/core-lab-boundary.test.ts` — 13 pass / 0 fail.
- **RED-first.** The old predicate returns `false` for `import("../lab")`; the new one returns `true`. The self-test now exercises the shared function, so reverting the guard fails the test that guards it — which was the whole problem.
- The negative cases are pinned too: `./management/lab-routes` and `./collaboration` must stay unmatched, so this does not become a substring trap.

`scripts/release.ts` is release automation, which `MAINTAINERS.md` reserves for explicit review. The change removes no check: preflight, branch restriction, tag/version validation, and the full local gate all run exactly as before.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing so dry runs and subsequent publish runs complete successfully without duplicate version bumps or commits.
  * Release commits and pushes now occur only when package changes are pending.

* **Tests**
  * Strengthened checks preventing unintended direct imports of Compatibility Lab functionality.
  * Added coverage for additional import styles, including bare-directory and dynamic imports, while preserving valid-module exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->