### PR TITLE
fix(images): retain canonical interception for alias choices

### DIFF
--- a/src/images/plan.ts
+++ b/src/images/plan.ts
@@ -48,11 +48,12 @@ export async function planImageBridge(
   if (config.images?.bridgeEnabled !== true) return undefined;
   if (!parsed._imageGeneration) return undefined;
   const toolAllowed = toolChoiceToolPredicate(parsed.options.toolChoice);
-  const toolNames = new Set(
-    [...parsed._imageGeneration.toolNames, IMAGE_GEN_TOOL_NAME]
-      .filter(name => toolAllowed({ name })),
-  );
+  const toolNames = new Set([...parsed._imageGeneration.toolNames].filter(name => toolAllowed({ name })));
+  if (toolAllowed({ name: IMAGE_GEN_TOOL_NAME })) toolNames.add(IMAGE_GEN_TOOL_NAME);
   if (toolNames.size === 0) return undefined;
+  // Responses advertises and rewrites authorized aliases to this synthetic name, so the loop
+  // must always intercept it once any image-generation name has armed the bridge.
+  toolNames.add(IMAGE_GEN_TOOL_NAME);
   // Don't intercept for OpenAI native passthrough
   const host = (() => { try { return new URL(routedProvider.baseUrl).hostname; } catch { return ""; } })();
   if (host === "api.openai.com") return undefined;

--- a/tests/images/plan.test.ts
+++ b/tests/images/plan.test.ts
@@ -116,8 +116,14 @@ describe("planImageBridge", () => {
     parsed.options.toolChoice = { name: "generate_image" };
     const aliasPlan = await planImageBridge(cfg, parsed, routed);
     expect(aliasPlan).toBeDefined();
-    expect(aliasPlan!.toolNames.has("image_gen")).toBe(false);
+    expect(aliasPlan!.toolNames.has("image_gen")).toBe(true);
     expect(aliasPlan!.toolNames.has("generate_image")).toBe(true);
+
+    parsed.options.toolChoice = { allowedTools: ["generate_image"], mode: "required" };
+    const allowedAliasPlan = await planImageBridge(cfg, parsed, routed);
+    expect(allowedAliasPlan).toBeDefined();
+    expect(allowedAliasPlan!.toolNames.has("image_gen")).toBe(true);
+    expect(allowedAliasPlan!.toolNames.has("generate_image")).toBe(true);
   });
 
   test("xAI provider with OAuth only (no API key) → undefined (API-key-only bridge)", async () => {

--- a/tests/images/z-handler-activation.test.ts
+++ b/tests/images/z-handler-activation.test.ts
@@ -28,6 +28,8 @@ const PREV_HOME = process.env.OPENCODEX_HOME;
 
 // --- Activation spies, flipped by the stubbed runners ---
 let imageBridgeRun = false;
+let imageBridgeToolNames: string[] = [];
+let imageBridgeToolChoice: unknown;
 let webSearchRun = false;
 /** Whether the stubbed adapter should expose runTurn (simulates Cursor-style adapters). */
 let useRunTurnAdapter = false;
@@ -71,8 +73,13 @@ beforeAll(async () => {
   const actualLoop = await import("../../src/images/loop");
   mock.module("../../src/images/loop", () => ({
     ...actualLoop,
-    runWithImageBridge: async () => {
+    runWithImageBridge: async (args: {
+      parsed: { options: { toolChoice?: unknown } };
+      plan: { toolNames: Set<string> };
+    }) => {
       imageBridgeRun = true;
+      imageBridgeToolNames = [...args.plan.toolNames].sort();
+      imageBridgeToolChoice = args.parsed.options.toolChoice;
       return new Response("data: {\"type\":\"done\"}\n\n", {
         status: 200, headers: { "content-type": "text/event-stream" },
       });
@@ -123,12 +130,18 @@ function makeConfig(): OcxConfig {
   } as OcxConfig;
 }
 
-function post(stream: boolean, tools: unknown[]): Promise<Response> {
+function post(stream: boolean, tools: unknown[], toolChoice?: unknown): Promise<Response> {
   return handleResponses(
     new Request("http://localhost/v1/responses", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ model: "fixture/model", input: "hello", stream, tools }),
+      body: JSON.stringify({
+        model: "fixture/model",
+        input: "hello",
+        stream,
+        tools,
+        ...(toolChoice !== undefined ? { tool_choice: toolChoice } : {}),
+      }),
     }),
     makeConfig(),
     { model: "", provider: "" } as never,
@@ -141,6 +154,27 @@ describe("image bridge dispatch priority (handler activation)", () => {
     imageBridgeRun = false; webSearchRun = false; mockWsPlan = undefined;
     const res = await post(true, [{ type: "image_generation" }]);
     expect(imageBridgeRun).toBe(true);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+  });
+
+  test("alias-only image tool_choice keeps canonical bridge interception armed", async () => {
+    imageBridgeRun = false;
+    imageBridgeToolNames = [];
+    imageBridgeToolChoice = undefined;
+    webSearchRun = false;
+    mockWsPlan = undefined;
+    const res = await post(
+      true,
+      [
+        { type: "image_generation" },
+        { type: "function", name: "generate_image", parameters: { type: "object" } },
+      ],
+      { type: "function", name: "generate_image" },
+    );
+    expect(imageBridgeRun).toBe(true);
+    expect(imageBridgeToolChoice).toEqual({ name: "image_gen" });
+    expect(imageBridgeToolNames).toContain("generate_image");
+    expect(imageBridgeToolNames).toContain("image_gen");
     expect(res.headers.get("content-type")).toBe("text/event-stream");
   });
 


### PR DESCRIPTION
## Summary

- Keep the canonical synthetic `image_gen` name in the image-bridge interception set after an authorized alias-only tool choice arms the bridge.
- Filter requested aliases before adding the canonical internal representation, so `none` and non-image choices still cannot activate the sidecar.
- Cover named and `allowed_tools` aliases plus the handler boundary where the alias is rewritten to `image_gen` before the bridge loop runs.

## Verification

- Bun 1.4 focused image regressions: `bun test --isolate tests/images/plan.test.ts tests/images/z-handler-activation.test.ts` — 25 passed, 0 failed, 59 assertions.
- The handler regression verifies an alias-only request is rewritten to canonical `image_gen` while both the authorized alias and canonical name remain interceptable.
- `bun run typecheck` — passed.
- Focused `oxlint src/images/plan.ts tests/images/plan.test.ts tests/images/z-handler-activation.test.ts` — passed.
- `bun run privacy:scan` — passed.
- `git diff --check` — passed.
- Independent exact-diff review — no actionable findings.
- Exact head `f73f3d220868fa3ca1a5d376243e9f157b2865dc`, based directly on `dev` at `4f41a8e936141af7ee828e335da314b9dc1ef761`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. This restores an internal alias-to-canonical bridge contract and adds no public API or configuration surface.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. Canonical interception is added only after an already-authorized image name arms the bridge; unrelated and disabled choices remain rejected.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image-generation tool selection when using aliases.
  - Ensured alias-only tool choices activate the image-generation bridge correctly.
  - Preserved both canonical and alias tool names while normalizing selections.
  - Improved streamed output handling for alias-based image-generation requests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->