### PR TITLE
feat(cli): add per-account quota to ocx account list

### DIFF
--- a/docs-site/src/content/docs/reference/cli/providers-accounts.md
+++ b/docs-site/src/content/docs/reference/cli/providers-accounts.md
@@ -140,7 +140,7 @@ and the plan/label column falls back across plan, masked email, label, and maske
 }
 ```
 
-### `ocx account list [provider] [--json] [--all]`
+### `ocx account list [provider] [--json] [--all] [--quota [--refresh]]`
 
 Without a provider, lists the Codex pool, OAuth accounts, and configured API-key pools. Empty
 providers are skipped unless `--all` is present. With a provider, lists only that credential family.
@@ -152,6 +152,20 @@ returns:
 
 ```text
 { accounts: AccountRow[], notes: string[] }
+```
+
+`--quota` adds a `QUOTA` column with each account's own usage, for providers that support a
+per-account probe (Anthropic today). It is opt-in because the proxy probes the upstream once per
+stored credential; the default listing stays a local read. `--refresh` bypasses the cached
+result. An account with no per-account quota shows `-`, and one whose probe failed shows
+`unavailable` — blank would read as "no usage" rather than "not measured". `--json` carries the
+full breakdown per account, not just the two summarized windows:
+
+```text
+$ ocx account list anthropic --quota
+PROVIDER   TYPE   ID        PLAN/LABEL         PRIORITY  STATUS  QUOTA
+anthropic  oauth  1278f8da  a***r@big5lms.com  -                 5h 7% wk 62%
+anthropic  oauth  e112f28b  k***1@gmail.com    -         active  5h 9% wk 45%
 ```
 
 ### `ocx account current <provider> [--json]`

--- a/src/cli/account-api.ts
+++ b/src/cli/account-api.ts
@@ -145,6 +145,14 @@ export interface CodexQuotaDto {
   monthlyPercent?: number;
   weeklyResetAt?: number;
   monthlyResetAt?: number;
+  /**
+   * Five-hour window, as the per-account provider probe reports it
+   * (`/api/oauth/accounts?quota=1`). Distinct from `shortPercent`, which is the Codex pool's
+   * self-declared burst window; the two surfaces name the same idea differently and both reach
+   * this DTO.
+   */
+  fiveHourPercent?: number;
+  fiveHourResetAt?: number;
   /** Sub-day burst window, when upstream declares one (#1791). */
   shortPercent?: number;
   shortResetAt?: number;
@@ -240,10 +248,22 @@ interface OAuthAccountDto {
   email?: string;
   active?: boolean;
   needsReauth?: boolean;
+  quota?: CodexQuotaDto | null;
+  quotaUnavailable?: boolean;
 }
 
-async function fetchOAuthRows(deps: AccountDeps, baseUrl: string, name: string): Promise<FamilyRows> {
-  const res = await apiJson(deps, baseUrl, "GET", `/api/oauth/accounts?provider=${encodeURIComponent(name)}`);
+async function fetchOAuthRows(
+  deps: AccountDeps,
+  baseUrl: string,
+  name: string,
+  quota?: { refresh?: boolean },
+): Promise<FamilyRows> {
+  // Quota is opt-in: the server probes the upstream once per stored credential when `quota=1`
+  // is present, so the default listing must stay a cheap local read (#2566).
+  const query = quota
+    ? `?provider=${encodeURIComponent(name)}&quota=1${quota.refresh ? "&refresh=1" : ""}`
+    : `?provider=${encodeURIComponent(name)}`;
+  const res = await apiJson(deps, baseUrl, "GET", `/api/oauth/accounts${query}`);
   if (res.status === 0) return { rows: [], activeId: null, status: 0, networkDown: true };
   if (res.status !== 200) return { rows: [], activeId: null, status: res.status, errorJson: res.json };
   const activeId = typeof res.json.activeAccountId === "string" ? res.json.activeAccountId : null;
@@ -256,6 +276,8 @@ async function fetchOAuthRows(deps: AccountDeps, baseUrl: string, name: string):
     email: a.email,
     active: a.active ?? a.id === activeId,
     needsReauth: a.needsReauth,
+    ...(a.quota !== undefined ? { quota: a.quota } : {}),
+    ...(a.quotaUnavailable !== undefined ? { quotaUnavailable: a.quotaUnavailable } : {}),
   }));
   return { rows, activeId, status: 200 };
 }
@@ -284,9 +306,15 @@ async function fetchKeyRows(deps: AccountDeps, baseUrl: string, name: string): P
   return { rows, activeId, status: 200 };
 }
 
-export function fetchRows(deps: AccountDeps, baseUrl: string, name: string, type: AccountType): Promise<FamilyRows> {
+export function fetchRows(
+  deps: AccountDeps,
+  baseUrl: string,
+  name: string,
+  type: AccountType,
+  quota?: { refresh?: boolean },
+): Promise<FamilyRows> {
   if (type === "codex") return fetchCodexRows(deps, baseUrl);
-  if (type === "oauth") return fetchOAuthRows(deps, baseUrl, name);
+  if (type === "oauth") return fetchOAuthRows(deps, baseUrl, name, quota);
   return fetchKeyRows(deps, baseUrl, name);
 }
 

--- a/src/cli/account.ts
+++ b/src/cli/account.ts
@@ -16,7 +16,7 @@ const MAIN_CODEX_ID = "__main__";
 const REPLACEMENT_STYLE_OAUTH = new Set(["kiro"]);
 
 const ACCOUNT_USAGE = `Usage:
