### PR TITLE
fix(scripts): restart proxy without setsid on macOS

### DIFF
--- a/devlog/_plan/260827_ocx_restart_macos_portability/000_plan.md
+++ b/devlog/_plan/260827_ocx_restart_macos_portability/000_plan.md
@@ -1,0 +1,67 @@
+# Portable detached restart on macOS
+
+## Loop specification
+
+- Archetype: repair
+- Trigger: `scripts/ocx-restart.sh` stops the active proxy and cannot relaunch it when `setsid` is unavailable.
+- Goal: the helper relaunches the development proxy on macOS while preserving the existing `setsid` isolation path where that command exists.
+- Non-goals: change service-manager semantics, change the proxy runtime, alter provider configuration, include the unrelated `package.json` edit, or publish a package release.
+- Verifier: a focused Bun test executes the real shell script with a controlled command path that deliberately has no `setsid`; `bash -n` checks shell syntax; live launchd status and `/healthz` prove operational recovery.
+- Stop condition: focused/full repository gates required by `scripts/AGENTS.md` pass, the exact scoped commit reaches `origin/dev`, and the repaired service answers on port 10100.
+- Memory artifact: this document plus the commit and command receipts reported at completion.
+- Expected terminal outcomes: DONE when code, push, and live recovery are proven; BLOCKED if current `origin/dev` moves incompatibly or launchd repair fails after the code fix.
+- Escalation condition: return to diagnosis if the no-`setsid` path still fails or if `ocx service repair` cannot produce a loaded healthy service.
+
+## Scope
+
+### In
+
+- `scripts/ocx-restart.sh`: select the existing `setsid` launch when available and a `nohup` fallback when it is not.
+- `tests/install-scripts.test.ts`: execute the real helper in an isolated home with command shims and no `setsid`, asserting that both stop and start are reached and the helper reports healthy.
+- This unit record, moved to `_fin/` after verification.
+
+### Out
+
+- `package.json` and every other pre-existing user change.
+- `src/service.ts`, launchd plist generation, provider routing, and Codex configuration.
+- Release, package publication, or branch cleanup.
+
+## Diff-level plan
+
+1. In `scripts/ocx-restart.sh`, replace the unconditional background launch with a capability check:
+   - when `command -v setsid` succeeds, retain `setsid nohup bun ... &`;
+   - otherwise run `nohup bun ... &` with the same stdin/stdout/stderr detachment;
+   - keep the existing health loop and failure output unchanged.
+2. In `tests/install-scripts.test.ts`, add a non-Windows behavior test that:
+   - creates an isolated `HOME` and a `PATH` containing only required command shims, intentionally omitting `setsid`;
+   - records fake Bun stop/start invocations, creates the runtime port and PID files on start, and makes the health probe succeed;
+   - invokes the repository's real restart script and asserts exit 0, healthy output, and ordered stop/start calls.
+3. Run the focused test, shell syntax check, typecheck, full test suite, and privacy scan. Inspect the staged diff to prove `package.json` is excluded.
+4. Commit named paths only, refresh the remote lease, and push `dev` with `--force-with-lease --no-verify` as explicitly authorized.
+5. Run `ocx service repair`, then verify a loaded service, a live PID/listener on 10100, HTTP 200 from `/healthz`, and healthy `ocx status`.
+
+## Acceptance criteria
+
+| Scenario | Activation | Observable proof |
+| --- | --- | --- |
+| `setsid` unavailable | Test `PATH` omits `setsid` while providing all other commands | Script exits 0, fake Bun log records stop then start, stdout reports healthy |
+| `setsid` available | Static review preserves the existing branch and shell syntax remains valid | Diff retains `setsid nohup`; `bash -n scripts/ocx-restart.sh` exits 0 |
+| Unrelated dirty work | `package.json` remains modified before and after commit | `git show --name-only` contains only the script, test, and unit record; working tree still shows `M package.json` |
+| Live service recovery | Run `ocx service repair` after the pushed fix | launchd is loaded, 10100 has a listener, `/healthz` returns HTTP 200, status reports running |
+
+## Verifier preflight
+
+- `bun test tests/install-scripts.test.ts`: exit 0 with 9 passing tests before the change. It does not yet observe `scripts/ocx-restart.sh`; the planned behavior test makes it the focused verifier in B/C.
+- `bash -n scripts/ocx-restart.sh`: exit 0 and directly reads the target script, proving syntax only.
+- `bun run typecheck`, `bun run test`, and `bun run privacy:scan`: repository-defined gates; their post-change receipts are required by `scripts/AGENTS.md` before completion.
+
+## Rollback
+
+Revert the scoped commit and run `ocx service repair` from the restored `dev` source. The existing launchd plist and user configuration are not modified by the code patch.
+
+## Build evidence
+
+- RED: `bun test tests/install-scripts.test.ts` failed the new no-`setsid` case with exit 1 on the unconditional launch.
+- GREEN: the same focused file passed 10 tests after the capability fallback; `bash -n scripts/ocx-restart.sh` and `git diff --check` also exited 0.
+- Operator override: the manually started `bun run prepush` was interrupted on request. Typecheck and the GUI no-change gate completed before interruption, but the incomplete full suite is not claimed as passing.
+- Pending terminal evidence: exact scoped commit/push and live launchd recovery.

