### PR TITLE
feat(cursor): expose Opus Fast families with live-verified effort tiers

### DIFF
--- a/src/adapters/cursor/discovery.ts
+++ b/src/adapters/cursor/discovery.ts
@@ -236,10 +236,15 @@ export const CURSOR_STATIC_MODELS: readonly CursorModelInfo[] = normalizeCursorM
   { id: "claude-4.6-opus", contextWindow: CONTEXT_200K, supportsReasoningEffort: true },
   { id: "claude-4.6-sonnet", contextWindow: CONTEXT_200K, supportsReasoningEffort: true },
   { id: "claude-opus-4-7", contextWindow: CONTEXT_200K, supportsReasoningEffort: true },
-  // opus-4-7-fast: effort-suffix tiers unverified -> no tier picker; sent bare like live-only ids.
-  { id: "claude-opus-4-7-fast", contextWindow: CONTEXT_200K },
+  // Opus Fast families: live GetUsableModels (260822) lists ONLY effort-suffixed wire ids
+  // ({base-without-fast}-{effort}-fast; the bare id returns not_found), so every entry
+  // carries a tier picker. Live-verified: claude-opus-4-8-high-fast completed a turn.
+  // Tiers per the 260822 dump (devlog 260822_senpi_cursor_transfer/300).
+  { id: "claude-opus-4-7-fast", contextWindow: CONTEXT_200K, supportsReasoningEffort: true },
+  { id: "claude-opus-4-8-fast", contextWindow: CONTEXT_200K, supportsReasoningEffort: true },
   { id: "claude-opus-4-8", contextWindow: CONTEXT_200K, supportsReasoningEffort: true },
   { id: "claude-opus-5", contextWindow: CONTEXT_200K, supportsReasoningEffort: true },
+  { id: "claude-opus-5-fast", contextWindow: CONTEXT_200K, supportsReasoningEffort: true },
   { id: "claude-fable-5", contextWindow: CONTEXT_200K, supportsReasoningEffort: true },
 
   { id: "composer-1", contextWindow: CONTEXT_200K },

--- a/src/adapters/cursor/effort-map.ts
+++ b/src/adapters/cursor/effort-map.ts
@@ -24,8 +24,14 @@ const CURSOR_MODEL_EFFORT_TIERS: Record<string, readonly string[]> = {
   // against Anthropic's effort ladder docs and Cursor's live model lineup.
   "claude-fable-5": ["low", "medium", "high", "xhigh", "max"],
   "claude-opus-4-7": ["low", "medium", "high", "xhigh", "max"],
+  // Opus Fast tiers from the 260822 GetUsableModels dump (devlog .../300): the wire
+  // exposes {base-without-fast}-{effort}-fast only; suffix derivation at the bottom of
+  // this file produces those ids. opus-5-fast has no xhigh/max (non-thinking) yet.
+  "claude-opus-4-7-fast": ["low", "medium", "high", "xhigh", "max"],
   "claude-opus-4-8": ["low", "medium", "high", "xhigh", "max"],
+  "claude-opus-4-8-fast": ["low", "medium", "high", "xhigh", "max"],
   "claude-opus-5": ["low", "medium", "high", "xhigh", "max"],
+  "claude-opus-5-fast": ["low", "medium", "high"],
   "claude-sonnet-5": ["low", "medium", "high", "xhigh", "max"],
   "glm-5.2": ["high", "max"],
   // 260814 preemptive: glm-5.3 seeded ahead of Cursor's lineup update. Unlike 5.2, Z.AI folds

--- a/tests/cursor-static-catalog.test.ts
+++ b/tests/cursor-static-catalog.test.ts
@@ -120,3 +120,34 @@ describe("Cursor static Codex catalog", () => {
     }
   });
 });
