### PR TITLE
[WRONG BRANCH] chore(fork): Windows-first 維護骨架

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # 不幫上游 bun.lock / package.json 開 npm Dependabot：上游幾乎每天發版，
+  # lockfile PR 會跟 merge 持續打架。本線只看 workflow 釘住的 actions。
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Asia/Taipei"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/cleanup-orphaned-workflows.yml
+++ b/.github/workflows/cleanup-orphaned-workflows.yml
@@ -25,6 +25,7 @@ concurrency:
 
 jobs:
   cleanup:
+    if: github.repository == 'lidge-jun/opencodex'
     name: Delete orphaned workflow runs
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: CodeQL
+
+# The proxy handles provider tokens, ChatGPT account-pool credentials, and
+# request bodies. Fork overlay tools also parse Markdown and shell out to git.
+# Weekly CodeQL asks the questions unit tests do not: injection, secret leak,
+# and unsafe workflow interpolation.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "41 4 * * 6"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: JavaScript security scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: javascript-typescript
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'lidge-jun/opencodex'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -33,6 +34,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.repository == 'lidge-jun/opencodex'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment:

--- a/.github/workflows/enforce-issue-quality.yml
+++ b/.github/workflows/enforce-issue-quality.yml
@@ -34,10 +34,11 @@ jobs:
   translate:
     name: Translate non-English issues
     if: >
-      github.event_name == 'issues' ||
+      github.repository == 'lidge-jun/opencodex' &&
+      (github.event_name == 'issues' ||
       (github.event_name == 'workflow_dispatch' &&
        inputs.backfill_open_areas != true &&
-       inputs.issue_number != '')
+       inputs.issue_number != ''))
     runs-on: ubuntu-latest
     # Serialize per-issue control-state RMW; workflow concurrency still cancels
     # superseded runs, but this queue avoids interleaved comment upserts.
@@ -442,7 +443,7 @@ jobs:
 
   translate-comment:
     name: Translate non-English issue comments
-    if: github.event_name == 'issue_comment' && github.event.issue.pull_request == null && github.event.comment.user.type != 'Bot'
+    if: github.repository == 'lidge-jun/opencodex' && github.event_name == 'issue_comment' && github.event.issue.pull_request == null && github.event.comment.user.type != 'Bot'
     runs-on: ubuntu-latest
     concurrency:
       # Shares the per-issue queue with the `translate` job: both jobs RMW the
@@ -750,6 +751,7 @@ jobs:
     # quality closure must not depend on translation success.
     needs: translate
     if: >
+      github.repository == 'lidge-jun/opencodex' &&
       always() &&
       needs.translate.result != 'cancelled' &&
       (github.event_name == 'issues' ||
@@ -1187,7 +1189,7 @@ jobs:
 
   backfill-open-areas:
     name: Backfill open issue area labels
-    if: github.event_name == 'workflow_dispatch' && inputs.backfill_open_areas == true
+    if: github.repository == 'lidge-jun/opencodex' && github.event_name == 'workflow_dispatch' && inputs.backfill_open_areas == true
     runs-on: ubuntu-latest
     permissions:
       # Read-only checkout of trusted scripts from the default branch.

--- a/.github/workflows/enforce-pr-target.yml
+++ b/.github/workflows/enforce-pr-target.yml
@@ -31,7 +31,8 @@ jobs:
     # before the write-capable job starts. The PR number is the stable identity
     # used by both gate writers even when a contributor pushes a new head SHA.
     if: >-
-      (github.event_name == 'status' &&
+      github.repository == 'lidge-jun/opencodex' &&
+      ((github.event_name == 'status' &&
        github.event.context == 'CodeRabbit' &&
        github.event.state == 'success' &&
        github.event.sender.login == 'coderabbitai[bot]' &&
@@ -44,7 +45,7 @@ jobs:
         github.event.label.name == 'test-exception-approved' ||
         github.event.label.name == 'suppression-approved' ||
         github.event.label.name == 'generated-change-approved' ||
-        github.event.label.name == 'dependency-change-approved'))
+        github.event.label.name == 'dependency-change-approved')))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -138,7 +139,7 @@ jobs:
 
   enforce-target:
     needs: resolve-pr
-    if: needs.resolve-pr.outputs.pull-number != ''
+    if: github.repository == 'lidge-jun/opencodex' && needs.resolve-pr.outputs.pull-number != ''
     runs-on: ubuntu-latest
     # Job-scoped permissions replace, rather than extend, the workflow default.
     permissions:

