### PR TITLE
docs(devlog): plan the ocx agentic control surface roadmap

### DIFF
--- a/devlog/_plan/260828_ocx_agentic_control/000_plan.md
+++ b/devlog/_plan/260828_ocx_agentic_control/000_plan.md
@@ -1,0 +1,116 @@
+# 000 — ocx as a complete agentic control surface
+
+## Objective
+
+Make the `ocx` CLI a complete, scriptable control surface for every capability the
+web dashboard exposes, so an AI agent can operate opencodex end to end from a
+terminal with machine-readable output and honest exit codes. Close the ten
+operator-facing CLI issues (#2696-#2705) at their root causes rather than at their
+symptoms, give help a single source of truth that a test can hold to the API
+surface, and ship a repo-owned agent skill that documents the resulting surface.
+
+## Why this unit exists
+
+The dashboard is the complete surface today and the CLI is a partial mirror of it.
+Three separate failure classes make the CLI unusable for unattended agent control:
+
+1. **Transport dishonesty.** `ocx models live` and `ocx provider quota` print an
+   error and exit 0 (#2697); a 503 arrives with a `reason` and `hint` the CLI
+   never renders (#2698); a launchd install can fence the entire management plane
+   closed and the CLI cannot say why (#2696); the PATH binary can be older than
+   the running proxy while its help claims otherwise (#2701).
+2. **DTO loss.** The API already returns fields the CLI throws away: usage
+   `accounts[]` (#2700), account `paused` and the 5h quota window (#2703), access
+   key `usage.requests7d`/`lastUsedAt` (#2705). One of these is worse than filed:
+   `projectQuota` strips `fiveHourPercent` before any renderer runs.
+3. **Missing verbs.** Pause/resume, pool strategy, sticky limit (#2702) and
+   `logs --conversationId` (#2704) exist as routes with no CLI caller, plus 13
+   further GUI-only capability classes found by inventory.
+
+Underneath all three sits the real defect: **there is no source of truth binding
+the CLI surface to the API surface.** Help lives in a hand-written 69-line banner
+plus 20 module-level `USAGE` constants with zero consumers outside their own
+files, free to drift. Nothing fails when a route lands with no verb.
+
+## Constraints
+
+- Bun-native TypeScript. No compile step, no Node-only APIs.
+- `src/lab/` must stay off the core request path; `tests/core-lab-boundary.test.ts`
+  and the `startServer` synchronous-window scan are hard gates.
+- Management auth is applied before dispatch for every `/api/` path. Three routes
+  require a browser session and MUST NOT get a CLI verb: `POST /api/github/star`
+  (user-consent boundary, `AGENTS_INSTALL.md`), the non-GET `/api/codex-prompt*`
+  verbs, and `POST /api/providers/reload` (capability principal, not a session).
+- `PUT /api/config` is a deliberate 405. Not a parity target.
+- No security triage in `devlog/`. Scratch space only.
+- Per the operator's instruction for this unit: no local full-suite runs during
+  build, no per-push CI polling, `--no-verify` pushes, and a single final
+  rebase-onto-`dev` plus parallel CI triage at the end.
+
+## Measured surface (see 001, 002, 003)
+
+| Surface | Count | Source |
+|---|---|---|
+| Reachable management routes | 183 (108 mutating) | 001 |
+| Dead/shadowed routes | 1 (`GET /api/storage` in logs-usage-routes) | 001 |
+| Session-only routes (never CLI) | 3 | 001 |
+| CLI dispatch runner keys | 52 (43 visible) | 002 |
+| Disconnected help sources | 20 module `USAGE` + 1 banner + 7 inline | 002 |
+| GUI-only capability classes | 13 | 003 |
+
+## Work-phase map (dependency-ordered, PHASE-SPLIT-01)
+
+Each phase consumes the verified output of the previous one. Ordering is by build
+structure — contract first, then the machinery that depends on the contract, then
+the capabilities that machinery exposes, then documentation of the finished
+surface — not by effort or payoff.
+
+| Phase | Doc | Deliverable | Depends on |
+|---|---|---|---|
+| wp2 | `010` | Transport honesty: exit codes, error rendering, token-collision refusal (#2697 #2698 #2696) | — |
+| wp3 | `020` | Capability registry as help SoT + API/CLI parity test + version skew (#2701) | wp2 |
+| wp4 | `030` | DTO fidelity (#2700 #2703 #2705) | wp3 |
+| wp5 | `040` | New verbs and filters (#2702 #2704) | wp3 |
+| wp6 | `050` | Per-account OAuth usage attribution (#2699) | wp4 |
+| wp7 | `060` | Residual GUI-parity closure (13 capability classes) | wp3 wp5 |
+| wp8 | `070` | `ocx` agent skill + docs-site CLI reference | wp7 |
+| wp9 | `080` | Stack rebase onto `dev`, final parallel CI triage | all |
+
+wp2 comes first because every later phase is verified through CLI output: a phase
+that lands while `ocx` still exits 0 on failure cannot be proven. wp3 comes second
+because the registry it introduces is the thing every later phase registers into —
+adding verbs before the registry means writing them twice.
+
+## Delivery shape
+
+A stacked pull-request chain (DEV-STACK-01), one PR per work-phase, each child
+targeting its parent's head branch. Base of the stack is `origin/dev`.
+
+```
+dev
+ └── codex/ocx-agentic-control-roadmap   (this unit's docs)
+      └── codex/ocx-transport-honesty     wp2
+           └── codex/ocx-capability-registry   wp3
+                └── codex/ocx-dto-fidelity     wp4
+                     └── codex/ocx-new-verbs    wp5
+                          └── codex/ocx-account-attribution   wp6
+                               └── codex/ocx-gui-parity        wp7
+                                    └── codex/ocx-agent-skill  wp8
+```
+
+## Accept criteria for the unit
+
+1. Every non-session, non-405 management capability has a CLI verb with `--json`.
+2. A parity test fails when a route lands with no verb and no recorded exemption.
+3. Help is generated from the registry; no hand-maintained command list survives.
+4. Every management failure path exits non-zero and prints `reason` and `hint`.
+5. A repo-owned skill documents the surface with copy-paste recipes.
+6. The whole stack is rebased on current `dev` with CI green.
+
+## Terminal-outcome definitions
+
+`DONE` requires all six above proven against the tree, not remembered.
+`BLOCKED` is a platform or credential refusal. `UNSAFE` is any fix that would
+weaken the admin-token or session boundary — stop and ask instead.
+`NEEDS_HUMAN` is a CLI-grammar choice the operator must make.
+

--- a/devlog/_plan/260828_ocx_agentic_control/000_plan.md
+++ b/devlog/_plan/260828_ocx_agentic_control/000_plan.md
@@ -29,8 +29,9 @@ Three separate failure classes make the CLI unusable for unattended agent contro
 
 Underneath all three sits the real defect: **there is no source of truth binding
 the CLI surface to the API surface.** Help lives in a hand-written 69-line banner
-plus 20 module-level `USAGE` constants with zero consumers outside their own
-files, free to drift. Nothing fails when a route lands with no verb.
+plus 37 module-level usage blocks — 20 of them exported constants with zero
+consumers outside their own files — all free to drift. Nothing fails when a route
+lands with no verb.
 
 ## Constraints
 
@@ -54,8 +55,8 @@ files, free to drift. Nothing fails when a route lands with no verb.
 | Reachable management routes | 183 (108 mutating) | 001 |
 | Dead/shadowed routes | 1 (`GET /api/storage` in logs-usage-routes) | 001 |
 | Session-only routes (never CLI) | 3 | 001 |
-| CLI dispatch runner keys | 52 (43 visible) | 002 |
-| Disconnected help sources | 20 module `USAGE` + 1 banner + 7 inline | 002 |
+| CLI dispatch runner keys | 57; registry 58 entries, 52 visible | 002 |
+| Disconnected help sources | 37 usage blocks (20 dead module exports) + 1 banner | 002 |
 | GUI-only capability classes | 13 | 003 |
 
 ## Work-phase map (dependency-ordered, PHASE-SPLIT-01)
@@ -69,7 +70,8 @@ surface — not by effort or payoff.
 |---|---|---|---|
 | wp2 | `010` | Transport honesty: exit codes, error rendering, token-collision refusal (#2697 #2698 #2696) | — |
 | wp3 | `020` | Capability registry as help SoT + API/CLI parity test + version skew (#2701) | wp2 |
-| wp4 | `030` | DTO fidelity (#2700 #2703 #2705) | wp3 |
+| wp3b | `025` | Uniform CLI contract: exit codes and `--json` order-independence | wp3 |
+| wp4 | `030` | DTO fidelity (#2700 #2703 #2705) | wp3b |
 | wp5 | `040` | New verbs and filters (#2702 #2704) | wp3 |
 | wp6 | `050` | Per-account OAuth usage attribution (#2699) | wp4 |
 | wp7 | `060` | Residual GUI-parity closure (13 capability classes) | wp3 wp5 |
@@ -113,4 +115,3 @@ dev
 `BLOCKED` is a platform or credential refusal. `UNSAFE` is any fix that would
 weaken the admin-token or session boundary — stop and ask instead.
 `NEEDS_HUMAN` is a CLI-grammar choice the operator must make.
-

--- a/devlog/_plan/260828_ocx_agentic_control/000_plan.md
+++ b/devlog/_plan/260828_ocx_agentic_control/000_plan.md
@@ -57,7 +57,8 @@ lands with no verb.
 | Session-only routes (never CLI) | 3 | 001 |
 | CLI dispatch runner keys | 57; registry 58 entries, 52 visible | 002 |
 | Disconnected help sources | 37 usage blocks (20 dead module exports) + 1 banner | 002 |
-| GUI-only capability classes | 13 | 003 |
+| GUI-only capability classes | 13 declared, 8 real gaps after exemptions | 003 |
+| Reviewer blockers folded at the A gate | 7 blockers + 4 medium + 2 low | 005 |
 
 ## Work-phase map (dependency-ordered, PHASE-SPLIT-01)
 
@@ -83,6 +84,15 @@ that lands while `ocx` still exits 0 on failure cannot be proven. wp3 comes seco
 because the registry it introduces is the thing every later phase registers into —
 adding verbs before the registry means writing them twice.
 
+wp3b exists because the uniform exit-code and `--json` contract *consumes* wp3's
+capability table (its tests read each capability's declared `json` mode), so it is a
+successor phase rather than a slice carved off to balance effort. PHASE-SPLIT-01
+forbids effort buckets, not dependency-ordered successors.
+
+wp6 follows wp4 rather than preceding it so that the `accounts` renderer already
+exists when the labels start being stamped — the phase's proof is then visible in
+`ocx usage` immediately instead of requiring a later phase to demonstrate it.
+
 ## Delivery shape
 
 A stacked pull-request chain (DEV-STACK-01), one PR per work-phase, each child
@@ -90,14 +100,15 @@ targeting its parent's head branch. Base of the stack is `origin/dev`.
 
 ```
 dev
- └── codex/ocx-agentic-control-roadmap   (this unit's docs)
-      └── codex/ocx-transport-honesty     wp2
-           └── codex/ocx-capability-registry   wp3
-                └── codex/ocx-dto-fidelity     wp4
-                     └── codex/ocx-new-verbs    wp5
-                          └── codex/ocx-account-attribution   wp6
-                               └── codex/ocx-gui-parity        wp7
-                                    └── codex/ocx-agent-skill  wp8
+ └── codex/ocx-agentic-control-roadmap        wp1  (this unit's docs, PR #2773)
+      └── codex/ocx-transport-honesty          wp2
+           └── codex/ocx-capability-registry     wp3
+                └── codex/ocx-uniform-contract     wp3b
+                     └── codex/ocx-dto-fidelity      wp4
+                          └── codex/ocx-new-verbs      wp5
+                               └── codex/ocx-account-attribution  wp6
+                                    └── codex/ocx-gui-parity        wp7
+                                         └── codex/ocx-agent-skill  wp8
 ```
 
 ## Accept criteria for the unit

--- a/devlog/_plan/260828_ocx_agentic_control/001_api_route_inventory.md
+++ b/devlog/_plan/260828_ocx_agentic_control/001_api_route_inventory.md
@@ -75,7 +75,7 @@ enumerate from a declared registry, not from source text.
 | agent settings | `/api/v2` GET+PUT, `/api/injection-model`, `/api/effort-caps`, `/api/subagent-models`, `/api/subagent-model-fallback`, `/api/codex-auth/features/default-mode-request-user-input` | `ocx agent`, `ocx v2`; the feature flag has no verb |
 | access keys | `/api/keys` GET+POST+PATCH+DELETE | `ocx access key` list/create/remove; PATCH rename has no verb |
 | oauth accounts | `/api/oauth/providers`, `/api/key-providers`, `/api/oauth/login` +cancel +code, `/status`, `/logout`, `/api/oauth/accounts` GET+DELETE, `/active`, `/pool` GET+PUT, `/clear-cooldown`, `/import`, `/alias`, `/api/providers/keys` +active +alias | `ocx account`; `/pool` (strategy/sticky) has no verb |
-| codex auth | 22 routes: accounts GET/DELETE, `/alias`, `/pause`, `/priority`, `/pause-exhausted`, `/clear-cooldown`, `/active` GET+PUT, `/auto-switch`, `/pool-strategy`, `/failover`, `/quota`, `/reset-credits` +consume, `/login` +code +cancel, `/login-status` | `ocx account`; pause, pause-exhausted, pool-strategy, failover, auto-switch, reset-credits have no verb |
+| codex auth | 22 routes: accounts GET/DELETE, `/alias`, `/pause`, `/priority`, `/pause-exhausted`, `/clear-cooldown`, `/active` GET+PUT, `/auto-switch`, `/pool-strategy`, `/failover`, `/quota`, `/reset-credits` +consume, `/login` +code +cancel, `/login-status` | `ocx account`; pause, pause-exhausted, pool-strategy, failover have no verb. `auto-switch` (account.ts:302 -> `cmdAutoSwitch`) and `reset-credits` (account.ts:313) DO have verbs — verified; an earlier draft wrongly listed them as gaps |
 | native main profiles | 10 routes under `/api/native-main-profiles` | `ocx account main` |
 | system | `/api/system/memory`, `/windows-replace-retries`, `/restart`, `/codex-app-server`, `/codex-restart`, `/api/stop` | `ocx restart`, `ocx stop`, `ocx observe memory` |
 | lab | 20 read routes + `/public/*` 4 + automation 5 | `ocx lab` reads local SQLite, never the HTTP routes |
@@ -92,4 +92,3 @@ From management-api.ts:237 — a CLI client should encode these once:
 - `503` with `reason` + `hint` from `src/server/management-auth.ts:455`
 
 The last one is #2698: the fields exist and the CLI does not print them.
-

--- a/devlog/_plan/260828_ocx_agentic_control/001_api_route_inventory.md
+++ b/devlog/_plan/260828_ocx_agentic_control/001_api_route_inventory.md
@@ -1,0 +1,95 @@
+# 001 — Management API route inventory
+
+Source: read of `src/server/management-api.ts`, `src/server/management/*`,
+`src/codex/auth-api.ts`, `src/codex/native-profile-api.ts` at `50e955604`.
+
+## How dispatch works
+
+There is no route table and no framework. Every route is a hand-written
+`if (url.pathname === … && req.method === …)` inside one of 17 handler functions,
+chained with `??` in `src/server/management-api.ts` around line 220. First handler
+returning non-`null` wins; a handler returning `null` falls through. **Dispatch is
+order-sensitive.**
+
+Auth is applied *before* dispatch, in `src/server/index.ts` near line 1010: every
+`/api/` path passes `requireManagementAuth`. No management route is unauthenticated.
+Individual routes then re-check the principal for consent.
+
+`pathInManagementNamespace` (management-api.ts:102) matches exact-or-child only, so
+`/api/labfoo` deliberately does not match `/api/lab`.
+
+## Totals
+
+- **183 reachable routes** across 19 files; **108 mutating**.
+- **1 dead route**: `GET /api/storage` at `logs-usage-routes.ts:346` is shadowed by
+  the identical claim at `storage-log-guard-routes.ts:150`, which runs earlier in the
+  chain and always returns. The live payload is the guard version (scan plus
+  `codexLogs`/`codexLogsError`). Audit parity against the guard version.
+- `/api/codex-auth/*` is gated by a `startsWith("/api/codex-auth/")` check with a
+  trailing slash, so a bare `/api/codex-auth` 404s.
+
+## Auth classes
+
+| Class | Meaning | Routes |
+|---|---|---|
+| admin | admin token or GUI session (default gate) | ~177 |
+| session | minted GUI session required; admin token gets 403 | `POST /api/github/star`, the 6 non-GET `/api/codex-prompt*` verbs |
+| cap | process-scoped HMAC capability principal | `POST /api/providers/reload`; read-cap for `/api/codex-auth/accounts` and `/api/system/memory` |
+
+The capability principals are narrow and replay-protected: local reads are limited
+to exactly those two paths with `url.search` required empty
+(`src/lib/local-management-capability.ts:10`).
+
+## Registration mechanisms a naive `rg '/api/'` misses
+
+| Mechanism | Where | What is missed |
+|---|---|---|
+| Lazy `import()` behind a namespace check | management-api.ts:115, :121 | all `/api/routing-profiles*` and `/api/lab*` — deliberate, eager mounting would pull ~70 `src/lab/` modules into every install |
+| Handlers mounted outside the `??` chain | management-api.ts:284, :289 | 10 `/api/native-main-profiles/*` and 22 `/api/codex-auth/*` routes, which live in `src/codex/` |
+| Path constants, not literals | `src/lib/codex-restart-contract.ts:17`, `system-restart-contract.ts:5`, `local-provider-reload-contract.ts:5` | `/api/system/codex-restart`, `/api/system/codex-app-server`, `/api/system/restart`, `/api/providers/reload` |
+| Prefix-decoded wildcard | integration-routes.ts:129 | `GET|PUT /api/client-integrations/{clientId}` |
+| Regex params | model-routes, lab-routes, lab-automation-routes | 7 routes |
+| Suffix matching | request-history-routes.ts:131 | `/route-decision` found via `endsWith` |
+| Namespace guards that swallow siblings | codex-prompt:278, request-history:47, lab:285 | unmatched children 404 from index.ts rather than falling through |
+
+**This table is the parity test's hard requirement.** A parity test that greps for
+`'/api/…'` string literals would miss 40+ routes and pass vacuously. The test must
+enumerate from a declared registry, not from source text.
+
+## Route families (grouped for CLI parity)
+
+| Family | Routes | Existing CLI reach |
+|---|---|---|
+| config/settings | `/api/config` (GET; PUT=405), `/api/settings` GET+PUT, `/api/diagnostics/project-config`, `/api/sync` | `ocx system`; `ocx config` is file-I/O only, never calls `/api/config` |
+| startup/tray | `/api/startup-health`, `/api/startup-action`, `/api/windows-tray` GET+POST | `ocx system` partial |
+| update | `/api/update/check`, `/run`, `/status`, `/badge` | `ocx system`, `ocx update` |
+| sidecar/shadow | `/api/sidecar-settings` GET+PUT, `/api/shadow-call-settings` GET+PUT | `ocx agent`, `ocx models` |
+| storage | `/api/storage`, `/cleanup`, `/cleanup/preview`, `/trash`, `/trash/restore`, `/cleanup-policy` GET+PUT, `/cleanup-policy/run`, `/codex-logs` +4 actions | `ocx observe storage` reaches only `/api/storage` and `/codex-logs*` |
+| logs/debug/usage | `/api/logs`, `/api/debug` GET+PUT, `/debug/logs`, `/debug/usage-logs`, `/debug/injection-logs`, `/api/claude/inbound-debug`, `/api/usage` | `ocx observe`, `ocx debug` |
+| request history | `/api/request-history`, `/{id}`, `/{id}/route-decision` | `ocx observe` partial |
+| routing | `/api/routing-profiles` GET+PUT+DELETE, `/dry-run`, `/api/routing-analytics` | `ocx route policy` |
+| providers | `/api/providers` GET+POST+PATCH+DELETE, `/test`, `/reload` (cap), `/api/provider-quotas`, `/api/provider-presets`, `/api/provider-context-caps` GET+PUT, `/api/provider-request-pacing` | `ocx provider`; pacing has no verb |
+| models | `/api/models`, `/api/catalog`, `/api/aliases`, `/api/default-aliases`, `/api/providers/{n}/alias`, `/model-aliases`, `/api/disabled-models`, `/api/model-visibility`, `/api/custom-models` +2, `/api/selected-models` GET+PUT, `/api/model-presets` GET+PUT, `/api/model-discovery` GET+PUT, `/acknowledge`, `/api/client-config` | `ocx models`, `ocx alias`, `ocx export`; `/api/client-config` has no verb |
+| combos | `/api/combos` GET+PUT+DELETE | `ocx combo` |
+| integrations | `/api/client-integrations` +journal +restore +`{clientId}` GET/PUT, `/api/native-integrations` +4 PUTs, `/api/claude-code` GET+PUT, `/api/claude-desktop` GET+PUT +apply +status, `/api/grok` +selection +apply | `ocx integration`, `ocx grok`, `ocx claude`; native-integrations has no verb |
+| agent settings | `/api/v2` GET+PUT, `/api/injection-model`, `/api/effort-caps`, `/api/subagent-models`, `/api/subagent-model-fallback`, `/api/codex-auth/features/default-mode-request-user-input` | `ocx agent`, `ocx v2`; the feature flag has no verb |
+| access keys | `/api/keys` GET+POST+PATCH+DELETE | `ocx access key` list/create/remove; PATCH rename has no verb |
+| oauth accounts | `/api/oauth/providers`, `/api/key-providers`, `/api/oauth/login` +cancel +code, `/status`, `/logout`, `/api/oauth/accounts` GET+DELETE, `/active`, `/pool` GET+PUT, `/clear-cooldown`, `/import`, `/alias`, `/api/providers/keys` +active +alias | `ocx account`; `/pool` (strategy/sticky) has no verb |
+| codex auth | 22 routes: accounts GET/DELETE, `/alias`, `/pause`, `/priority`, `/pause-exhausted`, `/clear-cooldown`, `/active` GET+PUT, `/auto-switch`, `/pool-strategy`, `/failover`, `/quota`, `/reset-credits` +consume, `/login` +code +cancel, `/login-status` | `ocx account`; pause, pause-exhausted, pool-strategy, failover, auto-switch, reset-credits have no verb |
+| native main profiles | 10 routes under `/api/native-main-profiles` | `ocx account main` |
+| system | `/api/system/memory`, `/windows-replace-retries`, `/restart`, `/codex-app-server`, `/codex-restart`, `/api/stop` | `ocx restart`, `ocx stop`, `ocx observe memory` |
+| lab | 20 read routes + `/public/*` 4 + automation 5 | `ocx lab` reads local SQLite, never the HTTP routes |
+| sidebar | `/api/github/star` GET+POST(session) | GET has no verb; POST must never get one |
+
+## Cross-cutting error envelopes
+
+From management-api.ts:237 — a CLI client should encode these once:
+
+- `413 request body too large` (2 MB cap)
+- `403 cross-origin request blocked`
+- `503 oauth_mutation_busy`, `503 catalog_busy` (both with `Retry-After: 1`)
+- `503 CONFIG_MUTATION_LOCK_UNAVAILABLE` for the codex-auth family
+- `503` with `reason` + `hint` from `src/server/management-auth.ts:455`
+
+The last one is #2698: the fields exist and the CLI does not print them.
+

--- a/devlog/_plan/260828_ocx_agentic_control/002_cli_surface_inventory.md
+++ b/devlog/_plan/260828_ocx_agentic_control/002_cli_surface_inventory.md
@@ -1,0 +1,123 @@
+# 002 — CLI surface and help inventory
+
+Source: read of `src/cli/*`, `bin/ocx.mjs`, `package.json`, `tests/cli-*.test.ts`.
+
+## Dispatch chain
+
+```
+bin/ocx.mjs  (Node shim, execs the bundled Bun binary)
+  -> src/cli/index.ts:99   runCli(argv.slice(2))
+       -> src/cli/root.ts:25   parseCliHead()          pure, no I/O
+            version/help -> exit 0
+            ready        -> pre-parsed, exit 64 before any I/O
+            command      -> maybeAutoRestoreCodexShim, return head
+  -> src/cli/index.ts:956  process.exit(await dispatchCommand(head, deps))
+       -> src/cli/dispatch.ts:584  commandRunners[resolveDispatchCommand(cmd)]
+```
+
+52 runner keys; the registry declares 49 entries, 43 visible. Aliases resolve
+through registry pairs (dispatch.ts:568): `setup->init`, `eject->restore`,
+`remove->uninstall`, `model->models`.
+
+Exit codes converge on the single `process.exit` at index.ts:956. A runner that
+returns `Number(process.exitCode ?? 0)` preserves inner failures; a runner with a
+hardcoded `return 0` discards them. That asymmetry is #2697.
+
+## Exit-code vocabulary
+
+From `src/cli/runtime-api.ts:311`: **0** ok, **2** `CliUsageError`, **4** HTTP 404,
+**5** HTTP 409, **1** everything else. Only `ready` uses **64**.
+
+A 503 and a generic failure are both **1**, so a script cannot distinguish
+"management plane fenced" from "your argument was wrong" by exit code alone.
+
+## Two management clients, two contracts
+
+**Client 1 — `src/cli/runtime-api.ts:61`.** Used by observe, combo, alias, access,
+agent, system, route-policy, export, integrations, v2.
+
+- Base URL: `deps.baseUrl` override, else `findLiveProxy()` (identity-checked,
+  finds fallback ports), then `http://{probeHostname(live.hostname)}:{live.port}`.
+- Auth: `X-OpenCodex-API-Key` from `src/lib/admin-secrets.ts:23` —
+  `OPENCODEX_ADMIN_AUTH_TOKEN` env, else `$configDir/admin-api-token`, validated
+  `/^ocx_admin_[A-Za-z0-9_-]{43}$/`, rejecting symlinks and files over 512 B.
+- Proxy down -> `RuntimeApiError(503)`; fetch throw -> 503 "unreachable". Both land
+  on exit 1.
+- Non-2xx -> throw with `status` **and the full `body` retained** (line 86).
+
+**Client 2 — `src/cli/account-api.ts:88` `apiJson`.** Used by the whole `account`
+family. Same base-URL and header resolution, but it **never throws**: it returns
+`{status, json}` and collapses every network error to sentinel `status: 0` inside a
+bare `catch {}` (line 106), discarding the underlying message. Failures funnel
+through `apiError` -> exit 1 always; no 404->4 / 409->5 mapping.
+
+## Error bodies are dropped: `reason` and `hint`
+
+`responseMessage` (runtime-api.ts:50) scans only `error`, `message`, `detail`.
+`apiError` (account-api.ts:123) reads only `json.error`. Management routes emit
+`reason` as the actionable field in roughly 39 places — integration-routes,
+native-integration-routes (`home_mismatch`, `apply_incomplete`,
+`metadata_unreadable`, `not_durable`), agent-settings-routes
+(`desired_state_changed`). A body of `{ok:false, reason:"home_mismatch"}` with no
+`error` key prints the generic `Management request failed (409)`.
+
+The body is already attached to the thrown error, so this is a rendering fix, not a
+plumbing one. One narrow exception is already special-cased: `cleanupRequired` at
+account-api.ts:126.
+
+## HELP-SOT: there is none
+
+Three disconnected tiers:
+
+1. **Registry** — `src/cli/registry.ts:10` `CLI_COMMANDS`, 49 entries with
+   `usage`/`summary`/`details`. Consumed only by `printSubcommandUsage`
+   (help.ts:94) and alias resolution.
+2. **Hand-written banner** — `src/cli/help.ts:18-88`, one 69-line template
+   literal, maintained by hand, **not generated from the registry**.
+3. **20 module-level `USAGE` constants**, each its own authority:
+
+account-auth.ts:33 · access.ts:12 · export-command.ts:53 · account.ts:18 ·
+account-extended.ts:38 · account-main.ts:15 · provider.ts:424 + :130 ·
+provider-runtime.ts:22 · models.ts:19-21 (three) · models-runtime.ts:16 ·
+agent.ts:23 · observe.ts:16 · combo.ts:13 · route-policy.ts:12 · alias.ts:3 ·
+system-command.ts:14 · config-command.ts:9 · lab.ts:76 · integrations.ts:15,24,30,227 ·
+claude-desktop.ts:25 (inline `console.log`) · debug.ts:184 (string interpolation).
+
+Plus one-off inline strings at index.ts:106, :835, :917; root.ts:74;
+dispatch.ts:344, :443, :506.
+
+`ocx ready`'s usage string is duplicated verbatim in **three** places —
+registry.ts:354, root.ts:74, ready.ts — with no test tying them together.
+
+**What is enforced today:** `tests/cli-registry.test.ts:107` greps `help.ts` source
+to assert every visible canonical command appears in the banner, and
+`tests/cli-dispatch.test.ts:12` asserts registry-to-dispatch coverage both ways.
+The banner is explicitly documented at test:104 as "curated… not required to match
+the registry exactly."
+
+**Nothing validates the 20 module `USAGE` blocks.** The exported constants
+(`OBSERVE_USAGE`, `COMBO_USAGE`, `LAB_USAGE`, `AGENT_USAGE`, `SYSTEM_USAGE`,
+`CONFIG_USAGE`, `ACCESS_USAGE`, `EXPORT_USAGE`, …) have zero consumers outside
+their own files, including in tests. They are dead exports, free to drift. That is
+the mechanism behind #2701's "help lies" symptom — a stale binary is one cause, an
+unvalidated help string is the other.
+
+## `--json` is not a uniform contract
+
+- Registry declares `--json` for `tray`, but `windowsTrayCommand` always returns 0.
+- `status` accepts `--json` only as a **lone** argument (index.ts:833), unlike the
+  order-independent `takeFlag` parsing used everywhere else.
+- `restore --json` is matched positionally at `args[1]`, so `ocx restore back --json`
+  silently ignores the flag.
+- `doctor`, `login`, `logout`, `sync`, `sync-cache`, `debug` have no `--json` at all.
+- `doctor` and `sync-cache` always exit 0, so neither can gate a script.
+
+## Commands with no HTTP reach at all
+
+- `ocx config` — direct file I/O; never calls `/api/config` (config-command.ts).
+- `ocx lab` — reads the local SQLite projection directly; never calls `/api/lab/*`.
+
+Both are capability-present/endpoint-absent. They are not parity gaps by
+capability, but they do mean a remote or containerized agent cannot reach them.
+Recorded as an explicit exemption class rather than folded into the parity count.
+

--- a/devlog/_plan/260828_ocx_agentic_control/002_cli_surface_inventory.md
+++ b/devlog/_plan/260828_ocx_agentic_control/002_cli_surface_inventory.md
@@ -15,7 +15,10 @@ bin/ocx.mjs  (Node shim, execs the bundled Bun binary)
        -> src/cli/dispatch.ts:584  commandRunners[resolveDispatchCommand(cmd)]
 ```
 
-52 runner keys; the registry declares 49 entries, 43 visible. Aliases resolve
+57 runner keys (`DISPATCH_COMMANDS.size`); the registry declares 58 entries
+(`CLI_COMMANDS.length`), 52 of them visible. Counted by importing the modules, not
+by regex — an earlier regex count of 52/49/43 was wrong in all three figures and
+would have sized wp3's banner test against the wrong set. Aliases resolve
 through registry pairs (dispatch.ts:568): `setup->init`, `eject->restore`,
 `remove->uninstall`, `model->models`.
 
@@ -69,12 +72,15 @@ account-api.ts:126.
 
 Three disconnected tiers:
 
-1. **Registry** — `src/cli/registry.ts:10` `CLI_COMMANDS`, 49 entries with
+1. **Registry** — `src/cli/registry.ts:10` `CLI_COMMANDS`, 58 entries with
    `usage`/`summary`/`details`. Consumed only by `printSubcommandUsage`
    (help.ts:94) and alias resolution.
 2. **Hand-written banner** — `src/cli/help.ts:18-88`, one 69-line template
    literal, maintained by hand, **not generated from the registry**.
-3. **20 module-level `USAGE` constants**, each its own authority:
+3. **37 module-level `USAGE`/usage-string blocks** by `rg` count, of which the
+   20 below are the named module-level constants. The 20 listed here are the
+   *dead exports*; the remaining ~17 are inline or locally-consumed usage strings
+   that also need a home in the capability table. Each is its own authority:
 
 account-auth.ts:33 · access.ts:12 · export-command.ts:53 · account.ts:18 ·
 account-extended.ts:38 · account-main.ts:15 · provider.ts:424 + :130 ·
@@ -95,7 +101,7 @@ to assert every visible canonical command appears in the banner, and
 The banner is explicitly documented at test:104 as "curated… not required to match
 the registry exactly."
 
-**Nothing validates the 20 module `USAGE` blocks.** The exported constants
+**Nothing validates the module `USAGE` blocks.** The exported constants
 (`OBSERVE_USAGE`, `COMBO_USAGE`, `LAB_USAGE`, `AGENT_USAGE`, `SYSTEM_USAGE`,
 `CONFIG_USAGE`, `ACCESS_USAGE`, `EXPORT_USAGE`, …) have zero consumers outside
 their own files, including in tests. They are dead exports, free to drift. That is
@@ -120,4 +126,3 @@ unvalidated help string is the other.
 Both are capability-present/endpoint-absent. They are not parity gaps by
 capability, but they do mean a remote or containerized agent cannot reach them.
 Recorded as an explicit exemption class rather than folded into the parity count.
-

--- a/devlog/_plan/260828_ocx_agentic_control/002_cli_surface_inventory.md
+++ b/devlog/_plan/260828_ocx_agentic_control/002_cli_surface_inventory.md
@@ -51,7 +51,7 @@ agent, system, route-policy, export, integrations, v2.
 **Client 2 — `src/cli/account-api.ts:88` `apiJson`.** Used by the whole `account`
 family. Same base-URL and header resolution, but it **never throws**: it returns
 `{status, json}` and collapses every network error to sentinel `status: 0` inside a
-bare `catch {}` (line 106), discarding the underlying message. Failures funnel
+catch block with an empty body (line 106), discarding the underlying message. Failures funnel
 through `apiError` -> exit 1 always; no 404->4 / 409->5 mapping.
 
 ## Error bodies are dropped: `reason` and `hint`

--- a/devlog/_plan/260828_ocx_agentic_control/003_gui_capability_map.md
+++ b/devlog/_plan/260828_ocx_agentic_control/003_gui_capability_map.md
@@ -1,0 +1,71 @@
+# 003 — GUI capability map and the GUI-only gap
+
+Source: read of `gui/src/**` (React + Vite) against `src/cli/**`.
+
+## The GUI has no central API client
+
+`gui/src/api.ts:265` `installApiAuthFetch()` monkey-patches `window.fetch` and
+injects `X-OpenCodex-API-Key`, `X-OpenCodex-GUI-Origin`, and (non-GET only)
+`X-OpenCodex-CSRF-Token` for same-origin `/api/*` paths. Session bootstrap reads
+meta tags `opencodex-session-token|csrf|origin` (api.ts:93); a 401 silently
+re-bootstraps `/opencodex-session`, falling back to an admin-token prompt validated
+against `GET /api/settings`.
+
+Endpoint URLs are inlined at roughly **78 call-site files**. There is no manifest to
+diff a CLI against, which is why the parity gate in wp3 must be built from a
+declared registry rather than harvested from the GUI.
+
+Page shell: 10 top-level pages in `gui/src/app-routing.ts:5` — dashboard, startup,
+providers, models, subagents, logs, usage, storage, codex-set, integrations.
+Combos, RoutingProfiles and CompatibilityMatrix are **tabs of Models**; Debug is a
+**tab of Logs**; ApiKeys is a **tab of Integrations**.
+
+## GUI-only capability classes
+
+Each verified absent from `src/cli/` by endpoint grep.
+
+| # | Capability | Endpoints with no CLI caller | Note |
+|---|---|---|---|
+| 1 | Codex prompt-layer management | 7 routes under `/api/codex-prompt*` | **Not a CLI target.** The 6 mutating verbs require a dashboard session (403 `dashboard_session_required`). Only `GET /api/codex-prompt` and `/text` are reachable — read verbs are in scope, writes are not. |
+| 2 | Storage cleanup, trash, cleanup policy | `/storage/cleanup`, `/cleanup/preview`, `/trash`, `/trash/restore`, `/cleanup-policy` GET+PUT, `/cleanup-policy/run` | `ocx observe storage` reaches only `/api/storage` and `/codex-logs*`. Destructive verbs need a confirm flag. |
+| 3 | Codex pool strategy / sticky | `/api/codex-auth/pool-strategy` | #2702 |
+| 4 | Anthropic account-pool strategy / sticky | `/api/oauth/accounts/pool` | #2702's sibling; separate route family |
+| 5 | Pause / resume a Codex account; pause all exhausted | `/api/codex-auth/accounts/pause`, `/pause-exhausted` | #2702. CLI has `clear-cooldown` and `priority` only |
+| 6 | Default-mode request-user-input feature toggle | `/api/codex-auth/features/default-mode-request-user-input` | |
+| 7 | Client config snippet generation | `/api/client-config?client=` | `ocx export --client` builds configs locally — different route, different output |
+| 8 | Native integrations enable/disable | `/api/native-integrations`, `/{client}` (4 PUTs) | |
+| 9 | Rename an access key | `PATCH /api/keys` | Noted in #2705's body as a separate gap |
+| 10 | Provider request pacing view | `/api/provider-request-pacing?name=` | |
+| 11 | GitHub star status and action | `/api/github/star` GET+POST | **POST must never get a CLI verb** — user-consent boundary per `AGENTS_INSTALL.md`, enforced at sidebar-routes.ts:75. GET status is fine. |
+| 12 | Compatibility Lab HTTP surface | 20 read routes under `/api/lab/*` | `ocx lab` reads local SQLite instead. Same data, different transport — capability-present, endpoint-absent |
+| 13 | Raw config document PUT | `PUT /api/config` | **Not a target**: deliberate 405 |
+
+## Reclassification after review
+
+Of the 13 classes, three are **not** parity work and must be recorded as
+exemptions so the parity test does not demand them:
+
+- class 1 write verbs, class 11 POST — session/consent boundary
+- class 13 — deliberate 405
+
+Two are **transport** exemptions rather than capability gaps (class 12, and `ocx
+config`'s file-I/O path): the capability exists in the CLI by another route. wp7
+decides whether to add an HTTP-backed `--remote` path for them; the default answer
+is no, with the exemption recorded and justified.
+
+That leaves **eight real capability gaps** for wp5 and wp7: classes 2, 3, 4, 5, 6,
+7, 8, 9, 10 minus the two folded into #2702 (3, 4, 5) which wp5 owns.
+
+## Notable DTO fields the GUI renders and the CLI drops
+
+| DTO | Fields | Issue |
+|---|---|---|
+| `GET /api/keys` | `usage.requests7d`, `usage.totalRequests`, `lastUsedAt`, `attributionSince`, `historyTruncated`, `authMatrix` | #2705 |
+| `GET /api/codex-auth/accounts` | `paused`, `quota.fiveHourPercent`, `health{status,reason,until}`, `usage30d{…}` | #2703 |
+| `GET /api/usage` | `accounts[]` | #2700 |
+| `GET /api/logs` | `conversationId` filter (server-side) | #2704 |
+
+`gui/src/hooks/useCodexAccountPool.ts:27` is the reference DTO shape for the
+account family — the CLI's `AccountRow` at `src/cli/account-api.ts:14` is a strict
+subset of it, and `projectQuota` at :195 narrows it further.
+

--- a/devlog/_plan/260828_ocx_agentic_control/004_issue_root_cause.md
+++ b/devlog/_plan/260828_ocx_agentic_control/004_issue_root_cause.md
@@ -90,7 +90,8 @@ Not implemented, rather than broken. Both halves exist:
   `ok v<version>` (status.ts:159). So on a healthy proxy `ocx status` never sees the
   version.
 - `LiveProxy` carries pid/port/hostname/source and no version
-  (proxy-liveness.ts:64) — even though `isOpencodexHealthz` already validated that a
+  (`src/server/proxy-liveness.ts:64`) — even though `isOpencodexHealthz` (:90)
+  already validated at :94 that a
   version string was present (line 94).
 - `doctor.ts` has no drift check; the only "older" warning is about the Codex binary.
 
@@ -183,10 +184,23 @@ Only the human branch is lossy.
 ## #2700 — usage report omits `accounts[]`
 
 `UsageReportInput` (usage-report.ts:23-41) has no `accounts` field and
-`formatUsageReport` renders only summary, providers, models (:115, :124). The server
-unconditionally includes `accounts` (`UsageSummary.accounts`, summary.ts:126; even
-the read-failure fallback ships `accounts: []` at logs-usage-routes.ts:334), and
-`observe.ts:153` passes the payload straight through.
+`formatUsageReport` renders only summary, providers, models (PROVIDER table at
+usage-report.ts:119, MODEL at :129). The server includes `accounts`
+(`UsageSummary.accounts`, summary.ts:126; the read-failure fallback ships
+`accounts: []` at logs-usage-routes.ts:334), and `observe.ts:153` passes the payload
+straight through.
+
+**Important qualification — `accounts` is NOT unconditional.**
+`projectUsageSummary` sets `accounts: []` whenever a provider or model filter is
+active (summary.ts:943, reasoned at :865-872): account rows are not
+provider-partitioned in a way the projection could honestly re-derive, and
+unfiltered account totals beside filtered model totals would invite the wrong
+reading. That is a deliberate correctness choice, not a bug.
+
+It matters for this unit because `ocx usage --provider xai --json` is exactly how an
+agent would check per-account spend for one provider, and it returns an empty
+`accounts` array with no explanation. wp4 must render that state explicitly rather
+than as an empty table.
 
 Fix: add the field and one `table([...])` block after PROVIDER, filtered to
 `requests > 0`. Render `legacy-ambiguous` rows with a marker — `ambiguous` is on the
@@ -245,4 +259,3 @@ rather than forgotten.
 | 2 | #2696 | The fail-closed collision, verified through wave-1 output. Security review required. |
 | 3 | #2703 + #2702, #2704, #2705 | Independent surface gaps. 2703/2702 share files and land together. |
 | 4 | #2699 -> #2700 | #2700's table is only meaningful for xai/cursor once #2699 stamps labels. |
-

--- a/devlog/_plan/260828_ocx_agentic_control/004_issue_root_cause.md
+++ b/devlog/_plan/260828_ocx_agentic_control/004_issue_root_cause.md
@@ -1,0 +1,248 @@
+# 004 — Per-issue root cause (#2696-#2705)
+
+Verified against `50e955604` / `package.json` 2.35.0. The issues were filed against
+2.33.0. **No issue in this set is already fixed on HEAD.** Three issue reports are
+inaccurate in ways that change the fix; those are called out.
+
+## #2697 — dispatch discards the exit code
+
+`dispatch.ts:419` (`provider`) and `:428` (`models`) both `await` the handler and
+`return 0`. The inner layers are correct: `handleModelsRuntimeCommand` returns
+`runCliAction(action)` (models-runtime.ts:337), `runCliAction` maps
+`RuntimeApiError` to 1 (runtime-api.ts:321), and `handleModels` (models.ts:434) and
+`handleProviderCommand` (provider.ts:477) both set `process.exitCode = code`. The
+dispatcher overwrites it, and index.ts:956's `process.exit(0)` makes it final.
+
+Fix: `return Number(process.exitCode ?? 0)` — the pattern already used for `service`
+at dispatch.ts:309 and eight other commands.
+
+Correction to the report: its quoted snippet is stale (HEAD uses dynamic
+`await import`). Its claim that `account` is unaffected holds — dispatch.ts:426
+returns `cmdAccount`'s code directly.
+
+Test: `tests/cli-dispatch.test.ts`, existing `dispatchCommand exit codes` block;
+the `service` case at line 80 is the template.
+
+## #2698 — 503 `reason` and `hint` never printed
+
+`responseMessage` (runtime-api.ts:50) returns on the first of `error`/`message`/
+`detail` and never reads `reason` or `hint`, which the server supplies at
+management-auth.ts:455-459. `runCliAction` prints only `error.message`.
+
+The full body is already on `RuntimeApiError.body` (runtime-api.ts:86) — nothing
+needs re-fetching. Fix is one function: append `reason` and `hint` as distinct
+lines, keep the 400-char cap on string bodies. Every `runtimeRequest` caller
+inherits it. `apiError` (account-api.ts:123) needs the same treatment.
+
+Test: `tests/cli-management-auth.test.ts` already drives `runtimeRequest` against an
+injected `fetchImpl`.
+
+## #2696 — launchd aliases the admin token as `OPENCODEX_API_AUTH_TOKEN`
+
+Three files together; no single one is wrong.
+
+- `src/service.ts:464` `buildServiceShellCommand` unconditionally exports
+  `~/.opencodex/service-api-token` as `OPENCODEX_API_AUTH_TOKEN` before `exec … start`.
+- `src/service.ts:383` `writeServiceApiTokenFile` copies whatever is in
+  `process.env.OPENCODEX_API_AUTH_TOKEN` into that file **with no check that the
+  value is not an `ocx_admin_…` management token**. Callers: 1887, 2025, 2378, 2576.
+- `src/server/management-auth.ts:200` `ready()` -> `isDataPlaneAdmissionSecret`
+  fails the **entire** management plane closed; `src/server/auth-cors.ts:349` matches
+  the presented admin token against `configuredApiAuthToken()`, which is exactly
+  `process.env.OPENCODEX_API_AUTH_TOKEN`.
+
+Behavior: when both hold the same string, boot records
+`{available:false, reason:"management credential conflicts with a data-plane credential"}`
+and every `/api/*` returns 503 — on a loopback install where `isApiAuthRequired()`
+is false and no data-plane token was ever needed. Exporting
+`OPENCODEX_ADMIN_AUTH_TOKEN` in the CLI cannot help: the server already fenced the
+plane at startup.
+
+Nothing in `src/` writes an admin token into the service token file — the collision
+comes from a user shell that had `OPENCODEX_API_AUTH_TOKEN` set to their admin
+token. That does not make it user error: `writeServiceApiTokenFile` is the chokepoint
+that should refuse.
+
+Fix: refuse at write time (`/^ocx_admin_/` or equal to `configuredAdminToken()`)
+with an actionable message; same guard in `assertServiceAuthEnvironment`
+(service.ts:369) so `install`/`repair` fail loudly. For existing installs, add a
+startup repair: when the two files are byte-identical **and the bind is loopback**,
+drop `service-api-token` rather than fencing `/api/*`.
+
+**Security-boundary note:** this touches credential handling, so it needs the
+explicit security review `MAINTAINERS.md` requires. The repair path must not widen
+admission — it removes a redundant data-plane secret on loopback only, and must not
+run for a non-loopback bind. If that cannot be established cleanly, the write-time
+refusal ships alone and the repair is deferred.
+
+Tests: `tests/service.test.ts` (already manipulates the env var at 20-28, 264-285);
+server-side fail-closed behavior in `tests/server-management-auth.test.ts`.
+
+## #2701 — PATH `ocx` can be older than the running proxy
+
+Not implemented, rather than broken. Both halves exist:
+
+- CLI version: `help.ts:8` `packageVersion()`, used only by `printVersion`.
+- Proxy version: `/healthz` returns `version: VERSION` (server/index.ts:959).
+- `collectStatus` throws it away: when `findLiveProxy()` succeeds it **skips the
+  health fetch entirely** and synthesizes `message: "ok (pid …)"` (status.ts:193-199,
+  deliberate race avoidance per the comment at 192). Only the non-live path formats
+  `ok v<version>` (status.ts:159). So on a healthy proxy `ocx status` never sees the
+  version.
+- `LiveProxy` carries pid/port/hostname/source and no version
+  (proxy-liveness.ts:64) — even though `isOpencodexHealthz` already validated that a
+  version string was present (line 94).
+- `doctor.ts` has no drift check; the only "older" warning is about the Codex binary.
+
+Fix: add `version?: string` to `LiveProxy`, populated in the probe that already
+parsed the body — no extra request, no new race. Compare in `collectStatus` against
+`packageVersion()`, emit a warning line plus `cliVersion`/`proxyVersion` on
+`CliStatusJson`. Mirror in `runDoctor`.
+
+Tests: `tests/cli-status-json.test.ts`, `tests/doctor.test.ts`.
+
+## #2702 — missing pause / strategy / sticky verbs
+
+Pure CLI gap; the routes are complete. `PUT /api/codex-auth/accounts/pause`
+(auth-api.ts:1494), `PUT …/pause-exhausted` (:1569),
+`PUT|PATCH /api/codex-auth/pool-strategy` (:1676, accepts `strategy` and
+`stickyLimit`).
+
+Correction to the report: those are **PUT**, not POST.
+
+The subcommand table at account.ts:298-309 has no `pause`, `pause-exhausted`,
+`strategy`, or `sticky`, and `ACCOUNT_USAGE` documents none. Fix follows the
+existing `cmdPriority` shape in account-extended.ts. Reuse
+`parseAccountPoolStickyLimit`'s 1-100 contract server-side; let the 400 be the
+authority rather than re-validating client-side.
+
+Test: `tests/cli-account.test.ts`, or `tests/cli-headless-parity.test.ts` which
+exists for exactly this gap class.
+
+## #2703 — `paused` and the 5h window dropped
+
+Three separate drops. The report understates the third, which is the one that
+matters:
+
+1. `paused` is absent from `AccountRow` (account-api.ts:14-27) and
+   `CodexAccountDto` (:184), so `fetchCodexRows` never reads it (:230-241) even
+   though the server always sends it (auth-api.ts:286 pool, :1315 main).
+   `statusText` (account.ts:65) can therefore only print `selected`/`needs-reauth`.
+2. `refreshLine` gates the whole quota block on weekly/monthly and prints
+   `quota: unknown` when only a 5h window exists (account-extended.ts:253). Five
+   lines below, `quotaParts` (:275) already renders `5h` correctly for the provider
+   path — the two halves of the file disagree.
+3. **Not in the issue:** `projectQuota` (account-api.ts:195) whitelists seven keys
+   and omits `fiveHourPercent`/`fiveHourResetAt`, so the field is stripped before
+   any renderer runs. `quotaText` reads `quota.fiveHourPercent ?? quota.shortPercent`
+   (account.ts:89) — the first operand is unreachable on the Codex path. **Fixing the
+   renderers alone does not fix the bug.**
+
+Also: `quota` is only populated under `--quota`, because `fetchCodexRows` spreads it
+conditionally on `forceRefresh` (:240) and `cmdList` only requests it under
+`--quota` (account.ts:166). That is the deliberate #2566 cost decision, not a bug —
+but it means "5h in `list`" means "5h in `list --quota`", and the docs must say so.
+
+## #2704 — `logs` has no `--conversationId`
+
+`observe.ts:60-70` parses only `--follow/-f`, `--provider`, `--model`, `--status`,
+`--limit`. The server accepts both spellings at request-log.ts:1032:
+`params.get("conversationId") || params.get("conversation")`.
+
+The report's second claim is correct and sharper: `filterRequestLogs` handles
+`provider`, `conversationId`, `status`, `tail`, `offset`, `limit` — and **no
+`model`**. So `ocx logs --model x` is silently accepted and silently ignored, which
+is worse than rejecting it. Implement `model` server-side (match `entry.model` plus
+`entry.attempts[].model`, mirroring the `provider` clause) rather than rejecting the
+flag: a silently-ignored filter produces wrong conclusions from correct-looking
+output.
+
+Tests: `tests/management-api-logs-metrics.test.ts` for the server filter; CLI
+query construction alongside `handleObserveCommand` coverage in
+`tests/cli-usage-report.test.ts`.
+
+## #2705 — access key usage fields dropped
+
+`access.ts:29` formats each key as exactly `id  name  prefix`. The server attaches
+`usage: rollup.get(k.id) ?? {requests7d:0, totalRequests:0}`
+(oauth-account-routes.ts:586) plus optional `attributionSince` and
+`historyTruncated` (589-590).
+
+Two things the fix must get right, both already encoded server-side:
+
+- `ApiKeyUsage` is a **discriminated union** (api-key-usage.ts:15):
+  `{ambiguous:true}` carries no numbers, and the comment at line 11 is explicit that
+  rendering a number beside an ambiguity marker is the failure mode to avoid. Print
+  `ambiguous`, never `0`.
+- `lastUsedAt` is optional; absent means "not used within the read window", which
+  `attributionSince` exists to disambiguate. Print it once as a footer.
+
+`--json` already works (`printData` dumps the raw payload, runtime-api.ts:288).
+Only the human branch is lossy.
+
+## #2700 — usage report omits `accounts[]`
+
+`UsageReportInput` (usage-report.ts:23-41) has no `accounts` field and
+`formatUsageReport` renders only summary, providers, models (:115, :124). The server
+unconditionally includes `accounts` (`UsageSummary.accounts`, summary.ts:126; even
+the read-failure fallback ships `accounts: []` at logs-usage-routes.ts:334), and
+`observe.ts:153` passes the payload straight through.
+
+Fix: add the field and one `table([...])` block after PROVIDER, filtered to
+`requests > 0`. Render `legacy-ambiguous` rows with a marker — `ambiguous` is on the
+DTO (summary.ts:97) for exactly that reason. Single file, no server change.
+
+## #2699 — per-account usage not persisted for OAuth providers
+
+The label type is Codex-only by construction:
+
+- `src/usage/log.ts:14`: `type CodexUsageAccountLogLabel = "main" | \`p${string}\``,
+  validated at :16 against `CODEX_ACCOUNT_LOG_LABEL_RE` = `/^p[a-f0-9]{6}$/`
+  (`src/codex/account-label.ts:6`).
+- Every writer drops a non-matching label: usage/log.ts:369, :456,
+  server/request-log.ts:262, :381.
+- The only producer, `codexAuthContextLogLabel` (account-label.ts:32), returns
+  `undefined` for anything that is not a Codex `pool`/`main-pool` context.
+- Attribution fallback also refuses: `legacyCodexAccountLabel` (summary.ts:681)
+  returns `null` unless `baseProviderLabel(provider) === "openai"`, so `buildAccounts`
+  drops the row at :706.
+
+The identity is already in hand and never stamped: `core.ts` resolves
+`resolved.accountId` from the OAuth snapshot and keeps it in
+`genericFailoverAccountId` (core.ts:2888) purely for 429 cooldown attribution.
+Anthropic already encodes its account into the provider label (core.ts:2876
+`formatAnthropicProviderForLog`) — so xai/cursor are the gap, not OAuth generally.
+
+Fix, privacy-preserving:
+
+1. Widen the label to a discriminated form: keep `"main" | p<hex6>` for Codex, add a
+   provider-scoped `o<hex6>` derived via `sha256(accountId)`, reusing the shape of
+   `fallbackCodexAccountLogLabel` (account-label.ts:17). Rename the type off
+   `Codex…` and widen the regex in one place.
+2. Stamp `logCtx.accountLogLabel` in `core.ts` beside the existing
+   `genericFailoverAccountId` assignment, and again after each rotation site
+   (4328, 4629, 5221) so a rotated request attributes to the account that served it.
+3. Let an explicit non-Codex label survive `accountLabelForAttribution` in
+   summary.ts. Leave `legacy-ambiguous` behavior for unlabeled openai rows alone.
+4. **Never persist emails.** The log path carries only the hash; `maskEmail` stays
+   on display paths.
+
+`supportsPerAccountQuota` (providers/quota.ts:1454, currently `=== "anthropic"`) is
+a separate concern and out of scope here.
+
+This is the only issue in the set that touches the request path
+(`src/server/responses/core.ts`) and the shared usage-log schema, so per
+`AGENTS.md` it needs full `bun run typecheck` and `bun run test` rather than a
+focused check. The operator suspended local suite runs for this loop, so that
+validation lands in wp9's CI pass — recorded here so the exception is explicit
+rather than forgotten.
+
+## Landing order
+
+| Wave | Issues | Rationale |
+|---|---|---|
+| 1 | #2697, #2698, #2701 | Diagnosability. Non-zero exits, full 503 text, version drift — small, and they make everything after them verifiable. |
+| 2 | #2696 | The fail-closed collision, verified through wave-1 output. Security review required. |
+| 3 | #2703 + #2702, #2704, #2705 | Independent surface gaps. 2703/2702 share files and land together. |
+| 4 | #2699 -> #2700 | #2700's table is only meaningful for xai/cursor once #2699 stamps labels. |
+

--- a/devlog/_plan/260828_ocx_agentic_control/005_audit_record.md
+++ b/devlog/_plan/260828_ocx_agentic_control/005_audit_record.md
@@ -1,0 +1,117 @@
+# 005 — A-gate audit record (wp1)
+
+Reviewer: independent read-only `gpt-5.6-sol` explorer, high effort, against
+`d3481ee` (14 docs, +1769). Verdict: **GO-WITH-FIXES (blockers=7)**.
+
+Every blocker below was **independently re-verified** against source before amending
+the plan — the reviewer's conclusions were not taken on trust. Where I confirmed a
+finding, the confirmation command or the source line is named.
+
+## What the reviewer verified as CORRECT
+
+Roughly 40 file:line anchors checked; the RCA layer held. Confirmed correct including
+every claim I asked to be re-checked: `projectQuota`'s 7-key whitelist stripping
+`fiveHourPercent` (account-api.ts:198) with `account.ts:89`'s unreachable first
+operand; the `dispatch.ts:419`/`:428` `return 0`; `responseMessage` scanning only
+three keys (runtime-api.ts:53) while the body is retained on the throw (:86);
+`reason`+`hint` at management-auth.ts:455-459; all four
+`writeServiceApiTokenFile` callers; the six account-label anchors;
+`filterRequestLogs` having no `model` clause while `observe.ts:70` still sends one;
+#2702's routes being PUT; `ApiKeyUsage` as a discriminated union with its warning
+comment; the 20 dead `USAGE` exports having zero external consumers; the shadowed
+`GET /api/storage`; all 7 non-literal registration mechanisms; the star-POST consent
+gate; and no `devlog/` security-triage or Lab-boundary violation.
+
+## Blockers and dispositions
+
+### C1 — 050.3 patched a function that does not exist — FOLDED
+
+The doc showed `legacyCodexAccountLabel(entry)`. Confirmed by reading
+summary.ts:680-690: `legacyCodexAccountLabel` takes `provider: string`, and the real
+gate is `accountLabelForAttribution(provider, explicit)` at :687, called from :705.
+The shown patch would not compile, and the widening decision sits in
+`isCodexUsageAccountLogLabel` at :688.
+
+Folded: 050.3 rewritten against `accountLabelForAttribution`, with the
+widening-ownership choice made explicit (add a sibling predicate rather than widen the
+Codex one, because that predicate is also the writers' validator).
+
+### C2 — the stamp site is inside an unreachable gate — FOLDED
+
+Confirmed: core.ts:2887 wraps the `genericFailoverAccountId` assignment in
+`isGenericFailoverProvider`, which requires `authMode === "oauth"` and excludes
+openai/anthropic (`src/oauth/generic-account-failover.ts:82`); the rotation paths at
+:4317, :4618, :4696, :4781 additionally require `isGenericOAuthFailoverEnabled`,
+which needs failover on and >= 2 accounts (:164).
+
+A single-account xai user would never stamp, while every listed test passed — exactly
+C-ACTIVATION-GROUNDING-01. Folded: attach at the `resolved` snapshot
+(core.ts:2878-2879) outside the gate; five re-stamp sites named, not three; and an
+explicit activation scenario recorded (xai, oauth, one account, failover off) with the
+observable effect C must check.
+
+### H1 — the recurrence-guard regex was vacuous — FOLDED
+
+The reviewer ran the proposed pattern against real `dispatch.ts`: one match at
+`handleLogin` (:195), and neither :419 nor :428, because `[^)]*` cannot span
+`deps.args.slice(1)`. The guard would have greened over the regression it existed to
+catch. Folded: `[^;]*` form, plus a mandatory red-first assertion against a pre-fix
+fixture.
+
+### H2 — the counts were wrong — FOLDED
+
+Confirmed by importing the modules: `CLI_COMMANDS.length` = 58, visible = 52,
+`DISPATCH_COMMANDS.size` = 57 — the docs said 49/43/52. Usage blocks are 37 by `rg`,
+of which 20 are the dead exports. Folded into 000 and 002, and 020.2's scope restated.
+
+### H3 — 040's sketch had four wrong signatures — FOLDED
+
+Confirmed: `apiJson(deps, baseUrl, method, path, body?, options?)` (account-api.ts:88),
+`apiError(json, fallback: string)` (:123), `printData(value, wantsJson, lines?: string[])`
+(runtime-api.ts:288), `configAndType(deps, name)` synchronous (account-extended.ts:230),
+and no `takeFlag`/`takeOption` in that module. Folded: sketch rewritten against
+`cmdPriority` (account-extended.ts:637-690) with a signature table naming each wrong
+assumption, and the `status === 0` transport check ordered first.
+
+### H4 — `accounts[]` is blanked under any filter — FOLDED
+
+Confirmed at summary.ts:943 with the reasoning at :865-872. 004's "unconditionally
+includes `accounts`" was false for filtered requests, and
+`ocx usage --provider xai --json` is the natural agent query. Folded: 004 qualified,
+and 030 now prints an explicit withheld-rows note instead of an empty table, with a
+new accept criterion and test.
+
+### H5 — two verbs already exist — FOLDED
+
+Confirmed: `auto-switch` at account.ts:302 -> `cmdAutoSwitch`, `reset-credits` at
+:313 -> `handleAccountAuthCommand`. 001's reach column and 060's seed list corrected.
+
+## Medium findings
+
+- **M1 (parity gate could pass vacuously) — FOLDED.** The two-direction check cannot
+  verify the 40+ non-literal routes, so an under-declared registry was undetectable.
+  Added a third per-module count-reconciliation check with an enumerated non-literal
+  allowlist. This mattered most: the parity gate is the unit's central claim.
+- **M2 (`ACCOUNT_USAGE` has 4 live consumers) — FOLDED.** Confirmed at account.ts:127,
+  :213, :256, :317. Documented the stderr-vs-stdout and `return 1`-vs-`process.exit`
+  difference and chose the smaller path: re-source the text, keep the call sites.
+- **M3 (inverted `responseMessage` args) — FOLDED.** Real order is `(body, status)`;
+  both snippets corrected to verbatim source.
+- **M4 (wp3 overloaded) — FOLDED.** Split 020.5 into wp3b (`025`). The split is
+  dependency-shaped, not effort-shaped: the contract tests consume wp3's capability
+  table, so wp3b is a genuine successor phase (PHASE-SPLIT-01 forbids effort buckets,
+  not successor phases).
+
+## Low findings
+
+L1 (bare `proxy-liveness.ts` path) and L2 (usage-report table lines are :119/:129, not
+:115/:124) folded. L3 was a confirmation, not a defect: 010.3's 404/409 mapping for the
+account client is a breaking change and 010 already disclosed it.
+
+## Residual
+
+None open. All 7 blockers and all 4 Mediums are folded as concrete amendments; no
+blocker was rebutted rather than fixed. The reviewer's own recommendation — fix
+C1/C2/H1-H3 before wp2 starts, correct H4/H5 so wp4/wp7 are not sized against bad
+inventory, and answer M1 before wp3 lands — is satisfied by these amendments.
+

--- a/devlog/_plan/260828_ocx_agentic_control/010_phase_transport_honesty.md
+++ b/devlog/_plan/260828_ocx_agentic_control/010_phase_transport_honesty.md
@@ -143,7 +143,7 @@ The 400-char cap stays for opaque string bodies; the structured path gets a wide
 MODIFY `src/cli/account-api.ts`.
 
 `apiJson` (line ~88) currently collapses any thrown fetch into `{status: 0}` inside
-a bare `catch {}`, discarding the message. Change the sentinel to carry it:
+a catch block with an empty body, discarding the message. Change the sentinel to carry it:
 
 ```ts
 export type ApiResult = { status: number; json: unknown; transportError?: string };

--- a/devlog/_plan/260828_ocx_agentic_control/010_phase_transport_honesty.md
+++ b/devlog/_plan/260828_ocx_agentic_control/010_phase_transport_honesty.md
@@ -1,0 +1,209 @@
+# 010 — wp2: transport honesty (#2697, #2698, #2696)
+
+Closes: #2697, #2698, #2696. Branch: `codex/ocx-transport-honesty` off
+`codex/ocx-agentic-control-roadmap`.
+
+Every later phase is verified through CLI output. A phase that lands while `ocx`
+exits 0 on failure and hides the server's `reason` cannot be proven, so this is
+first.
+
+## Scope
+
+IN: `src/cli/dispatch.ts`, `src/cli/runtime-api.ts`, `src/cli/account-api.ts`,
+`src/service.ts`, `src/server/management-auth.ts` (read-side only), tests.
+OUT: new verbs, help generation, DTO rendering, usage attribution.
+
+---
+
+## 010.1 — `dispatch.ts`: stop discarding exit codes
+
+MODIFY `src/cli/dispatch.ts` around line 419 and 428.
+
+Before:
+
+```ts
+  provider: async deps => {
+    const { handleProviderCommand } = await import("./provider.ts");
+    await handleProviderCommand(deps.args.slice(1), deps);
+    return 0;
+  },
+```
+
+After:
+
+```ts
+  provider: async deps => {
+    const { handleProviderCommand } = await import("./provider.ts");
+    await handleProviderCommand(deps.args.slice(1), deps);
+    // handleProviderCommand reports failure through process.exitCode
+    // (provider.ts sets it from handleProviderRuntimeCommand). Returning a
+    // literal 0 here made index.ts call process.exit(0) and erase it (#2697).
+    return Number(process.exitCode ?? 0);
+  },
+```
+
+Identical change for the `models` runner. Do not change `handleModels` /
+`handleProviderCommand` signatures — that is a wider refactor with no extra benefit
+while `process.exitCode` is already the contract eight other runners use.
+
+**Guard against recurrence.** A second one-line fix invites a third. Add to
+`tests/cli-dispatch.test.ts` a check that no runner body in `dispatch.ts` matches
+`/await\s+handle\w+\([^)]*\);\s*\n\s*return 0;/` — a source scan in the same
+spirit as `core-lab-boundary`. It has to allow runners that genuinely cannot fail
+(document them by an explicit allowlist of command names, so adding one is a
+deliberate act).
+
+---
+
+## 010.2 — `runtime-api.ts`: render `reason` and `hint`
+
+MODIFY `src/cli/runtime-api.ts` `responseMessage` (line ~50).
+
+Before (shape):
+
+```ts
+function responseMessage(status: number, body: unknown): string {
+  if (typeof body === "string") return body.slice(0, 400);
+  if (body && typeof body === "object") {
+    for (const key of ["error", "message", "detail"]) {
+      const v = (body as Record<string, unknown>)[key];
+      if (typeof v === "string" && v) return v;
+    }
+  }
+  return \`Management request failed (${status})\`;
+}
+```
+
+After:
+
+```ts
+const PRIMARY_MESSAGE_KEYS = ["error", "message", "detail"] as const;
+
+function stringField(body: Record<string, unknown>, key: string): string | undefined {
+  const v = body[key];
+  return typeof v === "string" && v.trim() ? v.trim() : undefined;
+}
+
+function responseMessage(status: number, body: unknown): string {
+  if (typeof body === "string") return body.slice(0, 400);
+  if (!body || typeof body !== "object") {
+    return \`Management request failed (${status})\`;
+  }
+  const obj = body as Record<string, unknown>;
+  let primary: string | undefined;
+  for (const key of PRIMARY_MESSAGE_KEYS) {
+    primary = stringField(obj, key);
+    if (primary) break;
+  }
+  // The server states WHY under 'reason' and WHAT TO DO under 'hint'
+  // (management-auth.ts:455). Both were dropped, so a fenced management plane
+  // read as a generic failure (#2698).
+  const reason = stringField(obj, "reason");
+  const hint = stringField(obj, "hint");
+  const parts: string[] = [];
+  parts.push(primary ?? \`Management request failed (${status})\`);
+  if (reason && reason !== primary) parts.push(\`reason: ${reason}\`);
+  if (hint) parts.push(\`hint: ${hint}\`);
+  return parts.join("\n").slice(0, 1200);
+}
+```
+
+The 400-char cap stays for opaque string bodies; the structured path gets a wider
+1200 cap because it now carries up to three labeled lines.
+
+## 010.3 — `account-api.ts`: same treatment, and stop erasing network errors
+
+MODIFY `src/cli/account-api.ts`.
+
+`apiJson` (line ~88) currently collapses any thrown fetch into `{status: 0}` inside
+a bare `catch {}`, discarding the message. Change the sentinel to carry it:
+
+```ts
+export type ApiResult = { status: number; json: unknown; transportError?: string };
+
+// ...
+  } catch (err) {
+    // status 0 is the transport sentinel; the message was previously discarded,
+    // which is why an unreachable proxy and a 500 were indistinguishable (#2698).
+    return { status: 0, json: null, transportError: err instanceof Error ? err.message : String(err) };
+  }
+```
+
+`apiError` (line ~123) reads only `json.error`. Extend it to the same
+primary/reason/hint composition, and to print `transportError` when `status === 0`.
+Keep the `cleanupRequired` special case.
+
+Exit-code mapping: `apiError` currently always yields 1. Map 404 to 4 and 409 to 5
+to match client 1's vocabulary (runtime-api.ts:311), so the two clients stop
+disagreeing. That is a behavior change for scripts that only checked `!== 0`;
+those keep working. Record it in the PR description.
+
+## 010.4 — `service.ts`: refuse the admin/data-plane token collision
+
+MODIFY `src/service.ts`.
+
+`writeServiceApiTokenFile` (line ~383) is the chokepoint. Add before the write:
+
+```ts
+  // A management (admin) token must never become the data-plane secret: the
+  // server fences the ENTIRE management plane closed when the two match
+  // (management-auth.ts:200 -> isDataPlaneAdmissionSecret), so every /api/*
+  // returns 503 and the CLI cannot even ask why (#2696).
+  assertNotAdminToken(token);
+```
+
+NEW helper in the same file:
+
+```ts
+const ADMIN_TOKEN_PREFIX = "ocx_admin_";
+
+export function assertNotAdminToken(token: string): void {
+  if (!token.startsWith(ADMIN_TOKEN_PREFIX)) return;
+  throw new Error(
+    "OPENCODEX_API_AUTH_TOKEN holds a management (admin) token. " +
+      "The service exports it as the data-plane secret, which fences the whole " +
+      "management API closed. Unset OPENCODEX_API_AUTH_TOKEN, or set it to a " +
+      "distinct data-plane key, then re-run the install.",
+  );
+}
+```
+
+Call it from `assertServiceAuthEnvironment` (line ~369) too, so `install` and
+`repair` fail loudly instead of producing a broken service.
+
+Deliberately NOT in this phase: the startup repair that deletes a colliding
+`service-api-token` on a loopback bind. It changes credential state on disk at boot
+and needs the `MAINTAINERS.md` security review plus a loopback-only proof. The
+write-time refusal fixes new installs and is safe on its own; existing broken
+installs get a diagnosable 503 (via 010.2) plus the actionable message. Repair is
+recorded in `081` as a follow-up decision, not silently dropped.
+
+## 010.5 — `ocx doctor`: surface the collision
+
+MODIFY `src/cli/doctor.ts`: add a check that reads the service token file and the
+admin token and reports a hard failure when they match, naming the fix. This is the
+one place an operator with an already-broken install will look.
+
+`doctor` currently always exits 0 (002). Leave that alone in this phase — changing
+it is a contract change for anything that runs `ocx doctor` in a pipeline; wp3 owns
+it as part of the exit-code contract work.
+
+## Tests
+
+| File | Assertion |
+|---|---|
+| `tests/cli-dispatch.test.ts` | `provider`/`models` runners propagate a handler-set `process.exitCode`; source scan rejects new `return 0` swallowing |
+| `tests/cli-management-auth.test.ts` | a 503 body `{error, reason, hint}` renders all three; a `{reason}`-only body does not degrade to the generic message |
+| `tests/cli-account.test.ts` | `apiJson` transport failure carries `transportError`; 404 -> 4, 409 -> 5 |
+| `tests/service.test.ts` | `writeServiceApiTokenFile` and `assertServiceAuthEnvironment` throw on an `ocx_admin_` value |
+| `tests/doctor.test.ts` | the collision check reports and names the remedy |
+
+## Accept criteria
+
+1. `ocx models live` and `ocx provider quota` against a stopped proxy exit non-zero.
+2. A 503 with `reason`+`hint` prints all three parts.
+3. `ocx service install` with an admin token in `OPENCODEX_API_AUTH_TOKEN` fails
+   with the actionable message instead of producing a fenced install.
+4. `ocx doctor` names an existing collision.
+5. No new `return 0` swallowing can be added without editing the allowlist.
+

--- a/devlog/_plan/260828_ocx_agentic_control/010_phase_transport_honesty.md
+++ b/devlog/_plan/260828_ocx_agentic_control/010_phase_transport_honesty.md
@@ -47,29 +47,56 @@ Identical change for the `models` runner. Do not change `handleModels` /
 while `process.exitCode` is already the contract eight other runners use.
 
 **Guard against recurrence.** A second one-line fix invites a third. Add to
-`tests/cli-dispatch.test.ts` a check that no runner body in `dispatch.ts` matches
-`/await\s+handle\w+\([^)]*\);\s*\n\s*return 0;/` — a source scan in the same
-spirit as `core-lab-boundary`. It has to allow runners that genuinely cannot fail
-(document them by an explicit allowlist of command names, so adding one is a
-deliberate act).
+`tests/cli-dispatch.test.ts` a source scan in the same spirit as
+`core-lab-boundary`, rejecting a runner that awaits a handler and then returns a
+literal 0.
+
+**The pattern must tolerate nested parentheses.** The obvious
+`/await\s+handle\w+\([^)]*\);\s*\n\s*return 0;/` does **not** work: `[^)]*`
+cannot span `deps.args.slice(1)` because of the inner `)`. Run against the real
+pre-fix `dispatch.ts` it matches exactly one site — `handleLogin` at :195 — and
+misses both :419 and :428, the two this phase fixes. A guard that greens against a
+pattern which never covered the regression is worse than no guard.
+
+Use a `;`-terminated form instead, and **drive it red first**:
+
+```ts
+const SWALLOW_RE = /await\s+handle\w+\([^;]*\);\s*\n\s*return 0;/g;
+```
+
+The test asserts two things, and the first is what keeps it honest:
+
+1. Against a fixture holding the pre-fix bodies of the `provider` and `models`
+   runners, `SWALLOW_RE` **matches** — proof the pattern sees the defect.
+2. Against current `dispatch.ts` source, every match's command name is in an
+   explicit allowlist of runners that genuinely cannot fail. Adding a name is then a
+   deliberate, reviewable act rather than a silent widening.
+
+The permissive `[\s\S]*?` variant matches 6 sites and is too loose; `[^;]*` is the
+narrowest form that spans an argument list without crossing a statement boundary.
 
 ---
 
 ## 010.2 — `runtime-api.ts`: render `reason` and `hint`
 
-MODIFY `src/cli/runtime-api.ts` `responseMessage` (line ~50).
+MODIFY `src/cli/runtime-api.ts` `responseMessage` (line 50).
 
-Before (shape):
+**Parameter order is `(body, status)`, not `(status, body)`** — the call site at :86
+is `responseMessage(body, response.status)`. Keep it; an earlier draft of this doc
+inverted it, which typechecks only if the call site is flipped too and otherwise
+binds `status` to the body object.
+
+Before (verbatim):
 
 ```ts
-function responseMessage(status: number, body: unknown): string {
-  if (typeof body === "string") return body.slice(0, 400);
+function responseMessage(body: unknown, status: number): string {
   if (body && typeof body === "object") {
+    const record = body as Record<string, unknown>;
     for (const key of ["error", "message", "detail"]) {
-      const v = (body as Record<string, unknown>)[key];
-      if (typeof v === "string" && v) return v;
+      if (typeof record[key] === "string" && record[key]) return record[key];
     }
   }
+  if (typeof body === "string" && body.trim()) return body.trim().slice(0, 400);
   return \`Management request failed (${status})\`;
 }
 ```
@@ -84,8 +111,8 @@ function stringField(body: Record<string, unknown>, key: string): string | undef
   return typeof v === "string" && v.trim() ? v.trim() : undefined;
 }
 
-function responseMessage(status: number, body: unknown): string {
-  if (typeof body === "string") return body.slice(0, 400);
+function responseMessage(body: unknown, status: number): string {
+  if (typeof body === "string" && body.trim()) return body.trim().slice(0, 400);
   if (!body || typeof body !== "object") {
     return \`Management request failed (${status})\`;
   }
@@ -206,4 +233,3 @@ it as part of the exit-code contract work.
    with the actionable message instead of producing a fenced install.
 4. `ocx doctor` names an existing collision.
 5. No new `return 0` swallowing can be added without editing the allowlist.
-

--- a/devlog/_plan/260828_ocx_agentic_control/020_phase_capability_registry.md
+++ b/devlog/_plan/260828_ocx_agentic_control/020_phase_capability_registry.md
@@ -1,0 +1,182 @@
+# 020 — wp3: capability registry as the single source of truth (#2701)
+
+Closes: #2701. Branch: `codex/ocx-capability-registry` off
+`codex/ocx-transport-honesty`.
+
+This is the keystone. Everything after it registers into the structure this phase
+introduces; building verbs first means writing them twice.
+
+## The problem in one line
+
+The CLI's help is 20 module `USAGE` constants with zero consumers outside their own
+files, plus a hand-written banner explicitly exempted from matching the registry,
+and **nothing anywhere relates the CLI surface to the 183 management routes.**
+
+## Design: one capability table, three consumers
+
+NEW `src/cli/capabilities.ts` — a declarative table describing, per CLI capability:
+the command path, the management route(s) it drives, its flags, whether it mutates,
+and its `--json` shape. Three consumers read it:
+
+1. `help.ts` generates the banner and every subcommand usage block from it.
+2. `tests/cli-api-parity.test.ts` asserts every route in the API registry has a
+   capability or a recorded exemption.
+3. The new `ocx capabilities` verb emits it as JSON — the machine-readable index an
+   agent reads first to discover what it can do.
+
+The third consumer is the point of the whole unit: an agent should not have to parse
+help text.
+
+### Shape
+
+```ts
+export type CapabilityRoute = {
+  readonly method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  readonly path: string;          // "/api/codex-auth/accounts/pause"
+};
+
+export type CapabilityFlag = {
+  readonly name: string;          // "--id"
+  readonly value?: "string" | "number" | "boolean";
+  readonly required?: boolean;
+  readonly summary: string;
+};
+
+export type Capability = {
+  readonly command: readonly string[];      // ["account", "pause"]
+  readonly summary: string;
+  readonly routes: readonly CapabilityRoute[];
+  readonly flags: readonly CapabilityFlag[];
+  readonly mutates: boolean;
+  readonly json: "payload" | "envelope" | "none";
+  readonly details?: readonly string[];
+};
+```
+
+### Route registry (server side)
+
+NEW `src/server/management/route-registry.ts` — a declared list of every reachable
+management route with method, path pattern, auth class, and a mutation flag.
+
+This must be **declared, not harvested.** 001 established that 40+ routes are
+invisible to a string grep: lazy `import()`, handlers outside the `??` chain, path
+constants, prefix decoding, regex params, `endsWith` matching. A parity test built on
+`rg` would pass vacuously while missing the entire `/api/codex-auth/*` family.
+
+To keep the declaration honest, add a second test that the registry does not drift
+from the handlers: for every registry entry, assert the owning handler module exports
+a marker or that the literal appears in the declared owner file, and for every
+`if (url.pathname === "…")` literal found by scan, assert it exists in the registry.
+The scan catches added literals; the declaration covers the non-literal routes the
+scan cannot see. Neither alone is sufficient; state that in the test's header comment
+so a future reader does not "simplify" it back to one mechanism.
+
+### Exemptions
+
+NEW in the registry: an `exempt` field with a required reason, one of:
+
+| Reason | Routes | Justification |
+|---|---|---|
+| `session-only` | `POST /api/github/star`, 6 `/api/codex-prompt*` writes | dashboard session required; the star POST is the user-consent boundary in `AGENTS_INSTALL.md` and must never get a verb |
+| `disabled` | `PUT /api/config` | deliberate 405 |
+| `capability-principal` | `POST /api/providers/reload` | process-scoped HMAC principal, not an operator action |
+| `test-seam` | `/api/storage/*/test-stream` (2) | test seams, not operator capability |
+| `local-transport` | 20 `/api/lab/*` reads | `ocx lab` reaches the same data via local SQLite |
+| `dead` | shadowed `GET /api/storage` in logs-usage-routes | unreachable; delete instead |
+
+An exemption without a reason string fails the test. That is what stops the gate
+from being silently widened later.
+
+## 020.1 — generate the banner
+
+MODIFY `src/cli/help.ts`. Replace the 69-line hand-written template (lines 18-88)
+with a renderer over `CAPABILITIES` grouped by section. Keep the existing top/bottom
+prose. `printSubcommandUsage` (line ~94) switches from `CLI_COMMANDS` to the
+capability table, falling back to the registry entry for commands that have no
+management route (`init`, `start`, `service`, …).
+
+MODIFY `tests/cli-registry.test.ts`: the current test greps `help.ts` source for
+command names, and its comment at line 104 licenses drift ("curated… not required to
+match the registry exactly"). Replace with an assertion that the rendered banner
+contains exactly the visible capability set — generation makes the license obsolete.
+
+## 020.2 — retire the 20 dead `USAGE` exports
+
+For each module listed in 002, delete the module-level `USAGE` constant and have the
+usage path call `printSubcommandUsage(["account"])` etc. Where a usage string
+carries genuinely local detail, move that detail into the capability's `details[]`.
+
+`ocx ready`'s triplicated string (registry.ts:354, root.ts:74, ready.ts) collapses to
+one capability entry.
+
+This is mechanical but large. It is in this phase rather than deferred because the
+generated banner and the hand-written blocks would otherwise contradict each other,
+which is the exact failure #2701's reporter hit.
+
+## 020.3 — `ocx capabilities`
+
+NEW `src/cli/capabilities-command.ts`:
+
+```
+ocx capabilities                 human tree
+ocx capabilities --json          full machine-readable table
+ocx capabilities --json --mutating-only
+ocx capabilities --route /api/keys   which commands drive this route
+```
+
+Register in `dispatch.ts` and `registry.ts`. This is the agent's entry point.
+
+## 020.4 — version skew (#2701)
+
+MODIFY `src/server/proxy-liveness.ts`: add `version?: string` to `LiveProxy` and
+populate it in the probe that already parsed and validated the healthz body
+(`isOpencodexHealthz`, line ~94). No extra request, so the race the comment at
+status.ts:192 avoids is not reintroduced.
+
+MODIFY `src/cli/status.ts` `collectStatus`: compare `live.version` against
+`packageVersion()` (export it from `help.ts`) and, when they differ, push
+
+```
+warning: CLI 2.35.0 does not match the running proxy 2.36.1 — this ocx on PATH is
+stale. Its help and features describe a different build. Reinstall or run the
+proxy's own binary.
+```
+
+Add `cliVersion` and `proxyVersion` to `CliStatusJson`. Mirror the warning in
+`runDoctor`.
+
+## 020.5 — the exit-code contract
+
+Now that help is generated, make the contract uniform and documented in one place:
+
+- `doctor` and `sync-cache` return non-zero on failure (002 flagged both as always 0).
+- `--json` becomes order-independent everywhere via `takeFlag`: fixes `status`
+  (lone-arg only) and `restore` (positional `args[1]`, so `ocx restore back --json`
+  currently ignores the flag).
+- `doctor`, `login`, `logout`, `sync`, `sync-cache`, `debug` gain `--json`.
+- The capability table declares each command's `json` mode, and a test asserts every
+  capability with `json !== "none"` actually accepts the flag anywhere in argv.
+
+`doctor` changing from always-0 is a **breaking change for pipelines**. Call it out
+in the PR description and the docs-site changelog entry; the alternative is a
+diagnostic command that cannot gate anything, which is worse.
+
+## Tests
+
+| File | Assertion |
+|---|---|
+| `tests/cli-api-parity.test.ts` (NEW) | every registry route has a capability or a reasoned exemption; every capability route exists in the registry |
+| `tests/management-route-registry.test.ts` (NEW) | registry vs handler-source drift, both directions |
+| `tests/cli-registry.test.ts` | generated banner equals the visible capability set |
+| `tests/cli-capabilities.test.ts` (NEW) | `--json` shape is stable; `--route` filter resolves |
+| `tests/cli-status-json.test.ts` | `cliVersion`/`proxyVersion` present; mismatch warns |
+| `tests/doctor.test.ts` | drift warning; non-zero exit on failure |
+
+## Accept criteria
+
+1. `ocx --help` is generated; no hand-maintained command list remains.
+2. A new route with no verb and no exemption fails `tests/cli-api-parity.test.ts`.
+3. `ocx capabilities --json` enumerates the surface with routes and flags.
+4. `ocx status` warns on version skew and reports both versions in JSON.
+5. Every capability declaring JSON accepts `--json` in any argv position.
+

--- a/devlog/_plan/260828_ocx_agentic_control/020_phase_capability_registry.md
+++ b/devlog/_plan/260828_ocx_agentic_control/020_phase_capability_registry.md
@@ -63,13 +63,31 @@ invisible to a string grep: lazy `import()`, handlers outside the `??` chain, pa
 constants, prefix decoding, regex params, `endsWith` matching. A parity test built on
 `rg` would pass vacuously while missing the entire `/api/codex-auth/*` family.
 
-To keep the declaration honest, add a second test that the registry does not drift
-from the handlers: for every registry entry, assert the owning handler module exports
-a marker or that the literal appears in the declared owner file, and for every
-`if (url.pathname === "…")` literal found by scan, assert it exists in the registry.
-The scan catches added literals; the declaration covers the non-literal routes the
-scan cannot see. Neither alone is sufficient; state that in the test's header comment
-so a future reader does not "simplify" it back to one mechanism.
+To keep the declaration honest the test needs **three** checks, not two. Two are
+obvious and insufficient:
+
+1. **Scan -> registry.** Every `if (url.pathname === "…")` literal in the management
+   files must exist in the registry. This has real reach — 188 such literals across
+   those files — and it catches an added literal route.
+2. **Registry -> source.** Every registry entry's path must appear in its declared
+   owner file.
+
+Check 2 **cannot hold for the 40+ non-literal routes** (lazy imports, path constants,
+regex params, `endsWith`, prefix decode) named in 001. For those entries neither
+direction verifies anything, so nothing detects an **under-declared** registry: a
+route registered through `codex-restart-contract.ts:17` and simply omitted from the
+registry is invisible to both, and `tests/cli-api-parity.test.ts` would then pass with
+a genuine gap. The gate would be blind exactly where 001 says it must not be.
+
+3. **Per-module route-count reconciliation.** For each handler module, assert
+   `registryRoutesFor(module).length === literalCountIn(module) + nonLiteralAllowlist[module].length`,
+   where `nonLiteralAllowlist` enumerates each non-literal route with the mechanism
+   that registers it. Adding a non-literal route without registering it then fails on
+   the count, and adding it to the allowlist without a registry entry fails too.
+
+State all three in the test's header comment, with why none is sufficient alone, so a
+future reader does not "simplify" it back to one mechanism. This is the unit's central
+claim — if this gate can pass vacuously, nothing else in the unit holds.
 
 ### Exemptions
 
@@ -103,8 +121,29 @@ contains exactly the visible capability set — generation makes the license obs
 ## 020.2 — retire the 20 dead `USAGE` exports
 
 For each module listed in 002, delete the module-level `USAGE` constant and have the
-usage path call `printSubcommandUsage(["account"])` etc. Where a usage string
-carries genuinely local detail, move that detail into the capability's `details[]`.
+usage path call `printSubcommandUsage("account")` etc. Where a usage string carries
+genuinely local detail, move that detail into the capability's `details[]`.
+
+**`ACCOUNT_USAGE` is not a dead export — it has four live consumers** at
+account.ts:127, :213, :256, :317, each `console.error(ACCOUNT_USAGE)`. Replacing them
+is a behavior change in two ways that must be handled deliberately:
+
+| | current | `printSubcommandUsage` |
+|---|---|---|
+| stream | `console.error` (stderr) | `console.log` (stdout) |
+| control flow | `return 1` | calls `process.exit(1)` on an unknown name |
+
+Moving account usage errors from stderr to stdout breaks any script that separates
+the streams, and swapping `return 1` for `process.exit` changes how the dispatcher
+sees the result. Either give `printSubcommandUsage` an explicit stream/exit mode and
+use the stderr+return variant here, or keep the four call sites returning 1 and only
+source their **text** from the capability table. The second is smaller and preferred.
+`tests/cli-account.test.ts:989` already drives `printSubcommandUsage("account")`, so
+it will catch a careless swap.
+
+Scope correction: 002 counts **37** usage blocks, of which 20 are the dead
+module-level exports. This phase deletes the 20 dead ones and re-sources the
+remainder's text; it does not delete the live ones.
 
 `ocx ready`'s triplicated string (registry.ts:354, root.ts:74, ready.ts) collapses to
 one capability entry.
@@ -145,9 +184,18 @@ proxy's own binary.
 Add `cliVersion` and `proxyVersion` to `CliStatusJson`. Mirror the warning in
 `runDoctor`.
 
-## 020.5 — the exit-code contract
+## 020.5 — moved out
 
-Now that help is generated, make the contract uniform and documented in one place:
+The uniform exit-code and `--json` contract work moved to its own work-phase,
+`025_phase_uniform_cli_contract.md` (wp3b). This phase already carries banner
+generation, ~20 constant deletions, a new command, a new server field, and three new
+test files, and it is the phase every later phase blocks on. Adding two breaking
+contract changes on top made it the largest phase in the stack by a wide margin.
+
+Split rationale is dependency-shaped, not effort-shaped: the contract work *consumes*
+the capability table this phase produces (it needs `json` declared per capability to
+test order-independence), so it is a genuine successor phase rather than a slice
+carved off to make this one smaller.
 
 - `doctor` and `sync-cache` return non-zero on failure (002 flagged both as always 0).
 - `--json` becomes order-independent everywhere via `takeFlag`: fixes `status`
@@ -179,4 +227,3 @@ diagnostic command that cannot gate anything, which is worse.
 3. `ocx capabilities --json` enumerates the surface with routes and flags.
 4. `ocx status` warns on version skew and reports both versions in JSON.
 5. Every capability declaring JSON accepts `--json` in any argv position.
-

--- a/devlog/_plan/260828_ocx_agentic_control/025_phase_uniform_cli_contract.md
+++ b/devlog/_plan/260828_ocx_agentic_control/025_phase_uniform_cli_contract.md
@@ -1,0 +1,70 @@
+# 025 — wp3b: uniform CLI contract (exit codes and `--json`)
+
+Branch: `codex/ocx-uniform-contract` off `codex/ocx-capability-registry`.
+
+Split out of wp3 (see `020` §020.5). It consumes wp3's capability table: the tests
+here read each capability's declared `json` mode, so this phase cannot precede it.
+
+## 025.1 — commands that cannot gate a script
+
+`doctor` and `sync-cache` always return 0 (002). A diagnostic that cannot fail is
+not usable in a pipeline, which is the whole point of an agentic surface.
+
+- `src/cli/doctor.ts` — return non-zero when any check fails. `010.5` added the
+  admin/data-plane collision check, which is exactly the case an operator needs to
+  gate on.
+- `sync-cache` — return non-zero on a failed cache write.
+
+**This is a breaking change for pipelines** that run `ocx doctor` and ignore the
+result. Call it out in the PR description and the docs-site changelog. The
+alternative — a diagnostic command that always claims success — is worse.
+
+## 025.2 — `--json` accepted in any argv position
+
+Two commands parse it specially and both are wrong for scripting:
+
+- `status` accepts `--json` **only as a lone argument** (`index.ts:833`:
+  `statusArgs.length === 1 && statusArgs[0] === "--json"`), so `ocx status --json --verbose`
+  silently prints human output.
+- `restore` matches it positionally at `args[1]`, so `ocx restore back --json`
+  **ignores the flag entirely**.
+
+Convert both to the order-independent `takeFlag` used everywhere else.
+
+## 025.3 — `--json` where it is missing
+
+`doctor`, `login`, `logout`, `sync`, `sync-cache`, `debug` have no `--json` at all
+(002). Each gets one, emitting the same data its human output describes.
+
+`debug` is the interesting one: it builds its usage text by string interpolation
+(`debug.ts:184`) and prints raw log rows. Its JSON mode should emit the rows as an
+array rather than a formatted blob, so an agent can filter without parsing text.
+
+## 025.4 — declare and enforce the contract
+
+Every capability in wp3's table declares a `json` mode. Add a test asserting that
+each capability with `json !== "none"` accepts `--json` in **any** argv position and
+emits parseable JSON on stdout. That is the assertion that stops the next drift:
+today's inconsistency exists because nothing ever checked.
+
+Also assert the exit-code vocabulary is uniform: 0 ok, 2 usage, 4 not found,
+5 conflict, 64 bad args (`ready` only), 1 otherwise — including for the `account`
+family after `010.3` gave it the 404/409 mapping.
+
+## Tests
+
+| File | Assertion |
+|---|---|
+| `tests/cli-json-contract.test.ts` (NEW) | every `json`-declaring capability accepts `--json` in any position and emits valid JSON |
+| `tests/cli-status-json.test.ts` | `ocx status --json` works alongside other flags |
+| `tests/doctor.test.ts` | non-zero exit on a failing check |
+| `tests/cli-dispatch.test.ts` | `restore back --json` honors the flag |
+
+## Accept criteria
+
+1. `doctor` and `sync-cache` exit non-zero on failure, and the change is documented
+   as breaking.
+2. `--json` works in any argv position for every capability that declares it.
+3. Six previously JSON-less commands emit JSON.
+4. A test enforces the contract rather than a convention.
+

--- a/devlog/_plan/260828_ocx_agentic_control/030_phase_dto_fidelity.md
+++ b/devlog/_plan/260828_ocx_agentic_control/030_phase_dto_fidelity.md
@@ -131,10 +131,37 @@ In `formatUsageReport`, after the PROVIDER table (line ~115) and before MODEL, a
   }
 ```
 
-Uses the existing `table`/`count`/`usd` helpers. Server already ships `accounts`
-unconditionally (summary.ts:126; the read-failure fallback ships `accounts: []` at
-logs-usage-routes.ts:334) and `observe.ts:153` passes the payload straight through,
-so this is one file.
+Uses the existing `table`/`count`/`usd` helpers. `observe.ts:153` passes the payload
+straight through, so this is one file.
+
+### The filtered case must not silently print nothing
+
+`accounts` is **not** unconditional. `projectUsageSummary` sets `accounts: []`
+whenever a provider or model filter is active (summary.ts:943, reasoned at
+:865-872) — deliberately, because account rows are not provider-partitioned in a way
+the projection could honestly re-derive, and unfiltered account totals beside
+filtered model totals would invite the wrong reading.
+
+So `ocx usage --provider xai --json` returns an empty `accounts` array. That is the
+most natural way an agent would ask "what did this provider cost me per account",
+and an empty table with no explanation is the same silently-wrong-output defect this
+unit exists to remove (compare #2704's silently-ignored `--model`).
+
+Distinguish the two empty cases explicitly:
+
+```ts
+  const filtered = Boolean(input.filter?.provider || input.filter?.model);
+  if (filtered) {
+    // Not "no accounts" — the server withholds account rows under a filter because
+    // they cannot be honestly re-partitioned (summary.ts:865-872).
+    out.push("ACCOUNT: not reported under a provider or model filter; run without filters for per-account totals");
+  } else if (accounts.length) {
+    out.push(table([...]));
+  }
+```
+
+Record the same sentence in the capability's `details[]` so
+`ocx capabilities --json` carries it, and in wp8's recipe for per-account spend.
 
 Rows for xai/cursor will be empty until wp6 (#2699) stamps their labels. That is
 expected and is why wp6 follows this phase rather than preceding it — the renderer
@@ -152,7 +179,7 @@ Add `account list --quota`'s new columns, `access key list`'s columns, and
 |---|---|
 | `tests/cli-account.test.ts` | `projectQuota` keeps `fiveHourPercent`/`fiveHourResetAt`; `statusText` prints `paused` and `paused (selected)`; `formatAccountTable` shows a 5h-only quota instead of `unknown` |
 | `tests/cli-headless-parity.test.ts` | `refreshLine` renders 5h and paused; `handleAccessCommand` prints usage columns, `ambiguous` for the union's ambiguous variant, and the footer |
-| `tests/cli-usage-report.test.ts` | `accounts` table renders, filters `requests === 0`, marks ambiguous rows, and is absent when the array is empty |
+| `tests/cli-usage-report.test.ts` | `accounts` table renders, filters `requests === 0`, marks ambiguous rows; an active filter prints the withheld-rows note instead of an empty table |
 
 ## Accept criteria
 
@@ -160,5 +187,6 @@ Add `account list --quota`'s new columns, `access key list`'s columns, and
 2. `ocx access key list` shows `requests7d`, total, `lastUsedAt`, and prints
    `ambiguous` rather than a fabricated `0`.
 3. `ocx usage` renders an ACCOUNT table with ambiguous rows marked.
-4. No server-side change in this phase's diff.
-
+4. `ocx usage --provider X` states that account rows are withheld under a filter
+   rather than printing an empty table.
+5. No server-side change in this phase's diff.

--- a/devlog/_plan/260828_ocx_agentic_control/030_phase_dto_fidelity.md
+++ b/devlog/_plan/260828_ocx_agentic_control/030_phase_dto_fidelity.md
@@ -1,0 +1,164 @@
+# 030 — wp4: DTO fidelity (#2700, #2703, #2705)
+
+Closes: #2700, #2703, #2705. Branch: `codex/ocx-dto-fidelity` off
+`codex/ocx-capability-registry`.
+
+Three cases of the CLI throwing away fields the API already returns. All three are
+CLI-side; no server change.
+
+## 030.1 — `#2703`: account `paused` and the 5h window
+
+Three drops, and the order matters: **fix the projection first**, or the renderer
+fixes have nothing to render.
+
+### (a) `projectQuota` strips the field — `src/cli/account-api.ts:195`
+
+The whitelist omits `fiveHourPercent` and `fiveHourResetAt`, so `quotaText`'s
+`quota.fiveHourPercent ?? quota.shortPercent` (account.ts:89) has an unreachable
+first operand.
+
+```ts
+ function projectQuota(raw: unknown): AccountQuota | undefined {
+   // ...
+   return {
++    fiveHourPercent: num(obj.fiveHourPercent),
++    fiveHourResetAt: str(obj.fiveHourResetAt),
+     weeklyPercent: num(obj.weeklyPercent),
+     // ... existing seven keys
+   };
+ }
+```
+
+### (b) `paused` is not in the row types — `account-api.ts:14-27`, `:184`
+
+```ts
+ export type AccountRow = {
+   // ...
++  paused?: boolean;
+ };
+
+ type CodexAccountDto = {
+   // ...
++  paused?: boolean;
+ };
+```
+
+Map it in `fetchCodexRows` (:230-241). The server always sends it — auth-api.ts:286
+for pool accounts, :1315 for main.
+
+### (c) renderers
+
+`statusText` (account.ts:65) gains a `paused` branch. Precedence: `paused` outranks
+`selected`, because a paused-but-selected account is the confusing state an operator
+most needs named. Print `paused (selected)` rather than picking one.
+
+`refreshLine` (account-extended.ts:253) gates the quota block on weekly/monthly and
+prints `quota: unknown` for a 5h-only account. Five lines below, `quotaParts` (:275)
+already does this correctly for the provider path. Rewrite `refreshLine`'s branch to
+call the same helper rather than maintaining a second dialect — the two halves of one
+file disagreeing is the actual defect.
+
+### Documentation obligation
+
+`quota` is only populated under `--quota` (`fetchCodexRows` spreads conditionally on
+`forceRefresh`, :240; `cmdList` requests it only under `--quota`, account.ts:166).
+That is the deliberate #2566 cost decision. So "5h in `list`" means "5h in
+`list --quota`" — say so in the capability `details[]` and in the docs-site page, or
+the next reporter files the same issue.
+
+## 030.2 — `#2705`: access key usage fields
+
+MODIFY `src/cli/access.ts:29`, which formats each key as exactly `id  name  prefix`.
+
+Target output:
+
+```
+ID        NAME       PREFIX      REQ 7D   TOTAL   LAST USED
+k_9f2a    ci-runner  ocx_live_…  1,204    18,330  2026-08-27T04:11Z
+k_11bd    laptop     ocx_live_…  ambiguous        2026-08-20T22:04Z
+
+attribution since 2026-07-29T00:00Z; older history truncated
+```
+
+Two contract requirements, both already encoded server-side:
+
+- `ApiKeyUsage` is a **discriminated union** (`api-key-usage.ts:15`). The
+  `{ambiguous:true}` variant carries no numbers, and the comment at line 11 states
+  that printing a number beside an ambiguity marker is the failure mode to avoid.
+  Render the word `ambiguous` spanning the numeric columns. Never `0`.
+- `lastUsedAt` absent means "not used within the read window", which
+  `attributionSince` disambiguates. Print `attributionSince` and `historyTruncated`
+  once as a footer, not per row.
+
+`--json` already emits the raw payload (`printData`, runtime-api.ts:288); only the
+human branch changes.
+
+## 030.3 — `#2700`: usage report `accounts[]`
+
+MODIFY `src/cli/usage-report.ts`.
+
+```ts
+ export type UsageReportInput = {
+   // ...
++  accounts?: readonly {
++    accountLogLabel: string;
++    ambiguous?: boolean;
++    requests: number;
++    totalTokens: number;
++    estimatedCostUsd?: number;
++  }[];
+ };
+```
+
+In `formatUsageReport`, after the PROVIDER table (line ~115) and before MODEL, add:
+
+```ts
+  const accounts = (input.accounts ?? []).filter(a => a.requests > 0);
+  if (accounts.length) {
+    out.push(
+      table(
+        ["ACCOUNT", "REQUESTS", "TOKENS", "EST. COST"],
+        accounts.map(a => [
+          // 'legacy-ambiguous' rows aggregate several accounts; an operator who
+          // reads them as one account draws the wrong conclusion (summary.ts:97).
+          a.ambiguous ? \`${a.accountLogLabel} (ambiguous)\` : a.accountLogLabel,
+          count(a.requests),
+          count(a.totalTokens),
+          a.estimatedCostUsd === undefined ? "-" : usd(a.estimatedCostUsd),
+        ]),
+      ),
+    );
+  }
+```
+
+Uses the existing `table`/`count`/`usd` helpers. Server already ships `accounts`
+unconditionally (summary.ts:126; the read-failure fallback ships `accounts: []` at
+logs-usage-routes.ts:334) and `observe.ts:153` passes the payload straight through,
+so this is one file.
+
+Rows for xai/cursor will be empty until wp6 (#2699) stamps their labels. That is
+expected and is why wp6 follows this phase rather than preceding it — the renderer
+lands first so wp6's proof is visible immediately.
+
+## 030.4 — register the capabilities
+
+Add `account list --quota`'s new columns, `access key list`'s columns, and
+`usage`'s accounts table to the wp3 capability entries' `details[]`, so
+`ocx capabilities --json` reflects what the commands now emit.
+
+## Tests
+
+| File | Assertion |
+|---|---|
+| `tests/cli-account.test.ts` | `projectQuota` keeps `fiveHourPercent`/`fiveHourResetAt`; `statusText` prints `paused` and `paused (selected)`; `formatAccountTable` shows a 5h-only quota instead of `unknown` |
+| `tests/cli-headless-parity.test.ts` | `refreshLine` renders 5h and paused; `handleAccessCommand` prints usage columns, `ambiguous` for the union's ambiguous variant, and the footer |
+| `tests/cli-usage-report.test.ts` | `accounts` table renders, filters `requests === 0`, marks ambiguous rows, and is absent when the array is empty |
+
+## Accept criteria
+
+1. `ocx account list --quota` shows paused state and a 5h-only quota.
+2. `ocx access key list` shows `requests7d`, total, `lastUsedAt`, and prints
+   `ambiguous` rather than a fabricated `0`.
+3. `ocx usage` renders an ACCOUNT table with ambiguous rows marked.
+4. No server-side change in this phase's diff.
+

--- a/devlog/_plan/260828_ocx_agentic_control/040_phase_new_verbs.md
+++ b/devlog/_plan/260828_ocx_agentic_control/040_phase_new_verbs.md
@@ -17,23 +17,52 @@ the issue says POST, the code says **PUT**:
 
 MODIFY `src/cli/account-extended.ts`: add `cmdPause`, `cmdResume`,
 `cmdPauseExhausted`, `cmdStrategy`, `cmdSticky` following the existing `cmdPriority`
-shape — `configAndType` -> `resolveBaseUrl` -> `apiJson` -> print or `--json`.
+shape (account-extended.ts:637-690).
+
+**Use the real signatures.** They are easy to get wrong, and an earlier draft of this
+doc got four of them wrong at once:
+
+| Helper | Real signature | Wrong assumption to avoid |
+|---|---|---|
+| `apiJson` | `(deps, baseUrl, method, path, body?, options?)` — account-api.ts:88 | not `(baseUrl, path, {method, body})`; method is the **third positional** arg |
+| `apiError` | `(json: Record<string, unknown>, fallback: string)` — account-api.ts:123 | takes the json record and a fallback **string**, not the result object and a boolean |
+| `configAndType` | `(deps, name)`, **synchronous**, returns a classify result — account-extended.ts:230 | not `await configAndType(deps)` returning `{baseUrl}`; base URL comes from `resolveBaseUrl(deps)` separately |
+| `flag` / `flagValue` | `(args, name)` — account-extended.ts:52, :59 | this module has no `takeFlag`/`takeOption`, and does not import `printData` |
+| `usage` | `(message?) => number` — account-extended.ts:224 | usage errors return a code; they do not throw `CliUsageError` here |
+
+Also note `status === 0` is the transport sentinel and must be checked **before** the
+status comparison, or an unreachable proxy reports as a management error.
 
 ```ts
 export async function cmdPause(args: string[], deps: AccountDeps, paused: boolean): Promise<number> {
-  const id = takeOption(args, "--id");
-  if (!id) throw new CliUsageError("account pause requires --id <accountId>");
-  const wantsJson = takeFlag(args, "--json");
-  const { baseUrl } = await configAndType(deps);
-  const res = await apiJson(baseUrl, "/api/codex-auth/accounts/pause", {
-    method: "PUT",
-    body: { id, paused },
-  });
-  if (res.status !== 200) return apiError(res, wantsJson);
-  return printData({ ok: true, id, paused }, wantsJson, () =>
-    \`${paused ? "paused" : "resumed"} ${id}\`);
+  const wantsJson = flag(args, "--json");
+  const name = args.shift();
+  const requestedId = args.shift();
+  if (!name || !requestedId || args.length) return usage();
+  const classified = configAndType(deps, name);
+  if ("error" in classified) return usage(`Error: ${classified.error}`);
+  if (classified.type !== "codex") {
+    return usage("Error: pause applies to the openai Codex account pool");
+  }
+  const id = requestedId === "main" ? MAIN_ID : requestedId;
+
+  const baseUrl = await resolveBaseUrl(deps);
+  if (!baseUrl) return proxyUnreachable();
+
+  const response = await apiJson(deps, baseUrl, "PUT", "/api/codex-auth/accounts/pause", { id, paused });
+  if (response.status === 0) return proxyUnreachable();
+  if (response.status !== 200) {
+    return apiError(response.json, `failed to ${paused ? "pause" : "resume"} ${requestedId}`);
+  }
+  if (wantsJson) console.log(JSON.stringify({ ok: true, provider: name, id, paused }, null, 2));
+  else console.log(`${name}: ${requestedId} ${paused ? "paused" : "resumed"}`);
+  return 0;
 }
 ```
+
+The other four verbs follow the same skeleton. `cmdStrategy` and `cmdSticky` share
+`PUT /api/codex-auth/pool-strategy`, so implement one helper taking the field to set
+rather than two near-duplicates.
 
 Do **not** re-validate `stickyLimit` client-side. The server owns the 1-100 contract
 (`parseAccountPoolStickyLimit`); a duplicated bound is a second thing to keep in
@@ -104,4 +133,3 @@ unit exists to remove.
 2. `ocx logs --conversation` filters server-side and the output shows the id.
 3. `ocx logs --model` actually filters, including failover attempts.
 4. All new verbs appear in `ocx capabilities --json`.
-

--- a/devlog/_plan/260828_ocx_agentic_control/040_phase_new_verbs.md
+++ b/devlog/_plan/260828_ocx_agentic_control/040_phase_new_verbs.md
@@ -1,0 +1,107 @@
+# 040 — wp5: new verbs and filters (#2702, #2704)
+
+Closes: #2702, #2704. Branch: `codex/ocx-new-verbs` off `codex/ocx-dto-fidelity`.
+
+## 040.1 — `#2702`: account pause / resume / strategy / sticky
+
+Server routes are complete; this is purely a missing CLI caller. Note the methods —
+the issue says POST, the code says **PUT**:
+
+| Verb | Route | Body |
+|---|---|---|
+| `ocx account pause --id <id>` | `PUT /api/codex-auth/accounts/pause` | `{id, paused: true}` |
+| `ocx account resume --id <id>` | same route | `{id, paused: false}` |
+| `ocx account pause-exhausted [--off]` | `PUT /api/codex-auth/accounts/pause-exhausted` | flag |
+| `ocx account strategy [<name>]` | `GET` via accounts payload / `PUT|PATCH /api/codex-auth/pool-strategy` | `{strategy}` |
+| `ocx account sticky [<n>]` | same route | `{stickyLimit}` |
+
+MODIFY `src/cli/account-extended.ts`: add `cmdPause`, `cmdResume`,
+`cmdPauseExhausted`, `cmdStrategy`, `cmdSticky` following the existing `cmdPriority`
+shape — `configAndType` -> `resolveBaseUrl` -> `apiJson` -> print or `--json`.
+
+```ts
+export async function cmdPause(args: string[], deps: AccountDeps, paused: boolean): Promise<number> {
+  const id = takeOption(args, "--id");
+  if (!id) throw new CliUsageError("account pause requires --id <accountId>");
+  const wantsJson = takeFlag(args, "--json");
+  const { baseUrl } = await configAndType(deps);
+  const res = await apiJson(baseUrl, "/api/codex-auth/accounts/pause", {
+    method: "PUT",
+    body: { id, paused },
+  });
+  if (res.status !== 200) return apiError(res, wantsJson);
+  return printData({ ok: true, id, paused }, wantsJson, () =>
+    \`${paused ? "paused" : "resumed"} ${id}\`);
+}
+```
+
+Do **not** re-validate `stickyLimit` client-side. The server owns the 1-100 contract
+(`parseAccountPoolStickyLimit`); a duplicated bound is a second thing to keep in
+sync, and the 400 is already actionable now that wp2 prints `reason`.
+
+Register in the `cmdAccount` chain (account.ts:298-309) and add the capability
+entries. `ACCOUNT_USAGE` no longer exists after wp3, so the help text comes from the
+capability table automatically — which is the payoff for ordering wp3 first.
+
+**Sibling gap:** `/api/oauth/accounts/pool` is the same capability for the Anthropic
+pool (GUI class 4 in 003) and has no verb either. Add `ocx account provider-strategy`
+/ `provider-sticky` (or `--provider` on the same verbs — decide at implementation
+time and record the choice) so the two pools are symmetric. A CLI that can steer one
+pool and not the other is a trap.
+
+## 040.2 — `#2704`: `logs --conversation`, and the silently-ignored `--model`
+
+### (a) CLI filter
+
+MODIFY `src/cli/observe.ts:60-70`:
+
+```ts
++  const conversation = takeOption(args, "--conversation") ?? takeOption(args, "--conversationId");
+   const provider = takeOption(args, "--provider");
+   const model = takeOption(args, "--model");
+   // ...
+-  const qs = query({ provider, model, status, limit });
++  const qs = query({ provider, model, status, limit, conversationId: conversation });
+```
+
+The server accepts both spellings (`request-log.ts:1032`:
+`params.get("conversationId") || params.get("conversation")`), so accept both on the
+CLI too rather than forcing operators to remember which.
+
+Also surface `conversationId` in `formatLog` (observe.ts:48), which prints only
+time/status/route/duration today. A conversation filter whose output does not show
+the conversation is hard to trust.
+
+### (b) the server-side `--model` hole
+
+`filterRequestLogs` handles `provider`, `conversationId`, `status`, `tail`,
+`offset`, `limit` — and **no `model`**. So `ocx logs --model x` is accepted and
+silently ignored today. That is worse than an error: it yields wrong conclusions from
+correct-looking output.
+
+MODIFY `src/server/request-log.ts` `filterRequestLogs`: add a `model` clause
+mirroring the `provider` clause one line above, matching `entry.model` **and**
+`entry.attempts[].model` — a request that failed over should match the model that
+actually served it, consistent with how `provider` already behaves.
+
+This is the one server-side change in wp5. It is in scope because leaving it means
+shipping a CLI whose documented filter lies, which is the class of defect this whole
+unit exists to remove.
+
+## Tests
+
+| File | Assertion |
+|---|---|
+| `tests/cli-account.test.ts` | pause/resume send `PUT` with `{id, paused}`; `strategy`/`sticky` hit `/api/codex-auth/pool-strategy`; a server 400 surfaces its `reason` (wp2 integration) |
+| `tests/cli-headless-parity.test.ts` | the new verbs appear in the capability table and in generated help |
+| `tests/cli-usage-report.test.ts` | `ocx logs --conversation X` and `--conversationId X` both build `conversationId=X` |
+| `tests/management-api-logs-metrics.test.ts` | `model` filter matches `entry.model` and `attempts[].model`; a non-matching model returns no rows |
+
+## Accept criteria
+
+1. Pause, resume, pause-exhausted, strategy, sticky all work from the CLI for the
+   Codex pool, and the provider pool has symmetric verbs.
+2. `ocx logs --conversation` filters server-side and the output shows the id.
+3. `ocx logs --model` actually filters, including failover attempts.
+4. All new verbs appear in `ocx capabilities --json`.
+

--- a/devlog/_plan/260828_ocx_agentic_control/050_phase_account_attribution.md
+++ b/devlog/_plan/260828_ocx_agentic_control/050_phase_account_attribution.md
@@ -59,22 +59,59 @@ Record it rather than widening the label and breaking the existing `p` format.
 
 MODIFY `src/server/responses/core.ts`.
 
-At the existing `genericFailoverAccountId` assignment (~2888), also set
-`logCtx.accountLogLabel = oauthAccountLogLabel(resolved.accountId)` when the
-provider is a non-Codex OAuth provider and the id is present.
+**Do not attach at the `genericFailoverAccountId` assignment.** That line
+(core.ts:2888) sits inside `if (isGenericFailoverProvider(route.providerName, route.provider))`
+at :2887, and that predicate (`src/oauth/generic-account-failover.ts:82`) requires
+`provider.authMode === "oauth"` and excludes `{openai, anthropic}`. The rotation
+paths are gated more tightly still: `isGenericOAuthFailoverEnabled` (:128) also
+requires failover enabled and, at :164, **at least two stored accounts**.
 
-Critically, repeat it after **each rotation site** (~4328, ~4629, ~5221). A request
-that rotated accounts must attribute to the account that actually served it, or the
-numbers are wrong in exactly the situation the operator cares about. Reuse a single
-small helper so the four call sites cannot drift:
+Attaching there would mean the ordinary case — one xai or cursor account, failover
+off — never stamps a label, while every test listed below still passes. That is the
+C-ACTIVATION-GROUNDING-01 trap, and it would make accept criterion 1 unreachable.
+
+Attach instead at the `resolved` snapshot itself (core.ts:2878-2879), which carries
+`resolved.accountId` unconditionally for every OAuth provider on this path,
+**outside** the failover gate:
 
 ```ts
-function stampOAuthAccountLabel(logCtx: RequestLogContext, provider: string, accountId: string | undefined): void {
+         const resolved = await getValidAccessTokenSnapshot(route.providerName);
+         replayOAuthCredentialSnapshot = { accountId: resolved.accountId, generation: resolved.generation };
++        // Attribution is independent of failover: a single-account xai/cursor user
++        // must still get per-account usage. Stamping inside the
++        // isGenericFailoverProvider gate below would silently skip them.
++        stampOAuthAccountLabel(logCtx, route.providerName, route.provider, resolved.accountId);
+```
+
+Then repeat it after **each rotation site** (core.ts:4317, :4618, and the
+`genericFailoverAccountId` re-resolutions at :4696 and :4781 — five sites, not the
+three an earlier draft named). A request that rotated accounts must attribute to the
+account that actually served it. Reuse one helper so the sites cannot drift:
+
+```ts
+// Lives in src/codex/account-label.ts (Lab-clean: it imports only node:crypto).
+export function stampOAuthAccountLabel(
+  logCtx: { accountLogLabel?: string },
+  providerName: string,
+  provider: OcxProviderConfig,
+  accountId: string | undefined,
+): void {
   if (!accountId) return;
-  if (!isNonCodexOAuthProvider(provider)) return;   // codex keeps its p-label producer
+  // openai keeps its own p-label producer; anthropic already folds the account
+  // into the provider label (core.ts:2876 formatAnthropicProviderForLog).
+  if (provider.authMode !== "oauth") return;
+  const base = baseProviderLabel(providerName);
+  if (base === "openai" || base === "anthropic") return;
   logCtx.accountLogLabel = oauthAccountLogLabel(accountId);
 }
 ```
+
+**Activation scenario (for C).** Provider `xai`, `authMode: "oauth"`, exactly one
+stored account, generic failover **disabled**. Observable effect: the persisted usage
+entry carries `accountLogLabel: "o<hex6>"` and `ocx usage --json` reports one
+non-`legacy-ambiguous` account row. If that case does not stamp, the phase has
+re-created the bug it set out to fix. A second scenario with two accounts and
+failover enabled proves the rotation re-stamp.
 
 Boundary: this must not reach into `src/lab/`. `core.ts` is one of the three files
 `tests/core-lab-boundary.test.ts` guards, so the helper lives in
@@ -82,20 +119,48 @@ Boundary: this must not reach into `src/lab/`. `core.ts` is one of the three fil
 
 ## 050.3 — let the label survive attribution
 
-MODIFY `src/usage/summary.ts` around `legacyCodexAccountLabel` (:681) and
-`buildAccounts` (:706): an **explicit** label on the row survives regardless of
-provider. Only the *fallback* path stays openai-gated.
+The gate is `accountLabelForAttribution` at `src/usage/summary.ts:687`, called from
+`buildAccounts` at :705 as `accountLabelForAttribution(input.provider, input.accountLogLabel)`.
+An earlier draft of this doc named `legacyCodexAccountLabel(entry)`, which does not
+exist — that function takes `provider: string` and is only the fallback.
+
+Current:
 
 ```ts
--  const label = legacyCodexAccountLabel(entry);
-+  // An explicitly stamped label is authoritative for any provider (#2699).
-+  // The legacy fallback stays openai-only: guessing 'main' for a non-Codex row
-+  // would silently merge unrelated accounts.
-+  const label = entry.accountLogLabel ?? legacyCodexAccountLabel(entry);
+function accountLabelForAttribution(provider: string, explicit: unknown): string | null {
+  if (isCodexUsageAccountLogLabel(explicit)) return explicit;
+  return legacyCodexAccountLabel(provider);
+}
 ```
 
-Leave `legacy-ambiguous` behavior for unlabeled openai rows untouched. wp4 already
-renders the `ambiguous` marker, so those rows stay honest.
+**Decide which layer owns the widening, because doing both is a no-op on top of a
+no-op.** Two options, and this doc chooses the second:
+
+1. Widen `isCodexUsageAccountLogLabel` to accept `o<hex6>`. Then :688 already passes
+   the new labels and this function needs no edit at all. But the predicate's name
+   then lies, and it is also the validator four writers use to *reject* bad labels —
+   widening it there weakens validation for a rename's convenience.
+2. **Chosen:** keep `isCodexUsageAccountLogLabel` as the Codex-specific predicate,
+   add a sibling `isOAuthUsageAccountLogLabel`, and widen only the attribution gate:
+
+```ts
+ function accountLabelForAttribution(provider: string, explicit: unknown): string | null {
+   if (isCodexUsageAccountLogLabel(explicit)) return explicit;
++  // An explicitly stamped non-Codex label is authoritative for any provider (#2699).
++  // The legacy fallback below stays openai-only: guessing for a non-Codex row would
++  // silently merge unrelated accounts into 'legacy-ambiguous'.
++  if (isOAuthUsageAccountLogLabel(explicit)) return explicit;
+   return legacyCodexAccountLabel(provider);
+ }
+```
+
+The writers in `src/usage/log.ts` and `src/server/request-log.ts` accept either
+family via `ACCOUNT_LOG_LABEL_RE` from 050.1, so persistence and attribution are
+widened in exactly one place each.
+
+Leave `legacy-ambiguous` behavior for unlabeled openai rows untouched (`buildAccounts`
+sets `ambiguous: label === LEGACY_AMBIGUOUS_ACCOUNT_LABEL` at :708). wp4 renders the
+marker, so those rows stay honest.
 
 ## 050.4 — out of scope, explicitly
 
@@ -132,4 +197,3 @@ the stack. If wp9's CI cannot run, this phase does not ship.
 3. `ocx usage` (wp4's table) shows those accounts.
 4. No email or raw account id is written to any log.
 5. The Lab core-boundary test still passes.
-

--- a/devlog/_plan/260828_ocx_agentic_control/050_phase_account_attribution.md
+++ b/devlog/_plan/260828_ocx_agentic_control/050_phase_account_attribution.md
@@ -1,0 +1,135 @@
+# 050 — wp6: per-account usage attribution for OAuth providers (#2699)
+
+Closes: #2699. Branch: `codex/ocx-account-attribution` off `codex/ocx-new-verbs`.
+
+The only phase in this unit that touches the request path and the shared usage-log
+schema. It is last among the code phases for that reason.
+
+## Root cause recap
+
+The label type is Codex-only by construction:
+
+`src/usage/log.ts:14` — `type CodexUsageAccountLogLabel = "main" | \`p${string}\``,
+validated at :16 against `CODEX_ACCOUNT_LOG_LABEL_RE = /^p[a-f0-9]{6}$/`
+(`src/codex/account-label.ts:6`). Four writers drop a non-matching label
+(usage/log.ts:369, :456; server/request-log.ts:262, :381). The only producer,
+`codexAuthContextLogLabel` (account-label.ts:32), returns `undefined` outside a
+Codex `pool`/`main-pool` context. And `legacyCodexAccountLabel` (summary.ts:681)
+returns `null` unless `baseProviderLabel(provider) === "openai"`, so `buildAccounts`
+drops the row at :706.
+
+The identity is already resolved at request time: `core.ts` puts
+`resolved.accountId` into `genericFailoverAccountId` (core.ts:2888) purely for 429
+cooldown attribution. Anthropic already folds its account into the provider label
+(core.ts:2876 `formatAnthropicProviderForLog`). So xai/cursor are the gap, not OAuth
+as a category.
+
+## 050.1 — widen the label type in one place
+
+MODIFY `src/codex/account-label.ts`.
+
+```ts
+-export const CODEX_ACCOUNT_LOG_LABEL_RE = /^p[a-f0-9]{6}$/;
++// 'p' = Codex pool account, 'o' = non-Codex OAuth provider account.
++// Both are sha256-derived hex6 digests: the label must never carry an email or a
++// raw provider account id (#2699 privacy requirement).
++export const CODEX_ACCOUNT_LOG_LABEL_RE = /^p[a-f0-9]{6}$/;
++export const OAUTH_ACCOUNT_LOG_LABEL_RE = /^o[a-f0-9]{6}$/;
++export const ACCOUNT_LOG_LABEL_RE = /^(?:main|[po][a-f0-9]{6})$/;
++
++export function oauthAccountLogLabel(accountId: string): string {
++  return "o" + createHash("sha256").update(accountId).digest("hex").slice(0, 6);
++}
+```
+
+Reuse the digest shape of the existing `fallbackCodexAccountLogLabel` (:17) so the
+two label families stay visually and structurally parallel.
+
+MODIFY `src/usage/log.ts:14`: rename the type off `Codex…` to
+`UsageAccountLogLabel = "main" | \`p${string}\` | \`o${string}\`` and validate at :16
+against `ACCOUNT_LOG_LABEL_RE`. The four writers then stop dropping `o…` labels
+without individual edits — one regex, one type.
+
+Collision note: hex6 is 16.7M values, so a birthday collision between two accounts
+is negligible at operator scale but not impossible. Two accounts colliding merge
+into one row, which is a reporting inaccuracy, not a correctness or privacy failure.
+Record it rather than widening the label and breaking the existing `p` format.
+
+## 050.2 — stamp the label in the request path
+
+MODIFY `src/server/responses/core.ts`.
+
+At the existing `genericFailoverAccountId` assignment (~2888), also set
+`logCtx.accountLogLabel = oauthAccountLogLabel(resolved.accountId)` when the
+provider is a non-Codex OAuth provider and the id is present.
+
+Critically, repeat it after **each rotation site** (~4328, ~4629, ~5221). A request
+that rotated accounts must attribute to the account that actually served it, or the
+numbers are wrong in exactly the situation the operator cares about. Reuse a single
+small helper so the four call sites cannot drift:
+
+```ts
+function stampOAuthAccountLabel(logCtx: RequestLogContext, provider: string, accountId: string | undefined): void {
+  if (!accountId) return;
+  if (!isNonCodexOAuthProvider(provider)) return;   // codex keeps its p-label producer
+  logCtx.accountLogLabel = oauthAccountLogLabel(accountId);
+}
+```
+
+Boundary: this must not reach into `src/lab/`. `core.ts` is one of the three files
+`tests/core-lab-boundary.test.ts` guards, so the helper lives in
+`src/codex/account-label.ts` or a `src/lib/` leaf, never in a Lab module.
+
+## 050.3 — let the label survive attribution
+
+MODIFY `src/usage/summary.ts` around `legacyCodexAccountLabel` (:681) and
+`buildAccounts` (:706): an **explicit** label on the row survives regardless of
+provider. Only the *fallback* path stays openai-gated.
+
+```ts
+-  const label = legacyCodexAccountLabel(entry);
++  // An explicitly stamped label is authoritative for any provider (#2699).
++  // The legacy fallback stays openai-only: guessing 'main' for a non-Codex row
++  // would silently merge unrelated accounts.
++  const label = entry.accountLogLabel ?? legacyCodexAccountLabel(entry);
+```
+
+Leave `legacy-ambiguous` behavior for unlabeled openai rows untouched. wp4 already
+renders the `ambiguous` marker, so those rows stay honest.
+
+## 050.4 — out of scope, explicitly
+
+`supportsPerAccountQuota` (`src/providers/quota.ts:1454`, currently
+`provider === "anthropic"`) is per-account **quota**, a different concern from log
+attribution. Not in this phase. Recorded in `081` as a candidate follow-up so it is
+a decision rather than an omission.
+
+## Verification exception
+
+Per `AGENTS.md`, a change to shared runtime, routing, config, or server behavior
+needs full `bun run typecheck` and `bun run test`. This phase qualifies: it edits
+`core.ts`, the usage-log schema, and the summary rollup.
+
+The operator suspended local suite runs for this loop, so full validation for this
+phase happens in wp9's CI pass. This is a **stated, bounded exception**, not an
+oversight: it is the only phase where a focused test is insufficient by the
+repository's own rule, and wp9 must not be skipped or reduced while this phase is in
+the stack. If wp9's CI cannot run, this phase does not ship.
+
+## Tests
+
+| File | Assertion |
+|---|---|
+| `tests/usage-log.test.ts` | an `o<hex6>` label round-trips through persist and read; an invalid label is still rejected |
+| `tests/usage-summary.test.ts` | an explicitly labeled xai row appears in `accounts[]`; an unlabeled openai row still reports `legacy-ambiguous`; a labeled non-openai row is not merged into it |
+| `tests/responses-account-label.test.ts` | the label is stamped for xai and cursor, and re-stamped after a rotation so the serving account is credited |
+| `tests/core-lab-boundary.test.ts` | unchanged and still green — the helper import must not pull Lab modules |
+
+## Accept criteria
+
+1. An xai or cursor request persists an `o<hex6>` account label.
+2. A rotated request attributes to the account that served it.
+3. `ocx usage` (wp4's table) shows those accounts.
+4. No email or raw account id is written to any log.
+5. The Lab core-boundary test still passes.
+

--- a/devlog/_plan/260828_ocx_agentic_control/060_phase_gui_parity.md
+++ b/devlog/_plan/260828_ocx_agentic_control/060_phase_gui_parity.md
@@ -1,0 +1,89 @@
+# 060 — wp7: residual GUI-parity closure
+
+Branch: `codex/ocx-gui-parity` off `codex/ocx-account-attribution`.
+
+wp5 closed the account-pool gaps. This phase closes the rest of 003's inventory so
+the parity test in wp3 can run with an empty unexplained-gap set.
+
+## The remaining gaps
+
+| 003 class | Capability | New verb | Route(s) |
+|---|---|---|---|
+| 2 | storage cleanup preview/run | `ocx storage cleanup [--percent N] [--preview] [--yes]` | `POST /api/storage/cleanup/preview`, `POST /api/storage/cleanup` |
+| 2 | storage trash list/restore | `ocx storage trash [list]`, `ocx storage trash restore <entry>` | `GET /api/storage/trash`, `POST /api/storage/trash/restore` |
+| 2 | cleanup policy | `ocx storage policy [show]`, `policy set …`, `policy run` | `GET|PUT /api/storage/cleanup-policy`, `POST /cleanup-policy/run` |
+| 6 | default-mode request-user-input | `ocx agent request-user-input [on|off]` | `GET|PUT /api/codex-auth/features/default-mode-request-user-input` |
+| 7 | client config snippet | `ocx integration client-config --client <id>` | `GET /api/client-config` |
+| 8 | native integrations | `ocx integration native [list]`, `native <client> on|off` | `GET /api/native-integrations`, `PUT /{client}` |
+| 9 | rename an access key | `ocx access key rename --id <id> --name <name>` | `PATCH /api/keys` |
+| 10 | provider request pacing | `ocx provider pacing [--name <p>]` | `GET /api/provider-request-pacing` |
+| — | codex prompt read | `ocx codex-prompt show [--text]` | `GET /api/codex-prompt`, `/text` |
+| — | github star status | `ocx status --star` or `ocx system star-status` | `GET /api/github/star` |
+
+Also worth adding while the surface is open, since each is a route with no verb found
+in 001's family table:
+
+- `ocx system settings [set …]` -> `GET|PUT /api/settings` (partially covered today)
+- `ocx system windows-replace-retries` -> `GET /api/system/windows-replace-retries`
+- `ocx account failover`, `auto-switch`, `reset-credits` -> the remaining
+  `/api/codex-auth/*` verbs
+- `ocx models discovery ack` -> `POST /api/model-discovery/acknowledge`
+- `ocx request-history` -> `GET /api/request-history`, `/{id}`, `/{id}/route-decision`
+  (`ocx observe` reaches only the route-decision variant)
+
+The exact list is settled at implementation time by running wp3's parity test and
+reading its failure output. **That is the phase's method:** the test names the gaps,
+so this doc does not need to pre-guess a list that would go stale.
+
+## Destructive-verb rules
+
+`storage cleanup`, `storage policy run`, and `trash restore` delete or move operator
+data. Rules for all three:
+
+1. Default to preview. `ocx storage cleanup` without `--yes` runs the preview route
+   and prints what *would* be freed, then exits 0 without mutating.
+2. `--yes` is required to mutate. No interactive prompt — an agent cannot answer one,
+   and a prompt an agent can answer is not a safety boundary (the reasoning in
+   `AGENTS.md` §User-consent actions).
+3. `--json` on the preview emits the exact target list, so an agent can decide.
+
+This is the opposite of the star POST: cleanup spends the operator's *data*, which a
+flag can authorize, while the star spends their *identity*, which no flag can.
+
+## Not parity targets
+
+Recorded as exemptions in wp3's registry with these reasons, so the test passes
+without them:
+
+- `POST /api/github/star` — `session-only`, user-consent boundary. GET is added; POST
+  never will be.
+- the 6 mutating `/api/codex-prompt*` verbs — `session-only` (403
+  `dashboard_session_required`). Read verbs are added.
+- `POST /api/providers/reload` — `capability-principal`.
+- `PUT /api/config` — `disabled` (405).
+- the 2 `test-stream` routes — `test-seam`.
+- 20 `/api/lab/*` reads — `local-transport`; `ocx lab` reads the same projection from
+  SQLite. **Decision recorded here:** no `--remote` HTTP path is added. A second
+  transport for the same data doubles the surface for an agent that already has the
+  local one, and a remote agent is not a supported topology today.
+- the shadowed `GET /api/storage` in `logs-usage-routes.ts:346` — `dead`. Delete it in
+  this phase rather than exempting it; an unreachable duplicate is a trap for the next
+  reader.
+
+## Tests
+
+| File | Assertion |
+|---|---|
+| `tests/cli-api-parity.test.ts` | passes with zero unexplained gaps |
+| `tests/cli-storage.test.ts` (NEW) | cleanup without `--yes` calls only the preview route; with `--yes` calls the mutating route; trash restore targets the named entry |
+| `tests/cli-headless-parity.test.ts` | each new verb hits its declared route and honors `--json` |
+| `tests/management-api-*.test.ts` | the deleted shadowed route changes no observable behavior |
+
+## Accept criteria
+
+1. `tests/cli-api-parity.test.ts` passes with every route either covered or
+   exempted with a reason.
+2. No destructive verb mutates without `--yes`.
+3. The dead route is gone and no test regressed.
+4. `ocx capabilities --json` lists every new verb.
+

--- a/devlog/_plan/260828_ocx_agentic_control/060_phase_gui_parity.md
+++ b/devlog/_plan/260828_ocx_agentic_control/060_phase_gui_parity.md
@@ -25,8 +25,8 @@ in 001's family table:
 
 - `ocx system settings [set …]` -> `GET|PUT /api/settings` (partially covered today)
 - `ocx system windows-replace-retries` -> `GET /api/system/windows-replace-retries`
-- `ocx account failover`, `auto-switch`, `reset-credits` -> the remaining
-  `/api/codex-auth/*` verbs
+- `ocx account failover` -> `PUT /api/codex-auth/failover`. Note `auto-switch` and
+  `reset-credits` already exist (account.ts:302, :313) — do not re-add them
 - `ocx models discovery ack` -> `POST /api/model-discovery/acknowledge`
 - `ocx request-history` -> `GET /api/request-history`, `/{id}`, `/{id}/route-decision`
   (`ocx observe` reaches only the route-decision variant)
@@ -86,4 +86,3 @@ without them:
 2. No destructive verb mutates without `--yes`.
 3. The dead route is gone and no test regressed.
 4. `ocx capabilities --json` lists every new verb.
-

--- a/devlog/_plan/260828_ocx_agentic_control/070_phase_agent_skill.md
+++ b/devlog/_plan/260828_ocx_agentic_control/070_phase_agent_skill.md
@@ -1,0 +1,119 @@
+# 070 — wp8: the `ocx` agent skill and docs-site reference
+
+Branch: `codex/ocx-agent-skill` off `codex/ocx-gui-parity`.
+
+Every prior phase widened what an agent *can* do. This phase makes it *discoverable*
+without reading the source.
+
+## 070.1 — where the skill lives
+
+NEW `skills/ocx/SKILL.md` in this repository, plus `skills/ocx/references/`.
+
+Repo-owned, not `$CODEX_HOME/skills`: the skill describes this repository's CLI
+contract and must version with it. A user-directory copy goes stale the moment the
+CLI changes, which is the same drift class as the 20 dead `USAGE` constants.
+
+```
+skills/ocx/
+  SKILL.md                        entry point, routing, safety rules
+  references/
+    01_management_surface.md      capability -> route map, generated
+    02_json_shapes.md             response envelopes and error shapes
+    03_recipes.md                 copy-paste task recipes
+    04_failure_semantics.md       exit codes, 503 classes, what to retry
+```
+
+## 070.2 — the generated half
+
+`references/01_management_surface.md` is **generated from wp3's capability table**,
+not hand-written, by a script under `scripts/`. A test asserts the committed file
+matches regeneration.
+
+Hand-writing it would recreate the exact defect this unit removed: a second
+description of the surface, free to drift from the first. If the generator and the
+committed file disagree, CI fails and someone regenerates.
+
+## 070.3 — SKILL.md content
+
+Front matter with `name: ocx` and a description naming real triggers (`ocx`,
+opencodex, proxy control, account pool, provider routing, usage report, access key,
+management API), so it activates on the tasks it covers.
+
+Body sections:
+
+**Orientation.** `ocx capabilities --json` first. It is the machine-readable index;
+everything else in the skill explains how to act on what it returns.
+
+**The three-step contract for any management call.**
+
+1. `ocx ready --json` — is the proxy up and admitting requests?
+2. `ocx status --json` — is this binary the same version as the running proxy?
+   A version mismatch means the help and flags describe a different build (#2701).
+3. Then the actual command with `--json`.
+
+**Exit codes.** 0 ok · 2 usage error · 4 not found · 5 conflict · 64 bad args
+(`ready` only) · 1 everything else, including transport and 503. Never treat a
+printed error with exit 0 as success — that was #2697, and a source scan now prevents
+its return.
+
+**Reading failures.** A management failure prints up to three lines: message,
+`reason:`, `hint:`. The `reason` is the machine-actionable part. Named 503 classes
+worth branching on: `oauth_mutation_busy` and `catalog_busy` (both send
+`Retry-After: 1` — retry once), `CONFIG_MUTATION_LOCK_UNAVAILABLE` (a config
+mutation holds the lock; retry), and the credential-conflict reason (a broken
+install; `ocx doctor` explains it, retrying will not help).
+
+**What an agent must not do.** `POST /api/github/star` has no CLI verb and must not
+be driven another way — starring spends the user's identity and needs their consent
+(`AGENTS_INSTALL.md`). Same for the session-gated `/api/codex-prompt` writes.
+Destructive storage verbs need explicit `--yes`; run the preview and report it first.
+
+**Recipes** (`references/03_recipes.md`), each a real sequence with the JSON field to
+read:
+
+- audit the account pool and pause an exhausted account
+- switch pool strategy and set a sticky limit
+- trace one conversation end to end (`ocx logs --conversation`, then
+  `ocx request-history <id> --route-decision`)
+- attribute spend per account (`ocx usage --json`, read `accounts[]`)
+- rotate an access key and confirm its usage went quiet
+- add a provider, test connectivity, make it default
+- diagnose "management API unavailable" (ready -> status -> doctor)
+- preview and then run a storage cleanup
+
+## 070.4 — docs-site
+
+NEW/MODIFY under `docs-site/`: a CLI reference page generated from the same
+capability table, and a changelog entry for the breaking changes this unit lands:
+
+- `doctor` and `sync-cache` now exit non-zero on failure (wp3)
+- `account` client error codes now map 404 -> 4 and 409 -> 5 (wp2)
+- `--json` is accepted in any argv position, including `ocx restore back --json`
+  which previously ignored it (wp3)
+
+Translated locales must not contradict the English source. If a locale cannot be
+updated in this phase, leave it untranslated rather than stale.
+
+## 070.5 — AGENTS.md pointer
+
+MODIFY `AGENTS.md`: one line under the commands section pointing at
+`skills/ocx/SKILL.md` as the operating-the-proxy reference, distinct from
+`AGENTS_INSTALL.md` (installing/operating consent) and this file
+(developing the codebase).
+
+## Tests
+
+| File | Assertion |
+|---|---|
+| `tests/skill-ocx.test.ts` (NEW) | `references/01_management_surface.md` matches regeneration from the capability table; every command named in SKILL.md exists in the table; no recipe references a session-only route |
+| `tests/repo-hygiene.test.ts` | the skill directory carries no credential-shaped strings |
+| `bun run privacy:scan` | stays green over the new files |
+
+## Accept criteria
+
+1. `skills/ocx/SKILL.md` exists and routes to four references.
+2. The surface reference is generated and a test enforces freshness.
+3. Recipes cover the eight tasks above and name the JSON fields to read.
+4. Failure semantics document exit codes and the named 503 classes.
+5. Docs-site has a generated CLI reference and the breaking-change note.
+

--- a/devlog/_plan/260828_ocx_agentic_control/080_phase_rebase_and_ci.md
+++ b/devlog/_plan/260828_ocx_agentic_control/080_phase_rebase_and_ci.md
@@ -1,0 +1,75 @@
+# 080 — wp9: stack rebase, final CI, parallel triage
+
+Branch: whichever heads exist at the time. No new source scope.
+
+The operator's instruction for this unit: no local full-suite runs during build, no
+per-push CI polling. **All verification concentrates here**, which makes this phase
+load-bearing rather than ceremonial.
+
+## 080.1 — rebase the whole stack onto current `dev`
+
+The stack is eight branches deep, so `dev` will have moved. Order matters: rebase
+parent-first, then each child onto its rebased parent, or a child re-applies commits
+its parent already carries.
+
+```
+git fetch origin dev
+for each branch in stack order:
+  git switch <branch>
+  git rebase <parent>        # roadmap rebases onto origin/dev
+  git push --force-with-lease --no-verify
+```
+
+`--force-with-lease`, never bare `--force`: the lease is what refuses to overwrite a
+push that arrived from elsewhere. Snapshot every branch SHA before starting
+(`git for-each-ref`) so any branch can be restored.
+
+Because each child PR targets its parent's head branch, the retarget order after
+rebasing is the same order — GitHub keeps the base pointer, so no PR edits are needed
+unless a parent has already merged (then retarget that child to `dev`, per
+`AGENTS.md`).
+
+## 080.2 — final CI
+
+CI runs `bun run typecheck`, `bun run test`, `bun run lint:gui`, and
+`bun run privacy:scan` on Linux, Windows, and macOS. **This is where wp6's stated
+verification exception is settled** (see `050` §Verification exception): the
+usage-log schema and `core.ts` changes have had no local full-suite run, so a green
+CI here is their only proof. If CI cannot run, wp6 does not ship.
+
+## 080.3 — parallel triage
+
+Read all PR check states at once rather than serially, and group failures by cause
+before fixing:
+
+- one failure appearing in every PR of the stack -> it originates in the lowest PR
+  that shows it; fix there and let the rebase carry it up. Fixing it in the top PR
+  leaves the stack red below.
+- a failure only in one PR -> local to that phase.
+- a platform-specific failure (Windows path handling, `schtasks`, case sensitivity)
+  -> fix in the phase that introduced the surface, not in a follow-up.
+
+Repeat rebase-push-check until every PR is green. A failure that reappears twice
+after two different fixes stops patching and gets a root-cause pass
+(`LOOP-REPAIR-01`) rather than a third guess.
+
+## 080.4 — PR hygiene
+
+Each PR uses `.github/PULL_REQUEST_TEMPLATE.md` with all three sections filled and
+`Closes #<n>` for the issues it resolves. Since these PRs target `dev` and GitHub
+only auto-closes on a default-branch merge, the issues get closed manually once the
+change is on `dev`.
+
+`enforce-target` will reject a thin description, and any PR whose title or
+description mentions `gui` needs a screenshot. None of these phases changes the GUI,
+so the word should not appear in a title — if a description must mention it, include
+the screenshot or reword.
+
+## Accept criteria
+
+1. Every stacked branch is rebased on current `origin/dev`, parent-first.
+2. Every PR's CI is green on all three platforms.
+3. wp6's deferred full-suite validation is satisfied by that green run.
+4. Every PR uses the template and links its issues.
+5. No branch was force-pushed without a lease, and pre-rebase SHAs were recorded.
+

--- a/devlog/_plan/260828_ocx_agentic_control/081_deferred_decisions.md
+++ b/devlog/_plan/260828_ocx_agentic_control/081_deferred_decisions.md
@@ -1,0 +1,36 @@
+# 081 — follow-up decisions deliberately deferred
+
+Not omissions. Each is recorded so a later reader sees a decision instead of a gap.
+
+## 081.1 — loopback repair for the token collision (#2696)
+
+`010` ships the write-time refusal only. The startup repair — delete a colliding
+`service-api-token` when the bind is loopback — changes credential state on disk at
+boot and needs the security review `MAINTAINERS.md` requires plus a proof that it
+cannot run for a non-loopback bind.
+
+Consequence of deferring: an install already broken by the collision stays broken
+until the operator re-installs. It is now *diagnosable* (`010.2` prints the reason,
+`010.5` names it in `doctor`), which was the actual complaint in the issue. Ship the
+repair as its own reviewed PR.
+
+## 081.2 — per-account quota for non-Anthropic providers
+
+`supportsPerAccountQuota` (`src/providers/quota.ts:1454`) is `provider === "anthropic"`.
+`050` deliberately scopes to log *attribution*, not quota fetching. Extending quota
+means per-provider quota endpoints and rate-limit budget, which is a different unit.
+
+## 081.3 — remote transport for `ocx lab` and `ocx config`
+
+Both reach their data locally (SQLite, file I/O) rather than over `/api/*`. `060`
+records these as `local-transport` exemptions and adds no `--remote` path: a second
+transport for the same data doubles the agent-facing surface, and an agent operating
+a proxy on another host is not a supported topology today. Revisit if that changes.
+
+## 081.4 — the GUI's 78 inlined endpoint call sites
+
+`003` found no central GUI API client; endpoints are inlined across ~78 files. That
+makes the GUI unable to participate in the parity gate — wp3's registry is declared
+server-side instead. A GUI-side endpoint manifest would let the test verify all three
+surfaces agree, but touching 78 files is its own unit and outside this scope.
+


### PR DESCRIPTION
## Summary

Phase-0 planning unit for making the `ocx` CLI a complete agentic control surface.
This PR is documentation only — no runtime code changes — and is the base of a
stacked chain that implements it.

The unit's finding: **nothing binds the CLI surface to the API surface.** The
management API has 183 reachable routes (108 mutating). The CLI has 52 dispatch
runners. Help lives in a hand-written 69-line banner plus 20 module-level `USAGE`
constants that have zero consumers outside their own files, and
`tests/cli-registry.test.ts:104` explicitly licenses the banner to drift. No test
fails when a route lands with no CLI verb. That is the mechanism behind the
operator-facing cluster #2696-#2705, not ten unrelated bugs.

Contents:

- `000_plan.md` — objective, constraints, dependency-ordered work-phase map
- `001` — full management route inventory, auth classes, and the 7 route-registration
  mechanisms a naive `rg '/api/'` misses (40+ routes)
- `002` — CLI dispatch chain, exit-code vocabulary, the two divergent management
  clients, and the help source-of-truth inventory
- `003` — GUI capability map and the 13 GUI-only capability classes, reclassified
  into 8 real gaps plus recorded exemptions
- `004` — per-issue root cause for #2696-#2705, including three corrections to the
  issue reports
- `010`-`080` — diff-level implementation docs for wp2-wp9
- `081` — decisions deliberately deferred, with consequences

Notable corrections found while root-causing: #2702's pause routes are `PUT`, not
`POST`; #2703 is worse than filed (`projectQuota` at `src/cli/account-api.ts:195`
strips `fiveHourPercent` before any renderer runs, so fixing the renderers alone
would not fix it); #2704's aside about `--model` being silently ignored server-side
is correct and is the sharper half of that ticket.

## Verification

Documentation only. No source, test, build, or GUI files are touched, so no
behavior can change from this PR.

- `git show --stat` confirms every path is under `devlog/_plan/260828_ocx_agentic_control/`
- Nothing in the build, typecheck, or test path reads from `devlog/`
- No pre-disclosure security material: the one credential-boundary item (#2696's
  token collision) is a filed public issue with a public diff pending, and the
  loopback-repair half that would need embargo is deferred to its own reviewed PR
  rather than described here

## Checklist

- [x] Follows the repository's devlog conventions (numbered lexicographic docs,
      research and implementation separated, unit under `devlog/_plan/`)
- [x] No security triage or pre-disclosure material in `devlog/`
- [x] Targets `dev`
- [x] No GUI change, so no screenshot required
- [x] No dependency, workflow, or release-automation change



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive roadmap for aligning the command-line experience with the web dashboard.
  * Documented API routes, CLI commands, GUI capabilities, error handling, data fields, and version compatibility.
  * Planned account controls, log filtering, capability discovery, usage attribution, consistent JSON output, and exit codes.
  * Defined agent guidance, CLI reference materials, testing requirements, and cross-platform CI validation.
  * Recorded security-sensitive, transport-related, and other deferred decisions for future review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->