### PR TITLE
feat(responses): make a silent empty completion observable by default

### DIFF
--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -336,6 +336,7 @@ import { responsesJsonToSseStream } from "../responses-json-events";
 import { guardTerminalEventStream } from "./terminal-guard";
 import {
   emptyCompletionRetryEnabled,
+  observeEmptyCompletion,
   guardEmptyCompletionEventStream,
 } from "./empty-completion-guard";
 import { preflightComboStreamResponse } from "./combo-stream-preflight";
@@ -4525,7 +4526,16 @@ async function handleResponsesInner(
             // signal — run the adapter transport again against a fresh queue.
             continuation: runTurnRetrySource,
           })
-        : eventSource;
+        // Guard off (the default): leave the stream alone, but record that the turn ended
+        // empty so the user has something to correlate instead of an unexplained blank
+        // result (#2472). Retrying by default would re-send a turn that may already have had
+        // billable side effects, so the honest default is observability, not recovery.
+        : observeEmptyCompletion(eventSource, () => {
+          console.warn(
+            `[opencodex] ${route.providerName}/${route.modelId} completed with no output text `
+            + "and no tool call. Set \"emptyCompletionRetry\": true to retry such turns once.",
+          );
+        });
       const sseStream = bridgeToResponsesSSE(
         guardedSource, parsed._responseModelId ?? parsed.modelId, toolNsMap, freeformToolNames, toolSearchToolNames,
         () => {

--- a/src/server/responses/empty-completion-guard.ts
+++ b/src/server/responses/empty-completion-guard.ts
@@ -36,6 +36,41 @@ export function emptyCompletionRetryEnabled(
 export const EMPTY_COMPLETION_RETRY_FAILED_CODE = "empty_completion_retry_failed";
 
 /**
+ * Observe an event stream for the empty-completion shape WITHOUT changing it (#2472).
+ *
+ * The guard above is opt-in, so with the default configuration a turn that completes with no
+ * output text and no tool call passes through untouched and the client records a silent
+ * success. That is the reported symptom: an empty result nobody can explain, with no trace
+ * that the proxy saw anything unusual.
+ *
+ * This is deliberately a passthrough observer, not a second guard. Retrying by default would
+ * re-send a turn that may have already had billable side effects; the honest default is to
+ * leave the stream alone and make the occurrence visible, so a user can correlate it and
+ * decide whether to enable the retry.
+ */
+export async function* observeEmptyCompletion(
+  events: AsyncIterable<AdapterEvent>,
+  onEmptyTurn: () => void,
+): AsyncGenerator<AdapterEvent> {
+  let sawContent = false;
+  let sawTerminal = false;
+  for await (const event of events) {
+    // Reasoning is deliberately NOT content, matching the guard: a reasoning-only stream that
+    // ends with nothing is the canonical shape of this failure.
+    if (isContentEvent(event)) sawContent = true;
+    if (isTerminalEvent(event)) {
+      sawTerminal = true;
+      // Only a successful terminal is the silent failure. `error` and `incomplete` are already
+      // a stated outcome the client can render, so flagging them would be noise.
+      if (!sawContent && event.type === "done") onEmptyTurn();
+    }
+    yield event;
+  }
+  // A stream that ends before any terminal is the pre-output EOF variant of the same failure.
+  if (!sawContent && !sawTerminal) onEmptyTurn();
+}
+
+/**
  * Terminal stop reasons the bridge renders as a visible `response.incomplete`
  * (max_tokens / content_filter). Those are already a stated failure, not the
  * silent empty success this guard exists to catch, and retrying the identical

--- a/tests/empty-completion-guard.test.ts
+++ b/tests/empty-completion-guard.test.ts
@@ -5,6 +5,7 @@ import {
   emptyCompletionRetryEnabled,
   guardEmptyCompletionEventStream,
   isContentEvent,
+  observeEmptyCompletion,
 } from "../src/server/responses/empty-completion-guard";
 import type { AdapterEvent } from "../src/types";
 
@@ -376,3 +377,71 @@ describe("empty-completion guard retry", () => {
     expect(events).toEqual([{ type: "text_delta", text: "partial" }]);
   });
 });
+
+describe("#2472 an empty turn is observable even when the retry guard is off", () => {
+  /**
+   * The guard is opt-in, so by default a turn that completes with no output text and no tool
+   * call passes through untouched and the client records a silent success — the reported
+   * "empty result nobody can explain". This observer changes nothing about the stream; it only
+   * makes the occurrence visible so a user can correlate it and decide whether to enable the
+   * retry. Retrying by default would re-send a turn that may already have had billable side
+   * effects.
+   */
+  async function drain(events: AdapterEvent[]): Promise<{ out: AdapterEvent[]; empties: number }> {
+    let empties = 0;
+    const out: AdapterEvent[] = [];
+    for await (const event of observeEmptyCompletion(eventsOf(...events), () => { empties += 1; })) {
+      out.push(event);
+    }
+    return { out, empties };
+  }
+
+  test("a reasoning-only turn that completes is flagged", async () => {
+    const { out, empties } = await drain([
+      { type: "reasoning_delta", text: "thinking" } as AdapterEvent,
+      { type: "done" } as AdapterEvent,
+    ]);
+    expect(empties).toBe(1);
+    // Passthrough: the stream is untouched.
+    expect(out.map(e => e.type)).toEqual(["reasoning_delta", "done"]);
+  });
+
+  test("a turn that produced text is not flagged", async () => {
+    const { empties } = await drain([
+      { type: "text_delta", text: "hello" } as AdapterEvent,
+      { type: "done" } as AdapterEvent,
+    ]);
+    expect(empties).toBe(0);
+  });
+
+  test("a tool call counts as content", async () => {
+    const { empties } = await drain([
+      { type: "tool_call_start", id: "c1", name: "shell" } as AdapterEvent,
+      { type: "done" } as AdapterEvent,
+    ]);
+    expect(empties).toBe(0);
+  });
+
+  test("an empty text delta is not content", async () => {
+    // Some batch adapters always carry "", which would otherwise mask the failure.
+    const { empties } = await drain([
+      { type: "text_delta", text: "" } as AdapterEvent,
+      { type: "done" } as AdapterEvent,
+    ]);
+    expect(empties).toBe(1);
+  });
+
+  test("a stated failure is not flagged as a silent one", async () => {
+    // error/incomplete already render for the client; flagging them would be noise.
+    const viaError = await drain([{ type: "error", message: "boom" } as AdapterEvent]);
+    expect(viaError.empties).toBe(0);
+    const viaIncomplete = await drain([{ type: "incomplete", reason: "max_tokens" } as AdapterEvent]);
+    expect(viaIncomplete.empties).toBe(0);
+  });
+
+  test("a pre-output EOF is the same failure and is flagged", async () => {
+    const { empties } = await drain([]);
+    expect(empties).toBe(1);
+  });
+});
+


### PR DESCRIPTION
## Summary

Addresses the OpenCodex-side half of #2472.

The empty-completion guard already exists and handles this failure mode well — but it is
opt-in (`emptyCompletionRetry`, default `false`). So with the default configuration a turn
that completes with no output text and no tool call passes through untouched, the client
records a silent success, and the user gets an empty result with no trace that the proxy saw
anything unusual. That matches the reported symptom.

`observeEmptyCompletion` is a **passthrough observer, not a second guard**. It changes
nothing about the stream and only records the occurrence, naming the knob that enables
recovery. Retrying by default would re-send a turn that may already have had billable side
effects — tool calls, paid work — so the honest default here is observability, not recovery.

Only a successful terminal counts. `error` and `incomplete` are already a stated outcome the
client renders, so flagging them would be noise. A pre-output EOF is the same failure and is
recorded too.

## On the issue's other half

The reported `wall_time_seconds` / `exec_command` envelope is owned by the Codex host, not
this proxy — neither identifier appears under `src/`. This PR does not claim to fix the
implausible wall-time reading. What it does fix is that OpenCodex can no longer *silently*
produce an empty successful turn: if the proxy is the producer, there is now a record.

## Verification

```
$ bun test tests/empty-completion-guard.test.ts
 26 pass, 0 fail

$ bun test tests/empty-completion-guard.test.ts tests/empty-completion-core.test.ts tests/empty-completion-hardening.test.ts
 44 pass, 0 fail, 117 expect() calls

# AGENTS.md gate for anything touching core.ts
$ bun test tests/core-lab-boundary.test.ts
 13 pass, 0 fail

$ bun x tsc --noEmit
(clean)
```

The added cases pin that a reasoning-only turn is flagged while the stream stays byte-identical,
that text and tool calls count as content, that an empty `text_delta` does not (some batch
adapters always carry `""`), that a stated failure is not flagged, and that a pre-output EOF is.

## Checklist

- [x] Targets `dev`
- [x] Based on the current `dev` head
- [x] Stream behaviour unchanged — observer only
- [x] Core/lab boundary gate green
- [x] Typecheck clean
- [x] No secrets or account identifiers in the diff



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monitoring of streamed responses that end without generated content.
  * Added warnings for silent completions when automatic retry is disabled.
  * Preserved streamed output and existing retry behavior across normal, reasoning-only, tool-call, error, and incomplete responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->