### PR TITLE
fix(claude): keep pre-output streams alive

### DIFF
--- a/src/claude/outbound.ts
+++ b/src/claude/outbound.ts
@@ -2,8 +2,9 @@
  * Claude Code outbound: internal /v1/responses output -> Anthropic Messages API shapes.
  *
  * Wire contract pinned in devlog/260711_claude_inbound/003_evidence.md (all Tier 2):
- *  - SSE order: message_start -> (content_block_start -> deltas -> content_block_stop)*
- *    -> message_delta -> message_stop; any number of `ping`.
+ *  - Transport-only `ping` events may appear at any point, including before
+ *    message_start. Semantic framing stays message_start ->
+ *    (content_block_start -> deltas -> content_block_stop)* -> message_delta -> message_stop.
  *  - thinking blocks get thinking_delta(s) then ONE synthetic signature_delta just
  *    before content_block_stop (CCR precedent: Claude Code does not verify signatures).
  *  - message_delta.usage is cumulative; message_start embeds a full message snapshot.

--- a/src/claude/outbound.ts
+++ b/src/claude/outbound.ts
@@ -267,12 +267,12 @@ export function responsesSseToAnthropicSse(
         emit("message_start", { type: "message_start", message: messageSnapshot(model) });
         emit("ping", { type: "ping" });
       };
