### PR TITLE
fix(gui): show the device code and authorization link on every login surface

### DIFF
--- a/devlog/_plan/260825_oauth_login_ux/000_baseline_and_scope.md
+++ b/devlog/_plan/260825_oauth_login_ux/000_baseline_and_scope.md
@@ -1,0 +1,112 @@
+# 000 — OAuth login UX: baseline, pain points, and work-phase map
+
+Unit opened 2026-08-25. Session `01a036cb-4f1c-7b81-8c8d-277f92c914a7`.
+Goalplan slug `fix-oauth-login-remote-headless-ux-in-opencodex`.
+
+## Baseline
+
+| Ref | SHA |
+|-----|-----|
+| `origin/dev` | `bb89eafbe` |
+| `origin/main` | `71c57ea64` |
+
+## The pain points, as reported
+
+These are the operator's own words, recorded before any code was read. Every
+work-phase in this unit traces back to one of them.
+
+> 지금 oauth 로그인 + 원격 지원이 너무 불편하다
+>
+> 1. 이미 프로바이더가 추가된 상태에서는 링크를 복사할 수 있지만 → 첫 추가 때 못함
+>    → 링크 복사 못함, 크롬 다른 프로필 못함
+> 2. 프로바이더 추가도 링크는 보이지만 device 로그인을 하기가 좀 불편함. GUI에서
+>    코드 붙여넣기가 있는 그록이나 claude 쪽도 약간 불편함
+
+In English, for the issue tracker:
+
+1. **The first add is the worst experience.** Once a provider exists, its
+   workspace panel shows the authorization URL with a copy button. During the
+   very first login — the one where the operator has no other way in — that
+   affordance is not there. No copyable link means no way to open the URL in a
+   *different* Chrome profile, and no way to finish the login from another
+   machine.
+2. **Device login is awkward in the GUI**, and the paste-a-code providers
+   (xAI Grok, Anthropic Claude) are awkward too.
+
+## What the code says
+
+The report is accurate, and the cause is a split that nobody planned. Two
+login surfaces exist and each one has exactly the half the other is missing.
+
+| Affordance | Workspace panel (existing provider) | Add-provider modal (first add) |
+|------------|-------------------------------------|--------------------------------|
+| Authorization URL + copy | yes | **no** |
+| Device / user code + copy | yes | **no** |
+| Paste redirect URL or code | **no** | yes |
+| Cancel | yes | no |
+
+- `gui/src/components/provider-workspace/ProviderAuthPanel.tsx` renders the
+  URL and the device code, and has no paste input anywhere in its 568 lines.
+- `gui/src/components/add-provider-oauth-pane.tsx` renders the paste input,
+  and its `LoginUrlBlock` is fed by a hook that never reads `deviceCode`.
+- `gui/src/components/use-add-provider-oauth.ts` parses the login response as
+  `{ url, instructions, error }`. The server returns `deviceCode` as well
+  (`src/server/management/oauth-account-routes.ts`); the modal discards it.
+- The Accounts tab of the add-provider modal
+  (`gui/src/components/provider-catalog/ProviderCatalog.tsx`) starts a login
+  through `Providers.tsx`, which stores the hint in `loginInfo` — read only
+  by `ProviderAuthPanel`. During a first add the modal is on screen and the
+  panel is not, so the hint is computed, stored, and never displayed.
+
+That is the whole of pain point 1: not a missing feature, a hint with no
+renderer.
+
+## The remote half
+
+`POST /api/oauth/login` calls `openUrl(authUrl)` unconditionally whenever a
+browser flow returns a URL. `src/lib/open-url.ts` shells out to `open` /
+`xdg-open` / `rundll32`, which means the **OS default browser profile** —
+the operator cannot send it to a second Chrome profile, and on a headless or
+SSH host the spawn is simply lost. There is no opt-out today: not a request
+field, not a config key, not an environment variable.
+
+## Work-phase map
+
+| Phase | Doc | Deliverable |
+|-------|-----|-------------|
+| WP1 | this unit | Docs-only roadmap at diff-level precision |
+| WP2 | `010` | One login-hint component: URL + device code + paste, on all three surfaces |
+| WP3 | `020` | First-add parity: the hint renders inside the add-provider modal |
+| WP4 | `030` | Operator control over server-side browser auto-open |
+| WP5 | `040` | Paste normalization and survivable failures |
+
+One work-phase is one full PABCD cycle, one decade doc, one issue, one PR
+against `dev`.
+
+## Scope boundary
+
+Out of scope, stated once:
+
+- Token storage format, credential refresh, and the account store schema.
+- New providers or adapters, account-pool routing, quota surfaces.
+- `src/lab/` — the core-lab boundary test exists for a reason.
+- Publishing, releasing, or merging anything.
+
+## Security invariants this unit must not break
+
+These are already load-bearing in the code and a UX change is not permitted to
+soften them:
+
+- `src/oauth/github-copilot.ts` constructs its verification URL locally and
+  refuses a non-allowlisted one; a server-supplied `verification_uri_complete`
+  is never handed to `openUrl`.
+- `src/oauth/callback-server.ts` enforces state on `url`/`query`-shaped
+  pastes and exempts only a syntactically raw in-session code.
+- `src/oauth/index.ts` bounds a pasted payload at 4 KiB and validates it
+  synchronously before it reaches the flow.
+- No token, authorization code, or request body may be logged.
+
+## Evidence rule
+
+A remembered pass is not evidence. Every completion claim carries exact command
+output, the issue and PR numbers, the head SHA, and the CI conclusion on it.

--- a/devlog/_plan/260825_oauth_login_ux/001_current_state_inventory.md
+++ b/devlog/_plan/260825_oauth_login_ux/001_current_state_inventory.md
@@ -1,0 +1,147 @@
+# 001 — Current-state inventory of every login surface
+
+Read at `bb89eafbe`. Every claim below is a file:line read, not a memory.
+
+## Three surfaces, three renderers
+
+There are three places a human can start an OAuth login in the GUI, and they
+do not share a renderer.
+
+### A. Workspace auth panel — an already-added provider
+
+`gui/src/components/provider-workspace/ProviderAuthPanel.tsx`
+
+- `:242` picks the hint for this row: `loginHint?.provider === item.name`.
+- `:392-401` renders the device code with a copy button.
+- `:402` renders `<LoginUrlBlock url={hintForThis.url ?? ""} />`.
+- `:403-408` renders Cancel.
+- A search for `paste`, `manual`, or `submitManual` across all 568 lines
+  returns nothing. **This surface cannot accept a pasted code.**
+
+### B. Add-provider modal, OAuth pane — a first add via a catalog preset
+
+`gui/src/components/add-provider-oauth-pane.tsx`
+
+- `:59` renders `<LoginUrlBlock url={oauthUrl} />`.
+- `:60-99` renders the paste input and submit button.
+- No device code is rendered anywhere. The prop does not exist.
+- When a device flow returns no `url`, `LoginUrlBlock` returns `null`
+  (`login-url-block.tsx:16`), so the pane shows a spinner label and an empty
+  paste box with nothing to act on.
+
+The hook behind it, `gui/src/components/use-add-provider-oauth.ts:53`:
+
+```ts
+const data = await res.json() as { url?: string; instructions?: string; error?: string };
+```
+
+`deviceCode` is not in the type and is never read, although
+`src/server/management/oauth-account-routes.ts:176` returns it:
+
+```ts
+return jsonResponse({ url: authUrl, instructions, deviceCode });
+```
+
+### C. Add-provider modal, Accounts tab — a first add via an account row
+
+`gui/src/components/provider-catalog/ProviderCatalog.tsx:148-212`
+
+The account rows call `onLogin(row.id)`, which is `Providers.tsx`'s
+`requestLoginOAuth`. That path stores the hint:
+
+- `gui/src/pages/use-providers-oauth.ts:93-96` reads `url`,
+  `instructions` **and** `deviceCode`, then calls `setLoginInfo`.
+- `gui/src/pages/Providers.tsx:365` passes `loginInfo` to
+  `ProviderDetails` → `ProviderAuthPanel`.
+
+`ProviderAuthPanel` is the workspace surface for an **existing** provider.
+During a first add the modal is open and no panel is mounted for that
+provider, so the hint has no renderer. The row renders
+`t("prov.waitingBrowser")` and a Cancel button, and that is all the operator
+gets: no URL, no code, no paste box.
+
+**This is pain point 1 exactly.** The data arrives; nothing draws it.
+
+### D. Codex account modal — a fourth, near-duplicate surface
+
+`gui/src/components/add-codex-account-waiting-step.tsx:38-69` renders
+`LoginUrlBlock` plus its own paste input against
+`/api/codex-auth/login/code`. `src/codex/auth-api.ts:2077` returns only
+`{ flowId, url, instructions }` — no device code on this path either.
+
+## What each provider actually returns
+
+`startLoginFlow` (`src/oauth/index.ts:1420-1504`) resolves
+`{ url, instructions?, deviceCode? }` from the provider's `onAuth` call.
+
+| Provider | Shape | Produced at |
+|----------|-------|-------------|
+| xAI, Anthropic, ChatGPT, Cursor, Antigravity, Kiro | browser redirect + loopback callback | `OAuthCallbackFlow.login()`, `callback-server.ts:116` |
+| Kimi | device flow | `kimi.ts:212` — `instructions: "Enter code: …"`, **no `deviceCode` field** |
+| Nous | device flow | `nous.ts:660-663` — sets `deviceCode: device.userCode` |
+| GitHub Copilot | device flow | `github-copilot.ts:393-402` — locally constructed verify URL, `deviceCode: device.userCode` |
+| local-token import | no browser | `index.ts:1473` resolves `{ url: "" }` with an explanatory string |
+
+Two observations that matter for WP2:
+
+1. Kimi puts the user code inside a free-text `instructions` string instead of
+   the structured `deviceCode` field, so no surface can render it as a code.
+2. `github-copilot.ts:170` refuses to trust `verification_uri_complete` and
+   builds the URL itself. That invariant is not negotiable in WP4.
+
+## The manual-paste path, end to end
+
+1. `POST /api/oauth/login/code` — `oauth-account-routes.ts:202-213`.
+   Caps input at 4096 chars, calls `submitManualLoginCode`, returns 409 on
+   failure.
+2. `submitManualLoginCode` — `index.ts:1329-1360`. Rejects empty, rejects
+   >4 KiB, rejects when no login is in progress, then `parseCallbackInput`.
+   Rejects when no `code` is found; for `url`/`query` shapes enforces
+   state once the flow has registered `expectedState`.
+3. `parseCallbackInput` — `callback-server.ts:273-300`. Three shapes:
+   a parseable URL, a string containing `code=`, or a raw code with optional
+   `#state`.
+4. `OAuthCallbackFlow.#waitForCallback` — `callback-server.ts:238-261`
+   re-parses and loops on a bad paste.
+
+The flow **does** survive a rejected paste — the loop re-prompts. What it does
+not do is tell the operator anything useful: the GUI shows
+`t("prov.pasteFail", { error })`, and only surface B has a paste box at all.
+
+Accepted today: `https://…/callback?code=X&state=Y`, `?code=X&state=Y`,
+`code=X&state=Y`, `X`, `X#Y`. Whitespace is trimmed at three separate
+layers. A URL missing `state` is rejected with a specific message.
+
+## Server-side browser opening
+
+`oauth-account-routes.ts:170-175`:
+
+```ts
+if (authUrl && !deviceCode) {
+  const { openUrl } = await import("../../lib/open-url");
+  openUrl(authUrl);
+}
+```
+
+Unconditional for browser flows. `src/codex/auth-api.ts:1844` does the same
+on the Codex path. `src/lib/open-url.ts:11-24` spawns the platform opener,
+which resolves the **default** browser and therefore the default profile. It
+swallows spawn errors deliberately (a headless host emits ENOENT
+asynchronously), so a failed open is indistinguishable from a successful one
+from the GUI's perspective.
+
+There is no opt-out: no request field, no config key, no environment variable.
+Grepping `openUrl` finds callers in `login-cli.ts:85`, `dispatch.ts:305`,
+`auth-api.ts:1844`, and `oauth-account-routes.ts:173`; none is conditional.
+
+## Existing tests
+
+`tests/oauth-manual-code.test.ts` covers the paste path;
+`tests/oauth-callback-server.test.ts` and `oauth-callback-binds.test.ts`
+cover parsing and binding; `tests/github-copilot-oauth.test.ts`,
+`nous-oauth.test.ts`, `kimi-oauth-identity.test.ts` cover device flows;
+`tests/oauth-public-surface.test.ts` and `oauth-status-privacy.test.ts`
+cover the management surface and its redaction.
+
+Not covered anywhere: what the GUI *renders* during a login. Every gap in this
+unit lives in that hole.

