### PR TITLE
fix(ci): stop the Windows leg from truncating and mismeasuring its own shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,7 +553,16 @@ jobs:
     # Sharded like the Linux legs. The single-leg run reached 30 minutes on a
     # green suite and was killed in cleanup; four shards put each leg inside the
     # same budget the Linux shards already hold.
-    timeout-minutes: 15
+    #
+    # 15 was that Linux budget, and on this leg it truncated the evidence rather
+    # than bounding a hang: shard 1/4 of run 32340498394 was CANCELLED at exactly
+    # 15m12s while still executing tests, so its result was neither pass nor fail
+    # and the composed-acceptance cases it carries could not be read at all. The
+    # other shards finished in 14-15 minutes, which is the wrong side of the
+    # margin. 25 leaves the outer bound in place — a wedged shard still dies —
+    # while making a completed shard the normal outcome. The crash-retry below can
+    # double a shard's work, and this ceiling has to cover that second attempt too.
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -101,7 +101,9 @@ describe("GitHub Actions hardening", () => {
     expect(ci.jobs?.test?.["timeout-minutes"]).toBe(15);
     expect(ci.jobs?.gates?.["timeout-minutes"]).toBe(15);
     expect(ci.jobs?.["platform-macos"]?.["timeout-minutes"]).toBe(30);
-    expect(ci.jobs?.["platform-windows"]?.["timeout-minutes"]).toBe(15);
+    // Higher than the Linux shards on purpose: at 15 the Windows leg cancelled a
+    // shard mid-suite, which reports as neither pass nor fail (#2152).
+    expect(ci.jobs?.["platform-windows"]?.["timeout-minutes"]).toBe(25);
     expect(ci.jobs?.["keyring-smoke"]?.["timeout-minutes"]).toBe(8);
     expect(ci.jobs?.["npm-global-smoke"]?.["timeout-minutes"]).toBe(8);
     expect(ci.jobs?.ci?.["timeout-minutes"]).toBe(5);

--- a/tests/claude-shell-hook.test.ts
+++ b/tests/claude-shell-hook.test.ts
@@ -83,13 +83,21 @@ describe("Claude Code shell-hook reconciliation", () => {
     expect(readFileSync(zshrcPath, "utf8").match(/opencodex claude-env hook/g)).toHaveLength(1);
   });
 
-  test("does not treat a non-executable claude file as an installed CLI", () => {
-    writeFileSync(join(binDir, "claude"), "#!/bin/sh\nexit 0\n", { mode: 0o644 });
+  // Windows has no execute permission bit: `accessSync(path, X_OK)` succeeds for any
+  // readable file, so a 0o644 fixture cannot express "present but not executable" there.
+  // The case asserts a POSIX permission semantic, and skipping it on a platform that
+  // cannot represent the precondition is honest; asserting it anyway measured the
+  // fixture, not the product (#2152).
+  test.skipIf(originalPlatform === "win32")(
+    "does not treat a non-executable claude file as an installed CLI",
+    () => {
+      writeFileSync(join(binDir, "claude"), "#!/bin/sh\nexit 0\n", { mode: 0o644 });
 
-    expect(claudeCodeCliInstalled()).toBe(false);
-    expect(reconcileShellHook(true)).toMatchObject({ changed: false, state: "absent" });
-    expect(existsSync(zshrcPath)).toBe(false);
-  });
+      expect(claudeCodeCliInstalled()).toBe(false);
+      expect(reconcileShellHook(true)).toMatchObject({ changed: false, state: "absent" });
+      expect(existsSync(zshrcPath)).toBe(false);
+    },
+  );
 
   test("removes the hook when system environment integration is inactive", () => {
     installClaudeCli();

--- a/tests/helpers/test-budget.ts
+++ b/tests/helpers/test-budget.ts
@@ -44,7 +44,22 @@ export const STORE_BUDGET_MS = 30_000;
  * assertion (durable spill is the product contract), so the wait is intrinsic; the
  * orphan-cleanup cap test measured ~34s on windows-latest against Bun's 5s default.
  */
-export const BULK_DURABLE_IO_BUDGET_MS = 90_000;
+export const BULK_DURABLE_IO_BUDGET_MS = bulkDurableIoBudgetMs();
+
+/**
+ * Windows needs a higher ceiling than the ~34s that sized this number, for the same
+ * reason `watchdogMs` carries a higher floor there: the leg runs four Bun pools on one
+ * runner, and every one of these writes is an individual fsync against a filesystem that
+ * is slower under that contention to begin with. The orphan-cleanup cap case ran 100.6s
+ * against the 90s budget on shard 4/4 (#2152) while doing exactly the work it claims —
+ * 521 durable writes — so the number was measuring runner contention, not a hang.
+ *
+ * 180s stays a bound rather than an absence of one, and it is gated on Windows so no
+ * other lane loses the shorter signal.
+ */
+function bulkDurableIoBudgetMs(): number {
+  return process.platform === "win32" ? 180_000 : 90_000;
+}
 
 /**
  * A deadline *inside* a test, for an await that would otherwise hang forever.


### PR DESCRIPTION
## Summary

Windows CI run [32340498394](https://github.com/lidge-jun/opencodex/actions/runs/32340498394) was dispatched at the release head. Three of its results were measurement artefacts rather than defects in this repository, and each one is fixed here.

**Shard 1/4 was cancelled at 15m12s while still executing tests.** A cancelled shard is neither a pass nor a fail: it removed the WP13 composed-acceptance cases from the evidence entirely, which is exactly the set #2178 was written to fix. The other three shards finished at 14-15 minutes, so the 15-minute ceiling was inside the noise band rather than above it. Raised to 25. A wedged shard still dies; the difference is that a completed shard is now the normal outcome, and the ceiling also covers the second attempt the Bun crash retry is allowed to make.

**`orphan cleanup obeys scan and cleanup caps` timed out at 100.6s against a 90s budget** on shard 4/4 while performing exactly the work it asserts: 521 individually fsync'd durable writes. `BULK_DURABLE_IO_BUDGET_MS` was sized from a ~34s windows-latest measurement, so at 90s it was measuring runner contention, not a hang. It now carries a Windows-only 180s ceiling, the same shape `watchdogMs` already uses for its Windows floor.

**`does not treat a non-executable claude file as an installed CLI` cannot express its own precondition on Windows.** The fixture writes `mode: 0o644` and expects `claudeCodeCliInstalled()` to return false. Windows has no execute-permission bit, so `accessSync(path, X_OK)` succeeds for any readable file. The case asserts a POSIX permission semantic; it now skips on win32, as several neighbouring symlink cases in the same suites already do.

### Deliberately not in scope

Shard 2/4 also failed `CL-10 public bundle and publisher > builds deterministic bundle ids and digests` with `public publisher key ACL hardening did not complete`, thrown from `requirePublisherKeyAcl` on a real icacls path. That is a genuine Windows-only behaviour question in `src/lab/public/signature.ts`, not a budget or a platform-semantics gap, and guessing at it from a log would be the wrong move. It is recorded on #2152 with the stack. No file under `src/` is touched by this PR.

## Verification

- `bun test --isolate tests/ci-workflows.test.ts tests/claude-shell-hook.test.ts` — 143 pass, 0 fail
- `bun test --isolate tests/lab-public-evidence.test.ts tests/lab-public-security-regressions.test.ts` — 23 pass, 0 fail
- `bun x tsc --noEmit` — clean
- The workflow-shape assertion in `tests/ci-workflows.test.ts` was updated alongside the timeout it pins, so the 25-minute value is asserted rather than merely present.

The real proof is the next dispatched Windows run: all four shards must complete rather than one being cancelled. That is checked after this merges, since the leg only runs on `workflow_dispatch`.

## Checklist

- [x] Tests added or updated
- [x] `bun run typecheck` passes
- [x] Focused suites pass
- [x] Docs updated if user-facing behavior changed (no user-facing behaviour changes; CI and test budgets only)

Refs #2152.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows test reliability by allowing longer CI timeouts and additional time for durable I/O workloads.
  * Prevented platform-specific permission checks from failing where Windows cannot represent POSIX file permissions.

* **Tests**
  * Updated CI validation to reflect the revised Windows timeout.
  * Preserved existing assertions for other platforms and test jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->