### PR TITLE
feat(codex): serve the prompt-layer state over /api/codex-prompt

### DIFF
--- a/devlog/_plan/260802_codex_set_prompt_composer/021_wp2_amendments.md
+++ b/devlog/_plan/260802_codex_set_prompt_composer/021_wp2_amendments.md
@@ -1,0 +1,180 @@
+# 021 — WP2 amendments after the WP1 landing
+
+`020` was written against the WP1 *plan*. WP1 then landed and moved. An
+independent audit against the shipped `src/codex/prompt-layers.ts` returned seven
+findings; this document resolves each one and is the authority where it and
+`020` disagree.
+
+## 1. `inventory[]` and `extensionLayersEnumerable`
+
+`inventory[]` is a projection of the exported `LAYER_INVENTORY`
+(`prompt-layers.ts:87`), serialized field-for-field. The route defines no second
+table.
+
+`extensionLayersEnumerable` is derivable from nothing WP1 exports, and it should
+not be: it is a statement about what opencodex *can* know, not about the file.
+The route emits the literal `false` with the reasoning inline. If class E ever
+becomes enumerable, this constant is the one place that changes.
+
+The `~/.codex/...` paths in `020`'s example are illustrative only. WP1 returns
+resolved absolute paths (`prompt-layers.ts:145-150`) and the route forwards them
+unmodified.
+
+## 2. The plugins row
+
+`020`'s example lists `plugins` as `feature-gated` with key `features.plugins`.
+The landed inventory has it as `runtime-conditional` with a null key
+(`prompt-layers.ts:99`), because `core/src/mcp.rs:200` computes
+`selected_plugin_available || !capability_summaries().is_empty()` — the feature
+flag influences one operand but does not gate emission.
+
+The landed code is correct. `020`'s example is stale and is superseded here.
+Because the route projects the inventory rather than restating it, this class of
+drift cannot recur.
+
+## 3. Error translation
+
+Five `020` codes pass through unchanged: `unknown_layer`, `stale_revision`,
+`config_unreadable`, `developer_instructions_not_owned`, `invalid_characters`.
+
+Two are route-derived, because WP1 cannot express them:
+
+| Code | Derivation |
+|---|---|
+| `layer_not_toggleable` | id is in `LAYER_INVENTORY` but `class !== "config-toggle"`. Checked **before** `setToggle`, which collapses every non-toggle id into `unknown_layer` (`prompt-layers.ts:748`). |
+| `adopt_unsupported_form` | `previewAdopt().reason === "unsupported_form"` (`prompt-layers.ts:826`). `adoptDeveloperInstructions` collapses it to `developer_instructions_not_owned`, so the route previews first and translates. |
+
+Seven are pure request validation and never reach WP1: `invalid_body`,
+`too_many_layers`, `invalid_layer_id`, `duplicate_layer_id`, `invalid_title`,
+`body_too_large`, `composed_too_large`. WP1 validates characters and normalizes;
+size and shape policy is the route's.
+
+Four WP1 errors `020` never mentioned need HTTP mappings, because a user can
+reach every one of them:
+
+| WriteError | Status | Meaning to the user |
+|---|---|---|
+| `locked` | 409 | another writer holds the cross-process lock; retry |
+| `write_superseded` | 409 | the file moved under the write; re-read and retry |
+| `recovery_required` | 409 | a journal could not be replayed; terminal until repaired |
+| `store_unreadable` | 409 | declared but not currently emitted; mapped so a future emission is not a 500 |
+
+An unmapped `WriteError` must be a typecheck failure, not a runtime surprise:
+the mapping is a `Record<WriteError, number>`, so adding a variant upstream
+breaks the build until it is classified.
+
+## 4. The path seam
+
+`ManagementApiDeps` gains `codexPromptPaths?: Paths`. Every WP1 entry point the
+route calls already accepts `Paths` (audit §4 verified all seven signatures), so
+the seam is a single optional field threaded through, with production leaving it
+unset and WP1 resolving the real `CODEX_HOME`.
+
+This is not a convenience. A route test that could not inject paths would read
+and **write** the developer's live `~/.codex/config.toml` — the same class of
+incident `ManagementApiDeps.saveConfigPreservingClaudeCode` exists to prevent
+(`context.ts:29-35`).
+
+## 5. Repair, honestly scoped
+
+`020` claimed four drift branches. Two are implementable from WP1 exports today
+and two are not. WP2 ships what it can prove and says so:
+
+| drift | WP2 behavior |
+|---|---|
+| `projection-stale` | re-project: `writeCustomLayers(snapshot.custom, revision, paths)`. Preview via `composeProjection`. |
+| `store-missing` | `previewSalvage` / `salvageProjection`. The preview returns `backupDir`, not a reserved filename — a read-only preview must not reserve one — and the response says so. |
+| `journal-present` | **not repairable from this route.** Recovery lives inside `commit` (`prompt-layers.ts:627-654`) and is not exported. The route returns `409 repair_unsupported` naming the drift, and any ordinary mutation triggers recovery on its own path. |
+| `owned-malformed` | `mode: "adopt"` only, through `previewAdopt`/`adoptDeveloperInstructions`. `mode: "replace"` has no WP1 export and is **not shipped**; the route refuses it with `409 repair_unsupported`. |
+
+Inventing a recovery-only export inside WP2 would put a second write path next
+to WP1's journal — the one place in this unit where a bug destroys a user's
+configuration. Two unsupported branches, named in the response, beat a
+hand-rolled duplicate of the transaction.
+
+`020`'s sentence "the only endpoint that resolves a drift" is also wrong about
+the landed code: `commit` replays a journal before performing any mutation
+(`prompt-layers.ts:650-668`), so recovery is not exclusive to repair. GET
+remains read-only, which is the part that mattered.
+
+## 6. Size caps are the route's
+
+The `previewAdopt` docstring mentions a "cap" step the implementation does not
+perform. WP2 does not rely on it: `body > 64 KiB` and `composed > 128 KiB` are
+checked in the route, before any file access, on adopt exactly as on custom
+writes.
+
+## 7. Test consequences
+
+`tests/codex-prompt-route.test.ts` keeps `020`'s nineteen cases and adds four:
+
+20. every `WriteError` variant maps to a status — table-driven over the union
+21. `repair_unsupported` for `journal-present` and for `mode: "replace"`
+22. the injected `codexPromptPaths` is honored on **every** verb, proven by
+    asserting the fixture file changed and no other path was touched
+23. `plugins` — a `runtime-conditional` row — is refused by toggle, which is
+    case 5's table, pinned as a named regression for finding §2
+
+## 8. Round-2 corrections
+
+Three findings survived the first amendment. All three are real.
+
+### 8.1 Salvage writes its backup before the revision is checked
+
+`salvageProjection` creates the durable backup and only then enters `commit`,
+where `stale_revision` is evaluated (`prompt-layers.ts:942-955`, `:656-664`). A
+stale request therefore leaves a `.salvage-*.txt` file behind while returning
+409 and changing nothing else.
+
+This is not a data-loss bug — the backup is additive, the config and store are
+untouched, and the file is exactly the text the user already has. It is still a
+side effect on a refused request, so WP2 does not pretend otherwise:
+
+- The route **pre-checks the revision** against the freshly read snapshot before
+  calling `salvageProjection`, which removes the ordinary stale-tab path.
+- The race that remains (the file moves between the pre-check and WP1's own
+  check) can still orphan one backup. The response documents the backup
+  directory, and the repair preview already names it.
+- WP1 is **not** modified from WP2 to close this. Reordering a write inside the
+  transaction is a WP1 change with its own test obligations, and a route may not
+  reach into it.
+
+### 8.2 Adopt caps are checked after a read-only preview, not before any file access
+
+§6 said "before any file access", which is impossible: the value being measured
+lives in `config.toml`, so `previewAdopt` must read it first. The accurate rule
+is **after the read-only preview and before any write**. `previewAdopt` performs
+no write (`prompt-layers.ts:813`), so nothing has been mutated at the point the
+cap is applied.
+
+Both limits are **UTF-8 byte length**, not character count. The composed cap on
+adopt measures the imported body together with the already-enabled custom
+layers, because that is what `composeProjection` will produce.
+
+### 8.3 Repair scope, stated correctly
+
+§5's summary line said "projection-stale + store-missing". Three branches are
+supported and one is not:
+
+| drift | supported |
+|---|---|
+| `projection-stale` | yes — re-project |
+| `store-missing` | yes — salvage, with 8.1's pre-check |
+| `owned-malformed` | yes for `mode: "adopt"`; `mode: "replace"` refused |
+| `journal-present` | no — `repair_unsupported` |
+
+### 8.4 Test cases 20 and 22, restated
+
+Case 20 cannot be "table-driven over the union": a TypeScript union does not
+exist at runtime. Exhaustiveness is a **typecheck** property of
+`Record<WriteError, number>`; the runtime test iterates `WRITE_ERROR_STATUS` and
+asserts every entry is a valid 4xx. `store_unreadable` is declared but never
+emitted by landed WP1, so no test induces it — the mapping exists so a future
+emission is not a 500.
+
+Case 22 cannot prove "no other path was touched" from fixture mutation alone.
+It uses a **second decoy directory** holding sentinel `config.toml` and
+`opencodex-prompt.json` files, asserts they stay byte-identical across every
+verb, and proves read-only verbs by reading fixture-specific content out of the
+response rather than by observing a change.
+

