### PR TITLE
fix(claude): warm empty Desktop-3P alias registry on first /v1/messages after restart

### DIFF
--- a/src/claude/desktop-3p.ts
+++ b/src/claude/desktop-3p.ts
@@ -312,6 +312,11 @@ export function generateDesktop3pModels(
   return models;
 }
 
+/** True while no Desktop registry has been generated in this process (fresh boot). */
+export function desktop3pRegistryIsEmpty(): boolean {
+  return desktop3pRegistry.size === 0;
+}
+
 /** Resolve an alias using the most recently generated Desktop model registry. */
 export function resolveDesktop3pAlias(alias: string): string | null {
   return desktop3pRegistry.get(alias) ?? null;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1283,6 +1283,25 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
         });
       }
 
+      // Desktop-3P alias self-heal: the registry that decodes hashed discovery ids
+      // (claude-opus-4-8-<code>) is in-memory and only rebuilt by an anthropic-flavor
+      // GET /v1/models. A client that cached such an id from a previous process can
+      // replay it as the FIRST request after a restart; with an empty registry the
+      // alias cannot decode and the request misroutes (classifier affinity or raw
+      // passthrough → upstream "Invalid model name"). Warm the registry once via
+      // loopback discovery — semantically the same as the client refreshing models.
+      if ((url.pathname === "/v1/messages" || url.pathname === "/v1/messages/count_tokens") && req.method === "POST") {
+        const { desktop3pRegistryIsEmpty } = await import("../claude/desktop-3p");
+        if (desktop3pRegistryIsEmpty()) {
+          const warmHeaders = new Headers({ "anthropic-version": "2023-06-01" });
+          const warmAuth = req.headers.get("authorization");
+          const warmKey = req.headers.get("x-api-key");
+          if (warmAuth) warmHeaders.set("authorization", warmAuth);
+          if (warmKey) warmHeaders.set("x-api-key", warmKey);
+          try { await fetch(new URL("/v1/models", url.origin), { headers: warmHeaders }); } catch { /* fall through to existing resolution */ }
+        }
+      }
+
       // Anthropic Messages inbound (Claude Code). count_tokens FIRST (longer path).
       // Claude Code posts `/v1/messages?beta=true` — pathname match ignores the query (003 G9).
       if (url.pathname === "/v1/messages/count_tokens" && req.method === "POST") {

--- a/tests/claude-messages-endpoint.test.ts
+++ b/tests/claude-messages-endpoint.test.ts
@@ -1571,3 +1571,53 @@ test("count_tokens is CJK-aware: Korean body counts more tokens than equal-lengt
     await server.stop(true);
   }
 });
+
+test("first /v1/messages after a restart self-heals an empty Desktop-3P registry (cached hashed id)", async () => {
+  const { server: upstream, captured } = mockChatUpstreamCapturing();
+  const baseUrl = `${upstream.url.toString().replace(/\/$/, "")}/v1`;
+  saveConfig({
+    port: 0,
+    defaultProvider: "mock",
+    providers: {
+      mock: {
+        adapter: "openai-chat",
+        baseUrl,
+        apiKey: "k",
+        allowPrivateNetwork: true,
+        liveModels: false,
+        models: ["test-model"],
+      },
+    },
+  } as OcxConfig);
+  const server = startServer(0);
+  try {
+    const { buildDesktop3pRegistry, desktop3pAlias } = await import("../src/claude/desktop-3p");
+    // Post-restart state: no discovery GET has run in this process, so the
+    // in-memory registry is empty while the client replays the hashed id it
+    // cached from the previous process.
+    buildDesktop3pRegistry([], []);
+    const alias = desktop3pAlias("mock", "test-model");
+    const response = await fetch(new URL("/v1/messages?beta=true", server.url), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": "placeholder",
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: alias,
+        max_tokens: 128,
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(response.status).toBe(200);
+    const text = await response.text();
+    expect(text).toContain("Hello");
+    // The upstream must see the decoded route, not the raw hashed alias.
+    expect(captured[0]?.model).toBe("test-model");
+  } finally {
+    await server.stop(true);
+    upstream.stop(true);
+  }
+}, { timeout: SERVER_BUDGET_MS });


### PR DESCRIPTION
Fixes #2297.

## Problem

The Desktop-3P alias registry (`desktop3pRegistry`) that decodes hashed discovery ids (`claude-opus-4-8-<code>`) is in-memory and only rebuilt by an anthropic-flavor `GET /v1/models`. A client that cached such an id from a previous process replays it as the **first** request after a proxy restart; the alias cannot decode, `resolveInboundModel` falls through to classifier affinity / raw passthrough, and the upstream rejects it:

```
400 {'error': 'anthropic_messages: Invalid model name passed in model=claude-opus-4-8-20260304. ...'}
```

Anything that happens to list models first (dashboard, connection test) hides the bug by rebuilding the registry as a side effect, so it presents as "connection test passes, real chat fails".

## Change

- `src/server/index.ts` — when a `POST /v1/messages` or `/v1/messages/count_tokens` arrives while the registry is empty, warm it once via a loopback anthropic-flavor `GET /v1/models` (forwarding the caller's auth headers, since discovery requires admission). Semantically identical to the client refreshing discovery before chatting; fires at most once per process in practice, `try/catch`-guarded so a discovery failure falls through to the existing resolution path unchanged.
- `src/claude/desktop-3p.ts` — export `desktop3pRegistryIsEmpty()` so the inbound route can observe the fresh-boot state.
- `tests/claude-messages-endpoint.test.ts` — regression test: empties the registry (simulating a fresh boot), POSTs a hashed alias as the first request, and asserts the mock upstream receives the **decoded** route (`test-model`), not the raw hash.

Considered instead: extracting the registry-build inputs (`fetchAllModels` + entitlements + the visibility/ordering derivation in the models handler) into a shared helper callable from the messages branch. That duplicates a ~60-line derivation chain across two call sites; the loopback reuses the whole handler and cannot drift from it. Happy to rework if maintainers prefer eager build at startup.

## Validation

- `bun test tests/claude-messages-endpoint.test.ts` — 43 pass, 0 fail (includes the new test)
- With the `src/` change stashed, the new test **fails** (`captured[0].model` is the raw hash) — confirms it guards the defect
- `bun test tests/desktop-3p.test.ts tests/claude-models-discovery.test.ts tests/claude-inbound.test.ts` — 59 pass, 0 fail
- `bun run typecheck` — clean

Environment: reproduced on v2.28.0 (Windows 11, bundled Bun 1.3.14); patch developed and tested on current `dev`.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability after server restarts by automatically restoring Desktop 3P model alias information when processing the first message request.
  - Cached hashed model aliases now decode correctly instead of failing after a restart.

- **Tests**
  - Added regression coverage for successful streaming and alias resolution following a restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->