### PR TITLE
fix(cursor): rotate OAuth accounts on adapter-event 429 before first output (#2568)

### DIFF
--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -74,6 +74,7 @@ import { isInjectionDebugEnabled } from "../../lib/debug-settings";
 import {
   CYBER_POLICY_ERROR_CODE,
   CYBER_POLICY_FALLBACK_MESSAGE,
+  adapterFailureFromMessage,
   isCyberPolicyCode,
   isCyberPolicyMessage,
 } from "../../lib/errors";
@@ -2871,6 +2872,7 @@ async function handleResponsesInner(
     (logCtx.attempts ??= []).push(attempt);
   }
   sealRequestAttemptIdentity(logCtx.activeAttempt, logCtx.provider, adapter.name, logCtx.accountLogLabel);
+  let runTurnAdapter = adapter;
   if (adapter.runTurn) {
     recordAdapterTierMetadata(logCtx, adapter.tierLogForRunTurn?.(parsed));
   }
@@ -4465,7 +4467,7 @@ async function handleResponsesInner(
             pacingSlotAcquired: true,
           },
         );
-        await adapter.runTurn?.(
+        await runTurnAdapter.runTurn?.(
           parsed,
           {
             headers: selectedForwardHeaders,
@@ -4498,6 +4500,81 @@ async function handleResponsesInner(
       }
     };
     const runTurn = async (): Promise<void> => runTurnAttempt(queue, undefined, true);
+    const rotateRunTurnAdapterOnPreflight429 = async (
+      error: Extract<AdapterEvent, { type: "error" }>,
+    ): Promise<boolean> => {
+      const status = error.status ?? adapterFailureFromMessage(error.message).httpStatus;
+      if (
+        status !== 429
+        || !genericFailoverAccountId
+        || genericFailovers >= GENERIC_OAUTH_MAX_FAILOVERS_PER_REQUEST
+        || !isGenericOAuthFailoverEnabled(config, route.providerName)
+      ) return false;
+      const nextAccountId = rotateGenericOAuthAccountOn429(
+        config,
+        route.providerName,
+        genericFailoverAccountId,
+        null,
+      );
+      if (!nextAccountId) return false;
+      try {
+        const snapshot = await failoverAccountSnapshot(route.providerName, nextAccountId);
+        genericFailoverAccountId = nextAccountId;
+        genericFailovers += 1;
+        route.provider = { ...route.provider, apiKey: snapshot.accessToken };
+        if (route.providerName === "kiro") parsed._kiroAuthContext = { ...(snapshot.kiro ?? {}) };
+        if (route.provider.googleMode === "cloud-code-assist" && snapshot.projectId) {
+          route.provider = { ...route.provider, project: snapshot.projectId };
+        }
+        // A Cursor conversation/checkpoint is credential-scoped. The failed attempt emitted no
+        // client-visible bytes, so replay is safe, but carrying its account identity into the next
+        // account would not be. Let the rotated adapter derive a fresh identity and conversation.
+        parsed._cursorIdentityScope = undefined;
+        parsed._cursorConversationId = undefined;
+        if (parsed._providerContinuation?.cursor) {
+          const { cursor: _discardedCursor, ...otherProviderState } = parsed._providerContinuation;
+          parsed._providerContinuation = otherProviderState;
+        }
+        const rotatedProvider = resolveWireProtocolOverride(
+          route.providerName,
+          route.modelId,
+          route.provider,
+          inboundWire,
+        );
+        const rotatedAdapter = resolveAdapter(rotatedProvider, config.cacheRetention);
+        if (!rotatedAdapter.runTurn) return false;
+        runTurnAdapter = rotatedAdapter;
+        bindRouteReasoningReplayScope({
+          parsed,
+          providerName: route.providerName,
+          provider: rotatedProvider,
+          adapterName: rotatedAdapter.name,
+          oauthCredentialSnapshot: { accountId: snapshot.accountId, generation: snapshot.generation },
+          codexAuthContext: authCtx,
+          forwardHeaders: selectedForwardHeaders,
+        });
+        sealRequestAttemptIdentity(logCtx.activeAttempt, logCtx.provider, rotatedAdapter.name, logCtx.accountLogLabel);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+    const preflightRunTurnFailover = async (
+      firstSource: AsyncIterable<AdapterEvent>,
+    ): Promise<AsyncIterable<AdapterEvent>> => {
+      let source = firstSource;
+      while (true) {
+        const preflight = await preflightAdapterEvents(source);
+        if (!preflight.error || !(await rotateRunTurnAdapterOnPreflight429(preflight.error))) {
+          return preflight.stream;
+        }
+        const retryQueue = createAdapterEventQueue({
+          onBacklogExceeded: () => runTurnAbort.abort(),
+        });
+        void runTurnAttempt(retryQueue, "oauth-account-429");
+        source = retryQueue.stream();
+      }
+    };
     // The empty-completion retry re-runs the turn against a fresh queue: the
     // first queue is closed once its attempt settles, and pushing into it after
     // close is a silent no-op.
@@ -4513,6 +4590,11 @@ async function handleResponsesInner(
     if (parsed.stream) {
       void runTurn();
       let eventSource: AsyncIterable<AdapterEvent> = queue.stream();
+      if (genericFailoverAccountId && isGenericOAuthFailoverEnabled(config, route.providerName)) {
+        // Preflight holds only heartbeats and the first meaningful event. A first-event 429 can be
+        // replayed transparently; after any output reaches the bridge, a later error stays terminal.
+        eventSource = await preflightRunTurnFailover(eventSource);
+      }
       if (options.comboAttempt) {
         const preflight = await preflightAdapterEvents(eventSource);
         if (preflight.error || preflight.empty) {
@@ -4592,15 +4674,22 @@ async function handleResponsesInner(
 
     await runTurn();
     const firstAttemptEvents = await queue.collect();
+    let runTurnEvents: AdapterEvent[] = firstAttemptEvents;
+    if (genericFailoverAccountId && isGenericOAuthFailoverEnabled(config, route.providerName)) {
+      runTurnEvents = [];
+      for await (const event of await preflightRunTurnFailover(
+        (async function* () { yield* firstAttemptEvents; })(),
+      )) runTurnEvents.push(event);
+    }
     let events: AdapterEvent[];
     if (emptyCompletionGuardEnabled) {
       events = [];
       for await (const event of guardEmptyCompletionEventStream({
-        firstEvents: (async function* () { yield* firstAttemptEvents; })(),
+        firstEvents: (async function* () { yield* runTurnEvents; })(),
         continuation: runTurnRetrySource,
       })) events.push(event);
     } else {
-      events = firstAttemptEvents;
+      events = runTurnEvents;
     }
     if (options.comboAttempt) {
       const firstMeaningful = events.find(event => event.type !== "heartbeat");

--- a/tests/adapter-event-oauth-failover.test.ts
+++ b/tests/adapter-event-oauth-failover.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ProviderAdapter } from "../src/adapters/base";
+import { clearGenericFailoverHealth } from "../src/oauth/generic-account-failover";
+import { saveCredential } from "../src/oauth/store";
+import type { AdapterEvent, OcxConfig, OcxProviderConfig } from "../src/types";
+
+const actualResolver = await import("../src/server/adapter-resolve");
+const actualResolveAdapter = actualResolver.resolveAdapter;
+let attempts: AdapterEvent[][] = [];
+let attemptKeys: string[] = [];
+
+function fixtureAdapter(provider: OcxProviderConfig): ProviderAdapter {
+  return {
+    name: "cursor",
+    buildRequest: () => ({ url: provider.baseUrl, method: "POST", headers: {}, body: "" }),
+    async *parseStream() {
+      yield { type: "error", message: "fixture uses runTurn" } as AdapterEvent;
+    },
+    async runTurn(_parsed, _incoming, emit) {
+      const index = attemptKeys.length;
+      attemptKeys.push(provider.apiKey ?? "");
+      for (const event of attempts[index] ?? []) emit(event);
+    },
+  };
+}
+
+mock.module("../src/server/adapter-resolve", () => ({
+  ...actualResolver,
+  resolveAdapter(provider: OcxProviderConfig, cacheRetention?: "none" | "short" | "long") {
+    if (provider.adapter === "cursor") return fixtureAdapter(provider);
+    return actualResolveAdapter(provider, cacheRetention);
+  },
+}));
+
+const { handleResponses } = await import("../src/server/responses");
+const originalHome = process.env.OPENCODEX_HOME;
+let home = "";
+
+function config(enabled = true): OcxConfig {
+  return {
+    port: 0,
+    defaultProvider: "cursor",
+    providers: {
+      cursor: {
+        adapter: "cursor",
+        baseUrl: "https://api2.cursor.sh",
+        authMode: "oauth",
+        models: ["model"],
+      },
+    },
+    ...(enabled ? { oauthAccountFailover: { enabled: true } } : {}),
+  } as OcxConfig;
+}
+
+function request(stream: boolean): Request {
+  return new Request("http://localhost/v1/responses", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ model: "cursor/model", input: "answer", stream }),
+  });
+}
+
+async function seedAccounts(count: number): Promise<void> {
+  for (let i = 0; i < count; i += 1) {
+    await saveCredential("cursor", {
+      access: `cursor-access-${i}`,
+      refresh: `cursor-refresh-${i}`,
+      expires: Date.now() + 3_600_000,
+      accountId: `cursor-account-${i}`,
+    }, { addAccount: true });
+  }
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ocx-adapter-event-failover-"));
+  process.env.OPENCODEX_HOME = home;
+  clearGenericFailoverHealth();
+  attempts = [];
+  attemptKeys = [];
+});
+
+afterEach(() => {
+  clearGenericFailoverHealth();
+  if (originalHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = originalHome;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("#2568 adapter-event OAuth failover", () => {
+  for (const stream of [true, false]) {
+    test(`${stream ? "streaming" : "non-streaming"} first-event 429 rotates and replays`, async () => {
+      await seedAccounts(2);
+      attempts = [
+        [{ type: "error", message: "Cursor rate limit exceeded: resource_exhausted" }],
+        [{ type: "text_delta", text: "alternate answer" }, { type: "done" }],
+      ];
+
+      const response = await handleResponses(request(stream), config(), { model: "", provider: "" });
+      const body = await response.text();
+
+      expect(attemptKeys).toEqual(["cursor-access-1", "cursor-access-0"]);
+      expect(body).toContain("alternate answer");
+      expect(body).not.toContain("Cursor rate limit exceeded");
+    });
+  }
+
+  test("a single account is a strict no-op", async () => {
+    await seedAccounts(1);
+    attempts = [[{ type: "error", message: "Cursor rate limit exceeded: resource_exhausted" }]];
+
+    const body = await (await handleResponses(request(true), config(), { model: "", provider: "" })).text();
+
+    expect(attemptKeys).toEqual(["cursor-access-0"]);
+    expect(body).toContain("rate_limit_exceeded");
+  });
+
+  test("Codex and Anthropic remain excluded", async () => {
+    for (const providerName of ["openai", "anthropic"] as const) {
+      attempts = [[{ type: "error", message: "Cursor rate limit exceeded: resource_exhausted" }]];
+      attemptKeys = [];
+      const excluded = config();
+      excluded.defaultProvider = providerName;
+      excluded.providers = { [providerName]: { ...excluded.providers.cursor! } };
+      const req = new Request("http://localhost/v1/responses", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: `${providerName}/model`, input: "answer", stream: true }),
+      });
+      const response = await handleResponses(req, excluded, { model: "", provider: "" });
+      await response.text();
+      expect(attemptKeys).toHaveLength(0);
+      expect(response.status).toBe(401);
+    }
+  });
+
+  test("an error after first output is terminal and is never replayed", async () => {
+    await seedAccounts(2);
+    attempts = [[
+      { type: "text_delta", text: "already visible" },
+      { type: "error", message: "Cursor rate limit exceeded: resource_exhausted" },
+    ]];
+
+    const body = await (await handleResponses(request(true), config(), { model: "", provider: "" })).text();
+
+    expect(attemptKeys).toEqual(["cursor-access-1"]);
+    expect(body).toContain("already visible");
+    expect(body).toContain("rate_limit_exceeded");
+  });
+});


### PR DESCRIPTION
## Summary

Closes the last live gap in #2568. Cursor's rate limit does not arrive as an HTTP 429: the request returns 200 and the limit shows up inside the stream, as a Connect `END_STREAM` frame carrying `{"error":{"code":"RESOURCE_EXHAUSTED",...}}` (`src/adapters/cursor/live-transport.ts:193,1152`), which `cursor-errors.ts:199` classifies and `lib/errors.ts:184` maps to 429 on the way out. So the HTTP-status rotator that landed for the main path and the sidecars structurally cannot see it — by the time a status exists, the turn is already over.

This rotates on the adapter-event signal instead, at the one point where replay is still honest: `preflightAdapterEvents` holds heartbeats and the first meaningful event, so a 429 arriving as that first event has emitted no client-visible bytes and the whole turn can be replayed on the next account. Both the streaming and non-streaming run-turn paths go through it.

**An error after first output stays terminal and is never replayed.** Once text, tool or reasoning bytes have reached the bridge, a transparent replay would duplicate or contradict output the client already saw. That limit is deliberate, documented in the code, and pinned by its own test rather than left as an unstated assumption.

The rotation also clears `_cursorIdentityScope`, `_cursorConversationId` and the cursor slice of `_providerContinuation`: a Cursor conversation and its checkpoints are credential-scoped, so carrying the failed account's conversation identity into the next account would be wrong even though replaying the turn is not.

`CursorCredentialRouter` is deliberately not used or wired — the maintainer review of #2568 named it as out of scope for this issue, and it stays that way.

Codex and Anthropic remain excluded through `isGenericFailoverProvider`; a single-account provider is a strict no-op; the whole path stays behind `oauthAccountFailover.enabled`.

## Verification

Merged onto `dev` at `87250870c` — the head that already carries the sidecar half — and verified there:

```
bun x tsc --noEmit                                   exit 0
bun test tests/adapter-event-oauth-failover.test.ts \
         tests/generic-oauth-failover.test.ts \
         tests/cursor-adapter.test.ts                36 pass / 0 fail
```

Falsified independently on the merge, not only on the branch: removing the streaming preflight hook drops `tests/adapter-event-oauth-failover.test.ts` to 4 pass / 1 fail (the streaming rotation case), and restoring it returns 5 pass / 0 fail. The non-streaming case survives that mutation on its own hook, which is why both paths are wired separately rather than through one shared entry.

## Checklist

- [x] Targets `dev`
- [x] Focused regression tests, including the post-first-output case behaving as documented
- [x] Opt-in default unchanged; single-account and non-participating providers are strict no-ops
- [x] Credential handling reviewed: full per-account snapshot, credential-scoped conversation state discarded on rotation, no token logging

Closes #2568.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth error handling when a request is rate-limited before producing output.
  * Automatically retries with refreshed credentials when another account is available.
  * Preserved consistent behavior for both streaming and non-streaming responses.
  * Avoided retries for unsupported providers and errors that occur after output has started.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->