### PR TITLE
fix(management): preserve the account-failover opt-out across a provider overwrite (#2568d)

### DIFF
--- a/devlog/_plan/260826_wp7e_presence_driven_oauth_failover/030_post_merge_f5.md
+++ b/devlog/_plan/260826_wp7e_presence_driven_oauth_failover/030_post_merge_f5.md
@@ -1,0 +1,39 @@
+# 030 — closing F5: the Add Provider path also had to stop dropping the opt-out
+
+`011_audit_response.md` scoped F5 out with a reason: `/api/providers` POST replaces a provider
+row wholesale and already discards every unrecognized key, so it looked like a general payload
+contract problem rather than this feature's problem.
+
+That reasoning was half right and the conclusion was wrong.
+
+## Why it could not stay deferred
+
+Every other field this path drops fails toward something neutral — a missing `modelCosts` means
+the Usage estimate falls back to registry prices, a missing `contextWindow` means the seed value
+applies. Losing `oauthAccountFailover` does not fail toward neutral. Activation is now
+presence-driven, so deleting an operator's `enabled: false` does not restore a default: it
+**enables** rotation across their second subscription account, as a side effect of an edit that
+had nothing to do with failover.
+
+That is the same failure shape as F4 (login rebuilding the row), which was accepted as blocking.
+The two paths differ only in which unrelated action triggers the loss.
+
+## What changed
+
+One preservation line in `src/server/management/provider-routes.ts`, next to the ones that
+already exist for `apiKeyPool`, `modelCosts`, `requestPacing`, and the context-window maps. The
+comment there records why absence means "not carried" rather than "deleted": `ProviderPayload`
+(`gui/src/provider-payload.ts`) structurally cannot express the field, so the dashboard's
+add/edit form can never send it. Deletion goes through PATCH with an explicit null, exactly as
+#1409 established for context windows.
+
+No GUI change. Widening `ProviderPayload` would be the wrong fix for the same reason it was the
+wrong fix for `modelCosts`: the form has no control for this setting, so a payload member would
+only give it a way to send `undefined` and re-create the problem.
+
+## Verification
+
+A regression next to the existing `modelCosts` overwrite test in
+`tests/management-provider-validation.test.ts`, driven against a real server: create a provider
+with `enabled: false`, POST an overwrite without the field, assert the opt-out survived.
+Falsified by disabling the preservation branch — the test fails, 74 pass / 1 fail.

--- a/src/server/management/provider-routes.ts
+++ b/src/server/management/provider-routes.ts
@@ -596,6 +596,12 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
     // erase hand-edited per-model prices from Logs/Usage estimates.
     const existingCosts = config.providers[name]?.modelCosts;
     if (existingCosts && !prov.modelCosts) prov.modelCosts = existingCosts;
+    // And to the per-provider account-failover opt-out (#2568d). `ProviderPayload` has no
+    // member for it either, so an add/edit save structurally cannot carry it — and dropping it
+    // silently ENABLES rotation, because activation is presence-driven once the knob is gone.
+    // An overwrite must not spend a second subscription account's quota as a side effect.
+    const existingFailover = config.providers[name]?.oauthAccountFailover;
+    if (existingFailover && !prov.oauthAccountFailover) prov.oauthAccountFailover = existingFailover;
     // ...and to hand-edited context windows. `ProviderPayload` (gui/src/provider-payload.ts)
     // has no member for either field, so the add/edit form structurally cannot send them:
     // absence in the request means "not carried", never "the user deleted it". Deletion goes

--- a/tests/management-provider-validation.test.ts
+++ b/tests/management-provider-validation.test.ts
@@ -654,6 +654,47 @@ describe("provider management validation", () => {
     }
   });
 
+  test("provider POST overwrite preserves the account-failover opt-out when the payload omits it (#2568d)", async () => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    saveConfig(config("127.0.0.1"));
+
+    const server = startServer(0);
+    try {
+      const create = await fetch(new URL("/api/providers", server.url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "custom-failover",
+          provider: {
+            adapter: "openai-chat",
+            baseUrl: "https://api.example.test/v1",
+            oauthAccountFailover: { enabled: false },
+          },
+        }),
+      });
+      expect(create.status).toBe(200);
+
+      // Losing this one is worse than losing a cosmetic field: activation is presence-driven,
+      // so dropping the opt-out does not fall back to a neutral default — it ENABLES rotation
+      // across the operator's second subscription account, as a side effect of an edit that had
+      // nothing to do with failover.
+      const overwrite = await fetch(new URL("/api/providers", server.url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "custom-failover",
+          provider: { adapter: "openai-chat", baseUrl: "https://api.example.test/v1" },
+        }),
+      });
+      expect(overwrite.status).toBe(200);
+      expect(loadConfig().providers["custom-failover"]?.oauthAccountFailover).toEqual({ enabled: false });
+    } finally {
+      await server.stop(true);
+    }
+  });
+
   // #1409: the add/edit form's payload type has no member for contextWindow or
   // modelContextWindows, so an overwrite arrives without them. Registry enrichment then fills
   // the absent fields from the seed and the stored row loses the user's values — for


### PR DESCRIPTION
## Summary

Closes the one finding the #2640 audit deferred: `POST /api/providers` dropped a provider's `oauthAccountFailover` on overwrite.

That path replaces a provider row with the submitted payload and carries forward an explicit allowlist. `ProviderPayload` (`gui/src/provider-payload.ts`) has no member for this key, so the dashboard's add/edit form structurally cannot send it — absence means "not carried", never "the user deleted it".

The audit response scoped this out as a general payload-contract problem. That reasoning does not hold once activation is presence-driven. Every other field this path drops fails toward something neutral: a missing `modelCosts` falls back to registry prices, a missing `contextWindow` to the registry seed. Losing `oauthAccountFailover` does not fail toward neutral — deleting an operator's `enabled: false` **enables** rotation across their second subscription account, as a side effect of an edit that had nothing to do with failover. That is the same failure shape as the login-path loss that shipped a fix in #2640.

The change is one preservation line beside the existing ones for `apiKeyPool`, `modelCosts`, `requestPacing`, and the context-window maps. Deletion still goes through PATCH with an explicit null, as #1409 established for context windows.

No GUI change. Widening `ProviderPayload` would be the wrong fix for the same reason it is wrong for `modelCosts`: the form has no control for this setting, so a payload member would only give it a way to send `undefined` and re-create the problem.

Rationale recorded in `devlog/_plan/260826_wp7e_presence_driven_oauth_failover/030_post_merge_f5.md`.

## Verification

- `bun x tsc --noEmit` — exit 0
- `bun run test` — full suite, 0 fail, exit 0
- `bun test tests/management-provider-validation.test.ts` — 75 pass
- Combined receipt across the four #2568d suites — 115 pass, 0 fail

Falsified: disabling the preservation branch fails the new test (74 pass / 1 fail), so it is not vacuous.

The regression runs against a real server next to the existing `modelCosts` overwrite test — create a provider with `enabled: false`, POST an overwrite without the field, assert the opt-out survived.

No GUI change, so no screenshot applies.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider updates now preserve the existing OAuth account failover setting when the field is omitted.
  * Disabled account failover can no longer be unintentionally re-enabled during provider overwrites.

* **Tests**
  * Added regression coverage to verify that a disabled failover setting remains disabled after updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->