### PR TITLE
fix(zcode): tolerate derived model metadata drift

### DIFF
--- a/docs-site/src/content/docs/reference/cli/agents.md
+++ b/docs-site/src/content/docs/reference/cli/agents.md
@@ -244,6 +244,16 @@ differs. A relative path in any of those three environment overrides is refused,
 and the client can have different working directories and would otherwise disagree about which
 file is meant.
 
+ZCode 3.8.1 may save runtime-derived `reasoning`, `limit.output`, and default context metadata back
+into the generated `provider.opencodex.models` entries. Managed integration status treats only
+those documented additions as refreshable drift. Provider identity and connection settings,
+including `options.baseURL`, model membership, names, modalities, and any context limit OpenCodex
+emitted authoritatively remain protected; editing them reports `conflict / foreign-edit` instead of
+overwriting the file. An ownership record created by an older OpenCodex version can recover
+automatically when the generated catalog is otherwise unchanged. If both the catalog and the block
+changed, re-apply only after reviewing the file because the older record cannot prove which change
+was ZCode-derived.
+
 :::caution[Merge, never replace]
 `ocx export` never writes your real client config. The destination is printed for you to merge by
 hand, and `--out` refuses to overwrite an existing file without `--force`, because replacing a

--- a/src/integrations/ownership-policy.ts
+++ b/src/integrations/ownership-policy.ts
@@ -1,0 +1,141 @@
+/**
+ * Client-scoped exceptions to strict managed-fragment ownership.
+ *
+ * Most clients must preserve every byte represented by their managed
+ * contribution. A client that persists runtime-derived fields back into an
+ * OpenCodex-owned fragment needs a narrower contract: name the exact paths it
+ * may rewrite, then fingerprint everything else. Keeping that policy here
+ * prevents a client quirk from weakening the shared classifier.
+ */
+import {
+  OPENCODE_PROVIDER_ID,
+  type ManagedContribution,
+  type ManagedFragment,
+} from "../clients/config-export";
+import { canonicalContribution, fingerprint } from "./ownership";
+
+type JsonObject = Record<string, unknown>;
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function pathStartsWith(path: readonly string[], prefix: readonly string[]): boolean {
+  return prefix.length <= path.length && prefix.every((part, index) => path[index] === part);
+}
+
+/** Delete one nested object member and prune only the empty ancestors created by that deletion. */
+function deletePath(root: unknown, path: readonly string[]): void {
+  if (!isObject(root) || path.length === 0) return;
+  const parents: Array<{ parent: JsonObject; key: string }> = [];
+  let cursor: JsonObject = root;
+  for (let index = 0; index < path.length - 1; index += 1) {
+    const key = path[index]!;
+    const next = cursor[key];
+    if (!isObject(next)) return;
+    parents.push({ parent: cursor, key });
+    cursor = next;
+  }
+  delete cursor[path[path.length - 1]!];
+  for (let index = parents.length - 1; index >= 0; index -= 1) {
+    if (Object.keys(cursor).length > 0) break;
+    const { parent, key } = parents[index]!;
+    delete parent[key];
+    cursor = parent;
+  }
+}
+
+function cloneFragment(fragment: ManagedFragment): ManagedFragment {
+  return {
+    path: [...fragment.path],
+    value: structuredClone(fragment.value),
+  };
+}
+
+/**
+ * Paths a client is documented to derive after OpenCodex writes its block.
+ *
+ * ZCode 3.8.1 persists reasoning and output defaults for every generated
+ * model. It may also fill a context default when OpenCodex intentionally
+ * omitted one; an authoritative context emitted by OpenCodex remains
+ * protected and is never listed here.
+ */
+export function refreshablePathsOf(
+  contribution: ManagedContribution,
+): readonly (readonly string[])[] {
+  if (contribution.clientId !== "zcode") return [];
+  const fragment = contribution.fragments.find(candidate => (
+    candidate.path.length === 2
+    && candidate.path[0] === "provider"
+    && candidate.path[1] === OPENCODE_PROVIDER_ID
+  ));
+  if (!fragment || !isObject(fragment.value) || !isObject(fragment.value.models)) return [];
+
+  const paths: string[][] = [];
+  for (const modelId of Object.keys(fragment.value.models).sort()) {
+    const entry = fragment.value.models[modelId];
+    if (!isObject(entry)) continue;
+    const base = [...fragment.path, "models", modelId];
+    paths.push([...base, "reasoning"]);
+    paths.push([...base, "limit", "output"]);
+    const limit = entry.limit;
+    if (!isObject(limit) || typeof limit.context !== "number") {
+      paths.push([...base, "limit", "context"]);
+    }
+  }
+  return paths;
+}
+
+export function validRefreshablePaths(
+  contribution: ManagedContribution,
+  value: unknown,
+): value is readonly (readonly string[])[] {
+  if (contribution.clientId !== "zcode" || !Array.isArray(value) || value.length === 0) {
+    return false;
+  }
+  const fragment = contribution.fragments.find(candidate => (
+    candidate.path.length === 2
+    && candidate.path[0] === "provider"
+    && candidate.path[1] === OPENCODE_PROVIDER_ID
+  ));
+  if (!fragment || !isObject(fragment.value) || !isObject(fragment.value.models)) return false;
+
+  const modelIds = new Set(Object.keys(fragment.value.models));
+  const seen = new Set<string>();
+  return value.every(path => {
+    if (!Array.isArray(path) || !path.every(part => typeof part === "string")) return false;
+    const modelId = path[3];
+    const isReasoning = path.length === 5 && path[4] === "reasoning";
+    const isLimitDefault = path.length === 6
+      && path[4] === "limit"
+      && (path[5] === "output" || path[5] === "context");
+    const key = path.join("\u0000");
+    if (
+      path[0] !== "provider"
+      || path[1] !== OPENCODE_PROVIDER_ID
+      || path[2] !== "models"
+      || typeof modelId !== "string"
+      || !modelIds.has(modelId)
+      || (!isReasoning && !isLimitDefault)
+      || seen.has(key)
+    ) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+/** Fingerprint a contribution after removing only its explicitly refreshable paths. */
+export function protectedContributionFingerprint(
+  contribution: ManagedContribution,
+  refreshablePaths: readonly (readonly string[])[],
+): string {
+  const fragments = contribution.fragments.map(cloneFragment);
+  for (const refreshablePath of refreshablePaths) {
+    for (const fragment of fragments) {
+      if (!pathStartsWith(refreshablePath, fragment.path)) continue;
+      deletePath(fragment.value, refreshablePath.slice(fragment.path.length));
+      break;
+    }
+  }
+  return fingerprint(canonicalContribution({ ...contribution, fragments }));
+}

--- a/src/integrations/ownership.ts
+++ b/src/integrations/ownership.ts
@@ -41,6 +41,16 @@ export interface OwnershipRecord {
   fileFingerprint: string;
   /** Hash of our contribution — detects catalog/port drift. */
   blockFingerprint: string;
+  /**
+   * Hash of the fields the client must not rewrite. Present only when a
+   * client has explicitly declared runtime-derived paths below.
+   */
+  protectedBlockFingerprint?: string;
+  /**
+   * Exact document paths a client may derive after apply. These are recorded
+   * per operation so later catalog changes cannot widen an older grant.
+   */
+  refreshablePaths?: readonly (readonly string[])[];
   /** The exact paths we own. Removal touches these and nothing else. */
   fragmentPaths: readonly (readonly string[])[];
   /**

--- a/src/integrations/state.ts
+++ b/src/integrations/state.ts
@@ -13,6 +13,11 @@ import type { OcxConfig } from "../types";
 import { PARSE_FAILED, loadTarget, parseConfig, type IntegrationIO } from "./config-io";
 import { SNAPSHOT_RETENTION } from "./journal";
 import { canonicalContribution, fingerprint, type OwnershipRecord } from "./ownership";
+import {
+  protectedContributionFingerprint,
+  refreshablePathsOf,
+  validRefreshablePaths,
+} from "./ownership-policy";
 import { INTEGRATION_CLIENTS, type IntegrationClientId } from "./registry";
 import { createIntegrationStateStore, type IntegrationStateStore } from "./store";
 
@@ -106,10 +111,10 @@ export function blockedContainerPath(
  * values lets another integration or a user add a sibling without blocking a
  * later refresh, while a change inside our block still fails closed.
  */
-function recordedFragmentFingerprint(
+function recordedContribution(
   doc: unknown,
   record: OwnershipRecord,
-): string | null {
+): ManagedContribution | null {
   if (
     !Array.isArray(record.fragmentPaths)
     || record.fragmentPaths.length === 0
@@ -125,10 +130,44 @@ function recordedFragmentFingerprint(
     if (value === undefined) return null;
     fragments.push({ path, value });
   }
-  return fingerprint(canonicalContribution({
+  return {
     clientId: record.clientId,
     fragments,
-  }));
+  };
+}
+
+/**
+ * Prove that every protected field still matches what OpenCodex wrote.
+ *
+ * New records carry an operation-scoped protected fingerprint and the exact
+ * paths excluded from it. Legacy records can recover only when the desired
+ * contribution has not moved since apply; otherwise catalog drift and a
+ * foreign edit are indistinguishable, so the classifier keeps failing closed.
+ */
+function recordedBlockIsOwned(
+  doc: unknown,
+  record: OwnershipRecord,
+  desired: ManagedContribution,
+): boolean {
+  const observed = recordedContribution(doc, record);
+  if (!observed) return false;
+  if (fingerprint(canonicalContribution(observed)) === record.blockFingerprint) return true;
+
+  if (
+    typeof record.protectedBlockFingerprint === "string"
+    && validRefreshablePaths(observed, record.refreshablePaths)
+    && record.refreshablePaths.length > 0
+  ) {
+    return protectedContributionFingerprint(observed, record.refreshablePaths)
+      === record.protectedBlockFingerprint;
+  }
+
+  const desiredFingerprint = fingerprint(canonicalContribution(desired));
+  if (desiredFingerprint !== record.blockFingerprint) return false;
+  const legacyPaths = refreshablePathsOf(desired);
+  return legacyPaths.length > 0
+    && protectedContributionFingerprint(observed, legacyPaths)
+      === protectedContributionFingerprint(desired, legacyPaths);
 }
 
 /**
@@ -191,7 +230,7 @@ export function classifyIntegration(input: {
    * conflict no matter what the rest of the file looks like, so the sibling-
    * edit exemption below can never mask it.
    */
-  if (recordedFragmentFingerprint(input.parsed, input.record) !== input.record.blockFingerprint) {
+  if (!recordedBlockIsOwned(input.parsed, input.record, input.contribution)) {
     return { state: "conflict", reason: "foreign-edit" };
   }
   if (!INTEGRATION_CLIENTS[clientId].sourcePreservingYaml

--- a/src/integrations/writer.ts
+++ b/src/integrations/writer.ts
@@ -16,6 +16,7 @@ import { isLoopbackHostname } from "../codex/inject";
 import type { OcxConfig } from "../types";
 import { PARSE_FAILED, defaultIntegrationIO, loadTarget, parseConfig, type IntegrationIO } from "./config-io";
 import { fingerprint, canonicalContribution, fragmentPathsOf, type OwnershipRecord } from "./ownership";
+import { protectedContributionFingerprint, refreshablePathsOf } from "./ownership-policy";
 import { createdContainerPaths, mergeContribution, removeFragments } from "./merge";
 import { INTEGRATION_CLIENTS, isLoopbackOnly, type IntegrationClientId } from "./registry";
 import { classifyIntegration, exportContextOf } from "./state";
@@ -353,12 +354,17 @@ function applyOrRefreshIntegration(input: IntegrationWriteInput, allowAbsent: bo
     opId, clientId, kind: classified.state === "stale" ? "refresh" : "apply", at, configPath,
     snapshot, resultFingerprint: fingerprint(text), resultAbsent: false, priorRecord: record,
   };
+  const refreshablePaths = refreshablePathsOf(contribution);
   return commit({
     io, store, clientId, configPath, before, nextText: text, state: "current",
     priorRecord: record,
     record: {
       clientId, configPath, fileFingerprint: fingerprint(text),
       blockFingerprint: fingerprint(canonicalContribution(contribution)),
+      ...(refreshablePaths.length > 0 ? {
+        protectedBlockFingerprint: protectedContributionFingerprint(contribution, refreshablePaths),
+        refreshablePaths,
+      } : {}),
       fragmentPaths: fragmentPathsOf(contribution), createdContainers: created,
       appliedAt: at, opId,
     },

--- a/structure/00_overview.md
+++ b/structure/00_overview.md
@@ -18,6 +18,7 @@ archaeology, debugging, or source research.
 | [`06_docs-and-release.md`](06_docs-and-release.md) | Public docs site, GitHub Pages, the workflow map, branch and devlog policy, README ownership, release flow. |
 | [`07_design-methodology.md`](07_design-methodology.md) | Design process discipline for new GUI, CLI, and user-facing surfaces. |
 | [`08_openai-provider-tiers.md`](08_openai-provider-tiers.md) | OpenAI Pool/Direct account-mode and API credential/routing invariants. |
+| [`09_client-integrations.md`](09_client-integrations.md) | Third-party client config ownership, state classification, snapshots, refresh, disable, and restore. |
 
 ## Product boundary
 

--- a/structure/09_client-integrations.md
+++ b/structure/09_client-integrations.md
@@ -1,0 +1,86 @@
+# Client Integrations
+
+The client-integration subsystem writes one generated OpenCodex provider contribution into a
+third-party client's existing config without taking ownership of the rest of that file. Its core
+promise is reversibility: apply snapshots first, writes atomically, records exactly what it owns,
+and refuses refresh, disable, or restore when the current file cannot be classified safely.
+
+## Module Responsibilities
+
+| Module | Responsibility |
+| --- | --- |
+| `src/clients/config-export.ts` | Pure per-client config builders and the exact managed fragments each client receives. It never writes files. |
+| `src/integrations/registry.ts` | Canonical config/detection paths, source-preserving YAML declarations, writer-lock behavior, and client IDs. |
+| `src/integrations/config-io.ts` | Bounded file loading and parsing. Values that cannot round-trip through the target serializer are rejected before mutation. |
+| `src/integrations/state.ts` | The single `absent` / `current` / `stale` / `conflict` / `unsafe` classifier used by status and every writer operation. |
+| `src/integrations/ownership.ts` | Durable ownership records: file, generated contribution, protected contribution, exact fragment paths, and operation identity. |
+| `src/integrations/ownership-policy.ts` | Client-scoped declarations for fields a client is documented to derive after apply. It must never contain a broad format-wide exemption. |
+| `src/integrations/writer.ts` | Apply, refresh, disable, and restore transactions, including snapshot-first ordering, compare-before-commit, and compensation. |
+| `src/integrations/store.ts` / `journal.ts` | One-root persistence for ownership records, operation history, snapshots, and retention maintenance. |
+
+## Data Flow
+
+```text
+client registry + export context
+  -> build managed contribution
+  -> load and parse current config
+  -> classify exact recorded fragments
+  -> snapshot prior bytes
+  -> merge or remove only recorded paths
+  -> compare current bytes again
+  -> atomic write
+  -> ownership record + operation journal
+```
+
+Status and mutation must use the same classifier. A special case added only to a status endpoint
+would be misleading because refresh or disable could still reject the same file; a special case
+added only to a writer would let a mutation bypass the state users saw.
+
+## Ownership Axes
+
+`fileFingerprint` records the exact whole-file result for restore and for serializers that may lose
+comments. `blockFingerprint` records the exact generated contribution and detects catalog, model,
+port, or provider drift. `fragmentPaths` bounds disable to the paths OpenCodex actually created.
+
+Clients normally protect every field in every recorded fragment. A client that writes documented,
+runtime-derived fields back into an owned fragment may additionally record:
+
+- `refreshablePaths`: the exact document paths that client may derive for this operation;
+- `protectedBlockFingerprint`: the contribution fingerprint after only those paths are removed.
+
+The paths are stored with the operation instead of recomputed from the latest catalog. That keeps a
+later catalog expansion from silently widening what an older ownership record allows. Malformed or
+incomplete policy records fail closed.
+
+## ZCode Runtime Metadata
+
+ZCode 3.8.1 persists model defaults into `provider.opencodex.models.*` after OpenCodex writes the
+provider. The accepted derived paths are deliberately narrow:
+
+- `reasoning` for model IDs emitted by that apply;
+- `limit.output` for model IDs emitted by that apply;
+- `limit.context` only when OpenCodex emitted no authoritative context for that model.
+
+Provider identity and connection fields (`name`, `kind`, `enabled`, `source`, and every `options`
+member), model membership, model names, modalities, and authoritative context limits remain
+protected. Changing any of them stays `conflict / foreign-edit`.
+
+Records written before the protected fingerprint existed can recover from ZCode-derived metadata
+only while the desired contribution is still identical to the one recorded at apply time. If the
+catalog also changed, the old record cannot distinguish catalog drift from a foreign edit and must
+fail closed. A successful refresh writes the new operation-scoped policy.
+
+[Decision Log]
+- 목적과 의도: Allow ZCode's documented runtime normalization without turning genuine provider or connection edits into refreshable drift.
+- 기존 구현 및 제약 조건: The classifier hashed the whole `provider.opencodex` fragment. That was safe for ordinary JSON clients but made every ZCode save a permanent foreign edit. Refresh and disable both depend on the same ownership proof.
+- 검토한 주요 대안: Ignore all model metadata; compare only the provider connection envelope; hard-code a ZCode branch directly in `state.ts`; store explicit operation-scoped mutable paths and a protected fingerprint.
+- 선택한 방식: Keep the strict generated contribution hash, add a separate protected fingerprint, and persist the exact ZCode-derived paths with each ownership record through a client-scoped policy module.
+- 다른 대안 대신 이 방식을 선택한 이유: Ignoring all model metadata would allow user model edits to be overwritten. Comparing only the connection envelope would stop protecting model membership and capabilities. A state-only special case would disagree with writer behavior. Operation-scoped paths preserve the original grant across later catalog changes.
+- 장점, 단점 및 영향: Normal ZCode saves become refreshable, connection edits still fail closed, and later catalog refreshes remain possible. Legacy records with simultaneous catalog drift still require a conservative manual recovery because the old schema did not store enough evidence.
+
+## Verification
+
+Behavior changes require real writer tests against a temporary home and state store. At minimum,
+cover accepted derived metadata, protected connection edits, protected authoritative context,
+catalog changes after a derived rewrite, and legacy-record fail-closed behavior. Synthetic
+fingerprint-only tests are supplementary; they cannot prove the status and writer paths agree.

--- a/tests/integrations-writer.test.ts
+++ b/tests/integrations-writer.test.ts
@@ -2,10 +2,12 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import type { ExportModel } from "../src/clients/config-export";
+import { buildClientContribution, type ExportModel } from "../src/clients/config-export";
 import { fileIO, type IntegrationIO } from "../src/integrations/config-io";
+import { protectedContributionFingerprint } from "../src/integrations/ownership-policy";
 import { INTEGRATION_CLIENTS } from "../src/integrations/registry";
 import { createIntegrationStateStore, type IntegrationStateStore } from "../src/integrations/store";
+import { exportContextOf, readIntegrationState } from "../src/integrations/state";
 import {
   applyIntegration,
   disableIntegration,
@@ -90,6 +92,14 @@ function installOmp(): string {
 
 function installDsh(): string {
   const spec = INTEGRATION_CLIENTS.dsh;
+  mkdirSync(spec.detectDir(TEST_ENV, home), { recursive: true });
+  const configPath = spec.configPath(TEST_ENV, home);
+  mkdirSync(dirname(configPath), { recursive: true });
+  return configPath;
+}
+
+function installZcode(): string {
+  const spec = INTEGRATION_CLIENTS.zcode;
   mkdirSync(spec.detectDir(TEST_ENV, home), { recursive: true });
   const configPath = spec.configPath(TEST_ENV, home);
   mkdirSync(dirname(configPath), { recursive: true });
@@ -193,6 +203,178 @@ describe("apply", () => {
     const third = applyIntegration(input({ clientId: "pi" }));
     expect(third.ok).toBe(true);
     if (third.ok) expect(third.changed).toBe(false);
+  });
+
+  test("ZCode runtime-derived model metadata is refreshable without weakening the provider envelope (#2389)", () => {
+    const configPath = installZcode();
+    const models: ExportModel[] = [
+      ...MODELS,
+      { namespaced: "mystery/model", provider: "mystery", id: "model" },
+    ];
+    const request = input({ clientId: "zcode", models });
+    expect(applyIntegration(request).ok).toBe(true);
+
+    const record = store.readRecords().zcode!;
+    expect(record.protectedBlockFingerprint).toMatch(/^[0-9a-f]{16}$/);
+    expect(record.refreshablePaths).toContainEqual([
+      "provider", "opencodex", "models", "mystery/model", "limit", "context",
+    ]);
+    expect(record.refreshablePaths).not.toContainEqual([
+      "provider", "opencodex", "models", "anthropic/claude-opus-4-8", "limit", "context",
+    ]);
+
+    const document = JSON.parse(readFileSync(configPath, "utf8")) as {
+      provider: Record<string, {
+        models: Record<string, Record<string, unknown>>;
+        options: Record<string, unknown>;
+      }>;
+    };
+    const provider = document.provider.opencodex!;
+    const authoritative = provider.models["anthropic/claude-opus-4-8"]!;
+    authoritative.reasoning = { enabled: true, variants: ["off", "high"] };
+    (authoritative.limit as Record<string, unknown>).output = 64_000;
+    provider.models["mystery/model"]!.limit = { context: 128_000, output: 32_000 };
+    provider.models["mystery/model"]!.reasoning = { enabled: false };
+    writeFileSync(configPath, `${JSON.stringify(document, null, 2)}\n`);
+
+    const status = readIntegrationState(request);
+    expect(status.state).toBe("stale");
+    expect(status.reason).toBeUndefined();
+
+    const refreshed = applyIntegration(request);
+    expect(refreshed.ok).toBe(true);
+    if (refreshed.ok) expect(refreshed.changed).toBe(true);
+
+    const after = JSON.parse(readFileSync(configPath, "utf8")) as typeof document;
+    expect(after.provider.opencodex!.models["anthropic/claude-opus-4-8"]!.reasoning).toBeUndefined();
+    expect((after.provider.opencodex!.models["anthropic/claude-opus-4-8"]!.limit as Record<string, unknown>).output).toBeUndefined();
+    expect(after.provider.opencodex!.models["mystery/model"]!.limit).toBeUndefined();
+  });
+
+  test("a legacy ZCode record accepts derived drift only while its generated catalog is unchanged (#2389)", () => {
+    const configPath = installZcode();
+    const request = input({ clientId: "zcode" });
+    expect(applyIntegration(request).ok).toBe(true);
+
+    const legacy = { ...store.readRecords().zcode! };
+    delete legacy.protectedBlockFingerprint;
+    delete legacy.refreshablePaths;
+    store.putRecord(legacy);
+
+    const document = JSON.parse(readFileSync(configPath, "utf8")) as {
+      provider: Record<string, { models: Record<string, Record<string, unknown>> }>;
+    };
+    document.provider.opencodex!.models["anthropic/claude-opus-4-8"]!.reasoning = { enabled: true };
+    writeFileSync(configPath, `${JSON.stringify(document, null, 2)}\n`);
+
+    expect(readIntegrationState(request).state).toBe("stale");
+    expect(applyIntegration(request).ok).toBe(true);
+  });
+
+  test("a recorded ZCode policy keeps derived drift refreshable across later catalog changes (#2389)", () => {
+    const configPath = installZcode();
+    const request = input({ clientId: "zcode" });
+    expect(applyIntegration(request).ok).toBe(true);
+
+    const document = JSON.parse(readFileSync(configPath, "utf8")) as {
+      provider: Record<string, { models: Record<string, Record<string, unknown>> }>;
+    };
+    document.provider.opencodex!.models["anthropic/claude-opus-4-8"]!.reasoning = { enabled: true };
+    writeFileSync(configPath, `${JSON.stringify(document, null, 2)}\n`);
+
+    const changedCatalog = input({
+      clientId: "zcode",
+      models: [...MODELS, { namespaced: "new/model", provider: "new", id: "model" }],
+    });
+    expect(readIntegrationState(changedCatalog).state).toBe("stale");
+    const result = applyIntegration(changedCatalog);
+    expect(result.ok).toBe(true);
+    const after = JSON.parse(readFileSync(configPath, "utf8")) as typeof document;
+    expect(after.provider.opencodex!.models["new/model"]).toBeDefined();
+  });
+
+  test("a legacy ZCode record fails closed when derived drift overlaps catalog drift (#2389)", () => {
+    const configPath = installZcode();
+    const request = input({ clientId: "zcode" });
+    expect(applyIntegration(request).ok).toBe(true);
+
+    const legacy = { ...store.readRecords().zcode! };
+    delete legacy.protectedBlockFingerprint;
+    delete legacy.refreshablePaths;
+    store.putRecord(legacy);
+
+    const document = JSON.parse(readFileSync(configPath, "utf8")) as {
+      provider: Record<string, { models: Record<string, Record<string, unknown>> }>;
+    };
+    document.provider.opencodex!.models["anthropic/claude-opus-4-8"]!.reasoning = { enabled: true };
+    writeFileSync(configPath, `${JSON.stringify(document, null, 2)}\n`);
+
+    const changedCatalog = input({
+      clientId: "zcode",
+      models: [...MODELS, { namespaced: "new/model", provider: "new", id: "model" }],
+    });
+    expect(readIntegrationState(changedCatalog)).toMatchObject({
+      state: "conflict",
+      reason: "foreign-edit",
+    });
+  });
+
+  test("ZCode connection edits remain a hard conflict after derived-drift support (#2389)", () => {
+    const configPath = installZcode();
+    const request = input({ clientId: "zcode" });
+    expect(applyIntegration(request).ok).toBe(true);
+
+    const document = JSON.parse(readFileSync(configPath, "utf8")) as {
+      provider: Record<string, { options: Record<string, unknown> }>;
+    };
+    document.provider.opencodex!.options.baseURL = "http://user-edited.invalid/v1";
+    writeFileSync(configPath, `${JSON.stringify(document, null, 2)}\n`);
+
+    const status = readIntegrationState(request);
+    expect(status).toMatchObject({ state: "conflict", reason: "foreign-edit" });
+    const result = applyIntegration(request);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("conflict");
+  });
+
+  test("a malformed recorded ZCode policy cannot widen refreshable drift (#2389)", () => {
+    const configPath = installZcode();
+    const request = input({ clientId: "zcode" });
+    expect(applyIntegration(request).ok).toBe(true);
+
+    const refreshablePaths = [["provider", "opencodex", "options", "baseURL"]] as const;
+    const contribution = buildClientContribution("zcode", exportContextOf(request));
+    store.putRecord({
+      ...store.readRecords().zcode!,
+      refreshablePaths,
+      protectedBlockFingerprint: protectedContributionFingerprint(contribution, refreshablePaths),
+    });
+
+    const document = JSON.parse(readFileSync(configPath, "utf8")) as {
+      provider: Record<string, { options: Record<string, unknown> }>;
+    };
+    document.provider.opencodex!.options.baseURL = "http://user-edited.invalid/v1";
+    writeFileSync(configPath, `${JSON.stringify(document, null, 2)}\n`);
+
+    expect(readIntegrationState(request)).toMatchObject({
+      state: "conflict",
+      reason: "foreign-edit",
+    });
+  });
+
+  test("ZCode cannot rewrite an authoritative OpenCodex context limit (#2389)", () => {
+    const configPath = installZcode();
+    const request = input({ clientId: "zcode" });
+    expect(applyIntegration(request).ok).toBe(true);
+
+    const document = JSON.parse(readFileSync(configPath, "utf8")) as {
+      provider: Record<string, { models: Record<string, Record<string, unknown>> }>;
+    };
+    const model = document.provider.opencodex!.models["anthropic/claude-opus-4-8"]!;
+    (model.limit as Record<string, unknown>).context = 1;
+    writeFileSync(configPath, `${JSON.stringify(document, null, 2)}\n`);
+
+    expect(readIntegrationState(request)).toMatchObject({ state: "conflict", reason: "foreign-edit" });
   });
 
   test("json disable after a sibling edit keeps the sibling (#1631)", () => {


### PR DESCRIPTION
## Summary

Fixes #2389.

ZCode 3.8.1 writes runtime-derived model metadata back into the OpenCodex-managed `provider.opencodex` block. The previous whole-fragment fingerprint treated that normal client rewrite as a permanent `conflict / foreign-edit`.

This PR introduces a client-scoped ownership-policy boundary:

- keeps provider identity, all connection options, model membership, names, modalities, and authoritative context limits protected;
- permits only recorded ZCode-derived `reasoning`, `limit.output`, and `limit.context` where OpenCodex emitted no authoritative context;
- persists an operation-scoped protected fingerprint and exact refreshable paths so a later catalog cannot widen an older grant;
- keeps legacy records fail-closed when catalog drift and client-derived drift cannot be distinguished;
- uses the same classifier for status, refresh, and disable;
- documents the integration ownership architecture and ZCode exception.

## Regression coverage

Real writer/state tests cover:

- accepted ZCode-derived metadata;
- connection edit remains a hard conflict;
- authoritative context edit remains a hard conflict;
- catalog refresh after recorded derived drift;
- legacy unchanged-catalog recovery;
- legacy catalog-drift fail-closed behavior;
- malformed policy records cannot widen the allowed paths.

## Verification

- `bun test tests/integrations-writer.test.ts tests/integrations-state.test.ts tests/zcode-client.test.ts` — 99 passed, 0 failed
- `bun run typecheck` — passed
- `git diff --check` — passed
- Full repository suite is running under the two-core CPU cap; this PR remains draft until that exact-head result is recorded.

No repository security/privacy scan was run in this task.

## Branch disposition

Targets `dev`. The repository currently has no remote `dev2-go` branch, and this change belongs to the TypeScript-only third-party client integration ownership subsystem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ZCode integrations now handle runtime-derived metadata changes without overwriting authoritative provider, connection, model catalog, or context-limit settings.
  * Unsafe or conflicting changes are reported for review instead of being overwritten.
  * Older integration records can recover automatically when the model catalog remains unchanged.

* **Documentation**
  * Added guidance covering client integrations, ownership rules, metadata updates, conflicts, and verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->