### PR TITLE
fix: disable Bun's fetch socket idle timeout for upstream provider requests (rebase of #2567)

### DIFF
--- a/src/server/claude-messages.ts
+++ b/src/server/claude-messages.ts
@@ -553,7 +553,7 @@ export async function fetchWithHeaderDeadline(
 ): Promise<HeaderDeadlineFetchResult> {
   const deadline = makeDeadline(timeoutMs, parent);
   try {
-    const upstream = await fetchImpl(input, { ...init, signal: deadline.signal });
+    const upstream = await fetchImpl(input, { ...init, signal: deadline.signal, timeout: 0 });
     return { kind: "response", upstream };
   } catch (error) {
     if (deadline.didExpire()) return { kind: "timeout" };

--- a/src/server/responses/fetch-helpers.ts
+++ b/src/server/responses/fetch-helpers.ts
@@ -69,7 +69,7 @@ export function providerFetch(
   };
   const httpFetch = Object.assign(
     (input: Parameters<typeof globalThis.fetch>[0], init?: RequestInit) =>
-      base(input, withUpstreamHttpVersion(input, init, provider)),
+      base(input, { ...withUpstreamHttpVersion(input, init, provider), timeout: 0 }),
     { preconnect },
   ) as typeof globalThis.fetch;
   // ChatGPT Codex backend: streaming turns ride the responses_websockets
@@ -139,6 +139,7 @@ export async function fetchWithHeaderTimeout(
       // indistinguishable from a pre-connection failure (#914).
       ...(manualRedirect ? { redirect: "manual" as const } : {}),
       signal: AbortSignal.any([abortSignal, timeout.signal]),
+      timeout: 0,
     });
   } finally {
     clearTimeout(timer);

--- a/tests/fetch-header-timeout.test.ts
+++ b/tests/fetch-header-timeout.test.ts
@@ -107,3 +107,85 @@ describe("fetchWithHeaderTimeout content-encoding policy", () => {
     expect(await readChunk(identityReader)).toBe("data: second\n\n");
   });
 });
