### PR TITLE
fix(catalog): advertise Muse Spark image input on OpenCode Go

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1409,6 +1409,11 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
       [OPENCODE_OX_ALPHA_FREE_MODEL]: ["text", "image"],
       // Experimental DeepSeek vision preview — expected to merge into deepseek-v4-flash later.
       [DEEPSEEK_VISION_PREVIEW_MODEL]: ["text", "image"],
+      // Muse Spark 1.2 Contributor is natively multimodal on Zen Go: it accepts input_image
+      // parts over /responses (probed 2026-08-26). Without this declaration the catalog
+      // advertises it text-only and the Codex app blocks image attachments client-side with
+      // "This model does not support image inputs" before the request ever reaches the proxy.
+      "muse-spark-1.2-contributor": ["text", "image"],
     },
     modelReasoningEfforts: {
       "gpt-5.6-luna": OPENAI_API_GPT56_REASONING_EFFORTS,

--- a/tests/opencode-go-muse-vision.test.ts
+++ b/tests/opencode-go-muse-vision.test.ts
@@ -16,6 +16,7 @@ import type { OcxProviderConfig } from "../src/types";
 
 const MUSE_MODEL = "muse-spark-1.2-contributor";
 
+/** Seeded OpenCode Go provider config for the Muse Spark vision assertions. */
 function opencodeGo(): OcxProviderConfig {
   const entry = getProviderRegistryEntry("opencode-go");
   if (!entry) throw new Error("missing opencode-go registry fixture");

--- a/tests/opencode-go-muse-vision.test.ts
+++ b/tests/opencode-go-muse-vision.test.ts
@@ -1,0 +1,50 @@
+/**
+ * OpenCode Go Muse Spark 1.2 Contributor multimodal regression.
+ *
+ * Muse Spark answers /responses on Zen Go and accepts input_image parts, but the
+ * registry declared no modelInputModalities for it, so the Codex catalog advertised
+ * it text-only. The app gates image attachments client-side on input_modalities,
+ * so a text-only entry blocks images ("This model does not support image inputs")
+ * before the request ever reaches the proxy. These tests lock the declaration in
+ * and prove the catalog advertises image input for Muse.
+ */
+import { describe, expect, test } from "bun:test";
+import { applyProviderConfigHints } from "../src/codex/catalog";
+import { getProviderRegistryEntry, PROVIDER_REGISTRY } from "../src/providers/registry";
+import { providerConfigSeed } from "../src/providers/derive";
+import type { OcxProviderConfig } from "../src/types";
+
+const MUSE_MODEL = "muse-spark-1.2-contributor";
+
+function opencodeGo(): OcxProviderConfig {
+  const entry = getProviderRegistryEntry("opencode-go");
+  if (!entry) throw new Error("missing opencode-go registry fixture");
+  return { ...providerConfigSeed(entry), apiKey: "test-key" };
+}
+
+describe("OpenCode Go Muse Spark image input (#vision)", () => {
+  test("registry declares Muse as text+image", () => {
+    const entry = PROVIDER_REGISTRY.find(e => e.id === "opencode-go");
+    expect(entry?.modelInputModalities?.[MUSE_MODEL]).toEqual(["text", "image"]);
+  });
+
+  test("the registry seed carries Muse as text+image", () => {
+    const prov = opencodeGo();
+    expect(prov.modelInputModalities?.[MUSE_MODEL]).toEqual(["text", "image"]);
+  });
+
+  test("applyProviderConfigHints advertises image input for Muse", () => {
+    const prov = opencodeGo();
+    const hinted = applyProviderConfigHints("opencode-go", prov, {
+      id: MUSE_MODEL,
+      provider: "opencode-go",
+    });
+    expect(hinted.inputModalities).toEqual(["text", "image"]);
+  });
+
+  test("Muse is NOT in noVisionModels (it is natively multimodal, not sidecar-only)", () => {
+    const prov = opencodeGo();
+    expect(prov.noVisionModels ?? []).not.toContain(MUSE_MODEL);
+    expect(prov.modelInputModalities?.[MUSE_MODEL]).toEqual(["text", "image"]);
+  });
+});


### PR DESCRIPTION
## Summary

`opencode-go` (OpenCode Go / Zen) serves Muse Spark 1.2 Contributor over the Responses endpoint and the model natively accepts images (`input_image` parts). The registry, however, declared no `modelInputModalities` for it, so the Codex catalog advertised Muse as **text-only**. The Codex app gates image attachments client-side on `input_modalities`, so a text-only entry blocks images ("This model does not support image inputs") before the request ever reaches the proxy.

This adds Muse Spark to `opencode-go`'s `modelInputModalities` map as `["text", "image"]`, matching the existing treatment of the other natively-multimodal models on the same provider (`kimi-k3`, Ox Alpha, DeepSeek vision preview).

It does **not** add Muse to `noVisionModels` — Muse is natively multimodal, not sidecar-only, so the vision-sidecar augmentation is the wrong mechanism for it.

## Verification

```
bun x tsc --noEmit                                 exit 0
bun test tests/opencode-go-muse-vision.test.ts    4 pass / 0 fail
bun test tests/catalog-vision-sidecar-modalities.test.ts \
         tests/opencode-go-luna-wire.test.ts \
         tests/catalog-input-modality-enum.test.ts   49 pass / 0 fail
```

Rebased onto the latest `origin/dev` (779b6090c) and re-ran the suite: 53 pass / 0 fail across the four files.

- Pre-existing unrelated timing failure in `tests/active-registry-admission.test.ts` (spins a live proxy and times out at 5000ms) also reproduces on clean `dev`; it does not touch this change.

## Checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenCode Go’s Muse Spark 1.2 Contributor model now supports both text and image input.

* **Bug Fixes**
  * Improved model capability recognition across configuration and catalog displays.
  * Ensured the model is correctly available for multimodal use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->