### PR TITLE
fix(gui): show CommandCode billing period end

### DIFF
--- a/gui/src/codex-quota-utils.ts
+++ b/gui/src/codex-quota-utils.ts
@@ -9,6 +9,14 @@ export interface AccountQuota {
   shortResetAt?: number;
   monthlyResetAt?: number;
   customWindows?: { label: string; percent: number; resetAt?: number }[];
+  creditsUsd?: {
+    used: number;
+    limit: number;
+    remaining: number;
+    percent: number;
+    expiresAt?: number;
+    unlimited?: boolean;
+  };
   resetCredits?: number;
   updatedAt: number;
 }
@@ -31,6 +39,7 @@ export function normalizeQuotaForPlan(quota: AccountQuota | null, plan: string |
   return {
     ...(normalized.monthlyPercent !== undefined ? { monthlyPercent: normalized.monthlyPercent } : {}),
     ...(normalized.monthlyResetAt !== undefined ? { monthlyResetAt: normalized.monthlyResetAt } : {}),
+    ...(normalized.creditsUsd !== undefined ? { creditsUsd: normalized.creditsUsd } : {}),
     ...(normalized.resetCredits !== undefined ? { resetCredits: normalized.resetCredits } : {}),
     updatedAt: normalized.updatedAt,
   };

--- a/gui/src/components/provider-workspace/ProviderCapacityQuota.tsx
+++ b/gui/src/components/provider-workspace/ProviderCapacityQuota.tsx
@@ -4,7 +4,7 @@
  * rows, current-account breakdown). Shared by the aggregate dashboard and the
  * single-provider Overview so both surfaces present the same capacity semantics.
  */
