### PR TITLE
test(catalog): pin the two model-preset convergence calls (#2465)

### DIFF
--- a/tests/codex-convergence-contract.test.ts
+++ b/tests/codex-convergence-contract.test.ts
@@ -372,10 +372,10 @@ test("a failure cause never carries message text, paths or identifiers (#1784)",
   expect(body).not.toContain("failed writing");
 });
 
-test("the route inventory contains exactly the specified 7 + 6 + 2 + 2 convergence calls", () => {
+test("the route inventory contains exactly the specified 7 + 8 + 2 + 2 convergence calls", () => {
   const counts = Object.fromEntries([
     ["provider-routes.ts", 7],
-    ["model-routes.ts", 6],
+    ["model-routes.ts", 8],
     ["combo-routes.ts", 2],
     ["agent-settings-routes.ts", 2],
   ].map(([file, expected]) => {
@@ -387,10 +387,33 @@ test("the route inventory contains exactly the specified 7 + 6 + 2 + 2 convergen
   }));
   expect(counts).toEqual({
     "provider-routes.ts": 7,
-    "model-routes.ts": 6,
+    "model-routes.ts": 8,
     "combo-routes.ts": 2,
     "agent-settings-routes.ts": 2,
   });
+});
+
+/**
+ * Same discipline as the reload-route assertion below: the count above went 6 -> 8 for the
+ * model-preset routes (#2465), and a bare count that only ever rises stops being a contract.
+ * Assert those two calls specifically, so a later bump cannot pass while some OTHER route
+ * quietly gained one, or while a preset route lost its own convergence.
+ *
+ * Both are write paths that change which models ship to the catalog — applying a preset
+ * narrows it, clearing back to "all" widens it — so each must converge for exactly the same
+ * reason `PUT /api/selected-models` does.
+ */
+test("both model-preset write paths converge the Codex catalog", () => {
+  const source = readFileSync(
+    join(import.meta.dir, "..", "src", "server", "management", "model-routes.ts"),
+    "utf8",
+  );
+  const handlerStart = source.indexOf('url.pathname === "/api/model-presets" && req.method === "PUT"');
+  expect(handlerStart).toBeGreaterThan(-1);
+  const handlerBody = source.slice(handlerStart, source.indexOf("url.pathname ===", handlerStart + 1));
+  // The "all" branch and the materialize branch each converge; "custom" only moves the marker,
+  // so it deliberately does not.
+  expect(handlerBody.match(/await convergeCodexCatalog\(\)/g)?.length).toBe(2);
 });
 
 /**


### PR DESCRIPTION
## Summary

`tests/codex-convergence-contract.test.ts` counts `convergeCodexCatalog()` calls per route file. #2465 added two `/api/model-presets` write paths, so `model-routes.ts` went 6 -> 8 and the inventory assertion went red on `dev` at 10c2570cf.

Raising the number alone would have been the wrong repair: the file's own comment says a count that only ever rises stops being a contract. So this raises the count **and** adds a companion assertion that names the two calls it accounts for — the "all" branch and the materialize branch of `PUT /api/model-presets`, both of which change which models reach the catalog. The "custom" branch only moves the marker and deliberately does not converge, which the new test also pins by expecting exactly 2 rather than 3.

## Verification

```
bun test tests/codex-convergence-contract.test.ts
16 pass / 0 fail / 60 expect() calls
```

Falsified: reverting the count to 6 makes the inventory test fail; deleting one `await convergeCodexCatalog()` from the preset handler makes the new companion test fail while the (then-stale) count would still pass. Both directions checked.

## Checklist

- [x] Targets `dev`
- [x] Focused regression test near the existing tests for the subsystem
- [x] No user-facing behavior change, so no `docs-site/` update
- [x] No credential, auth, workflow or release-automation surface touched



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded convergence contract coverage for additional model routes.
  * Added verification that standard model preset updates trigger catalog convergence.
  * Documented that custom preset updates intentionally do not trigger convergence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->