### PR TITLE
fix(tests): reap the recovery proxy instead of trusting `stop`

### DIFF
--- a/tests/update-stop-first.test.ts
+++ b/tests/update-stop-first.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { runNpmCachePreflight } from "../src/update/npm-cache-preflight.mjs";
-import { killProxy } from "../src/lib/process-control";
+import { isProcessAlive, killProxy } from "../src/lib/process-control";
 
 const repoRoot = join(import.meta.dir, "..");
 
@@ -63,6 +63,16 @@ const serverSource = readFileSync(join(import.meta.dir, "..", "src", "server", "
 const dispatchSource = readFileSync(join(import.meta.dir, "..", "src", "cli", "dispatch.ts"), "utf8");
 
 describe("update stops the running proxy before replacing files", () => {
+  // The recovery case starts a real detached proxy, and its own result says nothing about
+  // whether cleanup reaped it — it stayed green while an escapee spun on a deleted tree for
+  // hours. Auditing the pid once the suite is done turns a silent leak back into a red test.
+  let auditedRecoveryPid: number | undefined;
+
+  afterAll(() => {
+    if (auditedRecoveryPid === undefined) return;
+    expect(isProcessAlive(auditedRecoveryPid)).toBe(false);
+  });
+
   test("a failed cache pre-flight aborts before the stop callback can run", () => {
     let stopped = false;
     const malformedSpawn = (() => ({ status: 0, signal: null, stdout: "not-json", stderr: "" })) as never;
@@ -227,24 +237,42 @@ esac
         expect(runtime.pid).toBeGreaterThan(0);
         recoveredPid = runtime.pid;
       } finally {
-        const stopped = existsSync(launcher)
-          ? Bun.spawnSync(["node", launcher, "stop"], {
-              cwd: root,
-              env,
-              stdout: "ignore",
-              stderr: "ignore",
-              timeout: UPDATE_SPAWN_TIMEOUT_MS,
-            })
-          : null;
-        if (stopped?.exitCode !== 0) {
-          if (!recoveredPid) {
-            try {
-              recoveredPid = JSON.parse(readFileSync(join(opencodexHome, "runtime-port.json"), "utf8")).pid;
-            } catch { /* the proxy never wrote runtime state */ }
-          }
-          if (Number.isSafeInteger(recoveredPid) && recoveredPid! > 0) killProxy(recoveredPid!);
+        // Resolve the pid FIRST. `stop` rewrites runtime-port.json and the rmSync below
+        // deletes it outright, so this is the last moment the detached proxy the recovery
+        // path started can still be identified at all.
+        if (!recoveredPid) {
+          try {
+            recoveredPid = JSON.parse(readFileSync(join(opencodexHome, "runtime-port.json"), "utf8")).pid;
+          } catch { /* the proxy never wrote runtime state */ }
         }
-        rmSync(root, { recursive: true, force: true });
+        auditedRecoveryPid = Number.isSafeInteger(recoveredPid) && recoveredPid! > 0
+          ? recoveredPid
+          : undefined;
+        if (existsSync(launcher)) {
+          Bun.spawnSync(["node", launcher, "stop"], {
+            cwd: root,
+            env,
+            stdout: "ignore",
+            stderr: "ignore",
+            timeout: UPDATE_SPAWN_TIMEOUT_MS,
+          });
+        }
+        try {
+          // `stop` exiting 0 is a claim, not proof: it also reports success when it finds no
+          // live runtime to stop, which is indistinguishable here from one it failed to stop.
+          // Gating the reap on that exit code let a detached proxy survive, get reparented to
+          // init, and then spin on a fixture tree this same block had already deleted — one
+          // escapee burned a full core for hours. Verify liveness and reap regardless.
+          // bin/ocx.mjs mirrors its Bun child's exit, so reaping the recorded child pid takes
+          // the node launcher with it.
+          if (Number.isSafeInteger(recoveredPid) && recoveredPid! > 0 && isProcessAlive(recoveredPid!)) {
+            killProxy(recoveredPid!);
+          }
+        } finally {
+          // Ordered after the reap on purpose: deleting the tree out from under a live
+          // detached proxy is what turned a missed kill into a permanently spinning orphan.
+          rmSync(root, { recursive: true, force: true });
+        }
       }
     },
     RECOVERY_CASE_TIMEOUT_MS,


### PR DESCRIPTION
## Summary

The update-recovery case in `tests/update-stop-first.test.ts` starts a real detached proxy, and its cleanup ran the reap **only when** `node ocx.mjs stop` exited non-zero. That exit code is a claim, not proof: `stop` also reports success when it finds no live runtime to stop, which is indistinguishable here from one it failed to stop. On that path nothing killed the proxy, and the block went straight on to `rmSync` the fixture tree.

## What that produced

The survivor was reparented to init with its package tree, `src` symlink, and config deleted underneath it — unable to serve, unable to exit. One escapee was found sitting at **99% of a core for 3h38m, 202 minutes of CPU time**, listening on nothing:

```
14845  PPID=1  node .../T/ocx-update-recovery-l1bDDD/.../bin/ocx.mjs start --port 64113
14848  99% CPU .../bun.exe .../src/cli/index.ts start --port 64113
```

The fixture directory was already gone, which is what made it unrecoverable rather than merely leaked. It also held the test machine lock, which is how it surfaced at all.

## The fix

Cleanup now resolves the pid **before** anything destroys the record of it (`stop` rewrites `runtime-port.json`; the `rmSync` deletes it), runs `stop` for its graceful path, then verifies liveness and reaps **regardless of what `stop` claimed**. `rmSync` moves inside a nested `finally` so it still always runs, but strictly after the reap — deleting the tree out from under a live detached process is what turned a missed kill into a permanently spinning orphan.

Reaping the recorded pid is sufficient because `bin/ocx.mjs` mirrors its Bun child's exit (`child.on("exit", …)`), so the node launcher follows it down. Real `ocx stop` is unaffected.

## Why a regression guard was needed too

Reaping alone would still fail silently: **the case passed the entire time it was leaking**. An `afterAll` now audits the pid, so a future regression is red instead of invisible.

## Verification

A/B against the exact failure mode, with `stop` stubbed to exit 0 without killing anything:

| cleanup | result | orphan left |
| --- | --- | --- |
| original | 15 pass / 0 fail | **node + bun survive** |
| this PR | 15 pass / 0 fail | none |
| original + the new guard | **1 fail** | — |

- `bun run test` — **15163 pass, 12 skip, 0 fail, exit 0**; all six serial lanes green.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- Related lifecycle suites (`update-stop-first`, `ocx-launcher-runtime`, `process-control-graceful`, `grok-lifecycle`) — 43 pass / 0 fail.

`tests/ocx-launcher-runtime.test.ts` already used the safe pattern (kill unconditionally, collect cleanup errors so they cannot mask a real failure); this change follows it. The other two `killProxy` callers are source-text assertions that start no process.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


### Re-verified at head `4a0cbb55c` (base `50e955604`)

`bun run test` — 15191 pass, 12 skip, **1 fail**; all six serial lanes green.

The single failure is `key-login-live-update`, which **reproduces on unmodified `dev` @ `50e955604`
with zero changes** and is unrelated to this PR. Root-caused separately: the NAT64 well-known
prefix `64:ff9b::/96` was classified as a non-global address, so `providerDestinationResolvedError`
answered `409` to the live provider reload. Fixed in #2798; with that branch applied the suite is
15196 pass / 0 fail.

An earlier run of this same head reported 9 failures under a loaded machine (load average 26).
Re-running the four affected files at normal load gave 108 pass / 1 fail — the other 8 were 5s
timeouts, not defects.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved recovery test cleanup to consistently detect and stop detached processes.
  - Added suite-level verification that recovery processes are no longer running after tests complete.
  - Ensured temporary test files are removed only after associated processes have been safely terminated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
