### PR TITLE
fix(responses): bound terminal guard delta retention

### DIFF
--- a/src/server/responses/terminal-guard.ts
+++ b/src/server/responses/terminal-guard.ts
@@ -153,6 +153,16 @@ export interface GuardedEventStreamOptions {
   maxAutoContinuations?: number;
 }
 
+/**
+ * Events that are useful to the downstream stream consumer but carry no state used by the
+ * terminal-continuation decision or its rebuilt request. Keep them out of the retained event
+ * list so adapter liveness markers and arbitrarily large tool-argument fragments cannot make
+ * the guard's per-turn memory grow without adding any continuation semantics.
+ */
+export function isTerminalGuardPassthroughOnly(event: AdapterEvent): boolean {
+  return event.type === "heartbeat" || event.type === "tool_call_delta";
+}
+
 function mergeUsage(first: OcxUsage | undefined, second: OcxUsage | undefined): OcxUsage | undefined {
   if (!first) return second;
   if (!second) return first;
@@ -193,13 +203,10 @@ export async function* guardTerminalEventStream(options: GuardedEventStreamOptio
     const seen: AdapterEvent[] = [];
     let terminalSeen = false;
     for await (const event of source) {
-      // A heartbeat is adapter liveness, not turn content: it exists so the bridge watchdog
-      // can tell a buffering adapter from a hung one. Retaining it here would put an
-      // unbounded number of empty markers into `seen`, which feeds both the continuation
-      // analysis and the rebuilt request — and the openai-chat adapter now emits one per
-      // tool-call delta, so a long argument payload alone could grow this array without
-      // limit. The empty-completion guard already passes them through unretained; match it.
-      if (event.type === "heartbeat") {
+      // Liveness markers and tool argument fragments are passed through to the bridge, but
+      // neither analyzeTerminalTurn nor buildContinuationRequest consumes them. Retaining the
+      // fragments would duplicate arbitrarily large argument payloads in `seen` for no effect.
+      if (isTerminalGuardPassthroughOnly(event)) {
         yield event;
         continue;
       }

--- a/tests/terminal-guard.test.ts
+++ b/tests/terminal-guard.test.ts
@@ -3,6 +3,7 @@ import {
   analyzeTerminalTurn,
   buildContinuationRequest,
   guardTerminalEventStream,
+  isTerminalGuardPassthroughOnly,
 } from "../src/server/responses/terminal-guard";
 import { buildResponseJSON } from "../src/bridge";
 import type { AdapterEvent, OcxParsedRequest } from "../src/types";
@@ -234,6 +235,16 @@ describe("terminal guard", () => {
 
     expect(actual.filter(event => event.type === "heartbeat")).toHaveLength(50);
     expect(actual.filter(event => event.type === "done")).toHaveLength(1);
+  });
+
+  test("does not retain passthrough-only liveness or tool argument fragments", () => {
+    expect(isTerminalGuardPassthroughOnly({ type: "heartbeat" })).toBe(true);
+    expect(isTerminalGuardPassthroughOnly({
+      type: "tool_call_delta",
+      arguments: "x".repeat(1024 * 1024),
+    })).toBe(true);
+    expect(isTerminalGuardPassthroughOnly({ type: "tool_call_start", id: "call_1", name: "exec_command" })).toBe(false);
+    expect(isTerminalGuardPassthroughOnly({ type: "text_delta", text: "working" })).toBe(false);
   });
 
   test("stops after the configured continuation bound", async () => {


### PR DESCRIPTION
## Summary

- pass `heartbeat` and `tool_call_delta` events through the terminal guard without retaining them in its per-turn `seen` list
- keep semantic start/completion/text events available to continuation analysis and request rebuilding
- add a regression that classifies a 1 MiB tool-argument fragment as passthrough-only

## Why

`openai-chat` now emits liveness during buffered tool-call deltas. The terminal guard already stopped retaining heartbeats, but it still retained every `tool_call_delta`, duplicating arbitrarily large argument fragments in memory even though neither terminal analysis nor continuation rebuilding consumes those events.

This is the runtime fix behind the valid retention finding raised on #2181. It does not loosen EOF/tool-call safety or change continuation decisions.

## Verification

- `taskset -c 0,1 bun test tests/terminal-guard.test.ts` — 19 passed
- `taskset -c 0,1 bun run typecheck` — passed
- `taskset -c 0,1 bun run privacy:scan` — passed
- `git diff --check` — passed

Full-suite note: an earlier CPU-limited run reached unrelated environment failures (`react/jsx-dev-runtime` missing in a GUI suite and a 30-image native Claude test timing out under the two-core cap). The focused runtime suite and typecheck are green on the exact head.

## Integration note

This is TypeScript-only and has no current Go counterpart. Per maintainer policy, the author will not approve or merge this PR. Please review and merge only after exact-head CI is green.

Refs #2181


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal event handling so heartbeat signals and large tool-argument updates pass through without being retained in the per-turn event history.
  * Continued retaining tool-start and text-update events for consistent terminal behavior.

* **Tests**
  * Added coverage for passthrough and retained terminal event types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->