### PR TITLE
fix(zcode): use openai-compatible provider protocol to restore prefix caching

### DIFF
--- a/src/clients/config-export.ts
+++ b/src/clients/config-export.ts
@@ -937,10 +937,10 @@ export interface McodeGeneratedConfig {
 
 /**
  * ZCode's `~/.zcode/v2/config.json` provider entry (observed schema, validated
- * live against ZCode 3.7.7). `kind: "anthropic"` selects the Anthropic
- * Messages protocol, which the proxy serves at `/v1/messages`. `apiKeyRequired`
- * keeps ZCode's UI from prompting for a key it does not need on loopback; the
- * serialized key is always the non-secret loopback placeholder.
+ * live against ZCode 3.7.7 / 3.8.1). `kind: "openai-compatible"` selects the
+ * OpenAI Chat Completions protocol, which the proxy serves at `/v1/chat/completions`.
+ * `apiKeyRequired` keeps ZCode's UI from prompting for a key it does not need on
+ * loopback; the serialized key is always the non-secret loopback placeholder.
  */
 export interface ZcodeModelEntry {
   name?: string;
@@ -950,7 +950,7 @@ export interface ZcodeModelEntry {
 
 export interface ZcodeProviderBlock {
   name: "OpenCodex";
-  kind: "anthropic";
+  kind: "openai-compatible";
   enabled: true;
   source: "custom";
   options: {
@@ -1298,10 +1298,10 @@ function buildMcodeClientConfig(ctx: ExportContext): McodeGeneratedConfig {
 }
 
 /**
- * ZCode dials the Anthropic Messages surface, so `baseURL` is the proxy origin
- * without the `/v1` suffix (ZCode appends `/v1/messages` itself — the same
- * shape its builtin Z.ai providers use). Model ids are the proxy's canonical
- * `provider/id` selectors, which `/v1/messages` resolves directly. Context
+ * ZCode dials the OpenAI Chat Completions surface (`openai-compatible`), which
+ * appends `/chat/completions` to `baseURL`. We supply `baseURL` with the `/v1`
+ * suffix so requests land on `/v1/chat/completions`. Model ids are the proxy's canonical
+ * `provider/id` selectors, which `/v1/chat/completions` resolves directly. Context
  * limits follow the authoritative-window rule: a model without one ships
  * without `limit` rather than guessing. Modalities are ZCode's observed
  * `text`-floor vocabulary; image-capable rows advertise image input.
@@ -1330,12 +1330,12 @@ function buildZcodeClientConfig(ctx: ExportContext): ZcodeGeneratedConfig {
     provider: {
       [OPENCODE_PROVIDER_ID]: {
         name: "OpenCodex",
-        kind: "anthropic",
+        kind: "openai-compatible",
         enabled: true,
         source: "custom",
         options: {
           apiKey: LOOPBACK_API_KEY_PLACEHOLDER,
-          baseURL: ctx.baseUrl.replace(/\/v1\/?$/, ""),
+          baseURL: ctx.baseUrl.replace(/\/v1\/?$/, "") + "/v1",
           apiKeyRequired: true,
         },
         models,

--- a/tests/zcode-client.test.ts
+++ b/tests/zcode-client.test.ts
@@ -43,12 +43,12 @@ describe("ZCode client config", () => {
     expect(Object.keys(document)).toEqual(["provider"]);
     const provider = document.provider[OPENCODE_PROVIDER_ID]!;
     expect(provider.name).toBe("OpenCodex");
-    expect(provider.kind).toBe("anthropic");
+    expect(provider.kind).toBe("openai-compatible");
     expect(provider.enabled).toBe(true);
     expect(provider.source).toBe("custom");
     expect(provider.options).toEqual({
       apiKey: LOOPBACK_API_KEY_PLACEHOLDER,
-      baseURL: "http://127.0.0.1:10100",
+      baseURL: "http://127.0.0.1:10100/v1",
       apiKeyRequired: true,
     });
   });


### PR DESCRIPTION
## Summary

- Updated ZCode client integration (`src/clients/config-export.ts`) from `kind: "anthropic"` to `kind: "openai-compatible"`.
- Ensured `baseURL` is exported with the `/v1` suffix (i.e. `http://127.0.0.1:10100/v1`), which aligns with ZCode's `/chat/completions` path concatenation.
- Updated JSDoc comments describing ZCode client integration to document the `openai-compatible` protocol and `/v1/chat/completions` target.
- Restores DeepSeek / Chinese LLM prefix KV cache hit rate from ~80% back to 97%~99.7% in multi-turn tool calling sessions, and prevents `conflict: foreign-edit` when users select Chat Completions in ZCode.

## Verification

- Ran unit tests: `bun test tests/zcode-client.test.ts` (10 pass, 0 fail).
- Live verified against ZCode 3.8.1 with DeepSeek V4 Flash: verified continuous prefix cache hit rate above 99% across 20+ turns.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ZCode exports now target OpenAI-compatible Chat Completions endpoints.
  * Provider configurations use the `/v1` API path for request routing.

* **Updates**
  * ZCode provider metadata now identifies the provider as `openai-compatible`.
  * Existing model limits and supported modalities remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->