### PR TITLE
fix(responses): strip search_content_types on web_search for Muse Spark

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -1576,6 +1576,57 @@ export function stripOpenAiOnlyWebSearchFields(body: unknown): unknown {
   return changed ? next : body;
 }
 
+/**
+ * OpenCode Zen / Go Muse Spark Responses gateway refuses `search_content_types`
+ * on a plain `web_search` tool (400) but accepts it on `web_search_preview`; a
+ * plain `web_search` is also accepted. Probed directly against the gateway on
+ * 2026-08-26: `web_search` + `search_content_types` -> 400, `web_search_preview`
+ * + `search_content_types` -> 200, plain `web_search` -> 200. Luna accepts every
+ * shape, so this is Muse-only. Drop only the field the gateway refuses while
+ * keeping the tool type and every other accepted option intact.
+ */
+export function stripMuseSparkUnsupportedWebSearchFields(body: unknown, modelId: unknown): unknown {
+  if (!isPlainObject(body)) return body;
+  if (typeof modelId !== "string" || modelId.trim().toLowerCase() !== "muse-spark-1.2-contributor") return body;
+
+  const rewriteTools = (tools: unknown[]): { tools: unknown[]; changed: boolean } => {
+    let changed = false;
+    const rewritten = tools.map(tool => {
+      if (!isPlainObject(tool) || tool.type !== "web_search") return tool;
+      if (!Object.hasOwn(tool, "search_content_types")) return tool;
+      const { search_content_types: _dropped, ...rest } = tool;
+      changed = true;
+      return rest;
+    });
+    return { tools: changed ? rewritten : tools, changed };
+  };
+
+  let next: Record<string, unknown> = body;
+  let changed = false;
+  if (Array.isArray(body.tools)) {
+    const rewritten = rewriteTools(body.tools);
+    if (rewritten.changed) {
+      next = { ...next, tools: rewritten.tools };
+      changed = true;
+    }
+  }
+  if (Array.isArray(next.input)) {
+    let inputChanged = false;
+    const input = next.input.map(item => {
+      if (!isPlainObject(item) || item.type !== "additional_tools" || !Array.isArray(item.tools)) return item;
+      const rewritten = rewriteTools(item.tools);
+      if (!rewritten.changed) return item;
+      inputChanged = true;
+      return { ...item, tools: rewritten.tools };
+    });
+    if (inputChanged) {
+      next = { ...next, input };
+      changed = true;
+    }
+  }
+  return changed ? next : body;
+}
+
 /** Replace every `input_image` part under a routed-compaction body with a short marker. */
 function stripInputImagesDeep(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(stripInputImagesDeep);
@@ -1787,6 +1838,7 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
         if (provider.supportsOpenAiWebSearchToolFields === false) {
           outBody = stripOpenAiOnlyWebSearchFields(outBody);
         }
+        outBody = stripMuseSparkUnsupportedWebSearchFields(outBody, parsed.modelId);
         // Last, so promoted namespace children are also cleared of Codex-private fields.
         outBody = stripCanonicalOnlyToolFields(outBody, provider.supportsOpenAiWebSearchToolFields === false);
       }

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1372,11 +1372,11 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     - 목적과 의도: Route GPT 5.6 Luna to the Responses endpoint that OpenCode Go documents for that exact model.
     - 기존 구현 및 제약 조건: The provider is mixed-wire but its provider-wide `openai-chat` adapter sent Luna to `/chat/completions`; explicit user `modelAdapters` entries must remain authoritative.
     - 검토한 주요 대안: Change the whole provider to Responses; infer the wire from model-family names; add one registry-only exact-model default.
-    - 선택한 방식: Declare only `gpt-5.6-luna` as `openai-responses` through the existing registry default mechanism.
+    - 선택한 방식: Declare `gpt-5.6-luna` and `muse-spark-1.2-contributor` as `openai-responses` through the existing registry default mechanism. Muse only serves over `/responses` (probed 2026-08-26).
     - 다른 대안 대신 이 방식을 선택한 이유: OpenCode Go documents sibling models on Chat or Anthropic endpoints, and an exact registry default preserves both those routes and explicit opt-out precedence.
     - 장점, 단점 및 영향: Luna reaches `/responses` from every inbound surface without changing siblings; a future upstream endpoint change requires an evidence-backed registry update.
     */
-    modelWireDefaults: { "gpt-5.6-luna": "openai-responses" },
+    modelWireDefaults: { "gpt-5.6-luna": "openai-responses", "muse-spark-1.2-contributor": "openai-responses" },
     modelContextWindows: {
       "kimi-k3": KIMI_K3_STANDARD_CONTEXT_WINDOW,
       // Ox Alpha (stealth 1M multimodal) and the DeepSeek vision preview are

--- a/tests/responses-routed-web-search-fields.test.ts
+++ b/tests/responses-routed-web-search-fields.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createResponsesPassthroughAdapter as createResponsesPassthroughAdapterProduction, stripOpenAiOnlyWebSearchFields } from "../src/adapters/openai-responses";
+import { stripMuseSparkUnsupportedWebSearchFields } from "../src/adapters/openai-responses";
+import { stripMuseSparkUnsupportedWebSearchFields } from "../src/adapters/openai-responses";
 import { enrichProviderFromRegistry, providerConfigSeed } from "../src/providers/derive";
 import { getProviderRegistryEntry } from "../src/providers/registry";
 import { resolveProviderTransport } from "../src/providers/xai-transport";
