### PR TITLE
fix(google): clamp max output tokens per model, without inventing a ceiling for unknown ids (rebase of #2512)

### DIFF
--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -48,6 +48,25 @@ const GOOGLE_BREVITY_INSTRUCTION = [
   "- This applies only to intermediate progress text. Your final answer after the work is done is exempt: write it in full and at whatever length the task requires.",
 ].join("\n");
 
+export function maxOutputTokensForGoogleModel(modelId: string): number {
+  const lower = modelId.toLowerCase();
+  if (lower.includes("flash")) return 65536;
+  if (lower.includes("pro")) return 65535;
+  if (lower.includes("claude")) return 64000;
+  if (lower.includes("gpt-oss") || lower.includes("oss")) return 32768;
+  if (lower.startsWith("gemini")) return 65536;
+  return 16384;
+}
+
+export function clampGoogleMaxOutputTokens(
+  modelId: string,
+  requestedTokens?: number,
+): number | undefined {
+  if (requestedTokens === undefined || requestedTokens <= 0) return undefined;
+  const modelMax = maxOutputTokensForGoogleModel(modelId);
+  return Math.min(requestedTokens, modelMax);
+}
+
 /**
  * Some Google direct deployments expose current Gemini Flash generations with a `-tiered`
  * wire suffix (`gemini-3.7-flash` -> `gemini-3.7-flash-tiered`). Keep the picker-visible id
@@ -650,7 +669,8 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
       if (toolConfig) body.toolConfig = toolConfig;
 
       const generationConfig: Record<string, unknown> = {};
-      if (parsed.options.maxOutputTokens) generationConfig.maxOutputTokens = parsed.options.maxOutputTokens;
+      const clampedMaxOutputTokens = clampGoogleMaxOutputTokens(identityModelId, parsed.options.maxOutputTokens);
+      if (clampedMaxOutputTokens !== undefined) generationConfig.maxOutputTokens = clampedMaxOutputTokens;
       if (parsed.options.temperature !== undefined) generationConfig.temperature = parsed.options.temperature;
       if (parsed.options.topP !== undefined) generationConfig.topP = parsed.options.topP;
       if (parsed.options.stopSequences) generationConfig.stopSequences = parsed.options.stopSequences;

--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -48,14 +48,30 @@ const GOOGLE_BREVITY_INSTRUCTION = [
   "- This applies only to intermediate progress text. Your final answer after the work is done is exempt: write it in full and at whatever length the task requires.",
 ].join("\n");
 
-export function maxOutputTokensForGoogleModel(modelId: string): number {
-  const lower = modelId.toLowerCase();
-  if (lower.includes("flash")) return 65536;
-  if (lower.includes("pro")) return 65535;
-  if (lower.includes("claude")) return 64000;
-  if (lower.includes("gpt-oss") || lower.includes("oss")) return 32768;
-  if (lower.startsWith("gemini")) return 65536;
-  return 16384;
+/**
+ * Documented output ceiling for a Google-surface model, or `undefined` when the id is not
+ * recognized.
+ *
+ * Unknown ids return `undefined` deliberately. An earlier revision returned a 16,384 floor for
+ * anything unmatched, which silently truncated aliases, gateway ids, and any model added after
+ * this table was written — the operator asked for N tokens and got 16,384 with no signal. A cap
+ * we cannot justify is worse than no cap: `structure/02_config-and-codex-home.md` is explicit
+ * that an explicit request value wins, so an unrecognized model passes through untouched and the
+ * upstream remains the authority on its own limit.
+ *
+ * Matching is prefix/family based rather than substring based for the same reason: `includes("pro")`
+ * matched any id containing "pro" (`my-prototype-model`), and `includes("oss")` matched any id
+ * containing "oss" (`crossover-v2`).
+ */
+export function maxOutputTokensForGoogleModel(modelId: string): number | undefined {
+  const lower = modelId.toLowerCase().trim();
+  if (lower.startsWith("gemini")) {
+    // Pro tops out one token below the flash/other Gemini ceiling; both are documented values.
+    return /(^|[-.])pro([-.]|$)/.test(lower) ? 65535 : 65536;
+  }
+  if (lower.startsWith("claude")) return 64000;
+  if (lower.startsWith("gpt-oss")) return 32768;
+  return undefined;
 }
 
 export function clampGoogleMaxOutputTokens(
@@ -64,6 +80,8 @@ export function clampGoogleMaxOutputTokens(
 ): number | undefined {
   if (requestedTokens === undefined || requestedTokens <= 0) return undefined;
   const modelMax = maxOutputTokensForGoogleModel(modelId);
+  // Unknown model: honour the request as-is rather than inventing a ceiling for it.
+  if (modelMax === undefined) return requestedTokens;
   return Math.min(requestedTokens, modelMax);
 }
 

--- a/tests/google-output-clamp.test.ts
+++ b/tests/google-output-clamp.test.ts
@@ -9,7 +9,22 @@ describe("google maxOutputTokens clamp", () => {
     expect(maxOutputTokensForGoogleModel("claude-3-7-sonnet")).toBe(64000);
     expect(maxOutputTokensForGoogleModel("claude-3-5-sonnet@20241022")).toBe(64000);
     expect(maxOutputTokensForGoogleModel("gpt-oss-120b")).toBe(32768);
-    expect(maxOutputTokensForGoogleModel("custom-unknown-model")).toBe(16384);
+  });
+
+  test("an unrecognized model has no invented ceiling", () => {
+    // A cap we cannot justify silently truncates the operator's explicit request. Aliases,
+    // gateway ids, and models newer than this table must pass through untouched.
+    expect(maxOutputTokensForGoogleModel("custom-unknown-model")).toBeUndefined();
+    expect(clampGoogleMaxOutputTokens("custom-unknown-model", 128000)).toBe(128000);
+    expect(maxOutputTokensForGoogleModel("some-gateway/gemini-3-pro")).toBeUndefined();
+  });
+
+  test("family matching does not fire on incidental substrings", () => {
+    // "includes(pro)" matched my-prototype-model; "includes(oss)" matched crossover-v2.
+    expect(maxOutputTokensForGoogleModel("my-prototype-model")).toBeUndefined();
+    expect(maxOutputTokensForGoogleModel("crossover-v2")).toBeUndefined();
+    expect(maxOutputTokensForGoogleModel("gemini-3-pro-preview")).toBe(65535);
+    expect(maxOutputTokensForGoogleModel("gemini-3.5-flash")).toBe(65536);
   });
 
   test("downward clamps excessive requested tokens to model max", () => {

--- a/tests/google-output-clamp.test.ts
+++ b/tests/google-output-clamp.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { clampGoogleMaxOutputTokens, maxOutputTokensForGoogleModel } from "../src/adapters/google";
+
+describe("google maxOutputTokens clamp", () => {
+  test("returns model-specific max output tokens limit", () => {
+    expect(maxOutputTokensForGoogleModel("gemini-3.7-flash")).toBe(65536);
+    expect(maxOutputTokensForGoogleModel("gemini-3.7-flash-tiered")).toBe(65536);
+    expect(maxOutputTokensForGoogleModel("gemini-3-pro")).toBe(65535);
+    expect(maxOutputTokensForGoogleModel("claude-3-7-sonnet")).toBe(64000);
+    expect(maxOutputTokensForGoogleModel("claude-3-5-sonnet@20241022")).toBe(64000);
+    expect(maxOutputTokensForGoogleModel("gpt-oss-120b")).toBe(32768);
+    expect(maxOutputTokensForGoogleModel("custom-unknown-model")).toBe(16384);
+  });
+
+  test("downward clamps excessive requested tokens to model max", () => {
+    expect(clampGoogleMaxOutputTokens("gemini-3.7-flash", 128000)).toBe(65536);
+    expect(clampGoogleMaxOutputTokens("gemini-3-pro", 100000)).toBe(65535);
+    expect(clampGoogleMaxOutputTokens("claude-3-7-sonnet", 100000)).toBe(64000);
+    expect(clampGoogleMaxOutputTokens("gpt-oss-120b", 64000)).toBe(32768);
+  });
+
+  test("preserves requested tokens when within model max", () => {
+    expect(clampGoogleMaxOutputTokens("gemini-3.7-flash", 4096)).toBe(4096);
+    expect(clampGoogleMaxOutputTokens("gemini-3-pro", 8192)).toBe(8192);
+    expect(clampGoogleMaxOutputTokens("claude-3-7-sonnet", 32000)).toBe(32000);
+  });
+
+  test("returns undefined when requested tokens is undefined or non-positive", () => {
+    expect(clampGoogleMaxOutputTokens("gemini-3.7-flash", undefined)).toBeUndefined();
+    expect(clampGoogleMaxOutputTokens("gemini-3.7-flash", 0)).toBeUndefined();
+    expect(clampGoogleMaxOutputTokens("gemini-3.7-flash", -10)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Rebase of #2512 (by @Hsia97) onto current `dev`, with the review finding fixed.

The original change clamps Google-surface output tokens per model. The review objected to
two things, both real:

1. **An invented ceiling for unknown models.** Anything unmatched fell back to 16,384, so
   an alias, a gateway-prefixed id, or any model newer than the table was silently
   truncated no matter what the operator requested. `structure/02_config-and-codex-home.md`
   is explicit that an explicit request value wins. Unknown ids now return `undefined` and
   the request passes through untouched — the upstream stays the authority on its own limit.
2. **Substring matching.** `includes("pro")` matched `my-prototype-model` and
   `includes("oss")` matched `crossover-v2`. Matching is now prefix/family based.

The original test asserted the 16,384 fallback, which locked the defect in; it is replaced
with assertions for the passthrough contract and for the substring cases.

Closes #2512.

## Verification

```
$ bun test tests/google-output-clamp.test.ts
 6 pass, 0 fail

$ bun test tests/google-errors.test.ts tests/google-output-clamp.test.ts
 16 pass, 0 fail, 109 expect() calls

$ bun x tsc --noEmit
(clean)
```

`clampGoogleMaxOutputTokens` has a single call site (`src/adapters/google.ts:690`), which
is unaffected by the widened return type.

## Checklist

- [x] Targets `dev`
- [x] Rebased onto the current `dev` head (2/2, no conflicts)
- [x] Typecheck clean after the return-type change
- [x] Original authorship preserved in the commit history
- [x] No secrets or account identifiers in the diff



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Google model requests now automatically respect documented output-token limits.
  * Valid token requests are preserved, while excessive values are reduced to the supported maximum.
  * Invalid or non-positive token values continue to be omitted.
  * Unknown model types retain their requested limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->