--- a/src/server/management-api.ts
+++ b/src/server/management-api.ts
@@ -69,6 +69,7 @@ import { handleOauthAccountRoutes } from "./management/oauth-account-routes";
 import { handleComboRoutes } from "./management/combo-routes";
 import { handleSystemRoutes } from "./management/system-routes";
 import { handleSidebarRoutes } from "./management/sidebar-routes";
+import { handleCodexPromptRoutes } from "./management/codex-prompt-routes";
 import { handleIntegrationRoutes } from "./management/integration-routes";
 import { handleNativeIntegrationRoutes } from "./management/native-integration-routes";
 import type { ManagementContext } from "./management/context";
@@ -227,6 +228,7 @@ export async function handleManagementAPI(
     ??     (await handleIntegrationRoutes(ctx))
     ??     (await handleNativeIntegrationRoutes(ctx))
     ??     (await handleAgentSettingsRoutes(ctx))
+    ??     (await handleCodexPromptRoutes(ctx))
     ??     (await handleOauthAccountRoutes(ctx))
     ??     (await handleComboRoutes(ctx))
     ??     (await handleSystemRoutes(ctx))

--- a/src/server/management/codex-prompt-routes.ts
+++ b/src/server/management/codex-prompt-routes.ts
@@ -20,7 +20,7 @@
  * 020 wherever the landed WP1 module moved).
  */
 import { jsonResponse } from "../auth-cors";
