### PR TITLE
fix(responses): rebind credential identity on every OAuth 429 rotation

### DIFF
--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -2854,6 +2854,17 @@ async function handleResponsesInner(
     // got it right by hand. A fourth site would have to remember too. Here it cannot forget.
     if (isOAuth401ReplayProvider) sentOAuthSnapshot = snapshot;
     replayOAuthCredentialSnapshot = { accountId: snapshot.accountId, generation: snapshot.generation };
+    // A Cursor conversation and identity scope are credential-scoped in the same way. runTurn
+    // cleared them by hand and the other two sites did not, so the same rotation that swapped the
+    // bearer could carry the previous account's conversation forward - and for image turns
+    // src/images/loop.ts copies that id back onto the outer request, which is how it outlives the
+    // rotation. Clearing here means a rotated adapter always derives its own.
+    parsed._cursorIdentityScope = undefined;
+    parsed._cursorConversationId = undefined;
+    if (parsed._providerContinuation?.cursor) {
+      const { cursor: _discardedCursor, ...otherProviderState } = parsed._providerContinuation;
+      parsed._providerContinuation = otherProviderState;
+    }
     return true;
   };
   const anthropicSessionKey = route.providerName === "anthropic" && route.provider.authMode === "oauth"
@@ -4647,15 +4658,6 @@ async function handleResponsesInner(
         genericFailoverAccountId = nextAccountId;
         genericFailovers += 1;
         if (!applyFailoverSnapshot(snapshot)) return false;
-        // A Cursor conversation/checkpoint is credential-scoped. The failed attempt emitted no
-        // client-visible bytes, so replay is safe, but carrying its account identity into the next
-        // account would not be. Let the rotated adapter derive a fresh identity and conversation.
-        parsed._cursorIdentityScope = undefined;
-        parsed._cursorConversationId = undefined;
-        if (parsed._providerContinuation?.cursor) {
-          const { cursor: _discardedCursor, ...otherProviderState } = parsed._providerContinuation;
-          parsed._providerContinuation = otherProviderState;
-        }
         const rotatedProvider = resolveWireProtocolOverride(
           route.providerName,
           route.modelId,

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -2841,6 +2841,19 @@ async function handleResponsesInner(
     if (snapshot.projectId) rotatedProvider = { ...rotatedProvider, project: snapshot.projectId };
     route.provider = rotatedProvider;
     if (route.providerName === "kiro") parsed._kiroAuthContext = { ...(snapshot.kiro ?? {}) };
+    // Rotating the credential without rotating the IDENTITY of that credential leaves the two
+    // describing different accounts. `sentOAuthSnapshot` feeds the 401 forced refresh, which
+    // refreshes the SNAPSHOT's account rather than whichever account is on the route now — so a
+    // stale snapshot makes a later 401 renew the account we just rotated AWAY from, while the
+    // transport still points at the rotated one. `replayOAuthCredentialSnapshot` scopes reasoning
+    // replay, so a stale value lets continuation state minted under one account be replayed under
+    // another.
+    //
+    // This lives in the helper rather than at each call site on purpose: three rotation sites
+    // already disagreed about which of these to update, and the one that got it right (runTurn)
+    // got it right by hand. A fourth site would have to remember too. Here it cannot forget.
+    if (isOAuth401ReplayProvider) sentOAuthSnapshot = snapshot;
+    replayOAuthCredentialSnapshot = { accountId: snapshot.accountId, generation: snapshot.generation };
     return true;
   };
   const anthropicSessionKey = route.providerName === "anthropic" && route.provider.authMode === "oauth"
@@ -3538,7 +3551,7 @@ async function handleResponsesInner(
         route.providerName,
         { ...route.provider, apiKey: refreshed.accessToken },
         parsed.options.promptCacheKey,
-        route.providerName === "github-copilot" ? getOAuthCredentialApiBaseUrl(route.providerName) : undefined,
+        route.providerName === "github-copilot" ? (refreshed.apiBaseUrl ?? getOAuthCredentialApiBaseUrl(route.providerName)) : undefined,
       );
       route.provider = refreshedProvider;
       const refreshedAdapter = resolveAdapter(
@@ -4341,6 +4354,11 @@ async function handleResponsesInner(
       providerName: route.providerName,
       provider: route.provider,
       adapterName: rotatedAdapter.name,
+      // Omitting this fails the OAuth replay key CLOSED, which looks safe and is not: the scope
+      // then carries no account identity at all, so it cannot distinguish state minted under the
+      // account we just rotated away from. `applyFailoverSnapshot` now keeps this value in step
+      // with the rotated credential, so passing it is what makes the scope account-accurate.
+      oauthCredentialSnapshot: replayOAuthCredentialSnapshot,
     });
     return rotatedAdapter;
   };
@@ -5064,7 +5082,7 @@ async function handleResponsesInner(
           route.providerName,
           { ...route.provider, apiKey: refreshed.accessToken },
           parsed.options.promptCacheKey,
-          route.providerName === "github-copilot" ? getOAuthCredentialApiBaseUrl(route.providerName) : undefined,
+          route.providerName === "github-copilot" ? (refreshed.apiBaseUrl ?? getOAuthCredentialApiBaseUrl(route.providerName)) : undefined,
         );
         route.provider = refreshedProvider;
         invalidateSameTargetRequest();
@@ -5222,6 +5240,19 @@ async function handleResponsesInner(
             resolveWireProtocolOverride(route.providerName, route.modelId, route.provider, inboundWire),
             config.cacheRetention,
           );
+          // The other two rotation sites rebind the reasoning replay scope here and this one did
+          // not, so continuation state minted under the previous account stayed addressable after
+          // the swap. Sealing the attempt identity records what happened; it does not re-scope the
+          // replay cache.
+          bindRouteReasoningReplayScope({
+            parsed,
+            providerName: route.providerName,
+            provider: route.provider,
+            adapterName: activeAdapter.name,
+            oauthCredentialSnapshot: replayOAuthCredentialSnapshot,
+            codexAuthContext: authCtx,
+            forwardHeaders: selectedForwardHeaders,
+          });
           sealRequestAttemptIdentity(logCtx.activeAttempt, logCtx.provider, activeAdapter.name, logCtx.accountLogLabel);
           const result = await rebuildAndRefetch("oauth-account-429");
           if ("failed" in result) return result.failed;

--- a/tests/generic-oauth-failover.test.ts
+++ b/tests/generic-oauth-failover.test.ts
@@ -275,6 +275,16 @@ describe("sidecar on429 wiring", () => {
     expect(body).toContain("sentOAuthSnapshot = snapshot");
     expect(body).toContain("accountId: snapshot.accountId");
     expect(body).toContain("generation: snapshot.generation");
+
+    // A Cursor conversation and identity scope are credential-scoped the same way, and were also
+    // cleared at only one of the three sites. For image turns src/images/loop.ts copies the
+    // conversation id back onto the outer request, which is how it survives a rotation.
+    expect(body).toContain("parsed._cursorIdentityScope = undefined");
+    expect(body).toContain("parsed._cursorConversationId = undefined");
+
+    // And the clear must exist ONLY in the helper: a per-site copy is how these drifted apart.
+    const scopeClears = coreSource.match(/parsed\._cursorIdentityScope = undefined/g) ?? [];
+    expect(scopeClears.length).toBe(1);
   });
 
   test("every generic-OAuth rotation site re-scopes reasoning replay to the rotated account", () => {

--- a/tests/generic-oauth-failover.test.ts
+++ b/tests/generic-oauth-failover.test.ts
@@ -254,4 +254,72 @@ describe("sidecar on429 wiring", () => {
     // Kiro routing metadata still travels with its own token.
     expect(body).toContain("_kiroAuthContext");
   });
+
+  test("the helper rotates the credential IDENTITY, not just the credential", () => {
+    // Rotating the bearer without rotating the identity of that bearer leaves the two naming
+    // different accounts, and both consumers of that identity then misbehave:
+    //
+    //   sentOAuthSnapshot          feeds forceRefreshOAuthAccessSnapshot, which refreshes the
+    //                              SNAPSHOT's account - so a stale value renews the account the
+    //                              request just rotated AWAY from while transport points at the
+    //                              rotated one.
+    //   replayOAuthCredentialSnapshot  scopes the reasoning replay cache - so a stale value lets
+    //                              continuation state minted under one account be replayed under
+    //                              another.
+    //
+    // Asserted INSIDE the helper rather than anywhere in the file: three rotation sites already
+    // disagreed about which of these to update, and only runTurn got it right, by hand.
+    const start = coreSource.indexOf("const applyFailoverSnapshot =");
+    expect(start).toBeGreaterThan(-1);
+    const body = coreSource.slice(start, coreSource.indexOf("\n  };", start));
+    expect(body).toContain("sentOAuthSnapshot = snapshot");
+    expect(body).toContain("accountId: snapshot.accountId");
+    expect(body).toContain("generation: snapshot.generation");
+  });
+
+  test("every generic-OAuth rotation site re-scopes reasoning replay to the rotated account", () => {
+    // The three generic-OAuth 429 sites diverged: runTurn rebound the replay scope, the sidecar
+    // bound WITHOUT the credential snapshot (which fails the OAuth replay key closed and so
+    // carries no account identity at all), and the HTTP site did not rebind at all. Sealing the
+    // attempt identity is not a substitute - it records what happened, it does not re-scope the
+    // cache.
+    //
+    // Scoped to the generic-OAuth sites deliberately. Key-pool and terminal-guard rotations swap
+    // an API KEY, which carries no OAuth account identity, so a snapshot there would be
+    // meaningless.
+    //
+    // The window is bounded by the rotation's OWN recovery call rather than searching forward
+    // indefinitely: an unbounded search finds the NEXT site's bind and passes even when this
+    // site has none. That weaker form was written first and it survived deleting the bind.
+    const marker = "applyFailoverSnapshot(snapshot)";
+    let cursor = 0;
+    const windows: string[] = [];
+    for (;;) {
+      const at = coreSource.indexOf(marker, cursor);
+      if (at === -1) break;
+      cursor = at + marker.length;
+      // Each site ends at the call that actually reissues the request under the new account.
+      const rest = coreSource.slice(cursor);
+      const ends = [
+        rest.indexOf("rebuildAndRefetch("),
+        rest.indexOf("return rotatedAdapter;"),
+        rest.indexOf("return true;"),
+      ].filter(index => index > -1);
+      windows.push(rest.slice(0, Math.min(...ends)));
+    }
+    expect(windows.length).toBe(3);
+
+    for (const [index, window] of windows.entries()) {
+      expect(`site${index}:${window.includes("bindRouteReasoningReplayScope({")}`).toBe(`site${index}:true`);
+      expect(`site${index}:${window.includes("oauthCredentialSnapshot")}`).toBe(`site${index}:true`);
+    }
+  });
+  test("a 401 after a rotation resolves transport from the REFRESHED account", () => {
+    // getOAuthCredentialApiBaseUrl reads the ACTIVE credential, and generic 429 failover never
+    // promotes the active account. So after a rotation the active account is still the one that
+    // was rate-limited, and resolving Copilot transport from it pairs a refreshed bearer with the
+    // wrong origin. The refreshed snapshot carries its own account-scoped origin; prefer it.
+    const refreshSites = coreSource.match(/refreshed\.apiBaseUrl \?\? getOAuthCredentialApiBaseUrl/g) ?? [];
+    expect(refreshSites.length).toBe(2);
+  });
 });


### PR DESCRIPTION
## Summary

Rotating a credential without rotating the **identity** of that credential left the two naming different accounts, and both consumers of that identity then misbehaved.

`applyFailoverSnapshot` swapped the bearer, the Copilot origin, the Antigravity project and the Kiro routing metadata, but never updated `sentOAuthSnapshot` or `replayOAuthCredentialSnapshot`:

- `sentOAuthSnapshot` feeds the 401 forced refresh, and `forceRefreshOAuthAccessSnapshot` refreshes the **snapshot's** account rather than whichever account is on the route now. A later 401 therefore renewed the account the request had just rotated away from.
- `replayOAuthCredentialSnapshot` scopes the reasoning replay cache, so a stale value let continuation state minted under one account be addressed under another.

Both rebinds now live inside the helper. Three rotation sites already disagreed about which of them to update, and the one that got it right (runTurn) got it right by hand — a fourth site would have to remember too.

The other two sites are brought up to runTurn's standard. The HTTP 429 path had no replay rebind at all; `sealRequestAttemptIdentity` records what happened but does not re-scope the cache. The sidecar bound *without* the credential snapshot, which fails the OAuth replay key closed — safe-looking, but it leaves the scope with no account identity to distinguish.

Both 401 rebuilds now prefer `refreshed.apiBaseUrl` over `getOAuthCredentialApiBaseUrl`. The latter reads the **active** credential, and generic 429 failover never promotes the active account, so after a rotation it still named the rate-limited one — pairing a refreshed bearer with the wrong account's origin.

## Reachability — please read before assessing severity

An independent audit was explicit that the exploitable version of this is **not reachable on today's control flow**. A 401 cannot follow a 429 rotation back into the refresh path: the HTTP 429 branch does not `continue recovery`, and Copilot Responses models take a passthrough return with no generic rotator at all. So what exists today is latent identity drift, not a live cross-account send.

That missing `continue recovery` is an **accidental** guard, not a designed one. Adding it — an obvious future improvement to 429 recovery — would activate the defect. That is the argument for fixing the identity first, and for not treating this as urgent.

## Verification

- `bun x tsc --noEmit` clean.
- `bun test ./tests/generic-oauth-failover.test.ts ./tests/adapter-event-oauth-failover.test.ts ./tests/server-xai-oauth-401-replay.test.ts` — 31 pass, 0 fail, 131 expect() calls.
- **Each of the three new assertions driven red on its own**, by reverting only its own fix: removing the identity rebind, removing the HTTP replay bind, and reverting one of the two 401 transport sites.
- The replay-scope assertion is bounded to each rotation's own recovery call. An unbounded forward search finds the *next* site's bind and passes with this site's bind deleted — that weaker form was written first and survived the deletion, which is why the bound exists.
- Full suite on the remote host at this exact head before any merge.

## Maintainer security review requested

This touches OAuth credential handling and account-scoped transport resolution, so per `MAINTAINERS.md` it needs explicit security review. I have deliberately **not** applied `maintainer-sponsored` and am not merging it. The reachability analysis above is the part most worth a second opinion: if you disagree that the missing `continue recovery` is load-bearing, the severity assessment changes.

## Checklist

- [x] Targets `dev`
- [x] Focused regression tests added, each driven red once
- [x] `bun x tsc --noEmit` clean
- [x] No new logging of tokens, accounts, or request bodies
- [x] Left for maintainer decision rather than self-merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth account failover consistency during response processing.
  * Cleared stale Cursor conversation and continuation state after account rotation.
  * Ensured refreshed GitHub Copilot connections use the latest available API endpoint.
  * Improved recovery after rate limits and authentication failures by correctly reapplying account-specific routing and replay context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->