### PR TITLE
feat(cursor): catalog gemini-3.6/3.7-flash and expose the minimal effort rung

### DIFF
--- a/src/adapters/cursor/discovery.ts
+++ b/src/adapters/cursor/discovery.ts
@@ -257,6 +257,10 @@ export const CURSOR_STATIC_MODELS: readonly CursorModelInfo[] = normalizeCursorM
   { id: "gemini-3-pro-image-preview", contextWindow: CONTEXT_200K },
   { id: "gemini-3.1-pro", contextWindow: CONTEXT_GEMINI },
   { id: "gemini-3.5-flash", contextWindow: CONTEXT_200K },
+  // 260825 live GetUsableModels: both ship only as effort-suffixed ids, so each exposes a tier
+  // picker. 3.6 is the only Cursor model with a `minimal` rung.
+  { id: "gemini-3.6-flash", contextWindow: CONTEXT_GEMINI, supportsReasoningEffort: true },
+  { id: "gemini-3.7-flash", contextWindow: CONTEXT_GEMINI, supportsReasoningEffort: true },
 
   { id: "gpt-5-codex", contextWindow: CONTEXT_272K },
   { id: "gpt-5-fast", contextWindow: CONTEXT_272K },

--- a/src/adapters/cursor/effort-map.ts
+++ b/src/adapters/cursor/effort-map.ts
@@ -34,6 +34,10 @@ const CURSOR_MODEL_EFFORT_TIERS: Record<string, readonly string[]> = {
   "claude-opus-5-fast": ["low", "medium", "high"],
   "claude-sonnet-5": ["low", "medium", "high", "xhigh", "max"],
   "glm-5.2": ["high", "max"],
+  // 260825 live GetUsableModels. gemini-3.6-flash is the only Cursor model exposing `minimal`;
+  // listing it here is also what admits the suffix into CANONICAL_EFFORT_SUFFIXES below.
+  "gemini-3.6-flash": ["minimal", "low", "medium", "high"],
+  "gemini-3.7-flash": ["low", "medium", "high"],
   // 260814 preemptive: glm-5.3 seeded ahead of Cursor's lineup update. Unlike 5.2, Z.AI folds
   // 5.3 efforts into low/high/max (docs.z.ai/devpack/latest-model), so `low` is a real tier.
   "glm-5.3": ["low", "high", "max"],
@@ -70,6 +74,15 @@ export const CANONICAL_EFFORT_SUFFIXES: ReadonlySet<string> = new Set([
 ]);
 
 const CANONICAL_CODEX_EFFORT_ORDER = ["low", "medium", "high", "xhigh", "max"] as const;
+
+/**
+ * Picker order, which is the canonical ladder plus the declared sentinels that rank below `low`.
+ *
+ * `cursorModelEffortLadder` filters against this, so a tier absent from it is silently dropped
+ * from the Codex picker even though `cursorEffortSuffix` would happily send it. That is what
+ * hid `gemini-3.6-flash-minimal`, the one Cursor model with a `minimal` rung.
+ */
+const CURSOR_PICKER_EFFORT_ORDER = ["minimal", ...CANONICAL_CODEX_EFFORT_ORDER] as const;
 
 function normalizeRequestedEffort(reasoning: string | undefined): string | undefined {
   const normalized = reasoning?.toLowerCase();
@@ -119,7 +132,7 @@ export function cursorModelEffortLadder(baseModelId: string): string[] | undefin
   const tiers = CURSOR_MODEL_EFFORT_TIERS[baseModelId];
   if (!tiers || tiers.length === 0) return undefined;
   const tierSet = new Set(tiers);
-  return CANONICAL_CODEX_EFFORT_ORDER.filter(effort => tierSet.has(effort));
+  return CURSOR_PICKER_EFFORT_ORDER.filter(effort => tierSet.has(effort));
 }
 
 /** Base models known to carry a reasoning-effort suffix (everything else is sent bare). */

--- a/tests/cursor-effort-suffix.test.ts
+++ b/tests/cursor-effort-suffix.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createCursorRequest } from "../src/adapters/cursor/request-builder";
-import { cursorEffortSuffix, cursorModelEffortLadder } from "../src/adapters/cursor/effort-map";
+import { CANONICAL_EFFORT_SUFFIXES, cursorEffortSuffix, cursorModelEffortLadder } from "../src/adapters/cursor/effort-map";
+import { CURSOR_STATIC_MODELS, isCursorModelAvailableForAccount } from "../src/adapters/cursor/discovery";
 import type { OcxParsedRequest } from "../src/types";
 
 // Static fixture recorded from Cursor GetUsableModels on 2026-08-06. This pins the
