### PR TITLE
fix(integrations): sync MCode model capabilities (#2220 rebased)

### DIFF
--- a/docs-site/src/content/docs/fr/guides/integrations.md
+++ b/docs-site/src/content/docs/fr/guides/integrations.md
@@ -29,6 +29,9 @@ MiniMax Code recherche d’abord `MINIMAX_DATA_DIR`, puis `MAVIS_DATA_DIR`, avan
 `~/.minimax`. Son bloc géré ne possède que `custom_provider.opencodex`. Il ne modifie ni `defaultModel`, ni
 la source d’identification MiniMax sélectionnée, ni la connexion MiniMax de l’utilisateur. Après l’avoir
 connecté, choisissez dans MCode une entrée `custom_provider:opencodex/<provider/model>`.
+L’actualisation de l’intégration met également à jour les fenêtres de contexte par modèle et les choix
+d’effort de raisonnement faisant autorité ; les capacités inconnues sont omises et l’effort courant,
+qui appartient à la session MCode, est préservé.
 
 Les chemins respectent les variables de remplacement propres à chaque client, lorsqu'elles existent. Pour
 OMP, la présence de `OMP_PROFILE` l'emporte sur `PI_PROFILE`, même si sa valeur est explicitement vide. Un
@@ -148,6 +151,10 @@ Pour MiniMax Code, connectez une fois le fournisseur puis utilisez l’enveloppe
 ocx integration client enable --client mcode
 ocx mcode
 ```
+
+Une fois l’intégration connectée, `ocx sync` actualise également le bloc MCode géré avec les fenêtres de
+contexte et les niveaux d’effort de raisonnement actuels. Les blocs absents, modifiés par un tiers, non sûrs
+ou jamais gérés restent intacts ; réactivez explicitement l’intégration lorsque vous souhaitez la reconnecter.
 
 Le CLI distinct de la plateforme MiniMax (`mmx`) n’est pas une intégration à commutateur de fichier. Ses
 commandes textuelles utilisent le point de terminaison compatible avec Anthropic de MiniMax ; OpenCodex

--- a/docs-site/src/content/docs/fr/guides/minimax.md
+++ b/docs-site/src/content/docs/fr/guides/minimax.md
@@ -34,12 +34,14 @@ custom_provider:
       baseURL: http://127.0.0.1:10100
       authMode: api-key
     models:
-      anthropic/claude-opus-5: {}
+      anthropic/claude-opus-5:
+        limit:
+          context: 1000000
 ```
 
-La liste de modèles réellement générée provient du catalogue OpenCodex actif. Le bloc n’écrit aucune clé réelle, ne remplace pas `defaultModel` et ne modifie pas votre connexion MiniMax. Dans MCode, choisissez un modèle sous `custom_provider:opencodex/...`.
+La liste de modèles réellement générée, ainsi que les fenêtres de contexte et les niveaux d’effort de raisonnement connus, provient du catalogue OpenCodex actif. Lorsqu’aucune fenêtre de contexte ou échelle d’effort ne fait autorité pour un modèle, le champ correspondant est omis au lieu de recevoir une valeur supposée. MCode conserve l’effort actuellement sélectionné dans la session : OpenCodex exporte donc `effortOptions` sans remplacer cette sélection. Le bloc n’écrit aucune clé réelle, ne remplace pas `defaultModel` et ne modifie pas votre connexion MiniMax. Dans MCode, choisissez un modèle sous `custom_provider:opencodex/...`.
 
-`ocx mcode` vérifie que ce fournisseur pointe vers le proxy actuellement actif avant de lancer le client. Si le port a changé, actualisez le bloc géré en relançant la commande d’activation. Désactivez-le ou restaurez-le au moyen du même système d’intégration audité :
+`ocx mcode` vérifie que ce fournisseur pointe vers le proxy actuellement actif avant de lancer le client. Après l’activation initiale, `ocx sync` actualise le bloc géré lorsque le port ou les capacités du catalogue changent. La synchronisation automatique ne crée jamais un bloc non géré, ne recrée pas un bloc que vous avez supprimé et n’écrase pas un fichier modifié après l’écriture d’OpenCodex ; utilisez la commande d’activation lorsque vous souhaitez le reconnecter explicitement. Désactivez-le ou restaurez-le au moyen du même système d’intégration audité :
 
 ```bash
 ocx integration client disable --client mcode

--- a/docs-site/src/content/docs/guides/integrations.md
+++ b/docs-site/src/content/docs/guides/integrations.md
@@ -163,6 +163,10 @@ ocx integration client enable --client mcode
 ocx mcode
 ```
 
+Once connected, `ocx sync` also refreshes the owned MCode block with current context
+windows and reasoning-effort ladders. It leaves missing, foreign-edited, unsafe, and
+never-owned blocks untouched; re-enable explicitly when you intend to reconnect one.
+
 The separate MiniMax platform CLI (`mmx`) is not a file-toggle integration. Its text
 commands use MiniMax's Anthropic-compatible endpoint, so OpenCodex provides a
 credential-isolated, loopback-only launcher:

--- a/docs-site/src/content/docs/guides/integrations.md
+++ b/docs-site/src/content/docs/guides/integrations.md
@@ -29,7 +29,9 @@ MiniMax Code follows `MINIMAX_DATA_DIR`, then `MAVIS_DATA_DIR`, before falling
 back to `~/.minimax`. Its managed block owns only `custom_provider.opencodex`.
 It does not change `defaultModel`, the selected MiniMax credential source, or
 the user's MiniMax login. Choose a `custom_provider:opencodex/<provider/model>`
-entry in MCode after connecting it.
+entry in MCode after connecting it. Refreshing the integration also refreshes
+authoritative per-model context windows and reasoning-effort choices; unknown
+capabilities are omitted, and MCode's session-owned current effort is preserved.
 
 Prime Agent follows `PRIME_AGENT_CODING_AGENT_DIR` before falling back to
 `~/.prime/agent`; a relative value is refused so the proxy and the agent cannot

--- a/docs-site/src/content/docs/guides/minimax.md
+++ b/docs-site/src/content/docs/guides/minimax.md
@@ -37,12 +37,20 @@ custom_provider:
       baseURL: http://127.0.0.1:10100
       authMode: api-key
     models:
-      anthropic/claude-opus-5: {}
+      anthropic/claude-opus-5:
+        limit:
+          context: 1000000
+        thinking:
+          effortOptions: [low, medium, high, xhigh, max]
 ```
 
-The real generated model list comes from the running OpenCodex catalog. The block does
-not write a real key, does not replace `defaultModel`, and does not change your MiniMax
-login. In MCode, choose a model under `custom_provider:opencodex/...`.
+The real generated model list and its known context windows and reasoning-effort ladders
+come from the running OpenCodex catalog. A model with no authoritative context window or
+effort ladder omits that field instead of receiving a guessed value. MCode keeps the
+currently selected effort in the session, so OpenCodex exports `effortOptions` without
+overwriting that selection. The block does not write a real key, does not replace
+`defaultModel`, and does not change your MiniMax login. In MCode, choose a model under
+`custom_provider:opencodex/...`.
 
 `ocx mcode` verifies that this provider points at the currently running proxy before it
 launches the client. If the port changed, refresh the managed block by running the enable

--- a/docs-site/src/content/docs/guides/minimax.md
+++ b/docs-site/src/content/docs/guides/minimax.md
@@ -51,8 +51,11 @@ overwriting that selection. The block does not write a real key, does not replac
 `custom_provider:opencodex/...`.
 
 `ocx mcode` verifies that this provider points at the currently running proxy before it
-launches the client. If the port changed, refresh the managed block by running the enable
-command again. Disable or restore it through the same audited integration system:
+launches the client. After the one-time enable, `ocx sync` refreshes the owned block when
+the port or catalog capabilities change. Automatic sync never creates an unowned block,
+recreates one you removed, or overwrites a file that changed after OpenCodex wrote it; use
+the enable command when you intentionally want to reconnect. Disable or restore it through
+the same audited integration system:
 
 ```bash
 ocx integration client disable --client mcode

--- a/docs-site/src/content/docs/guides/minimax.md
+++ b/docs-site/src/content/docs/guides/minimax.md
@@ -40,8 +40,6 @@ custom_provider:
       anthropic/claude-opus-5:
         limit:
           context: 1000000
-        thinking:
-          effortOptions: [low, medium, high, xhigh, max]
 ```
 
 The real generated model list and its known context windows and reasoning-effort ladders

--- a/docs-site/src/content/docs/tr/guides/integrations.md
+++ b/docs-site/src/content/docs/tr/guides/integrations.md
@@ -31,6 +31,9 @@ son olarak `~/.minimax` dizinine geri döner. Yönetilen blok yalnızca
 `custom_provider.opencodex` alanına sahiptir; `defaultModel` değerini, seçilen
 MiniMax kimlik bilgisi kaynağını veya kullanıcının MiniMax oturumunu değiştirmez.
 Bağladıktan sonra MCode içinde bir `custom_provider:opencodex/<provider/model>` girdisi seçin.
+Entegrasyon yenilendiğinde model başına doğrulanmış bağlam pencereleri ve akıl yürütme
+çabası seçenekleri de yenilenir; bilinmeyen yetenekler atlanır ve MCode oturumunun
+yönettiği geçerli çaba seçimi korunur.
 
 Yollar, varsa her istemcinin kendi ortam geçersiz kılmalarını dikkate alır. OMP
 için `OMP_PROFILE`, açıkça boş olduğunda bile varlığıyla `PI_PROFILE`'a üstün
@@ -171,6 +174,11 @@ MiniMax Code için sağlayıcıyı bir kez bağlayın ve denetimli başlatıcı 
 ocx integration client enable --client mcode
 ocx mcode
 ```
+
+Bağlandıktan sonra `ocx sync`, yönetilen MCode bloğunu güncel bağlam pencereleri ve
+akıl yürütme çabası seçenekleriyle de yeniler. Eksik, dışarıdan düzenlenmiş, güvenli
+olmayan veya hiç sahiplenilmemiş bloklara dokunmaz; yeniden bağlamak istediğinizde
+entegrasyonu açıkça yeniden etkinleştirin.
 
 Ayrı MiniMax platform CLI'si (`mmx`) bir dosya anahtarı entegrasyonu değildir.
 Metin komutları MiniMax'ın Anthropic uyumlu uç noktasını kullandığı için OpenCodex,

--- a/docs-site/src/content/docs/zh-tw/guides/integrations.md
+++ b/docs-site/src/content/docs/zh-tw/guides/integrations.md
@@ -87,6 +87,10 @@ ocx integration client enable --client mcode
 ocx mcode
 ```
 
+完成一次連接後，`ocx sync` 也會以目前的 context window 與 reasoning-effort 階梯更新
+OpenCodex 已擁有的 MCode 區塊。若區塊已刪除、遭外部修改、不安全或從未由 OpenCodex
+建立，sync 會保持原檔不動；只有在你確定要重新連接時才再次執行 enable。
+
 另一個 MiniMax 平台 CLI（`mmx`）不是檔案開關整合。其文字命令使用 MiniMax 的
 Anthropic 相容端點，因此 OpenCodex 提供憑證隔離、僅限 loopback 的 launcher：
 

--- a/docs-site/src/content/docs/zh-tw/guides/integrations.md
+++ b/docs-site/src/content/docs/zh-tw/guides/integrations.md
@@ -26,7 +26,9 @@ loopback，而且絕不會寫入真實憑證。
 MiniMax Code 依序遵循 `MINIMAX_DATA_DIR`、`MAVIS_DATA_DIR`，最後才回退到
 `~/.minimax`。其受管理區塊只擁有 `custom_provider.opencodex`，不會變更
 `defaultModel`、MiniMax 憑證來源或使用者的 MiniMax 登入。連接後請在 MCode
-中選擇 `custom_provider:opencodex/<provider/model>`。
+中選擇 `custom_provider:opencodex/<provider/model>`。重新整理整合也會更新有可靠來源的
+逐模型 context window 與 reasoning-effort 選項；未知能力會省略，而 MCode session
+目前選取的 effort 不會被覆寫。
 
 路徑遵循客戶端自己的環境覆寫（environment override）。對 OMP 而言，`OMP_PROFILE` 以存在與否優先於 `PI_PROFILE`，即使明確為空也一樣。具名 profile 會把 `PI_CONFIG_DIR` 當作相對於使用者家目錄的目錄名稱，並忽略 `PI_CODING_AGENT_DIR`；沒有具名 profile 時，`PI_CODING_AGENT_DIR` 勝出。OMP 支援 provider 層級的 headers，但這個最初的整合刻意只支援 loopback；遠端 `x-opencodex-api-key` 的連線設定被延後。搬移過的 `HERMES_HOME`、`KIMI_CODE_HOME` 與 `XDG_CONFIG_HOME` 路徑同樣會被遵循，而非猜測。表格列出每個客戶端的預設值。
 

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -204,8 +204,9 @@ const commandRunners: Record<string, CommandRunner> = {
   },
   sync: async deps => {
     const restartCodex = deps.args.slice(1).includes("--restart-codex");
+    const live = await deps.findLiveProxy();
     const synced = await syncModelsToCodex(
-      (await deps.findLiveProxy())?.port,
+      live?.port,
       undefined,
       undefined,
       undefined,
@@ -228,6 +229,28 @@ const commandRunners: Record<string, CommandRunner> = {
     // exactly when a long-lived app-server is holding the stale list.
     if (synced.catalogWritten || synced.cacheSynced) {
       afterCatalogWriteHandleAppServers({ restart: restartCodex, log: console });
+    }
+    // `ocx sync` is a direct CLI path; it does not call the management
+    // `/api/sync` route. Refresh the already-connected MCode block here too,
+    // after Codex has published the catalog that supplies its capabilities.
+    if (synced.status !== "refused" && live) {
+      try {
+        const config = deps.loadConfig();
+        const { refreshOwnedIntegration } = await import("../integrations/owned-refresh");
+        const result = await refreshOwnedIntegration({
+          clientId: "mcode",
+          models: async () => {
+            const { loadExportModels } = await import("../server/management/model-rows");
+            return loadExportModels(config);
+          },
+          config,
+          port: live.port,
+        });
+        if (result?.changed) console.log("MCode integration refreshed from the current catalog.");
+        else if (result?.reason) console.warn(`MCode integration was not refreshed: ${result.reason}`);
+      } catch (error) {
+        console.warn(`MCode integration was not refreshed: ${error instanceof Error ? error.message : String(error)}`);
+      }
     }
     return code;
   },

--- a/src/clients/config-export.ts
+++ b/src/clients/config-export.ts
@@ -25,6 +25,7 @@ import { isAbsolute, join, resolve } from "node:path";
 import { shouldInjectApiAuthHeader } from "../codex/inject";
 import { FORMAT_MEDIA_TYPE, serializeDocument, type ConfigFormat } from "../integrations/serialize";
 import { providerCodexAccountMode } from "../providers/registry";
+import { sanitizeCodexReasoningEfforts } from "../reasoning-effort";
 import { probeHostname } from "../server/proxy-liveness";
 import type { OcxConfig } from "../types";
 
@@ -928,7 +929,14 @@ export interface McodeProviderBlock {
     baseURL: string;
     authMode: "api-key";
   };
-  models: Record<string, Record<string, never>>;
+  models: Record<string, McodeModelEntry>;
+}
+
+export interface McodeModelEntry {
+  /** MCode uses this value for context accounting and compaction. */
+  limit?: { context: number };
+  /** MCode exposes these exact levels in `/model` and sends the selected effort. */
+  thinking?: { effortOptions: string[] };
 }
 
 export interface McodeGeneratedConfig {
@@ -1273,12 +1281,29 @@ function buildDshClientConfig(ctx: ExportContext): DshGeneratedConfig {
 
 /**
  * MiniMax Code's `provider add` command persists custom providers under
- * `custom_provider.<id>`. Do not emit `defaultModel`: connecting a client must
- * not silently replace the user's current model selection.
+ * `custom_provider.<id>`. Its current model schema reads `limit.context` for
+ * context accounting and `thinking.effortOptions` for the `/model` effort
+ * control. Do not emit the removed `thinking.effort` / `defaultEffort` fields:
+ * MCode 0.1.6 migrates those into options and keeps the selected effort in the
+ * session. Do not emit `defaultModel` either: connecting a client must not
+ * silently replace the user's current model selection.
  */
 function buildMcodeClientConfig(ctx: ExportContext): McodeGeneratedConfig {
-  const models: Record<string, Record<string, never>> = {};
-  for (const model of normalizeExportModels(ctx.models)) models[model.namespaced] = {};
+  const models: Record<string, McodeModelEntry> = {};
+  for (const model of normalizeExportModels(ctx.models)) {
+    const entry: McodeModelEntry = {};
+    const context = authoritativeContextWindow(model.contextWindow);
+    if (context !== undefined) entry.limit = { context };
+    // `none` is an internal Codex catalog sentinel, not an MCode effort. MCode
+    // forwards every option as `output_config.effort` while keeping adaptive
+    // thinking enabled, and the Anthropic ingress deliberately accepts only
+    // minimal..ultra. Advertising `none` would therefore create a selectable
+    // value that cannot disable reasoning and is not forwarded as an effort.
+    const efforts = sanitizeCodexReasoningEfforts(model.reasoningEfforts)
+      ?.filter(effort => effort !== "none");
+    if (efforts && efforts.length > 0) entry.thinking = { effortOptions: efforts };
+    models[model.namespaced] = entry;
+  }
   return {
     custom_provider: {
       [OPENCODE_PROVIDER_ID]: {
@@ -1395,8 +1420,7 @@ function summarizeDsh(document: unknown): { modelCount: number; modelsWithoutLim
 
 function summarizeMcode(document: unknown): { modelCount: number; modelsWithoutLimits: number } {
   const models = Object.values((document as McodeGeneratedConfig | undefined)?.custom_provider?.[OPENCODE_PROVIDER_ID]?.models ?? {});
-  // MCode's custom-provider schema does not expose per-model context limits.
-  return { modelCount: models.length, modelsWithoutLimits: 0 };
+  return { modelCount: models.length, modelsWithoutLimits: models.filter(model => !model.limit).length };
 }
 
 function summarizeZcode(document: unknown): { modelCount: number; modelsWithoutLimits: number } {

--- a/src/integrations/mutation-flight.ts
+++ b/src/integrations/mutation-flight.ts
@@ -1,0 +1,71 @@
+import type { IntegrationClientId } from "./registry";
+
+const INTEGRATION_MUTATION_JOIN_MS = 120_000;
+export const INTEGRATION_MUTATION_TERMINAL_MS = 10 * 60_000;
+
+interface IntegrationMutationFlight {
+  key: string;
+  startedAt: number;
+  promise: Promise<unknown>;
+}
+
+export class IntegrationMutationBusyError extends Error {
+  constructor(readonly clientId: IntegrationClientId) {
+    super("integration_mutation_busy");
+  }
+}
+
+const integrationMutationFlights = new Map<IntegrationClientId, IntegrationMutationFlight>();
+let integrationMutationRunTestHook: ((operation: () => Promise<unknown>) => Promise<unknown>) | null = null;
+
+/**
+ * One in-process flight per client, shared by explicit HTTP mutations and
+ * implicit catalog refreshes. Equal operations join; different semantics are
+ * busy instead of, for example, letting an explicit apply join a refresh-only
+ * no-op for an absent block.
+ */
+export function runIntegrationMutationFlight<T>(
+  clientId: IntegrationClientId,
+  key: string,
+  now: () => number,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const startedAt = now();
+  const current = integrationMutationFlights.get(clientId);
+  if (current) {
+    const age = startedAt - current.startedAt;
+    if (current.key === key && age < INTEGRATION_MUTATION_JOIN_MS) {
+      return current.promise as Promise<T>;
+    }
+    if (age <= INTEGRATION_MUTATION_TERMINAL_MS) {
+      return Promise.reject(new IntegrationMutationBusyError(clientId));
+    }
+    if (integrationMutationFlights.get(clientId) === current) {
+      integrationMutationFlights.delete(clientId);
+    }
+  }
+
+  const flight: IntegrationMutationFlight = {
+    key,
+    startedAt,
+    promise: Promise.resolve(),
+  };
+  const run = async (): Promise<unknown> => operation();
+  flight.promise = (integrationMutationRunTestHook
+    ? integrationMutationRunTestHook(run)
+    : run()
+  ).finally(() => {
+    if (integrationMutationFlights.get(clientId) === flight) {
+      integrationMutationFlights.delete(clientId);
+    }
+  });
+  integrationMutationFlights.set(clientId, flight);
+  return flight.promise as Promise<T>;
+}
+
+export function setIntegrationMutationFlightTestHook(
+  run: ((operation: () => Promise<unknown>) => Promise<unknown>) | null,
+): void {
+  integrationMutationRunTestHook = run;
+  integrationMutationFlights.clear();
+}

--- a/src/integrations/owned-refresh.ts
+++ b/src/integrations/owned-refresh.ts
@@ -1,0 +1,70 @@
+/**
+ * Refresh a file integration only when OpenCodex already owns its block.
+ *
+ * This is the safe bridge between an implicit operation such as `ocx sync`
+ * and the explicit integration writer. An implicit sync may update a block
+ * the user previously enabled, but it must never claim an unowned block,
+ * recreate one the user removed, or overwrite edits made after our write.
+ */
+import type { ExportModel } from "../clients/config-export";
+import type { OcxConfig } from "../types";
+import type { IntegrationIO } from "./config-io";
+import type { IntegrationClientId } from "./registry";
+import { runIntegrationMutationFlight } from "./mutation-flight";
+import { createIntegrationStateStore, type IntegrationStateStore } from "./store";
+import { refreshIntegrationCoordinated } from "./writer";
+
+export interface OwnedIntegrationRefreshInput {
+  clientId: IntegrationClientId;
+  /** Lazy in `ocx sync`, so an unowned client does not even load the catalog. */
+  models: readonly ExportModel[] | (() => Promise<readonly ExportModel[]>);
+  config: OcxConfig;
+  port: number;
+  env?: NodeJS.ProcessEnv;
+  home?: string;
+  store?: IntegrationStateStore;
+  io?: IntegrationIO;
+}
+
+export interface OwnedIntegrationRefreshOutcome {
+  readonly client: IntegrationClientId;
+  readonly ok: boolean;
+  readonly changed?: boolean;
+  readonly reason?: string;
+}
+
+/**
+ * Returns `null` when the client has never been connected by OpenCodex.
+ * Callers use that distinction to report "left alone" rather than "skipped".
+ */
+export async function refreshOwnedIntegration(
+  input: OwnedIntegrationRefreshInput,
+): Promise<OwnedIntegrationRefreshOutcome | null> {
+  const store = input.store ?? createIntegrationStateStore();
+
+  // The ownership record is the user's durable opt-in. Do this check before
+  // reading or classifying the target so an implicit sync can never turn an
+  // unowned provider block into one of ours.
+  const record = store.readRecords()[input.clientId];
+  if (!record || record.clientId !== input.clientId) return null;
+
+  const { models: suppliedModels, ...rest } = input;
+  const models = typeof suppliedModels === "function"
+    ? await suppliedModels()
+    : suppliedModels;
+  const bound = { ...rest, models, store };
+  const result = await runIntegrationMutationFlight(
+    input.clientId,
+    "refresh",
+    input.io?.now ?? Date.now,
+    () => refreshIntegrationCoordinated(bound),
+  );
+  return result.ok
+    ? {
+        client: input.clientId,
+        ok: true,
+        changed: result.changed,
+        ...(result.state === "absent" ? { reason: result.message } : {}),
+      }
+    : { client: input.clientId, ok: false, reason: result.message };
+}

--- a/src/integrations/owned-refresh.ts
+++ b/src/integrations/owned-refresh.ts
@@ -12,7 +12,10 @@ import type { IntegrationIO } from "./config-io";
 import type { IntegrationClientId } from "./registry";
 import { runIntegrationMutationFlight } from "./mutation-flight";
 import { createIntegrationStateStore, type IntegrationStateStore } from "./store";
-import { refreshIntegrationCoordinated } from "./writer";
+import {
+  refreshIntegrationCoordinated,
+  type CoordinatedIntegrationOptions,
+} from "./writer";
 
 export interface OwnedIntegrationRefreshInput {
   clientId: IntegrationClientId;
@@ -39,6 +42,7 @@ export interface OwnedIntegrationRefreshOutcome {
  */
 export async function refreshOwnedIntegration(
   input: OwnedIntegrationRefreshInput,
+  options?: CoordinatedIntegrationOptions,
 ): Promise<OwnedIntegrationRefreshOutcome | null> {
   const store = input.store ?? createIntegrationStateStore();
 
@@ -57,7 +61,7 @@ export async function refreshOwnedIntegration(
     input.clientId,
     "refresh",
     input.io?.now ?? Date.now,
-    () => refreshIntegrationCoordinated(bound),
+    () => refreshIntegrationCoordinated(bound, options),
   );
   return result.ok
     ? {

--- a/src/integrations/registry.ts
+++ b/src/integrations/registry.ts
@@ -134,6 +134,7 @@ export const INTEGRATION_CLIENTS: Record<IntegrationClientId, IntegrationClientS
     id: "mcode",
     configPath: (env = process.env, home = homedir()) => mcodeConfigPath(env, home),
     detectDir: (env = process.env, home = homedir()) => mcodeHomeDir(env, home),
+    writerLock: { suffix: ".lock" },
   },
   zcode: {
     id: "zcode",

--- a/src/integrations/writer.ts
+++ b/src/integrations/writer.ts
@@ -240,7 +240,7 @@ function preflight(input: IntegrationWriteInput) {
   return { failed: undefined, store, io, clientId, spec, exportSpec, configPath, before, parsed, contribution, record, classified } as const;
 }
 
-export function applyIntegration(input: IntegrationWriteInput): WriteOutcome {
+function applyOrRefreshIntegration(input: IntegrationWriteInput, allowAbsent: boolean): WriteOutcome {
   const pre = preflight(input);
   if (pre.failed) return pre.failed;
   const { store, io, clientId, spec, exportSpec, configPath, before, parsed, contribution, record, classified } = pre;
@@ -270,6 +270,21 @@ export function applyIntegration(input: IntegrationWriteInput): WriteOutcome {
       classified.reason === "blocked-container"
         ? `${configPath} holds a value where opencodex would have to write a section, so applying would replace it`
         : `${configPath} cannot be changed safely`);
+  }
+  /*
+   * An implicit catalog sync is refresh-only. Keeping this decision inside the
+   * writer's one preflight closes the read-then-apply race where a user could
+   * remove the managed block after a caller classified it as stale and a
+   * normal apply would silently recreate it.
+   */
+  if (classified.state === "absent" && !allowAbsent) {
+    return {
+      ok: true,
+      changed: false,
+      state: "absent",
+      clientId,
+      message: "managed block is absent; refresh did not reconnect it",
+    };
   }
   if (classified.state === "current") {
     return { ok: true, changed: false, state: "current", clientId, message: "already applied" };
@@ -350,6 +365,15 @@ export function applyIntegration(input: IntegrationWriteInput): WriteOutcome {
     entry,
     snapshotPath: snapshotAbsPath(store, entry),
   });
+}
+
+export function applyIntegration(input: IntegrationWriteInput): WriteOutcome {
+  return applyOrRefreshIntegration(input, true);
+}
+
+/** Refresh an owned stale block, but never create or reconnect an absent one. */
+export function refreshIntegration(input: IntegrationWriteInput): WriteOutcome {
+  return applyOrRefreshIntegration(input, false);
 }
 
 export function disableIntegration(input: IntegrationWriteInput): WriteOutcome {
@@ -625,6 +649,13 @@ export function applyIntegrationCoordinated(
   options?: CoordinatedIntegrationOptions,
 ): Promise<WriteOutcome> {
   return coordinatedWrite(input, applyIntegration, options);
+}
+
+export function refreshIntegrationCoordinated(
+  input: IntegrationWriteInput,
+  options?: CoordinatedIntegrationOptions,
+): Promise<WriteOutcome> {
+  return coordinatedWrite(input, refreshIntegration, options);
 }
 
 export function disableIntegrationCoordinated(

--- a/src/server/management/config-routes.ts
+++ b/src/server/management/config-routes.ts
@@ -127,21 +127,22 @@ async function sidecarVisionResponseSettings(config: OcxConfig): Promise<{
 
 /** One client's outcome from a fan-out sync. Absent from the list means "left alone". */
 interface ClientIntegrationSyncOutcome {
-  readonly client: "grok" | "claude-desktop";
+  readonly client: "grok" | "claude-desktop" | "mcode";
   readonly ok: boolean;
   readonly changed?: boolean;
   readonly reason?: string;
 }
 
 /**
- * Re-inject every client integration the operator has switched ON.
+ * Re-inject native clients that are switched ON and file integrations whose
+ * OpenCodex ownership record is the operator's durable opt-in.
  *
  * Only Codex used to run here, so a catalog change reached Codex and nothing else: a Grok
  * fence or a written Desktop profile kept the context windows it was created with until the
  * next `ocx start`. The startup path already gates each client on its own toggle
  * (`src/cli/index.ts`), and this is that same fan-out for the on-demand command.
  *
- * A client that is OFF is omitted from the result rather than reported as skipped — the
+ * A client that is OFF or never connected is omitted from the result rather than reported as skipped — the
  * caller has to be able to tell "not touched" from "tried and failed". A client that fails
  * does not fail the sync: Codex is the one that matters for routing, and a broken Grok file
  * should surface as a warning, not as a 500 on a command that did its main job.
@@ -188,6 +189,31 @@ async function syncEnabledClientIntegrations(
     } catch (error) {
       out.push({ client: "claude-desktop", ok: false, reason: error instanceof Error ? error.message : String(error) });
     }
+  }
+
+  try {
+    const { refreshOwnedIntegration } = await import("../../integrations/owned-refresh");
+    const result = await refreshOwnedIntegration({
+      clientId: "mcode",
+      models: async () => {
+        const { loadExportModels } = await import("./model-rows");
+        return loadExportModels(config);
+      },
+      config,
+      port,
+    });
+    if (result) {
+      out.push(result.ok
+        ? {
+            client: "mcode",
+            ok: true,
+            changed: result.changed === true,
+            ...(result.reason ? { reason: result.reason } : {}),
+          }
+        : { client: "mcode", ok: false, reason: result.reason });
+    }
+  } catch (error) {
+    out.push({ client: "mcode", ok: false, reason: error instanceof Error ? error.message : String(error) });
   }
 
   return out;

--- a/src/server/management/integration-routes.ts
+++ b/src/server/management/integration-routes.ts
@@ -27,6 +27,12 @@ import {
   type WriteRefused,
 } from "../../integrations/writer";
 import { IntegrationWriterLockBusyError, type IntegrationWriterLockSeams } from "../../integrations/writer-lock";
+import {
+  INTEGRATION_MUTATION_TERMINAL_MS,
+  IntegrationMutationBusyError,
+  runIntegrationMutationFlight,
+  setIntegrationMutationFlightTestHook,
+} from "../../integrations/mutation-flight";
 import { jsonResponse } from "../auth-cors";
 import { readManagementJsonBody, rethrowManagementBodyTooLarge } from "./body";
 import type { ManagementContext } from "./context";
@@ -34,8 +40,7 @@ import { loadExportModels } from "./model-rows";
 
 
 const INTEGRATION_ROUTE_PREFIX = "/api/client-integrations/";
-const INTEGRATION_MUTATION_JOIN_MS = 120_000;
-export const INTEGRATION_MUTATION_TERMINAL_MS = 10 * 60_000;
+export { INTEGRATION_MUTATION_TERMINAL_MS };
 
 type IntegrationStateRecord = Awaited<ReturnType<typeof readIntegrationState>>;
 type ApplyResult = Awaited<ReturnType<typeof applyIntegrationCoordinated>>;
@@ -81,19 +86,6 @@ export interface IntegrationRestoreBody {
   confirmDrift?: boolean;
 }
 
-interface IntegrationMutationFlight {
-  key: string;
-  startedAt: number;
-  promise: Promise<unknown>;
-}
-
-class IntegrationMutationBusyError extends Error {
-  constructor(readonly clientId: IntegrationClientId) {
-    super("integration_mutation_busy");
-  }
-}
-
-const integrationMutationFlights = new Map<IntegrationClientId, IntegrationMutationFlight>();
 let integrationMutationTestHooks: {
   io?: IntegrationIO;
   lockSeams?: IntegrationWriterLockSeams;
@@ -145,45 +137,6 @@ function decodeClientPath(pathname: string): string | null {
   }
 }
 
-function runIntegrationMutationFlight<T>(
-  clientId: IntegrationClientId,
-  key: string,
-  now: () => number,
-  operation: () => Promise<T>,
-): Promise<T> {
-  const startedAt = now();
-  const current = integrationMutationFlights.get(clientId);
-  if (current) {
-    const age = startedAt - current.startedAt;
-    if (current.key === key && age < INTEGRATION_MUTATION_JOIN_MS) {
-      return current.promise as Promise<T>;
-    }
-    if (age <= INTEGRATION_MUTATION_TERMINAL_MS) {
-      return Promise.reject(new IntegrationMutationBusyError(clientId));
-    }
-    if (integrationMutationFlights.get(clientId) === current) {
-      integrationMutationFlights.delete(clientId);
-    }
-  }
-
-  const flight: IntegrationMutationFlight = {
-    key,
-    startedAt,
-    promise: Promise.resolve(),
-  };
-  const run = async (): Promise<unknown> => operation();
-  flight.promise = (integrationMutationTestHooks?.run
-    ? integrationMutationTestHooks.run(run)
-    : run()
-  ).finally(() => {
-    if (integrationMutationFlights.get(clientId) === flight) {
-      integrationMutationFlights.delete(clientId);
-    }
-  });
-  integrationMutationFlights.set(clientId, flight);
-  return flight.promise as Promise<T>;
-}
-
 export function setIntegrationMutationFlightTestHooks(
   hooks: {
     io?: IntegrationIO;
@@ -194,7 +147,7 @@ export function setIntegrationMutationFlightTestHooks(
   } | null,
 ): void {
   integrationMutationTestHooks = hooks;
-  integrationMutationFlights.clear();
+  setIntegrationMutationFlightTestHook(hooks?.run ?? null);
   // Path overrides are part of the same isolation contract: clearing flights
   // while leaving a temp home bound would let the next suite write real files.
   if (hooks === null) integrationPathTestHooks = null;

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -932,7 +932,11 @@ traffic cannot be sent off-machine, owns the temporary bridge lifecycle, and ref
 destination, region and credential overrides. It is
 loopback-only because MMX cannot carry the dedicated remote-admission header. MiniMax Code uses
 the separate reversible `custom_provider.opencodex` file integration and is likewise
-loopback-only; its generated block never changes `defaultModel`.
+loopback-only; its generated block never changes `defaultModel`. Each generated MCode model
+copies an authoritative catalog context window into `limit.context` and a nonempty canonical
+reasoning ladder into `thinking.effortOptions`. Missing capabilities stay absent instead of
+falling back to OpenCodex guesses, and the integration does not write the removed
+`thinking.effort` / `defaultEffort` fields because MCode owns the active effort per session.
 
 ## Anthropic structured-output compatibility
 

--- a/tests/integrations-invariants.test.ts
+++ b/tests/integrations-invariants.test.ts
@@ -102,8 +102,9 @@ describe("the client registries cannot drift apart", () => {
     expect(INTEGRATION_CLIENTS.dsh.sourcePreservingYaml?.path).toEqual([
       "llm-pi-ai", "providers", "opencodex",
     ]);
-    expect(INTEGRATION_CLIENT_IDS.filter(id => INTEGRATION_CLIENTS[id].writerLock)).toEqual(["dsh"]);
+    expect(INTEGRATION_CLIENT_IDS.filter(id => INTEGRATION_CLIENTS[id].writerLock)).toEqual(["dsh", "mcode"]);
     expect(INTEGRATION_CLIENTS.dsh.writerLock).toEqual({ suffix: ".lock" });
+    expect(INTEGRATION_CLIENTS.mcode.writerLock).toEqual({ suffix: ".lock" });
   });
 });
 

--- a/tests/management-client-config-route.test.ts
+++ b/tests/management-client-config-route.test.ts
@@ -10,6 +10,7 @@ import {
   opencodeGlobalConfigPath,
   type DshGeneratedConfig,
   type ExportModel,
+  type McodeGeneratedConfig,
   type OpencodeGeneratedConfig,
   type PiGeneratedConfig,
 } from "../src/clients/config-export";
@@ -67,6 +68,7 @@ function baseConfig(overrides: Partial<OcxConfig> = {}): OcxConfig {
         liveModels: false,
         models: ["m1", "m2"],
         modelContextWindows: { m1: 128_000 },
+        modelReasoningEfforts: { m1: ["none", "minimal", "low", "high"] },
       },
       b: {
         adapter: "openai-chat",
@@ -203,6 +205,22 @@ describe("GET /api/client-config", () => {
       xhigh: "xhigh",
       max: "max",
     });
+  }, 15_000);
+
+  test("MCode response carries catalog context and its usable reasoning ladder", async () => {
+    const response = await clientConfigApi(baseConfig(), "?client=mcode");
+    expect(response.status).toBe(200);
+    const body = await response.json() as ClientConfigEnvelope;
+    const provider = (body.config as McodeGeneratedConfig).custom_provider[OPENCODE_PROVIDER_ID]!;
+
+    expect(body.format).toBe("yaml");
+    expect(Bun.YAML.parse(body.text)).toEqual(body.config as Record<string, unknown>);
+    expect(provider.models["a/m1"]).toEqual({
+      limit: { context: 128_000 },
+      thinking: { effortOptions: ["minimal", "low", "high"] },
+    });
+    expect(provider.models["b/no-context"]).toEqual({});
+    expect(body.modelsWithoutLimits).toBeGreaterThan(0);
   }, 15_000);
 
   test("counts describe the emitted document, including models without limits", async () => {

--- a/tests/management-client-config-route.test.ts
+++ b/tests/management-client-config-route.test.ts
@@ -220,7 +220,7 @@ describe("GET /api/client-config", () => {
       thinking: { effortOptions: ["minimal", "low", "high"] },
     });
     expect(provider.models["b/no-context"]).toEqual({});
-    expect(body.modelsWithoutLimits).toBeGreaterThan(0);
+    expect(body.modelsWithoutLimits).toBe(2);
   }, 15_000);
 
   test("counts describe the emitted document, including models without limits", async () => {

--- a/tests/management-integration-routes.test.ts
+++ b/tests/management-integration-routes.test.ts
@@ -82,6 +82,7 @@ function baseConfig(): OcxConfig {
         liveModels: false,
         models: ["m1"],
         modelContextWindows: { m1: 128_000 },
+        modelReasoningEfforts: { m1: ["minimal", "low", "high"] },
       },
     },
   } as unknown as OcxConfig;
@@ -123,6 +124,12 @@ function installOmp(): string {
 
 function installDsh(): string {
   const spec = INTEGRATION_CLIENTS.dsh;
+  mkdirSync(spec.detectDir(routeEnv, home), { recursive: true });
+  return spec.configPath(routeEnv, home);
+}
+
+function installMcode(): string {
+  const spec = INTEGRATION_CLIENTS.mcode;
   mkdirSync(spec.detectDir(routeEnv, home), { recursive: true });
   return spec.configPath(routeEnv, home);
 }
@@ -319,6 +326,34 @@ describe("PUT /api/client-integrations/:clientId", () => {
     });
     expect(existsSync(hermesConfigPath())).toBe(false);
     expect(store.listOperations()).toHaveLength(0);
+  });
+
+  test("MCode apply and stale refresh write context and reasoning capabilities", async () => {
+    const configPath = installMcode();
+    expect((await put("mcode", true)).status).toBe(200);
+
+    const applied = Bun.YAML.parse(readFileSync(configPath, "utf8")) as {
+      custom_provider: { opencodex: { models: Record<string, unknown> } };
+    };
+    expect(applied.custom_provider.opencodex.models["a/m1"]).toEqual({
+      limit: { context: 128_000 },
+      thinking: { effortOptions: ["minimal", "low", "high"] },
+    });
+
+    config.providers.a!.modelContextWindows = { m1: 256_000 };
+    config.providers.a!.modelReasoningEfforts = { m1: ["low", "medium", "max"] };
+    const refreshed = await put("mcode", true);
+    expect(refreshed.status).toBe(200);
+    expect((await refreshed.json() as { changed: boolean }).changed).toBe(true);
+
+    const afterRefresh = Bun.YAML.parse(readFileSync(configPath, "utf8")) as {
+      custom_provider: { opencodex: { models: Record<string, unknown> } };
+    };
+    expect(afterRefresh.custom_provider.opencodex.models["a/m1"]).toEqual({
+      limit: { context: 256_000 },
+      thinking: { effortOptions: ["low", "medium", "max"] },
+    });
+    expect(store.listOperations("mcode").map(row => row.kind)).toEqual(["refresh", "apply"]);
   });
 });
 

--- a/tests/minimax-clients.test.ts
+++ b/tests/minimax-clients.test.ts
@@ -4,6 +4,7 @@ import { createServer } from "node:net";
 import { join } from "node:path";
 import {
   ClientPathError,
+  EXPORT_CLIENTS,
   LOOPBACK_API_KEY_PLACEHOLDER,
   OPENCODE_PROVIDER_ID,
   buildClientConfig,
@@ -39,14 +40,21 @@ function context(): ExportContext {
     baseUrl: "http://127.0.0.1:10100/v1",
     config: CONFIG,
     models: [
-      { namespaced: "openai/gpt-5.6-sol", provider: "openai", id: "gpt-5.6-sol" },
+      {
+        namespaced: "openai/gpt-5.6-sol",
+        provider: "openai",
+        id: "gpt-5.6-sol",
+        contextWindow: 272_000,
+        reasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
+        defaultReasoningEffort: "xhigh",
+      },
       { namespaced: "anthropic/claude-opus-5", provider: "anthropic", id: "claude-opus-5" },
     ],
   };
 }
 
 describe("MiniMax Code client config", () => {
-  test("adds only custom_provider.opencodex and never changes the selected model", () => {
+  test("adds only custom_provider.opencodex, syncs model capabilities, and never changes the selected model", () => {
     const document = buildClientConfig("mcode", context()) as McodeGeneratedConfig;
     expect(Object.keys(document)).toEqual(["custom_provider"]);
     expect(document).not.toHaveProperty("defaultModel");
@@ -63,9 +71,60 @@ describe("MiniMax Code client config", () => {
       },
       models: {
         "anthropic/claude-opus-5": {},
-        "openai/gpt-5.6-sol": {},
+        "openai/gpt-5.6-sol": {
+          limit: { context: 272_000 },
+          thinking: { effortOptions: ["low", "medium", "high", "xhigh", "max", "ultra"] },
+        },
       },
     });
+    expect(provider.models["openai/gpt-5.6-sol"]?.thinking).not.toHaveProperty("effort");
+    expect(provider.models["openai/gpt-5.6-sol"]?.thinking).not.toHaveProperty("defaultEffort");
+    expect(EXPORT_CLIENTS.mcode.summarize(document)).toEqual({ modelCount: 2, modelsWithoutLimits: 1 });
+  });
+
+  test("omits invalid context windows and empty effort ladders instead of guessing", () => {
+    const document = buildClientConfig("mcode", {
+      ...context(),
+      models: [
+        { namespaced: "mock/zero", provider: "mock", id: "zero", contextWindow: 0, reasoningEfforts: [] },
+        { namespaced: "mock/nan", provider: "mock", id: "nan", contextWindow: Number.NaN },
+      ],
+    }) as McodeGeneratedConfig;
+
+    expect(document.custom_provider[OPENCODE_PROVIDER_ID]!.models).toEqual({
+      "mock/nan": {},
+      "mock/zero": {},
+    });
+  });
+
+  test("canonicalizes declared effort options and drops unsupported values and Codex's none sentinel", () => {
+    const document = buildClientConfig("mcode", {
+      ...context(),
+      models: [{
+        namespaced: "mock/reasoning",
+        provider: "mock",
+        id: "reasoning",
+        reasoningEfforts: ["max", "none", "unsupported", "minimal", "low", "high", "low"],
+      }],
+    }) as McodeGeneratedConfig;
+
+    expect(document.custom_provider[OPENCODE_PROVIDER_ID]!.models["mock/reasoning"]).toEqual({
+      thinking: { effortOptions: ["minimal", "low", "high", "max"] },
+    });
+  });
+
+  test("omits thinking when none is the only declared effort", () => {
+    const document = buildClientConfig("mcode", {
+      ...context(),
+      models: [{
+        namespaced: "mock/no-reasoning",
+        provider: "mock",
+        id: "no-reasoning",
+        reasoningEfforts: ["none"],
+      }],
+    }) as McodeGeneratedConfig;
+
+    expect(document.custom_provider[OPENCODE_PROVIDER_ID]!.models["mock/no-reasoning"]).toEqual({});
   });
 
   test("native YAML round-trips and contains no credential-shaped value", () => {

--- a/tests/sync-client-integrations.test.ts
+++ b/tests/sync-client-integrations.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import type { ExportModel } from "../src/clients/config-export";
 import { claudeDesktopIntegrationEnabled, grokIntegrationEnabled } from "../src/codex/desired-state";
+import { INTEGRATION_CLIENTS } from "../src/integrations/registry";
+import { IntegrationMutationBusyError, runIntegrationMutationFlight } from "../src/integrations/mutation-flight";
+import { refreshOwnedIntegration } from "../src/integrations/owned-refresh";
+import { createIntegrationStateStore, type IntegrationStateStore } from "../src/integrations/store";
+import { applyIntegration } from "../src/integrations/writer";
 import type { OcxConfig } from "../src/types";
 
 /**
@@ -9,7 +18,7 @@ import type { OcxConfig } from "../src/types";
  *
  * These pin the gate the fan-out asks and the ordering the route depends on.
  */
-describe("ocx sync fans out to the client integrations that are switched on", () => {
+describe("ocx sync fans out to enabled native clients and owned file integrations", () => {
   const base = { port: 10100, defaultProvider: "x", providers: {} } as OcxConfig;
 
   test("an absent toggle means ON — that is the shipped default, not an opt-in", () => {
@@ -48,9 +57,11 @@ describe("ocx sync fans out to the client integrations that are switched on", ()
 
     expect(fn).toContain("grokIntegrationEnabled(config)");
     expect(fn).toContain("claudeDesktopIntegrationEnabled(config)");
-    // One catch per client: a broken Grok file is a warning, not a 500 on a command whose
+    expect(fn).toContain('clientId: "mcode"');
+    expect(fn).toContain("refreshOwnedIntegration");
+    // One catch per client: a broken client file is a warning, not a 500 on a command whose
     // main job (the Codex catalog) succeeded.
-    expect(fn.match(/catch \(error\)/g)?.length).toBe(2);
+    expect(fn.match(/catch \(error\)/g)?.length).toBe(3);
     // The Desktop write gets the native context limits, same as every other Desktop
     // call site. 8b672205e threaded `nativeContextLimits` through those writers and
     // left this assertion naming the retired `providerContextCap` spelling, so the
@@ -60,4 +71,188 @@ describe("ocx sync fans out to the client integrations that are switched on", ()
     // tell "left alone" from "tried and failed", so there is no skipped state to emit.
     expect(fn).not.toContain('"skipped"');
   });
+});
+
+describe("ocx sync refreshes an already-owned MCode integration", () => {
+  const env = {} as NodeJS.ProcessEnv;
+  const config = {
+    port: 10100,
+    hostname: "127.0.0.1",
+    defaultProvider: "mock",
+    providers: { mock: { adapter: "openai-chat", baseUrl: "http://127.0.0.1/v1" } },
+  } as OcxConfig;
+  const oldModels: ExportModel[] = [{
+    namespaced: "openai/gpt-5.6-sol",
+    provider: "openai",
+    id: "gpt-5.6-sol",
+    contextWindow: 272_000,
+    reasoningEfforts: ["low", "medium", "high", "xhigh"],
+  }];
+  const newModels: ExportModel[] = [{
+    namespaced: "openai/gpt-5.6-sol",
+    provider: "openai",
+    id: "gpt-5.6-sol",
+    contextWindow: 922_000,
+    reasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
+  }];
+
+  let root: string;
+  let home: string;
+  let store: IntegrationStateStore;
+  let configPath: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "ocx-mcode-auto-sync-"));
+    home = join(root, "home");
+    store = createIntegrationStateStore(join(root, "state", "integrations"));
+    const spec = INTEGRATION_CLIENTS.mcode;
+    mkdirSync(spec.detectDir(env, home), { recursive: true });
+    configPath = spec.configPath(env, home);
+    mkdirSync(dirname(configPath), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function input(models: readonly ExportModel[] | (() => Promise<readonly ExportModel[]>)) {
+    return { clientId: "mcode" as const, models, config, port: 10100, env, home, store };
+  }
+
+  test("updates context and the full max/ultra effort ladder through the real writer", async () => {
+    writeFileSync(configPath, "theme: dark\n");
+    const applied = applyIntegration(input(oldModels));
+    expect(applied.ok).toBe(true);
+
+    const refreshed = await refreshOwnedIntegration(input(newModels));
+    expect(refreshed).toEqual({ client: "mcode", ok: true, changed: true });
+
+    const document = Bun.YAML.parse(readFileSync(configPath, "utf8")) as {
+      custom_provider: { opencodex: { models: Record<string, unknown> } };
+    };
+    expect(document.custom_provider.opencodex.models["openai/gpt-5.6-sol"]).toEqual({
+      limit: { context: 922_000 },
+      thinking: { effortOptions: ["low", "medium", "high", "xhigh", "max", "ultra"] },
+    });
+    expect(document).toMatchObject({ theme: "dark" });
+    expect(store.listOperations("mcode").map(row => row.kind)).toEqual(["refresh", "apply"]);
+  });
+
+  test("does nothing and never loads the catalog when no ownership record exists", async () => {
+    const before = [
+      "custom_provider:",
+      "  opencodex:",
+      "    name: User-owned OpenCodex block",
+      "    models: {}",
+      "",
+    ].join("\n");
+    writeFileSync(configPath, before);
+
+    let catalogLoads = 0;
+    expect(await refreshOwnedIntegration(input(async () => {
+      catalogLoads += 1;
+      return newModels;
+    }))).toBeNull();
+    expect(catalogLoads).toBe(0);
+    expect(readFileSync(configPath, "utf8")).toBe(before);
+    expect(store.listOperations("mcode")).toHaveLength(0);
+  });
+
+  test("refuses a foreign edit without changing bytes or appending a journal row", async () => {
+    expect(applyIntegration(input(oldModels)).ok).toBe(true);
+    const recordBefore = JSON.stringify(store.readRecords().mcode);
+    const edited = readFileSync(configPath, "utf8").replace("context: 272000", "context: 123456");
+    expect(edited).not.toBe(readFileSync(configPath, "utf8"));
+    writeFileSync(configPath, edited);
+
+    const outcome = await refreshOwnedIntegration(input(newModels));
+    expect(outcome?.ok).toBe(false);
+    expect(outcome?.reason).toContain("changed after opencodex wrote it");
+    expect(readFileSync(configPath, "utf8")).toBe(edited);
+    expect(JSON.stringify(store.readRecords().mcode)).toBe(recordBefore);
+    expect(store.listOperations("mcode").map(row => row.kind)).toEqual(["apply"]);
+  });
+
+  test("refuses whole-file YAML drift even when the owned block itself is intact", async () => {
+    expect(applyIntegration(input(oldModels)).ok).toBe(true);
+    const recordBefore = JSON.stringify(store.readRecords().mcode);
+    const edited = `# user comment\n${readFileSync(configPath, "utf8")}`;
+    writeFileSync(configPath, edited);
+
+    const outcome = await refreshOwnedIntegration(input(newModels));
+    expect(outcome?.ok).toBe(false);
+    expect(outcome?.reason).toContain("changed after opencodex wrote it");
+    expect(readFileSync(configPath, "utf8")).toBe(edited);
+    expect(JSON.stringify(store.readRecords().mcode)).toBe(recordBefore);
+    expect(store.listOperations("mcode").map(row => row.kind)).toEqual(["apply"]);
+  });
+
+  test("does not recreate a managed block the user removed", async () => {
+    expect(applyIntegration(input(oldModels)).ok).toBe(true);
+    writeFileSync(configPath, "theme: dark\n");
+
+    const outcome = await refreshOwnedIntegration(input(newModels));
+    expect(outcome).toEqual({
+      client: "mcode",
+      ok: true,
+      changed: false,
+      reason: "managed block is absent; refresh did not reconnect it",
+    });
+    expect(readFileSync(configPath, "utf8")).toBe("theme: dark\n");
+    expect(store.listOperations("mcode").map(row => row.kind)).toEqual(["apply"]);
+  });
+
+  test("is a no-op when the owned block already matches the catalog", async () => {
+    expect(applyIntegration(input(newModels)).ok).toBe(true);
+
+    expect(await refreshOwnedIntegration(input(newModels)))
+      .toEqual({ client: "mcode", ok: true, changed: false });
+    expect(store.listOperations("mcode").map(row => row.kind)).toEqual(["apply"]);
+  });
+
+  test("does not recreate the client home or config when MCode was removed", async () => {
+    expect(applyIntegration(input(oldModels)).ok).toBe(true);
+    rmSync(INTEGRATION_CLIENTS.mcode.detectDir(env, home), { recursive: true, force: true });
+
+    const outcome = await refreshOwnedIntegration(input(newModels));
+    expect(outcome?.ok).toBe(false);
+    expect(outcome?.reason).toContain("mcode is not installed");
+    expect(existsSync(INTEGRATION_CLIENTS.mcode.detectDir(env, home))).toBe(false);
+    expect(store.listOperations("mcode").map(row => row.kind)).toEqual(["apply"]);
+  });
+});
+
+test("the direct ocx sync command refreshes MCode instead of relying on /api/sync", async () => {
+  const src = await Bun.file(new URL("../src/cli/dispatch.ts", import.meta.url)).text();
+  const start = src.indexOf("sync: async deps =>");
+  const command = src.slice(start, src.indexOf("v2: async deps =>", start));
+  expect(command).toContain("refreshOwnedIntegration");
+  expect(command).toContain('clientId: "mcode"');
+  expect(command.indexOf("syncModelsToCodex")).toBeLessThan(command.indexOf("refreshOwnedIntegration"));
+  expect(command).toContain('synced.status !== "refused"');
+});
+
+test("refresh joins refresh but cannot swallow an explicit apply or disable", async () => {
+  let release!: () => void;
+  const gate = new Promise<void>(resolve => { release = resolve; });
+  let refreshRuns = 0;
+  const first = runIntegrationMutationFlight("mcode", "refresh", () => 1_000, async () => {
+    refreshRuns += 1;
+    await gate;
+    return "refreshed";
+  });
+  const joined = runIntegrationMutationFlight("mcode", "refresh", () => 1_001, async () => {
+    refreshRuns += 1;
+    return "should-not-run";
+  });
+
+  await expect(runIntegrationMutationFlight("mcode", "apply", () => 1_002, async () => "applied"))
+    .rejects.toBeInstanceOf(IntegrationMutationBusyError);
+  await expect(runIntegrationMutationFlight("mcode", "disable", () => 1_003, async () => "disabled"))
+    .rejects.toBeInstanceOf(IntegrationMutationBusyError);
+
+  release();
+  expect(await first).toBe("refreshed");
+  expect(await joined).toBe("refreshed");
+  expect(refreshRuns).toBe(1);
 });

