### PR TITLE
test(core): lock the two invariants AGENTS.md claims are enforced

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,14 @@ subagent-fallback chain has nowhere to await, so an `await` added before the
 activation block would silently reroute subagents to a different model than the
 operator configured.
 
+That one is enforced too, in the same file: a scan reads the window between the
+`Bun.serve` call and the `labActivationRequired` check and fails on any `await`
+that would suspend `startServer` itself, plus on `startServer` being declared
+`async`. It has to ignore comments, string bodies, and nested functions to be
+usable, because the window legitimately contains three awaits inside the
+`server.stop` closure and two comments that mention the word. Until it existed,
+this paragraph was the only thing holding the guarantee.
+
 Design and audit history: `devlog/_fin/260814_lab_core_decoupling/`.
 
 ## The `devlog` directory

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -5191,10 +5191,14 @@ async function handleResponsesInner(
           break;
         }
       }
-      // Generic OAuth account failover (#2568) for providers with no pool of their own. Opt-in
-      // and a strict no-op otherwise, so a single-account install and every existing config are
-      // unchanged. Codex and Anthropic are excluded by isGenericFailoverProvider — their pools
-      // own quota scopes, probe leases and affinity that this must not reimplement.
+      // Generic OAuth account failover (#2568) for providers with no pool of their own.
+      // Presence is consent since #2568d: rotation is ON by default once two or more eligible
+      // accounts are stored for the provider, because a second deliberate login is read as the
+      // operator asking for it. A single-account install is still a strict no-op, and an
+      // explicit `oauthAccountFailover.enabled: false` (global or per provider) still wins --
+      // see isGenericOAuthFailoverEnabled in src/oauth/generic-account-failover.ts. Codex and
+      // Anthropic are excluded by isGenericFailoverProvider: their pools own quota scopes,
+      // probe leases and affinity that this must not reimplement.
       while (
         upstreamResponse.status === 429
         && genericFailoverAccountId

--- a/tests/core-lab-boundary.test.ts
+++ b/tests/core-lab-boundary.test.ts
@@ -137,6 +137,16 @@ export function namesLabDirectly(source: string): boolean {
  */
 const SERVE_ANCHOR = "server = Bun.serve<WsData>({ ...serveOptions, port: listenPort, hostname: bindHost });";
 const ACTIVATION_ANCHOR = "if (labActivationRequired(config, labConfigDir)) {";
+/**
+ * The window ends at the RETURN, not at the activation check.
+ *
+ * Stopping at the activation anchor left two blind spots: an `await` inside the
+ * `if (labActivationRequired(...))` body, and one between activation and `return server`.
+ * AGENTS.md and `080_activation_is_synchronous.md` both state the guarantee as covering
+ * everything from `Bun.serve` to the return, so a guard that stopped earlier was narrower
+ * than the invariant it claimed to hold. Found by an independent review of this guard.
+ */
+const RETURN_ANCHOR = "  return server;";
 
 /**
  * Blank comments and string bodies, preserving offsets and line breaks so reported line
@@ -357,12 +367,18 @@ describe("activation window stays synchronous", () => {
 
   test("no body-level await sits between Bun.serve and Lab activation", () => {
     const start = source.indexOf(SERVE_ANCHOR);
-    const end = source.indexOf(ACTIVATION_ANCHOR);
+    const end = source.indexOf(RETURN_ANCHOR, start);
+    const activation = source.indexOf(ACTIVATION_ANCHOR);
 
-    // Fail loudly if either anchor moves. A window that silently collapses to nothing is
-    // the way this guard would rot into a test that passes by measuring an empty string.
+    // Fail loudly if any anchor moves. A window that silently collapses to nothing is the
+    // way this guard would rot into a test that passes by measuring an empty string.
     expect(start).toBeGreaterThan(-1);
     expect(end).toBeGreaterThan(start);
+
+    // The activation check must sit INSIDE the window. If it drifted out, the scan would
+    // still be green while no longer covering the ordering it exists to protect.
+    expect(activation).toBeGreaterThan(start);
+    expect(activation).toBeLessThan(end);
 
     const region = source.slice(start, end);
     const offsetLine = source.slice(0, start).split("\n").length;
@@ -407,7 +423,7 @@ describe("activation window stays synchronous", () => {
     // above would stop being exercised by real code and this suite would quietly narrow to
     // synthetic strings only.
     const start = source.indexOf(SERVE_ANCHOR);
-    const end = source.indexOf(ACTIVATION_ANCHOR);
+    const end = source.indexOf(RETURN_ANCHOR, start);
     const region = source.slice(start, end);
 
     expect(region.includes("await runListenerShutdown(")).toBe(true);

--- a/tests/core-lab-boundary.test.ts
+++ b/tests/core-lab-boundary.test.ts
@@ -389,7 +389,8 @@ describe("activation window stays synchronous", () => {
     // enclosing function and must be reported.
     expect(bodyLevelAwaitLines("await first();\n")).toEqual([1]);
     expect(bodyLevelAwaitLines("if (flag) {\n  await gate();\n}\n")).toEqual([2]);
-    expect(bodyLevelAwaitLines("try {\n  await risky();\n} catch {}\n")).toEqual([2]);
+    const emptyCatch = `catch ${"{"}${"}"}`;
+    expect(bodyLevelAwaitLines(`try {\n  await risky();\n} ${emptyCatch}\n`)).toEqual([2]);
     expect(bodyLevelAwaitLines("for (const x of xs) {\n  await x;\n}\n")).toEqual([2]);
     expect(bodyLevelAwaitLines("for await (const x of xs) {\n  void x;\n}\n")).toEqual([1]);
 

--- a/tests/core-lab-boundary.test.ts
+++ b/tests/core-lab-boundary.test.ts
@@ -119,6 +119,148 @@ export function namesLabDirectly(source: string): boolean {
     || /\bimport\s*\(\s*["'][^"']*\/lab(?:\/|["'])/.test(source);
 }
 
+
+/**
+ * Guard 3: the activation window inside `startServer` must stay synchronous.
+ *
+ * `AGENTS.md` states this guarantee as if it were enforced, and
+ * `devlog/_fin/260814_lab_core_decoupling/080_activation_is_synchronous.md:143` recorded it
+ * as a Phase-4 test — but no such scan was ever written, so the invariant was held by
+ * nothing except the current code being correct.
+ *
+ * The failure it guards against is silent. Everything between `Bun.serve` and the return
+ * of `startServer` runs in one synchronous turn, which is what guarantees a policy route
+ * can never be evaluated before its evidence provider is registered. Add one `await` in
+ * that window and the synchronous subagent-fallback chain observes an empty slot and
+ * routes subagents to a different model than the operator configured. Nothing goes red;
+ * the wrong model simply answers.
+ */
+const SERVE_ANCHOR = "server = Bun.serve<WsData>({ ...serveOptions, port: listenPort, hostname: bindHost });";
+const ACTIVATION_ANCHOR = "if (labActivationRequired(config, labConfigDir)) {";
+
+/**
+ * Blank comments and string bodies, preserving offsets and line breaks so reported line
+ * numbers stay usable.
+ *
+ * This is not decoration. The window contains two comments that say the word "await" —
+ * `src/server/index.ts:1853` ("this rollback cannot await") and `:1950` ("nowhere to
+ * await") — so a naive text scan fails on correct code, and a guard that cries wolf on
+ * `dev` gets deleted rather than fixed.
+ *
+ * Template interpolations are kept as code rather than blanked with the rest of the
+ * template: `${await x()}` in a console.log is a real body-level await, and blanking the
+ * whole template would hide exactly the violation this looks for.
+ */
+export function blankCommentsAndStrings(source: string): string {
+  const out: string[] = [];
+  // A stack, because a template interpolation can contain another template.
+  const modes: Array<"code" | "template"> = ["code"];
+  const depths: number[] = [0];
+  let i = 0;
+  const keep = (ch: string) => out.push(ch === "\n" ? "\n" : " ");
+  while (i < source.length) {
+    const ch = source[i]!;
+    const next = source[i + 1];
+    if (modes[modes.length - 1] === "template") {
+      if (ch === "\\") { keep(ch); keep(next ?? " "); i += 2; continue; }
+      if (ch === "`") { modes.pop(); depths.pop(); keep(ch); i++; continue; }
+      if (ch === "$" && next === "{") {
+        modes.push("code");
+        depths.push(0);
+        keep(ch); keep(next); i += 2; continue;
+      }
+      keep(ch); i++; continue;
+    }
+    if (ch === "/" && next === "/") {
+      while (i < source.length && source[i] !== "\n") { keep(source[i]!); i++; }
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      keep(ch); keep(next); i += 2;
+      while (i < source.length && !(source[i] === "*" && source[i + 1] === "/")) { keep(source[i]!); i++; }
+      if (i < source.length) { keep("*"); keep("/"); i += 2; }
+      continue;
+    }
+    if (ch === "\"" || ch === "'") {
+      keep(ch); i++;
+      while (i < source.length) {
+        if (source[i] === "\\") { keep(source[i]!); keep(source[i + 1] ?? " "); i += 2; continue; }
+        if (source[i] === ch) { keep(source[i]!); i++; break; }
+        keep(source[i]!); i++;
+      }
+      continue;
+    }
+    if (ch === "`") { modes.push("template"); depths.push(0); keep(ch); i++; continue; }
+    if (ch === "{") { depths[depths.length - 1]! += 1; out.push(ch); i++; continue; }
+    if (ch === "}") {
+      if (depths[depths.length - 1] === 0 && modes.length > 1) {
+        // Closes a `${` interpolation, not a block.
+        modes.pop(); depths.pop(); keep(ch); i++; continue;
+      }
+      depths[depths.length - 1]! -= 1;
+      out.push(ch); i++; continue;
+    }
+    out.push(ch); i++;
+  }
+  return out.join("");
+}
+
+/**
+ * True when the `{` at `braceIndex` opens a function body rather than a block or an object
+ * literal. Brace depth alone cannot answer this: the window contains try/catch and an `if`,
+ * and the three legitimate awaits sit inside the async arrow assigned to `server.stop`,
+ * which runs at shutdown rather than during startup.
+ */
+function opensFunctionBody(code: string, braceIndex: number): boolean {
+  let j = braceIndex - 1;
+  while (j >= 0 && /\s/.test(code[j]!)) j--;
+  if (j >= 1 && code[j] === ">" && code[j - 1] === "=") return true;
+  if (code[j] !== ")") return false;
+  let depth = 0;
+  let k = j;
+  for (; k >= 0; k--) {
+    if (code[k] === ")") depth++;
+    else if (code[k] === "(") { depth--; if (depth === 0) break; }
+  }
+  if (k < 0) return false;
+  let m = k - 1;
+  while (m >= 0 && /\s/.test(code[m]!)) m--;
+  const end = m + 1;
+  while (m >= 0 && /[\w$]/.test(code[m]!)) m--;
+  const token = code.slice(m + 1, end);
+  return !["if", "for", "while", "switch", "catch", "do", "with"].includes(token);
+}
+
+/**
+ * 1-based line numbers (relative to `region`) of every `await` that would suspend
+ * `startServer` itself. An await inside a nested function is fine — that code runs later.
+ *
+ * Stated limits: a computed member named `await`, and a regex literal containing the word,
+ * are out of scope. Neither form is reachable in this window, and both would have to be
+ * written deliberately.
+ */
+export function bodyLevelAwaitLines(region: string): number[] {
+  const code = blankCommentsAndStrings(region);
+  const hits: number[] = [];
+  const stack: boolean[] = [];
+  let line = 1;
+  for (let i = 0; i < code.length; i++) {
+    const ch = code[i]!;
+    if (ch === "\n") { line++; continue; }
+    if (ch === "{") { stack.push(opensFunctionBody(code, i)); continue; }
+    if (ch === "}") { stack.pop(); continue; }
+    if (ch !== "a" || code.slice(i, i + 5) !== "await") continue;
+    const before = i > 0 ? code[i - 1]! : " ";
+    const after = code[i + 5] ?? " ";
+    if (/[\w$]/.test(before) || /[\w$]/.test(after)) continue;
+    // `.await` would be a property access, not the operator.
+    if (before === ".") continue;
+    if (!stack.some(isFunctionBody => isFunctionBody)) hits.push(line);
+    i += 4;
+  }
+  return hits;
+}
+
 describe("core / Compatibility Lab boundary", () => {
   // Guard 1: the obvious case, a direct import.
   test.each(PROTECTED)("%s has no direct src/lab import", file => {
@@ -196,3 +338,80 @@ describe("boundary guard cannot be defeated", () => {
     }
   });
 });
+
+describe("activation window stays synchronous", () => {
+  const indexPath = resolve(repoRoot, "src/server/index.ts");
+  const source = readFileSync(indexPath, "utf8");
+
+  test("startServer is not async", () => {
+    // An async startServer returns a Promise, so every caller treating the return value as a
+    // live Server would break. The subtler cost is that it makes a body-level await legal,
+    // which is the ordering this describe block exists to protect.
+    // Assert on a boolean, not on `source`: a raw `expect(source)` failure prints the whole
+    // 5000-line file and buries the finding it just made.
+    const declaration = /export\s+(async\s+)?function\s+startServer\s*\(/.exec(source);
+    expect(declaration?.[0] ?? "startServer declaration not found").toBe(
+      "export function startServer(",
+    );
+  });
+
+  test("no body-level await sits between Bun.serve and Lab activation", () => {
+    const start = source.indexOf(SERVE_ANCHOR);
+    const end = source.indexOf(ACTIVATION_ANCHOR);
+
+    // Fail loudly if either anchor moves. A window that silently collapses to nothing is
+    // the way this guard would rot into a test that passes by measuring an empty string.
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const region = source.slice(start, end);
+    const offsetLine = source.slice(0, start).split("\n").length;
+    const absolute = bodyLevelAwaitLines(region).map(relative => offsetLine + relative - 1);
+
+    expect(absolute).toEqual([]);
+  });
+
+  test("the scan ignores comments, strings, and nested functions but catches a real await", () => {
+    // Guard-on-the-guard. The window really does contain the word "await" twice in prose
+    // (src/server/index.ts:1853 and :1950) and three real awaits inside the server.stop
+    // closure, so a scan that cannot tell those apart either fails on correct code or
+    // passes on broken code. Both directions are pinned here.
+    expect(bodyLevelAwaitLines("// cannot await here\nvoid 0;\n")).toEqual([]);
+    expect(bodyLevelAwaitLines("/* nowhere to await */\nvoid 0;\n")).toEqual([]);
+    expect(bodyLevelAwaitLines("const s = \"await x\";\n")).toEqual([]);
+    expect(bodyLevelAwaitLines("const t = `await ${y}`;\n")).toEqual([]);
+
+    // Inside a later-running function: allowed, exactly like the server.stop closure.
+    expect(bodyLevelAwaitLines("value: async () => {\n  await stop();\n},\n")).toEqual([]);
+    expect(bodyLevelAwaitLines("f(async () => {\n  await g();\n});\n")).toEqual([]);
+
+    // Blocks are not function bodies, so an await inside if/try/for still suspends the
+    // enclosing function and must be reported.
+    expect(bodyLevelAwaitLines("await first();\n")).toEqual([1]);
+    expect(bodyLevelAwaitLines("if (flag) {\n  await gate();\n}\n")).toEqual([2]);
+    expect(bodyLevelAwaitLines("try {\n  await risky();\n} catch {}\n")).toEqual([2]);
+    expect(bodyLevelAwaitLines("for (const x of xs) {\n  await x;\n}\n")).toEqual([2]);
+    expect(bodyLevelAwaitLines("for await (const x of xs) {\n  void x;\n}\n")).toEqual([1]);
+
+    // A template interpolation is code, not string body.
+    expect(bodyLevelAwaitLines("console.log(`${await port()}`);\n")).toEqual([1]);
+
+    // Identifiers that merely contain the word are not the operator.
+    expect(bodyLevelAwaitLines("const awaited = 1;\nvoid awaited;\n")).toEqual([]);
+    expect(bodyLevelAwaitLines("thing.await();\n")).toEqual([]);
+  });
+
+  test("the real window contains the awaits it is supposed to tolerate", () => {
+    // If the server.stop closure were ever moved out of the window, the tolerance branch
+    // above would stop being exercised by real code and this suite would quietly narrow to
+    // synthetic strings only.
+    const start = source.indexOf(SERVE_ANCHOR);
+    const end = source.indexOf(ACTIVATION_ANCHOR);
+    const region = source.slice(start, end);
+
+    expect(region.includes("await runListenerShutdown(")).toBe(true);
+    expect(region.includes("await backgroundLifecycle.release();")).toBe(true);
+    expect(bodyLevelAwaitLines(region)).toEqual([]);
+  });
+});
+

--- a/tests/lab-activation.test.ts
+++ b/tests/lab-activation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, beforeEach } from "bun:test";
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -216,3 +216,105 @@ describe("failed scheduler start leaves nothing dangling", () => {
     stopLabAutomationScheduler(dir);
   });
 });
+
+/**
+ * R3-1: a genuinely profile-less dry-run must register nothing.
+ *
+ * `devlog/_fin/260814_lab_core_decoupling/090_audit_round3_closeout.md:47` required this as a
+ * behavioral assertion, and it was never written. The existing gate test above only proves
+ * that a bare CONFIG does not activate — it never exercises the management route, which is
+ * where the activation call actually lives
+ * (`src/server/management/routing-profile-routes.ts:293` and `:368`).
+ *
+ * That distinction is the whole point. Audit round 3 was about a guard that passes while the
+ * property is violated: the dry-run route activates Lab so an operator preview agrees with
+ * production, and if that call ever stopped being conditional, a profile-less install would
+ * start filling slots from an HTTP request and nothing here would notice.
+ */
+describe("R3-1 a profile-less dry-run registers no slot", () => {
+  let previousHome: string | undefined;
+  let homeDir = "";
+
+  beforeEach(() => {
+    previousHome = process.env.OPENCODEX_HOME;
+    homeDir = scratch();
+    // getConfigDir() reads this, and the route calls it rather than taking a directory, so
+    // the env var is the only seam that keeps this case off the real config directory.
+    process.env.OPENCODEX_HOME = homeDir;
+    resetLabActivationForTests();
+    resetServerResourceOwnershipForTests();
+    resetCompatibilityEvidenceProviderForTests();
+    resetPassiveRouteLinkerForTests();
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+    else process.env.OPENCODEX_HOME = previousHome;
+  });
+
+  test("an unknown profile on an install with no profiles fills neither slot", async () => {
+    const { handleManagementAPI } = await import("../src/server/management-api");
+    const { ManagementRequest } = await import("./helpers/management-auth");
+
+    const cfg = {
+      port: 10100,
+      defaultProvider: "a",
+      providers: { a: { adapter: "openai-responses", baseUrl: "https://a.example/v1", apiKey: "secret", models: ["m1"] } },
+      routingProfiles: {},
+    } as unknown as OcxConfig;
+
+    const req = new ManagementRequest("http://localhost/api/routing-profiles/dry-run", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ profile: "does-not-exist" }),
+    });
+    const response = await handleManagementAPI(req, new URL(req.url), cfg, {
+      saveConfigPreservingClaudeCode: () => {},
+      createManagementConvergeCodex: () => async () => ({
+        kind: "catalog-only" as const,
+        catalogRefresh: { status: "committed" as const, changed: false, degraded: false, notices: [] },
+      }),
+    } as never);
+
+    // 404 rather than 500: an unknown profile is a client error, and the route answers it
+    // before any assembly work.
+    expect(response?.status).toBe(404);
+
+    // The property under test. Neither slot may be filled, and no activation record may
+    // exist for this config dir.
+    expect(resolveCompatibilityEvidenceProvider()).toBeNull();
+    expect(hasPassiveRouteLinker()).toBe(false);
+    expect(isLabActivated(homeDir)).toBe(false);
+  });
+
+  test("the same route DOES register once a profile exists, so the assertion above is not vacuous", async () => {
+    const { handleManagementAPI } = await import("../src/server/management-api");
+    const { ManagementRequest } = await import("./helpers/management-auth");
+
+    const cfg = {
+      port: 10100,
+      defaultProvider: "a",
+      providers: { a: { adapter: "openai-responses", baseUrl: "https://a.example/v1", apiKey: "secret", models: ["m1"] } },
+      routingProfiles: { compat: { candidates: [{ provider: "a", model: "m1" }] } },
+    } as unknown as OcxConfig;
+
+    const req = new ManagementRequest("http://localhost/api/routing-profiles/dry-run", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ profile: "compat" }),
+    });
+    const response = await handleManagementAPI(req, new URL(req.url), cfg, {
+      saveConfigPreservingClaudeCode: () => {},
+      createManagementConvergeCodex: () => async () => ({
+        kind: "catalog-only" as const,
+        catalogRefresh: { status: "committed" as const, changed: false, degraded: false, notices: [] },
+      }),
+    } as never);
+
+    expect(response?.status).toBe(200);
+    // Same route, same process, one config field different: the slot is filled. Without
+    // this half, the case above would still pass if the route stopped activating entirely.
+    expect(resolveCompatibilityEvidenceProvider()).not.toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Summary

