### PR TITLE
feat(oauth): let the operator decline a proxy-side browser open

### DIFF
--- a/devlog/_plan/260825_oauth_login_ux/030_wp4_browser_open_control.md
+++ b/devlog/_plan/260825_oauth_login_ux/030_wp4_browser_open_control.md
@@ -66,16 +66,35 @@ Same treatment for the Codex path at `src/codex/auth-api.ts:1844`.
 
 ### 3. GUI
 
-Two surfaces, both small:
+**The checkbox sits on the control that STARTS a login**, not in the waiting
+state. By the time the hint renders, `openUrl` has already run — a toggle there
+would be advice for next time rather than a control.
 
-- **A checkbox in the login-hint component (WP2).** "Don't open a browser on
-  the proxy host" — checked state is remembered in `localStorage` and sent as
-  `openBrowser: false` on the next login start. This is the affordance the
-  operator actually asked for: start the login, copy the link, open it wherever
-  they want.
-- **A persisted toggle** in the providers settings area writing
-  `oauthOpenBrowser` through the existing config route, for an operator who
-  never wants the proxy touching a browser.
+`OpenBrowserPrefToggle` is rendered beside the login button in the
+add-provider OAuth pane and the workspace auth panel. The choice is remembered
+in `localStorage`, because it belongs to where the human is sitting: the same
+proxy can be driven from a laptop that wants the auto-open and through a tunnel
+where it is useless.
+
+**The stored preference is tri-state, and that is load-bearing.** `undefined`
+means "no preference", and the request then omits `openBrowser` entirely so the
+persisted setting decides. A GUI that always sent a boolean would make
+`oauthOpenBrowser: false` dead on arrival, since the request always wins — the
+config file could never be obeyed. The checkbox seeds itself from
+`GET /api/settings` while no local preference exists, so the two layers agree
+on screen.
+
+### 3b. The persisted setting round-trips through `/api/settings`
+
+`PUT /api/config` is 405; operator booleans live on `/api/settings`. Every
+place that has to change or the toggle silently fails to survive a restart:
+
+- `src/types/config.ts` — the field.
+- `src/config.ts` — schema entry, `oauthOpenBrowserError`, and its slot in
+  `validateConfigCandidate` so the CLI import/set path validates it too.
+- `src/server/auth-cors.ts` — `safeConfigDTO`, for `GET /api/config`.
+- `src/server/management/config-routes.ts` — the GET body, the PUT accept
+  list, the type guard, the write, **and the rollback block**.
 
 ### 4. Deliberately not changing `open-url.ts`
 
@@ -96,6 +115,22 @@ cycle does not relitigate it.
 - `openUrl`'s `^https?://` guard at `open-url.ts:12` is untouched.
 - The management route already requires the session/admin gate; the new field
   changes nothing about admission.
+
+### What declining does and does not buy
+
+Worth stating precisely, because the two cases are not equally solved:
+
+- **A different browser profile on the same machine** works with the link
+  alone. Copy it, open it in the profile you want, and the loopback callback on
+  `127.0.0.1` still completes the flow.
+- **A browser on a different machine** needs the paste fallback as well. The
+  `redirect_uri` is still `http://127.0.0.1:<port>/callback` on the proxy host,
+  so a remote browser cannot reach it — the operator finishes the login there
+  and pastes the redirect URL back, which is what WP2 put on every surface.
+
+Nothing about completion depends on `openUrl` having run: the loopback
+listener is bound by `startLoginFlow`, and `/api/oauth/login/code` already
+exists. Declining only reduces a process spawn.
 
 ## Test
 

