### PR TITLE
fix(responses): stop rewriting an unchanged snapshot every two seconds

### DIFF
--- a/docs-site/src/content/docs/troubleshooting/disk-usage-temp-files.md
+++ b/docs-site/src/content/docs/troubleshooting/disk-usage-temp-files.md
@@ -63,9 +63,11 @@ entirely.
 Together these keep the write rate roughly flat as the cache grows, instead of
 re-serializing and replacing the whole file every two seconds.
 
-A graceful shutdown always flushes, so the longer wait only widens the window in
-which a hard kill loses the most recent continuation entries — which are cache,
-as above.
+A graceful shutdown flushes immediately rather than waiting out the timer, so the
+longer wait mainly widens the window in which a hard kill loses the most recent
+continuation entries — which are cache, as above. That flush is still a disk
+write and can fail like any other, so a shutdown on a full or read-only volume
+can lose the same entries.
 
 ## Reclaiming files that already accumulated
 

--- a/docs-site/src/content/docs/troubleshooting/disk-usage-temp-files.md
+++ b/docs-site/src/content/docs/troubleshooting/disk-usage-temp-files.md
@@ -52,10 +52,13 @@ and the proxy never removes a file it is writing itself.
 
 ## How often the snapshot is written
 
-Writes are debounced, and the debounce scales with how large the snapshot
-actually is: a small cache is written about two seconds after a change, while one
-near the 24 MB bound waits up to thirty seconds. A flush that would reproduce the
-existing file byte-for-byte is skipped entirely.
+Writes are debounced, and the debounce is derived from the size of the **last
+snapshot actually written**: while that file is small the next write is scheduled
+about two seconds after a change, and once it is near the 24 MB bound the wait
+stretches to at most thirty seconds. A cache that has only just grown therefore
+still takes the short wait once — the longer cadence applies from the write after
+it. A flush that would reproduce the existing file byte-for-byte is skipped
+entirely.
 
 Together these keep the write rate roughly flat as the cache grows, instead of
 re-serializing and replacing the whole file every two seconds.

--- a/docs-site/src/content/docs/troubleshooting/disk-usage-temp-files.md
+++ b/docs-site/src/content/docs/troubleshooting/disk-usage-temp-files.md
@@ -50,6 +50,20 @@ running process can own those.
 The safety rules are unchanged: a file younger than 15 minutes is never removed,
 and the proxy never removes a file it is writing itself.
 
+## How often the snapshot is written
+
+Writes are debounced, and the debounce scales with how large the snapshot
+actually is: a small cache is written about two seconds after a change, while one
+near the 24 MB bound waits up to thirty seconds. A flush that would reproduce the
+existing file byte-for-byte is skipped entirely.
+
+Together these keep the write rate roughly flat as the cache grows, instead of
+re-serializing and replacing the whole file every two seconds.
+
+A graceful shutdown always flushes, so the longer wait only widens the window in
+which a hard kill loses the most recent continuation entries — which are cache,
+as above.
+
 ## Reclaiming files that already accumulated
 
 If the proxy runs, this happens automatically within a minute or two.

