### PR TITLE
fix(cursor): route composer-2.5 tool continuations through userMessageAction

### DIFF
--- a/src/adapters/cursor/discovery.ts
+++ b/src/adapters/cursor/discovery.ts
@@ -146,6 +146,24 @@ export function isCursorExternalWireModel(modelId: string): boolean {
   return !isCursorNativeWireModel(modelId);
 }
 
+/**
+ * Native composer models whose tool-result continuation must still be sent as a
+ * userMessageAction with the plain "Continue:" text instead of a bare resumeAction.
+ *
+ * Observed on live Cursor Connect traffic (2026-08-20): `composer-2.5` (the
+ * standard, non-fast build) resumes a tool-result turn with server-side native
+ * tool calls (read/grep/exec) instead of answering, or completes with zero text
+ * (empty `content` + `stop`). `composer-2.5-fast` answers correctly on the same
+ * resumeAction path, so only the affected id is listed here. Sending the same
+ * continuation as an explicit user message (external path) makes the model
+ * answer reliably.
+ */
+export function cursorNeedsExternalToolContinuation(modelId: string): boolean {
+  if (isCursorExternalWireModel(modelId)) return true;
+  const wire = cursorCodexToWireModelId(modelId).trim().toLowerCase();
+  return wire === "composer-2.5";
+}
+
 function stripCursorEffortSuffix(wireModelId: string): string {
   const suffixes = [...CANONICAL_EFFORT_SUFFIXES].sort((a, b) => b.length - a.length);
   for (const suffix of suffixes) {

--- a/src/adapters/cursor/protobuf-request.ts
+++ b/src/adapters/cursor/protobuf-request.ts
@@ -4,7 +4,7 @@ import { ValueSchema } from "@bufbuild/protobuf/wkt";
 import type { OcxAssistantContentPart, OcxMessage, OcxToolResultMessage } from "../../types";
 import { namespacedToolName } from "../../types";
 import type { CursorRunRequest } from "./types";
-import { isCursorExternalWireModel } from "./discovery";
+import { cursorNeedsExternalToolContinuation } from "./discovery";
 import { normalizeCursorToolResultText } from "./tool-result-normalize";
 import { debugProviderDiagnostic } from "../../lib/debug";
 import {
@@ -209,7 +209,7 @@ function rootPromptMessages(request: CursorRunRequest, requestScope: CursorBlobR
     };
   }
 
-  const externalModel = isCursorExternalWireModel(request.modelId);
+  const externalModel = cursorNeedsExternalToolContinuation(request.modelId);
   const lastRawIsToolResult = messages.at(-1)?.role === "toolResult";
   const activeUserIndex = lastRawIsToolResult ? -1 : lastActionIndex(messages);
 
@@ -641,7 +641,7 @@ function conversationTurns(
   const messages = request.rawMessages;
   if (!messages?.length) return [];
   const end = lastActionIndex(messages);
-  const externalModel = isCursorExternalWireModel(request.modelId);
+  const externalModel = cursorNeedsExternalToolContinuation(request.modelId);
   const historyEnd = messages.at(-1)?.role === "toolResult" ? messages.length : Math.max(0, end);
   const start = externalModel ? Math.max(0, historyMessageStart) : 0;
   const turns: Uint8Array[] = [];
@@ -793,8 +793,11 @@ function buildPreparedCursorRunRequest(
   const lastRawIsToolResult = request.rawMessages?.at(-1)?.role === "toolResult";
   // Native models resume the remembered Cursor conversation. External wire
   // models continue as userMessageAction so history-blob tool results stay
-  // visible without a ResumeAction.
-  const externalToolContinuation = lastRawIsToolResult && isCursorExternalWireModel(request.modelId);
+  // visible without a ResumeAction. Some native composer ids are also routed
+  // through the external continuation path (cursorNeedsExternalToolContinuation)
+  // because a bare resumeAction makes them continue exploring with native tools
+  // instead of answering (observed on composer-2.5; see discovery.ts).
+  const externalToolContinuation = lastRawIsToolResult && cursorNeedsExternalToolContinuation(request.modelId);
   const actionCase = (externalToolContinuation || (!lastRawIsToolResult && text.trim().length > 0))
     ? "userMessageAction"
     : "resumeAction";
@@ -832,7 +835,7 @@ function buildPreparedCursorRunRequest(
     action: actionCase,
     conversationId: request.conversationId,
     turnType: lastRawIsToolResult ? "tool-continuation" : "initial",
-    externalModel: isCursorExternalWireModel(request.modelId),
+    externalModel: cursorNeedsExternalToolContinuation(request.modelId),
     rawMessages: request.rawMessages?.length ?? 0,
     rootBlobs: rootPromptMessageIds.length,
     rootBytes: rootPromptMessagesState.byteLength,

--- a/src/adapters/cursor/protobuf-request.ts
+++ b/src/adapters/cursor/protobuf-request.ts
@@ -4,7 +4,7 @@ import { ValueSchema } from "@bufbuild/protobuf/wkt";
 import type { OcxAssistantContentPart, OcxMessage, OcxToolResultMessage } from "../../types";
 import { namespacedToolName } from "../../types";
 import type { CursorRunRequest } from "./types";
-import { cursorNeedsExternalToolContinuation } from "./discovery";
+import { cursorNeedsExternalToolContinuation, isCursorExternalWireModel } from "./discovery";
 import { normalizeCursorToolResultText } from "./tool-result-normalize";
 import { debugProviderDiagnostic } from "../../lib/debug";
 import {
@@ -209,7 +209,7 @@ function rootPromptMessages(request: CursorRunRequest, requestScope: CursorBlobR
     };
   }
 
-  const externalModel = cursorNeedsExternalToolContinuation(request.modelId);
+  const externalModel = isCursorExternalWireModel(request.modelId);
   const lastRawIsToolResult = messages.at(-1)?.role === "toolResult";
   const activeUserIndex = lastRawIsToolResult ? -1 : lastActionIndex(messages);
 
@@ -641,7 +641,7 @@ function conversationTurns(
   const messages = request.rawMessages;
   if (!messages?.length) return [];
   const end = lastActionIndex(messages);
-  const externalModel = cursorNeedsExternalToolContinuation(request.modelId);
+  const externalModel = isCursorExternalWireModel(request.modelId);
   const historyEnd = messages.at(-1)?.role === "toolResult" ? messages.length : Math.max(0, end);
   const start = externalModel ? Math.max(0, historyMessageStart) : 0;
   const turns: Uint8Array[] = [];
@@ -835,7 +835,7 @@ function buildPreparedCursorRunRequest(
     action: actionCase,
     conversationId: request.conversationId,
     turnType: lastRawIsToolResult ? "tool-continuation" : "initial",
-    externalModel: cursorNeedsExternalToolContinuation(request.modelId),
+    externalModel: isCursorExternalWireModel(request.modelId),
     rawMessages: request.rawMessages?.length ?? 0,
     rootBlobs: rootPromptMessageIds.length,
     rootBytes: rootPromptMessagesState.byteLength,

--- a/tests/cursor-blob.test.ts
+++ b/tests/cursor-blob.test.ts
@@ -602,8 +602,31 @@ describe("Cursor blob handshake", () => {
 
   test("keeps ResumeAction for native-model tool-result continuations", () => {
     const bytes = encodeCursorRunRequest({
-      modelId: "composer-2.5",
+      modelId: "composer-2.5-fast",
       conversationId: "c1",
+      system: ["You are helpful."],
+      messages: [{ role: "tool", content: "[tool_result]\ncall_id: call_1\nname: read_file\nis_error: false\noutput:\ncontents" }],
+      rawMessages: [
+        { role: "user", content: "read a file", timestamp: 1 },
+        {
+          role: "assistant",
+          model: "cursor/composer-2.5-fast",
+          timestamp: 2,
+          content: [{ type: "toolCall", id: "call_1", name: "read_file", arguments: { path: "a.txt" } }],
+        },
+        { role: "toolResult", toolCallId: "call_1", toolName: "read_file", content: "contents", isError: false, timestamp: 3 },
+      ],
+    });
+    const msg = fromBinary(AgentClientMessageSchema, bytes);
+    const run = msg.message.case === "runRequest" ? msg.message.value : undefined;
+
+    expect(run?.action?.action.case).toBe("resumeAction");
+  });
+
+  test("drives composer-2.5 tool-result continuations as userMessageAction", () => {
+    const bytes = encodeCursorRunRequest({
+      modelId: "composer-2.5",
+      conversationId: "c-composer-cont",
       system: ["You are helpful."],
       messages: [{ role: "tool", content: "[tool_result]\ncall_id: call_1\nname: read_file\nis_error: false\noutput:\ncontents" }],
       rawMessages: [
@@ -620,12 +643,16 @@ describe("Cursor blob handshake", () => {
     const msg = fromBinary(AgentClientMessageSchema, bytes);
     const run = msg.message.case === "runRequest" ? msg.message.value : undefined;
 
-    expect(run?.action?.action.case).toBe("resumeAction");
+    expect(run?.action?.action.case).toBe("userMessageAction");
+    const value = run?.action?.action.case === "userMessageAction" ? run.action.action.value : undefined;
+    expect(value?.userMessage?.text).toBe(CURSOR_EXTERNAL_TOOL_CONTINUATION_TEXT);
+    const roots = decodeRootMessages(bytes) as Array<{ role?: string }>;
+    expect(JSON.stringify(roots)).toContain("contents");
   });
 
   test("drives external-model tool-result continuations as userMessageAction", () => {
-    // External wire models encode tool-result hops as userMessageAction; native
-    // models keep resumeAction. Tool results stay in the history blobs.
+    // External wire models encode tool-result hops as userMessageAction. Native
+    // composer-2.5 uses the same path; other native composer ids keep resumeAction.
     const bytes = encodeCursorRunRequest({
       modelId: "claude-fable-5",
       conversationId: "c-ext-cont",

--- a/tests/cursor-blob.test.ts
+++ b/tests/cursor-blob.test.ts
@@ -525,7 +525,7 @@ describe("Cursor blob handshake", () => {
 
   test("native Cursor replay preserves tool calls with results in turn steps", () => {
     const bytes = encodeCursorRunRequest({
-      modelId: "composer-2.5",
+      modelId: "composer-2.5-fast",
       conversationId: "c1",
       system: ["You are helpful."],
       messages: [{ role: "tool", content: "[tool_result]\ncall_id: call_1\nname: read_file\nis_error: false\noutput:\ncontents" }],

--- a/tests/cursor-blob.test.ts
+++ b/tests/cursor-blob.test.ts
@@ -525,7 +525,7 @@ describe("Cursor blob handshake", () => {
 
   test("native Cursor replay preserves tool calls with results in turn steps", () => {
     const bytes = encodeCursorRunRequest({
-      modelId: "composer-2.5-fast",
+      modelId: "composer-2.5",
       conversationId: "c1",
       system: ["You are helpful."],
       messages: [{ role: "tool", content: "[tool_result]\ncall_id: call_1\nname: read_file\nis_error: false\noutput:\ncontents" }],
@@ -561,7 +561,44 @@ describe("Cursor blob handshake", () => {
         if (content?.case === "text") expect(content.value.text).toBe("contents");
       }
     }
-    expect(run?.action?.action.case).toBe("resumeAction");
+    expect(run?.action?.action.case).toBe("userMessageAction");
+    const value = run?.action?.action.case === "userMessageAction" ? run.action.action.value : undefined;
+    expect(value?.userMessage?.text).toBe(CURSOR_EXTERNAL_TOOL_CONTINUATION_TEXT);
+  });
+
+  test("composer-2.5 ordinary turns keep native replay semantics", () => {
+    const bytes = encodeCursorRunRequest({
+      modelId: "composer-2.5",
+      conversationId: "c-native-turn",
+      system: ["You are helpful."],
+      messages: [{ role: "user", content: "follow up" }],
+      rawMessages: [
+        { role: "user", content: "read a file", timestamp: 1 },
+        {
+          role: "assistant",
+          model: "cursor/composer-2.5",
+          timestamp: 2,
+          content: [
+            { type: "thinking", thinking: "hidden reasoning" },
+            { type: "text", text: "I'll read it" },
+          ],
+        },
+        { role: "user", content: "follow up", timestamp: 3 },
+      ],
+    });
+    const msg = fromBinary(AgentClientMessageSchema, bytes);
+    const run = msg.message.case === "runRequest" ? msg.message.value : undefined;
+    const turn = fromBinary(ConversationTurnStructureSchema, blobData(run?.conversationState?.turns[0] ?? new Uint8Array()));
+    expect(turn.turn.case).toBe("agentConversationTurn");
+    const steps = turn.turn.case === "agentConversationTurn" ? turn.turn.value.steps : [];
+    expect(steps).toHaveLength(2);
+    const firstStep = fromBinary(ConversationStepSchema, blobData(steps[0]!));
+    const secondStep = fromBinary(ConversationStepSchema, blobData(steps[1]!));
+    expect(firstStep.message.case).toBe("thinkingMessage");
+    expect(secondStep.message.case).toBe("assistantMessage");
+    expect(run?.action?.action.case).toBe("userMessageAction");
+    const roots = decodeRootMessages(bytes) as Array<{ role?: string; content?: unknown }>;
+    expect(JSON.stringify(roots)).toContain("hidden reasoning");
   });
 
   test("external Cursor replay uses text history instead of native tool/thinking structures", () => {

--- a/tests/cursor-discovery.test.ts
+++ b/tests/cursor-discovery.test.ts
@@ -16,6 +16,7 @@ import {
   inferCursorContextWindow,
   isCursorExternalWireModel,
   isCursorNativeWireModel,
+  cursorNeedsExternalToolContinuation,
   normalizeCursorModels,
 } from "../src/adapters/cursor/discovery";
 
@@ -186,5 +187,14 @@ describe("Cursor discovery metadata", () => {
     expect(isCursorExternalWireModel("gpt-5.6-sol-xhigh")).toBe(true);
     expect(isCursorExternalWireModel("claude-4.6-sonnet-high")).toBe(true);
     expect(isCursorExternalWireModel("cursor/gpt-5.6-sol")).toBe(true);
+  });
+
+  test("routes composer-2.5 tool continuations through the external userMessageAction path", () => {
+    expect(cursorNeedsExternalToolContinuation("composer-2.5")).toBe(true);
+    expect(cursorNeedsExternalToolContinuation("cursor/composer-2.5")).toBe(true);
+    expect(cursorNeedsExternalToolContinuation("composer-2.5-fast")).toBe(false);
+    expect(cursorNeedsExternalToolContinuation("cursor/composer-2.5-fast")).toBe(false);
+    expect(cursorNeedsExternalToolContinuation("auto")).toBe(false);
+    expect(cursorNeedsExternalToolContinuation("gpt-5.6-sol")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

`cursor/composer-2.5` returns empty `content` with `finish_reason: stop` after tool-result continuation when proxied through opencodex. `cursor/composer-2.5-fast` works correctly on the same code path.

On `resumeAction`, composer-2.5 either issues native Cursor tool calls (read/grep/exec) instead of answering, or completes with zero visible text while consuming tokens.

**Fix:** Add `cursorNeedsExternalToolContinuation()` — routes `composer-2.5` tool-result continuations through `userMessageAction` + `CURSOR_EXTERNAL_TOOL_CONTINUATION_TEXT` instead of bare `resumeAction`. `composer-2.5-fast` unchanged.

**Files changed:**
- `src/adapters/cursor/discovery.ts` — new helper function
- `src/adapters/cursor/protobuf-request.ts` — use helper in action selection + history encoding

## Verification

Tested locally against opencodex proxy on port 10100:
- Before: 0/3 tool-continuation requests returned content
- After: 3/3 returned correct summary (streaming + non-streaming)
- Regression: `composer-2.5-fast`, plain chat, and first-turn tool calls unaffected

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool continuation handling for Cursor models.
  * Ensured supported Composer models use the correct continuation flow for tool results, conversations, diagnostics, and replayed requests.
  * Preserved native handling for Composer models that do not require external continuation.
  * Updated continuation behavior for Composer 2.5 while preserving existing behavior for its fast variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->