### PR TITLE
fix(codex): serve the last catalog reading while the Windows probe refreshes

### DIFF
--- a/src/codex/app-server-processes.ts
+++ b/src/codex/app-server-processes.ts
@@ -750,6 +750,11 @@ const CATALOG_STATE_UNKNOWN_TTL_MS = 250;
  * previous reading immediately keeps that cost off the turn without pretending it is
  * fresh -- the refresh it triggers is what makes the next reading current.
  *
+ * Measured from expiry rather than from when the reading was taken, so a `fresh`
+ * entry stays servable for its own TTL plus this bound. Anchoring it to expiry keeps
+ * the stale window independent of the TTL -- a cap on total age would quietly turn
+ * this path off if the TTL were ever raised past it.
+ *
  * Bounded rather than unlimited: if the refresh keeps failing, an observation this
  * old stops being evidence about the machine and it is better to wait for a real one.
  * `unknown` is never served this way -- it is a failure to observe, not an
@@ -895,7 +900,7 @@ export async function collectCodexAppServerCatalogStateForRequest(
   // this entry already says.
   const servableStale = cached
     && cached.status.state !== "unknown"
-    && now - cached.atMs < CATALOG_STATE_MAX_STALE_MS
+    && now - cached.atMs < catalogStateTtlMs(cached.status.state) + CATALOG_STATE_MAX_STALE_MS
     ? cached.status
     : null;
   if (requestCatalogStateFlight

--- a/src/codex/app-server-processes.ts
+++ b/src/codex/app-server-processes.ts
@@ -740,6 +740,23 @@ const CATALOG_STATE_TTL_MS = 5_000;
  */
 const CATALOG_STATE_UNKNOWN_TTL_MS = 250;
 
+/**
+ * How long a real observation may still be SERVED after it expires, while a refresh
+ * runs behind it (#2499).
+ *
+ * The probe is advisory and, on Windows, slow: `Invoke-CimMethod GetOwner` costs
+ * ~0.4s per candidate process, so a cold probe routinely outlives the 5s TTL and
+ * every turn that misses the cache pays for it on the request path. Serving the
+ * previous reading immediately keeps that cost off the turn without pretending it is
+ * fresh -- the refresh it triggers is what makes the next reading current.
+ *
+ * Bounded rather than unlimited: if the refresh keeps failing, an observation this
+ * old stops being evidence about the machine and it is better to wait for a real one.
+ * `unknown` is never served this way -- it is a failure to observe, not an
+ * observation, and it already has its own short window for exactly that reason.
+ */
+export const CATALOG_STATE_MAX_STALE_MS = 60_000;
+
 export function catalogStateTtlMs(state: CodexAppServerCatalogState): number {
   return state === "unknown" ? CATALOG_STATE_UNKNOWN_TTL_MS : CATALOG_STATE_TTL_MS;
 }
@@ -853,16 +870,30 @@ export async function collectCodexAppServerCatalogStateForRequest(
     catalogMtimeMs: io.catalogMtimeMs,
     now: io.now,
   };
-  if (requestCatalogStateCache
+  const cached = requestCatalogStateCache
     && requestCatalogStateCache.generation === generation
     && sameRequestCatalogStateIdentity(requestCatalogStateCache.identity, identity)
-    && now - requestCatalogStateCache.atMs < catalogStateTtlMs(requestCatalogStateCache.status.state)) {
-    return requestCatalogStateCache.status;
+    ? requestCatalogStateCache
+    : null;
+  if (cached && now - cached.atMs < catalogStateTtlMs(cached.status.state)) {
+    return cached.status;
   }
+  // An expired real reading is still worth handing back while the refresh runs. It
+  // cannot have been invalidated by an ocx catalog write: every such write calls
+  // `resetCodexAppServerCatalogStateCache`, which advances the generation and drops
+  // this entry, so a generation match means no write has landed since it was taken.
+  // What it can miss is an app-server that started or stopped meanwhile -- and a
+  // server started after the reading is newer than the catalog, which is the `fresh`
+  // this entry already says.
+  const servableStale = cached
+    && cached.status.state !== "unknown"
+    && now - cached.atMs < CATALOG_STATE_MAX_STALE_MS
+    ? cached.status
+    : null;
   if (requestCatalogStateFlight
     && requestCatalogStateFlight.generation === generation
     && sameRequestCatalogStateIdentity(requestCatalogStateFlight.identity, identity)) {
-    return requestCatalogStateFlight.promise;
+    return servableStale ?? requestCatalogStateFlight.promise;
   }
 
   const refresh = async (): Promise<CodexAppServerCatalogStatus> => {
@@ -934,7 +965,9 @@ export async function collectCodexAppServerCatalogStateForRequest(
   });
   flight = { generation, identity, promise };
   requestCatalogStateFlight = flight;
-  return flight.promise;
+  // `promise` already absorbs its own failures, so leaving it unawaited here cannot
+  // surface as an unhandled rejection; the next caller picks up whatever it stored.
+  return servableStale ?? flight.promise;
 }
 
 /**

--- a/src/codex/app-server-processes.ts
+++ b/src/codex/app-server-processes.ts
@@ -852,6 +852,14 @@ export function collectCodexAppServerCatalogState(
  * - 선택한 방식: retain the synchronous API and use async PowerShell plus an identity-scoped in-flight refresh, short cache, and invalidation generation only for Windows requests.
  * - 다른 대안 대신 이 방식을 선택한 이유: it fixes unrelated `/healthz` starvation without widening the process-matching or restart contract.
  * - 장점, 단점 및 영향: concurrent turns share one CIM walk, invalidated pre-write results cannot repopulate the cache, and the event loop stays responsive; a cold v2 turn can still await the bounded advisory probe.
+ *
+ * [Decision Log · #2499]
+ * - 목적과 의도: a cold probe outlives its own 5s TTL on Windows (~435ms per candidate process for `Invoke-CimMethod GetOwner`), so the cache expires before it can serve and the miss lands on a turn.
+ * - 기존 구현 및 제약 조건: the reading is advisory, and only `fresh` authorizes positive guidance (`src/server/responses/collaboration.ts`); `unknown` is a failure to observe rather than an observation.
+ * - 검토한 주요 대안: drop the per-process GetOwner fan-out (issue suggestion 1), or widen the TTL past the probe duration (suggestion 3).
+ * - 선택한 방식: serve an expired reading immediately when its generation still matches, bounded by `CATALOG_STATE_MAX_STALE_MS`, never for `unknown`, and refresh behind it; a failed refresh no longer evicts the reading it was refreshing.
+ * - 다른 대안 대신 이 방식을 선택한 이유: the fan-out change alters what "could not verify the owner" means for the current-user scoping contract and needs its own ground-truth comparison; a wider TTL still pays the probe on every human-paced turn.
+ * - 장점, 단점 및 영향: after the first probe the request path never waits; a server that stopped between readings can be described as `fresh` for up to the stale bound; a catalog write still invalidates immediately through the generation, and the cold path is unchanged.
  */
 export async function collectCodexAppServerCatalogStateForRequest(
   io: CodexAppServerProcessIo = {},
@@ -951,7 +959,18 @@ export async function collectCodexAppServerCatalogStateForRequest(
     if (requestCatalogStateGeneration !== generation) {
       return { state: "unknown" as const, processes: [], catalogMtimeMs: null };
     }
-    if (requestCatalogStateFlight === flight) {
+    // A refresh that failed must not evict a real reading. Before this function
+    // served stale entries, caching `unknown` cost at most the 250ms that state
+    // is allowed to live. Now that an expired observation is what callers are
+    // handed, overwriting one with `unknown` would take the answer AWAY from
+    // them on a transient failure -- `unknown` is not servable, so the next
+    // caller waits for a probe instead of getting the reading it would have had.
+    // Keep the observation and let its own age retire it.
+    const wouldEvictAnObservation = status.state === "unknown"
+      && requestCatalogStateCache?.generation === generation
+      && requestCatalogStateCache.status.state !== "unknown"
+      && sameRequestCatalogStateIdentity(requestCatalogStateCache.identity, identity);
+    if (requestCatalogStateFlight === flight && !wouldEvictAnObservation) {
       requestCatalogStateCache = {
         generation,
         identity,

--- a/tests/codex-app-server-processes.test.ts
+++ b/tests/codex-app-server-processes.test.ts
@@ -1187,8 +1187,16 @@ describe("request-path catalog state serves stale while revalidating (#2499)", (
     releases[0]([...APP_SERVER]);
     await expect(cold).resolves.toMatchObject({ state: "fresh" });
 
-    // Past the point where the reading stops being evidence about the machine.
-    clock.ms += CATALOG_STATE_MAX_STALE_MS;
+    // One tick inside the bound, which runs from expiry rather than from when the
+    // reading was taken: still served, still without waiting.
+    clock.ms += catalogStateTtlMs("fresh") + CATALOG_STATE_MAX_STALE_MS - 1;
+    const last = collectCodexAppServerCatalogStateForRequest(io);
+    expect(await settledWithoutTheProbe(last)).toMatchObject({ state: "fresh" });
+
+    // One tick past it, where the reading stops being evidence about the machine.
+    // That call joins the refresh the previous one started rather than waiting on a
+    // second enumeration, so releasing that one probe is what settles it.
+    clock.ms += 1;
     const tooOld = collectCodexAppServerCatalogStateForRequest(io);
     expect(await settledWithoutTheProbe(tooOld)).toBe("waited");
     releases[1]([...APP_SERVER]);

--- a/tests/codex-app-server-processes.test.ts
+++ b/tests/codex-app-server-processes.test.ts
@@ -1092,6 +1092,20 @@ describe("request-path catalog state serves stale while revalidating (#2499)", (
     return { io, releases, enumerations: () => releases.length };
   }
 
+  /**
+   * Yield until the released refresh has stored its result, or give up loudly.
+   *
+   * A fixed sleep would be a bet on how many turns the refresh's continuation
+   * needs, and losing that bet on a slow runner looks like a product bug rather
+   * than a slow machine. This waits for the condition instead of for a duration.
+   */
+  async function drainUntil(predicate: () => boolean, what: string) {
+    for (let attempt = 0; attempt < 1_000; attempt += 1) {
+      if (predicate()) return;
+      await new Promise(resolve => setTimeout(resolve, 0));
+    }
+    throw new Error(`timed out waiting for ${what}`);
+  }
   /** Did *promise* settle without the pending probe being released? */
   async function settledWithoutTheProbe<T>(promise: Promise<T> | T): Promise<T | "waited"> {
     return Promise.race([
@@ -1147,8 +1161,17 @@ describe("request-path catalog state serves stale while revalidating (#2499)", (
     expect(await settledWithoutTheProbe(served)).toMatchObject({ state: "fresh" });
 
     // The background refresh finds the machine empty now.
+    let refreshed = false;
+    served.then(() => {}).catch(() => {});
     releases[1]([]);
-    await new Promise(resolve => setTimeout(resolve, 5));
+    // The refresh has landed once a read at the same instant reports the new
+    // state; before that it still answers from the entry it is replacing.
+    await drainUntil(() => {
+      void collectCodexAppServerCatalogStateForRequest(io).then(seen => {
+        if (seen.state === "not_running") refreshed = true;
+      });
+      return refreshed;
+    }, "the background refresh to store not_running");
 
     // Served from the refreshed entry, still without waiting.
     clock.ms += 1;
@@ -1170,6 +1193,43 @@ describe("request-path catalog state serves stale while revalidating (#2499)", (
     expect(await settledWithoutTheProbe(tooOld)).toBe("waited");
     releases[1]([...APP_SERVER]);
     await expect(tooOld).resolves.toMatchObject({ state: "fresh" });
+  });
+
+  test("a failed refresh does not evict the reading it was refreshing", async () => {
+    const clock = { ms: 5_000_000 };
+    const releases: Array<(snapshots: Array<{ pid: number; commandLine: string }>) => void> = [];
+    const rejects: Array<(reason: Error) => void> = [];
+    const io = {
+      platform: "win32" as const,
+      now: () => clock.ms,
+      listSnapshotsAsync: () =>
+        new Promise<Array<{ pid: number; commandLine: string }>>((resolve, reject) => {
+          releases.push(resolve);
+          rejects.push(reject);
+        }),
+      readStartMsBatchAsync: async (pids: number[]) => new Map(pids.map(pid => [pid, 2_000] as const)),
+      catalogMtimeMs: () => 1_000,
+    };
+
+    const cold = collectCodexAppServerCatalogStateForRequest(io);
+    releases[0]([{ pid: 42, commandLine: APP_SERVER_COMMAND_LINE }]);
+    await expect(cold).resolves.toMatchObject({ state: "fresh" });
+
+    // Expire it, take the stale answer, and let the refresh it started fail.
+    clock.ms += catalogStateTtlMs("fresh") + 1;
+    const served = collectCodexAppServerCatalogStateForRequest(io);
+    expect(await settledWithoutTheProbe(served)).toMatchObject({ state: "fresh" });
+    rejects[1](new Error("windows_enum_incomplete"));
+    await drainUntil(() => rejects.length === 2, "the failing refresh to be started");
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    // The transient failure must not have replaced the observation. Caching
+    // `unknown` over it would take the answer away from the next caller: `unknown`
+    // is not servable, so that caller would wait for a probe instead of being
+    // handed the reading it would otherwise have had.
+    clock.ms += 1;
+    const after = collectCodexAppServerCatalogStateForRequest(io);
+    expect(await settledWithoutTheProbe(after)).toMatchObject({ state: "fresh" });
   });
 
   test("`unknown` is never served stale -- a failure to observe is not an observation", async () => {

--- a/tests/codex-app-server-processes.test.ts
+++ b/tests/codex-app-server-processes.test.ts
@@ -7,6 +7,7 @@ import { setTrustedWindowsElevationExecutablesForTests } from "../src/lib/window
 import {
   afterCatalogWriteHandleAppServers,
   attachStaleAppServerHint,
+  CATALOG_STATE_MAX_STALE_MS,
   catalogStateTtlMs,
   collectCodexAppServerCatalogState,
   collectCodexAppServerCatalogStateForRequest,
@@ -1061,5 +1062,142 @@ describe("platform termination ladder", () => {
 
     expect(execCalls).toEqual([]);
     expect(signals).toEqual([{ pid: 4242, signal: "SIGTERM" }]);
+  });
+});
+
+describe("request-path catalog state serves stale while revalidating (#2499)", () => {
+  // The suite's other command-line fixture is scoped to its own describe block.
+  const APP_SERVER_COMMAND_LINE = "/usr/local/bin/codex app-server";
+  const APP_SERVER = [{ pid: 42, commandLine: APP_SERVER_COMMAND_LINE }];
+
+  /**
+   * A probe that never settles on its own. Every test here needs to observe what a
+   * caller gets back WHILE an enumeration is still running, which is the whole point:
+   * on Windows this probe costs ~0.4s per candidate process and routinely outlives
+   * the 5s TTL, so before this change one turn per window paid for it on the request
+   * path.
+   */
+  function makeIo(clock: { ms: number }) {
+    const releases: Array<(snapshots: Array<{ pid: number; commandLine: string }>) => void> = [];
+    const io = {
+      platform: "win32" as const,
+      now: () => clock.ms,
+      listSnapshotsAsync: () =>
+        new Promise<Array<{ pid: number; commandLine: string }>>(resolve => {
+          releases.push(resolve);
+        }),
+      readStartMsBatchAsync: async (pids: number[]) => new Map(pids.map(pid => [pid, 2_000] as const)),
+      catalogMtimeMs: () => 1_000,
+    };
+    return { io, releases, enumerations: () => releases.length };
+  }
+
+  /** Did *promise* settle without the pending probe being released? */
+  async function settledWithoutTheProbe<T>(promise: Promise<T> | T): Promise<T | "waited"> {
+    return Promise.race([
+      Promise.resolve(promise),
+      new Promise<"waited">(resolve => setTimeout(() => resolve("waited"), 25)),
+    ]);
+  }
+
+  beforeEach(() => {
+    resetCodexAppServerCatalogStateCache();
+  });
+
+  test("the first turn waits, later turns do not, and N turns cost one enumeration", async () => {
+    const clock = { ms: 1_000_000 };
+    const { io, releases, enumerations } = makeIo(clock);
+
+    // Cold: nothing cached, so this one has to wait for the probe.
+    const cold = collectCodexAppServerCatalogStateForRequest(io);
+    expect(await settledWithoutTheProbe(cold)).toBe("waited");
+    releases[0]([...APP_SERVER]);
+    await expect(cold).resolves.toMatchObject({ state: "fresh" });
+    expect(enumerations()).toBe(1);
+
+    // Past the TTL. The reading is expired, and the refresh it triggers is still
+    // running -- the caller must get the previous reading now, not wait for it.
+    clock.ms += catalogStateTtlMs("fresh") + 1;
+    const warm = collectCodexAppServerCatalogStateForRequest(io);
+    expect(await settledWithoutTheProbe(warm)).toMatchObject({ state: "fresh" });
+    expect(enumerations()).toBe(2);
+
+    // Three more turns while that refresh is still in flight: still served, and the
+    // in-flight dedup means none of them starts another enumeration.
+    for (let turn = 0; turn < 3; turn += 1) {
+      clock.ms += 10;
+      const next = collectCodexAppServerCatalogStateForRequest(io);
+      expect(await settledWithoutTheProbe(next)).toMatchObject({ state: "fresh" });
+    }
+    expect(enumerations()).toBe(2);
+  });
+
+  test("the refresh it triggers is what makes the next reading current", async () => {
+    const clock = { ms: 2_000_000 };
+    const { io, releases } = makeIo(clock);
+
+    const cold = collectCodexAppServerCatalogStateForRequest(io);
+    releases[0]([...APP_SERVER]);
+    await expect(cold).resolves.toMatchObject({ state: "fresh" });
+
+    clock.ms += catalogStateTtlMs("fresh") + 1;
+    // Served from the expired entry, and the refresh that call started is what the
+    // rest of this test is about.
+    const served = collectCodexAppServerCatalogStateForRequest(io);
+    expect(await settledWithoutTheProbe(served)).toMatchObject({ state: "fresh" });
+
+    // The background refresh finds the machine empty now.
+    releases[1]([]);
+    await new Promise(resolve => setTimeout(resolve, 5));
+
+    // Served from the refreshed entry, still without waiting.
+    clock.ms += 1;
+    const after = collectCodexAppServerCatalogStateForRequest(io);
+    expect(await settledWithoutTheProbe(after)).toMatchObject({ state: "not_running" });
+  });
+
+  test("a reading older than the bound is not served -- the caller waits for a real one", async () => {
+    const clock = { ms: 3_000_000 };
+    const { io, releases } = makeIo(clock);
+
+    const cold = collectCodexAppServerCatalogStateForRequest(io);
+    releases[0]([...APP_SERVER]);
+    await expect(cold).resolves.toMatchObject({ state: "fresh" });
+
+    // Past the point where the reading stops being evidence about the machine.
+    clock.ms += CATALOG_STATE_MAX_STALE_MS;
+    const tooOld = collectCodexAppServerCatalogStateForRequest(io);
+    expect(await settledWithoutTheProbe(tooOld)).toBe("waited");
+    releases[1]([...APP_SERVER]);
+    await expect(tooOld).resolves.toMatchObject({ state: "fresh" });
+  });
+
+  test("`unknown` is never served stale -- a failure to observe is not an observation", async () => {
+    const clock = { ms: 4_000_000 };
+    const releases: Array<(value: never[]) => void> = [];
+    const rejects: Array<(reason: Error) => void> = [];
+    const io = {
+      platform: "win32" as const,
+      now: () => clock.ms,
+      listSnapshotsAsync: () =>
+        new Promise<never[]>((resolve, reject) => {
+          releases.push(resolve);
+          rejects.push(reject);
+        }),
+      readStartMsBatchAsync: async (pids: number[]) => new Map(pids.map(pid => [pid, 2_000] as const)),
+      catalogMtimeMs: () => 1_000,
+    };
+
+    const cold = collectCodexAppServerCatalogStateForRequest(io);
+    rejects[0](new Error("windows_enum_incomplete"));
+    await expect(cold).resolves.toMatchObject({ state: "unknown" });
+
+    // Its own short window has passed. Handing `unknown` back again would keep
+    // guidance suppressed on the strength of a reading that never observed anything.
+    clock.ms += catalogStateTtlMs("unknown") + 1;
+    const next = collectCodexAppServerCatalogStateForRequest(io);
+    expect(await settledWithoutTheProbe(next)).toBe("waited");
+    releases[1]([]);
+    await expect(next).resolves.toMatchObject({ state: "not_running" });
   });
 });


### PR DESCRIPTION
Refs #2499. Takes suggestion **2** from that issue — serve stale while revalidating — and leaves suggestion 1 alone; reasoning for that split at the bottom.

## The shape of it

`collectCodexAppServerCatalogStateForRequest` awaits a probe whose cost can exceed its own TTL. `CATALOG_STATE_TTL_MS` is 5s; the Windows probe pays `Invoke-CimMethod GetOwner` once per candidate process. When the probe is slower than the window it populates, the window expires before it can serve much, and the miss lands on a turn.

**I could not reproduce the reporter's 7.5s end to end** — this box has 2 Codex candidates, so the whole enumeration is ~1.39s. What I could reproduce is the per-call cost that produces their number. Windows 11 26200, 371 processes with a readable command line, `powershell.exe` from System32, 3 runs each:

| step | cost |
|---|---|
| PowerShell startup (`-NoProfile -Command exit`) | 152 / 152 / 166 ms |
| `Get-CimInstance Win32_Process` + the command-line filter | 497 / 549 / 556 ms |
| the full `windowsSnapshotPowerShellCommand()`, 2 candidates | 1350 / 1387 / 1426 ms |

The remainder is 2 × `GetOwner` ≈ 870 ms, so **~435 ms per candidate**. The issue reports 43887 ms for 93 processes — 472 ms per call. Same cost, different candidate count, which is why one machine sees 1.4s and another 7.5s.

## What changed

`servableStale`: when the cached entry is expired but its **generation still matches**, hand it back immediately and let the refresh it just started run behind it.

The generation is what makes that safe, and it is worth being precise about. Every ocx catalog write calls `resetCodexAppServerCatalogStateCache()` (`app-server-restart-service.ts:114`), which advances `requestCatalogStateGeneration` **and nulls the cache**. So a generation match is a proof that no catalog write has landed since the reading was taken — the exact invalidation the existing in-flight guard already treats as decisive when it degrades a pre-write result to `unknown`.

What an expired reading can still miss is a server that started or stopped meanwhile. A server that started *after* the reading is newer than the catalog, which is the `fresh` the entry already reports. That leaves a stopped server, and `fresh` for a machine with one fewer app-server is not a claim that misleads guidance.

Two bounds, both deliberate:

- **`unknown` is never served this way.** It is a failure to observe, not an observation. It already has a 250 ms window for precisely that reason, and re-serving it would keep guidance suppressed on the strength of a reading that never saw anything.
- **60s ceiling.** If the refresh keeps failing, a reading that old stops being evidence about the machine, and waiting for a real one beats answering fast and wrong.

The cold path is unchanged: with nothing cached, the first turn still waits for the probe.

## Tests

Four, in `tests/codex-app-server-processes.test.ts`, all with a controllable clock and a probe that never settles on its own — no real timers, no platform dependency.

| test | what it pins |
|---|---|
| the first turn waits, later turns do not, and N turns cost one enumeration | the reporter's item 4, verbatim |
| the refresh it triggers is what makes the next reading current | the stale answer is not a dead end |
| a reading older than the bound is not served | the 60s ceiling |
| `unknown` is never served stale | the exclusion |

Mutation-checked. Each mutation was verified to have actually applied (occurrence counts) before the run:

| mutation | caught by |
|---|---|
| drop `servableStale ??` from both returns (2 → 0 occurrences) | tests 1 and 2 |
| drop `state !== "unknown"` | test 4 |
| drop the `CATALOG_STATE_MAX_STALE_MS` bound | test 3 |

Tests 3 and 4 do not detect the first mutation, and that is correct — they assert the cases where the value is *not* served, which reverting to always-await also satisfies. Saying so rather than implying all four guard everything.

## Local results

`bun test tests/codex-app-server-processes.test.ts`:

| tree | result |
|---|---|
| `origin/dev` @ `3e3a028fe`, no changes | 47 tests, **46 pass / 1 fail** |
| this branch | 51 tests, **50 pass / 1 fail** |

+4 passing, and the same single failure: `warnIfStaleCodexAppServersAfterStartupWrite (#1046) > a defaulted read is memoized, and invalidation is what clears it`. It is pre-existing on `dev` on this machine — I measured it on a clean tree before and after, and I flagged the same test in #2485. Since this diff touches the caching in that very module I re-baselined it rather than citing the old measurement.

Widened to the neighbouring files (`codex-app-server-path-spaces`, `api-catalog-route`, `cli-catalog-prewarm`): **58 pass / 1 fail**, same one.

`bun x tsc --noEmit`: exit 0.

One thing worth admitting: my first version of these tests never ran at all. I appended the block at file scope and reused `APP_SERVER_CMD`, which is declared inside another `describe`; the suite reported the same 46/47 as the baseline and a quiet `ReferenceError` between tests. The pass count not moving is what caught it.

## Why not suggestion 1 in this PR

Dropping the per-process `GetOwner` fan-out is the bigger win and I did prototype it — `Win32_SessionProcess` joined to `Win32_LoggedOnUser` maps every PID to an owner in ~460 ms total on this box, against ~435 ms *per candidate* today.

I am not shipping it here. `GetOwner` returning `ReturnValue=2` on a process is currently what makes the enumeration report `__OCX_ENUM_INCOMPLETE__`, and the association path answers a subtly different question — it is missing rows rather than denied, and `Win32_Process.CommandLine` is itself only readable for processes you own, so the two disagree about what "could not verify the owner" means. Getting that wrong loosens a current-user scoping contract that the restart path depends on. It deserves its own PR with its own ground-truth comparison, not a rider on a latency fix.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows catalog-state loading by returning recently cached results while updates refresh in the background.
  * Prevented unnecessary blocking when valid cached information is available.
  * Limited stale results to a maximum of 60 seconds.
  * Preserved valid cached information when a refresh fails.
  * Ensured outdated or unknown catalog states are refreshed appropriately.
  * Prevented multiple simultaneous refresh requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



