### PR TITLE
fix(cli): resolve the effort ladder the way the runtime resolves it

### DIFF
--- a/src/cli/models.ts
+++ b/src/cli/models.ts
@@ -5,7 +5,12 @@ import { randomUUID } from "node:crypto";
 import { createInterface } from "node:readline/promises";
 import { syncModelsToCodex } from "../codex/sync";
 import { hasOwnProvider, isValidProviderName, loadConfig, saveConfig } from "../config";
-import { canonicalizeReasoningEfforts, isDeclaredReasoningEffort, modelRecordValue } from "../reasoning-effort";
+import {
+  canonicalizeReasoningEfforts,
+  configuredReasoningEfforts,
+  isDeclaredReasoningEffort,
+  modelRecordValue,
+} from "../reasoning-effort";
 import { encodedModelIdCollides, routedSlug, slugEquals } from "../providers/slug-codec";
 import { knownModelIdsForProvider } from "../router";
 import { findLiveProxy } from "../server/proxy-liveness";
@@ -91,7 +96,6 @@ function collectModels(config: OcxConfig, providerFilter?: string): ModelEntry[]
     const seen = new Set<string>();
     const contextWindows = prov.modelContextWindows ?? {};
     const inputModalities = prov.modelInputModalities ?? {};
-    const reasoningEfforts = prov.modelReasoningEfforts ?? {};
     const globalContext = prov.contextWindow ?? null;
 
     const addModel = (model: string, isDefault: boolean) => {
@@ -107,7 +111,13 @@ function collectModels(config: OcxConfig, providerFilter?: string): ModelEntry[]
       // an exact `gpt-oss:120b` entry that lists "image", and the proxy rejects the image.
       const noVision = modelInList(prov.noVisionModels, model);
       const modalities = noVision ? ["text"] : (modelRecordValue(inputModalities, model) ?? null);
-      const efforts = modelRecordValue(reasoningEfforts, model) ?? prov.reasoningEfforts ?? null;
+      // Same reason, for the ladder: `configuredReasoningEfforts` is what the catalog
+      // (`provider-fetch`) and the effort cap (`effort-policy`) resolve through, and it
+      // does three things this expression did not — it returns [] for a noReasoningModels
+      // match, drops levels Codex does not declare, and re-adds tiers the wire map proves
+      // the model emits. Restating two of its five lines here reported a ladder the proxy
+      // strips, and unsanitized junk as a supported level.
+      const efforts = configuredReasoningEfforts(prov, model) ?? null;
 
       entries.push({
         provider: provName,

--- a/tests/cli-models.test.ts
+++ b/tests/cli-models.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { INTERNAL_DEADLINE_MS, SPAWN_BUDGET_MS } from "./helpers/test-budget";
+import { configuredReasoningEfforts } from "../src/reasoning-effort";
 import { isModelTextOnly } from "../src/vision";
 import type { OcxProviderConfig } from "../src/types";
 
@@ -198,6 +199,48 @@ describe("ocx models richer metadata", () => {
       expect(row.inputModalities).toEqual(["text"]);
       expect(row.contextWindow).toBe(131000);
       expect(row.reasoningEfforts).toEqual(["low", "high"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("the effort ladder is the one the runtime resolves, as with the modality", () => {
+    // `configuredReasoningEfforts` is what the catalog and the effort cap resolve
+    // through. Restating part of it here reported a ladder for a model the proxy
+    // strips reasoning from, and echoed a level Codex does not declare.
+    const dir = mkdtempSync(join(tmpdir(), "ocx-models-efforts-"));
+    const provider = {
+      adapter: "openai-chat",
+      baseUrl: "http://localhost:8080/v1",
+      allowPrivateNetwork: true,
+      defaultModel: "model-a",
+      models: ["model-a", "model-b", "model-c"],
+      reasoningEfforts: ["low", "medium", "high"],
+      noReasoningModels: ["model-b"],
+      modelReasoningEfforts: { "model-c": ["high", "bogus", "low"] },
+    };
+    writeFileSync(
+      join(dir, "config.json"),
+      JSON.stringify({ port: 10122, providers: { test: provider }, defaultProvider: "test" }),
+      "utf8",
+    );
+    try {
+      const config = provider as unknown as OcxProviderConfig;
+      // Ground truth first: what the proxy itself will do with this config.
+      expect(configuredReasoningEfforts(config, "model-a")).toEqual(["low", "medium", "high"]);
+      // An empty ladder is not the same claim as "no override": it says this model
+      // intentionally exposes no effort control, which is why it must survive to the row.
+      expect(configuredReasoningEfforts(config, "model-b")).toEqual([]);
+      expect(configuredReasoningEfforts(config, "model-c")).toEqual(["low", "high"]);
+
+      const result = runCli(["models", "--json"], { OPENCODEX_HOME: dir });
+      expect(result.status).toBe(0);
+      const rows = JSON.parse(result.stdout).models as { model: string; reasoningEfforts: unknown }[];
+      const ladderOf = (model: string) => rows.find((m) => m.model === model)?.reasoningEfforts;
+
+      expect(ladderOf("model-a")).toEqual(["low", "medium", "high"]);
+      expect(ladderOf("model-b")).toEqual([]);
+      expect(ladderOf("model-c")).toEqual(["low", "high"]);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## The defect

`ocx models` resolved the effort ladder with a bare per-model lookup and a provider-wide fallback (`src/cli/models.ts:110`):

```ts
const efforts = modelRecordValue(reasoningEfforts, model) ?? prov.reasoningEfforts ?? null;
```

The catalog (`src/codex/catalog/provider-fetch.ts:647`) and the effort cap (`src/server/effort-policy.ts:121`) both resolve through `configuredReasoningEfforts` (`src/reasoning-effort.ts:106`), which does three things the expression above does not: it returns `[]` on a `noReasoningModels` match, drops levels Codex does not declare, and re-adds tiers a wire map proves the model emits.

Measured on `dev` (`7881319e7`) with one hand-written provider:

```jsonc
"reasoningEfforts":      ["low", "medium", "high"],
"noReasoningModels":     ["model-b"],
"modelReasoningEfforts": { "model-c": ["high", "bogus", "low"] }
```

| model | `ocx models --json` | `configuredReasoningEfforts` — what the proxy does |
| --- | --- | --- |
| model-a | `["low","medium","high"]` | `["low","medium","high"]` |
| model-b | `["low","medium","high"]` | `[]` |
| model-c | `["high","bogus","low"]` | `["low","high"]` |

`mapReasoningEffort(prov, "model-b", "high")` returns `undefined`, so the effort never reaches the wire — the command advertised a three-rung ladder for a model the proxy strips reasoning from entirely, and printed `"bogus"` as a supported level.

`ocx models` is the command an operator reads to check what a config actually did, so a row that disagrees with the proxy is the one thing it must not print.

## The fix

One line, plus the now-unused local:

```ts
const efforts = configuredReasoningEfforts(prov, model) ?? null;
```

This is the sibling of #2086, which routed `modelContextWindows` / `modelInputModalities` / `noVisionModels` through the runtime's own resolvers on the two lines directly above and left this one a partial re-implementation. The empty ladder is preserved rather than collapsed to `null`, because `[]` and "no override" are different claims — `src/reasoning-effort.ts:102-104` documents that distinction and the catalog already relies on it.

## Verification

Windows, bun 1.3.14.

```
tests/cli-models.test.ts                    19 pass, 0 fail   (18 before — the case added)
  + cli-models-reasoning
  + cline-pass-reasoning-efforts
  + cursor-effort-suffix                    56 pass, 0 fail
bun x tsc --noEmit                          0 errors in either changed file
```

The new case asserts the ground truth first — `configuredReasoningEfforts` directly — and then requires the CLI to agree with it, so the test cannot drift into agreeing with the command instead of with the proxy. That mirrors how the existing `a family entry classifies its tagged siblings` case calls `isModelTextOnly` before running the CLI.

**Mutation-checked**, after confirming the edit applied: restoring the old expression fails exactly the new case (18 pass / 1 fail), so it pins the resolver rather than passing incidentally.

## Scope

Only `ocx models` is touched. I did not extend this to `src/routing/capability.ts:216`, which resolves the same value a third way and diverges from the runtime in both directions — that one carries a design judgement about whether `[]` should surface as evidence or stay collapsed to unknown, and it belongs in its own change if you want it.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI model metadata to accurately reflect supported reasoning-effort options.
  * Invalid reasoning-effort values are now filtered out, with appropriate defaults and model-specific overrides applied.

* **Tests**
  * Added coverage for models with default, empty, filtered, and customized reasoning-effort settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


