### PR TITLE
fix(responses): scope tool-field stripping per destination

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -156,26 +156,40 @@ function stripInvalidItemIds(body: unknown): unknown {
 }
 
 /**
- * Codex-private tool fields that only the ChatGPT backend understands.
+ * Tool fields with destination-specific support.
  *
- * A third-party Responses gateway validates its schema and rejects the whole request before
- * inference — xAI answers `Argument not supported: external_web_access` — so these are removed at
- * the noncanonical boundary while the tool and every public option stay.
+ * A third-party Responses gateway validates its schema and may reject the whole request before
+ * inference, so each entry declares which destinations understand it while the tool and every
+ * public option stay intact elsewhere.
  *
  * Keep this a table. Each private bit Codex attaches has so far arrived as its own bespoke strip
  * with its own traversal, and the traversals disagreed about which containers they covered; a new
- * one should be a row here instead. `toolTypes` omitted means the field is private on any tool.
+ * one should be a row here instead. `toolTypes` omitted means the field is scoped on any tool.
+ *
+ * `external_web_access` is understood by both OpenAI-operated Responses surfaces. Routed web-search
+ * incompatibility is also handled by the `supportsOpenAiWebSearchToolFields` capability flag, which
+ * strips the broader OpenAI-only web-search field set for explicit denials; do not collapse that
+ * layer into this table. `defer_loading` differs because it is private to the canonical ChatGPT
+ * surface and the official OpenAI API rejects it.
  */