--- a/devlog/_plan/260825_oauth_login_ux/002_plan_audit.md
+++ b/devlog/_plan/260825_oauth_login_ux/002_plan_audit.md
@@ -1,0 +1,93 @@
+# 002 — Plan audit: what ships, what does not, and how it splits
+
+## The one-sentence diagnosis
+
+Nothing here is missing infrastructure. The server already computes the
+authorization URL, the device code, and the manual-paste channel; four GUI
+surfaces each render a different subset of it, and one of them renders none of
+it at the exact moment the operator has no other option.
+
+## Candidate list, and the cut
+
+Eleven changes were on the table after reading the tree. Four ship in this
+unit. The rest are recorded here so a later cycle does not rediscover them.
+
+### Shipping
+
+| WP | Change | Why it is in |
+|----|--------|--------------|
+| WP2 | One login-hint component: URL + device code + paste on all surfaces | Directly answers pain point 2; every other GUI fix depends on it existing |
+| WP3 | The hint renders during a first add | Directly answers pain point 1 |
+| WP4 | Operator control over server-side auto-open | The "다른 Chrome 프로필" half of pain point 1, and the whole remote story |
+| WP5 | Paste normalization: hash-fragment redirects | A real paste that looks valid and is silently rejected today |
+
+### Deferred, with reasons
+
+- **Expiry countdown / poll interval in the GUI.** The polling math is already
+  correct in each provider; showing it is additive UI over a DTO that does not
+  carry `expiresAt` yet. Real, but not a pain point that was reported.
+- **Kimi allowlisting of `verification_uri_complete`.** Kimi and Nous pass the
+  provider-supplied complete URI into `onAuth`. Copilot refuses to
+  (`github-copilot.ts:393`). Tightening Kimi/Nous is a **security** change,
+  not a UX change, and it does not belong in a PR whose title says "GUI". It
+  gets its own issue.
+- **`openUrl` returning success/failure.** Attractive, but the spawn is
+  detached and a browser that opens then fails is indistinguishable from one
+  that never launched. A truthful signal needs more than an exit code.
+- **A browser/profile picker in the GUI.** WP4 gives the operator the
+  *ability* to not have their default profile hijacked. A full picker is a
+  product surface, and the operator asked for control, not a picker.
+- **`ocx login` re-prompt loop.** The CLI's one-shot readline is a smaller
+  version of the same bug, on a surface nobody reported. Own issue.
+
+## The default-preservation rule
+
+WP4 is the only phase that can change what already happens, so it carries the
+strictest constraint in this unit: **auto-open stays the default.** An
+operator who upgrades and does nothing must see byte-identical behavior. The
+new capability is an explicit choice, never an inferred one.
+
+That rules out the tempting version of this feature — sniffing
+`SSH_CONNECTION` or an absent `DISPLAY` and silently declining to open. A
+false positive there (X11 forwarding, WSLg, a desktop session that does not
+advertise itself) breaks a login that works today, and breaks it silently.
+Explicit opt-out first; inference is a separate decision with its own
+evidence.
+
+## Security invariants, restated as gates
+
+A PR in this unit fails review if it:
+
+1. Hands a provider-supplied `verification_uri_complete` to `openUrl`.
+2. Weakens state enforcement on `url`/`query`-shaped pastes
+   (`callback-server.ts:252`, `index.ts:1347-1350`).
+3. Accepts `access_token` from a URL fragment — hash parsing in WP5 reads
+   `code` and `state` only, never a token.
+4. Raises the 4 KiB paste bound or the 4096-char route cap.
+5. Logs a URL, a code, a token, or a request body.
+6. Passes a shell string where an argv array is required.
+
+## Dependency order and the PR stack
+
+```
+WP2 (shared hint component)
+ └── WP3 (first-add parity — renders the WP2 component)
+WP4 (auto-open control)      ← independent
+WP5 (paste normalization)    ← independent
+```
+
+WP3 stacks on WP2 because it mounts the component WP2 creates. WP4 and WP5
+touch disjoint files and target `dev` directly.
+
+| WP | Issue template | PR base | GUI screenshot |
+|----|----------------|---------|----------------|
+| WP2 | feature_request | `dev` | required |
+| WP3 | bug_report | WP2 head | required |
+| WP4 | feature_request | `dev` | required if GUI toggle lands |
+| WP5 | bug_report | `dev` | not required |
+
+## Verdict
+
+PASS. Four phases, dependency-ordered, each with a falsifiable test and a
+bounded diff. The audit's one binding instruction to later phases: WP4 must
+ship the explicit choice and must not ship inference.

--- a/devlog/_plan/260825_oauth_login_ux/003_delivery_map.md
+++ b/devlog/_plan/260825_oauth_login_ux/003_delivery_map.md
@@ -1,0 +1,118 @@
+# 003 — Delivery: four issues, four pull requests
+
+Each pain point gets its own issue and its own PR. Nothing here merges without
+the maintainer saying so.
+
+## Issue set
+
+| # | Template | Title | Area |
+|---|----------|-------|------|
+| I1 | `bug_report.yml` | First-time OAuth add shows no copyable authorization link | Dashboard |
+| I2 | `feature_request.yml` | Device-code logins need one consistent hint on every surface | Dashboard |
+| I3 | `feature_request.yml` | Let the operator stop the proxy from opening its own browser | Authentication and account pool |
+| I4 | `bug_report.yml` | A pasted redirect URL with fragment parameters is rejected as having no code | Authentication and account pool |
+
+All four use `Client or integration: OpenCodex dashboard` where the form asks,
+and every required field is filled — the `enforce-issue-quality` gate closes
+untemplated issues rather than nudging them.
+
+### I1 — required-field content
+
+**Summary.** Once a provider is added, its workspace panel shows the
+authorization URL with a copy button. During the *first* login for that
+provider, started from the add-provider dialog, no link is shown at all — only
+"Waiting for browser…". The proxy opens the URL in the OS default browser, so
+an operator who needs a different browser profile, or who is running the
+dashboard against a remote host, has no way to reach the login.
+
+**Reproduction.**
+
+1. Start with no xAI provider configured.
+2. Open the dashboard, Providers, Add provider, Accounts tab.
+3. Press Log in on a provider that is not yet added.
+4. Observe: a spinner and "Waiting for browser…". No URL, no copy button, no
+   device code, no paste field.
+5. Add the provider, log out, press Log in from its workspace panel instead.
+6. Observe: the URL, a copy button, and a device code when the provider sends
+   one.
+
+**Expected.** Step 4 offers the same recovery affordances as step 6.
+
+### I2 — required-field content
+
+**Goal.** Finish a device-code login from the dashboard without guessing.
+
+**Blocker.** The user code is rendered on exactly one of four login surfaces.
+The add-provider dialog reads only `url` and `instructions` from the login
+response and drops `deviceCode`. One provider never sets `deviceCode` at all
+and puts the code inside a prose string, so no surface can render it as a
+code.
+
+**Expected behavior.** Every surface that can start a login shows, when the
+provider supplies them: the user code with a copy button, the verification URL
+with a copy button, and a field to paste a redirect URL or code.
+
+### I3 — required-field content
+
+**Goal.** Complete an OAuth login in a chosen browser profile, or on a
+different machine from the one running the proxy.
+
+**Blocker.** `POST /api/oauth/login` always opens the authorization URL with
+the platform opener, which resolves the default browser and therefore the
+default profile. There is no request field, config key, or environment
+variable to decline. With the dashboard open against a remote host, the
+browser opens on the host.
+
+**Expected behavior.** An explicit operator choice not to open a browser,
+per login and persistently. Default behavior is unchanged: without that
+choice, the browser opens exactly as it does today.
+
+### I4 — required-field content
+
+**Summary.** A redirect URL whose `code` and `state` arrive in the fragment
+is rejected with "no authorization code found in input", although the paste
+hint explicitly asks for the full URL from the address bar.
+
+**Reproduction.** Start a login, complete it in a browser, paste a redirect of
+the form `http://localhost:1455/callback#code=…&state=…` into the paste
+field. Observe the rejection.
+
+**Expected.** The code is read from the fragment, and state is still enforced.
+
+## Pull requests
+
+| PR | Closes | Base | Title |
+|----|--------|------|-------|
+| P1 | I2 | `dev` | `fix(gui): show the device code and authorization link on every login surface` |
+| P2 | I1 | P1 head | `fix(gui): render the login hint during a first-time provider add` |
+| P3 | I3 | `dev` | `feat(oauth): let the operator decline a proxy-side browser open` |
+| P4 | I4 | `dev` | `fix(oauth): read code and state from a redirect URL fragment` |
+
+P2 targets P1's head because it mounts the component P1 introduces; the
+`enforce-target` check skips the wrong-base gate for a stacked child, and P2
+retargets to `dev` once P1 lands.
+
+### The disclosure P1 must carry
+
+P1's Summary states the behavior change plainly rather than letting it hide in
+the diff:
+
+> Setting `deviceCode` for the one device provider that omitted it also stops
+> the proxy from auto-opening that provider's verification URL, because the
+> login route skips the browser open whenever a device code is present. This
+> aligns it with the other two device providers and means no provider-supplied
+> verification URL is handed to a local process spawn. The URL remains visible
+> and copyable on every surface.
+
+A reviewer reading only `kimi.ts` would not see the route.
+
+## What is not delivered here
+
+Recorded so the next cycle inherits them rather than rediscovering them:
+
+- Allowlisting provider-supplied verification URIs for the two device
+  providers that pass them through (security issue, own PR).
+- Expiry countdown and poll-interval display.
+- `ocx login`'s one-shot paste prompt, which does not re-prompt after a bad
+  paste the way the dashboard does.
+- A browser/profile picker built on an operator-supplied command.

