### PR TITLE
fix(server): keep source checkout live during edits

### DIFF
--- a/src/lib/package-tree-integrity.ts
+++ b/src/lib/package-tree-integrity.ts
@@ -16,6 +16,7 @@ export interface PackageTreeIntegrityGuard {
 }
 
 type ObservePackageTree = () => PackageTreeObservation | null;
+type PackageTreeRuntimeInstall = "bun" | "npm" | "source";
 
 const packageManifestUrl = new URL("../../package.json", import.meta.url);
 
@@ -82,4 +83,19 @@ export function createPackageTreeIntegrityGuard(
       return { ok: true };
     },
   };
+}
+
+/**
+ * Installed packages fail closed when their manifest is replaced under a live process.
+ * A source checkout is different: editing package.json is ordinary development work, and
+ * Bun keeps serving the module snapshot already loaded by this process until the operator
+ * chooses to restart. Fencing every request there makes running dev directly impossible.
+ */
+export function createRuntimePackageTreeIntegrityGuard(
+  installer: PackageTreeRuntimeInstall,
+  observe: ObservePackageTree = observePackageManifest,
+  now: () => number = Date.now,
+): PackageTreeIntegrityGuard {
+  if (installer === "source") return { status: () => ({ ok: true }) };
+  return createPackageTreeIntegrityGuard(observe, now);
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -203,9 +203,10 @@ import { SYSTEM_RESTART_CAPABILITY_VERSION } from "../lib/system-restart-contrac
 import { LOCAL_PROVIDER_RELOAD_CAPABILITY_VERSION } from "../lib/local-provider-reload-contract";
 import { createReadinessGate, type ReadinessGate } from "./readiness";
 import {
-  createPackageTreeIntegrityGuard,
+  createRuntimePackageTreeIntegrityGuard,
   type PackageTreeIntegrityGuard,
 } from "../lib/package-tree-integrity";
+import { detectInstall } from "../update/index";
 
 export const MAX_WS_FRAME_BYTES = 50 * 1024 * 1024;
 const WEBSOCKET_IDLE_TIMEOUT_SECONDS = 0;
@@ -739,7 +740,8 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
   // passes it in, and transitions it after the post-startup sync settles. When
   // no gate is supplied (tests, ad-hoc starts) a fresh pending gate is created.
   const readinessGate = deps.readinessGate ?? createReadinessGate();
-  const packageTreeIntegrity = deps.packageTreeIntegrity ?? createPackageTreeIntegrityGuard();
+  const packageTreeIntegrity = deps.packageTreeIntegrity
+    ?? createRuntimePackageTreeIntegrityGuard(detectInstall());
   // Actual bound port, filled in after Bun.serve binds so /readyz reports the
   // real ephemeral port for startServer(0). /healthz keeps its existing port
   // field (the requested listenPort) byte-for-byte.

--- a/tests/package-tree-integrity.test.ts
+++ b/tests/package-tree-integrity.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { saveConfig } from "../src/config";
 import {
   createPackageTreeIntegrityGuard,
+  createRuntimePackageTreeIntegrityGuard,
   type PackageTreeObservation,
 } from "../src/lib/package-tree-integrity";
 import { startServer } from "../src/server";
@@ -45,6 +46,52 @@ afterEach(() => {
 });
 
 describe("package tree integrity", () => {
+  test("source checkouts stay live when package.json changes during development", () => {
+    let observation: PackageTreeObservation = {
+      device: 1n,
+      inode: 10n,
+      contentTimeNs: 100n,
+      size: 500n,
+    };
+    let clock = 0;
+    const sourceGuard = createRuntimePackageTreeIntegrityGuard(
+      "source",
+      () => observation,
+      () => clock,
+    );
+    const installedGuard = createPackageTreeIntegrityGuard(
+      () => observation,
+      () => clock,
+    );
+
+    expect(sourceGuard.status()).toEqual({ ok: true });
+    expect(installedGuard.status()).toEqual({ ok: true });
+    observation = { device: 1n, inode: 11n, contentTimeNs: 200n, size: 700n };
+    clock += 2_000;
+    expect(sourceGuard.status()).toEqual({ ok: true });
+    expect(installedGuard.status()).toEqual({ ok: false, reason: "package_tree_replaced" });
+  });
+
+  test.each(["npm", "bun"] as const)("%s installs still refuse a replaced package tree", installer => {
+    let observation: PackageTreeObservation = {
+      device: 1n,
+      inode: 10n,
+      contentTimeNs: 100n,
+      size: 500n,
+    };
+    let clock = 0;
+    const guard = createRuntimePackageTreeIntegrityGuard(
+      installer,
+      () => observation,
+      () => clock,
+    );
+
+    expect(guard.status()).toEqual({ ok: true });
+    observation = { ...observation, inode: 11n, contentTimeNs: 200n };
+    clock += 2_000;
+    expect(guard.status()).toEqual({ ok: false, reason: "package_tree_replaced" });
+  });
+
   test("detects replacement even when the package version and file size are unchanged", () => {
     let observation: PackageTreeObservation = {
       device: 1n,


### PR DESCRIPTION
## Summary

- Keep the package-tree replacement fence for npm and Bun global installs.
- Disable that fence for source checkouts, where editing `package.json` is normal development work and the running process continues serving its already-loaded module snapshot.
- Add A/B regression coverage proving the same manifest replacement is accepted for a source checkout and refused for installed runtimes.

## Verification

- `bun test tests/package-tree-integrity.test.ts` — 10 pass, 0 fail.
- `bun run typecheck` — exit 0.
- `git diff --check` — exit 0.
- Full `prepush` was not run, following the operator's explicit no-verify instruction.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Source checkouts now remain usable when package metadata changes during development.
  * Installed npm and Bun packages continue to detect and block replaced package trees.
* **Tests**
  * Added coverage for source-based development workflows and installed package integrity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->