### PR TITLE
feat(combo): adapt reasoning effort to target capabilities

### DIFF
--- a/docs-site/src/content/docs/guides/combos.md
+++ b/docs-site/src/content/docs/guides/combos.md
@@ -221,6 +221,14 @@ default and leaves the target's own behavior unchanged. Supported values are `lo
 `high`, `xhigh`, `max`, and `ultra`; omit the field or set it to `null` to leave effort entirely to
 the caller and target.
 
+By default, the combo picker intersects every known target effort ladder. Set
+`reasoningEffortMode: "adaptive"` only for a mixed-capability group where targets with an
+explicit empty ladder should remain eligible without suppressing the picker for siblings. In this
+mode, empty ladders are excluded from the published intersection; OpenCodex still resolves each
+selected target separately and omits the effort for targets that do not support it. Unknown
+ladders remain wildcards in both modes. This changes picker metadata only, not target order or
+failover policy.
+
 ## Image / multimodal capability
 
 By default a combo publishes the **intersection** of its targets' input modalities (image is
@@ -314,6 +322,7 @@ Combos are stored in the top-level `combos` object, keyed by combo id:
       "strategy": "round-robin",
       "stickyLimit": 2,
       "defaultEffort": "high",
+      "reasoningEffortMode": "adaptive",
       "alias": "team/balanced"
     }
   }
@@ -327,6 +336,7 @@ Combos are stored in the top-level `combos` object, keyed by combo id:
 | `strategy` | No | `"failover"` | `"failover"` or `"round-robin"`. |
 | `stickyLimit` | No | `1` | Integer from 1 to 100 successful requests per round-robin selection. |
 | `defaultEffort` | No | `null` | `low`, `medium`, `high`, `xhigh`, `max`, or `ultra`; applied only when the caller omits effort and the target advertises support. |
+| `reasoningEffortMode` | No | `"strict"` | `"strict"` intersects every known target effort ladder. `"adaptive"` excludes explicit empty ladders from the published picker intersection while preserving per-target effort omission at request time. |
 | `imageInput` | No | `"auto"` | `"auto"` or `"disabled"`. `"auto"` publishes image support only when every target supports images; `"disabled"` forces text-only (drops image from published modalities and rejects image-bearing requests before dispatch). |
 | `alias` | No | none | Optional trimmed public model id; use the alias rules above. An empty value is stored as no alias. |
 | `nativeAlias` | No | `false` | Explicitly permit a currently supported bare native `alias` to take routing and catalog precedence. Never inferred from the alias. |

--- a/docs-site/src/content/docs/reference/configuration/providers.md
+++ b/docs-site/src/content/docs/reference/configuration/providers.md
@@ -107,6 +107,7 @@ differing backup and rewrites known legacy namespaced selected ids to bare ids.
 | `modelReasoningEffortMap?` | `Record<string, Record<string, string>>` | Per-model wire aliases for reasoning labels. |
 | `reasoningWireFormat?` | `"gateway-object"` | For OpenAI-compatible gateways that accept `reasoning: { enabled, effort }` instead of `reasoning_effort`. The ClinePass preset sets this automatically. |
 | `noReasoningModels?` | `string[]` | Models that reject reasoning/thinking parameters. |
+| `omitReasoningEffortWithToolsModels?` | `string[]` | Exact `openai-chat` model IDs that accept reasoning effort on ordinary turns but reject it when function tools are present. The model may still advertise its configured effort ladder; on a tool-bearing request OpenCodex omits the wire reasoning field and uses the upstream model default. |
 | `noTemperatureModels?` | `string[]` | Models that reject caller-specified `temperature`. |
 | `noTopPModels?` | `string[]` | Models that reject caller-specified `top_p`. |
 | `noPenaltyModels?` | `string[]` | Models that reject presence/frequency penalties. |

--- a/docs-site/src/content/docs/reference/configuration/routing.md
+++ b/docs-site/src/content/docs/reference/configuration/routing.md
@@ -76,6 +76,7 @@ namespace, and cannot use reserved bare native families such as `gpt-*`, `o1-*`,
 | `strategy?` | `"failover" \| "round-robin"` | `"failover"` | Selection strategy. Target order is failover priority; weights shape smooth weighted round-robin. |
 | `stickyLimit?` | `number` | `1` | Successful requests retained in one round-robin batch. Range 1–100. |
 | `defaultEffort?` | `"low" \| "medium" \| "high" \| "xhigh" \| "max" \| "ultra" \| null` | unset | Applied only when the caller omits effort and the selected target advertises the requested rung. |
