### PR TITLE
feat(xai): opt-in x_search alongside hosted web search on the Responses lane

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -20,7 +20,7 @@ import { rewriteRoutedCustomToolsForUpstream } from "../responses/custom-tool-co
 import { rewriteRoutedToolSearchForUpstream } from "../responses/tool-search-compat";
 import { rewriteRoutedNamespaceToolsForUpstream } from "../responses/namespace-tool-compat";
 import { openaiResponsesUrl } from "./openai-responses-url";
-import { normalizeXaiResponsesWebSearch } from "./xai-web-search";
+import { injectXaiResponsesXSearch, normalizeXaiResponsesWebSearch } from "./xai-web-search";
 import {
   isXaiSchemaTarget,
   normalizeXaiToolParameters,
@@ -2070,6 +2070,7 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
         // Preserve xAI's cached-only fail-closed semantics and image-search mapping before the
         // generic capability fallback removes the private OpenAI fields.
         outBody = normalizeXaiResponsesWebSearch(outBody, provider);
+        outBody = injectXaiResponsesXSearch(outBody, provider, parsed._replayPrefixLen);
         // xAI and explicitly classified compatible gateways reject these OpenAI web_search
         // extensions. Keep them for OpenAI API-key traffic and unclassified gateways.
         if (provider.supportsOpenAiWebSearchToolFields === false) {

--- a/src/adapters/xai-web-search.ts
+++ b/src/adapters/xai-web-search.ts
@@ -3,6 +3,7 @@ import { isXaiResponsesDestination } from "../providers/xai-transport";
 
 const CODEX_WEB_SEARCH_TOOL = "web_search";
 const CODEX_WEB_SEARCH_PREVIEW_TOOL = "web_search_preview";
+const XAI_SEARCH_TOOL = "x_search";
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -135,6 +136,15 @@ function normalizeToolChoice(body: Record<string, unknown>): Record<string, unkn
   return body;
 }
 
+function currentInputStart(inputLength: number, replayPrefixLength: number | undefined): number {
+  if (typeof replayPrefixLength !== "number" || !Number.isFinite(replayPrefixLength)) return 0;
+  return Math.min(inputLength, Math.max(0, Math.trunc(replayPrefixLength)));
+}
+
+function hasToolType(tools: unknown, type: string): boolean {
+  return Array.isArray(tools) && tools.some(tool => isPlainObject(tool) && tool.type === type);
+}
+
 /**
  * Make Codex's hosted web-search declaration acceptable to xAI Responses without changing other
  * providers or mutating the caller-owned request body.
@@ -183,4 +193,52 @@ export function normalizeXaiResponsesWebSearch(
   }
 
   return normalizeToolChoice(next);
+}
+
+function isLiveWebSearchTool(tool: unknown): boolean {
+  return isPlainObject(tool)
+    && tool.type === CODEX_WEB_SEARCH_TOOL
+    && (!Object.hasOwn(tool, "external_web_access") || tool.external_web_access === true);
+}
+
+/**
+ * Add xAI's hosted X search declaration without changing web-search normalization or selectors.
+ * Destination classification belongs only to this opt-in injection path; the public-API
+ * normalizer above intentionally retains its narrower causality boundary.
+ */
+export function injectXaiResponsesXSearch(
+  body: unknown,
+  provider: Pick<OcxProviderConfig, "baseUrl" | "xaiResponsesXSearch">,
+  replayPrefixLength?: number,
+): unknown {
+  if (
+    !isPlainObject(body)
+    || !isXaiResponsesDestination(provider)
+    || provider.xaiResponsesXSearch !== true
+  ) return body;
+
+  const input = Array.isArray(body.input) ? body.input : undefined;
+  const inputStart = input ? currentInputStart(input.length, replayPrefixLength) : 0;
+  const currentInput = input?.slice(inputStart) ?? [];
+  const currentXSearchDeclared = hasToolType(body.tools, XAI_SEARCH_TOOL)
+    || currentInput.some(item =>
+      isPlainObject(item)
+      && item.type === "additional_tools"
+      && hasToolType(item.tools, XAI_SEARCH_TOOL)
+    );
+  if (currentXSearchDeclared) return body;
+
+  const liveWebSearchSurvives = Array.isArray(body.tools) && body.tools.some(isLiveWebSearchTool)
+    || currentInput.some(item =>
+      isPlainObject(item)
+      && item.type === "additional_tools"
+      && Array.isArray(item.tools)
+      && item.tools.some(isLiveWebSearchTool)
+    );
+  if (!liveWebSearchSurvives) return body;
+
+  // Declaration does not grant selection when `tool_choice` names a specific tool or carries an
+  // `allowed_tools` set that excludes x_search, so leave that selector byte-shape untouched.
+  const tools = Array.isArray(body.tools) ? body.tools : [];
+  return { ...body, tools: [...tools, { type: XAI_SEARCH_TOOL }] };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -530,6 +530,7 @@ const providerConfigSchema = z.object({
     repairInvalidIds: z.boolean().optional(),
   }).strict().optional(),
   responsesSnapshotRepair: z.boolean().optional(),
+  xaiResponsesXSearch: z.boolean().optional(),
 }).passthrough();
 
 export { isValidProviderName, hasOwnProvider } from "./config/provider-name";

