### PR TITLE
fix(codex): preview Pool account per fallback candidate

### DIFF
--- a/src/codex/routing.ts
+++ b/src/codex/routing.ts
@@ -612,6 +612,15 @@ export function tryAcquireCodexQuotaScopeProbeLease(
   return probeLeaseId;
 }
 
+/** Side-effect-free check for a confirmed model-specific quota probe. */
+export function canAcquireCodexQuotaScopeProbeLease(
+  accountId: string,
+  scope: CodexQuotaScope,
+  now = Date.now(),
+): boolean {
+  return canAcquireQuotaProbeLease(scopedHealthFor(accountId, scope), now);
+}
+
 /**
  * Hand a probe lease back without recording an upstream outcome. Used by paths
  * that take a lease and then fail before any request reaches upstream.

--- a/src/codex/subagent-model-fallback.ts
+++ b/src/codex/subagent-model-fallback.ts
@@ -15,12 +15,12 @@ import { CODEX_HOME, getCodexHome } from "./paths";
 import { CODEX_UNKNOWN_USAGE_SCORE, getAccountQuota } from "./quota";
 import {
   canAcquireCodexQuotaProbeLease,
+  canAcquireCodexQuotaScopeProbeLease,
   codexQuotaScopeForModel,
   computeCodexUsageScore,
   getCodexQuotaHealthSnapshot,
   getEffectiveActiveCodexAccountId,
   getPoolAccountPlan,
-  isCodexAccountInCooldown,
 } from "./routing";
 import {
   isCodexAccountUsable,
@@ -48,6 +48,11 @@ export const DEFAULT_SUBAGENT_MODEL_FALLBACK_POLL_MS = 60_000;
 const CODEX_FORWARD_ORIGIN = new URL(CODEX_FORWARD_BASE_URL).origin.toLowerCase();
 
 type SubagentQuotaPrimeFn = (config: OcxConfig, reason: string) => Promise<void>;
+/** Side-effect-free Pool account preview for one resolved fallback candidate. */
+export type SubagentPoolAccountPreview = (
+  modelId: string | undefined,
+  now: number,
+) => string | null;
 let subagentQuotaPrimeForTests: SubagentQuotaPrimeFn | null = null;
 let quotaPrimeInFlight: Promise<void> | null = null;
 