@@ -197,5 +198,32 @@ describe("Cursor per-model reasoning-effort suffix", () => {
     expect(cursorModelEffortLadder("claude-opus-4-8")).toEqual(["low", "medium", "high", "xhigh", "max"]);
     expect(cursorModelEffortLadder("glm-5.2")).toEqual(["high", "max"]);
     expect(cursorModelEffortLadder("composer-2.5")).toBeUndefined();
+  });
+});
+
+describe("#2569 Cursor catalog tracks the live GetUsableModels roster", () => {
+  test("the two Gemini families the live roster exposes are catalogued", () => {
+    const ids = new Set(CURSOR_STATIC_MODELS.map(model => model.id));
+    expect(ids.has("gemini-3.6-flash")).toBe(true);
+    expect(ids.has("gemini-3.7-flash")).toBe(true);
+  });
+
+  test("gemini-3.6-flash exposes its minimal rung in the picker ladder", () => {
+    // minimal is not in the canonical five-rung order, so the ladder filter dropped it and the
+    // tier was unreachable from Codex even though the wire accepts it.
+    expect(cursorModelEffortLadder("gemini-3.6-flash")).toEqual(["minimal", "low", "medium", "high"]);
+    expect(cursorEffortSuffix("gemini-3.6-flash", "minimal")).toBe("minimal");
+    expect(CANONICAL_EFFORT_SUFFIXES.has("minimal")).toBe(true);
+  });
+
+  test("gemini-3.7-flash carries the low/medium/high ladder the wire lists", () => {
+    expect(cursorModelEffortLadder("gemini-3.7-flash")).toEqual(["low", "medium", "high"]);
+  });
+
+  test("both families survive live-discovery filtering from effort-suffixed wire ids", () => {
+    // The live roster lists ONLY suffixed ids for these models; a base id that does not match
+    // one of them is dropped from the routed catalog.
+    expect(isCursorModelAvailableForAccount("gemini-3.6-flash", ["gemini-3.6-flash-minimal"])).toBe(true);
+    expect(isCursorModelAvailableForAccount("gemini-3.7-flash", ["gemini-3.7-flash-high"])).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Closes #2569 (the catalog-drift half).

Measured against a live `GetUsableModels` roster on 2026-08-25: 204 wire ids normalizing
to 34 base models, while `CURSOR_STATIC_MODELS` carried 50 and listed neither
`gemini-3.6-flash` nor `gemini-3.7-flash`. Both ship only as effort-suffixed ids, so
without a catalog entry they were invisible to the routed catalog — a model the account can
actually use never appeared in the picker.

Adding them surfaced a second, quieter bug. `gemini-3.6-flash` is the only Cursor model
with a `minimal` rung, and `cursorModelEffortLadder` filtered against the canonical
five-rung order (`low`..`max`). So even once `minimal` was declared, the tier was dropped
from the Codex picker while `cursorEffortSuffix` was perfectly willing to send it —
declared but unreachable. The ladder now filters against a picker order that includes the
sentinels ranking below `low`.

Declaring `minimal` in the tier table is also what admits it into
`CANONICAL_EFFORT_SUFFIXES`, which is what lets live-discovery matching recognize
`gemini-3.6-flash-minimal` as the `gemini-3.6-flash` base id.

Remaining #2569 work (the `-thinking` families, the 13 static-only entries, and the
drifted ladders on the existing GPT/Claude rows) is deliberately not in this PR — the
`-thinking` axis needs a design decision about suffix ordering, which differs per family.

## Verification

```
$ bun test tests/cursor-effort-suffix.test.ts
 17 pass, 0 fail

$ bun test tests/cursor-effort-suffix.test.ts tests/cursor-discovery.test.ts tests/cursor-adapter.test.ts tests/cursor-request-builder.test.ts tests/codex-catalog.test.ts
 291 pass, 0 fail, 1310 expect() calls

$ bun x tsc --noEmit
(clean)
```

Behaviour confirmed directly against the adapter:

```
minimal admitted: true
3.6 ladder: [ "minimal", "low", "medium", "high" ]
3.7 ladder: [ "low", "medium", "high" ]
3.6 minimal -> minimal
3.6 live match: true      # from ["gemini-3.6-flash-minimal", ...]
3.7 live match: true      # from ["gemini-3.7-flash-low", ...]
```

## Checklist

- [x] Targets `dev`
- [x] Based on the current `dev` head
- [x] Regression coverage for both the catalog entries and the picker ladder
- [x] Typecheck clean
- [x] No secrets or account identifiers in the diff



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Gemini 3.6 Flash and Gemini 3.7 Flash models in Cursor.
  * Added reasoning effort options, including a minimal-effort tier for Gemini 3.6 Flash.
  * Made these models available when selected through effort-specific model IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->