### PR TITLE
fix(release): run the preflight suite in the same groups CI does

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -519,7 +519,40 @@ await runLoud(["bun", "run", "audit:high"]);
 console.log("→ typecheck");
 await runLoud(["bun", "x", "tsc", "--noEmit"]);
 console.log("→ test suite");
-await runLoud(["bun", "test", "--isolate", "tests"]);
+// Match CI's isolation policy instead of inventing a second one. `ci.yml` runs
+// the storage-policy and api-usage harnesses in DEDICATED jobs and excludes them
+// from the general shards (`scripts/ci/run-bun-test-batches.sh`
+// `is_general_test_file`), because those Worker-heavy files corrupt the isolate
+// state around them.
+//
+// This preflight used to run `bun test --isolate tests` — the whole directory in
+// one process — so it exercised a grouping CI never runs. The result was a
+// release gate that failed on `api-usage` while every CI job for the same commit
+// was green: the worst kind of gate, one that blocks a good release and teaches
+// you to distrust it. Same files and same coverage as before (915), now in the
+// same groups CI uses.
+// Every command here stays a `bun` invocation. The release-helper suite shims
+// exactly `bun`, `gh`, `git` and `npm` onto a scratch PATH to record calls
+// without executing them; a `bash` step would miss that shim, escape into the
+// real suite, and fail the helper tests with exit 127.
+const ISOLATED_TEST_FILES = [
+  "./tests/api-storage-policy-already-running.test.ts",
+  "./tests/api-storage-policy-mutation-busy.test.ts",
+  "./tests/api-storage-policy-put-race.test.ts",
+  "./tests/api-storage-policy-run.test.ts",
+  "./tests/api-storage-policy.test.ts",
+  "./tests/api-storage.test.ts",
+  "./tests/api-usage.test.ts",
+];
+await runLoud([
+  "bun", "test", "--isolate", "tests",
+  "--path-ignore-patterns=**/api-storage-policy*.test.ts",
+  "--path-ignore-patterns=**/api-storage.test.ts",
+  "--path-ignore-patterns=**/api-usage.test.ts",
+]);
+for (const isolated of ISOLATED_TEST_FILES) {
+  await runLoud(["bun", "test", "--isolate", isolated]);
+}
 console.log("→ privacy scan");
 await runLoud(["bun", "run", "privacy:scan"]);
 

