### PR TITLE
refactor(codex): centralize history manifest contract

### DIFF
--- a/src/codex/history-manifest.ts
+++ b/src/codex/history-manifest.ts
@@ -1,0 +1,112 @@
+import { createHash } from "node:crypto";
+import { isAbsolute, resolve } from "node:path";
+
+/** Sources whose native OpenAI provenance can be restored exactly. */
+export const CODEX_HISTORY_RESUMABLE_SOURCES = ["cli", "vscode"] as const;
+
+export interface CodexHistoryBackupEntry {
+  id: string;
+  rolloutPath: string;
+  modelProvider: string;
+  source: string;
+  hasUserEvent: 0 | 1;
+}
+
+export interface CodexHistoryBackupManifest {
+  version: 1;
+  stateDbPath: string;
+  entries: Record<string, CodexHistoryBackupEntry>;
+}
+
+export type CodexHistoryManifestValidation =
+  | { readonly ok: true; readonly manifest: CodexHistoryBackupManifest }
+  | { readonly ok: false; readonly reason: "foreign-database" }
+  | {
+      readonly ok: false;
+      readonly reason: "schema";
+      readonly scope: "manifest" | "entry-shape" | "entry-provenance";
+    };
+
+function codexHistoryPathIdentity(path: string): string {
+  const canonical = resolve(path);
+  return process.platform === "win32" ? canonical.toLowerCase() : canonical;
+}
+
+/**
+ * Canonical identity used by both backup naming and manifest ownership checks.
+ * Windows paths are case-insensitive for this contract; other platforms keep
+ * the resolved path's case.
+ */
+export function codexHistoryStateDbIdentity(path: string): string {
+  return codexHistoryPathIdentity(path);
+}
+
+/** Stable, non-secret file-name component for one state database. */
+export function codexHistoryBackupId(stateDbPath: string): string {
+  return createHash("sha256")
+    .update(codexHistoryStateDbIdentity(stateDbPath))
+    .digest("hex")
+    .slice(0, 16);
+}
+
+/** Platform-aware identity comparison shared by database and rollout checks. */
+export function sameCodexHistoryPath(left: string, right: string): boolean {
+  return codexHistoryPathIdentity(left) === codexHistoryPathIdentity(right);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasAllowedProvenance(entry: Record<string, unknown>): boolean {
+  return (entry.modelProvider === "openai"
+      && CODEX_HISTORY_RESUMABLE_SOURCES.includes(
+        entry.source as (typeof CODEX_HISTORY_RESUMABLE_SOURCES)[number],
+      ))
+    || (entry.modelProvider === "opencodex" && entry.source === "exec");
+}
+
+/**
+ * Validate only the versioned data contract and database ownership identity.
+ * Filesystem type checks, reads, fingerprints, rollout inspection, SQLite, and
+ * mutation deliberately remain with the callers.
+ */
+export function validateCodexHistoryBackupManifest(
+  raw: unknown,
+  expectedStateDbPath: string,
+): CodexHistoryManifestValidation {
+  if (!isRecord(raw)
+    || raw.version !== 1
+    || typeof raw.stateDbPath !== "string"
+    || !raw.stateDbPath.trim()
+    || !isAbsolute(raw.stateDbPath)
+    || !isRecord(raw.entries)) {
+    return { ok: false, reason: "schema", scope: "manifest" };
+  }
+  if (!sameCodexHistoryPath(raw.stateDbPath, expectedStateDbPath)) {
+    return { ok: false, reason: "foreign-database" };
+  }
+
+  for (const [id, value] of Object.entries(raw.entries)) {
+    if (!isRecord(value)) {
+      return { ok: false, reason: "schema", scope: "entry-shape" };
+    }
+    if (!id
+      || value.id !== id
+      || typeof value.rolloutPath !== "string"
+      || !value.rolloutPath.trim()
+      || !isAbsolute(value.rolloutPath)
+      || typeof value.modelProvider !== "string"
+      || !value.modelProvider.trim()
+      || typeof value.source !== "string"
+      || !value.source.trim()
+      || typeof value.hasUserEvent !== "number"
+      || !Number.isSafeInteger(value.hasUserEvent)
+      || (value.hasUserEvent !== 0 && value.hasUserEvent !== 1)
+      || !hasAllowedProvenance(value)) {
+      return { ok: false, reason: "schema", scope: "entry-provenance" };
+    }
+  }
+
+  return { ok: true, manifest: raw as unknown as CodexHistoryBackupManifest };
+}

--- a/src/codex/history-provider.ts
+++ b/src/codex/history-provider.ts
@@ -1,10 +1,18 @@
 import { createHash } from "node:crypto";
 import { closeSync, existsSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, readSync, statSync, unlinkSync, writeSync } from "node:fs";
-import { dirname, isAbsolute, join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { zstdDecompressSync } from "node:zlib";
 import { Database } from "bun:sqlite";
 import { resolveCodexStateDbPath } from "./paths";
 import { atomicWriteFile, getConfigDir } from "../config";
+import {
+  CODEX_HISTORY_RESUMABLE_SOURCES,
+  codexHistoryBackupId,
+  sameCodexHistoryPath,
+  validateCodexHistoryBackupManifest,
+  type CodexHistoryBackupEntry,
+  type CodexHistoryBackupManifest,
+} from "./history-manifest";
 
 /**
  * Cap for decompressing a lone `.jsonl.zst` rollout during quarantine restore.
@@ -21,11 +29,8 @@ export const MAX_ROLLOUT_ZST_DECOMPRESSED_BYTES = 64 * 1024 * 1024;
  * the same way, since a manifest addressed differently is a different manifest.
  */
 export function historyBackupPathFor(stateDbPath: string): string {
-  const normalized = process.platform === "win32" ? resolve(stateDbPath).toLowerCase() : resolve(stateDbPath);
-  const id = createHash("sha256").update(normalized).digest("hex").slice(0, 16);
-  return join(getConfigDir(), `codex-history-backup-${id}.json`);
+  return join(getConfigDir(), `codex-history-backup-${codexHistoryBackupId(stateDbPath)}.json`);
 }
-const RESUMABLE_SOURCES = ["cli", "vscode"] as const;
 
 /**
  * Open the live `state_5.sqlite` the way the Codex app expects a *secondary* writer to behave:
@@ -256,20 +261,6 @@ function hasFirstUserMessage(value: string | null): boolean {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-interface BackupEntry {
-  id: string;
-  rolloutPath: string;
-  modelProvider: string;
-  source: string;
-  hasUserEvent: number;
-}
-
-interface BackupManifest {
-  version: 1;
-  stateDbPath?: string;
-  entries: Record<string, BackupEntry>;
-}
-
 export interface CodexHistoryVerifiedNoopProof {
   readonly kind: "verified-noop";
   readonly pendingRows: 0;
@@ -311,7 +302,7 @@ type StrictBackupRead =
   | {
       readonly kind: "known";
       readonly present: boolean;
-      readonly manifest: BackupManifest;
+      readonly manifest: CodexHistoryBackupManifest;
       readonly fingerprint: string;
     }
   | {
@@ -350,12 +341,6 @@ export function setAfterStrictHistoryRolloutAppendForTests(hook: (() => void) | 
 /** Test seam: runs after manifest snapshot publication and before apply's database CAS. */
 export function setBeforeHistoryApplyTransactionForTests(hook: (() => void) | undefined): void {
   beforeHistoryApplyTransactionForTests = hook;
-}
-
-function samePath(a: string, b: string): boolean {
-  const left = resolve(a);
-  const right = resolve(b);
-  return process.platform === "win32" ? left.toLowerCase() === right.toLowerCase() : left === right;
 }
 
 function readBackupStrict(path: string, stateDbPath: string): StrictBackupRead {
@@ -401,50 +386,18 @@ function readBackupStrict(path: string, stateDbPath: string): StrictBackupRead {
   } catch {
     return { kind: "unknown", present: true, reason: "manifest-read" };
   }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return { kind: "unknown", present: true, reason: "manifest-schema" };
-  }
-  const manifest = parsed as Partial<BackupManifest>;
-  if (manifest.version !== 1
-    || typeof manifest.stateDbPath !== "string"
-    || !manifest.stateDbPath.trim()
-    || !isAbsolute(manifest.stateDbPath)) {
-    return { kind: "unknown", present: true, reason: "manifest-schema" };
-  }
-  if (!samePath(manifest.stateDbPath, stateDbPath)) {
-    return { kind: "unknown", present: true, reason: "manifest-foreign" };
-  }
-  if (!manifest.entries || typeof manifest.entries !== "object" || Array.isArray(manifest.entries)) {
-    return { kind: "unknown", present: true, reason: "manifest-schema" };
-  }
-  for (const [id, value] of Object.entries(manifest.entries)) {
-    if (!value || typeof value !== "object" || Array.isArray(value)) {
-      return { kind: "unknown", present: true, reason: "manifest-schema" };
-    }
-    const entry = value as Partial<BackupEntry>;
-    if (!id
-      || entry.id !== id
-      || typeof entry.rolloutPath !== "string"
-      || !entry.rolloutPath.trim()
-      || !isAbsolute(entry.rolloutPath)
-      || typeof entry.modelProvider !== "string"
-      || !entry.modelProvider.trim()
-      || typeof entry.source !== "string"
-      || !entry.source.trim()
-      || typeof entry.hasUserEvent !== "number"
-      || !Number.isSafeInteger(entry.hasUserEvent)
-      || (entry.hasUserEvent !== 0 && entry.hasUserEvent !== 1)
-      || !(
-        (entry.modelProvider === "openai" && RESUMABLE_SOURCES.includes(entry.source as (typeof RESUMABLE_SOURCES)[number]))
-        || (entry.modelProvider === "opencodex" && entry.source === "exec")
-      )) {
-      return { kind: "unknown", present: true, reason: "manifest-schema" };
-    }
+  const validated = validateCodexHistoryBackupManifest(parsed, stateDbPath);
+  if (!validated.ok) {
+    return {
+      kind: "unknown",
+      present: true,
+      reason: validated.reason === "foreign-database" ? "manifest-foreign" : "manifest-schema",
+    };
   }
   return {
     kind: "known",
     present: true,
-    manifest: manifest as BackupManifest,
+    manifest: validated.manifest,
     fingerprint: createHash("sha256").update(raw).digest("hex"),
   };
 }
@@ -500,7 +453,7 @@ function consumeBackupIfUnchanged(path: string, stateDbPath: string, expectedFin
   unlinkSync(path);
 }
 
-function writeBackup(path: string, manifest: BackupManifest, stateDbPath?: string): void {
+function writeBackup(path: string, manifest: CodexHistoryBackupManifest, stateDbPath?: string): void {
   if (Object.keys(manifest.entries).length === 0) {
     if (existsSync(path)) unlinkSync(path);
     return;
@@ -509,7 +462,7 @@ function writeBackup(path: string, manifest: BackupManifest, stateDbPath?: strin
   atomicWriteFile(path, JSON.stringify({ ...manifest, stateDbPath: manifest.stateDbPath ?? stateDbPath }, null, 2) + "\n");
 }
 
-function rememberOriginal(manifest: BackupManifest, row: ThreadRow): void {
+function rememberOriginal(manifest: CodexHistoryBackupManifest, row: ThreadRow): void {
   if (manifest.entries[row.id]) return;
   manifest.entries[row.id] = {
     id: row.id,
@@ -531,7 +484,7 @@ function rowMatchesRestoreTuple(
     && row.has_user_event === hasUserEvent;
 }
 
-function rowMatchesExpectedPostImage(row: RestoreRowSnapshot, entry: BackupEntry): boolean {
+function rowMatchesExpectedPostImage(row: RestoreRowSnapshot, entry: CodexHistoryBackupEntry): boolean {
   if (entry.modelProvider === "openai") {
     const postHasUserEvent = hasFirstUserMessage(row.first_user_message) ? 1 : entry.hasUserEvent;
     return rowMatchesRestoreTuple(row, "opencodex", entry.source, postHasUserEvent);
@@ -564,7 +517,7 @@ function normalizedSessionMetaTuple(meta: ParsedSessionMeta): { provider: string
 
 function rolloutMatchesRestoreTuple(
   meta: ParsedSessionMeta,
-  entry: BackupEntry,
+  entry: CodexHistoryBackupEntry,
   provider: string,
   source: string,
 ): boolean {
@@ -574,7 +527,7 @@ function rolloutMatchesRestoreTuple(
     && tuple.source === source;
 }
 
-function rolloutMatchesExpectedPostImage(meta: ParsedSessionMeta, entry: BackupEntry): boolean {
+function rolloutMatchesExpectedPostImage(meta: ParsedSessionMeta, entry: CodexHistoryBackupEntry): boolean {
   if (entry.modelProvider === "openai") {
     const tuple = normalizedSessionMetaTuple(meta);
     const rawSource = meta.record.payload.source;
@@ -591,7 +544,7 @@ function rolloutMatchesExpectedPostImage(meta: ParsedSessionMeta, entry: BackupE
     || rolloutMatchesRestoreTuple(meta, entry, "openai", "cli");
 }
 
-function snapshotRolloutForRestore(entry: BackupEntry): RestoreRolloutSnapshot {
+function snapshotRolloutForRestore(entry: CodexHistoryBackupEntry): RestoreRolloutSnapshot {
   const identityBefore = historyFileIdentity(entry.rolloutPath);
   if (identityBefore === null) {
     throw new CodexHistoryIntegrityError("history_backup_rollout_unrestorable");
@@ -632,7 +585,7 @@ interface RestoreTargetPreflight {
  */
 function preflightRestoreTargets(
   getCurrent: (id: string) => RestoreRowSnapshot | null,
-  entries: BackupEntry[],
+  entries: CodexHistoryBackupEntry[],
 ): RestoreTargetPreflight {
   const snapshots = preflightRestoreRows(getCurrent, entries);
   const rolloutSnapshots = new Map<string, RestoreRolloutSnapshot>();
@@ -647,12 +600,12 @@ function preflightRestoreTargets(
 /** Cheap manifest-to-database authority check used by recurring no-op probes. */
 function preflightRestoreRows(
   getCurrent: (id: string) => RestoreRowSnapshot | null,
-  entries: BackupEntry[],
+  entries: CodexHistoryBackupEntry[],
 ): Map<string, RestoreRowSnapshot> {
   const snapshots = new Map<string, RestoreRowSnapshot>();
   for (const entry of entries) {
     const row = getCurrent(entry.id);
-    if (!row || typeof row.rollout_path !== "string" || !samePath(row.rollout_path, entry.rolloutPath)) {
+    if (!row || typeof row.rollout_path !== "string" || !sameCodexHistoryPath(row.rollout_path, entry.rolloutPath)) {
       throw new CodexHistoryIntegrityError("history_backup_target_mismatch");
     }
     if (!rowMatchesRestoreTuple(row, entry.modelProvider, entry.source, entry.hasUserEvent)
@@ -666,12 +619,12 @@ function preflightRestoreRows(
 
 function assertRestoreReadback(
   getCurrent: (id: string) => RestoreRowSnapshot | null,
-  entries: BackupEntry[],
+  entries: CodexHistoryBackupEntry[],
 ): void {
   for (const entry of entries) {
     const row = getCurrent(entry.id);
     if (!row
-      || !samePath(row.rollout_path, entry.rolloutPath)
+      || !sameCodexHistoryPath(row.rollout_path, entry.rolloutPath)
       || !rowMatchesRestoreTuple(row, entry.modelProvider, entry.source, entry.hasUserEvent)) {
       throw new CodexHistoryIntegrityError("history_backup_database_readback_mismatch");
     }
@@ -1177,7 +1130,7 @@ function syncCodexHistoryProviderUnsafe(provider: CodexHistoryProvider, stateDbP
 
   const db = openStateDb(stateDbPath);
   try {
-    const placeholders = RESUMABLE_SOURCES.map(() => "?").join(",");
+    const placeholders = CODEX_HISTORY_RESUMABLE_SOURCES.map(() => "?").join(",");
     const openaiRows = db
       .query<ApplyRowSnapshot, string[]>(`
         SELECT id, rollout_path, model_provider, source, has_user_event, first_user_message
@@ -1185,7 +1138,7 @@ function syncCodexHistoryProviderUnsafe(provider: CodexHistoryProvider, stateDbP
         WHERE model_provider = 'openai'
           AND source IN (${placeholders})
       `)
-      .all(...RESUMABLE_SOURCES);
+      .all(...CODEX_HISTORY_RESUMABLE_SOURCES);
     const execRows = db
       .query<ApplyRowSnapshot, []>(`
         SELECT id, rollout_path, model_provider, source, has_user_event, first_user_message
@@ -1470,7 +1423,7 @@ export function snapshotCodexHistoryNoop(
   const stateDbPresent = existsSync(stateDbPath);
   const backupPresent = existsSync(backupPath);
   const base = { canonicalStateDbPath, stateDbPresent, canonicalBackupPath, backupPresent };
-  if (!samePath(backupPath, historyBackupPathFor(stateDbPath))) {
+  if (!sameCodexHistoryPath(backupPath, historyBackupPathFor(stateDbPath))) {
     return { kind: "unknown", pendingRows: null, backupEntries: null, ...base, reason: "backup-path" };
   }
   const backup = inspectBackupForNoop(backupPath, stateDbPath);

--- a/src/codex/native-residue.ts
+++ b/src/codex/native-residue.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import {
   closeSync,
   fstatSync,
@@ -11,12 +10,13 @@ import {
   statSync,
 } from "node:fs";
 import type { Stats } from "node:fs";
-import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 
 import { Database } from "bun:sqlite";
 
 import { getConfigDir } from "../config";
 import { catalogHasRoutedEntries, parseCatalogJson } from "./catalog/parsing";
+import { codexHistoryBackupId, validateCodexHistoryBackupManifest } from "./history-manifest";
 import {
   hasInjectedCodexRouting,
   OCX_SECTION_MARKER,
@@ -583,11 +583,7 @@ function classifyHistoryDatabase(path: string): NativeRoutedResidueResult {
 }
 
 function historyBackupPath(stateDatabasePath: string): string {
-  const normalized = process.platform === "win32"
-    ? resolve(stateDatabasePath).toLowerCase()
-    : resolve(stateDatabasePath);
-  const id = createHash("sha256").update(normalized).digest("hex").slice(0, 16);
-  return join(getConfigDir(), `codex-history-backup-${id}.json`);
+  return join(getConfigDir(), `codex-history-backup-${codexHistoryBackupId(stateDatabasePath)}.json`);
 }
 
 function classifyHistoryBackup(path: string, stateDatabasePath: string): NativeRoutedResidueResult {
@@ -600,52 +596,25 @@ function classifyHistoryBackup(path: string, stateDatabasePath: string): NativeR
   } catch (error) {
     return indeterminate("history-backup", read.path, `malformed history backup JSON: ${errorReason(error)}`);
   }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return indeterminate("history-backup", read.path, "history backup has an unknown shape");
-  }
-  const manifest = parsed as Record<string, unknown>;
-  if (manifest.version !== 1
-    || typeof manifest.stateDbPath !== "string"
-    || !manifest.stateDbPath.trim()
-    || !isAbsolute(manifest.stateDbPath)
-    || !manifest.entries
-    || typeof manifest.entries !== "object"
-    || Array.isArray(manifest.entries)) {
-    return indeterminate("history-backup", read.path, "history backup has an unknown shape");
-  }
-  const expected = process.platform === "win32" ? resolve(stateDatabasePath).toLowerCase() : resolve(stateDatabasePath);
-  const actual = process.platform === "win32" ? resolve(manifest.stateDbPath).toLowerCase() : resolve(manifest.stateDbPath);
-  if (actual !== expected) {
+  const validated = validateCodexHistoryBackupManifest(parsed, stateDatabasePath);
+  if (!validated.ok && validated.reason === "foreign-database") {
     return indeterminate("history-backup", read.path, "history backup names a different state database");
   }
-  const entries = Object.entries(manifest.entries as Record<string, unknown>);
+  if (!validated.ok) {
+    return indeterminate(
+      "history-backup",
+      read.path,
+      validated.scope === "entry-shape"
+        ? "history backup entry has an unknown shape"
+        : validated.scope === "entry-provenance"
+          ? "history backup entry has invalid provenance metadata"
+          : "history backup has an unknown shape",
+    );
+  }
+  const entries = Object.entries(validated.manifest.entries);
   const references: RolloutReference[] = [];
-  for (const [id, entry] of entries) {
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
-      return indeterminate("history-backup", read.path, "history backup entry has an unknown shape");
-    }
-    const candidate = entry as Record<string, unknown>;
-    if (!id
-      || typeof candidate.id !== "string"
-      || candidate.id !== id
-      || typeof candidate.rolloutPath !== "string"
-      || !candidate.rolloutPath
-      || !isAbsolute(candidate.rolloutPath)
-      || typeof candidate.modelProvider !== "string"
-      || !candidate.modelProvider
-      || typeof candidate.source !== "string"
-      || !candidate.source
-      || typeof candidate.hasUserEvent !== "number"
-      || !Number.isSafeInteger(candidate.hasUserEvent)
-      || (candidate.hasUserEvent !== 0 && candidate.hasUserEvent !== 1)
-      || !(
-        (candidate.modelProvider === "openai"
-          && (candidate.source === "cli" || candidate.source === "vscode"))
-        || (candidate.modelProvider === "opencodex" && candidate.source === "exec")
-      )) {
-      return indeterminate("history-backup", read.path, "history backup entry has invalid provenance metadata");
-    }
-    references.push({ id: candidate.id, path: candidate.rolloutPath });
+  for (const entry of Object.values(validated.manifest.entries)) {
+    references.push({ id: entry.id, path: entry.rolloutPath });
   }
   const rollouts = classifyReferencedRollouts("history-backup", references);
   if (rollouts.kind !== "clean") return rollouts;

--- a/structure/02_config-and-codex-home.md
+++ b/structure/02_config-and-codex-home.md
@@ -233,6 +233,25 @@ Native Codex sub-agent defaults are a separate, explicit opt-in. When
 overwritten. Disabling the option and fallback restore remove only marker-owned values; journal
 restore must preserve later user edits while stripping those managed values.
 
+### History backup manifest contract
+
+`src/codex/history-manifest.ts` is the pure schema-and-identity leaf for the versioned history
+backup manifest. It owns the accepted provider/source provenance tuples, platform-aware database
+path identity, backup filename id, and validation from unknown JSON to a typed manifest. It does
+not read files, inspect rollouts, open SQLite, retry, fingerprint, write, or delete anything.
+
+`history-provider.ts` remains the strict mutation owner and maps shared validation failures to its
+restore/no-op integrity states. `native-residue.ts` remains a read-only observer and maps the same
+result to clean, residue, or indeterminate before inspecting referenced rollout files.
+
+[Decision Log]
+- 목적과 의도: Make restore and native-residue inspection accept and reject exactly the same versioned history provenance contract.
+- 기존 구현 및 제약 조건: Both modules independently checked version, database identity, entry ids, absolute rollout paths, provider/source tuples, and event markers; drift could make one module restore a manifest that the other refused to classify.
+- 검토한 주요 대안: Keep duplicate validators synchronized through review, import the mutation-heavy history provider into residue inspection, or extract a pure shared leaf.
+- 선택한 방식: Extract only types, path identity, filename id, provenance, and unknown-data validation; keep all filesystem, rollout, SQLite, retry, and mutation policy in the existing callers.
+- 다른 대안 대신 이 방식을 선택한 이유: A pure leaf removes schema drift without pulling write-side effects or database ownership into the read-only startup inspection graph.
+- 장점, 단점 및 영향: Format changes now have one validator and shared invalid fixtures; callers still intentionally own different user-facing failure mappings, so contract changes require updating both mappings and this document.
+
 If the root config selects a provider other than `openai` or `opencodex`, injection must leave the
 config byte-for-byte unchanged and skip profile creation/updates and history metadata restoration. External
 provider managers own that routing configuration, and replacing their provider id can hide

--- a/tests/codex-history-provider.test.ts
+++ b/tests/codex-history-provider.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { classifyRecoverableHistoryError, countPendingOpencodexHistory, historyBackupPathFor, isRecoverableHistoryError, migrateHistoryToOpenai, restoreLegacyOpenaiHistory, setAfterNoopPendingCountForTests, setAfterStrictHistoryRolloutAppendForTests, setBeforeHistoryApplyTransactionForTests, setBeforeHistoryBackupConsumeForTests, setBeforeStrictHistoryRolloutAppendForTests, setHistoryDbBusyTimeoutForTests, snapshotCodexHistoryNoop, syncCodexHistoryProvider, withHistoryRetry } from "../src/codex/history-provider";
+import { INVALID_HISTORY_BACKUP_FIXTURES, validHistoryBackupFixture } from "./helpers/codex-history-manifest-fixtures";
 
 // Windows CI: a transient file lock can consume the full production 5s busy timeout, tripping
 // bun's 5s default per-test timeout by itself. Fail fast into withHistoryRetry instead.
@@ -805,49 +806,8 @@ describe("Design B migration helpers", () => {
     const rolloutPath = join(dir, "rollout.jsonl");
     noopSnapshotArtifacts.add(backupPath);
     noopSnapshotArtifacts.add(dir);
-    type MutableManifest = {
-      version: number;
-      stateDbPath?: unknown;
-      entries: Record<string, {
-        id?: unknown;
-        rolloutPath?: unknown;
-        modelProvider?: unknown;
-        source?: unknown;
-        hasUserEvent?: unknown;
-      }>;
-    };
-    const cases: Array<{ name: string; mutate: (manifest: MutableManifest) => void }> = [
-      { name: "blank stateDbPath", mutate: manifest => { manifest.stateDbPath = ""; } },
-      { name: "relative stateDbPath", mutate: manifest => { manifest.stateDbPath = "state.sqlite"; } },
-      { name: "mismatched id", mutate: manifest => { manifest.entries["thread-1"].id = "thread-2"; } },
-      { name: "missing rolloutPath", mutate: manifest => { delete manifest.entries["thread-1"].rolloutPath; } },
-      { name: "blank rolloutPath", mutate: manifest => { manifest.entries["thread-1"].rolloutPath = ""; } },
-      { name: "relative rolloutPath", mutate: manifest => { manifest.entries["thread-1"].rolloutPath = "rollout.jsonl"; } },
-      { name: "missing modelProvider", mutate: manifest => { delete manifest.entries["thread-1"].modelProvider; } },
-      { name: "mistyped modelProvider", mutate: manifest => { manifest.entries["thread-1"].modelProvider = 7; } },
-      { name: "unsupported modelProvider", mutate: manifest => { manifest.entries["thread-1"].modelProvider = "other"; } },
-      { name: "missing source", mutate: manifest => { delete manifest.entries["thread-1"].source; } },
-      { name: "mistyped source", mutate: manifest => { manifest.entries["thread-1"].source = 7; } },
-      { name: "invalid provider/source tuple", mutate: manifest => { manifest.entries["thread-1"].source = "cli"; } },
-      { name: "missing hasUserEvent", mutate: manifest => { delete manifest.entries["thread-1"].hasUserEvent; } },
-      { name: "mistyped hasUserEvent", mutate: manifest => { manifest.entries["thread-1"].hasUserEvent = "0"; } },
-      { name: "non-boolean hasUserEvent", mutate: manifest => { manifest.entries["thread-1"].hasUserEvent = 2; } },
-    ];
-
-    for (const invalid of cases) {
-      const manifest: MutableManifest = {
-        version: 1,
-        stateDbPath: dbPath,
-        entries: {
-          "thread-1": {
-            id: "thread-1",
-            rolloutPath,
-            modelProvider: "opencodex",
-            source: "exec",
-            hasUserEvent: 0,
-          },
-        },
-      };
+    for (const invalid of INVALID_HISTORY_BACKUP_FIXTURES) {
+      const manifest = validHistoryBackupFixture(dbPath, rolloutPath);
       invalid.mutate(manifest);
       writeFileSync(backupPath, JSON.stringify(manifest));
       expect(snapshotCodexHistoryNoop(dbPath, backupPath), invalid.name)

--- a/tests/codex-native-residue.test.ts
+++ b/tests/codex-native-residue.test.ts
@@ -30,6 +30,7 @@ import {
   resolveEffectiveUserIdentity,
 } from "../src/codex/user-identity";
 import type { OcxConfig } from "../src/types";
+import { INVALID_HISTORY_BACKUP_FIXTURES, validHistoryBackupFixture } from "./helpers/codex-history-manifest-fixtures";
 
 let codexHome = "";
 let opencodexHome = "";
@@ -835,56 +836,37 @@ test("a missing manifest-referenced rollout is indeterminate", () => {
   });
 });
 
-type MutableHistoryBackupFixture = {
-  version: number;
-  stateDbPath?: unknown;
-  entries: Record<string, {
-    id?: unknown;
-    rolloutPath?: unknown;
-    modelProvider?: unknown;
-    source?: unknown;
-    hasUserEvent?: unknown;
-  }>;
-};
+test("history backup schema diagnostics preserve entry shape and provenance distinctions", () => {
+  const stateDbPath = join(realpathSync.native(codexHome), "state_5.sqlite");
+  const rolloutPath = pathInCodexHome("rollout.jsonl");
+  writeFileSync(historyBackupPath(), JSON.stringify({
+    version: 1,
+    stateDbPath,
+    entries: { "thread-1": null },
+  }));
+  expect(classifyNativeRoutedResidue()).toMatchObject({
+    kind: "indeterminate",
+    surface: "history-backup",
+    reason: "history backup entry has an unknown shape",
+  });
 
-const invalidHistoryBackupFixtures: Array<{
-  name: string;
-  mutate: (manifest: MutableHistoryBackupFixture) => void;
-}> = [
-  { name: "missing state database identity", mutate: manifest => { delete manifest.stateDbPath; } },
-  { name: "blank state database identity", mutate: manifest => { manifest.stateDbPath = ""; } },
-  { name: "relative state database identity", mutate: manifest => { manifest.stateDbPath = "state.sqlite"; } },
-  { name: "mismatched entry id", mutate: manifest => { manifest.entries["thread-1"].id = "thread-2"; } },
-  { name: "missing rollout path", mutate: manifest => { delete manifest.entries["thread-1"].rolloutPath; } },
-  { name: "blank rollout path", mutate: manifest => { manifest.entries["thread-1"].rolloutPath = ""; } },
-  { name: "relative rollout path", mutate: manifest => { manifest.entries["thread-1"].rolloutPath = "rollout.jsonl"; } },
-  { name: "missing model provider", mutate: manifest => { delete manifest.entries["thread-1"].modelProvider; } },
-  { name: "mistyped model provider", mutate: manifest => { manifest.entries["thread-1"].modelProvider = 7; } },
-  { name: "unsupported model provider", mutate: manifest => { manifest.entries["thread-1"].modelProvider = "other"; } },
-  { name: "missing source", mutate: manifest => { delete manifest.entries["thread-1"].source; } },
-  { name: "mistyped source", mutate: manifest => { manifest.entries["thread-1"].source = 7; } },
-  { name: "invalid provider/source tuple", mutate: manifest => { manifest.entries["thread-1"].modelProvider = "opencodex"; } },
-  { name: "missing event marker", mutate: manifest => { delete manifest.entries["thread-1"].hasUserEvent; } },
-  { name: "mistyped event marker", mutate: manifest => { manifest.entries["thread-1"].hasUserEvent = "1"; } },
-  { name: "non-boolean event marker", mutate: manifest => { manifest.entries["thread-1"].hasUserEvent = 2; } },
-];
+  const invalidProvenance = validHistoryBackupFixture(stateDbPath, rolloutPath);
+  invalidProvenance.entries["thread-1"].id = "thread-2";
+  writeFileSync(historyBackupPath(), JSON.stringify(invalidProvenance));
+  expect(classifyNativeRoutedResidue()).toMatchObject({
+    kind: "indeterminate",
+    surface: "history-backup",
+    reason: "history backup entry has invalid provenance metadata",
+  });
+});
 
-for (const fixture of invalidHistoryBackupFixtures) {
+for (const fixture of INVALID_HISTORY_BACKUP_FIXTURES) {
   test(`a history backup with ${fixture.name} is indeterminate and not adopted`, () => {
     writeFileSync(pathInCodexHome("rollout.jsonl"), sessionMeta("thread-1", "opencodex") + "\n");
-    const manifest: MutableHistoryBackupFixture = {
-      version: 1,
-      stateDbPath: join(realpathSync.native(codexHome), "state_5.sqlite"),
-      entries: {
-        "thread-1": {
-          id: "thread-1",
-          rolloutPath: pathInCodexHome("rollout.jsonl"),
-          modelProvider: "openai",
-          source: "cli",
-          hasUserEvent: 1,
-        },
-      },
-    };
+    const manifest = validHistoryBackupFixture(
+      join(realpathSync.native(codexHome), "state_5.sqlite"),
+      pathInCodexHome("rollout.jsonl"),
+    );
     fixture.mutate(manifest);
     writeFileSync(historyBackupPath(), JSON.stringify(manifest));
 

--- a/tests/helpers/codex-history-manifest-fixtures.ts
+++ b/tests/helpers/codex-history-manifest-fixtures.ts
@@ -1,0 +1,54 @@
+export type MutableHistoryBackupFixture = {
+  version: number;
+  stateDbPath?: unknown;
+  entries: Record<string, {
+    id?: unknown;
+    rolloutPath?: unknown;
+    modelProvider?: unknown;
+    source?: unknown;
+    hasUserEvent?: unknown;
+  }>;
+};
+
+export interface InvalidHistoryBackupFixture {
+  name: string;
+  mutate: (manifest: MutableHistoryBackupFixture) => void;
+}
+
+export const INVALID_HISTORY_BACKUP_FIXTURES: InvalidHistoryBackupFixture[] = [
+  { name: "missing state database identity", mutate: manifest => { delete manifest.stateDbPath; } },
+  { name: "blank state database identity", mutate: manifest => { manifest.stateDbPath = ""; } },
+  { name: "relative state database identity", mutate: manifest => { manifest.stateDbPath = "state.sqlite"; } },
+  { name: "mismatched entry id", mutate: manifest => { manifest.entries["thread-1"].id = "thread-2"; } },
+  { name: "missing rollout path", mutate: manifest => { delete manifest.entries["thread-1"].rolloutPath; } },
+  { name: "blank rollout path", mutate: manifest => { manifest.entries["thread-1"].rolloutPath = ""; } },
+  { name: "relative rollout path", mutate: manifest => { manifest.entries["thread-1"].rolloutPath = "rollout.jsonl"; } },
+  { name: "missing model provider", mutate: manifest => { delete manifest.entries["thread-1"].modelProvider; } },
+  { name: "mistyped model provider", mutate: manifest => { manifest.entries["thread-1"].modelProvider = 7; } },
+  { name: "unsupported model provider", mutate: manifest => { manifest.entries["thread-1"].modelProvider = "other"; } },
+  { name: "missing source", mutate: manifest => { delete manifest.entries["thread-1"].source; } },
+  { name: "mistyped source", mutate: manifest => { manifest.entries["thread-1"].source = 7; } },
+  { name: "invalid provider/source tuple", mutate: manifest => { manifest.entries["thread-1"].modelProvider = "opencodex"; } },
+  { name: "missing event marker", mutate: manifest => { delete manifest.entries["thread-1"].hasUserEvent; } },
+  { name: "mistyped event marker", mutate: manifest => { manifest.entries["thread-1"].hasUserEvent = "1"; } },
+  { name: "non-boolean event marker", mutate: manifest => { manifest.entries["thread-1"].hasUserEvent = 2; } },
+];
+
+export function validHistoryBackupFixture(
+  stateDbPath: string,
+  rolloutPath: string,
+): MutableHistoryBackupFixture {
+  return {
+    version: 1,
+    stateDbPath,
+    entries: {
+      "thread-1": {
+        id: "thread-1",
+        rolloutPath,
+        modelProvider: "openai",
+        source: "cli",
+        hasUserEvent: 1,
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add a pure history-manifest leaf for the versioned manifest types, provider/source provenance, platform-aware path identity, backup filename id, and unknown-data validation.
- Make strict restore/no-op inspection and read-only native-residue classification consume the same contract while preserving their existing filesystem, SQLite, rollout, retry, and mutation ownership.
- Share the full invalid-manifest fixture matrix across both caller test suites and document the boundary with a Decision Log.

Closes #2436

## Behavior boundary

- No manifest format or serialized bytes change.
- Accepted and rejected provenance remains openai with cli/vscode or opencodex with exec.
- History restore still maps schema and foreign-database failures to its existing fail-closed states.
- Native residue keeps its existing manifest, entry-shape, entry-provenance, and foreign-database diagnostics.
- The new leaf performs no filesystem reads, rollout inspection, SQLite access, retries, writes, or deletion.

## Verification

- Repository-pinned Bun 1.4.0: codex-history-provider plus codex-native-residue, 129 passed, 0 failed.
- Repository-pinned Bun 1.4.0: composed acceptance, history job, history worker, and uninstall, 32 passed, 0 failed.
- Typecheck passed.
- git diff --check passed.
- Exact head: f177483395b736cea5782195b0419be5e20ce395.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Architecture documentation and Why-focused Decision Log are included.
- [x] Existing error classifications and mutation boundaries are preserved.
- [x] Exact-head repository CI is required before independent review and merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of Codex history backup manifests, including file ownership, paths, identifiers, entry formats, and provenance.
  * Added clearer handling of invalid or unsupported backup data during inspection and restore preparation.
  * Improved consistency when identifying and comparing history backup files across platforms.

* **Documentation**
  * Documented the versioned history backup manifest format and supported resumable backup sources.

* **Tests**
  * Expanded coverage for malformed manifests, invalid entries, and unsupported provenance metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->