### PR TITLE
fix(cli): render quota bars in ocx provider quota

### DIFF
--- a/src/cli/account-extended.ts
+++ b/src/cli/account-extended.ts
@@ -279,7 +279,7 @@ function quotaParts(quota: ProviderQuotaDto): string[] {
   return parts;
 }
 
-function providerQuotaLine(name: string, report: ProviderQuotaReportDto): string {
+export function providerQuotaLine(name: string, report: ProviderQuotaReportDto): string {
   return [name, ...quotaParts(report.quota)].join(" ");
 }
 

--- a/src/cli/provider-runtime.ts
+++ b/src/cli/provider-runtime.ts
@@ -11,6 +11,13 @@ import {
   takeOption,
   type RuntimeApiDeps,
 } from "./runtime-api";
+import { providerQuotaLine } from "./account-extended";
+import type { ProviderQuotaReportDto } from "./account-api";
+
+interface ProviderQuotasDto {
+  generatedAt?: number;
+  reports?: ProviderQuotaReportDto[];
+}
 
 const USAGE = `Usage:
   ocx provider edit <name> [--adapter <id>] [--base-url <url>] [--default-model <id|->]
@@ -107,8 +114,15 @@ async function quota(argv: string[], deps: RuntimeApiDeps): Promise<void> {
   const wantsJson = takeFlag(args, "--json");
   const refresh = takeFlag(args, "--refresh");
   rejectArgs(args, USAGE);
-  const result = await runtimeRequest(`/api/provider-quotas${refresh ? "?refresh=1" : ""}`, {}, deps);
-  printData(result, wantsJson, summaryLines(result));
+  const result = await runtimeRequest<ProviderQuotasDto>(`/api/provider-quotas${refresh ? "?refresh=1" : ""}`, {}, deps);
+  // `summaryLines` is a depth-1 flattener: it renders a non-scalar array as "N item(s)", which
+  // collapsed the whole report to a count and made the command useless for its stated purpose
+  // (#2565). Render one line per report with the same formatter `ocx account refresh` uses.
+  const reports = Array.isArray(result?.reports) ? result.reports : [];
+  const lines = reports.length > 0
+    ? reports.map(report => providerQuotaLine(report.provider, report))
+    : ["no quota reports available"];
+  printData(result, wantsJson, lines);
 }
 
 async function presets(argv: string[], deps: RuntimeApiDeps): Promise<void> {

--- a/tests/cli-headless-parity.test.ts
+++ b/tests/cli-headless-parity.test.ts
@@ -9,6 +9,7 @@ import { handleConfigCommand } from "../src/cli/config-command";
 import { handleClientIntegrationCommand, handleGrokCommand } from "../src/cli/integrations";
 import { handleModelsRuntimeCommand } from "../src/cli/models-runtime";
 import { handleProviderRuntimeCommand } from "../src/cli/provider-runtime";
+import { providerQuotaLine } from "../src/cli/account-extended";
 
 type Recorded = { path: string; method: string; body: unknown };
 const servers: Array<ReturnType<typeof Bun.serve>> = [];
@@ -689,5 +690,43 @@ describe("headless GUI parity CLI", () => {
       else process.env.OPENCODEX_HOME = previous;
       rmSync(home, { recursive: true, force: true });
     }
+  });
+});
+
+describe("#2565 ocx provider quota renders bars, not a count", () => {
+  /**
+   * `quota()` rendered the response through `summaryLines()`, a depth-1 flattener that emits
+   * "N item(s)" for a non-scalar array. Every fetched report was discarded and the default
+   * invocation printed only `generatedAt` and `reports: 5 item(s)`.
+   */
+  const report = (provider: string, quota: Record<string, unknown>) => ({ provider, quota });
+
+  test("one line per report, using the same formatter as ocx account refresh", () => {
+    const line = providerQuotaLine("anthropic", report("anthropic", {
+      fiveHourPercent: 9,
+      fiveHourResetAt: 1_787_690_999_802,
+      weeklyPercent: 45,
+    }) as never);
+    expect(line).toContain("anthropic");
+    expect(line).toContain("5h 9%");
+    expect(line).toContain("weekly 45%");
+    expect(line).toContain("resets ");
+  });
+
+  test("custom windows keep their upstream labels", () => {
+    const line = providerQuotaLine("cursor", report("cursor", {
+      monthlyPercent: 0.69,
+      customWindows: [
+        { label: "First-party models", percent: 0.77 },
+        { label: "API usage", percent: 0.19 },
+      ],
+    }) as never);
+    expect(line).toContain("monthly 0.69%");
+    expect(line).toContain("First-party models 0.77%");
+    expect(line).toContain("API usage 0.19%");
+  });
+
+  test("a report with no windows still names its provider", () => {
+    expect(providerQuotaLine("plain", report("plain", {}) as never)).toBe("plain");
   });
 });


### PR DESCRIPTION
## Summary

Closes #2565.

`quota()` rendered the response through `summaryLines()`, a depth-1 flattener that emits
`N item(s)` for a non-scalar array. Every fetched report was discarded, so the default
invocation of the command printed a count and users had to pipe `--json` through a parser
to read their own quota.

The fix reuses `providerQuotaLine`, the formatter `ocx account refresh` already uses, so
both commands render the same shape.

## Verification

Before:

```
$ ocx provider quota
generatedAt: 1787668202536
reports: 5 item(s)
```

After, against the same live proxy:

```
$ ocx provider quota
openai weekly 1%
anthropic 5h 9% resets 2026-08-25T19:29:59.802Z weekly 45% resets 2026-08-28T14:59:59.802Z
xai weekly 28% resets 2026-08-27T10:26:01.460Z
cursor monthly 0.69% resets 2026-09-16T16:54:57.000Z First-party models 0.77% ...
google-antigravity Gem 0% resets 2026-08-25T21:41:18.000Z Cla 0% ...
```

```
$ bun test tests/cli-headless-parity.test.ts
 32 pass, 0 fail

$ bun x tsc --noEmit
(clean)
```

Percentages are not reformatted here: `ocx account refresh` prints the same raw values, and
changing the shared formatter's precision is a separate decision from repairing a dropped
projection.

## Checklist

- [x] Targets `dev`
- [x] Based on the current `dev` head
- [x] Verified against a live proxy, not only in tests
- [x] Typecheck clean
- [x] No secrets or account identifiers in the diff

