### PR TITLE
fix(responses): reject malformed selector namespaces and re-harden skipped snapshots

### DIFF
--- a/docs-site/src/content/docs/troubleshooting/disk-usage-temp-files.md
+++ b/docs-site/src/content/docs/troubleshooting/disk-usage-temp-files.md
@@ -57,8 +57,10 @@ snapshot actually written**: while that file is small the next write is schedule
 about two seconds after a change, and once it is near the 24 MB bound the wait
 stretches to at most thirty seconds. A cache that has only just grown therefore
 still takes the short wait once — the longer cadence applies from the write after
-it. A flush that would reproduce the existing file byte-for-byte is skipped
-entirely.
+it. A flush is skipped only when this process already wrote the same bytes to the
+same file and that file still matches on disk, so a fresh process rewrites an
+identical snapshot once, and a file changed underneath the proxy is repaired rather
+than left alone.
 
 Together these keep the write rate roughly flat as the cache grows, instead of
 re-serializing and replacing the whole file every two seconds.

--- a/src/responses/namespace-tool-compat.ts
+++ b/src/responses/namespace-tool-compat.ts
@@ -223,12 +223,19 @@ function rewriteNamedSelector(
   bareFallback: boolean,
 ): unknown {
   if (!isPlainObject(value) || typeof value.name !== "string") return value;
-  if (typeof value.namespace !== "string") {
+  // An ABSENT namespace is an unqualified selector and may fall back to the bare
+  // name. A PRESENT but non-string one is malformed, and must not take that path:
+  // treating it as absent lets `{type:"function", namespace:1, name:"safe"}` resolve
+  // to a namespace wire name, which then authorizes an alias the caller never named
+  // in any well-formed way. Fail closed and hand the selector back untouched.
+  if ("namespace" in value && typeof value.namespace !== "string") return value;
+  const namespace = value.namespace;
+  if (typeof namespace !== "string") {
     if (!bareFallback) return value;
     const wireName = plan.selectors.get(value.name) ?? undefined;
     return wireName === undefined || wireName === value.name ? value : { ...value, name: wireName };
   }
-  const { namespace, ...rest } = value;
+  const { namespace: _dropped, ...rest } = value;
   const wireName = plan.identities.get(loweredIdentity(namespace, value.name))
     ?? loweredWireName(namespace, value.name);
   return { ...rest, name: wireName };

--- a/src/responses/state.ts
+++ b/src/responses/state.ts
@@ -117,7 +117,18 @@ async function snapshotOnDiskMatches(path: string, payload: string, payloadBytes
   try {
     const file = Bun.file(path);
     if (file.size !== payloadBytes) return false;
-    return await file.text() === payload;
+    if (await file.text() !== payload) return false;
+    // Content matching is not the whole invariant. This file holds persisted request
+    // and response bodies, and `atomicWriteFileAsync` writes it owner-only; the
+    // unconditional rewrite used to restore that on every mutation. Skipping without
+    // checking would let a broadened mode persist indefinitely, so treat a widened
+    // file as "does not match" and let the caller rewrite it through the hardening
+    // path. POSIX only — Windows ACLs are re-applied by that same write path.
+    if (process.platform !== "win32") {
+      const mode = statSync(path).mode & 0o777;
+      if (mode !== 0o600) return false;
+    }
+    return true;
   } catch {
     return false;
   }

--- a/tests/namespace-tool-compat.test.ts
+++ b/tests/namespace-tool-compat.test.ts
@@ -263,6 +263,61 @@ describe("Responses namespace tool compatibility", () => {
     }).aliases.size).toBe(0);
   });
 
