### PR TITLE
feat(config): add OpenCodex-scoped noProxy

### DIFF
--- a/docs-site/src/content/docs/reference/configuration/server.md
+++ b/docs-site/src/content/docs/reference/configuration/server.md
@@ -13,6 +13,7 @@ runs helper features around provider requests.
 | `port` | `number` | `10100` | Proxy listen port. |
 | `hostname?` | `string` | `"127.0.0.1"` | Bind address. Non-loopback binds require `OPENCODEX_API_AUTH_TOKEN`. |
 | `proxy?` | `string` | — | Outbound HTTP(S) proxy URL or `${ENV_VAR}`. Applied to `HTTP_PROXY` / `HTTPS_PROXY` only when those variables are unset; loopback remains in `NO_PROXY`. |
+| `noProxy?` | `string \| string[]` | — | Hosts that bypass `proxy`, merged with inherited `NO_PROXY` and loopback entries. A string may use comma-separated `NO_PROXY` syntax or `${ENV_VAR}`. |
 | `emptyCompletionRetry?` | `boolean` | `false` | Opt in to one identical Responses retry when a turn has no text or tool call, including a stream that ends before a terminal event. The retry may be billable. `OCX_EMPTY_COMPLETION_RETRY=0` disables it without changing config; combo and routed-compaction turns remain excluded. |
 | `stallTimeoutSec?` | `number` | `300` | Seconds without upstream data before `response.incomplete`. Minimum 1. |
 | `oauthOpenBrowser?` | `boolean` | `true` | Whether a login may open a browser on the machine running the proxy. Absent and `true` both open, so an existing install is unchanged; only an explicit `false` declines. Decline when you need the authorization link in a different browser profile, or when the dashboard is not on the proxy's machine — the login still starts and the URL is still returned and displayed. `POST /api/oauth/login` and `POST /api/codex-auth/login` accept a per-request `openBrowser` boolean that overrides this, and the dashboard exposes the same choice beside the login button. Device-code flows never open a browser either way. |
@@ -30,6 +31,17 @@ runs helper features around provider requests.
 | `webSearchSidecar?` | `OcxWebSearchSidecarConfig` | on when usable | Web-search sidecar options. |
 | `visionSidecar?` | `OcxVisionSidecarConfig` | on when usable | Image-description sidecar options. |
 | `images?` | `OcxImagesConfig` | automatic OpenAI selection | Standalone Images relay options for Codex `image_gen`. |
+
+`noProxy` accepts either a comma-separated string or an array. Both forms add entries without
+replacing an inherited `NO_PROXY`:
+
+```jsonc
+{ "proxy": "http://proxy.corp:8080", "noProxy": "internal.example,10.0.0.0/8" }
+```
+
+```jsonc
+{ "proxy": "http://proxy.corp:8080", "noProxy": ["internal.example", "10.0.0.0/8"] }
+```
 
 If an older development build changed resume-history metadata before backup support existed, run
 `ocx recover-history --legacy-openai --yes` to force native-provider recovery.

