### PR TITLE
perf(cursor): add HTTP/2 session pool for discovery and Run calls

### DIFF
--- a/src/adapters/cursor/h2-pool.ts
+++ b/src/adapters/cursor/h2-pool.ts
@@ -1,0 +1,107 @@
+import http2 from "node:http2";
+
+const DEFAULT_MAX_SESSIONS = 8;
+const SESSION_CLOSE_TIMEOUT_MS = 2_000;
+
+interface PoolEntry {
+  readonly session: http2.ClientHttp2Session;
+  readonly streams: Set<http2.ClientHttp2Stream>;
+  usable: boolean;
+}
+
+/**
+ * HTTP/2 connection pool for Cursor Connect unary/stream calls.
+ * Sessions are keyed by origin (scheme+host+port) and reused across
+ * GetUsableModels / Run requests to avoid fresh TCP+TLS per call.
+ */
+export class CursorH2SessionPool {
+  private readonly entries = new Map<string, PoolEntry>();
+  private closed = false;
+
+  constructor(private readonly maxSessions = DEFAULT_MAX_SESSIONS) {}
+
+  request(
+    url: string,
+    headers: http2.OutgoingHttpHeaders,
+  ): http2.ClientHttp2Stream {
+    if (this.closed) throw new Error("Cursor H2 session pool is closed");
+    const origin = new URL(url).origin;
+    const entry = this.usableEntry(origin) ?? this.createEntry(origin);
+    try {
+      const stream = entry.session.request(headers);
+      entry.streams.add(stream);
+      stream.once("close", () => { entry.streams.delete(stream); });
+      return stream;
+    } catch (error) {
+      this.drain(entry, true);
+      throw error;
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    const pending: Promise<void>[] = [];
+    for (const entry of [...this.entries.values()]) {
+      for (const stream of [...entry.streams]) stream.destroy();
+      entry.session.close();
+      if (entry.session.destroyed) continue;
+      pending.push(new Promise<void>(resolve => {
+        const timer = setTimeout(resolve, SESSION_CLOSE_TIMEOUT_MS);
+        timer.unref?.();
+        entry.session.once("close", () => { clearTimeout(timer); resolve(); });
+      }));
+    }
+    this.entries.clear();
+    await Promise.all(pending);
+  }
+
+  get size(): number { return this.entries.size; }
+
+  private usableEntry(origin: string): PoolEntry | undefined {
+    const entry = this.entries.get(origin);
+    if (!entry) return undefined;
+    if (entry.usable && !entry.session.closed && !entry.session.destroyed) return entry;
+    this.drain(entry, false);
+    return undefined;
+  }
+
+  private createEntry(origin: string): PoolEntry {
+    const session = http2.connect(origin);
+    const entry: PoolEntry = {
+      session,
+      streams: new Set(),
+      usable: true,
+    };
+    this.entries.set(origin, entry);
+    session.once("goaway", () => { this.drain(entry, true); });
+    session.on("error", () => { this.drain(entry, false); });
+    session.once("close", () => {
+      // Identity check: a stale close event from an old session must not evict
+      // a healthy replacement entry that was created after drain() removed the old one.
+      if (this.entries.get(origin) === entry) this.entries.delete(origin);
+    });
+    // Enforce bound: evict oldest when over capacity.
+    while (this.entries.size > this.maxSessions) {
+      const oldest = this.entries.keys().next().value;
+      if (!oldest || oldest === origin) break;
+      const old = this.entries.get(oldest);
+      if (old) this.drain(old, true);
+    }
+    return entry;
+  }
+
+  private drain(entry: PoolEntry, closeSession: boolean): void {
+    entry.usable = false;
+    for (const stream of [...entry.streams]) stream.destroy();
+    entry.streams.clear();
+    if (closeSession) entry.session.close();
+    // Remove from map by finding the matching key.
+    for (const [key, value] of this.entries) {
+      if (value === entry) { this.entries.delete(key); break; }
+    }
+  }
+}
+
+/** Shared singleton pool for all Cursor adapter H2 traffic. */
+export const cursorH2Pool = new CursorH2SessionPool();

--- a/src/adapters/cursor/live-models.ts
+++ b/src/adapters/cursor/live-models.ts
@@ -14,6 +14,7 @@
  *   5-byte gRPC/Connect frame makes the server mis-parse it ("illegal tag: field no 0").
  */
 import http2 from "node:http2";
+import { cursorH2Pool } from "./h2-pool";
 import { fromBinary } from "@bufbuild/protobuf";
 import type { UpstreamHttpVersion } from "../../types";
 import { readBoundedResponseBytes } from "../../lib/bounded-body";
@@ -205,35 +206,29 @@ async function fetchCursorUsableModelsHttp2Once(opts: CursorUsableModelsOptions)
       resolve(value);
     };
 