--- a/tests/release-helper.test.ts
+++ b/tests/release-helper.test.ts
@@ -324,7 +324,21 @@ describe("release helper", () => {
 
     const auditIndex = findCallIndex(calls, "bun", call => call.args.join(" ") === "run audit:high");
     const typecheckIndex = findCallIndex(calls, "bun", call => call.args.join(" ") === "x tsc --noEmit");
-    const testIndex = findCallIndex(calls, "bun", call => call.args.join(" ") === "test --isolate tests");
+    // The suite runs in CI's two groups, not as one directory sweep: the general
+    // files with the Worker-heavy harnesses ignored, then those harnesses one at
+    // a time. Assert the grouping, not just that "a test command ran" — the whole
+    // point of the change is WHICH processes the files land in.
+    const testIndex = findCallIndex(calls, "bun", call =>
+      call.args[0] === "test"
+      && call.args.includes("tests")
+      && call.args.some(arg => arg.startsWith("--path-ignore-patterns=") && arg.includes("api-usage")),
+    );
+    const isolatedUsageIndex = findCallIndex(calls, "bun", call =>
+      call.args.join(" ") === "test --isolate ./tests/api-usage.test.ts",
+    );
+    const isolatedStorageIndex = findCallIndex(calls, "bun", call =>
+      call.args.join(" ") === "test --isolate ./tests/api-storage.test.ts",
+    );
     const privacyIndex = findCallIndex(calls, "bun", call => call.args.join(" ") === "run privacy:scan");
     const versionIndex = findCallIndex(calls, "npm", call => call.args.join(" ") === "version 9.9.9 --no-git-tag-version");
     const dispatchIndex = findCallIndex(calls, "gh", call =>
@@ -338,7 +352,10 @@ describe("release helper", () => {
     expect(auditIndex).toBeGreaterThanOrEqual(0);
     expect(typecheckIndex).toBeGreaterThan(auditIndex);
     expect(testIndex).toBeGreaterThan(typecheckIndex);
-    expect(privacyIndex).toBeGreaterThan(testIndex);
+    // Every excluded harness is still executed, in its own process.
+    expect(isolatedUsageIndex).toBeGreaterThan(testIndex);
+    expect(isolatedStorageIndex).toBeGreaterThan(testIndex);
+    expect(privacyIndex).toBeGreaterThan(isolatedUsageIndex);
     expect(versionIndex).toBeGreaterThan(privacyIndex);
     expect(dispatchIndex).toBeGreaterThan(versionIndex);
   });


### PR DESCRIPTION
## Summary

The release preflight ran a test grouping that CI never runs, so it could fail a commit whose CI was entirely green. It just did: `bun scripts/release.ts 2.33.0-preview.20260825` aborted on

```
(fail) GET /api/usage > usage route does not cache a summary whose overlay version changed mid-read
```

while every CI job for that same commit passed, including the dedicated `api usage` job.

### Cause

`.github/workflows/ci.yml` deliberately keeps the storage-policy and `api-usage` harnesses **out** of the general shards and runs them in dedicated jobs — `scripts/ci/run-bun-test-batches.sh` has an explicit `is_general_test_file` exclusion, and the workflow comment says why: those Worker-heavy files corrupt the isolate state around them.

`scripts/release.ts` did not know that. It ran `bun test --isolate tests` — the whole directory in one process — which is a combination that exists nowhere in CI.

That is the worst kind of gate: one that blocks a good release and teaches you to distrust it. Note the failure is not new and not caused by the release content — it reproduces on the already-shipped `main` (`71c57ea64`, v2.32.1) too.

### Fix

The preflight now mirrors CI's grouping exactly:

```ts
await runLoud(["bun", "test", "--isolate", "tests",
  "--path-ignore-patterns=**/api-storage-policy*.test.ts",
  "--path-ignore-patterns=**/api-storage.test.ts",
  "--path-ignore-patterns=**/api-usage.test.ts",
]);
for (const isolated of ISOLATED_TEST_FILES) {
  await runLoud(["bun", "test", "--isolate", isolated]);
}
```

**Same files, same coverage, same groups.** 915 test files total: 908 in the general sweep plus the 7 excluded harnesses, each in its own process. Nothing is skipped — the previous behavior ran the same 915 in one process.

Every step stays a `bun` invocation on purpose. The release-helper suite shims exactly `bun`, `gh`, `git` and `npm` onto a scratch PATH to record calls without executing them; a `bash` step would miss that shim, escape into the real suite, and fail with exit 127. I tried that first and the tests caught it.

## Verification

```
bun test tests/release-helper.test.ts    # 24 pass, 0 fail
bun x tsc --noEmit                        # exit 0
bun test --isolate tests --path-ignore-patterns=...   # 14647 pass, 11 skip, 1 fail
                                          # 908 files — the fail was the helper
                                          # assertion this PR updates
```

The release-helper test now asserts the **grouping**, not merely that "a test command ran": it requires the general sweep to carry the ignore pattern, and requires each excluded harness to run afterwards in its own process. That is a stronger assertion than the one it replaces.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. This touches release automation, so it warrants that review: it changes only how the local preflight groups test files. It does not weaken the gate — coverage is identical and the isolated harnesses still run — and it does not touch publishing, credentials, the workflow, or the deploy-key path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved release preflight validation to better match CI test isolation.
  * Added dedicated isolated checks for storage-policy and API-usage tests.
  * Ensured privacy scans run after each isolated test process.
  * Updated validation coverage for Worker-heavy test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->