### PR TITLE
fix(tools): coerce wait.yield_time_ms as an integral float

### DIFF
--- a/src/lib/tool-argument-integers.ts
+++ b/src/lib/tool-argument-integers.ts
@@ -77,11 +77,15 @@ function declaresString(schema: SchemaNode): boolean {
 // against it. It gets its own change when it gets its own reproduction.
 const U64_NUMBER_FIELDS = new Set(["timeout_ms"]);
 
-// Issue #2443: Codex Desktop's bare `wait` tool has the same schema/runtime split
-// for `yield-time_ms` and `max_tokens`. Scope these names to that bare tool so a
+// Issue #2443 / #2451: Codex Desktop's bare `wait` tool has the same schema/runtime
+// split for `yield_time_ms` and `max_tokens`. Scope these names to that bare tool so a
 // third-party or namespaced tool can still use fractional values legitimately.
+// #2448 allowlisted the hyphenated `yield-time_ms`; live Grok 4.6 calls and the
+// advertised wait schema both use the underscore form, so that name is the one
+// with a captured u64 rejection. Cursor still uses the same underscore name on a
+// namespaced tool; the wait-only map keeps that path byte-identical.
 const U64_NUMBER_FIELDS_BY_TOOL = new Map<string, ReadonlySet<string>>([
-  ["wait", new Set(["yield-time_ms", "max_tokens"])],
+  ["wait", new Set(["yield_time_ms", "max_tokens"])],
 ]);
 
 /** True when the node accepts a JSON number (`integer` or `number`), so a numeric

--- a/tests/tool-argument-integers.test.ts
+++ b/tests/tool-argument-integers.test.ts
@@ -341,6 +341,12 @@ describe("native u64 fields advertised as number (#2316)", () => {
       schema,
       "wait",
     )).toBe('{"yield_time_ms":20000,"max_tokens":5000,"priority":2}');
+    const priorityOnly = '{"priority":2.0}';
+    expect(coerceIntegerToolArguments(
+      priorityOnly,
+      schema,
+      "wait",
+    )).toBe(priorityOnly);
     const other = {
       type: "object",
       properties: { yield_time_ms: { type: "number" }, priority: { type: "number" } },

--- a/tests/tool-argument-integers.test.ts
+++ b/tests/tool-argument-integers.test.ts
@@ -325,15 +325,28 @@ describe("native u64 fields advertised as number (#2316)", () => {
       .toBe('{"timeout_ms":"120000"}');
   });
 
-  test("Cursor's sibling field stays unchanged even with wait identity", () => {
-    // Cursor uses yield_time_ms (underscore), not wait's yield-time_ms (hyphen).
-    // Keep this explicit scope proof from #2316: field names are never broadened globally.
-    const others = {
+  test("bare wait repairs yield_time_ms and leaves unrelated number fields alone", () => {
+    // Live Codex Desktop wait uses the underscore form (#2451). Wait identity
+    // repairs that field and max_tokens, but never a generic number field.
+    const schema = {
+      type: "object",
+      properties: {
+        yield_time_ms: { type: "number" },
+        max_tokens: { type: "number" },
+        priority: { type: "number" },
+      },
+    };
+    expect(coerceIntegerToolArguments(
+      '{"yield_time_ms":20000.0,"max_tokens":5000.0,"priority":2.0}',
+      schema,
+      "wait",
+    )).toBe('{"yield_time_ms":20000,"max_tokens":5000,"priority":2}');
+    const other = {
       type: "object",
       properties: { yield_time_ms: { type: "number" }, priority: { type: "number" } },
     };
     const raw = '{"yield_time_ms":60000.0,"priority":2.0}';
-    expect(coerceIntegerToolArguments(raw, others, "wait")).toBe(raw);
+    expect(coerceIntegerToolArguments(raw, other, "other_tool")).toBe(raw);
   });
 
   test("the namespaced wait_agent call is repaired through the real bridge", async () => {
@@ -367,7 +380,7 @@ describe("native u64 fields advertised as number (#2316)", () => {
 const CODEX_DESKTOP_WAIT_SCHEMA = {
   type: "object",
   properties: {
-    "yield-time_ms": { type: "number" },
+    "yield_time_ms": { type: "number" },
     max_tokens: { type: "number" },
   },
 };
@@ -384,26 +397,26 @@ const WAIT_SCOPE_NAMESPACE_MAP = new Map([
 
 const WAIT_SCOPE_EVENTS: AdapterEvent[] = [
   { type: "tool_call_start", id: "call_wait", name: "wait" },
-  { type: "tool_call_delta", arguments: '{"yield-time_ms":120000.0,"max_tokens":8000.0}' },
+  { type: "tool_call_delta", arguments: '{"yield_time_ms":120000.0,"max_tokens":8000.0}' },
   { type: "tool_call_end", id: "call_wait" },
   { type: "tool_call_start", id: "call_fractional", name: "wait" },
-  { type: "tool_call_delta", arguments: '{"yield-time_ms":1.5,"max_tokens":1.5}' },
+  { type: "tool_call_delta", arguments: '{"yield_time_ms":1.5,"max_tokens":1.5}' },
   { type: "tool_call_end", id: "call_fractional" },
   { type: "tool_call_start", id: "call_other", name: "other_tool" },
-  { type: "tool_call_delta", arguments: '{"yield-time_ms":120000.0,"max_tokens":8000.0}' },
+  { type: "tool_call_delta", arguments: '{"yield_time_ms":120000.0,"max_tokens":8000.0}' },
   { type: "tool_call_end", id: "call_other" },
   { type: "tool_call_start", id: "call_namespaced", name: "cursor_wait" },
-  { type: "tool_call_delta", arguments: '{"yield-time_ms":120000.0,"max_tokens":8000.0}' },
+  { type: "tool_call_delta", arguments: '{"yield_time_ms":120000.0,"max_tokens":8000.0}' },
   { type: "tool_call_end", id: "call_namespaced" },
   { type: "done" },
 ];
 
-describe("Codex Desktop wait native integers (#2443)", () => {
+describe("Codex Desktop wait native integers (#2443 / #2451)", () => {
   const expectedCalls = [
-    { name: "wait", namespace: undefined, arguments: '{"yield-time_ms":120000,"max_tokens":8000}' },
-    { name: "wait", namespace: undefined, arguments: '{"yield-time_ms":1.5,"max_tokens":1.5}' },
-    { name: "other_tool", namespace: undefined, arguments: '{"yield-time_ms":120000.0,"max_tokens":8000.0}' },
-    { name: "wait", namespace: "cursor", arguments: '{"yield-time_ms":120000.0,"max_tokens":8000.0}' },
+    { name: "wait", namespace: undefined, arguments: '{"yield_time_ms":120000,"max_tokens":8000}' },
+    { name: "wait", namespace: undefined, arguments: '{"yield_time_ms":1.5,"max_tokens":1.5}' },
+    { name: "other_tool", namespace: undefined, arguments: '{"yield_time_ms":120000.0,"max_tokens":8000.0}' },
+    { name: "wait", namespace: "cursor", arguments: '{"yield_time_ms":120000.0,"max_tokens":8000.0}' },
   ];
 
   test("streaming bridge scopes the repair to the bare wait tool", async () => {


### PR DESCRIPTION
Closes #2451.

## Summary

- #2448 scoped integral-float repair to the bare `wait` tool, which is the right boundary, but it allowlisted `yield-time_ms` (hyphen).
- Live Codex Desktop / Grok 4.6 calls still emit `yield_time_ms: 20000.0` (underscore). Codex advertises that field as JSON `number` and deserializes it as `u64`, so the call is rejected before `wait` runs.
- Rename the wait-scoped allowlist entry to the captured field. Keep `max_tokens` wait-scoped. Leave namespaced Cursor `wait` and any other tool's `yield_time_ms` byte-identical. A genuine fraction such as `1.5` still fails.

## Verification

- `bun test tests/tool-argument-integers.test.ts` — 35 pass, 0 fail, 47 expect() calls
- `bun run typecheck` — exit 0
- Red-green on the new unit case: before the source change, `wait` retained `20000.0`; after it, the live payload becomes `{"yield_time_ms":20000,"max_tokens":5000,...}`
- Existing #2443 bridge tests now lock the underscore form and still prove unrelated / namespaced tools are untouched
- CodeRabbit note on combined-payload re-serialization: added an isolated `{"priority":2.0}` assertion so ignored fields keep their original bytes

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (no user-facing config or docs change)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected handling of integer values for the `wait` tool’s `yield_time_ms` option.
  - Preserved fractional values for unrelated and namespaced tools.
  - Updated both streaming and non-streaming wait behavior for consistency.

- **Tests**
  - Added coverage confirming integer conversion applies only to the intended `wait` tool.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->