The wp6 audit's useful negative result: the core invariants hold on `dev`, but two of them were held by nothing except the current code being correct. This adds the two guards that were promised and never written, and corrects one comment that has become false.

### Gap 1 — the no-await activation scan

`AGENTS.md` states the synchronous-activation guarantee as if it were enforced, and [`080_activation_is_synchronous.md:143`](devlog/_fin/260814_lab_core_decoupling/080_activation_is_synchronous.md) recorded it as a Phase-4 test. `tests/core-lab-boundary.test.ts` only ever held the two import-graph guards.

The failure it guards against is silent. Everything between `Bun.serve` and the return of `startServer` runs in one synchronous turn, which is what guarantees a policy route cannot be evaluated before its evidence provider is registered. Add one `await` there and the synchronous subagent-fallback chain observes an empty slot and routes subagents to a different model than the operator configured. Nothing goes red — the wrong model simply answers.

The scan blanks comments and string bodies before looking, which is load-bearing rather than tidy: the window itself contains two comments that say the word *await* (`src/server/index.ts:1853` "cannot await", `:1950` "nowhere to await"). A naive text match fails on correct code, and a guard that cries wolf on `dev` gets deleted rather than fixed. Template interpolations stay code, because `${await x()}` is a genuine violation. Brace-depth tracking distinguishes a function body from a block, so the three awaits inside the `server.stop` closure are tolerated while an await inside `if`/`try`/`for` is still reported.

