### PR TITLE
feat(adapters): annotate present-but-empty tool outputs (DeepSeek default)

### DIFF
--- a/src/adapters/empty-tool-output-annotation.ts
+++ b/src/adapters/empty-tool-output-annotation.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared wire text and emptiness contract for present-but-empty tool outputs.
+ *
+ * Both the OpenAI Chat and Responses adapters use this module so the two wires
+ * cannot drift again: only a pure text/refusal part array whose joined content
+ * trims empty is "present but empty". Image, file, encrypted-content and any
+ * other non-text part is real output and is never replaced by the annotation.
+ */
+
+/** Wire text used when a present-but-empty tool output must stay visible to the model. */
+export const EMPTY_TOOL_OUTPUT_ANNOTATION =
+  "[ocx] empty tool output: the tool ran but produced no stdout or return value; do not treat this as success, failure, or user-provided input.";
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * True when every part is text/refusal and the joined text/refusal content trims
+ * empty. An empty array is the array twin of a blank string. Any image, file,
+ * encrypted-content or other non-text part makes the array non-empty so the
+ * model still receives the real payload.
+ */
+export function isWhitespaceOnlyTextPartArray(parts: readonly unknown[]): boolean {
+  if (parts.length === 0) return true;
+  let joined = "";
+  for (const part of parts) {
+    if (!isPlainObject(part)) return false;
+    if (part.type === "text" && typeof part.text === "string") {
+      joined += part.text;
+      continue;
+    }
+    if (part.type === "refusal" && typeof part.refusal === "string") {
+      joined += part.refusal;
+      continue;
+    }
+    return false;
+  }
+  return joined.trim() === "";
+}

--- a/src/adapters/empty-tool-output-annotation.ts
+++ b/src/adapters/empty-tool-output-annotation.ts
@@ -15,6 +15,9 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/** Part types that carry wire text on either adapter (Chat uses `text`, Responses uses `input_text`/`output_text`). */
+const TEXT_PART_TYPES = new Set(["text", "input_text", "output_text"]);
+
 /**
  * True when every part is text/refusal and the joined text/refusal content trims
  * empty. An empty array is the array twin of a blank string. Any image, file,
@@ -26,7 +29,7 @@ export function isWhitespaceOnlyTextPartArray(parts: readonly unknown[]): boolea
   let joined = "";
   for (const part of parts) {
     if (!isPlainObject(part)) return false;
-    if (part.type === "text" && typeof part.text === "string") {
+    if (typeof part.type === "string" && TEXT_PART_TYPES.has(part.type) && typeof part.text === "string") {
       joined += part.text;
       continue;
     }

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -8,6 +8,7 @@ import { isDebugEnabled } from "../lib/debug-settings";
 import { isCyberPolicyCode } from "../lib/errors";
 import { redactSecretString } from "../lib/redact";
 import { contentPartsToText } from "./image";
+import { EMPTY_TOOL_OUTPUT_ANNOTATION, isWhitespaceOnlyTextPartArray } from "./empty-tool-output-annotation";
 import { identifyRoutedModel } from "./identity";
 import { peekReasoningForCall } from "../responses/reasoning-replay-cache";
 import { buildNonOpenAIToolCatalogNudgeForTools, shouldInjectNonOpenAIToolCatalogNudge } from "./tool-catalog-nudge";
@@ -589,10 +590,6 @@ function isNativeOpenAIChatTarget(provider: OcxProviderConfig): boolean {
   }
 }
 
-/** Wire text used when a present-but-empty tool result must stay visible to the model. */
-const EMPTY_TOOL_OUTPUT_ANNOTATION =
-  "[ocx] empty tool output: the tool ran but produced no stdout or return value; do not treat this as success, failure, or user-provided input.";
-
 /**
  * Chat-completions image_url parts for images carried inside a tool result (issue #888). role:"tool"
  * content is text-only on every chat provider, so these ride in a follow-up user message instead of
@@ -608,10 +605,11 @@ function toolResultTextForWire(content: string | OcxContentPart[], annotateEmpty
     return content;
   }
   const text = content.filter((p) => p.type === "text").map((p) => (p as OcxTextContent).text).join("");
-  // A whitespace-only text-part array is the array twin of a blank string: the
-  // Responses adapter treats it as empty, so the Chat adapter must annotate it too
-  // instead of forwarding whitespace the model silently accepts (CodeRabbit).
-  if (annotateEmpty && content.every(part => part.type === "text") && text.trim() === "") {
+  // A whitespace-only text-part array is the array twin of a blank string; the
+  // shared emptiness contract (same module as the Responses adapter) annotates it
+  // instead of forwarding whitespace the model silently accepts. Image parts and
+  // any other non-text part keep the array non-empty.
+  if (annotateEmpty && isWhitespaceOnlyTextPartArray(content)) {
     return EMPTY_TOOL_OUTPUT_ANNOTATION;
   }
   if (text) {

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -608,6 +608,12 @@ function toolResultTextForWire(content: string | OcxContentPart[], annotateEmpty
     return content;
   }
   const text = content.filter((p) => p.type === "text").map((p) => (p as OcxTextContent).text).join("");
+  // A whitespace-only text-part array is the array twin of a blank string: the
+  // Responses adapter treats it as empty, so the Chat adapter must annotate it too
+  // instead of forwarding whitespace the model silently accepts (CodeRabbit).
+  if (annotateEmpty && content.every(part => part.type === "text") && text.trim() === "") {
+    return EMPTY_TOOL_OUTPUT_ANNOTATION;
+  }
   if (text) {
     const untransportableImages = content.filter((p) => p.type === "image" && !p.imageUrl).length;
     return `${text}${"[image]".repeat(untransportableImages)}`;

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -589,14 +589,24 @@ function isNativeOpenAIChatTarget(provider: OcxProviderConfig): boolean {
   }
 }
 
+/** Wire text used when a present-but-empty tool result must stay visible to the model. */
+const EMPTY_TOOL_OUTPUT_ANNOTATION =
+  "[ocx] empty tool output: the tool ran but produced no stdout or return value; do not treat this as success, failure, or user-provided input.";
+
 /**
  * Chat-completions image_url parts for images carried inside a tool result (issue #888). role:"tool"
  * content is text-only on every chat provider, so these ride in a follow-up user message instead of
  * being flattened to the "[image]" marker the model can't actually see. Data URLs and remote https
  * URLs are both valid in image_url.url, unlike Gemini inline_data which needs base64.
  */
