### PR TITLE
fix(responses): give tool_search_call and custom_tool_call their own id prefixes

### DIFF
--- a/src/server/responses/responses-field-backfill.ts
+++ b/src/server/responses/responses-field-backfill.ts
@@ -34,6 +34,14 @@ const ITEM_ID_PREFIXES: Readonly<Record<string, string>> = {
   message: "msg_",
   reasoning: "rs_",
   function_call: "fc_",
+  custom_tool_call: "ctc_",
+  // A routed tool_search lowering is restored to `tool_search_call` without an id, so this
+  // backfill is what names it. The generic `item_` fallback is not merely cosmetic here:
+  // `stripInvalidItemIds` in the Responses adapter deletes any id whose prefix does not match
+  // the type, so an `item_`-named tool_search_call silently loses its id on the NEXT turn and
+  // the client sees an item it cannot correlate. The prefixes here must stay a superset of the
+  // ones that serializer enforces.
+  tool_search_call: "tsc_",
   web_search_call: "ws_",
   file_search_call: "fs_",
   code_interpreter_call: "ci_",

--- a/tests/responses-field-backfill.test.ts
+++ b/tests/responses-field-backfill.test.ts
@@ -365,6 +365,36 @@ describe("responses-field-backfill", () => {
     expect(result.output[0]!.id).toBe("ig_ocx_0");
   });
 
+  // A routed tool_search lowering is restored as `tool_search_call` with no id, so this
+  // backfill names it. The generic `item_` fallback was not cosmetic: `stripInvalidItemIds`
+  // in the Responses adapter deletes an id whose prefix does not match its type, so the item
+  // silently lost its id on the NEXT turn and the client could no longer correlate it.
+  test("tool_search_call gets the prefix the request serializer accepts", () => {
+    const response = {
+      id: "resp_1",
+      object: "response",
+      status: "completed",
+      output: [{ type: "tool_search_call", call_id: "call_x", execution: "client" }],
+    };
+    const result = JSON.parse(backfillResponsesFieldsJson(JSON.stringify(response))) as {
+      output: { id: string }[];
+    };
+    expect(result.output[0]!.id).toBe("tsc_ocx_0");
+  });
+
+  test("custom_tool_call gets its own prefix too", () => {
+    const response = {
+      id: "resp_1",
+      object: "response",
+      status: "completed",
+      output: [{ type: "custom_tool_call", call_id: "call_y" }],
+    };
+    const result = JSON.parse(backfillResponsesFieldsJson(JSON.stringify(response))) as {
+      output: { id: string }[];
+    };
+    expect(result.output[0]!.id).toBe("ctc_ocx_0");
+  });
+
   // A malformed `output_index` falls back to a counter. While that counter lived in the same
   // numeric namespace as real indexes, a response whose real index reached the counter's base
   // produced the SAME id as a fallback — a duplicate, which is the one thing this backfill


### PR DESCRIPTION
## Summary

Release audit of `origin/main..origin/dev` found this by composing two changes that are each correct alone — the shape the audit was specifically looking for.

**The defect.** A routed `tool_search` lowering is restored as a `tool_search_call` with no id (#2145), and the universal output-item id backfill then names it (#2142). The backfill's prefix table had no entry for the type, so it fell through to the generic `item_`:

```
{"type":"tool_search_call","call_id":"call_x",...}  ->  id: "item_ocx_0"
{"type":"function_call","name":"x",...}             ->  id: "fc_ocx_0"
```

That is not cosmetic. `stripInvalidItemIds` in the Responses adapter deletes any id whose prefix does not match its type, and it lists `tsc_` as the only valid prefix for `tool_search_call`. So the synthesized id survived the turn that created it and was **silently dropped on the next one**, leaving the client an item it could not correlate.

Neither PR's focused suite caught it, because neither composes missing-id restoration with the backfill. That is exactly why this needed a cross-PR pass rather than per-PR CI.

`custom_tool_call` had the identical gap and is fixed alongside it: the serializer enforces `ctc_`, the backfill did not know the type.

The two tables are now a stated invariant — the backfill's prefixes must remain a superset of the ones the serializer enforces — recorded in a comment at the table so the next type added does not reopen it.

## Verification

- **RED-first.** Reverting only `src/server/responses/responses-field-backfill.ts` fails exactly the two new tests (20 pass / 2 fail).
- `bun x tsc --noEmit` — exit 0.
- `bun test --isolate tests/responses-field-backfill.test.ts` — 22 pass / 0 fail.
- `bun run test` on `ssh lidge` — **13717 pass / 15 skip / 0 fail** across 866 files.
- `bun run privacy:scan` — passed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

No credential or auth surface is touched; this only changes a synthesized id prefix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected backfilled tool-search and custom tool-call IDs to use the appropriate serializer-compatible prefixes.
  * Improved consistency and compatibility of generated response item identifiers.

* **Tests**
  * Added regression coverage for tool-search and custom tool-call ID generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->