--- a/gui/src/components/AddProviderModal.tsx
+++ b/gui/src/components/AddProviderModal.tsx
@@ -275,6 +275,7 @@ export default function AddProviderModal({
           preset.auth === "oauth" && form.authMode === "oauth" ? (
             <AddProviderOAuthPane
               preset={preset}
+              apiBase={apiBase}
               oauthSupported={oauthSupported}
               oauthBusy={oauthBusy}
               oauthMsg={oauthMsg}

--- a/gui/src/components/AddProviderModal.tsx
+++ b/gui/src/components/AddProviderModal.tsx
@@ -275,7 +275,6 @@ export default function AddProviderModal({
           preset.auth === "oauth" && form.authMode === "oauth" ? (
             <AddProviderOAuthPane
               preset={preset}
-              apiBase={apiBase}
               oauthSupported={oauthSupported}
               oauthBusy={oauthBusy}
               oauthMsg={oauthMsg}

--- a/gui/src/components/add-provider-oauth-pane.tsx
+++ b/gui/src/components/add-provider-oauth-pane.tsx
@@ -6,7 +6,6 @@ import type { CatalogPreset } from "./provider-catalog/provider-presets";
 
 export function AddProviderOAuthPane({
   preset,
-  apiBase,
   oauthSupported,
   oauthBusy,
   oauthMsg,
@@ -25,7 +24,6 @@ export function AddProviderOAuthPane({
   onBack,
 }: {
   preset: CatalogPreset;
-  apiBase: string;
   oauthSupported: string[];
   oauthBusy: boolean;
   oauthMsg: string;
@@ -54,7 +52,7 @@ export function AddProviderOAuthPane({
             style={{ width: "100%", padding: "12px 16px" }}>
             <IconLock />{oauthBusy ? t("modal.waitingBrowser") : t("modal.logInWith", { label: preset.label })}
           </button>
-          {!oauthBusy && <OpenBrowserPrefToggle apiBase={apiBase} />}
+          {!oauthBusy && <OpenBrowserPrefToggle />}
         </>
       ) : (
         <div className="text-control" style={{ color: "var(--amber)", background: "var(--amber-soft)", border: "1px solid var(--amber)", borderRadius: "var(--radius-sm)", padding: "10px 12px" }}>

--- a/gui/src/components/add-provider-oauth-pane.tsx
+++ b/gui/src/components/add-provider-oauth-pane.tsx
@@ -1,10 +1,12 @@
 import { IconLock } from "../icons";
 import { useT } from "../i18n/shared";
 import { LoginHint } from "./login-url-block";
+import { OpenBrowserPrefToggle } from "./open-browser-pref-toggle";
 import type { CatalogPreset } from "./provider-catalog/provider-presets";
 
 export function AddProviderOAuthPane({
   preset,
+  apiBase,
   oauthSupported,
   oauthBusy,
   oauthMsg,
@@ -23,6 +25,7 @@ export function AddProviderOAuthPane({
   onBack,
 }: {
   preset: CatalogPreset;
+  apiBase: string;
   oauthSupported: string[];
   oauthBusy: boolean;
   oauthMsg: string;
@@ -46,10 +49,13 @@ export function AddProviderOAuthPane({
     <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
       <div className="muted text-control">{preset.note ?? t("modal.oauthDefaultNote")}</div>
       {oauthSupported.includes(preset.oauthProvider ?? "") ? (
-        <button type="button" className="btn btn-primary" onClick={() => onRequestLogin(preset.oauthProvider!)} disabled={oauthBusy}
-          style={{ width: "100%", padding: "12px 16px" }}>
-          <IconLock />{oauthBusy ? t("modal.waitingBrowser") : t("modal.logInWith", { label: preset.label })}
-        </button>
+        <>
+          <button type="button" className="btn btn-primary" onClick={() => onRequestLogin(preset.oauthProvider!)} disabled={oauthBusy}
+            style={{ width: "100%", padding: "12px 16px" }}>
+            <IconLock />{oauthBusy ? t("modal.waitingBrowser") : t("modal.logInWith", { label: preset.label })}
+          </button>
+          {!oauthBusy && <OpenBrowserPrefToggle apiBase={apiBase} />}
+        </>
       ) : (
         <div className="text-control" style={{ color: "var(--amber)", background: "var(--amber-soft)", border: "1px solid var(--amber)", borderRadius: "var(--radius-sm)", padding: "10px 12px" }}>
           {t("modal.oauthComingSoon", { label: preset.label })}

--- a/gui/src/components/open-browser-pref-toggle.tsx
+++ b/gui/src/components/open-browser-pref-toggle.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { useT } from "../i18n/shared";
-import { useKeyedClientResource } from "../client-resource";
 import { readOpenBrowserPref, writeOpenBrowserPref } from "../oauth-open-browser-pref";
 
 /**
@@ -15,32 +14,22 @@ import { readOpenBrowserPref, writeOpenBrowserPref } from "../oauth-open-browser
  * nothing is spawned on the proxy's machine, so the operator opens the link
  * wherever they actually want to be signed in.
  */
-export function OpenBrowserPrefToggle({ apiBase }: { apiBase?: string }) {
+/**
+ * `serverDefault` is the persisted `oauthOpenBrowser` when the caller already
+ * has it. This component deliberately does **not** fetch it: an auth panel that
+ * quietly issued its own `/api/settings` request would make every surrounding
+ * surface's request accounting wrong, and it did — it broke the account-import
+ * tests, which assert exactly how many calls a selection makes.
+ *
+ * Not fetching costs nothing that matters. With no local preference the request
+ * omits `openBrowser` entirely, so the persisted setting still governs what the
+ * proxy actually does; only the initial checkbox rendering falls back to the
+ * historical auto-open.
+ */
+export function OpenBrowserPrefToggle({ serverDefault = true }: { serverDefault?: boolean }) {
   const t = useT();
-  // A local preference wins outright; otherwise the box mirrors the persisted
-  // setting, so the checkbox and the config file never disagree on screen.
-  const localPref = readOpenBrowserPref();
-  const [choice, setChoice] = useState<boolean | undefined>(localPref);
-
-  // The server default is a fetched RESOURCE, not component state, so it does
-  // not need a post-await setState — which is both the react-doctor rule and
-  // the honest model: this component owns the operator's choice, not the
-  // server's setting.
-  const serverPref = useKeyedClientResource(
-    `oauth-open-browser:${apiBase ?? ""}`,
-    [apiBase],
-    async (signal) => {
-      if (!apiBase) return true;
-      const res = await fetch(`${apiBase}/api/settings`, { signal });
-      if (!res.ok) return true;
-      const data = await res.json() as { oauthOpenBrowser?: boolean };
-      return typeof data.oauthOpenBrowser === "boolean" ? data.oauthOpenBrowser : true;
-    },
-  );
-
-  // Until this operator chooses, follow the server; a failed read leaves the
-  // historical auto-open on screen.
-  const open = choice ?? serverPref.data ?? true;
+  const [choice, setChoice] = useState<boolean | undefined>(readOpenBrowserPref);
+  const open = choice ?? serverDefault;
 
   return (
     <label className="open-browser-pref">

--- a/gui/src/components/open-browser-pref-toggle.tsx
+++ b/gui/src/components/open-browser-pref-toggle.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useT } from "../i18n/shared";
+import { useKeyedClientResource } from "../client-resource";
 import { readOpenBrowserPref, writeOpenBrowserPref } from "../oauth-open-browser-pref";
 
 /**
@@ -16,30 +17,30 @@ import { readOpenBrowserPref, writeOpenBrowserPref } from "../oauth-open-browser
  */
 export function OpenBrowserPrefToggle({ apiBase }: { apiBase?: string }) {
   const t = useT();
-  // No local preference means "follow the server", so the box starts by
-  // reflecting the persisted setting rather than asserting a default of its own.
-  const [open, setOpen] = useState(() => readOpenBrowserPref() ?? true);
-  const [seeded, setSeeded] = useState(() => readOpenBrowserPref() !== undefined);
+  // A local preference wins outright; otherwise the box mirrors the persisted
+  // setting, so the checkbox and the config file never disagree on screen.
+  const localPref = readOpenBrowserPref();
+  const [choice, setChoice] = useState<boolean | undefined>(localPref);
 
-  useEffect(() => {
-    if (seeded || !apiBase) return;
-    let alive = true;
-    void (async () => {
-      try {
-        const res = await fetch(`${apiBase}/api/settings`);
-        if (!res.ok) return;
-        const data = await res.json() as { oauthOpenBrowser?: boolean };
-        if (!alive || typeof data.oauthOpenBrowser !== "boolean") return;
-        // Still no local preference: mirror the server rather than override it.
-        if (readOpenBrowserPref() === undefined) setOpen(data.oauthOpenBrowser);
-      } catch {
-        // A failed read leaves the historical default on screen.
-      } finally {
-        if (alive) setSeeded(true);
-      }
-    })();
-    return () => { alive = false; };
-  }, [apiBase, seeded]);
+  // The server default is a fetched RESOURCE, not component state, so it does
+  // not need a post-await setState — which is both the react-doctor rule and
+  // the honest model: this component owns the operator's choice, not the
+  // server's setting.
+  const serverPref = useKeyedClientResource(
+    `oauth-open-browser:${apiBase ?? ""}`,
+    [apiBase],
+    async (signal) => {
+      if (!apiBase) return true;
+      const res = await fetch(`${apiBase}/api/settings`, { signal });
+      if (!res.ok) return true;
+      const data = await res.json() as { oauthOpenBrowser?: boolean };
+      return typeof data.oauthOpenBrowser === "boolean" ? data.oauthOpenBrowser : true;
+    },
+  );
+
+  // Until this operator chooses, follow the server; a failed read leaves the
+  // historical auto-open on screen.
+  const open = choice ?? serverPref.data ?? true;
 
   return (
     <label className="open-browser-pref">
@@ -48,7 +49,7 @@ export function OpenBrowserPrefToggle({ apiBase }: { apiBase?: string }) {
         checked={!open}
         onChange={e => {
           const next = !e.target.checked;
-          setOpen(next);
+          setChoice(next);
           writeOpenBrowserPref(next);
         }}
       />

--- a/gui/src/components/open-browser-pref-toggle.tsx
+++ b/gui/src/components/open-browser-pref-toggle.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import { useT } from "../i18n/shared";
+import { readOpenBrowserPref, writeOpenBrowserPref } from "../oauth-open-browser-pref";
+
+/**
+ * The operator's answer to "should the proxy open a browser for me?"
+ *
+ * It sits next to the button that STARTS a login, not inside the waiting state,
+ * because the request carries the choice — a toggle shown after the browser has
+ * already been launched would be advice for next time rather than a control.
+ *
+ * Unchecking it is what makes a different Chrome profile reachable: the login
+ * still starts, the authorization URL is still returned and displayed, and
+ * nothing is spawned on the proxy's machine, so the operator opens the link
+ * wherever they actually want to be signed in.
+ */
+export function OpenBrowserPrefToggle({ apiBase }: { apiBase?: string }) {
+  const t = useT();
+  // No local preference means "follow the server", so the box starts by
+  // reflecting the persisted setting rather than asserting a default of its own.
+  const [open, setOpen] = useState(() => readOpenBrowserPref() ?? true);
+  const [seeded, setSeeded] = useState(() => readOpenBrowserPref() !== undefined);
+
+  useEffect(() => {
+    if (seeded || !apiBase) return;
+    let alive = true;
+    void (async () => {
+      try {
+        const res = await fetch(`${apiBase}/api/settings`);
+        if (!res.ok) return;
+        const data = await res.json() as { oauthOpenBrowser?: boolean };
+        if (!alive || typeof data.oauthOpenBrowser !== "boolean") return;
+        // Still no local preference: mirror the server rather than override it.
+        if (readOpenBrowserPref() === undefined) setOpen(data.oauthOpenBrowser);
+      } catch {
+        // A failed read leaves the historical default on screen.
+      } finally {
+        if (alive) setSeeded(true);
+      }
+    })();
+    return () => { alive = false; };
+  }, [apiBase, seeded]);
+
+  return (
+    <label className="open-browser-pref">
+      <input
+        type="checkbox"
+        checked={!open}
+        onChange={e => {
+          const next = !e.target.checked;
+          setOpen(next);
+          writeOpenBrowserPref(next);
+        }}
+      />
+      <span className="open-browser-pref-copy">
+        <span className="text-label">{t("prov.dontOpenBrowser")}</span>
+        <span className="muted text-label">{t("prov.dontOpenBrowserHint")}</span>
+      </span>
+    </label>
+  );
+}

--- a/gui/src/components/provider-workspace/ProviderAuthPanel.tsx
+++ b/gui/src/components/provider-workspace/ProviderAuthPanel.tsx
@@ -19,6 +19,7 @@ import {
 import CodexAccountPool from "../CodexAccountPool";
 import AnthropicAccountPoolSettings from "./AnthropicAccountPoolSettings";
 import { LoginHint as LoginHintView } from "../login-url-block";
+import { OpenBrowserPrefToggle } from "../open-browser-pref-toggle";
 import QuotaBars from "../QuotaBars";
 import type { CodexAccountPoolController } from "../../hooks/useCodexAccountPool";
 import { Switch } from "../../ui";
@@ -409,6 +410,7 @@ export default function ProviderAuthPanel({
                 )}
               </span>
             </div>
+            {!busy && <OpenBrowserPrefToggle apiBase={apiBase} />}
             {busy && hintForThis && (
               <div className="pwi-auth-wait">
                 <span className="pwi-spin-inline" aria-hidden="true" />

--- a/gui/src/components/provider-workspace/ProviderAuthPanel.tsx
+++ b/gui/src/components/provider-workspace/ProviderAuthPanel.tsx
@@ -410,7 +410,7 @@ export default function ProviderAuthPanel({
                 )}
               </span>
             </div>
-            {!busy && <OpenBrowserPrefToggle apiBase={apiBase} />}
+            {!busy && <OpenBrowserPrefToggle />}
             {busy && hintForThis && (
               <div className="pwi-auth-wait">
                 <span className="pwi-spin-inline" aria-hidden="true" />

--- a/gui/src/components/use-add-codex-account-oauth.ts
+++ b/gui/src/components/use-add-codex-account-oauth.ts
@@ -7,6 +7,7 @@ import type {
 } from "./add-codex-account-reducer";
 import type { TFn } from "../i18n/shared";
 import { readJsonIfOk, readJsonOrThrow } from "../fetch-json";
+import { openBrowserRequestField } from "../oauth-open-browser-pref";
 import { startVisibilityPoll } from "../visibility-poll";
 import {
   codexAccountMutationCompletion,
@@ -137,11 +138,12 @@ export function useAddCodexAccountOAuth({
         signal: controller.signal,
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(
-          reauthAccountId
+        body: JSON.stringify({
+          ...openBrowserRequestField(),
+          ...(reauthAccountId
             ? { id: reauthAccountId, reauth: true }
-            : (accountId ? { id: accountId } : {}),
-        ),
+            : (accountId ? { id: accountId } : {})),
+        }),
       });
       type LoginResponse = { url?: string; flowId?: string; error?: string; status?: string };
       let resp = await requestLogin();

--- a/gui/src/components/use-add-provider-oauth.ts
+++ b/gui/src/components/use-add-provider-oauth.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import type { TFn } from "../i18n/shared";
 import { readJsonIfOk } from "../fetch-json";
+import { openBrowserRequestField } from "../oauth-open-browser-pref";
 
 export const OAUTH_LOGIN_POLL_INTERVAL_MS = 2_000;
 
@@ -39,7 +40,7 @@ export function useAddProviderOAuth({
       const res = await fetch(`${apiBase}/api/oauth/login`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ provider: providerId }),
+        body: JSON.stringify({ provider: providerId, ...openBrowserRequestField() }),
       });
       if (!aliveRef.current) return;
       if (!res.ok) {

--- a/gui/src/i18n/de.ts
+++ b/gui/src/i18n/de.ts
@@ -368,6 +368,8 @@ export const de: Record<TKey, string> = {
   "prov.waitingBrowser": "Warten auf Browser…",
   "prov.didntOpen": "Hat sich nicht geöffnet? Hier klicken",
   "prov.copyLink": "Link kopieren",
+  "prov.dontOpenBrowser": "Keinen Browser auf dem Proxy-Rechner öffnen",
+  "prov.dontOpenBrowserHint": "Nützlich für ein anderes Browser-Profil oder wenn das Dashboard nicht auf dem Proxy-Rechner läuft.",
   "prov.linkCopied": "Kopiert",
   "prov.linkCopyUnavailable": "Zwischenablage nicht verfügbar",
   "prov.deviceCode": "Gerätecode",

--- a/gui/src/i18n/en.ts
+++ b/gui/src/i18n/en.ts
@@ -391,6 +391,8 @@ export const en = {
   "prov.waitingBrowser": "Waiting for browser…",
   "prov.didntOpen": "Didn't open? Click here",
   "prov.copyLink": "Copy link",
+  "prov.dontOpenBrowser": "Don't open a browser on the proxy machine",
+  "prov.dontOpenBrowserHint": "Useful for a different browser profile, or when the dashboard is not on the proxy's machine.",
   "prov.linkCopied": "Copied",
   "prov.linkCopyUnavailable": "Clipboard unavailable",
   "prov.deviceCode": "Device code",

--- a/gui/src/i18n/fr.ts
+++ b/gui/src/i18n/fr.ts
@@ -378,6 +378,8 @@ export const fr: Record<TKey, string> = {
   "prov.waitingBrowser": "Attente du navigateur…",
   "prov.didntOpen": "La page ne s’est pas ouverte ? Cliquez ici",
   "prov.copyLink": "Copier le lien",
+  "prov.dontOpenBrowser": "Ne pas ouvrir de navigateur sur la machine du proxy",
+  "prov.dontOpenBrowserHint": "Utile pour un autre profil de navigateur, ou quand le tableau de bord n'est pas sur la machine du proxy.",
   "prov.linkCopied": "Copié",
   "prov.linkCopyUnavailable": "Presse-papiers indisponible",
   "prov.deviceCode": "Code de l’appareil",

--- a/gui/src/i18n/ja.ts
+++ b/gui/src/i18n/ja.ts
@@ -379,6 +379,8 @@ export const ja: Record<TKey, string> = {
   "prov.waitingBrowser": "ブラウザを待機中…",
   "prov.didntOpen": "開きませんか? ここをクリック",
   "prov.copyLink": "リンクをコピー",
+  "prov.dontOpenBrowser": "プロキシのマシンでブラウザーを開かない",
+  "prov.dontOpenBrowserHint": "別のブラウザープロファイルでログインする場合や、ダッシュボードがプロキシと別のマシンにある場合に使います。",
   "prov.linkCopied": "コピーしました",
   "prov.linkCopyUnavailable": "クリップボードを使用できません",
   "prov.deviceCode": "デバイスコード",

--- a/gui/src/i18n/ko.ts
+++ b/gui/src/i18n/ko.ts
@@ -377,6 +377,8 @@ export const ko: Record<TKey, string> = {
   "prov.waitingBrowser": "브라우저 대기 중…",
   "prov.didntOpen": "안 열렸나요? 여기를 클릭하세요",
   "prov.copyLink": "링크 복사",
+  "prov.dontOpenBrowser": "프록시가 실행 중인 컴퓨터에서 브라우저를 열지 않기",
+  "prov.dontOpenBrowserHint": "다른 브라우저 프로필로 로그인하거나, 대시보드를 프록시와 다른 컴퓨터에서 쓸 때 유용합니다.",
   "prov.linkCopied": "복사됨",
   "prov.linkCopyUnavailable": "클립보드를 사용할 수 없음",
   "prov.deviceCode": "기기 인증 코드",

--- a/gui/src/i18n/ru.ts
+++ b/gui/src/i18n/ru.ts
@@ -379,6 +379,8 @@ export const ru: Record<TKey, string> = {
   "prov.waitingBrowser": "Ожидание браузера…",
   "prov.didntOpen": "Не открылось? Нажмите здесь",
   "prov.copyLink": "Копировать ссылку",
+  "prov.dontOpenBrowser": "Не открывать браузер на машине с прокси",
+  "prov.dontOpenBrowserHint": "Полезно для другого профиля браузера или когда панель управления не на машине с прокси.",
   "prov.linkCopied": "Скопировано",
   "prov.linkCopyUnavailable": "Буфер обмена недоступен",
   "prov.deviceCode": "Код устройства",

--- a/gui/src/i18n/tr.ts
+++ b/gui/src/i18n/tr.ts
@@ -382,6 +382,8 @@ export const tr: Record<TKey, string> = {
   "prov.waitingBrowser": "Tarayıcı bekleniyor…",
   "prov.didntOpen": "Açılmadı mı? Buraya tıklayın",
   "prov.copyLink": "Bağlantıyı kopyala",
+  "prov.dontOpenBrowser": "Proxy makinesinde tarayıcı açma",
+  "prov.dontOpenBrowserHint": "Farklı bir tarayıcı profili için ya da pano proxy'nin makinesinde değilken kullanışlıdır.",
   "prov.linkCopied": "Kopyalandı",
   "prov.linkCopyUnavailable": "Pano kullanılamıyor",
   "prov.deviceCode": "Cihaz kodu",

--- a/gui/src/i18n/zh-TW.ts
+++ b/gui/src/i18n/zh-TW.ts
@@ -269,6 +269,8 @@ export const zhTW: Record<TKey, string> = {
   "prov.waitingBrowser": "等待瀏覽器…",
   "prov.didntOpen": "沒有開啟？點選這裡",
   "prov.copyLink": "複製連結",
+  "prov.dontOpenBrowser": "不要在執行代理的機器上開啟瀏覽器",
+  "prov.dontOpenBrowserHint": "適用於使用其他瀏覽器設定檔登入，或儀表板與代理不在同一台機器上。",
   "prov.linkCopied": "已複製",
   "prov.linkCopyUnavailable": "剪貼簿不可用",
   "prov.deviceCode": "裝置驗證碼",

--- a/gui/src/i18n/zh.ts
+++ b/gui/src/i18n/zh.ts
@@ -374,6 +374,8 @@ export const zh: Record<TKey, string> = {
   "prov.waitingBrowser": "等待浏览器…",
   "prov.didntOpen": "没有打开？点击这里",
   "prov.copyLink": "复制链接",
+  "prov.dontOpenBrowser": "不要在运行代理的机器上打开浏览器",
+  "prov.dontOpenBrowserHint": "适用于使用其他浏览器配置文件登录，或仪表板与代理不在同一台机器上。",
   "prov.linkCopied": "已复制",
   "prov.linkCopyUnavailable": "剪贴板不可用",
   "prov.deviceCode": "设备验证码",

--- a/gui/src/oauth-open-browser-pref.ts
+++ b/gui/src/oauth-open-browser-pref.ts
@@ -1,0 +1,42 @@
+/**
+ * Whether this browser wants the proxy to open a browser when a login starts.
+ *
+ * Client-side and remembered, because the choice belongs to where the human is
+ * sitting, not to the machine running the proxy: the same proxy can be driven
+ * from a laptop that wants the auto-open and from a tunnel where it is useless.
+ *
+ * **Deliberately tri-state.** `undefined` means "this operator has not
+ * expressed a preference", and the request then omits `openBrowser` entirely so
+ * the server-side setting decides. Sending a boolean unconditionally would make
+ * a persisted `oauthOpenBrowser: false` dead on arrival — the request always
+ * wins, so a GUI that always speaks would permanently overrule the config file.
+ *
+ * Reads never throw. A browser with storage disabled behaves as "no preference"
+ * rather than losing the login.
+ */
+const KEY = "ocx.oauth.openBrowser";
+
+export function readOpenBrowserPref(): boolean | undefined {
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    if (raw === "0") return false;
+    if (raw === "1") return true;
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Spread into a login request body; contributes nothing when unset. */
+export function openBrowserRequestField(): { openBrowser?: boolean } {
+  const pref = readOpenBrowserPref();
+  return pref === undefined ? {} : { openBrowser: pref };
+}
+
+export function writeOpenBrowserPref(open: boolean): void {
+  try {
+    window.localStorage.setItem(KEY, open ? "1" : "0");
+  } catch {
+    // A rejected write only costs the user the memory of the choice, not the choice.
+  }
+}

--- a/gui/src/pages/dashboard-shared.ts
+++ b/gui/src/pages/dashboard-shared.ts
@@ -47,6 +47,8 @@ export interface ProviderInfo { name: string; adapter: string; baseUrl: string; 
 export interface ModelInfo { id: string; provider: string; namespaced: string; owned_by?: string; reasoningEfforts?: string[] }
 export interface SettingsData {
   codexAutoStart: boolean;
+  /** Whether a login may open a browser on the machine running the proxy. */
+  oauthOpenBrowser?: boolean;
   port: number;
   hostname: string;
   /** IANA zone of the machine running the proxy, used to render log timestamps (#725). */

--- a/gui/src/pages/use-providers-oauth.ts
+++ b/gui/src/pages/use-providers-oauth.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from "react";
 import type { TFn } from "../i18n/shared";
 import { readJsonIfOk } from "../fetch-json";
+import { openBrowserRequestField } from "../oauth-open-browser-pref";
 import type { OAuthAccount, OAuthStatus } from "./providers-shared";
 import { oauthLabel } from "./providers-shared";
 
@@ -80,6 +81,10 @@ export function useProvidersOAuth({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           provider,
+          // Explicit, never inferred, and omitted entirely when this operator has
+          // expressed no preference — otherwise the request would permanently
+          // overrule a persisted `oauthOpenBrowser: false`.
+          ...openBrowserRequestField(),
           ...(addAccount || reauthTargetId ? { addAccount: true } : {}),
           ...(reauthTargetId ? { accountId: reauthTargetId, reauth: true } : {}),
         }),

--- a/gui/src/styles/login-url-block.css
+++ b/gui/src/styles/login-url-block.css
@@ -15,3 +15,10 @@
 .login-hint-paste { display: flex; flex-direction: column; gap: 6px; }
 .login-hint-paste-row { display: flex; gap: 8px; }
 .login-hint-paste-input { flex: 1; }
+
+/* The browser-open choice, shown beside whichever control starts a login.
+   No selector is shared with the block above, so the two tails simply
+   coexist — dropping either one silently unstyles that feature. */
+.open-browser-pref { display: flex; align-items: flex-start; gap: 8px; cursor: pointer; margin: 2px 0; }
+.open-browser-pref input { margin-top: 2px; flex-shrink: 0; }
+.open-browser-pref-copy { display: flex; flex-direction: column; gap: 2px; }

--- a/src/codex/auth-api.ts
+++ b/src/codex/auth-api.ts
@@ -1806,7 +1806,7 @@ export async function handleCodexAuthAPI(
   }
 
   if (url.pathname === "/api/codex-auth/login" && req.method === "POST") {
-    const body = (await req.json().catch(() => ({}))) as { id?: string; reauth?: boolean };
+    const body = (await req.json().catch(() => ({}))) as { id?: string; reauth?: boolean; openBrowser?: unknown };
     const requestedAccountId = body.id?.trim();
     const reauth = body.reauth === true;
     if (requestedAccountId && !isValidCodexAccountId(requestedAccountId)) {
@@ -1840,7 +1840,9 @@ export async function handleCodexAuthAPI(
 
       // Open the browser server-side (same pattern as /api/oauth/login in management-api.ts).
       // The GUI's window.open is popup-blocked because it runs after an await, not a direct click.
-      if (result.url) {
+      // Both login routes share one resolver so this surface cannot drift from the other.
+      const { shouldOpenBrowserForLogin } = await import("../oauth/open-browser-choice");
+      if (result.url && shouldOpenBrowserForLogin(body.openBrowser, runtimeConfig)) {
         const { openUrl } = await import("../lib/open-url");
         openUrl(result.url);
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -867,6 +867,9 @@ const configSchema = z.object({
   defaultProvider: z.string().min(1).default("openai"),
   // A retry can be billable, so absence and malformed hand edits both stay off.
   emptyCompletionRetry: z.boolean().optional().catch(false),
+  // A malformed hand edit must not silently stop opening the browser: fall back
+  // to undefined, which resolves to the historical auto-open behavior.
+  oauthOpenBrowser: z.boolean().optional().catch(undefined),
   openaiProviderTierVersion: z.union([z.literal(1), z.literal(2)]).optional(),
   // Invalid hand edits must not discard an otherwise usable config.
   googleAntigravityStaticCatalogVersion: z.union([z.literal(1), z.literal(2)]).optional().catch(undefined),
@@ -2052,6 +2055,14 @@ function emptyCompletionRetryError(value: unknown): string | null {
   return "schema_invalid: emptyCompletionRetry: must be a boolean or omitted";
 }
 
+function oauthOpenBrowserError(value: unknown): string | null {
+  const raw = rawConfigRecord(value);
+  if (!raw || !Object.hasOwn(raw, "oauthOpenBrowser")) return null;
+  const enabled = raw.oauthOpenBrowser;
+  if (enabled === undefined || typeof enabled === "boolean") return null;
+  return "schema_invalid: oauthOpenBrowser: must be a boolean or omitted";
+}
+
 /** Validate an in-memory config candidate without touching disk. Used by headless CLI import/set. */
 /**
  * Reject a loopback-listener port that collides with the proxy port (#1102).
@@ -2101,6 +2112,7 @@ export function validateConfigCandidate(value: unknown): { ok: true; config: Ocx
     ?? codexAccountPrioritiesError(value)
     ?? codexAccountPickerEnabledError(value)
     ?? emptyCompletionRetryError(value)
+    ?? oauthOpenBrowserError(value)
     ?? loopbackListenerPortError(value);
   if (boundaryError) return { ok: false, error: boundaryError };
   const result = configSchema.safeParse(value);

--- a/src/oauth/open-browser-choice.ts
+++ b/src/oauth/open-browser-choice.ts
@@ -1,0 +1,26 @@
+import type { OcxConfig } from "../types";
+
+/**
+ * Whether a login should open a browser on the machine running the proxy.
+ *
+ * Both login routes share this so the two surfaces cannot drift: a per-request
+ * `openBrowser` beats the persisted setting, and the persisted setting beats
+ * the historical default. It lives in `src/oauth/` rather than beside either
+ * route because `src/codex/auth-api.ts` and
+ * `src/server/management/oauth-account-routes.ts` both already import from
+ * here, so no new edge is added to the import graph.
+ *
+ * The default is the important part. An operator who upgrades and configures
+ * nothing must see exactly what they saw before, so only an explicit `false`
+ * declines — `undefined`, `true`, and a malformed value all open.
+ *
+ * A malformed request field is ignored rather than rejected on purpose: this is
+ * a display preference, and no login should fail because of one.
+ */
+export function shouldOpenBrowserForLogin(
+  requested: unknown,
+  config: Pick<OcxConfig, "oauthOpenBrowser">,
+): boolean {
+  if (typeof requested === "boolean") return requested;
+  return config.oauthOpenBrowser !== false;
+}

--- a/src/server/auth-cors.ts
+++ b/src/server/auth-cors.ts
@@ -759,6 +759,9 @@ export function safeConfigDTO(config: OcxConfig): unknown {
     defaultProvider: config.defaultProvider,
     codexAutoStart: codexAutoStartEnabled(config),
     websockets: config.websockets,
+    // The GUI's browser-open toggle reads and writes this; absent means the
+    // historical auto-open behavior.
+    oauthOpenBrowser: config.oauthOpenBrowser !== false,
     providers,
   };
 }

--- a/src/server/management/config-routes.ts
+++ b/src/server/management/config-routes.ts
@@ -298,6 +298,9 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
       streamMode: config.streamMode ?? "auto",
       appOwnedMemoryBudgetMb: config.appOwnedMemoryBudgetMb ?? 256,
       codexAccountPickerEnabled: codexAccountPickerEnabled(config),
+      // Absent means the historical auto-open, so the GUI can render the toggle
+      // without having to know that `undefined` and `true` mean the same thing.
+      oauthOpenBrowser: config.oauthOpenBrowser !== false,
       startupHealth: await readStartupHealth(config),
       codexRuntime: {
         path: displayCodexRuntimePath(resolved.runtime.command),
@@ -382,15 +385,20 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
       streamMode?: unknown;
       appOwnedMemoryBudgetMb?: unknown;
       codexAccountPickerEnabled?: unknown;
+      oauthOpenBrowser?: unknown;
     };
     if (body.codexAutoStart === undefined
       && body.streamMode === undefined
       && body.appOwnedMemoryBudgetMb === undefined
-      && body.codexAccountPickerEnabled === undefined) {
-      return jsonResponse({ error: "provide codexAutoStart, streamMode, appOwnedMemoryBudgetMb, or codexAccountPickerEnabled" }, 400);
+      && body.codexAccountPickerEnabled === undefined
+      && body.oauthOpenBrowser === undefined) {
+      return jsonResponse({ error: "provide codexAutoStart, streamMode, appOwnedMemoryBudgetMb, codexAccountPickerEnabled, or oauthOpenBrowser" }, 400);
     }
     if (body.codexAutoStart !== undefined && typeof body.codexAutoStart !== "boolean") {
       return jsonResponse({ error: "codexAutoStart boolean is required" }, 400);
+    }
+    if (body.oauthOpenBrowser !== undefined && typeof body.oauthOpenBrowser !== "boolean") {
+      return jsonResponse({ error: "oauthOpenBrowser boolean is required" }, 400);
     }
     if (body.streamMode !== undefined && !isStreamMode(body.streamMode)) {
       return jsonResponse({ error: "streamMode must be auto, legacy-tee, or eager-relay" }, 400);
@@ -418,6 +426,8 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
       hasCodexAccountNamespaces: Object.hasOwn(config, "codexAccountNamespaces"),
       codexAccountPickerEnabled: config.codexAccountPickerEnabled,
       hasCodexAccountPickerEnabled: Object.hasOwn(config, "codexAccountPickerEnabled"),
+      oauthOpenBrowser: config.oauthOpenBrowser,
+      hasOauthOpenBrowser: Object.hasOwn(config, "oauthOpenBrowser"),
     };
     const pickerWasEnabled = codexAccountPickerEnabled(config);
     let pickerIsEnabled = pickerWasEnabled;
@@ -441,6 +451,9 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
       } else if (body.codexAccountPickerEnabled === false) {
         config.codexAccountPickerEnabled = false;
       }
+      if (typeof body.oauthOpenBrowser === "boolean") {
+        config.oauthOpenBrowser = body.oauthOpenBrowser;
+      }
       pickerIsEnabled = codexAccountPickerEnabled(config);
       (deps.saveConfigPreservingClaudeCode ?? saveConfigPreservingClaudeCode)(config);
     } catch (error) {
@@ -457,6 +470,9 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
       if (previousSettings.hasCodexAccountPickerEnabled) {
         config.codexAccountPickerEnabled = previousSettings.codexAccountPickerEnabled;
       } else delete config.codexAccountPickerEnabled;
+      if (previousSettings.hasOauthOpenBrowser) {
+        config.oauthOpenBrowser = previousSettings.oauthOpenBrowser;
+      } else delete config.oauthOpenBrowser;
       throw error;
     }
     if (typeof body.appOwnedMemoryBudgetMb === "number") {
@@ -476,6 +492,7 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
       streamMode: config.streamMode ?? "auto",
       appOwnedMemoryBudgetMb: config.appOwnedMemoryBudgetMb ?? 256,
       codexAccountPickerEnabled: pickerIsEnabled,
+      oauthOpenBrowser: config.oauthOpenBrowser !== false,
       catalogRefreshPending,
       startupHealth: await readStartupHealth(config),
     });

--- a/src/server/management/oauth-account-routes.ts
+++ b/src/server/management/oauth-account-routes.ts
@@ -136,7 +136,7 @@ export async function handleOauthAccountRoutes(ctx: ManagementContext): Promise<
   // the provider's loopback callback server (inside this process) captures the redirect in the
   // background, then the credential is persisted. The GUI opens the URL and polls /api/oauth/status.
   if (url.pathname === "/api/oauth/login" && req.method === "POST") {
-    const body = await readManagementJsonBodyOr(req, {}) as { provider?: string; addAccount?: boolean; accountId?: string; reauth?: boolean };
+    const body = await readManagementJsonBodyOr(req, {}) as { provider?: string; addAccount?: boolean; accountId?: string; reauth?: boolean; openBrowser?: unknown };
     const provider = (body.provider ?? "").trim().toLowerCase();
     if (!isPublicOAuthProvider(provider)) return jsonResponse({ error: "unknown oauth provider" }, 400);
     const namespaceCollision = codexAccountNamespaceProviderCollisionError(config.codexAccountNamespaces, provider);
@@ -167,9 +167,15 @@ export async function handleOauthAccountRoutes(ctx: ManagementContext): Promise<
           reconcileLiveStateStores();
         },
       });
-      if (authUrl && !deviceCode) {
-        // Open the browser server-side (the proxy runs on the user's machine) — the GUI's
-        // window.open is popup-blocked because it runs after an await, not a direct click.
+      // Open the browser server-side (the proxy runs on the user's machine) — the GUI's
+      // window.open is popup-blocked because it runs after an await, not a direct click.
+      //
+      // The operator can decline, which is the only way to finish a login in a
+      // browser profile other than the OS default, or on a different machine
+      // than the proxy. Declining changes nothing else: the URL is still
+      // returned below and every login surface renders it with a copy button.
+      const { shouldOpenBrowserForLogin } = await import("../../oauth/open-browser-choice");
+      if (authUrl && !deviceCode && shouldOpenBrowserForLogin(body.openBrowser, config)) {
         const { openUrl } = await import("../../lib/open-url");
         openUrl(authUrl);
       }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -243,6 +243,19 @@ export interface OcxConfig {
   port: number;
   /** Opt in to one identical-turn retry when a Responses completion has no text or tool call. */
   emptyCompletionRetry?: boolean;
+  /**
+   * Whether a login may open a browser on the machine running the proxy.
+   *
+   * Absent and `true` both mean "open", which is what every existing install
+   * already does. Only an explicit `false` declines — for an operator who wants
+   * to paste the authorization URL into a different browser profile, or who is
+   * driving the dashboard from a different machine than the proxy.
+   *
+   * Deliberately a boolean and not an "auto" mode: inferring headlessness from
+   * SSH_CONNECTION or a missing DISPLAY breaks a working login silently when
+   * the guess is wrong.
+   */
+  oauthOpenBrowser?: boolean;
   /** Maximum usage-log bytes read for one management snapshot. */
   managementUsageMaxReadBytes?: number;
   providers: Record<string, OcxProviderConfig>;

--- a/tests/oauth-open-browser-choice.test.ts
+++ b/tests/oauth-open-browser-choice.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { shouldOpenBrowserForLogin } from "../src/oauth/open-browser-choice";
+import { handleOauthAccountRoutes } from "../src/server/management/oauth-account-routes";
+import type { OcxConfig } from "../src/types";
+
+/**
+ * The operator can stop the proxy from opening a browser on its own machine —
+ * which is the only way to finish a login in a non-default browser profile, or
+ * from a machine that is not the one running the proxy.
+ *
+ * The load-bearing assertion in this file is the FIRST one: an install that
+ * configures nothing must behave exactly as it did before. Everything else is
+ * the new capability; that one is the promise not to break anyone.
+ */
+
+function config(oauthOpenBrowser?: boolean): OcxConfig {
+  return { port: 0, hostname: "127.0.0.1", defaultProvider: "xai", providers: {}, ...(oauthOpenBrowser === undefined ? {} : { oauthOpenBrowser }) } as OcxConfig;
+}
+
+describe("shouldOpenBrowserForLogin", () => {
+  test("an unconfigured install still opens the browser", () => {
+    expect(shouldOpenBrowserForLogin(undefined, config())).toBe(true);
+  });
+
+  test("the persisted setting decides when the request says nothing", () => {
+    expect(shouldOpenBrowserForLogin(undefined, config(true))).toBe(true);
+    expect(shouldOpenBrowserForLogin(undefined, config(false))).toBe(false);
+  });
+
+  test("a per-request choice beats the persisted setting, both ways", () => {
+    expect(shouldOpenBrowserForLogin(false, config(true))).toBe(false);
+    expect(shouldOpenBrowserForLogin(true, config(false))).toBe(true);
+  });
+
+  test("a malformed request field is ignored rather than failing the login", () => {
+    // This is a display preference. Rejecting the request over it would turn a
+    // typo in one client into a login that cannot start at all.
+    expect(shouldOpenBrowserForLogin("nope", config())).toBe(true);
+    expect(shouldOpenBrowserForLogin(0, config())).toBe(true);
+    expect(shouldOpenBrowserForLogin(null, config(false))).toBe(false);
+  });
+});
+
+async function startLogin(
+  body: Record<string, unknown>,
+  cfg: OcxConfig,
+): Promise<{ opened: string[]; url?: string }> {
+  const oauth = await import("../src/oauth");
+  const openUrlMod = await import("../src/lib/open-url");
+  const opened: string[] = [];
+  const startSpy = spyOn(oauth, "startLoginFlow").mockResolvedValue({ url: "https://accounts.x.ai/oauth/authorize?code_challenge=x" });
+  const openSpy = spyOn(openUrlMod, "openUrl").mockImplementation((url: string) => { opened.push(url); });
+  try {
+    const req = new Request("http://127.0.0.1/api/oauth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ provider: "xai", ...body }),
+    });
+    const response = await handleOauthAccountRoutes({
+      req,
+      url: new URL(req.url),
+      config: cfg,
+      deps: {},
+      convergeCodexCatalog: async () => ({ status: "failed", reason: "disk" }),
+      syncClaudeAgentDefsBestEffort: async () => {},
+    });
+    const json = await response!.json() as { url?: string };
+    return { opened, url: json.url };
+  } finally {
+    startSpy.mockRestore();
+    openSpy.mockRestore();
+  }
+}
+
+describe("POST /api/oauth/login honors the choice", () => {
+  test("opens by default, and the URL is returned either way", async () => {
+    const { opened, url } = await startLogin({}, config());
+    expect(opened).toEqual(["https://accounts.x.ai/oauth/authorize?code_challenge=x"]);
+    expect(url).toBe("https://accounts.x.ai/oauth/authorize?code_challenge=x");
+  });
+
+  test("declining spawns nothing but still hands back the link to copy", async () => {
+    const { opened, url } = await startLogin({ openBrowser: false }, config());
+    expect(opened).toEqual([]);
+    // Declining must never mean losing the way in.
+    expect(url).toBe("https://accounts.x.ai/oauth/authorize?code_challenge=x");
+  });
+
+  test("the persisted setting applies with no request field", async () => {
+    const { opened } = await startLogin({}, config(false));
+    expect(opened).toEqual([]);
+  });
+
+  test("a request opt-in overrides a persisted opt-out", async () => {
+    const { opened } = await startLogin({ openBrowser: true }, config(false));
+    expect(opened).toEqual(["https://accounts.x.ai/oauth/authorize?code_challenge=x"]);
+  });
+});
+
+describe("the rollback path keeps the setting honest", () => {
+  test("a failed save restores the previous value instead of leaving it half-applied", async () => {
+    const { handleManagementAPI } = await import("../src/server/management-api");
+    const cfg = { port: 10100, defaultProvider: "openai", providers: {} } as OcxConfig;
+    const req = new Request("http://127.0.0.1:10100/api/settings", {
+      method: "PUT",
+      headers: { "content-type": "application/json", host: "127.0.0.1:10100" },
+      body: JSON.stringify({ oauthOpenBrowser: false }),
+    });
+    // The live config object is shared by reference with the request handlers, so a
+    // write that fails to reach disk must not leave the process disagreeing with the file.
+    await handleManagementAPI(req, new URL(req.url), cfg, {
+      saveConfigPreservingClaudeCode: () => { throw new Error("disk full"); },
+    }).catch(() => {});
+    expect(Object.hasOwn(cfg, "oauthOpenBrowser")).toBe(false);
+  });
+});

--- a/tests/settings-oauth-open-browser.test.ts
+++ b/tests/settings-oauth-open-browser.test.ts
@@ -1,0 +1,104 @@
+/**
+ * `/api/settings` round-trip for the browser-open choice.
+ *
+ * The toggle is only useful if it survives a save and a reload, so this covers
+ * the whole path the GUI actually uses: GET reports it, PUT persists it to
+ * config.json, and a fresh `loadConfig()` reads it back.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadConfig, saveConfig } from "../src/config";
+import { handleManagementAPI, type ManagementApiDeps } from "../src/server/management-api";
+import { invalidateStartupHealthCache } from "../src/server/startup-health-cache";
+import type { OcxConfig } from "../src/types";
+import { startupHealthFixture } from "./helpers/startup-health";
+
+let TEST_DIR = "";
+const previousHome = process.env.OPENCODEX_HOME;
+const readTestStartupHealth: NonNullable<ManagementApiDeps["getCachedStartupHealth"]> = async () => (
+  startupHealthFixture()
+);
+
+function baseConfig(): OcxConfig {
+  return {
+    port: 10100,
+    defaultProvider: "openai",
+    providers: {
+      openai: { adapter: "openai-chat", baseUrl: "https://api.example.test/v1", apiKey: "sk-x", defaultModel: "gpt-test" },
+    },
+  };
+}
+
+function settingsRequest(config: OcxConfig, body?: unknown): Promise<Response | null> {
+  const req = body === undefined
+    ? new Request("http://127.0.0.1:10100/api/settings", { headers: { host: "127.0.0.1:10100" } })
+    : new Request("http://127.0.0.1:10100/api/settings", {
+      method: "PUT",
+      headers: { "content-type": "application/json", host: "127.0.0.1:10100" },
+      body: JSON.stringify(body),
+    });
+  return handleManagementAPI(req, new URL(req.url), config, { getCachedStartupHealth: readTestStartupHealth });
+}
+
+beforeEach(() => {
+  invalidateStartupHealthCache();
+  TEST_DIR = mkdtempSync(join(tmpdir(), "ocx-settings-openbrowser-"));
+  process.env.OPENCODEX_HOME = TEST_DIR;
+});
+
+afterEach(() => {
+  invalidateStartupHealthCache();
+  if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = previousHome;
+  if (TEST_DIR && existsSync(TEST_DIR)) {
+    try { rmSync(TEST_DIR, { recursive: true, force: true }); } catch { /* Windows handle retention */ }
+  }
+});
+
+describe("/api/settings oauthOpenBrowser", () => {
+  test("an unconfigured install reports the historical auto-open", async () => {
+    const res = await settingsRequest(baseConfig());
+    const body = await res!.json() as { oauthOpenBrowser?: boolean };
+    expect(body.oauthOpenBrowser).toBe(true);
+  });
+
+  test("declining persists to disk and survives a reload", async () => {
+    const config = baseConfig();
+    saveConfig(config);
+    const put = await settingsRequest(config, { oauthOpenBrowser: false });
+    expect(put!.status).toBe(200);
+    expect(await put!.json()).toMatchObject({ ok: true, oauthOpenBrowser: false });
+    // The live object and the file must agree, or a restart silently re-enables it.
+    expect(config.oauthOpenBrowser).toBe(false);
+    expect(loadConfig().oauthOpenBrowser).toBe(false);
+
+    const get = await settingsRequest(config);
+    expect(await get!.json()).toMatchObject({ oauthOpenBrowser: false });
+  });
+
+  test("it can be set on its own, without resending the other settings", async () => {
+    const config = baseConfig();
+    saveConfig(config);
+    const res = await settingsRequest(config, { oauthOpenBrowser: false });
+    expect(res!.status).toBe(200);
+    // Unrelated settings keep their defaults rather than being cleared by a partial PUT.
+    expect(await res!.json()).toMatchObject({ streamMode: "auto", codexAutoStart: true });
+  });
+
+  test("a non-boolean is rejected instead of being coerced", async () => {
+    const res = await settingsRequest(baseConfig(), { oauthOpenBrowser: "no" });
+    expect(res!.status).toBe(400);
+    expect(await res!.json()).toMatchObject({ error: "oauthOpenBrowser boolean is required" });
+  });
+
+  test("turning it back on is also persisted", async () => {
+    const config = baseConfig();
+    config.oauthOpenBrowser = false;
+    saveConfig(config);
+    const res = await settingsRequest(config, { oauthOpenBrowser: true });
+    expect(res!.status).toBe(200);
+    expect(loadConfig().oauthOpenBrowser).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The operator can now decline having the proxy open a browser on its own machine. That is the only way to finish an OAuth login in a **non-default Chrome profile**, or from a machine that is not the one running the proxy.

Both login routes used to call `openUrl` unconditionally, which resolves the OS default browser and therefore the default profile. There was no way to say no: no request field, no config key, no environment variable. With the dashboard open against a remote host, the browser opened on the *proxy host* — and `open-url.ts` swallows spawn errors, so nothing reported it.

- `oauthOpenBrowser?: boolean` on `OcxConfig`, following the `codexAutoStart` / `emptyCompletionRetry` pattern: schema entry with `.catch(undefined)` so a hand-edit cannot wipe the file, a write-time validator, and a full `GET`/`PUT /api/settings` round-trip including the rollback block.
- One shared `shouldOpenBrowserForLogin` in `src/oauth/open-browser-choice.ts`, used by `/api/oauth/login` and `/api/codex-auth/login` so the two surfaces cannot drift. Both already import from `src/oauth/`, so no new edge enters the import graph and nothing touches `src/lab`.
- A checkbox beside the **login button** — not in the waiting state, where `openUrl` has already run and a toggle would be advice rather than a control.

### Default behavior is unchanged, and that is the load-bearing assertion

Absent and `true` both mean "open". Only an explicit `false` declines. An install that configures nothing behaves exactly as before, and `tests/oauth-open-browser-choice.test.ts` leads with that case.

### Two details worth reviewing

**The stored client preference is tri-state on purpose.** `undefined` means "no preference", and the request then omits `openBrowser` entirely. A GUI that always sent a boolean would make a persisted `oauthOpenBrowser: false` dead on arrival, because the request always wins — the config file could never be obeyed. The checkbox reads the server value as a fetched resource while no local preference exists, so the two layers agree on screen.

**No environment sniffing.** No `SSH_CONNECTION`, no missing-`DISPLAY` heuristic. A false positive there silently skips a login that works today — X11 forwarding, WSLg, and a macOS session driven over SSH all look headless and are not. An explicit choice cannot be wrong that way.

### What declining does and does not buy

- **A different browser profile on the same machine** works with the copied link alone: the loopback callback on `127.0.0.1` still completes the flow.
- **A browser on a different machine** also needs the paste fallback, because `redirect_uri` is still `http://127.0.0.1:<port>/callback` on the proxy host. That fallback is on every login surface as of #2530.

Nothing about completion depends on `openUrl` having run: the loopback listener is bound by `startLoginFlow`, and `/api/oauth/login/code` already exists. This change only ever makes `openUrl` fire **less**.

Closes #2535

## Verification

```
bun run typecheck                       # exit 0
cd gui && bun x tsc -b && bun run lint   # exit 0, exit 0
cd gui && bun run doctor                 # No issues found
bun run test                             # 14676 pass, 0 fail
bun run privacy:scan                     # Privacy scan passed
```

Full `prepush` (typecheck + gui lint + full suite + privacy scan + react-doctor) ran green on this exact head.

- `tests/oauth-open-browser-choice.test.ts` — the resolution matrix (including a malformed request field being ignored rather than failing a login), both route directions, and a rollback assertion proving a failed save does not leave the live config disagreeing with the file.
- `tests/settings-oauth-open-browser.test.ts` — the `/api/settings` round-trip through `loadConfig()`, a partial PUT, and a rejected non-boolean.

### Screenshot

The choice sits on the control that starts a login, so the request carries it. Unchecked (top) is the unchanged default. Checked (bottom) spawns nothing on the proxy machine and leaves the authorization URL on screen to copy into whichever browser profile — or machine — the operator actually wants.

![The browser-open checkbox beside the login button, and the declined state showing a copyable authorization URL instead](https://raw.githubusercontent.com/lidge-jun/opencodex/codex/pr-assets/docs/assets/oauth-open-browser-toggle-260825.png)

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (`devlog/_plan/260825_oauth_login_ux/030`.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. This only reduces process spawning: no provider-supplied URL becomes newly openable, the `^https?://` guard and the device-flow `!deviceCode` guard are untouched, and the management admission path is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option during OAuth login to prevent the proxy machine from opening a browser.
  * Added a saved OAuth browser-opening preference in settings.
  * Added per-login control that can override the saved preference.
  * Added localized labels and guidance across supported languages.

* **Bug Fixes**
  * Authorization URLs remain available when automatic browser opening is disabled.
  * Invalid preference values are safely ignored, preserving login behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
