### PR TITLE
fix(moonshot): intersect nested schema bounds

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -1113,7 +1113,8 @@ function intersectBound(target: unknown, sibling: unknown, direction: "max" | "m
  * Compose two `properties` maps. A property named in BOTH the referenced target and the
  * node is the same conjunction problem `required` had: letting the sibling win discards
  * the target's constraints for that member. Merge the two member schemas so neither side
- * loses its keywords, and let the node narrow on a genuine conflict.
+ * loses its keywords. Shared member bounds are the same conjunction one level down,
+ * and nested object members recurse through this helper instead of replacing the target.
  */
 function composeProperties(
   target: Record<string, unknown>,
@@ -1127,7 +1128,20 @@ function composeProperties(
       const member: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
       for (const [k, v] of Object.entries(existing)) member[k] = v;
       for (const [k, v] of Object.entries(sub)) {
-        member[k] = k === "required" ? unionRequired(member[k], v) : v;
+        if (k === "required") {
+          member[k] = unionRequired(member[k], v);
+          continue;
+        }
+        if (k === "properties" && isXaiObjectSchema(member[k]) && isXaiObjectSchema(v)) {
+          member[k] = composeProperties(member[k] as Record<string, unknown>, v);
+          continue;
+        }
+        const boundDirection = MOONSHOT_BOUND_KEYWORDS[k];
+        if (boundDirection && k in member) {
+          member[k] = intersectBound(member[k], v, boundDirection);
+          continue;
+        }
+        member[k] = v;
       }
       combined[name] = member;
       continue;

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -1093,6 +1093,21 @@ the shared Ark hostname is too broad because the two endpoint families reject op
 
 ## Chat structured-output compatibility
 
+First-party Kimi and Moonshot Chat destinations normalize a `$ref` with sibling keywords because
+their wire rejects that valid JSON Schema 2020-12 shape. Inlining preserves conjunction semantics:
+`required` members are unioned, lower numeric bounds take the maximum, upper numeric bounds take the
+minimum, and overlapping `properties` recurse with the same rules. The walk remains depth-, node-,
+and expansion-bounded. Unresolvable or cyclic references keep the existing bare-`$ref` fallback,
+and unrelated OpenAI-compatible providers retain the caller's schema unchanged.
+
+[Decision Log]
+- 목적과 의도: Make Moonshot's compatibility rewrite remove rejected sibling `$ref` shapes without silently weakening a tool schema.
+- 기존 구현 및 제약 조건: The target and sibling both apply under JSON Schema 2020-12, but a shallow shared-property merge let sibling bounds replace stricter target bounds; Moonshot still requires the local bounded rewrite.
+- 검토한 주요 대안: Keep shallow sibling precedence; emit `allOf`; intersect only top-level bounds; recursively compose the supported set-valued and ordered assertions.
+- 선택한 방식: Reuse the existing bound and required intersection rules recursively for overlapping object properties inside the first-party destination gate.
+- 다른 대안 대신 이 방식을 선택한 이유: Shallow precedence weakens constraints, while a new `allOf` wire shape needs separate provider evidence; recursive composition fixes the demonstrated loss without broadening normalization to custom providers.
+- 장점, 단점 및 영향: Looser siblings cannot relax nested constraints and tighter siblings still narrow them; non-ordered conflicting keywords retain the existing sibling precedence and are not treated as a complete JSON Schema algebra.
+
 The `openai-chat` adapter translates Responses `text.format` and Chat Completions
 `response_format` through one internal format, then emits `response_format` on the upstream chat
 wire. That remains the default because silently returning prose breaks clients that requested a

--- a/tests/moonshot-tool-schema.test.ts
+++ b/tests/moonshot-tool-schema.test.ts
@@ -325,6 +325,74 @@ describe("Moonshot tool schema normalization (issue #2673)", () => {
     expect(shared.type).toBe("string");
   });
 
+  test("intersects bounds when both sides define the same property", async () => {
+    const parameters = await emittedParameters("https://api.moonshot.ai/v1", {
+      name: "shared_property_bounds_tool",
+      parameters: {
+        type: "object",
+        $defs: {
+          Base: {
+            type: "object",
+            properties: {
+              looserSibling: { type: "string", minLength: 5, maxLength: 10 },
+              tighterSibling: { type: "string", minLength: 1, maxLength: 100 },
+            },
+          },
+        },
+        properties: {
+          value: {
+            $ref: "#/$defs/Base",
+            properties: {
+              looserSibling: { type: "string", minLength: 1, maxLength: 99 },
+              tighterSibling: { type: "string", minLength: 5, maxLength: 10 },
+            },
+          },
+        },
+      },
+    });
+
+    const value = (parameters?.properties as Record<string, Record<string, unknown>>).value!;
+    const properties = value.properties as Record<string, Record<string, unknown>>;
+    expect(properties.looserSibling).toMatchObject({ minLength: 5, maxLength: 10 });
+    expect(properties.tighterSibling).toMatchObject({ minLength: 5, maxLength: 10 });
+  });
+
+  test("intersects bounds recursively inside shared object properties", async () => {
+    const parameters = await emittedParameters("https://api.moonshot.ai/v1", {
+      name: "nested_shared_property_bounds_tool",
+      parameters: {
+        type: "object",
+        $defs: {
+          Base: {
+            type: "object",
+            properties: {
+              shared: {
+                type: "object",
+                properties: { leaf: { type: "string", minLength: 5, maxLength: 10 } },
+              },
+            },
+          },
+        },
+        properties: {
+          value: {
+            $ref: "#/$defs/Base",
+            properties: {
+              shared: {
+                type: "object",
+                properties: { leaf: { type: "string", minLength: 1, maxLength: 99 } },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const value = (parameters?.properties as Record<string, Record<string, unknown>>).value!;
+    const shared = (value.properties as Record<string, Record<string, unknown>>).shared!;
+    const leaf = (shared.properties as Record<string, Record<string, unknown>>).leaf!;
+    expect(leaf).toMatchObject({ minLength: 5, maxLength: 10 });
+  });
+
   test("leaves data-valued keywords alone, even when they look like schemas", async () => {
     // `enum` lists VALUES. Recursing into it treated a literal object carrying a "$ref"
     // string as a reference node and stripped the key, silently changing a value the tool


### PR DESCRIPTION
## Summary

Fixes #2763.

- Intersect ordered numeric bounds when a referenced Moonshot/Kimi schema target and its sibling both define the same property.
- Recurse through overlapping object `properties`, so a shallow merge cannot reintroduce the same weakening one level deeper.
- Preserve the existing first-party destination gate, required-set union, data-keyword handling, and depth/node/ref budgets.
- Document why the compatibility rewrite composes only the assertions it can order safely.

## Failure and fix

Before the patch, the focused regression emitted `minLength: 1` and `maxLength: 99` when the referenced target required `minLength: 5` and `maxLength: 10`. The same weakening reproduced inside a recursively shared object property.

The shared-property composer now applies the same conjunction rules already used at the sibling-`$ref` boundary: lower bounds use the maximum, upper bounds use the minimum, and nested property maps recurse. Non-ordered conflicting keywords keep the existing sibling precedence; this is not a general JSON Schema algebra or a rewrite for custom providers.

## Verification

- Regression before fix: `16 passed, 2 failed` with both new bound-intersection cases failing on the weakened values.
- `bun test tests/moonshot-tool-schema.test.ts --timeout 30000` with isolated homes and a two-CPU cap: `18 passed, 0 failed`.
- `git diff --check`: passed.
- A local `bun run typecheck` rerun currently reports the same three unrelated `fetch(..., { timeout })` errors on both this branch and a clean `dev@8b1b65b8d` worktree; exact-head CI is required before approval.
- Protected local Codex/OpenCodex/Paseo config files retained identical SHA-256 values before and after validation.

## Integration-line disposition

This is confined to the TypeScript `openai-chat` compatibility adapter. The repository currently exposes no remote `dev2-go` branch, so no Go counterpart can be opened in this session; the merging maintainer should record or track the port decision under the current transition policy.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] The architecture note records the compatibility decision and tradeoff.
- [x] No authentication, credential, workflow, release, dependency, GUI, or catalog surface is changed.
- [ ] Exact-head required CI is green.

This remains Draft until exact-head CI is green and a non-author maintainer reviews it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structured-schema handling for Kimi and Moonshot Chat destinations.
  * Preserved and combined validation rules when referenced schemas include additional constraints.
  * Nested object properties now retain the strictest compatible limits, including length and numeric bounds.
  * Added safer handling for unresolved or cyclic schema references while maintaining existing fallback behavior.

* **Tests**
  * Added coverage for constraint merging in both direct and nested referenced schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->