### PR TITLE
fix: repair verify-opencodex loopback fixture

### DIFF
--- a/.claude/skills/verify-opencodex/SKILL.md
+++ b/.claude/skills/verify-opencodex/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: verify-opencodex
+description: Drive the opencodex local proxy (HTTP API, CLI status, dashboard) the way a user would and capture proof. Use when proving a proxy, Responses, compact, models, or CLI-status change on a live instance.
+---
+
+# Verify opencodex
+
+opencodex is a local LLM proxy. Humans hit the dashboard at `/` and the CLI (`ocx`). Clients hit `POST /v1/responses`, `POST /v1/responses/compact`, and `GET /v1/models`. This skill drives a **disposable** instance. Never attach to a proxy you did not start.
+
+Secondary surfaces (do not use as the first proof): GUI Vite `bun run dev:gui`, `ocx service`, Codex/Claude/Grok shims.
+
+## Launch
+
+Repo root. Requires `bun` on PATH.
+
+```bash
+.claude/skills/verify-opencodex/scripts/verify.sh launch
+```
+
+Ready when `GET http://127.0.0.1:$PORT/healthz` returns JSON with `service: "opencodex"` and `port` equal to `$PORT`. The listen log line is `opencodex proxy running on http://localhost:<port>`.
+
+State file: `.claude/skills/verify-opencodex/.run-state` (HOME, PORT, MOCK_PORT, PROXY_PID, MOCK_PID, ARTIFACT_DIR). Source it before doctor/drive/cleanup.
+
+Isolation this script always sets:
+
+- `OPENCODEX_HOME` and `CODEX_HOME` under `/tmp/opencodex-verify-<id>/` (never `~/.opencodex` or `~/.codex`)
+- `--port` on 19101–19120, never 10100
+- `hostname: "127.0.0.1"` so data-plane admission is loopback (no API key)
+
+A second verification run can coexist with the user's `ocx` on 10100. Two verification runs at once need different ids (`OPENCODEX_VERIFY_ID`).
+
+Teardown: `scripts/verify.sh cleanup` (kills only the PIDs in `.run-state`).
+
+## Doctor
+
+```bash
+.claude/skills/verify-opencodex/scripts/verify.sh doctor
+```
+
+Pass only if all of these hold:
+
+- `.run-state` exists and `PROXY_PID` is alive
+- `/healthz` `service` is `opencodex`, `pid` equals `PROXY_PID`, `port` equals `PORT`
+- `/readyz` is JSON with `service: "opencodex"` (status may be `ready`, `pending`, or `failed`; a fixture catalog often lands `failed` — still drive `/healthz` and `/v1/*`)
+- `PORT` is not 10100
+
+Refuse and stop if `/healthz` pid/port does not match the run you started.
+
+## Drive
+
+Harness is curl against the launched proxy plus `ocx` with the same `OPENCODEX_HOME`. No browser. Stable handles are URL paths and JSON fields.
+
+```bash
+source .claude/skills/verify-opencodex/.run-state
+curl -sS "http://127.0.0.1:${PORT}/healthz"
+curl -sS "http://127.0.0.1:${PORT}/readyz"
+curl -sS "http://127.0.0.1:${PORT}/"
+curl -sS "http://127.0.0.1:${PORT}/v1/models"
+curl -sS -X POST "http://127.0.0.1:${PORT}/v1/responses" \
+  -H 'content-type: application/json' \
+  -d '{"model":"fixture/fixture-model","input":[{"type":"message","role":"user","content":"ping"}],"stream":false}'
+curl -sS -X POST "http://127.0.0.1:${PORT}/v1/responses/compact" \
+  -H 'content-type: application/json' \
+  -d '{"model":"fixture/fixture-model","input":[{"type":"message","role":"user","content":"ping"}]}'
+OPENCODEX_HOME="$OPENCODEX_HOME" CODEX_HOME="$CODEX_HOME" bun run src/cli/index.ts status --json
+```
+
+Feature recipes: `features/`. Drive from the map, not from an internal test helper.
+
+`role:system` folding for ChatGPT destinations is not reachable on this fixture (the gate is `chatgpt.com/backend-api/codex` or `api.openai.com/v1`). Prove that with `bun test tests/openai-responses-system-fold.test.ts tests/responses-compaction-routing.test.ts`.
+
+## Evidence
+
+Directory: `.claude/skills/verify-opencodex/artifacts/<run-id>/`. Named in `.run-state` as `ARTIFACT_DIR`. Cleanup must not delete it.
+
+Proof standards:
+
+- Hit the real HTTP paths a client uses. Do not call `startServer()` from a test file as the proof.
+- Save the request (method, path, body) and the response body plus status.
+- For mutations, read back a second way (`/healthz` pid vs `ps`, compact `output` vs the POST).
+- The mock upstream is a verification double for the LLM vendor. The proxy and CLI under test are real.
+
+## Cleanup
+
+```bash
+.claude/skills/verify-opencodex/scripts/verify.sh cleanup
+```
+
+Kills `PROXY_PID` and `MOCK_PID` from `.run-state` only. Removes `/tmp/opencodex-verify-<id>/`. Leaves `ARTIFACT_DIR`.
+
+## Helpers
+
+| command | meaning |
+|---|---|
+| `scripts/verify.sh launch` | mock upstream + isolated `ocx start` |
+| `scripts/verify.sh doctor` | pid/port/identity check |
+| `scripts/verify.sh drive-health` | healthz, readyz, dashboard GET `/` |
+| `scripts/verify.sh drive-responses` | POST `/v1/responses` |
+| `scripts/verify.sh drive-compact` | POST `/v1/responses/compact` |
+| `scripts/verify.sh drive-models` | GET `/v1/models` |
+| `scripts/verify.sh drive-status` | `ocx status --json` |
+| `scripts/verify.sh cleanup` | tear down this run |

