### PR TITLE
[WRONG BRANCH] Add `__omit__` reasoning-effort wire sentinel for per-effort field omission (closes #2356)

### DIFF
--- a/src/reasoning-effort.ts
+++ b/src/reasoning-effort.ts
@@ -157,6 +157,16 @@ export function reasoningEffortMapFor(provider: OcxProviderConfig, modelId: stri
 }
 
 /**
+ * Sentinel wire value for `reasoningEffortMap` / `modelReasoningEffortMap`: mapping a Codex
+ * effort label to `"__omit__"` drops the reasoning field from the upstream request entirely,
+ * letting the upstream model's own default apply. Needed when every expressible wire value
+ * for a tier is rejected upstream — e.g. ollama >=0.32 normalizes xhigh/ultra/max to "max"
+ * before rendering a GGUF chat template, and templates like Qwen3.8's accept only
+ * xhigh/medium/low, with the xhigh default reachable only by omitting `reasoning_effort`.
+ */
+export const REASONING_EFFORT_OMIT = "__omit__";
+
+/**
  * Translate Codex's reasoning label into the provider's real wire value. Prefer identity labels
  * (`xhigh` stays `xhigh`, `max` stays `max`); provider maps are only for real upstream aliases.
  */
@@ -170,7 +180,10 @@ export function mapReasoningEffort(provider: OcxProviderConfig, modelId: string,
   const boundary = requested === "ultra" ? "max" : requested;
 
   const wireMap = reasoningEffortMapFor(provider, modelId);
-  if (wireMap && Object.prototype.hasOwnProperty.call(wireMap, boundary)) return wireMap[boundary];
+  if (wireMap && Object.prototype.hasOwnProperty.call(wireMap, boundary)) {
+    const mapped = wireMap[boundary];
+    return mapped === REASONING_EFFORT_OMIT ? undefined : mapped;
+  }
 
   const supported = configuredReasoningEfforts(provider, modelId);
   const codexEffort = supported !== undefined ? clampToSupportedCodexEffort(boundary, supported) : requestToCodexEffort(boundary);
@@ -178,6 +191,9 @@ export function mapReasoningEffort(provider: OcxProviderConfig, modelId: string,
 
   // Belt for the odd config where the supported ladder is ultra-only and the clamp lands on it.
   const wire = codexEffort === "ultra" ? "max" : codexEffort;
-  if (wireMap && Object.prototype.hasOwnProperty.call(wireMap, wire)) return wireMap[wire];
+  if (wireMap && Object.prototype.hasOwnProperty.call(wireMap, wire)) {
+    const mapped = wireMap[wire];
+    return mapped === REASONING_EFFORT_OMIT ? undefined : mapped;
+  }
   return wire;
 }

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -364,9 +364,17 @@ export interface OcxProviderConfig {
    * SSE/JSON; raw inspection state remains authoritative.
    */
   responsesSnapshotRepair?: boolean;
-  /** Provider-wide mapping from Codex effort labels to upstream `reasoning_effort` values. */
+  /**
+   * Provider-wide mapping from Codex effort labels to upstream `reasoning_effort` values.
+   * Map a label to `REASONING_EFFORT_OMIT` ("__omit__") to omit the reasoning field for that
+   * effort so the upstream model's own default applies.
+   */
   reasoningEffortMap?: Record<string, string>;
-  /** Model-specific mapping from Codex effort labels to upstream `reasoning_effort` values. */
+  /**
+   * Model-specific mapping from Codex effort labels to upstream `reasoning_effort` values.
+   * Map a label to `REASONING_EFFORT_OMIT` ("__omit__") to omit the reasoning field for that
+   * effort so the upstream model's own default applies.
+   */
   modelReasoningEffortMap?: Record<string, Record<string, string>>;
   /** OpenAI-compatible gateway reasoning wire shape. Default sends `reasoning_effort`. */
   reasoningWireFormat?: "gateway-object";

--- a/tests/reasoning-effort.test.ts
+++ b/tests/reasoning-effort.test.ts
@@ -3,7 +3,7 @@ import { buildCatalogEntries } from "../src/codex/catalog";
 import { createAnthropicAdapter } from "../src/adapters/anthropic";
 import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
 import type { AdapterRequest } from "../src/adapters/base";
-import { configuredReasoningEfforts, mapReasoningEffort, sanitizeCodexReasoningEfforts } from "../src/reasoning-effort";
+import { configuredReasoningEfforts, mapReasoningEffort, REASONING_EFFORT_OMIT, sanitizeCodexReasoningEfforts } from "../src/reasoning-effort";
 import { routeModel } from "../src/router";
 import { resolveWireProtocolOverride } from "../src/server/adapter-resolve";
 import type { OcxConfig, OcxParsedRequest, OcxProviderConfig } from "../src/types";
@@ -972,5 +972,57 @@ describe("stale reasoning-ladder self-heal", () => {
       modelReasoningEffortMap: { model: { low: "low", high: "high" } },
     };
     expect(configuredReasoningEfforts(prov, "model")).toEqual([]);
+  });
+});
+
+describe("reasoning effort omission sentinel (__omit__)", () => {
+  // ollama >=0.32 normalizes xhigh/ultra/max to "max" before rendering a GGUF chat template,
+  // and templates like Qwen3.8's accept only xhigh/medium/low — with the xhigh default
+  // reachable only by omitting reasoning_effort. The sentinel makes that expressible.
+  const ollamaLike: OcxProviderConfig = {
+    adapter: "openai-chat",
+    baseUrl: "http://localhost:11434/v1",
+    modelReasoningEfforts: { "qwen-local": ["low", "medium", "high", "xhigh", "max"] },
+    modelReasoningEffortMap: {
+      "qwen-local": {
+        low: "low",
+        medium: "medium",
+        high: REASONING_EFFORT_OMIT,
+        xhigh: REASONING_EFFORT_OMIT,
+        max: REASONING_EFFORT_OMIT,
+      },
+    },
+  };
+
+  test("mapped __omit__ drops the wire value so the upstream default applies", () => {
+    expect(mapReasoningEffort(ollamaLike, "qwen-local", "high")).toBeUndefined();
+    expect(mapReasoningEffort(ollamaLike, "qwen-local", "xhigh")).toBeUndefined();
+    expect(mapReasoningEffort(ollamaLike, "qwen-local", "max")).toBeUndefined();
+  });
+
+  test("ultra collapses to the max boundary before the sentinel lookup", () => {
+    expect(mapReasoningEffort(ollamaLike, "qwen-local", "ultra")).toBeUndefined();
+  });
+
+  test("non-sentinel entries in the same map still pass through", () => {
+    expect(mapReasoningEffort(ollamaLike, "qwen-local", "low")).toBe("low");
+    expect(mapReasoningEffort(ollamaLike, "qwen-local", "medium")).toBe("medium");
+  });
+
+  test("provider-wide reasoningEffortMap sentinels apply to every model", () => {
+    const prov: OcxProviderConfig = { adapter: "openai-chat", reasoningEffortMap: { max: REASONING_EFFORT_OMIT } };
+    expect(mapReasoningEffort(prov, "anything", "max")).toBeUndefined();
+    expect(mapReasoningEffort(prov, "anything", "medium")).toBe("medium");
+  });
+
+  test("the openai-chat adapter omits reasoning_effort entirely for omitted efforts", () => {
+    const body = buildBody(ollamaLike, "qwen-local", { reasoning: "max" });
+    expect(body).not.toHaveProperty("reasoning_effort");
+    expect(body).not.toHaveProperty("reasoning");
+    expect(buildBody(ollamaLike, "qwen-local", { reasoning: "low" }).reasoning_effort).toBe("low");
+  });
+
+  test("__omit__ wire values never leak into the configured ladder", () => {
+    expect(configuredReasoningEfforts(ollamaLike, "qwen-local")).toEqual(["low", "medium", "high", "xhigh", "max"]);
   });
 });


