### PR TITLE
fix(codex): adopt pre-substrate homes into the write coordinator (#1049)

### DIFF
--- a/devlog/_plan/260826_pre_substrate_adoption/010_design.md
+++ b/devlog/_plan/260826_pre_substrate_adoption/010_design.md
@@ -1,0 +1,145 @@
+# #1049 — crash-safe pre-substrate home adoption
+
+## Current facts at `dev@f392e02eb3`
+
+1. `codexWriteCoordinationEligibility` treats every absent/stable-zero-byte coordinator with
+   routed or indeterminate native evidence as `legacy-uncoordinated`
+   (`src/codex/inject-coordination.ts:87-122`). Invalid integration records refuse before
+   residue classification (`src/codex/inject-coordination.ts:93-99`).
+2. Apply calls `applyNativeArtifacts()` directly for `legacy-uncoordinated`, without
+   `withCodexWriteLock` or `beginTransition` (`src/codex/inject.ts:940-952`). The coordinated
+   branch publishes a pending transition before touching native files
+   (`src/codex/inject.ts:953-1011`).
+3. Restore enters `withCodexWriteLock` only for `coordinated`; every other eligibility falls
+   through to the legacy config restore (`src/codex/inject.ts:1536-1554`,
+   `src/codex/inject.ts:1641-1647`).
+4. The runtime status validator and SQL constraint omit `adoption-pending`
+   (`src/codex/transition-state.ts:40-92`), while generation zero rejects all history identity
+   and schedule fields (`src/codex/transition-state.ts:211-221`).
+5. Missing-database creation opens the final path with SQLite `create:true` before schema and
+   singleton initialization (`src/codex/transition-state.ts:349-426`). A kill in that interval
+   can leave a final zero-byte or rowless file; existing unversioned and rowless files are then
+   deliberately refused (`src/codex/transition-state.ts:283-305`).
+6. `withCodexWriteLock` always opens the ordinary coordinator transaction, so routed residue is
+   rejected before its callback (`src/codex/codex-write-lock.ts:305-307`,
+   `src/codex/transition-state.ts:269-280`). Adoption needs an explicit transaction-open mode;
+   changing eligibility alone is unreachable.
+7. `adoption-pending` has no runtime occurrence. Its durable publication and recovery rules are
+   specified in `devlog/_fin/260804_codex_write_substrate/005_contract.md:706-790` and the
+   implementation deferral is recorded in
+   `devlog/_fin/260816_wave34_closeout/101_1049_legacy_adoption.md:58-109`.
+
+## Exclusions and necessity gate
+
+- Do not infer authority from indeterminate evidence. It remains legacy-operable and
+  uncoordinated; only positively classified routed residue is adoptable.
+- Do not add an artifact fingerprint. The archived correction explains that byte equality cannot
+  prove whether the retained callback started or partially completed; recovery must rerun the
+  idempotent high-level operation.
+- Do not delete or clear the singleton. Adoption advances the same durable row to the ordinary
+  positive-generation pending schedule.
+- Do not relax ordinary clean initialization or the existing unversioned/rowless refusals.
+- Do not add a second lock or a history-worker path. Adoption reuses N and the existing apply/remove
+  transition publication; workers still see only ordinary `pending` rows.
+
+Configuration and deletion cannot solve the issue: the missing behavior is durable migration of
+an already-routed home. Existing `beginTransition` is reused for adoption completion, while a new
+publisher is necessary because no existing owner atomically publishes a complete SQLite database.
+
+## Root-cause hypotheses and falsifiers
+
+- H1 (accepted): eligibility bypass is the sole cause. Falsifier: route routed residue to the
+  ordinary lock and observe successful callback entry. Current `assertInitialStateCanBeCreated`
+  rejects before callback, disproving sufficiency and showing the missing adoption opener.
+- H2 (rejected): adding `adoption-pending` only to the TypeScript union is sufficient. Falsifier:
+  persist such a row. Current SQL status and generation-zero shape constraints reject it, so schema,
+  runtime validation, and creation must move together.
+- H3 (rejected): create the final SQLite file and then fill it under N. Falsifier: terminate after
+  final-path creation but before commit. The next opener sees an unversioned/rowless authority and
+  refuses; therefore publication must make the complete database visible in one atomic step.
+
+The causal mechanism is structural: pre-substrate residue cannot seed the ordinary clean row, so
+eligibility bypasses N; direct writes then never create transition authority. Adoption must publish
+a distinct recoverable generation-zero row before native mutation, under the same N acquisition
+that serializes the retained callback, and then atomically advance it to the ordinary pending
+transition.
+
+## Design
+
+### State shape
+
+Add durable `history_status = 'adoption-pending'`. Its exact generation-zero identity is:
+
+- `native_generation = 0`, `current_tx_id = NULL`;
+- fresh non-empty `history_tx_id`;
+- intent-derived `history_direction = apply | remove`;
+- fresh opaque non-empty `history_authority_snapshot_id`;
+- null reason/retry/count fields and zero attempts.
+
+Generation zero accepts either the existing all-null `unknown` row or that complete adoption
+identity. `beginTransition` conditionally replaces either with generation one (or the next positive
+generation) and the ordinary `pending` schedule. Ordinary readers may report adoption-pending, but
+no history worker dispatches it because worker scheduling remains gated on `pending`.
+
+### Publication
+
+When and only when eligibility says `adopt`, `withCodexWriteLock` opens the coordinator in an
+adoption mode carrying `apply | remove` intent. If the final path is absent:
+
+1. Create a unique same-directory mode-0600 temporary file.
+2. Open SQLite at the temporary path, create the complete v1 schema and adoption singleton in a
+   committed rollback-journal transaction, set `user_version = 1`, and close SQLite.
+3. Reopen/validate the temp database through the same row parser, fsync its bytes, then close it.
+4. Atomically publish without replacement using same-directory `linkSync(temp, final)`. `EEXIST`
+   means a contestant won; unlink only this process's temp and strictly open the winner.
+5. Fsync the parent directory, unlink the temp alias, then open the final path normally and begin N.
+
+No SQLite handle crosses publication. No post-publication error path unlinks the final database.
+Existing final paths, including unversioned or rowless files, always take strict validation and are
+never rewritten by adoption.
+
+### Eligibility and callers
+
+- routed residue + missing or valid integration record + absent/stable-zero-byte coordinator:
+  `adopt`;
+- indeterminate residue: retain `legacy-uncoordinated`, preserving current operability;
+- clean: `coordinated`; invalid record: `refused`; any authoritative existing coordinator:
+  `coordinated` and strict opener validation.
+
+Apply and restore treat `adopt` as coordinated with the matching intent. The adoption row is visible
+before either retained native callback runs. The existing callback then calls `beginTransition`
+before filesystem mutation, replacing adoption-pending with ordinary pending in the same SQLite
+transaction. If callback publication or mutation throws, rollback leaves adoption-pending durable;
+the next authorized apply/restore reruns idempotently.
+
+### Crash-state table
+
+| Kill point | Final path after death | Next authorized operation |
+| --- | --- | --- |
+| after temp creation, before SQLite commit | absent | ignores private temp; republishes |
+| after complete temp commit, before link | absent | ignores private temp; republishes |
+| after no-clobber link, before alias cleanup | complete validated adoption-pending | opens and resumes |
+| after final open / during retained callback | complete adoption-pending or ordinary pending | reruns adoption callback or existing recovery |
+
+The publication primitive is the only absent-to-present boundary. Thus every observable final path
+is either absent or a complete validated v1 database.
+
+## Files and verification
+
+- `src/codex/convergence-types.ts`: durable status type.
+- `src/codex/transition-state.ts`: schema, row validation, complete temp publisher, adoption opener.
+- `src/codex/codex-write-lock.ts`: explicit adoption intent passed to the transaction owner.
+- `src/codex/inject-coordination.ts`: routed adoption classification.
+- `src/codex/inject.ts`: apply/restore route `adopt` through N.
+- focused tests beside coordinator/injection tests, including child-process kill checkpoints,
+  routed and indeterminate classification, and substrate-native unaffected behavior.
+
+Required proof:
+
+```text
+bun x tsc --noEmit
+bun test tests/codex-inject*.test.ts tests/codex-composed-acceptance.test.ts <all tests found by rg to touch inject-coordination>
+```
+
+Each new regression is mutation-checked by reverting its production hunk, observing the named test
+fail for the intended reason, restoring the hunk, and rerunning green.

--- a/src/codex/codex-write-lock.ts
+++ b/src/codex/codex-write-lock.ts
@@ -93,6 +93,8 @@ export interface CodexWriteLockOptions {
   admitted: CodexWriteWitness;
   /** Authoritative synchronous re-read while N and C are both held. */
   readAdmissionUnderLock(): CodexWriteWitness;
+  /** Positively authorized migration of an already-routed pre-substrate home. */
+  adoption?: { readonly direction: "apply" | "remove" };
 }
 
 /**
@@ -304,7 +306,7 @@ export async function withCodexWriteLock<T>(
 
     let transaction: ReturnType<typeof openCodexCoordinatorTransaction> | undefined;
     try {
-      transaction = openCodexCoordinatorTransaction(databasePath);
+      transaction = openCodexCoordinatorTransaction(databasePath, options.adoption);
     } catch (error) {
       // Only contention retries. A malformed database, an unsafe path, or an
       // identity failure will fail identically forever; telling a caller to retry

--- a/src/codex/convergence-types.ts
+++ b/src/codex/convergence-types.ts
@@ -34,7 +34,7 @@ export interface CodexIntegrationRecord {
 }
 
 export interface CodexHistoryState {
-  status: "converged" | "pending" | "running" | "blocked" | "unknown" | "not-evaluated";
+  status: "adoption-pending" | "converged" | "pending" | "running" | "blocked" | "unknown" | "not-evaluated";
   /**
    * Why it is not converged, when it is not. These are terminal observations
    * for one attempt, not reasons to collapse the durable retry schedule.

--- a/src/codex/inject-coordination.ts
+++ b/src/codex/inject-coordination.ts
@@ -41,6 +41,7 @@ export const DEFAULT_INJECT_LOCK_TIMEOUT_MS = 5_000;
  */
 export type CodexWriteCoordinationEligibility =
   | { kind: "coordinated" }
+  | { kind: "adopt" }
   | { kind: "legacy-uncoordinated"; reason: string }
   | { kind: "refused"; reason: string };
 
@@ -97,6 +98,7 @@ export function codexWriteCoordinationEligibility(deps: {
 
   const residue = deps.residue();
   if (residue.kind === "clean") return { kind: "coordinated" };
+  if (residue.kind === "residue" && !coordinatorIsStableZeroByte) return { kind: "adopt" };
   /*
    * Everything else keeps the path it has always had.
    *

--- a/src/codex/inject.ts
+++ b/src/codex/inject.ts
@@ -953,6 +953,7 @@ export async function injectCodexConfig(
     const coordinated = await withCodexWriteLock(
       {
         timeoutMs: options.lockTimeoutMs ?? DEFAULT_INJECT_LOCK_TIMEOUT_MS,
+        ...(eligibility.kind === "adopt" ? { adoption: { direction: "apply" as const } } : {}),
         admitted: { authoritySnapshotId: witness.comparisonId },
         readAdmissionUnderLock: () => ({
           authoritySnapshotId: recomputeInjectWitness({
@@ -1547,13 +1548,14 @@ export async function restoreNativeCodexAsync(
   let config: CodexRestoreConfigResult;
   let transitionReceipt: { nativeGeneration: number; currentTxId: string } | undefined;
 
-  if (eligibility.kind === "coordinated") {
+  if (eligibility.kind === "coordinated" || eligibility.kind === "adopt") {
     // The restore has no candidate bytes to witness; freshness comes from the
     // filesystem reads and the desired-state re-read performed under the lock.
     const witness = { authoritySnapshotId: "codex-native-restore" };
     const coordinated = await withCodexWriteLock(
       {
         timeoutMs: DEFAULT_INJECT_LOCK_TIMEOUT_MS,
+        ...(eligibility.kind === "adopt" ? { adoption: { direction: "remove" as const } } : {}),
         admitted: witness,
         readAdmissionUnderLock: () => witness,
       },

--- a/src/codex/transition-state.ts
+++ b/src/codex/transition-state.ts
@@ -10,7 +10,17 @@
  * Design record: devlog/_fin/260804_codex_write_substrate/005_contract.md §1.
  */
 import { randomUUID } from "node:crypto";
-import { chmodSync, lstatSync, realpathSync } from "node:fs";
+import {
+  chmodSync,
+  closeSync,
+  fsyncSync,
+  linkSync,
+  lstatSync,
+  openSync,
+  realpathSync,
+  unlinkSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
 
 import { Database } from "bun:sqlite";
 
@@ -38,7 +48,7 @@ import {
 } from "./user-identity";
 
 export const CODEX_COORDINATOR_SCHEMA_VERSION = 1;
-const DURABLE_HISTORY_STATUSES = new Set(["converged", "pending", "running", "blocked", "unknown"]);
+const DURABLE_HISTORY_STATUSES = new Set(["adoption-pending", "converged", "pending", "running", "blocked", "unknown"]);
 const DURABLE_HISTORY_REASONS = new Set([
   "db-busy",
   "permission",
@@ -66,7 +76,7 @@ const CREATE_TRANSITION_TABLE = `
     history_pending_rows INTEGER,
     history_backup_entries INTEGER,
     updated_at TEXT NOT NULL,
-    CHECK (history_status IN ('converged', 'pending', 'running', 'blocked', 'unknown')),
+    CHECK (history_status IN ('adoption-pending', 'converged', 'pending', 'running', 'blocked', 'unknown')),
     CHECK (history_reason IS NULL OR history_reason IN
       ('db-busy', 'permission', 'unreadable', 'schema', 'timeout',
        'shutdown-cancelled', 'worker-died', 'overtaken', 'record-write-failed')),
@@ -75,14 +85,20 @@ const CREATE_TRANSITION_TABLE = `
     CHECK ((native_generation = 0 AND current_tx_id IS NULL)
         OR (native_generation > 0 AND length(trim(current_tx_id)) > 0)),
     CHECK ((native_generation = 0
+            AND history_status = 'unknown'
             AND history_tx_id IS NULL
             AND history_direction IS NULL
             AND history_authority_snapshot_id IS NULL)
+        OR (native_generation = 0
+            AND history_status = 'adoption-pending'
+            AND length(trim(history_tx_id)) > 0
+            AND history_direction IS NOT NULL
+            AND length(trim(history_authority_snapshot_id)) > 0)
         OR (native_generation > 0
             AND history_tx_id = current_tx_id
             AND history_direction IS NOT NULL
             AND length(trim(history_authority_snapshot_id)) > 0)),
-    CHECK (native_generation > 0 OR
+    CHECK (native_generation > 0 OR history_status = 'adoption-pending' OR
       (history_status = 'unknown'
        AND history_reason IS NULL
        AND history_attempts = 0
@@ -99,6 +115,15 @@ const INITIALIZE_TRANSITION_ROW = `
     history_authority_snapshot_id, history_pending_rows,
     history_backup_entries, updated_at
   ) VALUES (1, 0, NULL, 'unknown', NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, ?)`;
+
+const INITIALIZE_ADOPTION_ROW = `
+  INSERT INTO codex_transition_state (
+    singleton, native_generation, current_tx_id,
+    history_status, history_reason, history_attempts,
+    history_next_retry_at, history_tx_id, history_direction,
+    history_authority_snapshot_id, history_pending_rows,
+    history_backup_entries, updated_at
+  ) VALUES (1, 0, NULL, 'adoption-pending', NULL, 0, NULL, ?, ?, ?, NULL, NULL, ?)`;
 
 const SELECT_TRANSITION_ROW = `
   SELECT native_generation, current_tx_id,
@@ -210,8 +235,15 @@ function rowToState(row: TransitionRow | null): CodexTransitionState {
 
   const generation = row.native_generation;
   if (generation === 0) {
-    if (row.current_tx_id !== null || row.history_tx_id !== null
-      || row.history_direction !== null || row.history_authority_snapshot_id !== null) {
+    const ordinaryInitial = row.history_status === "unknown"
+      && row.history_tx_id === null
+      && row.history_direction === null
+      && row.history_authority_snapshot_id === null;
+    const adoptionInitial = row.history_status === "adoption-pending"
+      && Boolean(row.history_tx_id?.trim())
+      && (row.history_direction === "apply" || row.history_direction === "remove")
+      && Boolean(row.history_authority_snapshot_id?.trim());
+    if (row.current_tx_id !== null || (!ordinaryInitial && !adoptionInitial)) {
       throw new CodexCoordinatorTransactionError("The initial coordinator row contains transition metadata.");
     }
   } else if (!row.current_tx_id?.trim()
@@ -234,11 +266,71 @@ function rowToState(row: TransitionRow | null): CodexTransitionState {
     nativeGeneration: generation,
     currentTxId: row.current_tx_id,
     history,
-    historySchedule: generation === 0 ? null : {
+    historySchedule: generation === 0 && row.history_status !== "adoption-pending" ? null : {
       direction: row.history_direction as "apply" | "remove",
       authoritySnapshotId: row.history_authority_snapshot_id as string,
     },
   };
+}
+
+export type CodexCoordinatorAdoptionCheckpoint = "temp-created" | "temp-committed" | "published";
+
+export interface CodexCoordinatorAdoptionOptions {
+  readonly direction: "apply" | "remove";
+  readonly onCheckpoint?: (checkpoint: CodexCoordinatorAdoptionCheckpoint) => void;
+}
+
+function fsyncPath(path: string): void {
+  const fd = openSync(path, "r");
+  try { fsyncSync(fd); } finally { closeSync(fd); }
+}
+
+function publishAdoptionDatabase(
+  finalDatabasePath: string,
+  options: CodexCoordinatorAdoptionOptions,
+): void {
+  const parent = dirname(finalDatabasePath);
+  const tempPath = join(parent, `.${basename(finalDatabasePath)}.adopt-${process.pid}-${randomUUID()}.tmp`);
+  let tempPresent = false;
+  try {
+    const fd = openSync(tempPath, "wx", 0o600);
+    closeSync(fd);
+    tempPresent = true;
+    options.onCheckpoint?.("temp-created");
+
+    const temp = new Database(tempPath, { readwrite: true, create: false });
+    try {
+      temp.exec("PRAGMA journal_mode = DELETE; BEGIN IMMEDIATE");
+      temp.exec(CREATE_TRANSITION_TABLE);
+      temp.query(INITIALIZE_ADOPTION_ROW).run(
+        randomUUID(),
+        options.direction,
+        randomUUID(),
+        new Date().toISOString(),
+      );
+      temp.exec(`PRAGMA user_version = ${CODEX_COORDINATOR_SCHEMA_VERSION}; COMMIT`);
+      readCodexCoordinatorState(temp);
+    } catch (error) {
+      try { temp.exec("ROLLBACK"); } catch { /* commit may already have completed */ }
+      throw error;
+    } finally {
+      temp.close();
+    }
+    fsyncPath(tempPath);
+    options.onCheckpoint?.("temp-committed");
+
+    linkSync(tempPath, finalDatabasePath);
+    options.onCheckpoint?.("published");
+    if (process.platform !== "win32") fsyncPath(parent);
+  } catch (error) {
+    if (errorCode(error) !== "EEXIST") throw error;
+  } finally {
+    if (tempPresent) {
+      try { unlinkSync(tempPath); } catch (error) {
+        if (errorCode(error) !== "ENOENT") throw error;
+      }
+    }
+  }
 }
 
 export function readCodexCoordinatorState(database: Database): CodexTransitionState {
@@ -346,7 +438,10 @@ function createCapability(
   };
 }
 
-export function openCodexCoordinatorTransaction(finalDatabasePath: string): CodexCoordinatorTransactionController {
+export function openCodexCoordinatorTransaction(
+  finalDatabasePath: string,
+  adoption?: CodexCoordinatorAdoptionOptions,
+): CodexCoordinatorTransactionController {
   let database: Database | undefined;
   let transactionOpen = false;
   let closed = false;
@@ -388,6 +483,10 @@ export function openCodexCoordinatorTransaction(finalDatabasePath: string): Code
     } catch (cause) {
       if (errorCode(cause) !== "ENOENT") throw cause;
       databaseWasAbsent = true;
+    }
+    if (databaseWasAbsent && adoption) {
+      publishAdoptionDatabase(finalDatabasePath, adoption);
+      databaseWasAbsent = false;
     }
     database = new Database(finalDatabasePath, { create: true });
     if (databaseWasAbsent) {

--- a/tests/codex-coordinator-doctor.test.ts
+++ b/tests/codex-coordinator-doctor.test.ts
@@ -205,3 +205,17 @@ test("a fresh zero-byte coordinator stays on the locked path until it is stable"
   });
   expect(settled.kind).toBe("legacy-uncoordinated");
 });
+
+test("routed homes adopt while indeterminate homes retain the legacy path", () => {
+  rmSync(coordinatorPath, { force: true });
+  expect(codexWriteCoordinationEligibility({
+    coordinatorPath: () => coordinatorPath,
+    residue: () => ({ kind: "residue" }),
+    integrationRecord: () => ({ kind: "missing" }),
+  })).toEqual({ kind: "adopt" });
+  expect(codexWriteCoordinationEligibility({
+    coordinatorPath: () => coordinatorPath,
+    residue: () => ({ kind: "indeterminate" }),
+    integrationRecord: () => ({ kind: "ready" }),
+  })).toMatchObject({ kind: "legacy-uncoordinated" });
+});

--- a/tests/codex-inject-write-lock.test.ts
+++ b/tests/codex-inject-write-lock.test.ts
@@ -268,13 +268,13 @@ describe("the lock is on the production path", () => {
   }, SPAWN_BUDGET_MS);
 });
 
-describe("homes the coordinator cannot adopt keep working", () => {
+describe("pre-substrate home adoption", () => {
   /**
    * Every install predating this substrate is routed with no coordinator row,
    * and that row cannot be created over routed bytes. Gating on the lock there
    * would have broken re-injection for the entire installed base.
    */
-  test("a pre-substrate routed home still injects, without a coordinator", () => {
+  test("a pre-substrate routed home adopts and records a coordinated transition", () => {
     writeFileSync(join(codexHome, "config.toml"), [
       'model_provider = "opencodex"',
       'model = "gpt-5.5"',
@@ -289,6 +289,24 @@ describe("homes the coordinator cannot adopt keep working", () => {
     const result = runInject(10100);
     expect(result.success).toBeTrue();
     expect(readFileSync(join(codexHome, "config.toml"), "utf-8")).toContain("openai_base_url");
+    const coordinatorPath = resolveCodexCoordinatorDatabasePath(
+      resolveEffectiveUserIdentity(),
+      realpathSync.native(codexHome),
+    );
+    coordinatorCleanup.push(coordinatorPath);
+    expect(existsSync(coordinatorPath)).toBeTrue();
+    const state = parseChildJson<{
+      kind: string;
+      state?: { nativeGeneration: number; history: { status: string } };
+    }>(runChild(["--eval", `
+      const { readCodexTransitionState } = require("./src/codex/transition-state");
+      console.log(JSON.stringify(readCodexTransitionState()));
+    `], {
+      ...process.env,
+      CODEX_HOME: codexHome,
+      OPENCODEX_HOME: opencodexHome,
+    }), "read adopted transition");
+    expect(state).toMatchObject({ kind: "ready", state: { nativeGeneration: 1 } });
   });
 
   test("a zero-byte coordinator remnant does not wedge a pre-substrate routed home", () => {

--- a/tests/codex-transition-state-adoption.test.ts
+++ b/tests/codex-transition-state-adoption.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { openCodexCoordinatorTransaction } from "../src/codex/transition-state";
+import {
+  resolveCodexCoordinatorDatabasePath,
+  resolveEffectiveUserIdentity,
+} from "../src/codex/user-identity";
+
+const CHILD = join(import.meta.dir, "helpers", "codex-adoption-crash-child.ts");
+let root = "";
+let codexHome = "";
+let opencodexHome = "";
+let coordinatorPath = "";
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "ocx-adoption-crash-"));
+  codexHome = mkdtempSync(join(root, "codex-"));
+  opencodexHome = mkdtempSync(join(root, "opencodex-"));
+  process.env.CODEX_HOME = codexHome;
+  process.env.OPENCODEX_HOME = opencodexHome;
+  coordinatorPath = resolveCodexCoordinatorDatabasePath(
+    resolveEffectiveUserIdentity(),
+    realpathSync.native(codexHome),
+  );
+});
+
+afterEach(() => {
+  delete process.env.CODEX_HOME;
+  delete process.env.OPENCODEX_HOME;
+  rmSync(coordinatorPath, { force: true });
+  rmSync(root, { recursive: true, force: true });
+});
+
+for (const checkpoint of ["temp-created", "temp-committed", "published"] as const) {
+  test(`a kill at ${checkpoint} leaves the home adoptable`, () => {
+    const child = spawnSync(process.execPath, [CHILD], {
+      cwd: join(import.meta.dir, ".."),
+      env: {
+        ...process.env,
+        CODEX_HOME: codexHome,
+        OPENCODEX_HOME: opencodexHome,
+        OCX_ADOPTION_CRASH_PAYLOAD: JSON.stringify({ coordinatorPath, checkpoint }),
+      },
+      encoding: "utf8",
+    });
+    expect(child.status).toBe(86);
+    expect(existsSync(coordinatorPath)).toBe(checkpoint === "published");
+
+    const resumed = openCodexCoordinatorTransaction(coordinatorPath, { direction: "apply" });
+    try {
+      const state = resumed.version();
+      expect(state).toEqual({ nativeGeneration: 0, currentTxId: null });
+      const expectation = resumed.expectation();
+      const update = resumed.capability.beginTransition(state, {
+        txId: expectation.txId,
+        direction: "apply",
+        authoritySnapshotId: "resume-authority",
+        nextRetryAt: "2026-08-26T00:00:00.000Z",
+      });
+      expect(update).toMatchObject({ kind: "updated", state: { nativeGeneration: 1 } });
+      resumed.assertPublished(expectation);
+      resumed.commit();
+    } finally {
+      resumed.close();
+    }
+  });
+}

--- a/tests/helpers/codex-adoption-crash-child.ts
+++ b/tests/helpers/codex-adoption-crash-child.ts
@@ -1,0 +1,13 @@
+import { openCodexCoordinatorTransaction } from "../../src/codex/transition-state";
+
+const payload = JSON.parse(process.env.OCX_ADOPTION_CRASH_PAYLOAD ?? "{}") as {
+  coordinatorPath: string;
+  checkpoint: "temp-created" | "temp-committed" | "published";
+};
+
+openCodexCoordinatorTransaction(payload.coordinatorPath, {
+  direction: "apply",
+  onCheckpoint(checkpoint) {
+    if (checkpoint === payload.checkpoint) process.exit(86);
+  },
+});


### PR DESCRIPTION
## Summary

Closes #1049. `inject-coordination.ts` classified routed and indeterminate pre-substrate homes as `legacy-uncoordinated`, and `inject.ts` skipped transition publication on that path, so a home that predates the write substrate never entered the coordinator. `git grep adoption-pending` returned nothing — the planned adoption state was designed and never built.

A routed pre-substrate home now publishes a complete `adoption-pending` coordinator before any native write, and both apply and restore adopt through the write lock. Indeterminate homes keep the legacy-operable path: they are the case where we genuinely cannot tell what we are looking at, and guessing there is what would strand a home.

**Crash-safety is the primary property here, not a footnote.** Publication is atomic by construction: the coordinator is built in a temp file, committed, fsynced, and then `linkSync`ed into place. Every crash window leaves exactly one of two states — no authoritative database at all, or a complete resumable one. There is no window that leaves a half-built coordinator, because a partially written temp file is never the published name.

## Verification

```
bun x tsc --noEmit                                     exit 0
bun test <inject/transition/doctor>                     17 pass / 0 fail
bun test <the above + codex-composed-acceptance>        25 pass / 0 fail
```

The crash tests are real: a child process is killed at each of the three checkpoints (`temp-created`, `temp-committed`, `published`) and the parent then asserts the home is still adoptable, resuming a full transition through it.

Falsified independently on the merge with `dev`, not only on the branch: replacing `linkSync` with in-place creation — the obvious "simpler" implementation — turns all three crash cases red with `CodexCoordinatorLegacyAmbiguousError: An existing unversioned coordinator database cannot be adopted automatically`. That is exactly the stranding this issue is about, and it is what the atomic publication buys. Restored, all three pass.

The subagent's own run additionally showed 99 pass across 8 files and 56 pass across 5 files, with five new regressions driven red by reverting their production hunks.

## Checklist

- [x] Targets `dev`
- [x] Design note recorded at `devlog/_plan/260826_pre_substrate_adoption/010_design.md`
- [x] Crash windows tested with real killed child processes, not simulated
- [x] Composed acceptance suite green
- [x] No credential, auth, workflow or release-automation surface touched



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added crash-safe adoption for existing routed homes with recoverable coordinator state.
  - Added explicit adoption handling for apply and restore operations.
  - Added detection for homes eligible for coordinator adoption.

- **Bug Fixes**
  - Improved resilience when adoption is interrupted, allowing operations to resume safely without overwriting existing data.

- **Tests**
  - Added coverage for adoption eligibility, coordinator creation, state transitions, and recovery across crash points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->