--- a/.github/workflows/fork-maintenance.yml
+++ b/.github/workflows/fork-maintenance.yml
@@ -1,0 +1,61 @@
+name: Fork maintenance
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - FORK.md
+      - NOTICE.md
+      - CLAUDE.md
+      - SKILL.md
+      - REVIEW.md
+      - AGENTS.md
+      - docs/fork/**
+      - tools/**
+      - tests/fork-hygiene.test.ts
+      - .github/workflows/fork-maintenance.yml
+      - .github/workflows/upstream-check.yml
+      - .github/workflows/codeql.yml
+      - .github/workflows/*.yml
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fork-maintenance-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: fork gate (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup project Bun
+        uses: ./.github/actions/setup-project-bun
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Canonical fork gate
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: pwsh -NoProfile -File tools/dev_check.ps1
+
+      - name: Canonical fork gate
+        if: runner.os != 'Windows'
+        run: |
+          bun test tests/fork-hygiene.test.ts
+          bun tools/check-links.ts

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   find-duplicates:
+    if: github.repository == 'lidge-jun/opencodex'
     name: Find similar issues
     runs-on: ubuntu-latest
     permissions:
@@ -161,7 +162,7 @@ jobs:
   post-duplicates:
     name: Post duplicate result
     needs: find-duplicates
-    if: needs.find-duplicates.outputs.matches
+    if: github.repository == 'lidge-jun/opencodex' && needs.find-duplicates.outputs.matches
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   hygiene:
+    if: github.repository == 'lidge-jun/opencodex'
     runs-on: ubuntu-latest
     # contents: read for the trusted script checkout; issues/pull-requests write
     # maintain the blocked label and one bot comment.

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -29,6 +29,7 @@ permissions:
 
 jobs:
   label:
+    if: github.repository == 'lidge-jun/opencodex'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout labeler script (default-branch trusted code)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ concurrency:
 
 jobs:
   validate-dispatch:
+    if: github.repository == 'lidge-jun/opencodex'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -71,6 +72,7 @@ jobs:
           NODE
   publish:
     needs: validate-dispatch
+    if: github.repository == 'lidge-jun/opencodex'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/service-lifecycle.yml
+++ b/.github/workflows/service-lifecycle.yml
@@ -35,6 +35,7 @@ concurrency:
 
 jobs:
   linux-systemd:
+    if: github.repository == 'lidge-jun/opencodex'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -155,6 +156,7 @@ jobs:
           fi
 
   macos-launchd:
+    if: github.repository == 'lidge-jun/opencodex'
     runs-on: macos-latest
     timeout-minutes: 10
     steps:
@@ -233,6 +235,7 @@ jobs:
           fi
 
   windows-schtasks:
+    if: github.repository == 'lidge-jun/opencodex'
     runs-on: windows-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/stale-needs-info.yml
+++ b/.github/workflows/stale-needs-info.yml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   stale:
+    if: github.repository == 'lidge-jun/opencodex'
     name: Stale needs-info issues
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/upstream-check.yml
+++ b/.github/workflows/upstream-check.yml
@@ -1,0 +1,49 @@
+name: Upstream check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - tools/check-upstream-updates.ts
+      - tools/upstream_baseline.json
+      - .github/workflows/upstream-check.yml
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: upstream-check
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out full history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup project Bun
+        uses: ./.github/actions/setup-project-bun
+
+      - name: Check upstream
+        id: upstream
+        continue-on-error: true
+        run: bun tools/check-upstream-updates.ts --strict
+
+      - name: Publish report
+        if: always()
+        run: cat upstream-review-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Require review when upstream changed
+        if: steps.upstream.outcome == 'failure'
+        run: |
+          echo "::error::Upstream changed or the check failed. Review the workflow summary."
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ tests/.tmp-*
 # `git add` three separate times and reached `dev` once — see
 # tests/repo-hygiene.test.ts, which fails if any path here becomes tracked again.
 go/
+
+# SanHsien fork generated reports
+upstream-review-report.md

--- a/.npmignore
+++ b/.npmignore
@@ -3,7 +3,14 @@
 # are explicit guards so dev-only content never leaks into the published tarball.
 devlog/
 docs-site/
+docs/fork/
 .github/
+tools/
+FORK.md
+NOTICE.md
+CLAUDE.md
+SKILL.md
+REVIEW.md
 .codex/
 
 # GUI: ship only the built gui/dist (via "files"); never the source/deps/config.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,10 @@
 # AGENTS.md
 
+> **SanHsien 維護型 fork overlay。** `origin` 是 [`SanHsien/opencodex`](https://github.com/SanHsien/opencodex)，`upstream` 是 [`lidge-jun/opencodex`](https://github.com/lidge-jun/opencodex)。
+> 本 fork 的維護規則以 [`FORK.md`](FORK.md) 為準；與下文衝突時以 FORK.md 優先。
+> 不要推 `upstream`、不要在本 fork 發 npm、不要部署 `docs-site` 到 GitHub Pages。
+> 產品行為（proxy、帳號池、provider、測試）仍遵守下文上游規則。
+
 Guidance for AI agents (and humans) working on or reviewing this repository.
 
 ## What this project is
@@ -24,6 +29,7 @@ Bun-native TypeScript with no separate server compile step.
   release authority.
 - `devlog/` — planning and investigation notes, tracked in this repository. See
   "The `devlog` directory" below for what may and may not go there.
+- `FORK.md` / `docs/fork/` — SanHsien maintenance overlay (not upstream product docs).
 
 Read the nearest nested `AGENTS.md` before changing files in a scoped
 directory (`src/`, `gui/`, `docs-site/`, `scripts/`, `.github/`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# CLAUDE.md
+
+請先完整閱讀並遵守 [`FORK.md`](FORK.md)。產品規則見上游內容為主的 [`AGENTS.md`](AGENTS.md)；衝突時以 FORK.md 為準。本檔只補充 Claude Code 的最小入口：
+
+- 這是保留上游歷史的 fork；不要移除 `upstream`、原作者或 MIT 授權標示。
+- `README.md` 是上游產品說明，不要改寫成本 fork 的維護索引，也不要翻譯成繁中。
+- 不要在本 fork 跑 npm publish、不要部署 GitHub Pages、不要把 fork-only 檔案送進上游。
+- 修改驗證腳本前，先跑對應測試；提交前跑 `pwsh -NoProfile -File tools\dev_check.ps1`。
+- API key、ChatGPT / Codex token、cookie 與帳號資料一律不可提交。
+- 帳號池只做路由與韌性，不把它做成規避 provider 條款的工具。
+- 使用繁體中文，直接交付可驗證結果，避免冗長背景鋪陳。

--- a/FORK.md
+++ b/FORK.md
@@ -1,0 +1,63 @@
+# Fork 維護說明
+
+本 repo fork 自 [`lidge-jun/opencodex`](https://github.com/lidge-jun/opencodex)，
+沿用 MIT License 與完整 Git 歷史。這是**可管理多個 ChatGPT / Codex 帳號**的那一個 OpenCodex：本機 proxy + dashboard 的 account pool，不是遠端桌面中介，也不是 OpenCode 的改名 fork。
+
+## 為什麼維護 fork
+
+- 在 Windows 11 本機跑 `ocx`：把 Claude、Gemini、Grok、DeepSeek、Ollama 等接到 Codex / Claude Code。
+- 使用並審查 **ChatGPT account pool**（多帳號、配額、thread affinity）。
+- 上游仍在快速發版；本線要能逐筆審查 `upstream/main`，而不是盲目跟。
+- 不當成第二個官方產品站，也不在本 fork 發 `@bitkyc08/opencodex`。
+
+**回貢判準：修的是上游 proxy / 帳號池 / 測試的 bug 就送回 `lidge-jun/opencodex`；這裡獨創的文件／Windows 維護骨架留在這裡。**
+
+## 與上游的差異
+
+| 項目 | 說明 |
+|---|---|
+| `README.md` | **不翻譯、不改寫。** 產品說明與帳號池條款以上游英文為準 |
+| `AGENTS.md` 開頭 overlay | 指向本檔；下文仍是上游產品規則 |
+| `FORK.md` / `NOTICE.md` / `CLAUDE.md` / `SKILL.md` / `REVIEW.md` | 本 fork 的維護入口 |
+| `docs/fork/` | Windows 開發、上游審查、決策 |
+| `tools/dev_check.ps1` | Windows 本機一鍵 fork gate |
+| `.github/workflows/fork-maintenance.yml` | fork 文件與連結檢查 |
+| `.github/workflows/upstream-check.yml` | 每週對 `upstream/main` 做未審查 commit 檢查 |
+| 上游 `release.yml` / `deploy-docs.yml` / issue·PR 治理 workflow | 加上只在官方 `lidge-jun/opencodex` 執行的 guard |
+| 上游 `ci.yml` | **保留並在本 fork 跑**，這是產品回歸 |
+
+上游 `CONTRIBUTING.md`、`MAINTAINERS.md`、`SECURITY.md`、`docs-site/`、`src/` 以上游為準，除非有已記錄的 fork 修正。
+
+## 分支與 remote
+
+- `origin/main`：SanHsien 維護主線（fork 當下對齊上游 release `main`）。
+- `upstream/main`：上游發版線；`upstream/dev` 是上游 PR 整合線，需要時再 fetch。
+- 本 fork 的一般修改從 `main` 建短期 branch，開 PR、讀完整 diff，等 CI 通過後再 squash merge 回 `main`。
+- 不要把 fork-only 的維護差異送到 upstream。上游的 `dev` 整合政策只適用於回貢，不適用本 fork 的日常 PR。
+
+不要 `git push upstream`。同步方式見 [`docs/fork/UPSTREAM.md`](docs/fork/UPSTREAM.md)。
+
+## 換一台電腦怎麼開發
+
+```powershell
+git clone https://github.com/SanHsien/opencodex.git
+cd opencodex
+bun install --frozen-lockfile
+pwsh -NoProfile -File tools\dev_check.ps1
+```
+
+完整產品回歸（較久）：
+
+```powershell
+bun run typecheck
+bun run test
+```
+
+只想當使用者跑 proxy、不開發時：
+
+```powershell
+npm install -g @bitkyc08/opencodex
+ocx start
+```
+
+然後打開 http://localhost:10100 設定 provider 與 ChatGPT 帳號池。

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,41 @@
+# NOTICE
+
+opencodex (SanHsien maintenance fork)
+Copyright 2026 SanHsien
+
+This project is derived from [`lidge-jun/opencodex`](https://github.com/lidge-jun/opencodex), originally licensed under the MIT License.
+
+Original work:
+
+- Project: `opencodex` (`@bitkyc08/opencodex`, CLI `ocx`)
+- Author / organization: `lidge-jun` and opencodex contributors
+- License: MIT
+- Original copyright notice: `Copyright (c) 2026 opencodex contributors`
+
+This repository keeps the original MIT license text in [`LICENSE`](LICENSE). Modifications, documentation, and future project-specific changes in this fork are maintained by SanHsien unless otherwise noted.
+
+## License Notes
+
+The MIT License allows use, copying, modification, merging, publication, distribution, sublicensing, and commercial use, provided that the original copyright notice and permission notice are included in all copies or substantial portions of the software.
+
+When redistributing this project or substantial parts of it:
+
+- Keep [`LICENSE`](LICENSE) with the original MIT text.
+- Keep attribution to `lidge-jun/opencodex`.
+- Add separate attribution for new third-party libraries when their licenses require it.
+
+## Project Scope
+
+This fork ships a local Bun-native provider proxy for OpenAI Codex, Claude Code, Claude Desktop, and Grok Build. It can route requests across many LLM providers and can manage a ChatGPT / Codex **account pool** for Codex auth (quota-aware selection, thread affinity, failover).
+
+It does not replace OpenAI, Anthropic, Google, xAI, or any other provider. Listing or proxying a provider is not an endorsement and does not grant a license to that service.
+
+Account pooling is for routing and operational resilience only. This project does not endorse using additional accounts to circumvent provider limits or sharing account credentials between people. Operators must follow each provider's current terms.
+
+## Credits
+
+`opencodex` belongs to the upstream project. The proxy runtime, GUI, docs-site, tests, and release tooling in this tree come from `lidge-jun/opencodex` unless a file in `docs/fork/` or the SanHsien overlay documents otherwise.
+
+This project is not affiliated with, endorsed by, or sponsored by OpenAI, Anthropic, Google, xAI, or any named provider.
+
+Do not commit secrets, API keys, cookies, ChatGPT / Codex tokens, OAuth credentials, or account data.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,56 @@
+# Repository review（Windows-first）
+
+- Review date: 2026-08-22
+- Review baseline: 上游 `main` `6ae83b1f189c353935d4977bb01227484fbdb52b`（`release: v2.31.0`）
+- Primary environment: Windows 11、PowerShell、Bun 1.3.14（本機）、產品宣告 Bun 1.4.0
+- Status: fork 維護骨架已建立；上游產品程式未改
+
+## 結論
+
+這個 fork 適合作為 Windows 本機使用與追蹤上游的維護線。產品是本機 provider proxy，含 ChatGPT / Codex **account pool**。
+
+本輪只做 fork 骨架與危險 workflow 隔離。**沒有**改 `src/`、**沒有**改帳號池行為、**沒有**回貢、**沒有**發 npm。
+
+## 已做
+
+| ID | 項目 | 說明 |
+|---|---|---|
+| F-01 | GitHub fork | `SanHsien/opencodex`，`upstream` = `lidge-jun/opencodex` |
+| F-02 | 維護文件 | `FORK.md`、`NOTICE.md`、`CLAUDE.md`、`SKILL.md`、`docs/fork/` |
+| F-03 | Windows gate | `tools/dev_check.ps1` + `tests/fork-hygiene.test.ts` |
+| F-04 | 上游追蹤 | `tools/check-upstream-updates.ts` + weekly workflow |
+| F-05 | 發佈隔離 | `release.yml` / `deploy-docs.yml` / 治理 workflow 加官方 repo guard |
+
+## 刻意不修
+
+| ID | 項目 | 理由 |
+|---|---|---|
+| U-01 | 上游 `dev` 整合線與 PR 模板 | 那是官方專案流程。本 fork 日常走 `main`。 |
+| U-02 | 翻譯 README / docs-site | 上游每週都在改；翻譯無法審查。 |
+| U-03 | 本機 Bun 1.3.14 vs 套件宣告 1.4.0 | 先用現有 Bun 驗證 fork gate；產品 CI 會裝 `package.json` 宣告的版本。 |
+
+## 本輪實證
+
+### 本機（Windows 11）
+
+```text
+bun install --frozen-lockfile
+→ 103 packages installed
+
+pwsh -NoProfile -File tools\dev_check.ps1
+→ fork-hygiene 14 pass / 0 fail
+→ check-links：11 份文件，0 斷連結
+→ WINDOWS DEV CHECK GREEN
+
+bun run typecheck
+→ bun x tsc --noEmit 成功（exit 0）
+
+bun tools/check-upstream-updates.ts
+→ No new upstream commits（仍在 6ae83b1f）
+```
+
+### 尚未宣稱範圍
+
+- **沒有**本機跑完整 `bun run test`（約數分鐘；交給 GitHub `ci.yml`）。
+- **沒有**用真實 ChatGPT 多帳號做 pool 端到端 smoke。
+- **不宣稱**本 fork 會發自己的 npm 套件。

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: opencodex
+description: 維護 SanHsien/opencodex：lidge-jun/opencodex 的 Windows-first fork。本機 Bun proxy，讓 Codex / Claude Code 使用任意 LLM，並管理 ChatGPT 多帳號 pool。
+---
+
+# opencodex
+
+完整維護規則先讀 [`FORK.md`](FORK.md)；產品行為再讀 [`AGENTS.md`](AGENTS.md)。
+
+## 何時使用
+
+使用者要維護 `SanHsien/opencodex` 時使用，例如：
+
+- 本機啟動 `ocx` / dashboard（`localhost:10100`）。
+- 審查或同步上游帳號池、provider、routing 變更。
+- 修 Windows 開發 gate、fork 文件或 workflow guard。
+- 調查 Codex / Claude Code 連到非 OpenAI 模型的行為。
+
+## 核心邊界
+
+- 這是**多帳號 ChatGPT pool** 的那一個 OpenCodex，不是遠端桌面中介，也不是 OpenCode fork。
+- 不發 `@bitkyc08/opencodex`，不部署官方 docs-site。
+- 不提交 token、cookie、OAuth、帳號池真實憑證。
+- 不把帳號池說成可以規避 provider 限額或條款。
+- 不翻譯 `README.md`。
+
+## 快速定位
+
+- `src/`：proxy runtime、routing、provider adapters、帳號池
+- `gui/`：dashboard
+- `tests/`：Bun 測試；fork 骨架在 `tests/fork-hygiene.test.ts`
+- `docs-site/`：上游公開文件（本 fork 不部署）
+- `docs/fork/`：本 fork 的開發、上游、決策
+- `tools/dev_check.ps1`：Windows 本機 fork gate
+- `NOTICE.md` / `SECURITY.md`：授權與安全回報
+
+## 驗證
+
+```powershell
+bun install --frozen-lockfile
+pwsh -NoProfile -File tools\dev_check.ps1
+```
+
+產品行為變更再追加 `bun run typecheck` 與 `bun run test`。沒有實機跑過 proxy / 帳號池時，不要宣稱端到端可用。

--- a/docs/fork/DECISIONS.md
+++ b/docs/fork/DECISIONS.md
@@ -1,0 +1,41 @@
+# 維護決策
+
+## 2026-08-22：fork 可管理多帳號的 lidge-jun/opencodex
+
+**決定**：fork [`lidge-jun/opencodex`](https://github.com/lidge-jun/opencodex)，保留 MIT 授權與完整歷史，預設分支維持 `main`。本線聚焦 Windows 開發 gate、fork CI、危險 workflow 隔離，以及逐筆審查的上游追蹤。產品 README 不翻譯。
+
+**理由**：主人要的是「可管理多帳號」的那一個。此專案在 dashboard 管理 ChatGPT / Codex account pool（配額、affinity、failover），並把任意 LLM 接到 Codex / Claude Code。GitHub 上另有遠端桌面中介與 OpenCode 改名專案，名稱相近但不是這個。fork 當下 HEAD 為 `6ae83b1f189c353935d4977bb01227484fbdb52b`（`release: v2.31.0`）。
+
+**限制**：
+
+- 不把 fork 包裝成原創專案，不移除原作者與 MIT 標示。
+- `README.md` 保持上游英文產品說明。
+- `CONTRIBUTING.md`、`MAINTAINERS.md`、`SECURITY.md`、`src/`、`gui/`、`docs-site/` 以上游為準。
+- 上游更新必須逐筆審查。
+- 本 fork 不發 npm、不部署 GitHub Pages。
+- 帳號池只做路由與韌性，不拿來規避 provider 條款。
+
+## 2026-08-22：隔離會在 fork 上造成傷害或噪音的上游 workflow
+
+**決定**：下列 workflow 加上 `github.repository == 'lidge-jun/opencodex'`，只在官方 repo 跑：
+
+- `release.yml`（npm Trusted Publishing）
+- `deploy-docs.yml`（GitHub Pages）
+- `service-lifecycle.yml`
+- issue / PR 治理：`enforce-issue-quality.yml`、`enforce-pr-target.yml`、`issue-triage.yml`、`pr-hygiene.yml`、`pr-labeler.yml`、`stale-needs-info.yml`、`cleanup-orphaned-workflows.yml`
+
+**保留在本 fork 跑**：`ci.yml`（產品回歸）、`react-doctor.yml`、`issue-quality-tests.yml`。
+
+**理由**：`release.yml` 在 fork 上若被手動觸發，有機會對 npm 做 Trusted Publishing。`enforce-pr-target` 會把 PR 逼去上游的 `dev` 線，與本 fork 的 `main` 工作流衝突。治理 bot 在個人 fork 沒有對應的 Copilot / CodeRabbit 設定，只會製造失敗與亂關 issue。
+
+## 2026-08-22：本 fork 日常走 main，不跟上游的 dev PR 政策
+
+**決定**：SanHsien 維護線以 `main` 為整合分支。回貢上游時才改對 `lidge-jun/opencodex` 的 `dev` 開 PR。
+
+**理由**：上游 `main` 是 release 線、`dev` 是 PR 整合線。fork 若同時模仿兩條線，Windows gate 與上游同步都會加倍。clone 時已用 `--default-branch-only` 對齊 `main`。
+
+## 2026-08-22：Dependabot 不啟用 npm
+
+**決定**：不幫上游的 `bun.lock` / `package.json` 開 npm Dependabot。fork-owned workflow 的 action pin 用 CodeQL / checkout SHA，之後若要自動升，只開 `github-actions`。
+
+**理由**：上游幾乎每天發版。對 lockfile 開 Dependabot 會與上游 merge 持續衝突。

--- a/docs/fork/DEVELOPMENT.md
+++ b/docs/fork/DEVELOPMENT.md
@@ -1,0 +1,65 @@
+# 開發環境
+
+維護者與 AI 接手用的開發文件。產品用法看 [`README.md`](../../README.md)；上游同步在 [`UPSTREAM.md`](UPSTREAM.md)；決策在 [`DECISIONS.md`](DECISIONS.md)。
+
+## 架構
+
+```text
+Codex / Claude Code / Claude Desktop / Grok Build
+        │
+        ▼
+ocx (Bun-native local proxy, default http://localhost:10100)
+        │
+        ├─ provider adapters（Claude / Gemini / Grok / DeepSeek / Ollama / …）
+        ├─ ChatGPT account pool（配額、affinity、failover）
+        └─ gui/dist dashboard
+```
+
+根目錄 `FORK.md`、`tools/`、`docs/fork/` 是本 fork 的開發與治理骨架。`src/`、`gui/`、`tests/`、`docs-site/` 以上游為準。
+
+## 本機開發（Windows）
+
+需要本機已安裝 [Bun](https://bun.sh)。產品套件會再帶一份 runtime，但貢獻指令用你 PATH 上的 `bun`。
+
+```powershell
+git clone https://github.com/SanHsien/opencodex.git
+cd opencodex
+bun install --frozen-lockfile
+pwsh -NoProfile -File tools\dev_check.ps1
+```
+
+啟動 dashboard / proxy：
+
+```powershell
+bun run src/cli/index.ts start
+```
+
+瀏覽器開 http://localhost:10100。帳號池與 provider 都在 GUI 設定；真實 token 只放本機 `~/.opencodex/`，不要進 Git。
+
+## Canonical fork gate
+
+`tools\dev_check.ps1` 會依序：
+
+1. `bun install --frozen-lockfile`（若 `node_modules` 不完整）
+2. `bun test tests/fork-hygiene.test.ts`
+3. `bun tools/check-links.ts`
+
+這是 fork 文件與 guard 的硬閘門，不是完整產品回歸。
+
+產品行為變更再跑：
+
+```powershell
+bun run typecheck
+bun run test
+```
+
+上游 `ci.yml` 仍會在本 fork 的 `main` 上跑 Linux / Windows / macOS。不要把那條 workflow 加上官方-repo-only guard。
+
+## 不要做的事
+
+- 不要翻譯 `README.md` 或 `docs-site/`。
+- 不要為了 fork 文件去改上游 `CONTRIBUTING.md` / `MAINTAINERS.md`。
+- 不要在本 fork 觸發 `release.yml` 真發佈，或 `deploy-docs.yml`。
+- 不要提交 API key、ChatGPT token、OAuth、帳號池真實資料。
+- 不要把帳號池描述成可以規避 OpenAI / 其他 provider 條款。
+- 測試不要打真實第三方帳號；fork 測試只鎖維護骨架。

--- a/docs/fork/UPSTREAM.md
+++ b/docs/fork/UPSTREAM.md
@@ -1,0 +1,38 @@
+# 上游維護
+
+## Remote
+
+- Fork：`origin` → `https://github.com/SanHsien/opencodex.git`
+- 原作者：`upstream` → `https://github.com/lidge-jun/opencodex.git`
+- 追蹤分支：`main`（發版線）。上游另有 `dev`（PR 整合）與 `preview`（prerelease），需要時再 `git fetch upstream dev`。
+
+## 檢查新提交
+
+```powershell
+git fetch upstream main
+bun tools/check-upstream-updates.ts --strict
+```
+
+工具以 `tools/upstream_baseline.json` 的 `reviewed_through` 為起點，列出所有未審查提交。
+有新提交或檢查失敗時，`--strict` 回傳非零；排程 workflow 也會因此明確失敗。
+
+## 審查清冊
+
+每次只做一次批次審查：
+
+1. 讀 commit 主旨與變更檔案。
+2. 判斷是否與 Windows gate、fork 文件、workflow guard 或測試衝突。
+3. 可直接同步的提交用 merge；只需要部分修正時 cherry-pick 或最小重做。
+4. 跑 `pwsh -NoProfile -File tools\dev_check.ps1`。產品檔有改再跑 `bun run typecheck` 與 `bun run test`。
+5. 在 `docs/fork/DECISIONS.md` 記錄採用／略過理由。
+6. 驗證完成後才把 baseline 推進到已審查的完整 40 字元 SHA。
+
+Baseline 代表「已審查」，不代表「全部已合併」。
+
+帳號池、provider、routing 的產品修正通常直接同步。workflow 變更必須核對官方-repo-only guard 是否仍在。
+
+## 2026-08-22：fork 起點
+
+本 fork 自上游 `main` `6ae83b1f189c353935d4977bb01227484fbdb52b`
+（`release: v2.31.0`）建立。此 SHA 設為第一個 `reviewed_through`。
+之後的上游 commit 才需要進入審查清冊。

--- a/tests/fork-hygiene.test.ts
+++ b/tests/fork-hygiene.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { checkDocument, iterDocuments } from "../tools/check-links";
+import { loadBaseline, renderMarkdown, UpstreamCheckError } from "../tools/check-upstream-updates";
+
+const ROOT = fileURLToPath(new URL("../", import.meta.url));
+const OFFICIAL_REPO_GUARD = "github.repository == 'lidge-jun/opencodex'";
+const FORK_OWNED_WORKFLOWS = new Set([
+  "fork-maintenance.yml",
+  "upstream-check.yml",
+  "codeql.yml",
+]);
+const KEEP_RUNNING_UPSTREAM_WORKFLOWS = new Set([
+  "ci.yml",
+  "react-doctor.yml",
+  "issue-quality-tests.yml",
+]);
+
+describe("fork maintainer files", () => {
+  test("required overlay files exist", () => {
+    const required = [
+      "FORK.md",
+      "NOTICE.md",
+      "CLAUDE.md",
+      "SKILL.md",
+      "REVIEW.md",
+      "SECURITY.md",
+      "AGENTS.md",
+      "README.md",
+      "LICENSE",
+      "docs/fork/UPSTREAM.md",
+      "docs/fork/DECISIONS.md",
+      "docs/fork/DEVELOPMENT.md",
+      "tools/dev_check.ps1",
+      "tools/check-upstream-updates.ts",
+      "tools/check-links.ts",
+      "tools/upstream_baseline.json",
+    ];
+    const missing = required.filter((rel) => !existsSync(join(ROOT, rel)));
+    expect(missing).toEqual([]);
+  });
+
+  test("README stays the upstream product page", async () => {
+    const agents = await Bun.file(join(ROOT, "AGENTS.md")).text();
+    const fork = await Bun.file(join(ROOT, "FORK.md")).text();
+    const readme = await Bun.file(join(ROOT, "README.md")).text();
+
+    expect(agents).toContain("SanHsien 維護型 fork overlay");
+    expect(fork).toContain("不翻譯、不改寫");
+    expect(readme).toContain("ChatGPT account pool");
+    expect(existsSync(join(ROOT, "README.en.md"))).toBe(false);
+    expect(existsSync(join(ROOT, "README.zh-Hant.md"))).toBe(false);
+  });
+
+  test("gitignore covers generated reports", async () => {
+    const gitignore = await Bun.file(join(ROOT, ".gitignore")).text();
+    expect(gitignore).toContain("upstream-review-report.md");
+  });
+});
+
+describe("upstream workflow isolation", () => {
+  test("non-fork workflows that must not run here have the official-repo guard", async () => {
+    const workflows = join(ROOT, ".github", "workflows");
+    const glob = new Bun.Glob("*.yml");
+    let scanned = 0;
+    for await (const name of glob.scan({ cwd: workflows })) {
+      if (FORK_OWNED_WORKFLOWS.has(name) || KEEP_RUNNING_UPSTREAM_WORKFLOWS.has(name)) {
+        continue;
+      }
+      scanned += 1;
+      const text = await Bun.file(join(workflows, name)).text();
+      expect(text.includes(OFFICIAL_REPO_GUARD)).toBe(true);
+    }
+    expect(scanned).toBeGreaterThanOrEqual(8);
+  });
+
+  test("product CI and fork-owned workflows stay enabled on this fork", async () => {
+    const ci = await Bun.file(join(ROOT, ".github/workflows/ci.yml")).text();
+    expect(ci).not.toContain(OFFICIAL_REPO_GUARD);
+
+    for (const name of FORK_OWNED_WORKFLOWS) {
+      const text = await Bun.file(join(ROOT, ".github/workflows", name)).text();
+      expect(text.includes(OFFICIAL_REPO_GUARD)).toBe(false);
+    }
+  });
+});
+
+describe("fork markdown links", () => {
+  test("check-links scans overlay docs and not README", () => {
+    const rels = iterDocuments().map((path) =>
+      relative(ROOT, path).replaceAll("\\", "/"),
+    );
+    expect(rels).toContain("FORK.md");
+    expect(rels).toContain("docs/fork/UPSTREAM.md");
+    expect(rels).not.toContain("README.md");
+  });
+
+  test("check-links rejects a path outside the repo", () => {
+    const dir = mkdtempSync(join(tmpdir(), "opencodex-fork-links-"));
+    const doc = join(dir, "note.md");
+    writeFileSync(doc, "[here](.)\n", "utf8");
+    const problems = checkDocument(doc);
+    expect(problems.some((item) => item.includes("逃出"))).toBe(true);
+  });
+
+  test("maintainer markdown links resolve", () => {
+    const failures: string[] = [];
+    for (const path of iterDocuments()) {
+      for (const problem of checkDocument(path)) {
+        failures.push(`${path}: ${problem}`);
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+});
+
+describe("upstream checker", () => {
+  test("baseline file is valid and complete", () => {
+    const baseline = loadBaseline();
+    expect(baseline.repo.endsWith("opencodex.git")).toBe(true);
+    expect(baseline.branch).toBe("main");
+    expect(baseline.reviewed_through).toHaveLength(40);
+    expect(baseline.reviewed_date).toBe("2026-08-22");
+  });
+
+  test("workflow is scheduled and fails on unreviewed commits", async () => {
+    const workflow = await Bun.file(
+      join(ROOT, ".github/workflows/upstream-check.yml"),
+    ).text();
+    expect(workflow).toContain("schedule:");
+    expect(workflow).toContain("cron:");
+    expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).toContain("tools/check-upstream-updates.ts");
+    expect(workflow).toContain("fetch-depth: 0");
+    expect(workflow).toContain("exit 1");
+  });
+
+  test("renderMarkdown reports no new commits", () => {
+    const baseline = {
+      repo: "https://example.invalid/upstream.git",
+      branch: "main",
+      reviewed_through: "a".repeat(40),
+      reviewed_date: "2026-08-22",
+    };
+    const report = renderMarkdown(baseline, []);
+    expect(report).toContain("No new upstream commits");
+  });
+
+  test("renderMarkdown surfaces check failure", () => {
+    const baseline = {
+      repo: "https://example.invalid/upstream.git",
+      branch: "main",
+      reviewed_through: "a".repeat(40),
+      reviewed_date: "2026-08-22",
+    };
+    const report = renderMarkdown(baseline, [], "git fetch failed");
+    expect(report).toContain("Check failed");
+    expect(report).toContain("git fetch failed");
+  });
+
+  test("loadBaseline rejects a missing file", () => {
+    expect(() => loadBaseline(join(ROOT, "tools", "nope.json"))).toThrow(
+      UpstreamCheckError,
+    );
+  });
+
+  test("baseline matches the decisions record", async () => {
+    const decisions = await Bun.file(join(ROOT, "docs/fork/DECISIONS.md")).text();
+    const upstream = await Bun.file(join(ROOT, "docs/fork/UPSTREAM.md")).text();
+    const baseline = loadBaseline();
+    expect(decisions).toContain(baseline.reviewed_date);
+    expect(upstream).toContain(baseline.reviewed_through);
+  });
+});

--- a/tools/check-links.ts
+++ b/tools/check-links.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env bun
+/**
+ * 檢查本 fork 維護文件之間的相對連結。
+ *
+ * 只掃 SanHsien overlay 與根目錄維護檔，不掃上游 README / docs-site。
+ *
+ *     bun tools/check-links.ts
+ */
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const LINK_PATTERN = /!\[[^\]]*\]\(([^)]+)\)|\[[^\]]*\]\(([^)]+)\)/g;
+const SKIP_PREFIXES = ["http://", "https://", "mailto:", "tel:", "#"];
+
+const ROOT_DOCS = [
+  "AGENTS.md",
+  "AGENTS_INSTALL.md",
+  "CLAUDE.md",
+  "FORK.md",
+  "NOTICE.md",
+  "REVIEW.md",
+  "SECURITY.md",
+  "SKILL.md",
+];
+
+export function iterDocuments(): string[] {
+  const documents = ROOT_DOCS.map((name) => join(ROOT, name)).filter((path) =>
+    existsSync(path),
+  );
+  const forkDocs = join(ROOT, "docs", "fork");
+  if (existsSync(forkDocs)) {
+    for (const name of readdirSync(forkDocs)) {
+      if (name.endsWith(".md")) documents.push(join(forkDocs, name));
+    }
+  }
+  return documents.sort();
+}
+
+export function checkDocument(path: string): string[] {
+  const problems: string[] = [];
+  const text = readFileSync(path, "utf8");
+  for (const match of text.matchAll(LINK_PATTERN)) {
+    const target = (match[1] ?? match[2] ?? "").trim().replace(/^<|>$/g, "");
+    if (!target || SKIP_PREFIXES.some((prefix) => target.startsWith(prefix))) {
+      continue;
+    }
+    const filePart = decodeURIComponent(target.split("#", 1)[0] ?? "");
+    if (!filePart) continue;
+    const resolved = filePart.startsWith("/")
+      ? resolve(ROOT, filePart.replace(/^\/+/, ""))
+      : resolve(dirname(path), filePart);
+    const relToRoot = relative(ROOT, resolved);
+    if (relToRoot.startsWith("..") || relToRoot === "") {
+      if (relToRoot.startsWith("..")) {
+        problems.push(`${target} → 連結逃出 repo 根目錄`);
+      }
+      continue;
+    }
+    if (!existsSync(resolved)) {
+      problems.push(`${target} → 找不到 ${relToRoot.replaceAll("\\", "/")}`);
+    }
+  }
+  return problems;
+}
+
+function main(): number {
+  const documents = iterDocuments();
+  if (documents.length === 0) {
+    console.log("找不到任何維護用 Markdown 檔");
+    return 1;
+  }
+
+  let failures = 0;
+  for (const path of documents) {
+    const problems = checkDocument(path);
+    const rel = relative(ROOT, path).replaceAll("\\", "/");
+    if (problems.length > 0) {
+      failures += 1;
+      for (const problem of problems) {
+        console.log(`FAIL ${rel}: ${problem}`);
+      }
+    } else {
+      console.log(`OK   ${rel}`);
+    }
+  }
+
+  console.log(`\n共 ${documents.length} 份文件，${failures} 份有斷掉的相對連結。`);
+  return failures ? 1 : 0;
+}
+
+if (import.meta.main) {
+  process.exit(main());
+}

