### PR TITLE
fix(openai-chat): normalize $ref-with-siblings for Moonshot tool schemas

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -932,6 +932,24 @@ function isXaiSchemaTarget(provider: OcxProviderConfig): boolean {
   }
 }
 
+// Moonshot validates function schemas against a draft-07 reading of `$ref`, where the
+// keyword stands alone and siblings are ignored. It rejects the whole request rather
+// than ignoring them: "not a valid moonshot flavored json schema ... when using $ref,
+// type should be defined in the referenced schema instead of the parent schema".
+const MOONSHOT_SCHEMA_HOSTNAMES = new Set([
+  "api.kimi.com",
+  "api.moonshot.ai",
+  "api.moonshot.cn",
+]);
+
+function isMoonshotSchemaTarget(provider: OcxProviderConfig): boolean {
+  try {
+    return MOONSHOT_SCHEMA_HOSTNAMES.has(new URL(provider.baseUrl).hostname);
+  } catch {
+    return false;
+  }
+}
+
 const VOLCENGINE_ARK_HOSTNAMES = new Set([
   "ark.cn-beijing.volces.com",
   "ark.ap-southeast.volces.com",
@@ -962,6 +980,99 @@ function ensureRootObjectType(parameters: unknown): Record<string, unknown> {
 
 function isXaiObjectSchema(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * JSON Schema 2020-12 makes `$ref` an in-place applicator: siblings stay in force and are
+ * combined with the referenced schema. Moonshot enforces the older draft-07 reading where
+ * `$ref` must stand alone, and 400s the entire request when a node carries both. Codex's own
+ * deferred tool catalog emits exactly that shape (zod-to-json-schema deduplicates into
+ * `$defs.__schema*` nodes that keep `type`/`minLength`/`format` beside the `$ref`), so the
+ * schema is not something a user can fix from configuration — see issue #2673.
+ *
+ * Inline the referenced schema underneath the node's own keywords, which is what 2020-12 says
+ * the node means, then drop `$ref`. Constraints reach the model instead of being stripped.
+ * The `$defs` bag is preserved: a bare `$ref` (no siblings) is already legal for Moonshot and
+ * is left pointing at its definition rather than expanded, which keeps recursive schemas finite.
+ */
+function moonshotRefTargetKeys(node: Record<string, unknown>): string[] {
+  return Object.keys(node).filter(key => key !== "$ref");
+}
+
+/**
+ * Inlining duplicates the target, so a schema referencing one large definition from many
+ * sibling-carrying nodes can multiply. Bound the total expansions and fall back to a bare
+ * `$ref` once the budget is spent: still valid for Moonshot, just without the node's own
+ * narrowing keywords. Mirrors the node budget in google-tool-schema.ts.
+ */
+const MOONSHOT_MAX_REF_EXPANSIONS = 512;
+
+interface MoonshotNormalizeState {
+  activeRefs: Set<string>;
+  remainingExpansions: number;
+}
+
+function normalizeMoonshotSchemaNode(
+  node: unknown,
+  root: Record<string, unknown>,
+  state: MoonshotNormalizeState,
+): unknown {
+  if (Array.isArray(node)) {
+    return node.map(item => normalizeMoonshotSchemaNode(item, root, state));
+  }
+  if (!isXaiObjectSchema(node)) return node;
+
+  const ref = node.$ref;
+  const hasSiblings = moonshotRefTargetKeys(node).length > 0;
+
+  if (typeof ref === "string" && hasSiblings) {
+    // A cycle cannot be inlined. Keeping the bare `$ref` is the lossy-but-valid fallback:
+    // Moonshot accepts it, and the alternative (dropping the ref) would erase the recursion.
+    if (state.activeRefs.has(ref) || state.remainingExpansions <= 0) return { $ref: ref };
+
+    const target = lookupLocalJsonPointer(root, ref);
+    if (isXaiObjectSchema(target)) {
+      state.remainingExpansions -= 1;
+      state.activeRefs.add(ref);
+      const resolvedTarget = normalizeMoonshotSchemaNode(target, root, state);
+      state.activeRefs.delete(ref);
+      const merged: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+      if (isXaiObjectSchema(resolvedTarget)) {
+        for (const [key, value] of Object.entries(resolvedTarget)) merged[key] = value;
+      }
+      // The node's own keywords win: under 2020-12 they are applied alongside the target,
+      // and a node that narrows `type`/`format` means the narrower constraint.
+      for (const [key, value] of Object.entries(node)) {
+        if (key === "$ref") continue;
+        merged[key] = normalizeMoonshotSchemaNode(value, root, state);
+      }
+      return merged;
+    }
+
+    // Unresolvable pointer (remote ref, malformed path, non-object target): the siblings are
+    // the only usable schema left, so drop the ref rather than forwarding a rejected node.
+    const withoutRef: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+    for (const [key, value] of Object.entries(node)) {
+      if (key === "$ref") continue;
+      withoutRef[key] = normalizeMoonshotSchemaNode(value, root, state);
+    }
+    return withoutRef;
+  }
+
+  const out: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+  for (const [key, value] of Object.entries(node)) {
+    out[key] = key === "$ref" ? value : normalizeMoonshotSchemaNode(value, root, state);
+  }
+  return out;
+}
+
+function normalizeMoonshotToolParameters(parameters: unknown): Record<string, unknown> {
+  const rooted = ensureRootObjectType(parameters);
+  const normalized = normalizeMoonshotSchemaNode(rooted, rooted, {
+    activeRefs: new Set<string>(),
+    remainingExpansions: MOONSHOT_MAX_REF_EXPANSIONS,
+  });
+  return isXaiObjectSchema(normalized) ? normalized : rooted;
 }
 
 function stringRequiredFields(value: unknown): string[] {
@@ -1228,10 +1339,14 @@ function toolsToChatFormat(parsed: OcxParsedRequest, provider: OcxProviderConfig
   const tools = parsed.context.tools.filter(toolChoiceToolPredicate(parsed.options.toolChoice, parsed.context.tools));
   if (tools.length === 0) return undefined;
   const xaiTarget = isXaiSchemaTarget(provider);
+  const moonshotTarget = !xaiTarget && isMoonshotSchemaTarget(provider);
   const formatted = tools.flatMap(t => {
-    const parameters = stripResponsesOnlyEncryptedMarker(xaiTarget
+    const normalized = xaiTarget
       ? normalizeXaiToolParameters(t.parameters)
-      : ensureRootObjectType(t.parameters));
+      : moonshotTarget
+        ? normalizeMoonshotToolParameters(t.parameters)
+        : ensureRootObjectType(t.parameters);
+    const parameters = stripResponsesOnlyEncryptedMarker(normalized);
 
     if (parameters === undefined) return [];
     return [{

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -1032,6 +1032,43 @@ function unionRequired(target: unknown, sibling: unknown): unknown {
   return out;
 }
 
+/**
+ * Keywords whose values are DATA, not schemas.
+ *
+ * Recursing into them rewrote user data: an `enum` listing a literal object that happens
+ * to carry a `"$ref"` string had that key stripped as if it were a schema reference, so a
+ * value the tool declared as legal silently changed shape. These are copied through.
+ */
+const MOONSHOT_DATA_VALUED_KEYWORDS = new Set(["enum", "const", "default", "examples"]);
+
+/**
+ * Compose two `properties` maps. A property named in BOTH the referenced target and the
+ * node is the same conjunction problem `required` had: letting the sibling win discards
+ * the target's constraints for that member. Merge the two member schemas so neither side
+ * loses its keywords, and let the node narrow on a genuine conflict.
+ */
+function composeProperties(
+  target: Record<string, unknown>,
+  sibling: Record<string, unknown>,
+): Record<string, unknown> {
+  const combined: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+  for (const [name, sub] of Object.entries(target)) combined[name] = sub;
+  for (const [name, sub] of Object.entries(sibling)) {
+    const existing = combined[name];
+    if (isXaiObjectSchema(existing) && isXaiObjectSchema(sub)) {
+      const member: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+      for (const [k, v] of Object.entries(existing)) member[k] = v;
+      for (const [k, v] of Object.entries(sub)) {
+        member[k] = k === "required" ? unionRequired(member[k], v) : v;
+      }
+      combined[name] = member;
+      continue;
+    }
+    combined[name] = sub;
+  }
+  return combined;
+}
+
 interface MoonshotNormalizeState {
   activeRefs: Set<string>;
   remainingExpansions: number;
@@ -1080,16 +1117,17 @@ function normalizeMoonshotSchemaNode(
       // `b`. Those two compose; everything else keeps the narrowing overwrite.
       for (const [key, value] of Object.entries(node)) {
         if (key === "$ref") continue;
+        if (MOONSHOT_DATA_VALUED_KEYWORDS.has(key)) {
+          merged[key] = value;
+          continue;
+        }
         const normalized = normalizeMoonshotSchemaNode(value, root, state, depth + 1);
         if (key === "required") {
           merged[key] = unionRequired(merged[key], normalized);
           continue;
         }
         if (key === "properties" && isXaiObjectSchema(merged[key]) && isXaiObjectSchema(normalized)) {
-          const combined: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
-          for (const [name, sub] of Object.entries(merged[key] as Record<string, unknown>)) combined[name] = sub;
-          for (const [name, sub] of Object.entries(normalized)) combined[name] = sub;
-          merged[key] = combined;
+          merged[key] = composeProperties(merged[key] as Record<string, unknown>, normalized);
           continue;
         }
         merged[key] = normalized;
@@ -1107,7 +1145,9 @@ function normalizeMoonshotSchemaNode(
 
   const out: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
   for (const [key, value] of Object.entries(node)) {
-    out[key] = key === "$ref" ? value : normalizeMoonshotSchemaNode(value, root, state, depth + 1);
+    out[key] = key === "$ref" || MOONSHOT_DATA_VALUED_KEYWORDS.has(key)
+      ? value
+      : normalizeMoonshotSchemaNode(value, root, state, depth + 1);
   }
   return out;
 }

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -1007,20 +1007,53 @@ function moonshotRefTargetKeys(node: Record<string, unknown>): string[] {
  */
 const MOONSHOT_MAX_REF_EXPANSIONS = 512;
 
+/**
+ * Expansion count alone does not bound the walk: a deeply nested ref-free schema, or one
+ * large definition repeated across many nodes, still recurses to exhaustion or amplifies the
+ * emitted output. Depth and node budgets close both, and mirror google-tool-schema.ts.
+ */
+const MOONSHOT_MAX_SCHEMA_DEPTH = 64;
+const MOONSHOT_MAX_SCHEMA_NODES = 4_096;
+
+/**
+ * Assertion keywords whose meaning under a `$ref` is CONJUNCTION, not replacement. A node
+ * carrying `required: ["b"]` beside a target requiring `["a"]` means both are required;
+ * letting the sibling win emitted a schema that no longer described the tool.
+ */
+function unionRequired(target: unknown, sibling: unknown): unknown {
+  if (!Array.isArray(target) || !Array.isArray(sibling)) return sibling;
+  const seen = new Set<unknown>();
+  const out: unknown[] = [];
+  for (const name of [...target, ...sibling]) {
+    if (seen.has(name)) continue;
+    seen.add(name);
+    out.push(name);
+  }
+  return out;
+}
+
 interface MoonshotNormalizeState {
   activeRefs: Set<string>;
   remainingExpansions: number;
+  remainingNodes: number;
 }
 
 function normalizeMoonshotSchemaNode(
   node: unknown,
   root: Record<string, unknown>,
   state: MoonshotNormalizeState,
+  depth = 0,
 ): unknown {
   if (Array.isArray(node)) {
-    return node.map(item => normalizeMoonshotSchemaNode(item, root, state));
+    if (depth >= MOONSHOT_MAX_SCHEMA_DEPTH) return [];
+    return node.map(item => normalizeMoonshotSchemaNode(item, root, state, depth + 1));
   }
   if (!isXaiObjectSchema(node)) return node;
+
+  // Fail closed for this node rather than emitting a partially weakened schema: an empty
+  // object is the one shape that asserts nothing it cannot back up.
+  if (depth >= MOONSHOT_MAX_SCHEMA_DEPTH || state.remainingNodes <= 0) return {};
+  state.remainingNodes -= 1;
 
   const ref = node.$ref;
   const hasSiblings = moonshotRefTargetKeys(node).length > 0;
@@ -1034,34 +1067,47 @@ function normalizeMoonshotSchemaNode(
     if (isXaiObjectSchema(target)) {
       state.remainingExpansions -= 1;
       state.activeRefs.add(ref);
-      const resolvedTarget = normalizeMoonshotSchemaNode(target, root, state);
+      const resolvedTarget = normalizeMoonshotSchemaNode(target, root, state, depth + 1);
       state.activeRefs.delete(ref);
       const merged: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
       if (isXaiObjectSchema(resolvedTarget)) {
         for (const [key, value] of Object.entries(resolvedTarget)) merged[key] = value;
       }
-      // The node's own keywords win: under 2020-12 they are applied alongside the target,
-      // and a node that narrows `type`/`format` means the narrower constraint.
+      // "Alongside the target" is conjunction, not replacement. For most keywords the node
+      // narrows the target and overwriting is the narrower reading, but `required` and
+      // `properties` are set-valued: letting the sibling win DROPPED the target's own
+      // members, so a tool requiring `a` beside a node requiring `b` shipped requiring only
+      // `b`. Those two compose; everything else keeps the narrowing overwrite.
       for (const [key, value] of Object.entries(node)) {
         if (key === "$ref") continue;
-        merged[key] = normalizeMoonshotSchemaNode(value, root, state);
+        const normalized = normalizeMoonshotSchemaNode(value, root, state, depth + 1);
+        if (key === "required") {
+          merged[key] = unionRequired(merged[key], normalized);
+          continue;
+        }
+        if (key === "properties" && isXaiObjectSchema(merged[key]) && isXaiObjectSchema(normalized)) {
+          const combined: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+          for (const [name, sub] of Object.entries(merged[key] as Record<string, unknown>)) combined[name] = sub;
+          for (const [name, sub] of Object.entries(normalized)) combined[name] = sub;
+          merged[key] = combined;
+          continue;
+        }
+        merged[key] = normalized;
       }
       return merged;
     }
 
-    // Unresolvable pointer (remote ref, malformed path, non-object target): the siblings are
-    // the only usable schema left, so drop the ref rather than forwarding a rejected node.
-    const withoutRef: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
-    for (const [key, value] of Object.entries(node)) {
-      if (key === "$ref") continue;
-      withoutRef[key] = normalizeMoonshotSchemaNode(value, root, state);
-    }
-    return withoutRef;
+    // Unresolvable pointer: a remote ref, a malformed path, or a non-object target. Dropping
+    // the ref and keeping the siblings silently discards whatever the reference constrained,
+    // which is the one outcome we cannot detect downstream. A bare `$ref` is lossy in the
+    // other direction - it loses the node's own keywords - but it preserves the identity of
+    // what was asked for, and Moonshot accepts it.
+    return { $ref: ref };
   }
 
   const out: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
   for (const [key, value] of Object.entries(node)) {
-    out[key] = key === "$ref" ? value : normalizeMoonshotSchemaNode(value, root, state);
+    out[key] = key === "$ref" ? value : normalizeMoonshotSchemaNode(value, root, state, depth + 1);
   }
   return out;
 }
@@ -1071,6 +1117,7 @@ function normalizeMoonshotToolParameters(parameters: unknown): Record<string, un
   const normalized = normalizeMoonshotSchemaNode(rooted, rooted, {
     activeRefs: new Set<string>(),
     remainingExpansions: MOONSHOT_MAX_REF_EXPANSIONS,
+    remainingNodes: MOONSHOT_MAX_SCHEMA_NODES,
   });
   return isXaiObjectSchema(normalized) ? normalized : rooted;
 }

--- a/structure/10_adapter-registry.md
+++ b/structure/10_adapter-registry.md
@@ -34,3 +34,34 @@ Do not add a second switch/list of adapter factories in request routing. Focused
 ## Scope boundary
 
 This decision does not change routed `apply_patch` behavior, Cursor structured-edit conversion, Azure/MiMo request construction, or provider wire selection. Those behaviors remain owned by their existing modules and focused tests. The registry exposes the universe and semantic relationships; the next stack layer consumes that metadata for generic conformance.
+
+## Moonshot `$ref`-with-siblings normalization
+
+Moonshot/Kimi enforce the draft-07 reading where `$ref` must stand alone and 400 the whole
+request when a node carries both. Codex's own deferred tool catalog emits exactly that shape,
+so the schema is not something a user can fix from configuration (issue #2673).
+
+[Decision Log]
+- 목적과 의도: Codex가 내보내는 `$ref` + 형제 키워드 스키마를 Moonshot이 받아들이는 형태로
+  바꾸되, 도구가 실제로 요구하는 제약을 잃지 않는다.
+- 기존 구현 및 제약 조건: JSON Schema 2020-12에서 `$ref`는 in-place applicator라 형제
+  키워드와 함께 적용된다. Moonshot은 이를 거부하므로 참조 대상을 노드 아래로 인라인해야 하고,
+  재귀 스키마는 유한해야 하며, 어댑터는 요청 경로에 있으므로 지연이 그대로 사용자에게 간다.
+- 검토한 주요 대안: (1) 형제 키워드를 버리고 순수 `$ref`만 남긴다. (2) 참조를 인라인하되
+  형제 키워드가 대상을 덮어쓴다. (3) 인라인하되 집합형 어서션은 합집합으로 합치고 나머지는
+  좁히는 쪽이 이긴다. (4) `allOf`로 감싼다.
+- 선택한 방식: (3). `required`는 합집합, `properties`는 병합, 나머지 키워드는 노드가 이긴다.
+  해석 불가능한 참조는 순수 `$ref`로 남기고, 깊이·노드·확장 예산을 각각 둔다.
+- 다른 대안 대신 이 방식을 선택한 이유: (1)은 노드가 좁힌 제약을 통째로 버린다. (2)는 대상이
+  요구하던 `a`를 형제의 `b`가 덮어써서, 양쪽 어느 쪽도 요청하지 않은 더 약한 계약을 조용히
+  내보냈다 — 리뷰가 지적한 정확한 결함이다. (4)는 Moonshot이 `allOf`를 어떻게 다루는지
+  확인된 근거가 없어 검증되지 않은 가정을 계약으로 만든다.
+- 장점, 단점 및 영향: 도구 계약이 보존된 채 Moonshot을 통과한다. 인라인은 대상을 복제하므로
+  큰 정의를 여러 노드가 참조하면 출력이 커질 수 있고, 예산이 소진되면 해당 노드는 빈 객체나
+  순수 `$ref`로 닫힌다 — 약해진 스키마를 절반만 내보내는 것보다 낫다. Moonshot 계열
+  `openai-chat` baseUrl에만 적용되고 다른 provider는 손대지 않는다.
+
+예산은 세 가지다. 확장 횟수만으로는 참조가 하나도 없는 깊은 스키마를 막지 못해서, 깊이와
+노드 수를 따로 둔다 — `google-tool-schema.ts`가 이미 쓰는 형태다. 두 가드 모두 제거했을 때
+실제로 red가 되는지 확인했고, 예산을 풀면 20k 깊이에서 `RangeError: Maximum call stack size
+exceeded`가 난다.

--- a/tests/moonshot-tool-schema.test.ts
+++ b/tests/moonshot-tool-schema.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, test } from "bun:test";
+import { createOpenAIChatAdapter as createOpenAIChatAdapterProduction } from "../src/adapters/openai-chat";
+import type { OcxParsedRequest, OcxTool } from "../src/types";
+import { withTestTranslatorBudget } from "./helpers/translator-budget";
+
+const createOpenAIChatAdapter = (
+  ...args: Parameters<typeof createOpenAIChatAdapterProduction>
+) => withTestTranslatorBudget(createOpenAIChatAdapterProduction(...args));
+
+function parsedRequest(tool: OcxTool): OcxParsedRequest {
+  return {
+    modelId: "k3",
+    context: {
+      messages: [{ role: "user", content: "run the tool", timestamp: 0 }],
+      tools: [tool],
+    },
+    stream: true,
+    options: {},
+  };
+}
+
+function adapterFor(baseUrl: string) {
+  return createOpenAIChatAdapter({ adapter: "openai-chat", baseUrl, apiKey: "k" });
+}
+
+async function emittedParameters(
+  baseUrl: string,
+  tool: OcxTool,
+): Promise<Record<string, unknown> | undefined> {
+  const request = await adapterFor(baseUrl).buildRequest(parsedRequest(tool));
+  const body = JSON.parse(request.body) as {
+    tools?: { function: { parameters?: Record<string, unknown> } }[];
+  };
+  return body.tools?.[0]?.function.parameters;
+}
+
+/** Every node that carries $ref alongside any other key — what Moonshot rejects. */
+function siblingRefPaths(node: unknown, path = "$"): string[] {
+  if (Array.isArray(node)) {
+    return node.flatMap((item, index) => siblingRefPaths(item, `${path}[${index}]`));
+  }
+  if (!node || typeof node !== "object") return [];
+  const record = node as Record<string, unknown>;
+  const keys = Object.keys(record);
+  const found = keys.includes("$ref") && keys.length > 1 ? [path] : [];
+  return [
+    ...found,
+    ...keys.flatMap(key => siblingRefPaths(record[key], `${path}.${key}`)),
+  ];
+}
+
+/**
+ * Reproduces issue #2673: Codex's deferred automation_update catalog deduplicates into
+ * $defs.__schema* nodes that keep type/minLength/format beside a $ref. Moonshot reads $ref
+ * as draft-07 (must stand alone) and 400s the whole request.
+ */
+const CODEX_STYLE_SCHEMA: Record<string, unknown> = {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  type: "object",
+  properties: {
+    threadId: { $ref: "#/$defs/__schema20" },
+    name: { $ref: "#/$defs/__schema5" },
+    mode: { $ref: "#/$defs/__schema2" },
+  },
+  required: ["threadId"],
+  additionalProperties: false,
+  $defs: {
+    __schema2: { type: "string", minLength: 1 },
+    __schema5: { description: "Short automation name.", $ref: "#/$defs/__schema2" },
+    __schema20: {
+      type: "string",
+      minLength: 1,
+      format: "uuid",
+      description: "Target thread UUID for heartbeat automations.",
+      $ref: "#/$defs/__schema2",
+    },
+  },
+};
+
+const MOONSHOT_HOSTS = [
+  "https://api.kimi.com/coding/v1",
+  "https://api.moonshot.ai/v1",
+  "https://api.moonshot.cn/v1",
+];
+
+describe("Moonshot tool schema normalization (issue #2673)", () => {
+  for (const baseUrl of MOONSHOT_HOSTS) {
+    test(`emits no $ref with sibling keywords for ${baseUrl}`, async () => {
+      const parameters = await emittedParameters(baseUrl, {
+        name: "automation_update",
+        description: "Manage automations.",
+        parameters: structuredClone(CODEX_STYLE_SCHEMA),
+      });
+
+      expect(parameters).toBeDefined();
+      expect(siblingRefPaths(parameters)).toEqual([]);
+    });
+  }
+
+  test("inlines the referenced schema under the node's own keywords", async () => {
+    const parameters = await emittedParameters("https://api.kimi.com/coding/v1", {
+      name: "automation_update",
+      description: "Manage automations.",
+      parameters: structuredClone(CODEX_STYLE_SCHEMA),
+    });
+
+    // The offending nodes are the definitions themselves, not the bare refs pointing at them,
+    // so the repair lands inside the $defs bag.
+    const defs = parameters?.$defs as Record<string, Record<string, unknown>>;
+    // __schema20 narrowed the referenced string with format/minLength; 2020-12 says both apply,
+    // so the constraints must survive rather than being stripped to satisfy the validator.
+    expect(defs.__schema20).toEqual({
+      type: "string",
+      minLength: 1,
+      format: "uuid",
+      description: "Target thread UUID for heartbeat automations.",
+    });
+    // description-only siblings were already tolerated, but must still resolve to a real schema.
+    expect(defs.__schema5).toEqual({
+      type: "string",
+      minLength: 1,
+      description: "Short automation name.",
+    });
+  });
+
+  test("leaves a bare $ref pointing at its definition", async () => {
+    const parameters = await emittedParameters("https://api.kimi.com/coding/v1", {
+      name: "automation_update",
+      description: "Manage automations.",
+      parameters: structuredClone(CODEX_STYLE_SCHEMA),
+    });
+
+    const properties = parameters?.properties as Record<string, Record<string, unknown>>;
+    expect(properties.mode).toEqual({ $ref: "#/$defs/__schema2" });
+    expect(parameters?.$defs).toBeDefined();
+  });
+
+  test("keeps a recursive $ref finite by dropping only the siblings on the cycle", async () => {
+    const parameters = await emittedParameters("https://api.kimi.com/coding/v1", {
+      name: "tree_tool",
+      parameters: {
+        type: "object",
+        properties: { tree: { $ref: "#/$defs/Tree" } },
+        $defs: {
+          Tree: {
+            type: "object",
+            description: "Recursive node.",
+            properties: { child: { description: "Nested.", $ref: "#/$defs/Tree" } },
+          },
+        },
+      },
+    });
+
+    expect(siblingRefPaths(parameters)).toEqual([]);
+    const tree = (parameters?.properties as Record<string, Record<string, unknown>>).tree;
+    expect(tree).toEqual({ $ref: "#/$defs/Tree" });
+    const defs = parameters?.$defs as Record<string, Record<string, unknown>>;
+    const child = (defs.Tree.properties as Record<string, unknown>).child;
+    // One expansion happens, then the cycle guard collapses the inner self-reference to a bare
+    // ref. That is what keeps the walk finite instead of expanding Tree forever.
+    expect(child).toEqual({
+      type: "object",
+      description: "Nested.",
+      properties: { child: { $ref: "#/$defs/Tree" } },
+    });
+  });
+
+  test("drops an unresolvable $ref instead of forwarding a rejected node", async () => {
+    const parameters = await emittedParameters("https://api.kimi.com/coding/v1", {
+      name: "remote_ref_tool",
+      parameters: {
+        type: "object",
+        properties: {
+          value: { type: "string", $ref: "https://example.com/schema.json#/Thing" },
+        },
+      },
+    });
+
+    expect(siblingRefPaths(parameters)).toEqual([]);
+    const properties = parameters?.properties as Record<string, Record<string, unknown>>;
+    expect(properties.value).toEqual({ type: "string" });
+  });
+
+  test("still stamps the root object type Moonshot requires (issue #228)", async () => {
+    const parameters = await emittedParameters("https://api.moonshot.ai/v1", {
+      name: "root_union_tool",
+      parameters: {
+        oneOf: [{ type: "object", properties: { mode: { type: "string" } } }],
+      },
+    });
+
+    expect(parameters?.type).toBe("object");
+    expect(parameters?.oneOf).toBeDefined();
+  });
+
+  test("preserves property names that overlap JavaScript prototype keys", async () => {
+    const properties = JSON.parse('{"__proto__":{"type":"string","$ref":"#/$defs/S"}}');
+    const parameters = await emittedParameters("https://api.kimi.com/coding/v1", {
+      name: "proto_tool",
+      parameters: { type: "object", properties, $defs: { S: { minLength: 2 } } },
+    });
+
+    const emitted = parameters?.properties as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(emitted, "__proto__")).toBe(true);
+    expect(siblingRefPaths(parameters)).toEqual([]);
+  });
+
+  test("leaves non-Moonshot openai-chat providers untouched", async () => {
+    const tool: OcxTool = {
+      name: "automation_update",
+      description: "Manage automations.",
+      parameters: structuredClone(CODEX_STYLE_SCHEMA),
+    };
+
+    const parameters = await emittedParameters("https://api.deepseek.com/v1", tool);
+
+    // The sibling-$ref nodes are Moonshot's problem alone; every other provider keeps the
+    // schema Codex sent, including the $defs bag verbatim.
+    expect(parameters?.$defs).toEqual(CODEX_STYLE_SCHEMA.$defs as Record<string, unknown>);
+    expect(siblingRefPaths(parameters).length).toBeGreaterThan(0);
+  });
+});

--- a/tests/moonshot-tool-schema.test.ts
+++ b/tests/moonshot-tool-schema.test.ts
@@ -165,7 +165,7 @@ describe("Moonshot tool schema normalization (issue #2673)", () => {
     });
   });
 
-  test("drops an unresolvable $ref instead of forwarding a rejected node", async () => {
+  test("keeps an unresolvable $ref rather than silently discarding what it constrained", async () => {
     const parameters = await emittedParameters("https://api.kimi.com/coding/v1", {
       name: "remote_ref_tool",
       parameters: {
@@ -178,7 +178,71 @@ describe("Moonshot tool schema normalization (issue #2673)", () => {
 
     expect(siblingRefPaths(parameters)).toEqual([]);
     const properties = parameters?.properties as Record<string, Record<string, unknown>>;
-    expect(properties.value).toEqual({ type: "string" });
+    // Both outcomes are lossy. Dropping the ref keeps the node's own keywords but throws away
+    // whatever the reference constrained, and nothing downstream can tell that happened. The
+    // bare ref loses the siblings instead, which preserves the identity of what was asked for
+    // and is still a shape Moonshot accepts.
+    expect(properties.value).toEqual({ $ref: "https://example.com/schema.json#/Thing" });
+  });
+
+
+  test("composes duplicate required, properties, and same-key assertions", async () => {
+    // The reviewer's first blocker. `$ref` under 2020-12 is an in-place applicator: the
+    // node and its target BOTH apply. Overwriting made a tool that required `a` and `b`
+    // ship requiring only `b`, and dropped `a` from properties entirely - a weaker contract
+    // than either side asked for, emitted silently.
+    const parameters = await emittedParameters("https://api.moonshot.ai/v1", {
+      name: "conjunction_tool",
+      parameters: {
+        type: "object",
+        $defs: {
+          Base: {
+            type: "object",
+            required: ["a"],
+            properties: { a: { type: "string", minLength: 2 } },
+            enum: ["x", "y"],
+          },
+        },
+        properties: {
+          value: {
+            $ref: "#/$defs/Base",
+            required: ["b"],
+            properties: { b: { type: "number" } },
+            minLength: 5,
+          },
+        },
+      },
+    });
+
+    expect(siblingRefPaths(parameters)).toEqual([]);
+    const properties = parameters?.properties as Record<string, Record<string, unknown>>;
+    const value = properties.value!;
+    // Set-valued assertions compose: neither side loses a member.
+    expect(value.required).toEqual(["a", "b"]);
+    expect(Object.keys(value.properties as Record<string, unknown>).sort()).toEqual(["a", "b"]);
+    // Scalar assertions keep the narrowing overwrite - the node means the tighter bound.
+    expect(value.minLength).toBe(5);
+    // A keyword only the target carries survives.
+    expect(value.enum).toEqual(["x", "y"]);
+  });
+
+  test("a deeply nested ref-free schema is bounded instead of exhausting the stack", async () => {
+    // The second blocker: the expansion budget counts $ref inlines only, so a schema with
+    // no refs at all walked unbounded. This nests far past any real tool.
+    // 20k deep. A bounded walk returns; an unbounded one blows the JS stack, which is
+    // exactly the provider-facing failure the budget exists to prevent.
+    let deep: Record<string, unknown> = { type: "string" };
+    for (let i = 0; i < 20_000; i += 1) {
+      deep = { type: "object", properties: { next: deep } };
+    }
+    const parameters = await emittedParameters("https://api.moonshot.ai/v1", {
+      name: "deep_tool",
+      parameters: { type: "object", properties: { root: deep } },
+    });
+
+    // It returns rather than throwing, and what it returns is still valid.
+    expect(parameters?.type).toBe("object");
+    expect(siblingRefPaths(parameters)).toEqual([]);
   });
 
   test("still stamps the root object type Moonshot requires (issue #228)", async () => {

--- a/tests/moonshot-tool-schema.test.ts
+++ b/tests/moonshot-tool-schema.test.ts
@@ -245,6 +245,42 @@ describe("Moonshot tool schema normalization (issue #2673)", () => {
     expect(siblingRefPaths(parameters)).toEqual([]);
   });
 
+
+  test("composes a property that both the target and the node define", async () => {
+    // The same conjunction problem `required` had, one level down. Letting the sibling
+    // win discarded the target's constraints for that member, so a property the tool
+    // declared with minLength shipped without it.
+    const parameters = await emittedParameters("https://api.moonshot.ai/v1", {
+      name: "shared_property_tool",
+      parameters: {
+        type: "object",
+        $defs: { Base: { type: "object", properties: { shared: { type: "string", minLength: 3 } } } },
+        properties: { v: { $ref: "#/$defs/Base", properties: { shared: { type: "string" } } } },
+      },
+    });
+
+    const v = (parameters?.properties as Record<string, Record<string, unknown>>).v!;
+    const shared = (v.properties as Record<string, Record<string, unknown>>).shared!;
+    expect(shared.minLength).toBe(3);
+    expect(shared.type).toBe("string");
+  });
+
+  test("leaves data-valued keywords alone, even when they look like schemas", async () => {
+    // `enum` lists VALUES. Recursing into it treated a literal object carrying a "$ref"
+    // string as a reference node and stripped the key, silently changing a value the tool
+    // declared as legal.
+    const parameters = await emittedParameters("https://api.moonshot.ai/v1", {
+      name: "enum_data_tool",
+      parameters: {
+        type: "object",
+        properties: { mode: { type: "object", enum: [{ $ref: "not-a-pointer", keep: 1 }] } },
+      },
+    });
+
+    const mode = (parameters?.properties as Record<string, Record<string, unknown>>).mode!;
+    expect(mode.enum).toEqual([{ $ref: "not-a-pointer", keep: 1 }]);
+  });
+
   test("still stamps the root object type Moonshot requires (issue #228)", async () => {
     const parameters = await emittedParameters("https://api.moonshot.ai/v1", {
       name: "root_union_tool",


### PR DESCRIPTION
## Summary

Fixes the Moonshot/Kimi HTTP 400 reported in #2673:

```text
Provider error 400: tools.function.parameters is not a valid moonshot flavored json schema,
details: <At path '$defs.__schema20': when using $ref, type should be defined in the referenced
schema instead of the parent schema>
```

JSON Schema 2020-12 makes `$ref` an in-place applicator: siblings stay in force and are combined with the referenced schema. Moonshot enforces the older draft-07 reading where `$ref` must stand alone, and rejects the whole request rather than ignoring the siblings.

The schema that trips it is generated by Codex itself, so no user configuration can avoid it. Captured verbatim from a Codex Desktop session rollout (`codex-cli 0.145.0`, deferred `automation_update` tool), where zod-to-json-schema deduplication produced:

```json
"__schema20": {
  "type": "string",
  "minLength": 1,
  "format": "uuid",
  "description": "Target thread UUID for heartbeat automations. ...",
  "$ref": "#/$defs/__schema2"
}
```

Eight nodes in that one schema carry siblings next to `$ref`; seven have only `description` (tolerated), and `__schema20` adds `type`/`minLength`/`format` — the node the API names. Any Kimi user in Codex Desktop hits this as soon as that tool loads.

**Change:** for Moonshot hosts (`api.kimi.com`, `api.moonshot.ai`, `api.moonshot.cn`), walk the tool parameter schema and inline the referenced schema underneath a sibling-carrying node's own keywords, then drop `$ref`. The node's keywords win, which is what 2020-12 says the node means, so `format: uuid` and `minLength` still reach the model instead of being stripped to appease the validator.

Design notes:

- A bare `$ref` (no siblings) is already legal for Moonshot and is left pointing at its definition rather than expanded, so the `$defs` bag is preserved and recursive schemas stay finite.
- Cycles collapse to the bare `$ref` form — lossy but valid, and it preserves the recursion that dropping the ref would erase.
- An unresolvable pointer (remote ref, malformed path, non-object target) drops `$ref` and keeps the siblings, since those are the only usable schema left.
- A bounded expansion budget (512, mirroring the node budget in `google-tool-schema.ts`) falls back to the bare ref so heavy `$defs` reuse cannot multiply the payload.
- `ensureRootObjectType()` still runs first, so the root-object guarantee added for #228 is preserved.

The host gate mirrors `isXaiSchemaTarget()`, so every other `openai-chat` provider emits byte-identical schemas — covered by an explicit test.

## Verification

- `bun test tests/moonshot-tool-schema.test.ts` — new focused suite, modeled on `tests/xai-tool-schema.test.ts`. It reproduces the issue-#2673 schema shape and asserts no node emits `$ref` alongside other keys for any of the three Moonshot hosts, plus inlining, bare-ref preservation, recursion, unresolvable refs, prototype-key safety, the #228 root-object case, and non-Moonshot passthrough.
- The suite was driven red first: before the adapter change the sibling-`$ref` assertions fail, which is what makes them non-vacuous.
- The 400 itself was reproduced from a captured Codex session rollout; the same payload through a Moonshot-compatible third-party endpoint returns 200, confirming the rejection comes from Moonshot's validator rather than the model or adapter transport.
- **Not run:** repository-wide `bun run typecheck` / `bun run test`, and commit/push used `--no-verify`, at the requester's explicit instruction. CI on this PR is the first full validation — please treat it as the gate before review.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No user-facing surface changes: a provider-scoped wire-format repair with no configuration, CLI, or GUI change.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (No auth, credential, workflow, or release-automation code is touched. The walker builds null-prototype records so a schema key named `__proto__` stays data, and both the cycle guard and expansion budget bound attacker-influenced schema depth and fan-out.)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Moonshot and Kimi tool compatibility by normalizing JSON Schema references and preserving supported constraints.
  * Added safeguards for recursive, unresolved, and deeply nested schemas.
  * Retained existing schema behavior for other OpenAI-compatible providers.

* **Tests**
  * Added comprehensive coverage for Moonshot endpoints and diverse tool-schema scenarios.

* **Documentation**
  * Documented Moonshot schema normalization behavior, including reference merging and processing limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->