### PR TITLE
devlog: pin the v2.32.1 report to the code SHA its gates describe

### DIFF
--- a/devlog/_plan/260824_v2_32_1_hotfix_train/900_go_nogo_readiness_report.md
+++ b/devlog/_plan/260824_v2_32_1_hotfix_train/900_go_nogo_readiness_report.md
@@ -1,6 +1,10 @@
 # 900 — v2.32.1 release-candidate readiness: GO/NO-GO
 
-Frozen `dev` SHA: **`faaa78dc05489625e5c9bf450050a46a7fa91d1f`**
+Frozen `dev` SHA (code): **`faaa78dc05489625e5c9bf450050a46a7fa91d1f`**
+Head at report close: `03c988cf3` — this report and two closeout docs, devlog only.
+`git diff --name-only faaa78dc0 03c988cf3` lists three `devlog/` files and nothing
+else, so every gate below still describes the tree that is shipping. CI does not
+run on a devlog-only push by design; the code evidence is pinned to `faaa78dc0`.
 Train started from: `origin/dev` `c44e43f00`, `origin/main` `96e2f67c3` (v2.32.0)
 Report written: 2026-08-25. Supersedes an earlier draft frozen at `02c302a54`,
 which a freeze audit rejected — see "What the audit changed" below.
@@ -115,4 +119,3 @@ Left to a human, per `MAINTAINERS.md`: the `dev` → `main` promotion and its
 version bump to `2.32.1`, fresh Cross-platform CI **and** Service lifecycle runs at
 the promoted `main` SHA (the `package.json` bump activates that gate), the tag, and
 `npm publish` with dry-run and install verification.
-


### PR DESCRIPTION
## Summary

The readiness report named `faaa78dc0` as the frozen SHA, then landed at `03c988cf3` — its own merge moved the head. The delta is three `devlog/` files and nothing else, so the gates still describe the shipping tree, but the report should say that rather than leave a reader to check.

CI does not run on a devlog-only push by design, which is why there is no run at `03c988cf3`; the code evidence stays pinned to `faaa78dc0`.

## Verification

Documentation only. `git diff --name-only faaa78dc0 03c988cf3` lists exactly the three devlog files.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved release readiness reporting with clearer validation and closure details.
  - Added clearer tracking of the reviewed release state and any subsequent documentation-only updates.
  - Clarified when automated checks are not triggered by documentation-only changes.
  - Removed unnecessary formatting for a cleaner, more consistent report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->