### PR TITLE
fix(catalog): stop advertising max for grok-4.6

### DIFF
--- a/src/codex/catalog/effort.ts
+++ b/src/codex/catalog/effort.ts
@@ -110,6 +110,13 @@ export function catalogEntryEfforts(entry: RawEntry): string[] {
 
 export const ROUTED_REASONING_LEVELS = [...CODEX_REASONING_LEVELS];
 
+/** grok-4.6's vendor ladder tops at xhigh. Do not advertise synthetic max/ultra. */
+export function isExactGrok46ReasoningLadder(modelId: string | undefined): boolean {
+  if (!modelId) return false;
+  const id = modelId.toLowerCase();
+  return id === "grok-4.6" || id === "grok-4.6-fast";
+}
+
 export function applyCatalogModelMetadata(entry: RawEntry, model?: CatalogModel): void {
   if (!model) return;
   // This marker survives strict catalog normalization and lets sync distinguish a stale

--- a/src/codex/catalog/sync.ts
+++ b/src/codex/catalog/sync.ts
@@ -50,7 +50,7 @@ import {
   resetBundledCatalogCacheForTests,
 } from "./bundled";
 import { isMultiAgentV2Enabled } from "../features";
-import { applyCatalogModelMetadata, applyReasoningLevels, catalogEntryEfforts, clampCatalogModelsToCodexSupport, ensureGpt56ReasoningLevels, ensureUltraReasoningLevel, isGpt56NativeSlug } from "./effort";
+import { applyCatalogModelMetadata, applyReasoningLevels, catalogEntryEfforts, clampCatalogModelsToCodexSupport, ensureGpt56ReasoningLevels, ensureUltraReasoningLevel, isExactGrok46ReasoningLadder, isGpt56NativeSlug } from "./effort";
 import {
   clearGatherRoutedModelsInflight,
   filterCatalogVisibleModels,
@@ -291,6 +291,7 @@ export function deriveEntry(
   contextCap?: NativeContextLimitsInput,
 ): RawEntry {
   const preserveExact = isExactComboCatalogModel(model, exactComboSlugs);
+  const preserveExactReasoning = preserveExact || isExactGrok46ReasoningLadder(model?.id);
   const codexForwardNativeCapabilityAlias = model?.codexForwardNativeCapabilityAlias === true
     ? upstreamNativeEntry(model.id)
     : null;
@@ -335,7 +336,7 @@ export function deriveEntry(
         e,
         model?.reasoningEfforts,
         model?.defaultReasoningEffort,
-        preserveExact || codexForwardNativeCapabilityAlias !== null,
+        preserveExactReasoning || codexForwardNativeCapabilityAlias !== null,
       );
       // This exact provider/model pair is the ChatGPT/Codex forward surface. Keep the pinned
       // native tool/search/responses-lite contract while preserving the routed slug and wire id.
@@ -385,7 +386,7 @@ export function deriveEntry(
   };
   if (isRouted) {
     applyRoutedCodexToolMode(entry, model?.codexToolMode);
-    applyReasoningLevels(entry, model?.reasoningEfforts, model?.defaultReasoningEffort, preserveExact);
+    applyReasoningLevels(entry, model?.reasoningEfforts, model?.defaultReasoningEffort, preserveExactReasoning);
   }
   else {
     applyReasoningLevels(entry, isGpt56NativeSlug(slug) ? undefined : ["low", "medium", "high", "xhigh"]);

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1024,7 +1024,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     // default on `high`, the picker would send `high` explicitly, and the request builder's
     // no-effort fallback to `kimi-k3-max` would never be reached. Mirrors the other K3
     // routes (kimi, kimi-code, opencode-go).
-    modelDefaultReasoningEfforts: { "kimi-k3": "max" },
+    modelDefaultReasoningEfforts: { "kimi-k3": "max", "grok-4.6": "high", "grok-4.6-fast": "high" },
     // Blind Cursor models (Auto routers, Composer, GLM-5.2, GLM-5.3) go through the vision sidecar;
     // multimodal hosts (Claude/Gemini/GPT/Kimi/Grok) take native SelectedImage. The catalog
     // still advertises image for noVision members so Codex can attach (sidecar option B).
@@ -1107,7 +1107,8 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     preserveReasoningContentModels: ["grok-4.6", "grok-4.5", "grok-4.3", "grok-4.20-0309-reasoning"],
     // grok-4.5 reasoning is always-on with low/medium/high (no off tier, no xhigh).
     // grok-4.6 adds xhigh per docs.x.ai/developers/model-capabilities/text/reasoning;
-    // xAI documents high as the upstream default.
+    // xAI documents high as the upstream default. Catalog generation keeps this
+    // ladder exact (no synthetic max/ultra); incoming max still clamps to xhigh.
     modelReasoningEfforts: { "grok-4.6": ["low", "medium", "high", "xhigh"], "grok-4.5": ["low", "medium", "high"] },
     modelDefaultReasoningEfforts: { "grok-4.6": "high" },
     modelContextWindows: {
@@ -1364,11 +1365,12 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
       "kimi-k3": KIMI_CODING_K3_REASONING_EFFORTS,
       "kimi-k2.7-code": [],
       "kimi-k2.7-code-highspeed": [],
+      "grok-4.6": ["low", "medium", "high", "xhigh"],
       ...Object.fromEntries(OPENCODE_GO_THINKING_TOGGLE_MODELS.map(id => [id, THINKING_TOGGLE_EFFORTS])),
       ...Object.fromEntries(OPENCODE_GO_THINKING_BUDGET_MODELS.map(id => [id, THINKING_BUDGET_EFFORTS])),
       ...Object.fromEntries(DEEPSEEK_THINKING_MODELS.map(id => [id, deepseekThinkingEffortsFor(id)])),
     },
-    modelDefaultReasoningEfforts: { "kimi-k3": "max" },
+    modelDefaultReasoningEfforts: { "kimi-k3": "max", "grok-4.6": "high" },
     // glm-5.2 uses identity labels now that `max` is a native Codex level (no alias map);
     // the thinking-toggle map is a REAL wire alias (effort -> enabled/disabled) and stays.
     modelReasoningEffortMap: {

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -1725,6 +1725,33 @@ describe("Google Gemini catalog metadata", () => {
   });
 });
 
+describe("xAI grok-4.6 catalog reasoning ladder", () => {
+  test("advertises low/medium/high/xhigh without synthetic max or ultra", async () => {
+    const xai = {
+      adapter: "openai-chat" as const,
+      baseUrl: "https://api.x.ai/v1",
+      authMode: "oauth" as const,
+      liveModels: false,
+    };
+    enrichProviderFromRegistry("xai", xai);
+    const models = await gatherRoutedModels({
+      port: 0,
+      defaultProvider: "xai",
+      providers: { xai },
+    });
+    const grok46 = buildCatalogEntries(nativeTemplate(), [], models)
+      .find(row => row.slug === "xai/grok-4.6");
+    const grok45 = buildCatalogEntries(nativeTemplate(), [], models)
+      .find(row => row.slug === "xai/grok-4.5");
+
+    expect((grok46?.supported_reasoning_levels as Array<{ effort: string }>).map(level => level.effort))
+      .toEqual(["low", "medium", "high", "xhigh"]);
+    expect(grok46?.default_reasoning_level).toBe("high");
+    expect((grok45?.supported_reasoning_levels as Array<{ effort: string }>).map(level => level.effort))
+      .toEqual(["low", "medium", "high", "max", "ultra"]);
+  });
+});
+
 describe("Cursor Kimi K3 catalog default effort", () => {
   // Regression for the effort-tier ladder added with cursor/kimi-k3: the Cursor ladder is
   // low/high/max with NO medium rung, so applyReasoningLevels' medium -> high -> first

--- a/tests/cursor-static-catalog.test.ts
+++ b/tests/cursor-static-catalog.test.ts
@@ -111,6 +111,11 @@ describe("Cursor static Codex catalog", () => {
       ]);
     expect(entries.find(item => item.slug === "cursor/glm-5.2")?.supported_reasoning_levels)
       .toMatchObject([{ effort: "high" }, { effort: "max" }, { effort: "ultra" }]);
+    expect(entries.find(item => item.slug === "cursor/grok-4.6")?.supported_reasoning_levels)
+      .toMatchObject([{ effort: "low" }, { effort: "medium" }, { effort: "high" }, { effort: "xhigh" }]);
+    expect(entries.find(item => item.slug === "cursor/grok-4.6")?.default_reasoning_level).toBe("high");
+    expect(entries.find(item => item.slug === "cursor/grok-4.6-fast")?.supported_reasoning_levels)
+      .toMatchObject([{ effort: "low" }, { effort: "medium" }, { effort: "high" }, { effort: "xhigh" }]);
 
     for (const modelId of ["auto", "composer-2.5", "gpt-5.5", "gemini-3-pro"]) {
       expect(

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -901,7 +901,7 @@ describe("provider registry parity", () => {
     expect(entry).toBeTruthy();
     expect(entry?.context_window).toBe(500_000);
     expect((entry?.supported_reasoning_levels as { effort: string }[]).map(l => l.effort))
-      .toEqual(["low", "medium", "high", "xhigh", "max", "ultra"]);
+      .toEqual(["low", "medium", "high", "xhigh"]);
     expect(entry?.default_reasoning_level).toBe("high");
   });
 


### PR DESCRIPTION
## Summary

- Stop advertising synthetic Codex `max`/`ultra` on grok-4.6. xAI's ladder is `low` / `medium` / `high` / `xhigh` (`high` default). The picker was still showing Max because `applyReasoningLevels` appends those rungs for `spawn_agent` membership.
- Catalog rows for `xai/grok-4.6`, `cursor/grok-4.6`, and `cursor/grok-4.6-fast` now keep the exact vendor ladder. Incoming `max` still clamps to `xhigh` on the wire.
- OpenCode Go grok-4.6 gets the same explicit ladder so live discovery does not fall back to the full routed list.
- grok-4.5 is unchanged.

Fixes #2420.

## Verification

- `bun test tests/reasoning-effort.test.ts tests/provider-registry-parity.test.ts tests/cursor-static-catalog.test.ts tests/cursor-effort-suffix.test.ts tests/codex-catalog.test.ts` — **287 pass / 0 fail**
- Focused catalog assertion: `xai/grok-4.6` → `["low", "medium", "high", "xhigh"]`, default `high`; `xai/grok-4.5` still `["low", "medium", "high", "max", "ultra"]`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Grok 4.6 and Grok 4.6 Fast reasoning levels.
  * Grok 4.6 now supports low, medium, high, and xhigh reasoning, with high as the default.
  * Cursor and OpenCode Go catalogs now include Grok 4.6 reasoning options.

* **Bug Fixes**
  * Preserved reasoning settings for Grok 4.6 across routed and fallback model entries.
  * Corrected Grok 4.6 metadata while retaining legacy levels for Grok 4.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->