--- a/.claude/skills/verify-opencodex/scripts/mock-upstream.mjs
+++ b/.claude/skills/verify-opencodex/scripts/mock-upstream.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env bun
+const port = Number(process.env.OPENCODEX_VERIFY_MOCK_PORT ?? "19102");
+const completed = {
+  id: "resp_verify",
+  object: "response",
+  status: "completed",
+  model: "fixture-model",
+  output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "pong" }] }],
+  usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+};
+Bun.serve({
+  hostname: "127.0.0.1",
+  port,
+  fetch(req) {
+    const url = new URL(req.url);
+    if (req.method === "GET" && url.pathname.endsWith("/models")) {
+      return Response.json({ object: "list", data: [{ id: "fixture-model", object: "model" }] });
+    }
+    if (req.method === "POST" && url.pathname.endsWith("/responses/compact")) {
+      return Response.json({
+        output: [{ type: "message", role: "user", content: [{ type: "input_text", text: "pong compact" }] }],
+      });
+    }
+    if (req.method === "POST" && url.pathname.endsWith("/responses")) {
+      return Response.json(completed);
+    }
+    return new Response("not found", { status: 404 });
+  },
+});
+console.log(`mock-upstream ${port}`);

--- a/.claude/skills/verify-opencodex/scripts/verify.sh
+++ b/.claude/skills/verify-opencodex/scripts/verify.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+SKILL="$ROOT/.claude/skills/verify-opencodex"
+STATE="$SKILL/.run-state"
+CMD="${1:-}"
+
+die() { echo "verify-opencodex: $*" >&2; exit 1; }
+
+load_state() {
+  [[ -f "$STATE" ]] || die "no .run-state; run launch first"
+  # shellcheck disable=SC1090
+  source "$STATE"
+}
+
+write_state() {
+  cat > "$STATE" <<EOF
+OPENCODEX_VERIFY_ID=$OPENCODEX_VERIFY_ID
+OPENCODEX_HOME=$OPENCODEX_HOME
+CODEX_HOME=$CODEX_HOME
+PORT=$PORT
+MOCK_PORT=$MOCK_PORT
+PROXY_PID=$PROXY_PID
+MOCK_PID=$MOCK_PID
+ARTIFACT_DIR=$ARTIFACT_DIR
+TMPDIR_RUN=$TMPDIR_RUN
+EOF
+}
+
+pick_port() {
+  local start="$1"
+  local p="$start"
+  local end=$((start + 19))
+  while [[ "$p" -le "$end" ]]; do
+    if [[ "$p" -eq 10100 ]]; then p=$((p + 1)); continue; fi
+    if ! nc -z 127.0.0.1 "$p" 2>/dev/null; then
+      echo "$p"
+      return 0
+    fi
+    p=$((p + 1))
+  done
+  die "no free port in $start-$((start+19))"
+}
+
+cmd_launch() {
+  [[ -f "$STATE" ]] && die "already launched; cleanup first"
+  OPENCODEX_VERIFY_ID="${OPENCODEX_VERIFY_ID:-$(date +%Y%m%dT%H%M%S)-$$}"
+  TMPDIR_RUN="/tmp/opencodex-verify-${OPENCODEX_VERIFY_ID}"
+  OPENCODEX_HOME="$TMPDIR_RUN/home"
+  CODEX_HOME="$TMPDIR_RUN/codex"
+  ARTIFACT_DIR="$SKILL/artifacts/${OPENCODEX_VERIFY_ID}"
+  mkdir -p "$OPENCODEX_HOME" "$CODEX_HOME" "$ARTIFACT_DIR"
+  PORT="$(pick_port "${OPENCODEX_VERIFY_PORT:-19101}")"
+  MOCK_PORT="$(pick_port "${OPENCODEX_VERIFY_MOCK_PORT:-19121}")"
+  cat > "$OPENCODEX_HOME/config.json" <<EOF
+{
+  "port": ${PORT},
+  "hostname": "127.0.0.1",
+  "clientIntegrations": { "codex": false },
+  "defaultProvider": "fixture",
+  "providers": {
+    "fixture": {
+      "adapter": "openai-responses",
+      "baseUrl": "http://127.0.0.1:${MOCK_PORT}/v1",
+      "authMode": "key",
+      "apiKey": "sk-verify",
+      "allowPrivateNetwork": true,
+      "defaultModel": "fixture-model"
+    }
+  }
+}
+EOF
+  bun "$SKILL/scripts/mock-upstream.mjs" > "$ARTIFACT_DIR/mock.log" 2>&1 &
+  MOCK_PID=$!
+  export OPENCODEX_VERIFY_MOCK_PORT="$MOCK_PORT"
+  # mock reads env at start; restart with env
+  kill "$MOCK_PID" 2>/dev/null || true
+  wait "$MOCK_PID" 2>/dev/null || true
+  OPENCODEX_VERIFY_MOCK_PORT="$MOCK_PORT" bun "$SKILL/scripts/mock-upstream.mjs" > "$ARTIFACT_DIR/mock.log" 2>&1 &
+  MOCK_PID=$!
+  export OPENCODEX_HOME CODEX_HOME
+  bun run "$ROOT/src/cli/index.ts" start --port "$PORT" > "$ARTIFACT_DIR/proxy.log" 2>&1 &
+  PROXY_PID=$!
+  write_state
+  local i=0
+  while [[ "$i" -lt 50 ]]; do
+    if curl -sf "http://127.0.0.1:${PORT}/healthz" | grep -q '"service":"opencodex"'; then
+      echo "launched port=$PORT mock=$MOCK_PORT pid=$PROXY_PID artifacts=$ARTIFACT_DIR"
+      return 0
+    fi
+    if ! kill -0 "$PROXY_PID" 2>/dev/null; then
+      cat "$ARTIFACT_DIR/proxy.log" >&2 || true
+      die "proxy exited before /healthz"
+    fi
+    i=$((i + 1))
+    sleep 0.2
+  done
+  cat "$ARTIFACT_DIR/proxy.log" >&2 || true
+  die "timeout waiting for /healthz on $PORT"
+}
+
+cmd_doctor() {
+  load_state
+  kill -0 "$PROXY_PID" || die "PROXY_PID $PROXY_PID is dead"
+  [[ "$PORT" != "10100" ]] || die "refusing port 10100"
+  local body
+  body="$(curl -sf "http://127.0.0.1:${PORT}/healthz")" || die "/healthz failed"
+  echo "$body"
+  echo "$body" | grep -q '"service":"opencodex"' || die "healthz is not opencodex"
+  echo "$body" | grep -q "\"port\":${PORT}" || die "healthz port mismatch"
+  echo "$body" | grep -q "\"pid\":${PROXY_PID}" || die "healthz pid mismatch"
+  curl -sf "http://127.0.0.1:${PORT}/readyz" || die "/readyz failed"
+  echo
+  echo "doctor ok"
+}
+
+save_http() {
+  local name="$1" method="$2" url="$3" data="${4:-}"
+  local hdr="$ARTIFACT_DIR/${name}.headers"
+  local body="$ARTIFACT_DIR/${name}.body"
+  if [[ -n "$data" ]]; then
+    curl -sS -D "$hdr" -o "$body" -w "%{http_code}" -X "$method" "$url" \
+      -H 'content-type: application/json' -d "$data" > "$ARTIFACT_DIR/${name}.status"
+  else
+    curl -sS -D "$hdr" -o "$body" -w "%{http_code}" -X "$method" "$url" > "$ARTIFACT_DIR/${name}.status"
+  fi
+  printf '%s %s\n' "$method" "$url" > "$ARTIFACT_DIR/${name}.request"
+  if [[ -n "$data" ]]; then
+    printf '%s\n' "$data" >> "$ARTIFACT_DIR/${name}.request"
+  fi
+}
+
+cmd_drive_health() {
+  load_state
+  cmd_doctor >/dev/null
+  save_http healthz GET "http://127.0.0.1:${PORT}/healthz"
+  save_http readyz GET "http://127.0.0.1:${PORT}/readyz"
+  save_http dashboard GET "http://127.0.0.1:${PORT}/"
+  [[ "$(cat "$ARTIFACT_DIR/healthz.status")" == "200" ]] || die "healthz not 200"
+  grep -q opencodex "$ARTIFACT_DIR/healthz.body" || die "healthz body"
+  [[ "$(cat "$ARTIFACT_DIR/readyz.status")" == "200" ]] || die "readyz not 200"
+  echo "drive-health ok -> $ARTIFACT_DIR"
+}
+
+cmd_drive_responses() {
+  load_state
+  save_http responses POST "http://127.0.0.1:${PORT}/v1/responses" \
+    '{"model":"fixture/fixture-model","input":[{"type":"message","role":"user","content":"ping"}],"stream":false}'
+  [[ "$(cat "$ARTIFACT_DIR/responses.status")" == "200" ]] || die "responses not 200: $(cat "$ARTIFACT_DIR/responses.body")"
+  grep -q pong "$ARTIFACT_DIR/responses.body" || die "responses missing pong"
+  echo "drive-responses ok -> $ARTIFACT_DIR"
+}
+
+cmd_drive_compact() {
+  load_state
+  save_http compact POST "http://127.0.0.1:${PORT}/v1/responses/compact" \
+    '{"model":"fixture/fixture-model","input":[{"type":"message","role":"user","content":"ping"}]}'
+  [[ "$(cat "$ARTIFACT_DIR/compact.status")" == "200" ]] || die "compact not 200: $(cat "$ARTIFACT_DIR/compact.body")"
+  echo "drive-compact ok -> $ARTIFACT_DIR"
+}
+
+cmd_drive_models() {
+  load_state
+  save_http models GET "http://127.0.0.1:${PORT}/v1/models"
+  [[ "$(cat "$ARTIFACT_DIR/models.status")" == "200" ]] || die "models not 200: $(cat "$ARTIFACT_DIR/models.body")"
+  echo "drive-models ok -> $ARTIFACT_DIR"
+}
+
+cmd_drive_status() {
+  load_state
+  OPENCODEX_HOME="$OPENCODEX_HOME" CODEX_HOME="$CODEX_HOME" \
+    bun run "$ROOT/src/cli/index.ts" status --json > "$ARTIFACT_DIR/status.json"
+  grep -q '"running": true' "$ARTIFACT_DIR/status.json" || die "status not running"
+  echo "drive-status ok -> $ARTIFACT_DIR"
+}
+
+cmd_cleanup() {
+  [[ -f "$STATE" ]] || { echo "nothing to clean"; return 0; }
+  load_state
+  if [[ -n "${PROXY_PID:-}" ]]; then kill "$PROXY_PID" 2>/dev/null || true; wait "$PROXY_PID" 2>/dev/null || true; fi
+  if [[ -n "${MOCK_PID:-}" ]]; then kill "$MOCK_PID" 2>/dev/null || true; wait "$MOCK_PID" 2>/dev/null || true; fi
+  if [[ -n "${TMPDIR_RUN:-}" && "$TMPDIR_RUN" == /tmp/opencodex-verify-* ]]; then rm -rf "$TMPDIR_RUN"; fi
+  rm -f "$STATE"
+  echo "cleanup ok (artifacts kept at ${ARTIFACT_DIR:-none})"
+}
+
+case "$CMD" in
+  launch) cmd_launch ;;
+  doctor) cmd_doctor ;;
+  drive-health) cmd_drive_health ;;
+  drive-responses) cmd_drive_responses ;;
+  drive-compact) cmd_drive_compact ;;
+  drive-models) cmd_drive_models ;;
+  drive-status) cmd_drive_status ;;
+  cleanup) cmd_cleanup ;;
+  *) die "usage: verify.sh launch|doctor|drive-health|drive-responses|drive-compact|drive-models|drive-status|cleanup" ;;
+esac


