### PR TITLE
fix(responses): retry pre-output EOFs affecting Ox Alpha

### DIFF
--- a/docs-site/src/content/docs/ja/reference/configuration/server.md
+++ b/docs-site/src/content/docs/ja/reference/configuration/server.md
@@ -12,7 +12,7 @@ description: リスナー、リモート アクセス、アドミッション �
 | `port` | `number` | `10100` |プロキシリッスンポート。 |
 | `hostname?` | `string` | `"127.0.0.1"` |バインドアドレス。非ループバック バインドには `OPENCODEX_API_AUTH_TOKEN` が必要です。 |
 | `proxy?` | `string` | — |送信 HTTP(S) プロキシ URL または `${ENV_VAR}`。これらの変数が設定されていない場合にのみ、`HTTP_PROXY` / `HTTPS_PROXY` に適用されます。ループバックは `NO_PROXY` に残ります。 |
-| `emptyCompletionRetry?` | `boolean` | `false` | テキストもツール呼び出しもない Responses 完了を、同一リクエストで 1 回再試行するよう明示的に有効化します。再試行は課金対象になる場合があります。`OCX_EMPTY_COMPLETION_RETRY=0` で設定を変更せず無効化できます。combo と routed-compaction turn は対象外です。 |
+| `emptyCompletionRetry?` | `boolean` | `false` | テキストもツール呼び出しもない Responses ターンを、ターミナルイベント前にストリームが終了した場合も含め、同一リクエストで 1 回再試行するよう明示的に有効化します。再試行は課金対象になる場合があります。`OCX_EMPTY_COMPLETION_RETRY=0` で設定を変更せず無効化できます。combo と routed-compaction turn は対象外です。 |
 | `stallTimeoutSec?` | `number` | `300` | `response.incomplete` より前にアップストリーム データがない秒数。最小 1。
 | `connectTimeoutMs?` | `number` | `200000` |試行ごとの DNS/TCP/TLS/最終ヘッダーの期限。本体が生成される前に終了します。 |
 | `shutdownTimeoutMs?` | `number` | `5000` |アクティブなターンが中止される前の正常な排出期限。 |

--- a/docs-site/src/content/docs/ko/reference/configuration/server.md
+++ b/docs-site/src/content/docs/ko/reference/configuration/server.md
@@ -12,7 +12,7 @@ description: 리스너, 원격 접근, admission 키, 타임아웃, 저장소, �
 | `port` | `number` | `10100` | 프록시 수신 포트입니다. |
 | `hostname?` | `string` | `"127.0.0.1"` | 바인드 주소입니다. 루프백이 아닌 바인드에는 `OPENCODEX_API_AUTH_TOKEN`이 필요합니다. |
 | `proxy?` | `string` | — | 송신용 HTTP(S) 프록시 URL 또는 `${ENV_VAR}`입니다. 해당 변수가 비어 있을 때만 `HTTP_PROXY` / `HTTPS_PROXY`에 적용되며, 루프백은 `NO_PROXY`에 그대로 남습니다. |
-| `emptyCompletionRetry?` | `boolean` | `false` | 텍스트나 도구 호출 없이 완료된 Responses 요청을 한 번 동일하게 재시도하도록 선택합니다. 재시도에는 비용이 발생할 수 있습니다. `OCX_EMPTY_COMPLETION_RETRY=0`은 설정을 바꾸지 않고 비활성화하며, combo 및 routed-compaction turn은 제외됩니다. |
+| `emptyCompletionRetry?` | `boolean` | `false` | 텍스트나 도구 호출이 없는 Responses 턴을, 터미널 이벤트 전에 스트림이 종료된 경우를 포함해 동일한 요청으로 한 번 재시도하도록 선택합니다. 재시도에는 비용이 발생할 수 있습니다. `OCX_EMPTY_COMPLETION_RETRY=0`은 설정을 바꾸지 않고 비활성화하며, combo 및 routed-compaction turn은 제외됩니다. |
 | `stallTimeoutSec?` | `number` | `300` | 업스트림 데이터가 없을 때 `response.incomplete`가 되기까지의 초 수입니다. 최소 1입니다. |
 | `connectTimeoutMs?` | `number` | `200000` | 시도별 DNS/TCP/TLS/최종 헤더 기한입니다. 본문 생성 전에 끝납니다. |
 | `shutdownTimeoutMs?` | `number` | `5000` | 진행 중인 turn을 중단하기 전에 허용하는 정상 종료 드레인 기한입니다. |