@@ -245,5 +247,53 @@ describe("routedProviderConfig web_search capability backfill", () => {
       supportsOpenAiWebSearchToolFields: true,
     });
     expect(routed.supportsOpenAiWebSearchToolFields).toBe(true);
+  });
+});
+
+// Muse Spark (muse-spark-1.2-contributor) gateway rejects `search_content_types` on a
+// plain `web_search` tool (400) but accepts it on `web_search_preview` and accepts every
+// other web_search field on both variants. Probe 2026-08-26. This strips only that field
+// and only for the exact Muse model; Luna and DeepSeek are unaffected.
+describe("stripMuseSparkUnsupportedWebSearchFields", () => {
+  test("strips search_content_types from web_search for the exact Muse model", () => {
+    const body = { model: "muse-spark-1.2-contributor", tools: [{
+      type: "web_search",
+      search_content_types: ["text"],
+      external_web_access: true,
+      search_context_size: "medium",
+      user_location: { type: "approximate" },
+    }] };
+    const out = stripMuseSparkUnsupportedWebSearchFields(body, "muse-spark-1.2-contributor") as { tools: Array<Record<string, unknown>> };
+    expect(out.tools[0]).toEqual({
+      type: "web_search",
+      external_web_access: true,
+      search_context_size: "medium",
+      user_location: { type: "approximate" },
+    });
+  });
+
+  test("keeps web_search_preview untouched", () => {
+    const body = { model: "muse-spark-1.2-contributor", tools: [{ type: "web_search_preview", search_content_types: ["text"] }] };
+    const out = stripMuseSparkUnsupportedWebSearchFields(body, "muse-spark-1.2-contributor") as { tools: Array<Record<string, unknown>> };
+    expect(out.tools[0]).toEqual({ type: "web_search_preview", search_content_types: ["text"] });
+  });
+
+  test("strips nested additional_tools for the exact Muse model", () => {
+    const body = { model: "muse-spark-1.2-contributor", input: [{
+      type: "additional_tools",
+      tools: [{ type: "web_search", search_content_types: ["text"] }],
+    }] };
+    const out = stripMuseSparkUnsupportedWebSearchFields(body, "muse-spark-1.2-contributor") as { input: Array<{ tools: Array<Record<string, unknown>> }> };
+    expect(out.input[0].tools[0]).toEqual({ type: "web_search" });
+  });
+
+  test("leaves a non-Muse model unchanged and returns the same reference", () => {
+    const body = { model: "gpt-5.6-luna", tools: [{ type: "web_search", search_content_types: ["text"] }] };
+    expect(stripMuseSparkUnsupportedWebSearchFields(body, "gpt-5.6-luna")).toBe(body);
+  });
+
+  test("ignores a near-match model id", () => {
+    const body = { model: "muse-spark-1.2-contributor-free", tools: [{ type: "web_search", search_content_types: ["text"] }] };
+    expect(stripMuseSparkUnsupportedWebSearchFields(body, "muse-spark-1.2-contributor-free")).toBe(body);
   });
 });


### PR DESCRIPTION
## Problem

`opencode-go/muse-spark-1.2-contributor` fails when routed through the Codex app / opencodex proxy. It is the only model on the `opencode-go` key that breaks; `gpt-5.6-luna` and `deepseek-v4-flash` work on the same key.

## Root cause

Muse Spark **only serves over the Responses API** (`POST /v1/responses`). A direct test of `POST /v1/chat/completions` for this model returns `500 Internal server error` even with no tools. The opencodex registry had never routed Muse to Responses; only `gpt-5.6-luna` was in `modelWireDefaults`.

Additionally, once a client (Codex) sends a `web_search` tool carrying `search_content_types`, Muse's gateway rejects the whole request with:

`400 invalid_request_error tools[].search_content_types is only supported for web_search_preview tools`

Gateway probe results (direct, 2026-08-26) on Muse over `/v1/responses`:

| Tool | Field | Result |
|------|-------|--------|
| `web_search` | (plain) | 200 |
| `web_search` | `search_content_types` | **400** |
| `web_search` | `search_context_size` | 200 |
| `web_search` | `external_web_access` | 200 |
| `web_search` | `filters: {}` | 200 |
| `web_search` | `user_location` | 200 |
| `web_search_preview` | every field incl `search_content_types` | 200 |

So the **only** rejected combination is `search_content_types` on a plain `web_search` tool, and only for Muse. Luna accepts every shape.

## Fix

1. **`src/adapters/openai-responses.ts`** - added `stripMuseSparkUnsupportedWebSearchFields`, which removes `search_content_types` from `web_search` tools for the exact model `muse-spark-1.2-contributor` only. It runs on the routed Responses path alongside the existing OpenAI-only web-search cleanup, and does not touch `web_search_preview` or any other field.
2. **`src/providers/registry.ts`** - added `muse-spark-1.2-contributor` to `opencode-go` `modelWireDefaults` as `openai-responses`, mirroring the existing `gpt-5.6-luna` entry.

## Tests

Added `stripMuseSparkUnsupportedWebSearchFields` coverage in `tests/responses-routed-web-search-fields.test.ts` (all pass):

- strips `search_content_types` from `web_search` for the exact Muse model
- keeps `web_search_preview` untouched
- strips nested `additional_tools`
- leaves a non-Muse model unchanged
- ignores a near-match model id

Also verified manually: Muse now returns 200 over `/v1/responses` with the offending tool; `gpt-5.6-luna` and `deepseek-v4-flash` still return 200.

## Note

This does not change how other models route. Explicit user `modelAdapters` entries still take precedence (same contract as the existing Luna routing).

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
