### PR TITLE
devlog: 310 maxMode big-context A/B results (NOOP, docs-only)

### DIFF
--- a/devlog/_plan/260822_senpi_cursor_transfer/310_maxmode_bigctx.md
+++ b/devlog/_plan/260822_senpi_cursor_transfer/310_maxmode_bigctx.md
@@ -25,3 +25,36 @@ Transcripts redacted; raw dumps in probe-host scratch, deleted after
 verdict. Cost cap: exactly 2 runs (~460K input tokens total). Abort rule:
 if run A errors before body completes upload, do not burn run B; record
 BLOCKED-transport.
+
+## Executed results (260822, claude-opus-4-8-high-fast)
+
+Round 1 (single ~230K-token message): BOTH arms failed identically with
+Connect invalid_argument (~16-19s in). Not overflow, not maxMode: a
+PER-MESSAGE BYTE CAP.
+
+Round 2 (cap bisection + multi-message):
+- single ~150K tokens (~1.06MB) -> invalid_argument.
+- single ~120K tokens (~850KB)  -> SUCCESS, needle answered
+  ("TANGERINE-4471"). Cap sits between ~0.85MB and ~1.06MB — consistent
+  with a 1 MiB UserMessage blob limit.
+- multi-message history summing well past the window, needle in EARLY
+  history: model answers "no launch code" on BOTH maxMode arms — server
+  keeps recent context and drops old history; maxMode does not change
+  retention.
+
+## Verdict: NOOP for maxMode propagation
+
+maxMode=true produced no behavioral difference in any shape (small turn,
+oversize single message, over-window history). The flag stays hardcoded
+false. Re-open only if Cursor documents maxMode semantics or a Max-mode
+plan shows different retention.
+
+## Side findings (feed the readiness audit)
+
+1. Single messages over ~1MiB fail as invalid_argument. The adapter's
+   invalid_argument handling includes a fresh-conversation replay fallback —
+   an oversized message could burn a pointless replay. P2: consider a
+   pre-flight size guard with a clear client error before the wire call.
+2. Over-window history is silently truncated server-side (old turns
+   dropped). Matches the checkpoint/context-usage design assumption; no
+   action.


### PR DESCRIPTION
## Summary

Docs-only: 310 executed on the probe host. maxMode=true produced no behavioral difference in any payload shape; verdict NOOP, flag stays hardcoded false. Side findings recorded: ~1MiB per-message invalid_argument cap (P2 pre-flight guard candidate) and server-side over-window history truncation.

## Verification

Docs-only. Probe host scratch cleaned per hygiene.

## Checklist

- [x] Targets dev
- [x] Docs-only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added results from two maxMode A/B test rounds.
  * Documented the approximately 1 MiB limit for individual messages.
  * Documented how older conversation history is handled when the context window is exceeded.
  * Recommended adding a pre-flight size check for oversized messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->