### PR TITLE
docs(devlog): close macOS restart repair

### DIFF
--- a/devlog/_fin/260827_ocx_restart_macos_portability/000_plan.md
+++ b/devlog/_fin/260827_ocx_restart_macos_portability/000_plan.md
@@ -64,4 +64,6 @@ Revert the scoped commit and run `ocx service repair` from the restored `dev` so
 - RED: `bun test tests/install-scripts.test.ts` failed the new no-`setsid` case with exit 1 on the unconditional launch.
 - GREEN: the same focused file passed 10 tests after the capability fallback; `bash -n scripts/ocx-restart.sh` and `git diff --check` also exited 0.
 - Operator override: the manually started `bun run prepush` was interrupted on request. Typecheck and the GUI no-change gate completed before interruption, but the incomplete full suite is not claimed as passing.
-- Pending terminal evidence: exact scoped commit/push and live launchd recovery.
+- Delivery: direct `dev` push was rejected by the active PR-only ruleset, so PR #2735 merged the exact scoped commit with merge commit `056d2996bcc0121b54bcbc0f2abf4df25633e794`. Local `dev`, `origin/dev`, and `git ls-remote` matched that SHA afterward.
+- Live recovery: `ocx service repair` exited 0; launchd reported `state = running`, PID 83423 owned `127.0.0.1:10100`, `/healthz` returned HTTP 200 with `status: ok`, and `/v1/models` returned HTTP 200.
+- Terminal outcome: DONE. The unrelated `package.json` edit remains uncommitted and preserved.


### PR DESCRIPTION
## Summary

- Move the completed macOS restart repair record from `devlog/_plan` to `devlog/_fin`.
- Record the landed `dev` SHA and live launchd, listener, and HTTP health evidence.

## Verification

- `ocx service repair` — exit 0.
- `ocx service status` — installed, loaded, and serving on port 10100.
- `GET /healthz` and `GET /v1/models` — HTTP 200.
- `git rev-parse HEAD origin/dev` and `git ls-remote` matched the landed repair SHA before this docs-only closeout.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build and release records to reflect completed delivery.
  * Documented successful service recovery and confirmed the service is running normally.
  * Added verification results showing health and model endpoints responded successfully.
  * Recorded the final outcome as complete while preserving unrelated pending work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->