### PR TITLE
fix(cursor): unknown exec replies with ExecClientThrow + streamClose instead of silence

### DIFF
--- a/src/adapters/cursor/native-exec-common.ts
+++ b/src/adapters/cursor/native-exec-common.ts
@@ -1,6 +1,7 @@
 import { create, toBinary } from "@bufbuild/protobuf";
 import {
   AgentClientMessageSchema,
+  ExecClientThrowSchema,
   ExecClientControlMessageSchema,
   ExecClientMessageSchema,
   ExecClientStreamCloseSchema,
@@ -44,6 +45,22 @@ export function execStreamCloseBytes(execMsg: ExecServerMessage): Uint8Array {
       case: "execClientControlMessage",
       value: create(ExecClientControlMessageSchema, {
         message: { case: "streamClose", value: create(ExecClientStreamCloseSchema, { id: execMsg.id }) },
+      }),
+    },
+  });
+}
+
+/**
+ * Exec-channel typed throw (`execClientControlMessage.throw`). senpi's contract (T05):
+ * a frame that cannot be answered at all must get an explicit error reply + stream-close
+ * so the server unblocks with a known failure, instead of waiting forever on silence.
+ */
+export function execThrowBytes(execMsg: ExecServerMessage, error: string): Uint8Array {
+  return clientBytes({
+    message: {
+      case: "execClientControlMessage",
+      value: create(ExecClientControlMessageSchema, {
+        message: { case: "throw", value: create(ExecClientThrowSchema, { id: execMsg.id, error }) },
       }),
     },
   });

--- a/src/adapters/cursor/native-exec.ts
+++ b/src/adapters/cursor/native-exec.ts
@@ -50,7 +50,7 @@ import {
   recordScreenExec,
   type CursorNativeToolDeps,
 } from "./native-exec-tools";
-import { clientBytes, execBytes } from "./native-exec-common";
+import { clientBytes, execBytes, execStreamCloseBytes, execThrowBytes } from "./native-exec-common";
 import type { McpToolDefinition } from "./gen/agent_pb";
 import { OCX_RESPONSES_TOOL_PROVIDER } from "./tool-definitions";
 
@@ -603,10 +603,15 @@ export async function handleCursorNativeExec(execMsg: ExecServerMessage, deps: C
     }))];
   }
   // Unknown exec case — Cursor added a new native exec type that our protobuf definition does not
-  // include yet. Return an empty reply so the stream stays alive instead of throwing (which kills
-  // the entire gRPC connection via failAndClear). Same class of bug as #116.
+  // include yet. T05 (senpi contract): reply with ExecClientThrow + stream-close so the server
+  // unblocks with a known failure. Previously this returned an empty reply (silence), which is
+  // the stall class senpi explicitly refused (#116 was about throwing into failAndClear and
+  // killing the whole connection; a typed in-band throw does not do that).
   debugProviderDiagnostic("cursor", "unknown-exec-case", { execCase: execCase ?? "unknown", execId: execMsg.execId });
-  return [];
+  return [
+    execThrowBytes(execMsg, "Unknown exec message variant; this client does not implement it."),
+    execStreamCloseBytes(execMsg),
+  ];
 }
 
 

--- a/tests/cursor-native-exec.test.ts
+++ b/tests/cursor-native-exec.test.ts
@@ -253,12 +253,39 @@ describe("Cursor native exec bridge", () => {
     }
   });
 
-  test("unknown exec cases return empty reply instead of throwing (#116 hardening)", async () => {
+  test("unknown exec cases reply with ExecClientThrow + streamClose instead of silence (T05)", async () => {
     const result = await handleCursorNativeExec(execMessage({
       case: undefined,
       value: undefined,
     }));
-    expect(result).toEqual([]);
+    // T05 (senpi contract): a frame that cannot be answered gets a typed in-band error
+    // + stream-close so the server unblocks with a known failure. #116 was about an
+    // unhandled throw propagating to failAndClear and killing the whole gRPC connection;
+    // a typed ExecClientThrow does not do that.
+    expect(result).toHaveLength(2);
+
+    // Control messages use a different top-level case; decode them directly from the wire.
+    const throwMsg = fromBinary(AgentClientMessageSchema, result[0]);
+    const closeMsg = fromBinary(AgentClientMessageSchema, result[1]);
+    expect(throwMsg.message.case).toBe("execClientControlMessage");
+    if (throwMsg.message.case === "execClientControlMessage") {
+      expect(throwMsg.message.value.message.case).toBe("throw");
+      if (throwMsg.message.value.message.case === "throw") {
+        expect(throwMsg.message.value.message.value.error).toContain("Unknown exec message variant");
+      }
+    }
+    expect(closeMsg.message.case).toBe("execClientControlMessage");
+    if (closeMsg.message.case === "execClientControlMessage") {
+      expect(closeMsg.message.value.message.case).toBe("streamClose");
+    }
+  });
+
+  test("unknown exec cases do NOT kill the gRPC connection (#116 hardening preserved)", async () => {
+    // The T05 typed reply must not propagate into failAndClear. The transport-level
+    // contract is that handleCursorNativeExec returns bytes (not throws), which is
+    // what live-transport writes back. This test pins that boundary.
+    const replies = await handleCursorNativeExec(execMessage({ case: undefined, value: undefined }));
+    expect(replies.length).toBeGreaterThan(0);
   });
 
   test("rejects native write and delete when apply_patch is available", async () => {


### PR DESCRIPTION
## Summary

- **T05** (senpi contract): a frame that cannot be answered gets a typed in-band `ExecClientThrow` + `streamClose` so the server unblocks with a known failure.
- Previously this returned an empty reply (silence), which is the stall class senpi explicitly refused.
- #116 was about an unhandled throw propagating to `failAndClear` and killing the whole gRPC connection; a typed `ExecClientThrow` does not do that.

Stacked on #2321 (T03 turnEnded close).

## Verification

- `bun test tests/cursor-native-exec.test.ts` — 18 pass / 0 fail
- `bun run typecheck` — exit 0
- New tests pin the typed reply shape and confirm #116 hardening is preserved (no throw into failAndClear).

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown execution message types now return a structured error response followed by stream closure.
  * Improved failure handling prevents unsupported messages from terminating the connection unexpectedly.
  * Preserved diagnostic logging for troubleshooting.

* **Tests**
  * Added coverage confirming typed error responses and proper stream closure for unknown execution messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->