### PR TITLE
docs(devlog): doc 110 new-wave triage rows (#2248-#2254)

### DIFF
--- a/devlog/_plan/260820_sidecar_selection_unification/110_global_merge_order.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/110_global_merge_order.md
@@ -46,5 +46,17 @@ itself (audit R1-B4).
 | #2213 | louis-tepe | OUT (draft, overlaps doc-130 design) | revisit post-switch |
 | #2072 | olddonkey | DEFERRED (audit R2-B2) | Fast policy composes later; must re-verify against both wires |
 
+## New wave (user expansion 260821, lands in step 5-6 order after the chat-default unit)
+
+| PR | author | disposition | rationale |
+|---|---|---|---|
+| #2248 | olddonkey | MERGE after #2227 unit | cross-backend reasoning strip on model switch; wire-agnostic hygiene |
+| #2249 | olddonkey | MERGE after #2228 line | compaction blob serving-identity comparison; composes with provenance fix |
+| #2251 | olddonkey | MERGE after #2227 unit | recovery when upstream rejects foreign opaque state |
+| #2252 | olddonkey | MERGE | strip output-only reasoning status unconditionally; small + wire-agnostic |
+| #2254 | olddonkey | RECONCILE with doc 130 | restores Grok Responses on the native passthrough route — must compose with the chat default + opt-in switch, not fight them; adjudicate against the doc-100 matrix |
+| #2250 | lilinxiong | MERGE (bug) | integrations honor OFF for Claude Desktop drift + Grok ensure |
+| #2253 | lilinxiong | MERGE (bug, gui) | dropdown opacity; needs screenshot per PR gate |
+
 Rebase anchors are named at execution time in each phase's B (exact dev head SHA),
 with cascade verification (typecheck + focused suites) after every land.


### PR DESCRIPTION
## Summary
Adds the new-wave triage rows (#2248-#2254, user-directed scope expansion) to doc 110 of the sidecar-selection unit: dispositions for the five olddonkey responses/xai fixes and the two lilinxiong bug PRs, ordered after the #2255 chat-default unit.

## Verification
- Docs-only; privacy:scan green locally.

## Checklist
- [x] Targets dev
- [x] No runtime changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “New wave” triage section covering PRs `#2248`–#2254.
  * Documented merge order, dispositions, dependencies, and rationale for the reviewed changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->