### PR TITLE
docs(structure): record semantic-progress ownership for continuation loops (#2600)

### DIFF
--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -47,6 +47,24 @@ the upstream HTTP-version helper. Server, provider, and WebSocket data types rem
 It must not import routing, combos, OAuth, adapters, sidecars, response parsing, logging, or relay
 modules merely because those imports existed in the pre-split `responses.ts` monolith.
 
+### Semantic progress ownership
+
+The Responses proxy does not treat transcript growth as repository progress. It can observe request
+boundaries, response items, tool names and payloads, adapter events, retained bytes, and elapsed
+silence. It cannot observe the client's workspace or prove whether a successful tool result changed
+repository state. Consequently, the active-turn and session-lane gates are concurrency admission
+limits, the translator budget is a live retained-byte limit, the response-state caps are cache
+retention limits, and the stall watchdog is a silence limit. None is a cumulative continuation or
+semantic no-progress budget.
+
+[Decision Log]
+- 목적과 의도: Keep long but progressing client-driven tool continuations valid while locating repository-semantic loop detection at the layer that owns the workspace and continuation policy.
+- 기존 구현 및 제약 조건: Issue #2600 recorded 18 persisted Cursor continuations whose transcript and tool counters grew while the worktree did not. Every proxy-local liveness and capacity bound was therefore satisfied, but the proxy had no workspace delta to compare.
+- 검토한 주요 대안: Stop after a fixed continuation count; classify read-like tool names as no progress; compare assistant prose; emit a new proxy-only terminal code after a time budget; or leave semantic progress to the client while preserving transport cancellation for objective proxy failures.
+- 선택한 방식: Do not add a proxy semantic cutoff without a client-supplied progress contract. Keep objective transport, byte, concurrency, and silence bounds typed and cancellable; require the workspace-owning client to bound repeated continuations using repository state plus its own side-effect ledger.
+- 다른 대안 대신 이 방식을 선택한 이유: Calls and prose are not a repository oracle, and tool names do not prove side effects. A proxy cutoff would either miss the reported loop because items kept changing or terminate legitimate slow work. Retrying after the cutoff could also replay side-effecting work.
+- 장점, 단점 및 영향: OpenCodex does not manufacture a root cause or silently terminate healthy long turns. The combined route still needs a client-side semantic boundary; if a future client sends an explicit privacy-safe progress marker, the proxy may enforce that contract without inferring workspace state.
+
 [Decision Log]
 - 목적과 의도: Keep transport helpers reusable without making every consumer evaluate the full routed Responses and sidecar graph at module load.
 - 기존 구현 및 제약 조건: The original `responses.ts` split copied the monolith import header into `fetch-helpers.ts`; seven helper exports therefore retained 39 distinct runtime import specifiers and reached 326 modules even though the implementations used only three runtime dependencies.

--- a/tests/active-registry-admission.test.ts
+++ b/tests/active-registry-admission.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { abortAndReleaseAllTurns, activeRegistryMetrics, trackStreamLifetime, tryAdmitTurn, unregisterTurn } from "../src/server/lifecycle";
+import { MAX_ACTIVE_TURNS, abortAndReleaseAllTurns, activeRegistryMetrics, trackStreamLifetime, tryAdmitTurn, unregisterTurn } from "../src/server/lifecycle";
 import {
   MAX_TRACKED_CODEX_WEBSOCKETS,
   getTrackedCodexWebSocketCountForAccount,
@@ -173,6 +173,16 @@ describe("active registry admission", () => {
     const nested = trackStreamLifetime(trackStreamLifetime(source, first, undefined, lease!), second, undefined, lease!);
     expect(activeRegistryMetrics().activeTurns.active).toBe(before + 1);
     await new Response(nested).arrayBuffer();
+    expect(activeRegistryMetrics().activeTurns.active).toBe(before);
+  });
+
+  test("the 256-turn gate bounds concurrency, not sequential continuation count", () => {
+    const before = activeRegistryMetrics().activeTurns.active;
+    for (let index = 0; index <= MAX_ACTIVE_TURNS; index += 1) {
+      const lease = tryAdmitTurn("one-logical-session");
+      expect(lease).not.toBeNull();
+      lease!.release();
+    }
     expect(activeRegistryMetrics().activeTurns.active).toBe(before);
   });
 

--- a/tests/responses-state.test.ts
+++ b/tests/responses-state.test.ts
@@ -138,6 +138,34 @@ describe("Responses previous_response_id state", () => {
     clearResponseStateMemoryForTests();
   });
 
+  test("a slow progressing Cursor chain remains replayable beyond the reported 18 continuations", () => {
+    let request: Record<string, unknown> = {
+      model: "cursor/grok-4.6",
+      input: [{ role: "user", content: "bounded task" }],
+      store: false,
+    };
+
+    for (let turn = 0; turn < 32; turn += 1) {
+      const responseId = `resp_progress_${turn}`;
+      const callId = `call_progress_${turn}`;
+      rememberResponseState(
+        request,
+        fixedResponse(responseId, [{ type: "function_call", call_id: callId, name: "inspect", arguments: "{}" }]),
+        { cursor: { conversationId: "cursor_progress_chain" } },
+        { force: true },
+      );
+      request = expandPreviousResponseInput({
+        model: "cursor/grok-4.6",
+        previous_response_id: responseId,
+        input: [{ type: "function_call_output", call_id: callId, output: `new evidence ${turn}` }],
+        store: false,
+      }) as Record<string, unknown>;
+    }
+
+    expect(request.input).toBeArrayOfSize(65);
+    expect(previousResponseConversationId("resp_progress_31")).toBe("cursor_progress_chain");
+  });
+
   afterEach(() => {
     setSpillIoForTest(null);
     setIcaclsRunnerForTests(null);


### PR DESCRIPTION
## Summary

Addresses #2600 with a **diagnosis and a recorded ownership decision**, not a runtime cutoff. The reporter was explicit that their evidence does not establish whether the cause is the Cursor model, the Codex client's continuation policy, or OpenCodex — and after tracing every bound on that path, the honest answer is that OpenCodex cannot make this determination at all.

## What actually bounds a Cursor continuation today

Every existing limit was satisfied while nothing changed in the repository, and each one measures something other than progress:

| Bound | What it counts | Why it did not fire |
|---|---|---|
| Stall watchdog, 300s (`src/stall-timeout.ts`) | upstream **silence** | every adapter event resets it, including heartbeats and read-only calls (`src/bridge.ts:872`) |
| `MAX_ACTIVE_TURNS = 256` (`src/server/lifecycle.ts:33`) | **concurrent** HTTP/WS turns | not cumulative; sequential continuations never approach it |
| `MAX_ACTIVE_SESSION_LANES = 64` | **concurrent** identified sessions | releasing one turn admits the next indefinitely |
| Translator budget, 2 MiB/call, 32 MiB/turn | **live retained bytes** | completed calls release their allocation |
| Response-state caps, 1000 entries / 1h / 64 MiB | **cache retention** | not chain depth |

The reporter's own numbers make the point: items 78→141, tool calls 13→28, 18 persisted continuations. Growth on every axis the proxy can see, zero change on the one that matters.

## Is this a #350 regression?

No. #350 fixed two concrete defects — reconstructing output items missing from terminal SSE, and deduplicating proxy-generated `multi_agent_mode` guidance. That deduplication still runs (`src/server/responses/collaboration.ts:511`), and the reporter confirmed only one copy was present. This is a pre-existing semantic-progress ownership gap that became visible *after* continuation reliability improved, not a regression introduced by it. The accumulating `apps_instructions` blocks are client-authored and outside #350's contract.

## Why no proxy cutoff

OpenCodex observes protocol events, tool names, payloads, bytes and timing. It cannot observe the client's workspace, and a tool name does not prove absence of side effects. Every heuristic available at this layer fails in one of two directions:

- count continuations, or compare assistant prose → **misses this incident**, because items and tool calls kept changing;
- classify read-like tools as no-progress → **terminates legitimate slow work**, and a false positive here kills a long turn a user wanted.

And the report explicitly warns against retry-after-cutoff, which could replay side-effecting work.

Repository-semantic loop detection belongs to the layer that owns the workspace, the continuation policy and the side-effect ledger. If a client later sends an explicit privacy-safe progress marker, the proxy can enforce **that contract** — enforcing an inferred one would be claiming knowledge it does not have.

## What ships

- The ownership decision recorded in `structure/04_transports-and-sidecars.md`, with the alternatives considered and why each was rejected.
- A test pinning that **257 sequential continuations are accepted** while the 256 gate stays concurrency-only — so nobody later reads that constant as a turn budget.
- A test pinning a **32-continuation Cursor chain with unique tool evidence as valid slow progress** — the false-positive case any future bound must not break.

## Verification

```
bun x tsc --noEmit                                          exit 0
bun test active-registry-admission + responses-state        126 pass / 0 fail
cursor adapter / continuation / live transport               52 pass / 0 fail
lifecycle / admission / session lanes / shutdown             32 pass / 0 fail
```

Both new tests were falsified with temporary mutations and failed for the intended reasons.

## Checklist

- [x] Targets `dev`
- [x] No runtime cutoff, retry, replay, or side-effecting behavior added
- [x] Decision recorded where the next reader of these bounds will find it
- [x] No credential, auth, workflow or release-automation surface touched


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cursor continuation chains can now remain replayable beyond 18 continuations while preserving conversation history.
  - Active-turn limits correctly apply to concurrent sessions without blocking sequential reuse of the same session.
- **Documentation**
  - Clarified which progress safeguards are enforced by the transport layer and which remain the responsibility of the client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->