### PR TITLE
fix(gui): inset the Claude account-pool warning and threshold field

### DIFF
--- a/gui/src/components/provider-workspace/AnthropicAccountPoolSettings.tsx
+++ b/gui/src/components/provider-workspace/AnthropicAccountPoolSettings.tsx
@@ -145,7 +145,7 @@ export default function AnthropicAccountPoolSettings({
   const toggleDisabled = loading || saving || loadError || (!enabled && accountCount < 2);
 
   return (
-    <div className="card" style={{ marginTop: 12 }} aria-busy={loading || saving}>
+    <div className="card anthropic-pool-card" aria-busy={loading || saving}>
       <div className="card-row" style={{ alignItems: "flex-start", gap: 12 }}>
         <div style={{ flex: 1 }}>
           <strong>{t("anthropicPool.title")}</strong>
@@ -179,17 +179,7 @@ export default function AnthropicAccountPoolSettings({
         </button>
       </div>
 
-      <div
-        role="alert"
-        className="card-sub"
-        style={{
-          marginTop: 10,
-          padding: "10px 16px",
-          border: "1px solid var(--border, #c9a227)",
-          borderRadius: 6,
-          background: "color-mix(in srgb, var(--warn, #c9a227) 12%, transparent)",
-        }}
-      >
+      <div role="alert" className="card-sub anthropic-pool-card__notice">
         {t("anthropicPool.experimentalWarning")}
       </div>
 
@@ -199,7 +189,7 @@ export default function AnthropicAccountPoolSettings({
 
       {enabled && state && (
         <>
-          <label className="field" style={{ display: "block", marginTop: 12 }}>
+          <label className="field anthropic-pool-card__field">
             <span className="field-label">{t("anthropicPool.threshold")}</span>
             <input
               className="input mono"

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -1732,7 +1732,8 @@ dialog.modal-overlay::backdrop {
 .account-pool-strategy-card > strong { display: block; margin: 0; }
 .account-pool-strategy-card > .card-sub,
 .account-pool-strategy-controls > .card-sub,
-.account-pool-strategy-controls .field .card-sub {
+.account-pool-strategy-controls .field .card-sub,
+.anthropic-pool-card__field .card-sub {
   /* Already inside the padded card — don't double-indent like account-card subs. */
   margin: 0;
   padding: 0;
@@ -1754,6 +1755,30 @@ dialog.modal-overlay::backdrop {
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
+}
+
+/*
+ * Claude account-pool card — the same inset `.account-pool-strategy-card` above already
+ * fixes, on the card that still had it. `.card` has no padding, so each child brings its
+ * own 16px: `.card-row`, `.card-sub` and `.setting-row` do, the warning box and the
+ * threshold field do not, so those two rendered flush against the card border.
+ *
+ * The warning takes margin, not padding: it is a bordered box, so its own padding insets
+ * the text and leaves the border itself on the card edge.
+ */
+.anthropic-pool-card { margin-top: 12px; }
+.anthropic-pool-card__notice {
+  margin: 10px 16px 0;
+  padding: 10px 16px;
+  border: 1px solid var(--border, #c9a227);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--warn, #c9a227) 12%, transparent);
+}
+.anthropic-pool-card__field {
+  display: block;
+  margin-top: 12px;
+  /* The `.input` inside is full-width, so the field owns the inset for the whole group. */
+  padding: 0 16px;
 }
 .api-active-keys-skeleton {
   min-height: 96px;

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -1764,7 +1764,8 @@ dialog.modal-overlay::backdrop {
  * threshold field do not, so those two rendered flush against the card border.
  *
  * The warning takes margin, not padding: it is a bordered box, so its own padding insets
- * the text and leaves the border itself on the card edge.
+ * the text and leaves the border itself on the card edge. The field takes padding — the
+ * `.input` inside is full-width, so the field owns the inset for the whole group.
  */
 .anthropic-pool-card { margin-top: 12px; }
 .anthropic-pool-card__notice {
@@ -1777,7 +1778,6 @@ dialog.modal-overlay::backdrop {
 .anthropic-pool-card__field {
   display: block;
   margin-top: 12px;
-  /* The `.input` inside is full-width, so the field owns the inset for the whole group. */
   padding: 0 16px;
 }
 .api-active-keys-skeleton {

--- a/gui/tests/anthropic-pool-card-layout.test.ts
+++ b/gui/tests/anthropic-pool-card-layout.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "bun:test";
+
+/**
+ * Claude account-pool card inset contract.
+ *
+ * Source-text assertions, not rendered measurements: happy-dom performs no layout, so a
+ * getBoundingClientRect() here returns zeros and would prove nothing. Rendered proof was
+ * captured in a real browser during the fix — the title sat 17px from the card's left
+ * edge while the warning box and the threshold input sat at 1px. This file's job is to
+ * keep the CSS shape that produced that gap from coming back silently.
+ *
+ * The bug: `.card` carries no padding of its own, so each child supplies the 16px inset.
+ * `.card-row`, `.card-sub` and `.setting-row` all do, which is why the title row, the help
+ * line and the rotation rows were indented. The experimental warning box and the threshold
+ * field are none of those three, so they ran flush against the card border.
+ */
+
+const cssUrl = new URL("../src/styles.css", import.meta.url);
+const tsxUrl = new URL(
+  "../src/components/provider-workspace/AnthropicAccountPoolSettings.tsx",
+  import.meta.url,
+);
+
+/** Strip comments so no assertion can pass on prose that quotes a value. */
+function withoutComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+/**
+ * Body of a top-level rule. Anchored with no leading whitespace on purpose: `.setting-row`
+ * also appears indented inside an `@media` block that only sets `flex-wrap`, and matching
+ * that one instead would read the inset off the wrong rule.
+ */
+function ruleBody(css: string, selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = css.match(new RegExp(`(^|\\n)${escaped}\\s*\\{([^}]*)\\}`));
+  if (!match) throw new Error(`rule not found: ${selector}`);
+  return match[2];
+}
+
+/** Horizontal component of a `margin`/`padding` shorthand, in px. */
+function horizontal(body: string, property: "margin" | "padding"): number {
+  const match = body.match(new RegExp(`(?:^|;)\\s*${property}:\\s*([^;]+)`));
+  if (!match) throw new Error(`${property} not found in: ${body.trim()}`);
+  const parts = match[1].trim().split(/\s+/);
+  // 1 value: all sides. 2-3 values: second is the horizontal one. 4: right, then left.
+  const side = parts.length === 1 ? parts[0] : parts[1];
+  const px = side.match(/^([\d.]+)(?:px)?$/);
+  if (!px) throw new Error(`${property} value is not a px length: ${side}`);
+  return Number(px[1]);
+}
+
+/** The inset every padded row in this card already uses. */
+async function rowInset(): Promise<number> {
+  const css = withoutComments(await Bun.file(cssUrl).text());
+  const cardRow = horizontal(ruleBody(css, ".card-row"), "padding");
+  const settingRow = horizontal(ruleBody(css, ".setting-row"), "padding");
+  const cardSub = horizontal(ruleBody(css, ".card-sub"), "padding");
+  // The three disagree only if the card's own baseline moved, which this contract cannot
+  // silently follow — a mismatch means the target inset has to be re-decided, not guessed.
+  expect(settingRow).toBe(cardRow);
+  expect(cardSub).toBe(cardRow);
+  return cardRow;
+}
+
+test("the warning box is inset by the same amount as the card's padded rows", async () => {
+  const css = withoutComments(await Bun.file(cssUrl).text());
+  const notice = ruleBody(css, ".anthropic-pool-card__notice");
+
+  // Margin, not padding: the box draws a border, so padding alone insets the text and
+  // leaves the border itself sitting on the card edge — the original bug, one layer in.
+  expect(horizontal(notice, "margin")).toBe(await rowInset());
+});
+
+test("the threshold field is inset by the same amount as the card's padded rows", async () => {
+  const css = withoutComments(await Bun.file(cssUrl).text());
+  const field = ruleBody(css, ".anthropic-pool-card__field");
+
+  // The `.input` inside is full-width, so the field carries the inset for the whole group;
+  // without it the input's own border reaches the card edge.
+  expect(horizontal(field, "padding")).toBe(await rowInset());
+});
+
+test("the help line inside the threshold field is not indented twice", async () => {
+  const css = withoutComments(await Bun.file(cssUrl).text());
+
+  // `.card-sub` brings its own 16px, which lands on top of the field's inset and pushes the
+  // help text out of line with the label directly above it.
+  const group = css.match(
+    /(^|\n)([^{}]*\.anthropic-pool-card__field \.card-sub\s*)\{([^}]*)\}/,
+  );
+  expect(group).not.toBeNull();
+  expect(horizontal(group![3], "padding")).toBe(0);
+});
+
+test("the component styles the warning and the field by class, not inline", async () => {
+  const tsx = await Bun.file(tsxUrl).text();
+
+  expect(tsx).toContain('className="card-sub anthropic-pool-card__notice"');
+  expect(tsx).toContain('className="field anthropic-pool-card__field"');
+
+  // The inline box styles are what bypassed the inset: an inline `padding` also outranks
+  // any stylesheet rule, so reintroducing one silently disables the fix above.
+  expect(tsx).not.toContain('padding: "10px 16px"');
+  expect(tsx).not.toContain("borderRadius");
+  expect(tsx).not.toMatch(/style=\{\{[^}]*marginTop: 10/);
+  expect(tsx).not.toMatch(/style=\{\{[^}]*display: "block"/);
+});

--- a/gui/tests/anthropic-pool-card-layout.test.ts
+++ b/gui/tests/anthropic-pool-card-layout.test.ts
@@ -1,18 +1,13 @@
 import { expect, test } from "bun:test";
 
 /**
- * Claude account-pool card inset contract.
+ * Claude account-pool card inset contract. The rule comment on
+ * `.anthropic-pool-card__notice` in `src/styles.css` explains why each value is what it is.
  *
  * Source-text assertions, not rendered measurements: happy-dom performs no layout, so a
  * getBoundingClientRect() here returns zeros and would prove nothing. Rendered proof was
- * captured in a real browser during the fix — the title sat 17px from the card's left
- * edge while the warning box and the threshold input sat at 1px. This file's job is to
- * keep the CSS shape that produced that gap from coming back silently.
- *
- * The bug: `.card` carries no padding of its own, so each child supplies the 16px inset.
- * `.card-row`, `.card-sub` and `.setting-row` all do, which is why the title row, the help
- * line and the rotation rows were indented. The experimental warning box and the threshold
- * field are none of those three, so they ran flush against the card border.
+ * captured in a real browser during the fix — the title sat 17px from the card's left edge
+ * while the warning box and the threshold input sat at 1px.
  */
 
 const cssUrl = new URL("../src/styles.css", import.meta.url);
@@ -66,26 +61,18 @@ async function rowInset(): Promise<number> {
 test("the warning box is inset by the same amount as the card's padded rows", async () => {
   const css = withoutComments(await Bun.file(cssUrl).text());
   const notice = ruleBody(css, ".anthropic-pool-card__notice");
-
-  // Margin, not padding: the box draws a border, so padding alone insets the text and
-  // leaves the border itself sitting on the card edge — the original bug, one layer in.
   expect(horizontal(notice, "margin")).toBe(await rowInset());
 });
 
 test("the threshold field is inset by the same amount as the card's padded rows", async () => {
   const css = withoutComments(await Bun.file(cssUrl).text());
   const field = ruleBody(css, ".anthropic-pool-card__field");
-
-  // The `.input` inside is full-width, so the field carries the inset for the whole group;
-  // without it the input's own border reaches the card edge.
   expect(horizontal(field, "padding")).toBe(await rowInset());
 });
 
 test("the help line inside the threshold field is not indented twice", async () => {
   const css = withoutComments(await Bun.file(cssUrl).text());
 
-  // `.card-sub` brings its own 16px, which lands on top of the field's inset and pushes the
-  // help text out of line with the label directly above it.
   const group = css.match(
     /(^|\n)([^{}]*\.anthropic-pool-card__field \.card-sub\s*)\{([^}]*)\}/,
   );


### PR DESCRIPTION
## Summary

`.card` carries no padding of its own — `.card-row`, `.card-sub` and `.setting-row` each supply the 16px inset themselves. In the Claude account-pool card the experimental warning box and the "New session usage threshold" field are none of those three, so they rendered flush against the card border while the title row above them and the rotation-strategy rows below them sat 16px in. Measured in the running dashboard at 814px card width: title 17px from the card's left edge, warning box and threshold input 1px (17px = the card's 1px border + the 16px inset).

This is the same inset `.account-pool-strategy-card` already carries for the Codex pool card — *"Match .card-row inset — .card itself has no padding"* — applied to the card that still had the gap.

- The warning takes `margin`, not `padding`. It draws its own border, so padding would inset only its text and leave the border itself sitting on the card edge — the same bug, one layer in.
- The threshold field takes `padding`, because the `.input` inside is full-width; the field owns the inset for the label, the control and the help line together.
- The field's help line joins the existing `margin: 0; padding: 0` group, so the field's inset and `.card-sub`'s own 16px do not stack.
- The box styles move out of inline `style` props into the stylesheet. That is part of the fix rather than cleanup: an inline `padding` outranks any stylesheet rule, so leaving it in place would keep the inset unreachable.

No copy, locale key, behavior, API, or dependency changes — CSS plus the two `className` strings that select it.

Closes #2489

**Before** — the warning box and the threshold input run edge to edge while the title and "Rotation strategy" are indented:

![Claude account-pool card with the warning box and threshold input flush against the card border](https://raw.githubusercontent.com/Yoonkeee/opencodex/issue-assets/anthropic-pool-card-before.png)

**After** — every row shares one left edge:

![The same card with the warning box and threshold field inset to match the title row](https://raw.githubusercontent.com/Yoonkeee/opencodex/issue-assets/anthropic-pool-card-after.png)

## Verification

Local, macOS 26.5.2, bun 1.3.13, branch rebased onto `dev` at 3e3a028fe.

| Command | Result |
| --- | --- |
| `bun run typecheck` | clean (exit 0) |
| `cd gui && bun run lint` | clean |
| `cd gui && bun run lint:i18n` | clean |
| `cd gui && bun run build` | built |
| `cd gui && bun test tests` | 978 pass, 0 fail (170 files) |
| `bun run privacy:scan` | Privacy scan passed |
| `bun run doctor:gui:if-changed` | exit 0 |
| `bun run test` (full suite) | 14537 pass, 2 fail — both unrelated, see below |

The two failures in the full suite are `tests/shutdown-launcher.test.ts` ("SIGTERM to the launcher tears down the Bun proxy") and `tests/server-auth.test.ts` ("websocket passthrough refreshes pool auth for each response.create turn"). Both pass when run on their own on this same commit — 3/3 and 86/86 — so they are parallel-run interference, not a regression from this change, which touches only `gui/`:

```
bun test tests/shutdown-launcher.test.ts   ->  3 pass, 0 fail
bun test tests/server-auth.test.ts         -> 86 pass, 0 fail
```

Rendered check, not only assertions: served the GUI against the running proxy with `OPENCODEX_PROXY_TARGET=http://127.0.0.1:10100 bun run dev` and measured the card in the browser, on the release build and on this branch.

| Element | Before | After |
| --- | --- | --- |
| Title `<strong>` (`.card-row`) | 17px | 17px |
| Experimental warning box (`[role="alert"]`) | 1px | 17px |
| Threshold label (`.field-label`) | 1px | 17px |
| Threshold `<input>` (`.input`) | 1px | 17px |
| "Rotation strategy" title (`.setting-row`) | 17px | 17px |

New regression test: `gui/tests/anthropic-pool-card-layout.test.ts`, following the source-text approach of `tests/sidecar-layout.test.ts` (happy-dom performs no layout, so a `getBoundingClientRect()` there would return zeros). It reads the target inset from `.card-row` / `.setting-row` / `.card-sub` rather than hard-coding 16, so the contract cannot drift from the card it is supposed to match, and it fails if the inline box styles come back.

It was driven red before being kept — with the notice margin changed to `10px 0 0`:

```
error: expect(received).toBe(expected)
Expected: 16
Received: 0
(fail) the warning box is inset by the same amount as the card's padded rows
```

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed — not needed; no user-facing behavior, copy, or configuration change, so nothing in `docs-site/` describes what moved.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults — none; the diff is CSS and two `className` strings, and touches no authentication, credential, workflow, release, or dependency surface. `bun run privacy:scan` is green.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved Anthropic account pool card layout and spacing.
  * Added consistent styling for warning notices, strategy fields, and help text.
  * Replaced inline styling with shared interface styles for a more consistent appearance and cleaner alignment across card content.

* **Tests**
  * Added coverage to verify account pool card layout, spacing, and styling consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
