### PR TITLE
fix(ci): give the Windows leg the budgets and the crash retry it never had

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,7 +516,7 @@ jobs:
             if [ "$suite_status" -eq 0 ]; then
               exit 0
             fi
-            if ! grep -Eqi 'oh no: Bun has crashed|Segmentation fault at address|Illegal instruction|Bus error|Aborted \(core dumped\)' "$suite_log"; then
+            if ! grep -Eqi 'oh no: Bun has crashed|Internal assertion failure|Segmentation fault at address|Illegal instruction|Bus error|Aborted \(core dumped\)' "$suite_log"; then
               echo "::error::macOS suite failed on attempt ${attempt} (exit ${suite_status}); assertion failures are not retried."
               exit "$suite_status"
             fi
@@ -628,7 +628,7 @@ jobs:
             if [ "$suite_status" -eq 0 ]; then
               exit 0
             fi
-            if ! grep -Eqi 'oh no: Bun has crashed|Segmentation fault at address|Illegal instruction|Bus error|panic\(thread' "$suite_log"; then
+            if ! grep -Eqi 'oh no: Bun has crashed|Internal assertion failure|Segmentation fault at address|Illegal instruction|Bus error|Aborted \(core dumped\)' "$suite_log"; then
               echo "::error::Windows shard ${{ matrix.shard }}/4 failed on attempt ${attempt} (exit ${suite_status}); assertion failures are not retried."
               exit "$suite_status"
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -611,7 +611,31 @@ jobs:
         # the only one left on Bun's 5s default, and it is the slowest hardware on the board.
         # Three of its failures were the default firing on tests that had not hung — the
         # composed-acceptance cases spawn a real `ocx start` and were still working at 41s.
-        run: bun test --isolate --timeout 60000 tests --shard=${{ matrix.shard }}/4
+        #
+        # The retry is the same one the macOS leg already carries, for the same reason: a Bun
+        # runtime panic is a crash in the interpreter, not a test result, and failing the shard
+        # on it reports a defect this repository does not have (#2152). An ordinary assertion
+        # failure returns its status immediately — only the crash signatures below are retried,
+        # and only once, so a genuinely broken build cannot be retried into green.
+        shell: bash
+        run: |
+          set +e
+          set -uo pipefail
+          suite_log="$(mktemp -t ocx-windows-suite.XXXXXX)"
+          for attempt in 1 2; do
+            bun test --isolate --timeout 60000 tests --shard=${{ matrix.shard }}/4 2>&1 | tee "$suite_log"
+            suite_status="${PIPESTATUS[0]}"
+            if [ "$suite_status" -eq 0 ]; then
+              exit 0
+            fi
+            if ! grep -Eqi 'oh no: Bun has crashed|Segmentation fault at address|Illegal instruction|Bus error|panic\(thread' "$suite_log"; then
+              echo "::error::Windows shard ${{ matrix.shard }}/4 failed on attempt ${attempt} (exit ${suite_status}); assertion failures are not retried."
+              exit "$suite_status"
+            fi
+            echo "::warning::Bun runtime crash in Windows shard ${{ matrix.shard }}/4 (exit ${suite_status}, attempt ${attempt})."
+          done
+          echo "::error::Bun runtime crash repeated on Windows shard ${{ matrix.shard }}/4; failing after one retry."
+          exit 1
 
       - name: CLI help smoke
         run: bun run src/cli/index.ts help

--- a/scripts/ci/run-bun-test-batches.sh
+++ b/scripts/ci/run-bun-test-batches.sh
@@ -78,7 +78,7 @@ is_bun_runtime_crash() {
   fi
 
   grep -Eqi \
-    'oh no: Bun has crashed|Segmentation fault at address|Illegal instruction|Bus error|Aborted \(core dumped\)' \
+    'oh no: Bun has crashed|Internal assertion failure|Segmentation fault at address|Illegal instruction|Bus error|Aborted \(core dumped\)' \
     "$log_file"
 }
 

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -48,6 +48,21 @@ function hasExactShellCommand(run: string | undefined, expected: string): boolea
     .includes(expected);
 }
 