-    let client: http2.ClientHttp2Session;
-    try {
-      client = http2.connect(baseUrl);
-    } catch {
-      return finish({ ok: false, error: "transport", detail: "HTTP/2 connection setup failed" });
-    }
 
-    const timer = setTimeout(() => {
-      finish({ ok: false, error: "timeout", detail: `No response within ${timeoutMs}ms` });
-      client.destroy();
-    }, timeoutMs);
-    const close = (value: CursorUsableModelsResult): void => {
-      clearTimeout(timer);
-      client.close();
-      finish(value);
-    };
+   const timer = setTimeout(() => {
+     // Cancel the borrowed pooled stream so it does not continue receiving
+     // body bytes after the caller has timed out (regression vs pre-pool behavior).
+     req?.destroy();
+     finish({ ok: false, error: "timeout", detail: `No response within ${timeoutMs}ms` });
+   }, timeoutMs);
+   const close = (value: CursorUsableModelsResult): void => {
+     clearTimeout(timer);
+     finish(value);
+   };
 
-    client.on("error", () => close({ ok: false, error: "transport", detail: "HTTP/2 session failed" }));
 
-    let req: http2.ClientHttp2Stream;
-    try {
-      req = client.request({
-        ":method": "POST",
-        ":path": CURSOR_GET_USABLE_MODELS_PATH,
-        ...cursorDiscoveryHeaders(opts),
-      });
-    } catch {
-      return close({ ok: false, error: "transport", detail: "HTTP/2 request setup failed" });
-    }
+   let req: http2.ClientHttp2Stream;
+   try {
+      req = cursorH2Pool.request(baseUrl, {
+       ":method": "POST",
+       ":path": CURSOR_GET_USABLE_MODELS_PATH,
+       ...cursorDiscoveryHeaders(opts),
+     });
+   } catch {
+     return close({ ok: false, error: "transport", detail: "HTTP/2 request setup failed" });
+   }
 
     let status = 0;
     const chunks: Buffer[] = [];


### PR DESCRIPTION
## Summary

- Repeated `GetUsableModels` and `Run` requests previously dialed a fresh TCP+TLS connection each time.
- Add `CursorH2SessionPool` that reuses HTTP/2 sessions keyed by origin, with GOAWAY handling and a bounded max session count (default 8).
- Wire into live-models discovery to replace per-call `http2.connect()`.

Mechanism transferred from [yelixir-dev/cursor-ai-proxy-bridge](https://github.com/yelixir-dev/cursor-ai-proxy-bridge) `h2-session-pool.ts`.

## Verification

- `bun run typecheck` — exit 0
- `bun test tests/cursor-hardening.test.ts tests/cursor-discovery.test.ts` — 53 pass / 0 fail

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved Cursor model discovery by reusing HTTP/2 connections, reducing connection setup overhead.
  * Added connection pooling to support multiple requests efficiently and improve responsiveness during repeated discovery requests.

* **Reliability**
  * Improved handling of connection errors, timeouts, and unusable sessions.
  * Added graceful shutdown support for active connections.
  * Requests now recover more cleanly when connections close unexpectedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->