### PR TITLE
fix(pricing): map Daybreak cost overlays and preserve model identity in logs

### DIFF
--- a/gui/src/model-display.ts
+++ b/gui/src/model-display.ts
@@ -4,7 +4,7 @@
  * 5.6 trio is instantly distinguishable. No emoji — Lucide-style SVG only.
  */
 import { createElement, type ReactNode } from "react";
-import { IconSun, IconGlobe, IconMoon } from "./icons";
+import { IconSun, IconGlobe, IconMoon, IconLock } from "./icons";
 
 type IconComponent = typeof IconSun;
 
@@ -14,7 +14,7 @@ const MODEL_ICON_MAP: Record<string, IconComponent> = {
   "gpt-5.6-luna": IconMoon,
   "gpt-daybreak-blue-latest": IconSun,
   "daybreak-blue-latest": IconSun,
-  "daybreak-red-latest": IconSun,
+  "daybreak-red-latest": IconLock,
 };
 
 const ICON_STYLE = { width: 14, height: 14, flexShrink: 0, verticalAlign: "text-bottom" as const };

--- a/gui/src/model-display.ts
+++ b/gui/src/model-display.ts
@@ -12,6 +12,9 @@ const MODEL_ICON_MAP: Record<string, IconComponent> = {
   "gpt-5.6-sol": IconSun,
   "gpt-5.6-terra": IconGlobe,
   "gpt-5.6-luna": IconMoon,
+  "gpt-daybreak-blue-latest": IconSun,
+  "daybreak-blue-latest": IconSun,
+  "daybreak-red-latest": IconSun,
 };
 
 const ICON_STYLE = { width: 14, height: 14, flexShrink: 0, verticalAlign: "text-bottom" as const };

