### PR TITLE
fix(quota): preserve Codex and Anthropic quota windows

### DIFF
--- a/src/codex/auth-api.ts
+++ b/src/codex/auth-api.ts
@@ -222,6 +222,7 @@ function quotaForPlan<T extends Omit<StoredAccountQuota, "updatedAt"> | StoredAc
     ...(quota.shortPercent !== undefined ? { shortPercent: quota.shortPercent } : {}),
     ...(quota.shortResetAt !== undefined ? { shortResetAt: quota.shortResetAt } : {}),
     ...(quota.shortWindowSeconds !== undefined ? { shortWindowSeconds: quota.shortWindowSeconds } : {}),
+    ...(quota.customWindows !== undefined ? { customWindows: quota.customWindows } : {}),
     ...(quota.resetCredits !== undefined ? { resetCredits: quota.resetCredits } : {}),
     ...("updatedAt" in quota ? { updatedAt: quota.updatedAt } : {}),
   } as T;

--- a/src/codex/quota.ts
+++ b/src/codex/quota.ts
@@ -296,7 +296,7 @@ export function setAccountQuotaFromParsed(
     // while silently dropping `monthlyIsPrimaryWindow` would look like tertiary-only data to
     // any future reader, and that failure would be invisible.
     if (quota.monthlyIsPrimaryWindow === true) next.monthlyIsPrimaryWindow = true;
-  } else if ((snapshotHasWeekly(quota) || snapshotHasShort(quota))
+  } else if ((snapshotHasWeekly(quota) || snapshotHasShort(quota) || snapshotHasCustom(quota))
       && existing?.monthlyPercent !== undefined) {
     next.monthlyPercent = existing.monthlyPercent;
     if (existing.monthlyResetAt !== undefined) next.monthlyResetAt = existing.monthlyResetAt;

--- a/src/codex/quota.ts
+++ b/src/codex/quota.ts
@@ -23,6 +23,7 @@ export type StoredAccountQuota = {
   shortPercent?: number;
   shortResetAt?: number;
   shortWindowSeconds?: number;
+  customWindows?: Array<{ label: string; percent: number; resetAt?: number }>;
   resetCredits?: number;
   /**
    * True when `monthlyPercent` came from an explicitly-monthly PRIMARY window —
@@ -60,6 +61,16 @@ export type WhamUsageResponse = {
   };
   rate_limit_reset_credits?: {
     available_count: number;
+  } | null;
+  additional_rate_limits?: WhamAdditionalRateLimit[] | null;
+};
+
+type WhamAdditionalRateLimit = {
+  limit_name?: unknown;
+  metered_feature?: unknown;
+  rate_limit?: {
+    primary_window?: WhamUsageWindow | null;
+    secondary_window?: WhamUsageWindow | null;
   } | null;
 };
 
@@ -187,7 +198,8 @@ function normalizeResetAt(value: unknown): number | undefined {
 
 function hasKnownQuotaValue(quota: Omit<StoredAccountQuota, "updatedAt">): boolean {
   return [quota.weeklyPercent, quota.monthlyPercent, quota.shortPercent]
-    .some(value => typeof value === "number" && Number.isFinite(value));
+    .some(value => typeof value === "number" && Number.isFinite(value))
+    || !!quota.customWindows?.some(window => Number.isFinite(window.percent));
 }
 
 /** True only for a window that DECLARES a duration shorter than a day. */
@@ -232,8 +244,12 @@ function snapshotHasShort(quota: Omit<StoredAccountQuota, "updatedAt">): boolean
     || quota.shortWindowSeconds !== undefined;
 }
 
+function snapshotHasCustom(quota: Omit<StoredAccountQuota, "updatedAt">): boolean {
+  return quota.customWindows !== undefined;
+}
+
 function snapshotHasUsage(quota: Omit<StoredAccountQuota, "updatedAt">): boolean {
-  return snapshotHasWeekly(quota) || snapshotHasMonthly(quota) || snapshotHasShort(quota);
+  return snapshotHasWeekly(quota) || snapshotHasMonthly(quota) || snapshotHasShort(quota) || snapshotHasCustom(quota);
 }
 export function setAccountQuotaFromParsed(
   accountId: string,
@@ -255,6 +271,7 @@ export function setAccountQuotaFromParsed(
     if (existing?.shortPercent !== undefined) next.shortPercent = existing.shortPercent;
     if (existing?.shortResetAt !== undefined) next.shortResetAt = existing.shortResetAt;
     if (existing?.shortWindowSeconds !== undefined) next.shortWindowSeconds = existing.shortWindowSeconds;
+    if (existing?.customWindows !== undefined) next.customWindows = existing.customWindows;
     next.resetCredits = quota.resetCredits;
     accountQuota.set(accountId, next);
     schedulePersistAccountQuotas();
@@ -297,6 +314,8 @@ export function setAccountQuotaFromParsed(
     if (existing?.shortResetAt !== undefined) next.shortResetAt = existing.shortResetAt;
     if (existing?.shortWindowSeconds !== undefined) next.shortWindowSeconds = existing.shortWindowSeconds;
   }
+
+  if (snapshotHasCustom(quota)) next.customWindows = quota.customWindows;
 
   if (quota.resetCredits !== undefined) next.resetCredits = quota.resetCredits;
   else if (existing?.resetCredits !== undefined) next.resetCredits = existing.resetCredits;
@@ -394,6 +413,7 @@ export function updateAccountQuota(
     ...(existing?.shortPercent !== undefined ? { shortPercent: existing.shortPercent } : {}),
     ...(existing?.shortResetAt !== undefined ? { shortResetAt: existing.shortResetAt } : {}),
     ...(existing?.shortWindowSeconds !== undefined ? { shortWindowSeconds: existing.shortWindowSeconds } : {}),
+    ...(existing?.customWindows !== undefined ? { customWindows: existing.customWindows } : {}),
     ...(existing?.resetCredits !== undefined ? { resetCredits: existing.resetCredits } : {}),
     updatedAt: Date.now(),
   };
@@ -506,6 +526,9 @@ export function parseUsageQuota(data: WhamUsageResponse): Omit<StoredAccountQuot
     : undefined;
 
   if (!data.rate_limit) {
+    if (data.additional_rate_limits?.length) {
+      return parseUsageQuota({ ...data, rate_limit: {} });
+    }
     return resetCredits !== undefined ? { resetCredits } : null;
   }
 
@@ -566,6 +589,32 @@ export function parseUsageQuota(data: WhamUsageResponse): Omit<StoredAccountQuot
     // account's governing quota; a tertiary window lands in the same field but describes a
     // different period, so recovery must not treat the two as interchangeable.
     if (primaryIsMonthly && primaryPercent !== undefined) quota.monthlyIsPrimaryWindow = true;
+  }
+
+  const spark = data.additional_rate_limits?.find(additional => {
+    const name = String(additional.limit_name ?? "").toLowerCase();
+    const feature = String(additional.metered_feature ?? "").toLowerCase();
+    return feature === "codex_bengalfox" || name.includes("gpt-5.3-codex-spark");
+  });
+  const sparkWindows = [spark?.rate_limit?.primary_window, spark?.rate_limit?.secondary_window]
+    .filter((window): window is WhamUsageWindow => !!window);
+  const sparkWeekly = sparkWindows.find(window => {
+    const percent = normalizeUsagePercent(window.used_percent);
+    const seconds = window.limit_window_seconds;
+    return percent !== undefined
+      && !isExplicitShortWindow(window)
+      && !isExplicitMonthlyWindow(window)
+      && (seconds === undefined || seconds >= WEEKLY_WINDOW_MIN_SECONDS);
+  });
+  const sparkPercent = normalizeUsagePercent(sparkWeekly?.used_percent);
+  if (sparkPercent !== undefined) {
+    const sparkWindow: { label: string; percent: number; resetAt?: number } = {
+      label: "GPT-5.3-Codex-Spark Weekly",
+      percent: sparkPercent,
+    };
+    const resetAt = normalizeResetAt(sparkWeekly?.reset_at);
+    if (resetAt !== undefined) sparkWindow.resetAt = resetAt;
+    quota.customWindows = [sparkWindow];
   }
   if (resetCredits !== undefined) quota.resetCredits = resetCredits;
 

--- a/src/providers/quota.ts
+++ b/src/providers/quota.ts
@@ -4,6 +4,7 @@ import {
   fetchMainAccountInfoSnapshot,
   listCodexAuthAccountsSnapshot,
 } from "../codex/auth-api";
+import type { StoredAccountQuota } from "../codex/quota";
 import { isMainAccountIdentityGenerationLive } from "../codex/main-account-cache";
 import { MAIN_CODEX_ACCOUNT_ID } from "../codex/main-account";
 import { codexPlanKey } from "../codex/plan";
@@ -166,6 +167,22 @@ function quotaSignatureValue(quota: CodexCapacityQuota | null): unknown {
   };
 }
 
+function providerQuotaFromCodexQuota(
+  quota: StoredAccountQuota | Omit<StoredAccountQuota, "updatedAt"> | null | undefined,
+): CodexCapacityQuota | null {
+  if (!quota) return null;
+  return {
+    ...(quota.shortPercent !== undefined ? { fiveHourPercent: quota.shortPercent } : {}),
+    ...(quota.shortResetAt !== undefined ? { fiveHourResetAt: quota.shortResetAt } : {}),
+    ...(quota.weeklyPercent !== undefined ? { weeklyPercent: quota.weeklyPercent } : {}),
+    ...(quota.weeklyResetAt !== undefined ? { weeklyResetAt: quota.weeklyResetAt } : {}),
+    ...(quota.monthlyPercent !== undefined ? { monthlyPercent: quota.monthlyPercent } : {}),
+    ...(quota.monthlyResetAt !== undefined ? { monthlyResetAt: quota.monthlyResetAt } : {}),
+    ...(quota.customWindows !== undefined ? { customWindows: quota.customWindows } : {}),
+    updatedAt: "updatedAt" in quota ? quota.updatedAt : Date.now(),
+  };
+}
+
 /** Hash only presentation-relevant state; account ids and email addresses never enter the key. */
 function cacheKeyWithAggregationState(
   config: OcxConfig,
@@ -183,7 +200,7 @@ function cacheKeyWithAggregationState(
         plan: codexPlanKey(account.plan) ?? null,
         paused: account.paused,
         needsReauth: account.needsReauth === true,
-        quota: quotaSignatureValue(account.quota as CodexCapacityQuota | null),
+        quota: quotaSignatureValue(providerQuotaFromCodexQuota(account.quota)),
       }));
       const canonicalRows = rows.map(row => JSON.stringify(row)).sort();
       const digest = createHash("sha256").update(JSON.stringify(canonicalRows)).digest("hex").slice(0, 24);
