### PR TITLE
[WRONG BRANCH] fix(moonshot): strip parent type/nullable siblings from $ref nodes in tool schemas

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -932,6 +932,61 @@ function isXaiSchemaTarget(provider: OcxProviderConfig): boolean {
   }
 }
 
+/** Moonshot flavored schema targets reject `$ref` nodes that carry a sibling `type`. */
+function isMoonshotSchemaTarget(provider: OcxProviderConfig): boolean {
+  try {
+    const hostname = new URL(provider.baseUrl).hostname;
+    return hostname === "api.kimi.com"
+      || hostname === "api.moonshot.ai"
+      || hostname === "api.moonshot.cn";
+  } catch {
+    return false;
+  }
+}
+
+const MOONSHOT_SCHEMA_MAP_KEYS = new Set(["properties", "$defs", "definitions", "patternProperties"]);
+const MOONSHOT_SCHEMA_LIST_KEYS = new Set(["oneOf", "anyOf", "allOf"]);
+
+/**
+ * Moonshot's JSON-schema validator (used by Kimi coding API) rejects any node that has both
+ * `$ref` and `type`: the type must live on the referenced schema, not the parent. OpenAI
+ * tolerates the parent `type` sibling (strict-mode generated schemas emit it). Recursively
+ * drop `type` (and nullable-ish siblings that only make sense with a concrete type) from any
+ * node that carries `$ref`, leaving the referenced definition intact.
+ */
+function sanitizeMoonshotToolParameters(schema: unknown): unknown {
+  if (Array.isArray(schema)) return schema.map(sanitizeMoonshotToolParameters);
+  if (!schema || typeof schema !== "object") return schema;
+  const input = schema as Record<string, unknown>;
+  if (typeof input.$ref === "string") {
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(input)) {
+      if (key === "type" || key === "nullable") continue; // type belongs on the referenced schema
+      out[key] = MOONSHOT_SCHEMA_MAP_KEYS.has(key) || MOONSHOT_SCHEMA_LIST_KEYS.has(key)
+        ? sanitizeMoonshotToolParameters(value)
+        : value;
+    }
+    return out;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (MOONSHOT_SCHEMA_MAP_KEYS.has(key) && value && typeof value === "object" && !Array.isArray(value)) {
+      const map: Record<string, unknown> = {};
+      for (const [name, child] of Object.entries(value as Record<string, unknown>)) {
+        map[name] = sanitizeMoonshotToolParameters(child);
+      }
+      out[key] = map;
+    } else if (MOONSHOT_SCHEMA_LIST_KEYS.has(key) && Array.isArray(value)) {
+      out[key] = value.map(sanitizeMoonshotToolParameters);
+    } else if (key === "items" || key === "additionalProperties" || key === "not") {
+      out[key] = sanitizeMoonshotToolParameters(value);
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
 const VOLCENGINE_ARK_HOSTNAMES = new Set([
   "ark.cn-beijing.volces.com",
   "ark.ap-southeast.volces.com",
@@ -1228,10 +1283,13 @@ function toolsToChatFormat(parsed: OcxParsedRequest, provider: OcxProviderConfig
   const tools = parsed.context.tools.filter(toolChoiceToolPredicate(parsed.options.toolChoice, parsed.context.tools));
   if (tools.length === 0) return undefined;
   const xaiTarget = isXaiSchemaTarget(provider);
+  const moonshotTarget = isMoonshotSchemaTarget(provider);
   const formatted = tools.flatMap(t => {
     const parameters = stripResponsesOnlyEncryptedMarker(xaiTarget
       ? normalizeXaiToolParameters(t.parameters)
-      : ensureRootObjectType(t.parameters));
+      : moonshotTarget
+        ? sanitizeMoonshotToolParameters(t.parameters)
+        : ensureRootObjectType(t.parameters));
 
     if (parameters === undefined) return [];
     return [{


### PR DESCRIPTION
## Problem

When routing Codex (desktop app, strict mode) through a Moonshot/Kimi provider, **every** tool-calling request fails with HTTP 400 before reaching the model:

```
Provider error 400: tools.function.parameters is not a valid moonshot flavored json schema,
details: <At path '$defs.__schema20': when using $ref, type should be defined in the
referenced schema instead of the parent schema>
```

Root cause: Codex strict mode generates tool parameter schemas where a `$ref` node also carries a sibling `type` (e.g. `{ "$ref": "#/$defs/__schema20", "type": "string" }`). OpenAI's API tolerates this; Moonshot's validator requires `type` to live **inside the referenced schema** and rejects the parent sibling outright.

opencodex already has schema-sanitizing precedent for other providers (zen/xai), but Moonshot targets were forwarded verbatim, so the request always blew up.

## Fix

Scope: `src/adapters/openai-chat.ts` only.

1. **`isMoonshotSchemaTarget()`** — detects Moonshot hosts (`api.kimi.com`, `api.moonshot.ai`, `api.moonshot.cn`) from the provider `baseUrl`.
2. **`sanitizeMoonshotToolParameters()`** — recursively walks the tool parameter schema; on any node carrying `$ref` it drops the sibling `type` / `nullable` (the type belongs on the referenced definition), while leaving `$defs`, `properties`, `oneOf`/`anyOf`/`allOf`, `items`, and all other structure intact. Non-`$ref` nodes pass through untouched.
3. Sanitization is applied **only** for Moonshot targets — all other providers keep the existing code path.

## Verification

Reproduced the exact 400 against the live Kimi coding API with the same generated schema (error message identical), then confirmed the fix end-to-end through a patched local opencodex instance:

| Scenario | Before | After |
|---|---|---|
| kimi-cn / k3-256k | 400 error | ✅ 200 |
| kimi-global / k3 | 400 error | ✅ 200 |

Also unit-verified the sanitizer behavior: sibling `type`/`nullable` removed from `$ref` nodes (including inside `oneOf`), referenced definitions and plain nodes untouched, host matching correct for kimi.com / moonshot.cn / moonshot.ai, and non-Moonshot / malformed base URLs safely excluded.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Moonshot and Kimi chat API endpoints.
  * Tool parameter schemas are now formatted correctly for these services, including schemas that use references and nested structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->