### PR TITLE
fix(gui): ignore stale Startup secondary responses

### DIFF
--- a/gui/src/pages/Startup.tsx
+++ b/gui/src/pages/Startup.tsx
@@ -88,8 +88,14 @@ export default function Startup({ apiBase }: { apiBase: string }) {
   /** True while settings (runtime notice) are still in flight — reserves notice slot height. */
   const [runtimeNoticePending, setRuntimeNoticePending] = useState(() => !cached?.data);
   const paintedRef = useRef(Boolean(cached?.data));
+  const secondaryGenerationRef = useRef(0);
+
+  useEffect(() => () => {
+    secondaryGenerationRef.current += 1;
+  }, [apiBase]);
 
   const fetchStartup = useCallback(async (signal: AbortSignal): Promise<StartupHealthData> => {
+    const secondaryGeneration = ++secondaryGenerationRef.current;
     const keepSecondary = paintedRef.current;
     // Keep prior notice/tray visible on revalidation; only reserve empty slots on first paint.
     if (!keepSecondary) {
@@ -154,7 +160,7 @@ export default function Startup({ apiBase }: { apiBase: string }) {
       // Health drives the main page, so publish it before the lower-priority settings/tray
       // requests finish. Their result updates the existing reserved slots independently.
       void Promise.all([settingsPromise, trayPromise]).then(([settings, trayResult]) => {
-        if (signal.aborted) return;
+        if (signal.aborted || secondaryGeneration !== secondaryGenerationRef.current) return;
         const nextTray = next.platform === "win32" ? trayResult.tray : null;
         if (next.platform === "win32") {
           setTray(nextTray);

--- a/gui/tests/startup-revisit-cache.test.tsx
+++ b/gui/tests/startup-revisit-cache.test.tsx
@@ -108,3 +108,48 @@ test("a revisit with session cache keeps Action required visible without a loadi
   await act(async () => { root.unmount(); });
   container.remove();
 });
+
+test("a superseded settings response cannot overwrite newer Startup cache", async () => {
+  const { createRoot } = await import("react-dom/client");
+  const container = document.createElement("div");
+  document.body.append(container);
+
+  let settingsCalls = 0;
+  let resolveStaleSettings!: (response: Response) => void;
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("/api/startup-health")) return Response.json(atRiskHealth());
+    if (!url.includes("/api/settings")) return new Response(null, { status: 404 });
+    settingsCalls += 1;
+    if (settingsCalls === 1) {
+      return await new Promise<Response>(resolve => { resolveStaleSettings = resolve; });
+    }
+    return Response.json({ codexRuntime: { version: "fresh", newerAvailable: { version: "new" } } });
+  }) as typeof fetch;
+
+  let root!: Root;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<LanguageProvider><Startup apiBase={API_BASE} /></LanguageProvider>);
+  });
+  await act(async () => { await new Promise<void>(r => testWindow.setTimeout(r, 20)); });
+
+  const refresh = Array.from(container.querySelectorAll("button"))
+    .find(button => button.textContent?.includes("Refresh"));
+  expect(refresh).toBeDefined();
+  await act(async () => { refresh?.click(); });
+  await act(async () => { await new Promise<void>(r => testWindow.setTimeout(r, 20)); });
+  expect(settingsCalls).toBe(2);
+  expect(testWindow.sessionStorage.getItem(CACHE_KEY)).toContain("fresh");
+
+  await act(async () => {
+    resolveStaleSettings(Response.json({ codexRuntime: { version: "stale", newerAvailable: { version: "new" } } }));
+    await new Promise<void>(r => testWindow.setTimeout(r, 20));
+  });
+
+  expect(testWindow.sessionStorage.getItem(CACHE_KEY)).toContain("fresh");
+  expect(testWindow.sessionStorage.getItem(CACHE_KEY)).not.toContain("stale");
+
+  await act(async () => { root.unmount(); });
+  container.remove();
+});


### PR DESCRIPTION
## Summary

- fence the detached Startup settings/tray follow-up with a per-request generation after primary health has already rendered
- invalidate older secondary callbacks when Refresh starts, `apiBase` changes, or the component unmounts
- prevent stale secondary responses from overwriting newer UI state or the Startup session cache while preserving the existing early health paint

Exact base: `c44e43f00f1b8001f30292067324fb419e5ffc86`  
Exact head: `8dfdb99f2e451969f3d54bc6647302c0c630375c`

The one-commit recut is patch-equivalent to the pre-rebase change by `git range-diff`; the intervening `dev` changes do not overlap its files.

## Verification

- exact head on Bun `1.4.0-canary.1` (`9fcdea80b`) - focused Startup matrix: **9 passed, 0 failed, 24 expectations**
- the stale-first/fresh-second regression proves a superseded settings response cannot replace the newer cached runtime notice
- GUI `bun x tsc -b` - passed
- focused GUI `oxlint src/pages/Startup.tsx tests/startup-revisit-cache.test.tsx` - passed
- `git diff --check` and clean-worktree readback - passed
- repository-wide local CI was not duplicated for this isolated GUI race fix; exact-head GitHub CI remains the repository gate
- screenshot not applicable: the change adds no layout or visual state; it rejects a superseded asynchronous result that should never become visible

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. This is an internal stale-response guard with no public API or configuration change.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. This changes no credential or authorization behavior.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
