### PR TITLE
test(runtime): pin the bundled Bun version (#1419)

### DIFF
--- a/tests/install-scripts.test.ts
+++ b/tests/install-scripts.test.ts
@@ -50,6 +50,7 @@ describe("install scripts", () => {
     expect(pkg.main).toBe("./bin/package-main.mjs");
     expect(pkg.exports?.["."]?.bun).toBe("./src/index.ts");
     expect(pkg.exports?.["."]?.default).toBe("./bin/package-main.mjs");
+    expect(pkg.dependencies?.bun).toBe("1.4.0");
     expect(pkg.dependencies?.zod).toBe("4.4.3");
     expect(pkg.devDependencies?.typescript).toBe("7.0.2");
     expect(pkg.devDependencies?.["@types/bun"]).toBe("1.4.0");


### PR DESCRIPTION
## Summary

Partial for #1419. The bundled runtime already moved from Bun 1.3.14 to **1.4.0** on `dev` (`27764f342`), and the reporter's crash is specific to 1.3.14. This pins that version so the bundled runtime cannot silently regress — the existing assertion covered only `@types/bun`, not the runtime actually shipped.

## What this does not claim

It does not claim the SIGTRAP is fixed. Symbolicating the reported offsets against Bun's matching binary UUID produced only:

```
52255300  crash_handler.crash +136
52218912  crash_handler.crashHandler +3204
15551472  JobControl.ttouBlocked +0
```

Those are the crash handler itself — they say a trap happened, not what trapped. The frames that would distinguish TLS/fetch from JSC/GC from another assertion are missing from the report. And while Bun has 1.3.14 SIGTRAP reports against the same binary UUID, no upstream issue or release notes establish that 1.4.0 fixes *this* signature.

So the honest position is: the runtime that produced the crash is no longer shipped, and that is now pinned; whether the crash is gone is unproven.

## One thing worth recording for whoever picks this up

An installed macOS service is supervised (`RunAtLoad` + `KeepAlive`, `src/service.ts:427`), so a native crash restarts. But `ocx gui` starts an **unref'd detached process** (`src/cli/dispatch.ts:286`, `src/cli/index.ts:965`) — without an installed service, a native crash strands the proxy with no supervisor. That is a real difference in blast radius between the two launch paths, and it is arguably the part OpenCodex can act on regardless of what Bun does.

Not changed here: adding a respawn loop to the detached path is a lifecycle decision, not a test fix.

## Verification

```
bun x tsc --noEmit                          exit 0
bun test ./tests/install-scripts.test.ts     9 pass / 0 fail
bun test <install + related suites>        176 pass / 0 fail
bun run privacy:scan                        Privacy scan passed
```

Falsified: restoring `bun: 1.3.14` in `package.json` reddens the new assertion (`Expected "1.4.0", received "1.3.14"`).

## Checklist

- [x] Targets `dev`
- [x] No speculative runtime bump or TLS workaround
- [x] Claim scoped to what the evidence supports
- [x] No credential, auth, workflow or release-automation surface touched


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that Bun 1.4.0 is declared as a runtime dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->