### PR TITLE
fix(web-search): sanitize relayed citation sources

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -19,6 +19,7 @@ import {
 } from "./responses/thought-signature-replay";
 import { resolveStallTimeoutSec } from "./stall-timeout";
 import { usageDisplayTotalTokens } from "./usage/totals";
+import { appendSafeWebSearchSource, safeWebSearchSources } from "./web-search/sources";
 import {
   isTranslatorBudgetExceededError,
   releaseTranslatedEvent,
@@ -1157,15 +1158,13 @@ export function bridgeToResponsesSSE(
                 });
                 currentWebSearch = { itemId: wsItemId2, eventId: event.id, outputIndex };
               }
-              closeCurrentWebSearch(event.status ?? "completed", event.queries, event.sources);
+              const safeSources = safeWebSearchSources(event.sources);
+              closeCurrentWebSearch(event.status ?? "completed", event.queries, safeSources);
               // Queue this search's sources for the next assistant message (dedup by URL).
-              if (event.sources) {
-                const seen = new Set(pendingWebSources.map(s => s.url));
-                for (const s of event.sources) {
-                  if (!seen.has(s.url)) {
-                    seen.add(s.url);
-                    chargeValue(s, "tool_search_sources");
-                    pendingWebSources.push(s);
+              if (safeSources.length > 0) {
+                for (const source of safeSources) {
+                  if (appendSafeWebSearchSource(pendingWebSources, source)) {
+                    chargeValue(source, "tool_search_sources");
                   }
                 }
               }
@@ -1566,6 +1565,7 @@ function buildResponseJSONWithBudget(
   const flushText = (inferredPhase?: OcxMessagePhase) => {
     if (!currentText) return;
     const phase = currentTextPhase ?? inferredPhase;
+    const sourceBytes = pendingWebSources.reduce((sum, source) => sum + bytesOf(JSON.stringify(source)), 0);
     const annotations = pendingWebSources.map(s => ({
       type: "url_citation", url: s.url, ...(s.title ? { title: s.title } : {}), start_index: 0, end_index: 0,
     }));
@@ -1576,6 +1576,7 @@ function buildResponseJSONWithBudget(
       ...(phase ? { phase } : {}),
     } as OutputItem;
     pushOutput(item, currentTextBytes);
+    budget?.releaseRetained(sourceBytes, { kind: "tool_search_sources" });
     currentText = "";
     currentTextBytes = 0;
     currentTextPhase = undefined;
@@ -1820,27 +1821,26 @@ function buildResponseJSONWithBudget(
         // Batch/non-streaming output has no in_progress phase to animate — the search cell is a
         // single finalized item, emitted on `end`. Begin is a no-op here.
         break;
-      case "web_search_call_end":
+      case "web_search_call_end": {
         if (currentText) flushText("commentary");
         if (currentSummaryReasoning) flushSummaryReasoning();
         if (currentRawReasoning) flushRawReasoning();
         flushToolCall();
+        const safeSources = safeWebSearchSources(e.sources);
         pushOutput({
           type: "web_search_call", id: `ws_${uuid()}`, status: e.status ?? "completed",
           action: webSearchAction(e.queries),
-          ...(e.sources && e.sources.length > 0 ? { sources: e.sources } : {}),
+          ...(safeSources.length > 0 ? { sources: safeSources } : {}),
         });
-        if (e.sources) {
-          const seen = new Set(pendingWebSources.map(s => s.url));
-          for (const s of e.sources) {
-            if (!seen.has(s.url)) {
-              seen.add(s.url);
-              budget?.chargeRetained(bytesOf(JSON.stringify(s)), { kind: "tool_search_sources" });
-              pendingWebSources.push(s);
+        if (safeSources.length > 0) {
+          for (const source of safeSources) {
+            if (appendSafeWebSearchSource(pendingWebSources, source)) {
+              budget?.chargeRetained(bytesOf(JSON.stringify(source)), { kind: "tool_search_sources" });
             }
           }
         }
         break;
+      }
       case "error":
         errorEvent = e;
         sawTerminal = true;
@@ -1872,6 +1872,11 @@ function buildResponseJSONWithBudget(
     if (budget) releaseTranslatedEvent(e, budget);
   }
   flushText(cleanDone && !errorEvent && !incompleteEvent ? "final_answer" : undefined);
+  if (pendingWebSources.length > 0) {
+    const sourceBytes = pendingWebSources.reduce((sum, source) => sum + bytesOf(JSON.stringify(source)), 0);
+    pendingWebSources = [];
+    budget?.releaseRetained(sourceBytes, { kind: "tool_search_sources" });
+  }
   flushSummaryReasoning();
   flushRawReasoning();
   // Open tool call on a failed/incomplete turn must not land as status:"completed" — and neither

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -527,17 +527,22 @@ export function bridgeToResponsesSSE(
       // url_citation annotations on that message (the desktop app's Sources chip), then cleared so
       // they bind to exactly one message. Deduped by URL across multiple searches in the turn.
       let pendingWebSources: { url: string; title?: string }[] = [];
+      let pendingWebSourceBytes = 0;
+      const releasePendingWebSources = () => {
+        if (pendingWebSources.length === 0) return;
+        pendingWebSources = [];
+        budget?.releaseRetained(pendingWebSourceBytes, { kind: "tool_search_sources" });
+        pendingWebSourceBytes = 0;
+      };
       const takeWebAnnotations = (): { type: string; url: string; title?: string; start_index: number; end_index: number }[] => {
         if (pendingWebSources.length === 0) return [];
         const anns = pendingWebSources.map(s => ({
           type: "url_citation", url: s.url, ...(s.title ? { title: s.title } : {}), start_index: 0, end_index: 0,
         }));
-        const sourceBytes = pendingWebSources.reduce((sum, source) => sum + bytesOf(JSON.stringify(source)), 0);
         const annotationBytes = bytesOf(JSON.stringify(anns));
         const reservation = budget?.reserveTransient(annotationBytes, { kind: "retained_collectors" });
-        pendingWebSources = [];
         reservation?.commitRetained();
-        budget?.releaseRetained(sourceBytes, { kind: "tool_search_sources" });
+        releasePendingWebSources();
         return anns;
       };
 
@@ -793,6 +798,7 @@ export function bridgeToResponsesSSE(
         handlingTranslatorOverflow = true;
         abortCurrentToolCallForTranslatorOverflow();
         currentWebSearch = null;
+        releasePendingWebSources();
         const failure = adapterFailureFromEvent({
           type: "error",
           status: 502,
@@ -1164,7 +1170,7 @@ export function bridgeToResponsesSSE(
               if (safeSources.length > 0) {
                 for (const source of safeSources) {
                   if (appendSafeWebSearchSource(pendingWebSources, source)) {
-                    chargeValue(source, "tool_search_sources");
+                    pendingWebSourceBytes += chargeValue(source, "tool_search_sources");
                   }
                 }
               }
@@ -1177,6 +1183,7 @@ export function bridgeToResponsesSSE(
               flushHiddenRawReasoning();
               if (currentToolCall) closeCurrentToolCall();
               if (currentWebSearch) closeCurrentWebSearch("completed", []);
+              releasePendingWebSources();
               // Redacted-only turns (or hidden thinking without a trailing signature event) still
               // need their envelope-only reasoning item so the blocks replay next turn.
               flushHiddenReasoningEnvelope();
@@ -1240,6 +1247,7 @@ export function bridgeToResponsesSSE(
               flushHiddenRawReasoning();
               if (currentToolCall) failCurrentToolCall();
               if (currentWebSearch) closeCurrentWebSearch("failed", []);
+              releasePendingWebSources();
               flushHiddenReasoningEnvelope();
               options?.onUsage?.(event.usage);
               await awaitThoughtSignatureDurability();
@@ -1269,6 +1277,7 @@ export function bridgeToResponsesSSE(
               flushHiddenRawReasoning();
               if (currentToolCall) failCurrentToolCall();
               if (currentWebSearch) closeCurrentWebSearch("failed", []);
+              releasePendingWebSources();
               const failure = adapterFailureFromEvent(event);
               if (event.usage) options?.onUsage?.(event.usage);
               await awaitThoughtSignatureDurability();
@@ -1303,6 +1312,7 @@ export function bridgeToResponsesSSE(
           flushHiddenRawReasoning();
           if (currentToolCall) failCurrentToolCall();
           if (currentWebSearch) closeCurrentWebSearch("failed", []);
+          releasePendingWebSources();
           emit("response.failed", {
             response: {
               ...responseSnapshot("failed", finishedItems),
@@ -1332,6 +1342,7 @@ export function bridgeToResponsesSSE(
         flushHiddenRawReasoning();
         if (currentToolCall) failCurrentToolCall();
         if (currentWebSearch) closeCurrentWebSearch("failed", []);
+        releasePendingWebSources();
         options?.onUsage?.(undefined);
         await awaitThoughtSignatureDurability();
         emit("response.incomplete", {
@@ -1374,6 +1385,7 @@ export function bridgeToResponsesSSE(
             flushHiddenRawReasoning();
             if (currentToolCall) failCurrentToolCall();
             if (currentWebSearch) closeCurrentWebSearch("failed", []);
+            releasePendingWebSources();
             // #1926 gap 2 residual: this beat callback is synchronous, so the durability
             // barrier is not awaited on the stall-timeout kill path. The in-memory store is
             // already updated; only a crash between here and the queued write loses it,
@@ -1426,6 +1438,7 @@ export function bridgeToResponsesSSE(
         clearOwnedWatchdog();
         if (beat !== undefined) clearBeatInterval(beat);
         cancelUpstreamOnce();
+        releasePendingWebSources();
         disposeOwnedBudget();
       },
     });

--- a/src/web-search/parse.ts
+++ b/src/web-search/parse.ts
@@ -55,7 +55,11 @@ function collectAnnotation(ann: AnnotationLike | undefined, sources: WebSearchSo
  * (`### Sources:`, `**Sources**`), a title line whose URL sits on the FOLLOWING line, and trailing
  * URL punctuation (`;`, `,`, `)`, `]`, `.`). Prose that follows the source list is preserved.
  */
-const URL_RE = /https?:\/\/[^\s<>()\[\]]+/;
+const URL_RE = /https?:\/\/[^\s<>()\[\]]+/i;
+// Recognize URI-like candidates separately from the HTTP(S)-only acceptance boundary. A rejected
+// citation (for example `javascript:`) still belongs to the trailing Sources block and must not be
+// left behind as ordinary assistant text.
+const URI_LIKE_RE = /[a-z][a-z0-9+.-]*:[^\s<>()\[\]]+/i;
 // A "Sources:" / "Source:" header, allowing markdown prefixes (#, *, -, >) and bold/italic wrappers.
 const SOURCES_WORD_RE = /^sources?/i;
 
@@ -137,10 +141,11 @@ function extractTrailingSources(text: string): { text: string; sources: WebSearc
     const raw = lines[i].trim();
     if (raw === "") {
       // Blank line between header and first entry is fine; a blank AFTER entries ends the list.
-      if (sources.length > 0 || pendingTitle !== null) break;
+      if (consumedSourceLine || pendingTitle !== null) break;
       continue;
     }
-    const m = raw.match(URL_RE);
+    const httpMatch = raw.match(URL_RE);
+    const m = httpMatch ?? raw.match(URI_LIKE_RE);
     if (!m) {
       // A list-ish line with no URL may be a title whose URL is on the next line. Only treat it as a
       // pending title when it looks like a list item; otherwise it's prose → stop.
@@ -149,6 +154,10 @@ function extractTrailingSources(text: string): { text: string; sources: WebSearc
       }
       break;
     }
+    // A non-HTTP URI embedded in prose is not sufficient to classify the line as a citation.
+    // Accept it as a consumed source line only when it is a list item or the whole line starts with
+    // the URI candidate, matching the existing bare-URL grammar.
+    if (!httpMatch && !/^[-*>\d.)]/.test(raw) && m.index !== 0) break;
     const url = cleanUrl(m[0]);
     if (!url) { break; }
     consumedSourceLine = true;

--- a/src/web-search/parse.ts
+++ b/src/web-search/parse.ts
@@ -1,10 +1,12 @@
 import { sseFieldValue } from "../lib/sse-decoder";
+import {
+  appendSafeWebSearchSource,
+  safeWebSearchSources,
+  type SafeWebSearchSource,
+} from "./sources";
 
 /** A single web source backing the sidecar's answer. */
-export interface WebSearchSource {
-  url: string;
-  title?: string;
-}
+export type WebSearchSource = SafeWebSearchSource;
 
 /** The sidecar's synthesized answer plus its sources (empty `sources` is fine). */
 export interface WebSearchResult {
@@ -36,8 +38,10 @@ export const MAX_SIDECAR_RESPONSE_BYTES = 64 * 1024;
 /** Push a `url_citation` annotation as a source, de-duplicated by URL. */
 function collectAnnotation(ann: AnnotationLike | undefined, sources: WebSearchSource[], seen: Set<string>): void {
   if (!ann || ann.type !== "url_citation" || typeof ann.url !== "string" || seen.has(ann.url)) return;
-  seen.add(ann.url);
-  sources.push({ url: ann.url, ...(ann.title ? { title: ann.title } : {}) });
+  if (appendSafeWebSearchSource(sources, {
+    url: ann.url,
+    ...(ann.title !== undefined ? { title: ann.title } : {}),
+  })) seen.add(ann.url);
 }
 
 /**
@@ -113,14 +117,14 @@ function cleanTitle(prefix: string): string {
   return title;
 }
 
-function extractTrailingSources(text: string): { text: string; sources: WebSearchSource[] } {
+function extractTrailingSources(text: string): { text: string; sources: WebSearchSource[]; stripped: boolean } {
   const lines = text.split("\n");
   // Find the LAST line that is a "Sources:" header (markdown prefixes allowed).
   let headerIdx = -1;
   for (let i = lines.length - 1; i >= 0; i--) {
     if (isSourcesHeader(lines[i])) { headerIdx = i; break; }
   }
-  if (headerIdx === -1) return { text, sources: [] };
+  if (headerIdx === -1) return { text, sources: [], stripped: false };
   const sources: WebSearchSource[] = [];
   const seen = new Set<string>();
   // Track the last line index actually consumed as part of the source list so trailing prose after
@@ -128,6 +132,7 @@ function extractTrailingSources(text: string): { text: string; sources: WebSearc
   let lastConsumed = headerIdx;
   // A title line whose URL is expected on a following line (multiline entry).
   let pendingTitle: string | null = null;
+  let consumedSourceLine = false;
   for (let i = headerIdx + 1; i < lines.length; i++) {
     const raw = lines[i].trim();
     if (raw === "") {
@@ -146,21 +151,21 @@ function extractTrailingSources(text: string): { text: string; sources: WebSearc
     }
     const url = cleanUrl(m[0]);
     if (!url) { break; }
+    consumedSourceLine = true;
     lastConsumed = i;
     // Title: text before the URL on this line, else a buffered title from a preceding line.
     const inlinePrefix = raw.slice(0, m.index);
     const title = cleanTitle(inlinePrefix) || (pendingTitle ? cleanTitle(pendingTitle) : "");
     pendingTitle = null;
     if (seen.has(url)) continue;
-    seen.add(url);
-    sources.push(title ? { url, title } : { url });
+    if (appendSafeWebSearchSource(sources, title ? { url, title } : { url })) seen.add(url);
   }
-  if (sources.length === 0) return { text, sources: [] };
+  if (!consumedSourceLine) return { text, sources: [], stripped: false };
   // Keep text before the header AND any prose after the consumed source lines.
   const before = lines.slice(0, headerIdx).join("\n").replace(/\s+$/, "");
   const after = lines.slice(lastConsumed + 1).join("\n").replace(/^\s+/, "");
   const body = after ? (before ? `${before}\n\n${after}` : after) : before;
-  return { text: body, sources };
+  return { text: body, sources, stripped: true };
 }
 
 /** Pull final text + url_citation sources from a completed Responses `output[]` array. */
@@ -283,22 +288,19 @@ export async function parseSidecarSSE(response: Response): Promise<WebSearchResu
     || acc.doneText.trim() && acc.doneText
     || acc.deltaText;
   // Merge sources from the final output[] and the streaming annotation events.
-  const sources = [...(acc.final?.sources ?? [])];
-  const seenMerge = new Set(sources.map(s => s.url));
+  const sources = safeWebSearchSources(acc.final?.sources ?? []);
   for (const s of acc.streamSources) {
-    if (!seenMerge.has(s.url)) { seenMerge.add(s.url); sources.push(s); }
+    appendSafeWebSearchSource(sources, s);
   }
   // Hosted web_search usually omits url_citation annotations and lists sources in a trailing
   // `Sources:` markdown block instead. Pull those out (and strip the block from the answer so the
   // tool_result renderer doesn't print sources twice). Annotation titles win; text-block titles
   // only fill a gap. URL-deduped against annotation sources.
-  const { text: body, sources: textSources } = extractTrailingSources(typeof text === "string" ? text : "");
+  const { text: body, sources: textSources, stripped } = extractTrailingSources(typeof text === "string" ? text : "");
   for (const s of textSources) {
-    if (seenMerge.has(s.url)) continue;
-    seenMerge.add(s.url);
-    sources.push(s);
+    appendSafeWebSearchSource(sources, s);
   }
-  const finalText = textSources.length > 0 ? body : (typeof text === "string" ? text : "");
+  const finalText = stripped ? body : (typeof text === "string" ? text : "");
   if (!finalText.trim() && acc.error) return { text: "", sources, error: acc.error };
   return { text: finalText, sources };
 }

--- a/src/web-search/sources.ts
+++ b/src/web-search/sources.ts
@@ -1,0 +1,60 @@
+export interface SafeWebSearchSource {
+  url: string;
+  title?: string;
+}
+
+export const MAX_WEB_SEARCH_SOURCES = 20;
+export const MAX_WEB_SEARCH_URL_BYTES = 2_048;
+export const MAX_WEB_SEARCH_TITLE_BYTES = 256;
+export const MAX_WEB_SEARCH_SOURCE_BYTES = 16_384;
+
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]/u;
+const encoder = new TextEncoder();
+
+function byteLength(value: string): number {
+  return encoder.encode(value).byteLength;
+}
+
+function serializedSourceBytes(source: SafeWebSearchSource): number {
+  return byteLength(JSON.stringify(source));
+}
+
+function safeTitle(value: unknown): string | undefined {
+  if (typeof value !== "string"
+    || value.trim().length === 0
+    || CONTROL_CHARACTERS.test(value)
+    || byteLength(value) > MAX_WEB_SEARCH_TITLE_BYTES) return undefined;
+  return value;
+}
+
+/** Add one client-safe citation while enforcing per-message count and byte budgets. */
+export function appendSafeWebSearchSource(target: SafeWebSearchSource[], source: unknown): boolean {
+  if (target.length >= MAX_WEB_SEARCH_SOURCES || !source || typeof source !== "object") return false;
+  const candidate = source as { url?: unknown; title?: unknown };
+  if (typeof candidate.url !== "string"
+    || candidate.url.length === 0
+    || candidate.url.trim() !== candidate.url
+    || CONTROL_CHARACTERS.test(candidate.url)
+    || byteLength(candidate.url) > MAX_WEB_SEARCH_URL_BYTES
+    || target.some(existing => existing.url === candidate.url)) return false;
+
+  let parsed: URL;
+  try { parsed = new URL(candidate.url); } catch { return false; }
+  if ((parsed.protocol !== "http:" && parsed.protocol !== "https:")
+    || parsed.username.length > 0
+    || parsed.password.length > 0) return false;
+
+  const title = safeTitle(candidate.title);
+  const next = title === undefined ? { url: candidate.url } : { url: candidate.url, title };
+  const usedBytes = target.reduce((sum, item) => sum + serializedSourceBytes(item), 0);
+  if (usedBytes + serializedSourceBytes(next) > MAX_WEB_SEARCH_SOURCE_BYTES) return false;
+  target.push(next);
+  return true;
+}
+
+export function safeWebSearchSources(sources: unknown): SafeWebSearchSource[] {
+  if (!Array.isArray(sources)) return [];
+  const safe: SafeWebSearchSource[] = [];
+  for (const source of sources) appendSafeWebSearchSource(safe, source);
+  return safe;
+}

--- a/tests/bridge.test.ts
+++ b/tests/bridge.test.ts
@@ -1125,6 +1125,35 @@ describe("Responses bridge web_search_call native item", () => {
       budget.dispose();
     }
   });
+
+  test("streaming source-only completion releases unconsumed citation ownership", async () => {
+    const events: AdapterEvent[] = [
+      { type: "web_search_call_begin", id: "ws_source_only" },
+      { type: "web_search_call_end", id: "ws_source_only", queries: ["docs"], sources: [
+        { url: "https://safe.test/docs", title: "Safe docs" },
+      ] },
+      { type: "done" },
+    ];
+    const budget = createTranslatorBudget();
+    try {
+      const frames = await collectSse(bridgeToResponsesSSE(
+        replay(events),
+        "routed/model",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { translatorBudget: budget },
+      ));
+      const terminal = frames.find(frame => frame.event === "response.completed")!;
+      const output = (terminal.data.response as Record<string, unknown>).output as Record<string, unknown>[];
+      expect(output.map(item => item.type)).toEqual(["web_search_call"]);
+      expect(budget.snapshot().currentBytes).toBe(Buffer.byteLength(JSON.stringify(output[0])));
+    } finally {
+      budget.dispose();
+    }
+  });
 });
 
 describe("Responses bridge stopReason threading (issue #246)", () => {

--- a/tests/bridge.test.ts
+++ b/tests/bridge.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { bridgeToResponsesSSE, buildResponseJSON, setOwnedBudgetAbandonedMsForTests } from "../src/bridge";
 import {
+  createTranslatorBudget,
   resetTranslatorAggregateForTests,
+  retainTranslatedEventBatch,
   translatorAggregateCurrentBytesForTests,
   translatorLiveBudgetCountForTests,
 } from "../src/lib/translator-budget";
@@ -1030,6 +1032,11 @@ describe("Responses bridge web_search_call native item", () => {
     ]), "routed/model"));
     const done = frames.find(f => f.event === "response.output_item.done"
       && (f.data.item as Record<string, unknown>)?.type === "message");
+    const searchDone = frames.find(f => f.event === "response.output_item.done"
+      && (f.data.item as Record<string, unknown>)?.type === "web_search_call");
+    expect((searchDone!.data.item as Record<string, unknown>).sources).toEqual([
+      { url: "https://nodejs.org", title: "Node.js" },
+    ]);
     const item = done!.data.item as Record<string, unknown>;
     const part = (item.content as Record<string, unknown>[])[0];
     expect(part.annotations).toEqual([{
@@ -1045,11 +1052,78 @@ describe("Responses bridge web_search_call native item", () => {
       { type: "done" },
     ], "routed/model");
     const output = json.output as Record<string, unknown>[];
+    expect(output.find(item => item.type === "web_search_call")?.sources).toEqual([
+      { url: "https://nodejs.org", title: "Node.js" },
+    ]);
     const message = output.find(item => item.type === "message") as Record<string, unknown>;
     const part = (message.content as Record<string, unknown>[])[0];
     expect(part.annotations).toEqual([{
       type: "url_citation", url: "https://nodejs.org", title: "Node.js", start_index: 0, end_index: 0,
     }]);
+  });
+
+  test("unsafe and oversized search sources are absent from cells and annotations", async () => {
+    const sources = [
+      { url: "javascript:alert(1)", title: "unsafe" },
+      { url: "https://user:pass@credential.test/private" },
+      { url: "https://control.test/path\u0000" },
+      { url: "https://safe.test/docs", title: "Safe docs" },
+      { url: "https://title.test", title: "bad\u0001title" },
+      { url: "https://safe.test/docs", title: "duplicate" },
+      ...Array.from({ length: 25 }, (_, index) => ({ url: `https://safe.test/${index}` })),
+    ];
+    const events: AdapterEvent[] = [
+      { type: "web_search_call_begin", id: "ws_safe" },
+      { type: "web_search_call_end", id: "ws_safe", queries: ["docs"], sources },
+      { type: "text_delta", text: "answer" },
+      { type: "done" },
+    ];
+
+    const frames = await collectSse(bridgeToResponsesSSE(replay(events), "routed/model"));
+    const streamingCell = frames.find(f => f.event === "response.output_item.done"
+      && (f.data.item as Record<string, unknown>)?.type === "web_search_call")!.data.item as Record<string, unknown>;
+    const streamingSources = streamingCell.sources as Record<string, unknown>[];
+    expect(streamingSources).toHaveLength(20);
+    expect(streamingSources.slice(0, 2)).toEqual([
+      { url: "https://safe.test/docs", title: "Safe docs" },
+      { url: "https://title.test" },
+    ]);
+    expect(streamingSources.some(source => String(source.url).includes("credential"))).toBe(false);
+
+    const streamingMessage = frames.find(f => f.event === "response.output_item.done"
+      && (f.data.item as Record<string, unknown>)?.type === "message")!.data.item as Record<string, unknown>;
+    const streamingAnnotations = (streamingMessage.content as Record<string, unknown>[])[0].annotations as Record<string, unknown>[];
+    expect(streamingAnnotations.map(({ url, title }) => ({ url, ...(title ? { title } : {}) })))
+      .toEqual(streamingSources);
+
+    const json = buildResponseJSON(events, "routed/model");
+    const output = json.output as Record<string, unknown>[];
+    const batchCell = output.find(item => item.type === "web_search_call")!;
+    expect(batchCell.sources).toEqual(streamingSources);
+    const batchMessage = output.find(item => item.type === "message")!;
+    const batchAnnotations = (batchMessage.content as Record<string, unknown>[])[0].annotations as Record<string, unknown>[];
+    expect(batchAnnotations).toEqual(streamingAnnotations);
+  });
+
+  test("non-streaming citation transfer releases its temporary source ownership", () => {
+    const events: AdapterEvent[] = [
+      { type: "web_search_call_begin", id: "ws_budget" },
+      { type: "web_search_call_end", id: "ws_budget", queries: ["docs"], sources: [
+        { url: "https://safe.test/docs", title: "Safe docs" },
+      ] },
+      { type: "text_delta", text: "answer" },
+      { type: "done" },
+    ];
+    const budget = createTranslatorBudget();
+    try {
+      retainTranslatedEventBatch(events, budget);
+      const json = buildResponseJSON(events, "routed/model", { translatorBudget: budget });
+      const output = json.output as Record<string, unknown>[];
+      const outputBytes = output.reduce((sum, item) => sum + Buffer.byteLength(JSON.stringify(item)), 0);
+      expect(budget.snapshot().currentBytes).toBe(outputBytes);
+    } finally {
+      budget.dispose();
+    }
   });
 });
 

--- a/tests/web-search-parse.test.ts
+++ b/tests/web-search-parse.test.ts
@@ -194,6 +194,24 @@ describe("parseSidecarSSE trailing Sources block", () => {
     expect(out).toEqual({ text: "Answer.", sources: [] });
   });
 
+  test("strips a trailing non-HTTP URI citation after rejecting it", async () => {
+    const out = await parseCompletedText(
+      "Answer.\n\nSources:\n- Unsafe: javascript:alert(1)",
+    );
+    expect(out).toEqual({ text: "Answer.", sources: [] });
+  });
+
+  test("preserves prose after a blank line following a rejected citation", async () => {
+    const out = await parseCompletedText(
+      "Answer.\n\nSources:\n- Credential URL: https://user:pass@private.test/path\n\n" +
+      "For details visit https://good.test/guide",
+    );
+    expect(out).toEqual({
+      text: "Answer.\n\nFor details visit https://good.test/guide",
+      sources: [],
+    });
+  });
+
   test("no Sources block leaves text and sources untouched", async () => {
     const text = "Just an answer mentioning https://example.com inline, no sources section.";
     const res = sse([

--- a/tests/web-search-parse.test.ts
+++ b/tests/web-search-parse.test.ts
@@ -164,6 +164,36 @@ describe("parseSidecarSSE trailing Sources block", () => {
     ]);
   });
 
+  test("sanitizes structured and trailing sources before returning them", async () => {
+    const text = "Answer.\n\nSources:\n" +
+      "- Credential URL: https://user:pass@private.test/path\n" +
+      "- Safe trailing URL: https://safe.test/trailing";
+    const res = sse([
+      { type: "response.completed", response: { output: [{ type: "message", content: [{
+        type: "output_text",
+        annotations: [
+          { type: "url_citation", url: "javascript:alert(1)", title: "unsafe" },
+          { type: "url_citation", url: "https://safe.test/structured", title: "bad\u0001title" },
+        ],
+        text,
+      }] }] } },
+    ]);
+
+    const out = await parseSidecarSSE(res);
+    expect(out.sources).toEqual([
+      { url: "https://safe.test/structured" },
+      { url: "https://safe.test/trailing", title: "Safe trailing URL" },
+    ]);
+    expect(out.text).toBe("Answer.");
+  });
+
+  test("strips a recognized Sources block even when every citation is rejected", async () => {
+    const out = await parseCompletedText(
+      "Answer.\n\nSources:\n- Credential URL: https://user:pass@private.test/path",
+    );
+    expect(out).toEqual({ text: "Answer.", sources: [] });
+  });
+
   test("no Sources block leaves text and sources untouched", async () => {
     const text = "Just an answer mentioning https://example.com inline, no sources section.";
     const res = sse([

--- a/tests/web-search-sources.test.ts
+++ b/tests/web-search-sources.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import {
+  MAX_WEB_SEARCH_SOURCE_BYTES,
+  MAX_WEB_SEARCH_SOURCES,
+  MAX_WEB_SEARCH_TITLE_BYTES,
+  MAX_WEB_SEARCH_URL_BYTES,
+  appendSafeWebSearchSource,
+  safeWebSearchSources,
+} from "../src/web-search/sources";
+
+const byteLength = (value: string): number => new TextEncoder().encode(value).byteLength;
+
+describe("web-search citation source sanitization", () => {
+  test("preserves ordinary HTTP(S) citations verbatim and deduplicates exact URLs", () => {
+    const sources = safeWebSearchSources([
+      { url: "https://docs.example.test/a?q=one#two", title: "Docs" },
+      { url: "http://example.test/plain" },
+      { url: "https://docs.example.test/a?q=one#two", title: "Duplicate" },
+    ]);
+
+    expect(sources).toEqual([
+      { url: "https://docs.example.test/a?q=one#two", title: "Docs" },
+      { url: "http://example.test/plain" },
+    ]);
+  });
+
+  test("rejects malformed, credential-bearing, non-HTTP, control, and padded URLs", () => {
+    expect(safeWebSearchSources([
+      null,
+      { url: 42 },
+      { url: "javascript:alert(1)" },
+      { url: "data:text/html,unsafe" },
+      { url: "https://user:pass@example.test/private" },
+      { url: "https://control.test/path\u0000" },
+      { url: " https://padded.test" },
+      { url: "https://safe.test" },
+    ])).toEqual([{ url: "https://safe.test" }]);
+    expect(safeWebSearchSources({ url: "https://not-an-array.test" })).toEqual([]);
+  });
+
+  test("keeps a safe URL but omits an invalid optional title", () => {
+    const exactUnicodeTitle = "😀".repeat(MAX_WEB_SEARCH_TITLE_BYTES / 4);
+    expect(byteLength(exactUnicodeTitle)).toBe(MAX_WEB_SEARCH_TITLE_BYTES);
+    expect(safeWebSearchSources([
+      { url: "https://empty-title.test", title: "" },
+      { url: "https://blank-title.test", title: "   " },
+      { url: "https://control-title.test", title: "bad\u0001title" },
+      { url: "https://typed-title.test", title: 42 },
+      { url: "https://large-title.test", title: `${exactUnicodeTitle}😀` },
+      { url: "https://exact-title.test", title: exactUnicodeTitle },
+    ])).toEqual([
+      { url: "https://empty-title.test" },
+      { url: "https://blank-title.test" },
+      { url: "https://control-title.test" },
+      { url: "https://typed-title.test" },
+      { url: "https://large-title.test" },
+      { url: "https://exact-title.test", title: exactUnicodeTitle },
+    ]);
+  });
+
+  test("enforces the URL byte cap exactly", () => {
+    const prefix = "https://bytes.test/";
+    const exact = `${prefix}${"a".repeat(MAX_WEB_SEARCH_URL_BYTES - byteLength(prefix))}`;
+    const sources: { url: string }[] = [];
+    expect(byteLength(exact)).toBe(MAX_WEB_SEARCH_URL_BYTES);
+    expect(appendSafeWebSearchSource(sources, { url: exact })).toBe(true);
+    expect(appendSafeWebSearchSource([], { url: `${exact}a` })).toBe(false);
+  });
+
+  test("enforces count and aggregate serialized-byte budgets", () => {
+    const countBounded = safeWebSearchSources(
+      Array.from({ length: MAX_WEB_SEARCH_SOURCES + 5 }, (_, index) => ({
+        url: `https://count.test/${index}`,
+      })),
+    );
+    expect(countBounded).toHaveLength(MAX_WEB_SEARCH_SOURCES);
+
+    const aggregateBounded = safeWebSearchSources(
+      Array.from({ length: MAX_WEB_SEARCH_SOURCES }, (_, index) => ({
+        url: `https://aggregate.test/${index}/${"a".repeat(1_000)}`,
+      })),
+    );
+    const serializedBytes = aggregateBounded.reduce(
+      (sum, source) => sum + byteLength(JSON.stringify(source)),
+      0,
+    );
+    expect(aggregateBounded.length).toBeLessThan(MAX_WEB_SEARCH_SOURCES);
+    expect(serializedBytes).toBeLessThanOrEqual(MAX_WEB_SEARCH_SOURCE_BYTES);
+  });
+});


### PR DESCRIPTION
## Summary

- validate provider-controlled web-search citation sources before they reach client-visible search cells or clickable annotations
- preserve ordinary HTTP(S) URLs verbatim while rejecting malformed URLs, unsafe schemes, embedded URL credentials, control characters, duplicates, and per-source/count/aggregate byte overflow
- keep a valid URL when only its optional title is invalid, strip rejected URI-like entries from recognized trailing `Sources:` blocks, and preserve prose after the source list
- apply the same shared sanitizer at sidecar parsing and the final streaming/non-streaming bridge boundary, including exact translator-budget ownership release after citations move into an assistant message or a source-only stream terminates

Exact base: `03735eca62398c55056d4595145561aecc444e91`  
Exact head: `9a345f409ad23e1e2db792b7787d496c6de6ef8f`

## Verification

- Bun 1.4 typecheck — passed
- citation helper — 5/5 passed
- web-search parser — 40/40 passed
- Responses bridge — 61/61 passed
- web-search sidecar — 57/57 passed
- privacy scan and `git diff --check` — passed
- exact-range security review of all 3 changed production files — no findings
- independent current-diff correctness/test reviews — no findings

The full repository suite was not duplicated locally; maintained cross-platform CI remains the merge gate. No GUI or configuration surface is changed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed; this internal output-boundary hardening adds no user-facing configuration or workflow.
- [x] Security-sensitive changes were reviewed for credential exposure, unsafe URL defaults, parser bypasses, and bounded memory ownership.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
