### PR TITLE
fix(xai): stop the undeclared-tool guard from killing hosted x_search turns

### DIFF
--- a/src/providers/xai-transport.ts
+++ b/src/providers/xai-transport.ts
@@ -4,6 +4,27 @@ import { resolveGithubCopilotTransport } from "./github-copilot-transport";
 
 export const XAI_GROK_CLI_BASE_URL = "https://cli-chat-proxy.grok.com/v1";
 
+/** The two hosts that serve xAI's Responses API: the public API and the Grok CLI proxy. */
+const XAI_RESPONSES_HOSTS = new Set(["api.x.ai", "cli-chat-proxy.grok.com"]);
+
+/**
+ * True when this provider's Responses traffic terminates at xAI itself.
+ *
+ * Probed 2026-08-22 one field per request: the two hosts accept and refuse exactly the same
+ * web_search fields, so they are one dialect rather than two. Matching is exact-host over
+ * https, which keeps lookalikes (`api.x.ai.evil.test`) and nonstandard ports out.
+ */
+export function isXaiResponsesDestination(provider: Pick<OcxProviderConfig, "baseUrl">): boolean {
+  try {
+    const url = new URL(provider.baseUrl);
+    return url.protocol === "https:"
+      && XAI_RESPONSES_HOSTS.has(url.hostname.toLowerCase())
+      && (url.port === "" || url.port === "443");
+  } catch {
+    return false;
+  }
+}
+
 export const XAI_GROK_COMPATIBILITY = {
   version: "0.2.93",
   userAgent: "opencodex-grok/0.2.93",

--- a/src/server/responses-undeclared-tool-guard.ts
+++ b/src/server/responses-undeclared-tool-guard.ts
@@ -4,6 +4,22 @@ import { sseDataPayload, type SseBlockRewrite } from "./sse-payload-rewrite";
 /** Item types the client executes through a request-declared wire name. */
 const CLIENT_EXECUTED_CALL_TYPES = new Set(["function_call", "custom_tool_call"]);
 
+/**
+ * Hosted declarations whose response items the PROVIDER executes, keyed by the item type it
+ * emits for them. These need no client answer, so their names are deliberately absent from the
+ * request catalog and must not be read as an undeclared client tool.
+ *
+ * xAI surfaces hosted `x_search` as `custom_tool_call`. Probed 2026-08-22 through the proxy:
+ * a request declaring a named client tool alongside `x_search` produced `response.failed` with
+ * zero output, while the identical request direct to xAI completed normally. Observed call
+ * names were `x_keyword_search` and `x_semantic_search` in one turn, and `x_user_search` on the
+ * other xAI host — three literals for one tool, which is why this keys on the DECLARATION and
+ * the item type, never on the name.
+ */
+export const PROVIDER_EXECUTED_DECLARATION_CALL_TYPES = new Map([
+  ["x_search", "custom_tool_call"],
+]);
+
 /** Nameless declaration kinds whose response items still require client execution. */
 const NAMELESS_CLIENT_DECLARATION_CALL_TYPES = new Map([
   ["local_shell", "local_shell_call"],
@@ -19,6 +35,7 @@ const NAMELESS_CLIENT_CALL_DISPLAY_NAMES = new Map([
 ]);
 
 const EMPTY_DECLARED_NAMELESS_CLIENT_CALL_TYPES: ReadonlySet<string> = new Set();
+const EMPTY_PROVIDER_EXECUTED_CALL_TYPES: ReadonlySet<string> = new Set<string>();
 
 /** Supported hosted/private declarations that carry no client-executable wire name. */
 const NAMELESS_TOOL_SPEC_TYPES = new Set([
@@ -127,6 +144,36 @@ function addNamelessClientCallTypes(callTypes: Set<string>, specs: unknown): voi
   }
 }
 
+function addProviderExecutedCallTypes(callTypes: Set<string>, specs: unknown): void {
+  if (!Array.isArray(specs)) return;
+  for (const spec of specs) {
+    if (!isPlainObject(spec) || typeof spec.type !== "string") continue;
+    const callType = PROVIDER_EXECUTED_DECLARATION_CALL_TYPES.get(spec.type);
+    if (callType) callTypes.add(callType);
+  }
+}
+
+/**
+ * Item types this turn's hosted declarations authorize the PROVIDER to emit unnamed.
+ *
+ * Caller must gate this on the destination actually being that provider; a declaration alone
+ * is not authority, or any upstream could claim a hosted shape it never serves.
+ */
+export function collectProviderExecutedCallTypes(body: unknown): Set<string> {
+  const callTypes = new Set<string>();
+  if (!isPlainObject(body)) return callTypes;
+  addProviderExecutedCallTypes(callTypes, body.tools);
+  if (Array.isArray(body.input)) {
+    for (const item of body.input) {
+      if (
+        isPlainObject(item)
+        && (item.type === "additional_tools" || item.type === "tool_search_output")
+      ) addProviderExecutedCallTypes(callTypes, item.tools);
+    }
+  }
+  return callTypes;
+}
+
 /** Nameless client-call item types authorized by supported request tool declarations. */
 export function collectDeclaredNamelessClientCallTypes(body: unknown): Set<string> {
   const callTypes = new Set<string>();
@@ -190,9 +237,18 @@ function undeclaredNameInItem(
   item: unknown,
   declared: ReadonlySet<string>,
   declaredNamelessClientCallTypes: ReadonlySet<string>,
+  providerExecutedCallTypes: ReadonlySet<string> = EMPTY_PROVIDER_EXECUTED_CALL_TYPES,
 ): string | undefined {
   if (!isPlainObject(item)) return undefined;
   if (typeof item.type !== "string") return undefined;
+  // The provider executes this one itself, so there is no client name to authorize.
+  //
+  // RESIDUAL RISK, deliberate: inside a turn that declared such a hosted tool ON that provider,
+  // a hallucinated client custom tool is exempted too, because the three observed xAI names
+  // prove the name channel carries no signal. The alternative is failing every hosted-search
+  // turn. #1700's protection is untouched for every other turn, provider and item type — the
+  // exemption needs BOTH the destination and the declaration.
+  if (providerExecutedCallTypes.has(item.type)) return undefined;
   const namelessDisplayName = NAMELESS_CLIENT_CALL_DISPLAY_NAMES.get(item.type);
   if (namelessDisplayName !== undefined) {
     // Only Codex's explicit `execution: "client"` form delegates tool search to the client.
@@ -214,14 +270,15 @@ export function undeclaredToolCallName(
   payload: unknown,
   declared: ReadonlySet<string>,
   declaredNamelessClientCallTypes: ReadonlySet<string> = EMPTY_DECLARED_NAMELESS_CLIENT_CALL_TYPES,
+  providerExecutedCallTypes: ReadonlySet<string> = EMPTY_PROVIDER_EXECUTED_CALL_TYPES,
 ): string | undefined {
   if (!isPlainObject(payload)) return undefined;
   if (payload.type === "response.output_item.added" || payload.type === "response.output_item.done") {
-    return undeclaredNameInItem(payload.item, declared, declaredNamelessClientCallTypes);
+    return undeclaredNameInItem(payload.item, declared, declaredNamelessClientCallTypes, providerExecutedCallTypes);
   }
   // Sparse gateways skip incremental items and only ever ship the terminal snapshot.
   if (payload.type === "response.completed" || payload.type === "response.incomplete") {
-    return undeclaredToolCallNameInResponse(payload.response, declared, declaredNamelessClientCallTypes);
+    return undeclaredToolCallNameInResponse(payload.response, declared, declaredNamelessClientCallTypes, providerExecutedCallTypes);
   }
   return undefined;
 }
@@ -231,10 +288,11 @@ export function undeclaredToolCallNameInResponse(
   response: unknown,
   declared: ReadonlySet<string>,
   declaredNamelessClientCallTypes: ReadonlySet<string> = EMPTY_DECLARED_NAMELESS_CLIENT_CALL_TYPES,
+  providerExecutedCallTypes: ReadonlySet<string> = EMPTY_PROVIDER_EXECUTED_CALL_TYPES,
 ): string | undefined {
   if (!isPlainObject(response) || !Array.isArray(response.output)) return undefined;
   for (const item of response.output) {
-    const name = undeclaredNameInItem(item, declared, declaredNamelessClientCallTypes);
+    const name = undeclaredNameInItem(item, declared, declaredNamelessClientCallTypes, providerExecutedCallTypes);
     if (name !== undefined) return name;
   }
   return undefined;
@@ -274,6 +332,7 @@ function failedBlocks(name: string, newline: string): readonly string[] {
 export function createUndeclaredToolCallGuardBlockRewrite(
   declared: ReadonlySet<string>,
   declaredNamelessClientCallTypes: ReadonlySet<string> = EMPTY_DECLARED_NAMELESS_CLIENT_CALL_TYPES,
+  providerExecutedCallTypes: ReadonlySet<string> = EMPTY_PROVIDER_EXECUTED_CALL_TYPES,
 ): SseBlockRewrite {
   let tripped = false;
   return (block: string) => {
@@ -286,7 +345,7 @@ export function createUndeclaredToolCallGuardBlockRewrite(
     } catch {
       return [block];
     }
-    const name = undeclaredToolCallName(parsed, declared, declaredNamelessClientCallTypes);
+    const name = undeclaredToolCallName(parsed, declared, declaredNamelessClientCallTypes, providerExecutedCallTypes);
     if (name === undefined) return [block];
     tripped = true;
     return failedBlocks(name, block.includes("\r\n") ? "\r\n" : "\n");

--- a/src/server/responses-undeclared-tool-guard.ts
+++ b/src/server/responses-undeclared-tool-guard.ts
@@ -5,19 +5,25 @@ import { sseDataPayload, type SseBlockRewrite } from "./sse-payload-rewrite";
 const CLIENT_EXECUTED_CALL_TYPES = new Set(["function_call", "custom_tool_call"]);
 
 /**
- * Hosted declarations whose response items the PROVIDER executes, keyed by the item type it
- * emits for them. These need no client answer, so their names are deliberately absent from the
- * request catalog and must not be read as an undeclared client tool.
+ * Hosted declarations whose response items the PROVIDER executes, keyed by the request
+ * declaration type. These need no client answer, so their names are deliberately absent from
+ * the request catalog and must not be read as an undeclared client tool.
  *
- * xAI surfaces hosted `x_search` as `custom_tool_call`. Probed 2026-08-22 through the proxy:
- * a request declaring a named client tool alongside `x_search` produced `response.failed` with
- * zero output, while the identical request direct to xAI completed normally. Observed call
- * names were `x_keyword_search` and `x_semantic_search` in one turn, and `x_user_search` on the
- * other xAI host — three literals for one tool, which is why this keys on the DECLARATION and
- * the item type, never on the name.
+ * xAI surfaces hosted `x_search` as `custom_tool_call`. Probed 2026-08-23 against the OAuth CLI
+ * destination: its hosted calls use an `xs_call-` call-id prefix. Observed call names were
+ * `x_keyword_search`, `x_semantic_search`, and `x_user_search` — three literals for one tool,
+ * which is why authorization keys on the declaration, item type, and call-id prefix, never on
+ * the name.
  */
-export const PROVIDER_EXECUTED_DECLARATION_CALL_TYPES = new Map([
-  ["x_search", "custom_tool_call"],
+export type ProviderExecutedCallType = Readonly<{
+  itemType: string;
+  callIdPrefix: string;
+}>;
+
+type ProviderExecutedCallTypes = ReadonlySet<ProviderExecutedCallType>;
+
+export const PROVIDER_EXECUTED_DECLARATION_CALL_TYPES = new Map<string, ProviderExecutedCallType>([
+  ["x_search", { itemType: "custom_tool_call", callIdPrefix: "xs_call-" }],
 ]);
 
 /** Nameless declaration kinds whose response items still require client execution. */
@@ -35,7 +41,7 @@ const NAMELESS_CLIENT_CALL_DISPLAY_NAMES = new Map([
 ]);
 
 const EMPTY_DECLARED_NAMELESS_CLIENT_CALL_TYPES: ReadonlySet<string> = new Set();
-const EMPTY_PROVIDER_EXECUTED_CALL_TYPES: ReadonlySet<string> = new Set<string>();
+const EMPTY_PROVIDER_EXECUTED_CALL_TYPES: ReadonlySet<ProviderExecutedCallType> = new Set();
 
 /** Supported hosted/private declarations that carry no client-executable wire name. */
 const NAMELESS_TOOL_SPEC_TYPES = new Set([
@@ -144,7 +150,10 @@ function addNamelessClientCallTypes(callTypes: Set<string>, specs: unknown): voi
   }
 }
 
-function addProviderExecutedCallTypes(callTypes: Set<string>, specs: unknown): void {
+function addProviderExecutedCallTypes(
+  callTypes: Set<ProviderExecutedCallType>,
+  specs: unknown,
+): void {
   if (!Array.isArray(specs)) return;
   for (const spec of specs) {
     if (!isPlainObject(spec) || typeof spec.type !== "string") continue;
@@ -159,8 +168,8 @@ function addProviderExecutedCallTypes(callTypes: Set<string>, specs: unknown): v
  * Caller must gate this on the destination actually being that provider; a declaration alone
  * is not authority, or any upstream could claim a hosted shape it never serves.
  */
-export function collectProviderExecutedCallTypes(body: unknown): Set<string> {
-  const callTypes = new Set<string>();
+export function collectProviderExecutedCallTypes(body: unknown): Set<ProviderExecutedCallType> {
+  const callTypes = new Set<ProviderExecutedCallType>();
   if (!isPlainObject(body)) return callTypes;
   addProviderExecutedCallTypes(callTypes, body.tools);
   if (Array.isArray(body.input)) {
@@ -172,6 +181,20 @@ export function collectProviderExecutedCallTypes(body: unknown): Set<string> {
     }
   }
   return callTypes;
+}
+
+function isAuthorizedProviderExecutedCall(
+  item: Record<string, unknown>,
+  callTypes: ProviderExecutedCallTypes,
+): boolean {
+  if (typeof item.call_id !== "string") return false;
+  for (const callType of callTypes) {
+    if (
+      item.type === callType.itemType
+      && item.call_id.startsWith(callType.callIdPrefix)
+    ) return true;
+  }
+  return false;
 }
 
 /** Nameless client-call item types authorized by supported request tool declarations. */
@@ -237,18 +260,14 @@ function undeclaredNameInItem(
   item: unknown,
   declared: ReadonlySet<string>,
   declaredNamelessClientCallTypes: ReadonlySet<string>,
-  providerExecutedCallTypes: ReadonlySet<string> = EMPTY_PROVIDER_EXECUTED_CALL_TYPES,
+  providerExecutedCallTypes: ProviderExecutedCallTypes = EMPTY_PROVIDER_EXECUTED_CALL_TYPES,
 ): string | undefined {
   if (!isPlainObject(item)) return undefined;
   if (typeof item.type !== "string") return undefined;
-  // The provider executes this one itself, so there is no client name to authorize.
-  //
-  // RESIDUAL RISK, deliberate: inside a turn that declared such a hosted tool ON that provider,
-  // a hallucinated client custom tool is exempted too, because the three observed xAI names
-  // prove the name channel carries no signal. The alternative is failing every hosted-search
-  // turn. #1700's protection is untouched for every other turn, provider and item type — the
-  // exemption needs BOTH the destination and the declaration.
-  if (providerExecutedCallTypes.has(item.type)) return undefined;
+  // The provider executes this exact measured shape itself, so there is no client name to
+  // authorize. The caller supplies these signatures only for the matching destination and
+  // declarations; the item must additionally carry the hosted call-id prefix.
+  if (isAuthorizedProviderExecutedCall(item, providerExecutedCallTypes)) return undefined;
   const namelessDisplayName = NAMELESS_CLIENT_CALL_DISPLAY_NAMES.get(item.type);
   if (namelessDisplayName !== undefined) {
     // Only Codex's explicit `execution: "client"` form delegates tool search to the client.
@@ -270,7 +289,7 @@ export function undeclaredToolCallName(
   payload: unknown,
   declared: ReadonlySet<string>,
   declaredNamelessClientCallTypes: ReadonlySet<string> = EMPTY_DECLARED_NAMELESS_CLIENT_CALL_TYPES,
-  providerExecutedCallTypes: ReadonlySet<string> = EMPTY_PROVIDER_EXECUTED_CALL_TYPES,
+  providerExecutedCallTypes: ProviderExecutedCallTypes = EMPTY_PROVIDER_EXECUTED_CALL_TYPES,
 ): string | undefined {
   if (!isPlainObject(payload)) return undefined;
   if (payload.type === "response.output_item.added" || payload.type === "response.output_item.done") {
@@ -288,7 +307,7 @@ export function undeclaredToolCallNameInResponse(
   response: unknown,
   declared: ReadonlySet<string>,
   declaredNamelessClientCallTypes: ReadonlySet<string> = EMPTY_DECLARED_NAMELESS_CLIENT_CALL_TYPES,
-  providerExecutedCallTypes: ReadonlySet<string> = EMPTY_PROVIDER_EXECUTED_CALL_TYPES,
+  providerExecutedCallTypes: ProviderExecutedCallTypes = EMPTY_PROVIDER_EXECUTED_CALL_TYPES,
 ): string | undefined {
   if (!isPlainObject(response) || !Array.isArray(response.output)) return undefined;
   for (const item of response.output) {
@@ -332,7 +351,7 @@ function failedBlocks(name: string, newline: string): readonly string[] {
 export function createUndeclaredToolCallGuardBlockRewrite(
   declared: ReadonlySet<string>,
   declaredNamelessClientCallTypes: ReadonlySet<string> = EMPTY_DECLARED_NAMELESS_CLIENT_CALL_TYPES,
-  providerExecutedCallTypes: ReadonlySet<string> = EMPTY_PROVIDER_EXECUTED_CALL_TYPES,
+  providerExecutedCallTypes: ProviderExecutedCallTypes = EMPTY_PROVIDER_EXECUTED_CALL_TYPES,
 ): SseBlockRewrite {
   let tripped = false;
   return (block: string) => {

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -315,6 +315,7 @@ import {
   undeclaredToolCallMessage,
   undeclaredToolCallName,
   undeclaredToolCallNameInResponse,
+  type ProviderExecutedCallType,
 } from "../responses-undeclared-tool-guard";
 import { createGithubCopilotResponsesBlockRewrite } from "../github-copilot-responses-repair";
 import { responsesJsonToSseStream } from "../responses-json-events";
@@ -2947,7 +2948,7 @@ async function handleResponsesInner(
     // declaration alone cannot buy the exemption on some other upstream that never serves it.
     const providerExecutedCallTypes = isXaiResponsesDestination(route.provider)
       ? collectProviderExecutedCallTypes(clientToolAuthorizationBody)
-      : new Set<string>();
+      : new Set<ProviderExecutedCallType>();
     let request: Awaited<ReturnType<typeof adapter.buildRequest>>;
     try {
       request = await adapter.buildRequest(parsed, { headers: selectedForwardHeaders, translatorBudget });

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -191,7 +191,7 @@ import {
   rotateProviderTransportOn429,
 } from "../../providers/key-failover";
 import { shouldAttemptImageTierRetry } from "../image-retry";
-import { resolveProviderTransport } from "../../providers/xai-transport";
+import { isXaiResponsesDestination, resolveProviderTransport } from "../../providers/xai-transport";
 import type { WsData } from "../ws-bridge";
 import { codexAccountSelectionForTurn, registerTurn, trackStreamLifetime, unregisterTurn } from "../lifecycle";
 import { redactSecretString, sanitizeLogMetadataString } from "../../lib/redact";
@@ -308,6 +308,7 @@ import {
 import {
   collectDeclaredNamelessClientCallTypes,
   collectDeclaredWireToolNames,
+  collectProviderExecutedCallTypes,
   createUndeclaredToolCallGuardBlockRewrite,
   currentTurnWireToolCatalogBody,
   hasExplicitWireToolCatalog,
@@ -2942,6 +2943,11 @@ async function handleResponsesInner(
     const clientDeclaredNamelessCallTypes = collectDeclaredNamelessClientCallTypes(
       clientToolAuthorizationBody,
     );
+    // Hosted calls the PROVIDER runs itself. Gated on the destination actually being xAI, so a
+    // declaration alone cannot buy the exemption on some other upstream that never serves it.
+    const providerExecutedCallTypes = isXaiResponsesDestination(route.provider)
+      ? collectProviderExecutedCallTypes(clientToolAuthorizationBody)
+      : new Set<string>();
     let request: Awaited<ReturnType<typeof adapter.buildRequest>>;
     try {
       request = await adapter.buildRequest(parsed, { headers: selectedForwardHeaders, translatorBudget });
@@ -3061,6 +3067,7 @@ async function handleResponsesInner(
         payload,
         declaredWireToolNames,
         declaredNamelessClientCallTypes,
+        providerExecutedCallTypes,
       ) !== undefined) {
         inspectionSawUndeclaredTool = true;
       }
@@ -3074,6 +3081,7 @@ async function handleResponsesInner(
             response,
             declaredWireToolNames,
             declaredNamelessClientCallTypes,
+            providerExecutedCallTypes,
           ) !== undefined
         ) {
           return;
@@ -3725,6 +3733,7 @@ async function handleResponsesInner(
           ? createUndeclaredToolCallGuardBlockRewrite(
             declaredWireToolNames,
             declaredNamelessClientCallTypes,
+            providerExecutedCallTypes,
           )
           : undefined,
       ].filter((rewrite): rewrite is NonNullable<typeof rewrite> => rewrite !== undefined);
@@ -3946,6 +3955,7 @@ async function handleResponsesInner(
               JSON.parse(clientJson),
               declaredWireToolNames,
               declaredNamelessClientCallTypes,
+              providerExecutedCallTypes,
             );
           } catch {
             return undefined;

--- a/tests/responses-undeclared-tool-guard.test.ts
+++ b/tests/responses-undeclared-tool-guard.test.ts
@@ -14,6 +14,7 @@ import {
   hasExplicitWireToolCatalog,
   undeclaredToolCallNameInResponse,
   UNDECLARED_TOOL_CALL_ERROR_CODE,
+  type ProviderExecutedCallType,
 } from "../src/server/responses-undeclared-tool-guard";
 import { relaySseWithBlockRewrite } from "../src/server/sse-payload-rewrite";
 import { handleResponses } from "../src/server/responses";
@@ -1252,12 +1253,10 @@ describe("undeclaredToolCallNameInResponse", () => {
 
 /**
  * xAI runs hosted `x_search` itself and reports the activity as a `custom_tool_call` whose name
- * is absent from the request catalog. Probed 2026-08-22: a request declaring a named client tool
- * alongside `x_search` completed normally direct to xAI, but through the proxy produced
- * `response.failed` with zero output — the guard read the provider's own hosted call as an
- * undeclared client tool. Observed names were `x_keyword_search` and `x_semantic_search` in one
- * turn, and `x_user_search` on the other xAI host, so authorization keys on the declaration and
- * the item type, never on the name.
+ * is absent from the request catalog. Probed 2026-08-23 against the OAuth CLI destination: the
+ * provider's hosted calls carry an `xs_call-` call-id prefix. Observed names were
+ * `x_keyword_search`, `x_semantic_search`, and `x_user_search`, so authorization keys on the
+ * declaration, item type, and call-id prefix, never on the name.
  */
 describe("provider-executed hosted calls", () => {
   const declared = new Set(["shell"]);
@@ -1272,7 +1271,7 @@ describe("provider-executed hosted calls", () => {
 
   test("authorizes the provider's hosted call under any of its observed names", () => {
     expect(collectProviderExecutedCallTypes({ tools: [{ type: "x_search" }] }))
-      .toEqual(new Set(["custom_tool_call"]));
+      .toEqual(new Set([{ itemType: "custom_tool_call", callIdPrefix: "xs_call-" }]));
     for (const name of ["x_keyword_search", "x_semantic_search", "x_user_search"]) {
       expect(undeclaredToolCallNameInResponse(
         hostedCall(name), declared, nameless, xSearchAuthorized,
@@ -1294,13 +1293,13 @@ describe("provider-executed hosted calls", () => {
     // core.ts passes an empty set unless the route actually terminates at xAI, so a declaration
     // alone cannot buy the exemption on an upstream that never serves the hosted tool.
     expect(undeclaredToolCallNameInResponse(
-      hostedCall("x_keyword_search"), declared, nameless, new Set<string>(),
+      hostedCall("x_keyword_search"), declared, nameless, new Set<ProviderExecutedCallType>(),
     )).toBe("x_keyword_search");
   });
 
   test("#1700 still holds: an undeclared client tool is refused inside an authorized turn", () => {
     expect(undeclaredToolCallNameInResponse(
-      { output: [{ type: "function_call", name: "apply_patch", call_id: "c1" }] },
+      { output: [{ type: "custom_tool_call", name: "apply_patch", call_id: "call_patch" }] },
       declared, nameless, xSearchAuthorized,
     )).toBe("apply_patch");
   });

--- a/tests/responses-undeclared-tool-guard.test.ts
+++ b/tests/responses-undeclared-tool-guard.test.ts
@@ -1311,3 +1311,68 @@ describe("provider-executed hosted calls", () => {
     )).toBeUndefined();
   });
 });
+
+describe("xAI hosted-call authorization through handleResponses", () => {
+  const hostedCall = {
+    type: "custom_tool_call",
+    id: "ctc_search",
+    call_id: "xs_call-1",
+    name: "x_keyword_search",
+    input: "{}",
+    status: "completed",
+  };
+
+  async function post(baseUrl: string): Promise<Response> {
+    const config = {
+      port: 0,
+      defaultProvider: "fixture",
+      providers: {
+        fixture: {
+          adapter: "openai-responses",
+          baseUrl,
+          authMode: "key",
+          apiKey: "fixture-key",
+        },
+      },
+    } as OcxConfig;
+    const savedFetch = globalThis.fetch;
+    globalThis.fetch = (async () => Response.json({
+      id: "resp_search",
+      status: "completed",
+      output: [hostedCall],
+    })) as typeof fetch;
+    try {
+      return await handleResponses(new Request("http://localhost/v1/responses", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "fixture/grok-4.6",
+          stream: false,
+          input: [{ role: "user", content: [{ type: "input_text", text: "search" }] }],
+          tools: [
+            { type: "function", name: "shell", parameters: { type: "object" } },
+            { type: "x_search" },
+          ],
+        }),
+      }), config, { model: "", provider: "" });
+    } finally {
+      globalThis.fetch = savedFetch;
+    }
+  }
+
+  test("accepts the measured xs_call shape for an exact xAI destination", async () => {
+    const response = await post("https://api.x.ai/v1");
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { output: Array<Record<string, unknown>> };
+    expect(body.output[0]).toMatchObject(hostedCall);
+  });
+
+  test("rejects the identical item for a lookalike destination", async () => {
+    const response = await post("https://api.x.ai.evil.test/v1");
+
+    expect(response.status).toBe(502);
+    const body = await response.json() as { error: { message: string } };
+    expect(body.error.message).toContain('undeclared client tool "x_keyword_search"');
+  });
+});

--- a/tests/responses-undeclared-tool-guard.test.ts
+++ b/tests/responses-undeclared-tool-guard.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, test } from "bun:test";
 import {
   collectDeclaredNamelessClientCallTypes,
   collectDeclaredWireToolNames,
+  collectProviderExecutedCallTypes,
   createUndeclaredToolCallGuardBlockRewrite,
   currentTurnWireToolCatalogBody,
   hasExplicitWireToolCatalog,
@@ -1245,6 +1246,69 @@ describe("undeclaredToolCallNameInResponse", () => {
       response,
       new Set(),
       new Set(["computer_call"]),
+    )).toBeUndefined();
+  });
+});
+
+/**
+ * xAI runs hosted `x_search` itself and reports the activity as a `custom_tool_call` whose name
+ * is absent from the request catalog. Probed 2026-08-22: a request declaring a named client tool
+ * alongside `x_search` completed normally direct to xAI, but through the proxy produced
+ * `response.failed` with zero output — the guard read the provider's own hosted call as an
+ * undeclared client tool. Observed names were `x_keyword_search` and `x_semantic_search` in one
+ * turn, and `x_user_search` on the other xAI host, so authorization keys on the declaration and
+ * the item type, never on the name.
+ */
+describe("provider-executed hosted calls", () => {
+  const declared = new Set(["shell"]);
+  const nameless = new Set<string>();
+  const xSearchAuthorized = collectProviderExecutedCallTypes({
+    tools: [{ type: "function", name: "shell" }, { type: "x_search" }],
+  });
+
+  function hostedCall(name: string) {
+    return { output: [{ type: "custom_tool_call", name, call_id: "xs_call-1" }] };
+  }
+
+  test("authorizes the provider's hosted call under any of its observed names", () => {
+    expect(collectProviderExecutedCallTypes({ tools: [{ type: "x_search" }] }))
+      .toEqual(new Set(["custom_tool_call"]));
+    for (const name of ["x_keyword_search", "x_semantic_search", "x_user_search"]) {
+      expect(undeclaredToolCallNameInResponse(
+        hostedCall(name), declared, nameless, xSearchAuthorized,
+      )).toBeUndefined();
+    }
+  });
+
+  test("without the x_search declaration the same item is still refused", () => {
+    const noHostedDeclaration = collectProviderExecutedCallTypes({
+      tools: [{ type: "function", name: "shell" }],
+    });
+    expect(noHostedDeclaration.size).toBe(0);
+    expect(undeclaredToolCallNameInResponse(
+      hostedCall("x_keyword_search"), declared, nameless, noHostedDeclaration,
+    )).toBe("x_keyword_search");
+  });
+
+  test("the caller gates on destination: an empty authorization set refuses the same item", () => {
+    // core.ts passes an empty set unless the route actually terminates at xAI, so a declaration
+    // alone cannot buy the exemption on an upstream that never serves the hosted tool.
+    expect(undeclaredToolCallNameInResponse(
+      hostedCall("x_keyword_search"), declared, nameless, new Set<string>(),
+    )).toBe("x_keyword_search");
+  });
+
+  test("#1700 still holds: an undeclared client tool is refused inside an authorized turn", () => {
+    expect(undeclaredToolCallNameInResponse(
+      { output: [{ type: "function_call", name: "apply_patch", call_id: "c1" }] },
+      declared, nameless, xSearchAuthorized,
+    )).toBe("apply_patch");
+  });
+
+  test("a declared client tool is unaffected", () => {
+    expect(undeclaredToolCallNameInResponse(
+      { output: [{ type: "function_call", name: "shell", call_id: "c1" }] },
+      declared, nameless, xSearchAuthorized,
     )).toBeUndefined();
   });
 });

--- a/tests/xai-transport.test.ts
+++ b/tests/xai-transport.test.ts
@@ -3,6 +3,7 @@ import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
 import { parseRequest } from "../src/responses/parser";
 import { buildModelsRequest } from "../src/oauth";
 import {
+  isXaiResponsesDestination,
   resolveProviderTransport,
   deriveXaiConvId,
   XAI_CONV_ID_HEADER,
@@ -50,6 +51,27 @@ function parsed(): OcxParsedRequest {
     options: { reasoning: "low" },
   };
 }
+
+describe("xAI Responses destination detection", () => {
+  test.each([
+    "https://api.x.ai/v1",
+    "https://api.x.ai:443/v1",
+    XAI_GROK_CLI_BASE_URL,
+    "https://CLI-CHAT-PROXY.GROK.COM:443/v1",
+  ])("accepts the exact xAI HTTPS destination %s", baseUrl => {
+    expect(isXaiResponsesDestination({ baseUrl })).toBe(true);
+  });
+
+  test.each([
+    "http://api.x.ai/v1",
+    "https://api.x.ai:444/v1",
+    "https://api.x.ai.evil.test/v1",
+    "https://cli-chat-proxy.grok.com.evil.test/v1",
+    "not a URL",
+  ])("rejects a non-xAI or malformed destination %s", baseUrl => {
+    expect(isXaiResponsesDestination({ baseUrl })).toBe(false);
+  });
+});
 
 describe("xAI auth-mode transport selection", () => {
   test("OAuth selects the Grok CLI subscription transport and required headers", () => {


### PR DESCRIPTION
## Summary

- xAI executes hosted `x_search` itself and reports the activity as a `custom_tool_call` whose name is absent from the request catalog.
- In the measured 2026-08-22 reproduction, the same request with a named `shell` tool plus `x_search` returned a complete answer directly from xAI, but failed through OpenCodex with `response.failed`, no `response.completed`, and zero output text.
- The fix authorizes only the measured provider-owned shape when all four scopes match:
  1. the Responses destination is exactly `api.x.ai` or `cli-chat-proxy.grok.com` over HTTPS on the standard port;
  2. the turn declared `x_search`;
  3. the response item is a `custom_tool_call`; and
  4. its `call_id` begins with the measured `xs_call-` prefix.
- Call names are deliberately not matched because the two xAI destinations emitted `x_keyword_search`, `x_semantic_search`, and `x_user_search` for the same hosted declaration.

## Verification

**Exact head `0beeac1c9`, rebased onto `02c302a54`**

- `./node_modules/.bin/bun test tests/responses-undeclared-tool-guard.test.ts tests/xai-transport.test.ts tests/core-lab-boundary.test.ts` — 121 passed on Bun 1.4.0. This includes exact xAI hosts, HTTPS/default 443, malformed/lookalike/nonstandard destinations, missing `x_search`, wrong call-id namespace, undeclared `apply_patch`, and the protected core-to-Lab import graph.
- `./node_modules/.bin/bun run typecheck` — passed.
- `./node_modules/.bin/bun run privacy:scan` — passed.
- `git diff --check upstream/dev...HEAD` — passed.
- First exact-head `./node_modules/.bin/bun run test --parallel=4` reached a terminal non-green summary: 14,589 pass / 11 skip / 4 fail / 3 errors across 908 files in 243.98s. The surfaced failure was the unrelated CL-07 `oversized patch fails safely` case.
- `./node_modules/.bin/bun test tests/lab-fabric-task.test.ts --rerun-each 10` then passed 460/460, including ten consecutive passes of that oversized-patch case.
- A second full 4-way run passed the CL-07 area but later hit two unrelated `tests/release-helper.test.ts` 30-second timeouts under suite load; it was stopped after the failures were established. No test process remained.
- Because the full suite is not terminal green, local-CI/readiness remain unchecked. This authentication/authorization boundary still requires an independent maintainer security approval before merge; the prior maintainer recheck dismissed its requested changes but explicitly deferred final approval until review-ready.

## Residual risk

Names carry no stable authorization signal, so an exact xAI turn that declared `x_search` will accept any `custom_tool_call` name when its `call_id` is in the measured `xs_call-` namespace. The exemption does not extend to a different destination, a turn without `x_search`, another item type, or another call-id prefix. In particular, the existing undeclared `apply_patch` guard remains active.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing xAI Responses destinations, including supported Grok endpoints.
  * Provider-hosted tools such as `x_search` are now authorized when matching provider call details are present.
* **Bug Fixes**
  * Prevented valid xAI-hosted tool calls from being incorrectly rejected.
  * Continued rejecting undeclared client tools and invalid or spoofed destinations.
* **Tests**
  * Added coverage for supported xAI URLs, invalid destinations, and hosted tool authorization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