--- a/tests/sync-client-integrations.test.ts
+++ b/tests/sync-client-integrations.test.ts
@@ -8,7 +8,8 @@ import { INTEGRATION_CLIENTS } from "../src/integrations/registry";
 import { IntegrationMutationBusyError, runIntegrationMutationFlight } from "../src/integrations/mutation-flight";
 import { refreshOwnedIntegration } from "../src/integrations/owned-refresh";
 import { createIntegrationStateStore, type IntegrationStateStore } from "../src/integrations/store";
-import { applyIntegration } from "../src/integrations/writer";
+import type { IntegrationWriterLockSeams } from "../src/integrations/writer-lock";
+import { applyIntegration, disableIntegrationCoordinated } from "../src/integrations/writer";
 import type { OcxConfig } from "../src/types";
 
 /**
@@ -219,6 +220,84 @@ describe("ocx sync refreshes an already-owned MCode integration", () => {
     expect(outcome?.reason).toContain("mcode is not installed");
     expect(existsSync(INTEGRATION_CLIENTS.mcode.detectDir(env, home))).toBe(false);
     expect(store.listOperations("mcode").map(row => row.kind)).toEqual(["apply"]);
+  });
+
+  test("serializes a CLI refresh racing a server disable across the process boundary", async () => {
+    expect(applyIntegration(input(oldModels)).ok).toBe(true);
+    const before = readFileSync(configPath, "utf8");
+    const recordBefore = JSON.stringify(store.readRecords().mcode);
+
+    let held = false;
+    let acquisitions = 0;
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    let observeFirst!: () => void;
+    let observeSecond!: () => void;
+    let observeWaiter!: () => void;
+    const firstGate = new Promise<void>(resolve => { releaseFirst = resolve; });
+    const secondGate = new Promise<void>(resolve => { releaseSecond = resolve; });
+    const firstAcquired = new Promise<void>(resolve => { observeFirst = resolve; });
+    const secondAcquired = new Promise<void>(resolve => { observeSecond = resolve; });
+    const waiterBlocked = new Promise<void>(resolve => { observeWaiter = resolve; });
+    const released: Array<() => void> = [];
+    const lockSeams: IntegrationWriterLockSeams = {
+      writeFile: async () => {
+        if (held) throw Object.assign(new Error("contended"), { code: "EEXIST" });
+        held = true;
+        acquisitions += 1;
+        if (acquisitions === 1) {
+          observeFirst();
+          await firstGate;
+        } else if (acquisitions === 2) {
+          observeSecond();
+          await secondGate;
+        }
+      },
+      removeFile: async () => {
+        held = false;
+        for (const release of released.splice(0)) release();
+      },
+      now: () => 0,
+      delay: async () => {
+        observeWaiter();
+        await new Promise<void>(resolve => { released.push(resolve); });
+      },
+      pid: 22,
+    };
+
+    // These calls model separate processes: owned refresh has the CLI's in-memory
+    // flight map, while the direct coordinated disable has the server's map.
+    const refresh = refreshOwnedIntegration(input(newModels), { lockSeams });
+    await firstAcquired;
+    const disable = disableIntegrationCoordinated(input(newModels), { lockSeams });
+    await waiterBlocked;
+
+    // The contender cannot observe or create a half-committed transaction.
+    expect(readFileSync(configPath, "utf8")).toBe(before);
+    expect(JSON.stringify(store.readRecords().mcode)).toBe(recordBefore);
+    expect(store.listOperations("mcode").map(row => row.kind)).toEqual(["apply"]);
+
+    releaseFirst();
+    await secondAcquired;
+    expect(await refresh).toEqual({ client: "mcode", ok: true, changed: true });
+    const refreshed = Bun.YAML.parse(readFileSync(configPath, "utf8")) as {
+      custom_provider: { opencodex: { models: Record<string, unknown> } };
+    };
+    expect(refreshed.custom_provider.opencodex.models["openai/gpt-5.6-sol"]).toEqual({
+      limit: { context: 922_000 },
+      thinking: { effortOptions: ["low", "medium", "high", "xhigh", "max", "ultra"] },
+    });
+    expect(store.readRecords().mcode).toBeDefined();
+    expect(store.listOperations("mcode").map(row => row.kind)).toEqual(["refresh", "apply"]);
+
+    releaseSecond();
+    expect((await disable).ok).toBe(true);
+    expect(store.readRecords().mcode).toBeUndefined();
+    expect(store.listOperations("mcode").map(row => row.kind)).toEqual(["disable", "refresh", "apply"]);
+    const finalDocument = Bun.YAML.parse(readFileSync(configPath, "utf8")) as {
+      custom_provider?: { opencodex?: unknown };
+    };
+    expect(finalDocument.custom_provider?.opencodex).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
Lands PR #2220 by @Hylouis233 (MCode capability sync), rebased onto current dev with the two remaining review blockers fixed:
- French/Turkish MCode docs synchronized with the English capability + session-authoritative effort contract.
- MCode cross-process writer locking across refresh/apply/disable transactions, with a deterministic CLI-refresh vs server-disable race regression.

## Verification
- 246/0 across nine exporter/management suites; docs build 393 pages; tsc + privacy green.

## Checklist
- [x] Targets dev
- [x] Credits #2220 (@Hylouis233)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MiniMax Code configurations now include authoritative per-model context limits and supported reasoning-effort options.
  * `ocx sync` refreshes managed MiniMax Code settings when catalog capabilities change while preserving the current session effort.
  * Synchronization safely skips missing, externally modified, unsafe, deleted, or unmanaged configuration blocks.

* **Documentation**
  * Updated MiniMax Code integration guidance across supported languages to explain model capabilities and synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->