+  // A selector's `namespace` is either absent — meaning "unqualified, resolve the bare
+  // name" — or a string naming the group. A present-but-malformed value is neither, and
+  // treating it as absent let it resolve to a namespace wire name and authorize an alias
+  // the caller never qualified. Fail closed instead: an unqualified selector is a
+  // deliberate shape, a malformed one is not.
+  describe("a malformed namespace field authorizes nothing", () => {
+    const namespaceTools = [{
+      type: "namespace",
+      name: "collaboration",
+      tools: [{ type: "function", name: "safe" }],
+    }];
+    const wireName = "collaboration__safe";
+
+    test.each([
+      ["a number", 1],
+      ["null", null],
+      ["an object", {}],
+      ["an array", ["collaboration"]],
+      ["a boolean", true],
+    ])("a forced selector whose namespace is %s", (_label, namespace) => {
+      const { aliases } = rewriteRoutedNamespaceToolsForUpstream({
+        tools: namespaceTools,
+        tool_choice: { type: "function", namespace, name: "safe" },
+      });
+      expect(aliases.size).toBe(0);
+      expect(restoreRoutedNamespaceCalls({ type: "function_call", name: wireName }, aliases).changed).toBe(false);
+    });
+
+    test("an allowed_tools entry whose namespace is malformed", () => {
+      const { aliases } = rewriteRoutedNamespaceToolsForUpstream({
+        tools: namespaceTools,
+        tool_choice: { type: "allowed_tools", mode: "required", tools: [{ type: "function", namespace: 1, name: "safe" }] },
+      });
+      expect(aliases.size).toBe(0);
+    });
+
+    test("a correctly qualified selector still authorizes, so this is not deny-all", () => {
+      const { aliases } = rewriteRoutedNamespaceToolsForUpstream({
+        tools: namespaceTools,
+        tool_choice: { type: "function", namespace: "collaboration", name: "safe" },
+      });
+      expect(aliases.get(wireName)).toEqual({ namespace: "collaboration", name: "safe", kind: "function" });
+    });
+
+    test("an unqualified selector keeps resolving by bare name", () => {
+      // The absent case is the one legitimate reason the fallback exists; narrowing
+      // malformed values must not take it away.
+      const { aliases } = rewriteRoutedNamespaceToolsForUpstream({
+        tools: namespaceTools,
+        tool_choice: { type: "function", name: "safe" },
+      });
+      expect(aliases.get(wireName)).toBeDefined();
+    });
+  });
+
   test("fails closed when flattening would collide with a declared wire name", () => {
     expect(() => rewriteRoutedNamespaceToolsForUpstream({
       tools: [

--- a/tests/responses-state-write-amplification.test.ts
+++ b/tests/responses-state-write-amplification.test.ts
@@ -8,7 +8,7 @@
  * of the snapshot actually being written.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -131,6 +131,25 @@ describe("responses-state snapshot write amplification (#2460)", () => {
     await flushResponseState();
 
     expect(readFileSync(snapshot, "utf-8")).toBe(original);
+  });
+
+  // Content is not the whole invariant. This file holds persisted request and response
+  // bodies and is written owner-only; the unconditional rewrite used to restore that on
+  // every mutation. Skipping on content alone would let a widened mode persist for the
+  // life of the process, which is a durable privacy regression rather than a slow one.
+  test.skipIf(process.platform === "win32")("a snapshot whose mode was broadened is rewritten and re-hardened", async () => {
+    remember("resp_amp_perm", "sensitive");
+    await flushResponseState();
+    expect(statSync(snapshot).mode & 0o777).toBe(0o600);
+
+    chmodSync(snapshot, 0o644);
+
+    // Same trick as above: the oversized entry is dropped by the per-entry bound, so
+    // the bounded payload is byte-identical and only the mode differs.
+    remember("resp_amp_perm_oversized", "y".repeat(3 * 1024 * 1024));
+    await flushResponseState();
+
+    expect(statSync(snapshot).mode & 0o777).toBe(0o600);
   });
 
   test("the scheduled debounce stays at its base value for a small snapshot", async () => {


### PR DESCRIPTION
## Summary

Closes two review threads that were opened on #2477 and #2476 minutes before each merged, so neither was addressed before the code landed. Both are real, both are one-line predicates, and both were reproduced before fixing.

**A malformed `namespace` authorized an alias (#2477 thread).** A selector's `namespace` is either absent — meaning "unqualified, resolve the bare name" — or a string naming the group. `rewriteNamedSelector` treated *every* non-string value as absent, so a present-but-invalid one took the unqualified path, resolved to a namespace wire name, and `authorizedAliases` retained it. An upstream call carrying that name could then be restored into a client namespace call the caller never qualified.

```
tool_choice                                      before   after
{type:function, namespace:"collaboration", ...}  authorized   authorized   <- unchanged
{type:function, namespace:"other", ...}          none         none         <- already correct
{type:function, namespace:1, ...}                authorized   none
{type:function, namespace:null, ...}             authorized   none
{type:function, namespace:{}, ...}               authorized   none
```

A *wrong* namespace already failed closed; only malformed ones slipped through, which is why it survived the original review. Present-and-invalid now returns the selector untouched.

**The snapshot fast path preserved broadened permissions (#2476 thread).** `responses-state.json` holds persisted request and response bodies and is written owner-only. The unconditional rewrite used to restore that mode on every mutation; skipping on content alone let a widened mode persist for the life of the process:

```
mode after write                     600
mode after external broadening       644
mode after unchanged-payload flush   644   <- before
mode after unchanged-payload flush   600   <- after
```

That is a durable privacy regression rather than a slow one, so a widened file is now treated as not matching and the caller rewrites it through the hardening path. POSIX-only check — Windows ACLs are re-applied by that same write path.

**Docs (#2476 thread).** The page said any byte-identical flush is skipped. The skip actually requires this process to have written the same bytes to the same resolved target, with the file still matching on disk — so a fresh process rewrites an identical snapshot once. Corrected.

## Verification

- `bun test tests/namespace-tool-compat.test.ts tests/responses-parser.test.ts tests/openai-responses-passthrough.test.ts` — 174 pass / 0 fail
- `bun test tests/responses-state-write-amplification.test.ts tests/responses-state.test.ts` — 124 pass / 0 fail
- `bun x tsc --noEmit` — exit 0

Both predicates are mutation-proven. Reverting the namespace guard fails exactly the six malformed cases; reverting the mode check fails exactly the permission regression. Positive controls prove neither fix is deny-all: a correctly qualified selector still authorizes, an unqualified selector still resolves by bare name, and an unchanged snapshot with intact permissions is still skipped.

Found during the v2.32.1 freeze audit, which is how they surfaced at all — the release gate requires zero unresolved review threads on merged PRs, and these three were the exception.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Snapshot files are now rewritten when their permissions are not restricted to owner-only access, improving file security.
  - Externally modified snapshot files are correctly repaired, while unchanged files avoid unnecessary rewrites.
  - Malformed namespace values no longer authorize unintended tool aliases or name conversions.

- **Documentation**
  - Updated troubleshooting guidance to clarify when identical snapshot data is rewritten and how file changes are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->