### PR DESCRIPTION
Implements the per-effort omission requested in #2356.

## Problem

With the stock ollama provider (`adapter: openai-chat`, `baseUrl: http://localhost:11434/v1`), Codex requests carrying efforts ≥ `high` (global `model_reasoning_effort = "ultra"` → wire `max`) fail with HTTP 500 and Codex retries forever:

```
Jinja Exception: Unexpected reasoning effort max. Supported types are xhigh (default), medium, and low.
```

ollama ≥0.32 normalizes effort values **before** rendering a GGUF chat template (verified on 0.32.15):

| wire value sent to ollama | value the template sees | result |
|---|---|---|
| *(omitted)* | default `xhigh` | ✅ deep mode |
| `minimal` | `low` | ✅ |
| `low` / `medium` | unchanged | ✅ |
| `high` | `high` | ❌ 500 |
| `xhigh` / `ultra` / `max` | `max` | ❌ 500 |
| `none` | thinking disabled | ✅ |

For templates like Qwen3.8's (accepts only `xhigh`/`medium`/`low`, with `xhigh` applied via `reasoning_effort|default('xhigh')`), the deep mode is therefore reachable **only by omitting the field** — and no existing config can express per-effort omission (`modelReasoningEffortMap` only rewrites values; `noReasoningModels` is all-or-nothing; `clampToSupportedCodexEffort` cannot help because the failure is on the wire).