@@ -177,8 +182,14 @@ function resolveRouteFallbackAccountId(
   route: RouteResult | null,
   config: OcxConfig,
   accountId?: string | null,
+  now = Date.now(),
+  poolAccountPreview?: SubagentPoolAccountPreview,
 ): string | null {
-  return route?.codexAccountId ?? resolvePoolFallbackAccountId(config, accountId);
+  if (route?.codexAccountId !== undefined) return route.codexAccountId;
+  if (route && isPoolCodexRoute(route) && poolAccountPreview) {
+    return poolAccountPreview(route.modelId, now);
+  }
+  return resolvePoolFallbackAccountId(config, accountId);
 }
 
 function isRoutableFallbackModel(model: string, config: OcxConfig): boolean {
@@ -237,17 +248,24 @@ export function isSubagentModelUnavailable(
   accountId?: string | null,
   now = Date.now(),
   accountUsabilityOptions?: CodexAccountUsabilityOptions,
+  poolAccountPreview?: SubagentPoolAccountPreview,
 ): boolean {
   if (isDisabledFallbackModel(model, config)) return true;
   if (!isRoutableFallbackModel(model, config)) return true;
   const route = tryRouteFallbackModel(config, model);
   if (!route || route.provider.disabled === true) return true;
-  if (isModelHealthBlocked(model, config, accountId, now)) return true;
+  const resolvedAccountId = resolveRouteFallbackAccountId(
+    route,
+    config,
+    accountId,
+    now,
+    poolAccountPreview,
+  );
+  if (isModelHealthBlocked(model, config, resolvedAccountId, now)) return true;
   if (!isPoolCodexRoute(route)) return false;
 
   // Pool candidates need a usable account. Derive requirement from the resolved
   // route (canonical openai defaults to pool even when codexAccountMode is omitted).
-  const resolvedAccountId = resolveRouteFallbackAccountId(route, config, accountId);
   if (!resolvedAccountId) return true;
   if (isCodexAccountPaused(config, resolvedAccountId)) return true;
   if (!isCodexAccountUsable(config, resolvedAccountId, accountUsabilityOptions)) return true;
@@ -257,13 +275,17 @@ export function isSubagentModelUnavailable(
     // advances instead of selecting a candidate that exact auth will reject.
     const quotaScope = codexQuotaScopeForModel(route.modelId);
     if (getCodexQuotaHealthSnapshot(resolvedAccountId, quotaScope, now) !== null) return true;
-  } else if (
-    isCodexAccountInCooldown(resolvedAccountId, now)
-    && !canAcquireCodexQuotaProbeLease(resolvedAccountId, now)
-  ) {
-    return true;
+  } else {
+    const quotaScope = codexQuotaScopeForModel(route.modelId);
+    const cooldown = getCodexQuotaHealthSnapshot(resolvedAccountId, quotaScope, now);
+    if (cooldown !== null) {
+      const probeAvailable = cooldown.quotaScope
+        ? canAcquireCodexQuotaScopeProbeLease(resolvedAccountId, cooldown.quotaScope, now)
+        : canAcquireCodexQuotaProbeLease(resolvedAccountId, now);
+      if (!probeAvailable) return true;
+    }
   }
-  return isNativeModelQuotaExhausted(model, config, accountId, now);
+  return isNativeModelQuotaExhausted(model, config, resolvedAccountId, now);
 }
 
 export function selectAvailableSubagentModel(
@@ -275,6 +297,7 @@ export function selectAvailableSubagentModel(
   nativeFallbackOnly = false,
   accountUsabilityOptions?: CodexAccountUsabilityOptions,
   trailingFallback: readonly string[] = [],
+  poolAccountPreview?: SubagentPoolAccountPreview,
 ): { model: string; rewritten: boolean; skipped: string[] } {
   const chain = normalizedChain(primary, config, extraFallback, trailingFallback);
   const skipped: string[] = [];
@@ -286,7 +309,14 @@ export function selectAvailableSubagentModel(
         continue;
       }
     }
-    if (isSubagentModelUnavailable(candidate, config, accountId, now, accountUsabilityOptions)) {
+    if (isSubagentModelUnavailable(
+      candidate,
+      config,
+      accountId,
+      now,
+      accountUsabilityOptions,
+      poolAccountPreview,
+    )) {
       skipped.push(candidate);
       continue;
     }
@@ -515,6 +545,7 @@ export function applySubagentModelFallback(
   now = Date.now(),
   nativeFallbackOnly = false,
   accountUsabilityOptions?: CodexAccountUsabilityOptions,
+  poolAccountPreview?: SubagentPoolAccountPreview,
 ): { from?: string; to?: string; skipped?: string[] } | null {
   if (!isThreadSpawnRequest(headers)) return null;
   const tomlRoleFallback = resolveAgentModelFallbackForPrimary(
@@ -536,6 +567,7 @@ export function applySubagentModelFallback(
     nativeFallbackOnly,
     accountUsabilityOptions,
     tomlRoleFallback,
+    poolAccountPreview,
   );
   if (!selection.rewritten) return selection.skipped.length > 0
     ? { from: parsed.modelId, to: parsed.modelId, skipped: selection.skipped }

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -203,6 +203,7 @@ import {
   applySubagentModelFallback,
   maybePrimeSubagentQuota,
   recordSubagentQuotaFailureForThreadSpawn,
+  type SubagentPoolAccountPreview,
 } from "../../codex/subagent-model-fallback";
 import { isNativeMainTrafficBlocked } from "../../codex/native-profile-startup";
 import {
@@ -2389,13 +2390,15 @@ async function handleResponsesInner(
     // so the preview must read the same scope slot — an undefined scope would map to the
     // "legacy" affinity bucket and never find a binding made under "shared" or a native
     // model scope, making the preview diverge from the account that actually authenticates.
-    const previewAccountId = previewCodexAccountForRequest(
+    const fallbackNow = Date.now();
+    const subagentFallbackAccountPreview: SubagentPoolAccountPreview = (modelId, previewNow) => previewCodexAccountForRequest(
       poolAffinityKey,
       config,
-      Date.now(),
-      codexQuotaScopeForModel(route.modelId),
+      previewNow,
+      codexQuotaScopeForModel(modelId),
       previewSelectionOptions,
     );
+    const previewAccountId = subagentFallbackAccountPreview(route.modelId, fallbackNow);
     subagentFallbackPreviewAccountId = previewAccountId;
     subagentFallbackAccountId = previewAccountId ?? config.activeCodexAccountId ?? null;
     const fallback = applySubagentModelFallback(
@@ -2403,9 +2406,10 @@ async function handleResponsesInner(
       req.headers,
       config,
       previewAccountId,
-      Date.now(),
+      fallbackNow,
       unreadableEncryptedAgentTask,
       previewSelectionOptions,
+      subagentFallbackAccountPreview,
     );
     if (fallback) {
       (logCtx as unknown as Record<string, unknown>).subagentModelFallbackFrom = fallback.from;

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -2367,7 +2367,7 @@ async function handleResponsesInner(
   };
   let selectedForwardHeaders = req.headers;
   let subagentFallbackAccountId = config.activeCodexAccountId ?? null;
-  let subagentFallbackPreviewAccountId: string | null | undefined;
+  let subagentFallbackAccountPreview: SubagentPoolAccountPreview | undefined;
   let subagentQuotaFailureModel = parsed.modelId;
   const parentThreadId = req.headers.get("x-codex-parent-thread-id")?.trim() ?? null;
   const poolAffinityKey = codexPoolAffinityKey(req.headers) ?? null;
@@ -2391,7 +2391,7 @@ async function handleResponsesInner(
     // "legacy" affinity bucket and never find a binding made under "shared" or a native
     // model scope, making the preview diverge from the account that actually authenticates.
     const fallbackNow = Date.now();
-    const subagentFallbackAccountPreview: SubagentPoolAccountPreview = (modelId, previewNow) => previewCodexAccountForRequest(
+    subagentFallbackAccountPreview = (modelId, previewNow) => previewCodexAccountForRequest(
       poolAffinityKey,
       config,
       previewNow,
@@ -2399,7 +2399,6 @@ async function handleResponsesInner(
       previewSelectionOptions,
     );
     const previewAccountId = subagentFallbackAccountPreview(route.modelId, fallbackNow);
-    subagentFallbackPreviewAccountId = previewAccountId;
     subagentFallbackAccountId = previewAccountId ?? config.activeCodexAccountId ?? null;
     const fallback = applySubagentModelFallback(
       parsed,
@@ -2492,15 +2491,37 @@ async function handleResponsesInner(
           // The ciphertext-only pass intentionally excludes routed candidates. Once recovery
           // makes the assignment readable, run selection again with the full configured chain
           // and keep the route in sync with any newly selected fallback.
-          const fallback = applySubagentModelFallback(
-            parsed,
-            req.headers,
-            config,
-            subagentFallbackPreviewAccountId,
-            Date.now(),
-            false,
-            previewSelectionOptions,
-          );
+          const recoverySelectionAdmission = codexAccountSelectionForTurn(options.turnAdmissionLease)?.();
+          const fallback = (() => {
+            try {
+              const recoveryNativeMainBlocked = isNativeMainTrafficBlocked();
+              const recoverySelectionOptions = {
+                nativeMainSelectionOnly: !recoveryNativeMainBlocked
+                  && recoverySelectionAdmission?.mainProfileDraining === true,
+              };
+              const recoveryNow = Date.now();
+              subagentFallbackAccountPreview = (modelId, previewNow) => previewCodexAccountForRequest(
+                poolAffinityKey,
+                config,
+                previewNow,
+                codexQuotaScopeForModel(modelId),
+                recoverySelectionOptions,
+              );
+              const recoveryPreviewAccountId = subagentFallbackAccountPreview(parsed.modelId, recoveryNow);
+              return applySubagentModelFallback(
+                parsed,
+                req.headers,
+                config,
+                recoveryPreviewAccountId,
+                recoveryNow,
+                false,
+                recoverySelectionOptions,
+                subagentFallbackAccountPreview,
+              );
+            } finally {
+              recoverySelectionAdmission?.release();
+            }
+          })();
           if (fallback) {
             (logCtx as unknown as Record<string, unknown>).subagentModelFallbackFrom = fallback.from;
             (logCtx as unknown as Record<string, unknown>).subagentModelFallbackTo = fallback.to;

--- a/tests/subagent-fallback-handle-responses.test.ts
+++ b/tests/subagent-fallback-handle-responses.test.ts
@@ -775,6 +775,73 @@ describe("native fallback account preview", () => {
     expect(finalAuth).toMatchObject({ kind: "pool", accountId: "pool-a" });
   });
 
+  test("fallback previews the Pool account separately for each candidate quota scope", async () => {
+    const cooldownAt = 1_800_000_000_000;
+    const now = cooldownAt + CODEX_QUOTA_PROBE_INTERVAL_MS + 1;
+    Date.now = () => now;
+    installPoolCredential("pool-a", "pool_acc_a", now);
+    installPoolCredential("pool-b", "pool_acc_b", now);
+    const cfg = poolNativePlusRoutedConfig({
+      activeCodexAccountId: "pool-a",
+      autoSwitchThreshold: 0,
+      subagentModelFallback: ["gpt-5.3-codex-spark", "xai/grok-4.5"],
+      codexAccounts: [
+        { id: "main", email: "main@example.test", isMain: true },
+        { id: "pool-a", email: "a@example.test", isMain: false, chatgptAccountId: "pool_acc_a" },
+        { id: "pool-b", email: "b@example.test", isMain: false, chatgptAccountId: "pool_acc_b" },
+      ],
+    });
+    const desktopHeaders = {
+      "session-id": "candidate-scope-session-private",
+      "thread-id": "candidate-scope-thread-private",
+    };
+    const bound = await resolveCodexAuthContext(new Headers(desktopHeaders), cfg, "pool", {
+      modelId: "gpt-5.6-sol",
+    });
+    expect(bound).toMatchObject({ kind: "pool", accountId: "pool-a" });
+    if (bound.kind !== "pool") throw new Error("expected pool context");
+    cfg.activeCodexAccountId = "pool-b";
+
+    recordCodexUpstreamOutcome(cfg, "pool-a", 429, {
+      modelId: "gpt-5.3-codex-spark",
+      now,
+      resetAt: Math.floor((now + 60 * 60_000) / 1_000),
+    });
+    recordCodexUpstreamOutcome(cfg, "pool-b", 429, {
+      modelId: "gpt-5.3-codex-spark",
+      now: cooldownAt,
+      resetAt: Math.floor((cooldownAt + 60 * 60_000) / 1_000),
+    });
+    const { noteSubagentModelFailure } = await import("../src/codex/subagent-model-fallback");
+    noteSubagentModelFailure("gpt-5.6-sol", "429", cfg, "pool-a", now);
+
+    expect(previewCodexAccountForRequest(bound.affinityKey ?? null, cfg, now, "shared")).toBe("pool-a");
+    expect(previewCodexAccountForRequest(bound.affinityKey ?? null, cfg, now, "spark")).toBe("pool-b");
+
+    let finalAuth: CodexAuthContext | undefined;
+    const capture = { urls: [] as string[], bodies: [] as string[], auths: [] as Array<string | null> };
+    mockUpstream(capture);
+
+    const response = await postSpawn(
+      cfg,
+      { model: "gpt-5.6-sol", input: readableAgentInput(), stream: false },
+      { onCodexAuthContextResolved: (ctx) => { finalAuth = ctx; } },
+      { model: "", provider: "" },
+      desktopHeaders,
+    );
+
+    expect(response.status).toBe(200);
+    expect(finalAuth).toMatchObject({
+      kind: "pool",
+      accountId: "pool-b",
+      probeQuotaScope: "spark",
+    });
+    expect((finalAuth as { probeLeaseId?: string }).probeLeaseId).toBeTruthy();
+    expect(capture.urls.some((url) => url.includes("chatgpt.com/backend-api/codex"))).toBe(true);
+    expect(capture.auths.some((auth) => auth?.includes("pool-b_token"))).toBe(true);
+    expect(capture.bodies.some((body) => body.includes('"model":"gpt-5.3-codex-spark"'))).toBe(true);
+  });
+
   test("uses healthier pool account B when active A is above threshold", async () => {
     const now = 1_800_000_000_000;
     Date.now = () => now;

--- a/tests/subagent-fallback-handle-responses.test.ts
+++ b/tests/subagent-fallback-handle-responses.test.ts
@@ -23,16 +23,24 @@ import {
   resolveCodexAccountForThreadDetailed,
 } from "../src/codex/routing";
 import {
+  DEFAULT_SUBAGENT_MODEL_FALLBACK_POLL_MS,
   isModelHealthBlocked,
   resetSubagentModelFallbackStateForTests,
   setSubagentQuotaPrimeForTests,
 } from "../src/codex/subagent-model-fallback";
 import { resolveCodexAuthContext, type CodexAuthContext } from "../src/codex/auth-context";
 import { handleResponses } from "../src/server/responses";
+import { resetAgentTaskRecoveryState } from "../src/server/responses/agent-task-recovery";
 import { isEagerRelaySseResponse } from "../src/server/relay";
+import type { ActiveTurnLease } from "../src/server/lifecycle";
 import type { OcxConfig } from "../src/types";
 import type { RequestLogContext } from "../src/server/request-log";
 import type { ResponsesTerminalStatus } from "../src/bridge";
+import {
+  codexHeaders,
+  encryptedInput as recoverableEncryptedInput,
+  recoverySse,
+} from "./helpers/agent-task-recovery";
 
 setDefaultTimeout(30_000);
 
@@ -51,6 +59,7 @@ beforeEach(() => {
   clearThreadAccountMap();
   clearCodexUpstreamHealth();
   clearAccountQuota();
+  resetAgentTaskRecoveryState();
   resetSubagentModelFallbackStateForTests();
 });
 
@@ -60,6 +69,7 @@ afterEach(() => {
   clearThreadAccountMap();
   clearCodexUpstreamHealth();
   clearAccountQuota();
+  resetAgentTaskRecoveryState();
   resetSubagentModelFallbackStateForTests();
   rmSync(testDir, { recursive: true, force: true });
   if (previousOpencodexHome === undefined) delete process.env.OPENCODEX_HOME;
@@ -840,6 +850,136 @@ describe("native fallback account preview", () => {
     expect(capture.urls.some((url) => url.includes("chatgpt.com/backend-api/codex"))).toBe(true);
     expect(capture.auths.some((auth) => auth?.includes("pool-b_token"))).toBe(true);
     expect(capture.bodies.some((body) => body.includes('"model":"gpt-5.3-codex-spark"'))).toBe(true);
+  });
+
+  test("recovery re-previews the Pool account for the candidate quota scope", async () => {
+    const now = 1_800_000_000_000;
+    let currentNow = now;
+    Date.now = () => currentNow;
+    installPoolCredential("pool-a", "pool_acc_a", now);
+    installPoolCredential("pool-b", "pool_acc_b", now);
+    const cfg = poolNativePlusRoutedConfig({
+      defaultProvider: "xai",
+      activeCodexAccountId: "pool-a",
+      autoSwitchThreshold: 0,
+      agentTaskRecovery: { enabled: true },
+      subagentModelFallback: ["gpt-5.3-codex-spark"],
+      codexAccounts: [
+        { id: "main", email: "main@example.test", isMain: true },
+        { id: "pool-a", email: "a@example.test", isMain: false, chatgptAccountId: "pool_acc_a" },
+        { id: "pool-b", email: "b@example.test", isMain: false, chatgptAccountId: "pool_acc_b" },
+      ],
+    });
+    const requestHeaders = codexHeaders("caller-account", {
+      "session-id": "recovery-candidate-scope-session-private",
+      "thread-id": "recovery-candidate-scope-thread-private",
+    });
+    const bound = await resolveCodexAuthContext(requestHeaders, cfg, "pool", {
+      modelId: "gpt-5.6-sol",
+    });
+    expect(bound).toMatchObject({ kind: "pool", accountId: "pool-a" });
+    if (bound.kind !== "pool") throw new Error("expected pool context");
+    cfg.activeCodexAccountId = "pool-b";
+
+    recordCodexUpstreamOutcome(cfg, "pool-a", 429, {
+      modelId: "gpt-5.3-codex-spark",
+      now,
+      resetAt: Math.floor((now + 60 * 60_000) / 1_000),
+    });
+    const { noteSubagentModelFailure } = await import("../src/codex/subagent-model-fallback");
+    noteSubagentModelFailure("gpt-5.3-codex-spark", "429", cfg, "pool-b", now);
+    noteSubagentModelFailure(
+      "gpt-5.3-codex-spark",
+      "429",
+      cfg,
+      "pool-a",
+      now,
+      10 * DEFAULT_SUBAGENT_MODEL_FALLBACK_POLL_MS,
+    );
+    noteSubagentModelFailure(
+      "xai/grok-4.5",
+      "429",
+      cfg,
+      undefined,
+      now,
+      10 * DEFAULT_SUBAGENT_MODEL_FALLBACK_POLL_MS,
+    );
+    noteSubagentModelFailure(
+      "grok-4.5",
+      "429",
+      cfg,
+      undefined,
+      now,
+      10 * DEFAULT_SUBAGENT_MODEL_FALLBACK_POLL_MS,
+    );
+
+    expect(previewCodexAccountForRequest(bound.affinityKey ?? null, cfg, now, "shared")).toBe("pool-a");
+    expect(previewCodexAccountForRequest(bound.affinityKey ?? null, cfg, now, "spark")).toBe("pool-b");
+
+    let selectionStarts = 0;
+    let selectionReleases = 0;
+    const turnAdmissionLease = {
+      release() {},
+      beginCodexAccountSelection() {
+        selectionStarts += 1;
+        return {
+          mainProfileDraining: false,
+          claimMainProfile: () => false,
+          release: () => { selectionReleases += 1; },
+        };
+      },
+    } satisfies Pick<ActiveTurnLease, "release" | "beginCodexAccountSelection">;
+    let finalAuth: CodexAuthContext | undefined;
+    const fetchedUrls: string[] = [];
+    const forwardedBodies: string[] = [];
+    const forwardedAuths: Array<string | null> = [];
+    globalThis.fetch = (async (input, init) => {
+      const raw = typeof init?.body === "string" ? init.body : "";
+      fetchedUrls.push(String(input));
+      forwardedBodies.push(raw);
+      forwardedAuths.push(new Headers(init?.headers).get("authorization"));
+      if (raw.includes("capture_assignment")) {
+        currentNow = now + DEFAULT_SUBAGENT_MODEL_FALLBACK_POLL_MS + 1;
+        return new Response(recoverySse("Use the recovered candidate-scope assignment."), {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      }
+      return Response.json({
+        id: "resp_recovered_candidate_scope",
+        object: "response",
+        status: "completed",
+        model: "gpt-5.3-codex-spark",
+        output: [],
+        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+      });
+    }) as typeof fetch;
+
+    const response = await postSpawn(
+      cfg,
+      { model: "xai/grok-4.5", input: recoverableEncryptedInput(), stream: false },
+      {
+        turnAdmissionLease,
+        onCodexAuthContextResolved: (ctx) => { finalAuth = ctx; },
+      },
+      { model: "", provider: "" },
+      requestHeaders,
+    );
+
+    expect(response.status).toBe(200);
+    const bodyRequests = forwardedBodies.map((body, index) => ({
+      body,
+      url: fetchedUrls[index],
+      auth: forwardedAuths[index],
+    })).filter(({ body }) => body.length > 0);
+    expect(bodyRequests).toHaveLength(2);
+    expect(bodyRequests[0]?.body).toContain("capture_assignment");
+    expect(bodyRequests[1]?.body).toContain("Use the recovered candidate-scope assignment.");
+    expect(bodyRequests[1]?.body).toContain('"model":"gpt-5.3-codex-spark"');
+    expect(selectionStarts).toBe(3);
+    expect(selectionReleases).toBe(3);
+    expect(finalAuth).toMatchObject({ kind: "pool", accountId: "pool-b" });
+    expect(bodyRequests[1]?.auth).toContain("pool-b_token");
   });
 
   test("uses healthier pool account B when active A is above threshold", async () => {

--- a/tests/subagent-model-fallback.test.ts
+++ b/tests/subagent-model-fallback.test.ts
@@ -24,6 +24,7 @@ import { clearAccountNeedsReauth, markAccountNeedsReauth } from "../src/codex/ac
 import { clearAccountQuota, updateAccountQuota } from "../src/codex/quota";
 import {
   canAcquireCodexQuotaProbeLease,
+  canAcquireCodexQuotaScopeProbeLease,
   clearCodexUpstreamHealthForAccount,
   CODEX_QUOTA_PROBE_INTERVAL_MS,
   recordCodexUpstreamOutcome,
@@ -215,6 +216,44 @@ describe("subagent model fallback chain", () => {
     });
   });
 
+  test("fixed account candidates do not call the Pool preview", () => {
+    updateAccountQuota("account-a", 10, undefined, 20);
+    const config = cfg({ codexAccountNamespaces: { team: "account-a" } });
+    const throwingPreview = () => {
+      throw new Error("fixed account must not call Pool preview");
+    };
+
+    expect(isSubagentModelUnavailable(
+      "team/gpt-5.5",
+      config,
+      "pool-a",
+      Date.now(),
+      undefined,
+      throwingPreview,
+    )).toBe(false);
+  });
+
+  test("a null candidate account preview does not fall back to the active Pool account", () => {
+    updateAccountQuota("pool-a", 10, undefined, 20);
+    const config = cfg({ subagentModelFallback: ["kimi/k3"] });
+
+    expect(selectAvailableSubagentModel(
+      "gpt-5.6-sol",
+      config,
+      [],
+      "pool-a",
+      Date.now(),
+      false,
+      undefined,
+      [],
+      () => null,
+    )).toEqual({
+      model: "kimi/k3",
+      rewritten: true,
+      skipped: ["gpt-5.6-sol"],
+    });
+  });
+
   test("case-distinct account selector fallbacks remain independent", () => {
     updateAccountQuota("pool-a", 95, undefined, 20);
     const config = cfg({
@@ -295,6 +334,76 @@ describe("subagent model fallback chain", () => {
       rewritten: true,
       skipped: ["gpt-5.6-sol"],
     });
+  });
+
+  test("Pool fallback skips a reset-derived cooldown in the model's quota scope", () => {
+    const now = 1_800_000_000_000;
+    updateAccountQuota("pool-a", 10, undefined, 20);
+    const config = cfg({ subagentModelFallback: ["kimi/k3"] });
+    recordCodexUpstreamOutcome(config, "pool-a", 429, {
+      modelId: "gpt-5.6-sol",
+      now,
+      resetAt: Math.floor((now + 60 * 60_000) / 1_000),
+    });
+
+    expect(selectAvailableSubagentModel("gpt-5.6-sol", config, [], "pool-a", now + 1)).toEqual({
+      model: "kimi/k3",
+      rewritten: true,
+      skipped: ["gpt-5.6-sol"],
+    });
+  });
+
+  test("Pool fallback admits a due reset-derived probe in the model's quota scope", () => {
+    const now = 1_800_000_000_000;
+    const probeAt = now + CODEX_QUOTA_PROBE_INTERVAL_MS + 1;
+    updateAccountQuota("pool-a", 10, undefined, 20);
+    const config = cfg({ subagentModelFallback: ["kimi/k3"] });
+    recordCodexUpstreamOutcome(config, "pool-a", 429, {
+      modelId: "gpt-5.6-sol",
+      now,
+      resetAt: Math.floor((now + 60 * 60_000) / 1_000),
+    });
+
+    expect(canAcquireCodexQuotaScopeProbeLease("pool-a", "shared", probeAt)).toBe(true);
+    expect(selectAvailableSubagentModel("gpt-5.6-sol", config, [], "pool-a", probeAt)).toEqual({
+      model: "gpt-5.6-sol",
+      rewritten: false,
+      skipped: [],
+    });
+  });
+
+  test("Pool fallback ignores a reset-derived cooldown for an unrelated quota scope", () => {
+    const now = 1_800_000_000_000;
+    updateAccountQuota("pool-a", 10, undefined, 20);
+    const config = cfg({ subagentModelFallback: ["kimi/k3"] });
+    recordCodexUpstreamOutcome(config, "pool-a", 429, {
+      modelId: "gpt-5.3-codex-spark",
+      now,
+      resetAt: Math.floor((now + 60 * 60_000) / 1_000),
+    });
+
+    expect(selectAvailableSubagentModel("gpt-5.6-sol", config, [], "pool-a", now + 1)).toEqual({
+      model: "gpt-5.6-sol",
+      rewritten: false,
+      skipped: [],
+    });
+  });
+
+  test("Pool fallback preserves account-wide cooldown probe pacing", () => {
+    const now = 1_800_000_000_000;
+    const probeAt = now + CODEX_QUOTA_PROBE_INTERVAL_MS + 1;
+    updateAccountQuota("pool-a", 10, undefined, 20);
+    const config = cfg({ subagentModelFallback: ["kimi/k3"] });
+    recordCodexUpstreamOutcome(config, "pool-a", 429, {
+      now,
+      resetAt: Math.floor((now + 60 * 60_000) / 1_000),
+    });
+
+    expect(selectAvailableSubagentModel("gpt-5.6-sol", config, [], "pool-a", now + 1).model)
+      .toBe("kimi/k3");
+    expect(canAcquireCodexQuotaProbeLease("pool-a", probeAt)).toBe(true);
+    expect(selectAvailableSubagentModel("gpt-5.6-sol", config, [], "pool-a", probeAt).model)
+      .toBe("gpt-5.6-sol");
   });
 
   test("account selector fallbacks still reject invalid or disabled native models", () => {


### PR DESCRIPTION
## Summary

- Preview the Pool account independently for every unqualified subagent fallback candidate, using that candidate's resolved Codex quota scope instead of reusing the initial model's account preview.
- Keep fixed account selectors fixed and keep preview side-effect-free: it does not move the account cursor, bind affinity, refresh credentials, or acquire a quota probe.
- Rebuild the candidate preview after encrypted task recovery under a fresh selection admission, release that admission in `finally`, and leave final authentication authoritative.
- Entitlement gating and atomic probe reservation ownership remain separate implementation units tracked in #2509.

This is the first focused implementation unit for #2509.

## Verification

- `bun test --isolate tests/subagent-model-fallback.test.ts tests/subagent-fallback-handle-responses.test.ts` on Bun 1.4.0: 86 passed, 2 Darwin-only skipped, 0 failed.
- Recovery regression: the original shared-scope preview selects `pool-a`, the recovered Spark candidate selects `pool-b`, and every fresh selection admission is released.
- `bun run typecheck`
- `bun run privacy:scan`
- `git diff --check`
- Reviewed the candidate-scoped preview and final-auth handoff for fixed-selector behavior, scoped cooldowns, quota checks, and probe-lease acquisition.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subagent model fallback when accounts are temporarily unavailable or subject to quota cooldowns.
  * Improved account selection for pooled subagent requests, including scope-specific quota handling.
  * Fixed encrypted-task recovery to re-evaluate account availability and authenticate with the correct account.
  * Preserved expected behavior for requests pinned to a specific account.

* **Tests**
  * Expanded coverage for fallback routing, quota cooldowns, account previews, and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->