### PR TITLE
fix(google): recognize antigravity quota exhaustion, including the unspaced retry-after spelling (rebase of #2510)

### DIFF
--- a/src/adapters/google-errors.ts
+++ b/src/adapters/google-errors.ts
@@ -15,14 +15,47 @@ function googleErrorDetail(payloadText: string): { message?: string; status?: st
   };
 }
 
+
+
+const GOOGLE_QUOTA_EXHAUSTED_NEEDLES = [
+  "quotafailure",
+  "quota exceeded",
+  "exceeded your current quota",
+  "billing",
+  "individual quota reached",
+  "quota reached",
+  "enable overages",
+  "exhausted your capacity",
+  "daily limit reached",
+  "weekly limit reached",
+];
+
+// Per-minute / per-second / concurrency limits are transient rate limits: they should be
+// retried, not treated as hard quota exhaustion. These guards run before the needles so a
+// message like "Per-minute quota exceeded" stays in the retryable bucket.
+const GOOGLE_TRANSIENT_RATE_LIMIT_PATTERNS = [
+  "per minute",
+  "per-minute",
+  "per min",
+  "rpm",
+  "requests per minute",
+  "too many requests",
+  "rate limit",
+  "retry after",
+  "concurrent request limit",
+];
+
+export function isGoogleQuotaExhaustedText(text: string): boolean {
+  const lower = text.toLowerCase();
+  if (GOOGLE_TRANSIENT_RATE_LIMIT_PATTERNS.some(needle => lower.includes(needle))) return false;
+  return GOOGLE_QUOTA_EXHAUSTED_NEEDLES.some(needle => lower.includes(needle));
+}
+
+
 function classifyGoogle(label: string, status: number | undefined, enumStatus: string | undefined, text: string): string {
   const lower = `${enumStatus ?? ""} ${text}`.toLowerCase();
-  const quotaExhausted =
-    lower.includes("quotafailure") ||
-    lower.includes("quota exceeded") ||
-    lower.includes("exceeded your current quota") ||
-    lower.includes("billing");
-  if (enumStatus === "RESOURCE_EXHAUSTED" && quotaExhausted) return `${label} quota exhausted`;
+  const quotaExhausted = isGoogleQuotaExhaustedText(lower);
+  if ((!enumStatus || enumStatus === "RESOURCE_EXHAUSTED") && quotaExhausted) return `${label} quota exhausted`;
   if (status === 429 || enumStatus === "RESOURCE_EXHAUSTED" || lower.includes("rate limit")) {
     return `${label} rate limit exceeded`;
   }
@@ -76,10 +109,6 @@ export function retryableGoogleStatus(status: number): boolean {
  */
 export function isQuotaExhaustedBody(payloadText: string): boolean {
   const { message, status } = googleErrorDetail(payloadText);
-  if (status !== "RESOURCE_EXHAUSTED") return false;
-  const lower = (message ?? "").toLowerCase();
-  return lower.includes("quotafailure")
-    || lower.includes("quota exceeded")
-    || lower.includes("exceeded your current quota")
-    || lower.includes("billing");
+  if (status && status !== "RESOURCE_EXHAUSTED") return false;
+  return isGoogleQuotaExhaustedText(message ?? payloadText);
 }

--- a/src/adapters/google-errors.ts
+++ b/src/adapters/google-errors.ts
@@ -42,6 +42,9 @@ const GOOGLE_TRANSIENT_RATE_LIMIT_PATTERNS = [
   "too many requests",
   "rate limit",
   "retry after",
+  // Upstream writes the header name both ways in prose ("retry-after: 60"); matching only the
+  // spaced spelling let a transient 429 fall through to the exhaustion needles below.
+  "retry-after",
   "concurrent request limit",
 ];
 

--- a/tests/google-errors.test.ts
+++ b/tests/google-errors.test.ts
@@ -56,6 +56,10 @@ describe("google error classification & quota exhaustion", () => {
       "Concurrent request limit reached, try again in a few seconds.",
       "Per-minute quota exceeded, retry later.",
       "Quota exceeded per minute (RPM).",
+      // Upstream writes the header name unspaced in prose. Matching only "retry after" let
+      // this fall through to the exhaustion needles and suppress a retry for a transient 429.
+      "Quota exceeded; retry-after: 60",
+      "RESOURCE_EXHAUSTED: quota exceeded. Retry-After: 30",
     ];
 
     for (const phrase of transientPhrases) {

--- a/tests/google-errors.test.ts
+++ b/tests/google-errors.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isGoogleQuotaExhaustedText,
+  isQuotaExhaustedBody,
+  safeAntigravityHttpErrorMessage,
+  safeGoogleHttpErrorMessage,
+  safeVertexHttpErrorMessage,
+} from "../src/adapters/google-errors";
+
+describe("google error classification & quota exhaustion", () => {
+  const antigravityPhrases = [
+    "Individual quota reached. Please try again later.",
+    "Quota exceeded for model gemini-3.7-flash",
+    "You have exceeded your current quota.",
+    "Please enable overages in your Cloud billing console.",
+    "You have exhausted your capacity for this period.",
+    "Daily limit reached for this account.",
+    "Weekly limit reached.",
+    "RESOURCE_EXHAUSTED: quotafailure at billing account",
+  ];
+
+  for (const phrase of antigravityPhrases) {
+    test(`recognizes quota phrase: "${phrase}"`, () => {
+      expect(isGoogleQuotaExhaustedText(phrase)).toBe(true);
+      const jsonBodyWithStatus = JSON.stringify({
+        error: {
+          code: 429,
+          status: "RESOURCE_EXHAUSTED",
+          message: phrase,
+        },
+      });
+      expect(isQuotaExhaustedBody(jsonBodyWithStatus)).toBe(true);
+      expect(safeAntigravityHttpErrorMessage(429, jsonBodyWithStatus)).toContain("Antigravity quota exhausted");
+      expect(safeVertexHttpErrorMessage(429, jsonBodyWithStatus)).toContain("Vertex AI quota exhausted");
+
+      // Also verify when JSON does not have an explicit status field (common in some Antigravity proxies)
+      const jsonBodyNoStatus = JSON.stringify({
+        error: {
+          code: 429,
+          message: phrase,
+        },
+      });
+      expect(isQuotaExhaustedBody(jsonBodyNoStatus)).toBe(true);
+      expect(safeAntigravityHttpErrorMessage(429, jsonBodyNoStatus)).toContain("Antigravity quota exhausted");
+
+      // Also verify raw plain text payload
+      expect(isQuotaExhaustedBody(phrase)).toBe(true);
+      expect(safeAntigravityHttpErrorMessage(429, phrase)).toContain("Antigravity quota exhausted");
+    });
+  }
+
+  test("does not classify transient rate limit as hard quota exhaustion", () => {
+    const transientPhrases = [
+      "Rate limit exceeded. Please retry with exponential backoff.",
+      "Too many requests per minute (RPM).",
+      "Concurrent request limit reached, try again in a few seconds.",
+      "Per-minute quota exceeded, retry later.",
+      "Quota exceeded per minute (RPM).",
+    ];
+
+    for (const phrase of transientPhrases) {
+      expect(isGoogleQuotaExhaustedText(phrase)).toBe(false);
+      const jsonBody = JSON.stringify({
+        error: {
+          code: 429,
+          status: "RESOURCE_EXHAUSTED",
+          message: phrase,
+        },
+      });
+      expect(isQuotaExhaustedBody(jsonBody)).toBe(false);
+      expect(safeAntigravityHttpErrorMessage(429, jsonBody)).toContain("Antigravity rate limit exceeded");
+    }
+  });
+
+  test("non-RESOURCE_EXHAUSTED status is not quota exhaustion even with quota keyword", () => {
+    const jsonBody = JSON.stringify({
+      error: {
+        code: 400,
+        status: "INVALID_ARGUMENT",
+        message: "quota configuration invalid",
+      },
+    });
+    expect(isQuotaExhaustedBody(jsonBody)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Rebase of #2510 (by @Hsia97) onto current `dev`, plus the one fixup the review asked for.

The original change classifies Antigravity quota exhaustion so a hard limit is not
retried. The review finding was that its transient guard matched `"retry after"` but not
the unspaced `"retry-after"`, which is how the header name is usually written in prose.
An upstream body like `Quota exceeded; retry-after: 60` therefore skipped the transient
bucket and fell through to the exhaustion needles — a transient 429 would suppress retry
and could drive account-fallback exhaustion.

This adds the missing needle and pins both spellings with regressions.

Closes #2510.

## Verification

The added cases were driven red before the fix:

```
# with the "retry-after" needle removed
$ bun test tests/google-errors.test.ts
 9 pass, 1 fail, 81 expect() calls

# with the fix
$ bun test tests/google-errors.test.ts
 10 pass, 0 fail, 86 expect() calls
```

## Checklist

- [x] Targets `dev`
- [x] Rebased onto the current `dev` head (1/1, no conflicts)
- [x] Regression driven red first, then green
- [x] Original authorship preserved in the commit history
- [x] No secrets or account identifiers in the diff



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Google quota exhaustion across structured errors and plain-text responses.
  * Correctly distinguishes temporary rate limits from exhausted quotas, preserving retry behavior for transient errors.
  * Improved error messages for quota exhaustion and rate-limit conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->