### PR TITLE
fix: disable Bun fetch socket idle timeout for upstream provider request

### DIFF
--- a/src/server/claude-messages.ts
+++ b/src/server/claude-messages.ts
@@ -553,7 +553,7 @@ export async function fetchWithHeaderDeadline(
 ): Promise<HeaderDeadlineFetchResult> {
   const deadline = makeDeadline(timeoutMs, parent);
   try {
-    const upstream = await fetchImpl(input, { ...init, signal: deadline.signal });
+    const upstream = await fetchImpl(input, { ...init, signal: deadline.signal, timeout: 0 });
     return { kind: "response", upstream };
   } catch (error) {
     if (deadline.didExpire()) return { kind: "timeout" };

--- a/src/server/responses/fetch-helpers.ts
+++ b/src/server/responses/fetch-helpers.ts
@@ -69,7 +69,7 @@ export function providerFetch(
   };
   const httpFetch = Object.assign(
     (input: Parameters<typeof globalThis.fetch>[0], init?: RequestInit) =>
-      base(input, withUpstreamHttpVersion(input, init, provider)),
+      base(input, { ...withUpstreamHttpVersion(input, init, provider), timeout: 0 }),
     { preconnect },
   ) as typeof globalThis.fetch;
   // ChatGPT Codex backend: streaming turns ride the responses_websockets
@@ -139,6 +139,7 @@ export async function fetchWithHeaderTimeout(
       // indistinguishable from a pre-connection failure (#914).
       ...(manualRedirect ? { redirect: "manual" as const } : {}),
       signal: AbortSignal.any([abortSignal, timeout.signal]),
+      timeout: 0,
     });
   } finally {
     clearTimeout(timer);


### PR DESCRIPTION
## Summary

I was having timeout issues when using local modals. 
This PR should fix the timeout issue

## Verification

- bun install
- bun run typecheck
- bun run test

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [ ] Docs or release notes were updated when needed.
- [ ] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of upstream requests so configured timeout and cancellation behavior works consistently.
  * Prevented runtime-level timeouts from interrupting requests before the application’s own timeout controls apply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->