### PR TITLE
fix(responses): reject malformed selectors at the authorization gate

### DIFF
--- a/docs-site/src/content/docs/troubleshooting/disk-usage-temp-files.md
+++ b/docs-site/src/content/docs/troubleshooting/disk-usage-temp-files.md
@@ -58,9 +58,10 @@ about two seconds after a change, and once it is near the 24 MB bound the wait
 stretches to at most thirty seconds. A cache that has only just grown therefore
 still takes the short wait once — the longer cadence applies from the write after
 it. A flush is skipped only when this process already wrote the same bytes to the
-same file and that file still matches on disk, so a fresh process rewrites an
-identical snapshot once, and a file changed underneath the proxy is repaired rather
-than left alone.
+same file, that file still matches on disk, and — outside Windows — its mode is
+still owner-only. A fresh process rewrites an identical snapshot once, and a file
+whose contents or permissions changed underneath the proxy is rewritten through the
+hardening path rather than left alone.
 
 Together these keep the write rate roughly flat as the cache grows, instead of
 re-serializing and replacing the whole file every two seconds.

--- a/src/responses/namespace-tool-compat.ts
+++ b/src/responses/namespace-tool-compat.ts
@@ -217,18 +217,27 @@ function rewriteToolList(
  * the failure this layer exists to prevent, and this layer's own response restoration is what put
  * the key on the item.
  */
+/**
+ * A selector's `namespace` is either absent — meaning "unqualified, resolve the bare
+ * name" — or a string naming the group. A present-but-non-string value is neither, and
+ * a malformed selector must not authorize anything: not through the unqualified
+ * fallback, and not by happening to carry an already-flattened wire name, which would
+ * otherwise match the alias map exactly and arm it anyway.
+ */
+function hasMalformedNamespace(value: Record<string, unknown>): boolean {
+  return "namespace" in value && typeof value.namespace !== "string";
+}
+
 function rewriteNamedSelector(
   value: unknown,
   plan: NamespaceRewritePlan,
   bareFallback: boolean,
 ): unknown {
   if (!isPlainObject(value) || typeof value.name !== "string") return value;
-  // An ABSENT namespace is an unqualified selector and may fall back to the bare
-  // name. A PRESENT but non-string one is malformed, and must not take that path:
-  // treating it as absent lets `{type:"function", namespace:1, name:"safe"}` resolve
-  // to a namespace wire name, which then authorizes an alias the caller never named
-  // in any well-formed way. Fail closed and hand the selector back untouched.
-  if ("namespace" in value && typeof value.namespace !== "string") return value;
+  // Malformed: hand it back untouched so no rewrite occurs. Authorization rejects it
+  // separately — returning it unchanged is not by itself enough, because the name it
+  // carries may already BE a wire name.
+  if (hasMalformedNamespace(value)) return value;
   const namespace = value.namespace;
   if (typeof namespace !== "string") {
     if (!bareFallback) return value;
@@ -276,6 +285,9 @@ function authorizedAliases(
     (toolChoice.type === "function" || toolChoice.type === "custom")
     && typeof toolChoice.name === "string"
   ) {
+    // A malformed namespace makes the whole selector untrustworthy, even when its
+    // name is already a flattened wire name that would match the alias map exactly.
+    if (hasMalformedNamespace(toolChoice)) return new Map();
     authorized = new Map([[toolChoice.name, toolChoice.type]]);
   } else if (toolChoice.type === "allowed_tools" && Array.isArray(toolChoice.tools)) {
     authorized = new Map();
@@ -290,6 +302,7 @@ function authorizedAliases(
       if (!isPlainObject(tool)) continue;
       if (tool.type !== "function" && tool.type !== "custom") continue;
       if (typeof tool.name !== "string") continue;
+      if (hasMalformedNamespace(tool)) continue;
       authorized.set(tool.name, tool.type);
     }
   } else {

--- a/tests/namespace-tool-compat.test.ts
+++ b/tests/namespace-tool-compat.test.ts
@@ -299,6 +299,35 @@ describe("Responses namespace tool compatibility", () => {
       expect(aliases.size).toBe(0);
     });
 
+    // Refusing to REWRITE a malformed selector is not enough on its own. If its name is
+    // already the flattened wire name, it matches the alias map exactly and arms it
+    // anyway — so authorization has to reject the selector itself, whatever name it
+    // carries. Both selector shapes, because a caller can write either.
+    test("a malformed selector already using the flattened wire name authorizes nothing", () => {
+      const forced = rewriteRoutedNamespaceToolsForUpstream({
+        tools: namespaceTools,
+        tool_choice: { type: "function", namespace: 1, name: wireName },
+      });
+      expect(forced.aliases.size).toBe(0);
+      expect(restoreRoutedNamespaceCalls({ type: "function_call", name: wireName }, forced.aliases).changed).toBe(false);
+
+      const allowed = rewriteRoutedNamespaceToolsForUpstream({
+        tools: namespaceTools,
+        tool_choice: { type: "allowed_tools", mode: "required", tools: [{ type: "function", namespace: 1, name: wireName }] },
+      });
+      expect(allowed.aliases.size).toBe(0);
+    });
+
+    test("an unqualified selector using the wire name still authorizes", () => {
+      // The legitimate shape this must not break: no namespace field at all, naming
+      // the flattened tool directly.
+      const { aliases } = rewriteRoutedNamespaceToolsForUpstream({
+        tools: namespaceTools,
+        tool_choice: { type: "function", name: wireName },
+      });
+      expect(aliases.get(wireName)).toBeDefined();
+    });
+
     test("a correctly qualified selector still authorizes, so this is not deny-all", () => {
       const { aliases } = rewriteRoutedNamespaceToolsForUpstream({
         tools: namespaceTools,


### PR DESCRIPTION
## Summary

Follow-up to #2500, closing the two threads it opened. The first is a genuine gap in my own fix.

**Refusing to rewrite a malformed selector was not enough.** #2500 made `rewriteNamedSelector` hand a malformed selector back untouched instead of treating it as unqualified. That closes the case where the name is short — but not when the name is *already* the flattened wire name:

```
tool_choice                                              #2500   this PR
{type:function, namespace:1, name:"safe"}                none    none
{type:function, namespace:1, name:"collaboration__safe"} ARMED   none
  same, via allowed_tools                                ARMED   none
{type:function, name:"collaboration__safe"}              armed   armed   <- legitimate, unchanged
```

Returning it unchanged leaves an exact match against the alias map, so the alias arms anyway and an upstream call is restored into the namespace. The check belongs at the authorization gate rather than only in the rewriter: a malformed `namespace` makes the whole selector untrustworthy no matter which name it carries. The unqualified shape — no `namespace` field at all — is deliberately untouched, since that is a legitimate selector.

**Docs.** The troubleshooting page described only the content half of the skip rule; it now states the POSIX permission precondition too.

## Verification

- `bun test tests/namespace-tool-compat.test.ts tests/responses-parser.test.ts tests/openai-responses-passthrough.test.ts tests/responses-state-write-amplification.test.ts` — 186 pass / 0 fail
- `bun x tsc --noEmit` — exit 0

Both malformed-with-wire-name shapes are covered, with a positive control on the unqualified selector so the fix cannot pass by being deny-all.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for malformed namespace values in tool selectors.
  - Prevented invalid forced or allowed tool selectors from authorizing unintended aliases.
  - Preserved authorization for valid unqualified selectors using flattened tool names.
  - Snapshot reuse now requires matching file contents and appropriate permissions; otherwise, files are safely rewritten.

- **Tests**
  - Added regression coverage for malformed namespace selectors and authorization behavior.

- **Documentation**
  - Clarified snapshot reuse and file-permission behavior in troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->