+
+describe("#2567 the upstream fetch disables Bun's per-request idle timeout", () => {
+  /**
+   * Bun's default socket idle timeout kills a long-quiet upstream turn even though the
+   * application-level deadline (AbortSignal) has not fired. Passing `timeout: 0` disables the
+   * per-request idle timer; the signal remains the only deadline that can end the request.
+   *
+   * These pin the propagation on all three call sites, because the value is easy to drop in a
+   * refactor and its absence is invisible until a slow provider stalls in production.
+   */
+  function recordingFetch(): { calls: RequestInit[]; fetch: typeof globalThis.fetch } {
+    const calls: RequestInit[] = [];
+    const fetch = (async (_input: unknown, init?: RequestInit) => {
+      calls.push(init ?? {});
+      return new Response("ok");
+    }) as unknown as typeof globalThis.fetch;
+    return { calls, fetch };
+  }
+
+  test("providerFetch passes timeout: 0 to the underlying fetch", async () => {
+    const { providerFetch } = await import("../src/server/responses/fetch-helpers");
+    const { calls, fetch } = recordingFetch();
+    const provider = {
+      adapter: "openai-chat",
+      baseUrl: "https://upstream.example.test/v1",
+      fetch,
+    } as unknown as Parameters<typeof providerFetch>[0];
+
+    await providerFetch(provider)("https://upstream.example.test/v1/chat/completions", { method: "POST" });
+
+    expect(calls.length).toBe(1);
+    expect((calls[0] as { timeout?: number }).timeout).toBe(0);
+  });
+
+  test("fetchWithHeaderTimeout passes timeout: 0 while keeping its abort signal", async () => {
+    const server = startHeaderEchoServer();
+    const seen: RequestInit[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+      seen.push(init ?? {});
+      return originalFetch(input as string, init);
+    }) as unknown as typeof globalThis.fetch;
+    try {
+      await fetchWithHeaderTimeout(
+        server.url.toString(),
+        {},
+        new AbortController().signal,
+        1_000,
+        false,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(seen.length).toBeGreaterThan(0);
+    const init = seen[0] as { timeout?: number; signal?: AbortSignal };
+    expect(init.timeout).toBe(0);
+    // The application deadline must survive: disabling the idle timer is not the same as
+    // removing the deadline.
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test("fetchWithHeaderDeadline passes timeout: 0 to its injected fetch", async () => {
+    const { fetchWithHeaderDeadline } = await import("../src/server/claude-messages");
+    const { calls, fetch } = recordingFetch();
+
+    const result = await fetchWithHeaderDeadline(
+      "https://upstream.example.test/v1/messages",
+      { method: "POST" },
+      1_000,
+      undefined,
+      undefined,
+      fetch,
+    );
+
+    expect(result.kind).toBe("response");
+    expect(calls.length).toBe(1);
+    const init = calls[0] as { timeout?: number; signal?: AbortSignal };
+    expect(init.timeout).toBe(0);
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/tests/upstream-http-version.test.ts
+++ b/tests/upstream-http-version.test.ts
@@ -128,7 +128,11 @@ describe("providerFetch upstreamHttpVersion propagation", () => {
     const seen: { init?: RequestInit } = {};
     const fetcher = providerFetch(provider({ fetch: stubFetch(seen) }));
     await fetcher(HTTPS_URL, { method: "POST", body: "{}" });
-    expect(seen.init).toEqual({ method: "POST", body: "{}" });
+    // The caller's fields survive untouched and no protocol pin is invented. `timeout: 0` is
+    // added unconditionally (#2567) to disable Bun's per-request socket idle timer, so assert
+    // the caller's fields and the absence of a pin rather than exact object equality.
+    expect(seen.init).toMatchObject({ method: "POST", body: "{}" });
+    expect((seen.init as RequestInit & { protocol?: string })?.protocol).toBeUndefined();
   });
 
   test("no init still applies a pinned version to the fetch call", async () => {


### PR DESCRIPTION
## Summary

Rebase of #2567 (by @eschcam) onto current `dev`, plus the regression the hygiene gate
asked for.

Bun applies a per-request socket idle timeout by default, which can kill a long-quiet
upstream turn even though the application-level deadline has not fired. `timeout: 0`
disables that idle timer while leaving `AbortSignal` as the only deadline that can end
the request.

The original PR changed two source files and added no test, which is exactly what
`hygiene` / `enforce-target` flagged as `missing_regression_test`. This adds coverage
for all three call sites — `providerFetch`, `fetchWithHeaderTimeout`, and
`fetchWithHeaderDeadline` — and asserts the abort signal survives in each, since
disabling the idle timer must not be mistaken for removing the deadline.

One pre-existing assertion in `tests/upstream-http-version.test.ts` used exact object
equality on the forwarded init. Its intent is that no protocol pin is invented when the
provider declares none, so it now asserts the caller's fields plus the absent pin; the
unconditional `timeout: 0` no longer reads as a contract change.

Closes #2567.

## Verification

The new cases were driven red first — reverting the three call sites fails exactly the
three new assertions:

```
# with timeout: 0 removed from all three sites
$ bun test tests/fetch-header-timeout.test.ts
 3 pass, 3 fail

# with the fix
$ bun test tests/fetch-header-timeout.test.ts tests/claude-messages-endpoint.test.ts tests/upstream-http-version.test.ts
 63 pass, 0 fail, 212 expect() calls

$ bun x tsc --noEmit
(clean)
```

## Checklist

- [x] Targets `dev`
- [x] Rebased onto the current `dev` head (1/1, no conflicts)
- [x] Regression driven red first, then green
- [x] Typecheck clean
- [x] Original authorship preserved in the commit history
- [x] No secrets or account identifiers in the diff



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request timeout handling to prevent premature connection termination while preserving application-level deadlines and cancellation.

* **Tests**
  * Added regression coverage for timeout behavior across supported request paths.
  * Updated request configuration checks to account for the improved timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->