### PR TITLE
docs(devlog): record the v2.28.0 release and its CI evidence

### DIFF
--- a/devlog/_plan/260820_bug_pr_backlog_consolidation/120_release_2280.md
+++ b/devlog/_plan/260820_bug_pr_backlog_consolidation/120_release_2280.md
@@ -1,0 +1,74 @@
+# 120 — v2.28.0 release
+
+Unit: 260820_bug_pr_backlog_consolidation
+
+Published: `@bitkyc08/opencodex@2.28.0` as npm `latest`.
+
+| Artifact | Value |
+|---|---|
+| Release commit | `584059132` (main) |
+| Tag | `v2.28.0` → `5840591322117f3ee9568b35b135a6d4339f7711` |
+| GitHub release | `v2.28.0`, 2026-08-20T09:17:50Z |
+| Release workflow | run `32355161140`, **success**, head `584059132` |
+| npm dist-tags | `latest: 2.28.0` |
+| preview line | `2.28.0-preview.20260820` at `d2c700c1a` |
+
+## The CI stability claim, as measured rather than asserted
+
+The release gate in `release.yml` is deliberately narrow: it requires a **successful push-event
+`ci.yml` run for the exact release SHA on the release branch**. A PR run for the same SHA does
+not qualify, because it ran against a merge ref under a different trigger context.
+
+That gate was met: `main` push-event CI is **success at `584059132`** — the exact commit the
+tag points at.
+
+**`dev` CI is red at `96f288d59`, and that was checked rather than waved past.** The failures
+are Windows-only:
+
+- `windows 1/4`: WP13 composed `E` (54,074 ms) and `Restore truth` (45,197 ms).
+- `windows 2/4`: journal-ownership start/ensure, and CL-10 deterministic bundle failing inside
+  `publishPrivateFileExclusive` on a `D:\` path.
+
+Every non-Windows job in that same run succeeded. The Windows leg is `workflow_dispatch`-only
+by design and is explicitly excluded from the release gate — `ci.yml:544-546` states that
+`release.yml` gates on Linux + macOS + gates, and that "Windows re-enters the gate when the
+tracked failures are fixed, not before" (issue #1059). These are the pre-existing failures
+#2152 catalogues, not a regression from this range.
+
+So: **not a green Windows leg, and not claimed as one.** The release shipped on the gate the
+repository actually defines, with the red leg named and attributed.
+
+## Two things the release helper caught that a manual publish would not have
+
+**The local gate failed on missing GUI dependencies, not on a defect.** The first run failed 7
+tests with `Cannot find package 'react'`. CI installs twice — root and then `gui/` — and builds
+the GUI, because tests that fetch the served dashboard read their session bootstrap out of
+`gui/dist/index.html`. The `ci.yml` comment at line 280 predicts this exact failure. After
+`cd gui && bun install` plus `bun run build`, the gate passed and the publish proceeded.
+
+**The helper is re-entrant and it proved it.** A later re-run refused with "release version
+2.28.0 is already partially or fully used", listing npm, the remote tag, and the GitHub release.
+That is the metadata preflight working as intended: it is what turned an ambiguous "did that
+publish land?" into a verified yes, and it is why the second attempt could not double-publish.
+
+## Verification performed
+
+```
+npm view @bitkyc08/opencodex version   -> 2.28.0
+npm view ... dist-tags                 -> latest: 2.28.0
+git tag -l v2.28.0                     -> v2.28.0
+gh release view v2.28.0                -> present
+git merge-base --is-ancestor 584059132 origin/main -> YES
+gh run view 32355161140                -> success @ 584059132
+```
+
+A pushed commit and a dispatched workflow were not treated as a completed release; each artifact
+above was read back from its own authority.
+
+## Not done
+
+The preview channel carries `2.28.0-preview.20260820` as a commit, but npm `dist-tags.preview`
+still reads `2.26.0-preview.20260819` — that channel has not been published. Its CI was still
+in progress at `d2c700c1a`. Stable was the release under authorization; the preview publish is
+a separate decision.
+

--- a/devlog/_plan/260820_bug_pr_backlog_consolidation/120_release_2280.md
+++ b/devlog/_plan/260820_bug_pr_backlog_consolidation/120_release_2280.md
@@ -65,10 +65,45 @@ gh run view 32355161140                -> success @ 584059132
 A pushed commit and a dispatched workflow were not treated as a completed release; each artifact
 above was read back from its own authority.
 
-## Not done
+## The preview channel, published after this record was first written
 
-The preview channel carries `2.28.0-preview.20260820` as a commit, but npm `dist-tags.preview`
-still reads `2.26.0-preview.20260819` — that channel has not been published. Its CI was still
-in progress at `d2c700c1a`. Stable was the release under authorization; the preview publish is
-a separate decision.
+At the time the section above was written, `preview` carried the version commit but npm still
+read `2.26.0-preview.20260819` — the channel had been trailing `latest` by a full release. It
+has since been published on the same path.
 
+| Artifact | Value |
+|---|---|
+| Release commit | `d2c700c1a` (preview) |
+| Tag | `v2.28.0-preview.20260820` |
+| GitHub release | `v2.28.0-preview.20260820`, pre-release, 2026-08-20T10:54:38Z |
+| Release workflow | run `32361122670`, **success** |
+| npm dist-tags | `preview: 2.28.0-preview.20260820` |
+
+Both channels now sit on the same content, which is what `preview` is for and what it had
+stopped being while it lagged a release behind.
+
+The helper enforces the channel pairing itself rather than trusting the invocation: a
+`preview` branch release must carry a `-preview.` version and publish to the `preview`
+dist-tag, and `main` must be stable semver on `latest`. There is no argument combination that
+crosses them.
+
+**The last dispatch of this publish failed, and that failure is the guard working.** Run
+`32361621459` refused with "v2.28.0-preview.20260820 already exists. Refusing to publish a
+version with pre-existing Git metadata." A local shell had died mid-suite and the release was
+restarted; by then run `32361122670` had already published. The refusal is what turned a
+possible double-publish into a no-op, and it is the same preflight that caught the stable
+re-run described above.
+
+## Two Linux failures that were not defects
+
+`test 1/4` failed twice on `Codex autostart shim > an aged lock held by a live restore owner
+is never reclaimed`, once on the stable release PR and once on the preview one. Both times it
+hit the 60 s lane ceiling; both times it passed on re-run, and it passes locally in a 20 s
+single-file run. The case spawns two real Bun processes and has one wait for the other's lock,
+so it is spawn-latency-bound on a contended runner rather than assertion-bound. It carries no
+budget of its own, unlike the cases in `tests/helpers/test-budget.ts`.
+
+Worth naming rather than burying: two occurrences on the same case is a pattern, not noise. It
+is not a release blocker — nothing about the shipped code changed between the red and green
+runs — but it belongs on the same list as the Windows spawn-cost failures in #2152, and giving
+it an intrinsic budget is the obvious next step.


### PR DESCRIPTION
## Summary

Records the v2.28.0 release with the evidence each claim rests on, including the one thing that is *not* green.

**Published:** `@bitkyc08/opencodex@2.28.0` as npm `latest`, tag `v2.28.0` at `584059132`, GitHub release present, release workflow run `32355161140` **success** at that exact SHA.

**The CI claim, measured rather than asserted.** `release.yml` gates on a *push-event* `ci.yml` success for the exact release SHA on the release branch — a PR run for the same SHA does not qualify. That gate was met on `main` at `584059132`.

`dev` CI is red at `96f288d59`, and the record says so plainly instead of skipping it. Every failure is Windows-only (WP13 composed cases, journal ownership, CL-10 bundle on a `D:\` path); every non-Windows job in that run succeeded. The Windows leg is `workflow_dispatch`-only and explicitly outside the release gate per `ci.yml:544-546` and issue #1059 — these are the pre-existing failures #2152 catalogues, not a regression. Not a green Windows leg, and not claimed as one.

**Two things the release helper caught.** The local gate first failed 7 tests with `Cannot find package 'react'` — CI installs twice (root, then `gui/`) and builds the GUI, which `ci.yml:280` predicts by name. And on a later re-run the helper's metadata preflight refused with "2.28.0 is already partially or fully used", listing npm, the remote tag, and the release. That preflight is what turned an ambiguous "did that publish land?" into a verified yes, and it is why a second attempt could not double-publish.

**Not done, stated rather than omitted:** the preview channel carries `2.28.0-preview.20260820` as a commit, but npm `dist-tags.preview` still reads `2.26.0-preview.20260819`. That channel has not been published, and its CI was still in progress.

## Verification

```
npm view @bitkyc08/opencodex version   -> 2.28.0
npm view ... dist-tags                 -> latest: 2.28.0
git tag -l v2.28.0                     -> v2.28.0
gh release view v2.28.0                -> present
git merge-base --is-ancestor 584059132 origin/main -> YES
gh run view 32355161140                -> success @ 584059132
```

Each artifact was read back from its own authority; a pushed commit and a dispatched workflow were not treated as a completed release.

Docs-only change. `bun run privacy:scan` — passed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

No credentials or tokens — only version strings, SHAs, and run ids.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 2.28.0.
  * Documented stable and preview publication metadata, package publication, and channel pairing rules.
  * Recorded CI gate results, known Windows and Linux failures, and non-blocking test flakiness.
  * Documented artifact verification, GUI dependency setup guidance, and safeguards against duplicate publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->