### PR TITLE
fix(web-search): bound Exa response bodies

### DIFF
--- a/src/web-search/exa-executor.ts
+++ b/src/web-search/exa-executor.ts
@@ -9,10 +9,11 @@
  * Never throws; every error string passes redactSecretString.
  */
 import { fetchWithResetRetry } from "../lib/upstream-retry";
-import { signalWithTimeout } from "../lib/abort";
+import { cancelBodyOnAbort, signalWithTimeout } from "../lib/abort";
+import { readBoundedResponseBytes } from "../lib/bounded-body";
 import { sidecarEnter } from "../lib/sidecar-tracker";
 import { redactSecretString } from "../lib/redact";
-import type { WebSearchSource } from "./parse";
+import { MAX_SIDECAR_RESPONSE_BYTES, type WebSearchSource } from "./parse";
 import type { SidecarOutcome, SidecarSettings } from "./executor";
 
 const EXA_SEARCH_URL = "https://api.exa.ai/search";
@@ -47,14 +48,40 @@ export async function runExaWebSearch(
       }),
       { abortSignal: linkedSignal.signal, label: "exa-web-search-sidecar" },
     );
-    if (!res.ok) {
-      const t = await res.text().catch(() => "");
-      // Scrub BEFORE truncating: slicing first can cut the literal key at the
-      // boundary, leaving an unscrubbable key prefix in the surviving text.
-      return { text: "", sources: [], error: `exa sidecar HTTP ${res.status}: ${scrub(t).slice(0, 200)}` };
+    const detachBodyGuard = cancelBodyOnAbort(res.body, linkedSignal.signal);
+    try {
+      let bounded: Awaited<ReturnType<typeof readBoundedResponseBytes>> | null = null;
+      try {
+        bounded = await readBoundedResponseBytes(res, {
+          maxBytes: MAX_SIDECAR_RESPONSE_BYTES,
+          signal: linkedSignal.signal,
+        });
+      } catch {
+        // Preserve the previous status-only/shapeless fallback for body read
+        // failures; fetch/header failures are still classified by the outer catch.
+      }
+      if (bounded?.oversized) {
+        const prefix = res.ok ? "exa sidecar response" : `exa sidecar HTTP ${res.status} response`;
+        return { text: "", sources: [], error: `${prefix} exceeded byte bound` };
+      }
+      // Response.text()/json() replace malformed UTF-8, so preserve that
+      // behavior while moving the byte bound ahead of decoding and parsing.
+      const text = bounded ? new TextDecoder().decode(bounded.bytes) : "";
+      if (!res.ok) {
+        // Scrub BEFORE truncating: slicing first can cut the literal key at the
+        // boundary, leaving an unscrubbable key prefix in the surviving text.
+        return { text: "", sources: [], error: `exa sidecar HTTP ${res.status}: ${scrub(text).slice(0, 200)}` };
+      }
+      let payload: unknown = null;
+      try {
+        payload = JSON.parse(text);
+      } catch {
+        // The mapper owns the stable malformed/empty JSON outcome.
+      }
+      return mapExaSearchResponse(payload);
+    } finally {
+      detachBodyGuard();
     }
-    const payload = await res.json().catch(() => null);
-    return mapExaSearchResponse(payload);
   } catch (e) {
     const kind = e instanceof Error && e.name === "TimeoutError" ? "timeout" : "connect_error";
     console.warn(`[web-search] exa sidecar ${kind} (${Date.now() - t0}ms)`);

--- a/src/web-search/exa-executor.ts
+++ b/src/web-search/exa-executor.ts
@@ -57,6 +57,10 @@ export async function runExaWebSearch(
           signal: linkedSignal.signal,
         });
       } catch {
+        const reason = linkedSignal.signal.reason;
+        if (linkedSignal.signal.aborted && reason instanceof Error && reason.name === "TimeoutError") {
+          throw reason;
+        }
         // Preserve the previous status-only/shapeless fallback for body read
         // failures; fetch/header failures are still classified by the outer catch.
       }

