### PR TITLE
fix(codex): show the five-hour quota on account cards (#2616)

### DIFF
--- a/gui/src/codex-quota-utils.ts
+++ b/gui/src/codex-quota-utils.ts
@@ -1,9 +1,12 @@
 export interface AccountQuota {
   weeklyPercent?: number;
   fiveHourPercent?: number;
+  /** Codex account API aliases for the same five-hour window. */
+  shortPercent?: number;
   monthlyPercent?: number;
   weeklyResetAt?: number;
   fiveHourResetAt?: number;
+  shortResetAt?: number;
   monthlyResetAt?: number;
   customWindows?: { label: string; percent: number; resetAt?: number }[];
   resetCredits?: number;
@@ -16,11 +19,19 @@ export function isThirtyDayOnlyPlan(plan: string | null | undefined): boolean {
 }
 
 export function normalizeQuotaForPlan(quota: AccountQuota | null, plan: string | null | undefined): AccountQuota | null {
-  if (!quota || !isThirtyDayOnlyPlan(plan)) return quota;
+  if (!quota) return null;
+  const normalized = quota.shortPercent === undefined && quota.shortResetAt === undefined
+    ? quota
+    : {
+        ...quota,
+        fiveHourPercent: quota.fiveHourPercent ?? quota.shortPercent,
+        fiveHourResetAt: quota.fiveHourResetAt ?? quota.shortResetAt,
+      };
+  if (!isThirtyDayOnlyPlan(plan)) return normalized;
   return {
-    ...(quota.monthlyPercent !== undefined ? { monthlyPercent: quota.monthlyPercent } : {}),
-    ...(quota.monthlyResetAt !== undefined ? { monthlyResetAt: quota.monthlyResetAt } : {}),
-    ...(quota.resetCredits !== undefined ? { resetCredits: quota.resetCredits } : {}),
-    updatedAt: quota.updatedAt,
+    ...(normalized.monthlyPercent !== undefined ? { monthlyPercent: normalized.monthlyPercent } : {}),
+    ...(normalized.monthlyResetAt !== undefined ? { monthlyResetAt: normalized.monthlyResetAt } : {}),
+    ...(normalized.resetCredits !== undefined ? { resetCredits: normalized.resetCredits } : {}),
+    updatedAt: normalized.updatedAt,
   };
 }

--- a/tests/rate-limit-reset-credits.test.ts
+++ b/tests/rate-limit-reset-credits.test.ts
@@ -239,6 +239,43 @@ describe("rate-limit reset credits", () => {
       expect(normalizeQuotaForPlan(quota, "pro")).toBe(quota);
     });
 
+    /**
+     * The five-hour window reaches the GUI under TWO names (#2616).
+     *
+     * `QuotaBars` reads `fiveHour*`, which is what the per-account provider probe reports. The
+     * Codex pool declares the same window as `short*` (auth-api.ts, and `account-api.ts` says
+     * outright that "the two surfaces name the same idea differently and both reach this DTO").
+     * A Codex account card therefore had a five-hour quota upstream and rendered no five-hour
+     * row at all.
+     *
+     * The canonical name wins when both are present: `short*` is an alias to fall back to, not
+     * an override, or a pool snapshot could quietly replace a probe reading.
+     */
+    it("renders the Codex pool's short window as the five-hour window (#2616)", async () => {
+      const { normalizeQuotaForPlan } = await import("../gui/src/codex-quota-utils");
+
+      expect(normalizeQuotaForPlan({ shortPercent: 71, shortResetAt: 555, updatedAt: 1 }, "pro"))
+        .toMatchObject({ fiveHourPercent: 71, fiveHourResetAt: 555 });
+
+      // Canonical values win; the alias does not overwrite a probe reading.
+      expect(normalizeQuotaForPlan(
+        { fiveHourPercent: 10, fiveHourResetAt: 111, shortPercent: 71, shortResetAt: 555, updatedAt: 1 },
+        "pro",
+      )).toMatchObject({ fiveHourPercent: 10, fiveHourResetAt: 111 });
+
+      // A quota carrying neither alias is still returned by identity, so the common path adds
+      // no allocation and no behavior change.
+      const untouched = { weeklyPercent: 5, updatedAt: 2 };
+      expect(normalizeQuotaForPlan(untouched, "pro")).toBe(untouched);
+
+      // A 30-day plan still strips non-monthly windows, alias or not — #1791's burst-window
+      // carve-out lives on the server DTO, not in this GUI normalizer.
+      expect(normalizeQuotaForPlan(
+        { shortPercent: 71, shortResetAt: 555, monthlyPercent: 12, updatedAt: 3 },
+        "go",
+      )).toEqual({ monthlyPercent: 12, updatedAt: 3 });
+    });
+
     it("does not exclude team or workspace plans from ticket badges", async () => {
       const [pool, helpers] = await Promise.all([
         Bun.file("gui/src/components/CodexAccountPool.tsx").text(),


### PR DESCRIPTION
## Summary

Carries #2616 by @terrytan95 with the regression test it needs.

The five-hour window reaches the GUI under **two names**. `QuotaBars` reads `fiveHour*`, which is what the per-account provider probe reports; the Codex pool declares the same window as `short*`. `src/cli/account-api.ts` says so outright — "the two surfaces name the same idea differently and both reach this DTO". So a Codex account card could have a five-hour quota upstream and render no five-hour row at all.

`normalizeQuotaForPlan` now maps the alias before rows are built. The canonical name wins when both are present: `short*` is a fallback, not an override, or a pool snapshot could quietly replace a probe reading. A quota carrying neither alias is returned by identity, so the common path adds no allocation and no behavior change.

## What I added

The original PR changes quota rendering with no test. The added regression pins four cases: the alias renders, the canonical value wins when both are present, the no-alias path is identity, and a 30-day plan still strips non-monthly windows (#1791's burst-window carve-out lives on the server DTO, not in this GUI normalizer).

## Verification

```
bun x tsc --noEmit                              exit 0
bun test ./tests/rate-limit-reset-credits.test.ts   32 pass / 0 fail
cd gui && bun run build                          ok
```

Falsified: collapsing the normalization to a passthrough reddens exactly this test and nothing else. No GUI strings changed, so no locale work applies.

## Checklist

- [x] Targets `dev`
- [x] Regression test added near the subsystem and falsified
- [x] No credential, auth, workflow or release-automation surface touched

Closes #2616.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved quota display by recognizing alternate five-hour usage and reset data.
  - Preserved existing quota values when canonical data is available.
  - Continued showing monthly quota information correctly for plans that support it.

- **Tests**
  - Added coverage for quota normalization, fallback handling, and plan-specific filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->