### PR TITLE
devlog: backlog triage - 18 stale PRs and 21 open issues (260826)

### DIFF
--- a/devlog/_plan/260826_backlog_triage/000_snapshot.md
+++ b/devlog/_plan/260826_backlog_triage/000_snapshot.md
@@ -1,0 +1,44 @@
+# 000 — backlog triage: audit basis
+
+## What this unit is
+
+A factual record of the OpenCodex backlog as of 2026-08-26, so the next maintainer session
+starts from evidence instead of re-auditing 39 items.
+
+Two read-only audits produced it, both against `dev` at `0a0a8821b`:
+
+- **Stale pull requests** — 18 open PRs, oldest first, checked for supersession, CI state,
+  distance behind `dev`, and whether the feature landed some other way.
+- **Open issues** — 21 issues checked against the actual code for quick-win feasibility.
+
+Method: for each item, read the real body via `gh`, then verify the claim against the tree.
+Nothing here is inferred from a title.
+
+## The rule this unit follows
+
+**Every verdict carries a commit SHA or a file:line pointer.** A triage document whose claims
+cannot be rechecked is worse than none — it ages into confident misinformation, and the next
+reader cannot tell which parts went stale.
+
+Where an audit and the tree disagreed, the tree won and the disagreement is recorded.
+
+## What was acted on immediately
+
+Six items were terminal and were closed in the same loop (wp6):
+
+| Item | Disposition |
+|---|---|
+| #2442 | already implemented — `openai-responses.ts:1587` |
+| #2423 | already implemented — `empty-completion-guard.ts:309` |
+| #2060 | declined with reason — 429 failover is the intended default |
+| PR #1769 | superseded by `74e8ce557` |
+| PR #2215 | superseded by `7fdb2cb8e` |
+
+Three more shipped as implementations in the same loop: #2406 (wp3), #1215 (wp4), #1060 (wp5).
+
+## Structure
+
+- `010_stale_prs.md` — the 18-row PR table with per-item evidence.
+- `020_issue_quick_wins.md` — the 21-row issue table with per-item file:line evidence.
+- `030_recommendations.md` — what to do next, and in what order.
+

