### PR TITLE
fix(anthropic): do not let the __omit__ sentinel become an effort value

### DIFF
--- a/src/adapters/anthropic.ts
+++ b/src/adapters/anthropic.ts
@@ -27,7 +27,7 @@ import { CLAUDE_CODE_HEADERS, claudeCodeSessionId } from "./client-fingerprint";
 import { buildNonOpenAIToolCatalogNudgeForTools } from "./tool-catalog-nudge";
 import { decodeServerSentEvents } from "../lib/sse-decoder";
 import { isTranslatorBudgetExceededError, retainTranslatedEventBatch, type TranslatorBudget } from "../lib/translator-budget";
-import { modelRecordValue } from "../reasoning-effort";
+import { isReasoningEffortOmitted, modelRecordValue } from "../reasoning-effort";
 
 /** Map a user content part to an Anthropic content block (text or image source). */
 function toAnthropicContentPart(p: OcxContentPart): unknown {
@@ -521,7 +521,14 @@ function adaptiveEffort(effort: string): string {
 
 function defaultReasoningEffort(provider: OcxProviderConfig, modelId: string): string | undefined {
   const value = modelRecordValue(provider.modelDefaultReasoningEfforts, modelId);
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  // `__omit__` means "send no reasoning field", not "an effort literally named
+  // __omit__". Without this the sentinel reached the wire as
+  // `output_config.effort: "__omit__"` on adaptive models, and enabled budget
+  // thinking on the rest — the opposite of what it asks for (#2432).
+  if (!trimmed || isReasoningEffortOmitted(trimmed)) return undefined;
+  return trimmed;
 }
 
 function usageFromAnthropic(usage: Record<string, number> | undefined): OcxUsage | undefined {

--- a/tests/anthropic-reasoning.test.ts
+++ b/tests/anthropic-reasoning.test.ts
@@ -487,3 +487,43 @@ describe("Claude Desktop classifier round trip (#545)", () => {
     expect(body.stop_sequences).toEqual(["</block>"]);
   });
 });
+
+describe("provider default reasoning effort (#2494)", () => {
+  const withDefault = (model: string, effort: string) => ({
+    ...(provider as unknown as Record<string, unknown>),
+    modelDefaultReasoningEfforts: { [model]: effort },
+  } as unknown as OcxProviderConfig);
+
+  test("a configured default applies when the caller omits reasoning", async () => {
+    const model = "anthropic/claude-sonnet-4.5";
+    const b = await bodyOf(parsed(undefined, {}, model), withDefault(model, "high"));
+    expect((b.thinking as { type?: string } | undefined)?.type).toBe("enabled");
+    expect((b.thinking as { budget_tokens?: number }).budget_tokens).toBe(16384);
+  });
+
+  test("an explicit caller effort still wins over the configured default", async () => {
+    const model = "anthropic/claude-sonnet-4.5";
+    const b = await bodyOf(parsed("none", {}, model), withDefault(model, "high"));
+    expect(b.thinking).toBeUndefined();
+  });
+
+  // The sentinel means "send no reasoning field". Treating it as an effort put
+  // output_config.effort: "__omit__" on the wire for adaptive models and turned
+  // budget thinking ON for the rest — the opposite of the request.
+  test("the __omit__ sentinel never becomes an effort value", async () => {
+    const adaptive = "anthropic/claude-fable-5";
+    const a = await bodyOf(parsed(undefined, {}, adaptive), withDefault(adaptive, "__omit__"));
+    expect(a.output_config).toBeUndefined();
+    expect(a.thinking).toBeUndefined();
+
+    const budget = "anthropic/claude-sonnet-4.5";
+    const b = await bodyOf(parsed(undefined, {}, budget), withDefault(budget, "__omit__"));
+    expect(b.thinking).toBeUndefined();
+  });
+
+  test("a blank default is ignored rather than treated as an effort", async () => {
+    const model = "anthropic/claude-sonnet-4.5";
+    const b = await bodyOf(parsed(undefined, {}, model), withDefault(model, "   "));
+    expect(b.thinking).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Immediate follow-up to #2494, which landed the right feature with one gap.

The provider default is read from `modelDefaultReasoningEfforts`, which can carry the `__omit__` wire sentinel meaning **send no reasoning field**. Treated as an ordinary effort string it did the opposite of what it asks:

- adaptive models received `output_config.effort: "__omit__"` on the wire
- budget models had thinking turned **on** with a default 8192-token budget

Verified by probe against the merged code before writing the fix:

```
ADAPTIVE __omit__ -> thinking={"type":"adaptive"} output_config={"effort":"__omit__"}
BUDGET   __omit__ -> thinking={"type":"enabled","budget_tokens":8192} max_tokens=16384
```

A caller-supplied `reasoning` was never affected — only the newly added default path. A blank/whitespace default is ignored the same way.

## Verification

```
bun test tests/anthropic-reasoning.test.ts   66 pass, 0 fail
bun x tsc --noEmit                           exit 0
```

The new regressions were proven red against the pre-fix adapter: `the __omit__ sentinel never becomes an effort value` fails without the change and passes with it.

## Checklist

- [x] Regression tests added, proven failing before the change
- [x] `bun x tsc --noEmit` clean
- [x] Caller-supplied reasoning behavior unchanged



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected handling of omitted reasoning settings so internal sentinel values are no longer sent to the service.
  - Blank default reasoning settings are now ignored.
  - Explicit request-level reasoning settings continue to override configured defaults.

- **Tests**
  - Added coverage for default reasoning behavior, overrides, omitted settings, and blank values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->