### PR TITLE
fix(xai): restore Chat default for Grok 4.5 and 4.6

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1023,19 +1023,18 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     // grok-4.5; the reasoning ladder does not — 4.6 adds the documented xhigh rung.
     models: ["grok-4.6", "grok-4.5", "grok-4.3", "grok-4.20-0309-reasoning", "grok-4.20-0309-non-reasoning", "grok-build-0.1", "grok-composer-2.5-fast"],
     defaultModel: "grok-4.5",
-    // The current Grok CLI catalog declares both subscription models as native Responses
-    // backends. Keep API-key and translated Chat/Anthropic callers on their existing wire;
-    // Codex Responses traffic can relay xAI's SSE as it arrives instead of waiting for the
-    // Chat Completions compatibility stream to flush at the end of a reasoning turn.
+    // Keep Codex Responses callers on the compatibility Chat wire until xAI can replay
+    // opaque reasoning continuation and compaction state across later turns. The scoped
+    // declaration also keeps caller-owned service tiers off the OAuth subscription route.
     modelWireDefaults: {
       "grok-4.6": {
-        wire: "openai-responses",
+        wire: "openai-chat",
         inbound: ["responses"],
         authModes: ["oauth"],
         forwardCallerServiceTier: false,
       },
       "grok-4.5": {
-        wire: "openai-responses",
+        wire: "openai-chat",
         inbound: ["responses"],
         authModes: ["oauth"],
         forwardCallerServiceTier: false,

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -80,14 +80,14 @@ different custom destination does not inherit its upstream assumptions. Object-f
 also narrow the decision by inbound protocol and authentication mode; an auth-scoped default must
 not leak from a subscription transport into an API-key or forwarded-credential route.
 
-xAI keeps `openai-chat` as its provider-wide compatibility wire. The official Grok CLI catalog
-declares the Grok 4.5 and 4.6 subscription models as Responses backends, so only OAuth-backed native
-Responses traffic for those exact models selects `openai-responses`. API-key requests, translated
-Chat/Anthropic callers, other Grok models, and explicit model adapter overrides retain their
-existing wire. This lets Codex receive native xAI SSE deltas as they arrive without widening the
-credential or compatibility boundary. These OAuth subscription defaults drop caller-owned
-`service_tier`; they neither advertise nor inject Fast. The API-key transport remains governed by
-its separate capability declaration.
+xAI keeps `openai-chat` as both its provider-wide compatibility wire and the default for Grok 4.5
+and 4.6 subscription traffic. The official Grok CLI catalog declares those models as Responses
+backends, but the current gateway rejects opaque reasoning continuation and compaction state on
+later turns. Operators may still select `openai-responses` with an explicit model adapter override
+while that compatibility work continues. The default OAuth route continues to drop caller-owned
+`service_tier`, and native Responses OAuth 401 replay remains available to explicit opt-ins.
+API-key requests, translated Chat/Anthropic callers, and other Grok models retain their existing
+wire.
 
 OpenCode Go documents `gpt-5.6-luna` on `/zen/go/v1/responses` while sibling models use its Chat or
 Anthropic endpoints. The built-in preset therefore selects `openai-responses` only for Luna and

--- a/tests/adapter-resolve.test.ts
+++ b/tests/adapter-resolve.test.ts
@@ -100,10 +100,10 @@ describe("registry per-model wire defaults", () => {
     });
   }
 
-  test("routes current xAI subscription models through Responses for native Codex traffic", () => {
+  test("keeps current xAI subscription models on Chat by default", () => {
     for (const model of ["grok-4.6", "grok-4.5"]) {
       expect(resolveWireProtocolOverride("xai", model, xai("oauth"), "responses").adapter)
-        .toBe("openai-responses");
+        .toBe("openai-chat");
     }
   });
 
@@ -118,10 +118,12 @@ describe("registry per-model wire defaults", () => {
       .toBe("openai-chat");
   });
 
-  test("an explicit xAI Chat override opts out of the subscription Responses default", () => {
-    const provider = xai("oauth", { modelAdapters: { "grok-4.6": "openai-chat" } });
-    expect(resolveWireProtocolOverride("xai", "grok-4.6", provider, "responses").adapter)
-      .toBe("openai-chat");
+  test("an explicit xAI Responses override opts into the native wire", () => {
+    for (const model of ["grok-4.6", "grok-4.5"]) {
+      const provider = xai("oauth", { modelAdapters: { [model]: "openai-responses" } });
+      expect(resolveWireProtocolOverride("xai", model, provider, "responses").adapter)
+        .toBe("openai-responses");
+    }
   });
 
   function deepseek(overrides: Partial<OcxProviderConfig> = {}): OcxProviderConfig {

--- a/tests/fastwire-policy.test.ts
+++ b/tests/fastwire-policy.test.ts
@@ -256,7 +256,7 @@ describe("resolveFastPolicy matrix", () => {
     expect(fastPolicyForModel(provider, MODEL, "fixture").capability).toBe(false);
   });
 
-  test("captured xAI registry defaults keep OAuth and key transports separate", () => {
+  test("captured xAI registry defaults keep the OAuth fallback on Chat", () => {
     const oauthProvider = Object.freeze({
       adapter: "openai-chat",
       baseUrl: "https://api.x.ai/v1",
@@ -269,7 +269,7 @@ describe("resolveFastPolicy matrix", () => {
     });
 
     expect(fastPolicyForModel(oauthProvider, "grok-4.6", "xai")).toMatchObject({
-      adapter: "openai-responses",
+      adapter: "openai-chat",
       eligibility: "unclassified",
       forwardCallerTier: false,
     });

--- a/tests/server-xai-oauth-401-replay.test.ts
+++ b/tests/server-xai-oauth-401-replay.test.ts
@@ -60,6 +60,7 @@ function xaiConfig(authMode: "oauth" | "key" = "oauth"): OcxConfig {
         baseUrl: "https://api.x.ai/v1",
         authMode,
         ...(authMode === "key" ? { apiKey: "xai-api-key" } : {}),
+        ...(authMode === "oauth" ? { modelAdapters: { "grok-4.5": "openai-responses" } } : {}),
         models: ["grok-4.5"],
       },
     },
@@ -142,7 +143,7 @@ function installOAuthFetch(
   return { chatAuth, counts };
 }
 
-describe("xAI OAuth upstream 401 replay", () => {
+describe("xAI OAuth Responses opt-in upstream 401 replay", () => {
   test("initial OAuth refresh projects raw provider failures before responding", async () => {
     await seedOAuth(0);
     saveConfig(xaiConfig());

--- a/tests/server-xai-responses-streaming.test.ts
+++ b/tests/server-xai-responses-streaming.test.ts
@@ -56,6 +56,8 @@ function config(): OcxConfig {
         baseUrl: "https://api.x.ai/v1",
         authMode: "oauth",
         models: ["grok-4.6"],
+        modelAdapters: { "grok-4.6": "openai-responses" },
+        modelSupportsServiceTier: { "grok-4.6": false },
       },
     },
   } as OcxConfig;
@@ -65,7 +67,7 @@ function sse(payload: unknown): Uint8Array {
   return encoder.encode(`data: ${JSON.stringify(payload)}\n\n`);
 }
 
-describe("xAI OAuth Responses streaming", () => {
+describe("xAI OAuth Responses streaming opt-in", () => {
   test("uses the native Responses wire and relays the first delta before completion", async () => {
     let releaseCompletion!: () => void;
     const completionGate = new Promise<void>(resolve => { releaseCompletion = resolve; });


### PR DESCRIPTION
## Summary

- **High priority compatibility hotfix:** restore the default xAI OAuth wire for Grok 4.5 and 4.6 from native Responses to `openai-chat`.
- Prevent ordinary Codex tool continuations, model switches, and compaction turns from sending opaque continuation state to an xAI Responses path that currently rejects it.
- Keep native xAI Responses available as an explicit `modelAdapters` opt-in, including the existing streaming and OAuth 401 refresh/replay coverage.
- Leave API-key xAI traffic, translated Chat/Anthropic callers, other Grok models, and every other provider unchanged.

## Verification

- `bun test tests/fastwire-policy.test.ts tests/adapter-resolve.test.ts tests/server-xai-responses-streaming.test.ts tests/server-xai-oauth-401-replay.test.ts tests/quota-bars-rows.test.ts tests/vision-sidecar-timeout-bounds.test.ts` — 271 pass, 0 fail.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `bun run test` — 13,733 pass, 10 skip, 1 fail. The sole failure is `CLI key-login live-update overlay preservation > notify after key login pushes the merged row and keeps modelCosts on live and disk`; it reproduces unchanged in a detached clean worktree at `upstream/dev` (`03735eca6`) and is unrelated to this xAI-only diff.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