--- a/src/server/auth-cors.ts
+++ b/src/server/auth-cors.ts
@@ -645,6 +645,9 @@ export function providerManagementConfigError(name: unknown, provider: unknown):
   if (raw.responsesSnapshotRepair !== undefined && typeof raw.responsesSnapshotRepair !== "boolean") {
     return `provider ${name} responsesSnapshotRepair must be a boolean`;
   }
+  if (raw.xaiResponsesXSearch !== undefined && typeof raw.xaiResponsesXSearch !== "boolean") {
+    return `provider ${name} xaiResponsesXSearch must be a boolean`;
+  }
   const defaultMaxOutputError = positiveIntegerConfigError(raw.defaultMaxOutputTokens, "defaultMaxOutputTokens");
   if (defaultMaxOutputError) return `provider ${name} ${defaultMaxOutputError}`;
   const maxOutputError = positiveIntegerRecordConfigError(raw.modelMaxOutputTokens, "modelMaxOutputTokens");

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -3385,9 +3385,10 @@ async function handleResponsesInner(
     );
     // Hosted calls the PROVIDER runs itself. Gated on the destination actually being xAI, so a
     // declaration alone cannot buy the exemption on some other upstream that never serves it.
-    const providerExecutedCallTypes = isXaiResponsesDestination(route.provider)
-      ? collectProviderExecutedCallTypes(clientToolAuthorizationBody)
-      : new Set<ProviderExecutedCallType>();
+    // Provider-executed declarations are authorized from the actual outbound body, after the
+    // adapter has applied destination-specific injection and normalization. Client-executed tool
+    // authority remains bounded to the caller-owned catalog above.
+    const providerExecutedCallTypes = new Set<ProviderExecutedCallType>();
     let request: Awaited<ReturnType<typeof adapter.buildRequest>>;
     try {
       request = await adapter.buildRequest(parsed, { headers: selectedForwardHeaders, translatorBudget });
@@ -3455,6 +3456,21 @@ async function handleResponsesInner(
     let undeclaredToolGuardActive = false;
     const refreshUndeclaredToolGuard = (builtRequest: AdapterRequest): void => {
       outboundRequestBody = parseOutboundRequestBody(builtRequest.body);
+      providerExecutedCallTypes.clear();
+      if (isXaiResponsesDestination(route.provider)) {
+        // Preserve the caller-declared authorization recognized by the original classifier, then
+        // add adapter-injected declarations from the actual current-turn outbound catalog.
+        for (const callType of collectProviderExecutedCallTypes(clientToolAuthorizationBody)) {
+          providerExecutedCallTypes.add(callType);
+        }
+        const currentOutboundCatalog = currentTurnWireToolCatalogBody(
+          outboundRequestBody,
+          replayedInputPrefixLength,
+        );
+        for (const callType of collectProviderExecutedCallTypes(currentOutboundCatalog)) {
+          providerExecutedCallTypes.add(callType);
+        }
+      }
       declaredWireToolNames.clear();
       // With no replay prefix the full outbound body belongs to this turn and its normalized
       // aliases are authoritative. A continuation's outbound body still contains historical

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -422,6 +422,12 @@ export interface OcxProviderConfig {
    */
   supportsOpenAiWebSearchToolFields?: boolean;
   /**
+   * Opt xAI Responses destinations into the provider-hosted `x_search` declaration when a live
+   * `web_search` tool survives final request normalization. Disabled by default. This is separate
+   * from the web-search sidecar's `search.xSearch` options and never widens caller tool selectors.
+   */
+  xaiResponsesXSearch?: boolean;
+  /**
    * Whether the Responses upstream accepts native custom tools and custom_tool_call items.
    * Set false only for a provider whose native contract rejects them; absence preserves
    * apply_patch passthrough compatibility for OpenAI and unclassified gateways.

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -901,6 +901,31 @@ describe("opencodex config defaults", () => {
     expect(readConfigDiagnostics().error).toContain("responsesSnapshotRepair");
   });
 
+  test("accepts only a boolean xaiResponsesXSearch provider opt-in", () => {
+    const provider = {
+      adapter: "openai-responses",
+      baseUrl: "https://cli-chat-proxy.grok.com/v1",
+    };
+    writeConfig({
+      port: 12345,
+      providers: { xai: { ...provider, xaiResponsesXSearch: true } },
+      defaultProvider: "xai",
+    });
+    expect(readConfigDiagnostics().error).toBeNull();
+    expect(readConfigDiagnostics().config.providers.xai.xaiResponsesXSearch).toBe(true);
+    expect(providerManagementConfigError("xai", { ...provider, xaiResponsesXSearch: true })).toBeNull();
+
+    writeConfig({
+      port: 12345,
+      providers: { xai: { ...provider, xaiResponsesXSearch: { enabled: true } } },
+      defaultProvider: "xai",
+    });
+    expect(readConfigDiagnostics().source).toBe("fallback");
+    expect(readConfigDiagnostics().error).toContain("xaiResponsesXSearch");
+    expect(providerManagementConfigError("xai", { ...provider, xaiResponsesXSearch: "true" }))
+      .toBe("provider xai xaiResponsesXSearch must be a boolean");
+  });
+
   test("direct Gemini wire rename opt-out is a boolean and round-trips", () => {
     const base = {
       port: 12345,

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -1647,6 +1647,120 @@ describe("OpenAI Responses passthrough sanitization", () => {
     expect(body.tools).toEqual([{ type: "web_search", external_web_access: true }]);
   });
 
+  function buildXaiXSearchBody({
+    baseUrl = "https://cli-chat-proxy.grok.com/v1",
+    enabled,
+    tools,
+    toolChoice,
+  }: {
+    baseUrl?: string;
+    enabled?: boolean;
+    tools: Record<string, unknown>[];
+    toolChoice?: unknown;
+  }): Record<string, unknown> {
+    const request = createResponsesPassthroughAdapter({
+      adapter: "openai-responses",
+      baseUrl,
+      authMode: "key",
+      apiKey: "xai-test",
+      supportsOpenAiWebSearchToolFields: false,
+      ...(enabled === undefined ? {} : { xaiResponsesXSearch: enabled }),
+    }).buildRequest({
+      modelId: "grok-4.6",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: {
+        model: "grok-4.6",
+        input: [],
+        tools,
+        ...(toolChoice === undefined ? {} : { tool_choice: toolChoice }),
+      },
+    }, { headers: new Headers() });
+    return JSON.parse(request.body) as Record<string, unknown>;
+  }
+
+  test.each([
+    "https://api.x.ai/v1",
+    "https://cli-chat-proxy.grok.com/v1",
+  ])("injects x_search after live web_search normalization for %s", baseUrl => {
+    const body = buildXaiXSearchBody({
+      baseUrl,
+      enabled: true,
+      tools: [
+        { type: "function", name: "shell", parameters: { type: "object" } },
+        { type: "web_search", external_web_access: true, search_context_size: "medium" },
+      ],
+    }) as { tools: Record<string, unknown>[] };
+
+    expect(body.tools).toEqual([
+      { type: "function", name: "shell", parameters: { type: "object" } },
+      { type: "web_search" },
+      { type: "x_search" },
+    ]);
+  });
+
+  test("does not inject x_search outside the exact activation contract", () => {
+    const cases = [
+      buildXaiXSearchBody({
+        tools: [{ type: "web_search", external_web_access: true }],
+      }),
+      buildXaiXSearchBody({
+        baseUrl: "https://responses.example.test/v1",
+        enabled: true,
+        tools: [{ type: "web_search", external_web_access: true }],
+      }),
+      buildXaiXSearchBody({
+        baseUrl: "https://api.x.ai/v1",
+        enabled: true,
+        tools: [
+          { type: "function", name: "shell", parameters: { type: "object" } },
+          { type: "web_search", external_web_access: false },
+        ],
+      }),
+      buildXaiXSearchBody({
+        enabled: true,
+        tools: [{ type: "function", name: "shell", parameters: { type: "object" } }],
+      }),
+    ];
+
+    for (const body of cases) {
+      expect((body.tools as Record<string, unknown>[] | undefined)?.some(tool => tool.type === "x_search") ?? false)
+        .toBe(false);
+    }
+    expect(cases[2].tools).toEqual([
+      { type: "function", name: "shell", parameters: { type: "object" } },
+    ]);
+  });
+
+  test("keeps specific and allowed_tools selectors unchanged when x_search is injected", () => {
+    const selectors = [
+      { type: "function", name: "shell" },
+      {
+        type: "allowed_tools",
+        mode: "auto",
+        tools: [{ type: "function", name: "shell" }, { type: "web_search" }],
+      },
+    ];
+
+    for (const selector of selectors) {
+      const body = buildXaiXSearchBody({
+        enabled: true,
+        tools: [
+          { type: "function", name: "shell", parameters: { type: "object" } },
+          { type: "web_search", external_web_access: true },
+        ],
+        toolChoice: selector,
+      }) as { tools: Record<string, unknown>[]; tool_choice: Record<string, unknown> };
+      expect(body.tools.some(tool => tool.type === "x_search")).toBe(true);
+      expect(body.tool_choice).toEqual(selector);
+      const allowed = body.tool_choice.type === "allowed_tools"
+        ? body.tool_choice.tools as Record<string, unknown>[]
+        : [];
+      expect(allowed.some(tool => tool.type === "x_search")).toBe(false);
+    }
+  });
+
   // `activateDeferredTool` clears `defer_loading` only for tools a `tool_search_output` already
   // loaded, so the first turn of a deferred catalog — and any child promoted out of a namespace
   // group — otherwise carries the private field to a gateway that rejects unknown arguments.

--- a/tests/responses-undeclared-tool-guard.test.ts
+++ b/tests/responses-undeclared-tool-guard.test.ts
@@ -1433,7 +1433,13 @@ describe("xAI hosted-call authorization through handleResponses", () => {
     status: "completed",
   };
 
-  async function post(baseUrl: string): Promise<Response> {
+  async function post(
+    baseUrl: string,
+    options: {
+      injectXSearch?: boolean;
+      observeOutbound?: (body: Record<string, unknown>) => void;
+    } = {},
+  ): Promise<Response> {
     const config = {
       port: 0,
       defaultProvider: "fixture",
@@ -1443,15 +1449,23 @@ describe("xAI hosted-call authorization through handleResponses", () => {
           baseUrl,
           authMode: "key",
           apiKey: "fixture-key",
+          ...(options.injectXSearch
+            ? { xaiResponsesXSearch: true, supportsOpenAiWebSearchToolFields: false }
+            : {}),
         },
       },
     } as OcxConfig;
     const savedFetch = globalThis.fetch;
-    globalThis.fetch = (async () => Response.json({
-      id: "resp_search",
-      status: "completed",
-      output: [hostedCall],
-    })) as typeof fetch;
+    globalThis.fetch = (async (_input, init) => {
+      if (options.observeOutbound && init?.body !== undefined) {
+        options.observeOutbound(JSON.parse(String(init.body)) as Record<string, unknown>);
+      }
+      return Response.json({
+        id: "resp_search",
+        status: "completed",
+        output: [hostedCall],
+      });
+    }) as typeof fetch;
     try {
       return await handleResponses(new Request("http://localhost/v1/responses", {
         method: "POST",
@@ -1460,10 +1474,15 @@ describe("xAI hosted-call authorization through handleResponses", () => {
           model: "fixture/grok-4.6",
           stream: false,
           input: [{ role: "user", content: [{ type: "input_text", text: "search" }] }],
-          tools: [
-            { type: "function", name: "shell", parameters: { type: "object" } },
-            { type: "x_search" },
-          ],
+          tools: options.injectXSearch
+            ? [
+              { type: "function", name: "shell", parameters: { type: "object" } },
+              { type: "web_search", external_web_access: true },
+            ]
+            : [
+              { type: "function", name: "shell", parameters: { type: "object" } },
+              { type: "x_search" },
+            ],
         }),
       }), config, { model: "", provider: "" });
     } finally {
@@ -1475,6 +1494,20 @@ describe("xAI hosted-call authorization through handleResponses", () => {
     const response = await post("https://api.x.ai/v1");
 
     expect(response.status).toBe(200);
+    const body = await response.json() as { output: Array<Record<string, unknown>> };
+    expect(body.output[0]).toMatchObject(hostedCall);
+  });
+
+  test("authorizes an x_search declaration injected into the actual xAI outbound body", async () => {
+    let outbound: Record<string, unknown> | undefined;
+    const response = await post("https://cli-chat-proxy.grok.com/v1", {
+      injectXSearch: true,
+      observeOutbound: body => { outbound = body; },
+    });
+
+    expect(response.status).toBe(200);
+    expect((outbound?.tools as Record<string, unknown>[]).map(tool => tool.type))
+      .toEqual(["function", "web_search", "x_search"]);
     const body = await response.json() as { output: Array<Record<string, unknown>> };
     expect(body.output[0]).toMatchObject(hostedCall);
   });


### PR DESCRIPTION
## Why this was blocked until now

xAI reports hosted `x_search` activity as a `custom_tool_call` whose name appears in no request catalog. Until the undeclared-tool guard learned to recognise provider-executed calls, injecting `x_search` would have turned every turn carrying a named client tool into `response.failed` — which is essentially every real Codex turn. That classifier landed first; this builds on it.

## Measurements

Against `cli-chat-proxy.grok.com`, grok-4.6:

| declared tools | result |
| --- | --- |
| `[web_search]` | 200 — 6 `web_search_call`, 5 annotations |
| `[web_search, x_search]` | 200 — 4 `web_search_call` + 2 `custom_tool_call`, 6 annotations |
| `[function:shell, web_search, x_search]` | 200 — 5 `web_search_call` + 3 `custom_tool_call` |

The third row is the shape the guard protects, and it works upstream.

## Activation contract

`x_search` is injected only when **all three** hold:

1. the resolved destination is an xAI Responses destination;
2. a **live** hosted `web_search` survives the destination's normalization and selector processing — **not** merely present on the raw inbound request;
3. the new provider opt-in is enabled (default off).

Condition 2 is deliberate. A cached-only declaration is removed during normalization, so keying on the raw inbound request would re-introduce network access that normalization had just taken away.

A caller's `tool_choice` or `allowed_tools` selector never gains the injected tool. Forced hosted selection is not supported upstream in any case: `tool_choice: {type:"x_search"}` and `allowed_tools` carrying `x_search` both return **422**.

The opt-in is a **new provider field**, not the web-search sidecar's `search.xSearch`. That switch belongs to a different lane with different activation; overloading it would make one setting mean two things.

## The subtle part: guard authorization

The injected declaration is **not in the caller's catalog**. Authorizing provider-executed calls from the caller catalog alone would have made the guard fail exactly the turns this feature creates — the new feature would have triggered the bug that was just fixed.

Provider-executed authorization therefore reads the **actual outbound body**, after injection. **Client-executed** tool authority is unchanged and still bounded to the caller-owned catalog: the diff touches no client-authorization source, verified by grepping the diff for `declaredWireToolNames` / `clientDeclared*` and finding no `+`/`-` lines. #1700's protection is not widened.

## Names are never matched

Three variants have now been observed — `x_keyword_search`, `x_semantic_search`, and `x_thread_fetch` — all carrying the same `xs_call-` call-id prefix the guard keys on. The third was found only while validating this change; a name-keyed implementation would already be broken by it.

## Gate

Branch and base run **back to back under identical conditions** (repo `tests/.tmp-*` fixture residue cleared before each), because this machine's baseline noise ranged from 3 to 29 failures across the session depending on accumulated residue and load.

**Branch 15224 pass / 10 fail vs base 15232 pass / 13 fail** — the branch is cleaner than base. The two branch-only failures were isolated per file across three rounds each:

- `openai-provider-option-e2e`: base failed **2 of 3**, branch **0 of 3**
- `release-helper`: 0 of 3 on both

One genuine regression was caught during review and fixed before this PR: an earlier revision had replaced the web-search normalizer's `api.x.ai`-only host gate with the both-hosts destination check, which silently disabled a causality control test proving the registry capability backfill is what strips the fatal fields. The normalizer's gate is restored; `isXaiResponsesDestination` is used only for the injection path it was introduced for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional support for xAI-hosted web search in Responses requests.
  * Automatically adds the `x_search` tool when eligible web search is enabled.
  * Preserves existing tool selections and authorizes injected hosted search calls.

* **Bug Fixes**
  * Improved authorization handling for provider-injected tools.

* **Tests**
  * Added coverage for configuration validation, injection conditions, selector preservation, and hosted search authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->