### PR TITLE
docs(devlog): bug-backlog train appended to the 2.28.0 release prep artifact

### DIFF
--- a/devlog/_plan/260820_sidecar_selection_unification/141_release_prep_artifact.md
+++ b/devlog/_plan/260820_sidecar_selection_unification/141_release_prep_artifact.md
@@ -40,6 +40,24 @@ Release command (maintainer-controlled): bun scripts/release.ts 2.28.0 --publish
 - Devlog: three-issue round record (#2181), backlog merge log (#2168),
   the 100-150 integration-train roadmap.
 
+## Bug-backlog train additions (260821, second loop)
+
+- #2269 — pool-switch ciphertext stripping locked + null-code encrypted-content
+  rejection recovery (fixes #2247).
+- #2271 — opencode-go /goal stream drops: namespace-flattening regression locked,
+  openaiChatEofTolerance opt-in for complete tool-call EOF (fixes #2260).
+- #2246 — google part-field contract enforcement (fixes #2233, maintainer PR
+  rebased+landed).
+- #2273 — deferred serving-identity commit + passthrough findings (credits #2264).
+- #2274 — zcode openai-compatible protocol, prefix-cache restore (credits #2261).
+- #2276 — MCode capability sync + writer locking (credits #2220).
+- #2277 — Cursor checkpoint reuse, fail-closed explicit refs (credits #2054).
+- Superseded/closed: #2267 (by #2262). Deferred to human security review: #2222.
+- Issues closed with evidence: #2247 #2260 #2233 #2240 #2188 #2190.
+
+RELEASE STATE: READY, NOT EXECUTED (user directive). One command away:
+`bun scripts/release.ts 2.28.0` (dry-run publish) or `--publish` — maintainer's call.
+
 ## Gate evidence (doc 150)
 - lidge full suite at 6aecc8f15: see /tmp/ocx-gate-final.log (this doc's D attest).
 - Local: tsc, oxlint (lint:gui), privacy:scan, build:gui + prepare-package green.


### PR DESCRIPTION
## Summary
Docs-only: appends the second-loop bug-backlog train to the 141 release-prep artifact (seven landed PRs, dispositions, closed issues) and records the release state: READY, NOT EXECUTED — one command away for the maintainer.

## Verification
- privacy:scan green; docs-only.

## Checklist
- [x] Targets dev


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a consolidated backlog section covering resolved, deferred, superseded, and closed issues.
  - Updated release documentation to reflect version 2.28.0 readiness.
  - Documented dry-run and publishing steps for the release process.
  - No user-facing product functionality or public APIs were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->