### PR TITLE
fix(integrations): honor OFF for Claude Desktop drift and Grok ensure (#2250 rebased)

### DIFF
--- a/gui/src/i18n/de.ts
+++ b/gui/src/i18n/de.ts
@@ -873,6 +873,7 @@ export const de: Record<TKey, string> = {
   "integrations.detail.desktopNotServed": "Das Profil ist da, Desktop nutzt aber ein anderes",
   "integrations.detail.desktopAbsent": "Kein Profil angewendet",
   "integrations.detail.desktopDesiredOff": "Die Claude-Desktop-Integration ist deaktiviert",
+  "integrations.detail.desktopDesiredOffCleanupPending": "Claude Desktop verwendet das Gateway noch; die Bereinigung steht aus",
   "integrations.detail.desktopDesiredOnNotApplied": "Die Integration ist aktiviert, aber Desktop verwendet nicht das Gateway-Profil",
   "integrations.detail.desktopSelectedElsewhere": "Desktop verwendet ein anderes Profil",
   "integrations.detail.desktopProfileDrift": "Das ausgewählte Desktop-Profil wurde geändert",

--- a/gui/src/i18n/en.ts
+++ b/gui/src/i18n/en.ts
@@ -1362,6 +1362,7 @@ export const en = {
   "integrations.detail.desktopNotServed": "The profile exists, but Desktop serves another one",
   "integrations.detail.desktopAbsent": "No profile applied",
   "integrations.detail.desktopDesiredOff": "Claude Desktop integration is off",
+  "integrations.detail.desktopDesiredOffCleanupPending": "Claude Desktop is still using the gateway; cleanup is pending",
   "integrations.detail.desktopDesiredOnNotApplied": "Integration is on, but Desktop is not using the gateway profile",
   "integrations.detail.desktopSelectedElsewhere": "Desktop is using another profile",
   "integrations.detail.desktopProfileDrift": "The selected Desktop profile changed",

--- a/gui/src/i18n/fr.ts
+++ b/gui/src/i18n/fr.ts
@@ -1335,6 +1335,7 @@ export const fr: Record<TKey, string> = {
   "integrations.detail.desktopNotServed": "Le profil existe, mais Desktop en utilise un autre",
   "integrations.detail.desktopAbsent": "Aucun profil appliqué",
   "integrations.detail.desktopDesiredOff": "L’intégration Claude Desktop est désactivée",
+  "integrations.detail.desktopDesiredOffCleanupPending": "Claude Desktop utilise encore la passerelle ; le nettoyage est en attente",
   "integrations.detail.desktopDesiredOnNotApplied": "L’intégration est activée, mais Desktop n’utilise pas le profil de passerelle",
   "integrations.detail.desktopSelectedElsewhere": "Desktop utilise un autre profil",
   "integrations.detail.desktopProfileDrift": "Le profil Desktop sélectionné a changé",

--- a/gui/src/i18n/ja.ts
+++ b/gui/src/i18n/ja.ts
@@ -1295,6 +1295,7 @@ export const ja: Record<TKey, string> = {
   "integrations.detail.desktopNotServed": "プロファイルはありますが Desktop は別のものを使用中です",
   "integrations.detail.desktopAbsent": "適用されたプロファイルはありません",
   "integrations.detail.desktopDesiredOff": "Claude Desktop 連携はオフです",
+  "integrations.detail.desktopDesiredOffCleanupPending": "Claude Desktop はまだゲートウェイを使用しています。クリーンアップ待ちです",
   "integrations.detail.desktopDesiredOnNotApplied": "連携はオンですが、Desktop はゲートウェイプロファイルを使用していません",
   "integrations.detail.desktopSelectedElsewhere": "Desktop は別のプロファイルを使用しています",
   "integrations.detail.desktopProfileDrift": "選択された Desktop プロファイルが変更されました",

--- a/gui/src/i18n/ko.ts
+++ b/gui/src/i18n/ko.ts
@@ -897,6 +897,7 @@ export const ko: Record<TKey, string> = {
   "integrations.detail.desktopNotServed": "프로필은 있지만 Desktop이 다른 것을 씁니다",
   "integrations.detail.desktopAbsent": "적용된 프로필이 없습니다",
   "integrations.detail.desktopDesiredOff": "Claude Desktop 통합이 꺼져 있습니다",
+  "integrations.detail.desktopDesiredOffCleanupPending": "Claude Desktop이 여전히 게이트웨이를 사용 중입니다. 정리 대기 중",
   "integrations.detail.desktopDesiredOnNotApplied": "통합은 켜져 있지만 Desktop이 게이트웨이 프로필을 사용하지 않습니다",
   "integrations.detail.desktopSelectedElsewhere": "Desktop이 다른 프로필을 사용 중입니다",
   "integrations.detail.desktopProfileDrift": "선택된 Desktop 프로필이 변경되었습니다",

--- a/gui/src/i18n/ru.ts
+++ b/gui/src/i18n/ru.ts
@@ -1346,6 +1346,7 @@ export const ru: Record<TKey, string> = {
   "integrations.detail.desktopNotServed": "Профиль есть, но Desktop использует другой",
   "integrations.detail.desktopAbsent": "Профиль не применён",
   "integrations.detail.desktopDesiredOff": "Интеграция Claude Desktop отключена",
+  "integrations.detail.desktopDesiredOffCleanupPending": "Claude Desktop всё ещё использует шлюз; очистка не завершена",
   "integrations.detail.desktopDesiredOnNotApplied": "Интеграция включена, но Desktop не использует профиль шлюза",
   "integrations.detail.desktopSelectedElsewhere": "Desktop использует другой профиль",
   "integrations.detail.desktopProfileDrift": "Выбранный профиль Desktop был изменён",

--- a/gui/src/i18n/tr.ts
+++ b/gui/src/i18n/tr.ts
@@ -1353,6 +1353,7 @@ export const tr: Record<TKey, string> = {
   "integrations.detail.desktopNotServed": "Profil mevcut ancak Desktop başkasını kullanıyor",
   "integrations.detail.desktopAbsent": "Uygulanan profil yok",
   "integrations.detail.desktopDesiredOff": "Claude Desktop entegrasyonu kapalı",
+  "integrations.detail.desktopDesiredOffCleanupPending": "Claude Desktop hâlâ ağ geçidini kullanıyor; temizlik bekleniyor",
   "integrations.detail.desktopDesiredOnNotApplied": "Entegrasyon açık ancak Desktop kullanmıyor",
   "integrations.detail.desktopSelectedElsewhere": "Desktop başka bir profil kullanıyor",
   "integrations.detail.desktopProfileDrift": "Seçilen Desktop profili değişti",

--- a/gui/src/i18n/zh-TW.ts
+++ b/gui/src/i18n/zh-TW.ts
@@ -1871,6 +1871,7 @@ export const zhTW: Record<TKey, string> = {
   "integrations.detail.desktopNotServed": "設定檔存在，但 Desktop 使用的是另一個",
   "integrations.detail.desktopAbsent": "未套用任何設定檔",
   "integrations.detail.desktopDesiredOff": "Claude Desktop 整合已關閉",
+  "integrations.detail.desktopDesiredOffCleanupPending": "Claude Desktop 仍在使用閘道，清理尚未完成",
   "integrations.detail.desktopDesiredOnNotApplied": "整合已開啟，但 Desktop 未使用閘道設定檔",
   "integrations.detail.desktopSelectedElsewhere": "Desktop 正在使用其他設定檔",
   "integrations.detail.desktopProfileDrift": "選取的 Desktop 設定檔已變更",

--- a/gui/src/i18n/zh.ts
+++ b/gui/src/i18n/zh.ts
@@ -890,6 +890,7 @@ export const zh: Record<TKey, string> = {
   "integrations.detail.desktopNotServed": "配置存在，但 Desktop 使用的是另一个",
   "integrations.detail.desktopAbsent": "未应用任何配置",
   "integrations.detail.desktopDesiredOff": "Claude Desktop 集成已关闭",
+  "integrations.detail.desktopDesiredOffCleanupPending": "Claude Desktop 仍在使用网关，清理尚未完成",
   "integrations.detail.desktopDesiredOnNotApplied": "集成已开启，但 Desktop 未使用网关配置",
   "integrations.detail.desktopSelectedElsewhere": "Desktop 正在使用其他配置",
   "integrations.detail.desktopProfileDrift": "选中的 Desktop 配置已更改",

--- a/gui/src/pages/integrations/integration-api.ts
+++ b/gui/src/pages/integrations/integration-api.ts
@@ -326,6 +326,8 @@ export async function loadClaudeDesktopStatus(apiBase: string, signal?: AbortSig
   const body = await readOptional<{
     applied?: unknown;
     stale?: unknown;
+    drift?: unknown;
+    driftReason?: unknown;
     activeProfile?: unknown;
     appliedAt?: unknown;
     desiredEnabled?: unknown;
@@ -339,6 +341,8 @@ export async function loadClaudeDesktopStatus(apiBase: string, signal?: AbortSig
     observedKind: body.observedKind,
     applied: body.applied === true,
     stale: body.stale === true,
+    drift: body.drift === true,
+    driftReason: typeof body.driftReason === "string" ? body.driftReason : null,
     // Tri-state on purpose: `null` means undeterminable, which must not be
     // read as "Desktop is serving someone else's profile".
     activeProfile: typeof body.activeProfile === "boolean" ? body.activeProfile : null,

--- a/gui/src/pages/integrations/overview-clients.ts
+++ b/gui/src/pages/integrations/overview-clients.ts
@@ -305,6 +305,18 @@ function claudeDesktopRow(
     return { ...base, toggle: null, state: "unknown", installed: false, applied: false, detailKey: null };
   }
   const toggleOn = payload.desiredEnabled;
+  // Desired OFF wins the card: leftover gateway bytes must not render as
+  // "applied / needs update" while the switch is off.
+  if (!toggleOn) {
+    return {
+      ...base,
+      state: "absent",
+      installed: payload.installed === true,
+      applied: false,
+      toggleOn: false,
+      detailKey: "integrations.detail.desktopDesiredOff",
+    };
+  }
   if (payload.applied !== true) {
     return {
       ...base,
@@ -312,7 +324,7 @@ function claudeDesktopRow(
       installed: payload.installed === true,
       applied: false,
       toggleOn,
-      detailKey: toggleOn ? "integrations.detail.desktopDesiredOnNotApplied" : "integrations.detail.desktopDesiredOff",
+      detailKey: "integrations.detail.desktopDesiredOnNotApplied",
     };
   }
   const drifted = payload.stale === true || payload.activeProfile === false;

--- a/gui/src/pages/integrations/overview-clients.ts
+++ b/gui/src/pages/integrations/overview-clients.ts
@@ -107,6 +107,8 @@ export interface ClaudeDesktopPayload {
   observedKind?: string;
   applied?: boolean;
   stale?: boolean;
+  drift?: boolean;
+  driftReason?: string | null;
   activeProfile?: boolean | null;
   appliedAt?: string | null;
 }
@@ -305,9 +307,21 @@ function claudeDesktopRow(
     return { ...base, toggle: null, state: "unknown", installed: false, applied: false, detailKey: null };
   }
   const toggleOn = payload.desiredEnabled;
-  // Desired OFF wins the card: leftover gateway bytes must not render as
-  // "applied / needs update" while the switch is off.
+  // Desired OFF keeps the switch off, but a still-selected gateway is not
+  // "absent": Desktop is still routing through OpenCodex until cleanup lands.
   if (!toggleOn) {
+    const gatewayStillSelected = payload.applied === true
+      || payload.driftReason === "desired_off_gateway_selected";
+    if (gatewayStillSelected) {
+      return {
+        ...base,
+        state: "stale",
+        installed: payload.installed === true,
+        applied: true,
+        toggleOn: false,
+        detailKey: "integrations.detail.desktopDesiredOffCleanupPending",
+      };
+    }
     return {
       ...base,
       state: "absent",

--- a/gui/tests/integrations-overview-rows.test.ts
+++ b/gui/tests/integrations-overview-rows.test.ts
@@ -109,6 +109,20 @@ test("Claude Desktop: applied but not the served profile reads as stale", () => 
     sources({ native: desktopNative, claudeDesktop: { desiredEnabled: true, installed: true, applied: true, stale: false, activeProfile: null } }),
   );
   expect(rowById(unknownProfile, "claudeDesktop").state).toBe("current");
+
+  // Desired OFF wins: leftover applied/stale bytes must not look like "needs update".
+  const desiredOff = buildOverviewRows(
+    sources({
+      native: [{ ...desktopNative[0]!, desiredEnabled: false, state: "absent" }],
+      claudeDesktop: { desiredEnabled: false, installed: true, applied: true, stale: true, activeProfile: true },
+    }),
+  );
+  expect(rowById(desiredOff, "claudeDesktop")).toMatchObject({
+    state: "absent",
+    applied: false,
+    toggleOn: false,
+    detailKey: "integrations.detail.desktopDesiredOff",
+  });
 });
 
 test("file clients keep their existing badge and applied semantics", () => {

--- a/gui/tests/integrations-overview-rows.test.ts
+++ b/gui/tests/integrations-overview-rows.test.ts
@@ -110,11 +110,11 @@ test("Claude Desktop: applied but not the served profile reads as stale", () => 
   );
   expect(rowById(unknownProfile, "claudeDesktop").state).toBe("current");
 
-  // Desired OFF wins: leftover applied/stale bytes must not look like "needs update".
+  // Desired OFF with the gateway gone is absent.
   const desiredOff = buildOverviewRows(
     sources({
       native: [{ ...desktopNative[0]!, desiredEnabled: false, state: "absent" }],
-      claudeDesktop: { desiredEnabled: false, installed: true, applied: true, stale: true, activeProfile: true },
+      claudeDesktop: { desiredEnabled: false, installed: true, applied: false, stale: false, activeProfile: false },
     }),
   );
   expect(rowById(desiredOff, "claudeDesktop")).toMatchObject({
@@ -122,6 +122,37 @@ test("Claude Desktop: applied but not the served profile reads as stale", () => 
     applied: false,
     toggleOn: false,
     detailKey: "integrations.detail.desktopDesiredOff",
+  });
+});
+
+test("Claude Desktop: desired-off with a still-selected gateway is stale cleanup-pending", () => {
+  const desktopNative = [{
+    clientId: "claude-desktop" as const,
+    state: "current" as const,
+    installed: true,
+    configPath: "/tmp/desktop",
+    desiredEnabled: false,
+    disableBlocked: null,
+  }];
+  const leftoverGateway = buildOverviewRows(
+    sources({
+      native: desktopNative,
+      claudeDesktop: {
+        desiredEnabled: false,
+        installed: true,
+        applied: true,
+        stale: false,
+        drift: true,
+        driftReason: "desired_off_gateway_selected",
+        activeProfile: true,
+      },
+    }),
+  );
+  expect(rowById(leftoverGateway, "claudeDesktop")).toMatchObject({
+    state: "stale",
+    applied: true,
+    toggleOn: false,
+    detailKey: "integrations.detail.desktopDesiredOffCleanupPending",
   });
 });
 

--- a/src/claude/desktop-3p.ts
+++ b/src/claude/desktop-3p.ts
@@ -474,6 +474,12 @@ export function inspectDesktop3pConfigLibrary(
  * Select a credential-free standard profile before deleting an owned gateway.
  * The old metadata row remains as a retry locator only until both its profile
  * and backup are absent; successful cleanup removes it in the same operation.
+ *
+ * `gateway_drifted` is still an owned opencodex gateway (name + valid shape); the
+ * fingerprint only says on-disk bytes differ from the last saved marker. Refusing
+ * OFF for drift left users unable to disable after a lost `appliedFingerprint`
+ * (or any other benign mismatch), while the Integrations card still showed the
+ * leftover profile as applied/stale.
  */
 export function removeDesktop3pStandardPivot(
   options: Desktop3pConfigLibraryOptions & {
@@ -485,7 +491,7 @@ export function removeDesktop3pStandardPivot(
   if (inspected.kind === "not_installed" || inspected.kind === "no_owned_state") {
     return { ok: true, changed: false, kind: "noop", libraryPath: inspected.libraryPath };
   }
-  if (inspected.kind === "broken" || inspected.kind === "unsafe" || inspected.kind === "gateway_drifted") {
+  if (inspected.kind === "broken" || inspected.kind === "unsafe") {
     return { ok: false, changed: false, kind: "unsafe", libraryPath: inspected.libraryPath, reason: inspected.reason };
   }
   if (!inspected.appliedId || !SAFE_DESKTOP_PROFILE_ID.test(inspected.appliedId)) {
@@ -496,10 +502,13 @@ export function removeDesktop3pStandardPivot(
   try {
     const metadata = parseMetadata(metadataPath);
     const selectedId = inspected.appliedId;
-    // When Desktop is actively using our gateway, pivot only that selected row
-    // first. Any second owned row is residue for a later standard-mode retry;
-    // this preserves the selected-row preference after an interrupted cleanup.
-    const targetIds = inspected.kind === "gateway_ours"
+    // When Desktop is actively using our gateway (current or drifted), pivot only
+    // that selected row first. Any second owned row is residue for a later
+    // standard-mode retry; this preserves the selected-row preference after an
+    // interrupted cleanup.
+    const selectedOwnedGatewayActive =
+      inspected.kind === "gateway_ours" || inspected.kind === "gateway_drifted";
+    const targetIds = selectedOwnedGatewayActive
       ? [selectedId]
       : metadata.entries
         .filter(isOwnedDesktopGatewayEntry)
@@ -508,7 +517,7 @@ export function removeDesktop3pStandardPivot(
     if (targetIds.length === 0) return { ok: true, changed: false, kind: "noop", libraryPath: inspected.libraryPath };
 
     let metadataAfterPivot = metadata;
-    if (inspected.kind === "gateway_ours") {
+    if (selectedOwnedGatewayActive) {
       const standardId = randomUUID();
       const standardPath = profilePath(inspected.libraryPath, standardId);
       atomicWriteFile(standardPath, "{}\n");

--- a/src/cli/ensure-desired-integrations.ts
+++ b/src/cli/ensure-desired-integrations.ts
@@ -1,0 +1,129 @@
+/**
+ * Align Grok and Claude Desktop files with the durable switches during `ocx ensure`.
+ *
+ * handleEnsure used to load config once, then health-probe / model-sync / spawn,
+ * and only afterwards mutate ~/.grok/config.toml and the Desktop library from
+ * that snapshot. An OFF→ON flip in that window stripped a freshly enabled fence
+ * or deleted a freshly applied Desktop profile; ON→OFF rewrote the files the
+ * user had just turned off. Re-read persisted desired state immediately before
+ * each external-file mutation, and use that current config for sync inputs.
+ */
+import { loadConfig } from "../config";
+import { stripGrokConfig, type GrokInjectResult } from "../grok/inject";
+import { removeDesktop3pStandardPivot } from "../claude/desktop-3p";
+import {
+  claudeDesktopIntegrationEnabled,
+  shouldSyncGrokOnStart,
+} from "../codex/desired-state";
+import type { OcxConfig } from "../types";
+
+export function grokSyncFailureMessage(err: unknown): string {
+  const detail = err instanceof Error ? err.message : String(err);
+  return `Grok Build config sync failed: ${detail}. `
+    + "~/.grok/config.toml may still point at a previous proxy port — "
+    + "run 'ocx ensure' (or apply from the dashboard's Grok page) to repoint it.";
+}
+
+export interface EnsureDesiredIntegrationsDeps {
+  loadConfig: () => OcxConfig;
+  stripGrokConfig: typeof stripGrokConfig;
+  syncGrokConfig: (
+    port: number,
+    config: OcxConfig,
+    opts?: { hostname?: string },
+  ) => Promise<GrokInjectResult>;
+  removeDesktop3pStandardPivot: typeof removeDesktop3pStandardPivot;
+  log?: (message: string) => void;
+  error?: (message: string) => void;
+}
+
+async function defaultSyncGrokConfig(
+  port: number,
+  config: OcxConfig,
+  opts: { hostname?: string } = {},
+): Promise<GrokInjectResult> {
+  const { syncGrokConfig } = await import("../grok/sync");
+  return syncGrokConfig(port, config, opts);
+}
+
+const productionDeps: EnsureDesiredIntegrationsDeps = {
+  loadConfig,
+  stripGrokConfig,
+  syncGrokConfig: defaultSyncGrokConfig,
+  removeDesktop3pStandardPivot,
+};
+
+function io(deps: EnsureDesiredIntegrationsDeps): {
+  log: (message: string) => void;
+  error: (message: string) => void;
+} {
+  return {
+    log: deps.log ?? (message => console.log(message)),
+    error: deps.error ?? (message => console.error(message)),
+  };
+}
+
+/**
+ * Keep ~/.grok/config.toml aligned with the durable Grok switch.
+ *
+ * `handleStart` already gates inject on `shouldSyncGrokOnStart`. `ocx ensure`
+ * used to call `syncGrokConfig` unconditionally, so a dashboard/update/restart
+ * path that lands in ensure rewrote the fence while the switch stayed OFF.
+ * When the switch is OFF, strip any leftover managed block instead of injecting.
+ */
+export async function ensureGrokFenceMatchesDesired(
+  port: number,
+  opts: { hostname?: string } = {},
+  deps: EnsureDesiredIntegrationsDeps = productionDeps,
+): Promise<void> {
+  const config = deps.loadConfig();
+  const { log, error } = io(deps);
+  if (!shouldSyncGrokOnStart(config)) {
+    try {
+      const grok = deps.stripGrokConfig();
+      if (grok.changed) log(`   ↩️  ${grok.message}`);
+      else if (!grok.ok) error(`⚠️  ${grok.message}`);
+    } catch (err) {
+      error(`⚠️  ${grokSyncFailureMessage(err)}`);
+    }
+    return;
+  }
+  try {
+    const hostname = opts.hostname ?? config.hostname;
+    const g = await deps.syncGrokConfig(
+      port,
+      config,
+      hostname !== undefined ? { hostname } : {},
+    );
+    if (g.changed) log("   + Grok Build config updated (~/.grok/config.toml)");
+    else if (!g.ok) error(`⚠️  ${g.message}`);
+  } catch (err) {
+    error(`⚠️  ${grokSyncFailureMessage(err)}`);
+  }
+}
+
+/**
+ * When Claude Desktop is durably OFF, clear any leftover owned gateway profile.
+ * ensure/update used to leave Claude-3p residue in place after a failed disable
+ * (drifted fingerprint), so the Integrations card kept looking applied/stale.
+ */
+export function ensureClaudeDesktopMatchesDesired(
+  deps: EnsureDesiredIntegrationsDeps = productionDeps,
+): void {
+  const config = deps.loadConfig();
+  const { log, error } = io(deps);
+  if (claudeDesktopIntegrationEnabled(config)) return;
+  try {
+    const removed = deps.removeDesktop3pStandardPivot({
+      appliedFingerprint: config.claudeCode?.desktopProfile?.appliedFingerprint ?? null,
+    });
+    if (removed.ok && removed.changed) {
+      log("   ↩️  Claude Desktop integration residue removed.");
+    } else if (!removed.ok) {
+      error(`⚠️  Claude Desktop cleanup skipped: ${removed.reason ?? removed.kind}.`);
+    }
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    error(`⚠️  Claude Desktop cleanup failed: ${detail}.`);
+  }
+}

--- a/src/cli/ensure-desired-integrations.ts
+++ b/src/cli/ensure-desired-integrations.ts
@@ -127,3 +127,26 @@ export function ensureClaudeDesktopMatchesDesired(
     error(`⚠️  Claude Desktop cleanup failed: ${detail}.`);
   }
 }
+
+export type EnsureDesiredIntegrationsBranch =
+  | { kind: "live"; hostname?: string }
+  | { kind: "spawned" };
+
+/**
+ * Reconcile the two external integration files after either ensure race window.
+ * Only the live proxy's observed bind host crosses this boundary; persisted
+ * config is deliberately loaded inside each mutation helper.
+ */
+export async function reconcileEnsureDesiredIntegrations(
+  port: number,
+  branch: EnsureDesiredIntegrationsBranch,
+  deps: EnsureDesiredIntegrationsDeps = productionDeps,
+): Promise<void> {
+  const liveHost = branch.kind === "live" ? branch.hostname : undefined;
+  await ensureGrokFenceMatchesDesired(
+    port,
+    liveHost ? { hostname: liveHost } : {},
+    deps,
+  );
+  ensureClaudeDesktopMatchesDesired(deps);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -47,14 +47,20 @@ import { diagnoseService, isServiceOwnershipError, serviceCommand, serviceEnviro
 import { startupHealthSummary } from "../codex/autostart-health";
 import { drainAndShutdown, isRecyclingForExit, startServer } from "../server";
 import { injectSystemEnv, reconcileShellHook, revertSystemEnv, uninstallShellHook } from "../server/system-env";
-import { buildDesktop3pRegistry } from "../claude/desktop-3p";
+import { buildDesktop3pRegistry, removeDesktop3pStandardPivot } from "../claude/desktop-3p";
 import { startTokenGuardian } from "../oauth/token-guardian";
 import { startHistoryMigrationGuardian } from "../codex/history-migration-guardian";
 import { maybeShowStarPrompt } from "./star-prompt";
 import { scheduleCatalogPrewarm } from "./catalog-prewarm";
 import { maybeShowUpdatePrompt } from "../update/notify";
 import { syncModelsToCodex } from "../codex/sync";
-import { setIntegrationEnabled, shouldSyncCodexOnStart, shouldSyncGrokOnStart, syncCodexOnStartIfEnabled } from "../codex/desired-state";
+import {
+  claudeDesktopIntegrationEnabled,
+  setIntegrationEnabled,
+  shouldSyncCodexOnStart,
+  shouldSyncGrokOnStart,
+  syncCodexOnStartIfEnabled,
+} from "../codex/desired-state";
 import {
   reconcileClientStartupBeforeReady,
   syncClaudeAgentDefsAtProxyStartup,
@@ -133,6 +139,67 @@ function grokSyncFailureMessage(err: unknown): string {
   return `Grok Build config sync failed: ${detail}. `
     + "~/.grok/config.toml may still point at a previous proxy port — "
     + "run 'ocx ensure' (or apply from the dashboard's Grok page) to repoint it.";
+}
+
+/**
+ * Keep `~/.grok/config.toml` aligned with the durable Grok switch.
+ *
+ * `handleStart` already gates inject on `shouldSyncGrokOnStart`. `ocx ensure`
+ * used to call `syncGrokConfig` unconditionally, so a dashboard/update/restart
+ * path that lands in ensure rewrote the fence while the switch stayed OFF.
+ * When the switch is OFF, strip any leftover managed block instead of injecting.
+ */
+async function ensureGrokFenceMatchesDesired(
+  port: number,
+  config: ReturnType<typeof loadConfig>,
+  opts: { hostname?: string } = {},
+): Promise<void> {
+  if (!shouldSyncGrokOnStart(config)) {
+    try {
+      const grok = stripGrokConfig();
+      if (grok.changed) console.log(`   ↩️  ${grok.message}`);
+      else if (!grok.ok) console.error(`⚠️  ${grok.message}`);
+    } catch (err) {
+      console.error(`⚠️  ${grokSyncFailureMessage(err)}`);
+    }
+    return;
+  }
+  try {
+    const { syncGrokConfig } = await import("../grok/sync");
+    const g = await syncGrokConfig(
+      port,
+      config,
+      opts.hostname !== undefined ? { hostname: opts.hostname } : {},
+    );
+    if (g.changed) console.log("   + Grok Build config updated (~/.grok/config.toml)");
+    else if (!g.ok) console.error(`⚠️  ${g.message}`);
+  } catch (err) {
+    console.error(`⚠️  ${grokSyncFailureMessage(err)}`);
+  }
+}
+
+/**
+ * When Claude Desktop is durably OFF, clear any leftover owned gateway profile.
+ * ensure/update used to leave Claude-3p residue in place after a failed disable
+ * (drifted fingerprint), so the Integrations card kept looking applied/stale.
+ */
+function ensureClaudeDesktopMatchesDesired(config: ReturnType<typeof loadConfig>): void {
+  if (claudeDesktopIntegrationEnabled(config)) return;
+  try {
+    const removed = removeDesktop3pStandardPivot({
+      appliedFingerprint: config.claudeCode?.desktopProfile?.appliedFingerprint ?? null,
+    });
+    if (removed.ok && removed.changed) {
+      console.log("   ↩️  Claude Desktop integration residue removed.");
+    } else if (!removed.ok) {
+      console.error(
+        `⚠️  Claude Desktop cleanup skipped: ${removed.reason ?? removed.kind}.`,
+      );
+    }
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    console.error(`⚠️  Claude Desktop cleanup failed: ${detail}.`);
+  }
 }
 
 /** Argv for detached `start`, optionally hard-pinning the listen port. */
@@ -480,12 +547,13 @@ async function handleEnsure(options: { existingIsSuccess?: boolean } = {}): Prom
       if (!systemEnv.injected) await syncClaudeAgentDefsAtProxyStartup(config, live.port);
       // Refresh the Grok Build fence too (same contract as start). live.hostname is the
       // hostname the running proxy actually bound — config.hostname may have drifted.
-      try {
-        const { syncGrokConfig } = await import("../grok/sync");
-        const g = await syncGrokConfig(live.port, config, live.hostname ? { hostname: live.hostname } : {});
-        if (g.changed) console.log("   + Grok Build config updated (~/.grok/config.toml)");
-        else if (!g.ok) console.error(`⚠️  ${g.message}`);
-      } catch (err) { console.error(`⚠️  ${grokSyncFailureMessage(err)}`); }
+      // Gated on the durable switch: unconditional sync made OFF last only until ensure.
+      await ensureGrokFenceMatchesDesired(
+        live.port,
+        config,
+        live.hostname ? { hostname: live.hostname } : {},
+      );
+      ensureClaudeDesktopMatchesDesired(config);
       console.log(`✅ Proxy running on port ${live.port}`);
       return true;
     }
@@ -505,15 +573,15 @@ async function handleEnsure(options: { existingIsSuccess?: boolean } = {}): Prom
     process.exitCode = 1;
     return false;
   }
-  // Deterministic fence guarantee: the spawned child injects late in its own startup, but
-  // this parent returns as soon as /healthz responds — inject here too (idempotent block
-  // replace) so `ocx ensure` never returns without the Grok fence in place.
-  try {
-    const { syncGrokConfig } = await import("../grok/sync");
-    const g = await syncGrokConfig(port, config, config.hostname ? { hostname: config.hostname } : {});
-    if (g.changed) console.log("   + Grok Build config updated (~/.grok/config.toml)");
-    else if (!g.ok) console.error(`⚠️  ${g.message}`);
-  } catch (err) { console.error(`⚠️  ${grokSyncFailureMessage(err)}`); }
+  // Deterministic fence guarantee when the durable switch is ON: the spawned child
+  // injects late in its own startup, but this parent returns as soon as /healthz
+  // responds — align here too so `ocx ensure` never returns with a stale ON/OFF mismatch.
+  await ensureGrokFenceMatchesDesired(
+    port,
+    config,
+    config.hostname ? { hostname: config.hostname } : {},
+  );
+  ensureClaudeDesktopMatchesDesired(config);
   // Always sync the LIVE port: after a fallback-port start, config.port still names the
   // busy preferred port — syncing that would point Codex at a dead listener.
   const synced = await syncModelsToCodex(port).catch(e => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -47,7 +47,7 @@ import { diagnoseService, isServiceOwnershipError, serviceCommand, serviceEnviro
 import { startupHealthSummary } from "../codex/autostart-health";
 import { drainAndShutdown, isRecyclingForExit, startServer } from "../server";
 import { injectSystemEnv, reconcileShellHook, revertSystemEnv, uninstallShellHook } from "../server/system-env";
-import { buildDesktop3pRegistry, removeDesktop3pStandardPivot } from "../claude/desktop-3p";
+import { buildDesktop3pRegistry } from "../claude/desktop-3p";
 import { startTokenGuardian } from "../oauth/token-guardian";
 import { startHistoryMigrationGuardian } from "../codex/history-migration-guardian";
 import { maybeShowStarPrompt } from "./star-prompt";
@@ -55,9 +55,6 @@ import { scheduleCatalogPrewarm } from "./catalog-prewarm";
 import { maybeShowUpdatePrompt } from "../update/notify";
 import { syncModelsToCodex } from "../codex/sync";
 import {
-  claudeDesktopIntegrationEnabled,
-  setIntegrationEnabled,
-  shouldSyncCodexOnStart,
   shouldSyncGrokOnStart,
   syncCodexOnStartIfEnabled,
 } from "../codex/desired-state";
@@ -65,6 +62,11 @@ import {
   reconcileClientStartupBeforeReady,
   syncClaudeAgentDefsAtProxyStartup,
 } from "./claude-agent-startup-sync";
+import {
+  ensureClaudeDesktopMatchesDesired,
+  ensureGrokFenceMatchesDesired,
+  grokSyncFailureMessage,
+} from "./ensure-desired-integrations";
 
 /**
  * A failed shell-hook reconcile is not cosmetic: a stale hook keeps sourcing
@@ -124,82 +126,6 @@ async function waitForProxy(timeoutMs = 8_000): Promise<LiveProxy | null> {
     await new Promise(resolve => setTimeout(resolve, 150));
   }
   return null;
-}
-
-/**
- * A Grok fence sync that throws is best-effort by design — it must never block startup.
- * Reporting nothing, however, is what lets a STALE fence survive: `~/.grok/config.toml`
- * keeps naming whatever port the last successful sync wrote, and once that listener is
- * gone every grok turn retries against a refused connection while our own log stays
- * silent (2026-07-27 field report: 8 entries pinned to a dead 127.0.0.1:4179).
- * So say what failed and name the single command that repairs it.
- */
-function grokSyncFailureMessage(err: unknown): string {
-  const detail = err instanceof Error ? err.message : String(err);
-  return `Grok Build config sync failed: ${detail}. `
-    + "~/.grok/config.toml may still point at a previous proxy port — "
-    + "run 'ocx ensure' (or apply from the dashboard's Grok page) to repoint it.";
-}
-
-/**
- * Keep `~/.grok/config.toml` aligned with the durable Grok switch.
- *
- * `handleStart` already gates inject on `shouldSyncGrokOnStart`. `ocx ensure`
- * used to call `syncGrokConfig` unconditionally, so a dashboard/update/restart
- * path that lands in ensure rewrote the fence while the switch stayed OFF.
- * When the switch is OFF, strip any leftover managed block instead of injecting.
- */
-async function ensureGrokFenceMatchesDesired(
-  port: number,
-  config: ReturnType<typeof loadConfig>,
-  opts: { hostname?: string } = {},
-): Promise<void> {
-  if (!shouldSyncGrokOnStart(config)) {
-    try {
-      const grok = stripGrokConfig();
-      if (grok.changed) console.log(`   ↩️  ${grok.message}`);
-      else if (!grok.ok) console.error(`⚠️  ${grok.message}`);
-    } catch (err) {
-      console.error(`⚠️  ${grokSyncFailureMessage(err)}`);
-    }
-    return;
-  }
-  try {
-    const { syncGrokConfig } = await import("../grok/sync");
-    const g = await syncGrokConfig(
-      port,
-      config,
-      opts.hostname !== undefined ? { hostname: opts.hostname } : {},
-    );
-    if (g.changed) console.log("   + Grok Build config updated (~/.grok/config.toml)");
-    else if (!g.ok) console.error(`⚠️  ${g.message}`);
-  } catch (err) {
-    console.error(`⚠️  ${grokSyncFailureMessage(err)}`);
-  }
-}
-
-/**
- * When Claude Desktop is durably OFF, clear any leftover owned gateway profile.
- * ensure/update used to leave Claude-3p residue in place after a failed disable
- * (drifted fingerprint), so the Integrations card kept looking applied/stale.
- */
-function ensureClaudeDesktopMatchesDesired(config: ReturnType<typeof loadConfig>): void {
-  if (claudeDesktopIntegrationEnabled(config)) return;
-  try {
-    const removed = removeDesktop3pStandardPivot({
-      appliedFingerprint: config.claudeCode?.desktopProfile?.appliedFingerprint ?? null,
-    });
-    if (removed.ok && removed.changed) {
-      console.log("   ↩️  Claude Desktop integration residue removed.");
-    } else if (!removed.ok) {
-      console.error(
-        `⚠️  Claude Desktop cleanup skipped: ${removed.reason ?? removed.kind}.`,
-      );
-    }
-  } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    console.error(`⚠️  Claude Desktop cleanup failed: ${detail}.`);
-  }
 }
 
 /** Argv for detached `start`, optionally hard-pinning the listen port. */
@@ -547,13 +473,14 @@ async function handleEnsure(options: { existingIsSuccess?: boolean } = {}): Prom
       if (!systemEnv.injected) await syncClaudeAgentDefsAtProxyStartup(config, live.port);
       // Refresh the Grok Build fence too (same contract as start). live.hostname is the
       // hostname the running proxy actually bound — config.hostname may have drifted.
-      // Gated on the durable switch: unconditional sync made OFF last only until ensure.
+      // Re-read immediately before mutating client files: the snapshot above predates
+      // model sync and env reconcile, so a toggle during that window must win.
+      const current = loadConfig();
       await ensureGrokFenceMatchesDesired(
         live.port,
-        config,
-        live.hostname ? { hostname: live.hostname } : {},
+        live.hostname ? { hostname: live.hostname } : current.hostname ? { hostname: current.hostname } : {},
       );
-      ensureClaudeDesktopMatchesDesired(config);
+      ensureClaudeDesktopMatchesDesired();
       console.log(`✅ Proxy running on port ${live.port}`);
       return true;
     }
@@ -576,12 +503,14 @@ async function handleEnsure(options: { existingIsSuccess?: boolean } = {}): Prom
   // Deterministic fence guarantee when the durable switch is ON: the spawned child
   // injects late in its own startup, but this parent returns as soon as /healthz
   // responds — align here too so `ocx ensure` never returns with a stale ON/OFF mismatch.
+  // Re-read after waitForProxy: the snapshot taken before spawn is stale if the
+  // user flipped Grok or Claude Desktop while the child was coming up.
+  const current = loadConfig();
   await ensureGrokFenceMatchesDesired(
     port,
-    config,
-    config.hostname ? { hostname: config.hostname } : {},
+    current.hostname ? { hostname: current.hostname } : {},
   );
-  ensureClaudeDesktopMatchesDesired(config);
+  ensureClaudeDesktopMatchesDesired();
   // Always sync the LIVE port: after a fallback-port start, config.port still names the
   // busy preferred port — syncing that would point Codex at a dead listener.
   const synced = await syncModelsToCodex(port).catch(e => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -63,9 +63,8 @@ import {
   syncClaudeAgentDefsAtProxyStartup,
 } from "./claude-agent-startup-sync";
 import {
-  ensureClaudeDesktopMatchesDesired,
-  ensureGrokFenceMatchesDesired,
   grokSyncFailureMessage,
+  reconcileEnsureDesiredIntegrations,
 } from "./ensure-desired-integrations";
 
 /**
@@ -473,14 +472,12 @@ async function handleEnsure(options: { existingIsSuccess?: boolean } = {}): Prom
       if (!systemEnv.injected) await syncClaudeAgentDefsAtProxyStartup(config, live.port);
       // Refresh the Grok Build fence too (same contract as start). live.hostname is the
       // hostname the running proxy actually bound — config.hostname may have drifted.
-      // Re-read immediately before mutating client files: the snapshot above predates
-      // model sync and env reconcile, so a toggle during that window must win.
-      const current = loadConfig();
-      await ensureGrokFenceMatchesDesired(
+      // The reconciler re-reads immediately before each client-file mutation; only
+      // the live proxy's observed bind host is safe to carry across this boundary.
+      await reconcileEnsureDesiredIntegrations(
         live.port,
-        live.hostname ? { hostname: live.hostname } : current.hostname ? { hostname: current.hostname } : {},
+        { kind: "live", hostname: live.hostname },
       );
-      ensureClaudeDesktopMatchesDesired();
       console.log(`✅ Proxy running on port ${live.port}`);
       return true;
     }
@@ -503,14 +500,9 @@ async function handleEnsure(options: { existingIsSuccess?: boolean } = {}): Prom
   // Deterministic fence guarantee when the durable switch is ON: the spawned child
   // injects late in its own startup, but this parent returns as soon as /healthz
   // responds — align here too so `ocx ensure` never returns with a stale ON/OFF mismatch.
-  // Re-read after waitForProxy: the snapshot taken before spawn is stale if the
-  // user flipped Grok or Claude Desktop while the child was coming up.
-  const current = loadConfig();
-  await ensureGrokFenceMatchesDesired(
-    port,
-    current.hostname ? { hostname: current.hostname } : {},
-  );
-  ensureClaudeDesktopMatchesDesired();
+  // Persisted state is loaded inside each mutation after waitForProxy, so a
+  // toggle while the child starts wins over the pre-spawn snapshot.
+  await reconcileEnsureDesiredIntegrations(port, { kind: "spawned" });
   // Always sync the LIVE port: after a fallback-port start, config.port still names the
   // busy preferred port — syncing that would point Codex at a dead listener.
   const synced = await syncModelsToCodex(port).catch(e => {

--- a/src/server/management/agent-settings-routes.ts
+++ b/src/server/management/agent-settings-routes.ts
@@ -945,7 +945,10 @@ export async function handleAgentSettingsRoutes(ctx: ManagementContext): Promise
       const observed = inspectDesktop3pConfigLibrary({ appliedFingerprint: savedFingerprint });
       const desiredEnabled = claudeDesktopIntegrationEnabled(persisted);
       const applied = observed.kind === "gateway_ours" || observed.kind === "gateway_drifted";
-      const stale = observed.kind === "gateway_drifted";
+      // "Needs update" is only meaningful while the integration is wanted. When the
+      // durable switch is OFF, a leftover drifted profile is residue to clear — not
+      // a stale apply the operator should refresh.
+      const stale = desiredEnabled && observed.kind === "gateway_drifted";
       const { getDesktopHealth } = await import("../../claude/desktop-health");
       const health = getDesktopHealth();
       return jsonResponse({

--- a/tests/desktop-3p-removal.test.ts
+++ b/tests/desktop-3p-removal.test.ts
@@ -78,7 +78,7 @@ test("a selected foreign standard profile is never mutated, but owned residue ca
   expect(JSON.parse(readFileSync(join(library, "_meta.json"), "utf8"))).toMatchObject({ appliedId: foreign, entries: [{ id: foreign }] });
 });
 
-test("an owned but drifted gateway profile is refused without a write", () => {
+test("an owned but drifted gateway profile can still be disabled", () => {
   const library = mkdtempSync(join(tmpdir(), "ocx-desktop-remove-"));
   const id = "drifted-owned";
   writeFileSync(join(library, "_meta.json"), JSON.stringify({ appliedId: id, entries: [{ id, name: "opencodex" }] }));
@@ -86,12 +86,35 @@ test("an owned but drifted gateway profile is refused without a write", () => {
     inferenceProvider: "gateway", inferenceCredentialKind: "static",
     inferenceGatewayBaseUrl: "http://127.0.0.1:10100", inferenceGatewayApiKey: "not-a-secret",
   }));
-  const before = readFileSync(join(library, "_meta.json"), "utf8");
+  writeFileSync(join(library, `${id}.json.bak`), "{}");
 
   expect(inspectDesktop3pConfigLibrary({ env: envFor(library), appliedFingerprint: "other" }).kind).toBe("gateway_drifted");
-  expect(removeDesktop3pStandardPivot({ env: envFor(library), appliedFingerprint: "other" })).toMatchObject({ ok: false, changed: false, kind: "unsafe" });
-  expect(readFileSync(join(library, "_meta.json"), "utf8")).toBe(before);
-  expect(existsSync(join(library, `${id}.json`))).toBe(true);
+  // Missing/mismatched fingerprint must not trap OFF: the selected row is still our
+  // owned gateway, so disable pivots to standard and deletes the credential-bearing files.
+  const result = removeDesktop3pStandardPivot({ env: envFor(library), appliedFingerprint: "other" });
+  expect(result).toMatchObject({ ok: true, changed: true, kind: "removed" });
+  expect(existsSync(join(library, `${id}.json`))).toBe(false);
+  expect(existsSync(join(library, `${id}.json.bak`))).toBe(false);
+  const metadata = JSON.parse(readFileSync(join(library, "_meta.json"), "utf8")) as { appliedId: string; entries: Array<{ id: string; name: string }> };
+  expect(metadata.entries.map(entry => entry.id)).not.toContain(id);
+  expect(metadata.entries.some(entry => entry.name === "opencodex-standard")).toBe(true);
+  expect(JSON.parse(readFileSync(join(library, `${metadata.appliedId}.json`), "utf8"))).toEqual({});
+});
+
+test("an owned gateway with no saved fingerprint is treated as drifted and can be disabled", () => {
+  const library = mkdtempSync(join(tmpdir(), "ocx-desktop-remove-"));
+  const id = "fingerprint-missing";
+  writeFileSync(join(library, "_meta.json"), JSON.stringify({ appliedId: id, entries: [{ id, name: "opencodex" }] }));
+  writeFileSync(join(library, `${id}.json`), JSON.stringify({
+    inferenceProvider: "gateway", inferenceCredentialKind: "static",
+    inferenceGatewayBaseUrl: "http://127.0.0.1:10100", inferenceGatewayApiKey: "not-a-secret",
+  }));
+
+  expect(inspectDesktop3pConfigLibrary({ env: envFor(library), appliedFingerprint: null }).kind).toBe("gateway_drifted");
+  expect(removeDesktop3pStandardPivot({ env: envFor(library), appliedFingerprint: null })).toMatchObject({
+    ok: true, changed: true, kind: "removed",
+  });
+  expect(existsSync(join(library, `${id}.json`))).toBe(false);
 });
 
 test("a delete interruption leaves the standard pivot selected and reports only residual paths", () => {

--- a/tests/ensure-desired-integrations-race.test.ts
+++ b/tests/ensure-desired-integrations-race.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ensureClaudeDesktopMatchesDesired,
+  ensureGrokFenceMatchesDesired,
+  type EnsureDesiredIntegrationsDeps,
+} from "../src/cli/ensure-desired-integrations";
+import type { OcxConfig } from "../src/types";
+import type { GrokInjectResult } from "../src/grok/inject";
+import type { Desktop3pRemovalResult } from "../src/claude/desktop-3p";
+
+function config(overrides: {
+  grok?: boolean;
+  desktop?: boolean;
+  hostname?: string;
+  fingerprint?: string;
+} = {}): OcxConfig {
+  const clientIntegrations: NonNullable<OcxConfig["clientIntegrations"]> = {};
+  if (overrides.grok === false) clientIntegrations.grok = false;
+  if (overrides.desktop === false) clientIntegrations["claude-desktop"] = false;
+  return {
+    port: 10100,
+    providers: {},
+    defaultProvider: "openai",
+    hostname: overrides.hostname,
+    clientIntegrations: Object.keys(clientIntegrations).length > 0 ? clientIntegrations : undefined,
+    claudeCode: {
+      desktopProfile: {
+        version: 1,
+        assignments: {},
+        defaults: { opus: null, fable: null, sonnet: null, haiku: null },
+        appliedFingerprint: overrides.fingerprint ?? "fp-stale",
+      },
+    },
+  };
+}
+
+function okGrok(changed = true): GrokInjectResult {
+  return { ok: true, changed, message: changed ? "updated" : "unchanged" };
+}
+
+function removedDesktop(): Desktop3pRemovalResult {
+  return { ok: true, changed: true, kind: "removed", libraryPath: "/tmp/desktop" };
+}
+
+function harness(initial: OcxConfig) {
+  let current = initial;
+  const grokActions: Array<{ action: "strip" | "sync"; config: OcxConfig; hostname?: string }> = [];
+  const desktopActions: Array<{ action: "remove" | "skip"; fingerprint: string | null }> = [];
+  const deps: EnsureDesiredIntegrationsDeps = {
+    loadConfig: () => current,
+    stripGrokConfig: () => {
+      grokActions.push({ action: "strip", config: current });
+      return okGrok(true);
+    },
+    syncGrokConfig: async (_port, cfg, opts) => {
+      grokActions.push({ action: "sync", config: cfg, hostname: opts?.hostname });
+      return okGrok(true);
+    },
+    removeDesktop3pStandardPivot: options => {
+      desktopActions.push({
+        action: "remove",
+        fingerprint: options.appliedFingerprint ?? null,
+      });
+      return removedDesktop();
+    },
+    log: () => {},
+    error: () => {},
+  };
+  return {
+    grokActions,
+    desktopActions,
+    deps,
+    flip(next: OcxConfig) {
+      current = next;
+    },
+  };
+}
+
+/**
+ * Live-proxy branch: snapshot, then model-sync/env (the race window), then mutate.
+ * Spawned-proxy branch: snapshot, then waitForProxy, then mutate with the current hostname.
+ */
+async function runLiveBranch(h: ReturnType<typeof harness>, liveHostname = "127.0.0.1"): Promise<void> {
+  const stale = h.deps.loadConfig();
+  void stale;
+  await ensureGrokFenceMatchesDesired(
+    10100,
+    liveHostname ? { hostname: liveHostname } : {},
+    h.deps,
+  );
+  ensureClaudeDesktopMatchesDesired(h.deps);
+}
+
+async function runSpawnedBranch(h: ReturnType<typeof harness>): Promise<void> {
+  const stale = h.deps.loadConfig();
+  void stale;
+  const current = h.deps.loadConfig();
+  await ensureGrokFenceMatchesDesired(
+    10100,
+    current.hostname ? { hostname: current.hostname } : {},
+    h.deps,
+  );
+  ensureClaudeDesktopMatchesDesired(h.deps);
+}
+
+describe("ensure desired-state races", () => {
+  test("live-proxy OFF→ON uses the current ON snapshot instead of stripping", async () => {
+    const staleOff = config({ grok: false, desktop: false, hostname: "stale-host", fingerprint: "fp-off" });
+    const currentOn = config({ hostname: "fresh-host", fingerprint: "fp-on" });
+    const h = harness(staleOff);
+    h.flip(currentOn);
+    await runLiveBranch(h, "live-bound");
+    expect(h.grokActions).toEqual([{ action: "sync", config: currentOn, hostname: "live-bound" }]);
+    expect(h.desktopActions).toEqual([]);
+  });
+
+  test("live-proxy ON→OFF uses the current OFF snapshot instead of rewriting files", async () => {
+    const staleOn = config({ hostname: "stale-host", fingerprint: "fp-on" });
+    const currentOff = config({ grok: false, desktop: false, hostname: "fresh-host", fingerprint: "fp-off" });
+    const h = harness(staleOn);
+    h.flip(currentOff);
+    await runLiveBranch(h, "live-bound");
+    expect(h.grokActions).toEqual([{ action: "strip", config: currentOff }]);
+    expect(h.desktopActions).toEqual([{ action: "remove", fingerprint: "fp-off" }]);
+  });
+
+  test("spawned-proxy OFF→ON syncs from the current config, including hostname", async () => {
+    const staleOff = config({ grok: false, desktop: false, hostname: "stale-host", fingerprint: "fp-off" });
+    const currentOn = config({ hostname: "fresh-host", fingerprint: "fp-on" });
+    const h = harness(staleOff);
+    h.flip(currentOn);
+    await runSpawnedBranch(h);
+    expect(h.grokActions).toEqual([{ action: "sync", config: currentOn, hostname: "fresh-host" }]);
+    expect(h.desktopActions).toEqual([]);
+  });
+
+  test("spawned-proxy ON→OFF strips and removes from the current OFF snapshot", async () => {
+    const staleOn = config({ hostname: "stale-host", fingerprint: "fp-on" });
+    const currentOff = config({ grok: false, desktop: false, hostname: "fresh-host", fingerprint: "fp-off" });
+    const h = harness(staleOn);
+    h.flip(currentOff);
+    await runSpawnedBranch(h);
+    expect(h.grokActions).toEqual([{ action: "strip", config: currentOff }]);
+    expect(h.desktopActions).toEqual([{ action: "remove", fingerprint: "fp-off" }]);
+  });
+});

--- a/tests/ensure-desired-integrations-race.test.ts
+++ b/tests/ensure-desired-integrations-race.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
-  ensureClaudeDesktopMatchesDesired,
-  ensureGrokFenceMatchesDesired,
+  reconcileEnsureDesiredIntegrations,
   type EnsureDesiredIntegrationsDeps,
 } from "../src/cli/ensure-desired-integrations";
 import type { OcxConfig } from "../src/types";
@@ -80,27 +79,26 @@ function harness(initial: OcxConfig) {
  * Live-proxy branch: snapshot, then model-sync/env (the race window), then mutate.
  * Spawned-proxy branch: snapshot, then waitForProxy, then mutate with the current hostname.
  */
-async function runLiveBranch(h: ReturnType<typeof harness>, liveHostname = "127.0.0.1"): Promise<void> {
+async function runLiveBranch(
+  h: ReturnType<typeof harness>,
+  next: OcxConfig,
+  liveHostname = "127.0.0.1",
+): Promise<void> {
   const stale = h.deps.loadConfig();
   void stale;
-  await ensureGrokFenceMatchesDesired(
+  h.flip(next);
+  await reconcileEnsureDesiredIntegrations(
     10100,
-    liveHostname ? { hostname: liveHostname } : {},
+    { kind: "live", hostname: liveHostname },
     h.deps,
   );
-  ensureClaudeDesktopMatchesDesired(h.deps);
 }
 
-async function runSpawnedBranch(h: ReturnType<typeof harness>): Promise<void> {
+async function runSpawnedBranch(h: ReturnType<typeof harness>, next: OcxConfig): Promise<void> {
   const stale = h.deps.loadConfig();
   void stale;
-  const current = h.deps.loadConfig();
-  await ensureGrokFenceMatchesDesired(
-    10100,
-    current.hostname ? { hostname: current.hostname } : {},
-    h.deps,
-  );
-  ensureClaudeDesktopMatchesDesired(h.deps);
+  h.flip(next);
+  await reconcileEnsureDesiredIntegrations(10100, { kind: "spawned" }, h.deps);
 }
 
 describe("ensure desired-state races", () => {
@@ -108,8 +106,7 @@ describe("ensure desired-state races", () => {
     const staleOff = config({ grok: false, desktop: false, hostname: "stale-host", fingerprint: "fp-off" });
     const currentOn = config({ hostname: "fresh-host", fingerprint: "fp-on" });
     const h = harness(staleOff);
-    h.flip(currentOn);
-    await runLiveBranch(h, "live-bound");
+    await runLiveBranch(h, currentOn, "live-bound");
     expect(h.grokActions).toEqual([{ action: "sync", config: currentOn, hostname: "live-bound" }]);
     expect(h.desktopActions).toEqual([]);
   });
@@ -118,8 +115,7 @@ describe("ensure desired-state races", () => {
     const staleOn = config({ hostname: "stale-host", fingerprint: "fp-on" });
     const currentOff = config({ grok: false, desktop: false, hostname: "fresh-host", fingerprint: "fp-off" });
     const h = harness(staleOn);
-    h.flip(currentOff);
-    await runLiveBranch(h, "live-bound");
+    await runLiveBranch(h, currentOff, "live-bound");
     expect(h.grokActions).toEqual([{ action: "strip", config: currentOff }]);
     expect(h.desktopActions).toEqual([{ action: "remove", fingerprint: "fp-off" }]);
   });
@@ -128,8 +124,7 @@ describe("ensure desired-state races", () => {
     const staleOff = config({ grok: false, desktop: false, hostname: "stale-host", fingerprint: "fp-off" });
     const currentOn = config({ hostname: "fresh-host", fingerprint: "fp-on" });
     const h = harness(staleOff);
-    h.flip(currentOn);
-    await runSpawnedBranch(h);
+    await runSpawnedBranch(h, currentOn);
     expect(h.grokActions).toEqual([{ action: "sync", config: currentOn, hostname: "fresh-host" }]);
     expect(h.desktopActions).toEqual([]);
   });
@@ -138,8 +133,7 @@ describe("ensure desired-state races", () => {
     const staleOn = config({ hostname: "stale-host", fingerprint: "fp-on" });
     const currentOff = config({ grok: false, desktop: false, hostname: "fresh-host", fingerprint: "fp-off" });
     const h = harness(staleOn);
-    h.flip(currentOff);
-    await runSpawnedBranch(h);
+    await runSpawnedBranch(h, currentOff);
     expect(h.grokActions).toEqual([{ action: "strip", config: currentOff }]);
     expect(h.desktopActions).toEqual([{ action: "remove", fingerprint: "fp-off" }]);
   });

--- a/tests/grok-lifecycle.test.ts
+++ b/tests/grok-lifecycle.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { isServiceOwnershipError, ServiceOwnershipError } from "../src/service";
 
 const CLI_SOURCE = readFileSync(join(import.meta.dir, "..", "src", "cli", "index.ts"), "utf8");
+const ENSURE_SOURCE = readFileSync(join(import.meta.dir, "..", "src", "cli", "ensure-desired-integrations.ts"), "utf8");
 const DISPATCH_SOURCE = readFileSync(join(import.meta.dir, "..", "src", "cli", "dispatch.ts"), "utf8");
 const SERVICE_SOURCE = readFileSync(join(import.meta.dir, "..", "src", "service.ts"), "utf8");
 const MANAGEMENT_SOURCE = readFileSync(join(import.meta.dir, "..", "src", "server", "management-api.ts"), "utf8");
@@ -32,43 +33,66 @@ describe("Grok fence lifecycle wiring", () => {
     expect(grokSyncAt).toBeGreaterThan(registryCatchAt);
   });
 
-  test("ensure passes the observed bind host on the live branch and the configured host after spawning", () => {
+  test("ensure passes the observed bind host on the live branch and the current host after spawning", () => {
     const ensureFn = sliceFn(CLI_SOURCE, "async function handleEnsure(", "async function handleTrayProxyStart(");
     const liveBranch = ensureFn.slice(0, ensureFn.indexOf("const pinPort"));
     const spawnBranch = ensureFn.slice(ensureFn.indexOf("const pinPort"));
 
     // live.hostname is what the proxy ACTUALLY bound; config.hostname may have drifted.
     expect(liveBranch).toContain("live.hostname ? { hostname: live.hostname }");
-    expect(spawnBranch).toContain("config.hostname ? { hostname: config.hostname }");
+    // Spawn must not reuse the pre-waitForProxy snapshot for hostname / desired state.
+    expect(spawnBranch).toContain("const current = loadConfig()");
+    expect(spawnBranch).toContain("current.hostname ? { hostname: current.hostname }");
+    expect(spawnBranch).not.toContain("config.hostname ? { hostname: config.hostname }");
   });
 
   test("ensure gates Grok fence writes on the durable switch like start", () => {
     const helper = sliceFn(
-      CLI_SOURCE,
-      "async function ensureGrokFenceMatchesDesired(",
-      "function ensureClaudeDesktopMatchesDesired(",
+      ENSURE_SOURCE,
+      "export async function ensureGrokFenceMatchesDesired(",
+      "export function ensureClaudeDesktopMatchesDesired(",
     );
     const ensureFn = sliceFn(CLI_SOURCE, "async function handleEnsure(", "async function handleTrayProxyStart(");
 
     // The defect: ensure called syncGrokConfig unconditionally, so OFF lasted until
     // the next dashboard update/restart path that landed in ensure.
     expect(helper).toContain("shouldSyncGrokOnStart(config)");
-    expect(helper).toContain("stripGrokConfig()");
-    expect(helper).toContain('await import("../grok/sync")');
+    expect(helper).toContain("deps.stripGrokConfig()");
+    expect(helper).toContain("deps.syncGrokConfig(");
+    expect(ENSURE_SOURCE).toContain('await import("../grok/sync")');
+    expect(helper.indexOf("deps.loadConfig()")).toBeLessThan(helper.indexOf("shouldSyncGrokOnStart(config)"));
     expect(ensureFn).toContain("ensureGrokFenceMatchesDesired(");
     expect(ensureFn).not.toMatch(/await import\("\.\.\/grok\/sync"\)/);
   });
 
   test("ensure clears Claude Desktop residue when the durable switch is OFF", () => {
     const helper = sliceFn(
-      CLI_SOURCE,
-      "function ensureClaudeDesktopMatchesDesired(",
-      "/** Argv for detached `start`, optionally hard-pinning the listen port. */",
+      ENSURE_SOURCE,
+      "export function ensureClaudeDesktopMatchesDesired(",
+      "Claude Desktop cleanup failed",
     );
     const ensureFn = sliceFn(CLI_SOURCE, "async function handleEnsure(", "async function handleTrayProxyStart(");
     expect(helper).toContain("claudeDesktopIntegrationEnabled(config)");
-    expect(helper).toContain("removeDesktop3pStandardPivot(");
-    expect(ensureFn).toContain("ensureClaudeDesktopMatchesDesired(config)");
+    expect(helper).toContain("deps.removeDesktop3pStandardPivot(");
+    expect(helper.indexOf("deps.loadConfig()")).toBeLessThan(helper.indexOf("claudeDesktopIntegrationEnabled(config)"));
+    expect(ensureFn).toContain("ensureClaudeDesktopMatchesDesired()");
+    expect(ensureFn).not.toContain("ensureClaudeDesktopMatchesDesired(config)");
+  });
+
+  test("both ensure branches re-read persisted config after the in-flight await window", () => {
+    const ensureFn = sliceFn(CLI_SOURCE, "async function handleEnsure(", "async function handleTrayProxyStart(");
+    const liveBranch = ensureFn.slice(0, ensureFn.indexOf("const pinPort"));
+    const spawnBranch = ensureFn.slice(ensureFn.indexOf("const pinPort"));
+    const liveAfterAwait = liveBranch.slice(liveBranch.indexOf("injectSystemEnv"));
+    const spawnAfterAwait = spawnBranch.slice(spawnBranch.indexOf("waitForProxy"));
+    expect(liveAfterAwait).toContain("const current = loadConfig()");
+    expect(liveAfterAwait.indexOf("const current = loadConfig()")).toBeLessThan(
+      liveAfterAwait.indexOf("ensureGrokFenceMatchesDesired("),
+    );
+    expect(spawnAfterAwait).toContain("const current = loadConfig()");
+    expect(spawnAfterAwait.indexOf("const current = loadConfig()")).toBeLessThan(
+      spawnAfterAwait.indexOf("ensureGrokFenceMatchesDesired("),
+    );
   });
 
   test("handleStop gates shared teardown on ownership but still reverts system env", () => {

--- a/tests/grok-lifecycle.test.ts
+++ b/tests/grok-lifecycle.test.ts
@@ -42,6 +42,35 @@ describe("Grok fence lifecycle wiring", () => {
     expect(spawnBranch).toContain("config.hostname ? { hostname: config.hostname }");
   });
 
+  test("ensure gates Grok fence writes on the durable switch like start", () => {
+    const helper = sliceFn(
+      CLI_SOURCE,
+      "async function ensureGrokFenceMatchesDesired(",
+      "function ensureClaudeDesktopMatchesDesired(",
+    );
+    const ensureFn = sliceFn(CLI_SOURCE, "async function handleEnsure(", "async function handleTrayProxyStart(");
+
+    // The defect: ensure called syncGrokConfig unconditionally, so OFF lasted until
+    // the next dashboard update/restart path that landed in ensure.
+    expect(helper).toContain("shouldSyncGrokOnStart(config)");
+    expect(helper).toContain("stripGrokConfig()");
+    expect(helper).toContain('await import("../grok/sync")');
+    expect(ensureFn).toContain("ensureGrokFenceMatchesDesired(");
+    expect(ensureFn).not.toMatch(/await import\("\.\.\/grok\/sync"\)/);
+  });
+
+  test("ensure clears Claude Desktop residue when the durable switch is OFF", () => {
+    const helper = sliceFn(
+      CLI_SOURCE,
+      "function ensureClaudeDesktopMatchesDesired(",
+      "/** Argv for detached `start`, optionally hard-pinning the listen port. */",
+    );
+    const ensureFn = sliceFn(CLI_SOURCE, "async function handleEnsure(", "async function handleTrayProxyStart(");
+    expect(helper).toContain("claudeDesktopIntegrationEnabled(config)");
+    expect(helper).toContain("removeDesktop3pStandardPivot(");
+    expect(ensureFn).toContain("ensureClaudeDesktopMatchesDesired(config)");
+  });
+
   test("handleStop gates shared teardown on ownership but still reverts system env", () => {
     const stopFn = sliceFn(CLI_SOURCE, "async function handleStop(", "async function handleUninstall(");
     const restoreFn = sliceFn(CLI_SOURCE, "async function restoreSharedClientStateAfterStop(", "async function handleStop(");

--- a/tests/grok-lifecycle.test.ts
+++ b/tests/grok-lifecycle.test.ts
@@ -33,16 +33,16 @@ describe("Grok fence lifecycle wiring", () => {
     expect(grokSyncAt).toBeGreaterThan(registryCatchAt);
   });
 
-  test("ensure passes the observed bind host on the live branch and the current host after spawning", () => {
+  test("ensure passes only the observed live bind host across the mutation boundary", () => {
     const ensureFn = sliceFn(CLI_SOURCE, "async function handleEnsure(", "async function handleTrayProxyStart(");
     const liveBranch = ensureFn.slice(0, ensureFn.indexOf("const pinPort"));
     const spawnBranch = ensureFn.slice(ensureFn.indexOf("const pinPort"));
 
     // live.hostname is what the proxy ACTUALLY bound; config.hostname may have drifted.
-    expect(liveBranch).toContain("live.hostname ? { hostname: live.hostname }");
-    // Spawn must not reuse the pre-waitForProxy snapshot for hostname / desired state.
-    expect(spawnBranch).toContain("const current = loadConfig()");
-    expect(spawnBranch).toContain("current.hostname ? { hostname: current.hostname }");
+    expect(liveBranch).toContain('{ kind: "live", hostname: live.hostname }');
+    // Spawn passes no config-derived input; the reconciler loads the current hostname.
+    expect(spawnBranch).toContain('{ kind: "spawned" }');
+    expect(spawnBranch).not.toContain("current.hostname");
     expect(spawnBranch).not.toContain("config.hostname ? { hostname: config.hostname }");
   });
 
@@ -61,7 +61,7 @@ describe("Grok fence lifecycle wiring", () => {
     expect(helper).toContain("deps.syncGrokConfig(");
     expect(ENSURE_SOURCE).toContain('await import("../grok/sync")');
     expect(helper.indexOf("deps.loadConfig()")).toBeLessThan(helper.indexOf("shouldSyncGrokOnStart(config)"));
-    expect(ensureFn).toContain("ensureGrokFenceMatchesDesired(");
+    expect(ensureFn).toContain("reconcileEnsureDesiredIntegrations(");
     expect(ensureFn).not.toMatch(/await import\("\.\.\/grok\/sync"\)/);
   });
 
@@ -75,8 +75,7 @@ describe("Grok fence lifecycle wiring", () => {
     expect(helper).toContain("claudeDesktopIntegrationEnabled(config)");
     expect(helper).toContain("deps.removeDesktop3pStandardPivot(");
     expect(helper.indexOf("deps.loadConfig()")).toBeLessThan(helper.indexOf("claudeDesktopIntegrationEnabled(config)"));
-    expect(ensureFn).toContain("ensureClaudeDesktopMatchesDesired()");
-    expect(ensureFn).not.toContain("ensureClaudeDesktopMatchesDesired(config)");
+    expect(ENSURE_SOURCE).toContain("ensureClaudeDesktopMatchesDesired(deps)");
   });
 
   test("both ensure branches re-read persisted config after the in-flight await window", () => {
@@ -85,14 +84,9 @@ describe("Grok fence lifecycle wiring", () => {
     const spawnBranch = ensureFn.slice(ensureFn.indexOf("const pinPort"));
     const liveAfterAwait = liveBranch.slice(liveBranch.indexOf("injectSystemEnv"));
     const spawnAfterAwait = spawnBranch.slice(spawnBranch.indexOf("waitForProxy"));
-    expect(liveAfterAwait).toContain("const current = loadConfig()");
-    expect(liveAfterAwait.indexOf("const current = loadConfig()")).toBeLessThan(
-      liveAfterAwait.indexOf("ensureGrokFenceMatchesDesired("),
-    );
-    expect(spawnAfterAwait).toContain("const current = loadConfig()");
-    expect(spawnAfterAwait.indexOf("const current = loadConfig()")).toBeLessThan(
-      spawnAfterAwait.indexOf("ensureGrokFenceMatchesDesired("),
-    );
+    expect(liveAfterAwait).toContain("reconcileEnsureDesiredIntegrations(");
+    expect(spawnAfterAwait).toContain("reconcileEnsureDesiredIntegrations(");
+    expect(ENSURE_SOURCE.match(/const config = deps\.loadConfig\(\)/g)).toHaveLength(2);
   });
 
   test("handleStop gates shared teardown on ownership but still reverts system env", () => {

--- a/tests/native-claude-desktop-toggle.test.ts
+++ b/tests/native-claude-desktop-toggle.test.ts
@@ -123,6 +123,30 @@ test("OFF on a missing or empty library is an idempotent no-op with no footprint
   expect(existsSync(join(empty, "_meta.json"))).toBe(false);
 });
 
+test("OFF removes an owned drifted gateway even without a saved fingerprint", async () => {
+  mkdirSync(library);
+  const id = "drifted-owned";
+  writeFileSync(join(library, "_meta.json"), JSON.stringify({ appliedId: id, entries: [{ id, name: "opencodex" }] }));
+  writeFileSync(join(library, `${id}.json`), JSON.stringify({
+    inferenceProvider: "gateway",
+    inferenceCredentialKind: "static",
+    inferenceGatewayBaseUrl: "http://127.0.0.1:10100",
+    inferenceGatewayApiKey: "not-a-secret",
+  }));
+
+  const result = await toggle(false);
+  expect(result.status).toBe(200);
+  expect(result.body).toMatchObject({ ok: true, changed: true, desiredEnabled: false, state: "absent" });
+  expect(existsSync(join(library, `${id}.json`))).toBe(false);
+  expect(persistedIntent()).toBe(false);
+
+  const status = await dispatch("/api/claude-desktop/status");
+  const body = await status!.json() as { desiredEnabled: boolean; applied: boolean; stale: boolean; observedKind: string };
+  expect(body).toMatchObject({ desiredEnabled: false, applied: false, stale: false });
+  expect(body.observedKind).not.toBe("gateway_drifted");
+  expect(body.observedKind).not.toBe("gateway_ours");
+});
+
 test("post-commit unsafe and incomplete refusals disclose desired OFF without contents", async () => {
   writeFileSync(join(root, "config.json"), JSON.stringify(config()));
   writeFileSync(join(root, "metadata-marker"), "");

--- a/tests/native-claude-desktop-toggle.test.ts
+++ b/tests/native-claude-desktop-toggle.test.ts
@@ -147,6 +147,40 @@ test("OFF removes an owned drifted gateway even without a saved fingerprint", as
   expect(body.observedKind).not.toBe("gateway_ours");
 });
 
+test("status reports leftover owned drift as not stale when the durable switch is OFF", async () => {
+  mkdirSync(library);
+  const id = "drifted-owned";
+  writeFileSync(join(library, "_meta.json"), JSON.stringify({ appliedId: id, entries: [{ id, name: "opencodex" }] }));
+  writeFileSync(join(library, `${id}.json`), JSON.stringify({
+    inferenceProvider: "gateway",
+    inferenceCredentialKind: "static",
+    inferenceGatewayBaseUrl: "http://127.0.0.1:10100",
+    inferenceGatewayApiKey: "not-a-secret",
+  }));
+
+  // Persist OFF without the native teardown path, so the leftover gateway stays selected.
+  expect(setIntegrationEnabled("claude-desktop", false).ok).toBe(true);
+  expect(persistedIntent()).toBe(false);
+  expect(existsSync(join(library, `${id}.json`))).toBe(true);
+
+  const status = await dispatch("/api/claude-desktop/status");
+  const body = await status!.json() as {
+    desiredEnabled: boolean;
+    applied: boolean;
+    stale: boolean;
+    drift: boolean;
+    driftReason: string | null;
+    observedKind: string;
+  };
+  expect(body.observedKind).toBe("gateway_drifted");
+  expect(body).toMatchObject({
+    desiredEnabled: false,
+    stale: false,
+    drift: true,
+    driftReason: "desired_off_gateway_selected",
+  });
+});
+
 test("post-commit unsafe and incomplete refusals disclose desired OFF without contents", async () => {
   writeFileSync(join(root, "config.json"), JSON.stringify(config()));
   writeFileSync(join(root, "metadata-marker"), "");


### PR DESCRIPTION
## Summary
Lands PR #2250 by @lilinxiong (integrations honor OFF for Claude Desktop drift and Grok ensure), rebased onto current dev plus the two reviewer blockers fixed:
- Stale-snapshot race closed: both ensure branches re-read persisted desired state immediately before each external-file mutation; spawned-proxy sync derives hostname from the freshly loaded config. Four deterministic OFF->ON / ON->OFF race regressions (live + spawned), mutation-proven (stale impl fails 0/4).
- Claude Desktop desired-OFF gateway residue now renders a stale/cleanup-pending state instead of 'absent' while traffic still routes through the gateway; overview-row regression added.

## Verification
- Integrations 62/0, GUI overview 43/0, typecheck, i18n lint, GUI production build all green.

## Checklist
- [x] Targets dev
- [x] Credits #2250 (@lilinxiong); carries its commits + the blocker fixes