-import { readManagementJsonBodyOr, rethrowManagementBodyTooLarge } from "./body";
+import { readManagementJsonBody, rethrowManagementBodyTooLarge } from "./body";
 import type { ManagementContext } from "./context";
 import {
   LAYER_INVENTORY,
@@ -191,9 +191,42 @@ function revisionOf(body: Record<string, unknown>): string | null {
   return typeof body.revision === "string" && body.revision.length > 0 ? body.revision : null;
 }
 
+/**
+ * Adopt-shaped size policy, applied wherever a config value is imported as a
+ * layer. The `owned-malformed` repair branch imports through the same WP1 call
+ * as `/adopt`, so it must pass the same caps: a route that enforces a limit on
+ * one path and not the other does not have a limit.
+ *
+ * Runs AFTER the read-only preview and BEFORE any write. The value being
+ * measured lives in config.toml, so it cannot be checked before a read; both
+ * limits are UTF-8 byte length, and the composed cap measures what
+ * `composeProjection` will actually produce — the imported layer plus every
+ * already-enabled custom layer.
+ */
+function adoptCapFailure(ctx: ManagementContext, decoded: string): Response | null {
+  if (utf8Bytes(decoded) > MAX_BODY_BYTES) {
+    return fail(ctx, "body_too_large", 400, `the existing value exceeds ${MAX_BODY_BYTES} bytes`);
+  }
+  const existing = readPromptLayers(paths(ctx)).custom;
+  const composed = composeProjection([
+    { id: "adopted", title: "Imported from config.toml", body: decoded, enabled: true },
+    ...existing,
+  ]);
+  if (utf8Bytes(composed) > MAX_COMPOSED_BYTES) {
+    return fail(ctx, "composed_too_large", 400, `the composed prompt would exceed ${MAX_COMPOSED_BYTES} bytes`);
+  }
+  return null;
+}
+
+/**
+ * Malformed JSON must be a 400, never an empty object. Swallowing a parse error
+ * into `{}` made a syntactically invalid adopt or repair request return a
+ * successful PREVIEW, and an invalid custom request return `stale_revision` —
+ * two answers that describe neither the request nor the file.
+ */
 async function readBody(ctx: ManagementContext): Promise<Record<string, unknown> | null> {
   try {
-    const parsed: unknown = await readManagementJsonBodyOr(ctx.req, {});
+    const parsed: unknown = await readManagementJsonBody(ctx.req);
     return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
       ? parsed as Record<string, unknown>
       : null;
@@ -253,6 +286,15 @@ export async function handleCodexPromptRoutes(ctx: ManagementContext): Promise<R
   if (url.pathname === "/api/codex-prompt/adopt" && req.method === "POST") {
     const body = await readBody(ctx);
     if (!body) return fail(ctx, "invalid_body", 400, "expected a JSON object");
+    // An unreadable file must say so. Both adopt and repair inspect read-derived
+    // state before ever reaching WP1's own `config_unreadable`, so without this
+    // the user was told "nothing to adopt" about a file we could not open.
+    const readState = readPromptLayers(paths(ctx));
+    if (!readState.readable) {
+      return fail(ctx, "config_unreadable", 409, "the configuration file exists but could not be read", {
+        path: readState.configPath,
+      });
+    }
     const preview = previewAdopt(paths(ctx));
 
     if (preview.reason === "nothing_to_adopt") {
@@ -274,25 +316,8 @@ export async function handleCodexPromptRoutes(ctx: ManagementContext): Promise<R
       return fail(ctx, "invalid_characters", 400, preview.detail, { path: preview.path, line: preview.line });
     }
 
-    // The WP1 docstring mentions a cap step its implementation does not perform,
-    // so the route enforces the same limits it applies to any other body. This
-    // runs AFTER the read-only preview and BEFORE any write: the value being
-    // measured lives in config.toml, so it cannot be checked before a read, and
-    // `previewAdopt` mutates nothing. Both limits are UTF-8 byte length.
-    const decoded = preview.decodedBody ?? "";
-    if (utf8Bytes(decoded) > MAX_BODY_BYTES) {
-      return fail(ctx, "body_too_large", 400, `the existing value exceeds ${MAX_BODY_BYTES} bytes`);
-    }
-    // Composed size is what `composeProjection` will actually produce: the
-    // imported layer plus every already-enabled custom layer, not the body alone.
-    const existing = readPromptLayers(paths(ctx)).custom;
-    const composedAfterAdopt = composeProjection([
-      { id: "adopted", title: "Imported from config.toml", body: decoded, enabled: true },
-      ...existing,
-    ]);
-    if (utf8Bytes(composedAfterAdopt) > MAX_COMPOSED_BYTES) {
-      return fail(ctx, "composed_too_large", 400, `the composed prompt would exceed ${MAX_COMPOSED_BYTES} bytes`);
-    }
+    const capFailure = adoptCapFailure(ctx, preview.decodedBody ?? "");
+    if (capFailure) return capFailure;
 
     if (body.confirm !== true) {
       // Preview writes nothing, by construction: previewAdopt is a pure read.
@@ -318,6 +343,11 @@ export async function handleCodexPromptRoutes(ctx: ManagementContext): Promise<R
     if (!body) return fail(ctx, "invalid_body", 400, "expected a JSON object");
     const snapshot = readPromptLayers(paths(ctx));
     const drift = snapshot.drift;
+    if (!snapshot.readable) {
+      return fail(ctx, "config_unreadable", 409, "the configuration file exists but could not be read", {
+        path: snapshot.configPath,
+      });
+    }
     if (drift === null) return fail(ctx, "nothing_to_repair", 409, "no drift is present");
 
     const confirm = body.confirm === true;
@@ -369,6 +399,12 @@ export async function handleCodexPromptRoutes(ctx: ManagementContext): Promise<R
 
     if (drift === "owned-malformed") {
       const mode = body.mode;
+      // Whitelist, not a single-value denial: an arbitrary or missing mode used to
+      // fall through to adopt, so a client that sent `mode: "reset"` mutated the
+      // file through a verb the contract never offered.
+      if (mode !== undefined && mode !== "adopt" && mode !== "replace") {
+        return fail(ctx, "invalid_body", 400, "mode must be \"adopt\" or \"replace\"", { drift });
+      }
       if (mode === "replace") {
         // No WP1 export performs this. Writing one here would put a second write
         // path beside the journal transaction, in the one place in this unit where
@@ -395,6 +431,11 @@ export async function handleCodexPromptRoutes(ctx: ManagementContext): Promise<R
         }, 200, req, ctx.config);
       }
       if (!revision) return fail(ctx, "stale_revision", 409, "revision required");
+      // Same import, same caps. This branch reaches adoptDeveloperInstructions
+      // exactly as /adopt does, so skipping the size policy here would mean the
+      // policy is bypassable by choosing the other endpoint.
+      const capFailure = adoptCapFailure(ctx, preview.decodedBody ?? "");
+      if (capFailure) return capFailure;
       return settle(ctx, adoptDeveloperInstructions(revision, paths(ctx)));
     }
 

--- a/src/server/management/codex-prompt-routes.ts
+++ b/src/server/management/codex-prompt-routes.ts
@@ -1,0 +1,411 @@
+/**
+ * /api/codex-prompt — the Codex prompt-layer surface.
+ *
+ * This route is an adapter over `src/codex/prompt-layers.ts`. It owns three
+ * things the core module deliberately does not: the projection of
+ * `LAYER_INVENTORY` into a DTO, request-shape and size policy, and the
+ * translation of a `WriteError` into an HTTP status. It owns no file access of
+ * its own and defines no second inventory.
+ *
+ * Privacy: the snapshot carries file paths and the user's own prompt text —
+ * text they typed into this same dashboard. It carries no token, API key, or
+ * account identifier, and nothing here is written to a log sink.
+ *
+ * Auth: the standard management gate covers /api/**, and unsafe methods already
+ * require Origin + CSRF. This is a local-config write, not an action that spends
+ * the user's GitHub identity, so it does NOT carry the `agent_consent_required`
+ * treatment `sidebar-routes.ts` applies to starring.
+ *
+ * Plan: devlog/_plan/260802_codex_set_prompt_composer/020 + 021 (021 supersedes
+ * 020 wherever the landed WP1 module moved).
+ */
+import { jsonResponse } from "../auth-cors";
+import { readManagementJsonBodyOr, rethrowManagementBodyTooLarge } from "./body";
+import type { ManagementContext } from "./context";
+import {
+  LAYER_INVENTORY,
+  adoptDeveloperInstructions,
+  composeProjection,
+  findInvalidCharacter,
+  normalizeBody,
+  previewAdopt,
+  previewSalvage,
+  readPromptLayers,
+  salvageProjection,
+  setToggle,
+  writeCustomLayers,
+  type CustomLayer,
+  type Paths,
+  type PromptLayerSnapshot,
+  type WriteError,
+  type WriteResult,
+} from "../../codex/prompt-layers";
+
+/**
+ * Third-party extension layers cannot be enumerated (devlog 001 class E), and no
+ * WP1 export can say so — it is a statement about what opencodex can know, not
+ * about the user's file. Stating it explicitly beats implying the inventory is
+ * exhaustive. If class E ever becomes enumerable, this constant is what changes.
+ */
+const EXTENSION_LAYERS_ENUMERABLE = false;
+
+/** Route policy, not a Codex limit: Codex validates nothing beyond readable-and-non-empty. */
+const MAX_LAYERS = 32;
+const MAX_TITLE_CHARS = 80;
+const MAX_BODY_BYTES = 64 * 1024;
+const MAX_COMPOSED_BYTES = 128 * 1024;
+
+const LAYER_ID = /^[a-z0-9]{6}$/;
+
+/**
+ * Every WriteError gets a status. This is a Record, not a switch with a default:
+ * a variant added to the union upstream breaks `bun run typecheck` here instead
+ * of silently becoming a 500 in front of a user.
+ */
+const WRITE_ERROR_STATUS: Record<WriteError, number> = {
+  config_unreadable: 409,
+  stale_revision: 409,
+  developer_instructions_not_owned: 409,
+  unknown_layer: 400,
+  store_unreadable: 409,
+  invalid_characters: 400,
+  write_superseded: 409,
+  recovery_required: 409,
+  locked: 409,
+};
+
+/** Read-only view for the route test that asserts every mapping is a client error. */
+export const WRITE_ERROR_STATUS_FOR_TESTS: Readonly<Record<WriteError, number>> = WRITE_ERROR_STATUS;
+
+function fail(ctx: ManagementContext, code: string, status: number, message?: string, extra?: Record<string, unknown>): Response {
+  return jsonResponse({ ok: false, code, ...(message ? { message } : {}), ...(extra ?? {}) }, status, ctx.req, ctx.config);
+}
+
+function failWrite(ctx: ManagementContext, result: Extract<WriteResult, { ok: false }>): Response {
+  return fail(ctx, result.error, WRITE_ERROR_STATUS[result.error], result.detail);
+}
+
+function paths(ctx: ManagementContext): Paths | undefined {
+  return ctx.deps.codexPromptPaths;
+}
+
+function utf8Bytes(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}
+
+/** The DTO. `inventory` is `LAYER_INVENTORY` serialized — never a second table. */
+function serialize(snapshot: PromptLayerSnapshot): Record<string, unknown> {
+  return {
+    configPath: snapshot.configPath,
+    storePath: snapshot.storePath,
+    configExists: snapshot.configExists,
+    readable: snapshot.readable,
+    developerInstructionsOwned: snapshot.developerInstructionsOwned,
+    drift: snapshot.drift,
+    revision: snapshot.revision,
+    inventory: LAYER_INVENTORY.map(d => ({
+      id: d.id,
+      class: d.class,
+      key: d.key,
+      default: d.default,
+      order: d.order,
+    })),
+    toggles: snapshot.toggles,
+    extensionLayersEnumerable: EXTENSION_LAYERS_ENUMERABLE,
+    custom: snapshot.custom,
+    modelInstructionsFile: snapshot.modelInstructionsFile,
+  };
+}
+
+function ok(ctx: ManagementContext, changed: boolean, snapshot: PromptLayerSnapshot): Response {
+  return jsonResponse({ ok: true, changed, snapshot: serialize(snapshot) }, 200, ctx.req, ctx.config);
+}
+
+/** Re-read after a mutation so the GUI can publish server truth, not optimistic state. */
+function settle(ctx: ManagementContext, result: WriteResult): Response {
+  return result.ok ? ok(ctx, result.changed, result.snapshot) : failWrite(ctx, result);
+}
+
+type ValidationError = { code: string; message: string; extra?: Record<string, unknown> };
+
+/**
+ * Request validation, entirely before any file access. WP1 validates characters
+ * and normalizes; shape and size policy is the route's, and the GUI's identical
+ * client-side rules are courtesy — this is the boundary.
+ */
+function validateLayers(raw: unknown): { layers: CustomLayer[] } | { error: ValidationError } {
+  if (!Array.isArray(raw)) return { error: { code: "invalid_body", message: "layers must be an array" } };
+  if (raw.length > MAX_LAYERS) {
+    return { error: { code: "too_many_layers", message: `at most ${MAX_LAYERS} layers` } };
+  }
+  const seen = new Set<string>();
+  const layers: CustomLayer[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return { error: { code: "invalid_body", message: "each layer must be an object" } };
+    }
+    const v = entry as Record<string, unknown>;
+    if (typeof v.id !== "string" || !LAYER_ID.test(v.id)) {
+      return { error: { code: "invalid_layer_id", message: "id must be six lowercase alphanumerics" } };
+    }
+    if (seen.has(v.id)) {
+      return { error: { code: "duplicate_layer_id", message: `duplicate id ${v.id}` } };
+    }
+    seen.add(v.id);
+    if (typeof v.title !== "string" || v.title.trim().length === 0
+      || v.title.length > MAX_TITLE_CHARS || /[\r\n]/.test(v.title)) {
+      return { error: { code: "invalid_title", message: "title must be 1-80 characters on a single line" } };
+    }
+    if (typeof v.body !== "string") {
+      return { error: { code: "invalid_body", message: "body must be a string" } };
+    }
+    if (typeof v.enabled !== "boolean") {
+      return { error: { code: "invalid_body", message: "enabled must be a boolean" } };
+    }
+    // Normalize first, then measure and scan: tabs and CRLF are normalized rather
+    // than rejected, so the cap must apply to what would actually be stored.
+    const body = normalizeBody(v.body);
+    if (utf8Bytes(body) > MAX_BODY_BYTES) {
+      return { error: { code: "body_too_large", message: `layer ${v.id} exceeds ${MAX_BODY_BYTES} bytes` } };
+    }
+    const invalid = findInvalidCharacter(body);
+    if (invalid !== null) {
+      return {
+        error: {
+          code: "invalid_characters",
+          message: `layer ${v.id}: code point ${invalid.position} is a ${invalid.reason}`,
+          extra: { layerId: v.id, position: invalid.position, reason: invalid.reason },
+        },
+      };
+    }
+    layers.push({ id: v.id, title: v.title, body, enabled: v.enabled });
+  }
+  const composed = composeProjection(layers);
+  if (utf8Bytes(composed) > MAX_COMPOSED_BYTES) {
+    return { error: { code: "composed_too_large", message: `composed prompt exceeds ${MAX_COMPOSED_BYTES} bytes` } };
+  }
+  return { layers };
+}
+
+function revisionOf(body: Record<string, unknown>): string | null {
+  return typeof body.revision === "string" && body.revision.length > 0 ? body.revision : null;
+}
+
+async function readBody(ctx: ManagementContext): Promise<Record<string, unknown> | null> {
+  try {
+    const parsed: unknown = await readManagementJsonBodyOr(ctx.req, {});
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch (error) {
+    rethrowManagementBodyTooLarge(error);
+    return null;
+  }
+}
+
+export async function handleCodexPromptRoutes(ctx: ManagementContext): Promise<Response | null> {
+  const { req, url } = ctx;
+  if (!url.pathname.startsWith("/api/codex-prompt")) return null;
+
+  if (url.pathname === "/api/codex-prompt" && req.method === "GET") {
+    // Pure read. A GET must never repair drift — it is reported here and
+    // resolved only by an explicit, revision-checked POST.
+    return jsonResponse(serialize(readPromptLayers(paths(ctx))), 200, req, ctx.config);
+  }
+
+  if (url.pathname === "/api/codex-prompt/toggle" && req.method === "PUT") {
+    const body = await readBody(ctx);
+    if (!body) return fail(ctx, "invalid_body", 400, "expected a JSON object");
+    const id = body.id;
+    if (typeof id !== "string") return fail(ctx, "invalid_body", 400, "id must be a string");
+    if (typeof body.enabled !== "boolean") return fail(ctx, "invalid_body", 400, "enabled must be a boolean");
+    const revision = revisionOf(body);
+    if (!revision) return fail(ctx, "stale_revision", 409, "revision required");
+
+    // Derived from the inventory, not a hand-maintained deny-list: classes base,
+    // feature-gated, runtime-conditional and extension-unknown are all covered by
+    // one rule, and a new upstream layer is protected the day WP1 lists it. The
+    // check must precede setToggle, which collapses every non-toggle id into
+    // unknown_layer.
+    const descriptor = LAYER_INVENTORY.find(d => d.id === id);
+    if (!descriptor) return fail(ctx, "unknown_layer", 400, `no layer ${id}`);
+    if (descriptor.class !== "config-toggle") {
+      return fail(ctx, "layer_not_toggleable", 409, `${id} is ${descriptor.class} and has no switch`, {
+        layerClass: descriptor.class,
+      });
+    }
+    return settle(ctx, setToggle(id, body.enabled, revision, paths(ctx)));
+  }
+
+  if (url.pathname === "/api/codex-prompt/custom" && req.method === "PUT") {
+    const body = await readBody(ctx);
+    if (!body) return fail(ctx, "invalid_body", 400, "expected a JSON object");
+    const revision = revisionOf(body);
+    if (!revision) return fail(ctx, "stale_revision", 409, "revision required");
+    const validated = validateLayers(body.layers);
+    if ("error" in validated) {
+      const status = validated.error.code === "invalid_characters" ? 400 : 400;
+      return fail(ctx, validated.error.code, status, validated.error.message, validated.error.extra);
+    }
+    return settle(ctx, writeCustomLayers(validated.layers, revision, paths(ctx)));
+  }
+
+  if (url.pathname === "/api/codex-prompt/adopt" && req.method === "POST") {
+    const body = await readBody(ctx);
+    if (!body) return fail(ctx, "invalid_body", 400, "expected a JSON object");
+    const preview = previewAdopt(paths(ctx));
+
+    if (preview.reason === "nothing_to_adopt") {
+      return fail(ctx, "nothing_to_adopt", 409, "developer_instructions is absent or already owned", {
+        path: preview.path,
+      });
+    }
+    if (preview.reason === "unsupported_form") {
+      // Translated here because adoptDeveloperInstructions collapses this into
+      // developer_instructions_not_owned, which would tell the user nothing about
+      // where their text is or why it cannot be imported.
+      return fail(ctx, "adopt_unsupported_form", 409, preview.detail, {
+        path: preview.path,
+        line: preview.line,
+        rawLine: preview.rawLine,
+      });
+    }
+    if (preview.reason === "invalid_characters") {
+      return fail(ctx, "invalid_characters", 400, preview.detail, { path: preview.path, line: preview.line });
+    }
+
+    // The WP1 docstring mentions a cap step its implementation does not perform,
+    // so the route enforces the same limits it applies to any other body. This
+    // runs AFTER the read-only preview and BEFORE any write: the value being
+    // measured lives in config.toml, so it cannot be checked before a read, and
+    // `previewAdopt` mutates nothing. Both limits are UTF-8 byte length.
+    const decoded = preview.decodedBody ?? "";
+    if (utf8Bytes(decoded) > MAX_BODY_BYTES) {
+      return fail(ctx, "body_too_large", 400, `the existing value exceeds ${MAX_BODY_BYTES} bytes`);
+    }
+    // Composed size is what `composeProjection` will actually produce: the
+    // imported layer plus every already-enabled custom layer, not the body alone.
+    const existing = readPromptLayers(paths(ctx)).custom;
+    const composedAfterAdopt = composeProjection([
+      { id: "adopted", title: "Imported from config.toml", body: decoded, enabled: true },
+      ...existing,
+    ]);
+    if (utf8Bytes(composedAfterAdopt) > MAX_COMPOSED_BYTES) {
+      return fail(ctx, "composed_too_large", 400, `the composed prompt would exceed ${MAX_COMPOSED_BYTES} bytes`);
+    }
+
+    if (body.confirm !== true) {
+      // Preview writes nothing, by construction: previewAdopt is a pure read.
+      return jsonResponse({
+        ok: true,
+        changed: false,
+        preview: {
+          rawLine: preview.rawLine,
+          decodedBody: preview.decodedBody,
+          path: preview.path,
+          line: preview.line,
+        },
+      }, 200, req, ctx.config);
+    }
+
+    const revision = revisionOf(body);
+    if (!revision) return fail(ctx, "stale_revision", 409, "revision required");
+    return settle(ctx, adoptDeveloperInstructions(revision, paths(ctx)));
+  }
+
+  if (url.pathname === "/api/codex-prompt/repair" && req.method === "POST") {
+    const body = await readBody(ctx);
+    if (!body) return fail(ctx, "invalid_body", 400, "expected a JSON object");
+    const snapshot = readPromptLayers(paths(ctx));
+    const drift = snapshot.drift;
+    if (drift === null) return fail(ctx, "nothing_to_repair", 409, "no drift is present");
+
+    const confirm = body.confirm === true;
+    const revision = revisionOf(body);
+
+    if (drift === "projection-stale") {
+      if (!confirm) {
+        return jsonResponse({
+          ok: true,
+          changed: false,
+          preview: { drift, projection: composeProjection(snapshot.custom) },
+        }, 200, req, ctx.config);
+      }
+      if (!revision) return fail(ctx, "stale_revision", 409, "revision required");
+      return settle(ctx, writeCustomLayers(snapshot.custom, revision, paths(ctx)));
+    }
+
+    if (drift === "store-missing") {
+      const preview = previewSalvage(paths(ctx));
+      if (preview.reason !== "ok") {
+        return fail(ctx, "nothing_to_repair", 409, "no live projection to salvage");
+      }
+      if (!confirm) {
+        // backupDir, not a filename: a read-only preview must not reserve one.
+        return jsonResponse({
+          ok: true,
+          changed: false,
+          preview: {
+            drift,
+            body: preview.body,
+            backupDir: preview.backupDir,
+            unrecoverable: preview.unrecoverable,
+          },
+        }, 200, req, ctx.config);
+      }
+      if (!revision) return fail(ctx, "stale_revision", 409, "revision required");
+      // Pre-check the revision against the snapshot we just read.
+      // `salvageProjection` writes its durable backup BEFORE entering the
+      // transaction that validates the revision (prompt-layers.ts:942-955), so a
+      // stale tab would otherwise leave an orphan .salvage-*.txt behind on a
+      // request that changes nothing. This closes the ordinary path; the narrow
+      // race between this check and WP1's own is documented in devlog 021 §8.1
+      // and is deliberately NOT fixed by reaching into WP1's write path.
+      if (revision !== snapshot.revision) {
+        return fail(ctx, "stale_revision", 409, "the configuration moved since it was read");
+      }
+      return settle(ctx, salvageProjection(revision, paths(ctx)));
+    }
+
+    if (drift === "owned-malformed") {
+      const mode = body.mode;
+      if (mode === "replace") {
+        // No WP1 export performs this. Writing one here would put a second write
+        // path beside the journal transaction, in the one place in this unit where
+        // a bug destroys a user's configuration.
+        return fail(ctx, "repair_unsupported", 409,
+          "replacing a reshaped developer_instructions is not supported from this route; edit the line by hand or adopt it", {
+            drift, path: snapshot.configPath,
+          });
+      }
+      const preview = previewAdopt(paths(ctx));
+      if (preview.reason === "unsupported_form") {
+        return fail(ctx, "adopt_unsupported_form", 409, preview.detail, {
+          drift, path: preview.path, line: preview.line, rawLine: preview.rawLine,
+        });
+      }
+      if (preview.reason !== "ok") {
+        return fail(ctx, "nothing_to_repair", 409, "nothing to adopt", { drift });
+      }
+      if (!confirm) {
+        return jsonResponse({
+          ok: true,
+          changed: false,
+          preview: { drift, rawLine: preview.rawLine, decodedBody: preview.decodedBody, line: preview.line },
+        }, 200, req, ctx.config);
+      }
+      if (!revision) return fail(ctx, "stale_revision", 409, "revision required");
+      return settle(ctx, adoptDeveloperInstructions(revision, paths(ctx)));
+    }
+
+    // journal-present: recovery lives inside WP1's commit and is not exported.
+    // Any ordinary mutation replays it on its own path, so the honest answer is
+    // to name the state rather than duplicate the transaction here.
+    return fail(ctx, "repair_unsupported", 409,
+      "a write journal is present; recovery runs automatically on the next write", {
+        drift, storePath: snapshot.storePath,
+      });
+  }
+
+  return null;
+}

--- a/src/server/management/codex-prompt-routes.ts
+++ b/src/server/management/codex-prompt-routes.ts
@@ -433,7 +433,8 @@ export async function handleCodexPromptRoutes(ctx: ManagementContext): Promise<R
       if (!revision) return fail(ctx, "stale_revision", 409, "revision required");
       // Same import, same caps. This branch reaches adoptDeveloperInstructions
       // exactly as /adopt does, so skipping the size policy here would mean the
-      // policy is bypassable by choosing the other endpoint.
+      // policy is bypassable by choosing the other endpoint. Proven by driving
+      // the "BOTH import paths" test red with this call deleted.
       const capFailure = adoptCapFailure(ctx, preview.decodedBody ?? "");
       if (capFailure) return capFailure;
       return settle(ctx, adoptDeveloperInstructions(revision, paths(ctx)));

--- a/src/server/management/context.ts
+++ b/src/server/management/context.ts
@@ -6,6 +6,7 @@ import type { StartupHealth } from "../../codex/autostart-health";
 import type { StartupInstallAction } from "../startup-action-control";
 import type { ManagementPrincipal } from "../management-auth";
 import type { CatalogModel } from "../../codex/catalog";
+import type { Paths as CodexPromptPaths } from "../../codex/prompt-layers";
 import type { injectGrokConfig } from "../../grok/inject";
 import type { removeDesktop3pStandardPivot, writeDesktop3pConfig } from "../../claude/desktop-3p";
 import type { RuntimePortState } from "../../config/process-state";
@@ -87,6 +88,14 @@ export interface ManagementApiDeps {
    * state inside their temporary Codex home.
    */
   codexLogGuardMaintenanceDeps?: CodexLogGuardMaintenanceDeps;
+  /**
+   * Prompt-layer path seam. Production leaves this unset and
+   * `src/codex/prompt-layers.ts` resolves the real CODEX_HOME. A route test
+   * that could not inject paths would read AND WRITE the developer's live
+   * ~/.codex/config.toml — the same class of incident
+   * `saveConfigPreservingClaudeCode` above exists to prevent.
+   */
+  codexPromptPaths?: CodexPromptPaths;
 }
 
 

--- a/tests/codex-prompt-route.test.ts
+++ b/tests/codex-prompt-route.test.ts
@@ -1,0 +1,447 @@
+/**
+ * Route-level contract for /api/codex-prompt (devlog 020 + 021).
+ *
+ * Every case injects fixture paths through `ManagementApiDeps.codexPromptPaths`, so
+ * no test may resolve the real CODEX_HOME. A decoy directory with sentinel files
+ * rides along and is asserted byte-identical after every verb: proving the
+ * fixture changed does not prove nothing else did.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleManagementAPI } from "../src/server/management-api";
+import { LAYER_INVENTORY, readPromptLayers } from "../src/codex/prompt-layers";
+import type { OcxConfig } from "../src/types";
+
+const MARKER = "# Auto-injected by opencodex";
+const config = { port: 10100, defaultProvider: "openai", providers: {} } as OcxConfig;
+const roots: string[] = [];
+
+interface Fixture {
+  configPath: string;
+  storePath: string;
+  decoyConfig: string;
+  decoyStore: string;
+}
+
+function fixture(configBytes?: string, storeBytes?: string): Fixture {
+  const root = mkdtempSync(join(tmpdir(), "ocx-prompt-route-"));
+  const decoy = mkdtempSync(join(tmpdir(), "ocx-prompt-decoy-"));
+  roots.push(root, decoy);
+  const configPath = join(root, "config.toml");
+  const storePath = join(root, "opencodex-prompt.json");
+  if (configBytes !== undefined) writeFileSync(configPath, configBytes, "utf8");
+  if (storeBytes !== undefined) writeFileSync(storePath, storeBytes, "utf8");
+  const decoyConfig = join(decoy, "config.toml");
+  const decoyStore = join(decoy, "opencodex-prompt.json");
+  writeFileSync(decoyConfig, "model = \"sentinel\"\n", "utf8");
+  writeFileSync(decoyStore, "{\"layers\":[]}", "utf8");
+  return { configPath, storePath, decoyConfig, decoyStore };
+}
+
+function storeJson(layers: unknown[]): string {
+  return JSON.stringify({ layers });
+}
+
+function ownedConfig(projection: string): string {
+  return MARKER + "\ndeveloper_instructions = \"" + projection + "\"\n";
+}
+
+function read(path: string): string | null {
+  return existsSync(path) ? readFileSync(path, "utf8") : null;
+}
+
+/** Sentinels must survive every verb: a route that wrote elsewhere is a route bug. */
+function expectDecoyUntouched(fx: Fixture): void {
+  expect(read(fx.decoyConfig)).toBe("model = \"sentinel\"\n");
+  expect(read(fx.decoyStore)).toBe("{\"layers\":[]}");
+}
+
+async function call(
+  method: string,
+  pathname: string,
+  fx: Fixture,
+  body?: unknown,
+): Promise<{ status: number; body: any; routed: boolean }> {
+  const url = new URL("http://127.0.0.1:10100" + pathname);
+  const headers: Record<string, string> = { host: "127.0.0.1:10100" };
+  if (body !== undefined) headers["content-type"] = "application/json";
+  const req = new Request(url, {
+    method,
+    headers,
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+  const res = await handleManagementAPI(req, url, config, {
+    codexPromptPaths: { configPath: fx.configPath, storePath: fx.storePath },
+  });
+  if (!res) return { status: 404, body: null, routed: false };
+  const raw = await res.text();
+  const parsed: unknown = raw ? JSON.parse(raw) : null;
+  expectDecoyUntouched(fx);
+  return { status: res.status, body: parsed, routed: true };
+}
+
+async function revision(fx: Fixture): Promise<string> {
+  const res = await call("GET", "/api/codex-prompt", fx);
+  return res.body.revision as string;
+}
+
+afterEach(() => {
+  while (roots.length) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+describe("GET /api/codex-prompt", () => {
+  test("1. returns the snapshot with the full inventory", async () => {
+    const fx = fixture("include_apps_instructions = false\n");
+    const res = await call("GET", "/api/codex-prompt", fx);
+    expect(res.status).toBe(200);
+    expect(res.body.inventory).toHaveLength(LAYER_INVENTORY.length);
+    expect(res.body.inventory.map((d: any) => d.id)).toEqual(LAYER_INVENTORY.map(d => d.id));
+    expect(res.body.configPath).toBe(fx.configPath);
+    expect(res.body.extensionLayersEnumerable).toBe(false);
+    const apps = res.body.toggles.find((t: any) => t.id === "apps");
+    expect(apps.userFileValue).toBe(false);
+  });
+
+  test("2. a missing config is a first run, not an error", async () => {
+    const fx = fixture();
+    const res = await call("GET", "/api/codex-prompt", fx);
+    expect(res.status).toBe(200);
+    expect(res.body.configExists).toBe(false);
+    expect(res.body.readable).toBe(true);
+    for (const t of res.body.toggles) expect(t.userFileValue).toBeNull();
+  });
+
+  test("17. every drift state is reported, and GET writes nothing", async () => {
+    // owned-malformed: marker-adjacent but reshaped.
+    const fx = fixture(MARKER + "\ndeveloper_instructions = 'single quoted'\n");
+    const before = read(fx.configPath);
+    const res = await call("GET", "/api/codex-prompt", fx);
+    expect(res.body.drift).toBe("owned-malformed");
+    expect(read(fx.configPath)).toBe(before);
+    expect(existsSync(fx.storePath)).toBe(false);
+  });
+
+  test("17b. store-missing is reported without repairing it", async () => {
+    const fx = fixture(ownedConfig("Be brief."));
+    const before = read(fx.configPath);
+    const res = await call("GET", "/api/codex-prompt", fx);
+    expect(res.body.drift).toBe("store-missing");
+    expect(read(fx.configPath)).toBe(before);
+  });
+});
+
+describe("PUT /api/codex-prompt/toggle", () => {
+  test("3. flips a value and echoes the new snapshot", async () => {
+    const fx = fixture("");
+    const rev = await revision(fx);
+    const res = await call("PUT", "/api/codex-prompt/toggle", fx, { id: "apps", enabled: false, revision: rev });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(read(fx.configPath)).toContain("include_apps_instructions = false");
+    const apps = res.body.snapshot.toggles.find((t: any) => t.id === "apps");
+    expect(apps.userFileValue).toBe(false);
+  });
+
+  test("4. an unknown id is refused", async () => {
+    const fx = fixture("");
+    const rev = await revision(fx);
+    const res = await call("PUT", "/api/codex-prompt/toggle", fx, { id: "no-such-layer", enabled: false, revision: rev });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("unknown_layer");
+  });
+
+  test("5. every non-config-toggle inventory id is refused, and nothing is written", async () => {
+    // Ask item 9 at the API boundary. Table-driven over LAYER_INVENTORY, so a new
+    // upstream layer is covered the day WP1 lists it.
+    const locked = LAYER_INVENTORY.filter(d => d.class !== "config-toggle");
+    expect(locked.length).toBeGreaterThan(0);
+    for (const descriptor of locked) {
+      const fx = fixture("");
+      const rev = await revision(fx);
+      const before = read(fx.configPath);
+      const res = await call("PUT", "/api/codex-prompt/toggle", fx, { id: descriptor.id, enabled: false, revision: rev });
+      expect(res.status).toBe(409);
+      expect(res.body.code).toBe("layer_not_toggleable");
+      expect(res.body.layerClass).toBe(descriptor.class);
+      expect(read(fx.configPath)).toBe(before);
+    }
+  });
+
+  test("6. every inventory id has one class, and every config-toggle has a key", async () => {
+    // The partition guard: without it the inventory can drift into a state where
+    // a row is neither switchable nor explained.
+    const ids = new Set<string>();
+    for (const d of LAYER_INVENTORY) {
+      expect(ids.has(d.id)).toBe(false);
+      ids.add(d.id);
+      expect(["base", "config-toggle", "feature-gated", "runtime-conditional", "extension-unknown"]).toContain(d.class);
+      if (d.class === "config-toggle") expect(typeof d.key).toBe("string");
+      if (d.class === "base" || d.class === "runtime-conditional") expect(d.key).toBeNull();
+    }
+  });
+
+  test("23. plugins is runtime-conditional and cannot be toggled", async () => {
+    // Named regression for devlog 021 §2: 020's example called this feature-gated.
+    const plugins = LAYER_INVENTORY.find(d => d.id === "plugins")!;
+    expect(plugins.class).toBe("runtime-conditional");
+    expect(plugins.key).toBeNull();
+    const fx = fixture("");
+    const rev = await revision(fx);
+    const res = await call("PUT", "/api/codex-prompt/toggle", fx, { id: "plugins", enabled: false, revision: rev });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("layer_not_toggleable");
+  });
+
+  test("9a. a stale revision is refused", async () => {
+    const fx = fixture("");
+    const res = await call("PUT", "/api/codex-prompt/toggle", fx, { id: "apps", enabled: false, revision: "sha256:stale" });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("stale_revision");
+  });
+
+  test("10b. toggles still work when developer_instructions is unowned", async () => {
+    const fx = fixture("developer_instructions = \"external\"\n");
+    const rev = await revision(fx);
+    const res = await call("PUT", "/api/codex-prompt/toggle", fx, { id: "apps", enabled: false, revision: rev });
+    expect(res.status).toBe(200);
+    expect(read(fx.configPath)).toContain("developer_instructions = \"external\"");
+  });
+});
+
+describe("PUT /api/codex-prompt/custom", () => {
+  const good = { id: "abc123", title: "House rules", body: "Be brief.", enabled: true };
+
+  test("7. round-trips order", async () => {
+    const fx = fixture("");
+    const rev = await revision(fx);
+    const res = await call("PUT", "/api/codex-prompt/custom", fx, {
+      revision: rev,
+      layers: [good, { id: "def456", title: "Second", body: "Then this.", enabled: true }],
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.snapshot.custom.map((l: any) => l.id)).toEqual(["abc123", "def456"]);
+    expect(read(fx.configPath)).toContain("Be brief.\\n\\nThen this.");
+  });
+
+  test("8. each validation rule is enforced", async () => {
+    const fx = fixture("");
+    const rev = await revision(fx);
+    const cases: Array<[unknown, string]> = [
+      ["not-an-array", "invalid_body"],
+      [Array.from({ length: 33 }, (_, i) => ({ ...good, id: String(i).padStart(6, "a").slice(0, 6) })), "too_many_layers"],
+      [[{ ...good, id: "BAD" }], "invalid_layer_id"],
+      [[good, good], "duplicate_layer_id"],
+      [[{ ...good, title: "" }], "invalid_title"],
+      [[{ ...good, title: "x".repeat(81) }], "invalid_title"],
+      [[{ ...good, title: "one\ntwo" }], "invalid_title"],
+      [[{ ...good, body: "x".repeat(64 * 1024 + 1) }], "body_too_large"],
+      [[{ ...good, enabled: "yes" }], "invalid_body"],
+    ];
+    for (const [layers, code] of cases) {
+      const res = await call("PUT", "/api/codex-prompt/custom", fx, { revision: rev, layers });
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe(code);
+    }
+    expect(existsSync(fx.storePath)).toBe(false);
+  });
+
+  test("8b. a composed prompt over the cap is refused", async () => {
+    const fx = fixture("");
+    const rev = await revision(fx);
+    const body = "y".repeat(60 * 1024);
+    const layers = ["aaaaaa", "bbbbbb", "cccccc"].map(id => ({ id, title: "big", body, enabled: true }));
+    const res = await call("PUT", "/api/codex-prompt/custom", fx, { revision: rev, layers });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("composed_too_large");
+  });
+
+  test("19. a control character is rejected with its position", async () => {
+    const fx = fixture("");
+    const rev = await revision(fx);
+    const res = await call("PUT", "/api/codex-prompt/custom", fx, {
+      revision: rev,
+      layers: [{ ...good, body: "ok\u0007bad" }],
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("invalid_characters");
+    expect(res.body.position).toBe(2);
+  });
+
+  test("10. an unowned developer_instructions is refused", async () => {
+    const fx = fixture("developer_instructions = \"hand written\"\n");
+    const rev = await revision(fx);
+    const res = await call("PUT", "/api/codex-prompt/custom", fx, { revision: rev, layers: [good] });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("developer_instructions_not_owned");
+    expect(read(fx.configPath)).toContain("hand written");
+  });
+
+  test("9b. a stale revision is refused on custom too", async () => {
+    const fx = fixture("");
+    const res = await call("PUT", "/api/codex-prompt/custom", fx, { revision: "sha256:stale", layers: [good] });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("stale_revision");
+  });
+
+  test("18. tabs and CRLF normalize rather than fail", async () => {
+    const fx = fixture("");
+    const rev = await revision(fx);
+    const res = await call("PUT", "/api/codex-prompt/custom", fx, {
+      revision: rev,
+      layers: [{ ...good, body: "a\tb\r\nc" }],
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.snapshot.custom[0].body).toBe("a    b\nc");
+  });
+});
+
+describe("POST /api/codex-prompt/adopt", () => {
+  test("14. preview returns the raw line and writes nothing", async () => {
+    const fx = fixture("developer_instructions = \"Answer in Korean.\"\n");
+    const before = read(fx.configPath);
+    const res = await call("POST", "/api/codex-prompt/adopt", fx, { confirm: false });
+    expect(res.status).toBe(200);
+    expect(res.body.changed).toBe(false);
+    expect(res.body.preview.decodedBody).toBe("Answer in Korean.");
+    expect(read(fx.configPath)).toBe(before);
+    expect(existsSync(fx.storePath)).toBe(false);
+  });
+
+  test("15. adopt without confirm writes nothing", async () => {
+    const fx = fixture("developer_instructions = \"Answer in Korean.\"\n");
+    await call("POST", "/api/codex-prompt/adopt", fx, {});
+    expect(existsSync(fx.storePath)).toBe(false);
+  });
+
+  test("15b. a confirmed adopt imports the value as one layer", async () => {
+    const fx = fixture("developer_instructions = \"Answer in Korean.\"\n");
+    const rev = await revision(fx);
+    const res = await call("POST", "/api/codex-prompt/adopt", fx, { confirm: true, revision: rev });
+    expect(res.status).toBe(200);
+    expect(res.body.snapshot.custom).toHaveLength(1);
+    expect(res.body.snapshot.custom[0].body).toBe("Answer in Korean.");
+    expect(res.body.snapshot.developerInstructionsOwned).toBe(true);
+  });
+
+  test("16. an unsupported form is refused with path and line", async () => {
+    const fx = fixture("model = \"gpt-5\"\ndeveloper_instructions = '''multi\nline'''\n");
+    const res = await call("POST", "/api/codex-prompt/adopt", fx, { confirm: true, revision: await revision(fx) });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("adopt_unsupported_form");
+    expect(res.body.path).toBe(fx.configPath);
+    expect(res.body.line).toBe(2);
+  });
+});
+
+describe("POST /api/codex-prompt/repair", () => {
+  test("18b. requires a matching revision", async () => {
+    const fx = fixture(ownedConfig("Be brief."), storeJson([
+      { id: "aaaaaa", title: "Old", body: "Something else.", enabled: true },
+    ]));
+    const res = await call("POST", "/api/codex-prompt/repair", fx, { confirm: true, revision: "sha256:stale" });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("stale_revision");
+  });
+
+  test("20a. projection-stale re-projects from the store", async () => {
+    const fx = fixture(ownedConfig("Be brief."), storeJson([
+      { id: "aaaaaa", title: "Old", body: "Something else.", enabled: true },
+    ]));
+    const get = await call("GET", "/api/codex-prompt", fx);
+    expect(get.body.drift).toBe("projection-stale");
+    const preview = await call("POST", "/api/codex-prompt/repair", fx, { confirm: false });
+    expect(preview.body.preview.projection).toBe("Something else.");
+    const res = await call("POST", "/api/codex-prompt/repair", fx, { confirm: true, revision: get.body.revision });
+    expect(res.status).toBe(200);
+    expect(res.body.snapshot.drift).toBeNull();
+    expect(read(fx.configPath)).toContain("Something else.");
+  });
+
+  test("20b. store-missing previews a salvage naming its backup directory", async () => {
+    const fx = fixture(ownedConfig("Be brief."));
+    const preview = await call("POST", "/api/codex-prompt/repair", fx, { confirm: false });
+    expect(preview.status).toBe(200);
+    expect(preview.body.preview.body).toBe("Be brief.");
+    expect(preview.body.preview.unrecoverable.length).toBeGreaterThan(0);
+    expect(existsSync(fx.storePath)).toBe(false);
+  });
+
+  test("20c. a stale salvage is refused before any backup file is created", async () => {
+    // devlog 021 §8.1: salvageProjection writes its backup BEFORE the transaction
+    // validates the revision, so the route pre-checks it.
+    const fx = fixture(ownedConfig("Be brief."));
+    const res = await call("POST", "/api/codex-prompt/repair", fx, { confirm: true, revision: "sha256:stale" });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("stale_revision");
+    const dirFiles = readdirSync(join(fx.storePath, "..")).filter(f => f.includes("salvage"));
+    expect(dirFiles).toHaveLength(0);
+  });
+
+  test("21a. journal-present is refused as repair_unsupported", async () => {
+    const fx = fixture(ownedConfig("Be brief."), storeJson([]));
+    writeFileSync(fx.storePath.replace(/\.json$/, "") + ".journal", "{}", "utf8");
+    const res = await call("POST", "/api/codex-prompt/repair", fx, { confirm: true, revision: await revision(fx) });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("repair_unsupported");
+    expect(res.body.drift).toBe("journal-present");
+  });
+
+  test("21b. owned-malformed refuses mode replace and offers adopt", async () => {
+    const fx = fixture(MARKER + "\ndeveloper_instructions = 'reshaped'\n");
+    const replace = await call("POST", "/api/codex-prompt/repair", fx, { confirm: true, mode: "replace", revision: await revision(fx) });
+    expect(replace.status).toBe(409);
+    expect(replace.body.code).toBe("repair_unsupported");
+    const adopt = await call("POST", "/api/codex-prompt/repair", fx, { confirm: false });
+    expect(adopt.status).toBe(409);
+    expect(adopt.body.code).toBe("adopt_unsupported_form");
+  });
+
+  test("repairing a clean file is refused", async () => {
+    const fx = fixture("");
+    const res = await call("POST", "/api/codex-prompt/repair", fx, { confirm: true, revision: await revision(fx) });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("nothing_to_repair");
+  });
+});
+
+describe("dispatch and safety", () => {
+  test("13. an unhandled path returns null so the chain continues", async () => {
+    const fx = fixture("");
+    const res = await call("GET", "/api/codex-prompt/nope", fx);
+    expect(res.routed).toBe(false);
+  });
+
+  test("20. every mapped write error carries a client-facing status", async () => {
+    // A TypeScript union does not exist at runtime, so exhaustiveness is a
+    // typecheck property of Record<WriteError, number>. This asserts the values.
+    const { WRITE_ERROR_STATUS_FOR_TESTS } = await import("../src/server/management/codex-prompt-routes");
+    const statuses = Object.values(WRITE_ERROR_STATUS_FOR_TESTS);
+    expect(statuses.length).toBeGreaterThanOrEqual(9);
+    for (const status of statuses) expect(status).toBeGreaterThanOrEqual(400);
+    for (const status of statuses) expect(status).toBeLessThan(500);
+  });
+
+  test("22. the injected paths are honored on every verb", async () => {
+    const fx = fixture("");
+    const rev = await revision(fx);
+    await call("PUT", "/api/codex-prompt/toggle", fx, { id: "apps", enabled: false, revision: rev });
+    const after = readPromptLayers({ configPath: fx.configPath, storePath: fx.storePath });
+    expect(after.toggles.find(t => t.id === "apps")!.userFileValue).toBe(false);
+    await call("PUT", "/api/codex-prompt/custom", fx, {
+      revision: after.revision,
+      layers: [{ id: "abc123", title: "T", body: "B", enabled: true }],
+    });
+    expect(read(fx.storePath)).toContain("abc123");
+    expectDecoyUntouched(fx);
+  });
+
+  test("12. no response serializes a token, key, or account identifier", async () => {
+    const fx = fixture("include_apps_instructions = false\n");
+    const res = await call("GET", "/api/codex-prompt", fx);
+    const raw = JSON.stringify(res.body);
+    expect(raw).not.toMatch(/sk-|Bearer |access_token|account_id|refresh_token/);
+  });
+});
+

--- a/tests/codex-prompt-route.test.ts
+++ b/tests/codex-prompt-route.test.ts
@@ -7,7 +7,7 @@
  * fixture changed does not prove nothing else did.
  */
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { handleManagementAPI } from "../src/server/management-api";
@@ -23,6 +23,7 @@ interface Fixture {
   storePath: string;
   decoyConfig: string;
   decoyStore: string;
+  decoyHome: string;
 }
 
 function fixture(configBytes?: string, storeBytes?: string): Fixture {
@@ -37,7 +38,7 @@ function fixture(configBytes?: string, storeBytes?: string): Fixture {
   const decoyStore = join(decoy, "opencodex-prompt.json");
   writeFileSync(decoyConfig, "model = \"sentinel\"\n", "utf8");
   writeFileSync(decoyStore, "{\"layers\":[]}", "utf8");
-  return { configPath, storePath, decoyConfig, decoyStore };
+  return { configPath, storePath, decoyConfig, decoyStore, decoyHome: decoy };
 }
 
 function storeJson(layers: unknown[]): string {
@@ -52,7 +53,12 @@ function read(path: string): string | null {
   return existsSync(path) ? readFileSync(path, "utf8") : null;
 }
 
-/** Sentinels must survive every verb: a route that wrote elsewhere is a route bug. */
+/**
+ * Sentinels must survive every verb. The decoy is installed as CODEX_HOME for the
+ * duration of each request, so this is not a vacuous check: a regression that
+ * dropped `codexPromptPaths` would fall back to CODEX_HOME and land here, on a
+ * temp directory, instead of on the developer's real ~/.codex.
+ */
 function expectDecoyUntouched(fx: Fixture): void {
   expect(read(fx.decoyConfig)).toBe("model = \"sentinel\"\n");
   expect(read(fx.decoyStore)).toBe("{\"layers\":[]}");
@@ -72,9 +78,21 @@ async function call(
     headers,
     ...(body === undefined ? {} : { body: JSON.stringify(body) }),
   });
-  const res = await handleManagementAPI(req, url, config, {
-    codexPromptPaths: { configPath: fx.configPath, storePath: fx.storePath },
-  });
+  // The decoy is CODEX_HOME for the duration of the call. Without this the
+  // sentinel assertion proves nothing: a route that ignored the injected paths
+  // would write to the developer's real home and both sentinels would still
+  // match. With it, that same regression lands on the decoy and is caught.
+  const previousHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = fx.decoyHome;
+  let res: Response | null;
+  try {
+    res = await handleManagementAPI(req, url, config, {
+      codexPromptPaths: { configPath: fx.configPath, storePath: fx.storePath },
+    });
+  } finally {
+    if (previousHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousHome;
+  }
   if (!res) return { status: 404, body: null, routed: false };
   const raw = await res.text();
   const parsed: unknown = raw ? JSON.parse(raw) : null;
@@ -445,3 +463,139 @@ describe("dispatch and safety", () => {
   });
 });
 
+describe("020 coverage completions", () => {
+  test("11. an unreadable config refuses every mutation by name", async () => {
+    // chmod 000 is not honored for root, and Windows ignores the mode entirely.
+    // A directory in place of the file is unreadable on every platform we ship.
+    const root = mkdtempSync(join(tmpdir(), "ocx-prompt-unreadable-"));
+    const decoy = mkdtempSync(join(tmpdir(), "ocx-prompt-decoy-"));
+    roots.push(root, decoy);
+    const configPath = join(root, "config.toml");
+    mkdirSync(configPath);
+    const fx: Fixture = {
+      configPath,
+      storePath: join(root, "opencodex-prompt.json"),
+      decoyConfig: join(decoy, "config.toml"),
+      decoyStore: join(decoy, "opencodex-prompt.json"),
+      decoyHome: decoy,
+    };
+    writeFileSync(fx.decoyConfig, "model = \"sentinel\"\n", "utf8");
+    writeFileSync(fx.decoyStore, "{\"layers\":[]}", "utf8");
+
+    const get = await call("GET", "/api/codex-prompt", fx);
+    expect(get.body.readable).toBe(false);
+
+    const toggle = await call("PUT", "/api/codex-prompt/toggle", fx, {
+      id: "apps", enabled: false, revision: get.body.revision,
+    });
+    expect(toggle.status).toBe(409);
+    expect(toggle.body.code).toBe("config_unreadable");
+
+    const custom = await call("PUT", "/api/codex-prompt/custom", fx, {
+      revision: get.body.revision,
+      layers: [{ id: "abc123", title: "T", body: "B", enabled: true }],
+    });
+    expect(custom.status).toBe(409);
+    expect(custom.body.code).toBe("config_unreadable");
+
+    const adopt = await call("POST", "/api/codex-prompt/adopt", fx, { confirm: true, revision: get.body.revision });
+    expect(adopt.status).toBe(409);
+    expect(adopt.body.code).toBe("config_unreadable");
+
+    const repair = await call("POST", "/api/codex-prompt/repair", fx, { confirm: true, revision: get.body.revision });
+    expect(repair.status).toBe(409);
+    expect(repair.body.code).toBe("config_unreadable");
+  });
+
+  test("12b. a hostile Origin is rejected before the route runs", async () => {
+    const fx = fixture("");
+    const url = new URL("http://127.0.0.1:10100/api/codex-prompt/toggle");
+    const req = new Request(url, {
+      method: "PUT",
+      headers: {
+        host: "127.0.0.1:10100",
+        origin: "http://evil.example",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ id: "apps", enabled: false, revision: "sha256:x" }),
+    });
+    const res = await handleManagementAPI(req, url, config, {
+      codexPromptPaths: { configPath: fx.configPath, storePath: fx.storePath },
+    });
+    expect(res).not.toBeNull();
+    expect(res!.status).toBeGreaterThanOrEqual(400);
+    expect(read(fx.configPath)).toBe("");
+  });
+
+  test("9c. adopt refuses a stale revision", async () => {
+    const fx = fixture("developer_instructions = \"Answer in Korean.\"\n");
+    const res = await call("POST", "/api/codex-prompt/adopt", fx, { confirm: true, revision: "sha256:stale" });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("stale_revision");
+    expect(existsSync(fx.storePath)).toBe(false);
+  });
+
+  test("17c. journal-present is reported by GET, which writes nothing", async () => {
+    const fx = fixture(ownedConfig("Be brief."), storeJson([]));
+    const journal = fx.storePath.replace(/\.json$/, "") + ".journal";
+    writeFileSync(journal, "{}", "utf8");
+    const before = read(fx.configPath);
+    const res = await call("GET", "/api/codex-prompt", fx);
+    expect(res.body.drift).toBe("journal-present");
+    expect(read(fx.configPath)).toBe(before);
+    expect(read(journal)).toBe("{}");
+  });
+
+  test("20d. each write error keeps its exact status, not merely a 4xx", async () => {
+    // A range assertion would still pass if unknown_layer silently became a 409.
+    const { WRITE_ERROR_STATUS_FOR_TESTS } = await import("../src/server/management/codex-prompt-routes");
+    expect(WRITE_ERROR_STATUS_FOR_TESTS).toEqual({
+      config_unreadable: 409,
+      stale_revision: 409,
+      developer_instructions_not_owned: 409,
+      unknown_layer: 400,
+      store_unreadable: 409,
+      invalid_characters: 400,
+      write_superseded: 409,
+      recovery_required: 409,
+      locked: 409,
+    });
+  });
+
+  test("malformed JSON is a 400, never an empty object", async () => {
+    // Swallowing a parse error into {} made an invalid adopt return a successful
+    // PREVIEW and an invalid custom return stale_revision.
+    const fx = fixture("developer_instructions = \"Answer in Korean.\"\n");
+    for (const path of ["/api/codex-prompt/toggle", "/api/codex-prompt/custom"]) {
+      const url = new URL("http://127.0.0.1:10100" + path);
+      const req = new Request(url, {
+        method: "PUT",
+        headers: { host: "127.0.0.1:10100", "content-type": "application/json" },
+        body: "{not json",
+      });
+      const res = await handleManagementAPI(req, url, config, {
+        codexPromptPaths: { configPath: fx.configPath, storePath: fx.storePath },
+      });
+      expect(res!.status).toBe(400);
+    }
+    const url = new URL("http://127.0.0.1:10100/api/codex-prompt/adopt");
+    const req = new Request(url, {
+      method: "POST",
+      headers: { host: "127.0.0.1:10100", "content-type": "application/json" },
+      body: "{not json",
+    });
+    const res = await handleManagementAPI(req, url, config, {
+      codexPromptPaths: { configPath: fx.configPath, storePath: fx.storePath },
+    });
+    expect(res!.status).toBe(400);
+  });
+
+  test("an unrecognized repair mode is refused rather than treated as adopt", async () => {
+    const fx = fixture(MARKER + "\ndeveloper_instructions = 'reshaped'\n");
+    const res = await call("POST", "/api/codex-prompt/repair", fx, {
+      confirm: true, mode: "reset", revision: await revision(fx),
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("invalid_body");
+  });
+});

--- a/tests/codex-prompt-route.test.ts
+++ b/tests/codex-prompt-route.test.ts
@@ -509,6 +509,10 @@ describe("020 coverage completions", () => {
 
   test("12b. a hostile Origin is rejected before the route runs", async () => {
     const fx = fixture("");
+    // The revision must be VALID. With a stale one this test passes even when
+    // origin enforcement is gone: the route runs, returns 409 stale_revision, and
+    // a >= 400 assertion is satisfied by the wrong rejection entirely.
+    const rev = await revision(fx);
     const url = new URL("http://127.0.0.1:10100/api/codex-prompt/toggle");
     const req = new Request(url, {
       method: "PUT",
@@ -517,14 +521,18 @@ describe("020 coverage completions", () => {
         origin: "http://evil.example",
         "content-type": "application/json",
       },
-      body: JSON.stringify({ id: "apps", enabled: false, revision: "sha256:x" }),
+      body: JSON.stringify({ id: "apps", enabled: false, revision: rev }),
     });
     const res = await handleManagementAPI(req, url, config, {
       codexPromptPaths: { configPath: fx.configPath, storePath: fx.storePath },
     });
     expect(res).not.toBeNull();
-    expect(res!.status).toBeGreaterThanOrEqual(400);
+    expect(res!.status).toBe(403);
+    // The toggle would otherwise have succeeded: this exact request with no
+    // Origin header writes the key. That is what makes the rejection meaningful.
     expect(read(fx.configPath)).toBe("");
+    const allowed = await call("PUT", "/api/codex-prompt/toggle", fx, { id: "apps", enabled: false, revision: rev });
+    expect(allowed.status).toBe(200);
   });
 
   test("9c. adopt refuses a stale revision", async () => {
@@ -588,6 +596,48 @@ describe("020 coverage completions", () => {
       codexPromptPaths: { configPath: fx.configPath, storePath: fx.storePath },
     });
     expect(res!.status).toBe(400);
+  });
+
+  test("adopt refuses an oversized value, through BOTH import paths", async () => {
+    // The owned-malformed repair branch reaches adoptDeveloperInstructions exactly
+    // as /adopt does. Without a test on that branch, deleting its cap call is
+    // invisible - which is how the bypass got in.
+    const big = "z".repeat(64 * 1024 + 10);
+
+    const viaAdopt = fixture("developer_instructions = \"" + big + "\"\n");
+    const adopt = await call("POST", "/api/codex-prompt/adopt", viaAdopt, {
+      confirm: true, revision: await revision(viaAdopt),
+    });
+    expect(adopt.status).toBe(400);
+    expect(adopt.body.code).toBe("body_too_large");
+    expect(existsSync(viaAdopt.storePath)).toBe(false);
+
+    // Marker-adjacent but reshaped: drift is owned-malformed, so repair takes the
+    // adopt branch rather than /adopt.
+    const viaRepair = fixture(MARKER + "\ndeveloper_instructions  =  \"" + big + "\"\n");
+    const get = await call("GET", "/api/codex-prompt", viaRepair);
+    expect(get.body.drift).toBe("owned-malformed");
+    const repair = await call("POST", "/api/codex-prompt/repair", viaRepair, {
+      confirm: true, mode: "adopt", revision: get.body.revision,
+    });
+    expect(repair.status).toBe(400);
+    expect(repair.body.code).toBe("body_too_large");
+    expect(existsSync(viaRepair.storePath)).toBe(false);
+  });
+
+  test("the composed cap counts existing enabled layers, not the imported body alone", async () => {
+    const existing = "y".repeat(70 * 1024);
+    const incoming = "z".repeat(60 * 1024);
+    const fx = fixture(
+      "developer_instructions = \"" + incoming + "\"\n",
+      storeJson([{ id: "aaaaaa", title: "Existing", body: existing, enabled: true }]),
+    );
+    const res = await call("POST", "/api/codex-prompt/adopt", fx, {
+      confirm: true, revision: await revision(fx),
+    });
+    // Each body is under the 64 KiB per-layer cap; together they exceed 128 KiB.
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("composed_too_large");
   });
 
   test("an unrecognized repair mode is refused rather than treated as adopt", async () => {


### PR DESCRIPTION
## Summary

Adds `/api/codex-prompt`, the management route behind the Codex Set prompt panel. It serves the prompt-layer inventory Codex assembles, the five config toggles that govern it, and the custom-layer store, plus the writes for toggling, authoring, adopting, and repairing drift.

Nothing calls it yet. This layer is an endpoint and its tests; the panel that consumes it arrives in the layer above.

Bottom of a 5-layer stack. Design: `devlog/_plan/260802_codex_set_prompt_composer/020_wp2_management_route.md` (021 supersedes it where WP1 moved).

**Stack** (merge bottom-up):

| # | PR | Layer | Review focus |
|---|----|-------|--------------|
| 5 | docs | guide + 8 locales | prose only |
| 4 | realtext | real prompt text, ordered stack | probe correctness |
| 3 | authoring | custom layers, presets | write races |
| 2 | shell | Codex Set page, taxonomy | rename + read path |
| 1 | route ← you are here | `/api/codex-prompt` | request policy, error mapping |

Review this PR's diff only.

## Verification

- `bun test ./tests/codex-prompt-route.test.ts`
- Heavier gates run on the stack head; each layer's own tests pass at its own tip.

Two things worth a reviewer's attention rather than a checkbox:

- `WRITE_ERROR_STATUS` is a `Record`, not a switch with a default. A variant added upstream breaks typecheck here instead of silently becoming a 500.
- The route owns no file access and defines no second inventory; it projects `LAYER_INVENTORY` from the WP1 core module.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

The snapshot carries file paths and the user's own prompt text — no token, API key, or account identifier, and nothing reaches a log sink. Unsafe methods sit behind the standard management gate with Origin + CSRF.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added management controls for viewing Codex prompt-layer status and snapshots.
  - Added options to enable or disable layers, update custom instructions, adopt developer instructions, and repair prompt drift.
  - Added read-only previews for supported and unsupported repair states.

- **Bug Fixes**
  - Improved validation for revisions, request sizes, characters, identifiers, and repair modes.
  - Added clearer error responses and safeguards against unsafe or unsupported changes.

- **Tests**
  - Expanded coverage for prompt management workflows, validation, permissions, drift handling, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->