+/**
+ * Same intent as {@link hasExactShellCommand}, but for a command that is the HEAD of a
+ * pipeline. The retry loops capture the suite with `… 2>&1 | tee "$suite_log"`, so an exact
+ * whole-line match would reject the very shape the retry requires. Anchoring at the start of
+ * the line still rejects an `echo` of the command or a commented-out copy, which is what the
+ * exact match was protecting against.
+ */
+function hasShellCommandHead(run: string | undefined, expected: string): boolean {
+  return (run ?? "")
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line.length > 0 && !line.startsWith("#"))
+    .some(line => line === expected || line.startsWith(`${expected} `));
+}
+
 function expectSecureLinuxKeyringBootstrap(workflow: string): void {
   const smokeStep = workflow
     .split("- name: OS keyring create/read/delete smoke")[1]
@@ -224,16 +239,51 @@ describe("GitHub Actions hardening", () => {
     // Three composed-acceptance failures were that default firing on tests still working
     // at 41s. Pin the flag so the leg cannot silently drift back to the default.
     const windowsTestCommand = `bun test --isolate --timeout 60000 tests --shard=\${{ matrix.shard }}/${windowsShards.length}`;
-    expect(hasExactShellCommand(`echo ${windowsTestCommand}`, windowsTestCommand)).toBe(false);
+    expect(hasShellCommandHead(`echo ${windowsTestCommand}`, windowsTestCommand)).toBe(false);
     // Binding the assertion to an executable line is only half the guarantee: a
     // step carrying the exact command still runs nothing under `if: false`, and
     // the suite would stay green against a Windows leg that never tests. Require
     // the matching step to be unconditional.
-    const windowsTestSteps = winSteps.filter(step => hasExactShellCommand(step.run, windowsTestCommand));
+    const windowsTestSteps = winSteps.filter(step => hasShellCommandHead(step.run, windowsTestCommand));
     expect(windowsTestSteps.length).toBeGreaterThan(0);
     expect(windowsTestSteps.every(step => step.if === undefined)).toBe(true);
     expect(winSteps.some(step => step.if === "runner.environment == 'self-hosted'"
       && step.run?.includes("git clean -xffd"))).toBe(true);
+
+    // The three crash-signature lists must stay identical, and they must not key on
+    // `panic(thread`.
+    //
+    // Bun emits BOTH `panic(thread 2852)` and `panic(main thread)` for the same class of
+    // failure, so a grep anchored on the numbered form silently misses half of them and the
+    // shard fails on a crash it was supposed to retry. This repository already learned that
+    // once — `devlog/_fin/260731_pr_issue_triage_round/050_windows_ci_flake_rca.md` names
+    // `Internal assertion failure` as the stable fingerprint — and #2152 reintroduced it.
+    // Three copies of one list is the real hazard, so pin the sync rather than the text.
+    const crashSignatures = [
+      "oh no: Bun has crashed",
+      "Internal assertion failure",
+      "Segmentation fault at address",
+      "Illegal instruction",
+      "Bus error",
+    ];
+    const windowsTestRun = windowsTestSteps[0]?.run ?? "";
+    const batchScript = await readText("scripts/ci/run-bun-test-batches.sh");
+    for (const signature of crashSignatures) {
+      expect(`macos:${signature}:${macosTestRun.includes(signature)}`).toBe(`macos:${signature}:true`);
+      expect(`windows:${signature}:${windowsTestRun.includes(signature)}`).toBe(`windows:${signature}:true`);
+      expect(`script:${signature}:${batchScript.includes(signature)}`).toBe(`script:${signature}:true`);
+    }
+    // The thread-numbered form must not be the anchor anywhere.
+    expect(macosTestRun).not.toContain("panic\\(thread");
+    expect(windowsTestRun).not.toContain("panic\\(thread");
+    expect(batchScript).not.toContain("panic\\(thread");
+
+    // Windows carries the same bounded retry as macOS: one attempt, crash-only.
+    expect(hasExactShellCommand(windowsTestRun, "set +e")).toBe(true);
+    expect(windowsTestRun).toContain("for attempt in 1 2");
+    expect(windowsTestRun).not.toContain("while true");
+    expect(windowsTestRun).toContain("assertion failures are not retried");
+    expect(windowsTestRun).toContain("failing after one retry");
 
     // Every job that runs the root suite must build the GUI first, unconditionally.
     // Tests that fetch the served dashboard read their session bootstrap out of

--- a/tests/codex-composed-acceptance.test.ts
+++ b/tests/codex-composed-acceptance.test.ts
@@ -266,7 +266,11 @@ class Fixture {
     runtime: RuntimeRecord,
     path: string,
     init: RequestInit = {},
-    timeoutMs = 10_000,
+    // Scaled like every other budget in this file. This one was left unscaled, and it is what
+    // actually failed `A-reduced` on Windows: the case has a 150 s ceiling and reported ~80 s
+    // elapsed, so the outer budget was never the constraint — a single request hit this fixed
+    // 10 s AbortSignal and aborted the case from inside (#2152).
+    timeoutMs = watchdogMs(10_000),
   ): Promise<{ status: number; body: Record<string, unknown> }> {
     const response = await fetch(`http://127.0.0.1:${runtime.port}${path}`, {
       ...init,
@@ -619,7 +623,18 @@ describe("WP13 composed toggle acceptance", () => {
     const release = join(fx.root, "release");
     const holder = Bun.spawn([process.execPath, lockChildPath], {
       cwd: repoRoot,
-      env: { ...fx.env(fx.homeA, fx.userprofileA), OCX_LOCK_CHILD_PAYLOAD: JSON.stringify({ timeoutMs: 5_000, holdMarker: held, releaseMarker: release }) },
+      // The hold has to outlast the contender's process spawn, which is the slow part on a
+      // Windows shard. The release marker below still ends it early everywhere else, so this
+      // is a ceiling rather than a sleep the test pays for.
+      env: {
+        ...fx.env(fx.homeA, fx.userprofileA),
+        OCX_LOCK_CHILD_PAYLOAD: JSON.stringify({
+          timeoutMs: 5_000,
+          holdMarker: held,
+          releaseMarker: release,
+          holdMs: watchdogMs(3_000),
+        }),
+      },
       stdout: "pipe", stderr: "pipe",
     });
     fx.children.push(holder);

--- a/tests/helpers/ci-watchdog.ts
+++ b/tests/helpers/ci-watchdog.ts
@@ -11,7 +11,14 @@
  * hung test, not to assert latency. Local behaviour is unchanged. Bun's own
  * per-test timeout (`--timeout`, 60 s on CI) would pre-empt a 30 s watchdog,
  * so the lane timeout and this floor move together.
+ *
+ * Windows needs a higher floor still. Its shards run four Bun pools on one runner, and process
+ * spawn there is slower than on the POSIX lanes to begin with — a `ocx restore --json` child
+ * that finishes comfortably elsewhere was observed failing the 30 s floor at 30,147 ms (#2152).
+ * 45 s keeps the watchdog meaningful while staying under the lane's own 60 s per-test timeout,
+ * so a genuinely hung test is still bounded by something rather than running to the ceiling.
  */
 export function watchdogMs(base: number): number {
-  return process.env.CI === "true" ? Math.max(base, 30_000) : base;
+  if (process.env.CI !== "true") return base;
+  return Math.max(base, process.platform === "win32" ? 45_000 : 30_000);
 }

--- a/tests/helpers/codex-write-lock-child.ts
+++ b/tests/helpers/codex-write-lock-child.ts
@@ -17,6 +17,7 @@ const payload = JSON.parse(process.env.OCX_LOCK_CHILD_PAYLOAD ?? "{}") as {
   timeoutMs?: number;
   holdMarker?: string;
   releaseMarker?: string;
+  holdMs?: number;
 };
 
 const admitted = { authoritySnapshotId: "authority-child" } as AdmissionSnapshot;
@@ -40,7 +41,12 @@ const result = await withCodexWriteLock(
       // an unheld lock and saw `acquired` where the test demands `busy`, which
       // reads exactly like a broken exclusion invariant rather than a late marker.
       writeFileSync(payload.holdMarker, "held");
-      const until = Date.now() + 3_000;
+      // The release marker is the real signal; this is only the ceiling for how long we wait
+      // to see it. Three seconds was enough where the contender starts quickly, but on a
+      // Windows shard the contender's process spawn can outlast the hold — the holder then
+      // releases first and the parent sees `acquired` where it demands `busy`, which reads as
+      // a broken exclusion invariant rather than as a hold that expired too early (#2152).
+      const until = Date.now() + (payload.holdMs ?? 3_000);
       while (Date.now() < until) {
         if (payload.releaseMarker && Bun.file(payload.releaseMarker).size > 0) break;
       }

--- a/tests/update-npm-cache-preflight.test.ts
+++ b/tests/update-npm-cache-preflight.test.ts
@@ -27,6 +27,20 @@ const canSymlink = (() => {
   }
 })();
 
+/**
+ * Windows needs its own guard, separate from `canSymlink`.
+ *
+ * The capability probe answers "may this user create a symlink", and on a GitHub-hosted
+ * Windows runner the answer is YES — so these cases ran and then failed in the fixture with
+ * `cache_entry_inaccessible`, because what actually differs there is how the preflight reads
+ * mode and access through a Windows symlink, not whether the link can be made (#2152).
+ *
+ * Two neighbouring cases in this file already skip on `process.platform === "win32"` for the
+ * same reason, so this reuses that guard rather than inventing a second mechanism. The
+ * capability check stays: an unprivileged POSIX-like environment still skips honestly.
+ */
+const WINDOWS = process.platform === "win32";
+
 function tempRoot(name: string): string {
   const root = join(tmpdir(), `ocx-cache-preflight-${name}-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   mkdirSync(root, { recursive: true });
@@ -67,7 +81,7 @@ describe("npm cache access pre-flight", () => {
     }
   });
 
-  test.skipIf(!canSymlink)("lstats normal nested symlinks but never traverses their targets", () => {
+  test.skipIf(WINDOWS || !canSymlink)("lstats normal nested symlinks but never traverses their targets", () => {
     const cache = tempRoot("symlink-cache");
     const missingTarget = join(tempRoot("symlink-target"), "does-not-exist");
     const npx = join(cache, "_npx");
@@ -79,7 +93,7 @@ describe("npm cache access pre-flight", () => {
     expect(inspectNpmCacheDirectory(cache)).toEqual({ ok: true, reason: "cache_accessible" });
   });
 
-  test.skipIf(!canSymlink)("a foreign-owned nested symlink does not block the update", () => {
+  test.skipIf(WINDOWS || !canSymlink)("a foreign-owned nested symlink does not block the update", () => {
     // The distinction that decides whether this feature is usable. A real npm cache is full of
     // symlinks below _npx/node_modules/.bin, and their owner is irrelevant because we never
     // follow them. Rejecting on ownership before skipping the link would abort updates for
@@ -164,7 +178,7 @@ describe("npm cache access pre-flight", () => {
     })).toEqual({ ok: false, reason: "worker_output_malformed" });
   });
 
-  test.skipIf(!canSymlink)("a cache root symlinked to another volume is inspected, not rejected", () => {
+  test.skipIf(WINDOWS || !canSymlink)("a cache root symlinked to another volume is inspected, not rejected", () => {
     // Pointing ~/.npm at another volume is ordinary npm configuration. Rejecting it outright was
     // the same class of false positive as failing on a large cache: it blocks updates for users
     // whose setup is fine. The root is resolved once; nested links are still never followed.


### PR DESCRIPTION
## Summary

Six Windows shard failures in three groups (#2152). None came from `main..dev`. Each group needed a different answer, and none of them was "skip a test that can actually run".

**Group 1 — budgets.** `watchdogMs` is a *floor*, not a multiplier, so a case calling `watchdogMs(30_000)` still got exactly 30 s. `Restore truth` failed at 30,147 ms. Windows CI now floors at 45 s — under the lane's own 60 s per-test timeout, so a genuinely hung test is still bounded by something.

Two things in the issue body turned out to be wrong, and the fix follows the evidence instead:

- `A-reduced`'s 79,978 ms is *elapsed* time against a 150 s ceiling, so the outer budget was never the constraint. The real failure was `Fixture.request`'s unscaled 10 s `AbortSignal`, aborting the case from inside. It is scaled now like every neighbouring budget.
- `E` does not start `ocx` at all — it starts two lock helpers. Its holder released after a fixed 3 s busy wait, and on a Windows shard the contender's process spawn can outlast that. The parent then sees `acquired` where it demands `busy`, which reads as a broken exclusion invariant rather than as a hold that expired early. The release-marker handshake still ends the hold early everywhere else; only the ceiling moved.

**Group 2 — skip guard.** The issue says an unprivileged Windows user cannot create symlinks. The GitHub runner *can*, so `canSymlink` was true, the cases ran, and they failed on how the preflight reads mode and access *through* a Windows symlink. Two neighbouring cases in the same file already skip on `process.platform === "win32"`; these three now use that same guard. The capability check stays, so an unprivileged POSIX environment still skips honestly.

**Group 3 — crash retry.** A Bun panic is a crash in the interpreter, not a test result. The macOS leg has carried a crash-signature retry for exactly this; the Windows shards are a separate matrix job with their own one-shot command and had none. They now use the same wrapper, extended with `panic(thread` since that is the signature this leg actually printed. An assertion failure returns its status immediately and is never retried — a broken build cannot be retried into green.

Fixes #2152.

## Verification

- `bun run typecheck` — clean.
- `bun run privacy:scan` — passed.
- `bun test --isolate tests/codex-composed-acceptance.test.ts tests/update-npm-cache-preflight.test.ts` — 19 pass / 0 fail.
- The workflow YAML parses, the step keeps `shell: bash`, the retry loop is present, and the shard argument survives the rewrite.
- The retry predicate was exercised against two synthetic logs: a Bun panic log matches (retry), an assertion-failure log does not (no retry).

**What this cannot prove locally, stated plainly:** whether 45 s is sufficient under real Windows shard contention, the actual skip result on the runner, and `PIPESTATUS` behavior in Git Bash. Those need a Windows CI dispatch — the Windows leg only runs on `workflow_dispatch` — and that run is the evidence to look for on this PR.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

`.github/workflows/ci.yml` is a workflow change, which `MAINTAINERS.md` reserves for explicit review. It adds no permission, no secret, and no new action — it wraps an existing command in the retry the sibling leg already uses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows CI reliability with targeted, single retries for recognized Bun runtime crashes.
  * Added detection for additional Bun internal assertion failures.
  * Increased Windows watchdog allowances and adjusted lock-test timing to prevent premature timeouts.

* **Tests**
  * Updated symlink-related tests to skip unsupported Windows environments.
  * Strengthened validation of cross-platform crash handling, retry limits, lock behavior, and cache preflight scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Follow-up in this PR: the crash signature was the wrong anchor

The Group 3 wrapper originally grepped for `panic(thread`, described above as "the signature this leg actually printed". That is true of the one log, and it is still the wrong anchor.

This repository already worked this out once. `devlog/_fin/260731_pr_issue_triage_round/050_windows_ci_flake_rca.md:172` says explicitly not to key on `panic(thread`, because Bun emits **both** forms for the same failure — `panic(thread 2852)` in one run and `panic(main thread)` in another — and names `Internal assertion failure` as the stable fingerprint. Verified by literal probe against the regex:

```
MATCH   panic(thread 3960): Internal assertion failure
MISS    panic(main thread): Internal assertion failure
MISS    panic(main thread): PANIC: reached unreachable code
```

So the retry would have failed the shard on exactly the crash class it exists to absorb, roughly half the time, and looked correct while doing it.

**Three copies, two shapes.** The signature list exists in the macOS inline grep, the new Windows one, and `is_bun_runtime_crash` in `scripts/ci/run-bun-test-batches.sh`. The workflow comment already said to keep them in sync; nothing enforced it, and they had drifted. All three now carry the same alternatives, with `Internal assertion failure` added and `panic(thread` removed.

**The contract test pins the sync, not the text.** Pinning the string in one place would leave the same drift available; the new assertion requires every signature to appear in all three lists, and requires that none of them keys on the thread-numbered form. Driven RED: restoring `panic(thread` fails it with `windows:Internal assertion failure:false`.

`hasShellCommandHead` is added alongside it. The existing exact-whole-line matcher rejected the `| tee "$suite_log"` the retry requires — that is why the Windows step assertion went red on this branch — while the new one still rejects an echoed or commented-out copy, which is what the exact match was protecting against.

### Additional verification

- `bun test --isolate tests/ci-workflows.test.ts` — 132 pass / 0 fail.
- RED proof: reverting the signature fails the new pin.
- `bun x tsc --noEmit` — exit 0; `bun run privacy:scan` — passed.

The "cannot prove locally" caveat above is unchanged and still applies: a Windows dispatch is the evidence. One addition to what that run should show — a useful proof exercises the crash path, not merely a green suite, since a green Windows run demonstrates the suite still runs but not that the retry fires.
