### PR TITLE
fix(router): backfill the xAI web-search capability into routed provider config

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -355,6 +355,17 @@ export function routedProviderConfig(providerName: string, provider: OcxProvider
     ...(provider.supportsServiceTier === undefined && registryEntry.supportsServiceTier !== undefined
       ? { supportsServiceTier: registryEntry.supportsServiceTier }
       : {}),
+    // Registry-only web-search capability: without this backfill a saved provider row reaches
+    // the Responses adapter with the flag `undefined`, so the capability gate added in #2262
+    // reads "unclassified" and forwards Codex's OpenAI-only `web_search` config fields. xAI
+    // rejects the whole request before inference ("Argument not supported:
+    // external_web_access"), which killed every routed Grok turn on the Responses lane.
+    // enrichProviderFromRegistry() already fills this, but the request path resolves through
+    // routedProviderConfig() and never called it.
+    ...(provider.supportsOpenAiWebSearchToolFields === undefined
+      && registryEntry.supportsOpenAiWebSearchToolFields !== undefined
+      ? { supportsOpenAiWebSearchToolFields: registryEntry.supportsOpenAiWebSearchToolFields }
+      : {}),
     ...(provider.preserveResponsesReasoningContent === undefined && registryEntry.preserveResponsesReasoningContent !== undefined
       ? { preserveResponsesReasoningContent: registryEntry.preserveResponsesReasoningContent }
       : {}),

--- a/tests/responses-routed-web-search-fields.test.ts
+++ b/tests/responses-routed-web-search-fields.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { createResponsesPassthroughAdapter as createResponsesPassthroughAdapterProduction, stripOpenAiOnlyWebSearchFields } from "../src/adapters/openai-responses";
 import { enrichProviderFromRegistry, providerConfigSeed } from "../src/providers/derive";
 import { getProviderRegistryEntry } from "../src/providers/registry";
+import { routedProviderConfig } from "../src/router";
 import type { OcxProviderConfig } from "../src/types";
 import { withTestTranslatorBudget } from "./helpers/translator-budget";
 
@@ -79,5 +80,54 @@ describe("Responses buildRequest web_search capability", () => {
       type: "web_search",
       user_location: { type: "approximate" },
     }]);
+  });
+});
+
+// The request path resolves a saved provider row through routedProviderConfig(), NOT through
+// enrichProviderFromRegistry(). Until this backfill existed, a saved xai row reached the
+// Responses adapter with supportsOpenAiWebSearchToolFields === undefined, so the #2262
+// capability gate read "unclassified" and forwarded the fields; live xAI answered
+// `400 Argument not supported: external_web_access` and every routed Grok turn on the
+// Responses lane died before inference (verified against cli-chat-proxy.grok.com 2026-08-21).
+// Asserting on the adapter with a hand-built provider cannot catch this — the gap is upstream
+// of the adapter, in what the router hands it.
+describe("routedProviderConfig web_search capability backfill", () => {
+  test("a saved xai row without the flag is classified by the registry", () => {
+    const saved: OcxProviderConfig = {
+      adapter: "openai-chat",
+      baseUrl: "https://api.x.ai/v1",
+      authMode: "oauth",
+      // The GUI Responses opt-in writes only modelAdapters; it never writes the capability.
+      modelAdapters: { "grok-4.6": "openai-responses" },
+    };
+    expect(saved.supportsOpenAiWebSearchToolFields).toBeUndefined();
+
+    const routed = routedProviderConfig("xai", saved);
+    expect(routed.supportsOpenAiWebSearchToolFields).toBe(false);
+  });
+
+  test("the routed row actually strips the fatal fields at the adapter", () => {
+    const routed = routedProviderConfig("xai", {
+      adapter: "openai-chat",
+      baseUrl: "https://api.x.ai/v1",
+      authMode: "oauth",
+      modelAdapters: { "grok-4.6": "openai-responses" },
+    });
+
+    const body = buildWebSearchBody({ ...routed, adapter: "openai-responses" });
+    expect(body.tools).toEqual([{
+      type: "web_search",
+      user_location: { type: "approximate" },
+    }]);
+  });
+
+  test("an explicit saved value still overrides the registry default", () => {
+    const routed = routedProviderConfig("xai", {
+      adapter: "openai-responses",
+      baseUrl: "https://api.x.ai/v1",
+      authMode: "oauth",
+      supportsOpenAiWebSearchToolFields: true,
+    });
+    expect(routed.supportsOpenAiWebSearchToolFields).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Routed Grok turns on the Responses lane died with `400 Argument not supported: external_web_access` before inference, so every tool-use turn failed.

`routedProviderConfig()` backfills every other registry-only scalar (`supportsServiceTier`, `preserveResponsesReasoningContent`, `fastWire`) but not `supportsOpenAiWebSearchToolFields`. `enrichProviderFromRegistry()` does fill it — and the request path never calls that function. So a saved `xai` row reached the Responses adapter with the flag `undefined`, the #2262 capability gate read that as "unclassified upstream, keep the fields", and Codex's OpenAI-only `web_search` config went to the wire.

A live probe against the OAuth Grok endpoint (2026-08-21) isolates the cause: bare `{type:"web_search"}` returns 200, `+external_web_access` returns 400, `+search_context_size` returns 400 — each individually, before inference.

The fix is one backfill entry next to the existing registry-only scalars. An explicit saved user value still wins, and only providers whose registry entry declares the capability are affected (today: `xai`).

## Verification

- `bun run typecheck` — exit 0
- `bun run test` — 14090 pass / 0 fail across 887 files
- `bun run privacy:scan` — passed
- `bun test --isolate tests/responses-routed-web-search-fields.test.ts` — 7 pass / 0 fail
- New tests driven **red** against the unfixed router (2 fail), then green with the fix — they are not vacuous.
- End-to-end on a remote macOS host running this dev head: with the GUI Responses opt-in on and **no** hand-written capability in `config.json`, a multi-step `codex exec` tool-use turn (mkdir, write, cat, uname) completed over adapter `"openai-responses"` with `status: 200` in `usage.jsonl`. The same turn 400'd on the same host before the fix.

The existing tests could not catch this: they hand-build a provider with the flag already set, or call `enrichProviderFromRegistry()` directly, so both start downstream of the break. The new tests assert on `routedProviderConfig()` output.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routed provider configuration to correctly apply web-search capability defaults when saved settings omit them.
  * Preserved explicitly configured provider capabilities.
  * Prevented unsupported web-search fields from being sent to providers that do not support them.

* **Tests**
  * Added coverage for default capability handling, explicit overrides, and request-field filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->