-      // Once a semantic Anthropic message has started, keepalive pings protect remote
-      // deployments behind LB/NAT idle timeouts. Transport-only Responses prelude frames
-      // must not manufacture a message before a possible initial error.
+      // Keepalive pings protect remote deployments behind LB/NAT idle timeouts even
+      // before semantic output. They are transport-only and must not manufacture a
+      // message before a possible initial error.
       if (pingIntervalMs > 0) {
         pingTimer = setInterval(() => {
-          if (terminated || !started) return;
+          if (terminated || (controller.desiredSize ?? 0) <= 0) return;
           try {
             emit("ping", { type: "ping" });
           } catch { /* controller torn down; the read loop is ending anyway */ }
@@ -352,7 +352,8 @@ export function responsesSseToAnthropicSse(
         const type = upstreamDerived && isTransientUpstreamStatus(status) ? "overloaded_error" : undefined;
         if (!started) {
           // An initial upstream failure is an Anthropic error stream, not a partial message.
-          // Do not manufacture message_start/ping before the terminal error.
+          // Do not manufacture message_start before the terminal error. Earlier transport-only
+          // pings remain valid and do not turn the failure into a partial message.
           emit("error", anthropicErrorBody(status, message, type, code));
           return;
         }
@@ -366,7 +367,7 @@ export function responsesSseToAnthropicSse(
             // Transport prelude only. Start Anthropic framing on semantic output or completion.
             break;
           case "response.heartbeat":
-            if (started) emit("ping", { type: "ping" });
+            if ((controller.desiredSize ?? 0) > 0) emit("ping", { type: "ping" });
             break;
           case "response.output_text.delta": {
             if (typeof data.delta !== "string" || data.delta.length === 0) break;

--- a/tests/claude-outbound.test.ts
+++ b/tests/claude-outbound.test.ts
@@ -510,6 +510,18 @@ describe("claude outbound SSE", () => {
     expect(events.at(-1)!.data).toEqual({ type: "error", error: { type: "overloaded_error", message: "bad gateway" } });
   });
 
+  test("pre-output heartbeat stays transport-only before an initial error", async () => {
+    const upstream = [
+      sse("response.created", { response: {} }),
+      sse("response.heartbeat", {}),
+      sse("response.failed", { response: { status: "failed", error: { status: 502, message: "bad gateway" } } }),
+    ].join("");
+    const events = await collectEvents(responsesSseToAnthropicSse(streamFrom(upstream), "m", { pingIntervalMs: 0 }));
+    expect(events.map(event => event.name)).toEqual(["ping", "error"]);
+    expect(events.some(event => event.name === "message_start")).toBe(false);
+    expect(events.at(-1)!.data).toEqual({ type: "error", error: { type: "overloaded_error", message: "bad gateway" } });
+  });
+
   test("failed with NO status (relaySseWithFailedTail synthetic tail) -> default 500 -> overloaded_error", async () => {
     const upstream = [
       sse("response.created", { response: {} }),
@@ -615,6 +627,53 @@ describe("claude outbound SSE", () => {
     const pings = events.filter(e => e.name === "ping").length;
     expect(pings).toBeGreaterThanOrEqual(3); // startup ping + >=2 idle pings after semantic start
     expect(events.at(-1)!.name).toBe("message_stop");
+  });
+
+  test("idle keepalive pings flow before the first semantic output", async () => {
+    const PING_INTERVAL_MS = 25;
+    const SILENCE_MS = 300;
+    const encoder = new TextEncoder();
+    const upstream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        controller.enqueue(encoder.encode(sse("response.created", { response: {} })));
+        await new Promise(r => setTimeout(r, SILENCE_MS));
+        controller.enqueue(encoder.encode(sse("response.output_text.delta", { delta: "x" })));
+        controller.enqueue(encoder.encode(sse("response.completed", { response: { status: "completed", usage: { input_tokens: 1, output_tokens: 1 } } })));
+        controller.close();
+      },
+    });
+    const events = await collectEvents(responsesSseToAnthropicSse(upstream, "m", { pingIntervalMs: PING_INTERVAL_MS }));
+    const messageStartIndex = events.findIndex(event => event.name === "message_start");
+    expect(messageStartIndex).toBeGreaterThanOrEqual(2);
+    expect(events.slice(0, messageStartIndex).every(event => event.name === "ping")).toBe(true);
+    expect(events.at(-1)!.name).toBe("message_stop");
+  });
+
+  test("unread pre-output keepalives preserve budget for semantic output", async () => {
+    const encoder = new TextEncoder();
+    const upstream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        controller.enqueue(encoder.encode(sse("response.created", { response: {} })));
+        for (let index = 0; index < 100; index++) {
+          controller.enqueue(encoder.encode(sse("response.heartbeat", {})));
+        }
+        await new Promise(r => setTimeout(r, 75));
+        controller.enqueue(encoder.encode(sse("response.output_text.delta", { delta: "x" })));
+        controller.enqueue(encoder.encode(sse("response.completed", { response: { status: "completed", usage: { input_tokens: 1, output_tokens: 1 } } })));
+        controller.close();
+      },
+    });
+    const budget = createTestTranslatorBudget({ maxTurnBytes: 2 * 1024 });
+    const output = responsesSseToAnthropicSse(upstream, "m", { pingIntervalMs: 5, translatorBudget: budget });
+    await new Promise(r => setTimeout(r, 100));
+
+    const events = await collectEvents(output);
+    expect(events.filter(event => event.name === "ping")).toHaveLength(2);
+    expect(events.some(event => event.name === "error")).toBe(false);
+    expect(events.at(-1)!.name).toBe("message_stop");
+    const snapshot = budget.snapshot();
+    expect(snapshot.overflows).toBe(0);
+    expect(snapshot.highWaterBytes).toBeLessThan(2 * 1024);
   });
 
   test("no-output completed still emits a valid empty message", async () => {

--- a/tests/claude-outbound.test.ts
+++ b/tests/claude-outbound.test.ts
@@ -650,25 +650,30 @@ describe("claude outbound SSE", () => {
   });
 
   test("unread pre-output keepalives preserve budget for semantic output", async () => {
+    const HEARTBEAT_COUNT = 100;
+    const MAX_BUFFERED_PINGS = 10;
+    const UNREAD_MS = 100;
     const encoder = new TextEncoder();
     const upstream = new ReadableStream<Uint8Array>({
       async start(controller) {
         controller.enqueue(encoder.encode(sse("response.created", { response: {} })));
-        for (let index = 0; index < 100; index++) {
+        for (let index = 0; index < HEARTBEAT_COUNT; index++) {
           controller.enqueue(encoder.encode(sse("response.heartbeat", {})));
         }
-        await new Promise(r => setTimeout(r, 75));
+        await new Promise(r => setTimeout(r, UNREAD_MS));
         controller.enqueue(encoder.encode(sse("response.output_text.delta", { delta: "x" })));
         controller.enqueue(encoder.encode(sse("response.completed", { response: { status: "completed", usage: { input_tokens: 1, output_tokens: 1 } } })));
         controller.close();
       },
     });
     const budget = createTestTranslatorBudget({ maxTurnBytes: 2 * 1024 });
-    const output = responsesSseToAnthropicSse(upstream, "m", { pingIntervalMs: 5, translatorBudget: budget });
-    await new Promise(r => setTimeout(r, 100));
+    const output = responsesSseToAnthropicSse(upstream, "m", { pingIntervalMs: 1, translatorBudget: budget });
+    await new Promise(r => setTimeout(r, UNREAD_MS + 25));
 
     const events = await collectEvents(output);
-    expect(events.filter(event => event.name === "ping")).toHaveLength(2);
+    // The exact number admitted depends on the runtime's stream queue size. A generous
+    // ceiling still catches either an unguarded heartbeat burst or the 1 ms timer.
+    expect(events.filter(event => event.name === "ping").length).toBeLessThanOrEqual(MAX_BUFFERED_PINGS);
     expect(events.some(event => event.name === "error")).toBe(false);
     expect(events.at(-1)!.name).toBe("message_stop");
     const snapshot = budget.snapshot();


### PR DESCRIPTION
## Summary

- keep Claude streaming connections active while waiting for the first semantic output
- relay periodic keepalives and upstream heartbeats as transport-only `ping` events without manufacturing `message_start`
- skip optional keepalives under output backpressure so a stalled reader cannot consume the semantic translation budget
- preserve initial upstream failures as error streams even when a transport-only ping was already sent

## Verification

- `bun test --isolate tests/claude-outbound.test.ts` (Bun 1.4.0-canary.1: 41 pass, 0 fail)
- `bun run typecheck`
- `bun run privacy:scan`
- `git diff --check`
- regression mutation check: removing either keepalive backpressure guard fails the bounded-ping test
- independent current-diff review: no actionable findings

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming keepalive behavior before semantic output begins.
  * Prevented incomplete message framing when an upstream connection fails early.
  * Ensured idle connections remain responsive while awaiting the first output.
  * Safely handles unread keepalive signals without disrupting stream completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->