### PR TITLE
feat(providers): add opt-in transient-5xx retry policy for key-auth providers

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -445,6 +445,18 @@ const retryOn429PolicySchema = z.object({
   respectRetryAfter: z.boolean().optional(),
 }).strict();
 
+/**
+ * Bounds for the opt-in transient-5xx retry policy. Delays intentionally stay
+ * non-configurable in the first version: the runtime uses the shared safe
+ * constants in lib/upstream-retry.ts (400ms base, 5s cap, Retry-After honored).
+ * Strict, so an unknown key is rejected at every validation boundary instead of
+ * being silently ignored.
+ */
+const transientRetryOn5xxPolicySchema = z.object({
+  enabled: z.boolean().optional(),
+  attempts: z.number().int().min(1).max(10).optional(),
+}).strict();
+
 const requestPacingRuleSchema = z.object({
   // Keep the RPM-derived timer within the same one-hour bound as minIntervalMs.
   requestsPerMinute: z.number().min(1 / 60).max(60_000).optional(),
@@ -517,6 +529,7 @@ const providerConfigSchema = z.object({
     .transform(normalizeNonBlankStringArray)
     .optional(),
   retryOn429: retryOn429PolicySchema.optional(),
+  transientRetryOn5xx: transientRetryOn5xxPolicySchema.optional(),
   codexAccountMode: z.enum(["pool", "direct"]).optional(),
   // Validated rather than passed through: this schema ends in `.passthrough()`, so an
   // undeclared key survives verbatim. A misspelled `codexToolMode` therefore used to be
@@ -1392,6 +1405,59 @@ function sanitizeRetryOn429ForLoad(parsed: unknown): void {
 }
 
 /**
+ * Load-time degradation for `transientRetryOn5xx` (loadConfig only), mirroring
+ * {@link sanitizeRetryOn429ForLoad}: one hand-edited invalid optional field must not
+ * trip the whole provider schema. Invalid fields are dropped with a warning; an
+ * explicitly present but invalid master switch drops the whole policy so a malformed
+ * disable-oriented edit stays disabled.
+ */
+function sanitizeTransientRetryOn5xxForLoad(parsed: unknown): void {
+  if (!parsed || typeof parsed !== "object") return;
+  const root = parsed as Record<string, unknown>;
+  const providers = root.providers;
+  if (!providers || typeof providers !== "object" || Array.isArray(providers)) return;
+  for (const [name, provider] of Object.entries(providers as Record<string, unknown>)) {
+    const safeProviderName = JSON.stringify(redactSecretString(name));
+    if (!provider || typeof provider !== "object" || Array.isArray(provider)) continue;
+    const p = provider as Record<string, unknown>;
+    const policy = p.transientRetryOn5xx;
+    if (policy === undefined) continue;
+    if (!policy || typeof policy !== "object" || Array.isArray(policy)) {
+      delete p.transientRetryOn5xx;
+      console.warn(`⚠️  config.json providers.${safeProviderName}.transientRetryOn5xx (${typeof policy}) is invalid — ignoring the policy`);
+      continue;
+    }
+    const policyRecord = policy as Record<string, unknown>;
+    if ("enabled" in policyRecord && typeof policyRecord.enabled !== "boolean") {
+      delete p.transientRetryOn5xx;
+      console.warn(`⚠️  config.json providers.${safeProviderName}.transientRetryOn5xx.enabled (${typeof policyRecord.enabled}) is invalid — ignoring the whole policy`);
+      continue;
+    }
+    const policyShape = transientRetryOn5xxPolicySchema.shape;
+    const hadPolicyEntries = Object.keys(policyRecord).length > 0;
+    const cleaned: Record<string, unknown> = {};
+    for (const [key, fieldSchema] of Object.entries(policyShape)) {
+      const value = policyRecord[key];
+      if (value === undefined) continue;
+      if (fieldSchema.safeParse(value).success) cleaned[key] = value;
+      else console.warn(`⚠️  config.json providers.${safeProviderName}.transientRetryOn5xx.${key} (${typeof value}) is invalid — ignoring the field`);
+    }
+    const knownKeys = new Set(Object.keys(policyShape));
+    for (const key of Object.keys(policyRecord)) {
+      if (!knownKeys.has(key)) {
+        console.warn(`⚠️  config.json providers.${safeProviderName}.transientRetryOn5xx.${JSON.stringify(redactSecretString(key))} is not a recognized field — ignoring it`);
+      }
+    }
+    if (hadPolicyEntries && Object.keys(cleaned).length === 0) {
+      delete p.transientRetryOn5xx;
+      console.warn(`⚠️  config.json providers.${safeProviderName}.transientRetryOn5xx has no valid fields left — removing the policy (an empty policy would enable retries with defaults)`);
+    } else {
+      p.transientRetryOn5xx = cleaned;
+    }
+  }
+}
+
+/**
  * Management write-boundary validation for `retryOn429` (fail closed). Unlike the
  * lenient load-time sanitizer, invalid values and unknown keys are rejected outright so
  * a POST/PATCH cannot persist a policy the proxy would then silently degrade. Reuses the
@@ -1411,6 +1477,26 @@ export function retryOn429PolicyConfigError(policy: unknown): string | null {
   if (first.path.length === 0) return `retryOn429 is invalid (${first.message})`;
   const field = String(first.path[first.path.length - 1]);
   return `retryOn429.${field} is invalid (${first.message})`;
+}
+
+/**
+ * Management write-boundary validation for `transientRetryOn5xx` (fail closed),
+ * mirroring {@link retryOn429PolicyConfigError}. Reuses the shared policy schema.
+ * Never echoes values, and secret-shaped unknown field names are redacted.
+ */
+export function transientRetryOn5xxPolicyConfigError(policy: unknown): string | null {
+  if (policy === undefined) return null;
+  const result = transientRetryOn5xxPolicySchema.safeParse(policy);
+  if (result.success) return null;
+  const first = result.error.issues[0];
+  if (!first) return "transientRetryOn5xx is invalid";
+  if (first.code === "unrecognized_keys") {
+    const names = first.keys.map(key => JSON.stringify(redactSecretString(key))).join(", ");
+    return `transientRetryOn5xx has unrecognized field${first.keys.length > 1 ? "s" : ""}: ${names}`;
+  }
+  if (first.path.length === 0) return `transientRetryOn5xx is invalid (${first.message})`;
+  const field = String(first.path[first.path.length - 1]);
+  return `transientRetryOn5xx.${field} is invalid (${first.message})`;
 }
 
 /**
@@ -1816,6 +1902,7 @@ export function loadConfig(): OcxConfig {
     const parsed = JSON.parse(raw);
     sanitizeAliasesForLoad(parsed);
     sanitizeRetryOn429ForLoad(parsed);
+    sanitizeTransientRetryOn5xxForLoad(parsed);
     sanitizeModelCostsForLoad(parsed);
     const result = configSchema.safeParse(parsed);
     if (result.success) {
@@ -2199,6 +2286,7 @@ function configDiagnosticsFromRaw(raw: string): ConfigDiagnostics {
     // schema and send the caller a default-config fallback (the config command could then
     // persist that fallback over the user's providers/keys).
     sanitizeRetryOn429ForLoad(parsed);
+    sanitizeTransientRetryOn5xxForLoad(parsed);
     sanitizeModelCostsForLoad(parsed);
     const result = configSchema.safeParse(parsed);
     if (result.success) {

--- a/src/providers/key-failover.ts
+++ b/src/providers/key-failover.ts
@@ -41,8 +41,6 @@ const DEFAULT_RATE_LIMIT_RETRY = {
 const DEFAULT_TRANSIENT_RETRY = {
   enabled: true,
   attempts: 3,
-  baseDelayMs: 400,
-  maxDelayMs: 5_000,
 } as const satisfies Required<TransientRetryPolicy>;
 
 /**
@@ -60,8 +58,6 @@ export function transientRetryPolicyFor(
   return {
     enabled: policy.enabled ?? DEFAULT_TRANSIENT_RETRY.enabled,
     attempts: policy.attempts ?? DEFAULT_TRANSIENT_RETRY.attempts,
-    baseDelayMs: policy.baseDelayMs ?? DEFAULT_TRANSIENT_RETRY.baseDelayMs,
-    maxDelayMs: policy.maxDelayMs ?? DEFAULT_TRANSIENT_RETRY.maxDelayMs,
   };
 }
 

--- a/src/providers/key-failover.ts
+++ b/src/providers/key-failover.ts
@@ -9,7 +9,7 @@
  * Modelled after src/codex/routing.ts cooldown logic but scoped to plain API-key pools.
  */
 import { saveConfigPreservingClaudeCode } from "../config";
-import type { OcxConfig, OcxProviderConfig, RateLimitRetryPolicy } from "../types";
+import type { OcxConfig, OcxProviderConfig, RateLimitRetryPolicy, TransientRetryPolicy } from "../types";
 import { resolveProviderTransport, type OcxProviderTransport } from "./xai-transport";
 import { sweepExpiredOnWrite } from "../lib/state-store-sweeper";
 
@@ -33,6 +33,37 @@ const DEFAULT_RATE_LIMIT_RETRY = {
   maxIntervalMs: 60_000,
   respectRetryAfter: true,
 } as const satisfies Required<RateLimitRetryPolicy>;
+
+/**
+ * Default transient-5xx retry policy used when a provider opts in via a bare
+ * `transientRetryOn5xx: {}` (presence = opt-in with these defaults).
+ */
+const DEFAULT_TRANSIENT_RETRY = {
+  enabled: true,
+  attempts: 3,
+  baseDelayMs: 400,
+  maxDelayMs: 5_000,
+} as const satisfies Required<TransientRetryPolicy>;
+
+/**
+ * Normalize a provider's `transientRetryOn5xx` policy, or return null when the knob is absent,
+ * explicitly disabled, or the provider is not key-auth. OAuth/forward credentials are
+ * never replayed on the same token, and local runtimes have no remote key to preserve.
+ * The returned policy is fully defaulted so callers never re-check fields.
+ */
+export function transientRetryPolicyFor(
+  provider: Pick<OcxProviderConfig, "transientRetryOn5xx" | "authMode">,
+): Required<TransientRetryPolicy> | null {
+  const policy = provider.transientRetryOn5xx;
+  if (!policy || policy.enabled === false) return null;
+  if (provider.authMode !== undefined && provider.authMode !== "key") return null;
+  return {
+    enabled: policy.enabled ?? DEFAULT_TRANSIENT_RETRY.enabled,
+    attempts: policy.attempts ?? DEFAULT_TRANSIENT_RETRY.attempts,
+    baseDelayMs: policy.baseDelayMs ?? DEFAULT_TRANSIENT_RETRY.baseDelayMs,
+    maxDelayMs: policy.maxDelayMs ?? DEFAULT_TRANSIENT_RETRY.maxDelayMs,
+  };
+}
 
 /** Map<`${providerName}\0${keyId}`, KeyCooldown> */
 const keyCooldowns = new Map<string, KeyCooldown>();

--- a/src/server/chat-native.ts
+++ b/src/server/chat-native.ts
@@ -21,6 +21,7 @@ import { isModelTextOnly } from "../vision";
 import {
   applyUpstreamRecoveryInit,
   fetchWithResetRetry,
+  fetchWithTransientRetry,
   prepareSameTarget429Wait,
   type UpstreamSendRecovery,
 } from "../lib/upstream-retry";
@@ -33,6 +34,7 @@ import {
   rateLimitRetryDelayMs,
   rateLimitRetryPolicyFor,
   rotateProviderTransportOn429,
+  transientRetryPolicyFor,
 } from "../providers/key-failover";
 import { fastPolicyForModel } from "../providers/service-tier";
 import type { RouteResult } from "../router";
@@ -204,7 +206,9 @@ export async function handleNativeChatCompletions(options: HandleNativeChatOptio
 
   const send = async (request: AdapterRequest, recovery?: "rate-limit-429" | "key-429"): Promise<Response> => {
     try {
-      return await fetchWithResetRetry(
+      const transientPolicy = transientRetryPolicyFor(activeProvider);
+      const doFetchWithRetry = transientPolicy ? fetchWithTransientRetry : fetchWithResetRetry;
+      return await doFetchWithRetry(
         (transportRecovery?: UpstreamSendRecovery) => {
           noteAttemptSend(attempt, logCtx.usageLogInputTokens, transportRecovery ?? recovery);
           return fetchWithHeaderTimeout(
@@ -223,7 +227,11 @@ export async function handleNativeChatCompletions(options: HandleNativeChatOptio
             }),
           );
         },
-        { abortSignal: upstream.signal, label: safeHostLabel(request.url) },
+        {
+          abortSignal: upstream.signal,
+          label: safeHostLabel(request.url),
+          ...(transientPolicy ? { attempts: transientPolicy.attempts } : {}),
+        },
       );
     } finally {
       request.releaseBodyObservation?.();

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -218,6 +218,7 @@ import {
   rateLimitRetryDelayMs,
   rateLimitRetryPolicyFor,
   rotateProviderTransportOn429,
+  transientRetryPolicyFor,
 } from "../../providers/key-failover";
 import { shouldAttemptImageTierRetry } from "../image-retry";
 import { isXaiResponsesDestination, resolveProviderTransport } from "../../providers/xai-transport";
@@ -5278,11 +5279,12 @@ async function handleResponsesInner(
         }),
       });
     } else {
-      // #1851 scope guard: transient-5xx retry on this generic adapter path is opt-in for
-      // direct Google AI Studio only (Vertex/Antigravity use fetchResponse above). Other
-      // adapters keep reset-only retry so combo failover still hops on the first 5xx
+      // #1851 scope guard: transient-5xx retry on this generic adapter path is opt-in via
+      // provider config (transientRetryOn5xx) or the legacy Google adapter exception.
+      // Other adapters keep reset-only retry so combo failover still hops on the first 5xx
       // instead of burning ~1.2s of same-target retries per hop.
-      const fetchWithRetryPolicy = route.provider.adapter === "google" ? fetchWithTransientRetry : fetchWithResetRetry;
+      const transientPolicy = transientRetryPolicyFor(route.provider);
+      const fetchWithRetryPolicy = transientPolicy || route.provider.adapter === "google" ? fetchWithTransientRetry : fetchWithResetRetry;
       upstreamResponse = await fetchWithRetryPolicy(
         recovery => {
           noteAttemptSend(logCtx.activeAttempt, inputTokenEstimate, recovery);
@@ -5296,7 +5298,11 @@ async function handleResponsesInner(
               modelId: route.modelId,
             }));
         },
-        { abortSignal: upstream.signal, label: safeHostLabel(builtInitialRequest.url) },
+        {
+          abortSignal: upstream.signal,
+          label: safeHostLabel(builtInitialRequest.url),
+          ...(transientPolicy ? { attempts: transientPolicy.attempts } : {}),
+        },
       );
     }
   } catch (err) {
@@ -5797,9 +5803,10 @@ async function handleResponsesInner(
             }),
           });
         }