--- a/src/responses/state.ts
+++ b/src/responses/state.ts
@@ -18,6 +18,12 @@ import {
 const MAX_STORED_RESPONSES = 1_000;
 const RESPONSE_TTL_MS = 60 * 60 * 1_000;
 const SNAPSHOT_DEBOUNCE_MS = 2_000;
+/** Snapshot size below which the debounce stays at its base value. */
+const SNAPSHOT_DEBOUNCE_SCALE_FROM_BYTES = 1 * 1024 * 1024;
+/** Ceiling for the stretched debounce. Continuation state is only read after a
+ *  restart, and a graceful shutdown flushes, so the exposure a longer debounce adds
+ *  is bounded by a hard kill — paid against rewriting the whole snapshot every 2 s. */
+const SNAPSHOT_DEBOUNCE_MAX_MS = 30_000;
 /** In-memory high-water byte cap across all entries. Forced store:false retention (kiro/cursor
  * continuation chains) stores the full expanded input each turn — ~quadratic bytes per chain —
  * so a count cap alone cannot bound memory. Oldest-first eviction applies past this mark. */
@@ -90,6 +96,11 @@ let oldestResidentId: string | undefined;
 let oldestResidentAt: number | null = null;
 let byteCapOverride: number | null = null;
 let stateRevision = 0;
+/** Byte length and digest of the last snapshot actually written, for the
+ *  identical-payload skip and the size-scaled debounce. The payload itself is not
+ *  retained: at the 24 MiB bound that would double the snapshot's memory cost. */
+let lastSnapshotBytes = 0;
+let lastSnapshotDigest: string | null = null;
 const spillCounters = { writes: 0, writeFailures: 0, readFailures: 0 };
 /**
  * Admission-boundary observability (test-visible). directSpills: oversized
@@ -788,9 +799,25 @@ async function writeBoundedSnapshot(path: string): Promise<SnapshotWriteOutcome>
         entries.push(persistEntry);
       }
       entries.reverse();
-      mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-      try { chmodSync(dirname(path), 0o700); } catch { /* best-effort (e.g. Windows) */ }
-      await atomicWriteFileAsync(path, JSON.stringify({ version: 2, states: entries }));
+      const payload = JSON.stringify({ version: 2, states: entries });
+      const payloadBytes = Buffer.byteLength(payload, "utf8");
+      const payloadDigest = Bun.hash(payload).toString(36);
+      // A mutation does not always change what gets persisted: entries past the
+      // per-entry or total byte bound are dropped from the selection, and spill
+      // demotion moves bytes out of it. Re-writing a byte-identical 24 MiB file
+      // buys nothing, so compare first — but only skip while the file we would be
+      // reproducing is still there.
+      const unchanged = lastSnapshotDigest !== null
+        && payloadDigest === lastSnapshotDigest
+        && payloadBytes === lastSnapshotBytes
+        && existsSync(path);
+      if (!unchanged) {
+        mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+        try { chmodSync(dirname(path), 0o700); } catch { /* best-effort (e.g. Windows) */ }
+        await atomicWriteFileAsync(path, payload);
+        lastSnapshotDigest = payloadDigest;
+        lastSnapshotBytes = payloadBytes;
+      }
       persistAttemptHookForTests?.();
       if (revision === stateRevision) return "stable";
     }
@@ -809,11 +836,26 @@ function drainPendingSpillUnlinks(): void {
   }
 }
 
+/**
+ * Debounce scaled by the size of the last snapshot written.
+ *
+ * The whole snapshot is re-serialized and atomically replaced on every flush, so at
+ * the 24 MiB bound a fixed 2 s debounce is up to ~12 MB/s of write amplification for
+ * state nothing reads until the next start (#2460). Small snapshots keep the base
+ * cadence; the stretch is linear in size and clamped, so the write rate is roughly
+ * flat instead of growing with the file.
+ */
+function snapshotDebounceMs(): number {
+  if (lastSnapshotBytes <= SNAPSHOT_DEBOUNCE_SCALE_FROM_BYTES) return SNAPSHOT_DEBOUNCE_MS;
+  const scaled = Math.round(SNAPSHOT_DEBOUNCE_MS * (lastSnapshotBytes / SNAPSHOT_DEBOUNCE_SCALE_FROM_BYTES));
+  return Math.min(scaled, SNAPSHOT_DEBOUNCE_MAX_MS);
+}
+
 function schedulePersistAt(path: string, replace = false): void {
   if (persistTimer && !replace) return;
   if (persistTimer) clearTimeout(persistTimer);
   pendingPersistPath = path;
-  persistTimer = setTimeout(() => { void persistNow(path); }, SNAPSHOT_DEBOUNCE_MS);
+  persistTimer = setTimeout(() => { void persistNow(path); }, snapshotDebounceMs());
   (persistTimer as { unref?: () => void }).unref?.();
 }
 
@@ -1418,6 +1460,8 @@ export function clearResponseStateMemoryForTests(): void {
   replayScopeMismatchDrops = 0;
   replayOverlapSkips = 0;
   persistAttemptHookForTests = null;
+  lastSnapshotBytes = 0;
+  lastSnapshotDigest = null;
   loaded = false;
 }
 

--- a/src/responses/state.ts
+++ b/src/responses/state.ts
@@ -101,6 +101,27 @@ let stateRevision = 0;
  *  retained: at the 24 MiB bound that would double the snapshot's memory cost. */
 let lastSnapshotBytes = 0;
 let lastSnapshotDigest: string | null = null;
