### PR TITLE
fix(devlog): stop the audit record from breaking its own privacy gate

### DIFF
--- a/devlog/_plan/260820_bug_pr_backlog_consolidation/100_release_audit.md
+++ b/devlog/_plan/260820_bug_pr_backlog_consolidation/100_release_audit.md
@@ -36,9 +36,14 @@ The sanitizer on that path is not sufficient, for two independent reasons — bo
 the shipped code, not reasoned about:
 
 ```
-"gpt-5.6-luna\nBearer sk-abc123def456ghi789jkl"      -> "gpt-5.6-lunaBearer [REDACTED]"
-"gpt-5.6-luna\nAIzaSyA1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6" -> unchanged, key intact
+"<prefix>\n<Bearer + an sk-shaped value>"    -> control stripped, value redacted
+"<prefix>\n<a Google AIza-shaped key>"       -> control stripped, value INTACT
 ```
+
+(Written as shapes rather than literals on purpose: `scripts/privacy-scan.ts` matches those
+patterns wherever they appear, so pasting a real-looking transcript breaks the `gates` job for
+every branch cut from `dev`. That is precisely what #2175 had to undo, and this record
+reintroduced it — the scanner does not care that a credential is fake.)
 
 1. Control characters are stripped **before** redaction, so the newline that separated marker
    from credential is gone by the time the `Bearer` rule looks for a word boundary.
@@ -191,4 +196,3 @@ this closeout resolves them; they need a product decision, not a patch.
 
 Release execution remains unauthorized: no `scripts/release.ts`, no publish, no tag, no change
 to `main` or `preview`.
-


### PR DESCRIPTION
## Summary

`dev`'s `gates` job is red again, and this time my own audit record caused it.

The record documenting the shadow-marker leak pasted the reproduction transcript verbatim, including an `sk-`-shaped value after a `Bearer` label. `scripts/privacy-scan.ts` matches those patterns wherever they appear:

```
100_release_audit.md:39 bearer-token: Bearer sk-...
100_release_audit.md:39 token-looking: sk-...
```

This is the same failure #2175 had just undone, reintroduced by the write-up describing it. Worth stating plainly rather than quietly fixing: I hit the exact hazard I had documented one commit earlier.

The scanner cannot tell a fake credential from a real one, and it should not have to. Writing the two cases as shapes keeps the finding intact — the point was never the literal bytes, it was that control characters are stripped *before* redaction and that the deny-list has no rule for one of the two families. Both facts survive the rewrite, with a note at the code block explaining why it is written that way.

## Verification

- `bun run privacy:scan` — passed. Fails on `dev` without this change; verified both directions.

Docs-only; no runtime code touched.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

This removes credential-shaped strings from the tree rather than adding any.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sanitizer examples to use clearly non-sensitive credential placeholders.
  * Preserved documentation of redaction behavior and privacy-scan warnings.
  * Cleaned up trailing whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->