### PR TITLE
feat(cursor): expose the explicit-thinking model families

### DIFF
--- a/src/adapters/cursor/discovery.ts
+++ b/src/adapters/cursor/discovery.ts
@@ -1,7 +1,9 @@
 import {
   CANONICAL_EFFORT_SUFFIXES,
   cursorModelEffortLadder,
+  cursorModelHasEffortTiers,
   cursorWireModelIdWithEffort,
+  CURSOR_THINKING_MODEL_IDS,
 } from "./effort-map";
 
 export interface CursorModelInfo {
@@ -261,6 +263,17 @@ export const CURSOR_STATIC_MODELS: readonly CursorModelInfo[] = normalizeCursorM
   // picker. 3.6 is the only Cursor model with a `minimal` rung.
   { id: "gemini-3.6-flash", contextWindow: CONTEXT_GEMINI, supportsReasoningEffort: true },
   { id: "gemini-3.7-flash", contextWindow: CONTEXT_GEMINI, supportsReasoningEffort: true },
+
+  // Explicit-thinking variants (260825 live roster). Exposed as first-class ids the same way the
+  // Opus Fast families were in 831810c13: `isCursorModelAvailableForAccount` matches a base id
+  // against `{base}`, `{base}-{effort}` and the family's wire form, and none of those ever
+  // matched a `-thinking` id, so every one of these was invisible in the routed catalog.
+  // Suffix ORDER differs per family; `cursorWireModelIdWithEffort` owns that mapping.
+  ...CURSOR_THINKING_MODEL_IDS.map(id => ({
+    id,
+    contextWindow: CONTEXT_200K,
+    supportsReasoningEffort: cursorModelHasEffortTiers(id),
+  })),
 
   { id: "gpt-5-codex", contextWindow: CONTEXT_272K },
   { id: "gpt-5-fast", contextWindow: CONTEXT_272K },

--- a/src/adapters/cursor/effort-map.ts
+++ b/src/adapters/cursor/effort-map.ts
@@ -38,6 +38,20 @@ const CURSOR_MODEL_EFFORT_TIERS: Record<string, readonly string[]> = {
   // listing it here is also what admits the suffix into CANONICAL_EFFORT_SUFFIXES below.
   "gemini-3.6-flash": ["minimal", "low", "medium", "high"],
   "gemini-3.7-flash": ["low", "medium", "high"],
+  // Explicit-thinking variants (260825 live roster). Tiers are the rungs the wire actually
+  // lists for each family, which is not always the same set the non-thinking id carries:
+  // 4.6-opus thinks only at high/max, 4.5-opus only at high, 4.6-sonnet only at medium.
+  "claude-opus-5-thinking": ["low", "medium", "high", "xhigh", "max"],
+  "claude-opus-5-thinking-fast": ["low", "medium", "high", "xhigh", "max"],
+  "claude-opus-4-8-thinking": ["low", "medium", "high", "xhigh", "max"],
+  "claude-opus-4-8-thinking-fast": ["low", "medium", "high", "xhigh", "max"],
+  "claude-opus-4-7-thinking": ["low", "medium", "high", "xhigh", "max"],
+  "claude-opus-4-7-thinking-fast": ["low", "medium", "high", "xhigh", "max"],
+  "claude-sonnet-5-thinking": ["low", "medium", "high", "xhigh", "max"],
+  "claude-fable-5-thinking": ["low", "medium", "high", "xhigh", "max"],
+  "claude-4.6-opus-thinking": ["high", "max"],
+  "claude-4.5-opus-thinking": ["high"],
+  "claude-4.6-sonnet-thinking": ["medium"],
   // 260814 preemptive: glm-5.3 seeded ahead of Cursor's lineup update. Unlike 5.2, Z.AI folds
   // 5.3 efforts into low/high/max (docs.z.ai/devpack/latest-model), so `low` is a real tier.
   "glm-5.3": ["low", "high", "max"],
@@ -74,6 +88,37 @@ export const CANONICAL_EFFORT_SUFFIXES: ReadonlySet<string> = new Set([
 ]);
 
 const CANONICAL_CODEX_EFFORT_ORDER = ["low", "medium", "high", "xhigh", "max"] as const;
+
+/**
+ * Cursor's explicit-thinking variants, exposed as first-class Codex model ids the same way the
+ * `-fast` families were.
+ *
+ * `source` is the id whose wire name the variant is built from; `order` is where Cursor puts the
+ * thinking marker relative to the effort rung. All three shapes exist in the live roster
+ * (GetUsableModels, 260825), and using the wrong one is rejected with ERROR_BAD_MODEL_NAME:
+ *
+ *   thinking-then-effort  claude-opus-5-thinking-high, claude-opus-5-thinking-high-fast
+ *   effort-then-thinking  claude-4.6-opus-high-thinking
+ *   bare                  claude-4.5-sonnet-thinking (the model has no effort rung)
+ */
+const CURSOR_THINKING_FAMILIES: Readonly<Record<string, { source: string; order: "thinking-then-effort" | "effort-then-thinking" | "bare" }>> = {
+  "claude-opus-5-thinking": { source: "claude-opus-5", order: "thinking-then-effort" },
+  "claude-opus-5-thinking-fast": { source: "claude-opus-5-fast", order: "thinking-then-effort" },
+  "claude-opus-4-8-thinking": { source: "claude-opus-4-8", order: "thinking-then-effort" },
+  "claude-opus-4-8-thinking-fast": { source: "claude-opus-4-8-fast", order: "thinking-then-effort" },
+  "claude-opus-4-7-thinking": { source: "claude-opus-4-7", order: "thinking-then-effort" },
+  "claude-opus-4-7-thinking-fast": { source: "claude-opus-4-7-fast", order: "thinking-then-effort" },
+  "claude-sonnet-5-thinking": { source: "claude-sonnet-5", order: "thinking-then-effort" },
+  "claude-fable-5-thinking": { source: "claude-fable-5", order: "thinking-then-effort" },
+  "claude-4.6-opus-thinking": { source: "claude-4.6-opus", order: "effort-then-thinking" },
+  "claude-4.5-opus-thinking": { source: "claude-4.5-opus", order: "effort-then-thinking" },
+  "claude-4.6-sonnet-thinking": { source: "claude-4.6-sonnet", order: "effort-then-thinking" },
+  "claude-4.5-sonnet-thinking": { source: "claude-4.5-sonnet", order: "bare" },
+  "claude-4-sonnet-thinking": { source: "claude-4-sonnet", order: "bare" },
+};
+
+/** Codex-facing ids for Cursor's explicit-thinking variants. */
+export const CURSOR_THINKING_MODEL_IDS = Object.keys(CURSOR_THINKING_FAMILIES);
 
 /**
  * Picker order, which is the canonical ladder plus the declared sentinels that rank below `low`.
@@ -146,6 +191,23 @@ export function cursorModelHasEffortTiers(baseModelId: string): boolean {
  * and send the base model plus requested_model parameters instead.
  */
 export function cursorWireModelIdWithEffort(baseModelId: string, effortSuffix: string): string {
+  const thinking = CURSOR_THINKING_FAMILIES[baseModelId];
+  if (thinking) {
+    const { source, order } = thinking;
+    // Cursor writes the thinking marker on either side of the effort depending on family
+    // (measured against GetUsableModels, 260825):
+    //   thinking-then-effort  claude-opus-5-thinking-high, ...-thinking-high-fast
+    //   effort-then-thinking  claude-4.6-opus-high-thinking
+    //   bare                  claude-4.5-sonnet-thinking (no effort rung at all)
+    // Sending the wrong order returns ERROR_BAD_MODEL_NAME, so this is not cosmetic.
+    if (order === "bare") return `${source}-thinking`;
+    if (order === "effort-then-thinking") return `${source}-${effortSuffix}-thinking`;
+    if (source.endsWith("-fast")) {
+      const stem = source.slice(0, -"-fast".length);
+      return `${stem}-thinking-${effortSuffix}-fast`;
+    }
+    return `${source}-thinking-${effortSuffix}`;
+  }
   if (baseModelId.endsWith("-fast")) {
     return `${baseModelId.slice(0, -"-fast".length)}-${effortSuffix}-fast`;
   }

--- a/tests/cursor-effort-suffix.test.ts
+++ b/tests/cursor-effort-suffix.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { createCursorRequest } from "../src/adapters/cursor/request-builder";
-import { CANONICAL_EFFORT_SUFFIXES, cursorEffortSuffix, cursorModelEffortLadder } from "../src/adapters/cursor/effort-map";
+import { CANONICAL_EFFORT_SUFFIXES, cursorEffortSuffix, cursorModelEffortLadder, cursorWireModelIdWithEffort, CURSOR_THINKING_MODEL_IDS } from "../src/adapters/cursor/effort-map";
 import { CURSOR_STATIC_MODELS, isCursorModelAvailableForAccount } from "../src/adapters/cursor/discovery";
 import type { OcxParsedRequest } from "../src/types";
 
@@ -227,3 +227,51 @@ describe("#2569 Cursor catalog tracks the live GetUsableModels roster", () => {
     expect(isCursorModelAvailableForAccount("gemini-3.7-flash", ["gemini-3.7-flash-high"])).toBe(true);
   });
 });
+
+describe("#2569 Cursor explicit-thinking variants", () => {
+  /**
+   * Suffix ORDER differs per family and the wrong one is rejected ERROR_BAD_MODEL_NAME.
+   * Cases recorded from the live GetUsableModels roster on 2026-08-25.
+   */
+  const WIRE_CASES: ReadonlyArray<readonly [string, string, string]> = [
+    ["claude-opus-5-thinking", "high", "claude-opus-5-thinking-high"],
+    ["claude-opus-5-thinking-fast", "max", "claude-opus-5-thinking-max-fast"],
+    ["claude-opus-4-8-thinking", "low", "claude-opus-4-8-thinking-low"],
+    ["claude-opus-4-8-thinking-fast", "xhigh", "claude-opus-4-8-thinking-xhigh-fast"],
+    ["claude-sonnet-5-thinking", "medium", "claude-sonnet-5-thinking-medium"],
+    ["claude-fable-5-thinking", "xhigh", "claude-fable-5-thinking-xhigh"],
+    // The marker moves to the END for these families.
+    ["claude-4.6-opus-thinking", "max", "claude-4.6-opus-max-thinking"],
+    ["claude-4.5-opus-thinking", "high", "claude-4.5-opus-high-thinking"],
+    ["claude-4.6-sonnet-thinking", "medium", "claude-4.6-sonnet-medium-thinking"],
+  ];
+
+  for (const [id, effort, expected] of WIRE_CASES) {
+    test(`${id} at ${effort} composes ${expected}`, () => {
+      expect(cursorWireModelIdWithEffort(id, effort)).toBe(expected);
+    });
+  }
+
+  test("families with no effort rung send the bare thinking id", () => {
+    expect(cursorWireModelIdWithEffort("claude-4.5-sonnet-thinking", "high")).toBe("claude-4.5-sonnet-thinking");
+    expect(cursorWireModelIdWithEffort("claude-4-sonnet-thinking", "low")).toBe("claude-4-sonnet-thinking");
+    expect(cursorModelEffortLadder("claude-4.5-sonnet-thinking")).toBeUndefined();
+  });
+
+  test("every thinking variant is catalogued and survives live-discovery filtering", () => {
+    const ids = new Set(CURSOR_STATIC_MODELS.map(model => model.id));
+    for (const id of CURSOR_THINKING_MODEL_IDS) expect(ids.has(id)).toBe(true);
+
+    // A base id is kept only when it matches a live wire id; before this change none of the
+    // -thinking forms matched, so every variant was invisible in the routed catalog.
+    expect(isCursorModelAvailableForAccount("claude-opus-5-thinking", ["claude-opus-5-thinking-high"])).toBe(true);
+    expect(isCursorModelAvailableForAccount("claude-4.6-opus-thinking", ["claude-4.6-opus-max-thinking"])).toBe(true);
+    expect(isCursorModelAvailableForAccount("claude-4.5-sonnet-thinking", ["claude-4.5-sonnet-thinking"])).toBe(true);
+  });
+
+  test("a thinking variant never collapses onto its non-thinking source", () => {
+    expect(cursorWireModelIdWithEffort("claude-opus-5", "high")).toBe("claude-opus-5-high");
+    expect(cursorWireModelIdWithEffort("claude-opus-5-fast", "high")).toBe("claude-opus-5-high-fast");
+  });
+});
+


### PR DESCRIPTION
## Summary

Second half of #2569: the `-thinking` families.

The live `GetUsableModels` roster carries 46 thinking wire ids across 13 families, and
`isCursorModelAvailableForAccount` matched none of them. It compares a configured base id
against `{base}`, `{base}-{effort}`, and the family's wire form; no `-thinking` id matches
any of those, so every variant was invisible in the routed catalog.

The awkward part is that the marker's position is family-dependent, and the wrong order is
rejected with `ERROR_BAD_MODEL_NAME`. All three shapes are live today: thinking-then-effort
(`claude-opus-5-thinking-high`, `claude-opus-5-thinking-max-fast`), effort-then-thinking
(`claude-4.6-opus-max-thinking`), and bare with no effort rung
(`claude-4.5-sonnet-thinking`). `cursorWireModelIdWithEffort` now owns that mapping, and
the variants are exposed as first-class Codex ids the same way the Opus Fast families were
in `831810c13`.

Tiers are per-family and are not always the source model's set: `claude-4.6-opus` thinks
only at high/max, `claude-4.5-opus` only at high, `claude-4.6-sonnet` only at medium.

## Verification

Composed every catalogued id/tier pair and checked each against the live roster:

```
wire ids matched: 46
MISMATCHES: none
```

Catalog coverage against the same roster:

```
static entries: 69
visible after live filter: 52     # was 41
thinking variants now visible: 13
```

```
$ bun test tests/cursor-effort-suffix.test.ts
 29 pass, 0 fail

$ bun test tests/cursor-effort-suffix.test.ts tests/cursor-discovery.test.ts tests/cursor-adapter.test.ts tests/cursor-request-builder.test.ts tests/codex-catalog.test.ts
 303 pass, 0 fail, 1340 expect() calls

$ bun x tsc --noEmit
(clean)
```

## Checklist

- [x] Targets `dev`
- [x] Based on the current `dev` head
- [x] Every composed wire id verified against a live account roster
- [x] Regression pins all three suffix orders and the no-collapse rule
- [x] Typecheck clean
- [x] No secrets or account identifiers in the diff

