### PR TITLE
fix(anthropic): apply provider default reasoning effort when caller omits it

### DIFF
--- a/src/adapters/anthropic.ts
+++ b/src/adapters/anthropic.ts
@@ -27,6 +27,7 @@ import { CLAUDE_CODE_HEADERS, claudeCodeSessionId } from "./client-fingerprint";
 import { buildNonOpenAIToolCatalogNudgeForTools } from "./tool-catalog-nudge";
 import { decodeServerSentEvents } from "../lib/sse-decoder";
 import { isTranslatorBudgetExceededError, retainTranslatedEventBatch, type TranslatorBudget } from "../lib/translator-budget";
+import { modelRecordValue } from "../reasoning-effort";
 
 /** Map a user content part to an Anthropic content block (text or image source). */
 function toAnthropicContentPart(p: OcxContentPart): unknown {
@@ -518,6 +519,11 @@ function adaptiveEffort(effort: string): string {
   return effort === "minimal" ? "low" : effort;
 }
 
+function defaultReasoningEffort(provider: OcxProviderConfig, modelId: string): string | undefined {
+  const value = modelRecordValue(provider.modelDefaultReasoningEfforts, modelId);
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
 function usageFromAnthropic(usage: Record<string, number> | undefined): OcxUsage | undefined {
   if (!usage) return undefined;
   const hasCache = usage.cache_read_input_tokens !== undefined || usage.cache_creation_input_tokens !== undefined;
@@ -926,16 +932,17 @@ export function createAnthropicAdapter(provider: OcxProviderConfig, cacheRetenti
       // anyway, and thinking shares the caller's `max_tokens` — which truncates a small-budget
       // request before it can emit its stop sequence (#545). Say "disabled" out loud where the
       // model both defaults to thinking and accepts being told not to.
-      if (parsed.options.reasoning === "none" && supportsExplicitThinkingDisable(parsed.modelId)) {
+      const effectiveReasoning = parsed.options.reasoning ?? defaultReasoningEffort(provider, parsed.modelId);
+      if (effectiveReasoning === "none" && supportsExplicitThinkingDisable(parsed.modelId)) {
         body.thinking = { type: "disabled" };
-      } else if (typeof parsed.options.reasoning === "string" && parsed.options.reasoning !== "none") {
+      } else if (typeof effectiveReasoning === "string" && effectiveReasoning !== "none") {
         if (usesAdaptiveThinking(parsed.modelId)) {
           // Adaptive-thinking models replace the token budget with an effort knob and reject
           // `thinking.type: "enabled"` outright. `max_tokens` still caps thinking plus visible
           // output, so high effort needs the same total-token headroom as budget thinking or a
           // default 8192-token request can spend everything on thought and return empty text.
           body.thinking = { type: "adaptive" };
-          const effort = adaptiveEffort(parsed.options.reasoning);
+          const effort = adaptiveEffort(effectiveReasoning);
           body.output_config = { effort };
           const explicitMaxOut = parsed.options.maxOutputTokens;
           const wantBudget = reasoningBudget(effort);
@@ -951,7 +958,7 @@ export function createAnthropicAdapter(provider: OcxProviderConfig, cacheRetenti
           // 400s ("max_tokens must be greater than thinking.budget_tokens"). Size them so max_tokens
           // always exceeds the budget within a model-safe ceiling, reserving room for visible output.
           const maxOut = parsed.options.maxOutputTokens ?? DEFAULT_MAX_TOKENS;
-          const wantBudget = reasoningBudget(parsed.options.reasoning);
+          const wantBudget = reasoningBudget(effectiveReasoning);
           const maxTokens = Math.min(REASONING_MAX_TOKENS_CEILING, Math.max(maxOut, wantBudget + OUTPUT_HEADROOM));
           const budget = Math.max(MIN_THINKING_BUDGET, Math.min(wantBudget, maxTokens - OUTPUT_FLOOR));
           body.max_tokens = maxTokens;

--- a/tests/anthropic-reasoning.test.ts
+++ b/tests/anthropic-reasoning.test.ts
@@ -40,6 +40,28 @@ describe("anthropic extended-thinking gate", () => {
     expect(b.top_p).toBe(0.8);
   });
 
+  test("modelDefaultReasoningEfforts supplies reasoning when caller omits it", async () => {
+    const b = await bodyOf(parsed(undefined, { temperature: 0.5, topP: 0.8 }, "always-thinking-model"), {
+      ...provider,
+      modelDefaultReasoningEfforts: { "always-thinking-model": "high" },
+    });
+    const thinking = b.thinking as { type: string; budget_tokens: number } | undefined;
+    expect(thinking?.type).toBe("enabled");
+    expect(typeof thinking?.budget_tokens).toBe("number");
+    expect(b.temperature).toBeUndefined();
+    expect(b.top_p).toBeUndefined();
+  });
+
+  test("explicit reasoning overrides modelDefaultReasoningEfforts", async () => {
+    const b = await bodyOf(parsed("low", {}, "always-thinking-model"), {
+      ...provider,
+      modelDefaultReasoningEfforts: { "always-thinking-model": "high" },
+    });
+    const thinking = b.thinking as { type: string; budget_tokens: number } | undefined;
+    expect(thinking?.type).toBe("enabled");
+    expect(thinking?.budget_tokens).toBe(4096);
+  });
+
   test("reasoning 'high' enables thinking and drops sampling (extended-thinking rule)", async () => {
     const b = await bodyOf(parsed("high", { temperature: 0.3, topP: 0.9 }));
     const thinking = b.thinking as { type: string; budget_tokens: number } | undefined;


### PR DESCRIPTION
## Summary

Anthropic-compatible models that require explicit thinking now work when the caller omits `reasoning.effort`, as long as the provider declares `modelDefaultReasoningEfforts`. Before this, those defaults were visible in model metadata but the Anthropic adapter did not apply them to outbound `/v1/messages` requests, so always-thinking gateways could reject otherwise valid Claude Code/OpenCodex calls.

Explicit caller reasoning still wins over the provider default, preserving the existing override behavior.

## Changes

- `src/adapters/anthropic.ts` — read `provider.modelDefaultReasoningEfforts` via `modelRecordValue` when `parsed.options.reasoning` is absent; use the effective effort for the adaptive-thinking / budget-thinking branches.
- `tests/anthropic-reasoning.test.ts` — two new tests: default supplies reasoning when omitted; explicit reasoning overrides the default.

## Validation

- `bun test tests/anthropic-reasoning.test.ts` → **53 pass, 0 fail** (includes the 2 new tests)
- `bun x esbuild src/adapters/anthropic.ts` → clean
- Local manual check against an Anthropic-compatible Joybuilder GLM route: request without explicit `thinking` changed from upstream 400 to a successful response after applying `modelDefaultReasoningEfforts`.

Supersedes #2468 (which was opened from a wrong base and bundled the already-merged regex fix).

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Anthropic models now apply their configured reasoning effort when none is specified.
  * Reasoning settings consistently control thinking, output effort, token budgets, and sampling behavior.
  * Explicit reasoning choices take precedence over model defaults.

* **Tests**
  * Added coverage for default and explicitly selected reasoning configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
