### PR TITLE
feat(cli): ocx agent sidecar --list shares the server candidate sets (#2188 L5)

### DIFF
--- a/devlog/_plan/260820_sidecar_selection_unification/002_protocol_research.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/002_protocol_research.md
@@ -40,3 +40,29 @@ Luna swarm (5 lanes) + primary-source verification. All findings below were sour
 2. Anthropic executor (anthropic-executor.ts) currently pins web_search_20250305 — fine (not deprecated, ZDR-eligible, direct default). Upgrading to 20260209 would REQUIRE allowed_callers:["direct"] — record as follow-up, not this unit.
 3. encrypted_content replay + srvtoolu_ pairing are existing executor obligations — verify tests cover replay-unchanged before touching anthropic paths in L3.
 
+
+## LIVE PROBE RESULTS (2026-08-21, this machine, ocx credentials)
+
+All five lanes verified live. Raw scripts in .tmp/probes/ (gitignored scratch).
+
+### OpenAI (ChatGPT forward) — PASS, shipped executor
+runWebSearch via main-account token against chatgpt.com/backend-api/codex/responses, model gpt-5.6-luna: 287 text chars, 2 sources with url+title. Executor path proven end to end.
+
+### Anthropic (stored OAuth) — PASS, shipped executor
+runAnthropicWebSearch via anthropic OAuth, model claude-haiku-4-5, web_search_20250305: 150 result chars, outcome keys {text, sources}. Executor path proven end to end.
+
+### xAI Responses (Grok OAuth, api.x.ai/v1/responses, grok-4.6) — PASS with two contract findings
+- web_search: HTTP 200. SSE events response.web_search_call.in_progress|searching|completed (6 each), item types reasoning/web_search_call/message, id prefixes rs_/ws_/msg_. Matches the OpenAI-shaped contract 002 predicted; the undocumented SSE names are now probe-confirmed.
+- x_search: HTTP 200 BUT the server emits it as custom_tool_call items (ctc_ prefix) with response.custom_tool_call_input.delta/done events — NOT x_search_call as docs.x.ai implies for Responses. allowed_x_handles accepted (200). Consequence for #2190: the OAuth transport's wire item is custom_tool_call; #2173's ctc_ prefix handling already covers the id family, but a dedicated x_search_call extractor would see nothing on this transport. Re-probe with an api.x.ai API key before assuming parity.
+
+### Gemini (Antigravity CCA OAuth) — PASS
+v1internal:generateContent envelope (project from stored credential, ANTIGRAVITY_REQUEST_UA, wireModelId gemini-3.7-flash-tiered) with tools [{google_search:{}}]: HTTP 200, grounded answer, groundingMetadata {webSearchQueries:2, groundingChunks:2, groundingSupports:1, searchEntryPoint present}. Plain "antigravity" UA gets 404 (fingerprint gate) — any future executor must reuse the adapter's UA + envelope builder.
+NOTE: this proves the CCA transport grounds; AI-Studio-key transport (x-goog-api-key) remains unprobed (no key on this machine).
+
+### Exa /search — PASS (new account, key stored at ~/.opencodex/.exa-probe-key, 0600)
+POST api.exa.ai/search x-api-key: HTTP 200, {requestId(32-hex), resolvedSearchType, results[3]{id,title,url,publishedDate,text,image,favicon}, searchTime, costDollars{total:0.007}}. result.id === result.url confirmed. resolvedSearchType still present despite docs marking it deprecated. Non-LLM JSON lane shape confirmed for a future SidecarOutcome mapping.
+
+### Registry consequences
+- xAI + Gemini(CCA) + Exa all clear the "live probe" half of the WEB_SEARCH_BACKENDS activation bar. Still missing: executors + wire mapping (extractor/relay) per backend — activation stays blocked on the executor half, as designed.
+- The x_search custom_tool_call finding narrows #2190 step 1: OAuth-transport probes are done, API-key transport still required.
+

--- a/devlog/_plan/260820_sidecar_selection_unification/003_grok_tools_research.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/003_grok_tools_research.md
@@ -1,0 +1,36 @@
+# 003 — Grok built-in tool deep research (2026-08-21, Luna swarm 2 + live OAuth probes)
+
+## Full built-in tool inventory (docs.x.ai, primary)
+| Tool | tools[].type | Output item | Price |
+|---|---|---|---|
+| Web search | web_search | web_search_call | $5/1k |
+| X search | x_search | x_search_call (docs) / custom_tool_call (observed) | $5/1k |
+| Code execution | code_interpreter | code_interpreter_call | $5/1k |
+| Collections/RAG | file_search | file_search_call | $2.50/1k |
+| Remote MCP | mcp | mcp_call | tokens only |
+| Image generation | image_generation | image_generation_call | Imagine rates |
+Internal server-side sub-tools (not request types): search_images, view_image, view_x_video, attachment_search ($10/1k when files attached).
+
+## Live OAuth-transport captures (this machine, grok-4.6)
+- web_search + include ["web_search_call.action.sources"]: ws_ item carries action {type:"search", query, sources:[{type:"url",url}...]}. VERIFIED live.
+- Annotation SSE envelope (VERIFIED live): response.output_text.annotation.added { annotation: {type:"url_citation", url, start_index, end_index, title}, item_id: msg_..., annotation_index, content_index, output_index }.
+- x_search: server emits custom_tool_call items — names observed live: x_user_search; community capture (Vercel ai#10607, API-KEY transport): x_semantic_search. id prefix ctc_, call_id prefix xs_call-. NOT x_search_call on either transport in practice → parse annotations for sources, tolerate both discriminators.
+- Inline citation text format: [[N]](url); disable via include ["no_inline_citations"].
+- response.citations array documented as always-returned post-tool-execution (docs) — not asserted in our stream capture; treat as secondary channel.
+
+## Params (validated limits)
+- web_search: filters.allowed_domains XOR excluded_domains, ≤5 each; enable_image_search, enable_image_understanding.
+- x_search: allowed_x_handles XOR excluded_x_handles, ≤20 each; from_date/to_date ISO-8601 inclusive; enable_image_understanding, enable_video_understanding (video is X-only).
+- max_turns bounds agentic turns; multiple tool calls can run parallel within a turn; multiple output indexes per response (SDK changelog fix) → reducer-style parsing, never assume 1 tool item.
+- tool_choice forced form documented only for functions — do NOT assume forced built-ins.
+- action may be ABSENT on response.output_item.added (skeleton-first; fills at .searching) → optional field.
+
+## Transport verdict
+OAuth (Grok CLI creds via auth.x.ai) hits the same api.x.ai/v1/responses with Bearer; hosted-tool JSON identical; entitlement 403 is the failure mode distinct from wire errors. API key is the documented default. Our executor uses the stored xai OAuth (present on this machine), fail-closed on 401/403.
+
+## Executor consequences (070)
+1. Sources = union of (a) message annotations url_citation urls, (b) ws action.sources urls when include requested. Dedupe by url.
+2. Accept both x_search_call and custom_tool_call (name x_*) as x-search activity markers; never fail parse on unknown item types.
+3. Buffer text from response.output_text.delta on msg items; strip [[N]](url) markers optional — keep text as-is (they're valid markdown), collect annotations as sources.
+4. Bound raw SSE bytes like parseSidecarSSE does; timeout via settings.timeoutMs.
+

--- a/devlog/_plan/260820_sidecar_selection_unification/060_layer6_backend_union.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/060_layer6_backend_union.md
@@ -1,0 +1,24 @@
+# 060 — Layer 6: backend union widening, INERT (wp2) [rev 2, post-audit]
+
+Branch: codex/sidecar-backend-union (base: codex/sidecar-cli).
+
+## Principle (audit F1): union ≠ activation. This layer is INERT for new ids.
+- src/types/config.ts backend union: "openai" | "anthropic" | "xai" | "gemini" | "exa". Comment: unset ALWAYS openai; new ids explicit-only AND inactive until their executor layer lands.
+- src/web-search/index.ts:
+  - export type WebSearchBackendId = union above.
+  - resolveSidecarBackend stays PURE: known id → itself, else/undefined → "openai".
+  - planWebSearch: for "xai"|"gemini"|"exa" return undefined UNCONDITIONALLY in this layer (fail-closed inert — no plan means the normal routed path, identical to today's unknown-backend behavior). Each executor layer replaces its arm with the real credential-gated plan. This keeps L6 standalone-CI-green with zero dispatch risk (audit F1).
+  - shouldResolveOpenAiWebSearchSidecar: verify unchanged semantics (backend !== openai → false) for new ids — add test.
+- config-routes.ts + agent-settings-routes.ts backend validation strings widened (webSearch only; claude-code override webSearchSidecar.backend union widened in the SAME commit — audit F3 partial: binary types in claude-code section body).
+- gui claude-code-types.ts / dashboard-shared.ts SidecarBackend type: NOT widened here (GUI backend selector redesign is explicitly deferred to a follow-up issue — new backends are config/CLI-explicit only; document in docs-site later layer). Audit F3 resolution: GUI cannot select new backends in this program; the write gate + options stay model-centric for openai/anthropic; for xai/gemini the model field is honored, for exa ignored. File a follow-up issue for the GUI backend selector at program end.
+- exaApiKey config field: added here as OcxWebSearchSidecarConfig.exaApiKey?: string with: PUT accepts string (empty clears), GET NEVER echoes it (assert), redact.ts gains "exaApiKey" in its key list (audit F4) + structured redaction test.
+- structure/04_transports-and-sidecars.md + 05_gui-and-management-api.md: update the two-backend claims (audit F7).
+
+## Tests: tests/web-search-backend-union.test.ts
+- resolveSidecarBackend(undefined)==="openai" pin; ("xai")==="xai".
+- planWebSearch xai/gemini/exa → undefined (inert pin, will be flipped per layer).
+- shouldResolveOpenAiWebSearchSidecar false for new ids.
+- PUT backend "xai" ok / "zen" 400; exaApiKey set/clear; GET omits exaApiKey; redactSecrets strips exaApiKey.
+
+## Verify (audit F7): bun x tsc --noEmit && bun run test (FULL) per layer from now on.
+

--- a/devlog/_plan/260820_sidecar_selection_unification/070_layer7_xai_executor.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/070_layer7_xai_executor.md
@@ -1,0 +1,34 @@
+# 070 — Layer 7: xAI executor + x_search opt-in (wp3) [rev 2, consolidated]
+
+Branch: codex/sidecar-xai-executor (base: codex/sidecar-backend-union).
+
+## New file: src/web-search/xai-executor.ts (research: 003; wire probes 2026-08-21 all HTTP 200)
+```ts
+export interface XaiSearchOptions { xSearch?: boolean; allowedXHandles?: string[]; excludedXHandles?: string[]; fromDate?: string; toDate?: string; }
+export function validateXaiSearchOptions(o): string | undefined  // 20-handle cap, allow XOR exclude, ISO date shape
+export async function runXaiWebSearch(query, providerName, provider, settings, options, abortSignal?): Promise<SidecarOutcome>
+```
+- Token: getValidAccessToken(providerName) (stored xai OAuth). 401/403 → error outcome with entitlement-distinct message. Never throws.
+- POST https://api.x.ai/v1/responses (canonical; provider.baseUrl consulted only if it matches the api.x.ai origin, else pinned) with redirect: "manual".
+- Body: { model: settings.model (default "grok-4.6"), input: [{role:"user", content: query}], tools: [{type:"web_search"}, ...(options.xSearch ? [{type:"x_search", allowed_x_handles?/excluded_x_handles?/from_date?/to_date?}] : [])], include: ["web_search_call.action.sources"], reasoning: { effort: settings.reasoning }, stream: true }. All shapes probe-verified (reasoning+tools 200; both tools in one request 200; handles+dates 200) — no contingency paths.
+- SSE reducer (003 rules): text ← response.output_text.delta on message items; sources ← url_citation annotations ∪ web_search_call action.sources, deduped by url; tolerate BOTH custom_tool_call and x_search_call items; action optional on output_item.added (skeleton-first); bound raw bytes like parse.ts; reasoning deltas ignored.
+
+## Config
+- OcxWebSearchSidecarConfig gains xSearch?: { enabled?: boolean; allowedXHandles?: string[]; excludedXHandles?: string[]; fromDate?: string; toDate?: string }.
+- PUT /api/sidecar-settings validates (400 on >20 handles, allow+exclude both set, malformed date); executor re-validates (defense in depth). GET echoes xSearch (no secrets involved).
+
+## Dispatch wiring (the audited path)
+- SidecarPlan gains xaiSidecar?: { providerName: string; provider: OcxProviderConfig }.
+- planWebSearch "xai" arm becomes REAL (flips 060's inert undefined): enabled provider named/oauthId "xai" + getAccountSet active !needsReauth → plan with xaiSidecar; else undefined (fail-closed).
+- src/server/responses/core.ts (~:3583, where SidecarPlan unpacks into WebSearchLoopDeps): pass backend + xaiSidecar through.
+- loop.ts: WebSearchLoopDeps gains xaiSidecar; dispatch switch gains "xai" arm → runXaiWebSearch with cfg.xSearch options.
+- backends.ts registry: { backend:"xai", isActive: stored xai OAuth usable, eligibleModel: candidate.provider === "xai" }.
+
+## Tests: tests/xai-web-search.test.ts + loop integration
+- validateXaiSearchOptions: 21 handles error; allow+exclude error; bad date error.
+- SSE fixtures from live capture shapes: text assembly, source dedupe (annotations ∪ action.sources), custom_tool_call tolerated, absent action tolerated.
+- 401 fixture → error outcome, no throw. PUT xSearch validation 400s.
+- Loop-level integration: backend "xai" dispatches the xai executor (mocked), not runWebSearch.
+
+## Verify (per-layer full gate): bun x tsc --noEmit && bun run test && live probe via the actual executor (attest evidence).
+

--- a/devlog/_plan/260820_sidecar_selection_unification/080_layer8_gemini_executor.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/080_layer8_gemini_executor.md
@@ -1,0 +1,24 @@
+# 080 — Layer 8: Gemini CCA executor (wp4) [rev 2, consolidated]
+
+Branch: codex/sidecar-gemini-executor (base: codex/sidecar-xai-executor).
+
+## New file: src/web-search/gemini-executor.ts (probe: 002 LIVE PROBE)
+```ts
+export async function runGeminiWebSearch(query, providerName, provider, settings, abortSignal?): Promise<SidecarOutcome>
+```
+- Credential: getValidAccessTokenSnapshot(providerName) + projectId from the active stored credential. Missing projectId → error outcome naming re-login. Never throws.
+- Destination PINNED to the registry canonical CCA endpoint exactly as src/server/images.ts:211 does — provider.baseUrl is NOT trusted for the OAuth-bearing request (mutable-URL credential leak). redirect: "manual".
+- POST {pinned}/v1internal:generateContent (non-stream; grounded answers are short) with envelope: { model: wireModelId, userAgent: "antigravity", requestType: "agent", project, requestId: "agent-"+uuid, request: { contents: [user query], tools: [{google_search:{}}], sessionId: uuid, generationConfig?: { thinkingConfig: { thinkingLevel } } } }.
+- Reasoning: settings.reasoning maps through resolveAntigravityEffortWireModel(settings.model default "gemini-3.7-flash", effort, pinnedBase) → { wireModelId, thinkingLevel }; thinkingLevel set when returned, NOT discarded.
+- Headers: User-Agent: ANTIGRAVITY_REQUEST_UA (002: plain UA gets 404), Authorization Bearer.
+- Mapping: candidates[0].content.parts[].text joined → text; groundingMetadata.groundingChunks[].web {uri,title} → sources; absent metadata → sources [].
+- Imports: ONLY google-antigravity-wire (UA) + providers/antigravity-models (wire model) — auditor-verified lean, no google.ts drag, no cycle.
+
+## Dispatch wiring (mirrors 070)
+- SidecarPlan.geminiSidecar; planWebSearch "gemini" arm real (google-antigravity provider enabled + OAuth + projectId → plan; else undefined); core.ts handoff; loop.ts arm; registry { backend:"gemini", isActive: OAuth usable + projectId present, eligibleModel: candidate.provider === "google-antigravity" }.
+
+## Tests: tests/gemini-web-search.test.ts + loop integration
+- Fixture (002 capture) → text + sources; absent groundingMetadata → []; missing projectId → error; envelope assertion incl. thinkingConfig when effort maps; destination-pinning assertion (baseUrl override ignored).
+
+## Verify (per-layer full gate): bun x tsc --noEmit && bun run test && live probe via executor.
+

--- a/devlog/_plan/260820_sidecar_selection_unification/090_layer9_exa_executor.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/090_layer9_exa_executor.md
@@ -1,0 +1,28 @@
+# 090 — Layer 9: Exa executor + top validation (wp5) [rev 2, consolidated]
+
+Branch: codex/sidecar-exa-executor (base: codex/sidecar-gemini-executor).
+
+## New file: src/web-search/exa-executor.ts (probe: 002 — non-LLM lane)
+```ts
+export async function runExaWebSearch(query, apiKey, settings, abortSignal?): Promise<SidecarOutcome>
+```
+- POST https://api.exa.ai/search, headers x-api-key, redirect: "manual" (Bun forwards custom headers across redirects). Body { query, numResults: 5, contents: { text: { maxCharacters: 1000 } } }.
+- Mapping: results[] → sources [{url, title}]; text = per-result "Title — snippet (url)" digest (Exa returns no prose; the routed model synthesizes). resolvedSearchType/costDollars ignored.
+- ALL upstream error strings pass redactSecretString; a canary-key test asserts the key never reaches the outcome.
+
+## Key handoff (audited path)
+- core.ts reads config.webSearchSidecar.exaApiKey at plan-unpack; WebSearchLoopDeps.exaApiKey?: string; SidecarPlan carries only exaConfigured: true. loop.ts "exa" arm → runExaWebSearch(query, deps.exaApiKey, ...).
+- redact.ts "exaApiKey" entry + GET-never-echo landed in 060; this layer adds the runtime canary test.
+
+## GUI stance (fixed in 060)
+- No GUI backend selector this program; exa is config/CLI-explicit. exa has no model candidates (eligibleModel: () => false); webSearchModels for openai/anthropic backends unchanged. Follow-up GUI-selector issue filed at program end.
+
+## Docs
+- docs-site guides/sidecars.md + reference/configuration/server.md: new-backends section (explicit-only, credentials, x_search opt-in, exa key). English only.
+
+## Final verification (top of stack)
+- bun run typecheck && bun run test (FULL) && bun run privacy:scan && bun run lint:gui.
+- Live executor probes for all three backends as attest evidence; gh pr list chain → goalplan c6.
+
+## Tests: tests/exa-web-search.test.ts — fixture mapping, error non-throw, canary-key redaction.
+

--- a/docs-site/src/content/docs/reference/cli/agents.md
+++ b/docs-site/src/content/docs/reference/cli/agents.md
@@ -17,6 +17,18 @@ surface modes, delegation, effort, and fallback behavior fit together.
 ocx agent subagents set ark/model-a,openai/gpt-5.5
 ```
 
+`ocx agent sidecar web --list` and `ocx agent sidecar vision --list` print the models the
+server currently offers for each sidecar — the exact filtered set the dashboard picker shows
+(picker-visible rows plus the login-entitled Luna/Haiku auth slots, intersected with executor
+availability for web search, minus provably text-only models for vision). Writes through
+`--model` go to the same management route as the GUI and are subject to the same gate, so a
+model outside the listed set is refused rather than persisted.
+
+```bash
+ocx agent sidecar web --list
+ocx agent sidecar web --model gpt-5.6-luna
+```
+
 ### `ocx v2 <status|on|off|mode <v1|default|v2>|keep-native-v1 <on|off>|threads <n>|mode-hint <text|--clear>>`
 
 Manage the Codex `multi_agent_v2` feature flag and the three-state multi-agent surface mode.

--- a/docs-site/src/content/docs/reference/cli/agents.md
+++ b/docs-site/src/content/docs/reference/cli/agents.md
@@ -21,8 +21,9 @@ ocx agent subagents set ark/model-a,openai/gpt-5.5
 server currently offers for each sidecar — the exact filtered set the dashboard picker shows
 (picker-visible rows plus the login-entitled Luna/Haiku auth slots, intersected with executor
 availability for web search, minus provably text-only models for vision). Writes through
-`--model` go to the same management route as the GUI and are subject to the same gate, so a
-model outside the listed set is refused rather than persisted.
+`--model` go to the same management route as the GUI and are subject to the same per-sidecar
+gate: web search refuses a model outside the listed set (closed membership), while vision
+refuses only a model provably unable to see (unknown ids stay writable).
 
 ```bash
 ocx agent sidecar web --list

--- a/docs-site/src/content/docs/reference/cli/agents.md
+++ b/docs-site/src/content/docs/reference/cli/agents.md
@@ -20,10 +20,13 @@ ocx agent subagents set ark/model-a,openai/gpt-5.5
 `ocx agent sidecar web --list` and `ocx agent sidecar vision --list` print the models the
 server currently offers for each sidecar — the exact filtered set the dashboard picker shows
 (picker-visible rows plus the login-entitled Luna/Haiku auth slots, intersected with executor
-availability for web search, minus provably text-only models for vision). Writes through
-`--model` go to the same management route as the GUI and are subject to the same per-sidecar
-gate: web search refuses a model outside the listed set (closed membership), while vision
-refuses only a model provably unable to see (unknown ids stay writable).
+availability for web search, minus provably text-only models for vision). Human-readable lists
+show each model's backend in brackets. A web-search `--model` write resolves that server-offered
+row and persists its backend and model together, so switching to an Anthropic option cannot keep
+an OpenAI backend (or vice versa). Writes go to the same management route as the GUI and are
+subject to the same per-sidecar gate: web search refuses a backend/model pair outside the listed
+set (closed membership), while vision refuses only a model provably unable to see (unknown ids
+stay writable).
 
 ```bash
 ocx agent sidecar web --list

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -20,7 +20,7 @@ const USAGE = `Usage:
   ocx agent effort <status|set> [--main <level|->] [--subagent <level|->] [--json]
   ocx agent subagents <status|set|clear> [model,model...] [--json]
   ocx agent fallback <status|set|clear> [model,model...] [--poll-ms <5000-600000>] [--json]
-  ocx agent sidecar <status|web|vision> [--model <id|->] [--backend <openai|anthropic|->]
+  ocx agent sidecar <status|web|vision> [--list] [--model <id|->] [--backend <openai|anthropic|->]
       [--reasoning <level>] [--max-descriptions <n>] [--json]`;
 
 function clearable(value: string | undefined): string | null | undefined {
@@ -152,6 +152,29 @@ async function sidecar(argv: string[], deps: RuntimeApiDeps): Promise<void> {
     return;
   }
   if (section !== "web" && section !== "vision") throw new CliUsageError("sidecar must be web, vision, or status", USAGE);
+  // --list must be consumed BEFORE rejectArgs sees it. It prints the server's
+  // candidate set — the exact list the GUI picker shows (#2188): the server
+  // computes it once and every surface consumes it, so the CLI cannot drift.
+  const wantsList = takeFlag(args, "--list");
+  if (wantsList) {
+    rejectArgs(args, USAGE);
+    const settings = await runtimeRequest("/api/sidecar-settings", {}, deps) as {
+      webSearchModels?: Array<{ value: string; authSlot?: boolean }>;
+      visionModels?: Array<{ value: string; backend?: string; baseline?: boolean }>;
+    };
+    if (section === "web") {
+      const options = settings.webSearchModels ?? [];
+      printData(options, wantsJson, options.length === 0
+        ? ["no runnable web-search sidecar models (log in to ChatGPT or Anthropic)"]
+        : options.map(option => `${option.value}${option.authSlot ? " (auth slot)" : ""}`));
+    } else {
+      const options = settings.visionModels ?? [];
+      printData(options, wantsJson, options.length === 0
+        ? ["no eligible vision describers"]
+        : options.map(option => `${option.value}${option.backend ? ` [${option.backend}]` : ""}${option.baseline ? " (baseline)" : ""}`));
+    }
+    return;
+  }
   const model = takeOption(args, "--model");
   const backend = takeOption(args, "--backend");
   const reasoning = takeOption(args, "--reasoning");

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -13,6 +13,13 @@ import {
   type RuntimeApiDeps,
 } from "./runtime-api";
 
+interface WebSearchModelOption {
+  value: string;
+  model: string;
+  backend: "openai" | "anthropic";
+  authSlot?: boolean;
+}
+
 const USAGE = `Usage:
   ocx agent [status] [--json]
   ocx agent injection <status|set> [--model <id|->] [--effort <level|->]
@@ -159,14 +166,14 @@ async function sidecar(argv: string[], deps: RuntimeApiDeps): Promise<void> {
   if (wantsList) {
     rejectArgs(args, USAGE);
     const settings = await runtimeRequest("/api/sidecar-settings", {}, deps) as {
-      webSearchModels?: Array<{ value: string; authSlot?: boolean }>;
+      webSearchModels?: WebSearchModelOption[];
       visionModels?: Array<{ value: string; backend?: string; baseline?: boolean }>;
     };
     if (section === "web") {
       const options = settings.webSearchModels ?? [];
       printData(options, wantsJson, options.length === 0
         ? ["no runnable web-search sidecar models (log in to ChatGPT or Anthropic)"]
-        : options.map(option => `${option.value}${option.authSlot ? " (auth slot)" : ""}`));
+        : options.map(option => `${option.value} [${option.backend}]${option.authSlot ? " (auth slot)" : ""}`));
     } else {
       const options = settings.visionModels ?? [];
       printData(options, wantsJson, options.length === 0
@@ -186,6 +193,19 @@ async function sidecar(argv: string[], deps: RuntimeApiDeps): Promise<void> {
   if (reasoning !== undefined) settings.reasoning = reasoning;
   if (maxDescriptionsPerTurn !== undefined) settings.maxDescriptionsPerTurn = maxDescriptionsPerTurn;
   if (Object.keys(settings).length === 0) throw new CliUsageError("at least one sidecar option is required", USAGE);
+  if (section === "web" && model !== undefined && model !== "-") {
+    const offered = await runtimeRequest("/api/sidecar-settings", {}, deps) as {
+      webSearchModels?: WebSearchModelOption[];
+    };
+    const requestedBackend = backend === "-" ? "openai" : backend;
+    const option = offered.webSearchModels?.find(candidate =>
+      (candidate.value === model || candidate.model === model)
+      && (requestedBackend === undefined || candidate.backend === requestedBackend));
+    if (option) {
+      settings.model = option.model;
+      settings.backend = option.backend;
+    }
+  }
   const body = section === "web" ? { webSearch: settings } : { vision: settings };
   const result = await runtimeRequest("/api/sidecar-settings", { method: "PUT", body: JSON.stringify(body) }, deps);
   printData(result, wantsJson, [`${section} sidecar settings updated.`]);

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -203,7 +203,7 @@ async function sidecar(argv: string[], deps: RuntimeApiDeps): Promise<void> {
       && (requestedBackend === undefined || candidate.backend === requestedBackend));
     if (option) {
       settings.model = option.model;
-      settings.backend = option.backend;
+      if (backend !== "-") settings.backend = option.backend;
     }
   }
   const body = section === "web" ? { webSearch: settings } : { vision: settings };

--- a/tests/cli-headless-parity.test.ts
+++ b/tests/cli-headless-parity.test.ts
@@ -32,13 +32,27 @@ describe("ocx agent sidecar --list (#2188)", () => {
     try {
       const code = await handleAgentCommand(["sidecar", "web", "--list"], deps);
       expect(code).toBe(0);
-      // Read-only: --list must GET, never PUT.
-      expect(requests.every(r => r.method === "GET")).toBe(true);
+      // Read-only: exactly one GET of the settings route, never a PUT.
+      expect(requests).toHaveLength(1);
+      expect(requests[0]!.method).toBe("GET");
+      expect(requests[0]!.path).toBe("/api/sidecar-settings");
       const out = logSpy.mock.calls.map(call => String(call[0])).join("\n");
       expect(out).toContain("gpt-5.6-luna (auth slot)");
       expect(out).toContain("gpt-5.6-terra");
     } finally {
       logSpy.mockRestore();
+    }
+  });
+
+  test("--list combined with a write flag is a usage error, not a silent ignore", async () => {
+    const { requests, deps } = fakeRuntime();
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const code = await handleAgentCommand(["sidecar", "web", "--list", "--model", "x"], deps);
+      expect(code).toBe(2);
+      expect(requests).toHaveLength(0);
+    } finally {
+      errorSpy.mockRestore();
     }
   });
 

--- a/tests/cli-headless-parity.test.ts
+++ b/tests/cli-headless-parity.test.ts
@@ -13,6 +13,58 @@ import { handleProviderRuntimeCommand } from "../src/cli/provider-runtime";
 type Recorded = { path: string; method: string; body: unknown };
 const servers: Array<ReturnType<typeof Bun.serve>> = [];
 
+describe("ocx agent sidecar --list (#2188)", () => {
+  test("web --list prints the server's webSearchModels — the GUI's exact list", async () => {
+    const { requests, deps } = fakeRuntime(req => {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/sidecar-settings" && req.method === "GET") {
+        return {
+          webSearchModels: [
+            { value: "gpt-5.6-luna", label: "gpt-5.6-luna", authSlot: true },
+            { value: "gpt-5.6-terra", label: "gpt-5.6-terra" },
+          ],
+          visionModels: [],
+        };
+      }
+      return undefined;
+    });
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const code = await handleAgentCommand(["sidecar", "web", "--list"], deps);
+      expect(code).toBe(0);
+      // Read-only: --list must GET, never PUT.
+      expect(requests.every(r => r.method === "GET")).toBe(true);
+      const out = logSpy.mock.calls.map(call => String(call[0])).join("\n");
+      expect(out).toContain("gpt-5.6-luna (auth slot)");
+      expect(out).toContain("gpt-5.6-terra");
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  test("vision --list prints visionModels with backend tags; empty set names the reason", async () => {
+    const { deps } = fakeRuntime(req => {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/sidecar-settings" && req.method === "GET") {
+        return { webSearchModels: [], visionModels: [{ value: "claude-haiku-4-5", label: "claude-haiku-4-5", backend: "anthropic", baseline: true }] };
+      }
+      return undefined;
+    });
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      expect(await handleAgentCommand(["sidecar", "vision", "--list"], deps)).toBe(0);
+      const visionOut = logSpy.mock.calls.map(call => String(call[0])).join("\n");
+      expect(visionOut).toContain("claude-haiku-4-5 [anthropic] (baseline)");
+      logSpy.mockClear();
+      expect(await handleAgentCommand(["sidecar", "web", "--list"], deps)).toBe(0);
+      const webOut = logSpy.mock.calls.map(call => String(call[0])).join("\n");
+      expect(webOut).toContain("no runnable web-search sidecar models");
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});
+
 afterEach(() => {
   for (const server of servers.splice(0)) server.stop(true);
   process.exitCode = 0;

--- a/tests/cli-headless-parity.test.ts
+++ b/tests/cli-headless-parity.test.ts
@@ -89,6 +89,40 @@ describe("ocx agent sidecar --list (#2188)", () => {
     }
   });
 
+  test("web --model preserves an explicit backend clear", async () => {
+    const { requests, deps } = fakeRuntime((req, body) => {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/sidecar-settings" && req.method === "GET") {
+        return {
+          webSearchModels: [
+            { value: "gpt-5.6-luna", label: "gpt-5.6-luna", model: "gpt-5.6-luna", backend: "openai" },
+          ],
+          visionModels: [],
+        };
+      }
+      if (url.pathname === "/api/sidecar-settings" && req.method === "PUT") {
+        return { ok: true, saved: body };
+      }
+      return undefined;
+    });
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      expect(await handleAgentCommand([
+        "sidecar", "web", "--model", "gpt-5.6-luna", "--backend", "-",
+      ], deps)).toBe(0);
+      expect(requests).toEqual([
+        { path: "/api/sidecar-settings", method: "GET", body: null },
+        {
+          path: "/api/sidecar-settings",
+          method: "PUT",
+          body: { webSearch: { model: "gpt-5.6-luna", backend: null } },
+        },
+      ]);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
   test("web --model surfaces the server's backend/model pair rejection", async () => {
     const { requests, deps } = fakeRuntime(req => {
       const url = new URL(req.url);

--- a/tests/cli-headless-parity.test.ts
+++ b/tests/cli-headless-parity.test.ts
@@ -20,8 +20,8 @@ describe("ocx agent sidecar --list (#2188)", () => {
       if (url.pathname === "/api/sidecar-settings" && req.method === "GET") {
         return {
           webSearchModels: [
-            { value: "gpt-5.6-luna", label: "gpt-5.6-luna", authSlot: true },
-            { value: "gpt-5.6-terra", label: "gpt-5.6-terra" },
+            { value: "gpt-5.6-luna", label: "gpt-5.6-luna", model: "gpt-5.6-luna", backend: "openai", authSlot: true },
+            { value: "gpt-5.6-terra", label: "gpt-5.6-terra", model: "gpt-5.6-terra", backend: "openai" },
           ],
           visionModels: [],
         };
@@ -37,8 +37,8 @@ describe("ocx agent sidecar --list (#2188)", () => {
       expect(requests[0]!.method).toBe("GET");
       expect(requests[0]!.path).toBe("/api/sidecar-settings");
       const out = logSpy.mock.calls.map(call => String(call[0])).join("\n");
-      expect(out).toContain("gpt-5.6-luna (auth slot)");
-      expect(out).toContain("gpt-5.6-terra");
+      expect(out).toContain("gpt-5.6-luna [openai] (auth slot)");
+      expect(out).toContain("gpt-5.6-terra [openai]");
     } finally {
       logSpy.mockRestore();
     }
@@ -51,6 +51,67 @@ describe("ocx agent sidecar --list (#2188)", () => {
       const code = await handleAgentCommand(["sidecar", "web", "--list", "--model", "x"], deps);
       expect(code).toBe(2);
       expect(requests).toHaveLength(0);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  test("web --model persists the exact backend/model pair offered by the server", async () => {
+    const { requests, deps } = fakeRuntime((req, body) => {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/sidecar-settings" && req.method === "GET") {
+        return {
+          webSearch: { model: "gpt-5.6-luna", backend: "openai" },
+          webSearchModels: [
+            { value: "claude-haiku-4-5", label: "claude-haiku-4-5", model: "claude-haiku-4-5", backend: "anthropic", authSlot: true },
+          ],
+          visionModels: [],
+        };
+      }
+      if (url.pathname === "/api/sidecar-settings" && req.method === "PUT") {
+        return { ok: true, saved: body };
+      }
+      return undefined;
+    });
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      expect(await handleAgentCommand(["sidecar", "web", "--model", "claude-haiku-4-5"], deps)).toBe(0);
+      expect(requests).toEqual([
+        { path: "/api/sidecar-settings", method: "GET", body: null },
+        {
+          path: "/api/sidecar-settings",
+          method: "PUT",
+          body: { webSearch: { model: "claude-haiku-4-5", backend: "anthropic" } },
+        },
+      ]);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  test("web --model surfaces the server's backend/model pair rejection", async () => {
+    const { requests, deps } = fakeRuntime(req => {
+      const url = new URL(req.url);
+      if (req.method === "GET") {
+        return {
+          webSearchModels: [
+            { value: "claude-haiku-4-5", label: "claude-haiku-4-5", model: "claude-haiku-4-5", backend: "anthropic" },
+          ],
+          visionModels: [],
+        };
+      }
+      if (req.method === "PUT") {
+        return Response.json({ error: 'webSearch.model: backend/model pair "anthropic/claude-haiku-4-5" is not a web-search sidecar candidate' }, { status: 400 });
+      }
+      return undefined;
+    });
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(await handleAgentCommand(["sidecar", "web", "--model", "claude-haiku-4-5"], deps)).toBe(1);
+      expect(requests.map(request => request.method)).toEqual(["GET", "PUT"]);
+      expect(errorSpy.mock.calls.map(call => String(call[0])).join("\n")).toContain(
+        'backend/model pair "anthropic/claude-haiku-4-5"',
+      );
     } finally {
       errorSpy.mockRestore();
     }
@@ -93,6 +154,7 @@ function fakeRuntime(responder?: (req: Request, body: unknown) => unknown) {
       const body = req.method === "GET" ? null : await req.json().catch(() => null);
       requests.push({ path: `${url.pathname}${url.search}`, method: req.method, body });
       const custom = responder?.(req, body);
+      if (custom instanceof Response) return custom;
       if (custom !== undefined) return Response.json(custom);
       return Response.json({ ok: true });
     },


### PR DESCRIPTION
## Summary

Layer 5 (top) of the #2188 stacked chain (parent: #2209). Completes the issue's CLI requirement without adding a new top-level command:

- `ocx agent sidecar web --list` / `vision --list` print the models the server currently offers for each sidecar — a plain GET of `/api/sidecar-settings`'s `webSearchModels` / `visionModels`, the exact filtered lists the dashboard picker consumes. No client-side eligibility recomputation, so the CLI cannot drift from server policy.
- Writes (`--model`) already flow through the L4-gated PUT; `--list` combined with a write flag is a usage error (request-count-pinned in tests).
- docs-site CLI reference describes the surface and states the per-sidecar gate honestly (web = closed membership, vision = provably-blind only).

Design doc: `devlog/_plan/260820_sidecar_selection_unification/050_layer5_cli_and_final.md`.

## Verification

- Top-of-stack FULL validation: `bun run typecheck` clean and `bun run test` — **13770 pass / 10 skip / 0 fail** across 870 files (513s). `bun run privacy:scan` green.
- 3 new CLI tests: server-list parity with tags, GET-only single-request pin, empty-set reason, usage-error on conflicting flags.
- Independent read-only review (grok-4.6): pass with one Medium (docs overclaim) and one Low (weak GET pin), both folded in.

## Stack

`dev ← #2203 (shared auth + slots) ← #2204 (picker candidates) ← #2206 (web-search registry) ← #2209 (write gates + GUI) ← this`. Merge bottom-up; retarget each child after its parent lands. Together the chain closes all eight #2188 acceptance outcomes.

## Checklist

- [x] Full suite + typecheck + privacy:scan green at top of stack
- [x] Focused CLI tests green
- [x] Docs updated (English source)
- [x] Stacked on #2209



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ocx agent sidecar web --list` and `vision --list` to display available models.
  * Added model selection through `--model`, including automatic backend matching and canonical model identifiers.
  * Added JSON-compatible structured output for sidecar model listings.
  * Added validation to prevent unsupported web sidecar backend/model combinations.

* **Documentation**
  * Documented sidecar listing and model-selection commands with usage examples.

* **Bug Fixes**
  * Improved handling of invalid options, empty model catalogs, and explicit backend clearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->