### PR TITLE
fix(devlog): unbreak privacy:scan on dev

### DIFF
--- a/devlog/_plan/260820_bug_pr_backlog_consolidation/100_release_safety_audit.md
+++ b/devlog/_plan/260820_bug_pr_backlog_consolidation/100_release_safety_audit.md
@@ -27,7 +27,7 @@ and the adapter forwarded our own proxy secret. Reproduced through the real adap
 
 ```
 URL:  https://chatgpt.com/backend-api/codex/responses
-AUTH: Bearer ocx_data_this_is_our_proxy_key
+AUTH: Bearer <the proxy's own admission secret, verbatim>
 LEAKED: true
 ```
 
@@ -120,4 +120,3 @@ Version line on `dev` is `2.27.0`, equal to the published `latest` and the `v2.2
 pre-release state, not a half-finished bump.
 
 This remains a readiness record. No release was executed.
-


### PR DESCRIPTION
## Summary

`dev`'s own release gate is currently failing, and has been since `0637a3548`. This unbreaks it.

That commit's audit record pasted a reproduction transcript containing a literal `Bearer <value>` line. `scripts/privacy-scan.ts` matches that shape regardless of whether the value is a real credential:

```
devlog/_plan/.../100_release_safety_audit.md:30 bearer-token: Bearer ocx_data_...
error: script "privacy:scan" exited with code 1
```

The blast radius is wider than the one file: `privacy:scan` runs in the `gates` job, so **every PR branched from `dev` inherits the failure**. That is how this was found — an unrelated PR's `gates` job went red.

The value was a placeholder from a local reproduction, not a real secret. But the scanner cannot know that, and it should not have to: a documented transcript that looks exactly like a leaked credential is indistinguishable from one. Describing the header instead of pasting it keeps the finding legible and the gate green.

## Verification

- `bun run privacy:scan` — passed (fails on `dev` without this change; verified both directions on `ssh lidge`).

Docs-only; no runtime code touched.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

This removes a credential-shaped string from the tree rather than adding one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Redacted a reproduced authorization value in the release safety audit and replaced it with a placeholder.
  * No functional behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->