### PR TITLE
fix(catalog): do not carry a retained compact limit onto a corrected window

### DIFF
--- a/src/codex/catalog/parsing.ts
+++ b/src/codex/catalog/parsing.ts
@@ -320,6 +320,9 @@ export function applyNativeOpenAiContextOverride(entry: RawEntry, limits?: Nativ
     ?? (isNativeOpenAiEntry(entry) ? entry.slug as string : undefined);
   if (!nativeSlug) return;
   const override = NATIVE_OPENAI_CONTEXT_OVERRIDES[nativeSlug];
+  // Captured before any override/cap rewrites the row: a retained compaction threshold only
+  // describes the window it arrived with.
+  const incomingContextWindow = typeof entry.context_window === "number" ? entry.context_window : undefined;
   if (override) {
     // Read the effective values through the accessors rather than re-deriving them from the
     // static table: this function used to apply only the provider cap, so a per-model window
@@ -352,7 +355,14 @@ export function applyNativeOpenAiContextOverride(entry: RawEntry, limits?: Nativ
     : undefined;
   if (effectiveContext !== undefined) {
     const derivedAutoCompactTokenLimit = nativeOpenAiAutoCompactTokenLimit(nativeSlug, limits);
-    const retainedAutoCompactTokenLimit = isNativeOpenAiEntry(entry)
+    // Only trust a retained threshold that still describes THIS window. When sync corrects the
+    // window, the old number is an artifact of the old one: a 115_200 limit retained from a
+    // 128k row would pin a corrected 272k model to 42% of its real window and compact every
+    // long turn early. Lower-is-policy still holds whenever the window is unchanged.
+    const retainedDescribesCurrentContext = incomingContextWindow === undefined
+      || incomingContextWindow === effectiveContext;
+    const retainedAutoCompactTokenLimit = retainedDescribesCurrentContext
+      && isNativeOpenAiEntry(entry)
       && typeof entry.auto_compact_token_limit === "number"
       && Number.isSafeInteger(entry.auto_compact_token_limit)
       && entry.auto_compact_token_limit > 0


### PR DESCRIPTION
## Summary

Post-merge fix for a regression #1905 introduced. CI caught it on `dev` at `121c1fbe2` — `Codex catalog sync hardening > account rows reconcile idempotently` failed on both `macos` and `test 1/4`, and it reproduces locally, so it is not a flake.

#1905 added the rule that catalog sync must never *raise* a compaction threshold retained from Codex. That rule is right, but the retained number was trusted unconditionally — including when sync corrects the row's context window in the same pass.

The fixture is exactly that case: an upstream entry arrives with `context_window: 128_000` and `auto_compact_token_limit: 115_200`, and the native override widens the window to `272_000`. The retained 115200 then pinned a 272k model to **42% of its real window**, silently compacting every long turn early. Expected 244800, got 115200.

A retained threshold only describes the window it arrived with. This captures the incoming window before any override or cap rewrites the row, and trusts the retained value only when the window is unchanged. Lower-is-policy still holds in that case, which is what #1905 was protecting.

## Verification

```
bun test tests/codex-catalog-sync-hardening.test.ts tests/codex-catalog.test.ts \
         tests/auto-compact-budget.test.ts tests/native-model-toggle.test.ts \
         tests/codex-convergence-account-selectors.test.ts
273 pass, 0 fail

bun x tsc --noEmit   exit 0
```

The failing test passes without being modified — the fixture already encoded the correct expectation.

## Checklist

- [x] Root cause identified by bisect (passes at `d659c542f~1`, fails after)
- [x] Existing test restored without changing its expectation
- [x] #1905's lowering rule preserved for the unchanged-window case
- [x] `bun x tsc --noEmit` clean



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed automatic compaction limits when a model’s context window changes.
  * Prevented outdated thresholds from restricting the corrected context window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->