### PR TITLE
feat(agents): add opt-in plaintext V2 collaboration messages

### DIFF
--- a/docs-site/src/content/docs/guides/sub-agent-surface.md
+++ b/docs-site/src/content/docs/guides/sub-agent-surface.md
@@ -138,6 +138,15 @@ Recovery options are to select a native ChatGPT child, add a native ChatGPT targ
 v1 for heterogeneous-provider delegation, or resend the task as plaintext v2 `agent_message`
 content when you control the caller.
 
+The experimental `plaintextV2AgentMessages: true` option attempts to prevent application-layer
+encryption for eligible new native ChatGPT v2 tool calls. It removes the message marker under a
+request-scoped namespace alias and restores `collaboration` in the response. It handles
+`spawn_agent`, `send_message`, and `followup_task` and adds no recovery request. HTTPS remains
+encrypted, but task text can be retained in Codex history, routed-provider requests, and local
+response/debug state. Existing ciphertext is unchanged, and the option depends on undocumented
+ChatGPT and Codex behavior. See
+[Agent configuration: Plaintext v2 agent messages](/reference/configuration/agents/#plaintext-v2-agent-messages).
+
 An experimental, disabled-by-default `agentTaskRecovery` option can recover this specific native-
 to-routed shape through a raw Responses passthrough to the fixed ChatGPT `/responses` endpoint using
 the incoming credential shape used by the canonical `openai` provider with `authMode: "forward"`.

--- a/docs-site/src/content/docs/guides/sub-agent-surface.md
+++ b/docs-site/src/content/docs/guides/sub-agent-surface.md
@@ -138,10 +138,14 @@ Recovery options are to select a native ChatGPT child, add a native ChatGPT targ
 v1 for heterogeneous-provider delegation, or resend the task as plaintext v2 `agent_message`
 content when you control the caller.
 
-The experimental `plaintextV2AgentMessages: true` option attempts to prevent application-layer
-encryption for eligible new native ChatGPT v2 tool calls. It assigns request-scoped aliases to the
-namespace and three reserved message-tool names, removes the message marker, and restores the
-original identities in the response. It handles
+The experimental `plaintextV2AgentMessages` field is unset in a fresh config and runs only when set
+to `true`. The caller must use the Responses wire, and the final destination must use
+`adapter: "openai-responses"`, `authMode: "forward"`, and the exact base URL
+`https://chatgpt.com/backend-api/codex`. OpenAI API-key providers, custom compatible gateways,
+routes to other providers, and non-Responses callers are excluded. For an eligible new native
+ChatGPT v2 tool call, the option assigns request-scoped aliases to the namespace and three reserved
+message-tool names, removes the message marker, and restores the original identities in the
+response. It handles
 `spawn_agent`, `send_message`, and `followup_task` and adds no recovery request. HTTPS remains
 encrypted, but task text can be retained in Codex history, routed-provider requests, and local
 response/debug state. Existing ciphertext is unchanged, and the option depends on undocumented

--- a/docs-site/src/content/docs/guides/sub-agent-surface.md
+++ b/docs-site/src/content/docs/guides/sub-agent-surface.md
@@ -139,8 +139,9 @@ v1 for heterogeneous-provider delegation, or resend the task as plaintext v2 `ag
 content when you control the caller.
 
 The experimental `plaintextV2AgentMessages: true` option attempts to prevent application-layer
-encryption for eligible new native ChatGPT v2 tool calls. It removes the message marker under a
-request-scoped namespace alias and restores `collaboration` in the response. It handles
+encryption for eligible new native ChatGPT v2 tool calls. It assigns request-scoped aliases to the
+namespace and three reserved message-tool names, removes the message marker, and restores the
+original identities in the response. It handles
 `spawn_agent`, `send_message`, and `followup_task` and adds no recovery request. HTTPS remains
 encrypted, but task text can be retained in Codex history, routed-provider requests, and local
 response/debug state. Existing ciphertext is unchanged, and the option depends on undocumented

--- a/docs-site/src/content/docs/reference/configuration/agents.md
+++ b/docs-site/src/content/docs/reference/configuration/agents.md
@@ -23,7 +23,7 @@ routes, and limits delegated work.
 | `subagentModelFallbackPollMs?` | `number` | `60000` | Availability-probe cache interval. Values below 1000 ms fall back to the default. |
 | `effortCap?` | `string` | — | Hard ceiling for qualifying v2 main turns and marked spawned-child turns. Accepts `low` through `ultra`. |
 | `subagentEffortCap?` | `string` | — | Additional ceiling for spawned-child turns only. When both caps apply, the lower wins. |
-| `plaintextV2AgentMessages?` | `boolean` | `false` | Experimental opt-in that asks native ChatGPT v2 parents to emit `spawn_agent`, `send_message`, and `followup_task` message arguments as plaintext. See [Plaintext v2 agent messages](#plaintext-v2-agent-messages). |
+| `plaintextV2AgentMessages?` | `boolean` | — (unset) | Experimental opt-in. It runs only when explicitly set to `true` and asks eligible native ChatGPT v2 parents to emit `spawn_agent`, `send_message`, and `followup_task` message arguments as plaintext. See [Plaintext v2 agent messages](#plaintext-v2-agent-messages). |
 | `agentTaskRecovery?` | `object` | — | Experimental opt-in recovery for backend-encrypted v2 tasks sent to routed providers. Disabled unless `enabled: true`; see [Encrypted v2 task recovery](#encrypted-v2-task-recovery). |
 
 Manage the surface with the dashboard or
@@ -123,15 +123,24 @@ fails instead of routing unreadable ciphertext elsewhere.
 
 ## Plaintext v2 agent messages
 
-`plaintextV2AgentMessages` is an experimental, disabled-by-default alternative to post-encryption
-recovery. On a v2 Responses request whose final destination is the canonical ChatGPT backend,
-opencodex recognizes the v2 catalog by a top-level `collaboration` namespace with a direct
-`spawn_agent` child. It removes `parameters.properties.message.encrypted: true`, when present, only
-from `spawn_agent`, `send_message`, and `followup_task`. ChatGPT reserves both the `collaboration`
-namespace and those three tool names, so the request uses fixed private aliases for all four
-identities. OpenCodex restores the original namespace and tool names in JSON, SSE, and WebSocket
-responses before Codex receives the tool call. The `encrypted_function_args: []` field is preserved
-so compatible Codex clients recognize the message as plaintext.
+`plaintextV2AgentMessages` is unset in a fresh config and runs only when explicitly set to `true`.
+The caller must use the Responses wire, and the final destination must use the canonical ChatGPT
+Codex forward transport: `adapter: "openai-responses"`, `authMode: "forward"`, and the exact base URL
+`https://chatgpt.com/backend-api/codex`. OpenAI API-key providers, custom OpenAI-compatible
+gateways, routes whose final destination is another provider, and non-Responses callers are never
+rewritten.
+
+For an eligible v2 request, opencodex recognizes the catalog by a top-level `collaboration`
+namespace with a direct `spawn_agent` child. It removes
+`parameters.properties.message.encrypted: true`, when present, only from `spawn_agent`,
+`send_message`, and `followup_task`. ChatGPT reserves both the `collaboration` namespace and those
+three tool names, so the request uses fixed private aliases for all four identities. Before making
+that change, opencodex checks top-level and `additional_tools` catalogs, nested namespaces,
+`tool_search_output` declarations, `tool_choice`, and prior call items for the private namespace and
+fixed aliases. Any conflict leaves the entire request unchanged. OpenCodex restores only the
+request-scoped aliases in JSON, SSE, and WebSocket responses before Codex receives the tool call.
+The `encrypted_function_args: []` field is preserved so compatible Codex clients recognize the
+message as plaintext.
 
 This path adds no recovery request and therefore does not spend the extra ChatGPT quota used by a
 cache miss in `agentTaskRecovery`. It cannot change tasks that are already encrypted. If the request
@@ -140,6 +149,11 @@ unchanged; separately enabled recovery can still handle a routed task that is la
 ChatGPT rejects or ignores the modified schema, or the Codex client does not recognize the plaintext
 response fields, the call can fail. OpenCodex does not retry the parent request with the original
 schema because doing so could duplicate quota use or tool calls.
+
+Restoration uses a 10,000-identity traversal budget for each response payload. If a payload exhausts
+that budget, bounded JSON returns HTTP 502 and a stream returns `response.failed`; neither path
+sends the private aliases to Codex or saves the refused response for `previous_response_id`
+continuation.
 
 For successfully rewritten calls, the option removes application-layer encryption from agent
 message arguments. HTTPS still encrypts network transport, but message text can appear in Codex

--- a/docs-site/src/content/docs/reference/configuration/agents.md
+++ b/docs-site/src/content/docs/reference/configuration/agents.md
@@ -127,11 +127,11 @@ fails instead of routing unreadable ciphertext elsewhere.
 recovery. On a v2 Responses request whose final destination is the canonical ChatGPT backend,
 opencodex recognizes the v2 catalog by a top-level `collaboration` namespace with a direct
 `spawn_agent` child. It removes `parameters.properties.message.encrypted: true`, when present, only
-from `spawn_agent`, `send_message`, and `followup_task`. Because ChatGPT reserves the
-`collaboration` namespace and rejects a modified schema under that name, the request uses a private
-namespace alias. OpenCodex restores `collaboration` in JSON, SSE, and WebSocket responses before
-Codex receives the tool call. The `encrypted_function_args: []` field is preserved so compatible
-Codex clients recognize the message as plaintext.
+from `spawn_agent`, `send_message`, and `followup_task`. ChatGPT reserves both the `collaboration`
+namespace and those three tool names, so the request uses fixed private aliases for all four
+identities. OpenCodex restores the original namespace and tool names in JSON, SSE, and WebSocket
+responses before Codex receives the tool call. The `encrypted_function_args: []` field is preserved
+so compatible Codex clients recognize the message as plaintext.
 
 This path adds no recovery request and therefore does not spend the extra ChatGPT quota used by a
 cache miss in `agentTaskRecovery`. It cannot change tasks that are already encrypted. If the request

--- a/docs-site/src/content/docs/reference/configuration/agents.md
+++ b/docs-site/src/content/docs/reference/configuration/agents.md
@@ -23,6 +23,7 @@ routes, and limits delegated work.
 | `subagentModelFallbackPollMs?` | `number` | `60000` | Availability-probe cache interval. Values below 1000 ms fall back to the default. |
 | `effortCap?` | `string` | — | Hard ceiling for qualifying v2 main turns and marked spawned-child turns. Accepts `low` through `ultra`. |
 | `subagentEffortCap?` | `string` | — | Additional ceiling for spawned-child turns only. When both caps apply, the lower wins. |
+| `plaintextV2AgentMessages?` | `boolean` | `false` | Experimental opt-in that asks native ChatGPT v2 parents to emit `spawn_agent`, `send_message`, and `followup_task` message arguments as plaintext. See [Plaintext v2 agent messages](#plaintext-v2-agent-messages). |
 | `agentTaskRecovery?` | `object` | — | Experimental opt-in recovery for backend-encrypted v2 tasks sent to routed providers. Disabled unless `enabled: true`; see [Encrypted v2 task recovery](#encrypted-v2-task-recovery). |
 
 Manage the surface with the dashboard or
@@ -119,6 +120,42 @@ fails instead of routing unreadable ciphertext elsewhere.
   "subagentEffortCap": "high"
 }
 ```
+
+## Plaintext v2 agent messages
+
+`plaintextV2AgentMessages` is an experimental, disabled-by-default alternative to post-encryption
+recovery. On a v2 Responses request whose final destination is the canonical ChatGPT backend,
+opencodex recognizes the v2 catalog by a top-level `collaboration` namespace with a direct
+`spawn_agent` child. It removes `parameters.properties.message.encrypted: true`, when present, only
+from `spawn_agent`, `send_message`, and `followup_task`. Because ChatGPT reserves the
+`collaboration` namespace and rejects a modified schema under that name, the request uses a private
+namespace alias. OpenCodex restores `collaboration` in JSON, SSE, and WebSocket responses before
+Codex receives the tool call. The `encrypted_function_args: []` field is preserved so compatible
+Codex clients recognize the message as plaintext.
+
+This path adds no recovery request and therefore does not spend the extra ChatGPT quota used by a
+cache miss in `agentTaskRecovery`. It cannot change tasks that are already encrypted. If the request
+already declares the private alias or a conflicting reference, opencodex leaves that request
+unchanged; separately enabled recovery can still handle a routed task that is later encrypted. If
+ChatGPT rejects or ignores the modified schema, or the Codex client does not recognize the plaintext
+response fields, the call can fail. OpenCodex does not retry the parent request with the original
+schema because doing so could duplicate quota use or tool calls.
+
+For successfully rewritten calls, the option removes application-layer encryption from agent
+message arguments. HTTPS still encrypts network transport, but message text can appear in Codex
+task history, routed-provider requests, `responses-state.json` or its spill files, and
+`usage-debug.jsonl` when debug capture is enabled. The behavior depends on undocumented ChatGPT
+schema and response fields and may stop working after a backend or client update. Startup prints a
+warning while it is enabled.
+
+```json
+{
+  "plaintextV2AgentMessages": true
+}
+```
+
+The equivalent CLI command is `ocx config set plaintextV2AgentMessages true`. Restart the proxy
+after changing the setting.
 
 ## Encrypted v2 task recovery
 

--- a/docs-site/src/content/docs/zh-cn/guides/sub-agent-surface.md
+++ b/docs-site/src/content/docs/zh-cn/guides/sub-agent-surface.md
@@ -86,6 +86,13 @@ opencodex 会安全失败，而不是转发空任务或不可读任务：
 
 恢复选项是选择原生 ChatGPT 子级、在 combo 中添加原生 ChatGPT 目标、在异构 provider 委派中使用 v1，或者在你控制调用方时将任务作为明文 v2 `agent_message` 内容重新发送。
 
+实验性的 `plaintextV2AgentMessages: true` 会尝试取消符合条件的新原生 ChatGPT v2 工具调用的
+应用层加密。它临时改写 namespace 并删除消息字段的加密标记，在响应返回 Codex 前再恢复
+`collaboration`。它处理 `spawn_agent`、`send_message` 和 `followup_task`，不会增加恢复请求。
+HTTPS 仍会加密网络传输，但任务文字可能保存在 Codex 历史、外部模型请求和本地响应或调试文件中。
+已有密文不会改变。该选项依赖 ChatGPT 和 Codex 未公开的行为。详见
+[明文 v2 代理消息](/zh-cn/reference/configuration/agents/#明文-v2-代理消息)。
+
 实验性的 `agentTaskRecovery` 默认关闭。显式启用后，它可以通过向固定 ChatGPT 端点发送额外的认证请求来恢复这种格式，但会消耗配额、增加延迟，并依赖非公开的后端行为。任何失败都会保留原有的 `unreadable_encrypted_agent_task` 错误。详见[英文配置参考](/reference/configuration/agents/#encrypted-v2-task-recovery)。
 
 ## 更改模式

--- a/docs-site/src/content/docs/zh-cn/guides/sub-agent-surface.md
+++ b/docs-site/src/content/docs/zh-cn/guides/sub-agent-surface.md
@@ -87,8 +87,8 @@ opencodex 会安全失败，而不是转发空任务或不可读任务：
 恢复选项是选择原生 ChatGPT 子级、在 combo 中添加原生 ChatGPT 目标、在异构 provider 委派中使用 v1，或者在你控制调用方时将任务作为明文 v2 `agent_message` 内容重新发送。
 
 实验性的 `plaintextV2AgentMessages: true` 会尝试取消符合条件的新原生 ChatGPT v2 工具调用的
-应用层加密。它临时改写 namespace 并删除消息字段的加密标记，在响应返回 Codex 前再恢复
-`collaboration`。它处理 `spawn_agent`、`send_message` 和 `followup_task`，不会增加恢复请求。
+应用层加密。它临时改写 namespace 和三个保留工具名，并删除消息字段的加密标记；响应返回 Codex
+前会恢复原 namespace 与工具名。它处理 `spawn_agent`、`send_message` 和 `followup_task`，不会增加恢复请求。
 HTTPS 仍会加密网络传输，但任务文字可能保存在 Codex 历史、外部模型请求和本地响应或调试文件中。
 已有密文不会改变。该选项依赖 ChatGPT 和 Codex 未公开的行为。详见
 [明文 v2 代理消息](/zh-cn/reference/configuration/agents/#明文-v2-代理消息)。

--- a/docs-site/src/content/docs/zh-cn/guides/sub-agent-surface.md
+++ b/docs-site/src/content/docs/zh-cn/guides/sub-agent-surface.md
@@ -86,9 +86,13 @@ opencodex 会安全失败，而不是转发空任务或不可读任务：
 
 恢复选项是选择原生 ChatGPT 子级、在 combo 中添加原生 ChatGPT 目标、在异构 provider 委派中使用 v1，或者在你控制调用方时将任务作为明文 v2 `agent_message` 内容重新发送。
 
-实验性的 `plaintextV2AgentMessages: true` 会尝试取消符合条件的新原生 ChatGPT v2 工具调用的
-应用层加密。它临时改写 namespace 和三个保留工具名，并删除消息字段的加密标记；响应返回 Codex
-前会恢复原 namespace 与工具名。它处理 `spawn_agent`、`send_message` 和 `followup_task`，不会增加恢复请求。
+新配置不会写入实验性的 `plaintextV2AgentMessages` 字段，只有显式设置为 `true` 才会启用。
+调用方必须使用 Responses 格式，最终目标必须采用 `adapter: "openai-responses"`、
+`authMode: "forward"` 和准确的基础地址 `https://chatgpt.com/backend-api/codex`。OpenAI API key
+provider、自定义兼容网关、最终发往其他 provider 的请求，以及非 Responses 调用都不会被改写。
+对于符合条件的新原生 ChatGPT v2 工具调用，该选项会临时改写 namespace 和三个保留工具名，
+并删除消息字段的加密标记；响应返回 Codex 前会恢复原 namespace 与工具名。它处理
+`spawn_agent`、`send_message` 和 `followup_task`，不会增加恢复请求。
 HTTPS 仍会加密网络传输，但任务文字可能保存在 Codex 历史、外部模型请求和本地响应或调试文件中。
 已有密文不会改变。该选项依赖 ChatGPT 和 Codex 未公开的行为。详见
 [明文 v2 代理消息](/zh-cn/reference/configuration/agents/#明文-v2-代理消息)。

--- a/docs-site/src/content/docs/zh-cn/reference/configuration/agents.md
+++ b/docs-site/src/content/docs/zh-cn/reference/configuration/agents.md
@@ -21,6 +21,7 @@ description: 多代理界面、委派引导、首选模型、回退链、原生�
 | `subagentModelFallbackPollMs?` | `number` | `60000` | 可用性探测缓存间隔。低于 1000 ms 的值会回退到默认值。 |
 | `effortCap?` | `string` | — | 对符合条件的 v2 主轮次和标记的派生子轮次设置硬上限。接受 `low` 到 `ultra`。 |
 | `subagentEffortCap?` | `string` | — | 仅针对派生子轮次的额外上限。两个上限同时适用时，较低者生效。 |
+| `plaintextV2AgentMessages?` | `boolean` | `false` | 实验性选项。启用后，opencodex 会尝试让符合条件的新 `spawn_agent`、`send_message` 和 `followup_task` 调用使用明文消息参数。详见[明文 v2 代理消息](#明文-v2-代理消息)。 |
 
 通过仪表板或 `ocx v2 status|on|off|mode <v1|default|v2>|threads <n>` 管理该界面。模式变更会应用于新会话。`maxConcurrentThreadsPerSession` 是 `PUT /api/v2` 字段，不是 `config.json` 键；`ocx v2 threads <n>` 会在启用 v2 后，将 `max_concurrent_threads_per_session` 写入 Codex 的 `$CODEX_HOME/config.toml` 中的 `[features.multi_agent_v2]` 下。
 
@@ -69,6 +70,31 @@ opencodex 会跳过已禁用、不可路由、不健康、处于冷却中，或�
   "subagentEffortCap": "high"
 }
 ```
+
+## 明文 v2 代理消息
+
+`plaintextV2AgentMessages` 默认关闭。opencodex 只识别顶层 `collaboration` namespace，而且它必须直接包含
+`spawn_agent`。原生 ChatGPT 收到这类 v2 Responses 请求前，opencodex 会删除 `spawn_agent`、
+`send_message` 和 `followup_task` 中已有的 `parameters.properties.message.encrypted: true`。
+ChatGPT 会校验保留的 `collaboration` namespace，因此请求会临时使用一个私有名称。opencodex 在 JSON、
+SSE 和 WebSocket 响应中把名称改回 `collaboration`，并保留 `encrypted_function_args: []`，让兼容的
+Codex 客户端把参数识别为明文。
+
+这个选项不会增加恢复请求，也不会使用 `agentTaskRecovery` 在缓存未命中时产生的额外 ChatGPT
+配额。它只能影响新工具调用，不能修改已有密文。请求已占用私有名称或有冲突引用时，opencodex 会保持该请求不变；若它后来生成加密的路由子任务，单独启用的 `agentTaskRecovery` 仍可处理。ChatGPT 拒绝或忽略修改后的 schema，或 Codex 客户端不识别明文响应字段时，调用可能失败。opencodex 不会用原 schema 自动重发父请求，因为重发可能重复消耗配额或重复执行工具。
+
+成功改写后，这个选项会取消代理消息参数的应用层加密。HTTPS 仍会加密网络传输，但消息文字可能出现在 Codex
+任务历史、外部模型请求、`responses-state.json` 及其 spill 文件，以及启用调试记录时的
+`usage-debug.jsonl`。该行为依赖 ChatGPT 未公开的 schema 和响应字段，后端或客户端更新后可能失效。
+服务启动时会打印警告。
+
+```json
+{
+  "plaintextV2AgentMessages": true
+}
+```
+
+等价命令是 `ocx config set plaintextV2AgentMessages true`。修改后重启代理。
 
 ## Effort 上限
 

--- a/docs-site/src/content/docs/zh-cn/reference/configuration/agents.md
+++ b/docs-site/src/content/docs/zh-cn/reference/configuration/agents.md
@@ -76,9 +76,9 @@ opencodex 会跳过已禁用、不可路由、不健康、处于冷却中，或�
 `plaintextV2AgentMessages` 默认关闭。opencodex 只识别顶层 `collaboration` namespace，而且它必须直接包含
 `spawn_agent`。原生 ChatGPT 收到这类 v2 Responses 请求前，opencodex 会删除 `spawn_agent`、
 `send_message` 和 `followup_task` 中已有的 `parameters.properties.message.encrypted: true`。
-ChatGPT 会校验保留的 `collaboration` namespace，因此请求会临时使用一个私有名称。opencodex 在 JSON、
-SSE 和 WebSocket 响应中把名称改回 `collaboration`，并保留 `encrypted_function_args: []`，让兼容的
-Codex 客户端把参数识别为明文。
+ChatGPT 会按保留的 `collaboration` namespace 和三个工具名处理消息，因此请求会给这四个名称使用固定的
+临时别名。opencodex 在 JSON、SSE 和 WebSocket 响应中恢复原名称，并保留
+`encrypted_function_args: []`，让兼容的 Codex 客户端把参数识别为明文。
 
 这个选项不会增加恢复请求，也不会使用 `agentTaskRecovery` 在缓存未命中时产生的额外 ChatGPT
 配额。它只能影响新工具调用，不能修改已有密文。请求已占用私有名称或有冲突引用时，opencodex 会保持该请求不变；若它后来生成加密的路由子任务，单独启用的 `agentTaskRecovery` 仍可处理。ChatGPT 拒绝或忽略修改后的 schema，或 Codex 客户端不识别明文响应字段时，调用可能失败。opencodex 不会用原 schema 自动重发父请求，因为重发可能重复消耗配额或重复执行工具。

--- a/docs-site/src/content/docs/zh-cn/reference/configuration/agents.md
+++ b/docs-site/src/content/docs/zh-cn/reference/configuration/agents.md
@@ -21,7 +21,7 @@ description: 多代理界面、委派引导、首选模型、回退链、原生�
 | `subagentModelFallbackPollMs?` | `number` | `60000` | 可用性探测缓存间隔。低于 1000 ms 的值会回退到默认值。 |
 | `effortCap?` | `string` | — | 对符合条件的 v2 主轮次和标记的派生子轮次设置硬上限。接受 `low` 到 `ultra`。 |
 | `subagentEffortCap?` | `string` | — | 仅针对派生子轮次的额外上限。两个上限同时适用时，较低者生效。 |
-| `plaintextV2AgentMessages?` | `boolean` | `false` | 实验性选项。启用后，opencodex 会尝试让符合条件的新 `spawn_agent`、`send_message` 和 `followup_task` 调用使用明文消息参数。详见[明文 v2 代理消息](#明文-v2-代理消息)。 |
+| `plaintextV2AgentMessages?` | `boolean` | —（未设置） | 实验性选项。只有显式设置为 `true` 才会启用。符合条件的新 `spawn_agent`、`send_message` 和 `followup_task` 调用会使用明文消息参数。详见[明文 v2 代理消息](#明文-v2-代理消息)。 |
 
 通过仪表板或 `ocx v2 status|on|off|mode <v1|default|v2>|threads <n>` 管理该界面。模式变更会应用于新会话。`maxConcurrentThreadsPerSession` 是 `PUT /api/v2` 字段，不是 `config.json` 键；`ocx v2 threads <n>` 会在启用 v2 后，将 `max_concurrent_threads_per_session` 写入 Codex 的 `$CODEX_HOME/config.toml` 中的 `[features.multi_agent_v2]` 下。
 
@@ -73,15 +73,26 @@ opencodex 会跳过已禁用、不可路由、不健康、处于冷却中，或�
 
 ## 明文 v2 代理消息
 
-`plaintextV2AgentMessages` 默认关闭。opencodex 只识别顶层 `collaboration` namespace，而且它必须直接包含
-`spawn_agent`。原生 ChatGPT 收到这类 v2 Responses 请求前，opencodex 会删除 `spawn_agent`、
-`send_message` 和 `followup_task` 中已有的 `parameters.properties.message.encrypted: true`。
-ChatGPT 会按保留的 `collaboration` namespace 和三个工具名处理消息，因此请求会给这四个名称使用固定的
-临时别名。opencodex 在 JSON、SSE 和 WebSocket 响应中恢复原名称，并保留
-`encrypted_function_args: []`，让兼容的 Codex 客户端把参数识别为明文。
+新配置不会写入 `plaintextV2AgentMessages`。只有显式设置为 `true` 才会启用。调用方必须使用 Responses
+格式，最终目标必须采用规范的 ChatGPT Codex 转发配置，即 `adapter: "openai-responses"`、
+`authMode: "forward"` 和准确的基础地址 `https://chatgpt.com/backend-api/codex`。OpenAI API key
+provider、自定义 OpenAI 兼容网关、最终发往其他 provider 的请求，以及非 Responses 调用都不会被改写。
+
+对于符合条件的 v2 请求，opencodex 只识别顶层 `collaboration` namespace，而且它必须直接包含
+`spawn_agent`。原生 ChatGPT 收到请求前，opencodex 会删除 `spawn_agent`、`send_message` 和
+`followup_task` 中已有的 `parameters.properties.message.encrypted: true`。ChatGPT 会按保留的
+`collaboration` namespace 和三个工具名处理消息，因此请求会给这四个名称使用固定的临时别名。
+修改前，opencodex 会检查顶层和 `additional_tools` 工具目录、嵌套 namespace、
+`tool_search_output` 声明、`tool_choice` 和历史调用项。只要发现私有 namespace 或固定别名冲突，
+整个请求就保持原样。opencodex 只会在 JSON、SSE 和 WebSocket 响应中恢复本次请求生成的别名，
+并保留 `encrypted_function_args: []`，让兼容的 Codex 客户端把参数识别为明文。
 
 这个选项不会增加恢复请求，也不会使用 `agentTaskRecovery` 在缓存未命中时产生的额外 ChatGPT
 配额。它只能影响新工具调用，不能修改已有密文。请求已占用私有名称或有冲突引用时，opencodex 会保持该请求不变；若它后来生成加密的路由子任务，单独启用的 `agentTaskRecovery` 仍可处理。ChatGPT 拒绝或忽略修改后的 schema，或 Codex 客户端不识别明文响应字段时，调用可能失败。opencodex 不会用原 schema 自动重发父请求，因为重发可能重复消耗配额或重复执行工具。
+
+每个响应的恢复检查最多处理 10,000 个身份位置。达到限制时，JSON 响应返回 HTTP 502，流式响应返回
+`response.failed`。这两种情况都不会把私有别名发给 Codex，也不会保存该响应供后续
+`previous_response_id` 继续使用。
 
 成功改写后，这个选项会取消代理消息参数的应用层加密。HTTPS 仍会加密网络传输，但消息文字可能出现在 Codex
 任务历史、外部模型请求、`responses-state.json` 及其 spill 文件，以及启用调试记录时的

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -91,6 +91,8 @@ export interface AdapterRequest {
     convertedRoutedToolSearchNames?: ReadonlySet<string>;
     /** Upstream-only aliases for namespace tools flattened in this request. */
     convertedRoutedNamespaceToolAliases?: ReadonlyMap<string, { namespace: string; name: string; kind: "function" | "custom" }>;
+    /** Request-declared collaboration child names eligible for plaintext-v2 alias restoration. */
+    plaintextV2AgentMessageToolNames?: ReadonlySet<string>;
     /** Releases observation of a serialized request body after its final fetch attempt settles. */
     releaseBodyObservation?: () => void;
     /** Exact reasoning parameter emitted by the adapter, for request-log diagnostics only. */

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -93,6 +93,8 @@ export interface AdapterRequest {
     convertedRoutedNamespaceToolAliases?: ReadonlyMap<string, { namespace: string; name: string; kind: "function" | "custom" }>;
     /** Request-declared collaboration child names eligible for plaintext-v2 alias restoration. */
     plaintextV2AgentMessageToolNames?: ReadonlySet<string>;
+    /** Collaboration message-tool names actually rewritten to fixed aliases in this request. */
+    plaintextV2AgentMessageAliasedToolNames?: ReadonlySet<string>;
     /** Releases observation of a serialized request body after its final fetch attempt settles. */
     releaseBodyObservation?: () => void;
     /** Exact reasoning parameter emitted by the adapter, for request-log diagnostics only. */

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -2111,6 +2111,7 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
       let convertedRoutedToolSearchNames: Set<string> | undefined;
       let convertedRoutedNamespaceToolAliases: Map<string, { namespace: string; name: string; kind: "function" | "custom" }> | undefined;
       let plaintextV2AgentMessageToolNames: ReadonlySet<string> | undefined;
+      let plaintextV2AgentMessageAliasedToolNames: ReadonlySet<string> | undefined;
       const unexpandedMiss = !!parsed.previousResponseId && parsed._previousResponseInputExpanded !== true;
       let outBody = stripPreviousResponseId(
         parsed._rawBody,
@@ -2221,6 +2222,9 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
         plaintextV2AgentMessageToolNames = prepared.namespaceAliased
           ? prepared.toolNames
           : undefined;
+        plaintextV2AgentMessageAliasedToolNames = prepared.namespaceAliased
+          ? prepared.aliasedAgentMessageToolNames
+          : undefined;
       }
       const threadServingIdentityChanged = parsed._stripReasoningEncryptedContent === true;
       const sanitizedBody = normalizeToolSchemas(
@@ -2282,6 +2286,7 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
         ...(convertedRoutedToolSearchNames ? { convertedRoutedToolSearchNames } : {}),
         ...(convertedRoutedNamespaceToolAliases ? { convertedRoutedNamespaceToolAliases } : {}),
         ...(plaintextV2AgentMessageToolNames ? { plaintextV2AgentMessageToolNames } : {}),
+        ...(plaintextV2AgentMessageAliasedToolNames ? { plaintextV2AgentMessageAliasedToolNames } : {}),
         ...(tierLog ? { tierLog } : {}),
       };
     },

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -19,6 +19,7 @@ import type { TranslatorBudget } from "../lib/translator-budget";
 import { rewriteRoutedCustomToolsForUpstream } from "../responses/custom-tool-compat";
 import { rewriteRoutedToolSearchForUpstream } from "../responses/tool-search-compat";
 import { rewriteRoutedNamespaceToolsForUpstream } from "../responses/namespace-tool-compat";
+import { preparePlaintextV2AgentMessages } from "../responses/plaintext-v2-agent-messages";
 import { openaiResponsesUrl } from "./openai-responses-url";
 import { injectXaiResponsesXSearch, normalizeXaiResponsesWebSearch } from "./xai-web-search";
 import { EMPTY_TOOL_OUTPUT_ANNOTATION, isWhitespaceOnlyTextPartArray } from "./empty-tool-output-annotation";
@@ -2109,6 +2110,7 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
       let routedCustomToolRepairNames: Set<string> | undefined;
       let convertedRoutedToolSearchNames: Set<string> | undefined;
       let convertedRoutedNamespaceToolAliases: Map<string, { namespace: string; name: string; kind: "function" | "custom" }> | undefined;
+      let plaintextV2AgentMessageToolNames: ReadonlySet<string> | undefined;
       const unexpandedMiss = !!parsed.previousResponseId && parsed._previousResponseInputExpanded !== true;
       let outBody = stripPreviousResponseId(
         parsed._rawBody,
@@ -2210,6 +2212,16 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
       if (parsed._compactionRequest === true && !isCanonicalOpenAiForwardProvider(provider)) {
         outBody = buildRoutedCompactionBody(outBody);
       }
+      if (
+        parsed._plaintextV2AgentMessages === true
+        && isCanonicalOpenAiForwardProvider(provider)
+      ) {
+        const prepared = preparePlaintextV2AgentMessages(outBody);
+        outBody = prepared.body;
+        plaintextV2AgentMessageToolNames = prepared.namespaceAliased
+          ? prepared.toolNames
+          : undefined;
+      }
       const threadServingIdentityChanged = parsed._stripReasoningEncryptedContent === true;
       const sanitizedBody = normalizeToolSchemas(
         stripSparkCompatibility(
@@ -2269,6 +2281,7 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
         ...(routedCustomToolRepairNames ? { routedCustomToolRepairNames } : {}),
         ...(convertedRoutedToolSearchNames ? { convertedRoutedToolSearchNames } : {}),
         ...(convertedRoutedNamespaceToolAliases ? { convertedRoutedNamespaceToolAliases } : {}),
+        ...(plaintextV2AgentMessageToolNames ? { plaintextV2AgentMessageToolNames } : {}),
         ...(tierLog ? { tierLog } : {}),
       };
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -1057,6 +1057,8 @@ const configSchema = z.object({
   providerContextCaps: z.record(z.string(), z.number().int().positive()).optional(),
   contextCapValue: z.number().int().positive().optional(),
   multiAgentGuidanceEnabled: z.boolean().optional(),
+  // Invalid hand edits disable only this experimental plaintext path.
+  plaintextV2AgentMessages: z.boolean().optional().catch(undefined),
   // Invalid optional recovery config must not discard unrelated provider/account state.
   agentTaskRecovery: agentTaskRecoverySchema.optional().catch(undefined),
   // These selections pre-date schema validation and used to pass through as
@@ -1929,6 +1931,19 @@ function warnDegradedOptionalRemoteBlocks(rawParsed: unknown): void {
   }
 }
 
+function malformedPlaintextV2AgentMessagesWarning(rawParsed: unknown): string | null {
+  const raw = rawConfigRecord(rawParsed);
+  if (!raw || !Object.hasOwn(raw, "plaintextV2AgentMessages")) return null;
+  const enabled = raw.plaintextV2AgentMessages;
+  if (enabled === undefined || typeof enabled === "boolean") return null;
+  return "plaintextV2AgentMessages ignored: expected a boolean";
+}
+
+function warnDegradedPlaintextV2AgentMessages(rawParsed: unknown): void {
+  const warning = malformedPlaintextV2AgentMessagesWarning(rawParsed);
+  if (warning) console.warn(`⚠️  config.json ${warning}. Other settings were preserved.`);
+}
+
 type NativeSubagentPersistedField = "injectionModel" | "injectionEffort" | "syncCodexSubagentDefaults";
 
 function rawConfigRecord(rawParsed: unknown): Record<string, unknown> | null {
@@ -2082,6 +2097,7 @@ export function loadConfig(): OcxConfig {
       warnDegradedNativeSubagentConfig(parsed, config);
       warnDegradedCodexAccountPicker(parsed);
       warnDegradedUpstreamHostCircuitThreshold(parsed);
+      warnDegradedPlaintextV2AgentMessages(parsed);
       warnDegradedAgentTaskRecovery(parsed);
       warnDegradedRuntimeRole(parsed);
       warnDegradedOptionalRemoteBlocks(parsed);
@@ -2108,6 +2124,7 @@ export function loadConfig(): OcxConfig {
       warnDegradedNativeSubagentConfig(parsed, config);
       warnDegradedCodexAccountPicker(parsed);
       warnDegradedUpstreamHostCircuitThreshold(parsed);
+      warnDegradedPlaintextV2AgentMessages(parsed);
       warnDegradedAgentTaskRecovery(parsed);
       warnDegradedRuntimeRole(parsed);
       warnDegradedOptionalRemoteBlocks(parsed);
@@ -2130,6 +2147,7 @@ export function loadConfig(): OcxConfig {
         warnDegradedNativeSubagentConfig(parsed, config);
         warnDegradedCodexAccountPicker(parsed);
         warnDegradedUpstreamHostCircuitThreshold(parsed);
+        warnDegradedPlaintextV2AgentMessages(parsed);
         warnDegradedAgentTaskRecovery(parsed);
         warnDegradedRuntimeRole(parsed);
         warnDegradedOptionalRemoteBlocks(parsed);
@@ -2273,6 +2291,8 @@ function validFileConfigDiagnostics(config: OcxConfig, rawParsed: unknown): Conf
   if (remoteGuiWarning) warnings.push(remoteGuiWarning);
   const clientWarning = malformedClientConnectionWarning(rawParsed);
   if (clientWarning) warnings.push(clientWarning);
+  const plaintextMessagesWarning = malformedPlaintextV2AgentMessagesWarning(rawParsed);
+  if (plaintextMessagesWarning) warnings.push(plaintextMessagesWarning);
   if (syncDisabledReason) {
     warnings.push(`syncCodexSubagentDefaults ignored: ${syncDisabledReason}`);
   }
@@ -2409,6 +2429,14 @@ function clientRolePairError(value: unknown): string | null {
     return "schema_invalid: client connection requires runtimeRole client";
   }
   return null;
+}
+
+function plaintextV2AgentMessagesError(value: unknown): string | null {
+  const raw = rawConfigRecord(value);
+  if (!raw || !Object.hasOwn(raw, "plaintextV2AgentMessages")) return null;
+  const enabled = raw.plaintextV2AgentMessages;
+  if (enabled === undefined || typeof enabled === "boolean") return null;
+  return "schema_invalid: plaintextV2AgentMessages: must be a boolean or omitted";
 }
 
 /**
@@ -2568,6 +2596,7 @@ export function validateConfigCandidate(value: unknown): { ok: true; config: Ocx
     ?? claudeSubagentEffortError(value)
     ?? appOwnedMemoryBudgetError(value)
     ?? upstreamHostCircuitThresholdError(value)
+    ?? plaintextV2AgentMessagesError(value)
     ?? agentTaskRecoveryError(value)
     ?? googleAntigravityStaticCatalogVersionError(value)
     ?? codexAccountPrioritiesError(value)

--- a/src/responses/plaintext-v2-agent-messages.ts
+++ b/src/responses/plaintext-v2-agent-messages.ts
@@ -11,6 +11,16 @@ const PLAINTEXT_V2_AGENT_MESSAGE_TOOLS = new Set([
   "followup_task",
 ]);
 
+const PLAINTEXT_V2_AGENT_MESSAGE_TOOL_ALIASES = new Map<string, string>([
+  ["spawn_agent", "start_delegated_task"],
+  ["send_message", "deliver_delegated_message"],
+  ["followup_task", "continue_delegated_task"],
+]);
+
+const PLAINTEXT_V2_AGENT_MESSAGE_TOOL_NAMES = new Map<string, string>(
+  [...PLAINTEXT_V2_AGENT_MESSAGE_TOOL_ALIASES].map(([name, alias]) => [alias, name]),
+);
+
 export function shouldPreparePlaintextV2AgentMessages(args: {
   enabled: boolean;
   inboundWire: string;
@@ -185,27 +195,93 @@ function hasAgentMessageEncryptionMarker(tool: Record<string, unknown>): boolean
     && tool.parameters.properties.message.encrypted === true;
 }
 
-function withoutAgentMessageEncryptionMarker(tool: Record<string, unknown>): Record<string, unknown> {
-  if (
-    !hasAgentMessageEncryptionMarker(tool)
-    || !isPlainObject(tool.parameters)
-    || !isPlainObject(tool.parameters.properties)
-    || !isPlainObject(tool.parameters.properties.message)
-  ) {
-    return tool;
-  }
+function rewriteAgentMessageToolDeclaration(tool: Record<string, unknown>): Record<string, unknown> {
+  const alias = tool.type === "function" && typeof tool.name === "string"
+    ? PLAINTEXT_V2_AGENT_MESSAGE_TOOL_ALIASES.get(tool.name)
+    : undefined;
+  if (!alias) return tool;
 
-  const { encrypted: _encrypted, ...messageSchema } = tool.parameters.properties.message;
-  return {
-    ...tool,
-    parameters: {
-      ...tool.parameters,
-      properties: {
-        ...tool.parameters.properties,
-        message: messageSchema,
+  let rewritten: Record<string, unknown> = { ...tool, name: alias };
+  if (
+    hasAgentMessageEncryptionMarker(tool)
+    && isPlainObject(tool.parameters)
+    && isPlainObject(tool.parameters.properties)
+    && isPlainObject(tool.parameters.properties.message)
+  ) {
+    const { encrypted: _encrypted, ...messageSchema } = tool.parameters.properties.message;
+    rewritten = {
+      ...rewritten,
+      parameters: {
+        ...tool.parameters,
+        properties: {
+          ...tool.parameters.properties,
+          message: messageSchema,
+        },
       },
-    },
-  };
+    };
+  }
+  return rewritten;
+}
+
+function hasAgentMessageToolAliasCatalogConflict(catalogs: readonly unknown[][]): boolean {
+  for (const tools of catalogs) {
+    for (const tool of tools) {
+      if (
+        !isPlainObject(tool)
+        || tool.type !== "namespace"
+        || tool.name !== COLLABORATION_NAMESPACE
+        || !Array.isArray(tool.tools)
+      ) {
+        continue;
+      }
+      if (tool.tools.some(child => (
+        isPlainObject(child)
+        && typeof child.name === "string"
+        && PLAINTEXT_V2_AGENT_MESSAGE_TOOL_NAMES.has(child.name)
+      ))) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function hasAgentMessageToolAliasReference(value: unknown): boolean {
+  if (!isPlainObject(value) || !isToolIdentity(value) || typeof value.name !== "string") {
+    return false;
+  }
+  if (
+    value.namespace === COLLABORATION_NAMESPACE
+    && PLAINTEXT_V2_AGENT_MESSAGE_TOOL_NAMES.has(value.name)
+  ) {
+    return true;
+  }
+  for (const prefix of [COLLABORATION_NAME_PREFIX, COLLABORATION_DOTTED_NAME_PREFIX]) {
+    if (
+      value.name.startsWith(prefix)
+      && PLAINTEXT_V2_AGENT_MESSAGE_TOOL_NAMES.has(value.name.slice(prefix.length))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasAgentMessageToolAliasReferenceConflict(body: Record<string, unknown>): boolean {
+  if (hasAgentMessageToolAliasReference(body.tool_choice)) return true;
+  if (
+    isPlainObject(body.tool_choice)
+    && Array.isArray(body.tool_choice.tools)
+    && body.tool_choice.tools.some(hasAgentMessageToolAliasReference)
+  ) {
+    return true;
+  }
+  if (!Array.isArray(body.input)) return false;
+  return body.input.some(item => (
+    isPlainObject(item)
+    && (item.type === "function_call" || item.type === "custom_tool_call")
+    && hasAgentMessageToolAliasReference(item)
+  ));
 }
 
 function hasFlattenedCollaborationDeclarationConflict(
@@ -258,7 +334,7 @@ function rewriteToolCatalog(tools: unknown[]): {
       return tool;
     }
     const childTools = tool.tools.map(child => (
-      isPlainObject(child) ? withoutAgentMessageEncryptionMarker(child) : child
+      isPlainObject(child) ? rewriteAgentMessageToolDeclaration(child) : child
     ));
     namespaceAliased = true;
     changed = true;
@@ -280,7 +356,10 @@ function aliasCollaborationReference(
   const canCarryNamespace = isToolIdentity(value);
   let rewritten = value;
   if (canCarryNamespace && value.namespace === COLLABORATION_NAMESPACE) {
-    rewritten = { ...rewritten, namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE };
+    const name = (type === "function" || type === "function_call") && typeof value.name === "string"
+      ? PLAINTEXT_V2_AGENT_MESSAGE_TOOL_ALIASES.get(value.name) ?? value.name
+      : value.name;
+    rewritten = { ...rewritten, namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE, name };
   }
   if (type === "namespace" && value.name === COLLABORATION_NAMESPACE) {
     rewritten = { ...rewritten, name: PLAINTEXT_V2_COLLABORATION_NAMESPACE };
@@ -290,9 +369,14 @@ function aliasCollaborationReference(
     && value.name.startsWith(COLLABORATION_NAME_PREFIX)
     && collaborationToolNames.has(value.name.slice(COLLABORATION_NAME_PREFIX.length))
   ) {
+    const childName = value.name.slice(COLLABORATION_NAME_PREFIX.length);
     rewritten = {
       ...rewritten,
-      name: `${PLAINTEXT_V2_COLLABORATION_NAME_PREFIX}${value.name.slice(COLLABORATION_NAME_PREFIX.length)}`,
+      name: `${PLAINTEXT_V2_COLLABORATION_NAME_PREFIX}${
+        (type === "function" || type === "function_call")
+          ? PLAINTEXT_V2_AGENT_MESSAGE_TOOL_ALIASES.get(childName) ?? childName
+          : childName
+      }`,
     };
   } else if (
     canCarryNamespace
@@ -300,9 +384,14 @@ function aliasCollaborationReference(
     && value.name.startsWith(COLLABORATION_DOTTED_NAME_PREFIX)
     && collaborationToolNames.has(value.name.slice(COLLABORATION_DOTTED_NAME_PREFIX.length))
   ) {
+    const childName = value.name.slice(COLLABORATION_DOTTED_NAME_PREFIX.length);
     rewritten = {
       ...rewritten,
-      name: `${PLAINTEXT_V2_COLLABORATION_DOTTED_NAME_PREFIX}${value.name.slice(COLLABORATION_DOTTED_NAME_PREFIX.length)}`,
+      name: `${PLAINTEXT_V2_COLLABORATION_DOTTED_NAME_PREFIX}${
+        (type === "function" || type === "function_call")
+          ? PLAINTEXT_V2_AGENT_MESSAGE_TOOL_ALIASES.get(childName) ?? childName
+          : childName
+      }`,
     };
   }
   return rewritten;
@@ -331,8 +420,8 @@ function aliasCollaborationToolChoice(
 /**
  * Prepare v2 collaboration tools for plaintext messages on the canonical ChatGPT wire.
  *
- * `collaboration` is a backend-reserved namespace, so changing its schema alone is rejected.
- * The namespace is therefore request-scoped and restored on every client-facing response.
+ * ChatGPT reserves both `collaboration` and the three message-tool names. The request therefore
+ * uses fixed, request-scoped aliases for both, then restores every identity before Codex sees it.
  */
 export function preparePlaintextV2AgentMessages(body: unknown): {
   body: unknown;
@@ -348,6 +437,8 @@ export function preparePlaintextV2AgentMessages(body: unknown): {
     || hasOptimizedReferenceConflict(body)
     || hasToolSearchCollaborationConflict(body)
     || hasFlattenedCollaborationDeclarationConflict(catalogs, catalogInfo.toolNames)
+    || hasAgentMessageToolAliasCatalogConflict(catalogs)
+    || hasAgentMessageToolAliasReferenceConflict(body)
   ) {
     return { body, namespaceAliased: false, toolNames: new Set() };
   }
@@ -432,16 +523,27 @@ function reserveIdentities(context: RestoreContext, count: number): boolean {
   return true;
 }
 
-function declaredChildName(name: unknown, toolNames: ReadonlySet<string>): string | undefined {
+function declaredChildName(
+  name: unknown,
+  toolNames: ReadonlySet<string>,
+  allowAgentMessageAlias: boolean,
+): string | undefined {
   if (typeof name !== "string") return undefined;
   if (toolNames.has(name)) return name;
-  if (name.startsWith(PLAINTEXT_V2_COLLABORATION_NAME_PREFIX)) {
-    const childName = name.slice(PLAINTEXT_V2_COLLABORATION_NAME_PREFIX.length);
-    return toolNames.has(childName) ? childName : undefined;
+  if (allowAgentMessageAlias) {
+    const restoredName = PLAINTEXT_V2_AGENT_MESSAGE_TOOL_NAMES.get(name);
+    if (restoredName && toolNames.has(restoredName)) return restoredName;
   }
-  if (name.startsWith(PLAINTEXT_V2_COLLABORATION_DOTTED_NAME_PREFIX)) {
-    const childName = name.slice(PLAINTEXT_V2_COLLABORATION_DOTTED_NAME_PREFIX.length);
-    return toolNames.has(childName) ? childName : undefined;
+  for (const prefix of [
+    PLAINTEXT_V2_COLLABORATION_NAME_PREFIX,
+    PLAINTEXT_V2_COLLABORATION_DOTTED_NAME_PREFIX,
+  ]) {
+    if (!name.startsWith(prefix)) continue;
+    const childName = name.slice(prefix.length);
+    const restoredChildName = allowAgentMessageAlias
+      ? PLAINTEXT_V2_AGENT_MESSAGE_TOOL_NAMES.get(childName) ?? childName
+      : childName;
+    return toolNames.has(restoredChildName) ? restoredChildName : undefined;
   }
   return undefined;
 }
@@ -459,7 +561,17 @@ function restoreToolIdentity(
     && value.type === "namespace"
     && value.name === PLAINTEXT_V2_COLLABORATION_NAMESPACE
   ) {
-    return { value: { ...value, name: COLLABORATION_NAMESPACE }, changed: true, overflow: false };
+    const children = restoreIdentityList(value.tools, context, false);
+    if (children.overflow) return { ...unchanged(value), overflow: true };
+    return {
+      value: {
+        ...value,
+        name: COLLABORATION_NAMESPACE,
+        ...(children.changed ? { tools: children.value } : {}),
+      },
+      changed: true,
+      overflow: false,
+    };
   }
 
   const identityType = value.type;
@@ -473,7 +585,10 @@ function restoreToolIdentity(
     return unchanged(value);
   }
 
-  const childName = declaredChildName(value.name, context.toolNames);
+  const allowAgentMessageAlias = identityType === "function"
+    || identityType === "function_call"
+    || identityType === "response.function_call_arguments.done";
+  const childName = declaredChildName(value.name, context.toolNames, allowAgentMessageAlias);
   if (!childName) return unchanged(value);
 
   let restored = value;
@@ -482,7 +597,10 @@ function restoreToolIdentity(
     restored = { ...restored, namespace: COLLABORATION_NAMESPACE };
     changed = true;
   }
-  if (typeof value.name === "string" && value.name.startsWith(PLAINTEXT_V2_COLLABORATION_NAME_PREFIX)) {
+  if (allowAgentMessageAlias && PLAINTEXT_V2_AGENT_MESSAGE_TOOL_NAMES.has(value.name as string)) {
+    restored = { ...restored, name: childName };
+    changed = true;
+  } else if (typeof value.name === "string" && value.name.startsWith(PLAINTEXT_V2_COLLABORATION_NAME_PREFIX)) {
     restored = { ...restored, name: `${COLLABORATION_NAME_PREFIX}${childName}` };
     changed = true;
   } else if (
@@ -593,7 +711,12 @@ export function restorePlaintextV2AgentMessageCallsInJson(
   payload: string,
   toolNames: ReadonlySet<string>,
 ): string {
-  if (!payload.includes(PLAINTEXT_V2_COLLABORATION_NAMESPACE)) return payload;
+  if (
+    !payload.includes(PLAINTEXT_V2_COLLABORATION_NAMESPACE)
+    && ![...PLAINTEXT_V2_AGENT_MESSAGE_TOOL_NAMES.keys()].some(alias => payload.includes(alias))
+  ) {
+    return payload;
+  }
 
   let value: unknown;
   try {

--- a/src/responses/plaintext-v2-agent-messages.ts
+++ b/src/responses/plaintext-v2-agent-messages.ts
@@ -1,0 +1,612 @@
+const COLLABORATION_NAMESPACE = "collaboration";
+export const PLAINTEXT_V2_COLLABORATION_NAMESPACE = "collaboration-optimize";
+const COLLABORATION_NAME_PREFIX = `${COLLABORATION_NAMESPACE}__`;
+const COLLABORATION_DOTTED_NAME_PREFIX = `${COLLABORATION_NAMESPACE}.`;
+const PLAINTEXT_V2_COLLABORATION_NAME_PREFIX = `${PLAINTEXT_V2_COLLABORATION_NAMESPACE}__`;
+const PLAINTEXT_V2_COLLABORATION_DOTTED_NAME_PREFIX = `${PLAINTEXT_V2_COLLABORATION_NAMESPACE}.`;
+
+const PLAINTEXT_V2_AGENT_MESSAGE_TOOLS = new Set([
+  "spawn_agent",
+  "send_message",
+  "followup_task",
+]);
+
+export function shouldPreparePlaintextV2AgentMessages(args: {
+  enabled: boolean;
+  inboundWire: string;
+  canonicalChatGpt: boolean;
+  requestBody: unknown;
+}): boolean {
+  return args.enabled
+    && args.inboundWire === "responses"
+    && args.canonicalChatGpt
+    && hasPlaintextV2CollaborationCatalog(args.requestBody);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function responseToolCatalogs(body: Record<string, unknown>): unknown[][] {
+  const catalogs: unknown[][] = [];
+  if (Array.isArray(body.tools)) catalogs.push(body.tools);
+  if (!Array.isArray(body.input)) return catalogs;
+  for (const item of body.input) {
+    if (
+      isPlainObject(item)
+      && item.type === "additional_tools"
+      && Array.isArray(item.tools)
+    ) {
+      catalogs.push(item.tools);
+    }
+  }
+  return catalogs;
+}
+
+function collaborationCatalogInfo(catalogs: readonly unknown[][]): {
+  hasV2Catalog: boolean;
+  toolNames: Set<string>;
+} {
+  let hasV2Catalog = false;
+  const toolNames = new Set<string>();
+  for (const tools of catalogs) {
+    for (const tool of tools) {
+      if (
+        !isPlainObject(tool)
+        || tool.type !== "namespace"
+        || tool.name !== COLLABORATION_NAMESPACE
+        || !Array.isArray(tool.tools)
+      ) {
+        continue;
+      }
+      for (const child of tool.tools) {
+        if (
+          isPlainObject(child)
+          && (child.type === "function" || child.type === "custom")
+          && typeof child.name === "string"
+        ) {
+          toolNames.add(child.name);
+          if (child.type === "function" && child.name === "spawn_agent") hasV2Catalog = true;
+        }
+      }
+    }
+  }
+  return { hasV2Catalog, toolNames };
+}
+
+export function hasPlaintextV2CollaborationCatalog(body: unknown): boolean {
+  if (!isPlainObject(body)) return false;
+  return collaborationCatalogInfo(responseToolCatalogs(body)).hasV2Catalog;
+}
+
+function hasOptimizedNamespaceConflict(catalogs: readonly unknown[][]): boolean {
+  const pending = [...catalogs];
+  while (pending.length > 0) {
+    const tools = pending.pop()!;
+    for (const tool of tools) {
+      if (!isPlainObject(tool)) continue;
+      if (
+        typeof tool.name === "string"
+        && (
+          tool.name === PLAINTEXT_V2_COLLABORATION_NAMESPACE
+          || tool.name.startsWith(PLAINTEXT_V2_COLLABORATION_NAME_PREFIX)
+          || tool.name.startsWith(PLAINTEXT_V2_COLLABORATION_DOTTED_NAME_PREFIX)
+        )
+      ) {
+        return true;
+      }
+      if (tool.type === "namespace" && Array.isArray(tool.tools)) pending.push(tool.tools);
+    }
+  }
+  return false;
+}
+
+function isToolIdentity(value: Record<string, unknown>): boolean {
+  return value.type === "function"
+    || value.type === "custom"
+    || value.type === "function_call"
+    || value.type === "custom_tool_call";
+}
+
+function isOptimizedToolIdentity(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  if (
+    isToolIdentity(value)
+    && (
+      value.namespace === PLAINTEXT_V2_COLLABORATION_NAMESPACE
+      || (
+        typeof value.name === "string"
+        && (
+          value.name === PLAINTEXT_V2_COLLABORATION_NAMESPACE
+          || value.name.startsWith(PLAINTEXT_V2_COLLABORATION_NAME_PREFIX)
+          || value.name.startsWith(PLAINTEXT_V2_COLLABORATION_DOTTED_NAME_PREFIX)
+        )
+      )
+    )
+  ) {
+    return true;
+  }
+  return value.type === "namespace" && value.name === PLAINTEXT_V2_COLLABORATION_NAMESPACE;
+}
+
+function hasOptimizedReferenceConflict(body: Record<string, unknown>): boolean {
+  if (isOptimizedToolIdentity(body.tool_choice)) return true;
+  if (
+    isPlainObject(body.tool_choice)
+    && Array.isArray(body.tool_choice.tools)
+    && body.tool_choice.tools.some(isOptimizedToolIdentity)
+  ) {
+    return true;
+  }
+  if (!Array.isArray(body.input)) return false;
+  return body.input.some(item => (
+    isPlainObject(item)
+    && (item.type === "function_call" || item.type === "custom_tool_call")
+    && isOptimizedToolIdentity(item)
+  ));
+}
+
+function hasToolSearchCollaborationConflict(body: Record<string, unknown>): boolean {
+  if (!Array.isArray(body.input)) return false;
+  for (const item of body.input) {
+    if (!isPlainObject(item) || item.type !== "tool_search_output" || !Array.isArray(item.tools)) {
+      continue;
+    }
+    const pending = [item.tools];
+    while (pending.length > 0) {
+      const tools = pending.pop()!;
+      for (const tool of tools) {
+        if (!isPlainObject(tool)) continue;
+        if (
+          typeof tool.name === "string"
+          && (tool.name === COLLABORATION_NAMESPACE
+            || tool.name === PLAINTEXT_V2_COLLABORATION_NAMESPACE
+            || tool.name.startsWith(COLLABORATION_NAME_PREFIX)
+              || tool.name.startsWith(COLLABORATION_DOTTED_NAME_PREFIX)
+              || tool.name.startsWith(PLAINTEXT_V2_COLLABORATION_NAME_PREFIX)
+            || tool.name.startsWith(PLAINTEXT_V2_COLLABORATION_DOTTED_NAME_PREFIX))
+        ) {
+          return true;
+        }
+        if (tool.type === "namespace" && Array.isArray(tool.tools)) pending.push(tool.tools);
+      }
+    }
+  }
+  return false;
+}
+
+function hasAgentMessageEncryptionMarker(tool: Record<string, unknown>): boolean {
+  return tool.type === "function"
+    && typeof tool.name === "string"
+    && PLAINTEXT_V2_AGENT_MESSAGE_TOOLS.has(tool.name)
+    && isPlainObject(tool.parameters)
+    && isPlainObject(tool.parameters.properties)
+    && isPlainObject(tool.parameters.properties.message)
+    && tool.parameters.properties.message.encrypted === true;
+}
+
+function withoutAgentMessageEncryptionMarker(tool: Record<string, unknown>): Record<string, unknown> {
+  if (
+    !hasAgentMessageEncryptionMarker(tool)
+    || !isPlainObject(tool.parameters)
+    || !isPlainObject(tool.parameters.properties)
+    || !isPlainObject(tool.parameters.properties.message)
+  ) {
+    return tool;
+  }
+
+  const { encrypted: _encrypted, ...messageSchema } = tool.parameters.properties.message;
+  return {
+    ...tool,
+    parameters: {
+      ...tool.parameters,
+      properties: {
+        ...tool.parameters.properties,
+        message: messageSchema,
+      },
+    },
+  };
+}
+
+function hasFlattenedCollaborationDeclarationConflict(
+  catalogs: readonly unknown[][],
+  collaborationToolNames: ReadonlySet<string>,
+): boolean {
+  const qualifiedNames = new Set(
+    [...collaborationToolNames].flatMap(name => [
+      `${COLLABORATION_NAME_PREFIX}${name}`,
+      `${COLLABORATION_DOTTED_NAME_PREFIX}${name}`,
+    ]),
+  );
+  const pending = catalogs.map(tools => ({ tools, collaborationNamespace: false }));
+  while (pending.length > 0) {
+    const { tools, collaborationNamespace } = pending.pop()!;
+    for (const tool of tools) {
+      if (!isPlainObject(tool)) continue;
+      if (
+        !collaborationNamespace
+        && (tool.type === "function" || tool.type === "custom")
+        && typeof tool.name === "string"
+        && qualifiedNames.has(tool.name)
+      ) {
+        return true;
+      }
+      if (tool.type === "namespace" && Array.isArray(tool.tools)) {
+        pending.push({
+          tools: tool.tools,
+          collaborationNamespace: tool.name === COLLABORATION_NAMESPACE,
+        });
+      }
+    }
+  }
+  return false;
+}
+
+function rewriteToolCatalog(tools: unknown[]): {
+  tools: unknown[];
+  namespaceAliased: boolean;
+} {
+  let namespaceAliased = false;
+  let changed = false;
+  const rewritten = tools.map(tool => {
+    if (
+      !isPlainObject(tool)
+      || tool.type !== "namespace"
+      || tool.name !== COLLABORATION_NAMESPACE
+      || !Array.isArray(tool.tools)
+    ) {
+      return tool;
+    }
+    const childTools = tool.tools.map(child => (
+      isPlainObject(child) ? withoutAgentMessageEncryptionMarker(child) : child
+    ));
+    namespaceAliased = true;
+    changed = true;
+    return {
+      ...tool,
+      name: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+      tools: childTools,
+    };
+  });
+  return { tools: changed ? rewritten : tools, namespaceAliased };
+}
+
+function aliasCollaborationReference(
+  value: unknown,
+  collaborationToolNames: ReadonlySet<string>,
+): unknown {
+  if (!isPlainObject(value)) return value;
+  const type = value.type;
+  const canCarryNamespace = isToolIdentity(value);
+  let rewritten = value;
+  if (canCarryNamespace && value.namespace === COLLABORATION_NAMESPACE) {
+    rewritten = { ...rewritten, namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE };
+  }
+  if (type === "namespace" && value.name === COLLABORATION_NAMESPACE) {
+    rewritten = { ...rewritten, name: PLAINTEXT_V2_COLLABORATION_NAMESPACE };
+  } else if (
+    canCarryNamespace
+    && typeof value.name === "string"
+    && value.name.startsWith(COLLABORATION_NAME_PREFIX)
+    && collaborationToolNames.has(value.name.slice(COLLABORATION_NAME_PREFIX.length))
+  ) {
+    rewritten = {
+      ...rewritten,
+      name: `${PLAINTEXT_V2_COLLABORATION_NAME_PREFIX}${value.name.slice(COLLABORATION_NAME_PREFIX.length)}`,
+    };
+  } else if (
+    canCarryNamespace
+    && typeof value.name === "string"
+    && value.name.startsWith(COLLABORATION_DOTTED_NAME_PREFIX)
+    && collaborationToolNames.has(value.name.slice(COLLABORATION_DOTTED_NAME_PREFIX.length))
+  ) {
+    rewritten = {
+      ...rewritten,
+      name: `${PLAINTEXT_V2_COLLABORATION_DOTTED_NAME_PREFIX}${value.name.slice(COLLABORATION_DOTTED_NAME_PREFIX.length)}`,
+    };
+  }
+  return rewritten;
+}
+
+function aliasCollaborationToolChoice(
+  toolChoice: unknown,
+  collaborationToolNames: ReadonlySet<string>,
+): unknown {
+  if (!isPlainObject(toolChoice)) return toolChoice;
+  let rewritten = aliasCollaborationReference(
+    toolChoice,
+    collaborationToolNames,
+  ) as Record<string, unknown>;
+  if (!Array.isArray(toolChoice.tools)) return rewritten;
+  let toolsChanged = false;
+  const tools = toolChoice.tools.map(tool => {
+    const aliased = aliasCollaborationReference(tool, collaborationToolNames);
+    toolsChanged ||= aliased !== tool;
+    return aliased;
+  });
+  if (toolsChanged) rewritten = { ...rewritten, tools };
+  return rewritten;
+}
+
+/**
+ * Prepare v2 collaboration tools for plaintext messages on the canonical ChatGPT wire.
+ *
+ * `collaboration` is a backend-reserved namespace, so changing its schema alone is rejected.
+ * The namespace is therefore request-scoped and restored on every client-facing response.
+ */
+export function preparePlaintextV2AgentMessages(body: unknown): {
+  body: unknown;
+  namespaceAliased: boolean;
+  toolNames: ReadonlySet<string>;
+} {
+  if (!isPlainObject(body)) return { body, namespaceAliased: false, toolNames: new Set() };
+  const catalogs = responseToolCatalogs(body);
+  const catalogInfo = collaborationCatalogInfo(catalogs);
+  if (
+    !catalogInfo.hasV2Catalog
+    || hasOptimizedNamespaceConflict(catalogs)
+    || hasOptimizedReferenceConflict(body)
+    || hasToolSearchCollaborationConflict(body)
+    || hasFlattenedCollaborationDeclarationConflict(catalogs, catalogInfo.toolNames)
+  ) {
+    return { body, namespaceAliased: false, toolNames: new Set() };
+  }
+
+  let namespaceAliased = false;
+  let tools = body.tools;
+  if (Array.isArray(body.tools)) {
+    const rewritten = rewriteToolCatalog(body.tools);
+    tools = rewritten.tools;
+    namespaceAliased ||= rewritten.namespaceAliased;
+  }
+
+  let input = body.input;
+  if (Array.isArray(body.input)) {
+    let inputChanged = false;
+    const rewrittenInput = body.input.map(item => {
+      if (
+        !isPlainObject(item)
+        || item.type !== "additional_tools"
+        || !Array.isArray(item.tools)
+      ) {
+        return item;
+      }
+      const rewritten = rewriteToolCatalog(item.tools);
+      namespaceAliased ||= rewritten.namespaceAliased;
+      if (rewritten.tools === item.tools) return item;
+      inputChanged = true;
+      return { ...item, tools: rewritten.tools };
+    });
+    if (inputChanged) input = rewrittenInput;
+  }
+
+  let toolChoice = body.tool_choice;
+  if (namespaceAliased) {
+    toolChoice = aliasCollaborationToolChoice(body.tool_choice, catalogInfo.toolNames);
+    if (Array.isArray(input)) {
+      let inputChanged = false;
+      const aliasedInput = input.map(item => {
+        if (!isPlainObject(item)) return item;
+        if (item.type !== "function_call" && item.type !== "custom_tool_call") return item;
+        const aliased = aliasCollaborationReference(item, catalogInfo.toolNames);
+        inputChanged ||= aliased !== item;
+        return aliased;
+      });
+      if (inputChanged) input = aliasedInput;
+    }
+  }
+
+  if (!namespaceAliased || (tools === body.tools && input === body.input && toolChoice === body.tool_choice)) {
+    return { body, namespaceAliased: false, toolNames: new Set() };
+  }
+  return {
+    body: {
+      ...body,
+      ...(tools !== body.tools ? { tools } : {}),
+      ...(input !== body.input ? { input } : {}),
+      ...(toolChoice !== body.tool_choice ? { tool_choice: toolChoice } : {}),
+    },
+    namespaceAliased,
+    toolNames: new Set(catalogInfo.toolNames),
+  };
+}
+
+const MAX_RESTORED_TOOL_IDENTITIES = 10_000;
+
+type RestoreOutcome = {
+  value: unknown;
+  changed: boolean;
+  overflow: boolean;
+};
+
+type RestoreContext = {
+  toolNames: ReadonlySet<string>;
+  remainingIdentities: number;
+};
+
+const unchanged = (value: unknown): RestoreOutcome => ({ value, changed: false, overflow: false });
+
+function reserveIdentities(context: RestoreContext, count: number): boolean {
+  if (count > context.remainingIdentities) return false;
+  context.remainingIdentities -= count;
+  return true;
+}
+
+function declaredChildName(name: unknown, toolNames: ReadonlySet<string>): string | undefined {
+  if (typeof name !== "string") return undefined;
+  if (toolNames.has(name)) return name;
+  if (name.startsWith(PLAINTEXT_V2_COLLABORATION_NAME_PREFIX)) {
+    const childName = name.slice(PLAINTEXT_V2_COLLABORATION_NAME_PREFIX.length);
+    return toolNames.has(childName) ? childName : undefined;
+  }
+  if (name.startsWith(PLAINTEXT_V2_COLLABORATION_DOTTED_NAME_PREFIX)) {
+    const childName = name.slice(PLAINTEXT_V2_COLLABORATION_DOTTED_NAME_PREFIX.length);
+    return toolNames.has(childName) ? childName : undefined;
+  }
+  return undefined;
+}
+
+function restoreToolIdentity(
+  value: unknown,
+  context: RestoreContext,
+  allowNamespaceDeclaration = false,
+): RestoreOutcome {
+  if (!isPlainObject(value)) return unchanged(value);
+  if (!reserveIdentities(context, 1)) return { ...unchanged(value), overflow: true };
+
+  if (
+    allowNamespaceDeclaration
+    && value.type === "namespace"
+    && value.name === PLAINTEXT_V2_COLLABORATION_NAMESPACE
+  ) {
+    return { value: { ...value, name: COLLABORATION_NAMESPACE }, changed: true, overflow: false };
+  }
+
+  const identityType = value.type;
+  if (
+    identityType !== "function"
+    && identityType !== "custom"
+    && identityType !== "function_call"
+    && identityType !== "custom_tool_call"
+    && identityType !== "response.function_call_arguments.done"
+  ) {
+    return unchanged(value);
+  }
+
+  const childName = declaredChildName(value.name, context.toolNames);
+  if (!childName) return unchanged(value);
+
+  let restored = value;
+  let changed = false;
+  if (value.namespace === PLAINTEXT_V2_COLLABORATION_NAMESPACE) {
+    restored = { ...restored, namespace: COLLABORATION_NAMESPACE };
+    changed = true;
+  }
+  if (typeof value.name === "string" && value.name.startsWith(PLAINTEXT_V2_COLLABORATION_NAME_PREFIX)) {
+    restored = { ...restored, name: `${COLLABORATION_NAME_PREFIX}${childName}` };
+    changed = true;
+  } else if (
+    typeof value.name === "string"
+    && value.name.startsWith(PLAINTEXT_V2_COLLABORATION_DOTTED_NAME_PREFIX)
+  ) {
+    restored = { ...restored, name: `${COLLABORATION_DOTTED_NAME_PREFIX}${childName}` };
+    changed = true;
+  }
+  return { value: restored, changed, overflow: false };
+}
+
+function restoreIdentityList(
+  values: unknown,
+  context: RestoreContext,
+  allowNamespaceDeclaration: boolean,
+): RestoreOutcome {
+  if (!Array.isArray(values)) return unchanged(values);
+  if (values.length > context.remainingIdentities) {
+    return { ...unchanged(values), overflow: true };
+  }
+  let restored: unknown[] | undefined;
+  for (let index = 0; index < values.length; index += 1) {
+    const result = restoreToolIdentity(values[index], context, allowNamespaceDeclaration);
+    if (result.overflow) return { ...unchanged(values), overflow: true };
+    if (!result.changed) continue;
+    restored ??= values.slice();
+    restored[index] = result.value;
+  }
+  return restored
+    ? { value: restored, changed: true, overflow: false }
+    : unchanged(values);
+}
+
+function restoreToolChoice(value: unknown, context: RestoreContext): RestoreOutcome {
+  const direct = restoreToolIdentity(value, context);
+  if (direct.overflow || !isPlainObject(value) || !Array.isArray(value.tools)) return direct;
+  const tools = restoreIdentityList(value.tools, context, false);
+  if (tools.overflow) return { ...unchanged(value), overflow: true };
+  if (!tools.changed) return direct;
+  const base = direct.value as Record<string, unknown>;
+  return { value: { ...base, tools: tools.value }, changed: true, overflow: false };
+}
+
+function restoreResponseSnapshot(value: unknown, context: RestoreContext): RestoreOutcome {
+  if (!isPlainObject(value)) return unchanged(value);
+  const output = restoreIdentityList(value.output, context, false);
+  if (output.overflow) return { ...unchanged(value), overflow: true };
+  const tools = restoreIdentityList(value.tools, context, true);
+  if (tools.overflow) return { ...unchanged(value), overflow: true };
+  const toolChoice = restoreToolChoice(value.tool_choice, context);
+  if (toolChoice.overflow) return { ...unchanged(value), overflow: true };
+  if (!output.changed && !tools.changed && !toolChoice.changed) return unchanged(value);
+  return {
+    value: {
+      ...value,
+      ...(output.changed ? { output: output.value } : {}),
+      ...(tools.changed ? { tools: tools.value } : {}),
+      ...(toolChoice.changed ? { tool_choice: toolChoice.value } : {}),
+    },
+    changed: true,
+    overflow: false,
+  };
+}
+
+/**
+ * Restore request-scoped collaboration aliases only at documented Responses identity positions.
+ * Tool arguments, tool results, and extension metadata are deliberately opaque.
+ */
+export function restorePlaintextV2AgentMessageCalls(
+  value: unknown,
+  toolNames: ReadonlySet<string>,
+): { value: unknown; changed: boolean; overflowed: boolean } {
+  if (toolNames.size === 0 || !isPlainObject(value)) {
+    return { value, changed: false, overflowed: false };
+  }
+  const context: RestoreContext = {
+    toolNames,
+    remainingIdentities: MAX_RESTORED_TOOL_IDENTITIES,
+  };
+
+  const rootIdentity = restoreToolIdentity(value, context);
+  if (rootIdentity.overflow) return { value, changed: false, overflowed: true };
+  const root = rootIdentity.value as Record<string, unknown>;
+  const item = restoreToolIdentity(root.item, context);
+  if (item.overflow) return { value, changed: false, overflowed: true };
+  const response = restoreResponseSnapshot(root.response, context);
+  if (response.overflow) return { value, changed: false, overflowed: true };
+  const snapshot = restoreResponseSnapshot(root, context);
+  if (snapshot.overflow) return { value, changed: false, overflowed: true };
+
+  let restored = snapshot.value as Record<string, unknown>;
+  let changed = rootIdentity.changed || snapshot.changed;
+  if (item.changed) {
+    restored = { ...restored, item: item.value };
+    changed = true;
+  }
+  if (response.changed) {
+    restored = { ...restored, response: response.value };
+    changed = true;
+  }
+  return changed
+    ? { value: restored, changed: true, overflowed: false }
+    : { value, changed: false, overflowed: false };
+}
+
+export function restorePlaintextV2AgentMessageCallsInJson(
+  payload: string,
+  toolNames: ReadonlySet<string>,
+): string {
+  if (!payload.includes(PLAINTEXT_V2_COLLABORATION_NAMESPACE)) return payload;
+
+  let value: unknown;
+  try {
+    value = JSON.parse(payload);
+  } catch {
+    return payload;
+  }
+  const restored = restorePlaintextV2AgentMessageCalls(value, toolNames);
+  return restored.changed ? JSON.stringify(restored.value) : payload;
+}
+
+export function createPlaintextV2AgentMessageCallRestoreRewrite(
+  toolNames: ReadonlySet<string>,
+): (payload: string) => string {
+  return payload => restorePlaintextV2AgentMessageCallsInJson(payload, toolNames);
+}

--- a/src/responses/plaintext-v2-agent-messages.ts
+++ b/src/responses/plaintext-v2-agent-messages.ts
@@ -56,9 +56,11 @@ function responseToolCatalogs(body: Record<string, unknown>): unknown[][] {
 function collaborationCatalogInfo(catalogs: readonly unknown[][]): {
   hasV2Catalog: boolean;
   toolNames: Set<string>;
+  aliasedAgentMessageToolNames: Set<string>;
 } {
   let hasV2Catalog = false;
   const toolNames = new Set<string>();
+  const aliasedAgentMessageToolNames = new Set<string>();
   for (const tools of catalogs) {
     for (const tool of tools) {
       if (
@@ -76,12 +78,18 @@ function collaborationCatalogInfo(catalogs: readonly unknown[][]): {
           && typeof child.name === "string"
         ) {
           toolNames.add(child.name);
+          if (
+            child.type === "function"
+            && PLAINTEXT_V2_AGENT_MESSAGE_TOOL_ALIASES.has(child.name)
+          ) {
+            aliasedAgentMessageToolNames.add(child.name);
+          }
           if (child.type === "function" && child.name === "spawn_agent") hasV2Catalog = true;
         }
       }
     }
   }
-  return { hasV2Catalog, toolNames };
+  return { hasV2Catalog, toolNames, aliasedAgentMessageToolNames };
 }
 
 export function hasPlaintextV2CollaborationCatalog(body: unknown): boolean {
@@ -223,24 +231,33 @@ function rewriteAgentMessageToolDeclaration(tool: Record<string, unknown>): Reco
   return rewritten;
 }
 
-function hasAgentMessageToolAliasCatalogConflict(catalogs: readonly unknown[][]): boolean {
-  for (const tools of catalogs) {
-    for (const tool of tools) {
+function hasAgentMessageToolAliasCatalogConflict(
+  body: Record<string, unknown>,
+  catalogs: readonly unknown[][],
+): boolean {
+  const pending = [...catalogs];
+  if (Array.isArray(body.input)) {
+    for (const item of body.input) {
       if (
-        !isPlainObject(tool)
-        || tool.type !== "namespace"
-        || tool.name !== COLLABORATION_NAMESPACE
-        || !Array.isArray(tool.tools)
+        isPlainObject(item)
+        && item.type === "tool_search_output"
+        && Array.isArray(item.tools)
       ) {
-        continue;
+        pending.push(item.tools);
       }
-      if (tool.tools.some(child => (
-        isPlainObject(child)
-        && typeof child.name === "string"
-        && PLAINTEXT_V2_AGENT_MESSAGE_TOOL_NAMES.has(child.name)
-      ))) {
+    }
+  }
+  while (pending.length > 0) {
+    const tools = pending.pop()!;
+    for (const tool of tools) {
+      if (!isPlainObject(tool)) continue;
+      if (
+        typeof tool.name === "string"
+        && PLAINTEXT_V2_AGENT_MESSAGE_TOOL_NAMES.has(tool.name)
+      ) {
         return true;
       }
+      if (tool.type === "namespace" && Array.isArray(tool.tools)) pending.push(tool.tools);
     }
   }
   return false;
@@ -250,12 +267,7 @@ function hasAgentMessageToolAliasReference(value: unknown): boolean {
   if (!isPlainObject(value) || !isToolIdentity(value) || typeof value.name !== "string") {
     return false;
   }
-  if (
-    value.namespace === COLLABORATION_NAMESPACE
-    && PLAINTEXT_V2_AGENT_MESSAGE_TOOL_NAMES.has(value.name)
-  ) {
-    return true;
-  }
+  if (PLAINTEXT_V2_AGENT_MESSAGE_TOOL_NAMES.has(value.name)) return true;
   for (const prefix of [COLLABORATION_NAME_PREFIX, COLLABORATION_DOTTED_NAME_PREFIX]) {
     if (
       value.name.startsWith(prefix)
@@ -427,8 +439,16 @@ export function preparePlaintextV2AgentMessages(body: unknown): {
   body: unknown;
   namespaceAliased: boolean;
   toolNames: ReadonlySet<string>;
+  aliasedAgentMessageToolNames: ReadonlySet<string>;
 } {
-  if (!isPlainObject(body)) return { body, namespaceAliased: false, toolNames: new Set() };
+  if (!isPlainObject(body)) {
+    return {
+      body,
+      namespaceAliased: false,
+      toolNames: new Set(),
+      aliasedAgentMessageToolNames: new Set(),
+    };
+  }
   const catalogs = responseToolCatalogs(body);
   const catalogInfo = collaborationCatalogInfo(catalogs);
   if (
@@ -437,10 +457,15 @@ export function preparePlaintextV2AgentMessages(body: unknown): {
     || hasOptimizedReferenceConflict(body)
     || hasToolSearchCollaborationConflict(body)
     || hasFlattenedCollaborationDeclarationConflict(catalogs, catalogInfo.toolNames)
-    || hasAgentMessageToolAliasCatalogConflict(catalogs)
+    || hasAgentMessageToolAliasCatalogConflict(body, catalogs)
     || hasAgentMessageToolAliasReferenceConflict(body)
   ) {
-    return { body, namespaceAliased: false, toolNames: new Set() };
+    return {
+      body,
+      namespaceAliased: false,
+      toolNames: new Set(),
+      aliasedAgentMessageToolNames: new Set(),
+    };
   }
 
   let namespaceAliased = false;
@@ -488,7 +513,12 @@ export function preparePlaintextV2AgentMessages(body: unknown): {
   }
 
   if (!namespaceAliased || (tools === body.tools && input === body.input && toolChoice === body.tool_choice)) {
-    return { body, namespaceAliased: false, toolNames: new Set() };
+    return {
+      body,
+      namespaceAliased: false,
+      toolNames: new Set(),
+      aliasedAgentMessageToolNames: new Set(),
+    };
   }
   return {
     body: {
@@ -499,10 +529,20 @@ export function preparePlaintextV2AgentMessages(body: unknown): {
     },
     namespaceAliased,
     toolNames: new Set(catalogInfo.toolNames),
+    aliasedAgentMessageToolNames: new Set(catalogInfo.aliasedAgentMessageToolNames),
   };
 }
 
 const MAX_RESTORED_TOOL_IDENTITIES = 10_000;
+export const PLAINTEXT_V2_AGENT_MESSAGE_RESTORE_OVERFLOW_MESSAGE =
+  "plaintext V2 agent-message response exceeded the safe identity limit";
+
+export class PlaintextV2AgentMessageRestoreOverflowError extends Error {
+  constructor() {
+    super(PLAINTEXT_V2_AGENT_MESSAGE_RESTORE_OVERFLOW_MESSAGE);
+    this.name = "PlaintextV2AgentMessageRestoreOverflowError";
+  }
+}
 
 type RestoreOutcome = {
   value: unknown;
@@ -512,6 +552,7 @@ type RestoreOutcome = {
 
 type RestoreContext = {
   toolNames: ReadonlySet<string>;
+  aliasedAgentMessageToolNames: ReadonlySet<string>;
   remainingIdentities: number;
 };
 
@@ -526,23 +567,30 @@ function reserveIdentities(context: RestoreContext, count: number): boolean {
 function declaredChildName(
   name: unknown,
   toolNames: ReadonlySet<string>,
+  aliasedAgentMessageToolNames: ReadonlySet<string>,
   allowAgentMessageAlias: boolean,
 ): string | undefined {
   if (typeof name !== "string") return undefined;
-  if (toolNames.has(name)) return name;
   if (allowAgentMessageAlias) {
     const restoredName = PLAINTEXT_V2_AGENT_MESSAGE_TOOL_NAMES.get(name);
-    if (restoredName && toolNames.has(restoredName)) return restoredName;
+    if (restoredName) {
+      return aliasedAgentMessageToolNames.has(restoredName) && toolNames.has(restoredName)
+        ? restoredName
+        : undefined;
+    }
   }
+  if (toolNames.has(name)) return name;
   for (const prefix of [
     PLAINTEXT_V2_COLLABORATION_NAME_PREFIX,
     PLAINTEXT_V2_COLLABORATION_DOTTED_NAME_PREFIX,
   ]) {
     if (!name.startsWith(prefix)) continue;
     const childName = name.slice(prefix.length);
-    const restoredChildName = allowAgentMessageAlias
-      ? PLAINTEXT_V2_AGENT_MESSAGE_TOOL_NAMES.get(childName) ?? childName
-      : childName;
+    const restoredAlias = allowAgentMessageAlias
+      ? PLAINTEXT_V2_AGENT_MESSAGE_TOOL_NAMES.get(childName)
+      : undefined;
+    if (restoredAlias && !aliasedAgentMessageToolNames.has(restoredAlias)) return undefined;
+    const restoredChildName = restoredAlias ?? childName;
     return toolNames.has(restoredChildName) ? restoredChildName : undefined;
   }
   return undefined;
@@ -585,10 +633,20 @@ function restoreToolIdentity(
     return unchanged(value);
   }
 
-  const allowAgentMessageAlias = identityType === "function"
+  const allowAgentMessageAlias = (
+    identityType === "function"
     || identityType === "function_call"
-    || identityType === "response.function_call_arguments.done";
-  const childName = declaredChildName(value.name, context.toolNames, allowAgentMessageAlias);
+    || identityType === "response.function_call_arguments.done"
+  ) && (
+    value.namespace === undefined
+    || value.namespace === PLAINTEXT_V2_COLLABORATION_NAMESPACE
+  );
+  const childName = declaredChildName(
+    value.name,
+    context.toolNames,
+    context.aliasedAgentMessageToolNames,
+    allowAgentMessageAlias,
+  );
   if (!childName) return unchanged(value);
 
   let restored = value;
@@ -673,12 +731,14 @@ function restoreResponseSnapshot(value: unknown, context: RestoreContext): Resto
 export function restorePlaintextV2AgentMessageCalls(
   value: unknown,
   toolNames: ReadonlySet<string>,
+  aliasedAgentMessageToolNames: ReadonlySet<string> = toolNames,
 ): { value: unknown; changed: boolean; overflowed: boolean } {
   if (toolNames.size === 0 || !isPlainObject(value)) {
     return { value, changed: false, overflowed: false };
   }
   const context: RestoreContext = {
     toolNames,
+    aliasedAgentMessageToolNames,
     remainingIdentities: MAX_RESTORED_TOOL_IDENTITIES,
   };
 
@@ -707,29 +767,56 @@ export function restorePlaintextV2AgentMessageCalls(
     : { value, changed: false, overflowed: false };
 }
 
-export function restorePlaintextV2AgentMessageCallsInJson(
+export function restorePlaintextV2AgentMessageCallsInJsonResult(
   payload: string,
   toolNames: ReadonlySet<string>,
-): string {
+  aliasedAgentMessageToolNames: ReadonlySet<string> = toolNames,
+): { value: string; changed: boolean; overflowed: boolean } {
   if (
     !payload.includes(PLAINTEXT_V2_COLLABORATION_NAMESPACE)
     && ![...PLAINTEXT_V2_AGENT_MESSAGE_TOOL_NAMES.keys()].some(alias => payload.includes(alias))
   ) {
-    return payload;
+    return { value: payload, changed: false, overflowed: false };
   }
 
   let value: unknown;
   try {
     value = JSON.parse(payload);
   } catch {
-    return payload;
+    return { value: payload, changed: false, overflowed: false };
   }
-  const restored = restorePlaintextV2AgentMessageCalls(value, toolNames);
-  return restored.changed ? JSON.stringify(restored.value) : payload;
+  const restored = restorePlaintextV2AgentMessageCalls(
+    value,
+    toolNames,
+    aliasedAgentMessageToolNames,
+  );
+  if (restored.overflowed) return { value: payload, changed: false, overflowed: true };
+  return restored.changed
+    ? { value: JSON.stringify(restored.value), changed: true, overflowed: false }
+    : { value: payload, changed: false, overflowed: false };
+}
+
+export function restorePlaintextV2AgentMessageCallsInJson(
+  payload: string,
+  toolNames: ReadonlySet<string>,
+  aliasedAgentMessageToolNames: ReadonlySet<string> = toolNames,
+): string {
+  const restored = restorePlaintextV2AgentMessageCallsInJsonResult(
+    payload,
+    toolNames,
+    aliasedAgentMessageToolNames,
+  );
+  if (restored.overflowed) throw new PlaintextV2AgentMessageRestoreOverflowError();
+  return restored.value;
 }
 
 export function createPlaintextV2AgentMessageCallRestoreRewrite(
   toolNames: ReadonlySet<string>,
+  aliasedAgentMessageToolNames: ReadonlySet<string> = toolNames,
 ): (payload: string) => string {
-  return payload => restorePlaintextV2AgentMessageCallsInJson(payload, toolNames);
+  return payload => restorePlaintextV2AgentMessageCallsInJson(
+    payload,
+    toolNames,
+    aliasedAgentMessageToolNames,
+  );
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -633,9 +633,19 @@ export function warnAgentTaskRecoveryStartup(config: {
   console.warn("   Recovered plaintext assignment data is retained only in a bounded, process-local in-memory cache; exact fidelity is not guaranteed and the path depends on undocumented backend behavior.");
 }
 
+export function warnPlaintextV2AgentMessagesStartup(config: {
+  plaintextV2AgentMessages?: boolean;
+}): void {
+  if (config.plaintextV2AgentMessages !== true) return;
+  console.warn("⚠️  Experimental plaintext V2 agent messages are enabled.");
+  console.warn("   Eligible new canonical ChatGPT v2 spawn_agent, send_message, and followup_task calls may carry message arguments without application-layer encryption; HTTPS transport encryption is unchanged.");
+  console.warn("   Message text may appear in Codex history, routed-provider requests, and local response/debug state. This depends on undocumented ChatGPT and Codex behavior and may stop working after a backend or client change.");
+}
+
 export function startServer(port?: number, deps: StartServerDeps = {}): Server<WsData> {
   const localAttestationSecret = deps.localAttestationSecret ?? createLocalAttestationSecret();
   const config = runModelRenameStartupMigration(runAlibabaRegionStartupMigration(runOpenAiTierStartupMigration(loadConfig())));
+  warnPlaintextV2AgentMessagesStartup(config);
   warnAgentTaskRecoveryStartup(config);
   setLiveStateStoreConfig(config);
   applyProxyEnv(config);

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -367,8 +367,9 @@ import {
 } from "../../responses/namespace-tool-compat";
 import {
   createPlaintextV2AgentMessageCallRestoreRewrite,
+  PLAINTEXT_V2_AGENT_MESSAGE_RESTORE_OVERFLOW_MESSAGE,
   restorePlaintextV2AgentMessageCalls,
-  restorePlaintextV2AgentMessageCallsInJson,
+  restorePlaintextV2AgentMessageCallsInJsonResult,
   shouldPreparePlaintextV2AgentMessages,
 } from "../../responses/plaintext-v2-agent-messages";
 import {
@@ -3628,9 +3629,12 @@ async function handleResponsesInner(
 
   let routedNamespaceToolAliases: RoutedNamespaceToolAliases = new Map();
   let plaintextV2AgentMessageToolNames: ReadonlySet<string> = new Set();
+  let plaintextV2AgentMessageAliasedToolNames: ReadonlySet<string> = new Set();
   const refreshRequestToolAliases = (builtRequest: AdapterRequest): void => {
     routedNamespaceToolAliases = builtRequest.convertedRoutedNamespaceToolAliases ?? new Map();
     plaintextV2AgentMessageToolNames = builtRequest.plaintextV2AgentMessageToolNames ?? new Set();
+    plaintextV2AgentMessageAliasedToolNames =
+      builtRequest.plaintextV2AgentMessageAliasedToolNames ?? new Set();
   };
 
   if ("passthrough" in adapter && adapter.passthrough && !routedCompaction) {
@@ -3862,10 +3866,14 @@ async function handleResponsesInner(
           declaredWireToolNames,
         ).value as { id?: unknown; output?: unknown; status?: unknown };
         const plaintextRestore = plaintextV2AgentMessageToolNames.size > 0
-          ? restorePlaintextV2AgentMessageCalls(customRestoredResponse, plaintextV2AgentMessageToolNames)
+          ? restorePlaintextV2AgentMessageCalls(
+            customRestoredResponse,
+            plaintextV2AgentMessageToolNames,
+            plaintextV2AgentMessageAliasedToolNames,
+          )
           : undefined;
-        // Keep the client response intact on structural overflow, but do not persist an
-        // internal namespace that a later turn (or a disabled option) could replay.
+        // Never persist a response whose aliases exceeded the restoration bound; the client
+        // relay independently replaces it with a safe error.
         if (plaintextRestore?.overflowed) return;
         const restoredResponse = (plaintextRestore?.value ?? customRestoredResponse) as typeof response;
         if (
@@ -4185,7 +4193,7 @@ async function handleResponsesInner(
           headers: selectedForwardHeaders,
           translatorBudget,
         });
-        refreshRoutedNamespaceToolAliases(request);
+        refreshRequestToolAliases(request);
         recordAdapterReasoning(logCtx, request);
         recordAdapterTier(logCtx, request);
         refreshUndeclaredToolGuard(request);
@@ -4512,7 +4520,13 @@ async function handleResponsesInner(
     // treating a successful body as SSE when the caller requested streaming.
     const passthroughCt = headers.get("content-type")?.toLowerCase();
     const isEventStream = passthroughCt?.includes("text/event-stream")
-      || (upstreamResponse.ok && !!upstreamResponse.body && !passthroughCt && parsed.stream);
+      || (
+        plaintextV2AgentMessageToolNames.size === 0
+        && upstreamResponse.ok
+        && !!upstreamResponse.body
+        && !passthroughCt
+        && parsed.stream
+      );
     const recordTerminalOutcome = codexForwardTerminalOutcomeRecorder(
       config,
       authCtx,
@@ -4706,7 +4720,10 @@ async function handleResponsesInner(
         // this request-scoped alias after that copy and before the client guard runs.
         plaintextV2AgentMessageToolNames.size > 0
           ? payloadRewriteAsBlockRewrite(
-            createPlaintextV2AgentMessageCallRestoreRewrite(plaintextV2AgentMessageToolNames),
+            createPlaintextV2AgentMessageCallRestoreRewrite(
+              plaintextV2AgentMessageToolNames,
+              plaintextV2AgentMessageAliasedToolNames,
+            ),
           )
           : undefined,
         createResponsesFieldBackfillBlockRewrite(),
@@ -4899,6 +4916,7 @@ async function handleResponsesInner(
       }
       const text = bounded.text;
       inspectResponseLogJson(logCtx, text);
+      let plaintextV2RestoreOverflowed = false;
       const clientJson = (() => {
         const restoredImageGen = restoreImageGenCallsInJson(text, imageGenCallAliases);
         const restoredNamespace = restoreRoutedNamespaceCallsInJson(
@@ -4922,9 +4940,15 @@ async function handleResponsesInner(
         const repaired = hasResponsesSnapshotRepair(route.provider.responsesSnapshotRepair)
           ? repairResponsesSnapshotJson(restoredToolSearch, outboundRequestBody)
           : restoredToolSearch;
-        const restoredPlaintextV2Namespace = plaintextV2AgentMessageToolNames.size > 0
-          ? restorePlaintextV2AgentMessageCallsInJson(repaired, plaintextV2AgentMessageToolNames)
-          : repaired;
+        const plaintextV2Restore = plaintextV2AgentMessageToolNames.size > 0
+          ? restorePlaintextV2AgentMessageCallsInJsonResult(
+            repaired,
+            plaintextV2AgentMessageToolNames,
+            plaintextV2AgentMessageAliasedToolNames,
+          )
+          : undefined;
+        if (plaintextV2Restore?.overflowed) plaintextV2RestoreOverflowed = true;
+        const restoredPlaintextV2Namespace = plaintextV2Restore?.value ?? repaired;
         const modelRewritten = parsed._responseModelId !== undefined && parsed._responseModelId !== parsed.modelId
           ? rewriteResponsesModelJson(backfillResponsesFieldsJson(restoredPlaintextV2Namespace), parsed._responseModelId)
           : backfillResponsesFieldsJson(restoredPlaintextV2Namespace);
@@ -4936,6 +4960,13 @@ async function handleResponsesInner(
           ? rewriteReasoningSummaryInJsonString(modelRewritten)
           : modelRewritten;
       })();
+      if (plaintextV2RestoreOverflowed) {
+        return formatErrorResponse(
+          502,
+          "upstream_error",
+          PLAINTEXT_V2_AGENT_MESSAGE_RESTORE_OVERFLOW_MESSAGE,
+        );
+      }
       // #1700: same fail-closed policy as the SSE relay above. Both the plain JSON answer and
       // the reframed-SSE branch below are built from this body, so one check covers them. This
       // runs BEFORE the continuation cache write below: a refused turn must not become state a
@@ -5038,6 +5069,14 @@ async function handleResponsesInner(
         statusText: upstreamResponse.statusText,
         headers,
       });
+    }
+    if (plaintextV2AgentMessageToolNames.size > 0) {
+      try { void upstreamResponse.body?.cancel().catch(() => {}); } catch { /* already closed */ }
+      return formatErrorResponse(
+        502,
+        "upstream_error",
+        "plaintext V2 agent-message response used an unsupported content type",
+      );
     }
     // An unclassified passthrough body is relayed directly and has no bounded completion observer;
     // use the same non-error-status success boundary as SSE instead of retaining per-stream state.

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -366,6 +366,12 @@ import {
   type RoutedNamespaceToolAliases,
 } from "../../responses/namespace-tool-compat";
 import {
+  createPlaintextV2AgentMessageCallRestoreRewrite,
+  restorePlaintextV2AgentMessageCalls,
+  restorePlaintextV2AgentMessageCallsInJson,
+  shouldPreparePlaintextV2AgentMessages,
+} from "../../responses/plaintext-v2-agent-messages";
+import {
   collectDeclaredNamelessClientCallTypes,
   collectDeclaredWireToolNames,
   collectProviderExecutedCallTypes,
@@ -2035,6 +2041,12 @@ async function applyFinalRouteRequestNormalization(args: {
   // Settle the wire once so logging, fast-mode, auth, and sidecars read the adapter
   // this request will actually use (#404).
   route.provider = resolveWireProtocolOverride(route.providerName, route.modelId, route.provider, inboundWire);
+  parsed._plaintextV2AgentMessages = shouldPreparePlaintextV2AgentMessages({
+    enabled: config.plaintextV2AgentMessages === true,
+    inboundWire,
+    canonicalChatGpt: isCanonicalOpenAiForwardProvider(route.provider),
+    requestBody: parsed._rawBody,
+  });
   if (preserveAnthropicResponseModel) parsed._responseModelId = responseModelId;
   logCtx.model = route.modelId;
   logCtx.provider = route.providerName;
@@ -3615,8 +3627,10 @@ async function handleResponsesInner(
   }
 
   let routedNamespaceToolAliases: RoutedNamespaceToolAliases = new Map();
-  const refreshRoutedNamespaceToolAliases = (builtRequest: AdapterRequest): void => {
+  let plaintextV2AgentMessageToolNames: ReadonlySet<string> = new Set();
+  const refreshRequestToolAliases = (builtRequest: AdapterRequest): void => {
     routedNamespaceToolAliases = builtRequest.convertedRoutedNamespaceToolAliases ?? new Map();
+    plaintextV2AgentMessageToolNames = builtRequest.plaintextV2AgentMessageToolNames ?? new Set();
   };
 
   if ("passthrough" in adapter && adapter.passthrough && !routedCompaction) {
@@ -3704,7 +3718,7 @@ async function handleResponsesInner(
       // would incorrectly disable restoration for the exact ambiguous-name case the alias fixes.
       routedToolSearchNames.add(name);
     }
-    refreshRoutedNamespaceToolAliases(request);
+    refreshRequestToolAliases(request);
     // #1700: the bridged paths refuse a call to a tool the request never declared
     // (`declaredToolNames`, src/bridge.ts). The passthrough had no equivalent, so a routed
     // provider's top-level `apply_patch` — which under Codex code mode exists only as a nested
@@ -3841,12 +3855,19 @@ async function handleResponsesInner(
     const rememberPassthroughResponseChecked = rememberPassthroughResponse
       ? (response: { id?: unknown; output?: unknown; status?: unknown }) => {
         if (inspectionSawUndeclaredTool) return;
-        const restoredResponse = restoreRoutedCustomCalls(
+        const customRestoredResponse = restoreRoutedCustomCalls(
           restoreAuthorizedBareNamespaceToolCalls(response),
           routedCustomToolNames,
           routedCustomToolRepairNames,
           declaredWireToolNames,
         ).value as { id?: unknown; output?: unknown; status?: unknown };
+        const plaintextRestore = plaintextV2AgentMessageToolNames.size > 0
+          ? restorePlaintextV2AgentMessageCalls(customRestoredResponse, plaintextV2AgentMessageToolNames)
+          : undefined;
+        // Keep the client response intact on structural overflow, but do not persist an
+        // internal namespace that a later turn (or a disabled option) could replay.
+        if (plaintextRestore?.overflowed) return;
+        const restoredResponse = (plaintextRestore?.value ?? customRestoredResponse) as typeof response;
         if (
           undeclaredToolGuardActive
           && undeclaredToolCallNameInResponse(
@@ -4053,7 +4074,7 @@ async function handleResponsesInner(
           headers: selectedForwardHeaders,
           translatorBudget,
         });
-        refreshRoutedNamespaceToolAliases(request);
+        refreshRequestToolAliases(request);
         recordAdapterReasoning(logCtx, request);
         recordAdapterTier(logCtx, request);
       } catch (err) {
@@ -4271,7 +4292,7 @@ async function handleResponsesInner(
           headers: selectedForwardHeaders,
           translatorBudget,
         });
-        refreshRoutedNamespaceToolAliases(request);
+        refreshRequestToolAliases(request);
         recordAdapterReasoning(logCtx, request);
         recordAdapterTier(logCtx, request);
       } catch (err) {
@@ -4452,7 +4473,7 @@ async function handleResponsesInner(
         if (retry.kind === "retried") {
           authCtx = retry.authCtx;
           request = retry.request;
-          refreshRoutedNamespaceToolAliases(request);
+          refreshRequestToolAliases(request);
           refreshUndeclaredToolGuard(request);
           upstreamResponse = retry.upstreamResponse;
           selectedForwardHeaders = retry.selectedForwardHeaders;
@@ -4681,6 +4702,13 @@ async function handleResponsesInner(
         snapshotRepairEnabled
           ? createResponsesSnapshotBlockRewrite(outboundRequestBody, translatorBudget)
           : undefined,
+        // Snapshot repair can copy tools/tool_choice from the outbound request. Restore
+        // this request-scoped alias after that copy and before the client guard runs.
+        plaintextV2AgentMessageToolNames.size > 0
+          ? payloadRewriteAsBlockRewrite(
+            createPlaintextV2AgentMessageCallRestoreRewrite(plaintextV2AgentMessageToolNames),
+          )
+          : undefined,
         createResponsesFieldBackfillBlockRewrite(),
         // Last: every rewrite above can still rename or reshape a call item, so the guard must
         // compare the names the client will actually receive against the declared catalog.
@@ -4872,8 +4900,9 @@ async function handleResponsesInner(
       const text = bounded.text;
       inspectResponseLogJson(logCtx, text);
       const clientJson = (() => {
+        const restoredImageGen = restoreImageGenCallsInJson(text, imageGenCallAliases);
         const restoredNamespace = restoreRoutedNamespaceCallsInJson(
-          restoreImageGenCallsInJson(text, imageGenCallAliases),
+          restoredImageGen,
           routedNamespaceToolAliases,
         );
         const restoredAuthorizedBareNamespace = restoreRoutedNamespaceCallsInJson(
@@ -4893,9 +4922,12 @@ async function handleResponsesInner(
         const repaired = hasResponsesSnapshotRepair(route.provider.responsesSnapshotRepair)
           ? repairResponsesSnapshotJson(restoredToolSearch, outboundRequestBody)
           : restoredToolSearch;
+        const restoredPlaintextV2Namespace = plaintextV2AgentMessageToolNames.size > 0
+          ? restorePlaintextV2AgentMessageCallsInJson(repaired, plaintextV2AgentMessageToolNames)
+          : repaired;
         const modelRewritten = parsed._responseModelId !== undefined && parsed._responseModelId !== parsed.modelId
-          ? rewriteResponsesModelJson(backfillResponsesFieldsJson(repaired), parsed._responseModelId)
-          : backfillResponsesFieldsJson(repaired);
+          ? rewriteResponsesModelJson(backfillResponsesFieldsJson(restoredPlaintextV2Namespace), parsed._responseModelId)
+          : backfillResponsesFieldsJson(restoredPlaintextV2Namespace);
         // The bounded-JSON answer bypasses the SSE payload rewrite, so content-
         // channel reasoning needs the same normalization here for the plain
         // JSON answer and every reframed-SSE variant built from clientJson.
@@ -5677,7 +5709,7 @@ async function handleResponsesInner(
     Math.max(1, budget - transientSendsUsed);
   try {
     initialRequest = await activeAdapter.buildRequest(parsed, { headers: selectedForwardHeaders, translatorBudget });
-    refreshRoutedNamespaceToolAliases(initialRequest);
+    refreshRequestToolAliases(initialRequest);
     recordAdapterReasoning(logCtx, initialRequest);
     recordAdapterTier(logCtx, initialRequest);
     inputTokenEstimate = typeof initialRequest.usageLog?.inputTokens === "number"
@@ -5822,7 +5854,7 @@ async function handleResponsesInner(
         sameTargetParsed = parsed;
         sameTargetToken = transportToken;
       }
-      refreshRoutedNamespaceToolAliases(retryRequest);
+      refreshRequestToolAliases(retryRequest);
       const retryEstimate = typeof retryRequest.usageLog?.inputTokens === "number"
         ? retryRequest.usageLog.inputTokens
         : undefined;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -554,6 +554,8 @@ export interface OcxConfig {
    * Routed parents get v2 tools; Sol/Terra can still spawn Grok/Claude (issue #92).
    */
   keepNativeChatGptOnV1?: boolean;
+  /** Experimental, default-off plaintext delivery for native v2 collaboration messages. */
+  plaintextV2AgentMessages?: boolean;
   /** Experimental, default-off ChatGPT recovery for encrypted V2 routed tasks. */
   agentTaskRecovery?: {
     enabled?: boolean;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -554,7 +554,7 @@ export interface OcxConfig {
    * Routed parents get v2 tools; Sol/Terra can still spawn Grok/Claude (issue #92).
    */
   keepNativeChatGptOnV1?: boolean;
-  /** Experimental, default-off plaintext delivery for native v2 collaboration messages. */
+  /** Experimental plaintext delivery for native v2 collaboration messages; disabled unless true. */
   plaintextV2AgentMessages?: boolean;
   /** Experimental, default-off ChatGPT recovery for encrypted V2 routed tasks. */
   agentTaskRecovery?: {

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -77,6 +77,8 @@ export interface OcxParsedRequest {
    * prepareOpaqueBlobRecovery after an authoritative rejection; consumers strip replayed blobs.
    */
   _stripReasoningEncryptedContent?: boolean;
+  /** Final-route opt-in: emit v2 collaboration message arguments as plaintext on ChatGPT. */
+  _plaintextV2AgentMessages?: boolean;
   /**
    * Optional authenticated tenant/operator namespace for Cursor thread→conversation derivation.
    * When absent (single-operator local proxy), derivation stays local-scoped.

--- a/tests/agent-task-recovery.test.ts
+++ b/tests/agent-task-recovery.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { createTranslatorBudget } from "../src/lib/translator-budget";
-import { warnAgentTaskRecoveryStartup } from "../src/server";
+import { warnAgentTaskRecoveryStartup, warnPlaintextV2AgentMessagesStartup } from "../src/server";
 import { resetAgentTaskRecoveryState } from "../src/server/responses/agent-task-recovery";
 import { agentTaskRecoveryWaiterCountForTests } from "../src/server/responses/agent-task-recovery-cache";
 import {
@@ -120,6 +120,28 @@ describe("agent task recovery (opt-in, default off)", () => {
       expect(warnings.join("\n")).toContain("Recovered plaintext assignment data");
       expect(warnings.join("\n")).toContain("process-local in-memory cache");
       expect(warnings.join("\n")).not.toContain(secret);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  test("warns about plaintext retention only for an explicit v2 message opt-in", () => {
+    const originalWarn = console.warn;
+    const capture = (enabled: boolean | undefined): string[] => {
+      const warnings: string[] = [];
+      console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(" ")); };
+      warnPlaintextV2AgentMessagesStartup({ plaintextV2AgentMessages: enabled });
+      return warnings;
+    };
+
+    try {
+      expect(capture(undefined)).toEqual([]);
+      expect(capture(false)).toEqual([]);
+      const warnings = capture(true);
+      expect(warnings).toHaveLength(3);
+      expect(warnings.join("\n")).toContain("Experimental plaintext V2 agent messages are enabled");
+      expect(warnings.join("\n")).toContain("HTTPS transport encryption is unchanged");
+      expect(warnings.join("\n")).toContain("local response/debug state");
     } finally {
       console.warn = originalWarn;
     }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -848,6 +848,46 @@ describe("opencodex config defaults", () => {
     }
   });
 
+  test("plaintextV2AgentMessages is explicit and degrades invalid hand edits", () => {
+    const base = {
+      port: 12345,
+      providers: {
+        custom: {
+          adapter: "openai-responses",
+          baseUrl: "https://example.test/v1",
+        },
+      },
+      defaultProvider: "custom",
+    };
+    expect(getDefaultConfig().plaintextV2AgentMessages).toBeUndefined();
+
+    writeConfig({ ...base, plaintextV2AgentMessages: true });
+    expect(loadConfig()).toMatchObject({ ...base, plaintextV2AgentMessages: true });
+    expect(validateConfigCandidate({ ...base, plaintextV2AgentMessages: true })).toMatchObject({
+      ok: true,
+      config: { plaintextV2AgentMessages: true },
+    });
+
+    for (const invalid of [null, "true", 1, {}]) {
+      writeConfig({ ...base, plaintextV2AgentMessages: invalid });
+      const diagnostics = readConfigDiagnostics();
+      expect(diagnostics).toMatchObject({
+        source: "file",
+        error: null,
+        config: base,
+      });
+      expect(diagnostics.config.plaintextV2AgentMessages).toBeUndefined();
+      expect(diagnostics.warnings).toContain(
+        "plaintextV2AgentMessages ignored: expected a boolean",
+      );
+      expect(validateConfigCandidate({ ...base, plaintextV2AgentMessages: invalid })).toMatchObject({
+        ok: false,
+        error: expect.stringContaining("plaintextV2AgentMessages"),
+      });
+      expect(backupNames()).toEqual([]);
+    }
+  });
+
   test("native subagent-default sync is opt-in and ignores malformed opt-ins without falling back", () => {
     const base = {
       port: 12345,

--- a/tests/plaintext-v2-agent-messages-server.test.ts
+++ b/tests/plaintext-v2-agent-messages-server.test.ts
@@ -104,7 +104,7 @@ function completedResponsePayload(id = "resp-plaintext-v2") {
       type: "function_call",
       call_id: "call-spawn",
       namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
-      name: "spawn_agent",
+      name: "start_delegated_task",
       arguments: JSON.stringify({ message: "plain assignment" }),
       encrypted_function_args: [],
     }],
@@ -126,7 +126,7 @@ describe("plaintext v2 agent messages at the Responses server boundary", () => {
           type: "response.function_call_arguments.done",
           item_id: "fc-spawn",
           namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
-          name: `${PLAINTEXT_V2_COLLABORATION_NAMESPACE}__spawn_agent`,
+          name: `${PLAINTEXT_V2_COLLABORATION_NAMESPACE}__start_delegated_task`,
           arguments: JSON.stringify({ message: "plain assignment" }),
           encrypted_function_args: [],
         })}\n\nevent: response.completed\ndata: ${JSON.stringify({
@@ -144,11 +144,18 @@ describe("plaintext v2 agent messages at the Responses server boundary", () => {
     );
     const clientBody = await response.text();
     const sentBody = JSON.parse(sentBodies[0]!) as {
-      tools: Array<{ name: string; tools: Array<{ parameters: { properties: { message: Record<string, unknown> } } }> }>;
+      tools: Array<{
+        name: string;
+        tools: Array<{
+          name: string;
+          parameters: { properties: { message: Record<string, unknown> } };
+        }>;
+      }>;
     };
 
     expect(sentBodies).toHaveLength(1);
     expect(sentBody.tools[0]!.name).toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(sentBody.tools[0]!.tools[0]!.name).toBe("start_delegated_task");
     expect(sentBody.tools[0]!.tools[0]!.parameters.properties.message.encrypted).toBeUndefined();
     expect(clientBody).not.toContain(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
     expect(clientBody).toContain('"namespace":"collaboration"');
@@ -360,7 +367,7 @@ describe("plaintext v2 agent messages at the Responses server boundary", () => {
             type: "function_call",
             call_id: `call-${index}`,
             namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
-            name: "spawn_agent",
+            name: "start_delegated_task",
             arguments: "{}",
           })),
         }

--- a/tests/plaintext-v2-agent-messages-server.test.ts
+++ b/tests/plaintext-v2-agent-messages-server.test.ts
@@ -6,7 +6,11 @@ import { saveCodexAccountCredential } from "../src/codex/account-store";
 import { clearAccountQuota, updateAccountQuota } from "../src/codex/auth-api";
 import { clearCodexUpstreamHealth, clearThreadAccountMap } from "../src/codex/routing";
 import { CODEX_FORWARD_BASE_URL } from "../src/providers/openai-tiers";
-import { PLAINTEXT_V2_COLLABORATION_NAMESPACE } from "../src/responses/plaintext-v2-agent-messages";
+import { PROVIDER_REGISTRY } from "../src/providers/registry";
+import {
+  PLAINTEXT_V2_AGENT_MESSAGE_RESTORE_OVERFLOW_MESSAGE,
+  PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+} from "../src/responses/plaintext-v2-agent-messages";
 import { clearResponseStateForTests } from "../src/responses/state";
 import { handleResponses } from "../src/server/responses";
 import type { OcxConfig } from "../src/types";
@@ -18,7 +22,11 @@ afterEach(() => {
   clearResponseStateForTests();
 });
 
-function config(enabled: boolean, snapshotRepair = false): OcxConfig {
+function config(
+  enabled: boolean,
+  snapshotRepair = false,
+  streamMode?: "auto" | "legacy-tee" | "eager-relay",
+): OcxConfig {
   return {
     defaultProvider: "native",
     providers: {
@@ -30,6 +38,7 @@ function config(enabled: boolean, snapshotRepair = false): OcxConfig {
       },
     },
     plaintextV2AgentMessages: enabled,
+    ...(streamMode ? { streamMode } : {}),
   } as OcxConfig;
 }
 
@@ -111,6 +120,20 @@ function completedResponsePayload(id = "resp-plaintext-v2") {
   };
 }
 
+function overLimitResponsePayload(id = "resp-plaintext-v2-overflow") {
+  return {
+    id,
+    status: "completed",
+    output: Array.from({ length: 10_000 }, (_, index) => ({
+      type: "function_call",
+      call_id: `call-${index}`,
+      namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+      name: "start_delegated_task",
+      arguments: "{}",
+    })),
+  };
+}
+
 describe("plaintext v2 agent messages at the Responses server boundary", () => {
   test("rewrites the canonical request and restores every SSE response snapshot", async () => {
     const sentBodies: string[] = [];
@@ -179,6 +202,25 @@ describe("plaintext v2 agent messages at the Responses server boundary", () => {
     expect(clientBody).not.toContain(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
     expect(clientBody).toContain('"namespace":"collaboration"');
     expect(clientBody).toContain('"encrypted_function_args":[]');
+  });
+
+  test("rejects an unclassified successful response while restoration is required", async () => {
+    globalThis.fetch = (async () => new Response(
+      JSON.stringify(completedResponsePayload()),
+      { status: 200 },
+    )) as typeof fetch;
+
+    const response = await handleResponses(
+      collaborationRequest(),
+      config(true),
+      { model: "", provider: "" },
+    );
+    const clientBody = await response.text();
+
+    expect(response.status).toBe(502);
+    expect(clientBody).toContain("unsupported content type");
+    expect(clientBody).not.toContain(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(clientBody).not.toContain("start_delegated_task");
   });
 
   test("restores aliases after SSE snapshot repair copies request tools and tool choice", async () => {
@@ -325,6 +367,14 @@ describe("plaintext v2 agent messages at the Responses server boundary", () => {
       }
 
       const sentBodies: string[] = [];
+      const entitlementSnapshot = {
+        modelsByAccount: new Map([
+          ["pool-a", new Set(["gpt-5.6-sol"])],
+          ["pool-b", new Set(["gpt-5.6-sol"])],
+        ]),
+        confirmedAccountIds: new Set(["pool-a", "pool-b"]),
+        credentialIdentities: new Map<string, string>(),
+      };
       globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
         sentBodies.push(typeof init?.body === "string" ? init.body : "");
         if (sentBodies.length === 1) {
@@ -340,6 +390,7 @@ describe("plaintext v2 agent messages at the Responses server boundary", () => {
         collaborationRequest({ model: "gpt-5.6-sol" }),
         poolConfig,
         { model: "", provider: "" },
+        { resolveCodexModelEntitlements: async () => entitlementSnapshot },
       );
       const clientBody = await response.text();
 
@@ -353,24 +404,92 @@ describe("plaintext v2 agent messages at the Responses server boundary", () => {
     });
   });
 
-  test("returns an over-limit response but does not retain its private alias for continuation", async () => {
+  test("fails closed for over-limit streamed responses in both relay modes", async () => {
+    for (const streamMode of ["legacy-tee", "eager-relay"] as const) {
+      globalThis.fetch = (async () => new Response(
+        `event: response.completed\ndata: ${JSON.stringify({
+          type: "response.completed",
+          response: overLimitResponsePayload(`resp-${streamMode}`),
+        })}\n\ndata: [DONE]\n\n`,
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      )) as typeof fetch;
+
+      const response = await handleResponses(
+        collaborationRequest(),
+        config(true, false, streamMode),
+        { model: "", provider: "" },
+      );
+      const clientBody = await response.text();
+
+      expect(response.status).toBe(200);
+      expect(clientBody).toContain('"type":"response.failed"');
+      expect(clientBody).toContain(PLAINTEXT_V2_AGENT_MESSAGE_RESTORE_OVERFLOW_MESSAGE);
+      expect(clientBody).toContain("data: [DONE]");
+      expect(clientBody).not.toContain(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+      expect(clientBody).not.toContain("start_delegated_task");
+    }
+  });
+
+  test("rejects over-limit bounded JSON before HTTP or WebSocket reframing", async () => {
+    const fixtureId = "plaintext-v2-bounded-json-fixture";
+    const fixtureModel = "fixture-model";
+    const mutableRegistry = PROVIDER_REGISTRY as unknown as Array<Record<string, unknown>>;
+    mutableRegistry.push({
+      id: fixtureId,
+      label: "Plaintext V2 bounded JSON fixture",
+      baseUrl: CODEX_FORWARD_BASE_URL,
+      adapter: "openai-responses",
+      authKind: "forward",
+      models: [fixtureModel],
+      defaultModel: fixtureModel,
+      modelResponsesUpstreamStreaming: { [fixtureModel]: false },
+    });
+    const fixtureConfig = {
+      defaultProvider: fixtureId,
+      providers: {
+        [fixtureId]: {
+          adapter: "openai-responses",
+          baseUrl: CODEX_FORWARD_BASE_URL,
+          authMode: "forward",
+        },
+      },
+      plaintextV2AgentMessages: true,
+    } as OcxConfig;
+
+    try {
+      for (const inboundTransport of [undefined, "websocket"] as const) {
+        globalThis.fetch = (async () => Response.json(overLimitResponsePayload())) as typeof fetch;
+        const response = await handleResponses(
+          collaborationRequest({ model: `${fixtureId}/${fixtureModel}` }),
+          fixtureConfig,
+          { model: "", provider: "" },
+          inboundTransport
+            ? { inboundWire: "responses", inboundTransport }
+            : undefined,
+        );
+        const clientBody = await response.text();
+
+        expect(response.status).toBe(502);
+        expect(response.headers.get("content-type")).toContain("application/json");
+        expect(clientBody).toContain(PLAINTEXT_V2_AGENT_MESSAGE_RESTORE_OVERFLOW_MESSAGE);
+        expect(clientBody).not.toContain(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+        expect(clientBody).not.toContain("start_delegated_task");
+        expect(clientBody).not.toContain("data: [DONE]");
+      }
+    } finally {
+      const index = mutableRegistry.findIndex(entry => entry.id === fixtureId);
+      if (index >= 0) mutableRegistry.splice(index, 1);
+    }
+  });
+
+  test("rejects an over-limit JSON response and does not retain it for continuation", async () => {
     const sentBodies: string[] = [];
     let requestIndex = 0;
     globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
       sentBodies.push(typeof init?.body === "string" ? init.body : "");
       requestIndex += 1;
       const payload = requestIndex === 1
-        ? {
-          id: "resp-plaintext-v2-overflow",
-          status: "completed",
-          output: Array.from({ length: 10_001 }, (_, index) => ({
-            type: "function_call",
-            call_id: `call-${index}`,
-            namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
-            name: "start_delegated_task",
-            arguments: "{}",
-          })),
-        }
+        ? overLimitResponsePayload()
         : { id: "resp-after-overflow", status: "completed", output: [] };
       return Response.json(payload);
     }) as typeof fetch;
@@ -381,8 +500,10 @@ describe("plaintext v2 agent messages at the Responses server boundary", () => {
       { model: "", provider: "" },
     );
     const firstBody = await first.text();
-    expect(first.status).toBe(200);
-    expect(firstBody).toContain(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(first.status).toBe(502);
+    expect(firstBody).toContain(PLAINTEXT_V2_AGENT_MESSAGE_RESTORE_OVERFLOW_MESSAGE);
+    expect(firstBody).not.toContain(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(firstBody).not.toContain("start_delegated_task");
 
     const second = await handleResponses(
       collaborationRequest({

--- a/tests/plaintext-v2-agent-messages-server.test.ts
+++ b/tests/plaintext-v2-agent-messages-server.test.ts
@@ -1,0 +1,436 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { saveCodexAccountCredential } from "../src/codex/account-store";
+import { clearAccountQuota, updateAccountQuota } from "../src/codex/auth-api";
+import { clearCodexUpstreamHealth, clearThreadAccountMap } from "../src/codex/routing";
+import { CODEX_FORWARD_BASE_URL } from "../src/providers/openai-tiers";
+import { PLAINTEXT_V2_COLLABORATION_NAMESPACE } from "../src/responses/plaintext-v2-agent-messages";
+import { clearResponseStateForTests } from "../src/responses/state";
+import { handleResponses } from "../src/server/responses";
+import type { OcxConfig } from "../src/types";
+
+const originalFetch = globalThis.fetch;
+beforeEach(() => { clearResponseStateForTests(); });
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  clearResponseStateForTests();
+});
+
+function config(enabled: boolean, snapshotRepair = false): OcxConfig {
+  return {
+    defaultProvider: "native",
+    providers: {
+      native: {
+        adapter: "openai-responses",
+        baseUrl: CODEX_FORWARD_BASE_URL,
+        authMode: "forward",
+        ...(snapshotRepair ? { responsesSnapshotRepair: true } : {}),
+      },
+    },
+    plaintextV2AgentMessages: enabled,
+  } as OcxConfig;
+}
+
+function collaborationRequest(options: {
+  input?: unknown[];
+  model?: string;
+  previousResponseId?: string;
+  toolChoice?: unknown;
+} = {}): Request {
+  return new Request("http://localhost/v1/responses", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: options.model ?? "native/gpt-5.6-sol",
+      store: false,
+      stream: true,
+      input: options.input ?? [{
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "delegate" }],
+      }],
+      ...(options.previousResponseId ? { previous_response_id: options.previousResponseId } : {}),
+      ...(options.toolChoice ? { tool_choice: options.toolChoice } : {}),
+      tools: [{
+        type: "namespace",
+        name: "collaboration",
+        tools: [
+          {
+            type: "function",
+            name: "spawn_agent",
+            parameters: {
+              type: "object",
+              properties: { message: { type: "string", encrypted: true } },
+              required: ["message"],
+            },
+          },
+          { type: "function", name: "send_message", parameters: { type: "object" } },
+        ],
+      }],
+    }),
+  });
+}
+
+async function withPoolHome<T>(run: () => Promise<T>): Promise<T> {
+  const home = mkdtempSync(join(tmpdir(), "ocx-plaintext-v2-pool-"));
+  const previousOpencodexHome = process.env.OPENCODEX_HOME;
+  const previousCodexHome = process.env.CODEX_HOME;
+  process.env.OPENCODEX_HOME = home;
+  process.env.CODEX_HOME = home;
+  clearCodexUpstreamHealth();
+  clearThreadAccountMap();
+  clearAccountQuota();
+  try {
+    return await run();
+  } finally {
+    clearCodexUpstreamHealth();
+    clearThreadAccountMap();
+    clearAccountQuota();
+    rmSync(home, { recursive: true, force: true });
+    if (previousOpencodexHome === undefined) delete process.env.OPENCODEX_HOME;
+    else process.env.OPENCODEX_HOME = previousOpencodexHome;
+    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodexHome;
+  }
+}
+
+function completedResponsePayload(id = "resp-plaintext-v2") {
+  return {
+    id,
+    status: "completed",
+    output: [{
+      type: "function_call",
+      call_id: "call-spawn",
+      namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+      name: "spawn_agent",
+      arguments: JSON.stringify({ message: "plain assignment" }),
+      encrypted_function_args: [],
+    }],
+  };
+}
+
+describe("plaintext v2 agent messages at the Responses server boundary", () => {
+  test("rewrites the canonical request and restores every SSE response snapshot", async () => {
+    const sentBodies: string[] = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      sentBodies.push(typeof init?.body === "string" ? init.body : "");
+      const response = completedResponsePayload();
+      return new Response(
+        `event: response.output_item.added\ndata: ${JSON.stringify({
+          type: "response.output_item.added",
+          output_index: 0,
+          item: response.output[0],
+        })}\n\nevent: response.function_call_arguments.done\ndata: ${JSON.stringify({
+          type: "response.function_call_arguments.done",
+          item_id: "fc-spawn",
+          namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+          name: `${PLAINTEXT_V2_COLLABORATION_NAMESPACE}__spawn_agent`,
+          arguments: JSON.stringify({ message: "plain assignment" }),
+          encrypted_function_args: [],
+        })}\n\nevent: response.completed\ndata: ${JSON.stringify({
+          type: "response.completed",
+          response,
+        })}\n\ndata: [DONE]\n\n`,
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      );
+    }) as typeof fetch;
+
+    const response = await handleResponses(
+      collaborationRequest(),
+      config(true),
+      { model: "", provider: "" },
+    );
+    const clientBody = await response.text();
+    const sentBody = JSON.parse(sentBodies[0]!) as {
+      tools: Array<{ name: string; tools: Array<{ parameters: { properties: { message: Record<string, unknown> } } }> }>;
+    };
+
+    expect(sentBodies).toHaveLength(1);
+    expect(sentBody.tools[0]!.name).toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(sentBody.tools[0]!.tools[0]!.parameters.properties.message.encrypted).toBeUndefined();
+    expect(clientBody).not.toContain(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(clientBody).toContain('"namespace":"collaboration"');
+    expect(clientBody).toContain('"name":"collaboration__spawn_agent"');
+    expect(clientBody).toContain('"encrypted_function_args":[]');
+  });
+
+  test("restores the namespace in bounded JSON responses", async () => {
+    globalThis.fetch = (async () => new Response(JSON.stringify(completedResponsePayload()), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })) as typeof fetch;
+
+    const response = await handleResponses(
+      collaborationRequest(),
+      config(true),
+      { model: "", provider: "" },
+    );
+    const clientBody = await response.text();
+
+    expect(clientBody).not.toContain(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(clientBody).toContain('"namespace":"collaboration"');
+    expect(clientBody).toContain('"encrypted_function_args":[]');
+  });
+
+  test("restores aliases after SSE snapshot repair copies request tools and tool choice", async () => {
+    globalThis.fetch = (async () => {
+      const response = completedResponsePayload("resp-snapshot-sse");
+      return new Response(
+        `event: response.completed\ndata: ${JSON.stringify({
+          type: "response.completed",
+          response,
+        })}\n\ndata: [DONE]\n\n`,
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      );
+    }) as typeof fetch;
+
+    const response = await handleResponses(
+      collaborationRequest({
+        toolChoice: { type: "function", namespace: "collaboration", name: "spawn_agent" },
+      }),
+      config(true, true),
+      { model: "", provider: "" },
+    );
+    const completedLine = (await response.text()).split("\n")
+      .find(line => line.includes('"response.completed"'))!;
+    const completed = JSON.parse(completedLine.replace(/^data: /, "")) as {
+      response: {
+        tool_choice: { namespace: string };
+        tools: Array<{ name: string }>;
+        output: Array<{ namespace: string; encrypted_function_args: unknown[] }>;
+      };
+    };
+
+    expect(completed.response.tool_choice.namespace).toBe("collaboration");
+    expect(completed.response.tools[0]!.name).toBe("collaboration");
+    expect(completed.response.output[0]!.namespace).toBe("collaboration");
+    expect(completed.response.output[0]!.encrypted_function_args).toEqual([]);
+  });
+
+  test("restores aliases after bounded JSON snapshot repair", async () => {
+    globalThis.fetch = (async () => new Response(
+      JSON.stringify(completedResponsePayload("resp-snapshot-json")),
+      { status: 200, headers: { "content-type": "application/json" } },
+    )) as typeof fetch;
+
+    const response = await handleResponses(
+      collaborationRequest({
+        toolChoice: { type: "function", namespace: "collaboration", name: "spawn_agent" },
+      }),
+      config(true, true),
+      { model: "", provider: "" },
+    );
+    const completed = await response.json() as {
+      tool_choice: { namespace: string };
+      tools: Array<{ name: string }>;
+      output: Array<{ namespace: string; encrypted_function_args: unknown[] }>;
+    };
+
+    expect(completed.tool_choice.namespace).toBe("collaboration");
+    expect(completed.tools[0]!.name).toBe("collaboration");
+    expect(completed.output[0]!.namespace).toBe("collaboration");
+    expect(completed.output[0]!.encrypted_function_args).toEqual([]);
+  });
+
+  test("keeps the marker and reserved namespace when the option is disabled", async () => {
+    const sentBodies: string[] = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      sentBodies.push(typeof init?.body === "string" ? init.body : "");
+      return new Response("data: [DONE]\n\n", {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    }) as typeof fetch;
+
+    await handleResponses(collaborationRequest(), config(false), { model: "", provider: "" });
+    const sentBody = JSON.parse(sentBodies[0]!) as {
+      tools: Array<{ name: string; tools: Array<{ parameters: { properties: { message: Record<string, unknown> } } }> }>;
+    };
+
+    expect(sentBodies).toHaveLength(1);
+    expect(sentBody.tools[0]!.name).toBe("collaboration");
+    expect(sentBody.tools[0]!.tools[0]!.parameters.properties.message.encrypted).toBe(true);
+  });
+
+  test("keeps the whole request unchanged when tool-search history conflicts with the alias", async () => {
+    const sentBodies: string[] = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      sentBodies.push(typeof init?.body === "string" ? init.body : "");
+      return new Response("data: [DONE]\n\n", {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    }) as typeof fetch;
+
+    await handleResponses(collaborationRequest({
+      input: [{
+        type: "tool_search_output",
+        tools: [{
+          type: "namespace",
+          name: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+          tools: [],
+        }],
+      }],
+    }), config(true), { model: "", provider: "" });
+
+    const sent = JSON.parse(sentBodies[0]!) as {
+      tools: Array<{
+        name: string;
+        tools: Array<{ parameters: { properties: { message: Record<string, unknown> } } }>;
+      }>;
+    };
+    expect(sent.tools[0]!.name).toBe("collaboration");
+    expect(sent.tools[0]!.tools[0]!.parameters.properties.message.encrypted).toBe(true);
+  });
+
+  test("rebuilds the plaintext alias after a canonical pool quota retry", async () => {
+    await withPoolHome(async () => {
+      const poolConfig = {
+        defaultProvider: "openai",
+        activeCodexAccountId: "pool-a",
+        autoSwitchThreshold: 0,
+        providers: {
+          openai: {
+            adapter: "openai-responses",
+            baseUrl: CODEX_FORWARD_BASE_URL,
+            authMode: "forward",
+            codexAccountMode: "pool",
+          },
+        },
+        codexAccounts: ["pool-a", "pool-b"].map(id => ({
+          id,
+          email: `${id}@example.test`,
+          isMain: false,
+          chatgptAccountId: `${id}_chatgpt`,
+        })),
+        plaintextV2AgentMessages: true,
+      } as OcxConfig;
+      for (const [index, id] of ["pool-a", "pool-b"].entries()) {
+        saveCodexAccountCredential(id, {
+          accessToken: `${id}-access-token`,
+          refreshToken: `${id}-refresh-token`,
+          expiresAt: Date.now() + 300_000,
+          chatgptAccountId: `${id}_chatgpt`,
+        });
+        updateAccountQuota(id, 10 + index * 10);
+      }
+
+      const sentBodies: string[] = [];
+      globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+        sentBodies.push(typeof init?.body === "string" ? init.body : "");
+        if (sentBodies.length === 1) {
+          return Response.json({ error: { message: "rate limited" } }, {
+            status: 429,
+            headers: { "retry-after": "1" },
+          });
+        }
+        return Response.json(completedResponsePayload("resp-pool-retry"));
+      }) as typeof fetch;
+
+      const response = await handleResponses(
+        collaborationRequest({ model: "gpt-5.6-sol" }),
+        poolConfig,
+        { model: "", provider: "" },
+      );
+      const clientBody = await response.text();
+
+      expect(sentBodies).toHaveLength(2);
+      for (const body of sentBodies) {
+        const sent = JSON.parse(body) as { tools: Array<{ name: string }> };
+        expect(sent.tools[0]!.name).toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+      }
+      expect(clientBody).toContain('"namespace":"collaboration"');
+      expect(clientBody).not.toContain(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    });
+  });
+
+  test("returns an over-limit response but does not retain its private alias for continuation", async () => {
+    const sentBodies: string[] = [];
+    let requestIndex = 0;
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      sentBodies.push(typeof init?.body === "string" ? init.body : "");
+      requestIndex += 1;
+      const payload = requestIndex === 1
+        ? {
+          id: "resp-plaintext-v2-overflow",
+          status: "completed",
+          output: Array.from({ length: 10_001 }, (_, index) => ({
+            type: "function_call",
+            call_id: `call-${index}`,
+            namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+            name: "spawn_agent",
+            arguments: "{}",
+          })),
+        }
+        : { id: "resp-after-overflow", status: "completed", output: [] };
+      return Response.json(payload);
+    }) as typeof fetch;
+
+    const first = await handleResponses(
+      collaborationRequest(),
+      config(true),
+      { model: "", provider: "" },
+    );
+    const firstBody = await first.text();
+    expect(first.status).toBe(200);
+    expect(firstBody).toContain(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+
+    const second = await handleResponses(
+      collaborationRequest({
+        previousResponseId: "resp-plaintext-v2-overflow",
+        input: [{
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "continue" }],
+        }],
+      }),
+      config(false),
+      { model: "", provider: "" },
+    );
+    const secondBody = await second.text();
+    expect({ status: second.status, body: secondBody, sends: sentBodies.length }).toEqual({
+      status: 400,
+      body: expect.stringContaining("continuation state is unavailable or expired"),
+      sends: 1,
+    });
+  });
+
+  test("stores the client namespace so disabling the option cannot replay the private alias", async () => {
+    const sentBodies: string[] = [];
+    let requestIndex = 0;
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      sentBodies.push(typeof init?.body === "string" ? init.body : "");
+      requestIndex += 1;
+      const payload = requestIndex === 1
+        ? completedResponsePayload("resp-toggle-plaintext-v2")
+        : { id: "resp-after-toggle", status: "completed", output: [] };
+      return new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const first = await handleResponses(
+      collaborationRequest(),
+      config(true),
+      { model: "", provider: "" },
+    );
+    await first.text();
+    const second = await handleResponses(
+      collaborationRequest({
+        previousResponseId: "resp-toggle-plaintext-v2",
+        input: [{ type: "function_call_output", call_id: "call-spawn", output: "done" }],
+      }),
+      config(false),
+      { model: "", provider: "" },
+    );
+    await second.text();
+
+    const replay = JSON.parse(sentBodies[1]!) as { input: Array<Record<string, unknown>> };
+    const replayedCall = replay.input.find(item => item.type === "function_call");
+    expect(replayedCall?.namespace).toBe("collaboration");
+    expect(JSON.stringify(replay)).not.toContain(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+  });
+});

--- a/tests/plaintext-v2-agent-messages.test.ts
+++ b/tests/plaintext-v2-agent-messages.test.ts
@@ -81,6 +81,11 @@ describe("plaintext v2 agent message request preparation", () => {
     ]);
     expect(namespace.name).toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
     expect(additionalNamespace.name).toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(spawn.name).toBe("start_delegated_task");
+    expect(send.name).toBe("deliver_delegated_message");
+    expect(followup.name).toBe("continue_delegated_task");
+    expect(additional.name).toBe("continue_delegated_task");
+    expect(wait.name).toBe("wait_agent");
     expect(message(spawn).encrypted).toBeUndefined();
     expect(message(send).encrypted).toBeUndefined();
     expect(message(additional).encrypted).toBeUndefined();
@@ -124,6 +129,7 @@ describe("plaintext v2 agent message request preparation", () => {
     const privateMessage = ((privateTool.parameters as Record<string, unknown>).properties as Record<string, Record<string, unknown>>).message;
 
     expect(privateMessage.encrypted).toBe(true);
+    expect(privateTool.name).toBe("send_message");
   });
 
   test("does not strip an independent flat tool beside a collaboration namespace", () => {
@@ -142,6 +148,7 @@ describe("plaintext v2 agent message request preparation", () => {
     const flatTool = (prepared.body as typeof body).tools[1] as Record<string, unknown>;
     const flatMessage = ((flatTool.parameters as Record<string, unknown>).properties as Record<string, Record<string, unknown>>).message;
     expect(flatMessage.encrypted).toBe(true);
+    expect(flatTool.name).toBe("send_message");
   });
 
   test("aliases selectors and replayed calls with the rewritten collaboration catalog", () => {
@@ -179,8 +186,10 @@ describe("plaintext v2 agent message request preparation", () => {
 
     expect(result.tools[0]!.name).toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
     expect(result.tool_choice.tools[0]!.namespace).toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(result.tool_choice.tools[0]!.name).toBe("deliver_delegated_message");
     expect(result.tool_choice.tools[1]!.namespace).toBe("private_mail");
     expect(result.input[0]!.namespace).toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(result.input[0]!.name).toBe("start_delegated_task");
     expect(result.input[1]).toEqual(replayedOutput);
   });
 
@@ -197,6 +206,7 @@ describe("plaintext v2 agent message request preparation", () => {
     const prepared = preparePlaintextV2AgentMessages(body);
     expect((prepared.body as typeof body).tool_choice.namespace)
       .toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect((prepared.body as typeof body).tool_choice.name).toBe("continue_delegated_task");
   });
 
   test("aliases both supported qualified-name forms using declared child names", () => {
@@ -216,8 +226,10 @@ describe("plaintext v2 agent message request preparation", () => {
     };
 
     const result = preparePlaintextV2AgentMessages(body).body as typeof body;
-    expect(result.tool_choice.name).toBe(`${PLAINTEXT_V2_COLLABORATION_NAMESPACE}__spawn_agent`);
-    expect(result.input[0]!.name).toBe(`${PLAINTEXT_V2_COLLABORATION_NAMESPACE}.send_message`);
+    expect(result.tool_choice.name)
+      .toBe(`${PLAINTEXT_V2_COLLABORATION_NAMESPACE}__start_delegated_task`);
+    expect(result.input[0]!.name)
+      .toBe(`${PLAINTEXT_V2_COLLABORATION_NAMESPACE}.deliver_delegated_message`);
   });
 
   test("aliases every duplicate collaboration declaration in one request", () => {
@@ -302,7 +314,47 @@ describe("plaintext v2 agent message request preparation", () => {
     const prepared = preparePlaintextV2AgentMessages(body);
     expect((prepared.body as typeof body).tools[0]!.name)
       .toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect((prepared.body as typeof body).tools[0]!.tools[0]!.name)
+      .toBe("start_delegated_task");
     expect(prepared.namespaceAliased).toBe(true);
+  });
+
+  test("leaves the whole request untouched when a collaboration child already uses a private tool alias", () => {
+    const body = {
+      tools: [{
+        type: "namespace",
+        name: "collaboration",
+        tools: [
+          collaborationTool("spawn_agent"),
+          collaborationTool("start_delegated_task"),
+        ],
+      }],
+    };
+
+    const prepared = preparePlaintextV2AgentMessages(body);
+    expect(prepared.body).toBe(body);
+    expect(prepared.namespaceAliased).toBe(false);
+  });
+
+  test("leaves the whole request untouched when replay history already uses a private tool alias", () => {
+    const body = {
+      tools: [{
+        type: "namespace",
+        name: "collaboration",
+        tools: [collaborationTool("spawn_agent")],
+      }],
+      input: [{
+        type: "function_call",
+        call_id: "call-private-name",
+        namespace: "collaboration",
+        name: "start_delegated_task",
+        arguments: "{}",
+      }],
+    };
+
+    const prepared = preparePlaintextV2AgentMessages(body);
+    expect(prepared.body).toBe(body);
+    expect(prepared.namespaceAliased).toBe(false);
   });
 
   test("leaves the whole request untouched when the private alias already exists", () => {
@@ -393,18 +445,18 @@ describe("plaintext v2 agent message response restoration", () => {
         tool_choice: {
           type: "function",
           namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
-          name: "spawn_agent",
+          name: "start_delegated_task",
         },
         tools: [{
           type: "namespace",
           name: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
-          tools: [],
+          tools: [{ type: "function", name: "start_delegated_task" }],
         }],
         output: [
           {
             type: "function_call",
             namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
-            name: "spawn_agent",
+            name: "start_delegated_task",
             arguments: JSON.stringify({
               message: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
             }),
@@ -412,7 +464,7 @@ describe("plaintext v2 agent message response restoration", () => {
           },
           {
             type: "function_call",
-            name: `${PLAINTEXT_V2_COLLABORATION_NAMESPACE}__send_message`,
+            name: `${PLAINTEXT_V2_COLLABORATION_NAMESPACE}__deliver_delegated_message`,
             arguments: "{}",
             encrypted_function_args: [],
           },
@@ -444,7 +496,10 @@ describe("plaintext v2 agent message response restoration", () => {
     expect(flattened!.encrypted_function_args).toEqual([]);
     expect(toolOutput!.output).toEqual({ namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE });
     expect(restored.response.tool_choice.namespace).toBe("collaboration");
+    expect(restored.response.tool_choice.name).toBe("spawn_agent");
     expect(restored.response.tools[0]!.name).toBe("collaboration");
+    expect((restored.response.tools[0]!.tools as Array<Record<string, unknown>>)[0]!.name)
+      .toBe("spawn_agent");
   });
 
   test("restores the identity on streamed function-call argument completion", () => {
@@ -452,7 +507,7 @@ describe("plaintext v2 agent message response restoration", () => {
       type: "response.function_call_arguments.done",
       item_id: "fc-spawn",
       namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
-      name: `${PLAINTEXT_V2_COLLABORATION_NAMESPACE}__spawn_agent`,
+      name: `${PLAINTEXT_V2_COLLABORATION_NAMESPACE}__start_delegated_task`,
       arguments: JSON.stringify({ message: PLAINTEXT_V2_COLLABORATION_NAMESPACE }),
       encrypted_function_args: [],
     });
@@ -473,11 +528,26 @@ describe("plaintext v2 agent message response restoration", () => {
     }
   });
 
+  test("restores an unqualified private tool alias in streamed JSON", () => {
+    const payload = JSON.stringify({
+      type: "function_call",
+      name: "start_delegated_task",
+      arguments: JSON.stringify({ message: "plain assignment" }),
+      encrypted_function_args: [],
+    });
+
+    const restored = JSON.parse(
+      restorePlaintextV2AgentMessageCallsInJson(payload, declaredToolNames),
+    ) as Record<string, unknown>;
+    expect(restored.name).toBe("spawn_agent");
+    expect(restored.encrypted_function_args).toEqual([]);
+  });
+
   test("leaves undeclared aliases and nested extension metadata untouched", () => {
     const extensionCall = {
       type: "function_call",
       namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
-      name: "spawn_agent",
+      name: "start_delegated_task",
     };
     const payload = JSON.stringify({
       type: "response.completed",
@@ -492,7 +562,7 @@ describe("plaintext v2 agent message response restoration", () => {
           {
             type: "function_call",
             namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
-            name: "spawn_agent",
+            name: "start_delegated_task",
             arguments: "{}",
           },
         ],
@@ -523,7 +593,7 @@ describe("plaintext v2 agent message response restoration", () => {
       output: Array.from({ length: 10_001 }, () => ({
         type: "function_call",
         namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
-        name: "spawn_agent",
+        name: "start_delegated_task",
       })),
     };
     const payload = JSON.stringify(value);
@@ -604,6 +674,7 @@ describe("canonical Responses adapter plaintext v2 integration", () => {
     const message = ((spawn.parameters as Record<string, unknown>).properties as Record<string, Record<string, unknown>>).message;
 
     expect(namespace.name).toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(spawn.name).toBe("start_delegated_task");
     expect(message.encrypted).toBeUndefined();
     expect([...(request.plaintextV2AgentMessageToolNames ?? [])]).toEqual(["spawn_agent"]);
     expect(rawBody.tools[0]!.name).toBe("collaboration");

--- a/tests/plaintext-v2-agent-messages.test.ts
+++ b/tests/plaintext-v2-agent-messages.test.ts
@@ -1,0 +1,620 @@
+import { describe, expect, test } from "bun:test";
+import { createResponsesPassthroughAdapter as createResponsesPassthroughAdapterProduction } from "../src/adapters/openai-responses";
+import {
+  PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+  preparePlaintextV2AgentMessages,
+  restorePlaintextV2AgentMessageCalls,
+  restorePlaintextV2AgentMessageCallsInJson,
+  shouldPreparePlaintextV2AgentMessages,
+} from "../src/responses/plaintext-v2-agent-messages";
+import { withTestTranslatorBudget } from "./helpers/translator-budget";
+
+const createResponsesPassthroughAdapter = (...args: Parameters<typeof createResponsesPassthroughAdapterProduction>) =>
+  withTestTranslatorBudget(createResponsesPassthroughAdapterProduction(...args));
+
+function collaborationTool(name: string, encrypted: boolean = true): Record<string, unknown> {
+  return {
+    type: "function",
+    name,
+    parameters: {
+      type: "object",
+      properties: {
+        message: {
+          type: "string",
+          encrypted,
+          const: { encrypted: true },
+        },
+        encrypted: { type: "boolean" },
+      },
+      required: ["message"],
+    },
+  };
+}
+
+describe("plaintext v2 agent message request preparation", () => {
+  test("strips only the three message markers and aliases collaboration catalogs", () => {
+    const body = {
+      model: "gpt-5.6-sol",
+      tools: [{
+        type: "namespace",
+        name: "collaboration",
+        tools: [
+          collaborationTool("spawn_agent"),
+          collaborationTool("send_message"),
+          collaborationTool("followup_task", false),
+          collaborationTool("wait_agent"),
+        ],
+      }],
+      input: [{
+        type: "additional_tools",
+        tools: [{
+          type: "namespace",
+          name: "collaboration",
+          tools: [collaborationTool("followup_task")],
+        }],
+      }],
+    };
+    const before = structuredClone(body);
+
+    const prepared = preparePlaintextV2AgentMessages(body);
+    const result = prepared.body as typeof body;
+    const namespace = result.tools[0] as typeof body.tools[0];
+    const spawn = namespace.tools[0] as ReturnType<typeof collaborationTool>;
+    const send = namespace.tools[1] as ReturnType<typeof collaborationTool>;
+    const followup = namespace.tools[2] as ReturnType<typeof collaborationTool>;
+    const wait = namespace.tools[3] as ReturnType<typeof collaborationTool>;
+    const additionalNamespace = result.input[0].tools[0] as {
+      name: string;
+      tools: Array<ReturnType<typeof collaborationTool>>;
+    };
+    const additional = additionalNamespace.tools[0]!;
+    const message = (tool: Record<string, unknown>) => (
+      ((tool.parameters as Record<string, unknown>).properties as Record<string, Record<string, unknown>>).message
+    );
+
+    expect(prepared.namespaceAliased).toBe(true);
+    expect([...prepared.toolNames].sort()).toEqual([
+      "followup_task",
+      "send_message",
+      "spawn_agent",
+      "wait_agent",
+    ]);
+    expect(namespace.name).toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(additionalNamespace.name).toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(message(spawn).encrypted).toBeUndefined();
+    expect(message(send).encrypted).toBeUndefined();
+    expect(message(additional).encrypted).toBeUndefined();
+    expect(message(followup).encrypted).toBe(false);
+    expect(message(wait).encrypted).toBe(true);
+    expect(message(spawn).const).toEqual({ encrypted: true });
+    expect(((spawn.parameters as Record<string, unknown>).properties as Record<string, unknown>).encrypted)
+      .toEqual({ type: "boolean" });
+    expect(body).toEqual(before);
+  });
+
+  test("does not reinterpret a flat same-named function as the Codex v2 catalog", () => {
+    const body = { tools: [collaborationTool("spawn_agent")] };
+    const prepared = preparePlaintextV2AgentMessages(body);
+    const tool = (prepared.body as typeof body).tools[0] as Record<string, unknown>;
+    const message = ((tool.parameters as Record<string, unknown>).properties as Record<string, Record<string, unknown>>).message;
+
+    expect(message.encrypted).toBe(true);
+    expect(prepared.body).toBe(body);
+    expect(prepared.namespaceAliased).toBe(false);
+  });
+
+  test("does not strip same-named tools from another namespace", () => {
+    const body = {
+      tools: [
+        {
+          type: "namespace",
+          name: "collaboration",
+          tools: [collaborationTool("spawn_agent")],
+        },
+        {
+          type: "namespace",
+          name: "private_mail",
+          tools: [collaborationTool("send_message")],
+        },
+      ],
+    };
+
+    const prepared = preparePlaintextV2AgentMessages(body);
+    const privateTool = (prepared.body as typeof body).tools[1]!.tools[0] as Record<string, unknown>;
+    const privateMessage = ((privateTool.parameters as Record<string, unknown>).properties as Record<string, Record<string, unknown>>).message;
+
+    expect(privateMessage.encrypted).toBe(true);
+  });
+
+  test("does not strip an independent flat tool beside a collaboration namespace", () => {
+    const body = {
+      tools: [
+        {
+          type: "namespace",
+          name: "collaboration",
+          tools: [collaborationTool("spawn_agent")],
+        },
+        collaborationTool("send_message"),
+      ],
+    };
+
+    const prepared = preparePlaintextV2AgentMessages(body);
+    const flatTool = (prepared.body as typeof body).tools[1] as Record<string, unknown>;
+    const flatMessage = ((flatTool.parameters as Record<string, unknown>).properties as Record<string, Record<string, unknown>>).message;
+    expect(flatMessage.encrypted).toBe(true);
+  });
+
+  test("aliases selectors and replayed calls with the rewritten collaboration catalog", () => {
+    const replayedCall = {
+      type: "function_call",
+      call_id: "call-old",
+      namespace: "collaboration",
+      name: "spawn_agent",
+      arguments: "{}",
+    };
+    const replayedOutput = {
+      type: "function_call_output",
+      call_id: "call-old",
+      output: { namespace: "collaboration" },
+    };
+    const body = {
+      tools: [{
+        type: "namespace",
+        name: "collaboration",
+        tools: [collaborationTool("spawn_agent"), collaborationTool("send_message")],
+      }],
+      tool_choice: {
+        type: "allowed_tools",
+        mode: "required",
+        tools: [
+          { type: "function", namespace: "collaboration", name: "send_message" },
+          { type: "function", namespace: "private_mail", name: "send_message" },
+        ],
+      },
+      input: [replayedCall, replayedOutput],
+    };
+
+    const prepared = preparePlaintextV2AgentMessages(body);
+    const result = prepared.body as typeof body;
+
+    expect(result.tools[0]!.name).toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(result.tool_choice.tools[0]!.namespace).toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(result.tool_choice.tools[1]!.namespace).toBe("private_mail");
+    expect(result.input[0]!.namespace).toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(result.input[1]).toEqual(replayedOutput);
+  });
+
+  test("aliases a forced collaboration tool choice", () => {
+    const body = {
+      tools: [{
+        type: "namespace",
+        name: "collaboration",
+        tools: [collaborationTool("spawn_agent"), collaborationTool("followup_task")],
+      }],
+      tool_choice: { type: "function", namespace: "collaboration", name: "followup_task" },
+    };
+
+    const prepared = preparePlaintextV2AgentMessages(body);
+    expect((prepared.body as typeof body).tool_choice.namespace)
+      .toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+  });
+
+  test("aliases both supported qualified-name forms using declared child names", () => {
+    const body = {
+      tools: [{
+        type: "namespace",
+        name: "collaboration",
+        tools: [collaborationTool("spawn_agent"), collaborationTool("send_message")],
+      }],
+      tool_choice: { type: "function", name: "collaboration__spawn_agent" },
+      input: [{
+        type: "function_call",
+        call_id: "call-send",
+        name: "collaboration.send_message",
+        arguments: "{}",
+      }],
+    };
+
+    const result = preparePlaintextV2AgentMessages(body).body as typeof body;
+    expect(result.tool_choice.name).toBe(`${PLAINTEXT_V2_COLLABORATION_NAMESPACE}__spawn_agent`);
+    expect(result.input[0]!.name).toBe(`${PLAINTEXT_V2_COLLABORATION_NAMESPACE}.send_message`);
+  });
+
+  test("aliases every duplicate collaboration declaration in one request", () => {
+    const body = {
+      tools: [
+        {
+          type: "namespace",
+          name: "collaboration",
+          tools: [collaborationTool("spawn_agent")],
+        },
+        {
+          type: "namespace",
+          name: "collaboration",
+          tools: [{ type: "function", name: "wait_agent", parameters: { type: "object" } }],
+        },
+      ],
+      tool_choice: { type: "function", namespace: "collaboration", name: "wait_agent" },
+    };
+
+    const result = preparePlaintextV2AgentMessages(body).body as typeof body;
+    expect(result.tools.map(tool => tool.name)).toEqual([
+      PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+      PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+    ]);
+    expect(result.tool_choice.namespace).toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+  });
+
+  test("does not reinterpret an independent flattened-looking tool name", () => {
+    const body = {
+      tools: [
+        {
+          type: "namespace",
+          name: "collaboration",
+          tools: [collaborationTool("spawn_agent")],
+        },
+        { type: "function", name: "collaboration__audit", parameters: { type: "object" } },
+      ],
+      tool_choice: {
+        type: "allowed_tools",
+        tools: [{ type: "function", name: "collaboration__audit" }],
+      },
+      input: [{
+        type: "function_call",
+        call_id: "call-audit",
+        name: "collaboration__audit",
+        arguments: "{}",
+      }],
+    };
+
+    const prepared = preparePlaintextV2AgentMessages(body);
+    const result = prepared.body as typeof body;
+    expect(result.tool_choice.tools[0]!.name).toBe("collaboration__audit");
+    expect(result.input[0]!.name).toBe("collaboration__audit");
+  });
+
+  test("skips aliasing when a flat declaration collides with a namespace child", () => {
+    const body = {
+      tools: [
+        {
+          type: "namespace",
+          name: "collaboration",
+          tools: [collaborationTool("spawn_agent")],
+        },
+        { type: "function", name: "collaboration__spawn_agent", parameters: { type: "object" } },
+      ],
+    };
+
+    const prepared = preparePlaintextV2AgentMessages(body);
+    expect(prepared.body).toBe(body);
+    expect(prepared.namespaceAliased).toBe(false);
+  });
+
+  test("aliases a recognized collaboration catalog even when the marker is already absent", () => {
+    const body = {
+      tools: [{
+        type: "namespace",
+        name: "collaboration",
+        tools: [collaborationTool("spawn_agent", false)],
+      }],
+    };
+
+    const prepared = preparePlaintextV2AgentMessages(body);
+    expect((prepared.body as typeof body).tools[0]!.name)
+      .toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(prepared.namespaceAliased).toBe(true);
+  });
+
+  test("leaves the whole request untouched when the private alias already exists", () => {
+    const body = {
+      tools: [
+        { type: "namespace", name: PLAINTEXT_V2_COLLABORATION_NAMESPACE, tools: [] },
+        {
+          type: "namespace",
+          name: "collaboration",
+          tools: [collaborationTool("spawn_agent")],
+        },
+      ],
+    };
+
+    const prepared = preparePlaintextV2AgentMessages(body);
+    expect(prepared.body).toBe(body);
+    expect(prepared.namespaceAliased).toBe(false);
+    expect(JSON.stringify(prepared.body)).toContain('"encrypted":true');
+  });
+
+  test("leaves the request untouched when replay history already uses the private alias", () => {
+    const body = {
+      tools: [{
+        type: "namespace",
+        name: "collaboration",
+        tools: [collaborationTool("spawn_agent")],
+      }],
+      input: [{
+        type: "function_call",
+        call_id: "call-private",
+        namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+        name: "audit",
+        arguments: "{}",
+      }],
+    };
+
+    const prepared = preparePlaintextV2AgentMessages(body);
+    expect(prepared.body).toBe(body);
+    expect(prepared.namespaceAliased).toBe(false);
+  });
+
+  test("leaves the request untouched when tool-search history declares the private alias", () => {
+    const body = {
+      tools: [{
+        type: "namespace",
+        name: "collaboration",
+        tools: [collaborationTool("spawn_agent")],
+      }],
+      input: [{
+        type: "tool_search_output",
+        tools: [{
+          type: "namespace",
+          name: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+          tools: [],
+        }],
+      }],
+    };
+
+    const prepared = preparePlaintextV2AgentMessages(body);
+    expect(prepared.body).toBe(body);
+    expect(prepared.namespaceAliased).toBe(false);
+  });
+
+  test("does not treat a collaboration namespace nested under another namespace as Codex v2", () => {
+    const depth = 20_000;
+    const collaboration = {
+      type: "namespace",
+      name: "collaboration",
+      tools: [collaborationTool("spawn_agent")],
+    } as Record<string, unknown>;
+    let root: Record<string, unknown> = collaboration;
+    for (let index = 0; index < depth; index++) {
+      root = { type: "namespace", name: `nest-${index}`, tools: [root] };
+    }
+
+    const prepared = preparePlaintextV2AgentMessages({ tools: [root] });
+    expect(prepared.namespaceAliased).toBe(false);
+  });
+});
+
+describe("plaintext v2 agent message response restoration", () => {
+  const declaredToolNames = new Set(["spawn_agent", "send_message"]);
+
+  test("restores tool identities and preserves the plaintext proof and user data", () => {
+    const payload = JSON.stringify({
+      type: "response.completed",
+      response: {
+        tool_choice: {
+          type: "function",
+          namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+          name: "spawn_agent",
+        },
+        tools: [{
+          type: "namespace",
+          name: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+          tools: [],
+        }],
+        output: [
+          {
+            type: "function_call",
+            namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+            name: "spawn_agent",
+            arguments: JSON.stringify({
+              message: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+            }),
+            encrypted_function_args: [],
+          },
+          {
+            type: "function_call",
+            name: `${PLAINTEXT_V2_COLLABORATION_NAMESPACE}__send_message`,
+            arguments: "{}",
+            encrypted_function_args: [],
+          },
+          {
+            type: "function_call_output",
+            output: { namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE },
+          },
+        ],
+      },
+    });
+
+    const restored = JSON.parse(
+      restorePlaintextV2AgentMessageCallsInJson(payload, declaredToolNames),
+    ) as {
+      response: {
+        tool_choice: Record<string, unknown>;
+        tools: Array<Record<string, unknown>>;
+        output: Array<Record<string, unknown>>;
+      };
+    };
+    const [namespaced, flattened, toolOutput] = restored.response.output;
+
+    expect(namespaced!.namespace).toBe("collaboration");
+    expect(namespaced!.name).toBe("spawn_agent");
+    expect(namespaced!.encrypted_function_args).toEqual([]);
+    expect(JSON.parse(namespaced!.arguments as string).message)
+      .toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(flattened!.name).toBe("collaboration__send_message");
+    expect(flattened!.encrypted_function_args).toEqual([]);
+    expect(toolOutput!.output).toEqual({ namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE });
+    expect(restored.response.tool_choice.namespace).toBe("collaboration");
+    expect(restored.response.tools[0]!.name).toBe("collaboration");
+  });
+
+  test("restores the identity on streamed function-call argument completion", () => {
+    const payload = JSON.stringify({
+      type: "response.function_call_arguments.done",
+      item_id: "fc-spawn",
+      namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+      name: `${PLAINTEXT_V2_COLLABORATION_NAMESPACE}__spawn_agent`,
+      arguments: JSON.stringify({ message: PLAINTEXT_V2_COLLABORATION_NAMESPACE }),
+      encrypted_function_args: [],
+    });
+
+    const restored = JSON.parse(
+      restorePlaintextV2AgentMessageCallsInJson(payload, declaredToolNames),
+    ) as Record<string, unknown>;
+    expect(restored.namespace).toBe("collaboration");
+    expect(restored.name).toBe("collaboration__spawn_agent");
+    expect(JSON.parse(restored.arguments as string).message)
+      .toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(restored.encrypted_function_args).toEqual([]);
+  });
+
+  test("is byte-identical for invalid JSON and payloads without the private alias", () => {
+    for (const payload of ["not json", '{"type":"response.completed"}']) {
+      expect(restorePlaintextV2AgentMessageCallsInJson(payload, declaredToolNames)).toBe(payload);
+    }
+  });
+
+  test("leaves undeclared aliases and nested extension metadata untouched", () => {
+    const extensionCall = {
+      type: "function_call",
+      namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+      name: "spawn_agent",
+    };
+    const payload = JSON.stringify({
+      type: "response.completed",
+      response: {
+        output: [
+          {
+            type: "function_call",
+            namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+            name: "audit",
+            arguments: "{}",
+          },
+          {
+            type: "function_call",
+            namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+            name: "spawn_agent",
+            arguments: "{}",
+          },
+        ],
+        metadata: {
+          nested: extensionCall,
+          values: Array.from({ length: 20_000 }, (_, index) => index),
+        },
+      },
+    });
+
+    const restored = JSON.parse(
+      restorePlaintextV2AgentMessageCallsInJson(payload, declaredToolNames),
+    ) as {
+      response: {
+        output: Array<Record<string, unknown>>;
+        metadata: { nested: Record<string, unknown>; values: number[] };
+      };
+    };
+
+    expect(restored.response.output[0]!.namespace).toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(restored.response.output[1]!.namespace).toBe("collaboration");
+    expect(restored.response.metadata.nested).toEqual(extensionCall);
+    expect(restored.response.metadata.values).toHaveLength(20_000);
+  });
+
+  test("fails closed when known identity arrays exceed the work limit", () => {
+    const value = {
+      output: Array.from({ length: 10_001 }, () => ({
+        type: "function_call",
+        namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+        name: "spawn_agent",
+      })),
+    };
+    const payload = JSON.stringify(value);
+
+    expect(restorePlaintextV2AgentMessageCallsInJson(payload, declaredToolNames)).toBe(payload);
+    expect(restorePlaintextV2AgentMessageCalls(value, declaredToolNames)).toEqual({
+      value,
+      changed: false,
+      overflowed: true,
+    });
+  });
+});
+
+describe("plaintext v2 agent message route policy", () => {
+  test("requires an explicit opt-in, Responses inbound, canonical ChatGPT, and a v2 catalog", () => {
+    const requestBody = {
+      input: [{
+        type: "additional_tools",
+        tools: [{
+          type: "namespace",
+          name: "collaboration",
+          tools: [collaborationTool("spawn_agent")],
+        }],
+      }],
+    };
+    const baseline = {
+      enabled: true,
+      inboundWire: "responses",
+      canonicalChatGpt: true,
+      requestBody,
+    };
+    expect(shouldPreparePlaintextV2AgentMessages(baseline)).toBe(true);
+    expect(shouldPreparePlaintextV2AgentMessages({ ...baseline, enabled: false })).toBe(false);
+    expect(shouldPreparePlaintextV2AgentMessages({ ...baseline, inboundWire: "anthropic" })).toBe(false);
+    expect(shouldPreparePlaintextV2AgentMessages({ ...baseline, canonicalChatGpt: false })).toBe(false);
+    expect(shouldPreparePlaintextV2AgentMessages({
+      ...baseline,
+      requestBody: { tools: [collaborationTool("spawn_agent")] },
+    })).toBe(false);
+  });
+});
+
+describe("canonical Responses adapter plaintext v2 integration", () => {
+  const provider = {
+    adapter: "openai-responses",
+    baseUrl: "https://chatgpt.com/backend-api/codex",
+    authMode: "forward" as const,
+  };
+
+  function build(enabled: boolean) {
+    const rawBody = {
+      model: "gpt-5.6-sol",
+      store: false,
+      stream: true,
+      input: "delegate",
+      tools: [{
+        type: "namespace",
+        name: "collaboration",
+        tools: [collaborationTool("spawn_agent")],
+      }],
+    };
+    const request = createResponsesPassthroughAdapter(provider).buildRequest({
+      modelId: "gpt-5.6-sol",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: rawBody,
+      ...(enabled ? { _plaintextV2AgentMessages: true } : {}),
+    }, { headers: new Headers({ authorization: "Bearer test" }) });
+    return { request, rawBody };
+  }
+
+  test("changes only the serialized upstream body when enabled", () => {
+    const { request, rawBody } = build(true);
+    const sent = JSON.parse(request.body) as typeof rawBody;
+    const namespace = sent.tools[0]!;
+    const spawn = namespace.tools[0] as Record<string, unknown>;
+    const message = ((spawn.parameters as Record<string, unknown>).properties as Record<string, Record<string, unknown>>).message;
+
+    expect(namespace.name).toBe(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(message.encrypted).toBeUndefined();
+    expect([...(request.plaintextV2AgentMessageToolNames ?? [])]).toEqual(["spawn_agent"]);
+    expect(rawBody.tools[0]!.name).toBe("collaboration");
+    expect(JSON.stringify(rawBody)).toContain('"encrypted":true');
+  });
+
+  test("keeps the upstream collaboration schema unchanged when disabled", () => {
+    const { request, rawBody } = build(false);
+    const sent = JSON.parse(request.body);
+
+    expect(sent).toEqual(rawBody);
+    expect(request.plaintextV2AgentMessageToolNames).toBeUndefined();
+  });
+});

--- a/tests/plaintext-v2-agent-messages.test.ts
+++ b/tests/plaintext-v2-agent-messages.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { createResponsesPassthroughAdapter as createResponsesPassthroughAdapterProduction } from "../src/adapters/openai-responses";
 import {
+  PlaintextV2AgentMessageRestoreOverflowError,
   PLAINTEXT_V2_COLLABORATION_NAMESPACE,
   preparePlaintextV2AgentMessages,
   restorePlaintextV2AgentMessageCalls,
   restorePlaintextV2AgentMessageCallsInJson,
+  restorePlaintextV2AgentMessageCallsInJsonResult,
   shouldPreparePlaintextV2AgentMessages,
 } from "../src/responses/plaintext-v2-agent-messages";
 import { withTestTranslatorBudget } from "./helpers/translator-budget";
@@ -336,6 +338,82 @@ describe("plaintext v2 agent message request preparation", () => {
     expect(prepared.namespaceAliased).toBe(false);
   });
 
+  test("leaves the whole request untouched when a top-level tool uses a fixed message alias", () => {
+    const body = {
+      tools: [
+        {
+          type: "namespace",
+          name: "collaboration",
+          tools: [collaborationTool("spawn_agent")],
+        },
+        { type: "function", name: "start_delegated_task", parameters: { type: "object" } },
+      ],
+    };
+
+    const prepared = preparePlaintextV2AgentMessages(body);
+    expect(prepared.body).toBe(body);
+    expect(prepared.namespaceAliased).toBe(false);
+  });
+
+  test("leaves the whole request untouched when another namespace uses a fixed message alias", () => {
+    const body = {
+      tools: [{
+        type: "namespace",
+        name: "collaboration",
+        tools: [collaborationTool("spawn_agent")],
+      }],
+      input: [{
+        type: "additional_tools",
+        tools: [{
+          type: "namespace",
+          name: "foreign",
+          tools: [{ type: "function", name: "deliver_delegated_message", parameters: { type: "object" } }],
+        }],
+      }],
+    };
+
+    const prepared = preparePlaintextV2AgentMessages(body);
+    expect(prepared.body).toBe(body);
+    expect(prepared.namespaceAliased).toBe(false);
+  });
+
+  test("scans tool-search declarations and foreign references for fixed message aliases", () => {
+    const catalog = [{
+      type: "namespace",
+      name: "collaboration",
+      tools: [collaborationTool("spawn_agent")],
+    }];
+    const cases = [
+      {
+        tools: catalog,
+        input: [{
+          type: "tool_search_output",
+          tools: [{ type: "function", name: "continue_delegated_task", parameters: { type: "object" } }],
+        }],
+      },
+      {
+        tools: catalog,
+        tool_choice: { type: "function", name: "start_delegated_task" },
+      },
+      {
+        tools: catalog,
+        input: [{
+          type: "function_call",
+          namespace: "foreign",
+          name: "deliver_delegated_message",
+          call_id: "foreign-call",
+          arguments: "{}",
+        }],
+      },
+    ];
+
+    for (const body of cases) {
+      const prepared = preparePlaintextV2AgentMessages(body);
+      expect(prepared.body).toBe(body);
+      expect(prepared.namespaceAliased).toBe(false);
+    }
+  });
+
   test("leaves the whole request untouched when replay history already uses a private tool alias", () => {
     const body = {
       tools: [{
@@ -543,6 +621,42 @@ describe("plaintext v2 agent message response restoration", () => {
     expect(restored.encrypted_function_args).toEqual([]);
   });
 
+  test("does not restore a fixed alias authenticated by another namespace", () => {
+    const payload = JSON.stringify({
+      type: "function_call",
+      namespace: "foreign",
+      name: "start_delegated_task",
+      arguments: "{}",
+    });
+
+    expect(restorePlaintextV2AgentMessageCallsInJson(payload, declaredToolNames)).toBe(payload);
+  });
+
+  test("restores only message aliases that this request actually generated", () => {
+    const prepared = preparePlaintextV2AgentMessages({
+      tools: [{
+        type: "namespace",
+        name: "collaboration",
+        tools: [
+          collaborationTool("spawn_agent"),
+          { type: "custom", name: "send_message" },
+        ],
+      }],
+    });
+    const payload = JSON.stringify({
+      type: "function_call",
+      name: "deliver_delegated_message",
+      arguments: "{}",
+    });
+
+    expect([...prepared.aliasedAgentMessageToolNames]).toEqual(["spawn_agent"]);
+    expect(restorePlaintextV2AgentMessageCallsInJson(
+      payload,
+      prepared.toolNames,
+      prepared.aliasedAgentMessageToolNames,
+    )).toBe(payload);
+  });
+
   test("leaves undeclared aliases and nested extension metadata untouched", () => {
     const extensionCall = {
       type: "function_call",
@@ -598,7 +712,13 @@ describe("plaintext v2 agent message response restoration", () => {
     };
     const payload = JSON.stringify(value);
 
-    expect(restorePlaintextV2AgentMessageCallsInJson(payload, declaredToolNames)).toBe(payload);
+    expect(restorePlaintextV2AgentMessageCallsInJsonResult(payload, declaredToolNames)).toEqual({
+      value: payload,
+      changed: false,
+      overflowed: true,
+    });
+    expect(() => restorePlaintextV2AgentMessageCallsInJson(payload, declaredToolNames))
+      .toThrow(PlaintextV2AgentMessageRestoreOverflowError);
     expect(restorePlaintextV2AgentMessageCalls(value, declaredToolNames)).toEqual({
       value,
       changed: false,
@@ -677,6 +797,7 @@ describe("canonical Responses adapter plaintext v2 integration", () => {
     expect(spawn.name).toBe("start_delegated_task");
     expect(message.encrypted).toBeUndefined();
     expect([...(request.plaintextV2AgentMessageToolNames ?? [])]).toEqual(["spawn_agent"]);
+    expect([...(request.plaintextV2AgentMessageAliasedToolNames ?? [])]).toEqual(["spawn_agent"]);
     expect(rawBody.tools[0]!.name).toBe("collaboration");
     expect(JSON.stringify(rawBody)).toContain('"encrypted":true');
   });
@@ -687,5 +808,6 @@ describe("canonical Responses adapter plaintext v2 integration", () => {
 
     expect(sent).toEqual(rawBody);
     expect(request.plaintextV2AgentMessageToolNames).toBeUndefined();
+    expect(request.plaintextV2AgentMessageAliasedToolNames).toBeUndefined();
   });
 });

--- a/tests/ws-upstream.test.ts
+++ b/tests/ws-upstream.test.ts
@@ -288,6 +288,152 @@ describe("handleResponses Codex WS relay selection", () => {
     expect(text).toContain("data: [DONE]");
   });
 
+  test("plaintext v2 collaboration rewriting applies to WS requests and responses", async () => {
+    installFake(ws => {
+      ws.emit("open", {});
+      ws.emit("message", {
+        data: JSON.stringify({
+          type: "response.created",
+          response: {
+            id: "r-plaintext-v2-ws",
+            object: "response",
+            status: "in_progress",
+            output: [],
+          },
+        }),
+      });
+      ws.emit("message", {
+        data: JSON.stringify({
+          type: "response.output_item.added",
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_spawn",
+            call_id: "call-spawn",
+            namespace: "collaboration-optimize",
+            name: "spawn_agent",
+            arguments: "",
+            encrypted_function_args: [],
+            status: "in_progress",
+          },
+        }),
+      });
+      ws.emit("message", {
+        data: JSON.stringify({
+          type: "response.function_call_arguments.done",
+          item_id: "fc_spawn",
+          output_index: 0,
+          namespace: "collaboration-optimize",
+          name: "collaboration-optimize__spawn_agent",
+          arguments: JSON.stringify({ message: "plain WS assignment" }),
+          encrypted_function_args: [],
+        }),
+      });
+      ws.emit("message", {
+        data: JSON.stringify({
+          type: "response.output_item.done",
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_spawn",
+            call_id: "call-spawn",
+            namespace: "collaboration-optimize",
+            name: "spawn_agent",
+            arguments: JSON.stringify({ message: "plain WS assignment" }),
+            encrypted_function_args: [],
+            status: "completed",
+          },
+        }),
+      });
+      ws.emit("message", {
+        data: JSON.stringify({
+          type: "response.completed",
+          response: {
+            id: "r-plaintext-v2-ws",
+            status: "completed",
+            output: [{
+              type: "function_call",
+              id: "fc_spawn",
+              call_id: "call-spawn",
+              namespace: "collaboration-optimize",
+              name: "spawn_agent",
+              arguments: JSON.stringify({ message: "plain WS assignment" }),
+              encrypted_function_args: [],
+              status: "completed",
+            }],
+          },
+        }),
+      });
+    });
+    const config = { ...forwardConfig(), plaintextV2AgentMessages: true } as OcxConfig;
+    const request = new Request("http://localhost/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer test" },
+      body: JSON.stringify({
+        model: "gpt-5.6-luna",
+        stream: true,
+        input: [
+          {
+            type: "additional_tools",
+            tools: [{
+              type: "namespace",
+              name: "collaboration",
+              tools: [
+                {
+                  type: "function",
+                  name: "spawn_agent",
+                  parameters: {
+                    type: "object",
+                    properties: { message: { type: "string", encrypted: true } },
+                  },
+                },
+                { type: "function", name: "send_message", parameters: { type: "object" } },
+              ],
+            }],
+          },
+          { type: "message", role: "user", content: [{ type: "input_text", text: "delegate" }] },
+        ],
+      }),
+    });
+
+    const response = await handleResponses(request, config, { model: "", provider: "" }, {
+      codexWsRuntimeIdentity: BOUNDED_WS_RUNTIME,
+    });
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    const frame = JSON.parse(FakeWebSocket.instances[0]!.sent[0]!) as {
+      type: string;
+      stream?: unknown;
+      input: Array<Record<string, unknown>>;
+    };
+    const additionalTools = frame.input.find(item => item.type === "additional_tools") as {
+      tools: Array<{
+        name: string;
+        tools: Array<{ parameters: { properties: { message: Record<string, unknown> } } }>;
+      }>;
+    };
+    expect(frame.type).toBe("response.create");
+    expect(frame.stream).toBeUndefined();
+    expect(additionalTools.tools[0]!.name).toBe("collaboration-optimize");
+    expect(additionalTools.tools[0]!.tools[0]!.parameters.properties.message.encrypted).toBeUndefined();
+
+    expect(isEagerRelaySseResponse(response)).toBe(true);
+    const clientText = await response.text();
+    expect(clientText).toContain("response.function_call_arguments.done");
+    const argumentDoneLine = clientText.split("\n")
+      .find(line => line.includes('"response.function_call_arguments.done"'))!;
+    const argumentDone = JSON.parse(argumentDoneLine.replace(/^data: /, "")) as Record<string, unknown>;
+    expect(argumentDone.namespace).toBe("collaboration");
+    expect(argumentDone.name).toBe("collaboration__spawn_agent");
+    expect(argumentDone.encrypted_function_args).toEqual([]);
+    const completedLine = clientText.split("\n")
+      .find(line => line.includes('"response.completed"'))!;
+    const completed = JSON.parse(completedLine.replace(/^data: /, "")) as {
+      response: { output: Array<Record<string, unknown>> };
+    };
+    expect(completed.response.output[0]!.namespace).toBe("collaboration");
+    expect(completed.response.output[0]!.encrypted_function_args).toEqual([]);
+  });
+
   test("an HTTP fallback remains on the configured legacy tee path", async () => {
     installFake(ws => ws.close());
     globalThis.fetch = (async () => new Response(

--- a/tests/ws-upstream.test.ts
+++ b/tests/ws-upstream.test.ts
@@ -311,7 +311,7 @@ describe("handleResponses Codex WS relay selection", () => {
             id: "fc_spawn",
             call_id: "call-spawn",
             namespace: "collaboration-optimize",
-            name: "spawn_agent",
+            name: "start_delegated_task",
             arguments: "",
             encrypted_function_args: [],
             status: "in_progress",
@@ -324,7 +324,7 @@ describe("handleResponses Codex WS relay selection", () => {
           item_id: "fc_spawn",
           output_index: 0,
           namespace: "collaboration-optimize",
-          name: "collaboration-optimize__spawn_agent",
+          name: "collaboration-optimize__start_delegated_task",
           arguments: JSON.stringify({ message: "plain WS assignment" }),
           encrypted_function_args: [],
         }),
@@ -338,7 +338,7 @@ describe("handleResponses Codex WS relay selection", () => {
             id: "fc_spawn",
             call_id: "call-spawn",
             namespace: "collaboration-optimize",
-            name: "spawn_agent",
+            name: "start_delegated_task",
             arguments: JSON.stringify({ message: "plain WS assignment" }),
             encrypted_function_args: [],
             status: "completed",
@@ -356,7 +356,7 @@ describe("handleResponses Codex WS relay selection", () => {
               id: "fc_spawn",
               call_id: "call-spawn",
               namespace: "collaboration-optimize",
-              name: "spawn_agent",
+              name: "start_delegated_task",
               arguments: JSON.stringify({ message: "plain WS assignment" }),
               encrypted_function_args: [],
               status: "completed",
@@ -408,12 +408,16 @@ describe("handleResponses Codex WS relay selection", () => {
     const additionalTools = frame.input.find(item => item.type === "additional_tools") as {
       tools: Array<{
         name: string;
-        tools: Array<{ parameters: { properties: { message: Record<string, unknown> } } }>;
+        tools: Array<{
+          name: string;
+          parameters: { properties: { message: Record<string, unknown> } };
+        }>;
       }>;
     };
     expect(frame.type).toBe("response.create");
     expect(frame.stream).toBeUndefined();
     expect(additionalTools.tools[0]!.name).toBe("collaboration-optimize");
+    expect(additionalTools.tools[0]!.tools[0]!.name).toBe("start_delegated_task");
     expect(additionalTools.tools[0]!.tools[0]!.parameters.properties.message.encrypted).toBeUndefined();
 
     expect(isEagerRelaySseResponse(response)).toBe(true);
@@ -431,6 +435,7 @@ describe("handleResponses Codex WS relay selection", () => {
       response: { output: Array<Record<string, unknown>> };
     };
     expect(completed.response.output[0]!.namespace).toBe("collaboration");
+    expect(completed.response.output[0]!.name).toBe("spawn_agent");
     expect(completed.response.output[0]!.encrypted_function_args).toEqual([]);
   });
 

--- a/tests/ws-upstream.test.ts
+++ b/tests/ws-upstream.test.ts
@@ -4,6 +4,10 @@ import { handleResponses } from "../src/server/responses";
 import { isEagerRelaySseResponse } from "../src/server/relay";
 import { isWin32EagerRewrite } from "../src/lib/bun-stream-caps";
 import {
+  PLAINTEXT_V2_AGENT_MESSAGE_RESTORE_OVERFLOW_MESSAGE,
+  PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+} from "../src/responses/plaintext-v2-agent-messages";
+import {
   bunSupportsBoundedCodexWsRelay,
   CODEX_WS_CREATE_FRAME_LIMIT_BYTES,
   codexWsCreateFrameExceedsLimit,
@@ -268,6 +272,38 @@ describe("handleResponses Codex WS relay selection", () => {
     });
   }
 
+  function plaintextV2CollaborationRequest(): Request {
+    return new Request("http://localhost/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer test" },
+      body: JSON.stringify({
+        model: "gpt-5.5",
+        stream: true,
+        input: [
+          {
+            type: "additional_tools",
+            tools: [{
+              type: "namespace",
+              name: "collaboration",
+              tools: [
+                {
+                  type: "function",
+                  name: "spawn_agent",
+                  parameters: {
+                    type: "object",
+                    properties: { message: { type: "string", encrypted: true } },
+                  },
+                },
+                { type: "function", name: "send_message", parameters: { type: "object" } },
+              ],
+            }],
+          },
+          { type: "message", role: "user", content: [{ type: "input_text", text: "delegate" }] },
+        ],
+      }),
+    });
+  }
+
   test("a successful WS upgrade bypasses the configured legacy tee path", async () => {
     installFake(ws => {
       ws.emit("open", {});
@@ -366,35 +402,7 @@ describe("handleResponses Codex WS relay selection", () => {
       });
     });
     const config = { ...forwardConfig(), plaintextV2AgentMessages: true } as OcxConfig;
-    const request = new Request("http://localhost/v1/responses", {
-      method: "POST",
-      headers: { "content-type": "application/json", authorization: "Bearer test" },
-      body: JSON.stringify({
-        model: "gpt-5.6-luna",
-        stream: true,
-        input: [
-          {
-            type: "additional_tools",
-            tools: [{
-              type: "namespace",
-              name: "collaboration",
-              tools: [
-                {
-                  type: "function",
-                  name: "spawn_agent",
-                  parameters: {
-                    type: "object",
-                    properties: { message: { type: "string", encrypted: true } },
-                  },
-                },
-                { type: "function", name: "send_message", parameters: { type: "object" } },
-              ],
-            }],
-          },
-          { type: "message", role: "user", content: [{ type: "input_text", text: "delegate" }] },
-        ],
-      }),
-    });
+    const request = plaintextV2CollaborationRequest();
 
     const response = await handleResponses(request, config, { model: "", provider: "" }, {
       codexWsRuntimeIdentity: BOUNDED_WS_RUNTIME,
@@ -437,6 +445,46 @@ describe("handleResponses Codex WS relay selection", () => {
     expect(completed.response.output[0]!.namespace).toBe("collaboration");
     expect(completed.response.output[0]!.name).toBe("spawn_agent");
     expect(completed.response.output[0]!.encrypted_function_args).toEqual([]);
+  });
+
+  test("plaintext v2 restoration overflow fails closed on the WS upstream path", async () => {
+    installFake(ws => {
+      ws.emit("open", {});
+      ws.emit("message", {
+        data: JSON.stringify({
+          type: "response.completed",
+          response: {
+            id: "r-plaintext-v2-ws-overflow",
+            status: "completed",
+            output: Array.from({ length: 10_000 }, (_, index) => ({
+              type: "function_call",
+              call_id: `call-${index}`,
+              namespace: PLAINTEXT_V2_COLLABORATION_NAMESPACE,
+              name: "start_delegated_task",
+              arguments: "{}",
+            })),
+          },
+        }),
+      });
+    });
+    const config = { ...forwardConfig(), plaintextV2AgentMessages: true } as OcxConfig;
+
+    const response = await handleResponses(
+      plaintextV2CollaborationRequest(),
+      config,
+      { model: "", provider: "" },
+      { codexWsRuntimeIdentity: BOUNDED_WS_RUNTIME },
+    );
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(isEagerRelaySseResponse(response)).toBe(true);
+    const clientText = await response.text();
+    expect(clientText).toContain("event: response.failed");
+    expect(clientText).toContain(PLAINTEXT_V2_AGENT_MESSAGE_RESTORE_OVERFLOW_MESSAGE);
+    expect(clientText).toContain("data: [DONE]");
+    expect(clientText).not.toContain(PLAINTEXT_V2_COLLABORATION_NAMESPACE);
+    expect(clientText).not.toContain("start_delegated_task");
+    expect(FakeWebSocket.instances[0]!.closed).toBe(true);
   });
 
   test("an HTTP fallback remains on the configured legacy tee path", async () => {


### PR DESCRIPTION
## Summary

- Add the experimental `plaintextV2AgentMessages` configuration field. A fresh config leaves the field unset, and the path runs only when the operator explicitly sets it to `true`.
- Limit request rewriting to a Responses-wire caller whose final destination uses `adapter: "openai-responses"`, `authMode: "forward"`, and `https://chatgpt.com/backend-api/codex`.
- For an eligible top-level MultiAgentV2 `collaboration` catalog, replace the namespace and the reserved `spawn_agent`, `send_message`, and `followup_task` function names with fixed request-scoped aliases. Remove only `parameters.properties.message.encrypted: true` from those three declarations.
- Refuse the rewrite when any fixed alias is already declared or referenced at the top level, in another namespace, in `additional_tools`, in tool-search results, in tool choices, or in replay history.
- Restore only aliases that the request actually generated. Foreign namespaces retain their original identities. JSON, SSE, upstream WebSocket, retry, snapshot repair, and continuation paths use the same request-scoped restoration metadata.
- Fail safely when restoration exceeds the 10,000-identity limit. Bounded JSON returns HTTP 502, streams emit `response.failed`, private aliases are not sent to Codex, and the refused response is not retained for `previous_response_id`.
- Document the exact transport boundary, unset default, collision rules, failure behavior, plaintext-retention risk, and dependence on undocumented ChatGPT and Codex behavior in English and Simplified Chinese.

Addresses #2495.

### Scope and compatibility

OpenAI API-key providers, custom OpenAI-compatible gateways, routes whose final destination is another provider, Anthropic-protocol callers, V1 tools, custom collaboration namespaces, and disabled configurations remain unchanged. The option adds no recovery request and does not decrypt an existing task. HTTPS still protects transport, but the rewritten task text may remain in Codex history, OpenCodex response state or debug files, and the selected child provider.

The implementation was checked against Codex CLI `0.149.1`. That version retains the six-tool default collaboration catalog, the three encrypted message fields, and the `encrypted_function_args: []` plaintext receiving rule. These fields do not have a public compatibility promise.

### Review 5058244495

- Restoration overflow now stops every client delivery path. Tests cover bounded JSON, legacy and eager SSE relays, JSON-to-SSE reframing, client WebSocket reframing, upstream WebSocket delivery, and continuation storage.
- Collision checks now cover every declaration and reference location used by the request. Restoration also requires the private namespace or a bare alias that this request generated.
- English and Simplified Chinese documentation now state that the field is unset in a fresh config and list the exact canonical ChatGPT forward transport and excluded destinations.
- The exact pushed head is `1a4cb4aab`, replayed onto current `dev` commit `f84dbf91e` before the final push.
- The rebase conflict in `tests/provider-quota.test.ts` came from `dev` commit `fcf0da257`, which had independently adopted the same #3198 baseline-weight expectation. The redundant test-only commit was skipped, so that file is no longer part of this PR's diff.

## Verification

- `bun test --isolate tests/plaintext-v2-agent-messages.test.ts tests/plaintext-v2-agent-messages-server.test.ts tests/ws-upstream.test.ts tests/config.test.ts tests/agent-task-recovery.test.ts`
  - 270 passed, 0 failed.
- `bun test --isolate tests/provider-quota.test.ts tests/provider-capacity.test.ts`
  - 128 passed, 0 failed.
- `bun test --isolate tests/cli-capabilities.test.ts`
  - 16 passed, 0 failed on final base `f84dbf91e`.
- `bun run test --parallel=1` on `c17bc94c2`, the direct parent of the final base
  - The 17,111-test main lane and all 161 serial-lane tests passed. 16 tests were skipped and 0 failed.
- Post-rebase verification on the final `f84dbf91e` base
  - The 270 feature and adjacent tests, 128 capacity tests, and 16 capability tests passed, together with typecheck, privacy scan, and `git diff --check`.
- `bun run test:changed` on intermediate base `ef7b3c9cf`
  - 13,669 passed and 14 skipped. The run reported two failures: the keychain capability omission already fixed by final-base commit `f84dbf91e`, and a load-sensitive five-second timeout that passed in isolation below.
- `bun test --isolate tests/codex-log-guard-maintenance-coderabbit.test.ts`
  - 6 passed, 0 failed.
- `bun run typecheck`
  - Passed.
- `bun run privacy:scan`
  - Passed.
- `cd docs-site && bun run build`
  - The last successful run built 409 pages before the final conflict-only rebase. The final local attempt stopped before Astro loaded because the available Node runtime is `20.19.4` and current Astro requires `>=22.12.0`.
- `git diff --check`
  - Passed.

The default changed-test run exposed a load-sensitive five-second timeout in `codex-log-guard-maintenance-coderabbit.test.ts`; the same six-test file passed in isolation. The temporary capability failure belonged to the intermediate `dev` base and passes after rebasing onto #3215. GitHub created exact-head Cross-platform CI and React Doctor runs for `1a4cb4aab`, but both require upstream maintainer approval before fork code can execute.

A captured live failure established why both the namespace and the three message-tool names must change. Namespace aliasing plus marker removal alone still produced a Fernet-shaped `gAAAA…` value in `spawn_agent.arguments.message`, and the routed Fable task received an empty `Payload:`. A post-fix isolated Codex CLI `0.149.1` canary used a native `gpt-5.5` parent and a `combo/fable` child. The child returned the exact marker `FABLE_ALIAS_CANARY_20260826`. The available pool account did not advertise `gpt-5.6-sol`, so this evidence does not claim a GPT-5.6 canary.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