--- a/devlog/_plan/260826_backlog_triage/010_stale_prs.md
+++ b/devlog/_plan/260826_backlog_triage/010_stale_prs.md
@@ -1,0 +1,54 @@
+# 010 — stale pull requests: 18 audited
+
+"Behind" is GitHub compare's count of `dev` commits absent from the PR head, measured
+2026-08-26 against `0a0a8821b`. Ages are completed days.
+
+| PR | Author | Age | Draft | CI | Behind | Scope | Verdict |
+|---|---|---:|:---:|---|---:|---|---|
+| #1557 | LeoWang331 | 13d | yes | 5 pass / 3 fail | 1855 | 2545+/69−, 28 files; catalog endpoint, server auth | NEEDS-AUTHOR |
+| #1645 | waw4303 | 12d | yes | 13 pass | 419 | 1425+/151−, 68 files; vision runtime, GUI | NEEDS-AUTHOR |
+| #1756 | takltc | 10d | no | 14 pass | 380 | 850+/116−, 17 files; Grok injection | NEEDS-AUTHOR |
+| #1769 | dbc-hbin | 10d | yes | 9 pass / 2 fail | 411 | 963+/36−, 19 files; OAuth + GUI | **SUPERSEDED — closed** |
+| #1794 | riique | 10d | no | 10 pass | 71 | 1916+/7−, 50 files; recovery + OpenRouter GUI | REVIVABLE-LARGE |
+| #1829 | luvs01 | 9d | no | 10 pass | **0** | 2878+/2−, 4 files; reset-credit ledger | REVIVABLE-LARGE |
+| #2033 | louis-tepe | 7d | yes | 8 pass | 869 | **14+/0−**, 2 files; sidecar enabled field | **REVIVABLE-SMALL** |
+| #2050 | x3M3x | 7d | no | 14 pass | 44 | 404+/18−, 15 files; combo strategies | REVIVABLE-LARGE |
+| #2083 | zhou-zhichao | 7d | no | 19 pass / 6 cancelled | 239 | 1003+/65−, 24 files; xAI image relay | NEEDS-AUTHOR |
+| #2113 | cb8010d6 | 6d | no | 8 pass | 71 | 2228+/110−, 65 files; encrypted V2 trust | NEEDS-AUTHOR |
+| #2122 | chilung-cgu | 6d | yes | 5 pass | 54 | 730+/29−, 15 files; catalog retention | REVIVABLE-LARGE |
+| #2123 | chilung-cgu | 6d | yes | 3 pass / 1 fail | 54 | 755+/40−, 9 files; Antigravity quota | NEEDS-AUTHOR |
+| #2213 | louis-tepe | 5d | yes | 11 pass | 535 | 494+/101−, 18 files; Grok tool projection | NEEDS-AUTHOR |
+| #2215 | parkjs101 | 5d | yes | 9 pass | 537 | 126+/41−, 8 docs | **SUPERSEDED — closed** |
+| #2230 | ppvia | 5d | yes | 10 pass / 6 fail | 535 | 1637+/61−, 33 files; Gemini OAuth | NEEDS-AUTHOR |
+| #2244 | ZSN12 | 5d | yes | 6 pass / 4 fail | 511 | 913+/0−, 9 files; WorkBuddy OAuth | NEEDS-AUTHOR |
+| #2299 | abhisheksharma2411 | 4d | no | 9 pass / 3 cancelled | 11 | 910+/3−, 10 files; display labels | REVIVABLE-LARGE |
+| #2326 | JasonSujaya | 4d | yes | 4 pass / 1 fail | 363 | 398+/7−, 14 files; GUI shortcuts | NEEDS-AUTHOR |
+
+## Findings that are not obvious from the table
+
+**#1829 is 0 commits behind `dev` with CI green.** The only stalled PR that is not stale. If
+any large PR is worth a maintainer pass, it is this one — the usual rebase tax is zero.
+
+**#2033 is 14 lines and a real gap.** Both GET and PUT sidecar responses return model, backend,
+stream and X-search fields but no `enabled` field
+([config-routes.ts:571](../../../src/server/management/config-routes.ts) and :809). Worth a
+maintainer revival. Caveat: 869 commits behind, so it is a fresh reimplementation rather than a
+rebase.
+
+**#2083 does not merely conflict — it disagrees.** The xAI image bridge landed via
+`de35caa4d`, but current code returns no image credential for OAuth configurations
+([images/plan.ts:32](../../../src/images/plan.ts)) and the public guide states an API key is
+required. The PR proposes the opposite contract. That is an owner decision about the image-auth
+boundary, not a rebase, and asking the author to "just rebase" would waste their time.
+
+**#1794 is a partial duplicate, not superseded.** Core recovery landed via `9bea7707b` and
+configurable OpenRouter routing via `3c6f3caa4`, but the PR's GUI exposure files have no
+equivalent on `dev`. Closing it as superseded would overstate the equivalence.
+
+**#2123 is NOT superseded** by existing Antigravity quota work: per-account eligibility still
+accepts Anthropic only ([providers/quota.ts:1447](../../../src/providers/quota.ts)).
+
+**No PR is abandoned.** All 16 distinct author accounts still resolve on GitHub. Conflict volume
+alone was not treated as abandonment — that would be closing other people's work for the
+convenience of the backlog.
+

