### PR TITLE
fix(cli): neutralize usage report terminal controls

### DIFF
--- a/src/cli/usage-report.ts
+++ b/src/cli/usage-report.ts
@@ -42,6 +42,15 @@ interface UsageReportInput {
 
 const MAX_MODEL_ROWS = 10;
 
+function terminalText(value: string): string {
+  return value.replace(/[\x00-\x1f\x7f-\x9f]/g, character => {
+    const code = character.charCodeAt(0);
+    return code <= 0x7f
+      ? `\\x${code.toString(16).padStart(2, "0")}`
+      : `\\u${code.toString(16).padStart(4, "0")}`;
+  });
+}
+
 function count(value: number | undefined): string {
   return (value ?? 0).toLocaleString("en-US");
 }
@@ -58,6 +67,8 @@ function usd(value: number | undefined): string {
 
 function table(header: string[], rows: string[][]): string[] {
   if (rows.length === 0) return [];
+  header = header.map(terminalText);
+  rows = rows.map(row => row.map(terminalText));
   const widths = header.map((h, i) => Math.max(h.length, ...rows.map(r => (r[i] ?? "").length)));
   const line = (cols: string[]): string => cols.map((c, i) => (c ?? "").padEnd(widths[i]!)).join("  ").trimEnd();
   return [line(header), ...rows.map(line)];
@@ -68,7 +79,7 @@ function describeScope(data: UsageReportInput): string {
   if (data.surface && data.surface !== "all") parts.push(`surface=${data.surface}`);
   if (data.filter?.provider) parts.push(`provider=${data.filter.provider}`);
   if (data.filter?.model) parts.push(`model=${data.filter.model}`);
-  return parts.join(", ");
+  return terminalText(parts.join(", "));
 }
 
 export function formatUsageReport(data: UsageReportInput): string[] {
@@ -78,7 +89,7 @@ export function formatUsageReport(data: UsageReportInput): string[] {
   if (data.filter && !data.filter.matched) {
     const what = [data.filter.provider && `provider "${data.filter.provider}"`, data.filter.model && `model "${data.filter.model}"`]
       .filter(Boolean).join(" and ");
-    lines.push(`No usage recorded for ${what} in this range.`);
+    lines.push(`No usage recorded for ${terminalText(what)} in this range.`);
     lines.push("Check the spelling against `ocx usage --json`, or widen --range.");
     return lines;
   }

--- a/tests/cli-usage-report.test.ts
+++ b/tests/cli-usage-report.test.ts
@@ -62,6 +62,31 @@ describe("formatUsageReport", () => {
     expect(out).not.toContain("item(s)");
   });
 
+  test("renders terminal control characters as inert text", () => {
+    const control = "demo-\x1b]52;c;SGVsbG8=\x07-after\nnext\x7f-\x80";
+    const out = formatUsageReport(payload({
+      providers: [{ provider: control, requests: 1, totalTokens: 2 }],
+      models: [{ provider: control, model: control, requests: 1, totalTokens: 2 }],
+      filter: { provider: control, model: control, matched: true, comboOverlap: false },
+    }) as never).join("\n");
+    const noMatch = formatUsageReport(payload({
+      summary: { requests: 0, totalTokens: 0, estimatedCostUsd: 0 },
+      providers: [], models: [], days: [],
+      filter: { provider: control, model: null, matched: false, comboOverlap: false },
+    }) as never).join("\n");
+
+    expect(out).not.toContain("\x1b");
+    expect(out).not.toContain("\x07");
+    expect(out).not.toContain("\x7f");
+    expect(out).not.toContain("\x80");
+    expect(out).toContain("demo-\\x1b]52;c;SGVsbG8=\\x07-after\\x0anext\\x7f-\\u0080");
+    expect(noMatch).not.toContain("\x1b");
+    expect(noMatch).not.toContain("\x07");
+    expect(noMatch).not.toContain("\x7f");
+    expect(noMatch).not.toContain("\x80");
+    expect(noMatch).toContain('provider "demo-\\x1b]52;c;SGVsbG8=\\x07-after\\x0anext\\x7f-\\u0080"');
+  });
+
   test("a zero total is distinguishable from an unpriced one", () => {
     const priced = formatUsageReport(payload({
       summary: { requests: 5, totalTokens: 100, estimatedCostUsd: 0, unpricedRequests: 0, unmeteredRequests: 0 },


### PR DESCRIPTION
## Summary

- Render C0, DEL, and C1 control characters as visible escape text before formatting the human `ocx usage` report.
- Apply the same protection to provider/model table cells, the scope header, and the no-match filter message while leaving JSON output unchanged.
- Add focused coverage for both matched and unmatched filter paths so OSC, ESC, BEL, and newline bytes cannot reach the terminal.

## Verification

- `bun 1.4.0-canary.1 test tests/cli-usage-report.test.ts` — 13 passed, 0 failed.
- `bun 1.4.0-canary.1 run typecheck` — passed.
- `bun 1.4.0-canary.1 run privacy:scan` — passed.
- `git diff --check HEAD^..HEAD` — passed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. No documentation change is needed because this only makes unsafe control bytes visible in the existing text format.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. The exact changed range introduces no credential, authentication, or unsafe-default surface.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage report output by escaping control characters in headers, table values, scope descriptions, and empty-result messages.
  * Prevents terminal escape sequences, bell characters, and similar content from corrupting displayed reports.

* **Tests**
  * Added coverage for safely rendering control characters in provider, model, and filter output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
