### PR TITLE
fix(zcode): use openai-compatible provider protocol to restore prefix caching (#2261 rebased)

### DIFF
--- a/src/clients/config-export.ts
+++ b/src/clients/config-export.ts
@@ -937,10 +937,10 @@ export interface McodeGeneratedConfig {
 
 /**
  * ZCode's `~/.zcode/v2/config.json` provider entry (observed schema, validated
- * live against ZCode 3.7.7). `kind: "anthropic"` selects the Anthropic
- * Messages protocol, which the proxy serves at `/v1/messages`. `apiKeyRequired`
- * keeps ZCode's UI from prompting for a key it does not need on loopback; the
- * serialized key is always the non-secret loopback placeholder.
+ * live against ZCode 3.7.7 / 3.8.1). `kind: "openai-compatible"` selects the
+ * OpenAI Chat Completions protocol, which the proxy serves at `/v1/chat/completions`.
+ * `apiKeyRequired` keeps ZCode's UI from prompting for a key it does not need on
+ * loopback; the serialized key is always the non-secret loopback placeholder.
  */
 export interface ZcodeModelEntry {
   name?: string;
@@ -950,7 +950,7 @@ export interface ZcodeModelEntry {
 
 export interface ZcodeProviderBlock {
   name: "OpenCodex";
-  kind: "anthropic";
+  kind: "openai-compatible";
   enabled: true;
   source: "custom";
   options: {
@@ -1298,10 +1298,10 @@ function buildMcodeClientConfig(ctx: ExportContext): McodeGeneratedConfig {
 }
 
 /**
- * ZCode dials the Anthropic Messages surface, so `baseURL` is the proxy origin
- * without the `/v1` suffix (ZCode appends `/v1/messages` itself — the same
- * shape its builtin Z.ai providers use). Model ids are the proxy's canonical
- * `provider/id` selectors, which `/v1/messages` resolves directly. Context
+ * ZCode dials the OpenAI Chat Completions surface (`openai-compatible`), which
+ * appends `/chat/completions` to `baseURL`. We supply `baseURL` with the `/v1`
+ * suffix so requests land on `/v1/chat/completions`. Model ids are the proxy's canonical
+ * `provider/id` selectors, which `/v1/chat/completions` resolves directly. Context
  * limits follow the authoritative-window rule: a model without one ships
  * without `limit` rather than guessing. Modalities are ZCode's observed
  * `text`-floor vocabulary; image-capable rows advertise image input.
@@ -1330,12 +1330,12 @@ function buildZcodeClientConfig(ctx: ExportContext): ZcodeGeneratedConfig {
     provider: {
       [OPENCODE_PROVIDER_ID]: {
         name: "OpenCodex",
-        kind: "anthropic",
+        kind: "openai-compatible",
         enabled: true,
         source: "custom",
         options: {
           apiKey: LOOPBACK_API_KEY_PLACEHOLDER,
-          baseURL: ctx.baseUrl.replace(/\/v1\/?$/, ""),
+          baseURL: ctx.baseUrl.replace(/\/v1\/?$/, "") + "/v1",
           apiKeyRequired: true,
         },
         models,

--- a/tests/zcode-client.test.ts
+++ b/tests/zcode-client.test.ts
@@ -43,12 +43,12 @@ describe("ZCode client config", () => {
     expect(Object.keys(document)).toEqual(["provider"]);
     const provider = document.provider[OPENCODE_PROVIDER_ID]!;
     expect(provider.name).toBe("OpenCodex");
-    expect(provider.kind).toBe("anthropic");
+    expect(provider.kind).toBe("openai-compatible");
     expect(provider.enabled).toBe(true);
     expect(provider.source).toBe("custom");
     expect(provider.options).toEqual({
       apiKey: LOOPBACK_API_KEY_PLACEHOLDER,
-      baseURL: "http://127.0.0.1:10100",
+      baseURL: "http://127.0.0.1:10100/v1",
       apiKeyRequired: true,
     });
   });


### PR DESCRIPTION
## Summary
Lands PR #2261 by @leon80900 (re-filed from the wrong-branch #2216 onto dev): the ZCode client export switches from the Anthropic Messages protocol to openai-compatible — `kind: "openai-compatible"` with `baseURL` carrying the `/v1` suffix so ZCode's `/chat/completions` concatenation lands on the proxy's chat surface.
- Restores DeepSeek/Chinese-LLM prefix KV cache hit rates (~80% -> 97-99.7% per the author's live measurements) in multi-turn tool sessions and prevents `conflict: foreign-edit`.
- Aligns with the repo's chat-first direction for third-party lanes; observed schema validated by the author against ZCode 3.7.7/3.8.1.

## Verification
- tests/zcode-client.test.ts 10/0 on the rebased head; tsc clean.

## Checklist
- [x] Targets dev
- [x] Credits #2261 (@leon80900)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ZCode client compatibility by using the OpenAI-compatible protocol.
  * Corrected the service URL path so requests are routed properly.
* **Tests**
  * Updated configuration validation to reflect the corrected provider type and service URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->