### PR TITLE
test(codex): repair dev by granting the gated 5.6 roster to candidate-scope preview cases

### DIFF
--- a/tests/subagent-fallback-handle-responses.test.ts
+++ b/tests/subagent-fallback-handle-responses.test.ts
@@ -843,6 +843,12 @@ describe("native fallback account preview", () => {
     const now = cooldownAt + CODEX_QUOTA_PROBE_INTERVAL_MS + 1;
     Date.now = () => now;
     installPoolCredential("pool-a", "pool_acc_a", now);
+    // This case binds on gpt-5.6-sol, which is account-gated: without a roster the
+    // entitlement snapshot fails closed and no account is eligible (#2550).
+    installCodexRosterMock({
+      pool_acc_a: GPT56_NATIVE_MODELS,
+      pool_acc_b: GPT56_NATIVE_MODELS,
+    });
     installPoolCredential("pool-b", "pool_acc_b", now);
     const cfg = poolNativePlusRoutedConfig({
       activeCodexAccountId: "pool-a",
@@ -910,6 +916,11 @@ describe("native fallback account preview", () => {
     let currentNow = now;
     Date.now = () => currentNow;
     installPoolCredential("pool-a", "pool_acc_a", now);
+    // Same account-gated binding as above: grant the roster to both pool accounts.
+    installCodexRosterMock({
+      pool_acc_a: GPT56_NATIVE_MODELS,
+      pool_acc_b: GPT56_NATIVE_MODELS,
+    });
     installPoolCredential("pool-b", "pool_acc_b", now);
     const cfg = poolNativePlusRoutedConfig({
       defaultProvider: "xai",


### PR DESCRIPTION
## Summary

`dev` is currently red. #2515 and #2550 were each green in isolation, but their
interaction is semantic: #2550 made `gpt-5.6-*` account-gated and fails closed when the
entitlement snapshot carries no roster for an account (`src/codex/auth-context.ts:463`),
while two account-preview cases added by #2515 bind on `gpt-5.6-sol` without installing a
roster mock. On dev both now throw `CodexPoolAuthenticationError: No eligible Codex account
supports this model`.

This grants those two cases the same roster the neighbouring preview cases already install
(`installCodexRosterMock` with `GPT56_NATIVE_MODELS`, the pattern introduced by #2550
itself at lines 732 and 793). Test-only change; no runtime behaviour is modified.

Failing run before the fix: https://github.com/lidge-jun/opencodex/actions/runs/32863008724

## Verification

```
$ bun test tests/subagent-model-fallback.test.ts tests/subagent-fallback-handle-responses.test.ts
 88 pass
 0 fail
 238 expect() calls
```

Before the change the same command reported `86 pass / 2 fail`.

## Checklist

- [x] Targets `dev`
- [x] Focused regression run locally
- [x] No runtime behaviour change (test fixture only)
- [x] No secrets or account details in the diff



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated subagent fallback pool tests to reflect account eligibility for gated models.
  * Improved test coverage for affinity binding and entitlement handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->