### PR TITLE
fix(management): reject non-object custom-model bodies

### DIFF
--- a/src/server/management/model-routes.ts
+++ b/src/server/management/model-routes.ts
@@ -394,8 +394,10 @@ export async function handleModelRoutes(ctx: ManagementContext): Promise<Respons
   }
 
   if (url.pathname === "/api/custom-models" && req.method === "POST") {
-    let body: { provider?: unknown; modelId?: unknown; displayName?: unknown; contextWindow?: unknown; inputModalities?: unknown; reasoningEfforts?: unknown; defaultReasoningEffort?: unknown };
-    try { body = await readManagementJsonBody(req); } catch (error) { rethrowManagementBodyTooLarge(error); return jsonResponse({ error: "invalid JSON body" }, 400); }
+    let parsedBody: unknown;
+    try { parsedBody = await readManagementJsonBody(req); } catch (error) { rethrowManagementBodyTooLarge(error); return jsonResponse({ error: "invalid JSON body" }, 400); }
+    if (!isPlainRecord(parsedBody)) return jsonResponse({ error: "invalid JSON body" }, 400);
+    const body = parsedBody;
     const provider = typeof body.provider === "string" ? body.provider.trim() : "";
     const modelId = typeof body.modelId === "string" ? body.modelId.trim() : "";
     if (!provider || !modelId) return jsonResponse({ error: "provider and modelId are required" }, 400);
@@ -441,8 +443,10 @@ export async function handleModelRoutes(ctx: ManagementContext): Promise<Respons
   if (customPutMatch && req.method === "PUT") {
     let id: string;
     try { id = decodeURIComponent(customPutMatch[1]); } catch { return jsonResponse({ error: "invalid id encoding" }, 400); }
-    let body: { displayName?: unknown; contextWindow?: unknown; inputModalities?: unknown; modelId?: unknown; reasoningEfforts?: unknown; defaultReasoningEffort?: unknown };
-    try { body = await readManagementJsonBody(req); } catch (error) { rethrowManagementBodyTooLarge(error); return jsonResponse({ error: "invalid JSON body" }, 400); }
+    let parsedBody: unknown;
+    try { parsedBody = await readManagementJsonBody(req); } catch (error) { rethrowManagementBodyTooLarge(error); return jsonResponse({ error: "invalid JSON body" }, 400); }
+    if (!isPlainRecord(parsedBody)) return jsonResponse({ error: "invalid JSON body" }, 400);
+    const body = parsedBody;
     const list = config.customModels ?? [];
     const idx = list.findIndex(cm => cm.id === id);
     if (idx === -1) return jsonResponse({ error: "not found" }, 404);

--- a/tests/catalog-input-modality-enum.test.ts
+++ b/tests/catalog-input-modality-enum.test.ts
@@ -106,6 +106,24 @@ describe("custom-model API rejects out-of-enum input modalities", () => {
     });
   }
 
+  test("POST and PUT reject non-object JSON bodies without persisting", async () => {
+    for (const body of [null, [], "model"]) {
+      persistCalls = 0;
+      const before = structuredClone(fixtureConfig.customModels);
+
+      const posted = await callCustomModels("POST", body);
+      expect(posted?.status).toBe(400);
+      expect(await posted!.json()).toEqual({ error: "invalid JSON body" });
+
+      const put = await callCustomModels("PUT", body, "/api/custom-models/existing-uuid");
+      expect(put?.status).toBe(400);
+      expect(await put!.json()).toEqual({ error: "invalid JSON body" });
+
+      expect(persistCalls).toBe(0);
+      expect(fixtureConfig.customModels).toEqual(before);
+    }
+  });
+
   test("POST refuses a rejected modality with 400 instead of storing it", async () => {
     persistCalls = 0;
     const res = await callCustomModels("POST", {


### PR DESCRIPTION
## Summary

- Require custom-model `POST` and `PUT` JSON bodies to be plain records before field access.
- Return the existing `400 { "error": "invalid JSON body" }` envelope for `null`, arrays, and primitive JSON values.
- Preserve malformed JSON, oversized-body, and valid-object behavior while preventing rejected bodies from reaching persistence.

## Verification

- Bun 1.4 focused regression: `bun test --isolate tests/catalog-input-modality-enum.test.ts` — 31 passed, 0 failed, 107 assertions.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `git diff --check` — passed.
- Independent exact-diff review — no actionable findings.
- Exact head `be305244762bca7078a26adaf474933a37de2a6e`, based directly on `dev` at `4f41a8e936141af7ee828e335da314b9dc1ef761`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. This adds defensive input validation without changing configuration or public API shape.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. This changes no credential or authorization boundary and prevents invalid bodies from reaching persistence.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom model creation and updates now reject invalid JSON bodies, including `null`, arrays, and strings.
  * Invalid requests return a clear HTTP 400 error without modifying existing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->