+// The resolved file the digest above describes. Keeping it means a config-dir
+// change or a retargeted symlink is a miss rather than a false "unchanged".
+let lastSnapshotTarget: string | null = null;
+
+/**
+ * Is the snapshot on disk still byte-for-byte what we last wrote?
+ *
+ * The cached digest proves what this process wrote, not what is there now. Size is
+ * checked first so the common mismatch costs a `stat`, and the content comparison
+ * only runs when the size already agrees. Any read failure answers "no" and the
+ * caller rewrites — the safe direction.
+ */
+async function snapshotOnDiskMatches(path: string, payload: string, payloadBytes: number): Promise<boolean> {
+  try {
+    const file = Bun.file(path);
+    if (file.size !== payloadBytes) return false;
+    return await file.text() === payload;
+  } catch {
+    return false;
+  }
+}
 const spillCounters = { writes: 0, writeFailures: 0, readFailures: 0 };
 /**
  * Admission-boundary observability (test-visible). directSpills: oversized
@@ -805,18 +826,31 @@ async function writeBoundedSnapshot(path: string): Promise<SnapshotWriteOutcome>
       // A mutation does not always change what gets persisted: entries past the
       // per-entry or total byte bound are dropped from the selection, and spill
       // demotion moves bytes out of it. Re-writing a byte-identical 24 MiB file
-      // buys nothing, so compare first — but only skip while the file we would be
-      // reproducing is still there.
+      // buys nothing, so compare first — but the cached digest describes what THIS
+      // process last wrote, which is not the same claim as "that is what is on disk
+      // now". A second proxy sharing the home, or anything that rewrites the file
+      // in place, leaves the digest describing bytes that are gone. Before every
+      // release-of-a-write, the previous behaviour rewrote unconditionally and so
+      // repaired that silently; skipping without checking would turn a repaired
+      // snapshot into a lost one at the next restart.
+      //
+      // Verify against the file itself, keyed to the resolved target so a retargeted
+      // symlink is also a miss. Reading back a matching-size file costs far less
+      // than the atomic replace it avoids, and only happens when the digest already
+      // matched — the amplification this fixes is the repeated WRITE, not the read.
       const unchanged = lastSnapshotDigest !== null
         && payloadDigest === lastSnapshotDigest
         && payloadBytes === lastSnapshotBytes
-        && existsSync(path);
+        && lastSnapshotTarget === resolveWriteTarget(path)
+        && existsSync(path)
+        && await snapshotOnDiskMatches(path, payload, payloadBytes);
       if (!unchanged) {
         mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
         try { chmodSync(dirname(path), 0o700); } catch { /* best-effort (e.g. Windows) */ }
         await atomicWriteFileAsync(path, payload);
         lastSnapshotDigest = payloadDigest;
         lastSnapshotBytes = payloadBytes;
+        lastSnapshotTarget = resolveWriteTarget(path);
       }
       persistAttemptHookForTests?.();
       if (revision === stateRevision) return "stable";
@@ -1462,6 +1496,7 @@ export function clearResponseStateMemoryForTests(): void {
   persistAttemptHookForTests = null;
   lastSnapshotBytes = 0;
   lastSnapshotDigest = null;
+  lastSnapshotTarget = null;
   loaded = false;
 }
 

--- a/tests/responses-state-write-amplification.test.ts
+++ b/tests/responses-state-write-amplification.test.ts
@@ -8,7 +8,7 @@
  * of the snapshot actually being written.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, rmSync, statSync, utimesSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -108,6 +108,31 @@ describe("responses-state snapshot write amplification (#2460)", () => {
     expect(existsSync(snapshot)).toBe(true);
   });
 