--- a/devlog/_plan/260826_backlog_triage/020_issue_quick_wins.md
+++ b/devlog/_plan/260826_backlog_triage/020_issue_quick_wins.md
@@ -1,0 +1,53 @@
+# 020 — open issues: 21 audited for quick-win feasibility
+
+A quick win means: small diff (roughly under 150 lines), no new subsystem, no schema migration,
+clear correct behaviour, testable with a focused `bun test`. Estimates include tests and any
+directly required UI or docs.
+
+## Shipped in this loop
+
+| Issue | Verdict | Where |
+|---|---|---|
+| #2406 CommandCode image capabilities | QUICK-WIN | wp3 — static modality maps in `registry.ts` |
+| #1215 OpenCodex-scoped noProxy | QUICK-WIN | wp4 — the existing NO_PROXY merge in `config.ts:3116` |
+| #1060 billing-period end | QUICK-WIN (grew) | wp5 — the GUI drops the whole `creditsUsd` object, not just one field |
+
+## Closed with evidence
+
+| Issue | Verdict | Evidence |
+|---|---|---|
+| #2442 | ALREADY-DONE | `openai-responses.ts:1587`, `muse-spark-web-search-compat.test.ts:38` |
+| #2423 | ALREADY-DONE | `empty-completion-guard.ts:309`, `empty-completion-guard.test.ts:326` |
+| #2060 | DECLINED WITH REASON | `key-failover.ts:82` — 429 failover is the intended default; eager round-robin is a pool policy |
+
+## Medium (140-300 lines)
+
+| Issue | Why it is not a quick win |
+|---|---|
+| #2539 Anthropic weekly quota routing | selection scores only `fiveHour` today; adding a weekly policy crosses routing, management API, GUI persistence |
+| #2279 suppress synthetic max | catalog synthesis adds `max` and `ultra` together; config has an exact override, not an independent suppression policy |
+| #2201 display names for discovered models | `displayName` exists only on custom models; needs schema, precedence, API, GUI, catalog propagation |
+| #1820 cost and cache metrics in Usage | **most attractive of this tier** — the backend already computes both ([summary.ts:67](../../../src/usage/summary.ts)); only the GUI row types and tables omit the columns |
+| #1690 config-level retainModels | retention comes from hardcoded/Vertex/combo inputs, not provider config; the retained-but-404 diagnostic adds runtime behaviour |
+| #1533 explain V2 compatibility state | API exposes mode and preferred model independently; no joined state for the GUI to explain |
+
+## Not quick (250-700 lines)
+
+#2511 request byte budget · #2455 queue latency and granted tier · #2399 delete ZCode snapshots ·
+#2275 durable reset-credit identity · #2221 native-main token refresh · #2046 K12 denial and
+cross-account threads · #1711 grey out zero-credit models · #1525 Windows proxy auto-detect ·
+#1213 additive Claude Desktop catalog
+
+Two of these deserve a note:
+
+- **#2221** touches authentication-critical paths: native-main injects a read-only `auth.json`
+  token without refresh ([auth-context.ts:550](../../../src/codex/auth-context.ts)), while only
+  pool credentials pass through `getValidCodexToken`. Fixing ownership and replay is not a
+  small change, and it is the one on this list most likely to bite users.
+- **#2046** is half done: nested `detail.code` K12 detection already exists
+  ([quota-rejection.ts:81](../../../src/codex/quota-rejection.ts)). What remains conflicts with
+  current credential-affinity preservation and needs upstream thread-contract evidence.
+
+No issue was classified INVALID. Several are partially implemented; their remaining acceptance
+criteria are too broad to call quick wins.
+

