### PR TITLE
docs(devlog): record that dev advanced past the readiness sha

### DIFF
--- a/devlog/_plan/260827_dev_hardening/070_wp7_promotion_readiness.md
+++ b/devlog/_plan/260827_dev_hardening/070_wp7_promotion_readiness.md
@@ -58,3 +58,26 @@ the version line, locale docs, and the local gates. It did not audit provider ad
 the GUI beyond its lint configuration, or the release workflow itself. A green suite at
 this head is evidence about the code that has tests, which is the ordinary limit of this
 kind of statement and worth saying out loud rather than implying otherwise.
+
+## Addendum — `dev` has advanced past the sha above
+
+The statement was written at `2a72cc017` and `dev` has since moved twice, so the head it
+names is no longer the tip. Recorded here rather than left to rot, because a readiness
+statement whose sha is stale is worse than no statement.
+
+| Head | What it added | Proven |
+| --- | --- | --- |
+| `2a72cc017` | wp6 invariant locks | remote suite rc=0, 15,324 pass; CI green |
+| `c457c7085` | this document (#2752) | docs only, no code differs from `2a72cc017` |
+| `eeb774026` | #2750, Kiro code-mode delegation surface | remote suite rc=0, 15,334 pass; CI green |
+
+#2750 was 14 commits behind `dev` when it came up for merge — past the 10-commit
+threshold the readiness gate documents — so it was rebased onto `c457c7085` first and
+re-verified at the rebased head `942193852` rather than merged on a stale base. The
+rebase replayed all five commits with no conflicts. Alongside its own 68 Kiro tests, the
+invariant guards and version-line locks that landed during this unit were re-run against
+it (167 pass, 0 fail) to confirm the two lines of work do not interfere.
+
+Everything the body of this document says about promotion still holds at `eeb774026`: the
+version line, the gates, the invariant locks, and the deferral of #2745 are all unchanged
+by the two commits above.


### PR DESCRIPTION
## Summary

The promotion-readiness statement merged in #2752 was written at `2a72cc017`, and `dev` has since moved to `eeb774026`. A readiness statement whose sha is stale is worse than no statement, so this records the drift instead of leaving it to rot. Docs only.

| Head | What it added | Proven |
| --- | --- | --- |
| `2a72cc017` | wp6 invariant locks (#2751) | remote suite rc=0, 15,324 pass; CI green |
| `c457c7085` | the readiness statement (#2752) | docs only, no code differs from `2a72cc017` |
| `eeb774026` | Kiro code-mode delegation surface (#2750) | remote suite rc=0, 15,334 pass; CI green |

It also records why #2750 was rebased rather than merged as it stood: it had fallen 14 commits behind `dev`, past the 10-commit threshold the readiness gate documents. The rebase replayed all five commits with no conflicts, and the invariant guards and version-line locks from this unit were re-run against the rebased head (167 pass, 0 fail) to confirm the two lines of work do not interfere.

Nothing in the body of the statement changes: the version line, the local gates, the invariant locks, and the deferral of #2745 all still hold at `eeb774026`.

## Verification

- `dev` = `eeb774026`, Cross-platform CI completed **success** (run `33068172386`, macOS included)
- every sha, pass count, and PR number in the addendum was resolved from a command

## Checklist

- [x] Local CI green (docs-only change)
- [x] Branch is on the latest `dev` commit
- [x] All correct Codex and CodeRabbit findings fixed
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated promotion-readiness records to reflect the latest development progress.
  * Documented the successful rebase and verification of all changes, with 167 checks passing and no failures.
  * Confirmed that promotion-readiness statements remain valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->