### PR TITLE
fix(fastwire): do not read a non-authoritative tier echo as a Fast downgrade

### DIFF
--- a/src/providers/fastwire.ts
+++ b/src/providers/fastwire.ts
@@ -246,6 +246,7 @@ export function tierObservationContext(
   policy: ResolvedFastPolicy,
   fastMode: boolean | undefined,
   callerTier: string | undefined,
+  responseTierAuthoritative?: boolean,
 ): TierObservationContext {
   return {
     capability: policy.capability,
@@ -253,6 +254,7 @@ export function tierObservationContext(
     fastWire: policy.fastWire,
     demandDecision: fastMode === true ? "force-fast" : fastMode === false ? "force-default" : "inherit",
     ...(callerTier !== undefined ? { callerTier } : {}),
+    ...(responseTierAuthoritative !== undefined ? { responseTierAuthoritative } : {}),
   };
 }
 
@@ -344,7 +346,11 @@ export function createAdapterTierMetadata(
 
   const responseCanConfirmFast = effectiveFastRequested
     && context.eligibility === "eligible"
-    && wireValue !== null;
+    && wireValue !== null
+    // A destination whose echo is not authoritative can neither confirm nor deny Fast. The
+    // ChatGPT-internal Codex backend echoes "default" on priority-scheduled turns, so believing
+    // it reported every Fast request as `response-declined` (#2558).
+    && context.responseTierAuthoritative !== false;
   return {
     outcome,
     observeResponseServiceTier(value: unknown) {

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -1701,7 +1701,15 @@ async function applyFinalRouteRequestNormalization(args: {
   );
   const modelServiceTierSupport = serviceTierSupportFromPolicy(fastPolicy);
   const callerTier = parsed.options.serviceTier;
-  parsed.options.tierObservation = tierObservationContext(fastPolicy, config.fastMode, callerTier);
+  // The ChatGPT-internal Codex backend echoes `service_tier: "default"` even on turns it
+  // scheduled as priority, so its echo cannot confirm OR deny Fast. Believing it reported every
+  // Fast request as `response-declined` (#2558). The public API's echo stays authoritative.
+  parsed.options.tierObservation = tierObservationContext(
+    fastPolicy,
+    config.fastMode,
+    callerTier,
+    isCanonicalOpenAiForwardProvider(route.provider) ? false : undefined,
+  );
   parsed.options.tierDecision = decideTier(fastPolicy, config.fastMode, callerTier);
   parsed.options.serviceTier = tierValueAfterDecision(parsed.options.tierDecision, callerTier);
   if (fastPolicy.capability === true && fastPolicy.fastWire === null) {

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -115,6 +115,15 @@ export interface TierObservationContext {
   fastWire: FastWire | null;
   demandDecision: "force-fast" | "force-default" | "inherit";
   callerTier?: string;
+  /**
+   * Whether the destination's echoed `service_tier` is authoritative about Fast scheduling.
+   *
+   * The ChatGPT-internal Codex backend returns `service_tier: "default"` on turns that were in
+   * fact scheduled as priority, so treating its echo as a downgrade produced a false
+   * `response-declined` on every Fast request (#2558). Absent means "assume authoritative",
+   * preserving the behaviour for the public API where the echo does mean what it says.
+   */
+  responseTierAuthoritative?: boolean;
 }
 
 export type TierDecision =

--- a/tests/fastwire-observability.test.ts
+++ b/tests/fastwire-observability.test.ts
@@ -827,3 +827,51 @@ describe("FastWire gate and compatibility fingerprint", () => {
     expect(buildBehaviorFingerprintV1(base)).not.toBe(buildBehaviorFingerprintV1(performance));
   });
 });
+
+describe("#2558 a non-authoritative destination cannot confirm or deny Fast", () => {
+  /**
+   * The ChatGPT-internal Codex backend echoes service_tier: "default" even on turns it
+   * scheduled as priority. Believing that echo classified every Fast request as
+   * response-declined, which is a false negative that also drives priority cost attribution.
+   */
+  const nonAuthoritative = () => observation({ responseTierAuthoritative: false });
+
+  test("an echoed default is not a downgrade when the destination is not authoritative", () => {
+    const tracker = createAdapterTierMetadata(
+      nonAuthoritative(),
+      { kind: "set", value: "priority" },
+      "service-tier",
+      "priority",
+    )!;
+    tracker.observeResponseServiceTier("default");
+    expect(tracker.outcome.fastDowngradeReason).toBeUndefined();
+    expect(tracker.outcome.fastOutcome).not.toBe("downgraded");
+    // The raw echo is still recorded — this suppresses a verdict, not the evidence.
+    expect(tracker.outcome.responseServiceTier).toBe("default");
+  });
+
+  test("the same echo IS a downgrade on an authoritative destination", () => {
+    const tracker = createAdapterTierMetadata(
+      observation(),
+      { kind: "set", value: "priority" },
+      "service-tier",
+      "priority",
+    )!;
+    tracker.observeResponseServiceTier("default");
+    expect(tracker.outcome.fastOutcome).toBe("downgraded");
+    expect(tracker.outcome.fastDowngradeReason).toBe("response-declined");
+  });
+
+  test("an omitted flag keeps the authoritative default", () => {
+    // Absent must mean "assume authoritative" so the public API path is unchanged.
+    const tracker = createAdapterTierMetadata(
+      observation({}),
+      { kind: "set", value: "priority" },
+      "service-tier",
+      "priority",
+    )!;
+    tracker.observeResponseServiceTier("default");
+    expect(tracker.outcome.fastOutcome).toBe("downgraded");
+  });
+});
+


### PR DESCRIPTION
## Summary

Closes #2558.

OpenCodex reported every Codex Fast request as `fastOutcome: downgraded` /
`fastDowngradeReason: response-declined`, while the request was correctly sent as
`service_tier: "priority"` and observed throughput differed from a no-tier request. The
issue's suspicion was right: the ChatGPT-internal Codex backend returns
`service_tier: "default"` even on turns it scheduled as priority, so its echo was being
read as a verdict it cannot give.

Two consequences, not one. The visible symptom is a false negative in the diagnostics; the
quieter one is cost attribution, because `fastOutcome` drives priority pricing.

`TierObservationContext` gains `responseTierAuthoritative`. Absent means "assume
authoritative", so the public API path — where an echoed `default` really does mean the
request was declined — is unchanged. `core.ts` sets it `false` only for the canonical
ChatGPT-forward destination, using the existing `isCanonicalOpenAiForwardProvider` check.

The raw echo is still recorded in `responseServiceTier`. This suppresses a verdict, not the
evidence: an operator can still see exactly what the backend returned.

## Verification

Driven red first — removing the guard fails exactly the new case and nothing else:

```
# guard removed
$ bun test tests/fastwire-observability.test.ts
 31 pass, 1 fail

# with the fix
$ bun test tests/fastwire-observability.test.ts
 32 pass, 0 fail, 95 expect() calls

$ bun x tsc --noEmit
(clean)
```

The three added cases pin all three states: a non-authoritative destination does not
classify a downgrade, an authoritative one still does, and an omitted flag keeps the
authoritative default.

## Checklist

- [x] Targets `dev`
- [x] Based on the current `dev` head
- [x] Regression driven red first, then green
- [x] Existing fastwire behaviour unchanged for authoritative destinations
- [x] Typecheck clean
- [x] No secrets or account identifiers in the diff



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Fast-mode status reporting for routes that cannot reliably confirm the upstream service tier.
  * Prevented echoed default-tier responses from being incorrectly classified as declined Fast requests.
  * Preserved existing downgrade detection for destinations with authoritative tier information.

* **Tests**
  * Added coverage for authoritative and non-authoritative service-tier responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->