-import { useT, useI18n } from "../../i18n/shared";
+import { useT, useI18n, type Locale } from "../../i18n/shared";
 import {
   accountQuotaFromReport,
   capacityAggregationFromReport,
@@ -14,11 +14,30 @@ import {
 import { type QuotaWindowKey } from "../QuotaBars";
 import QuotaBars from "../QuotaBars";
 
+function bcp47(locale: Locale): string {
+  switch (locale) {
+    case "en": return "en-GB";
+    case "de": return "de-DE";
+    case "fr": return "fr-FR";
+    case "ko": return "ko-KR";
+    case "zh": return "zh-CN";
+    case "zh-TW": return "zh-TW";
+    case "ru": return "ru-RU";
+    case "ja": return "ja-JP";
+    case "tr": return "tr-TR";
+    default: {
+      const _exhaustive: never = locale;
+      return _exhaustive;
+    }
+  }
+}
+
 export function ProviderCapacityQuota({ report, pending }: { report: ProviderQuotaReportView; pending: boolean }) {
   const t = useT();
   const { locale } = useI18n();
   const aggregation = capacityAggregationFromReport(report);
   const primaryQuota = accountQuotaFromReport(report);
+  const credits = primaryQuota?.creditsUsd;
   const showsAggregate = aggregation?.presentation === "aggregate";
   const incompleteWindowKeys = new Set<QuotaWindowKey>();
   const incompleteCustomWindowLabels = new Set<string>();
@@ -41,6 +60,14 @@ export function ProviderCapacityQuota({ report, pending }: { report: ProviderQuo
     dateStyle: "medium",
     timeStyle: "short",
   }).format(new Date(value > 10_000_000_000 ? value : value * 1000));
+  const localeTag = bcp47(locale);
+  const formatCredits = (value: number) => new Intl.NumberFormat(localeTag, {
+    style: "currency",
+    currency: "USD",
+  }).format(value);
+  const formatPeriodEnd = (value: number) => new Intl.DateTimeFormat(localeTag, {
+    dateStyle: "medium",
+  }).format(new Date(value > 10_000_000_000 ? value : value * 1000));
 
   return (
     <>
@@ -56,8 +83,19 @@ export function ProviderCapacityQuota({ report, pending }: { report: ProviderQuo
           incompleteCustomWindowLabels={showsAggregate ? incompleteCustomWindowLabels : undefined}
         />
       )}
-      {aggregation && (
+      {(credits || aggregation) && (
         <div className="pws-capacity-details">
+          {credits && (
+            <div className="pws-capacity-recovery">
+              <span>{t("quota.creditsBalance")}</span>
+              <strong>{formatCredits(credits.remaining)}</strong>
+            </div>
+          )}
+          {credits?.expiresAt !== undefined && (
+            <div className="pws-capacity-recovery">
+              <span>{t("quota.creditsPeriodEnds", { date: formatPeriodEnd(credits.expiresAt) })}</span>
+            </div>
+          )}
           {recoveryRows.flatMap(({ key, label, window }) => (
             window.nextRecoveryAt !== undefined && window.nextRecoveryPercent !== undefined
               ? [<div className="pws-capacity-recovery" key={key}>
@@ -66,7 +104,7 @@ export function ProviderCapacityQuota({ report, pending }: { report: ProviderQuo
                 </div>]
               : []
           ))}
-          {showsAggregate && aggregation.currentAccount?.quota && (
+          {showsAggregate && aggregation && aggregation.currentAccount?.quota && (
             <div className="pws-capacity-current">
               <span className="pws-capacity-label">
                 {t("pws.capacity.currentAccount")}
@@ -75,7 +113,7 @@ export function ProviderCapacityQuota({ report, pending }: { report: ProviderQuo
               <QuotaBars quota={aggregation.currentAccount.quota} threshold={80} t={t} layout="stacked" />
             </div>
           )}
-          {aggregation.incomplete && aggregation.excludedAccounts > 0 && (
+          {aggregation && aggregation.incomplete && aggregation.excludedAccounts > 0 && (
             <div className="pws-capacity-incomplete">
               {t("pws.capacity.incomplete", {
                 excluded: aggregation.excludedAccounts,
@@ -83,7 +121,7 @@ export function ProviderCapacityQuota({ report, pending }: { report: ProviderQuo
               })}
             </div>
           )}
-          {aggregation.partialWindowAccounts > 0 && (
+          {aggregation && aggregation.partialWindowAccounts > 0 && (
             <div className="pws-capacity-incomplete">
               {t("pws.capacity.partial", { count: aggregation.partialWindowAccounts })}
             </div>

--- a/gui/src/i18n/de.ts
+++ b/gui/src/i18n/de.ts
@@ -1571,6 +1571,8 @@ export const de: Record<TKey, string> = {
   "quota.cursorFirstParty": "Erstanbieter-Modelle",
   "quota.cursorApiUsage": "API-Nutzung",
   "quota.totalSubscriptionCredits": "Gesamtes Abo-Guthaben",
+  "quota.creditsBalance": "Guthabenstand",
+  "quota.creditsPeriodEnds": "Abrechnungszeitraum endet am {date}",
   "quota.usedPercent": "{pct} % genutzt",
   "quota.limitReached": "Limit erreicht",
   "quota.resetsToday": "Zurücksetzung heute um {time}",

--- a/gui/src/i18n/en.ts
+++ b/gui/src/i18n/en.ts
@@ -1064,6 +1064,8 @@ export const en = {
   "quota.cursorFirstParty": "First-party models",
   "quota.cursorApiUsage": "API usage",
   "quota.totalSubscriptionCredits": "Total subscription credits",
+  "quota.creditsBalance": "Credits balance",
+  "quota.creditsPeriodEnds": "Billing period ends {date}",
   "quota.usedPercent": "{pct}% used",
   "quota.limitReached": "Limit reached",
   "quota.resetsToday": "Resets today at {time}",

--- a/gui/src/i18n/fr.ts
+++ b/gui/src/i18n/fr.ts
@@ -1037,6 +1037,8 @@ export const fr: Record<TKey, string> = {
   "quota.cursorFirstParty": "Modèles propriétaires",
   "quota.cursorApiUsage": "Utilisation de l’API",
   "quota.totalSubscriptionCredits": "Total des crédits d’abonnement",
+  "quota.creditsBalance": "Solde de crédits",
+  "quota.creditsPeriodEnds": "La période de facturation se termine le {date}",
   "quota.usedPercent": "{pct} % utilisés",
   "quota.limitReached": "Limite atteinte",
   "quota.resetsToday": "Réinitialisation aujourd’hui à {time}",

--- a/gui/src/i18n/ja.ts
+++ b/gui/src/i18n/ja.ts
@@ -1007,6 +1007,8 @@ export const ja: Record<TKey, string> = {
   "quota.cursorFirstParty": "ファーストパーティモデル",
   "quota.cursorApiUsage": "API 使用量",
   "quota.totalSubscriptionCredits": "サブスクリプションクレジット合計",
+  "quota.creditsBalance": "クレジット残高",
+  "quota.creditsPeriodEnds": "請求期間終了日: {date}",
   "quota.usedPercent": "{pct}% 使用",
   "quota.limitReached": "上限に達しました",
   "quota.resetsToday": "今日 {time} にリセット",

--- a/gui/src/i18n/ko.ts
+++ b/gui/src/i18n/ko.ts
@@ -1598,6 +1598,8 @@ export const ko: Record<TKey, string> = {
   "quota.cursorFirstParty": "자사 모델",
   "quota.cursorApiUsage": "API 사용량",
   "quota.totalSubscriptionCredits": "전체 구독 크레딧",
+  "quota.creditsBalance": "크레딧 잔액",
+  "quota.creditsPeriodEnds": "청구 기간 종료: {date}",
   "quota.usedPercent": "{pct}% 사용",
   "quota.limitReached": "한도 도달",
   "quota.resetsToday": "오늘 {time} 초기화",

--- a/gui/src/i18n/ru.ts
+++ b/gui/src/i18n/ru.ts
@@ -1048,6 +1048,8 @@ export const ru: Record<TKey, string> = {
   "quota.cursorFirstParty": "Собственные модели",
   "quota.cursorApiUsage": "Использование API",
   "quota.totalSubscriptionCredits": "Всего кредитов подписки",
+  "quota.creditsBalance": "Остаток кредитов",
+  "quota.creditsPeriodEnds": "Расчётный период заканчивается {date}",
   "quota.usedPercent": "Использовано {pct}%",
   "quota.limitReached": "Лимит исчерпан",
   "quota.resetsToday": "Сброс сегодня в {time}",

--- a/gui/src/i18n/tr.ts
+++ b/gui/src/i18n/tr.ts
@@ -1055,6 +1055,8 @@ export const tr: Record<TKey, string> = {
   "quota.cursorFirstParty": "Birinci taraf modeller",
   "quota.cursorApiUsage": "API kullanımı",
   "quota.totalSubscriptionCredits": "Toplam abonelik kredileri",
+  "quota.creditsBalance": "Kredi bakiyesi",
+  "quota.creditsPeriodEnds": "Faturalandırma dönemi {date} tarihinde sona erer",
   "quota.usedPercent": "%{pct} kullanıldı",
   "quota.limitReached": "Limite ulaşıldı",
   "quota.resetsToday": "Bugün {time} saatinde sıfırlanır",

--- a/gui/src/i18n/zh-TW.ts
+++ b/gui/src/i18n/zh-TW.ts
@@ -850,6 +850,8 @@ export const zhTW: Record<TKey, string> = {
   "quota.cursorFirstParty": "官方模型",
   "quota.cursorApiUsage": "API 用量",
   "quota.totalSubscriptionCredits": "訂閱總額度",
+  "quota.creditsBalance": "額度餘額",
+  "quota.creditsPeriodEnds": "帳單週期結束於 {date}",
   "quota.usedPercent": "已用 {pct}%",
   "quota.limitReached": "已達上限",
   "quota.resetsToday": "今天 {time} 重設",

--- a/gui/src/i18n/zh.ts
+++ b/gui/src/i18n/zh.ts
@@ -1591,6 +1591,8 @@ export const zh: Record<TKey, string> = {
   "quota.cursorFirstParty": "官方模型",
   "quota.cursorApiUsage": "API 用量",
   "quota.totalSubscriptionCredits": "订阅总额度",
+  "quota.creditsBalance": "额度余额",
+  "quota.creditsPeriodEnds": "账单周期结束于 {date}",
   "quota.usedPercent": "已用 {pct}%",
   "quota.limitReached": "已达上限",
   "quota.resetsToday": "今天 {time} 重置",

--- a/gui/src/provider-workspace/report.ts
+++ b/gui/src/provider-workspace/report.ts
@@ -54,6 +54,27 @@ function quotaFromUnknown(quota: unknown, fallbackUpdatedAt?: number): AccountQu
         }];
       })
     : [];
+  const creditsRaw = q.creditsUsd && typeof q.creditsUsd === "object" && !Array.isArray(q.creditsUsd)
+    ? q.creditsUsd as Record<string, unknown>
+    : null;
+  const creditsUsed = finite(creditsRaw?.used);
+  const creditsLimit = finite(creditsRaw?.limit);
+  const creditsRemaining = finite(creditsRaw?.remaining);
+  const creditsPercent = finite(creditsRaw?.percent);
+  const creditsExpiresAt = finite(creditsRaw?.expiresAt);
+  const creditsUsd = creditsUsed !== undefined
+    && creditsLimit !== undefined
+    && creditsRemaining !== undefined
+    && creditsPercent !== undefined
+    ? {
+        used: creditsUsed,
+        limit: creditsLimit,
+        remaining: creditsRemaining,
+        percent: creditsPercent,
+        ...(creditsExpiresAt !== undefined ? { expiresAt: creditsExpiresAt } : {}),
+        ...(typeof creditsRaw?.unlimited === "boolean" ? { unlimited: creditsRaw.unlimited } : {}),
+      }
+    : undefined;
   const out: AccountQuota = {
     ...(finite(q.fiveHourPercent) !== undefined ? { fiveHourPercent: q.fiveHourPercent as number } : {}),
     ...(finite(q.fiveHourResetAt) !== undefined ? { fiveHourResetAt: q.fiveHourResetAt as number } : {}),
@@ -62,12 +83,14 @@ function quotaFromUnknown(quota: unknown, fallbackUpdatedAt?: number): AccountQu
     ...(finite(q.monthlyPercent) !== undefined ? { monthlyPercent: q.monthlyPercent as number } : {}),
     ...(finite(q.monthlyResetAt) !== undefined ? { monthlyResetAt: q.monthlyResetAt as number } : {}),
     ...(windows.length > 0 ? { customWindows: windows } : {}),
+    ...(creditsUsd ? { creditsUsd } : {}),
     updatedAt: finite(q.updatedAt) ?? fallbackUpdatedAt ?? Date.now(),
   };
   return out.fiveHourPercent !== undefined
     || out.weeklyPercent !== undefined
     || out.monthlyPercent !== undefined
     || (out.customWindows?.length ?? 0) > 0
+    || out.creditsUsd !== undefined
     ? out
     : null;
 }

--- a/gui/tests/provider-capacity-credits.test.tsx
+++ b/gui/tests/provider-capacity-credits.test.tsx
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ProviderCapacityQuota } from "../src/components/provider-workspace/ProviderCapacityQuota";
+import { LanguageProvider } from "../src/i18n/provider";
+
+const PERIOD_END = Date.UTC(2026, 7, 26);
+
+function renderCredits(expiresAt?: number): string {
+  return renderToStaticMarkup(
+    <LanguageProvider>
+      <ProviderCapacityQuota
+        pending={false}
+        report={{
+          updatedAt: 123,
+          quota: {
+            creditsUsd: {
+              used: 12.5,
+              limit: 50,
+              remaining: 37.5,
+              percent: 25,
+              ...(expiresAt === undefined ? {} : { expiresAt }),
+            },
+          },
+        }}
+      />
+    </LanguageProvider>,
+  );
+}
+
+test("credits without an expiry render the balance and no billing-period line", () => {
+  const markup = renderCredits();
+  expect(markup).toContain("Credits balance");
+  expect(markup).toContain("US$37.50");
+  expect(markup).not.toContain("Billing period ends");
+});
+
+test("credits with an expiry render the localized billing-period end date", () => {
+  const markup = renderCredits(PERIOD_END);
+  expect(markup).toContain("Credits balance");
+  expect(markup).toContain("Billing period ends 26 Aug 2026");
+});

--- a/gui/tests/provider-capacity.test.ts
+++ b/gui/tests/provider-capacity.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { capacityAggregationFromReport } from "../src/provider-workspace/report";
+import { accountQuotaFromReport, capacityAggregationFromReport } from "../src/provider-workspace/report";
 
 function selectorBlock(css: string, selector: string): string {
   const start = css.indexOf(`${selector} {`);
@@ -11,6 +11,56 @@ function selectorBlock(css: string, selector: string): string {
 
 test("legacy provider quota reports remain valid without aggregation metadata", () => {
   expect(capacityAggregationFromReport({ quota: { weeklyPercent: 42 } })).toBeNull();
+});
+
+test("provider quota reports preserve the complete USD credits contract", () => {
+  expect(accountQuotaFromReport({
+    updatedAt: 123,
+    quota: {
+      creditsUsd: {
+        used: 12.5,
+        limit: 50,
+        remaining: 37.5,
+        percent: 25,
+        expiresAt: 1_800_000_000,
+        unlimited: false,
+      },
+    },
+  })).toEqual({
+    creditsUsd: {
+      used: 12.5,
+      limit: 50,
+      remaining: 37.5,
+      percent: 25,
+      expiresAt: 1_800_000_000,
+      unlimited: false,
+    },
+    updatedAt: 123,
+  });
+});
+
+test("provider quota reports reject malformed required credits and drop malformed optional members", () => {
+  expect(accountQuotaFromReport({
+    updatedAt: 123,
+    quota: { creditsUsd: { used: Number.NaN, limit: 50, remaining: 37.5, percent: 25 } },
+  })).toBeNull();
+
+  expect(accountQuotaFromReport({
+    updatedAt: 123,
+    quota: {
+      creditsUsd: {
+        used: 12.5,
+        limit: 50,
+        remaining: 37.5,
+        percent: 25,
+        expiresAt: Number.NaN,
+        unlimited: "yes",
+      },
+    },
+  })).toEqual({
+    creditsUsd: { used: 12.5, limit: 50, remaining: 37.5, percent: 25 },
+    updatedAt: 123,
+  });
 });
 
 test("capacity metadata preserves estimate, raw current quota, recovery percent, and incomplete coverage", () => {


### PR DESCRIPTION
## Summary

- Preserve the complete CommandCode `creditsUsd` contract through the provider-workspace projection. Previously credits-only reports were dropped because `AccountQuota` had no credits shape and the adapter accepted only usage windows.
- Render the localized USD credit balance and the optional billing-period end date. Absence of `expiresAt` remains a normal state and renders no placeholder or period line.
- Add the two labels to all nine locales and lock projection and rendered presence/absence behavior with focused tests.

Closes #1060

## Verification

- `cd gui && bun test tests/provider-capacity.test.ts tests/provider-capacity-credits.test.tsx` — 10 pass, 0 fail.
- Falsification: temporarily disconnected `creditsUsd` from the account projection — 6 pass, 4 fail; restored implementation — 10 pass, 0 fail.
- `cd gui && bun test` — 998 pass, 0 fail, 8,794 assertions.
- `bun x tsc --noEmit` — exit 0.
- `cd gui && bun run lint:i18n` — exit 0; existing `Models.tsx` exhaustive-deps warning remains.
- `cd gui && bun run build` — exit 0.
- Browser QA at `http://localhost:5201/#providers` — balance and billing-period rows rendered; browser console produced no output.

![Providers workspace showing the CommandCode credits balance and billing period end](https://raw.githubusercontent.com/lidge-jun/opencodex/codex/pr-assets/pr-wp5/billing-period-ends.png)

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. No documentation change is needed for presenting an existing quota field.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. This change only narrows and presents the existing sanitized quota response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added visibility into remaining account credits, including balances, usage limits, percentages, and billing-period expiration dates.
  - Credit-only quota information is now recognized and displayed alongside existing capacity details.
- **Localization**
  - Added translated credit balance and billing-period labels across supported languages.
  - Currency and dates now follow the selected locale.
- **Bug Fixes**
  - Improved handling of incomplete or invalid quota information to prevent misleading displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->