--- a/docs-site/src/content/docs/reference/configuration/server.md
+++ b/docs-site/src/content/docs/reference/configuration/server.md
@@ -13,7 +13,7 @@ runs helper features around provider requests.
 | `port` | `number` | `10100` | Proxy listen port. |
 | `hostname?` | `string` | `"127.0.0.1"` | Bind address. Non-loopback binds require `OPENCODEX_API_AUTH_TOKEN`. |
 | `proxy?` | `string` | — | Outbound HTTP(S) proxy URL or `${ENV_VAR}`. Applied to `HTTP_PROXY` / `HTTPS_PROXY` only when those variables are unset; loopback remains in `NO_PROXY`. |
-| `emptyCompletionRetry?` | `boolean` | `false` | Opt in to one identical Responses retry when a completion has no text or tool call. The retry may be billable. `OCX_EMPTY_COMPLETION_RETRY=0` disables it without changing config; combo and routed-compaction turns remain excluded. |
+| `emptyCompletionRetry?` | `boolean` | `false` | Opt in to one identical Responses retry when a turn has no text or tool call, including a stream that ends before a terminal event. The retry may be billable. `OCX_EMPTY_COMPLETION_RETRY=0` disables it without changing config; combo and routed-compaction turns remain excluded. |
 | `stallTimeoutSec?` | `number` | `300` | Seconds without upstream data before `response.incomplete`. Minimum 1. |
 | `connectTimeoutMs?` | `number` | `200000` | Per-attempt DNS/TCP/TLS/final-header deadline; it ends before body generation. |
 | `shutdownTimeoutMs?` | `number` | `5000` | Graceful drain deadline before active turns are aborted. |

--- a/docs-site/src/content/docs/ru/reference/configuration/server.md
+++ b/docs-site/src/content/docs/ru/reference/configuration/server.md
@@ -13,7 +13,7 @@ description: Listener, удалённый доступ, admission key, тайм�
 | `port` | `number` | `10100` | Порт, который слушает прокси. |
 | `hostname?` | `string` | `"127.0.0.1"` | Адрес bind'а. Не-loopback bind требует `OPENCODEX_API_AUTH_TOKEN`. |
 | `proxy?` | `string` | — | URL исходящего HTTP(S)-прокси или `${ENV_VAR}`. Применяется к `HTTP_PROXY` / `HTTPS_PROXY` только когда эти переменные не заданы; loopback всегда остаётся в `NO_PROXY`. |
-| `emptyCompletionRetry?` | `boolean` | `false` | Явно включает один идентичный повтор Responses, если completion не содержит ни текста, ни tool call. Повтор может тарифицироваться. `OCX_EMPTY_COMPLETION_RETRY=0` отключает его без изменения config; combo и routed-compaction turn исключены. |
+| `emptyCompletionRetry?` | `boolean` | `false` | Явно включает один идентичный повтор Responses, если в turn нет ни текста, ни tool call, включая случай, когда stream завершается до terminal event. Повтор может тарифицироваться. `OCX_EMPTY_COMPLETION_RETRY=0` отключает его без изменения config; combo и routed-compaction turn исключены. |
 | `stallTimeoutSec?` | `number` | `300` | Секунды без upstream-данных до `response.incomplete`. Минимум 1. |
 | `connectTimeoutMs?` | `number` | `200000` | Дедлайн одной попытки DNS/TCP/TLS/final-header; он завершается до генерации тела ответа. |
 | `shutdownTimeoutMs?` | `number` | `5000` | Дедлайн graceful-drain до принудительного прерывания активных turn'ов. |

--- a/docs-site/src/content/docs/zh-cn/reference/configuration/server.md
+++ b/docs-site/src/content/docs/zh-cn/reference/configuration/server.md
@@ -13,7 +13,7 @@ description: 监听、远程访问、准入密钥、超时、存储、侧车、�
 | `port` | `number` | `10100` | 代理监听端口。 |
 | `hostname?` | `string` | `"127.0.0.1"` | 绑定地址。非回环绑定需要 `OPENCODEX_API_AUTH_TOKEN`。 |
 | `proxy?` | `string` | — | 出站 HTTP(S) 代理 URL，或 `${ENV_VAR}`。仅当 `HTTP_PROXY` / `HTTPS_PROXY` 未设置时才会应用；回环地址始终保留在 `NO_PROXY` 中。 |
