### PR TITLE
test(clients): assert the Pi override with join, not a POSIX separator

### DIFF
--- a/tests/management-client-config-route.test.ts
+++ b/tests/management-client-config-route.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
 import { handleManagementAPI } from "../src/server/management-api";
 import {
   OPENCODE_API_KEY_ENV,
@@ -332,12 +333,17 @@ describe("GET /api/client-config", () => {
 
   test("an accepted override still resolves through the route", async () => {
     const previous = process.env.PI_CODING_AGENT_DIR;
-    process.env.PI_CODING_AGENT_DIR = "/tmp/opencodex-pi-route-fixture";
+    // One binding for the override, so the env value and the expectation cannot
+    // drift apart, and `join` for the separator: the resolver builds the
+    // destination with `join`, which is `\` on win32, so a hard-coded POSIX
+    // string asserted the platform rather than the override taking effect.
+    const overrideDir = "/tmp/opencodex-pi-route-fixture";
+    process.env.PI_CODING_AGENT_DIR = overrideDir;
     try {
       const response = await clientConfigApi(baseConfig(), "?client=pi");
       expect(response.status).toBe(200);
       const body = await response.json() as ClientConfigEnvelope;
-      expect(body.destination).toBe("/tmp/opencodex-pi-route-fixture/models.json");
+      expect(body.destination).toBe(join(overrideDir, "models.json"));
     } finally {
       if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
       else process.env.PI_CODING_AGENT_DIR = previous;


### PR DESCRIPTION
Refs #2152.

## What this fixes

`tests/management-client-config-route.test.ts` has one case that cannot pass on Windows:

```
(fail) GET /api/client-config > an accepted override still resolves through the route
Expected: "/tmp/opencodex-pi-route-fixture/models.json"
Received: "\tmp\opencodex-pi-route-fixture\models.json"
```

`piConfigPath` builds the destination with `join(piAgentDir(env, home), "models.json")`, and `join` emits `\` on win32. The expectation was a hard-coded POSIX string, so the case asserted the host's path separator rather than the thing it was written to prove — that `PI_CODING_AGENT_DIR` took effect instead of falling back to `~/.pi/agent`.

The production behaviour is right; only the assertion was platform-bound.

## The change

The expectation is now built with `join` from a single binding shared with the env value, so the override and the assertion cannot drift apart:

```ts
const overrideDir = "/tmp/opencodex-pi-route-fixture";
process.env.PI_CODING_AGENT_DIR = overrideDir;
...
expect(body.destination).toBe(join(overrideDir, "models.json"));
```

`join` is identity for this input on POSIX, so the Linux and macOS legs see the same string they see today:

```
$ node -e "const p=require('node:path'); console.log(p.win32.join('/tmp/opencodex-pi-route-fixture','models.json')); console.log(p.posix.join('/tmp/opencodex-pi-route-fixture','models.json'))"
\tmp\opencodex-pi-route-fixture\models.json
/tmp/opencodex-pi-route-fixture/models.json
```

I used `join` rather than calling `piConfigPath` in the test. Deriving the expectation from the same resolver that produced the value would have made the case pass no matter what the resolver did.

## Verification — Windows 11, Bun 1.3.14

```
tests/management-client-config-route.test.ts        14 pass, 0 fail   (13 pass / 1 fail before)
+ client-config-export, client-config-export-new-clients,
  client-config-new-clients                        111 pass, 0 fail
bun x tsc --noEmit -p tsconfig.json                  0 errors
bun run privacy:scan                                 Privacy scan passed
```

**Mutation-checked.** Making `piAgentDir` ignore `PI_CODING_AGENT_DIR` entirely, keeping the new assertion:

```
(fail) a refused path override answers 400 with the bounded message, not a thrown 500
(fail) an accepted override still resolves through the route
(fail) a refused override wins over a failing catalog, and skips the catalog work
 11 pass | 3 fail
```

This case is among them, so it still pins the override taking effect rather than merely matching whatever the resolver returns.

## How I found it

Running the full local suite on Windows: **14029 tests, this was the only failure**. It is not in the four remaining failures listed on #2152, so it is an additional one in the same platform class rather than a duplicate of any of them.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform test coverage for custom configuration directory path resolution.
  * Updated expected paths to match platform-specific path formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


