### PR TITLE
fix: normalize Azure Model Router function schemas

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -1290,7 +1290,7 @@ function toolsToChatFormatForProvider(parsed: OcxParsedRequest, provider: OcxPro
     const parameters = azureChat
       ? sanitizeAzureChatToolParameters(functionDef.parameters ?? {})
       : ensureZenRootObjectSchema(functionDef.parameters ?? {});
-    const nextFunction = { ...functionDef, parameters };
+    const nextFunction: Record<string, unknown> = { ...functionDef, parameters };
     // strict: true plus a flattened schema is rejected by Gemini-in-the-pool routers.
     if (azureChat) delete nextFunction.strict;
     return {

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -922,6 +922,37 @@ function shouldSanitizeZenToolParameters(provider: OcxProviderConfig): boolean {
     || baseUrl === "https://opencode.ai/zen/go/v1";
 }
 
+/** Azure Model Router (and Gemini-in-the-pool) 400s Codex MCP schemas whose root is a union. */
+const AZURE_CHAT_FORBIDDEN_ROOT_KEYS = ["oneOf", "anyOf", "allOf", "enum", "const", "not"] as const;
+
+function isAzureOpenAiChatTarget(provider: OcxProviderConfig): boolean {
+  try {
+    const host = new URL(provider.baseUrl).hostname.toLowerCase();
+    return host.endsWith(".openai.azure.com")
+      || host.endsWith(".cognitiveservices.azure.com")
+      || host.endsWith(".services.ai.azure.com")
+      || host.endsWith(".ai.azure.com");
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Azure Foundry Model Router validates every function schema against the strictest model in
+ * the pool (Gemini-shaped): root must be {type:"object"} with no oneOf/anyOf/allOf/enum/
+ * const/not. Codex App MCP tools such as mcp__codex_app__automation_update ship a root
+ * union, which 400s the whole turn. Flatten like Zen, then strip leftover forbidden keys.
+ */
+function sanitizeAzureChatToolParameters(parameters: unknown): Record<string, unknown> {
+  const root = ensureZenRootObjectSchema(parameters);
+  for (const key of AZURE_CHAT_FORBIDDEN_ROOT_KEYS) delete root[key];
+  root.type = "object";
+  if (!root.properties || typeof root.properties !== "object" || Array.isArray(root.properties)) {
+    root.properties = {};
+  }
+  return root;
+}
+
 function isXaiSchemaTarget(provider: OcxProviderConfig): boolean {
   try {
     // Public api.x.ai accepts native root object unions. Only the Grok CLI proxy
@@ -1249,17 +1280,22 @@ function toolsToChatFormat(parsed: OcxParsedRequest, provider: OcxProviderConfig
 
 function toolsToChatFormatForProvider(parsed: OcxParsedRequest, provider: OcxProviderConfig): unknown[] | undefined {
   const base = toolsToChatFormat(parsed, provider);
-  if (!base || !shouldSanitizeZenToolParameters(provider)) return base;
+  const azureChat = isAzureOpenAiChatTarget(provider);
+  const zenChat = shouldSanitizeZenToolParameters(provider);
+  if (!base || (!zenChat && !azureChat)) return base;
   return base.map(tool => {
     if (!tool || typeof tool !== "object") return tool;
     const functionDef = (tool as { function?: Record<string, unknown> }).function;
     if (!functionDef || typeof functionDef !== "object") return tool;
+    const parameters = azureChat
+      ? sanitizeAzureChatToolParameters(functionDef.parameters ?? {})
+      : ensureZenRootObjectSchema(functionDef.parameters ?? {});
+    const nextFunction = { ...functionDef, parameters };
+    // strict: true plus a flattened schema is rejected by Gemini-in-the-pool routers.
+    if (azureChat) delete nextFunction.strict;
     return {
       ...tool,
-      function: {
-        ...functionDef,
-        parameters: ensureZenRootObjectSchema(functionDef.parameters ?? {}),
-      },
+      function: nextFunction,
     };
   });
 }

--- a/tests/azure-model-router-tool-schema.test.ts
+++ b/tests/azure-model-router-tool-schema.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { createOpenAIChatAdapter } from "../src/adapters/openai-chat";
+import type { OcxParsedRequest, OcxProviderConfig } from "../src/types";
+
+const toolSchema = {
+  oneOf: [
+    { type: "object", properties: { id: { type: "string" } }, required: ["id"] },
+    { type: "object", properties: { name: { type: "string" } }, required: ["name"] },
+  ],
+  enum: ["invalid-at-root"],
+  const: "invalid-at-root",
+  not: { type: "null" },
+};
+
+function requestFor(provider: OcxProviderConfig): Record<string, unknown> {
+  const parsed: OcxParsedRequest = {
+    modelId: "model-router",
+    context: {
+      messages: [{ role: "user", content: "Use the tool", timestamp: 0 }],
+      tools: [{ name: "automation_update", namespace: "mcp__codex_app", description: "Update an automation", parameters: toolSchema, strict: true }],
+    },
+    stream: false,
+    options: {},
+  };
+  return JSON.parse(createOpenAIChatAdapter(provider).buildRequest(parsed).body) as Record<string, unknown>;
+}
+
+describe("Azure Model Router tool schemas", () => {
+  test("flattens forbidden root composition and removes strict", () => {
+    const body = requestFor({
+      adapter: "openai-chat",
+      baseUrl: "https://example.openai.azure.com/openai/v1",
+      apiKey: "test-key",
+      authMode: "key",
+    });
+    const fn = ((body.tools as Array<{ function: Record<string, unknown> }>)[0]).function;
+    const parameters = fn.parameters as Record<string, unknown>;
+
+    expect(parameters.type).toBe("object");
+    expect(parameters.properties).toMatchObject({ id: { type: "string" }, name: { type: "string" } });
+    for (const key of ["oneOf", "anyOf", "allOf", "enum", "const", "not"]) expect(parameters[key]).toBeUndefined();
+    expect(fn.strict).toBeUndefined();
+  });
+
+  test("leaves non-Azure OpenAI-compatible tool schemas unchanged", () => {
+    const body = requestFor({ adapter: "openai-chat", baseUrl: "https://api.example.test/v1", apiKey: "test-key", authMode: "key" });
+    const fn = ((body.tools as Array<{ function: Record<string, unknown> }>)[0]).function;
+    expect(fn.parameters).toEqual({ ...toolSchema, type: "object" });
+    expect(fn.strict).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Azure Foundry Model Router rejects Codex App function schemas when their root contains `oneOf`, `anyOf`, `allOf`, `enum`, `const`, or `not`. A representative failure was:

```text
Provider error 400: Invalid schema for function `mcp__codex_app__automation_update`: schema must have type `object` and not have `oneOf`/`anyOf`/`allOf`/`enum`/`const`/`not` at the top level.
```

This normalizes function schemas only for Azure/OpenAI Foundry hosts:

- flattens root composition into an object schema using the existing Zen helper;
- removes Azure-forbidden root keywords; and
- removes `strict`, which Model Router also rejects after flattening.

Non-Azure OpenAI-compatible providers retain their existing wire schema behavior.

## Verification

- `bun test tests/azure-model-router-tool-schema.test.ts` — passed.
- `bun run typecheck` — passed after `bun install --frozen-lockfile`.
- `bun run privacy:scan` — passed.
- `bun run prepush` — the full suite began successfully but hung in this environment after many passing tests; it needs a clean successful completion before the PR is ready. GUI checks are expected to be no-ops because no GUI files changed.
- Manual regression: Azure Model Router successfully executed a Codex App web-search request after this normalization.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (not needed: internal adapter compatibility fix with inline comments and regression coverage).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults (none added; behavior is limited to Azure endpoint hostnames).

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [ ] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.
- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->