### PR TITLE
fix(openai-chat): recover complete tool calls at EOF on the opencode-go lane

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -1563,6 +1563,16 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
         pendingToolCalls.length = 0;
         return calls;
       };
+      const pendingToolCallsAreCompleteJsonObjects = (): boolean =>
+        pendingToolCalls.length > 0 && pendingToolCalls.every(call => {
+          if (call.name.trim().length === 0 || !call.sawArgumentsString || call.args.length === 0) return false;
+          try {
+            const parsed = JSON.parse(call.args) as unknown;
+            return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed);
+          } catch {
+            return false;
+          }
+        });
       // Returns "terminate" when a pending call cannot be dispatched, so every flush site
       // stops the turn instead of emitting an unusable call. `closeToolCalls()` runs first,
       // so budget reservations are released for every pending call even on the early return.
@@ -1823,6 +1833,15 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
         }
         const sawFinish = finishReason !== undefined;
         if (!sawFinish && pendingToolCalls.length > 0) {
+          // Some OpenAI-compatible gateways close immediately after a complete function-call
+          // delta and omit both terminal conventions. Keep the default fail-closed policy, and
+          // let an opted-in provider recover only calls whose assembled argument payload is a
+          // complete JSON object. A partial JSON prefix still takes the truncation path below.
+          if (provider.openaiChatEofTolerance === true && pendingToolCallsAreCompleteJsonObjects()) {
+            if ((yield* flushToolCalls()) === "terminate") return;
+            yield { type: "done", usage: pendingUsage };
+            return;
+          }
           debugProviderDiagnostic("openai-chat", "stream-truncated", {
             finishReason: null,
             hadUsage: pendingUsage !== undefined,

--- a/src/lab/subject/behavior-fingerprint.ts
+++ b/src/lab/subject/behavior-fingerprint.ts
@@ -12,7 +12,7 @@ const CLOSED_KEYS = new Set([
   "reasoning.supported", "reasoning.efforts", "reasoning.defaultEffort", "reasoning.effortMap", "reasoning.wireFormat",
   "reasoning.summaryMode", "reasoning.replayMode", "reasoning.splitMode", "reasoning.toggleMode", "reasoning.budgetMode",
   "tools.choiceRestrictions", "tools.parallel", "tools.hostedPreference", "tools.customFreeform", "tools.builtinNameEscaping",
-  "cache.forwarding", "cache.retention", "anthropic.eofPolicy",
+  "cache.forwarding", "cache.retention", "anthropic.eofPolicy", "openai-chat.eofPolicy",
   "google.mode", "google.projectFingerprint", "google.locationFingerprint",
   "openrouter.order", "openrouter.only", "openrouter.allowFallbacks",
   "sidecars.vision", "sidecars.webSearch",

--- a/src/providers/derive.ts
+++ b/src/providers/derive.ts
@@ -47,6 +47,7 @@ export interface DerivedKeyLoginProvider {
   thinkingToggleModels?: string[];
   thinkingBudgetModels?: string[];
   escapeBuiltinToolNames?: boolean;
+  openaiChatEofTolerance?: boolean;
   googleMode?: "ai-studio" | "vertex" | "cloud-code-assist";
   project?: string;
   location?: string;
@@ -247,6 +248,7 @@ export function providerConfigSeed(entry: ProviderRegistryEntry): OcxProviderCon
     ...(entry.parallelToolCalls !== undefined ? { parallelToolCalls: entry.parallelToolCalls } : {}),
     ...(entry.promptCacheKey !== undefined ? { promptCacheKey: entry.promptCacheKey } : {}),
     ...(entry.chatServiceTier !== undefined ? { chatServiceTier: entry.chatServiceTier } : {}),
+    ...(entry.openaiChatEofTolerance !== undefined ? { openaiChatEofTolerance: entry.openaiChatEofTolerance } : {}),
     ...(entry.responsesPath !== undefined ? { responsesPath: entry.responsesPath } : {}),
     ...(entry.statelessResponses !== undefined ? { statelessResponses: entry.statelessResponses } : {}),
     ...(entry.requiresAdjacentResponsesToolResults !== undefined
@@ -306,6 +308,7 @@ export function deriveKeyLoginMap(): Record<string, DerivedKeyLoginProvider> {
       ...(entry.thinkingToggleModels ? { thinkingToggleModels: [...entry.thinkingToggleModels] } : {}),
       ...(entry.thinkingBudgetModels ? { thinkingBudgetModels: [...entry.thinkingBudgetModels] } : {}),
       ...(entry.escapeBuiltinToolNames !== undefined ? { escapeBuiltinToolNames: entry.escapeBuiltinToolNames } : {}),
+      ...(entry.openaiChatEofTolerance !== undefined ? { openaiChatEofTolerance: entry.openaiChatEofTolerance } : {}),
       ...(entry.googleMode ? { googleMode: entry.googleMode } : {}),
       ...(entry.project ? { project: entry.project } : {}),
       ...(entry.location ? { location: entry.location } : {}),
@@ -461,6 +464,9 @@ export function enrichProviderFromRegistry(name: string, prov: OcxProviderConfig
   if (prov.parallelToolCalls === undefined && seed.parallelToolCalls !== undefined) prov.parallelToolCalls = seed.parallelToolCalls;
   if (prov.promptCacheKey === undefined && seed.promptCacheKey !== undefined) prov.promptCacheKey = seed.promptCacheKey;
   if (prov.chatServiceTier === undefined && seed.chatServiceTier !== undefined) prov.chatServiceTier = seed.chatServiceTier;
+  if (prov.openaiChatEofTolerance === undefined && seed.openaiChatEofTolerance !== undefined) {
+    prov.openaiChatEofTolerance = seed.openaiChatEofTolerance;
+  }
   // Fill-only: a hand-edited path must survive, and a config saved before the registry
   // learned this route still gets backfilled.
   if (prov.responsesPath === undefined && seed.responsesPath !== undefined) prov.responsesPath = seed.responsesPath;

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -268,6 +268,8 @@ export interface ProviderRegistryEntry {
    * `supportsServiceTier`, which governs the Responses wire.
    */
   chatServiceTier?: boolean;
+  /** OpenAI Chat EOF policy for gateways that omit terminal frames after complete tool calls. */
+  openaiChatEofTolerance?: boolean;
   autoToolChoiceOnlyModels?: string[];
   preserveReasoningContentModels?: string[];
   requiresReasoningPlaceholderModels?: string[];
@@ -293,7 +295,7 @@ export type ProviderConfigSeed = Pick<
   | "modelMaxInputTokens" | "defaultMaxOutputTokens" | "modelMaxOutputTokens"
   | "reasoningEfforts" | "modelReasoningEfforts" | "modelDefaultReasoningEfforts" | "reasoningEffortMap" | "modelReasoningEffortMap" | "reasoningWireFormat"
   | "noVisionModels" | "noReasoningModels" | "noTemperatureModels" | "noTopPModels" | "noPenaltyModels"
-  | "autoToolChoiceOnlyModels" | "preserveReasoningContentModels" | "requiresReasoningPlaceholderModels" | "reasoningSplitModels" | "thinkingToggleModels" | "thinkingBudgetModels" | "escapeBuiltinToolNames"
+  | "autoToolChoiceOnlyModels" | "preserveReasoningContentModels" | "requiresReasoningPlaceholderModels" | "reasoningSplitModels" | "thinkingToggleModels" | "thinkingBudgetModels" | "escapeBuiltinToolNames" | "openaiChatEofTolerance"
   | "googleMode" | "project" | "location" | "headers"
 >;
 
@@ -1278,6 +1280,9 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     id: "opencode-go", label: "opencode go", adapter: "openai-chat", baseUrl: "https://opencode.ai/zen/go/v1",
     authKind: "key", featured: true, dashboardUrl: "https://opencode.ai/auth", defaultModel: "kimi-k2.7-code",
     jawcodeBundle: "opencode-go", note: "GLM, DeepSeek, Kimi, Qwen, MiMo…",
+    // Zen Go can close a Chat stream after a fully assembled function call without sending
+    // finish_reason or [DONE] (#2260). The adapter still rejects incomplete argument JSON.
+    openaiChatEofTolerance: true,
     /* [Decision Log]
     - 목적과 의도: Route GPT 5.6 Luna to the Responses endpoint that OpenCode Go documents for that exact model.
     - 기존 구현 및 제약 조건: The provider is mixed-wire but its provider-wide `openai-chat` adapter sent Luna to `/chat/completions`; explicit user `modelAdapters` entries must remain authoritative.

--- a/src/router.ts
+++ b/src/router.ts
@@ -398,6 +398,9 @@ export function routedProviderConfig(providerName: string, provider: OcxProvider
     ...(provider.parallelToolCalls === undefined && registryEntry.parallelToolCalls !== undefined ? { parallelToolCalls: registryEntry.parallelToolCalls } : {}),
     ...(provider.promptCacheKey === undefined && registryEntry.promptCacheKey !== undefined ? { promptCacheKey: registryEntry.promptCacheKey } : {}),
     ...(provider.chatServiceTier === undefined && registryEntry.chatServiceTier !== undefined ? { chatServiceTier: registryEntry.chatServiceTier } : {}),
+    ...(provider.openaiChatEofTolerance === undefined && registryEntry.openaiChatEofTolerance !== undefined
+      ? { openaiChatEofTolerance: registryEntry.openaiChatEofTolerance }
+      : {}),
     ...(provider.reasoningWireFormat === undefined && registryEntry.reasoningWireFormat !== undefined
       ? { reasoningWireFormat: registryEntry.reasoningWireFormat }
       : {}),

--- a/src/routing/compatibility/behavior.ts
+++ b/src/routing/compatibility/behavior.ts
@@ -228,6 +228,7 @@ export function resolveProductionBehaviorValues(
     "cache.forwarding": behaviorRow("provider_config", effective.promptCacheKey === true),
     "cache.retention": behaviorRow("global_config", config.cacheRetention ?? "short"),
     "anthropic.eofPolicy": behaviorRow("provider_config", effective.anthropicEofTolerance === true ? "tolerant" : "strict"),
+    "openai-chat.eofPolicy": behaviorRow("provider_config", effective.openaiChatEofTolerance === true ? "tolerant" : "strict"),
     "google.mode": behaviorRow("provider_config", effective.googleMode ?? null),
     "google.projectFingerprint": behaviorRow(
       "provider_config",

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -412,6 +412,13 @@ export interface OcxProviderConfig {
    */
   terminalContinuationGuard?: boolean;
   /**
+   * Opt-in for OpenAI-compatible chat gateways that may close after emitting a complete
+   * tool-call delta without `finish_reason` or `[DONE]`. The adapter accepts that EOF only
+   * when every pending call has a non-empty name and complete JSON-object arguments;
+   * incomplete JSON, missing arguments, and empty streams remain truncation errors.
+   */
+  openaiChatEofTolerance?: boolean;
+  /**
    * Opt-in: forward `prompt_cache_key` to the upstream `/chat/completions` body.
    * OpenAI-specific extension; strict backends (Groq, Cerebras, etc.) reject unknown
    * fields. Default off; only enable for providers that document this parameter.

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -82,6 +82,7 @@ describe("provider registry parity", () => {
     expect(KEY_LOGIN_PROVIDERS["opencode-go"].noTopPModels).toContain("kimi-k3");
     expect(KEY_LOGIN_PROVIDERS["opencode-go"].noPenaltyModels).toContain("kimi-k3");
     expect(KEY_LOGIN_PROVIDERS["opencode-go"].preserveReasoningContentModels).toContain("kimi-k3");
+    expect(KEY_LOGIN_PROVIDERS["opencode-go"].openaiChatEofTolerance).toBe(true);
     expect(KEY_LOGIN_PROVIDERS.umans.modelContextWindows?.["umans-coder"]).toBe(262_144);
     expect(KEY_LOGIN_PROVIDERS.umans.modelContextWindows?.["umans-glm-5.2"]).toBe(405_504);
     expect(KEY_LOGIN_PROVIDERS.umans.modelInputModalities?.["umans-coder"]).toEqual(["text", "image"]);

--- a/tests/server-opencode-go-goal-streaming.test.ts
+++ b/tests/server-opencode-go-goal-streaming.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { saveConfig } from "../src/config";
+import { startServer } from "../src/server";
+import type { OcxConfig } from "../src/types";
+import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+
+const CHAT_ENDPOINT = "https://opencode.ai/zen/go/v1/chat/completions";
+
+let testDir = "";
+let previousHome: string | undefined;
+let isolatedCodexHome: IsolatedCodexHome | null = null;
+let originalFetch: typeof fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  previousHome = process.env.OPENCODEX_HOME;
+  isolatedCodexHome = installIsolatedCodexHome("ocx-opencode-go-goal-codex-");
+  testDir = mkdtempSync(join(tmpdir(), "ocx-opencode-go-goal-"));
+  process.env.OPENCODEX_HOME = testDir;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = previousHome;
+  isolatedCodexHome?.restore();
+  isolatedCodexHome = null;
+  if (testDir) rmSync(testDir, { recursive: true, force: true });
+});
+
+function config(): OcxConfig {
+  return {
+    port: 0,
+    hostname: "127.0.0.1",
+    defaultProvider: "opencode-go",
+    providers: {
+      "opencode-go": {
+        adapter: "openai-chat",
+        baseUrl: "https://opencode.ai/zen/go/v1",
+        apiKey: "test-key",
+        models: ["deepseek-v4-flash"],
+      },
+    },
+  } as OcxConfig;
+}
+
+function goalRequestBody(): Record<string, unknown> {
+  return {
+    model: "opencode-go/deepseek-v4-flash",
+    input: "Create a goal",
+    stream: true,
+    store: false,
+    tools: [{
+      type: "namespace",
+      name: "functions",
+      description: "Client functions",
+      tools: [{
+        type: "function",
+        name: "update_plan",
+        description: "Update the current goal plan",
+        parameters: {
+          type: "object",
+          properties: {
+            explanation: { type: "string" },
+            plan: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  step: { type: "string" },
+                  status: { type: "string", enum: ["pending", "in_progress", "completed"] },
+                },
+                required: ["step", "status"],
+                additionalProperties: false,
+              },
+            },
+          },
+          required: ["plan"],
+          additionalProperties: false,
+        },
+        strict: false,
+      }],
+    }],
+  };
+}
+
+function toolCallFrame(argumentsDelta: string): string {
+  return `data: ${JSON.stringify({
+    id: "chatcmpl_goal",
+    object: "chat.completion.chunk",
+    model: "deepseek-v4-flash",
+    choices: [{
+      index: 0,
+      delta: {
+        tool_calls: [{
+          index: 0,
+          id: "call_update_plan",
+          type: "function",
+          function: { name: "update_plan", arguments: argumentsDelta },
+        }],
+      },
+      finish_reason: null,
+    }],
+  })}\n\n`;
+}
+
+async function runGoal(upstreamBody: string): Promise<{
+  responseText: string;
+  outboundBody: Record<string, unknown>;
+}> {
+  let outboundBody: Record<string, unknown> | undefined;
+  globalThis.fetch = (async (input, init) => {
+    const url = input instanceof Request ? input.url : String(input);
+    if (url !== CHAT_ENDPOINT) return originalFetch(input, init);
+    outboundBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    return new Response(upstreamBody, { headers: { "content-type": "text/event-stream" } });
+  }) as typeof fetch;
+
+  saveConfig(config());
+  const server = startServer(0);
+  try {
+    const response = await originalFetch(new URL("/v1/responses", server.url), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(goalRequestBody()),
+    });
+    expect(response.status).toBe(200);
+    const responseText = await response.text();
+    expect(outboundBody).toBeDefined();
+    return { responseText, outboundBody: outboundBody! };
+  } finally {
+    await server.stop(true);
+  }
+}
+
+function outboundToolNames(body: Record<string, unknown>): string[] {
+  const tools = body.tools as Array<{ function?: { name?: string } }> | undefined;
+  return tools?.flatMap(tool => tool.function?.name ? [tool.function.name] : []) ?? [];
+}
+
+describe("opencode-go /goal streaming (#2260)", () => {
+  test("Codex 0.147 functions namespace authorizes a returned update_plan call", async () => {
+    const args = JSON.stringify({
+      explanation: "Start the goal",
+      plan: [{ step: "Inspect", status: "in_progress" }],
+    });
+    const terminal = `data: ${JSON.stringify({
+      choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+    })}\n\ndata: [DONE]\n\n`;
+
+    const { responseText, outboundBody } = await runGoal(toolCallFrame(args) + terminal);
+
+    expect(outboundToolNames(outboundBody)).toContain("update_plan");
+    expect(responseText).toContain('"type":"function_call"');
+    expect(responseText).toContain('"name":"update_plan"');
+    expect(responseText).toContain("event: response.completed");
+    expect(responseText).not.toContain("undeclared client tool");
+  });
+
+  test("EOF after a complete update_plan call synthesizes a clean tool-call terminal", async () => {
+    const args = JSON.stringify({
+      explanation: "Start the goal",
+      plan: [{ step: "Inspect", status: "in_progress" }],
+    });
+
+    const { responseText } = await runGoal(toolCallFrame(args));
+
+    expect(responseText).toContain('"type":"function_call"');
+    expect(responseText).toContain('"name":"update_plan"');
+    expect(responseText).toContain("response.function_call_arguments.done");
+    expect(responseText).toContain("event: response.completed");
+    expect(responseText).not.toContain("possible truncation");
+  });
+
+  test("EOF with incomplete update_plan arguments still fails closed", async () => {
+    const { responseText } = await runGoal(toolCallFrame('{"plan":['));
+
+    expect(responseText).toContain("event: response.failed");
+    expect(responseText).toContain("possible truncation");
+    expect(responseText).not.toContain("response.function_call_arguments.done");
+    expect(responseText).not.toContain("event: response.completed");
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the two #2260 stream-drop symptoms on the opencode-go lane (Codex App /goal against opencode-go/deepseek-v4-flash):
- Symptom A ('undeclared client tool update_plan'): already fixed on dev by 5f2b93979 (Codex 0.147 functions-namespace flattening) — now locked with a real-server regression proving update_plan stays declared through the Responses->Chat translation and is accepted by the bridge. The undeclared-tool guard itself is untouched.
- Symptom B ('ended without a terminal signal — possible truncation'): reproduced on dev (red repro: a COMPLETE tool-call delta followed by EOF without finish_reason/[DONE] errored as truncation). New narrow opt-in `openaiChatEofTolerance` on the provider contract, enabled for opencode-go in the registry: EOF is accepted only when every pending call has a non-empty name and complete JSON-object arguments; partial JSON, missing arguments, and empty streams still fail as truncation.

## Verification
- Red reproduction recorded (2/1 fail pre-fix), then 264/0 + 186/0 across the guard/bridge/router/adapter suites; tsc + privacy:scan green.
- Full-suite authority runs on the release host as the aggregate gate (local full-suite run hit the known memory-pathology flake; focused suites and the real-server regression are green).

## Checklist
- [x] Targets dev
- [x] Fixes #2260 (both reported symptoms)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved OpenAI-compatible streaming for gateways that end cleanly after complete tool calls without sending a terminal signal.
  * Complete tool calls now finish successfully, while incomplete or invalid arguments continue to report truncation errors.
  * Added provider-level configuration to control EOF tolerance for supported gateways.

* **Bug Fixes**
  * Resolved tool-call handling issues for opencode-go goal streaming, including plan updates and clean completion events.

* **Tests**
  * Added coverage for successful complete calls and failures caused by incomplete arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->