--- a/devlog/_plan/260826_backlog_triage/030_recommendations.md
+++ b/devlog/_plan/260826_backlog_triage/030_recommendations.md
@@ -1,0 +1,43 @@
+# 030 — recommendations
+
+Ordered by value per unit of risk, not by size.
+
+## 1. #1829 — a maintainer pass on the only non-stale large PR
+
+0 commits behind `dev`, CI green, 4 files. Every other large PR on the list carries a rebase
+tax measured in hundreds of commits; this one carries none. If it is going to be reviewed at
+all, reviewing it now costs the least it will ever cost.
+
+## 2. #2033 — reimplement the 14-line sidecar gap
+
+The gap is real: GET and PUT sidecar responses omit an `enabled` field
+([config-routes.ts:571](../../../src/server/management/config-routes.ts), :809). At 869 commits
+behind, revival means reimplementation rather than rebase — which is fine at this size, and the
+author should be credited in the commit message.
+
+## 3. #1820 — the best of the MEDIUM tier
+
+The backend already computes aggregate cache tokens and per-model estimated cost
+([summary.ts:67](../../../src/usage/summary.ts)). The work is GUI row types and table columns,
+which is a bounded, verifiable slice.
+
+## 4. #2083 — ask the owner, not the author
+
+The image-auth contract disagreement is a product decision. Asking for a rebase before deciding
+whether OAuth-authenticated image relay is wanted would waste the contributor's time on a PR
+that may be declined on principle.
+
+## 5. Author check-ins, not closures
+
+#1557, #1645, #1756, #2213, #2230, #2244, #2326 need explicit continuation from their authors.
+All accounts still resolve. Closing them for being behind would be closing other people's work
+for the backlog's convenience — the honest move is to ask, and to say plainly that a rebase of
+that size is a rewrite.
+
+## What NOT to do
+
+**Do not batch-close by age.** The audit found exactly two safe supersessions (#1769, #2215) out
+of 18, and both were proven by naming the commit that landed first. Age correlated with nothing
+useful: #1829 is nine days old and perfectly current; #2033 is seven days old and 869 commits
+behind.
+


### PR DESCRIPTION
## Summary

A factual record of the OpenCodex backlog as of 2026-08-26, so the next maintainer session starts from evidence instead of re-auditing 39 items. Docs-only.

Two read-only audits produced it against `dev`: 18 open PRs checked for supersession, CI state, distance behind `dev`, and whether the feature landed some other way; 21 open issues checked against the actual code for quick-win feasibility.

**Every verdict carries a commit SHA or a file:line pointer.** A triage document whose claims cannot be rechecked is worse than none — it ages into confident misinformation and the next reader cannot tell which parts went stale.

## Findings worth surfacing

**#1829 is 0 commits behind `dev` with CI green** — the only stalled PR that is not stale. Every other large PR carries a rebase tax in the hundreds of commits. If any large PR is worth reviewing, reviewing that one now costs the least it ever will.

**#2033 is 14 lines and a real gap.** GET and PUT sidecar responses omit an `enabled` field ([config-routes.ts:571](../blob/dev/src/server/management/config-routes.ts) and :809). At 869 commits behind it is a reimplementation rather than a rebase — fine at this size, with credit to the author.

**#2083 does not merely conflict, it disagrees.** Current code returns no image credential for OAuth configurations ([images/plan.ts:32](../blob/dev/src/images/plan.ts)) and the public guide states an API key is required, while the PR proposes the opposite contract. That is an owner decision about the image-auth boundary; asking for a rebase first would waste the contributor's time on a PR that may be declined on principle.

**#1794 is a partial duplicate, not superseded.** Core recovery landed via `9bea7707b` and OpenRouter routing via `3c6f3caa4`, but its GUI exposure files have no equivalent on `dev`. Closing it as superseded would overstate the equivalence.

**No PR is abandoned.** All 16 distinct author accounts still resolve on GitHub. Conflict volume alone was not treated as abandonment — that would be closing other people's work for the backlog's convenience.

The recommendations doc says plainly what *not* to do: batch-closing by age would have been wrong here. Exactly two of eighteen were safely superseded (#1769 via `74e8ce557`, #2215 via `7fdb2cb8e`), both proven by naming the commit that landed first, and age correlated with nothing useful.

## Related closures

Six items were terminal and closed with code-citing comments in the same loop: #2442, #2423, #2060, PR #1769, PR #2215. Three more shipped as implementations: #2406, #1215, #1060.

## Verification

Docs-only; nothing in the build, typecheck, or test path reads from `devlog/`. Verdicts were derived from `gh` reads plus tree verification, not from titles.

No GUI change, so no screenshot applies.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a backlog-triage snapshot covering 18 stale pull requests and 21 open issues.
  * Documented evidence-based verdicts, completed items, shipped implementations, and recommended follow-up actions.
  * Identified priority reviews, reimplementation candidates, product decisions, and author check-ins.
  * Recorded safely superseded items while avoiding broad, age-based closures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->