+| `reasoningEffortMode?` | `"strict" \| "adaptive"` | `"strict"` | `"strict"` intersects every known target effort ladder. `"adaptive"` excludes explicit empty ladders from the public picker intersection; dispatch remains per-target and unsupported effort fields are omitted. |
 | `imageInput?` | `"auto" \| "disabled"` | `"auto"` | `"auto"` publishes image only when every target supports images; `"disabled"` forces text-only (drops image from published modalities and rejects image-bearing requests before dispatch). |
 | `alias?` | `string` | — | Optional public model id in place of the canonical picker slug. |
 | `nativeAlias?` | `boolean` | `false` | Let a currently supported bare native id take precedence only for that unqualified id. Bare `gpt-5.6-*` ids use Codex Pool/Direct credentials. Account-qualified routes remain distinct. Provider-qualified routes such as `openai-apikey/gpt-5.6-*` use their configured API-key route and never fall through to the native alias. |
@@ -92,6 +93,7 @@ namespace, and cannot use reserved bare native families such as `gpt-*`, `o1-*`,
       ],
       "strategy": "failover",
       "defaultEffort": "high",
+      "reasoningEffortMode": "adaptive",
       "alias": "coding-primary"
     }
   }

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -1425,10 +1425,16 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
       }
       if (parsed.options.stopSequences !== undefined) body.stop = parsed.options.stopSequences;
       const reasoningDisabled = modelInList(provider.noReasoningModels, parsed.modelId);
-      const reasoningEffort = mapReasoningEffort(provider, parsed.modelId, parsed.options.reasoning);
+      // Keep a model's picker capability when it only rejects the tools plus reasoning
+      // parameter combination; omit the incompatible wire field for this request only.
+      const omitReasoningEffortWithTools = !!tools
+        && modelInList(provider.omitReasoningEffortWithToolsModels, parsed.modelId);
+      const reasoningEffort = omitReasoningEffortWithTools
+        ? undefined
+        : mapReasoningEffort(provider, parsed.modelId, parsed.options.reasoning);
       const nativeOpenAI = isNativeOpenAIChatTarget(provider);
       let reasoningLog: AdapterRequest["reasoningLog"];
