### PR TITLE
fix(kiro): preserve keyword-named composed properties

### DIFF
--- a/src/adapters/kiro-tools.ts
+++ b/src/adapters/kiro-tools.ts
@@ -103,7 +103,7 @@ function ensureRootObjectType(schema: unknown): Record<string, unknown> {
   // Seed with the root's own properties/required so a schema like
   // { type:"object", properties:{path}, required:["path"], oneOf:[...] } keeps them.
   if (obj.properties && typeof obj.properties === "object") {
-    Object.assign(props, sanitizeKiroSchema(obj.properties) as Record<string, unknown>);
+    Object.assign(props, sanitizeSchemaMap(obj.properties) as Record<string, unknown>);
   }
   if (Array.isArray(obj.required)) {
     for (const r of obj.required) if (typeof r === "string") required.add(r);
@@ -118,7 +118,7 @@ function ensureRootObjectType(schema: unknown): Record<string, unknown> {
       if (!variant || typeof variant !== "object" || Array.isArray(variant)) continue;
       const v = variant as Record<string, unknown>;
       if (v.properties && typeof v.properties === "object") {
-        Object.assign(props, sanitizeKiroSchema(v.properties) as Record<string, unknown>);
+        Object.assign(props, sanitizeSchemaMap(v.properties) as Record<string, unknown>);
       }
       if (mergeRequired && Array.isArray(v.required)) {
         for (const r of v.required) if (typeof r === "string") required.add(r);

--- a/tests/kiro-adapter.test.ts
+++ b/tests/kiro-adapter.test.ts
@@ -675,6 +675,16 @@ describe("kiro adapter — buildRequest", () => {
     const withDefs = await pick({ $defs: { X: { type: "string" } }, anyOf: [{ properties: { a: { $ref: "#/$defs/X" } } }] });
     expect(withDefs.$defs).toEqual({ X: { type: "string" } });
     expect(withDefs.properties).toEqual({ a: { $ref: "#/$defs/X" } });
+
+    // Property names remain data while flattening, even when they collide with rejected keywords.
+    const keywordNames = await pick({
+      properties: { format: { type: "string", format: "uuid" } },
+      required: ["format"],
+      oneOf: [{ properties: { pattern: { type: "string", pattern: "^x" } } }],
+    });
+    expect(keywordNames.properties.format).toEqual({ type: "string" });
+    expect(keywordNames.properties.pattern).toEqual({ type: "string" });
+    expect(keywordNames.required).toEqual(["format"]);
   });
 
   test("tool descriptions use deterministic model-specific caps without prompt injection", async () => {


### PR DESCRIPTION
## Summary

- Preserve Kiro tool property names such as `format` and `pattern` while flattening root `oneOf` / `anyOf` / `allOf` schemas.
- Reuse the existing schema-map sanitizer at both flattening sites, so property names survive while unsupported validation keywords inside each child schema are still removed.
- Add a regression covering both root-owned and composed keyword-named properties.

Closes #2571.

## Verification

- `bun test tests/kiro-adapter.test.ts` (Bun 1.4.0: 56 pass, 0 fail)
- `bun run typecheck`
- `bun run privacy:scan`
- `git diff --check`

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schema processing for properties named `format` or `pattern`.
  * Preserved these property names while correctly removing unsupported nested validation keywords.
  * Ensured root-level required fields remain intact when schemas are flattened.

* **Tests**
  * Added coverage for schema compositions involving reserved keyword property names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
