### PR TITLE
ci: delete branches left behind by closed pull requests

### DIFF
--- a/.github/scripts/closed-pr-branch-cleanup.cjs
+++ b/.github/scripts/closed-pr-branch-cleanup.cjs
@@ -1,0 +1,162 @@
+"use strict";
+
+/**
+ * Deletion planning for branches left behind by closed-without-merge pull
+ * requests.
+ *
+ * GitHub's repository-level `delete_branch_on_merge` only fires on merge, so a
+ * PR that is closed unmerged leaves its head branch in the repository forever.
+ * This module decides which of those branches may be deleted; the workflow
+ * performs the deletion.
+ *
+ * Kept as a pure module so the safety rules can be unit-tested without Actions
+ * and without a live repository.
+ */
+
+/** Branches that may never be deleted regardless of pull-request state. */
+const PROTECTED_BRANCHES = Object.freeze(["main", "dev", "preview", "gh-pages"]);
+
+/** Default grace period before a closed PR's head branch becomes eligible. */
+const DEFAULT_GRACE_DAYS = 14;
+
+function normalizeBranchName(value) {
+  return String(value || "").trim();
+}
+
+function isProtectedBranch(name) {
+  return PROTECTED_BRANCHES.includes(normalizeBranchName(name));
+}
+
+function toTimestamp(value) {
+  if (!value) return null;
+  const ms = Date.parse(String(value));
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * Reasons a candidate branch is kept. Exported so the workflow can log a
+ * stable, greppable verdict per branch instead of a free-form sentence.
+ */
+const KEEP_REASONS = Object.freeze({
+  PROTECTED: "protected-branch",
+  MERGED: "pull-request-merged",
+  OPEN: "open-pull-request",
+  BASE_OF_OPEN: "base-of-open-pull-request",
+  CROSS_REPOSITORY: "cross-repository-head",
+  MISSING_CLOSED_AT: "missing-closed-at",
+  WITHIN_GRACE: "within-grace-period",
+});
+
+/**
+ * Plan deletions for head branches of closed-unmerged pull requests.
+ *
+ * Every rule here is a safety rule, and each one exists because the opposite
+ * behavior destroys work that is still referenced:
+ *
+ * - A branch is a candidate only when *every* pull request that ever used it as
+ *   a head is closed and unmerged. One open or merged PR on the same branch
+ *   keeps it, because reopening a PR whose head branch is gone cannot restore
+ *   the commits.
+ * - A branch that is the base of an open pull request is kept. Deleting it
+ *   closes the stacked child PR that targets it.
+ * - Cross-repository (fork) heads are never touched: they live in the
+ *   contributor's repository and this token has no business there.
+ * - A grace period after `closed_at` leaves room to reopen a PR that was
+ *   closed by mistake.
+ *
+ * @param {object} input
+ * @param {Array<object>} input.pullRequests Pull requests with
+ *   `headRefName`, `baseRefName`, `state`, `merged`, `closedAt`, and
+ *   `isCrossRepository`.
+ * @param {Array<string>} input.branches Branch names that currently exist.
+ * @param {number} [input.now] Current time in milliseconds.
+ * @param {number} [input.graceDays] Days to wait after `closedAt`.
+ * @returns {{ deletions: Array<{branch: string, pullRequests: number[]}>,
+ *   keeps: Array<{branch: string, reason: string}> }}
+ */
+function planClosedPrBranchDeletions({
+  pullRequests = [],
+  branches = [],
+  now = Date.now(),
+  graceDays = DEFAULT_GRACE_DAYS,
+}) {
+  const existing = new Set(branches.map(normalizeBranchName).filter(Boolean));
+  const graceMs = Math.max(0, Number(graceDays) || 0) * 24 * 60 * 60 * 1000;
+
+  /** @type {Map<string, object[]>} */
+  const byHead = new Map();
+  const openBases = new Set();
+
+  for (const pr of pullRequests) {
+    const head = normalizeBranchName(pr && pr.headRefName);
+    if (head) {
+      const list = byHead.get(head) || [];
+      list.push(pr);
+      byHead.set(head, list);
+    }
+    const isOpen = String(pr && pr.state).toUpperCase() === "OPEN";
+    if (isOpen) {
+      const base = normalizeBranchName(pr && pr.baseRefName);
+      if (base) openBases.add(base);
+    }
+  }
+
+  const deletions = [];
+  const keeps = [];
+
+  for (const branch of [...existing].sort()) {
+    if (isProtectedBranch(branch)) {
+      keeps.push({ branch, reason: KEEP_REASONS.PROTECTED });
+      continue;
+    }
+
+    const related = byHead.get(branch) || [];
+    if (related.length === 0) continue; // No PR ever used it; out of scope.
+
+    if (related.some((pr) => pr && pr.isCrossRepository === true)) {
+      keeps.push({ branch, reason: KEEP_REASONS.CROSS_REPOSITORY });
+      continue;
+    }
+    if (related.some((pr) => pr && pr.merged === true)) {
+      keeps.push({ branch, reason: KEEP_REASONS.MERGED });
+      continue;
+    }
+    if (related.some((pr) => String(pr && pr.state).toUpperCase() === "OPEN")) {
+      keeps.push({ branch, reason: KEEP_REASONS.OPEN });
+      continue;
+    }
+    if (openBases.has(branch)) {
+      keeps.push({ branch, reason: KEEP_REASONS.BASE_OF_OPEN });
+      continue;
+    }
+
+    const closedTimestamps = related.map((pr) => toTimestamp(pr && pr.closedAt));
+    if (closedTimestamps.some((ts) => ts === null)) {
+      keeps.push({ branch, reason: KEEP_REASONS.MISSING_CLOSED_AT });
+      continue;
+    }
+    const newestClosedAt = Math.max(...closedTimestamps);
+    if (now - newestClosedAt < graceMs) {
+      keeps.push({ branch, reason: KEEP_REASONS.WITHIN_GRACE });
+      continue;
+    }
+
+    deletions.push({
+      branch,
+      pullRequests: related
+        .map((pr) => Number(pr && pr.number))
+        .filter((n) => Number.isFinite(n))
+        .sort((a, b) => a - b),
+    });
+  }
+
+  return { deletions, keeps };
+}
+
+module.exports = {
+  DEFAULT_GRACE_DAYS,
+  KEEP_REASONS,
+  PROTECTED_BRANCHES,
+  isProtectedBranch,
+  planClosedPrBranchDeletions,
+};

--- a/.github/scripts/closed-pr-branch-cleanup.test.cjs
+++ b/.github/scripts/closed-pr-branch-cleanup.test.cjs
@@ -1,0 +1,165 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  DEFAULT_GRACE_DAYS,
+  KEEP_REASONS,
+  isProtectedBranch,
+  planClosedPrBranchDeletions,
+} = require("./closed-pr-branch-cleanup.cjs");
+
+const NOW = Date.parse("2026-08-26T00:00:00Z");
+const DAY = 24 * 60 * 60 * 1000;
+const longAgo = new Date(NOW - 60 * DAY).toISOString();
+
+function closedPr(overrides) {
+  return {
+    number: 1,
+    state: "CLOSED",
+    merged: false,
+    isCrossRepository: false,
+    headRefName: "codex/example",
+    baseRefName: "dev",
+    closedAt: longAgo,
+    ...overrides,
+  };
+}
+
+function keepReason(result, branch) {
+  const hit = result.keeps.find((entry) => entry.branch === branch);
+  return hit ? hit.reason : null;
+}
+
+function deletedBranches(result) {
+  return result.deletions.map((entry) => entry.branch);
+}
+
+describe("isProtectedBranch", () => {
+  it("protects the integration, release, and prerelease lines", () => {
+    for (const name of ["main", "dev", "preview", "gh-pages"]) {
+      assert.equal(isProtectedBranch(name), true, name);
+    }
+    assert.equal(isProtectedBranch("codex/dev"), false);
+  });
+});
+
+describe("planClosedPrBranchDeletions", () => {
+  it("deletes a branch whose only pull request closed unmerged past the grace period", () => {
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [closedPr({ number: 42, headRefName: "codex/stale" })],
+      branches: ["codex/stale", "dev"],
+      now: NOW,
+    });
+    assert.deepEqual(deletedBranches(result), ["codex/stale"]);
+    assert.deepEqual(result.deletions[0].pullRequests, [42]);
+  });
+
+  it("keeps a branch that any merged pull request used as a head", () => {
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [
+        closedPr({ number: 10, headRefName: "codex/reused" }),
+        closedPr({ number: 11, headRefName: "codex/reused", state: "MERGED", merged: true }),
+      ],
+      branches: ["codex/reused"],
+      now: NOW,
+    });
+    assert.deepEqual(deletedBranches(result), []);
+    assert.equal(keepReason(result, "codex/reused"), KEEP_REASONS.MERGED);
+  });
+
+  it("keeps a branch that still has an open pull request", () => {
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [
+        closedPr({ number: 20, headRefName: "codex/active" }),
+        closedPr({ number: 21, headRefName: "codex/active", state: "OPEN", closedAt: null }),
+      ],
+      branches: ["codex/active"],
+      now: NOW,
+    });
+    assert.deepEqual(deletedBranches(result), []);
+    assert.equal(keepReason(result, "codex/active"), KEEP_REASONS.OPEN);
+  });
+
+  it("keeps a closed stack parent while an open child still targets it", () => {
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [
+        closedPr({ number: 30, headRefName: "codex/stack-1" }),
+        closedPr({
+          number: 31,
+          state: "OPEN",
+          closedAt: null,
+          headRefName: "codex/stack-2",
+          baseRefName: "codex/stack-1",
+        }),
+      ],
+      branches: ["codex/stack-1", "codex/stack-2"],
+      now: NOW,
+    });
+    assert.deepEqual(deletedBranches(result), []);
+    assert.equal(keepReason(result, "codex/stack-1"), KEEP_REASONS.BASE_OF_OPEN);
+  });
+
+  it("never touches a fork head branch", () => {
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [
+        closedPr({ number: 40, headRefName: "patch-1", isCrossRepository: true }),
+      ],
+      branches: ["patch-1"],
+      now: NOW,
+    });
+    assert.deepEqual(deletedBranches(result), []);
+    assert.equal(keepReason(result, "patch-1"), KEEP_REASONS.CROSS_REPOSITORY);
+  });
+
+  it("waits out the grace period so a mistaken close can be reopened", () => {
+    const recent = new Date(NOW - 3 * DAY).toISOString();
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [closedPr({ number: 50, headRefName: "codex/recent", closedAt: recent })],
+      branches: ["codex/recent"],
+      now: NOW,
+      graceDays: DEFAULT_GRACE_DAYS,
+    });
+    assert.deepEqual(deletedBranches(result), []);
+    assert.equal(keepReason(result, "codex/recent"), KEEP_REASONS.WITHIN_GRACE);
+  });
+
+  it("keeps a branch when a closed pull request has no closed_at timestamp", () => {
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [closedPr({ number: 60, headRefName: "codex/unknown", closedAt: null })],
+      branches: ["codex/unknown"],
+      now: NOW,
+    });
+    assert.deepEqual(deletedBranches(result), []);
+    assert.equal(keepReason(result, "codex/unknown"), KEEP_REASONS.MISSING_CLOSED_AT);
+  });
+
+  it("refuses to delete a protected branch even if a closed pull request used it", () => {
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [closedPr({ number: 70, headRefName: "dev" })],
+      branches: ["dev", "main", "preview"],
+      now: NOW,
+    });
+    assert.deepEqual(deletedBranches(result), []);
+    assert.equal(keepReason(result, "dev"), KEEP_REASONS.PROTECTED);
+  });
+
+  it("ignores branches that no pull request ever used", () => {
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [closedPr({ number: 80, headRefName: "codex/known" })],
+      branches: ["codex/known", "codex/never-a-pr"],
+      now: NOW,
+    });
+    assert.deepEqual(deletedBranches(result), ["codex/known"]);
+    assert.equal(keepReason(result, "codex/never-a-pr"), null);
+  });
+
+  it("only plans deletions for branches that still exist", () => {
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [closedPr({ number: 90, headRefName: "codex/already-gone" })],
+      branches: [],
+      now: NOW,
+    });
+    assert.deepEqual(deletedBranches(result), []);
+  });
+});

