### PR TITLE
fix: repair three regressions from the #2463/#1478 landings

### DIFF
--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -52,6 +52,7 @@ Usage:
   ocx provider <sub>          Providers, connectivity, quota, and selected models
   ocx account <sub>           Accounts, login/reauth, key pools, and quota controls
   ocx models <sub>            Live/custom models, visibility, context, and shadow calls
+  ocx alias <sub>             Short names for providers and models (list, set, rm, defaults)
   ocx combo <sub>             Combo failover/round-robin routing
   ocx agent <sub>             Subagents, injection, effort caps, and sidecars
   ocx observe <sub>           Logs, usage, storage, memory, and debug data

--- a/src/config/rebase-provenance.ts
+++ b/src/config/rebase-provenance.ts
@@ -40,7 +40,12 @@ export function projectConfigRebaseProvenance(config: OcxConfig): OcxConfig {
   for (const key of [...deleted]) {
     if (Object.hasOwn(record, key) && record[key] !== undefined) deleted.delete(key);
   }
-  const projected = structuredClone(config);
+  // A SHALLOW copy, deliberately. A provider entry may carry a non-cloneable value — a test
+  // fixture injects its own `fetch`, and `structuredClone` throws DataCloneError on a function,
+  // which took every provider-probe and CLI-parity suite down. Only the provenance key is
+  // rewritten here, so nothing below the top level needs to be copied at all; the deep clone
+  // was doing work this projection never asked for.
+  const projected = { ...config };
   if (deleted.size === 0) delete projected.configRebaseProvenance;
   else projected.configRebaseProvenance = {
     version: 1,

--- a/src/server/management/model-routes.ts
+++ b/src/server/management/model-routes.ts
@@ -264,6 +264,11 @@ export async function handleModelRoutes(ctx: ManagementContext): Promise<Respons
   const providerAliasMatch = url.pathname.match(/^\/api\/providers\/([^/]+)\/alias$/);
   if (providerAliasMatch && req.method === "PUT") {
     const name = decodeURIComponent(providerAliasMatch[1]!);
+    // `keys` is not a provider name: `/api/providers/keys/alias` is the API-KEY POOL's rename
+    // endpoint (oauth-account-routes.ts), and model routes are dispatched BEFORE it. Without
+    // this guard the alias route matched `name = "keys"`, found no such provider, and returned
+    // 404 for every key-pool rename.
+    if (name === "keys") return null;
     const provider = config.providers[name];
     if (!provider) return jsonResponse({ error: `provider '${name}' not found` }, 404, req, config);
     let raw: unknown;
@@ -286,6 +291,7 @@ export async function handleModelRoutes(ctx: ManagementContext): Promise<Respons
   const modelAliasMatch = url.pathname.match(/^\/api\/providers\/([^/]+)\/model-aliases$/);
   if (modelAliasMatch && req.method === "PUT") {
     const name = decodeURIComponent(modelAliasMatch[1]!);
+    if (name === "keys") return null;
     const provider = config.providers[name];
     if (!provider) return jsonResponse({ error: `provider '${name}' not found` }, 404, req, config);
     let raw: unknown;

--- a/tests/cli-headless-parity.test.ts
+++ b/tests/cli-headless-parity.test.ts
@@ -237,6 +237,11 @@ describe("headless GUI parity CLI", () => {
       ["/api/combos", "ocx combo"],
       ["/api/client-config", "ocx export"],
       ["/api/client-integrations", "ocx integration client"],
+      // #2463: both read and write reach the CLI. `ocx alias list` reads /api/aliases,
+      // `ocx alias defaults` writes /api/default-aliases, and the per-provider writes sit
+      // under /api/providers/:name/alias, already covered by the /api/providers prefix.
+      ["/api/aliases", "ocx alias"],
+      ["/api/default-aliases", "ocx alias defaults"],
       // GUI-only for now: the overview card switches for Claude Code and Grok.
       // Their effect is already reachable from the CLI by other names —
       // `ocx grok apply` regenerates the fence and `ocx stop` strips it, and
@@ -767,4 +772,3 @@ describe("#2566 per-account quota in ocx account list", () => {
     expect(formatAccountTable([row({ quotaUnavailable: true })] as never, true)).toContain("unavailable");
   });
 });
-


### PR DESCRIPTION
## Summary

The full suite on `dev` HEAD reported 36 failures across four files. Each of the three PRs that caused them (#2610, #2613) was green on its own focused run — these only appear once the landings are combined, which is exactly what a full-suite gate is for.

**1. `DataCloneError` in the provenance projection.** `projectConfigRebaseProvenance` deep-cloned the whole config, and a provider entry may carry a value `structuredClone` refuses — a test fixture injects its own `fetch`, and a function is not cloneable. That took down every `POST /api/providers/test` case and both CLI parity suites. The projection only rewrites the top-level provenance key, so nothing below the top level ever needed copying: a shallow copy is both correct and what the function actually meant. The deep clone was doing work it never asked for.

**2. The new alias route swallowed the API-key-pool rename.** `/api/providers/:name/alias` matched `/api/providers/keys/alias` with `name = "keys"`. Model routes dispatch before `oauth-account-routes`, so the alias handler found no provider named `keys` and returned 404 for every key-pool rename. Fixed with an explicit guard rather than by reordering dispatch, since that order is load-bearing for other routes and reordering to fix a pattern collision would trade one silent shadow for another.

**3. `ocx alias` and its two endpoints were undocumented.** Missing from the `printUsage` banner and from the GUI/CLI parity coverage map. Both sweeps exist to catch precisely this, and both did.

## Verification

```
bun x tsc --noEmit                              exit 0
bun test ./tests/provider-api-keys.test.ts \
         ./tests/provider-connection-test.test.ts \
         ./tests/config-user-edits.test.ts \
         ./tests/config-rebase-provenance-writers.test.ts   69 pass / 0 fail
bun test ./tests/cli-headless-parity.test.ts \
         ./tests/cli-registry.test.ts                       45 pass / 0 fail
bun test ./tests/alias-management-api.test.ts + pool        5 pass / 0 fail
```

Each repair was verified against the specific failing assertion it addresses — the `DataCloneError` stack, the `expect(rename.status).toBe(200)` that received 404, and the two coverage sweeps' `Expected [] / Received ["alias"]` and `["/api/aliases", "/api/default-aliases"]`.

## Checklist

- [x] Targets `dev`
- [x] No behavior change beyond restoring the pre-existing contracts
- [x] No credential, auth, workflow or release-automation surface touched

