### PR TITLE
fix(quota): avoid arbitrary Antigravity family window

### DIFF
--- a/src/providers/quota.ts
+++ b/src/providers/quota.ts
@@ -2103,9 +2103,11 @@ async function fetchAntigravityQuota(provider: string, config: OcxProviderConfig
     if (!modelInfo) continue;
     for (const quotaInfo of quotaInfoEntries(modelInfo)) {
       const label = classifyAntigravityFamily(modelId, modelInfo, quotaInfo);
-      if (!label || windows.has(label)) continue;
+      if (!label) continue;
       const percent = antigravityUsedPercent(quotaInfo);
       if (percent === undefined) continue;
+      const current = windows.get(label);
+      if (current && current.percent <= percent) continue;
       windows.set(label, {
         label,
         percent,

--- a/tests/provider-quota.test.ts
+++ b/tests/provider-quota.test.ts
@@ -171,6 +171,14 @@ describe("fetchProviderQuotaReports", () => {
       if (url === "https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels") {
         return new Response(JSON.stringify({
           models: {
+            "gemini-3.1-pro": {
+              displayName: "Gemini 3.1 Pro",
+              quotaInfo: { remainingFraction: 0.05, resetTime: "2026-07-05T13:00:00Z" },
+            },
+            "gemini-3.7-flash": {
+              displayName: "Gemini 3.7 Flash",
+              quotaInfo: { remainingFraction: 0.99, resetTime: "2026-07-05T13:30:00Z" },
+            },
             "gemini-3.6-flash-medium": {
               displayName: "Gemini 3.6 Flash (Medium)",
               quotaInfo: { remainingFraction: 0.64, resetTime: "2026-07-05T14:00:00Z" },
@@ -221,7 +229,7 @@ describe("fetchProviderQuotaReports", () => {
       { label: "Sonnet", percent: 19 },
     ]);
     expect(byProvider["google-antigravity"]?.quota.customWindows).toEqual([
-      { label: "Gem", percent: 36, resetAt: Date.parse("2026-07-05T14:00:00Z") },
+      { label: "Gem", percent: 1, resetAt: Date.parse("2026-07-05T13:30:00Z") },
       { label: "Cla", percent: 79, resetAt: Date.parse("2026-07-05T15:00:00Z") },
     ]);
     expect(byProvider.cursor?.source).toBe("cursor:period-usage");


### PR DESCRIPTION
## Summary

- Select the least-used quota window within each Antigravity model family instead of whichever model happens to appear first in the upstream response.
- Add a regression fixture where an earlier Gemini model is 95% used and another is 1% used; the generic Gemini window now reports 1% used.

## Verification

- `node node_modules/typescript/bin/tsc --noEmit`
- `bun test tests/provider-quota.test.ts` (105 passed)
- `bun scripts/privacy-scan.ts`
- Full suite was started but not completed; this remains a draft PR.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (not needed for this behavioral bug fix).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
