### PR TITLE
fix(claude): derive response.failed status from the classified error payload

### DIFF
--- a/src/adapters/cursor/cursor-errors.ts
+++ b/src/adapters/cursor/cursor-errors.ts
@@ -248,6 +248,14 @@ export function classifyCursorError(message: string, sizeContext?: CursorSizeCon
     lower.includes("server is busy")
   ) return "Cursor server overloaded";
 
+  // gRPC FAILED_PRECONDITION is deterministic and non-retryable (unlike UNAVAILABLE):
+  // the backend rejected the call because the account/plan state does not allow it —
+  // seen live when a plan-gated model (e.g. claude-fable-5) runs on a plan without it.
+  // Leaving it as "Cursor upstream error" (502) made clients retry it as overload.
+  if (lower.includes("failed_precondition") || lower.includes("failed precondition")) {
+    return "Cursor invalid request";
+  }
+
   if (
     lower.includes("invalid") ||
     lower.includes("not found") ||

--- a/src/claude/outbound.ts
+++ b/src/claude/outbound.ts
@@ -11,6 +11,7 @@
  *  - errors: {type:"error", error:{type,message}}; may arrive mid-stream after HTTP 200.
  */
 import { createHash } from "node:crypto";
+import { httpStatusFromTerminalError } from "../lib/errors";
 import { isTransientUpstreamStatus } from "../lib/upstream-retry";
 import {
   isTranslatorBudgetExceededError,
@@ -555,9 +556,19 @@ export function responsesSseToAnthropicSse(
             }
             const status = code === "translation_buffer_limit"
               ? 413
-              : typeof error.status === "number" ? error.status : 500;
-            // status-absent response.failed (relaySseWithFailedTail synthetic tail) defaults
-            // to 500, which is in the transient set — the mid-stream reset shape maps to
+              : typeof error.status === "number"
+                ? error.status
+                // Internal response.failed envelopes carry the classified {type, code, message}
+                // but no numeric status. Derive it with the same mapping /api/logs uses so a
+                // classified 429/401/400 reaches Claude Code as its real Anthropic error type
+                // instead of being masked as retryable overload.
+                : httpStatusFromTerminalError({
+                  type: typeof error.type === "string" ? error.type : undefined,
+                  code: typeof error.code === "string" ? error.code : null,
+                  message,
+                });
+            // Unclassified status-absent response.failed (relaySseWithFailedTail synthetic
+            // tail) still lands on a transient 5xx here — the mid-stream reset shape maps to
             // overloaded_error by design.
             fail(
               status,

--- a/tests/claude-outbound.test.ts
+++ b/tests/claude-outbound.test.ts
@@ -534,6 +534,79 @@ describe("claude outbound SSE", () => {
     });
   });
 
+  // Internal response.failed envelopes carry the classified {type, code, message} but no
+  // numeric status (adapterFailureFromEvent drops httpStatus at the wire boundary). The
+  // classified status must be derived the same way /api/logs derives it, or every classified
+  // failure is masked as retryable overloaded_error — a Cursor plan/quota 429 surfaced in
+  // Claude Code as "Repeated 529 Overloaded errors".
+  test("failed with classified rate_limit_error but NO numeric status -> rate_limit_error, not overloaded", async () => {
+    const upstream = [
+      sse("response.created", { response: {} }),
+      sse("response.failed", {
+        response: {
+          status: "failed",
+          error: { type: "rate_limit_error", code: "rate_limit_exceeded", message: "Cursor rate limit exceeded: quota exhausted" },
+        },
+      }),
+    ].join("");
+    const events = await collectEvents(responsesSseToAnthropicSse(streamFrom(upstream), "m"));
+    expect(events.at(-1)!.data).toEqual({
+      type: "error",
+      error: { type: "rate_limit_error", message: "Cursor rate limit exceeded: quota exhausted" },
+    });
+  });
+
+  test("failed with classified authentication_error but NO numeric status -> authentication_error, not overloaded", async () => {
+    const upstream = [
+      sse("response.created", { response: {} }),
+      sse("response.failed", {
+        response: {
+          status: "failed",
+          error: { type: "authentication_error", code: "invalid_api_key", message: "Cursor authentication failed: expired token" },
+        },
+      }),
+    ].join("");
+    const events = await collectEvents(responsesSseToAnthropicSse(streamFrom(upstream), "m"));
+    expect(events.at(-1)!.data).toEqual({
+      type: "error",
+      error: { type: "authentication_error", message: "Cursor authentication failed: expired token" },
+    });
+  });
+
+  test("failed with classified invalid_request_error but NO numeric status -> invalid_request_error, not overloaded", async () => {
+    const upstream = [
+      sse("response.created", { response: {} }),
+      sse("response.failed", {
+        response: {
+          status: "failed",
+          error: { type: "invalid_request_error", code: "context_length_exceeded", message: "Cursor context limit exceeded" },
+        },
+      }),
+    ].join("");
+    const events = await collectEvents(responsesSseToAnthropicSse(streamFrom(upstream), "m"));
+    expect(events.at(-1)!.data).toEqual({
+      type: "error",
+      error: { type: "invalid_request_error", message: "Cursor context limit exceeded" },
+    });
+  });
+
+  test("failed with classified server overload but NO numeric status -> still overloaded_error", async () => {
+    const upstream = [
+      sse("response.created", { response: {} }),
+      sse("response.failed", {
+        response: {
+          status: "failed",
+          error: { type: "server_error", code: "server_is_overloaded", message: "Cursor server overloaded: unavailable" },
+        },
+      }),
+    ].join("");
+    const events = await collectEvents(responsesSseToAnthropicSse(streamFrom(upstream), "m"));
+    expect(events.at(-1)!.data).toEqual({
+      type: "error",
+      error: { type: "overloaded_error", message: "Cursor server overloaded: unavailable" },
+    });
+  });
+
   test("internal reader exception stays api_error (not promoted to overloaded)", async () => {
     const boom = new ReadableStream<Uint8Array>({
       start(controller) {

--- a/tests/cursor-errors.test.ts
+++ b/tests/cursor-errors.test.ts
@@ -5,6 +5,7 @@ import {
   isCursorInvalidArgumentError,
   safeCursorErrorMessage,
 } from "../src/adapters/cursor/cursor-errors";
+import { inferHttpStatusFromAdapterMessage } from "../src/lib/errors";
 
 describe("classifyCursorError", () => {
   test("rate limit and resource exhaustion stay distinct", () => {
@@ -57,6 +58,15 @@ describe("classifyCursorError", () => {
   test("invalid request / not found", () => {
     expect(classifyCursorError("model not found: bad-model-id")).toBe("Cursor invalid request");
     expect(classifyCursorError("invalid request: malformed tool schema")).toBe("Cursor invalid request");
+  });
+
+  test("failed_precondition is a deterministic non-retryable rejection, not overload", () => {
+    // Live evidence: a plan-gated model (claude-fable-5) invoked on a plan without it
+    // returns "Cursor Connect error failed_precondition: Error". gRPC FAILED_PRECONDITION
+    // is non-retryable by definition; as "Cursor upstream error" (502) clients retried it
+    // as overload, and the Claude inbound surfaced it as a misleading 529.
+    expect(classifyCursorError("Cursor Connect error failed_precondition: Error")).toBe("Cursor invalid request");
+    expect(inferHttpStatusFromAdapterMessage("Cursor invalid request: Cursor Connect error failed_precondition: Error")).toBe(400);
   });
 
   test("timeout / deadline", () => {


### PR DESCRIPTION
## Summary

- Fixes Claude Code showing `API Error: Repeated 529 Overloaded errors` when the real upstream failure was something else — observed live with `cursor/claude-fable-5`, where Cursor rejected the Run and `/api/logs` recorded the real status (**429**, later **502-class**) while the client was told **529 overloaded**.
- Root cause 1: internal `response.failed` envelopes carry the classified `{type, code, message}` (e.g. `rate_limit_error` / `rate_limit_exceeded`) but never a numeric `status` (`adapterFailureFromEvent` drops `httpStatus` at the wire boundary). The Claude outbound in `src/claude/outbound.ts` only honored a numeric `error.status` and defaulted everything else to 500, which sits in the transient set, so every classified adapter failure was promoted to `overloaded_error` and Claude Code retried it as if the API were at capacity. The outbound now derives a missing status with `httpStatusFromTerminalError` — the exact mapping `/api/logs` already uses — so the client signal and the request log agree by construction: 429 → `rate_limit_error`, 401 → `authentication_error`, 400 → `invalid_request_error`, while unclassified synthetic tails (mid-stream resets) still land on transient 5xx and map to `overloaded_error` as designed.
- Root cause 2: a plan-gated Cursor model invoked on a plan without it (live: `cursor/claude-fable-5` → `Cursor Connect error failed_precondition`) fell through to `Cursor upstream error` (502), a transient status that clients retried as overload. gRPC `FAILED_PRECONDITION` is deterministic and non-retryable by definition, so `classifyCursorError` now maps it to `Cursor invalid request` (400).

## Verification

- `bun test tests/claude-outbound.test.ts` — 45 pass, including 4 new regression tests: classified `rate_limit_error` / `authentication_error` / `invalid_request_error` payloads without a numeric status keep their real Anthropic error type, and classified server-overload plus the status-less synthetic tail still map to `overloaded_error`.
- `bun test tests/cursor-errors.test.ts` — new regression test: `failed_precondition` classifies as `Cursor invalid request` and infers HTTP 400.
- `bun test tests/claude-529-mapping.test.ts tests/claude-messages-endpoint.test.ts tests/error-fidelity.test.ts tests/cyber-policy-error-fidelity.test.ts tests/sse-failed-tail.test.ts tests/cl01-claude-outbound-review-regressions.test.ts` — 87 pass, 0 fail.
- `bun run typecheck` — clean.
- `bun run test` — the claude/cursor error-mapping suites all pass; the run also shows failures in unrelated files (`tests/server-auth.test.ts`, `tests/api-key-attribution.test.ts`, `tests/lab-*.test.ts`, `tests/loopback-listener-integration.test.ts`, …) which reproduce identically on a clean `dev` checkout without this change (verified via `git stash`), i.e. pre-existing local-environment failures, not regressions from this PR.
- Live evidence from the machine that hit the bug: `/api/logs` showed `cursor/claude-fable-5` → 429 `failed` and `cursor/claude-4.6-opus` → 429/502 while Claude Code displayed repeated 529s; after the account change the same model fails with `failed_precondition` while `cursor/claude-sonnet-5`, `cursor/claude-4.6-sonnet`, and `cursor/kimi-k3-1m` succeed through the identical path.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streaming failures without an explicit HTTP status.
  * Rate-limit, authentication, invalid-request, and server-overload errors now retain the correct error classification.
  * Plan-gated model rejections are correctly identified as invalid requests instead of server overloads.
  * Unclassified failures continue to use the transient server-error fallback.

* **Tests**
  * Added regression coverage for classified failures missing numeric status codes and plan-gated model rejection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->