### PR TITLE
feat(slug): one selection resolver that reports what it matched (#2491 partial)

### DIFF
--- a/src/providers/slug-codec.ts
+++ b/src/providers/slug-codec.ts
@@ -101,3 +101,55 @@ export function slugEquivalenceKey(slug: string): string {
 export function slugsEquivalent(a: string, b: string): boolean {
   return a === b || slugEquivalenceKey(a) === slugEquivalenceKey(b);
 }
+
+/**
+ * Resolve one config selection against a provider's known native ids (#2491).
+ *
+ * `slugEquivalenceKey` is deliberately lossy — the Codex one-slash rule forces `a/b` and
+ * `a-b` onto the same encoded form — so a selection written in either spelling matches BOTH
+ * when a provider publishes both. Filtering and persisted sync share that key, which keeps
+ * them consistent with each other but silently over-grants.
+ *
+ * This resolver keeps the tolerant behaviour (a selection still matches through either
+ * spelling, and an id absent from an incomplete live roster still resolves) while reporting
+ * whether the match was EXACT or merely equivalent. A caller that can afford to be strict —
+ * one holding a complete known-id set — can then prefer the exact row instead of granting the
+ * whole collision class.
+ *
+ * Returning the ambiguity rather than resolving it is deliberate: the roster is an incomplete
+ * dictionary, so silently narrowing to the exact spelling would hide a published id whenever
+ * discovery omitted it. The caller owns that tradeoff because only the caller knows whether
+ * its id set is complete.
+ */
+export interface SlugSelectionMatch {
+  /** Native ids this selection admits. */
+  readonly matched: readonly string[];
+  /** The id whose raw form the selection names exactly, when one exists. */
+  readonly exact: string | undefined;
+  /** True when more than one known id shares the selection's encoded form. */
+  readonly ambiguous: boolean;
+}
+
+export function resolveSlugSelection(
+  provider: string,
+  selection: string,
+  knownIds: Iterable<string>,
+): SlugSelectionMatch {
+  // A slash in the selection is ambiguous on its own: `p/a-b` is provider-qualified, while
+  // `a/b` is a bare NATIVE id that happens to contain a slash. Treating every slash-bearing
+  // selection as provider-qualified made `a/b` resolve against provider "a", so the same
+  // collision reported ambiguous through the dash spelling and unambiguous through the slash
+  // spelling — the exact asymmetry this resolver exists to remove.
+  const qualified = selection.startsWith(`${provider}/`)
+    ? selection
+    : routedSlug(provider, selection);
+  const selectionKey = slugEquivalenceKey(qualified);
+  const matched: string[] = [];
+  let exact: string | undefined;
+  for (const id of knownIds) {
+    if (slugEquivalenceKey(routedSlug(provider, id)) !== selectionKey) continue;
+    matched.push(id);
+    if (id === selection || `${provider}/${id}` === selection) exact = id;
+  }
+  return { matched, exact, ambiguous: matched.length > 1 };
+}

--- a/tests/slug-codec.test.ts
+++ b/tests/slug-codec.test.ts
@@ -6,6 +6,7 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import {
   decodeRoutedModelId,
+  resolveSlugSelection,
   decodeRoutedModelIdOrThrow,
   encodeRoutedModelId,
   encodedModelIdCollides,
@@ -320,3 +321,53 @@ describe("catalog emission (Codex-facing)", () => {
     expect(encodedFeatured.find(e => e.slug === "zenmux/moonshotai-kimi-k3")?.priority).toBe(0);
   });
 });
+
+describe("#2491 one selection resolver reports what it actually matched", () => {
+  /**
+   * The Codex one-slash rule forces `a/b` and `a-b` onto the same encoded form, so the
+   * equivalence key cannot separate them. Filtering and persisted sync already share that key;
+   * what was missing is any way for a caller to LEARN that a selection was ambiguous instead of
+   * silently granting the whole collision class.
+   */
+  test("an unambiguous selection resolves to exactly one id, marked exact", () => {
+    const match = resolveSlugSelection("p", "a-b", ["a-b", "unrelated"]);
+    expect(match.matched).toEqual(["a-b"]);
+    expect(match.exact).toBe("a-b");
+    expect(match.ambiguous).toBe(false);
+  });
+
+  test("both spellings present is reported as ambiguous, with the exact one named", () => {
+    const both = ["a/b", "a-b"];
+    const viaDash = resolveSlugSelection("p", "a-b", both);
+    expect(viaDash.ambiguous).toBe(true);
+    expect(viaDash.matched.sort()).toEqual(["a-b", "a/b"]);
+    // The caller can still prefer the row the operator literally typed.
+    expect(viaDash.exact).toBe("a-b");
+
+    const viaSlash = resolveSlugSelection("p", "a/b", both);
+    expect(viaSlash.ambiguous).toBe(true);
+    expect(viaSlash.exact).toBe("a/b");
+  });
+
+  test("a selection written as the full routed slug resolves the same way", () => {
+    const match = resolveSlugSelection("p", "p/a-b", ["a/b", "a-b"]);
+    expect(match.ambiguous).toBe(true);
+    expect(match.matched.sort()).toEqual(["a-b", "a/b"]);
+  });
+
+  test("an id absent from an incomplete roster still reports no match rather than guessing", () => {
+    // Live discovery can omit a published id; the resolver must not invent one.
+    const match = resolveSlugSelection("p", "missing", ["a-b"]);
+    expect(match.matched).toEqual([]);
+    expect(match.exact).toBeUndefined();
+    expect(match.ambiguous).toBe(false);
+  });
+
+  test("a nested-slash id resolves through its fully encoded form", () => {
+    const match = resolveSlugSelection("p", "x-y-z", ["x/y/z"]);
+    expect(match.matched).toEqual(["x/y/z"]);
+    // Encoded-only: the operator did not type the native spelling.
+    expect(match.exact).toBeUndefined();
+  });
+});
+


### PR DESCRIPTION
## Summary

Partial work on #2491.

The issue names four relations. Checking them against the tree, two of them — catalog
visibility (`provider-fetch.ts`) and persisted sync (`sync.ts`) — **already share**
`slugEquivalenceKey`, so they agree with each other. The real gap is different from the
issue's framing: nothing lets a caller learn that a selection was *ambiguous* rather than
exact, so an over-grant is indistinguishable from an intended match.

The lossiness itself is externally forced and not something to remove here. Codex's
models-manager resolves per-model metadata with an exact one-slash rule, so `a/b` and
`a-b` must collapse to one Codex-facing form.

This adds `resolveSlugSelection`: same tolerant matching, but it also reports the exact id
when the operator typed one and whether the selection admitted more than one row. A caller
holding a complete known-id set can then prefer the exact row instead of granting the whole
collision class; a caller working from an incomplete live roster keeps today's behaviour.
Returning the ambiguity rather than resolving it is deliberate — only the caller knows
whether its id set is complete, and silently narrowing would hide a published id whenever
discovery omitted it.

## A real bug found while writing the test

The first version treated every slash-bearing selection as provider-qualified. That is
wrong: `p/a-b` is qualified, but `a/b` is a bare native id that happens to contain a slash.
So the same collision reported **ambiguous** through the dash spelling and **unambiguous**
through the slash spelling — precisely the asymmetry this resolver exists to remove. Fixed,
and both directions are now pinned.

## Not done

The `ocx models remove` relation (`slugEquals`) and the routing collision check
(`decodeRoutedModelIdOrThrow`) are not migrated in this PR. They answer different questions
— exact-selector matching and encode-collision refusal — and folding them into one relation
needs a decision about whether `models remove` should become tolerant, which changes
destructive-command behaviour. #2491 stays open.

## Verification

```
$ bun test tests/slug-codec.test.ts tests/selected-models.test.ts
 43 pass, 0 fail

$ bun test tests/slug-codec.test.ts tests/selected-models.test.ts tests/router.test.ts tests/codex-catalog.test.ts
 260 pass, 0 fail, 1032 expect() calls

$ bun x tsc --noEmit
(clean)
```

The existing test that pins the known lossy over-grant is unchanged, so this adds a capability
without altering current visibility behaviour.

## Checklist

- [x] Targets `dev`
- [x] Based on the current `dev` head
- [x] Existing selection/visibility behaviour unchanged
- [x] Typecheck clean
- [x] No secrets or account identifiers in the diff



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider model selection to recognize both raw and encoded slug formats.
  * Added support for provider-qualified selections and nested slash-containing model IDs.
  * Clearly identifies exact matches and reports ambiguous selections instead of guessing.
  * Returns no match when a selection does not correspond to a known model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->