### PR TITLE
fix(responses): bound upstream error body reads

### DIFF
--- a/src/lib/bounded-body.ts
+++ b/src/lib/bounded-body.ts
@@ -103,6 +103,16 @@ function cancelWithoutWaiting(reader: ReadableStreamDefaultReader<Uint8Array>, r
 	}
 }
 
+function cancelBodyWithoutWaiting(body: ReadableStream<Uint8Array>, reason?: unknown): void {
+	// A signal can already be aborted before a reader is attached. Still settle the
+	// original body so fetch-backed streams cannot retain a rejected read in that gap.
+	try {
+		void body.cancel(reason).catch(() => undefined);
+	} catch {
+		// A locked or non-conforming stream may throw synchronously from cancel().
+	}
+}
+
 /**
  * Consume the original response body as raw bytes under a strict memory ceiling.
  *
@@ -208,9 +218,11 @@ export async function readBoundedResponseBody(
 	options: BoundedBodyOptions = {},
 ): Promise<BoundedBodyResult> {
 	const signal = options.signal;
-	if (signal?.aborted) throw signal.reason;
-
 	const body = response.body;
+	if (signal?.aborted) {
+		if (body) cancelBodyWithoutWaiting(body, signal.reason);
+		throw signal.reason;
+	}
 	if (!body) {
 		return {
 			text: "",

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -634,6 +634,26 @@ async function opaqueBlobRejectionBodyForRecovery(
   }
 }
 
+/**
+ * Materialize an upstream error body only when the bounded reader observed a complete,
+ * display-safe payload. Partial timeout and over-limit prefixes are attacker-controlled,
+ * so callers keep their existing status-only fallback instead.
+ */
+export async function readDisplaySafeErrorText(
+  response: Response,
+  signal: AbortSignal,
+  fallback: string,
+): Promise<string> {
+  try {
+    const body = await readBoundedResponseBody(response, { signal });
+    return body.displaySafe ? body.text : fallback;
+  } catch {
+    // Preserve the former Response.text().catch(fallback) contract. Request-abort
+    // classification remains owned by the surrounding response pipeline.
+    return fallback;
+  }
+}
+
 function prepareOpaqueBlobRecovery(parsed: OcxParsedRequest): void {
   parsed._stripReasoningEncryptedContent = true;
 }
@@ -3546,19 +3566,13 @@ async function handleResponsesInner(
         options.onConsumedComboFailure?.(failure);
         return failure.response;
       }
-      // The plain passthrough error path has no bounded reader of its own: `.text()` attaches
-      // the reader only when it runs, so an abort landing between fetch resolution and that
-      // call orphans Bun's internal read rejection (src/lib/abort.ts).
-      const detachPassthroughErrorGuard = cancelBodyOnAbort(upstreamResponse.body, upstream.signal);
-      try {
-        const errorText = await upstreamResponse.text().catch(() => "");
-        return formatPassthroughUpstreamError(upstreamResponse.status, errorText, {
-          statusText: upstreamResponse.statusText,
-          headers,
-        });
-      } finally {
-        detachPassthroughErrorGuard();
-      }
+      // The bounded reader owns the original body, deadline, abort settlement, and lock.
+      // Unsafe partial data falls back to #452's non-empty status-only JSON.
+      const errorText = await readDisplaySafeErrorText(upstreamResponse, upstream.signal, "");
+      return formatPassthroughUpstreamError(upstreamResponse.status, errorText, {
+        statusText: upstreamResponse.statusText,
+        headers,
+      });
     }
 
     // Bun#32111 workaround: passthrough SSE uses tee()+native relay to avoid the
@@ -4827,14 +4841,16 @@ async function handleResponsesInner(
         options.onConsumedComboFailure?.(failure);
         return failure.response;
       }