-| `emptyCompletionRetry?` | `boolean` | `false` | 显式启用：当 Responses 完成时既无文本也无工具调用，使用相同请求重试一次。重试可能产生费用。`OCX_EMPTY_COMPLETION_RETRY=0` 可在不修改配置的情况下禁用；combo 与 routed-compaction turn 不参与。 |
+| `emptyCompletionRetry?` | `boolean` | `false` | 显式启用：当 Responses turn 既无文本也无工具调用时，使用相同请求重试一次，包括流在终止事件之前结束的情况。重试可能产生费用。`OCX_EMPTY_COMPLETION_RETRY=0` 可在不修改配置的情况下禁用；combo 与 routed-compaction turn 不参与。 |
 | `stallTimeoutSec?` | `number` | `300` | 在上游没有数据之前可等待的秒数，超过后返回 `response.incomplete`。最小值为 1。 |
 | `connectTimeoutMs?` | `number` | `200000` | 每次尝试的 DNS/TCP/TLS/最终响应头截止时间；它在正文生成之前结束。 |
 | `shutdownTimeoutMs?` | `number` | `5000` | 优雅停机截止时间，超过后会中止仍在进行中的请求。 |

--- a/src/server/responses/empty-completion-guard.ts
+++ b/src/server/responses/empty-completion-guard.ts
@@ -153,9 +153,10 @@ export interface EmptyCompletionGuardOptions {
  * Watch an adapter event stream for the empty-completion failure mode. Events
  * are held until the turn produces content or ends: reasoning and other
  * pre-content events stay buffered (released in order on first content), the
- * terminal is withheld, and an empty terminal triggers one identical-turn
- * retry through `continuation`. Usage is merged across attempts so the bridge
- * and request log meter the whole turn, not just the attempt that succeeded.
+ * terminal is withheld, and an empty terminal or pre-output EOF triggers one
+ * identical-turn retry through `continuation`. Usage is merged across attempts
+ * so the bridge and request log meter the whole turn, not just the attempt that
+ * succeeded.
  *
  * Heartbeats always pass through untouched: they feed the bridge's stall
  * watchdog, so holding them behind the content gate would trip false
@@ -194,7 +195,11 @@ export async function* guardEmptyCompletionEventStream(
       if (sawContent || passthrough) {
         // Buffered content is already flowing; everything downstream passes
         // through. Every terminal carries usage merged across every attempt.
-        yield isTerminalEvent(event) ? withUsage(event) : event;
+        if (isTerminalEvent(event)) {
+          yield withUsage(event);
+          return;
+        }
+        yield event;
         continue;
       }
       if (isContentEvent(event)) {
@@ -267,8 +272,25 @@ export async function* guardEmptyCompletionEventStream(
       if (isReasoningEvent(event)) yield { type: "heartbeat" };
     }
     if (!terminalSeen) {
-      // The source ended without a terminal event (truncated stream). Release
-      // what was held so the bridge can mark the stream incomplete.
+      // A terminal-less EOF before text or a tool call is replay-safe: nothing
+      // actionable reached the client. Retry once, then surface a stated error
+      // instead of letting the bridge reduce the turn to adapter_eof.
+      if (!sawContent && !passthrough && retries < maxRetries) {
+        retries += 1;
+        try {
+          source = await options.continuation();
+        } catch {
+          yield emptyCompletionRetryFailedEvent(usage, true);
+          return;
+        }
+        continue;
+      }
+      if (!sawContent && retries > 0) {
+        yield emptyCompletionRetryFailedEvent(usage, true);
+        return;
+      }
+      // Post-output EOF remains incomplete; replaying could duplicate text or
+      // executable tool calls.
       yield* releaseHeld();
       return;
     }

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -491,14 +491,16 @@ configurable via `stallTimeoutSec`, checked on the 2 s heartbeat tick) closes th
 `response.incomplete` / `upstream_stall_timeout` and cancels the upstream request if no real
 adapter events arrive. Adapter-yielded `{ type: "heartbeat" }` events DO reset the watchdog.
 
-Top-level `emptyCompletionRetry: true` opts Responses turns into one identical replay when a
-successful upstream completion contains neither output text nor a tool call. The default is off
-because the replay may be billable; `OCX_EMPTY_COMPLETION_RETRY=0` is a disable-only emergency
-override. Streaming and buffered HTTP adapters plus `runTurn` transports share the same guard,
-while combo attempts and routed compaction stay excluded. Pre-content reasoning is retained under
-named event-count and byte caps and emits liveness heartbeats while held. A second empty result or
-retry failure becomes typed 502 `empty_completion_retry_failed`; usage is merged across sends, and
-the Logs attempt records recovery kind `empty-completion`.
+Top-level `emptyCompletionRetry: true` opts Responses turns into one identical replay when an
+upstream turn produces neither output text nor a tool call, including a stream that ends before a
+terminal event. A terminal-less stream is replayed only before actionable output; post-output EOF
+remains incomplete so text or tool calls cannot be duplicated. The default is off because the replay
+may be billable; `OCX_EMPTY_COMPLETION_RETRY=0` is a disable-only emergency override. Streaming and
+buffered HTTP adapters plus `runTurn` transports share the same guard, while combo attempts and
+routed compaction stay excluded. Pre-content reasoning is retained under named event-count and byte
+caps and emits liveness heartbeats while held. A second empty result or retry failure becomes typed
+502 `empty_completion_retry_failed`; usage is merged across sends, and the Logs attempt records
+recovery kind `empty-completion`.
 
 The web-search loop requests `stream: true` for every routed-model iteration, but buffers the events
 needed to decide whether to intercept a synthetic search call. Text explicitly phased as

--- a/tests/empty-completion-guard.test.ts
+++ b/tests/empty-completion-guard.test.ts
@@ -322,17 +322,57 @@ describe("empty-completion guard retry", () => {
     ]);
   });
 
