### PR TITLE
chore(test): queue only full-suite runs behind the exclusive-run lock

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -5,6 +5,7 @@
 # so a bare `bun test` — or `bun test tests/` (a substring filter that also matches
 # devlog/opencode-cursor/tests/) — drags them in and reports hundreds of spurious failures.
 # `root` pins discovery to ./tests so every invocation stays on the real suite.
+# File-level `--parallel` has no bunfig key; `scripts/test.ts` passes it for `bun run test`.
 # The npm script already uses `bun test ./tests/`; this makes a bare `bun test` behave the same.
 [test]
 root = "tests"

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -59,6 +59,33 @@ export function createIsolatedTestEnvironment(
   };
 }
 
+function hasCliFlag(requested: string[], name: string): boolean {
+  return requested.some(arg => arg === name || arg.startsWith(`${name}=`));
+}
+
+/** True for a filter-less `bun run test`. `--timeout` / `--dots` / `--parallel=N` still count. */
+function isFullSuiteRun(requested: string[]): boolean {
+  return !requested.some(arg => arg !== "-" && !arg.startsWith("-"));
+}
+
+/**
+ * Default `bun test` argv for this repo.
+ *
+ * `--isolate` keeps a fresh global per file, and is the substring the exclusive-run pgrep
+ * matches. `--parallel` is what makes the suite finishable: with isolate alone Bun re-evaluates
+ * the module graph once per file on a single core, so past ~900 files the run stops looking slow
+ * and starts looking hung — measured here at 1 h 29 m with zero output, ~57 % CPU and 8.5 MB RSS,
+ * against ~110-190 s for the identical suite with `--parallel`. A caller-supplied `--parallel=N`
+ * is left alone.
+ */
+export function resolveBunTestArgs(requested: string[]): string[] {
+  const args = ["--isolate"];
+  if (!hasCliFlag(requested, "--parallel")) args.push("--parallel");
+  args.push(...requested);
+  if (isFullSuiteRun(requested)) args.push("./tests/");
+  return args;
+}
+
 /**
  * Other `bun test` runners already on this machine.
  *
@@ -141,7 +168,7 @@ if (import.meta.main) {
     await waitForExclusiveRun(process.pid);
     const startedAt = Date.now();
     const child = Bun.spawnSync(
-      [process.execPath, "test", "--isolate", ...(requestedTests.length > 0 ? requestedTests : ["./tests/"])],
+      [process.execPath, "test", ...resolveBunTestArgs(requestedTests)],
       {
         env: isolated.env,
         stdin: "inherit",
@@ -152,7 +179,7 @@ if (import.meta.main) {
     const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);
     if (requestedTests.length === 0 && elapsedSeconds > 600) {
       console.warn(
-        `[test] the suite took ${elapsedSeconds}s; it normally runs in about 210s on an idle machine. `
+        `[test] the suite took ${elapsedSeconds}s; with --parallel it should finish in a few minutes on an idle machine. `
         + "Check for another test runner, a busy CPU, or a test that started polling something real.",
       );
     }

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -165,7 +165,15 @@ if (import.meta.main) {
   const isolated = createIsolatedTestEnvironment();
   try {
     const requestedTests = process.argv.slice(2);
-    await waitForExclusiveRun(process.pid);
+    // Only full-suite runs queue. The lock guards CPU contention, not state — each run gets its
+    // own mkdtemp sandbox — and the case it was written for is two 900-file suites crawling into
+    // what reads as a hang. A focused file finishes in seconds, so making it wait behind someone
+    // else's multi-minute suite costs more than the contention it avoids. The trade-off is real
+    // though: with --parallel a full run already saturates the machine, so a focused run started
+    // alongside one does slow it.
+    if (isFullSuiteRun(requestedTests)) {
+      await waitForExclusiveRun(process.pid);
+    }
     const startedAt = Date.now();
     const child = Bun.spawnSync(
       [process.execPath, "test", ...resolveBunTestArgs(requestedTests)],

--- a/tests/test-runner.test.ts
+++ b/tests/test-runner.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
 import { isAbsolute, join } from "node:path";
-import { createIsolatedTestEnvironment } from "../scripts/test";
+import { createIsolatedTestEnvironment, resolveBunTestArgs } from "../scripts/test";
 import {
   decodeWindowsIdentityPowerShellOutputForTests,
   windowsIdentityPowerShellCommandForTests,
@@ -67,4 +67,33 @@ describe("test runner isolation", () => {
       }
     },
   );
+});
+
+/**
+ * Without `--parallel`, `--isolate` re-evaluates the module graph once per file on a single
+ * core. Past ~900 files that stops reading as slow and starts reading as hung: measured at
+ * 1 h 29 m with zero output, ~57 % CPU and 8.5 MB RSS, against ~110-190 s for the identical
+ * suite with the flag. These pin the argv so the flag cannot be dropped again silently.
+ */
+describe("bun test argv", () => {
+  test("a filter-less run gets isolate, parallel and the suite path", () => {
+    expect(resolveBunTestArgs([])).toEqual(["--isolate", "--parallel", "./tests/"]);
+  });
+
+  test("a file filter keeps isolate and parallel but no suite path", () => {
+    expect(resolveBunTestArgs(["tests/foo.test.ts"]))
+      .toEqual(["--isolate", "--parallel", "tests/foo.test.ts"]);
+  });
+
+  test("a caller-supplied concurrency is left alone", () => {
+    expect(resolveBunTestArgs(["--parallel=2"]))
+      .toEqual(["--isolate", "--parallel=2", "./tests/"]);
+    expect(resolveBunTestArgs(["--parallel"]))
+      .toEqual(["--isolate", "--parallel", "./tests/"]);
+  });
+
+  test("option-only arguments still count as a full suite run", () => {
+    expect(resolveBunTestArgs(["--timeout=30000"]))
+      .toEqual(["--isolate", "--parallel", "--timeout=30000", "./tests/"]);
+  });
 });