+  // Deletion is the easy half. The cached digest describes what THIS process last
+  // wrote, which is not the same claim as "that is what is on disk now" — a second
+  // proxy sharing the home, or anything rewriting the file in place, leaves the
+  // digest describing bytes that are gone. Before the skip existed, every flush
+  // rewrote and so repaired that silently; skipping on the digest alone would turn
+  // a self-healing snapshot into a permanently corrupt one, discovered only at the
+  // next restart when the continuation state fails to load.
+  //
+  // Same-length replacement is the case that defeats a size-only check, so that is
+  // what this drives.
+  test("a snapshot replaced with different bytes of the same length is rewritten", async () => {
+    remember("resp_amp_replaced", "kept");
+    await flushResponseState();
+
+    const original = readFileSync(snapshot, "utf-8");
+    writeFileSync(snapshot, "X".repeat(Buffer.byteLength(original, "utf8")));
+
+    // A mutation whose bounded payload is byte-identical to the last write: the
+    // oversized entry is dropped by the per-entry bound, so the digest still matches.
+    remember("resp_amp_replaced_oversized", "y".repeat(3 * 1024 * 1024));
+    await flushResponseState();
+
+    expect(readFileSync(snapshot, "utf-8")).toBe(original);
+  });
+
   test("the scheduled debounce stays at its base value for a small snapshot", async () => {
     remember("resp_amp_tiny", "tiny");
     await flushResponseState();
@@ -131,6 +156,50 @@ describe("responses-state snapshot write amplification (#2460)", () => {
     expect(delay).toBeLessThanOrEqual(30_000);
     // Roughly proportional to size: ~3.2 MiB of payload is ~6 s, not ~2 s.
     expect(delay).toBeGreaterThanOrEqual(5_000);
+  });
+
+  // The ceiling is the half of the scaling rule that a proportional formula gets
+  // wrong silently: `<= 30_000` passes for any well-behaved input, so it proves
+  // the clamp exists only when something actually reaches it. A snapshot at the
+  // byte cap is the case that does.
+  test("the scheduled debounce clamps to exactly 30s at the snapshot cap", async () => {
+    // The scaling rule is 2s per MiB, so a payload at or past 15 MiB computes above
+    // the ceiling. 900 KB of text per entry matters: the entry is serialized with the
+    // input echoed alongside the output, so ~1.5 MB of text lands past the 2 MiB
+    // per-entry bound and is skipped entirely, leaving an empty snapshot.
+    for (let i = 0; i < 20; i += 1) remember(`resp_amp_cap_${i}`, "c".repeat(900 * 1024));
+    await flushResponseState();
+    // Guard the premise: if the snapshot did not actually get large, a passing
+    // clamp assertion below would be proving nothing.
+    expect(statSync(snapshot).size).toBeGreaterThan(15 * 1024 * 1024);
+
+    const delay = scheduledDelay(() => remember("resp_amp_cap_next", "next"));
+    await flushResponseState();
+
+    expect(delay).toBe(30_000);
+  });
+
+  // Shutdown is the one moment the debounce must not apply: a pending write that
+  // waits out a 30s timer during a graceful stop is a lost turn, and the longer
+  // the debounce grows the more there is to lose. The existing tests all flush
+  // immediately after each change, so none of them proves the pending case.
+  test("a graceful flush writes changes still sitting behind the debounce", async () => {
+    remember("resp_amp_drain_seed", "seed");
+    await flushResponseState();
+
+    // Two changes with NO flush between them: the debounce timer is pending and
+    // neither has reached disk when the graceful flush arrives.
+    remember("resp_amp_drain_late", "late");
+    remember("resp_amp_drain_late2", "late2");
+
+    await flushResponseState();
+
+    const parsed = JSON.parse(await Bun.file(snapshot).text()) as {
+      states: [string, Record<string, unknown>][];
+    };
+    const ids = parsed.states.map(([id]) => id);
+    expect(ids).toContain("resp_amp_drain_late");
+    expect(ids).toContain("resp_amp_drain_late2");
   });
 
   test("the snapshot still round-trips after a skipped write", async () => {

--- a/tests/responses-state-write-amplification.test.ts
+++ b/tests/responses-state-write-amplification.test.ts
@@ -1,0 +1,149 @@
+/**
+ * #2460 — `responses-state.json` was rewritten in full on a fixed 2 s debounce.
+ *
+ * The snapshot is bounded at 24 MiB, so under sustained traffic every debounce
+ * paid a complete re-serialization plus an atomic replacement of a file nothing
+ * reads until the next start. Two narrow measures are covered here: a
+ * byte-identical payload is not rewritten, and the debounce scales with the size
+ * of the snapshot actually being written.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, statSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  clearResponseStateForTests,
+  clearResponseStateMemoryForTests,
+  flushResponseState,
+  rememberResponseState,
+  setResponseStateByteCapForTests,
+} from "../src/responses/state";
+
+function remember(id: string, text: string): void {
+  rememberResponseState(
+    { model: "test/model", input: text, store: false },
+    { id, output: [{ type: "message", role: "assistant", content: text }], status: "completed" },
+    undefined,
+    { force: true },
+  );
+}
+
+describe("responses-state snapshot write amplification (#2460)", () => {
+  let home: string;
+  const priorHome = process.env["OPENCODEX_HOME"];
+  let snapshot: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "ocx-state-amp-"));
+    process.env["OPENCODEX_HOME"] = home;
+    snapshot = join(home, "responses-state.json");
+    clearResponseStateMemoryForTests();
+  });
+
+  afterEach(() => {
+    setResponseStateByteCapForTests(null);
+    clearResponseStateForTests();
+    rmSync(home, { recursive: true, force: true });
+    if (priorHome === undefined) delete process.env["OPENCODEX_HOME"];
+    else process.env["OPENCODEX_HOME"] = priorHome;
+  });
+
+  /** Record the delay the store hands to setTimeout when it schedules its next write. */
+  function scheduledDelay(schedule: () => void): number {
+    const realSetTimeout = globalThis.setTimeout;
+    const delays: number[] = [];
+    globalThis.setTimeout = ((handler: TimerHandler, ms?: number, ...rest: unknown[]) => {
+      delays.push(ms ?? 0);
+      return (realSetTimeout as (...a: unknown[]) => unknown)(handler, ms, ...rest);
+    }) as unknown as typeof setTimeout;
+    try {
+      schedule();
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+    }
+    expect(delays).toHaveLength(1);
+    return delays[0]!;
+  }
+
+  /** Backdate the snapshot so "was it rewritten?" is a mtime comparison, not a clock race. */
+  function backdate(): number {
+    const past = new Date(Date.now() - 60_000);
+    utimesSync(snapshot, past, past);
+    return statSync(snapshot).mtimeMs;
+  }
+
+  test("a flush that would reproduce the same bytes does not rewrite the file", async () => {
+    remember("resp_amp_small", "kept");
+    await flushResponseState();
+    expect(existsSync(snapshot)).toBe(true);
+    const before = backdate();
+
+    // An entry past the 2 MiB per-entry bound is dropped from the selection, so
+    // recording it mutates state without changing a single persisted byte.
+    remember("resp_amp_oversized", "x".repeat(3 * 1024 * 1024));
+    await flushResponseState();
+
+    expect(statSync(snapshot).mtimeMs).toBe(before);
+  });
+
+  test("a flush that changes the payload still rewrites the file", async () => {
+    remember("resp_amp_first", "first");
+    await flushResponseState();
+    const before = backdate();
+
+    remember("resp_amp_second", "second");
+    await flushResponseState();
+
+    expect(statSync(snapshot).mtimeMs).toBeGreaterThan(before);
+  });
+
+  test("a snapshot deleted underneath us is rewritten even when the payload matches", async () => {
+    remember("resp_amp_restore", "kept");
+    await flushResponseState();
+    rmSync(snapshot, { force: true });
+
+    remember("resp_amp_oversized_2", "y".repeat(3 * 1024 * 1024));
+    await flushResponseState();
+
+    expect(existsSync(snapshot)).toBe(true);
+  });
+
+  test("the scheduled debounce stays at its base value for a small snapshot", async () => {
+    remember("resp_amp_tiny", "tiny");
+    await flushResponseState();
+
+    const delay = scheduledDelay(() => remember("resp_amp_tiny_2", "tiny"));
+    await flushResponseState();
+
+    expect(delay).toBe(2_000);
+  });
+
+  test("the scheduled debounce stretches once the snapshot is large", async () => {
+    // Four ~800 KiB entries: each under the 2 MiB per-entry bound, so all four are
+    // persisted and the payload lands well past the 1 MiB scaling threshold.
+    for (let i = 0; i < 4; i += 1) remember(`resp_amp_big_${i}`, "z".repeat(800 * 1024));
+    await flushResponseState();
+
+    const delay = scheduledDelay(() => remember("resp_amp_big_next", "next"));
+    await flushResponseState();
+
+    expect(delay).toBeGreaterThan(2_000);
+    expect(delay).toBeLessThanOrEqual(30_000);
+    // Roughly proportional to size: ~3.2 MiB of payload is ~6 s, not ~2 s.
+    expect(delay).toBeGreaterThanOrEqual(5_000);
+  });
+
+  test("the snapshot still round-trips after a skipped write", async () => {
+    remember("resp_amp_roundtrip", "payload");
+    await flushResponseState();
+    remember("resp_amp_roundtrip_oversized", "w".repeat(3 * 1024 * 1024));
+    await flushResponseState();
+
+    const parsed = JSON.parse(await Bun.file(snapshot).text()) as {
+      version: number;
+      states: [string, Record<string, unknown>][];
+    };
+    expect(parsed.version).toBe(2);
+    expect(parsed.states.map(([id]) => id)).toContain("resp_amp_roundtrip");
+  });
+});


### PR DESCRIPTION
## Summary

`~/.opencodex/responses-state.json` is bounded at 24 MiB and rewritten **whole**
on a fixed 2 s debounce, so under sustained traffic each cycle paid a complete
re-serialization plus an atomic replacement of a file nothing reads until the
next start. That is the mechanism behind #2460 (and the earlier #1385).

This implements only the two narrow measures triage endorsed. The journal /
incremental store direction is deliberately **not** attempted here.

**1. A byte-identical snapshot is not rewritten.**
A mutation does not always change what gets persisted: entries past
`SNAPSHOT_ENTRY_MAX_BYTES` or the 24 MiB total are dropped from the selection,
and spill demotion moves bytes out of it. `writeBoundedSnapshot` now compares the
serialized payload against the last one written and skips the replacement when
they match. The comparison keeps a byte length plus a `Bun.hash` digest rather
than the payload itself — retaining a 24 MiB string would double the snapshot's
memory cost. The skip is also conditional on the file still existing, so a
snapshot deleted underneath the process is restored rather than assumed present.

**2. The debounce scales with the snapshot's size.**
Base 2 s below 1 MiB, linear above it, clamped at 30 s
(`SNAPSHOT_DEBOUNCE_MAX_MS`). The write rate is then roughly flat as the cache
grows instead of growing with it: at the 24 MiB bound the previous cadence is up
to ~12 MB/s of rewrite for state that is only read at the next start.

### Trade-offs, stated plainly

- **Durability.** A graceful shutdown flushes (`flushResponseState`), so the
  longer debounce only widens the window in which a **hard kill** loses the most
  recent continuation entries. Those entries are cache: losing them costs a
  re-sent context, not configuration or history.
- **Digest, not full compare.** `Bun.hash` is 64-bit, so a collision at an
  identical byte length is theoretically possible; the consequence would be one
  skipped rewrite, corrected by the next differing write. A cryptographic digest
  would remove even that, at roughly 40 ms of synchronous CPU per pass on a
  24 MiB payload, which seemed the worse trade on the serving process's event
  loop.
- Serialization still happens on every pass. Skipping that as well needs the
  change-tracking the journal direction implies, which is out of scope here.

## Verification

```
bun test responses-state.test.ts + the new file      117 pass, 4 skip, 0 fail
bun test repo-hygiene + core-lab-boundary + new       30 pass, 0 fail
bun run typecheck                                     clean
bun run privacy:scan                                  Privacy scan passed
```

`bun run test` (full suite) is still running locally as this is opened. I will
report its result in a comment and tick the local-CI box only once it is green.

`tests/responses-state-write-amplification.test.ts` (new, 6 cases) covers: a
flush that would reproduce the same bytes leaves the file's mtime untouched; a
flush that changes the payload does rewrite it; a snapshot deleted underneath the
process is rewritten even when the payload matches; the delay handed to
`setTimeout` is 2 s for a small snapshot and above 5 s once ~3 MiB is persisted;
and the snapshot still parses and round-trips after a skipped write.

Mutation check — reverting each measure alone fails exactly its own case:

```
const unchanged = false                     x  does not rewrite the file
setTimeout(..., SNAPSHOT_DEBOUNCE_MS)       x  the scheduled debounce stretches
```

Docs: `docs-site/.../troubleshooting/disk-usage-temp-files.md` already explains
that the snapshot is rewritten whole; it now also states the cadence and the
skip, next to the existing note that these files are cache.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults — no auth, credential, workflow, or dependency surface is touched; `privacy:scan` green.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced unnecessary snapshot rewrites when saved data has not changed.
  - Snapshot save timing now adjusts to snapshot size, up to 30 seconds, improving write efficiency.
  - Changed or externally removed snapshot files are repaired automatically.
  - Graceful shutdown now flushes pending snapshot changes immediately.

- **Documentation**
  - Added guidance on snapshot-write timing, shutdown behavior, and potential data-loss considerations after forced termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
