### PR TITLE
fix(registry): retain verified CommandCode image capabilities

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -495,6 +495,28 @@ const DEEPSEEK_THINKING_MODELS = ["deepseek-v4-pro", "deepseek-v4-flash"];
  * at which point this id retires the same way deepseek-chat/reasoner did.
  */
 const DEEPSEEK_VISION_PREVIEW_MODEL = "deepseek-v4-flash-vision-exp";
+/**
+ * CommandCode routes verified to accept image input end-to-end (#2406).
+ *
+ * Verified-negative and therefore deliberately ABSENT: deepseek/deepseek-v4-flash,
+ * deepseek/deepseek-v4-pro, zai-org/GLM-5.2, zai-org/GLM-5.3, xai/grok-4.6. Those
+ * routes accept the request and drop the image, which is worse than declining it — the
+ * model answers about an image it never saw. Do not add an id here on family resemblance;
+ * capability intersection trusts this map.
+ */
+const COMMAND_CODE_IMAGE_MODELS = [
+  "stealth/ox-alpha",
+  "openai/ox-alpha",
+  `deepseek/${DEEPSEEK_VISION_PREVIEW_MODEL}`,
+  "gpt-5.6-luna",
+  "gpt-5.6-sol",
+  "MiniMaxAI/MiniMax-M3",
+  "moonshotai/Kimi-K3",
+  "meta/muse-spark-1.2",
+  "meta/muse-spark-1.2-contributor",
+] as const;
+const COMMAND_CODE_MODEL_INPUT_MODALITIES: Record<string, ["text", "image"]> =
+  Object.fromEntries(COMMAND_CODE_IMAGE_MODELS.map(id => [id, ["text", "image"]]));
 const OPENCODE_FREE_DEEPSEEK_MODELS = ["deepseek-v4-flash-free"];
 /*
  * OpenCode Zen's free slug for the OpenRouter stealth model "Ox Alpha"
@@ -1181,10 +1203,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
       "stealth/ox-alpha": OX_ALPHA_CONTEXT_WINDOW,
       [`deepseek/${DEEPSEEK_VISION_PREVIEW_MODEL}`]: 1_048_576,
     },
-    modelInputModalities: {
-      "stealth/ox-alpha": ["text", "image"],
-      [`deepseek/${DEEPSEEK_VISION_PREVIEW_MODEL}`]: ["text", "image"],
-    },
+    modelInputModalities: COMMAND_CODE_MODEL_INPUT_MODALITIES,
     defaultMaxOutputTokens: 64_000,
     // The proprietary generate wire has no verified per-request serialization flag.
     parallelToolCalls: false,
@@ -1922,10 +1941,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
       "stealth/ox-alpha": OX_ALPHA_CONTEXT_WINDOW,
       [`deepseek/${DEEPSEEK_VISION_PREVIEW_MODEL}`]: 1_048_576,
     },
-    modelInputModalities: {
-      "stealth/ox-alpha": ["text", "image"],
-      [`deepseek/${DEEPSEEK_VISION_PREVIEW_MODEL}`]: ["text", "image"],
-    },
+    modelInputModalities: COMMAND_CODE_MODEL_INPUT_MODALITIES,
     modelDiscovery: {
       path: "models",
       maxResponseBytes: 256 * 1024,

--- a/tests/command-code-provider.test.ts
+++ b/tests/command-code-provider.test.ts
@@ -83,6 +83,39 @@ describe("Command Code provider", () => {
     });
   });
 
+  test("OAuth and API-key presets share only verified image capabilities", () => {
+    const oauth = PROVIDER_REGISTRY.find(row => row.id === "command-code");
+    const apiKey = PROVIDER_REGISTRY.find(row => row.id === "commandcode");
+    const verifiedImageModels = [
+      "stealth/ox-alpha",
+      "openai/ox-alpha",
+      "deepseek/deepseek-v4-flash-vision-exp",
+      "gpt-5.6-luna",
+      "gpt-5.6-sol",
+      "MiniMaxAI/MiniMax-M3",
+      "moonshotai/Kimi-K3",
+      "meta/muse-spark-1.2",
+      "meta/muse-spark-1.2-contributor",
+    ];
+    const verifiedTextOnlyModels = [
+      "deepseek/deepseek-v4-flash",
+      "deepseek/deepseek-v4-pro",
+      "zai-org/GLM-5.2",
+      "zai-org/GLM-5.3",
+      "xai/grok-4.6",
+    ];
+
+    expect(apiKey?.modelInputModalities).toEqual(oauth?.modelInputModalities);
+    for (const preset of [oauth, apiKey]) {
+      for (const id of verifiedImageModels) {
+        expect(preset?.modelInputModalities?.[id]).toEqual(["text", "image"]);
+      }
+      for (const id of verifiedTextOnlyModels) {
+        expect(preset?.modelInputModalities?.[id]).toBeUndefined();
+      }
+    }
+  });
+
   test("validates callback shape and state without exposing the key", () => {
     const secret = "super-secret-callback-key";
     const parsedCallback = parseCommandCodeCallback({ apiKey: secret, state: "state", userId: "u", userName: "name", keyName: "cli" }, "state");


### PR DESCRIPTION
## Summary

- Share one CommandCode image-modality table between the OAuth and API-key presets so preset drift cannot disable image input in generated catalogs.
- Add only the routes verified by end-to-end image probes; keep the five full upstream IDs that silently drop images absent.
- Closes #2406.

## Verification

- `bun test tests/command-code-provider.test.ts` — 31 pass, 0 fail.
- Falsification: removed `openai/ox-alpha` from the shared table — 30 pass, 1 fail; restored it — 31 pass, 0 fail.
- `bun x tsc --noEmit` — exit 0.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. No docs change is needed for corrected built-in capability metadata.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. This change only updates static provider capability facts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image input support for verified multimodal Command Code models.
  * Ensured OAuth and API-key configurations provide consistent image-capability metadata.
  * Prevented text-only models from incorrectly advertising image support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->