### PR TITLE
fix(usage): reject persisted rows without provider labels

### DIFF
--- a/src/usage/log.ts
+++ b/src/usage/log.ts
@@ -1142,6 +1142,14 @@ export async function readUsageEntriesForManagement(): Promise<PersistedUsageEnt
   return (await readUsageSnapshotForManagement()).entries;
 }
 
+/** Keep legacy optional fields permissive, but reject rows that cannot be safely attributed. */
+function normalizePersistedUsageRow(value: unknown): PersistedUsageEntry | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const row = value as Record<string, unknown>;
+  if (typeof row.requestId !== "string" || typeof row.provider !== "string") return undefined;
+  return normalizeUsageEntry(row as unknown as PersistedUsageEntry);
+}
+
 export function readUsageEntries(): PersistedUsageEntry[] {
   const path = usageLogPath();
   if (!existsSync(path)) return [];
@@ -1150,10 +1158,8 @@ export function readUsageEntries(): PersistedUsageEntry[] {
   for (const line of lines) {
     if (!line.trim()) continue;
     try {
-      const parsed = JSON.parse(line) as PersistedUsageEntry;
-      if (parsed && typeof parsed === "object" && typeof parsed.requestId === "string") {
-        entries.push(normalizeUsageEntry(parsed));
-      }
+      const parsed = normalizePersistedUsageRow(JSON.parse(line));
+      if (parsed) entries.push(parsed);
     } catch {
       /* keep reading after a partially written or hand-edited line */
     }
@@ -1166,10 +1172,8 @@ function parseUsageLines(lines: string[]): PersistedUsageEntry[] {
   for (const line of lines) {
     if (!line.trim()) continue;
     try {
-      const parsed = JSON.parse(line) as PersistedUsageEntry;
-      if (parsed && typeof parsed === "object" && typeof parsed.requestId === "string") {
-        entries.push(normalizeUsageEntry(parsed));
-      }
+      const parsed = normalizePersistedUsageRow(JSON.parse(line));
+      if (parsed) entries.push(parsed);
     } catch {
       /* skip partial / hand-edited lines */
     }

--- a/tests/usage-log.test.ts
+++ b/tests/usage-log.test.ts
@@ -226,7 +226,7 @@ describe("usage log", () => {
   test("usage byte-prefix truncation and entry-count truncation report independent metadata", async () => {
     writeFileSync(
       usageLogPath(),
-      `${Array.from({ length: 500_001 }, (_, index) => JSON.stringify({ requestId: String(index) })).join("\n")}\n`,
+      `${Array.from({ length: 500_001 }, (_, index) => JSON.stringify({ requestId: String(index), provider: "p" })).join("\n")}\n`,
     );
     const snapshot = await readUsageSnapshotForManagement();
     expect(snapshot.entries).toHaveLength(500_000);
@@ -739,14 +739,26 @@ describe("usage log", () => {
     }]);
   });
 
-  test("skips malformed JSONL lines while keeping valid entries", () => {
+  test("skips malformed JSONL and rows without string usage identities", async () => {
     writeFileSync(usageLogPath(), [
-      "{\"requestId\":\"a\",\"timestamp\":1,\"provider\":\"p\",\"model\":\"m\",\"status\":200,\"durationMs\":1,\"usageStatus\":\"unreported\"}",
+      persistedLine("a"),
       "{not-json",
-      "{\"requestId\":\"b\",\"timestamp\":2,\"provider\":\"p\",\"model\":\"m\",\"status\":200,\"durationMs\":1,\"usageStatus\":\"reported\",\"usage\":{\"inputTokens\":1,\"outputTokens\":2},\"totalTokens\":3}",
+      "null",
+      "42",
+      "[]",
+      "{}",
+      JSON.stringify({ provider: "p", timestamp: 2 }),
+      JSON.stringify({ requestId: 42, provider: "p", timestamp: 2 }),
+      JSON.stringify({ requestId: "missing-provider", timestamp: 2 }),
+      JSON.stringify({ requestId: "null-provider", provider: null, timestamp: 2 }),
+      JSON.stringify({ requestId: "number-provider", provider: 42, timestamp: 2 }),
+      JSON.stringify({ requestId: "object-provider", provider: {}, timestamp: 2 }),
+      JSON.stringify({ requestId: "array-provider", provider: [], timestamp: 2 }),
+      persistedLine("b"),
     ].join("\n"));
 
     expect(readUsageEntries().map(entry => entry.requestId)).toEqual(["a", "b"]);
+    expect((await readUsageEntriesForManagement()).map(entry => entry.requestId)).toEqual(["a", "b"]);
   });
 
   test("keeps missing usage distinct from zero usage", () => {


### PR DESCRIPTION
## Summary

- Reject malformed persisted usage rows unless both `requestId` and `provider` are strings, at both the synchronous and cooperative reader boundaries.
- Preserve the existing permissive normalization of optional legacy fields while skipping only rows whose identity cannot be used safely.
- Prevent one provider-less JSONL row from throwing during provider-label grouping and collapsing `/api/usage` into a `read_failed` empty summary.

## Verification

- Bun 1.4 focused regression: `bun test --isolate tests/usage-log.test.ts tests/usage-summary.test.ts tests/usage-provider-label.test.ts` — 83 passed, 0 failed, 353 assertions.
- Regression coverage includes null, scalar, and array roots; missing or non-string request identities; malformed provider values; both reader paths; and the 500,001-row retention-cap fixture.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `git diff --check` — passed.
- Independent exact-diff review — no actionable findings.
- Exact head `35f0b88cd9486df788318e1f54a6ff72e7a2be6c`, based directly on `dev` at `4f41a8e936141af7ee828e335da314b9dc1ef761`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. This hardens an internal persisted-log read boundary and adds no public API or configuration surface.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. This changes no credential, authorization, or external-input trust boundary.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage log processing to ignore malformed entries and rows missing required request or provider information.
  * Ensured invalid or incomplete log lines no longer interrupt processing of valid entries.
* **Tests**
  * Expanded coverage for invalid usage records across standard and management log readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->