### PR TITLE
fix(google): clamp max output tokens per model

### DIFF
--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -48,6 +48,25 @@ const GOOGLE_BREVITY_INSTRUCTION = [
   "- This applies only to intermediate progress text. Your final answer after the work is done is exempt: write it in full and at whatever length the task requires.",
 ].join("\n");
 
+export function maxOutputTokensForGoogleModel(modelId: string): number {
+  const lower = modelId.toLowerCase();
+  if (lower.includes("flash")) return 65536;
+  if (lower.includes("pro")) return 65535;
+  if (lower.includes("claude")) return 64000;
+  if (lower.includes("gpt-oss") || lower.includes("oss")) return 32768;
+  if (lower.startsWith("gemini")) return 65536;
+  return 16384;
+}
+
+export function clampGoogleMaxOutputTokens(
+  modelId: string,
+  requestedTokens?: number,
+): number | undefined {
+  if (requestedTokens === undefined || requestedTokens <= 0) return undefined;
+  const modelMax = maxOutputTokensForGoogleModel(modelId);
+  return Math.min(requestedTokens, modelMax);
+}
+
 /**
  * Some Google direct deployments expose current Gemini Flash generations with a `-tiered`
  * wire suffix (`gemini-3.7-flash` -> `gemini-3.7-flash-tiered`). Keep the picker-visible id
@@ -650,7 +669,8 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
       if (toolConfig) body.toolConfig = toolConfig;
 
       const generationConfig: Record<string, unknown> = {};
-      if (parsed.options.maxOutputTokens) generationConfig.maxOutputTokens = parsed.options.maxOutputTokens;
+      const clampedMaxOutputTokens = clampGoogleMaxOutputTokens(identityModelId, parsed.options.maxOutputTokens);
+      if (clampedMaxOutputTokens !== undefined) generationConfig.maxOutputTokens = clampedMaxOutputTokens;
       if (parsed.options.temperature !== undefined) generationConfig.temperature = parsed.options.temperature;
       if (parsed.options.topP !== undefined) generationConfig.topP = parsed.options.topP;
       if (parsed.options.stopSequences) generationConfig.stopSequences = parsed.options.stopSequences;

--- a/tests/google-output-clamp.test.ts
+++ b/tests/google-output-clamp.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { clampGoogleMaxOutputTokens, maxOutputTokensForGoogleModel } from "../src/adapters/google";
+
+describe("google maxOutputTokens clamp", () => {
+  test("returns model-specific max output tokens limit", () => {
+    expect(maxOutputTokensForGoogleModel("gemini-3.7-flash")).toBe(65536);
+    expect(maxOutputTokensForGoogleModel("gemini-3.7-flash-tiered")).toBe(65536);
+    expect(maxOutputTokensForGoogleModel("gemini-3-pro")).toBe(65535);
+    expect(maxOutputTokensForGoogleModel("claude-3-7-sonnet")).toBe(64000);
+    expect(maxOutputTokensForGoogleModel("claude-3-5-sonnet@20241022")).toBe(64000);
+    expect(maxOutputTokensForGoogleModel("gpt-oss-120b")).toBe(32768);
+    expect(maxOutputTokensForGoogleModel("custom-unknown-model")).toBe(16384);
+  });
+
+  test("downward clamps excessive requested tokens to model max", () => {
+    expect(clampGoogleMaxOutputTokens("gemini-3.7-flash", 128000)).toBe(65536);
+    expect(clampGoogleMaxOutputTokens("gemini-3-pro", 100000)).toBe(65535);
+    expect(clampGoogleMaxOutputTokens("claude-3-7-sonnet", 100000)).toBe(64000);
+    expect(clampGoogleMaxOutputTokens("gpt-oss-120b", 64000)).toBe(32768);
+  });
+
+  test("preserves requested tokens when within model max", () => {
+    expect(clampGoogleMaxOutputTokens("gemini-3.7-flash", 4096)).toBe(4096);
+    expect(clampGoogleMaxOutputTokens("gemini-3-pro", 8192)).toBe(8192);
+    expect(clampGoogleMaxOutputTokens("claude-3-7-sonnet", 32000)).toBe(32000);
+  });
+
+  test("returns undefined when requested tokens is undefined or non-positive", () => {
+    expect(clampGoogleMaxOutputTokens("gemini-3.7-flash", undefined)).toBeUndefined();
+    expect(clampGoogleMaxOutputTokens("gemini-3.7-flash", 0)).toBeUndefined();
+    expect(clampGoogleMaxOutputTokens("gemini-3.7-flash", -10)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Split from #2470 (closed). Scope: maxOutputTokens clamping only.

Changes:
- Add maxOutputTokensForGoogleModel / clampGoogleMaxOutputTokens.
- Clamp requested maxOutputTokens per model (Flash 65536, Pro 65535, Claude 64000, GPT-OSS 32768, default 16384).
- No thinkingBudget coupling in this PR; the clamp is purely a downward cap on the requested value.

Verification:
- un test tests/google-output-clamp.test.ts -> 4 pass / 0 fail
- un run typecheck -> 0 errors

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
