### PR TITLE
fix(sidecars): rotate generic OAuth accounts on 429 (#2568)

### DIFF
--- a/src/images/loop.ts
+++ b/src/images/loop.ts
@@ -258,10 +258,11 @@ export interface ImageBridgeDeps {
   /** Raw adapter usage at the terminal event, pre wire-normalization (see bridgeToResponsesSSE onUsage). */
   onUsage?: (usage: OcxUsage | undefined) => void;
   /**
-   * Optional 429 key-failover for the routed (non-xAI) model. Return a rebuilt adapter for the
-   * rotated key, or null when the pool is exhausted.
+   * Optional 429 failover for the routed (non-xAI) model. Return a rebuilt adapter for the
+   * rotated credential, or null when the pool is exhausted. Async hooks support OAuth refresh;
+   * existing synchronous key-pool hooks remain valid.
    */
-  on429?: (retryAfterHeader: string | null) => ProviderAdapter | null;
+  on429?: (retryAfterHeader: string | null) => ProviderAdapter | null | Promise<ProviderAdapter | null>;
   /** Opt-in same-target 429 policy (key-auth providers). When present, 429 replays on the SAME key before on429 rotation. */
   retryOn429Policy?: Required<RateLimitRetryPolicy> | null;
   /** Called when the bridged Responses stream completes (parity with runTurn / routed paths). */
@@ -572,7 +573,7 @@ export async function runWithImageBridge(deps: ImageBridgeDeps): Promise<Respons
       }
       // 429 key-failover parity with web-search / normal routed path.
       while (prepared.response.status === 429 && deps.on429) {
-        const rotated = deps.on429(prepared.response.headers.get("retry-after"));
+        const rotated = await deps.on429(prepared.response.headers.get("retry-after"));
         if (!rotated) break;
         try { void prepared.response.body?.cancel().catch(() => {}); } catch { /* already closed */ }
         adapter = rotated;

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -196,7 +196,7 @@ import {
   providerModelResponsesUpstreamStreaming,
   type InboundWire,
 } from "../../providers/registry";
-import type { AdapterRequest } from "../../adapters/base";
+import type { AdapterRequest, ProviderAdapter } from "../../adapters/base";
 import {
   hasKeyPoolFailover,
   rateLimitRetryDelayMs,
@@ -4195,6 +4195,53 @@ async function handleResponsesInner(
   const imgPlan = !routedCompaction ? await planImageBridge(config, parsed, route.provider) : undefined;
   const vidPlan = !routedCompaction ? await planVideoBridge(config, parsed, route.provider) : undefined;
   const canRunWebSearch = !!wsPlan && !adapter.runTurn;
+  const rotateSidecarProviderOn429 = async (retryAfter: string | null): Promise<ProviderAdapter | null> => {
+    const rotated = rotateProviderTransportOn429(config, route.providerName, route.provider, {
+      retryAfter,
+      now: Date.now(),
+      attemptedKey: route.provider.apiKey,
+      promptCacheKey: parsed.options.promptCacheKey,
+    });
+    if (rotated) {
+      route.provider = rotated;
+    } else {
+      if (
+        !genericFailoverAccountId
+        || genericFailovers >= GENERIC_OAUTH_MAX_FAILOVERS_PER_REQUEST
+        || !isGenericOAuthFailoverEnabled(config, route.providerName)
+      ) return null;
+      const nextAccountId = rotateGenericOAuthAccountOn429(
+        config,
+        route.providerName,
+        genericFailoverAccountId,
+        retryAfter,
+      );
+      if (!nextAccountId) return null;
+      try {
+        const snapshot = await failoverAccountSnapshot(route.providerName, nextAccountId);
+        genericFailoverAccountId = nextAccountId;
+        genericFailovers += 1;
+        route.provider = { ...route.provider, apiKey: snapshot.accessToken };
+        if (route.providerName === "kiro") parsed._kiroAuthContext = { ...(snapshot.kiro ?? {}) };
+        if (route.provider.googleMode === "cloud-code-assist" && snapshot.projectId) {
+          route.provider = { ...route.provider, project: snapshot.projectId };
+        }
+      } catch {
+        return null;
+      }
+    }
+    const rotatedAdapter = resolveAdapter(
+      resolveWireProtocolOverride(route.providerName, route.modelId, route.provider, inboundWire),
+      config.cacheRetention,
+    );
+    bindRouteReasoningReplayScope({
+      parsed,
+      providerName: route.providerName,
+      provider: route.provider,
+      adapterName: rotatedAdapter.name,
+    });
+    return rotatedAdapter;
+  };
   if ((imgPlan || vidPlan) && canRunWebSearch) {
     // Web search takes priority when both are active — the media bridge cannot run
     // alongside runWithWebSearch. Surface a runtime signal so the user knows their
@@ -4285,27 +4332,7 @@ async function handleResponsesInner(
           if (logCtx.activeAttempt) logCtx.activeAttempt.usage = usage;
         }
       },
-      on429: retryAfter => {
-        const rotated = rotateProviderTransportOn429(config, route.providerName, route.provider, {
-          retryAfter,
-          now: Date.now(),
-          attemptedKey: route.provider.apiKey,
-          promptCacheKey: parsed.options.promptCacheKey,
-        });
-        if (!rotated) return null;
-        route.provider = rotated;
-        const rotatedAdapter = resolveAdapter(
-          resolveWireProtocolOverride(route.providerName, route.modelId, route.provider, inboundWire),
-          config.cacheRetention,
-        );
-        bindRouteReasoningReplayScope({
-          parsed,
-          providerName: route.providerName,
-          provider: route.provider,
-          adapterName: rotatedAdapter.name,
-        });
-        return rotatedAdapter;
-      },
+      on429: rotateSidecarProviderOn429,
       retryOn429Policy: rateLimitRetryPolicyFor(route.provider),
       ...(options.onFirstOutput ? { onFirstOutput: options.onFirstOutput } : {}),
       ...(options.forceEmptyResponseId ? { forceEmptyResponseId: true } : {}),
@@ -4373,27 +4400,7 @@ async function handleResponsesInner(
       routedModelStallTimeoutMs: wsPlan.routedModelStallTimeoutMs,
       stallTimeoutSec: wsPlan.stallTimeoutSec,
       streamRoutedModelOutput: wsPlan.streamRoutedModelOutput,
-      on429: retryAfter => {
-        const rotated = rotateProviderTransportOn429(config, route.providerName, route.provider, {
-          retryAfter,
-          now: Date.now(),
-          attemptedKey: route.provider.apiKey,
-          promptCacheKey: parsed.options.promptCacheKey,
-        });
-        if (!rotated) return null;
-        route.provider = rotated;
-        const rotatedAdapter = resolveAdapter(
-          resolveWireProtocolOverride(route.providerName, route.modelId, route.provider, inboundWire),
-          config.cacheRetention,
-        );
-        bindRouteReasoningReplayScope({
-          parsed,
-          providerName: route.providerName,
-          provider: route.provider,
-          adapterName: rotatedAdapter.name,
-        });
-        return rotatedAdapter;
-      },
+      on429: rotateSidecarProviderOn429,
       retryOn429Policy: rateLimitRetryPolicyFor(route.provider),
       onCompletedResponse: commitReasoningReplayServingRoute,
     });

--- a/src/web-search/loop.ts
+++ b/src/web-search/loop.ts
@@ -304,10 +304,11 @@ export interface WebSearchLoopDeps {
   /** Called before each routed-model dispatch in the loop, for attempt telemetry. Same-target 429 replays pass the `rate-limit-429` recovery kind. */
   onAttemptSend?: (recovery?: AttemptRecoveryKind) => void;
   /**
-   * 429 key-failover hook: rotate the provider's active pool key and return a rebuilt adapter,
-   * or null when the pool is exhausted (same semantics as the normal routed path).
+   * 429 failover hook: rotate the provider's active credential and return a rebuilt adapter,
+   * or null when the pool is exhausted. Async hooks support OAuth refresh; existing synchronous
+   * key-pool hooks remain valid.
    */
-  on429?: (retryAfterHeader: string | null) => ProviderAdapter | null;
+  on429?: (retryAfterHeader: string | null) => ProviderAdapter | null | Promise<ProviderAdapter | null>;
   /** Opt-in same-target 429 policy (key-auth providers). When present, 429 replays on the SAME key before on429 rotation. */
   retryOn429Policy?: Required<RateLimitRetryPolicy> | null;
   /** Called only when the final bridged Responses stream reaches completed or incomplete. */
@@ -509,7 +510,7 @@ export async function runWithWebSearch(deps: WebSearchLoopDeps): Promise<Respons
       // 429 key-failover parity with the normal routed path: rotate pool keys until one responds
       // or the pool is exhausted (deps.on429 returns null — cooldown map guarantees termination).
       while (prepared.response.status === 429 && deps.on429) {
-        const rotated = deps.on429(prepared.response.headers.get("retry-after"));
+        const rotated = await deps.on429(prepared.response.headers.get("retry-after"));
         if (!rotated) break;
         // Never let a broken body's cancel promise outlive the cumulative header deadline. Observe
         // it, but proceed immediately to the rotated fetch under the SAME deadline signal.

--- a/tests/generic-oauth-failover.test.ts
+++ b/tests/generic-oauth-failover.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -113,3 +113,59 @@ describe("#2568 generic OAuth account failover", () => {
   });
 });
 
+/**
+ * The sidecar wiring (#2568).
+ *
+ * The rotator above is a pure module and the two sidecar loops are covered by their own await
+ * tests, but neither reaches the part that actually closes the gap: the `on429` hook `core.ts`
+ * injects into the image and web-search loops. That hook is a closure over request-local state
+ * (`route`, `genericFailoverAccountId`, `genericFailovers`), so it is not importable, and
+ * driving it end to end means standing up a full sidecar request against a stubbed provider.
+ *
+ * These are structural assertions on the source, in the same spirit as the route-inventory
+ * contract in `codex-convergence-contract.test.ts`: they cannot prove the rotation works, and
+ * they are not a substitute for the loop tests — but they DO catch the regression that actually
+ * threatens this feature, which is one sidecar silently keeping a key-pool-only hook while the
+ * other gets the OAuth-aware one. That divergence is exactly how the gap was introduced in the
+ * first place: the main response path grew generic rotation and the two sidecars did not.
+ */
+describe("sidecar on429 wiring", () => {
+  const coreSource = readFileSync(
+    join(import.meta.dir, "..", "src", "server", "responses", "core.ts"),
+    "utf8",
+  );
+
+  test("both sidecar loops receive the SAME hook, so neither can drift key-pool-only", () => {
+    const hooks = coreSource.match(/^\s*on429: (\w+),$/gm)?.map(line => line.trim()) ?? [];
+    // Two injection sites — the image bridge and the web-search loop — and one shared hook.
+    expect(hooks).toHaveLength(2);
+    expect(new Set(hooks).size).toBe(1);
+    expect(hooks[0]).toBe("on429: rotateSidecarProviderOn429,");
+  });
+
+  test("the shared hook tries the key pool first and only then the OAuth roster", () => {
+    const start = coreSource.indexOf("const rotateSidecarProviderOn429 =");
+    expect(start).toBeGreaterThan(-1);
+    const body = coreSource.slice(start, coreSource.indexOf("\n  };", start));
+
+    // Key-pool rotation stays first and unconditional: an API-key provider must behave exactly
+    // as it did before this hook existed.
+    const keyPool = body.indexOf("rotateProviderTransportOn429(");
+    const oauth = body.indexOf("rotateGenericOAuthAccountOn429(");
+    expect(keyPool).toBeGreaterThan(-1);
+    expect(oauth).toBeGreaterThan(keyPool);
+
+    // The OAuth branch is gated on all three of: an account this request actually used, the
+    // per-request bound, and the knob. Dropping any one of them turns an opt-in feature into a
+    // default-on one, or lets a short Retry-After spin.
+    expect(body).toContain("!genericFailoverAccountId");
+    expect(body).toContain("genericFailovers >= GENERIC_OAUTH_MAX_FAILOVERS_PER_REQUEST");
+    expect(body).toContain("!isGenericOAuthFailoverEnabled(config, route.providerName)");
+
+    // The FULL snapshot, not a bare bearer: Kiro carries routing metadata and Antigravity pairs
+    // an account-matched projectId with its token, so a token-only swap mixes two accounts.
+    expect(body).toContain("failoverAccountSnapshot(");
+    expect(body).toContain("_kiroAuthContext");
+    expect(body).toContain("snapshot.projectId");
+  });
+});

--- a/tests/images/loop.test.ts
+++ b/tests/images/loop.test.ts
@@ -652,7 +652,7 @@ describe("runWithImageBridge", () => {
     expect(seen).toEqual({ inputTokens: 13, outputTokens: 6 });
   });
 
-  test("429 key rotation rebuilds the adapter and retries the iteration", async () => {
+  test("429 OAuth rotation awaits a refreshed adapter and retries the iteration", async () => {
     let fetchCalls = 0;
     let rotations = 0;
     let activeAdapter: ProviderAdapter | undefined;
@@ -677,8 +677,9 @@ describe("runWithImageBridge", () => {
       parsed: makeParsed(),
       adapter: firstAdapter,
       plan,
-      on429: () => {
+      on429: async () => {
         rotations++;
+        await Promise.resolve();
         activeAdapter = secondAdapter;
         return secondAdapter;
       },

--- a/tests/web-search.test.ts
+++ b/tests/web-search.test.ts
@@ -769,7 +769,7 @@ describe("BUG-R86 routed web-search timeout semantics", () => {
 });
 
 describe("web-search sidecar native web_search_call emission", () => {
-  test("loop 429 triggers on429 rotation and succeeds with the rebuilt adapter", async () => {
+  test("loop 429 awaits OAuth on429 rotation and succeeds with the rebuilt adapter", async () => {
     globalThis.fetch = (() => Promise.resolve(new Response(
       'event: response.completed\ndata: {"type":"response.completed"}\n\n',
       { headers: { "Content-Type": "text/event-stream" } },
@@ -825,9 +825,10 @@ describe("web-search sidecar native web_search_call emission", () => {
       settings: { model: "gpt-5.4-mini", reasoning: "low", timeoutMs: 30_000 },
       maxSearches: 1,
       onRequestBuilt: request => reasoningLogs.push(request.reasoningLog),
-      on429: retryAfter => {
+      on429: async retryAfter => {
         rotations++;
         expect(retryAfter).toBe("30");
+        await Promise.resolve();
         return rotatedAdapter;
       },
     });


### PR DESCRIPTION
## Summary

Completes the sidecar half of #2568. Generic OAuth account rotation on 429 already worked on the main response path, but the image bridge and the web-search loop each received an `on429` hook that only called `rotateProviderTransportOn429` — key-pool-only, since `hasKeyPoolFailover` returns false for `authMode: "oauth"`. So a provider with three logged-in accounts recovered from a 429 on a normal turn and failed on an image or web-search turn.

The blocking constraint was that `on429` is synchronous (`ProviderAdapter | null`) while OAuth rotation needs `failoverAccountSnapshot`, which may refresh a token. The contract is widened to `ProviderAdapter | null | Promise<ProviderAdapter | null>` and both loops await it; every existing synchronous key-pool caller keeps working unchanged.

Both injection sites now share one hook. It tries the key pool first and unconditionally, so an API-key provider behaves exactly as before, and only falls through to the OAuth roster when the key pool declines. The rotation swaps in the FULL credential snapshot rather than a bare bearer — Kiro carries routing metadata and Antigravity pairs an account-matched `projectId` with its token, so a token-only swap would mix one account's credential with another's routing data.

Codex and Anthropic stay excluded through `isGenericFailoverProvider`: their pools own quota scopes, probe leases and affinity that this must not reimplement. A single-account provider is a strict no-op, and the whole path stays behind `oauthAccountFailover.enabled`.

## Verification

Merged onto `dev` at `f392e02eb` and verified there, not on the branch's own base:

```
bun x tsc --noEmit                                          exit 0
bun test tests/generic-oauth-failover.test.ts \
         tests/images/loop.test.ts tests/web-search.test.ts  95 pass / 0 fail
bun test tests/generic-oauth-failover.test.ts               10 pass / 0 fail
```

Falsification, all four directions:

- image loop, `await` removed → fails, expected 2 fetches received 1
- web-search loop, `await` removed → fails, expected 200 received 502
- web-search site given a divergent key-pool-only hook → fails the hook-identity assertion (expected 1 distinct hook, received 2)
- knob gate removed from the shared hook → fails the gate assertion

The last two come from a test added on review. The two loop tests stub `on429` and therefore never reach the OAuth branch; the hook is a closure over request-local state (`route`, `genericFailoverAccountId`, `genericFailovers`) and is not importable. The added assertions are structural, in the same spirit as the route-inventory contract — they cannot prove rotation works, but they do catch the regression that actually threatens this feature: one sidecar silently keeping the key-pool-only hook while the other gets the OAuth-aware one. That is exactly how the gap arose in the first place.

## Checklist

- [x] Targets `dev`
- [x] Focused regression tests near the existing tests for the subsystem
- [x] Opt-in default unchanged; single-account and key-auth paths are strict no-ops
- [x] Credential handling reviewed: full snapshot per account, no token logging, no cross-account mixing

Closes part of #2568.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added asynchronous provider failover during rate-limit recovery, supporting credential refresh and adapter rebuilding before retrying.
  - Centralized failover handling across image and web-search requests.
  - Added bounded OAuth account failover when provider rotation is unavailable.

- **Bug Fixes**
  - Improved rate-limit retry behavior by ensuring refreshed providers are ready before requests continue.

- **Tests**
  - Added coverage for provider rotation order, OAuth eligibility, and asynchronous failover completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->