--- a/tools/check-upstream-updates.ts
+++ b/tools/check-upstream-updates.ts
@@ -1,0 +1,228 @@
+#!/usr/bin/env bun
+/** Report upstream commits that have not yet been reviewed by this fork. */
+
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const REPO_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)));
+export const BASELINE_PATH = resolve(REPO_ROOT, "tools", "upstream_baseline.json");
+const UPSTREAM_REF_PREFIX = "refs/upstream-check";
+const REQUIRED_FIELDS = ["repo", "branch", "reviewed_through", "reviewed_date"] as const;
+const FULL_SHA_LENGTH = 40;
+const UNIT_SEPARATOR = "\u001f";
+
+export class UpstreamCheckError extends Error {}
+
+export type Baseline = {
+  repo: string;
+  branch: string;
+  reviewed_through: string;
+  reviewed_date: string;
+};
+
+export type Commit = {
+  sha: string;
+  short: string;
+  date: string;
+  subject: string;
+  files: string[];
+};
+
+export function loadBaseline(path = BASELINE_PATH): Baseline {
+  if (!existsSync(path)) {
+    throw new UpstreamCheckError(`missing baseline file: ${path}`);
+  }
+  let baseline: Baseline;
+  try {
+    baseline = JSON.parse(readFileSync(path, "utf8")) as Baseline;
+  } catch (error) {
+    throw new UpstreamCheckError(`invalid baseline file: ${path}: ${String(error)}`);
+  }
+  const missing = REQUIRED_FIELDS.filter((field) => !baseline[field]);
+  if (missing.length > 0) {
+    throw new UpstreamCheckError(`baseline missing fields: ${missing.join(", ")}`);
+  }
+  if (String(baseline.reviewed_through).length !== FULL_SHA_LENGTH) {
+    throw new UpstreamCheckError("reviewed_through must be a full 40-character SHA");
+  }
+  return baseline;
+}
+
+export function runGit(args: string[], cwd: string): string {
+  const result = Bun.spawnSync(["git", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (result.exitCode !== 0) {
+    const stderr = new TextDecoder().decode(result.stderr).trim();
+    throw new UpstreamCheckError(`git ${args.join(" ")} failed: ${stderr}`);
+  }
+  return new TextDecoder().decode(result.stdout);
+}
+
+export function fetchUpstream(baseline: Baseline, repoDir: string): string {
+  const ref = `${UPSTREAM_REF_PREFIX}/${baseline.branch}`;
+  runGit(
+    ["fetch", "--quiet", baseline.repo, `+refs/heads/${baseline.branch}:${ref}`],
+    repoDir,
+  );
+  return ref;
+}
+
+export function collectNewCommits(
+  baseline: Baseline,
+  repoDir: string,
+  ref: string,
+): Commit[] {
+  const raw = runGit(
+    [
+      "log",
+      "--reverse",
+      "--date=short",
+      `--format=%H${UNIT_SEPARATOR}%ad${UNIT_SEPARATOR}%s`,
+      `${baseline.reviewed_through}..${ref}`,
+    ],
+    repoDir,
+  );
+  const commits: Commit[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    const parts = line.split(UNIT_SEPARATOR);
+    if (parts.length < 3) {
+      throw new UpstreamCheckError(`unexpected git log line: ${JSON.stringify(line)}`);
+    }
+    const [sha, date, subject] = parts;
+    const files = runGit(["show", "--name-only", "--format=", sha], repoDir)
+      .split("\n")
+      .map((item) => item.trim())
+      .filter(Boolean);
+    commits.push({
+      sha,
+      short: sha.slice(0, 7),
+      date,
+      subject,
+      files,
+    });
+  }
+  return commits;
+}
+
+export function renderMarkdown(
+  baseline: Baseline,
+  commits: Commit[],
+  error?: string,
+): string {
+  const lines = [
+    "# Upstream review report",
+    "",
+    `- Upstream: \`${baseline.repo}\` (\`${baseline.branch}\`)`,
+    `- Reviewed through: \`${baseline.reviewed_through.slice(0, 7)}\``,
+    `- Last review date: ${baseline.reviewed_date}`,
+    "",
+  ];
+  if (error) {
+    lines.push("## Check failed", "", "```text", error, "```", "");
+    return `${lines.join("\n")}\n`;
+  }
+  if (commits.length === 0) {
+    lines.push("## Result", "", "No new upstream commits. Nothing to review.", "");
+    return `${lines.join("\n")}\n`;
+  }
+  lines.push(
+    "## Result",
+    "",
+    `${commits.length} upstream commit(s) require review.`,
+    "",
+    "| Commit | Date | Subject | Files |",
+    "| --- | --- | --- | --- |",
+  );
+  for (const commit of commits) {
+    const subject = commit.subject.replaceAll("|", "\\|");
+    let files = commit.files
+      .slice(0, 8)
+      .map((item) => item.replaceAll("|", "\\|"))
+      .join("<br>");
+    if (commit.files.length > 8) {
+      files += `<br>… +${commit.files.length - 8} more`;
+    }
+    lines.push(
+      `| \`${commit.short}\` | ${commit.date} | ${subject} | ${files || "(none)"} |`,
+    );
+  }
+  lines.push(
+    "",
+    "Review each commit, record adopt/skip decisions in `docs/fork/DECISIONS.md`, ",
+    "then advance `tools/upstream_baseline.json` only after verification.",
+    "",
+  );
+  return `${lines.join("\n")}\n`;
+}
+
+function parseArgs(args: string[]) {
+  const options = {
+    output: "upstream-review-report.md",
+    repoDir: REPO_ROOT,
+    githubOutput: false,
+    strict: false,
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--strict") options.strict = true;
+    else if (arg === "--github-output") options.githubOutput = true;
+    else if (arg === "--output" && args[index + 1]) {
+      options.output = args[index + 1] ?? options.output;
+      index += 1;
+    } else if (arg === "--repo-dir" && args[index + 1]) {
+      options.repoDir = args[index + 1] ?? options.repoDir;
+      index += 1;
+    }
+  }
+  return options;
+}
+
+export function main(args = Bun.argv.slice(2)): number {
+  const options = parseArgs(args);
+  let baseline: Baseline = {
+    repo: "unknown",
+    branch: "unknown",
+    reviewed_through: "0".repeat(FULL_SHA_LENGTH),
+    reviewed_date: "unknown",
+  };
+  let commits: Commit[] = [];
+  let error: string | undefined;
+
+  try {
+    baseline = loadBaseline();
+    const ref = fetchUpstream(baseline, options.repoDir);
+    commits = collectNewCommits(baseline, options.repoDir, ref);
+  } catch (caught) {
+    if (!(caught instanceof UpstreamCheckError)) throw caught;
+    error = caught.message;
+  }
+
+  const report = renderMarkdown(baseline, commits, error);
+  writeFileSync(options.output, report, "utf8");
+  process.stdout.write(report);
+
+  if (options.githubOutput && process.env.GITHUB_OUTPUT) {
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      [
+        `needs_attention=${commits.length > 0 || Boolean(error) ? "true" : "false"}`,
+        `check_failed=${error ? "true" : "false"}`,
+        `report_path=${options.output}`,
+        "",
+      ].join("\n"),
+    );
+  }
+
+  if (error) return 2;
+  if (options.strict && commits.length > 0) return 1;
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(main());
+}

--- a/tools/dev_check.ps1
+++ b/tools/dev_check.ps1
@@ -1,0 +1,42 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location -LiteralPath $repoRoot
+
+function Invoke-BunStep {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Label,
+        [Parameter(Mandatory)]
+        [string[]]$Arguments
+    )
+
+    Write-Host "==> $Label"
+    & bun @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Label failed with exit code $LASTEXITCODE"
+    }
+}
+
+if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
+    throw "bun is not on PATH. Install from https://bun.sh and re-run."
+}
+
+$lockfile = Join-Path $repoRoot "bun.lock"
+$modules = Join-Path $repoRoot "node_modules"
+if (-not (Test-Path -LiteralPath $modules) -or -not (Test-Path -LiteralPath $lockfile)) {
+    Invoke-BunStep -Label "Install dependencies" -Arguments @("install", "--frozen-lockfile")
+}
+
+Invoke-BunStep -Label "Fork hygiene tests" -Arguments @(
+    "test", "tests/fork-hygiene.test.ts"
+)
+Invoke-BunStep -Label "Check fork Markdown links" -Arguments @(
+    "tools/check-links.ts"
+)
+
+Write-Host "WINDOWS DEV CHECK GREEN"