--- a/devlog/_plan/260825_oauth_login_ux/010_wp2_shared_login_hint.md
+++ b/devlog/_plan/260825_oauth_login_ux/010_wp2_shared_login_hint.md
@@ -23,7 +23,13 @@ string and never sets `deviceCode`.
 ### 1. `gui/src/components/login-url-block.tsx` → a full hint component
 
 Keep `LoginUrlBlock` as-is (it has three callers and a clean contract) and add
-a sibling in the same file that composes it:
+a sibling in the same file that composes it.
+
+**Naming, as landed:** `ProviderAuthPanel` already imports a `LoginHint`
+*type* from `./types` (the `{ provider, url, instructions, deviceCode }`
+shape). The new component therefore has to be aliased at that one call site —
+`import { LoginHint as LoginHintView }` — or the identifier collides. Renaming
+the existing type would touch more files than the feature does.
 
 ```tsx
 export type LoginHintData = {
@@ -67,14 +73,33 @@ a device flow with no URL still has a code to show. Guard on
 +const data = await res.json() as { url?: string; instructions?: string; deviceCode?: string; error?: string };
 -if (data.url) { setOauthUrl(data.url, providerId); setOauthMsg(t("modal.waitingLogin")); }
 -else { setOauthMsg(data.instructions || t("modal.loggingIn")); }
-+setOauthHint({ url: data.url, deviceCode: data.deviceCode, instructions: data.instructions }, providerId);
-+setOauthMsg(data.url || data.deviceCode ? t("modal.waitingLogin") : (data.instructions || t("modal.loggingIn")));
++setOauthUrl(data.url ?? "", providerId, data.deviceCode, data.instructions);
++if (data.url || data.deviceCode) setOauthMsg(t("modal.waitingLogin"));
++else setOauthMsg(data.instructions || t("modal.loggingIn"));
 ```
 
-The reducer in `add-provider-modal-reducer.ts` carries `oauthUrl` +
-`oauthUrlProvider` today; widen to an `oauthHint` object with the same
-provider tag so a stale hint from a cancelled provider still cannot leak into
-another provider's pane.
+**Reducer, as landed.** The plan first proposed replacing `oauthUrl` with an
+`oauthHint` object. That was rejected during implementation: `set-oauth-url`
+already carries the provider tag and the "switched away" guard, and swapping
+the slot for an object would have rewritten that guard for no behavioral gain.
+
+What shipped instead is the smaller change — two sibling fields beside the
+existing one, carried by the same action and cleared by the same three cases:
+
+```diff
+   oauthUrl: string;
++  oauthDeviceCode: string;
++  oauthInstructions: string;
+   oauthUrlProvider: string | null;
+
+-  | { type: "set-oauth-url"; url: string; providerId: string }
++  | { type: "set-oauth-url"; url: string; providerId: string; deviceCode?: string; instructions?: string }
+```
+
+The leak guard is unchanged and still load-bearing: `set-oauth-url` returns
+`state` untouched when `state.preset?.oauthProvider !== action.providerId`,
+and `choose-preset` / `back` / `use-api-key-instead` clear all three fields
+together. A hint for one provider cannot render under another.
 
 ### 3. `src/oauth/kimi.ts:212`
 
@@ -125,13 +150,17 @@ what is *displayed*, not what is *executed*.
 
 - `add-provider-oauth-pane.tsx:59-99` — replace `LoginUrlBlock` + the inline
   paste block with one `<LoginHint hint={hint} paste={…} />`.
-- `ProviderAuthPanel.tsx:392-402` — replace the inline device-code block and
-  `LoginUrlBlock` with `<LoginHint>`, **and pass `paste`**. This is the
-  first time the workspace panel can accept a pasted code; it needs the same
-  `submitManualCode` the modal already has, pointed at
+- `provider-workspace/ProviderAuthPanel.tsx:392-402` — replace the inline
+  device-code block and `LoginUrlBlock` with the aliased `<LoginHintView>`,
+  **and pass `paste`**. This is the first time the workspace panel can accept
+  a pasted code; it gets its own `submitManualCode` pointed at
   `/api/oauth/login/code`.
 - `add-codex-account-waiting-step.tsx:38-69` — same swap. Its submit goes to
-  `/api/codex-auth/login/code`, so `paste.onSubmit` stays caller-owned.
+  `/api/codex-auth/login/code`, so `paste.onSubmit` stays caller-owned —
+  sharing a renderer does not merge two backends.
+
+**Still not covered by this phase:** the add-provider Accounts-tab rows render
+no hint at all. That is WP3's whole subject (`020`), not an omission here.
 
 ## i18n
 

