### PR TITLE
test(server): give the Daybreak compact case the server budget

### DIFF
--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -2243,7 +2243,11 @@ describe("server local API auth", () => {
     } finally {
       await stopPoolRetryHarness(harness);
     }
-  });
+    // Same budget as the other harness cases in this file: this one starts a real server and
+    // was left on Bun's 5s default, so it timed out at 5003ms under full-suite parallel load
+    // while passing 3/3 in isolation on two machines. A server-backed case measured against a
+    // default meant for pure unit tests is a load flake, not a signal.
+  }, { timeout: SERVER_BUDGET_MS });
 
   test("#2097: a confirmed entitled account survives two transient unsupported-model 400s in place", async () => {
     const model = "gpt-daybreak-blue-latest";


### PR DESCRIPTION
## Summary

A full-suite parallel run on the Linux test host reported one failure:

```
(fail) server local API auth > #2097: Daybreak compact uses the stable wire model without retention [5003.01ms]
```

`5003ms` is Bun's default 5s test timeout, not an assertion failure. The case passes 3/3 in isolation on both macOS and the Linux host.

It starts a real server through `startPoolRetryHarness`, and its neighbours in this file already declare `SERVER_BUDGET_MS` for that reason — this one was left on the default intended for pure unit tests. Under full-suite parallel load, server startup plus the request exceeded 5s.

## Verification

```
bun test ./tests/server-auth.test.ts    86 pass / 0 fail
```

Isolation runs before the change: 3/3 pass on macOS (2.78s, 504ms, 737ms) and 3/3 on Linux (301ms, 325ms, 315ms) — which is what identifies this as load-dependent rather than a real defect.

## Checklist

- [x] Targets `dev`
- [x] Test-only; no production behavior changed
- [x] Budget matches the existing convention in the same file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the pool retry test to use the server time budget for more reliable timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->