### PR TITLE
fix(responses): capability-gate external_web_access in the canonical-only table

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -166,16 +166,20 @@ function stripInvalidItemIds(body: unknown): unknown {
  * with its own traversal, and the traversals disagreed about which containers they covered; a new
  * one should be a row here instead. `toolTypes` omitted means the field is private on any tool.
  */
-const CANONICAL_ONLY_TOOL_FIELDS: readonly { field: string; toolTypes?: ReadonlySet<string> }[] = [
+const CANONICAL_ONLY_TOOL_FIELDS: readonly { field: string; toolTypes?: ReadonlySet<string>; capabilityGated?: boolean }[] = [
   // ChatGPT's browsing policy bit. The public hosted tool is enabled by its presence alone.
-  { field: "external_web_access", toolTypes: new Set(["web_search", "web_search_preview"]) },
+  // OWNERSHIP: official OpenAI API-key traffic and unclassified gateways ACCEPT this field, so
+  // it is only stripped when the provider capability denies it (supportsOpenAiWebSearchToolFields
+  // === false), matching stripOpenAiOnlyWebSearchFields; see
+  // tests/responses-routed-web-search-fields.test.ts.
+  { field: "external_web_access", toolTypes: new Set(["web_search", "web_search_preview"]), capabilityGated: true },
   // Deferred-discovery marker. `activateDeferredTool` clears it only for tools a `tool_search_output`
   // already loaded, so a still-deferred declaration — including one promoted out of a namespace
   // group — otherwise reaches the wire carrying it.
   { field: "defer_loading" },
 ];
 
-function stripCanonicalOnlyToolFields(body: unknown): unknown {
+function stripCanonicalOnlyToolFields(body: unknown, includeCapabilityGated: boolean): unknown {
   if (!isPlainObject(body)) return body;
 
   const rewriteTools = (tools: unknown[]): unknown[] => {
@@ -183,7 +187,8 @@ function stripCanonicalOnlyToolFields(body: unknown): unknown {
     const rewritten = tools.map(tool => {
       if (!isPlainObject(tool)) return tool;
       let next = tool;
-      for (const { field, toolTypes } of CANONICAL_ONLY_TOOL_FIELDS) {
+      for (const { field, toolTypes, capabilityGated } of CANONICAL_ONLY_TOOL_FIELDS) {
+        if (capabilityGated && !includeCapabilityGated) continue;
         if (!Object.hasOwn(next, field)) continue;
         if (toolTypes && (typeof next.type !== "string" || !toolTypes.has(next.type))) continue;
         const { [field]: _private, ...rest } = next;
@@ -1722,7 +1727,7 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
         outBody = rewritten.body;
         convertedRoutedNamespaceToolAliases = rewritten.aliases;
         // Last, so promoted namespace children are also cleared of Codex-private fields.
-        outBody = stripCanonicalOnlyToolFields(outBody);
+        outBody = stripCanonicalOnlyToolFields(outBody, provider.supportsOpenAiWebSearchToolFields === false);
       }
       const threadServingIdentityChanged = parsed._stripReasoningEncryptedContent === true;
       const sanitizedBody = normalizeToolSchemas(stripSparkCompatibility(stripUnsupportedReasoningParams(stripItemIdsWhenUnstored(stripInvalidItemIds(stripUnsupportedHostedTools(sanitizeReasoningInputContent(scrubOcxCompactionItems(

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -976,13 +976,16 @@ describe("OpenAI Responses passthrough sanitization", () => {
     expect(body.tools[0]).toMatchObject({ type: "image_generation" });
   });
 
-  test("drops ChatGPT's external_web_access hint but keeps routed web search", () => {
-    const adapter = createResponsesPassthroughAdapter({
-      adapter: "openai-responses",
-      baseUrl: "https://api.x.ai/v1",
-      authMode: "key" as const,
-      apiKey: "xai-test",
-    });
+ test("drops ChatGPT's external_web_access hint but keeps routed web search", () => {
+   const adapter = createResponsesPassthroughAdapter({
+     adapter: "openai-responses",
+     baseUrl: "https://api.x.ai/v1",
+     authMode: "key" as const,
+     apiKey: "xai-test",
+      // The registry declares this denial for xAI; the strip is capability-driven, not
+      // hostname-driven (official OpenAI API-key traffic keeps the fields).
+      supportsOpenAiWebSearchToolFields: false,
+   });
     const request = adapter.buildRequest({
       modelId: "grok-4.6",
       context: { messages: [] },
@@ -1033,13 +1036,14 @@ describe("OpenAI Responses passthrough sanitization", () => {
   // `activateDeferredTool` clears `defer_loading` only for tools a `tool_search_output` already
   // loaded, so the first turn of a deferred catalog — and any child promoted out of a namespace
   // group — otherwise carries the private field to a gateway that rejects unknown arguments.
-  test("drops Codex-private tool fields from routed declarations", () => {
-    const adapter = createResponsesPassthroughAdapter({
-      adapter: "openai-responses",
-      baseUrl: "https://api.x.ai/v1",
-      authMode: "key" as const,
-      apiKey: "xai-test",
-    });
+ test("drops Codex-private tool fields from routed declarations", () => {
+   const adapter = createResponsesPassthroughAdapter({
+     adapter: "openai-responses",
+     baseUrl: "https://api.x.ai/v1",
+     authMode: "key" as const,
+     apiKey: "xai-test",
+      supportsOpenAiWebSearchToolFields: false,
+   });
     const request = adapter.buildRequest({
       modelId: "grok-4.6",
       context: { messages: [] },


### PR DESCRIPTION
## Summary
Post-merge reconciliation between #2238 and #2258: the consolidated series' unconditional CANONICAL_ONLY_TOOL_FIELDS strip removed `external_web_access` from official OpenAI API-key traffic, breaking #2238's capability contract (caught by the lidge full-suite lagging gate: 1 fail / 14025).
- `external_web_access` in the declarative table is now `capabilityGated: true`: stripped only when the provider declares `supportsOpenAiWebSearchToolFields: false` (the xAI registry entry does), matching `stripOpenAiOnlyWebSearchFields` ownership.
- `defer_loading` stays unconditional (private on any tool for every noncanonical gateway).
- The two passthrough tests using bare xAI configs now declare the registry capability explicitly — the strip is capability-driven, not hostname-driven.

## Verification
- 387/0 across six suites: routed web-search fields (incl. the OpenAI retain regression), namespace compat, passthrough sanitization, redact, fastwire policy, chat reasoning-streaming E2E.
- bun x tsc --noEmit clean.

## Checklist
- [x] Targets dev
- [x] Regression that caught this stays red-provable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when sending web-search tool settings to providers with different capability support.
  * Preserved supported web-search fields while removing unsupported settings to prevent request errors.
* **Tests**
  * Updated coverage to verify correct handling of provider-specific web-search capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->