### PR TITLE
fix(cli): stop reporting success for failed management calls (#2696 #2697 #2698)

### DIFF
--- a/devlog/_plan/260828_ocx_agentic_control/011_wp2_implementation_record.md
+++ b/devlog/_plan/260828_ocx_agentic_control/011_wp2_implementation_record.md
@@ -63,3 +63,59 @@ in this diff touches that harness or `handleAgentCommand`.
 Not claimed as fixed and not dismissed as flaky. If it recurs in wp9's CI, the first
 thing to check is the harness's port allocation, not this phase's changes.
 
+## Review round: two blockers, both real, both folded
+
+Two independent read-only reviewers were dispatched on the committed diff. Both
+returned `GO-WITH-FIXES (blockers=2)`, and between them they found three defects I had
+missed. Each was re-verified against source before being fixed.
+
+### The fix was half-inert (both reviewers, independently)
+
+`apiError` gained a `status` parameter and `apiJson` gained `transportError` — and
+**no production caller passed or read either.** All 19 `apiError` call sites passed two
+arguments, so the 404→4 / 409→5 mapping never executed; all 30 `proxyUnreachable()`
+call sites passed no argument, so the retained transport cause was never printed. The
+behavior existed only in this phase's own unit tests, while the commit message and
+`010.3` claimed it shipped.
+
+That is worse than an incomplete fix: it is a false claim backed by a passing test.
+Fixed by threading the status through all 19 call sites and the cause through the 14
+`status === 0` guards (one quota-report site legitimately has no such field). Two new
+tests assert the **call sites**, not the helpers, so the capability cannot go inert
+again.
+
+### `tray` had the identical #2697 defect and the guard could not see it
+
+`windowsTrayCommand` reports failure through `process.exitCode` (tray/windows.ts:742,
+:755) and returns void, so `ocx tray install` printed an error and exited 0 — exactly
+the defect this phase claimed to close.
+
+The recurrence guard missed it because `SWALLOWED_EXIT_CODE` was anchored on
+`await handle\w+\(`, scoping it to the `handle*` naming convention rather than to the
+defect class. A guard that only sees defects that follow a naming convention is a guard
+against tidy code, not against the bug.
+
+Pattern broadened to `await [\w.]+\(`. That immediately surfaced four more candidates
+(`update`, `__refresh-version`, `__tray-host`, `__gui-update-worker`), each verified in
+its handler before being allowlisted with its own stated reason: `runUpdate` exits 1 on
+all six failure paths, and the three hidden helpers never assign `process.exitCode`.
+
+### Corrected: the `login` allowlist reason
+
+The committed comment said `login` exits 1 on failure. It exits 1 only for an unknown
+provider; a real OAuth failure makes `runLogin` **throw**, propagating past the runner.
+The conclusion (`return 0` is unreachable after a failure) holds, but via a different
+mechanism. Corrected, because an allowlist entry justified by the wrong mechanism is
+one refactor away from being wrong.
+
+### Findings accepted as out of scope
+
+- Doctor reports the collision as WARN while the plane is fully fenced. `OAuthDoctorCheck`
+  has no FAIL level and doctor's exit code belongs to wp3b (`025`). Recorded there.
+- `dataPlaneCredentialCollisionCheck` takes an injectable `env` but calls
+  `configuredAdminToken()` without it, so half the comparison reads real machine state.
+  Real seam defect; folded now since it is one argument.
+- The multi-line error message reaches line-oriented log consumers as orphan lines.
+  Intended tradeoff of #2698, recorded not contested.
+- `assertNotAdminToken`'s prefix-only test misses an env-set admin token without the
+  `ocx_admin_` prefix, which the doctor equality check does catch. Asymmetry folded.

--- a/devlog/_plan/260828_ocx_agentic_control/011_wp2_implementation_record.md
+++ b/devlog/_plan/260828_ocx_agentic_control/011_wp2_implementation_record.md
@@ -1,0 +1,65 @@
+# 011 — wp2 implementation record
+
+Branch `codex/ocx-transport-honesty`. Implements `010` (#2697, #2698, #2696).
+
+## What landed
+
+| File | Change |
+|---|---|
+| `src/cli/dispatch.ts` | `provider` and `models` runners return `Number(process.exitCode ?? 0)` instead of a literal 0 (#2697) |
+| `src/cli/runtime-api.ts` | `responseMessage` composes primary + `reason:` + `hint:`, capped at 1200 chars (#2698) |
+| `src/cli/account-api.ts` | `ApiResult.transportError` retains the cause behind the status-0 sentinel; `apiError` renders `reason`/`hint` and maps 404→4, 409→5; `proxyUnreachable` accepts the cause |
+| `src/service.ts` | `assertNotAdminToken` refuses an `ocx_admin_` value as the data-plane secret, called from both `writeServiceApiTokenFile` and `assertServiceAuthEnvironment` before the loopback short-circuit (#2696) |
+| `src/cli/doctor.ts` | `dataPlaneCredentialCollisionCheck` names an already-broken install and its remedy without echoing the credential |
+| `tests/cli-transport-honesty.test.ts` | 16 tests, new file |
+
+`apiError` gained an optional third parameter, so all existing call sites keep
+compiling and their current exit code.
+
+## The guard found a real error in its own plan
+
+`010` specified an allowlist of `["login", "logout", "tray"]` for runners allowed to
+return a literal 0. That was a guess, and the guard contradicted it: the actual
+offenders are `debug` and `login`, and `logout`/`tray` do not match the pattern at all.
+
+Both are allowlisted on a verified basis rather than an assumed one:
+`handleDebugCommand` and `handleLogin` report every failure with `process.exit(1)`
+from inside the handler (debug.ts does so on 11 paths), so control reaches `return 0`
+only on success.
+
+That is a narrower claim than "these commands cannot fail". `login` reporting success
+for a failed OAuth flow is a real gap — it belongs to wp3b's uniform exit-code
+contract (`025`), not to this phase's management-transport scope. Recorded rather than
+silently absorbed.
+
+The `[^;]*` form was also necessary, not stylistic: the `[^)]*` form `010` originally
+proposed matches neither target runner, and the red-first assertion in the test exists
+so that can never regress unnoticed.
+
+## Verification
+
+- `tsc --noEmit`: clean. Proven non-vacuous by injecting a type error into
+  `account-api.ts`, observing `TS2322` at the exact line, then restoring and
+  re-confirming clean.
+- `bun test tests/cli-transport-honesty.test.ts`: 16 pass.
+- `bun test` over `cli-dispatch`, `cli-management-auth`, `cli-account`, `service`,
+  `cli-registry`, `cli-headless-parity`: 297 pass.
+
+## One unexplained failure, recorded rather than dismissed
+
+The first run of that six-file batch reported 296 pass / 1 fail — the
+`vision --list` case in `cli-headless-parity`. The same batch on a pristine
+`origin/dev` worktree gave 297/0, so the initial reading was that this diff caused it.
+
+It did not reproduce in 26 subsequent runs, including the same batch on this branch.
+The test passes in isolation.
+
+Most plausible mechanism, stated as a hypothesis and not a conclusion:
+`fakeRuntime` starts a real `Bun.serve` per test, and files run in parallel, so a
+port-level collision would return another fake's payload — which is exactly the shape
+of the failure (a missing `visionModels` entry rather than a wrong assertion). Nothing
+in this diff touches that harness or `handleAgentCommand`.
+
+Not claimed as fixed and not dismissed as flaky. If it recurs in wp9's CI, the first
+thing to check is the harness's port allocation, not this phase's changes.
+

--- a/devlog/_plan/260828_ocx_agentic_control/021_wp3_stale_check_amendment.md
+++ b/devlog/_plan/260828_ocx_agentic_control/021_wp3_stale_check_amendment.md
@@ -1,0 +1,299 @@
+# 021 — wp3 P-phase stale-check amendment
+
+Four parallel read-only Sol explorers checked `020` against the tree at `43b0788e0`.
+All four returned VERDICT: FAIL. Every blocking finding below was re-verified
+independently against source before being accepted; the counts here are ones
+reproduced directly, not ones handed over.
+
+`020` is not withdrawn. Its design — one capability table, three consumers — survives
+intact. What failed is the measurement layer: the numbers it reasons from, and the
+arithmetic identity of the gate it calls its own central claim.
+
+The single root cause: **`020` and `001` count grep lines and call them routes.** Every
+blocking finding is a consequence.
+
+## A1 — check 3's identity cannot balance (blocking)
+
+`020` specifies:
+
+```
+registryRoutesFor(module).length === literalCountIn(module) + nonLiteralAllowlist[module].length
+```
+
+This fails on today's correct tree, in four independent ways:
+
+| Failure | Evidence |
+|---|---|
+| A literal line can carry two routes | `oauth-account-routes.ts:332` and `codex/auth-api.ts:1676` both match `PUT \|\| PATCH` |
+| 19 literal lines carry no inline method | method decided by an enclosing block: `lab-routes.ts:296,309,322,336,354,358,370,385,411,441,471,516`, `storage-log-guard-routes.ts:112,128,135,140,145`, `integration-routes.ts:313,373` |
+| 2 live routes use a **negated** guard and appear in no literal count | `storage-log-guard-routes.ts:150` (`GET /api/storage`), `routing-analytics-routes.ts:26` (`GET /api/routing-analytics`) |
+| One module has 1 route and 0 literals | `routing-analytics-routes.ts` — a literal-count-keyed test omits the module entirely |
+
+The negated guards, confirmed directly:
+
+```
+$ rg -n 'pathname !== "' src/server/management/*.ts
+storage-log-guard-routes.ts:150:  if (url.pathname !== "/api/storage" || req.method !== "GET") return null;
+routing-analytics-routes.ts:26:  if (url.pathname !== "/api/routing-analytics" || req.method !== "GET") return null;
+```
+
+The second is the finding that matters most. `020` proposes the `===` scan specifically
+to stop a vacuous pass, and that scan cannot see `/api/routing-analytics` at all.
+Worse, for `GET /api/storage` the scan sees **only the dead shadowed copy** at
+`logs-usage-routes.ts:346` and never the live one. A gate built as written would
+mistake the corpse for the patient.
+
+**Amendment.** Reconcile on distinct `(method, path)` pairs, never on `rg` line hits.
+The scanner must:
+
+1. match both `pathname === "…"` and `pathname !== "…"` forms;
+2. resolve the method from the same line, else the two following lines, else the
+   enclosing block — and **fail loudly when it cannot resolve one**, rather than
+   defaulting to GET;
+3. expand `X || Y` method disjunctions into separate pairs;
+4. key the per-module allowlist by `(method, path, mechanism)`, so the mechanism is
+   recorded per route rather than per module.
+
+Requirement 2's fail-loud clause is the one to defend in review. A scanner that
+silently guesses a method is a scanner that reports a number nobody can trust, which
+is how `001` arrived at figures no one can reproduce.
+
+## A2 — "188 literals" and "40+ invisible" contradict each other (blocking)
+
+Both cannot be true, because the 188 was measured over a **wider file set** than the
+one the "40+" claims are invisible from.
+
+```
+$ rg -o 'pathname === "' src/server/management-api.ts src/server/management/ | wc -l
+159
+$ rg -o 'pathname === "' src/server/management-api.ts src/server/management/ \
+    src/codex/auth-api.ts src/codex/native-profile-api.ts | wc -l
+188
+```
+
+The 159 was reproduced independently before any explorer's number was read. The
+29-line difference is `src/codex/auth-api.ts` (20) and `src/codex/native-profile-api.ts`
+(9) — the exact files whose routes `001` counts as "invisible because mounted outside
+the `??` chain." They are invisible to a scan **scoped to `src/server/management/`**,
+and plainly visible in the scan that produced 188.
+
+**Amendment.** The genuinely non-literal count is **18**, enumerated with mechanism
+and `file:line` below. State the file set explicitly wherever a count appears: 21
+route-carrying files, of which 20 contain literals.
+
+| # | Route | Mechanism | Site |
+|---|---|---|---|
+| 1 | `GET /api/storage` | negated guard | `storage-log-guard-routes.ts:150` |
+| 2 | `GET /api/routing-analytics` | negated guard | `routing-analytics-routes.ts:26` |
+| 3 | `GET /api/system/codex-app-server` | path constant | `system-routes.ts:164` |
+| 4 | `POST /api/system/codex-restart` | path constant | `system-routes.ts:165` |
+| 5 | `POST /api/providers/reload` | path constant | `provider-routes.ts:467` |
+| 6-7 | `GET\|PUT /api/client-integrations/{clientId}` | prefix decode | `integration-routes.ts:130` |
+| 8 | `GET /api/request-history/{id}` | `pathname.slice` | `request-history-routes.ts:176` |
+| 9 | `GET /api/request-history/{id}/route-decision` | `endsWith` | `request-history-routes.ts:131` |
+| 10-13 | provider alias, model-aliases, custom-model PUT/DELETE | regex | `model-routes.ts:264,291,606,678` |
+| 14-16 | lab subjects/events/artifacts by id | regex | `lab-routes.ts:424,499,545` |
+| 17 | `POST /api/lab/automation/runs/{id}/cancel` | regex | `lab-automation-routes.ts:106` |
+| 18 | `POST /api/system/restart` | **literal** — `001` wrongly calls it a path constant | `system-routes.ts:133` |
+
+Regex routes are **8**, not `001`'s 7. Native-main-profiles is **9**, not 10. Codex-auth
+is **23** `(method, path)` pairs over 20 literal guards, not 22.
+
+## A3 — the lab exemption is wrong and makes accept criterion 2 unsatisfiable (blocking)
+
+`020` exempts "20 `/api/lab/*` reads" under `local-transport`, on the grounds that
+`ocx lab` reads the same data from local SQLite. The premise is sound —
+`src/cli/lab.ts` imports `../lab/query` directly and never fetches `/api/lab` — but the
+set is wrong in a way that matters.
+
+The family is **21 routes: 14 GET and 7 mutating.** The mutating seven, verified:
+
+```
+lab-routes.ts:296  POST /api/lab/public/preview
+lab-routes.ts:309  POST /api/lab/public/export
+lab-routes.ts:322  POST /api/lab/public/verify
+lab-routes.ts:336  POST /api/lab/public/community/import
+lab-automation-routes.ts:119  POST /api/lab/automation/run
+lab-automation-routes.ts:163  PUT  /api/lab/automation
+lab-automation-routes.ts:106  POST /api/lab/automation/runs/{id}/cancel   (regex)
+```
+
+A local SQLite read cannot start an automation run or import a community bundle, so
+`local-transport` does not cover any of these seven. As written, seven existing routes
+have no verb and no valid exemption, so accept criterion 2 — "a new route with no verb
+and no exemption fails the parity test" — is violated on day one. The gate must be
+born red or widened at birth, and widening it at birth is precisely the silent erosion
+`020` says the mandatory reason string exists to prevent.
+
+**Amendment.** Split the row:
+
+- **11** lab reads are `local-transport`-exempt (8 literals at `lab-routes.ts:354,358,370,385,411,441,471,516` plus 3 regex at `:424,499,545`).
+- **3** further GETs (`/api/lab/public/community`, `/api/lab/automation`, `/api/lab/automation/runs`) are exempt only if the doc says so explicitly. Decision: include them, reason `local-transport`.
+- **The 7 mutating routes get real verbs in wp7**, not an exemption. wp3 declares them with `exempt: { reason: "deferred-verb", owner: "wp7" }` — a *bounded* exemption naming the phase that retires it, so the gate stays honest and the debt stays visible rather than absorbed.
+
+Introducing `deferred-verb` is a real widening of the exemption vocabulary, so it is
+constrained: it requires an `owner` field naming a work-phase, and
+`tests/cli-api-parity.test.ts` asserts every `deferred-verb` owner is a phase that
+still exists in the goalplan. An exemption that outlives its owner fails the build.
+
+## A4 — the version-skew edit targets a function that cannot carry a value (blocking)
+
+`020.4` says to populate `version` "in the probe that already parsed and validated the
+healthz body (`isOpencodexHealthz`)". That function is a pure predicate:
+
+```ts
+export function isOpencodexHealthz(body: HealthzIdentity | null): boolean
+```
+
+It receives the body and returns a boolean. The parsed body lives one frame up in
+`proxyIdentityAt`, whose signature discards everything but the pid:
+
+```ts
+): Promise<{ pid: number | null } | null> {
+  …
+  return { pid };
+```
+
+**Amendment.** The edit is three hops, not one: widen `proxyIdentityAt`'s return type
+to carry `version?: string` (guarded by `typeof === "string"`, mirroring the existing
+pid guard), thread it through all three `findLiveProxy` construction sites, then add
+the `LiveProxy` field. `020.4`'s "no extra request" conclusion still holds — the body
+is already parsed — but for a different reason than it states.
+
+### A4.1 — 12 exhaustive assertions break, and the doc does not list the file
+
+`tests/proxy-liveness.test.ts` appears nowhere in `020`'s file list or test table. It
+holds 9 `expect(live).toEqual(…)` and 3 `expect(identity).toEqual(…)` assertions
+(counts reproduced directly). Bun's `toEqual` rejects an extra **defined** key while
+tolerating an `undefined` one, so every assertion whose mock body carries a version
+string fails the moment the field is threaded through. Add the file to the amended test
+table as MODIFIED.
+
+### A4.2 — the warning has no semantic home
+
+`020.4` says to "push" the warning into the warnings array. There is no
+general-purpose warnings array. The only candidate is `warningParts` at `status.ts:238`,
+which is joined into `codexRuntime.warning` and printed under the Codex-runtime
+heading. A stale-`ocx`-on-PATH warning is not a Codex-runtime fact.
+
+**Amendment.** Add a dedicated top-level `versionSkew` object to `CliStatusJson` (type
+at `status.ts:23`, construction literal at `status.ts:312`) plus a printer edit in
+`src/cli/index.ts` near `handleStatus`. Without the printer edit the warning is
+invisible in non-JSON `ocx status`, which defeats accept criterion 4 while appearing to
+satisfy it.
+
+Two fallbacks must suppress the warning rather than report skew against a placeholder:
+server-side `VERSION` falls back to `"0.0.0"`, and `packageVersion()` returns
+`"unknown"`. `schemaVersion` stays `1`: additive optional fields do not break the
+contract, and `tests/cli-status-json.test.ts:88` pins it.
+
+## A5 — 020.2 is a contract change, not a deletion sweep (blocking)
+
+`020`'s opening line — "20 module `USAGE` constants with zero consumers outside their
+own files" — conflates three different quantities. The truth:
+
+- **20** is the *file* count.
+- **37** usage constants are declared across those files.
+- **12** are exported (count reproduced directly).
+- The 12 exports are one-line **aliases** at file bottoms (`export const ACCESS_USAGE = USAGE;`). Those alias statements are dead.
+- The constants they alias are **heavily live**: 243 non-declaration references inside their own files.
+
+The live consumers are not incidental. They are the second argument to a contract:
+
+```ts
+export class CliUsageError extends Error {
+  constructor(message: string, readonly usage?: string) {
+export function rejectArgs(args: string[], usage: string, options?: RejectArgsOptions): void {
+```
+
+So "delete the module-level `USAGE` constant and have the usage path call
+`printSubcommandUsage`" is not mechanical. It changes what `CliUsageError.usage`
+carries across hundreds of call sites, and `CliUsageError` is how the CLI reports
+argument errors — the surface these very issues are about.
+
+**Amendment.** wp3 deletes the **12 dead alias exports** and re-sources usage *text*
+from the capability table, leaving `rejectArgs(args, USAGE)` call sites structurally
+intact: each module's `const USAGE` becomes a lookup into the capability table rather
+than a literal. Same identifier, same call sites, generated content. The four
+`ACCOUNT_USAGE` sites keep `console.error` + `return 1` exactly as `020` already
+preferred.
+
+## A6 — "exactly the visible capability set" is unsatisfiable as stated
+
+The banner carries `help` and `--version`, and `CLI_COMMANDS` has an entry for neither,
+though both are real dispatch runners. It also carries subcommand lines (`ocx restore
+back`, `ocx doctor --reclaim-response-temps`, `ocx claude desktop`) that are not
+registry entries.
+
+**Amendment.** Add `help` and `--version` capability entries, and declare a
+`bannerLines` field so a capability can contribute more than one banner row. Then
+"exactly" is checkable. Without this, accept criterion 1 ("no hand-maintained command
+list remains") is not reachable.
+
+## A7 — 020.3's registration constraints, stated
+
+A literal reading of "register in `dispatch.ts` and `registry.ts`" fails the existing
+parity assertions. The binding constraints:
+
+1. `CLI_COMMANDS` entry needs `name`, `usage`, `summary` (all required).
+2. No `hidden: true` — the hidden set is pinned to exactly six `__`-prefixed names.
+3. A `capabilities:` key in `commandRunners` returning `Promise<number>`.
+4. No aliases unless a matching own-name entry exists.
+5. **Ordering: 020.1 lands before 020.3.** The banner test greps `help.ts` source text,
+   so a registry entry added before the banner is generated requires a hand-edit that
+   020.1 then deletes. `020` states no ordering; this amendment fixes it.
+
+## A8 — the `src/lab/` boundary risk `020` never mentions
+
+`020` does not address the Lab boundary at all, and the protected set is **four** files,
+not three: `tests/core-lab-boundary.test.ts` includes `src/server/management-api.ts` —
+which statically imports every `src/server/management/` handler, making it the natural
+importer of a new `route-registry.ts`. If that registry reaches `src/lab/`, the guard
+fails.
+
+**Mechanism, verified against the guard's own source.** The registry holds only inert
+data — `{ method, path, module, auth, mutates, exempt? }`. Three specifics make it safe:
+
+- Path strings are data. `"/api/lab/status"` in a string literal creates no module edge; the walker follows only `import`/`export … from` and direct `import()`.
+- Any Lab-adjacent type comes in via `import type`, which the guard's regex excludes with a negative lookahead on every alternative.
+- The `module` field names the *handler module* (`"./management/lab-routes"`), which the guard deliberately does not treat as naming Lab. Existing lazy dispatch at `management-api.ts:126,129` stays untouched: the registry describes those routes, it must never resolve their handlers.
+
+Verify with `bun test tests/core-lab-boundary.test.ts`, which prints the offending
+chain on failure, rather than by inspection.
+
+## A9 — unreproducible headline numbers
+
+`001`'s "183 reachable routes / 108 mutating / 19 files" records no counting method and
+no command. An independent enumeration produced 206/116/21. Neither was adjudicated,
+and that is the point: **an unreproducible number has no place in the phase whose
+entire purpose is preventing a vacuous gate.**
+
+**Amendment.** `001` is annotated to mark the figures unsourced. wp3 does not depend on
+them — the registry is *declared*, and once it exists it becomes the count, with the
+reconciliation test as its proof. Accept criteria are restated against the registry
+rather than against any prior number.
+
+## Amended test table
+
+| File | State | Assertion |
+|---|---|---|
+| `tests/management-route-registry.test.ts` | NEW | three checks: scan→registry, registry→source, per-module `(method,path)` reconciliation with fail-loud method resolution |
+| `tests/cli-api-parity.test.ts` | NEW | every route has a capability or a reasoned exemption; every `deferred-verb` owner is a live goalplan phase |
+| `tests/cli-capabilities.test.ts` | NEW | `--json` shape stable; `--route` filter resolves |
+| `tests/cli-registry.test.ts` | MODIFIED | generated banner equals the visible capability set incl. `help`/`--version`/`bannerLines` |
+| `tests/proxy-liveness.test.ts` | **MODIFIED (was missing)** | 12 `toEqual` assertions carry `version` |
+| `tests/cli-status-json.test.ts` | MODIFIED | `versionSkew` present; `schemaVersion` stays 1; stderr stays empty under `--json` |
+| `tests/doctor.test.ts` | MODIFIED | skew section emitted (exists: 763 lines, drives `runDoctor`) |
+| `tests/core-lab-boundary.test.ts` | UNCHANGED, must stay green | the registry reaches no `src/lab/` module |
+
+## Amended accept criteria
+
+1. `ocx --help` is generated; no hand-maintained command list remains.
+2. A new route with no capability and no reasoned exemption fails `tests/cli-api-parity.test.ts` — and the gate is **green on day one**, because the 7 mutating lab routes carry bounded `deferred-verb` exemptions owned by wp7.
+3. `ocx capabilities --json` enumerates the surface with routes and flags.
+4. `ocx status` warns on skew in **both** human and JSON output, and suppresses the warning when either side reports a placeholder version.
+5. The reconciliation test fails on a route added by any of the mechanisms in A2's table, proven by adding one and observing red before removing it.
+
+Criterion 5 replaces a claim with a demonstration. Given that `020`'s original gate
+would have failed on correct code while believing itself rigorous, a gate that has not
+been driven red is not yet evidence of anything.

--- a/devlog/_plan/260828_ocx_agentic_control/021_wp3_stale_check_amendment.md
+++ b/devlog/_plan/260828_ocx_agentic_control/021_wp3_stale_check_amendment.md
@@ -297,3 +297,112 @@ rather than against any prior number.
 Criterion 5 replaces a claim with a demonstration. Given that `020`'s original gate
 would have failed on correct code while believing itself rigorous, a gate that has not
 been driven red is not yet evidence of anything.
+
+## A10 — self-audit: four defects in this amendment
+
+The A-gate audit of this document was attempted twice with an adversarial reviewer and
+both attempts died on provider rate limits (`429`), so the audit was performed directly
+instead. Recording that substitution honestly matters: an unaudited amendment claiming
+to fix an unaudited plan is the same failure one level up.
+
+Four defects were found in the amendment itself. Two are blocking.
+
+### A10.1 — A1's method resolution looks the wrong direction (blocking)
+
+A1 says resolve the method "from the same line, else the two following lines, else the
+enclosing block." In `lab-routes.ts` the method is fixed by a **preceding early-return
+guard**, not an enclosing block:
+
+```ts
+  if (req.method !== "GET") return null;      // lab-routes.ts:352
+
+  if (url.pathname === "/api/lab/status") {   // :354 — GET, decided 2 lines earlier
+```
+
+`storage-log-guard-routes.ts` inverts it again — the path is outer and the method is
+the **inner** early return:
+
+```ts
+  if (url.pathname === "/api/storage/codex-logs") {   // :112
+    if (req.method !== "GET") return null;            // :113
+```
+
+So three distinct shapes carry a method: same-line conjunction, a preceding sibling
+guard that narrows everything after it, and a nested guard inside the path block. A
+scanner that only looks forward and outward resolves none of the 8 lab reads.
+
+**Fix.** Resolve the method by walking the enclosing function's statements in order and
+maintaining a *method narrowing context*: a top-level `if (req.method !== X) return`
+narrows every subsequent sibling statement to X; a nested one narrows only its own
+block; a same-line conjunction binds only that route. This is a small interpreter over
+guard statements, not a regex, and A1 must say so — the honest cost of the fail-loud
+requirement is that the scanner cannot be a one-line `rg`.
+
+### A10.2 — A3's `owner` assertion cannot run in CI (blocking)
+
+A3 has `tests/cli-api-parity.test.ts` assert that every `deferred-verb` owner "is a
+phase that still exists in the goalplan." The goalplan is machine-local and
+**gitignored**:
+
+```
+$ rg -n 'codexclaw' .gitignore
+45:.codexclaw/
+46:**/.codexclaw/
+$ git ls-files .codexclaw      # empty
+```
+
+`tests/repo-hygiene.test.ts` additionally forbids tracking it. A test reading that file
+passes on this machine and cannot even find it in CI, which is the same class of
+vacuous gate this amendment exists to eliminate — and it would have been introduced by
+the fix, not the original.
+
+**Fix.** Bind the exemption to a **tracked** artifact instead. `deferred-verb` carries
+`owner: "wp7"` plus `ownerDoc: "devlog/_plan/260828_ocx_agentic_control/060_phase_gui_parity.md"`,
+and the test asserts the doc exists and names the route. `devlog/` is tracked ordinary
+markdown, so the assertion means the same thing in CI as locally. The debt stays
+visible in the repository rather than in one developer's state directory.
+
+### A10.3 — A5's lookup can silently produce empty usage text (major)
+
+A5 has each module's `const USAGE` become a lookup into the capability table. Those
+constants are **top-level**, evaluated at import time (`access.ts:12` and its 19
+siblings). ESM tolerates a top-level cycle by yielding `undefined` rather than
+throwing, so if the capability table ever imports a module that imports it back, every
+`rejectArgs(args, USAGE)` in that module quietly starts reporting empty usage — a
+silent regression in exactly the error-reporting surface these issues are about.
+
+Today the direction is clean (`help.ts` imports only `./registry`; nothing imports
+`access.ts`, `combo.ts`, or `observe.ts`), so the cycle is a risk introduced by the
+change, not a present defect.
+
+**Fix.** `src/cli/capabilities.ts` imports **nothing** from `src/cli/` — it is a leaf
+data module, same discipline A8 imposes on the route registry. Add a guard test
+asserting `capabilities.ts` has no `./`-relative import into a command module, and
+assert each generated `USAGE` is a non-empty string so an accidental cycle fails loudly
+instead of degrading.
+
+### A10.4 — A6's `--version` entry is wrong; `help` is deliberately excluded (major)
+
+A6 proposes capability entries for `help` and `--version`. Both are mis-specified.
+
+`--version`, `-v`, and `version` never reach the dispatch table at all. They are
+resolved in the CLI head (`root.ts:28`) and exit before dispatch, so `--version` has no
+runner key and an entry named `--version` would fail the assertion that every canonical
+entry is a direct runner key.
+
+`help` is not an oversight either. `tests/cli-registry.test.ts:14-21` documents the
+exclusion in a comment and encodes it in a `headHandled` set — `help`/`--help`/`-h` are
+"head-handled pseudo-cases, not commands." A6 read a deliberate decision as a gap.
+
+**Fix.** Neither becomes a `CLI_COMMANDS` entry. The capability table gains a separate
+`headCapabilities` list for head-handled surfaces, which contributes banner lines and
+`ocx capabilities --json` output without touching runner-key parity. The banner
+equality assertion then compares against `visible capabilities + headCapabilities`,
+which is satisfiable — A6's version was not.
+
+### Confirmed correct in A2
+
+`agent-settings-routes.ts` and `oauth-account-routes.ts` are rightly absent from the
+18-route table. Their `startsWith`/`slice` hits are payload manipulation
+(`oauth-account-routes.ts:584` truncates a key prefix; `agent-settings-routes.ts:900`
+filters model routes), not path guards. The omission was checked rather than assumed.

--- a/src/cli/account-api.ts
+++ b/src/cli/account-api.ts
@@ -85,7 +85,7 @@ export interface ApiResult {
   json: Record<string, unknown>;
   /**
    * Message from the thrown transport error when `status` is 0. Previously the
-   * error was swallowed by a bare `catch {}`, so an unreachable proxy, a DNS
+   * error was swallowed by a catch block with an empty body, so an unreachable proxy, a DNS
    * failure and a TLS error were indistinguishable (#2698).
    */
   transportError?: string;

--- a/src/cli/account-api.ts
+++ b/src/cli/account-api.ts
@@ -152,7 +152,7 @@ function accountStringField(json: Record<string, unknown>, key: string): string 
  * failure exited 1, so a script could not distinguish a missing account from a
  * concurrent mutation.
  */
-export function apiError(json: Record<string, unknown>, fallback: string, status?: number): number {
+export function apiError(json: Record<string, unknown>, fallback: string, status: number): number {
   const primary = accountStringField(json, "error") ?? fallback;
   const lines = [`Error: ${primary}`];
   const reason = accountStringField(json, "reason");
@@ -175,6 +175,8 @@ export interface FamilyRows {
   /** Set when the family endpoint returned an error. */
   errorJson?: Record<string, unknown>;
   networkDown?: boolean;
+  /** Transport cause when `networkDown` is set. Callers must forward this to `proxyUnreachable`. */
+  transportError?: string;
 }
 
 export interface CodexQuotaDto {
@@ -255,7 +257,13 @@ export async function fetchCodexRows(
     return { rows: [], activeId: null, status: activeRes.status, errorJson: activeRes.json };
   }
   if (accountsRes.status === 0 || activeRes.status === 0) {
-    return { rows: [], activeId: null, status: 0, networkDown: true };
+    return {
+      rows: [],
+      activeId: null,
+      status: 0,
+      networkDown: true,
+      transportError: accountsRes.transportError ?? activeRes.transportError,
+    };
   }
   const activeId = typeof activeRes.json.activeCodexAccountId === "string"
     ? activeRes.json.activeCodexAccountId
@@ -301,7 +309,9 @@ async function fetchOAuthRows(
     ? `?provider=${encodeURIComponent(name)}&quota=1${quota.refresh ? "&refresh=1" : ""}`
     : `?provider=${encodeURIComponent(name)}`;
   const res = await apiJson(deps, baseUrl, "GET", `/api/oauth/accounts${query}`);
-  if (res.status === 0) return { rows: [], activeId: null, status: 0, networkDown: true };
+  if (res.status === 0) {
+    return { rows: [], activeId: null, status: 0, networkDown: true, transportError: res.transportError };
+  }
   if (res.status !== 200) return { rows: [], activeId: null, status: res.status, errorJson: res.json };
   const activeId = typeof res.json.activeAccountId === "string" ? res.json.activeAccountId : null;
   const accounts = Array.isArray(res.json.accounts) ? res.json.accounts as OAuthAccountDto[] : [];
@@ -328,7 +338,9 @@ interface ApiKeyDto {
 
 async function fetchKeyRows(deps: AccountDeps, baseUrl: string, name: string): Promise<FamilyRows> {
   const res = await apiJson(deps, baseUrl, "GET", `/api/providers/keys?name=${encodeURIComponent(name)}`);
-  if (res.status === 0) return { rows: [], activeId: null, status: 0, networkDown: true };
+  if (res.status === 0) {
+    return { rows: [], activeId: null, status: 0, networkDown: true, transportError: res.transportError };
+  }
   if (res.status !== 200) return { rows: [], activeId: null, status: res.status, errorJson: res.json };
   const activeId = typeof res.json.activeId === "string" ? res.json.activeId : null;
   const keys = Array.isArray(res.json.keys) ? res.json.keys as ApiKeyDto[] : [];
@@ -359,8 +371,11 @@ export async function fetchProviderQuotaReport(
   deps: AccountDeps,
   baseUrl: string,
   name: string,
-): Promise<{ status: number; report: ProviderQuotaReportDto | null; errorJson?: Record<string, unknown> }> {
+): Promise<{ status: number; report: ProviderQuotaReportDto | null; errorJson?: Record<string, unknown>; transportError?: string }> {
   const res = await apiJson(deps, baseUrl, "GET", "/api/provider-quotas?refresh=1");
+  if (res.status === 0) {
+    return { status: 0, report: null, errorJson: res.json, transportError: res.transportError };
+  }
   if (res.status !== 200) return { status: res.status, report: null, errorJson: res.json };
   const reports = Array.isArray(res.json.reports) ? res.json.reports as ProviderQuotaReportDto[] : [];
   return { status: 200, report: reports.find(report => report?.provider === name) ?? null };

--- a/src/cli/account-api.ts
+++ b/src/cli/account-api.ts
@@ -83,6 +83,12 @@ export interface ApiResult {
   /** 0 = network-level failure (proxy unreachable). */
   status: number;
   json: Record<string, unknown>;
+  /**
+   * Message from the thrown transport error when `status` is 0. Previously the
+   * error was swallowed by a bare `catch {}`, so an unreachable proxy, a DNS
+   * failure and a TLS error were indistinguishable (#2698).
+   */
+  transportError?: string;
 }
 
 export async function apiJson(
@@ -103,8 +109,14 @@ export async function apiJson(
     });
     const json = (await res.json().catch(() => ({}))) as Record<string, unknown>;
     return { status: res.status, json };
-  } catch {
-    return { status: 0, json: {} };
+  } catch (error) {
+    // status 0 stays the transport sentinel, but keep the cause: callers can now
+    // tell the operator why the request never reached the proxy (#2698).
+    return {
+      status: 0,
+      json: {},
+      transportError: error instanceof Error ? error.message : String(error),
+    };
   }
 }
 
@@ -115,18 +127,43 @@ export async function resolveBaseUrl(deps: AccountDeps): Promise<string | null> 
   return `http://${probeHostname(live.hostname)}:${live.port}`;
 }
 
-export function proxyUnreachable(): number {
+export function proxyUnreachable(transportError?: string): number {
   console.error("Proxy not reachable. Start it with 'ocx start' or 'ocx ensure'.");
+  // Naming the transport cause distinguishes "nothing is listening" from a refused
+  // or reset connection, which is what made #2696-class breakage undiagnosable.
+  if (transportError) console.error(`reason: ${transportError}`);
   return 1;
 }
 
-export function apiError(json: Record<string, unknown>, fallback: string): number {
-  const message = typeof json.error === "string" ? json.error : fallback;
-  console.error(`Error: ${message}`);
+function accountStringField(json: Record<string, unknown>, key: string): string | undefined {
+  const value = json[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/**
+ * Report a failed management call from the account family.
+ *
+ * `reason` and `hint` are the actionable fields on a refusal — the management plane
+ * sets both on a 503, and several routes return `reason` with no `error` key at all,
+ * which used to print only the generic fallback (#2698).
+ *
+ * `status` selects the exit code so the account client speaks the same vocabulary as
+ * runtime-api.ts: 4 for not-found, 5 for conflict, 1 otherwise. Previously every
+ * failure exited 1, so a script could not distinguish a missing account from a
+ * concurrent mutation.
+ */
+export function apiError(json: Record<string, unknown>, fallback: string, status?: number): number {
+  const primary = accountStringField(json, "error") ?? fallback;
+  const lines = [`Error: ${primary}`];
+  const reason = accountStringField(json, "reason");
+  if (reason && reason !== primary) lines.push(`reason: ${reason}`);
+  const hint = accountStringField(json, "hint");
+  if (hint && hint !== primary) lines.push(`hint: ${hint}`);
+  for (const line of lines) console.error(line);
   if (json.cleanupRequired === true) {
     console.error("Warning: native-login staging cleanup is still required; run 'ocx account main doctor'.");
   }
-  return 1;
+  return status === 404 ? 4 : status === 409 ? 5 : 1;
 }
 
 export interface FamilyRows {

--- a/src/cli/account-extended.ts
+++ b/src/cli/account-extended.ts
@@ -233,7 +233,7 @@ function configAndType(deps: AccountDeps, name: string) {
 
 function familyFailure(result: FamilyRows, fallback: string): number | null {
   if (result.networkDown) return proxyUnreachable();
-  if (result.errorJson) return apiError(result.errorJson, fallback);
+  if (result.errorJson) return apiError(result.errorJson, fallback, result.status);
   return null;
 }
 
@@ -326,7 +326,7 @@ export async function cmdRefresh(args: string[], deps: AccountDeps): Promise<num
   if (classified.type !== "codex") {
     const result = await fetchProviderQuotaReport(deps, baseUrl, name);
     if (result.status === 0) return proxyUnreachable();
-    if (result.status !== 200) return apiError(result.errorJson ?? {}, `failed to refresh ${name}`);
+    if (result.status !== 200) return apiError(result.errorJson ?? {}, `failed to refresh ${name}`, result.status);
     if (wantsJson) console.log(JSON.stringify({ provider: name, report: result.report }, null, 2));
     else console.log(result.report ? providerQuotaLine(name, result.report) : `no quota report available for ${name}`);
     return 0;
@@ -360,15 +360,15 @@ export async function cmdAutoSwitch(args: string[], deps: AccountDeps): Promise<
   if (!baseUrl) return proxyUnreachable();
   if (action === "status") {
     const response = await apiJson(deps, baseUrl, "GET", "/api/codex-auth/active");
-    if (response.status === 0) return proxyUnreachable();
+    if (response.status === 0) return proxyUnreachable(response.transportError);
     if (response.status !== 200 || typeof response.json.autoSwitchThreshold !== "number") {
-      return apiError(response.json, "failed to read auto-switch status");
+      return apiError(response.json, "failed to read auto-switch status", response.status);
     }
     threshold = response.json.autoSwitchThreshold;
   } else {
     const response = await apiJson(deps, baseUrl, "PUT", "/api/codex-auth/auto-switch", { threshold });
-    if (response.status === 0) return proxyUnreachable();
-    if (response.status !== 200) return apiError(response.json, "failed to update auto-switch");
+    if (response.status === 0) return proxyUnreachable(response.transportError);
+    if (response.status !== 200) return apiError(response.json, "failed to update auto-switch", response.status);
   }
   const enabled = threshold! > 0;
   if (wantsJson) console.log(JSON.stringify({ provider: name, autoSwitchThreshold: threshold, enabled }, null, 2));
@@ -459,8 +459,8 @@ export async function cmdAddKey(args: string[], deps: AccountDeps): Promise<numb
   const baseUrl = await resolveBaseUrl(deps);
   if (!baseUrl) return proxyUnreachable();
   const response = await apiJson(deps, baseUrl, "POST", "/api/providers/keys", { name, key, ...(label ? { label } : {}) });
-  if (response.status === 0) return proxyUnreachable();
-  if (response.status !== 201) return apiError(response.json, `failed to add a key for ${name}`);
+  if (response.status === 0) return proxyUnreachable(response.transportError);
+  if (response.status !== 201) return apiError(response.json, `failed to add a key for ${name}`, response.status);
   const id = typeof response.json.id === "string" ? response.json.id : null;
   // Redact the key inside the label BEFORE serialization — a key containing
   // JSON-escaped characters (" or \) would otherwise survive the whole-output
@@ -589,8 +589,8 @@ export async function cmdClearCooldown(args: string[], deps: AccountDeps): Promi
   const baseUrl = await resolveBaseUrl(deps);
   if (!baseUrl) return proxyUnreachable();
   const response = await apiJson(deps, baseUrl, "POST", "/api/codex-auth/accounts/clear-cooldown", { id });
-  if (response.status === 0) return proxyUnreachable();
-  if (response.status !== 200) return apiError(response.json, `failed to clear cooldown for ${requestedId}`);
+  if (response.status === 0) return proxyUnreachable(response.transportError);
+  if (response.status !== 200) return apiError(response.json, `failed to clear cooldown for ${requestedId}`, response.status);
   const cleared = response.json?.cleared === true;
   if (wantsJson) console.log(JSON.stringify({ ok: true, provider: name, id, cleared }, null, 2));
   else if (cleared) console.log(`${name}: cooldown lifted for ${requestedId}`);
@@ -680,8 +680,8 @@ export async function cmdPriority(args: string[], deps: AccountDeps): Promise<nu
   }
 
   const response = await apiJson(deps, baseUrl, "PUT", "/api/codex-auth/accounts/priority", { id, priority });
-  if (response.status === 0) return proxyUnreachable();
-  if (response.status !== 200) return apiError(response.json, `failed to set selection order for ${requestedId}`);
+  if (response.status === 0) return proxyUnreachable(response.transportError);
+  if (response.status !== 200) return apiError(response.json, `failed to set selection order for ${requestedId}`, response.status);
   const applied = typeof response.json.priority === "number" ? response.json.priority : (priority ?? 0);
   if (wantsJson) {
     console.log(JSON.stringify(
@@ -728,8 +728,8 @@ export async function cmdAlias(args: string[], deps: AccountDeps): Promise<numbe
       ? { provider: name, accountId: id, alias }
       : { name, id, alias };
   const response = await apiJson(deps, baseUrl, "PUT", path, body);
-  if (response.status === 0) return proxyUnreachable();
-  if (response.status !== 200) return apiError(response.json, `failed to rename ${requestedId}`);
+  if (response.status === 0) return proxyUnreachable(response.transportError);
+  if (response.status !== 200) return apiError(response.json, `failed to rename ${requestedId}`, response.status);
   const result = { ok: true, provider: name, id, alias: alias || null };
   if (wantsJson) console.log(JSON.stringify(result, null, 2));
   else console.log(alias ? `${name}: ${requestedId} is now “${alias}”` : `${name}: cleared alias for ${requestedId}`);

--- a/src/cli/account-extended.ts
+++ b/src/cli/account-extended.ts
@@ -232,8 +232,8 @@ function configAndType(deps: AccountDeps, name: string) {
 }
 
 function familyFailure(result: FamilyRows, fallback: string): number | null {
-  if (result.networkDown) return proxyUnreachable();
-  if (result.errorJson) return apiError(result.errorJson, fallback, result.status);
+  if (result.networkDown) return proxyUnreachable(result.transportError);
+  if (result.errorJson) return apiError(result.errorJson, fallback, result.status ?? 1);
   return null;
 }
 
@@ -325,7 +325,7 @@ export async function cmdRefresh(args: string[], deps: AccountDeps): Promise<num
   if (!baseUrl) return proxyUnreachable();
   if (classified.type !== "codex") {
     const result = await fetchProviderQuotaReport(deps, baseUrl, name);
-    if (result.status === 0) return proxyUnreachable();
+    if (result.status === 0) return proxyUnreachable(result.transportError);
     if (result.status !== 200) return apiError(result.errorJson ?? {}, `failed to refresh ${name}`, result.status);
     if (wantsJson) console.log(JSON.stringify({ provider: name, report: result.report }, null, 2));
     else console.log(result.report ? providerQuotaLine(name, result.report) : `no quota report available for ${name}`);
@@ -536,7 +536,7 @@ export async function cmdImport(args: string[], deps: AccountDeps): Promise<numb
     clearTimeout(timer);
   }
   if (response.status === 0) {
-    if (!timedOut) return proxyUnreachable();
+    if (!timedOut) return proxyUnreachable(response.transportError);
     console.error(`Error: import_timeout after ${importTimeoutMs}ms`);
     return 1;
   }

--- a/src/cli/account-main.ts
+++ b/src/cli/account-main.ts
@@ -190,8 +190,8 @@ export async function cmdNativeMainAccount(args: string[], deps: AccountDeps): P
     if (args.length > 0 || confirmed || rollback) return reject(args);
     const path = sub === "doctor" ? "/api/native-main-profiles/doctor" : "/api/native-main-profiles";
     const result = await apiJson(deps, baseUrl, "GET", path);
-    if (result.status === 0) return proxyUnreachable();
-    if (result.status !== 200) return apiError(result.json, `failed to ${sub} native profiles`);
+    if (result.status === 0) return proxyUnreachable(result.transportError);
+    if (result.status !== 200) return apiError(result.json, `failed to ${sub} native profiles`, result.status);
     if (wantsJson || sub === "doctor") console.log(JSON.stringify(result.json, null, 2));
     else printProfiles(Array.isArray(result.json.profiles) ? result.json.profiles as PublicProfile[] : []);
     return 0;
@@ -201,8 +201,8 @@ export async function cmdNativeMainAccount(args: string[], deps: AccountDeps): P
     const label = args.shift();
     if (!label || args.length > 0 || confirmed || rollback) return reject(args);
     const result = await apiJson(deps, baseUrl, "POST", "/api/native-main-profiles/register", { label });
-    if (result.status === 0) return proxyUnreachable();
-    if (result.status !== 200) return apiError(result.json, "failed to register the current native login");
+    if (result.status === 0) return proxyUnreachable(result.transportError);
+    if (result.status !== 200) return apiError(result.json, "failed to register the current native login", result.status);
     if (wantsJson) console.log(JSON.stringify(result.json, null, 2));
     else console.log(`Registered '${label}' for ${effectiveCodexHome(result.json)}.`);
     return 0;
@@ -212,8 +212,8 @@ export async function cmdNativeMainAccount(args: string[], deps: AccountDeps): P
     const label = args.shift();
     if (!label || args.length > 0 || wantsJson || confirmed || rollback) return reject(args);
     const stage = await apiJson(deps, baseUrl, "POST", "/api/native-main-profiles/stage", {});
-    if (stage.status === 0) return proxyUnreachable();
-    if (stage.status !== 200) return apiError(stage.json, "failed to prepare native login staging");
+    if (stage.status === 0) return proxyUnreachable(stage.transportError);
+    if (stage.status !== 200) return apiError(stage.json, "failed to prepare native login staging", stage.status);
     const stageId = typeof stage.json.stageId === "string" ? stage.json.stageId : "";
     const writerToken = typeof stage.json.writerToken === "string" ? stage.json.writerToken : "";
     const stagingHome = typeof stage.json.stagingCodexHome === "string" ? stage.json.stagingCodexHome : "";
@@ -258,8 +258,8 @@ export async function cmdNativeMainAccount(args: string[], deps: AccountDeps): P
       if (leaseLost) throw new Error("The native-login staging lease was lost before login completed.");
       if (exitCode !== 0) throw new Error("Official Codex login did not complete successfully.");
       const finish = await apiJson(deps, baseUrl, "POST", "/api/native-main-profiles/stage/finish", { stageId, writerToken, label });
-      if (finish.status === 0) return proxyUnreachable();
-      if (finish.status !== 200) return apiError(finish.json, "failed to encrypt the staged native login");
+      if (finish.status === 0) return proxyUnreachable(finish.transportError);
+      if (finish.status !== 200) return apiError(finish.json, "failed to encrypt the staged native login", finish.status);
       finished = true;
       console.log(`Added encrypted native profile '${label}' for ${effectiveCodexHome(finish.json)}.`);
       return 0;
@@ -283,8 +283,8 @@ export async function cmdNativeMainAccount(args: string[], deps: AccountDeps): P
       return reject(args);
     }
     const result = await apiJson(deps, baseUrl, "POST", "/api/native-main-profiles/switch", { target, confirmedStopped: true });
-    if (result.status === 0) return proxyUnreachable();
-    if (result.status !== 200) return apiError(result.json, "failed to switch the native login");
+    if (result.status === 0) return proxyUnreachable(result.transportError);
+    if (result.status !== 200) return apiError(result.json, "failed to switch the native login", result.status);
     if (wantsJson) console.log(JSON.stringify(result.json, null, 2));
     else {
       const profile = result.json.activeProfile as PublicProfile | undefined;
@@ -301,8 +301,8 @@ export async function cmdNativeMainAccount(args: string[], deps: AccountDeps): P
     const result = await apiJson(deps, baseUrl, "POST", "/api/native-main-profiles/recover", rollback
       ? { rollback: true, confirmedStopped: true }
       : { rollback: false });
-    if (result.status === 0) return proxyUnreachable();
-    if (result.status !== 200) return apiError(result.json, "failed to recover the native-profile transaction");
+    if (result.status === 0) return proxyUnreachable(result.transportError);
+    if (result.status !== 200) return apiError(result.json, "failed to recover the native-profile transaction", result.status);
     if (wantsJson) console.log(JSON.stringify(result.json, null, 2));
     else {
       const home = effectiveCodexHome(result.json);

--- a/src/cli/account.ts
+++ b/src/cli/account.ts
@@ -164,9 +164,9 @@ async function cmdList(rest: string[], deps: AccountDeps): Promise<number> {
   const notes: string[] = [];
   for (const t of targets) {
     const r = await fetchRows(deps, baseUrl, t.name, t.type, wantsQuota ? { refresh: refreshQuota } : undefined);
-    if (r.networkDown) return proxyUnreachable();
+    if (r.networkDown) return proxyUnreachable(r.transportError);
     if (r.errorJson) {
-      if (name) return apiError(r.errorJson, `failed to list ${t.name}`, r.status);
+      if (name) return apiError(r.errorJson, `failed to list ${t.name}`, r.status ?? 1);
       const errorText = typeof r.errorJson.error === "string" ? r.errorJson.error : "";
       const skipUnknownKey = t.type === "api-key"
         && r.status === 404
@@ -176,7 +176,7 @@ async function cmdList(rest: string[], deps: AccountDeps): Promise<number> {
         && r.status === 400
         && errorText.includes("unknown oauth provider");
       if (skipUnknownKey || skipConfigOAuth) continue;
-      return apiError(r.errorJson, `failed to list ${t.name}`, r.status);
+      return apiError(r.errorJson, `failed to list ${t.name}`, r.status ?? 1);
     }
     if (r.rows.length === 0) {
       if (showAll) notes.push(`${t.name}: no stored accounts or keys`);
@@ -222,8 +222,8 @@ async function cmdCurrent(rest: string[], deps: AccountDeps): Promise<number> {
   const baseUrl = await resolveBaseUrl(deps);
   if (!baseUrl) return proxyUnreachable();
   const r = await fetchRows(deps, baseUrl, name, c.type);
-  if (r.networkDown) return proxyUnreachable();
-  if (r.errorJson) return apiError(r.errorJson, `failed to read ${name}`, r.status);
+  if (r.networkDown) return proxyUnreachable(r.transportError);
+  if (r.errorJson) return apiError(r.errorJson, `failed to read ${name}`, r.status ?? 1);
 
   const activeRow = r.rows.find(row => row.active) ?? null;
   if (wantsJson) {

--- a/src/cli/account.ts
+++ b/src/cli/account.ts
@@ -150,8 +150,8 @@ async function cmdList(rest: string[], deps: AccountDeps): Promise<number> {
     };
     push("openai", "codex");
     const providersRes = await apiJson(deps, baseUrl, "GET", "/api/oauth/providers");
-    if (providersRes.status === 0) return proxyUnreachable();
-    if (providersRes.status !== 200) return apiError(providersRes.json, "failed to list OAuth providers");
+    if (providersRes.status === 0) return proxyUnreachable(providersRes.transportError);
+    if (providersRes.status !== 200) return apiError(providersRes.json, "failed to list OAuth providers", providersRes.status);
     if (Array.isArray(providersRes.json.providers)) {
       for (const p of providersRes.json.providers) {
         if (typeof p === "string") push(p, "live-oauth-list");
@@ -166,7 +166,7 @@ async function cmdList(rest: string[], deps: AccountDeps): Promise<number> {
     const r = await fetchRows(deps, baseUrl, t.name, t.type, wantsQuota ? { refresh: refreshQuota } : undefined);
     if (r.networkDown) return proxyUnreachable();
     if (r.errorJson) {
-      if (name) return apiError(r.errorJson, `failed to list ${t.name}`);
+      if (name) return apiError(r.errorJson, `failed to list ${t.name}`, r.status);
       const errorText = typeof r.errorJson.error === "string" ? r.errorJson.error : "";
       const skipUnknownKey = t.type === "api-key"
         && r.status === 404
@@ -176,7 +176,7 @@ async function cmdList(rest: string[], deps: AccountDeps): Promise<number> {
         && r.status === 400
         && errorText.includes("unknown oauth provider");
       if (skipUnknownKey || skipConfigOAuth) continue;
-      return apiError(r.errorJson, `failed to list ${t.name}`);
+      return apiError(r.errorJson, `failed to list ${t.name}`, r.status);
     }
     if (r.rows.length === 0) {
       if (showAll) notes.push(`${t.name}: no stored accounts or keys`);
@@ -223,7 +223,7 @@ async function cmdCurrent(rest: string[], deps: AccountDeps): Promise<number> {
   if (!baseUrl) return proxyUnreachable();
   const r = await fetchRows(deps, baseUrl, name, c.type);
   if (r.networkDown) return proxyUnreachable();
-  if (r.errorJson) return apiError(r.errorJson, `failed to read ${name}`);
+  if (r.errorJson) return apiError(r.errorJson, `failed to read ${name}`, r.status);
 
   const activeRow = r.rows.find(row => row.active) ?? null;
   if (wantsJson) {
@@ -277,8 +277,8 @@ async function cmdUse(rest: string[], deps: AccountDeps): Promise<number> {
     activeId = id;
     res = await apiJson(deps, baseUrl, "PUT", "/api/providers/keys/active", { name, id });
   }
-  if (res.status === 0) return proxyUnreachable();
-  if (res.status !== 200) return apiError(res.json, `failed to switch ${name}`);
+  if (res.status === 0) return proxyUnreachable(res.transportError);
+  if (res.status !== 200) return apiError(res.json, `failed to switch ${name}`, res.status);
 
   if (wantsJson) console.log(JSON.stringify({ ok: true, provider: name, type: c.type, activeId }, null, 2));
   else console.log(`${name}: active ${c.type === "api-key" ? "key" : "account"} is now ${displayId(activeId)}`);

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -419,7 +419,11 @@ const commandRunners: Record<string, CommandRunner> = {
   provider: async deps => {
     const { handleProviderCommand } = await import("./provider");
     await handleProviderCommand(deps.args.slice(1));
-    return 0;
+    // handleProviderCommand reports failure through process.exitCode, which it sets
+    // from handleProviderRuntimeCommand. Returning a literal 0 here made index.ts
+    // call process.exit(0) and erase it, so `ocx provider quota` against a stopped
+    // proxy printed an error and still exited 0 (#2697).
+    return Number(process.exitCode ?? 0);
   },
   account: async deps => {
     const { cmdAccount } = await import("./account");
@@ -428,7 +432,9 @@ const commandRunners: Record<string, CommandRunner> = {
   models: async deps => {
     const { handleModels } = await import("./models");
     await handleModels(deps.args.slice(1));
-    return 0;
+    // Same as the provider runner above: handleModels sets process.exitCode from
+    // handleModelsRuntimeCommand, and a literal 0 discarded it (#2697).
+    return Number(process.exitCode ?? 0);
   },
   alias: async deps => {
     const { handleAliasCommand } = await import("./alias");

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -418,6 +418,9 @@ const commandRunners: Record<string, CommandRunner> = {
   },
   provider: async deps => {
     const { handleProviderCommand } = await import("./provider");
+    // Reset first, like the service runner below: reading process.exitCode only
+    // reports THIS command's outcome if nothing earlier in the process set it.
+    process.exitCode = 0;
     await handleProviderCommand(deps.args.slice(1));
     // handleProviderCommand reports failure through process.exitCode, which it sets
     // from handleProviderRuntimeCommand. Returning a literal 0 here made index.ts
@@ -431,6 +434,7 @@ const commandRunners: Record<string, CommandRunner> = {
   },
   models: async deps => {
     const { handleModels } = await import("./models");
+    process.exitCode = 0;
     await handleModels(deps.args.slice(1));
     // Same as the provider runner above: handleModels sets process.exitCode from
     // handleModelsRuntimeCommand, and a literal 0 discarded it (#2697).

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -315,8 +315,12 @@ const commandRunners: Record<string, CommandRunner> = {
   },
   tray: async deps => {
     const { windowsTrayCommand } = await import("../tray/windows");
+    // windowsTrayCommand reports failure through process.exitCode (tray/windows.ts sets
+    // it for bad usage and for a failed install/start/stop/uninstall) and returns void,
+    // so a literal 0 here made `ocx tray install` print an error and exit 0 (#2697).
+    process.exitCode = 0;
     await windowsTrayCommand(deps.args.slice(1));
-    return 0;
+    return Number(process.exitCode ?? 0);
   },
   "codex-shim": async deps => {
     const { codexShimStatus, diagnoseCodexShim, installCodexShim, uninstallCodexShim } = await import("../codex/shim");

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -159,7 +159,9 @@ export function dataPlaneCredentialCollisionCheck(env: NodeJS.ProcessEnv = proce
   if (!dataPlane) {
     return { level: "OK", message: "No data-plane token is set, so it cannot collide with the management token." };
   }
-  const admin = configuredAdminToken();
+  // Pass the env seam through: reading process.env here while the caller injected a
+  // different env made half the comparison depend on real machine state.
+  const admin = configuredAdminToken(getConfigDir(), env);
   const collides = dataPlane.startsWith("ocx_admin_") || (admin !== null && dataPlane === admin);
   if (!collides) {
     return { level: "OK", message: "Data-plane and management credentials are distinct." };

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -59,7 +59,16 @@ import {
 } from "../server/local-management-read-client";
 export { resolveCodexHomeDir } from "../codex/home";
 
-export type OAuthDoctorCheck = { level: "OK" | "WARN"; message: string };
+/**
+ * `FAIL` exists for a condition that makes the surface unusable rather than degraded.
+ * A review of the #2696 work pointed out that reporting a fully fenced management plane
+ * — every `/api/*` returning 503 — at the same level as a directory-permission note
+ * misleads the reader about severity.
+ *
+ * Doctor's own exit code still belongs to the uniform contract in wp3b (devlog 025);
+ * this type only fixes what the operator is told.
+ */
+export type OAuthDoctorCheck = { level: "OK" | "WARN" | "FAIL"; message: string };
 
 function pathIsWritable(path: string): boolean {
   try {
@@ -167,7 +176,9 @@ export function dataPlaneCredentialCollisionCheck(env: NodeJS.ProcessEnv = proce
     return { level: "OK", message: "Data-plane and management credentials are distinct." };
   }
   return {
-    level: "WARN",
+    // Not a degradation: while this holds, every /api/* returns 503 and no ocx
+    // management command can work at all.
+    level: "FAIL",
     message:
       "OPENCODEX_API_AUTH_TOKEN holds the management (admin) token, so the proxy fences the "
       + "whole management API closed and every ocx management command fails with 503. "

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -16,7 +16,8 @@ import { findLiveProxy, type LiveProxy } from "../server/proxy-liveness";
 import { BUN_RUNTIME_SOURCES } from "../lib/bun-runtime";
 import type { BunRuntimeSource } from "../lib/bun-runtime";
 import { maskAccountId } from "../lib/privacy";
-import { configuredAdminToken } from "../lib/admin-secrets";
+import { tokenCollidesWithAdmin } from "../lib/admin-secrets";
+import { readInstalledServiceToken } from "../lib/service-secrets";
 import { PROXY_ENV_KEYS, proxyEnvPresent } from "../lib/proxy-env";
 import { LOCAL_MANAGEMENT_READ_PATHS } from "../lib/local-management-capability";
 import { readCodexTokens } from "../codex/auth-collision";
@@ -163,16 +164,19 @@ function describeDoctorHealth(entry: OAuthHealthEntry): string {
  * Observe-only, like the rest of doctor: it compares shapes and never prints, logs, or
  * returns a credential value.
  */
-export function dataPlaneCredentialCollisionCheck(env: NodeJS.ProcessEnv = process.env): OAuthDoctorCheck {
-  const dataPlane = env.OPENCODEX_API_AUTH_TOKEN?.trim();
+export function dataPlaneCredentialCollisionCheck(
+  env: NodeJS.ProcessEnv = process.env,
+  installedServiceToken: string | null = readInstalledServiceToken(),
+): OAuthDoctorCheck {
+  const dataPlane = env.OPENCODEX_API_AUTH_TOKEN?.trim() || installedServiceToken?.trim() || "";
   if (!dataPlane) {
     return { level: "OK", message: "No data-plane token is set, so it cannot collide with the management token." };
   }
-  // Pass the env seam through: reading process.env here while the caller injected a
-  // different env made half the comparison depend on real machine state.
-  const admin = configuredAdminToken(getConfigDir(), env);
-  const collides = dataPlane.startsWith("ocx_admin_") || (admin !== null && dataPlane === admin);
-  if (!collides) {
+  // Same comparison as assertNotAdminToken: minted prefix or configuredAdminToken
+  // (env or admin-api-token file). The file token is the one the service wrapper
+  // actually exports; inspecting only the doctor process env reported OK on every
+  // already-broken install (#2696).
+  if (!tokenCollidesWithAdmin(dataPlane, env)) {
     return { level: "OK", message: "Data-plane and management credentials are distinct." };
   }
   return {
@@ -180,10 +184,11 @@ export function dataPlaneCredentialCollisionCheck(env: NodeJS.ProcessEnv = proce
     // management command can work at all.
     level: "FAIL",
     message:
-      "OPENCODEX_API_AUTH_TOKEN holds the management (admin) token, so the proxy fences the "
-      + "whole management API closed and every ocx management command fails with 503. "
-      + "Action: unset OPENCODEX_API_AUTH_TOKEN (or set it to a distinct data-plane key), "
-      + "then re-run `ocx service install` and restart the proxy",
+      "The data-plane secret (OPENCODEX_API_AUTH_TOKEN or the service token file) holds the "
+      + "management (admin) token, so the proxy fences the whole management API closed and "
+      + "every ocx management command fails with 503. "
+      + "Action: unset OPENCODEX_API_AUTH_TOKEN, replace the service token file with a distinct "
+      + "data-plane key, then re-run `ocx service install` and restart the proxy",
   };
 }
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -16,6 +16,7 @@ import { findLiveProxy, type LiveProxy } from "../server/proxy-liveness";
 import { BUN_RUNTIME_SOURCES } from "../lib/bun-runtime";
 import type { BunRuntimeSource } from "../lib/bun-runtime";
 import { maskAccountId } from "../lib/privacy";
+import { configuredAdminToken } from "../lib/admin-secrets";
 import { PROXY_ENV_KEYS, proxyEnvPresent } from "../lib/proxy-env";
 import { LOCAL_MANAGEMENT_READ_PATHS } from "../lib/local-management-capability";
 import { readCodexTokens } from "../codex/auth-collision";
@@ -138,6 +139,42 @@ function describeDoctorHealth(entry: OAuthHealthEntry): string {
 }
 
 /**
+ * Detect the management/data-plane credential collision behind #2696.
+ *
+ * The service exports the service token file as `OPENCODEX_API_AUTH_TOKEN` before
+ * starting the proxy. When that value is the admin token, the server treats the
+ * management credential as a data-plane admission secret and fences the ENTIRE
+ * management plane closed at boot: every `/api/*` returns 503, including on a loopback
+ * install that never needed a data-plane secret.
+ *
+ * `assertNotAdminToken` in src/service.ts now refuses to create this state, but an
+ * install made before that guard existed is already broken on disk, and the symptom
+ * (every management command failing) points nowhere. This is the check that names it.
+ *
+ * Observe-only, like the rest of doctor: it compares shapes and never prints, logs, or
+ * returns a credential value.
+ */
+export function dataPlaneCredentialCollisionCheck(env: NodeJS.ProcessEnv = process.env): OAuthDoctorCheck {
+  const dataPlane = env.OPENCODEX_API_AUTH_TOKEN?.trim();
+  if (!dataPlane) {
+    return { level: "OK", message: "No data-plane token is set, so it cannot collide with the management token." };
+  }
+  const admin = configuredAdminToken();
+  const collides = dataPlane.startsWith("ocx_admin_") || (admin !== null && dataPlane === admin);
+  if (!collides) {
+    return { level: "OK", message: "Data-plane and management credentials are distinct." };
+  }
+  return {
+    level: "WARN",
+    message:
+      "OPENCODEX_API_AUTH_TOKEN holds the management (admin) token, so the proxy fences the "
+      + "whole management API closed and every ocx management command fails with 503. "
+      + "Action: unset OPENCODEX_API_AUTH_TOKEN (or set it to a distinct data-plane key), "
+      + "then re-run `ocx service install` and restart the proxy",
+  };
+}
+
+/**
  * OAuth reliability checks for `ocx doctor`. Observe-only: never mutates
  * credentials, locks, or networking. Every WARN includes a recovery Action.
  */
@@ -146,6 +183,8 @@ export async function collectOAuthDoctorChecks(
   deps: Parameters<typeof collectOAuthHealthEntriesForCli>[1] = {},
 ): Promise<OAuthDoctorCheck[]> {
   const checks: OAuthDoctorCheck[] = [];
+
+  checks.push(dataPlaneCredentialCollisionCheck());
 
   if (isOAuthCredentialStorageWritable()) {
     checks.push({ level: "OK", message: "OAuth credential storage directory is writable for atomic auth.json updates." });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -45,7 +45,7 @@ import { runReady, type ReadyArgs } from "./ready";
 import { runCli } from "./root";
 import { ProxyOwnershipRefusedError, stopProxy } from "../lib/process-control";
 import { loadServiceTokenFromFile } from "../lib/service-secrets";
-import { diagnoseService, isServiceOwnershipError, serviceCommand, serviceEnvironmentOwnedHere, serviceStartableFromTray, serviceStatusSummary, stopServiceIfInstalled, uninstallServiceIfInstalled } from "../service";
+import { assertNotAdminToken, diagnoseService, isServiceOwnershipError, serviceCommand, serviceEnvironmentOwnedHere, serviceStartableFromTray, serviceStatusSummary, stopServiceIfInstalled, uninstallServiceIfInstalled } from "../service";
 import { formatStartupRoutingDetail, startupHealthSummary } from "../codex/autostart-health";
 import { drainAndShutdown, isRecyclingForExit, startServer } from "../server";
 import { injectSystemEnv, reconcileShellHook, revertSystemEnv, uninstallShellHook } from "../server/system-env";
@@ -223,6 +223,11 @@ async function handleStart(options: { block?: boolean } = {}) {
   // auth path reads OPENCODEX_API_AUTH_TOKEN from the environment.
   const serviceToken = loadServiceTokenFromFile(process.env);
   if (serviceToken) process.env.OPENCODEX_API_AUTH_TOKEN = serviceToken;
+  // The service wrapper (and WinSW via OCX_API_TOKEN_FILE) can still export a colliding
+  // token that install now refuses to write. Refuse it here too, before bind, so an
+  // already-broken file cannot fence /api/* closed at boot (#2696).
+  const present = process.env.OPENCODEX_API_AUTH_TOKEN?.trim();
+  if (present) assertNotAdminToken(present);
   const requestedPort = parsePortOption();
   const owner = await findProxyOwnerBeforeJournalRecovery();
   if (owner.live) {

--- a/src/cli/runtime-api.ts
+++ b/src/cli/runtime-api.ts
@@ -47,15 +47,37 @@ export async function runtimeBaseUrl(deps: RuntimeApiDeps = {}): Promise<string>
   return `http://${probeHostname(live.hostname)}:${live.port}`;
 }
 
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/**
+ * Compose the operator-facing message from a management error body.
+ *
+ * The server states WHY a request was refused under `reason` and WHAT TO DO under
+ * `hint` (see management-auth.ts, which sets both on a 503 when the management plane
+ * is unavailable). Both were dropped here, so a fenced management plane was
+ * indistinguishable from a generic failure and an operator had no way to tell a port
+ * collision from an ACL refusal from a stopped proxy (#2698).
+ */
 function responseMessage(body: unknown, status: number): string {
-  if (body && typeof body === "object") {
-    const record = body as Record<string, unknown>;
-    for (const key of ["error", "message", "detail"]) {
-      if (typeof record[key] === "string" && record[key]) return record[key];
-    }
-  }
   if (typeof body === "string" && body.trim()) return body.trim().slice(0, 400);
-  return `Management request failed (${status})`;
+  if (!body || typeof body !== "object") return `Management request failed (${status})`;
+  const record = body as Record<string, unknown>;
+  let primary: string | undefined;
+  for (const key of ["error", "message", "detail"]) {
+    primary = stringField(record, key);
+    if (primary) break;
+  }
+  const parts = [primary ?? `Management request failed (${status})`];
+  const reason = stringField(record, "reason");
+  // A body of {ok:false, reason:"…"} with no `error` key used to degrade to the
+  // generic line, discarding the only actionable field.
+  if (reason && reason !== primary) parts.push(`reason: ${reason}`);
+  const hint = stringField(record, "hint");
+  if (hint && hint !== primary) parts.push(`hint: ${hint}`);
+  return parts.join("\n").slice(0, 1200);
 }
 
 export async function runtimeRequest<T = unknown>(

--- a/src/lib/admin-secrets.ts
+++ b/src/lib/admin-secrets.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import { lstatSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { getConfigDir } from "../config";
@@ -22,4 +23,27 @@ export function loadAdminTokenFromFile(configDir = getConfigDir()): string | nul
 
 export function configuredAdminToken(configDir = getConfigDir(), env: NodeJS.ProcessEnv = process.env): string | null {
   return env.OPENCODEX_ADMIN_AUTH_TOKEN?.trim() || loadAdminTokenFromFile(configDir);
+}
+
+export const ADMIN_TOKEN_PREFIX = "ocx_admin_";
+
+function secretTextEquals(left: string, right: string): boolean {
+  const a = Buffer.from(left);
+  const b = Buffer.from(right);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+/**
+ * True when `token` is a management credential: minted `ocx_admin_…` shape, or
+ * byte-equal to the configured admin token (env or admin-api-token file).
+ * Used by the service write/start chokepoint and by doctor so the two cannot drift.
+ */
+export function tokenCollidesWithAdmin(
+  token: string,
+  env: NodeJS.ProcessEnv = process.env,
+  configDir = getConfigDir(),
+): boolean {
+  if (token.startsWith(ADMIN_TOKEN_PREFIX)) return true;
+  const admin = configuredAdminToken(configDir, env);
+  return admin !== null && secretTextEquals(token, admin);
 }

--- a/src/lib/service-secrets.ts
+++ b/src/lib/service-secrets.ts
@@ -23,3 +23,18 @@ export function loadServiceTokenFromFile(env: Record<string, string | undefined>
     return null;
   }
 }
+
+/**
+ * Contents of the installed service token file. The launch wrapper always re-exports
+ * this file as OPENCODEX_API_AUTH_TOKEN, so doctor and start must inspect it even
+ * when the calling shell has no data-plane env var.
+ * Returns the token or null — never throws, never logs the value.
+ */
+export function readInstalledServiceToken(): string | null {
+  try {
+    const token = readFileSync(serviceApiTokenFilePath(), "utf8").trim();
+    return token || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/service.ts
+++ b/src/service.ts
@@ -366,8 +366,39 @@ export function serviceRetryCommand(
   return diag.installed && !diag.conflict ? "ocx service repair" : "ocx service install";
 }
 
+const ADMIN_TOKEN_PREFIX = "ocx_admin_";
+
+/**
+ * Refuse a management (admin) token as the data-plane secret.
+ *
+ * The service exports the contents of the service token file as
+ * `OPENCODEX_API_AUTH_TOKEN` before starting the proxy. When that value is the admin
+ * token, the server treats the management credential as a data-plane admission secret
+ * and fails the ENTIRE management plane closed at boot, so every `/api/*` request
+ * returns 503 — even on a loopback install that never needed a data-plane secret.
+ * Exporting the admin token in the CLI cannot recover it, because the fence is decided
+ * server-side at startup (#2696).
+ *
+ * Nothing in this codebase puts an admin token in that env var; it arrives from the
+ * installing shell. This function is the chokepoint that should refuse it rather than
+ * writing a file that produces a broken service.
+ */
+export function assertNotAdminToken(token: string): void {
+  if (!token.startsWith(ADMIN_TOKEN_PREFIX)) return;
+  throw new Error(
+    "OPENCODEX_API_AUTH_TOKEN holds a management (admin) token. The service exports it "
+      + "as the data-plane secret, which fences the whole management API closed and makes "
+      + "every ocx management command fail with 503. Unset OPENCODEX_API_AUTH_TOKEN, or set "
+      + "it to a distinct data-plane key, then rerun the install.",
+  );
+}
+
 export function assertServiceAuthEnvironment(): void {
   const config = loadConfig();
+  // Check the collision before the loopback short-circuit: a loopback install writes
+  // the token file too, so returning early here is what let the broken state through.
+  const present = process.env.OPENCODEX_API_AUTH_TOKEN?.trim();
+  if (present) assertNotAdminToken(present);
   if (isLoopbackHostname(config.hostname)) return;
   if (process.env.OPENCODEX_API_AUTH_TOKEN?.trim()) return;
   // Reached from `service repair` as well as `install`, so name a command that can
@@ -383,6 +414,9 @@ export function assertServiceAuthEnvironment(): void {
 function writeServiceApiTokenFile(): string | null {
   const token = process.env.OPENCODEX_API_AUTH_TOKEN?.trim();
   if (!token) return null;
+  // Last line of defence: every install/repair path funnels through here, so a
+  // collision cannot reach disk regardless of which caller ran (#2696).
+  assertNotAdminToken(token);
   const path = serviceApiTokenFilePath();
   const dir = getConfigDir();
   recordOwnedConfigPath(dir, path);

--- a/src/service.ts
+++ b/src/service.ts
@@ -19,6 +19,7 @@ import { BUN_RUNTIME_PATH_ENV, BUN_RUNTIME_SOURCE_ENV, durableBunRuntime } from 
 import type { BunRuntimeSource } from "./lib/bun-runtime";
 import { isProcessAlive, stopProxy } from "./lib/process-control";
 import { serviceApiTokenFilePath } from "./lib/service-secrets";
+import { tokenCollidesWithAdmin } from "./lib/admin-secrets";
 import { PROXY_ENV_KEYS } from "./lib/proxy-env";
 import { randomUUID } from "node:crypto";
 import {
@@ -366,8 +367,6 @@ export function serviceRetryCommand(
   return diag.installed && !diag.conflict ? "ocx service repair" : "ocx service install";
 }
 
-const ADMIN_TOKEN_PREFIX = "ocx_admin_";
-
 /**
  * Refuse a management (admin) token as the data-plane secret.
  *
@@ -381,14 +380,11 @@ const ADMIN_TOKEN_PREFIX = "ocx_admin_";
  *
  * Nothing in this codebase puts an admin token in that env var; it arrives from the
  * installing shell. This function is the chokepoint that should refuse it rather than
- * writing a file that produces a broken service.
+ * writing a file that produces a broken service. Comparison is the same helper doctor
+ * uses: minted `ocx_admin_…` prefix, or byte-equal to configuredAdminToken (env or file).
  */
 export function assertNotAdminToken(token: string, env: NodeJS.ProcessEnv = process.env): void {
-  // Prefix covers a minted management token; the equality arm covers an operator-set
-  // admin token that does not carry the prefix, which the prefix test alone would miss.
-  const admin = env.OPENCODEX_ADMIN_AUTH_TOKEN?.trim();
-  const collides = token.startsWith(ADMIN_TOKEN_PREFIX) || (Boolean(admin) && token === admin);
-  if (!collides) return;
+  if (!tokenCollidesWithAdmin(token, env)) return;
   throw new Error(
     "OPENCODEX_API_AUTH_TOKEN holds a management (admin) token. The service exports it "
       + "as the data-plane secret, which fences the whole management API closed and makes "

--- a/src/service.ts
+++ b/src/service.ts
@@ -383,8 +383,12 @@ const ADMIN_TOKEN_PREFIX = "ocx_admin_";
  * installing shell. This function is the chokepoint that should refuse it rather than
  * writing a file that produces a broken service.
  */
-export function assertNotAdminToken(token: string): void {
-  if (!token.startsWith(ADMIN_TOKEN_PREFIX)) return;
+export function assertNotAdminToken(token: string, env: NodeJS.ProcessEnv = process.env): void {
+  // Prefix covers a minted management token; the equality arm covers an operator-set
+  // admin token that does not carry the prefix, which the prefix test alone would miss.
+  const admin = env.OPENCODEX_ADMIN_AUTH_TOKEN?.trim();
+  const collides = token.startsWith(ADMIN_TOKEN_PREFIX) || (Boolean(admin) && token === admin);
+  if (!collides) return;
   throw new Error(
     "OPENCODEX_API_AUTH_TOKEN holds a management (admin) token. The service exports it "
       + "as the data-plane secret, which fences the whole management API closed and makes "

--- a/tests/cli-account.test.ts
+++ b/tests/cli-account.test.ts
@@ -550,10 +550,14 @@ describe("ocx account CLI (issue #180 matrix)", () => {
     expect(result.stderr).toContain("anthropic");
   });
 
-  test("9: an OAuth API 404 exits one and surfaces the server error", async () => {
+  test("9: an OAuth API 404 exits four and surfaces the server error", async () => {
     const result = await run(["use", "anthropic", "nope"]);
 
-    expect(result.code).toBe(1);
+    // 4 (not 1) since #2698 aligned the account client with the exit-code vocabulary
+    // runtime-api.ts already used: 2 usage, 4 not-found, 5 conflict, 1 otherwise. Before
+    // that, every account failure exited 1, so a script could not tell a missing account
+    // from a concurrent mutation or a dead proxy. Scripts testing `!== 0` are unaffected.
+    expect(result.code).toBe(4);
     expect(result.stderr).toContain("anthropic account nope was not found");
   });
 

--- a/tests/cli-native-profile.test.ts
+++ b/tests/cli-native-profile.test.ts
@@ -30,14 +30,14 @@ describe("ocx account main", () => {
     const errors: string[] = [];
     console.error = (...values: unknown[]) => errors.push(values.join(" "));
 
-    expect(apiError({ error: "validation failed" }, "fallback")).toBe(1);
-    expect(apiError({ error: "validation failed", cleanupRequired: "true" }, "fallback")).toBe(1);
+    expect(apiError({ error: "validation failed" }, "fallback", 500)).toBe(1);
+    expect(apiError({ error: "validation failed", cleanupRequired: "true" }, "fallback", 500)).toBe(1);
     expect(errors).toEqual([
       "Error: validation failed",
       "Error: validation failed",
     ]);
 
-    expect(apiError({ error: "validation failed", cleanupRequired: true }, "fallback")).toBe(1);
+    expect(apiError({ error: "validation failed", cleanupRequired: true }, "fallback", 500)).toBe(1);
     expect(errors.at(-1)).toBe("Warning: native-login staging cleanup is still required; run 'ocx account main doctor'.");
   });
 

--- a/tests/cli-native-profile.test.ts
+++ b/tests/cli-native-profile.test.ts
@@ -216,7 +216,11 @@ describe("ocx account main", () => {
       baseUrl: "http://127.0.0.1:10100",
       fetchImpl,
       runCodexLoginImpl: async () => 0,
-    })).toBe(1);
+      // 409 from `stage/finish` is a conflict, so the uniform exit vocabulary maps it to 5.
+      // This asserted 1 only because every account-family failure used to exit 1 regardless
+      // of status, which is the defect the 404->4 / 409->5 mapping fixed; the cancel-fallback
+      // behaviour this test actually covers is unchanged.
+    })).toBe(5);
     expect(requests).toEqual([
       "/api/native-main-profiles/stage",
       "/api/native-main-profiles/stage/heartbeat",

--- a/tests/cli-transport-honesty.test.ts
+++ b/tests/cli-transport-honesty.test.ts
@@ -167,9 +167,11 @@ describe("#2696 doctor names the credential collision", () => {
     expect(check.level).toBe("OK");
   });
 
-  test("warns and names the remedy when the admin token is the data-plane secret", () => {
+  test("fails and names the remedy when the admin token is the data-plane secret", () => {
     const check = dataPlaneCredentialCollisionCheck({ OPENCODEX_API_AUTH_TOKEN: ADMIN } as NodeJS.ProcessEnv);
-    expect(check.level).toBe("WARN");
+    // FAIL, not WARN: while this holds every /api/* returns 503, so the management
+    // surface is unusable rather than degraded.
+    expect(check.level).toBe("FAIL");
     expect(check.message).toContain("management (admin) token");
     expect(check.message).toContain("Action:");
     // Never echo the credential itself, even in a diagnostic.

--- a/tests/cli-transport-honesty.test.ts
+++ b/tests/cli-transport-honesty.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { RuntimeApiError, runtimeRequest } from "../src/cli/runtime-api";
+import { apiError, apiJson, proxyUnreachable } from "../src/cli/account-api";
+import { assertNotAdminToken, assertServiceAuthEnvironment } from "../src/service";
+import { dataPlaneCredentialCollisionCheck } from "../src/cli/doctor";
+import type { AccountDeps } from "../src/cli/account-api";
+
+/**
+ * wp2 (#2696 #2697 #2698): the CLI must not lie about a failed management call.
+ *
+ * Three defects made unattended operation impossible: a runner that discarded its
+ * handler's exit code, an error renderer that dropped the server's `reason`/`hint`,
+ * and a service installer that would happily write a management token into the
+ * data-plane secret and fence the whole management API closed.
+ */
+
+const DISPATCH_SOURCE = readFileSync(join(import.meta.dir, "..", "src", "cli", "dispatch.ts"), "utf8");
+
+/**
+ * Matches `await handleX(...); return 0;` — the shape that silently discards a
+ * handler's failure.
+ *
+ * `[^;]*` rather than `[^)]*` is deliberate and load-bearing: the argument lists here
+ * contain nested calls (`deps.args.slice(1)`), so a `[^)]*` form stops at the inner
+ * `)` and matches neither the provider nor the models runner — it would green while
+ * the regression it guards is present. The red-first test below proves this pattern
+ * actually sees the defect.
+ */
+const SWALLOWED_EXIT_CODE = /await\s+handle\w+\([^;]*\);\s*\n\s*return 0;/g;
+
+/**
+ * Runners whose handler cannot return a failure, so a literal 0 is honest.
+ *
+ * Both entries were found by this guard rather than assumed, and both are accurate for
+ * a specific reason: `handleDebugCommand` and `handleLogin` report every failure with
+ * `process.exit(1)` from inside the handler (debug.ts does so on 11 paths), so control
+ * only reaches `return 0` on success.
+ *
+ * That is a narrower claim than "these commands always succeed". `login` reporting
+ * success for a failed OAuth flow is a real gap, but it belongs to the uniform
+ * exit-code contract in wp3b (devlog 025), not to this phase's management-transport
+ * scope. Adding a name here must come with a reason of this kind.
+ */
+const CANNOT_FAIL_ALLOWLIST = new Set(["debug", "login"]);
+
+function swallowingRunners(source: string): string[] {
+  const found: string[] = [];
+  for (const match of source.matchAll(SWALLOWED_EXIT_CODE)) {
+    const before = source.slice(0, match.index ?? 0);
+    // The nearest preceding `name: async deps =>` is the runner that owns this body.
+    const runner = [...before.matchAll(/^\s{2}([a-z0-9-]+|"[^"]+"):\s*async/gm)].pop();
+    found.push(runner?.[1]?.replace(/"/g, "") ?? "<unknown>");
+  }
+  return found;
+}
+
+describe("#2697 dispatch runners preserve handler exit codes", () => {
+  test("the guard pattern matches the pre-fix shape (red-first)", () => {
+    // The exact bodies the fix removed. If this fails, the pattern below is vacuous
+    // and cannot protect anything.
+    const preFix = [
+      "  provider: async deps => {",
+      '    const { handleProviderCommand } = await import("./provider");',
+      "    await handleProviderCommand(deps.args.slice(1));",
+      "    return 0;",
+      "  },",
+    ].join("\n");
+    expect(preFix.match(SWALLOWED_EXIT_CODE)).not.toBeNull();
+  });
+
+  test("no runner discards a handler exit code outside the allowlist", () => {
+    const offenders = swallowingRunners(DISPATCH_SOURCE).filter(name => !CANNOT_FAIL_ALLOWLIST.has(name));
+    expect(offenders).toEqual([]);
+  });
+
+  test("provider and models return process.exitCode rather than a literal 0", () => {
+    for (const runner of ["provider", "models"]) {
+      const body = DISPATCH_SOURCE.split(new RegExp(`^  ${runner}: async`, "m"))[1] ?? "";
+      const upToNext = body.split(/^  [a-z]/m)[0] ?? "";
+      expect(upToNext, `${runner} runner must propagate process.exitCode`)
+        .toContain("Number(process.exitCode ?? 0)");
+    }
+  });
+});
+
+describe("#2696 doctor names the credential collision", () => {
+  const ADMIN = `ocx_admin_${"a".repeat(43)}`;
+
+  test("reports OK when no data-plane token is set", () => {
+    const check = dataPlaneCredentialCollisionCheck({} as NodeJS.ProcessEnv);
+    expect(check.level).toBe("OK");
+  });
+
+  test("reports OK when the two credentials are distinct", () => {
+    const check = dataPlaneCredentialCollisionCheck({ OPENCODEX_API_AUTH_TOKEN: "ocx_data_live" } as NodeJS.ProcessEnv);
+    expect(check.level).toBe("OK");
+  });
+
+  test("warns and names the remedy when the admin token is the data-plane secret", () => {
+    const check = dataPlaneCredentialCollisionCheck({ OPENCODEX_API_AUTH_TOKEN: ADMIN } as NodeJS.ProcessEnv);
+    expect(check.level).toBe("WARN");
+    expect(check.message).toContain("management (admin) token");
+    expect(check.message).toContain("Action:");
+    // Never echo the credential itself, even in a diagnostic.
+    expect(check.message).not.toContain(ADMIN);
+  });
+});
+
+describe("#2698 management errors carry reason and hint", () => {
+  async function messageFor(body: unknown, status: number): Promise<string> {
+    try {
+      await runtimeRequest("/api/config", {}, {
+        baseUrl: "http://127.0.0.1:10100",
+        fetchImpl: async () => Response.json(body, { status }),
+      });
+    } catch (error) {
+      if (error instanceof RuntimeApiError) return error.message;
+      throw error;
+    }
+    throw new Error("expected a RuntimeApiError");
+  }
+
+  test("a 503 renders the primary message, the reason and the hint", async () => {
+    const message = await messageFor(
+      {
+        error: "management API unavailable",
+        reason: "management credential conflicts with a data-plane credential",
+        hint: "unset OPENCODEX_API_AUTH_TOKEN and reinstall the service",
+      },
+      503,
+    );
+    expect(message).toContain("management API unavailable");
+    expect(message).toContain("reason: management credential conflicts with a data-plane credential");
+    expect(message).toContain("hint: unset OPENCODEX_API_AUTH_TOKEN and reinstall the service");
+  });
+
+  test("a reason-only body does not degrade to the generic message", async () => {
+    // Several routes return {ok:false, reason:"…"} with no error key at all.
+    const message = await messageFor({ ok: false, reason: "home_mismatch" }, 409);
+    expect(message).toContain("home_mismatch");
+  });
+
+  test("an opaque body still reports the status", async () => {
+    const message = await messageFor({ ok: false }, 500);
+    expect(message).toContain("500");
+  });
+
+  test("a reason identical to the primary message is not repeated", async () => {
+    const message = await messageFor({ error: "catalog_busy", reason: "catalog_busy" }, 503);
+    expect(message.match(/catalog_busy/g)).toHaveLength(1);
+  });
+});
+
+describe("#2698 the account client keeps the transport cause and maps status codes", () => {
+  const deps = { fetchImpl: async () => { throw new Error("connect ECONNREFUSED 127.0.0.1:10100"); } } as unknown as AccountDeps;
+
+  test("a transport failure reports status 0 and retains the cause", async () => {
+    const result = await apiJson(deps, "http://127.0.0.1:10100", "GET", "/api/codex-auth/accounts");
+    expect(result.status).toBe(0);
+    expect(result.transportError).toContain("ECONNREFUSED");
+  });
+
+  test("apiError maps 404 to 4 and 409 to 5, matching the runtime client", () => {
+    expect(apiError({ error: "no such account" }, "fallback", 404)).toBe(4);
+    expect(apiError({ error: "busy" }, "fallback", 409)).toBe(5);
+    expect(apiError({ error: "boom" }, "fallback", 500)).toBe(1);
+    // Callers that pass no status keep the previous behavior.
+    expect(apiError({ error: "boom" }, "fallback")).toBe(1);
+  });
+
+  test("proxyUnreachable surfaces the transport cause when given one", () => {
+    expect(proxyUnreachable("connect ECONNREFUSED")).toBe(1);
+    expect(proxyUnreachable()).toBe(1);
+  });
+});
+
+describe("#2696 a management token is refused as the data-plane secret", () => {
+  const ADMIN = `ocx_admin_${"a".repeat(43)}`;
+
+  test("assertNotAdminToken rejects an ocx_admin_ value with an actionable message", () => {
+    expect(() => assertNotAdminToken(ADMIN)).toThrow(/management \(admin\) token/);
+    expect(() => assertNotAdminToken(ADMIN)).toThrow(/OPENCODEX_API_AUTH_TOKEN/);
+  });
+
+  test("assertNotAdminToken accepts a distinct data-plane secret", () => {
+    expect(() => assertNotAdminToken("ocx_data_live_secret")).not.toThrow();
+    expect(() => assertNotAdminToken("local-secret")).not.toThrow();
+  });
+
+  test("assertServiceAuthEnvironment refuses the collision even on loopback", () => {
+    // The loopback short-circuit used to return before any token check, which is how
+    // an install could produce a service whose management plane was fenced closed.
+    const previous = process.env.OPENCODEX_API_AUTH_TOKEN;
+    try {
+      process.env.OPENCODEX_API_AUTH_TOKEN = ADMIN;
+      expect(() => assertServiceAuthEnvironment()).toThrow(/management \(admin\) token/);
+    } finally {
+      if (previous === undefined) delete process.env.OPENCODEX_API_AUTH_TOKEN;
+      else process.env.OPENCODEX_API_AUTH_TOKEN = previous;
+    }
+  });
+});

--- a/tests/cli-transport-honesty.test.ts
+++ b/tests/cli-transport-honesty.test.ts
@@ -19,31 +19,63 @@ import type { AccountDeps } from "../src/cli/account-api";
 const DISPATCH_SOURCE = readFileSync(join(import.meta.dir, "..", "src", "cli", "dispatch.ts"), "utf8");
 
 /**
- * Matches `await handleX(...); return 0;` — the shape that silently discards a
+ * Matches `await someHandler(...); return 0;` — the shape that silently discards a
  * handler's failure.
  *
- * `[^;]*` rather than `[^)]*` is deliberate and load-bearing: the argument lists here
- * contain nested calls (`deps.args.slice(1)`), so a `[^)]*` form stops at the inner
- * `)` and matches neither the provider nor the models runner — it would green while
- * the regression it guards is present. The red-first test below proves this pattern
- * actually sees the defect.
+ * Two scoping decisions, both learned from a review that caught this test being too
+ * narrow:
+ *
+ * - `[^;]*` rather than `[^)]*`: argument lists here contain nested calls
+ *   (`deps.args.slice(1)`), so a `[^)]*` form stops at the inner `)` and matches
+ *   neither the provider nor the models runner. It would have greened while the
+ *   regression it guards was present.
+ * - `[\w.]+` rather than `handle\w+`: anchoring on the `handle*` naming convention made
+ *   the guard blind to `tray`, whose handler is `windowsTrayCommand` and which carried
+ *   the identical defect. The defect class is "await a handler, then return a literal
+ *   0", not "await a function whose name begins with handle".
+ *
+ * Exemptions belong in the allowlist below, where they need a stated reason — not in
+ * the pattern, where they would be invisible.
  */
-const SWALLOWED_EXIT_CODE = /await\s+handle\w+\([^;]*\);\s*\n\s*return 0;/g;
+const SWALLOWED_EXIT_CODE = /await\s+[\w.]+\([^;]*\);\s*\n\s*return 0;/g;
 
 /**
- * Runners whose handler cannot return a failure, so a literal 0 is honest.
+ * Runners whose handler cannot return a failure through `process.exitCode`, so a
+ * literal 0 is honest.
  *
- * Both entries were found by this guard rather than assumed, and both are accurate for
- * a specific reason: `handleDebugCommand` and `handleLogin` report every failure with
- * `process.exit(1)` from inside the handler (debug.ts does so on 11 paths), so control
- * only reaches `return 0` on success.
+ * Every entry was found by this guard rather than assumed, and each was verified by
+ * reading its handler. The mechanism differs between them, which is why the reason
+ * matters more than the name:
  *
- * That is a narrower claim than "these commands always succeed". `login` reporting
- * success for a failed OAuth flow is a real gap, but it belongs to the uniform
- * exit-code contract in wp3b (devlog 025), not to this phase's management-transport
- * scope. Adding a name here must come with a reason of this kind.
+ * - `debug` — `handleDebugCommand` calls `process.exit(1)` on every failure path (12
+ *   sites in debug.ts, including the fallthrough), so control cannot reach `return 0`
+ *   after a failure.
+ * - `login` — exits 1 for an unknown provider; for a real OAuth failure `runLogin`
+ *   THROWS and the error propagates out past the runner.
+ * - `update` — `runUpdate` calls `process.exit(1)` on every failure path (6 sites in
+ *   update/index.ts). Its early `return 0` is the deliberate `--help` short-circuit.
+ * - `__refresh-version`, `__tray-host`, `__gui-update-worker` — hidden helpers whose
+ *   handlers never assign `process.exitCode`, so there is no code to preserve.
+ *   `__gui-update-worker` returns 1 directly for a missing job id.
+ *
+ * This is narrower than "these commands always succeed", and it is not a claim that
+ * their exit-code handling is ideal — a throw-based failure produces an unhandled
+ * rejection rather than a chosen exit code. Making that uniform belongs to wp3b
+ * (devlog 025), not to this phase's management-transport scope.
+ *
+ * Adding a name here requires a reason of this kind, verified in the handler. A review
+ * of this phase caught `tray` sitting outside the then-narrower pattern with the
+ * identical defect, which is why the pattern is now name-agnostic and the exemptions
+ * live here instead.
  */
-const CANNOT_FAIL_ALLOWLIST = new Set(["debug", "login"]);
+const CANNOT_FAIL_ALLOWLIST = new Set([
+  "debug",
+  "login",
+  "update",
+  "__refresh-version",
+  "__tray-host",
+  "__gui-update-worker",
+]);
 
 function swallowingRunners(source: string): string[] {
   const found: string[] = [];
@@ -82,6 +114,43 @@ describe("#2697 dispatch runners preserve handler exit codes", () => {
       expect(upToNext, `${runner} runner must propagate process.exitCode`)
         .toContain("Number(process.exitCode ?? 0)");
     }
+  });
+});
+
+describe("#2698 the status mapping and transport cause are actually reachable", () => {
+  /**
+   * The first review of this phase found both additions were dead code: apiError
+   * accepted a status no caller passed, and apiJson recorded a transportError no caller
+   * read. A capability that exists only in its own unit test is not a fix, so these
+   * assertions are about the CALL SITES rather than the helpers.
+   */
+  const SOURCES = ["account.ts", "account-extended.ts", "account-main.ts"].map(name =>
+    readFileSync(join(import.meta.dir, "..", "src", "cli", name), "utf8"));
+
+  test("every apiError call site forwards the response status", () => {
+    const bare: string[] = [];
+    for (const source of SOURCES) {
+      for (const line of source.split("\n")) {
+        if (!line.includes("apiError(")) continue;
+        if (line.includes("export function apiError")) continue;
+        // Third argument present means the 404 -> 4 / 409 -> 5 mapping can fire.
+        if (!/\.status\s*\)\s*;?\s*$/.test(line.trim())) bare.push(line.trim());
+      }
+    }
+    expect(bare).toEqual([]);
+  });
+
+  test("proxyUnreachable call sites guarded by status === 0 forward the cause", () => {
+    const bare: string[] = [];
+    for (const source of SOURCES) {
+      for (const line of source.split("\n")) {
+        if (!/status === 0.*proxyUnreachable\(/.test(line)) continue;
+        if (!line.includes("transportError")) bare.push(line.trim());
+      }
+    }
+    // One site reads a quota-report shape that carries no transportError field; it is
+    // allowed to call proxyUnreachable() bare rather than inventing a cause.
+    expect(bare.length).toBeLessThanOrEqual(1);
   });
 });
 

--- a/tests/cli-transport-honesty.test.ts
+++ b/tests/cli-transport-honesty.test.ts
@@ -148,9 +148,9 @@ describe("#2698 the status mapping and transport cause are actually reachable", 
         if (!line.includes("transportError")) bare.push(line.trim());
       }
     }
-    // One site reads a quota-report shape that carries no transportError field; it is
-    // allowed to call proxyUnreachable() bare rather than inventing a cause.
-    expect(bare.length).toBeLessThanOrEqual(1);
+    // One site used to be allowed to call proxyUnreachable() bare on a quota-report
+    // shape; that path now forwards transportError too.
+    expect(bare).toEqual([]);
   });
 });
 
@@ -158,23 +158,32 @@ describe("#2696 doctor names the credential collision", () => {
   const ADMIN = `ocx_admin_${"a".repeat(43)}`;
 
   test("reports OK when no data-plane token is set", () => {
-    const check = dataPlaneCredentialCollisionCheck({} as NodeJS.ProcessEnv);
+    const check = dataPlaneCredentialCollisionCheck({} as NodeJS.ProcessEnv, null);
     expect(check.level).toBe("OK");
   });
 
   test("reports OK when the two credentials are distinct", () => {
-    const check = dataPlaneCredentialCollisionCheck({ OPENCODEX_API_AUTH_TOKEN: "ocx_data_live" } as NodeJS.ProcessEnv);
+    const check = dataPlaneCredentialCollisionCheck({ OPENCODEX_API_AUTH_TOKEN: "ocx_data_live" } as NodeJS.ProcessEnv, null);
     expect(check.level).toBe("OK");
   });
 
   test("fails and names the remedy when the admin token is the data-plane secret", () => {
-    const check = dataPlaneCredentialCollisionCheck({ OPENCODEX_API_AUTH_TOKEN: ADMIN } as NodeJS.ProcessEnv);
+    const check = dataPlaneCredentialCollisionCheck({ OPENCODEX_API_AUTH_TOKEN: ADMIN } as NodeJS.ProcessEnv, null);
     // FAIL, not WARN: while this holds every /api/* returns 503, so the management
     // surface is unusable rather than degraded.
     expect(check.level).toBe("FAIL");
     expect(check.message).toContain("management (admin) token");
     expect(check.message).toContain("Action:");
     // Never echo the credential itself, even in a diagnostic.
+    expect(check.message).not.toContain(ADMIN);
+  });
+
+  test("fails when the installed service token file collides and the doctor shell has no env", () => {
+    // Production doctor almost never has OPENCODEX_API_AUTH_TOKEN; the service wrapper
+    // re-exports the file. Passing null-env + the file token is the already-broken install.
+    const check = dataPlaneCredentialCollisionCheck({} as NodeJS.ProcessEnv, ADMIN);
+    expect(check.level).toBe("FAIL");
+    expect(check.message).toContain("service token file");
     expect(check.message).not.toContain(ADMIN);
   });
 });
@@ -237,8 +246,6 @@ describe("#2698 the account client keeps the transport cause and maps status cod
     expect(apiError({ error: "no such account" }, "fallback", 404)).toBe(4);
     expect(apiError({ error: "busy" }, "fallback", 409)).toBe(5);
     expect(apiError({ error: "boom" }, "fallback", 500)).toBe(1);
-    // Callers that pass no status keep the previous behavior.
-    expect(apiError({ error: "boom" }, "fallback")).toBe(1);
   });
 
   test("proxyUnreachable surfaces the transport cause when given one", () => {
@@ -260,6 +267,12 @@ describe("#2696 a management token is refused as the data-plane secret", () => {
     expect(() => assertNotAdminToken("local-secret")).not.toThrow();
   });
 
+  test("assertNotAdminToken rejects a non-prefixed admin token equal to the configured value", () => {
+    expect(() => assertNotAdminToken("shared-secret", {
+      OPENCODEX_ADMIN_AUTH_TOKEN: "shared-secret",
+    } as NodeJS.ProcessEnv)).toThrow(/management \(admin\) token/);
+  });
+
   test("assertServiceAuthEnvironment refuses the collision even on loopback", () => {
     // The loopback short-circuit used to return before any token check, which is how
     // an install could produce a service whose management plane was fenced closed.
@@ -271,5 +284,15 @@ describe("#2696 a management token is refused as the data-plane secret", () => {
       if (previous === undefined) delete process.env.OPENCODEX_API_AUTH_TOKEN;
       else process.env.OPENCODEX_API_AUTH_TOKEN = previous;
     }
+  });
+
+  test("handleStart asserts the token it is about to export", () => {
+    const source = readFileSync(join(import.meta.dir, "..", "src", "cli", "index.ts"), "utf8");
+    expect(source).toContain("assertNotAdminToken(present)");
+  });
+
+  test("familyFailure forwards the transport cause", () => {
+    const source = readFileSync(join(import.meta.dir, "..", "src", "cli", "account-extended.ts"), "utf8");
+    expect(source).toMatch(/networkDown\) return proxyUnreachable\(result\.transportError\)/);
   });
 });


### PR DESCRIPTION
## Summary

Stacked on #2773 (targets `codex/ocx-agentic-control-roadmap`, not `dev`).
Implements `devlog/_plan/260828_ocx_agentic_control/010_phase_transport_honesty.md`.

Three defects made the `ocx` CLI unusable for unattended operation, and they share a
theme: **a failed management call did not look like a failure.**

**#2697 — exit codes discarded.** The `provider` and `models` dispatch runners awaited
their handler then `return 0`, so `index.ts`'s single `process.exit(...)` erased the
code the handler had set. `ocx provider quota` against a stopped proxy printed an error
and exited 0 — silently green in any script or CI. Both runners now return
`Number(process.exitCode ?? 0)`, the pattern ten other runners already use, and reset
it first like the `service` runner does.

**#2698 — the server's diagnosis was thrown away.** `responseMessage` read only
`error`/`message`/`detail`, never `reason` or `hint` — the two fields the management
plane sets to say *why* it refused and *what to do*. Routes that return
`{ok:false, reason:"…"}` with no `error` key degraded to a generic
`Management request failed (409)`. The body was already attached to the thrown error,
so this was pure rendering loss. The account client was worse: it collapsed every
transport error into a bare status-0 sentinel inside `catch {}`, discarding the cause,
and exited 1 for everything including 404 and 409.

**#2696 — a management token could fence the whole management plane closed.** The
service exports its token file as `OPENCODEX_API_AUTH_TOKEN` before starting the proxy,
and nothing refused a management token in that slot. When the two match, the server
treats the admin credential as a data-plane admission secret and fails the entire
management plane closed at boot: every `/api/*` returns 503, even on a loopback install
that never needed a data-plane secret. The CLI could not recover it, because the fence
is decided server-side at startup.

`assertNotAdminToken` now refuses it at the write chokepoint and in
`assertServiceAuthEnvironment` — before the loopback short-circuit, since a loopback
install writes the token file too and returning early there is what let the broken
state through. For an install already in that state, `ocx doctor` names the cause and
the remedy without echoing the credential.

### The recurrence guard corrected its own plan

The plan specified an allowlist of `["login", "logout", "tray"]` for runners permitted
to return a literal 0. The guard contradicted it: the real offenders are `debug` and
`login`, and the pattern the plan proposed (`[^)]*`) matched **neither target runner**
because argument lists here contain nested calls. The test now uses `[^;]*` and asserts
red-first against the pre-fix shape, so a vacuous pattern cannot slip in.

`debug` and `login` are allowlisted on a verified basis: both report every failure with
`process.exit(1)` from inside the handler, so `return 0` is reached only on success.
That is narrower than "cannot fail" — `login` reporting success for a failed OAuth flow
is a real gap, and it belongs to the uniform exit-code contract phase rather than this
one. Recorded in `011` rather than silently absorbed.

## Verification

- `bun run typecheck` — clean. Proven **non-vacuous**: injecting a type error into
  `account-api.ts` produced `TS2322` at the exact line; restoring returned it to clean.
- `bun test tests/cli-transport-honesty.test.ts` — 16 pass (new file).
- `bun test` over `cli-dispatch`, `cli-management-auth`, `cli-account`, `service`,
  `cli-registry`, `cli-headless-parity` — 297 pass.
- `apiError`'s new `status` parameter is optional, so every existing call site keeps
  its current exit code.

One honest caveat, recorded in `011`: the first run of the six-file batch reported one
failure in `cli-headless-parity`'s `vision --list` case. It did not reproduce in 26
subsequent runs and passes in isolation. The likely mechanism is port contention
between the real `Bun.serve` fakes that harness starts per test, which this diff does
not touch — but it is written down rather than dismissed as flaky, so CI recurrence has
a starting point.

## Checklist

- [x] Focused regression tests added next to the affected subsystems
- [x] `bun run typecheck` clean, and verified to actually inspect the changed files
- [x] Touches credential handling (`src/service.ts`, `src/cli/doctor.ts`) — **flagged
      for the security review `MAINTAINERS.md` requires.** No credential value is
      logged, printed, or returned; the checks compare shapes only
- [x] No Node-only APIs introduced; Bun-native throughout
- [x] No GUI change, so no screenshot required
- [x] Stacked child PR: targets the parent's head branch per `AGENTS.md`; retarget to
      `dev` once #2773 lands

Closes #2696
Closes #2697
Closes #2698



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer management API errors with actionable reasons, hints, transport details, and status-based exit codes.
  * Added diagnostics and startup safeguards for conflicting administrative and service credentials.
  * Improved command failure handling so non-zero exit codes are preserved consistently.

* **Bug Fixes**
  * Corrected account and profile commands to report transport failures and HTTP statuses accurately.
  * Improved handling of not-found, conflict, and timeout responses.

* **Documentation**
  * Added implementation records and planning amendments covering transport behavior, route verification, credential protections, and validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->