### PR TITLE
devlog: close the v2.32.1 hotfix train with the GO/NO-GO report

### DIFF
--- a/devlog/_plan/260824_v2_32_1_hotfix_train/070_wp2_pr2427_parallel_test_runner.md
+++ b/devlog/_plan/260824_v2_32_1_hotfix_train/070_wp2_pr2427_parallel_test_runner.md
@@ -73,3 +73,68 @@ IN: `scripts/test.ts`, `bunfig.toml`, `tests/test-runner.test.ts`.
 OUT: #2429 (`test:changed`), which is stacked on this PR and belongs to the next
 minor.
 
+---
+
+## Outcome (wp2 close, 2026-08-25): DEFERRED
+
+Ran last, exactly as the roadmap audit required, and the deferral is this
+document's own rule applied rather than a new judgement: *"If it does not, it is
+deferred and the train proceeds on the existing runner. It is a convenience,
+never a blocker."*
+
+### The measurement
+
+Five full-suite runs on an idle machine, across two heads. The PR head moved
+mid-phase — the author pushed `cdeda10c` bounding the default to
+`--parallel=4` while the first runs were in flight, so the first two rows are
+stale and are kept only to show the bound's effect.
+
+| head | workers | result | wall |
+|------|---------|--------|------|
+| `e03b9fca` | 15x | 14601 pass / 0 fail | 47s |
+| `e03b9fca` | 15x | 14600 pass / **1 fail** (`codex-shim`) | 47s |
+| `cdeda10c` | 4x | 14601 pass / 0 fail | 130s |
+| `cdeda10c` | 4x | 14601 pass / 0 fail | 125s |
+| `cdeda10c` | 4x | 14600 pass / **1 fail** (`issue-452`) | 123s |
+
+Serial baseline on the same machine: ~560s. The speedup is real and the four-worker
+bound measurably reduces the failure rate. Neither fact was the deciding one.
+
+### Why it was deferred
+
+Four **different** tests failed intermittently across those runs —
+`cursor-native-exec-shell`, `openai-provider-option-e2e`, `codex-shim`,
+`issue-452-empty-503` — and every one passes in isolation (17/17 and 88/88
+respectively). An independent reviewer additionally had one run stop emitting
+output for ten minutes without a terminal summary.
+
+These are **pre-existing latent order dependencies that parallelism exposes**, not
+defects the PR introduces. The reviewer named a concrete mechanism worth chasing:
+`scripts/test.ts` supplies one common startup `HOME`, and `homedir()` is fixed at
+process start, so the `.claude` sentinel in `openai-provider-option-e2e` can observe
+a path shared across workers even after preload rewrites the environment.
+
+The blocking argument is specific to this train's position: wp8's freeze gate **is**
+a full-suite run, and every remaining criterion depends on it meaning something. A
+runner that fails roughly one run in three for unrelated reasons makes a red result
+indistinguishable from noise — the same attribution problem that moved this PR from
+first to last, arriving one step later.
+
+### What would land it
+
+Fix or quarantine the order-dependent tests (the shared-`HOME` sentinel first), then
+three consecutive green full-suite runs at one head plus Linux and Windows CI. It
+belongs early in the next cycle: 2 minutes versus 9 changes how often the suite gets
+run at all.
+
+Criterion c-7's #2427 half is met by this recorded deferral. Nothing in the v2.32.1
+train depends on it; wp8 freezes on the existing serial runner. Posted to the PR at
+https://github.com/lidge-jun/opencodex/pull/2427#issuecomment-5402835810.
+
+**LOOP-PESSIMIST-01.** What died here is my own P-phase recommendation: I reached A
+saying MERGE on one green run at what turned out to be a stale head. Two lessons,
+both cheap to state and easy to skip: re-read the PR head immediately before
+claiming exact-head evidence, because a contributor can push mid-verification; and
+one green run of a flaky-capable suite is not evidence of stability — the third run
+is what produced the finding.
+

--- a/devlog/_plan/260824_v2_32_1_hotfix_train/090_wp9_issue2472_mixed_sequence_regression.md
+++ b/devlog/_plan/260824_v2_32_1_hotfix_train/090_wp9_issue2472_mixed_sequence_regression.md
@@ -84,3 +84,67 @@ where the fix goes.
 OUT: implementing that fix inside this phase; restarting or reconfiguring the
 user's running proxy; any live provider call.
 
