### PR TITLE
fix(codex): keep oversized Responses turns off the WS transport

### DIFF
--- a/src/server/responses/fetch-helpers.ts
+++ b/src/server/responses/fetch-helpers.ts
@@ -64,14 +64,26 @@ export function providerFetch(
   options: ProviderFetchOptions = {},
 ): ProviderFetch {
   const base = (provider as OcxProviderConfig & { fetch?: typeof globalThis.fetch }).fetch ?? globalThis.fetch;
+  const preconnect = (...args: Parameters<typeof globalThis.fetch.preconnect>): void => {
+    base.preconnect?.(...args);
+  };
+  const httpFetch = Object.assign(
+    (input: Parameters<typeof globalThis.fetch>[0], init?: RequestInit) =>
+      base(input, withUpstreamHttpVersion(input, init, provider)),
+    { preconnect },
+  ) as typeof globalThis.fetch;
   // ChatGPT Codex backend: streaming turns ride the responses_websockets
   // transport (measured ~3s faster TTFT than the SSE POST queue); everything
   // else keeps the provider's HTTP fetch. See ws-upstream.ts for the details.
   const unpaced = async (input: Parameters<typeof globalThis.fetch>[0], init?: RequestInit) => {
     if (typeof input === "string" && init && shouldUseCodexWsUpstream(input, init, runtime)) {
-      return codexWsUpstreamFetch(input, init, base, runtime);
+      // The fallback has to be the same HTTP fetch the non-WS branch would have
+      // used, protocol pin included: a WS turn that falls back is serving the
+      // request over HTTP, and dropping the provider's `upstreamHttpVersion`
+      // there would silently negotiate a transport the operator ruled out.
+      return codexWsUpstreamFetch(input, init, httpFetch, runtime);
     }
-    return base(input, withUpstreamHttpVersion(input, init, provider));
+    return httpFetch(input, init);
   };
   let pacingSlotAcquired = options.pacingSlotAcquired === true;
   const waitForPacing = (signal?: AbortSignal) => {
@@ -86,9 +98,6 @@ export function providerFetch(
   const wrapped = async (input: Parameters<typeof globalThis.fetch>[0], init?: RequestInit) => {
     await waitForPacing(init?.signal ?? undefined);
     return unpaced(input, init);
-  };
-  const preconnect = (...args: Parameters<typeof globalThis.fetch.preconnect>): void => {
-    base.preconnect?.(...args);
   };
   return Object.assign(wrapped, {
     preconnect,

--- a/src/server/responses/ws-upstream.ts
+++ b/src/server/responses/ws-upstream.ts
@@ -28,6 +28,22 @@ const UPGRADE_DEADLINE_MS = 10_000;
 export const MAX_CODEX_WS_FRAME_BYTES = MAX_CLIENT_SSE_FRAME_BYTES;
 export const MAX_CODEX_WS_QUEUE_BYTES = 8 * 1024 * 1024;
 export const MIN_BOUNDED_CODEX_WS_BUN_VERSION = "1.4.0";
+// The backend drops any inbound message of 16 MiB or more: it closes the socket
+// (1009) without a Responses terminal event, which reaches clients as a bare
+// 502 upstream_server_error. Measured against the live endpoint 2026-08-23:
+// 16,777,000 B completed, 16,777,300 B closed in ~1s, every time. The same
+// request body succeeds over HTTP SSE, so the ceiling belongs to this transport
+// alone (see #2426). A full-replay thread reaches it with ~11 pasted
+// screenshots, and then never recovers, because each retry resends the frame.
+export const MAX_CODEX_WS_CREATE_FRAME_BYTES = 16 * 1024 * 1024;
+// Bun frames the payload it is handed, so the send-side budget is the JSON text
+// itself. The margin only absorbs the difference between the measurement here
+// and what a future caller might append after it.
+const CODEX_WS_CREATE_FRAME_MARGIN_BYTES = 64 * 1024;
+export const CODEX_WS_CREATE_FRAME_LIMIT_BYTES =
+  MAX_CODEX_WS_CREATE_FRAME_BYTES - CODEX_WS_CREATE_FRAME_MARGIN_BYTES;
+/** Close code the backend uses for an oversized message (RFC 6455 "message too big"). */
+const WS_CLOSE_MESSAGE_TOO_BIG = 1009;
 
 export type BunRuntimeIdentity = {
   version: string;
@@ -102,6 +118,45 @@ export function shouldUseCodexWsUpstream(
   }
 }
 
+const CLOSED_BEFORE_TERMINAL = "codex websocket closed before a Responses terminal event";
+
+/**
+ * The close code is the only thing that separates "the backend refused this
+ * payload" from "the network dropped", and both used to reach the logs as the
+ * same bare 502. Naming the oversized case here is what makes it diagnosable
+ * without reading the client's own rollout files.
+ */
+function closedBeforeTerminalMessage(event: unknown): string {
+  const detail = event as { code?: unknown; reason?: unknown } | null | undefined;
+  const code = typeof detail?.code === "number" ? detail.code : null;
+  const reason = typeof detail?.reason === "string" ? detail.reason.trim() : "";
+  if (code === null) return CLOSED_BEFORE_TERMINAL;
+  const suffix = reason ? ` ${code} ${reason}` : ` ${code}`;
+  if (code === WS_CLOSE_MESSAGE_TOO_BIG) {
+    return `codex websocket rejected the request frame as too large (close${suffix});`
+      + ` requests at or above ${MAX_CODEX_WS_CREATE_FRAME_BYTES} bytes must use the HTTP SSE transport`;
+  }
+  return `${CLOSED_BEFORE_TERMINAL} (close${suffix})`;
+}
+
+/**
+ * True when the `response.create` frame is at or above the backend's inbound
+ * message ceiling, so this turn must take the HTTP SSE path instead.
+ *
+ * Sizing a 16 MiB string should not cost a 16 MiB copy. UTF-8 never encodes
+ * below one byte per UTF-16 code unit and never above three, so both tails are
+ * settled from the string length alone; only the narrow band between them pays
+ * for a real byte count, and `Buffer.byteLength` measures without allocating.
+ */
+export function codexWsCreateFrameExceedsLimit(
+  frameText: string,
+  limitBytes: number = CODEX_WS_CREATE_FRAME_LIMIT_BYTES,
+): boolean {
+  if (frameText.length >= limitBytes) return true;
+  if (frameText.length * 3 < limitBytes) return false;
+  return Buffer.byteLength(frameText, "utf8") >= limitBytes;
+}
+
 export function codexWsUpstreamFetch(
   url: string,
   init: RequestInit,
@@ -124,6 +179,14 @@ export function codexWsUpstreamFetch(
     delete body.stream;
     frameText = JSON.stringify({ ...body, type: "response.create" });
   } catch {
+    return sseFallback(url, init);
+  }
+
+  // Decide before dialing. Once the socket is open the caller already holds a
+  // streaming Response, so the oversized close can only be surfaced as a stream
+  // error — and a resend at that point could double-generate. Measuring the
+  // frame we are about to send keeps the whole failure mode unreachable.
+  if (codexWsCreateFrameExceedsLimit(frameText)) {
     return sseFallback(url, init);
   }
 
@@ -279,7 +342,7 @@ export function codexWsUpstreamFetch(
       }
     });
 
-    ws.addEventListener("close", () => {
+    ws.addEventListener("close", (event: unknown) => {
       signal?.removeEventListener("abort", onAbort);
       if (!opened) {
         if (settledPreOpen) return;
@@ -297,7 +360,7 @@ export function codexWsUpstreamFetch(
         // here would reach clients with no response.completed/failed at all —
         // relaySseWithFailedTail() only synthesizes a failed terminal when the
         // body read THROWS. Error the stream like a reset TCP socket.
-        try { controller.error(new Error("codex websocket closed before a Responses terminal event")); } catch { /* stream already done */ }
+        try { controller.error(new Error(closedBeforeTerminalMessage(event))); } catch { /* stream already done */ }
       }
     });
 

--- a/src/server/responses/ws-upstream.ts
+++ b/src/server/responses/ws-upstream.ts
@@ -37,8 +37,11 @@ export const MIN_BOUNDED_CODEX_WS_BUN_VERSION = "1.4.0";
 // screenshots, and then never recovers, because each retry resends the frame.
 export const MAX_CODEX_WS_CREATE_FRAME_BYTES = 16 * 1024 * 1024;
 // Bun frames the payload it is handed, so the send-side budget is the JSON text
-// itself. The margin only absorbs the difference between the measurement here
-// and what a future caller might append after it.
+// itself, and nothing is appended between the check and the send. The margin is
+// a conservative cushion, not a computed requirement: it covers RFC 6455 frame
+// overhead in case the backend counts it (14 bytes at this payload size — an
+// 8-byte extended length plus a 4-byte client mask, leaving ~65.5 KiB spare),
+// and it leaves room for a future caller that appends to the frame.
 const CODEX_WS_CREATE_FRAME_MARGIN_BYTES = 64 * 1024;
 export const CODEX_WS_CREATE_FRAME_LIMIT_BYTES =
   MAX_CODEX_WS_CREATE_FRAME_BYTES - CODEX_WS_CREATE_FRAME_MARGIN_BYTES;
@@ -122,9 +125,16 @@ const CLOSED_BEFORE_TERMINAL = "codex websocket closed before a Responses termin
 
 /**
  * The close code is the only thing that separates "the backend refused this
- * payload" from "the network dropped", and both used to reach the logs as the
- * same bare 502. Naming the oversized case here is what makes it diagnosable
- * without reading the client's own rollout files.
+ * payload" from "the network dropped", and both used to reach the caller as the
+ * same bare 502. Naming the oversized case here puts that distinction in the
+ * message the client receives.
+ *
+ * It does NOT reach the request log as a typed code. The eager relay turns any
+ * stream error into a generic `upstream_reset` synthetic terminal
+ * (`relay.ts`, `relay-eager.ts`) without feeding that frame back through the
+ * inspector, so `/api/logs` keeps neither this message nor a specific code —
+ * only `streamAborted`. Machine-readable typing would mean changing the error
+ * taxonomy, which is deliberately out of scope for this transport fix.
  */
 function closedBeforeTerminalMessage(event: unknown): string {
   const detail = event as { code?: unknown; reason?: unknown } | null | undefined;

--- a/tests/ws-upstream.test.ts
+++ b/tests/ws-upstream.test.ts
@@ -5,9 +5,12 @@ import { isEagerRelaySseResponse } from "../src/server/relay";
 import { isWin32EagerRewrite } from "../src/lib/bun-stream-caps";
 import {
   bunSupportsBoundedCodexWsRelay,
+  CODEX_WS_CREATE_FRAME_LIMIT_BYTES,
+  codexWsCreateFrameExceedsLimit,
   codexWsUpstreamFetch as rawCodexWsUpstreamFetch,
   currentBunRuntimeIdentity,
   isCodexWsUpstreamResponse,
+  MAX_CODEX_WS_CREATE_FRAME_BYTES,
   MAX_CODEX_WS_FRAME_BYTES,
   MAX_CODEX_WS_QUEUE_BYTES,
   shouldUseCodexWsUpstream as rawShouldUseCodexWsUpstream,
@@ -670,5 +673,104 @@ describe("codexWsUpstreamFetch", () => {
 
     await expect(response.text()).rejects.toThrow("turn cancelled");
     expect(FakeWebSocket.instances[0].closed).toBe(true);
+  });
+});
+
+describe("codexWsCreateFrameExceedsLimit", () => {
+  test("measures the frame in UTF-8 bytes, not code units", () => {
+    // Two UTF-8 bytes per code unit, so half the limit in "é" is exactly the limit.
+    const halfLimit = CODEX_WS_CREATE_FRAME_LIMIT_BYTES / 2;
+    expect(codexWsCreateFrameExceedsLimit("é".repeat(halfLimit))).toBe(true);
+    expect(codexWsCreateFrameExceedsLimit("é".repeat(halfLimit - 1))).toBe(false);
+  });
+
+  test("holds the boundary at the limit itself", () => {
+    expect(codexWsCreateFrameExceedsLimit("x".repeat(CODEX_WS_CREATE_FRAME_LIMIT_BYTES))).toBe(true);
+    expect(codexWsCreateFrameExceedsLimit("x".repeat(CODEX_WS_CREATE_FRAME_LIMIT_BYTES - 1))).toBe(false);
+  });
+
+  test("keeps a margin under the backend's measured ceiling", () => {
+    // Measured against the live endpoint: 16,777,000 B completed, 16,777,300 B
+    // closed the socket. The gate has to trip below the smaller of those.
+    expect(MAX_CODEX_WS_CREATE_FRAME_BYTES).toBe(16 * 1024 * 1024);
+    expect(CODEX_WS_CREATE_FRAME_LIMIT_BYTES).toBeLessThan(16_777_000);
+  });
+});
+
+describe("oversized Codex create frames", () => {
+  test("takes the HTTP SSE path instead of dialing a socket the backend would close", async () => {
+    installFake(() => { throw new Error("WS must not be dialed for an oversized frame"); });
+    const sentinel = new Response("sse");
+    let fallbackCalls = 0;
+    const fallback = (async () => {
+      fallbackCalls += 1;
+      return sentinel;
+    }) as unknown as typeof fetch;
+
+    const oversized = streamingInit({ padding: "x".repeat(CODEX_WS_CREATE_FRAME_LIMIT_BYTES) });
+    expect(await codexWsUpstreamFetch(CODEX_URL, oversized, fallback)).toBe(sentinel);
+    expect(fallbackCalls).toBe(1);
+    // Nothing was sent, so the SSE resend cannot double-generate a turn.
+    expect(FakeWebSocket.instances).toHaveLength(0);
+  });
+
+  test("keeps the provider's HTTP version pin on the fallback", async () => {
+    installFake(() => { throw new Error("WS must not be dialed for an oversized frame"); });
+    const seen: RequestInit[] = [];
+    const provider = {
+      upstreamHttpVersion: "http1.1",
+      fetch: (async (_input: unknown, init: RequestInit) => {
+        seen.push(init);
+        return new Response("sse");
+      }) as unknown as typeof fetch,
+    } as unknown as OcxProviderConfig;
+    const wrapped = providerFetch(provider, BOUNDED_WS_RUNTIME);
+
+    await wrapped(CODEX_URL, streamingInit({ padding: "x".repeat(CODEX_WS_CREATE_FRAME_LIMIT_BYTES) }));
+
+    expect(FakeWebSocket.instances).toHaveLength(0);
+    // Falling back means serving the turn over HTTP, so the operator's pin has
+    // to survive the transport switch.
+    expect((seen[0] as { protocol?: string }).protocol).toBe("http1.1");
+  });
+
+  test("still uses WS for a frame that fits", async () => {
+    installFake(ws => {
+      ws.emit("open", {});
+      ws.emit("message", { data: JSON.stringify({ type: "response.completed", response: {} }) });
+    });
+    const fallback = (() => {
+      throw new Error("fallback must not run for a frame that fits");
+    }) as unknown as typeof fetch;
+
+    const response = await codexWsUpstreamFetch(CODEX_URL, streamingInit({ padding: "x".repeat(1024) }), fallback);
+    expect(isCodexWsUpstreamResponse(response)).toBe(true);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+
+  test("names the oversized close instead of reporting a bare drop", async () => {
+    installFake(ws => {
+      ws.emit("open", {});
+      ws.emit("close", { code: 1009, reason: "Message Too Big" });
+    });
+    const response = await codexWsUpstreamFetch(CODEX_URL, streamingInit(), (() => {
+      throw new Error("fallback must not run after open");
+    }) as unknown as typeof fetch);
+
+    await expect(response.text()).rejects.toThrow(
+      /rejected the request frame as too large \(close 1009 Message Too Big\)/,
+    );
+  });
+
+  test("carries the close code for any other pre-terminal drop", async () => {
+    installFake(ws => {
+      ws.emit("open", {});
+      ws.emit("close", { code: 1006 });
+    });
+    const response = await codexWsUpstreamFetch(CODEX_URL, streamingInit(), (() => {
+      throw new Error("fallback must not run after open");
+    }) as unknown as typeof fetch);
+
+    await expect(response.text()).rejects.toThrow("closed before a Responses terminal event (close 1006)");
   });
 });

--- a/tests/ws-upstream.test.ts
+++ b/tests/ws-upstream.test.ts
@@ -748,6 +748,69 @@ describe("oversized Codex create frames", () => {
     expect(FakeWebSocket.instances).toHaveLength(1);
   });
 
+  // The unit tests above measure the helper; these two measure the REAL serialized
+  // frame, one byte on each side of the limit. That distinction matters because the
+  // request body is not the frame: `stream` is deleted and `type` is added before
+  // sending, so padding sized against the body would sit at a different offset than
+  // the bytes actually transmitted. An off-by-one lives exactly here and nowhere else.
+  describe("the adjacent-byte transport boundary", () => {
+    // Build padding such that the serialized frame is EXACTLY `target` bytes.
+    function initForFrameBytes(target: number): RequestInit {
+      const probe = frameTextFor(0);
+      const padding = "x".repeat(target - Buffer.byteLength(probe, "utf8"));
+      const init = streamingInit({ padding });
+      const actual = Buffer.byteLength(frameTextFor(padding.length), "utf8");
+      if (actual !== target) throw new Error(`frame sizing is wrong: wanted ${target}, built ${actual}`);
+      return init;
+    }
+
+    function frameTextFor(paddingLength: number): string {
+      const body = JSON.parse(streamingInit({ padding: "x".repeat(paddingLength) }).body as string) as Record<string, unknown>;
+      delete body.stream;
+      return JSON.stringify({ ...body, type: "response.create" });
+    }
+
+    test("a frame one byte under the limit goes over WS", async () => {
+      installFake(ws => {
+        ws.emit("open", {});
+        ws.emit("message", { data: JSON.stringify({ type: "response.completed", response: {} }) });
+      });
+      const fallback = (() => {
+        throw new Error("fallback must not run one byte under the limit");
+      }) as unknown as typeof fetch;
+
+      const response = await codexWsUpstreamFetch(
+        CODEX_URL,
+        initForFrameBytes(CODEX_WS_CREATE_FRAME_LIMIT_BYTES - 1),
+        fallback,
+      );
+      expect(isCodexWsUpstreamResponse(response)).toBe(true);
+      expect(FakeWebSocket.instances).toHaveLength(1);
+      expect(FakeWebSocket.instances[0]!.sent).toHaveLength(1);
+      // Byte length, not code units: the limit is a byte budget, and this
+      // assertion should keep meaning the same thing if the fixture ever
+      // carries non-ASCII text.
+      expect(Buffer.byteLength(FakeWebSocket.instances[0]!.sent[0]!, "utf8"))
+        .toBe(CODEX_WS_CREATE_FRAME_LIMIT_BYTES - 1);
+    });
+
+    test("the very next byte takes SSE without dialing", async () => {
+      installFake(() => { throw new Error("WS must not be dialed at the limit"); });
+      const sentinel = new Response("sse");
+      let fallbackCalls = 0;
+      const fallback = (async () => { fallbackCalls += 1; return sentinel; }) as unknown as typeof fetch;
+
+      const response = await codexWsUpstreamFetch(
+        CODEX_URL,
+        initForFrameBytes(CODEX_WS_CREATE_FRAME_LIMIT_BYTES),
+        fallback,
+      );
+      expect(response).toBe(sentinel);
+      expect(fallbackCalls).toBe(1);
+      expect(FakeWebSocket.instances).toHaveLength(0);
+    });
+  });
+
   test("names the oversized close instead of reporting a bare drop", async () => {
     installFake(ws => {
       ws.emit("open", {});


### PR DESCRIPTION
## Summary

Closes #2426.

The Codex backend closes the socket on any inbound message of **16 MiB or more** without sending a Responses terminal event. `codexWsUpstreamFetch` only fell back to SSE when the *upgrade* failed, so a close after open became a bare `502 upstream_server_error` with no fallback — and a thread that crossed the ceiling could never recover, because every retry resent the same oversized frame.

I measured the boundary against the live endpoint on 2026-08-23:

```
16,777,000 B = 16.000 MiB -> OK   (6.6s, response.completed)
16,777,300 B = 16.000 MiB -> FAIL (1.0s, socket closed before any event)
```

Exactly 16 MiB = 16,777,216 B, reproducible byte-for-byte. It is not a Bun send-side cap — a local Bun WS server with `maxPayloadLength: 512 MiB` accepts a 20 MiB frame from the same client — so the ceiling is the backend's, consistent with close code 1009. #2426's control observation shows the same body still succeeding over HTTP SSE on 2.28.0.

**The fix:** size the `response.create` frame before dialing and take the SSE path when it does not fit. Deciding before the socket opens is what keeps the resend safe — after open the caller already holds a streaming `Response`, and retrying there could double-generate the turn (the concern raised in #2426).

Two supporting changes in the same path:

- **Carry the WS close code and reason into the stream error.** A 1009 was indistinguishable from an ordinary network drop, and neither `usage.jsonl` nor `/api/logs` recorded the real cause — the only place the truth survived was the *client's* rollout file. An oversized close now says so.
- **Apply the provider's `upstreamHttpVersion` pin to the SSE fallback.** `providerFetch` passed the raw `base` fetch as the fallback, so any WS turn that fell back lost the operator's protocol pin. That was already true for the existing fallbacks; this change makes the fallback a routine path, so it is fixed here rather than left as a latent hole.

Not in scope, and worth separate issues: an image budget / downscaling for inline `input_image` payloads (what actually keeps threads away from the ceiling — under full replay ~11 pasted screenshots is enough to cross it), and suppressing account rotation on a 1009-class refusal.

## Verification

**Exact head `f093bf06f`, rebased onto `a60d51748`**

- `./node_modules/.bin/bun test tests/ws-upstream.test.ts tests/upstream-http-version.test.ts tests/request-pacing.test.ts tests/cursor-adapter.test.ts tests/agent-task-recovery.test.ts tests/agent-task-recovery-security.test.ts` — 113 passed, 1 runtime-specific skip.
- `./node_modules/.bin/bun run typecheck` — passed.
- `./node_modules/.bin/bun run privacy:scan` — passed.
- `git diff --check upstream/dev...HEAD` — passed.
- `bun run test:changed` is not available on current `dev`; that script is introduced by the still-open #2429, so it was not reported as passed.
- `./node_modules/.bin/bun run test` — 2 failures across 14,574 tests / 907 files in 636.51s:
  - `tests/key-login-live-update.test.ts` reproduces identically on untouched `dev` at `a60d51748`;
  - the Codex shim delayed-redispatch timing test failed under the full-suite load, then passed 1/1 in an isolated exact-head rerun.
- No WS, Responses, fetch-helper, pacing, or adjacent recovery test failed. Because the exact-head full-suite invocation itself was not green, the PR remains Draft and local-CI/readiness stay unchecked.
- The measured upstream 16 MiB boundary and the real-thread replay evidence in the Summary are retained as historical reproduction evidence; they were not re-probed against a live paid upstream during this rebase.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. — No user-facing surface changes; transport selection is internal.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. — The new error text carries only the WS close code and the backend's own close reason, and still passes through `redactSecretString` at the log layer. No auth or credential paths touched; the fallback reuses the same authenticated fetch the non-WS branch already used.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the configured upstream HTTP version for standard and fallback requests.
  * Automatically falls back to HTTP streaming when WebSocket requests exceed the supported size.
  * Added UTF-8-aware request size validation with a safety margin.
  * Improved WebSocket error messages, including oversized payloads and unexpected connection closures.
* **Reliability**
  * Maintained connection preconnect behavior across supported request paths.
  * Preserved WebSocket usage for requests within the supported size limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