+
+describe("Opus Fast catalog families (devlog 300, live-verified 260822)", () => {
+  test("all three -fast families are present with tier pickers", async () => {
+    const { CURSOR_STATIC_MODELS } = await import("../src/adapters/cursor/discovery");
+    for (const id of ["claude-opus-4-7-fast", "claude-opus-4-8-fast", "claude-opus-5-fast"]) {
+      const entry = CURSOR_STATIC_MODELS.find(model => model.id === id);
+      expect(entry, `${id} missing from static catalog`).toBeDefined();
+      expect(entry?.supportsReasoningEffort, `${id} must carry a tier picker — the bare wire id is not_found`).toBe(true);
+    }
+  });
+
+  test("tier ladders match the 260822 GetUsableModels dump", async () => {
+    const { cursorModelEffortLadder } = await import("../src/adapters/cursor/effort-map");
+    expect(cursorModelEffortLadder("claude-opus-4-7-fast")).toEqual(["low", "medium", "high", "xhigh", "max"]);
+    expect(cursorModelEffortLadder("claude-opus-4-8-fast")).toEqual(["low", "medium", "high", "xhigh", "max"]);
+    expect(cursorModelEffortLadder("claude-opus-5-fast")).toEqual(["low", "medium", "high"]);
+  });
+
+  test("wire-id derivation produces the live-verified suffixed forms and never a bare -fast id", async () => {
+    const { cursorWireModelIdWithEffort, cursorEffortSuffix } = await import("../src/adapters/cursor/effort-map");
+    expect(cursorWireModelIdWithEffort("claude-opus-4-8-fast", "high")).toBe("claude-opus-4-8-high-fast");
+    expect(cursorWireModelIdWithEffort("claude-opus-5-fast", "medium")).toBe("claude-opus-5-medium-fast");
+    expect(cursorWireModelIdWithEffort("claude-opus-4-7-fast", "max")).toBe("claude-opus-4-7-max-fast");
+    // No-effort requests must still resolve to a suffix (bare id is not_found on the wire).
+    for (const id of ["claude-opus-4-7-fast", "claude-opus-4-8-fast", "claude-opus-5-fast"]) {
+      expect(cursorEffortSuffix(id, undefined), `${id} must never send bare`).toBeTruthy();
+    }
+    // Out-of-ladder effort clamps within the family ladder (opus-5-fast has no xhigh).
+    expect(cursorEffortSuffix("claude-opus-5-fast", "xhigh")).toBe("high");
+  });
+});


### PR DESCRIPTION
## Summary

Live GetUsableModels (260822, [devlog 300](https://github.com/lidge-jun/opencodex/blob/dev/devlog/_plan/260822_senpi_cursor_transfer/300_opus_fast_catalog.md)) shows the Opus Fast wire ids exist ONLY in effort-suffixed form; the bare id is not_found — which is exactly why `cursor/claude-opus-4-7-fast` failed through the proxy (static catalog sent it bare, "tiers unverified"). A live turn on `claude-opus-4-8-high-fast` succeeded, so the families are callable on this plan tier.

- `discovery.ts`: `claude-opus-4-7-fast` gains its tier picker; add `claude-opus-4-8-fast` and `claude-opus-5-fast` (CONTEXT_200K, reasoning-effort capable).
- `effort-map.ts`: ladders per the dump — 4-7/4-8-fast: low/medium/high/xhigh/max; opus-5-fast: low/medium/high.
- No-effort requests resolve to a suffix (max) via the existing rank clamp, so a bare -fast id can never reach the wire; no registry default entry needed (verified in-code, unlike the kimi-k3 case).
- Vision: opus families are Claude-hosted; CURSOR_NO_VISION curation unchanged.

## Verification

- `bun x tsc --noEmit` clean.
- `tests/cursor-static-catalog.test.ts` +3 tests (family presence with tier pickers, exact ladders, wire-id derivation incl. no-bare rule and clamping) — 17 pass with cursor-discovery.
- Post-merge live smoke planned on the probe host (routed `cursor/claude-opus-4-8-fast` turn).
- Full suite deferred to CI per maintainer instruction.

## Checklist

- [x] Targets dev
- [x] Focused regression tests added
- [x] Tier data from a live dump recorded in the devlog unit
- [x] No credential/logging changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional fast Opus model variants.
  * Added configurable reasoning effort levels for supported fast models.
  * Improved handling of model identifiers and unsupported effort levels.

* **Bug Fixes**
  * Corrected the available reasoning configuration for an existing fast Opus model.

* **Tests**
  * Added coverage for model variants, effort levels, identifier generation, defaults, and effort limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->