### PR TITLE
feat(cli): add an opt-in Windows desktop-app restart for a stale model picker

### DIFF
--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -203,7 +203,11 @@ const commandRunners: Record<string, CommandRunner> = {
     return 0;
   },
   sync: async deps => {
-    const restartCodex = deps.args.slice(1).includes("--restart-codex");
+    const syncArgs = deps.args.slice(1);
+    const restartCodex = syncArgs.includes("--restart-codex");
+    // Separate flag on purpose: --restart-codex promises app-server-only scope,
+    // and quitting the desktop app ends live conversations.
+    const restartDesktopApp = syncArgs.includes("--restart-desktop-app");
     const live = await deps.findLiveProxy();
     const synced = await syncModelsToCodex(
       live?.port,
@@ -229,6 +233,7 @@ const commandRunners: Record<string, CommandRunner> = {
     // exactly when a long-lived app-server is holding the stale list.
     if (synced.catalogWritten || synced.cacheSynced) {
       afterCatalogWriteHandleAppServers({ restart: restartCodex, log: console });
+      if (restartDesktopApp) await handleDesktopAppRestart(console);
     }
     // `ocx sync` is a direct CLI path; it does not call the management
     // `/api/sync` route. Refresh the already-connected MCode block here too,
@@ -259,7 +264,9 @@ const commandRunners: Record<string, CommandRunner> = {
     return await cmdV2(deps.args.slice(1), {}, async () => (await deps.findLiveProxy())?.port);
   },
   "sync-cache": async deps => {
-    const restartCodex = deps.args.slice(1).includes("--restart-codex");
+    const cacheArgs = deps.args.slice(1);
+    const restartCodex = cacheArgs.includes("--restart-codex");
+    const restartDesktopApp = cacheArgs.includes("--restart-desktop-app");
     const { withCatalogWriteSerialization } = await import("../codex/catalog-write-serialization");
     const { invalidateCodexModelsCacheWithPermit } = await import("../codex/catalog/sync");
     const { getCodexHome } = await import("../codex/paths");
@@ -270,6 +277,7 @@ const commandRunners: Record<string, CommandRunner> = {
     // Only warn/restart when models_cache was actually rewritten from a readable catalog.
     if (invalidated.kind === "completed" && invalidated.value) {
       afterCatalogWriteHandleAppServers({ restart: restartCodex, log: console });
+      if (restartDesktopApp) await handleDesktopAppRestart(console);
     } else if (desiredDisabled) {
       console.log("Codex integration is OFF; cache sync skipped (no catalog or cache write).");
     }
@@ -583,3 +591,43 @@ export async function dispatchCommand(head: CliHead, deps: CliDispatchDeps): Pro
   }
   return await runner(deps);
 }
+
+/**
+ * Report the outcome of an opt-in desktop-app restart. Kept next to the two
+ * callers so `sync` and `sync-cache` cannot drift in what they tell the user.
+ */
+async function handleDesktopAppRestart(log: Pick<Console, "log" | "error">): Promise<void> {
+  const { restartCodexDesktopApp } = await import("../codex/desktop-app-restart");
+  const result = restartCodexDesktopApp();
+  switch (result.reason) {
+    case "windows_only":
+      log.error("--restart-desktop-app is supported on Windows only; nothing was stopped.");
+      return;
+    case "package_discovery_failed":
+      log.error(
+        "Could not identify the installed Codex desktop package. Quit and relaunch the desktop app "
+        + "manually to refresh the model picker.",
+      );
+      return;
+    case "self_ancestry":
+      log.error(
+        "Refusing to restart the desktop app because this command is running inside it. "
+        + "Run 'ocx sync --restart-desktop-app' from an external terminal instead.",
+      );
+      return;
+    case "no_targets":
+      log.log("Codex desktop app is not running; nothing to restart.");
+      return;
+    case "targets_survived":
+      log.error(
+        `Codex desktop app PID(s) ${result.surviving.join(", ")} did not exit, so it was not relaunched. `
+        + "Quit the desktop app manually to refresh the model picker.",
+      );
+      return;
+    default:
+      if (result.relaunch === "started") {
+        log.log("Codex desktop app restarted; its model picker will re-read the catalog.");
+      }
+  }
+}
+

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1148,7 +1148,7 @@ export async function runDoctor(args: string[] = []): Promise<void> {
   const { collectCodexAppServerCatalogState } = await import("../codex/app-server-processes");
   const catalogState = collectCodexAppServerCatalogState();
   if (catalogState.state === "stale") {
-    console.log(`  [WARN] Codex app-server (PID(s): ${catalogState.processes.map(p => p.pid).join(", ")}) started before the on-disk catalog changed; its in-memory model list disagrees with ocx. Action: restart Codex (or run \`ocx sync --restart-codex\`)`);
+    console.log(`  [WARN] Codex app-server (PID(s): ${catalogState.processes.map(p => p.pid).join(", ")}) started before the on-disk catalog changed; its in-memory model list disagrees with ocx. Action: restart Codex (or run \`ocx sync --restart-codex\`; on Windows the desktop app may need \`ocx sync --restart-desktop-app\`)`);
   } else if (catalogState.state === "unknown") {
     console.log("  [WARN] Could not verify whether the running Codex app-server's model catalog is current (start time or catalog unreadable). Action: if the model list looks stale, restart Codex");
   } else if (catalogState.state === "fresh") {

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -88,20 +88,22 @@ export const CLI_COMMANDS: CliCommandEntry[] = [
   { name: "ensure", usage: "ocx ensure", summary: "Ensure the proxy is running and Codex config/cache are current." },
   {
     name: "sync",
-    usage: "ocx sync [--restart-codex]",
+    usage: "ocx sync [--restart-codex] [--restart-desktop-app]",
     summary: "Fetch provider models and inject them into Codex config.",
     details: [
       "After writing the catalog, warns if long-lived Codex app-server processes are still running.",
       "--restart-codex sends SIGTERM only to matching app-server / code-mode-host processes (may interrupt active turns).",
+      "--restart-desktop-app (Windows only, opt-in) fully restarts the Codex desktop app so its model picker re-reads the catalog. Never implied by --restart-codex: it ends live conversations.",
     ],
   },
   {
     name: "sync-cache",
-    usage: "ocx sync-cache [--restart-codex]",
+    usage: "ocx sync-cache [--restart-codex] [--restart-desktop-app]",
     summary: "Refresh Codex's model cache from the active catalog.",
     details: [
       "Warns when Codex app-server processes still hold an in-memory model list.",
       "--restart-codex sends SIGTERM only to matching app-server / code-mode-host processes (may interrupt active turns).",
+      "--restart-desktop-app (Windows only, opt-in) fully restarts the Codex desktop app so its model picker re-reads the catalog. Never implied by --restart-codex: it ends live conversations.",
     ],
   },
   { name: "status", usage: "ocx status", summary: "Check proxy server status." },

--- a/src/codex/app-server-processes.ts
+++ b/src/codex/app-server-processes.ts
@@ -17,7 +17,8 @@ import {
 import { readCodexCatalogPath } from "./catalog/parsing";
 
 export const STALE_CODEX_APP_SERVER_HINT =
-  "If Codex still shows an older model list, restart its long-lived app-server process after sync (ocx sync --restart-codex).";
+  "If Codex still shows an older model list, restart its long-lived app-server process after sync (ocx sync --restart-codex). "
+  + "On Windows the desktop app itself may also need a full restart (ocx sync --restart-desktop-app).";
 
 /** Attach the shared dashboard hint only after a catalog or models_cache write. */
 export function attachStaleAppServerHint<T extends {
@@ -505,6 +506,7 @@ export function formatStaleCodexAppServerWarning(
     `WARNING: ${processes.length} Codex app-server process(es) still running (PID${processes.length === 1 ? "" : "s"}: ${pids}). `
     + "Disk catalog/cache were updated, but Codex may keep showing the old model list until those processes restart. "
     + "Re-run with `ocx sync --restart-codex` (or `ocx sync-cache --restart-codex`) to send SIGTERM only to matching app-server processes. "
+    + "On Windows the desktop app itself may also need a full restart (`ocx sync --restart-desktop-app`). "
     + "Active turns may be interrupted."
   );
 }

--- a/src/codex/desktop-app-restart.ts
+++ b/src/codex/desktop-app-restart.ts
@@ -1,0 +1,342 @@
+/**
+ * Full restart of the Codex desktop app (the Electron shell), Windows only.
+ *
+ * `--restart-codex` deliberately signals only `codex app-server` /
+ * `codex-code-mode-host` processes: `isCodexAppServerCommandLine` requires a
+ * `codex` executable token, so the shell that owns the model picker is never a
+ * match. On macOS that is enough, because the respawned app-server re-emits
+ * `codex-app-server-initialized` and the renderer drops its cached
+ * `model/list`. On Windows MSIX it is not: externally terminating the child
+ * does not reliably re-emit that event in the surviving shell, so the picker
+ * keeps showing the old catalog until the app itself is restarted (#2292).
+ *
+ * This is therefore a SEPARATE opt-in flag rather than a widening of
+ * `--restart-codex`. Quitting the desktop app ends live conversations, which is
+ * a different consent from restarting a background helper, and the CLI contract
+ * for `--restart-codex` promises the narrow behavior.
+ *
+ * Everything here fails CLOSED: if the package cannot be identified, if a
+ * target is part of our own ancestry, or if any target survives termination,
+ * nothing is relaunched and the caller is told to restart manually. A stale
+ * picker is a much smaller problem than a wrongly killed process.
+ */
+import { resolveTrustedWindowsPowerShellExe, resolveTrustedWindowsTaskkillExe } from "../lib/windows-elevation";
+import { execFileSync } from "node:child_process";
+
+/** Bounded subprocess options. A hung Appx/CIM probe must never wedge `ocx sync`. */
+export interface DesktopAppExecOptions {
+  timeout?: number;
+  windowsHide?: boolean;
+}
+
+export interface DesktopAppRestartIo {
+  platform?: NodeJS.Platform;
+  /** Returns stdout. Options are part of the seam so the timeout is testable. */
+  execFile?: (file: string, args: readonly string[], options?: DesktopAppExecOptions) => string;
+  /** Process ancestry of the current process, innermost first. Used for the self-kill guard. */
+  ancestryPids?: () => number[];
+  isAlive?: (pid: number) => boolean;
+  sleep?: (ms: number) => void;
+  now?: () => number;
+}
+
+export type DesktopAppRestartReason =
+  | "windows_only"
+  | "package_discovery_failed"
+  | "no_targets"
+  | "self_ancestry"
+  | "targets_survived";
+
+export interface DesktopAppRestartResult {
+  attempted: boolean;
+  stopped: number[];
+  surviving: number[];
+  relaunch: "started" | "skipped";
+  reason?: DesktopAppRestartReason;
+}
+
+/** How long a graceful close is given before the forced pass. */
+const GRACEFUL_EXIT_TIMEOUT_MS = 15_000;
+/** How long a forced kill is given before the target counts as surviving. */
+const FORCED_EXIT_TIMEOUT_MS = 5_000;
+/** Every probe is bounded; PowerShell module loading is the slow part. */
+const PROBE_TIMEOUT_MS = 10_000;
+
+interface DesktopPackage {
+  family: string;
+  installLocation: string;
+  aumid: string;
+}
+
+/**
+ * Runtime discovery, never a hardcoded identifier. The beta MSIX package family
+ * changes between builds, so a literal AUMID would silently stop matching and
+ * then either do nothing or — worse — match a package we did not mean.
+ */
+function discoverPackage(exec: NonNullable<DesktopAppRestartIo["execFile"]>): DesktopPackage | null {
+  const script = [
+    "$ErrorActionPreference='SilentlyContinue'",
+    "Import-Module Appx -ErrorAction SilentlyContinue",
+    "$p = Get-AppxPackage -Name OpenAI.Codex",
+    "if (-not $p) { $p = Get-AppxPackage -Name OpenAI.CodexBeta }",
+    "if (-not $p -or -not $p.InstallLocation) { 'MISS' } else {",
+    "  $p.PackageFamilyName; $p.InstallLocation; \"$($p.PackageFamilyName)!App\"",
+    "}",
+  ].join("; ");
+  let stdout: string;
+  try {
+    stdout = exec(resolveTrustedWindowsPowerShellExe(), ["-NoProfile", "-NonInteractive", "-Command", script], {
+      timeout: PROBE_TIMEOUT_MS,
+      windowsHide: true,
+    });
+  } catch {
+    return null;
+  }
+  const lines = stdout.split(/\r?\n/).map(line => line.trim()).filter(line => line.length > 0);
+  if (lines.length < 3 || lines[0] === "MISS") return null;
+  const [family, installLocation, aumid] = lines;
+  if (!family || !installLocation || !aumid) return null;
+  return { family, installLocation, aumid };
+}
+
+interface DesktopProcess {
+  pid: number;
+  parentPid: number;
+  /** Win32_Process CreationDate. Guards against PID reuse across the wait window. */
+  createdAt: string;
+}
+
+/**
+ * Only `ChatGPT.exe` processes whose image lives under the discovered install
+ * location AND owned by the current user. The install location alone is not
+ * enough: an MSIX package under `WindowsApps` is shared, so on a multi-user
+ * machine another account's Codex desktop matches the same path. The app-server
+ * collector already pays for `GetOwner` for exactly this reason.
+ *
+ * `CreationDate` is captured so a PID can be re-verified before it is signalled;
+ * a graceful-close window is long enough for Windows to recycle a PID.
+ */
+function listPackageProcesses(
+  exec: NonNullable<DesktopAppRestartIo["execFile"]>,
+  installLocation: string,
+): DesktopProcess[] {
+  const literal = installLocation.replace(/'/g, "''");
+  const script = [
+    "$ErrorActionPreference='SilentlyContinue'",
+    `$root = '${literal}'`,
+    "$me = ([Security.Principal.WindowsIdentity]::GetCurrent()).Name",
+    "Get-CimInstance Win32_Process -Filter \"Name='ChatGPT.exe'\" |",
+    "  Where-Object { $_.ExecutablePath -and $_.ExecutablePath.StartsWith($root, 'OrdinalIgnoreCase') } |",
+    "  ForEach-Object {",
+    "    $o = Invoke-CimMethod -InputObject $_ -MethodName GetOwner",
+    "    if ($o -and $o.ReturnValue -eq 0 -and $o.User) {",
+    "      $owner = if ($o.Domain) { \"$($o.Domain)\\$($o.User)\" } else { $o.User }",
+    "      if ($owner -ieq $me) {",
+    "        \"$($_.ProcessId) $($_.ParentProcessId) $($_.CreationDate.ToString('o'))\"",
+    "      }",
+    "    }",
+    "  }",
+  ].join(" ");
+  let stdout: string;
+  try {
+    stdout = exec(resolveTrustedWindowsPowerShellExe(), ["-NoProfile", "-NonInteractive", "-Command", script], {
+      timeout: PROBE_TIMEOUT_MS,
+      windowsHide: true,
+    });
+  } catch {
+    return [];
+  }
+  const processes: DesktopProcess[] = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    const match = /^\s*(\d+)\s+(\d+)\s+(\S+)\s*$/.exec(line);
+    if (!match) continue;
+    const pid = Number(match[1]);
+    const parentPid = Number(match[2]);
+    const createdAt = match[3]!;
+    if (Number.isSafeInteger(pid) && Number.isSafeInteger(parentPid)) {
+      processes.push({ pid, parentPid, createdAt });
+    }
+  }
+  return processes;
+}
+
+/**
+ * True when the PID still names the same process we verified. Between listing
+ * and signalling there is a graceful-close window, and a `taskkill /T /F` on a
+ * recycled PID would tear down an unrelated process tree.
+ */
+function stillSameProcess(
+  exec: NonNullable<DesktopAppRestartIo["execFile"]>,
+  installLocation: string,
+  target: DesktopProcess,
+): boolean {
+  const current = listPackageProcesses(exec, installLocation)
+    .find(p => p.pid === target.pid);
+  return current !== undefined && current.createdAt === target.createdAt;
+}
+
+/** Roots are the package processes whose parent is not itself in the package tree. */
+function rootProcesses(processes: readonly DesktopProcess[]): DesktopProcess[] {
+  const inTree = new Set(processes.map(p => p.pid));
+  return processes.filter(p => !inTree.has(p.parentPid));
+}
+
+/**
+ * Full Windows parent chain for this process, innermost first.
+ *
+ * `process.ppid` is one level, which is not enough: a terminal hosted inside the
+ * desktop app sits several hops below `ChatGPT.exe`, so a one-level check would
+ * miss the exact case the guard exists for and we would terminate our own host.
+ * The chain therefore comes from CIM, with a bound so a corrupted parent cycle
+ * cannot spin.
+ */
+function windowsAncestryPids(exec: NonNullable<DesktopAppRestartIo["execFile"]>): number[] {
+  const chain: number[] = [process.pid];
+  let current = process.pid;
+  for (let hop = 0; hop < 16; hop++) {
+    let stdout: string;
+    try {
+      stdout = exec(resolveTrustedWindowsPowerShellExe(), [
+        "-NoProfile", "-NonInteractive", "-Command",
+        `$ErrorActionPreference='SilentlyContinue'; (Get-CimInstance Win32_Process -Filter "ProcessId=${current}").ParentProcessId`,
+      ], { timeout: PROBE_TIMEOUT_MS, windowsHide: true });
+    } catch {
+      // An unreadable chain must not be read as "not our ancestor".
+      return [];
+    }
+    const parent = Number(stdout.trim());
+    if (!Number.isSafeInteger(parent) || parent <= 0 || chain.includes(parent)) break;
+    chain.push(parent);
+    current = parent;
+  }
+  return chain;
+}
+
+function defaultExecFile(file: string, args: readonly string[], options?: DesktopAppExecOptions): string {
+  return execFileSync(file, [...args], {
+    encoding: "utf-8",
+    timeout: options?.timeout ?? PROBE_TIMEOUT_MS,
+    windowsHide: options?.windowsHide ?? true,
+  });
+}
+
+function defaultIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function defaultSleep(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function waitForExit(
+  pid: number,
+  timeoutMs: number,
+  isAlive: (pid: number) => boolean,
+  sleep: (ms: number) => void,
+  now: () => number,
+): boolean {
+  const deadline = now() + timeoutMs;
+  while (now() < deadline) {
+    if (!isAlive(pid)) return true;
+    sleep(250);
+  }
+  return !isAlive(pid);
+}
+
+/**
+ * Stop every package-tree root gracefully, force the stragglers, then relaunch
+ * through the discovered AUMID. Returns without relaunching if anything
+ * survived, because launching a second shell beside a stuck one is worse than
+ * leaving the user to restart it.
+ */
+export function restartCodexDesktopApp(io: DesktopAppRestartIo = {}): DesktopAppRestartResult {
+  const platform = io.platform ?? process.platform;
+  const skipped = (reason: DesktopAppRestartReason): DesktopAppRestartResult => ({
+    attempted: false, stopped: [], surviving: [], relaunch: "skipped", reason,
+  });
+  if (platform !== "win32") return skipped("windows_only");
+
+  const exec = io.execFile ?? defaultExecFile;
+  const pkg = discoverPackage(exec);
+  if (!pkg) return skipped("package_discovery_failed");
+
+  const processes = listPackageProcesses(exec, pkg.installLocation);
+  const roots = rootProcesses(processes);
+  if (roots.length === 0) return skipped("no_targets");
+
+  const ancestryPids = io.ancestryPids ? io.ancestryPids() : windowsAncestryPids(exec);
+  if (ancestryPids.length === 0) {
+    // Fail closed: an unreadable ancestry chain cannot prove we are outside the
+    // tree we are about to terminate.
+    return skipped("self_ancestry");
+  }
+  const ancestry = new Set(ancestryPids);
+  if (processes.some(p => ancestry.has(p.pid))) {
+    // Terminating our own tree would kill this command mid-flight and leave the
+    // user with neither a restarted app nor an explanation.
+    return skipped("self_ancestry");
+  }
+
+  const isAlive = io.isAlive ?? defaultIsAlive;
+  const sleep = io.sleep ?? defaultSleep;
+  const now = io.now ?? (() => Date.now());
+  const stopped: number[] = [];
+  const surviving: number[] = [];
+
+  for (const root of roots) {
+    const pid = root.pid;
+    // Re-verify immediately before the graceful close: the listing is already
+    // one probe old.
+    if (!stillSameProcess(exec, pkg.installLocation, root)) {
+      stopped.push(pid);
+      continue;
+    }
+    try {
+      exec(resolveTrustedWindowsPowerShellExe(), [
+        "-NoProfile", "-NonInteractive", "-Command",
+        `$p = Get-Process -Id ${pid} -ErrorAction SilentlyContinue; if ($p) { [void]$p.CloseMainWindow() }`,
+      ], { timeout: PROBE_TIMEOUT_MS, windowsHide: true });
+    } catch {
+      /* a refused graceful close still gets the forced pass below */
+    }
+    if (waitForExit(pid, GRACEFUL_EXIT_TIMEOUT_MS, isAlive, sleep, now)) {
+      stopped.push(pid);
+      continue;
+    }
+    // The wait window is long enough for Windows to recycle a PID, and the next
+    // step is `/T /F` against a whole tree. Confirm the PID is still the process
+    // we verified, or leave it alone.
+    if (!stillSameProcess(exec, pkg.installLocation, root)) {
+      stopped.push(pid);
+      continue;
+    }
+    try {
+      exec(resolveTrustedWindowsTaskkillExe(), ["/PID", String(pid), "/T", "/F"], {
+        timeout: PROBE_TIMEOUT_MS, windowsHide: true,
+      });
+    } catch {
+      /* fall through to the liveness check: the process state decides, not the exit code */
+    }
+    if (waitForExit(pid, FORCED_EXIT_TIMEOUT_MS, isAlive, sleep, now)) stopped.push(pid);
+    else surviving.push(pid);
+  }
+
+  if (surviving.length > 0) {
+    return { attempted: true, stopped, surviving, relaunch: "skipped", reason: "targets_survived" };
+  }
+
+  try {
+    exec(resolveTrustedWindowsPowerShellExe(), [
+      "-NoProfile", "-NonInteractive", "-Command",
+      `Start-Process 'shell:AppsFolder\\${pkg.aumid}'`,
+    ], { timeout: PROBE_TIMEOUT_MS, windowsHide: true });
+  } catch {
+    return { attempted: true, stopped, surviving, relaunch: "skipped", reason: "targets_survived" };
+  }
+  return { attempted: true, stopped, surviving, relaunch: "started" };
+}

--- a/tests/codex-app-server-processes.test.ts
+++ b/tests/codex-app-server-processes.test.ts
@@ -623,7 +623,7 @@ describe("CLI /api sync wiring for stale app-servers (#476)", () => {
 
   test("ocx sync only handles app-servers after a catalog/cache write and forwards --restart-codex", () => {
     const syncCase = dispatchSource.slice(dispatchSource.indexOf("sync: async"), dispatchSource.indexOf("v2: async"));
-    expect(syncCase).toContain('deps.args.slice(1).includes("--restart-codex")');
+    expect(syncCase).toContain('includes("--restart-codex")');
     expect(syncCase).toContain("synced.catalogWritten || synced.cacheSynced");
     expect(syncCase).toContain("afterCatalogWriteHandleAppServers");
     expect(syncCase).toContain("restart: restartCodex");
@@ -633,6 +633,21 @@ describe("CLI /api sync wiring for stale app-servers (#476)", () => {
     const gatedBlock = syncCase.slice(syncCase.indexOf("if (synced.catalogWritten"));
     expect(gatedBlock).toContain("afterCatalogWriteHandleAppServers");
     expect(syncCase.replace(gatedBlock, "")).not.toContain("afterCatalogWriteHandleAppServers");
+  });
+
+  test("--restart-desktop-app is a separate opt-in that --restart-codex never implies (#2292)", () => {
+    for (const [name, endMarker] of [["sync: async", "v2: async"], ['"sync-cache": async', "gui: async"]] as const) {
+      const handler = dispatchSource.slice(dispatchSource.indexOf(name), dispatchSource.indexOf(endMarker));
+      // Two independent flag reads. If the desktop restart were derived from
+      // restartCodex, quitting the user's app would ride along on a flag whose
+      // documented contract is app-server-only.
+      expect(handler).toContain('includes("--restart-desktop-app")');
+      expect(handler).toContain("if (restartDesktopApp) await handleDesktopAppRestart(console)");
+      expect(handler).not.toContain("restartDesktopApp = restartCodex");
+      // Gated behind the same real-write condition as the app-server handling.
+      const desktopAt = handler.indexOf("restartDesktopApp) await handleDesktopAppRestart");
+      expect(handler.indexOf("afterCatalogWriteHandleAppServers")).toBeLessThan(desktopAt);
+    }
   });
 
   test("ocx sync-cache only handles app-servers after a successful models_cache write", () => {

--- a/tests/desktop-app-restart.test.ts
+++ b/tests/desktop-app-restart.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, test } from "bun:test";
+import { restartCodexDesktopApp, type DesktopAppRestartIo } from "../src/codex/desktop-app-restart";
+import { setTrustedWindowsElevationExecutablesForTests } from "../src/lib/windows-elevation";
+
+/**
+ * #2292: the desktop restart is the one path in the CLI that terminates a user's
+ * app. Every branch is driven through the io seam so the guards are proved on
+ * any platform, not asserted from a comment.
+ */
+
+const PS = "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
+const TASKKILL = "C:\\Windows\\System32\\taskkill.exe";
+const INSTALL = "C:\\Program Files\\WindowsApps\\OpenAI.Codex_2p2nqsd0c76g0";
+const AUMID = "OpenAI.Codex_2p2nqsd0c76g0!App";
+
+function withTrustedExes<T>(run: () => T): T {
+  setTrustedWindowsElevationExecutablesForTests({ powershell: PS, taskkill: TASKKILL });
+  try {
+    return run();
+  } finally {
+    setTrustedWindowsElevationExecutablesForTests(null);
+  }
+}
+
+interface Call { file: string; args: string[] }
+
+/** Scripted exec seam: discovery, then process list, then whatever the branch does. */
+function scriptedIo(options: {
+  discovery?: string;
+  processes?: string;
+  aliveFor?: (pid: number, poll: number) => boolean;
+  calls: Call[];
+  ancestry?: number[];
+  throwOn?: (file: string, args: readonly string[]) => boolean;
+}): DesktopAppRestartIo {
+  const polls = new Map<number, number>();
+  return {
+    platform: "win32",
+    ancestryPids: () => options.ancestry ?? [4242],
+    sleep: () => {},
+    now: (() => { let t = 0; return () => (t += 500); })(),
+    isAlive: pid => {
+      const n = (polls.get(pid) ?? 0) + 1;
+      polls.set(pid, n);
+      return options.aliveFor ? options.aliveFor(pid, n) : false;
+    },
+    execFile: (file, args) => {
+      options.calls.push({ file, args: [...args] });
+      if (options.throwOn?.(file, args)) throw new Error("exec failed");
+      const joined = args.join(" ");
+      if (joined.includes("Get-AppxPackage")) return options.discovery ?? "MISS";
+      if (joined.includes("Win32_Process")) return options.processes ?? "";
+      return "";
+    },
+  };
+}
+
+const DISCOVERY = [AUMID.replace("!App", ""), INSTALL, AUMID].join("\n");
+
+describe("Codex desktop app restart (#2292)", () => {
+  test("is a no-op off Windows and never execs anything", () => {
+    const calls: Call[] = [];
+    const result = restartCodexDesktopApp({ platform: "darwin", execFile: (f, a) => { calls.push({ file: f, args: [...a] }); return ""; } });
+    expect(result).toEqual({ attempted: false, stopped: [], surviving: [], relaunch: "skipped", reason: "windows_only" });
+    expect(calls).toEqual([]);
+  });
+
+  test("fails closed when the package cannot be identified, killing nothing", () => {
+    const calls: Call[] = [];
+    const result = withTrustedExes(() => restartCodexDesktopApp(scriptedIo({ discovery: "MISS", calls })));
+    expect(result.attempted).toBe(false);
+    expect(result.reason).toBe("package_discovery_failed");
+    expect(calls.some(c => c.file === TASKKILL)).toBe(false);
+    expect(calls.some(c => c.args.join(" ").includes("Start-Process"))).toBe(false);
+  });
+
+  test("a discovery probe that throws is also fail-closed", () => {
+    const calls: Call[] = [];
+    const result = withTrustedExes(() => restartCodexDesktopApp(scriptedIo({
+      discovery: DISCOVERY, calls, throwOn: (_f, a) => a.join(" ").includes("Get-AppxPackage"),
+    })));
+    expect(result.reason).toBe("package_discovery_failed");
+    expect(calls.some(c => c.file === TASKKILL)).toBe(false);
+  });
+
+  test("closes the root gracefully and relaunches through the DISCOVERED aumid", () => {
+    const calls: Call[] = [];
+    const result = withTrustedExes(() => restartCodexDesktopApp(scriptedIo({
+      discovery: DISCOVERY, processes: "1000 900 2026-08-22T10:00:00.000Z", calls,
+      aliveFor: (_pid, poll) => poll <= 2,
+    })));
+    expect(result).toEqual({ attempted: true, stopped: [1000], surviving: [], relaunch: "started" });
+    expect(calls.some(c => c.args.join(" ").includes("CloseMainWindow"))).toBe(true);
+    // Graceful exit means no forced pass at all.
+    expect(calls.some(c => c.file === TASKKILL)).toBe(false);
+    const launch = calls.find(c => c.args.join(" ").includes("Start-Process"));
+    expect(launch?.args.join(" ")).toContain(AUMID);
+  });
+
+  test("forces only after the graceful window elapses", () => {
+    const calls: Call[] = [];
+    const result = withTrustedExes(() => restartCodexDesktopApp(scriptedIo({
+      discovery: DISCOVERY, processes: "1000 900 2026-08-22T10:00:00.000Z", calls,
+      // Alive through the graceful window, dead once taskkill has run.
+      aliveFor: (_pid, poll) => poll <= 31,
+    })));
+    expect(result.relaunch).toBe("started");
+    expect(result.stopped).toEqual([1000]);
+    const kill = calls.find(c => c.file === TASKKILL);
+    expect(kill?.args).toEqual(["/PID", "1000", "/T", "/F"]);
+  });
+
+  test("a surviving target blocks the relaunch", () => {
+    const calls: Call[] = [];
+    const result = withTrustedExes(() => restartCodexDesktopApp(scriptedIo({
+      discovery: DISCOVERY, processes: "1000 900 2026-08-22T10:00:00.000Z", calls, aliveFor: () => true,
+    })));
+    expect(result.surviving).toEqual([1000]);
+    expect(result.relaunch).toBe("skipped");
+    expect(result.reason).toBe("targets_survived");
+    expect(calls.some(c => c.args.join(" ").includes("Start-Process"))).toBe(false);
+  });
+
+  test("refuses to kill its own ancestry", () => {
+    const calls: Call[] = [];
+    const result = withTrustedExes(() => restartCodexDesktopApp(scriptedIo({
+      discovery: DISCOVERY, processes: "1000 900 2026-08-22T10:00:00.000Z", calls, ancestry: [1000, 55],
+    })));
+    expect(result.reason).toBe("self_ancestry");
+    expect(calls.some(c => c.file === TASKKILL)).toBe(false);
+    expect(calls.some(c => c.args.join(" ").includes("CloseMainWindow"))).toBe(false);
+  });
+
+  test("only package-tree roots are targeted, and children are not killed twice", () => {
+    const calls: Call[] = [];
+    // 1000 is the root; 1001 and 1002 are its children inside the package tree.
+    const result = withTrustedExes(() => restartCodexDesktopApp(scriptedIo({
+      discovery: DISCOVERY, processes: "1000 900 T0\n1001 1000 T1\n1002 1000 T2", calls,
+      aliveFor: (_pid, poll) => poll <= 1,
+    })));
+    expect(result.stopped).toEqual([1000]);
+    const closes = calls.filter(c => c.args.join(" ").includes("CloseMainWindow"));
+    expect(closes).toHaveLength(1);
+  });
+
+  test("no running desktop app is reported rather than treated as a failure", () => {
+    const calls: Call[] = [];
+    const result = withTrustedExes(() => restartCodexDesktopApp(scriptedIo({
+      discovery: DISCOVERY, processes: "", calls,
+    })));
+    expect(result.reason).toBe("no_targets");
+    expect(result.attempted).toBe(false);
+  });
+
+  test("the relaunch identifier comes from discovery, never a hardcoded package", () => {
+    const calls: Call[] = [];
+    const betaAumid = "OpenAI.CodexBeta_9zzzzzzzzzzzz!App";
+    withTrustedExes(() => restartCodexDesktopApp(scriptedIo({
+      discovery: ["OpenAI.CodexBeta_9zzzzzzzzzzzz", INSTALL, betaAumid].join("\n"),
+      processes: "1000 900 2026-08-22T10:00:00.000Z", calls, aliveFor: () => false,
+    })));
+    const launch = calls.find(c => c.args.join(" ").includes("Start-Process"));
+    expect(launch?.args.join(" ")).toContain(betaAumid);
+    expect(launch?.args.join(" ")).not.toContain("2p2nqsd0c76g0");
+  });
+
+  test("the process probe is scoped to the discovered install location", () => {
+    const calls: Call[] = [];
+    withTrustedExes(() => restartCodexDesktopApp(scriptedIo({
+      discovery: DISCOVERY, processes: "1000 900 2026-08-22T10:00:00.000Z", calls, aliveFor: () => false,
+    })));
+    const probe = calls.find(c => c.args.join(" ").includes("Win32_Process"));
+    const script = probe?.args.join(" ") ?? "";
+    expect(script).toContain("Name='ChatGPT.exe'");
+    expect(script).toContain(INSTALL);
+    expect(script).toContain("OrdinalIgnoreCase");
+  });
+
+  test("every probe is bounded by a timeout", () => {
+    const seen: (number | undefined)[] = [];
+    withTrustedExes(() => restartCodexDesktopApp({
+      platform: "win32",
+      ancestryPids: () => [4242],
+      sleep: () => {},
+      isAlive: () => false,
+      execFile: (_file, args, options) => {
+        seen.push(options?.timeout);
+        return args.join(" ").includes("Get-AppxPackage") ? DISCOVERY : "1000 900";
+      },
+    }));
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen.every(t => typeof t === "number" && t > 0)).toBe(true);
+  });
+});
+
+
+describe("Codex desktop app restart — kill-authority guards (#2292)", () => {
+  test("the process probe is scoped to the CURRENT USER, not just the package path", () => {
+    const calls: Call[] = [];
+    withTrustedExes(() => restartCodexDesktopApp(scriptedIo({
+      discovery: DISCOVERY, processes: "1000 900 T0", calls, aliveFor: () => false,
+    })));
+    const probe = calls.find(c => c.args.join(" ").includes("Win32_Process"));
+    const script = probe?.args.join(" ") ?? "";
+    // An MSIX InstallLocation under WindowsApps is shared between accounts, so
+    // path scoping alone would match another user's desktop app.
+    expect(script).toContain("GetOwner");
+    expect(script).toContain("WindowsIdentity");
+  });
+
+  test("a PID recycled during the graceful wait is never force-killed", () => {
+    const calls: Call[] = [];
+    let listings = 0;
+    const io: DesktopAppRestartIo = {
+      platform: "win32",
+      ancestryPids: () => [4242],
+      sleep: () => {},
+      now: (() => { let t = 0; return () => (t += 500); })(),
+      isAlive: () => true,           // never exits, so the forced pass is reached
+      execFile: (file, args) => {
+        calls.push({ file, args: [...args] });
+        const joined = args.join(" ");
+        if (joined.includes("Get-AppxPackage")) return DISCOVERY;
+        if (joined.includes("Win32_Process")) {
+          listings += 1;
+          // First two listings: the process we verified. Third (pre-taskkill
+          // re-check): same PID, different CreationDate — a recycled PID.
+          return listings >= 3 ? "1000 900 T-RECYCLED" : "1000 900 T0";
+        }
+        return "";
+      },
+    };
+    const result = withTrustedExes(() => restartCodexDesktopApp(io));
+    expect(calls.some(c => c.file === TASKKILL)).toBe(false);
+    expect(result.surviving).toEqual([]);
+  });
+
+  test("an unreadable ancestry chain fails closed instead of assuming we are outside it", () => {
+    const calls: Call[] = [];
+    const result = withTrustedExes(() => restartCodexDesktopApp({
+      platform: "win32",
+      sleep: () => {},
+      isAlive: () => false,
+      // No ancestryPids override: production walks the chain via CIM, and here
+      // that walk throws.
+      execFile: (file, args) => {
+        calls.push({ file, args: [...args] });
+        const joined = args.join(" ");
+        if (joined.includes("Get-AppxPackage")) return DISCOVERY;
+        if (joined.includes("ProcessId=")) throw new Error("cim unavailable");
+        if (joined.includes("Win32_Process")) return "1000 900 T0";
+        return "";
+      },
+    }));
+    expect(result.reason).toBe("self_ancestry");
+    expect(calls.some(c => c.file === TASKKILL)).toBe(false);
+    expect(calls.some(c => c.args.join(" ").includes("CloseMainWindow"))).toBe(false);
+  });
+
+  test("the ancestry walk climbs past the immediate parent", () => {
+    const calls: Call[] = [];
+    const parents: Record<number, string> = { 900: "800", 800: "1000", 1000: "0" };
+    const result = withTrustedExes(() => restartCodexDesktopApp({
+      platform: "win32",
+      sleep: () => {},
+      isAlive: () => false,
+      execFile: (file, args) => {
+        calls.push({ file, args: [...args] });
+        const joined = args.join(" ");
+        if (joined.includes("Get-AppxPackage")) return DISCOVERY;
+        const hop = /ProcessId=(\d+)/.exec(joined);
+        // The chain is self -> 900 -> 800 -> 1000, so the target IS an ancestor
+        // several hops up. A process.ppid-only check would have missed it.
+        if (hop) return parents[Number(hop[1])] ?? String(900);
+        if (joined.includes("Win32_Process")) return "1000 900 T0";
+        return "";
+      },
+    }));
+    expect(result.reason).toBe("self_ancestry");
+    expect(calls.some(c => c.file === TASKKILL)).toBe(false);
+  });
+});
+


### PR DESCRIPTION
## Summary

Adds an opt-in `--restart-desktop-app` flag to `ocx sync` and `ocx sync-cache` for #2292: on Windows, the model picker stays stale after `--restart-codex`.

`--restart-codex` deliberately signals only `codex app-server` / `codex-code-mode-host` processes — `isCodexAppServerCommandLine` requires a `codex` executable token, so the Electron shell that owns the picker is never a match. macOS recovers anyway, because the respawned app-server re-emits `codex-app-server-initialized` and the renderer drops its cached `model/list`. Windows MSIX does not.

So this is a **separate flag**, not a widening. Quitting the desktop app ends live conversations — a different consent from restarting a background helper — and the registry contract for `--restart-codex` promises the narrow behavior. macOS and Linux are unaffected; passing the flag there prints a no-op rather than acting.

## Kill authority is bounded on four axes

This is the only CLI path that terminates a user's application, so each guard is proved by an injected test rather than asserted in a comment:

| Guard | Why |
|---|---|
| Runtime package discovery via `Get-AppxPackage` | the beta MSIX family changes per build, so a hardcoded AUMID eventually matches nothing — or something we did not mean |
| `ChatGPT.exe` under the discovered `InstallLocation` **and** owned by the current user | a `WindowsApps` package directory is shared, so path scoping alone matches another account's desktop app. The app-server collector already pays for `GetOwner` for exactly this reason |
| PID re-verified against `CreationDate` before the graceful close **and** before `taskkill` | the graceful window is long enough for Windows to recycle a PID, and the forced pass is `/T /F` against a whole tree |
| Bounded CIM ancestry walk, not `process.ppid` | a terminal hosted inside the desktop app sits several hops below `ChatGPT.exe`; a one-level check misses the exact case the guard exists for |

Discovery failure, self-ancestry, an unreadable ancestry chain, and any surviving target all **skip the relaunch** and tell the user to restart manually. A stale picker is a much smaller problem than a wrongly terminated process.

The stale-app-server warning, the doctor action line, and CLI help now mention the Windows flag, so a Windows user is no longer pointed only at the flag that cannot refresh their picker.

## Verification

```
bun x tsc --noEmit                              exit 0
bun test tests/desktop-app-restart.test.ts      16 pass / 0 fail
bun test tests/codex-app-server-processes.test.ts  46 pass / 1 skip / 0 fail
bun test tests/cli-dispatch.test.ts              9 pass / 0 fail
bun run privacy:scan                            Privacy scan passed
```

Every branch is driven through the `DesktopAppRestartIo` seam plus `setTrustedWindowsElevationExecutablesForTests`, so the guards are verified on macOS CI — including the recycled-PID case (third listing returns a different `CreationDate`; `taskkill` is never called) and the multi-hop ancestry case.

**What is not claimed:** the end-to-end picker refresh needs a real Windows host. This PR proves the kill/relaunch contract and its refusals, not that the renderer re-reads the catalog on a live machine.

## Checklist

- [x] Focused regression tests added for every guard
- [x] `tsc` clean, `privacy:scan` green
- [x] Opt-in: `--restart-codex` cannot imply it (locked by a source test)
- [x] No behavior change on macOS/Linux

Refs #2292


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `--restart-desktop-app` option to `sync` and `sync-cache` on Windows.
  * Sync can now fully restart the Codex desktop app to refresh the model picker.
  * Added clear status reporting for unsupported platforms, restart failures, and successful relaunches.

* **Documentation**
  * Updated troubleshooting guidance with the desktop app restart option for stale catalog and process issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->