-      // The plain error path has no bounded reader of its own: `.text()` attaches the reader
-      // only when it runs, so an abort landing between fetch resolution and that call orphans
-      // Bun's internal read rejection — the uncatchable teardown `cancelBodyOnAbort` absorbs
-      // (src/lib/abort.ts). Found while investigating #1419; not a fix for the native trap.
-      const detachErrorBodyGuard = cancelBodyOnAbort(upstreamResponse.body, upstream.signal);
-      const errorText = await upstreamResponse.text().catch(() => "unknown error");
-      detachErrorBodyGuard();
-      cleanupUpstreamAbort();
+      let errorText: string;
+      try {
+        errorText = await readDisplaySafeErrorText(
+          upstreamResponse,
+          upstream.signal,
+          "unknown error",
+        );
+      } finally {
+        cleanupUpstreamAbort();
+      }
       if (!isFixedCodexAccount(authCtx)) {
         recordSubagentQuotaFailureForThreadSpawn(
           req.headers,
@@ -5125,12 +5141,7 @@ async function handleResponsesInner(
     }
 
     if (!response.ok) {
-      // Same pre-read guard as the initial response's error branch: a non-2xx continuation body
-      // is still a Bun fetch body, and an abort landing before `.text()` attaches its reader
-      // orphans the internal rejection.
-      const detachContinuationErrorGuard = cancelBodyOnAbort(response.body, upstream.signal);
-      const errorText = await response.text().catch(() => "unknown error");
-      detachContinuationErrorGuard();
+      const errorText = await readDisplaySafeErrorText(response, upstream.signal, "unknown error");
       yield {
         type: "error",
         status: response.status,

--- a/tests/bounded-body.test.ts
+++ b/tests/bounded-body.test.ts
@@ -312,6 +312,30 @@ describe("readBoundedResponseBody", () => {
 		}
 	});
 
+	test("an already-aborted signal still settles the original response body", async () => {
+		let cancelReason: unknown;
+		const body = new ReadableStream<Uint8Array>({
+			pull() { return new Promise<never>(() => {}); },
+			cancel(reason) { cancelReason = reason; },
+		}, { highWaterMark: 0 });
+		const response = new Response(body);
+		const controller = new AbortController();
+		const reason = { code: "already-stopped" };
+		controller.abort(reason);
+
+		let caught: unknown;
+		try {
+			await readBoundedResponseBody(response, { signal: controller.signal });
+		} catch (error) {
+			caught = error;
+		}
+		await Promise.resolve();
+
+		expect(caught).toBe(reason);
+		expect(cancelReason).toBe(reason);
+		expect(body.locked).toBe(false);
+	});
+
 	test("parent abort wins when EOF settles in the same turn", async () => {
 		const parent = new AbortController();
 		const reason = new Error("same-turn cancel");

--- a/tests/cancel-body-on-abort.test.ts
+++ b/tests/cancel-body-on-abort.test.ts
@@ -82,12 +82,16 @@ describe("readBodyCapped settles the stream when a read throws", () => {
     expect(source).toContain("detachBodyGuard()");
   });
 
-  test("the passthrough error branch attaches the body guard before consuming it", async () => {
+  test("the bounded reader exclusively owns all non-combo Responses error bodies", async () => {
     const source = await Bun.file(new URL("../src/server/responses/core.ts", import.meta.url)).text();
 
-    const guardAt = source.indexOf("cancelBodyOnAbort(upstreamResponse.body, upstream.signal)");
-    expect(guardAt).toBeGreaterThan(-1);
-    expect(source).toContain("detachPassthroughErrorGuard");
+    expect(source.match(/\breadDisplaySafeErrorText\(/g)).toHaveLength(4);
+    expect(source).not.toContain("detachPassthroughErrorGuard");
+    expect(source).not.toContain("detachErrorBodyGuard");
+    expect(source).not.toContain("detachContinuationErrorGuard");
+    expect(source).not.toContain("upstreamResponse.text().catch(() => \"\")");
+    expect(source).not.toContain("upstreamResponse.text().catch(() => \"unknown error\")");
+    expect(source).not.toContain("response.text().catch(() => \"unknown error\")");
   });
 
   // The combo branches are deliberately NOT guarded: consumeComboFailure ->

--- a/tests/issue-452-empty-503.test.ts
+++ b/tests/issue-452-empty-503.test.ts
@@ -6,10 +6,12 @@ import { clearAccountNeedsReauth, clearAccountQuota, updateAccountQuota } from "
 import { clearCodexUpstreamHealth, clearThreadAccountMap } from "../src/codex/routing";
 import { saveConfig } from "../src/config";
 import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
+import { BOUNDED_BODY_MAX_BYTES } from "../src/lib/bounded-body";
 import { getDebugLogEntries, resetDebugLogBufferForTests } from "../src/lib/debug-log-buffer";
 import { resetDebugSettingsForTests } from "../src/lib/debug-settings";
 import { setDraining } from "../src/server/lifecycle";
 import { startServer } from "../src/server";
+import { readDisplaySafeErrorText } from "../src/server/responses/core";
 import { formatPassthroughUpstreamError } from "../src/server/responses/passthrough-error";
 import type { OcxConfig, OcxParsedRequest } from "../src/types";
 import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
@@ -116,6 +118,73 @@ describe("formatPassthroughUpstreamError (#452)", () => {
   });
 });
 
+describe("bounded passthrough error bodies", () => {
+  test("preserves complete safe bodies, including an intentionally empty body", async () => {
+    const signal = new AbortController().signal;
+    expect(await readDisplaySafeErrorText(new Response("upstream detail"), signal, "fallback"))
+      .toBe("upstream detail");
+    expect(await readDisplaySafeErrorText(new Response(null), signal, "fallback")).toBe("");
+  });
+
+  test("drops an oversized prefix, cancels once, and does not drain the tail", async () => {
+    let pullCount = 0;
+    let cancelCount = 0;
+    let tailPulled = false;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pullCount += 1;
+        if (pullCount === 1) {
+          controller.enqueue(new Uint8Array(BOUNDED_BODY_MAX_BYTES).fill(0x61));
+        } else if (pullCount === 2) {
+          controller.enqueue(new Uint8Array([0x62]));
+        } else {
+          tailPulled = true;
+          controller.enqueue(new Uint8Array([0x63]));
+        }
+      },
+      cancel() { cancelCount += 1; },
+    }, { highWaterMark: 0 });
+
+    const text = await readDisplaySafeErrorText(
+      new Response(body),
+      new AbortController().signal,
+      "status only",
+    );
+    await Promise.resolve();
+
+    expect(text).toBe("status only");
+    expect(cancelCount).toBe(1);
+    expect(tailPulled).toBe(false);
+    expect(body.locked).toBe(false);
+  });
+
+  test("uses the fallback after a read rejection or caller abort", async () => {
+    const failing = new ReadableStream<Uint8Array>({
+      pull() { throw new Error("upstream reset"); },
+    });
+    expect(await readDisplaySafeErrorText(
+      new Response(failing),
+      new AbortController().signal,
+      "fallback",
+    )).toBe("fallback");
+    expect(failing.locked).toBe(false);
+
+    let cancelReason: unknown;
+    const pending = new ReadableStream<Uint8Array>({
+      pull() { return new Promise<never>(() => {}); },
+      cancel(reason) { cancelReason = reason; },
+    }, { highWaterMark: 0 });
+    const controller = new AbortController();
+    const reason = { code: "caller-abort" };
+    const reading = readDisplaySafeErrorText(new Response(pending), controller.signal, "fallback");
+    controller.abort(reason);
+    expect(await reading).toBe("fallback");
+    await Promise.resolve();
+    expect(cancelReason).toBe(reason);
+    expect(pending.locked).toBe(false);
+  });
+});
+
 async function withPoolPassthrough(
   reply: (request: Request) => Response | Promise<Response>,
   run: (serverUrl: string) => Promise<void>,
@@ -189,6 +258,33 @@ describe("passthrough empty 503 (#452)", () => {
         expect(typeof json.error?.message).toBe("string");
         expect(json.error!.message!.trim().length).toBeGreaterThan(0);
         expect(json.error!.message!.toLowerCase()).not.toBe("unknown error");
+      },
+    );
+  });
+
+  test("oversized passthrough errors become bounded status-only JSON", async () => {
+    const hostilePrefix = "do-not-relay-this-prefix";
+    const body = hostilePrefix + "x".repeat(BOUNDED_BODY_MAX_BYTES + 1);
+    await withPoolPassthrough(
+      () => new Response(body, {
+        status: 418,
+        statusText: "Upstream Teapot",
+        headers: { "content-type": "text/plain", "retry-after": "4" },
+      }),
+      async (serverUrl) => {
+        const response = await originalGlobalFetch(new URL("/v1/responses", serverUrl), {
+          method: "POST",
+          headers: { "content-type": "application/json", authorization: "Bearer inbound-token" },
+          body: JSON.stringify({ model: "gpt-5.6-sol", input: "hi", stream: false }),
+        });
+        expect(response.status).toBe(418);
+        expect(response.headers.get("content-type")).toContain("application/json");
+        expect(response.headers.get("retry-after")).toBe("4");
+        const text = await response.text();
+        expect(text.length).toBeLessThan(1_024);
+        expect(text).not.toContain(hostilePrefix);
+        const json = JSON.parse(text) as { error?: { message?: string } };
+        expect(json.error?.message).toContain("418");
       },
     );
   });


### PR DESCRIPTION
## Summary

- Bound all three non-combo Responses error-body reads with the existing 64 KiB and timeout-aware reader instead of materializing arbitrary upstream bodies with `Response.text()`.
- Preserve complete safe error bodies, status text, sanitized headers, and `Retry-After`; oversized, stalled, or failed reads now use the existing status-only fallback without exposing an untrusted partial prefix.
- Let the bounded reader exclusively own cancellation and lock release, including settling an original response body when its signal is already aborted before reader attachment.

## Verification

- Bun 1.4 focused server/body suite: 134 passed, 0 failed across `bounded-body`, `cancel-body-on-abort`, `issue-452-empty-503`, `terminal-guard-server`, and `server-combo-failover-e2e`.
- Bun 1.4 focused compatibility suite: 47 passed, 0 failed across `passthrough-abort`, `retry-after-429`, and `cyber-policy-error-fidelity`.
- `bun run typecheck`
- `bun run privacy:scan`
- `git diff --check`
- Independent exact-diff review: no actionable findings.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. No configuration, GUI, or documented public API changes are required.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. The change retains only complete bounded upstream error text and fails closed on unsafe partial data.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of aborted or cancelled response bodies, preserving the original cancellation reason.
  * Prevented error handling from hanging or consuming unbounded response bodies.
  * Added safe fallbacks for oversized, empty, partial, or failed error responses.
  * Preserved status-only error responses and valid retry timing information.

* **Tests**
  * Added regression coverage for cancellation, stream cleanup, bounded reads, and passthrough error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->