### PR TITLE
docs(responses): state the reasoning sanitizer's real rule and pin it by equality

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -46,6 +46,15 @@ export const FORWARD_HEADERS = [
   "x-responsesapi-include-timing-metrics",
 ];
 
+/**
+ * Sanitize reasoning input by field policy, not by preserving each item's shape. Retaining a
+ * native `encrypted_content` guarantees only that blob value: `status` is always removed;
+ * proxy-owned `ocxr1:` envelopes are always removed; and native blobs are removed when the caller
+ * requests stripping after a route-identity change or opaque-blob recovery. On routed/non-OpenAI
+ * destinations, a present non-array `content` field is omitted. Otherwise non-empty array content
+ * is blanked unless raw reasoning preservation is enabled; removing an `ocxr1:` envelope selects
+ * the same blanking path when non-array omission is not active.
+ */
 export function sanitizeReasoningInputContent(
   body: unknown,
   opts?: {
@@ -77,12 +86,11 @@ export function sanitizeReasoningInputContent(
     // rather than the field it actually refused, which is why this reads as a blob failure. Drop the
     // key so the item matches the shape the upstream issued.
     //
-    // Gated to routed destinations. An OpenAI-operated backend binds the blob to the item's exact
-    // shape, so deleting a field there invalidates it (`The encrypted content ... could not be
-    // verified`); the two requirements are exactly opposed, and a live regression proved it. That
-    // gate is also why this drop may touch an item that keeps its blob: xAI demonstrably accepts its
-    // own blob without the null channel, and the destinations that bind blobs to item shape never
-    // reach this branch. This is independent of the output-only status removal below.
+    // Gated to routed destinations. An OpenAI-operated backend rejects a blob-bearing item when its
+    // null `content` channel is deleted (`The encrypted content ... could not be verified`); that
+    // live result establishes this channel constraint, not whole-item shape preservation. The gate
+    // is also why this drop may touch an item that keeps its blob: xAI demonstrably accepts its own
+    // blob without the null channel. This is independent of the output-only status removal below.
     const dropNullContentChannel = opts?.dropNullContentChannel === true
       && "content" in rec && !Array.isArray(rec.content);
     // `status` is output-only. Measured OpenAI reasoning items never contain it, and Grok accepts

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -3156,14 +3156,17 @@ describe("reasoning input content channel", () => {
       summary: [{ type: "summary_text", text: "thinking" }],
       encrypted_content: "upstream-issued-blob",
     });
-    expect(out).not.toHaveProperty("content");
-    expect(out.encrypted_content).toBe("upstream-issued-blob");
-    expect(out.summary).toEqual([{ type: "summary_text", text: "thinking" }]);
+    expect(out).toEqual({
+      type: "reasoning",
+      summary: [{ type: "summary_text", text: "thinking" }],
+      encrypted_content: "upstream-issued-blob",
+    });
   });
 
-  // An OpenAI-operated backend binds the blob to the item's exact shape, so deleting a field there
-  // invalidates it: `The encrypted content ... could not be verified`. Caught in live traffic after
-  // an ungated first version of this fix shipped locally — the two backends want opposite things.
+  // An OpenAI-operated backend rejects a blob-bearing item when its null `content` channel is
+  // deleted: `The encrypted content ... could not be verified`. Caught in live traffic after an
+  // ungated first version of this fix shipped locally — the two backends want opposite things for
+  // this channel.
   test("keeps a null content channel on OpenAI-operated destinations", () => {
     const item = {
       type: "reasoning",
@@ -3184,9 +3187,7 @@ describe("reasoning input content channel", () => {
         _rawBody: { model: "gpt-5.6-sol", store: false, input: [item] },
       }, { headers: new Headers({ authorization: "Bearer token" }) });
       const out = (JSON.parse(request.body) as { input: Record<string, unknown>[] }).input[0];
-      expect(out).toHaveProperty("content");
-      expect(out.content).toBeNull();
-      expect(out.encrypted_content).toBe("openai-issued-blob");
+      expect(out).toEqual(item);
     }
   });
 


### PR DESCRIPTION
## A sentence that kept getting repeated is not what the code does

> "an item that keeps its `encrypted_content` is not otherwise modified"

`sanitizeReasoningInputContent` removes `status` and blanks array content **while retaining the blob**. Retaining a native blob guarantees the blob *value*, not the item's byte shape.

The in-tree form of the overbroad claim was in `tests/openai-responses-passthrough.test.ts`:

> "An OpenAI-operated backend binds the blob to the item's **exact shape**, so deleting a field there invalidates it"

What was actually measured is narrower: deleting the **null `content` channel** invalidates the blob there. "Exact shape" invites the reader to believe nothing else is ever touched — false in the same function.

## What changed

The sanitizer now carries the real field policy, **enumerated rather than summarised**, since summarising is how the false version arose: `status` always removed; proxy-owned `ocxr1:` envelopes always removed; native blobs removed on route-identity change or recovery-requested stripping; present non-array `content` omitted on routed/non-OpenAI destinations; otherwise non-empty array content blanked unless raw reasoning preservation is on.

The "exact shape" comment is narrowed to the measured behavior.

Both null-channel tests move from field-wise assertions to **whole-object equality**, so any additional change to a blob-bearing item fails the test instead of slipping past. Both destination directions are kept.

## No behavior change

**The source diff is comments only** — verified by filtering comment lines out of the diff, not by trusting the summary.

That is deliberate. This path has broken OpenAI in production once already: a reasoning-only change passed an independent review, shipped, and a live request caught it within minutes because the two backends want opposite things from the same field. Anything beyond documentation here needs its own unit with live verification on both routes.

## Gate

Exact head 8056ebd87, rebased onto 98ed186c7. Source diff remains comment-only (verified by dropping comment lines from src/adapters/openai-responses.ts). bun test tests/openai-responses-passthrough.test.ts: 100 pass / 0 fail. bun x tsc --noEmit: passed. git diff --check: passed. No open CodeRabbit threads on this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how reasoning input content is sanitized.
  * Improved explanation of destination-specific handling for empty content fields.

* **Tests**
  * Updated reasoning-content coverage to verify exact serialized output.
  * Added checks confirming that routed destinations remove empty content fields, while OpenAI-operated destinations preserve them with encrypted content.

* **Maintenance**
  * No user-facing functionality changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
