### PR TITLE
fix(gui): allow pinning an active unpinned account

### DIFF
--- a/gui/src/components/codex-account-pool-cards.tsx
+++ b/gui/src/components/codex-account-pool-cards.tsx
@@ -100,7 +100,7 @@ export function CodexAccountPoolCards({
                 </span>
               )}
             </span>
-            {!a.paused && !isNext(a) && !showReauth && !inCooldown && (
+            {!a.paused && (!isNext(a) || pinnedId !== a.id) && !showReauth && !inCooldown && (
               <button type="button" className="btn btn-ghost btn-sm codex-account-switch" onClick={() => onSwitch(a)}>
                 {switchActionLabel}
               </button>

--- a/gui/src/components/codex-account-pool-main-card.tsx
+++ b/gui/src/components/codex-account-pool-main-card.tsx
@@ -105,7 +105,7 @@ export function CodexAccountPoolMainCard({
             </span>
           )}
         </span>
-        {!main?.paused && !isMainActive && !showReauth && !inCooldown && (
+        {!main?.paused && (!isMainActive || pinnedId !== "__main__") && !showReauth && !inCooldown && (
           <button type="button" className="btn btn-ghost btn-sm codex-account-switch" onClick={() => onSwitch(mainSwitchEntry)}>
             {switchActionLabel}
           </button>

--- a/gui/tests/codex-account-pool-pinned-badge.test.tsx
+++ b/gui/tests/codex-account-pool-pinned-badge.test.tsx
@@ -141,12 +141,17 @@ function hasPinnedHint(scope: ParentNode): boolean {
   return [...scope.querySelectorAll(".card-sub")].some((el) => (el.textContent ?? "").trim() === en["codexAuth.pinnedHint"]);
 }
 
+function switchAction(scope: ParentNode): HTMLButtonElement | null {
+  return scope.querySelector<HTMLButtonElement>("button.codex-account-switch");
+}
+
 test("a pinned pool account says so, and only on its own card", async () => {
   await mountPool(makeController({ activeId: "pool-1", activePinnedId: "pool-1" }));
 
   const pooled = cardFor("pool@example.test");
   expect(hasPinnedBadge(pooled)).toBe(true);
   expect(hasPinnedHint(pooled)).toBe(false);
+  expect(switchAction(pooled)).toBeNull();
 
   const main = cardFor("main@example.test");
   expect(hasPinnedBadge(main)).toBe(false);
@@ -159,6 +164,7 @@ test("a pinned app login says so, and only on its own card", async () => {
   const main = cardFor("main@example.test");
   expect(hasPinnedBadge(main)).toBe(true);
   expect(hasPinnedHint(main)).toBe(false);
+  expect(switchAction(main)).toBeNull();
 
   const pooled = cardFor("pool@example.test");
   expect(hasPinnedBadge(pooled)).toBe(false);
@@ -193,6 +199,42 @@ test("an account rotation picked carries no pin", async () => {
   expect(hasPinnedHint(host)).toBe(false);
 });
 
+test("an active unpinned pool account keeps the manual pin action", async () => {
+  await mountPool(makeController({ activeId: "pool-1", activePinnedId: null }));
+
+  const action = switchAction(cardFor("pool@example.test"));
+  expect(action).toBeTruthy();
+  expect(action!.textContent).toContain(en["codexAuth.setAsNext"]);
+
+  await act(async () => { action!.click(); });
+  expect(host.querySelector("dialog")?.textContent).toContain("pool@example.test");
+});
+
+test("an active unpinned app login keeps the manual pin action", async () => {
+  await mountPool(makeController({ activeId: null, activePinnedId: null }));
+
+  const action = switchAction(cardFor("main@example.test"));
+  expect(action).toBeTruthy();
+  expect(action!.textContent).toContain(en["codexAuth.setAsNext"]);
+});
+
+test("an active account that already owns the pin hides the redundant action", async () => {
+  await mountPool(makeController({ activeId: "pool-1", activePinnedId: "pool-1" }));
+
+  expect(switchAction(cardFor("pool@example.test"))).toBeNull();
+});
+
+test("an active account can replace a sibling's pin", async () => {
+  const sibling: CodexAccountEntry = { ...account, id: "pool-2", email: "sibling@example.test" };
+  await mountPool(makeController({
+    accounts: [mainAccount, account, sibling],
+    activeId: "pool-2",
+    activePinnedId: "pool-1",
+  }));
+
+  expect(switchAction(cardFor("sibling@example.test"))).toBeTruthy();
+});
+
 test("a paused account is never shown as pinned", async () => {
   // Pausing releases the pin server-side, so a pin that still names an excluded account is
   // a stale read. Routing cannot be sitting on it, so the card must not claim otherwise.
@@ -204,6 +246,25 @@ test("a paused account is never shown as pinned", async () => {
 
   expect(hasPinnedBadge(host)).toBe(false);
   expect(hasPinnedHint(host)).toBe(false);
+  expect(switchAction(cardFor("pool@example.test"))).toBeNull();
+});
+
+test("reauth and cooldown guards still hide the pin action", async () => {
+  const needsReauth: CodexAccountEntry = { ...account, needsReauth: true };
+  const coolingDown: CodexAccountEntry = {
+    ...account,
+    id: "pool-2",
+    email: "cooldown@example.test",
+    health: { status: "cooldown", reason: "rate_limit", until: "2099-01-01T00:00:00.000Z" },
+  };
+  await mountPool(makeController({
+    accounts: [mainAccount, needsReauth, coolingDown],
+    activeId: "pool-1",
+    activePinnedId: null,
+  }));
+
+  expect(switchAction(cardFor("pool@example.test"))).toBeNull();
+  expect(switchAction(cardFor("cooldown@example.test"))).toBeNull();
 });
 
 test("healthy account cards omit log-label and 30-day usage copy", async () => {


### PR DESCRIPTION
## Summary

- Keep the existing manual pin action visible when automatic routing makes a Codex account effective-active without giving it the manual pin.
- Apply the same active-versus-pinned distinction to the app-login card and added-account cards.
- Preserve the existing paused, reauthentication, and cooldown gates, and hide the action when the active account already owns the pin.
- Add mounted-DOM coverage for active-unpinned main and pool accounts, sibling pin replacement, redundant-action suppression, health guards, and the existing confirmation target.

Closes #2554.

## Verification

- `cd gui && bun test --isolate tests/codex-account-pool-pinned-badge.test.tsx tests/codex-account-pool-controller.test.ts` (Bun 1.4.0-canary.1: 19 passed, 0 failed)
- `cd gui && bun test tests` (Bun 1.4.0-canary.1: 984 passed, 0 failed)
- `cd gui && bun run lint`
- `cd gui && bun run build` (passed; existing bundle-size warning remains)
- `git diff --check`
- independent current-diff review: no actionable findings

## Screenshot

Sanitized active-unpinned pool state:

<img width="1200" height="640" alt="Active unpinned account keeps the manual pin action" src="https://github.com/user-attachments/assets/e1f0c728-1ce5-4cdb-9e2e-ee3e577074c3" />

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved account switching controls to correctly hide actions for pinned, paused, reauthentication-required, and cooldown accounts.
  - Account switching remains available for active accounts that are not pinned.
  - Updated the main account card to show the switch option when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->