+---
+
+## Outcome (wp9 close, 2026-08-25)
+
+**Terminal outcome: cannot be driven deterministically → #2472 deregistered as a GO
+criterion and recorded as a deferred known defect.** This is the third of the three
+outcomes this document allowed, and it is the honest one.
+
+### What was attempted
+
+The planned regression was written: `tests/cursor-zero-output-turn.test.ts`, seven
+tests driving the native/host call-id dedupe, including three routes that each
+produce a turn whose only event is the terminal `done`. It passed. It was then
+**deleted**, because an independent review showed it pins the wrong mechanism.
+
+### Why it was wrong
+
+The dedupe lives on the **pre-execution announcement** side of the tool boundary.
+`planMcpArgsHandling` deliberately ends turn 1 as `done` and cancels the Cursor run
+without a result — `live-transport.ts:220-225` states outright that the real tool
+result arrives on the NEXT `/v1/responses` request as structured history. #2472
+reports output lost **after** the calling agent already produced non-empty text,
+which is downstream of that boundary. A test that reproduced an empty-looking turn
+on the announcement side would have looked like evidence while proving nothing.
+
+The other two routes were equally unreachable: the empty-argument case only goes
+silent under `allowEmptyArgs: false`, and the live bridge passes `true`
+(`live-transport.ts:258`), where malformed shell arguments raise an explicit error.
+
+### What is settled
+
+- The bridge-version theory from the issue's own point 3 is closed: `88b7cc057`
+  (zero-output combo failover) is an ancestor of `dev`, and the regression the issue
+  asked for exists and passes — `tests/combo-stream-preflight.test.ts`, *"converts a
+  zero-output failed terminal into a retryable HTTP failure"*, 4 pass / 0 fail.
+- The dedupe is correct and stays. Without it every repeated `tool_call_start`
+  becomes another Responses `function_call` item, i.e. a duplicate execution request.
+
+### What remains open
+
+There is no turn-wide semantic-output ledger. `finalizeTurnEvents` reports an error
+for a call left OPEN at turn end but is silent for a turn that closed with zero
+output, and the bridge emits `response.completed` with an empty snapshot. The
+`empty-completion-guard` would catch it but is opt-in and defaults to false. The gap
+is real **if a reachable producer exists**; none was constructible on current `dev`.
+
+Settling it needs a reproduction at the `function_call_output`/next-request boundary,
+not another adapter-level probe. The microsecond `wall_time_seconds` in the report is
+the strongest remaining lead and deserves its own telemetry issue.
+
+### Consequence for this train
+
+Per 000's canary section, #2472 **stops being a GO criterion**. Criterion c-9 is met
+by this recorded disposition rather than by a passing canary. Nothing about the six
+merged runtime fixes depends on it, and the issue stays open with the investigation
+posted at https://github.com/lidge-jun/opencodex/issues/2472#issuecomment-5402463174.
+
+**LOOP-PESSIMIST-01.** The hypothesis that died is mine: that the zero-output symptom
+could be reproduced from the adapter's event mapper. Two cycles in a row (wp7's
+config-dir guard, wp9's dedupe theory) I built a plausible mechanism and had to
+discard it against evidence. The pattern worth carrying: a reproduction that only
+exercises code I chose to call is not a reproduction — it has to start from the
+reported observable and work backwards to a path the runtime actually takes.
+

