### PR TITLE
fix(claude): do not let a non-registering row veto a bare context key

### DIFF
--- a/src/claude/context-windows.ts
+++ b/src/claude/context-windows.ts
@@ -118,17 +118,24 @@ export function buildClaudeContextWindows(
     put(desktop3pAlias("native", slug), window);
     put(aliasForNative(slug), window);
   }
+  // Anthropic passthrough guard (audit 021 #3): canonical claude ids ride the
+  // subscription passthrough — marking a sub-1M one would strap [1m]/1M-beta onto
+  // a model that cannot host it. Register anthropic rows only at >=1M.
+  const registrable = routedModels.filter(
+    m =>
+      typeof m.contextWindow === "number" &&
+      m.contextWindow > 0 &&
+      !(m.provider === "anthropic" && m.contextWindow < ONE_MILLION),
+  );
   // Bare routed ids are registered only when unambiguous across providers (audit
-  // 021 #5) — natives are registered first, so a native slug always wins the bare key.
+  // 021 #5) — natives are registered first, so a native slug always wins the bare
+  // key. Counted over the rows that can actually claim the key: a row this loop
+  // skips contributes no window, so letting it veto the bare key withholds an
+  // answer that was never in doubt.
   const bareCounts = new Map<string, number>();
-  for (const m of routedModels) bareCounts.set(m.id, (bareCounts.get(m.id) ?? 0) + 1);
-  for (const m of routedModels) {
-    const window = m.contextWindow;
-    if (typeof window !== "number" || window <= 0) continue;
-    // Anthropic passthrough guard (audit 021 #3): canonical claude ids ride the
-    // subscription passthrough — marking a sub-1M one would strap [1m]/1M-beta onto
-    // a model that cannot host it. Register anthropic rows only at >=1M.
-    if (m.provider === "anthropic" && window < ONE_MILLION) continue;
+  for (const m of registrable) bareCounts.set(m.id, (bareCounts.get(m.id) ?? 0) + 1);
+  for (const m of registrable) {
+    const window = m.contextWindow as number;
     put(`${m.provider}/${m.id}`, window);
     put(desktop3pAlias(m.provider, m.id), window);
     put(aliasForRoute(m.provider, m.id), window);

--- a/tests/claude-context-windows.test.ts
+++ b/tests/claude-context-windows.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { AUTO_COMPACT_WINDOW_DEFAULT, boundedContextWindows, buildClaudeContextWindows, effectiveModelEnv, resolveAutoContext, shouldMarkOneMillion, withOneMillionMarker } from "../src/claude/context-windows";
 import { desktop3pAlias } from "../src/claude/desktop-3p";
+import type { CatalogModel } from "../src/codex/catalog";
 
 describe("claude context-window map (devlog 260712 B2)", () => {
   const routed = [
@@ -130,6 +131,42 @@ describe("auto-context (devlog 260712 020 + audit 021)", () => {
     expect(map["gpt-5.6-luna"]).toBe(400_000);
     expect(map["shared-model"]).toBeUndefined();
     expect(map["gpt-5.6-sol"]).toBe(272_000); // native default, not 999k
+  });
+
+  test("a row that registers nothing does not make a bare id ambiguous", () => {
+    // Only one of these two rows can claim the bare key, so there is nothing to
+    // be ambiguous about — withholding it left a 1M model with no window, and a
+    // slot set to the bare id lost its [1m] marker.
+    const noWindow = buildClaudeContextWindows([], [
+      { provider: "a", id: "shared-model", contextWindow: 1_000_000 },
+      { provider: "b", id: "shared-model" } as CatalogModel,
+    ]);
+    expect(noWindow["shared-model"]).toBe(1_000_000);
+
+    // Same for a row the anthropic sub-1M guard skips.
+    const anthropicSkipped = buildClaudeContextWindows([], [
+      { provider: "openrouter", id: "claude-x", contextWindow: 1_000_000 },
+      { provider: "anthropic", id: "claude-x", contextWindow: 200_000 },
+    ]);
+    expect(anthropicSkipped["claude-x"]).toBe(1_000_000);
+    expect(anthropicSkipped["anthropic/claude-x"]).toBeUndefined();
+
+    // A zero or negative window is not a claim either.
+    const zeroWindow = buildClaudeContextWindows([], [
+      { provider: "a", id: "shared-model", contextWindow: 400_000 },
+      { provider: "b", id: "shared-model", contextWindow: 0 },
+    ]);
+    expect(zeroWindow["shared-model"]).toBe(400_000);
+  });
+
+  test("two providers that both register keep the bare id withheld", () => {
+    const map = buildClaudeContextWindows([], [
+      { provider: "a", id: "shared-model", contextWindow: 300_000 },
+      { provider: "b", id: "shared-model", contextWindow: 900_000 },
+    ]);
+    expect(map["shared-model"]).toBeUndefined();
+    expect(map["a/shared-model"]).toBe(300_000);
+    expect(map["b/shared-model"]).toBe(900_000);
   });
 
   test("auto-context marks a wide native slot, and turning it off unmarks anything under 1M", () => {


### PR DESCRIPTION
## A row that registers nothing still vetoes the bare key

`buildClaudeContextWindows` registers a bare routed id only when it is unambiguous across providers. The count that decides that is taken over **every** routed model — including the ones the loop directly below then skips:

```ts
const bareCounts = new Map<string, number>();
for (const m of routedModels) bareCounts.set(m.id, (bareCounts.get(m.id) ?? 0) + 1);
for (const m of routedModels) {
  const window = m.contextWindow;
  if (typeof window !== "number" || window <= 0) continue;          // ← skipped
  if (m.provider === "anthropic" && window < ONE_MILLION) continue; // ← skipped
  ...
  if (bareCounts.get(m.id) === 1) put(m.id, window);
}
```

A skipped row contributes no window, so it cannot disagree with anything — but it still pushes the count to 2, and the bare key is withheld.

Measured against the current `dev`:

```
[{a/m: 1_000_000}, {b/m: <no contextWindow>}]
  -> {"a/m":1000000, "claude-ocx-a--m":1000000, ...}          # bare "m" absent

[{openrouter/claude-x: 1_000_000}, {anthropic/claude-x: 200_000}]
  -> {"openrouter/claude-x":1000000, ...}                     # bare "claude-x" absent
```

## Why it matters

The map holds exactly one authoritative answer and refuses to give it. A Claude Code slot configured as the bare id then resolves to no window, so `shouldMarkOneMillion` returns `false` — and a genuine 1M model loses its `[1m]` marker and the CLI's 1M accounting because some unrelated provider happens to list the same id.

The anthropic case is the sharper one: the guard exists so a sub-1M canonical claude id never gets marked, and the side effect is that it also suppresses a **different** provider's 1M row under the same id.

## The fix

Count over the rows that can actually claim the key — filter first, then count and register over the same list.

Real ambiguity is untouched: two providers that both register a window still withhold the bare id, and the audit #5 test passes unchanged.

## Tests

Two cases added to `tests/claude-context-windows.test.ts`:

- a row with no window, a row skipped by the anthropic guard, and a row with `contextWindow: 0` each stop vetoing the bare key — while `anthropic/claude-x` itself stays unregistered, as the guard intends
- two providers that both register keep the bare id withheld, with both prefixed keys present

Mutation-checked — restoring the count over `routedModels` turns the first red:

```
(fail) a row that registers nothing does not make a bare id ambiguous
15 pass, 1 fail
```

`bun test tests/claude-context-windows.test.ts tests/claude-agents-inject.test.ts`: 32 pass, 1 skip, 0 fail. `tsc --noEmit`: no errors.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Bare model IDs are now available when duplicate catalog entries are invalid or excluded from context-window registration.
  - Models with missing, nonpositive, or unsupported context windows no longer incorrectly block valid model IDs.
  - Provider-qualified model IDs remain available when multiple providers register the same model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


