### PR TITLE
fix(codex): show five-hour quota on account cards

### DIFF
--- a/gui/src/codex-quota-utils.ts
+++ b/gui/src/codex-quota-utils.ts
@@ -1,9 +1,12 @@
 export interface AccountQuota {
   weeklyPercent?: number;
   fiveHourPercent?: number;
+  /** Codex account API aliases for the same five-hour window. */
+  shortPercent?: number;
   monthlyPercent?: number;
   weeklyResetAt?: number;
   fiveHourResetAt?: number;
+  shortResetAt?: number;
   monthlyResetAt?: number;
   customWindows?: { label: string; percent: number; resetAt?: number }[];
   resetCredits?: number;
@@ -16,11 +19,19 @@ export function isThirtyDayOnlyPlan(plan: string | null | undefined): boolean {
 }
 
 export function normalizeQuotaForPlan(quota: AccountQuota | null, plan: string | null | undefined): AccountQuota | null {
-  if (!quota || !isThirtyDayOnlyPlan(plan)) return quota;
+  if (!quota) return null;
+  const normalized = quota.shortPercent === undefined && quota.shortResetAt === undefined
+    ? quota
+    : {
+        ...quota,
+        fiveHourPercent: quota.fiveHourPercent ?? quota.shortPercent,
+        fiveHourResetAt: quota.fiveHourResetAt ?? quota.shortResetAt,
+      };
+  if (!isThirtyDayOnlyPlan(plan)) return normalized;
   return {
-    ...(quota.monthlyPercent !== undefined ? { monthlyPercent: quota.monthlyPercent } : {}),
-    ...(quota.monthlyResetAt !== undefined ? { monthlyResetAt: quota.monthlyResetAt } : {}),
-    ...(quota.resetCredits !== undefined ? { resetCredits: quota.resetCredits } : {}),
-    updatedAt: quota.updatedAt,
+    ...(normalized.monthlyPercent !== undefined ? { monthlyPercent: normalized.monthlyPercent } : {}),
+    ...(normalized.monthlyResetAt !== undefined ? { monthlyResetAt: normalized.monthlyResetAt } : {}),
+    ...(normalized.resetCredits !== undefined ? { resetCredits: normalized.resetCredits } : {}),
+    updatedAt: normalized.updatedAt,
   };
 }


### PR DESCRIPTION
## Summary

- Closes #2615.
- Normalize the Codex account API's `shortPercent` / `shortResetAt` aliases to the existing `fiveHourPercent` / `fiveHourResetAt` quota contract before account cards build their rows.
- Plus, Business, and legacy Team account cards now retain both the five-hour and weekly windows, including independent reset times. Existing canonical five-hour values still win when both spellings are present.

## Verification

- Source-level Plus/Business/Team reproduction: each plan now renders `fiveHour` at 42% with reset `2000000000`, followed by `weekly` at 7% with reset `2000500000`.
- `bun test tests/quota-bars-rows.test.ts` — 13 pass, 0 fail.
- `bun run typecheck` — passed with bundled Node 24.19.0.
- `cd gui && bun run lint` — passed; one pre-existing `Models.tsx` exhaustive-deps warning remains.
- `cd gui && bun run build` — passed.
- `cd gui && bun test tests --only-failures` — 988 pass, 4 unrelated localization failures already present on the current `upstream/dev`: German is missing one alias key, and French/zh-TW still contain the 13 newly landed English alias placeholders.
- No test files were added or modified.

## Screenshot

The real account-card and quota-bar components render the Codex `short*` wire fields as separate five-hour and weekly rows:

![Plus account card showing five-hour and weekly quota bars](https://raw.githubusercontent.com/terrytan95/opencodex/pr-assets-2616/five-hour-quota.png)

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No documentation change: this restores an already-supported five-hour quota row.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (Display-only field normalization; no credentials, account identifiers, or transport behavior changed.)

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
