### PR TITLE
feat(sidecar): unified picker candidate set for both sidecars (#2188 L2)

### DIFF
--- a/src/server/management/vision-sidecar-options.ts
+++ b/src/server/management/vision-sidecar-options.ts
@@ -17,7 +17,8 @@ import {
   type VisionSidecarBackend,
 } from "../../vision/eligibility";
 import { listOpenAiForwardSidecarCandidates } from "../../providers/openai-sidecar";
-import { listManagementModelRows } from "./model-rows";
+import { pickerVisibleSidecarCandidates, visionSidecarCandidates } from "../../sidecar/candidates";
+import { resolveSidecarAuth } from "../../sidecar/auth";
 
 /**
  * Backends whose executor could actually run: openai forward, anthropic OAuth.
@@ -41,17 +42,20 @@ export function enabledVisionBackends(
   return backends.length > 0 ? backends : ["openai", "anthropic"];
 }
 
-/** Visible catalog rows in the shape the eligibility predicate consumes. */
+/**
+ * Visible catalog rows in the shape the eligibility predicate consumes.
+ * Now sourced from the unified picker set (#2188): picker-visible rows ∪ auth
+ * slots, then rule 2 (− provably text-only). The auth slots are what keep a
+ * hidden Luna/Haiku offerable for a logged-in side.
+ */
 export async function visionCandidateRows(config: OcxConfig): Promise<VisionCandidateModel[]> {
-  let rows: Awaited<ReturnType<typeof listManagementModelRows>> = [];
-  // A catalog outage must not 500 the settings route nor reject a write; with []
-  // the option list degrades to the baselines, which is the intended floor.
-  try { rows = await listManagementModelRows(config); } catch { rows = []; }
-  return rows.filter(row => row.disabled !== true).map(row => ({
-    provider: row.provider,
-    id: row.id,
-    ...(row.inputModalities ? { inputModalities: row.inputModalities } : {}),
-    ...(row.native ? { native: true } : {}),
+  const auth = resolveSidecarAuth(config);
+  const all = await pickerVisibleSidecarCandidates(config, auth);
+  return visionSidecarCandidates(config, all).map(candidate => ({
+    provider: candidate.provider,
+    id: candidate.id,
+    ...(candidate.inputModalities ? { inputModalities: candidate.inputModalities } : {}),
+    ...(candidate.native ? { native: true } : {}),
   }));
 }
 

--- a/src/server/management/vision-sidecar-options.ts
+++ b/src/server/management/vision-sidecar-options.ts
@@ -17,7 +17,7 @@ import {
   type VisionSidecarBackend,
 } from "../../vision/eligibility";
 import { listOpenAiForwardSidecarCandidates } from "../../providers/openai-sidecar";
-import { pickerVisibleSidecarCandidates, visionSidecarCandidates } from "../../sidecar/candidates";
+import { pickerVisibleSidecarCandidates } from "../../sidecar/candidates";
 import { resolveSidecarAuth } from "../../sidecar/auth";
 
 /**
@@ -44,14 +44,17 @@ export function enabledVisionBackends(
 
 /**
  * Visible catalog rows in the shape the eligibility predicate consumes.
- * Now sourced from the unified picker set (#2188): picker-visible rows ∪ auth
- * slots, then rule 2 (− provably text-only). The auth slots are what keep a
- * hidden Luna/Haiku offerable for a logged-in side.
+ * Sourced from the unified picker set (#2188): picker-visible rows ∪ auth
+ * slots, UNFILTERED. Rule 2 (− provably text-only) belongs to the OPTIONS
+ * path only (visionEligibleModelOptions already applies it). The PUT gate
+ * consumes this list as EVIDENCE: a picker row proving an id text-only is
+ * exactly what visionDescriberIsProvablyBlind needs to reject that id, so
+ * pre-filtering here would deaden the gate (review F1: reject → allow flip).
  */
 export async function visionCandidateRows(config: OcxConfig): Promise<VisionCandidateModel[]> {
   const auth = resolveSidecarAuth(config);
   const all = await pickerVisibleSidecarCandidates(config, auth);
-  return visionSidecarCandidates(config, all).map(candidate => ({
+  return all.map(candidate => ({
     provider: candidate.provider,
     id: candidate.id,
     ...(candidate.inputModalities ? { inputModalities: candidate.inputModalities } : {}),

--- a/src/sidecar/candidates.ts
+++ b/src/sidecar/candidates.ts
@@ -1,0 +1,83 @@
+/**
+ * The unified picker-visibility candidate set both sidecars consume (#2188).
+ *
+ * Rule 1 (picker): a model may be OFFERED as a sidecar backend only if the
+ * management picker would show it — the same `listManagementModelRows` rows
+ * the GUI Models tab renders, minus disabled rows. Rule 1's only exception is
+ * the auth slots: a logged-in side keeps its fixed slot model (Luna/Haiku)
+ * even when the picker hides it, because the slot is the login's entitlement.
+ *
+ * Vision additionally applies rule 2 (− provably text-only); web-search
+ * applies its own rule 2 (∩ probed backend with an executor) in
+ * src/web-search/backends.ts. Both start from THIS set so the two sidecars
+ * cannot diverge on what "visible" means.
+ */
+import type { OcxConfig } from "../types";
+import { listManagementModelRows } from "../server/management/model-rows";
+import { modelAcceptsImageInput, type VisionCandidateModel } from "../vision/eligibility";
+import { sidecarAuthSlots, type SidecarAuthState } from "./auth";
+
+export interface SidecarCandidate {
+  provider: string;
+  id: string;
+  native?: boolean;
+  inputModalities?: string[];
+  /** True when this row is an auth-slot entitlement rather than a picker row. */
+  authSlot?: boolean;
+}
+
+/**
+ * (picker-visible rows) ∪ (auth slots). De-duplicated by provider+id with the
+ * auth-slot flag winning, so a slot model that is ALSO picker-visible still
+ * reads as slot-backed. A catalog outage degrades to slots only — the settings
+ * routes must not 500 and must keep the logged-in floor populated.
+ */
+export async function pickerVisibleSidecarCandidates(
+  config: OcxConfig,
+  auth: SidecarAuthState,
+): Promise<SidecarCandidate[]> {
+  let rows: Awaited<ReturnType<typeof listManagementModelRows>> = [];
+  try { rows = await listManagementModelRows(config); } catch { rows = []; }
+  const byKey = new Map<string, SidecarCandidate>();
+  for (const row of rows) {
+    if (row.disabled === true) continue;
+    byKey.set(`${row.provider}/${row.id}`, {
+      provider: row.provider,
+      id: row.id,
+      ...(row.inputModalities ? { inputModalities: row.inputModalities } : {}),
+      ...(row.native ? { native: true } : {}),
+    });
+  }
+  for (const slot of sidecarAuthSlots(auth)) {
+    byKey.set(`${slot.provider}/${slot.id}`, {
+      provider: slot.provider,
+      id: slot.id,
+      // Slot models are known image-capable; their only exclusion path is the
+      // provider's explicit consumer list (same stance as baselineCandidate).
+      inputModalities: ["text", "image"],
+      authSlot: true,
+    });
+  }
+  return [...byKey.values()];
+}
+
+/**
+ * Rule 2 for vision: drop rows PROVABLY text-only. Unknown stays eligible —
+ * the picker filter (rule 1) already bounded the set, so permissive-unknown
+ * no longer expands to the whole catalog.
+ */
+export function visionSidecarCandidates(
+  config: Pick<OcxConfig, "providers">,
+  all: readonly SidecarCandidate[],
+): SidecarCandidate[] {
+  return all.filter(candidate => modelAcceptsImageInput(config, toVisionCandidate(candidate)) !== false);
+}
+
+function toVisionCandidate(candidate: SidecarCandidate): VisionCandidateModel {
+  return {
+    provider: candidate.provider,
+    id: candidate.id,
+    ...(candidate.inputModalities ? { inputModalities: candidate.inputModalities } : {}),
+    ...(candidate.native ? { native: true } : {}),
+  };
+}

--- a/tests/sidecar-candidates.test.ts
+++ b/tests/sidecar-candidates.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import * as storeModule from "../src/oauth/store";
+import * as usabilityModule from "../src/codex/account-usability";
+import * as modelRowsModule from "../src/server/management/model-rows";
+
+let accountSets: Record<string, { accounts: Array<{ id: string; needsReauth?: boolean }>; activeAccountId?: string }> = {};
+let usableCodexAccounts: Set<string> = new Set();
+let managementRows: Array<Record<string, unknown>> | Error = [];
+
+mock.module("../src/oauth/store", () => ({
+  ...storeModule,
+  getAccountSet: (provider: string) => accountSets[provider] ?? null,
+}));
+mock.module("../src/codex/account-usability", () => ({
+  ...usabilityModule,
+  isCodexAccountUsable: (_config: unknown, accountId: string) => usableCodexAccounts.has(accountId),
+}));
+mock.module("../src/server/management/model-rows", () => ({
+  ...modelRowsModule,
+  listManagementModelRows: async () => {
+    if (managementRows instanceof Error) throw managementRows;
+    return managementRows;
+  },
+}));
+
+import { pickerVisibleSidecarCandidates, visionSidecarCandidates } from "../src/sidecar/candidates";
+import { resolveSidecarAuth } from "../src/sidecar/auth";
+import { MAIN_CODEX_ACCOUNT_ID } from "../src/codex/account-id";
+import type { OcxConfig, OcxProviderConfig } from "../src/types";
+
+const forward: OcxProviderConfig = { adapter: "openai-responses", baseUrl: "https://chatgpt.com/backend-api/codex", authMode: "forward" };
+const anthropicOAuth: OcxProviderConfig = { adapter: "anthropic", baseUrl: "https://api.anthropic.com", authMode: "oauth" };
+
+function config(overrides: Partial<OcxConfig> = {}): OcxConfig {
+  return { port: 10100, defaultProvider: "openai", providers: { openai: forward }, ...overrides };
+}
+
+afterEach(() => {
+  accountSets = {};
+  usableCodexAccounts = new Set();
+  managementRows = [];
+});
+
+function loginBoth(): void {
+  usableCodexAccounts.add(MAIN_CODEX_ACCOUNT_ID);
+  accountSets = { claude: { accounts: [{ id: "a1" }], activeAccountId: "a1" } };
+}
+
+describe("pickerVisibleSidecarCandidates", () => {
+  test("disabled rows disappear; hidden Luna survives via the auth slot", async () => {
+    loginBoth();
+    managementRows = [
+      { provider: "openai", id: "gpt-5.6-luna", disabled: true, native: true },
+      { provider: "openai", id: "gpt-5.6-terra", disabled: false, native: true },
+      { provider: "routed", id: "some-model", disabled: false },
+    ];
+    const cfg = config({ providers: { openai: forward, claude: anthropicOAuth } });
+    const all = await pickerVisibleSidecarCandidates(cfg, resolveSidecarAuth(cfg));
+    const ids = all.map(c => `${c.provider}/${c.id}`).sort();
+    expect(ids).toEqual([
+      "claude/claude-haiku-4-5",
+      "openai/gpt-5.6-luna",
+      "openai/gpt-5.6-terra",
+      "routed/some-model",
+    ]);
+    expect(all.find(c => c.id === "gpt-5.6-luna")?.authSlot).toBe(true);
+  });
+
+  test("picker-visible slot model keeps the slot flag (slot wins de-dup)", async () => {
+    loginBoth();
+    managementRows = [{ provider: "openai", id: "gpt-5.6-luna", disabled: false, native: true }];
+    const cfg = config({ providers: { openai: forward, claude: anthropicOAuth } });
+    const all = await pickerVisibleSidecarCandidates(cfg, resolveSidecarAuth(cfg));
+    expect(all.filter(c => c.id === "gpt-5.6-luna")).toHaveLength(1);
+    expect(all.find(c => c.id === "gpt-5.6-luna")?.authSlot).toBe(true);
+  });
+
+  test("catalog outage degrades to auth slots only, not a 500", async () => {
+    loginBoth();
+    managementRows = new Error("catalog down");
+    const cfg = config({ providers: { openai: forward, claude: anthropicOAuth } });
+    const all = await pickerVisibleSidecarCandidates(cfg, resolveSidecarAuth(cfg));
+    expect(all.map(c => c.id).sort()).toEqual(["claude-haiku-4-5", "gpt-5.6-luna"]);
+  });
+
+  test("no logins and empty catalog -> empty set", async () => {
+    const all = await pickerVisibleSidecarCandidates(config(), resolveSidecarAuth(config()));
+    expect(all).toEqual([]);
+  });
+});
+
+describe("visionSidecarCandidates (rule 2: − provably text-only)", () => {
+  test("provably text-only row excluded; unknown stays; slots stay", async () => {
+    loginBoth();
+    managementRows = [
+      { provider: "routed", id: "text-model", disabled: false, inputModalities: ["text"] },
+      { provider: "routed", id: "unknown-model", disabled: false },
+    ];
+    const cfg = config({ providers: { openai: forward, claude: anthropicOAuth } });
+    const all = await pickerVisibleSidecarCandidates(cfg, resolveSidecarAuth(cfg));
+    const vision = visionSidecarCandidates(cfg, all);
+    const ids = vision.map(c => c.id).sort();
+    expect(ids).toEqual(["claude-haiku-4-5", "gpt-5.6-luna", "unknown-model"]);
+  });
+
+  test("noVisionModels consumer listing beats the slot's advertised modalities", async () => {
+    loginBoth();
+    const blindLuna: OcxProviderConfig = { ...forward, noVisionModels: ["gpt-5.6-luna"] };
+    const cfg = config({ providers: { openai: blindLuna, claude: anthropicOAuth } });
+    const all = await pickerVisibleSidecarCandidates(cfg, resolveSidecarAuth(cfg));
+    const vision = visionSidecarCandidates(cfg, all);
+    expect(vision.map(c => c.id)).not.toContain("gpt-5.6-luna");
+    expect(vision.map(c => c.id)).toContain("claude-haiku-4-5");
+  });
+});

--- a/tests/sidecar-candidates.test.ts
+++ b/tests/sidecar-candidates.test.ts
@@ -25,6 +25,7 @@ mock.module("../src/server/management/model-rows", () => ({
 
 import { pickerVisibleSidecarCandidates, visionSidecarCandidates } from "../src/sidecar/candidates";
 import { resolveSidecarAuth } from "../src/sidecar/auth";
+import { visionCandidateRows, visionDescriberIsProvablyBlind } from "../src/server/management/vision-sidecar-options";
 import { MAIN_CODEX_ACCOUNT_ID } from "../src/codex/account-id";
 import type { OcxConfig, OcxProviderConfig } from "../src/types";
 
@@ -111,5 +112,20 @@ describe("visionSidecarCandidates (rule 2: − provably text-only)", () => {
     const vision = visionSidecarCandidates(cfg, all);
     expect(vision.map(c => c.id)).not.toContain("gpt-5.6-luna");
     expect(vision.map(c => c.id)).toContain("claude-haiku-4-5");
+  });
+});
+
+describe("write-gate evidence is NOT pre-filtered (review F1 regression)", () => {
+  test("a picker row proving an id text-only still reaches the PUT gate and rejects it", async () => {
+    loginBoth();
+    managementRows = [
+      { provider: "routed", id: "row-proven-blind", disabled: false, inputModalities: ["text"] },
+    ];
+    const cfg = config({ providers: { openai: forward, claude: anthropicOAuth } });
+    const candidates = await visionCandidateRows(cfg);
+    // The evidence row must survive into the candidates list...
+    expect(candidates.map(c => c.id)).toContain("row-proven-blind");
+    // ...so the gate can prove blindness from it (neither vendor table knows this id).
+    expect(visionDescriberIsProvablyBlind(cfg, "row-proven-blind", candidates, undefined)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Layer 2 of the #2188 stacked chain (parent: #2203). Adds `src/sidecar/candidates.ts` — the unified picker-visibility set both sidecars consume:

- `pickerVisibleSidecarCandidates` = management picker rows (disabled rows dropped) ∪ auth slots, de-duplicated with the slot flag winning; a catalog outage degrades to the logged-in slots, not an empty 500.
- `visionSidecarCandidates` applies rule 2 (drop provably text-only) for the options path.
- `visionCandidateRows` now wraps the unified set UNFILTERED: the PUT gate consumes picker rows as rejection evidence, so pre-filtering would deaden `visionDescriberIsProvablyBlind`'s catalog-row proof (caught in review; regression test added).

Design doc: `devlog/_plan/260820_sidecar_selection_unification/020_layer2_picker_candidates.md`.

## Verification

- `bun x tsc --noEmit` clean.
- `bun test --isolate` across sidecar-candidates, sidecar-auth, sidecar-settings-vision-filter, vision-eligibility, catalog-vision-sidecar-modalities, sidecar-settings-vision-controls, claude-sidecar-override — all green.
- 7 new tests incl. hidden-Luna survival, slot-wins de-dup, outage degradation, text-only exclusion, noVisionModels-beats-slot, and the write-gate-evidence regression.
- Independent read-only review (grok-4.6): one FAIL (gate evidence pre-filtered) fixed and re-verified to pass.

## Checklist

- [x] Focused tests green (`--isolate`, matching the repo runner)
- [x] `bun run typecheck` clean
- [x] Write-gate semantics preserved (regression-pinned)
- [x] Stacked on #2203; retarget to dev after parent lands



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified sidecar model selection across management and picker views.
  * Authenticated sidecar options now appear in the picker, with duplicate entries removed.
  * Vision-capable models are identified more accurately while retaining models with unknown capabilities.
* **Bug Fixes**
  * Sidecar options remain available when model catalog services are temporarily unavailable.
  * Preserved model modality and native metadata for more reliable selection and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->