### PR TITLE
fix(cursor): reject invented native-tool failure commentary

### DIFF
--- a/devlog/_plan/260826_cursor_responses_gap/150_routing_commentary_hallucination.md
+++ b/devlog/_plan/260826_cursor_responses_gap/150_routing_commentary_hallucination.md
@@ -59,3 +59,12 @@ not a useful repair: the model ignored the existing exact instruction.
   - Adversarial raw Responses batch seeded the prior assistant history with the
     false blocked/switching sentence: 10/10 HTTP 200, each returned one real
     exec custom tool call, zero leaked Read/Grep/Shell failure commentary.
+
+## Independent review closure
+
+- Reviewer found that a failure claim split as “Shell was blocked” + newline +
+  “Switching to exec_command” could flush after the first line. The sniffer now
+  holds an incomplete first-line failure claim for one additional line.
+- Reviewer found a context-free request redirection sentence could match without
+  naming a native tool. Detection now requires at least one unavailable native
+  tool name in addition to the failure claim. Both cases have direct tests.

--- a/devlog/_plan/260826_cursor_responses_gap/150_routing_commentary_hallucination.md
+++ b/devlog/_plan/260826_cursor_responses_gap/150_routing_commentary_hallucination.md
@@ -52,4 +52,10 @@ not a useful repair: the model ignored the existing exact instruction.
   retry, no leaked commentary, and the existing envelope cases.
 - Focused suite: 54 pass / 0 fail across output quarantine, tool definitions,
   repetition breaker, silent redirect, and tool continuation tests.
-- Live verification follows after ocx service repair on the gap-11 branch.
+- Live verification after ocx service repair on the gap-11 branch:
+  - Fresh codex exec session with cursor/kimi-k3-1m: first visible action was
+    the real command execution (cat /tmp/ocx-routing-live.txt), exit 0; final
+    response was LIVE_ROUTING_OK=ROUTING_LIVE_7391; no tool-selection prose.
+  - Adversarial raw Responses batch seeded the prior assistant history with the
+    false blocked/switching sentence: 10/10 HTTP 200, each returned one real
+    exec custom tool call, zero leaked Read/Grep/Shell failure commentary.

--- a/devlog/_plan/260826_cursor_responses_gap/150_routing_commentary_hallucination.md
+++ b/devlog/_plan/260826_cursor_responses_gap/150_routing_commentary_hallucination.md
@@ -1,0 +1,55 @@
+# 150 — gap-11: invented Read/Grep/Shell failures in code-mode commentary
+
+## Symptom
+
+Session 01a03cdb-cdfd-75d3-b8d3-cc3b3deb8d27, model
+cursor/kimi-k3-1m, 2026-08-26. The model repeatedly stated that native
+Read, Grep, or Shell calls were blocked and that it was switching to
+exec_command. It later concluded that a Codex harness content guard was
+intercepting file contents.
+
+## Evidence and rejected hypotheses
+
+- **H1 — Codex harness content guard. Rejected.** At 07:06:44Z the actual
+  exec tool called nested exec_command with head -c 200; the
+  CommandExecution event completed exit 0 and the output reached the model.
+  At 07:06:56Z a heading extraction command also completed and reached the
+  model. There was no substituted or interrupted tool result.
+- **H2 — native Read/Grep/Shell calls failed. Rejected.** The session NDJSON
+  contains 11 custom_tool_call rows and every one has name=exec.
+  Its item_completed inventory contains 11 CommandExecution rows and zero
+  native Read/Grep/Shell execution rows.
+- **H3 — model-generated routing commentary. Supported.** At 07:06:44.201Z
+  the model emitted “Shell path was blocked; switching to exec_command”; the
+  real exec tool call followed at 07:06:44.203Z and succeeded. The claimed
+  failure therefore preceded any corresponding tool call and could not be a
+  report of runtime state.
+
+The static code-mode system note already forbids these tool names and this
+commentary shape (tool-definitions.ts), so another prompt-only sentence is
+not a useful repair: the model ignored the existing exact instruction.
+
+## Fix
+
+- Add CursorRoutingCommentarySniffer beside the existing gap-10 envelope
+  sniffer. It is armed only for external Cursor models when the active catalog
+  exposes code-mode exec or a Codex shell bridge.
+- Quarantine the bounded first output line. Reject only a failure claim that
+  also contains either (a) an explicit redirect to a bridge/execution surface,
+  or (b) two distinct unavailable native-tool names. This avoids treating a
+  legitimate sentence such as “Shell is unavailable on this OS” as fabricated
+  routing history.
+- Before any invalid delta reaches the client, rotate to a fresh conversation
+  and retry once with a corrective active-turn note. A second rejection fails
+  closed instead of looping.
+
+## Verification
+
+- RED: adapter regression expected two attempts but observed one; the invented
+  Shell commentary leaked unchanged.
+- GREEN: tests/cursor-envelope-echo-retry.test.ts covers fragmented Korean
+  fallback commentary, multi-tool failure claims, legitimate prose, adapter
+  retry, no leaked commentary, and the existing envelope cases.
+- Focused suite: 54 pass / 0 fail across output quarantine, tool definitions,
+  repetition breaker, silent redirect, and tool continuation tests.
+- Live verification follows after ocx service repair on the gap-11 branch.

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -29,9 +29,13 @@ import { debugProviderDiagnostic } from "../lib/debug";
 import { estimateTokens } from "../lib/token-estimate";
 import { rememberCursorThreadConversation } from "./cursor/thread-continuity";
 import { runCursorTurnWithRetry } from "./cursor/transport-retry";