-function toolResultTextForWire(content: string | OcxContentPart[]): string {
-  if (typeof content === "string") return content;
+function toolResultTextForWire(content: string | OcxContentPart[], annotateEmpty = false): string {
+  // An empty content array is a present-but-empty result; `contentPartsToText` would
+  // otherwise fall back to the "[image]" marker and hide the emptiness from the model.
+  if (annotateEmpty && Array.isArray(content) && content.length === 0) return EMPTY_TOOL_OUTPUT_ANNOTATION;
+  if (typeof content === "string") {
+    if (annotateEmpty && content.trim() === "") return EMPTY_TOOL_OUTPUT_ANNOTATION;
+    return content;
+  }
   const text = content.filter((p) => p.type === "text").map((p) => (p as OcxTextContent).text).join("");
   if (text) {
     const untransportableImages = content.filter((p) => p.type === "image" && !p.imageUrl).length;
@@ -784,7 +794,7 @@ function messagesToChatFormat(parsed: OcxParsedRequest, provider: OcxProviderCon
           out.push({
             role: "tool",
             tool_call_id: toolCallId,
-            content: toolResultTextForWire(msg.content),
+            content: toolResultTextForWire(msg.content, provider.annotateEmptyToolOutputs === true),
           });
           pendingToolResultImageParts.push(...toolResultImageChatParts(msg.content));
           pendingToolCalls.splice(matchIdx, 1);
@@ -829,7 +839,7 @@ function messagesToChatFormat(parsed: OcxParsedRequest, provider: OcxProviderCon
           out.push({
             role: "tool",
             tool_call_id: toolCallId,
-            content: toolResultTextForWire(msg.content),
+            content: toolResultTextForWire(msg.content, provider.annotateEmptyToolOutputs === true),
           });
           pendingToolResultImageParts.push(...toolResultImageChatParts(msg.content));
           flushToolResultImages();

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -21,6 +21,7 @@ import { rewriteRoutedToolSearchForUpstream } from "../responses/tool-search-com
 import { rewriteRoutedNamespaceToolsForUpstream } from "../responses/namespace-tool-compat";
 import { openaiResponsesUrl } from "./openai-responses-url";
 import { injectXaiResponsesXSearch, normalizeXaiResponsesWebSearch } from "./xai-web-search";
+import { EMPTY_TOOL_OUTPUT_ANNOTATION, isWhitespaceOnlyTextPartArray } from "./empty-tool-output-annotation";
 import {
   isXaiSchemaTarget,
   normalizeXaiToolParameters,
@@ -821,20 +822,15 @@ function toolOutputText(output: unknown): string {
   }).filter(Boolean).join("\n");
 }
 
-/** Wire text used when a present-but-empty tool output must stay visible to the model. */
-const EMPTY_TOOL_OUTPUT_ANNOTATION =
-  "[ocx] empty tool output: the tool ran but produced no stdout or return value; do not treat this as success, failure, or user-provided input.";
-
 /** True when a Responses tool output item is present but carries no usable content. */
 function isToolOutputEmpty(output: unknown): boolean {
   if (typeof output === "string") return output.trim() === "";
   if (Array.isArray(output)) {
-    return output.every(part => {
-      if (!isPlainObject(part)) return true;
-      if (typeof part.text === "string" && part.text.trim() !== "") return false;
-      if (part.type === "refusal" && typeof part.refusal === "string" && part.refusal.trim() !== "") return false;
-      return true;
-    });
+    // Mirror the Chat wire rule through the shared contract: only a pure
+    // text/refusal part array whose joined content trims empty is annotated.
+    // input_image, encrypted_content, input_file and any other non-text part is
+    // real output and must never be replaced.
+    return isWhitespaceOnlyTextPartArray(output);
   }
   return output === undefined || output === null;
 }

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -821,6 +821,41 @@ function toolOutputText(output: unknown): string {
   }).filter(Boolean).join("\n");
 }
 
+/** Wire text used when a present-but-empty tool output must stay visible to the model. */
+const EMPTY_TOOL_OUTPUT_ANNOTATION =
+  "[ocx] empty tool output: the tool ran but produced no stdout or return value; do not treat this as success, failure, or user-provided input.";
+
+/** True when a Responses tool output item is present but carries no usable content. */
+function isToolOutputEmpty(output: unknown): boolean {
+  if (typeof output === "string") return output.trim() === "";
+  if (Array.isArray(output)) {
+    return output.every(part => {
+      if (!isPlainObject(part)) return true;
+      if (typeof part.text === "string" && part.text.trim() !== "") return false;
+      if (part.type === "refusal" && typeof part.refusal === "string" && part.refusal.trim() !== "") return false;
+      return true;
+    });
+  }
+  return output === undefined || output === null;
+}
+
+/**
+ * Rewrite present-but-empty tool outputs to an explicit annotation. Synthetic
+ * missing-result placeholders are non-empty and pass through untouched. No-op unless
+ * the provider opts in (`annotateEmptyToolOutputs`).
+ */
+function annotateEmptyResponsesToolOutputs(body: unknown, enabled: boolean): unknown {
+  if (!enabled || !isPlainObject(body) || !Array.isArray(body.input)) return body;
+  let changed = false;
+  const input = body.input.map(item => {
+    if (!isPlainObject(item) || (item.type !== "function_call_output" && item.type !== "custom_tool_call_output")) return item;
+    if (!isToolOutputEmpty(item.output)) return item;
+    changed = true;
+    return { ...item, output: EMPTY_TOOL_OUTPUT_ANNOTATION };
+  });
+  return changed ? { ...body, input } : body;
+}
+
 /**
  * Repair a forward-mode input array whose continuation context was lost. When the replay
  * expansion misses (proxy restart, unrecorded prior turn), previous_response_id is stripped
@@ -2010,6 +2045,9 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
       // reaches the wire is unparseable.
       if (forward || stateless) {
         outBody = repairOrphanedInputItems(outBody, unexpandedMiss, stateless && !forward);
+      }
+      if (provider.annotateEmptyToolOutputs === true) {
+        outBody = annotateEmptyResponsesToolOutputs(outBody, true);
       }
       if (provider.requiresAdjacentResponsesToolResults === true) {
         outBody = normalizeResponsesToolResultAdjacency(outBody);

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -832,7 +832,11 @@ function isToolOutputEmpty(output: unknown): boolean {
     // real output and must never be replaced.
     return isWhitespaceOnlyTextPartArray(output);
   }
-  return output === undefined || output === null;
+  // A missing or null `output` is not a present-but-empty result: it is an
+  // incomplete payload. Leave it untouched so the upstream contract fails
+  // closed, and the orphan repair can surface it honestly instead of claiming
+  // the tool ran with no output.
+  return false;
 }
 
 /**

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -2039,11 +2039,11 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
       // pair from its own storage either, so it needs the same repair the forward
       // backend gets — dropping previous_response_id is not much use if the body that
       // reaches the wire is unparseable.
-      if (forward || stateless) {
-        outBody = repairOrphanedInputItems(outBody, unexpandedMiss, stateless && !forward);
-      }
       if (provider.annotateEmptyToolOutputs === true) {
         outBody = annotateEmptyResponsesToolOutputs(outBody, true);
+      }
+      if (forward || stateless) {
+        outBody = repairOrphanedInputItems(outBody, unexpandedMiss, stateless && !forward);
       }
       if (provider.requiresAdjacentResponsesToolResults === true) {
         outBody = normalizeResponsesToolResultAdjacency(outBody);

--- a/src/config.ts
+++ b/src/config.ts
@@ -501,6 +501,7 @@ const providerConfigSchema = z.object({
   responsesPath: z.string().min(1).optional(),
   statelessResponses: z.boolean().optional(),
   requiresAdjacentResponsesToolResults: z.boolean().optional(),
+  annotateEmptyToolOutputs: z.boolean().optional(),
   fastWire: fastWireSchema.nullable().optional(),
   supportsServiceTier: z.boolean().optional(),
   modelSupportsServiceTier: z.record(z.string().min(1), z.boolean()).optional(),

--- a/src/config.ts
+++ b/src/config.ts
@@ -3162,7 +3162,7 @@ export function applyProxyEnv(config: OcxConfig): void {
   // malformed values with a privacy-safe warning instead: they cannot express a routing
   // intent, and refusing to start is a worse answer than starting without them.
   const rawProxy = config.proxy;
-  const proxy = typeof rawProxy === "string" ? resolveEnvValue(rawProxy) : undefined;
+  const proxy = typeof rawProxy === "string" ? resolveEnvValue(rawProxy)?.trim() : undefined;
   if (!proxy) {
     if (rawProxy !== undefined) warnProxyConfigDiscardOnce("proxy");
     return;

--- a/src/config.ts
+++ b/src/config.ts
@@ -3162,7 +3162,10 @@ export function applyProxyEnv(config: OcxConfig): void {
   // malformed values with a privacy-safe warning instead: they cannot express a routing
   // intent, and refusing to start is a worse answer than starting without them.
   const rawProxy = config.proxy;
-  const proxy = typeof rawProxy === "string" ? resolveEnvValue(rawProxy)?.trim() : undefined;
+  // Trim before resolution so a whitespace-padded environment reference (e.g.
+  // "  ${VAR}  ") still resolves, then trim the resolved value so a whitespace-only
+  // env value falls back to direct egress instead of leaking into HTTP(S)_PROXY.
+  const proxy = typeof rawProxy === "string" ? resolveEnvValue(rawProxy.trim())?.trim() : undefined;
   if (!proxy) {
     if (rawProxy !== undefined) warnProxyConfigDiscardOnce("proxy");
     return;

--- a/src/config/provider-validation.ts
+++ b/src/config/provider-validation.ts
@@ -1,4 +1,5 @@
 import { isCanonicalOpenAiForwardProvider } from "../providers/openai-tiers";
+import { redactSecretString } from "../lib/redact";
 import { modelRecordValue } from "../reasoning-effort";
 import {
   isWirePinnedModel,
@@ -128,7 +129,7 @@ export function providerEmptyToolOutputConfigError(name: string, provider: unkno
   const raw = provider as Record<string, unknown> | null | undefined;
   const value = raw === null || raw === undefined ? undefined : raw.annotateEmptyToolOutputs;
   if (value !== undefined && typeof value !== "boolean") {
-    return `provider ${name} annotateEmptyToolOutputs must be a boolean`;
+    return `provider ${JSON.stringify(redactSecretString(name))} annotateEmptyToolOutputs must be a boolean`;
   }
   return null;
 }

--- a/src/config/provider-validation.ts
+++ b/src/config/provider-validation.ts
@@ -123,6 +123,16 @@ export function booleanRecordConfigError(value: unknown, field: string): string 
   return null;
 }
 
+/** Validate the management DTO boundary for the opt-in empty-tool-output annotation. */
+export function providerEmptyToolOutputConfigError(name: string, provider: unknown): string | null {
+  const raw = provider as Record<string, unknown> | null | undefined;
+  const value = raw === null || raw === undefined ? undefined : raw.annotateEmptyToolOutputs;
+  if (value !== undefined && typeof value !== "boolean") {
+    return `provider ${name} annotateEmptyToolOutputs must be a boolean`;
+  }
+  return null;
+}
+
 export function reasoningSummaryDeliveryRecordConfigError(
   value: unknown,
   supportsReasoningSummaries: unknown,

--- a/src/providers/derive.ts
+++ b/src/providers/derive.ts
@@ -254,6 +254,9 @@ export function providerConfigSeed(entry: ProviderRegistryEntry): OcxProviderCon
     ...(entry.requiresAdjacentResponsesToolResults !== undefined
       ? { requiresAdjacentResponsesToolResults: entry.requiresAdjacentResponsesToolResults }
       : {}),
+    ...(entry.annotateEmptyToolOutputs !== undefined
+      ? { annotateEmptyToolOutputs: entry.annotateEmptyToolOutputs }
+      : {}),
     ...(entry.autoToolChoiceOnlyModels ? { autoToolChoiceOnlyModels: [...entry.autoToolChoiceOnlyModels] } : {}),
     ...(entry.preserveReasoningContentModels ? { preserveReasoningContentModels: [...entry.preserveReasoningContentModels] } : {}),
     ...(entry.requiresReasoningPlaceholderModels ? { requiresReasoningPlaceholderModels: [...entry.requiresReasoningPlaceholderModels] } : {}),
@@ -500,6 +503,9 @@ export function enrichProviderFromRegistry(name: string, prov: OcxProviderConfig
   if (prov.statelessResponses === undefined && seed.statelessResponses !== undefined) prov.statelessResponses = seed.statelessResponses;
   if (prov.requiresAdjacentResponsesToolResults === undefined && seed.requiresAdjacentResponsesToolResults !== undefined) {
     prov.requiresAdjacentResponsesToolResults = seed.requiresAdjacentResponsesToolResults;
+  }
+  if (prov.annotateEmptyToolOutputs === undefined && seed.annotateEmptyToolOutputs !== undefined) {
+    prov.annotateEmptyToolOutputs = seed.annotateEmptyToolOutputs;
   }
   // Registry-only metadata (never seeded into saved config): backfill straight from
   // the entry so an explicit user value stays distinguishable from the default.

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -216,6 +216,11 @@ export interface ProviderRegistryEntry {
    */
   requiresAdjacentResponsesToolResults?: boolean;
   /**
+   * When enabled, tool results that are present but empty are annotated on the wire.
+   * Seeded/backfilled like other fixed wire capabilities.
+   */
+  annotateEmptyToolOutputs?: boolean;
+  /**
    * Registry default for the provider's `service_tier` support; see
    * `OcxProviderConfig.supportsServiceTier`. Registry-only: backfilled (never
    * overriding) at enrich/route time and deliberately NOT seeded into saved
@@ -1784,6 +1789,10 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     // context splits a call from its result (#1292); parallel calls remain one
     // reasoning-bearing assistant batch rather than being split per pair (#1477).
     requiresAdjacentResponsesToolResults: true,
+    // DeepSeek exec tool results can be present-but-empty (a script that ran without
+    // calling text(...)); annotate them so routed models do not silently accept an
+    // empty result or re-issue the same call.
+    annotateEmptyToolOutputs: true,
     /* [Decision Log]
     - 목적: DeepSeek V4 thinking mode multi-turn/tool-call requests must replay prior assistant reasoning_content.
     - 대안 분석: Globally preserve reasoning_content for all OpenAI-compatible models; preserve it for legacy deepseek-reasoner too; mark only V4 thinking models in registry metadata.

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -2573,8 +2573,8 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     adapter: "ollama-native",
     authKind: "key",
     dashboardUrl: "https://ollama.com/settings/keys",
-    // Live IDs verified 2026-07-10; qwen3-coder:480b retires 2026-07-15.
-    models: ["glm-5.3", "glm-5.3-flash", "glm-5.2", "deepseek-v4-pro", "qwen3-coder:480b", "gpt-oss:120b", "kimi-k2.6", "minimax-m3", "qwen3.5:397b", "gemma4:31b"],
+    // Live IDs verified 2026-07-10; qwen3-coder:480b retired 2026-07-15 and was removed.
+    models: ["glm-5.3", "glm-5.3-flash", "glm-5.2", "deepseek-v4-pro", "gpt-oss:120b", "kimi-k2.6", "minimax-m3", "qwen3.5:397b", "gemma4:31b"],
     defaultModel: "glm-5.3",
     // Owner-audited exact outage fallback: these current Ollama Cloud GLM-5.3 rows have
     // 1,048,576-token context windows. Live discovery and successful /api/show enrichment keep

--- a/src/router.ts
+++ b/src/router.ts
@@ -354,6 +354,10 @@ export function routedProviderConfig(providerName: string, provider: OcxProvider
       && registryEntry.requiresAdjacentResponsesToolResults !== undefined
       ? { requiresAdjacentResponsesToolResults: registryEntry.requiresAdjacentResponsesToolResults }
       : {}),
+    ...(provider.annotateEmptyToolOutputs === undefined
+      && registryEntry.annotateEmptyToolOutputs !== undefined
+      ? { annotateEmptyToolOutputs: registryEntry.annotateEmptyToolOutputs }
+      : {}),
     ...(provider.fastWire === undefined && registryEntry.fastWire !== undefined
       ? {
         fastWire: cloneFastWire(registryEntry.fastWire),

--- a/src/server/auth-cors.ts
+++ b/src/server/auth-cors.ts
@@ -649,6 +649,9 @@ export function providerManagementConfigError(name: unknown, provider: unknown):
   if (raw.xaiResponsesXSearch !== undefined && typeof raw.xaiResponsesXSearch !== "boolean") {
     return `provider ${name} xaiResponsesXSearch must be a boolean`;
   }
+  if (raw.annotateEmptyToolOutputs !== undefined && typeof raw.annotateEmptyToolOutputs !== "boolean") {
+    return `provider ${name} annotateEmptyToolOutputs must be a boolean`;
+  }
   const defaultMaxOutputError = positiveIntegerConfigError(raw.defaultMaxOutputTokens, "defaultMaxOutputTokens");
   if (defaultMaxOutputError) return `provider ${name} ${defaultMaxOutputError}`;
   const maxOutputError = positiveIntegerRecordConfigError(raw.modelMaxOutputTokens, "modelMaxOutputTokens");

--- a/src/server/auth-cors.ts
+++ b/src/server/auth-cors.ts
@@ -649,9 +649,6 @@ export function providerManagementConfigError(name: unknown, provider: unknown):
   if (raw.xaiResponsesXSearch !== undefined && typeof raw.xaiResponsesXSearch !== "boolean") {
     return `provider ${name} xaiResponsesXSearch must be a boolean`;
   }
-  if (raw.annotateEmptyToolOutputs !== undefined && typeof raw.annotateEmptyToolOutputs !== "boolean") {
-    return `provider ${name} annotateEmptyToolOutputs must be a boolean`;
-  }
   const defaultMaxOutputError = positiveIntegerConfigError(raw.defaultMaxOutputTokens, "defaultMaxOutputTokens");
   if (defaultMaxOutputError) return `provider ${name} ${defaultMaxOutputError}`;
   const maxOutputError = positiveIntegerRecordConfigError(raw.modelMaxOutputTokens, "modelMaxOutputTokens");

--- a/src/server/management/provider-routes.ts
+++ b/src/server/management/provider-routes.ts
@@ -188,6 +188,17 @@ function applyProviderPatchFields(
     next.liveModels = rawBody.liveModels;
     touched = true;
   }
+  if (Object.hasOwn(rawBody, "annotateEmptyToolOutputs")) {
+    const value = rawBody.annotateEmptyToolOutputs;
+    if (value === null) {
+      delete next.annotateEmptyToolOutputs;
+    } else if (typeof value === "boolean") {
+      next.annotateEmptyToolOutputs = value;
+    } else {
+      return { error: "annotateEmptyToolOutputs must be a boolean or null" };
+    }
+    touched = true;
+  }
   if (Object.hasOwn(rawBody, "xaiResponsesOptIn")) {
     if (name !== "xai") return { error: "xaiResponsesOptIn is valid only for provider xai" };
     if (typeof rawBody.xaiResponsesOptIn !== "boolean") {

--- a/src/server/management/provider-routes.ts
+++ b/src/server/management/provider-routes.ts
@@ -77,6 +77,7 @@ import { estimateComboCost, estimateRequestCost, normalizeCostTokens, tokensPerS
 import type { PersistedUsageAttempt } from "../../usage/log";
 import { isAllowedRequestOrigin, jsonResponse, providerManagementConfigError, publicProviderBaseUrl, safeConfigDTO } from "../auth-cors";
 import { providerServiceTierConfigError } from "./provider-capability-config";
+import { providerEmptyToolOutputConfigError } from "../../config/provider-validation";
 import { applySystemEnvToggle } from "../system-env";
 import {
   LOCAL_PROVIDER_RELOAD_NAME_HEADER,
@@ -412,7 +413,8 @@ function canonicalOpenAiBudgetPatchError(
   }
   const applied = applyProviderPatchFields("openai", seed, rawBody, keys, config);
   if ("error" in applied) return applied.error;
-  return providerManagementConfigError("openai", applied.next);
+  return providerManagementConfigError("openai", applied.next)
+    ?? providerEmptyToolOutputConfigError("openai", applied.next);
 }
 
 export async function handleProviderRoutes(ctx: ManagementContext): Promise<Response | null> {
@@ -484,7 +486,8 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
       return jsonResponse({ error: "provider reload target unavailable" }, 404);
     }
     const provider = diskConfig.providers[name]!;
-    const providerError = providerManagementConfigError(name, provider);
+    const providerError = providerManagementConfigError(name, provider)
+      ?? providerEmptyToolOutputConfigError(name, provider);
     if (providerError) return jsonResponse({ error: "provider reload target invalid" }, 409);
     const namespaceCollision = codexAccountNamespaceProviderCollisionError(
       diskConfig.codexAccountNamespaces,
@@ -543,7 +546,8 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
     let body: { name?: unknown; provider?: unknown; setDefault?: boolean };
     try { body = await readManagementJsonBody(req); } catch (error) { rethrowManagementBodyTooLarge(error); return jsonResponse({ error: "invalid JSON body" }, 400); }
     const name = typeof body.name === "string" ? body.name.trim() : "";
-    const providerError = providerManagementConfigError(name, body.provider);
+    const providerError = providerManagementConfigError(name, body.provider)
+      ?? providerEmptyToolOutputConfigError(name, body.provider);
     if (providerError) return jsonResponse({ error: providerError }, 400);
     const serviceTierError = providerServiceTierConfigError(name, body.provider);
     if (serviceTierError) return jsonResponse({ error: serviceTierError }, 400);
@@ -717,7 +721,8 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
     if (applied.editorTouched && !pacingOnly) {
       const providerError = canonicalBudgetOnly
         ? canonicalOpenAiBudgetPatchError(next, rawBody, keys, config)
-        : providerManagementConfigError(name, next);
+        : providerManagementConfigError(name, next)
+          ?? providerEmptyToolOutputConfigError(name, next);
       if (providerError) return jsonResponse({ error: providerError }, 400);
       if (!canonicalBudgetOnly) {
         const serviceTierError = providerServiceTierConfigError(name, next);
@@ -750,7 +755,8 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
       if (replay.editorTouched && !pacingOnly) {
         const syncError = canonicalBudgetOnly
           ? canonicalOpenAiBudgetPatchError(replay.next, rawBody, keys, config)
-          : providerManagementConfigError(name, replay.next);
+          : providerManagementConfigError(name, replay.next)
+            ?? providerEmptyToolOutputConfigError(name, replay.next);
         if (syncError) {
           replayError = syncError;
           return;

--- a/src/server/management/provider-routes.ts
+++ b/src/server/management/provider-routes.ts
@@ -557,6 +557,15 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
     let body: { name?: unknown; provider?: unknown; setDefault?: boolean };
     try { body = await readManagementJsonBody(req); } catch (error) { rethrowManagementBodyTooLarge(error); return jsonResponse({ error: "invalid JSON body" }, 400); }
     const name = typeof body.name === "string" ? body.name.trim() : "";
+    // Canonicalize a POST null exactly like PATCH's "clear" before validation: the
+    // dashboard's form clears the opt-out with null, and rejecting it here would
+    // force a two-step edit for something PATCH already accepts as a delete.
+    if (body.provider && typeof body.provider === "object" && !Array.isArray(body.provider)) {
+      const providerPayload = body.provider as Record<string, unknown>;
+      if (Object.hasOwn(providerPayload, "annotateEmptyToolOutputs") && providerPayload.annotateEmptyToolOutputs === null) {
+        delete providerPayload.annotateEmptyToolOutputs;
+      }
+    }
     const providerError = providerManagementConfigError(name, body.provider)
       ?? providerEmptyToolOutputConfigError(name, body.provider);
     if (providerError) return jsonResponse({ error: providerError }, 400);

--- a/src/server/management/provider-routes.ts
+++ b/src/server/management/provider-routes.ts
@@ -557,6 +557,14 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
     let body: { name?: unknown; provider?: unknown; setDefault?: boolean };
     try { body = await readManagementJsonBody(req); } catch (error) { rethrowManagementBodyTooLarge(error); return jsonResponse({ error: "invalid JSON body" }, 400); }
     const name = typeof body.name === "string" ? body.name.trim() : "";
+    // Capture field presence BEFORE null canonicalization: a submitted null is an
+    // explicit "clear" and must not be mistaken for an omitted field, otherwise the
+    // carry-over guard below restores the existing override instead of clearing it.
+    const submittedAnnotateEmptyToolOutputs =
+      body.provider !== null
+      && typeof body.provider === "object"
+      && !Array.isArray(body.provider)
+      && Object.hasOwn(body.provider as Record<string, unknown>, "annotateEmptyToolOutputs");
     // Canonicalize a POST null exactly like PATCH's "clear" before validation: the
     // dashboard's form clears the opt-out with null, and rejecting it here would
     // force a two-step edit for something PATCH already accepts as a delete.
@@ -609,7 +617,6 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
     const submittedModelContextWindows = Object.hasOwn(prov, "modelContextWindows");
     const submittedModelAutoCompactTokenLimits = Object.hasOwn(prov, "modelAutoCompactTokenLimits");
     const submittedRequestPacing = Object.hasOwn(prov, "requestPacing");
-    const submittedAnnotateEmptyToolOutputs = Object.hasOwn(prov, "annotateEmptyToolOutputs");
     enrichProviderFromCatalog(name, prov);
     const { saveConfigPreservingClaudeCode: save } = await import("../../config");
     // Overwriting an existing provider must not drop its multi-key pool: carry it over, then

--- a/src/server/management/provider-routes.ts
+++ b/src/server/management/provider-routes.ts
@@ -600,6 +600,7 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
     const submittedModelContextWindows = Object.hasOwn(prov, "modelContextWindows");
     const submittedModelAutoCompactTokenLimits = Object.hasOwn(prov, "modelAutoCompactTokenLimits");
     const submittedRequestPacing = Object.hasOwn(prov, "requestPacing");
+    const submittedAnnotateEmptyToolOutputs = Object.hasOwn(prov, "annotateEmptyToolOutputs");
     enrichProviderFromCatalog(name, prov);
     const { saveConfigPreservingClaudeCode: save } = await import("../../config");
     // Overwriting an existing provider must not drop its multi-key pool: carry it over, then
@@ -627,6 +628,12 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
     }
     if (!submittedContextWindow && existing?.contextWindow !== undefined) {
       prov.contextWindow = existing.contextWindow;
+    }
+    // Same contract for the empty-tool-output annotation opt-out: the GUI add/edit form
+    // does not send it, and registry enrichment backfills DeepSeek to true, so an unrelated
+    // POST must not silently flip an operator's explicit false back to true.
+    if (!submittedAnnotateEmptyToolOutputs && existing?.annotateEmptyToolOutputs !== undefined) {
+      prov.annotateEmptyToolOutputs = existing.annotateEmptyToolOutputs;
     }
     if (existing?.modelContextWindows) {
       // When the client did send a map, its keys win and the user's other keys survive. When

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -212,6 +212,8 @@ export interface OcxProviderConfig {
    * so models do not silently accept an empty result or re-issue the same call.
    * Non-empty results and missing-result placeholders stay byte-identical.
    * Seeded true for DeepSeek; absent keeps legacy behavior for every other provider.
+   * Only the OpenAI-family adapters (openai-chat / openai-responses) read this option;
+   * other adapters ignore it.
    */
   annotateEmptyToolOutputs?: boolean;
   /**

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -209,7 +209,7 @@ export interface OcxProviderConfig {
   /**
    * When enabled, a tool result that is present but empty (no usable text or content
    * part) is rewritten to an explicit annotation before it reaches the upstream wire,
-   * so models do not silently accept an empty result or re-issue the same call
+   * so models do not silently accept an empty result or re-issue the same call.
    * Non-empty results and missing-result placeholders stay byte-identical.
    * Seeded true for DeepSeek; absent keeps legacy behavior for every other provider.
    */

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -207,6 +207,14 @@ export interface OcxProviderConfig {
    */
   requiresAdjacentResponsesToolResults?: boolean;
   /**
+   * When enabled, a tool result that is present but empty (no usable text or content
+   * part) is rewritten to an explicit annotation before it reaches the upstream wire,
+   * so models do not silently accept an empty result or re-issue the same call
+   * Non-empty results and missing-result placeholders stay byte-identical.
+   * Seeded true for DeepSeek; absent keeps legacy behavior for every other provider.
+   */
+  annotateEmptyToolOutputs?: boolean;
+  /**
    * Provider fallback for canonical Fast capability over an OpenAI `service_tier` wire.
    * This pure tri-state feeds catalog publication, routing eligibility, compatibility
    * fingerprints, and proxy-owned canonical Fast injection on both Responses and Chat routes.

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -6029,3 +6029,11 @@ describe("Codex 0.151 catalog contract fields", () => {
     });
   });
 });
+
+describe("ollama cloud fallback catalog", () => {
+  test("no longer exposes the retired qwen3-coder:480b", () => {
+    const ollama = PROVIDER_REGISTRY.find(e => e.id === "ollama-cloud");
+    expect(ollama).toBeDefined();
+    expect(ollama!.models).not.toContain("qwen3-coder:480b");
+  });
+});

--- a/tests/empty-tool-output-annotation.test.ts
+++ b/tests/empty-tool-output-annotation.test.ts
@@ -198,4 +198,68 @@ describe("openai-responses empty tool output annotation", () => {
     const input = body.input as Array<Record<string, unknown>>;
     expect(input[0].output).toBe("");
   });
+
+  test("whitespace-only text-part array is annotated when enabled", async () => {
+    const { body } = await drive(responsesConfig(true), [
+      { type: "function_call_output", call_id: "call_5", output: [{ type: "text", text: "   \n  " }] },
+    ]);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input[0].output).toBe(ANNOTATION);
+  });
+
+  test("image-only output is never replaced when enabled", async () => {
+    const output = [{ type: "input_image", image_url: { url: "data:image/png;base64,AAAA" } }];
+    const { body } = await drive(responsesConfig(true), [
+      { type: "function_call_output", call_id: "call_6", output },
+    ]);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input[0].output).toEqual(output);
+  });
+
+  test("image plus whitespace text is never replaced when enabled", async () => {
+    const output = [
+      { type: "text", text: "   " },
+      { type: "input_image", image_url: { url: "data:image/png;base64,AAAA" } },
+    ];
+    const { body } = await drive(responsesConfig(true), [
+      { type: "function_call_output", call_id: "call_7", output },
+    ]);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input[0].output).toEqual(output);
+  });
+
+  test("encrypted_content output is never replaced when enabled", async () => {
+    const output = [{ type: "encrypted_content", data: "opaque-blob" }];
+    const { body } = await drive(responsesConfig(true), [
+      { type: "function_call_output", call_id: "call_8", output },
+    ]);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input[0].output).toEqual(output);
+  });
+
+  test("file_id-only output is never replaced when enabled", async () => {
+    const output = [{ type: "input_file", file_id: "file_123" }];
+    const { body } = await drive(responsesConfig(true), [
+      { type: "custom_tool_call_output", call_id: "call_9", output },
+    ]);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input[0].output).toEqual(output);
+  });
+
+  test("non-empty refusal output is never replaced when enabled", async () => {
+    const output = [{ type: "refusal", refusal: "I cannot do that" }];
+    const { body } = await drive(responsesConfig(true), [
+      { type: "function_call_output", call_id: "call_10", output },
+    ]);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input[0].output).toEqual(output);
+  });
+
+  test("whitespace-only refusal output is annotated when enabled", async () => {
+    const { body } = await drive(responsesConfig(true), [
+      { type: "function_call_output", call_id: "call_11", output: [{ type: "refusal", refusal: "   " }] },
+    ]);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input[0].output).toBe(ANNOTATION);
+  });
 });

--- a/tests/empty-tool-output-annotation.test.ts
+++ b/tests/empty-tool-output-annotation.test.ts
@@ -77,6 +77,27 @@ describe("openai-chat empty tool output annotation", () => {
     expect(tool?.content).toBe(ANNOTATION);
   });
 
+  test("whitespace-only text-part array is annotated when enabled", () => {
+    const messages = wire(providerWithFlag, toolCallTurn([{ type: "text", text: "   \n  " }]));
+    const tool = messages.find(m => m.role === "tool");
+    expect(tool?.content).toBe(ANNOTATION);
+  });
+
+  test("whitespace-only text-part array stays unchanged when the option is absent", () => {
+    const messages = wire(providerWithoutFlag, toolCallTurn([{ type: "text", text: "   " }]));
+    const tool = messages.find(m => m.role === "tool");
+    expect(tool?.content).toBe("   ");
+  });
+
+  test("image parts with whitespace text are not treated as empty", () => {
+    const messages = wire(providerWithFlag, toolCallTurn([
+      { type: "text", text: "   " },
+      { type: "image", imageUrl: "data:image/png;base64,AAAA" },
+    ]));
+    const tool = messages.find(m => m.role === "tool");
+    expect(tool?.content).not.toBe(ANNOTATION);
+  });
+ 
   test("non-empty result stays byte-identical when enabled", () => {
     const messages = wire(providerWithFlag, toolCallTurn("real output"));
     const tool = messages.find(m => m.role === "tool");

--- a/tests/empty-tool-output-annotation.test.ts
+++ b/tests/empty-tool-output-annotation.test.ts
@@ -109,7 +109,24 @@ describe("openai-chat empty tool output annotation", () => {
     const tool = messages.find(m => m.role === "tool");
     expect(tool?.content).toBe("");
   });
+
+  test("orphaned empty result is annotated when enabled", () => {
+    const messages = wire(providerWithFlag, [
+      { role: "toolResult", toolCallId: "call_orphan", toolName: "exec_command", content: "", isError: false, timestamp: 0 },
+    ]);
+    const tool = messages.find(m => m.role === "tool");
+    expect(tool?.content).toBe(ANNOTATION);
+  });
+
+  test("orphaned empty result stays empty when the option is absent", () => {
+    const messages = wire(providerWithoutFlag, [
+      { role: "toolResult", toolCallId: "call_orphan", toolName: "exec_command", content: "", isError: false, timestamp: 0 },
+    ]);
+    const tool = messages.find(m => m.role === "tool");
+    expect(tool?.content).toBe("");
+  });
 });
+
 
 describe("openai-responses empty tool output annotation", () => {
   const originalFetch = globalThis.fetch;

--- a/tests/empty-tool-output-annotation.test.ts
+++ b/tests/empty-tool-output-annotation.test.ts
@@ -97,7 +97,6 @@ describe("openai-chat empty tool output annotation", () => {
     const tool = messages.find(m => m.role === "tool");
     expect(tool?.content).not.toBe(ANNOTATION);
   });
- 
   test("non-empty result stays byte-identical when enabled", () => {
     const messages = wire(providerWithFlag, toolCallTurn("real output"));
     const tool = messages.find(m => m.role === "tool");
@@ -205,6 +204,31 @@ describe("openai-responses empty tool output annotation", () => {
     ]);
     const input = body.input as Array<Record<string, unknown>>;
     expect(input[0].output).toBe(ANNOTATION);
+  });
+
+  test("whitespace-only input_text part array is annotated when enabled", async () => {
+    const { body } = await drive(responsesConfig(true), [
+      { type: "function_call_output", call_id: "call_5b", output: [{ type: "input_text", text: "   \n" }] },
+    ]);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input[0].output).toBe(ANNOTATION);
+  });
+
+  test("whitespace-only output_text part array is annotated when enabled", async () => {
+    const { body } = await drive(responsesConfig(true), [
+      { type: "custom_tool_call_output", call_id: "call_5c", output: [{ type: "output_text", text: "\t" }] },
+    ]);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input[0].output).toBe(ANNOTATION);
+  });
+
+  test("non-empty input_text part array is never replaced when enabled", async () => {
+    const output = [{ type: "input_text", text: "real tool text" }];
+    const { body } = await drive(responsesConfig(true), [
+      { type: "function_call_output", call_id: "call_5d", output },
+    ]);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input[0].output).toEqual(output);
   });
 
   test("image-only output is never replaced when enabled", async () => {

--- a/tests/empty-tool-output-annotation.test.ts
+++ b/tests/empty-tool-output-annotation.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
 import { providerConfigSeed } from "../src/providers/derive";
 import { getProviderRegistryEntry } from "../src/providers/registry";
+import { routedProviderConfig } from "../src/router";
 import { handleResponses } from "../src/server/responses/core";
 import type { OcxConfig, OcxMessage, OcxParsedRequest, OcxProviderConfig } from "../src/types";
 
@@ -17,6 +18,24 @@ describe("annotateEmptyToolOutputs (DeepSeek default ON)", () => {
   test("non-deepseek registry seed leaves the option unset", () => {
     const seed = providerConfigSeed(getProviderRegistryEntry("cerebras")!);
     expect(seed.annotateEmptyToolOutputs).toBeUndefined();
+  });
+});
+
+describe("annotateEmptyToolOutputs runtime backfill (DeepSeek)", () => {
+  const deepseekSavedConfig: OcxProviderConfig = {
+    adapter: "openai-chat",
+    baseUrl: "https://api.deepseek.com",
+    apiKey: "sk-test",
+    authMode: "key",
+  };
+
+  test("a saved deepseek provider without the flag is backfilled true at routing", () => {
+    expect(routedProviderConfig("deepseek", deepseekSavedConfig).annotateEmptyToolOutputs).toBe(true);
+  });
+
+  test("an explicit false survives routing and is never overridden", () => {
+    const routed = routedProviderConfig("deepseek", { ...deepseekSavedConfig, annotateEmptyToolOutputs: false });
+    expect(routed.annotateEmptyToolOutputs).toBe(false);
   });
 });
 
@@ -285,5 +304,21 @@ describe("openai-responses empty tool output annotation", () => {
     ]);
     const input = body.input as Array<Record<string, unknown>>;
     expect(input[0].output).toBe(ANNOTATION);
+  });
+
+  test("null output is never replaced when enabled", async () => {
+    const { body } = await drive(responsesConfig(true), [
+      { type: "function_call_output", call_id: "call_12", output: null },
+    ]);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input[0]).toEqual({ type: "function_call_output", call_id: "call_12", output: null });
+  });
+
+  test("missing output key is never replaced when enabled", async () => {
+    const { body } = await drive(responsesConfig(true), [
+      { type: "custom_tool_call_output", call_id: "call_13" },
+    ]);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input[0]).toEqual({ type: "custom_tool_call_output", call_id: "call_13" });
   });
 });

--- a/tests/empty-tool-output-annotation.test.ts
+++ b/tests/empty-tool-output-annotation.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
+import { providerConfigSeed } from "../src/providers/derive";
+import { getProviderRegistryEntry } from "../src/providers/registry";
+import { handleResponses } from "../src/server/responses/core";
+import type { OcxConfig, OcxMessage, OcxParsedRequest, OcxProviderConfig } from "../src/types";
+
+const ANNOTATION =
+  "[ocx] empty tool output: the tool ran but produced no stdout or return value; do not treat this as success, failure, or user-provided input.";
+
+describe("annotateEmptyToolOutputs (DeepSeek default ON)", () => {
+  test("deepseek registry seed defaults the option to true", () => {
+    const seed = providerConfigSeed(getProviderRegistryEntry("deepseek")!);
+    expect(seed.annotateEmptyToolOutputs).toBe(true);
+  });
+
+  test("non-deepseek registry seed leaves the option unset", () => {
+    const seed = providerConfigSeed(getProviderRegistryEntry("cerebras")!);
+    expect(seed.annotateEmptyToolOutputs).toBeUndefined();
+  });
+});
+
+describe("openai-chat empty tool output annotation", () => {
+  function wire(provider: OcxProviderConfig, messages: OcxMessage[]): Array<Record<string, unknown>> {
+    const parsed: OcxParsedRequest = {
+      modelId: "test-model",
+      context: { messages },
+      stream: false,
+      options: {},
+    };
+    const req = createOpenAIChatAdapter(provider).buildRequest(parsed) as { body: string };
+    return (JSON.parse(req.body) as { messages: Array<Record<string, unknown>> }).messages;
+  }
+
+  function toolCallTurn(emptyResult: string | unknown[]): OcxMessage[] {
+    return [
+      { role: "user", content: "hi", timestamp: 0 },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec_command", arguments: {} }],
+        timestamp: 0,
+      },
+      { role: "toolResult", toolCallId: "call_1", toolName: "exec_command", content: emptyResult as never, isError: false, timestamp: 0 },
+    ];
+  }
+
+  const providerWithFlag: OcxProviderConfig = {
+    adapter: "openai-chat",
+    baseUrl: "https://example.test/v1",
+    apiKey: "sk-test",
+    authMode: "key",
+    annotateEmptyToolOutputs: true,
+  };
+
+  const providerWithoutFlag: OcxProviderConfig = {
+    adapter: "openai-chat",
+    baseUrl: "https://example.test/v1",
+    apiKey: "sk-test",
+    authMode: "key",
+  };
+
+  test("empty string result is annotated when enabled", () => {
+    const messages = wire(providerWithFlag, toolCallTurn(""));
+    const tool = messages.find(m => m.role === "tool");
+    expect(tool?.content).toBe(ANNOTATION);
+  });
+
+  test("whitespace-only result is annotated when enabled", () => {
+    const messages = wire(providerWithFlag, toolCallTurn("   \n  "));
+    const tool = messages.find(m => m.role === "tool");
+    expect(tool?.content).toBe(ANNOTATION);
+  });
+
+  test("empty content array is annotated when enabled", () => {
+    const messages = wire(providerWithFlag, toolCallTurn([]));
+    const tool = messages.find(m => m.role === "tool");
+    expect(tool?.content).toBe(ANNOTATION);
+  });
+
+  test("non-empty result stays byte-identical when enabled", () => {
+    const messages = wire(providerWithFlag, toolCallTurn("real output"));
+    const tool = messages.find(m => m.role === "tool");
+    expect(tool?.content).toBe("real output");
+  });
+
+  test("empty result stays empty when the option is absent (legacy behavior)", () => {
+    const messages = wire(providerWithoutFlag, toolCallTurn(""));
+    const tool = messages.find(m => m.role === "tool");
+    expect(tool?.content).toBe("");
+  });
+});
+
+describe("openai-responses empty tool output annotation", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  async function drive(config: OcxConfig, input: unknown[]): Promise<{ body: Record<string, unknown> }> {
+    const requests: Array<{ body: Record<string, unknown> }> = [];
+    globalThis.fetch = (async (inputUrl: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({ body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
+      return Response.json({ id: "resp_test", object: "response", status: "completed", output: [] });
+    }) as typeof fetch;
+    await handleResponses(
+      new Request("http://localhost/v1/responses", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "test/model", input, stream: true }),
+      }),
+      config,
+      { model: "", provider: "" },
+    );
+    return requests[0] ?? { body: {} };
+  }
+
+  function responsesConfig(annotate: boolean | undefined): OcxConfig {
+    return {
+      port: 0,
+      defaultProvider: "test",
+      providers: {
+        test: {
+          adapter: "openai-responses",
+          baseUrl: "https://example.test",
+          apiKey: "sk-test",
+          authMode: "key",
+          ...(annotate === undefined ? {} : { annotateEmptyToolOutputs: annotate }),
+        },
+      },
+    } as unknown as OcxConfig;
+  }
+
+  test("empty function_call_output is annotated when enabled", async () => {
+    const { body } = await drive(responsesConfig(true), [
+      { type: "function_call_output", call_id: "call_1", output: "" },
+    ]);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input[0]).toMatchObject({ type: "function_call_output", call_id: "call_1" });
+    expect(input[0].output).toBe(ANNOTATION);
+  });
+
+  test("empty custom_tool_call_output is annotated when enabled", async () => {
+    const { body } = await drive(responsesConfig(true), [
+      { type: "custom_tool_call_output", call_id: "call_2", output: "   " },
+    ]);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input[0].output).toBe(ANNOTATION);
+  });
+
+  test("non-empty output stays byte-identical when enabled", async () => {
+    const { body } = await drive(responsesConfig(true), [
+      { type: "function_call_output", call_id: "call_3", output: "ok" },
+    ]);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input[0].output).toBe("ok");
+  });
+
+  test("empty output stays empty when the option is absent", async () => {
+    const { body } = await drive(responsesConfig(undefined), [
+      { type: "function_call_output", call_id: "call_4", output: "" },
+    ]);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input[0].output).toBe("");
+  });
+});

--- a/tests/management-provider-validation.test.ts
+++ b/tests/management-provider-validation.test.ts
@@ -324,6 +324,21 @@ describe("provider management validation", () => {
       .toEqual(["deepseek-v4-flash", "other-model"]);
   });
 
+  test("provider management validates annotateEmptyToolOutputs as boolean", () => {
+    const provider = {
+      adapter: "openai-chat",
+      baseUrl: "https://relay.example/v1",
+      annotateEmptyToolOutputs: true,
+    };
+    expect(providerManagementConfigError("relay", provider)).toBeNull();
+    for (const annotateEmptyToolOutputs of ["yes", 42, {}, []]) {
+      expect(providerManagementConfigError("relay", {
+        ...provider,
+        annotateEmptyToolOutputs,
+      })).toContain("annotateEmptyToolOutputs");
+    }
+  });
+
   test("provider management rejects modelCosts rows with extra fields", () => {
     const error = providerManagementConfigError("blsc", {
       adapter: "openai-chat",

--- a/tests/management-provider-validation.test.ts
+++ b/tests/management-provider-validation.test.ts
@@ -369,6 +369,60 @@ describe("provider management validation", () => {
     }
   });
 
+  test("provider PATCH sets, clears, and rejects annotateEmptyToolOutputs", async () => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    saveConfig(config("127.0.0.1"));
+
+    const server = startServer(0);
+    try {
+      const create = await fetch(new URL("/api/providers", server.url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "relay",
+          provider: { adapter: "openai-chat", baseUrl: "https://relay.example/v1" },
+        }),
+      });
+      expect(create.status).toBe(200);
+
+      const reject = await fetch(new URL("/api/providers?name=relay", server.url), {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ annotateEmptyToolOutputs: "yes" }),
+      });
+      expect(reject.status).toBe(400);
+      expect(await reject.json()).toMatchObject({ error: "annotateEmptyToolOutputs must be a boolean or null" });
+
+      const enable = await fetch(new URL("/api/providers?name=relay", server.url), {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ annotateEmptyToolOutputs: true }),
+      });
+      expect(enable.status).toBe(200);
+      expect(loadConfig().providers.relay?.annotateEmptyToolOutputs).toBe(true);
+
+      const disable = await fetch(new URL("/api/providers?name=relay", server.url), {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ annotateEmptyToolOutputs: false }),
+      });
+      expect(disable.status).toBe(200);
+      expect(loadConfig().providers.relay?.annotateEmptyToolOutputs).toBe(false);
+
+      const clear = await fetch(new URL("/api/providers?name=relay", server.url), {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ annotateEmptyToolOutputs: null }),
+      });
+      expect(clear.status).toBe(200);
+      expect(loadConfig().providers.relay).not.toHaveProperty("annotateEmptyToolOutputs");
+    } finally {
+      await server.stop(true);
+    }
+  });
+
   test("provider management rejects modelCosts rows with extra fields", () => {
     const error = providerManagementConfigError("blsc", {
       adapter: "openai-chat",

--- a/tests/management-provider-validation.test.ts
+++ b/tests/management-provider-validation.test.ts
@@ -30,6 +30,7 @@ import {
 } from "../src/server";
 import { handleManagementAPI } from "../src/server/management-api";
 import { providerManagementConfigError } from "../src/server/auth-cors";
+import { providerEmptyToolOutputConfigError } from "../src/config/provider-validation";
 import { providerServiceTierConfigError, withProviderServiceTierDTO } from "../src/server/management/provider-capability-config";
 import { clearModelCache, markProviderDiscoveryFailed } from "../src/codex/model-cache";
 import type { OcxConfig } from "../src/types";
@@ -330,12 +331,41 @@ describe("provider management validation", () => {
       baseUrl: "https://relay.example/v1",
       annotateEmptyToolOutputs: true,
     };
-    expect(providerManagementConfigError("relay", provider)).toBeNull();
+    expect(providerEmptyToolOutputConfigError("relay", provider)).toBeNull();
     for (const annotateEmptyToolOutputs of ["yes", 42, {}, []]) {
-      expect(providerManagementConfigError("relay", {
+      expect(providerEmptyToolOutputConfigError("relay", {
         ...provider,
         annotateEmptyToolOutputs,
       })).toContain("annotateEmptyToolOutputs");
+    }
+  });
+
+  test("provider POST rejects a non-boolean annotateEmptyToolOutputs at the management boundary", async () => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    saveConfig(config("127.0.0.1"));
+
+    const server = startServer(0);
+    try {
+      const response = await fetch(new URL("/api/providers", server.url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "relay",
+          provider: {
+            adapter: "openai-chat",
+            baseUrl: "https://relay.example/v1",
+            annotateEmptyToolOutputs: "yes",
+          },
+        }),
+      });
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({
+        error: expect.stringContaining("annotateEmptyToolOutputs"),
+      });
+    } finally {
+      await server.stop(true);
     }
   });
 

--- a/tests/management-provider-validation.test.ts
+++ b/tests/management-provider-validation.test.ts
@@ -13,7 +13,7 @@ import {
   getCodexUpstreamHealth,
   recordCodexUpstreamOutcome,
 } from "../src/codex/routing";
-import { loadConfig, saveConfig } from "../src/config";
+import { getConfigPath, loadConfig, saveConfig } from "../src/config";
 import { deriveProviderPresets } from "../src/providers/derive";
 import { MAIN_CODEX_ACCOUNT_ID } from "../src/codex/main-account";
 import {
@@ -390,7 +390,104 @@ describe("provider management validation", () => {
         }),
       });
       expect(create.status).toBe(200);
-      expect(loadConfig().providers.relay).not.toHaveProperty("annotateEmptyToolOutputs");
+      const persisted = loadConfig();
+      expect(persisted.providers.relay).toBeDefined();
+      expect(persisted.providers.relay).not.toHaveProperty("annotateEmptyToolOutputs");
+      const onDisk = JSON.parse(readFileSync(getConfigPath(), "utf8")) as OcxConfig;
+      expect(onDisk.providers.relay).toBeDefined();
+      expect(onDisk.providers.relay).not.toHaveProperty("annotateEmptyToolOutputs");
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("provider POST null clears an existing explicit annotateEmptyToolOutputs override", async () => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    saveConfig(config("127.0.0.1"));
+
+    const server = startServer(0);
+    try {
+      const create = await fetch(new URL("/api/providers", server.url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "relay",
+          provider: {
+            adapter: "openai-chat",
+            baseUrl: "https://relay.example/v1",
+            annotateEmptyToolOutputs: true,
+          },
+        }),
+      });
+      expect(create.status).toBe(200);
+      expect(loadConfig().providers.relay?.annotateEmptyToolOutputs).toBe(true);
+
+      // null means "clear the override", not "leave it untouched".
+      const overwrite = await fetch(new URL("/api/providers", server.url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "relay",
+          provider: {
+            adapter: "openai-chat",
+            baseUrl: "https://relay.example/v1",
+            annotateEmptyToolOutputs: null,
+          },
+        }),
+      });
+      expect(overwrite.status).toBe(200);
+      const persisted = loadConfig();
+      expect(persisted.providers.relay).toBeDefined();
+      expect(persisted.providers.relay).not.toHaveProperty("annotateEmptyToolOutputs");
+      const onDisk = JSON.parse(readFileSync(getConfigPath(), "utf8")) as OcxConfig;
+      expect(onDisk.providers.relay).not.toHaveProperty("annotateEmptyToolOutputs");
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("provider POST null on DeepSeek restores the registry default after enrichment", async () => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    saveConfig(config("127.0.0.1"));
+
+    const server = startServer(0);
+    try {
+      const create = await fetch(new URL("/api/providers", server.url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "deepseek",
+          provider: {
+            adapter: "openai-chat",
+            baseUrl: "https://api.deepseek.com",
+            apiKey: "sk-test",
+            annotateEmptyToolOutputs: false,
+          },
+        }),
+      });
+      expect(create.status).toBe(200);
+      expect(loadConfig().providers.deepseek?.annotateEmptyToolOutputs).toBe(false);
+
+      // Clearing the opt-out must let registry enrichment re-enable annotation.
+      const overwrite = await fetch(new URL("/api/providers", server.url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "deepseek",
+          provider: {
+            adapter: "openai-chat",
+            baseUrl: "https://api.deepseek.com",
+            apiKey: "sk-test",
+            annotateEmptyToolOutputs: null,
+          },
+        }),
+      });
+      expect(overwrite.status).toBe(200);
+      expect(loadConfig().providers.deepseek?.annotateEmptyToolOutputs).toBe(true);
     } finally {
       await server.stop(true);
     }

--- a/tests/management-provider-validation.test.ts
+++ b/tests/management-provider-validation.test.ts
@@ -369,6 +369,33 @@ describe("provider management validation", () => {
     }
   });
 
+  test("provider POST canonicalizes annotateEmptyToolOutputs null to an omitted field", async () => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    saveConfig(config("127.0.0.1"));
+
+    const server = startServer(0);
+    try {
+      const create = await fetch(new URL("/api/providers", server.url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "relay",
+          provider: {
+            adapter: "openai-chat",
+            baseUrl: "https://relay.example/v1",
+            annotateEmptyToolOutputs: null,
+          },
+        }),
+      });
+      expect(create.status).toBe(200);
+      expect(loadConfig().providers.relay).not.toHaveProperty("annotateEmptyToolOutputs");
+    } finally {
+      await server.stop(true);
+    }
+  });
+
   test("provider PATCH sets, clears, and rejects annotateEmptyToolOutputs", async () => {
     if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
     mkdirSync(TEST_DIR, { recursive: true });

--- a/tests/management-provider-validation.test.ts
+++ b/tests/management-provider-validation.test.ts
@@ -794,6 +794,52 @@ describe("provider management validation", () => {
     }
   });
 
+  test("provider POST overwrite preserves an explicit annotateEmptyToolOutputs false when the payload omits it", async () => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    saveConfig(config("127.0.0.1"));
+
+    const server = startServer(0);
+    try {
+      const create = await fetch(new URL("/api/providers", server.url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "deepseek",
+          provider: {
+            adapter: "openai-chat",
+            baseUrl: "https://api.deepseek.com",
+            apiKey: "sk-test",
+            annotateEmptyToolOutputs: false,
+          },
+        }),
+      });
+      expect(create.status).toBe(200);
+      expect(loadConfig().providers.deepseek?.annotateEmptyToolOutputs).toBe(false);
+
+      // The dashboard add/edit form does not send this field, and registry enrichment
+      // backfills DeepSeek to true — an unrelated overwrite must not silently flip the
+      // operator's explicit opt-out back on.
+      const overwrite = await fetch(new URL("/api/providers", server.url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "deepseek",
+          provider: {
+            adapter: "openai-chat",
+            baseUrl: "https://api.deepseek.com",
+            apiKey: "sk-test",
+          },
+        }),
+      });
+      expect(overwrite.status).toBe(200);
+      expect(loadConfig().providers.deepseek?.annotateEmptyToolOutputs).toBe(false);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
   // #1409: the add/edit form's payload type has no member for contextWindow or
   // modelContextWindows, so an overwrite arrives without them. Registry enrichment then fills
   // the absent fields from the seed and the stored row loses the user's values — for

--- a/tests/proxy-env.test.ts
+++ b/tests/proxy-env.test.ts
@@ -82,6 +82,13 @@ describe("applyProxyEnv with values the schema does not constrain", () => {
     expect(process.env.HTTPS_PROXY).toBeUndefined();
   });
 
+  test("a whitespace-padded environment reference still resolves before assignment", () => {
+    process.env.OCX_TEST_PROXY_REF = "http://proxy.corp:8080";
+    applyProxyEnv(configWithRawProxy("  ${OCX_TEST_PROXY_REF}  "));
+    expect(process.env.HTTP_PROXY).toBe("http://proxy.corp:8080");
+    expect(process.env.HTTPS_PROXY).toBe("http://proxy.corp:8080");
+  });
+
   test("a non-string noProxy does not throw and keeps loopback exclusions", () => {
     expect(() => applyProxyEnv(configWithRawProxy("http://proxy.corp:8080", 42))).not.toThrow();
     expect(process.env.NO_PROXY).toBe("localhost,127.0.0.1,::1,[::1]");

--- a/tests/proxy-env.test.ts
+++ b/tests/proxy-env.test.ts
@@ -74,6 +74,14 @@ describe("applyProxyEnv with values the schema does not constrain", () => {
     expect(process.env.HTTPS_PROXY).toBeUndefined();
   });
 
+  // The discard warning is once-per-process and an earlier test already consumes it, so
+  // assert the observable contract only: whitespace must not leak into the proxy env vars.
+  test("a whitespace-only proxy is discarded and keeps direct egress", () => {
+    applyProxyEnv(configWithRawProxy("   "));
+    expect(process.env.HTTP_PROXY).toBeUndefined();
+    expect(process.env.HTTPS_PROXY).toBeUndefined();
+  });
+
   test("a non-string noProxy does not throw and keeps loopback exclusions", () => {
     expect(() => applyProxyEnv(configWithRawProxy("http://proxy.corp:8080", 42))).not.toThrow();
     expect(process.env.NO_PROXY).toBe("localhost,127.0.0.1,::1,[::1]");

--- a/tests/responses-stateless-dangling-call-repair.test.ts
+++ b/tests/responses-stateless-dangling-call-repair.test.ts
@@ -194,6 +194,26 @@ describe("stateless Responses wire repairs orphaned tool calls", () => {
     expect(JSON.stringify(input[0])).toContain("[ocx] empty tool output");
   });
 
+  test("never claims a tool ran when an orphan output is null (regression)", async () => {
+    const { body } = await drive([
+      { type: "function_call_output", call_id: "call_unknown", output: null },
+    ]);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input[0]).toMatchObject({ type: "message", role: "user" });
+    expect(JSON.stringify(input[0])).not.toContain("[ocx] empty tool output");
+    expect(JSON.stringify(input[0])).not.toContain("no tool result was recorded");
+  });
+
+  test("leaves a paired null output untouched when annotation is enabled (regression)", async () => {
+    const { body } = await drive([
+      { type: "function_call", id: "fc_1", call_id: "call_null", name: "exec_command", arguments: "{}" },
+      { type: "function_call_output", call_id: "call_null", output: null },
+    ]);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input[1]).toMatchObject({ type: "function_call_output", call_id: "call_null", output: null });
+    expect(JSON.stringify(body)).not.toContain("[ocx] empty tool output");
+  });
+
   test("preserves synthetic missing-result placeholders when annotation is enabled (regression)", async () => {
     const { body } = await drive([
       { type: "function_call", id: "fc_dangling", call_id: "call_dangling", name: "exec_command", arguments: "{}" },

--- a/tests/responses-stateless-dangling-call-repair.test.ts
+++ b/tests/responses-stateless-dangling-call-repair.test.ts
@@ -184,4 +184,23 @@ describe("stateless Responses wire repairs orphaned tool calls", () => {
     expect(input[0]).toMatchObject({ type: "message", role: "user" });
     expect(JSON.stringify(input[0])).toContain("orphan result");
   });
+
+  test("annotates an empty orphan output before repairing it into a user message (regression)", async () => {
+    const { body } = await drive([
+      { type: "function_call_output", call_id: "call_unknown", output: "" },
+    ]);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input[0]).toMatchObject({ type: "message", role: "user" });
+    expect(JSON.stringify(input[0])).toContain("[ocx] empty tool output");
+  });
+
+  test("preserves synthetic missing-result placeholders when annotation is enabled (regression)", async () => {
+    const { body } = await drive([
+      { type: "function_call", id: "fc_dangling", call_id: "call_dangling", name: "exec_command", arguments: "{}" },
+    ]);
+    const input = body.input as Array<Record<string, unknown>>;
+    expect(input[1]).toMatchObject({ type: "function_call_output", call_id: "call_dangling" });
+    expect(String((input[1] as { output: unknown }).output)).toContain("no tool result was recorded");
+    expect(JSON.stringify(input[1])).not.toContain("[ocx] empty tool output");
+  });
 });


### PR DESCRIPTION
## Summary

- Empty tool results (a script ran without calling `text(...)`) were forwarded as an empty string, so routed models silently accepted them or re-issued the same call.
- Adds an opt-in provider option `annotateEmptyToolOutputs` that rewrites present-but-empty tool outputs to an explicit `[ocx] empty tool output ...` annotation on the OpenAI-compatible Chat and Responses wires; non-empty outputs and missing-result placeholders stay byte-identical.
- Seeds the option `true` for the DeepSeek registry entry and backfills existing DeepSeek configs; every other provider keeps legacy behavior unless the option is set explicitly.
- Management boundary: POST/PATCH validate the boolean, PATCH can set or clear it with `null`, and provider-name errors are redacted.

**Upgrade note:** existing DeepSeek configs start annotating empty tool outputs on the next upgrade; set `annotateEmptyToolOutputs: false` in the provider row to keep the legacy empty-string behavior.

## Test plan

- `bun test tests/empty-tool-output-annotation.test.ts tests/management-provider-validation.test.ts tests/responses-stateless-dangling-call-repair.test.ts` — 122 pass / 0 fail
- `bun run typecheck` — clean; `git diff --check` — clean

## Verification

- Rebased on latest `upstream/dev` (`223a0a287`) before push; head `182d881db`

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
