### PR TITLE
fix(xai): normalize web search on the Grok CLI proxy, not just the public API

### DIFF
--- a/src/adapters/xai-web-search.ts
+++ b/src/adapters/xai-web-search.ts
@@ -1,8 +1,8 @@
 import type { OcxProviderConfig } from "../types";
+import { isXaiResponsesDestination } from "../providers/xai-transport";
 
 const CODEX_WEB_SEARCH_TOOL = "web_search";
 const CODEX_WEB_SEARCH_PREVIEW_TOOL = "web_search_preview";
-const XAI_API_HOST = "api.x.ai";
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -10,18 +10,6 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function isCodexWebSearchToolType(value: unknown): boolean {
   return value === CODEX_WEB_SEARCH_TOOL || value === CODEX_WEB_SEARCH_PREVIEW_TOOL;
-}
-
-/** Match only xAI's documented public API, not arbitrary Responses-compatible gateways. */
-function isXaiPublicApi(provider: Pick<OcxProviderConfig, "baseUrl">): boolean {
-  try {
-    const url = new URL(provider.baseUrl);
-    return url.protocol === "https:"
-      && url.hostname.toLowerCase() === XAI_API_HOST
-      && (url.port === "" || url.port === "443");
-  } catch {
-    return false;
-  }
 }
 
 type ToolGroupRewrite = {
@@ -150,12 +138,20 @@ function normalizeToolChoice(body: Record<string, unknown>): Record<string, unkn
 /**
  * Make Codex's hosted web-search declaration acceptable to xAI Responses without changing other
  * providers or mutating the caller-owned request body.
+ *
+ * Scoped to BOTH xAI Responses hosts, not just the public API. The 2026-08-22 probe recorded in
+ * `normalizeToolGroup` and in `isXaiResponsesDestination` already found the two hosts to be one
+ * dialect, but this gate stayed on `api.x.ai` alone, so the Grok CLI proxy — the OAuth lane — was
+ * left unnormalized. Re-probed 2026-08-27 against `cli-chat-proxy.grok.com`:
+ * `web_search_preview` -> 422 `unknown variant`, `external_web_access` -> 400 on every value,
+ * `search_context_size` -> 400, while `user_location` and `search_content_types` -> 200. Identical
+ * to the public API, which is what makes one shared gate correct.
  */
 export function normalizeXaiResponsesWebSearch(
   body: unknown,
   provider: Pick<OcxProviderConfig, "baseUrl">,
 ): unknown {
-  if (!isXaiPublicApi(provider) || !isPlainObject(body)) return body;
+  if (!isXaiResponsesDestination(provider) || !isPlainObject(body)) return body;
 
   let next: Record<string, unknown> = body;
   if (Array.isArray(body.tools)) {

--- a/tests/responses-routed-web-search-fields.test.ts
+++ b/tests/responses-routed-web-search-fields.test.ts
@@ -213,7 +213,7 @@ describe("routedProviderConfig web_search capability backfill", () => {
     }]);
   });
 