--- a/scripts/ocx-restart.sh
+++ b/scripts/ocx-restart.sh
@@ -16,9 +16,14 @@ sleep 2
 rm -f "$HOME/.opencodex/ocx.pid"
 
 echo "[ocx-restart] starting detached proxy (log: $LOG_FILE)..."
-# setsid + nohup fully detaches from the controlling terminal and process group, so the proxy
-# survives the agent turn. </dev/null prevents any stdin coupling.
-setsid nohup bun run src/cli/index.ts start >"$LOG_FILE" 2>&1 </dev/null &
+# setsid + nohup fully detaches from the controlling terminal and process group where setsid
+# is available. macOS does not ship setsid, so fall back to nohup there. </dev/null prevents
+# stdin coupling, and disown below removes the job from this shell's lifecycle.
+if command -v setsid >/dev/null 2>&1; then
+  setsid nohup bun run src/cli/index.ts start >"$LOG_FILE" 2>&1 </dev/null &
+else
+  nohup bun run src/cli/index.ts start >"$LOG_FILE" 2>&1 </dev/null &
+fi
 disown || true
 
 for i in $(seq 1 30); do

--- a/tests/install-scripts.test.ts
+++ b/tests/install-scripts.test.ts
@@ -32,6 +32,20 @@ function removeModeFixture(path: string): void {
   try { rmSync(path, { recursive: true, force: true }); } catch { /* best-effort cleanup */ }
 }
 
+function systemCommandPath(command: string): string {
+  const result = spawnSync("/bin/sh", ["-c", `command -v ${command}`], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error(`required test command is unavailable: ${command}`);
+  }
+  return result.stdout.trim();
+}
+
+function writeExecutable(path: string, source: string): void {
+  writeFileSync(path, source, { encoding: "utf8", mode: 0o755 });
+}
+
 async function readText(path: string): Promise<string> {
   return await Bun.file(new URL(path, root)).text();
 }
@@ -113,6 +127,58 @@ describe("install scripts", () => {
     expect(script).not.toContain("bun install -g @bitkyc08/opencodex");
     expect(script).not.toContain("bun.sh/install.ps1");
   });
+
+  test.skipIf(process.platform === "win32")(
+    "restart helper launches without setsid in PATH",
+    async () => {
+      const fixtureRoot = mkdtempSync(join(tmpdir(), "ocx-restart-no-setsid-"));
+      const home = join(fixtureRoot, "home");
+      const binDir = join(fixtureRoot, "bin");
+      const callsPath = join(fixtureRoot, "bun-calls.log");
+      const restartLog = join(fixtureRoot, "restart.log");
+
+      try {
+        mkdirSync(join(home, ".opencodex"), { recursive: true });
+        mkdirSync(binDir, { recursive: true });
+        for (const command of ["cat", "dirname", "nohup", "rm", "seq", "tail"]) {
+          symlinkSync(systemCommandPath(command), join(binDir, command));
+        }
+        writeExecutable(join(binDir, "sleep"), "#!/bin/sh\n/bin/sleep 0.02\n");
+        writeExecutable(join(binDir, "node"), "#!/bin/sh\nprintf '10100'\n");
+        writeExecutable(join(binDir, "curl"), "#!/bin/sh\nexit 0\n");
+        writeExecutable(join(binDir, "bun"), `#!/bin/sh
+printf '%s\\n' "$*" >> "$OCX_TEST_CALLS"
+if [ "$3" = "start" ]; then
+  /bin/mkdir -p "$HOME/.opencodex"
+  printf '{"port":10100}\\n' > "$HOME/.opencodex/runtime-port.json"
+  printf '%s\\n' "$$" > "$HOME/.opencodex/ocx.pid"
+fi
+exit 0
+`);
+
+        const result = spawnSync("/bin/bash", [join(repoRoot, "scripts/ocx-restart.sh")], {
+          cwd: repoRoot,
+          encoding: "utf8",
+          env: {
+            HOME: home,
+            PATH: binDir,
+            OCX_RESTART_LOG: restartLog,
+            OCX_TEST_CALLS: callsPath,
+          },
+          timeout: 10_000,
+        });
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain("[ocx-restart] healthy on port 10100");
+        expect((await Bun.file(callsPath).text()).trim().split("\n")).toEqual([
+          "run src/cli/index.ts stop",
+          "run src/cli/index.ts start",
+        ]);
+      } finally {
+        removeModeFixture(fixtureRoot);
+      }
+    },
+  );
 
   test("Node launcher handles npm self-update before starting Bun", async () => {
     const launcher = await readText("bin/ocx.mjs");


### PR DESCRIPTION
## Summary

- Make `scripts/ocx-restart.sh` retain its `setsid` launch where available and fall back to `nohup` on macOS, where `setsid` is absent.
- Add a behavioral regression test that executes the real helper with an isolated `PATH` lacking `setsid` and proves both stop and start are reached.
- Record the repair scope and evidence in the public devlog.

## Verification

- `bun test tests/install-scripts.test.ts` — 10 pass, 0 fail.
- `bash -n scripts/ocx-restart.sh` — exit 0.
- `git diff --check` — exit 0.
- `bun run prepush` was interrupted at the operator's request after typecheck and the GUI no-change gate completed; the incomplete full suite is not claimed as passing.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detached restart behavior on macOS systems where `setsid` is unavailable.
  * Ensured restart output is consistently redirected and the process runs independently in the background.

* **Tests**
  * Added coverage validating restart recovery in a sandboxed POSIX environment.
  * Verified the service reaches a healthy state and follows the expected stop-then-start sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->