--- a/gui/tests/claude-code-background-helper.test.tsx
+++ b/gui/tests/claude-code-background-helper.test.tsx
@@ -71,7 +71,7 @@ test("selected background helper keeps the neutral description and hides the nat
 // "[object Object]". These render the options the page actually builds, so
 // reintroducing String() fails here rather than only on screen.
 test("icon-bearing models render their name, never [object Object] (#668)", () => {
-  const slugs = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"];
+  const slugs = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-daybreak-blue-latest", "daybreak-blue-latest", "daybreak-red-latest"];
   // The closed picker renders only the SELECTED option, so assert per slug.
   for (const slug of slugs) {
     const html = renderToStaticMarkup(
@@ -87,6 +87,14 @@ test("icon-bearing models render their name, never [object Object] (#668)", () =
     expect(html).toContain(slug);
     expect(html).toContain("<svg");
   }
+});
+
+test("Daybreak Red uses a cyber lock rather than the Blue solar identity", () => {
+  const blue = renderToStaticMarkup(modelLabel("daybreak-blue-latest"));
+  const red = renderToStaticMarkup(modelLabel("daybreak-red-latest"));
+  expect(blue).toContain('<circle cx="12" cy="12" r="4"></circle>');
+  expect(red).toContain('<rect x="4" y="11" width="16" height="10" rx="2"></rect>');
+  expect(red).not.toBe(blue);
 });
 
 test("background helper options keep icon labels as nodes and lead with the unset entry (#668)", () => {

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -930,11 +930,15 @@ export function codexAccountGatedCanonicalWireModel(modelId: string): string | u
   return undefined;
 }
 
-function applyCodexAccountGatedWireNormalization(parsed: OcxParsedRequest, route: RouteResult): void {
+function applyCodexAccountGatedWireNormalization(parsed: OcxParsedRequest, route: RouteResult, logCtx?: RequestLogContext): void {
   if (!isCanonicalOpenAiForwardProvider(route.provider)) return;
   const wireModel = codexAccountGatedCanonicalWireModel(route.modelId);
   if (!wireModel) return;
 
+  if (logCtx) {
+    logCtx.preserveResolvedModelFromRoute = true;
+    delete logCtx.resolvedModel;
+  }
   parsed.modelId = wireModel;
   if (!parsed._rawBody || typeof parsed._rawBody !== "object") return;
   const raw = parsed._rawBody as Record<string, unknown>;
@@ -2719,7 +2723,7 @@ async function handleResponsesInner(
   }
 
   route.provider = applyCodexAuthContextToProvider(route.provider, authCtx, route.codexAccountMode);
-  applyCodexAccountGatedWireNormalization(parsed, route);
+  applyCodexAccountGatedWireNormalization(parsed, route, logCtx);
   logCtx.provider = route.codexAccountNamespace
     ? `${route.providerName}-${route.codexAccountNamespace}`
     : formatCodexProviderForLog(route.providerName, codexLogAccountId(authCtx), config);
@@ -3650,7 +3654,7 @@ async function handleResponsesInner(
     }
     const headers = sanitizePassthroughHeaders(upstreamResponse.headers);
     const resolvedModel = headers.get("openai-model")?.trim();
-    if (resolvedModel) logCtx.resolvedModel = resolvedModel;
+    if (resolvedModel && !logCtx.preserveResolvedModelFromRoute) logCtx.resolvedModel = resolvedModel;
     if (isUsageDebugEnabled()) {
       const upstreamContentType = upstreamResponse.headers.get("content-type");
       if (upstreamContentType) logCtx.usageDebugContentType = upstreamContentType;

--- a/src/usage/expected-prices.ts
+++ b/src/usage/expected-prices.ts
@@ -126,6 +126,10 @@ export const EXPECTED_PRICE_OVERLAYS: readonly ExpectedPriceOverlay[] = [
   // Daybreak aliases: priced as their current snapshots (red -> gpt-5.6-cyber,
   // blue -> gpt-5.6-sol). The alias ids carry no rows of their own upstream, hence
   // verified-derived. Blue deliberately reuses GPT56_SOL rather than duplicating the tuple.
+  { provider: "openai", modelId: "gpt-daybreak-blue-latest", cost4: GPT56_SOL, source: `alias of gpt-5.6-sol ${OPENAI_GPT56_PRICING}`, verifiedAt: "2026-08-11", status: "verified-derived" },
+  { provider: "openai", modelId: "daybreak-blue-latest", cost4: GPT56_SOL, source: `alias of gpt-5.6-sol ${OPENAI_GPT56_PRICING}`, verifiedAt: "2026-08-11", status: "verified-derived" },
+  { provider: "openai", modelId: "daybreak-red-latest", cost4: DAYBREAK_RED, source: `alias of gpt-5.6-cyber ${OPENAI_GPT56_PRICING}`, verifiedAt: "2026-08-11", status: "verified-derived" },
+  { provider: "openai-apikey", modelId: "gpt-daybreak-blue-latest", cost4: GPT56_SOL, source: `alias of gpt-5.6-sol ${OPENAI_GPT56_PRICING}`, verifiedAt: "2026-08-11", status: "verified-derived" },
   { provider: "openai-apikey", modelId: "daybreak-red-latest", cost4: DAYBREAK_RED, source: `alias of gpt-5.6-cyber ${OPENAI_GPT56_PRICING}`, verifiedAt: "2026-08-11", status: "verified-derived" },
   { provider: "openai-apikey", modelId: "daybreak-blue-latest", cost4: GPT56_SOL, source: `alias of gpt-5.6-sol ${OPENAI_GPT56_PRICING}`, verifiedAt: "2026-08-11", status: "verified-derived" },
   { provider: "google-antigravity", modelId: "gemini-3.1-pro-low", cost4: GEMINI_31_PRO, source: `derived: gemini-3.1-pro (<=200k tier) ${GEMINI_PRICING}`, verifiedAt: "2026-07-20", status: "verified-derived" },
@@ -223,6 +227,8 @@ export function findExpectedPriceOverlay(
 /** OpenAI Fast price multipliers retained as a compatibility export. */
 export const PRIORITY_MULTIPLIERS: Readonly<Record<string, number>> = {
   "gpt-5.6-sol": 2,
+  "gpt-daybreak-blue-latest": 2,
+  "daybreak-blue-latest": 2,
   // Post-price-cut Fast tables (https://openai.com/api-fast-mode/, 2026-08-05):
   // Terra 4/24/0.40/5 and Luna 0.40/2.40/0.04/0.50 are both 2× the corrected
   // standard tuples; the stale bases made these look like 1.6/0.4 (#907).
@@ -334,6 +340,10 @@ const OPENAI_GPT56_CONTEXT_MODELS = [
   "gpt-5.6-sol-pro",
   "gpt-5.6-terra-pro",
   "gpt-5.6-luna-pro",
+  // Daybreak Blue aliases gpt-5.6-sol (shares the 272k long-context tier).
+  // Daybreak Red (cyber snapshot) has all "-" long-context cells and thus has no tier row.
+  "gpt-daybreak-blue-latest",
+  "daybreak-blue-latest",
 ];
 
 export const CONTEXT_TIERS: readonly ContextTier[] = [
@@ -370,22 +380,6 @@ export const CONTEXT_TIERS: readonly ContextTier[] = [
     confirmedPriorityRelation: "lower-bound",
     source: "https://docs.x.ai/developers/pricing",
     verifiedAt: "2026-08-18",
-  },
-  {
-    // daybreak-blue-latest aliases gpt-5.6-sol, which publishes the full long-context row
-    // ($10 / $1 / $12.50 / $45). Scoped to openai-apikey ON PURPOSE: Daybreak is not
-    // routable on the Codex-login `openai` provider, so adding the alias to the shared
-    // OPENAI_GPT56_CONTEXT_MODELS list (expanded across both providers above) would mint a
-    // tier for a provider/model pair that cannot exist.
-    // daybreak-red-latest has NO tier row: the cyber snapshot's four long-context cells are
-    // all "-" on the pricing page (verified 2026-08-11).
-    provider: "openai-apikey",
-    modelId: "daybreak-blue-latest",
-    thresholdInputTokens: 272_000,
-    inclusive: false,
-    multiplier: OPENAI_LONG_CONTEXT,
-    source: OPENAI_PRICING_DOC,
-    verifiedAt: "2026-08-11",
   },
   ...["minimax", "minimax-cn"].map((provider): ContextTier => ({
     provider,

--- a/src/usage/expected-prices.ts
+++ b/src/usage/expected-prices.ts
@@ -126,10 +126,10 @@ export const EXPECTED_PRICE_OVERLAYS: readonly ExpectedPriceOverlay[] = [
   // Daybreak aliases: priced as their current snapshots (red -> gpt-5.6-cyber,
   // blue -> gpt-5.6-sol). The alias ids carry no rows of their own upstream, hence
   // verified-derived. Blue deliberately reuses GPT56_SOL rather than duplicating the tuple.
+  // The `gpt-` selector is native to ChatGPT/Codex accounts. The bare aliases below belong to
+  // the separately billed API-key catalog; keep those namespaces disjoint so pricing metadata
+  // cannot make an unroutable provider/model pair look supported.
   { provider: "openai", modelId: "gpt-daybreak-blue-latest", cost4: GPT56_SOL, source: `alias of gpt-5.6-sol ${OPENAI_GPT56_PRICING}`, verifiedAt: "2026-08-11", status: "verified-derived" },
-  { provider: "openai", modelId: "daybreak-blue-latest", cost4: GPT56_SOL, source: `alias of gpt-5.6-sol ${OPENAI_GPT56_PRICING}`, verifiedAt: "2026-08-11", status: "verified-derived" },
-  { provider: "openai", modelId: "daybreak-red-latest", cost4: DAYBREAK_RED, source: `alias of gpt-5.6-cyber ${OPENAI_GPT56_PRICING}`, verifiedAt: "2026-08-11", status: "verified-derived" },
-  { provider: "openai-apikey", modelId: "gpt-daybreak-blue-latest", cost4: GPT56_SOL, source: `alias of gpt-5.6-sol ${OPENAI_GPT56_PRICING}`, verifiedAt: "2026-08-11", status: "verified-derived" },
   { provider: "openai-apikey", modelId: "daybreak-red-latest", cost4: DAYBREAK_RED, source: `alias of gpt-5.6-cyber ${OPENAI_GPT56_PRICING}`, verifiedAt: "2026-08-11", status: "verified-derived" },
   { provider: "openai-apikey", modelId: "daybreak-blue-latest", cost4: GPT56_SOL, source: `alias of gpt-5.6-sol ${OPENAI_GPT56_PRICING}`, verifiedAt: "2026-08-11", status: "verified-derived" },
   { provider: "google-antigravity", modelId: "gemini-3.1-pro-low", cost4: GEMINI_31_PRO, source: `derived: gemini-3.1-pro (<=200k tier) ${GEMINI_PRICING}`, verifiedAt: "2026-07-20", status: "verified-derived" },
@@ -340,10 +340,6 @@ const OPENAI_GPT56_CONTEXT_MODELS = [
   "gpt-5.6-sol-pro",
   "gpt-5.6-terra-pro",
   "gpt-5.6-luna-pro",
-  // Daybreak Blue aliases gpt-5.6-sol (shares the 272k long-context tier).
-  // Daybreak Red (cyber snapshot) has all "-" long-context cells and thus has no tier row.
-  "gpt-daybreak-blue-latest",
-  "daybreak-blue-latest",
 ];
 
 export const CONTEXT_TIERS: readonly ContextTier[] = [
@@ -359,6 +355,29 @@ export const CONTEXT_TIERS: readonly ContextTier[] = [
       verifiedAt: "2026-08-03",
     })),
   ),
+  {
+    // The native Codex selector aliases gpt-5.6-sol and shares its 272k long-context tier.
+    provider: "openai",
+    modelId: "gpt-daybreak-blue-latest",
+    thresholdInputTokens: 272_000,
+    inclusive: false,
+    multiplier: OPENAI_LONG_CONTEXT,
+    confirmedPriorityRelation: "exclusive",
+    source: OPENAI_PRICING_DOC,
+    verifiedAt: "2026-08-11",
+  },
+  {
+    // The bare selector is the separately billed API-key alias. Daybreak Red has no tier row:
+    // the cyber snapshot's four long-context cells are all "-" on the pricing page.
+    provider: "openai-apikey",
+    modelId: "daybreak-blue-latest",
+    thresholdInputTokens: 272_000,
+    inclusive: false,
+    multiplier: OPENAI_LONG_CONTEXT,
+    confirmedPriorityRelation: "exclusive",
+    source: OPENAI_PRICING_DOC,
+    verifiedAt: "2026-08-11",
+  },
   {
     provider: "xai",
     modelId: "grok-4.5",

--- a/src/usage/expected-prices.ts
+++ b/src/usage/expected-prices.ts
@@ -39,7 +39,7 @@ export interface ExpectedPriceOverlay {
 }
 
 const GEMINI_31_PRO: Cost4 = { input: 2, output: 12, cacheRead: 0.2, cacheWrite: 0 };
-const GPT56_SOL: Cost4 = { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 };
+const GPT56_SOL: Cost4 = { input: 4, output: 20, cacheRead: 0.4, cacheWrite: 5 };
 /**
  * Daybreak aliases. `daybreak-*-latest` never appears in the pricing table itself — only its
  * current snapshot does — so these tuples are the snapshot's published rates and carry
@@ -263,13 +263,19 @@ const XAI_PRIORITY_PRICING = "https://docs.x.ai/developers/advanced-api-usage/pr
  */
 export const PRIORITY_PRICING_RULES: readonly PriorityPricingRule[] = [
   ...["openai", "openai-apikey"].flatMap(provider =>
-    Object.entries(PRIORITY_MULTIPLIERS).map(([modelId, multiplier]): PriorityPricingRule => ({
-      provider,
-      modelId,
-      multiplier,
-      source: OPENAI_FAST_PRICING,
-      verifiedAt: "2026-08-05",
-    })),
+    Object.entries(PRIORITY_MULTIPLIERS)
+      // Daybreak's `gpt-` selector belongs to ChatGPT/Codex accounts; its bare selector belongs
+      // to the separately billed API-key catalog. All ordinary GPT ids remain valid on both.
+      .filter(([modelId]) => provider === "openai"
+        ? modelId !== "daybreak-blue-latest"
+        : modelId !== "gpt-daybreak-blue-latest")
+      .map(([modelId, multiplier]): PriorityPricingRule => ({
+        provider,
+        modelId,
+        multiplier,
+        source: OPENAI_FAST_PRICING,
+        verifiedAt: "2026-08-05",
+      })),
   ),
   ...["grok-4.5", "grok-4.6"].map((modelId): PriorityPricingRule => ({
     provider: "xai",

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -2167,7 +2167,10 @@ describe("server local API auth", () => {
     const harness = await startPoolRetryHarness(
       async (_accountId, request) => {
         upstreamBody = await request.json() as Record<string, unknown>;
-        return Response.json({ id: "canonical-wire-success", status: "completed", output: [] });
+        return Response.json(
+          { id: "canonical-wire-success", status: "completed", output: [], usage: { input_tokens: 1000, output_tokens: 100 } },
+          { headers: { "openai-model": "gpt-5.6-sol" } },
+        );
       },
       {
         secondAccount: false,
@@ -2183,6 +2186,14 @@ describe("server local API auth", () => {
       expect(upstreamBody?.model).toBe("gpt-5.6-sol");
       expect(upstreamBody).not.toHaveProperty("prompt_cache_retention");
       expect(harness.dispatches).toEqual(["acct-pool-a"]);
+
+      const logs = logsFromApiBody(await fetch(new URL("/api/logs?tail=1", harness.server.url), { headers: managementHeaders() }).then(r => r.json()));
+      expect(logs.at(-1)).toMatchObject({
+        model: "gpt-daybreak-blue-latest",
+        status: 200,
+      });
+      expect(logs.at(-1)?.resolvedModel).toBeUndefined();
+      expect(logs.at(-1)?.displayMetrics?.cost?.kind).toBe("value");
     } finally {
       await stopPoolRetryHarness(harness);
     }

--- a/tests/usage-cost.test.ts
+++ b/tests/usage-cost.test.ts
@@ -269,14 +269,18 @@ describe("resolveMatchedPrice", () => {
     expect(resolveMatchedPrice("openrouter", "anthropic-claude-3.5-sonnet")).toBeNull();
   });
 
-  test("16. shipped overlay membership: 55 keys, including Opus 5 and compatibility prices", () => {
-    expect(EXPECTED_PRICE_OVERLAYS.length).toBe(55);
+  test("16. shipped overlay membership: 59 keys, including Opus 5 and compatibility prices", () => {
+    expect(EXPECTED_PRICE_OVERLAYS.length).toBe(59);
     expect(EXPECTED_PRICE_OVERLAYS.some(row => row.status === "unverified")).toBe(false);
     const keys = new Set(EXPECTED_PRICE_OVERLAYS.map(row => `${row.provider}/${row.modelId}`));
     for (const expected of [
       "anthropic/claude-opus-5",
       "cursor/claude-opus-5",
       "kiro/claude-opus-5",
+      "openai/gpt-daybreak-blue-latest",
+      "openai/daybreak-blue-latest",
+      "openai/daybreak-red-latest",
+      "openai-apikey/gpt-daybreak-blue-latest",
       "openai-apikey/daybreak-red-latest",
       "openai-apikey/daybreak-blue-latest",
       "minimax/MiniMax-M2.1-highspeed",
@@ -540,6 +544,8 @@ describe("priority (Fast) service tier multiplier", () => {
 
   test("P8. resolvePriorityMultiplier returns correct values", () => {
     expect(resolvePriorityMultiplier("gpt-5.6-sol")).toBe(2);
+    expect(resolvePriorityMultiplier("gpt-daybreak-blue-latest")).toBe(2);
+    expect(resolvePriorityMultiplier("daybreak-blue-latest")).toBe(2);
     expect(resolvePriorityMultiplier("gpt-5.6-terra")).toBe(2);
     expect(resolvePriorityMultiplier("gpt-5.6-luna")).toBe(2);
     expect(resolvePriorityMultiplier("gpt-5.5")).toBe(2.5);
@@ -550,8 +556,10 @@ describe("priority (Fast) service tier multiplier", () => {
   });
 
   test("P9. PRIORITY_MULTIPLIERS table has expected entries", () => {
-    expect(Object.keys(PRIORITY_MULTIPLIERS)).toHaveLength(6);
+    expect(Object.keys(PRIORITY_MULTIPLIERS)).toHaveLength(8);
     expect(PRIORITY_MULTIPLIERS["gpt-5.6-sol"]).toBe(2);
+    expect(PRIORITY_MULTIPLIERS["gpt-daybreak-blue-latest"]).toBe(2);
+    expect(PRIORITY_MULTIPLIERS["daybreak-blue-latest"]).toBe(2);
     expect(PRIORITY_MULTIPLIERS["gpt-5.6-terra"]).toBe(2);
     expect(PRIORITY_MULTIPLIERS["gpt-5.6-luna"]).toBe(2);
     expect(PRIORITY_MULTIPLIERS["gpt-5.5"]).toBe(2.5);
@@ -764,28 +772,39 @@ describe("long-context pricing tiers (#908)", () => {
     // An alias is priced as its current snapshot, so the shipped rows are the real check.
     const red = resolveMatchedPrice("openai-apikey", "daybreak-red-latest");
     const blue = resolveMatchedPrice("openai-apikey", "daybreak-blue-latest");
+    const gptBlueApiKey = resolveMatchedPrice("openai-apikey", "gpt-daybreak-blue-latest");
+    const gptBlueOpenAi = resolveMatchedPrice("openai", "gpt-daybreak-blue-latest");
+    const blueOpenAi = resolveMatchedPrice("openai", "daybreak-blue-latest");
     expect(red?.cost4).toEqual({ input: 12.5, output: 75, cacheRead: 1.25, cacheWrite: 15.625 });
     expect(blue?.cost4).toEqual({ input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 });
+    expect(gptBlueApiKey?.cost4).toEqual({ input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 });
+    expect(gptBlueOpenAi?.cost4).toEqual({ input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 });
+    expect(blueOpenAi?.cost4).toEqual({ input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 });
     // verified-derived, never verified: the pricing page has no daybreak-* rows, only the
     // snapshots'. This status is also what keeps `estimated` on downstream, and an alias is
     // more drift-prone than a normal row because OpenAI can repoint it.
     expect(red?.status).toBe("verified-derived");
     expect(blue?.status).toBe("verified-derived");
+    expect(gptBlueApiKey?.status).toBe("verified-derived");
+    expect(gptBlueOpenAi?.status).toBe("verified-derived");
+    expect(blueOpenAi?.status).toBe("verified-derived");
 
-    const alias = (model: string, usage: Record<string, number>) =>
-      estimateRequestCost({ provider: "openai-apikey", model, usageStatus: "reported", usage });
+    const alias = (model: string, usage: Record<string, number>, provider = "openai-apikey") =>
+      estimateRequestCost({ provider, model, usageStatus: "reported", usage });
     // Blue aliases gpt-5.6-sol, which publishes a long-context row: same exclusive boundary.
     expect(alias("daybreak-blue-latest", { inputTokens: 272_000, outputTokens: 10_000 })!.contextTier).toBeUndefined();
     expect(alias("daybreak-blue-latest", { inputTokens: 272_001, outputTokens: 10_000 })!.contextTier).toBe("long");
+    expect(alias("gpt-daybreak-blue-latest", { inputTokens: 272_000, outputTokens: 10_000 }, "openai")!.contextTier).toBeUndefined();
+    expect(alias("gpt-daybreak-blue-latest", { inputTokens: 272_001, outputTokens: 10_000 }, "openai")!.contextTier).toBe("long");
     // Red aliases gpt-5.6-cyber, whose four long-context cells are all "-" — no tier at all,
     // so a large prompt must stay on the standard rate rather than inheriting the family rule.
     const redOver = alias("daybreak-red-latest", { inputTokens: 272_001, outputTokens: 10_000 })!;
     expect(redOver.contextTier).toBeUndefined();
     expect(redOver.cost.input / (272_001 / 1e6)).toBeCloseTo(12.5, 9);
 
-    // The Blue tier is scoped to openai-apikey: Daybreak is not routable on Codex login, so
-    // it must not drift back into the shared two-provider expansion.
-    expect(CONTEXT_TIERS.filter(t => t.modelId === "daybreak-blue-latest").map(t => t.provider)).toEqual(["openai-apikey"]);
+    // Blue tiers exist for both openai and openai-apikey.
+    expect(CONTEXT_TIERS.filter(t => t.modelId === "daybreak-blue-latest").map(t => t.provider)).toEqual(["openai", "openai-apikey"]);
+    expect(CONTEXT_TIERS.filter(t => t.modelId === "gpt-daybreak-blue-latest").map(t => t.provider)).toEqual(["openai", "openai-apikey"]);
     expect(CONTEXT_TIERS.some(t => t.modelId === "daybreak-red-latest")).toBe(false);
   });
 

--- a/tests/usage-cost.test.ts
+++ b/tests/usage-cost.test.ts
@@ -269,8 +269,8 @@ describe("resolveMatchedPrice", () => {
     expect(resolveMatchedPrice("openrouter", "anthropic-claude-3.5-sonnet")).toBeNull();
   });
 
-  test("16. shipped overlay membership: 59 keys, including Opus 5 and compatibility prices", () => {
-    expect(EXPECTED_PRICE_OVERLAYS.length).toBe(59);
+  test("16. shipped overlay membership: 56 keys, including Opus 5 and compatibility prices", () => {
+    expect(EXPECTED_PRICE_OVERLAYS.length).toBe(56);
     expect(EXPECTED_PRICE_OVERLAYS.some(row => row.status === "unverified")).toBe(false);
     const keys = new Set(EXPECTED_PRICE_OVERLAYS.map(row => `${row.provider}/${row.modelId}`));
     for (const expected of [
@@ -278,9 +278,6 @@ describe("resolveMatchedPrice", () => {
       "cursor/claude-opus-5",
       "kiro/claude-opus-5",
       "openai/gpt-daybreak-blue-latest",
-      "openai/daybreak-blue-latest",
-      "openai/daybreak-red-latest",
-      "openai-apikey/gpt-daybreak-blue-latest",
       "openai-apikey/daybreak-red-latest",
       "openai-apikey/daybreak-blue-latest",
       "minimax/MiniMax-M2.1-highspeed",
@@ -330,6 +327,13 @@ describe("resolveMatchedPrice", () => {
       "cursor/auto",
     ]) {
       expect(keys.has(expected)).toBe(true);
+    }
+    for (const impossible of [
+      "openai/daybreak-blue-latest",
+      "openai/daybreak-red-latest",
+      "openai-apikey/gpt-daybreak-blue-latest",
+    ]) {
+      expect(keys.has(impossible)).toBe(false);
     }
 
     const direct = findExpectedPriceOverlay("google", "gemini-3.6-flash");
@@ -772,22 +776,19 @@ describe("long-context pricing tiers (#908)", () => {
     // An alias is priced as its current snapshot, so the shipped rows are the real check.
     const red = resolveMatchedPrice("openai-apikey", "daybreak-red-latest");
     const blue = resolveMatchedPrice("openai-apikey", "daybreak-blue-latest");
-    const gptBlueApiKey = resolveMatchedPrice("openai-apikey", "gpt-daybreak-blue-latest");
     const gptBlueOpenAi = resolveMatchedPrice("openai", "gpt-daybreak-blue-latest");
-    const blueOpenAi = resolveMatchedPrice("openai", "daybreak-blue-latest");
     expect(red?.cost4).toEqual({ input: 12.5, output: 75, cacheRead: 1.25, cacheWrite: 15.625 });
     expect(blue?.cost4).toEqual({ input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 });
-    expect(gptBlueApiKey?.cost4).toEqual({ input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 });
     expect(gptBlueOpenAi?.cost4).toEqual({ input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 });
-    expect(blueOpenAi?.cost4).toEqual({ input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 });
     // verified-derived, never verified: the pricing page has no daybreak-* rows, only the
     // snapshots'. This status is also what keeps `estimated` on downstream, and an alias is
     // more drift-prone than a normal row because OpenAI can repoint it.
     expect(red?.status).toBe("verified-derived");
     expect(blue?.status).toBe("verified-derived");
-    expect(gptBlueApiKey?.status).toBe("verified-derived");
     expect(gptBlueOpenAi?.status).toBe("verified-derived");
-    expect(blueOpenAi?.status).toBe("verified-derived");
+    expect(resolveMatchedPrice("openai-apikey", "gpt-daybreak-blue-latest")).toBeNull();
+    expect(resolveMatchedPrice("openai", "daybreak-blue-latest")).toBeNull();
+    expect(resolveMatchedPrice("openai", "daybreak-red-latest")).toBeNull();
 
     const alias = (model: string, usage: Record<string, number>, provider = "openai-apikey") =>
       estimateRequestCost({ provider, model, usageStatus: "reported", usage });
@@ -802,9 +803,9 @@ describe("long-context pricing tiers (#908)", () => {
     expect(redOver.contextTier).toBeUndefined();
     expect(redOver.cost.input / (272_001 / 1e6)).toBeCloseTo(12.5, 9);
 
-    // Blue tiers exist for both openai and openai-apikey.
-    expect(CONTEXT_TIERS.filter(t => t.modelId === "daybreak-blue-latest").map(t => t.provider)).toEqual(["openai", "openai-apikey"]);
-    expect(CONTEXT_TIERS.filter(t => t.modelId === "gpt-daybreak-blue-latest").map(t => t.provider)).toEqual(["openai", "openai-apikey"]);
+    // Each spelling stays in the provider namespace where that selector is routable.
+    expect(CONTEXT_TIERS.filter(t => t.modelId === "daybreak-blue-latest").map(t => t.provider)).toEqual(["openai-apikey"]);
+    expect(CONTEXT_TIERS.filter(t => t.modelId === "gpt-daybreak-blue-latest").map(t => t.provider)).toEqual(["openai"]);
     expect(CONTEXT_TIERS.some(t => t.modelId === "daybreak-red-latest")).toBe(false);
   });
 

--- a/tests/usage-cost.test.ts
+++ b/tests/usage-cost.test.ts
@@ -570,6 +570,13 @@ describe("priority (Fast) service tier multiplier", () => {
     expect(PRIORITY_MULTIPLIERS["gpt-5.4-mini"]).toBe(2);
   });
 
+  test("P9b. Daybreak priority rules stay inside their routable provider namespace", () => {
+    expect(findPriorityPricingRule("openai", "gpt-daybreak-blue-latest")?.multiplier).toBe(2);
+    expect(findPriorityPricingRule("openai-apikey", "daybreak-blue-latest")?.multiplier).toBe(2);
+    expect(findPriorityPricingRule("openai-apikey", "gpt-daybreak-blue-latest")).toBeUndefined();
+    expect(findPriorityPricingRule("openai", "daybreak-blue-latest")).toBeUndefined();
+  });
+
   test("P10. attempt cost with priority tier", () => {
     const base = estimateAttemptCost({ ordinal: 1, provider: "openai", model: "gpt-5.6-sol", usageStatus: "reported", usage }, overlays);
     const fast = estimateAttemptCost({ ordinal: 1, provider: "openai", model: "gpt-5.6-sol", usageStatus: "reported", usage }, overlays, "priority");
@@ -778,8 +785,8 @@ describe("long-context pricing tiers (#908)", () => {
     const blue = resolveMatchedPrice("openai-apikey", "daybreak-blue-latest");
     const gptBlueOpenAi = resolveMatchedPrice("openai", "gpt-daybreak-blue-latest");
     expect(red?.cost4).toEqual({ input: 12.5, output: 75, cacheRead: 1.25, cacheWrite: 15.625 });
-    expect(blue?.cost4).toEqual({ input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 });
-    expect(gptBlueOpenAi?.cost4).toEqual({ input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 });
+    expect(blue?.cost4).toEqual({ input: 4, output: 20, cacheRead: 0.4, cacheWrite: 5 });
+    expect(gptBlueOpenAi?.cost4).toEqual({ input: 4, output: 20, cacheRead: 0.4, cacheWrite: 5 });
     // verified-derived, never verified: the pricing page has no daybreak-* rows, only the
     // snapshots'. This status is also what keeps `estimated` on downstream, and an alias is
     // more drift-prone than a normal row because OpenAI can repoint it.


### PR DESCRIPTION
## Summary

- Adds provider-scoped Daybreak pricing overlays for the routable model identities:
  - `openai/gpt-daybreak-blue-latest`
  - `openai-apikey/daybreak-blue-latest`
  - `openai-apikey/daybreak-red-latest`
- Prices Daybreak Blue using official `gpt-5.6-sol` rates ($4/$0.40/$5/$20) and Daybreak Red as `gpt-5.6-cyber`, including the supported Fast multiplier and 272k long-context tier for Blue.
- Scopes `PRIORITY_PRICING_RULES` strictly per routable provider namespace (`openai` vs `openai-apikey`) and adds negative test assertions to prevent unroutable combinations.
- Preserves `gpt-daybreak-blue-latest` as the request-log model after the authenticated wire request is normalized to `gpt-5.6-sol`, allowing `/api/logs`, `usage.jsonl`, and `/api/usage` to resolve the expected cost without replacing the user-selected identity.
- Distinguishes model icons in the dashboard: Daybreak Blue uses the Sun icon and Daybreak Red uses a cyber lock icon (`IconLock`).
- Adds regression coverage for cost resolution, provider scoping, negative cross-namespace priority rules, long-context pricing, canonical wire normalization, request-log model identity, and icon rendering.

## UI Evidence

![Daybreak model log details](https://github.com/user-attachments/assets/media_1787671267696.png)

## Verification

Passed:

- `bun test tests/usage-cost.test.ts tests/server-auth.test.ts tests/core-lab-boundary.test.ts` — 174 tests
- `cd gui && bun test tests` — 985 tests (including icon rendering for Daybreak Red/Blue)
- `bun run typecheck`
- `bun run privacy:scan`
- `bun run lint:gui`
- `bun run build:gui`
- `cd gui && bun run lint`
- `cd gui && bun run build`

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Daybreak Blue and Daybreak Red model aliases.
  * Added Sun and Lock icons for recognized Daybreak models.
  * Added pricing, priority, and long-context handling for supported Daybreak Blue aliases.
* **Bug Fixes**
  * Improved model reporting so Daybreak requests retain their requested model identity.
  * Corrected GPT-5.6 Sol pricing.
  * Enhanced usage and cost reporting for Daybreak requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->