### PR TITLE
fix(catalog): resolve the verbosity default from config, not the registry

### DIFF
--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -650,15 +650,16 @@ function configuredVerbositySupport(name: string, prov: OcxProviderConfig | unde
   const explicit = prov ? modelRecordValue(prov.modelSupportsVerbosity, id) : undefined;
   if (explicit !== undefined) return explicit;
   if (!prov) return undefined;
-  const entry = (providerMatchesRegistryTransport(name, prov) ? getProviderRegistryEntry(name) : undefined)
-    ?? registryEntryForProviderDestination(prov);
-  if (!entry) return undefined;
-  const perModel = modelRecordValue(entry.modelSupportsVerbosity, id);
-  if (perModel !== undefined) return perModel;
-  // Provider-wide fallback. `modelSupportsVerbosity` only enumerates the ids present when the
-  // registry row was written, so a live-discovered model used to fall through here and
-  // re-advertise a control the upstream accepts and ignores. A per-model entry still wins.
-  return entry.supportsVerbosity;
+  void name;
+  // Provider-wide fallback for ids the per-model map does not enumerate — a live-discovered
+  // model would otherwise re-advertise a control the upstream accepts and ignores.
+  //
+  // Read from the PROVIDER CONFIG, never from PROVIDER_REGISTRY. A gather flight captures its
+  // registry authority up front and forbids any later registry read, so consulting the registry
+  // here made a custom-destination flight fall back to "configured" instead of serving its own
+  // discovery result (tests/codex-gather-authority.test.ts). `applyVerbosityDefaults` in
+  // providers/derive.ts materializes the registry default into the config at seed/enrich time.
+  return prov.supportsVerbosity;
 }
 
 export function applyProviderConfigHints(name: string, prov: OcxProviderConfig, model: CatalogModel, providerCap?: number): CatalogModel {

--- a/src/oauth/key-providers.ts
+++ b/src/oauth/key-providers.ts
@@ -19,7 +19,8 @@ export const KEY_LOGIN_PROVIDERS: Record<string, KeyLoginProvider> = deriveKeyLo
  * caller didn't already supply. Lets the vision/reasoning classification actually reach the saved
  * config (the GUI/API only send adapter/baseUrl/apiKey/defaultModel). No-op for unknown names.
  *
- * `modelSupportsReasoningSummaries` is deliberately excluded from what gets persisted. It is
+ * `modelSupportsReasoningSummaries` and the verbosity capability are deliberately excluded from
+ * what gets persisted. They are
  * registry-only metadata resolved at runtime, and this function feeds a config that is about to
  * be written to disk. Persisting today's registry defaults would freeze them as the user's own
  * overrides: a later registry correction — say we learn a model's backend rejects summary
@@ -30,9 +31,17 @@ export const KEY_LOGIN_PROVIDERS: Record<string, KeyLoginProvider> = deriveKeyLo
 export function enrichProviderFromCatalog(name: string, prov: OcxProviderConfig): void {
   const hadOwnSummaries = Object.hasOwn(prov, "modelSupportsReasoningSummaries");
   const submittedSummaries = prov.modelSupportsReasoningSummaries;
+  const hadOwnVerbosity = Object.hasOwn(prov, "modelSupportsVerbosity");
+  const submittedVerbosity = prov.modelSupportsVerbosity;
+  const hadOwnProviderVerbosity = Object.hasOwn(prov, "supportsVerbosity");
+  const submittedProviderVerbosity = prov.supportsVerbosity;
   enrichProviderFromRegistry(name, prov);
   if (hadOwnSummaries) prov.modelSupportsReasoningSummaries = submittedSummaries;
   else delete prov.modelSupportsReasoningSummaries;
+  if (hadOwnVerbosity) prov.modelSupportsVerbosity = submittedVerbosity;
+  else delete prov.modelSupportsVerbosity;
+  if (hadOwnProviderVerbosity) prov.supportsVerbosity = submittedProviderVerbosity;
+  else delete prov.supportsVerbosity;
 }
 
 export function isKeyLoginProvider(name: string): boolean {

--- a/src/providers/derive.ts
+++ b/src/providers/derive.ts
@@ -391,6 +391,32 @@ function serviceTierModelDefaultsFor(
 }
 
 /**
+ * Materialize the registry's verbosity opt-out into the provider config at seed/enrich time.
+ *
+ * The catalog hint pass must not read PROVIDER_REGISTRY: a gather flight captures its registry
+ * authority up front and forbids any later read, so consulting the registry per model turned
+ * every hint pass into a post-lookup read and dropped a custom-destination flight's own
+ * discovery result (tests/codex-gather-authority.test.ts).
+ *
+ * Registry values go in first so an explicit user entry still wins, matching
+ * `applyReasoningSummaryDefaults`. `supportsVerbosity` is the provider-wide default, expanded
+ * across the seeded model list so an id discovered later still inherits it through the same
+ * Record the hint pass already reads.
+ */
+function applyVerbosityDefaults(prov: OcxProviderConfig, entry: ProviderRegistryEntry | undefined): void {
+  if (!entry) return;
+  const perModel = entry.modelSupportsVerbosity;
+  if (!perModel && entry.supportsVerbosity === undefined) return;
+  prov.modelSupportsVerbosity = {
+    ...(perModel ?? {}),
+    ...(prov.modelSupportsVerbosity ?? {}),
+  };
+  if (entry.supportsVerbosity !== undefined) {
+    prov.supportsVerbosity ??= entry.supportsVerbosity;
+  }
+}
+
+/**
  * Last-resort enrichment for a provider whose NAME matches no registry id.
  *
  * #1100 was reported against a hand-added provider called "GLM" pointing at a vendor endpoint
@@ -426,6 +452,7 @@ export function enrichProviderFromRegistry(name: string, prov: OcxProviderConfig
     // destinations, so a templated or overridable base URL cannot be claimed by it.
     enrichReasoningSummariesByDestination(prov);
     applyServiceTierModelDefaults(prov, serviceTierModelDefaultsFor(registryEntryForProviderDestination(prov), prov));
+    applyVerbosityDefaults(prov, registryEntryForProviderDestination(prov));
     return;
   }
   const explicitDirectReasoning: DirectReasoningEffortOverrides = {
@@ -489,6 +516,7 @@ export function enrichProviderFromRegistry(name: string, prov: OcxProviderConfig
   if (prov.preserveResponsesReasoningContent === undefined && entry.preserveResponsesReasoningContent !== undefined) prov.preserveResponsesReasoningContent = entry.preserveResponsesReasoningContent;
   applyReasoningSummaryDefaults(prov, entry.modelSupportsReasoningSummaries);
   applyServiceTierModelDefaults(prov, serviceTierModelDefaultsFor(entry, prov));
+  applyVerbosityDefaults(prov, entry);
   // Registry-only repair policy (#938): fill only when the runtime provider has
   // no explicit policy, and deep-clone so saved/user values never alias the
   // registry constant.

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -348,6 +348,12 @@ export interface OcxProviderConfig {
    */
   modelSupportsVerbosity?: Record<string, boolean>;
   /**
+   * Provider-wide Codex Responses verbosity capability, applied to models the per-model map
+   * does not enumerate (a live-discovered id, for example). Materialized from the registry at
+   * seed/enrich time so the catalog hint pass never has to read PROVIDER_REGISTRY.
+   */
+  supportsVerbosity?: boolean;
+  /**
    * Per-model wire value for Responses `stream_options.reasoning_summary_delivery`.
    * Presence also advertises reasoning-summary support for that routed model.
    */


### PR DESCRIPTION
## Summary

Repairs a regression I introduced in #2578.

That PR added a provider-wide verbosity default and had the catalog hint pass read it from
`PROVIDER_REGISTRY`. A gather flight captures its registry authority up front and then
forbids any further registry read, so every hint pass became exactly that forbidden
post-lookup read: a custom-destination flight threw, fell back to `configured`, and lost
its own discovery result.

Bisected across the merge train — green at `4d3d2716e`, red from `844885ab1` (#2578).

The fix moves the registry lookup to where the other registry defaults already live:
`applyVerbosityDefaults` in `src/providers/derive.ts` materializes it into the provider
config at seed/enrich time, next to `applyReasoningSummaryDefaults` and
`applyServiceTierModelDefaults`. The hint pass now reads only the config and never touches
the registry.

`enrichProviderFromCatalog` strips both verbosity fields the same way it already strips
`modelSupportsReasoningSummaries`, so a registry default is never frozen into saved config
where a later correction could not reach the user (#1100). That invariant's own test caught
the first version of this patch, which is why the strip is here.

## Verification

```
$ bun test tests/codex-gather-authority.test.ts
 6 pass, 0 fail        # was 5 pass / 1 fail on dev

$ bun test tests/codex-catalog.test.ts tests/codex-gather-authority.test.ts tests/codex-tool-mode.test.ts
 211 pass, 0 fail, 918 expect() calls

$ bun test tests/openai-responses-passthrough.test.ts
 103 pass, 0 fail

$ bun x tsc --noEmit
(clean)
```

The #2503 behaviour this preserves — combo derivation keeping a member's opt-out, and a
live-discovered id inheriting the provider-wide default — stays covered by the tests added
in #2578.

## Checklist

- [x] Targets `dev`
- [x] Cause bisected to a specific commit, not guessed
- [x] The failing test is green and the surrounding suites pass
- [x] Typecheck clean
- [x] No secrets or account identifiers in the diff



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-wide support for configuring verbosity capabilities.
  * Improved handling of verbosity settings for individual models and dynamically discovered models.

* **Bug Fixes**
  * Preserved user-configured verbosity and reasoning-summary settings during provider enrichment.
  * Improved application of registry-based verbosity defaults across matched providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->