### PR TITLE
fix(google): stabilize thought-signature replay and evict rejected signatures on every mode (rebase of #2513)

### DIFF
--- a/src/adapters/google-antigravity-replay.ts
+++ b/src/adapters/google-antigravity-replay.ts
@@ -19,6 +19,7 @@ import { enforceAppOwnedMemoryBudget } from "../lib/app-owned-memory";
 
 interface ReplayCall {
   signature: string;
+  signatures?: string[];
   sizeBytes: number;
   touchedAtMs: number;
 }
@@ -34,6 +35,7 @@ interface ReplayEntry {
 }
 
 const MIN_SIGNATURE_LEN = 16;
+const MAX_SIGNATURES_PER_CALL = 32;
 const REPLAY_TTL_MS = 60 * 60 * 1000; // 1h
 export const ANTIGRAVITY_REPLAY_MAX_ENTRIES = 10_240;
 const REPLAY_EVICT_BATCH = 128;
@@ -103,16 +105,38 @@ function loadReplaySnapshotEntry(key: string, value: unknown): void {
   for (const pair of rec.byCall) {
     if (!Array.isArray(pair) || pair.length !== 2 || typeof pair[0] !== "string") continue;
     if (!/^[0-9a-f]{64}$/.test(pair[0])) continue;
-    const call = pair[1] as { signature?: unknown; touchedAtMs?: unknown } | null;
+    const call = pair[1] as { signature?: unknown; signatures?: unknown; touchedAtMs?: unknown } | null;
     if (!call || typeof call !== "object" || Array.isArray(call)) continue;
     if (typeof call.signature !== "string" || call.signature.length < MIN_SIGNATURE_LEN) continue;
     if (typeof call.touchedAtMs !== "number" || !Number.isFinite(call.touchedAtMs)) continue;
-    // Never trust a serialized sizeBytes: a forged snapshot could claim a tiny
-    // size for a huge signature and bypass every byte cap. Recompute from the
-    // signature itself, exactly like the live write path.
-    const signatureBytes = utf8.encode(call.signature).byteLength;
-    if (signatureBytes > replayLimits.maxSignatureBytes) continue;
-    const callBytes = utf8.encode(pair[0]).byteLength + signatureBytes;
+    let sigs: string[] = [];
+    if (Array.isArray(call.signatures)) {
+      for (const s of call.signatures) {
+        if (typeof s === "string" && s.length >= MIN_SIGNATURE_LEN) {
+          sigs.push(s);
+        }
+      }
+    }
+    if (sigs.length === 0) {
+      sigs = [call.signature];
+    } else if (!sigs.includes(call.signature)) {
+      sigs.push(call.signature);
+    }
+    if (sigs.length > MAX_SIGNATURES_PER_CALL) {
+      sigs = sigs.slice(-MAX_SIGNATURES_PER_CALL);
+    }
+    let totalSigBytes = 0;
+    let anySigOversized = false;
+    for (const s of sigs) {
+      const sb = utf8.encode(s).byteLength;
+      if (sb > replayLimits.maxSignatureBytes) {
+        anySigOversized = true;
+        break;
+      }
+      totalSigBytes += sb;
+    }
+    if (anySigOversized) continue;
+    const callBytes = utf8.encode(pair[0]).byteLength + totalSigBytes;
     if (callBytes > replayLimits.maxBytesPerSession) continue;
     // A duplicated call key would overstate entry.bytes (the map keeps only the
     // last value) and could evict valid sessions; keep the first occurrence.
@@ -122,6 +146,7 @@ function loadReplaySnapshotEntry(key: string, value: unknown): void {
     }
     byCall.set(pair[0], {
       signature: call.signature,
+      signatures: sigs,
       sizeBytes: callBytes,
       touchedAtMs: call.touchedAtMs,
     });
@@ -226,7 +251,11 @@ async function persistReplaySnapshotNow(): Promise<void> {
     for (const [key, entry] of [...replayCache].sort((a, b) => b[1].lastActiveAtMs - a[1].lastActiveAtMs)) {
       const byCall = [...entry.byCall].map(([callKey, call]) => [
         callKey,
-        { signature: call.signature, touchedAtMs: call.touchedAtMs },
+        {
+          signature: call.signature,
+          ...(call.signatures && call.signatures.length > 1 ? { signatures: call.signatures } : {}),
+          touchedAtMs: call.touchedAtMs,
+        },
       ]);
       const persistEntry: [string, unknown] = [key, {
         byCall,
@@ -644,10 +673,37 @@ export function observeAntigravityReplay(
     const ck = functionCallKey(fc.name, fc.args);
     if (!ck) continue; // only function-call signatures are replayable by identity
     const signatureBytes = utf8.encode(callSig).byteLength;
-    const sizeBytes = utf8.encode(ck).byteLength + signatureBytes;
-    if (signatureBytes > replayLimits.maxSignatureBytes || sizeBytes > replayLimits.maxBytesPerSession) continue;
+    if (signatureBytes > replayLimits.maxSignatureBytes) continue;
+
+    const existingCall = entry.byCall.get(ck);
+    let sigs: string[];
+    if (existingCall) {
+      sigs = existingCall.signatures && existingCall.signatures.length > 0
+        ? [...existingCall.signatures]
+        : [existingCall.signature];
+      if (!sigs.includes(callSig)) {
+        if (sigs.length >= MAX_SIGNATURES_PER_CALL) {
+          sigs.shift();
+        }
+        sigs.push(callSig);
+      }
+    } else {
+      sigs = [callSig];
+    }
+    let totalSigBytes = 0;
+    for (const s of sigs) {
+      totalSigBytes += utf8.encode(s).byteLength;
+    }
+    const sizeBytes = utf8.encode(ck).byteLength + totalSigBytes;
+    if (sizeBytes > replayLimits.maxBytesPerSession) continue;
+
     deleteReplayCall(entry, ck);
-    entry.byCall.set(ck, { signature: callSig, sizeBytes, touchedAtMs: now });
+    entry.byCall.set(ck, {
+      signature: callSig,
+      signatures: sigs,
+      sizeBytes,
+      touchedAtMs: now,
+    });
     entry.bytes += sizeBytes;
     replayBytes += sizeBytes;
     inserted = true;
@@ -692,15 +748,22 @@ export function applyAntigravityReplay(model: string, sessionId: string, content
   if (!entry) {
     return contents;
   }
+
   let touched = false;
-  for (const c of contents as { role?: string; parts?: unknown[] }[]) {
+  // Align from the END of the recorded signature list. History may have been truncated
+  // (compaction / previous_response_id): the last remaining occurrence is the most recent call,
+  // so it must receive the newest signature. Iterate backwards and count every occurrence
+  // (signed or not) so signed Mechanism-① parts still occupy their chronological slot.
+  const reverseOccurrence = new Map<string, number>();
+  for (let ci = (contents as { role?: string; parts?: unknown[] }[]).length - 1; ci >= 0; ci--) {
+    const c = (contents as { role?: string; parts?: unknown[] }[])[ci];
     if (!c || typeof c !== "object" || c.role !== "model" || !Array.isArray(c.parts)) continue;
-    for (const raw of c.parts) {
+    for (let pi = c.parts.length - 1; pi >= 0; pi--) {
+      const raw = c.parts[pi];
       if (!raw || typeof raw !== "object") continue;
       const part = raw as Record<string, unknown>;
       const fc = part.functionCall as { name?: unknown; args?: unknown } | undefined;
       if (!fc) continue;
-      if (part.thoughtSignature !== undefined || part.thought_signature !== undefined) continue;
       const ck = functionCallKey(fc.name, fc.args);
       let call = ck ? entry.byCall.get(ck) : undefined;
       let matchedKey = ck;
@@ -717,27 +780,43 @@ export function applyAntigravityReplay(model: string, sessionId: string, content
           ) {
             try {
               const parsedInput = JSON.parse(trimmedInput);
-            if (parsedInput && typeof parsedInput === "object") {
-              const altKey = functionCallKey(fc.name, parsedInput);
-              if (altKey && entry.byCall.has(altKey)) {
-                call = entry.byCall.get(altKey);
-                matchedKey = altKey;
+              if (parsedInput && typeof parsedInput === "object") {
+                const altKey = functionCallKey(fc.name, parsedInput);
+                if (altKey && entry.byCall.has(altKey)) {
+                  call = entry.byCall.get(altKey);
+                  matchedKey = altKey;
+                }
               }
-            }
             } catch {
               // not JSON, keep default
             }
           }
         }
       }
-      if (call && matchedKey) {
+      if (matchedKey) {
+        const revIdx = reverseOccurrence.get(matchedKey) ?? 0;
+        reverseOccurrence.set(matchedKey, revIdx + 1);
+        if (part.thoughtSignature !== undefined || part.thought_signature !== undefined) {
+          // Already signed (e.g. Mechanism ① or upstream response), preserve it.
+          continue;
+        }
+        if (call) {
+          const sigs = call.signatures && call.signatures.length > 0 ? call.signatures : [call.signature];
+          const chosenSig = revIdx < sigs.length
+            ? sigs[sigs.length - 1 - revIdx]
+            : sigs[sigs.length - 1] ?? call.signature;
+          part.thoughtSignature = chosenSig;
+          entry.byCall.delete(matchedKey);
+          entry.byCall.set(matchedKey, { ...call, touchedAtMs: now });
+          touched = true;
+        }
+      } else if (part.thoughtSignature === undefined && part.thought_signature === undefined && call) {
         part.thoughtSignature = call.signature;
-        entry.byCall.delete(matchedKey);
-        entry.byCall.set(matchedKey, { ...call, touchedAtMs: now });
         touched = true;
       }
     }
   }
+
   if (touched) {
     entry.lastActiveAtMs = now;
     refreshReplaySessionCandidate(replayKey(model, sessionId), entry);

--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -671,14 +671,23 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
     const text = errorMessage ?? "";
     const isInvalidArgument = /invalid_argument|invalid argument/i.test(text);
     const isSignatureError = /signature|thought_signature|thoughtSignature/i.test(text);
-    if (provider.googleMode === "cloud-code-assist" || provider.googleMode === "vertex") {
-      if (replayModel && replaySession && (isInvalidArgument || isSignatureError)) {
-        clearAntigravityReplay(replayModel, replaySession);
-      }
-      if (isSignatureError) {
-        for (const callId of lastInjectedCallIds) {
-          forgetThoughtSignatureForReplay(callId, lastReasoningReplayScope);
-        }
+    // The in-memory Antigravity replay cache only exists for CCA/Vertex, so clearing it stays
+    // scoped to those modes (replayModel/replaySession are undefined elsewhere anyway).
+    if (
+      (provider.googleMode === "cloud-code-assist" || provider.googleMode === "vertex")
+      && replayModel && replaySession && (isInvalidArgument || isSignatureError)
+    ) {
+      clearAntigravityReplay(replayModel, replaySession);
+    }
+    // The DURABLE store is not mode-scoped: signatures are remembered through
+    // rememberAndSerializeExtraContent and read back by lookupReplayThoughtSignature on every
+    // Google mode, including AI Studio. Gating eviction on CCA/Vertex therefore left AI Studio
+    // with rejected signatures cached forever, replaying them into every subsequent turn — the
+    // store poisons itself and the request keeps failing. Eviction follows the same scope the
+    // write does.
+    if (isSignatureError) {
+      for (const callId of lastInjectedCallIds) {
+        forgetThoughtSignatureForReplay(callId, lastReasoningReplayScope);
       }
     }
   }

--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -26,7 +26,7 @@ import { identifyRoutedModel } from "./identity";
 import { antigravityUsesReplayCache, applyAntigravityReplay, clearAntigravityReplay, observeAntigravityReplay } from "./google-antigravity-replay";
 import { resolveAntigravityEffortWireModel } from "../providers/antigravity-models";
 import { googleVertexLocationConfigError } from "../providers/google-vertex-location";
-import { lookupReplayThoughtSignature } from "../responses/thought-signature-replay";
+import { forgetThoughtSignatureForReplay, lookupReplayThoughtSignature } from "../responses/thought-signature-replay";
 import {
   isTranslatorBudgetExceededError,
   retainTranslatedEventBatch,
@@ -221,7 +221,7 @@ function geminiOrphanToolResultParts(msg: OcxToolResultMessage): unknown[] {
 function messagesToGeminiFormat(
   parsed: OcxParsedRequest,
   identityModelId: string,
-): { systemInstruction?: unknown; contents: unknown[] } {
+): { systemInstruction?: unknown; contents: unknown[]; replayedCallIds: string[] } {
   // Neutralize Codex's GPT-5 identity line (Gemini/Antigravity share this path) so a routed model
   // never misreports as GPT-5/OpenAI, and never leaks the proxy identity upstream.
   const toolCatalogNudge = buildNonOpenAIToolCatalogNudgeForTools(parsed.context.tools, parsed.options.toolChoice);
@@ -233,6 +233,7 @@ function messagesToGeminiFormat(
   const systemInstruction = { parts: [{ text: systemText }] };
 
   const contents: unknown[] = [];
+  const replayedCallIds: string[] = [];
 
   const callIds = createToolCallIdAllocator();
   for (const msg of parsed.context.messages) {
@@ -308,7 +309,10 @@ function messagesToGeminiFormat(
             const signature = tc.providerMetadata?.google?.thoughtSignature
               ?? tc.thoughtSignature
               ?? lookupReplayThoughtSignature(tc.id, parsed._reasoningReplayScope);
-            if (isLikelyRealThoughtSignature(signature)) part.thoughtSignature = signature;
+            if (isLikelyRealThoughtSignature(signature)) {
+              part.thoughtSignature = signature;
+              replayedCallIds.push(tc.id);
+            }
             parts.push(part);
           }
         }
@@ -360,7 +364,7 @@ function messagesToGeminiFormat(
     }
   }
 
-  return { systemInstruction, contents };
+  return { systemInstruction, contents, replayedCallIds };
 }
 
 function toolsToGeminiFormat(parsed: OcxParsedRequest): unknown[] | undefined {
@@ -647,6 +651,38 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
   let vertexReplayModel: string | undefined;
   let vertexReplaySession: string | undefined;
   let restoreGoogleToolName = (name: string): string => name;
+  let lastInjectedCallIds: string[] = [];
+  let lastReasoningReplayScope: OcxParsedRequest["_reasoningReplayScope"];
+
+  // Conservative batch invalidation: upstream Gemini/Antigravity errors (e.g.
+  // "Function call is missing a thought_signature in functionCall parts") do not specify which
+  // specific call_id was rejected. When a request containing replayed signatures is rejected,
+  // we evict all callIds injected in that turn (lastInjectedCallIds) from the durable store
+  // and clear the session replay cache, preventing poisoned-signature loops while allowing
+  // subsequent turns to re-accumulate valid signatures. Unrelated calls from other turns remain intact.
+  //
+  // Memory-cache clearing stays broad (any invalid-argument/signature error can poison the
+  // session replay cache), but durable-store eviction is intentionally narrower: it only runs
+  // when the error text explicitly mentions a signature, so a generic tool-schema
+  // INVALID_ARGUMENT does not destroy valid durable signatures.
+  function handleSignatureRejection(errorMessage?: string) {
+    const replayModel = provider.googleMode === "cloud-code-assist" ? antigravityModel : vertexReplayModel;
+    const replaySession = provider.googleMode === "cloud-code-assist" ? antigravitySession : vertexReplaySession;
+    const text = errorMessage ?? "";
+    const isInvalidArgument = /invalid_argument|invalid argument/i.test(text);
+    const isSignatureError = /signature|thought_signature|thoughtSignature/i.test(text);
+    if (provider.googleMode === "cloud-code-assist" || provider.googleMode === "vertex") {
+      if (replayModel && replaySession && (isInvalidArgument || isSignatureError)) {
+        clearAntigravityReplay(replayModel, replaySession);
+      }
+      if (isSignatureError) {
+        for (const callId of lastInjectedCallIds) {
+          forgetThoughtSignatureForReplay(callId, lastReasoningReplayScope);
+        }
+      }
+    }
+  }
+
   return {
     name: "google",
 
@@ -675,7 +711,9 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
           : resolveDirectGeminiWireModelId(parsed.modelId, provider.directGeminiWireRenames !== false);
       // AI Studio's `-tiered` spelling is wire-only; CCA aliases may migrate to another generation.
       const identityModelId = provider.googleMode === "cloud-code-assist" ? routedModelId : parsed.modelId;
-      const { systemInstruction, contents } = messagesToGeminiFormat(parsed, identityModelId);
+      const { systemInstruction, contents, replayedCallIds } = messagesToGeminiFormat(parsed, identityModelId);
+      lastInjectedCallIds = [...replayedCallIds];
+      lastReasoningReplayScope = parsed._reasoningReplayScope;
       const tools = toolsToGeminiFormat(parsed);
 
       const body: Record<string, unknown> = { contents };
@@ -902,14 +940,9 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
         if (chunk.error) {
           const err = chunk.error as { message?: string } | undefined;
           // Clear-on-invalid: a signature rejection means our replayed thoughtSignatures are stale.
-          // Drop the cache entry so the next turn starts clean instead of re-injecting a bad sig.
-          const replayModel = provider.googleMode === "cloud-code-assist" ? antigravityModel : vertexReplayModel;
-          const replaySession = provider.googleMode === "cloud-code-assist" ? antigravitySession : vertexReplaySession;
-          if ((provider.googleMode === "cloud-code-assist" || provider.googleMode === "vertex")
-            && replayModel && replaySession
-            && /signature|invalid_argument|invalid argument/i.test(err?.message ?? "")) {
-            clearAntigravityReplay(replayModel, replaySession);
-          }
+          // Drop the cache entry and durable store entry for rejected calls so the next turn
+          // starts clean instead of re-injecting a bad sig.
+          handleSignatureRejection(err?.message);
           yield { type: "error", message: err?.message ?? "upstream error" };
           return "terminate";
         }
@@ -1224,6 +1257,7 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
       };
       if (raw.error) {
         const err = raw.error as { message?: string };
+        handleSignatureRejection(err.message);
         return finish([{ type: "error", message: err.message ?? "upstream error" }]);
       }
       // Antigravity (CCA) nests the standard Gemini payload under `response`; unwrap it.

--- a/src/responses/thought-signature-replay.ts
+++ b/src/responses/thought-signature-replay.ts
@@ -308,6 +308,23 @@ export function lookupReplayThoughtSignature(
   return entry.sig;
 }
 
+/** Drop a remembered signature for a specific callId and scope (e.g. when upstream rejects it). */
+export function forgetThoughtSignatureForReplay(
+  callId: string,
+  scope: OcxReasoningReplayScopeRef | undefined,
+): boolean {
+  const key = keyFor(callId, scope);
+  if (key === undefined) return false;
+  load();
+  const entry = entries.get(key);
+  if (!entry) return false;
+  entries.delete(key);
+  totalBytes -= entry.sig.length;
+  prune(Date.now());
+  void persist();
+  return true;
+}
+
 /** Test seams: clear in-memory state and the loaded flag without touching the file. */
 export function resetThoughtSignatureReplayForTests(): void {
   entries = new Map();

--- a/tests/google-antigravity-replay.test.ts
+++ b/tests/google-antigravity-replay.test.ts
@@ -25,7 +25,13 @@ import {
 } from "../src/adapters/google-antigravity-replay";
 import { sanitizeAntigravityClaudeSignatures } from "../src/adapters/google-antigravity-wire";
 
-afterEach(() => setAntigravityReplayLimitsForTests());
+import { setAsyncIcaclsRunnerForTests, setIcaclsRunnerForTests } from "../src/lib/windows-secret-acl";
+
+afterEach(() => {
+  setAntigravityReplayLimitsForTests();
+  setIcaclsRunnerForTests(null);
+  setAsyncIcaclsRunnerForTests(null);
+});
 
 // Sandbox OPENCODEX_HOME: the replay cache now snapshots to disk, and these tests must
 // never touch the real ~/.opencodex.
@@ -33,6 +39,8 @@ let replayTestHome: string;
 const priorOpenCodexHome = process.env["OPENCODEX_HOME"];
 
 beforeEach(() => {
+  setIcaclsRunnerForTests(() => ({ success: true, exitCode: 0, timedOut: false, stdout: "processed file: 1" }));
+  setAsyncIcaclsRunnerForTests(async () => ({ success: true, exitCode: 0, timedOut: false, stdout: "processed file: 1" }));
   replayTestHome = mkdtempSync(join(tmpdir(), "ocx-antigravity-replay-test-"));
   process.env["OPENCODEX_HOME"] = replayTestHome;
 });

--- a/tests/google-signature-history-roundtrip.test.ts
+++ b/tests/google-signature-history-roundtrip.test.ts
@@ -7,16 +7,22 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createGoogleAdapter as createGoogleAdapterProduction } from "../src/adapters/google";
-import { __resetAntigravityReplayCache, observeAntigravityReplay } from "../src/adapters/google-antigravity-replay";
+import {
+  __resetAntigravityReplayCache,
+  applyAntigravityReplay,
+  observeAntigravityReplay,
+} from "../src/adapters/google-antigravity-replay";
 import { parseRequest } from "../src/responses/parser";
 import {
   flushThoughtSignatureReplayForTests,
+  forgetThoughtSignatureForReplay,
   lookupReplayThoughtSignature,
   rememberThoughtSignatureForReplay,
   resetThoughtSignatureReplayForTests,
 } from "../src/responses/thought-signature-replay";
 import { durableReplayDestinationIdentity } from "../src/responses/reasoning-replay-cache";
-import type { AdapterEvent, OcxParsedRequest, OcxProviderConfig } from "../src/types";
+import { setAsyncIcaclsRunnerForTests, setIcaclsRunnerForTests } from "../src/lib/windows-secret-acl";
+import type { AdapterEvent, OcxParsedRequest, OcxProviderConfig, OcxReasoningReplayScopeRef } from "../src/types";
 import { withTestTranslatorBudget } from "./helpers/translator-budget";
 
 const createGoogleAdapter = (...args: Parameters<typeof createGoogleAdapterProduction>) =>
@@ -40,7 +46,6 @@ const aiStudioProvider = {
   apiKey: "ai-studio-test-key",
 } as OcxProviderConfig;
 
-
 /**
  * A replay scope is now REQUIRED for the store to remember or return anything: a
  * client-visible call_id is not unique across threads, accounts, providers or models,
@@ -51,7 +56,7 @@ function scopeFor(
   modelId = MODEL,
   providerName = "google",
   destination = "https://generativelanguage.googleapis.com",
-) {
+): OcxReasoningReplayScopeRef {
   return {
     clientThreadId: threadId,
     current: {
@@ -68,9 +73,12 @@ function scopeFor(
 }
 
 /** parseRequest with the replay scope bound, as the server does after route selection. */
-function parseRequestScoped(body: unknown, scope = scopeFor()) {
-  return parseRequest(body, { replayCacheScope: scope });
+function parseRequestScoped(body: unknown, scope = scopeFor()): OcxParsedRequest {
+  const req = parseRequest(body, { replayCacheScope: scope });
+  req._reasoningReplayScope = scope;
+  return req;
 }
+
 function firstTurn(): OcxParsedRequest {
   return {
     modelId: MODEL,
@@ -108,11 +116,19 @@ function sseResponse(frames: string[]): Response {
   return new Response(stream);
 }
 
+const fcPart = (name: string, args: unknown, sig?: string) => {
+  const part: Record<string, unknown> = { functionCall: { name, args } };
+  if (sig) part.thoughtSignature = sig;
+  return part;
+};
+
 describe("#1735 thought signature survives history replay", () => {
   let previousHome: string | undefined;
   let testDir: string;
 
   beforeEach(() => {
+    setIcaclsRunnerForTests(() => ({ success: true, exitCode: 0, timedOut: false, stdout: "processed file: 1" }));
+    setAsyncIcaclsRunnerForTests(async () => ({ success: true, exitCode: 0, timedOut: false, stdout: "processed file: 1" }));
     __resetAntigravityReplayCache();
     resetThoughtSignatureReplayForTests();
     previousHome = process.env.OPENCODEX_HOME;
@@ -120,10 +136,14 @@ describe("#1735 thought signature survives history replay", () => {
     process.env.OPENCODEX_HOME = testDir;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await flushThoughtSignatureReplayForTests();
+    resetThoughtSignatureReplayForTests();
     if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
     else process.env.OPENCODEX_HOME = previousHome;
     rmSync(testDir, { recursive: true, force: true });
+    setIcaclsRunnerForTests(null);
+    setAsyncIcaclsRunnerForTests(null);
   });
 
   test("the adapter attaches the signature to the tool call that produced it", async () => {
@@ -413,67 +433,47 @@ describe("#1735 thought signature survives history replay", () => {
     expect(part?.thoughtSignature).toBeUndefined();
   });
 
-
   test("the same call_id in a different thread does not borrow the signature (#1823)", () => {
-    // A client-visible call_id is not unique. Keyed on it alone, one conversation's
-    // signature was handed to another's replay -- and a second thread writing the same
-    // id silently overwrote the first.
     rememberThoughtSignatureForReplay("call_shared", SIGNATURE, scopeFor("thread-a"));
-
     expect(lookupReplayThoughtSignature("call_shared", scopeFor("thread-a"))).toBe(SIGNATURE);
     expect(lookupReplayThoughtSignature("call_shared", scopeFor("thread-b"))).toBeUndefined();
   });
 
   test("a different account or model is a different scope (#1823)", () => {
     rememberThoughtSignatureForReplay("call_scoped", SIGNATURE, scopeFor("thread-a", MODEL, "google"));
-
     expect(lookupReplayThoughtSignature("call_scoped", scopeFor("thread-a", MODEL, "google"))).toBe(SIGNATURE);
-    // Same thread and call id, different provider identity: opaque signatures are not
-    // portable across providers, so this must miss rather than cross-contaminate.
     expect(lookupReplayThoughtSignature("call_scoped", scopeFor("thread-a", MODEL, "antigravity"))).toBeUndefined();
-    // Same thread and provider, different model.
     expect(lookupReplayThoughtSignature("call_scoped", scopeFor("thread-a", "gemini-3.6-pro", "google"))).toBeUndefined();
   });
 
   test("a conflicting signature under one key fails closed instead of overwriting (#1823)", () => {
     expect(rememberThoughtSignatureForReplay("call_conflict", SIGNATURE, scopeFor()).result).toBe("stored");
-    // Re-remembering the same value is a no-op, not a conflict: retries are ordinary.
     expect(rememberThoughtSignatureForReplay("call_conflict", SIGNATURE, scopeFor()).result).toBe("already-equal");
-    // A DIFFERENT value under the same complete key means two upstream turns claimed one
-    // identity. Keeping the first is the fail-closed choice; last-write-wins would let a
-    // later turn silently invalidate an earlier replay.
     expect(rememberThoughtSignatureForReplay("call_conflict", SIGNATURE_B, scopeFor()).result).toBe("conflict");
     expect(lookupReplayThoughtSignature("call_conflict", scopeFor())).toBe(SIGNATURE);
   });
 
   test("an incomplete scope remembers nothing rather than remembering globally (#1823)", () => {
-    // A partially identified entry is exactly the cross-thread collision this store exists
-    // to prevent, so it must not be stored under a degraded key.
     expect(rememberThoughtSignatureForReplay("call_unscoped", SIGNATURE, undefined).result).toBe("unscoped");
     expect(rememberThoughtSignatureForReplay("call_unscoped", SIGNATURE, { clientThreadId: "t" }).result).toBe("unscoped");
     expect(lookupReplayThoughtSignature("call_unscoped", scopeFor())).toBeUndefined();
   });
 
   test("a store write reports when it is durable (#1823)", async () => {
-    // The caller can await this before exposing the tool-call item, so a client cannot
-    // observe a call whose signature was never persisted.
     const { result, durable } = rememberThoughtSignatureForReplay("call_durable", SIGNATURE, scopeFor());
     expect(result).toBe("stored");
     await durable;
     expect(lookupReplayThoughtSignature("call_durable", scopeFor())).toBe(SIGNATURE);
   });
+
   test("the proxy-side store survives a process restart via its snapshot", async () => {
     rememberThoughtSignatureForReplay("call_disk_1", SIGNATURE, scopeFor());
     await flushThoughtSignatureReplayForTests();
-    // Simulate a fresh process: drop in-memory state; lookup must reload from disk.
     resetThoughtSignatureReplayForTests();
     expect(lookupReplayThoughtSignature("call_disk_1", scopeFor())).toBe(SIGNATURE);
   });
 
   test("one provider name serving two endpoints does not share signatures", () => {
-    // The gap the durable key closes. providerName, adapterName, modelId and thread can all
-    // be identical across two upstreams — a gateway and a direct endpoint under one config
-    // name — and an opaque signature minted by one is meaningless to the other.
     const primary = scopeFor("thread-a", MODEL, "google", "https://generativelanguage.googleapis.com");
     const secondary = scopeFor("thread-a", MODEL, "google", "https://gateway.internal.example/v1beta");
 
@@ -484,14 +484,9 @@ describe("#1735 thought signature survives history replay", () => {
   });
 
   test("the durable destination identity is stable across restarts, unlike the process-local one", async () => {
-    // The reason this is a separate digest rather than the sibling cache's HMAC: that one is
-    // keyed by randomBytes minted at module load, so reusing it here would change every key
-    // on restart and the store would silently stop matching — a worse failure than the
-    // over-broad key it replaced, because it looks like it is working.
     const url = "https://generativelanguage.googleapis.com";
     expect(durableReplayDestinationIdentity(url)).toBe(durableReplayDestinationIdentity(url));
     expect(durableReplayDestinationIdentity(url)).not.toBe(durableReplayDestinationIdentity("https://other.example"));
-    // Trailing-slash normalization matches the process-local form.
     expect(durableReplayDestinationIdentity(`${url}/`)).toBe(durableReplayDestinationIdentity(url));
 
     rememberThoughtSignatureForReplay("call_dest_restart", SIGNATURE, scopeFor());
@@ -501,9 +496,6 @@ describe("#1735 thought signature survives history replay", () => {
   });
 
   test("adapter serialization reads the durable store with the post-parse bound scope (#1926 wiring)", async () => {
-    // The server parses BEFORE the route/credential scope exists, so the parser's own
-    // lookup cannot hit; the google adapter's serialization-time fallback must read the
-    // durable store once the scope identity has been bound.
     rememberThoughtSignatureForReplay("call_wire_1", SIGNATURE, scopeFor());
     await flushThoughtSignatureReplayForTests();
     const scope: { clientThreadId: string; current?: unknown } = { clientThreadId: "thread-a" };
@@ -517,7 +509,6 @@ describe("#1735 thought signature survives history replay", () => {
       ],
       tools: [{ type: "function", name: "shell_command", description: "run", parameters: { type: "object" } }],
     }, scope as never);
-    // Identity binds after parse, as bindRouteReasoningReplayScope does server-side.
     scope.current = scopeFor().current;
     parsed._reasoningReplayScope = scope as never;
     const adapter = createGoogleAdapter(provider);
@@ -525,5 +516,266 @@ describe("#1735 thought signature survives history replay", () => {
     const parts = modelParts(String(req.body));
     const fnPart = parts.find(p => (p as { functionCall?: unknown }).functionCall) as { thoughtSignature?: string } | undefined;
     expect(fnPart?.thoughtSignature).toBe(SIGNATURE);
+  });
+
+  test("adapter invalidation: clear-on-invalid evicts the rejected callId from durable store while preserving others", async () => {
+    const scope = scopeFor();
+    rememberThoughtSignatureForReplay("call_invalid_A", SIGNATURE, scope);
+    rememberThoughtSignatureForReplay("call_valid_B", SIGNATURE_B, scope);
+    await flushThoughtSignatureReplayForTests();
+
+    // Round 1: Turn containing call_invalid_A
+    const parsedA = parseRequestScoped({
+      model: MODEL,
+      stream: false,
+      input: [
+        { role: "user", content: [{ type: "input_text", text: "run A" }] },
+        { type: "function_call", call_id: "call_invalid_A", name: "shell_command", arguments: "{}" },
+        { type: "function_call_output", call_id: "call_invalid_A", output: "error" },
+      ],
+      tools: [{ type: "function", name: "shell_command", description: "run", parameters: { type: "object" } }],
+    }, scope);
+
+    const adapter = createGoogleAdapter(provider);
+    await adapter.buildRequest(parsedA);
+
+    // Upstream returns 400 Invalid Argument / thought_signature rejection
+    const errorResponse = new Response(JSON.stringify({
+      error: {
+        code: 400,
+        status: "INVALID_ARGUMENT",
+        message: "Invalid thought_signature provided for function call",
+      },
+    }));
+
+    const events = await adapter.parseResponse!(errorResponse);
+    expect(events[0].type).toBe("error");
+
+    // Verify call_invalid_A is evicted from durable store
+    expect(lookupReplayThoughtSignature("call_invalid_A", scope)).toBeUndefined();
+    // Verify call_valid_B remains intact in durable store
+    expect(lookupReplayThoughtSignature("call_valid_B", scope)).toBe(SIGNATURE_B);
+  });
+
+  test("adapter invalidation: multi-call request rejected by upstream performs conservative batch invalidation", async () => {
+    const scope = scopeFor();
+    const SIG_C = "CiQAx-history-thought-signature-third-call-77";
+    rememberThoughtSignatureForReplay("call_batch_1", SIGNATURE, scope);
+    rememberThoughtSignatureForReplay("call_batch_2", SIGNATURE_B, scope);
+    rememberThoughtSignatureForReplay("call_unrelated_3", SIG_C, scope);
+    await flushThoughtSignatureReplayForTests();
+
+    // Turn containing both call_batch_1 and call_batch_2:
+    const parsed = parseRequestScoped({
+      model: MODEL,
+      stream: false,
+      input: [
+        { role: "user", content: [{ type: "input_text", text: "run batch" }] },
+        { type: "function_call", call_id: "call_batch_1", name: "shell_command", arguments: "{}" },
+        { type: "function_call_output", call_id: "call_batch_1", output: "out1" },
+        { type: "function_call", call_id: "call_batch_2", name: "shell_command", arguments: "{}" },
+        { type: "function_call_output", call_id: "call_batch_2", output: "out2" },
+      ],
+      tools: [{ type: "function", name: "shell_command", description: "run", parameters: { type: "object" } }],
+    }, scope);
+
+    const adapter = createGoogleAdapter(provider);
+    await adapter.buildRequest(parsed);
+
+    // Upstream 400 rejection (Google error payload does not name which callId failed)
+    const errorResponse = new Response(JSON.stringify({
+      error: {
+        code: 400,
+        status: "INVALID_ARGUMENT",
+        message: "Function call is missing a thought_signature in functionCall parts",
+      },
+    }));
+
+    const events = await adapter.parseResponse!(errorResponse);
+    expect(events[0].type).toBe("error");
+
+    // Both injected callIds in the rejected request are evicted (conservative batch eviction)
+    expect(lookupReplayThoughtSignature("call_batch_1", scope)).toBeUndefined();
+    expect(lookupReplayThoughtSignature("call_batch_2", scope)).toBeUndefined();
+    // Unrelated call from another turn is preserved
+    expect(lookupReplayThoughtSignature("call_unrelated_3", scope)).toBe(SIG_C);
+  });
+});
+
+describe("Antigravity Multi-Signature History Stability (Mechanism ②)", () => {
+  beforeEach(() => {
+    __resetAntigravityReplayCache();
+  });
+
+  test("preserves chronological signatures across repeated identical tool calls", () => {
+    const sessionId = "session-hist-1";
+    const model = "gemini-3.7-flash";
+
+    // Round 1: Model calls bash(command: "ls"), returns sig1
+    observeAntigravityReplay(model, sessionId, [
+      fcPart("bash", { command: "ls" }, "sig-turn-1-abcdef123456"),
+    ]);
+
+    // Round 2: Model calls bash(command: "ls") again, returns sig2
+    observeAntigravityReplay(model, sessionId, [
+      fcPart("bash", { command: "ls" }, "sig-turn-2-ghijkl123456"),
+    ]);
+
+    // Round 3: Model calls bash(command: "ls") a third time, returns sig3
+    observeAntigravityReplay(model, sessionId, [
+      fcPart("bash", { command: "ls" }, "sig-turn-3-mnopqr123456"),
+    ]);
+
+    // Client now sends the full history of 3 tool calls without signatures:
+    const contents = [
+      {
+        role: "model",
+        parts: [{ functionCall: { name: "bash", args: { command: "ls" } } }],
+      },
+      {
+        role: "user",
+        parts: [{ functionResponse: { name: "bash", response: { output: "file1" } } }],
+      },
+      {
+        role: "model",
+        parts: [{ functionCall: { name: "bash", args: { command: "ls" } } }],
+      },
+      {
+        role: "user",
+        parts: [{ functionResponse: { name: "bash", response: { output: "file2" } } }],
+      },
+      {
+        role: "model",
+        parts: [{ functionCall: { name: "bash", args: { command: "ls" } } }],
+      },
+    ];
+
+    applyAntigravityReplay(model, sessionId, contents);
+
+    // Verify each occurrence gets its corresponding historical signature without prefix mutation:
+    const part1 = contents[0].parts[0] as { thoughtSignature?: string };
+    const part2 = contents[2].parts[0] as { thoughtSignature?: string };
+    const part3 = contents[4].parts[0] as { thoughtSignature?: string };
+
+    expect(part1.thoughtSignature).toBe("sig-turn-1-abcdef123456");
+    expect(part2.thoughtSignature).toBe("sig-turn-2-ghijkl123456");
+    expect(part3.thoughtSignature).toBe("sig-turn-3-mnopqr123456");
+  });
+
+  test("handles interleaved repeated and distinct tool calls correctly", () => {
+    const sessionId = "session-hist-interleaved";
+    const model = "gemini-3.7-flash";
+
+    // Round 1: Model calls read(file: "a.ts") -> sigA1
+    observeAntigravityReplay(model, sessionId, [
+      fcPart("read", { file: "a.ts" }, "sig-read-a-1-12345678"),
+    ]);
+
+    // Round 2: Model calls read(file: "b.ts") -> sigB1
+    observeAntigravityReplay(model, sessionId, [
+      fcPart("read", { file: "b.ts" }, "sig-read-b-1-12345678"),
+    ]);
+
+    // Round 3: Model calls read(file: "a.ts") again -> sigA2
+    observeAntigravityReplay(model, sessionId, [
+      fcPart("read", { file: "a.ts" }, "sig-read-a-2-12345678"),
+    ]);
+
+    const contents = [
+      { role: "model", parts: [{ functionCall: { name: "read", args: { file: "a.ts" } } }] },
+      { role: "user", parts: [{ functionResponse: { name: "read", response: { output: "aaa" } } }] },
+      { role: "model", parts: [{ functionCall: { name: "read", args: { file: "b.ts" } } }] },
+      { role: "user", parts: [{ functionResponse: { name: "read", response: { output: "bbb" } } }] },
+      { role: "model", parts: [{ functionCall: { name: "read", args: { file: "a.ts" } } }] },
+    ];
+
+    applyAntigravityReplay(model, sessionId, contents);
+
+    expect((contents[0].parts[0] as any).thoughtSignature).toBe("sig-read-a-1-12345678");
+    expect((contents[2].parts[0] as any).thoughtSignature).toBe("sig-read-b-1-12345678");
+    expect((contents[4].parts[0] as any).thoughtSignature).toBe("sig-read-a-2-12345678");
+  });
+
+
+
+  test("does not overwrite existing thoughtSignature provided by client", () => {
+    const sessionId = "session-hist-3";
+    const model = "gemini-3.7-flash";
+
+    observeAntigravityReplay(model, sessionId, [
+      fcPart("grep", { pattern: "test" }, "sig-cached-1234567890"),
+    ]);
+
+    const contents = [
+      {
+        role: "model",
+        parts: [{ functionCall: { name: "grep", args: { pattern: "test" } }, thoughtSignature: "client-provided-sig" }],
+      },
+    ];
+
+    applyAntigravityReplay(model, sessionId, contents);
+
+    const part = contents[0].parts[0] as { thoughtSignature?: string };
+    expect(part.thoughtSignature).toBe("client-provided-sig");
+  });
+});
+
+describe("Durable Thought-Signature Replay Store Single-Call Invalidation (Mechanism ①)", () => {
+  let previousHome: string | undefined;
+  let testDir: string;
+
+  const scope: OcxReasoningReplayScopeRef = {
+    clientThreadId: "thread-123",
+    current: {
+      providerName: "antigravity",
+      adapterName: "google",
+      modelId: "gemini-3.7-flash",
+      credentialDurableIdentity: "cred-xyz-12345",
+      providerDestinationDurableIdentity: "dest-abc-67890",
+    },
+  };
+
+  beforeEach(() => {
+    setIcaclsRunnerForTests(() => ({ success: true, exitCode: 0, timedOut: false, stdout: "processed file: 1" }));
+    setAsyncIcaclsRunnerForTests(async () => ({ success: true, exitCode: 0, timedOut: false, stdout: "processed file: 1" }));
+    resetThoughtSignatureReplayForTests();
+    previousHome = process.env.OPENCODEX_HOME;
+    testDir = mkdtempSync(join(tmpdir(), "ocx-tsig-inval-"));
+    process.env.OPENCODEX_HOME = testDir;
+  });
+
+  afterEach(async () => {
+    await flushThoughtSignatureReplayForTests();
+    resetThoughtSignatureReplayForTests();
+    if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+    else process.env.OPENCODEX_HOME = previousHome;
+    rmSync(testDir, { recursive: true, force: true });
+    setIcaclsRunnerForTests(null);
+    setAsyncIcaclsRunnerForTests(null);
+  });
+
+  test("can remember and selectively forget a specific callId", () => {
+    const callId1 = "call-001";
+    const callId2 = "call-002";
+    const sig1 = "sig-val-001-1234567890abcdef";
+    const sig2 = "sig-val-002-1234567890abcdef";
+
+    rememberThoughtSignatureForReplay(callId1, sig1, scope);
+    rememberThoughtSignatureForReplay(callId2, sig2, scope);
+
+    expect(lookupReplayThoughtSignature(callId1, scope)).toBe(sig1);
+    expect(lookupReplayThoughtSignature(callId2, scope)).toBe(sig2);
+
+    // Evict only callId1
+    const forgotten = forgetThoughtSignatureForReplay(callId1, scope);
+    expect(forgotten).toBe(true);
+
+    // callId1 is gone
+    expect(lookupReplayThoughtSignature(callId1, scope)).toBeUndefined();
+    // callId2 remains intact
+    expect(lookupReplayThoughtSignature(callId2, scope)).toBe(sig2);
+
+    // Forgetting non-existent callId returns false
+    expect(forgetThoughtSignatureForReplay("call-999", scope)).toBe(false);
   });
 });

--- a/tests/google-signature-history-roundtrip.test.ts
+++ b/tests/google-signature-history-roundtrip.test.ts
@@ -779,3 +779,85 @@ describe("Durable Thought-Signature Replay Store Single-Call Invalidation (Mecha
     expect(forgetThoughtSignatureForReplay("call-999", scope)).toBe(false);
   });
 });
+
+describe("#2513 rejected signatures are evicted on every Google mode", () => {
+  let previousHome: string | undefined;
+  let testDir: string;
+
+  beforeEach(() => {
+    setIcaclsRunnerForTests(() => ({ success: true, exitCode: 0, timedOut: false, stdout: "processed file: 1" }));
+    setAsyncIcaclsRunnerForTests(async () => ({ success: true, exitCode: 0, timedOut: false, stdout: "processed file: 1" }));
+    __resetAntigravityReplayCache();
+    resetThoughtSignatureReplayForTests();
+    previousHome = process.env.OPENCODEX_HOME;
+    testDir = mkdtempSync(join(tmpdir(), "ocx-tsig-mode-"));
+    process.env.OPENCODEX_HOME = testDir;
+  });
+
+  afterEach(async () => {
+    await flushThoughtSignatureReplayForTests();
+    resetThoughtSignatureReplayForTests();
+    if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+    else process.env.OPENCODEX_HOME = previousHome;
+    rmSync(testDir, { recursive: true, force: true });
+    setIcaclsRunnerForTests(null);
+    setAsyncIcaclsRunnerForTests(null);
+  });
+
+  /**
+   * The durable store is NOT mode-scoped: a signature is remembered and looked up on every
+   * Google mode, AI Studio included. Eviction used to be gated on cloud-code-assist/vertex,
+   * so an AI Studio turn whose signature the upstream rejected kept replaying that same
+   * rejected signature out of the store on every following turn.
+   */
+  for (const [label, modeProvider] of [
+    ["ai-studio", aiStudioProvider],
+    ["vertex", provider],
+  ] as const) {
+    test(`${label}: a rejected signature does not survive in the durable store`, async () => {
+      const scope = scopeFor("thread-evict", MODEL, "google");
+      const parsed = { ...firstTurn(), _reasoningReplayScope: scope } as unknown as OcxParsedRequest;
+
+      const adapter = createGoogleAdapter(modeProvider);
+      // Warm the store the way a real turn does, then replay it so the adapter records the
+      // call id as injected for this turn.
+      rememberThoughtSignatureForReplay("call_evict_1", SIGNATURE, scope);
+      await flushThoughtSignatureReplayForTests();
+      expect(lookupReplayThoughtSignature("call_evict_1", scope)).toBe(SIGNATURE);
+
+      const replayParsed = parseRequestScoped({
+        model: MODEL,
+        input: [
+          { type: "message", role: "user", content: [{ type: "input_text", text: "run pwd" }] },
+          {
+            type: "function_call",
+            call_id: "call_evict_1",
+            name: "shell_command",
+            arguments: JSON.stringify({ command: "pwd" }),
+          },
+          { type: "function_call_output", call_id: "call_evict_1", output: "/workspace" },
+        ],
+        tools: [{ type: "function", name: "shell_command", description: "run", parameters: { type: "object" } }],
+      }, scope);
+      await adapter.buildRequest(replayParsed);
+      void parsed;
+
+      // The upstream rejects the replayed signature.
+      const events = await adapter.parseResponse!(new Response(
+        JSON.stringify({
+          error: {
+            code: 400,
+            status: "INVALID_ARGUMENT",
+            message: "Function call is missing a thought_signature in functionCall parts",
+          },
+        }),
+        { status: 400 },
+      ));
+      expect(events.some((event: AdapterEvent) => event.type === "error")).toBe(true);
+
+      await flushThoughtSignatureReplayForTests();
+      expect(lookupReplayThoughtSignature("call_evict_1", scope)).toBeUndefined();
+    });
+  }
+});
+

--- a/tests/thought-signature-credential-scope.test.ts
+++ b/tests/thought-signature-credential-scope.test.ts
@@ -16,6 +16,7 @@ import {
   thoughtSignatureReplaySalt,
 } from "../src/responses/thought-signature-replay";
 import { durableReplayCredentialIdentity, durableReplayDestinationIdentity } from "../src/responses/reasoning-replay-cache";
+import { setAsyncIcaclsRunnerForTests, setIcaclsRunnerForTests } from "../src/lib/windows-secret-acl";
 
 const SIG = "CiQAx-credential-scope-signature-0123456789abcdef";
 
@@ -39,6 +40,8 @@ describe("#1926 durable credential scope", () => {
   let testDir: string;
 
   beforeEach(() => {
+    setIcaclsRunnerForTests(() => ({ success: true, exitCode: 0, timedOut: false, stdout: "processed file: 1" }));
+    setAsyncIcaclsRunnerForTests(async () => ({ success: true, exitCode: 0, timedOut: false, stdout: "processed file: 1" }));
     resetThoughtSignatureReplayForTests();
     previousHome = process.env.OPENCODEX_HOME;
     testDir = mkdtempSync(join(tmpdir(), "ocx-tsig-scope-"));
@@ -51,6 +54,8 @@ describe("#1926 durable credential scope", () => {
     if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
     else process.env.OPENCODEX_HOME = previousHome;
     rmSync(testDir, { recursive: true, force: true });
+    setIcaclsRunnerForTests(null);
+    setAsyncIcaclsRunnerForTests(null);
   });
 
   test("two credentials on one destination never share a signature", () => {


### PR DESCRIPTION
## Summary

Rebase of #2513 (by @Hsia97) onto current `dev`, with the review finding fixed.

The original change stabilizes thought-signature replay across repeated and truncated
history. The review objected that eviction was gated on `cloud-code-assist`/`vertex`
while the durable store is not mode-scoped, and that is correct: signatures are written by
`rememberAndSerializeExtraContent` and read back by `lookupReplayThoughtSignature` on
every Google mode, AI Studio included (`src/adapters/google.ts:311`).

So an AI Studio turn whose signature the upstream rejected kept that signature in the
store and replayed it into every following turn — the store poisons itself and the request
keeps failing with the same rejection. Eviction now follows the same scope the write does.

Clearing the in-memory Antigravity replay cache stays CCA/Vertex-scoped, because that
cache only exists for those modes.

The test-home isolation the review also asked for is already present on this branch
(`OPENCODEX_HOME` is redirected to an `mkdtemp` directory in `beforeEach`).

Closes #2513.

## Verification

The added regression was driven red first:

```
# with eviction re-gated on CCA/Vertex (the pre-fix behaviour)
$ bun test tests/google-signature-history-roundtrip.test.ts
 31 pass, 1 fail   <- only the ai-studio case fails

# with the fix
$ bun test tests/google-signature-history-roundtrip.test.ts
 32 pass, 0 fail

$ bun x tsc --noEmit
(clean)
```

The new block covers both `ai-studio` and `vertex` so the mode symmetry stays pinned.

## Checklist

- [x] Targets `dev`
- [x] Rebased onto the current `dev` head (1/1, no conflicts)
- [x] Regression driven red first, then green
- [x] Typecheck clean
- [x] Original authorship preserved in the commit history
- [x] No secrets or account identifiers in the diff



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replay of thought signatures across repeated and interleaved tool calls.
  * Preserved client-provided signatures and restored saved signatures after process restarts.
  * Improved handling of rejected signatures by removing invalid replay data consistently.
  * Added support for matching custom-tool JSON inputs against parsed arguments.

* **Reliability**
  * Enforced per-signature and per-session storage limits.
  * Added durable deletion and cleanup of invalid replay entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->