### PR TITLE
fix(cursor): quarantine catalog models whose runs always fail upstream

### DIFF
--- a/src/adapters/cursor/discovery.ts
+++ b/src/adapters/cursor/discovery.ts
@@ -214,9 +214,22 @@ export function filterCursorConfiguredModelsByLiveDiscovery<T extends { id: stri
   liveIds: readonly string[],
 ): T[] {
   return configured.filter(model =>
-    isCursorRouterModelId(model.id) || isCursorModelAvailableForAccount(model.id, liveIds),
+    !CURSOR_KNOWN_UNCALLABLE_MODEL_IDS.has(model.id)
+    && (isCursorRouterModelId(model.id) || isCursorModelAvailableForAccount(model.id, liveIds)),
   );
 }
+
+/**
+ * Models GetUsableModels advertises but whose every Run returns not_found (catalog honesty,
+ * devlog 260826_cursor_responses_gap 060). Live probes 2026-08-26: cursor/claude-opus-5 failed
+ * 100% ("Cursor Connect error not_found") while its -fast and -thinking siblings — separate
+ * wire families — succeed. Quarantined here, in the shared filter, so live, cached, stale, and
+ * static serving paths all agree. Custom user provider overrides are not routed through this
+ * canonical seed and stay untouched.
+ */
+export const CURSOR_KNOWN_UNCALLABLE_MODEL_IDS: ReadonlySet<string> = new Set([
+  "claude-opus-5",
+]);
 
 export const CURSOR_STATIC_MODELS: readonly CursorModelInfo[] = normalizeCursorModels([
   // Context windows and the model lineup mirror Cursor's public models/pricing docs plus the jawcode
@@ -245,7 +258,8 @@ export const CURSOR_STATIC_MODELS: readonly CursorModelInfo[] = normalizeCursorM
   { id: "claude-opus-4-7-fast", contextWindow: CONTEXT_200K, supportsReasoningEffort: true },
   { id: "claude-opus-4-8-fast", contextWindow: CONTEXT_200K, supportsReasoningEffort: true },
   { id: "claude-opus-4-8", contextWindow: CONTEXT_200K, supportsReasoningEffort: true },
-  { id: "claude-opus-5", contextWindow: CONTEXT_200K, supportsReasoningEffort: true },
+  // claude-opus-5 (bare) removed from the seed: GetUsableModels lists it but every Run returns
+  // not_found (quarantined via CURSOR_KNOWN_UNCALLABLE_MODEL_IDS; -fast/-thinking families stay).
   { id: "claude-opus-5-fast", contextWindow: CONTEXT_200K, supportsReasoningEffort: true },
   { id: "claude-fable-5", contextWindow: CONTEXT_200K, supportsReasoningEffort: true },
 

--- a/tests/cursor-uncallable-quarantine.test.ts
+++ b/tests/cursor-uncallable-quarantine.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CURSOR_KNOWN_UNCALLABLE_MODEL_IDS,
+  CURSOR_STATIC_MODELS,
+  filterCursorConfiguredModelsByLiveDiscovery,
+} from "../src/adapters/cursor/discovery";
+
+describe("cursor uncallable-model quarantine (devlog 260826 060)", () => {
+  test("static seed no longer carries bare claude-opus-5", () => {
+    expect(CURSOR_STATIC_MODELS.some(model => model.id === "claude-opus-5")).toBe(false);
+  });
+
+  test("siblings from other wire families survive", () => {
+    expect(CURSOR_STATIC_MODELS.some(model => model.id === "claude-opus-5-fast")).toBe(true);
+  });
+
+  test("live filter drops quarantined ids even when GetUsableModels lists them", () => {
+    const configured = [{ id: "claude-opus-5" }, { id: "claude-opus-5-fast" }, { id: "grok-4.6" }];
+    const live = ["claude-opus-5-high", "claude-opus-5-high-fast", "grok-4.6-high"];
+    const filtered = filterCursorConfiguredModelsByLiveDiscovery(configured, live);
+    expect(filtered.map(model => model.id)).toEqual(["claude-opus-5-fast", "grok-4.6"]);
+  });
+
+  test("quarantine applies with an empty live list too (stale/static degradation path)", () => {
+    const configured = [{ id: "claude-opus-5" }, { id: "auto" }];
+    const filtered = filterCursorConfiguredModelsByLiveDiscovery(configured, []);
+    expect(filtered.some(model => model.id === "claude-opus-5")).toBe(false);
+  });
+
+  test("quarantine set stays narrow", () => {
+    expect([...CURSOR_KNOWN_UNCALLABLE_MODEL_IDS]).toEqual(["claude-opus-5"]);
+  });
+});


### PR DESCRIPTION
## Summary

- `/v1/models` served `cursor/claude-opus-5` while every live Run against it failed upstream with `Cursor Connect error not_found` (probe C2a in devlog/_plan/260826_cursor_responses_gap, 100% failure incl. plain retry) — a picker offering a model that cannot answer.
- Removes the bare `claude-opus-5` row from `CURSOR_STATIC_MODELS` and adds a narrow `CURSOR_KNOWN_UNCALLABLE_MODEL_IDS` quarantine applied inside `filterCursorConfiguredModelsByLiveDiscovery`, so live, cached, stale, and static serving paths all agree. `-fast`/`-thinking` siblings (separate wire families with success evidence) are preserved; custom user provider overrides are not routed through this canonical seed and stay untouched.

Stacked on #2652. Design: 060_catalog_honesty.md.

## Verification

- `bun test tests/cursor-uncallable-quarantine.test.ts` — 5 pass (seed removal, sibling survival, live-list drop, empty-live degradation path, set narrowness).
- `bun test tests/cursor-discovery.test.ts tests/cursor-static-catalog.test.ts tests/cursor-hardening.test.ts tests/cursor-effort-suffix.test.ts` — 92 pass 0 fail total.
- `bun x tsc --noEmit` — clean.

## Checklist

- [x] Focused tests green
- [x] Typecheck clean
- [x] All degradation paths share the gate
- [x] Devlog updated (060)

