### PR TITLE
devlog: model/provider UX design unit — aliases, new-models-off, default preset (#2463 #2464 #2465)

### DIFF
--- a/devlog/_plan/260824_model_ux_aliases_and_defaults/000_plan.md
+++ b/devlog/_plan/260824_model_ux_aliases_and_defaults/000_plan.md
@@ -18,9 +18,9 @@ catalog refresh introduces new models already enabled.
 
 | Doc | Design | Issue |
 |-----|--------|-------|
-| 010 | Provider & model aliases (pencil edit, defaults set, CLI space) | Feature proposal A |
-| 020 | Newly discovered models arrive OFF by default | Feature proposal B |
-| 030 | Latest-only default preset per provider | Feature proposal C |
+| 010 | Provider & model aliases (pencil edit, defaults set, CLI space) | [#2463](https://github.com/lidge-jun/opencodex/issues/2463) |
+| 020 | Newly discovered models arrive OFF by default | [#2464](https://github.com/lidge-jun/opencodex/issues/2464) |
+| 030 | Latest-only default preset per provider | [#2465](https://github.com/lidge-jun/opencodex/issues/2465) |
 
 ## Current behavior (evidence base)
 

--- a/devlog/_plan/260824_model_ux_aliases_and_defaults/000_plan.md
+++ b/devlog/_plan/260824_model_ux_aliases_and_defaults/000_plan.md
@@ -1,0 +1,68 @@
+# 000 — model_ux_aliases_and_defaults: Plan & Research
+
+## Objective
+
+Design — to issue-ready, near-implementation precision — three model/provider UX
+improvements, file them as three templated GitHub issues on
+`lidge-jun/opencodex`, and land this design unit on `dev` via a docs-only PR.
+No implementation code in this unit.
+
+Trigger: X feedback on the model picker
+([@terryaidev](https://x.com/terryaidev/status/2091696002550083870)):
+"Probably add customized model name, since some of the model names can be very
+long and not good for user experience." Plus two operator-observed defaults
+problems: live-catalog providers (OpenRouter) expose 400+ models all-on, and
+catalog refresh introduces new models already enabled.
+
+## Deliverables
+
+| Doc | Design | Issue |
+|-----|--------|-------|
+| 010 | Provider & model aliases (pencil edit, defaults set, CLI space) | Feature proposal A |
+| 020 | Newly discovered models arrive OFF by default | Feature proposal B |
+| 030 | Latest-only default preset per provider | Feature proposal C |
+
+## Current behavior (evidence base)
+
+- Visibility is a two-filter system (`src/server/management/model-routes.ts`):
+  - Per-provider allowlist `providers.<name>.selectedModels` — absent/empty
+    means "expose everything" (`/api/selected-models` GET/PUT, line ~531).
+  - Global blocklist `config.disabledModels` (`/api/disabled-models`, ~272).
+  - `/api/model-visibility` (PUT, ~285) updates both atomically; scope
+    `models` or `provider`; native rows use only the blocklist.
+- GUI: `gui/src/model-visibility.ts` — `modelIncluded()` returns true when
+  the allowlist is absent OR empty; `gui/src/pages/Models.tsx` renders per-
+  provider toggle lists ("모두 켜기 / 모두 끄기", custom window).
+- CLI: `ocx models` subcommands `live/edit/enable/disable/provider/selected/
+  context/shadow` (`src/cli/models.ts:415`, `src/cli/models-runtime.ts`).
+- `ModelConfig.displayName` already exists (`src/types/config.ts:190,626`)
+  but only for custom models; there is no provider alias and no resolvable
+  model alias.
+- Live catalogs: `liveModels?: boolean` (`src/types/provider.ts:260`);
+  `getProviderLiveModelCount` feeds the GUI. New live models are visible the
+  moment they are discovered (allowlist absent = all-on).
+
+## Loop-spec
+
+- Loop archetype: verifier-defined (issues exist + PR merged = done).
+- Write scope: `devlog/_plan/260824_model_ux_aliases_and_defaults/**` only.
+  Out of scope: any `src/`, `gui/`, `docs-site/` change; implementation.
+- External writes: 3 issues on lidge-jun/opencodex; 1 PR to `dev` + merge
+  (explicitly user-authorized in the request).
+- Budget: single PABCD work-phase; sol-medium subagent drafts, main verifies.
+
+## Work-phase map (one phase = one full PABCD cycle)
+
+| WP | Doc | Slice | Depends on |
+|----|-----|-------|------------|
+| wp1 | 000/010/020/030 | Research + three designs + 3 issues + docs PR merged to dev | — |
+
+Implementation work-phases are intentionally NOT scheduled here; each issue
+becomes its own future unit when picked up.
+
+## Accept criteria
+
+- c1: three issues created on lidge-jun/opencodex using the exact
+  `feature_request.yml` form headings (survives enforce-issue-quality).
+- c2: this unit contains 000/010/020/030 at design precision.
+- c3: docs-only PR targeting `dev` merged; merge SHA recorded in 090.

--- a/devlog/_plan/260824_model_ux_aliases_and_defaults/010_aliases.md
+++ b/devlog/_plan/260824_model_ux_aliases_and_defaults/010_aliases.md
@@ -1,0 +1,149 @@
+# 010 — Provider & Model Aliases
+
+Status: design proposal (no code). Scope: config schema, request-time resolution, catalog exposure, management API, CLI, GUI.
+
+## Motivation
+
+X feedback: "add customized model name, since some model names can be very long." Real routed slugs today are things like `google-antigravity/gemini-3-pro-preview-11-2025` or `openrouter/anthropic-claude-opus-4.6`. Users type these into Codex's model picker, `/model`, CLI flags, and combo targets. A short, user-chosen alias (`agy/opus`) removes friction on every one of those surfaces. Combos already prove the concept: `OcxComboConfig.alias` (src/types/config.ts:626 area, src/combos/types.ts:43) gives a combo a public short id that resolves at request time. This design generalizes that to providers and individual models.
+
+## Current behavior (verified)
+
+- `OcxCustomModel.displayName` exists (src/types/config.ts:190) and combo `displayName` (src/types/config.ts:626). Both are display-only: src/codex/catalog/effort.ts:118-124 sets `entry.display_name` and explicitly never touches routing.
+- Combo aliases are the only *resolvable* aliases today: `comboPublicModelId` (src/combos/types.ts:76), uniqueness + reserved-namespace validation (src/combos/types.ts:123-165), resolved in `routeModelInternal` before provider namespaces (src/router.ts:627-636).
+- Request routing order in `routeModelInternal` (src/router.ts:558-706): policy namespace → Codex account namespace → combo alias → explicit `<provider>/<model>` for a *configured* provider name → bare native OpenAI family → provider `defaultModel` match → known-model-pattern → provider `models` list → `defaultProvider` fallback.
+- Codex-facing slugs are `routedSlug(provider, id)` with inner slashes encoded to `-` and an exact bijective decode against known ids (src/providers/slug-codec.ts:28-82).
+- Live-catalog providers (`liveModels: true`, src/providers/registry.ts:165; e.g. openrouter with 400+ models) have model ids that never appear in static config — any per-model alias store must key by model id on the provider, not by config model rows.
+- Provider names are validated by `isValidProviderName` (src/config/provider-name.ts:15) with `RESERVED_PROVIDER_NAMES` (prototype-pollution guards + system namespaces).
+
+## Design
+
+### Config schema
+
+```jsonc
+{
+  "providers": {
+    "google-antigravity": {
+      "alias": "agy",                       // NEW: provider alias (id-shaped, no "/")
+      "modelAliases": {                     // NEW: per-model aliases keyed by NATIVE model id
+        "gemini-3-pro-preview-11-2025": "g3p"
+      },
+      "defaultAliases": true                // NEW: opt into built-in alias set for this provider
+    }
+  },
+  "defaultModelAliases": true               // NEW: global opt-in, applied across ALL providers
+}
+```
+
+Field semantics:
+
+- `providers.<name>.alias?: string` — one alias per provider. Must pass `isValidProviderName` (same pattern, same reserved set) and must not equal any configured provider name, any other provider's alias, `policy`, `combo`, or a Codex account namespace. Validated at config load and at the write API.
+- `providers.<name>.modelAliases?: Record<string, string>` — native model id → alias. Keys are native ids (may contain "/", e.g. openrouter's `anthropic/claude-opus-4.6`), matching the `modelContextWindows` / `modelCosts` convention (src/types/provider.ts:272-296). This is why it lives on the provider and not on model rows: live-catalog models have no config row, but a Record keyed by id survives catalog refresh untouched.
+- `providers.<name>.defaultAliases?: boolean` and top-level `defaultModelAliases?: boolean` — enable the built-in alias set per provider or globally. Per-provider value wins over global when both are set. Default: off (aliases are additive surface area; opt-in keeps zero behavior change).
+- Alias value pattern for models: `^[A-Za-z0-9][A-Za-z0-9._-]*$`, no "/". A model alias is always used as the segment after the provider segment (or bare, see resolution), so it must be slash-free — same constraint custom-model `displayName` already enforces (model-routes.ts:407).
+
+### Built-in default alias set
+
+Shipped in code as a new module `src/providers/default-aliases.ts`:
+
+```ts
+/** Native-model-id pattern -> alias. First match wins; ordered most-specific first. */
+export const DEFAULT_MODEL_ALIASES: ReadonlyArray<{ match: RegExp; alias: string }> = [
+  { match: /^claude-opus-5/, alias: "opus" },
+  { match: /^claude-sonnet-5/, alias: "sonnet" },
+  { match: /^claude-haiku/, alias: "haiku" },
+  { match: /^gemini-3(\.\d+)?-pro/, alias: "g3p" },
+  { match: /^gemini-3(\.\d+)?-flash/, alias: "g3f" },
+  { match: /^deepseek-v4/, alias: "ds4" },
+  { match: /^grok-4/, alias: "grok" },
+  // ...curated, extended over releases; also matches after stripping a vendor prefix
+  // ("anthropic/claude-opus-5" on openrouter matches the opus rule).
+];
+```
+
+Vendor-prefixed ids (aggregators) are matched against both the full id and the segment after the last "/". Built-ins are patterns, not exact ids, so snapshot suffixes (`-20260115`) keep their alias across provider refreshes. Precedence: user `modelAliases` entry > built-in rule. Within built-ins, when two models on the SAME provider both match one rule (e.g. two opus snapshots), the built-in alias binds to none of them — ambiguity disables the built-in for that provider and the models list shows a hint; the user resolves it with an explicit `modelAliases` entry. Deterministic and safe over "latest wins" guessing.
+
+### Request-time resolution
+
+Two hook points in `routeModelInternal` (src/router.ts), not one — the qualified and bare forms live at different depths of the existing resolution ladder:
+
+- **Qualified (`head/tail`) aliases** extend the explicit provider-namespace step (src/router.ts:640-665): when the head matches no configured provider name, try provider aliases before falling through; within a resolved provider, when the tail matches no known id/encoded slug, try model aliases. This stays below combo aliases (src/router.ts:627-636), so any name a combo already claims keeps its current meaning.
+- **Bare model aliases** are a LATE step: after every existing bare-resolution step (native OpenAI family, provider defaultModel, known-model pattern, provider models list — src/router.ts:672-698) and immediately BEFORE the `defaultProvider` fallback (src/router.ts:699-703).
+
+One deliberate, documented behavior change follows from the bare-alias slot: a bare id that today reaches the `defaultProvider` fallback resolves via alias instead when it matches an enabled one. This only triggers for alias values the user defined (or a built-in set the user explicitly turned on), which is exactly the intent of defining the alias; the design accepts this as opt-in shadowing of the fallback, and the collision rules below keep aliases from shadowing anything that resolves earlier in the ladder.
+
+Rules for an incoming model id `X`:
+
+1. If `X` contains "/": split at the first "/". Resolve the head as a provider: exact configured-provider name first, else a provider whose `alias` matches. Resolve the tail within that provider: exact known model id / encoded slug first, else a `modelAliases` value match, else an enabled built-in alias match. `agy/opus` → provider `google-antigravity`, model `claude-opus-5-...` — resolved in one pass, both segments may be aliases independently. Note the current slash-path already has partial-match fallbacks (src/router.ts:659-665), so "exact first" describes ordering within the extended step, not a claim that the whole step is untouched.
+2. If `X` is bare (no "/"): existing steps run first (native OpenAI family, provider defaultModel, pattern, models list). If ALL miss, a bare model alias resolves — ahead of the `defaultProvider` fallback (src/router.ts:699-703) — iff exactly one enabled (provider, model) pair carries that alias; two providers sharing alias `opus` make the bare form an error listing both candidates ("model alias 'opus' is ambiguous: agy/opus, claude/opus"), while the qualified forms keep working. A bare provider alias alone never routes.
+3. Aliases resolve for main requests, combo target strings, and subagent model fields — anywhere `routeModel` runs. Resolution happens once, before adapters; upstream always receives the native id. Usage logs and request logs record the native slug plus a `requestedAlias` field so log rows stay joinable.
+
+Collision rules (validated at write time, enforced again defensively at load):
+
+- Provider alias vs real provider name: rejected (409 from API, config-load warning + alias ignored for hand-edited config).
+- Provider alias vs another provider alias: rejected.
+- Model alias vs a real model id on the same provider: rejected for user-set; built-in rule silently skipped (catalog drift must not break startup).
+- Two models on one provider with the same user alias: rejected at write time (last write loses, 409 "alias already used by <id>").
+- Case sensitivity: aliases are stored as typed but matched case-insensitively. Rationale: aliases are typed by hand (the whole point is typing less), so `Opus`/`opus` diverging silently would be a trap; the reserved-name guard already normalizes with `name.toLowerCase()` (src/config/provider-name.ts), and matching follows that convention. Two aliases differing only by case collide.
+
+### Catalog exposure (/v1/models and Codex catalog)
+
+Two options considered:
+
+- (a) Alias replaces the id: shortest picker entries, but breaks log/usage continuity, breaks any client that persisted the old slug, and makes disabledModels/selectedModels matching ambiguous.
+- (b) Alias as an additional resolvable id; display uses alias: canonical slug `provider/model` stays the row id everywhere; the catalog row gains `display_name` = `alias` (provider-alias-qualified: `agy/opus`) via the existing display_name path (src/codex/catalog/effort.ts:118-124); /v1/models additionally lists the alias id as its own entry marked `"alias_of": "google-antigravity/claude-opus-5"` so scripted clients can request it directly.
+
+Recommendation: (b). Persistence (selectedModels, disabledModels, combos, usage) keeps canonical slugs only; aliases are a resolution/display layer that can be renamed or removed without touching stored state. `slugEquals` and the visibility filters (src/codex/catalog/provider-fetch.ts:1555-1577) are unchanged.
+
+### Management API
+
+- `PUT /api/providers/:name/alias` body `{"alias": "agy"}` → `{"ok":true,"provider":"google-antigravity","alias":"agy"}`; `{"alias": null}` clears. 409 on collision with `{"error":"alias conflicts with provider 'x'"}`.
+- `PUT /api/providers/:name/model-aliases` body `{"set": {"gemini-3-pro-preview-11-2025": "g3p"}, "remove": ["old-id"]}` → `{"ok":true,"aliases":{...}}`. Partial-update semantics like other model-keyed Records; 409 per-entry collisions reported as `{"error":"...","conflicts":[{"alias":"g3p","heldBy":"..."}]}`.
+- `PUT /api/default-aliases` body `{"enabled": true, "provider": "openrouter"}` (provider omitted = global) → `{"ok":true}`.
+- `GET /api/aliases` → effective view: `{"providers":{"google-antigravity":"agy"},"models":{"google-antigravity":{"gemini-3-pro-preview-11-2025":{"alias":"g3p","source":"user"}}},"defaults":{"global":false,"providers":{"openrouter":true}},"ambiguousBuiltins":{"claude":["opus"]}}`. The GUI and CLI both read this one endpoint.
+- All writes go through `saveConfigPreservingClaudeCode` and end with `convergeCodexCatalog()` like the existing model routes (model-routes.ts:172, 277-279), so display_name changes reach Codex on the next turn.
+
+### CLI
+
+Namespace: `ocx alias` (top-level; aliases span providers and models, and `ocx models` is already eight subcommands deep — src/cli/models.ts:415).
+
+```
+ocx alias list [--json]                          # effective table: kind, target, alias, source (user|builtin)
+ocx alias set <provider> <alias>                 # provider alias:  ocx alias set google-antigravity agy
+ocx alias set <provider>/<modelId> <alias>       # model alias:     ocx alias set openrouter/anthropic/claude-opus-4.6 opus
+ocx alias rm <provider>[/<modelId>]              # clear
+ocx alias defaults on|off [--provider <name>]    # built-in set, global or per provider
+```
+
+`<provider>/<modelId>` splits at the FIRST "/" (provider names cannot contain "/"); the remainder is the native id, slashes included. Implemented in `src/cli/alias.ts` following the models-runtime.ts pattern (runtimeRequest against the management API, offline config fallback like `ocx models add`).
+
+### GUI
+
+- Models window (gui/src/pages/Models.tsx): pencil icon after the provider group header sets the provider alias; pencil on each model row sets/clears the model alias (inline edit, Enter saves, shows 409 conflicts inline). Rows show `alias · canonical-id` with alias emphasized.
+- Provider header overflow menu gains "Use default aliases" toggle (per provider); a global toggle sits in the Models window toolbar next to the existing visibility controls. Built-in-derived aliases render with a subtle "auto" badge; clicking one pre-fills the edit field to promote it to a user alias.
+- Bulk view: toolbar "Aliases" button opens a filterable table (provider, model, alias, source) with inline editing — the GET /api/aliases payload verbatim.
+
+## Resolution & edge cases
+
+- Catalog refresh: `modelAliases` keys pointing at ids no longer discovered are kept (snapshot churn is temporary); `GET /api/aliases` marks them `"stale": true` and the GUI dims them. Nothing auto-deletes user intent.
+- Export/import: aliases live inside config.json, so existing config export/import carries them. Client config export (`/api/client-config`, ocx export) emits canonical ids; a follow-up may add `--use-aliases`.
+- Combos: combo target strings may use aliases (resolved through routeModel); the combo `alias` field itself is unchanged and keeps winning at its earlier resolution slot. Collision checks are bidirectional: a provider/model alias colliding with an existing combo alias is rejected at write time, and combo alias validation (src/combos/types.ts:123-165) gains the mirror check against existing provider/model aliases.
+- Native OpenAI models: bare native family ids (src/router.ts:672) resolve before alias lookup, so a built-in alias can never shadow `gpt-5.6-sol`; a user alias equal to a native family id is rejected (same guard combos apply via nativeAlias, src/combos/types.ts:146-152).
+- Codex account namespaces resolve before aliases (src/router.ts:598); an alias equal to a configured account namespace is rejected.
+- Renaming a provider (config key change) orphans its alias with it — aliases are stored inside the provider object, so they move or die with the provider entry atomically.
+
+## Migration & compatibility
+
+- No migration: all fields optional, absent = today's behavior exactly. Old binaries reading a new config ignore unknown keys (config parse is tolerant; `safeConfigDTO` should include the new fields for the GUI).
+- Requests by canonical slug are untouched at every step — alias resolution only runs where today's resolution would already have missed or after exact matches fail. The one intentional exception is the bare-alias-over-defaultProvider shadowing documented in Request-time resolution above.
+
+## Out of scope
+
+- Aliases for combos (exists), policies, or Codex accounts.
+- Alias-based filtering in usage/cost summaries (logs store canonical + requestedAlias; summary UX later).
+- Per-client alias sets (different aliases for Claude Code vs Codex).
+
+## Open questions
+
+1. Should /v1/models list alias entries as separate rows or only annotate? Proposed: separate row with `alias_of`, gated behind a query param `?aliases=1` initially to avoid confusing existing clients. Default recommendation: annotate-only in v1, separate rows once a client asks.
+2. Bare model alias (`opus` with no provider) — allow when globally unique? Proposed: yes (rule 2 above); it is the highest-value typing shortcut and the ambiguity error is deterministic.
+3. Built-in alias list curation cadence — proposed: update alongside the provider registry in normal releases; no runtime fetch.

--- a/devlog/_plan/260824_model_ux_aliases_and_defaults/020_new_models_off.md
+++ b/devlog/_plan/260824_model_ux_aliases_and_defaults/020_new_models_off.md
@@ -1,0 +1,131 @@
+# 020 — Newly Discovered Models Arrive OFF by Default
+
+Status: design proposal (no code). Scope: discovery baseline, policy setting, API/GUI surfacing, migration.
+
+## Motivation
+
+Providers with `liveModels: true` (src/providers/registry.ts:165; most rows, including openrouter) re-fetch their `/models` endpoint on catalog sync. Any model the vendor publishes overnight appears in the user's Codex picker on the next refresh, silently. That is the wrong default for a proxy that routes real spend: a new model can be more expensive, unvetted, or a duplicate snapshot. The user should opt models IN as they arrive, not race to turn them off.
+
+## Current behavior (verified)
+
+- Visibility is two persisted filters composed in `filterCatalogVisibleModels` (src/codex/catalog/provider-fetch.ts:1555-1577): a per-provider allowlist `providers.<name>.selectedModels` (non-empty = only these ship; empty/absent = ALL discovered models ship — src/types/provider.ts:262-268) and a global blocklist `config.disabledModels` (src/types/config.ts:391).
+- With an EMPTY allowlist, every newly discovered model is immediately visible: it is not in `disabledModels` and there is no allowlist to exclude it.
+- With a NON-EMPTY allowlist, newly discovered models are already effectively off — they are not in `selectedModels`, so the filter drops them. The problem is exclusively the empty-allowlist ("all on") state, which is the default for every provider.
+- There is no persisted record of which models a provider was known to have: the live model cache is in-memory with a 5-minute TTL (src/codex/model-cache.ts:15, DEFAULT_MODEL_CACHE_TTL_MS), and the on-disk Codex catalog is a rendered artifact, not a per-provider baseline. Nothing today can distinguish "newly discovered" from "always been there".
+- `/api/model-visibility` PUT (src/server/management/model-routes.ts:285-390) mutates both filters atomically; enable with scope=provider clears the allowlist entirely (line 350), enable with scope=models appends to a non-empty allowlist (line 368-371).
+
+## Design
+
+### Core mechanism: persisted known-model baseline
+
+A model is "new" iff it is discovered now and absent from the last persisted baseline. Add to config:
+
+```jsonc
+{
+  "modelDiscovery": {
+    "newModelPolicy": "off",              // "off" | "on" | "inherit"  (per-install default)
+    "knownModels": {                      // baseline: native ids seen per provider
+      "openrouter": {
+        "ids": ["anthropic/claude-opus-4.6", "..."],
+        "removed": [],
+        "updatedAt": "2026-08-24T00:00:00Z"
+      }
+    },
+    "recentArrivals": {                   // ring buffer for the GUI "new" badge, max ~50/provider
+      "openrouter": [ { "id": "x-ai/grok-5", "at": "2026-08-24T02:11:00Z" } ]
+    }
+  },
+  "providers": {
+    "openrouter": { "newModelPolicy": "off" }   // per-provider override of the global policy
+  }
+}
+```
+
+- `newModelPolicy`: `"on"` = today's behavior (new arrivals visible). `"off"` = new arrivals hidden until enabled. Per-provider `"inherit"` (or absent) falls back to the global value; global absent = `"on"` for existing installs (see Migration) and `"off"` seeded for fresh installs.
+- `knownModels` stores NATIVE ids (the same form `selectedModels` uses). It is written only after a SUCCESSFUL live fetch for that provider — a failed or partial fetch must never shrink the baseline, otherwise a provider outage would mark the entire catalog "new" on recovery. Sorted, deduped, size-bounded per provider (cap ~2000 ids; over cap, policy degrades to "on" for that provider with a logged warning rather than corrupting the baseline).
+
+### Applying the policy at catalog convergence
+
+Hook point: the catalog gather path that already runs on every convergence (`gatherRoutedModels` → `filterCatalogVisibleModels`, provider-fetch.ts). After a provider's live fetch succeeds and before visibility filtering:
+
+1. `newIds = discovered − knownModels[provider].ids − knownModels[provider].removed` (first run with no baseline: everything is "known", nothing is new — baseline bootstrap must not hide the whole catalog).
+2. If effective policy is `"off"` and `newIds` is non-empty:
+   - Empty allowlist ("all on") case: append `routedSlug(provider, id)` for each new id to `config.disabledModels`. The blocklist is the right store here because it composes with an empty allowlist without freezing it — seeding `selectedModels` with the full current list would convert "all on" into a frozen snapshot and silently change the meaning of the user's existing state. The blocklist grows only by genuinely new arrivals.
+   - Non-empty allowlist case: do nothing. The allowlist already excludes new ids; adding blocklist rows would be redundant state to reconcile later.
+3. Record arrivals in `recentArrivals` and update the baseline.
+4. Persist via `saveConfigPreservingClaudeCode` once per convergence (single write, all providers batched).
+
+Existing user choices are never flipped: the step only APPENDS blocklist entries for ids that were not in the baseline, and `slugEquals`-matching entries already present are not duplicated. A user who enables a new arrival removes its blocklist row through the existing `/api/model-visibility` enable path — the baseline already contains the id by then, so the next refresh does not re-disable it.
+
+Models that DISAPPEAR from a provider's catalog are removed from the active baseline only after N=3 consecutive successful fetches without them (vendor list flapping is real); their blocklist rows are left alone (harmless, and the model may return). Removal is NOT deletion: pruned ids move to a compact per-provider tombstone list `knownModels[provider].removed: string[]` (ids only, same size bound). The newness test is `newIds = discovered − ids − removed`, so a model that leaves and later returns is never "new" again. This is what makes the correctness claim hold unconditionally: the union `ids ∪ removed` grows monotonically across successful fetches, so each id can be auto-disabled at most once, ever — including the flapping case where a user enabled the model, the vendor dropped it long enough to prune the active baseline, and it then returned. A rename still counts as new (the new id was never in either set), which remains the safe reading.
+
+### Scenario walkthrough (correctness check)
+
+State: openrouter, empty allowlist (all on), policy "off", baseline B = {a, b, c}.
+
+| Event | discovered | new = disc − B | action | user-visible result |
+|---|---|---|---|---|
+| Refresh, vendor adds d | {a,b,c,d} | {d} | append `openrouter/d` to disabledModels; B←{a,b,c,d}; record arrival | a,b,c shown; d hidden with NEW badge |
+| User enables d | — | — | existing enable path removes blocklist row | d shown; badge cleared |
+| Next refresh | {a,b,c,d} | {} | none (d ∈ B) | d STAYS enabled — no re-disable |
+| User disables b manually | — | — | ordinary blocklist row | b hidden |
+| Vendor drops b, then restores it | {a,c,d} ×3 → {a,b,c,d} | {b} after drop-out | b left in blocklist untouched; on return, b re-enters B; its old blocklist row still applies | b stays hidden — user intent preserved |
+| User ENABLES d; vendor drops d ×3 (pruned to tombstone); vendor restores d | {a,b,c} ×3 → {a,b,c,d} | {} — d ∈ removed tombstone | none; d re-enters active baseline from tombstone | d comes back ENABLED — no re-disable, at-most-once holds |
+| Vendor renames c → c-v2 | {a,b,d,c-v2} | {c-v2} | c-v2 auto-disabled as a new arrival | rename = removal + arrival; user opts into c-v2 explicitly |
+
+The last row is deliberate: a rename is indistinguishable from a new model, and treating it as new is the safe reading (pricing/behavior may have changed with the rename).
+
+### Native models exception
+
+Bare native OpenAI family models (`isBareOpenAiFamilyModel`, defined at src/router.ts:496, applied in resolution at src/router.ts:672) are exempt: they come from the pinned Codex runtime contract, not live vendor discovery, and hiding a new `gpt-5.x` row would break the primary Codex account flow. Policy applies to routed providers only. Custom models (`config.customModels`) are user-created and always on.
+
+### Setting surface
+
+- API: `GET/PUT /api/model-discovery` — `{"policy":"off","providers":{"openrouter":"inherit"},"recentArrivals":{...}}`; PUT accepts `{"policy":"on"|"off","provider":"openrouter"|null}`. A dedicated `POST /api/model-discovery/acknowledge` body `{"provider":"openrouter","ids":["x-ai/grok-5"]}` clears "new" badges without changing visibility.
+
+  Full GET response shape:
+
+  ```json
+  {
+    "policy": "off",
+    "providers": { "openrouter": "inherit", "claude": "on" },
+    "recentArrivals": {
+      "openrouter": [
+        { "id": "x-ai/grok-5", "at": "2026-08-24T02:11:00Z", "state": "auto-disabled" }
+      ]
+    },
+    "baselineCounts": { "openrouter": 412, "claude": 14 }
+  }
+  ```
+
+  `state` is derived at read time (`auto-disabled` | `enabled` | `acknowledged`) so the GUI needs no extra bookkeeping. PUT responses echo `{"ok":true,"policy":...,"provider":...}` and, when flipping global policy to "off" for the first time, include `"baselineBootstrapped": true` so the CLI can print what happened.
+- CLI: `ocx models new-policy [on|off] [--provider <name>]` (show current when no argument) and `ocx models new-arrivals [--json]` listing recent arrivals with their on/off state. Lives beside the existing runtime subcommands (src/cli/models-runtime.ts USAGE block).
+- GUI (gui/src/pages/Models.tsx): global toggle "New models start disabled" in the Models toolbar; per-provider override in the provider header menu. Each recent arrival's row shows a "NEW" badge (from `recentArrivals`) until acknowledged or enabled; the provider header shows a count chip ("3 new, off"). Enabling from the row uses the existing putModelVisibility path (gui/src/model-visibility.ts:58) unchanged.
+
+## Resolution & edge cases
+
+- Baseline bootstrap: first successful fetch after upgrade writes the baseline and disables nothing. No thundering "everything is new" event.
+- Provider added by the user: the add flow seeds an empty baseline entry; the FIRST fetch after an explicit provider add is treated as bootstrap (nothing new) — the user just chose this provider and expects to see its models. Doc 030's preset then narrows the initial set; from the second fetch on, arrivals follow the policy.
+- Fetch failures / partial catalogs: baseline updates only on `{status:"ok"}` discovery (ProviderModelDiscoveryStatus, src/codex/model-cache.ts). A provider returning a truncated list on error paths cannot poison the baseline.
+- disabledModels growth: bounded by real vendor additions; entries are plain routed slugs indistinguishable from user-authored ones (deliberate — one store, one semantics). `recentArrivals` carries the "why" for the GUI instead of tagging blocklist entries.
+- Combos/policies referencing a new-and-disabled model: unaffected — `disabledModels` hides models from DISCOVERY (catalog + /v1/models) but does not block direct proxy calls (src/types/config.ts:385-390 comment). Routing keeps working; only the picker hides it.
+- Interaction with aliases (doc 010): aliases are a resolution layer over canonical slugs; a disabled new arrival simply has no catalog row, alias or not. Built-in default aliases may match a new arrival — fine, resolution still works for direct calls.
+- Interaction with preset (doc 030): a provider in preset mode has a non-empty `selectedModels`, so this policy is a no-op there by construction (case 2 above). The two features compose without coordination: preset governs the initial curated set, new-model policy governs drift for all-on providers.
+
+## Migration & compatibility
+
+- Existing installs: absent `modelDiscovery` = policy `"on"`, zero behavior change until the user opts in. On first opt-in, the current catalog becomes the baseline (bootstrap), so opting in never hides anything retroactively.
+- Fresh installs: `ocx` init writes `"newModelPolicy": "off"` — new users get the safe default; the GUI onboarding mentions it once.
+- Downgrade: older binaries ignore `modelDiscovery` and simply stop enforcing the policy; blocklist entries appended earlier keep working (they are ordinary `disabledModels` rows). No lossy state.
+
+## Out of scope
+
+- Notification channels beyond the GUI badge (no email/webhook on new arrivals).
+- Auto-enabling arrivals matching a pattern ("always enable new -flash models") — expressible later as preset-pattern reuse.
+- Per-model metadata diffing (context window changes on an EXISTING id are not "new").
+
+## Open questions
+
+1. Should auto-appended blocklist rows be tagged (e.g. `disabledModelsMeta`) so the GUI can distinguish "auto-disabled on arrival" from "user disabled"? Proposed: no separate store; `recentArrivals` covers the UX need and one blocklist keeps semantics simple.
+2. Baseline location — config.json vs a sidecar state file? Proposed: config.json under `modelDiscovery` for atomicity with the blocklist writes it drives; if size becomes a problem (openrouter ~400 ids ≈ 15KB) move `knownModels` to `~/.opencodex/model-baseline.json` in a follow-up while keeping the policy flag in config.
+3. Disappearance grace count N=3 — tune after observing real vendor flapping; the constant is otherwise arbitrary.

--- a/devlog/_plan/260824_model_ux_aliases_and_defaults/030_default_preset.md
+++ b/devlog/_plan/260824_model_ux_aliases_and_defaults/030_default_preset.md
@@ -1,0 +1,120 @@
+# 030 — Latest-Only Default Preset per Provider
+
+Status: design proposal (no code). Scope: shipped preset registry, preset mode semantics, reconciliation on upgrade, API/CLI/GUI.
+
+## Motivation
+
+Adding openrouter exposes 400+ models to Codex's picker on day one; adding an Anthropic provider exposes every historical snapshot (`claude-3-*` through current). The useful set is a handful of current flagships. Today the burden is inverted: the user must build `selectedModels` by hand from hundreds of rows. The default for a newly added provider should be a curated "latest/core" preset, with "everything" one click away.
+
+## Current behavior (verified)
+
+- Per-provider allowlist `providers.<name>.selectedModels` (src/types/provider.ts:262-268): non-empty = only these ship to the Codex catalog and /v1/models; empty/absent = all. Managed by `GET/PUT /api/selected-models` (src/server/management/model-routes.ts:531-562); PUT with an empty list deletes the allowlist ("all on", line 557-558).
+- The admin `/api/models` list is deliberately unfiltered so pickers can offer the full set (provider.ts:266 comment).
+- `deriveProviderPresets` (src/providers/derive.ts:346) exists but is a different concept — dashboard provider-setup presets (which providers to offer), not model curation. Naming must not collide; this design uses "model preset".
+- Provider registry rows already carry curated static `models` arrays and per-model metadata (src/providers/registry.ts, e.g. ANTIGRAVITY_MODELS at line 1600), so a code-maintained per-provider list is an established pattern.
+- There is no record of whether a user ever edited `selectedModels` — absence is indistinguishable from "user chose all". Preset reconciliation needs an explicit marker (below).
+
+## Design
+
+### Shipped preset registry
+
+New module `src/providers/model-presets.ts`, keyed by registry provider id, values are ID PATTERNS so vendor snapshot suffixes don't stale the preset between releases:
+
+```ts
+export interface ModelPresetRule { pattern: RegExp; }
+export const MODEL_PRESETS: Readonly<Record<string, { version: number; rules: ModelPresetRule[] }>> = {
+  openrouter: { version: 3, rules: [
+    { pattern: /^anthropic\/claude-(opus|sonnet)-[45]/ },
+    { pattern: /^google\/gemini-3(\.\d+)?-(pro|flash)/ },
+    { pattern: /^openai\/gpt-5/ },
+    { pattern: /^deepseek\/deepseek-v4/ },
+    { pattern: /^x-ai\/grok-[45]/ },
+  ]},
+  claude: { version: 2, rules: [
+    { pattern: /^claude-opus-5/ }, { pattern: /^claude-sonnet-5/ }, { pattern: /^claude-haiku-4/ },
+  ]},
+  // ...one entry per high-volume provider; providers without an entry have no preset (mode "all").
+};
+```
+
+`version` bumps whenever a provider's rules change; it drives upgrade reconciliation. Patterns match native ids (and, for aggregators, the full vendor-prefixed id). Curation cadence: same release train as the provider registry.
+
+### Config schema
+
+```jsonc
+{
+  "providers": {
+    "openrouter": {
+      "selectedModels": ["anthropic/claude-opus-4.6", "..."],   // existing field, seeded by the preset
+      "modelPreset": {                                          // NEW marker object
+        "mode": "preset",                 // "preset" | "all" | "custom"
+        "appliedVersion": 3,              // MODEL_PRESETS version materialized into selectedModels
+        "appliedAt": "2026-08-24T00:00:00Z"
+      }
+    }
+  }
+}
+```
+
+Semantics — the preset is a SEED, not a lock:
+
+- `mode: "preset"`: `selectedModels` was materialized from the preset rules against the then-current catalog and the user has not diverged. The proxy may re-materialize on upgrade (below).
+- `mode: "custom"`: the user edited the selection after seeding. The proxy never touches `selectedModels` again. Any write through `PUT /api/selected-models` or `/api/model-visibility` that changes the list while mode is "preset" flips it to "custom" automatically — divergence is detected at the write path, not by diffing.
+- `mode: "all"` (or the whole `modelPreset` object absent): no allowlist management; empty `selectedModels` = everything visible, exactly today's semantics.
+- Materialization: evaluate rules against the provider's discovered catalog at apply time and store CONCRETE ids in `selectedModels`. Concrete ids keep `filterCatalogVisibleModels` (src/codex/catalog/provider-fetch.ts:1555) and every existing consumer byte-compatible — no pattern matching enters the visibility hot path, and older binaries see a plain allowlist.
+
+### When the preset applies
+
+- Newly added provider (fresh install or existing install adding a provider): if `MODEL_PRESETS` has an entry, seed `mode:"preset"` and materialize on the first successful live fetch (static-catalog providers materialize immediately from registry `models`). The add-provider GUI/CLI flow states it plainly: "Showing the N current core models — switch to All to see everything."
+- Existing configured providers on upgrade: untouched (mode stays absent = "all"). Opt-in via GUI/CLI below. Silently narrowing an existing user's catalog is a behavior break; a one-time dashboard hint ("openrouter exposes 412 models — apply the core preset?") is the migration nudge instead.
+- Preset updates on upgrade: on catalog convergence, if a provider is in `mode:"preset"` and `MODEL_PRESETS[provider].version > appliedVersion`, re-materialize (new rules against current catalog, replace `selectedModels`, update marker). Because any user edit flips mode to "custom", auto-re-apply only ever happens for users who never diverged — the reconciliation question collapses to a version compare. A "custom" provider with a newer preset shows a non-blocking GUI hint ("Preset updated — apply and discard your edits?") that requires explicit confirmation.
+- Re-materialization on ordinary refresh (no version bump): also allowed in `mode:"preset"` — when a NEW model matches the rules (e.g. claude-opus-5.1 ships), it is added to `selectedModels` automatically. This is the "latest" promise: preset mode tracks flagships as they arrive. Models that stop matching are removed only on version bumps, not on refresh (rules are stable between releases, so refresh-time changes are additive by construction).
+
+### API
+
+- `GET /api/model-presets` → `{"providers":{"openrouter":{"mode":"preset","appliedVersion":3,"availableVersion":3,"presetIds":["..."],"presetCount":9,"totalCount":412}}}` — preview without applying (`presetIds` = rules evaluated against the current catalog).
+- `PUT /api/model-presets` body `{"provider":"openrouter","mode":"preset"|"all"|"custom"}` → applies/clears; `mode:"preset"` materializes immediately and returns `{"ok":true,"selected":[...],"catalogRefresh":...}`. `mode:"all"` deletes `selectedModels` + marker (same effect as today's empty-list PUT, model-routes.ts:557-558).
+- Existing `PUT /api/selected-models` and `PUT /api/model-visibility` gain one line of behavior: mutating `selectedModels` for a provider whose marker says `mode:"preset"` sets `mode:"custom"`. No request/response shape changes.
+
+### CLI
+
+```
+ocx models preset show [--provider <name>] [--json]   # mode, applied/available version, id preview per provider
+ocx models preset apply <provider>                    # switch to preset mode, materialize now
+ocx models preset apply <provider> --all              # back to "all" (clears allowlist + marker)
+```
+
+Slots into the existing runtime dispatch (src/cli/models.ts:415 subcommand list; handler beside `selected` in src/cli/models-runtime.ts). `ocx models selected <provider> --set ...` keeps working and flips mode to custom via the API-side rule.
+
+### GUI
+
+- Provider group header in Models.tsx gains a compact segmented selector: **Preset / All / Custom** ("프리셋 / 전체 / 커스텀"). Custom is not directly clickable — it activates automatically on edit and shows as the current state; clicking Preset from Custom shows the confirm dialog ("replaces your selection with N preset models").
+- Preset mode shows "9 of 412 shown — core preset v3"; stale version shows an "update available" chip that re-materializes on click (only reachable in Custom mode, per auto-apply rule above).
+- Add-provider flow: providers with a preset default the selector to Preset and say so before the first save.
+
+## Resolution & edge cases
+
+- Preset matches zero models (catalog drift outran rules): keep the previous `selectedModels` untouched, log a warning, surface a GUI chip ("preset matched nothing — showing previous selection"). Never write an empty allowlist from a preset, because empty means ALL (model-routes.ts:556-558) and would silently un-curate. For a freshly added provider there is no previous selection to keep: zero matches at first materialization falls back to `mode:"all"` (marker records `fallback:"preset-empty"`), the add flow says so, and the next convergence retries materialization while the fallback marker is present.
+- Custom models (`config.customModels`) and combo rows are outside preset scope — visibility for those already has its own paths; preset materialization only writes provider-catalog ids.
+- Interaction with 020 (new-model policy): preset mode maintains a non-empty allowlist, so 020's blocklist-append branch never fires for preset providers (its allowlist case is a no-op by design). A new flagship arrives ON in preset mode iff it matches the rules — that is the point of preset mode, and 020's policy explicitly yields to it: allowlisted providers are governed by their allowlist. Providers in "all" mode remain 020's territory.
+- Interaction with 010 (aliases): orthogonal. Preset governs which rows exist; aliases govern how rows are named/resolved. Built-in default aliases target flagship patterns, so preset-mode catalogs get near-complete alias coverage for free.
+- Disabled providers, providers with `liveModels:false`: preset materializes from the registry's static `models` list; no live fetch needed.
+- Export/import of config: marker + materialized ids are plain config fields; an import onto a newer binary reconciles by version like any upgrade.
+
+## Migration & compatibility
+
+- Zero change for every existing provider (mode absent = "all"). Fresh installs and newly added providers get preset mode by default only when a registry preset exists.
+- Downgrade: older binaries ignore `modelPreset` and honor `selectedModels` as a plain allowlist — the materialized-concrete-ids decision makes downgrade lossless. Re-upgrading resumes reconciliation from the stored marker.
+- The marker travels inside the provider object, so provider deletion/rename carries or removes it atomically.
+
+## Out of scope
+
+- User-defined preset rules (custom regex sets) — the marker structure leaves room (`mode:"preset"` could later carry a `rules` override) but v1 ships code-maintained presets only.
+- Cross-provider "global preset" (one switch curating every provider at once) — expressible later as a bulk PUT.
+- Cost/quality-based automatic curation.
+
+## Open questions
+
+1. Should refresh-time additive re-materialization (new flagship auto-ON) be a sub-toggle? Proposed: no — it is the defining behavior of preset mode; a user who dislikes it is by definition Custom.
+2. Preset for the native `openai` provider (hide old gpt snapshots)? Proposed: exclude in v1 — native rows flow through a different catalog path (nativeModelRows) and the blocklist already handles them; revisit if users ask.
+3. Naming collision with `deriveProviderPresets` (provider-setup presets): rename risk is docs-only; proposed to consistently say "model preset" in code (`MODEL_PRESETS`, `modelPreset`) and UI copy.


### PR DESCRIPTION
## Summary

- Adds design unit `devlog/_plan/260824_model_ux_aliases_and_defaults/` (docs only, no runtime change): research notes plus three issue-ready designs for model/provider UX defaults.
- 010 — provider & model aliases (pencil-icon editing, built-in default alias set, `ocx alias` CLI space, request-time resolution and collision rules). Filed as #2463.
- 020 — newly discovered live-catalog models arrive disabled by default via a persisted known-model baseline with tombstoned removals. Filed as #2464.
- 030 — latest-only default model preset per provider (versioned pattern registry, seed-not-lock semantics, divergence detection at the write path). Filed as #2465.

## Verification

- Docs-only change; no `src/`, `gui/`, or `docs-site/` files touched (`git diff --stat origin/dev` shows only `devlog/_plan/260824_model_ux_aliases_and_defaults/`).
- Pre-push hook ran `bun run typecheck`, `bun run test`, and `bun run privacy:scan` — all green.
- Designs were adversarially reviewed against the live tree (12+ file:line citations spot-verified; 3 correctness findings found and fixed, final verdict PASS).

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added planning and design documentation for model and provider usability improvements.
  * Proposed support for aliases, configurable handling of newly discovered models, and provider-specific latest-model presets.
  * Documented expected configuration, catalog, API, CLI, and GUI behavior, along with migration considerations and open questions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->