### PR TITLE
fix(cli): route models remove through the shared slug relation

### DIFF
--- a/src/cli/models.ts
+++ b/src/cli/models.ts
@@ -11,7 +11,7 @@ import {
   isDeclaredReasoningEffort,
   modelRecordValue,
 } from "../reasoning-effort";
-import { encodedModelIdCollides, routedSlug, slugEquals } from "../providers/slug-codec";
+import { encodedModelIdCollides, resolveSlugSelection, routedSlug } from "../providers/slug-codec";
 import { knownModelIdsForProvider } from "../router";
 import { findLiveProxy } from "../server/proxy-liveness";
 import { modelInList, type OcxConfig, type OcxCustomModel } from "../types";
@@ -277,11 +277,17 @@ async function handleCustomRemove(args: string[]): Promise<void> {
 
   const config = loadConfig();
   const existing = config.customModels ?? [];
-  const matchingIndexes = existing.flatMap((model, index) => (
-    target.includes("/")
-      ? slugEquals(target, model.provider, model.modelId)
-      : model.id === target
-  ) ? [index] : []);
+  // Slug matching goes through the shared resolver so this command sees the same collision
+  // class catalog filtering and persisted sync see (#2491). `slugEquals` compares the raw and
+  // encoded spellings of ONE id, so a selector written in the native slash form matched only
+  // that row while the dash form matched both — the two relations disagreed on the same
+  // config. Removal stays exact-or-refuse: an ambiguous selector still aborts below, which is
+  // the right default for a destructive command.
+  const matchingIndexes = existing.flatMap((model, index) => {
+    if (!target.includes("/")) return model.id === target ? [index] : [];
+    const resolved = resolveSlugSelection(model.provider, target, [model.modelId]);
+    return resolved.matched.length > 0 ? [index] : [];
+  });
   if (matchingIndexes.length === 0) fail(`custom model "${target}" not found`);
   if (matchingIndexes.length > 1) {
     fail(`custom model selector "${target}" is ambiguous; use the custom model id`);

--- a/tests/cli-models.test.ts
+++ b/tests/cli-models.test.ts
@@ -433,3 +433,50 @@ describe("ocx models custom slash ids", () => {
     }
   });
 });
+
+describe("#2491 the removal selector uses the shared equivalence relation", () => {
+  /**
+   * `slugEquals` compared the raw and encoded spellings of ONE id, so a selector written in
+   * the NATIVE slash form matched only the slash row while the encoded form matched both.
+   * Catalog filtering and persisted sync had already agreed on the collision class through
+   * `slugEquivalenceKey`; this command disagreed with both on the same config.
+   */
+  test("a native-slash selector sees the same collision the encoded one does", () => {
+    const { dir } = freshConfig({
+      customModels: [
+        { id: "11111111-1111-4111-8111-111111111111", provider: "test", modelId: "openai/gpt-5.5" },
+        { id: "22222222-2222-4222-8222-222222222222", provider: "test", modelId: "openai-gpt-5.5" },
+      ],
+    });
+    try {
+      // Before: this deleted the slash row outright, because slugEquals matched only it.
+      const result = runCli(["models", "remove", "test/openai/gpt-5.5", "--yes"], { OPENCODEX_HOME: dir });
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("ambiguous");
+      // Refusing is the right default for a destructive command: nothing was removed.
+      const config = JSON.parse(readFileSync(join(dir, "config.json"), "utf8"));
+      expect(config.customModels).toHaveLength(2);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("an unambiguous slash selector still removes its row", () => {
+    // Widening the relation must not make ordinary removal ambiguous.
+    const { dir } = freshConfig({
+      customModels: [
+        { id: "11111111-1111-4111-8111-111111111111", provider: "test", modelId: "openai/gpt-5.5" },
+        { id: "33333333-3333-4333-8333-333333333333", provider: "test", modelId: "unrelated" },
+      ],
+    });
+    try {
+      const result = runCli(["models", "remove", "test/openai/gpt-5.5", "--yes"], { OPENCODEX_HOME: dir });
+      expect(result.status).toBe(0);
+      const config = JSON.parse(readFileSync(join(dir, "config.json"), "utf8"));
+      expect(config.customModels.map((m: { modelId: string }) => m.modelId)).toEqual(["unrelated"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary

Completes #2491, together with #2594.

`slugEquals` compares the raw and encoded spellings of **one** id, so a removal selector
written in the native slash form matched only the slash row while the encoded form matched
both. Catalog filtering and persisted sync had already agreed on the collision class through
`slugEquivalenceKey`; `ocx models remove` disagreed with both on the same config. That is
the inconsistency the issue reports.

Demonstrated directly against a config publishing both spellings:

```
p/a-b | slugEquals -> ["a/b","a-b"] | resolver -> ["a/b","a-b"]  ambiguous=true
p/a/b | slugEquals -> ["a/b"]       | resolver -> ["a/b","a-b"]  ambiguous=true
```

Removal now goes through `resolveSlugSelection` (added in #2594), so all three surfaces see
the same collision.

**Ambiguous selectors still refuse, deliberately.** That behaviour is unchanged — what
changes is that the command now refuses in a case where it previously deleted a row
silently. For a destructive command, refusing on an ambiguous selector is the right default,
so the relation was widened without making removal tolerant.

## Not changed

`decodeRoutedModelIdOrThrow` keeps its own encode-collision check. It answers a different
question — may this request be routed at all — and it already fails closed on ambiguity, so
folding it into the selection resolver would trade a hard refusal for a softer match on the
request path. Recorded rather than silently left out.

## Verification

Driven red: replacing the shared resolver with the narrow exact-only relation fails 3 of the
21 cases.

```
# narrow exact-only relation
$ bun test tests/cli-models.test.ts
 18 pass, 3 fail

# with the shared resolver
$ bun test tests/cli-models.test.ts
 21 pass, 0 fail

$ bun test tests/cli-models.test.ts tests/slug-codec.test.ts tests/selected-models.test.ts tests/router.test.ts
 89 pass, 0 fail, 234 expect() calls

$ bun x tsc --noEmit
(clean)
```

New cases pin both directions: a native-slash selector now sees the same collision the
encoded one does, and an unambiguous slash selector still removes its row — widening the
relation must not make ordinary removal ambiguous.

## Checklist

- [x] Targets `dev`
- [x] Based on the current `dev` head
- [x] Destructive-command behaviour reviewed explicitly, not incidentally
- [x] Driven red first, then green
- [x] Typecheck clean
- [x] No secrets or account identifiers in the diff



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved custom model removal using slash-form selectors.
  - Ambiguous selectors are now rejected without deleting any models.
  - Unambiguous slash-form selectors continue to remove the intended model.
  - UUID-based selectors retain exact matching behavior.

- **Tests**
  - Added coverage for ambiguous and unambiguous custom model removal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->