### PR TITLE
docs(config): document oauthAccountFailover

### DIFF
--- a/docs-site/src/content/docs/reference/configuration/providers.md
+++ b/docs-site/src/content/docs/reference/configuration/providers.md
@@ -279,6 +279,42 @@ Leave this disabled unless you understand Anthropic account policy risk. Prefer 
 `ocx account use anthropic <id>` switching when unsure.
 :::
 
+### `oauthAccountFailover` (experimental)
+
+Rotates to another logged-in account of the same provider when one is rate-limited, for OAuth
+providers that have no pool of their own — xAI, Cursor, Kimi, GitHub Copilot, Google Antigravity,
+and Nous. Off by default.
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `oauthAccountFailover.enabled?` | `boolean` | `false` | Enable 429 cooldown failover across stored OAuth accounts. |
+
+Deliberately narrower than `anthropicAccountPool`: no session affinity, no quota-ranked
+selection, no probe leases. It answers one question — the account that just returned 429 is
+cooled, is there another one available.
+
+The Codex pool and the Anthropic pool are excluded and keep their own rotation; enabling this
+changes neither. A provider with a single stored account is a strict no-op, and no cooldown is
+recorded for it.
+
+On a 429 the failed account is cooled using `Retry-After` when present (capped at 15 minutes)
+or a default backoff, and the request is replayed on the next eligible account, up to three
+rotations per request. An account flagged for reauthentication is never selected. Cooldowns are
+process-local, so a restart forgets them.
+
+Rotation carries the alternate account's **full** credential snapshot, not just its bearer, so a
+provider that pairs routing metadata with its token — Antigravity's Cloud Code Assist project id,
+for example — cannot end up sending one account's token with another account's metadata.
+
+Current scope is the ordinary Responses request paths. Cursor reports rate limits as adapter
+events rather than an HTTP status, and the standalone Antigravity image endpoint has its own
+request path; neither rotates yet.
+
+:::caution[Experimental]
+Rotating across subscription accounts spends a second account's quota and may violate provider
+terms. Leave this disabled unless that is a tradeoff you have decided to make.
+:::
+
 ### Managed record shapes
 
 `apiKeys[]` entries contain `id`, `name`, generated `key`, and ISO `createdAt` strings.


### PR DESCRIPTION
## Summary

Documents the `oauthAccountFailover` knob added in #2590. Docs only.

The reference page already covers `anthropicAccountPool`; this adds the sibling section so the
new knob's scope limits are discoverable rather than implied by absence — specifically the
excluded pools, the single-account no-op, the bounded cooldown, and the two request paths
(Cursor's adapter-event rate limits and the standalone Antigravity image endpoint) that do
not rotate yet.

Also states why rotation carries the full credential snapshot: a provider pairing routing
metadata with its token must not end up sending one account's bearer with another's metadata.

## Verification

Docs only; no code paths touched.

## Checklist

- [x] Targets `dev`
- [x] Based on the current `dev` head
- [x] Scope limits and the ToS caution stated explicitly
- [x] No secrets or account identifiers



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added experimental configuration guidance for OAuth account failover.
  - Documented bounded account rotation after rate-limit responses, including cooldowns and reauthentication exclusions.
  - Clarified that provider account pools are managed independently and identified unsupported integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->