-  ocx account list [provider] [--json] [--all]
+  ocx account list [provider] [--json] [--all] [--quota [--refresh]]
   ocx account current <provider> [--json]
   ocx account use <provider> <account-or-key-id|main> [--json]
   ocx account refresh <provider> [--json]
@@ -75,11 +75,29 @@ function priorityText(row: AccountRow): string {
   return row.priority > 0 ? `+${row.priority}` : String(row.priority);
 }
 
-export function formatAccountTable(rows: AccountRow[]): string {
+/**
+ * Compact per-account quota for the opt-in QUOTA column: the two windows an operator actually
+ * decides on before a long session. The full breakdown stays in `--json`.
+ */
+function quotaText(row: AccountRow): string {
+  if ((row as { quotaUnavailable?: boolean }).quotaUnavailable) return "unavailable";
+  const quota = row.quota;
+  if (!quota) return "-";
+  const parts: string[] = [];
+  // Two spellings reach this DTO: the per-account provider probe reports `fiveHourPercent`,
+  // while the Codex pool reports the same idea as `shortPercent`.
+  const short = quota.fiveHourPercent ?? quota.shortPercent;
+  if (typeof short === "number") parts.push(`5h ${short}%`);
+  if (typeof quota.weeklyPercent === "number") parts.push(`wk ${quota.weeklyPercent}%`);
+  return parts.length > 0 ? parts.join(" ") : "-";
+}
+
+export function formatAccountTable(rows: AccountRow[], withQuota = false): string {
   const header = ["PROVIDER", "TYPE", "ID", "PLAN/LABEL", "PRIORITY", "STATUS"];
+  if (withQuota) header.push("QUOTA");
   const data = rows.map(r => {
     const keyLabel = r.masked && r.label !== r.masked ? `${r.masked} (${r.label})` : r.masked;
-    return [
+    const cols = [
       r.provider,
       r.type,
       displayId(r.id),
@@ -87,6 +105,8 @@ export function formatAccountTable(rows: AccountRow[]): string {
       priorityText(r),
       statusText(r),
     ];
+    if (withQuota) cols.push(quotaText(r));
+    return cols;
   });
   const widths = header.map((h, i) => Math.max(h.length, ...data.map(d => d[i]!.length)));
   const line = (cols: string[]) => cols.map((c, i) => c.padEnd(widths[i]!)).join("  ").trimEnd();
@@ -96,6 +116,10 @@ export function formatAccountTable(rows: AccountRow[]): string {
 async function cmdList(rest: string[], deps: AccountDeps): Promise<number> {
   const wantsJson = consumeFlag(rest, "--json");
   const showAll = consumeFlag(rest, "--all");
+  // Opt-in: the server probes the upstream once per stored credential, so the default listing
+  // stays a cheap local read (#2566). --refresh bypasses the server-side TTL.
+  const wantsQuota = consumeFlag(rest, "--quota");
+  const refreshQuota = consumeFlag(rest, "--refresh");
   const name = rest.shift();
   const leftover = leftoverArgsError(rest);
   if (leftover) {
@@ -139,7 +163,7 @@ async function cmdList(rest: string[], deps: AccountDeps): Promise<number> {
   const rows: AccountRow[] = [];
   const notes: string[] = [];
   for (const t of targets) {
-    const r = await fetchRows(deps, baseUrl, t.name, t.type);
+    const r = await fetchRows(deps, baseUrl, t.name, t.type, wantsQuota ? { refresh: refreshQuota } : undefined);
     if (r.networkDown) return proxyUnreachable();
     if (r.errorJson) {
       if (name) return apiError(r.errorJson, `failed to list ${t.name}`);
@@ -174,7 +198,7 @@ async function cmdList(rest: string[], deps: AccountDeps): Promise<number> {
     console.log(JSON.stringify({ accounts: rows, notes }, null, 2));
     return 0;
   }
-  if (rows.length > 0) console.log(formatAccountTable(rows));
+  if (rows.length > 0) console.log(formatAccountTable(rows, wantsQuota));
   for (const n of notes) console.log(n);
   if (rows.length === 0 && notes.length === 0) console.log("No stored accounts or keys.");
   return 0;

--- a/tests/cli-headless-parity.test.ts
+++ b/tests/cli-headless-parity.test.ts
@@ -10,6 +10,7 @@ import { handleClientIntegrationCommand, handleGrokCommand } from "../src/cli/in
 import { handleModelsRuntimeCommand } from "../src/cli/models-runtime";
 import { handleProviderRuntimeCommand } from "../src/cli/provider-runtime";
 import { providerQuotaLine } from "../src/cli/account-extended";
+import { formatAccountTable } from "../src/cli/account";
 
 type Recorded = { path: string; method: string; body: unknown };
 const servers: Array<ReturnType<typeof Bun.serve>> = [];
@@ -730,3 +731,40 @@ describe("#2565 ocx provider quota renders bars, not a count", () => {
     expect(providerQuotaLine("plain", report("plain", {}) as never)).toBe("plain");
   });
 });
+
+describe("#2566 per-account quota in ocx account list", () => {
+  const row = (over: Record<string, unknown> = {}) => ({
+    provider: "anthropic",
+    type: "oauth" as const,
+    id: "acc-1",
+    label: "a@example.test",
+    active: false,
+    ...over,
+  });
+
+  test("the QUOTA column only exists when it is asked for", () => {
+    // The server probes the upstream once per stored credential for quota=1, so the default
+    // listing must stay a cheap local read.
+    expect(formatAccountTable([row()] as never)).not.toContain("QUOTA");
+    expect(formatAccountTable([row()] as never, true)).toContain("QUOTA");
+  });
+
+  test("both DTO spellings of the sub-day window render as 5h", () => {
+    // The per-account provider probe reports fiveHourPercent; the Codex pool reports the same
+    // idea as shortPercent.
+    expect(formatAccountTable([row({ quota: { fiveHourPercent: 7, weeklyPercent: 62 } })] as never, true))
+      .toContain("5h 7% wk 62%");
+    expect(formatAccountTable([row({ quota: { shortPercent: 3, weeklyPercent: 10 } })] as never, true))
+      .toContain("5h 3% wk 10%");
+  });
+
+  test("a provider without per-account quota is blank, not zero", () => {
+    // Blank means "not probed"; 0% would claim the account is fully drained.
+    expect(formatAccountTable([row({ provider: "xai" })] as never, true)).toContain("-");
+  });
+
+  test("an account whose probe failed says so instead of reading as empty", () => {
+    expect(formatAccountTable([row({ quotaUnavailable: true })] as never, true)).toContain("unavailable");
+  });
+});
+


### PR DESCRIPTION
## Summary

Closes #2566.

The proxy already probes per-credential usage (`fetchProviderAccountQuotas`) and exposes it
at `/api/oauth/accounts?provider=…&quota=1`, and the dashboard already renders it. The CLI
just never passed `quota=1`, so a headless or SSH session had to hand-roll an authenticated
curl against the management API — with the admin token read off disk — to answer "which
account has quota left before I start a long session".

`--quota` opts into the probe and adds a `QUOTA` column. It stays opt-in because the server
probes the upstream once per stored credential; the default listing remains a local read.
`--refresh` bypasses the cached result.

Two details worth naming:

- An unprobed provider shows `-` and a failed probe shows `unavailable`. Blank would read as
  "no usage" rather than "not measured", which is the wrong thing to tell someone choosing an
  account.
- Two DTO spellings reach the same field: the per-account probe reports `fiveHourPercent`
  while the Codex pool reports the same idea as `shortPercent`. Both render as `5h`.

## Verification

Against a live proxy with three Anthropic logins:

```
$ ocx account list anthropic --quota
PROVIDER   TYPE   ID                                PLAN/LABEL         PRIORITY  STATUS  QUOTA
anthropic  oauth  1278f8da                          a***r@big5lms.com  -                 5h 7% wk 62%
anthropic  oauth  e112f28b                          k***1@gmail.com    -         active  5h 9% wk 45%
anthropic  oauth  b245be9769d72f90b5f1d1c6c1ab4baf  l***n@gmail.com    -                 5h 0% wk 98%
```

Exactly the decision the issue describes: the active account is at 45% weekly while a sibling
sits at 98%.

The default listing is unchanged (no `QUOTA` column), and a full `--quota` run shows `-` for
providers without a per-account probe. `--json` carries the complete breakdown.

```
$ bun test tests/cli-headless-parity.test.ts
 36 pass, 0 fail

$ bun x tsc --noEmit
(clean)
```

Docs updated in `docs-site/src/content/docs/reference/cli/providers-accounts.md`.

## Checklist

- [x] Targets `dev`
- [x] Based on the current `dev` head
- [x] Verified against a live proxy, not only in tests
- [x] Docs updated for the user-facing flag
- [x] Typecheck clean
- [x] Account identifiers in the output above are the CLI's own masked form

