### PR TITLE
feat(config): explicit rebase provenance for deletion vs unseen keys (#1478)

### DIFF
--- a/devlog/_plan/260826_config_rebase_provenance/010_design.md
+++ b/devlog/_plan/260826_config_rebase_provenance/010_design.md
@@ -1,0 +1,84 @@
+# 010 — Config rebase deletion provenance
+
+## Current facts
+
+- `configSchema` accepts unknown top-level fields through `.passthrough()`
+  (`src/config.ts:837-934`), and successful loads return that parsed object
+  (`src/config.ts:1795-1812`). An additive metadata field therefore remains readable
+  by an older binary and survives its ordinary whole-config save.
+- The long-lived rebase state contains cloned config values only
+  (`src/config.ts:2601-2627`). It cannot record an absent key's cause.
+- Guarded save consequently derives authority from key presence: disk-only keys are
+  excluded from reconciliation (`src/config.ts:2912-2935`). This preserves an
+  explicit deletion but also discards an unseen concurrent addition.
+- The two pinned outcomes are distinct. A disk-only `claudeCode` edit must survive an
+  unrelated save (`tests/config-user-edits.test.ts:221-231`), while an explicit live
+  deletion of a disk-only `grokExcludedModels` key must win
+  (`tests/config-user-edits.test.ts:652-675`). Presence alone cannot satisfy both.
+
+## Persisted contract
+
+Add optional top-level metadata:
+
+```json
+{
+  "configRebaseProvenance": {
+    "version": 1,
+    "deletedTopLevelKeys": ["grokExcludedModels"]
+  }
+}
+```
+
+`deletedTopLevelKeys` is a sorted, duplicate-free tombstone set. A top-level deletion
+writer records the key through one config-owned helper. Before persistence, every key
+that is present in the candidate removes its tombstone; an empty set removes the
+metadata. Thus a later explicit assignment supersedes an earlier deletion.
+
+Only a schema-valid version-1 record grants deletion authority. Missing metadata keeps
+the current presence-based behavior until a writer explicitly records a deletion.
+Unknown/future records pass through opaquely and grant no authority. Loading or arming
+a baseline never creates provenance because neither operation knows why a key is absent.
+
+The metadata key itself is excluded from ordinary three-way reconciliation. The guarded
+save combines the candidate's explicit tombstones with the newest disk metadata, then
+uses only candidate tombstones to decide whether a disk-only field is reconciled or
+deleted. This lets an unseen concurrent key survive while preserving an explicit live
+deletion.
+
+## Top-level deletion-writer inventory
+
+The current source contains these top-level config deletions; nested provider,
+`claudeCode`, sidecar, combo-row, and routing-profile-row deletions are not top-level
+provenance events.
+
+- `src/server/management/agent-settings-routes.ts:98` — `clientIntegrations`
+- `src/server/management/agent-settings-routes.ts:344` — `multiAgentMode`
+- `src/server/management/agent-settings-routes.ts:351` — `keepNativeChatGptOnV1`
+- `src/server/management/agent-settings-routes.ts:562-568` — four injection fields
+- `src/server/management/agent-settings-routes.ts:599` — generic delegation fields
+- `src/server/management/agent-settings-routes.ts:718-720` — two fallback fields
+- `src/server/management/agent-settings-routes.ts:761` — `grokExcludedModels`
+- `src/server/management/config-routes.ts:440,461-475` — seven general settings
+- `src/server/management/combo-routes.ts:249` — `combos`
+- `src/server/management/routing-profile-routes.ts:332` — `routingProfiles`
+- `src/providers/context-cap.ts:53,74,81` — `providerContextCaps`
+- `src/codex/account-priority.ts:37,81` — priorities and active pin
+- `src/codex/account-pause.ts:15` — paused account IDs
+- `src/codex/desired-state.ts:117` — `clientIntegrations`
+- `src/providers/provider-id-rewrite.ts:177` — `customModels`
+- `src/cli/v2.ts:196,220` — two CLI general settings
+- `src/cli/provider.ts:313` — a nested provider row, excluded from top-level provenance
+
+The implementation replaces every included statement with the config-owned helper.
+Normalization-only deletes in `src/config.ts` are excluded: they sanitize parsed data
+and are not user-intent writers. Reconciliation deletes are also excluded because they
+apply another writer's state rather than originate intent.
+
+## Verification and falsification
+
+- Focused tests cover explicit deletion versus unseen addition, missing/version-1/future
+  migration behavior, old-reader passthrough, and every writer's use of the helper.
+- For each new behavior test, revert the production hunk it exercises, confirm failure,
+  then restore it before final verification.
+- Final gates: `bun x tsc --noEmit`, all `tests/config*.test.ts`, and every additional
+  test file found by imports of `src/config.ts` or the changed deletion-writer modules.

--- a/src/cli/v2.ts
+++ b/src/cli/v2.ts
@@ -15,7 +15,7 @@ import { dirname } from "node:path";
 import { activeCodexConfigPath, getAgentsEnabled, getAgentsMaxDepth, getLogicalMaxThreads, getMultiAgentModeHintText, getSubagentDeveloperInstructions, hasAgentsMaxThreads, isMultiAgentV2Enabled, setMultiAgentModeHintText, transitionMultiAgentV2 } from "../codex/features";
 
 import { commandInvocation, type SpawnInvocation } from "../lib/win-exec";
-import { loadConfig, saveConfig } from "../config";
+import { deleteConfigTopLevelKey, loadConfig, saveConfig } from "../config";
 import { resolveAndPersistCodexRuntime, type ResolveCodexRuntimeDeps } from "../codex/runtime";
 
 export interface V2CliDeps {
@@ -193,7 +193,7 @@ export async function cmdV2(args: string[], deps: V2CliDeps = {}, findPort?: () 
         return 1;
       }
     }
-    if (modeArg === "default") delete cfg.multiAgentMode;
+    if (modeArg === "default") deleteConfigTopLevelKey(cfg, "multiAgentMode");
     else cfg.multiAgentMode = modeArg as "v1" | "v2";
     saveConfig(cfg);
     try {
@@ -217,7 +217,7 @@ export async function cmdV2(args: string[], deps: V2CliDeps = {}, findPort?: () 
     const next = flag === "on";
     const already = cfg.keepNativeChatGptOnV1 === true === next;
     if (next) cfg.keepNativeChatGptOnV1 = true;
-    else delete cfg.keepNativeChatGptOnV1;
+    else deleteConfigTopLevelKey(cfg, "keepNativeChatGptOnV1");
     saveConfig(cfg);
     try {
       const sync = deps.sync ?? (await import("../codex/sync")).syncModelsToCodex;

--- a/src/codex/account-pause.ts
+++ b/src/codex/account-pause.ts
@@ -1,4 +1,5 @@
 import type { OcxConfig } from "../types";
+import { deleteConfigTopLevelKey } from "../config/rebase-provenance";
 
 /** Whether an account is administratively excluded from future pool selection. */
 export function isCodexAccountPaused(config: OcxConfig, accountId: string): boolean {
@@ -12,7 +13,7 @@ export function setCodexAccountPaused(config: OcxConfig, accountId: string, paus
   else pausedIds.delete(accountId);
 
   if (pausedIds.size > 0) config.pausedCodexAccountIds = [...pausedIds];
-  else delete config.pausedCodexAccountIds;
+  else deleteConfigTopLevelKey(config, "pausedCodexAccountIds");
 }
 
 export function forgetCodexAccountPause(config: OcxConfig, accountId: string): void {

--- a/src/codex/account-priority.ts
+++ b/src/codex/account-priority.ts
@@ -1,6 +1,7 @@
 import { isValidCodexAccountId, MAIN_CODEX_ACCOUNT_ID } from "./account-id";
 import { DEFAULT_ACCOUNT_PRIORITY, normalizeAccountPriority } from "./pool-rotation";
 import type { OcxConfig } from "../types";
+import { deleteConfigTopLevelKey } from "../config/rebase-provenance";
 
 /**
  * Which ids may carry a selection order: any pool account, plus the synthetic
@@ -34,7 +35,7 @@ export function setCodexAccountPriority(config: OcxConfig, accountId: string, pr
   else entries.set(accountId, priority);
 
   if (entries.size > 0) config.codexAccountPriorities = Object.fromEntries(entries);
-  else delete config.codexAccountPriorities;
+  else deleteConfigTopLevelKey(config, "codexAccountPriorities");
 }
 
 export function forgetCodexAccountPriority(config: OcxConfig, accountId: string): void {
@@ -78,6 +79,6 @@ export function setCodexAccountPin(config: OcxConfig, accountId: string): void {
 /** Release the pin. With `accountId` given, only when it is the pinned account. */
 export function clearCodexAccountPin(config: OcxConfig, accountId?: string): void {
   if (accountId === undefined || config.activeCodexAccountPinned === accountId) {
-    delete config.activeCodexAccountPinned;
+    deleteConfigTopLevelKey(config, "activeCodexAccountPinned");
   }
 }

--- a/src/codex/desired-state.ts
+++ b/src/codex/desired-state.ts
@@ -20,7 +20,7 @@
  *
  * Design record: devlog/_fin/260803_codex_desktop_toggle/030_desired_state.md.
  */
-import { loadConfig, mutatePersistedConfig } from "../config";
+import { deleteConfigTopLevelKey, loadConfig, mutatePersistedConfig } from "../config";
 import type { OcxClientIntegrationsConfig, OcxConfig } from "../types";
 import { runStartupReadinessSync, type ReadinessGate, type SyncOutcomeLike } from "../server/readiness";
 
@@ -114,7 +114,7 @@ export function setIntegrationEnabled(
     }
     // Drop the key entirely once nothing is left in it, so enabling twice does
     // not leave `"clientIntegrations": {}` behind in the user's file.
-    if (Object.keys(integrations).length === 0) delete config.clientIntegrations;
+    if (Object.keys(integrations).length === 0) deleteConfigTopLevelKey(config, "clientIntegrations");
     else config.clientIntegrations = integrations;
     return { changed: true, value: enabled };
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -141,6 +141,15 @@ export {
   writeRuntimePort,
   type RuntimePortState,
 } from "./config/process-state";
+import {
+  clearPendingConfigTopLevelDeletions,
+  configHasRebaseProvenance,
+  configRebaseDeletionKeys,
+  CONFIG_REBASE_PROVENANCE_KEY,
+  deleteConfigTopLevelKey,
+  projectConfigRebaseProvenance,
+} from "./config/rebase-provenance";
+export { deleteConfigTopLevelKey } from "./config/rebase-provenance";
 
 export class OpenAiTierBackupCleanupError extends Error {
   constructor() { super("OpenAI tier backup temporary cleanup failed"); this.name = "OpenAiTierBackupCleanupError"; }
@@ -865,6 +874,9 @@ const configSchema = z.object({
   ]).optional().catch(undefined),
   providers: z.record(z.string(), providerConfigSchema),
   defaultProvider: z.string().min(1).default("openai"),
+  // Future versions remain opaque through passthrough-compatible whole-config saves.
+  // Only version 1 grants deletion authority in the rebase path.
+  configRebaseProvenance: z.unknown().optional(),
   // A retry can be billable, so absence and malformed hand edits both stay off.
   emptyCompletionRetry: z.boolean().optional().catch(false),
   // A malformed hand edit must not silently stop opening the browser: fall back
@@ -2456,7 +2468,12 @@ function persistConfigUnlocked(config: OcxConfig): boolean {
   // External editors can add provider rows the live config deliberately does
   // not route with yet; merge them at the serialization boundary so an
   // unrelated in-process save cannot erase the provider or its overlay.
+  // Provider preservation reads symbol-keyed live-owner state, which structuredClone
+  // intentionally drops. Resolve that ownership before projecting JSON provenance.
+  const provenanceProjection = projectConfigRebaseProvenance(config);
   const persisted = withPreservedDiskOnlyProviders(config);
+  if (provenanceProjection.configRebaseProvenance === undefined) delete persisted.configRebaseProvenance;
+  else persisted.configRebaseProvenance = provenanceProjection.configRebaseProvenance;
   const bytes = JSON.stringify(persisted, null, 2) + "\n";
   let unchanged = false;
   try {
@@ -2484,9 +2501,15 @@ export function saveConfig(config: OcxConfig): void {
   // Keep the real-home assertion ahead of even lock-directory preparation.
   assertNotRealHomeUnderTest(getConfigDir());
   withConfigMutationLockSync(() => {
-    const projected = projectCustomModelCatalogMigration(readRawConfigJson(), config);
-    if (persistConfigUnlocked(projected)) bumpGenerationForCooperatingConfigWrite();
-    adoptCustomModelCatalogMigration(config, projected);
+    const withProvenance = projectCustomModelCatalogMigration(
+      readRawConfigJson(),
+      projectConfigRebaseProvenance(config),
+    );
+    if (persistConfigUnlocked(withProvenance)) bumpGenerationForCooperatingConfigWrite();
+    adoptCustomModelCatalogMigration(config, withProvenance);
+    if (withProvenance.configRebaseProvenance === undefined) delete config.configRebaseProvenance;
+    else config.configRebaseProvenance = structuredClone(withProvenance.configRebaseProvenance);
+    clearPendingConfigTopLevelDeletions(config);
   });
 }
 
@@ -2605,7 +2628,6 @@ const claudeCodeBaseline = new WeakMap<OcxConfig, unknown>();
  * reconciliation paths below.
  */
 const liveConfigBaseline = new WeakMap<OcxConfig, OcxConfig>();
-
 /**
  * The live config retains the address of the socket Bun actually opened, while
  * this map retains the operator's desired address for the next process start.
@@ -2909,6 +2931,8 @@ export function saveConfigPreservingClaudeCode(config: OcxConfig): void {
     if (baseline && onDisk !== undefined) {
       const persistedDiagnostics = configDiagnosticsFromRaw(JSON.stringify(onDisk));
       if (persistedDiagnostics.source === "file") {
+        const deletedKeys = configRebaseDeletionKeys(config);
+        const provenanceExists = configHasRebaseProvenance(config);
         // Only keys this live config is actually known to have diverged on may be
         // rebased. The baseline is captured once when the server arms it, so any key
         // that appeared on disk afterwards — through saveConfig(), a hand edit, or
@@ -2922,8 +2946,11 @@ export function saveConfigPreservingClaudeCode(config: OcxConfig): void {
         const rebaseableKeys = new Set([
           ...Object.keys(baseline as unknown as Record<string, unknown>),
           ...Object.keys(config as unknown as Record<string, unknown>),
+          ...(provenanceExists
+            ? Object.keys(persistedDiagnostics.config as unknown as Record<string, unknown>)
+            : []),
         ]);
-        const skipped = new Set(["hostname", "port", "claudeCode"]);
+        const skipped = new Set(["hostname", "port", "claudeCode", CONFIG_REBASE_PROVENANCE_KEY]);
         for (const key of Object.keys(persistedDiagnostics.config as unknown as Record<string, unknown>)) {
           if (!rebaseableKeys.has(key)) skipped.add(key);
         }
@@ -2933,6 +2960,7 @@ export function saveConfigPreservingClaudeCode(config: OcxConfig): void {
           persistedDiagnostics.config as unknown as Record<string, unknown>,
           skipped,
         );
+        for (const key of deletedKeys) delete (config as unknown as Record<string, unknown>)[key];
       }
     }
     if (claudeCodeBaseline.has(config)) {
@@ -2946,10 +2974,13 @@ export function saveConfigPreservingClaudeCode(config: OcxConfig): void {
         }
       }
     }
+    const provenanceProjection = projectConfigRebaseProvenance(config);
     const projectedConfig = projectCustomModelCatalogMigration(
       onDisk,
       config,
     );
+    if (provenanceProjection.configRebaseProvenance === undefined) delete projectedConfig.configRebaseProvenance;
+    else projectedConfig.configRebaseProvenance = provenanceProjection.configRebaseProvenance;
     const persistedBinding = bindingBaseline && onDisk
       ? readPersistedServerBinding(onDisk, bindingBaseline)
       : bindingBaseline;
@@ -2967,8 +2998,11 @@ export function saveConfigPreservingClaudeCode(config: OcxConfig): void {
       claudeCodeBaseline.set(config, structuredClone(config.claudeCode));
     }
     if (liveConfigBaseline.has(config)) {
-      liveConfigBaseline.set(config, structuredClone(config));
+      if (projectedConfig.configRebaseProvenance === undefined) delete config.configRebaseProvenance;
+      else config.configRebaseProvenance = structuredClone(projectedConfig.configRebaseProvenance);
+      liveConfigBaseline.set(config, structuredClone(projectedConfig));
     }
+    clearPendingConfigTopLevelDeletions(config);
   });
 }
 

--- a/src/config/rebase-provenance.ts
+++ b/src/config/rebase-provenance.ts
@@ -1,0 +1,63 @@
+import type { OcxConfig } from "../types";
+
+const pendingTopLevelDeletions = new WeakMap<OcxConfig, Set<string>>();
+export const CONFIG_REBASE_PROVENANCE_KEY = "configRebaseProvenance";
+
+export function parsedConfigRebaseDeletionKeys(config: OcxConfig): Set<string> | null {
+  const value = config.configRebaseProvenance;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (record.version !== 1 || !Array.isArray(record.deletedTopLevelKeys)) return null;
+  if (!record.deletedTopLevelKeys.every(key => typeof key === "string" && key !== CONFIG_REBASE_PROVENANCE_KEY)) {
+    return null;
+  }
+  return new Set(record.deletedTopLevelKeys as string[]);
+}
+
+export function configRebaseDeletionKeys(config: OcxConfig): Set<string> {
+  const deleted = new Set([
+    ...(parsedConfigRebaseDeletionKeys(config) ?? []),
+    ...(pendingTopLevelDeletions.get(config) ?? []),
+  ]);
+  const record = config as unknown as Record<string, unknown>;
+  for (const key of [...deleted]) {
+    if (Object.hasOwn(record, key) && record[key] !== undefined) deleted.delete(key);
+  }
+  return deleted;
+}
+
+export function configHasRebaseProvenance(config: OcxConfig): boolean {
+  return parsedConfigRebaseDeletionKeys(config) !== null || pendingTopLevelDeletions.has(config);
+}
+
+export function projectConfigRebaseProvenance(config: OcxConfig): OcxConfig {
+  const pending = pendingTopLevelDeletions.get(config);
+  const parsed = parsedConfigRebaseDeletionKeys(config);
+  // Preserve unknown future metadata byte-for-value. It carries no authority here.
+  if (config.configRebaseProvenance !== undefined && parsed === null) return config;
+  const deleted = new Set([...(parsed ?? []), ...(pending ?? [])]);
+  const record = config as unknown as Record<string, unknown>;
+  for (const key of [...deleted]) {
+    if (Object.hasOwn(record, key) && record[key] !== undefined) deleted.delete(key);
+  }
+  const projected = structuredClone(config);
+  if (deleted.size === 0) delete projected.configRebaseProvenance;
+  else projected.configRebaseProvenance = {
+    version: 1,
+    deletedTopLevelKeys: [...deleted].sort(),
+  };
+  return projected;
+}
+
+/** Delete one top-level config key and retain the writer's explicit intent for rebasing. */
+export function deleteConfigTopLevelKey<K extends keyof OcxConfig>(config: OcxConfig, key: K): void {
+  delete config[key];
+  if (key === CONFIG_REBASE_PROVENANCE_KEY) return;
+  const deleted = pendingTopLevelDeletions.get(config) ?? new Set<string>();
+  deleted.add(key);
+  pendingTopLevelDeletions.set(config, deleted);
+}
+
+export function clearPendingConfigTopLevelDeletions(config: OcxConfig): void {
+  pendingTopLevelDeletions.delete(config);
+}

--- a/src/providers/context-cap.ts
+++ b/src/providers/context-cap.ts
@@ -1,4 +1,5 @@
 import type { OcxConfig } from "../types";
+import { deleteConfigTopLevelKey } from "../config/rebase-provenance";
 
 export const DEFAULT_PROVIDER_CONTEXT_CAP = 350_000;
 
@@ -50,7 +51,7 @@ export function setProviderContextCap(config: OcxConfig, provider: string, enabl
     delete next[provider];
   }
   if (Object.keys(next).length > 0) config.providerContextCaps = next;
-  else delete config.providerContextCaps;
+  else deleteConfigTopLevelKey(config, "providerContextCaps");
 }
 
 /**
@@ -71,12 +72,12 @@ export function setGlobalContextCapValue(config: OcxConfig, value: number, apply
 /** Enable the cap for every named provider at the current value, or clear all caps. */
 export function setAllProviderContextCaps(config: OcxConfig, providerNames: string[], enabled: boolean): void {
   if (!enabled) {
-    delete config.providerContextCaps;
+    deleteConfigTopLevelKey(config, "providerContextCaps");
     return;
   }
   const value = globalContextCapValue(config);
   const next: Record<string, number> = {};
   for (const name of providerNames) next[name] = value;
   if (Object.keys(next).length > 0) config.providerContextCaps = next;
-  else delete config.providerContextCaps;
+  else deleteConfigTopLevelKey(config, "providerContextCaps");
 }

--- a/src/providers/provider-id-rewrite.ts
+++ b/src/providers/provider-id-rewrite.ts
@@ -1,4 +1,5 @@
 import type { OcxConfig } from "../types";
+import { deleteConfigTopLevelKey } from "../config/rebase-provenance";
 
 export interface ProviderRewriteResult {
   /** Number of references re-pointed. */
@@ -174,6 +175,6 @@ export function dropProviderCustomModels(config: OcxConfig, provider: string): n
   // `[]`, so the `customModels` field is absent either way. Only that field —
   // the `customModelCatalogMigration` marker is deliberately left in place.
   if (kept.length > 0) config.customModels = kept;
-  else delete config.customModels;
+  else deleteConfigTopLevelKey(config, "customModels");
   return existing.length - kept.length;
 }

--- a/src/server/management/agent-settings-routes.ts
+++ b/src/server/management/agent-settings-routes.ts
@@ -5,6 +5,7 @@ import { catalogModelSlug, invalidateCodexModelsCache, nativeContextLimits, nati
 import {
   DEFAULT_SUBAGENT_MODELS,
   codexAutoStartEnabled,
+  deleteConfigTopLevelKey,
   hasOwnProvider,
   isValidProviderName,
   loadConfig,
@@ -95,7 +96,7 @@ function mirrorDesiredEnabledOntoSnapshot(config: OcxConfig, client: "claude-des
   const integrations = { ...(config.clientIntegrations ?? {}) };
   if (enabled) delete integrations[client];
   else integrations[client] = false;
-  if (Object.keys(integrations).length === 0) delete config.clientIntegrations;
+  if (Object.keys(integrations).length === 0) deleteConfigTopLevelKey(config, "clientIntegrations");
   else config.clientIntegrations = integrations;
 }
 
@@ -341,14 +342,14 @@ export async function handleAgentSettingsRoutes(ctx: ManagementContext): Promise
       if (result.changed && result.threadLimit !== null) warnings.push(`Thread limit ${result.threadLimit} preserved for ${targetFlag ? "v2" : "v1"}.`);
     }
     if (wantsMode) {
-      if (mode === "default") delete config.multiAgentMode;
+      if (mode === "default") deleteConfigTopLevelKey(config, "multiAgentMode");
       else config.multiAgentMode = mode;
       saveConfigPreservingClaudeCode(config);
       warnings.push(`Multi-agent mode set to '${mode}'. Applies to new sessions.`);
     }
     if (wantsKeepNative) {
       if (body.keepNativeChatGptOnV1 === true) config.keepNativeChatGptOnV1 = true;
-      else delete config.keepNativeChatGptOnV1;
+      else deleteConfigTopLevelKey(config, "keepNativeChatGptOnV1");
       saveConfigPreservingClaudeCode(config);
       const effectiveMode = mode ?? config.multiAgentMode ?? "default";
       warnings.push(body.keepNativeChatGptOnV1 === true
@@ -559,13 +560,13 @@ export async function handleAgentSettingsRoutes(ctx: ManagementContext): Promise
 
     config.multiAgentGuidanceEnabled = nextEnabled;
     if (nextSyncCodexSubagentDefaults) config.syncCodexSubagentDefaults = true;
-    else delete config.syncCodexSubagentDefaults;
+    else deleteConfigTopLevelKey(config, "syncCodexSubagentDefaults");
     if (nextModel) config.injectionModel = nextModel;
-    else delete config.injectionModel;
+    else deleteConfigTopLevelKey(config, "injectionModel");
     if (nextEffort) config.injectionEffort = nextEffort;
-    else delete config.injectionEffort;
+    else deleteConfigTopLevelKey(config, "injectionEffort");
     if (nextPrompt) config.injectionPrompt = nextPrompt;
-    else delete config.injectionPrompt;
+    else deleteConfigTopLevelKey(config, "injectionPrompt");
 
     saveConfigPreservingClaudeCode(config);
     return jsonResponse({
@@ -596,7 +597,7 @@ export async function handleAgentSettingsRoutes(ctx: ManagementContext): Promise
     for (const key of ["effortCap", "subagentEffortCap"] as const) {
       if (!(key in body)) continue;
       const value = body[key];
-      if (value === null || value === "") { delete config[key]; continue; }
+      if (value === null || value === "") { deleteConfigTopLevelKey(config, key); continue; }
       if (typeof value !== "string" || !isCodexReasoningEffort(value)) {
         return jsonResponse({ error: `unknown reasoning effort "${String(value)}"` }, 400);
       }
@@ -715,9 +716,9 @@ export async function handleAgentSettingsRoutes(ctx: ManagementContext): Promise
       }
     }
     if (nextModels !== undefined) config.subagentModelFallback = nextModels;
-    else delete config.subagentModelFallback;
+    else deleteConfigTopLevelKey(config, "subagentModelFallback");
     if (nextPollMs !== undefined) config.subagentModelFallbackPollMs = nextPollMs;
-    else delete config.subagentModelFallbackPollMs;
+    else deleteConfigTopLevelKey(config, "subagentModelFallbackPollMs");
     saveConfigPreservingClaudeCode(config);
     return jsonResponse({
       ok: true,
@@ -758,7 +759,7 @@ export async function handleAgentSettingsRoutes(ctx: ManagementContext): Promise
     // cannot grow config.json without bound.
     const excluded = [...new Set(raw as string[])].sort();
     if (excluded.length > 2000) return jsonResponse({ error: "excluded list is too large" }, 400);
-    if (excluded.length === 0) delete config.grokExcludedModels;
+    if (excluded.length === 0) deleteConfigTopLevelKey(config, "grokExcludedModels");
     else config.grokExcludedModels = excluded;
     saveConfigPreservingClaudeCode(config);
     return jsonResponse({ ok: true, excluded });

--- a/src/server/management/combo-routes.ts
+++ b/src/server/management/combo-routes.ts
@@ -5,6 +5,7 @@ import { catalogModelSlug, invalidateCodexModelsCache, nativeModelRows, uniqueCa
 import {
   DEFAULT_SUBAGENT_MODELS,
   codexAutoStartEnabled,
+  deleteConfigTopLevelKey,
   hasOwnProvider,
   isValidProviderName,
   multiAgentGuidanceEnabled,
@@ -246,7 +247,7 @@ export async function handleComboRoutes(ctx: ManagementContext): Promise<Respons
     }
     const { clearComboSelectionState, clearComboTargetCooldowns } = await import("../../combos");
     delete config.combos![id];
-    if (Object.keys(config.combos!).length === 0) delete config.combos;
+    if (Object.keys(config.combos!).length === 0) deleteConfigTopLevelKey(config, "combos");
     saveConfigPreservingClaudeCode(config);
     reconcileLiveStateStores();
     clearComboSelectionState(id);

--- a/src/server/management/config-routes.ts
+++ b/src/server/management/config-routes.ts
@@ -5,6 +5,7 @@ import { catalogModelSlug, invalidateCodexModelsCache, nativeContextLimits, nati
 import {
   DEFAULT_SUBAGENT_MODELS,
   codexAutoStartEnabled,
+  deleteConfigTopLevelKey,
   hasOwnProvider,
   isValidProviderName,
   multiAgentGuidanceEnabled,
@@ -437,7 +438,7 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
       }
       if (body.streamMode !== undefined) {
         if (body.streamMode === "auto") {
-          delete config.streamMode;
+          deleteConfigTopLevelKey(config, "streamMode");
         } else {
           config.streamMode = body.streamMode as "legacy-tee" | "eager-relay";
         }
@@ -458,21 +459,21 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
       (deps.saveConfigPreservingClaudeCode ?? saveConfigPreservingClaudeCode)(config);
     } catch (error) {
       if (previousSettings.hasCodexAutoStart) config.codexAutoStart = previousSettings.codexAutoStart;
-      else delete config.codexAutoStart;
+      else deleteConfigTopLevelKey(config, "codexAutoStart");
       if (previousSettings.hasStreamMode) config.streamMode = previousSettings.streamMode;
-      else delete config.streamMode;
+      else deleteConfigTopLevelKey(config, "streamMode");
       if (previousSettings.hasAppOwnedMemoryBudgetMb) {
         config.appOwnedMemoryBudgetMb = previousSettings.appOwnedMemoryBudgetMb;
-      } else delete config.appOwnedMemoryBudgetMb;
+      } else deleteConfigTopLevelKey(config, "appOwnedMemoryBudgetMb");
       if (previousSettings.hasCodexAccountNamespaces) {
         config.codexAccountNamespaces = previousSettings.codexAccountNamespaces;
-      } else delete config.codexAccountNamespaces;
+      } else deleteConfigTopLevelKey(config, "codexAccountNamespaces");
       if (previousSettings.hasCodexAccountPickerEnabled) {
         config.codexAccountPickerEnabled = previousSettings.codexAccountPickerEnabled;
-      } else delete config.codexAccountPickerEnabled;
+      } else deleteConfigTopLevelKey(config, "codexAccountPickerEnabled");
       if (previousSettings.hasOauthOpenBrowser) {
         config.oauthOpenBrowser = previousSettings.oauthOpenBrowser;
-      } else delete config.oauthOpenBrowser;
+      } else deleteConfigTopLevelKey(config, "oauthOpenBrowser");
       throw error;
     }
     if (typeof body.appOwnedMemoryBudgetMb === "number") {

--- a/src/server/management/routing-profile-routes.ts
+++ b/src/server/management/routing-profile-routes.ts
@@ -20,7 +20,7 @@ import { assemblePolicyCandidateEvidence } from "../../routing/compatibility/ass
 import { activateLab, labActivationRequired } from "../../lib/lab-activation";
 import { quotaEvidenceForCandidate } from "../../routing/quota";
 import { routedProviderConfig } from "../../router";
-import { saveConfigPreservingClaudeCode, getConfigDir } from "../../config";
+import { deleteConfigTopLevelKey, saveConfigPreservingClaudeCode, getConfigDir } from "../../config";
 import { reconcileLiveStateStores } from "../../lib/state-store-registrations";
 import { isPlainRecord } from "./shared";
 import { readManagementJsonBody, rethrowManagementBodyTooLarge } from "./body";
@@ -329,7 +329,7 @@ export async function handleRoutingProfileRoutes(ctx: ManagementContext): Promis
     const nextProfiles = { ...(config.routingProfiles ?? {}) };
     delete nextProfiles[id];
     if (Object.keys(nextProfiles).length > 0) config.routingProfiles = nextProfiles;
-    else delete config.routingProfiles;
+    else deleteConfigTopLevelKey(config, "routingProfiles");
     const saveConfigPreservingClaudeCodeSafe = deps.saveConfigPreservingClaudeCode ?? saveConfigPreservingClaudeCode;
     saveConfigPreservingClaudeCodeSafe(config);
     reconcileLiveStateStores();

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,7 @@ export type {
   OcxCustomModel,
   OcxApiKeyEntry,
   OcxClientIntegrationsConfig,
+  OcxConfigRebaseProvenance,
   OcxConfig,
   OcxAccountPoolRotationStrategy,
   OcxComboStrategy,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -239,6 +239,11 @@ export interface OcxClientIntegrationsConfig {
   "claude-desktop"?: boolean;
 }
 
+export interface OcxConfigRebaseProvenance {
+  version: 1;
+  deletedTopLevelKeys: string[];
+}
+
 export interface OcxConfig {
   port: number;
   /** Opt in to one identical-turn retry when a Responses completion has no text or tool call. */
@@ -260,6 +265,8 @@ export interface OcxConfig {
   managementUsageMaxReadBytes?: number;
   providers: Record<string, OcxProviderConfig>;
   defaultProvider: string;
+  /** Explicit top-level deletion intent used by stale whole-config rebases. */
+  configRebaseProvenance?: OcxConfigRebaseProvenance | Record<string, unknown>;
   /** OpenAI provider-contract migration marker (v2 = single `openai` provider with account mode). */
   openaiProviderTierVersion?: 1 | 2;
   /** One-time migration marker for Antigravity's static-catalog defaults. */

--- a/tests/config-rebase-provenance-writers.test.ts
+++ b/tests/config-rebase-provenance-writers.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const writerContracts: Record<string, string[]> = {
+  "src/server/management/agent-settings-routes.ts": [
+    "clientIntegrations", "multiAgentMode", "keepNativeChatGptOnV1",
+    "syncCodexSubagentDefaults", "injectionModel", "injectionEffort", "injectionPrompt",
+    "subagentModelFallback", "subagentModelFallbackPollMs", "grokExcludedModels",
+  ],
+  "src/server/management/config-routes.ts": [
+    "streamMode", "codexAutoStart", "appOwnedMemoryBudgetMb", "codexAccountNamespaces",
+    "codexAccountPickerEnabled", "oauthOpenBrowser",
+  ],
+  "src/server/management/combo-routes.ts": ["combos"],
+  "src/server/management/routing-profile-routes.ts": ["routingProfiles"],
+  "src/providers/context-cap.ts": ["providerContextCaps"],
+  "src/codex/account-priority.ts": ["codexAccountPriorities", "activeCodexAccountPinned"],
+  "src/codex/account-pause.ts": ["pausedCodexAccountIds"],
+  "src/codex/desired-state.ts": ["clientIntegrations"],
+  "src/providers/provider-id-rewrite.ts": ["customModels"],
+  "src/cli/v2.ts": ["multiAgentMode", "keepNativeChatGptOnV1"],
+};
+
+test("every enumerated top-level deletion writer records config rebase provenance", () => {
+  for (const [path, keys] of Object.entries(writerContracts)) {
+    const source = readFileSync(join(import.meta.dir, "..", path), "utf8");
+    for (const key of keys) {
+      const configCall = `deleteConfigTopLevelKey(config, "${key}")`;
+      const cliCall = `deleteConfigTopLevelKey(cfg, "${key}")`;
+      expect(source.includes(configCall) || source.includes(cliCall),
+        `${path} must record deletion provenance for ${key}`).toBe(true);
+    }
+    if (path.endsWith("agent-settings-routes.ts")) {
+      expect(source).toContain("deleteConfigTopLevelKey(config, key)");
+    }
+  }
+});
+
+test("live-config writers contain no untracked direct top-level deletion", () => {
+  for (const path of Object.keys(writerContracts)) {
+    const source = readFileSync(join(import.meta.dir, "..", path), "utf8");
+    expect(source.match(/delete (?:config|cfg)\.[A-Za-z_$][A-Za-z0-9_$]*[;\n]/g) ?? [], path)
+      .toEqual([]);
+    expect(source.match(/delete config\[[^\]]+\]/g) ?? [], path).toEqual([]);
+  }
+});

--- a/tests/config-user-edits.test.ts
+++ b/tests/config-user-edits.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   armClaudeCodeBaseline,
   adoptPersistedProviderIntoLiveConfig,
+  deleteConfigTopLevelKey,
   getConfigPath,
   getDefaultConfig,
   loadConfig,
@@ -668,11 +669,84 @@ test("a live deletion of a key that only ever existed on disk is not undone by t
   // The live writer adopts it and then deletes it, exactly as the management route
   // does for an empty selection.
   live.grokExcludedModels = ["a"];
-  delete live.grokExcludedModels;
+  deleteConfigTopLevelKey(live, "grokExcludedModels");
   saveConfigPreservingClaudeCode(live);
 
   expect(diskConfig().grokExcludedModels).toBeUndefined();
   expect(live.grokExcludedModels).toBeUndefined();
+});
+
+test("provenance distinguishes an unseen disk key from an explicit deletion", () => {
+  const live = loadConfig();
+  armClaudeCodeBaseline(live);
+  deleteConfigTopLevelKey(live, "injectionPrompt");
+
+  const onDisk = loadConfig();
+  onDisk.grokExcludedModels = ["added-elsewhere"];
+  saveConfig(onDisk);
+
+  saveConfigPreservingClaudeCode(live);
+
+  expect(live.grokExcludedModels).toEqual(["added-elsewhere"]);
+  expect(diskConfig().grokExcludedModels).toEqual(["added-elsewhere"]);
+  expect(diskConfig().configRebaseProvenance).toEqual({
+    version: 1,
+    deletedTopLevelKeys: ["injectionPrompt"],
+  });
+});
+
+test("a config without provenance keeps the legacy disk-only-key behavior", () => {
+  const live = loadConfig();
+  armClaudeCodeBaseline(live);
+  const onDisk = loadConfig();
+  onDisk.grokExcludedModels = ["disk-only"];
+  saveConfig(onDisk);
+
+  saveConfigPreservingClaudeCode(live);
+
+  expect(diskConfig().grokExcludedModels).toBeUndefined();
+  expect(diskConfig().configRebaseProvenance).toBeUndefined();
+});
+
+test("version-1 provenance round-trips through load and an older-style whole-config save", () => {
+  const config = loadConfig();
+  deleteConfigTopLevelKey(config, "grokExcludedModels");
+  saveConfig(config);
+  const loaded = loadConfig();
+
+  saveConfig(loaded);
+
+  expect(diskConfig().configRebaseProvenance).toEqual({
+    version: 1,
+    deletedTopLevelKeys: ["grokExcludedModels"],
+  });
+});
+
+test("future provenance is preserved opaquely and grants no deletion authority", () => {
+  const future = { version: 2, opaque: { keep: true } };
+  writeDiskConfig({ configRebaseProvenance: future });
+  const live = loadConfig();
+  armClaudeCodeBaseline(live);
+  const onDisk = loadConfig();
+  onDisk.grokExcludedModels = ["disk-only"];
+  saveConfig(onDisk);
+
+  saveConfigPreservingClaudeCode(live);
+
+  expect(diskConfig().configRebaseProvenance).toEqual(future);
+  expect(diskConfig().grokExcludedModels).toBeUndefined();
+});
+
+test("assigning a deleted key clears its persisted tombstone", () => {
+  const config = loadConfig();
+  deleteConfigTopLevelKey(config, "grokExcludedModels");
+  saveConfig(config);
+  config.grokExcludedModels = ["restored"];
+
+  saveConfig(config);
+
+  expect(diskConfig().grokExcludedModels).toEqual(["restored"]);
+  expect(diskConfig().configRebaseProvenance).toBeUndefined();
 });
 
 test("a provider deletion from a newer disk snapshot survives an unrelated live save", () => {


### PR DESCRIPTION
## Summary

Closes #1478. `src/config.ts` stored snapshot baselines only and inferred intent from key **presence**, so "the live writer deleted this key" and "this key was never in the live config" were the same observation. The rebase path had to guess, and both wrong guesses were separately pinned by existing tests.

Deletion intent is now explicit. `deleteConfigTopLevelKey()` records the writer's intent alongside the delete, and a versioned `configRebaseProvenance: { version: 1, deletedTopLevelKeys: [...] }` carries it across a stale whole-config rebase. Every top-level deletion writer routes through it — 10 modules, 27 named deletion paths plus one generic keyed path, enumerated in the design note rather than trusted to the issue's estimate.

Compatibility is lossless in both directions, and each direction has a test:

- A config with **no** provenance behaves exactly as it does today. Absence grants no authority, so an install that never writes provenance sees zero change.
- **Future** provenance versions are preserved byte-for-value and grant no deletion authority. Only version 1 is authoritative, so an older binary reading a newer config neither loses the metadata nor acts on something it does not understand.
- Assigning a deleted key clears its tombstone, so intent cannot outlive itself.

One subtlety worth naming: provider preservation reads symbol-keyed live-owner state that `structuredClone` drops, so ownership is resolved **before** the JSON provenance projection rather than after. Getting that order wrong silently loses disk-only provider rows.

## Verification

```
bun x tsc --noEmit                                    exit 0
bun test tests/config-user-edits.test.ts \
         tests/config-rebase-provenance-writers.test.ts  45 pass / 0 fail
bun test <the above + convergence + alias + policy>      76 pass / 0 fail
```

Falsified independently on the merge with current `dev`: dropping the provenance-aware key set from the rebase turns "provenance distinguishes an unseen disk key from an explicit deletion" red while the other 42 stay green — which is what pins that the change discriminates rather than just widening the rebase. Restored, all green. The subagent additionally falsified the account-pause writer by reverting it to a raw `delete`.

One pinned test changed: the Grok deletion case now expresses deletion intent explicitly instead of relying on a bare `delete`. That assertion was pinning the ambiguity this issue exists to remove. The pinned Claude hand-edit assertion is untouched.

## Merge note

Two conflicts with `dev`, both the same shape: #2463 and #2464 added top-level config fields at the position this branch also extends. Both sides kept — they are independent additions, not competing ones.

## Checklist

- [x] Targets `dev`
- [x] Design note and writer inventory recorded at `devlog/_plan/260826_config_rebase_provenance/010_design.md`
- [x] Migration tested in both directions, including opaque future versions
- [x] No credential, auth, workflow or release-automation surface touched



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration deletions are now preserved during rebases, preventing removed settings from unexpectedly returning.
  * Configuration metadata tracks explicit top-level setting removals across saves and synchronization.
* **Bug Fixes**
  * Improved handling of concurrent configuration edits and deleted settings.
  * Deleted settings are cleared from tracking when they are intentionally restored.
* **Tests**
  * Added coverage for deletion tracking, rebasing, legacy configurations, metadata compatibility, and configuration writers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->