--- a/tests/exa-web-search.test.ts
+++ b/tests/exa-web-search.test.ts
@@ -3,6 +3,7 @@ import { mapExaSearchResponse, runExaWebSearch } from "../src/web-search/exa-exe
 import { planWebSearch } from "../src/web-search";
 import { parseRequest } from "../src/responses/parser";
 import { runWithWebSearch, type WebSearchLoopDeps } from "../src/web-search/loop";
+import { MAX_SIDECAR_RESPONSE_BYTES } from "../src/web-search/parse";
 import { createTestTranslatorBudget } from "./helpers/translator-budget";
 import type { AdapterEvent, ProviderAdapter } from "../src/adapters/base";
 import type { OcxConfig, OcxProviderConfig } from "../src/types";
@@ -13,6 +14,19 @@ function config(overrides: Partial<OcxConfig> = {}): OcxConfig {
 }
 function parsedWithWebSearch() {
   return parseRequest({ model: "routed/model", input: "search", stream: true, tools: [{ type: "web_search" }] });
+}
+
+function oversizedResponse(status: number, onCancel: () => void, prefix = ""): Response {
+  const bytes = new Uint8Array(MAX_SIDECAR_RESPONSE_BYTES + 1);
+  bytes.set(new TextEncoder().encode(prefix).subarray(0, bytes.byteLength));
+  return new Response(new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+    },
+    cancel() {
+      onCancel();
+    },
+  }), { status });
 }
 
 describe("mapExaSearchResponse (002 probe shape)", () => {
@@ -72,6 +86,121 @@ describe("runExaWebSearch key hygiene (canary)", () => {
       const out = await runExaWebSearch("q", key, { model: "m", reasoning: "low", timeoutMs: 5000, describeImages: false });
       expect(out.error).toBeDefined();
       expect(JSON.stringify(out)).not.toContain("exa-canary");
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  test("an oversized successful response is rejected and its stream is cancelled", async () => {
+    let cancelled = false;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => oversizedResponse(200, () => { cancelled = true; })) as typeof fetch;
+    try {
+      const out = await runExaWebSearch("q", "key-1", { model: "m", reasoning: "low", timeoutMs: 5000, describeImages: false });
+      expect(out).toEqual({ text: "", sources: [], error: "exa sidecar response exceeded byte bound" });
+      expect(cancelled).toBe(true);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  test("a valid successful response at the exact byte bound is accepted", async () => {
+    const prefix = '{"results":[{"url":"https://e.com","text":"';
+    const suffix = '"}]}';
+    const filler = "x".repeat(MAX_SIDECAR_RESPONSE_BYTES - new TextEncoder().encode(prefix + suffix).byteLength);
+    const body = new TextEncoder().encode(prefix + filler + suffix);
+    expect(body.byteLength).toBe(MAX_SIDECAR_RESPONSE_BYTES);
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(body, { status: 200 })) as typeof fetch;
+    try {
+      const out = await runExaWebSearch("q", "key-1", { model: "m", reasoning: "low", timeoutMs: 5000, describeImages: false });
+      expect(out.error).toBeUndefined();
+      expect(out.sources).toEqual([{ url: "https://e.com" }]);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  test("an oversized error response is rejected without retaining its body", async () => {
+    let cancelled = false;
+    const key = "exa-canary-oversized-9876543210";
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => oversizedResponse(401, () => { cancelled = true; }, key)) as typeof fetch;
+    try {
+      const out = await runExaWebSearch("q", key, { model: "m", reasoning: "low", timeoutMs: 5000, describeImages: false });
+      expect(out).toEqual({ text: "", sources: [], error: "exa sidecar HTTP 401 response exceeded byte bound" });
+      expect(cancelled).toBe(true);
+      expect(JSON.stringify(out)).not.toContain("exa-canary");
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  test("malformed JSON keeps the stable shapeless outcome", async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response("not-json", { status: 200 })) as typeof fetch;
+    try {
+      const out = await runExaWebSearch("q", "key-1", { model: "m", reasoning: "low", timeoutMs: 5000, describeImages: false });
+      expect(out.error).toBe("exa sidecar returned a non-JSON or shapeless body");
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  test("malformed UTF-8 preserves response replacement decoding", async () => {
+    const encoder = new TextEncoder();
+    const prefix = encoder.encode('{"results":[{"url":"https://e.com","title":"');
+    const suffix = encoder.encode('"}]}');
+    const body = new Uint8Array(prefix.byteLength + 1 + suffix.byteLength);
+    body.set(prefix);
+    body[prefix.byteLength] = 0xff;
+    body.set(suffix, prefix.byteLength + 1);
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(body, { status: 200 })) as typeof fetch;
+    try {
+      const out = await runExaWebSearch("q", "key-1", { model: "m", reasoning: "low", timeoutMs: 5000, describeImages: false });
+      expect(out.sources).toEqual([{ url: "https://e.com", title: "�" }]);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  test("a body read rejection preserves the HTTP status-only fallback", async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(new Error("body-reset"));
+      },
+    }), { status: 502 })) as typeof fetch;
+    try {
+      const out = await runExaWebSearch("q", "key-1", { model: "m", reasoning: "low", timeoutMs: 5000, describeImages: false });
+      expect(out.error).toBe("exa sidecar HTTP 502: ");
+      expect(out.error).not.toContain("body-reset");
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  test("an already-aborted response body is cancelled before reader attachment", async () => {
+    const parent = new AbortController();
+    let cancelled = false;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      const response = new Response(new ReadableStream<Uint8Array>({
+        pull() {
+          // Stay pending until cancellation owns the body.
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }), { status: 200 });
+      parent.abort(new DOMException("parent stopped", "AbortError"));
+      return response;
+    }) as typeof fetch;
+    try {
+      const out = await runExaWebSearch("q", "key-1", { model: "m", reasoning: "low", timeoutMs: 5000, describeImages: false }, parent.signal);
+      expect(out.error).toBe("exa sidecar returned a non-JSON or shapeless body");
+      expect(cancelled).toBe(true);
     } finally {
       globalThis.fetch = realFetch;
     }

--- a/tests/exa-web-search.test.ts
+++ b/tests/exa-web-search.test.ts
@@ -206,6 +206,26 @@ describe("runExaWebSearch key hygiene (canary)", () => {
     }
   });
 
+  test("a response body timeout keeps the timeout outcome", async () => {
+    let cancelled = false;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(new ReadableStream<Uint8Array>({
+      pull() {
+        // Stay pending until the linked deadline expires.
+      },
+      cancel() {
+        cancelled = true;
+      },
+    }), { status: 200 })) as typeof fetch;
+    try {
+      const out = await runExaWebSearch("q", "key-1", { model: "m", reasoning: "low", timeoutMs: 5, describeImages: false });
+      expect(out.error).toBe("Timeout elapsed");
+      expect(cancelled).toBe(true);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
   test("request carries x-api-key, manual redirect, pinned url; empty key fails closed with no fetch", async () => {
     const captured: Array<{ url: string; init: RequestInit }> = [];
     const realFetch = globalThis.fetch;


### PR DESCRIPTION
## Summary

- Read Exa success and error response bodies through the existing 64 KiB sidecar byte bound before decoding or JSON parsing.
- Discard retained prefixes and cancel oversized or already-aborted bodies while preserving the existing HTTP-status-only, shapeless-JSON, UTF-8 replacement, key-scrubbing, and body-read timeout behavior.
- Cover exact-limit success, over-limit success and error cancellation, malformed JSON and UTF-8 compatibility, body read failure fallback, pending-body timeout classification, and the pre-reader abort window.

## Verification

- Bun 1.4.0: `bun test tests/bounded-body.test.ts tests/exa-web-search.test.ts` — 44 passed, 0 failed.
- Bun 1.4.0: `bun run typecheck`.
- Bun 1.4.0: `bun run privacy:scan`.
- `git diff --check`.
- Independent current-diff review found no remaining P0–P2 issue.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

No credential destination or authentication decision changes. API-key canary coverage and the privacy scan pass; maintainer security review remains available if required for this untrusted-response boundary.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of oversized web-search responses with clear error messages.
  * Added safer processing for malformed content, invalid text encoding, interrupted reads, and cancelled requests.
  * Preserved sensitive information redaction in HTTP error responses.
  * Ensured response streams are properly cancelled and cleaned up when limits are exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->