### PR TITLE
fix(cursor): normalize display aliases in textual pseudo tool-call markers (#2305)

### DIFF
--- a/src/adapters/cursor/protobuf-events.ts
+++ b/src/adapters/cursor/protobuf-events.ts
@@ -11,6 +11,7 @@ import {
   isCodexShellBridgeToolName,
   isCursorStructuredEditToolName,
   normalizeCursorWireName,
+  normalizeCursorTextToolMarkers,
   OCX_RESPONSES_TOOL_PROVIDER,
   resolveShellBridgeAliasKey,
   responsesToolNameFromCursorWire,
@@ -1243,7 +1244,10 @@ export function mapCursorProtobufServerMessage(
   const update = serverMessage.message.value.message;
   switch (update.case) {
     case "textDelta":
-      return update.value.text ? [{ type: "text", text: update.value.text }] : [];
+      // #2305: fold Cursor display aliases inside textual pseudo tool-call markers back to
+      // the advertised wire name before any client sees the text. Real frames are already
+      // normalized structurally (mcpWireNameFromArgs above).
+      return update.value.text ? [{ type: "text", text: normalizeCursorTextToolMarkers(update.value.text) }] : [];
     case "thinkingDelta":
       return update.value.text ? [{ type: "thinking", thinking: update.value.text }] : [];
     case "toolCallStarted": {

--- a/src/adapters/cursor/tool-definitions.ts
+++ b/src/adapters/cursor/tool-definitions.ts
@@ -336,6 +336,26 @@ export function normalizeCursorWireName(name: string): string {
   return name.startsWith(CURSOR_MCP_DISPLAY_PREFIX) ? name.slice(CURSOR_MCP_DISPLAY_PREFIX.length) : name;
 }
 
+/**
+ * #2305: some models emit a TEXTUAL pseudo tool call ("[TOOL_CALL]name[ARGS]{...}")
+ * instead of a real frame, using Cursor's display alias as the name. Text-mode clients
+ * (Pi) parse that text and then cannot dispatch the undeclared display name. Rewrite the
+ * display alias to the advertised wire name ONLY inside the marker pair — prose that
+ * merely mentions the alias stays untouched, and the scope guard is the exact
+ * `mcp_${OCX_RESPONSES_TOOL_PROVIDER}_` prefix, never generic `mcp_`.
+ * Known limit (recorded in devlog 230): a marker split across two streaming deltas is
+ * not rewritten; tail-buffering is deferred until a live trace shows split markers.
+ */
+const CURSOR_TEXT_TOOL_MARKER = new RegExp(
+  String.raw`\[TOOL_CALL\](${CURSOR_MCP_DISPLAY_PREFIX.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[^\[\]]+)\[ARGS\]`,
+  "g",
+);
+
+export function normalizeCursorTextToolMarkers(text: string): string {
+  if (!text.includes(CURSOR_MCP_DISPLAY_PREFIX)) return text;
+  return text.replace(CURSOR_TEXT_TOOL_MARKER, (_match, name: string) => `[TOOL_CALL]${normalizeCursorWireName(name)}[ARGS]`);
+}
+
 export function responsesToolNameFromCursorWire(name: string, cursorToolNameMap?: ReadonlyMap<string, string>): string {
   const normalized = normalizeCursorWireName(name);
   if (!cursorToolNameMap) return normalized;

--- a/tests/cursor-protobuf-events.test.ts
+++ b/tests/cursor-protobuf-events.test.ts
@@ -8,6 +8,7 @@ import {
   McpArgsSchema,
   McpToolCallSchema,
   PartialToolCallUpdateSchema,
+  TextDeltaUpdateSchema,
   TokenDeltaUpdateSchema,
   ToolCallCompletedUpdateSchema,
   ToolCallSchema,
@@ -1100,5 +1101,41 @@ describe("request-local input estimate (#373)", () => {
     const usage = done?.type === "done" ? done.usage : undefined;
 
     expect(usage?.inputTokens).toBe(0);
+  });
+});
+
+describe("textual pseudo tool-call marker normalization (#2305)", () => {
+  function textDelta(text: string) {
+    return interaction({ case: "textDelta", value: create(TextDeltaUpdateSchema, { text }) });
+  }
+
+  test("display alias inside [TOOL_CALL]...[ARGS] markers folds to the wire name", () => {
+    const state = createCursorProtobufEventState();
+    const events = mapCursorProtobufServerMessage(
+      textDelta('[TOOL_CALL]mcp_opencodex-responses_grep[ARGS]{"pattern":"OpenCodex"}'),
+      state,
+    );
+    expect(events).toEqual([{ type: "text", text: '[TOOL_CALL]grep[ARGS]{"pattern":"OpenCodex"}' }]);
+  });
+
+  test("prose mentioning the display alias without markers stays untouched", () => {
+    const state = createCursorProtobufEventState();
+    const prose = "You could call mcp_opencodex-responses_grep here.";
+    const events = mapCursorProtobufServerMessage(textDelta(prose), state);
+    expect(events).toEqual([{ type: "text", text: prose }]);
+  });
+
+  test("markers with a non-opencodex provider prefix are not rewritten", () => {
+    const state = createCursorProtobufEventState();
+    const other = "[TOOL_CALL]mcp_other-provider_grep[ARGS]{}";
+    const events = mapCursorProtobufServerMessage(textDelta(other), state);
+    expect(events).toEqual([{ type: "text", text: other }]);
+  });
+
+  test("already-short names inside markers pass through unchanged", () => {
+    const state = createCursorProtobufEventState();
+    const short = "[TOOL_CALL]grep[ARGS]{}";
+    const events = mapCursorProtobufServerMessage(textDelta(short), state);
+    expect(events).toEqual([{ type: "text", text: short }]);
   });
 });


### PR DESCRIPTION
## Summary

Fix for #2305 ([devlog 230](https://github.com/lidge-jun/opencodex/blob/dev/devlog/_plan/260822_senpi_cursor_transfer/230_issue2305.md)): Cursor models sometimes emit a TEXTUAL pseudo tool call (`[TOOL_CALL]mcp_opencodex-responses_grep[ARGS]{...}`) instead of a real frame. Text-mode clients (Pi) parse that text and cannot dispatch the undeclared display alias, killing the turn.

The fix folds the display alias back to the advertised wire name at the `textDelta` mapping boundary in the Cursor event mapper:

- Marker-scoped: both `[TOOL_CALL]` and `[ARGS]` delimiters required — prose that merely mentions the alias is untouched.
- Provider-guarded: only the exact `mcp_opencodex-responses_` prefix (OCX_RESPONSES_TOOL_PROVIDER); generic `mcp_*` names from other providers pass through.
- Real frames unaffected: structural tool-call frames were already normalized via `mcpWireNameFromArgs`.
- Recorded non-goal: a marker split across two streaming deltas is not rewritten; tail-buffering is deferred until a live trace shows split markers (doc 230).

Closes #2305.

## Verification

- `bun x tsc --noEmit` clean.
- `tests/cursor-protobuf-events.test.ts` extended with 4 cases (marker folds, prose untouched, foreign prefix untouched, short name pass-through) — 44 pass / 0 fail.
- Root cause and fix point were established by an independent read-only investigation lane with file:line evidence (devlog 230).
- Full suite deferred to CI per maintainer instruction (no-verify push authorized).

## Checklist

- [x] Targets dev
- [x] Focused regression tests added next to the subsystem
- [x] Cursor-adapter-scoped; no other adapter or client path touched
- [x] No logging or credential changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized Cursor pseudo-tool-call markers in streamed text so display aliases resolve to the correct tool names.
  * Preserved ordinary prose, unrelated provider names, and already-normalized tool names without modification.
* **Tests**
  * Added coverage for supported aliases, unchanged prose, unrelated providers, and pre-normalized markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->