### PR TITLE
[WRONG BRANCH] release: v2.28.0-preview.20260820

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitkyc08/opencodex",
-  "version": "2.27.0",
+  "version": "2.28.0-preview.20260820",
   "description": "Universal provider proxy for OpenAI Codex & Claude Code — use any LLM with Codex CLI/App/SDK and Claude Code",
   "type": "module",
   "main": "./bin/package-main.mjs",


### PR DESCRIPTION
## Summary

Version bump to **2.28.0-preview.20260820** on `preview`, produced by `scripts/release.ts 2.28.0-preview.20260820 --publish`. One line changes: `package.json` `version`.

Same shape as #2189 on `main`: the helper wants to push its release commit directly, branch protection requires a pull request, so this PR carries that exact commit (`19fbc939b`). After it merges the helper is re-run from a `preview` checkout — it finds `package.json` already at the target version, reuses the existing release commit, and continues to the CI wait and the workflow dispatch with npm dist-tag `preview`.

**Why this version exists.** The `preview` channel is a release behind `latest` on npm — `2.26.0-preview.20260819` against `2.27.0` — so the prerelease train has been trailing the stable one. #2187 already synced `preview` to the same content `main` is publishing as 2.28.0; this puts the matching prerelease on npm so the two channels line up again.

The helper enforces the pairing itself: a `preview` branch release must carry a `-preview.` version and must publish with the `preview` dist-tag, and a `main` release must be stable semver on `latest`. There is no path here that crosses the channels.

## Verification

The helper's full local gate ran to completion at `a3c33bb72` before producing this commit:

- `bun run audit:high` — clean
- `bun x tsc --noEmit` — clean
- `bun test --isolate tests` — **13727 pass, 0 fail**, 866 files, 544s
- `bun run privacy:scan` — passed
- Release metadata preflight: the version is unused on npm and moves the `preview` channel forward from 2.26.0-preview.20260819

Content verification is the same body of work cited in #2186 and #2189, since `preview` and `main` carry identical trees at this point.

## Checklist

- [x] Tests added or updated (n/a — version bump only)
- [x] `bun run typecheck` passes
- [x] Full suite passes (13727/13727 locally)
- [x] Docs updated if user-facing behavior changed (n/a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to version `2.28.0-preview.20260820`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->