### PR TITLE
fix(responses): bound orphan call reordering work

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -756,10 +756,7 @@ function repairOrphanedInputItems(body: unknown, dropReasoning: boolean, synthes
         continue;
       }
       const batchOutputs: unknown[] = [];
-      const emittedKeys = new Set<string>();
       for (const batchKey of batchKeys) {
-        if (emittedKeys.has(batchKey)) continue;
-        emittedKeys.add(batchKey);
         const bucket = outputIndexesByKey.get(batchKey);
         if (!bucket) continue;
         while (bucket.offset < bucket.indexes.length && bucket.indexes[bucket.offset]! < cursor) {
@@ -771,6 +768,7 @@ function repairOrphanedInputItems(body: unknown, dropReasoning: boolean, synthes
           if (claimedOutputIndexes.has(outputIndex)) continue;
           claimedOutputIndexes.add(outputIndex);
           batchOutputs.push(items[outputIndex]);
+          break;
         }
       }
       ordered.push(...batch, ...batchOutputs);

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -725,8 +725,18 @@ function repairOrphanedInputItems(body: unknown, dropReasoning: boolean, synthes
   };
   const reorderBatchOutputs = (items: unknown[]): unknown[] => {
     const ordered: unknown[] = [];
+    const claimedOutputIndexes = new Set<number>();
+    const outputIndexesByKey = new Map<string, { indexes: number[]; offset: number }>();
+    for (let outputIndex = 0; outputIndex < items.length; outputIndex += 1) {
+      const outputKey = outputKeyOf(items[outputIndex]);
+      if (outputKey === null) continue;
+      const bucket = outputIndexesByKey.get(outputKey);
+      if (bucket) bucket.indexes.push(outputIndex);
+      else outputIndexesByKey.set(outputKey, { indexes: [outputIndex], offset: 0 });
+    }
     let index = 0;
     while (index < items.length) {
+      if (claimedOutputIndexes.has(index)) { index += 1; continue; }
       const key = callKeyOf(items[index]);
       if (key === null) { ordered.push(items[index]); index += 1; continue; }
       const batch: unknown[] = [];
@@ -745,20 +755,26 @@ function repairOrphanedInputItems(body: unknown, dropReasoning: boolean, synthes
         index = cursor;
         continue;
       }
-      const remainder: unknown[] = [];
-      const batchOutputs: Array<{ key: string; item: unknown }> = [];
-      for (let probe = cursor; probe < items.length; probe += 1) {
-        const outputKey = outputKeyOf(items[probe]);
-        if (outputKey !== null && batchKeys.includes(outputKey)) {
-          batchOutputs.push({ key: outputKey, item: items[probe] });
-        } else {
-          remainder.push(items[probe]);
+      const batchOutputs: unknown[] = [];
+      const emittedKeys = new Set<string>();
+      for (const batchKey of batchKeys) {
+        if (emittedKeys.has(batchKey)) continue;
+        emittedKeys.add(batchKey);
+        const bucket = outputIndexesByKey.get(batchKey);
+        if (!bucket) continue;
+        while (bucket.offset < bucket.indexes.length && bucket.indexes[bucket.offset]! < cursor) {
+          bucket.offset += 1;
+        }
+        while (bucket.offset < bucket.indexes.length) {
+          const outputIndex = bucket.indexes[bucket.offset]!;
+          bucket.offset += 1;
+          if (claimedOutputIndexes.has(outputIndex)) continue;
+          claimedOutputIndexes.add(outputIndex);
+          batchOutputs.push(items[outputIndex]);
         }
       }
-      batchOutputs.sort((left, right) => batchKeys.indexOf(left.key) - batchKeys.indexOf(right.key));
-      ordered.push(...batch, ...batchOutputs.map(output => output.item));
-      ordered.push(...reorderBatchOutputs(remainder));
-      return ordered;
+      ordered.push(...batch, ...batchOutputs);
+      index = cursor;
     }
     return ordered;
   };

--- a/tests/responses-stateless-dangling-call-repair.test.ts
+++ b/tests/responses-stateless-dangling-call-repair.test.ts
@@ -125,6 +125,38 @@ describe("stateless Responses wire repairs orphaned tool calls", () => {
     expect(String((input[4] as { output: unknown }).output)).toContain("no tool result was recorded");
   });
 
+  test("repairs many separated dangling calls without recursive reprocessing", async () => {
+    const callCount = 20_000;
+    const requestInput = Array.from({ length: callCount }, (_, index) => [
+      { type: "function_call", id: `fc_${index}`, call_id: `call_${index}`, name: "exec_command", arguments: "{}" },
+      { type: "message", role: "user", content: [{ type: "input_text", text: `separator ${index}` }] },
+    ]).flat();
+
+    const { body } = await drive(requestInput);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input).toHaveLength(callCount * 3);
+    expect(input[0]).toMatchObject({ type: "function_call", call_id: "call_0" });
+    expect(input[1]).toMatchObject({ type: "function_call_output", call_id: "call_0" });
+    expect(input.at(-3)).toMatchObject({ type: "function_call", call_id: `call_${callCount - 1}` });
+    expect(input.at(-2)).toMatchObject({ type: "function_call_output", call_id: `call_${callCount - 1}` });
+    expect(input.at(-1)).toMatchObject({ type: "message" });
+  });
+
+  test("consumes repeated output-key indexes once without dropping repaired items", async () => {
+    const callCount = 2_000;
+    const requestInput = Array.from({ length: callCount }, (_, index) => [
+      { type: "function_call", id: `fc_repeat_${index}`, call_id: "call_repeat", name: "exec_command", arguments: "{}" },
+      { type: "message", role: "user", content: [{ type: "input_text", text: `separator ${index}` }] },
+    ]).flat();
+
+    const { body } = await drive(requestInput);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input).toHaveLength(callCount * 3);
+    expect(input.filter(item => item.type === "function_call")).toHaveLength(callCount);
+    expect(input.filter(item => item.type === "function_call_output")).toHaveLength(callCount);
+    expect(input.filter(item => item.type === "message")).toHaveLength(callCount);
+  });
+
   test("leaves intact call/output pairs untouched", async () => {
     const { body } = await drive([
       { type: "function_call", id: "fc_ok", call_id: "call_ok", name: "exec_command", arguments: "{}" },

--- a/tests/responses-stateless-dangling-call-repair.test.ts
+++ b/tests/responses-stateless-dangling-call-repair.test.ts
@@ -155,6 +155,13 @@ describe("stateless Responses wire repairs orphaned tool calls", () => {
     expect(input.filter(item => item.type === "function_call")).toHaveLength(callCount);
     expect(input.filter(item => item.type === "function_call_output")).toHaveLength(callCount);
     expect(input.filter(item => item.type === "message")).toHaveLength(callCount);
+    for (let index = 0; index < callCount; index += 1) {
+      expect(input.slice(index * 3, index * 3 + 3)).toMatchObject([
+        { type: "function_call", call_id: "call_repeat" },
+        { type: "function_call_output", call_id: "call_repeat" },
+        { type: "message", content: [{ type: "input_text", text: `separator ${index}` }] },
+      ]);
+    }
   });
 
   test("leaves intact call/output pairs untouched", async () => {


### PR DESCRIPTION
## Summary

- replace the recursive orphan-call remainder scan with an iterative pass over pre-indexed output positions
- consume each output-key index through a durable per-key cursor, avoiding repeated `includes`, `indexOf`, sorting, and rescanning even when request-controlled call IDs repeat
- preserve the parallel call/output ordering contract established in #1912 while adding large unique-key and repeated-key regressions

Exact base: `f2ebd30679381f1f39cefd7c9ccec6510eba3373`  
Exact head: `b591cac294047b74e5c8a11b3b0c1b0f5c3566e8`

## Verification

- Bun 1.4.0-canary.1 test-only run on the exact base: the 20,000-call regression exceeded the 5-second limit and finished its synchronous work after 24.9 seconds
- Bun 1.4.0-canary.1 exact-head rerun of the same test — 1 pass, 0 fail; 0.49 seconds for the test body
- Bun 1.4.0-canary.1 `bun test tests/responses-stateless-dangling-call-repair.test.ts` — 10 pass, 0 fail
- Bun 1.4.0-canary.1 repeated-key adjacency regression — failed before the review fix, then passed after each batch was limited to its own output
- Bun 1.4.0-canary.1 `bun test tests/responses-forward-dangling-call.test.ts tests/deepseek-inbound-wire.test.ts` — 42 pass, 0 fail
- Bun 1.4.0-canary.1 `bun run typecheck` — passed
- Bun 1.4.0-canary.1 `bun run privacy:scan` — passed
- `git diff --check` — passed

No GUI files or user-facing configuration schema are changed. Maintained cross-platform CI remains the full-suite merge gate.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of separated function calls and their outputs.
  * Preserved correct call/output ordering, including repeated call identifiers.
  * Ensured separators and all repaired items are retained during processing.
  * Improved reliability when processing large batches without recursive behavior.

* **Tests**
  * Added regression and stress coverage for dangling function call repairs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->