### PR TITLE
fix(responses): scope reasoning replay by conversation and remember proven blob rejections

### DIFF
--- a/src/responses/reasoning-replay-cache.ts
+++ b/src/responses/reasoning-replay-cache.ts
@@ -29,6 +29,7 @@ import type {
 const MAX_ENTRIES = 64;
 const MAX_TOTAL_BYTES = 256 * 1024;
 const TTL_MS = 60 * 60 * 1000;
+const OPAQUE_BLOB_REJECTION_TTL_MS = 5 * 60 * 1000;
 const replayIdentityKey = randomBytes(32);
 const CREDENTIAL_HEADER_NAMES = new Set([
   "authorization",
@@ -58,10 +59,17 @@ interface ServingIdentityEntry {
   at: number;
 }
 
+interface OpaqueBlobRejectionEntry {
+  bytes: number;
+  at: number;
+}
+
 const entries = new Map<string, CacheEntry>();
 const servingIdentities = new Map<string, ServingIdentityEntry>();
+const opaqueBlobRejections = new Map<string, OpaqueBlobRejectionEntry>();
 let totalBytes = 0;
 let servingIdentityTotalBytes = 0;
+let opaqueBlobRejectionTotalBytes = 0;
 let clockForTests: (() => number) | null = null;
 
 const now = (): number => clockForTests?.() ?? Date.now();
@@ -142,6 +150,26 @@ function servingIdentityFor(
   return { threadId, identity: JSON.stringify(identityTuple) };
 }
 
+function opaqueBlobRejectionKeyFor(
+  scope: OcxReasoningReplayScopeRef | undefined,
+): string | undefined {
+  const current = servingIdentityFor(scope);
+  return current ? JSON.stringify([current.threadId, current.identity]) : undefined;
+}
+
+function deleteOpaqueBlobRejection(key: string): void {
+  const entry = opaqueBlobRejections.get(key);
+  if (!entry) return;
+  opaqueBlobRejections.delete(key);
+  opaqueBlobRejectionTotalBytes -= entry.bytes;
+}
+
+function sweepExpiredOpaqueBlobRejections(at: number): void {
+  for (const [key, entry] of opaqueBlobRejections) {
+    if (at - entry.at >= OPAQUE_BLOB_REJECTION_TTL_MS) deleteOpaqueBlobRejection(key);
+  }
+}
+
 /**
  * Compare this request's route with the last successfully serving route for its conversation.
  * A live mismatch means replayed opaque reasoning was minted by another backend and must not be
@@ -197,6 +225,54 @@ export function commitReasoningReplayServingIdentity(
     }
     if (oldestThreadId === undefined) break;
     deleteServingIdentity(oldestThreadId);
+  }
+}
+
+/**
+ * Whether this exact conversation and durable serving identity previously rejected opaque replay.
+ *
+ * The five serving dimensions deliberately match the serving record. Missing durable destination
+ * or credential identity is unknown and never falls back to process-local dimensions. The five
+ * minute TTL is shorter than the serving record's hour: a stale memo silently degrades reasoning,
+ * while expiry costs one visible recovery round trip and can safely re-establish the memo.
+ */
+export function reasoningReplayOpaqueBlobRejectionMemoized(
+  scope: OcxReasoningReplayScopeRef | undefined,
+): boolean {
+  const key = opaqueBlobRejectionKeyFor(scope);
+  if (!key) return false;
+  const at = now();
+  sweepExpiredOpaqueBlobRejections(at);
+  return opaqueBlobRejections.has(key);
+}
+
+/** Record only after a blobless retry succeeded for this durable serving identity. */
+export function rememberReasoningReplayOpaqueBlobRejection(
+  scope: OcxReasoningReplayScopeRef | undefined,
+): void {
+  const key = opaqueBlobRejectionKeyFor(scope);
+  if (!key) return;
+  const bytes = Buffer.byteLength(key, "utf8");
+  if (bytes > MAX_TOTAL_BYTES) return;
+  const at = now();
+  sweepExpiredOpaqueBlobRejections(at);
+  if (opaqueBlobRejections.has(key)) deleteOpaqueBlobRejection(key);
+  opaqueBlobRejections.set(key, { bytes, at });
+  opaqueBlobRejectionTotalBytes += bytes;
+  while (
+    (opaqueBlobRejectionTotalBytes > MAX_TOTAL_BYTES || opaqueBlobRejections.size > MAX_ENTRIES)
+    && opaqueBlobRejections.size > 1
+  ) {
+    let oldestKey: string | undefined;
+    let oldestAt = Infinity;
+    for (const [candidateKey, entry] of opaqueBlobRejections) {
+      if (entry.at < oldestAt) {
+        oldestAt = entry.at;
+        oldestKey = candidateKey;
+      }
+    }
+    if (oldestKey === undefined) break;
+    deleteOpaqueBlobRejection(oldestKey);
   }
 }
 
@@ -420,7 +496,9 @@ export function peekReasoningForCall(
 export function clearReasoningReplayCacheForTests(clock?: (() => number) | null): void {
   entries.clear();
   servingIdentities.clear();
+  opaqueBlobRejections.clear();
   totalBytes = 0;
   servingIdentityTotalBytes = 0;
+  opaqueBlobRejectionTotalBytes = 0;
   clockForTests = clock ?? null;
 }

--- a/src/responses/reasoning-replay-cache.ts
+++ b/src/responses/reasoning-replay-cache.ts
@@ -143,10 +143,10 @@ function servingIdentityFor(
 }
 
 /**
- * Compare this request's route with the last successfully serving route for its client thread.
+ * Compare this request's route with the last successfully serving route for its conversation.
  * A live mismatch means replayed opaque reasoning was minted by another backend and must not be
  * forwarded to this one. Comparison deliberately does not refresh or replace the recorded route:
- * a failed candidate request did not serve the thread.
+ * a failed candidate request did not serve the conversation.
  *
  * Serving provenance uses restart-stable destination and credential dimensions so token
  * generations and other volatile credential material cannot create false route changes. Missing
@@ -164,7 +164,7 @@ export function reasoningReplayServingIdentityChanged(
   return previous !== undefined && previous.identity !== current.identity;
 }
 
-/** Record the route only after it has successfully served the client thread. */
+/** Record the route only after it has successfully served the conversation. */
 export function commitReasoningReplayServingIdentity(
   scope: OcxReasoningReplayScopeRef | undefined,
 ): void {

--- a/src/server/request-log-conversation.ts
+++ b/src/server/request-log-conversation.ts
@@ -61,6 +61,36 @@ export function sessionIdHeaderFromRequest(headers: Headers): string | null {
   return headers.get("session_id") ?? headers.get("session-id");
 }
 
+function firstSanitizedConversationId(
+  ...values: Array<string | null | undefined>
+): string | undefined {
+  for (const value of values) {
+    const sanitized = sanitizeConversationIdInput(value);
+    if (sanitized) return sanitized;
+  }
+  return undefined;
+}
+
+/**
+ * Conversation namespace for reasoning replay. Unlike the persisted log id, this stays the raw
+ * sanitized identity so mixed headers that carry the same conversation still hit one serving
+ * record. Do not hash, and do not prefer session_id over a true per-conversation thread/Cursor
+ * identity: session_id can be synthesized from a shared prompt_cache_key.
+ */
+export function reasoningReplayConversationIdFromResponsesRequest(input: {
+  clientThreadId?: string;
+  threadIdHeader?: string | null;
+  cursorConversationId?: string;
+  sessionIdHeader?: string | null;
+}): string | undefined {
+  return firstSanitizedConversationId(
+    input.clientThreadId,
+    input.threadIdHeader,
+    input.cursorConversationId,
+    input.sessionIdHeader,
+  );
+}
+
 export function conversationIdFromResponsesRequest(input: {
   clientThreadId?: string;
   sessionIdHeader?: string | null;

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -22,8 +22,10 @@ import {
   durableReplayDestinationIdentity,
   durableReplayCredentialIdentity,
   reasoningReplayKeyCredentialIdentity,
+  reasoningReplayOpaqueBlobRejectionMemoized,
   reasoningReplayOAuthCredentialIdentity,
   reasoningReplayServingIdentityChanged,
+  rememberReasoningReplayOpaqueBlobRejection,
 } from "../../responses/reasoning-replay-cache";
 import { awaitThoughtSignatureDurability, thoughtSignatureReplaySalt } from "../../responses/thought-signature-replay";
 import { buildCompactV1Output, COMPACT_PROMPT, decodeCompactionSummary, extractCompactUserMessages } from "../../responses/compaction";
@@ -515,6 +517,9 @@ function bindRouteReasoningReplayScope(args: {
   if (reasoningReplayServingIdentityChanged(parsed._reasoningReplayScope)) {
     parsed._stripReasoningEncryptedContent = true;
   }
+  if (reasoningReplayOpaqueBlobRejectionMemoized(parsed._reasoningReplayScope)) {
+    parsed._stripReasoningEncryptedContent = true;
+  }
   bindProviderContinuationForRoute(parsed, continuationOwner);
 }
 
@@ -668,9 +673,20 @@ async function attemptOpaqueBlobRecovery(
   }
 
   args.guard.attempted = true;
+  const rejectedScope = args.parsed._reasoningReplayScope
+    ? {
+        clientThreadId: args.parsed._reasoningReplayScope.clientThreadId,
+        ...(args.parsed._reasoningReplayScope.current
+          ? { current: { ...args.parsed._reasoningReplayScope.current } }
+          : {}),
+      }
+    : undefined;
   prepareOpaqueBlobRecovery(args.parsed);
   try { void args.response.body?.cancel().catch(() => {}); } catch { /* already consumed/closed */ }
   const result = await rebuild("opaque-blob-rejection");
+  if (!("failed" in result) && result.ok) {
+    rememberReasoningReplayOpaqueBlobRejection(rejectedScope);
+  }
   return "failed" in result
     ? { kind: "failed", response: result.failed }
     : { kind: "recovered", response: result };

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -2185,7 +2185,6 @@ async function handleResponsesInner(
     if (providerContinuationCandidate) parsed._providerContinuationCandidate = providerContinuationCandidate;
     if (inboundClientThreadId) {
       parsed._clientThreadId = inboundClientThreadId;
-      parsed._reasoningReplayScope = { clientThreadId: inboundClientThreadId };
     } else if (
       options.inboundWire === "anthropic"
       && options.promptCacheKeyIsSharedCohort !== true
@@ -2221,15 +2220,26 @@ async function handleResponsesInner(
     ...(force ? { force: true } : {}),
     ...(parsed._clientThreadId ? { clientThreadId: parsed._clientThreadId } : {}),
   });
+  const resolvedConversationId = conversationIdFromResponsesRequest({
+    clientThreadId: parsed._clientThreadId,
+    sessionIdHeader: sessionIdHeaderFromRequest(req.headers),
+    threadIdHeader: req.headers.get("thread-id"),
+    cursorConversationId: parsed._cursorConversationId,
+  });
+  // `_clientThreadId` remains the routing/continuation identity supplied by Codex. Replay state
+  // only needs a conversation namespace, so headerless callers may use the same opaque fallback
+  // already resolved for request logs. Keep the raw parent-thread key when present so that path is
+  // byte-for-byte unchanged.
+  if (!parsed._reasoningReplayScope) {
+    const reasoningReplayConversationId = parsed._clientThreadId ?? resolvedConversationId;
+    if (reasoningReplayConversationId) {
+      parsed._reasoningReplayScope = { clientThreadId: reasoningReplayConversationId };
+    }
+  }
   // Prefer a pre-populated id (routed Claude) over Responses headers that may be
   // absent or synthetically injected (session_id from prompt_cache_key).
   if (!logCtx.conversationId) {
-    logCtx.conversationId = conversationIdFromResponsesRequest({
-      clientThreadId: parsed._clientThreadId,
-      sessionIdHeader: sessionIdHeaderFromRequest(req.headers),
-      threadIdHeader: req.headers.get("thread-id"),
-      cursorConversationId: parsed._cursorConversationId,
-    });
+    logCtx.conversationId = resolvedConversationId;
   }
   logCtx.requestedModel = parsed.modelId;
   logCtx.requestedEffort = parsed.options.reasoning;

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -227,6 +227,7 @@ import {
 import {
   conversationIdFromResponsesRequest,
   normalizeLogConversationId,
+  reasoningReplayConversationIdFromResponsesRequest,
   sessionIdHeaderFromRequest,
 } from "../request-log-conversation";
 import type { AttemptRecoveryKind } from "../../usage/log";
@@ -2242,12 +2243,17 @@ async function handleResponsesInner(
     threadIdHeader: req.headers.get("thread-id"),
     cursorConversationId: parsed._cursorConversationId,
   });
-  // `_clientThreadId` remains the routing/continuation identity supplied by Codex. Replay state
-  // only needs a conversation namespace, so headerless callers may use the same opaque fallback
-  // already resolved for request logs. Keep the raw parent-thread key when present so that path is
-  // byte-for-byte unchanged.
+  // _clientThreadId remains the routing/continuation identity supplied by Codex. Replay state uses
+  // a dedicated raw conversation namespace so mixed headers that carry the same identity still
+  // match, and a shared/synthetic session_id cannot coalesce distinct thread/Cursor conversations.
+  // Keep an Anthropic prompt_cache_key scope already bound above (#1735/#1926).
   if (!parsed._reasoningReplayScope) {
-    const reasoningReplayConversationId = parsed._clientThreadId ?? resolvedConversationId;
+    const reasoningReplayConversationId = reasoningReplayConversationIdFromResponsesRequest({
+      clientThreadId: parsed._clientThreadId,
+      threadIdHeader: req.headers.get("thread-id"),
+      cursorConversationId: parsed._cursorConversationId,
+      sessionIdHeader: sessionIdHeaderFromRequest(req.headers),
+    });
     if (reasoningReplayConversationId) {
       parsed._reasoningReplayScope = { clientThreadId: reasoningReplayConversationId };
     }

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -32,7 +32,8 @@ export interface OcxReasoningReplayIdentity {
 export interface OcxReasoningReplayScopeRef {
   /**
    * Conversation namespace for replay state. Historically this was always the Codex parent-thread
-   * id; headerless Responses callers use an opaque session/thread/Cursor conversation fallback.
+   * id; headerless Responses callers use a raw sanitized thread/Cursor/session fallback, never the
+   * hashed request-log conversation id.
    */
   readonly clientThreadId: string;
   current?: Readonly<OcxReasoningReplayIdentity>;

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -30,6 +30,10 @@ export interface OcxReasoningReplayIdentity {
  * the holder, so late tool-call cache writes see the active physical identity.
  */
 export interface OcxReasoningReplayScopeRef {
+  /**
+   * Conversation namespace for replay state. Historically this was always the Codex parent-thread
+   * id; headerless Responses callers use an opaque session/thread/Cursor conversation fallback.
+   */
   readonly clientThreadId: string;
   current?: Readonly<OcxReasoningReplayIdentity>;
 }
@@ -63,7 +67,7 @@ export interface OcxParsedRequest {
   _cursorConversationId?: string;
   /** Stable upstream client thread identity, used only to derive provider-scoped continuation ids. */
   _clientThreadId?: string;
-  /** Provider/account/model-bound namespace for process-local raw-reasoning replay. */
+  /** Conversation/provider/account/model-bound namespace for reasoning replay state. */
   _reasoningReplayScope?: OcxReasoningReplayScopeRef;
   /**
    * Set by bindRouteReasoningReplayScope after a proven serving-identity change, or by

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -618,6 +618,15 @@ switch therefore costs one extra upstream round trip and one turn of degraded re
 wedging the thread; unrelated 4xx responses and requests whose outbound body carries no blob never
 enter this recovery.
 
+After a self-identified opaque-blob rejection, the proxy also keeps a five-minute rejection memo.
+The memo key is the resolved conversation identity plus the durable serving identity: provider,
+destination, adapter, model, and credential. It is recorded only when the blobless recovery resend
+succeeds. A missing durable destination or credential prevents memo creation and lookup. On a later
+request with the same key, pre-flight sanitation removes opaque reasoning `encrypted_content` and
+degrades compaction blobs before the first upstream send. This skips the rejected first send and
+the recovery round trip. A different serving identity does not match the memo, so returning to the
+blob-minting destination preserves valid blobs. Memo expiry returns to the fail-soft recovery path.
+
 A combo target rotation between turns legitimately changes that serving identity, so the following
 turn drops blobs minted by the prior target. This is correct because the new target cannot decode
 them, but it is intentionally unobvious to the client: `pickComboTarget` keys selection state only by

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -624,8 +624,8 @@ destination, adapter, model, and credential. It is recorded only when the bloble
 succeeds. A missing durable destination or credential prevents memo creation and lookup. On a later
 request with the same key, pre-flight sanitation removes opaque reasoning `encrypted_content` and
 degrades compaction blobs before the first upstream send. This skips the rejected first send and
-the recovery round trip. A different serving identity does not match the memo, so returning to the
-blob-minting destination preserves valid blobs. Memo expiry returns to the fail-soft recovery path.
+the recovery round trip. A different serving identity does not match the memo. Route changes still
+follow the normal pre-flight stripping rule. Memo expiry returns to the fail-soft recovery path.
 
 A combo target rotation between turns legitimately changes that serving identity, so the following
 turn drops blobs minted by the prior target. This is correct because the new target cannot decode

--- a/tests/reasoning-replay-identity.test.ts
+++ b/tests/reasoning-replay-identity.test.ts
@@ -9,9 +9,11 @@ import {
   reasoningReplayCredentialIdentity,
   reasoningReplayDestinationIdentity,
   reasoningReplayKeyCredentialIdentity,
+  reasoningReplayOpaqueBlobRejectionMemoized,
   reasoningReplayOAuthCredentialIdentity,
   reasoningReplayServingIdentityChanged,
   rememberReasoningForCall,
+  rememberReasoningReplayOpaqueBlobRejection,
 } from "../src/responses/reasoning-replay-cache";
 import type { AdapterEvent, OcxReasoningReplayScopeRef } from "../src/types";
 
@@ -140,6 +142,51 @@ describe("reasoning replay provider and credential identity", () => {
       ...scope({ modelId: "different-model" }),
       clientThreadId: destinationThreadId,
     })).toBe(false);
+  });
+
+  test("opaque-blob rejection memos use the durable serving identity and refuse incomplete scopes", () => {
+    const rejected = scope({ modelId: "destination-b-model" });
+    rememberReasoningReplayOpaqueBlobRejection(rejected);
+    expect(reasoningReplayOpaqueBlobRejectionMemoized(rejected)).toBe(true);
+    expect(reasoningReplayOpaqueBlobRejectionMemoized(scope({ modelId: "destination-a-model" }))).toBe(false);
+    expect(reasoningReplayOpaqueBlobRejectionMemoized({
+      ...rejected,
+      clientThreadId: "another-conversation",
+    })).toBe(false);
+
+    for (const incomplete of [
+      scope({ credentialDurableIdentity: undefined }),
+      scope({ providerDestinationDurableIdentity: undefined }),
+      { clientThreadId: THREAD },
+    ]) {
+      rememberReasoningReplayOpaqueBlobRejection(incomplete);
+      expect(reasoningReplayOpaqueBlobRejectionMemoized(incomplete)).toBe(false);
+    }
+  });
+
+  test("opaque-blob rejection memos use the serving record's 64-entry bound", () => {
+    let clock = 1_000;
+    clearReasoningReplayCacheForTests(() => clock);
+    for (let i = 0; i < 65; i++) {
+      rememberReasoningReplayOpaqueBlobRejection({
+        ...scope(),
+        clientThreadId: `memo-thread-${i}`,
+      });
+      clock += 1;
+    }
+
+    expect(reasoningReplayOpaqueBlobRejectionMemoized({
+      ...scope(),
+      clientThreadId: "memo-thread-0",
+    })).toBe(false);
+    expect(reasoningReplayOpaqueBlobRejectionMemoized({
+      ...scope(),
+      clientThreadId: "memo-thread-1",
+    })).toBe(true);
+    expect(reasoningReplayOpaqueBlobRejectionMemoized({
+      ...scope(),
+      clientThreadId: "memo-thread-64",
+    })).toBe(true);
   });
 
   test("expired serving identity is unknown rather than a backend change", () => {

--- a/tests/request-log-conversation.test.ts
+++ b/tests/request-log-conversation.test.ts
@@ -6,6 +6,7 @@ import {
   conversationIdFromResponsesRequest,
   matchesLogConversationId,
   normalizeLogConversationId,
+  reasoningReplayConversationIdFromResponsesRequest,
   sessionIdHeaderFromRequest,
   summarizeConversationLogs,
 } from "../src/server/request-log-conversation";
@@ -91,6 +92,51 @@ describe("conversationIdFromResponsesRequest", () => {
     expect(conversationIdFromResponsesRequest({
       cursorConversationId: "cursor",
     })).toBe(digest32("cursor"));
+  });
+});
+
+describe("reasoningReplayConversationIdFromResponsesRequest", () => {
+  test("keeps the raw identity instead of the hashed log id", () => {
+    expect(reasoningReplayConversationIdFromResponsesRequest({
+      clientThreadId: "parent-thread",
+    })).toBe("parent-thread");
+    expect(reasoningReplayConversationIdFromResponsesRequest({
+      sessionIdHeader: "session",
+    })).not.toBe(digest32("session"));
+  });
+
+  test("prefers parent thread, then thread-id, then cursor, then session_id", () => {
+    expect(reasoningReplayConversationIdFromResponsesRequest({
+      clientThreadId: "parent-thread",
+      threadIdHeader: "thread",
+      cursorConversationId: "cursor",
+      sessionIdHeader: "session",
+    })).toBe("parent-thread");
+    expect(reasoningReplayConversationIdFromResponsesRequest({
+      threadIdHeader: "thread",
+      cursorConversationId: "cursor",
+      sessionIdHeader: "session",
+    })).toBe("thread");
+    expect(reasoningReplayConversationIdFromResponsesRequest({
+      cursorConversationId: "cursor",
+      sessionIdHeader: "session",
+    })).toBe("cursor");
+    expect(reasoningReplayConversationIdFromResponsesRequest({
+      sessionIdHeader: "session",
+    })).toBe("session");
+  });
+
+  test("skips empty, control-bearing, and overlong fallbacks", () => {
+    expect(reasoningReplayConversationIdFromResponsesRequest({
+      threadIdHeader: "  ",
+      cursorConversationId: "cursor",
+    })).toBe("cursor");
+    expect(reasoningReplayConversationIdFromResponsesRequest({
+      sessionIdHeader: "bad\nid",
+    })).toBeUndefined();
+    expect(reasoningReplayConversationIdFromResponsesRequest({
+      sessionIdHeader: "x".repeat(4097),
+    })).toBeUndefined();
   });
 });
 

--- a/tests/responses-opaque-blob-recovery.test.ts
+++ b/tests/responses-opaque-blob-recovery.test.ts
@@ -719,6 +719,61 @@ describe("reasoning replay serving identity commit through /v1/responses", () =>
     expect(outbound.map(hasBlob)).toEqual([true, false, true]);
   });
 
+  test("a later session_id fallback continues the same raw parent-thread conversation", async () => {
+    const outbound: Array<Record<string, unknown>> = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      outbound.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return success(`resp-${outbound.length}`);
+    }) as typeof fetch;
+
+    const identity = "mixed-header-conversation";
+    const first = await handleResponses(
+      requestWithIdentityHeaders("first", { "x-codex-parent-thread-id": identity }),
+      config(),
+      { model: "", provider: "" },
+    );
+    expect(first.status).toBe(200);
+    await first.text();
+    const second = await handleResponses(
+      requestWithIdentityHeaders("second", { session_id: identity }),
+      config(),
+      { model: "", provider: "" },
+    );
+    expect(second.status).toBe(200);
+    await second.text();
+
+    expect(outbound).toHaveLength(2);
+    expect(outbound.map(hasBlob)).toEqual([true, false]);
+  });
+
+  test("a shared session_id does not coalesce distinct thread-id conversations", async () => {
+    const outbound: Array<Record<string, unknown>> = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      outbound.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return success(`resp-${outbound.length}`);
+    }) as typeof fetch;
+
+    const cases = [
+      ["first", "thread-a"],
+      ["second", "thread-b"],
+    ] as const;
+    for (const [provider, threadId] of cases) {
+      const response = await handleResponses(
+        requestWithIdentityHeaders(provider, {
+          "thread-id": threadId,
+          session_id: "shared-cache-session",
+        }),
+        config(),
+        { model: "", provider: "" },
+      );
+      expect(response.status).toBe(200);
+      await response.text();
+    }
+
+    expect(outbound).toHaveLength(2);
+    expect(outbound.map(hasBlob)).toEqual([true, true]);
+  });
+
   test("requests without any usable conversation identity keep blobs and record nothing", async () => {
     const outbound: Array<Record<string, unknown>> = [];
     globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {

--- a/tests/responses-opaque-blob-recovery.test.ts
+++ b/tests/responses-opaque-blob-recovery.test.ts
@@ -539,21 +539,21 @@ describe("reasoning replay serving identity commit through /v1/responses", () =>
     expect(hasBlob(outbound[1]!)).toBe(false);
   });
 
-  test("foreign blobs recover once, then alternating routes strip pre-flight on later headerless turns", async () => {
+  test("foreign blobs recover once, then the same destination strips pre-flight on later headerless turns", async () => {
     const outbound: Array<Record<string, unknown>> = [];
     const turns: RequestLogContext[] = [];
     globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
       const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
       outbound.push(body);
-      if (outbound.length === 1 && hasBlob(body)) return rejection(XAI_DECODE_ERROR);
+      if (hasBlob(body)) return rejection(XAI_DECODE_ERROR);
       return success(`resp-${outbound.length}`);
     }) as typeof fetch;
 
-    for (const provider of ["first", "second", "first"]) {
+    for (let turn = 0; turn < 3; turn++) {
       const logCtx: RequestLogContext = { model: "", provider: "" };
       turns.push(logCtx);
       const response = await handleResponses(
-        requestWithIdentityHeaders(provider, { session_id: "three-turn-headerless-session" }),
+        requestWithIdentityHeaders("first", { session_id: "three-turn-headerless-session" }),
         config(),
         logCtx,
       );
@@ -569,6 +569,129 @@ describe("reasoning replay serving identity commit through /v1/responses", () =>
       [],
       [],
     ]);
+  });
+
+  test("a destination rejection memo does not keep stripping after switching back to the blob-minting destination", async () => {
+    const outbound = new Map<string, Array<Record<string, unknown>>>([
+      ["first", []],
+      ["second", []],
+    ]);
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const provider = String(input).includes("first.example.test") ? "first" : "second";
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      outbound.get(provider)!.push(body);
+      if (provider === "first" && hasBlob(body)) return rejection(XAI_DECODE_ERROR);
+      return success(`resp-${provider}-${outbound.get(provider)!.length}`);
+    }) as typeof fetch;
+
+    for (const provider of ["first", "second", "second"]) {
+      const response = await handleResponses(
+        requestWithIdentityHeaders(provider, { session_id: "switch-back-identity-session" }),
+        config(),
+        { model: "", provider: "" },
+      );
+      expect(response.status).toBe(200);
+      await response.text();
+    }
+
+    expect(outbound.get("first")!.map(hasBlob)).toEqual([true, false]);
+    // The first switch-back turn is still stripped by the unchanged deterministic serving record.
+    // Once that record commits `second`, `first`'s memo must not suppress `second`'s own good blob.
+    expect(outbound.get("second")!.map(hasBlob)).toEqual([false, true]);
+  });
+
+  test("a failed blobless resend records no memo, so the next turn tries the blob again", async () => {
+    const outbound: Array<Record<string, unknown>> = [];
+    const turns: RequestLogContext[] = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      outbound.push(body);
+      if (hasBlob(body)) return rejection(XAI_DECODE_ERROR);
+      return new Response(JSON.stringify({
+        error: { type: "invalid_request_error", code: "unknown_parameter", message: "retry also failed" },
+      }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    for (let turn = 0; turn < 2; turn++) {
+      const logCtx: RequestLogContext = { model: "", provider: "" };
+      turns.push(logCtx);
+      const response = await handleResponses(
+        requestWithIdentityHeaders("first", { session_id: "failed-resend-session" }),
+        config(),
+        logCtx,
+      );
+      expect(response.status).toBe(400);
+      await response.text();
+    }
+
+    expect(outbound.map(hasBlob)).toEqual([true, false, true, false]);
+    expect(turns.map(turn => turn.activeAttempt?.sendCount)).toEqual([2, 2]);
+    expect(turns.map(turn => turn.activeAttempt?.recoveryKinds)).toEqual([
+      ["opaque-blob-rejection"],
+      ["opaque-blob-rejection"],
+    ]);
+  });
+
+  test("an expired rejection memo rechecks once, then settles back to one send", async () => {
+    let clock = 1_000;
+    clearReasoningReplayCacheForTests(() => clock);
+    const outbound: Array<Record<string, unknown>> = [];
+    const turns: RequestLogContext[] = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      outbound.push(body);
+      return hasBlob(body) ? rejection(XAI_DECODE_ERROR) : success(`resp-${outbound.length}`);
+    }) as typeof fetch;
+
+    for (let turn = 0; turn < 4; turn++) {
+      if (turn === 2) clock += 5 * 60 * 1000 + 1;
+      const logCtx: RequestLogContext = { model: "", provider: "" };
+      turns.push(logCtx);
+      const response = await handleResponses(
+        requestWithIdentityHeaders("first", { session_id: "memo-expiry-session" }),
+        config(),
+        logCtx,
+      );
+      expect(response.status).toBe(200);
+      await response.text();
+    }
+
+    expect(outbound.map(hasBlob)).toEqual([true, false, false, true, false, false]);
+    expect(turns.map(turn => turn.activeAttempt?.sendCount)).toEqual([2, 1, 2, 1]);
+    expect(turns.map(turn => turn.activeAttempt?.recoveryKinds)).toEqual([
+      ["opaque-blob-rejection"],
+      [],
+      ["opaque-blob-rejection"],
+      [],
+    ]);
+  });
+
+  test("a stable conversation without a rejection memo remains unchanged", async () => {
+    const outbound: Array<Record<string, unknown>> = [];
+    const turns: RequestLogContext[] = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      outbound.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return success(`resp-${outbound.length}`);
+    }) as typeof fetch;
+
+    for (let turn = 0; turn < 3; turn++) {
+      const logCtx: RequestLogContext = { model: "", provider: "" };
+      turns.push(logCtx);
+      const response = await handleResponses(
+        requestWithIdentityHeaders("first", { session_id: "no-rejection-memo-session" }),
+        config(),
+        logCtx,
+      );
+      expect(response.status).toBe(200);
+      await response.text();
+    }
+
+    expect(outbound.map(hasBlob)).toEqual([true, true, true]);
+    expect(turns.map(turn => turn.activeAttempt?.sendCount)).toEqual([1, 1, 1]);
+    expect(turns.map(turn => turn.activeAttempt?.recoveryKinds)).toEqual([[], [], []]);
   });
 
   test("the parent-thread header remains authoritative over fallback identities", async () => {

--- a/tests/responses-opaque-blob-recovery.test.ts
+++ b/tests/responses-opaque-blob-recovery.test.ts
@@ -112,11 +112,20 @@ function config(): OcxConfig {
 }
 
 function request(provider = "first", threadId = "thread-opaque-recovery"): Request {
+  return requestWithIdentityHeaders(provider, {
+    "x-codex-parent-thread-id": threadId,
+  });
+}
+
+function requestWithIdentityHeaders(
+  provider = "first",
+  identityHeaders: Record<string, string> = {},
+): Request {
   return new Request("http://localhost/v1/responses", {
     method: "POST",
     headers: {
       "content-type": "application/json",
-      "x-codex-parent-thread-id": threadId,
+      ...identityHeaders,
     },
     body: JSON.stringify({
       model: `${provider}/model-a`,
@@ -508,6 +517,132 @@ describe("opaque blob recovery through /v1/responses", () => {
 });
 
 describe("reasoning replay serving identity commit through /v1/responses", () => {
+  test("a stable session identity records and detects a serving-identity change without a parent-thread header", async () => {
+    const outbound: Array<Record<string, unknown>> = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      outbound.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return success(`resp-${outbound.length}`);
+    }) as typeof fetch;
+
+    for (const provider of ["first", "second"]) {
+      const response = await handleResponses(
+        requestWithIdentityHeaders(provider, { session_id: "session-without-parent-thread" }),
+        config(),
+        { model: "", provider: "" },
+      );
+      expect(response.status).toBe(200);
+      await response.text();
+    }
+
+    expect(outbound).toHaveLength(2);
+    expect(hasBlob(outbound[0]!)).toBe(true);
+    expect(hasBlob(outbound[1]!)).toBe(false);
+  });
+
+  test("foreign blobs recover once, then alternating routes strip pre-flight on later headerless turns", async () => {
+    const outbound: Array<Record<string, unknown>> = [];
+    const turns: RequestLogContext[] = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      outbound.push(body);
+      if (outbound.length === 1 && hasBlob(body)) return rejection(XAI_DECODE_ERROR);
+      return success(`resp-${outbound.length}`);
+    }) as typeof fetch;
+
+    for (const provider of ["first", "second", "first"]) {
+      const logCtx: RequestLogContext = { model: "", provider: "" };
+      turns.push(logCtx);
+      const response = await handleResponses(
+        requestWithIdentityHeaders(provider, { session_id: "three-turn-headerless-session" }),
+        config(),
+        logCtx,
+      );
+      expect(response.status).toBe(200);
+      await response.text();
+    }
+
+    expect(outbound).toHaveLength(4);
+    expect(outbound.map(hasBlob)).toEqual([true, false, false, false]);
+    expect(turns.map(turn => turn.activeAttempt?.sendCount)).toEqual([2, 1, 1]);
+    expect(turns.map(turn => turn.activeAttempt?.recoveryKinds)).toEqual([
+      ["opaque-blob-rejection"],
+      [],
+      [],
+    ]);
+  });
+
+  test("the parent-thread header remains authoritative over fallback identities", async () => {
+    const outbound: Array<Record<string, unknown>> = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      outbound.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return success(`resp-${outbound.length}`);
+    }) as typeof fetch;
+
+    const cases = [
+      ["first", "parent-thread-a", "shared-session"],
+      ["second", "parent-thread-a", "different-session"],
+      ["second", "parent-thread-b", "shared-session"],
+    ] as const;
+    for (const [provider, parentThreadId, sessionId] of cases) {
+      const response = await handleResponses(requestWithIdentityHeaders(provider, {
+        "x-codex-parent-thread-id": parentThreadId,
+        session_id: sessionId,
+      }), config(), { model: "", provider: "" });
+      expect(response.status).toBe(200);
+      await response.text();
+    }
+
+    expect(outbound).toHaveLength(3);
+    expect(outbound.map(hasBlob)).toEqual([true, false, true]);
+  });
+
+  test("requests without any usable conversation identity keep blobs and record nothing", async () => {
+    const outbound: Array<Record<string, unknown>> = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      outbound.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return success(`resp-${outbound.length}`);
+    }) as typeof fetch;
+
+    for (const provider of ["first", "second"]) {
+      const response = await handleResponses(
+        requestWithIdentityHeaders(provider),
+        config(),
+        { model: "", provider: "" },
+      );
+      expect(response.status).toBe(200);
+      await response.text();
+    }
+
+    expect(outbound).toHaveLength(2);
+    expect(outbound.map(hasBlob)).toEqual([true, true]);
+  });
+
+  test("distinct fallback conversation identities never share a serving record", async () => {
+    const outbound: Array<Record<string, unknown>> = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      outbound.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return success(`resp-${outbound.length}`);
+    }) as typeof fetch;
+
+    const cases = [
+      ["first", "conversation-a"],
+      ["second", "conversation-b"],
+      ["second", "conversation-a"],
+    ] as const;
+    for (const [provider, sessionId] of cases) {
+      const response = await handleResponses(
+        requestWithIdentityHeaders(provider, { session_id: sessionId }),
+        config(),
+        { model: "", provider: "" },
+      );
+      expect(response.status).toBe(200);
+      await response.text();
+    }
+
+    expect(outbound).toHaveLength(3);
+    expect(outbound.map(hasBlob)).toEqual([true, true, false]);
+  });
+
   test("a failed A-to-B turn does not commit B, so the next B retry still strips A-minted blobs", async () => {
     const outbound: Array<Record<string, unknown>> = [];
     globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {


### PR DESCRIPTION
Rebased onto current `dev` (`401c24f74`). The two #2264 commits this was stacked on already landed as #2273, so they are no longer in this branch. Exact head is 0 behind / 2 ahead.

Closes the blind spot that made the serving-identity record pay full price on every turn instead of once.

## 1. The record could not be written at all without a Codex header

The scope was keyed solely on `x-codex-parent-thread-id`. With no header there was **no scope object**, so nothing could be recorded or compared: every turn stayed permanently cold, the deterministic pre-flight never fired, and each turn fell through to the opaque-blob recovery — one extra full upload of the transcript, every turn.

Measured across 95 live xAI conversations: 70 recoveries, **67 of them in two conversations**.

| conversation | requests | recoveries |
|---|---|---|
| f4be51de | 86 | 55 |
| c14e85a7 | 66 | 12 |
| e925d065 | 165 | 1 ← healthy: one cold first turn |

Both outliers are sessions where the backend was switched mid-conversation, so their transcripts permanently carry foreign-minted reasoning blobs replayed on every later turn. An instrumented build confirmed those exact requests carried no client thread id. At ~150k input tokens per send, that is the whole transcript uploaded twice per turn.

`conversationIdFromResponsesRequest` already resolves a conversation identity for the request log through a four-level fallback, so this reuses it as the replay scope key when the header is absent. **`_clientThreadId` is untouched** — it stays the routing and continuation identity, and the header path is byte-for-byte unchanged.

The scope is shared with the process-local raw-reasoning replay and the durable thought-signature replay. Widening is safe for both: they key additionally by provider, destination, adapter, model and credential, so a conversation namespace only narrows what they already isolate. A fallback that yields no identity still produces no scope, preserving today's keep-the-blobs behaviour.

## 2. …and fixing that was not enough

This is the part worth reading. With the scope working, live behaviour was still wrong — **three consecutive turns to the same destination**, replaying a grok-minted blob to `gpt-5.6-sol`:

```
turn 1  sends=1  recovery=[]                       pre-flight strips, one send
turn 2  sends=2  recovery=[opaque-blob-rejection]   record now says sol == sol,
turn 3  sends=2  recovery=[opaque-blob-rejection]   no strip, upstream rejects again
```

**The serving-identity model assumes the transcript only contains blobs from the last-serving destination.** That assumption dies the moment a switch happens: the switch occurs once, but the foreign blob stays in the replayed history forever, so every later comparison returns "same identity" and the pre-flight stops stripping.

So when a recovery **succeeds**, the upstream has just proven this conversation's replayed opaque state is unusable for that destination. Remember it, and pre-strip instead of rediscovering it at the cost of a round trip per turn.

Two properties carry the safety of that memo:

- **Keyed by conversation _and_ durable serving identity.** Keyed by conversation alone it would strip the original destination's own valid blobs the moment the user switched back — a silent, permanent quality regression with no error to notice. There is a regression test for exactly that.
- **Recorded only when the blobless resend actually succeeded.** If the resend failed too, the blob was not the problem and nothing is learned.

TTL is five minutes against the serving record's hour, and the asymmetry is deliberate: a stale memo silently degrades reasoning, while an expired one costs a single visible recovery round trip that re-establishes it.

## Verification

Live, on the deployed build, after both commits:

```
turn 1  SOL    sends=1  recovery=[]                      pre-flight strip
turn 2  SOL    sends=2  recovery=[opaque-blob-rejection]  memo established
turn 3  SOL    sends=1  recovery=[]                      memo hit
back to grok   sends=1  recovery=[]                      its own blobs survive
```

The last line is the one that would be invisible in production if it regressed.

## Live measurement on the deployed stack (2026-08-21)

Deployed as `v2.29.0` + #2270 + this branch and used for ~40 minutes of real Codex traffic (PDT 11:43–12:25): **124 xAI requests, 124 sends — zero extra sends, zero recoveries**; the single non-200 is a 499 from the proxy restart itself. Cached-input share 95.8% overall; the main session 96.0%, with 98.0–99.8% per turn over its last 30 turns.

Switch checks on the same build (synthetic headerless threads through the proxy): grok mint → replay to `gpt-5.6-sol` on the same thread → back to grok, and the reverse direction — every hop `sendCount=1`, no recovery (warm record → deterministic pre-strip). The cold-record path (first hop pays one recovery, later hops on the same destination do not: `[2, 1, 1]`) was verified live on these exact commits earlier the same day; see Verification above.

For scale: the two conversations that motivated this PR had sent 219 times for 152 requests before it.

## Tests

Focused replay/recovery/log suites 60/60, including the mixed-header continuity and shared-session isolation regressions. `bun run typecheck` and `bun run privacy:scan` pass on this SHA. The old `responses-routed-web-search-fields` failure is gone after rebasing onto current `dev` (#2283).

Full local suite on `1e771a22e`: 14187 pass / 10 skip / 1 fail across 891 files. The remaining failure is `tests/key-login-live-update.test.ts` > "notify after key login pushes the merged row and keeps modelCosts on live and disk". It fails the same way in isolation on current `dev` (`401c24f74`), so it is not a regression from this PR.

An earlier revision of the three-turn regression alternated destinations between turns. That passes for the wrong reason: the identity changes every turn, so ordinary switch detection fires and the memo is never exercised. The destination is now held constant, which is what the production pathology looks like.

Part of #2240.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reasoning replay recovery when switching providers, destinations, or session identities.
  * Prevented repeated opaque-content failures by temporarily remembering rejected replay data.
  * Enabled pre-flight removal of incompatible encrypted reasoning content after confirmed recovery.
  * Improved conversation identification across headers, cursors, and session fallbacks.
  * Added safer handling for missing, invalid, or expired conversation identifiers.
* **Tests**
  * Expanded coverage for identity changes, recovery failures, expiration, isolation, and fallback behavior.
* **Documentation**
  * Clarified conversation identity and replay handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->






