### PR TITLE
fix(claude): avoid creating agents directory when disabled

### DIFF
--- a/src/claude/agents-inject.ts
+++ b/src/claude/agents-inject.ts
@@ -218,7 +218,14 @@ function isOwnedFile(path: string): boolean {
 export function syncClaudeAgentDefs(defs: readonly ClaudeAgentDef[], configDir = claudeConfigDir()): string[] | null {
   try {
     const dir = join(configDir, "agents");
-    mkdirSync(dir, { recursive: true });
+    if (defs.length === 0) {
+      try { lstatSync(dir); } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+        throw error;
+      }
+    } else {
+      mkdirSync(dir, { recursive: true });
+    }
     const keep = new Set(defs.map(d => d.file));
     for (const existing of readdirSync(dir)) {
       if (!existing.startsWith(OWNED_PREFIX) || !existing.endsWith(".md")) continue;

--- a/tests/claude-agents-inject.test.ts
+++ b/tests/claude-agents-inject.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildClaudeAgentDefs, injectClaudeAgentDefs, syncClaudeAgentDefs } from "../src/claude/agents-inject";
@@ -269,6 +269,12 @@ describe("buildClaudeAgentDefs (devlog 070 + audit 071)", () => {
 });
 
 describe("syncClaudeAgentDefs ownership contract (audit 071 #2/#3)", () => {
+  test("empty sync leaves an absent agents directory absent", () => {
+    const dir = tempDir();
+    expect(syncClaudeAgentDefs([], dir)).toEqual([]);
+    expect(existsSync(join(dir, "agents"))).toBe(false);
+  });
+
   test("writes, overwrites, and prunes ONLY marker-verified ocx files", () => {
     const dir = tempDir();
     writeFileSync(join(dir, "settings.json"), JSON.stringify({ model: "claude-ocx-native--gpt-5.6-sol" }));


### PR DESCRIPTION
## Summary

- Avoid creating `~/.claude/agents` when the Claude integration has no definitions to write and the directory does not already exist.
- Preserve cleanup of marker-owned stale definitions when the directory already exists, and preserve normal writes for non-empty rosters.
- Add a focused filesystem regression test for the absent-directory contract. This is a follow-up to #2200.
- No documentation change is needed because this removes an unintended filesystem side effect without changing the configured integration surface.

## Verification

- `bun test tests/claude-agents-inject.test.ts` — 18 passed.
- `bun test tests/claude-agent-startup-sync.test.ts` — 5 passed.
- `bun run typecheck` — passed.
- Isolated-home startup replay with `claudeCode.enabled=false` — returned no definitions and left `.claude` absent.
- `bun run test` — the 4x parallel phase reported 14,814 passed, 12 skipped, 15 failed, and 3 errors; every listed retry file passed in the subsequent 1x serial reruns, but the command exited 1. The reported failures are outside this PR's two-file diff.
- `bun run privacy:scan` — blocked by pre-existing email examples in `docs-site/src/content/docs/reference/cli/providers-accounts.md:167-168`, which this PR does not modify.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented creation of an empty agents directory when no agent definitions are available.
  - Preserved cleanup of existing directories and continued reporting unexpected filesystem errors.

- **Tests**
  - Added regression coverage confirming empty synchronization results in no directory being created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->