### PR TITLE
feat(sidecar): shared auth module with login-shaped flags and auth slots (#2188 L1)

### DIFF
--- a/devlog/_plan/260820_sidecar_selection_unification/000_unit_overview.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/000_unit_overview.md
@@ -1,0 +1,56 @@
+# 260820 — Sidecar selection unification (#2188)
+
+Roadmap for implementing issue #2188 as a stacked PR chain onto dev.
+Session 01a01f4b; goalplan implement-github-issue-2188-feat-sidecar-unify-w.
+
+## Docs
+- 000 (this file) — unit overview + stack map.
+- 000_wp0 — branch/worktree cleanup record (executed, closed).
+- 001 — research: current selection state at dev f2ebd3067.
+- 010 — Layer 1: src/sidecar/auth.ts shared auth + slots (branch codex/sidecar-auth-slots → dev).
+- 020 — Layer 2: src/sidecar/candidates.ts picker set + vision filter (codex/sidecar-picker-candidates → L1).
+- 030 — Layer 3: web-search backend registry + candidate ∩ (no default-backend change) (codex/sidecar-websearch-slots → L2).
+- 031 — future-backend research table + probe contracts (doc-only, inside L3 PR).
+- 040 — Layer 4: write gates + GUI lists (codex/sidecar-write-gates → L3).
+- 050 — Layer 5: ocx agent sidecar --list + docs-site + full validation (codex/sidecar-cli → L4).
+
+## Stack invariants (DEV-STACK)
+Bottom targets dev; each child targets the branch below. Merge bottom-up; retarget children after parent lands. Each layer: own tests green + typecheck before PR; full suite at top layer. Every A/C gate: xai/grok-4.6 read-only reviewer, verdict binding.
+
+## Out of scope (issue-fixed)
+Gemini/Grok/Zen/Exa executors, #2190 x_search, #398, types.ts-split rebases.
+
+
+## AMENDMENT 1 (post-audit, auditor Hegel VERDICT: fail — all four blockers accepted)
+
+### B1 — isCodexAuth must mean LOGIN, not provider presence (fixes 010)
+```ts
+// src/sidecar/auth.ts
+isCodexAuth = listOpenAiForwardSidecarCandidates(config).length > 0
+  && ( isCodexAccountUsable(config, MAIN_CODEX_ACCOUNT_ID)            // live ~/.codex auth.json token
+       || (config.codexAccounts ?? []).some(a => isSelectableCodexPoolAccount(a)
+             && isCodexAccountUsable(config, a.id)) )                  // any usable pool credential
+```
+Symmetric with the Anthropic predicate (stored OAuth + !needsReauth). Uses src/codex/account-usability.ts:17 isCodexAccountUsable; no header/request context needed. Test: forward provider present but no live token & no pool creds → isCodexAuth false → Luna slot absent.
+
+### B2 — extend ocx agent sidecar, do NOT add ocx sidecar (fixes 001 + 050)
+001 correction: src/cli/agent.ts:23 already ships `ocx agent sidecar <status|web|vision>` → PUT /api/sidecar-settings. Layer 5 extends it:
+- `ocx agent sidecar web --list` / `vision --list` print the exact candidate sets via a new GET consumer (same functions as GUI).
+- Writes already flow through the PUT gate added in L4 (server-side gate covers CLI automatically — the "CLI cannot bypass" property comes from gating the shared route, not from a parallel client check).
+- No new top-level command. 050's src/cli/sidecar.ts is WITHDRAWN.
+
+### B3 — claude-code webSearch write gate is REQUIRED in L4 (fixes 040)
+- src/server/management/agent-settings-routes.ts:1064 writes webSearchSidecar.model ungated → same membership gate as /api/sidecar-settings (shared helper in src/server/management/web-search-sidecar-options.ts, mirroring vision-sidecar-options.ts placement; extraction happens IN L4, so L5 never restacks routes — also resolves the L5 write-gate.ts smell).
+- `ocx claude config set --web-model` rides the same route → covered.
+- Out of scope (explicit): `ocx config set webSearchSidecar.model` raw JSON writes bypass management gates by design (operator escape hatch, same as vision today).
+- GUI contract: GET must send webSearchModels: [] when empty, never omit (dashboard-shared.ts:273 omission fallback would show the full union). Persisted-but-now-illegal model: display-grandfather into options (same as vision GET :115) but reject NEW writes.
+
+### B4 — default-backend decision split & pinned (fixes 030)
+- resolveSidecarBackend(explicit) keeps today's contract: unset → openai, no auth argument (web-search-anthropic.test.ts:58 assertion unchanged).
+- resolveVisionBackend keeps today's contract: unset → anthropic when OAuth credential exists.
+- The "전역 플래그로 맞춘다" issue sentence is satisfied by both resolvers CONSUMING resolveSidecarAuth for credential presence (shared auth state), NOT by unifying their default preference. Changing dual-auth default preference is a user-facing behavior change #2188 never ordered → OUT OF SCOPE, recorded for a follow-up issue.
+- L3 no longer touches src/vision/index.ts at all (removes the cross-surface smell).
+
+### Corrections
+- 001: isCodexAuthContextUsable is auth-context.ts:612.
+

--- a/devlog/_plan/260820_sidecar_selection_unification/000_wp0_branch_worktree_cleanup.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/000_wp0_branch_worktree_cleanup.md
@@ -1,0 +1,77 @@
+# WP0 cleanup plan (session 01a01f4b)
+## Protected (never touch): dev, main, preview, open-PR heads (31), dirty worktrees.
+## Worktrees to REMOVE (all clean; commit content preserved in dev or by a surviving branch):
+/private/tmp/ocx-m2148.LzD2/wt (absorb-baseurl-override, merged)
+/private/tmp/opencodex-pr2068.uXcKNC (detached 5a4068bbd, kept by branch pr2068-check, PR2068 OPEN -> branch kept)
+tmp.2IOChwQmxR/wp1b + tmp.t3YTdy1JDC/wp1b (detached b2ac2500c, superseded WP1b lineage; merged version a0f8c0135 in dev)
+tmp.bxVhqaJyPc/sweeper (tmp-reclaim-1-sweeper, merged)
+tmp.bzZ2ssU8WM/wp1b (split-wp1b-type-clusters, merged)
+tmp.gLNBuhAyoP (detached d0cd99672, merge of two dev ancestors, nothing unique)
+tmp.LfX0NlBXvp/r1876 (ingw/fix-windows-v2-catalog-blocking-1852, merged)
+tmp.Mb171xHMCb/r2031 (ingw/fix-mimo-vision-1927, merged)
+tmp.pQMnjf3VMg/wp1 (split-wp1-types, merged)
+tmp.UFYNSQT3qw/land1920 -> KEEP (DIRTY 2 changes + 3 unique commits)
+tmp.vSBe0MZ0LP/w2080 (pr2080, PR merged)
+tmp.xfjQ3jxADE/w1934 (pr1934, PR merged)
+~/.codex/worktrees/3a35 (devlog-release-2280, merged)
+~/.codex/worktrees/3b3b (cursor-call-release-note-2, merged, upstream gone)
+~/.codex/worktrees/648b -> KEEP (DIRTY 1 change)
+~/.codex/worktrees/71a2 -> KEEP (DIRTY 1 change; branch split-wp2a-config-names stays checked out)
+~/.codex/worktrees/83d5 (tmp-reclaim-2-doctor, merged)
+~/.codex/worktrees/c6d8 (zcode-client, merged)
+~/.codex/worktrees/fe69 (detached 63bfd149d, clean, reachable from many branches)
+.tmp/pr-2045-review (b92bb611c; PR2045 merged into dev as 0161a66d9)
+.tmp/pr1903-review-8c38989f4 (PR1903 merged; commit kept by remotes/review/pr1903)
+## Local branches DELETE - merged into origin/dev (git branch --merged proof):
+all 46 merged branches except: dev, split-wp2a-config-names (checked out in kept dirty worktree)
+## Local branches DELETE - unmerged but 0 unique patches vs dev (git cherry all '-'):
+absorb-account-entitlement-stacked, absorb-capability-evidence, absorb-k12-short-window, absorb-xai-oauth-streaming, consolidate-prompt-cache-retention, fix-bearer-admission-2132, land-1842 (PR closed), land-1876, ocx/integration, ocx/verify-2167
+## Local branches KEEP (unique commits or open PR):
+combo-quota-badges (PR1704 OPEN), compat-multiagent-v2-catalog (4u), devlog-merge-log (1u), devlog-three-issues (PR2181 OPEN), external-vision (1u), issue-quality-provider-defect-bug-label (1u), land-1920 (3u+dirty wt), cursor-call-prerebase-260818 (2u), ocx-dev-verify (1u), ocx/rebuild-2178 (1u), wip/* (unique), pr2053-check (2u), pr2056-check (1u), pr2068-check (PR OPEN), pr2072-check (PR OPEN), pr2101-probe (5u), pr2105tmp (3u), main, preview, dev
+## Remote branches DELETE (origin, merged into origin/dev, not an open-PR head): 37 listed in remote_deletable
+## Remote branches DELETE (unmerged, 0 unique, PR closed/merged): codex/absorb-account-entitlement-stacked, codex/absorb-capability-evidence, codex/absorb-k12-short-window, codex/absorb-xai-oauth-streaming, codex/consolidate-prompt-cache-retention, codex/fix-bearer-admission-2132, codex/land-1842, codex/land-1876
+
+
+## AMENDMENT 1 (post-audit synthesis, auditor Goodall VERDICT: fail)
+- BLOCKER FIX: before removing tmp.2IOChwQmxR/wp1b and tmp.t3YTdy1JDC/wp1b, create preservation branch wip/wp1b-superseded-b2ac2500c at b2ac2500c (unique cherry patches, no surviving ref). Superseded by a0f8c0135 in dev but preserved per no-data-loss rule.
+- FIX: add /Users/jun/.codex/worktrees/land-1842/opencodex to worktree REMOVE list (clean, PR #1842 CLOSED, 0 unique patches) so codex/land-1842 branch delete can proceed.
+- FIX: codex/merge-loop-closeout => KEEP (2 unique local commits).
+- DOC FIX: the 37 remote deletable branches are exactly:
+codex/absorb-agentrouter-language-framing
+codex/absorb-antigravity-thought-signatures
+codex/absorb-baseurl-override
+codex/absorb-claude-shell-hook-gate
+codex/absorb-fastwire-native-chat
+codex/absorb-oauth-superseded-commit
+codex/absorb-openai-chat-padding-repeats
+codex/absorb-opencode-free-static-headers
+codex/absorb-opencode-go-quota-siblings
+codex/absorb-responses-id-backfill
+codex/absorb-shadow-helper-attribution
+codex/absorb-tool-search-passthrough
+codex/audit-closeout
+codex/audit-record
+codex/audit-shadow-marker-leak
+codex/audit-tool-search-id
+codex/devlog-audit
+codex/devlog-release-2280
+codex/fix-admission-bearer-transport
+codex/fix-audit-record-scan
+codex/fix-privacy-scan-devlog
+codex/fix-subagent-roster-truncation
+codex/fix-windows-ci-shards
+codex/harden-core-lab-guard
+codex/logs-intercepted-helper-attribution
+codex/merge-loop-closeout
+codex/merge-loop-outcome
+codex/openai-chat-tool-call-heartbeat
+codex/promote-2.28.0
+codex/split-wp1-types
+codex/split-wp1b-type-clusters
+codex/split-wp2a-config-names
+codex/sync-preview-2.28.0
+codex/windows-shard-truncation-and-budgets
+ingw/docs-tool-search-troubleshooting-1872
+ingw/fix-mimo-vision-1927
+ingw/fix-windows-v2-catalog-blocking-1852
+

--- a/devlog/_plan/260820_sidecar_selection_unification/000_wp0_branch_worktree_cleanup.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/000_wp0_branch_worktree_cleanup.md
@@ -1,77 +1,106 @@
-# WP0 cleanup plan (session 01a01f4b)
-## Protected (never touch): dev, main, preview, open-PR heads (31), dirty worktrees.
-## Worktrees to REMOVE (all clean; commit content preserved in dev or by a surviving branch):
-/private/tmp/ocx-m2148.LzD2/wt (absorb-baseurl-override, merged)
-/private/tmp/opencodex-pr2068.uXcKNC (detached 5a4068bbd, kept by branch pr2068-check, PR2068 OPEN -> branch kept)
-tmp.2IOChwQmxR/wp1b + tmp.t3YTdy1JDC/wp1b (detached b2ac2500c, superseded WP1b lineage; merged version a0f8c0135 in dev)
-tmp.bxVhqaJyPc/sweeper (tmp-reclaim-1-sweeper, merged)
-tmp.bzZ2ssU8WM/wp1b (split-wp1b-type-clusters, merged)
-tmp.gLNBuhAyoP (detached d0cd99672, merge of two dev ancestors, nothing unique)
-tmp.LfX0NlBXvp/r1876 (ingw/fix-windows-v2-catalog-blocking-1852, merged)
-tmp.Mb171xHMCb/r2031 (ingw/fix-mimo-vision-1927, merged)
-tmp.pQMnjf3VMg/wp1 (split-wp1-types, merged)
-tmp.UFYNSQT3qw/land1920 -> KEEP (DIRTY 2 changes + 3 unique commits)
-tmp.vSBe0MZ0LP/w2080 (pr2080, PR merged)
-tmp.xfjQ3jxADE/w1934 (pr1934, PR merged)
-~/.codex/worktrees/3a35 (devlog-release-2280, merged)
-~/.codex/worktrees/3b3b (cursor-call-release-note-2, merged, upstream gone)
-~/.codex/worktrees/648b -> KEEP (DIRTY 1 change)
-~/.codex/worktrees/71a2 -> KEEP (DIRTY 1 change; branch split-wp2a-config-names stays checked out)
-~/.codex/worktrees/83d5 (tmp-reclaim-2-doctor, merged)
-~/.codex/worktrees/c6d8 (zcode-client, merged)
-~/.codex/worktrees/fe69 (detached 63bfd149d, clean, reachable from many branches)
-.tmp/pr-2045-review (b92bb611c; PR2045 merged into dev as 0161a66d9)
-.tmp/pr1903-review-8c38989f4 (PR1903 merged; commit kept by remotes/review/pr1903)
-## Local branches DELETE - merged into origin/dev (git branch --merged proof):
-all 46 merged branches except: dev, split-wp2a-config-names (checked out in kept dirty worktree)
-## Local branches DELETE - unmerged but 0 unique patches vs dev (git cherry all '-'):
-absorb-account-entitlement-stacked, absorb-capability-evidence, absorb-k12-short-window, absorb-xai-oauth-streaming, consolidate-prompt-cache-retention, fix-bearer-admission-2132, land-1842 (PR closed), land-1876, ocx/integration, ocx/verify-2167
-## Local branches KEEP (unique commits or open PR):
-combo-quota-badges (PR1704 OPEN), compat-multiagent-v2-catalog (4u), devlog-merge-log (1u), devlog-three-issues (PR2181 OPEN), external-vision (1u), issue-quality-provider-defect-bug-label (1u), land-1920 (3u+dirty wt), cursor-call-prerebase-260818 (2u), ocx-dev-verify (1u), ocx/rebuild-2178 (1u), wip/* (unique), pr2053-check (2u), pr2056-check (1u), pr2068-check (PR OPEN), pr2072-check (PR OPEN), pr2101-probe (5u), pr2105tmp (3u), main, preview, dev
-## Remote branches DELETE (origin, merged into origin/dev, not an open-PR head): 37 listed in remote_deletable
-## Remote branches DELETE (unmerged, 0 unique, PR closed/merged): codex/absorb-account-entitlement-stacked, codex/absorb-capability-evidence, codex/absorb-k12-short-window, codex/absorb-xai-oauth-streaming, codex/consolidate-prompt-cache-retention, codex/fix-bearer-admission-2132, codex/land-1842, codex/land-1876
+# WP0 cleanup — EXECUTED RECORD (session 01a01f4b, performed 2026-08-20)
 
+STATUS: HISTORICAL. Every deletion below was executed during wp0 and verified against
+live state afterwards (post-check 2026-08-21: 33 local branches remain, 0 deleted
+remote refs resurrected, 9 worktrees). Nothing in this file is a pending command.
+Anyone repeating a cleanup of this shape MUST run the preflight template at the end
+against CURRENT state first; this snapshot is not reusable as a target list.
 
-## AMENDMENT 1 (post-audit synthesis, auditor Goodall VERDICT: fail)
-- BLOCKER FIX: before removing tmp.2IOChwQmxR/wp1b and tmp.t3YTdy1JDC/wp1b, create preservation branch wip/wp1b-superseded-b2ac2500c at b2ac2500c (unique cherry patches, no surviving ref). Superseded by a0f8c0135 in dev but preserved per no-data-loss rule.
-- FIX: add /Users/jun/.codex/worktrees/land-1842/opencodex to worktree REMOVE list (clean, PR #1842 CLOSED, 0 unique patches) so codex/land-1842 branch delete can proceed.
-- FIX: codex/merge-loop-closeout => KEEP (2 unique local commits).
-- DOC FIX: the 37 remote deletable branches are exactly:
-codex/absorb-agentrouter-language-framing
-codex/absorb-antigravity-thought-signatures
-codex/absorb-baseurl-override
-codex/absorb-claude-shell-hook-gate
-codex/absorb-fastwire-native-chat
-codex/absorb-oauth-superseded-commit
-codex/absorb-openai-chat-padding-repeats
-codex/absorb-opencode-free-static-headers
-codex/absorb-opencode-go-quota-siblings
-codex/absorb-responses-id-backfill
-codex/absorb-shadow-helper-attribution
-codex/absorb-tool-search-passthrough
-codex/audit-closeout
-codex/audit-record
-codex/audit-shadow-marker-leak
-codex/audit-tool-search-id
-codex/devlog-audit
-codex/devlog-release-2280
-codex/fix-admission-bearer-transport
-codex/fix-audit-record-scan
-codex/fix-privacy-scan-devlog
-codex/fix-subagent-roster-truncation
-codex/fix-windows-ci-shards
-codex/harden-core-lab-guard
-codex/logs-intercepted-helper-attribution
-codex/merge-loop-closeout
-codex/merge-loop-outcome
-codex/openai-chat-tool-call-heartbeat
-codex/promote-2.28.0
-codex/split-wp1-types
-codex/split-wp1b-type-clusters
-codex/split-wp2a-config-names
-codex/sync-preview-2.28.0
-codex/windows-shard-truncation-and-budgets
-ingw/docs-tool-search-troubleshooting-1872
-ingw/fix-mimo-vision-1927
-ingw/fix-windows-v2-catalog-blocking-1852
+## Protected set (mechanical, applied before every batch)
 
+The protected set was computed mechanically, not by eye, and deletion aborted on any
+intersection: `dev`, `main`, `preview`, every open-PR head (31 at snapshot time),
+every branch checked out in any worktree, and every dirty worktree. KEEP entries
+below are the rows the protected set excluded from their surrounding batch.
+
+## Worktrees removed (were all clean; content preserved in dev or a surviving ref)
+
+- /private/tmp/ocx-m2148.LzD2/wt (absorb-baseurl-override, merged)
+- tmp.bxVhqaJyPc/sweeper (tmp-reclaim-1-sweeper, merged)
+- tmp.bzZ2ssU8WM/wp1b (split-wp1b-type-clusters, merged)
+- tmp.gLNBuhAyoP (detached d0cd99672, merge of two dev ancestors, nothing unique)
+- tmp.LfX0NlBXvp/r1876 (ingw/fix-windows-v2-catalog-blocking-1852, merged)
+- tmp.Mb171xHMCb/r2031 (ingw/fix-mimo-vision-1927, merged)
+- tmp.pQMnjf3VMg/wp1 (split-wp1-types, merged)
+- tmp.vSBe0MZ0LP/w2080 (pr2080, PR merged)
+- tmp.xfjQ3jxADE/w1934 (pr1934, PR merged)
+- tmp.2IOChwQmxR/wp1b + tmp.t3YTdy1JDC/wp1b (detached b2ac2500c) — removed ONLY
+  after preservation branch wip/wp1b-superseded-b2ac2500c was created at b2ac2500c
+  and verified (unique cherry patches; superseded by a0f8c0135 in dev).
+- ~/.codex/worktrees/3a35 (devlog-release-2280, merged)
+- ~/.codex/worktrees/3b3b (cursor-call-release-note-2, merged, upstream gone)
+- ~/.codex/worktrees/83d5 (tmp-reclaim-2-doctor, merged)
+- ~/.codex/worktrees/c6d8 (zcode-client, merged)
+- ~/.codex/worktrees/fe69 (detached 63bfd149d, clean, reachable from many branches)
+- ~/.codex/worktrees/land-1842 (clean, PR #1842 CLOSED, 0 unique patches)
+- .tmp/pr-2045-review (b92bb611c; PR2045 merged into dev as 0161a66d9)
+- .tmp/pr1903-review-8c38989f4 (PR1903 merged; commit kept by remotes/review/pr1903)
+
+## Worktrees kept (dirty or otherwise protected — never in a removal batch)
+
+- /private/tmp/opencodex-pr2068.uXcKNC (detached 5a4068bbd, kept by branch
+  pr2068-check; PR 2068 OPEN)
+- tmp.UFYNSQT3qw/land1920 (DIRTY, 2 changes + 3 unique commits)
+- ~/.codex/worktrees/648b (DIRTY, 1 change)
+- ~/.codex/worktrees/71a2 (DIRTY, 1 change; split-wp2a-config-names stays checked out)
+
+## Local branches deleted
+
+- Merged into origin/dev (git branch --merged proof at snapshot): all 46 merged
+  branches except dev and split-wp2a-config-names (checked out in a kept worktree).
+- Unmerged but 0 unique patches vs dev (git cherry all '-'):
+  absorb-account-entitlement-stacked, absorb-capability-evidence,
+  absorb-k12-short-window, absorb-xai-oauth-streaming,
+  consolidate-prompt-cache-retention, fix-bearer-admission-2132, land-1842
+  (PR closed), land-1876, ocx/integration, ocx/verify-2167.
+
+## Local branches kept (unique commits or open PR)
+
+combo-quota-badges (PR1704 OPEN), compat-multiagent-v2-catalog (4u), devlog-merge-log
+(1u), devlog-three-issues (PR2181 OPEN), external-vision (1u),
+issue-quality-provider-defect-bug-label (1u), land-1920 (3u+dirty wt),
+cursor-call-prerebase-260818 (2u), ocx-dev-verify (1u), ocx/rebuild-2178 (1u), wip/*
+(unique, incl. wip/wp1b-superseded-b2ac2500c), pr2053-check (2u), pr2056-check (1u),
+pr2068-check (PR OPEN), pr2072-check (PR OPEN), pr2101-probe (5u), pr2105tmp (3u),
+codex/merge-loop-closeout (2 unique local commits), main, preview, dev.
+
+## Remote branches deleted (origin)
+
+- 36 merged-into-origin/dev refs, none an open-PR head. The original 37-row list
+  mistakenly included codex/merge-loop-closeout; the executed batch EXCLUDED it (it
+  is a local-only KEEP with 2 unique commits and had no remote ref to delete):
+  codex/absorb-agentrouter-language-framing, codex/absorb-antigravity-thought-signatures,
+  codex/absorb-baseurl-override, codex/absorb-claude-shell-hook-gate,
+  codex/absorb-fastwire-native-chat, codex/absorb-oauth-superseded-commit,
+  codex/absorb-openai-chat-padding-repeats, codex/absorb-opencode-free-static-headers,
+  codex/absorb-opencode-go-quota-siblings, codex/absorb-responses-id-backfill,
+  codex/absorb-shadow-helper-attribution, codex/absorb-tool-search-passthrough,
+  codex/audit-closeout, codex/audit-record, codex/audit-shadow-marker-leak,
+  codex/audit-tool-search-id, codex/devlog-audit, codex/devlog-release-2280,
+  codex/fix-admission-bearer-transport, codex/fix-audit-record-scan,
+  codex/fix-privacy-scan-devlog, codex/fix-subagent-roster-truncation,
+  codex/fix-windows-ci-shards, codex/harden-core-lab-guard,
+  codex/logs-intercepted-helper-attribution, codex/merge-loop-outcome,
+  codex/openai-chat-tool-call-heartbeat, codex/promote-2.28.0, codex/split-wp1-types,
+  codex/split-wp1b-type-clusters, codex/split-wp2a-config-names,
+  codex/sync-preview-2.28.0, codex/windows-shard-truncation-and-budgets,
+  ingw/docs-tool-search-troubleshooting-1872, ingw/fix-mimo-vision-1927,
+  ingw/fix-windows-v2-catalog-blocking-1852
+- Unmerged, 0 unique, PR closed/merged: codex/absorb-account-entitlement-stacked,
+  codex/absorb-capability-evidence, codex/absorb-k12-short-window,
+  codex/absorb-xai-oauth-streaming, codex/consolidate-prompt-cache-retention,
+  codex/fix-bearer-admission-2132, codex/land-1842, codex/land-1876
+
+## Preflight template (mandatory for any future cleanup batch)
+
+Run immediately before EACH delete batch; abort the batch on any intersection:
+
+1. `git worktree list --porcelain` — collect checked-out branches + dirty worktrees.
+2. `gh pr list --state open --json headRefName` — collect every open-PR head.
+3. Protected = {dev, main, preview} ∪ open-PR heads ∪ checked-out ∪ dirty-worktree
+   branches. `comm -12` the sorted candidate list against sorted Protected; any
+   overlap aborts the whole batch, not just the row.
+4. For unmerged candidates, re-prove 0 unique patches with `git cherry dev <ref>`
+   at execution time; a snapshot proof is stale the moment the tree moves.
+5. Detached commits require a durable preservation ref (branch or tag) verified with
+   `git rev-parse` BEFORE the containing worktree is removed.

--- a/devlog/_plan/260820_sidecar_selection_unification/000_wp0_branch_worktree_cleanup.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/000_wp0_branch_worktree_cleanup.md
@@ -95,7 +95,11 @@ codex/merge-loop-closeout (2 unique local commits), main, preview, dev.
 
 Run immediately before EACH delete batch; abort the batch on any intersection:
 
-1. `git worktree list --porcelain` — collect checked-out branches + dirty worktrees.
+1. `git worktree list --porcelain` — collect worktree paths and checked-out branches
+   (this reports metadata only, NOT status). Then for EACH listed path run
+   `git -C <path> status --porcelain`; any output marks that worktree dirty.
+   Protect both the dirty path and its attached branch (detached dirty worktrees
+   protect the path itself).
 2. `gh pr list --state open --json headRefName` — collect every open-PR head.
 3. Protected = {dev, main, preview} ∪ open-PR heads ∪ checked-out ∪ dirty-worktree
    branches. `comm -12` the sorted candidate list against sorted Protected; any

--- a/devlog/_plan/260820_sidecar_selection_unification/000_wp0_branch_worktree_cleanup.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/000_wp0_branch_worktree_cleanup.md
@@ -101,9 +101,11 @@ Run immediately before EACH delete batch; abort the batch on any intersection:
    Protect both the dirty path and its attached branch (detached dirty worktrees
    protect the path itself).
 2. `gh pr list --state open --json headRefName` — collect every open-PR head.
-3. Protected = {dev, main, preview} ∪ open-PR heads ∪ checked-out ∪ dirty-worktree
-   branches. `comm -12` the sorted candidate list against sorted Protected; any
-   overlap aborts the whole batch, not just the row.
+3. Protected = {dev, main, preview} ∪ open-PR heads ∪ checked-out branches ∪
+   dirty-worktree branches ∪ dirty-worktree PATHS (a detached dirty worktree has
+   no branch — its path itself is the protected row). `comm -12` the sorted
+   candidate list against sorted Protected; any overlap aborts the whole batch,
+   not just the row.
 4. For unmerged candidates, re-prove 0 unique patches with `git cherry dev <ref>`
    at execution time; a snapshot proof is stale the moment the tree moves.
 5. Detached commits require a durable preservation ref (branch or tag) verified with

--- a/devlog/_plan/260820_sidecar_selection_unification/001_research_current_state.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/001_research_current_state.md
@@ -1,0 +1,46 @@
+# 001 — Research: current sidecar selection state (#2188)
+
+Verified against dev @ f2ebd3067 (2026-08-20).
+
+## Auth pieces (scattered today)
+- Codex/ChatGPT: `listOpenAiForwardSidecarCandidates` (src/providers/openai-sidecar.ts:56) — canonical forward provider, pinned baseUrl; `isCodexAuthContextUsable` (src/codex/auth-context.ts:613) — per-context account usability.
+- Anthropic: `findAnthropicSidecarProvider` (src/web-search/index.ts:87) and `findAnthropicVisionProvider` (src/vision/index.ts:219) — DUPLICATED predicate: enabled + adapter==="anthropic" + authMode==="oauth" + active account needsReauth!==true.
+
+## Backend resolution asymmetry (issue-confirmed)
+- Web-search `resolveSidecarBackend` (src/web-search/index.ts:104-108): explicit anthropic else openai. types/config.ts:787-796 comment claims "unset prefers anthropic" — WRONG vs code.
+- Vision `resolveVisionBackend` (src/vision/index.ts:231-236): unset prefers anthropic when credential exists. Opposite default.
+
+## Picker sets
+- `visibleNativeSlugs` (src/codex/catalog/metadata.ts:331): nativeOpenAiSlugs − disabled − alias-shadowed.
+- `listManagementModelRows` (src/server/management/model-rows.ts:50): native rows (incl. disabled, flagged) + account-bound + routed catalog rows.
+- `visionCandidateRows` (src/server/management/vision-sidecar-options.ts:45): rows.filter(disabled !== true) — close to picker policy but no auth-slot concept.
+
+## Vision candidate expansion defect
+- `visionEligibleModelOptions` (src/vision/eligibility.ts:201): iterates ALL passed candidates + baselines. Candidates from visionCandidateRows = full catalog (all providers' rows), not picker-limited native set; anthropic side gated only by provider name match.
+
+## Write gates
+- Vision: PUT /api/sidecar-settings (config-routes.ts:584) rejects via `visionDescriberIsProvablyBlind`. Claude-code override shares module.
+- Web-search: config-routes.ts:604-606 persists webSearch.model verbatim. NO GATE.
+
+## GUI
+- gui/src/pages/dashboard-overview-sections.tsx + use-dashboard-data.ts render webSearch/vision sidecar settings; GET /api/sidecar-settings returns visionModels options but NO webSearchModels options list.
+
+## CLI
+- No ocx sidecar command exists (src/cli/ has no sidecar.ts; only GUI/PUT paths).
+
+## Tests nearby
+tests/vision-eligibility.test.ts, tests/sidecar-settings-vision-filter.test.ts, tests/web-search.test.ts, tests/sidecar-settings-vision-controls.test.ts, tests/claude-sidecar-override.test.ts.
+
+## Executors that exist today (probe-relevant)
+- openai: src/web-search/executor.ts (ChatGPT forward /responses hosted web_search).
+- anthropic: src/web-search/anthropic-executor.ts (web_search_20250305 via OAuth Messages).
+- NO gemini/grok/zen/exa executor → per #2188 filter rule 2, only openai+anthropic can be active web-search backends in this unit.
+
+
+## CORRECTION (post-audit)
+- isCodexAuthContextUsable is src/codex/auth-context.ts:612 (not 613).
+- CLI: `ocx agent sidecar <status|web|vision>` ALREADY EXISTS (src/cli/agent.ts:23) writing PUT /api/sidecar-settings. The gap is only: no --list surface, and the PUT it calls has no web-search membership gate. "No ocx sidecar command exists" above is WRONG.
+- Additional ungated write path: PUT /api/claude-code writes webSearchSidecar.model verbatim (src/server/management/agent-settings-routes.ts:1064); `ocx claude config set --web-model` rides it.
+- GUI contract: dashboard-shared.ts:273 — an OMITTED visionModels key falls back to the full openai+anthropic union; [] means none. Any new webSearchModels key must always be present.
+- GET /api/sidecar-settings grandfathers the persisted vision model into options (config-routes.ts:115).
+

--- a/devlog/_plan/260820_sidecar_selection_unification/002_protocol_research.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/002_protocol_research.md
@@ -1,0 +1,42 @@
+# 002 — Hosted web-search protocol research (규약, verified 2026-08-20)
+
+Luna swarm (5 lanes) + primary-source verification. All findings below were source-opened (official docs) unless flagged lead. Supersedes the doc-only table in 031 with verified wire contracts.
+
+## OpenAI Responses (current openai backend)
+- Tool: `{"type":"web_search"}` (legacy: web_search_preview; preview models gpt-4o-*-search-preview shut down 2026-07-23).
+- Output item `web_search_call`, id prefix `ws_`; action.type ∈ search|open_page|find_in_page; sources via include: ["web_search_call.action.sources"].
+- filters.allowed_domains / blocked_domains ≤ 100 each (web_search only, not preview); external_web_access toggle.
+- SSE: response.web_search_call.in_progress|searching|completed (item_id, output_index, sequence_number).
+- $10/1k calls (+ content tokens). [developers.openai.com web-search guide; platform pricing]
+
+## Anthropic Messages (current anthropic backend)
+- Tool versions: web_search_20250305 (basic, direct-call default, ZDR-eligible), web_search_20260209 (dynamic filtering via code_execution_20260120; allowed_callers defaults to code-exec — direct use requires allowed_callers:["direct"]), web_search_20260318 (response-inclusion control). 20250305 NOT deprecated.
+- Blocks: server_tool_use (id prefix srvtoolu_) → web_search_tool_result (tool_use_id pairing); encrypted_content MUST be replayed unchanged in continuations or 400.
+- SSE: content_block_start(server_tool_use) → input_json_delta → content_block_stop → content_block_start(web_search_tool_result); usage server_tool_use.web_search_requests in message_delta.
+- max_uses cap → web_search_tool_result_error(max_uses_exceeded); org-level enablement required else 400.
+- NOT on Bedrock; Vertex basic-only. $10/1k searches, failures unbilled. [platform.claude.com web-search-tool, server-tools, streaming]
+
+## xAI Grok Responses (future backend candidate)
+- POST api.x.ai/v1/responses; tools `{"type":"web_search"}` / `{"type":"x_search"}`; output items web_search_call / x_search_call (server-executed, NOT function_call).
+- web_search: filters.allowed_domains ≤ 5, allowed/excluded mutually exclusive. x_search: allowed_x_handles ≤ 20 on tool object (NOT nested under filters).
+- include: web_search_call.action.sources documented; x_search_call sources selector UNDOCUMENTED → live probe required. Id prefixes undocumented → treat opaque, live probe required (matches #2190).
+- Responses SSE event names NOT documented (only SDK chunk.tool_calls) → probe required before relay implementation.
+- Live Search: no formal deprecation notice found (issue #2188 text says 2026-01 deprecate — docs do not confirm; treat as legacy either way). $5/1k per tool. [docs.x.ai tools/*, pricing, release-notes]
+
+## Google Gemini (future backend candidate)
+- Legacy generateContent: tools [{google_search: {}}] (older models: google_search_retrieval); response candidates[].groundingMetadata {webSearchQueries, searchEntryPoint.renderedContent, groundingChunks[].web{uri,title}, groundingSupports[].segment+groundingChunkIndices}. Chunk indices accumulate across stream.
+- Interactions API: tools [{type:"google_search"}]; steps google_search_call (id ex. search_call_19201, arguments.queries[], search_type web_search|image_search|enterprise_web_search, optional signature) → google_search_result (call_id) → model_output with inline URL annotations. SSE: interaction.created, step.start|delta|stop, interaction.completed, done.
+- Stateless clients must replay id + encrypted signature manually. Tool-choice: validated mode required with tool-context circulation; auto unsupported.
+- Auth x-goog-api-key; standard-key support ends 2026-09. Pricing: Gemini 3.x 5,000 free searches/mo then $14/1k per actual query; ≤2.5 models $35/1k per grounded prompt. [ai.google.dev grounding, interactions-api, pricing]
+
+## Non-LLM vendors (Exa-class lane, #414)
+- Exa: POST api.exa.ai/search, x-api-key or Bearer; {query, type, numResults, contents} → {requestId, results[{title,url,id,publishedDate,text/highlights/summary}], costDollars}. SSE only with outputSchema (OpenAI chat-chunk shaped).
+- Tavily: POST api.tavily.com/search, Bearer tvly-*; plain JSON, no SSE. $0.008/credit.
+- Brave: GET api.search.brave.com/res/v1/web/search, X-Subscription-Token; plain JSON. $5/1k.
+- OpenCode upstream now uses MCP JSON-RPC (mcp.exa.ai/mcp, search.parallel.ai/mcp; tools/call name="web_search") — NOT a Responses hosted tool. Zen /zen/go/v1/responses hosted web_search: LEAD ONLY, inconsistent SSE observed, {"type":"remote_tool"} rejected by backend; #1616's probe claim needs fresh re-verification before any Zen backend work.
+
+## Consequences for this unit
+1. 031's future-descriptor probe contracts updated by this doc (xAI/Gemini both need live probes for SSE + id shapes; Zen demoted to lead).
+2. Anthropic executor (anthropic-executor.ts) currently pins web_search_20250305 — fine (not deprecated, ZDR-eligible, direct default). Upgrading to 20260209 would REQUIRE allowed_callers:["direct"] — record as follow-up, not this unit.
+3. encrypted_content replay + srvtoolu_ pairing are existing executor obligations — verify tests cover replay-unchanged before touching anthropic paths in L3.
+

--- a/devlog/_plan/260820_sidecar_selection_unification/010_layer1_sidecar_auth.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/010_layer1_sidecar_auth.md
@@ -1,0 +1,40 @@
+# 010 — Layer 1: shared sidecar auth module (wp2)
+
+Branch: codex/sidecar-auth-slots (base: dev). PR bottom of stack, targets dev.
+
+## New file: src/sidecar/auth.ts
+```ts
+export interface SidecarAuthState {
+  isCodexAuth: boolean;      // ChatGPT LOGIN usable (not mere provider presence)
+  isAnthropicAuth: boolean;  // enabled anthropic-adapter OAuth provider w/ active !needsReauth account
+  anthropicProviderName?: string;
+  anthropicProvider?: OcxProviderConfig;
+}
+export function resolveSidecarAuth(config: OcxConfig): SidecarAuthState
+// isCodexAuth = listOpenAiForwardSidecarCandidates(config).length > 0
+//   && ( isCodexAccountUsable(config, MAIN_CODEX_ACCOUNT_ID)          // live ~/.codex/auth.json token
+//        || (config.codexAccounts ?? []).some(a =>
+//              isSelectableCodexPoolAccount(a) && isCodexAccountUsable(config, a.id)) )
+// (src/codex/account-usability.ts:17 — request-context-free, symmetric with Anthropic)
+// isAnthropicAuth + provider = the shared predicate now duplicated in
+//   findAnthropicSidecarProvider (web-search/index.ts:87) and findAnthropicVisionProvider (vision/index.ts:219)
+
+export const AUTH_SLOT_MODELS = { codex: "gpt-5.6-luna", anthropic: "claude-haiku-4-5" } as const;
+export function sidecarAuthSlots(auth: SidecarAuthState): Array<{ provider: string; id: string; slot: "codex" | "anthropic" }>
+// codex slot when isCodexAuth; anthropic slot (provider = anthropicProviderName) when isAnthropicAuth
+```
+
+## Refactors (behavior-preserving)
+- src/web-search/index.ts: findAnthropicSidecarProvider delegates to resolveSidecarAuth (keep export).
+- src/vision/index.ts: findAnthropicVisionProvider delegates likewise.
+- No caller behavior change in this layer.
+
+## Tests: tests/sidecar-auth.test.ts
+- isCodexAuth FALSE when forward provider exists but no live main token and no usable pool account (the B1 pin).
+- isCodexAuth TRUE with live main token; TRUE with usable selectable pool credential only.
+- isAnthropicAuth false when: disabled, wrong adapter, key auth, needsReauth active account, no account set.
+- Slots: hidden/disabled Luna & Haiku still emitted when auth present (core #2188 invariant).
+- Delegation equivalence for both find* helpers.
+
+## Verify: bun x tsc --noEmit && bun test tests/sidecar-auth.test.ts tests/web-search.test.ts tests/vision-eligibility.test.ts
+

--- a/devlog/_plan/260820_sidecar_selection_unification/020_layer2_picker_candidates.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/020_layer2_picker_candidates.md
@@ -1,0 +1,27 @@
+# 020 — Layer 2: unified picker candidate function + vision set (wp3)
+
+Branch: codex/sidecar-picker-candidates (base: codex/sidecar-auth-slots).
+
+## New file: src/sidecar/candidates.ts
+```ts
+export interface SidecarCandidate { provider: string; id: string; native?: boolean; inputModalities?: string[]; authSlot?: boolean }
+export async function pickerVisibleSidecarCandidates(config: OcxConfig, auth: SidecarAuthState): Promise<SidecarCandidate[]>
+// = listManagementModelRows(config).filter(disabled !== true)  (catalog outage → [])
+//   ∪ sidecarAuthSlots(auth) marked authSlot: true (added even when hidden/disabled/absent)
+// de-dup by provider+id; auth-slot flag wins.
+export function visionSidecarCandidates(config, all: SidecarCandidate[]): SidecarCandidate[]
+// = all − provably text-only (modelAcceptsImageInput(config, c) === false)
+// auth slots carry inputModalities ["text","image"] like baselineCandidate today.
+```
+
+## Changes
+- src/server/management/vision-sidecar-options.ts: visionCandidateRows → wrapper over pickerVisibleSidecarCandidates (keeps export shape); visionModelOptionsFrom feeds visionEligibleModelOptions ONLY picker-visible+auth-slot candidates. Baseline injection in visionEligibleModelOptions stays but baselines == auth slots when auth present; without auth, current baseline fallback preserved (no regression for fresh installs).
+- Keep visionDescriberIsProvablyBlind gate semantics unchanged (write gate ≠ suggestion list).
+
+## Tests: tests/sidecar-candidates.test.ts (+ update sidecar-settings-vision-filter.test.ts)
+- Hidden native slug (disabledModels) disappears from options; Luna survives via auth slot.
+- Routed provider's catalog row visible in rows appears; text-only proven row excluded.
+- Catalog outage → auth slots + baselines only.
+
+## Verify: bun x tsc --noEmit && bun test tests/sidecar-candidates.test.ts tests/sidecar-settings-vision-filter.test.ts tests/vision-eligibility.test.ts tests/catalog-vision-sidecar-modalities.test.ts
+

--- a/devlog/_plan/260820_sidecar_selection_unification/030_layer3_websearch_slots.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/030_layer3_websearch_slots.md
@@ -1,0 +1,33 @@
+# 030 — Layer 3: web-search candidate set + backend registry (wp4)
+
+Branch: codex/sidecar-websearch-slots (base: codex/sidecar-picker-candidates).
+
+## New file: src/web-search/backends.ts (probe/executor registry)
+```ts
+export interface WebSearchBackendDescriptor {
+  backend: "openai" | "anthropic";
+  hasExecutor: true;
+  probe: "chatgpt-forward" | "anthropic-oauth"; // auth presence == probe for these two
+  eligibleModel(candidate: SidecarCandidate): boolean;
+}
+export const WEB_SEARCH_BACKENDS: WebSearchBackendDescriptor[]  // openai + anthropic only (001/002: no other executor)
+export function webSearchSidecarCandidates(config, auth, all: SidecarCandidate[]): SidecarCandidate[]
+// = (picker-visible ∪ auth slots) ∩ (backend active: auth flag true + executor exists + model family matches)
+// openai backend: native rows + Luna slot; anthropic backend: anthropicProviderName rows + Haiku slot.
+```
+Future backends (Gemini/Grok/Zen/Exa): descriptor probe contracts recorded in 002/031; NOT registered.
+
+## Config/docs alignment (NO default-behavior change — B4)
+- src/types/config.ts:787-796: fix the lying comment to match code ("unset resolves to openai").
+- resolveSidecarBackend keeps EXACT contract: unset → openai, explicit-only anthropic (web-search-anthropic.test.ts:58 assertion UNTOUCHED).
+- resolveVisionBackend UNTOUCHED (unset → anthropic-if-credential). L3 does NOT edit src/vision/index.ts.
+- planWebSearch consumes resolveSidecarAuth for credential presence (replacing its inline findAnthropicSidecarProvider call) — presence only, not preference. resolveDefaultSidecarBackend is WITHDRAWN; dual-auth preference unification deferred to a follow-up issue.
+- DEFAULT_SIDECAR_MODEL stays gpt-5.6-luna; DEFAULT_ANTHROPIC_SIDECAR_MODEL stays claude-sonnet-5; auth SLOTS stay Luna/Haiku (issue text).
+
+## Tests: tests/web-search-candidates.test.ts
+- No Codex login (provider present, no token) → openai side inactive → native rows + Luna absent; Haiku present when anthropic auth.
+- Hidden Luna + Codex login → present. Model outside both backend families → absent.
+- resolveSidecarBackend(undefined) === "openai" still green (existing test untouched).
+
+## Verify: bun x tsc --noEmit && bun test tests/web-search-candidates.test.ts tests/web-search.test.ts tests/web-search-anthropic.test.ts
+

--- a/devlog/_plan/260820_sidecar_selection_unification/031_future_backend_research.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/031_future_backend_research.md
@@ -1,0 +1,13 @@
+# 031 — Future web-search backend research table (doc-only)
+
+Recorded from issue #2188 research (2026-08-20, docs not live probes). These are NOT registered backends; each needs live probe + executor before entering WEB_SEARCH_BACKENDS (filter rule 2).
+
+| Candidate | Protocol | Tool/endpoint | Probe contract before activation |
+| --- | --- | --- | --- |
+| Gemini | Gemini/Interactions | google_search grounding | API-key probe: grounding metadata + citations round-trip; simultaneous-tool limit check |
+| xAI Grok | Responses | { type: "web_search" } | api.x.ai key probe: 200 + web_search_call item + allowed_domains behavior |
+| OpenCode Zen | Responses | hosted web_search | POST …/zen/go/v1/responses probe (#1616 evidence 2026-08-13) re-verified fresh |
+| Exa-class vendors | own Search API | JSON → SidecarOutcome mapping | not an LLM; separate lane from hosted-tool probes (#414) |
+
+Each future descriptor must state: probe fn, executor module, eligibleModel predicate, id/citation wire mapping. Until then the union in config stays "openai" | "anthropic".
+

--- a/devlog/_plan/260820_sidecar_selection_unification/040_layer4_write_gates_gui.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/040_layer4_write_gates_gui.md
@@ -1,0 +1,26 @@
+# 040 — Layer 4: management API write gates + GUI lists (wp5)
+
+Branch: codex/sidecar-write-gates (base: codex/sidecar-websearch-slots).
+
+## New file: src/server/management/web-search-sidecar-options.ts (extraction happens HERE, not L5)
+- webSearchModelOptionsFor(config): candidate option list from webSearchSidecarCandidates.
+- webSearchModelIsRejected(config, requested): membership gate — reject when requested is neither a candidate nor an auth-slot model; empty string always allowed (clears).
+- Shared by BOTH routes below (mirrors vision-sidecar-options.ts pattern).
+
+## Server
+- config-routes.ts GET /api/sidecar-settings: add webSearchModels — ALWAYS present, [] when empty (dashboard-shared.ts:273 omission fallback). Display-grandfather the persisted model into options (parity with vision GET :115) while rejecting NEW illegal writes.
+- PUT /api/sidecar-settings webSearch.model: 400 with error naming the filter when webSearchModelIsRejected.
+- PUT /api/claude-code (agent-settings-routes.ts:1064): SAME gate, REQUIRED — covers ocx claude config set --web-model.
+- Out of scope (explicit): ocx config set webSearchSidecar.model raw JSON writes (operator escape hatch, same as vision).
+- Vision PUT unchanged (provably-blind gate stays).
+
+## GUI
+- use-dashboard-data.ts / dashboard-overview-sections.tsx: web-search model select consumes webSearchModels; [] renders empty-state, not full union.
+- gui screenshot REQUIRED in PR body (enforce-target).
+
+## Tests
+- new tests/sidecar-settings-web-search-gate.test.ts: PUT rejected for non-candidate; accepted for candidate + auth-slot; empty clears; claude-code route rejects the same id (今日 persists "claude-search" — update that fixture); GET always carries webSearchModels key.
+- bun run lint:gui.
+
+## Verify: bun x tsc --noEmit && bun test tests/sidecar-settings-web-search-gate.test.ts tests/sidecar-settings-vision-controls.test.ts tests/claude-sidecar-override.test.ts && bun run lint:gui
+

--- a/devlog/_plan/260820_sidecar_selection_unification/050_layer5_cli_and_final.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/050_layer5_cli_and_final.md
@@ -1,0 +1,18 @@
+# 050 — Layer 5: CLI --list + docs + top-layer full validation (wp6)
+
+Branch: codex/sidecar-cli (base: codex/sidecar-write-gates).
+
+## CLI (extend EXISTING command — no new top-level command; src/cli/sidecar.ts WITHDRAWN)
+- src/cli/agent.ts `ocx agent sidecar <status|web|vision>` gains `--list`: prints the candidate sets from GET /api/sidecar-settings (webSearchModels / visionModels) — the exact sets the GUI sees, produced by the same server functions.
+- Parse --list BEFORE the existing rejectArgs call (auditor note).
+- Writes need no client-side gate: L4's server-side gate on the shared PUT covers CLI automatically.
+
+## Docs
+- docs-site: web-search + vision pages updated (selection rules, auth slots, --list). English source only.
+
+## Final verification (top layer)
+- bun run typecheck && bun run test (FULL suite) && bun run privacy:scan && bun run lint:gui
+- gh pr list chain state recorded in goalplan c7.
+
+## Tests: extend existing CLI/agent tests for --list output parity with GET payload.
+

--- a/src/sidecar/auth.ts
+++ b/src/sidecar/auth.ts
@@ -1,0 +1,91 @@
+/**
+ * The one place that decides whether a sidecar may treat ChatGPT or Anthropic
+ * auth as PRESENT (#2188). Web-search and vision consumed two hand-rolled
+ * copies of the Anthropic predicate and no Codex-login predicate at all —
+ * provider presence was standing in for "logged in", which let a fresh install
+ * with the built-in forward provider but no credential offer Luna as a
+ * describer it could never run.
+ *
+ * Both flags are request-context-free: they read config plus the stored
+ * account state, never headers. Per-request usability (exact accounts,
+ * generation fences) stays in resolveFirstUsableOpenAiSidecar and the
+ * executors; this module only answers "is this side worth offering at all?".
+ */
+import type { OcxConfig, OcxProviderConfig } from "../types";
+import { listOpenAiForwardSidecarCandidates } from "../providers/openai-sidecar";
+import { isCodexAccountUsable } from "../codex/account-usability";
+import { MAIN_CODEX_ACCOUNT_ID, isSelectableCodexPoolAccount } from "../codex/account-id";
+import { getAccountSet } from "../oauth/store";
+
+export interface SidecarAuthState {
+  /** ChatGPT login usable: canonical forward provider AND a live stored credential. */
+  isCodexAuth: boolean;
+  /** Enabled anthropic-adapter OAuth provider whose active account is not marked for reauth. */
+  isAnthropicAuth: boolean;
+  /** The provider an Anthropic-side executor would dispatch through, when isAnthropicAuth. */
+  anthropicProviderName?: string;
+  anthropicProvider?: OcxProviderConfig;
+}
+
+/**
+ * Fixed auth-slot models (#2188): logged-in sides keep these candidates even
+ * when the picker hides or disables them. The slot is the LOGIN's entitlement,
+ * not the catalog's.
+ */
+export const AUTH_SLOT_MODELS = {
+  codex: "gpt-5.6-luna",
+  anthropic: "claude-haiku-4-5",
+} as const;
+
+export interface SidecarAuthSlot {
+  provider: string;
+  id: string;
+  slot: keyof typeof AUTH_SLOT_MODELS;
+}
+
+/** Login-shaped, not provider-shaped: a forward provider with no credential is NOT Codex auth. */
+function hasUsableCodexLogin(config: OcxConfig): boolean {
+  if (listOpenAiForwardSidecarCandidates(config).length === 0) return false;
+  if (isCodexAccountUsable(config, MAIN_CODEX_ACCOUNT_ID)) return true;
+  return (config.codexAccounts ?? []).some(account =>
+    isSelectableCodexPoolAccount(account) && isCodexAccountUsable(config, account.id));
+}
+
+/**
+ * The predicate previously duplicated as findAnthropicSidecarProvider
+ * (web-search) and findAnthropicVisionProvider (vision): first enabled
+ * anthropic-adapter OAuth provider whose ACTIVE stored account holds a usable
+ * credential. getAccountSet + needsReauth, not getCredential — a terminally
+ * invalid account must not present as auth (audit F1).
+ */
+function findAnthropicAuthProvider(
+  config: OcxConfig,
+): { providerName: string; provider: OcxProviderConfig } | undefined {
+  for (const [providerName, provider] of Object.entries(config.providers)) {
+    if (provider.disabled === true) continue;
+    if (provider.adapter !== "anthropic" || provider.authMode !== "oauth") continue;
+    const set = getAccountSet(providerName);
+    const active = set?.accounts.find(account => account.id === set.activeAccountId);
+    if (active && active.needsReauth !== true) return { providerName, provider };
+  }
+  return undefined;
+}
+
+export function resolveSidecarAuth(config: OcxConfig): SidecarAuthState {
+  const anthropic = findAnthropicAuthProvider(config);
+  return {
+    isCodexAuth: hasUsableCodexLogin(config),
+    isAnthropicAuth: anthropic !== undefined,
+    ...(anthropic ? { anthropicProviderName: anthropic.providerName, anthropicProvider: anthropic.provider } : {}),
+  };
+}
+
+/** The auth-entitled fixed candidates. Emitted regardless of picker visibility. */
+export function sidecarAuthSlots(auth: SidecarAuthState): SidecarAuthSlot[] {
+  const slots: SidecarAuthSlot[] = [];
+  if (auth.isCodexAuth) slots.push({ provider: "openai", id: AUTH_SLOT_MODELS.codex, slot: "codex" });
+  if (auth.isAnthropicAuth && auth.anthropicProviderName) {
+    slots.push({ provider: auth.anthropicProviderName, id: AUTH_SLOT_MODELS.anthropic, slot: "anthropic" });
+  }
+  return slots;
+}

--- a/src/sidecar/auth.ts
+++ b/src/sidecar/auth.ts
@@ -13,6 +13,7 @@
  */
 import type { OcxConfig, OcxProviderConfig } from "../types";
 import { listOpenAiForwardSidecarCandidates } from "../providers/openai-sidecar";
+import { OPENAI_CODEX_PROVIDER_ID } from "../providers/openai-tiers";
 import { isCodexAccountUsable } from "../codex/account-usability";
 import { MAIN_CODEX_ACCOUNT_ID, isSelectableCodexPoolAccount } from "../codex/account-id";
 import { getAccountSet } from "../oauth/store";
@@ -83,7 +84,7 @@ export function resolveSidecarAuth(config: OcxConfig): SidecarAuthState {
 /** The auth-entitled fixed candidates. Emitted regardless of picker visibility. */
 export function sidecarAuthSlots(auth: SidecarAuthState): SidecarAuthSlot[] {
   const slots: SidecarAuthSlot[] = [];
-  if (auth.isCodexAuth) slots.push({ provider: "openai", id: AUTH_SLOT_MODELS.codex, slot: "codex" });
+  if (auth.isCodexAuth) slots.push({ provider: OPENAI_CODEX_PROVIDER_ID, id: AUTH_SLOT_MODELS.codex, slot: "codex" });
   if (auth.isAnthropicAuth && auth.anthropicProviderName) {
     slots.push({ provider: auth.anthropicProviderName, id: AUTH_SLOT_MODELS.anthropic, slot: "anthropic" });
   }

--- a/src/vision/index.ts
+++ b/src/vision/index.ts
@@ -7,7 +7,7 @@ import { describeImage, type DescribeOutcome, type VisionSettings } from "./desc
 import { describeImageAnthropic } from "./anthropic-describe";
 import { normalizeVisionReasoningForModel } from "./reasoning";
 import type { CodexAuthContext } from "../codex/auth-context";
-import { getAccountSet } from "../oauth/store";
+import { resolveSidecarAuth } from "../sidecar/auth";
 import type { ResolvedOpenAiForwardSidecar } from "../providers/openai-sidecar";
 import type { SidecarOutcomeRecorder } from "../web-search/executor";
 import { enforceAppOwnedMemoryBudget } from "../lib/app-owned-memory";
@@ -215,15 +215,14 @@ export interface AnthropicVisionProvider {
   provider: OcxProviderConfig;
 }
 
-/** First enabled Anthropic OAuth provider whose active stored account is not marked for reauth. */
+/**
+ * First enabled Anthropic OAuth provider whose active stored account is not marked for reauth.
+ * Delegates to the shared sidecar auth module (#2188) — same predicate as web-search.
+ */
 export function findAnthropicVisionProvider(config: OcxConfig): AnthropicVisionProvider | undefined {
-  for (const [providerName, provider] of Object.entries(config.providers)) {
-    if (provider.disabled === true || provider.adapter !== "anthropic" || provider.authMode !== "oauth") continue;
-    const accountSet = getAccountSet(providerName);
-    const active = accountSet?.accounts.find(account => account.id === accountSet.activeAccountId);
-    if (active && active.needsReauth !== true) return { providerName, provider };
-  }
-  return undefined;
+  const auth = resolveSidecarAuth(config);
+  if (!auth.isAnthropicAuth || !auth.anthropicProviderName || !auth.anthropicProvider) return undefined;
+  return { providerName: auth.anthropicProviderName, provider: auth.anthropicProvider };
 }
 
 export function resolveVisionBackend(

--- a/src/web-search/index.ts
+++ b/src/web-search/index.ts
@@ -3,7 +3,7 @@ import { modelInList, toolChoiceToolPredicate } from "../types";
 import { isModelTextOnly } from "../vision";
 import type { SidecarSettings } from "./executor";
 import type { ResolvedOpenAiForwardSidecar } from "../providers/openai-sidecar";
-import { getAccountSet } from "../oauth/store";
+import { resolveSidecarAuth } from "../sidecar/auth";
 import { DEFAULT_STALL_TIMEOUT_SEC } from "../stall-timeout";
 import { buildWebSearchTool, extractHostedWebSearch, WEB_SEARCH_TOOL_NAME } from "./synthetic-tool";
 
@@ -83,16 +83,13 @@ export interface AnthropicSidecarProvider {
  * only path that can run web_search_20250305 without a ChatGPT forward provider. Presence is decided by
  * getAccountSet + the active account's `needsReauth` marker (audit F1: getCredential alone can pick a
  * terminally-invalid account); token refresh happens later at executor time.
+ * Delegates to the shared sidecar auth module (#2188) so web-search and vision
+ * cannot drift on what "Anthropic auth present" means.
  */
 export function findAnthropicSidecarProvider(config: OcxConfig): AnthropicSidecarProvider | undefined {
-  for (const [name, prov] of Object.entries(config.providers)) {
-    if (prov.disabled === true) continue;
-    if (prov.adapter !== "anthropic" || prov.authMode !== "oauth") continue;
-    const set = getAccountSet(name);
-    const active = set?.accounts.find(a => a.id === set.activeAccountId);
-    if (active && active.needsReauth !== true) return { providerName: name, provider: prov };
-  }
-  return undefined;
+  const auth = resolveSidecarAuth(config);
+  if (!auth.isAnthropicAuth || !auth.anthropicProviderName || !auth.anthropicProvider) return undefined;
+  return { providerName: auth.anthropicProviderName, provider: auth.anthropicProvider };
 }
 
 /**

--- a/tests/sidecar-auth.test.ts
+++ b/tests/sidecar-auth.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import * as storeModule from "../src/oauth/store";
+import * as usabilityModule from "../src/codex/account-usability";
+
+// The shared auth module reads two stores: the OAuth account store (Anthropic
+// side) and the Codex account credential state (ChatGPT side). Both are mocked
+// at module level so no test touches disk.
+let accountSets: Record<string, { accounts: Array<{ id: string; needsReauth?: boolean }>; activeAccountId?: string }> = {};
+let usableCodexAccounts: Set<string> = new Set();
+
+mock.module("../src/oauth/store", () => ({
+  ...storeModule,
+  getAccountSet: (provider: string) => accountSets[provider] ?? null,
+}));
+mock.module("../src/codex/account-usability", () => ({
+  ...usabilityModule,
+  isCodexAccountUsable: (_config: unknown, accountId: string) => usableCodexAccounts.has(accountId),
+}));
+
+import { AUTH_SLOT_MODELS, resolveSidecarAuth, sidecarAuthSlots } from "../src/sidecar/auth";
+import { findAnthropicSidecarProvider } from "../src/web-search";
+import { findAnthropicVisionProvider } from "../src/vision";
+import { MAIN_CODEX_ACCOUNT_ID } from "../src/codex/account-id";
+import type { OcxConfig, OcxProviderConfig } from "../src/types";
+
+const forward: OcxProviderConfig = { adapter: "openai-responses", baseUrl: "https://chatgpt.com/backend-api/codex", authMode: "forward" };
+const anthropicOAuth: OcxProviderConfig = { adapter: "anthropic", baseUrl: "https://api.anthropic.com", authMode: "oauth" };
+
+function config(overrides: Partial<OcxConfig> = {}): OcxConfig {
+  return { port: 10100, defaultProvider: "openai", providers: { openai: forward }, ...overrides };
+}
+
+afterEach(() => {
+  accountSets = {};
+  usableCodexAccounts = new Set();
+});
+
+describe("isCodexAuth is login-shaped, not provider-shaped", () => {
+  test("forward provider present but no live token and no pool account -> false (B1 pin)", () => {
+    expect(resolveSidecarAuth(config()).isCodexAuth).toBe(false);
+  });
+
+  test("live main token -> true", () => {
+    usableCodexAccounts.add(MAIN_CODEX_ACCOUNT_ID);
+    expect(resolveSidecarAuth(config()).isCodexAuth).toBe(true);
+  });
+
+  test("usable selectable pool credential alone -> true", () => {
+    usableCodexAccounts.add("acct-1");
+    const cfg = config({ codexAccounts: [{ id: "acct-1", label: "one" } as never] });
+    expect(resolveSidecarAuth(cfg).isCodexAuth).toBe(true);
+  });
+
+  test("credential without a canonical forward provider -> false", () => {
+    usableCodexAccounts.add(MAIN_CODEX_ACCOUNT_ID);
+    const keyed: OcxProviderConfig = { adapter: "openai-responses", baseUrl: "https://other.test/v1", authMode: "key", apiKey: "k" };
+    const cfg = config({ providers: { openai: keyed } });
+    expect(resolveSidecarAuth(cfg).isCodexAuth).toBe(false);
+  });
+});
+
+describe("isAnthropicAuth mirrors the stored-OAuth predicate", () => {
+  const active = { accounts: [{ id: "a1" }], activeAccountId: "a1" };
+
+  test("enabled anthropic OAuth provider with healthy active account -> true, provider named", () => {
+    accountSets = { claude: active };
+    const auth = resolveSidecarAuth(config({ providers: { openai: forward, claude: anthropicOAuth } }));
+    expect(auth.isAnthropicAuth).toBe(true);
+    expect(auth.anthropicProviderName).toBe("claude");
+  });
+
+  test.each([
+    ["disabled provider", { ...anthropicOAuth, disabled: true }, active],
+    ["wrong adapter", { ...anthropicOAuth, adapter: "openai-chat" } as OcxProviderConfig, active],
+    ["key auth", { ...anthropicOAuth, authMode: "key", apiKey: "k" } as OcxProviderConfig, active],
+    ["active account needs reauth", anthropicOAuth, { accounts: [{ id: "a1", needsReauth: true }], activeAccountId: "a1" }],
+    ["no account set", anthropicOAuth, undefined],
+  ])("%s -> false", (_name, provider, set) => {
+    accountSets = set ? { claude: set } : {};
+    const auth = resolveSidecarAuth(config({ providers: { openai: forward, claude: provider } }));
+    expect(auth.isAnthropicAuth).toBe(false);
+  });
+});
+
+describe("auth slots survive picker hiding (#2188 core invariant)", () => {
+  test("hidden/disabled Luna and Haiku still emitted when both logins present", () => {
+    usableCodexAccounts.add(MAIN_CODEX_ACCOUNT_ID);
+    accountSets = { claude: { accounts: [{ id: "a1" }], activeAccountId: "a1" } };
+    const cfg = config({
+      providers: { openai: forward, claude: anthropicOAuth },
+      // Both slot models hidden from the picker: slots must not care.
+      disabledModels: [AUTH_SLOT_MODELS.codex, AUTH_SLOT_MODELS.anthropic],
+    });
+    const slots = sidecarAuthSlots(resolveSidecarAuth(cfg));
+    expect(slots).toEqual([
+      { provider: "openai", id: "gpt-5.6-luna", slot: "codex" },
+      { provider: "claude", id: "claude-haiku-4-5", slot: "anthropic" },
+    ]);
+  });
+
+  test("no logins -> no slots", () => {
+    expect(sidecarAuthSlots(resolveSidecarAuth(config()))).toEqual([]);
+  });
+});
+
+describe("find* helpers delegate to the shared predicate", () => {
+  test("web-search and vision return the same provider the shared module resolved", () => {
+    accountSets = { claude: { accounts: [{ id: "a1" }], activeAccountId: "a1" } };
+    const cfg = config({ providers: { openai: forward, claude: anthropicOAuth } });
+    const auth = resolveSidecarAuth(cfg);
+    const ws = findAnthropicSidecarProvider(cfg);
+    const vision = findAnthropicVisionProvider(cfg);
+    expect(ws?.providerName).toBe(auth.anthropicProviderName);
+    expect(vision?.providerName).toBe(auth.anthropicProviderName);
+    expect(ws?.provider).toBe(vision?.provider);
+  });
+
+  test("all three agree on absence", () => {
+    const cfg = config();
+    expect(resolveSidecarAuth(cfg).isAnthropicAuth).toBe(false);
+    expect(findAnthropicSidecarProvider(cfg)).toBeUndefined();
+    expect(findAnthropicVisionProvider(cfg)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Layer 1 of the #2188 stacked chain (sidecar selection unification). Adds `src/sidecar/auth.ts`, the one place that decides whether ChatGPT or Anthropic auth is PRESENT for sidecar purposes:

- `isCodexAuth` is login-shaped, not provider-shaped: a canonical forward provider AND a live stored credential (main `~/.codex/auth.json` token or a usable selectable pool account). A fresh install with the built-in provider but no login no longer counts as Codex auth.
- `isAnthropicAuth` extracts the predicate previously duplicated in `findAnthropicSidecarProvider` (web-search) and `findAnthropicVisionProvider` (vision); both helpers now delegate, so the two sidecars can no longer drift on what "Anthropic auth present" means.
- `sidecarAuthSlots` emits the fixed auth-slot candidates (`gpt-5.6-luna` / `claude-haiku-4-5`) that survive picker hiding — the core #2188 invariant. Slots read only auth state, never `disabledModels`.

Design doc: `devlog/_plan/260820_sidecar_selection_unification/010_layer1_sidecar_auth.md`. Later layers (candidate sets, web-search registry, write gates, CLI `--list`) stack on this branch.

## Verification

- `bun x tsc --noEmit` clean.
- `bun test tests/sidecar-auth.test.ts tests/web-search.test.ts tests/vision-eligibility.test.ts tests/web-search-anthropic.test.ts tests/claude-sidecar-override.test.ts` — 100 pass / 0 fail.
- 14 new tests: the B1 pin (forward provider without login → no Codex auth), pool-only login, Anthropic predicate negatives (disabled/adapter/key/needsReauth/no-set), hidden-Luna/Haiku slot survival, delegation equivalence for both find* helpers.
- Independent read-only review (grok-4.6): spec conformance, behavior preservation, mock isolation, no import cycle — pass.

## Checklist

- [x] Focused tests green (`bun test tests/sidecar-auth.test.ts` + neighbor suites)
- [x] `bun run typecheck` clean
- [x] Behavior-preserving delegation for existing callers
- [x] Docs: devlog unit committed on dev (64293ee5d)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified authentication handling for ChatGPT and Anthropic sidecar options.
  * Added authenticated model slots for eligible providers, including options that may not appear in the picker.
  * Improved consistency between web-search and vision provider availability.
* **Documentation**
  * Added planning and research documentation covering sidecar selection, supported protocols, and future backend considerations.
* **Tests**
  * Added coverage for authentication detection, model availability, option generation, and provider consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->