### PR TITLE
fix(codex): write the provenance ledger, bounded (#2622)

### DIFF
--- a/devlog/_plan/260826_provenance_writer/010_design.md
+++ b/devlog/_plan/260826_provenance_writer/010_design.md
@@ -1,0 +1,39 @@
+# Codex provenance writer
+
+Issue: #2622
+
+## Placement and ordering
+
+The writer runs in `src/codex/inject.ts` immediately after `withCodexWriteLock`
+returns an acquired apply or remove transaction. At that point the native files
+and the coordinator row carrying the transaction id have committed. The call
+uses only `updateIntegrationRecord`; it does not perform its own read, merge, or
+write.
+
+The ledger append is best-effort. Provenance is optional in the v1 record, and a
+non-CAS JSON failure must not turn a committed native transaction into a reported
+failure. If the process crashes after the transaction commit and before the
+ledger append, the native transaction remains admitted and the ledger has no
+matching entry. That ordering is safe because absence grants no restore authority
+and existing acceptance treats absence as unavailable evidence; writing before
+the transaction commit could instead leave provenance for a transaction that
+never committed.
+
+## Entry shape
+
+One admitted transaction appends entries for the native artifacts it may mutate:
+`config`, `generated-profile`, and `injection-journal`. Every entry contains the
+transaction id, one shared observation timestamp, the exact pre-transaction
+baseline (`absent` or SHA-256 plus base64 bytes), and the SHA-256 post-image or
+`null` when the artifact is absent after the transaction.
+
+Existing version-1 records without provenance remain valid. The update spreads
+the old record and appends to its existing entries; `updateIntegrationRecord`
+remains responsible for preserving unknown record, ledger, entry, artifact, and
+baseline extensions and for refusing malformed bytes.
+
+## Lifecycle
+
+The record stays under the owned OpenCodex home at `integrations/codex.json`.
+`ocx uninstall` already removes that owned home, so this ledger does not add an
+external artifact or a removal precondition.

--- a/src/codex/inject-coordination.ts
+++ b/src/codex/inject-coordination.ts
@@ -11,7 +11,12 @@ import { atomicWriteFile } from "../config";
 import type { CodexWriteLockResult } from "./codex-write-lock";
 import { inspectCodexCoordinatorPath } from "./coordinator-doctor";
 import { JOURNAL_PATH } from "./journal";
+import { updateIntegrationRecord } from "./integration-record";
 import { CODEX_CONFIG_PATH, CODEX_PROFILE_PATH } from "./paths";
+import type {
+  CodexArtifactId,
+  CodexProvenanceEntry,
+} from "./convergence-types";
 import {
   codexWriteCoordination,
   type CodexWriteCandidate,
@@ -176,6 +181,49 @@ export function captureCodexPreImages(): CodexPreImages {
     profile: readOrNull(CODEX_PROFILE_PATH),
     journal: readOrNull(JOURNAL_PATH),
   };
+}
+
+function provenanceBaseline(bytes: string | null): CodexProvenanceEntry["baseline"] {
+  if (bytes === null) return { kind: "absent" };
+  return {
+    kind: "present",
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    bytesBase64: Buffer.from(bytes).toString("base64"),
+  };
+}
+
+function provenancePostImage(path: string): string | null {
+  try {
+    return createHash("sha256").update(readFileSync(path)).digest("hex");
+  } catch {
+    return null;
+  }
+}
+
+/** Append evidence for an already-committed native transaction, best-effort. */
+export function recordCodexNativeTransactionProvenance(
+  preImages: CodexPreImages,
+  txId: string,
+) {
+  const at = new Date().toISOString();
+  const surfaces: readonly [CodexArtifactId, string, string | null][] = [
+    [{ kind: "config" }, CODEX_CONFIG_PATH, preImages.config],
+    [{ kind: "generated-profile" }, CODEX_PROFILE_PATH, preImages.profile],
+    [{ kind: "injection-journal" }, JOURNAL_PATH, preImages.journal],
+  ];
+  const entries: readonly CodexProvenanceEntry[] = surfaces.map(([artifact, path, baseline]) => ({
+    artifact,
+    baseline: provenanceBaseline(baseline),
+    postImage: provenancePostImage(path),
+    txId,
+    at,
+  }));
+  return updateIntegrationRecord(record => ({
+    ...record,
+    provenance: {
+      entries: [...(record.provenance?.entries ?? []), ...entries],
+    },
+  }));
 }
 
 /**

--- a/src/codex/inject-coordination.ts
+++ b/src/codex/inject-coordination.ts
@@ -183,6 +183,19 @@ export function captureCodexPreImages(): CodexPreImages {
   };
 }
 
+/**
+ * How many transactions of evidence the ledger keeps.
+ *
+ * Each transaction appends three entries, and a `present` baseline embeds the artifact's exact
+ * bytes as base64 — a 25 KB `config.toml` is ~34 KB per entry, so roughly 100 KB per transaction.
+ * A machine that syncs on every start would grow this file without limit, and it is re-read and
+ * re-serialized on every append, so the cost is quadratic rather than merely large.
+ *
+ * A ledger is evidence, not an archive. The most recent transactions are the ones anyone
+ * diagnoses against, so the window keeps those and drops the oldest.
+ */
+export const CODEX_PROVENANCE_MAX_TRANSACTIONS = 16;
+
 function provenanceBaseline(bytes: string | null): CodexProvenanceEntry["baseline"] {
   if (bytes === null) return { kind: "absent" };
   return {
@@ -198,6 +211,25 @@ function provenancePostImage(path: string): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Keep the newest `CODEX_PROVENANCE_MAX_TRANSACTIONS` transactions, whole.
+ *
+ * Trimming by ENTRY count would cut a transaction in half and leave evidence that says a
+ * transaction touched two artifacts when it touched three — worse than dropping it outright,
+ * because a partial record still reads as complete. Order is preserved; only whole leading
+ * transactions are removed.
+ */
+export function boundProvenanceEntries(
+  entries: readonly CodexProvenanceEntry[],
+  maxTransactions = CODEX_PROVENANCE_MAX_TRANSACTIONS,
+): readonly CodexProvenanceEntry[] {
+  const order: string[] = [];
+  for (const entry of entries) if (!order.includes(entry.txId)) order.push(entry.txId);
+  if (order.length <= maxTransactions) return entries;
+  const keep = new Set(order.slice(order.length - maxTransactions));
+  return entries.filter(entry => keep.has(entry.txId));
 }
 
 /** Append evidence for an already-committed native transaction, best-effort. */
@@ -221,7 +253,8 @@ export function recordCodexNativeTransactionProvenance(
   return updateIntegrationRecord(record => ({
     ...record,
     provenance: {
-      entries: [...(record.provenance?.entries ?? []), ...entries],
+      ...record.provenance,
+      entries: boundProvenanceEntries([...(record.provenance?.entries ?? []), ...entries]),
     },
   }));
 }

--- a/src/codex/inject.ts
+++ b/src/codex/inject.ts
@@ -19,6 +19,7 @@ import {
   CodexWriteConflictError,
   DEFAULT_INJECT_LOCK_TIMEOUT_MS,
   recomputeInjectWitness,
+  recordCodexNativeTransactionProvenance,
   restoreCodexPreImages,
 } from "./inject-coordination";
 import { readIntegrationRecord } from "./integration-record";
@@ -1020,6 +1021,7 @@ export async function injectCodexConfig(
         }
         return {
           kind: "applied" as const,
+          preImages,
           /*
            * The receipt the terminal update matches on. The transition commits
            * when the callback returns, so this pair is what the post-job
@@ -1037,6 +1039,10 @@ export async function injectCodexConfig(
     if (coordinated.status !== "acquired") {
       return codexInjectLockOutcome(coordinated);
     }
+    recordCodexNativeTransactionProvenance(
+      coordinated.value.preImages,
+      coordinated.value.receipt.currentTxId,
+    );
     transitionReceipt = coordinated.value.receipt;
   }
   // Legacy mode still forward-tags history so re-tagged threads stay listable. Design B needs
@@ -1591,6 +1597,7 @@ export async function restoreNativeCodexAsync(
         }
         return {
           config: restored,
+          preImages,
           receipt: {
             nativeGeneration: ctx.expectation.nativeAfter,
             currentTxId: ctx.expectation.txId,
@@ -1609,6 +1616,10 @@ export async function restoreNativeCodexAsync(
           : `Codex configuration was not restored: ${coordinated.message}`,
       };
     } else {
+      recordCodexNativeTransactionProvenance(
+        coordinated.value.preImages,
+        coordinated.value.receipt.currentTxId,
+      );
       config = coordinated.value.config;
       transitionReceipt = coordinated.value.receipt;
     }

--- a/tests/codex-inject-write-lock.test.ts
+++ b/tests/codex-inject-write-lock.test.ts
@@ -163,6 +163,11 @@ describe("the lock is on the production path", () => {
 
   test("a clean first apply coordinates and records a transition", () => {
     seedNative();
+    mkdirSync(join(opencodexHome, "integrations"), { recursive: true });
+    writeFileSync(join(opencodexHome, "integrations", "codex.json"), JSON.stringify({
+      version: 1,
+      futureSection: { owner: "newer-writer" },
+    }));
     const result = runInject(10100);
     expect(result.success).toBeTrue();
 
@@ -184,6 +189,61 @@ describe("the lock is on the production path", () => {
     // Guessing null passes on a fresh machine and fails on a real one, so the
     // id being present is part of the claim.
     expect(typeof row.state?.currentTxId).toBe("string");
+
+    const record = JSON.parse(
+      readFileSync(join(opencodexHome, "integrations", "codex.json"), "utf8"),
+    ) as {
+      futureSection?: unknown;
+      provenance?: { entries?: Array<{ txId?: string; artifact?: { kind?: string } }> };
+    };
+    expect(record.futureSection).toEqual({ owner: "newer-writer" });
+    const matching = record.provenance?.entries?.filter(entry =>
+      entry.txId === row.state?.currentTxId) ?? [];
+    expect(matching.map(entry => entry.artifact?.kind).sort()).toEqual([
+      "config",
+      "generated-profile",
+      "injection-journal",
+    ]);
+  });
+
+  test("a provenance append failure does not undo an admitted transaction", () => {
+    seedNative();
+    expect(runInject(10100).success).toBeTrue();
+
+    const readTransition = () => parseChildJson<{
+      kind?: string;
+      state?: { nativeGeneration?: number; currentTxId?: string | null };
+    }>(runChild(["--eval", `
+      const { readCodexTransitionState } = require("./src/codex/transition-state");
+      console.log(JSON.stringify(readCodexTransitionState()));
+    `], {
+      ...process.env,
+      CODEX_HOME: codexHome,
+      OPENCODEX_HOME: opencodexHome,
+    }), "read transition state around failed provenance append");
+    const admitted = readTransition();
+    expect(typeof admitted.state?.currentTxId).toBe("string");
+
+    writeFileSync(join(opencodexHome, "integrations", "codex.json"), "{ malformed", "utf8");
+    const append = parseChildJson<{ kind?: string }>(runChild(["--eval", `
+      const {
+        captureCodexPreImages,
+        recordCodexNativeTransactionProvenance,
+      } = require("./src/codex/inject-coordination");
+      console.log(JSON.stringify(recordCodexNativeTransactionProvenance(
+        captureCodexPreImages(),
+        process.env.OCX_TEST_TX_ID,
+      )));
+    `], {
+      ...process.env,
+      CODEX_HOME: codexHome,
+      OPENCODEX_HOME: opencodexHome,
+      OCX_TEST_TX_ID: admitted.state!.currentTxId!,
+    }), "failed provenance append");
+    expect(append.kind).toBe("invalid");
+    expect(readTransition()).toEqual(admitted);
+    expect(readFileSync(join(opencodexHome, "integrations", "codex.json"), "utf8"))
+      .toBe("{ malformed");
   });
 
   /**

--- a/tests/codex-inject-write-lock.test.ts
+++ b/tests/codex-inject-write-lock.test.ts
@@ -15,7 +15,7 @@ import {
   resolveCodexCoordinatorDatabasePath,
   resolveEffectiveUserIdentity,
 } from "../src/codex/user-identity";
-import { STABLE_ZERO_BYTE_COORDINATOR_AGE_MS } from "../src/codex/inject-coordination";
+import { boundProvenanceEntries, STABLE_ZERO_BYTE_COORDINATOR_AGE_MS } from "../src/codex/inject-coordination";
 import { SPAWN_BUDGET_MS } from "./helpers/test-budget";
 
 const repoRoot = join(import.meta.dir, "..");
@@ -464,5 +464,48 @@ describe("the transition is resolved, not left pending", () => {
     // Opt-out is a completed decision, not a failure: converged, never blocked,
     // and never left pending for a job that chose to do nothing.
     expect(row.state?.history?.status).toBe("converged");
+  });
+});
+
+/**
+ * The ledger is evidence, not an archive (#2622).
+ *
+ * Each admitted transaction appends three entries, and a `present` baseline carries the artifact's
+ * exact bytes as base64 — a 25 KB `config.toml` is roughly 100 KB per transaction. Unbounded, a
+ * machine that syncs on every start grows this file forever, and since the record is re-read and
+ * re-serialized on every append, the cost is quadratic rather than merely large.
+ */
+describe("provenance ledger bound", () => {
+  const entry = (txId: string, kind: "config" | "generated-profile" | "injection-journal") => ({
+    artifact: { kind },
+    baseline: { kind: "absent" as const },
+    postImage: null,
+    txId,
+    at: "2026-08-26T00:00:00.000Z",
+  });
+  const transaction = (txId: string) => [
+    entry(txId, "config"),
+    entry(txId, "generated-profile"),
+    entry(txId, "injection-journal"),
+  ];
+
+  test("keeps the newest transactions and drops the oldest whole", () => {
+    const entries = Array.from({ length: 20 }, (_, i) => transaction(`tx-${i}`)).flat();
+    const bounded = boundProvenanceEntries(entries, 16);
+
+    const kept = [...new Set(bounded.map(e => e.txId))];
+    expect(kept).toHaveLength(16);
+    expect(kept[0]).toBe("tx-4");
+    expect(kept.at(-1)).toBe("tx-19");
+    // Whole transactions only. A half-trimmed transaction would claim it touched two artifacts
+    // when it touched three, which reads as complete and is worse than dropping it.
+    for (const txId of kept) {
+      expect(bounded.filter(e => e.txId === txId)).toHaveLength(3);
+    }
+  });
+
+  test("a ledger within the window is returned unchanged", () => {
+    const entries = Array.from({ length: 16 }, (_, i) => transaction(`tx-${i}`)).flat();
+    expect(boundProvenanceEntries(entries, 16)).toBe(entries);
   });
 });


### PR DESCRIPTION
## Summary

Closes #2622. `updateIntegrationRecord` had no production caller, so the Codex provenance ledger was never written — a tested, exported, documented writer that nothing invoked, which reads as implemented. The apply and remove paths now append evidence for the artifacts a native transaction may mutate: `config`, `generated-profile`, and `injection-journal`.

**Ordering is the load-bearing decision.** The append runs *after* `withCodexWriteLock` returns an acquired transaction, so the native files and the coordinator row have already committed. A crash between the two leaves an admitted transaction with no ledger entry — safe, because absence grants no restore authority and existing acceptance already treats absence as unavailable evidence. Writing *before* the commit would be the unsafe direction: it would leave provenance for a transaction that never happened. The append is best-effort for the same reason; a non-CAS JSON failure must not turn a committed native transaction into a reported failure.

## Bound added on review

As written the ledger was unbounded, and that is not a small leak. Each transaction appends three entries, and a `present` baseline embeds the artifact's exact bytes as base64 — a 25 KB `config.toml` measures ~34 KB per entry, so roughly **100 KB per transaction**. A machine that syncs on every start grows `integrations/codex.json` without limit, and because the record is re-read and re-serialized on every append, the cost is quadratic rather than merely large.

The window keeps the newest 16 transactions, **whole**. Trimming by entry count would cut a transaction in half and leave a record claiming it touched two artifacts when it touched three — a partial record still reads as complete, which is worse than dropping it outright.

The append also now spreads the existing `provenance` object, so an unknown ledger-level key from a newer writer survives — the record contract requires that, and the original append dropped it.

## Verification

```
bun x tsc --noEmit                                exit 0
bun test <inject-write-lock + integration-record
          + composed-acceptance + convergence>     40 pass / 0 fail
bun run privacy:scan                              Privacy scan passed
```

Falsified both ways: removing the production writer leaves an admitted transaction with `[]` matching artifacts instead of the three expected ones; removing the window reddens the trimming test while the within-window identity case stays green — which pins the bound as a bound rather than an unconditional filter.

## Checklist

- [x] Targets `dev`
- [x] Design note at `devlog/_plan/260826_provenance_writer/010_design.md`
- [x] Records without provenance stay valid; unknown extensions preserved
- [x] No credential, auth, workflow or release-automation surface touched


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provenance tracking for completed configuration, profile, and journal changes.
  * Records transaction details, timestamps, previous metadata, and resulting file fingerprints.
  * Retains the 16 most recent complete transactions while preserving compatibility with existing data.
  * Provenance data remains within the Codex home and is removed during uninstallation.

* **Bug Fixes**
  * Invalid provenance data is safely rejected without altering existing files or transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->