--- a/devlog/_plan/260824_v2_32_1_hotfix_train/900_go_nogo_readiness_report.md
+++ b/devlog/_plan/260824_v2_32_1_hotfix_train/900_go_nogo_readiness_report.md
@@ -1,0 +1,118 @@
+# 900 — v2.32.1 release-candidate readiness: GO/NO-GO
+
+Frozen `dev` SHA: **`faaa78dc05489625e5c9bf450050a46a7fa91d1f`**
+Train started from: `origin/dev` `c44e43f00`, `origin/main` `96e2f67c3` (v2.32.0)
+Report written: 2026-08-25. Supersedes an earlier draft frozen at `02c302a54`,
+which a freeze audit rejected — see "What the audit changed" below.
+
+## Verdict
+
+**GO** for promoting `dev` → `main` and publishing **v2.32.1** as a bugfix-only
+release. Promotion, tagging, and publishing were deliberately not performed; they
+are human decisions and this unit ends before them.
+
+## What landed
+
+| # | PR | Merge SHA | What review changed |
+|---|-----|-----------|---------------------|
+| wp1 | #2487 | `73a11a8f1` | Baseline was misread as divergence; `dev` was an *ancestor* of `main` |
+| wp3 | #2483 | `3e3a028fe` | The fix regressed `claude-opus-4-8.1`; tail corrected to `(?!\d)` |
+| wp4 | #2481 | `a60d51748` | **My** replacement was disproved and reverted |
+| wp5 | #2473 | `84ade0f15` | Clean — the only unit needing no code correction |
+| wp6 | #2477 | `1d4a92a32` | Two defects: the flagged `allowed_tools` hole and a cross-kind residual |
+| wp7 | #2476 | `02c302a54` | Skip-on-digest was a persistence regression |
+| — | #2500 | `43227ac07` | Post-merge: malformed `namespace`; unrestored file permissions |
+| — | #2501 | `faaa78dc0` | Post-merge: malformed selector using a pre-flattened wire name |
+
+Two units closed without a merge, both pre-registered outcomes: **#2472**
+NOT_REPRODUCED (deregistered as a GO criterion), **#2427** DEFERRED (three runs
+gave 0/0/1 failures; four different tests flaked across five runs).
+
+## What the audit changed
+
+The first freeze at `02c302a54` was audited and **failed**, correctly, on three
+counts. All three are now closed:
+
+1. **Three unresolved review threads on merged PRs**, which the GO criteria forbid.
+   Two were live defects that had been opened minutes before their PRs merged: a
+   malformed `namespace` authorizing an alias, and the snapshot fast path never
+   restoring broadened file permissions on a file holding request/response bodies.
+   Fixed in #2500, then #2501 after review found #2500 was itself incomplete — a
+   malformed selector carrying an already-flattened wire name still matched the
+   alias map exactly. **All threads across all seven PRs are now resolved: 0.**
+2. **The full-suite gate was red** and the first draft argued an exception in the
+   report itself. That is retroactive gate-weakening and the audit was right to
+   reject it. The gate is now decomposed the way CI actually partitions it, below.
+3. **Missing frozen-head receipts.** Recorded below.
+
+## Gate results at the frozen SHA
+
+CI partitions the suite because three files are known to be load-sensitive:
+`scripts/ci/run-bun-test-batches.sh:50` excludes `api-storage-policy*`,
+`api-storage`, and `api-usage` from the general batches, and `ci.yml` runs each in
+its own job. Running `bun run test` as one process is therefore *not* the same
+gate CI applies. Both forms are recorded:
+
+| Gate | Command | Result |
+|------|---------|--------|
+| Typecheck | `bun x tsc --noEmit` | exit 0 |
+| Privacy | `bun run privacy:scan` | `Privacy scan passed`, exit 0 |
+| **General suite** (CI's partition) | `bun test --isolate` over 1787 files, excluding the three segregated | **14565 pass, 0 fail, exit 0** |
+| Storage-policy job | `bun test --isolate` over the six files `ci.yml` names | **9 pass, 0 fail, exit 0** |
+| api-usage job | `bun test --isolate ./tests/api-usage.test.ts` | 31 pass, **1 fail** — see below |
+| Whole suite in one process | `bun run test` | 14604 pass, 3 fail — the segregated storage-policy family |
+
+**The one `api-usage` failure is pre-existing and environmental.** The same test
+fails identically on the untouched pre-train baseline `c44e43f00`, no merged unit
+touches usage or overlay code, and CI's own `api usage` job is green at this SHA.
+It is a local-environment artifact, not a candidate defect.
+
+## Push-event CI at the frozen SHA
+
+Run **`32793104507`**, event `push`, head `faaa78dc0`, conclusion **success**.
+Every job green: `test 1/4`–`4/4`, `storage policy`, `api usage`, `gates`,
+`macos`, `keyring` and `npm-global` on ubuntu/windows/macOS, and the `ci`
+aggregate. This is the artifact `release.yml` requires.
+
+## GO conditions
+
+| Condition | Evidence |
+|-----------|----------|
+| `main` lineage in `dev` | `git merge-base --is-ancestor origin/main origin/dev` → 0 |
+| Version line synced | `origin/dev:package.json` → `2.32.0` |
+| Every PR merged post-wp1 | eight merge SHAs, each `--is-ancestor` verified |
+| Maintainer approval | `reviewDecision=APPROVED` on all merged PRs |
+| **Zero unresolved review threads** | **0 across #2483, #2481, #2473, #2477, #2476, #2500, #2501** |
+| #2477 security review | independent lane recorded in wp6; both follow-ups landed |
+| Push-event CI green at frozen SHA | run `32793104507` success |
+| Typecheck / privacy / general suite | all exit 0 at `faaa78dc0` |
+| Scope clean | `origin/main..origin/dev` is devlog + the runtime units only; no package/lockfile/workflow delta, no tag |
+
+## NO-GO conditions, each checked
+
+| Condition | Status |
+|-----------|--------|
+| Foreign tool-type selector authorizes a namespace alias | **Closed** (wp6) |
+| Malformed `namespace` authorizes an alias | **Closed** (#2500, #2501) |
+| Oversized turn opens a socket before falling back | **Closed** (wp5) |
+| Snapshot skip loses state or permissions | **Closed** (wp7, #2500) |
+| #2476 changed the 24 MiB cap, TTL, or eviction order | **Not changed** |
+| A hygiene-blocked PR reached the train | **None** |
+| A merge justified by remembered results | **None** — every close carries a bound receipt |
+| New runtime feature work after freeze | **None** |
+
+## Known defects shipping in v2.32.1
+
+**#2407** (Kiro `tool_search`), **#2458** (Gemini video 502 — deferred because its
+fix touches the guard wp6 hardened), **#2459** (Windows reinstall module graph),
+**#2472** (zero-output, not reproduced), **#2491** (four divergent slug-equivalence
+relations, filed during this train). Queue at freeze: ~50 open PRs, 20 open `bug`
+issues. The train deliberately took six.
+
+## What promotion still requires
+
+Left to a human, per `MAINTAINERS.md`: the `dev` → `main` promotion and its
+version bump to `2.32.1`, fresh Cross-platform CI **and** Service lifecycle runs at
+the promoted `main` SHA (the `package.json` bump activates that gate), the tag, and
+`npm publish` with dry-run and install verification.
+


### PR DESCRIPTION
## Summary

Closes the v2.32.1 hotfix train: the GO/NO-GO readiness report plus the two work-phases that ended without a merge. Documentation only.

**The readiness report** freezes `dev` at `faaa78dc0` with the verdict **GO**, and records the audit history rather than only the outcome. The first freeze at `02c302a54` was rejected on three counts, all now closed:

- Three unresolved review threads on merged PRs, which the GO criteria forbid. Two were live defects opened minutes before their PRs merged, so they were never addressed — a malformed `namespace` authorizing a tool alias, and the snapshot fast path never restoring broadened permissions on a file holding request and response bodies. Fixed in #2500, then #2501 when review found #2500 was itself incomplete against a pre-flattened wire name. All threads across all seven PRs now resolve to zero.
- The full-suite gate was red and the first draft argued an exception in the report itself, which is gate-weakening after the fact. The gate is now decomposed the way `scripts/ci/run-bun-test-batches.sh` and `ci.yml` actually partition the suite, and passes in that form: **14565 pass / 0 fail** across the general batches, storage-policy **9/9** in its own job. The one `api-usage` failure is proven identical on the untouched pre-train baseline `c44e43f00`, with no merged unit touching usage code and CI's own job green.
- Missing frozen-head receipts, now recorded.

**Two units closed without merging**, both pre-registered outcomes:

- **#2472 — NOT_REPRODUCED.** A regression was written, passed, and then deleted once review showed it pinned the pre-execution announcement path rather than the post-execution result loss the issue describes. The wrong lead is written down so nobody re-walks it.
- **#2427 — DEFERRED** on five runs of data: four different tests flaked, each green in isolation. A runner that fails one run in three would make the freeze gate itself unfalsifiable.

## Verification

Documentation only; no code changes. Gates that observe it, at `faaa78dc0`:

- `bun run privacy:scan` — pass, exit 0 (the gate that matters for `devlog/`)
- `bun x tsc --noEmit` — exit 0
- `bun test tests/repo-hygiene.test.ts` — 11 pass / 0 fail, including "no open devlog plan carries an unresolved security verdict"

Everything described here is already public: the security findings were posted by CodeRabbit and Codex on their own PRs, and every fix has shipped. Nothing in these documents is pre-disclosure material.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release-readiness documentation for version 2.32.1, including the release candidate’s GO decision and remaining promotion steps.
  * Documented the deferral of parallel test execution in favor of the existing serial runner.
  * Recorded a known output-regression defect as deferred, along with investigation findings and remaining coverage gaps.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->