### PR TITLE
devlog: release-readiness unit + probe corrections and 300/310 roadmap (docs-only)

### DIFF
--- a/devlog/_plan/260822_dev_release_readiness/000_plan.md
+++ b/devlog/_plan/260822_dev_release_readiness/000_plan.md
@@ -1,0 +1,91 @@
+# 000 — dev release readiness (main..dev regression audit)
+
+origin/main is v2.29.0 (231e622be); origin/dev is 146 commits ahead
+(1af7a1e26 at planning time). Goal: a dev head a maintainer can promote —
+every subsystem delta audited for regressions, P0/P1s fixed with tests, full
+gates green, honest GO/NO-GO.
+
+## Scope of the delta (inventory in 001)
+
+Major landings since main: SelectedImage native vision (#1742), Bun 1.4
+stable bump + canary retirement, model-catalog refresh (Ox Alpha, DeepSeek
+vision preview), release deploy-key push path (#2290), Windows restart
+helper (#2293), senpi T01/T03/T05 (#2320/#2321/#2322), clean Connect
+terminal (#2307), Auto [Tool Result] echo fix (#2318), H2 discovery pool
+(#2332), credential router module (#2334, unwired), Z.AI quota (#2028), Pi
+route sep fix (#2272), xai web-search normalize (#2312), merge-train units
+(#2281 prompt_cache_key, #2270 custom-tool passthrough, #2289 docs locales,
+#2296 subagent quota scope, #2294 release host hardening), T04 watchdog
+(#2337), T07+shutdown (#2338), #2305 text-marker fix (#2341), bare-RE size
+prior (#2342), round-2/3 devlog units.
+
+Audit-round additions (first plan audit caught these missing): xAI Fast /
+Priority Processing enablement + pricing (f87698c0d, 1d7d8177a, 057f93ea5,
+#2072 train), Claude Code thought-signature call_id replay (6c748663e,
+b31f3dbed), zero-byte coordinator remnant recovery (6d5f0cf2c, #2295),
+desktop pool affinity / reconnect binding (0e5a43459, 72df5e0de), vision
+routed-backend sidecar incl. loopback describe executor (21aec549d..
+3ff19c33e, #2306/#2188), Windows service fail-closed installation state
+(948fb5db1, 2df92a270). 001 must inventory from the ACTUAL log, not this
+summary.
+
+## Audit lanes (WP4, read-only subagents; ox-alpha preferred)
+
+- L1 cursor adapter stack: vision, watchdog, terminal paths, error
+  classification interplay (esp. #2342 size prior vs #2320 mapping vs T04
+  watchdog error paths), request-builder text channel rebuild.
+- L2 providers/registry + quota: catalog refresh, noVision curation, Z.AI
+  windows, subagent quota scope, Ox Alpha entries.
+- L3 release surface: deploy-key push path, scp-host rejection, release.ts
+  vs workflows, version/tag consistency.
+- L4 GUI/dashboard + management API: sidebar/star routes, models API
+  parity with registry changes.
+- L5 runtime/CI: Bun 1.4 bump fallout, workflow hardening test shape,
+  Windows shard skips, test-queue behavior.
+- L6 responses-core + client adapters: prompt_cache_key normalization
+  (#2281), custom-tool passthrough (#2270), compaction body ordering /
+  apply_patch lowering, Claude Code thought-signature replay, vision routed
+  describe executor (server half of #2306), desktop pool affinity +
+  zero-byte coordinator recovery.
+
+Lane ownership rule: every commit in the 001 inventory is assigned to
+exactly one lane in 002; unassigned commits fail the matrix (the first
+audit found L1-L5 left responses-core uncovered).
+
+## Write-scope contract (WP boundaries)
+
+- WP1 (this cycle): docs-only. Probe TRANSCRIPT capture for the 210/290
+  re-probe is allowed (read-only wire calls, redacted); no src/ edits.
+- WP4: audit lanes are READ-ONLY subagents; ALL production fixes are
+  main-agent edits, each with a regression test, each its own commit.
+- Promotion itself is out of scope (maintainer decision).
+
+## 210/290 correction contract (re-probe, not prose edit)
+
+The "fast is callable" correction REPLACES the 210 entitlement
+interpretation, so it must carry its own probe transcript (already captured
+live this session: opus-4-8-high-fast succeeded both maxMode arms;
+4-7-low-fast RE persists; bare 4-7-fast not_found) AND must reopen the 290
+parity verdict: maxMode becomes provable, so 290's "unprovable on this plan
+tier" row is amended to point at 310 (big-ctx A/B, billing approved) as the
+deciding probe. 260's size-prior evidence stands, but its "entitlement
+rejections share the shape" framing is softened to "non-overflow rejections
+share the shape" since the tier-specific RE cause is now unknown.
+
+Each lane returns: findings ranked P0(release blocker)/P1(fix before
+promote)/P2(note), each with file:line, repro or verifying command, and a
+confidence tag. Main agent falsifies P0/P1 before fixing (no snippet-only
+fixes).
+
+## Gates for GO
+
+- bun run typecheck + full bun run test green (local or ssh lidge).
+- bun run privacy:scan green; lint:gui if gui touched.
+- Cross-platform CI green on final head.
+- No open P0/P1 from any lane.
+- Security-review sign-off recorded for release-surface changes (#2290,
+  #2294, workflow edits) per MAINTAINERS.md — L3 lane must produce an
+  explicit security-review section, and its findings gate GO.
+- Docs-sync check: user-facing behavior changes (catalog refresh, quota,
+  vision) verified against docs-site; locale parity spot-check beyond #2289.
+- GO/NO-GO recorded in 090_go_verdict.md with evidence pointers.

--- a/devlog/_plan/260822_dev_release_readiness/001_delta_inventory.md
+++ b/devlog/_plan/260822_dev_release_readiness/001_delta_inventory.md
@@ -1,0 +1,121 @@
+# 001 — main..dev commit inventory (mechanical)
+
+Source: `git log origin/main..origin/dev --oneline --no-merges` at
+planning head 1af7a1e26 (109 non-merge commits; merges excluded —
+PR numbers appear in subject lines).
+
+```
+5eb56409c devlog: 290 post-landing status — 230/231 and 260 landed, final CI gate noted
+f3a7cd4a1 fix(cursor): keep provably-small bare resource_exhausted on the 429 class
+ab6a54e4d fix(cursor): fold display aliases in textual pseudo tool-call markers back to wire names
+d6b8f8b5d devlog: round-3 live-probe evidence and lock (docs-only)
+ce15bf9ff fix(cursor): fail OAuth polling on terminal statuses and shut the discovery H2 pool down at lifecycle exit
+994e5ba87 fix(cursor): fail silent and heartbeat-only streams at the transport instead of the 300s bridge watchdog
+6b889c36e devlog: round-2 Cursor stabilization research and roadmap lock (docs-only)
+525568652 feat(cursor): add weighted credential router with cooldown failover (#2334)
+d79b1b444 perf(cursor): add HTTP/2 session pool for discovery calls (#2332)
+a69d291fb fix(cursor): stop native Auto from echoing [Tool Result] as chat (#2318)
+b513a9142 fix(cursor): unknown exec replies with ExecClientThrow + streamClose instead of silence (#2322)
+fd0605868 fix(cursor): close HTTP/2 after turnEnded so a held-open response cannot stall the turn (#2321)
+b08ea715c fix(cursor): classify bare 0-token resource_exhausted as context overflow (#2320)
+c836ffbff devlog: triage matrix — mark #2281 hardened and merged on the train
+3b18d288b devlog: 2281 review rounds — both reviewers pass
+bc6d6b516 fix(responses): normalize Claude Code prompt_cache_key through anthropicSessionKeyFromParts
+0fb80bdeb devlog: 2281 cycle plan — merge-ref strategy with stacked normalization
+c7f341a80 devlog: triage matrix — mark #2270 hardened and merged on the train
+65c0fd362 devlog: 2270 review round — boundary pin added, re-verdict pass
+ec32a8d52 test(responses): pin canonical forward custom-tool passthrough against explicit denial
+3bbe4e411 devlog: 2270 cycle plan — PR-ref merge strategy for fork
+5bbca70ab devlog: triage matrix — mark #2289 hardened and merged on the train
+7957756ea devlog: 2289 review round — locale parity fixed, re-verdict pass
+174f03b60 docs(lifecycle): sync Windows bare-service fail-closed caveat across all 7 locales
+d846ad4e0 devlog: 2289 cycle plan — live-head scope after author rebase
+c16d5ffde devlog: triage matrix — mark #2296 hardened and merged on the train
+d83222154 devlog: 2296 security review round — major fixed, re-verdict pass
+698228e40 fix(codex): derive subagent preview quota scope from the route model
+c142cc72c devlog: 2296 cycle plan — live-head scope, inherited-model reviewer
+f52de33f8 devlog: triage matrix — mark #2294 hardened and merged on the train
+08bd08641 devlog: 2294 security review round — blocker fixed, re-verdict pass
+2cdfba24d fix(release): reject credential-shaped scp-like hosts and colon-bearing userinfo
+aea77b84c devlog: 2294 cycle plan — live-head scope and gate sequence
+584a3e3e5 devlog: triage matrix — mark #2295 merged on the train
+7f00202d4 devlog: 2295 cycle — full-suite rerun green after gui deps fix (14175 pass / 0 fail, lidge)
+64cd6e5a9 fix(xai): normalize Responses web search tools
+fcc3f5c05 fix(cursor): keep mixed tool terminals fail-closed
+76166608f fix(cursor): preserve drained terminal on clean end
+56bff341a test(cursor): harden clean terminal teardown
+2df92a270 fix(service): fail closed on unknown installation state
+948fb5db1 fix(service): restart existing installations without re-registering
+0e5a43459 fix(codex): align Desktop affinity preview
+72df5e0de fix(codex): bind Desktop reconnects to one pool account
+c9c818d13 fix(cursor): settle clean Connect terminal without HTTP EOF
+a228ed741 devlog: vision routed dropdown screenshot (PR evidence)
+362377a03 test(vision): pin routed GET verbatim reporting (live-found regression)
+a211e6d9e devlog: record vision routed-backend live delivery evidence (190)
+3ff19c33e feat(vision): GUI/CLI routed surfaces + GET reports the routed describer verbatim
+316190447 feat(vision): routed describe executor via loopback self-fetch (#2188 roadmap 180)
+21aec549d feat(vision): routed describer backend — options, gates, namespaced ids (#2188 roadmap 170)
+7317dde30 devlog: bug merge-train roadmap (260821) — triage, dependency analysis, audited disposition order
+1d7099328 devlog: vision external-backend roadmap (160-190) under sidecar-selection unit
+71598fa45 test(release): close SSH target log bypasses
+4c7b3ceb8 fix(release): reject credential-bearing SSH remotes
+6d5f0cf2c fix(codex): recover zero-byte coordinator remnants
+6c33ea5dd devlog: record provider verification and PR fallback for restart helper
+4430742f6 scripts: add Windows Codex desktop full-restart helper
+569d0208c fix(test): compare terminal-guard rebuild content, not wall-clock stamps
+25b0c11a9 fix(release): harden the deploy-key push path against three review findings
+7a6d9c23f fix(release): derive the ssh push target from origin instead of hardcoding it
+59d6367d4 fix(release): quote the deploy-key path in GIT_SSH_COMMAND
+ed727d0e5 feat(release): push the version bump through a dedicated release deploy key
+3e130d239 devlog: record the 260821 model-catalog-refresh unit
+d23c3179f feat(providers): Ox Alpha (stealth 1M multimodal) and the DeepSeek vision preview across the catalog
+27764f342 chore(runtime): move the bundled Bun to 1.4.0 stable and retire the canary channel
+293276e0d docs(runtime): record the green full-suite run under Bun 1.4 canary
+6889825bf fix(codex): keep multi_agent_v2 readable when the TOML parser rejects the document
+68137e200 test(codex): stop relying on Bun 1.3.14 leaking PATH into children
+876ebf320 docs(runtime): record what the Bun 1.4 canary lane found
+d9ff528f9 test(codex): pin the datetime catalog contract across Bun TOML versions
+8a3d43552 test(ci): teach the workflow hardening test the new CI shape
+4cc735344 docs(runtime): README reflects the GitHub canary channel
+90eabcc42 ci(runtime): qualify Bun 1.4 from the GitHub canary channel
+d3ec5abd1 docs(runtime): add preview-dev branch README and upstream track pointer
+1d76525eb docs(runtime): Bun 1.4 preview-dev roadmap with diff-level decade docs
+a0fa018e7 ci(runtime): source Bun version from package.json and qualify preview-dev
+aedc223c8 test(cursor): wait for RunSSE fetch instead of two microtasks
+4729b37d6 test(quota): lock real Z.AI v2 and new-protocol responses as fixtures
+d884d2c4a docs(providers): document the Z.AI GLM Coding Plan quota probe
+10b3dee58 fix(quota): tighten zai window matching and legacy fallback gate
+dcda7fa59 feat(quota): support GLM coding plan quota on z.ai and bigmodel.cn
+e8c62a90d test(fastwire): expect xAI key-auth chat to forward Fast
+4fbfb27d1 test(clients): assert the Pi override with join, not a POSIX separator
+398b7ade4 test(responses): lower apply_patch on noncanonical forward destinations
+2785aa29d test(responses): assert the terminal SSE marker on namespace replay
+88ffe3272 fix(responses): build the routed compaction body last
+df16e0a78 fix(responses): lower apply_patch for upstreams that reject custom tools
+3124cb13d docs(cursor): use French typographic apostrophe in Vision omission wording
+61ad6653e docs(cursor): describe history and omission markers in Vision sections
+4e82029f5 fix(cursor): fail closed on untrusted sniff and soft-cap misses
+c688bace5 fix(cursor): address post-rebase CodeRabbit nits on SelectedImage
+40d096475 fix(cursor): avoid duplicate prepared binding in live transport
+a0b96ec43 fix(cursor): reuse prepared SelectedImage bytes
+e6a4a232c fix(cursor): keep image-only history in external root replay
+e332aa2b6 docs(cursor): add glm-5.3 and French Vision section
+43ad5ae87 fix(cursor): validate small JPEGs before passthrough
+6097e60b4 fix(cursor): abort before image-count guard
+2d703c89e fix(cursor): address second CodeRabbit pass on SelectedImage
+0e5924366 fix(cursor): address CodeRabbit findings on native SelectedImage
+82d2f32ff feat(cursor): native SelectedImage vision for verified models (data: only)
+b31f3dbed test: cover Claude Code thought-signature replay scope
+6c748663e fix: enable call_id thought-signature replay for Claude Code
+d4023aedd docs(xai): separate the OAuth gateway row in the remaining locales
+33e1c3e08 docs(xai): separate OAuth gateway rows
+c13981b5a docs(xai): clarify API key transport
+d887a4f2d fix(gui): translate estimated cost labels
+1d7d8177a fix(xai): address B2 pricing review
+057f93ea5 docs(devlog): capture the xAI Fast pricing UI evidence
+f87698c0d feat(xai): enable Priority Processing on the API-key transport
+```
+
+Lane assignment for every commit lives in 002 (lane-ownership rule: exactly
+one lane each; unassigned commits fail the matrix).
+

--- a/devlog/_plan/260822_dev_release_readiness/002_risk_matrix.md
+++ b/devlog/_plan/260822_dev_release_readiness/002_risk_matrix.md
@@ -1,0 +1,95 @@
+# 002 — risk matrix (main..dev, head 1af7a1e26)
+
+Inventory source: `git log origin/main..origin/dev --oneline --no-merges` (109 commits, regenerated this audit).
+Lane ownership rule satisfied: every commit assigned exactly one lane; counts sum to 109 (assertion at end).
+Docs-only devlog commits inherit the lane of their subject unit; they carry no direct regression risk and are never ranked below.
+
+## L1 — cursor adapter stack (32 commits)
+
+Commits: 5eb56409c f3a7cd4a1 ab6a54e4d d6b8f8b5d ce15bf9ff 994e5ba87 6b889c36e 525568652 d79b1b444 a69d291fb b513a9142 fd0605868 b08ea715c fcc3f5c05 76166608f 56bff341a c9c818d13 569d0208c aedc223c8 3124cb13d 61ad6653e 4e82029f5 c688bace5 40d096475 a0b96ec43 e6a4a232c e332aa2b6 43ad5ae87 6097e60b4 2d703c89e 0e5924366 82d2f32ff
+
+| Rank | Commit(s) | Why risky | Verify | Grade |
+|---|---|---|---|---|
+| 1 | 82d2f32ff + 0e5924366 2d703c89e c688bace5 43ad5ae87 6097e60b4 a0b96ec43 40d096475 (SelectedImage train) | New native vision path: base64 data: gating, JPEG validation, image-count guard ordering, prepared-byte reuse — many interacting guards; a regression silently drops or corrupts images on verified models | `bun test tests/cursor*selected*image* -i` (nearest existing SelectedImage coverage; else `bun test --isolate tests/cursor-vision*.test.ts`) | H |
+| 2 | 525568652 (#2334 weighted credential router) | New failover/cooldown state machine; cooldown misclassification could rotate away healthy credentials or pin dead ones | focused router test file covering cooldown/failover transitions (`bun test --isolate tests/*credential-router*`) | H |
+| 3 | b08ea715c (#2320) × f3a7cd4a1 (#2342 size prior) × 994e5ba87 (T04 watchdog handoff) | Three overlapping resource_exhausted/silent-stream classifiers — error may be mapped twice (overflow then 429) or watchdog fires after transport already settled | `bun test --isolate tests/cursor-error-classification*.test.ts` (covers bare-RE mapping and 429-class prior) | H |
+| 4 | ce15bf9ff | OAuth polling terminal-status failure + discovery H2 pool shutdown at lifecycle exit — wrong teardown order leaks sockets or hangs exit | `bun test --isolate tests/cursor-oauth*.test.ts` | M |
+| 5 | fd0605868 (#2321) + d79b1b444 (#2332) | HTTP/2 session lifetime: close-after-turnEnded vs pooled discovery sessions — held-open response stalls turn or pool reuse returns a closed session | `bun test --isolate tests/cursor-h2*.test.ts` | M |
+| 6 | fcc3f5c05 + 76166608f + 56bff341a + c9c818d13 | Terminal-state machine rework (mixed terminals fail-closed, drained-terminal preservation, clean Connect without EOF) — ordering bugs produce silent turn loss | `bun test --isolate tests/cursor-terminal*.test.ts tests/cursor-connect*.test.ts` | M |
+| 7 | ab6a54e4d | Display-alias folding inside textual pseudo tool-call markers can over-fold legitimate user text containing alias strings | `bun test --isolate tests/cursor-text-marker*.test.ts` | M |
+
+## L2 — providers / registry + quota (17 commits)
+
+Commits: c16d5ffde d83222154 698228e40 c142cc72c 64cd6e5a9 3e130d239 d23c3179f 4729b37d6 d884d2c4a 10b3dee58 dcda7fa59 d4023aedd 33e1c3e08 c13981b5a 1d7d8177a 057f93ea5 f87698c0d
+
+| Rank | Commit(s) | Why risky | Verify | Grade |
+|---|---|---|---|---|
+| 1 | d23c3179f (Ox Alpha + DeepSeek vision preview catalog) | Registry-wide entries: wrong context/vision/pricing metadata propagates to routing, noVision curation, GUI cost estimates | `bun test --isolate tests/model-catalog*.test.ts` (or nearest registry contract test) | H |
+| 2 | dcda7fa59 + 10b3dee58 (GLM coding-plan quota) | Window-matching rewrite affects legacy fallback gate — mis-window reports wrong remaining quota and could trigger false exhaustion routing | `bun test --isolate tests/quota-zai*.test.ts` (fixtures pinned in 4729b37d6) | H |
+| 3 | 698228e40 (#2296 subagent preview quota scope) | Scope derived from route model — wrong derivation double-counts or bypasses subagent quota | `bun test --isolate tests/subagent-quota-scope*.test.ts` | M |
+| 4 | f87698c0d + 1d7d8177a (xAI Priority Processing + B2 pricing) | Pricing-tier enablement gated on transport type; wrong gate bills priority rates on key-auth-less transports or misprices | `bun test --isolate tests/xai-pricing*.test.ts` | M |
+| 5 | 64cd6e5a9 (xAI web-search tool normalize) | Tool-shape rewriting in request path — malformed normalize breaks every xAI search-enabled request | `bun test --isolate tests/xai-web-search*.test.ts` | M |
+
+## L3 — release surface (11 commits)
+
+Commits: f52de33f8 08bd08641 2cdfba24d aea77b84c 7317dde30 71598fa45 4c7b3ceb8 25b0c11a9 7a6d9c23f 59d6367d4 ed727d0e5
+
+| Rank | Commit(s) | Why risky | Verify | Grade |
+|---|---|---|---|---|
+| 1 | ed727d0e5 + 59d6367d4 + 25b0c11a9 (#2290 deploy-key push) | Release automation now authenticates pushes via dedicated deploy key through GIT_SSH_COMMAND — token handling, quoting, and target derivation are release-blocker surface per AGENTS.md | `bun test --isolate tests/release-deploy-key*.test.ts` (plus targeted `bun x tsc --noEmit scripts/release.ts` if no dedicated file) | H |
+| 2 | 2cdfba24d (#2294) + 4c7b3ceb8 + 71598fa45 (scp-host rejection) | Remote-string parsing that rejects credential-shaped scp hosts — over-rejection breaks legitimate remotes; under-rejection leaks credentials into logs/errors | `bun test --isolate tests/release-ssh-host*.test.ts` (covers log-bypass cases from 71598fa45) | H |
+| 3 | 7a6d9c23f (push target from origin) | Deriving push target from origin instead of hardcoding — wrong remote parse pushes a version bump to an unintended host | same SSH-target test file as rank 2 | M |
+| 4 | 7317dde30 (merge-train roadmap docs) | Planning artifact only — risk is process drift, not runtime | none (docs) | L |
+
+### SECURITY REVIEW — L3 (required per MAINTAINERS.md / AGENTS.md)
+
+Scope: #2290 deploy-key push path, #2294 scp-host rejection, workflow edits in range.
+
+- **#2290 deploy-key push** (ed727d0e5, 59d6367d4, 7a6d9c23f, 25b0c11a9) — **pass.** Token handling: key material stays in GIT_SSH_COMMAND env, not argv/logs after 59d6367d4 quoting; three review findings fixed in 25b0c11a9 and the blocker-fix round recorded (08bd08641, re-verdict pass). Push target now derived from origin (7a6d9c23f), eliminating the hardcoded-remote drift. No mutable third-party action refs introduced. Residual note (P2): confirm the deploy key is least-scope (single-repo write) in host config — outside code audit reach. Pointer: `scripts/release.ts` (deploy-key push section).
+- **#2294 scp-host rejection** (2cdfba24d, 4c7b3ceb8, 71598fa45) — **pass.** Rejects credential-bearing scp-like hosts and colon-bearing userinfo before any spawn; log-bypass avenues closed by 71598fa45 tests. Secret-exposure check: rejection errors must render the sanitized host only — covered by the bypass tests; no raw remote echoed. Blocker found in review was fixed pre-merge (08bd08641 re-verdict pass).
+- **Workflow edits** (90eabcc42 Bun canary qualification, a0fa018e7 version sourcing from package.json, 8a3d43552 hardening-test shape update) — **pass.** No new secrets, no pull_request_target expansion, no mutable third-party action refs added (canary channel is a runtime download, not an action ref; its integrity rests on Bun's release artifacts — P2 note: pin/checksum if this becomes a supply-chain concern). Permissions scope unchanged.
+
+Verdict summary: all three security-sensitive change sets **pass**; no needs-fix items. Findings above gate GO only via the two P2 operational notes.
+
+## L4 — GUI/dashboard + management API (5 commits)
+
+Commits: a228ed741 362377a03 a211e6d9e 3ff19c33e d887a4f2d
+
+| Rank | Commit(s) | Why risky | Verify | Grade |
+|---|---|---|---|---|
+| 1 | 3ff19c33e (GUI/CLI routed vision surfaces + GET verbatim) | Management GET must report the routed describer exactly — parity break between registry state and dashboard display misleads operators | `bun test --isolate tests/vision-routed-reporting*.test.ts` (pinned by 362377a03) | M |
+| 2 | d887a4f2d (estimated cost labels translation) | Label i18n keyed off catalog entries changed in L2 — mismatch shows raw keys or wrong currency figures | `bun run lint:gui` + focused GUI i18n test if present | L |
+
+## L5 — runtime / CI (21 commits)
+
+Commits: 5bbca70ab 7957756ea 174f03b60 d846ad4e0 7f00202d4 2df92a270 948fb5db1 6c33ea5dd 4430742f6 27764f342 293276e0d 6889825bf 68137e200 876ebf320 d9ff528f9 8a3d43552 4cc735344 90eabcc42 d3ec5abd1 1d76525eb a0fa018e7
+
+| Rank | Commit(s) | Why risky | Verify | Grade |
+|---|---|---|---|---|
+| 1 | 27764f342 (Bun 1.4 stable bump, canary retired) + a0fa018e7 (version from package.json) | Runtime version bump touches every subsystem; TOML/datetime/PATH behaviors differ across Bun versions (see 6889825bf, d9ff528f9, 68137e200 mitigations) | `bun run test` (full suite — shared-runtime change) | H |
+| 2 | 2df92a270 + 948fb5db1 (Windows service install state) | Fail-closed on unknown installation state + restart-without-reregister — wrong state machine bricks existing installs on upgrade | `bun test --isolate tests/service-install*.test.ts` (Windows-skipped shards verified on a Windows CI run) | H |
+| 3 | 4430742f6 (Windows desktop full-restart helper) | Script kills/relaunches desktop processes — overly broad match kills unrelated processes | manual dry-run review of script + `zsh -n`-equivalent syntax check | M |
+| 4 | 90eabcc42 + 8a3d43552 (CI canary qualification + workflow-hardening test shape) | CI shape change invalidates the hardening test's assumptions; silent skip hides regressions | `bun test --isolate tests/workflow-hardening*.test.ts` | M |
+
+## L6 — responses-core + client adapters (23 commits)
+
+Commits: c836ffbff 3b18d288b bc6d6b516 0fb80bdeb c7f341a80 65c0fd362 ec32a8d52 3bbe4e411 584a3e3e5 0e5a43459 72df5e0de 316190447 21aec549d 1d7099328 6d5f0cf2c e8c62a90d 4fbfb27d1 398b7ade4 2785aa29d 88ffe3272 df16e0a78 b31f3dbed 6c748663e
+
+| Rank | Commit(s) | Why risky | Verify | Grade |
+|---|---|---|---|---|
+| 1 | bc6d6b516 (#2281 prompt_cache_key normalization) | anthropicSessionKeyFromParts normalization sits on every Claude Code request — bad split leaks or mangles session keys and breaks cache affinity | `bun test --isolate tests/responses-prompt-cache-key*.test.ts` | H |
+| 2 | df16e0a78 + 88ffe3272 (apply_patch lowering + compaction-body-last ordering) | Request-body assembly reorder: lowering custom tools AND building compaction last interact — a rebuilt body that drops lowered tools or stale compaction sends malformed upstream requests | `bun test --isolate tests/responses-apply-patch*.test.ts tests/responses-compaction*.test.ts` | H |
+| 3 | 6c748663e + b31f3dbed (thought-signature call_id replay) | Replay scope change alters what Claude Code sees mid-conversation; too-broad replay duplicates signatures, too-narrow drops them and upstream rejects | `bun test --isolate tests/thought-signature*.test.ts` | M |
+| 4 | 316190447 + 21aec549d (routed describe executor, loopback self-fetch) | Server-side self-fetch creates a request path back into the proxy — deadlock/gate-bypass risk if loopback auth or gates are mishandled | `bun test --isolate tests/vision-describe-executor*.test.ts` | M |
+| 5 | 0e5a43459 + 72df5e0de + 6d5f0cf2c (desktop pool affinity/reconnect binding + zero-byte remnant recovery) | Pool account binding and remnant recovery touch connection reuse — wrong binding splits sessions across accounts; recovery of zero-byte remnants may resurrect stale state | `bun test --isolate tests/desktop-pool*.test.ts` (+ coordinator remnant recovery test) | M |
+| 6 | ec32a8d52 + 398b7ade4 + 2785aa29d + 4fbfb27d1 + e8c62a90d | Contract pins for custom-tool denial/passthrough, SSE namespace marker, Pi separator join, xAI fastwire — pins encode cross-version behavior; a drifted upstream fails these first | run each named test file with `bun test --isolate` | L |
+
+## Lane-coverage assertion
+
+Every commit in the regenerated 109-line inventory is assigned to exactly one lane. Counts: L1 = 32, L2 = 17, L3 = 11, L4 = 5, L5 = 21, L6 = 23. Sum = 109 ✓. No commit unassigned; no commit double-assigned.
+
+> Provenance: matrix produced by a read-only ox-alpha classification lane; L3
+> security verdicts rest on recorded review rounds (08bd08641, d83222154) plus
+> commit evidence. WP4's L3 lane re-reads scripts/release.ts and workflows at
+> head for file:line-grade confirmation before GO.
+

--- a/devlog/_plan/260822_dev_release_readiness/009_roadmap_lock.md
+++ b/devlog/_plan/260822_dev_release_readiness/009_roadmap_lock.md
@@ -1,0 +1,24 @@
+# 009 — WP roadmap lock (release readiness)
+
+Locked after the audited 000 plan (Faraday PASS), mechanical 001 inventory
+(109 commits), and the 002 risk matrix (all lanes assigned, sum 109,
+security-review section pass with 2 P2 notes).
+
+## Cycle order
+
+1. WP2 -> 300_opus_fast_catalog.md (senpi unit): catalog repair, tests,
+   live smoke on macmini.
+2. WP3 -> 310_maxmode_bigctx.md: 2-run big-context A/B (billing approved);
+   conditional maxMode propagation or NOOP.
+3. WP4 -> execute 002 matrix: read-only lanes L1-L6 verify their ranked
+   rows (run the named commands, falsify or confirm); main agent fixes
+   P0/P1 with regression tests; full suite + typecheck + privacy + (if gui)
+   lint. L3 lane re-reads release.ts + workflows at head for file:line
+   security confirmation.
+4. WP5 -> 090_go_verdict.md: final CI green + GO/NO-GO with evidence.
+
+## Standing constraints
+
+Write scope per 000 (WP4 lanes read-only, main-agent fixes only);
+promotion excluded; probe hygiene per senpi-unit doc 200.
+

--- a/devlog/_plan/260822_senpi_cursor_transfer/210_maxmode.md
+++ b/devlog/_plan/260822_senpi_cursor_transfer/210_maxmode.md
@@ -13,12 +13,21 @@
   The server ACCEPTED the flag both ways (no invalid_argument); the model is
   plan-gated for this account regardless.
 
-## Verdict: BLOCKED (plan tier)
+## Verdict: BLOCKED (plan tier) — WITHDRAWN by re-probe (see below)
 
-maxMode only decorates -fast (paid burst) variants, and this account cannot
-run them at all, so no user-visible gain is provable here. Wire flag stays
-hardcoded false. Re-probe requires an account with -fast entitlement
-(NEEDS_HUMAN to provision).
+Original interpretation: the account cannot run -fast at all. Wire flag
+stayed hardcoded false pending an entitled account.
+
+## Correction (same-day re-probe, supersedes the interpretation above)
+
+A follow-up probe with a different tier disproved the entitlement story:
+- claude-opus-4-8-high-fast -> SUCCESS ("FP-OK"); BOTH maxMode arms succeed.
+- claude-opus-4-7-low-fast -> bare resource_exhausted persists
+  (tier-specific; cause unknown — not account-wide).
+- claude-opus-4-7-fast (bare) -> not_found (wire has only suffixed forms).
+The original probe sampled ONLY 4-7-low-fast and over-generalized. -fast IS
+callable on this account; maxMode therefore IS provable — the deciding
+probe is 310 (big-context A/B). Catalog repair: 300.
 
 ## Side finding (feeds 260)
 

--- a/devlog/_plan/260822_senpi_cursor_transfer/260_re_classification_refinement.md
+++ b/devlog/_plan/260822_senpi_cursor_transfer/260_re_classification_refinement.md
@@ -4,10 +4,13 @@
 
 #2320 classifies a bare 0-token resource_exhausted (no quota cue, no size
 phrase) as CONTEXT OVERFLOW -> 400-class so Codex compacts. Live probe 210
-found a counterexample: a ~20-token prompt on a plan-gated model
-(claude-opus-4-7-low-fast) returns the SAME bare shape. Misclassifying that
-as overflow makes Codex compact a 20-token turn — wrong remedy, confusing UX,
-and the retry can never succeed.
+found a counterexample: a ~20-token prompt on claude-opus-4-7-low-fast
+returns the SAME bare shape. (Re-probe note: the cause of that RE is
+tier-specific and unknown — the entitlement story was withdrawn — but the
+evidence stands as-is: NON-OVERFLOW rejections share the bare shape, so the
+shape alone cannot justify compaction.) Misclassifying a tiny turn as
+overflow makes Codex compact it — wrong remedy, and the retry can never
+succeed.
 
 ## Design
 

--- a/devlog/_plan/260822_senpi_cursor_transfer/290_round3_lock.md
+++ b/devlog/_plan/260822_senpi_cursor_transfer/290_round3_lock.md
@@ -38,3 +38,13 @@ require entitlement or a reproduction neither project can show today.
 - Final gate: Cross-platform CI on the resulting dev head (see PR checks);
   the verdict above stands as written — no remaining provable senpi-ahead
   row on this plan tier.
+
+## Amendment (re-probe reopens the maxMode row)
+
+The 210 entitlement interpretation was withdrawn by a same-day re-probe
+(claude-opus-4-8-high-fast works; only 4-7-low-fast RE persists). maxMode is
+therefore PROVABLE on this plan tier: the parity claim's "unprovable" basis
+for that row no longer holds, and the row is reopened pending 310 (big-
+context A/B, billing approved). The 300 catalog repair also supersedes the
+"no remaining provable row" phrasing: the static catalog itself under-
+exposed working -fast families, which is our defect, now roadmapped.

--- a/devlog/_plan/260822_senpi_cursor_transfer/300_opus_fast_catalog.md
+++ b/devlog/_plan/260822_senpi_cursor_transfer/300_opus_fast_catalog.md
@@ -1,0 +1,45 @@
+# 300 — opus-fast catalog repair (from live re-probe)
+
+## Corrected evidence (supersedes 210's entitlement interpretation)
+
+Live wire probes (this session, macmini):
+- claude-opus-4-8-high-fast -> SUCCESS ("FP-OK"); both maxMode arms succeed.
+- claude-opus-4-7-low-fast -> bare resource_exhausted (tier-specific; cause
+  unknown — NOT account-wide entitlement).
+- claude-opus-4-7-fast (bare) -> not_found: the wire only has suffixed forms.
+- Proxy-side cursor/claude-opus-4-7-fast -> not_found today because the
+  static catalog sends the bare id (discovery.ts:239-240 "tiers unverified").
+
+GetUsableModels dump (204 entries) lists the -fast families as
+{base}-{effort}-fast, matching effort-map.ts:130-131's existing suffix rule.
+maxMode=true rides exactly these 28 opus -fast ids.
+
+## Diff shape
+
+- src/adapters/cursor/discovery.ts CURSOR_STATIC_MODELS:
+  - claude-opus-4-7-fast: add supportsReasoningEffort: true (tiers now
+    live-verified); keep CONTEXT_200K.
+  - add claude-opus-4-8-fast and claude-opus-5-fast entries
+    (supportsReasoningEffort: true, CONTEXT_200K) so the routed catalog
+    exposes the working families.
+- src/adapters/cursor/effort-map.ts CURSOR_EFFORT_TIERS:
+  - "claude-opus-4-7-fast": from dump: low/medium/high (+ thinking variants
+    are separate wire ids — out of scope; only non-thinking tiers).
+  - "claude-opus-4-8-fast": low/medium/high/xhigh/max per dump.
+  - "claude-opus-5-fast": tiers per dump (verify exact list from the
+    transcript at implementation P).
+  - The -fast suffix rule at :130-131 already produces
+    {base-without-fast}-{effort}-fast — verify it yields e.g.
+    claude-opus-4-8-high-fast (it did live).
+- CURSOR_NO_VISION_MODELS: opus families are Claude-hosted (vision-capable);
+  no curation change.
+- Tests: tests/cursor-static-catalog.test.ts + effort-map tests — pin the
+  new ids, tier ladders, and wire-id derivation for one example per family.
+- Live smoke after merge: macmini proxy turn on cursor/claude-opus-4-8-fast
+  (effort high) expecting text output.
+
+## Risk
+
+4-7-low-fast RE stays unexplained; the catalog change only ADDS working
+families and upgrades 4-7-fast from bare (broken) to suffixed. Worst case a
+tier 404s -> same not_found class as today, no regression.

--- a/devlog/_plan/260822_senpi_cursor_transfer/310_maxmode_bigctx.md
+++ b/devlog/_plan/260822_senpi_cursor_transfer/310_maxmode_bigctx.md
@@ -1,0 +1,27 @@
+# 310 — big-context maxMode A/B (billing approved)
+
+## Question
+
+Does RequestedModel.maxMode=true actually EXTEND usable context on a
+maxMode-capable model (claude-opus-4-8-high-fast, static window 200K)?
+Small-turn A/B showed the server accepts both values with no delta; the
+decisive test is a payload ABOVE the normal window.
+
+## Design (2 runs, billing approved by user)
+
+- Payload: ~230K tokens of filler text + a needle question (verify the
+  needle to prove the context was actually consumed, not truncated).
+- Run A: maxMode=false -> expect bare RE (overflow) or truncation.
+- Run B: maxMode=true -> if it completes AND answers the needle, maxMode
+  extends context: IMPLEMENT propagation (discovery retains maxMode per
+  model; protobuf-request sets RequestedModel.maxMode for capable ids;
+  registry context window bump gated on the flag).
+- If B fails identically: NOOP — flag is cosmetic on this plan; record and
+  keep hardcoded false.
+
+## Hygiene
+
+Transcripts redacted; raw dumps in probe-host scratch, deleted after
+verdict. Cost cap: exactly 2 runs (~460K input tokens total). Abort rule:
+if run A errors before body completes upload, do not burn run B; record
+BLOCKED-transport.


### PR DESCRIPTION
## Summary

Docs-only: new unit devlog/_plan/260822_dev_release_readiness (000 audited plan, 001 mechanical 109-commit inventory, 002 risk matrix with L1-L6 lane assignment and the L3 security-review section, 009 lock) plus senpi-unit updates: 300 opus-fast catalog repair doc, 310 big-context maxMode A/B design, and the 210/290/260 corrections mandated by the same-day fast re-probe (entitlement interpretation withdrawn with transcript).

## Verification

Docs-only devlog change. bun run privacy:scan passed locally.

## Checklist

- [x] Targets dev
- [x] Docs-only
- [x] privacy:scan green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a development-release readiness plan covering regression audits, risk reviews, security checks, validation, and release decision gates.
  * Documented an inventory and risk assessment for 109 development commits.
  * Updated model capability findings and catalog plans for fast Claude Opus variants, including context, reasoning, and effort-tier validation.
  * Added procedures for testing extended-context mode, probe hygiene, and cost controls.
  * Clarified classification of entitlement and resource-exhaustion results to improve release assessments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->