-      if (!reasoningDisabled && provider.reasoningWireFormat === "gateway-object" && parsed.options.reasoning === "none") {
+      if (!reasoningDisabled && !omitReasoningEffortWithTools && provider.reasoningWireFormat === "gateway-object" && parsed.options.reasoning === "none") {
         if (nativeOpenAI) {
           body.reasoning_effort = "none";
           reasoningLog = {

--- a/src/codex/catalog/aggregation.ts
+++ b/src/codex/catalog/aggregation.ts
@@ -137,11 +137,16 @@ export function deriveComboCatalogModel(
     ? derivedInputModalities.filter(modality => modality !== "image")
     : derivedInputModalities;
   if (inputModalities.length === 0) return null;
-  // Unknown ladders (`undefined`) are wildcards for catalog derivation — same
-  // boundary as the GUI picker. An explicit empty ladder still constrains.
-  const advertisedLadders = members
+  // Unknown ladders are wildcards for catalog derivation. Strict mode keeps the legacy rule
+  // that an explicit empty ladder constrains the whole combo. Adaptive mode is opt-in for
+  // mixed-capability failover groups: an empty ladder means this concrete target receives no
+  // effort field, while non-empty ladders still define the picker intersection.
+  const knownLadders = members
     .map(member => member.reasoningEfforts)
     .filter((ladder): ladder is string[] => ladder !== undefined);
+  const advertisedLadders = combo.reasoningEffortMode === "adaptive"
+    ? knownLadders.filter(ladder => ladder.length > 0)
+    : knownLadders;
   const reasoningEfforts = advertisedLadders.length === 0
     ? []
     : intersectStrings(advertisedLadders);

--- a/src/combos/types.ts
+++ b/src/combos/types.ts
@@ -3,6 +3,7 @@ import { SUPPORTED_NATIVE_OPENAI_SLUGS } from "../codex/catalog/native-models";
 import type {
   OcxComboConfig,
   OcxComboDefaultEffort,
+  OcxComboReasoningEffortMode,
   OcxComboStrategy,
   OcxComboTarget,
   OcxConfig,
@@ -37,6 +38,7 @@ export interface NormalizedComboConfig {
   strategy: OcxComboStrategy;
   stickyLimit: number;
   defaultEffort: OcxComboDefaultEffort | null;
+  reasoningEffortMode: OcxComboReasoningEffortMode;
   /** Disable image input; `auto` preserves the intersection derived from all targets. */
   imageInput: "auto" | "disabled";
   /** Trimmed public alias, or null when the combo keeps the default `combo/<id>` slug. */
@@ -232,6 +234,11 @@ export function comboConfigIssues(
       message: "defaultEffort must be one of: low, medium, high, xhigh, max, ultra",
     });
   }
+  if (body.reasoningEffortMode !== undefined
+    && body.reasoningEffortMode !== "strict"
+    && body.reasoningEffortMode !== "adaptive") {
+    issues.push({ path: ["reasoningEffortMode"], message: 'reasoningEffortMode must be "strict" or "adaptive"' });
+  }
   if (body.imageInput !== undefined && body.imageInput !== "auto" && body.imageInput !== "disabled") {
     issues.push({ path: ["imageInput"], message: 'imageInput must be "auto" or "disabled"' });
   }
@@ -354,6 +361,7 @@ export function normalizeComboConfig(raw: OcxComboConfig): NormalizedComboConfig
     strategy: raw.strategy ?? "failover",
     stickyLimit: raw.stickyLimit ?? 1,
     defaultEffort: raw.defaultEffort ?? null,
+    reasoningEffortMode: raw.reasoningEffortMode === "adaptive" ? "adaptive" : "strict",
     imageInput: raw.imageInput === "disabled" ? "disabled" : "auto",
     alias: alias || null,
     nativeAlias: raw.nativeAlias === true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -516,6 +516,9 @@ const providerConfigSchema = z.object({
   noStructuredOutputModels: z.array(z.string().min(1))
     .transform(normalizeNonBlankStringArray)
     .optional(),
+  omitReasoningEffortWithToolsModels: z.array(z.string().min(1))
+    .transform(normalizeNonBlankStringArray)
+    .optional(),
   retryOn429: retryOn429PolicySchema.optional(),
   codexAccountMode: z.enum(["pool", "direct"]).optional(),
   // Validated rather than passed through: this schema ends in `.passthrough()`, so an
@@ -1211,6 +1214,17 @@ const configSchema = z.object({
         code: "custom",
         path: ["providers", redactSecretString(name), "noStructuredOutputModels"],
         message: structuredOutputOptOutError,
+      });
+    }
+    const toolReasoningOptOutError = nonBlankStringArrayConfigError(
+      (provider as { omitReasoningEffortWithToolsModels?: unknown }).omitReasoningEffortWithToolsModels,
+      "omitReasoningEffortWithToolsModels",
+    );
+    if (toolReasoningOptOutError) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["providers", redactSecretString(name), "omitReasoningEffortWithToolsModels"],
+        message: toolReasoningOptOutError,
       });
     }
     if (Object.hasOwn(provider, "codexAccountMode") && provider.codexAccountMode !== undefined) {

--- a/src/server/auth-cors.ts
+++ b/src/server/auth-cors.ts
@@ -654,6 +654,11 @@ export function providerManagementConfigError(name: unknown, provider: unknown):
     "noStructuredOutputModels",
   );
   if (structuredOutputOptOutError) return `provider ${name} ${structuredOutputOptOutError}`;
+  const toolReasoningOptOutError = nonBlankStringArrayConfigError(
+    raw.omitReasoningEffortWithToolsModels,
+    "omitReasoningEffortWithToolsModels",
+  );
+  if (toolReasoningOptOutError) return `provider ${name} ${toolReasoningOptOutError}`;
   const openRouterError = openRouterRoutingConfigError(typed);
   if (openRouterError) return `provider ${name} ${openRouterError}`;
   if (typed.authMode === "local") {
@@ -739,6 +744,7 @@ export function safeConfigDTO(config: OcxConfig): unknown {
       "reasoningWireFormat",
       "noVisionModels",
       "noReasoningModels",
+      "omitReasoningEffortWithToolsModels",
       "noTemperatureModels",
       "noTopPModels",
       "noPenaltyModels",

--- a/src/server/management/provider-routes.ts
+++ b/src/server/management/provider-routes.ts
@@ -326,6 +326,19 @@ function applyProviderPatchFields(
     }
     touched = true;
   }
+  if (Object.hasOwn(rawBody, "omitReasoningEffortWithToolsModels")) {
+    const value = rawBody.omitReasoningEffortWithToolsModels;
+    if (value === null) {
+      delete next.omitReasoningEffortWithToolsModels;
+    } else {
+      const error = nonBlankStringArrayConfigError(value, "omitReasoningEffortWithToolsModels");
+      if (error) return { error };
+      const models = normalizeNonBlankStringArray(value as string[]);
+      if (models.length > 0) next.omitReasoningEffortWithToolsModels = models;
+      else delete next.omitReasoningEffortWithToolsModels;
+    }
+    touched = true;
+  }
 
   // headers is the one object-valued field in the mask. PATCH semantics merge it
   // shallowly into the existing block so a single fingerprint header can be added
@@ -454,6 +467,7 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
       modelAutoCompactTokenLimits: p.modelAutoCompactTokenLimits,
       modelSupportsServiceTier: p.modelSupportsServiceTier,
       noStructuredOutputModels: p.noStructuredOutputModels,
+      omitReasoningEffortWithToolsModels: p.omitReasoningEffortWithToolsModels,
       upstreamHttpVersion: p.upstreamHttpVersion,
       authMode: p.authMode,
       apiKeyTransport: p.apiKeyTransport,

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,7 @@ export type {
   OcxAccountPoolRotationStrategy,
   OcxComboStrategy,
   OcxComboDefaultEffort,
+  OcxComboReasoningEffortMode,
   OcxComboTarget,
   OcxComboConfig,
   OcxRoutingUnknownEvidenceMode,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -656,6 +656,8 @@ export type OcxAccountPoolRotationStrategy = "quota" | "round-robin" | "fill-fir
 
 export type OcxComboStrategy = "failover" | "round-robin";
 export type OcxComboDefaultEffort = "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
+/** How a combo derives its public reasoning picker from mixed target capabilities. */
+export type OcxComboReasoningEffortMode = "strict" | "adaptive";
 
 export interface OcxComboTarget {
   provider: string;
@@ -672,6 +674,11 @@ export interface OcxComboConfig {
   stickyLimit?: number;
   /** Used when the client omits reasoning.effort. null/omitted leaves the target default unchanged. */
   defaultEffort?: OcxComboDefaultEffort | null;
+  /**
+   * strict (default) intersects every known target ladder. Adaptive ignores explicit empty
+   * ladders while deriving the public picker; concrete targets still own wire compatibility.
+   */
+  reasoningEffortMode?: OcxComboReasoningEffortMode;
   /**
    * Disable image input even when every target supports it.
    * Omitted / `"auto"` keeps automatic capability derivation (default: enabled when

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -444,6 +444,12 @@ export interface OcxProviderConfig {
    * reasoning_effort for these even when Codex selects a reasoning level (e.g. xAI grok-build-0.1).
    */
   noReasoningModels?: string[];
+  /**
+   * Models that accept caller-selected reasoning on ordinary Chat Completions turns but reject
+   * the tools plus reasoning parameter combination. The adapter keeps the public reasoning
+   * capability and omits only the upstream reasoning field for tool-bearing requests.
+   */
+  omitReasoningEffortWithToolsModels?: string[];
   /** Model ids that reject caller-specified temperature. */
   noTemperatureModels?: string[];
   /** Model ids that reject caller-specified top_p. */

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -261,6 +261,18 @@ describe("combo catalog capability intersection", () => {
     ]);
     expect(empty?.reasoningEfforts).toEqual([]);
     expect(empty).not.toHaveProperty("defaultReasoningEffort");
+
+    const adaptive = deriveComboCatalogModel("adaptive", normalizedCombo({
+      defaultEffort: "medium",
+      reasoningEffortMode: "adaptive",
+    }), [
+      memberA,
+      { ...memberB, reasoningEfforts: [] },
+    ]);
+    expect(adaptive).toEqual(expect.objectContaining({
+      reasoningEfforts: ["low", "medium", "high"],
+      defaultReasoningEffort: "medium",
+    }));
   });
 
   test("fails closed for missing members, unknown context, duplicate targets, and empty modalities", () => {

--- a/tests/combo-management-api.test.ts
+++ b/tests/combo-management-api.test.ts
@@ -254,13 +254,13 @@ describe("combo management API", () => {
         success: true,
         id: "zeta",
         model: "combo/zeta",
-        combo: { strategy: "failover", stickyLimit: 1, defaultEffort: null },
+        combo: { strategy: "failover", stickyLimit: 1, defaultEffort: null, reasoningEffortMode: "strict" },
       });
       const updated = await comboApi(config, "PUT", "/api/combos", {
         id: "zeta",
-        combo: { strategy: "round-robin", stickyLimit: 2, defaultEffort: "high", targets: [{ provider: "b", model: "m2", weight: 3 }] },
+        combo: { strategy: "round-robin", stickyLimit: 2, defaultEffort: "high", reasoningEffortMode: "adaptive", targets: [{ provider: "b", model: "m2", weight: 3 }] },
       });
-      expect((await responseJson(updated)).combo).toMatchObject({ strategy: "round-robin", stickyLimit: 2, defaultEffort: "high" });
+      expect((await responseJson(updated)).combo).toMatchObject({ strategy: "round-robin", stickyLimit: 2, defaultEffort: "high", reasoningEffortMode: "adaptive" });
       await comboApi(config, "PUT", "/api/combos", {
         id: "alpha",
         combo: { targets: [{ provider: "a", model: "m1" }] },

--- a/tests/combos.test.ts
+++ b/tests/combos.test.ts
@@ -595,6 +595,7 @@ describe("combo validation and normalization", () => {
       { raw: { ...VALID_COMBO, strategy: "random" }, path: ["strategy"], message: "failover" },
       { raw: { ...VALID_COMBO, stickyLimit: 1.5 }, path: ["stickyLimit"], message: "integer from 1 to 100" },
       { raw: { ...VALID_COMBO, defaultEffort: "turbo" }, path: ["defaultEffort"], message: "low, medium, high" },
+      { raw: { ...VALID_COMBO, reasoningEffortMode: "unsafe" }, path: ["reasoningEffortMode"], message: "strict" },
       { raw: { targets: [] }, path: ["targets"], message: "non-empty array" },
       { raw: { targets: [null] }, path: ["targets", 0], message: "must be an object" },
       { raw: { targets: [{ provider: " ", model: "m1" }] }, path: ["targets", 0, "provider"], message: "is required" },
@@ -644,11 +645,13 @@ describe("combo validation and normalization", () => {
   test("normalizes valid values and returns defensive default efforts", () => {
     expect(normalizeComboConfig({
       defaultEffort: "high",
+      reasoningEffortMode: "strict",
       targets: [{ provider: " a ", model: " m1 ", weight: 2 }],
     })).toEqual({
       strategy: "failover",
       stickyLimit: 1,
       defaultEffort: "high",
+      reasoningEffortMode: "strict",
       imageInput: "auto",
       alias: null,
       nativeAlias: false,
@@ -656,6 +659,7 @@ describe("combo validation and normalization", () => {
       targets: [{ provider: "a", model: "m1", weight: 2 }],
     });
     expect(normalizeComboConfig({ targets: [{ provider: "a", model: "m1" }] }).defaultEffort).toBeNull();
+    expect(normalizeComboConfig({ targets: [{ provider: "a", model: "m1" }], reasoningEffortMode: "adaptive" }).reasoningEffortMode).toBe("adaptive");
     expect(comboDefaultEffort(baseConfig(), "free")).toBeNull();
     const aliased = baseConfig({
       combos: { free: { ...VALID_COMBO, alias: "  deepseek-v4-flash  " } },

--- a/tests/management-provider-validation.test.ts
+++ b/tests/management-provider-validation.test.ts
@@ -304,6 +304,27 @@ describe("provider management validation", () => {
     expect(dto.providers.relay?.noStructuredOutputModels).toEqual(["deepseek-v4-flash"]);
   });
 
+  test("validates and exposes tool-sensitive reasoning model opt-outs", () => {
+    const provider = {
+      adapter: "openai-chat",
+      baseUrl: "https://relay.example/v1",
+      omitReasoningEffortWithToolsModels: ["tool-sensitive"],
+    };
+    expect(providerManagementConfigError("relay", provider)).toBeNull();
+    for (const omitReasoningEffortWithToolsModels of ["tool-sensitive", [""], ["   "], [42]]) {
+      expect(providerManagementConfigError("relay", {
+        ...provider,
+        omitReasoningEffortWithToolsModels,
+      })).toContain("omitReasoningEffortWithToolsModels");
+    }
+    const dto = safeConfigDTO({
+      port: 10100,
+      defaultProvider: "relay",
+      providers: { relay: provider },
+    } as OcxConfig) as { providers: Record<string, { omitReasoningEffortWithToolsModels?: string[] }> };
+    expect(dto.providers.relay?.omitReasoningEffortWithToolsModels).toEqual(["tool-sensitive"]);
+  });
+
   test("normalizes hand-edited structured-output model opt-outs at load", () => {
     if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
     mkdirSync(TEST_DIR, { recursive: true });
@@ -322,6 +343,26 @@ describe("provider management validation", () => {
 
     expect(loadConfig().providers.relay?.noStructuredOutputModels)
       .toEqual(["deepseek-v4-flash", "other-model"]);
+  });
+
+  test("normalizes hand-edited tool-sensitive reasoning model opt-outs at load", () => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    writeFileSync(join(TEST_DIR, "config.json"), JSON.stringify({
+      ...config("127.0.0.1"),
+      defaultProvider: "relay",
+      providers: {
+        relay: {
+          adapter: "openai-chat",
+          baseUrl: "https://relay.example/v1",
+          omitReasoningEffortWithToolsModels: [" tool-sensitive ", "tool-sensitive", " sibling "],
+        },
+      },
+    }));
+
+    expect(loadConfig().providers.relay?.omitReasoningEffortWithToolsModels)
+      .toEqual(["tool-sensitive", "sibling"]);
   });
 
   test("provider management rejects modelCosts rows with extra fields", () => {

--- a/tests/openai-chat-hardening.test.ts
+++ b/tests/openai-chat-hardening.test.ts
@@ -111,6 +111,41 @@ function routedProvider(name: "litellm" | "ollama", apiKey?: string): OcxProvide
 }
 
 describe("openai-chat request hardening", () => {
+  test("omits reasoning effort only for configured tool-bearing model requests", () => {
+    const configured = provider({
+      modelReasoningEfforts: { "tool-sensitive": ["low", "high"] },
+      omitReasoningEffortWithToolsModels: ["tool-sensitive"],
+    });
+    const withTools = createOpenAIChatAdapter(configured).buildRequest({
+      ...parsed(),
+      modelId: "tool-sensitive",
+      options: { reasoning: "high" },
+      context: {
+        messages: [{ role: "user", content: "hi", timestamp: 0 }],
+        tools: [{ name: "probe", description: "probe", parameters: { type: "object" } }],
+      },
+    });
+    expect(JSON.parse(withTools.body)).not.toHaveProperty("reasoning_effort");
+
+    const withoutTools = createOpenAIChatAdapter(configured).buildRequest({
+      ...parsed(),
+      modelId: "tool-sensitive",
+      options: { reasoning: "high" },
+    });
+    expect(JSON.parse(withoutTools.body)).toMatchObject({ reasoning_effort: "high" });
+
+    const sibling = createOpenAIChatAdapter(configured).buildRequest({
+      ...parsed(),
+      modelId: "ordinary",
+      options: { reasoning: "high" },
+      context: {
+        messages: [{ role: "user", content: "hi", timestamp: 0 }],
+        tools: [{ name: "probe", description: "probe", parameters: { type: "object" } }],
+      },
+    });
+    expect(JSON.parse(sibling.body)).toMatchObject({ reasoning_effort: "high" });
+  });
+
   test("strips Responses-only encrypted annotations without changing schema names or literal values", () => {
     const parameters = {
       type: "object",


### PR DESCRIPTION
## Summary

- Add omitReasoningEffortWithToolsModels for OpenAI Chat targets that support selectable reasoning on ordinary requests but reject the tools plus reasoning-parameter combination. The adapter omits the incompatible wire field only when the request actually carries tools.
- Add opt-in Combo reasoningEffortMode: adaptive. Default strict behavior remains unchanged; adaptive derives the picker ladder from non-empty target ladders while concrete targets still omit unsupported effort fields.
- Validate, normalize, expose, PATCH, and document both configuration surfaces.

Closes #2731

## Verification

- Focused adapter, provider-validation, combo, catalog, and management tests: 403 pass.
- bun run typecheck
- bun run test using the repository standard preload and parallel runner.
- bun run privacy:scan
- docs-site: bun install --frozen-lockfile and bun run build.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.
- [ ] Local CI green against the current PR commit.
- [ ] Branch is on the latest dev commit.
- [ ] All correct Codex and CodeRabbit findings are fixed.
- [ ] Ready for review confirmation.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