--- a/devlog/_plan/260825_oauth_login_ux/010_wp2_shared_login_hint.md
+++ b/devlog/_plan/260825_oauth_login_ux/010_wp2_shared_login_hint.md
@@ -123,10 +123,10 @@ gates its browser-open on that exact field:
 if (authUrl && !deviceCode) { openUrl(authUrl); }
 ```
 
-Today Kimi sets no `deviceCode`, so the proxy auto-opens
-`device.verificationUriComplete` — a **provider-supplied** URL. Setting
-`deviceCode` means Kimi stops being auto-opened, exactly like Nous and
-Copilot already are.
+Before this change Kimi set no `deviceCode`, so the proxy auto-opened
+`device.verificationUriComplete` — a **provider-supplied** URL. Setting the
+field means Kimi stops being auto-opened, exactly like Nous and Copilot
+already are.
 
 That is the correct direction on both counts. It ends an inconsistency where
 two device providers are treated as device flows and the third is not, and it
@@ -164,28 +164,37 @@ no hint at all. That is WP3's whole subject (`020`), not an omission here.
 
 ## i18n
 
-`prov.deviceCode` exists. New keys, added to **all** locale files under
-`gui/src/i18n/` (en, ko, ja, zh, zh-TW, de, fr, ru, tr):
-
-- `prov.deviceCodeHint` — "Enter this code after opening the link."
-
-English is the source; a locale that has no translation yet falls back through
-the existing mechanism rather than shipping an English string in a translated
-file.
+**No new keys were needed.** `prov.deviceCode`, `prov.copyCode`,
+`prov.codeCopied`, `prov.pasteRedirect`, `prov.pasteRedirectHint`,
+`prov.pasteSubmit`, and `prov.pasteSubmitting` already exist in all nine
+locale files, because both halves of this component already shipped — just on
+different surfaces. Unifying them is a wiring change, not a copy change, so no
+locale is left with an untranslated English string.
 
 ## Test
 
-`tests/oauth-login-hint.test.ts` (new):
+Two new files, split by what they lock:
 
-1. `loginKimi` calls `onAuth` with `deviceCode` equal to the user code —
-   fake the device-authorization fetch, assert the field. This is the one
-   assertion that would have caught the original gap.
-2. Re-assert the same for `loginNous` and `loginGithubCopilot` so the
-   contract is enforced for every device provider, not just the one being
-   fixed.
-3. Route-level: with `deviceCode` present, `POST /api/oauth/login` does not
-   call the opener; with a browser flow it does. This locks the consequence
-   described above so it can never regress silently in either direction.
+`tests/oauth-device-code-contract.test.ts` — `loginKimi` calls `onAuth`
+with `deviceCode` equal to the user code, against a faked
+device-authorization response. This is the assertion that would have caught
+the original gap. It was driven red against the pre-fix `kimi.ts` before
+being accepted, so it is not vacuous. `loginNous` and
+`loginGithubCopilot` already have equivalent `onAuth` assertions in
+`tests/nous-oauth.test.ts` and `tests/github-copilot-oauth.test.ts`, so
+re-asserting them here would duplicate rather than protect.
+
+`tests/oauth-login-open-browser.test.ts` — the route consequence, both
+directions: with `deviceCode` present, `POST /api/oauth/login` does not call
+the opener and still returns the URL and code; with a plain browser flow it
+opens exactly as before. The second case is the compatibility guard.
+
+Two existing seam tests were **updated, not relaxed**:
+`tests/provider-workspace-auth.test.ts` still demands a device-code widget,
+now pointed at its new owner, and gains an assertion that the workspace can
+reach `/api/oauth/login/code`; `tests/codex-auth-modal-status.test.ts` still
+locks the same four-part submit guard and the distinct submitting copy, now as
+props rather than a JSX string.
 
 GUI rendering is verified by screenshot in the PR; this repo has no component
 test harness and this phase is not the place to introduce one.

--- a/devlog/_plan/260825_oauth_login_ux/010_wp2_shared_login_hint.md
+++ b/devlog/_plan/260825_oauth_login_ux/010_wp2_shared_login_hint.md
@@ -1,0 +1,169 @@
+# 010 — WP2: one login-hint component on every surface
+
+**Issue:** feature proposal. **PR base:** `dev`. **Screenshot:** required.
+
+## The defect
+
+Four GUI surfaces render a login-in-progress. Each renders a different subset
+of what the server sent:
+
+| Surface | URL | Device code | Paste |
+|---------|-----|-------------|-------|
+| `ProviderAuthPanel` | yes | yes | **no** |
+| `AddProviderOAuthPane` | yes | **no** | yes |
+| `ProviderCatalog` account row | **no** | **no** | **no** |
+| `AddCodexAccountWaitingStep` | yes | **no** | yes |
+
+No surface has all three. A Kimi login shows an empty box on every one of
+them, because `kimi.ts:212` puts the user code in a prose `instructions`
+string and never sets `deviceCode`.
+
+## The change
+
+### 1. `gui/src/components/login-url-block.tsx` → a full hint component
+
+Keep `LoginUrlBlock` as-is (it has three callers and a clean contract) and add
+a sibling in the same file that composes it:
+
+```tsx
+export type LoginHintData = {
+  url?: string;
+  deviceCode?: string;
+  instructions?: string;
+};
+
+export function LoginHint({ hint, paste }: {
+  hint: LoginHintData;
+  paste?: {
+    value: string;
+    busy: boolean;
+    message: string;
+    ok: boolean;
+    onChange: (v: string) => void;
+    onSubmit: () => void;
+  };
+}) { … }
+```
+
+Render order, which is the UX decision this phase is actually making:
+
+1. **Device code first when present.** It is the thing the human has to type,
+   and it is short. Copy button beside it, reusing `useCopyFeedback` and the
+   existing `.pwi-device-code` styles lifted into
+   `gui/src/styles/login-url-block.css`.
+2. **Then the URL**, via the existing `LoginUrlBlock` — selectable text, copy,
+   and the "didn't open?" external link.
+3. **Then `instructions`**, if the provider sent prose.
+4. **Then the paste row**, when the caller supplies `paste`.
+
+`LoginUrlBlock` returns `null` on an empty URL today; `LoginHint` must not —
+a device flow with no URL still has a code to show. Guard on
+"nothing at all to render" instead.
+
+### 2. `gui/src/components/use-add-provider-oauth.ts:53`
+
+```diff
+-const data = await res.json() as { url?: string; instructions?: string; error?: string };
++const data = await res.json() as { url?: string; instructions?: string; deviceCode?: string; error?: string };
+-if (data.url) { setOauthUrl(data.url, providerId); setOauthMsg(t("modal.waitingLogin")); }
+-else { setOauthMsg(data.instructions || t("modal.loggingIn")); }
++setOauthHint({ url: data.url, deviceCode: data.deviceCode, instructions: data.instructions }, providerId);
++setOauthMsg(data.url || data.deviceCode ? t("modal.waitingLogin") : (data.instructions || t("modal.loggingIn")));
+```
+
+The reducer in `add-provider-modal-reducer.ts` carries `oauthUrl` +
+`oauthUrlProvider` today; widen to an `oauthHint` object with the same
+provider tag so a stale hint from a cancelled provider still cannot leak into
+another provider's pane.
+
+### 3. `src/oauth/kimi.ts:212`
+
+```diff
+-ctrl.onAuth?.({ url: device.verificationUriComplete, instructions: `Enter code: ${device.userCode}` });
++ctrl.onAuth?.({
++  url: device.verificationUriComplete,
++  instructions: `Enter code: ${device.userCode}`,
++  deviceCode: device.userCode,
++});
+```
+
+Matches `nous.ts:660-663` and `github-copilot.ts:396-400`, and `instructions`
+is unchanged so the CLI keeps printing what it printed.
+
+**This is not purely additive, and the PR must say so.** The management route
+gates its browser-open on that exact field:
+
+```ts
+// oauth-account-routes.ts:170
+if (authUrl && !deviceCode) { openUrl(authUrl); }
+```
+
+Today Kimi sets no `deviceCode`, so the proxy auto-opens
+`device.verificationUriComplete` — a **provider-supplied** URL. Setting
+`deviceCode` means Kimi stops being auto-opened, exactly like Nous and
+Copilot already are.
+
+That is the correct direction on both counts. It ends an inconsistency where
+two device providers are treated as device flows and the third is not, and it
+stops handing a server-supplied URI to a local process spawn — the very thing
+`github-copilot.ts:392-394` refuses to do. The operator does not lose access
+to the link: WP2 is the phase that puts that URL on screen with a copy button
+on every surface, which is strictly more reach than an auto-open into whatever
+profile happens to be default.
+
+It still must be **stated in the PR description as a behavior change**, with
+the before/after in the Summary section, rather than buried under "additive".
+A reviewer who reads only the diff to `kimi.ts` will not see the route.
+
+**Not in this phase:** allowlisting `verificationUriComplete` before it
+reaches `onAuth` at all, for Kimi and Nous. That is a separate security
+change with its own issue (`002`). Note the ordering benefit: after WP2, no
+device provider's server-supplied URL reaches `openUrl`, so that issue governs
+what is *displayed*, not what is *executed*.
+
+### 4. Call sites
+
+- `add-provider-oauth-pane.tsx:59-99` — replace `LoginUrlBlock` + the inline
+  paste block with one `<LoginHint hint={hint} paste={…} />`.
+- `ProviderAuthPanel.tsx:392-402` — replace the inline device-code block and
+  `LoginUrlBlock` with `<LoginHint>`, **and pass `paste`**. This is the
+  first time the workspace panel can accept a pasted code; it needs the same
+  `submitManualCode` the modal already has, pointed at
+  `/api/oauth/login/code`.
+- `add-codex-account-waiting-step.tsx:38-69` — same swap. Its submit goes to
+  `/api/codex-auth/login/code`, so `paste.onSubmit` stays caller-owned.
+
+## i18n
+
+`prov.deviceCode` exists. New keys, added to **all** locale files under
+`gui/src/i18n/` (en, ko, ja, zh, zh-TW, de, fr, ru, tr):
+
+- `prov.deviceCodeHint` — "Enter this code after opening the link."
+
+English is the source; a locale that has no translation yet falls back through
+the existing mechanism rather than shipping an English string in a translated
+file.
+
+## Test
+
+`tests/oauth-login-hint.test.ts` (new):
+
+1. `loginKimi` calls `onAuth` with `deviceCode` equal to the user code —
+   fake the device-authorization fetch, assert the field. This is the one
+   assertion that would have caught the original gap.
+2. Re-assert the same for `loginNous` and `loginGithubCopilot` so the
+   contract is enforced for every device provider, not just the one being
+   fixed.
+3. Route-level: with `deviceCode` present, `POST /api/oauth/login` does not
+   call the opener; with a browser flow it does. This locks the consequence
+   described above so it can never regress silently in either direction.
+
+GUI rendering is verified by screenshot in the PR; this repo has no component
+test harness and this phase is not the place to introduce one.
+
+## Acceptance
+
+- A Kimi login shows a copyable code on all three surfaces.
+- The workspace panel accepts a pasted redirect URL for the first time.
+- `bun run typecheck`, `bun run test`, `bun run lint:gui` green.
+- Screenshot of the waiting state with a device code visible.

--- a/devlog/_plan/260825_oauth_login_ux/020_wp3_first_add_parity.md
+++ b/devlog/_plan/260825_oauth_login_ux/020_wp3_first_add_parity.md
@@ -1,0 +1,101 @@
+# 020 — WP3: the login hint renders during a first add
+
+**Issue:** bug report. **PR base:** WP2's head branch (stacked). **Screenshot:** required.
+
+## The defect
+
+Pain point 1, verbatim: *"이미 프로바이더가 추가된 상태에서는 링크를 복사할 수
+있지만 → 첫 추가 때 못함."*
+
+The hint is computed and stored. `use-providers-oauth.ts:93-96` reads
+`url`, `instructions`, and `deviceCode` and calls `setLoginInfo`.
+`Providers.tsx:365` passes `loginInfo` into `ProviderDetails`, which passes
+it to `ProviderAuthPanel` — the workspace surface for a provider that already
+exists.
+
+During a first add there is no such provider. The modal is open, the panel is
+not mounted, and `ProviderCatalog.tsx:205` renders
+`t("prov.waitingBrowser")` with a Cancel button. The URL exists in React
+state and has no renderer.
+
+That is the whole bug. It is not "the modal cannot show a link" — it is
+"nobody asked it to."
+
+## The change
+
+### 1. `ProviderCatalog.tsx` accepts and renders the hint
+
+```diff
+ export default function ProviderCatalog({
+   presets, usageRank, presetsLoading, initialTier,
+   onSelectPreset, onSelectCustom,
+   accountRows, accountStatus, busyProvider,
++  loginHint,
++  onSubmitLoginCode,
+   onLogin, onCancelLogin, onLogout, onManage,
+ }: {
++  /** Hint for the account row whose login is in flight; ignored for other rows. */
++  loginHint?: { provider: string; url?: string; instructions?: string; deviceCode?: string } | null;
++  onSubmitLoginCode?: (provider: string, input: string) => Promise<{ ok: boolean; error?: string }>;
+```
+
+Inside the account-row map (`:148-212`), when
+`busyProvider === row.id && loginHint?.provider === row.id`, render the WP2
+`<LoginHint>` **below** the row rather than inside its badge strip — the
+strip is a horizontal flex of buttons and a URL block belongs on its own line.
+
+The row is currently a `<div className="list-row">` with two children. It
+becomes a wrapper with the row on top and the hint underneath, so the
+non-busy layout is byte-identical.
+
+### 2. Paste state lives in the modal, not the catalog
+
+`ProviderCatalog` is presentational by contract (its own header comment says
+so). The paste value, busy flag, and message belong in `AddProviderModal`,
+which already owns exactly those fields in its reducer for the preset pane
+(`manualCode`, `manualCodeBusy`, `manualCodeMsg`, `manualCodeOk`).
+
+`AddProviderModal` passes them down; the catalog renders them. One reducer,
+two panes, no duplicated state.
+
+### 3. `Providers.tsx` threads the hint into the modal
+
+`loginInfo` already lives in `Providers.tsx:39`. It is passed to
+`ProvidersPageModals` alongside `addModalAccountRows` and
+`accountLoginStatus`, which the modal already receives. One more prop.
+
+### 4. Cancel already works
+
+`onCancelLogin` is wired at `ProviderCatalog.tsx:200-204` and hits
+`cancelLoginFlow`. No change.
+
+## What this phase must not do
+
+- **Do not** move `loginInfo` into a context or a store. One prop, one hop.
+- **Do not** change `ProviderAuthPanel`. WP2 already reworked it; this phase
+  only teaches a second surface to render the same component.
+- **Do not** auto-open the modal to a provider's workspace on login start.
+  `onLoginSettled` already does that on success, and doing it earlier would
+  unmount the modal mid-login — which is a longer way of reintroducing this
+  exact bug.
+
+## Test
+
+`tests/oauth-first-add-hint.test.ts` (new): a pure-function test over the
+row-visibility predicate extracted from the JSX, asserting that a hint renders
+only for the row whose provider matches and only while that provider is busy.
+Extract it as `shouldShowLoginHint(row, busyProvider, hint)` in
+`provider-presets.ts` so it is testable without a DOM.
+
+The cross-provider case is the one that matters: a hint for `anthropic` must
+never render on the `xai` row, which is the same class of leak the
+`oauthUrlProvider` tag guards against in the preset pane.
+
+## Acceptance
+
+- Starting a login for a not-yet-added provider from the Accounts tab shows
+  the URL with a copy button, the device code when the provider sends one, a
+  paste input, and Cancel — without leaving the modal.
+- The link can be copied and opened in a different browser profile.
+- `bun run typecheck`, `bun run test`, `bun run lint:gui` green.
+- Screenshot of a first-add waiting state showing the copyable link.

--- a/devlog/_plan/260825_oauth_login_ux/030_wp4_browser_open_control.md
+++ b/devlog/_plan/260825_oauth_login_ux/030_wp4_browser_open_control.md
@@ -1,0 +1,125 @@
+# 030 — WP4: the operator decides whether the proxy opens a browser
+
+**Issue:** feature proposal. **PR base:** `dev`. **Screenshot:** required if the GUI toggle lands.
+
+## The defect
+
+`oauth-account-routes.ts:170-175`:
+
+```ts
+if (authUrl && !deviceCode) {
+  const { openUrl } = await import("../../lib/open-url");
+  openUrl(authUrl);
+}
+```
+
+`open-url.ts:11-24` spawns `open` / `xdg-open` / `rundll32`, which resolves
+the **OS default browser** and therefore the default profile. Two consequences
+the operator reported:
+
+1. **Wrong profile.** The login lands in whichever Chrome profile is default.
+   An operator who wants a second account, or a work identity, cannot get
+   there — and because the URL is not copyable during a first add (WP3), there
+   is no way around it either.
+2. **Wrong machine.** With the GUI open over SSH or a tunnel, the browser
+   opens on the *proxy host*, which is not where the human is. `open-url.ts`
+   swallows spawn errors deliberately, so nothing reports that this happened.
+
+## The change
+
+### 1. Config — `src/types/config.ts`
+
+```ts
+/** Whether a login may open a browser on the machine running the proxy. */
+oauthOpenBrowser?: boolean;
+```
+
+A boolean, not an enum. `undefined` and `true` both mean "open" — that is
+the existing behavior, and it stays the behavior for every operator who does
+nothing. `false` means "never open; give me the link."
+
+An `"auto"` mode that sniffs `SSH_CONNECTION` or a missing `DISPLAY` is
+deliberately **not** in this phase (`002`). Inference that is wrong breaks a
+working login silently; that needs its own evidence and its own issue.
+
+### 2. Per-request override — `POST /api/oauth/login`
+
+```diff
+-const body = … as { provider?: string; addAccount?: boolean; accountId?: string; reauth?: boolean };
++const body = … as { provider?: string; addAccount?: boolean; accountId?: string; reauth?: boolean; openBrowser?: boolean };
+```
+
+Resolution, in one helper so both login routes share it:
+
+```ts
+// Request beats config; config beats the historical default.
+function shouldOpenBrowserForLogin(requested: unknown, config: OcxConfig): boolean {
+  if (typeof requested === "boolean") return requested;
+  return config.oauthOpenBrowser !== false;
+}
+```
+
+A non-boolean `openBrowser` is ignored rather than rejected: this is a UX
+preference, and a malformed one must not fail a login.
+
+Same treatment for the Codex path at `src/codex/auth-api.ts:1844`.
+
+### 3. GUI
+
+Two surfaces, both small:
+
+- **A checkbox in the login-hint component (WP2).** "Don't open a browser on
+  the proxy host" — checked state is remembered in `localStorage` and sent as
+  `openBrowser: false` on the next login start. This is the affordance the
+  operator actually asked for: start the login, copy the link, open it wherever
+  they want.
+- **A persisted toggle** in the providers settings area writing
+  `oauthOpenBrowser` through the existing config route, for an operator who
+  never wants the proxy touching a browser.
+
+### 4. Deliberately not changing `open-url.ts`
+
+Honoring a `BROWSER` environment variable or a configured argv is a real
+pattern and a real request ("크롬 다른 프로필"). It is also the part of this
+change that can execute an operator-supplied command, and it belongs in a PR
+that can be reviewed as a command-execution change rather than as a UX change.
+
+If it lands later, the shape is fixed now: **argv array only**, never a shell
+string, `shell: false` preserved, empty means skip. Recorded here so the next
+cycle does not relitigate it.
+
+## Security
+
+- Device flows still never auto-open (`!deviceCode` guard preserved).
+- No provider-supplied URL becomes newly openable. This phase only ever makes
+  `openUrl` fire *less*.
+- `openUrl`'s `^https?://` guard at `open-url.ts:12` is untouched.
+- The management route already requires the session/admin gate; the new field
+  changes nothing about admission.
+
+## Test
+
+`tests/oauth-open-browser-choice.test.ts` (new), against
+`shouldOpenBrowserForLogin` and the route:
+
+| `openBrowser` in body | `oauthOpenBrowser` in config | opens? |
+|---|---|---|
+| absent | absent | **yes** — the compatibility case |
+| absent | `true` | yes |
+| absent | `false` | no |
+| `false` | absent | no |
+| `false` | `true` | no |
+| `true` | `false` | yes |
+| `"nope"` | absent | yes — malformed is ignored |
+
+Row 1 is the one that matters: it is the regression test for "we did not
+silently change what already worked."
+
+The route test injects a spy opener rather than spawning a real browser.
+
+## Acceptance
+
+- Default install: identical behavior, proven by row 1.
+- With the box checked, no browser is spawned and the link is on screen to
+  copy into any profile or any machine.
+- `bun run typecheck`, `bun run test`, `bun run privacy:scan` green.

--- a/devlog/_plan/260825_oauth_login_ux/040_wp5_paste_normalization.md
+++ b/devlog/_plan/260825_oauth_login_ux/040_wp5_paste_normalization.md
@@ -1,0 +1,101 @@
+# 040 — WP5: a pasted redirect that looks right must not be silently refused
+
+**Issue:** bug report. **PR base:** `dev`. **Screenshot:** not required.
+
+## The defect
+
+`parseCallbackInput` (`callback-server.ts:273-300`) tries three shapes in
+order: a parseable URL, a string containing `code=`, then a raw code with an
+optional `#state`.
+
+The URL branch reads `url.searchParams` only:
+
+```ts
+const url = new URL(value);
+return {
+  kind: "url",
+  code: url.searchParams.get("code") ?? undefined,
+  state: url.searchParams.get("state") ?? undefined,
+};
+```
+
+A redirect that returns its parameters in the **fragment** —
+`http://localhost:1455/callback#code=abc&state=xyz` — parses as a valid URL,
+yields no `code`, and is rejected by `submitManualLoginCode:1345` with
+"no authorization code found in input".
+
+From the operator's chair this is the worst possible failure: they pasted the
+entire address bar, exactly as the hint text instructed
+(`prov.pasteRedirectHint`: "copy the full URL from its address bar"), and were
+told their paste contains no code.
+
+Note the asymmetry that makes this a bug rather than a limitation: the **raw**
+branch already understands `code#state`, and the **query** branch already
+strips a leading `#` (`value.replace(/^[?#]/, "")`). Fragments are understood
+everywhere except the one shape most likely to be pasted.
+
+## The change
+
+One function, `callback-server.ts:277-283`:
+
+```diff
+ try {
+   const url = new URL(value);
+-  return {
+-    kind: "url",
+-    code: url.searchParams.get("code") ?? undefined,
+-    state: url.searchParams.get("state") ?? undefined,
+-  };
++  const fragment = new URLSearchParams(url.hash.replace(/^#/, ""));
++  // A redirect may return its parameters in the fragment. Query wins when both
++  // are present: it is the authorization-code response location, and a fragment
++  // is the shape an implicit-grant response uses.
++  return {
++    kind: "url",
++    code: url.searchParams.get("code") ?? fragment.get("code") ?? undefined,
++    state: url.searchParams.get("state") ?? fragment.get("state") ?? undefined,
++  };
+ } catch {
+   // Not a URL - check for query string format
+ }
+```
+
+### What must not change
+
+- **`kind` stays `"url"`.** That is what makes state mandatory
+  (`callback-server.ts:252`, `index.ts:1347-1350`). A fragment-carried
+  response is still an authorization response and gets the same CSRF
+  treatment as a query-carried one. Downgrading it to `raw` to skip the state
+  check would be a security regression wearing a convenience costume.
+- **Only `code` and `state` are read.** Never `access_token`, never
+  `id_token`. This repo does not implement the implicit grant and a paste
+  path must not become the place it appears.
+- **Query beats fragment** when both exist, so no existing paste changes
+  meaning.
+
+## Test
+
+Extend `tests/oauth-manual-code.test.ts`, which already has a
+`parseCallbackInput kinds` block (`:32-52`):
+
+| Input | Expected |
+|---|---|
+| `http://localhost:1455/callback#code=abc&state=xyz` | `kind: "url"`, code `abc`, state `xyz` |
+| `http://localhost:1455/callback?code=q&state=s#code=f&state=f` | query wins: `q` / `s` |
+| `http://localhost:1455/callback#code=abc` | `kind: "url"`, code `abc`, **state undefined** |
+| `http://localhost:1455/callback#access_token=t` | no code — a token fragment is not an authorization response |
+
+Plus one end-to-end assertion through `submitManualLoginCode`: a
+fragment-carried paste with a **mismatched** state is still rejected with the
+state-mismatch error, proving the fix did not open a CSRF hole.
+
+And one gap the inventory surfaced that belongs here because it is the same
+function: `code#state` in the **raw** branch has no test today despite being
+supported. Add it.
+
+## Acceptance
+
+- A fragment-carried redirect URL completes a login.
+- A fragment-carried redirect with a bad state is refused, with the specific
+  state-mismatch message.
+- `bun run typecheck`, `bun run test` green.

--- a/gui/src/components/AddProviderModal.tsx
+++ b/gui/src/components/AddProviderModal.tsx
@@ -96,6 +96,7 @@ export default function AddProviderModal({
   const usageRank = Object.fromEntries((usagePoll.data?.providers ?? []).map(row => [row.provider, row.requests]));
   const {
     preset, form, saving, error, oauthBusy, oauthMsg, oauthMsgTone, oauthUrl, oauthUrlProvider,
+    oauthDeviceCode, oauthInstructions,
     manualCode, manualCodeBusy, manualCodeMsg, manualCodeOk, endpointChoice, oauthTosPending,
   } = state;
 
@@ -198,7 +199,8 @@ export default function AddProviderModal({
     setOauthBusy: (busy: boolean) => dispatch({ type: "set-oauth-busy", busy }),
     setOauthMsg: (msg: string) => dispatch({ type: "set-oauth-msg", msg }),
     setOauthMsgTone: (tone: "ok" | "warn") => dispatch({ type: "set-oauth-tone", tone }),
-    setOauthUrl: (url: string, providerId: string) => dispatch({ type: "set-oauth-url", url, providerId }),
+    setOauthUrl: (url: string, providerId: string, deviceCode?: string, instructions?: string) =>
+      dispatch({ type: "set-oauth-url", url, providerId, deviceCode, instructions }),
     setManualCode: (code: string) => dispatch({ type: "set-manual-code", code }),
     setManualCodeMsg: (msg: string) => dispatch({ type: "set-manual-code-msg", msg }),
     setManualCodeOk: (ok: boolean) => dispatch({ type: "set-manual-code-msg", msg: manualCodeMsg, ok }),
@@ -265,6 +267,8 @@ export default function AddProviderModal({
               oauthMsg={oauthMsg}
               oauthMsgTone={oauthMsgTone}
               oauthUrl={oauthUrlProvider === preset.oauthProvider ? oauthUrl : ""}
+              oauthDeviceCode={oauthUrlProvider === preset.oauthProvider ? oauthDeviceCode : ""}
+              oauthInstructions={oauthUrlProvider === preset.oauthProvider ? oauthInstructions : ""}
               manualCode={manualCode}
               manualCodeBusy={manualCodeBusy}
               manualCodeMsg={manualCodeMsg}

--- a/gui/src/components/add-codex-account-waiting-step.tsx
+++ b/gui/src/components/add-codex-account-waiting-step.tsx
@@ -1,5 +1,5 @@
 import { useT } from "../i18n/shared";
-import { LoginUrlBlock } from "./login-url-block";
+import { LoginHint } from "./login-url-block";
 import type { StatusTone } from "./add-codex-account-reducer";
 
 export function AddCodexAccountWaitingStep({
@@ -35,38 +35,22 @@ export function AddCodexAccountWaitingStep({
     <>
       <h3 style={{ marginBottom: 4 }}>{reauthAccountId ? t("codexAuth.reauthenticate") : t("codexAuth.oauthLogin")}</h3>
       <p className="modal-desc">{t("codexAuth.oauthWaiting")}</p>
-      <LoginUrlBlock url={authUrl} />
-      <div style={{ display: "flex", flexDirection: "column", gap: 6, marginTop: 12 }}>
-        <div className="muted text-label">{t("prov.pasteRedirectHint")}</div>
-        <div style={{ display: "flex", gap: 8 }}>
-          <input
-            type="text"
-            autoComplete="off"
-            spellCheck={false}
-            value={manualCode}
-            onChange={e => onManualCodeChange(e.target.value)}
-            onKeyDown={e => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                onSubmitManualCode();
-              }
-            }}
-            placeholder={t("prov.pasteRedirect")}
-            aria-label={t("prov.pasteRedirect")}
-            disabled={manualCodeBusy || manualCodeWaiting}
-            className="input text-label"
-            style={{ flex: 1 }}
-          />
-          <button
-            className="btn btn-ghost"
-            type="button"
-            disabled={manualCodeBusy || manualCodeWaiting || !manualCode.trim() || !flowId}
-            onClick={onSubmitManualCode}
-          >
-            {manualCodeBusy ? t("codexAuth.oauthSubmittingCode") : t("prov.pasteSubmit")}
-          </button>
-        </div>
-      </div>
+      <LoginHint
+        hint={{ url: authUrl }}
+        paste={{
+          value: manualCode,
+          busy: manualCodeBusy,
+          // The submit stays gated while a prior code is still settling, or before
+          // the flow id arrives — but the field itself is only disabled while a
+          // submission is actually in flight.
+          disabled: manualCodeBusy || manualCodeWaiting || !manualCode.trim() || !flowId,
+          submittingLabel: t("codexAuth.oauthSubmittingCode"),
+          message: "",
+          ok: true,
+          onChange: onManualCodeChange,
+          onSubmit: onSubmitManualCode,
+        }}
+      />
       {statusNotice && (
         <div
           className={statusTone === "warn" ? "notice-warn" : "notice notice-ok"}

--- a/gui/src/components/add-provider-modal-reducer.ts
+++ b/gui/src/components/add-provider-modal-reducer.ts
@@ -14,6 +14,10 @@ export type AddProviderModalState = {
   oauthMsgTone: "ok" | "warn";
   /** Authorization URL for the in-flight OAuth login, so the pane can offer copy/open. */
   oauthUrl: string;
+  /** User code for a device-flow login; the pane renders it beside the URL. */
+  oauthDeviceCode: string;
+  /** Provider-supplied prose for the in-flight login. */
+  oauthInstructions: string;
   /** Provider the pending `oauthUrl` belongs to; a late response for a switched-away provider must not render. */
   oauthUrlProvider: string | null;
   manualCode: string;
@@ -34,7 +38,7 @@ export type AddProviderModalAction =
   | { type: "set-oauth-busy"; busy: boolean }
   | { type: "set-oauth-msg"; msg: string; tone?: "ok" | "warn" }
   | { type: "set-oauth-tone"; tone: "ok" | "warn" }
-  | { type: "set-oauth-url"; url: string; providerId: string }
+  | { type: "set-oauth-url"; url: string; providerId: string; deviceCode?: string; instructions?: string }
   | { type: "set-manual-code"; code: string }
   | { type: "set-manual-code-busy"; busy: boolean }
   | { type: "set-manual-code-msg"; msg: string; ok?: boolean }
@@ -64,6 +68,8 @@ export function createInitialAddProviderState(
     oauthMsg: "",
     oauthMsgTone: "ok",
     oauthUrl: "",
+    oauthDeviceCode: "",
+    oauthInstructions: "",
     oauthUrlProvider: null,
     manualCode: "",
     manualCodeBusy: false,
@@ -89,6 +95,8 @@ export function addProviderModalReducer(
         oauthMsg: "",
         oauthMsgTone: "ok",
         oauthUrl: "",
+        oauthDeviceCode: "",
+        oauthInstructions: "",
         oauthUrlProvider: null,
         oauthBusy: false,
         manualCode: "",
@@ -105,6 +113,8 @@ export function addProviderModalReducer(
         oauthMsg: "",
         oauthMsgTone: "ok",
         oauthUrl: "",
+        oauthDeviceCode: "",
+        oauthInstructions: "",
         oauthUrlProvider: null,
         oauthBusy: false,
         manualCode: "",
@@ -129,7 +139,13 @@ export function addProviderModalReducer(
       // A login response for a provider the user already switched away from must
       // neither render under the new provider nor clobber its URL.
       if (state.preset?.oauthProvider !== action.providerId) return state;
-      return { ...state, oauthUrl: action.url, oauthUrlProvider: action.providerId };
+      return {
+        ...state,
+        oauthUrl: action.url,
+        oauthDeviceCode: action.deviceCode ?? "",
+        oauthInstructions: action.instructions ?? "",
+        oauthUrlProvider: action.providerId,
+      };
     case "set-manual-code":
       return { ...state, manualCode: action.code };
     case "set-manual-code-busy":
@@ -139,7 +155,7 @@ export function addProviderModalReducer(
     case "set-oauth-tos-pending":
       return { ...state, oauthTosPending: action.providerId };
     case "use-oauth-login":
-      return { ...state, form: action.form, error: "", oauthUrl: "", oauthUrlProvider: null };
+      return { ...state, form: action.form, error: "", oauthUrl: "", oauthDeviceCode: "", oauthInstructions: "", oauthUrlProvider: null };
     case "use-api-key-instead":
       return {
         ...state,
@@ -147,6 +163,8 @@ export function addProviderModalReducer(
         oauthMsg: "",
         oauthMsgTone: "ok",
         oauthUrl: "",
+        oauthDeviceCode: "",
+        oauthInstructions: "",
         oauthUrlProvider: null,
         oauthBusy: false,
         manualCode: "",

--- a/gui/src/components/add-provider-oauth-pane.tsx
+++ b/gui/src/components/add-provider-oauth-pane.tsx
@@ -1,6 +1,6 @@
 import { IconLock } from "../icons";
 import { useT } from "../i18n/shared";
-import { LoginUrlBlock } from "./login-url-block";
+import { LoginHint } from "./login-url-block";
 import type { CatalogPreset } from "./provider-catalog/provider-presets";
 
 export function AddProviderOAuthPane({
@@ -10,6 +10,8 @@ export function AddProviderOAuthPane({
   oauthMsg,
   oauthMsgTone,
   oauthUrl,
+  oauthDeviceCode,
+  oauthInstructions,
   manualCode,
   manualCodeBusy,
   manualCodeMsg,
@@ -26,6 +28,8 @@ export function AddProviderOAuthPane({
   oauthMsg: string;
   oauthMsgTone: "ok" | "warn";
   oauthUrl: string;
+  oauthDeviceCode?: string;
+  oauthInstructions?: string;
   manualCode: string;
   manualCodeBusy: boolean;
   manualCodeMsg: string;
@@ -56,46 +60,19 @@ export function AddProviderOAuthPane({
           {oauthMsg}
         </div>
       )}
-      {oauthBusy && <LoginUrlBlock url={oauthUrl} />}
       {oauthBusy && (
-        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-          <div className="muted text-label">
-            {t("prov.pasteRedirectHint")}
-          </div>
-          <div style={{ display: "flex", gap: 8 }}>
-            <input
-              type="text"
-              autoComplete="off"
-              spellCheck={false}
-              value={manualCode}
-              onChange={e => onManualCodeChange(e.target.value)}
-              onKeyDown={e => {
-                if (e.key === "Enter" && preset.oauthProvider) {
-                  e.preventDefault();
-                  onSubmitManualCode(preset.oauthProvider);
-                }
-              }}
-              placeholder={t("prov.pasteRedirect")}
-              aria-label={t("prov.pasteRedirect")}
-              disabled={manualCodeBusy}
-              className="input text-label"
-              style={{ flex: 1 }}
-            />
-            <button
-              className="btn btn-ghost"
-              type="button"
-              disabled={manualCodeBusy || !manualCode.trim() || !preset.oauthProvider}
-              onClick={() => preset.oauthProvider && onSubmitManualCode(preset.oauthProvider)}
-            >
-              {manualCodeBusy ? t("prov.pasteSubmitting") : t("prov.pasteSubmit")}
-            </button>
-          </div>
-          {manualCodeMsg && (
-            <div className="text-label" style={{ color: manualCodeOk ? "var(--accent-hover)" : "var(--amber)" }}>
-              {manualCodeMsg}
-            </div>
-          )}
-        </div>
+        <LoginHint
+          hint={{ url: oauthUrl, deviceCode: oauthDeviceCode, instructions: oauthInstructions }}
+          paste={{
+            value: manualCode,
+            busy: manualCodeBusy,
+            disabled: !preset.oauthProvider,
+            message: manualCodeMsg,
+            ok: manualCodeOk,
+            onChange: onManualCodeChange,
+            onSubmit: () => { if (preset.oauthProvider) onSubmitManualCode(preset.oauthProvider); },
+          }}
+        />
       )}
       <div style={{ display: "flex", gap: 8, alignItems: "center", marginTop: 2 }}>
         <button type="button" className="link-btn" onClick={onUseApiKeyInstead}>

--- a/gui/src/components/login-url-block.tsx
+++ b/gui/src/components/login-url-block.tsx
@@ -38,3 +38,110 @@ export function LoginUrlBlock({ url }: { url: string }) {
     </div>
   );
 }
+
+/** What a login-in-progress knows about how the user should finish it. */
+export type LoginHintData = {
+  url?: string;
+  deviceCode?: string;
+  instructions?: string;
+};
+
+export type LoginHintPaste = {
+  value: string;
+  busy: boolean;
+  message: string;
+  ok: boolean;
+  /** Extra submit-only gating (a missing flow id, a preset with no provider). */
+  disabled?: boolean;
+  /** Surface-specific "submitting" copy; defaults to the shared paste label. */
+  submittingLabel?: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+};
+
+/**
+ * The single renderer for a login in progress, on every surface that can start
+ * one: the provider workspace panel, the add-provider modal, and the Codex
+ * account modal.
+ *
+ * It exists because those surfaces each used to render a different subset — one
+ * showed the device code but had no paste field, another had the paste field
+ * and dropped the device code, and a third showed nothing at all. Which
+ * affordances a user gets is a property of the provider's flow, not of which
+ * dialog they happened to open.
+ *
+ * Order is deliberate: the device code first because it is the short thing a
+ * human has to type, then the URL, then any provider prose, then the paste
+ * fallback for when the browser cannot reach the loopback callback.
+ */
+export function LoginHint({ hint, paste }: { hint: LoginHintData; paste?: LoginHintPaste }) {
+  const t = useT();
+  const deviceCopy = useCopyFeedback<string>();
+
+  const deviceCode = hint.deviceCode ?? "";
+  const url = hint.url ?? "";
+  // A device flow may carry no URL at all, so this must not reuse LoginUrlBlock's
+  // "empty url means render nothing" rule: the code alone is still actionable.
+  if (!deviceCode && !url && !hint.instructions && !paste) return null;
+
+  const deviceOutcome = deviceCopy.outcomeFor(deviceCode);
+  const deviceCopyLabel = deviceOutcome === "copied"
+    ? t("prov.codeCopied")
+    : deviceOutcome === "unavailable"
+      ? t("prov.linkCopyUnavailable")
+      : t("prov.copyCode");
+
+  return (
+    <div className="login-hint">
+      {deviceCode && (
+        <div className="login-hint-device pwi-device-code-wrap">
+          <span className="text-label">{t("prov.deviceCode")}</span>
+          <code className="login-hint-device-code pwi-device-code">{deviceCode}</code>
+          <button type="button" className="btn btn-primary btn-sm"
+            onClick={() => deviceCopy.copy(deviceCode, deviceCode)}>
+            <span aria-live="polite">{deviceCopyLabel}</span>
+          </button>
+        </div>
+      )}
+      <LoginUrlBlock url={url} />
+      {hint.instructions && <div className="muted text-label">{hint.instructions}</div>}
+      {paste && (
+        <div className="login-hint-paste">
+          <div className="muted text-label">{t("prov.pasteRedirectHint")}</div>
+          <div className="login-hint-paste-row">
+            <input
+              type="text"
+              autoComplete="off"
+              spellCheck={false}
+              value={paste.value}
+              onChange={e => paste.onChange(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  paste.onSubmit();
+                }
+              }}
+              placeholder={t("prov.pasteRedirect")}
+              aria-label={t("prov.pasteRedirect")}
+              disabled={paste.busy}
+              className="input text-label login-hint-paste-input"
+            />
+            <button
+              type="button"
+              className="btn btn-ghost"
+              disabled={paste.busy || paste.disabled === true || !paste.value.trim()}
+              onClick={paste.onSubmit}
+            >
+              {paste.busy ? (paste.submittingLabel ?? t("prov.pasteSubmitting")) : t("prov.pasteSubmit")}
+            </button>
+          </div>
+          {paste.message && (
+            <div className="text-label" aria-live="polite" style={{ color: paste.ok ? "var(--accent-hover)" : "var(--amber)" }}>
+              {paste.message}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/gui/src/components/provider-workspace/ProviderAuthPanel.tsx
+++ b/gui/src/components/provider-workspace/ProviderAuthPanel.tsx
@@ -18,9 +18,8 @@ import {
 } from "../../oauth-health-display";
 import CodexAccountPool from "../CodexAccountPool";
 import AnthropicAccountPoolSettings from "./AnthropicAccountPoolSettings";
-import { LoginUrlBlock } from "../login-url-block";
+import { LoginHint as LoginHintView } from "../login-url-block";
 import QuotaBars from "../QuotaBars";
-import { useCopyFeedback } from "../use-copy-feedback";
 import type { CodexAccountPoolController } from "../../hooks/useCodexAccountPool";
 import { Switch } from "../../ui";
 import type {
@@ -192,7 +191,10 @@ export default function ProviderAuthPanel({
   const [importResult, setImportResult] = useState<CockpitImportResult | null>(null);
   const [reserveQuotaSlots, setReserveQuotaSlots] = useState(false);
   const importFileRef = useRef<HTMLInputElement>(null);
-  const deviceCodeCopy = useCopyFeedback<string>();
+  const [manualCode, setManualCode] = useState("");
+  const [manualCodeBusy, setManualCodeBusy] = useState(false);
+  const [manualCodeMsg, setManualCodeMsg] = useState("");
+  const [manualCodeOk, setManualCodeOk] = useState(true);
 
   // Soft &quota=1 enrichment lands after the local account list. Reserve stacked
   // bar height briefly so bars don't shove rows when WHAM returns.
@@ -240,13 +242,36 @@ export default function ProviderAuthPanel({
   if (!surface || !authHandlers) return null;
 
   const hintForThis = loginHint?.provider === item.name ? loginHint : null;
-  const deviceCode = hintForThis?.deviceCode ?? "";
-  const deviceCodeOutcome = deviceCodeCopy.outcomeFor(deviceCode);
-  const deviceCodeCopyLabel = deviceCodeOutcome === "copied"
-    ? t("prov.codeCopied")
-    : deviceCodeOutcome === "unavailable"
-      ? t("prov.linkCopyUnavailable")
-      : t("prov.copyCode");
+  // Paste fallback for when the browser cannot reach the loopback callback
+  // (remote dashboard, SSH, blocked localhost). A rejected paste reports why and
+  // leaves the flow running, so the user can correct it and try again.
+  const submitManualCode = async () => {
+    const input = manualCode.trim();
+    if (!input || manualCodeBusy) return;
+    setManualCodeBusy(true);
+    setManualCodeMsg("");
+    try {
+      const res = await fetch(`${apiBase}/api/oauth/login/code`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider: item.name, input }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({})) as { error?: string };
+        setManualCodeOk(false);
+        setManualCodeMsg(t("prov.pasteFail", { error: data.error || res.statusText }));
+        return;
+      }
+      setManualCode("");
+      setManualCodeOk(true);
+      setManualCodeMsg(t("prov.pasteOk"));
+    } catch {
+      setManualCodeOk(false);
+      setManualCodeMsg(t("modal.networkError"));
+    } finally {
+      setManualCodeBusy(false);
+    }
+  };
   const loggedIn = accounts.length > 0 || oauth?.loggedIn === true;
   const activeReauthAccount = accounts.find(a => a.active && a.needsReauth);
   const activeNeedsReauth = Boolean(activeReauthAccount);
@@ -389,17 +414,21 @@ export default function ProviderAuthPanel({
                 <span className="pwi-spin-inline" aria-hidden="true" />
                 <div className="pwi-auth-wait-copy">
                   <div className="pwi-auth-wait-title">{t("prov.waitingBrowser")}</div>
-                  {hintForThis.deviceCode && (
-                    <div className="pwi-device-code-wrap">
-                      <span>{t("prov.deviceCode")}</span>
-                      <code className="pwi-device-code">{hintForThis.deviceCode}</code>
-                      <button type="button" className="btn btn-primary btn-sm"
-                        onClick={() => deviceCodeCopy.copy(deviceCode, deviceCode)}>
-                        <span aria-live="polite">{deviceCodeCopyLabel}</span>
-                      </button>
-                    </div>
-                  )}
-                  <LoginUrlBlock url={hintForThis.url ?? ""} />
+                  <LoginHintView
+                    hint={{
+                      url: hintForThis.url,
+                      deviceCode: hintForThis.deviceCode,
+                      instructions: hintForThis.instructions,
+                    }}
+                    paste={{
+                      value: manualCode,
+                      busy: manualCodeBusy,
+                      message: manualCodeMsg,
+                      ok: manualCodeOk,
+                      onChange: setManualCode,
+                      onSubmit: () => { void submitManualCode(); },
+                    }}
+                  />
                   {authHandlers.onCancelLogin && (
                     <button type="button" className="btn btn-ghost btn-sm" onClick={() => void authHandlers.onCancelLogin?.(item.name)}>
                       {t("common.cancel")}

--- a/gui/src/components/use-add-provider-oauth.ts
+++ b/gui/src/components/use-add-provider-oauth.ts
@@ -21,7 +21,7 @@ export function useAddProviderOAuth({
       setOauthBusy: (v: boolean) => void;
       setOauthMsg: (v: string) => void;
       setOauthMsgTone: (v: "ok" | "warn") => void;
-      setOauthUrl: (url: string, providerId: string) => void;
+      setOauthUrl: (url: string, providerId: string, deviceCode?: string, instructions?: string) => void;
       setManualCode: (v: string) => void;
       setManualCodeMsg: (v: string) => void;
       setManualCodeOk: (v: boolean) => void;
@@ -50,9 +50,13 @@ export function useAddProviderOAuth({
           : (data.error || t("modal.loginFailStart")));
         return;
       }
-      const data = await res.json() as { url?: string; instructions?: string; error?: string };
-      if (data.url) { setOauthUrl(data.url, providerId); setOauthMsg(t("modal.waitingLogin")); }
-      else { setOauthMsg(data.instructions || t("modal.loggingIn")); }
+      // A device flow may return a user code with no URL, and `instructions` may
+      // carry the only human-readable step. Keep all three: the hint renderer
+      // decides what to show, rather than this hook deciding what to discard.
+      const data = await res.json() as { url?: string; instructions?: string; deviceCode?: string; error?: string };
+      setOauthUrl(data.url ?? "", providerId, data.deviceCode, data.instructions);
+      if (data.url || data.deviceCode) setOauthMsg(t("modal.waitingLogin"));
+      else setOauthMsg(data.instructions || t("modal.loggingIn"));
       for (let i = 0; i < 100; i++) {
         await new Promise(r => setTimeout(r, OAUTH_LOGIN_POLL_INTERVAL_MS));
         if (!aliveRef.current) return;

--- a/gui/src/styles/login-url-block.css
+++ b/gui/src/styles/login-url-block.css
@@ -6,3 +6,12 @@
 .login-url-block-text { display: block; max-width: 100%; overflow-wrap: anywhere; padding: 8px 10px; border: 1px solid var(--border); border-radius: var(--radius-xs); background: var(--surface); font-size: var(--text-label); color: var(--text); user-select: all; }
 .login-url-block-actions { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 .login-url-block-open { font-size: var(--text-label); color: var(--accent); text-decoration: underline; cursor: pointer; }
+
+/* LoginHint — the composed login-in-progress surface (device code + URL +
+   provider prose + paste fallback), shared by the same three surfaces. */
+.login-hint { display: flex; flex-direction: column; gap: 8px; }
+.login-hint-device { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; padding: 12px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface); }
+.login-hint-device-code { font-size: 20px; font-weight: 800; letter-spacing: .14em; color: var(--text); user-select: all; }
+.login-hint-paste { display: flex; flex-direction: column; gap: 6px; }
+.login-hint-paste-row { display: flex; gap: 8px; }
+.login-hint-paste-input { flex: 1; }

--- a/src/oauth/kimi.ts
+++ b/src/oauth/kimi.ts
@@ -209,7 +209,15 @@ async function pollForToken(deviceCode: string, intervalMs: number, expiresInMs:
 
 export async function loginKimi(ctrl: OAuthController): Promise<OAuthCredentials> {
   const device = await requestDeviceAuthorization();
-  ctrl.onAuth?.({ url: device.verificationUriComplete, instructions: `Enter code: ${device.userCode}` });
+  // `deviceCode` carries the human-typed user code, matching the other device
+  // providers. It is also what tells the management login route this is a device
+  // flow, so a provider-supplied verification URI is no longer handed to a local
+  // browser spawn — the URL stays visible and copyable in every login surface.
+  ctrl.onAuth?.({
+    url: device.verificationUriComplete,
+    instructions: `Enter code: ${device.userCode}`,
+    deviceCode: device.userCode,
+  });
   return pollForToken(device.deviceCode, device.intervalMs, device.expiresInMs, ctrl.signal);
 }
 

--- a/tests/codex-auth-modal-status.test.ts
+++ b/tests/codex-auth-modal-status.test.ts
@@ -11,7 +11,14 @@ describe("Codex auth modal status feedback", () => {
     expect(reducer).toContain('manualCodeState: "idle"');
     expect(oauth).toContain('statusNotice: t("codexAuth.oauthCodeSubmitted")');
     expect(oauth).toContain('statusNotice: t("codexAuth.oauthStatusRetrying")');
-    expect(waiting).toContain("disabled={manualCodeBusy || manualCodeWaiting || !manualCode.trim() || !flowId}");
+    // The paste control now comes from the shared LoginHint component, so this
+    // guard is a prop rather than a JSX attribute. The condition itself is
+    // unchanged: a submit stays blocked while a code is in flight, while a
+    // previous one is still settling, when the field is empty, and before the
+    // flow id arrives.
+    expect(waiting).toContain("disabled: manualCodeBusy || manualCodeWaiting || !manualCode.trim() || !flowId");
+    // The distinct "submitting" copy must survive the move to a shared control.
+    expect(waiting).toContain('submittingLabel: t("codexAuth.oauthSubmittingCode")');
     expect(waiting).toContain('aria-live="polite"');
   });
 

--- a/tests/oauth-device-code-contract.test.ts
+++ b/tests/oauth-device-code-contract.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { loginKimi } from "../src/oauth/kimi";
+import type { OAuthController } from "../src/oauth/types";
+
+/**
+ * Every device-flow provider must report the human-typed user code in the
+ * structured `deviceCode` field, not only inside prose `instructions`.
+ *
+ * Two things depend on it, and neither is visible from the provider file:
+ * the GUI renders a copyable code widget from that field, and the management
+ * login route uses its presence to decide that a flow is a device flow and
+ * therefore must NOT be handed to a local browser spawn. A provider that
+ * omits it silently loses both.
+ */
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function deviceAuthorizationResponder(): void {
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (url.includes("/api/oauth/device_authorization")) {
+      return new Response(JSON.stringify({
+        user_code: "WDJB-MJHT",
+        device_code: "device-code-opaque",
+        verification_uri: "https://auth.kimi.com/device",
+        verification_uri_complete: "https://auth.kimi.com/device?user_code=WDJB-MJHT",
+        expires_in: 900,
+        interval: 5,
+      }), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    // Any token poll: keep the flow pending so the test only observes onAuth.
+    return new Response(JSON.stringify({ error: "authorization_pending" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+describe("device-flow onAuth contract", () => {
+  test("Kimi reports the user code in deviceCode, not only in instructions", async () => {
+    deviceAuthorizationResponder();
+    const abort = new AbortController();
+    let seen: { url?: string; instructions?: string; deviceCode?: string } | undefined;
+    const ctrl: OAuthController = {
+      onAuth: (info) => {
+        seen = info;
+        // The credential never arrives in this test; stop the poll loop here.
+        abort.abort("observed");
+      },
+      signal: abort.signal,
+    };
+
+    await loginKimi(ctrl).catch(() => {});
+
+    expect(seen?.deviceCode).toBe("WDJB-MJHT");
+    // The prose is unchanged, so the CLI keeps printing what it printed.
+    expect(seen?.instructions).toContain("WDJB-MJHT");
+    expect(seen?.url).toBe("https://auth.kimi.com/device?user_code=WDJB-MJHT");
+  });
+});

--- a/tests/oauth-login-open-browser.test.ts
+++ b/tests/oauth-login-open-browser.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { handleOauthAccountRoutes } from "../src/server/management/oauth-account-routes";
+import type { OcxConfig } from "../src/types";
+
+/**
+ * The login route decides whether to spawn a browser on the machine running the
+ * proxy, and it decides it from one field: a flow that reports a `deviceCode`
+ * is a device flow and is never auto-opened.
+ *
+ * That coupling is invisible from either side. A provider author setting
+ * `deviceCode` for a GUI widget is also, silently, turning off a process spawn;
+ * a reader of the route sees a field whose producer is three files away. These
+ * assertions pin both directions so neither can drift without a red test.
+ */
+
+function loginRequest(provider: string): Request {
+  return new Request("http://127.0.0.1/api/oauth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ provider }),
+  });
+}
+
+function baseConfig(): OcxConfig {
+  return { port: 0, hostname: "127.0.0.1", defaultProvider: "kimi", providers: {} } as OcxConfig;
+}
+
+async function startLogin(flow: { url: string; instructions?: string; deviceCode?: string }): Promise<{
+  opened: string[];
+  body: { url?: string; deviceCode?: string; instructions?: string };
+}> {
+  const oauth = await import("../src/oauth");
+  const openUrlMod = await import("../src/lib/open-url");
+  const opened: string[] = [];
+  const startSpy = spyOn(oauth, "startLoginFlow").mockResolvedValue(flow);
+  const openSpy = spyOn(openUrlMod, "openUrl").mockImplementation((url: string) => { opened.push(url); });
+  try {
+    const req = loginRequest("kimi");
+    const response = await handleOauthAccountRoutes({
+      req,
+      url: new URL(req.url),
+      config: baseConfig(),
+      deps: {},
+      convergeCodexCatalog: async () => ({ status: "failed", reason: "disk" }),
+      syncClaudeAgentDefsBestEffort: async () => {},
+    });
+    return { opened, body: await response!.json() as { url?: string; deviceCode?: string; instructions?: string } };
+  } finally {
+    startSpy.mockRestore();
+    openSpy.mockRestore();
+  }
+}
+
+describe("POST /api/oauth/login browser opening", () => {
+  test("a device flow is not opened server-side, and still returns its URL and code", async () => {
+    const { opened, body } = await startLogin({
+      url: "https://auth.kimi.com/device?user_code=WDJB-MJHT",
+      instructions: "Enter code: WDJB-MJHT",
+      deviceCode: "WDJB-MJHT",
+    });
+
+    // No provider-supplied verification URI reaches a local process spawn.
+    expect(opened).toEqual([]);
+    // The user keeps every way to finish the login by hand.
+    expect(body.url).toBe("https://auth.kimi.com/device?user_code=WDJB-MJHT");
+    expect(body.deviceCode).toBe("WDJB-MJHT");
+  });
+
+  test("a browser redirect flow is still opened, exactly as before", async () => {
+    const { opened, body } = await startLogin({ url: "https://accounts.example.test/authorize?code=1" });
+
+    expect(opened).toEqual(["https://accounts.example.test/authorize?code=1"]);
+    expect(body.deviceCode).toBeUndefined();
+  });
+});

--- a/tests/provider-workspace-auth.test.ts
+++ b/tests/provider-workspace-auth.test.ts
@@ -144,11 +144,12 @@ describe("workspace account integration seam", () => {
   });
 
   test("wires OAuth re-authenticate handlers into the workspace detail", async () => {
-    const [page, panel, details, overview] = await Promise.all([
+    const [page, panel, details, overview, loginHint] = await Promise.all([
       providersPageSeam(),
       Bun.file("gui/src/components/provider-workspace/ProviderAuthPanel.tsx").text(),
       Bun.file("gui/src/components/provider-workspace/ProviderDetails.tsx").text(),
       Bun.file("gui/src/components/provider-workspace/ProviderOverview.tsx").text(),
+      Bun.file("gui/src/components/login-url-block.tsx").text(),
     ]);
     expect(page).toContain("onReauth:");
     expect(page).toContain("onCancelLogin: cancelLoginOAuth");
@@ -158,7 +159,14 @@ describe("workspace account integration seam", () => {
     expect(page).toContain("oauthLoginGenerationRef");
     expect(page).toContain("/api/oauth/login/cancel");
     expect(page).toContain("deviceCode");
-    expect(panel).toContain("pwi-device-code");
+    // The device-code widget is now owned by the shared login-hint component so
+    // every login surface renders the same one. The panel's obligation is to
+    // pass the code through; the widget itself lives with the component.
+    expect(panel).toContain("deviceCode: hintForThis.deviceCode");
+    expect(loginHint).toContain("pwi-device-code");
+    // The workspace can accept a pasted redirect URL — previously only the
+    // add-provider modal could, which stranded remote/SSH re-authentication.
+    expect(panel).toContain("/api/oauth/login/code");
     // Add Provider account row CTA: OAuth uses loginOAuth; openai deep-links to Codex Auth.
     expect(page).toContain('href: "#codex-auth"');
     expect(panel).toContain("onReauth");


### PR DESCRIPTION
## Summary

Every OAuth login surface in the dashboard now renders the same thing, because they all render the same component.

Before this change the affordances a login needs were split across four surfaces and no surface had all of them: the provider workspace panel showed the URL and device code but had **no paste field**, the add-provider OAuth pane had the paste field but **dropped `deviceCode` entirely**, and the Codex account modal showed neither a code nor provider instructions.

- New `LoginHint` in `gui/src/components/login-url-block.tsx` renders, in order: the device code with a copy button, the authorization URL (via the existing `LoginUrlBlock`), any provider instructions, and the paste-a-redirect-or-code fallback. `LoginUrlBlock` is unchanged and is still what draws the URL.
- Reused by `ProviderAuthPanel` (aliased `LoginHintView`, since `./types` already owns a `LoginHint` **type**), `AddProviderOAuthPane`, and `AddCodexAccountWaitingStep`. Sharing a renderer does not merge backends: the Codex modal still posts to `/api/codex-auth/login/code` and the others to `/api/oauth/login/code`.
- **The provider workspace can accept a pasted redirect URL for the first time.** That was the gap that stranded remote/SSH re-authentication on an already-added provider.
- `useAddProviderOAuth` no longer discards `deviceCode`; the modal reducer carries `oauthDeviceCode`/`oauthInstructions` on the existing `set-oauth-url` action, behind its existing provider-tag guard, so a hint for one provider still cannot render under another.
- No new i18n keys: every string this needs already shipped in all nine locales, just on different surfaces.

### Behavior change, stated deliberately

`src/oauth/kimi.ts` now reports its user code in the structured `deviceCode` field instead of only inside a prose `instructions` string, matching Nous and GitHub Copilot.

That field is also what `POST /api/oauth/login` uses to decide a flow is a device flow: `if (authUrl && !deviceCode) openUrl(authUrl)`. **So this also stops the proxy from auto-opening Kimi's provider-supplied verification URI.** That is the intended direction — it ends an inconsistency where two of three device providers were treated as device flows, and it stops handing a server-supplied URL to a local process spawn, which is exactly what `github-copilot.ts` already refuses to do. Nothing is lost: this PR is what puts that URL on screen with a copy button on every surface.

Closes #2529

## Verification

```
bun run typecheck                      # exit 0
cd gui && bun x tsc -b && bun run lint  # exit 0, exit 0
bun run test                           # 14665 pass, 0 fail, 912 files
bun run privacy:scan                   # Privacy scan passed
```

Full `prepush` (typecheck + gui lint + full suite + privacy scan) ran green on this exact head.

New tests:

- `tests/oauth-device-code-contract.test.ts` — `loginKimi` reports the user code in `deviceCode`. Driven **red** against the pre-fix `kimi.ts` before being accepted, so it is not vacuous.
- `tests/oauth-login-open-browser.test.ts` — both directions of the route coupling: a device flow is not opened server-side and still returns its URL and code; a plain browser flow opens exactly as before. The second case is the compatibility guard.

Two existing seam tests were **updated, not relaxed**. `tests/provider-workspace-auth.test.ts` still demands a device-code widget, now pointed at its new owner, and gains an assertion that the workspace can reach `/api/oauth/login/code`. `tests/codex-auth-modal-status.test.ts` still locks the same four-part submit guard and the distinct submitting copy, now as props rather than a JSX string.

### Screenshot

The shared hint on two surfaces — a device-code login with a copyable code, and a browser login with a copyable URL. Both now offer the paste fallback.

![Shared login hint rendering a device code, an authorization URL, and the paste fallback](https://raw.githubusercontent.com/lidge-jun/opencodex/codex/pr-assets/docs/assets/oauth-login-hint-260825.png)

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (`devlog/_plan/260825_oauth_login_ux/` records the pain points and the as-landed design.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. This PR only ever makes `openUrl` fire **less**; no provider-supplied URL becomes newly openable, state enforcement on pasted redirects is untouched, and the 4 KiB paste bound is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth login flows now consistently display authorization links, device codes, and provider instructions.
  * Added copyable device codes and a shared paste-and-submit fallback with validation and status feedback.
  * First-time provider setup now shows login guidance during authentication.
  * Device-code flows no longer automatically open a browser, while redirect-based flows retain browser opening.

* **Documentation**
  * Added planning and delivery documentation for OAuth login experience improvements.

* **Tests**
  * Added coverage for device-code handling, browser-opening behavior, and login guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->