### PR TITLE
fix(google): recognize antigravity quota exhaustion without retrying transient rate limits

### DIFF
--- a/src/adapters/google-errors.ts
+++ b/src/adapters/google-errors.ts
@@ -15,14 +15,47 @@ function googleErrorDetail(payloadText: string): { message?: string; status?: st
   };
 }
 
+
+
+const GOOGLE_QUOTA_EXHAUSTED_NEEDLES = [
+  "quotafailure",
+  "quota exceeded",
+  "exceeded your current quota",
+  "billing",
+  "individual quota reached",
+  "quota reached",
+  "enable overages",
+  "exhausted your capacity",
+  "daily limit reached",
+  "weekly limit reached",
+];
+
+// Per-minute / per-second / concurrency limits are transient rate limits: they should be
+// retried, not treated as hard quota exhaustion. These guards run before the needles so a
+// message like "Per-minute quota exceeded" stays in the retryable bucket.
+const GOOGLE_TRANSIENT_RATE_LIMIT_PATTERNS = [
+  "per minute",
+  "per-minute",
+  "per min",
+  "rpm",
+  "requests per minute",
+  "too many requests",
+  "rate limit",
+  "retry after",
+  "concurrent request limit",
+];
+
+export function isGoogleQuotaExhaustedText(text: string): boolean {
+  const lower = text.toLowerCase();
+  if (GOOGLE_TRANSIENT_RATE_LIMIT_PATTERNS.some(needle => lower.includes(needle))) return false;
+  return GOOGLE_QUOTA_EXHAUSTED_NEEDLES.some(needle => lower.includes(needle));
+}
+
+
 function classifyGoogle(label: string, status: number | undefined, enumStatus: string | undefined, text: string): string {
   const lower = `${enumStatus ?? ""} ${text}`.toLowerCase();
-  const quotaExhausted =
-    lower.includes("quotafailure") ||
-    lower.includes("quota exceeded") ||
-    lower.includes("exceeded your current quota") ||
-    lower.includes("billing");
-  if (enumStatus === "RESOURCE_EXHAUSTED" && quotaExhausted) return `${label} quota exhausted`;
+  const quotaExhausted = isGoogleQuotaExhaustedText(lower);
+  if ((!enumStatus || enumStatus === "RESOURCE_EXHAUSTED") && quotaExhausted) return `${label} quota exhausted`;
   if (status === 429 || enumStatus === "RESOURCE_EXHAUSTED" || lower.includes("rate limit")) {
     return `${label} rate limit exceeded`;
   }
@@ -76,10 +109,6 @@ export function retryableGoogleStatus(status: number): boolean {
  */
 export function isQuotaExhaustedBody(payloadText: string): boolean {
   const { message, status } = googleErrorDetail(payloadText);
-  if (status !== "RESOURCE_EXHAUSTED") return false;
-  const lower = (message ?? "").toLowerCase();
-  return lower.includes("quotafailure")
-    || lower.includes("quota exceeded")
-    || lower.includes("exceeded your current quota")
-    || lower.includes("billing");
+  if (status && status !== "RESOURCE_EXHAUSTED") return false;
+  return isGoogleQuotaExhaustedText(message ?? payloadText);
 }

--- a/tests/google-errors.test.ts
+++ b/tests/google-errors.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isGoogleQuotaExhaustedText,
+  isQuotaExhaustedBody,
+  safeAntigravityHttpErrorMessage,
+  safeGoogleHttpErrorMessage,
+  safeVertexHttpErrorMessage,
+} from "../src/adapters/google-errors";
+
+describe("google error classification & quota exhaustion", () => {
+  const antigravityPhrases = [
+    "Individual quota reached. Please try again later.",
+    "Quota exceeded for model gemini-3.7-flash",
+    "You have exceeded your current quota.",
+    "Please enable overages in your Cloud billing console.",
+    "You have exhausted your capacity for this period.",
+    "Daily limit reached for this account.",
+    "Weekly limit reached.",
+    "RESOURCE_EXHAUSTED: quotafailure at billing account",
+  ];
+
+  for (const phrase of antigravityPhrases) {
+    test(`recognizes quota phrase: "${phrase}"`, () => {
+      expect(isGoogleQuotaExhaustedText(phrase)).toBe(true);
+      const jsonBodyWithStatus = JSON.stringify({
+        error: {
+          code: 429,
+          status: "RESOURCE_EXHAUSTED",
+          message: phrase,
+        },
+      });
+      expect(isQuotaExhaustedBody(jsonBodyWithStatus)).toBe(true);
+      expect(safeAntigravityHttpErrorMessage(429, jsonBodyWithStatus)).toContain("Antigravity quota exhausted");
+      expect(safeVertexHttpErrorMessage(429, jsonBodyWithStatus)).toContain("Vertex AI quota exhausted");
+
+      // Also verify when JSON does not have an explicit status field (common in some Antigravity proxies)
+      const jsonBodyNoStatus = JSON.stringify({
+        error: {
+          code: 429,
+          message: phrase,
+        },
+      });
+      expect(isQuotaExhaustedBody(jsonBodyNoStatus)).toBe(true);
+      expect(safeAntigravityHttpErrorMessage(429, jsonBodyNoStatus)).toContain("Antigravity quota exhausted");
+
+      // Also verify raw plain text payload
+      expect(isQuotaExhaustedBody(phrase)).toBe(true);
+      expect(safeAntigravityHttpErrorMessage(429, phrase)).toContain("Antigravity quota exhausted");
+    });
+  }
+
+  test("does not classify transient rate limit as hard quota exhaustion", () => {
+    const transientPhrases = [
+      "Rate limit exceeded. Please retry with exponential backoff.",
+      "Too many requests per minute (RPM).",
+      "Concurrent request limit reached, try again in a few seconds.",
+      "Per-minute quota exceeded, retry later.",
+      "Quota exceeded per minute (RPM).",
+    ];
+
+    for (const phrase of transientPhrases) {
+      expect(isGoogleQuotaExhaustedText(phrase)).toBe(false);
+      const jsonBody = JSON.stringify({
+        error: {
+          code: 429,
+          status: "RESOURCE_EXHAUSTED",
+          message: phrase,
+        },
+      });
+      expect(isQuotaExhaustedBody(jsonBody)).toBe(false);
+      expect(safeAntigravityHttpErrorMessage(429, jsonBody)).toContain("Antigravity rate limit exceeded");
+    }
+  });
+
+  test("non-RESOURCE_EXHAUSTED status is not quota exhaustion even with quota keyword", () => {
+    const jsonBody = JSON.stringify({
+      error: {
+        code: 400,
+        status: "INVALID_ARGUMENT",
+        message: "quota configuration invalid",
+      },
+    });
+    expect(isQuotaExhaustedBody(jsonBody)).toBe(false);
+  });
+});


### PR DESCRIPTION
Split from #2470 (closed). Scope: Antigravity/Google 429 quota classification only.

Changes:
- Add Antigravity-native quota-exhaustion phrases to isGoogleQuotaExhaustedText.
- Exclude transient rate-limit patterns (per-minute, RPM, too many requests, retry after, concurrent request limit) so those remain retryable.
- isQuotaExhaustedBody still requires RESOURCE_EXHAUSTED when present, but also accepts missing status and raw text payloads.

Verification:
- un test tests/google-errors.test.ts -> 10 pass / 0 fail
- un run typecheck -> 0 errors

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Google quota-exhaustion errors across structured and plain-text responses.
  * Preserved accurate classification of temporary rate-limit errors as retryable.
  * Improved error messages to distinguish exhausted quotas from exceeded rate limits.
  * Added support for quota responses that omit an explicit status field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->