--- a/src/config.ts
+++ b/src/config.ts
@@ -3124,10 +3124,17 @@ export function applyProxyEnv(config: OcxConfig): void {
   const existing = process.env.NO_PROXY ?? process.env.no_proxy ?? "";
   const entries = existing.split(",").map(s => s.trim()).filter(Boolean);
   const seen = new Set(entries.map(e => e.toLowerCase()));
-  for (const host of ["localhost", "127.0.0.1", "::1", "[::1]"]) {
-    if (!seen.has(host)) {
+  // Configured entries first, then loopback: loopback is unconditional, so appending it last
+  // keeps it present even when the operator lists a loopback host themselves.
+  const raw = config.noProxy;
+  const configured = (Array.isArray(raw) ? raw : (resolveEnvValue(raw) ?? "").split(","))
+    .map(entry => entry.trim())
+    .filter(Boolean);
+  for (const host of [...configured, "localhost", "127.0.0.1", "::1", "[::1]"]) {
+    const key = host.toLowerCase();
+    if (!seen.has(key)) {
       entries.push(host);
-      seen.add(host);
+      seen.add(key);
     }
   }
   process.env.NO_PROXY = entries.join(",");

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -505,6 +505,13 @@ export interface OcxConfig {
    */
   proxy?: string;
   /**
+   * Hosts that bypass `proxy` for OpenCodex's own outbound provider calls, merged into
+   * NO_PROXY at startup. Accepts a comma-separated string (NO_PROXY syntax) or an array.
+   * Loopback is always excluded regardless of this setting, and an inherited NO_PROXY is
+   * preserved — this ADDS entries, it never replaces the environment.
+   */
+  noProxy?: string | string[];
+  /**
    * Upstream stall timeout (seconds). After this many seconds of no upstream data, emits
    * response.incomplete. Default 300. Min 1.
    */

--- a/tests/proxy-env.test.ts
+++ b/tests/proxy-env.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { applyProxyEnv } from "../src/config";
 import type { OcxConfig } from "../src/types";
 
-const PROXY_ENV_KEYS = ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy", "OCX_TEST_PROXY_REF"] as const;
+const PROXY_ENV_KEYS = ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy", "OCX_TEST_PROXY_REF", "OCX_TEST_NO_PROXY_REF"] as const;
 let saved: Record<string, string | undefined>;
 
 beforeEach(() => {
@@ -20,16 +20,27 @@ afterEach(() => {
   }
 });
 
-function configWithProxy(proxy?: string): OcxConfig {
-  return { proxy, providers: {} } as unknown as OcxConfig;
+function configWithProxy(proxy?: string, noProxy?: string | string[]): OcxConfig {
+  return { proxy, noProxy, providers: {} } as unknown as OcxConfig;
 }
 
 describe("applyProxyEnv", () => {
   test("no-op when config.proxy is unset", () => {
-    applyProxyEnv(configWithProxy(undefined));
+    process.env.NO_PROXY = "operator-owned.example";
+    applyProxyEnv(configWithProxy(undefined, "internal.example"));
     expect(process.env.HTTP_PROXY).toBeUndefined();
     expect(process.env.HTTPS_PROXY).toBeUndefined();
-    expect(process.env.NO_PROXY).toBeUndefined();
+    expect(process.env.NO_PROXY).toBe("operator-owned.example");
+  });
+
+  test("merges configured comma-separated noProxy entries", () => {
+    applyProxyEnv(configWithProxy("http://proxy.corp:8080", "internal.example,10.0.0.0/8"));
+    expect(process.env.NO_PROXY).toBe("internal.example,10.0.0.0/8,localhost,127.0.0.1,::1,[::1]");
+  });
+
+  test("merges configured noProxy array entries like the string form", () => {
+    applyProxyEnv(configWithProxy("http://proxy.corp:8080", ["internal.example", "10.0.0.0/8"]));
+    expect(process.env.NO_PROXY).toBe("internal.example,10.0.0.0/8,localhost,127.0.0.1,::1,[::1]");
   });
 
   test("mirrors config.proxy into HTTP(S)_PROXY and excludes loopback (IPv4 + IPv6)", () => {
@@ -56,6 +67,17 @@ describe("applyProxyEnv", () => {
     process.env.NO_PROXY = "LOCALHOST,[::1]";
     applyProxyEnv(configWithProxy("http://proxy.corp:8080"));
     expect(process.env.NO_PROXY).toBe("LOCALHOST,[::1],127.0.0.1,::1");
+  });
+
+  test("dedup is case-insensitive for configured entries while preserving their casing", () => {
+    applyProxyEnv(configWithProxy("http://proxy.corp:8080", "LOCALHOST"));
+    expect(process.env.NO_PROXY).toBe("LOCALHOST,127.0.0.1,::1,[::1]");
+  });
+
+  test("resolves ${VAR}-style noProxy references", () => {
+    process.env.OCX_TEST_NO_PROXY_REF = "internal.example,10.0.0.0/8";
+    applyProxyEnv(configWithProxy("http://proxy.corp:8080", "${OCX_TEST_NO_PROXY_REF}"));
+    expect(process.env.NO_PROXY).toBe("internal.example,10.0.0.0/8,localhost,127.0.0.1,::1,[::1]");
   });
 
   test("resolves ${VAR}-style env references like other config secrets", () => {


### PR DESCRIPTION
## Summary

- Add an optional noProxy string-or-array config field so operators can bypass an outbound proxy for OpenCodex provider calls without changing machine-owned environment configuration.
- Merge configured entries with inherited NO_PROXY and unconditional loopback entries, using case-insensitive lookup keys while preserving operator casing. This prevents configured LOCALHOST from producing a duplicate localhost entry.
- Preserve the early return when proxy is unset and document both accepted forms.

Closes #1215

## Verification

- bun test tests/proxy-env.test.ts — 10 pass, 0 fail
- bun x tsc --noEmit — exit 0
- bun run test — 14,921 pass, 12 skip, 0 fail in the parallel suite; all serial shield suites exited 0
- cd docs-site && bun install --frozen-lockfile && bun run build — 393 pages built, exit 0
- Falsification: temporarily removed lowercase lookup-key normalization; focused suite produced 9 pass, 1 fail with duplicate LOCALHOST,localhost. Restored implementation returned 10 pass, 0 fail.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional `noProxy` server setting for hosts that should bypass the configured proxy.
  - Supports comma-separated `NO_PROXY` syntax, environment variable references, and arrays of hostnames.
  - Preserves inherited bypass settings and automatically excludes loopback addresses.

- **Documentation**
  - Added configuration guidance and examples for both supported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->