### PR TITLE
feat(catalog): shipped model presets with write-path divergence (#2465)

### DIFF
--- a/src/cli/models-runtime.ts
+++ b/src/cli/models-runtime.ts
@@ -22,6 +22,8 @@ const USAGE = `Usage:
   ocx models <enable|disable> <provider/model|native-model> [--native] [--json]
   ocx models provider <name> <on|off> [--json]
   ocx models selected <provider> [--set <id,id...>|--clear] [--json]
+  ocx models preset show [--provider <name>] [--json]
+  ocx models preset apply <provider> [--all] [--json]
   ocx models context <status|value <tokens> [--set-all]|provider <name> on [--value <tokens>]|provider <name> off|all <on|off>> [--json]
   ocx models shadow <status|set> [model|-] [--enabled <on|off>] [--json]`;
 
@@ -162,6 +164,68 @@ async function selected(argv: string[], deps: RuntimeApiDeps): Promise<void> {
   printData(result, wantsJson, [`${provider}: ${models.length ? models.join(", ") : "all models"}`]);
 }
 
+
+interface ModelPresetView {
+  mode: string;
+  appliedVersion?: number;
+  availableVersion: number;
+  presetIds: string[];
+  presetCount: number;
+  totalCount: number;
+  fallback?: string;
+}
+
+function presetLine(name: string, view: ModelPresetView): string {
+  const parts = [`${name}: mode=${view.mode}`];
+  if (view.appliedVersion !== undefined && view.appliedVersion !== view.availableVersion) {
+    parts.push(`applied v${view.appliedVersion}, available v${view.availableVersion}`);
+  } else {
+    parts.push(`preset v${view.availableVersion}`);
+  }
+  parts.push(`(${view.presetCount} of ${view.totalCount} models)`);
+  if (view.fallback) parts.push(`fallback=${view.fallback}`);
+  return parts.join(" ");
+}
+
+async function preset(argv: string[], deps: RuntimeApiDeps): Promise<void> {
+  const args = [...argv];
+  const action = (args.shift() ?? "show").toLowerCase();
+  const wantsJson = takeFlag(args, "--json");
+  if (action === "show") {
+    const only = takeOption(args, "--provider")?.trim();
+    rejectArgs(args, USAGE);
+    const result = await runtimeRequest<{ providers?: Record<string, ModelPresetView> }>("/api/model-presets", {}, deps);
+    const providers = result.providers ?? {};
+    const entries = Object.entries(providers).filter(([name]) => !only || name === only);
+    const lines = entries.length > 0
+      ? entries.map(([name, view]) => presetLine(name, view))
+      // A provider with no shipped preset is not an error: it simply has nothing to curate.
+      : [only ? `${only}: no model preset is shipped for this provider` : "no providers have a shipped model preset"];
+    printData(only ? providers[only] ?? {} : result, wantsJson, lines);
+    return;
+  }
+  if (action !== "apply") throw new CliUsageError(`unknown preset action '${action}'`, USAGE);
+  const provider = args.shift()?.trim();
+  const all = takeFlag(args, "--all");
+  if (!provider) throw new CliUsageError("provider is required", USAGE);
+  rejectArgs(args, USAGE);
+  const mode = all ? "all" : "preset";
+  const result = await runtimeRequest<{ selected?: string[]; fallback?: string; appliedVersion?: number }>(
+    "/api/model-presets",
+    { method: "PUT", body: JSON.stringify({ provider, mode }) },
+    deps,
+  );
+  const selectedIds = result.selected ?? [];
+  const line = result.fallback === "preset-empty"
+    // Never silently narrow to nothing: empty means ALL, so a zero-match preset keeps what was
+    // there and says so.
+    ? `${provider}: preset matched no models — selection unchanged (fallback to all)`
+    : all
+      ? `${provider}: showing all models (allowlist cleared)`
+      : `${provider}: preset v${result.appliedVersion ?? "?"} applied — ${selectedIds.length} models selected`;
+  printData(result, wantsJson, [line]);
+}
+
 async function context(argv: string[], deps: RuntimeApiDeps): Promise<void> {
   const args = [...argv];
   const action = (args.shift() ?? "status").toLowerCase();
@@ -236,6 +300,7 @@ export async function handleModelsRuntimeCommand(sub: string, argv: string[], de
   else if (sub === "disable") action = () => visibility(false, argv, deps);
   else if (sub === "provider") action = () => providerVisibility(argv, deps);
   else if (sub === "selected") action = () => selected(argv, deps);
+  else if (sub === "preset") action = () => preset(argv, deps);
   else if (sub === "context") action = () => context(argv, deps);
   else if (sub === "shadow") action = () => shadow(argv, deps);
   if (!action) return null;

--- a/src/cli/models.ts
+++ b/src/cli/models.ts
@@ -428,7 +428,7 @@ export async function handleModels(args: string[]): Promise<void> {
     handleCustomList(rest);
     return;
   }
-  if (["live", "edit", "enable", "disable", "provider", "selected", "context", "shadow"].includes(subcommand ?? "")) {
+  if (["live", "edit", "enable", "disable", "provider", "selected", "preset", "context", "shadow"].includes(subcommand ?? "")) {
     const { handleModelsRuntimeCommand } = await import("./models-runtime");
     const code = await handleModelsRuntimeCommand(subcommand!, rest);
     if (code !== null) process.exitCode = code;

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -167,7 +167,7 @@ export const CLI_COMMANDS: CliCommandEntry[] = [
   {
     name: "models",
     aliases: ["model"],
-    usage: "ocx models <list|live|add|edit|remove|enable|disable|provider|selected|context|shadow> ...",
+    usage: "ocx models <list|live|add|edit|remove|enable|disable|provider|selected|preset|context|shadow> ...",
     summary: "List models and manage custom (manually registered) models.",
     details: [
       "List available models from static config with no subcommand (liveModels may add more at runtime).",

--- a/src/providers/model-presets.ts
+++ b/src/providers/model-presets.ts
@@ -1,0 +1,119 @@
+/**
+ * Shipped per-provider "latest/core" model presets (#2465).
+ *
+ * Adding a high-volume provider exposes its entire catalog to the Codex picker on day one:
+ * openrouter ships 400+ rows, an Anthropic provider ships every historical snapshot. The useful
+ * set is a handful of current flagships, so a newly added provider seeds from a curated preset
+ * and "everything" stays one click away.
+ *
+ * Rules are ID PATTERNS rather than literal id lists so a vendor snapshot suffix does not stale
+ * the preset between releases: `claude-opus-5-20260814` and `claude-opus-5` both match one rule.
+ *
+ * The preset is a SEED, not a lock. Materialization evaluates these rules against the provider's
+ * current catalog and stores CONCRETE ids in `selectedModels`, so the visibility hot path
+ * (`filterCatalogVisibleModels`) never learns about patterns and an older binary still sees a
+ * plain allowlist. Design: devlog/_plan/260824_model_ux_aliases_and_defaults/030_default_preset.md
+ */
+
+import type { OcxProviderConfig } from "../types";
+
+export interface ModelPresetRule {
+  readonly pattern: RegExp;
+}
+
+export interface ModelPreset {
+  /** Bumped whenever this provider's rules change; drives upgrade reconciliation. */
+  readonly version: number;
+  readonly rules: readonly ModelPresetRule[];
+}
+
+/**
+ * Curated on the same release train as the provider registry. A provider WITHOUT an entry has no
+ * preset and behaves exactly as today (mode "all").
+ *
+ * Deliberately limited to high-volume catalogs. A provider that already ships a short curated
+ * list gains nothing from a preset and would only add a marker to reconcile.
+ */
+export const MODEL_PRESETS: Readonly<Record<string, ModelPreset>> = Object.freeze({
+  openrouter: {
+    version: 1,
+    rules: [
+      { pattern: /^anthropic\/claude-(opus|sonnet|haiku)-[45]/ },
+      { pattern: /^google\/gemini-3(\.\d+)?-(pro|flash)/ },
+      { pattern: /^openai\/gpt-5(\.\d+)?/ },
+      { pattern: /^deepseek\/deepseek-(v4|r2)/ },
+      { pattern: /^x-ai\/grok-4(\.\d+)?/ },
+      { pattern: /^moonshotai\/kimi-k[23]/ },
+      { pattern: /^z-ai\/glm-[45]/ },
+    ],
+  },
+  anthropic: {
+    version: 1,
+    rules: [
+      { pattern: /^claude-opus-[45]/ },
+      { pattern: /^claude-sonnet-[45]/ },
+      { pattern: /^claude-haiku-[45]/ },
+      { pattern: /^claude-fable-5/ },
+    ],
+  },
+  "anthropic-apikey": {
+    version: 1,
+    rules: [
+      { pattern: /^claude-opus-[45]/ },
+      { pattern: /^claude-sonnet-[45]/ },
+      { pattern: /^claude-haiku-[45]/ },
+      { pattern: /^claude-fable-5/ },
+    ],
+  },
+});
+
+/** The preset for a provider, or undefined when none is shipped. */
+export function modelPresetFor(providerName: string): ModelPreset | undefined {
+  return MODEL_PRESETS[providerName];
+}
+
+/** True when a provider has a shipped preset at all. */
+export function hasModelPreset(providerName: string): boolean {
+  return modelPresetFor(providerName) !== undefined;
+}
+
+/**
+ * Evaluate a provider's rules against concrete catalog ids.
+ *
+ * Input order is preserved so a caller can show the preset in the same order the picker does.
+ * Duplicates are collapsed; a model matching several rules is selected once.
+ */
+export function materializeModelPreset(
+  providerName: string,
+  catalogModelIds: Iterable<string>,
+): string[] {
+  const preset = modelPresetFor(providerName);
+  if (!preset) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const id of catalogModelIds) {
+    if (seen.has(id)) continue;
+    // `RegExp.test` on a shared literal is safe here because no rule uses the `g` flag; a
+    // sticky/global pattern would carry lastIndex between calls and skip rows.
+    if (preset.rules.some(rule => rule.pattern.test(id))) {
+      seen.add(id);
+      out.push(id);
+    }
+  }
+  return out;
+}
+
+
+/**
+ * Flip a provider out of preset mode when the user edits its selection (#2465).
+ *
+ * No-op unless the provider is currently in preset mode: "all" has no marker to keep, and
+ * "custom" is already terminal. The applied version is retained so the GUI can still offer
+ * "a newer preset is available" without losing what the user chose.
+ */
+export function markModelPresetDiverged(provider: OcxProviderConfig): void {
+  const marker = provider.modelPreset;
+  if (marker?.mode !== "preset") return;
+  provider.modelPreset = { ...marker, mode: "custom" };
+}
+

--- a/src/server/management/model-routes.ts
+++ b/src/server/management/model-routes.ts
@@ -149,6 +149,12 @@ import type { MetricUnavailableReason, TokPerSecondResult, CostEstimateReason, C
 import type { ManagementContext } from "./context";
 import { listManagementModelRows, loadExportModels } from "./model-rows";
 import { readManagementJsonBody, rethrowManagementBodyTooLarge } from "./body";
+import {
+  hasModelPreset,
+  markModelPresetDiverged,
+  materializeModelPreset,
+  modelPresetFor,
+} from "../../providers/model-presets";
 
 /**
  * Counts read back off the SERIALIZED document rather than recomputed from the input rows.
@@ -543,6 +549,104 @@ export async function handleModelRoutes(ctx: ManagementContext): Promise<Respons
     }
     return jsonResponse({ selected, available, liveModelCounts });
   }
+  if (url.pathname === "/api/model-presets" && req.method === "GET") {
+    // Preview without applying: rules evaluated against the CURRENT catalog, so the count the
+    // user sees is the count they would get.
+    const models = await fetchAllModels(config);
+    const byProvider = new Map<string, string[]>();
+    for (const m of models) {
+      const ids = byProvider.get(m.provider) ?? [];
+      ids.push(m.id);
+      byProvider.set(m.provider, ids);
+    }
+    const providers: Record<string, unknown> = {};
+    for (const [name, prov] of Object.entries(config.providers)) {
+      const preset = modelPresetFor(name);
+      if (!preset) continue;
+      const catalogIds = byProvider.get(name) ?? [];
+      const presetIds = materializeModelPreset(name, catalogIds);
+      providers[name] = {
+        mode: prov.modelPreset?.mode ?? "all",
+        ...(prov.modelPreset?.appliedVersion !== undefined
+          ? { appliedVersion: prov.modelPreset.appliedVersion }
+          : {}),
+        availableVersion: preset.version,
+        presetIds,
+        presetCount: presetIds.length,
+        totalCount: catalogIds.length,
+        ...(prov.modelPreset?.fallback ? { fallback: prov.modelPreset.fallback } : {}),
+      };
+    }
+    return jsonResponse({ providers });
+  }
+  if (url.pathname === "/api/model-presets" && req.method === "PUT") {
+    let body: { provider?: unknown; mode?: unknown };
+    try { body = await readManagementJsonBody(req); } catch (error) { rethrowManagementBodyTooLarge(error); return jsonResponse({ error: "invalid JSON body" }, 400); }
+    const provider = typeof body.provider === "string" ? body.provider : "";
+    if (!provider || !hasOwnProvider(config.providers, provider)) {
+      return jsonResponse({ error: "unknown provider" }, provider ? 404 : 400);
+    }
+    const mode = body.mode;
+    if (mode !== "preset" && mode !== "all" && mode !== "custom") {
+      return jsonResponse({ error: "mode must be preset, all, or custom" }, 400);
+    }
+    const target = config.providers[provider];
+    if (mode === "all") {
+      // Same effect as today's empty-list PUT: no allowlist, no marker to reconcile.
+      delete target.selectedModels;
+      delete target.modelPreset;
+      persistConfig(config);
+      return jsonResponse({ ok: true, provider, mode, selected: [], catalogRefresh: await convergeCodexCatalog() });
+    }
+    if (mode === "custom") {
+      // Keep whatever is selected; only the marker changes, so a user can pin their edits
+      // without the proxy re-materializing over them.
+      target.modelPreset = { ...(target.modelPreset ?? {}), mode: "custom" };
+      persistConfig(config);
+      return jsonResponse({ ok: true, provider, mode, selected: [...(target.selectedModels ?? [])] });
+    }
+    if (!hasModelPreset(provider)) {
+      return jsonResponse({ error: `no model preset is shipped for provider '${provider}'` }, 400);
+    }
+    const models = await fetchAllModels(config);
+    const catalogIds = models.filter(m => m.provider === provider).map(m => m.id);
+    const presetIds = materializeModelPreset(provider, catalogIds);
+    const preset = modelPresetFor(provider)!;
+    if (presetIds.length === 0) {
+      // NEVER write an empty allowlist from a preset: empty means ALL, so it would silently
+      // un-curate instead of curating. Keep the previous selection and record the fallback so
+      // the next convergence can retry.
+      target.modelPreset = {
+        mode: "all",
+        appliedVersion: preset.version,
+        appliedAt: new Date().toISOString(),
+        fallback: "preset-empty",
+      };
+      persistConfig(config);
+      return jsonResponse({
+        ok: true,
+        provider,
+        mode: "all",
+        fallback: "preset-empty",
+        selected: [...(target.selectedModels ?? [])],
+      });
+    }
+    target.selectedModels = presetIds;
+    target.modelPreset = {
+      mode: "preset",
+      appliedVersion: preset.version,
+      appliedAt: new Date().toISOString(),
+    };
+    persistConfig(config);
+    return jsonResponse({
+      ok: true,
+      provider,
+      mode: "preset",
+      appliedVersion: preset.version,
+      selected: presetIds,
+      catalogRefresh: await convergeCodexCatalog(),
+    });
+  }
   if (url.pathname === "/api/selected-models" && req.method === "PUT") {
     let body: { provider?: unknown; models?: unknown };
     try { body = await readManagementJsonBody(req); } catch (error) { rethrowManagementBodyTooLarge(error); return jsonResponse({ error: "invalid JSON body" }, 400); }
@@ -556,6 +660,10 @@ export async function handleModelRoutes(ctx: ManagementContext): Promise<Respons
     // Empty list clears the allowlist (provider reverts to exposing all models).
     if (models.length > 0) config.providers[provider].selectedModels = models;
     else delete config.providers[provider].selectedModels;
+    // Divergence is detected at the WRITE path, not by diffing (#2465): a user edit while the
+    // provider is in preset mode makes the selection theirs, and the proxy must never
+    // re-materialize over it afterwards.
+    markModelPresetDiverged(config.providers[provider]);
     persistConfig(config);
     const catalogRefresh = await convergeCodexCatalog();
     return jsonResponse({ ok: true, provider, selected: models, catalogRefresh });

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -275,6 +275,31 @@ export interface OcxProviderConfig {
    * full set so the user can pick). See devlog issue_052_provider-model-allowlist.
    */
   selectedModels?: string[];
+  /**
+   * Model-preset marker for `selectedModels` (#2465). Absent means "all", exactly today's
+   * semantics — an existing provider is never narrowed by an upgrade.
+   *
+   * The preset is a SEED, not a lock: `selectedModels` holds concrete ids materialized from
+   * the shipped rules, so every existing consumer and older binaries keep working against a
+   * plain allowlist. Divergence is detected at the WRITE path rather than by diffing — any user
+   * edit while the mode is "preset" flips it to "custom", after which the proxy never
+   * re-materializes. That collapses upgrade reconciliation to a version compare.
+   *
+   * Deliberately distinct from `deriveProviderPresets`, which curates WHICH PROVIDERS to offer.
+   * This curates which MODELS a provider exposes; the code says "model preset" throughout.
+   */
+  modelPreset?: {
+    mode: "preset" | "all" | "custom";
+    /** MODEL_PRESETS version materialized into `selectedModels`. */
+    appliedVersion?: number;
+    appliedAt?: string;
+    /**
+     * Set when materialization matched nothing and the provider fell back to "all". A preset
+     * must never write an empty allowlist, because empty means ALL and would silently
+     * un-curate; the fallback marker lets the next convergence retry.
+     */
+    fallback?: "preset-empty";
+  };
   /** Provider-wide fallback when context metadata is absent; otherwise caps the reported window. */
   contextWindow?: number;
   /** Per-model fallback when context metadata is absent; otherwise caps the reported window. */

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -5668,3 +5668,105 @@ describe("Codex reasoning-effort capability clamp", () => {
   });
 });
 import { ManagementRequest as Request } from "./helpers/management-auth";
+
+describe("#2465 model preset management routes", () => {
+  const originalFetchForPresets = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = originalFetchForPresets; clearModelCache(); });
+
+  function presetConfig(selected?: string[], marker?: Record<string, unknown>) {
+    return {
+      port: 10100,
+      defaultProvider: "openrouter",
+      providers: {
+        openrouter: {
+          adapter: "openai-chat",
+          baseUrl: "https://openrouter.ai/api/v1",
+          apiKey: "k",
+          liveModels: false,
+          models: [
+            "anthropic/claude-opus-5",
+            "openai/gpt-5.6-sol",
+            "meta-llama/llama-2-7b",
+            "some-vendor/ancient-v1",
+          ],
+          ...(selected ? { selectedModels: selected } : {}),
+          ...(marker ? { modelPreset: marker } : {}),
+        },
+      },
+    } as unknown as Parameters<typeof handleManagementAPI>[2];
+  }
+
+  async function call(config: Parameters<typeof handleManagementAPI>[2], method: string, body?: unknown) {
+    const url = new URL("http://127.0.0.1/api/model-presets");
+    const init: RequestInit = body === undefined
+      ? { method }
+      : { method, body: JSON.stringify(body), headers: { "content-type": "application/json" } };
+    const response = await handleManagementAPI(new Request(url, init), url, config);
+    return { status: response!.status, body: await response!.json() as Record<string, unknown> };
+  }
+
+  test("GET previews the preset against the current catalog without applying it", async () => {
+    clearModelCache();
+    const config = presetConfig();
+    const { body } = await call(config, "GET");
+    const view = (body.providers as Record<string, Record<string, unknown>>).openrouter;
+    expect(view.mode).toBe("all");
+    expect(view.presetIds).toEqual(["anthropic/claude-opus-5", "openai/gpt-5.6-sol"]);
+    expect(view.totalCount).toBe(4);
+    // Preview must not mutate: the provider is still unfiltered.
+    expect(config.providers.openrouter.selectedModels).toBeUndefined();
+  });
+
+  test("PUT preset materializes concrete ids and records the version", async () => {
+    clearModelCache();
+    const config = presetConfig();
+    const { body } = await call(config, "PUT", { provider: "openrouter", mode: "preset" });
+    expect(body.mode).toBe("preset");
+    expect(config.providers.openrouter.selectedModels).toEqual([
+      "anthropic/claude-opus-5",
+      "openai/gpt-5.6-sol",
+    ]);
+    // Concrete ids, not patterns: the visibility hot path and older binaries stay compatible.
+    expect(config.providers.openrouter.modelPreset?.mode).toBe("preset");
+    expect(config.providers.openrouter.modelPreset?.appliedVersion).toBeGreaterThan(0);
+  });
+
+  test("PUT all clears both the allowlist and the marker", async () => {
+    clearModelCache();
+    const config = presetConfig(["anthropic/claude-opus-5"], { mode: "preset", appliedVersion: 1 });
+    await call(config, "PUT", { provider: "openrouter", mode: "all" });
+    expect(config.providers.openrouter.selectedModels).toBeUndefined();
+    expect(config.providers.openrouter.modelPreset).toBeUndefined();
+  });
+
+  test("a preset matching nothing never writes an empty allowlist", async () => {
+    clearModelCache();
+    // Empty means ALL, so a zero-match preset must keep the previous selection rather than
+    // silently un-curating the provider.
+    const config = presetConfig(["some-vendor/ancient-v1"]);
+    config.providers.openrouter.models = ["some-vendor/ancient-v1"];
+    const { body } = await call(config, "PUT", { provider: "openrouter", mode: "preset" });
+    expect(body.fallback).toBe("preset-empty");
+    expect(config.providers.openrouter.selectedModels).toEqual(["some-vendor/ancient-v1"]);
+    expect(config.providers.openrouter.modelPreset?.mode).toBe("all");
+    expect(config.providers.openrouter.modelPreset?.fallback).toBe("preset-empty");
+  });
+
+  test("an unknown provider and an invalid mode are rejected", async () => {
+    clearModelCache();
+    const config = presetConfig();
+    expect((await call(config, "PUT", { provider: "nope", mode: "preset" })).status).toBe(404);
+    expect((await call(config, "PUT", { provider: "openrouter", mode: "sideways" })).status).toBe(400);
+  });
+
+  test("a provider with no shipped preset cannot be switched into preset mode", async () => {
+    clearModelCache();
+    const config = presetConfig();
+    (config.providers as Record<string, unknown>).groq = {
+      adapter: "openai-chat", baseUrl: "https://api.groq.com/openai/v1", apiKey: "k", liveModels: false, models: ["x"],
+    };
+    const { status } = await call(config, "PUT", { provider: "groq", mode: "preset" });
+    expect(status).toBe(400);
+  });
+});
+

--- a/tests/model-presets.test.ts
+++ b/tests/model-presets.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import {
+  hasModelPreset,
+  markModelPresetDiverged,
+  materializeModelPreset,
+  modelPresetFor,
+  MODEL_PRESETS,
+} from "../src/providers/model-presets";
+import type { OcxProviderConfig } from "../src/types";
+
+describe("#2465 model presets", () => {
+  test("rules match vendor snapshot suffixes, not just bare ids", () => {
+    // The whole point of patterns over literal lists: a dated snapshot must not stale the
+    // preset between releases.
+    const ids = ["claude-opus-5", "claude-opus-5-20260814", "claude-3-opus-20240229"];
+    const matched = materializeModelPreset("anthropic", ids);
+    expect(matched).toContain("claude-opus-5");
+    expect(matched).toContain("claude-opus-5-20260814");
+    // A historical snapshot outside the rules stays out — that is the curation.
+    expect(matched).not.toContain("claude-3-opus-20240229");
+  });
+
+  test("an aggregator preset narrows a large catalog to flagships", () => {
+    const catalog = [
+      "anthropic/claude-opus-5",
+      "openai/gpt-5.6-sol",
+      "x-ai/grok-4.6",
+      "meta-llama/llama-2-7b",
+      "some-vendor/ancient-model-v1",
+      "google/gemini-3.1-pro",
+    ];
+    const matched = materializeModelPreset("openrouter", catalog);
+    expect(matched).toEqual([
+      "anthropic/claude-opus-5",
+      "openai/gpt-5.6-sol",
+      "x-ai/grok-4.6",
+      "google/gemini-3.1-pro",
+    ]);
+  });
+
+  test("input order is preserved and duplicates collapse", () => {
+    // Order matters so the preview lists models the way the picker will.
+    const matched = materializeModelPreset("anthropic", ["claude-sonnet-5", "claude-opus-5", "claude-sonnet-5"]);
+    expect(matched).toEqual(["claude-sonnet-5", "claude-opus-5"]);
+  });
+
+  test("a provider without a shipped preset matches nothing", () => {
+    expect(hasModelPreset("groq")).toBe(false);
+    expect(materializeModelPreset("groq", ["llama-3.3-70b"])).toEqual([]);
+  });
+
+  test("no rule uses a global or sticky flag", () => {
+    // A /g or /y pattern carries lastIndex between .test() calls and would skip rows
+    // non-deterministically depending on catalog order.
+    for (const [provider, preset] of Object.entries(MODEL_PRESETS)) {
+      for (const rule of preset.rules) {
+        // Assert the FLAGS, not a label containing them — "anthropic-apikey" has a "y" in it.
+        expect({ provider, flags: rule.pattern.flags }).toEqual({ provider, flags: "" });
+      }
+    }
+  });
+
+  test("every shipped preset carries a version", () => {
+    for (const preset of Object.values(MODEL_PRESETS)) {
+      expect(preset.version).toBeGreaterThan(0);
+      expect(preset.rules.length).toBeGreaterThan(0);
+    }
+  });
+
+  describe("divergence is detected at the write path", () => {
+    test("an edit while in preset mode flips to custom and keeps the applied version", () => {
+      const provider = {
+        modelPreset: { mode: "preset" as const, appliedVersion: 1, appliedAt: "2026-08-26T00:00:00Z" },
+      } as OcxProviderConfig;
+      markModelPresetDiverged(provider);
+      expect(provider.modelPreset?.mode).toBe("custom");
+      // Retained so the GUI can still offer "a newer preset is available".
+      expect(provider.modelPreset?.appliedVersion).toBe(1);
+    });
+
+    test("custom is terminal and all has nothing to flip", () => {
+      const custom = { modelPreset: { mode: "custom" as const } } as OcxProviderConfig;
+      markModelPresetDiverged(custom);
+      expect(custom.modelPreset?.mode).toBe("custom");
+
+      const none = {} as OcxProviderConfig;
+      markModelPresetDiverged(none);
+      // Absent marker means "all", exactly today's semantics — no marker is invented.
+      expect(none.modelPreset).toBeUndefined();
+    });
+  });
+
+  test("the anthropic OAuth and API-key rows share one curation", () => {
+    // They expose the same vendor catalog; diverging them would curate the same models twice.
+    expect(modelPresetFor("anthropic")?.rules.length).toBe(modelPresetFor("anthropic-apikey")?.rules.length);
+  });
+});


### PR DESCRIPTION
## Summary

Implements #2465 per its design doc
(`devlog/_plan/260824_model_ux_aliases_and_defaults/030_default_preset.md`).

Adding a high-volume provider exposes its whole catalog on day one — openrouter ships 400+
rows, an Anthropic provider ships every historical snapshot — while the useful set is a
handful of flagships.

**Shipped registry.** `src/providers/model-presets.ts` keys providers to versioned id
*patterns*, not literal lists, so a vendor snapshot suffix (`claude-opus-5-20260814`) does not
stale the preset between releases.

**Seed, not lock.** Materialization evaluates the rules against the current catalog and stores
**concrete ids** in `selectedModels`, so `filterCatalogVisibleModels` never learns about
patterns and an older binary still sees a plain allowlist. Downgrade stays lossless.

**Divergence at the write path, not by diffing.** Any edit through `PUT /api/selected-models`
while a provider is in preset mode flips the marker to `custom`, after which the proxy never
re-materializes. That is what collapses upgrade reconciliation to a version compare instead of
a three-way merge.

**The zero-match case is the one that needed care.** A preset that matches nothing must never
write an empty allowlist, because empty means *ALL* — it would silently un-curate the provider
it was asked to curate. It keeps the previous selection, falls back to `all`, and records
`fallback: "preset-empty"` so a later convergence can retry.

**Existing providers are untouched.** An absent marker means `all`, exactly today's semantics;
no upgrade narrows anyone's catalog.

## Surfaces

- `GET /api/model-presets` — preview (mode, applied/available version, ids, counts)
- `PUT /api/model-presets` — `{provider, mode: "preset"|"all"|"custom"}`
- `ocx models preset show [--provider <name>] [--json]`
- `ocx models preset apply <provider> [--all] [--json]`

## Not in this PR

The GUI segmented selector (Preset / All / Custom in the provider header). It is a visual
surface, and per this repo's process it needs design review and a rendered screenshot rather
than being asserted from code — so it ships separately. #2465 stays open until it lands.

## Verification

```
$ bun test tests/model-presets.test.ts
 9 pass, 0 fail

$ bun test tests/codex-catalog.test.ts
 198 pass, 0 fail        # includes 6 new cases driving the real management routes

$ bun test tests/model-presets.test.ts tests/codex-catalog.test.ts tests/cli-headless-parity.test.ts tests/selected-models.test.ts
 256 pass, 0 fail, 1050 expect() calls

$ bun x tsc --noEmit
(clean)
```

The API cases go through `handleManagementAPI` rather than calling helpers, so a route that
forgot to persist or converge would fail. They pin: preview does not mutate, PUT materializes
concrete ids, `all` clears both allowlist and marker, zero-match keeps the previous selection,
and an unknown provider / invalid mode / preset-less provider are rejected.

One unit test asserts no rule carries a `g` or `y` flag — a sticky pattern would carry
`lastIndex` between `.test()` calls and skip rows depending on catalog order.

## Checklist

- [x] Targets `dev`
- [x] Based on the current `dev` head
- [x] Existing providers unchanged (absent marker = all)
- [x] Typecheck clean
- [x] No secrets or account identifiers in the diff



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider model presets with curated model selections for supported providers.
  * Added CLI commands to preview and apply presets, select all models, and filter by provider.
  * Added API support for previewing and applying presets.
  * Added fallback handling when a preset matches no available models.
* **Bug Fixes**
  * Manual model selection changes now correctly switch preset selections to custom mode.
* **Tests**
  * Added coverage for preset application, validation, filtering, fallback behavior, and model matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->