### Gap 2 — the R3-1 profile-less dry-run assertion

[`090_audit_round3_closeout.md:47`](devlog/_fin/260814_lab_core_decoupling/090_audit_round3_closeout.md) required a behavioral assertion that a genuinely profile-less dry-run registers no slot. `tests/lab-activation.test.ts` only checked that a bare *config* never activates, which never exercises the management route where the activation call actually lives (`src/server/management/routing-profile-routes.ts:293` and `:368`).

This was exactly the "guard passes while the property is violated" path from audit round 3, so it is asserted in both directions: the same route, same process, one config field different must still fill the slot. Without that half, the negative case would keep passing if the route stopped activating altogether.

### Prose correction

`src/server/responses/core.ts:5194` still described generic OAuth failover as "opt-in and a strict no-op otherwise". Since #2568d presence is consent: rotation defaults ON at two or more eligible accounts (`src/oauth/generic-account-failover.ts:104-128`). Single-account installs are still a no-op and an explicit `oauthAccountFailover.enabled: false` still wins, so only the "opt-in" half was wrong. The behaviour is a recorded owner decision and is unchanged.

## Verification

Each new assertion was driven red before being kept:

| Injected regression | Result |
| --- | --- |
| `await Promise.resolve()` before the activation block + `startServer` marked `async` | 3 of 4 new boundary assertions fail |
| dry-run `activateLab` moved above the unknown-profile 404 and made unconditional | the R3-1 case fails, its anti-vacuity twin still passes |

Both injections reverted; `git status` confirmed clean afterwards.

At this head:

- `bun test tests/core-lab-boundary.test.ts tests/lab-activation.test.ts` — 32 pass, 0 fail
- `bun x tsc --noEmit` — exit 0
- full `bun run test` on the Linux CI host at this exact head

The scan's own behaviour is pinned by a guard-on-the-guard case covering comments, string literals, template interpolation, nested async callbacks, `for await`, and identifiers that merely contain the word.

## Checklist

- [x] Local CI green (focused tests, typecheck; full suite on the remote host at this head)
- [x] Branch is on the latest `dev` commit
- [x] All correct Codex and CodeRabbit findings fixed
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that generic OAuth account failover is enabled by default when multiple eligible accounts are available, with an opt-out setting. Certain providers remain excluded.
  * Documented safeguards that keep server activation synchronous and prevent unintended suspension.

* **Tests**
  * Added coverage for activation-window boundaries and synchronous server startup.
  * Added dry-run coverage for profile-less installations, including correct error handling and prevention of unintended activation records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->