### PR TITLE
test(codex): follow #2398 on the oversized pool-retry 400 body (dev is red)

### DIFF
--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -2957,11 +2957,29 @@ describe("server local API auth", () => {
     }
   }, { timeout: SERVER_BUDGET_MS });
 
+  // #2398 changed what the caller sees here, and this test had to move with it.
+  //
+  // The invariant this test exists for is unchanged and still asserted: an oversized 400
+  // must NOT authorize a pool retry, so exactly one account is dispatched and neither
+  // account is marked unhealthy. What changed is the body. Relaying 65 KiB of
+  // attacker-controlled bytes back to the client is precisely what #2398 stopped, so the
+  // caller now gets #452's bounded status-only JSON instead of the original prefix
+  // (pinned from the other side by "oversized passthrough errors become bounded
+  // status-only JSON" in tests/issue-452-empty-503.test.ts).
+  //
+  // The upstream's own headers still survive, which is what keeps pool-retry diagnostics
+  // honest — that part is still checked below.
   test("oversized 400 body never authorizes a pool retry", async () => {
-    const body = `${unsupportedModelBody()}${"x".repeat(65_536)}`;
+    const hostileSuffix = "x".repeat(65_536);
+    const body = `${unsupportedModelBody()}${hostileSuffix}`;
     const harness = await startPoolRetryHarness(() => rejectionResponse(body));
     try {
-      await expectOriginal400(await harness.request(), body);
+      const response = await harness.request();
+      expect(response.status).toBe(400);
+      const text = await response.text();
+      expect(text).not.toContain(hostileSuffix);
+      expect(text.length).toBeLessThan(1_024);
+
       expect(harness.dispatches).toEqual(["acct-pool-a"]);
       expect(getCodexUpstreamHealth("pool-a")).toBeNull();
       expect(getCodexUpstreamHealth("pool-b")).toBeNull();


### PR DESCRIPTION
## Summary

`dev` is currently red. `tests/server-auth.test.ts` → **`oversized 400 body never authorizes a pool retry`** fails at HEAD.

Bisected to #2398:

| commit | result |
|---|---|
| `3611850c5` (#2395, immediately before) | 1 pass, 0 fail |
| `383279cd2` (#2398 merge) | 0 pass, 1 fail |
| `c9d10ed37` (current `dev`) | 0 pass, 1 fail |

### Why it broke

#2398 stopped relaying attacker-controlled upstream error prefixes: an oversized body now becomes #452's bounded status-only JSON instead of being passed through verbatim. That is the right call, and #2398 added `oversized passthrough errors become bounded status-only JSON` (`tests/issue-452-empty-503.test.ts`) to assert it.

It left `oversized 400 body never authorizes a pool retry` asserting the **opposite** — that the original 65 KiB body comes back byte-for-byte. The two tests state contradictory contracts for the same path.

### Why CI did not catch it

Both branches were green on their own heads. The failing test does not exist on #2398's head — it arrived on `dev` from another branch. The test job runs against the PR head, not the merge result, so two independently-green PRs can land a broken `dev`. That is a structural gap, not bad luck: the same shape can recur for any pair touching `src/server/responses/core.ts`.

### The fix

The security intent wins; the stale expectation moves. **The invariant that test exists for is unchanged and still asserted** — an oversized 400 must not authorize a pool retry, so exactly one account is dispatched and neither account is marked unhealthy. Only the body expectation changes, and it now additionally asserts the hostile suffix never reaches the client:

```ts
expect(text).not.toContain(hostileSuffix);
expect(text.length).toBeLessThan(1_024);
```

Test-only change. No source file is touched.

I did first try preserving the upstream headers through the empty-body branch of `formatPassthroughUpstreamError`, since that file's own doc comment promises to keep "original bytes and headers". That broke two of #2398's Retry-After tests, so it is the wrong seam — reverted, and not part of this PR.

## Verification

```
bun run typecheck                                    # green
bun test tests/server-auth.test.ts \
  tests/issue-452-empty-503.test.ts \
  tests/bounded-body.test.ts \
  tests/cancel-body-on-abort.test.ts \
  tests/retry-after-429.test.ts                      # 162 pass, 0 fail
```

Before this change the same two-file run was 103 tests with 1 failure; it is now 103/0.

Full repository suite not run, per standing instruction; this is a test-only change to a path covered by the runs above.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (`devlog/_plan/260823_bug_pr_zero/020_2398_regression.md` on the sidecar branch carries the bisect)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (this preserves #2398's hardening rather than relaxing it)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of oversized authentication errors by returning a concise, bounded response.
  * Prevented potentially hostile trailing content from appearing in error responses.
  * Preserved existing behavior for retry handling and account health.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->