### PR TITLE
fix(combos): bound preflight retained chunk count

### DIFF
--- a/src/server/responses/combo-stream-preflight.ts
+++ b/src/server/responses/combo-stream-preflight.ts
@@ -4,6 +4,12 @@ import { createSseInspector } from "../relay";
 import { MAX_CLIENT_SSE_FRAME_BYTES } from "../sse-frame-buffer";
 
 const COMBO_STREAM_PREFLIGHT_MAX_BYTES = MAX_CLIENT_SSE_FRAME_BYTES;
+// Keep retained object count proportional to the same byte budget used by the
+// shared SSE framer. Tiny or empty upstream reads must not bypass the byte cap.
+const COMBO_STREAM_PREFLIGHT_MAX_CHUNKS = Math.max(
+  1,
+  Math.ceil(COMBO_STREAM_PREFLIGHT_MAX_BYTES / 1024),
+);
 
 const PRE_OUTPUT_CONTROL_EVENTS = new Set([
   "response.created",
@@ -105,8 +111,8 @@ export type ComboStreamPreflightResult =
 /**
  * Buffer a combo child's downstream SSE only until the request becomes unsafe to
  * replay or reaches a terminal. This owns exactly one body reader. The aggregate
- * buffer is capped; hitting the cap commits the current target instead of growing
- * memory or guessing that replay is safe.
+ * buffer is capped by bytes and retained chunks; hitting either cap commits the
+ * current target instead of growing memory or guessing that replay is safe.
  */
 export async function preflightComboStreamResponse(
   response: Response,
@@ -161,7 +167,8 @@ export async function preflightComboStreamResponse(
         return { kind: "failed", response: failedTerminalResponse(response, failedPayload, logCtx) };
       }
       if (next.done || terminalStatus !== undefined || outputCommitted
-        || bufferedBytes >= COMBO_STREAM_PREFLIGHT_MAX_BYTES) {
+        || bufferedBytes >= COMBO_STREAM_PREFLIGHT_MAX_BYTES
+        || buffered.length >= COMBO_STREAM_PREFLIGHT_MAX_CHUNKS) {
         return { kind: "accepted", response: replayBufferedResponse(response, reader, buffered) };
       }
     }

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -1200,8 +1200,8 @@ reader and buffers only until one of these boundaries:
   target is committed and cross-target replay is forbidden;
 - a `response.failed` terminal arrives first, in which case the terminal is converted back through
   the ordinary bounded combo-failure classifier and may advance to the next declared target;
-- a completed/incomplete terminal or the aggregate preflight byte cap is reached, in which case the
-  current target is committed conservatively.
+- a completed/incomplete terminal or the aggregate preflight byte or retained-chunk cap is reached,
+  in which case the current target is committed conservatively.
 
 The buffered bytes are replayed unchanged before the reader continues. Native passthrough and eager
 relay identity markers are restored on the wrapped response so Windows/Bun stream paths and deferred

--- a/tests/combo-stream-preflight.test.ts
+++ b/tests/combo-stream-preflight.test.ts
@@ -11,6 +11,8 @@ const sse = (...payloads: unknown[]): Response => new Response(
   { headers: { "content-type": "text/event-stream" } },
 );
 
+const preflightChunkLimit = Math.max(1, Math.ceil(MAX_CLIENT_SSE_FRAME_BYTES / 1024));
+
 describe("combo stream preflight", () => {
   test("keeps only lifecycle preamble replayable and treats unknown output conservatively", () => {
     expect(comboStreamPayloadCommitsOutput({ type: "response.created" })).toBe(false);
@@ -89,5 +91,102 @@ describe("combo stream preflight", () => {
     expect(new TextDecoder().decode(first.value)).toBe(new TextDecoder().decode(preamble));
     expect(second.value).toBe(oversized);
     await reader.cancel();
+  });
+
+  test("commits at the retained-chunk boundary without reading one more chunk", async () => {
+    const prefix = Array.from(
+      { length: preflightChunkLimit },
+      (_, index) => Uint8Array.of((index % 251) + 1),
+    );
+    const tail = Uint8Array.of(252, 253);
+    let sourceIndex = 0;
+    let releaseTail: (() => void) | undefined;
+    let reportNextPull!: () => void;
+    const nextPull = new Promise<void>(resolve => { reportNextPull = resolve; });
+    const response = new Response(new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (sourceIndex < prefix.length) {
+          controller.enqueue(prefix[sourceIndex++]!);
+          return;
+        }
+        reportNextPull();
+        return new Promise<void>(resolve => {
+          releaseTail = () => {
+            controller.enqueue(tail);
+            controller.close();
+            resolve();
+          };
+        });
+      },
+    }, { highWaterMark: 0 }), { headers: { "content-type": "text/event-stream" } });
+
+    const preflight = preflightComboStreamResponse(response, { model: "m1", provider: "a" });
+    const winner = await Promise.race([
+      preflight.then(result => ({ kind: "preflight" as const, result })),
+      nextPull.then(() => ({ kind: "next-pull" as const })),
+    ]);
+    if (winner.kind === "next-pull") {
+      releaseTail!();
+      const late = await preflight;
+      await late.response.body?.cancel();
+    }
+    expect(winner.kind).toBe("preflight");
+    if (winner.kind !== "preflight") return;
+
+    expect(winner.result.kind).toBe("accepted");
+    const reader = winner.result.response.body!.getReader();
+    for (let index = 0; index < prefix.length; index += 1) {
+      const next = await reader.read();
+      expect(next.done).toBe(false);
+      expect(next.value).not.toBe(prefix[index]);
+      expect(next.value).toEqual(prefix[index]);
+    }
+
+    const tailRead = reader.read();
+    await nextPull;
+    expect(releaseTail).toBeDefined();
+    releaseTail!();
+    const replayedTail = await tailRead;
+    expect(replayedTail.done).toBe(false);
+    expect(replayedTail.value).toBe(tail);
+    expect((await reader.read()).done).toBe(true);
+  });
+
+  test("keeps a failed terminal authoritative at the retained-chunk boundary", async () => {
+    const encoder = new TextEncoder();
+    const comment = encoder.encode(":\n\n");
+    const failed = encoder.encode(`data: ${JSON.stringify({
+      type: "response.failed",
+      response: {
+        status: "failed",
+        error: { type: "server_error", code: "upstream_server_error", message: "busy" },
+        usage: { input_tokens: 9, output_tokens: 0, total_tokens: 9 },
+        provider_trace_id: "must-not-cross-the-combo-boundary",
+      },
+    })}\n\n`);
+    let sourceIndex = 0;
+    const response = new Response(new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (sourceIndex < preflightChunkLimit - 1) {
+          sourceIndex += 1;
+          controller.enqueue(comment);
+          return;
+        }
+        if (sourceIndex === preflightChunkLimit - 1) {
+          sourceIndex += 1;
+          controller.enqueue(failed);
+        }
+      },
+    }, { highWaterMark: 0 }), { headers: { "content-type": "text/event-stream" } });
+
+    const result = await preflightComboStreamResponse(response, { model: "m1", provider: "a" });
+    expect(result.kind).toBe("failed");
+    expect(result.response.status).toBe(502);
+    const body = await result.response.json();
+    expect(body).toMatchObject({
+      error: { code: "upstream_server_error", message: "busy" },
+      response: { usage: { input_tokens: 9, output_tokens: 0 } },
+    });
+    expect(JSON.stringify(body)).not.toContain("provider_trace_id");
   });
 });


### PR DESCRIPTION
## Summary

- Bound the combo SSE preflight replay prefix by retained chunk count as well as aggregate bytes.
- Commit the current target exactly at the chunk boundary without an extra upstream read, while keeping a zero-output response.failed terminal authoritative.
- Preserve byte-exact replay and live-tail identity, and document the transport invariant.

Closes #2592.

## Verification

- bun test tests/combo-stream-preflight.test.ts (Bun 1.4.0: 6 pass, 0 fail)
- bun test tests/server-combo-failover-e2e.test.ts (Bun 1.4.0: 74 pass, 0 fail)
- bun run typecheck
- git diff --check
- Independent static review: no actionable findings
- bun run privacy:scan reports two pre-existing documentation examples outside this three-file diff; this change adds no credential, account, request, or personal data.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved combo streaming memory protection by enforcing both byte and retained-chunk limits.
  * Ensured responses are committed and replayed correctly when either limit is reached.
  * Prevented premature reading of deferred chunks.
  * Preserved authoritative terminal errors with sanitized output at commit boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->