## Change

- `src/reasoning-effort.ts`: new exported `REASONING_EFFORT_OMIT = "__omit__"`. `mapReasoningEffort` returns `undefined` when a wire-map entry resolves to the sentinel, at both lookup sites (direct boundary lookup and post-clamp lookup). All adapters already treat `undefined` as "send no reasoning field", so openai-chat and google both benefit.
- `src/types/provider.ts`: doc comments on `reasoningEffortMap` / `modelReasoningEffortMap` document the sentinel.
- `tests/reasoning-effort.test.ts`: 6 new tests — sentinel drops high/xhigh/max, `ultra` collapses to the `max` boundary first, non-sentinel entries pass through, provider-wide maps work, the openai-chat body omits `reasoning_effort`/`reasoning` entirely, and sentinels never leak into the configured ladder (`healMappedTiers` already filters non-Codex wire values).

Fully backward compatible: behavior changes only for map values literally equal to `"__omit__"`.

## Example config (the #2356 scenario)

```json
"ollama": {
  "adapter": "openai-chat",
  "baseUrl": "http://localhost:11434/v1",
  "modelReasoningEfforts": { "qwen3.8-uncensored:27b-q4": ["low", "medium", "high", "xhigh", "max"] },
  "modelReasoningEffortMap": {
    "qwen3.8-uncensored:27b-q4": {
      "low": "low", "medium": "medium",
      "high": "__omit__", "xhigh": "__omit__", "max": "__omit__"
    }
  }
}
```

→ Codex `low`/`medium` stay fast; `high`/`xhigh`/`max`/`ultra` omit the field and the template falls back to its `xhigh` deep-thinking default.

## Validation

- `bun test tests/reasoning-effort.test.ts`: **51/51 pass** (45 pre-existing + 6 new), `tsc --noEmit` clean.
- Live end-to-end through the proxy against ollama 0.32.15 + Qwen3.8-27B GGUF: `max` → HTTP 200 with the model confirming the template's `xhigh` instruction; `low` → HTTP 200 with the `low` instruction (previously: guaranteed 500 for anything ≥ `high`).

Note: `src/types/provider.ts` was rebased over current main (picks up `supportsResponsesCustomTools` untouched).

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for omitting upstream reasoning settings through configurable reasoning-effort mappings.
  * Added handling for advanced effort levels that exceed a provider’s supported range.

* **Documentation**
  * Expanded guidance on provider-wide and model-specific reasoning-effort mappings, including omission behavior.

* **Bug Fixes**
  * Ensured omitted reasoning values are excluded from transmitted requests and configured effort options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->