### PR TITLE
test(cursor): pin the empty-turn producer path end to end

### DIFF
--- a/tests/cursor-protobuf-events.test.ts
+++ b/tests/cursor-protobuf-events.test.ts
@@ -22,6 +22,8 @@ import {
   mapSyntheticMcpExecToToolEvents,
 } from "../src/adapters/cursor/protobuf-events";
 import { createTranslatorBudget } from "../src/lib/translator-budget";
+import { observeEmptyCompletion } from "../src/server/responses/empty-completion-guard";
+import type { AdapterEvent } from "../src/types";
 
 const encoder = new TextEncoder();
 
@@ -1137,5 +1139,68 @@ describe("textual pseudo tool-call marker normalization (#2305)", () => {
     const short = "[TOOL_CALL]grep[ARGS]{}";
     const events = mapCursorProtobufServerMessage(textDelta(short), state);
     expect(events).toEqual([{ type: "text", text: short }]);
+  });
+});
+
+describe("#2472 the Cursor producer path for a silent empty turn", () => {
+  /**
+   * A turnEnded with no text and no committed tool call finalizes to a bare `done`. That is a
+   * successful terminal carrying no content — the exact shape the client records as a
+   * completed turn that said nothing, which is the reported symptom.
+   *
+   * This pins the producer so the shape stays visible. The observer added in #2597 is what
+   * makes it recorded rather than silent; this proves the stream really can reach that state
+   * from a real adapter rather than only in the observer's own fixtures.
+   */
+  test("turnEnded with no output finalizes to a content-free done", () => {
+    const state = createCursorProtobufEventState();
+    const events = mapCursorProtobufServerMessage(turnEndedFrame(), state);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe("done");
+    // No text_delta and no tool_call_* were emitted at any point in this turn.
+    expect(events.some(event => event.type === "text_delta")).toBe(false);
+    expect(events.some(event => event.type.startsWith("tool_call"))).toBe(false);
+  });
+
+  test("an incomplete tool call is a stated error, not a silent empty turn", () => {
+    // The distinction matters: this path already tells the client something went wrong, so it
+    // is NOT the failure mode #2472 describes and must not be conflated with it.
+    const state = createCursorProtobufEventState();
+    state.openToolCalls.set("call-1", { name: "shell", args: "" } as never);
+    const events = finalizeTurnEvents(state);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe("error");
+  });
+
+  test("a turn that produced text finalizes with content already emitted", () => {
+    const state = createCursorProtobufEventState();
+    state.usage.outputTokens = 3;
+    const events = finalizeTurnEvents(state);
+    expect(events[0]!.type).toBe("done");
+    // Usage alone is not content: the observer keys on emitted events, not token counters,
+    // which is why a turn can report output tokens and still be empty to the client.
+    expect(events.some(event => event.type === "text_delta")).toBe(false);
+  });
+});
+
+
+describe("#2472 end to end: the real producer output reaches the observer", () => {
+  /**
+   * The two halves were verified separately — the Cursor adapter can finalize a turn to a
+   * content-free `done`, and the observer flags a content-free `done`. This joins them so a
+   * future change to either side cannot quietly break the pairing.
+   */
+  test("a Cursor turnEnded with no output is flagged by the observer", async () => {
+    const state = createCursorProtobufEventState();
+    const produced = mapCursorProtobufServerMessage(turnEndedFrame(), state) as unknown as AdapterEvent[];
+
+    let flagged = 0;
+    const seen: AdapterEvent[] = [];
+    const stream = (async function* () { yield* produced; })();
+    for await (const event of observeEmptyCompletion(stream, () => { flagged += 1; })) seen.push(event);
+
+    expect(flagged).toBe(1);
+    // Passthrough: the adapter's own events are delivered unchanged.
+    expect(seen).toEqual(produced);
   });
 });


### PR DESCRIPTION
## Summary

Completes #2472, together with #2597.

#2597 added the observer. This proves the **producer** side rather than assuming it: a Cursor
`turnEnded` with no text and no committed tool call finalizes to a bare `done`
(`finalizeTurnEvents`) — a successful terminal carrying no content, which is exactly the
shape a client records as a completed turn that said nothing.

That matters because the earlier investigation of this issue leaned toward "not an OpenCodex
defect". The envelope fields it named (`wall_time_seconds`) really are host-owned, but that
was never evidence that the proxy could not *produce* an empty successful turn. It can, and
now there is a test saying so.

Three distinctions are pinned deliberately:

- the empty-turn shape itself;
- an incomplete tool call, which finalizes to an **error** — already a stated failure, so not
  this failure mode and not to be conflated with it;
- a turn reporting output tokens while emitting no content — usage counters are not content,
  which is why a turn can look non-empty in metering and still be blank to the client.

The two halves are then joined: the adapter's real output is fed through
`observeEmptyCompletion` and asserted to be both flagged and passed through unchanged, so a
future change to either side cannot quietly break the pairing.

## Verification

```
$ bun test tests/cursor-protobuf-events.test.ts
 48 pass, 0 fail

$ bun test tests/cursor-protobuf-events.test.ts tests/empty-completion-guard.test.ts tests/cursor-adapter.test.ts
 95 pass, 0 fail, 281 expect() calls

$ bun x tsc --noEmit
(clean)
```

Tests only; no runtime behaviour changes in this PR.

## Checklist

- [x] Targets `dev`
- [x] Based on the current `dev` head
- [x] Producer path proved, not assumed
- [x] Typecheck clean
- [x] No secrets or account identifiers in the diff



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of responses that finish without generated content.
  * Incomplete tool interactions now report an appropriate error instead of appearing successfully completed.
  * Usage-only responses are no longer incorrectly treated as having meaningful content.

* **Tests**
  * Added regression and end-to-end coverage for silent completions, incomplete tool calls, and event pass-through behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->