### PR TITLE
test(bridge): pin legacy shell-name normalization on the SSE path

### DIFF
--- a/tests/bridge-legacy-shell-normalization.test.ts
+++ b/tests/bridge-legacy-shell-normalization.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { bridgeToResponsesSSE } from "../src/bridge";
+import type { AdapterEvent } from "../src/types";
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value, { stream: true });
+  }
+  return out;
+}
+
+async function* toolTurn(name: string): AsyncGenerator<AdapterEvent> {
+  yield { type: "tool_call_start", id: "call-1", name } as AdapterEvent;
+  yield { type: "tool_call_delta", id: "call-1", delta: '{"cmd":"ls"}' } as AdapterEvent;
+  yield { type: "tool_call_end", id: "call-1" } as AdapterEvent;
+  yield { type: "done" } as AdapterEvent;
+}
+
+// #2493: Codex 0.149 declares the shell tool as `exec`, whose own description names the
+// nested `tools.exec_command(...)` helper. Routed models echo the helper name back, and the
+// undeclared-tool guard turned that into a 502 mid-turn. These pin the SSE path the guard
+// actually runs on, which the review flagged as untested.
+describe("bridge normalizes legacy shell names against the declared catalog (#2493)", () => {
+  test("exec_command is delivered as the declared exec instead of failing the turn", async () => {
+    const sse = await drain(bridgeToResponsesSSE(
+      toolTurn("exec_command"), "deepseek-x", undefined, undefined, undefined, undefined, 50_000,
+      { declaredToolNames: new Set(["exec"]) },
+    ));
+    expect(sse).not.toContain("undeclared client tool");
+    expect(sse).toContain('"name":"exec"');
+  });
+
+  test("shell_command normalizes the same way", async () => {
+    const sse = await drain(bridgeToResponsesSSE(
+      toolTurn("shell_command"), "deepseek-x", undefined, undefined, undefined, undefined, 50_000,
+      { declaredToolNames: new Set(["exec"]) },
+    ));
+    expect(sse).not.toContain("undeclared client tool");
+    expect(sse).toContain('"name":"exec"');
+  });
+
+  test("a genuinely undeclared tool still fails the turn", async () => {
+    const sse = await drain(bridgeToResponsesSSE(
+      toolTurn("apply_patch"), "deepseek-x", undefined, undefined, undefined, undefined, 50_000,
+      { declaredToolNames: new Set(["exec"]) },
+    ));
+    expect(sse).toContain("undeclared client tool");
+  });
+
+  test("a catalog that declares exec_command itself is never rewritten", async () => {
+    const sse = await drain(bridgeToResponsesSSE(
+      toolTurn("exec_command"), "deepseek-x", undefined, undefined, undefined, undefined, 50_000,
+      { declaredToolNames: new Set(["exec", "exec_command"]) },
+    ));
+    expect(sse).not.toContain("undeclared client tool");
+    expect(sse).toContain('"name":"exec_command"');
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #2493, closing the coverage gap its review named.

#2493 normalizes `exec_command`/`shell_command` to the declared `exec`, and tested that through the undeclared-tool guard helper. The failure it fixes happens on the **SSE bridge path** — `bridgeToResponsesSSE` in `src/bridge.ts`, where the 502 was emitted mid-turn — and that path had no test.

Four cases, all against `bridgeToResponsesSSE` directly:

- `exec_command` is delivered as `exec` rather than failing the turn
- `shell_command` normalizes the same way
- a genuinely undeclared tool (`apply_patch`) still fails the turn
- a catalog that declares `exec_command` itself is never rewritten, so an MCP server advertising that name under its own namespace keeps it

## Verification

```
bun test tests/bridge-legacy-shell-normalization.test.ts   4 pass, 0 fail
```

Proven load-bearing: on `dev` **before** #2493 landed, the same file was 2 pass / 2 fail. They fail without the normalization and pass with it.

## Checklist

- [x] Tests only, no production change
- [x] Proven failing against the pre-fix tree
- [x] Covers both the fix and its two guard rails



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with legacy shell-tool names in the Responses SSE bridge.
  * Legacy `exec_command` and `shell_command` names are now recognized as `exec` when appropriate.
  * Explicitly declared tool names continue to behave as configured.
  * Undeclared tools remain correctly rejected.

* **Tests**
  * Added regression coverage for legacy tool-name normalization and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->