### PR TITLE
fix(anthropic): classify capitalized/dotted Claude ids as adaptive thinking

### DIFF
--- a/src/adapters/anthropic.ts
+++ b/src/adapters/anthropic.ts
@@ -469,10 +469,10 @@ function claudeFamilyVersion(modelId: string): { family: string; major: number; 
   // Find the segment that actually starts with `claude-`, rather than assuming it is either
   // the first (breaks `anthropic/claude-sonnet-5`) or the last (breaks `claude-sonnet-5/variant`,
   // where the slash carries a vendor suffix rather than a routing prefix).
-  const match = /(?:^|\/)claude-([a-z]+)-(\d+)(?:-(\d{1,2}))?(?!\d)/.exec(modelId);
+  const match = /(?:^|\/)claude-([a-z]+)-(\d+)(?:[.-](\d{1,2}))?(?![\d.])/i.exec(modelId);
   if (!match) return undefined;
   return {
-    family: match[1]!,
+    family: match[1]!.toLowerCase(),
     major: Number(match[2]),
     minor: match[3] === undefined ? 0 : Number(match[3]),
   };

--- a/src/adapters/anthropic.ts
+++ b/src/adapters/anthropic.ts
@@ -469,7 +469,7 @@ function claudeFamilyVersion(modelId: string): { family: string; major: number; 
   // Find the segment that actually starts with `claude-`, rather than assuming it is either
   // the first (breaks `anthropic/claude-sonnet-5`) or the last (breaks `claude-sonnet-5/variant`,
   // where the slash carries a vendor suffix rather than a routing prefix).
-  const match = /(?:^|\/)claude-([a-z]+)-(\d+)(?:[.-](\d{1,2}))?(?![\d.])/i.exec(modelId);
+  const match = /(?:^|\/)claude-([a-z]+)-(\d+)(?:[.-](\d{1,2}))?(?!\d)/i.exec(modelId);
   if (!match) return undefined;
   return {
     family: match[1]!.toLowerCase(),

--- a/tests/anthropic-reasoning.test.ts
+++ b/tests/anthropic-reasoning.test.ts
@@ -62,6 +62,18 @@ describe("anthropic extended-thinking gate", () => {
     // out to a model that rejects it with a 400 (Bedrock ValidationException).
     "Claude-Opus-4.8-joybuilder",
     "claude-opus-4.8-joybuilder",
+    // The separator and the capitalization are independent axes, and the PR changed
+    // both at once ([.-] plus the /i flag). Cover the whole 2x2 so a later regex edit
+    // that repairs one axis while breaking the other cannot pass: dashed-capitalized
+    // and dotted-lowercase are exactly the cells the original two cases leave open.
+    "Claude-Opus-4-8",
+    "Claude-Opus-4.8",
+    "claude-opus-4.8",
+    // A dotted SUFFIX after a dashed minor is not a dotted minor. Widening the tail to
+    // (?![\d.]) to stop "4.20250514" also rejected "4-8.1", silently demoting an id the
+    // old regex classified correctly — a regression inside the fix for the opposite bug.
+    // The tail must reject a longer NUMBER, not any dot.
+    "claude-opus-4-8.1",
   ])("adaptive-thinking model %s sends thinking.adaptive + output_config.effort", async (modelId) => {
     const b = await bodyOf(parsed("xhigh", { temperature: 0.3, topP: 0.9 }, modelId));
     expect(b.thinking).toEqual({ type: "adaptive" });
@@ -283,6 +295,12 @@ describe("anthropic extended-thinking gate", () => {
     // Capitalized/dotted ids below the adaptive threshold must stay on the legacy
     // wire shape (guard against over-broad family parsing).
     "Claude-Opus-4.6-joybuilder",
+    // The date-pinned guard is the reason the minor group is bounded to {1,2} with a
+    // (?!\d) tail. A capitalized date-pinned id never matched the old lowercase regex
+    // at all, so it reached this branch by failing to parse rather than by parsing
+    // correctly — the same observable outcome for two opposite reasons. Now that /i
+    // makes it parse, assert it still reads as minor 0 and stays legacy.
+    "Claude-Opus-4-20250514",
   ])("budget-thinking model %s keeps thinking.enabled with budget_tokens", async (modelId) => {
     const b = await bodyOf(parsed("high", {}, modelId));
     const thinking = b.thinking as { type: string; budget_tokens: number } | undefined;
@@ -327,6 +345,14 @@ describe("anthropic extended-thinking gate", () => {
     // The slash can also carry a vendor SUFFIX rather than a routing prefix, so the family
     // segment is not reliably first or last. Both directions are real routed shapes.
     "claude-sonnet-5/variant",
+    // claudeFamilyVersion() has TWO callers through meetsFamilyMinimum():
+    // usesAdaptiveThinking() and supportsExplicitThinkingDisable(). Every case above
+    // reaches only the first one, so a capitalization regression in the parser would
+    // silently drop the explicit disable while the adaptive matrix stayed green.
+    // A missed disable is invisible in the wire shape: the request simply goes out
+    // without the field and the model thinks anyway, on a 64-token budget it shares
+    // with generation (#545).
+    "Claude-Sonnet-5",
   ])("%s + reasoning 'none' sends an explicit thinking disable (#545)", async (modelId) => {
     const b = await bodyOf(parsed("none", { maxOutputTokens: 64, stopSequences: ["</block>"] }, modelId));
     expect(b.thinking).toEqual({ type: "disabled" });

--- a/tests/anthropic-reasoning.test.ts
+++ b/tests/anthropic-reasoning.test.ts
@@ -57,6 +57,11 @@ describe("anthropic extended-thinking gate", () => {
     "claude-opus-4-7",
     "claude-opus-4-8",
     "claude-opus-4-8[1m]",
+    // Vendor ids may be capitalized and/or use a dotted minor; the family parser must
+    // still classify them as adaptive or the legacy thinking.enabled wire shape goes
+    // out to a model that rejects it with a 400 (Bedrock ValidationException).
+    "Claude-Opus-4.8-joybuilder",
+    "claude-opus-4.8-joybuilder",
   ])("adaptive-thinking model %s sends thinking.adaptive + output_config.effort", async (modelId) => {
     const b = await bodyOf(parsed("xhigh", { temperature: 0.3, topP: 0.9 }, modelId));
     expect(b.thinking).toEqual({ type: "adaptive" });
@@ -275,6 +280,9 @@ describe("anthropic extended-thinking gate", () => {
     "claude-sonnet-4-5",
     "claude-opus-4-6",
     "claude-opus-4-20250514",
+    // Capitalized/dotted ids below the adaptive threshold must stay on the legacy
+    // wire shape (guard against over-broad family parsing).
+    "Claude-Opus-4.6-joybuilder",
   ])("budget-thinking model %s keeps thinking.enabled with budget_tokens", async (modelId) => {
     const b = await bodyOf(parsed("high", {}, modelId));
     const thinking = b.thinking as { type: string; budget_tokens: number } | undefined;


### PR DESCRIPTION
## Summary

`claudeFamilyVersion` only classified lowercase `claude-<family>-<major>-<minor>` model ids. Vendor ids such as `Claude-Opus-4.8-joybuilder` failed **both** checks:

1. the prefix match is case-sensitive (`claude-` lowercase only), so `Claude-...` returned `undefined`;
2. even lowercased, a dotted minor (`claude-opus-4.8-...`) parsed as minor `0`, so `opus 4.8` was treated as `opus 4.0` — below the adaptive-thinking threshold (`opus >= 4.7`).

Both failures sent the legacy wire shape `thinking: {type: "enabled", budget_tokens}` to models that reject it, e.g. via Bedrock:

```
ValidationException: "thinking.type.enabled" is not supported for this model.
Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
```

Fix: make the parser case-insensitive, accept `.` as a minor separator, and lowercase the captured family before table lookup.

## Verification

- Regression matrix over 11 model ids (node): `Claude-Opus-4.8-joybuilder` → adaptive ✓; `claude-opus-4-8`, `claude-sonnet-5`, `claude-opus-4-7` → adaptive (unchanged); `claude-opus-4-6`, `claude-opus-4-20250514` (date-pinned), `claude-sonnet-4-5-...` → legacy (unchanged); `GLM-*`/`kimi-*` unaffected.
- Live end-to-end: `POST /v1/messages` with `model=claude-ocx-combo--joy-claude`, `effort=high` → `200` in ~3s (previously `400` `thinking.type.enabled` from Bedrock).
- New test cases: `Claude-Opus-4.8-joybuilder` / `claude-opus-4.8-joybuilder` assert the adaptive wire shape; `Claude-Opus-4.6-joybuilder` asserts the legacy shape (guards against over-broad parsing). `bun test tests/anthropic-reasoning.test.ts` → 54 pass.
- Date-pinned and suffixed ids keep their previous classification (lookahead now also guards `.`).

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of Anthropic model versions across different capitalization and separator formats.
  * Prevented longer numeric or date-like suffixes from being misclassified as minor versions.
  * Improved adaptive and legacy reasoning-wire classification for varied model IDs.
  * Added more reliable handling for dotted, suffixed, and slash-containing model identifiers, including explicit disablement of reasoning features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
