### PR TITLE
docs(devlog): dev hardening inventory and remediation roadmap

### DIFF
--- a/devlog/_plan/260827_dev_hardening/000_inventory.md
+++ b/devlog/_plan/260827_dev_hardening/000_inventory.md
@@ -1,0 +1,111 @@
+# 260827 dev hardening — inventory
+
+Head: `dev` @ `7547c8937`. Baseline: `origin/main` @ `ec51e42d7` (`v2.33.0`).
+Delta: 254 commits, 551 files, +44296/-1917. Goal: make this head promotable.
+
+## Baseline that already holds
+
+| gate | result |
+|---|---|
+| full suite on `ssh lidge` at `7547c8937` | `hardsuite: OK rc=0` |
+| dev CI on `7547c8937` | `completed success` |
+| `bun x tsc --noEmit` | clean |
+| `bun run privacy:scan` | passed |
+| `bun run lint:gui` | exit 0 (1 warning) |
+| `docs-site` build | 401 pages, success |
+
+Earlier dev runs show `cancelled` for `70159d9e7` and `77e037077`. That is
+`concurrency: cancel-in-progress: true` (`.github/workflows/ci.yml:52-54`) superseding
+in-flight runs as merges landed back to back — not failures. The head run is green.
+
+## Blocker 1 — promoting this head produces an unpublishable version
+
+`dev` has not touched `package.json` since the merge base, so the merge RESULT carries
+the already-consumed release string:
+
+```
+$ git merge-tree --write-tree origin/main origin/dev -> tree 6c33df7a8
+$ git cat-file -p 6c33df7a8:package.json | jq -r .version
+2.33.0
+
+$ npm view @bitkyc08/opencodex dist-tags
+{ "latest": "2.33.0", "preview": "2.33.0-preview.20260825" }
+```
+
+So a `dev` -> `main` promotion succeeds in git and then fails at publish:
+`assertUnusedReleaseVersion` (`scripts/release.ts`) refuses a consumed version, and
+`release.yml` refuses an existing npm version / git tag / GitHub Release. The trap is
+that `release.yml`'s documented "bump package.json before dispatching" path leaves
+`2.33.0` already matching, so the version check PASSES and the failure only surfaces at
+`npm publish`.
+
+`dev`'s own string is worse: `2.32.1-preview.20260825` is BEHIND `latest`, so
+`assertChannelVersionMovesForward` rejects it as a channel regression. It is also the
+runtime identity — `src/cli/help.ts`, `src/server/management-api.ts`,
+`src/update/index.ts`, `bin/ocx.mjs` all read it — so `ocx --version` on a source
+install prints a preview npm superseded twice, and `defaultUpdateTag()` reads the
+`-preview.` suffix and points `ocx update` at the preview channel.
+
+`2.34.0` is free (`npm view ... E404`, no `v2.34.0` tag). This exact class was already
+fixed once in `32529c2b2` / PR #2136.
+
+## Blocker 2 — credential identity is not fully rebound after 429 rotation
+
+`applyFailoverSnapshot` (`src/server/responses/core.ts:2830-2845`) swaps `apiKey`,
+Copilot transport, Antigravity `project` and Kiro context — but does NOT update
+`sentOAuthSnapshot`, which is assigned once at line 2883.
+
+A later pre-stream 401 (lines 3516-3529, 5043-5055) refreshes
+`forceRefreshOAuthAccessSnapshot(sentOAuthSnapshot)` — still account A — after HTTP 429
+already rotated to account B at line 5219. The Copilot transport is then resolved from
+the ACTIVE credential rather than the refreshed snapshot, so A's bearer can be paired
+with B's allowlisted `*.githubcopilot.com` origin. Preventing exactly that mix is why
+the failover snapshot exists.
+
+Related, same root cause: the runTurn 429 path (line 4632) clears Cursor conversation
+state and rebinds replay identity, but the HTTP 429 path (5219) and the sidecar 429
+path (4330) do not. Continuation/thought-signature state minted under A can be replayed
+under B.
+
+## Not a defect — presence-driven failover default
+
+Rotation defaults on when 2+ eligible accounts exist
+(`src/oauth/generic-account-failover.ts:104-128`, "Presence IS consent", #2568d).
+A reviewer flagged this as a release risk. It is a recorded owner decision with explicit
+precedence (per-provider boolean > global boolean > presence), and `hasKeyPoolFailover`
+already reads a 2+ key pool the same way. Left as-is; the stale comment at
+`core.ts:5194` calling it "opt-in and a strict no-op otherwise" is wrong and should be
+corrected.
+
+## Docs contradict the code in shipped locales
+
+```
+$ for k in defaultModelAliases promptCacheKey oauthAccountFailover auto_review_model noProxy; do ...
+defaultModelAliases: en=1 locales=0
+promptCacheKey:      en=1 locales=0
+oauthAccountFailover:en=1 locales=0
+auto_review_model:   en=1 locales=0
+noProxy:             en=1 locales=0
+```
+
+Seven locales (fr/ja/ko/ru/tr/zh-cn/zh-tw) document none of the five new config
+surfaces. Worse, two locales state the OPPOSITE of the code: FR
+`fr/reference/adapters.md:33` and TR `tr/reference/adapters.md:52` say ClinePass clamps
+every requested tier to `low`, while `src/providers/registry.ts:1604` seeds
+`["low","medium","high","xhigh","max"]` and the English page says the tier is preserved.
+
+## Local gate that fails while CI passes
+
+`bun run doctor:gui` exits 1 on 2 warnings, both the same
+`gui/src/pages/Models.tsx:498` missing-dependency finding. The omission is deliberate
+and documented in-file, but the suppression comment names `react/react-compiler` and
+`eslint react-hooks/exhaustive-deps` — neither silences oxlint's own
+`react-hooks(exhaustive-deps)` nor react-doctor's `react-doctor/exhaustive-deps`.
+
+`doctor:gui` is part of `prepush`, so every gui-touching push needs `--no-verify`.
+
+## Deferred from the bug-PR merge round
+
+1. `parsedProfileEfforts` cannot read commandcode.ai profiles (dead for every row).
+2. Field backfill mutates verbatim passthrough bodies (`status` and `created_at`).
+3. #2671's "probed 2026-08-26" provenance is unverified on a merged change.

--- a/devlog/_plan/260827_dev_hardening/010_wp2_version_line.md
+++ b/devlog/_plan/260827_dev_hardening/010_wp2_version_line.md
@@ -1,0 +1,56 @@
+# wp2 — move dev's version line past the published channel
+
+Blocker 1 in `000_inventory.md`. Smallest change with the largest promotion impact.
+
+## The change
+
+`package.json` `version`: `2.32.1-preview.20260825` -> `2.34.0`.
+
+One line. No other file carries the product version: a repo-wide search for the
+current and neighbouring version strings, excluding `node_modules`, `.tmp`, `devlog`
+and `gui/dist`, hits only `package.json:3`. `gui/package.json` is `0.0.0` and
+unpublished; `docs-site/package.json` is `0.0.1`; `src/generated/*` are catalog
+hashes, not semver; the install scripts check Node, not opencodex.
+
+## Why `2.34.0` and not something else
+
+| candidate | verdict |
+|---|---|
+| `2.32.1-preview.20260825` (current) | BEHIND `latest`; rejected by `assertChannelVersionMovesForward` |
+| `2.33.0` | consumed — on npm, tagged `v2.33.0`, GitHub Release exists |
+| `2.33.0-preview.*` | moves preview forward but strands the `2.33.0` core, which is already stable |
+| `2.33.1` | mechanically legal, but labels 254 commits / 551 files / +44296 as a patch |
+| **`2.34.0`** | free (`npm view` E404, no `v2.34.0` tag), forward on `latest`, matches the range's content |
+
+The minor-not-patch choice follows the precedent recorded in `32529c2b2`: "2.27.0
+rather than 2.26.1, because the range carries user-visible behavior changes and not
+only fixes." This range carries new providers, new config surfaces, GUI work and
+adapter contract changes.
+
+## What this does NOT do
+
+It does not publish, tag, or promote. `scripts/release.ts` refuses to run anywhere but
+`main`/`preview`, and the actual release remains a maintainer action. This only stops
+`dev` from carrying a string that is both a channel regression and, after promotion, an
+unpublishable duplicate.
+
+Do NOT "sync" by merging `main`/`preview` back into `dev`: that lands the consumed
+`2.33.0` string on top of 254 newer commits and reintroduces the same trap.
+
+## Regression test
+
+`tests/release-version-line.test.ts` (new): assert the in-tree version is a valid
+semver AND is strictly forward of the highest version reachable from
+`origin/main`'s tags in the repository, so a future `dev` cannot silently sit behind
+its own release branch again. This is the check `32529c2b2` fixed by hand once and
+that nothing currently enforces.
+
+If the test cannot read remote refs in CI, scope it to the local tag set and skip
+cleanly when no tags are present, rather than asserting a hardcoded number that would
+need editing every release.
+
+## Verification
+
+- `bun x tsc --noEmit`
+- `bun test ./tests/release-version-line.test.ts` and `./tests/release-helper.test.ts`
+- full suite on `ssh lidge` at the branch head

--- a/devlog/_plan/260827_dev_hardening/020_wp3_failover_identity.md
+++ b/devlog/_plan/260827_dev_hardening/020_wp3_failover_identity.md
@@ -1,0 +1,75 @@
+# wp3 — rebind credential identity on every 429 rotation
+
+Blocker 2 in `000_inventory.md`. A credential-routing defect, so it is also the phase
+that needs maintainer security review per `MAINTAINERS.md` before it lands.
+
+## The defect
+
+`sentOAuthSnapshot` is assigned once (`src/server/responses/core.ts:2883`) and is the
+input to the pre-stream 401 refresh at lines 3523 and 5050.
+`applyFailoverSnapshot` (2830-2845) rotates the provider on 429 but never updates it.
+
+Sequence that mixes identity:
+
+```
+1. request built with account A            -> sentOAuthSnapshot = A
+2. upstream 429                            -> applyFailoverSnapshot(B)
+                                              route.provider.apiKey = B
+                                              Copilot transport = B's origin
+                                              sentOAuthSnapshot STILL A
+3. rebuilt request 401                     -> forceRefreshOAuthAccessSnapshot(A)
+4. transport resolved from ACTIVE credential, not the refreshed snapshot
+   -> A's bearer can travel to B's allowlisted *.githubcopilot.com origin
+```
+
+Preventing exactly that pairing is the stated purpose of the failover snapshot
+(`src/oauth/index.ts:62`). The Copilot origin allowlist itself is tight
+(`src/oauth/github-copilot.ts:118`) — the defect is using the RIGHT allowlist for the
+WRONG account.
+
+## Second half of the same root cause
+
+Only the runTurn 429 path rebinds replay identity:
+
+| rotation site | line | clears Cursor state | updates replayOAuthCredentialSnapshot | binds replay scope |
+|---|---|---|---|---|
+| runTurn 429 | 4632 | yes | yes | yes |
+| HTTP 429 | 5219 | no | no | no |
+| sidecar 429 | 4330 | no | no | binds WITHOUT oauthCredentialSnapshot |
+
+So continuation and thought-signature state minted under A can be replayed under B, and
+for Cursor image turns the conversation id copied back by `src/images/loop.ts:447` can
+cross accounts.
+
+## The fix
+
+Move the identity rebind INTO `applyFailoverSnapshot` so no rotation site can forget
+it. It becomes the single place that:
+
+1. sets `sentOAuthSnapshot = snapshot`
+2. sets `replayOAuthCredentialSnapshot = { accountId, generation }`
+3. clears Cursor conversation/checkpoint state
+4. calls `bindRouteReasoningReplayScope({ ..., oauthCredentialSnapshot })`
+
+and on the 401 path, resolve the transport from `refreshed.apiBaseUrl` rather than
+`getOAuthCredentialApiBaseUrl()`, which reads whatever credential is active now.
+
+Doing it inside the helper rather than at each call site is the point: three sites
+already diverged, and a fourth would diverge again.
+
+## Regression tests
+
+Behavioral, not `coreSource.indexOf` string checks — the existing coverage for this
+area asserts on source text, which cannot catch a rotation site that forgets a step.
+
+1. Copilot A -> 429 -> rotate to B -> 401: assert the retried request carries B's
+   bearer AND B's origin. Fails today.
+2. HTTP 429 rotation: assert `replayOAuthCredentialSnapshot` names the rotated account.
+3. Cursor sidecar 429: assert `_cursorConversationId` does not survive the rotation.
+
+## Boundary
+
+This is an authentication/credential surface. `MAINTAINERS.md` requires explicit
+security review, and the hygiene gate will label it `unsponsored_surface`. Do NOT
+self-apply `maintainer-sponsored`. Land the branch, post the evidence, and let a
+maintainer make the call.

--- a/devlog/_plan/260827_dev_hardening/030_wp4_locale_docs.md
+++ b/devlog/_plan/260827_dev_hardening/030_wp4_locale_docs.md
@@ -1,0 +1,66 @@
+# wp4 — stop shipping locale docs that contradict the code
+
+GitHub Pages publishes every locale. Two of them currently tell operators the opposite
+of what the code does, and seven document none of the config surfaces added since
+`main`.
+
+## Contradiction (fix first)
+
+`src/providers/registry.ts:1604` seeds ClinePass with
+`["low","medium","high","xhigh","max"]`, with a comment recording a 2026-08-13 live
+probe across every static model. English says the requested tier is preserved.
+
+- `fr/reference/adapters.md:33` — "limite les autres niveaux demandés au niveau `low`"
+- `tr/reference/adapters.md:52` — same claim
+
+French's own `fr/guides/providers.md:268` already agrees with English, so the FR docs
+contradict each other as well. Rewrite both bullets to match English.
+
+## Missing surfaces
+
+```
+defaultModelAliases  en=1 locales=0
+promptCacheKey       en=1 locales=0
+oauthAccountFailover en=1 locales=0
+auto_review_model    en=1 locales=0
+noProxy              en=1 locales=0
+```
+
+Across fr/ja/ko/ru/tr/zh-cn/zh-tw. `oauthAccountFailover` is the one that matters most:
+it defaults ON with 2+ accounts and can spend a second subscription, and the English
+page carries a terms-of-service warning that no locale reader will see.
+
+Also stale: fr/ru/tr/zh-tw `adapters.md` still describe Responses passthrough as
+untranslated, after this cycle added system-message folding, `truncation` stripping and
+`prompt_cache_breakpoint` removal. And `zh-tw/reference/adapters.md:125` still presents
+`unsafeAllowNativeLocalExec` as the live control for a sandbox-bypass feature whose
+current opt-in is `nativeLocalExec: "on"`.
+
+## Scope decision
+
+Full translation of every English diff into seven locales is not this loop's work and
+would produce machine-translated docs nobody verified. The bar here is: **no locale may
+state the opposite of the code.**
+
+Priority order:
+
+1. FR/TR ClinePass contradiction — factually wrong, fix now.
+2. ZH-TW native-exec flag — security-relevant control, fix now.
+3. fr/ru/tr/zh-tw passthrough "no translation" — now false, fix now.
+4. The five missing config surfaces — record as a documented gap with an issue rather
+   than bulk-translating in this loop.
+
+## English-side corrections in the same pass
+
+`reference/adapters.md:3` and `reference/architecture.md:18,62` say "seven provider
+adapters". `src/adapters/registry.ts:53` registers command-code, openai-chat,
+anthropic, openai-responses, google, kiro, azure/azure-openai, cursor and mimo-free.
+The count was already wrong on `main`; promotion would carry it forward.
+
+`README.md:24,30,34` render three GIFs that `package.json` `files` does not ship, so
+they 404 on the npm listing. Either add them to `files` or stop referencing them.
+
+## Verification
+
+`cd docs-site && bun run build` (currently 401 pages, success) plus a re-run of the
+locale scan showing the contradictions gone.

--- a/devlog/_plan/260827_dev_hardening/040_wp5_local_gates.md
+++ b/devlog/_plan/260827_dev_hardening/040_wp5_local_gates.md
@@ -1,0 +1,55 @@
+# wp5 — make the local gates agree with CI
+
+`bun run doctor:gui` exits 1 on `dev`. It is part of `prepush`
+(`package.json` `"prepush"`), so every gui-touching push needs `--no-verify` to get
+through. A gate everyone routinely bypasses is not a gate.
+
+## The finding
+
+Both reported issues are the same line:
+
+```
+2 issues
+Bugs: 2 warnings
+  Missing effect dependencies  react-hooks/exhaustive-deps      src/pages/Models.tsx:498
+  Missing effect dependencies  react-doctor/exhaustive-deps     src/pages/Models.tsx:498
+```
+
+The omission is deliberate. `gui/src/pages/Models.tsx:509-513` explains it: the effect
+calls `loadPresets` and `loadModelDiscovery`, which are plain async loaders rather than
+`useCallback`s, a `useCallback` wrapper trips PreserveManualMemo, and the effect only
+ever needs the current closure.
+
+The suppression comments name `react/react-compiler` and eslint's
+`react-hooks/exhaustive-deps`. Neither silences oxlint's own
+`react-hooks(exhaustive-deps)` nor react-doctor's `react-doctor/exhaustive-deps`,
+which is why the same intentional exception is reported twice and fails the gate.
+
+## Options, in order of preference
+
+1. **Add the matching suppressions.** Extend the existing comment block with the two
+   rule ids actually being reported. Smallest change, preserves the documented
+   reasoning, and makes `prepush` pass without `--no-verify`.
+2. **Satisfy the rule.** Wrap both loaders in `useCallback` and add them to the dep
+   array. Rejected by the in-file note as tripping PreserveManualMemo — verify that
+   claim before choosing this, since it was written for the eslint rule and may not
+   hold for oxlint.
+3. **Change `doctor.config.json` blocking from `warning` to `error`.** Rejected: that
+   silences every future warning, not this one, and `scripts/doctor-gui-if-changed.ts`
+   documents `blocking: "warning"` as the intended contract.
+
+Take option 1 unless option 2 proves clean.
+
+## Why CI passes while local fails
+
+`gui/package.json` runs doctor with `--scope changed --base origin/main`. In CI the
+changed set is the PR's diff; locally on `dev` it is the whole 254-commit,
+551-file range, so the local run inspects far more than CI ever does. That asymmetry is
+worth recording even after the warning is fixed: a green `react-doctor` check on a PR
+does not mean `bun run doctor:gui` is clean on `dev`.
+
+## Verification
+
+- `bun run lint:gui` — exit 0, and confirm the warning count drops to 0
+- `bun run doctor:gui` — exit 0
+- `cd gui && bun run build` — success

--- a/devlog/_plan/260827_dev_hardening/050_wp6_invariant_locks.md
+++ b/devlog/_plan/260827_dev_hardening/050_wp6_invariant_locks.md
@@ -1,0 +1,64 @@
+# wp6 — lock the invariants AGENTS.md claims are enforced
+
+The audit's most useful negative result: the core invariants HOLD on `dev`, but two of
+them are held by nothing except the current code being correct.
+
+## Verified holding (do not "fix")
+
+- `src/router.ts`, `src/server/lifecycle.ts`, `src/server/responses/core.ts` do not
+  reach `src/lab/`, including through dynamic `import()`. Independently re-walked.
+- `src/server/index.ts:519` is `export function startServer` — not async. Bind at
+  1836, activation at 1950, `return` at 1954, with no body-level `await` between.
+  `scheduleStartupRun()` is a `setTimeout(..., 0)`, which does not yield the turn.
+- Hygiene: 0 tracked `160000` gitlinks, no `.gitmodules`, no vendored reference
+  clones, no security triage in open `_plan` (434 markdown files scanned).
+- 13 new `src/` files since `main` all respect the slot pattern.
+
+## Gap 1 — the promised no-await scan was never written
+
+`AGENTS.md` states the synchronous activation guarantee as if it were enforced, and
+`devlog/_fin/260814_lab_core_decoupling/080_activation_is_synchronous.md:143` recorded
+it as a Phase-4 test. `tests/core-lab-boundary.test.ts` contains only the two
+import-graph guards; no such scan exists anywhere under `tests/`.
+
+That matters more than an ordinary missing test. The failure it guards against is
+silent: an `await` added before the activation block lets the synchronous
+subagent-fallback chain observe an empty evidence slot and route subagents to a
+different model than the operator configured. Nothing goes red; the wrong model just
+answers.
+
+**Fix.** Add to `tests/core-lab-boundary.test.ts`:
+
+- fail if `startServer` is declared `async`
+- fail on a non-nested `await` between the `Bun.serve` call and `labActivationRequired`
+- allow the awaits inside the `server.stop` closure (1877, 1888, 1889), which run later
+
+Drive it red once — insert a temporary `await` — to prove it is not vacuous. That is
+the standard `tests/repo-hygiene.test.ts` was held to.
+
+## Gap 2 — the R3-1 profile-less dry-run assertion is missing
+
+`devlog/_fin/260814_lab_core_decoupling/090_audit_round3_closeout.md:47` required a
+behavioral assertion that a genuinely profile-less dry-run registers no slot. The
+production fix is present (`src/server/management/routing-profile-routes.ts:293,368`)
+but `tests/lab-activation.test.ts:62` only checks that a bare config never activates.
+
+This was the exact "guard passes while the property is violated" path from audit round
+3, so leaving it unpinned re-opens the door it was closed for.
+
+**Fix.** One HTTP case: empty `routingProfiles`, dry-run a missing/unknown profile,
+assert `hasPassiveRouteLinker() === false` and no evidence provider registered.
+
+## Also correct the prose
+
+`src/server/responses/core.ts:5194` still describes generic OAuth failover as "opt-in
+and a strict no-op otherwise". Since #2568d it defaults ON at 2+ eligible accounts
+(`src/oauth/generic-account-failover.ts:104-128`). The behavior is a recorded owner
+decision and stays; the comment is simply now false and will mislead the next reader of
+that path.
+
+## Verification
+
+- `bun test ./tests/core-lab-boundary.test.ts ./tests/lab-activation.test.ts`
+- each new assertion driven red once before being accepted
+- full suite on `ssh lidge` at the branch head

--- a/devlog/_plan/260827_dev_hardening/060_wp8_launcher_flake.md
+++ b/devlog/_plan/260827_dev_hardening/060_wp8_launcher_flake.md
@@ -1,0 +1,53 @@
+# wp8 — the launcher-recovery flake is not a budget problem
+
+`tests/update-stop-first.test.ts` > "npm launcher restarts the stopped runtime after a
+staged update failure" failed twice during this round's CI, both times at ~46.8s, while
+passing locally in ~2.5s.
+
+## Why the obvious answer is wrong
+
+The reflex is "raise the timeout". That has already been done twice:
+
+- `34ef53966` raised the readiness wait 15s -> 45s
+- `538a602af` (#2666) then fixed the arithmetic, because 30s spawn + 45s readiness +
+  30s teardown could not fit in a 60s Bun case timeout
+
+Both are ON `dev` (`git merge-base --is-ancestor 538a602af origin/dev` -> true, 174
+commits back). The failure still reproduces. So the budget is no longer the constraint.
+
+## What the timestamp actually says
+
+`PROXY_READY_TIMEOUT_MS = 45_000` (`tests/update-stop-first.test.ts:39`), and
+`waitForProxy` polls `/healthz` every 100ms until that deadline, returning `false` on
+expiry. The observed failure is `expect(await waitForProxy(port)).toBe(true)` receiving
+`false` at 46,797ms — the 45s budget plus the surrounding spawn work.
+
+That is not a case that ran out of room. It is a proxy that did not answer `/healthz`
+within 45 seconds on a loaded macOS runner. The assertion is doing its job; the thing
+under test is genuinely slow or genuinely not recovering.
+
+## What to determine before changing anything
+
+1. Does the recovered proxy eventually become ready — is 45s slow, or never? Capture
+   the child's stdout/stderr on failure instead of discarding it, so the next CI
+   failure says WHY rather than only that readiness expired.
+2. Is the recovery spawn racing the stop that precedes it? The case stops a running
+   proxy, fails a staged update, then expects the launcher to restart the previous
+   version. A port still held by the stopping process would present exactly as
+   "healthz never answers".
+3. Is this macOS-specific? Both observed failures were on the macOS shard.
+
+## Rule for this repository
+
+Per the user's standing instruction — "flacky는 전부 놔두면 안돼" — a rerun-to-green is
+only acceptable after the causal question has been asked. It was asked in this round
+(the diff touches no update/launcher file, and the case has two prior timing repairs),
+which is why the reruns were legitimate. But the underlying slowness is now a KNOWN
+open defect rather than an unexplained blip, and a third timeout bump would be the
+wrong fix.
+
+## Scope
+
+Diagnosis only in this loop unless the capture in (1) immediately reveals the cause.
+A speculative fix to a test that passes locally, on a runner we cannot reproduce, would
+be the same mistake in a new direction.


### PR DESCRIPTION
## Summary

Docs-only. Records the release-readiness audit of `main..dev` (254 commits, 551 files) in `devlog/_plan/260827_dev_hardening/`, one decade doc per remediation phase, plus the launcher-recovery flake diagnosis.

Two blockers are documented with evidence, and neither is fixed here:

1. **Version line** — `dev` never touched `package.json` after the merge base, so `git merge-tree origin/main origin/dev` yields a tree whose version is `2.33.0`: already on npm, tagged, released. `dev`'s own string `2.32.1-preview.20260825` sits *behind* the `latest` dist-tag and is rejected by `assertChannelVersionMovesForward` (`scripts/release.ts:342`). Remediation plan: `010_wp2_version_line.md`.
2. **Credential identity on 429 rotation** — `applyFailoverSnapshot` rotates provider/apiKey/transport but never updates `sentOAuthSnapshot`, so a later 401 refreshes the original account while the transport resolves from the rotated one. This is an auth surface and is left for maintainer security review: `020_wp3_failover_identity.md`.

Lower-severity findings each get their own doc: locale docs that contradict the code (`030`), `doctor:gui` exiting 1 on a deliberate omission (`040`), invariants `AGENTS.md` claims are enforced but that no test locks (`050`), and the launcher flake where both prior timeout repairs are already on `dev` and the 46.8s failure still reproduces (`060`).

## Verification

- Docs-only change: nothing in the build, typecheck, or test path reads from `devlog/`.
- `bun run privacy:scan` does read `devlog/` and passes.
- Baseline this audit was taken against (`7547c8937`): remote full suite `rc=0`, dev CI `completed success`, `tsc` clean, `lint:gui` exit 0, docs-site 401 pages.
- Rebased onto the current `dev` head (`06fa6801d`) before pushing.

## Checklist

- [x] Targets `dev`
- [x] No runtime behavior change
- [x] No security-sensitive material in `devlog/` (open findings are described only where a public diff already reveals the weakness; the failover finding is a code-visible read of committed source, not an unreleased exploit)
- [x] Docs follow the decade-numbered `_plan` convention



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a development-hardening inventory covering release readiness, versioning, credential failover, localized documentation, validation gates, invariant checks, and launcher reliability.
  * Documented identified release blockers, verification plans, regression-test proposals, and deferred issues.
  * Recorded areas where product documentation and behavior need alignment, including configuration coverage and failover descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->