--- a/.github/workflows/cleanup-closed-pr-branches.yml
+++ b/.github/workflows/cleanup-closed-pr-branches.yml
@@ -1,0 +1,148 @@
+name: Clean branches from closed pull requests
+
+# GitHub's repository setting `delete_branch_on_merge` only deletes a head
+# branch when the pull request MERGES. A pull request that is closed without
+# merging leaves its head branch behind forever, which is how this repository
+# accumulated dozens of dead `codex/*` and `ingw/*` branches.
+#
+# Scheduled workflows only run from the repository DEFAULT branch (currently
+# `main`), not from `dev`. Landing this on `dev` alone does not start the
+# cleanup until the change is also promoted to that default branch.
+on:
+  schedule:
+    # Daily at 06:30 UTC (offset from the hour to reduce Action load spikes).
+    - cron: "30 6 * * *"
+  # No workflow_dispatch: a branch-selected manual run would execute that
+  # branch's workflow body with contents:write, bypassing default-branch
+  # review. Schedule-only keeps the trusted revision on the default branch.
+
+permissions: {}
+
+concurrency:
+  group: cleanup-closed-pr-branches
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Delete branches left by closed pull requests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      # contents: write is required to delete refs; pull-requests: read supplies
+      # the closed/open/merged state the deletion plan plus its keep rules read.
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Checkout trusted default-branch code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+
+      - name: Delete head branches of closed, unmerged pull requests
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          # Days to wait after a pull request is closed. A mistaken close can be
+          # reopened inside this window with its head branch still intact.
+          GRACE_DAYS: "14"
+          # Set to "true" to log the plan without deleting anything.
+          DRY_RUN: "false"
+        with:
+          script: |
+            const path = require("node:path");
+            const { planClosedPrBranchDeletions } = require(
+              path.join(process.cwd(), ".github", "scripts", "closed-pr-branch-cleanup.cjs"),
+            );
+
+            const { owner, repo } = context.repo;
+            const dryRun = String(process.env.DRY_RUN || "").toLowerCase() === "true";
+            const graceDays = Number(process.env.GRACE_DAYS || "14");
+
+            const rawPulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "all",
+              per_page: 100,
+            });
+            const pullRequests = rawPulls.map((pr) => ({
+              number: pr.number,
+              state: String(pr.state || "").toUpperCase(),
+              merged: Boolean(pr.merged_at),
+              closedAt: pr.closed_at,
+              headRefName: pr.head && pr.head.ref,
+              baseRefName: pr.base && pr.base.ref,
+              // A fork head lives in the contributor's repository. Comparing
+              // repo ids (not names) keeps a same-name fork from looking local.
+              isCrossRepository:
+                !pr.head || !pr.head.repo || pr.head.repo.id !== pr.base.repo.id,
+            }));
+
+            const rawBranches = await github.paginate(github.rest.repos.listBranches, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+            const branches = rawBranches.map((branch) => branch.name);
+            const protectedByGitHub = new Set(
+              rawBranches.filter((branch) => branch.protected).map((branch) => branch.name),
+            );
+
+            const { deletions, keeps } = planClosedPrBranchDeletions({
+              pullRequests,
+              branches,
+              now: Date.now(),
+              graceDays,
+            });
+
+            const keepCounts = new Map();
+            for (const entry of keeps) {
+              keepCounts.set(entry.reason, (keepCounts.get(entry.reason) || 0) + 1);
+            }
+            for (const [reason, count] of [...keepCounts].sort()) {
+              core.info(`kept ${count} branch(es): ${reason}`);
+            }
+
+            let deleted = 0;
+            const failures = [];
+            for (const entry of deletions) {
+              // Branch protection is authoritative over any plan this job made.
+              if (protectedByGitHub.has(entry.branch)) {
+                core.info(`skip ${entry.branch}: branch protection`);
+                continue;
+              }
+              const prs = entry.pullRequests.map((n) => `#${n}`).join(", ");
+              if (dryRun) {
+                core.info(`[dry-run] would delete ${entry.branch} (closed: ${prs})`);
+                continue;
+              }
+              try {
+                await github.rest.git.deleteRef({
+                  owner,
+                  repo,
+                  ref: `heads/${entry.branch}`,
+                });
+                deleted += 1;
+                core.info(`deleted ${entry.branch} (closed: ${prs})`);
+              } catch (err) {
+                // 422 means the ref moved or vanished between plan and delete.
+                if (err.status === 422 || err.status === 404) {
+                  core.info(`skip ${entry.branch}: already gone`);
+                  continue;
+                }
+                failures.push(`${entry.branch}: ${err.message || err}`);
+              }
+            }
+
+            core.summary
+              .addHeading("Closed-PR branch cleanup", 3)
+              .addRaw(
+                dryRun
+                  ? `Dry run: ${deletions.length} branch(es) eligible.`
+                  : `Deleted ${deleted} of ${deletions.length} eligible branch(es).`,
+              )
+              .addRaw(` Kept ${keeps.length} branch(es).`);
+            await core.summary.write();
+
+            if (failures.length > 0) {
+              core.setFailed(`Failed to delete ${failures.length} branch(es):\n${failures.join("\n")}`);
+            }


### PR DESCRIPTION
## Summary

- The repository already sets `delete_branch_on_merge`, so a **merged** pull request cleans up its own head branch. A pull request **closed without merging** does not: GitHub leaves that head branch in the repository indefinitely. That gap is how this repository accumulated dozens of dead `codex/*` and `ingw/*` branches whose pull requests were closed months ago.
- Adds a scheduled job that closes the gap, plus a pure planning module (`.github/scripts/closed-pr-branch-cleanup.cjs`) so the safety rules are testable without Actions or a live repository.

A branch is deleted only when **every** pull request that ever used it as a head is closed and unmerged. Each keep rule exists because the opposite behavior destroys work that is still referenced:

- one merged or open pull request on the same head keeps the branch, because reopening a pull request whose head branch is gone cannot restore the commits;
- a branch that is the base of an open pull request is kept, since deleting it closes the stacked child PR that targets it;
- fork heads are never touched, and repo **ids** are compared rather than names so a same-name fork cannot be mistaken for a local branch;
- a 14-day grace period after `closed_at` leaves room to reopen a mistaken close;
- GitHub branch protection is re-checked at delete time and overrides the plan.

Security-relevant workflow properties, per `.github/AGENTS.md`:

- `permissions: {}` at workflow level; the job grants only `contents: write` (required to delete refs) and `pull-requests: read`.
- Schedule-only, with **no** `workflow_dispatch`: a branch-selected manual run would execute that branch's body with `contents: write` and bypass default-branch review.
- Both third-party actions are pinned to full commit SHAs with their version comments preserved.
- Scheduled workflows run only from the default branch, so this does nothing until it is promoted to `main`.

## Verification

- `node --test .github/scripts/closed-pr-branch-cleanup.test.cjs` — 11 pass, 0 fail. Covers the merged/open/stacked-base/fork/grace-period/missing-timestamp/protected-branch keep rules and the delete case.
- `bun run typecheck` — clean.
- `bun run test` — full suite, exit 0.
- `bun test tests/ci-workflows.test.ts tests/repo-hygiene.test.ts` — 143 pass, 0 fail.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.