-        // Same #1851 scope guard as the initial send: transient-5xx retry only for direct
-        // Google AI Studio; every other adapter keeps reset-only semantics here.
-        const fetchContinuationWithRetryPolicy = route.provider.adapter === "google" ? fetchWithTransientRetry : fetchWithResetRetry;
+        // Same #1851 scope guard as the initial send: transient-5xx retry via
+        // provider config (transientRetryOn5xx) or the legacy Google adapter exception.
+        const transientPolicy = transientRetryPolicyFor(route.provider);
+        const fetchContinuationWithRetryPolicy = transientPolicy || route.provider.adapter === "google" ? fetchWithTransientRetry : fetchWithResetRetry;
         return await fetchContinuationWithRetryPolicy(
           recovery => {
             noteAttemptSend(logCtx.activeAttempt, continuationEstimate, recovery ?? replayKind);
@@ -5819,8 +5826,12 @@ async function handleResponsesInner(
               }),
             );
           },
-          { abortSignal: upstream.signal, label: safeHostLabel(builtContinuationRequest.url) },
-          );
+          {
+            abortSignal: upstream.signal,
+            label: safeHostLabel(builtContinuationRequest.url),
+            ...(transientPolicy ? { attempts: transientPolicy.attempts } : {}),
+          },
+        );
       } finally {
         builtContinuationRequest.releaseBodyObservation?.();
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,7 @@ export type {
   OpenRouterProviderRouting,
   ResponsesItemIdRepairConfig,
   RateLimitRetryPolicy,
+  TransientRetryPolicy,
   ProviderCostOverlay,
   RequestPacingRule,
   ProviderRequestPacingConfig,

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -55,18 +55,15 @@ export interface RateLimitRetryPolicy {
  * Transient-5xx retry policy (providers.<name>.transientRetryOn5xx). When present and not
  * explicitly disabled, the proxy retries the initial request with exponential backoff on
  * transient upstream statuses (500/502/503/504/520/521/522) before surfacing the error.
- * All fields optional; the runtime applies defaults (attempts=3, baseDelayMs=400,
- * maxDelayMs=5000, enabled=true). Only honored for key-auth providers.
+ * All fields optional; the runtime applies the shared defaults (attempts=3,
+ * enabled=true) with the fixed backoff constants in lib/upstream-retry.ts
+ * (400ms base, 5s cap, Retry-After honored). Only honored for key-auth providers.
  */
 export interface TransientRetryPolicy {
   /** Master switch. The presence of the object also enables the policy (default true). */
   enabled?: boolean;
   /** Extra retry attempts after the first transient failure (1..10, default 3). */
   attempts?: number;
-  /** Base delay in ms for the first retry backoff (default 400). */
-  baseDelayMs?: number;
-  /** Cap for any single retry wait, including an upstream Retry-After (default 5000). */
-  maxDelayMs?: number;
 }
 
 /**

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -52,6 +52,24 @@ export interface RateLimitRetryPolicy {
 }
 
 /**
+ * Transient-5xx retry policy (providers.<name>.transientRetryOn5xx). When present and not
+ * explicitly disabled, the proxy retries the initial request with exponential backoff on
+ * transient upstream statuses (500/502/503/504/520/521/522) before surfacing the error.
+ * All fields optional; the runtime applies defaults (attempts=3, baseDelayMs=400,
+ * maxDelayMs=5000, enabled=true). Only honored for key-auth providers.
+ */
+export interface TransientRetryPolicy {
+  /** Master switch. The presence of the object also enables the policy (default true). */
+  enabled?: boolean;
+  /** Extra retry attempts after the first transient failure (1..10, default 3). */
+  attempts?: number;
+  /** Base delay in ms for the first retry backoff (default 400). */
+  baseDelayMs?: number;
+  /** Cap for any single retry wait, including an upstream Retry-After (default 5000). */
+  maxDelayMs?: number;
+}
+
+/**
  * User-configured display price for one model (USD per 1M tokens).
  * Mirrors the `Cost4` shape used by the usage cost estimator; structurally
  * compatible so config rows can be lifted directly into price overlays.
@@ -537,6 +555,15 @@ export interface OcxProviderConfig {
    * before any response bytes are relayed, so the replay is lossless.
    */
   retryOn429?: RateLimitRetryPolicy;
+  /**
+   * Opt-in transient-5xx retry policy. When present, the proxy retries the initial
+   * request with exponential backoff on transient upstream statuses (500/502/503/504/520/521/522)
+   * before surfacing the error. Pre-stream only: a transient error arrives before any
+   * response bytes are relayed, so the replay is lossless. This extends the same protection
+   * that the Google adapter already receives via fetchWithTransientRetry to any key-auth
+   * provider that opts in. Disabled by default.
+   */
+  transientRetryOn5xx?: TransientRetryPolicy;
   /**
    * Model ids whose OpenAI-compatible chat endpoint accepts `reasoning_split: true` and returns
    * thinking separately in `reasoning_content` / `reasoning_details` instead of visible content.

--- a/tests/transient-retry-policy.test.ts
+++ b/tests/transient-retry-policy.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { transientRetryPolicyFor } from "../src/providers/key-failover";
+import type { OcxProviderConfig } from "../src/types";
+
+describe("transientRetryPolicyFor", () => {
+  test("returns null when transientRetryOn5xx is absent", () => {
+    const provider = { adapter: "openai-chat", baseUrl: "http://x/v1" } as OcxProviderConfig;
+    expect(transientRetryPolicyFor(provider)).toBeNull();
+  });
+
+  test("returns null when explicitly disabled", () => {
+    const provider = {
+      adapter: "openai-chat",
+      baseUrl: "http://x/v1",
+      transientRetryOn5xx: { enabled: false },
+    } as OcxProviderConfig;
+    expect(transientRetryPolicyFor(provider)).toBeNull();
+  });
+
+  test("returns defaults for a bare opt-in", () => {
+    const provider = {
+      adapter: "openai-chat",
+      baseUrl: "http://x/v1",
+      transientRetryOn5xx: {},
+    } as OcxProviderConfig;
+    const policy = transientRetryPolicyFor(provider);
+    expect(policy).not.toBeNull();
+    expect(policy!.enabled).toBe(true);
+    expect(policy!.attempts).toBe(3);
+    expect(policy!.baseDelayMs).toBe(400);
+    expect(policy!.maxDelayMs).toBe(5_000);
+  });
+
+  test("returns null for oauth providers", () => {
+    const provider = {
+      adapter: "openai-chat",
+      baseUrl: "http://x/v1",
+      authMode: "oauth",
+      transientRetryOn5xx: {},
+    } as OcxProviderConfig;
+    expect(transientRetryPolicyFor(provider)).toBeNull();
+  });
+
+  test("returns null for forward providers", () => {
+    const provider = {
+      adapter: "openai-chat",
+      baseUrl: "http://x/v1",
+      authMode: "forward",
+      transientRetryOn5xx: {},
+    } as OcxProviderConfig;
+    expect(transientRetryPolicyFor(provider)).toBeNull();
+  });
+
+  test("honours custom attempts and delays", () => {
+    const provider = {
+      adapter: "openai-chat",
+      baseUrl: "http://x/v1",
+      transientRetryOn5xx: { attempts: 5, baseDelayMs: 200, maxDelayMs: 10_000 },
+    } as OcxProviderConfig;
+    const policy = transientRetryPolicyFor(provider);
+    expect(policy).not.toBeNull();
+    expect(policy!.attempts).toBe(5);
+    expect(policy!.baseDelayMs).toBe(200);
+    expect(policy!.maxDelayMs).toBe(10_000);
+  });
+});
+

--- a/tests/transient-retry-policy.test.ts
+++ b/tests/transient-retry-policy.test.ts
@@ -1,67 +1,203 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { transientRetryPolicyFor } from "../src/providers/key-failover";
-import type { OcxProviderConfig } from "../src/types";
+import { handleResponses } from "../src/server/responses";
+import { transientRetryOn5xxPolicyConfigError } from "../src/config";
+import type { OcxConfig, OcxProviderConfig } from "../src/types";
 
 describe("transientRetryPolicyFor", () => {
-  test("returns null when transientRetryOn5xx is absent", () => {
-    const provider = { adapter: "openai-chat", baseUrl: "http://x/v1" } as OcxProviderConfig;
-    expect(transientRetryPolicyFor(provider)).toBeNull();
+  test("null when absent or explicitly disabled", () => {
+    expect(transientRetryPolicyFor({} as OcxProviderConfig)).toBeNull();
+    expect(transientRetryPolicyFor({ transientRetryOn5xx: { enabled: false } } as OcxProviderConfig)).toBeNull();
   });
 
-  test("returns null when explicitly disabled", () => {
-    const provider = {
-      adapter: "openai-chat",
-      baseUrl: "http://x/v1",
-      transientRetryOn5xx: { enabled: false },
-    } as OcxProviderConfig;
-    expect(transientRetryPolicyFor(provider)).toBeNull();
-  });
-
-  test("returns defaults for a bare opt-in", () => {
-    const provider = {
-      adapter: "openai-chat",
-      baseUrl: "http://x/v1",
-      transientRetryOn5xx: {},
-    } as OcxProviderConfig;
-    const policy = transientRetryPolicyFor(provider);
-    expect(policy).not.toBeNull();
-    expect(policy!.enabled).toBe(true);
-    expect(policy!.attempts).toBe(3);
-    expect(policy!.baseDelayMs).toBe(400);
-    expect(policy!.maxDelayMs).toBe(5_000);
-  });
-
-  test("returns null for oauth providers", () => {
-    const provider = {
-      adapter: "openai-chat",
-      baseUrl: "http://x/v1",
+  test("null for OAuth, forward, local, and unknown auth modes (fail closed)", () => {
+    expect(transientRetryPolicyFor({
       authMode: "oauth",
       transientRetryOn5xx: {},
-    } as OcxProviderConfig;
-    expect(transientRetryPolicyFor(provider)).toBeNull();
-  });
-
-  test("returns null for forward providers", () => {
-    const provider = {
-      adapter: "openai-chat",
-      baseUrl: "http://x/v1",
+    } as OcxProviderConfig)).toBeNull();
+    expect(transientRetryPolicyFor({
       authMode: "forward",
       transientRetryOn5xx: {},
-    } as OcxProviderConfig;
-    expect(transientRetryPolicyFor(provider)).toBeNull();
+    } as OcxProviderConfig)).toBeNull();
+    expect(transientRetryPolicyFor({
+      authMode: "local",
+      transientRetryOn5xx: {},
+    } as OcxProviderConfig)).toBeNull();
+    expect(transientRetryPolicyFor({
+      authMode: "custom-unknown",
+      transientRetryOn5xx: {},
+    } as OcxProviderConfig)).toBeNull();
+    expect(transientRetryPolicyFor({
+      authMode: "key",
+      transientRetryOn5xx: {},
+    } as OcxProviderConfig)).not.toBeNull();
   });
 
-  test("honours custom attempts and delays", () => {
-    const provider = {
-      adapter: "openai-chat",
-      baseUrl: "http://x/v1",
-      transientRetryOn5xx: { attempts: 5, baseDelayMs: 200, maxDelayMs: 10_000 },
-    } as OcxProviderConfig;
-    const policy = transientRetryPolicyFor(provider);
-    expect(policy).not.toBeNull();
-    expect(policy!.attempts).toBe(5);
-    expect(policy!.baseDelayMs).toBe(200);
-    expect(policy!.maxDelayMs).toBe(10_000);
+  test("applies defaults when the object is present", () => {
+    expect(transientRetryPolicyFor({ transientRetryOn5xx: {} } as OcxProviderConfig)).toEqual({
+      enabled: true,
+      attempts: 3,
+    });
+  });
+
+  test("honors explicit attempts", () => {
+    expect(transientRetryPolicyFor({
+      transientRetryOn5xx: { attempts: 5 },
+    } as OcxProviderConfig)).toEqual({
+      enabled: true,
+      attempts: 5,
+    });
+  });
+});
+
+describe("transientRetryOn5xxPolicyConfigError", () => {
+  test("accepts undefined and valid policies", () => {
+    expect(transientRetryOn5xxPolicyConfigError(undefined)).toBeNull();
+    expect(transientRetryOn5xxPolicyConfigError({})).toBeNull();
+    expect(transientRetryOn5xxPolicyConfigError({ enabled: true, attempts: 3 })).toBeNull();
+  });
+
+  test("rejects invalid field values", () => {
+    expect(transientRetryOn5xxPolicyConfigError({ enabled: "yes" })).toContain("enabled");
+    expect(transientRetryOn5xxPolicyConfigError({ attempts: 0 })).toContain("attempts");
+    expect(transientRetryOn5xxPolicyConfigError({ attempts: 99 })).toContain("attempts");
+  });
+
+  test("rejects unknown fields without echoing secret-shaped names", () => {
+    const err = transientRetryOn5xxPolicyConfigError({ intervalMs: 1000 });
+    expect(err).toContain("unrecognized");
+    expect(err).toContain("intervalMs");
+  });
+});
+
+describe("transient-5xx fetch path", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function makeConfig(transientRetryOn5xx?: unknown): OcxConfig {
+    return {
+      port: 0,
+      defaultProvider: "corp",
+      providers: {
+        corp: {
+          adapter: "openai-chat",
+          baseUrl: "https://gateway.corp.example",
+          authMode: "key",
+          apiKey: "key-alpha-000111222333",
+          ...(transientRetryOn5xx !== undefined ? { transientRetryOn5xx } : {}),
+        },
+      },
+    } as OcxConfig;
+  }
+
+  function postResponses(config: OcxConfig): Promise<Response> {
+    return handleResponses(new Request("http://localhost/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "corp/some-model", input: "hello", stream: false }),
+    }), config, { model: "corp/some-model", provider: "corp" });
+  }
+
+  function okPayload(): Response {
+    return new Response(JSON.stringify({
+      id: "chatcmpl-mock",
+      object: "chat.completion",
+      created: 1,
+      model: "some-model",
+      choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }), { status: 200, headers: { "content-type": "application/json" } });
+  }
+
+  test("503 then success: retries transparently and returns 200", async () => {
+    let sends = 0;
+    globalThis.fetch = (async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.startsWith("https://gateway.corp.example/")) {
+        sends += 1;
+        if (sends < 3) {
+          return new Response(JSON.stringify({ error: { message: "server_is_overloaded" } }),
+            { status: 503, headers: { "content-type": "application/json" } });
+        }
+        return okPayload();
+      }
+      return originalFetch(input, init);
+    }) as typeof fetch;
+
+    const response = await postResponses(makeConfig({ attempts: 3 }));
+    expect(response.status).toBe(200);
+    expect(sends).toBe(3);
+  });
+
+  test("retries exhausted: final 503 is surfaced to the client", async () => {
+    let sends = 0;
+    globalThis.fetch = (async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.startsWith("https://gateway.corp.example/")) {
+        sends += 1;
+        return new Response(JSON.stringify({ error: { message: "server_is_overloaded" } }),
+          { status: 503, headers: { "content-type": "application/json" } });
+      }
+      return originalFetch(input, init);
+    }) as typeof fetch;
+
+    const response = await postResponses(makeConfig({ attempts: 2 }));
+    expect(response.status).toBe(503);
+    expect(sends).toBe(2);
+  });
+
+  test("no opt-in: 503 is surfaced immediately with a single send", async () => {
+    let sends = 0;
+    globalThis.fetch = (async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.startsWith("https://gateway.corp.example/")) {
+        sends += 1;
+        return new Response(JSON.stringify({ error: { message: "server_is_overloaded" } }),
+          { status: 503, headers: { "content-type": "application/json" } });
+      }
+      return originalFetch(input, init);
+    }) as typeof fetch;
+
+    const response = await postResponses(makeConfig());
+    expect(response.status).toBe(503);
+    expect(sends).toBe(1);
+  });
+
+  test("explicitly disabled: 503 is surfaced immediately", async () => {
+    let sends = 0;
+    globalThis.fetch = (async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.startsWith("https://gateway.corp.example/")) {
+        sends += 1;
+        return new Response(JSON.stringify({ error: { message: "server_is_overloaded" } }),
+          { status: 503, headers: { "content-type": "application/json" } });
+      }
+      return originalFetch(input, init);
+    }) as typeof fetch;
+
+    const response = await postResponses(makeConfig({ enabled: false }));
+    expect(response.status).toBe(503);
+    expect(sends).toBe(1);
+  });
+
+  test("400 is never retried even with the policy enabled", async () => {
+    let sends = 0;
+    globalThis.fetch = (async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.startsWith("https://gateway.corp.example/")) {
+        sends += 1;
+        return new Response(JSON.stringify({ error: { message: "bad request" } }),
+          { status: 400, headers: { "content-type": "application/json" } });
+      }
+      return originalFetch(input, init);
+    }) as typeof fetch;
+
+    const response = await postResponses(makeConfig({ attempts: 3 }));
+    expect(response.status).toBe(400);
+    expect(sends).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary

Add `transientRetryOn5xx` provider config field that allows any key-auth provider to opt into `fetchWithTransientRetry` (500/502/503/504/520/521/522) with exponential backoff. Previously only the Google adapter had this protection via a hardcoded scope guard (#1851).

**Motivation:** Custom providers behind shared corporate gateways often return 503 `server_is_overloaded` under load instead of 429. Without transient-5xx retry, these transient errors kill the Codex turn immediately instead of surviving a burst.

**Scope (narrowed per review on #2643/#2655):** first version exposes only `enabled` and `attempts`. Delays stay on the shared safe constants in `lib/upstream-retry.ts` (400 ms base, 5 s cap, `Retry-After` honored). No `baseDelayMs`/`maxDelayMs` user config — the earlier draft declared them but never wired them into `TransientRetryOptions`, which would have been dead config.

## Changes

- `src/types/provider.ts`: `TransientRetryPolicy` (`enabled`, `attempts`) + `OcxProviderConfig.transientRetryOn5xx`
- `src/providers/key-failover.ts`: `transientRetryPolicyFor()` resolver (fail-closed for non-key auth modes), mirroring `rateLimitRetryPolicyFor()`
- `src/config.ts`: strict zod schema on the provider schema, a load-time sanitizer mirroring `sanitizeRetryOn429ForLoad` (invalid fields dropped with warnings; an invalid master switch drops the whole policy so a malformed disable stays disabled), and `transientRetryOn5xxPolicyConfigError` for the management write boundary
- `src/server/responses/core.ts`: policy-driven retry selection replaces the hardcoded `adapter === "google"` check on both the initial send and the continuation send (Google exception preserved)
- `src/server/chat-native.ts`: same policy-driven selection on the `/v1/chat/completions` send path
- `tests/transient-retry-policy.test.ts`: 12 tests — resolver defaults/fail-closed, write-boundary validation, and fetch-path coverage through `handleResponses` (503-then-success retries to 200, exhaustion surfaces 503, no-opt-in and `enabled:false` short-circuit with one send, 400 never retried)

## Verification

- `bun run typecheck` — pass
- `bun run test tests/transient-retry-policy.test.ts` — 12 pass, 0 fail
- `bun run test` (full suite) — all pass except `tests/codex-shim.test.ts` "Unix install rejects delayed detached redispatch after the launcher closes its lease fd", which also fails on a clean `dev` checkout (pre-existing, unrelated to this change)
- `bun run privacy:scan` — pass

## Checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.

Closes #2643

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional transient 5xx retry support for key-authenticated providers.
  * Configurable retry attempts use exponential backoff and honor `Retry-After` headers.
  * Retries apply before streaming begins for eligible transient upstream errors.

* **Bug Fixes**
  * Invalid retry settings are safely rejected or sanitized with redacted warnings.
  * Non-retryable errors and unsupported authentication modes continue without retries.

* **Tests**
  * Added coverage for defaults, disabled policies, validation, successful retries, exhausted retries, and non-retryable responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->