### PR DESCRIPTION
## Summary

- Add the repository `verify-opencodex` skill and its disposable loopback fixture harness.
- Explicitly opt the loopback provider into private-network access so current config validation accepts it.
- Disable native Codex integration inside the disposable fixture so `/readyz` reflects the harness itself, and keep GET evidence capture compatible with `set -e`.

## Verification

- `.claude/skills/verify-opencodex/scripts/verify.sh launch`
- `.claude/skills/verify-opencodex/scripts/verify.sh doctor`
- `.claude/skills/verify-opencodex/scripts/verify.sh drive-health`
- `.claude/skills/verify-opencodex/scripts/verify.sh drive-responses`
- `.claude/skills/verify-opencodex/scripts/verify.sh drive-compact`
- `.claude/skills/verify-opencodex/scripts/verify.sh drive-status`
- `.claude/skills/verify-opencodex/scripts/verify.sh cleanup`
- `bash -n .claude/skills/verify-opencodex/scripts/verify.sh`
- `git diff --cached --check`

The successful run returned `/readyz` with `status: "ready"`; health, Responses, compact, and CLI status drives passed. Artifacts remain under `.claude/skills/verify-opencodex/artifacts/ocx-siw-20260824-pass/` locally after cleanup.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a verification toolkit for testing proxy health, readiness, responses, compact responses, model listings, and status checks.
  * Added an isolated local mock service for exercising verification workflows.
  * Added command-line operations for launching checks, collecting diagnostics, running targeted tests, and cleaning up temporary resources.

* **Documentation**
  * Added guidance for validating processes, endpoints, command-line behavior, test evidence, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->