-const CANONICAL_ONLY_TOOL_FIELDS: readonly { field: string; toolTypes?: ReadonlySet<string> }[] = [
-  // ChatGPT's browsing policy bit. The public hosted tool is enabled by its presence alone.
-  { field: "external_web_access", toolTypes: new Set(["web_search", "web_search_preview"]) },
+const CANONICAL_ONLY_TOOL_FIELDS: readonly {
+  field: string;
+  toolTypes?: ReadonlySet<string>;
+  isSupportedDestination: (provider: OcxProviderConfig) => boolean;
+}[] = [
+  // OpenAI's browsing policy bit. The public hosted tool is enabled by its presence alone.
+  {
+    field: "external_web_access",
+    toolTypes: new Set(["web_search", "web_search_preview"]),
+    isSupportedDestination: isOpenAiOperatedResponsesDestination,
+  },
   // Deferred-discovery marker. `activateDeferredTool` clears it only for tools a `tool_search_output`
   // already loaded, so a still-deferred declaration — including one promoted out of a namespace
   // group — otherwise reaches the wire carrying it.
-  { field: "defer_loading" },
+  { field: "defer_loading", isSupportedDestination: isCanonicalOpenAiForwardProvider },
 ];
 
-function stripCanonicalOnlyToolFields(body: unknown): unknown {
+function stripCanonicalOnlyToolFields(body: unknown, provider: OcxProviderConfig): unknown {
   if (!isPlainObject(body)) return body;
 
   const rewriteTools = (tools: unknown[]): unknown[] => {
@@ -183,7 +197,8 @@ function stripCanonicalOnlyToolFields(body: unknown): unknown {
     const rewritten = tools.map(tool => {
       if (!isPlainObject(tool)) return tool;
       let next = tool;
-      for (const { field, toolTypes } of CANONICAL_ONLY_TOOL_FIELDS) {
+      for (const { field, toolTypes, isSupportedDestination } of CANONICAL_ONLY_TOOL_FIELDS) {
+        if (isSupportedDestination(provider)) continue;
         if (!Object.hasOwn(next, field)) continue;
         if (toolTypes && (typeof next.type !== "string" || !toolTypes.has(next.type))) continue;
         const { [field]: _private, ...rest } = next;
@@ -1721,9 +1736,10 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
         const rewritten = rewriteRoutedNamespaceToolsForUpstream(outBody);
         outBody = rewritten.body;
         convertedRoutedNamespaceToolAliases = rewritten.aliases;
-        // Last, so promoted namespace children are also cleared of Codex-private fields.
-        outBody = stripCanonicalOnlyToolFields(outBody);
       }
+      // Last, so promoted namespace children are also cleared of destination-unsupported fields.
+      // This still runs for OpenAI API-key traffic, where only the canonical-only entries apply.
+      outBody = stripCanonicalOnlyToolFields(outBody, provider);
       const threadServingIdentityChanged = parsed._stripReasoningEncryptedContent === true;
       const sanitizedBody = normalizeToolSchemas(stripSparkCompatibility(stripUnsupportedReasoningParams(stripItemIdsWhenUnstored(stripInvalidItemIds(stripUnsupportedHostedTools(sanitizeReasoningInputContent(scrubOcxCompactionItems(
         outBody,

--- a/tests/responses-routed-web-search-fields.test.ts
+++ b/tests/responses-routed-web-search-fields.test.ts
@@ -28,6 +28,25 @@ function buildWebSearchBody(provider: OcxProviderConfig): Record<string, unknown
   return JSON.parse(request.body) as Record<string, unknown>;
 }
 
+function buildScopedToolFieldsBody(provider: OcxProviderConfig): Record<string, unknown> {
+  const request = createResponsesPassthroughAdapter(provider).buildRequest({
+    modelId: "test-model",
+    context: { messages: [] },
+    stream: true,
+    options: {},
+    _rawBody: {
+      model: "test-model",
+      input: "ping",
+      tools: [{
+        type: "web_search",
+        external_web_access: true,
+        defer_loading: true,
+      }],
+    },
+  }, { headers: new Headers() });
+  return JSON.parse(request.body) as Record<string, unknown>;
+}
+
 // #2188 follow-up: routed Responses upstreams (xAI api.x.ai) 400 the WHOLE request on
 // OpenAI-only web_search config fields (probe 2026-08-21: external_web_access and
 // search_context_size each 400 individually; user_location and filters are accepted).
@@ -78,6 +97,36 @@ describe("Responses buildRequest web_search capability", () => {
     expect(body.tools).toEqual([{
       type: "web_search",
       user_location: { type: "approximate" },
+    }]);
+  });
+});
+
+describe("Responses buildRequest destination-scoped tool fields", () => {
+  test("official OpenAI API-key provider keeps external_web_access and drops defer_loading", () => {
+    const body = buildScopedToolFieldsBody({
+      adapter: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+      authMode: "key",
+      apiKey: "test-openai-key",
+    });
+
+    expect(body.tools).toEqual([{
+      type: "web_search",
+      external_web_access: true,
+    }]);
+  });
+
+  test("canonical ChatGPT forward provider keeps both fields", () => {
+    const body = buildScopedToolFieldsBody({
+      adapter: "openai-responses",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+      authMode: "forward",
+    });
+
+    expect(body.tools).toEqual([{
+      type: "web_search",
+      external_web_access: true,
+      defer_loading: true,
     }]);
   });
 });


### PR DESCRIPTION
Fixes a test that fails on untouched `dev` @ `6c928aace`: `tests/responses-routed-web-search-fields.test.ts` > "official OpenAI API-key traffic retains OpenAI web_search fields" (3 pass / 1 fail).

`external_web_access` was stripped from traffic bound for the official OpenAI API, which supports it.

## Cause — two layers, one of them too broad

1. `stripOpenAiOnlyWebSearchFields` is gated correctly: it runs only when `provider.supportsOpenAiWebSearchToolFields === false`, which xAI declares in the registry (`src/providers/registry.ts:1011`).
2. `CANONICAL_ONLY_TOOL_FIELDS` applied its **whole table** under one outer gate, `!isCanonicalOpenAiForwardProvider`. An official OpenAI API provider is not the canonical ChatGPT surface, so the table stripped the field there as well.

The two fields in that table do not have the same scope:

| field | understood by | must be stripped for |
|---|---|---|
| `external_web_access` | canonical ChatGPT Codex **and** the official OpenAI API | everything else (xAI: `Argument not supported`) |
| `defer_loading` | canonical ChatGPT Codex only | everything else, **including** the official OpenAI API |

One gate cannot express both, so the narrower field dragged the wider one down with it.

## The obvious fix is wrong

Deleting the `external_web_access` row looks right — xAI already declares the capability flag, so the capability layer covers the case the row was added for. Verified it is not: that turns the failing test green and breaks three that correctly require the field stripped for routed providers.

```
OpenAI Responses passthrough sanitization > drops ChatGPT's external_web_access hint but keeps routed web search
OpenAI Responses passthrough sanitization > drops Codex-private tool fields from routed declarations
xAI OAuth Responses streaming opt-in > lowers Codex namespaces for xAI and restores routed calls on the client stream
```

## Approach

Each row now carries its own `isSupportedDestination` predicate, and the call moves outside the namespace-lowering gate so OpenAI API-key traffic is covered too — where only the canonical-only row applies.

The table stays **declarative**: adding a field remains a data change rather than a new traversal. That property is why the table exists — before it, each Codex-private bit arrived as its own bespoke strip, and the traversals disagreed about which containers they covered.

A comment names the capability flag as the mechanism that owns the routed web-search case, so a later reader does not collapse the two layers back together.

## Tests

`bun run test`: **14016 pass, 10 skip, 1 fail across 886 files.**

The single failure is `tests/key-login-live-update.test.ts` > "notify after key login pushes the merged row and keeps modelCosts on live and disk" — pre-existing and unrelated, and it fails identically on untouched `dev`.

New coverage: an official OpenAI API-key provider keeps `external_web_access` and loses `defer_loading`; a canonical ChatGPT forward provider keeps both. The three tests quoted above are unchanged and still pass.

(Plain `bun test` with no arguments hangs on this tree with high CPU and no progress — use `bun run test`.)

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for web-search requests across supported OpenAI destinations.
  - Preserved `external_web_access` where supported while removing unsupported deferred-loading settings.
  - Ensured request fields are consistently sanitized for API-key and routed connections.

- **Tests**
  - Added coverage verifying destination-specific handling of web-search fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->