--- a/tools/upstream_baseline.json
+++ b/tools/upstream_baseline.json
@@ -1,0 +1,6 @@
+{
+  "repo": "https://github.com/lidge-jun/opencodex.git",
+  "branch": "main",
+  "reviewed_through": "6ae83b1f189c353935d4977bb01227484fbdb52b",
+  "reviewed_date": "2026-08-22"
+}


### PR DESCRIPTION
## Summary
- Fork overlay for SanHsien/opencodex, tracking the ChatGPT **account pool** product from lidge-jun/opencodex.
- Isolate official npm publish, GitHub Pages, and issue/PR governance workflows so they only run on `lidge-jun/opencodex`.
- Add Windows gate (`tools/dev_check.ps1`), overlay docs, weekly upstream review, and CodeQL.

## Test plan
- [x] `bun install --frozen-lockfile`
- [x] `pwsh -NoProfile -File tools\dev_check.ps1` (14 fork tests + link check)
- [x] `bun run typecheck`
- [x] `bun tools/check-upstream-updates.ts` (no new commits)
- [ ] GitHub Actions: fork-maintenance, CodeQL, and upstream `ci.yml` on this PR
- [ ] After merge: `bun run src/cli/index.ts start` and open http://localhost:10100 to configure providers / account pool

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated security analysis and upstream change monitoring.
  - Added fork maintenance checks for links, configuration, and cross-platform workflows.
  - Added safeguards to prevent repository-specific publishing and deployment tasks from running in forks.

- **Documentation**
  - Added comprehensive fork maintenance, development, licensing, review, and upstream tracking guidance.

- **Chores**
  - Enabled weekly automated updates for GitHub Actions.
  - Added rules to exclude maintenance materials from published packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->