### PR TITLE
test(xai): declare the web-search field capability in the raw streaming config

### DIFF
--- a/tests/server-xai-responses-streaming.test.ts
+++ b/tests/server-xai-responses-streaming.test.ts
@@ -56,8 +56,11 @@ function config(): OcxConfig {
         baseUrl: "https://api.x.ai/v1",
         authMode: "oauth",
         models: ["grok-4.6"],
-        modelAdapters: { "grok-4.6": "openai-responses" },
-        modelSupportsServiceTier: { "grok-4.6": false },
+       modelAdapters: { "grok-4.6": "openai-responses" },
+       modelSupportsServiceTier: { "grok-4.6": false },
+        // Raw test config bypasses registry enrichment; production xai providers get
+        // this denial from the registry entry (see derive.ts enrichProviderFromRegistry).
+        supportsOpenAiWebSearchToolFields: false,
       },
     },
   } as OcxConfig;


### PR DESCRIPTION
## Summary
Follow-up to #2262: the xAI Responses streaming test injects a raw provider config that bypasses registry enrichment, so the now-capability-gated external_web_access strip stopped firing there (lidge dev3: 1 fail / 14025). The test config now declares supportsOpenAiWebSearchToolFields: false exactly as production enrichment does (derive.ts backfills it from the registry entry).

## Verification
- tests/server-xai-responses-streaming.test.ts 3/0; tsc clean.

## Checklist
- [x] Targets dev
- [x] Test-only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated xAI streaming test configuration to explicitly disable OpenAI web search tool field support.
  * Preserved existing streaming and namespace-restoration coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->