-  test("an equivalent unclassified OAuth row retains fatal fields at the CLI adapter", () => {
+  test("an unclassified OAuth row is still stripped at the CLI adapter by the host normalizer", () => {
     const routed = routedProviderConfig("xai", {
       adapter: "openai-chat",
       baseUrl: "https://api.x.ai/v1",
@@ -227,10 +227,13 @@ describe("routedProviderConfig web_search capability backfill", () => {
     expect(transport.baseUrl).toBe("https://cli-chat-proxy.grok.com/v1");
     expect(transport.supportsOpenAiWebSearchToolFields).toBeUndefined();
     const body = buildWebSearchBody({ ...transport, adapter: "openai-responses" });
+    // The capability backfill is no longer the only thing standing between a hand-edited row and
+    // a 400: `normalizeXaiResponsesWebSearch` is scoped to the xAI HOST rather than to the
+    // capability, so both fatal fields go regardless of how the row is classified. That was
+    // already true for api.x.ai; it now holds for the CLI proxy, which serves the same dialect.
+    // Everything xAI accepts still survives untouched.
     expect(body.tools).toEqual([{
       type: "web_search",
-      external_web_access: true,
-      search_context_size: "medium",
       user_location: { type: "approximate" },
       search_content_types: ["text"],
       filters: { allowed_domains: ["x.ai"] },

--- a/tests/xai-web-search-compat.test.ts
+++ b/tests/xai-web-search-compat.test.ts
@@ -134,6 +134,50 @@ describe("xAI Responses web-search compatibility", () => {
     });
   });
 
+  test("normalizes the Grok CLI proxy identically to the public API", () => {
+    // Re-probed 2026-08-27 against cli-chat-proxy.grok.com: `web_search_preview` -> 422
+    // "unknown variant", `external_web_access` -> 400 on every value including true,
+    // `search_context_size` -> 400, while `user_location` and `search_content_types` -> 200.
+    // The two hosts are one dialect, so one gate covers both.
+    const cliProvider = { baseUrl: "https://cli-chat-proxy.grok.com/v1" };
+
+    // A legacy `web_search_preview` reached the proxy verbatim and 422'd the whole turn.
+    expect(normalizeXaiResponsesWebSearch({
+      model: "grok-4.6",
+      tools: [{ type: "web_search_preview", external_web_access: true }],
+    }, cliProvider)).toEqual({
+      model: "grok-4.6",
+      tools: [{ type: "web_search" }],
+    });
+
+    // A cached/index-only declaration must NOT survive as live search. The downstream capability
+    // strip only deletes the flag, so leaving the CLI proxy unnormalized turned "no network" into
+    // an ordinary live web_search — the exact widening this normalizer exists to refuse.
+    expect(normalizeXaiResponsesWebSearch({
+      model: "grok-4.6",
+      tools: [{ type: "web_search", external_web_access: false }],
+    }, cliProvider)).toEqual({ model: "grok-4.6" });
+
+    // Fields xAI accepts are still preserved on this host.
+    expect(normalizeXaiResponsesWebSearch({
+      model: "grok-4.6",
+      tools: [{
+        type: "web_search",
+        external_web_access: true,
+        search_context_size: "medium",
+        user_location: { type: "approximate", country: "US" },
+        search_content_types: ["text"],
+      }],
+    }, cliProvider)).toEqual({
+      model: "grok-4.6",
+      tools: [{
+        type: "web_search",
+        user_location: { type: "approximate", country: "US" },
+        search_content_types: ["text"],
+      }],
+    });
+  });
+
   test("does not rewrite OpenAI, lookalike, or nonstandard-port providers", () => {
     const original = {
       model: "gpt-5.6-sol",


### PR DESCRIPTION
## Summary

`normalizeXaiResponsesWebSearch` was gated on `isXaiPublicApi`, so it ran for `api.x.ai` and skipped `cli-chat-proxy.grok.com` — the OAuth lane. Scope the gate to `isXaiResponsesDestination`, which covers both hosts.

That gate contradicted evidence already in the same file: the 2026-08-22 probe recorded in `normalizeToolGroup` and in `isXaiResponsesDestination` had already found the two hosts to be one dialect.

## Measurements

Re-probed 2026-08-27 directly against `cli-chat-proxy.grok.com`, grok-4.6, one field per request:

| declared | result |
| --- | --- |
| `[web_search]` | 200 |
| `[web_search, x_search]` | 200 |
| `[web_search_preview]` | **422** — `unknown variant 'web_search_preview', expected one of 'function', 'web_search', 'x_search', …` |
| `[web_search, external_web_access: true]` | **400** — `Argument not supported: external_web_access` |
| `[web_search, search_context_size: "medium"]` | **400** — `Argument not supported: search_context_size` |
| `[web_search, user_location: {...}]` | 200 |
| `[web_search, search_content_types: ["image"]]` | 200 |

Identical to the public API, which is what makes one shared gate correct.

## What was broken

Both reproduced at the adapter before the fix.

**A cached/index-only declaration became a live web search.** This normalizer omits the whole tool when `external_web_access` is not `true`, precisely so that dropping the flag cannot silently widen network access. On the CLI proxy the normalizer never ran, and the downstream capability strip only *deletes* that flag and keeps the tool — so a caller asking for no network reached xAI with an ordinary `{type:"web_search"}`:

```
api.x.ai | cached-only (external_web_access:false) -> undefined        (tool omitted)
grokCLI  | cached-only (external_web_access:false) -> [{"type":"web_search"}]
```

This is the widening the file exists to refuse, on the lane OAuth users actually take.

**A legacy `web_search_preview` 422'd the entire turn**, because the type conversion lives behind the same gate:

```
api.x.ai | web_search_preview -> [{"type":"web_search"}]
grokCLI  | web_search_preview -> [{"type":"web_search_preview"}]   -> 422 upstream
```

## Note on one changed expectation

`responses-routed-web-search-fields` had a case asserting that an *unclassified* OAuth row leaks the fatal fields at the CLI adapter. The host-scoped normalizer now strips them regardless of how the row is classified — which was already true for `api.x.ai`, since this normalizer has always been host-gated rather than capability-gated. That expectation is corrected rather than adjusted, and everything xAI accepts still survives untouched.

## Verification

- `bun run test` — **15108 pass, 12 skip, 0 fail, exit 0**; all six serial lanes green.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- Reverting the gate to `api.x.ai` turns the new coverage red.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web search compatibility for xAI Responses destinations, including the Grok CLI proxy.
  * Legacy web search configurations are now normalized consistently across supported xAI endpoints.
  * Unsupported search settings are removed while supported location and content-type options are preserved.

* **Tests**
  * Added coverage verifying consistent normalization and handling of unsupported web search fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
