### PR TITLE
fix(codex): distinguish a failed desktop probe from an absent app

### DIFF
--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -615,6 +615,15 @@ async function handleDesktopAppRestart(log: Pick<Console, "log" | "error">): Pro
         + "Run 'ocx sync --restart-desktop-app' from an external terminal instead.",
       );
       return;
+    case "process_probe_failed":
+      // Distinct from `no_targets`: we could not look, which is not the same as looking and
+      // finding nothing. Saying "not running" here sent users away believing there was nothing
+      // to restart (#2557).
+      log.error(
+        "Could not enumerate Codex desktop processes, so the app was not restarted. "
+        + "Quit and relaunch the desktop app manually to refresh the model picker.",
+      );
+      return;
     case "no_targets":
       log.log("Codex desktop app is not running; nothing to restart.");
       return;
@@ -630,4 +639,3 @@ async function handleDesktopAppRestart(log: Pick<Console, "log" | "error">): Pro
       }
   }
 }
-

--- a/src/codex/desktop-app-restart.ts
+++ b/src/codex/desktop-app-restart.ts
@@ -43,6 +43,7 @@ export interface DesktopAppRestartIo {
 export type DesktopAppRestartReason =
   | "windows_only"
   | "package_discovery_failed"
+  | "process_probe_failed"
   | "no_targets"
   | "self_ancestry"
   | "targets_survived";
@@ -119,7 +120,7 @@ interface DesktopProcess {
 function listPackageProcesses(
   exec: NonNullable<DesktopAppRestartIo["execFile"]>,
   installLocation: string,
-): DesktopProcess[] {
+): DesktopProcess[] | null {
   const literal = installLocation.replace(/'/g, "''");
   const script = [
     "$ErrorActionPreference='SilentlyContinue'",
@@ -136,7 +137,10 @@ function listPackageProcesses(
     "      }",
     "    }",
     "  }",
-  ].join(" ");
+  // Statements must be newline-separated. Joining with a space concatenates
+  // `$ErrorActionPreference='SilentlyContinue' $root = '...'` into one malformed statement,
+  // which PowerShell rejects — so the probe threw and every caller read "not running" (#2557).
+  ].join("\n");
   let stdout: string;
   try {
     stdout = exec(resolveTrustedWindowsPowerShellExe(), ["-NoProfile", "-NonInteractive", "-Command", script], {
@@ -144,7 +148,10 @@ function listPackageProcesses(
       windowsHide: true,
     });
   } catch {
-    return [];
+    // A probe that could not run is NOT proof the app is absent. Returning [] here made a
+    // failed enumeration indistinguishable from "no targets", so the CLI reported the app as
+    // not running and skipped a restart the user had explicitly asked for.
+    return null;
   }
   const processes: DesktopProcess[] = [];
   for (const line of stdout.split(/\r?\n/)) {
@@ -170,8 +177,11 @@ function stillSameProcess(
   installLocation: string,
   target: DesktopProcess,
 ): boolean {
-  const current = listPackageProcesses(exec, installLocation)
-    .find(p => p.pid === target.pid);
+  const processes = listPackageProcesses(exec, installLocation);
+  // Fail CLOSED on a failed re-probe: this guards a kill, and "we could not look" must not be
+  // read as "the pid was recycled and is now someone else's process".
+  if (processes === null) return false;
+  const current = processes.find(p => p.pid === target.pid);
   return current !== undefined && current.createdAt === target.createdAt;
 }
 
@@ -266,6 +276,9 @@ export function restartCodexDesktopApp(io: DesktopAppRestartIo = {}): DesktopApp
   if (!pkg) return skipped("package_discovery_failed");
 
   const processes = listPackageProcesses(exec, pkg.installLocation);
+  // A probe that could not run is not evidence of absence. Reporting it as `no_targets` told
+  // the user the app was not running and silently skipped the restart they asked for (#2557).
+  if (processes === null) return skipped("process_probe_failed");
   const roots = rootProcesses(processes);
   if (roots.length === 0) return skipped("no_targets");
 

--- a/tests/desktop-app-restart.test.ts
+++ b/tests/desktop-app-restart.test.ts
@@ -281,3 +281,46 @@ describe("Codex desktop app restart — kill-authority guards (#2292)", () => {
   });
 });
 
+
+describe("#2557 a failed probe is not an absent app", () => {
+  test("an enumeration that throws reports process_probe_failed, not no_targets", () => {
+    // Returning [] on a throwing probe made "we could not look" indistinguishable from
+    // "we looked and found nothing", so the CLI said the app was not running and silently
+    // skipped the restart the user asked for.
+    const calls: Call[] = [];
+    const result = withTrustedExes(() => restartCodexDesktopApp(scriptedIo({
+      discovery: DISCOVERY,
+      calls,
+      throwOn: (_file, args) => args.join(" ").includes("Win32_Process"),
+    })));
+    expect(result.reason).toBe("process_probe_failed");
+    expect(result.attempted).toBe(false);
+    // Fail closed: nothing was terminated and nothing was relaunched on unreadable evidence.
+    expect(result.stopped).toEqual([]);
+    expect(result.relaunch).toBe("skipped");
+  });
+
+  test("an empty enumeration still reports no_targets", () => {
+    // The two states must stay distinguishable in both directions.
+    const calls: Call[] = [];
+    const result = withTrustedExes(() => restartCodexDesktopApp(scriptedIo({
+      discovery: DISCOVERY, processes: "", calls,
+    })));
+    expect(result.reason).toBe("no_targets");
+  });
+
+  test("the probe script separates PowerShell statements with newlines", () => {
+    // Joined with spaces, `$ErrorActionPreference='SilentlyContinue' $root = '...'` is one
+    // malformed statement and PowerShell rejects the whole script.
+    const calls: Call[] = [];
+    withTrustedExes(() => restartCodexDesktopApp(scriptedIo({
+      discovery: DISCOVERY, processes: "", calls,
+    })));
+    const probe = calls.find(call => call.args.join(" ").includes("Win32_Process"));
+    expect(probe).toBeTruthy();
+    const script = probe!.args[probe!.args.length - 1]!;
+    expect(script).toContain("SilentlyContinue'\n");
+    expect(script).not.toContain("SilentlyContinue' $root");
+  });
+});
+


### PR DESCRIPTION
## Summary

Closes #2557. Two defects on the Windows `--restart-desktop-app` path, and the second is
what made the first invisible.

**The probe script was malformed.** `listPackageProcesses` joined its PowerShell statements
with a space, so `$ErrorActionPreference='SilentlyContinue' $root = '...'` became a single
statement and PowerShell rejected the whole script. Statements are now newline-separated.

**A failed probe was reported as an absent app.** The resulting throw was caught and
returned `[]`, which is indistinguishable from a successful enumeration that found nothing.
That became `no_targets`, and the CLI told the user "Codex desktop app is not running;
nothing to restart" — silently skipping the restart they had explicitly asked for. A failed
probe now returns `null` and the caller reports a new `process_probe_failed` reason with an
honest message.

The PID re-check (`stillSameProcess`) fails closed the same way. It guards a kill, so "we
could not look" must never be read as "the pid was recycled and now belongs to someone
else".

## Verification

Each fix was driven red independently — reverting one fails exactly its own cases:

```
# newline join reverted to a space
$ bun test tests/desktop-app-restart.test.ts
 18 pass, 1 fail

# failed probe reverted to returning []
$ bun test tests/desktop-app-restart.test.ts
 17 pass, 2 fail

# both fixes in place
$ bun test tests/desktop-app-restart.test.ts
 19 pass, 0 fail, 50 expect() calls

$ bun x tsc --noEmit
(clean)
```

The new cases assert that a throwing probe reports `process_probe_failed` while terminating
nothing and relaunching nothing, that an empty enumeration still reports `no_targets` so the
two states stay distinguishable in both directions, and that the emitted script separates
its statements.

This is exercised through the existing `io` seam, so the guards are proved on any platform
rather than asserted from a comment — the convention `#2292` established for this file.

## Checklist

- [x] Targets `dev`
- [x] Based on the current `dev` head
- [x] Each fix driven red first, then green
- [x] Termination path still fails closed on unreadable evidence
- [x] Typecheck clean
- [x] No secrets or account identifiers in the diff



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows desktop app restart handling when running processes cannot be detected.
  - Reports process-detection failures separately from cases where no restartable processes are found.
  - Prevents termination or relaunch when process identity checks cannot be completed, avoiding unsafe restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->