### PR TITLE
feat(agent): named subagent role catalog

### DIFF
--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -12,6 +12,7 @@ import {
   takeOption,
   type RuntimeApiDeps,
 } from "./runtime-api";
+import { readFileSync } from "node:fs";
 
 interface WebSearchModelOption {
   value: string;
@@ -26,6 +27,7 @@ const USAGE = `Usage:
       [--prompt <text|->] [--guidance <on|off>] [--json]
   ocx agent effort <status|set> [--main <level|->] [--subagent <level|->] [--json]
   ocx agent subagents <status|set|clear> [model,model...] [--json]
+  ocx agent roles <status|set|remove> [--file <path>] [--json]
   ocx agent fallback <status|set|clear> [model,model...] [--poll-ms <5000-600000>] [--json]
   ocx agent sidecar <status|web|vision> [--list] [--model <id|->] [--backend <openai|anthropic|xai|gemini|exa|->]
       [--reasoning <level>] [--max-descriptions <n>] [--json]`;
@@ -38,15 +40,16 @@ async function status(argv: string[], deps: RuntimeApiDeps): Promise<void> {
   const args = [...argv];
   const wantsJson = takeFlag(args, "--json");
   rejectArgs(args, USAGE);
-  const [v2, injection, caps, subagents, fallback, sidecars] = await Promise.all([
+  const [v2, injection, caps, subagents, roles, fallback, sidecars] = await Promise.all([
     runtimeRequest("/api/v2", {}, deps),
     runtimeRequest("/api/injection-model", {}, deps),
     runtimeRequest("/api/effort-caps", {}, deps),
     runtimeRequest("/api/subagent-models", {}, deps),
+    runtimeRequest("/api/subagent-roles", {}, deps),
     runtimeRequest("/api/subagent-model-fallback", {}, deps),
     runtimeRequest("/api/sidecar-settings", {}, deps),
   ]);
-  const result = { v2, injection, caps, subagents, fallback, sidecars };
+  const result = { v2, injection, caps, subagents, roles, fallback, sidecars };
   printData(result, wantsJson, summaryLines(result));
 }
 
@@ -119,6 +122,63 @@ async function subagents(argv: string[], deps: RuntimeApiDeps): Promise<void> {
   if (models.length > 5) throw new CliUsageError("at most 5 subagent models are allowed", USAGE);
   const result = await runtimeRequest("/api/subagent-models", { method: "PUT", body: JSON.stringify({ models }) }, deps);
   printData(result, wantsJson, [`Subagent roster: ${models.join(", ") || "cleared"}`]);
+}
+
+async function readRolesDocument(deps: RuntimeApiDeps, file: string | undefined): Promise<unknown> {
+  const raw = file
+    ? readFileSync(file, "utf8")
+    : await readStdinDocument(deps);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new CliUsageError("roles JSON is invalid", USAGE);
+  }
+  if (Array.isArray(parsed)) return { roles: parsed };
+  return parsed;
+}
+
+async function readStdinDocument(deps: RuntimeApiDeps): Promise<string> {
+  const input = deps.stdinImpl ?? process.stdin;
+  if (input.isTTY) throw new CliUsageError("roles set requires --file <path> or JSON on stdin", USAGE);
+  const chunks: Buffer[] = [];
+  for await (const chunk of input) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+  }
+  const text = Buffer.concat(chunks).toString("utf8").trim();
+  if (!text) throw new CliUsageError("roles JSON was empty", USAGE);
+  return text;
+}
+
+async function roles(argv: string[], deps: RuntimeApiDeps): Promise<void> {
+  const args = [...argv];
+  const action = (args.shift() ?? "status").toLowerCase();
+  const wantsJson = takeFlag(args, "--json");
+  if (action === "status") {
+    rejectArgs(args, USAGE);
+    const result = await runtimeRequest("/api/subagent-roles", {}, deps);
+    printData(result, wantsJson, summaryLines(result));
+    return;
+  }
+  if (action === "set") {
+    const file = takeOption(args, "--file");
+    rejectArgs(args, USAGE);
+    const body = await readRolesDocument(deps, file);
+    if (!body || typeof body !== "object" || Array.isArray(body) || !("roles" in body)) {
+      throw new CliUsageError("roles JSON must be { roles: [...] } or an array", USAGE);
+    }
+    const result = await runtimeRequest("/api/subagent-roles", { method: "PUT", body: JSON.stringify(body) }, deps);
+    printData(result, wantsJson, ["Agent roles updated."]);
+    return;
+  }
+  if (action !== "remove") throw new CliUsageError(`unknown roles action ${action}`, USAGE);
+  const id = args.shift();
+  if (!id) throw new CliUsageError("role id is required", USAGE);
+  rejectArgs(args, USAGE);
+  const current = await runtimeRequest("/api/subagent-roles", {}, deps) as { roles?: Array<{ id?: string }> };
+  const next = (current.roles ?? []).filter(role => role.id !== id);
+  const result = await runtimeRequest("/api/subagent-roles", { method: "PUT", body: JSON.stringify({ roles: next }) }, deps);
+  printData(result, wantsJson, [`Removed role ${id}.`]);
 }
 
 async function fallback(argv: string[], deps: RuntimeApiDeps): Promise<void> {
@@ -218,6 +278,7 @@ export async function handleAgentCommand(argv: string[], deps: RuntimeApiDeps = 
     else if (sub === "injection" || sub === "guidance") await injection(rest, deps);
     else if (sub === "effort") await effort(rest, deps);
     else if (sub === "subagents" || sub === "roster") await subagents(rest, deps);
+    else if (sub === "roles") await roles(rest, deps);
     else if (sub === "fallback") await fallback(rest, deps);
     else if (sub === "sidecar") await sidecar(rest, deps);
     else throw new CliUsageError(`unknown agent command ${sub}`, USAGE);

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -175,9 +175,10 @@ async function roles(argv: string[], deps: RuntimeApiDeps): Promise<void> {
   const id = args.shift();
   if (!id) throw new CliUsageError("role id is required", USAGE);
   rejectArgs(args, USAGE);
-  const current = await runtimeRequest("/api/subagent-roles", {}, deps) as { roles?: Array<{ id?: string }> };
-  const next = (current.roles ?? []).filter(role => role.id !== id);
-  const result = await runtimeRequest("/api/subagent-roles", { method: "PUT", body: JSON.stringify({ roles: next }) }, deps);
+  const result = await runtimeRequest("/api/subagent-roles", {
+    method: "PUT",
+    body: JSON.stringify({ remove: id }),
+  }, deps);
   printData(result, wantsJson, [`Removed role ${id}.`]);
 }
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -51,7 +51,7 @@ Usage:
   ocx account <sub>           Accounts, login/reauth, key pools, and quota controls
   ocx models <sub>            Live/custom models, visibility, context, and shadow calls
   ocx combo <sub>             Combo failover/round-robin routing
-  ocx agent <sub>             Subagents, injection, effort caps, and sidecars
+  ocx agent <sub>             Subagents, roles, injection, effort caps, and sidecars
   ocx observe <sub>           Logs, usage, storage, memory, and debug data
   ocx route <sub>             Routing features (combo, policy)
   ocx logs [filters]          Alias of ocx observe logs

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -192,8 +192,8 @@ export const CLI_COMMANDS: CliCommandEntry[] = [
   },
   {
     name: "agent",
-    usage: "ocx agent <status|injection|effort|subagents|fallback|sidecar> ...",
-    summary: "Manage headless multi-agent, roster, effort, injection, and sidecar settings.",
+    usage: "ocx agent <status|injection|effort|subagents|roles|fallback|sidecar> ...",
+    summary: "Manage headless multi-agent, roster, roles, effort, injection, and sidecar settings.",
   },
   {
     name: "observe",

--- a/src/codex/agent-roles.ts
+++ b/src/codex/agent-roles.ts
@@ -1,0 +1,205 @@
+/**
+ * Named subagent role catalog: validate, render `{{roles}}`, and union models
+ * into the 5-slot spawn picker roster.
+ *
+ * Roles are user-authored specialists. The parent still decides whether to
+ * spawn; this module never inspects spawn task text.
+ */
+import { isCodexReasoningEffort } from "../reasoning-effort";
+import type { OcxConfig, OcxSubagentRole } from "../types";
+
+export const SUBAGENT_ROLE_ID_RE = /^[a-z][a-z0-9-]{0,31}$/;
+export const SUBAGENT_ROLE_MAX_COUNT = 8;
+export const SUBAGENT_ROLE_MAX_UNIQUE_MODELS = 5;
+export const SUBAGENT_ROLE_DESCRIPTION_MAX = 240;
+export const SUBAGENT_ROLE_INSTRUCTIONS_MAX = 8000;
+
+export type SubagentRoleParseResult =
+  | { ok: true; role: OcxSubagentRole }
+  | { ok: false; error: string; index?: number };
+
+export type SubagentRolesParseResult =
+  | { ok: true; roles: OcxSubagentRole[] }
+  | { ok: false; error: string; index?: number };
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function boundedString(value: unknown, field: string, min: number, max: number): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = field === "developerInstructions" ? value : value.trim();
+  const candidate = field === "developerInstructions" ? value : trimmed;
+  if (candidate.length < min || candidate.length > max) return null;
+  if (field === "developerInstructions" && candidate.trim().length === 0) return null;
+  return field === "developerInstructions" ? candidate : trimmed;
+}
+
+export function parseSubagentRole(value: unknown, index?: number): SubagentRoleParseResult {
+  const prefix = index === undefined ? "subagentRoles" : `subagentRoles[${index}]`;
+  const row = asRecord(value);
+  if (!row) return { ok: false, error: `${prefix} must be an object`, index };
+
+  const id = typeof row.id === "string" ? row.id.trim() : "";
+  if (!SUBAGENT_ROLE_ID_RE.test(id)) {
+    return { ok: false, error: `${prefix}.id must match [a-z][a-z0-9-]{0,31}`, index };
+  }
+  const description = boundedString(row.description, "description", 1, SUBAGENT_ROLE_DESCRIPTION_MAX);
+  if (description === null) {
+    return { ok: false, error: `${prefix}.description must be a string of 1..${SUBAGENT_ROLE_DESCRIPTION_MAX} characters`, index };
+  }
+  const model = typeof row.model === "string" ? row.model.trim() : "";
+  if (!model) {
+    return { ok: false, error: `${prefix}.model must be a non-empty string`, index };
+  }
+  let effort: string | undefined;
+  if (row.effort !== undefined && row.effort !== null && row.effort !== "") {
+    if (typeof row.effort !== "string" || !isCodexReasoningEffort(row.effort)) {
+      return { ok: false, error: `${prefix}.effort must be a Codex reasoning ladder value`, index };
+    }
+    effort = row.effort;
+  }
+  const developerInstructions = boundedString(
+    row.developerInstructions,
+    "developerInstructions",
+    1,
+    SUBAGENT_ROLE_INSTRUCTIONS_MAX,
+  );
+  if (developerInstructions === null) {
+    return {
+      ok: false,
+      error: `${prefix}.developerInstructions must be a string of 1..${SUBAGENT_ROLE_INSTRUCTIONS_MAX} characters`,
+      index,
+    };
+  }
+  if (row.enabled !== undefined && typeof row.enabled !== "boolean") {
+    return { ok: false, error: `${prefix}.enabled must be a boolean`, index };
+  }
+
+  const role: OcxSubagentRole = {
+    id,
+    description,
+    model,
+    developerInstructions,
+    enabled: row.enabled !== false,
+  };
+  if (effort) role.effort = effort;
+  return { ok: true, role };
+}
+
+export function parseSubagentRoles(value: unknown): SubagentRolesParseResult {
+  if (!Array.isArray(value)) {
+    return { ok: false, error: "subagentRoles must be an array" };
+  }
+  if (value.length > SUBAGENT_ROLE_MAX_COUNT) {
+    return { ok: false, error: `subagentRoles: at most ${SUBAGENT_ROLE_MAX_COUNT} roles are allowed` };
+  }
+  const roles: OcxSubagentRole[] = [];
+  const seen = new Set<string>();
+  for (let index = 0; index < value.length; index++) {
+    const parsed = parseSubagentRole(value[index], index);
+    if (!parsed.ok) return parsed;
+    if (seen.has(parsed.role.id)) {
+      return { ok: false, error: `subagentRoles: duplicate id "${parsed.role.id}"`, index };
+    }
+    seen.add(parsed.role.id);
+    roles.push(parsed.role);
+  }
+  return { ok: true, roles };
+}
+
+export function salvageSubagentRoles(value: unknown): { roles: OcxSubagentRole[] | undefined; warnings: string[] } {
+  if (value === undefined) return { roles: undefined, warnings: [] };
+  if (!Array.isArray(value)) {
+    return { roles: undefined, warnings: ["subagentRoles ignored: expected an array"] };
+  }
+  const roles: OcxSubagentRole[] = [];
+  const warnings: string[] = [];
+  const seen = new Set<string>();
+  for (let index = 0; index < value.length; index++) {
+    if (roles.length >= SUBAGENT_ROLE_MAX_COUNT) {
+      warnings.push(`subagentRoles truncated: at most ${SUBAGENT_ROLE_MAX_COUNT} roles are kept`);
+      break;
+    }
+    const parsed = parseSubagentRole(value[index], index);
+    if (!parsed.ok) {
+      warnings.push(`${parsed.error} — ignored`);
+      continue;
+    }
+    if (seen.has(parsed.role.id)) {
+      warnings.push(`subagentRoles[${index}]: duplicate id "${parsed.role.id}" ignored`);
+      continue;
+    }
+    seen.add(parsed.role.id);
+    roles.push(parsed.role);
+  }
+  if (value.length === 0) return { roles: [], warnings };
+  return { roles, warnings };
+}
+
+export function enabledSubagentRoles(roles: readonly OcxSubagentRole[] | undefined): OcxSubagentRole[] {
+  return (roles ?? []).filter(role => role.enabled !== false);
+}
+
+export function renderRolesCatalog(
+  roles: readonly OcxSubagentRole[],
+  options: { maxDescriptionChars?: number } = {},
+): string {
+  const parts: string[] = [];
+  for (const role of enabledSubagentRoles(roles)) {
+    const modelBit = role.effort ? `${role.model}, ${role.effort}` : role.model;
+    const max = options.maxDescriptionChars;
+    if (max === 0) {
+      parts.push(`${role.id} (${modelBit})`);
+      continue;
+    }
+    const description = max === undefined ? role.description : role.description.slice(0, max);
+    if (!description) {
+      parts.push(`${role.id} (${modelBit})`);
+      continue;
+    }
+    parts.push(`${role.id} (${modelBit}) for ${description}`);
+  }
+  return parts.join("; ");
+}
+
+export function unionRoleModelsIntoRoster(
+  existing: string[] | undefined,
+  roles: readonly OcxSubagentRole[],
+): { models: string[]; droppedRoleIds: string[] } {
+  const enabled = enabledSubagentRoles(roles);
+  const roleModels: string[] = [];
+  for (const role of enabled) {
+    if (!roleModels.includes(role.model)) roleModels.push(role.model);
+  }
+  const base = existing ?? [];
+  const rest = base.filter(model => !roleModels.includes(model));
+  const combined = [...roleModels, ...rest];
+  const models = combined.slice(0, SUBAGENT_ROLE_MAX_UNIQUE_MODELS);
+  const kept = new Set(models);
+  const droppedRoleIds = enabled.filter(role => !kept.has(role.model)).map(role => role.id);
+  return { models, droppedRoleIds };
+}
+
+/** Slash models that are not account-qualified native ChatGPT rows. */
+export function isRoutedRoleModel(model: string): boolean {
+  const slash = model.indexOf("/");
+  if (slash <= 0) return false;
+  const rest = model.slice(slash + 1);
+  return !rest.startsWith("gpt-");
+}
+
+export function routedOnV2Warnings(
+  roles: readonly OcxSubagentRole[],
+  config: Pick<OcxConfig, "multiAgentMode" | "keepNativeChatGptOnV1">,
+): string[] {
+  if (config.multiAgentMode !== "v2" || config.keepNativeChatGptOnV1 === true) return [];
+  const routed = enabledSubagentRoles(roles).filter(role => isRoutedRoleModel(role.model));
+  if (routed.length === 0) return [];
+  const ids = routed.map(role => role.id).join(", ");
+  return [
+    `Role model(s) ${ids} are routed while multiAgentMode is v2 without keepNativeChatGptOnV1; ChatGPT-native v2 parents encrypt child tasks (#92).`,
+  ];
+}

--- a/src/codex/agent-roles.ts
+++ b/src/codex/agent-roles.ts
@@ -6,6 +6,7 @@
  * spawn; this module never inspects spawn task text.
  */
 import { isCodexReasoningEffort } from "../reasoning-effort";
+import { codexAccountNamespaceForModel } from "./account-namespace-match";
 import type { OcxConfig, OcxSubagentRole } from "../types";
 
 export const SUBAGENT_ROLE_ID_RE = /^[a-z][a-z0-9-]{0,31}$/;
@@ -13,6 +14,7 @@ export const SUBAGENT_ROLE_MAX_COUNT = 8;
 export const SUBAGENT_ROLE_MAX_UNIQUE_MODELS = 5;
 export const SUBAGENT_ROLE_DESCRIPTION_MAX = 240;
 export const SUBAGENT_ROLE_INSTRUCTIONS_MAX = 8000;
+export const SUBAGENT_ROLE_MODEL_MAX = 128;
 
 export type SubagentRoleParseResult =
   | { ok: true; role: OcxSubagentRole }
@@ -51,8 +53,12 @@ export function parseSubagentRole(value: unknown, index?: number): SubagentRoleP
     return { ok: false, error: `${prefix}.description must be a string of 1..${SUBAGENT_ROLE_DESCRIPTION_MAX} characters`, index };
   }
   const model = typeof row.model === "string" ? row.model.trim() : "";
-  if (!model) {
-    return { ok: false, error: `${prefix}.model must be a non-empty string`, index };
+  if (!model || model.length > SUBAGENT_ROLE_MODEL_MAX) {
+    return {
+      ok: false,
+      error: `${prefix}.model must be a non-empty string of at most ${SUBAGENT_ROLE_MODEL_MAX} characters`,
+      index,
+    };
   }
   let effort: string | undefined;
   if (row.effort !== undefined && row.effort !== null && row.effort !== "") {
@@ -165,6 +171,24 @@ export function renderRolesCatalog(
   return parts.join("; ");
 }
 
+/** Shorten, then drop trailing roles, then omit the catalog so it fits `budget`. */
+export function compactRolesCatalog(
+  roles: readonly OcxSubagentRole[],
+  budget: number,
+): string {
+  if (budget <= 0) return "";
+  const enabled = enabledSubagentRoles(roles);
+  if (enabled.length === 0) return "";
+  for (const descBudget of [undefined, 80, 40, 0] as const) {
+    const options = descBudget === undefined ? {} : { maxDescriptionChars: descBudget };
+    for (let count = enabled.length; count > 0; count--) {
+      const text = renderRolesCatalog(enabled.slice(0, count), options);
+      if (text.length <= budget) return text;
+    }
+  }
+  return "";
+}
+
 export function unionRoleModelsIntoRoster(
   existing: string[] | undefined,
   roles: readonly OcxSubagentRole[],
@@ -174,7 +198,7 @@ export function unionRoleModelsIntoRoster(
   for (const role of enabled) {
     if (!roleModels.includes(role.model)) roleModels.push(role.model);
   }
-  const base = existing ?? [];
+  const base = [...new Set(existing ?? [])];
   const rest = base.filter(model => !roleModels.includes(model));
   const combined = [...roleModels, ...rest];
   const models = combined.slice(0, SUBAGENT_ROLE_MAX_UNIQUE_MODELS);
@@ -183,20 +207,21 @@ export function unionRoleModelsIntoRoster(
   return { models, droppedRoleIds };
 }
 
-/** Slash models that are not account-qualified native ChatGPT rows. */
-export function isRoutedRoleModel(model: string): boolean {
+/** Slash models that are not a configured Codex account-qualified native row. */
+export function isRoutedRoleModel(model: string, namespaces?: unknown): boolean {
   const slash = model.indexOf("/");
   if (slash <= 0) return false;
-  const rest = model.slice(slash + 1);
-  return !rest.startsWith("gpt-");
+  return !codexAccountNamespaceForModel(namespaces, model);
 }
 
 export function routedOnV2Warnings(
   roles: readonly OcxSubagentRole[],
-  config: Pick<OcxConfig, "multiAgentMode" | "keepNativeChatGptOnV1">,
+  config: Pick<OcxConfig, "multiAgentMode" | "keepNativeChatGptOnV1" | "codexAccountNamespaces">,
 ): string[] {
   if (config.multiAgentMode !== "v2" || config.keepNativeChatGptOnV1 === true) return [];
-  const routed = enabledSubagentRoles(roles).filter(role => isRoutedRoleModel(role.model));
+  const routed = enabledSubagentRoles(roles).filter(role =>
+    isRoutedRoleModel(role.model, config.codexAccountNamespaces),
+  );
   if (routed.length === 0) return [];
   const ids = routed.map(role => role.id).join(", ");
   return [

--- a/src/config.ts
+++ b/src/config.ts
@@ -80,6 +80,7 @@ import {
 import { resolveOpenAiVirtualModel } from "./providers/openai-virtual-models";
 import { parseDesktopProfile } from "./claude/desktop-profile";
 import { isCodexReasoningEffort, modelRecordValue } from "./reasoning-effort";
+import { parseSubagentRoles, salvageSubagentRoles } from "./codex/agent-roles";
 import {
   COST4_RATE_KEYS,
   isValidCost4Rate,
@@ -1277,6 +1278,8 @@ const configSchema = z.object({
   injectionModel: z.string().optional().catch(undefined),
   injectionEffort: z.string().optional().catch(undefined),
   syncCodexSubagentDefaults: z.boolean().optional().catch(undefined),
+  // Salvage element by element. A malformed neighbour must not wipe the catalog.
+  subagentRoles: z.unknown().optional(),
   // Per-primary-model fallback chains. Values must be non-empty string arrays;
   // malformed entries degrade to undefined rather than rejecting the whole config.
   subagentModelFallbackByModel: z.record(
@@ -2024,6 +2027,36 @@ function warnDegradedClaudeSubagentEffort(rawParsed: unknown): void {
   }
 }
 
+function normalizeSubagentRoles(config: OcxConfig, rawParsed: unknown): OcxConfig {
+  const raw = rawConfigRecord(rawParsed);
+  if (!raw || !Object.hasOwn(raw, "subagentRoles")) return config;
+  const salvaged = salvageSubagentRoles(raw.subagentRoles);
+  const normalized = { ...config };
+  if (salvaged.roles === undefined) delete normalized.subagentRoles;
+  else normalized.subagentRoles = salvaged.roles;
+  return normalized;
+}
+
+function subagentRolesLoadWarnings(rawParsed: unknown): string[] {
+  const raw = rawConfigRecord(rawParsed);
+  if (!raw || !Object.hasOwn(raw, "subagentRoles")) return [];
+  return salvageSubagentRoles(raw.subagentRoles).warnings;
+}
+
+function warnDegradedSubagentRoles(rawParsed: unknown): void {
+  for (const warning of subagentRolesLoadWarnings(rawParsed)) {
+    console.warn(`⚠️  config.json ${warning}. Other settings were preserved.`);
+  }
+}
+
+function subagentRolesError(value: unknown): string | null {
+  const raw = rawConfigRecord(value);
+  if (!raw || !Object.hasOwn(raw, "subagentRoles")) return null;
+  const parsed = parseSubagentRoles(raw.subagentRoles);
+  if (parsed.ok) return null;
+  return `schema_invalid: ${parsed.error}`;
+}
+
 function malformedUpstreamHostCircuitThresholdWarning(rawParsed: unknown): string | null {
   const raw = rawConfigRecord(rawParsed);
   if (!raw || !Object.hasOwn(raw, "upstreamHostCircuitThreshold")) return null;
@@ -2203,11 +2236,12 @@ export function loadConfig(): OcxConfig {
       warnDegradedApiKeys(parsed, config);
       warnDegradedCodexAccountPriorities(parsed, config);
       warnDegradedClaudeSubagentEffort(parsed);
+      warnDegradedSubagentRoles(parsed);
       warnDegradedNativeSubagentConfig(parsed, config);
       warnDegradedCodexAccountPicker(parsed);
       warnDegradedUpstreamHostCircuitThreshold(parsed);
       warnDegradedAgentTaskRecovery(parsed);
-      return withRefreshedCostOverlays(normalizeClaudeSubagentEffort(normalizeNativeSubagentSync(config, parsed), parsed));
+      return withRefreshedCostOverlays(normalizeSubagentRoles(normalizeClaudeSubagentEffort(normalizeNativeSubagentSync(config, parsed), parsed), parsed));
     }
     // Schema validation failed — merge defaults into the raw object instead of
     // discarding it entirely, so pool accounts and providers survive a missing
@@ -2227,11 +2261,12 @@ export function loadConfig(): OcxConfig {
       warnDegradedApiKeys(parsed, config);
       warnDegradedCodexAccountPriorities(parsed, config);
       warnDegradedClaudeSubagentEffort(parsed);
+      warnDegradedSubagentRoles(parsed);
       warnDegradedNativeSubagentConfig(parsed, config);
       warnDegradedCodexAccountPicker(parsed);
       warnDegradedUpstreamHostCircuitThreshold(parsed);
       warnDegradedAgentTaskRecovery(parsed);
-      return withRefreshedCostOverlays(normalizeClaudeSubagentEffort(normalizeNativeSubagentSync(config, parsed), parsed));
+      return withRefreshedCostOverlays(normalizeSubagentRoles(normalizeClaudeSubagentEffort(normalizeNativeSubagentSync(config, parsed), parsed), parsed));
     }
     // Still failing, but if every complaint is about one or more named entries
     // in an independent section, drop exactly those and keep the rest. Falling
@@ -2247,11 +2282,12 @@ export function loadConfig(): OcxConfig {
         warnDegradedApiKeys(parsed, config);
         warnDegradedCodexAccountPriorities(parsed, config);
         warnDegradedClaudeSubagentEffort(parsed);
+        warnDegradedSubagentRoles(parsed);
         warnDegradedNativeSubagentConfig(parsed, config);
         warnDegradedCodexAccountPicker(parsed);
         warnDegradedUpstreamHostCircuitThreshold(parsed);
         warnDegradedAgentTaskRecovery(parsed);
-        return withRefreshedCostOverlays(normalizeClaudeSubagentEffort(normalizeNativeSubagentSync(config, parsed), parsed));
+        return withRefreshedCostOverlays(normalizeSubagentRoles(normalizeClaudeSubagentEffort(normalizeNativeSubagentSync(config, parsed), parsed), parsed));
       }
     }
     // Merge couldn't fix it — truly broken config
@@ -2300,13 +2336,14 @@ function validFileConfigDiagnostics(config: OcxConfig, rawParsed: unknown): Conf
   // ordinary save persists the normalized absence.
   const syncDisabledReason = nativeSubagentSyncDisabledReason(config, rawParsed);
   const rawEffort = rawClaudeSubagentEffort(rawParsed);
-  const normalized = normalizeClaudeSubagentEffort(normalizeNativeSubagentSync(config, rawParsed), rawParsed);
+  const normalized = normalizeSubagentRoles(normalizeClaudeSubagentEffort(normalizeNativeSubagentSync(config, rawParsed), rawParsed), rawParsed);
   const warnings = configPlaceholderWarnings(normalized);
   warnings.push(...inheritedFastWireConflictProviderNames(normalized).map(inheritedFastWireConflictWarning));
   warnings.push(...degradedCodexAccountPriorityWarnings(rawParsed, normalized));
   if (rawEffort !== undefined && !isClaudeSubagentEffort(rawEffort)) {
     warnings.push(`claudeCode.subagentEffort ignored: expected one of ${CLAUDE_SUBAGENT_EFFORTS.join(", ")}`);
   }
+  warnings.push(...subagentRolesLoadWarnings(rawParsed));
   warnings.push(...malformedNativeSubagentFields(rawParsed).map(malformedNativeSubagentFieldWarning));
   const pickerWarning = malformedCodexAccountPickerWarning(rawParsed);
   if (pickerWarning) warnings.push(pickerWarning);
@@ -2506,6 +2543,7 @@ function loopbackListenerPortError(value: unknown): string | null {
 export function validateConfigCandidate(value: unknown): { ok: true; config: OcxConfig } | { ok: false; error: string } {
   const boundaryError = blankHostnameError(value)
     ?? claudeSubagentEffortError(value)
+    ?? subagentRolesError(value)
     ?? appOwnedMemoryBudgetError(value)
     ?? upstreamHostCircuitThresholdError(value)
     ?? agentTaskRecoveryError(value)
@@ -2518,6 +2556,11 @@ export function validateConfigCandidate(value: unknown): { ok: true; config: Ocx
   const result = configSchema.safeParse(value);
   if (result.success) {
     const config = normalizeApiKeyIds(result.data as OcxConfig);
+    if (value && typeof value === "object" && !Array.isArray(value) && Object.hasOwn(value, "subagentRoles")) {
+      const parsedRoles = parseSubagentRoles((value as { subagentRoles?: unknown }).subagentRoles);
+      if (!parsedRoles.ok) return { ok: false, error: `schema_invalid: ${parsedRoles.error}` };
+      config.subagentRoles = parsedRoles.roles;
+    }
     return { ok: true, config };
   }
   return { ok: false, error: schemaDiagnosticsError(result.error) };

--- a/src/providers/openai-tiers.ts
+++ b/src/providers/openai-tiers.ts
@@ -176,6 +176,7 @@ function hasKnownLegacyOpenAiReference(config: OcxConfig): boolean {
   return config.defaultProvider === LEGACY_OPENAI_MULTI_PROVIDER_ID
     || matchesList(config.disabledModels)
     || matchesList(config.subagentModels)
+    || (config.subagentRoles ?? []).some(role => matches(role.model))
     || matches(config.injectionModel)
     || matches(config.shadowCallIntercept?.model)
     || matches(config.webSearchSidecar?.model)
@@ -194,6 +195,11 @@ function hasKnownLegacyOpenAiReference(config: OcxConfig): boolean {
 function rewriteLegacyOpenAiReferences(config: OcxConfig, warnings: string[]): void {
   config.disabledModels = rewriteLegacyOpenAiModelList(config.disabledModels);
   config.subagentModels = rewriteLegacyOpenAiModelList(config.subagentModels);
+  if (config.subagentRoles) {
+    for (const role of config.subagentRoles) {
+      role.model = rewriteLegacyOpenAiSelectedId(role.model);
+    }
+  }
   if (config.injectionModel) config.injectionModel = rewriteLegacyOpenAiSelectedId(config.injectionModel);
   if (config.shadowCallIntercept?.model) {
     config.shadowCallIntercept.model = rewriteLegacyOpenAiSelectedId(config.shadowCallIntercept.model);
@@ -236,6 +242,7 @@ function isKnownLegacyValuePath(path: readonly string[]): boolean {
   const joined = path.join(".");
   if (joined === "defaultProvider") return true;
   if (/^(disabledModels|subagentModels)\.\d+$/.test(joined)) return true;
+  if (/^subagentRoles\.\d+\.model$/.test(joined)) return true;
   if (/^providers\.(openai|openai-multi)\.selectedModels\.\d+$/.test(joined)) return true;
   return new Set([
     "injectionModel",

--- a/src/providers/provider-id-rewrite.ts
+++ b/src/providers/provider-id-rewrite.ts
@@ -73,6 +73,12 @@ export function rewriteProviderReferences(config: OcxConfig, from: string, to: s
   routeListAt("disabledModels");
   routeListAt("subagentModels");
   routeListAt("subagentModelFallback");
+  if (config.subagentRoles) {
+    for (const role of config.subagentRoles) {
+      const next = route(role.model);
+      if (next) role.model = next;
+    }
+  }
 
   const scalarOwners: Array<[Record<string, unknown> | undefined, string]> = [
     [config as unknown as Record<string, unknown>, "injectionModel"],

--- a/src/server/management/agent-settings-routes.ts
+++ b/src/server/management/agent-settings-routes.ts
@@ -69,6 +69,11 @@ import { isAllowedRequestOrigin, jsonResponse, providerManagementConfigError, pu
 import { applySystemEnvToggle } from "../system-env";
 
 import { isPlainRecord, parseDebugLogQuery, tokPerSecondResult, unavailableCostReason, costResult, requestLogDto, stripRegistryOnlyStaticHeaders, fetchAllModels, fetchGrokCandidateModels, buildClaudeDesktopState } from "./shared";
+import {
+  parseSubagentRoles,
+  routedOnV2Warnings,
+  unionRoleModelsIntoRoster,
+} from "../../codex/agent-roles";
 import type { MetricUnavailableReason, TokPerSecondResult, CostEstimateReason, CostResult, MetricSource } from "./shared";
 import { readManagementJsonBody, readOptionalManagementJsonBody, rethrowManagementBodyTooLarge } from "./body";
 
@@ -653,6 +658,63 @@ export async function handleAgentSettingsRoutes(ctx: ManagementContext): Promise
     await syncClaudeAgentDefsBestEffort();
     await autoApplyDesktopBestEffort();
     return jsonResponse({ ok: true, applied: chosen, catalogRefresh });
+  }
+
+  if (url.pathname === "/api/subagent-roles" && req.method === "GET") {
+    const models = await fetchAllModels(config);
+    const disabled = new Set(config.disabledModels ?? []);
+    const { listCatalogNativeSlugs } = await import("../../codex/catalog");
+    const { CODEX_REASONING_LEVELS } = await import("../../reasoning-effort");
+    const nativeModels = listCatalogNativeSlugs()
+      .filter(slug => !disabled.has(slug))
+      .map(slug => ({ provider: "openai", model: slug, namespaced: slug }));
+    const routedModels = uniqueCatalogModelsForPublicList(models)
+      .map(m => ({ provider: m.provider, model: m.id, namespaced: catalogModelSlug(m) }))
+      .filter(m => ![...disabled].some(stored => (
+        stored === m.namespaced || slugEquals(stored, m.provider, m.model)
+      )));
+    return jsonResponse({
+      roles: config.subagentRoles ?? [],
+      efforts: CODEX_REASONING_LEVELS.map(l => l.effort),
+      available: [...nativeModels, ...routedModels],
+    });
+  }
+  if (url.pathname === "/api/subagent-roles" && req.method === "PUT") {
+    let parsedBody: unknown;
+    try {
+      parsedBody = await readManagementJsonBody(req);
+    } catch (error) {
+      rethrowManagementBodyTooLarge(error);
+      return jsonResponse({ error: "invalid JSON body" }, 400);
+    }
+    if (!parsedBody || typeof parsedBody !== "object" || Array.isArray(parsedBody)) {
+      return jsonResponse({ error: "body must be a JSON object" }, 400);
+    }
+    const body = parsedBody as { roles?: unknown };
+    if (!("roles" in body)) return jsonResponse({ error: "body.roles is required" }, 400);
+    const parsed = parseSubagentRoles(body.roles);
+    if (!parsed.ok) return jsonResponse({ error: parsed.error, index: parsed.index }, 400);
+
+    const warnings: string[] = [];
+    const union = unionRoleModelsIntoRoster(config.subagentModels, parsed.roles);
+    if (union.droppedRoleIds.length > 0) {
+      warnings.push(`Featured roster truncated to 5 models; dropped role id(s): ${union.droppedRoleIds.join(", ")}`);
+    }
+    warnings.push(...routedOnV2Warnings(parsed.roles, config));
+
+    config.subagentRoles = parsed.roles;
+    config.subagentModels = union.models;
+    const { saveConfigPreservingClaudeCode: save } = await import("../../config");
+    save(config);
+    const catalogRefresh = await convergeCodexCatalog();
+    await syncClaudeAgentDefsBestEffort();
+    await autoApplyDesktopBestEffort();
+    return jsonResponse({
+      ok: true,
+      roles: config.subagentRoles,
+      warnings,
+      catalogRefresh,
+    });
   }
 
   // Priority-ordered subagent model fallback chain for quota-aware spawn routing.

--- a/src/server/management/agent-settings-routes.ts
+++ b/src/server/management/agent-settings-routes.ts
@@ -690,7 +690,26 @@ export async function handleAgentSettingsRoutes(ctx: ManagementContext): Promise
     if (!parsedBody || typeof parsedBody !== "object" || Array.isArray(parsedBody)) {
       return jsonResponse({ error: "body must be a JSON object" }, 400);
     }
-    const body = parsedBody as { roles?: unknown };
+    const body = parsedBody as { roles?: unknown; remove?: unknown };
+    if ("remove" in body) {
+      if ("roles" in body) return jsonResponse({ error: "body.remove cannot be combined with body.roles" }, 400);
+      if (typeof body.remove !== "string" || body.remove.trim().length === 0) {
+        return jsonResponse({ error: "body.remove must be a non-empty role id" }, 400);
+      }
+      const id = body.remove.trim();
+      config.subagentRoles = (config.subagentRoles ?? []).filter(role => role.id !== id);
+      const { saveConfigPreservingClaudeCode: save } = await import("../../config");
+      save(config);
+      const catalogRefresh = await convergeCodexCatalog();
+      await syncClaudeAgentDefsBestEffort();
+      await autoApplyDesktopBestEffort();
+      return jsonResponse({
+        ok: true,
+        roles: config.subagentRoles,
+        warnings: [],
+        catalogRefresh,
+      });
+    }
     if (!("roles" in body)) return jsonResponse({ error: "body.roles is required" }, 400);
     const parsed = parseSubagentRoles(body.roles);
     if (!parsed.ok) return jsonResponse({ error: parsed.error, index: parsed.index }, 400);

--- a/src/server/management/combo-routes.ts
+++ b/src/server/management/combo-routes.ts
@@ -192,6 +192,11 @@ export async function handleComboRoutes(ctx: ManagementContext): Promise<Respons
       if (config.subagentModels) {
         config.subagentModels = [...new Set(config.subagentModels.map(migrateAgentReference))];
       }
+      if (config.subagentRoles) {
+        for (const role of config.subagentRoles) {
+          role.model = migrateAgentReference(role.model);
+        }
+      }
       if (config.injectionModel && migratedModels.has(config.injectionModel)) {
         config.injectionModel = migrateReference(config.injectionModel);
       }

--- a/src/server/management/routing-profile-routes.ts
+++ b/src/server/management/routing-profile-routes.ts
@@ -177,6 +177,11 @@ function migrateProfileModelReferences(
   if (config.subagentModels) {
     config.subagentModels = [...new Set(config.subagentModels.map(migrateAgentReference))];
   }
+  if (config.subagentRoles) {
+    for (const role of config.subagentRoles) {
+      role.model = migrateAgentReference(role.model);
+    }
+  }
   if (config.subagentModelFallback) {
     config.subagentModelFallback = [...new Set(config.subagentModelFallback.map(migrateAgentReference))];
   }

--- a/src/server/responses/collaboration.ts
+++ b/src/server/responses/collaboration.ts
@@ -27,7 +27,7 @@ import {
 import { isInjectionDebugEnabled } from "../../lib/debug-settings";
 import { injectionDebugLog } from "../../lib/injection-debug-log";
 import { modelInList, namespacedToolName, toolChoiceToolPredicate } from "../../types";
-import type { AdapterEvent, OcxConfig, OcxParsedRequest, OcxProviderConfig, OcxProviderContinuationState, OcxUsage } from "../../types";
+import type { AdapterEvent, OcxConfig, OcxParsedRequest, OcxProviderConfig, OcxProviderContinuationState, OcxSubagentRole, OcxUsage } from "../../types";
 import {
   forceRefreshOAuthAccessSnapshot,
   getOAuthCredentialApiBaseUrl,
@@ -62,6 +62,7 @@ import { listOpenAiForwardSidecarCandidates, resolveFirstUsableOpenAiSidecar, ty
 import { isCanonicalOpenAiForwardProvider } from "../../providers/openai-tiers";
 import { slugsEquivalent } from "../../providers/slug-codec";
 import { subagentFallbackGuidanceText } from "../../codex/subagent-model-fallback";
+import { renderRolesCatalog } from "../../codex/agent-roles";
 import { applyOpenAiVirtualModel, resolveOpenAiCompactModel } from "../../providers/openai-virtual-models";
 import { isUsageDebugEnabled } from "../../usage/debug";
 import { readJsonRequestBody, DecompressedBodyTooLargeError, UnsupportedContentEncodingError } from "../request-decompress";
@@ -212,6 +213,7 @@ export interface MultiAgentGuidanceOptions {
   subagentModels?: string[];
   subagentModelFallback?: string[];
   injectionPrompt?: string;
+  subagentRoles?: OcxSubagentRole[];
 }
 
 
@@ -271,6 +273,7 @@ export async function multiAgentGuidanceText(
     subagentModels,
     subagentModelFallback,
     injectionPrompt,
+    subagentRoles,
   } = options;
   const activeAccountNamespace = codexAccountNamespace?.length
     ? codexAccountNamespace
@@ -362,30 +365,39 @@ export async function multiAgentGuidanceText(
         .join(", ")}`);
     }
     const fallbackGuidance = subagentFallbackGuidanceText({ subagentModelFallback } as OcxConfig);
-    if (!injectionModel && roster === "" && fallbackGuidance === "") return null;
+    const rolesText = renderRolesCatalog(subagentRoles ?? []);
+    if (!injectionModel && roster === "" && fallbackGuidance === "" && rolesText === "") return null;
     if (injectionPrompt) {
       // Bare ids must resolve to a unique/current-route candidate. Preserve the legacy raw
       // fallback only for explicit routed/account-qualified ids.
       const promptModel = preferred?.model
         ?? (injectionModel?.includes("/") ? injectionModel : undefined);
-      return `<multi_agent_mode>${applyInjectionPlaceholders(injectionPrompt, promptModel, injectionEffort, roster, fallbackGuidance)}</multi_agent_mode>`;
+      return `<multi_agent_mode>${applyInjectionPlaceholders(injectionPrompt, promptModel, injectionEffort, roster, fallbackGuidance, rolesText)}</multi_agent_mode>`;
     }
-    if (!preferred && roster === "" && fallbackGuidance === "") return null;
-    let text = "When the active spawn_agent tool supports optional \"model\" or \"reasoning_effort\" overrides, "
+    if (!preferred && roster === "" && fallbackGuidance === "" && rolesText === "") return null;
+    const preamble = "When the active spawn_agent tool supports optional \"model\" or \"reasoning_effort\" overrides, "
       + "use only models listed for this collaboration surface. "
       + "When setting either override, set fork_turns to \"none\" "
       + "(or a positive turn count such as \"3\"; full-history forks reject overrides) "
       + "and make the task message self-contained.";
+    let preferredText = "";
     if (preferred) {
-      text += ` Preferred sub-agent: model "${preferred.model}"`
+      preferredText = ` Preferred sub-agent: model "${preferred.model}"`
         + (injectionEffort ? `, reasoning_effort "${injectionEffort}"` : "")
         + " — use it unless the user names another.";
     }
-    text += fallbackGuidance;
-    text += roster;
+    const specialist = (catalog: string): string =>
+      catalog ? ` When spawning, use a named specialist: ${catalog}.` : "";
+    let text = preamble + preferredText + fallbackGuidance + specialist(rolesText) + roster;
     if (text.length > V2_GUIDANCE_CHAR_BUDGET) {
-      // Roster is the only unbounded part — drop it before breaking the budget.
-      text = text.slice(0, text.length - roster.length);
+      text = preamble + preferredText + fallbackGuidance + specialist(rolesText);
+    }
+    if (text.length > V2_GUIDANCE_CHAR_BUDGET) {
+      for (const descBudget of [80, 40, 0]) {
+        const shortened = renderRolesCatalog(subagentRoles ?? [], { maxDescriptionChars: descBudget });
+        text = preamble + preferredText + fallbackGuidance + specialist(shortened);
+        if (text.length <= V2_GUIDANCE_CHAR_BUDGET) break;
+      }
     }
     return `<multi_agent_mode>${text}</multi_agent_mode>`;
   }
@@ -401,12 +413,13 @@ export async function multiAgentGuidanceText(
 
 export const V2_GUIDANCE_CHAR_BUDGET = 700;
 
-export function applyInjectionPlaceholders(prompt: string, model?: string, effort?: string, roster?: string, fallback?: string): string {
+export function applyInjectionPlaceholders(prompt: string, model?: string, effort?: string, roster?: string, fallback?: string, roles?: string): string {
   return prompt
     .replaceAll("{{model}}", model ?? "")
     .replaceAll("{{effort}}", effort ?? "")
     .replaceAll("{{roster}}", roster ?? "")
-    .replaceAll("{{fallback}}", fallback ?? "");
+    .replaceAll("{{fallback}}", fallback ?? "")
+    .replaceAll("{{roles}}", roles ?? "");
 }
 
 

--- a/src/server/responses/collaboration.ts
+++ b/src/server/responses/collaboration.ts
@@ -62,7 +62,7 @@ import { listOpenAiForwardSidecarCandidates, resolveFirstUsableOpenAiSidecar, ty
 import { isCanonicalOpenAiForwardProvider } from "../../providers/openai-tiers";
 import { slugsEquivalent } from "../../providers/slug-codec";
 import { subagentFallbackGuidanceText } from "../../codex/subagent-model-fallback";
-import { renderRolesCatalog } from "../../codex/agent-roles";
+import { compactRolesCatalog, enabledSubagentRoles } from "../../codex/agent-roles";
 import { applyOpenAiVirtualModel, resolveOpenAiCompactModel } from "../../providers/openai-virtual-models";
 import { isUsageDebugEnabled } from "../../usage/debug";
 import { readJsonRequestBody, DecompressedBodyTooLargeError, UnsupportedContentEncodingError } from "../request-decompress";
@@ -365,16 +365,27 @@ export async function multiAgentGuidanceText(
         .join(", ")}`);
     }
     const fallbackGuidance = subagentFallbackGuidanceText({ subagentModelFallback } as OcxConfig);
-    const rolesText = renderRolesCatalog(subagentRoles ?? []);
-    if (!injectionModel && roster === "" && fallbackGuidance === "" && rolesText === "") return null;
+    const visibleRoles = enabledSubagentRoles(subagentRoles).filter((role) => {
+      const match = effective.candidates.find(candidate =>
+        slugsEquivalent(candidate.model, role.model) || candidate.model === role.model,
+      );
+      if (!match) return false;
+      const matchesPreferred = Boolean(injectionModel)
+        && (slugsEquivalent(match.model, injectionModel!) || match.model === injectionModel);
+      if (!withinCandidateWindow(match) || (!allowedForCurrentRoute(match) && !matchesPreferred)) return false;
+      if (role.effort && !match.efforts.includes(role.effort)) return false;
+      return true;
+    });
+    const customRolesText = compactRolesCatalog(visibleRoles, V2_GUIDANCE_CHAR_BUDGET);
+    if (!injectionModel && roster === "" && fallbackGuidance === "" && customRolesText === "") return null;
     if (injectionPrompt) {
       // Bare ids must resolve to a unique/current-route candidate. Preserve the legacy raw
       // fallback only for explicit routed/account-qualified ids.
       const promptModel = preferred?.model
         ?? (injectionModel?.includes("/") ? injectionModel : undefined);
-      return `<multi_agent_mode>${applyInjectionPlaceholders(injectionPrompt, promptModel, injectionEffort, roster, fallbackGuidance, rolesText)}</multi_agent_mode>`;
+      return `<multi_agent_mode>${applyInjectionPlaceholders(injectionPrompt, promptModel, injectionEffort, roster, fallbackGuidance, customRolesText)}</multi_agent_mode>`;
     }
-    if (!preferred && roster === "" && fallbackGuidance === "" && rolesText === "") return null;
+    if (!preferred && roster === "" && fallbackGuidance === "" && customRolesText === "") return null;
     const preamble = "When the active spawn_agent tool supports optional \"model\" or \"reasoning_effort\" overrides, "
       + "use only models listed for this collaboration surface. "
       + "When setting either override, set fork_turns to \"none\" "
@@ -388,16 +399,20 @@ export async function multiAgentGuidanceText(
     }
     const specialist = (catalog: string): string =>
       catalog ? ` When spawning, use a named specialist: ${catalog}.` : "";
+    const rolesBudget = (withRoster: boolean): number => {
+      const wrapper = specialist("x").length - 1;
+      return V2_GUIDANCE_CHAR_BUDGET
+        - preamble.length
+        - preferredText.length
+        - fallbackGuidance.length
+        - (withRoster ? roster.length : 0)
+        - wrapper;
+    };
+    let rolesText = compactRolesCatalog(visibleRoles, Math.max(0, rolesBudget(true)));
     let text = preamble + preferredText + fallbackGuidance + specialist(rolesText) + roster;
     if (text.length > V2_GUIDANCE_CHAR_BUDGET) {
+      rolesText = compactRolesCatalog(visibleRoles, Math.max(0, rolesBudget(false)));
       text = preamble + preferredText + fallbackGuidance + specialist(rolesText);
-    }
-    if (text.length > V2_GUIDANCE_CHAR_BUDGET) {
-      for (const descBudget of [80, 40, 0]) {
-        const shortened = renderRolesCatalog(subagentRoles ?? [], { maxDescriptionChars: descBudget });
-        text = preamble + preferredText + fallbackGuidance + specialist(shortened);
-        if (text.length <= V2_GUIDANCE_CHAR_BUDGET) break;
-      }
     }
     return `<multi_agent_mode>${text}</multi_agent_mode>`;
   }

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -1472,6 +1472,7 @@ async function applyFinalRouteRequestNormalization(args: {
       subagentModels: config.subagentModels,
       subagentModelFallback: config.subagentModelFallback,
       injectionPrompt: config.injectionPrompt,
+      subagentRoles: config.subagentRoles,
     });
     if (guidance) {
       injectDeveloperMessage(parsed, guidance);

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,7 @@ export type {
   OcxCustomModel,
   OcxApiKeyEntry,
   OcxClientIntegrationsConfig,
+  OcxSubagentRole,
   OcxConfig,
   OcxAccountPoolRotationStrategy,
   OcxComboStrategy,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -245,7 +245,7 @@ export interface OcxSubagentRole {
   id: string;
   /** 1..240 chars; parent "when to use" this specialist. */
   description: string;
-  /** Bare native or `provider/model`. */
+  /** Bare native or `provider/model`, at most 128 characters. */
   model: string;
   /** Codex reasoning ladder; optional. */
   effort?: string;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -239,6 +239,22 @@ export interface OcxClientIntegrationsConfig {
   "claude-desktop"?: boolean;
 }
 
+/** User-authored specialist the Codex parent may spawn by name. */
+export interface OcxSubagentRole {
+  /** `[a-z][a-z0-9-]{0,31}`, unique within the catalog. */
+  id: string;
+  /** 1..240 chars; parent "when to use" this specialist. */
+  description: string;
+  /** Bare native or `provider/model`. */
+  model: string;
+  /** Codex reasoning ladder; optional. */
+  effort?: string;
+  /** 1..8000 chars; child's developer prompt. */
+  developerInstructions: string;
+  /** Default true. Disabled roles stay in config but are omitted from guidance. */
+  enabled?: boolean;
+}
+
 export interface OcxConfig {
   port: number;
   /** Opt in to one identical-turn retry when a Responses completion has no text or tool call. */
@@ -265,6 +281,13 @@ export interface OcxConfig {
    * into a selector-qualified group; Codex still advertises only the first 5 visible rows.
    */
   subagentModels?: string[];
+  /**
+   * Named specialist roles the parent may spawn: id, when-to-use description,
+   * model, optional effort, and child developer instructions. Max 8 roles and
+   * 5 unique enabled models (the spawn picker window). Do not store
+   * `model_fallback` here — use `subagentModelFallbackByModel`.
+   */
+  subagentRoles?: OcxSubagentRole[];
   /**
    * Optional full picker ordering for the Codex model catalog, independent of the
    * 5-slot `subagentModels` spawn_agent cap. DISPLAY-ONLY: it controls the visual order of
@@ -360,7 +383,9 @@ export interface OcxConfig {
    * remain unchanged),
    * `{{effort}}` -> injectionEffort, `{{roster}}` -> the resolved sub-agent roster
    * block ("" when nothing resolves), `{{fallback}}` -> the configured subagent
-   * model fallback guidance block ("" when unset).
+   * model fallback guidance block ("" when unset), `{{roles}}` -> the compact
+   * enabled role catalog ("" when none). A custom prompt replaces the built-in
+   * body; include `{{roles}}` to keep the catalog.
    */
   injectionPrompt?: string;
   /**

--- a/tests/codex-convergence-contract.test.ts
+++ b/tests/codex-convergence-contract.test.ts
@@ -372,12 +372,12 @@ test("a failure cause never carries message text, paths or identifiers (#1784)",
   expect(body).not.toContain("failed writing");
 });
 
-test("the route inventory contains exactly the specified 7 + 6 + 2 + 2 convergence calls", () => {
+test("the route inventory contains exactly the specified 7 + 6 + 2 + 4 convergence calls", () => {
   const counts = Object.fromEntries([
     ["provider-routes.ts", 7],
     ["model-routes.ts", 6],
     ["combo-routes.ts", 2],
-    ["agent-settings-routes.ts", 2],
+    ["agent-settings-routes.ts", 4],
   ].map(([file, expected]) => {
     const source = readFileSync(join(import.meta.dir, "..", "src", "server", "management", file as string), "utf8");
     const count = source.match(/await convergeCodexCatalog\(\)/g)?.length ?? 0;
@@ -389,7 +389,7 @@ test("the route inventory contains exactly the specified 7 + 6 + 2 + 2 convergen
     "provider-routes.ts": 7,
     "model-routes.ts": 6,
     "combo-routes.ts": 2,
-    "agent-settings-routes.ts": 2,
+    "agent-settings-routes.ts": 4,
   });
 });
 
@@ -411,4 +411,29 @@ test("the attested reload route converges the Codex catalog like the other write
   // The reload handler returns before the next route check; scope the search to its body.
   const handlerBody = source.slice(handlerStart, source.indexOf("url.pathname ===", handlerStart + 1));
   expect(handlerBody).toContain("await convergeCodexCatalog()");
+});
+
+/**
+ * Named role save/remove write the same catalog-visible config as the featured-roster
+ * PUT, so both branches must converge. A count bump from 2 to 4 would otherwise pass
+ * while one of these paths quietly dropped its call, or while some other route gained one.
+ */
+test("the attested subagent-roles write paths converge the Codex catalog", () => {
+  const source = readFileSync(
+    join(import.meta.dir, "..", "src", "server", "management", "agent-settings-routes.ts"),
+    "utf8",
+  );
+  const handlerStart = source.indexOf("url.pathname === \"/api/subagent-roles\" && req.method === \"PUT\"");
+  expect(handlerStart).toBeGreaterThan(-1);
+  const handlerBody = source.slice(
+    handlerStart,
+    source.indexOf("url.pathname === \"/api/subagent-model-fallback\"", handlerStart + 1),
+  );
+  const removeStart = handlerBody.indexOf('"remove" in body');
+  const saveStart = handlerBody.indexOf('if (!("roles" in body))');
+  expect(removeStart).toBeGreaterThan(-1);
+  expect(saveStart).toBeGreaterThan(removeStart);
+  expect(handlerBody.slice(removeStart, saveStart)).toContain("await convergeCodexCatalog()");
+  expect(handlerBody.slice(saveStart)).toContain("await convergeCodexCatalog()");
+  expect(handlerBody.match(/await convergeCodexCatalog\(\)/g)?.length).toBe(2);
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -356,6 +356,86 @@ describe("opencodex config defaults", () => {
     warnSpy.mockRestore();
   });
 
+  test("config candidates validate subagentRoles id, uniqueness, and length rules", () => {
+    const base = getDefaultConfig();
+    const role = {
+      id: "reviewer",
+      description: "PR review",
+      model: "anthropic/claude-sonnet-5",
+      effort: "high",
+      developerInstructions: "Review the diff for regressions.",
+    };
+    expect(validateConfigCandidate({ ...base, subagentRoles: [role] })).toMatchObject({
+      ok: true,
+      config: { subagentRoles: [expect.objectContaining({ id: "reviewer", enabled: true })] },
+    });
+    expect(validateConfigCandidate({ ...base, subagentRoles: [] })).toMatchObject({
+      ok: true,
+      config: { subagentRoles: [] },
+    });
+    expect(validateConfigCandidate({
+      ...base,
+      subagentRoles: [{ ...role, id: "Reviewer" }],
+    })).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("subagentRoles"),
+    });
+    expect(validateConfigCandidate({
+      ...base,
+      subagentRoles: [role, { ...role, id: "reviewer", description: "duplicate" }],
+    })).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("subagentRoles"),
+    });
+    expect(validateConfigCandidate({
+      ...base,
+      subagentRoles: Array.from({ length: 9 }, (_, i) => ({ ...role, id: `role-${i}` })),
+    })).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("subagentRoles"),
+    });
+  });
+
+  test("malformed persisted subagentRoles are dropped with a warning without wiping config", () => {
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    writeConfig({
+      port: 12345,
+      defaultProvider: "custom",
+      providers: { custom: { adapter: "openai-chat", baseUrl: "https://example.test/v1", apiKey: "upstream-secret" } },
+      apiKeys: [{ id: "key-1", name: "default", key: "ocx_persisted", createdAt: "2026-07-28T00:00:00.000Z" }],
+      subagentRoles: [
+        {
+          id: "reviewer",
+          description: "PR review",
+          model: "anthropic/claude-sonnet-5",
+          developerInstructions: "Review the diff.",
+        },
+        { id: "BAD", description: "nope", model: "gpt-5.6-luna", developerInstructions: "x" },
+      ],
+    });
+
+    const config = loadConfig();
+    const diagnostics = readConfigDiagnostics();
+
+    expect(config.subagentRoles).toEqual([
+      expect.objectContaining({ id: "reviewer", model: "anthropic/claude-sonnet-5" }),
+    ]);
+    expect(config).toMatchObject({
+      port: 12345,
+      defaultProvider: "custom",
+      providers: { custom: { baseUrl: "https://example.test/v1", apiKey: "upstream-secret" } },
+      apiKeys: [expect.objectContaining({ id: "key-1", key: "ocx_persisted" })],
+    });
+    expect(diagnostics).toMatchObject({
+      source: "file",
+      error: null,
+      warnings: [expect.stringContaining("subagentRoles")],
+    });
+    expect(backupNames()).toEqual([]);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
   test("a blank hostname already on disk degrades without wiping providers or keys", () => {
     // Regression: rejecting a blank hostname in the schema made loadConfig fail twice
     // (getDefaultConfig() has no hostname key, so the merge-defaults repair cannot fix

--- a/tests/multi-agent-compat.test.ts
+++ b/tests/multi-agent-compat.test.ts
@@ -755,6 +755,113 @@ describe("multiAgentGuidanceText", () => {
     expect(text).toContain("kimi/k3");
   });
 
+  test("v2 built-in guidance includes enabled role id and model", async () => {
+    const dir = codexHomeFixture(V2_ON);
+    catalogFixture(dir, [{
+      slug: "anthropic/claude-sonnet-5",
+      efforts: ["low", "medium", "high", "xhigh"],
+    }]);
+    const text = await multiAgentGuidanceText(
+      parsedFixture({ tools: [{ name: "spawn_agent" }] }),
+      {
+        injectionModel: "anthropic/claude-sonnet-5",
+        subagentRoles: [{
+          id: "reviewer",
+          description: "PR review",
+          model: "anthropic/claude-sonnet-5",
+          effort: "high",
+          developerInstructions: "Review the diff.",
+          enabled: true,
+        }],
+      },
+    );
+    expect(text).toContain("reviewer");
+    expect(text).toContain("anthropic/claude-sonnet-5");
+    expect(text).toContain("named specialist");
+    expect(text).toContain("fork_turns");
+  });
+
+  test("custom injectionPrompt without {{roles}} does not leak the catalog", async () => {
+    const dir = codexHomeFixture(V2_ON);
+    catalogFixture(dir, [{ slug: "anthropic/claude-sonnet-5", efforts: ["high"] }]);
+    const text = await multiAgentGuidanceText(
+      parsedFixture({ tools: [{ name: "spawn_agent" }] }),
+      {
+        injectionModel: "anthropic/claude-sonnet-5",
+        injectionPrompt: "Use {{model}} only.",
+        subagentRoles: [{
+          id: "reviewer",
+          description: "PR review",
+          model: "anthropic/claude-sonnet-5",
+          developerInstructions: "Review the diff.",
+        }],
+      },
+    );
+    expect(text).toContain("Use anthropic/claude-sonnet-5 only.");
+    expect(text).not.toContain("reviewer");
+    expect(text).not.toContain("named specialist");
+  });
+
+  test("custom injectionPrompt with {{roles}} substitutes the catalog", async () => {
+    const dir = codexHomeFixture(V2_ON);
+    catalogFixture(dir, [{ slug: "gpt-5.6-luna", efforts: ["high"] }]);
+    const text = await multiAgentGuidanceText(
+      parsedFixture({ tools: [{ name: "spawn_agent" }] }),
+      {
+        injectionModel: "gpt-5.6-luna",
+        injectionPrompt: "ROLES={{roles}}",
+        subagentRoles: [{
+          id: "explorer",
+          description: "read-only search",
+          model: "gpt-5.6-luna",
+          developerInstructions: "Search the tree.",
+        }],
+      },
+    );
+    expect(text).toContain("explorer (gpt-5.6-luna) for read-only search");
+    expect(text).not.toContain("{{roles}}");
+  });
+
+  test("v1 ignores roles even at max", async () => {
+    codexHomeFixture(V2_OFF);
+    const text = await multiAgentGuidanceText(
+      parsedFixture({
+        reasoning: "max",
+        tools: [{ name: "spawn_agent", namespace: "agents" }, { name: "send_input", namespace: "agents" }],
+      }),
+      {
+        subagentRoles: [{
+          id: "reviewer",
+          description: "PR review",
+          model: "anthropic/claude-sonnet-5",
+          developerInstructions: "Review the diff.",
+        }],
+      },
+    );
+    expect(text).toContain("Proactive multi-agent delegation is active");
+    expect(text).not.toContain("reviewer");
+    expect(text).not.toContain("named specialist");
+  });
+
+  test("stale catalog still returns null even when roles are configured", async () => {
+    const dir = codexHomeFixture(V2_ON);
+    catalogFixture(dir, [{ slug: "anthropic/claude-sonnet-5", efforts: ["high"] }]);
+    const text = await multiAgentGuidanceText(
+      parsedFixture({ tools: [{ name: "spawn_agent" }] }),
+      {
+        injectionModel: "anthropic/claude-sonnet-5",
+        subagentRoles: [{
+          id: "reviewer",
+          description: "PR review",
+          model: "anthropic/claude-sonnet-5",
+          developerInstructions: "Review the diff.",
+        }],
+      },
+      { collectCatalogState: () => ({ state: "stale" }) },
+    );
+    expect(text).toBeNull();
+  });
+
   test("v1 ignores injectionPrompt and custom prompt does not fire a bare v2 surface", async () => {
     codexHomeFixture(V2_ON);
     const custom = "CUSTOM RULES model={{model}} effort={{effort}}{{roster}}";

--- a/tests/multi-agent-compat.test.ts
+++ b/tests/multi-agent-compat.test.ts
@@ -7,7 +7,7 @@ import { afterAll, afterEach, describe, expect, test } from "bun:test";
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { injectDeveloperMessage, multiAgentGuidanceText, sanitizeEncryptedContentInPlace } from "../src/server/responses";
+import { injectDeveloperMessage, multiAgentGuidanceText, sanitizeEncryptedContentInPlace, V2_GUIDANCE_CHAR_BUDGET } from "../src/server/responses";
 import { parseRequest } from "../src/responses/parser";
 import type { OcxParsedRequest } from "../src/types";
 import { CODEX_ACCOUNT_BOUND_CATALOG_KIND, effectiveSubagentRoster } from "../src/codex/catalog";
@@ -779,6 +779,116 @@ describe("multiAgentGuidanceText", () => {
     expect(text).toContain("anthropic/claude-sonnet-5");
     expect(text).toContain("named specialist");
     expect(text).toContain("fork_turns");
+  });
+
+  test("omits a role whose model is outside the v2 candidate window", async () => {
+    const dir = codexHomeFixture(V2_ON);
+    catalogFixture(dir, [{
+      slug: "anthropic/claude-sonnet-5",
+      efforts: ["low", "medium", "high", "xhigh"],
+    }]);
+    const text = await multiAgentGuidanceText(
+      parsedFixture({ tools: [{ name: "spawn_agent" }] }),
+      {
+        injectionModel: "anthropic/claude-sonnet-5",
+        subagentRoles: [
+          {
+            id: "reviewer",
+            description: "PR review",
+            model: "anthropic/claude-sonnet-5",
+            effort: "high",
+            developerInstructions: "Review the diff.",
+            enabled: true,
+          },
+          {
+            id: "explorer",
+            description: "read-only search",
+            model: "kimi/k3",
+            developerInstructions: "Search the tree.",
+            enabled: true,
+          },
+        ],
+      },
+    );
+    expect(text).toContain("reviewer");
+    expect(text).not.toContain("explorer");
+    expect(text).not.toContain("kimi/k3");
+  });
+
+  test("omits a role whose effort is not supported on the resolved model", async () => {
+    const dir = codexHomeFixture(V2_ON);
+    catalogFixture(dir, [{
+      slug: "anthropic/claude-sonnet-5",
+      efforts: ["low", "medium"],
+    }]);
+    const text = await multiAgentGuidanceText(
+      parsedFixture({ tools: [{ name: "spawn_agent" }] }),
+      {
+        injectionModel: "anthropic/claude-sonnet-5",
+        subagentRoles: [{
+          id: "reviewer",
+          description: "PR review",
+          model: "anthropic/claude-sonnet-5",
+          effort: "high",
+          developerInstructions: "Review the diff.",
+          enabled: true,
+        }],
+      },
+    );
+    expect(text).not.toContain("reviewer");
+    expect(text).not.toContain("named specialist");
+  });
+
+  test("built-in eight-role catalog stays within the v2 guidance budget", async () => {
+    const dir = codexHomeFixture(V2_ON);
+    const models = Array.from({ length: 8 }, (_, i) => ({
+      slug: `provider-${i}/model-${"m".repeat(80)}`,
+      efforts: ["high"],
+    }));
+    catalogFixture(dir, models);
+    const text = await multiAgentGuidanceText(
+      parsedFixture({ tools: [{ name: "spawn_agent" }] }),
+      {
+        injectionModel: models[0]!.slug,
+        subagentRoles: models.map((model, i) => ({
+          id: `role-${i}`,
+          description: "when to use this specialist for a long task description",
+          model: model.slug,
+          developerInstructions: "Do the specialist work.",
+          enabled: true,
+        })),
+      },
+    );
+    expect(text).toContain("<multi_agent_mode>");
+    expect(text!.length).toBeLessThanOrEqual(V2_GUIDANCE_CHAR_BUDGET + "<multi_agent_mode></multi_agent_mode>".length);
+    expect(text).toContain("fork_turns");
+  });
+
+  test("custom {{roles}} substitution stays within the catalog budget", async () => {
+    const dir = codexHomeFixture(V2_ON);
+    const models = Array.from({ length: 8 }, (_, i) => ({
+      slug: `provider-${i}/model-${"m".repeat(80)}`,
+      efforts: ["high"],
+    }));
+    catalogFixture(dir, models);
+    const text = await multiAgentGuidanceText(
+      parsedFixture({ tools: [{ name: "spawn_agent" }] }),
+      {
+        injectionModel: models[0]!.slug,
+        injectionPrompt: "ROLES={{roles}}",
+        subagentRoles: models.map((model, i) => ({
+          id: `role-${i}`,
+          description: "when to use this specialist for a long task description",
+          model: model.slug,
+          developerInstructions: "Do the specialist work.",
+          enabled: true,
+        })),
+      },
+    );
+    expect(text).not.toContain("{{roles}}");
+    const inner = text!.replace(/^<multi_agent_mode>/, "").replace(/<\/multi_agent_mode>$/, "");
+    const roles = inner.slice("ROLES=".length);
+    expect(roles.length).toBeLessThanOrEqual(V2_GUIDANCE_CHAR_BUDGET);
   });
 
   test("custom injectionPrompt without {{roles}} does not leak the catalog", async () => {

--- a/tests/provider-id-rewrite.test.ts
+++ b/tests/provider-id-rewrite.test.ts
@@ -14,6 +14,7 @@ test("rewrites every routed-string site", () => {
     subagentModels: [`${FROM}/qwen3.7-max`],
     subagentModelFallback: [`${FROM}/qwen3.6-flash`],
     injectionModel: `${FROM}/qwen3.7-plus`,
+    subagentRoles: [{ id: "reviewer", description: "PR review", model: `${FROM}/qwen3.7-max`, developerInstructions: "Review." }],
     shadowCallIntercept: { model: `${FROM}/qwen3.6-flash` },
     webSearchSidecar: { model: `${FROM}/qwen3.7-max` },
     visionSidecar: { model: `${FROM}/qwen3.7-max` },
@@ -27,10 +28,10 @@ test("rewrites every routed-string site", () => {
     },
   } as unknown as OcxConfig;
 
-  // 14 sites: defaultProvider, one of two disabledModels, subagentModels,
-  // subagentModelFallback, injectionModel, shadowCallIntercept.model,
+  // 15 sites: defaultProvider, one of two disabledModels, subagentModels,
+  // subagentModelFallback, injectionModel, subagentRoles[].model, shadowCallIntercept.model,
   // webSearchSidecar.model, visionSidecar.model, and the six claudeCode entries.
-  expect(rewriteProviderReferences(config, FROM, TO)).toEqual({ changed: 14, collisions: [] });
+  expect(rewriteProviderReferences(config, FROM, TO)).toEqual({ changed: 15, collisions: [] });
   expect(JSON.stringify(config)).not.toContain(`"${FROM}/`);
   expect(config.disabledModels).toContain("anthropic/claude-sonnet-5");
 });

--- a/tests/subagent-roles-api.test.ts
+++ b/tests/subagent-roles-api.test.ts
@@ -1,0 +1,140 @@
+/**
+ * GET/PUT /api/subagent-roles: atomic validation, roster union warnings, routed-on-v2.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleManagementAPI } from "../src/server/management-api";
+import type { OcxConfig, OcxSubagentRole } from "../src/types";
+import { ManagementRequest as Request } from "./helpers/management-auth";
+
+const savedHome = process.env.OPENCODEX_HOME;
+let tempHome: string | null = null;
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = savedHome;
+  if (tempHome) {
+    rmSync(tempHome, { recursive: true, force: true });
+    tempHome = null;
+  }
+});
+
+function isolatedHome(): void {
+  tempHome = mkdtempSync(join(tmpdir(), "ocx-subagent-roles-api-"));
+  process.env.OPENCODEX_HOME = tempHome;
+}
+
+const sampleRole: OcxSubagentRole = {
+  id: "reviewer",
+  description: "PR review",
+  model: "anthropic/claude-sonnet-5",
+  effort: "high",
+  developerInstructions: "Review the diff for regressions.",
+  enabled: true,
+};
+
+function makeConfig(overrides: Partial<OcxConfig> = {}): OcxConfig {
+  return {
+    port: 10100,
+    providers: {},
+    defaultProvider: "openai",
+    subagentModels: ["gpt-5.5", "gpt-5.6-sol"],
+    ...overrides,
+  } as OcxConfig;
+}
+
+async function put(config: OcxConfig, body: unknown): Promise<Response> {
+  const req = new Request("http://localhost/api/subagent-roles", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const res = await handleManagementAPI(req, new URL(req.url), config);
+  expect(res).not.toBeNull();
+  return res!;
+}
+
+async function get(config: OcxConfig): Promise<Response> {
+  const req = new Request("http://localhost/api/subagent-roles");
+  const res = await handleManagementAPI(req, new URL(req.url), config);
+  expect(res).not.toBeNull();
+  return res!;
+}
+
+describe("/api/subagent-roles atomic validation", () => {
+  test("PUT invalid id returns 400 and leaves previous config unchanged", async () => {
+    isolatedHome();
+    const previous = [sampleRole];
+    const config = makeConfig({ subagentRoles: [...previous] });
+
+    const res = await put(config, {
+      roles: [{ ...sampleRole, id: "Reviewer" }],
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/id/i);
+    expect(config.subagentRoles).toEqual(previous);
+    expect(config.subagentModels).toEqual(["gpt-5.5", "gpt-5.6-sol"]);
+  });
+
+  test("PUT 9 roles returns 400 without truncating the previous catalog", async () => {
+    isolatedHome();
+    const previous = [sampleRole];
+    const config = makeConfig({ subagentRoles: [...previous] });
+    const roles = Array.from({ length: 9 }, (_, i) => ({ ...sampleRole, id: `role-${i}` }));
+    const res = await put(config, { roles });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: expect.stringContaining("8") });
+    expect(config.subagentRoles).toEqual(previous);
+  });
+
+  test("PUT a routed model on v2 without keepNativeChatGptOnV1 records a warning", async () => {
+    isolatedHome();
+    const config = makeConfig({ multiAgentMode: "v2" });
+    const res = await put(config, { roles: [sampleRole] });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean; roles: OcxSubagentRole[]; warnings: string[] };
+    expect(body.ok).toBe(true);
+    expect(body.roles).toEqual([expect.objectContaining({ id: "reviewer" })]);
+    expect(body.warnings.some(warning => /routed|v2|#92/i.test(warning))).toBe(true);
+    expect(config.subagentRoles?.[0]?.id).toBe("reviewer");
+  });
+
+  test("GET returns available models like injection-model", async () => {
+    isolatedHome();
+    const config = makeConfig({ subagentRoles: [sampleRole] });
+    const res = await get(config);
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      roles: OcxSubagentRole[];
+      available: Array<{ provider?: string; model?: string; namespaced?: string } | string>;
+      efforts: string[];
+    };
+    expect(body.roles).toEqual([expect.objectContaining({ id: "reviewer" })]);
+    expect(Array.isArray(body.available)).toBe(true);
+    expect(body.available.length).toBeGreaterThan(0);
+    expect(body.efforts).toContain("high");
+  });
+
+  test("PUT unions enabled role models into subagentModels and warns when truncated", async () => {
+    isolatedHome();
+    const config = makeConfig({
+      subagentModels: ["gpt-5.5", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.4-mini"],
+    });
+    const roles = [
+      { ...sampleRole, id: "a", model: "m-1" },
+      { ...sampleRole, id: "b", model: "m-2" },
+      { ...sampleRole, id: "c", model: "m-3" },
+      { ...sampleRole, id: "d", model: "m-4" },
+      { ...sampleRole, id: "e", model: "m-5" },
+      { ...sampleRole, id: "f", model: "m-6" },
+    ];
+    const res = await put(config, { roles });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { warnings: string[] };
+    expect(config.subagentModels).toEqual(["m-1", "m-2", "m-3", "m-4", "m-5"]);
+    expect(body.warnings.some(warning => warning.includes("f"))).toBe(true);
+  });
+});

--- a/tests/subagent-roles-api.test.ts
+++ b/tests/subagent-roles-api.test.ts
@@ -137,4 +137,28 @@ describe("/api/subagent-roles atomic validation", () => {
     expect(config.subagentModels).toEqual(["m-1", "m-2", "m-3", "m-4", "m-5"]);
     expect(body.warnings.some(warning => warning.includes("f"))).toBe(true);
   });
+
+  test("PUT remove deletes one id from the live catalog without a client snapshot", async () => {
+    isolatedHome();
+    const explorer = { ...sampleRole, id: "explorer", description: "search" };
+    const config = makeConfig({ subagentRoles: [sampleRole, explorer] });
+    const res = await put(config, { remove: "reviewer" });
+    expect(res.status).toBe(200);
+    expect(config.subagentRoles).toEqual([expect.objectContaining({ id: "explorer" })]);
+    expect(await res.json()).toMatchObject({
+      ok: true,
+      roles: [expect.objectContaining({ id: "explorer" })],
+    });
+  });
+
+  test("PUT openrouter/gpt-* on v2 records the routed warning", async () => {
+    isolatedHome();
+    const config = makeConfig({ multiAgentMode: "v2" });
+    const res = await put(config, {
+      roles: [{ ...sampleRole, model: "openrouter/gpt-5.4" }],
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { warnings: string[] };
+    expect(body.warnings.some(warning => /routed|v2|#92/i.test(warning))).toBe(true);
+  });
 });

--- a/tests/subagent-roles.test.ts
+++ b/tests/subagent-roles.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Named subagent role catalog: validation, {{roles}} rendering, roster union, CLI.
+ */
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import { handleAgentCommand } from "../src/cli/agent";
+import {
+  parseSubagentRole,
+  parseSubagentRoles,
+  renderRolesCatalog,
+  salvageSubagentRoles,
+  unionRoleModelsIntoRoster,
+} from "../src/codex/agent-roles";
+import type { OcxSubagentRole } from "../src/types";
+
+const role = (over: Partial<OcxSubagentRole> & Pick<OcxSubagentRole, "id">): OcxSubagentRole => ({
+  description: "when to use this specialist",
+  model: "gpt-5.6-luna",
+  developerInstructions: "Do the specialist work.",
+  enabled: true,
+  ...over,
+});
+
+describe("parseSubagentRoles", () => {
+  test("accepts a valid role and defaults enabled to true", () => {
+    const parsed = parseSubagentRole({
+      id: "reviewer",
+      description: "PR review",
+      model: "anthropic/claude-sonnet-5",
+      effort: "high",
+      developerInstructions: "Review the diff.",
+    });
+    expect(parsed).toEqual({
+      ok: true,
+      role: {
+        id: "reviewer",
+        description: "PR review",
+        model: "anthropic/claude-sonnet-5",
+        effort: "high",
+        developerInstructions: "Review the diff.",
+        enabled: true,
+      },
+    });
+  });
+
+  test("rejects an invalid id without accepting the rest of the catalog", () => {
+    const parsed = parseSubagentRoles([
+      role({ id: "reviewer" }),
+      { id: "Reviewer", description: "x", model: "gpt-5.6-luna", developerInstructions: "y" },
+    ]);
+    expect(parsed).toMatchObject({ ok: false, index: 1, error: expect.stringContaining("id") });
+  });
+
+  test("rejects a ninth role", () => {
+    const roles = Array.from({ length: 9 }, (_, i) => role({ id: `role-${i}` }));
+    expect(parseSubagentRoles(roles)).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("8"),
+    });
+  });
+});
+
+describe("salvageSubagentRoles", () => {
+  test("drops malformed entries and keeps valid neighbors", () => {
+    const salvaged = salvageSubagentRoles([
+      role({ id: "reviewer", model: "anthropic/claude-sonnet-5" }),
+      { id: "NOPE", description: "x", model: "gpt-5.6-luna", developerInstructions: "y" },
+    ]);
+    expect(salvaged.roles).toEqual([expect.objectContaining({ id: "reviewer" })]);
+    expect(salvaged.warnings.some(warning => warning.includes("subagentRoles"))).toBe(true);
+  });
+
+  test("preserves an explicit empty array", () => {
+    expect(salvageSubagentRoles([])).toEqual({ roles: [], warnings: [] });
+  });
+});
+
+describe("renderRolesCatalog", () => {
+  test("renders id, model, optional effort, and when-to-use description", () => {
+    const text = renderRolesCatalog([
+      role({
+        id: "reviewer",
+        model: "anthropic/claude-sonnet-5",
+        effort: "high",
+        description: "PR review",
+      }),
+      role({ id: "explorer", model: "gpt-5.6-luna", description: "read-only search" }),
+    ]);
+    expect(text).toContain("reviewer (anthropic/claude-sonnet-5, high) for PR review");
+    expect(text).toContain("explorer (gpt-5.6-luna) for read-only search");
+    expect(text).not.toContain("Do the specialist work");
+  });
+
+  test("omits disabled roles", () => {
+    const text = renderRolesCatalog([
+      role({ id: "reviewer", enabled: false, description: "PR review" }),
+      role({ id: "explorer", description: "read-only search" }),
+    ]);
+    expect(text).not.toContain("reviewer");
+    expect(text).toContain("explorer");
+  });
+});
+
+describe("unionRoleModelsIntoRoster", () => {
+  test("puts enabled role models first and truncates to 5 with dropped role ids", () => {
+    const existing = ["gpt-5.5", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.4-mini"];
+    const roles = [
+      role({ id: "reviewer", model: "anthropic/claude-sonnet-5" }),
+      role({ id: "explorer", model: "gpt-5.6-luna" }),
+      role({ id: "writer", model: "kimi/k3", enabled: false }),
+    ];
+    const result = unionRoleModelsIntoRoster(existing, roles);
+    expect(result.models).toEqual([
+      "anthropic/claude-sonnet-5",
+      "gpt-5.6-luna",
+      "gpt-5.5",
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+    ]);
+    expect(result.droppedRoleIds).toEqual([]);
+  });
+
+  test("warns with dropped role ids when more than 5 unique enabled models", () => {
+    const roles = [
+      role({ id: "a", model: "m-1" }),
+      role({ id: "b", model: "m-2" }),
+      role({ id: "c", model: "m-3" }),
+      role({ id: "d", model: "m-4" }),
+      role({ id: "e", model: "m-5" }),
+      role({ id: "f", model: "m-6" }),
+    ];
+    const result = unionRoleModelsIntoRoster([], roles);
+    expect(result.models).toEqual(["m-1", "m-2", "m-3", "m-4", "m-5"]);
+    expect(result.droppedRoleIds).toEqual(["f"]);
+  });
+});
+
+describe("ocx agent roles CLI", () => {
+  const servers: Array<ReturnType<typeof Bun.serve>> = [];
+
+  afterEach(() => {
+    for (const server of servers.splice(0)) server.stop(true);
+    process.exitCode = 0;
+  });
+
+  function fakeRuntime(responder?: (req: Request, body: unknown) => unknown) {
+    const requests: Array<{ path: string; method: string; body: unknown }> = [];
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+        const body = req.method === "GET" ? null : await req.json().catch(() => null);
+        requests.push({ path: url.pathname, method: req.method, body });
+        const custom = responder?.(req, body);
+        if (custom !== undefined) return Response.json(custom);
+        return Response.json({ ok: true, roles: [] });
+      },
+    });
+    servers.push(server);
+    return { requests, deps: { baseUrl: `http://127.0.0.1:${server.port}` } };
+  }
+
+  test("status JSON round-trips the catalog from GET /api/subagent-roles", async () => {
+    const catalog = {
+      roles: [role({ id: "reviewer", model: "anthropic/claude-sonnet-5", effort: "high", description: "PR review" })],
+    };
+    const runtime = fakeRuntime((req) => {
+      if (new URL(req.url).pathname === "/api/subagent-roles") return catalog;
+      return undefined;
+    });
+    const logs: string[] = [];
+    const logSpy = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    });
+    expect(await handleAgentCommand(["roles", "status", "--json"], runtime.deps)).toBe(0);
+    logSpy.mockRestore();
+    expect(runtime.requests).toEqual([{ path: "/api/subagent-roles", method: "GET", body: null }]);
+    expect(JSON.parse(logs.join("\n"))).toMatchObject(catalog);
+  });
+
+  test("set --file PUTs the JSON catalog without stuffing the prompt into argv", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ocx-roles-cli-"));
+    try {
+      const file = join(dir, "roles.json");
+      const payload = {
+        roles: [role({
+          id: "reviewer",
+          model: "anthropic/claude-sonnet-5",
+          developerInstructions: "Review the diff for regressions.",
+        })],
+      };
+      writeFileSync(file, JSON.stringify(payload));
+      const runtime = fakeRuntime();
+      expect(await handleAgentCommand(["roles", "set", "--file", file, "--json"], runtime.deps)).toBe(0);
+      expect(runtime.requests).toEqual([{
+        path: "/api/subagent-roles",
+        method: "PUT",
+        body: payload,
+      }]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("set reads a full JSON document from stdin", async () => {
+    const payload = { roles: [role({ id: "explorer", description: "search" })] };
+    const runtime = fakeRuntime();
+    const stdinImpl = Readable.from([JSON.stringify(payload)]) as NodeJS.ReadableStream & { isTTY?: boolean };
+    stdinImpl.isTTY = false;
+    expect(await handleAgentCommand(["roles", "set", "--json"], { ...runtime.deps, stdinImpl })).toBe(0);
+    expect(runtime.requests).toEqual([{
+      path: "/api/subagent-roles",
+      method: "PUT",
+      body: payload,
+    }]);
+  });
+
+  test("remove PUTs the catalog without the named id", async () => {
+    const existing = [
+      role({ id: "reviewer" }),
+      role({ id: "explorer" }),
+    ];
+    const runtime = fakeRuntime((req, body) => {
+      if (new URL(req.url).pathname === "/api/subagent-roles" && req.method === "GET") {
+        return { roles: existing };
+      }
+      return { ok: true, roles: (body as { roles?: unknown }).roles ?? [] };
+    });
+    expect(await handleAgentCommand(["roles", "remove", "reviewer", "--json"], runtime.deps)).toBe(0);
+    expect(runtime.requests[0]).toEqual({ path: "/api/subagent-roles", method: "GET", body: null });
+    expect(runtime.requests[1]).toEqual({
+      path: "/api/subagent-roles",
+      method: "PUT",
+      body: { roles: [role({ id: "explorer" })] },
+    });
+  });
+});

--- a/tests/subagent-roles.test.ts
+++ b/tests/subagent-roles.test.ts
@@ -8,10 +8,13 @@ import { join } from "node:path";
 import { Readable } from "node:stream";
 import { handleAgentCommand } from "../src/cli/agent";
 import {
+  isRoutedRoleModel,
   parseSubagentRole,
   parseSubagentRoles,
   renderRolesCatalog,
   salvageSubagentRoles,
+  compactRolesCatalog,
+  SUBAGENT_ROLE_MODEL_MAX,
   unionRoleModelsIntoRoster,
 } from "../src/codex/agent-roles";
 import type { OcxSubagentRole } from "../src/types";
@@ -60,6 +63,16 @@ describe("parseSubagentRoles", () => {
       ok: false,
       error: expect.stringContaining("8"),
     });
+  });
+
+  test("rejects a model id longer than the bound", () => {
+    const parsed = parseSubagentRole({
+      id: "reviewer",
+      description: "PR review",
+      model: `p/${"m".repeat(SUBAGENT_ROLE_MODEL_MAX)}`,
+      developerInstructions: "Review.",
+    });
+    expect(parsed).toMatchObject({ ok: false, error: expect.stringContaining("model") });
   });
 });
 
@@ -135,6 +148,42 @@ describe("unionRoleModelsIntoRoster", () => {
     const result = unionRoleModelsIntoRoster([], roles);
     expect(result.models).toEqual(["m-1", "m-2", "m-3", "m-4", "m-5"]);
     expect(result.droppedRoleIds).toEqual(["f"]);
+  });
+
+  test("deduplicates existing roster entries before filling the five-slot window", () => {
+    const result = unionRoleModelsIntoRoster(
+      ["a", "a", "b", "c", "d"],
+      [role({ id: "r", model: "role-model" })],
+    );
+    expect(result.models).toEqual(["role-model", "a", "b", "c", "d"]);
+  });
+});
+
+describe("isRoutedRoleModel", () => {
+  test("treats openrouter/gpt-* as routed even though the model id starts with gpt-", () => {
+    expect(isRoutedRoleModel("openrouter/gpt-5.4", { work: "acct-1" })).toBe(true);
+  });
+
+  test("treats a configured account-qualified gpt-* row as native", () => {
+    expect(isRoutedRoleModel("work/gpt-5.4", { work: "acct-1" })).toBe(false);
+  });
+
+  test("treats a bare native gpt-* id as not routed", () => {
+    expect(isRoutedRoleModel("gpt-5.4", { work: "acct-1" })).toBe(false);
+  });
+});
+
+describe("compactRolesCatalog", () => {
+  test("fits eight max-length role models into a 700-character budget", () => {
+    const longModel = `p/${"m".repeat(SUBAGENT_ROLE_MODEL_MAX - 2)}`;
+    const roles = Array.from({ length: 8 }, (_, i) => role({
+      id: `role-${i}`,
+      model: longModel,
+      description: "x".repeat(240),
+    }));
+    const text = compactRolesCatalog(roles, 700);
+    expect(text.length).toBeLessThanOrEqual(700);
+    expect(text.length).toBeGreaterThan(0);
   });
 });
 
@@ -218,23 +267,13 @@ describe("ocx agent roles CLI", () => {
     }]);
   });
 
-  test("remove PUTs the catalog without the named id", async () => {
-    const existing = [
-      role({ id: "reviewer" }),
-      role({ id: "explorer" }),
-    ];
-    const runtime = fakeRuntime((req, body) => {
-      if (new URL(req.url).pathname === "/api/subagent-roles" && req.method === "GET") {
-        return { roles: existing };
-      }
-      return { ok: true, roles: (body as { roles?: unknown }).roles ?? [] };
-    });
+  test("remove PUTs an atomic remove id rather than a whole-catalog snapshot", async () => {
+    const runtime = fakeRuntime();
     expect(await handleAgentCommand(["roles", "remove", "reviewer", "--json"], runtime.deps)).toBe(0);
-    expect(runtime.requests[0]).toEqual({ path: "/api/subagent-roles", method: "GET", body: null });
-    expect(runtime.requests[1]).toEqual({
+    expect(runtime.requests).toEqual([{
       path: "/api/subagent-roles",
       method: "PUT",
-      body: { roles: [role({ id: "explorer" })] },
-    });
+      body: { remove: "reviewer" },
+    }]);
   });
 });


### PR DESCRIPTION
## Summary

- Add a named `subagentRoles` catalog so operators can declare specialists (id, when-to-use description, model, optional effort, child developer instructions) instead of stuffing those prompts into argv. Max 8 roles and 5 unique enabled models.
- Validate the catalog atomically on write, salvage malformed persisted entries without wiping the rest of the config, and rewrite role model ids with other routed references.
- Expose GET/PUT `/api/subagent-roles` and `ocx agent roles`. v2 guidance renders enabled roles through `{{roles}}`; a custom `injectionPrompt` only includes the catalog when that placeholder is present. Native TOML projection and the dashboard editor are intentionally not in this slice.

## Verification

- `bun run typecheck`
- `bun test tests/subagent-roles.test.ts tests/subagent-roles-api.test.ts tests/config.test.ts tests/multi-agent-compat.test.ts tests/provider-id-rewrite.test.ts`
- `bun test tests/core-lab-boundary.test.ts`

Ran on macOS locally against this head. Did not claim repository CI.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

CLI `--help` / command registry mention the new `roles` subcommand. Public docs-site pages for the dashboard editor and native TOML sync belong with the stacked follow-up, not this slice.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable specialist roles for subagents, including descriptions, models, instructions, effort settings, and enabled status.
  - Added CLI commands to view, set, and remove roles using JSON files or standard input.
  - Added API management for retrieving, updating, and removing roles, with validation and model roster updates.
  - Added role catalogs and `{{roles}}` prompt support in multi-agent guidance.
  - Added migration support for role model references across provider, profile, and combo changes.

- **Bug Fixes**
  - Invalid role entries are safely discarded with warnings while valid configuration is preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
