### PR TITLE
[WRONG BRANCH] fix(zcode): use openai-compatible provider protocol to restore prefix caching

### DIFF
--- a/src/clients/config-export.ts
+++ b/src/clients/config-export.ts
@@ -908,7 +908,7 @@ export interface ZcodeModelEntry {
 
 export interface ZcodeProviderBlock {
   name: "OpenCodex";
-  kind: "anthropic";
+  kind: "openai-compatible";
   enabled: true;
   source: "custom";
   options: {
@@ -1288,12 +1288,12 @@ function buildZcodeClientConfig(ctx: ExportContext): ZcodeGeneratedConfig {
     provider: {
       [OPENCODE_PROVIDER_ID]: {
         name: "OpenCodex",
-        kind: "anthropic",
+        kind: "openai-compatible",
         enabled: true,
         source: "custom",
         options: {
           apiKey: LOOPBACK_API_KEY_PLACEHOLDER,
-          baseURL: ctx.baseUrl.replace(/\/v1\/?$/, ""),
+          baseURL: ctx.baseUrl.replace(/\/v1\/?$/, "") + "/v1",
           apiKeyRequired: true,
         },
         models,

--- a/tests/zcode-client.test.ts
+++ b/tests/zcode-client.test.ts
@@ -43,12 +43,12 @@ describe("ZCode client config", () => {
     expect(Object.keys(document)).toEqual(["provider"]);
     const provider = document.provider[OPENCODE_PROVIDER_ID]!;
     expect(provider.name).toBe("OpenCodex");
-    expect(provider.kind).toBe("anthropic");
+    expect(provider.kind).toBe("openai-compatible");
     expect(provider.enabled).toBe(true);
     expect(provider.source).toBe("custom");
     expect(provider.options).toEqual({
       apiKey: LOOPBACK_API_KEY_PLACEHOLDER,
-      baseURL: "http://127.0.0.1:10100",
+      baseURL: "http://127.0.0.1:10100/v1",
       apiKeyRequired: true,
     });
   });


### PR DESCRIPTION
### Summary

In current OpenCodex versions, ZCode client integration (`src/clients/config-export.ts`) generates the provider configuration with:
```json
{
  "kind": "anthropic",
  "options": {
    "baseURL": "http://127.0.0.1:10100"
  }
}
```

This causes two major issues:
1. **Severe Prefix Cache Degradation for DeepSeek / LLMs with Prefix Caching**:
   When using Anthropic Messages protocol, prompt inlining and dynamic tool results break KV cache prefix alignment. In practice, DeepSeek's KV cache hit rate drops from **99% to ~80%** (or lower).
2. **Integration Conflict on Manual Switch**:
   When users manually switch the protocol to `Chat Completions` inside ZCode's UI, OpenCodex's fingerprint guard detects an unowned foreign edit (`conflict: foreign-edit`) and stops managing the client.

### Changes
- Updated `ZcodeProviderBlock.kind` and `buildZcodeClientConfig` in `src/clients/config-export.ts` to use `openai-compatible`.
- Ensured `baseURL` is exported with the `/v1` suffix (i.e. `http://127.0.0.1:10100/v1`), which matches ZCode's `/chat/completions` URL concatenation.
- Updated `tests/zcode-client.test.ts` unit tests to assert the new provider kind and baseURL.

### Verification
- Ran test suite with `bun test tests/zcode-client.test.ts`: 10 pass, 0 fail.
- Live verified in ZCode: DeepSeek prefix KV cache hit rate restored to **97% ~ 99.7%**.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated ZCode exports to use the OpenAI-compatible provider format.
  * Preserved the `/v1` path in exported base URLs for improved compatibility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->