### PR TITLE
[WRONG BRANCH] release: v2.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitkyc08/opencodex",
-  "version": "2.27.0",
+  "version": "2.28.0",
   "description": "Universal provider proxy for OpenAI Codex & Claude Code — use any LLM with Codex CLI/App/SDK and Claude Code",
   "type": "module",
   "main": "./bin/package-main.mjs",


### PR DESCRIPTION
## Summary

Version bump to **2.28.0** on `main`, produced by `scripts/release.ts 2.28.0 --publish`. One line changes: `package.json` `version`.

The helper wants to push this commit to `main` directly; branch protection requires a pull request, so this PR carries the same commit (`ce4e05dde`) it would have pushed. Once merged, the helper is re-run from a `main` checkout at that SHA — it treats the bump as a desired end state, finds `package.json` already at 2.28.0, reuses the existing release commit, and proceeds to the CI wait and the workflow dispatch.

## Verification

The helper's full local gate ran to completion at `5bdf56077` before producing this commit:

- `bun run audit:high` — clean
- `bun x tsc --noEmit` — clean
- `bun test --isolate tests` — **13737 pass, 0 fail**, 866 files, 509s
- `bun run privacy:scan` — passed
- Release metadata preflight: 2.28.0 is unused on npm and moves the `latest` channel forward from 2.27.0

Cross-platform CI is green at the parent commit `5bdf56077` ([32347982184](https://github.com/lidge-jun/opencodex/actions/runs/32347982184)) and Service lifecycle passed there too ([32347982293](https://github.com/lidge-jun/opencodex/actions/runs/32347982293)). This PR adds no source change on top of that, so the release SHA's own push run is the one that gates the publish.

Version reasoning is in #2186: one user-visible feature (Logs intercepted-helper attribution) plus provider behaviour changes across xAI, Anthropic, Google, and the capability gate — new behaviour on upgrade, not only fixes.

## Checklist

- [x] Tests added or updated (n/a — version bump only)
- [x] `bun run typecheck` passes
- [x] Full suite passes (13737/13737 locally, plus green CI at the parent)
- [x] Docs updated if user-facing behavior changed (n/a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version from 2.27.0 to 2.28.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->