### PR TITLE
fix(responses): strip cross-backend reasoning state on a model switch

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -41,7 +41,10 @@ export const FORWARD_HEADERS = [
 
 export function sanitizeReasoningInputContent(
   body: unknown,
-  opts?: { preserveRawReasoningContent?: boolean },
+  opts?: {
+    preserveRawReasoningContent?: boolean;
+    stripEncryptedContent?: boolean;
+  },
 ): unknown {
   if (!body || typeof body !== "object" || Array.isArray(body)) return body;
   const raw = body as Record<string, unknown>;
@@ -56,14 +59,23 @@ export function sanitizeReasoningInputContent(
     // ocxr1 envelopes are proxy-minted (Anthropic signatures), not OpenAI encryption — the native
     // backend cannot decrypt them and would reject the request. Strip regardless of content shape.
     const hasOcxEnvelope = typeof rec.encrypted_content === "string" && rec.encrypted_content.startsWith(OCX_REASONING_PREFIX);
-    if (!hasRawContent && !hasOcxEnvelope) return item;
-    if (hasOcxEnvelope) {
-      changed = true;
-      const next: Record<string, unknown> = { ...rec };
-      delete next.encrypted_content;
-      if (!opts?.preserveRawReasoningContent) next.content = [];
-      return next;
-    }
+    const hasOutputStatus = Object.prototype.hasOwnProperty.call(rec, "status");
+    const hasEncryptedContent = Object.prototype.hasOwnProperty.call(rec, "encrypted_content");
+    const stripEncryptedContent = hasOcxEnvelope
+      || (opts?.stripEncryptedContent === true && hasEncryptedContent);
+    const retainsEncryptedContent = hasEncryptedContent && !stripEncryptedContent;
+    // Invariant for fields newly stripped by this cross-backend layer: an item whose
+    // encrypted_content is forwarded keeps status because OpenAI-operated backends bind opaque
+    // reasoning blobs to the item shape. Content blanking predates this invariant and remains
+    // required by ChatGPT's input contract; a native blob plus raw content is a known unresolved
+    // shape conflict, not an oversight to resolve by preserving content here.
+    const stripOutputStatus = hasOutputStatus && !retainsEncryptedContent;
+    const blankContent = !opts?.preserveRawReasoningContent && (hasRawContent || hasOcxEnvelope);
+    if (!blankContent && !stripOutputStatus && !stripEncryptedContent) return item;
+    changed = true;
+    const next: Record<string, unknown> = { ...rec };
+    if (stripOutputStatus) delete next.status;
+    if (stripEncryptedContent) delete next.encrypted_content;
     // Routed models can produce raw `reasoning_text` output items. Codex echoes those in later
     // native GPT requests, but ChatGPT's Responses backend accepts reasoning input only with empty
     // `content`; keep summaries/ids and drop the raw content so native passthrough does not 400.
@@ -71,9 +83,8 @@ export function sanitizeReasoningInputContent(
     // guide merges reasoning items into the adjacent assistant message), so providers flagged
     // `preserveResponsesReasoningContent` keep it — deleting valid replay content there breaks
     // continuations after tool calls (issue #875 family).
-    if (opts?.preserveRawReasoningContent) return item;
-    changed = true;
-    return { ...rec, content: [] };
+    if (blankContent) next.content = [];
+    return next;
   });
 
   return changed ? { ...raw, input } : body;
@@ -1572,7 +1583,10 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
         outBody = rewritten.body;
         convertedRoutedToolSearchNames = rewritten.names;
       }
-      const sanitizedBody = normalizeToolSchemas(stripSparkCompatibility(stripUnsupportedReasoningParams(stripItemIdsWhenUnstored(stripInvalidItemIds(stripUnsupportedHostedTools(sanitizeReasoningInputContent(scrubOcxCompactionItems(outBody), { preserveRawReasoningContent: provider.preserveResponsesReasoningContent === true })))))));
+      const sanitizedBody = normalizeToolSchemas(stripSparkCompatibility(stripUnsupportedReasoningParams(stripItemIdsWhenUnstored(stripInvalidItemIds(stripUnsupportedHostedTools(sanitizeReasoningInputContent(scrubOcxCompactionItems(outBody), {
+        preserveRawReasoningContent: provider.preserveResponsesReasoningContent === true,
+        stripEncryptedContent: parsed._stripReasoningEncryptedContent === true,
+      })))))));
       const finalBody = stripDisabledReasoningSummaries(
         normalizeConfiguredReasoningSummaryDelivery(sanitizedBody, provider, parsed.modelId),
         provider,

--- a/src/responses/reasoning-replay-cache.ts
+++ b/src/responses/reasoning-replay-cache.ts
@@ -52,8 +52,16 @@ interface CacheEntry {
   at: number;
 }
 
+interface ServingIdentityEntry {
+  identity: string;
+  bytes: number;
+  at: number;
+}
+
 const entries = new Map<string, CacheEntry>();
+const servingIdentities = new Map<string, ServingIdentityEntry>();
 let totalBytes = 0;
+let servingIdentityTotalBytes = 0;
 let clockForTests: (() => number) | null = null;
 
 const now = (): number => clockForTests?.() ?? Date.now();
@@ -62,26 +70,95 @@ function nonEmpty(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-function keyFor(callId: string, scope: OcxReasoningReplayScopeRef | undefined): string | undefined {
-  const identity = scope?.current;
+type ReasoningReplayIdentityTuple = readonly [string, string, string, string, string];
+
+function tupleForIdentity(
+  identity: Readonly<OcxReasoningReplayIdentity> | undefined,
+): ReasoningReplayIdentityTuple | undefined {
   if (
-    !nonEmpty(callId)
-    || !nonEmpty(scope?.clientThreadId)
-    || !nonEmpty(identity?.providerName)
+    !nonEmpty(identity?.providerName)
     || !nonEmpty(identity?.providerDestinationIdentity)
     || !nonEmpty(identity?.adapterName)
     || !nonEmpty(identity?.modelId)
     || !nonEmpty(identity?.credentialIdentity)
   ) return undefined;
-  return JSON.stringify([
-    scope.clientThreadId,
+  return [
     identity.providerName,
     identity.providerDestinationIdentity,
     identity.adapterName,
     identity.modelId,
     identity.credentialIdentity,
+  ];
+}
+
+function keyFor(callId: string, scope: OcxReasoningReplayScopeRef | undefined): string | undefined {
+  const identity = tupleForIdentity(scope?.current);
+  if (!nonEmpty(callId) || !nonEmpty(scope?.clientThreadId) || !identity) return undefined;
+  return JSON.stringify([
+    scope.clientThreadId,
+    ...identity,
     callId,
   ]);
+}
+
+function deleteServingIdentity(threadId: string): void {
+  const entry = servingIdentities.get(threadId);
+  if (!entry) return;
+  servingIdentities.delete(threadId);
+  servingIdentityTotalBytes -= entry.bytes;
+}
+
+function sweepExpiredServingIdentities(at: number): void {
+  for (const [threadId, entry] of servingIdentities) {
+    if (at - entry.at >= TTL_MS) deleteServingIdentity(threadId);
+  }
+}
+
+/**
+ * Compare this request's route with the last route recorded for its client thread, then
+ * record the current route. A live mismatch means replayed opaque reasoning was minted by
+ * another backend and must not be forwarded to this one.
+ *
+ * Missing, expired, or evicted state is deliberately unknown rather than a mismatch. This
+ * store is process-local, so a backend switch spanning a proxy restart is not detected.
+ */
+export function updateReasoningReplayServingIdentity(
+  scope: OcxReasoningReplayScopeRef | undefined,
+): boolean {
+  const threadId = scope?.clientThreadId;
+  const identityTuple = tupleForIdentity(scope?.current);
+  if (!nonEmpty(threadId) || !identityTuple) return false;
+  const identity = JSON.stringify(identityTuple);
+
+  const at = now();
+  sweepExpiredServingIdentities(at);
+  const previous = servingIdentities.get(threadId);
+  const changed = previous !== undefined && previous.identity !== identity;
+  const bytes = Buffer.byteLength(JSON.stringify([threadId, identity]), "utf8");
+  if (bytes > MAX_TOTAL_BYTES) {
+    deleteServingIdentity(threadId);
+    return false;
+  }
+
+  if (previous) deleteServingIdentity(threadId);
+  servingIdentities.set(threadId, { identity, bytes, at });
+  servingIdentityTotalBytes += bytes;
+  while (
+    (servingIdentityTotalBytes > MAX_TOTAL_BYTES || servingIdentities.size > MAX_ENTRIES)
+    && servingIdentities.size > 1
+  ) {
+    let oldestThreadId: string | undefined;
+    let oldestAt = Infinity;
+    for (const [candidateThreadId, entry] of servingIdentities) {
+      if (entry.at < oldestAt) {
+        oldestAt = entry.at;
+        oldestThreadId = candidateThreadId;
+      }
+    }
+    if (oldestThreadId === undefined) break;
+    deleteServingIdentity(oldestThreadId);
+  }
+  return changed;
 }
 
 function processLocalIdentity(domain: string, material: string): string {
@@ -303,6 +380,8 @@ export function peekReasoningForCall(
 /** Test-only: reset the cache and optionally pin the clock. */
 export function clearReasoningReplayCacheForTests(clock?: (() => number) | null): void {
   entries.clear();
+  servingIdentities.clear();
   totalBytes = 0;
+  servingIdentityTotalBytes = 0;
   clockForTests = clock ?? null;
 }

--- a/src/responses/reasoning-replay-cache.ts
+++ b/src/responses/reasoning-replay-cache.ts
@@ -91,6 +91,25 @@ function tupleForIdentity(
   ];
 }
 
+function tupleForServingIdentity(
+  identity: Readonly<OcxReasoningReplayIdentity> | undefined,
+): ReasoningReplayIdentityTuple | undefined {
+  if (
+    !nonEmpty(identity?.providerName)
+    || !nonEmpty(identity?.providerDestinationDurableIdentity)
+    || !nonEmpty(identity?.adapterName)
+    || !nonEmpty(identity?.modelId)
+    || !nonEmpty(identity?.credentialDurableIdentity)
+  ) return undefined;
+  return [
+    identity.providerName,
+    identity.providerDestinationDurableIdentity,
+    identity.adapterName,
+    identity.modelId,
+    identity.credentialDurableIdentity,
+  ];
+}
+
 function keyFor(callId: string, scope: OcxReasoningReplayScopeRef | undefined): string | undefined {
   const identity = tupleForIdentity(scope?.current);
   if (!nonEmpty(callId) || !nonEmpty(scope?.clientThreadId) || !identity) return undefined;
@@ -119,14 +138,16 @@ function sweepExpiredServingIdentities(at: number): void {
  * record the current route. A live mismatch means replayed opaque reasoning was minted by
  * another backend and must not be forwarded to this one.
  *
- * Missing, expired, or evicted state is deliberately unknown rather than a mismatch. This
- * store is process-local, so a backend switch spanning a proxy restart is not detected.
+ * Serving provenance uses restart-stable destination and credential dimensions so token
+ * generations and other volatile credential material cannot create false route changes. Missing
+ * durable identity, expired, or evicted state is deliberately unknown rather than a mismatch.
+ * This store is process-local, so a backend switch spanning a proxy restart is not detected.
  */
 export function updateReasoningReplayServingIdentity(
   scope: OcxReasoningReplayScopeRef | undefined,
 ): boolean {
   const threadId = scope?.clientThreadId;
-  const identityTuple = tupleForIdentity(scope?.current);
+  const identityTuple = tupleForServingIdentity(scope?.current);
   if (!nonEmpty(threadId) || !identityTuple) return false;
   const identity = JSON.stringify(identityTuple);
 

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -21,6 +21,7 @@ import {
   durableReplayCredentialIdentity,
   reasoningReplayKeyCredentialIdentity,
   reasoningReplayOAuthCredentialIdentity,
+  updateReasoningReplayServingIdentity,
 } from "../../responses/reasoning-replay-cache";
 import { awaitThoughtSignatureDurability, thoughtSignatureReplaySalt } from "../../responses/thought-signature-replay";
 import { buildCompactV1Output, COMPACT_PROMPT, decodeCompactionSummary, extractCompactUserMessages } from "../../responses/compaction";
@@ -407,6 +408,11 @@ function bindRouteReasoningReplayScope(args: {
         }
       : undefined,
   );
+  // Keep this sticky for the whole outbound request: a later auth/key rebind may compare equal
+  // after the first mismatch, but it cannot make history minted by the prior route decodable.
+  if (updateReasoningReplayServingIdentity(parsed._reasoningReplayScope)) {
+    parsed._stripReasoningEncryptedContent = true;
+  }
 }
 
 function nonEmptyProviderApiKey(provider: OcxProviderConfig): string | undefined {

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -65,6 +65,8 @@ export interface OcxParsedRequest {
   _clientThreadId?: string;
   /** Provider/account/model-bound namespace for process-local raw-reasoning replay. */
   _reasoningReplayScope?: OcxReasoningReplayScopeRef;
+  /** A known in-process route switch requires opaque Responses reasoning blobs to be dropped. */
+  _stripReasoningEncryptedContent?: boolean;
   /**
    * Optional authenticated tenant/operator namespace for Cursor thread→conversation derivation.
    * When absent (single-operator local proxy), derivation stays local-scoped.

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -488,14 +488,29 @@ blob is kept unless the in-process thread record proves that the current provide
 adapter, model, or credential differs from the route recorded for the prior request on that client
 thread. On a proven change the blob and `status` are removed while the reasoning item and its summary
 survive; `status` is also removed from blobless reasoning items. Missing, expired, or evicted identity
-state is unknown. The record is deliberately process-local, so a backend switch spanning a proxy
+state is unknown. The comparison uses the durable destination and credential identities with the
+provider, adapter, and model, so OAuth token-generation refreshes do not look like backend changes;
+when either durable dimension is unavailable it refuses to record rather than falling back to a
+volatile identity. The record is deliberately process-local, so a backend switch spanning a proxy
 restart is not detected and may still be rejected upstream.
+
+A combo target rotation between turns legitimately changes that serving identity, so the following
+turn drops blobs minted by the prior target. This is correct because the new target cannot decode
+them, but it is intentionally unobvious to the client: `pickComboTarget` keys selection state only by
+combo id, without a conversation dimension, and the SSE model-name rewrite preserves the requested
+combo name instead of exposing the concrete target switch. A user can therefore observe a reasoning
+cache drop with no visible model change.
+
+The image and web-search auxiliary loops consume `_reasoningReplayScope` for bridge-level replay but
+never call `bindRouteReasoningReplayScope`, so their internal small-model requests do not update the
+serving-identity record. That omission is intentional: binding those routes would poison the main
+conversation's last-serving identity and cause a later main-model turn to strip valid blobs.
 
 [Decision Log]
 - 목적과 의도: Keep same-backend opaque reasoning replay while preventing backend-private blobs and output-only fields from breaking the first turn after a route change.
 - 기존 구현 및 제약 조건: Reasoning-input sanitation already handled raw content and `ocxr1:` envelopes; the replay cache already supplied a bounded, thread-scoped physical-route identity, but no record connected that identity to native `encrypted_content` provenance.
 - 검토한 주요 대안: Strip every opaque blob, persist provenance across restarts, retry after an upstream 4xx, or compare and strip before the first outbound request only when an in-process record proves a route change.
-- 선택한 방식: Preserve `status` whenever its blob is forwarded without changing the pre-existing raw-`content` blanking rule; otherwise remove output-only `status`, compare and update a 64-entry/256 KiB/one-hour in-process serving-identity record at request time, and pass the proven-change decision into the Responses adapter to remove foreign `encrypted_content`.
+- 선택한 방식: Preserve `status` whenever its blob is forwarded without changing the pre-existing raw-`content` blanking rule; otherwise remove output-only `status`, compare and update a 64-entry/256 KiB/one-hour in-process serving-identity record using durable destination and credential dimensions at request time, and pass the proven-change decision into the Responses adapter to remove foreign `encrypted_content`.
 - 다른 대안 대신 이 방식을 선택한 이유: Unknown provenance can still be valid after restart, durable storage is unnecessary for this bounded compatibility hint, and a deterministic pre-flight decision avoids a second paid or stateful upstream attempt.
 - 장점, 단점 및 영향: Same-route and unknown replay retain cached reasoning, known cross-route replay keeps the reasoning item without its undecodable blob, and switches spanning a proxy restart remain an explicit coverage gap.
 

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -479,6 +479,26 @@ replays are explicit and receive the same repair.
 These compatibility guards are covered by focused tests and should stay close to the adapters that
 need them.
 
+Responses passthrough keeps output-only `status` on any `reasoning` input item that retains opaque
+`encrypted_content` because OpenAI-operated backends may bind the blob to that field. The established
+raw-`content` rule remains separate: ChatGPT accepts reasoning input only with empty `content`, so a
+native blob plus raw content keeps the blob and `status` but still blanks `content`. That shape is a
+known unresolved contract conflict, not evidence that either existing rule is safe to broaden. The
+blob is kept unless the in-process thread record proves that the current provider, destination,
+adapter, model, or credential differs from the route recorded for the prior request on that client
+thread. On a proven change the blob and `status` are removed while the reasoning item and its summary
+survive; `status` is also removed from blobless reasoning items. Missing, expired, or evicted identity
+state is unknown. The record is deliberately process-local, so a backend switch spanning a proxy
+restart is not detected and may still be rejected upstream.
+
+[Decision Log]
+- 목적과 의도: Keep same-backend opaque reasoning replay while preventing backend-private blobs and output-only fields from breaking the first turn after a route change.
+- 기존 구현 및 제약 조건: Reasoning-input sanitation already handled raw content and `ocxr1:` envelopes; the replay cache already supplied a bounded, thread-scoped physical-route identity, but no record connected that identity to native `encrypted_content` provenance.
+- 검토한 주요 대안: Strip every opaque blob, persist provenance across restarts, retry after an upstream 4xx, or compare and strip before the first outbound request only when an in-process record proves a route change.
+- 선택한 방식: Preserve `status` whenever its blob is forwarded without changing the pre-existing raw-`content` blanking rule; otherwise remove output-only `status`, compare and update a 64-entry/256 KiB/one-hour in-process serving-identity record at request time, and pass the proven-change decision into the Responses adapter to remove foreign `encrypted_content`.
+- 다른 대안 대신 이 방식을 선택한 이유: Unknown provenance can still be valid after restart, durable storage is unnecessary for this bounded compatibility hint, and a deterministic pre-flight decision avoids a second paid or stateful upstream attempt.
+- 장점, 단점 및 영향: Same-route and unknown replay retain cached reasoning, known cross-route replay keeps the reasoning item without its undecodable blob, and switches spanning a proxy restart remain an explicit coverage gap.
+
 DeepSeek's stateless Responses compatibility pass normalizes only unambiguous tool-call batches.
 Calls emitted before the first matched output stay together as one assistant batch, followed by
 their outputs in call order; hook-injected messages that split the batch move after it without being

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -774,6 +774,154 @@ describe("OpenAI Responses passthrough sanitization", () => {
     });
   });
 
+  test("keeps a blob-bearing reasoning item byte-identical when the route is unchanged", () => {
+    const adapter = createResponsesPassthroughAdapter(provider);
+    const reasoningItem = {
+      type: "reasoning",
+      id: "rs_same_backend",
+      status: "completed",
+      summary: [{ type: "summary_text", text: "summary" }],
+      encrypted_content: "backend-minted-blob",
+      content: [],
+    };
+    const request = adapter.buildRequest({
+      modelId: "gpt-5.6-sol",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: {
+        model: "gpt-5.6-sol",
+        store: true,
+        input: [reasoningItem],
+      },
+    }, { headers: new Headers({ authorization: "Bearer token" }) });
+    const body = JSON.parse(request.body) as { input: Record<string, unknown>[] };
+
+    expect(JSON.stringify(body.input[0])).toBe(JSON.stringify(reasoningItem));
+  });
+
+  test("keeps a native blob while blanking its raw reasoning content", () => {
+    const adapter = createResponsesPassthroughAdapter(provider);
+    const request = adapter.buildRequest({
+      modelId: "gpt-5.6-sol",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: {
+        model: "gpt-5.6-sol",
+        input: [{
+          type: "reasoning",
+          status: "completed",
+          summary: [],
+          encrypted_content: "native-backend-blob",
+          content: [{ type: "reasoning_text", text: "raw routed reasoning" }],
+        }],
+      },
+    }, { headers: new Headers({ authorization: "Bearer token" }) });
+    const body = JSON.parse(request.body) as { input: Record<string, unknown>[] };
+
+    expect(body.input[0]).toEqual({
+      type: "reasoning",
+      status: "completed",
+      summary: [],
+      encrypted_content: "native-backend-blob",
+      content: [],
+    });
+  });
+
+  test("keeps encrypted reasoning content without a proven route switch", () => {
+    const adapter = createResponsesPassthroughAdapter(provider);
+    const request = adapter.buildRequest({
+      modelId: "gpt-5.6-sol",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: {
+        model: "gpt-5.6-sol",
+        input: [{
+          type: "reasoning",
+          summary: [],
+          encrypted_content: "same-backend-blob",
+        }],
+      },
+    }, { headers: new Headers({ authorization: "Bearer token" }) });
+    const body = JSON.parse(request.body) as { input: Record<string, unknown>[] };
+
+    expect(body.input[0]).toEqual({
+      type: "reasoning",
+      summary: [],
+      encrypted_content: "same-backend-blob",
+    });
+  });
+
+  test("strips encrypted reasoning content after a known route switch but keeps the item", () => {
+    const adapter = createResponsesPassthroughAdapter(provider);
+    const request = adapter.buildRequest({
+      modelId: "gpt-5.6-sol",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _stripReasoningEncryptedContent: true,
+      _rawBody: {
+        model: "gpt-5.6-sol",
+        input: [
+          {
+            type: "reasoning",
+            id: "rs_foreign_backend",
+            status: "completed",
+            summary: [{ type: "summary_text", text: "still useful" }],
+            encrypted_content: "foreign-backend-blob",
+          },
+          {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "continue" }],
+          },
+        ],
+      },
+    }, { headers: new Headers({ authorization: "Bearer token" }) });
+    const body = JSON.parse(request.body) as { input: Record<string, unknown>[] };
+
+    expect(body.input).toEqual([
+      {
+        type: "reasoning",
+        id: "rs_foreign_backend",
+        summary: [{ type: "summary_text", text: "still useful" }],
+      },
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "continue" }],
+      },
+    ]);
+  });
+
+  test("strips status from a reasoning item that has no encrypted content", () => {
+    const adapter = createResponsesPassthroughAdapter(provider);
+    const request = adapter.buildRequest({
+      modelId: "gpt-5.6-sol",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: {
+        model: "gpt-5.6-sol",
+        input: [{
+          type: "reasoning",
+          id: "rs_without_blob",
+          status: "completed",
+          summary: [{ type: "summary_text", text: "summary" }],
+        }],
+      },
+    }, { headers: new Headers({ authorization: "Bearer token" }) });
+    const body = JSON.parse(request.body) as { input: Record<string, unknown>[] };
+
+    expect(body.input[0]).toEqual({
+      type: "reasoning",
+      id: "rs_without_blob",
+      summary: [{ type: "summary_text", text: "summary" }],
+    });
+  });
+
   test("strips image_generation hosted tool for codex-spark passthrough", () => {
     const adapter = createResponsesPassthroughAdapter(provider);
     const request = adapter.buildRequest({

--- a/tests/reasoning-replay-identity.test.ts
+++ b/tests/reasoning-replay-identity.test.ts
@@ -26,9 +26,11 @@ function scope(
     current: {
       providerName: "provider-a",
       providerDestinationIdentity: "destination:provider-a",
+      providerDestinationDurableIdentity: "destination:durable-provider-a",
       adapterName: "openai-chat",
       modelId: "deepseek-v4-flash",
       credentialIdentity: "key:physical-a",
+      credentialDurableIdentity: "credential:durable-slot-a",
       ...overrides,
     },
   };
@@ -70,23 +72,63 @@ describe("reasoning replay provider and credential identity", () => {
     }
   });
 
-  test("serving identity comparison reports only known model or destination changes", () => {
-    expect(updateReasoningReplayServingIdentity(scope())).toBe(false);
-    expect(updateReasoningReplayServingIdentity(scope())).toBe(false);
+  test("serving identity ignores credential generation but reports durable route changes", () => {
+    expect(updateReasoningReplayServingIdentity(scope({
+      credentialIdentity: "oauth:slot-a-generation-a",
+    }))).toBe(false);
+    expect(updateReasoningReplayServingIdentity(scope({
+      credentialIdentity: "oauth:slot-a-generation-b",
+    }))).toBe(false);
 
-    const changedModel = scope({ modelId: "deepseek-v4" });
+    const changedModel = scope({
+      modelId: "deepseek-v4",
+      credentialIdentity: "oauth:slot-a-generation-b",
+    });
     expect(updateReasoningReplayServingIdentity(changedModel)).toBe(true);
     expect(updateReasoningReplayServingIdentity(changedModel)).toBe(false);
+
+    const changedCredential = scope({
+      modelId: "deepseek-v4",
+      credentialIdentity: "oauth:slot-b-generation-a",
+      credentialDurableIdentity: "credential:durable-slot-b",
+    });
+    expect(updateReasoningReplayServingIdentity(changedCredential)).toBe(true);
+    expect(updateReasoningReplayServingIdentity(changedCredential)).toBe(false);
 
     const changedDestination = scope({
       modelId: "deepseek-v4",
       providerDestinationIdentity: "destination:provider-b",
+      providerDestinationDurableIdentity: "destination:durable-provider-b",
+      credentialIdentity: "oauth:slot-b-generation-a",
+      credentialDurableIdentity: "credential:durable-slot-b",
     });
     expect(updateReasoningReplayServingIdentity(changedDestination)).toBe(true);
     expect(updateReasoningReplayServingIdentity(changedDestination)).toBe(false);
 
     expect(updateReasoningReplayServingIdentity(undefined)).toBe(false);
     expect(updateReasoningReplayServingIdentity({ clientThreadId: "thread-unknown" })).toBe(false);
+  });
+
+  test("serving identity refuses to record when durable dimensions are unavailable", () => {
+    const clientThreadId = "thread-without-durable-identity";
+    expect(updateReasoningReplayServingIdentity({
+      ...scope({ credentialDurableIdentity: undefined }),
+      clientThreadId,
+    })).toBe(false);
+    expect(updateReasoningReplayServingIdentity({
+      ...scope({ modelId: "different-model" }),
+      clientThreadId,
+    })).toBe(false);
+
+    const destinationThreadId = "thread-without-durable-destination";
+    expect(updateReasoningReplayServingIdentity({
+      ...scope({ providerDestinationDurableIdentity: undefined }),
+      clientThreadId: destinationThreadId,
+    })).toBe(false);
+    expect(updateReasoningReplayServingIdentity({
+      ...scope({ modelId: "different-model" }),
+      clientThreadId: destinationThreadId,
+    })).toBe(false);
   });
 
   test("expired serving identity is unknown rather than a backend change", () => {

--- a/tests/reasoning-replay-identity.test.ts
+++ b/tests/reasoning-replay-identity.test.ts
@@ -10,6 +10,7 @@ import {
   reasoningReplayKeyCredentialIdentity,
   reasoningReplayOAuthCredentialIdentity,
   rememberReasoningForCall,
+  updateReasoningReplayServingIdentity,
 } from "../src/responses/reasoning-replay-cache";
 import type { AdapterEvent, OcxReasoningReplayScopeRef } from "../src/types";
 
@@ -67,6 +68,55 @@ describe("reasoning replay provider and credential identity", () => {
     ]) {
       expect(peekReasoningForCall(CALL_ID, changed)).toBeUndefined();
     }
+  });
+
+  test("serving identity comparison reports only known model or destination changes", () => {
+    expect(updateReasoningReplayServingIdentity(scope())).toBe(false);
+    expect(updateReasoningReplayServingIdentity(scope())).toBe(false);
+
+    const changedModel = scope({ modelId: "deepseek-v4" });
+    expect(updateReasoningReplayServingIdentity(changedModel)).toBe(true);
+    expect(updateReasoningReplayServingIdentity(changedModel)).toBe(false);
+
+    const changedDestination = scope({
+      modelId: "deepseek-v4",
+      providerDestinationIdentity: "destination:provider-b",
+    });
+    expect(updateReasoningReplayServingIdentity(changedDestination)).toBe(true);
+    expect(updateReasoningReplayServingIdentity(changedDestination)).toBe(false);
+
+    expect(updateReasoningReplayServingIdentity(undefined)).toBe(false);
+    expect(updateReasoningReplayServingIdentity({ clientThreadId: "thread-unknown" })).toBe(false);
+  });
+
+  test("expired serving identity is unknown rather than a backend change", () => {
+    let clock = 1_000;
+    clearReasoningReplayCacheForTests(() => clock);
+    expect(updateReasoningReplayServingIdentity(scope())).toBe(false);
+
+    clock += 60 * 60 * 1000 + 1;
+    expect(updateReasoningReplayServingIdentity(scope({ modelId: "deepseek-v4" }))).toBe(false);
+  });
+
+  test("repeated identity changes do not grow the thread store beyond 64 entries", () => {
+    const servingScope = (
+      threadId: string,
+      modelId: string,
+    ): OcxReasoningReplayScopeRef => ({
+      ...scope({ modelId }),
+      clientThreadId: threadId,
+    });
+
+    for (let i = 0; i < 64; i++) {
+      expect(updateReasoningReplayServingIdentity(servingScope(`thread-${i}`, "model-a"))).toBe(false);
+    }
+    for (let i = 0; i < 70; i++) {
+      expect(updateReasoningReplayServingIdentity(servingScope("thread-63", `model-change-${i}`))).toBe(true);
+    }
+
+    expect(updateReasoningReplayServingIdentity(servingScope("thread-64", "model-a"))).toBe(false);
+    expect(updateReasoningReplayServingIdentity(servingScope("thread-1", "model-b"))).toBe(true);
+    expect(updateReasoningReplayServingIdentity(servingScope("thread-0", "model-b"))).toBe(false);
   });
 
   test("incomplete, unscoped, and legacy thread-only namespaces fail closed", () => {


### PR DESCRIPTION
## Summary

Switching model mid-conversation breaks the next turn. Both failures are cross-backend: the client replays history minted by the previous destination, and the new one rejects it.

Reproduced against live providers through the proxy — mint a reasoning item on `xai/grok-4.6`, then replay that history to `openai/gpt-5.6-sol`:

```
replay grok -> grok : OK
replay grok -> SOL  : FAILED  Unknown parameter: 'input[1].status'
  ... with `status` removed:
replay grok -> SOL  : FAILED  The encrypted content ZvQ+...fBJg could not be verified.
                              Reason: Encrypted content could not be decrypted or parsed.
  ... with `status` and `encrypted_content` removed:
replay grok -> SOL  : OK
```

Two independent problems, in that order.

**(a) `status` on a replayed reasoning item.** Grok emits `status: "completed"`; OpenAI rejects the field on input. It is output-only — Grok itself still accepts a replayed item without it, so removing it is safe in both directions.

**(b) A reasoning blob is only decodable by the backend that minted it.** Same class as the compaction-blob provenance problem in #2228, with `encrypted_content` on reasoning items instead.

## Approach — extend the existing mechanism, not a new one

`src/responses/reasoning-replay-cache.ts` already implements a bounded, thread-scoped store (64 entries / 256 KiB / 1 h TTL) and already computes the identity tuple `bindRouteReasoningReplayScope` uses. This adds a small parallel record with the same discipline: remember, per client thread, the identity that served the most recent request; on the next request for that thread, if the identity differs, strip `encrypted_content` from replayed reasoning items before the request goes out.

**No retry-on-4xx.** Deterministic pre-flight only.

### The record compares rotation-safe dimensions

The identity tuple includes the credential's OAuth generation, which changes on every token refresh — and six of the eight `bindRouteReasoningReplayScope` call sites are rotation or refresh rebinds. Comparing that tuple would make every key-pool provider look like a destination switch on refresh. The serving record therefore compares only durable dimensions (`providerDestinationDurableIdentity`, `credentialDurableIdentity`) and **refuses to record** when either is missing, rather than falling back to volatile ones. The proxy's own cache keeps its strict key unchanged.

The failure directions are deliberately asymmetric: **a missed strip costs one degraded turn; a spurious strip is a permanent quality regression.**

### What is deliberately not covered

No record — fresh process, evicted, expired, or no client thread id — keeps the blobs. Stripping on "unknown" would discard valid cached reasoning after every restart. This is stated in a comment rather than papered over, and it is real: a switch that spans a proxy restart still fails. Closing it needs the upstream's own error signal and is a separate change.

### Interaction with other model routing, documented not changed

- **Combo rotation** legitimately drops blobs, and the SSE model-name rewrite hides the switch from the client, so the user sees reasoning quality change with no visible cause.
- **The image and web-search sidecar loops** consume the reasoning scope without rebinding it. That is what keeps internal small-model calls from poisoning the thread's record — worth stating explicitly, since "helpfully" adding a bind there would break it.

Prompts carrying images are unaffected: these transforms touch tool containers, reasoning items and compaction items, never message content.

## Verification

Live, through the deployed proxy, with real blob-bearing items on both routes (blobs 468–3128 chars):

| check | result |
|---|---|
| grok replay, own blob + `content: null` | 200 |
| openai replay, own blob intact | 200 |
| **grok history -> SOL, same thread** | **200** |
| SOL history -> grok, same thread | 200 |

Counterfactual, to show the strip is what does the work rather than the upstream having become lenient — the same grok item (726-char blob, `status` present) replayed to `gpt-5.6-sol`:

| thread | record | result |
|---|---|---|
| same thread id | exists -> strip fires | **200** |
| fresh thread id | none -> blob kept by design | **400** |

That second row is the documented restart gap behaving exactly as designed.

## Tests

`bun run test` — 13742 pass, 10 skip, **1 fail**: `tests/key-login-live-update.test.ts` ("notify after key login pushes the merged row and keeps modelCosts"). That failure is pre-existing and unrelated — it reproduces identically on branches that never touch CLI code, and appears on every branch in this series.

Part of #2240.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of encrypted reasoning data during response passthrough.
  - Preserves encrypted reasoning content when routing remains unchanged.
  - Removes stale encrypted content after a confirmed route change.
  - Cleans up reasoning metadata when encrypted content is unavailable.
  - Maintains consistent behavior during credential, model, and destination changes.

- **Tests**
  - Added coverage for reasoning-content preservation, cleanup, route changes, expiration, and bounded replay history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->