@@ -1103,9 +1120,8 @@ async function fetchChatGptForwardQuota(
 ): Promise<ProviderQuotaReport | null> {
   if (providerCodexAccountMode(provider, providerConfig) === "direct") {
     const snapshot = await fetchMainAccountInfoSnapshot(forceRefresh);
-    const quota = snapshot.info.quota
-      ? { ...snapshot.info.quota, updatedAt: Date.now() } as ProviderQuota
-      : null;
+    const quota = providerQuotaFromCodexQuota(snapshot.info.quota);
+    if (quota) quota.updatedAt = Date.now();
     return quota
       ? tagNativeMainReport(report(provider, "chatgpt:wham", quota), snapshot.mainIdentityGeneration)
       : null;
@@ -1113,10 +1129,14 @@ async function fetchChatGptForwardQuota(
   const snapshot = await (prefetchedSnapshot ?? listCodexAuthAccountsSnapshot(config, forceRefresh));
   const accounts = snapshot.accounts;
   const activeId = effectiveCodexAuthAccountId(config);
-  const capacityAccounts = accounts.map(account => ({ ...account, active: account.id === activeId }));
+  const capacityAccounts = accounts.map(account => ({
+    ...account,
+    active: account.id === activeId,
+    quota: providerQuotaFromCodexQuota(account.quota),
+  }));
   const active = capacityAccounts.find(account => account.active)
-    ?? accounts.find(account => account.id === MAIN_CODEX_ACCOUNT_ID)
-    ?? accounts[0];
+    ?? capacityAccounts.find(account => account.id === MAIN_CODEX_ACCOUNT_ID)
+    ?? capacityAccounts[0];
   const now = Date.now();
   const capacity = aggregateCodexPoolCapacity(capacityAccounts, now);
   if (capacity.aggregation && capacity.quota) {
@@ -1278,6 +1298,24 @@ function parseClaudeBucket(value: unknown): { percent?: number; resetAt?: number
   return { percent, resetAt };
 }
 
+function parseClaudeLimit(value: unknown): { label: string; percent: number; resetAt?: number } | null {
+  const rec = asRecord(value);
+  if (!rec) return null;
+  const percent = normalizePercent(rec.percent);
+  if (percent === undefined) return null;
+  const scope = asRecord(rec.scope);
+  const model = asRecord(scope?.model);
+  const rawLabel = String(model?.display_name ?? "").trim();
+  if (!rawLabel) return null;
+  const lowerLabel = rawLabel.toLowerCase();
+  const label = lowerLabel.includes("fable") ? "Fable"
+    : lowerLabel.includes("opus") ? "Opus"
+      : lowerLabel.includes("sonnet") ? "Sonnet"
+        : rawLabel;
+  const resetAt = normalizeResetAt(rec.resets_at);
+  return { label, percent, ...(resetAt !== undefined ? { resetAt } : {}) };
+}
+
 /** Claude's OAuth usage endpoint, probed with ONE account's own bearer token. */
 const anthropicUsageInflight = new Map<string, Promise<ProviderQuota | null>>();
 
@@ -1301,11 +1339,25 @@ async function fetchAnthropicUsageQuota(accessToken: string): Promise<ProviderQu
     if (!body) return null;
     const fiveHour = parseClaudeBucket(body.five_hour);
     const sevenDay = parseClaudeBucket(body.seven_day);
+    const fable = parseClaudeBucket(body.seven_day_fable);
     const opus = parseClaudeBucket(body.seven_day_opus);
     const sonnet = parseClaudeBucket(body.seven_day_sonnet);
     const customWindows: ProviderQuotaWindow[] = [];
+    if (fable?.percent !== undefined) customWindows.push({ label: "Fable", percent: fable.percent, ...(fable.resetAt !== undefined ? { resetAt: fable.resetAt } : {}) });
     if (opus?.percent !== undefined) customWindows.push({ label: "Opus", percent: opus.percent, ...(opus.resetAt !== undefined ? { resetAt: opus.resetAt } : {}) });
     if (sonnet?.percent !== undefined) customWindows.push({ label: "Sonnet", percent: sonnet.percent, ...(sonnet.resetAt !== undefined ? { resetAt: sonnet.resetAt } : {}) });
+    const knownLabels = new Set(customWindows.map(window => window.label.toLowerCase()));
+    const limits = Array.isArray(body.limits) ? body.limits : [];
+    for (const rawLimit of limits) {
+      const limitRecord = asRecord(rawLimit);
+      // `session` and `weekly_all` mirror the canonical five-hour and weekly
+      // buckets above; only model-scoped weekly limits add a third window.
+      if (String(limitRecord?.kind ?? "").trim().toLowerCase() !== "weekly_scoped") continue;
+      const limit = parseClaudeLimit(rawLimit);
+      if (!limit || knownLabels.has(limit.label.toLowerCase())) continue;
+      knownLabels.add(limit.label.toLowerCase());
+      customWindows.push(limit);
+    }
     const quota: ProviderQuota = {
       // Claude's 5-hour window is a first-class rate limit, same as the Codex login 5h/weekly
       // rows: report it in the canonical fields so the dashboard renders it with the standard

--- a/tests/codex-routing.test.ts
+++ b/tests/codex-routing.test.ts
@@ -38,9 +38,11 @@ import { removeCodexAccountCredential, saveCodexAccountCredential } from "../src
 import {
   clearAccountNeedsReauth,
   clearAccountQuota,
+  getAccountQuota,
   handleCodexAuthAPI,
   isAccountNeedsReauth,
   parseUsageQuota,
+  setAccountQuotaFromParsed,
   updateAccountQuota,
 } from "../src/codex/auth-api";
 import { CODEX_UNKNOWN_USAGE_SCORE, isCodexQuotaExhausted } from "../src/codex/quota";
@@ -1273,6 +1275,32 @@ describe("codex routing", () => {
       shortWindowSeconds: 5 * 60 * 60,
       weeklyPercent: 22,
       weeklyResetAt: 2,
+      customWindows: [{ label: "GPT-5.3-Codex-Spark Weekly", percent: 33, resetAt: 3 }],
+    });
+  });
+
+  test("a Spark-only WHAM snapshot preserves the stored monthly window", () => {
+    setAccountQuotaFromParsed("a", {
+      monthlyPercent: 44,
+      monthlyResetAt: 4,
+      monthlyIsPrimaryWindow: true,
+    });
+    const sparkOnly = parseUsageQuota({
+      additional_rate_limits: [{
+        limit_name: "GPT-5.3-Codex-Spark",
+        metered_feature: "codex_bengalfox",
+        rate_limit: {
+          primary_window: { used_percent: 33, reset_at: 3, limit_window_seconds: 7 * 24 * 60 * 60 },
+        },
+      }],
+    });
+
+    setAccountQuotaFromParsed("a", sparkOnly);
+
+    expect(getAccountQuota("a")).toMatchObject({
+      monthlyPercent: 44,
+      monthlyResetAt: 4,
+      monthlyIsPrimaryWindow: true,
       customWindows: [{ label: "GPT-5.3-Codex-Spark Weekly", percent: 33, resetAt: 3 }],
     });
   });

--- a/tests/codex-routing.test.ts
+++ b/tests/codex-routing.test.ts
@@ -1254,6 +1254,29 @@ describe("codex routing", () => {
     });
   });
 
+  test("WHAM preserves the 5h, weekly, and Spark weekly windows", () => {
+    expect(parseUsageQuota({
+      rate_limit: {
+        primary_window: { used_percent: 11, reset_at: 1, limit_window_seconds: 5 * 60 * 60 },
+        secondary_window: { used_percent: 22, reset_at: 2, limit_window_seconds: 7 * 24 * 60 * 60 },
+      },
+      additional_rate_limits: [{
+        limit_name: "GPT-5.3-Codex-Spark",
+        metered_feature: "codex_bengalfox",
+        rate_limit: {
+          primary_window: { used_percent: 33, reset_at: 3, limit_window_seconds: 7 * 24 * 60 * 60 },
+        },
+      }],
+    })).toEqual({
+      shortPercent: 11,
+      shortResetAt: 1,
+      shortWindowSeconds: 5 * 60 * 60,
+      weeklyPercent: 22,
+      weeklyResetAt: 2,
+      customWindows: [{ label: "GPT-5.3-Codex-Spark Weekly", percent: 33, resetAt: 3 }],
+    });
+  });
+
 
   test("a sub-day primary window does not masquerade as the weekly quota (#1791)", () => {
     // K12 and similar plans send a 5-hour primary plus a 7-day secondary. Folding the primary

--- a/tests/provider-quota.test.ts
+++ b/tests/provider-quota.test.ts
@@ -114,6 +114,80 @@ describe("fetchProviderQuotaReports", () => {
     expect(cancelCalls).toBe(1);
   });
 
+  test("Codex report exposes primary, weekly, and Spark weekly windows", async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe("https://chatgpt.com/backend-api/wham/usage");
+      return Response.json({
+        plan_type: "plus",
+        rate_limit: {
+          primary_window: { used_percent: 11, reset_at: 1, limit_window_seconds: 5 * 60 * 60 },
+          secondary_window: { used_percent: 22, reset_at: 2, limit_window_seconds: 7 * 24 * 60 * 60 },
+        },
+        additional_rate_limits: [{
+          limit_name: "GPT-5.3-Codex-Spark",
+          metered_feature: "codex_bengalfox",
+          rate_limit: {
+            primary_window: { used_percent: 33, reset_at: 3, limit_window_seconds: 7 * 24 * 60 * 60 },
+          },
+        }],
+      });
+    }) as typeof fetch;
+
+    const result = await fetchProviderQuotaReports({
+      defaultProvider: "openai",
+      providers: {
+        openai: {
+          adapter: "openai-responses",
+          authMode: "forward",
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+          codexAccountMode: "direct",
+        },
+      },
+    } as OcxConfig, true);
+
+    expect(result.reports[0]?.quota).toMatchObject({
+      fiveHourPercent: 11,
+      fiveHourResetAt: 1,
+      weeklyPercent: 22,
+      weeklyResetAt: 2,
+      customWindows: [{ label: "GPT-5.3-Codex-Spark Weekly", percent: 33, resetAt: 3 }],
+    });
+  });
+
+  test("Anthropic report exposes the canonical Fable window from direct and limits payloads", async () => {
+    await saveCredential("anthropic", { access: "claude-access-secret", refresh: "claude-refresh-secret", expires: Date.now() + 3600_000 });
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe("https://api.anthropic.com/api/oauth/usage");
+      return Response.json({
+        five_hour: { utilization: 11, resets_at: "2026-07-05T12:00:00Z" },
+        seven_day: { utilization: 22, resets_at: "2026-07-11T12:00:00Z" },
+        seven_day_fable: null,
+        limits: [
+          { kind: "session", percent: 44, resets_at: "2026-07-13T12:00:00Z" },
+          { kind: "weekly_all", percent: 55, resets_at: "2026-07-14T12:00:00Z" },
+          {
+            kind: "weekly_scoped",
+            scope: { model: { display_name: "Claude Fable 5" } },
+            percent: 33,
+            resets_at: "2026-07-12T12:00:00Z",
+          },
+        ],
+      });
+    }) as typeof fetch;
+
+    const result = await fetchProviderQuotaReports({
+      defaultProvider: "anthropic",
+      providers: { anthropic: { adapter: "anthropic", authMode: "oauth", baseUrl: "https://api.anthropic.com/v1" } },
+    } as OcxConfig, true);
+
+    expect(result.reports[0]?.quota).toMatchObject({
+      fiveHourPercent: 11,
+      weeklyPercent: 22,
+      customWindows: [{ label: "Fable", percent: 33, resetAt: Date.parse("2026-07-12T12:00:00Z") }],
+    });
+    expect(result.reports[0]?.quota.customWindows).toHaveLength(1);
+  });
+
   test("returns active provider quota rows without leaking credentials or raw upstream payloads", async () => {
     await saveCredential("xai", { access: "xai-access-secret", refresh: "xai-refresh-secret", expires: Date.now() + 3600_000 });
     await saveCredential("anthropic", { access: "claude-access-secret", refresh: "claude-refresh-secret", expires: Date.now() + 3600_000 });


### PR DESCRIPTION
## Summary

- Preserve model-specific Spark weekly usage from Codex WHAM `additional_rate_limits`.
- Preserve Anthropic model-scoped weekly limits from `limits[]` without duplicating canonical session and weekly rows.
- Preserve stored monthly quota across Spark-only partial WHAM snapshots.

## Verification

- `bun test tests/codex-routing.test.ts tests/provider-quota.test.ts` — 237 passed, 0 failed.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `bun run lint:gui:if-changed` and `bun run doctor:gui:if-changed` — passed (no GUI changes).
- `bun test --isolate --timeout 60000 tests/update-job.test.ts` — 54 passed, 0 failed.
- Clean Linux `codex-app-server-processes.test.ts` run — 46 passed, 1 Windows-only skipped. The full macOS run's only host-process-sensitive failure passed in this clean process environment.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex quota tracking for custom usage windows, including Spark weekly limits.
  * Preserved quota and reset information during partial updates and plan projections.
  * Improved Claude usage reporting for Fable, Opus, and Sonnet model limits.
  * Ensured direct and pooled quota reports use consistent data.

* **Tests**
  * Added coverage for Codex burst, weekly, and Spark-specific quota windows.
  * Added coverage for selecting canonical Claude usage limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->