+import { cursorRequestHasShellAlias, cursorRequestUsesCodeMode } from "./cursor/tool-definitions";
 import {
   CURSOR_ECHO_RETRY_CONTINUATION_TEXT,
+  CURSOR_ROUTING_COMMENTARY_RETRY_TEXT,
   CursorEnvelopeEchoSniffer,
+  CursorRoutingCommentaryError,
+  CursorRoutingCommentarySniffer,
   CursorToolResultEchoError,
 } from "./cursor/envelope-echo";
 import {
@@ -228,14 +232,26 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
             isCursorExternalWireModel(activeRequest.modelId)
             && (_parsed.context.messages ?? []).some(message => message.role === "toolResult");
           const echoSniffer = armEchoSniffer ? new CursorEnvelopeEchoSniffer() : undefined;
-          let echoHeld: AdapterEvent[] = [];
-          const releaseEchoHeld = () => {
-            for (const held of echoHeld) {
+          const armRoutingCommentarySniffer =
+            isCursorExternalWireModel(activeRequest.modelId)
+            && (
+              cursorRequestUsesCodeMode(activeRequest.tools, activeRequest.toolChoice)
+              || cursorRequestHasShellAlias(activeRequest.tools)
+            );
+          const routingCommentarySniffer = armRoutingCommentarySniffer
+            ? new CursorRoutingCommentarySniffer()
+            : undefined;
+          let guardHeld: AdapterEvent[] = [];
+          const releaseGuardHeld = () => {
+            for (const held of guardHeld) {
               if (held.type !== "heartbeat") emittedOutput = true;
               emit(held);
             }
-            echoHeld = [];
+            guardHeld = [];
           };
+          const guardsSettled = () =>
+            (!echoSniffer || echoSniffer.settled)
+            && (!routingCommentarySniffer || routingCommentarySniffer.settled);
           await runCursorTurnWithRetry(
             makeTransport,
             {
@@ -268,30 +284,41 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
                },
              });
              for (const event of events) {
-                if (echoSniffer && !echoSniffer.settled) {
+                if (!guardsSettled()) {
                   if (event.type === "text_delta") {
-                    const decision = echoSniffer.feed(event.text);
-                    if (decision.kind === "echo") {
-                      echoHeld = [];
-                      throw new CursorToolResultEchoError(decision.marker);
+                    guardHeld.push(event);
+                    if (echoSniffer && !echoSniffer.settled) {
+                      const decision = echoSniffer.feed(event.text);
+                      if (decision.kind === "echo") {
+                        guardHeld = [];
+                        throw new CursorToolResultEchoError(decision.marker);
+                      }
                     }
-                    if (decision.kind === "hold") {
-                      echoHeld.push(event);
-                      continue;
+                    if (routingCommentarySniffer && !routingCommentarySniffer.settled) {
+                      const decision = routingCommentarySniffer.feed(event.text);
+                      if (decision.kind === "hallucination") {
+                        guardHeld = [];
+                        throw new CursorRoutingCommentaryError();
+                      }
                     }
-                    // flush: release everything held, then fall through to emit this event.
-                    releaseEchoHeld();
+                    if (guardsSettled()) releaseGuardHeld();
+                    continue;
                   } else if (event.type === "thinking_delta" || event.type === "heartbeat") {
-                    // Reasoning/liveness before first text never decides the echo question;
-                    // hold thinking in order, pass heartbeats through.
+                    // Reasoning before first text stays ordered; liveness still passes through.
                     if (event.type === "thinking_delta") {
-                      echoHeld.push(event);
+                      guardHeld.push(event);
                       continue;
                     }
                   } else {
-                    // A tool call, done, or error settles it: not an echo. Release and disarm.
-                    echoSniffer.finish();
-                    releaseEchoHeld();
+                    // A tool call, done, or error closes the text quarantine. Re-check the full
+                    // held first line before release so a fragmented routing claim cannot leak.
+                    echoSniffer?.finish();
+                    const routingDecision = routingCommentarySniffer?.finish();
+                    if (routingDecision?.kind === "hallucination") {
+                      guardHeld = [];
+                      throw new CursorRoutingCommentaryError();
+                    }
+                    releaseGuardHeld();
                   }
                 }
                 if (event.type !== "heartbeat") emittedOutput = true;
@@ -325,26 +352,37 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
         try {
           await runOnce(request);
         } catch (err) {
-          // One-shot corrective retry for an echoed tool-result envelope (devlog 260826 gap-10).
-          // The sniffer guarantees no client-visible delta escaped, so a fresh-conversation
-          // full replay with a corrective active turn is safe. A second echo propagates as an
-          // error rather than looping.
-          if (
+          const outputGuardRetryText =
             err instanceof CursorToolResultEchoError
+              ? CURSOR_ECHO_RETRY_CONTINUATION_TEXT
+              : err instanceof CursorRoutingCommentaryError
+                ? CURSOR_ROUTING_COMMENTARY_RETRY_TEXT
+                : undefined;
+          // One-shot corrective retry for guarded external output (devlog 260826 gap-10/11).
+          // The quarantine guarantees no client-visible delta escaped, so a fresh-conversation
+          // retry is safe. A second rejection propagates as an error rather than looping.
+          if (
+            outputGuardRetryText
             && !emittedOutput
             && !replayUnsafe
             && !incoming.abortSignal?.aborted
           ) {
-            debugProviderDiagnostic("cursor", "envelope-echo-retry", {
+            debugProviderDiagnostic(
+              "cursor",
+              err instanceof CursorToolResultEchoError
+                ? "envelope-echo-retry"
+                : "routing-commentary-retry",
+              {
               wireModel: request.modelId,
               conversationHash: request.conversationId.slice(0, 16),
-            });
+              },
+            );
             const echoedConversationId = request.conversationId;
             lastTransport = undefined;
             _parsed._cursorConversationId = undefined;
             request = {
               ...createCursorRequest(_parsed, { forceFreshConversation: true }),
-              echoRetryContinuationText: CURSOR_ECHO_RETRY_CONTINUATION_TEXT,
+              echoRetryContinuationText: outputGuardRetryText,
             };
             rekeyContextUsage(echoedConversationId, request.conversationId);
             _parsed._cursorConversationId = request.conversationId;

--- a/src/adapters/cursor/envelope-echo.ts
+++ b/src/adapters/cursor/envelope-echo.ts
@@ -121,12 +121,16 @@ export class CursorRoutingCommentarySniffer {
       this.done = true;
       return { kind: "hallucination" };
     }
-    const firstLineComplete = /\r?\n/u.test(this.buffered);
+    const lineBreakCount = (this.buffered.match(/\n/gu) ?? []).length;
     const hasRoutingHint = ROUTING_TOOL_HINT.test(this.buffered) || ROUTING_FAILURE_CLAIM.test(this.buffered);
+    const pendingFailureClaim =
+      ROUTING_TOOL_HINT.test(this.buffered)
+      && ROUTING_FAILURE_CLAIM.test(this.buffered)
+      && lineBreakCount < 2;
     if (
       this.byteCount < MAX_ROUTING_COMMENTARY_BYTES
       && this.buffered.length < MAX_HOLD_BYTES
-      && !firstLineComplete
+      && (lineBreakCount === 0 || pendingFailureClaim)
       && (hasRoutingHint || this.byteCount < 64)
     ) {
       return { kind: "hold" };
@@ -146,6 +150,7 @@ export class CursorRoutingCommentarySniffer {
     const nativeTools = new Set(
       [...this.buffered.matchAll(ROUTING_NATIVE_TOOL_NAME)].map(match => match[1]?.toLowerCase()),
     );
+    if (nativeTools.size === 0) return false;
     return ROUTING_REDIRECT_CLAIM.test(this.buffered) || nativeTools.size >= 2;
   }
 }

--- a/src/adapters/cursor/envelope-echo.ts
+++ b/src/adapters/cursor/envelope-echo.ts
@@ -1,19 +1,21 @@
 /**
- * Tool-result envelope echo detection for external full-replay continuations
- * (devlog 260826 gap-10).
+ * External Cursor output quarantine (devlog 260826 gaps 10-11).
  *
- * External models receive prior tool results as flattened assistant-role text
- * ("[Tool Result]\n[tool_result]\ncall_id: ..."). Mimicking models (kimi-k3
- * observed at ~30-40% of multi-round probes) sometimes ECHO that envelope as
- * their own reply instead of continuing the task. A prompt-side guard note did
- * not reduce the rate, so the boundary is observation: quarantine the first
- * bytes of assistant text until they provably diverge from the markers, and
- * classify a completed marker as a retryable semantic failure.
+ * Gap 10: flattened tool-result history can prime an external model to echo the
+ * "[Tool Result]" envelope as its own reply.
+ *
+ * Gap 11: a model can invent a blocked native-tool attempt in visible commentary
+ * even though the only real current-turn tool is the advertised Codex bridge.
+ *
+ * Both failures are observable only at the output boundary. The sniffers below
+ * hold a bounded prefix until it either diverges or proves the failure, allowing
+ * cursor.ts to retry before any invalid text reaches the client.
  */
 
 const ECHO_MARKERS = ["[Tool Result]", "[Tool Error]", "[tool_result]"] as const;
 const MAX_SNIFF_BYTES = 40;
-/** Aggregate quarantine cap: past this, flush and disarm (never a marker at this size). */
+const MAX_ROUTING_COMMENTARY_BYTES = 512;
+/** Aggregate quarantine cap: past this, flush and disarm. */
 const MAX_HOLD_BYTES = 8 * 1024;
 const encoder = new TextEncoder();
 
@@ -21,9 +23,18 @@ export class CursorToolResultEchoError extends Error {
   readonly code = "cursor_tool_result_echo";
   constructor(marker: string) {
     super(
-      `Cursor external model echoed the replayed tool-result envelope ("${marker}") instead of continuing the task.`,
+      "Cursor external model echoed the replayed tool-result envelope (\"" + marker
+      + "\") instead of continuing the task.",
     );
     this.name = "CursorToolResultEchoError";
+  }
+}
+
+export class CursorRoutingCommentaryError extends Error {
+  readonly code = "cursor_routing_commentary_hallucination";
+  constructor() {
+    super("Cursor external model invented a blocked tool surface before any tool call occurred.");
+    this.name = "CursorRoutingCommentaryError";
   }
 }
 
@@ -33,19 +44,14 @@ export type EchoSnifferDecision =
   | { kind: "echo"; marker: string };
 
 /**
- * Incremental prefix sniffer. Feed assistant text deltas in order; it answers
- * hold (still ambiguous), flush (provably not an echo — release everything and
- * disarm), or echo (a marker completed at the start of the reply).
- *
- * Leading whitespace (bounded by MAX_SNIFF_BYTES) is tolerated before the
- * marker, matching how models reproduce the envelope after a newline.
+ * Incremental envelope-prefix sniffer. Leading whitespace is tolerated so a
+ * marker copied after a newline is still caught.
  */
 export class CursorEnvelopeEchoSniffer {
   private buffered = "";
   private byteCount = 0;
   private done = false;
 
-  /** True once the sniffer reached a terminal decision (flush or echo). */
   get settled(): boolean {
     return this.done;
   }
@@ -67,12 +73,10 @@ export class CursorEnvelopeEchoSniffer {
     if (stillPrefix && this.byteCount <= MAX_SNIFF_BYTES && this.buffered.length < MAX_HOLD_BYTES) {
       return { kind: "hold" };
     }
-    // Diverged, exceeded the sniff window, or exceeded the hold cap: not an echo.
     this.done = true;
     return { kind: "flush" };
   }
 
-  /** End-of-stream: anything still held is not an echo. */
   finish(): EchoSnifferDecision {
     if (this.done) return { kind: "flush" };
     this.done = true;
@@ -80,10 +84,74 @@ export class CursorEnvelopeEchoSniffer {
   }
 }
 
+export type RoutingCommentaryDecision =
+  | { kind: "hold" }
+  | { kind: "flush" }
+  | { kind: "hallucination" };
+
+const ROUTING_NATIVE_TOOL_NAME = /\b(shell|read|grep|list|bash)\b/giu;
+const ROUTING_TOOL_HINT =
+  /(?:\b(?:shell|read|grep|list|bash)\b|exec_command|shell_command|브리지|네이티브\s*(?:셸|쉘))/iu;
+const ROUTING_FAILURE_CLAIM =
+  /(?:blocked|unavailable|interrupted|차단|중단|막혀)/iu;
+const ROUTING_REDIRECT_CLAIM =
+  /(?:exec_command|shell_command|\bexec\b|브리지|redirected|fallback|switch(?:ed|ing)?|전환|우회|통과(?:되|하)|다른\s*(?:도구|경로)|경로로)/iu;
+
 /**
- * Corrective active-turn text for the single echo retry. Deliberately does NOT
- * contain the marker strings themselves (repeating the trigger inside the
- * prompt is what made the static guard note ineffective).
+ * Quarantines the first line of code-mode / bridge output long enough to reject
+ * an impossible routing claim. It requires a failure claim plus either an
+ * explicit redirect to another execution surface or two distinct unadvertised
+ * native-tool names; a legitimate sentence such as "Shell is unavailable on
+ * this OS" therefore passes.
  */
+export class CursorRoutingCommentarySniffer {
+  private buffered = "";
+  private byteCount = 0;
+  private done = false;
+
+  get settled(): boolean {
+    return this.done;
+  }
+
+  feed(textDelta: string): RoutingCommentaryDecision {
+    if (this.done) return { kind: "flush" };
+    this.buffered += textDelta;
+    this.byteCount += encoder.encode(textDelta).byteLength;
+    if (this.matchesHallucination()) {
+      this.done = true;
+      return { kind: "hallucination" };
+    }
+    const firstLineComplete = /\r?\n/u.test(this.buffered);
+    const hasRoutingHint = ROUTING_TOOL_HINT.test(this.buffered) || ROUTING_FAILURE_CLAIM.test(this.buffered);
+    if (
+      this.byteCount < MAX_ROUTING_COMMENTARY_BYTES
+      && this.buffered.length < MAX_HOLD_BYTES
+      && !firstLineComplete
+      && (hasRoutingHint || this.byteCount < 64)
+    ) {
+      return { kind: "hold" };
+    }
+    this.done = true;
+    return { kind: "flush" };
+  }
+
+  finish(): RoutingCommentaryDecision {
+    if (this.done) return { kind: "flush" };
+    this.done = true;
+    return this.matchesHallucination() ? { kind: "hallucination" } : { kind: "flush" };
+  }
+
+  private matchesHallucination(): boolean {
+    if (!ROUTING_FAILURE_CLAIM.test(this.buffered)) return false;
+    const nativeTools = new Set(
+      [...this.buffered.matchAll(ROUTING_NATIVE_TOOL_NAME)].map(match => match[1]?.toLowerCase()),
+    );
+    return ROUTING_REDIRECT_CLAIM.test(this.buffered) || nativeTools.size >= 2;
+  }
+}
+
 export const CURSOR_ECHO_RETRY_CONTINUATION_TEXT =
   "Your previous reply copied an internal tool-output record verbatim and was rejected. Continue the original task now: issue the next required tool call, or answer in your own words if no tool is needed.";
+
+export const CURSOR_ROUTING_COMMENTARY_RETRY_TEXT =
+  "Your previous reply claimed an execution-surface failure that did not occur and was rejected. Use the current tool catalog as ground truth. Perform the requested operation through the advertised execution tool now, with no commentary before the tool call.";

--- a/tests/cursor-envelope-echo-retry.test.ts
+++ b/tests/cursor-envelope-echo-retry.test.ts
@@ -3,6 +3,7 @@ import { createCursorAdapter as createCursorAdapterProduction } from "../src/ada
 import {
   CURSOR_ECHO_RETRY_CONTINUATION_TEXT,
   CursorEnvelopeEchoSniffer,
+  CursorRoutingCommentarySniffer,
 } from "../src/adapters/cursor/envelope-echo";
 import type { AdapterEvent, OcxParsedRequest, OcxProviderConfig } from "../src/types";
 import type { CursorRunRequest, CursorServerMessage } from "../src/adapters/cursor/types";
@@ -59,7 +60,7 @@ function echoingThenHealthyTransportFactory() {
   };
 }
 
-describe("cursor envelope echo detection + corrective retry (devlog 260826 gap-10)", () => {
+describe("cursor external output quarantine + corrective retry (devlog 260826 gaps 10-11)", () => {
   test("sniffer: marker split across deltas is detected; divergent text flushes", () => {
     const echo = new CursorEnvelopeEchoSniffer();
     expect(echo.feed("[Tool ").kind).toBe("hold");
@@ -74,6 +75,20 @@ describe("cursor envelope echo detection + corrective retry (devlog 260826 gap-1
 
     const whitespace = new CursorEnvelopeEchoSniffer();
     expect(whitespace.feed("\n  [tool_result]").kind).toBe("echo");
+  });
+
+  test("routing-commentary sniffer catches fragmented invented fallback but not legitimate Shell prose", () => {
+    const hallucination = new CursorRoutingCommentarySniffer();
+    expect(hallucination.feed("Shell 경로는 또 같은 문구로 ").kind).toBe("hold");
+    expect(hallucination.feed("차단됐으니, 통과가 확인된 ").kind).toBe("hold");
+    expect(hallucination.feed("exec_command 경로로 읽겠습니다.").kind).toBe("hallucination");
+
+    const multiToolClaim = new CursorRoutingCommentarySniffer();
+    expect(multiToolClaim.feed("Read와 Grep이 모두 blocked 상태입니다.").kind).toBe("hallucination");
+
+    const legitimate = new CursorRoutingCommentarySniffer();
+    expect(legitimate.feed("Shell is unavailable on this operating system.").kind).toBe("hold");
+    expect(legitimate.finish().kind).toBe("flush");
   });
 
   test("external tool-result echo retries once with the corrective action text and no leaked envelope", async () => {
@@ -181,6 +196,51 @@ describe("cursor envelope echo detection + corrective retry (devlog 260826 gap-1
     expect(attempts()).toBe(2);
     const text = events.filter(e => e.type === "text_delta").map(e => (e as { text: string }).text).join("");
     expect(text).toBe("STATE A17");
+    expect(runRequests[1]?.echoRetryContinuationText).toBeDefined();
+  });
+
+  test("code-mode routing commentary that invents a blocked native Shell is quarantined and retried", async () => {
+    let attempt = 0;
+    const runRequests: CursorRunRequest[] = [];
+    const factory = () => ({
+      async *run(request: CursorRunRequest) {
+        runRequests.push(request);
+        attempt += 1;
+        if (attempt === 1) {
+          yield {
+            type: "text",
+            text: "`Shell` 경로는 또 같은 문구로 차단됐으니, 통과가 확인된 `exec_command` 경로로 읽겠습니다.",
+          } satisfies CursorServerMessage;
+        } else {
+          yield { type: "text", text: "READ_OK" } satisfies CursorServerMessage;
+        }
+        yield { type: "done", usage: { inputTokens: 1, outputTokens: 1 } } satisfies CursorServerMessage;
+      },
+      writeClient() {},
+    });
+    const body = {
+      modelId: "cursor/kimi-k3-1m",
+      context: {
+        messages: [{ role: "user", content: "Read the file and report its first line.", timestamp: 1 }],
+        tools: [{
+          name: "exec",
+          description: "Run JavaScript code to orchestrate nested tool calls.",
+          parameters: {},
+          freeform: true,
+        }],
+      },
+      stream: false,
+      options: {},
+      _cursorConversationId: "cursor_routing_commentary",
+      _cursorIdentityScope: "acct-routing-commentary",
+    } as OcxParsedRequest;
+    const adapter = createCursorAdapter({ ...provider, apiKey: "cursor-token" }, { createTransport: factory as never });
+    const events: AdapterEvent[] = [];
+    await adapter.runTurn?.(body, { headers: new Headers() }, event => events.push(event));
+    const text = events.filter(e => e.type === "text_delta").map(e => (e as { text: string }).text).join("");
+    expect(attempt).toBe(2);
+    expect(text).toBe("READ_OK");
+    expect(text).not.toContain("Shell");
     expect(runRequests[1]?.echoRetryContinuationText).toBeDefined();
   });
 });

--- a/tests/cursor-envelope-echo-retry.test.ts
+++ b/tests/cursor-envelope-echo-retry.test.ts
@@ -86,9 +86,17 @@ describe("cursor external output quarantine + corrective retry (devlog 260826 ga
     const multiToolClaim = new CursorRoutingCommentarySniffer();
     expect(multiToolClaim.feed("Read와 Grep이 모두 blocked 상태입니다.").kind).toBe("hallucination");
 
+    const multiline = new CursorRoutingCommentarySniffer();
+    expect(multiline.feed("Shell was blocked.\n").kind).toBe("hold");
+    expect(multiline.feed("Switching to exec_command.").kind).toBe("hallucination");
+
     const legitimate = new CursorRoutingCommentarySniffer();
     expect(legitimate.feed("Shell is unavailable on this operating system.").kind).toBe("hold");
     expect(legitimate.finish().kind).toBe("flush");
+
+    const contextFree = new CursorRoutingCommentarySniffer();
+    expect(contextFree.feed("The request was blocked and redirected to exec_command.").kind).toBe("hold");
+    expect(contextFree.finish().kind).toBe("flush");
   });
 
   test("external tool-result echo retries once with the corrective action text and no leaked envelope", async () => {


### PR DESCRIPTION
## Summary

- Stacked on #2669 (base: codex/cursor-gap-10).
- Session evidence disproves the prior “Codex harness content guard” diagnosis: every recorded tool call was exec; the two content-reading exec commands completed exit 0 and their output reached the model; Read/Grep/Shell had zero execution rows.
- The failure was model-generated routing commentary: Kimi said Shell was blocked and it was switching surfaces before the real exec call occurred.
- Add a bounded routing-commentary sniffer to the existing external-output quarantine. It arms only when an external Cursor turn advertises code-mode exec or a Codex shell bridge.
- Reject only a failure claim paired with an execution-surface redirect or two distinct unavailable native-tool names. Suppress the invalid prefix and retry once in a fresh conversation; a second rejection fails closed.

## Verification

- RED: the adapter regression leaked the false Shell commentary and made one attempt; expected two.
- GREEN: bun test tests/cursor-envelope-echo-retry.test.ts — 8 pass / 0 fail.
- Focused cursor regression set — 54 pass / 0 fail.
- bun x tsc --noEmit — exit 0.
- Fresh codex exec session with cursor/kimi-k3-1m: first action was real command execution; final LIVE_ROUTING_OK=ROUTING_LIVE_7391.
- Adversarial raw Responses batch seeded the false prior commentary: 10/10 returned a real exec custom tool call, zero leaked routing commentary.
- Independent sol-medium review found and closed two edge cases: multiline blocked/switching text is held across one additional line; context-free request redirection cannot match without a native-tool name.
- Final remote CI on HEAD ab54fe6b0: macOS PASS (10m41s), test shards 4/4 PASS, aggregate ci PASS.
- Full repository suite intentionally not rerun per operator instruction; focused adapter suite and live dogfood cover the changed boundary.

## Checklist

- [x] Targets the parent stack branch; retarget to dev after #2669 lands
- [x] Regression test reproduces the observed production transcript
- [x] Typecheck and focused tests pass
- [x] Live service repaired and dogfooded
- [x] No GUI or public API change
