### PR TITLE
docs(devlog): close the release audit with the merged fixes and the verified dev state

### DIFF
--- a/devlog/_plan/260820_bug_pr_backlog_consolidation/100_release_audit.md
+++ b/devlog/_plan/260820_bug_pr_backlog_consolidation/100_release_audit.md
@@ -161,3 +161,34 @@ this range. Recorded so it is not rediscovered as new, but it is not this releas
 Full suite at the tip carrying both: **13717 pass / 15 skip / 0 fail** across 866 files;
 typecheck exit 0; privacy scan passed. All on `ssh lidge`.
 
+
+## Closeout — the fixes are on dev
+
+All four landed in dependency order. The order was forced, not chosen: `privacy:scan` runs in
+the `gates` job, so while `dev` itself was failing it, every branch cut from `dev` inherited
+the failure. #2173 was red for exactly that reason and went green once #2175 landed.
+
+| PR | dev merge commit | What it fixes |
+|---|---|---|
+| #2175 | `5bcc91d0e` | the broken `privacy:scan` gate on `dev` itself |
+| #2170 | `9eb6647d5` | caller-controlled marker reaching `usage.jsonl` and `/api/logs` |
+| #2173 | `b2878f8e8` | `tool_search_call` / `custom_tool_call` id namespace |
+| #2174 | `12c14d5c3` | this audit record |
+
+Verified at the `dev` tip on `ssh lidge`:
+
+- `bun run test` — **13719 pass / 15 skip / 0 fail** across 866 files.
+- `bun x tsc --noEmit` — exit 0.
+- `bun run privacy:scan` — passed. It **failed** on `dev` before #2175, which is the whole
+  reason that PR exists.
+- GitHub CI run `32334852749` — completed **success** at `b2878f8e8`, the commit carrying both
+  code fixes. `12c14d5c3` above it is docs-only.
+- Fixes present in `dev` source, not just in a merge commit: `shadowSourceModelPrefix` ×1,
+  `tool_search_call` ×3.
+
+The three findings under "Deliberately left" are unchanged and still open questions. Nothing in
+this closeout resolves them; they need a product decision, not a patch.
+
+Release execution remains unauthorized: no `scripts/release.ts`, no publish, no tag, no change
+to `main` or `preview`.
+


### PR DESCRIPTION
## Summary

Closes out the release-safety audit record with what actually landed and the verified `dev` state.

All four audit PRs are now on `dev`, merged in dependency order. The order was forced rather than chosen: `privacy:scan` runs in the `gates` job, so while `dev` itself was failing it, every branch cut from `dev` inherited the failure. #2173 was red for exactly that reason and went green once #2175 landed.

| PR | dev merge commit |
|---|---|
| #2175 | `5bcc91d0e` — the broken `privacy:scan` gate on `dev` itself |
| #2170 | `9eb6647d5` — caller-controlled marker reaching `usage.jsonl` and `/api/logs` |
| #2173 | `b2878f8e8` — `tool_search_call` / `custom_tool_call` id namespace |
| #2174 | `12c14d5c3` — the audit record |

The three findings under "Deliberately left" are unchanged and still open questions. Nothing here resolves them; they need a product decision, not a patch.

## Verification

At the `dev` tip, on `ssh lidge`:

- `bun run test` — **13719 pass / 15 skip / 0 fail** across 866 files.
- `bun x tsc --noEmit` — exit 0.
- `bun run privacy:scan` — passed. It **failed** on `dev` before #2175, which is why that PR exists.
- GitHub CI run `32334852749` — completed **success** at `b2878f8e8`, the commit carrying both code fixes. `12c14d5c3` above it is docs-only.
- Fixes verified present in `dev` source rather than only in a merge commit: `shadowSourceModelPrefix` ×1, `tool_search_call` ×3.

Docs-only change.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

No credential values appear in the record — only PR numbers, commit SHAs, and file paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a release audit closeout documenting completed merges and validation results.
  - Recorded final test, type-check, privacy-scan, and CI outcomes.
  - Confirmed the fixes are present in the development branch.
  - Documented three previously identified findings that remain open.
  - Clarified that release execution has not been authorized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->