-  test("a truncated first source (no terminal) releases held events and ends", async () => {
+  test("a pre-output EOF retries once and succeeds", async () => {
     let continuations = 0;
     const events = await collect(guardEmptyCompletionEventStream({
       firstEvents: eventsOf({ type: "thinking_delta", thinking: "..." }),
       continuation: () => {
         continuations += 1;
-        return eventsOf();
+        return eventsOf(
+          { type: "text_delta", text: "recovered" },
+          { type: "done" },
+        );
+      },
+    }));
+
+    expect(continuations).toBe(1);
+    expect(withoutHeartbeats(events)).toEqual([
+      { type: "thinking_delta", thinking: "..." },
+      { type: "text_delta", text: "recovered" },
+      { type: "done" },
+    ]);
+  });
+
+  test("a second pre-output EOF surfaces empty_completion_retry_failed", async () => {
+    let continuations = 0;
+    const events = await collect(guardEmptyCompletionEventStream({
+      firstEvents: eventsOf({ type: "thinking_delta", thinking: "first" }),
+      continuation: () => {
+        continuations += 1;
+        return eventsOf({ type: "thinking_delta", thinking: "second" });
+      },
+    }));
+
+    expect(continuations).toBe(1);
+    expect(withoutHeartbeats(events)).toEqual([
+      expect.objectContaining({
+        type: "error",
+        code: EMPTY_COMPLETION_RETRY_FAILED_CODE,
+      }),
+    ]);
+  });
+
+  test("a post-output EOF is not retried", async () => {
+    let continuations = 0;
+    const events = await collect(guardEmptyCompletionEventStream({
+      firstEvents: eventsOf({ type: "text_delta", text: "partial" }),
+      continuation: () => {
+        continuations += 1;
+        return eventsOf({ type: "text_delta", text: "duplicate" }, { type: "done" });
       },
     }));
 
     expect(continuations).toBe(0);
-    expect(withoutHeartbeats(events)).toEqual([{ type: "thinking_delta", thinking: "..." }]);
+    expect(events).toEqual([{ type: "text_delta", text: "partial" }]);
   });
 });


### PR DESCRIPTION
## Summary

- Retry a terminal-less Responses stream once when `emptyCompletionRetry` is enabled and no text or tool call reached the client.
- Keep post-output EOFs non-retryable, so text and tool calls cannot be duplicated.
- Add focused coverage and update the config and transport docs.

Ox Alpha made this early-stop path visible in practice. The safety boundary matches OpenCode's handling: replay only before actionable output. This is intentionally narrower than #2423, whose trace shows text surviving the provider adapter, so it does not claim to close that issue.

## Verification

- `bun test tests/empty-completion-guard.test.ts tests/empty-completion-hardening.test.ts` — 26 passed
- `bun run test` — 14,541 passed
- `bun run typecheck`
- `bun run privacy:scan`
- `bun run doctor:gui:if-changed`

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Empty Responses streams that end before producing content or a terminal event are now retried automatically.
  - Retry failures return a clear `empty_completion_retry_failed` error.
  - Streams that end after producing output remain marked incomplete and are not retried, preventing duplicate content.
- **Documentation**
  - Updated configuration and transport documentation to describe the expanded retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
