### PR TITLE
fix(subagents): carry entitlement into the encrypted-recovery preview (#2509)

### DIFF
--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -2630,14 +2630,23 @@ async function handleResponsesInner(
                   && recoverySelectionAdmission?.mainProfileDraining === true,
               };
               const recoveryNow = Date.now();
-              subagentFallbackAccountPreview = (modelId, previewNow) => previewCodexAccountForRequest(
+              // Carry the entitlement filter through recovery too (#2509/#2623). The scope was
+              // already re-previewed per candidate here; the ELIGIBLE-ACCOUNT set was not, so a
+              // recovered assignment could select an account that is not entitled to the model
+              // and then fail closed at final auth — the same class of stale-selection bug as
+              // the quota scope, one layer over.
+              subagentFallbackAccountPreview = (modelId, previewNow, modelEligibleAccountIds) => previewCodexAccountForRequest(
                 poolAffinityKey,
                 config,
                 previewNow,
                 codexQuotaScopeForModel(modelId),
-                recoverySelectionOptions,
+                { ...recoverySelectionOptions, modelEligibleAccountIds },
               );
-              const recoveryPreviewAccountId = subagentFallbackAccountPreview(parsed.modelId, recoveryNow);
+              const recoveryPreviewAccountId = subagentFallbackAccountPreview(
+                parsed.modelId,
+                recoveryNow,
+                subagentFallbackModelEligibleAccountIdsForModel?.(parsed.modelId),
+              );
               return applySubagentModelFallback(
                 parsed,
                 req.headers,
@@ -2647,6 +2656,7 @@ async function handleResponsesInner(
                 false,
                 recoverySelectionOptions,
                 subagentFallbackAccountPreview,
+                subagentFallbackModelEligibleAccountIdsForModel,
               );
             } finally {
               recoverySelectionAdmission?.release();

--- a/tests/subagent-fallback-handle-responses.test.ts
+++ b/tests/subagent-fallback-handle-responses.test.ts
@@ -1274,6 +1274,39 @@ describe("native fallback account preview", () => {
     expect(bodyRequests[1]?.auth).toContain("pool-b_token");
   });
 
+  /**
+   * Recovery must carry the ENTITLEMENT filter too, not only the quota scope (#2509).
+   *
+   * The end-to-end case above grants the roster to both pool accounts, so it can only prove the
+   * SCOPE is re-previewed per candidate. The recovery path re-previewed the scope but passed no
+   * eligible-account set, so it could select an account with no entitlement to the recovered
+   * model and fail closed at final auth — the same stale-selection class as the quota scope, one
+   * layer over.
+   *
+   * Asserted structurally on the source, like the route-inventory contract: driving it end to end
+   * needs a recovered encrypted assignment AND an account-gated candidate whose entitlement
+   * differs per account, and the resulting fixture proved more fragile than the thing it checks.
+   * What this does catch is the regression that actually threatens the fix — one of the two
+   * preview sites silently losing the eligibility argument again.
+   */
+  test("both fallback preview sites pass the model-eligible account set (#2509)", async () => {
+    const source = await Bun.file(
+      new URL("../src/server/responses/core.ts", import.meta.url).pathname,
+    ).text();
+
+    const previews = source.match(/subagentFallbackAccountPreview = \([^)]*\)/g) ?? [];
+    // Two assignment sites: the primary selection path and the encrypted-recovery path.
+    expect(previews).toHaveLength(2);
+    // Neither may drop the third parameter — that is exactly how recovery lost it.
+    for (const preview of previews) {
+      expect(preview).toContain("modelEligibleAccountIds");
+    }
+
+    // And both must actually forward it into the preview call, not merely accept it.
+    const forwarded = source.match(/\{ \.\.\.(previewSelectionOptions|recoverySelectionOptions), modelEligibleAccountIds \}/g) ?? [];
+    expect(forwarded).toHaveLength(2);
+  });
+
   test("uses healthier pool account B when active A is above threshold", async () => {
     const now = 1_800_000_000_000;
     Date.now = () => now;


### PR DESCRIPTION
## Summary

Closes the remaining half of #2509. #2515 fixed the primary selection path to preview the Pool account per candidate **quota scope**, and #2623 added the **entitled-account** filter there. The encrypted-recovery path got the scope but not the filter.

So recovery re-previewed per candidate and passed no eligible-account set, which means a recovered assignment could select an account with no entitlement to the model and then fail closed at final auth. That is the same stale-selection class the issue is about, one layer over — selection rejecting or mis-picking before model-aware auth runs.

## Verification

```
bun x tsc --noEmit                                        exit 0
bun test subagent-fallback-handle-responses + subagent-model-fallback   94 pass / 0 fail
```

Falsified: reverting the recovery site to its two-argument form reddens exactly the new test and nothing else.

## On the test shape, since it is a structural assertion

I tried the end-to-end version first and dropped it. Driving this properly needs a recovered encrypted assignment **and** an account-gated candidate whose entitlement differs per account — the existing recovery case grants the roster to both pool accounts, so it can only prove the scope is re-previewed. The fixture I built for it was more fragile than the behavior it checked, and a flaky test on a credential-selection path is worse than an honest structural one.

What this test does catch is the regression that actually threatens the fix: one of the two preview sites silently losing the eligibility argument again, which is precisely how recovery lost it. It asserts both assignment sites accept `modelEligibleAccountIds` **and** forward it into the preview call — accepting it without forwarding was a plausible half-fix.

## What remains open on #2509

Not everything in that issue is closed by this. Selection still only checks probe availability rather than atomically reserving it (`src/codex/subagent-model-fallback.ts:294`), which is a separate lifecycle question. Saying so rather than closing the issue on a partial fix.

## Checklist

- [x] Targets `dev`
- [x] Regression pinned and falsified
- [x] Credential-selection change reviewed: no token logging, no cross-account reuse introduced
- [x] No workflow or release-automation surface touched


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved encrypted-task recovery to select only accounts eligible for the requested model.
  * Prevented fallback handling from choosing unavailable or unauthorized model accounts.

* **Tests**
  * Added regression coverage for account eligibility during primary and encrypted recovery fallback flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->