### PR TITLE
feat(web-search): backend registry and executor-runnable candidate set (#2188 L3)

### DIFF
--- a/docs-site/src/content/docs/guides/claude-code.md
+++ b/docs-site/src/content/docs/guides/claude-code.md
@@ -332,8 +332,9 @@ Both sidecars can use either backend:
 | `openai` | A small GPT model through the ChatGPT `forward` provider | A ChatGPT login and an enabled `authMode: "forward"` provider |
 | `anthropic` | Claude through stored Anthropic OAuth; web search uses `web_search_20250305` and vision sends the image to Claude for description | An enabled `adapter: "anthropic"`, `authMode: "oauth"` provider whose active stored account is not marked `needsReauth` |
 
-An explicit `backend` always wins. When it is omitted, opencodex selects `anthropic` if a usable
-stored Anthropic OAuth account exists; otherwise it selects `openai`. Explicitly selecting
+An explicit `backend` always wins. When it is omitted, the **web-search** sidecar always selects
+`openai` (`anthropic` runs only when explicitly configured), while the **vision** sidecar selects
+`anthropic` if a usable stored Anthropic OAuth account exists, otherwise `openai`. Explicitly selecting
 `anthropic` without a usable credential **fails closed**: opencodex does not silently borrow
 ChatGPT credentials or switch backends. The OpenAI backend likewise stays off without both login
 auth and a forward provider.

--- a/docs-site/src/content/docs/guides/sidecars.md
+++ b/docs-site/src/content/docs/guides/sidecars.md
@@ -9,10 +9,11 @@ stored Anthropic OAuth provider. Sidecar errors become bounded tool results or i
 of failing the whole turn.
 
 :::note[Automatic backend selection]
-Explicit `backend` config wins. When unset, opencodex uses `anthropic` if an enabled Anthropic OAuth
-provider has an active account not marked `needsReauth`; otherwise it uses `openai`. Explicit
-`anthropic` without that credential fails closed. `openai` requires both ChatGPT login auth and an
-enabled `forward` provider.
+Explicit `backend` config wins. The two sidecars default differently when `backend` is unset:
+**web search** always defaults to `openai` — `anthropic` runs only when explicitly configured.
+**Vision** defaults to `anthropic` if an enabled Anthropic OAuth provider has an active account not
+marked `needsReauth`, otherwise `openai`. Explicit `anthropic` without that credential fails
+closed. `openai` requires both ChatGPT login auth and an enabled `forward` provider.
 :::
 
 ## Web-search sidecar

--- a/docs-site/src/content/docs/reference/configuration/server.md
+++ b/docs-site/src/content/docs/reference/configuration/server.md
@@ -205,7 +205,7 @@ Images API paths and response shape expected by Codex.
 | Field | Type | Default | Meaning |
 | --- | --- | --- | --- |
 | `enabled?` | `boolean` | on when usable | Master switch. |
-| `backend?` | `"openai" \| "anthropic"` | auto | Explicit wins; otherwise usable stored Anthropic OAuth selects `anthropic`, then `openai`. |
+| `backend?` | `"openai" \| "anthropic"` | `openai` | Explicit wins; unset always resolves to `openai`. `anthropic` runs only when explicitly configured. |
 | `model?` | `string` | backend-dependent | `gpt-5.6-luna` for OpenAI or `claude-sonnet-5` for Anthropic. Legacy explicit `gpt-5.4-mini` migrates on start. |
 | `reasoning?` | `string` | `low` | Sidecar effort. `minimal` is rejected with web search. |
 | `maxSearchesPerTurn?` | `number` | `3` | Real searches allowed per main-model turn. |

--- a/docs-site/src/content/docs/reference/configuration/server.md
+++ b/docs-site/src/content/docs/reference/configuration/server.md
@@ -227,7 +227,7 @@ an inactivity guard, not a total generation deadline.
 | Field | Type | Default | Meaning |
 | --- | --- | --- | --- |
 | `enabled?` | `boolean` | on when usable | Master image-description switch. |
-| `backend?` | `"openai" \| "anthropic"` | auto | Same explicit-first, Anthropic-credential-aware selection as web search. |
+| `backend?` | `"openai" \| "anthropic"` | auto | Explicit wins; unset prefers a usable stored Anthropic OAuth credential, else `openai`. |
 | `model?` | `string` | backend-dependent | `gpt-5.4-mini` for OpenAI or `claude-sonnet-5` for Anthropic. |
 | `maxDescriptionsPerTurn?` | `number` | `8` | New description cache misses admitted per main turn. `0` disables calls; invalid values use default. |
 | `timeoutMs?` | `number` | `45000` | Sidecar fetch timeout. Integer 1–2147483647. |

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -790,8 +790,9 @@ export interface OcxWebSearchSidecarConfig {
   /**
    * Which backend actually runs the server-side search. "openai" replays the hosted web_search via
    * the ChatGPT forward provider (gpt-mini sidecar); "anthropic" runs web_search_20250305 on a Claude
-   * model authenticated by the STORED anthropic OAuth credential. Unset resolves to "anthropic" when a
-   * usable anthropic OAuth credential exists, else "openai".
+   * model authenticated by the STORED anthropic OAuth credential. Unset resolves to "openai";
+   * "anthropic" runs only when explicitly configured (auto-selecting it from credential availability
+   * once sent incompatible models to the Anthropic API — see resolveSidecarBackend).
    */
   backend?: "openai" | "anthropic";
   /** Sidecar model that runs the real server-side web_search (must be a native ChatGPT model). */

--- a/src/web-search/backends.ts
+++ b/src/web-search/backends.ts
@@ -32,10 +32,15 @@ export const WEB_SEARCH_BACKENDS: readonly WebSearchBackendDescriptor[] = [
   {
     backend: "openai",
     isActive: auth => auth.isCodexAuth,
-    // The ChatGPT forward executor runs native rows: provider "openai" catalog
-    // rows and the Codex auth slot. Routed providers named openai-* speak the
-    // wire but cannot borrow the hosted web_search execution.
-    eligibleModel: candidate => candidate.provider === "openai",
+    // The ChatGPT forward executor runs BARE native slugs and the Codex auth
+    // slot — settings.model is POSTed verbatim to the forward /responses, so
+    // an account-bound "selector/slug" row (model-rows emits those as
+    // provider "openai", native true) or a custom openai-keyed row would
+    // persist an id the executor cannot run (review F1). The sidecar never
+    // calls routeModel; there is no prefix-stripping on this path.
+    eligibleModel: candidate => candidate.provider === "openai"
+      && (candidate.native === true || candidate.authSlot === true)
+      && !candidate.id.includes("/"),
   },
   {
     backend: "anthropic",

--- a/src/web-search/backends.ts
+++ b/src/web-search/backends.ts
@@ -1,0 +1,67 @@
+/**
+ * Which backends may RUN a hosted web_search, and which candidate rows each
+ * can run (#2188 rule 2 for web-search: ∩ probed backend with an executor).
+ *
+ * A backend registers here only when BOTH hold:
+ *  - an executor exists in this repository (src/web-search/executor.ts or
+ *    anthropic-executor.ts today), and
+ *  - its liveness probe passes. For the two shipped backends the probe IS
+ *    auth presence — the ChatGPT forward path and the stored Anthropic OAuth
+ *    path fail closed without a credential, so a live credential is the
+ *    strongest pre-flight signal short of spending a search.
+ *
+ * Future backends (Gemini google_search, Grok web_search, Zen hosted search,
+ * Exa-class vendors) stay OUT of this table until a live probe and an
+ * executor land — the research and probe contracts are recorded in
+ * devlog/_plan/260820_sidecar_selection_unification/002 and 031. Documenting
+ * a tool is not the same as being able to run it.
+ */
+import type { OcxConfig } from "../types";
+import { AUTH_SLOT_MODELS, type SidecarAuthState } from "../sidecar/auth";
+import type { SidecarCandidate } from "../sidecar/candidates";
+
+export interface WebSearchBackendDescriptor {
+  backend: "openai" | "anthropic";
+  /** Liveness signal for this backend (auth presence for the shipped two). */
+  isActive(auth: SidecarAuthState): boolean;
+  /** Which candidate rows this backend's executor can actually run. */
+  eligibleModel(candidate: SidecarCandidate, auth: SidecarAuthState): boolean;
+}
+
+export const WEB_SEARCH_BACKENDS: readonly WebSearchBackendDescriptor[] = [
+  {
+    backend: "openai",
+    isActive: auth => auth.isCodexAuth,
+    // The ChatGPT forward executor runs native rows: provider "openai" catalog
+    // rows and the Codex auth slot. Routed providers named openai-* speak the
+    // wire but cannot borrow the hosted web_search execution.
+    eligibleModel: candidate => candidate.provider === "openai",
+  },
+  {
+    backend: "anthropic",
+    isActive: auth => auth.isAnthropicAuth,
+    // The stored-OAuth Messages executor dispatches through exactly ONE
+    // provider — the one the shared auth module resolved. Same-adapter keyed
+    // rows are unreachable, mirroring visionBackendForCandidate's stance.
+    eligibleModel: (candidate, auth) => candidate.provider === auth.anthropicProviderName,
+  },
+];
+
+/**
+ * (picker-visible ∪ auth slots) ∩ (active backend able to run the row).
+ * The auth slots always survive their own side's activation: a logged-in
+ * side keeps Luna/Haiku even when the picker hides them.
+ */
+export function webSearchSidecarCandidates(
+  _config: OcxConfig,
+  auth: SidecarAuthState,
+  all: readonly SidecarCandidate[],
+): SidecarCandidate[] {
+  const active = WEB_SEARCH_BACKENDS.filter(descriptor => descriptor.isActive(auth));
+  return all.filter(candidate => active.some(descriptor => descriptor.eligibleModel(candidate, auth)));
+}
+
+/** True when the id is one of the fixed auth-slot models (#2188 write-gate exception). */
+export function isWebSearchAuthSlotModel(id: string): boolean {
+  return id === AUTH_SLOT_MODELS.codex || id === AUTH_SLOT_MODELS.anthropic;
+}

--- a/src/web-search/index.ts
+++ b/src/web-search/index.ts
@@ -154,7 +154,12 @@ export function planWebSearch(
   const routedModelStallTimeoutMs = resolveRoutedModelStallTimeoutMs(cfg.routedModelStallTimeoutMs);
   // Same `?? 200_000` default the server applies when threading connectTimeoutMs into the loop.
   const connectTimeoutMs = config.connectTimeoutMs ?? 200_000;
-  const anthropicSidecar = findAnthropicSidecarProvider(config);
+  // Shared auth state (#2188): presence only — backend PREFERENCE stays with
+  // resolveSidecarBackend's explicit-or-openai contract.
+  const auth = resolveSidecarAuth(config);
+  const anthropicSidecar = auth.isAnthropicAuth && auth.anthropicProviderName && auth.anthropicProvider
+    ? { providerName: auth.anthropicProviderName, provider: auth.anthropicProvider }
+    : undefined;
   const backend = resolveSidecarBackend(cfg.backend);
   const maxSearches = cfg.maxSearchesPerTurn ?? DEFAULT_MAX_SEARCHES;
   const stallTimeoutSec = webSearchStallTimeoutSec(

--- a/tests/web-search-candidates.test.ts
+++ b/tests/web-search-candidates.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import * as storeModule from "../src/oauth/store";
+import * as usabilityModule from "../src/codex/account-usability";
+import * as modelRowsModule from "../src/server/management/model-rows";
+
+let accountSets: Record<string, { accounts: Array<{ id: string; needsReauth?: boolean }>; activeAccountId?: string }> = {};
+let usableCodexAccounts: Set<string> = new Set();
+let managementRows: Array<Record<string, unknown>> = [];
+
+mock.module("../src/oauth/store", () => ({
+  ...storeModule,
+  getAccountSet: (provider: string) => accountSets[provider] ?? null,
+}));
+mock.module("../src/codex/account-usability", () => ({
+  ...usabilityModule,
+  isCodexAccountUsable: (_config: unknown, accountId: string) => usableCodexAccounts.has(accountId),
+}));
+mock.module("../src/server/management/model-rows", () => ({
+  ...modelRowsModule,
+  listManagementModelRows: async () => managementRows,
+}));
+
+import { isWebSearchAuthSlotModel, webSearchSidecarCandidates } from "../src/web-search/backends";
+import { pickerVisibleSidecarCandidates } from "../src/sidecar/candidates";
+import { resolveSidecarAuth } from "../src/sidecar/auth";
+import { resolveSidecarBackend } from "../src/web-search";
+import { MAIN_CODEX_ACCOUNT_ID } from "../src/codex/account-id";
+import type { OcxConfig, OcxProviderConfig } from "../src/types";
+
+const forward: OcxProviderConfig = { adapter: "openai-responses", baseUrl: "https://chatgpt.com/backend-api/codex", authMode: "forward" };
+const anthropicOAuth: OcxProviderConfig = { adapter: "anthropic", baseUrl: "https://api.anthropic.com", authMode: "oauth" };
+
+function config(overrides: Partial<OcxConfig> = {}): OcxConfig {
+  return { port: 10100, defaultProvider: "openai", providers: { openai: forward, claude: anthropicOAuth }, ...overrides };
+}
+
+afterEach(() => {
+  accountSets = {};
+  usableCodexAccounts = new Set();
+  managementRows = [];
+});
+
+async function candidatesFor(cfg: OcxConfig) {
+  const auth = resolveSidecarAuth(cfg);
+  const all = await pickerVisibleSidecarCandidates(cfg, auth);
+  return webSearchSidecarCandidates(cfg, auth, all);
+}
+
+describe("webSearchSidecarCandidates = (picker ∪ slots) ∩ active backend", () => {
+  test("no Codex login: openai side inactive — native rows and Luna absent, Haiku present", async () => {
+    accountSets = { claude: { accounts: [{ id: "a1" }], activeAccountId: "a1" } };
+    managementRows = [
+      { provider: "openai", id: "gpt-5.6-terra", disabled: false, native: true },
+      { provider: "claude", id: "claude-sonnet-5", disabled: false },
+    ];
+    const ids = (await candidatesFor(config())).map(c => c.id).sort();
+    expect(ids).toEqual(["claude-haiku-4-5", "claude-sonnet-5"]);
+  });
+
+  test("hidden Luna + Codex login: present via the slot", async () => {
+    usableCodexAccounts.add(MAIN_CODEX_ACCOUNT_ID);
+    managementRows = [{ provider: "openai", id: "gpt-5.6-terra", disabled: false, native: true }];
+    const cfg = config({ disabledModels: ["gpt-5.6-luna"] });
+    const ids = (await candidatesFor(cfg)).map(c => c.id).sort();
+    expect(ids).toEqual(["gpt-5.6-luna", "gpt-5.6-terra"]);
+  });
+
+  test("rows outside both backend families are excluded even when picker-visible", async () => {
+    usableCodexAccounts.add(MAIN_CODEX_ACCOUNT_ID);
+    accountSets = { claude: { accounts: [{ id: "a1" }], activeAccountId: "a1" } };
+    managementRows = [
+      { provider: "routed", id: "grok-4.6", disabled: false },
+      { provider: "openai", id: "gpt-5.6-terra", disabled: false, native: true },
+    ];
+    const ids = (await candidatesFor(config())).map(c => c.id).sort();
+    expect(ids).toEqual(["claude-haiku-4-5", "gpt-5.6-luna", "gpt-5.6-terra"]);
+  });
+
+  test("keyed same-adapter anthropic provider rows stay unreachable", async () => {
+    accountSets = { claude: { accounts: [{ id: "a1" }], activeAccountId: "a1" } };
+    const keyedClaude: OcxProviderConfig = { adapter: "anthropic", baseUrl: "https://api.anthropic.com", authMode: "key", apiKey: "k" };
+    managementRows = [{ provider: "keyed-claude", id: "claude-sonnet-5", disabled: false }];
+    const cfg = config({ providers: { openai: forward, claude: anthropicOAuth, "keyed-claude": keyedClaude } });
+    const ids = (await candidatesFor(cfg)).map(c => c.id).sort();
+    expect(ids).toEqual(["claude-haiku-4-5"]);
+  });
+
+  test("no logins at all -> empty candidate set", async () => {
+    managementRows = [{ provider: "openai", id: "gpt-5.6-terra", disabled: false, native: true }];
+    expect(await candidatesFor(config())).toEqual([]);
+  });
+});
+
+describe("existing contracts stay pinned", () => {
+  test("resolveSidecarBackend(undefined) is still openai (B4: no default change)", () => {
+    expect(resolveSidecarBackend(undefined)).toBe("openai");
+  });
+
+  test("auth-slot membership helper knows exactly the two slot models", () => {
+    expect(isWebSearchAuthSlotModel("gpt-5.6-luna")).toBe(true);
+    expect(isWebSearchAuthSlotModel("claude-haiku-4-5")).toBe(true);
+    expect(isWebSearchAuthSlotModel("gpt-5.6-terra")).toBe(false);
+  });
+});

--- a/tests/web-search-candidates.test.ts
+++ b/tests/web-search-candidates.test.ts
@@ -89,6 +89,26 @@ describe("webSearchSidecarCandidates = (picker ∪ slots) ∩ active backend", (
     managementRows = [{ provider: "openai", id: "gpt-5.6-terra", disabled: false, native: true }];
     expect(await candidatesFor(config())).toEqual([]);
   });
+
+  test("account-bound selector/slug native rows are excluded (executor cannot run them)", async () => {
+    usableCodexAccounts.add(MAIN_CODEX_ACCOUNT_ID);
+    managementRows = [
+      { provider: "openai", id: "work/gpt-future-unlisted", disabled: false, native: true },
+      { provider: "openai", id: "gpt-5.6-terra", disabled: false, native: true },
+    ];
+    const ids = (await candidatesFor(config())).map(c => c.id).sort();
+    expect(ids).toEqual(["gpt-5.6-luna", "gpt-5.6-terra"]);
+  });
+
+  test("custom openai-keyed rows without the native flag are excluded", async () => {
+    usableCodexAccounts.add(MAIN_CODEX_ACCOUNT_ID);
+    managementRows = [
+      { provider: "openai", id: "my-custom-gpt", disabled: false },
+      { provider: "openai", id: "gpt-5.6-terra", disabled: false, native: true },
+    ];
+    const ids = (await candidatesFor(config())).map(c => c.id).sort();
+    expect(ids).toEqual(["gpt-5.6-luna", "gpt-5.6-terra"]);
+  });
 });
 
 describe("existing contracts stay pinned", () => {


### PR DESCRIPTION
## Summary

Layer 3 of the #2188 stacked chain (parent: #2204). Web-search rule 2 — a model may be OFFERED as the web-search sidecar only when an active, executor-backed backend can actually run it:

- `src/web-search/backends.ts`: `WEB_SEARCH_BACKENDS` registers the two shipped backends (ChatGPT forward, Anthropic stored-OAuth) with auth-presence as the liveness probe. Future backends (Gemini/Grok/Zen/Exa) stay out until a live probe + executor land; probe contracts are recorded in the devlog unit (002/031).
- `webSearchSidecarCandidates` = (picker-visible ∪ auth slots) ∩ active-backend-runnable. The openai side requires a bare native slug or the Luna auth slot — account-bound `selector/slug` rows and custom openai-keyed rows are excluded because the forward executor POSTs `settings.model` verbatim (review-caught).
- `planWebSearch` consumes the shared auth state for credential presence. `resolveSidecarBackend`'s explicit-or-openai preference is deliberately unchanged; the `types/config.ts` comment and three docs-site pages that claimed anthropic-preferred for web-search now tell the truth (vision keeps its own anthropic-if-credential default).

Design doc: `devlog/_plan/260820_sidecar_selection_unification/030_layer3_websearch_slots.md`.

## Verification

- `bun x tsc --noEmit` clean; `bun test --isolate` across web-search-candidates, web-search, web-search-anthropic, sidecar-candidates, sidecar-auth — green (9 new tests incl. selector/slug and custom-row exclusions, hidden-Luna slot survival, keyed-anthropic unreachability, `resolveSidecarBackend(undefined) === "openai"` pin).
- Independent read-only review (grok-4.6): one High (selector/slug ids) + two Mediums (custom rows, docs-site claims) found, fixed, and re-verified to pass across three rounds.

## Checklist

- [x] Focused tests green (`--isolate`)
- [x] `bun run typecheck` clean
- [x] No default-backend behavior change (test-pinned)
- [x] Stacked on #2204; retarget after parent lands



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Web search now defaults to OpenAI unless Anthropic is explicitly selected.
  - Vision automatically prefers a usable Anthropic account, otherwise falling back to OpenAI.
  - Web-search model availability now reflects active authentication and backend eligibility.

- **Bug Fixes**
  - Clarified and aligned backend-selection behavior across configuration and user documentation.
  - Explicit Anthropic configuration continues to fail safely when credentials are unavailable.

- **Tests**
  - Added coverage for backend eligibility, authentication requirements, custom models, and disabled accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->