### PR TITLE
fix(responses): bound retained tool-search item IDs

### DIFF
--- a/src/server/responses-tool-search-repair.ts
+++ b/src/server/responses-tool-search-repair.ts
@@ -1,5 +1,6 @@
 import {
   isTranslatorBudgetExceededError,
+  TranslatorBudgetExceededError,
   type TranslatorBudget,
 } from "../lib/translator-budget";
 import {
@@ -24,6 +25,19 @@ type PendingArgumentBlock = {
 
 const MAX_PENDING_ARGUMENT_FRAMES = 256;
 const MAX_PENDING_ARGUMENT_BYTES = 1024 * 1024;
+const MAX_CLASSIFIED_ITEM_IDS = 256;
+const MAX_CLASSIFIED_ITEM_ID_BYTES = 256 * 1024;
+
+class ClassifiedItemIdCountExceededError extends Error {
+  readonly code = "translation_buffer_limit";
+  readonly kind = "item_ids";
+  readonly limitItems = MAX_CLASSIFIED_ITEM_IDS;
+
+  constructor() {
+    super(`translator item_ids count exceeded ${MAX_CLASSIFIED_ITEM_IDS} items`);
+    this.name = "ClassifiedItemIdCountExceededError";
+  }
+}
 
 /**
  * Public Responses gateways stream a lowered search as a normal function lifecycle. Codex expects
@@ -36,6 +50,7 @@ export function createRoutedToolSearchRestoreBlockRewrite(
 ): SseBlockRewrite {
   const routedItemIds = new Set<string>();
   const ordinaryItemIds = new Set<string>();
+  let classifiedItemIdBytes = 0;
   let pendingArguments: PendingArgumentBlock[] = [];
   let pendingArgumentBytes = 0;
   let passthrough = false;
@@ -49,8 +64,43 @@ export function createRoutedToolSearchRestoreBlockRewrite(
     }
     pendingArguments = [];
     pendingArgumentBytes = 0;
+    if (classifiedItemIdBytes > 0) {
+      budget?.releaseRetained(classifiedItemIdBytes, { kind: "item_ids" });
+    }
+    classifiedItemIdBytes = 0;
     routedItemIds.clear();
     ordinaryItemIds.clear();
+  };
+
+  const clearOrdinaryItemIds = (): void => {
+    let releasedBytes = 0;
+    for (const itemId of ordinaryItemIds) {
+      releasedBytes += Buffer.byteLength(JSON.stringify(itemId), "utf8");
+    }
+    ordinaryItemIds.clear();
+    classifiedItemIdBytes = Math.max(0, classifiedItemIdBytes - releasedBytes);
+    if (releasedBytes > 0) budget?.releaseRetained(releasedBytes, { kind: "item_ids" });
+  };
+
+  const classifyItemId = (itemId: string, routed: boolean): void => {
+    const target = routed ? routedItemIds : ordinaryItemIds;
+    const previous = routed ? ordinaryItemIds : routedItemIds;
+    if (target.has(itemId)) return;
+    if (previous.delete(itemId)) {
+      target.add(itemId);
+      return;
+    }
+
+    if (routedItemIds.size + ordinaryItemIds.size >= MAX_CLASSIFIED_ITEM_IDS) {
+      throw new ClassifiedItemIdCountExceededError();
+    }
+    const retainedBytes = Buffer.byteLength(JSON.stringify(itemId), "utf8");
+    if (classifiedItemIdBytes + retainedBytes > MAX_CLASSIFIED_ITEM_ID_BYTES) {
+      throw new TranslatorBudgetExceededError("item_ids", MAX_CLASSIFIED_ITEM_ID_BYTES);
+    }
+    budget?.chargeRetained(retainedBytes, { kind: "item_ids" });
+    target.add(itemId);
+    classifiedItemIdBytes += retainedBytes;
   };
 
   const retainPending = (
@@ -73,7 +123,7 @@ export function createRoutedToolSearchRestoreBlockRewrite(
       // that we forget what we already classified: an item restored to `tool_search_call`
       // upstream of here would otherwise start emitting `function_call_arguments.*` again and
       // the client would see a mixed private/public lifecycle for one call.
-      ordinaryItemIds.clear();
+      clearOrdinaryItemIds();
       return flushed;
     }
     if (retainedBytes > 0) {
@@ -90,7 +140,7 @@ export function createRoutedToolSearchRestoreBlockRewrite(
         passthrough = true;
         // Same reasoning as the frame/byte overflow above: an already-restored routed item
         // must keep its frames suppressed even once buffering stops.
-        ordinaryItemIds.clear();
+        clearOrdinaryItemIds();
         return flushed;
       }
     }
@@ -135,7 +185,11 @@ export function createRoutedToolSearchRestoreBlockRewrite(
   const rewrite: SseBlockRewrite = (block: string): readonly string[] => {
     if (disposed) return [block];
     const payload = sseDataPayload(block);
-    if (payload === null || payload === "[DONE]") return [block];
+    if (payload === null) return [block];
+    if (payload === "[DONE]") {
+      releaseAll();
+      return [block];
+    }
     let parsed: unknown;
     try {
       parsed = JSON.parse(payload);
@@ -145,11 +199,16 @@ export function createRoutedToolSearchRestoreBlockRewrite(
     if (!isPlainObject(parsed)) return [block];
 
     const type = typeof parsed.type === "string" ? parsed.type : "";
+    const terminal = type === "response.completed" || type === "response.failed" || type === "response.incomplete";
     // After overflow we stop BUFFERING unknown frames, but an item already restored to
     // `tool_search_call` must keep its public argument frames suppressed — otherwise the client
     // receives a private item followed by `function_call_arguments.*` for the same id, which is
     // exactly the mixed lifecycle this rewrite exists to prevent. Everything else passes through.
     if (passthrough) {
+      if (terminal) {
+        releaseAll();
+        return [block];
+      }
       const passthroughItemId = typeof parsed.item_id === "string" ? parsed.item_id : undefined;
       const isArgumentEvent = type === "response.function_call_arguments.delta"
         || type === "response.function_call_arguments.done";
@@ -169,22 +228,14 @@ export function createRoutedToolSearchRestoreBlockRewrite(
     ) {
       const itemId = typeof parsed.item.id === "string" ? parsed.item.id : undefined;
       const routed = names.has(parsed.item.name);
-      if (itemId) {
-        if (routed) {
-          routedItemIds.add(itemId);
-          ordinaryItemIds.delete(itemId);
-        } else {
-          ordinaryItemIds.add(itemId);
-          routedItemIds.delete(itemId);
-        }
-      }
+      if (itemId) classifyItemId(itemId, routed);
       const pending = takePending(itemId, outputIndex);
       const restored = routed ? restoreRoutedToolSearchCalls(parsed, names) : { value: parsed, changed: false };
       const restoredBlock = restored.changed
         ? replaceSseDataPayload(block, JSON.stringify(restored.value))
         : block;
       // Classification is retained past `output_item.done` for BOTH kinds, until the terminal
-      // event releases everything.
+      // event releases the bounded, budgeted state.
       //
       // `done` ends the item, not the id's relevance. Forgetting a ROUTED id let a trailing
       // `function_call_arguments.*` — which some upstreams emit after done — fall through to
@@ -204,7 +255,6 @@ export function createRoutedToolSearchRestoreBlockRewrite(
     }
     if (argumentEvent && itemId && routedItemIds.has(itemId)) return [];
 
-    const terminal = type === "response.completed" || type === "response.failed" || type === "response.incomplete";
     if (!terminal) return [block];
     const restored = restoreRoutedToolSearchCalls(parsed, names);
     releaseAll();

--- a/tests/responses-tool-search-repair.test.ts
+++ b/tests/responses-tool-search-repair.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { isTranslatorBudgetExceededError } from "../src/lib/translator-budget";
 import {
   restoreRoutedToolSearchCallsInJson,
   rewriteRoutedToolSearchForUpstream,
@@ -237,7 +238,8 @@ describe("routed Responses tool-search compatibility", () => {
       arguments: {},
       status: "in_progress",
     });
-    expect(budget.snapshot().currentBytes).toBe(0);
+    expect(budget.snapshot().currentBytes)
+      .toBe(Buffer.byteLength(JSON.stringify("fc_search"), "utf8"));
 
     expect(rewrite(frame("response.function_call_arguments.done", {
       output_index: 0,
@@ -627,5 +629,149 @@ describe("routed Responses tool-search compatibility", () => {
       delta: "x",
     }));
     expect(trailing).toHaveLength(1);
+  });
+
+  test("bounds classified item ids by count and releases the retained charge", () => {
+    const budget = createTestTranslatorBudget();
+    const rewrite = createRoutedToolSearchRestoreBlockRewrite(new Set(["tool_search"]), budget);
+    let expectedRetainedBytes = 0;
+
+    for (let index = 0; index < 256; index += 1) {
+      const itemId = `fc_${index}`;
+      expectedRetainedBytes += Buffer.byteLength(JSON.stringify(itemId), "utf8");
+      rewrite(frame("response.output_item.done", {
+        output_index: index,
+        item: { type: "function_call", id: itemId, name: "tool_search", arguments: "{}" },
+      }));
+    }
+
+    const beforeOverflow = budget.snapshot().currentBytes;
+    expect(beforeOverflow).toBe(expectedRetainedBytes);
+    let overflow: unknown;
+    try {
+      rewrite(frame("response.output_item.done", {
+        output_index: 256,
+        item: { type: "function_call", id: "fc_overflow", name: "tool_search", arguments: "{}" },
+      }));
+    } catch (error) {
+      overflow = error;
+    }
+    expect(isTranslatorBudgetExceededError(overflow)).toBe(true);
+    expect(overflow).toBeInstanceOf(Error);
+    expect((overflow as Error).message).toBe("translator item_ids count exceeded 256 items");
+    expect(budget.snapshot().currentBytes).toBe(beforeOverflow);
+
+    rewrite.dispose?.();
+    rewrite.dispose?.();
+    expect(budget.snapshot().currentBytes).toBe(0);
+  });
+
+  test("bounds classified item ids by serialized UTF-8 bytes", () => {
+    const budget = createTestTranslatorBudget();
+    const rewrite = createRoutedToolSearchRestoreBlockRewrite(new Set(["tool_search"]), budget);
+    const nearlyFullId = "x".repeat(256 * 1024 - 7);
+    rewrite(frame("response.output_item.done", {
+      output_index: 0,
+      item: { type: "function_call", id: nearlyFullId, name: "tool_search", arguments: "{}" },
+    }));
+    expect(budget.snapshot().currentBytes).toBe(256 * 1024 - 5);
+    rewrite(frame("response.output_item.done", {
+      output_index: 1,
+      item: { type: "function_call", id: "界", name: "tool_search", arguments: "{}" },
+    }));
+    expect(budget.snapshot().currentBytes).toBe(256 * 1024);
+
+    let overflow: unknown;
+    try {
+      rewrite(frame("response.output_item.done", {
+        output_index: 2,
+        item: {
+          type: "function_call",
+          id: "y",
+          name: "tool_search",
+          arguments: "{}",
+        },
+      }));
+    } catch (error) {
+      overflow = error;
+    }
+    if (!isTranslatorBudgetExceededError(overflow)) throw overflow;
+    expect(overflow.kind).toBe("item_ids");
+    expect(overflow.limitBytes).toBe(256 * 1024);
+    expect(budget.snapshot().currentBytes).toBe(256 * 1024);
+    rewrite.dispose?.();
+    expect(budget.snapshot().currentBytes).toBe(0);
+  });
+
+  test("deduplicates and reclassifies one item id without double charging", () => {
+    const budget = createTestTranslatorBudget();
+    const rewrite = createRoutedToolSearchRestoreBlockRewrite(new Set(["tool_search"]), budget);
+    const itemId = "fc_shared";
+    const retainedBytes = Buffer.byteLength(JSON.stringify(itemId), "utf8");
+    const emit = (event: "response.output_item.added" | "response.output_item.done", name: string) => {
+      rewrite(frame(event, {
+        output_index: 0,
+        item: { type: "function_call", id: itemId, name, arguments: "{}" },
+      }));
+      expect(budget.snapshot().currentBytes).toBe(retainedBytes);
+    };
+
+    emit("response.output_item.added", "tool_search");
+    emit("response.output_item.done", "tool_search");
+    const argument = frame("response.function_call_arguments.delta", {
+      output_index: 0,
+      item_id: itemId,
+      delta: "x",
+    });
+    expect(rewrite(argument)).toEqual([]);
+    emit("response.output_item.added", "ordinary");
+    expect(rewrite(argument)).toEqual([argument]);
+    emit("response.output_item.done", "tool_search");
+    expect(rewrite(argument)).toEqual([]);
+
+    rewrite(frame("response.completed", {
+      response: { id: "resp_done", status: "completed", output: [] },
+    }));
+    expect(budget.snapshot().currentBytes).toBe(0);
+  });
+
+  test("releases routed ids on terminal and DONE after pending passthrough", () => {
+    const budget = createTestTranslatorBudget({ maxTurnBytes: 64 });
+    const rewrite = createRoutedToolSearchRestoreBlockRewrite(new Set(["tool_search"]), budget);
+    const routedBytes = Buffer.byteLength(JSON.stringify("fc_search"), "utf8");
+    const ordinaryBytes = Buffer.byteLength(JSON.stringify("fc_plain"), "utf8");
+    rewrite(frame("response.output_item.added", {
+      output_index: 0,
+      item: { type: "function_call", id: "fc_search", name: "tool_search", arguments: "{}" },
+    }));
+    rewrite(frame("response.output_item.added", {
+      output_index: 1,
+      item: { type: "function_call", id: "fc_plain", name: "ordinary", arguments: "{}" },
+    }));
+    expect(budget.snapshot().currentBytes).toBe(routedBytes + ordinaryBytes);
+
+    const pending = frame("response.function_call_arguments.delta", {
+      output_index: 1,
+      item_id: "unknown",
+      delta: "x".repeat(256),
+    });
+    expect(rewrite(pending)).toEqual([pending]);
+    expect(budget.snapshot().currentBytes).toBe(routedBytes);
+    rewrite(frame("response.completed", {
+      response: { id: "resp_done", status: "completed", output: [] },
+    }));
+    expect(budget.snapshot().currentBytes).toBe(0);
+
+    const doneBudget = createTestTranslatorBudget();
+    const doneRewrite = createRoutedToolSearchRestoreBlockRewrite(new Set(["tool_search"]), doneBudget);
+    doneRewrite(frame("response.output_item.added", {
+      output_index: 0,
+      item: { type: "function_call", id: "fc_done", name: "tool_search", arguments: "{}" },
+    }));
+    expect(doneBudget.snapshot().currentBytes).toBeGreaterThan(0);
+    expect(doneRewrite("data: [DONE]")).toEqual(["data: [DONE]"]);
+    expect(doneBudget.snapshot().currentBytes).toBe(0);
+    doneRewrite.dispose?.();
+    expect(doneBudget.snapshot().currentBytes).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- cap routed tool-search item classification at 256 unique IDs and 256 KiB of serialized UTF-8 state
- charge each retained ID to the shared translator budget before insertion, without double charging duplicate or reclassified IDs
- preserve late function-call argument suppression and ordinary passthrough while releasing retained state on terminal events, `[DONE]`, EOF, cancellation, errors, and idempotent disposal
- report count and byte overflows distinctly and fail closed before mutating retained state

Exact base: `03735eca62398c55056d4595145561aecc444e91`  
Exact head: `207f73302d16e7daa7b113b36f62e1faffd904da`

## Verification

- Bun 1.4 `bun test tests/responses-tool-search-repair.test.ts` — 21/21 passed, 94 assertions
- Bun 1.4 `bun run typecheck` — passed
- `bun run privacy:scan` — passed
- `git diff --check` — passed
- independent production-semantic and regression-test reviews — no remaining findings

The full repository suite was not duplicated locally; maintained cross-platform CI remains the merge gate. No GUI files or user-facing configuration are changed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed; this internal bound does not change a user-facing workflow or configuration.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults; this patch touches no credential or authentication surface.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when processing streamed tool-search results.
  * Prevented excessive item tracking from exceeding configured count or size limits.
  * Ensured resources are released when streams finish, including `[DONE]` events and terminal responses.
  * Correctly handles duplicate or reclassified items and preserves budget state during overflow conditions.

* **Tests**
  * Added coverage for item limits, UTF-8 byte limits, terminal cleanup, disposal, and duplicate item handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->