### PR TITLE
fix(lab): name the ACL failure code in the publisher key error

### DIFF
--- a/src/lab/public/signature.ts
+++ b/src/lab/public/signature.ts
@@ -52,6 +52,22 @@ function publisherForPrivateKey(privateKeyPem: string): PublicPublisherV1 {
   };
 }
 
+/**
+ * The bounded errno-shaped code from a failed ACL harden, or null when the cause
+ * carries none.
+ *
+ * Only the code is allowed into the message. `hardenSecretPath` already sanitizes
+ * its own diagnostic prose, but this error is what reaches a CI log, so what
+ * crosses that boundary is re-checked here rather than trusted: an errno code has
+ * no separator, no lowercase and a bounded length, and therefore cannot carry the
+ * key pathname or the username component inside it.
+ */
+function aclFailureCode(error: unknown): string | null {
+  if (!(error instanceof Error) || !("code" in error)) return null;
+  const code = (error as NodeJS.ErrnoException).code;
+  return typeof code === "string" && /^[A-Z][A-Z0-9_]{1,30}$/.test(code) ? code : null;
+}
+
 function requirePublisherKeyAcl(path: string, timeoutMemoKey = path): void {
   privateRegularFileSize(path, PRIVATE_KEY_FILE_OPTIONS);
   let hardened: { ok: boolean };
@@ -63,9 +79,17 @@ function requirePublisherKeyAcl(path: string, timeoutMemoKey = path): void {
     hardened = { ok: false };
   }
   if (!hardened.ok) {
+    // Name the cause in the message, not only on `cause`. Every harden failure
+    // reaches a CI log as this one string, and the three that occur there need
+    // different fixes: ETIMEDOUT is the budget, EACLIDENTITY is the effective-SID
+    // lookup, EICACLS is icacls refusing the path. A message identical across all
+    // three cannot be acted on without a Windows box to re-run it under (#2152).
+    const code = aclFailureCode(hardeningError);
     const failure = new PublicEvidenceValidationError(
       "public_publisher_key_unsafe",
-      "public publisher key ACL hardening did not complete",
+      code
+        ? `public publisher key ACL hardening did not complete (${code})`
+        : "public publisher key ACL hardening did not complete",
     );
     if (hardeningError !== undefined) {
       (failure as Error & { cause?: unknown }).cause = hardeningError;

--- a/tests/lab-public-security-regressions.test.ts
+++ b/tests/lab-public-security-regressions.test.ts
@@ -15,11 +15,13 @@ import {
   setIcaclsRunnerForTests,
   setPlatformForTests,
 } from "../src/lib/windows-secret-acl";
+import { setWindowsPrincipalRunnerForTests } from "../src/lib/windows-user-principal";
 
 const roots: string[] = [];
 
 afterEach(() => {
   setIcaclsRunnerForTests(null);
+  setWindowsPrincipalRunnerForTests(null);
   setPlatformForTests(null);
   resetHardenedStateForTests();
   for (const root of roots.splice(0)) {
@@ -185,4 +187,63 @@ test("publisher key ACL failures preserve their underlying cause", () => {
 
   expect(caught).toBeInstanceOf(Error);
   expect((caught as Error & { cause?: unknown }).cause).toBeInstanceOf(Error);
+});
+
+function publisherKeyAclFailureMessage(prefix: string): string {
+  const home = configDir(prefix);
+  try {
+    getOrCreatePublicPublisher(home);
+  } catch (error) {
+    return (error as Error).message;
+  }
+  throw new Error("expected required publisher key ACL hardening to fail");
+}
+
+// #2152: on the Windows CI leg every publisher-key harden failure arrived as one
+// fixed string. The three causes that occur there need different fixes -- the
+// budget, the effective-SID lookup, or icacls itself -- and the code lived only on
+// `cause`, which the reporter does not print. Diagnosing it needed a Windows box.
+test("a required publisher key ACL timeout names ETIMEDOUT in its message", () => {
+  resetHardenedStateForTests();
+  setPlatformForTests("win32");
+  setIcaclsRunnerForTests(() => ({ success: false, exitCode: null, timedOut: true, stdout: "" }));
+
+  expect(publisherKeyAclFailureMessage("ocx-cl10-acl-code-timeout-")).toContain("ETIMEDOUT");
+});
+
+test("a required publisher key icacls refusal names EICACLS in its message", () => {
+  resetHardenedStateForTests();
+  setPlatformForTests("win32");
+  setIcaclsRunnerForTests(() => ({ success: false, exitCode: 5, timedOut: false, stdout: "" }));
+
+  expect(publisherKeyAclFailureMessage("ocx-cl10-acl-code-icacls-")).toContain("EICACLS");
+});
+
+// The identity code is raised by windows-user-principal, one module further out
+// than the icacls runner, so this also pins that it survives the hand-off.
+test("a required publisher key SID lookup failure names EACLIDENTITY in its message", () => {
+  resetHardenedStateForTests();
+  setPlatformForTests("win32");
+  setIcaclsRunnerForTests(() => ({ success: true, exitCode: 0, timedOut: false, stdout: "" }));
+  setWindowsPrincipalRunnerForTests(() => ({
+    success: false,
+    exitCode: null,
+    timedOut: true,
+    stdout: "",
+  }));
+
+  expect(publisherKeyAclFailureMessage("ocx-cl10-acl-code-identity-")).toContain("EACLIDENTITY");
+});
+
+// A cause with no errno-shaped code must leave the message alone rather than
+// print an empty parenthetical, and nothing but the bounded code may be appended.
+test("a publisher key ACL failure without a bounded code keeps the plain message", () => {
+  resetHardenedStateForTests();
+  setPlatformForTests("win32");
+  setIcaclsRunnerForTests(() => {
+    throw new Error("synthetic icacls runner failure");
+  });
+
+  const message = publisherKeyAclFailureMessage("ocx-cl10-acl-code-plain-");
+  expect(message).toBe("public publisher key ACL hardening did not complete");
 });


### PR DESCRIPTION
Refs #2152.

## What this changes

`CL-10 public bundle and publisher > builds deterministic bundle ids and digests` fails on the Windows leg with:

```
PublicEvidenceValidationError: public publisher key ACL hardening did not complete
      at requirePublisherKeyAcl (src\lab\public\signature.ts:73:11)
```

That message is the same string for every required-harden failure. You wrote in #2152 that telling the three causes apart needs `error.cause.code` and that you would rather leave the question open than aim a fix at the wrong one. This PR does not guess at the cause — it puts the code in the message, so the next dispatched run answers the question by itself.

After this change the same failure reads `... did not complete (ETIMEDOUT)`, `(EACLIDENTITY)` or `(EICACLS)`.

## Why the message and not just `cause`

`cause` is already attached — `requirePublisherKeyAcl` sets it — but the reporter prints `message` and the stack, which is why the trace in the issue has no cause line. Confirmed on Windows by driving the failure through the existing seams and reading both fields:

```
[EICACLS   (icacls refused)]
   message   = public publisher key ACL hardening did not complete
   cause.code= EICACLS
[ETIMEDOUT (budget)]
   message   = public publisher key ACL hardening did not complete
   cause.code= ETIMEDOUT
```

Identical messages, different causes. Nothing in the log distinguishes them.

## What crosses the boundary

Only the errno-shaped code, and its shape is re-checked at the point of use rather than trusted:

```ts
return typeof code === "string" && /^[A-Z][A-Z0-9_]{1,30}$/.test(code) ? code : null;
```

`sanitizedAclError` already allowlists which codes it copies, so this is the second bound rather than the only one — it means a code added there later cannot widen what a public log prints without also passing this shape. A code in that shape has no separator, no lowercase and a bounded length, so it cannot carry the key pathname or the username component inside it. A cause with no such code keeps the previous message byte-for-byte, so no failure gains an empty `()`.

`PublicEvidenceValidationError.code` stays `public_publisher_key_unsafe` and `cause` is untouched, so nothing that branches on either changes.

## One observation about the CI failure itself, offered as a lead, not a claim

Running `bun test tests/lab-public-evidence.test.ts` alone on Windows 11, unelevated, Bun 1.3.14: **14 pass, 0 fail**. So it is not categorically broken on Windows, which narrows it to the runner.

Of your three candidates, one has a property that matches the shape you described — the first call failing and the very next one succeeding on a different temp home. A *successful* SID lookup is process-cached in `windows-user-principal.ts`; a *failed* one is not, so a cold or contended first lookup fails alone and the next call re-runs it warm. Driving exactly that through the seam reproduces your pattern:

```
[call #1 (lookup times out)] cause.code=EACLIDENTITY
[call #2 (lookup recovers)]  OK (no throw)
   principal lookups attempted = 2
```

That is consistent with EACLIDENTITY, not evidence for it — ETIMEDOUT would look similar if the memo key differed per stage. I have not reproduced the CI failure itself and am not proposing a fix for it here. The point of this PR is that the next `platform-windows` dispatch will print which one it was.

## Verification

Windows 11, Bun 1.3.14, on this branch:

```
tests/lab-public-security-regressions.test.ts                  13 pass, 0 fail
8 lab-public suites (evidence, core-contract, lifecycle-hardening,
  surfaces, export-transaction, provenance-recovery, file-safety,
  security-regressions)                                        56 pass, 1 skip, 0 fail
tests/windows-secret-acl.test.ts + windows-user-principal.test.ts
                                                              177 pass, 0 fail
bun x tsc --noEmit -p tsconfig.json                             0 errors
bun run privacy:scan                                            Privacy scan passed
```

Measured on both sides: the same 8 suites on the unpatched tree are `52 pass, 1 skip, 0 fail` across 53 tests, and 57 tests here. The delta is the 4 added cases and nothing else.

**Mutation-checked.** Reverting only the message to the old fixed string, keeping the tests:

```
(fail) a required publisher key ACL timeout names ETIMEDOUT in its message
(fail) a required publisher key icacls refusal names EICACLS in its message
(fail) a required publisher key SID lookup failure names EACLIDENTITY in its message
 10 pass | 3 fail
```

Exactly the three naming cases, while `keeps the plain message` stays green — it covers the other branch, so it should not move, and it does not.

## Tests added

Four cases in `lab-public-security-regressions.test.ts`:

- ETIMEDOUT, EICACLS and EACLIDENTITY each named in the message. The EACLIDENTITY case is injected through `setWindowsPrincipalRunnerForTests`, one module further out than the icacls runner, so it also pins that the code survives the hand-off from `windows-user-principal` rather than only the icacls path.
- a cause with no errno-shaped code leaves the message byte-for-byte unchanged.

`afterEach` now also clears the principal runner, so an injected lookup cannot leak into a later test in the file.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ACL security error messages by including validated diagnostic codes when available.
  * Preserved a clear generic message when no recognized error code is provided.
  * Retained the original underlying error for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
