### PR TITLE
feat(models): newly discovered provider models arrive disabled (#2464)

### DIFF
--- a/docs-site/src/content/docs/guides/model-routing.md
+++ b/docs-site/src/content/docs/guides/model-routing.md
@@ -82,6 +82,13 @@ Routing and catalog visibility are separate controls:
   for that model.
 - A provider's non-empty `selectedModels` is another catalog allowlist. Live discovery and direct
   routing still work; only catalog and `/v1/models` emission are narrowed.
+- Fresh installs set `modelDiscovery.newModelPolicy` to `"off"`. After the first successful live
+  fetch establishes a baseline, later arrivals are appended to `disabledModels` and carry a **NEW**
+  dashboard badge until enabled or acknowledged. Existing installs remain `"on"` until opted in.
+  Use `ocx models new-policy off` globally, add `--provider <name>` for an override, and inspect
+  `ocx models new-arrivals [--json]`. Failed/degraded fetches never change the baseline. Providers
+  with a non-empty `selectedModels` (including preset mode) are already curated, so this policy is
+  deliberately inert for them.
 - `provider.disabled: true` removes that provider from catalog discovery. Explicit
   `provider/model` requests fail, and `defaultModel` / `models[]` scans skip it.
 - `providerContextCaps` applies per-provider Codex-visible context caps. `contextCapValue` is the

--- a/gui/src/i18n/de.ts
+++ b/gui/src/i18n/de.ts
@@ -2113,4 +2113,6 @@ export const de: Record<TKey, string> = {
   "dash.visionTimeout": "Timeout",
   "dash.visionTimeoutInvalid": "Geben Sie eine ganze Zahl von {min} bis {max} Millisekunden ein.",
   "dash.visionAdvancedPopover": "Erweiterte Vision-Einstellungen",
+  "models.newPolicyGlobal": "Neue Modelle zunächst deaktivieren", "models.newPolicyProvider": "Richtlinie für neue Modelle",
+  "models.newPolicy_inherit": "Übernehmen", "models.newPolicy_off": "Aus", "models.newPolicy_on": "An", "models.newBadge": "NEU", "models.newCount": "{count} neu, aus",
 };

--- a/gui/src/i18n/en.ts
+++ b/gui/src/i18n/en.ts
@@ -2143,6 +2143,9 @@ export const en = {
   "lab.layer.live_route_compatibility": "Live route compatibility",
   "lab.layer.task_effectiveness": "Task effectiveness",
 
+  "models.newPolicyGlobal": "New models start disabled", "models.newPolicyProvider": "New model policy",
+  "models.newPolicy_inherit": "Inherit", "models.newPolicy_off": "Off", "models.newPolicy_on": "On",
+  "models.newBadge": "NEW", "models.newCount": "{count} new, off",
 } as const;
 
 export type TKey = keyof typeof en;

--- a/gui/src/i18n/fr.ts
+++ b/gui/src/i18n/fr.ts
@@ -2101,4 +2101,6 @@ export const fr: Record<TKey, string> = {
   "lab.layer.protocol_conformance": "Conformité du protocole",
   "lab.layer.live_route_compatibility": "Compatibilité des routes en direct",
   "lab.layer.task_effectiveness": "Efficacité des tâches",
+  "models.newPolicyGlobal": "Désactiver les nouveaux modèles par défaut", "models.newPolicyProvider": "Politique des nouveaux modèles",
+  "models.newPolicy_inherit": "Hériter", "models.newPolicy_off": "Désactivé", "models.newPolicy_on": "Activé", "models.newBadge": "NOUVEAU", "models.newCount": "{count} nouveaux, désactivés",
 };

--- a/gui/src/i18n/ja.ts
+++ b/gui/src/i18n/ja.ts
@@ -2134,4 +2134,6 @@ export const ja: Record<TKey, string> = {
   "dash.visionTimeout": "タイムアウト",
   "dash.visionTimeoutInvalid": "{min} から {max} ミリ秒の整数を入力してください。",
   "dash.visionAdvancedPopover": "詳細なビジョン設定",
+  "models.newPolicyGlobal": "新しいモデルを無効で追加", "models.newPolicyProvider": "新しいモデルのポリシー",
+  "models.newPolicy_inherit": "継承", "models.newPolicy_off": "オフ", "models.newPolicy_on": "オン", "models.newBadge": "新着", "models.newCount": "新着 {count} 件、オフ",
 };

--- a/gui/src/i18n/ko.ts
+++ b/gui/src/i18n/ko.ts
@@ -2135,4 +2135,6 @@ export const ko: Record<TKey, string> = {
   "dash.visionTimeout": "제한 시간",
   "dash.visionTimeoutInvalid": "{min}에서 {max} 밀리초 사이의 정수를 입력하세요.",
   "dash.visionAdvancedPopover": "고급 비전 설정",
+  "models.newPolicyGlobal": "새 모델을 비활성화 상태로 추가", "models.newPolicyProvider": "새 모델 정책",
+  "models.newPolicy_inherit": "상속", "models.newPolicy_off": "끔", "models.newPolicy_on": "켬", "models.newBadge": "신규", "models.newCount": "신규 {count}개, 꺼짐",
 };

--- a/gui/src/i18n/ru.ts
+++ b/gui/src/i18n/ru.ts
@@ -2136,4 +2136,6 @@ export const ru: Record<TKey, string> = {
   "dash.visionTimeout": "Таймаут",
   "dash.visionTimeoutInvalid": "Введите целое число от {min} до {max} миллисекунд.",
   "dash.visionAdvancedPopover": "Дополнительные настройки изображений",
+  "models.newPolicyGlobal": "Добавлять новые модели выключенными", "models.newPolicyProvider": "Политика новых моделей",
+  "models.newPolicy_inherit": "Наследовать", "models.newPolicy_off": "Выкл.", "models.newPolicy_on": "Вкл.", "models.newBadge": "НОВАЯ", "models.newCount": "Новых: {count}, выкл.",
 };

--- a/gui/src/i18n/tr.ts
+++ b/gui/src/i18n/tr.ts
@@ -2136,4 +2136,6 @@ export const tr: Record<TKey, string> = {
   "dash.visionTimeout": "Zaman aşımı",
   "dash.visionTimeoutInvalid": "{min} ile {max} milisaniye arasında bir tam sayı girin.",
   "dash.visionAdvancedPopover": "Gelişmiş görsel ayarları",
+  "models.newPolicyGlobal": "Yeni modeller devre dışı başlasın", "models.newPolicyProvider": "Yeni model ilkesi",
+  "models.newPolicy_inherit": "Devral", "models.newPolicy_off": "Kapalı", "models.newPolicy_on": "Açık", "models.newBadge": "YENİ", "models.newCount": "{count} yeni, kapalı",
 };

--- a/gui/src/i18n/zh-TW.ts
+++ b/gui/src/i18n/zh-TW.ts
@@ -2099,4 +2099,6 @@ export const zhTW: Record<TKey, string> = {
   "dash.visionTimeout": "逾時",
   "dash.visionTimeoutInvalid": "請輸入 {min} 到 {max} 毫秒之間的整數。",
   "dash.visionAdvancedPopover": "進階視覺設定",
+  "models.newPolicyGlobal": "新模型預設停用", "models.newPolicyProvider": "新模型策略",
+  "models.newPolicy_inherit": "繼承", "models.newPolicy_off": "關閉", "models.newPolicy_on": "開啟", "models.newBadge": "新增", "models.newCount": "{count} 個新增，已關閉",
 };

--- a/gui/src/i18n/zh.ts
+++ b/gui/src/i18n/zh.ts
@@ -2134,4 +2134,6 @@ export const zh: Record<TKey, string> = {
   "dash.visionTimeout": "超时",
   "dash.visionTimeoutInvalid": "请输入 {min} 到 {max} 毫秒之间的整数。",
   "dash.visionAdvancedPopover": "高级视觉设置",
+  "models.newPolicyGlobal": "新模型默认停用", "models.newPolicyProvider": "新模型策略",
+  "models.newPolicy_inherit": "继承", "models.newPolicy_off": "关闭", "models.newPolicy_on": "开启", "models.newBadge": "新增", "models.newCount": "{count} 个新增，已关闭",
 };

--- a/gui/src/pages/Models.tsx
+++ b/gui/src/pages/Models.tsx
@@ -113,6 +113,11 @@ interface ModelPresetView {
   totalCount: number;
   fallback?: string;
 }
+interface ModelDiscoveryView {
+  policy: "on" | "off";
+  providers: Record<string, "on" | "off" | "inherit">;
+  recentArrivals: Record<string, Array<{ id: string; at: string; state: string }>>;
+}
 
 export default function Models({ apiBase, restartEpoch = 0 }: { apiBase: string; restartEpoch?: number }) {
   // Codex app-server staleness (devlog/_fin/260815_gui_codex_restart). Named
@@ -240,6 +245,7 @@ export default function Models({ apiBase, restartEpoch = 0 }: { apiBase: string;
   // #2465: per-provider model-preset state. Keyed by provider so one card's busy state cannot
   // freeze the others.
   const [presets, setPresets] = useState<Record<string, ModelPresetView>>({});
+  const [modelDiscovery, setModelDiscovery] = useState<ModelDiscoveryView | null>(null);
   const [presetBusy, setPresetBusy] = useState<string | null>(null);
   const [v2Loading, setV2Loading] = useState(true);
   const [v2Busy, setV2Busy] = useState(false);
@@ -440,6 +446,7 @@ export default function Models({ apiBase, restartEpoch = 0 }: { apiBase: string;
       // Preset previews belong to the same tab. Loaded once rather than polled: the rules are
       // shipped code and the catalog poll above already refreshes the rows they describe.
       void loadPresets();
+      void loadModelDiscovery();
     }, 0);
     // Hidden tab: no timer, no /api/v2 traffic; the make-up tick refreshes on return.
     const stop = startVisibilityPoll(() => {
@@ -881,6 +888,22 @@ export default function Models({ apiBase, restartEpoch = 0 }: { apiBase: string;
     }
   };
 
+  const loadModelDiscovery = async () => {
+    try {
+      const r = await fetch(`${apiBase}/api/model-discovery`);
+      setModelDiscovery((await readJsonIfOk<ModelDiscoveryView>(r)) ?? null);
+    } catch { setModelDiscovery(null); }
+  };
+
+  const saveModelDiscovery = async (policy: "on" | "off", provider?: string) => {
+    const r = await fetch(`${apiBase}/api/model-discovery`, {
+      method: "PUT", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ policy, provider: provider ?? null }),
+    });
+    await readJsonIfOk(r);
+    await Promise.all([loadModelDiscovery(), load()]);
+  };
+
   const applyPreset = async (provider: string, mode: "preset" | "all") => {
     if (presetBusy) return;
     setPresetBusy(provider);
@@ -1089,6 +1112,8 @@ export default function Models({ apiBase, restartEpoch = 0 }: { apiBase: string;
       disabled.has(model.namespaced),
     );
     const activeCount = rows.filter(isVisible).length;
+    const recentForProvider = modelDiscovery?.recentArrivals[provider] ?? [];
+    const recentIds = new Set(recentForProvider.map(row => row.id));
     const capOn = contextCaps[provider] !== undefined;
     const providerCap = contextCaps[provider] ?? contextCapValue;
     // With the cap off, `providerCap` is only the value a future toggle would apply — for the
@@ -1155,6 +1180,7 @@ export default function Models({ apiBase, restartEpoch = 0 }: { apiBase: string;
            </span>
          )}
           <span className="muted mono text-label">{t("models.active", { active: activeCount, total: rows.length })}</span>
+          {recentForProvider.length > 0 && <span className="models-chip mono text-caption">{t("models.newCount", { count: recentForProvider.length })}</span>}
           </button>
            <div className="row models-provider-actions">
              {/* Available on every card, including the native one: the canonical `openai` seed
@@ -1305,6 +1331,21 @@ export default function Models({ apiBase, restartEpoch = 0 }: { apiBase: string;
         {!isCollapsed && (
           <div className="models-provider-body">
             {nativeProviderGroup && <p className="muted text-label models-provider-hint">{t("models.nativeHint")}</p>}
+            {!nativeProviderGroup && modelDiscovery && (
+              <div className="row models-provider-hint">
+                <span className="muted text-label">{t("models.newPolicyProvider")}</span>
+                <div className="segmented models-segmented" role="radiogroup" aria-label={t("models.newPolicyProvider")}>
+                  {(["off", "on"] as const).map(mode => (
+                    <button key={mode} type="button" role="radio"
+                      aria-checked={(modelDiscovery.providers[provider] ?? "inherit") === mode}
+                      className={`btn btn-sm${(modelDiscovery.providers[provider] ?? "inherit") === mode ? " btn-primary" : " btn-ghost"}`}
+                      onClick={() => void saveModelDiscovery(mode, provider)}>
+                      {t(`models.newPolicy_${mode}` as TKey)}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
             {rows.length === 0 && (
               <EmptyProviderHint liveModels={liveModels} discovery={discovery} showFailureBadge={false} />
             )}
@@ -1339,6 +1380,7 @@ export default function Models({ apiBase, restartEpoch = 0 }: { apiBase: string;
                          {t("models.customBadge")}
                        </span>
                      )}
+                     {!m.custom && recentIds.has(m.id) && <span className="badge badge-amber">{t("models.newBadge")}</span>}
                      {m.contextCapped && <span className="models-chip muted mono text-caption">{t("models.contextCappedValue", { value: fmtK(m.contextCap ?? contextCapValue) })}</span>}
                    </div>
                    {hoveredModel?.namespaced === m.namespaced && (() => {
@@ -1450,6 +1492,12 @@ export default function Models({ apiBase, restartEpoch = 0 }: { apiBase: string;
   const controlsBlock = (
     <>
       <div className="models-control-top-row">
+        {modelDiscovery && (
+          <div className="models-shadow-row row muted text-control">
+            <span className="models-shadow-label">{t("models.newPolicyGlobal")}</span>
+            <Switch on={modelDiscovery.policy === "off"} onClick={() => void saveModelDiscovery(modelDiscovery.policy === "off" ? "on" : "off")} label={t("models.newPolicyGlobal")} />
+          </div>
+        )}
         <div className="models-shadow-row row muted text-control" aria-busy={!shadowCall || undefined}>
           <span className="models-shadow-label">{t("models.shadowCallIntercept")} <Tooltip content={t("models.shadowCallInterceptHint", { models: shadowSourceModelLabel(shadowCall?.sourceModels) })} side="top" maxWidth={320}><span style={{ cursor: "help" }} aria-label={t("models.shadowCallInterceptHint", { models: shadowSourceModelLabel(shadowCall?.sourceModels) })}>ⓘ</span></Tooltip></span>
           <code className="text-caption models-shadow-warning" style={{ opacity: 0.6 }}>{t("models.shadowCallOriginal", { models: shadowSourceModelBadge(shadowCall?.sourceModels) })}</code>

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -165,6 +165,7 @@ export async function runInit(): Promise<void> {
       port,
       providers: { [providerName]: providerConfig },
       defaultProvider: providerName,
+      modelDiscovery: { newModelPolicy: "off" },
     };
 
     saveConfig(config);

--- a/src/cli/models-runtime.ts
+++ b/src/cli/models-runtime.ts
@@ -24,6 +24,8 @@ const USAGE = `Usage:
   ocx models selected <provider> [--set <id,id...>|--clear] [--json]
   ocx models preset show [--provider <name>] [--json]
   ocx models preset apply <provider> [--all] [--json]
+  ocx models new-policy [on|off] [--provider <name>] [--json]
+  ocx models new-arrivals [--json]
   ocx models context <status|value <tokens> [--set-all]|provider <name> on [--value <tokens>]|provider <name> off|all <on|off>> [--json]
   ocx models shadow <status|set> [model|-] [--enabled <on|off>] [--json]`;
 
@@ -226,6 +228,32 @@ async function preset(argv: string[], deps: RuntimeApiDeps): Promise<void> {
   printData(result, wantsJson, [line]);
 }
 
+async function newPolicy(argv: string[], deps: RuntimeApiDeps): Promise<void> {
+  const args = [...argv];
+  const state = args[0] && !args[0].startsWith("--") ? args.shift()!.toLowerCase() : undefined;
+  const provider = takeOption(args, "--provider")?.trim();
+  const wantsJson = takeFlag(args, "--json");
+  if (state !== undefined && state !== "on" && state !== "off") throw new CliUsageError("new policy must be on or off", USAGE);
+  rejectArgs(args, USAGE);
+  if (!state) {
+    const result = await runtimeRequest<{ policy: string; providers: Record<string, string> }>("/api/model-discovery", {}, deps);
+    const value = provider ? result.providers[provider] ?? "inherit" : result.policy;
+    printData(provider ? { provider, policy: value } : result, wantsJson, [`${provider ?? "global"}: ${value}`]);
+    return;
+  }
+  const result = await runtimeRequest<{ baselineBootstrapped?: boolean }>("/api/model-discovery", {
+    method: "PUT", body: JSON.stringify({ policy: state, provider: provider ?? null }),
+  }, deps);
+  printData(result, wantsJson, [`${provider ?? "global"}: ${state}${result.baselineBootstrapped ? " (current models recorded as known)" : ""}`]);
+}
+
+async function newArrivals(argv: string[], deps: RuntimeApiDeps): Promise<void> {
+  const args = [...argv]; const wantsJson = takeFlag(args, "--json"); rejectArgs(args, USAGE);
+  const result = await runtimeRequest<{ recentArrivals: Record<string, Array<{ id: string; at: string; state: string }>> }>("/api/model-discovery", {}, deps);
+  const lines = Object.entries(result.recentArrivals).flatMap(([provider, rows]) => rows.map(row => `${provider}/${row.id}  [${row.state}]  ${row.at}`));
+  printData(result.recentArrivals, wantsJson, lines.length ? lines : ["no recent model arrivals"]);
+}
+
 async function context(argv: string[], deps: RuntimeApiDeps): Promise<void> {
   const args = [...argv];
   const action = (args.shift() ?? "status").toLowerCase();
@@ -301,6 +329,8 @@ export async function handleModelsRuntimeCommand(sub: string, argv: string[], de
   else if (sub === "provider") action = () => providerVisibility(argv, deps);
   else if (sub === "selected") action = () => selected(argv, deps);
   else if (sub === "preset") action = () => preset(argv, deps);
+  else if (sub === "new-policy") action = () => newPolicy(argv, deps);
+  else if (sub === "new-arrivals") action = () => newArrivals(argv, deps);
   else if (sub === "context") action = () => context(argv, deps);
   else if (sub === "shadow") action = () => shadow(argv, deps);
   if (!action) return null;

--- a/src/codex/convergence.ts
+++ b/src/codex/convergence.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 
-import { getConfigDir, websocketsEnabled, withExpectedConfigGenerationSync } from "../config";
+import { getConfigDir, saveConfigPreservingClaudeCode, websocketsEnabled, withExpectedConfigGenerationSync } from "../config";
+import { reconcileSuccessfulModelDiscoveries } from "../providers/new-model-policy";
 import { COMBO_NAMESPACE } from "../combos";
 import { getAuthStorePath } from "../oauth/store";
 import type { OcxConfig } from "../types";
@@ -135,6 +136,7 @@ interface CandidateState {
   readonly changed: boolean;
   readonly notices: readonly CatalogNotice[];
   readonly modelEntitlements: CodexModelEntitlementSnapshot;
+  readonly discoveryConfig?: OcxConfig;
 }
 
 const candidateStates = new WeakMap<object, CandidateState>();
@@ -436,8 +438,17 @@ export async function gatherCodexCatalogCandidate(
           ? active
           : !hasRoutedEntries(source.catalog) ? source.catalog : null)
         : null);
+    const discoveryConfig = structuredClone(snapshot.config) as OcxConfig;
+    const discoveryChanged = reconcileSuccessfulModelDiscoveries({
+      config: discoveryConfig,
+      models: routedModels,
+      authoritativeProviders: providerModelOutcomes
+        .filter(outcome => outcome.state === "authoritative")
+        .map(outcome => outcome.provider),
+      now: new Date().toISOString(),
+    });
     const preparedCatalog = prepareCatalog(
-      snapshot.config,
+      discoveryConfig,
       source,
       active,
       routedModels,
@@ -502,6 +513,7 @@ export async function gatherCodexCatalogCandidate(
         || Buffer.from(cacheBytes ?? []).toString("utf8") !== preparedCacheBytes,
       notices: Object.freeze([...notices]),
       modelEntitlements,
+      ...(discoveryChanged ? { discoveryConfig } : {}),
     });
     return { kind: "candidate", candidate };
   } catch (error) {
@@ -649,6 +661,12 @@ export async function convergeCodexCatalog(
   const state = candidateStates.get(gathered.candidate as object)!;
   lifecycle.onCommitBegin?.();
   const committed = await commitCodexCatalogCandidate(gathered.candidate, request.deadlineMs);
+  if (committed.kind === "committed" && state.discoveryConfig) {
+    const mutable = snapshot.config as OcxConfig;
+    mutable.modelDiscovery = state.discoveryConfig.modelDiscovery;
+    mutable.disabledModels = state.discoveryConfig.disabledModels;
+    saveConfigPreservingClaudeCode(mutable);
+  }
   return {
     changed: committed.kind === "committed" ? committed.changed : false,
     catalogRefresh: projectCommit(committed, state.notices),

--- a/src/providers/new-model-policy.ts
+++ b/src/providers/new-model-policy.ts
@@ -1,0 +1,116 @@
+import type { OcxConfig } from "../types";
+import { routedSlug } from "./slug-codec";
+
+export const MODEL_REMOVAL_GRACE_FETCHES = 3;
+export const MAX_KNOWN_MODELS_PER_PROVIDER = 2_000;
+export const MAX_RECENT_ARRIVALS_PER_PROVIDER = 50;
+
+export type KnownModelBaseline = NonNullable<NonNullable<OcxConfig["modelDiscovery"]>["knownModels"]>[string];
+export type NewModelPolicy = "on" | "off";
+
+export interface NewModelPolicyResult {
+  newIds: string[];
+  nextBaseline: KnownModelBaseline;
+  slugsToDisable: string[];
+  arrivals: Array<{ id: string; at: string }>;
+  overflow: boolean;
+}
+
+/** Pure successful-discovery transition. An absent baseline bootstraps without hiding anything. */
+export function applyNewModelPolicy(options: {
+  provider: string;
+  discoveredIds: Iterable<string>;
+  baseline?: KnownModelBaseline;
+  policy: NewModelPolicy;
+  hasSelectedModels?: boolean;
+  now: string;
+}): NewModelPolicyResult {
+  const discovered = [...new Set(options.discoveredIds)].sort();
+  const prior = options.baseline;
+  if (!prior) {
+    return {
+      newIds: [],
+      nextBaseline: { ids: discovered, removed: [], updatedAt: options.now },
+      slugsToDisable: [], arrivals: [],
+      overflow: discovered.length > MAX_KNOWN_MODELS_PER_PROVIDER,
+    };
+  }
+  const active = new Set(prior.ids);
+  const removed = new Set(prior.removed);
+  const seen = new Set(discovered);
+  const newIds = discovered.filter(id => !active.has(id) && !removed.has(id));
+  const missing: Record<string, number> = {};
+  for (const id of active) {
+    if (seen.has(id)) continue;
+    const count = (prior.missing?.[id] ?? 0) + 1;
+    if (count >= MODEL_REMOVAL_GRACE_FETCHES) {
+      active.delete(id);
+      removed.add(id);
+    } else missing[id] = count;
+  }
+  for (const id of discovered) active.add(id);
+  const unionSize = active.size + removed.size;
+  const overflow = unionSize > MAX_KNOWN_MODELS_PER_PROVIDER;
+  const arrivals = newIds.map(id => ({ id, at: options.now }));
+  return {
+    newIds,
+    nextBaseline: {
+      ids: [...active].sort(), removed: [...removed].sort(), updatedAt: options.now,
+      ...(Object.keys(missing).length ? { missing } : {}),
+    },
+    // A non-empty preset/custom allowlist already excludes arrivals. This explicit no-op is
+    // deliberate: preset mode owns which matching flagships arrive on.
+    slugsToDisable: !overflow && options.policy === "off" && !options.hasSelectedModels
+      ? newIds.map(id => routedSlug(options.provider, id)) : [],
+    arrivals,
+    overflow,
+  };
+}
+
+export function effectiveNewModelPolicy(config: OcxConfig, provider: string): NewModelPolicy {
+  const local = config.providers[provider]?.newModelPolicy;
+  if (local === "on" || local === "off") return local;
+  return config.modelDiscovery?.newModelPolicy ?? "on";
+}
+
+/** Apply authoritative provider rows to a mutable convergence copy; degraded providers are omitted. */
+export function reconcileSuccessfulModelDiscoveries(options: {
+  config: OcxConfig;
+  models: Iterable<{ provider: string; id: string; custom?: boolean }>;
+  authoritativeProviders: Iterable<string>;
+  now: string;
+}): boolean {
+  const byProvider = new Map<string, string[]>();
+  for (const model of options.models) {
+    if (model.custom) continue;
+    const ids = byProvider.get(model.provider) ?? [];
+    ids.push(model.id); byProvider.set(model.provider, ids);
+  }
+  let changed = false;
+  for (const provider of options.authoritativeProviders) {
+    const configured = options.config.providers[provider];
+    if (!configured || configured.liveModels === false) continue;
+    const discoveredIds = byProvider.get(provider) ?? [];
+    const discovery = options.config.modelDiscovery ??= {};
+    const known = discovery.knownModels ??= {};
+    const result = applyNewModelPolicy({
+      provider, discoveredIds, baseline: known[provider],
+      policy: effectiveNewModelPolicy(options.config, provider),
+      hasSelectedModels: (configured.selectedModels?.length ?? 0) > 0,
+      now: options.now,
+    });
+    if (result.overflow) continue;
+    known[provider] = result.nextBaseline;
+    if (result.slugsToDisable.length) {
+      const disabled = options.config.disabledModels ??= [];
+      for (const slug of result.slugsToDisable) if (!disabled.includes(slug)) disabled.push(slug);
+    }
+    if (result.arrivals.length) {
+      const recent = discovery.recentArrivals ??= {};
+      recent[provider] = [...(recent[provider] ?? []), ...result.arrivals]
+        .slice(-MAX_RECENT_ARRIVALS_PER_PROVIDER);
+    }
+    changed = true;
+  }
+  return changed;
+}

--- a/src/providers/new-model-policy.ts
+++ b/src/providers/new-model-policy.ts
@@ -16,6 +16,26 @@ export interface NewModelPolicyResult {
   overflow: boolean;
 }
 
+/**
+ * Whether a transition actually changes persisted state.
+ *
+ * `updatedAt` moves on every successful fetch, so comparing whole baselines would report a
+ * change every time and rewrite config.json on every catalog convergence — a write amplification
+ * that also churns the config generation other writers revalidate against. Only the fields that
+ * carry meaning are compared.
+ */
+function baselineDiffers(prior: KnownModelBaseline | undefined, next: KnownModelBaseline): boolean {
+  if (!prior) return true;
+  const sameList = (a: readonly string[], b: readonly string[]) =>
+    a.length === b.length && a.every((value, index) => value === b[index]);
+  if (!sameList(prior.ids, next.ids) || !sameList(prior.removed, next.removed)) return true;
+  const priorMissing = prior.missing ?? {};
+  const nextMissing = next.missing ?? {};
+  const keys = new Set([...Object.keys(priorMissing), ...Object.keys(nextMissing)]);
+  for (const key of keys) if (priorMissing[key] !== nextMissing[key]) return true;
+  return false;
+}
+
 /** Pure successful-discovery transition. An absent baseline bootstraps without hiding anything. */
 export function applyNewModelPolicy(options: {
   provider: string;
@@ -100,17 +120,27 @@ export function reconcileSuccessfulModelDiscoveries(options: {
       now: options.now,
     });
     if (result.overflow) continue;
+    const priorBaseline = known[provider];
+    const baselineChanged = baselineDiffers(priorBaseline, result.nextBaseline);
     known[provider] = result.nextBaseline;
+    // Keep the previous timestamp when nothing else moved, so a steady-state roster does not
+    // make the baseline look dirty on the next comparison either.
+    if (!baselineChanged && priorBaseline) known[provider] = priorBaseline;
     if (result.slugsToDisable.length) {
       const disabled = options.config.disabledModels ??= [];
-      for (const slug of result.slugsToDisable) if (!disabled.includes(slug)) disabled.push(slug);
+      for (const slug of result.slugsToDisable) {
+        if (disabled.includes(slug)) continue;
+        disabled.push(slug);
+        changed = true;
+      }
     }
     if (result.arrivals.length) {
       const recent = discovery.recentArrivals ??= {};
       recent[provider] = [...(recent[provider] ?? []), ...result.arrivals]
         .slice(-MAX_RECENT_ARRIVALS_PER_PROVIDER);
+      changed = true;
     }
-    changed = true;
+    if (baselineChanged) changed = true;
   }
   return changed;
 }

--- a/src/server/management/model-routes.ts
+++ b/src/server/management/model-routes.ts
@@ -177,6 +177,69 @@ export async function handleModelRoutes(ctx: ManagementContext): Promise<Respons
   // ~/.opencodex/config.json with the `existing-uuid` test fixture.
   const persistConfig = deps.saveConfigPreservingClaudeCode ?? saveConfigPreservingClaudeCode;
 
+  if (url.pathname === "/api/model-discovery" && req.method === "GET") {
+    const providers = Object.fromEntries(Object.entries(config.providers).map(([name, provider]) => [
+      name, provider.newModelPolicy ?? "inherit",
+    ]));
+    const recentArrivals = Object.fromEntries(Object.entries(config.modelDiscovery?.recentArrivals ?? {}).map(([name, rows]) => [
+      name,
+      rows.map(row => ({
+        ...row,
+        state: (config.disabledModels ?? []).some(slug => slugEquals(slug, name, row.id))
+          ? "auto-disabled" : "enabled",
+      })),
+    ]));
+    const baselineCounts = Object.fromEntries(Object.entries(config.modelDiscovery?.knownModels ?? {}).map(([name, baseline]) => [
+      name, baseline.ids.length,
+    ]));
+    return jsonResponse({
+      policy: config.modelDiscovery?.newModelPolicy ?? "on", providers, recentArrivals, baselineCounts,
+    });
+  }
+
+  if (url.pathname === "/api/model-discovery" && req.method === "PUT") {
+    let body: { policy?: unknown; provider?: unknown };
+    try { body = await readManagementJsonBody(req); } catch (error) { rethrowManagementBodyTooLarge(error); return jsonResponse({ error: "invalid JSON body" }, 400); }
+    if (body.policy !== "on" && body.policy !== "off") return jsonResponse({ error: "policy must be on or off" }, 400);
+    const provider = typeof body.provider === "string" && body.provider.trim() ? body.provider.trim() : null;
+    let baselineBootstrapped = false;
+    if (provider) {
+      if (!hasOwnProvider(config.providers, provider)) return jsonResponse({ error: "unknown provider" }, 404);
+      config.providers[provider].newModelPolicy = body.policy;
+    } else {
+      const wasAbsent = config.modelDiscovery?.newModelPolicy === undefined;
+      config.modelDiscovery ??= {};
+      config.modelDiscovery.newModelPolicy = body.policy;
+      if (body.policy === "off" && wasAbsent) {
+        const models = await fetchAllModels(config);
+        const known = config.modelDiscovery.knownModels ??= {};
+        const at = new Date().toISOString();
+        for (const name of Object.keys(config.providers)) {
+          known[name] ??= { ids: [...new Set(models.filter(m => m.provider === name).map(m => m.id))].sort(), removed: [], updatedAt: at };
+        }
+        baselineBootstrapped = true;
+      }
+    }
+    persistConfig(config);
+    const catalogRefresh = await convergeCodexCatalog();
+    return jsonResponse({ ok: true, policy: body.policy, provider, ...(baselineBootstrapped ? { baselineBootstrapped } : {}), catalogRefresh });
+  }
+
+  if (url.pathname === "/api/model-discovery/acknowledge" && req.method === "POST") {
+    let body: { provider?: unknown; ids?: unknown };
+    try { body = await readManagementJsonBody(req); } catch (error) { rethrowManagementBodyTooLarge(error); return jsonResponse({ error: "invalid JSON body" }, 400); }
+    const provider = typeof body.provider === "string" ? body.provider.trim() : "";
+    if (!provider || !Array.isArray(body.ids) || body.ids.some(id => typeof id !== "string")) {
+      return jsonResponse({ error: "provider and string ids are required" }, 400);
+    }
+    const acknowledged = new Set(body.ids as string[]);
+    const recent = config.modelDiscovery?.recentArrivals;
+    if (recent?.[provider]) recent[provider] = recent[provider].filter(row => !acknowledged.has(row.id));
+    persistConfig(config);
+    const catalogRefresh = await convergeCodexCatalog();
+    return jsonResponse({ ok: true, provider, acknowledged: [...acknowledged], catalogRefresh });
+  }
+
   if (url.pathname === "/api/catalog" && req.method === "GET") {
     const { readCatalog, readCodexCatalogPath } = await import("../../codex/catalog");
     const catalog = readCatalog(readCodexCatalogPath());
@@ -376,6 +439,10 @@ export async function handleModelRoutes(ctx: ManagementContext): Promise<Respons
           providerConfig.selectedModels = [...new Set([...providerConfig.selectedModels, ...additions])];
         }
         disabled = disabled.filter(stored => !targets.some(target => matchesTarget(stored, target)));
+        const arrivals = config.modelDiscovery?.recentArrivals?.[provider];
+        if (arrivals) config.modelDiscovery!.recentArrivals![provider] = arrivals.filter(row => (
+          !targets.some(target => !target.native && target.id === row.id)
+        ));
       }
     } else {
       for (const target of targets) {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -260,6 +260,18 @@ export interface OcxConfig {
   managementUsageMaxReadBytes?: number;
   providers: Record<string, OcxProviderConfig>;
   defaultProvider: string;
+  /** Persisted state for newly discovered provider models (#2464). Absent keeps legacy "on" behavior. */
+  modelDiscovery?: {
+    newModelPolicy?: "on" | "off";
+    knownModels?: Record<string, {
+      ids: string[];
+      removed: string[];
+      updatedAt: string;
+      /** Consecutive successful discoveries in which an active id was absent. */
+      missing?: Record<string, number>;
+    }>;
+    recentArrivals?: Record<string, Array<{ id: string; at: string }>>;
+  };
   /** OpenAI provider-contract migration marker (v2 = single `openai` provider with account mode). */
   openaiProviderTierVersion?: 1 | 2;
   /** One-time migration marker for Antigravity's static-catalog defaults. */

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -275,6 +275,8 @@ export interface OcxProviderConfig {
    * full set so the user can pick). See devlog issue_052_provider-model-allowlist.
    */
   selectedModels?: string[];
+  /** Override for newly discovered models. Absent/"inherit" uses the install policy. */
+  newModelPolicy?: "on" | "off" | "inherit";
   /**
    * Model-preset marker for `selectedModels` (#2465). Absent means "all", exactly today's
    * semantics — an existing provider is never narrowed by an upgrade.

--- a/tests/codex-convergence-contract.test.ts
+++ b/tests/codex-convergence-contract.test.ts
@@ -372,10 +372,10 @@ test("a failure cause never carries message text, paths or identifiers (#1784)",
   expect(body).not.toContain("failed writing");
 });
 
-test("the route inventory contains exactly the specified 7 + 8 + 2 + 2 convergence calls", () => {
+test("the route inventory contains exactly the specified 7 + 10 + 2 + 2 convergence calls", () => {
   const counts = Object.fromEntries([
     ["provider-routes.ts", 7],
-    ["model-routes.ts", 8],
+    ["model-routes.ts", 10],
     ["combo-routes.ts", 2],
     ["agent-settings-routes.ts", 2],
   ].map(([file, expected]) => {
@@ -387,10 +387,18 @@ test("the route inventory contains exactly the specified 7 + 8 + 2 + 2 convergen
   }));
   expect(counts).toEqual({
     "provider-routes.ts": 7,
-    "model-routes.ts": 8,
+    "model-routes.ts": 10,
     "combo-routes.ts": 2,
     "agent-settings-routes.ts": 2,
   });
+});
+
+test("both model-discovery write paths converge the Codex catalog", () => {
+  const source = readFileSync(join(import.meta.dir, "..", "src", "server", "management", "model-routes.ts"), "utf8");
+  const settings = source.slice(source.indexOf('url.pathname === "/api/model-discovery" && req.method === "PUT"'), source.indexOf('url.pathname === "/api/model-discovery/acknowledge"'));
+  const acknowledge = source.slice(source.indexOf('url.pathname === "/api/model-discovery/acknowledge"'), source.indexOf('url.pathname === "/api/catalog"'));
+  expect(settings.match(/await convergeCodexCatalog\(\)/g)?.length).toBe(1);
+  expect(acknowledge.match(/await convergeCodexCatalog\(\)/g)?.length).toBe(1);
 });
 
 /**

--- a/tests/model-discovery-management-api.test.ts
+++ b/tests/model-discovery-management-api.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { handleManagementAPI } from "../src/server/management-api";
+import type { OcxConfig } from "../src/types";
+import { ManagementRequest as Request } from "./helpers/management-auth";
+
+function config(): OcxConfig {
+  return { port: 10100, defaultProvider: "vendor", providers: { vendor: { liveModels: false, models: ["known"] } }, disabledModels: ["vendor/new"] };
+}
+
+async function call(live: OcxConfig, path: string, method = "GET", body?: unknown) {
+  const url = new URL(`http://localhost${path}`);
+  const response = await handleManagementAPI(new Request(url, {
+    method, ...(body === undefined ? {} : { headers: { "content-type": "application/json" }, body: JSON.stringify(body) }),
+  }), url, live, {
+    saveConfigPreservingClaudeCode: () => {},
+    fetchAllModels: async () => [{ provider: "vendor", id: "known" } as never],
+    createManagementConvergeCodex: () => async () => ({ kind: "catalog-only", changed: false, catalogRefresh: { status: "unchanged" }, observed: {} as never, history: {} as never }),
+  });
+  return { response: response!, json: await response!.json() as Record<string, unknown> };
+}
+
+describe("model discovery management API", () => {
+  test("PUT off bootstraps, GET reports state, and provider override persists", async () => {
+    const live = config();
+    const put = await call(live, "/api/model-discovery", "PUT", { policy: "off", provider: null });
+    expect(put.response.status).toBe(200); expect(put.json.baselineBootstrapped).toBe(true);
+    expect(live.modelDiscovery?.knownModels?.vendor.ids).toEqual(["known"]);
+    await call(live, "/api/model-discovery", "PUT", { policy: "on", provider: "vendor" });
+    expect(live.providers.vendor.newModelPolicy).toBe("on");
+    const get = await call(live, "/api/model-discovery");
+    expect(get.json.policy).toBe("off");
+  });
+
+  test("acknowledge removes recent badges without changing visibility", async () => {
+    const live = config();
+    live.modelDiscovery = { recentArrivals: { vendor: [{ id: "new", at: "2026-08-24T00:00:00Z" }] } };
+    const result = await call(live, "/api/model-discovery/acknowledge", "POST", { provider: "vendor", ids: ["new"] });
+    expect(result.response.status).toBe(200);
+    expect(live.modelDiscovery.recentArrivals?.vendor).toEqual([]);
+    expect(live.disabledModels).toEqual(["vendor/new"]);
+  });
+});

--- a/tests/new-model-policy.test.ts
+++ b/tests/new-model-policy.test.ts
@@ -34,4 +34,49 @@ describe("new-model policy", () => {
     expect(reconcileSuccessfulModelDiscoveries({ config, models: [{ provider: "vendor", id: "a" }], authoritativeProviders: [], now })).toBe(false);
     expect(config.modelDiscovery.knownModels.vendor.ids).toEqual(["a", "b"]);
   });
+
+  /**
+   * The steady state is the common case: a provider's roster is identical on almost every
+   * convergence, and convergence runs on every catalog write. Reporting "changed" there would
+   * rewrite config.json each time and move the config generation that other writers revalidate
+   * against — a write amplification with no user-visible cause.
+   */
+  test("an unchanged roster reports no change, so convergence does not rewrite config", () => {
+    const config = {
+      port: 10100, defaultProvider: "vendor", providers: { vendor: {} },
+      modelDiscovery: {
+        newModelPolicy: "off" as const,
+        knownModels: { vendor: { ids: ["a", "b"], removed: [], updatedAt: "2026-01-01T00:00:00Z" } },
+      },
+    };
+    const changed = reconcileSuccessfulModelDiscoveries({
+      config,
+      models: [{ provider: "vendor", id: "a" }, { provider: "vendor", id: "b" }],
+      authoritativeProviders: ["vendor"],
+      now,
+    });
+    expect(changed).toBe(false);
+    // The timestamp is deliberately NOT advanced: a bumped updatedAt would make the very next
+    // comparison look dirty and reintroduce the rewrite it just avoided.
+    expect(config.modelDiscovery.knownModels.vendor.updatedAt).toBe("2026-01-01T00:00:00Z");
+  });
+
+  test("a genuine arrival still reports a change and records the disable", () => {
+    const config = {
+      port: 10100, defaultProvider: "vendor", providers: { vendor: {} },
+      modelDiscovery: {
+        newModelPolicy: "off" as const,
+        knownModels: { vendor: { ids: ["a"], removed: [], updatedAt: "2026-01-01T00:00:00Z" } },
+      },
+    } as Parameters<typeof reconcileSuccessfulModelDiscoveries>[0]["config"];
+    const changed = reconcileSuccessfulModelDiscoveries({
+      config,
+      models: [{ provider: "vendor", id: "a" }, { provider: "vendor", id: "b" }],
+      authoritativeProviders: ["vendor"],
+      now,
+    });
+    expect(changed).toBe(true);
+    expect(config.disabledModels).toEqual(["vendor/b"]);
+    expect(config.modelDiscovery!.knownModels!.vendor!.updatedAt).toBe(now);
+  });
 });

--- a/tests/new-model-policy.test.ts
+++ b/tests/new-model-policy.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { applyNewModelPolicy, reconcileSuccessfulModelDiscoveries } from "../src/providers/new-model-policy";
+
+const now = "2026-08-24T02:11:00Z";
+
+describe("new-model policy", () => {
+  test("bootstraps without hiding the existing catalog", () => {
+    const r = applyNewModelPolicy({ provider: "openrouter", discoveredIds: ["a", "b"], policy: "off", now });
+    expect(r.newIds).toEqual([]); expect(r.slugsToDisable).toEqual([]); expect(r.nextBaseline.ids).toEqual(["a", "b"]);
+  });
+
+  test("walks the design scenario and auto-disables each id at most once", () => {
+    let baseline = { ids: ["a", "b", "c"], removed: [], updatedAt: now };
+    let r = applyNewModelPolicy({ provider: "openrouter", discoveredIds: ["a", "b", "c", "d"], baseline, policy: "off", now });
+    expect(r.slugsToDisable).toEqual(["openrouter/d"]); baseline = r.nextBaseline;
+    r = applyNewModelPolicy({ provider: "openrouter", discoveredIds: ["a", "b", "c", "d"], baseline, policy: "off", now });
+    expect(r.newIds).toEqual([]); baseline = r.nextBaseline;
+    for (let i = 0; i < 3; i++) baseline = applyNewModelPolicy({ provider: "openrouter", discoveredIds: ["a", "b", "c"], baseline, policy: "off", now }).nextBaseline;
+    expect(baseline.removed).toContain("d");
+    r = applyNewModelPolicy({ provider: "openrouter", discoveredIds: ["a", "b", "c", "d"], baseline, policy: "off", now });
+    expect(r.newIds).toEqual([]); expect(r.slugsToDisable).toEqual([]);
+    baseline = r.nextBaseline;
+    r = applyNewModelPolicy({ provider: "openrouter", discoveredIds: ["a", "b", "d", "c-v2"], baseline, policy: "off", now });
+    expect(r.slugsToDisable).toEqual(["openrouter/c-v2"]);
+  });
+
+  test("preset mode is a deliberate no-op while still recording the arrival", () => {
+    const r = applyNewModelPolicy({ provider: "openrouter", discoveredIds: ["a", "d"], baseline: { ids: ["a"], removed: [], updatedAt: now }, policy: "off", hasSelectedModels: true, now });
+    expect(r.newIds).toEqual(["d"]); expect(r.arrivals).toEqual([{ id: "d", at: now }]); expect(r.slugsToDisable).toEqual([]);
+  });
+
+  test("degraded providers do not poison a persisted baseline", () => {
+    const config = { port: 10100, defaultProvider: "vendor", providers: { vendor: {} }, modelDiscovery: { newModelPolicy: "off" as const, knownModels: { vendor: { ids: ["a", "b"], removed: [], updatedAt: now } } } };
+    expect(reconcileSuccessfulModelDiscoveries({ config, models: [{ provider: "vendor", id: "a" }], authoritativeProviders: [], now })).toBe(false);
+    expect(config.modelDiscovery.knownModels.vendor.ids).toEqual(["a", "b"]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2464. A provider with `liveModels: true` re-fetches its `/models` endpoint on every catalog sync, so any model the vendor publishes overnight appears in the Codex picker silently. For a proxy that routes real spend, the user should opt models IN as they arrive.

The mechanism is a persisted per-provider baseline: a model is new iff it is discovered now and absent from the last successful baseline. New arrivals get a `disabledModels` row instead of a `selectedModels` seed — the blocklist composes with an empty allowlist, whereas seeding the allowlist with the full current roster would convert "all on" into a frozen snapshot and silently change what the user's existing state means.

Three properties carry the design:

**Each id can be auto-disabled at most once, ever.** A model that disappears moves to a tombstone after three consecutive successful fetches without it, and newness is `discovered − ids − removed`. Since `ids ∪ removed` grows monotonically, the flapping case holds: a user enables a new arrival, the vendor drops it long enough to prune, the vendor restores it — it comes back enabled. A rename still counts as new, which is the safe reading since pricing may have changed with it.

**A degraded fetch can never shrink the baseline.** Reconciliation runs only for providers whose gather outcome is `authoritative`. A provider outage would otherwise mark its entire catalog "new" on recovery.

**Bootstrap hides nothing.** The first run with no baseline marks everything known. Existing installs have no `modelDiscovery` key at all, which means policy "on" — today's behavior exactly, with zero change until the user opts in.

Preset mode (#2465) is a **deliberate, tested** no-op: a non-empty allowlist already excludes arrivals, so the blocklist branch would be redundant state to reconcile later. That interaction is the reason #2464 had to land after #2465 rather than beside it.

## Verification

```
bun x tsc --noEmit                                exit 0
bun test tests/new-model-policy.test.ts \
         tests/model-discovery-management-api.test.ts \
         tests/codex-convergence-contract.test.ts \
         tests/model-presets.test.ts               34 pass / 0 fail
bun run build:gui                                 ok
bun run lint:gui                                  no errors
```

Falsified per hunk: bootstrap reporting the initial catalog as new, auto-disable slugs suppressed, preset-mode providers auto-disabled, degraded providers reconciled, and each API route hunk removed — every one turned its test red, and all were restored before the final run.

The GUI was rendered against a stubbed management API rather than trusted to typecheck; the first render exposed header crowding, which moved the per-provider override into the expanded body.

**Review fix included:** reconciliation originally reported `changed = true` for every authoritative provider, so convergence rewrote `config.json` on every catalog write even when the roster was byte-identical. That is write amplification that also moves the config generation other writers revalidate against. Now only meaningful fields are compared — `updatedAt` cannot participate, since it moves on every fetch and would report a change every time. Falsified: forcing `changed = true` fails the steady-state test while the genuine-arrival test stays green, which pins that the guard narrows the write rather than disabling the policy.

The convergence-call count in `codex-convergence-contract.test.ts` goes 8 → 10 with a companion assertion naming the two new model-discovery write paths, following the pattern the preset routes established — a bare count that only ever rises stops being a contract.

## Checklist

- [x] Targets `dev`
- [x] Focused regression tests, including the full design scenario table
- [x] `docs-site/` updated
- [x] Strings added to all nine locales
- [x] No credential, auth, workflow or release-automation surface touched



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controls for automatically handling newly discovered models globally or per provider.
  * Newly discovered models can be marked **NEW**, disabled by default, enabled, or acknowledged.
  * Added model-arrival counts and badges in the Models screen.
  * Added CLI commands to view or update policies and inspect recent arrivals.
  * Added management API support for policy updates and acknowledging arrivals.

* **Documentation**
  * Documented model-discovery behavior, policy options, baseline handling, and CLI commands.
  * Added translations for the new controls and status indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->