### PR TITLE
fix(gui): make doctor:gui agree with CI instead of being bypassed

### DIFF
--- a/gui/.oxlintrc.json
+++ b/gui/.oxlintrc.json
@@ -150,6 +150,17 @@
       "rules": {
         "local-i18n/no-hardcoded-data-copy": "error"
       }
+    },
+    {
+      "files": [
+        "src/pages/Models.tsx"
+      ],
+      "rules": {
+        "react/exhaustive-deps": "off"
+      },
+      "plugins": [
+        "react"
+      ]
     }
   ]
 }

--- a/gui/doctor.config.json
+++ b/gui/doctor.config.json
@@ -3,7 +3,20 @@
   "scope": "full",
   "blocking": "warning",
   "ignore": {
-    "files": ["dist/**", "node_modules/**"]
+    "files": [
+      "dist/**",
+      "node_modules/**"
+    ],
+    "overrides": [
+      {
+        "files": [
+          "src/pages/Models.tsx"
+        ],
+        "rules": [
+          "react-hooks/exhaustive-deps"
+        ]
+      }
+    ]
   },
   "rules": {
     "react-doctor/no-fetch-in-effect": "off",

--- a/gui/src/pages/Models.tsx
+++ b/gui/src/pages/Models.tsx
@@ -513,7 +513,10 @@ export default function Models({ apiBase, restartEpoch = 0 }: { apiBase: string;
     // to useCallback and completing the dep array turns ONE warning into five react-compiler
     // errors - two PreserveManualMemo, two Immutability (they are declared ~430 lines below this
     // effect), and one EffectSetState - so the note above still holds against oxlint 1.78.
-    // react-doctor-disable-next-line react-doctor/exhaustive-deps -- same intentional exception
+    // Both gates suppress this one rule for this one file by config rather than by comment:
+    // gui/.oxlintrc.json (override) and gui/doctor.config.json (ignore.overrides). An in-file
+    // react-doctor-disable comment was tried and removed - it changed nothing, and
+    // react/react-compiler penalises a component for carrying suppressions at all.
   }, [catalogActive, loadShadowCall, loadV2]);
 
   const groups = useMemo(

--- a/gui/src/pages/Models.tsx
+++ b/gui/src/pages/Models.tsx
@@ -509,7 +509,11 @@ export default function Models({ apiBase, restartEpoch = 0 }: { apiBase: string;
     // oxlint-disable-next-line react/react-compiler -- existing exhaustive-deps exception is intentional
     // eslint-disable-next-line react-hooks/exhaustive-deps -- loadPresets is a plain async loader
     // like the rest of this file's; a useCallback wrapper trips PreserveManualMemo, and the
-    // effect only ever needs the current closure.
+    // effect only ever needs the current closure. Verified 2026-08-27: converting both loaders
+    // to useCallback and completing the dep array turns ONE warning into five react-compiler
+    // errors - two PreserveManualMemo, two Immutability (they are declared ~430 lines below this
+    // effect), and one EffectSetState - so the note above still holds against oxlint 1.78.
+    // react-doctor-disable-next-line react-doctor/exhaustive-deps -- same intentional exception
   }, [catalogActive, loadShadowCall, loadV2]);
 
   const groups = useMemo(

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -5176,3 +5176,89 @@ describe("lint-gui-if-changed", () => {
     expect(run.stdout.toString()).toContain("lint:gui: skip");
   });
 });
+
+describe("gui exhaustive-deps suppression stays scoped and effective", () => {
+  // `bun run doctor:gui` exited 1 on dev for one deliberate exception at
+  // gui/src/pages/Models.tsx, and doctor:gui runs inside `prepush`, so every
+  // gui-touching push needed --no-verify. Two config edits fixed it, and each has a
+  // failure mode that is silent rather than loud, which is what these assertions cover.
+
+  test("the oxlint override carries its own react plugin, or it resolves to nothing", async () => {
+    const oxlintrc = JSON.parse(await readText("gui/.oxlintrc.json")) as {
+      overrides?: Array<{ files?: string[]; rules?: Record<string, unknown>; plugins?: string[] }>;
+    };
+    const overrides = oxlintrc.overrides ?? [];
+    const scoped = overrides.filter(entry => (entry.files ?? []).includes("src/pages/Models.tsx"));
+
+    expect(scoped).toHaveLength(1);
+    const override = scoped[0]!;
+
+    // Rule id must match the style the rest of this config uses ("react/..."). The
+    // eslint-style "react-hooks/..." id silently matches nothing here.
+    expect(override.rules?.["react/exhaustive-deps"]).toBe("off");
+    expect(override.rules).not.toHaveProperty("react-hooks/exhaustive-deps");
+
+    // Without a per-override plugins key the override is inert: the rule stays on and
+    // the warning comes back. This is the assertion that catches a well-meaning cleanup
+    // that deletes a key looking redundant next to the top-level plugin list.
+    expect(override.plugins).toContain("react");
+
+    // Narrow by construction: the override turns off exactly one rule. rules-of-hooks and
+    // react-compiler must keep firing in that file, and a probe confirmed they do.
+    expect(Object.keys(override.rules ?? {})).toEqual(["react/exhaustive-deps"]);
+  });
+
+  test("react-doctor scopes the ignore to one file instead of going blind everywhere", async () => {
+    const config = JSON.parse(await readText("gui/doctor.config.json")) as {
+      blocking?: string;
+      ignore?: { overrides?: Array<{ files?: string[]; rules?: string[] }> };
+      rules?: Record<string, unknown>;
+    };
+
+    // A global rules entry was tried first and rejected: it silenced the rule repo-wide,
+    // proven by injecting a missing-dep violation into Startup.tsx and watching doctor
+    // report "No issues". ignore.overrides keeps that violation failing.
+    expect(config.rules).not.toHaveProperty("react-doctor/exhaustive-deps");
+    expect(config.rules).not.toHaveProperty("react-hooks/exhaustive-deps");
+
+    const overrides = config.ignore?.overrides ?? [];
+    const scoped = overrides.filter(entry => (entry.files ?? []).includes("src/pages/Models.tsx"));
+    expect(scoped).toHaveLength(1);
+    expect(scoped[0]!.rules).toContain("react-hooks/exhaustive-deps");
+
+    // Every ignore override must name at least one file. An empty or missing files list
+    // would apply the ignore to the whole scan, which is the failure this pair guards.
+    for (const entry of overrides) {
+      expect((entry.files ?? []).length).toBeGreaterThan(0);
+      expect((entry.rules ?? []).length).toBeGreaterThan(0);
+    }
+
+    // blocking must stay at warning; flipping it to error would hide the next finding
+    // instead of this one. scripts/doctor-gui-if-changed.ts documents that contract.
+    expect(config.blocking).toBe("warning");
+  });
+
+  test("the effect keeps the in-file record of why the dep array stays short", async () => {
+    const models = await readText("gui/src/pages/Models.tsx");
+    const effectEnd = models.indexOf("}, [catalogActive, loadShadowCall, loadV2]);");
+    expect(effectEnd).toBeGreaterThan(-1);
+
+    // The reasoning has to sit on the effect, not in a commit message. Read the comment
+    // block immediately above the dep array rather than the whole file, or this passes on
+    // any incidental mention elsewhere.
+    const preceding = models.slice(0, effectEnd).split(/\r?\n/).slice(-8).join("\n");
+    expect(preceding).toContain("PreserveManualMemo");
+    expect(preceding).toContain("five react-compiler");
+
+    // Both suppressions are config-side, so the note must point at the two files a reader
+    // would otherwise have to find by grep.
+    expect(preceding).toContain("gui/.oxlintrc.json");
+    expect(preceding).toContain("gui/doctor.config.json");
+
+    // An in-file react-doctor disable was tried and removed: doctor passes without it, and
+    // react/react-compiler penalises a component merely for carrying suppressions. If one
+    // reappears, the config route has been misunderstood.
+    expect(models).not.toContain("react-doctor-disable-next-line");
+  });
+});
+


### PR DESCRIPTION
## Summary

`bun run doctor:gui` exits 1 on `dev`. It runs inside `prepush`, so every gui-touching push has needed `--no-verify` to get through. A gate everyone routinely bypasses is not a gate, so this makes the local gate agree with CI.

Both reported issues are the same line — the deliberate exhaustive-deps exception at `gui/src/pages/Models.tsx:498`:

```
Missing effect dependencies  react-hooks/exhaustive-deps    src/pages/Models.tsx:498
Missing effect dependencies  react-doctor/exhaustive-deps   src/pages/Models.tsx:498
```

The omission is intentional and documented in the file. The problem is that the existing suppression comments name `react/react-compiler` and eslint's `react-hooks/exhaustive-deps`, which silence neither oxlint's own `react-hooks(exhaustive-deps)` nor react-doctor's `react-doctor/exhaustive-deps`.

### Two other routes were tried and disproven

**Adding matching in-file suppressions made it worse.** `react/react-compiler` fires *because* a suppression exists — React Compiler skips optimizing a component when one or more React ESLint rules are disabled — so 2 warnings became 3 issues including 1 error.

**Satisfying the rule confirmed the in-file note.** Wrapping `loadPresets` and `loadModelDiscovery` in `useCallback` and completing the dep array produced five `react-compiler` errors: 2 PreserveManualMemo, 2 Immutability (both loaders are declared ~430 lines *below* the effect), 1 EffectSetState.

That leaves file-scoped config suppression as the only correct route.

### Two config details that are load-bearing

- The oxlint override needs its own `"plugins": ["react"]` key. Without it the override resolves to nothing and the warning stays.
- react-doctor needs `ignore.overrides`, not a global `rules` entry. A global entry blinds doctor everywhere, which I proved by injecting a violation into `Startup.tsx` and watching doctor report "No issues".

### Why CI was green while local failed

`gui/package.json` runs doctor with `--scope changed --base origin/main`. In CI the changed set is the PR diff; locally on `dev` it is the whole 254-commit, 551-file range. A green react-doctor check on a PR therefore does not imply `bun run doctor:gui` is clean on `dev`.

## Verification

Local, at this head:

| Check | Result |
| --- | --- |
| `bun run lint:gui` | exit 0 |
| `bun run doctor:gui` | exit 0, "No issues found" across 62 files |
| `bun x tsc --noEmit -p gui/tsconfig.json` | exit 0 |

Scoping proven in both directions, so the suppression cannot rot into a blanket:

- Injecting a missing-dep violation into `gui/src/pages/Startup.tsx` still fails doctor — `doctor_exit=1`, both rule ids reported at `Startup.tsx:228` and `:230`. Reverted after the check.
- Injecting a conditional `useMemo` into `Models.tsx` itself still errors: `error react-hooks(rules-of-hooks)` at `Models.tsx:519`, `lint_exit=1`. The override narrows one rule in one file, not the file. Reverted after the check.

Full `bun run test` runs on the Linux CI host at this exact head (`e6661f21c`); CI covers Linux, Windows, and macOS.

## Checklist

- [x] Local CI green (lint:gui, doctor:gui, gui typecheck; full suite on the remote host at this head)
- [x] Branch is on the latest `dev` commit (`802f04adc`)
- [x] All correct Codex and CodeRabbit findings fixed
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved code analysis configuration for the Models page to recognize an intentional dependency exception.
  * Clarified the related behavior with updated in-code guidance.
* **Tests**
  * Added coverage to verify that analysis rules remain appropriately scoped and existing quality checks continue to work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->