### PR TITLE
fix(openai-responses): fold system items into instructions

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -156,35 +156,20 @@ function stripInvalidItemIds(body: unknown): unknown {
   return changed ? { ...body, input } : body;
 }
 
-function isSystemMessageItem(item: unknown): item is Record<string, unknown> {
-  return isPlainObject(item)
-    && item.role === "system"
-    && (item.type === "message" || item.type === undefined);
-}
-
-function splitSystemItem(item: Record<string, unknown>): { text: string; nonText: unknown[] } {
+function systemItemText(item: Record<string, unknown>): string {
   const content = item.content;
-  if (typeof content === "string") return { text: content, nonText: [] };
-  if (!Array.isArray(content)) return { text: "", nonText: [] };
-  const texts: string[] = [];
-  const nonText: unknown[] = [];
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
   for (const block of content) {
-    if (
-      isPlainObject(block)
-      && (block.type === "input_text" || block.type === "text")
-      && typeof block.text === "string"
-      && block.text.length > 0
-    ) {
-      texts.push(block.text);
-      continue;
-    }
-    nonText.push(block);
+    if (!isPlainObject(block)) continue;
+    if (block.type !== "input_text" && block.type !== "text") continue;
+    if (typeof block.text === "string" && block.text.length > 0) parts.push(block.text);
   }
-  return { text: texts.join("\n\n"), nonText };
+  return parts.join("\n\n");
 }
 
-// ChatGPT's Responses and compact endpoints reject role:system in input.
-// Text can live in instructions. Images and files cannot, so they stay as developer.
+// ponytail: ChatGPT 400s on role:system. Non-text on those items is dropped; no caller sends it.
 export function foldSystemMessagesIntoInstructions(body: unknown): unknown {
   if (!isPlainObject(body) || !Array.isArray(body.input)) return body;
 
@@ -192,23 +177,25 @@ export function foldSystemMessagesIntoInstructions(body: unknown): unknown {
   const systemParts: string[] = [];
   let foundSystem = false;
   for (const item of body.input) {
-    if (!isSystemMessageItem(item)) {
+    if (
+      !isPlainObject(item)
+      || item.role !== "system"
+      || (item.type !== "message" && item.type !== undefined)
+    ) {
       remaining.push(item);
       continue;
     }
     foundSystem = true;
-    const { text, nonText } = splitSystemItem(item);
+    const text = systemItemText(item);
     if (text.length > 0) systemParts.push(text);
-    if (nonText.length > 0) remaining.push({ ...item, role: "developer", content: nonText });
   }
   if (!foundSystem) return body;
 
   const next: Record<string, unknown> = { ...body, input: remaining };
-  if (systemParts.length > 0) {
-    const joined = systemParts.join("\n\n");
-    const existing = typeof body.instructions === "string" ? body.instructions : "";
-    next.instructions = existing.length > 0 ? `${existing}\n\n${joined}` : joined;
-  }
+  if (systemParts.length === 0) return next;
+  const joined = systemParts.join("\n\n");
+  const existing = typeof body.instructions === "string" ? body.instructions : "";
+  next.instructions = existing.length > 0 ? `${existing}\n\n${joined}` : joined;
   return next;
 }
 

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -156,47 +156,59 @@ function stripInvalidItemIds(body: unknown): unknown {
   return changed ? { ...body, input } : body;
 }
 
-function systemItemText(item: Record<string, unknown>): string {
-  const content = item.content;
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  const parts: string[] = [];
-  for (const block of content) {
-    if (!isPlainObject(block)) continue;
-    if (block.type !== "input_text" && block.type !== "text") continue;
-    if (typeof block.text !== "string" || block.text.length === 0) continue;
-    parts.push(block.text);
-  }
-  return parts.join("\n\n");
+function isSystemMessageItem(item: unknown): item is Record<string, unknown> {
+  return isPlainObject(item)
+    && item.role === "system"
+    && (item.type === "message" || item.type === undefined);
 }
 
-// Native ChatGPT backend rejects system message items in `input`.
-function foldSystemMessagesIntoInstructions(body: unknown): unknown {
+function splitSystemItem(item: Record<string, unknown>): { text: string; nonText: unknown[] } {
+  const content = item.content;
+  if (typeof content === "string") return { text: content, nonText: [] };
+  if (!Array.isArray(content)) return { text: "", nonText: [] };
+  const texts: string[] = [];
+  const nonText: unknown[] = [];
+  for (const block of content) {
+    if (
+      isPlainObject(block)
+      && (block.type === "input_text" || block.type === "text")
+      && typeof block.text === "string"
+      && block.text.length > 0
+    ) {
+      texts.push(block.text);
+      continue;
+    }
+    nonText.push(block);
+  }
+  return { text: texts.join("\n\n"), nonText };
+}
+
+// ChatGPT's Responses and compact endpoints reject role:system in input.
+// Text can live in instructions. Images and files cannot, so they stay as developer.
+export function foldSystemMessagesIntoInstructions(body: unknown): unknown {
   if (!isPlainObject(body) || !Array.isArray(body.input)) return body;
 
   const remaining: unknown[] = [];
   const systemParts: string[] = [];
   let foundSystem = false;
   for (const item of body.input) {
-    if (
-      !isPlainObject(item)
-      || item.role !== "system"
-      || (item.type !== "message" && item.type !== undefined)
-    ) {
+    if (!isSystemMessageItem(item)) {
       remaining.push(item);
       continue;
     }
     foundSystem = true;
-    const text = systemItemText(item);
+    const { text, nonText } = splitSystemItem(item);
     if (text.length > 0) systemParts.push(text);
+    if (nonText.length > 0) remaining.push({ ...item, role: "developer", content: nonText });
   }
   if (!foundSystem) return body;
 
   const next: Record<string, unknown> = { ...body, input: remaining };
-  if (systemParts.length === 0) return next;
-  const joined = systemParts.join("\n\n");
-  const existing = typeof body.instructions === "string" ? body.instructions : "";
-  next.instructions = existing.length > 0 ? `${existing}\n\n${joined}` : joined;
+  if (systemParts.length > 0) {
+    const joined = systemParts.join("\n\n");
+    const existing = typeof body.instructions === "string" ? body.instructions : "";
+    next.instructions = existing.length > 0 ? `${existing}\n\n${joined}` : joined;
+  }
   return next;
 }
 

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -156,6 +156,50 @@ function stripInvalidItemIds(body: unknown): unknown {
   return changed ? { ...body, input } : body;
 }
 
+function systemItemText(item: Record<string, unknown>): string {
+  const content = item.content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!isPlainObject(block)) continue;
+    if (block.type !== "input_text" && block.type !== "text") continue;
+    if (typeof block.text !== "string" || block.text.length === 0) continue;
+    parts.push(block.text);
+  }
+  return parts.join("\n\n");
+}
+
+// Native ChatGPT backend rejects system message items in `input`.
+function foldSystemMessagesIntoInstructions(body: unknown): unknown {
+  if (!isPlainObject(body) || !Array.isArray(body.input)) return body;
+
+  const remaining: unknown[] = [];
+  const systemParts: string[] = [];
+  let foundSystem = false;
+  for (const item of body.input) {
+    if (
+      !isPlainObject(item)
+      || item.role !== "system"
+      || (item.type !== "message" && item.type !== undefined)
+    ) {
+      remaining.push(item);
+      continue;
+    }
+    foundSystem = true;
+    const text = systemItemText(item);
+    if (text.length > 0) systemParts.push(text);
+  }
+  if (!foundSystem) return body;
+
+  const next: Record<string, unknown> = { ...body, input: remaining };
+  if (systemParts.length === 0) return next;
+  const joined = systemParts.join("\n\n");
+  const existing = typeof body.instructions === "string" ? body.instructions : "";
+  next.instructions = existing.length > 0 ? `${existing}\n\n${joined}` : joined;
+  return next;
+}
+
 /**
  * Codex-private tool fields that only the ChatGPT backend understands.
  *
@@ -1801,7 +1845,10 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
         actualServiceTier === null ? null : "service-tier",
         actualServiceTier,
       );
-      const body = JSON.stringify(finalBody);
+      const wireBody = isOpenAiOperatedResponsesDestination(provider)
+        ? foldSystemMessagesIntoInstructions(finalBody)
+        : finalBody;
+      const body = JSON.stringify(wireBody);
       const releaseBodyObservation = translatorBudget.observeExternallyCapped(
         "passthrough_serialization",
         new TextEncoder().encode(body).byteLength,

--- a/src/server/responses/compact.ts
+++ b/src/server/responses/compact.ts
@@ -7,7 +7,7 @@ import {
 } from "../../config";
 import { parseRequest } from "../../responses/parser";
 import { buildCompactV1Output, COMPACT_PROMPT, decodeCompactionSummary, extractCompactUserMessages } from "../../responses/compaction";
-import { FORWARD_HEADERS, sanitizeReasoningInputContent } from "../../adapters/openai-responses";
+import { FORWARD_HEADERS, foldSystemMessagesIntoInstructions, sanitizeReasoningInputContent } from "../../adapters/openai-responses";
 import { expandPreviousResponseInput, previousResponseProviderState, rememberResponseState } from "../../responses/state";
 import { NoEligiblePolicyCandidateError, routeModel } from "../../router";
 import { evidenceFromBody } from "../../routing/request-evidence";
@@ -420,10 +420,12 @@ export async function handleResponsesCompact(
       headers.set("authorization", `Bearer ${resolveEnvValue(compactProvider.apiKey)}`);
     }
     const { reasoning: _reasoning, ...compactBodyRaw } = raw as typeof raw & { reasoning?: unknown };
-    // The regular /v1/responses path applies sanitizeReasoningInputContent via the adapter's
-    // buildRequest, but the compact endpoint forwards directly. Apply the same sanitizer here
-    // so routed-model reasoning items (reasoning_text content) don't 400 the ChatGPT backend.
-    const compactBody = sanitizeReasoningInputContent(compactBodyRaw) as typeof compactBodyRaw;
+    // Native compact POSTs {base}/responses/compact and never enters buildRequest.
+    // Copy the ChatGPT-facing body transforms that path already runs: blank reasoning_text
+    // content, and fold role:system out of input.
+    const compactBody = foldSystemMessagesIntoInstructions(
+      sanitizeReasoningInputContent(compactBodyRaw),
+    ) as typeof compactBodyRaw;
     const compactUrl = `${base}/responses/compact`;
     const actualCompactHostKey = upstreamHostHealthKey(
       route.providerName,

--- a/src/server/responses/compact.ts
+++ b/src/server/responses/compact.ts
@@ -420,9 +420,7 @@ export async function handleResponsesCompact(
       headers.set("authorization", `Bearer ${resolveEnvValue(compactProvider.apiKey)}`);
     }
     const { reasoning: _reasoning, ...compactBodyRaw } = raw as typeof raw & { reasoning?: unknown };
-    // Native compact POSTs {base}/responses/compact and never enters buildRequest.
-    // Copy the ChatGPT-facing body transforms that path already runs: blank reasoning_text
-    // content, and fold role:system out of input.
+    // compact never enters buildRequest; copy the two ChatGPT body transforms.
     const compactBody = foldSystemMessagesIntoInstructions(
       sanitizeReasoningInputContent(compactBodyRaw),
     ) as typeof compactBodyRaw;

--- a/tests/openai-responses-system-fold.test.ts
+++ b/tests/openai-responses-system-fold.test.ts
@@ -154,6 +154,27 @@ describe("OpenAI-operated Responses system-message folding", () => {
       expect(body.input.filter(item => item.role === "system"), "dropped system items from input").toEqual([]);
       expect(body.input, "left developer items in input").toEqual([developer, userHello]);
     });
+
+    test("keeps system images as developer items", () => {
+      const image = { type: "input_image", image_url: "https://example.test/a.png" };
+      const body = buildWire(canonicalForward, {
+        model: "test-model",
+        input: [
+          {
+            type: "message",
+            role: "system",
+            content: [{ type: "input_text", text: "You are a coding agent." }, image],
+          },
+          userHello,
+        ],
+      });
+      expect(body.instructions, "folded system text into instructions").toBe("You are a coding agent.");
+      expect(body.input.filter(item => item.role === "system"), "dropped system items from input").toEqual([]);
+      expect(body.input, "kept leftover system images as developer items").toEqual([
+        { type: "message", role: "developer", content: [image] },
+        userHello,
+      ]);
+    });
   });
 
   describe("official OpenAI API key", () => {

--- a/tests/openai-responses-system-fold.test.ts
+++ b/tests/openai-responses-system-fold.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import { createResponsesPassthroughAdapter as createResponsesPassthroughAdapterProduction } from "../src/adapters/openai-responses";
+import { withTestTranslatorBudget } from "./helpers/translator-budget";
+
+const createResponsesPassthroughAdapter = (...args: Parameters<typeof createResponsesPassthroughAdapterProduction>) =>
+  withTestTranslatorBudget(createResponsesPassthroughAdapterProduction(...args));
+
+const canonicalForward = {
+  adapter: "openai-responses",
+  baseUrl: "https://chatgpt.com/backend-api/codex",
+  authMode: "forward" as const,
+};
+
+const officialOpenAi = {
+  adapter: "openai-responses",
+  baseUrl: "https://api.openai.com/v1",
+  authMode: "key" as const,
+  apiKey: "sk-test",
+};
+
+const nonCanonicalForward = {
+  adapter: "openai-responses",
+  baseUrl: "https://provider.example/v1/",
+  authMode: "forward" as const,
+};
+
+const codingAgentSystem = { type: "message", role: "system", content: "You are a coding agent." };
+const userHello = { type: "message", role: "user", content: "hello" };
+const codingAgentInput = [codingAgentSystem, userHello];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function buildWire(
+  provider: Parameters<typeof createResponsesPassthroughAdapter>[0],
+  rawBody: Record<string, unknown>,
+) {
+  const request = createResponsesPassthroughAdapter(provider).buildRequest({
+    modelId: "test-model",
+    context: { messages: [] },
+    stream: false,
+    options: {},
+    _rawBody: rawBody,
+  });
+  const parsed: unknown = JSON.parse(request.body);
+  if (!isRecord(parsed)) throw new Error("adapter body must be a JSON object");
+  if (!Array.isArray(parsed.input)) throw new Error("adapter body.input must be an array");
+  if (!parsed.input.every(isRecord)) throw new Error("adapter body.input items must be objects");
+  const body: { input: Record<string, unknown>[]; instructions?: unknown } = {
+    input: parsed.input,
+  };
+  if ("instructions" in parsed) body.instructions = parsed.instructions;
+  return body;
+}
+
+function expectCodingAgentFold(body: { input: Record<string, unknown>[]; instructions?: unknown }) {
+  expect(body.instructions, "folded system text into instructions").toBe("You are a coding agent.");
+  expect(body.input.filter(item => item.role === "system"), "dropped system items from input").toEqual([]);
+  expect(body.input, "kept the user item in input").toEqual([userHello]);
+}
+
+describe("OpenAI-operated Responses system-message folding", () => {
+  describe("canonical ChatGPT forward", () => {
+    test("folds a string system message into instructions", () => {
+      const body = buildWire(canonicalForward, {
+        model: "test-model",
+        input: codingAgentInput,
+      });
+      expectCodingAgentFold(body);
+    });
+
+    test("appends folded system text after existing instructions", () => {
+      const body = buildWire(canonicalForward, {
+        model: "test-model",
+        instructions: "base instructions",
+        input: codingAgentInput,
+      });
+      expect(body.instructions, "appended folded system text after existing instructions")
+        .toBe("base instructions\n\nYou are a coding agent.");
+      expect(body.input.filter(item => item.role === "system"), "dropped system items from input").toEqual([]);
+      expect(body.input, "kept the user item in input").toEqual([userHello]);
+    });
+
+    test("folds input_text array system content into instructions", () => {
+      const body = buildWire(canonicalForward, {
+        model: "test-model",
+        input: [
+          { type: "message", role: "system", content: [{ type: "input_text", text: "array system" }] },
+          userHello,
+        ],
+      });
+      expect(body.instructions, "folded array system text into instructions").toBe("array system");
+      expect(body.input.filter(item => item.role === "system"), "dropped system items from input").toEqual([]);
+      expect(body.input, "kept the user item in input").toEqual([userHello]);
+    });
+
+    test("joins multiple system messages with a blank line", () => {
+      const body = buildWire(canonicalForward, {
+        model: "test-model",
+        input: [
+          { type: "message", role: "system", content: "first" },
+          { type: "message", role: "system", content: "second" },
+          userHello,
+        ],
+      });
+      expect(body.instructions, "joined system texts with a blank line").toBe("first\n\nsecond");
+      expect(body.input.filter(item => item.role === "system"), "dropped system items from input").toEqual([]);
+      expect(body.input, "kept the user item in input").toEqual([userHello]);
+    });
+
+    test("drops empty system items without inventing instructions", () => {
+      const body = buildWire(canonicalForward, {
+        model: "test-model",
+        input: [
+          { type: "message", role: "system", content: "" },
+          userHello,
+        ],
+      });
+      expect(body.input.filter(item => item.role === "system"), "dropped system items from input").toEqual([]);
+      expect(body.instructions, "did not invent empty instructions").toBeUndefined();
+      expect(body.input, "kept the user item in input").toEqual([userHello]);
+    });
+
+    test("leaves input and instructions unchanged when no system items exist", () => {
+      const input = [userHello];
+      const body = buildWire(canonicalForward, {
+        model: "test-model",
+        instructions: "base instructions",
+        input,
+      });
+      expect(body.input, "left input unchanged").toEqual(input);
+      expect(body.instructions, "left instructions unchanged").toBe("base instructions");
+    });
+
+    test("folds omitted-type system items into instructions", () => {
+      const body = buildWire(canonicalForward, {
+        model: "test-model",
+        input: [
+          { role: "system", content: "You are a coding agent." },
+          userHello,
+        ],
+      });
+      expectCodingAgentFold(body);
+    });
+
+    test("leaves developer items in input", () => {
+      const developer = { type: "message", role: "developer", content: "prefer diffs" };
+      const body = buildWire(canonicalForward, {
+        model: "test-model",
+        input: [codingAgentSystem, developer, userHello],
+      });
+      expect(body.instructions, "folded system text into instructions").toBe("You are a coding agent.");
+      expect(body.input.filter(item => item.role === "system"), "dropped system items from input").toEqual([]);
+      expect(body.input, "left developer items in input").toEqual([developer, userHello]);
+    });
+  });
+
+  describe("official OpenAI API key", () => {
+    test("folds a string system message into instructions", () => {
+      const body = buildWire(officialOpenAi, {
+        model: "test-model",
+        input: codingAgentInput,
+      });
+      expectCodingAgentFold(body);
+    });
+  });
+
+  describe("non-canonical forward", () => {
+    test("leaves system items in input", () => {
+      const body = buildWire(nonCanonicalForward, {
+        model: "test-model",
+        input: codingAgentInput,
+      });
+      expect(body.input, "left system items in input").toEqual(codingAgentInput);
+      expect(body.instructions, "did not fold system text into instructions").toBeUndefined();
+    });
+  });
+});

--- a/tests/openai-responses-system-fold.test.ts
+++ b/tests/openai-responses-system-fold.test.ts
@@ -154,27 +154,6 @@ describe("OpenAI-operated Responses system-message folding", () => {
       expect(body.input.filter(item => item.role === "system"), "dropped system items from input").toEqual([]);
       expect(body.input, "left developer items in input").toEqual([developer, userHello]);
     });
-
-    test("keeps system images as developer items", () => {
-      const image = { type: "input_image", image_url: "https://example.test/a.png" };
-      const body = buildWire(canonicalForward, {
-        model: "test-model",
-        input: [
-          {
-            type: "message",
-            role: "system",
-            content: [{ type: "input_text", text: "You are a coding agent." }, image],
-          },
-          userHello,
-        ],
-      });
-      expect(body.instructions, "folded system text into instructions").toBe("You are a coding agent.");
-      expect(body.input.filter(item => item.role === "system"), "dropped system items from input").toEqual([]);
-      expect(body.input, "kept leftover system images as developer items").toEqual([
-        { type: "message", role: "developer", content: [image] },
-        userHello,
-      ]);
-    });
   });
 
   describe("official OpenAI API key", () => {

--- a/tests/responses-compaction-routing.test.ts
+++ b/tests/responses-compaction-routing.test.ts
@@ -172,7 +172,7 @@ describe("supportsNativeResponsesCompactEndpoint (#422)", () => {
 });
 
 describe("native compact system-message folding", () => {
-  test("folds role:system out of compact input and keeps leftover images as developer", async () => {
+  test("folds role:system out of compact input", async () => {
     const config = {
       defaultProvider: "openai-apikey",
       providers: {
@@ -184,35 +184,27 @@ describe("native compact system-message folding", () => {
         },
       },
     } as unknown as OcxConfig;
-    const image = { type: "input_image", image_url: "https://example.test/a.png" };
     let captured: Record<string, unknown> | undefined;
     globalThis.fetch = (async (_input, init) => {
       captured = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
       return jsonResponse(completedPayload("native summary"));
     }) as typeof fetch;
+    const user = { type: "message", role: "user", content: [{ type: "input_text", text: "earlier turn" }] };
     const response = await handleResponsesCompact(
       compactionRequest({
         model: "openai-apikey/gpt-5.5",
         instructions: "base instructions",
         input: [
-          {
-            type: "message",
-            role: "system",
-            content: [{ type: "input_text", text: "You are a coding agent." }, image],
-          },
-          { type: "message", role: "user", content: [{ type: "input_text", text: "earlier turn" }] },
+          { type: "message", role: "system", content: "You are a coding agent." },
+          user,
         ],
       }),
       config,
       { model: "", provider: "" },
     );
     expect(response.status).toBe(200);
-    expect(captured?.instructions, "folded system text into compact instructions")
-      .toBe("base instructions\n\nYou are a coding agent.");
-    expect(captured?.input, "kept leftover system images as developer items").toEqual([
-      { type: "message", role: "developer", content: [image] },
-      { type: "message", role: "user", content: [{ type: "input_text", text: "earlier turn" }] },
-    ]);
+    expect(captured?.instructions).toBe("base instructions\n\nYou are a coding agent.");
+    expect(captured?.input).toEqual([user]);
   });
 });
 

--- a/tests/responses-compaction-routing.test.ts
+++ b/tests/responses-compaction-routing.test.ts
@@ -171,6 +171,51 @@ describe("supportsNativeResponsesCompactEndpoint (#422)", () => {
   });
 });
 
+describe("native compact system-message folding", () => {
+  test("folds role:system out of compact input and keeps leftover images as developer", async () => {
+    const config = {
+      defaultProvider: "openai-apikey",
+      providers: {
+        "openai-apikey": {
+          adapter: "openai-responses",
+          baseUrl: "https://api.openai.com/v1",
+          authMode: "key",
+          apiKey: "sk-test",
+        },
+      },
+    } as unknown as OcxConfig;
+    const image = { type: "input_image", image_url: "https://example.test/a.png" };
+    let captured: Record<string, unknown> | undefined;
+    globalThis.fetch = (async (_input, init) => {
+      captured = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+      return jsonResponse(completedPayload("native summary"));
+    }) as typeof fetch;
+    const response = await handleResponsesCompact(
+      compactionRequest({
+        model: "openai-apikey/gpt-5.5",
+        instructions: "base instructions",
+        input: [
+          {
+            type: "message",
+            role: "system",
+            content: [{ type: "input_text", text: "You are a coding agent." }, image],
+          },
+          { type: "message", role: "user", content: [{ type: "input_text", text: "earlier turn" }] },
+        ],
+      }),
+      config,
+      { model: "", provider: "" },
+    );
+    expect(response.status).toBe(200);
+    expect(captured?.instructions, "folded system text into compact instructions")
+      .toBe("base instructions\n\nYou are a coding agent.");
+    expect(captured?.input, "kept leftover system images as developer items").toEqual([
+      { type: "message", role: "developer", content: [image] },
+      { type: "message", role: "user", content: [{ type: "input_text", text: "earlier turn" }] },
+    ]);
+  });
+});
+
 describe("native compact usage reporting", () => {
   test("the buffered upstream body fills the request log usage and stays intact for the client", async () => {
     const config = {


### PR DESCRIPTION
## Why

ChatGPT's Responses backend rejects `input` items with `role: "system"` (`System messages are not allowed`). Claude inbound and Chat Completions inbound already fold that text into `instructions`. Native Responses passthrough forwarded the items unchanged. Clients that speak Responses directly (Grok Build among them) hit the 400.

The rule belongs at the OpenAI-operated destination, not at each inbound. A later native client would otherwise rediscover the same failure.

## Scope

- `foldSystemMessagesIntoInstructions` in `src/adapters/openai-responses.ts` drops `role: "system"` message items (including omitted `type`) from `input` and appends their text to `instructions`.
- `createResponsesPassthroughAdapter.buildRequest` runs it after `stripDisabledReasoningSummaries`, only when `isOpenAiOperatedResponsesDestination` is true, then `JSON.stringify`s that body. HTTP and the Codex websocket both consume this payload.
- `tests/openai-responses-system-fold.test.ts` pins canonical ChatGPT forward, official `api.openai.com` key-auth, and non-canonical forward.

Out of scope: schema still accepts system items inbound. Third-party forward gateways are unchanged. Native `/responses/compact` does not go through this adapter.

## Tradeoffs

Existing string `instructions` stay first. Folded system text is appended, joined with a blank line. `developer` items stay in `input`. Empty system items are dropped without writing empty `instructions`.

Claude inbound already has a similar extract. It walks Anthropic `text` blocks and always translates. This walk is Responses `input_text`/`text` and is destination-gated. Sharing a helper would hide those two shapes.

## Blast Radius

OpenAI-operated Responses traffic only (canonical ChatGPT Codex URL, or official `https://api.openai.com/v1/responses`). Callers that already send `instructions` plus user/assistant input are unchanged. A system item that carries only `input_image`/`input_file` loses that content when folded into string `instructions`.

## Verification

- Reproduced the wire before the fold: canonical forward `buildRequest` emitted `roles: ["system","user"]` with `instructions` left as the original string.
- `bun test tests/openai-responses-system-fold.test.ts` against committed `dev` without the adapter change: 8 fail, 2 pass.
- Same file with the fold: 10 pass, 0 fail.
- `bun test tests/openai-responses-system-fold.test.ts tests/openai-responses-passthrough.test.ts`: 110 pass, 0 fail.

The first commit is the test file. The second is the fold. Checkout of the first commit is the red state.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with OpenAI Responses by correctly handling system messages.
  * System message text is now included as instructions while preserving other message content.
  * Supports string and array-based system messages, multiple messages, and existing instructions.
  * Non-OpenAI and non-canonical forwarding behavior remains unchanged.

* **Tests**
  * Added coverage for system-message handling, developer messages, empty messages, and requests without system messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->