### PR TITLE
fix(xai): Chat default for Grok 4.5/4.6 OAuth + unconditional tier policy (doc 100 unit)

### DIFF
--- a/src/providers/fastwire.ts
+++ b/src/providers/fastwire.ts
@@ -143,34 +143,40 @@ function resolvePolicyAdapter(
   inbound: InboundWire,
 ): { adapter: string; hardPinned: boolean; forwardCallerServiceTier?: boolean } {
   // Hard pins and configured overrides deliberately use the same exact-key semantics as
-  // resolveWireProtocolOverride(). Registry defaults alone normalize ids at their boundary.
+  // resolveWireProtocolOverride(). Registry route policy normalizes ids at its boundary.
   const hardPin = Object.hasOwn(authority.hardPins, modelId)
     ? authority.hardPins[modelId]
     : undefined;
   if (typeof hardPin === "string") return { adapter: hardPin, hardPinned: true };
   if (authority.modelWireOverrideAllowed) {
+    const registryDefault = MODEL_ADAPTER_OVERRIDE_ALLOWED.has(authority.providerAdapter)
+      ? registryDefaultForModel(
+          authority.registryWireDefaults,
+          modelId,
+          inbound,
+          authority.providerAuthMode,
+        )
+      : undefined;
     const configured = Object.hasOwn(authority.modelAdapters, modelId)
       ? authority.modelAdapters[modelId]
       : undefined;
     if (typeof configured === "string" && MODEL_ADAPTER_OVERRIDE_ALLOWED.has(configured)) {
-      return { adapter: configured, hardPinned: false };
+      return {
+        adapter: configured,
+        hardPinned: false,
+        ...(registryDefault?.forwardCallerServiceTier === false
+          ? { forwardCallerServiceTier: false }
+          : {}),
+      };
     }
-    if (MODEL_ADAPTER_OVERRIDE_ALLOWED.has(authority.providerAdapter)) {
-      const registryDefault = registryDefaultForModel(
-        authority.registryWireDefaults,
-        modelId,
-        inbound,
-        authority.providerAuthMode,
-      );
-      if (registryDefault !== undefined) {
-        return {
-          adapter: registryDefault.adapter,
-          hardPinned: false,
-          ...(registryDefault.forwardCallerServiceTier !== undefined
-            ? { forwardCallerServiceTier: registryDefault.forwardCallerServiceTier }
-            : {}),
-        };
-      }
+    if (registryDefault !== undefined) {
+      return {
+        adapter: registryDefault.adapter,
+        hardPinned: false,
+        ...(registryDefault.forwardCallerServiceTier !== undefined
+          ? { forwardCallerServiceTier: registryDefault.forwardCallerServiceTier }
+          : {}),
+      };
     }
   }
   return { adapter: authority.providerAdapter, hardPinned: false };

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1026,19 +1026,18 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     // grok-4.5; the reasoning ladder does not — 4.6 adds the documented xhigh rung.
     models: ["grok-4.6", "grok-4.5", "grok-4.3", "grok-4.20-0309-reasoning", "grok-4.20-0309-non-reasoning", "grok-build-0.1", "grok-composer-2.5-fast"],
     defaultModel: "grok-4.5",
-    // The current Grok CLI catalog declares both subscription models as native Responses
-    // backends. Keep API-key and translated Chat/Anthropic callers on their existing wire;
-    // Codex Responses traffic can relay xAI's SSE as it arrives instead of waiting for the
-    // Chat Completions compatibility stream to flush at the end of a reasoning turn.
+    // Keep Codex Responses callers on the compatibility Chat wire until xAI can replay
+    // opaque reasoning continuation and compaction state across later turns. The scoped
+    // declaration also keeps caller-owned service tiers off the OAuth subscription route.
     modelWireDefaults: {
       "grok-4.6": {
-        wire: "openai-responses",
+        wire: "openai-chat",
         inbound: ["responses"],
         authModes: ["oauth"],
         forwardCallerServiceTier: false,
       },
       "grok-4.5": {
-        wire: "openai-responses",
+        wire: "openai-chat",
         inbound: ["responses"],
         authModes: ["oauth"],
         forwardCallerServiceTier: false,

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -80,14 +80,14 @@ different custom destination does not inherit its upstream assumptions. Object-f
 also narrow the decision by inbound protocol and authentication mode; an auth-scoped default must
 not leak from a subscription transport into an API-key or forwarded-credential route.
 
-xAI keeps `openai-chat` as its provider-wide compatibility wire. The official Grok CLI catalog
-declares the Grok 4.5 and 4.6 subscription models as Responses backends, so only OAuth-backed native
-Responses traffic for those exact models selects `openai-responses`. API-key requests, translated
-Chat/Anthropic callers, other Grok models, and explicit model adapter overrides retain their
-existing wire. This lets Codex receive native xAI SSE deltas as they arrive without widening the
-credential or compatibility boundary. These OAuth subscription defaults drop caller-owned
-`service_tier`; they neither advertise nor inject Fast. The API-key transport remains governed by
-its separate capability declaration.
+xAI keeps `openai-chat` as both its provider-wide compatibility wire and the default for Grok 4.5
+and 4.6 subscription traffic. The official Grok CLI catalog declares those models as Responses
+backends, but the current gateway rejects opaque reasoning continuation and compaction state on
+later turns. Operators may still select `openai-responses` with an explicit model adapter override
+while that compatibility work continues. The OAuth route drops caller-owned `service_tier` even
+when an override selects Responses, and native Responses OAuth 401 replay remains available to
+explicit opt-ins. API-key requests, translated Chat/Anthropic callers, and other Grok models retain
+their existing wire and tier policy.
 
 OpenCode Go documents `gpt-5.6-luna` on `/zen/go/v1/responses` while sibling models use its Chat or
 Anthropic endpoints. The built-in preset therefore selects `openai-responses` only for Luna and

--- a/tests/adapter-resolve.test.ts
+++ b/tests/adapter-resolve.test.ts
@@ -100,10 +100,10 @@ describe("registry per-model wire defaults", () => {
     });
   }
 
-  test("routes current xAI subscription models through Responses for native Codex traffic", () => {
+  test("keeps current xAI subscription models on Chat by default", () => {
     for (const model of ["grok-4.6", "grok-4.5"]) {
       expect(resolveWireProtocolOverride("xai", model, xai("oauth"), "responses").adapter)
-        .toBe("openai-responses");
+        .toBe("openai-chat");
     }
   });
 
@@ -118,10 +118,12 @@ describe("registry per-model wire defaults", () => {
       .toBe("openai-chat");
   });
 
-  test("an explicit xAI Chat override opts out of the subscription Responses default", () => {
-    const provider = xai("oauth", { modelAdapters: { "grok-4.6": "openai-chat" } });
-    expect(resolveWireProtocolOverride("xai", "grok-4.6", provider, "responses").adapter)
-      .toBe("openai-chat");
+  test("an explicit xAI Responses override opts into the native wire", () => {
+    for (const model of ["grok-4.6", "grok-4.5"]) {
+      const provider = xai("oauth", { modelAdapters: { [model]: "openai-responses" } });
+      expect(resolveWireProtocolOverride("xai", model, provider, "responses").adapter)
+        .toBe("openai-responses");
+    }
   });
 
   function deepseek(overrides: Partial<OcxProviderConfig> = {}): OcxProviderConfig {

--- a/tests/fastwire-policy.test.ts
+++ b/tests/fastwire-policy.test.ts
@@ -256,25 +256,95 @@ describe("resolveFastPolicy matrix", () => {
     expect(fastPolicyForModel(provider, MODEL, "fixture").capability).toBe(false);
   });
 
-  test("captured xAI registry defaults keep OAuth and key transports separate", () => {
-    const oauthProvider = Object.freeze({
-      adapter: "openai-chat",
-      baseUrl: "https://api.x.ai/v1",
-      authMode: "oauth" as const,
-    });
-    const keyProvider = Object.freeze({
-      adapter: "openai-chat",
-      baseUrl: "https://api.x.ai/v1",
-      authMode: "key" as const,
-    });
+  test("locks the five-row xAI and DeepSeek wire/tier regression matrix", () => {
+    const rows = [
+      {
+        name: "xAI OAuth default",
+        providerName: "xai",
+        modelIds: ["grok-4.6", "grok-4.5"],
+        provider: {
+          adapter: "openai-chat",
+          baseUrl: "https://api.x.ai/v1",
+          authMode: "oauth" as const,
+        },
+        adapter: "openai-chat",
+        forwardCallerTier: false,
+        callerTier: undefined,
+        settledCallerTier: undefined,
+      },
+      {
+        name: "xAI OAuth Responses override",
+        providerName: "xai",
+        modelIds: ["grok-4.6", "grok-4.5"],
+        provider: {
+          adapter: "openai-chat",
+          baseUrl: "https://api.x.ai/v1",
+          authMode: "oauth" as const,
+          modelAdapters: { "grok-4.6": "openai-responses", "grok-4.5": "openai-responses" },
+        },
+        adapter: "openai-responses",
+        forwardCallerTier: false,
+        callerTier: "flex",
+        settledCallerTier: undefined,
+      },
+      {
+        name: "xAI API-key default",
+        providerName: "xai",
+        modelIds: ["grok-4.6", "grok-4.5"],
+        provider: {
+          adapter: "openai-chat",
+          baseUrl: "https://api.x.ai/v1",
+          authMode: "key" as const,
+        },
+        adapter: "openai-chat",
+        forwardCallerTier: false,
+        callerTier: undefined,
+        settledCallerTier: undefined,
+      },
+      {
+        name: "xAI API-key Responses override",
+        providerName: "xai",
+        modelIds: ["grok-4.6", "grok-4.5"],
+        provider: {
+          adapter: "openai-chat",
+          baseUrl: "https://api.x.ai/v1",
+          authMode: "key" as const,
+          modelAdapters: { "grok-4.6": "openai-responses", "grok-4.5": "openai-responses" },
+        },
+        adapter: "openai-responses",
+        forwardCallerTier: true,
+        callerTier: "flex",
+        settledCallerTier: "flex",
+      },
+      {
+        name: "DeepSeek V4 defaults",
+        providerName: "deepseek",
+        modelIds: ["deepseek-v4-flash", "deepseek-v4-pro"],
+        provider: {
+          adapter: "openai-chat",
+          baseUrl: "https://api.deepseek.com",
+          authMode: "key" as const,
+        },
+        adapter: "openai-responses",
+        forwardCallerTier: false,
+        callerTier: undefined,
+        settledCallerTier: undefined,
+      },
+    ] as const;
 
-    expect(fastPolicyForModel(oauthProvider, "grok-4.6", "xai")).toMatchObject({
-      adapter: "openai-responses",
-      eligibility: "unclassified",
-      forwardCallerTier: false,
-    });
-    expect(fastPolicyForModel(keyProvider, "grok-4.6", "xai").adapter)
-      .toBe("openai-chat");
+    for (const row of rows) {
+      for (const modelId of row.modelIds) {
+        const policy = fastPolicyForModel(row.provider, modelId, row.providerName);
+        expect(policy.adapter).toBe(row.adapter);
+        expect(policy.forwardCallerTier).toBe(row.forwardCallerTier);
+        expect(tierValueAfterDecision(decideTier(policy, undefined, undefined), undefined))
+          .toBeUndefined();
+        if (row.callerTier !== undefined) {
+          expect(tierValueAfterDecision(decideTier(policy, undefined, row.callerTier), row.callerTier))
+            .toBe(row.settledCallerTier);
+        }
+      }
+    }
   });
 
   test("prototype-named providers and models use only own wire-policy rows", () => {

--- a/tests/server-xai-chat-reasoning-streaming.test.ts
+++ b/tests/server-xai-chat-reasoning-streaming.test.ts
@@ -12,7 +12,7 @@ import { startServer } from "../src/server";
 import type { OcxConfig } from "../src/types";
 import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
 
-const RESPONSES_ENDPOINT = `${XAI_GROK_CLI_BASE_URL}/responses`;
+const CHAT_ENDPOINT = `${XAI_GROK_CLI_BASE_URL}/chat/completions`;
 const encoder = new TextEncoder();
 
 let testDir = "";
@@ -23,8 +23,8 @@ let originalFetch: typeof fetch;
 beforeEach(async () => {
   originalFetch = globalThis.fetch;
   previousHome = process.env.OPENCODEX_HOME;
-  isolatedCodexHome = installIsolatedCodexHome("ocx-xai-responses-codex-");
-  testDir = mkdtempSync(join(tmpdir(), "ocx-xai-responses-"));
+  isolatedCodexHome = installIsolatedCodexHome("ocx-xai-chat-reasoning-codex-");
+  testDir = mkdtempSync(join(tmpdir(), "ocx-xai-chat-reasoning-"));
   process.env.OPENCODEX_HOME = testDir;
   await saveCredential("xai", {
     access: "stream-access",
@@ -49,26 +49,23 @@ function config(): OcxConfig {
     port: 0,
     hostname: "127.0.0.1",
     defaultProvider: "xai",
-    fastMode: true,
     providers: {
       xai: {
         adapter: "openai-chat",
         baseUrl: "https://api.x.ai/v1",
         authMode: "oauth",
         models: ["grok-4.6"],
-        modelAdapters: { "grok-4.6": "openai-responses" },
-        modelSupportsServiceTier: { "grok-4.6": false },
       },
     },
   } as OcxConfig;
 }
 
-function sse(payload: unknown): Uint8Array {
+function chatSse(payload: unknown): Uint8Array {
   return encoder.encode(`data: ${JSON.stringify(payload)}\n\n`);
 }
 
-describe("xAI OAuth Responses streaming opt-in", () => {
-  test("uses the native Responses wire and relays the first delta before completion", async () => {
+describe("xAI OAuth Chat reasoning streaming", () => {
+  test("bridges reasoning_content before content and response.completed", async () => {
     let releaseCompletion!: () => void;
     const completionGate = new Promise<void>(resolve => { releaseCompletion = resolve; });
     let completionReleased = false;
@@ -78,81 +75,47 @@ describe("xAI OAuth Responses streaming opt-in", () => {
 
     globalThis.fetch = (async (input, init) => {
       const url = input instanceof Request ? input.url : String(input);
-      if (url !== RESPONSES_ENDPOINT) return originalFetch(input, init);
+      if (url !== CHAT_ENDPOINT) return originalFetch(input, init);
       upstreamCalls += 1;
       outboundHeaders = new Headers(init?.headers);
       outboundBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
 
       const body = new ReadableStream<Uint8Array>({
         start(controller) {
-          controller.enqueue(sse({
-            type: "response.created",
-            sequence_number: 0,
-            response: {
-              id: "resp_xai_stream",
-              object: "response",
-              status: "in_progress",
-              model: "grok-4.6",
-              output: [],
-            },
+          controller.enqueue(chatSse({
+            id: "chatcmpl_xai_reasoning",
+            object: "chat.completion.chunk",
+            model: "grok-4.6",
+            choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
           }));
-          controller.enqueue(sse({
-            type: "response.output_item.added",
-            sequence_number: 1,
-            output_index: 0,
-            item: { id: "msg_xai_stream", type: "message", status: "in_progress", role: "assistant", content: [] },
+          controller.enqueue(chatSse({
+            id: "chatcmpl_xai_reasoning",
+            object: "chat.completion.chunk",
+            model: "grok-4.6",
+            choices: [{ index: 0, delta: { reasoning_content: "first thought" }, finish_reason: null }],
           }));
-          controller.enqueue(sse({
-            type: "response.content_part.added",
-            sequence_number: 2,
-            item_id: "msg_xai_stream",
-            output_index: 0,
-            content_index: 0,
-            part: { type: "output_text", text: "", annotations: [] },
-          }));
-          controller.enqueue(sse({
-            type: "response.output_text.delta",
-            sequence_number: 3,
-            item_id: "msg_xai_stream",
-            output_index: 0,
-            content_index: 0,
-            delta: "first",
+          controller.enqueue(chatSse({
+            id: "chatcmpl_xai_reasoning",
+            object: "chat.completion.chunk",
+            model: "grok-4.6",
+            choices: [{ index: 0, delta: { reasoning_content: " then second" }, finish_reason: null }],
           }));
           void completionGate.then(() => {
             completionReleased = true;
-            const message = {
-              id: "msg_xai_stream",
-              type: "message",
-              status: "completed",
-              role: "assistant",
-              content: [{ type: "output_text", text: "first second", annotations: [] }],
-            };
-            controller.enqueue(sse({
-              type: "response.output_text.delta",
-              sequence_number: 4,
-              item_id: "msg_xai_stream",
-              output_index: 0,
-              content_index: 0,
-              delta: " second",
+            controller.enqueue(chatSse({
+              id: "chatcmpl_xai_reasoning",
+              object: "chat.completion.chunk",
+              model: "grok-4.6",
+              choices: [{ index: 0, delta: { content: "answer" }, finish_reason: null }],
             }));
-            controller.enqueue(sse({
-              type: "response.output_item.done",
-              sequence_number: 5,
-              output_index: 0,
-              item: message,
+            controller.enqueue(chatSse({
+              id: "chatcmpl_xai_reasoning",
+              object: "chat.completion.chunk",
+              model: "grok-4.6",
+              choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+              usage: { prompt_tokens: 1, completion_tokens: 3, total_tokens: 4 },
             }));
-            controller.enqueue(sse({
-              type: "response.completed",
-              sequence_number: 6,
-              response: {
-                id: "resp_xai_stream",
-                object: "response",
-                status: "completed",
-                model: "grok-4.6",
-                output: [message],
-                usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
-              },
-            }));
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
             controller.close();
           });
         },
@@ -182,28 +145,29 @@ describe("xAI OAuth Responses streaming opt-in", () => {
       let received = "";
       await Promise.race([
         (async () => {
-          while (!received.includes("response.output_text.delta")) {
+          while (!received.includes("response.reasoning_summary_text.delta")) {
             const chunk = await reader!.read();
-            if (chunk.done) throw new Error("stream ended before the first xAI delta");
+            if (chunk.done) throw new Error("stream ended before the first xAI reasoning delta");
             received += decoder.decode(chunk.value, { stream: true });
           }
         })(),
         new Promise<never>((_, reject) => setTimeout(
-          () => reject(new Error("the first xAI delta was not relayed before completion")),
+          () => reject(new Error("xAI reasoning was not relayed before completion")),
           1_500,
         )),
       ]);
 
-      expect(received).toContain("first");
+      expect(received).toContain("first thought");
+      expect(received).not.toContain("response.completed");
       expect(completionReleased).toBe(false);
       expect(upstreamCalls).toBe(1);
       expect(outboundBody?.model).toBe("grok-4.6");
-      expect(outboundBody?.input).toBe("hello");
+      expect(outboundBody?.messages).toBeArray();
       expect(outboundBody?.stream).toBe(true);
       expect(outboundBody?.service_tier).toBeUndefined();
-      expect(outboundBody?.reasoning).toMatchObject({ effort: "xhigh" });
-      expect(outboundBody?.messages).toBeUndefined();
-      expect(outboundBody?.reasoning_effort).toBeUndefined();
+      expect(outboundBody?.reasoning_effort).toBe("xhigh");
+      expect(outboundBody?.input).toBeUndefined();
+      expect(outboundBody?.reasoning).toBeUndefined();
       expect(outboundHeaders?.get("authorization")).toBe("Bearer stream-access");
       expect(outboundHeaders?.get("x-grok-client-identifier")).toBe("opencodex");
       expect(outboundHeaders?.get("x-grok-client-version")).toBe(XAI_GROK_CLIENT_VERSION);
@@ -214,8 +178,14 @@ describe("xAI OAuth Responses streaming opt-in", () => {
         if (chunk.done) break;
         received += decoder.decode(chunk.value, { stream: true });
       }
-      expect(received).toContain("response.completed");
-      expect(received).toContain(" second");
+      const reasoningIndex = received.indexOf("response.reasoning_summary_text.delta");
+      const contentIndex = received.indexOf("response.output_text.delta");
+      const completedIndex = received.indexOf("response.completed");
+      expect(reasoningIndex).toBeGreaterThanOrEqual(0);
+      expect(contentIndex).toBeGreaterThan(reasoningIndex);
+      expect(completedIndex).toBeGreaterThan(contentIndex);
+      expect(received).toContain("then second");
+      expect(received).toContain("answer");
     } finally {
       releaseCompletion();
       await reader?.cancel().catch(() => {});

--- a/tests/server-xai-oauth-401-replay.test.ts
+++ b/tests/server-xai-oauth-401-replay.test.ts
@@ -60,6 +60,7 @@ function xaiConfig(authMode: "oauth" | "key" = "oauth"): OcxConfig {
         baseUrl: "https://api.x.ai/v1",
         authMode,
         ...(authMode === "key" ? { apiKey: "xai-api-key" } : {}),
+        ...(authMode === "oauth" ? { modelAdapters: { "grok-4.5": "openai-responses" } } : {}),
         models: ["grok-4.5"],
       },
     },
@@ -142,7 +143,7 @@ function installOAuthFetch(
   return { chatAuth, counts };
 }
 
-describe("xAI OAuth upstream 401 replay", () => {
+describe("xAI OAuth Responses opt-in upstream 401 replay", () => {
   test("initial OAuth refresh projects raw provider failures before responding", async () => {
     await seedOAuth(0);
     saveConfig(xaiConfig());


### PR DESCRIPTION
## Summary
The doc-100 atomic unit: Chat becomes the default wire for Grok 4.5/4.6 OAuth traffic, and the OAuth tier policy becomes unconditional — landed together so no intermediate dev head can leak caller `service_tier` through a `modelAdapters` opt-in.
- Registry: grok-4.6/grok-4.5 OAuth `modelWireDefaults` flip `openai-responses` -> `openai-chat` (ports #2227 by olddonkey, adapted to current dev; inbound/authModes/forwardCallerServiceTier preserved).
- Fastwire: a configured `modelAdapters` wire override now inherits the registry's `forwardCallerServiceTier: false` on the xai OAuth route instead of bypassing it. No new config field. API-key routes keep current semantics (caller tier forwards verbatim; absent stays absent).
- Five-row regression matrix (now covering both 4.5 and 4.6): OAuth chat default / OAuth Responses override with tier dropped / API-key chat default / API-key Responses override with tier forwarded / DeepSeek V4 flash+pro locked to their Responses defaults (explicit non-regression, DeepSeek untouched per maintainer decision).
- New reasoning-streaming E2E through the running /v1/responses path: mocked xAI Chat SSE emits reasoning_content first; the bridged stream must emit reasoning-summary deltas BEFORE completion — the #1886 blank-screen regression can no longer return silently.
- structure/04 rewritten for the Chat default; the Responses implementation stays reachable via explicit modelAdapters and will get a GUI opt-in switch next (doc 130).

## Verification
- Focused suites: 258/0 across five suites pre-amend; fastwire-policy 236/0 post-amend with both models in the matrix.
- Tier-bypass mutation evidence: the bypass test was red (235/1) before the fastwire fix, green after.
- `bun x tsc --noEmit`, `bun run privacy:scan` green.
- Adversarial reviewer (independent): VERDICT PASS, no blockers; NIT (4.5 matrix rows) folded in the amend.

## Checklist
- [x] Targets dev
- [x] Focused regression tests added
- [x] structure/ docs updated
- [x] Credits #2227 (olddonkey) as the ported foundation; closes the default-ownership question from that review thread
