### PR TITLE
docs(devlog): close the dev hardening unit with a promotion-readiness statement

### DIFF
--- a/devlog/_plan/260827_dev_hardening/070_wp7_promotion_readiness.md
+++ b/devlog/_plan/260827_dev_hardening/070_wp7_promotion_readiness.md
@@ -1,0 +1,60 @@
+# wp7 — promotion readiness at `2a72cc017`
+
+This is the closing record for the 260827 dev hardening unit. It states what is proven
+about the current `dev` head, what is deliberately not on it, and what a promoter still
+has to do. It is not an approval to promote.
+
+## The head
+
+`dev` = `2a72cc0173af36d4b8172b70ba0a3384db9e6047`, 283 commits ahead of `main`
+(`ec51e42d7`, v2.33.0). `package.json` reads `2.34.0`, so the version line is ahead of the
+published channel rather than behind it — which is the whole subject of wp2 and is now
+guarded by `tests/release-version-line.test.ts`.
+
+## What this unit changed
+
+| Work phase | PR | Merged as | What it closed |
+| --- | --- | --- | --- |
+| wp1 | #2738 | `5dfee1a05` | inventory and remediation roadmap |
+| wp2 | #2739 | `ca3b379e1` | dev carried a version behind its own releases |
+| wp2b | #2743 | `a57b9620a` | the version guard could go inert without `fetch-tags` |
+| wp3 | #2745 | **not merged** | credential identity on OAuth 429 rotation |
+| wp4 | #2746 | `802f04adc` | locale pages that contradicted the code |
+| wp5 | #2749 | `5000321e6` | `doctor:gui` failed on dev, so prepush was routinely bypassed |
+| wp6 | #2751 | `2a72cc017` | two invariants AGENTS.md claimed were enforced, and were not |
+
+## Proven at this head
+
+- Full `bun run test` on the Linux host: rc=0. The three runs during wp6 reported 15,324
+  passing tests and 0 failures with no `(fail)` lines; the wp5 runs reported 15,318.
+- Cross-platform CI green on each merged head, covering Linux, Windows, and macOS. The
+  macOS leg is the slow one at roughly 9-11 minutes and is always last to report.
+- `bun x tsc --noEmit`, `bun run lint:gui`, and `bun run doctor:gui` all exit 0 locally on
+  `dev` — the last of those for the first time this unit, which is what wp5 was for.
+
+## Not on this head, on purpose
+
+**PR #2745 (wp3) is open and must stay open.** It changes credential identity handling on
+OAuth 429 rotation, which `MAINTAINERS.md` puts behind explicit security review. It was not
+self-merged and `maintainer-sponsored` was deliberately not applied. Anyone promoting `dev`
+should know that the failover identity drift described in
+`devlog/_plan/260827_dev_hardening/020_wp3_failover_identity.md` is still present on `dev`.
+
+The review lane that examined it refuted the exploit's reachability — the missing
+`continue recovery` acts as an accidental guard — so this is a correctness defect rather
+than a live vulnerability. That is the reason it is a normal review queue item and not a
+release blocker.
+
+## What a promoter still has to do
+
+Nothing here substitutes for the release procedure in `MAINTAINERS.md`. Promotion is
+maintainer-controlled, and `scripts/release.ts` remains the release authority. This record
+only establishes that the integration branch is in a state worth promoting from.
+
+## What this unit did not attempt
+
+The audit walked the core/Lab boundary, the startup activation window, repository hygiene,
+the version line, locale docs, and the local gates. It did not audit provider adapters,
+the GUI beyond its lint configuration, or the release workflow itself. A green suite at
+this head is evidence about the code that has tests, which is the ordinary limit of this
+kind of statement and worth saying out loud rather than implying otherwise.


### PR DESCRIPTION
## Summary

Closes the 260827 dev hardening unit with a record of what is proven about `dev` at `2a72cc017`, what is deliberately not on it, and what a promoter still has to do. Docs only — no runtime change.

It is a state record, not an approval to promote. `MAINTAINERS.md` and `scripts/release.ts` remain the release authority.

### What the unit changed

| Work phase | PR | Merged as | What it closed |
| --- | --- | --- | --- |
| wp1 | #2738 | `5dfee1a05` | inventory and remediation roadmap |
| wp2 | #2739 | `ca3b379e1` | dev carried a version behind its own releases |
| wp2b | #2743 | `a57b9620a` | the version guard could go inert without `fetch-tags` |
| wp3 | #2745 | **not merged** | credential identity on OAuth 429 rotation |
| wp4 | #2746 | `802f04adc` | locale pages that contradicted the code |
| wp5 | #2749 | `5000321e6` | `doctor:gui` failed on dev, so prepush was routinely bypassed |
| wp6 | #2751 | `2a72cc017` | two invariants AGENTS.md claimed were enforced, and were not |

### Two things the statement is explicit about

**PR #2745 stays open.** It touches credential identity on OAuth 429 rotation, which `MAINTAINERS.md` puts behind explicit security review, so the identity drift is still present on `dev`. The review lane refuted the exploit's reachability — the missing `continue recovery` acts as an accidental guard — which is why this is a review-queue item rather than a release blocker. Anyone promoting `dev` should know it is there.

**The audit scope was bounded.** It covered the core/Lab boundary, the startup activation window, repository hygiene, the version line, locale docs, and the local gates. It did not cover provider adapters, the GUI beyond its lint configuration, or the release workflow itself. A green suite is evidence about code that has tests, and the statement says so rather than implying more.

## Verification

- `dev` = `2a72cc0173af36d4b8172b70ba0a3384db9e6047`, 283 commits ahead of `main` (`ec51e42d7`, v2.33.0); `package.json` reads `2.34.0`
- full `bun run test` on the Linux host at the exact dev head: rc=0
- Cross-platform CI green on every merged head in the table above (Linux, Windows, macOS)
- every figure in the document was resolved from a command rather than from memory

## Checklist

- [x] Local CI green (docs-only change; full suite on the remote host at the dev head)
- [x] Branch is on the latest `dev` commit
- [x] All correct Codex and CodeRabbit findings fixed
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a promotion-readiness record summarizing the current development status.
  * Documented completed and outstanding work, validation results, release requirements, and audit scope.
  * Recorded a known OAuth rate-limit credential-identity issue that remains unresolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->