### PR TITLE
fix(claude): derive response.failed status from the classified error payload

### DIFF
--- a/src/adapters/cursor/cursor-errors.ts
+++ b/src/adapters/cursor/cursor-errors.ts
@@ -248,6 +248,14 @@ export function classifyCursorError(message: string, sizeContext?: CursorSizeCon
     lower.includes("server is busy")
   ) return "Cursor server overloaded";
 
+  // gRPC FAILED_PRECONDITION is deterministic and non-retryable (unlike UNAVAILABLE):
+  // the backend rejected the call because the account/plan state does not allow it —
+  // seen live when a plan-gated model (e.g. claude-fable-5) runs on a plan without it.
+  // Leaving it as "Cursor upstream error" (502) made clients retry it as overload.
+  if (lower.includes("failed_precondition") || lower.includes("failed precondition")) {
+    return "Cursor invalid request";
+  }
+
   if (
     lower.includes("invalid") ||
     lower.includes("not found") ||

--- a/src/adapters/cursor/cursor-errors.ts
+++ b/src/adapters/cursor/cursor-errors.ts
@@ -241,20 +241,27 @@ export function classifyCursorError(message: string, sizeContext?: CursorSizeCon
     lower.includes("access denied")
   ) return "Cursor authentication failed";
 
+  // gRPC FAILED_PRECONDITION is deterministic and non-retryable (unlike UNAVAILABLE):
+  // the backend rejected the call because the account/plan state does not allow it —
+  // seen live when a plan-gated model (e.g. claude-fable-5) runs on a plan without it.
+  // Leaving it as "Cursor upstream error" (502) made clients retry it as overload.
+  //
+  // This MUST precede the overload keywords. The explicit gRPC status code is a
+  // structured signal from the backend; the keywords are inference over free text. A
+  // plan-gated rejection routinely reads "failed_precondition: model unavailable for
+  // this plan", which matched "unavailable" first and came back as a retryable
+  // overload — the exact misclassification this branch was added to stop. Checking the
+  // code first lets the deterministic signal win over the words around it.
+  if (lower.includes("failed_precondition") || lower.includes("failed precondition")) {
+    return "Cursor invalid request";
+  }
+
   if (
     lower.includes("unavailable") ||
     lower.includes("overloaded") ||
     lower.includes("temporarily") ||
     lower.includes("server is busy")
   ) return "Cursor server overloaded";
-
-  // gRPC FAILED_PRECONDITION is deterministic and non-retryable (unlike UNAVAILABLE):
-  // the backend rejected the call because the account/plan state does not allow it —
-  // seen live when a plan-gated model (e.g. claude-fable-5) runs on a plan without it.
-  // Leaving it as "Cursor upstream error" (502) made clients retry it as overload.
-  if (lower.includes("failed_precondition") || lower.includes("failed precondition")) {
-    return "Cursor invalid request";
-  }
 
   if (
     lower.includes("invalid") ||

--- a/src/claude/outbound.ts
+++ b/src/claude/outbound.ts
@@ -11,6 +11,7 @@
  *  - errors: {type:"error", error:{type,message}}; may arrive mid-stream after HTTP 200.
  */
 import { createHash } from "node:crypto";
+import { httpStatusFromTerminalError } from "../lib/errors";
 import { isTransientUpstreamStatus } from "../lib/upstream-retry";
 import {
   isTranslatorBudgetExceededError,
@@ -555,9 +556,19 @@ export function responsesSseToAnthropicSse(
             }
             const status = code === "translation_buffer_limit"
               ? 413
-              : typeof error.status === "number" ? error.status : 500;
-            // status-absent response.failed (relaySseWithFailedTail synthetic tail) defaults
-            // to 500, which is in the transient set — the mid-stream reset shape maps to
+              : typeof error.status === "number"
+                ? error.status
+                // Internal response.failed envelopes carry the classified {type, code, message}
+                // but no numeric status. Derive it with the same mapping /api/logs uses so a
+                // classified 429/401/400 reaches Claude Code as its real Anthropic error type
+                // instead of being masked as retryable overload.
+                : httpStatusFromTerminalError({
+                  type: typeof error.type === "string" ? error.type : undefined,
+                  code: typeof error.code === "string" ? error.code : null,
+                  message,
+                });
+            // Unclassified status-absent response.failed (relaySseWithFailedTail synthetic
+            // tail) still lands on a transient 5xx here — the mid-stream reset shape maps to
             // overloaded_error by design.
             fail(
               status,

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -404,20 +404,30 @@ export function httpStatusFromTerminalError(error: {
   ) return 403;
   if (error.type === "insufficient_quota" || error.code === "insufficient_quota") return 429;
   if (error.type === "server_error" && error.code === "server_is_overloaded") return 503;
-  // A structured generic upstream/server classification outranks message inference.
-  // classifyError assigns `server_error` + `upstream_server_error` to every 5xx it sees,
-  // so the class is authoritative: the provider already told us this was a server failure.
-  // Falling through to the message heuristics below inverts that, because an upstream 500
-  // whose text happens to contain "malformed" or "invalid request" is read as a client
-  // error and returns 400. Claude Code then stops retrying a failure that was retryable,
-  // and the caller sees invalid_request_error for an upstream outage.
-  if (error.type === "server_error" || error.code === "upstream_server_error") return 502;
   // Client-closed messages often arrive as invalid_request_error after classifyError; check message
   // before treating every invalid_request_error as HTTP 400.
   const message = error.message ?? "";
   if (message && isClientClosedMessage(message)) return 499;
   if (error.type === "invalid_request_error") return 400;
   if (error.type === "proxy_error") return 500;
-  if (message) return inferHttpStatusFromAdapterMessage(message);
+  // A structured server class must not be downgraded to a CLIENT error by message wording.
+  // classifyError assigns `server_error` + `upstream_server_error` to every 5xx it sees, so
+  // the class is authoritative about blame: the upstream failed, the caller did not send a
+  // bad request. What it is NOT authoritative about is which server status fits — a stall is
+  // genuinely 504 and an overload genuinely 503, and flattening those to 502 discards
+  // information both the log surface and the retry policy read. So message inference still
+  // chooses the specific status, and only a client-error verdict is overridden.
+  //
+  // The override is deliberately narrowed to 400 alone. 429, 499, 401 and 403 are all
+  // actionable signals the caller routes on — retry-after, client cancellation, re-auth,
+  // entitlement — and overriding them would trade one kind of misreport for another. 400 is
+  // the single verdict that both blames the caller and stops the retry, which is the failure
+  // being fixed: an upstream 500 whose text happens to contain "malformed" or "invalid
+  // request" used to return 400, so Claude Code stopped retrying a retryable failure.
+  const structuredServerClass = error.type === "server_error" || error.code === "upstream_server_error";
+  if (message) {
+    const inferred = inferHttpStatusFromAdapterMessage(message);
+    return structuredServerClass && inferred === 400 ? 502 : inferred;
+  }
   return 502;
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -404,6 +404,14 @@ export function httpStatusFromTerminalError(error: {
   ) return 403;
   if (error.type === "insufficient_quota" || error.code === "insufficient_quota") return 429;
   if (error.type === "server_error" && error.code === "server_is_overloaded") return 503;
+  // A structured generic upstream/server classification outranks message inference.
+  // classifyError assigns `server_error` + `upstream_server_error` to every 5xx it sees,
+  // so the class is authoritative: the provider already told us this was a server failure.
+  // Falling through to the message heuristics below inverts that, because an upstream 500
+  // whose text happens to contain "malformed" or "invalid request" is read as a client
+  // error and returns 400. Claude Code then stops retrying a failure that was retryable,
+  // and the caller sees invalid_request_error for an upstream outage.
+  if (error.type === "server_error" || error.code === "upstream_server_error") return 502;
   // Client-closed messages often arrive as invalid_request_error after classifyError; check message
   // before treating every invalid_request_error as HTTP 400.
   const message = error.message ?? "";

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -335,6 +335,12 @@ export function inferHttpStatusFromAdapterMessage(message: string): number {
   // subscription/permission wording.
   if (isAuthenticationMessage(lower)) return 401;
   if (isSubscriptionGateMessage(lower) || isPermissionMessage(lower)) return 403;
+  // Same precedence rule as classifyCursorError: an explicit gRPC FAILED_PRECONDITION is a
+  // structured, deterministic rejection, so it outranks the overload keywords that routinely
+  // appear beside it ("failed_precondition: model unavailable for this plan"). Without this,
+  // the message matched "unavailable" and returned a retryable 503, so clients kept retrying
+  // a rejection that can never succeed.
+  if (lower.includes("failed_precondition") || lower.includes("failed precondition")) return 400;
   if (
     lower.includes("unavailable") ||
     lower.includes("overloaded") ||

--- a/tests/claude-outbound.test.ts
+++ b/tests/claude-outbound.test.ts
@@ -534,6 +534,79 @@ describe("claude outbound SSE", () => {
     });
   });
 
+  // Internal response.failed envelopes carry the classified {type, code, message} but no
+  // numeric status (adapterFailureFromEvent drops httpStatus at the wire boundary). The
+  // classified status must be derived the same way /api/logs derives it, or every classified
+  // failure is masked as retryable overloaded_error — a Cursor plan/quota 429 surfaced in
+  // Claude Code as "Repeated 529 Overloaded errors".
+  test("failed with classified rate_limit_error but NO numeric status -> rate_limit_error, not overloaded", async () => {
+    const upstream = [
+      sse("response.created", { response: {} }),
+      sse("response.failed", {
+        response: {
+          status: "failed",
+          error: { type: "rate_limit_error", code: "rate_limit_exceeded", message: "Cursor rate limit exceeded: quota exhausted" },
+        },
+      }),
+    ].join("");
+    const events = await collectEvents(responsesSseToAnthropicSse(streamFrom(upstream), "m"));
+    expect(events.at(-1)!.data).toEqual({
+      type: "error",
+      error: { type: "rate_limit_error", message: "Cursor rate limit exceeded: quota exhausted" },
+    });
+  });
+
+  test("failed with classified authentication_error but NO numeric status -> authentication_error, not overloaded", async () => {
+    const upstream = [
+      sse("response.created", { response: {} }),
+      sse("response.failed", {
+        response: {
+          status: "failed",
+          error: { type: "authentication_error", code: "invalid_api_key", message: "Cursor authentication failed: expired token" },
+        },
+      }),
+    ].join("");
+    const events = await collectEvents(responsesSseToAnthropicSse(streamFrom(upstream), "m"));
+    expect(events.at(-1)!.data).toEqual({
+      type: "error",
+      error: { type: "authentication_error", message: "Cursor authentication failed: expired token" },
+    });
+  });
+
+  test("failed with classified invalid_request_error but NO numeric status -> invalid_request_error, not overloaded", async () => {
+    const upstream = [
+      sse("response.created", { response: {} }),
+      sse("response.failed", {
+        response: {
+          status: "failed",
+          error: { type: "invalid_request_error", code: "context_length_exceeded", message: "Cursor context limit exceeded" },
+        },
+      }),
+    ].join("");
+    const events = await collectEvents(responsesSseToAnthropicSse(streamFrom(upstream), "m"));
+    expect(events.at(-1)!.data).toEqual({
+      type: "error",
+      error: { type: "invalid_request_error", message: "Cursor context limit exceeded" },
+    });
+  });
+
+  test("failed with classified server overload but NO numeric status -> still overloaded_error", async () => {
+    const upstream = [
+      sse("response.created", { response: {} }),
+      sse("response.failed", {
+        response: {
+          status: "failed",
+          error: { type: "server_error", code: "server_is_overloaded", message: "Cursor server overloaded: unavailable" },
+        },
+      }),
+    ].join("");
+    const events = await collectEvents(responsesSseToAnthropicSse(streamFrom(upstream), "m"));
+    expect(events.at(-1)!.data).toEqual({
+      type: "error",
+      error: { type: "overloaded_error", message: "Cursor server overloaded: unavailable" },
+    });
+  });
+
   test("internal reader exception stays api_error (not promoted to overloaded)", async () => {
     const boom = new ReadableStream<Uint8Array>({
       start(controller) {

--- a/tests/claude-outbound.test.ts
+++ b/tests/claude-outbound.test.ts
@@ -607,6 +607,38 @@ describe("claude outbound SSE", () => {
     });
   });
 
+  // Deriving the status from the classified payload is only safe if a STRUCTURED server
+  // class outranks the message heuristics. `httpStatusFromTerminalError` recognized only
+  // `server_error` + `server_is_overloaded`, so a generic `upstream_server_error` fell
+  // through to `inferHttpStatusFromAdapterMessage`. An upstream 5xx whose text happens to
+  // contain "malformed" or "invalid request" then returned 400, and Claude Code stopped
+  // retrying a genuinely retryable upstream failure — the exact inversion this PR set out
+  // to fix, reintroduced one layer down. classifyError assigns `upstream_server_error` to
+  // every 5xx it sees, so the class is authoritative over the words in the message.
+  test("generic upstream_server_error with client-sounding text stays a transient server failure", async () => {
+    const upstream = [
+      sse("response.created", { response: {} }),
+      sse("response.failed", {
+        response: {
+          status: "failed",
+          error: {
+            type: "server_error",
+            code: "upstream_server_error",
+            message: "upstream stream produced malformed tool call arguments",
+          },
+        },
+      }),
+    ].join("");
+    const events = await collectEvents(responsesSseToAnthropicSse(streamFrom(upstream), "m"));
+    expect(events.at(-1)!.data).toEqual({
+      type: "error",
+      error: {
+        type: "overloaded_error",
+        message: "upstream stream produced malformed tool call arguments",
+      },
+    });
+  });
+
   test("internal reader exception stays api_error (not promoted to overloaded)", async () => {
     const boom = new ReadableStream<Uint8Array>({
       start(controller) {

--- a/tests/cursor-errors.test.ts
+++ b/tests/cursor-errors.test.ts
@@ -5,6 +5,7 @@ import {
   isCursorInvalidArgumentError,
   safeCursorErrorMessage,
 } from "../src/adapters/cursor/cursor-errors";
+import { inferHttpStatusFromAdapterMessage } from "../src/lib/errors";
 
 describe("classifyCursorError", () => {
   test("rate limit and resource exhaustion stay distinct", () => {
@@ -57,6 +58,15 @@ describe("classifyCursorError", () => {
   test("invalid request / not found", () => {
     expect(classifyCursorError("model not found: bad-model-id")).toBe("Cursor invalid request");
     expect(classifyCursorError("invalid request: malformed tool schema")).toBe("Cursor invalid request");
+  });
+
+  test("failed_precondition is a deterministic non-retryable rejection, not overload", () => {
+    // Live evidence: a plan-gated model (claude-fable-5) invoked on a plan without it
+    // returns "Cursor Connect error failed_precondition: Error". gRPC FAILED_PRECONDITION
+    // is non-retryable by definition; as "Cursor upstream error" (502) clients retried it
+    // as overload, and the Claude inbound surfaced it as a misleading 529.
+    expect(classifyCursorError("Cursor Connect error failed_precondition: Error")).toBe("Cursor invalid request");
+    expect(inferHttpStatusFromAdapterMessage("Cursor invalid request: Cursor Connect error failed_precondition: Error")).toBe(400);
   });
 
   test("timeout / deadline", () => {

--- a/tests/cursor-errors.test.ts
+++ b/tests/cursor-errors.test.ts
@@ -69,6 +69,30 @@ describe("classifyCursorError", () => {
     expect(inferHttpStatusFromAdapterMessage("Cursor invalid request: Cursor Connect error failed_precondition: Error")).toBe(400);
   });
 
+  test("failed_precondition wins over overload keywords in the same message", () => {
+    // The original arm sat AFTER the overload keywords, so the shape this branch exists
+    // to catch slipped straight past it: a plan-gated rejection normally reads
+    // "failed_precondition: model unavailable for this plan", which matched "unavailable"
+    // first and came back "Cursor server overloaded" -> 503. Clients then retried a
+    // deterministic rejection forever. The explicit gRPC status is a structured signal
+    // from the backend; "unavailable" and "temporarily" here are just words near it.
+    expect(classifyCursorError("failed_precondition: model unavailable for this plan"))
+      .toBe("Cursor invalid request");
+    expect(classifyCursorError("failed_precondition: model temporarily gated"))
+      .toBe("Cursor invalid request");
+    expect(inferHttpStatusFromAdapterMessage("Cursor invalid request: failed_precondition: model unavailable for this plan"))
+      .toBe(400);
+
+    // A real overload with no gRPC precondition code must still be retryable.
+    expect(classifyCursorError("service temporarily unavailable")).toBe("Cursor server overloaded");
+    expect(classifyCursorError("backend overloaded, retry")).toBe("Cursor server overloaded");
+    expect(classifyCursorError("server is busy")).toBe("Cursor server overloaded");
+
+    // Authentication is checked earlier and stays authoritative over both.
+    expect(classifyCursorError("failed_precondition: unauthorized token"))
+      .toBe("Cursor authentication failed");
+  });
+
   test("timeout / deadline", () => {
     expect(classifyCursorError("Cursor transport timed out before first response")).toBe("Cursor request timed out");
     expect(classifyCursorError("deadline exceeded")).toBe("Cursor request timed out");


### PR DESCRIPTION
## Summary

Supersedes #2729 by carrying its two commits onto current `dev` and closing the blocker its review identified.

#2729's diagnosis is correct: internal `response.failed` envelopes carry the classified `{type, code, message}` but no numeric status, so every classified failure was masked as a retryable `overloaded_error`. A Cursor plan/quota 429 surfaced in Claude Code as "Repeated 529 Overloaded errors". Deriving the status from the classified payload is the right fix.

But that derivation is only correct if the classification actually wins, and it did not. `httpStatusFromTerminalError` recognized a structured server class for exactly one code pair — `server_error` + `server_is_overloaded` — and let everything else fall through to message inference. A generic `upstream_server_error` whose text happened to contain "malformed" or "invalid request" therefore returned **400**:

    upstream_server_error + "upstream stream produced malformed tool call arguments"  ->  400

Claude Code then receives `invalid_request_error` and stops retrying a genuinely retryable upstream failure — the same inversion #2729 set out to fix, one layer down.

`classifyError` assigns `server_error` + `upstream_server_error` to **every** 5xx it observes (`src/lib/errors.ts`), so the class is authoritative about blame.

## The scope of the override, and why it is narrow

The classification is authoritative about **blame**, not about which server status fits. My first attempt returned a blanket 502 for any structured server class, and exact-head CI rejected it: that flattens genuine 504 and 503 verdicts, breaking `tests/web-search-timeout-contract.test.ts`, where a stalled routed body really is a gateway timeout and the log surface asserts `status: 504`.

So message inference still chooses the specific status, and **only the 400 verdict is overridden** — the single case that both blames the caller and stops the retry. 429, 499, 401 and 403 are deliberately left alone: each is a signal the caller routes on (retry-after, client cancellation, re-auth, entitlement), and overriding them would trade one misreport for another.

## Verification

Differential probe against unpatched `origin/dev`. Exactly two cases change:

| case | before | after |
|---|---|---|
| `upstream_server_error` + "malformed" text | 400 | **502** |
| `upstream_server_error` + "invalid request" text | 400 | **502** |
| web-search stall | 504 | 504 |
| "temporarily unavailable" | 503 | 503 |
| rate-limit text under server class | 429 | 429 |
| client close under server class | 499 | 499 |
| cyber-policy by message | 400 | 400 |
| auth text under server class | 401 | 401 |
| permission text under server class | 403 | 403 |
| `server_is_overloaded` | 503 | 503 |
| real `invalid_request_error` | 400 | 400 |
| `proxy_error` | 500 | 500 |
| no message | 502 | 502 |

Focused suites — all nine files that touch this function: **210 pass / 0 fail**. `bun x tsc --noEmit` exit 0.

Mutation-verified oracle: revert only the `src/lib/errors.ts` change and keep the new test -> **45 pass / 1 fail**; with the fix -> **46 pass / 0 fail**.

## Integration-line disposition

No Go runtime counterpart. No authentication decision, credential state, token, OAuth, or account-routing surface is touched — this maps already-classified error envelopes to HTTP status codes.

## Checklist

- [x] Scope is limited to the classified-status derivation and its regression.
- [x] Every non-overridden classification arm verified unchanged against `origin/dev`.
- [x] The new regression is behavioral and fails without the fix.
- [x] Rebased on current `dev`.
- [ ] Exact-head required CI is green.
- [ ] A non-author maintainer has approved.

Closes #2729.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for invalid requests from Cursor.
  - Preserved accurate HTTP error statuses when Claude responses fail without an explicit status.
  - Prevented upstream server errors from being misclassified as client-side request errors.
  - Ensured rate-limit, authentication, and invalid-request errors are surfaced accurately instead of appearing as temporary overloads.

- **Tests**
  - Added coverage for Cursor precondition failures and Claude error classification scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->