### PR DESCRIPTION
> **Stacked on #2427**, which introduces `isFullSuiteRun`. The first commit here is that PR; review the second. The diff collapses once #2427 lands.

## What changes

`waitForExclusiveRun` currently makes **every** invocation wait, including a single-file run. Behind a full suite that is a multi-minute wait for a check that takes seconds — the common case while implementing.

This narrows the wait to full-suite runs.

## What the lock actually guards

**CPU contention, not shared state.** Each invocation gets its own `mkdtemp` sandbox (`createIsolatedTestEnvironment`), so concurrent runs do not collide on `HOME`, `OPENCODEX_HOME` or `CODEX_HOME`. The incident the lock was written for is recorded in its own comment: a suite that normally took ~210 s took **26 minutes** against a runner an earlier session had left behind, and neither process said anything, so the slowdown read as a hang.

## The trade-off, stated plainly

With `--parallel` (#2427) a full run already saturates the machine, so a focused run started alongside one **does** slow it. This is a judgement call, not a free win:

- **for**: blocking every focused check behind a multi-minute suite costs more in daily use than the contention it avoids, and a focused run is bounded at seconds;
- **against**: it removes a guard that exists precisely because contention is invisible and reads as a hang.

Full suites still queue behind each other, which is the case the lock was written for.

This is separated from #2427 exactly because it is a behavior decision rather than a fix — I did not want it riding along inside a PR whose justification is "the suite does not finish".

## Tests

None added. The lock's behavior is process-level (`pgrep` for competing runners plus a wait loop) and I did not find a way to pin it that would not amount to asserting the implementation back to itself. Flagging that rather than adding a test that only restates the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Test runs now use isolated, parallel execution by default for faster and more reliable full-suite testing.
  * Existing file filters and explicitly provided concurrency settings are preserved.
  * Option-only test arguments are handled correctly during full-suite runs.
* **Documentation**
  * Added guidance clarifying where parallel test execution is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->