### PR TITLE
feat: declare the management route surface and add ocx capabilities

### DIFF
--- a/src/cli/capabilities-command.ts
+++ b/src/cli/capabilities-command.ts
@@ -1,0 +1,93 @@
+/**
+ * `ocx capabilities` -- the surface index an agent reads first.
+ *
+ * The point of this verb is that driving `ocx` programmatically should not require
+ * parsing help text. `--json` emits the capability table with the management routes each
+ * capability drives; `--route` answers the inverse question.
+ */
+import {
+  CAPABILITIES,
+  HEAD_CAPABILITIES,
+  capabilitiesForRoute,
+  capabilityInvocation,
+  type Capability,
+} from "./capabilities";
+import { takeFlag } from "./runtime-api";
+
+function takeValueFlag(args: string[], flag: string): string | undefined {
+  // Order-independent by construction: scan for the flag anywhere in argv rather than
+  // reading a fixed position. Positional flag handling is exactly why
+  // `ocx restore back --json` ignored its flag.
+  const idx = args.indexOf(flag);
+  if (idx === -1) return undefined;
+  const value = args[idx + 1];
+  args.splice(idx, value === undefined ? 1 : 2);
+  return value;
+}
+
+function renderHuman(caps: readonly Capability[], includeHead: boolean): void {
+  for (const cap of caps) {
+    const marker = cap.mutates ? "!" : " ";
+    console.log(`${marker} ${capabilityInvocation(cap)}`);
+    console.log(`    ${cap.summary}`);
+    if (cap.routes.length > 0) {
+      console.log(`    routes: ${cap.routes.map(r => `${r.method} ${r.path}`).join(", ")}`);
+    }
+    if (cap.flags.length > 0) {
+      console.log(`    flags:  ${cap.flags.map(f => f.name).join(" ")}`);
+    }
+  }
+  if (!includeHead) return;
+  for (const head of HEAD_CAPABILITIES) {
+    console.log(`  ocx ${head.invocations[0]}`);
+    console.log(`    ${head.summary}`);
+  }
+}
+
+export async function runCapabilities(argv: string[]): Promise<number> {
+  const args = [...argv];
+  const json = takeFlag(args, "--json");
+  const mutatingOnly = takeFlag(args, "--mutating-only");
+  const route = takeValueFlag(args, "--route");
+
+  if (route !== undefined && route.length === 0) {
+    console.error("Usage: ocx capabilities --route <path>");
+    return 64;
+  }
+
+  let selected: readonly Capability[] = route === undefined ? CAPABILITIES : capabilitiesForRoute(route);
+  if (mutatingOnly) selected = selected.filter(cap => cap.mutates);
+
+  if (route !== undefined && selected.length === 0) {
+    // An unmatched route is a real answer, not an error: the route may be exempt or may
+    // not exist. Say which, rather than exiting 0 with silence.
+    if (json) {
+      console.log(JSON.stringify({ schemaVersion: 1, route, capabilities: [] }, null, 2));
+    } else {
+      console.error(`No CLI capability drives ${route}.`);
+    }
+    return 4;
+  }
+
+  if (json) {
+    console.log(JSON.stringify({
+      schemaVersion: 1,
+      ...(route === undefined ? {} : { route }),
+      capabilities: selected.map(cap => ({
+        command: cap.command,
+        invocation: capabilityInvocation(cap),
+        summary: cap.summary,
+        routes: cap.routes,
+        flags: cap.flags,
+        mutates: cap.mutates,
+        json: cap.json,
+        ...(cap.details ? { details: cap.details } : {}),
+      })),
+      ...(route === undefined && !mutatingOnly ? { headCapabilities: HEAD_CAPABILITIES } : {}),
+    }, null, 2));
+    return 0;
+  }
+
+  renderHuman(selected, route === undefined && !mutatingOnly);
+  return 0;
+}

--- a/src/cli/capabilities-command.ts
+++ b/src/cli/capabilities-command.ts
@@ -21,7 +21,8 @@ function takeValueFlag(args: string[], flag: string): string | undefined {
   const idx = args.indexOf(flag);
   if (idx === -1) return undefined;
   const value = args[idx + 1];
-  args.splice(idx, value === undefined ? 1 : 2);
+  args.splice(idx, value === undefined || value.startsWith("-") ? 1 : 2);
+  if (value === undefined || value.startsWith("-")) return "";
   return value;
 }
 

--- a/src/cli/capabilities.ts
+++ b/src/cli/capabilities.ts
@@ -1,0 +1,174 @@
+/**
+ * What `ocx` can do, as data an agent can read without parsing help text.
+ *
+ * This is the machine-readable index behind `ocx capabilities`. It relates each CLI
+ * capability to the management route(s) it drives, which nothing in this repository did
+ * before: help lived in twenty per-module `USAGE` constants and a hand-written banner
+ * that a test explicitly licensed to drift from the command registry.
+ *
+ * LEAF MODULE. It imports nothing from `src/cli/`, and nothing here may import a command
+ * module. That is not tidiness. Each command module declares its usage text as a
+ * top-level `const USAGE`, evaluated at import time, so a cycle back into this table
+ * would resolve to `undefined` under ESM rather than throwing -- silently emptying the
+ * usage text that `rejectArgs` hands to `CliUsageError`, in the exact error-reporting
+ * surface the CLI-operability issues are about. `tests/cli-capabilities.test.ts` asserts
+ * the absence of those imports and that every rendered usage string is non-empty, so the
+ * failure mode is loud instead of degraded.
+ *
+ * Head-handled surfaces (`--version`, `help`) are declared separately in
+ * `HEAD_CAPABILITIES`. They exit in the CLI head (`root.ts`) before dispatch and have no
+ * runner key, so listing them as ordinary capabilities would break the registry parity
+ * assertion that every canonical entry is a direct runner. `help` is excluded from
+ * `CLI_COMMANDS` deliberately -- `tests/cli-registry.test.ts` documents it as a
+ * head-handled pseudo-case -- and that decision is preserved here rather than reversed.
+ */
+
+/** A management route a capability drives. Path text only; never a handler reference. */
+export interface CapabilityRoute {
+  readonly method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  readonly path: string;
+}
+
+export interface CapabilityFlag {
+  readonly name: string;
+  readonly value?: "string" | "number" | "boolean";
+  readonly required?: boolean;
+  readonly summary: string;
+}
+
+/**
+ * How a capability emits JSON.
+ *
+ * - `payload`: the API payload, largely unwrapped.
+ * - `envelope`: a CLI-shaped object with its own schema.
+ * - `none`: no `--json` mode.
+ */
+export type CapabilityJsonMode = "payload" | "envelope" | "none";
+
+export interface Capability {
+  /** Command path, e.g. `["account", "pause"]`. */
+  readonly command: readonly string[];
+  readonly summary: string;
+  readonly routes: readonly CapabilityRoute[];
+  readonly flags: readonly CapabilityFlag[];
+  readonly mutates: boolean;
+  readonly json: CapabilityJsonMode;
+  readonly details?: readonly string[];
+  /**
+   * Extra banner rows this capability owns, for surfaces the banner shows separately
+   * from the bare command (`ocx restore back`, `ocx doctor --reclaim-response-temps`).
+   * Without this the banner cannot equal the capability set: it legitimately carries more
+   * rows than there are commands.
+   */
+  readonly bannerLines?: readonly string[];
+}
+
+/**
+ * Surfaces resolved in the CLI head, before dispatch.
+ *
+ * They belong in `ocx capabilities` output and in the banner, but not in `CLI_COMMANDS`:
+ * `--version`, `-v`, and `version` are answered at `root.ts` and exit, so none of them is
+ * a runner key to parity-check against.
+ */
+export interface HeadCapability {
+  readonly invocations: readonly string[];
+  readonly summary: string;
+  readonly bannerLine: string;
+}
+
+export const HEAD_CAPABILITIES: readonly HeadCapability[] = [
+  {
+    invocations: ["--version", "-v", "version"],
+    summary: "Print the CLI version and exit.",
+    bannerLine: "ocx --version | -v          Print version",
+  },
+  {
+    invocations: ["help", "--help", "-h"],
+    summary: "Print the command list, or one command's usage with `ocx help <command>`.",
+    bannerLine: "ocx help [command]          Show help for a command",
+  },
+];
+
+/**
+ * Capabilities that drive a management route.
+ *
+ * Deliberately incomplete at this phase: it covers the read/write surface the CLI
+ * already reaches, and later phases add entries as they add verbs. The parity test
+ * measures routes against capabilities plus declared exemptions, so a missing entry
+ * shows up as an unexplained route rather than being quietly tolerated.
+ */
+export const CAPABILITIES: readonly Capability[] = [
+  {
+    command: ["status"],
+    summary: "Proxy status, injection state, and version skew between this CLI and the running proxy.",
+    // No management route: `collectStatus` identity-probes `/healthz` through
+    // `findLiveProxy` and reads local config. Declaring `GET /api/status` here was wrong
+    // -- that route does not exist, and the registry cross-check caught it.
+    routes: [],
+    flags: [{ name: "--json", value: "boolean", summary: "Emit the status envelope as JSON." }],
+    mutates: false,
+    json: "envelope",
+    details: ["Reads /healthz plus local config; drives no management API route."],
+  },
+  {
+    command: ["capabilities"],
+    summary: "Enumerate every CLI capability with the management routes it drives.",
+    routes: [],
+    flags: [
+      { name: "--json", value: "boolean", summary: "Emit the full capability table as JSON." },
+      { name: "--mutating-only", value: "boolean", summary: "Restrict output to capabilities that mutate state." },
+      { name: "--route", value: "string", summary: "Show which capabilities drive a management route." },
+    ],
+    mutates: false,
+    json: "envelope",
+    details: ["Start here when driving ocx programmatically: it is the surface index."],
+  },
+  {
+    command: ["provider", "list"],
+    summary: "Configured providers with connectivity and selected models.",
+    routes: [{ method: "GET", path: "/api/providers" }],
+    flags: [{ name: "--json", value: "boolean", summary: "Emit the provider list as JSON." }],
+    mutates: false,
+    json: "payload",
+  },
+  {
+    command: ["account", "list"],
+    summary: "Codex OAuth accounts with pool priority and pause state.",
+    routes: [{ method: "GET", path: "/api/codex-auth/accounts" }],
+    flags: [{ name: "--json", value: "boolean", summary: "Emit the account list as JSON." }],
+    mutates: false,
+    json: "payload",
+  },
+  {
+    command: ["usage"],
+    summary: "Token and estimated-cost report over a time range.",
+    routes: [{ method: "GET", path: "/api/usage" }],
+    flags: [
+      { name: "--range", value: "string", summary: "today | 1d | 7d | 30d | all" },
+      { name: "--provider", value: "string", summary: "Restrict to one provider." },
+      { name: "--model", value: "string", summary: "Restrict to one model id." },
+      { name: "--json", value: "boolean", summary: "Emit the usage report as JSON." },
+    ],
+    mutates: false,
+    json: "payload",
+  },
+];
+
+/** Capabilities that drive `route`, for `ocx capabilities --route`. */
+export function capabilitiesForRoute(path: string): Capability[] {
+  return CAPABILITIES.filter(cap => cap.routes.some(r => r.path === path));
+}
+
+/** Every `(method, path)` pair any capability drives. */
+export function capabilityRouteKeys(): Set<string> {
+  const keys = new Set<string>();
+  for (const cap of CAPABILITIES) {
+    for (const route of cap.routes) keys.add(`${route.method} ${route.path}`);
+  }
+  return keys;
+}
+
+/** Rendered command path, e.g. `ocx account pause`. */
+export function capabilityInvocation(cap: Capability): string {
+  return `ocx ${cap.command.join(" ")}`;
+}

--- a/src/cli/capabilities.ts
+++ b/src/cli/capabilities.ts
@@ -90,12 +90,9 @@ export const HEAD_CAPABILITIES: readonly HeadCapability[] = [
 ];
 
 /**
- * Capabilities that drive a management route.
- *
- * Deliberately incomplete at this phase: it covers the read/write surface the CLI
- * already reaches, and later phases add entries as they add verbs. The parity test
- * measures routes against capabilities plus declared exemptions, so a missing entry
- * shows up as an unexplained route rather than being quietly tolerated.
+ * Capabilities declared so far. Incomplete by design: later phases add verbs.
+ * `ocx capabilities` is the index of what is listed here, not of every CLI command.
+ * A capability must not name a route the command does not actually fetch.
  */
 export const CAPABILITIES: readonly Capability[] = [
   {
@@ -112,7 +109,7 @@ export const CAPABILITIES: readonly Capability[] = [
   },
   {
     command: ["capabilities"],
-    summary: "Enumerate every CLI capability with the management routes it drives.",
+    summary: "List the declared CLI capabilities and the management routes they drive.",
     routes: [],
     flags: [
       { name: "--json", value: "boolean", summary: "Emit the full capability table as JSON." },
@@ -121,15 +118,17 @@ export const CAPABILITIES: readonly Capability[] = [
     ],
     mutates: false,
     json: "envelope",
-    details: ["Start here when driving ocx programmatically: it is the surface index."],
+    details: ["Start here when driving ocx programmatically: it is the declared surface index, not a complete verb list."],
   },
   {
     command: ["provider", "list"],
     summary: "Configured providers with connectivity and selected models.",
-    routes: [{ method: "GET", path: "/api/providers" }],
+    // Local config + PROVIDER_REGISTRY. Does not call GET /api/providers.
+    routes: [],
     flags: [{ name: "--json", value: "boolean", summary: "Emit the provider list as JSON." }],
     mutates: false,
-    json: "payload",
+    json: "envelope",
+    details: ["Reads local config; drives no management API route."],
   },
   {
     command: ["account", "list"],

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -399,6 +399,10 @@ const commandRunners: Record<string, CommandRunner> = {
     await deps.handleProxyRestart(deps.handleRestartStartWhenStopped);
     return Number(process.exitCode ?? 0);
   },
+  capabilities: async deps => {
+    const { runCapabilities } = await import("./capabilities-command");
+    return await runCapabilities(deps.args.slice(1));
+  },
   health: async deps => {
     const healthArgs = deps.args.slice(1);
     const wantsHealthJson = healthArgs.includes("--json");

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1072,6 +1072,20 @@ export async function runDoctor(args: string[] = []): Promise<void> {
     configFn: () => ({ port: doctorConfig.port, hostname: doctorConfig.hostname }),
   });
 
+  // Mirrors `ocx status` through the same comparison rather than a second implementation:
+  // two diagnostics disagreeing about whether an install is stale is worse than one (#2701).
+  // No extra probe -- findLiveProxy already carried the version back.
+  {
+    const { packageVersion } = await import("./help");
+    const { computeVersionSkew } = await import("./version-skew");
+    const skew = computeVersionSkew(packageVersion(), live?.version);
+    if (skew.skewed && skew.warning) {
+      console.log(`!! ${skew.warning}`);
+    } else if (skew.proxyVersion !== null) {
+      console.log(`ok ocx ${skew.cliVersion} matches the running proxy`);
+    }
+  }
+
   const currentProxyEnv = collectProxyEnv();
   const configuredProxy = collectConfiguredProxy();
   const runningProxyEnv = collectRunningProxyEnv({

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -5,7 +5,14 @@ import { findCommand } from "./registry";
 
 const repoRoot = dirname(fileURLToPath(new URL("../../package.json", import.meta.url)));
 
-function packageVersion(): string {
+/**
+ * Version of the `ocx` bundle this process is running from.
+ *
+ * Exported so `status`/`doctor` can compare it against the version the live proxy reports,
+ * which is how a stale `ocx` earlier on PATH becomes visible (#2701). Returns `"unknown"`
+ * rather than throwing; callers must treat that as "cannot compare", not as a mismatch.
+ */
+export function packageVersion(): string {
   const raw = readFileSync(join(repoRoot, "package.json"), "utf8");
   const parsed = JSON.parse(raw) as { version?: unknown };
   return typeof parsed.version === "string" ? parsed.version : "unknown";

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -55,7 +55,7 @@ Usage:
   ocx restart                  Stop and restart the proxy
   ocx v2 <sub>                multi_agent_v2 surface (status|on|off|mode|keep-native-v1|threads|mode-hint)
   ocx health [--json]          Check proxy health (exit 0=healthy, 1=not)
-  ocx capabilities [--json]    List every capability and the API routes it drives
+  ocx capabilities [--json]    List declared capabilities and the API routes they drive
   ocx ready [--json] [--wait [--timeout <s>]]  Check post-sync readiness (exit 0 only when ready)
   ocx provider <sub>          Providers, connectivity, quota, and selected models
   ocx account <sub>           Accounts, login/reauth, key pools, and quota controls

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -48,6 +48,7 @@ Usage:
   ocx restart                  Stop and restart the proxy
   ocx v2 <sub>                multi_agent_v2 surface (status|on|off|mode|keep-native-v1|threads|mode-hint)
   ocx health [--json]          Check proxy health (exit 0=healthy, 1=not)
+  ocx capabilities [--json]    List every capability and the API routes it drives
   ocx ready [--json] [--wait [--timeout <s>]]  Check post-sync readiness (exit 0 only when ready)
   ocx provider <sub>          Providers, connectivity, quota, and selected models
   ocx account <sub>           Accounts, login/reauth, key pools, and quota controls

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -848,6 +848,12 @@ async function handleStatus() {
     console.log(`❌ Proxy: ${status.proxyLabel}`);
   }
   console.log(`   Health: ${status.healthLabel}`);
+  // Printed here, not only in --json: a stale ocx on PATH is exactly the situation where
+  // the operator is reading human output and wondering why the CLI disagrees with the
+  // dashboard. Adding the JSON field alone would satisfy a test and help nobody (#2701).
+  if (status.json.versionSkew.warning) {
+    console.log(`   ⚠️  ${status.json.versionSkew.warning}`);
+  }
   for (const line of unusedProxyWarningLines({
     proxyUp: Boolean(status.json.proxy.pid || status.json.proxy.health.ok),
     routingKind: status.json.startup.routingKind,

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -350,6 +350,15 @@ export const CLI_COMMANDS: CliCommandEntry[] = [
     details: ["Use --json for structured output: {ok, pid, port}."],
   },
   {
+    name: "capabilities",
+    usage: "ocx capabilities [--json] [--mutating-only] [--route <path>]",
+    summary: "Enumerate every CLI capability with the management routes it drives.",
+    details: [
+      "The machine-readable surface index: start here when driving ocx programmatically instead of parsing help text.",
+      "--route <path> answers the inverse question: which commands drive this management route.",
+    ],
+  },
+  {
     name: "ready",
     usage: "ocx ready [--json] [--wait [--timeout <seconds>]]",
     summary: "Check post-sync readiness. Exits 0 only when ready.",

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -352,7 +352,7 @@ export const CLI_COMMANDS: CliCommandEntry[] = [
   {
     name: "capabilities",
     usage: "ocx capabilities [--json] [--mutating-only] [--route <path>]",
-    summary: "Enumerate every CLI capability with the management routes it drives.",
+    summary: "List the declared CLI capabilities and the management routes they drive.",
     details: [
       "The machine-readable surface index: start here when driving ocx programmatically instead of parsing help text.",
       "--route <path> answers the inverse question: which commands drive this management route.",

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -10,6 +10,8 @@ import { collectStartupHealth, type StartupHealth } from "../codex/autostart-hea
 import { getCodexRoutingKind } from "../codex/inject";
 import { diagnoseCodexShim } from "../codex/shim";
 import { displayCodexRuntimePath, effortClampAppliesToRuntime, loadLastEffortClamp, resolveCodexRuntime } from "../codex/runtime";
+import { packageVersion } from "./help";
+import { computeVersionSkew, type VersionSkew } from "./version-skew";
 import { redactSecretString, redactUserPath } from "../lib/redact";
 import { collectOrcaCodexHomeDiagnostic, type OrcaCodexHomeDiagnostic } from "../codex/home";
 import { grokFenceEndpointDrift, readGrokStatus } from "../grok/status";
@@ -70,6 +72,13 @@ export type CliStatusJson = {
     };
   };
   codexHome: OrcaCodexHomeDiagnostic;
+  /**
+   * This CLI's version against the running proxy's (#2701).
+   *
+   * Additive and optional-by-value, so `schemaVersion` stays 1: an existing consumer that
+   * ignores the key is unaffected, and `proxyVersion` is null when nothing is live.
+   */
+  versionSkew: VersionSkew;
 };
 
 export type CliStatusView = {
@@ -180,6 +189,9 @@ export async function collectStatus(): Promise<CliStatusView> {
   const pidFile = readPid();
   // Preserve an authoritative null from orphan/legacy liveness — do not restore pidFile.
   const pid = resolveStatusPid(live, pidFile);
+  // No extra request: findLiveProxy's identity probe already parsed and validated the
+  // healthz body, so the version came back with the liveness result.
+  const versionSkew = computeVersionSkew(packageVersion(), live?.version);
   const listen = live
     ? {
       port: live.port,
@@ -347,6 +359,10 @@ export async function collectStatus(): Promise<CliStatusView> {
       codexPlugins,
       codexRuntime,
       codexHome,
+      // Own field rather than a line in `codexRuntime.warning`: a stale ocx on PATH is a
+      // fact about this install, not about the Codex runtime, and filing it there would
+      // print it under the wrong heading (#2701).
+      versionSkew,
     },
   };
 }

--- a/src/cli/version-skew.ts
+++ b/src/cli/version-skew.ts
@@ -1,0 +1,46 @@
+/**
+ * CLI-versus-proxy version skew (#2701).
+ *
+ * The reported failure: `ocx` on PATH is an older install than the running proxy, so its
+ * help describes commands the proxy does not have and its output describes a different
+ * build. Nothing surfaced that, because the CLI never compared the two.
+ *
+ * Kept in its own module rather than inside `status.ts` so `doctor` can reuse the exact
+ * comparison instead of reimplementing it -- two diagnostics disagreeing about whether an
+ * install is stale would be worse than neither reporting it.
+ */
+
+/** Placeholder versions that mean "unknown", not "different". */
+const PLACEHOLDERS = new Set(["unknown", "0.0.0"]);
+
+export interface VersionSkew {
+  readonly cliVersion: string;
+  /** Version the live proxy reported, or null when nothing is live or it reported none. */
+  readonly proxyVersion: string | null;
+  readonly skewed: boolean;
+  /** Operator-facing explanation; null when there is nothing to report. */
+  readonly warning: string | null;
+}
+
+/**
+ * Compare the running CLI against the live proxy.
+ *
+ * Suppressed rather than reported when either side is a placeholder. `packageVersion()`
+ * answers `"unknown"` when `package.json` carries no string version, and the server's
+ * `VERSION` falls back to `"0.0.0"` when it cannot resolve its own package -- comparing
+ * against either would report skew that says nothing about the install. A false stale-CLI
+ * warning would send an operator to reinstall a healthy setup.
+ */
+export function computeVersionSkew(cliVersion: string, proxyVersion: string | undefined): VersionSkew {
+  const proxy = proxyVersion ?? null;
+  if (proxy === null || PLACEHOLDERS.has(proxy) || PLACEHOLDERS.has(cliVersion) || proxy === cliVersion) {
+    return { cliVersion, proxyVersion: proxy, skewed: false, warning: null };
+  }
+  return {
+    cliVersion,
+    proxyVersion: proxy,
+    skewed: true,
+    warning: `CLI ${cliVersion} does not match the running proxy ${proxy} — this ocx on PATH is stale. `
+      + "Its help and features describe a different build. Reinstall, or run the proxy's own binary.",
+  };
+}

--- a/src/server/management/route-registry.ts
+++ b/src/server/management/route-registry.ts
@@ -1,0 +1,312 @@
+/**
+ * Declared inventory of every reachable management route.
+ *
+ * DECLARED, not harvested. A grep cannot see this surface: 18 routes are registered
+ * through a regex, an `endsWith`, a `pathname.slice`, a prefix decode, a path constant, or a
+ * negated `pathname !== "…"` guard, and two of those are live routes whose only textual
+ * trace is the negated form. For `GET /api/storage` an equality scan finds solely the dead
+ * shadowed copy in `logs-usage-routes.ts` and never the live one.
+ *
+ * This module is pure DATA and must stay that way. It is imported by
+ * `src/server/management-api.ts`, which `tests/core-lab-boundary.test.ts` protects: a user
+ * with one provider and no Lab must execute no Lab code. Route paths are strings, so
+ * declaring `/api/lab/status` here creates no module edge. Never import a handler, and
+ * never import anything from `src/lab/`. The `module` field names the owning file as text
+ * for exactly this reason.
+ *
+ * Reconciliation lives in `tests/management-route-registry.test.ts`, which resolves
+ * `(method, path)` pairs from source and fails loudly on a route whose method it cannot
+ * determine. Adding a route without declaring it here fails that test.
+ */
+
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD";
+
+/**
+ * Why a route has no CLI verb. Every value is a claim about the route that a reviewer
+ * can check, not a way to quiet the parity test.
+ */
+export type ExemptionReason =
+  /** Requires a dashboard browser session. Includes the user-consent star boundary. */
+  | "session-only"
+  /** Deliberately returns 405; there is nothing to drive. */
+  | "disabled"
+  /** Gated on a process-scoped capability principal, not an operator action. */
+  | "capability-principal"
+  /** A test seam, not an operator capability. */
+  | "test-seam"
+  /** The CLI reaches the same data through a local transport instead of HTTP. */
+  | "local-transport"
+  /** Unreachable in the live dispatch order; delete rather than expose. */
+  | "dead"
+  /**
+   * A verb is owed but belongs to a later work-phase. BOUNDED: requires `owner` and
+   * `ownerDoc`, and the parity test asserts that tracked doc exists and names the route.
+   * The doc is deliberately a repository file rather than the goalplan, which is
+   * gitignored -- a test reading machine-local state passes here and finds nothing in CI.
+   */
+  | "deferred-verb";
+
+export interface RouteExemption {
+  readonly reason: ExemptionReason;
+  /** Free text; required, because an exemption nobody justified is how a gate erodes. */
+  readonly why: string;
+  /** Work-phase that owes the verb. Required for `deferred-verb`. */
+  readonly owner?: string;
+  /** Tracked doc naming the route. Required for `deferred-verb`. */
+  readonly ownerDoc?: string;
+}
+
+/** How a route is registered, for routes an equality scan cannot see. */
+export type NonLiteralMechanism =
+  | "negated-guard"
+  | "path-constant"
+  | "prefix-decode"
+  | "slice"
+  | "ends-with"
+  | "regex";
+
+export interface ManagementRoute {
+  readonly method: HttpMethod;
+  readonly path: string;
+  /** Owning source file, repo-relative without the `src/` prefix or `.ts` suffix. */
+  readonly module: string;
+  readonly mutates: boolean;
+  /** Set when the route is not recoverable from an equality scan of its own file. */
+  readonly mechanism?: NonLiteralMechanism;
+  readonly exempt?: RouteExemption;
+}
+
+
+/** Every reachable management route. */
+export const MANAGEMENT_ROUTES: readonly ManagementRoute[] = [
+  // server/management-api
+  { method: "POST", path: "/api/stop", module: "server/management-api", mutates: true },
+  // codex/auth-api
+  { method: "DELETE", path: "/api/codex-auth/accounts", module: "codex/auth-api", mutates: true },
+  { method: "GET", path: "/api/codex-auth/accounts", module: "codex/auth-api", mutates: false },
+  { method: "GET", path: "/api/codex-auth/active", module: "codex/auth-api", mutates: false },
+  { method: "GET", path: "/api/codex-auth/login-status", module: "codex/auth-api", mutates: false },
+  { method: "GET", path: "/api/codex-auth/quota", module: "codex/auth-api", mutates: false },
+  { method: "GET", path: "/api/codex-auth/reset-credits", module: "codex/auth-api", mutates: false },
+  { method: "PATCH", path: "/api/codex-auth/pool-strategy", module: "codex/auth-api", mutates: true },
+  { method: "POST", path: "/api/codex-auth/accounts", module: "codex/auth-api", mutates: true },
+  { method: "POST", path: "/api/codex-auth/accounts/clear-cooldown", module: "codex/auth-api", mutates: true },
+  { method: "POST", path: "/api/codex-auth/login", module: "codex/auth-api", mutates: true },
+  { method: "POST", path: "/api/codex-auth/login/cancel", module: "codex/auth-api", mutates: true },
+  { method: "POST", path: "/api/codex-auth/login/code", module: "codex/auth-api", mutates: true },
+  { method: "POST", path: "/api/codex-auth/reset-credits/consume", module: "codex/auth-api", mutates: true },
+  { method: "PUT", path: "/api/codex-auth/accounts/alias", module: "codex/auth-api", mutates: true },
+  { method: "PUT", path: "/api/codex-auth/accounts/pause", module: "codex/auth-api", mutates: true },
+  { method: "PUT", path: "/api/codex-auth/accounts/pause-exhausted", module: "codex/auth-api", mutates: true },
+  { method: "PUT", path: "/api/codex-auth/accounts/priority", module: "codex/auth-api", mutates: true },
+  { method: "PUT", path: "/api/codex-auth/active", module: "codex/auth-api", mutates: true },
+  { method: "PUT", path: "/api/codex-auth/auto-switch", module: "codex/auth-api", mutates: true },
+  { method: "PUT", path: "/api/codex-auth/failover", module: "codex/auth-api", mutates: true },
+  { method: "PUT", path: "/api/codex-auth/pool-strategy", module: "codex/auth-api", mutates: true },
+  // codex/native-profile-api
+  { method: "GET", path: "/api/native-main-profiles", module: "codex/native-profile-api", mutates: false },
+  { method: "GET", path: "/api/native-main-profiles/doctor", module: "codex/native-profile-api", mutates: false },
+  { method: "POST", path: "/api/native-main-profiles/recover", module: "codex/native-profile-api", mutates: true },
+  { method: "POST", path: "/api/native-main-profiles/register", module: "codex/native-profile-api", mutates: true },
+  { method: "POST", path: "/api/native-main-profiles/stage", module: "codex/native-profile-api", mutates: true },
+  { method: "POST", path: "/api/native-main-profiles/stage/cancel", module: "codex/native-profile-api", mutates: true },
+  { method: "POST", path: "/api/native-main-profiles/stage/finish", module: "codex/native-profile-api", mutates: true },
+  { method: "POST", path: "/api/native-main-profiles/stage/heartbeat", module: "codex/native-profile-api", mutates: true },
+  { method: "POST", path: "/api/native-main-profiles/switch", module: "codex/native-profile-api", mutates: true },
+  // server/management/agent-settings-routes
+  { method: "GET", path: "/api/claude-code", module: "server/management/agent-settings-routes", mutates: false },
+  { method: "GET", path: "/api/claude-desktop", module: "server/management/agent-settings-routes", mutates: false },
+  { method: "GET", path: "/api/claude-desktop/status", module: "server/management/agent-settings-routes", mutates: false },
+  { method: "GET", path: "/api/codex-auth/features/default-mode-request-user-input", module: "server/management/agent-settings-routes", mutates: false },
+  { method: "GET", path: "/api/effort-caps", module: "server/management/agent-settings-routes", mutates: false },
+  { method: "GET", path: "/api/grok", module: "server/management/agent-settings-routes", mutates: false },
+  { method: "GET", path: "/api/injection-model", module: "server/management/agent-settings-routes", mutates: false },
+  { method: "GET", path: "/api/subagent-model-fallback", module: "server/management/agent-settings-routes", mutates: false },
+  { method: "GET", path: "/api/subagent-models", module: "server/management/agent-settings-routes", mutates: false },
+  { method: "GET", path: "/api/v2", module: "server/management/agent-settings-routes", mutates: false },
+  { method: "POST", path: "/api/claude-desktop/apply", module: "server/management/agent-settings-routes", mutates: true },
+  { method: "POST", path: "/api/grok/apply", module: "server/management/agent-settings-routes", mutates: true },
+  { method: "PUT", path: "/api/claude-code", module: "server/management/agent-settings-routes", mutates: true },
+  { method: "PUT", path: "/api/claude-desktop", module: "server/management/agent-settings-routes", mutates: true },
+  { method: "PUT", path: "/api/codex-auth/features/default-mode-request-user-input", module: "server/management/agent-settings-routes", mutates: true },
+  { method: "PUT", path: "/api/effort-caps", module: "server/management/agent-settings-routes", mutates: true },
+  { method: "PUT", path: "/api/grok/selection", module: "server/management/agent-settings-routes", mutates: true },
+  { method: "PUT", path: "/api/injection-model", module: "server/management/agent-settings-routes", mutates: true },
+  { method: "PUT", path: "/api/subagent-model-fallback", module: "server/management/agent-settings-routes", mutates: true },
+  { method: "PUT", path: "/api/subagent-models", module: "server/management/agent-settings-routes", mutates: true },
+  { method: "PUT", path: "/api/v2", module: "server/management/agent-settings-routes", mutates: true },
+  // server/management/codex-prompt-routes
+  { method: "GET", path: "/api/codex-prompt", module: "server/management/codex-prompt-routes", mutates: false },
+  { method: "GET", path: "/api/codex-prompt/text", module: "server/management/codex-prompt-routes", mutates: false },
+  { method: "POST", path: "/api/codex-prompt/adopt", module: "server/management/codex-prompt-routes", mutates: true, exempt: { reason: "session-only", why: "Prompt adoption requires the gui-session principal (codex-prompt-routes.ts:298)." } },
+  { method: "POST", path: "/api/codex-prompt/repair", module: "server/management/codex-prompt-routes", mutates: true, exempt: { reason: "session-only", why: "Prompt repair requires the gui-session principal (codex-prompt-routes.ts:298)." } },
+  { method: "PUT", path: "/api/codex-prompt/base", module: "server/management/codex-prompt-routes", mutates: true, exempt: { reason: "session-only", why: "Base prompt write requires the gui-session principal (codex-prompt-routes.ts:298)." } },
+  { method: "PUT", path: "/api/codex-prompt/base/select", module: "server/management/codex-prompt-routes", mutates: true, exempt: { reason: "session-only", why: "Base prompt selection requires the gui-session principal (codex-prompt-routes.ts:298)." } },
+  { method: "PUT", path: "/api/codex-prompt/custom", module: "server/management/codex-prompt-routes", mutates: true, exempt: { reason: "session-only", why: "Custom prompt write requires the gui-session principal (codex-prompt-routes.ts:298)." } },
+  { method: "PUT", path: "/api/codex-prompt/toggle", module: "server/management/codex-prompt-routes", mutates: true, exempt: { reason: "session-only", why: "Prompt toggle requires the gui-session principal (codex-prompt-routes.ts:298)." } },
+  // server/management/combo-routes
+  { method: "DELETE", path: "/api/combos", module: "server/management/combo-routes", mutates: true },
+  { method: "GET", path: "/api/combos", module: "server/management/combo-routes", mutates: false },
+  { method: "PUT", path: "/api/combos", module: "server/management/combo-routes", mutates: true },
+  // server/management/config-routes
+  { method: "GET", path: "/api/config", module: "server/management/config-routes", mutates: false },
+  { method: "GET", path: "/api/diagnostics/project-config", module: "server/management/config-routes", mutates: false },
+  { method: "GET", path: "/api/settings", module: "server/management/config-routes", mutates: false },
+  { method: "GET", path: "/api/shadow-call-settings", module: "server/management/config-routes", mutates: false },
+  { method: "GET", path: "/api/sidecar-settings", module: "server/management/config-routes", mutates: false },
+  { method: "GET", path: "/api/startup-health", module: "server/management/config-routes", mutates: false },
+  { method: "GET", path: "/api/update/check", module: "server/management/config-routes", mutates: false },
+  { method: "GET", path: "/api/update/status", module: "server/management/config-routes", mutates: false },
+  { method: "GET", path: "/api/windows-tray", module: "server/management/config-routes", mutates: false },
+  { method: "POST", path: "/api/startup-action", module: "server/management/config-routes", mutates: true },
+  { method: "POST", path: "/api/sync", module: "server/management/config-routes", mutates: true },
+  { method: "POST", path: "/api/update/run", module: "server/management/config-routes", mutates: true },
+  { method: "POST", path: "/api/windows-tray", module: "server/management/config-routes", mutates: true },
+  { method: "PUT", path: "/api/config", module: "server/management/config-routes", mutates: true, exempt: { reason: "disabled", why: "Returns 405 by design; provider changes go through POST /api/providers." } },
+  { method: "PUT", path: "/api/settings", module: "server/management/config-routes", mutates: true },
+  { method: "PUT", path: "/api/shadow-call-settings", module: "server/management/config-routes", mutates: true },
+  { method: "PUT", path: "/api/sidecar-settings", module: "server/management/config-routes", mutates: true },
+  // server/management/integration-routes
+  { method: "GET", path: "/api/client-integrations", module: "server/management/integration-routes", mutates: false },
+  { method: "GET", path: "/api/client-integrations/journal", module: "server/management/integration-routes", mutates: false },
+  { method: "POST", path: "/api/client-integrations/restore", module: "server/management/integration-routes", mutates: true },
+  // server/management/lab-automation-routes
+  { method: "GET", path: "/api/lab/automation", module: "server/management/lab-automation-routes", mutates: false, exempt: { reason: "local-transport", why: "ocx lab reads the same rows from the local SQLite projection; src/cli/lab.ts imports ../lab/query directly and never fetches /api/lab." } },
+  { method: "GET", path: "/api/lab/automation/runs", module: "server/management/lab-automation-routes", mutates: false, exempt: { reason: "local-transport", why: "ocx lab reads the same rows from the local SQLite projection; src/cli/lab.ts imports ../lab/query directly and never fetches /api/lab." } },
+  { method: "POST", path: "/api/lab/automation/run", module: "server/management/lab-automation-routes", mutates: true, exempt: { reason: "deferred-verb", why: "Lab automation run has no CLI verb yet. A local SQLite read cannot drive it, so local-transport does not apply.", owner: "wp7", ownerDoc: "devlog/_plan/260828_ocx_agentic_control/060_phase_gui_parity.md" } },
+  { method: "PUT", path: "/api/lab/automation", module: "server/management/lab-automation-routes", mutates: true, exempt: { reason: "deferred-verb", why: "Lab automation config update has no CLI verb yet. A local SQLite read cannot drive it, so local-transport does not apply.", owner: "wp7", ownerDoc: "devlog/_plan/260828_ocx_agentic_control/060_phase_gui_parity.md" } },
+  // server/management/lab-routes
+  { method: "GET", path: "/api/lab/artifacts", module: "server/management/lab-routes", mutates: false, exempt: { reason: "local-transport", why: "ocx lab reads the same rows from the local SQLite projection; src/cli/lab.ts imports ../lab/query directly and never fetches /api/lab." } },
+  { method: "GET", path: "/api/lab/catalog", module: "server/management/lab-routes", mutates: false, exempt: { reason: "local-transport", why: "ocx lab reads the same rows from the local SQLite projection; src/cli/lab.ts imports ../lab/query directly and never fetches /api/lab." } },
+  { method: "GET", path: "/api/lab/events", module: "server/management/lab-routes", mutates: false, exempt: { reason: "local-transport", why: "ocx lab reads the same rows from the local SQLite projection; src/cli/lab.ts imports ../lab/query directly and never fetches /api/lab." } },
+  { method: "GET", path: "/api/lab/observations", module: "server/management/lab-routes", mutates: false, exempt: { reason: "local-transport", why: "ocx lab reads the same rows from the local SQLite projection; src/cli/lab.ts imports ../lab/query directly and never fetches /api/lab." } },
+  { method: "GET", path: "/api/lab/production-signals", module: "server/management/lab-routes", mutates: false, exempt: { reason: "local-transport", why: "ocx lab reads the same rows from the local SQLite projection; src/cli/lab.ts imports ../lab/query directly and never fetches /api/lab." } },
+  { method: "GET", path: "/api/lab/public/community", module: "server/management/lab-routes", mutates: false, exempt: { reason: "local-transport", why: "ocx lab reads the same rows from the local SQLite projection; src/cli/lab.ts imports ../lab/query directly and never fetches /api/lab." } },
+  { method: "GET", path: "/api/lab/status", module: "server/management/lab-routes", mutates: false, exempt: { reason: "local-transport", why: "ocx lab reads the same rows from the local SQLite projection; src/cli/lab.ts imports ../lab/query directly and never fetches /api/lab." } },
+  { method: "GET", path: "/api/lab/subjects", module: "server/management/lab-routes", mutates: false, exempt: { reason: "local-transport", why: "ocx lab reads the same rows from the local SQLite projection; src/cli/lab.ts imports ../lab/query directly and never fetches /api/lab." } },
+  { method: "GET", path: "/api/lab/verdicts", module: "server/management/lab-routes", mutates: false, exempt: { reason: "local-transport", why: "ocx lab reads the same rows from the local SQLite projection; src/cli/lab.ts imports ../lab/query directly and never fetches /api/lab." } },
+  { method: "POST", path: "/api/lab/public/community/import", module: "server/management/lab-routes", mutates: true, exempt: { reason: "deferred-verb", why: "Community evidence import has no CLI verb yet. A local SQLite read cannot drive it, so local-transport does not apply.", owner: "wp7", ownerDoc: "devlog/_plan/260828_ocx_agentic_control/060_phase_gui_parity.md" } },
+  { method: "POST", path: "/api/lab/public/export", module: "server/management/lab-routes", mutates: true, exempt: { reason: "deferred-verb", why: "Public evidence export has no CLI verb yet. A local SQLite read cannot drive it, so local-transport does not apply.", owner: "wp7", ownerDoc: "devlog/_plan/260828_ocx_agentic_control/060_phase_gui_parity.md" } },
+  { method: "POST", path: "/api/lab/public/preview", module: "server/management/lab-routes", mutates: true, exempt: { reason: "deferred-verb", why: "Public evidence preview has no CLI verb yet. A local SQLite read cannot drive it, so local-transport does not apply.", owner: "wp7", ownerDoc: "devlog/_plan/260828_ocx_agentic_control/060_phase_gui_parity.md" } },
+  { method: "POST", path: "/api/lab/public/verify", module: "server/management/lab-routes", mutates: true, exempt: { reason: "deferred-verb", why: "Public evidence verification has no CLI verb yet. A local SQLite read cannot drive it, so local-transport does not apply.", owner: "wp7", ownerDoc: "devlog/_plan/260828_ocx_agentic_control/060_phase_gui_parity.md" } },
+  // server/management/logs-usage-routes
+  { method: "GET", path: "/api/claude/inbound-debug", module: "server/management/logs-usage-routes", mutates: false },
+  { method: "GET", path: "/api/debug", module: "server/management/logs-usage-routes", mutates: false },
+  { method: "GET", path: "/api/debug/injection-logs", module: "server/management/logs-usage-routes", mutates: false },
+  { method: "GET", path: "/api/debug/logs", module: "server/management/logs-usage-routes", mutates: false },
+  { method: "GET", path: "/api/debug/usage-logs", module: "server/management/logs-usage-routes", mutates: false },
+  { method: "GET", path: "/api/logs", module: "server/management/logs-usage-routes", mutates: false },
+  { method: "GET", path: "/api/storage/cleanup-policy", module: "server/management/logs-usage-routes", mutates: false },
+  { method: "GET", path: "/api/storage/cleanup-policy/test-stream", module: "server/management/logs-usage-routes", mutates: false, exempt: { reason: "test-seam", why: "Opt-in streaming seam declared at src/storage/policy-job.ts:71." } },
+  { method: "GET", path: "/api/storage/trash", module: "server/management/logs-usage-routes", mutates: false },
+  { method: "GET", path: "/api/storage/trash/restore/test-stream", module: "server/management/logs-usage-routes", mutates: false, exempt: { reason: "test-seam", why: "Opt-in streaming seam declared at src/storage/restore-job.ts:34." } },
+  { method: "GET", path: "/api/usage", module: "server/management/logs-usage-routes", mutates: false },
+  { method: "POST", path: "/api/storage/cleanup", module: "server/management/logs-usage-routes", mutates: true },
+  { method: "POST", path: "/api/storage/cleanup-policy/run", module: "server/management/logs-usage-routes", mutates: true },
+  { method: "POST", path: "/api/storage/cleanup/preview", module: "server/management/logs-usage-routes", mutates: true },
+  { method: "POST", path: "/api/storage/trash/restore", module: "server/management/logs-usage-routes", mutates: true },
+  { method: "PUT", path: "/api/debug", module: "server/management/logs-usage-routes", mutates: true },
+  { method: "PUT", path: "/api/storage/cleanup-policy", module: "server/management/logs-usage-routes", mutates: true },
+  // server/management/model-routes
+  { method: "GET", path: "/api/aliases", module: "server/management/model-routes", mutates: false },
+  { method: "GET", path: "/api/catalog", module: "server/management/model-routes", mutates: false },
+  { method: "GET", path: "/api/client-config", module: "server/management/model-routes", mutates: false },
+  { method: "GET", path: "/api/custom-models", module: "server/management/model-routes", mutates: false },
+  { method: "GET", path: "/api/model-discovery", module: "server/management/model-routes", mutates: false },
+  { method: "GET", path: "/api/model-presets", module: "server/management/model-routes", mutates: false },
+  { method: "GET", path: "/api/models", module: "server/management/model-routes", mutates: false },
+  { method: "GET", path: "/api/selected-models", module: "server/management/model-routes", mutates: false },
+  { method: "POST", path: "/api/custom-models", module: "server/management/model-routes", mutates: true },
+  { method: "POST", path: "/api/model-discovery/acknowledge", module: "server/management/model-routes", mutates: true },
+  { method: "PUT", path: "/api/default-aliases", module: "server/management/model-routes", mutates: true },
+  { method: "PUT", path: "/api/disabled-models", module: "server/management/model-routes", mutates: true },
+  { method: "PUT", path: "/api/model-discovery", module: "server/management/model-routes", mutates: true },
+  { method: "PUT", path: "/api/model-presets", module: "server/management/model-routes", mutates: true },
+  { method: "PUT", path: "/api/model-visibility", module: "server/management/model-routes", mutates: true },
+  { method: "PUT", path: "/api/selected-models", module: "server/management/model-routes", mutates: true },
+  // server/management/native-integration-routes
+  { method: "GET", path: "/api/native-integrations", module: "server/management/native-integration-routes", mutates: false },
+  { method: "PUT", path: "/api/native-integrations/claude", module: "server/management/native-integration-routes", mutates: true },
+  { method: "PUT", path: "/api/native-integrations/claude-desktop", module: "server/management/native-integration-routes", mutates: true },
+  { method: "PUT", path: "/api/native-integrations/codex", module: "server/management/native-integration-routes", mutates: true },
+  { method: "PUT", path: "/api/native-integrations/grok", module: "server/management/native-integration-routes", mutates: true },
+  // server/management/oauth-account-routes
+  { method: "DELETE", path: "/api/keys", module: "server/management/oauth-account-routes", mutates: true },
+  { method: "DELETE", path: "/api/oauth/accounts", module: "server/management/oauth-account-routes", mutates: true },
+  { method: "DELETE", path: "/api/providers/keys", module: "server/management/oauth-account-routes", mutates: true },
+  { method: "GET", path: "/api/key-providers", module: "server/management/oauth-account-routes", mutates: false },
+  { method: "GET", path: "/api/keys", module: "server/management/oauth-account-routes", mutates: false },
+  { method: "GET", path: "/api/oauth/accounts", module: "server/management/oauth-account-routes", mutates: false },
+  { method: "GET", path: "/api/oauth/accounts/pool", module: "server/management/oauth-account-routes", mutates: false },
+  { method: "GET", path: "/api/oauth/providers", module: "server/management/oauth-account-routes", mutates: false },
+  { method: "GET", path: "/api/oauth/status", module: "server/management/oauth-account-routes", mutates: false },
+  { method: "GET", path: "/api/providers/keys", module: "server/management/oauth-account-routes", mutates: false },
+  { method: "PATCH", path: "/api/keys", module: "server/management/oauth-account-routes", mutates: true },
+  { method: "PATCH", path: "/api/oauth/accounts/pool", module: "server/management/oauth-account-routes", mutates: true },
+  { method: "POST", path: "/api/keys", module: "server/management/oauth-account-routes", mutates: true },
+  { method: "POST", path: "/api/oauth/accounts/clear-cooldown", module: "server/management/oauth-account-routes", mutates: true },
+  { method: "POST", path: "/api/oauth/accounts/import", module: "server/management/oauth-account-routes", mutates: true },
+  { method: "POST", path: "/api/oauth/login", module: "server/management/oauth-account-routes", mutates: true },
+  { method: "POST", path: "/api/oauth/login/cancel", module: "server/management/oauth-account-routes", mutates: true },
+  { method: "POST", path: "/api/oauth/login/code", module: "server/management/oauth-account-routes", mutates: true },
+  { method: "POST", path: "/api/oauth/logout", module: "server/management/oauth-account-routes", mutates: true },
+  { method: "POST", path: "/api/providers/keys", module: "server/management/oauth-account-routes", mutates: true },
+  { method: "PUT", path: "/api/oauth/accounts/active", module: "server/management/oauth-account-routes", mutates: true },
+  { method: "PUT", path: "/api/oauth/accounts/alias", module: "server/management/oauth-account-routes", mutates: true },
+  { method: "PUT", path: "/api/oauth/accounts/pool", module: "server/management/oauth-account-routes", mutates: true },
+  { method: "PUT", path: "/api/providers/keys/active", module: "server/management/oauth-account-routes", mutates: true },
+  { method: "PUT", path: "/api/providers/keys/alias", module: "server/management/oauth-account-routes", mutates: true },
+  // server/management/provider-routes
+  { method: "DELETE", path: "/api/providers", module: "server/management/provider-routes", mutates: true },
+  { method: "GET", path: "/api/provider-context-caps", module: "server/management/provider-routes", mutates: false },
+  { method: "GET", path: "/api/provider-presets", module: "server/management/provider-routes", mutates: false },
+  { method: "GET", path: "/api/provider-quotas", module: "server/management/provider-routes", mutates: false },
+  { method: "GET", path: "/api/provider-request-pacing", module: "server/management/provider-routes", mutates: false },
+  { method: "GET", path: "/api/providers", module: "server/management/provider-routes", mutates: false },
+  { method: "PATCH", path: "/api/providers", module: "server/management/provider-routes", mutates: true },
+  { method: "POST", path: "/api/providers", module: "server/management/provider-routes", mutates: true },
+  { method: "POST", path: "/api/providers/test", module: "server/management/provider-routes", mutates: true },
+  { method: "PUT", path: "/api/provider-context-caps", module: "server/management/provider-routes", mutates: true },
+  // server/management/request-history-routes
+  { method: "GET", path: "/api/request-history", module: "server/management/request-history-routes", mutates: false },
+  // server/management/routing-analytics-routes
+  // server/management/routing-profile-routes
+  { method: "DELETE", path: "/api/routing-profiles", module: "server/management/routing-profile-routes", mutates: true },
+  { method: "GET", path: "/api/routing-profiles", module: "server/management/routing-profile-routes", mutates: false },
+  { method: "POST", path: "/api/routing-profiles/dry-run", module: "server/management/routing-profile-routes", mutates: true },
+  { method: "PUT", path: "/api/routing-profiles", module: "server/management/routing-profile-routes", mutates: true },
+  // server/management/sidebar-routes
+  { method: "GET", path: "/api/github/star", module: "server/management/sidebar-routes", mutates: false },
+  { method: "GET", path: "/api/update/badge", module: "server/management/sidebar-routes", mutates: false },
+  { method: "POST", path: "/api/github/star", module: "server/management/sidebar-routes", mutates: true, exempt: { reason: "session-only", why: "User-consent boundary in AGENTS_INSTALL.md: starring spends the user's identity. Must never gain a CLI verb." } },
+  // server/management/storage-log-guard-routes
+  { method: "GET", path: "/api/storage/codex-logs", module: "server/management/storage-log-guard-routes", mutates: false },
+  { method: "POST", path: "/api/storage/codex-logs/compact", module: "server/management/storage-log-guard-routes", mutates: true },
+  { method: "POST", path: "/api/storage/codex-logs/protect", module: "server/management/storage-log-guard-routes", mutates: true },
+  { method: "POST", path: "/api/storage/codex-logs/repair", module: "server/management/storage-log-guard-routes", mutates: true },
+  { method: "POST", path: "/api/storage/codex-logs/unprotect", module: "server/management/storage-log-guard-routes", mutates: true },
+  // server/management/system-routes
+  { method: "GET", path: "/api/system/memory", module: "server/management/system-routes", mutates: false },
+  { method: "GET", path: "/api/system/windows-replace-retries", module: "server/management/system-routes", mutates: false },
+  { method: "POST", path: "/api/system/restart", module: "server/management/system-routes", mutates: true },
+  // --- Routes an equality scan of their own file cannot see (18). ---
+  // Each carries `mechanism`; the reconciliation test counts these separately.
+  { method: "GET", path: "/api/storage", module: "server/management/storage-log-guard-routes", mutates: false, mechanism: "negated-guard" },
+  { method: "GET", path: "/api/routing-analytics", module: "server/management/routing-analytics-routes", mutates: false, mechanism: "negated-guard" },
+  { method: "GET", path: "/api/system/codex-app-server", module: "server/management/system-routes", mutates: false, mechanism: "path-constant" },
+  { method: "POST", path: "/api/system/codex-restart", module: "server/management/system-routes", mutates: true, mechanism: "path-constant" },
+  { method: "POST", path: "/api/providers/reload", module: "server/management/provider-routes", mutates: true, mechanism: "path-constant", exempt: { reason: "capability-principal", why: "Gated on the local-provider-reload-capability principal (provider-routes.ts:467), not an operator action." } },
+  { method: "GET", path: "/api/client-integrations/{clientId}", module: "server/management/integration-routes", mutates: false, mechanism: "prefix-decode" },
+  { method: "PUT", path: "/api/client-integrations/{clientId}", module: "server/management/integration-routes", mutates: true, mechanism: "prefix-decode" },
+  { method: "GET", path: "/api/request-history/{id}", module: "server/management/request-history-routes", mutates: false, mechanism: "slice" },
+  { method: "GET", path: "/api/request-history/{id}/route-decision", module: "server/management/request-history-routes", mutates: false, mechanism: "ends-with" },
+  { method: "PUT", path: "/api/providers/{provider}/alias", module: "server/management/model-routes", mutates: true, mechanism: "regex" },
+  { method: "PUT", path: "/api/providers/{provider}/model-aliases", module: "server/management/model-routes", mutates: true, mechanism: "regex" },
+  { method: "PUT", path: "/api/custom-models/{id}", module: "server/management/model-routes", mutates: true, mechanism: "regex" },
+  { method: "DELETE", path: "/api/custom-models/{id}", module: "server/management/model-routes", mutates: true, mechanism: "regex" },
+  { method: "GET", path: "/api/lab/subjects/{id}", module: "server/management/lab-routes", mutates: false, mechanism: "regex", exempt: { reason: "local-transport", why: "ocx lab reads the same rows from the local SQLite projection; src/cli/lab.ts imports ../lab/query directly and never fetches /api/lab." } },
+  { method: "GET", path: "/api/lab/events/{id}", module: "server/management/lab-routes", mutates: false, mechanism: "regex", exempt: { reason: "local-transport", why: "ocx lab reads the same rows from the local SQLite projection; src/cli/lab.ts imports ../lab/query directly and never fetches /api/lab." } },
+  { method: "GET", path: "/api/lab/artifacts/{digest}", module: "server/management/lab-routes", mutates: false, mechanism: "regex", exempt: { reason: "local-transport", why: "ocx lab reads the same rows from the local SQLite projection; src/cli/lab.ts imports ../lab/query directly and never fetches /api/lab." } },
+  { method: "POST", path: "/api/lab/automation/runs/{id}/cancel", module: "server/management/lab-automation-routes", mutates: true, mechanism: "regex", exempt: { reason: "deferred-verb", why: "Lab automation run cancellation has no CLI verb yet. A local SQLite read cannot drive it, so local-transport does not apply.", owner: "wp7", ownerDoc: "devlog/_plan/260828_ocx_agentic_control/060_phase_gui_parity.md" } },
+  { method: "GET", path: "/api/storage", module: "server/management/logs-usage-routes", mutates: false, mechanism: "negated-guard", exempt: { reason: "dead", why: "Shadowed: handleStorageLogGuardRoutes runs first (management-api.ts:221) and never returns null for GET /api/storage, so logs-usage-routes.ts:346 is unreachable. Declared so the reconciliation stays honest; delete rather than expose." } },
+];

--- a/src/server/proxy-liveness.ts
+++ b/src/server/proxy-liveness.ts
@@ -68,6 +68,14 @@ export interface LiveProxy {
   hostname?: string;
   /** Whether the successful probe used runtime-port metadata or the configured listen port. */
   source: "runtime" | "config";
+  /**
+   * Version the live proxy reported on `/healthz`, when it reported one.
+   *
+   * Carried so a stale `ocx` on PATH can be detected without a second request: the
+   * identity probe already parsed and validated this body. Absent for a legacy proxy whose
+   * healthz body predates the field.
+   */
+  version?: string;
 }
 
 /**
@@ -99,7 +107,7 @@ export async function proxyIdentityAt(
   port: number,
   opts: { hostname?: string; expectedPid?: number } = {},
   io: LivenessIo = {},
-): Promise<{ pid: number | null } | null> {
+): Promise<{ pid: number | null; version?: string } | null> {
   const fetchFn = io.fetchFn ?? directLocalHttpFetch;
   const sleepFn = io.sleepFn ?? ((ms: number) => new Promise<void>(r => setTimeout(r, ms)));
   const nowFn = io.nowFn ?? Date.now;
@@ -122,7 +130,9 @@ export async function proxyIdentityAt(
       if (!isOpencodexHealthz(body)) return null;
       const pid = typeof body?.pid === "number" ? body.pid : null;
       if (opts.expectedPid !== undefined && pid !== null && pid !== opts.expectedPid) return null;
-      return { pid };
+      // Guarded the same way `pid` is: a non-string version is absent, not coerced.
+      const version = typeof body?.version === "string" ? body.version : undefined;
+      return version === undefined ? { pid } : { pid, version };
     } catch {
       // Transport failure (timeout / refused) — retry while budget remains; a proxy that
       // has only just begun listening can miss a single short probe (#764).
@@ -180,7 +190,13 @@ export async function findLiveProxy(io: LivenessIo = {}): Promise<LiveProxy | nu
         // healthz confirmed the pid itself → trusted; a pidless legacy body did not,
         // so the cheap pid must pass full identity verification before it is returned.
         const trusted = identity.pid === pid ? pid : killablePid(pid);
-        return { pid: trusted, port: runtime.port, hostname: runtime.hostname, source: "runtime" };
+        return {
+          pid: trusted,
+          port: runtime.port,
+          hostname: runtime.hostname,
+          source: "runtime",
+          ...(identity.version === undefined ? {} : { version: identity.version }),
+        };
       }
     }
   }
@@ -197,7 +213,13 @@ export async function findLiveProxy(io: LivenessIo = {}): Promise<LiveProxy | nu
     // (its process dead, the port reused by a pidless legacy proxy) — synthesizing it
     // would hand destructive callers (stopProxy → kill fallback) a reusable pid.
     if (identity) {
-      return { pid: verifiedReportedPid(identity.pid), port: record.port, hostname: record.hostname, source: "runtime" };
+      return {
+        pid: verifiedReportedPid(identity.pid),
+        port: record.port,
+        hostname: record.hostname,
+        source: "runtime",
+        ...(identity.version === undefined ? {} : { version: identity.version }),
+      };
     }
   }
 
@@ -211,6 +233,7 @@ export async function findLiveProxy(io: LivenessIo = {}): Promise<LiveProxy | nu
       port,
       hostname: config.hostname,
       source: "config",
+      ...(identity.version === undefined ? {} : { version: identity.version }),
     };
   }
   return null;

--- a/tests/cli-capabilities.test.ts
+++ b/tests/cli-capabilities.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  CAPABILITIES,
+  HEAD_CAPABILITIES,
+  capabilitiesForRoute,
+  capabilityInvocation,
+  capabilityRouteKeys,
+} from "../src/cli/capabilities";
+import { CLI_COMMANDS, findCommand } from "../src/cli/registry";
+import { runCapabilities } from "../src/cli/capabilities-command";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function captureStdout(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => { lines.push(args.map(String).join(" ")); };
+  return { lines, restore: () => { console.log = original; } };
+}
+
+describe("capability table is a leaf data module", () => {
+  test("capabilities.ts imports nothing from src/cli", () => {
+    // Each command module declares `const USAGE` at top level, evaluated at import time.
+    // A cycle back into this table resolves to `undefined` under ESM instead of throwing,
+    // which would silently empty the usage text that rejectArgs hands CliUsageError --
+    // a degraded failure in the exact surface these issues are about.
+    const src = readFileSync(join(repoRoot, "src/cli/capabilities.ts"), "utf8");
+    const relative = src.match(/from\s+["']\.[^"']*["']/g) ?? [];
+    expect(relative).toEqual([]);
+    expect(/\bimport\s*\(/.test(src)).toBe(false);
+  });
+
+  test("every capability renders a non-empty invocation and summary", () => {
+    // Guards the degraded-cycle failure mode directly: an empty string here means the
+    // table resolved to undefined somewhere rather than throwing.
+    const empty = CAPABILITIES.filter(c => capabilityInvocation(c).trim() === "ocx" || c.summary.trim() === "");
+    expect(empty).toEqual([]);
+    for (const head of HEAD_CAPABILITIES) {
+      expect(head.invocations.length).toBeGreaterThan(0);
+      expect(head.summary.trim().length).toBeGreaterThan(0);
+      expect(head.bannerLine.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  test("a capability declaring routes marks mutation consistently", () => {
+    // A capability that drives only GETs must not claim to mutate, and one driving a
+    // write must not claim otherwise -- the flag is what --mutating-only filters on.
+    const wrong: string[] = [];
+    for (const cap of CAPABILITIES) {
+      if (cap.routes.length === 0) continue;
+      const anyWrite = cap.routes.some(r => r.method !== "GET");
+      if (anyWrite !== cap.mutates) wrong.push(capabilityInvocation(cap));
+    }
+    expect(wrong).toEqual([]);
+  });
+
+  test("head-handled surfaces are NOT registry commands", () => {
+    // tests/cli-registry.test.ts excludes help/--help/-h as head-handled pseudo-cases,
+    // and --version exits in the CLI head before dispatch. Declaring either as a
+    // CLI_COMMANDS entry would break the runner-key parity assertion.
+    const names = new Set(CLI_COMMANDS.map(e => e.name));
+    for (const head of HEAD_CAPABILITIES) {
+      for (const invocation of head.invocations) {
+        expect(names.has(invocation), `${invocation} must stay head-handled`).toBe(false);
+      }
+    }
+  });
+
+  test("the capabilities verb itself is a registered command", () => {
+    expect(findCommand("capabilities")?.name).toBe("capabilities");
+    expect(CAPABILITIES.some(c => c.command[0] === "capabilities")).toBe(true);
+  });
+});
+
+describe("ocx capabilities output", () => {
+  test("--json emits a stable envelope with routes and flags", async () => {
+    const cap = captureStdout();
+    let code: number;
+    try { code = await runCapabilities(["--json"]); } finally { cap.restore(); }
+    expect(code).toBe(0);
+    const parsed = JSON.parse(cap.lines.join("\n")) as {
+      schemaVersion: number;
+      capabilities: { invocation: string; routes: unknown[]; flags: unknown[]; mutates: boolean; json: string }[];
+      headCapabilities?: unknown[];
+    };
+    expect(parsed.schemaVersion).toBe(1);
+    expect(parsed.capabilities.length).toBe(CAPABILITIES.length);
+    expect(parsed.headCapabilities).toHaveLength(HEAD_CAPABILITIES.length);
+    for (const entry of parsed.capabilities) {
+      expect(entry.invocation.startsWith("ocx ")).toBe(true);
+      expect(Array.isArray(entry.routes)).toBe(true);
+      expect(Array.isArray(entry.flags)).toBe(true);
+      expect(typeof entry.mutates).toBe("boolean");
+      expect(["payload", "envelope", "none"]).toContain(entry.json);
+    }
+  });
+
+  test("--route resolves to the capabilities driving that route", async () => {
+    const target = "/api/codex-auth/accounts";
+    expect(capabilitiesForRoute(target).length).toBeGreaterThan(0);
+    const cap = captureStdout();
+    let code: number;
+    try { code = await runCapabilities(["--route", target, "--json"]); } finally { cap.restore(); }
+    expect(code).toBe(0);
+    const parsed = JSON.parse(cap.lines.join("\n")) as { route: string; capabilities: { invocation: string }[] };
+    expect(parsed.route).toBe(target);
+    expect(parsed.capabilities.map(c => c.invocation)).toContain("ocx account list");
+  });
+
+  test("--route accepts the flag in any argv position", async () => {
+    // Order-independence is the point: positional flag reading is why
+    // `ocx restore back --json` silently ignored its flag.
+    const cap = captureStdout();
+    let code: number;
+    try { code = await runCapabilities(["--json", "--route", "/api/usage"]); } finally { cap.restore(); }
+    expect(code).toBe(0);
+    const parsed = JSON.parse(cap.lines.join("\n")) as { capabilities: { invocation: string }[] };
+    expect(parsed.capabilities.map(c => c.invocation)).toEqual(["ocx usage"]);
+  });
+
+  test("an unmatched route exits non-zero instead of reporting empty success", async () => {
+    // Reporting success for a route no verb drives is the class of dishonesty wp2 fixed
+    // in the transport layer; do not reintroduce it here.
+    const cap = captureStdout();
+    let code: number;
+    try { code = await runCapabilities(["--route", "/api/does-not-exist", "--json"]); } finally { cap.restore(); }
+    expect(code).toBe(4);
+  });
+
+  test("--mutating-only keeps only mutating capabilities", async () => {
+    const cap = captureStdout();
+    try { await runCapabilities(["--mutating-only", "--json"]); } finally { cap.restore(); }
+    const parsed = JSON.parse(cap.lines.join("\n")) as { capabilities: { mutates: boolean }[] };
+    expect(parsed.capabilities.every(c => c.mutates)).toBe(true);
+  });
+
+  test("every route a capability declares exists in the management registry", async () => {
+    // The capability table must not advertise a route the server does not serve.
+    const { MANAGEMENT_ROUTES } = await import("../src/server/management/route-registry");
+    const declared = new Set(MANAGEMENT_ROUTES.map(r => `${r.method} ${r.path}`));
+    const unknown = [...capabilityRouteKeys()].filter(k => !declared.has(k));
+    expect(unknown).toEqual([]);
+  });
+});

--- a/tests/cli-capabilities.test.ts
+++ b/tests/cli-capabilities.test.ts
@@ -131,10 +131,25 @@ describe("ocx capabilities output", () => {
   });
 
   test("--mutating-only keeps only mutating capabilities", async () => {
+    const expected = CAPABILITIES.filter(c => c.mutates);
     const cap = captureStdout();
     try { await runCapabilities(["--mutating-only", "--json"]); } finally { cap.restore(); }
     const parsed = JSON.parse(cap.lines.join("\n")) as { capabilities: { mutates: boolean }[] };
+    expect(parsed.capabilities).toHaveLength(expected.length);
     expect(parsed.capabilities.every(c => c.mutates)).toBe(true);
+  });
+
+  test("ocx provider list does not claim GET /api/providers", () => {
+    const cap = CAPABILITIES.find(c => c.command[0] === "provider" && c.command[1] === "list");
+    expect(cap).toBeDefined();
+    expect(cap?.routes).toEqual([]);
+  });
+
+  test("--route without a path is usage, not a full table dump", async () => {
+    const cap = captureStdout();
+    let code: number;
+    try { code = await runCapabilities(["--route"]); } finally { cap.restore(); }
+    expect(code).toBe(64);
   });
 
   test("every route a capability declares exists in the management registry", async () => {

--- a/tests/cli-version-skew.test.ts
+++ b/tests/cli-version-skew.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { computeVersionSkew } from "../src/cli/version-skew";
+import { packageVersion } from "../src/cli/help";
+
+/**
+ * #2701: an older `ocx` earlier on PATH than the running proxy described a different
+ * build, and nothing surfaced it because the CLI never compared the two versions.
+ */
+describe("version skew detection", () => {
+  test("reports skew when the proxy reports a different version", () => {
+    const skew = computeVersionSkew("2.35.0", "2.36.1");
+    expect(skew.skewed).toBe(true);
+    expect(skew.cliVersion).toBe("2.35.0");
+    expect(skew.proxyVersion).toBe("2.36.1");
+    expect(skew.warning).toContain("2.35.0");
+    expect(skew.warning).toContain("2.36.1");
+    expect(skew.warning).toContain("stale");
+  });
+
+  test("stays quiet when the versions match", () => {
+    const skew = computeVersionSkew("2.35.0", "2.35.0");
+    expect(skew.skewed).toBe(false);
+    expect(skew.warning).toBeNull();
+  });
+
+  test("stays quiet when nothing is live", () => {
+    const skew = computeVersionSkew("2.35.0", undefined);
+    expect(skew.skewed).toBe(false);
+    expect(skew.proxyVersion).toBeNull();
+    expect(skew.warning).toBeNull();
+  });
+
+  test("suppresses the warning when the proxy reports the 0.0.0 placeholder", () => {
+    // The server's VERSION falls back to "0.0.0" when it cannot resolve its own package.
+    // Comparing against it would send an operator to reinstall a healthy install.
+    expect(computeVersionSkew("2.35.0", "0.0.0").skewed).toBe(false);
+    expect(computeVersionSkew("2.35.0", "0.0.0").warning).toBeNull();
+  });
+
+  test("suppresses the warning when the CLI cannot resolve its own version", () => {
+    // packageVersion() answers "unknown" for a non-string version; that means "cannot
+    // compare", not "different".
+    expect(computeVersionSkew("unknown", "2.36.1").skewed).toBe(false);
+    expect(computeVersionSkew("unknown", "2.36.1").warning).toBeNull();
+  });
+
+  test("a legacy proxy version still compares, since it is a real version", () => {
+    // A pre-identity healthz body carries a version even without a pid, and an older proxy
+    // is precisely the skew worth reporting.
+    expect(computeVersionSkew("2.35.0", "2.6.16").skewed).toBe(true);
+  });
+
+  test("packageVersion is exported and resolves a real version", () => {
+    const version = packageVersion();
+    expect(typeof version).toBe("string");
+    expect(version.length).toBeGreaterThan(0);
+    expect(version).not.toBe("unknown");
+  });
+});

--- a/tests/helpers/management-route-scan.ts
+++ b/tests/helpers/management-route-scan.ts
@@ -1,0 +1,218 @@
+/**
+ * Static route scanner for the management surface.
+ *
+ * This exists because a route count is only useful if it is reproducible. The wp3 plan
+ * originally reconciled `rg` line hits against a registry, and that identity cannot
+ * balance: one guard line can register two routes (`PUT || PATCH`), a preceding sibling
+ * guard can fix the method for every route after it, and two live routes are written as
+ * `pathname !== "…"` so a `===` scan never sees them at all. One module
+ * (`routing-analytics-routes.ts`) has one route and zero `===` literals, so a
+ * literal-keyed check omits the module entirely. Worse, for `GET /api/storage` a `===`
+ * scan finds only the dead shadowed copy in `logs-usage-routes.ts` and never the live
+ * negated-guard one, so it would have mistaken the corpse for the patient.
+ *
+ * So this resolves `(method, path)` pairs instead of counting lines, and it maintains a
+ * method NARROWING CONTEXT while walking statements in order:
+ *
+ * - `if (req.method !== "GET") return null;` at some brace depth narrows every later
+ *   statement at that depth or deeper to GET, until the depth closes.
+ * - `if (req.method === "POST") {` narrows only its own block.
+ * - A same-line conjunction (`pathname === "/x" && req.method === "POST"`) binds only
+ *   that route.
+ *
+ * Both nesting orders occur in real code and neither is inferable from the other:
+ * `lab-routes.ts:352` narrows method BEFORE eight path literals, while
+ * `storage-log-guard-routes.ts:112` opens with the path and puts the method guard INSIDE
+ * at :113. A scanner that only looked forward and outward resolved none of the lab reads.
+ *
+ * FAIL LOUD, never guess. When a path guard is found with no resolvable method, the
+ * route is returned with `method: null` and the caller is expected to fail. Defaulting
+ * to GET is how a scanner produces a number nobody can trust.
+ *
+ * Out of scope by construction (declared in the registry's allowlist instead): regex
+ * matching, `endsWith`, `pathname.slice`, and path constants. A static text walker
+ * cannot resolve those, and pretending otherwise is what made the original figures
+ * unreproducible.
+ */
+import { readFileSync } from "node:fs";
+
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD";
+
+export interface ScannedRoute {
+  readonly path: string;
+  /** null means the scanner could not resolve a method; callers must fail, not guess. */
+  readonly method: HttpMethod | null;
+  readonly line: number;
+  /** `equality` for `pathname === "…"`, `negated` for `pathname !== "…"`. */
+  readonly form: "equality" | "negated";
+}
+
+const METHODS: readonly HttpMethod[] = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"];
+
+/** A `req.method !== "X"` early return in force from `depth` downward. */
+interface Narrowing {
+  readonly depth: number;
+  readonly method: HttpMethod;
+}
+
+function stripCommentsAndStrings(line: string): string {
+  // Only line comments matter here: the guards this scanner reads are single-line, and
+  // a block comment mentioning `pathname === "/api/x"` inside a doc comment would
+  // otherwise register as a route. Keeps string bodies, because the paths live in them.
+  const idx = line.indexOf("//");
+  if (idx === -1) return line;
+  // Do not cut inside a string literal (`"http://…"`).
+  let quote: string | null = null;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (quote) {
+      if (ch === "\\") { i++; continue; }
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") { quote = ch; continue; }
+    if (ch === "/" && line[i + 1] === "/") return line.slice(0, i);
+  }
+  return line;
+}
+
+function methodsOnLine(line: string): HttpMethod[] {
+  const found: HttpMethod[] = [];
+  for (const m of METHODS) {
+    if (new RegExp(`method\\s*===\\s*"${m}"`).test(line)) found.push(m);
+  }
+  return found;
+}
+
+function depthDelta(line: string): number {
+  let delta = 0;
+  let quote: string | null = null;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (quote) {
+      if (ch === "\\") { i++; continue; }
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") { quote = ch; continue; }
+    if (ch === "{") delta++;
+    else if (ch === "}") delta--;
+  }
+  return delta;
+}
+
+/**
+ * Scan one source file for `(method, path)` route guards.
+ *
+ * Deliberately text-based rather than AST-based: the assertion this feeds is about
+ * catching a route someone ADDS, and a walker small enough to read in one sitting is
+ * more trustworthy for that than a parser whose failure mode is silence.
+ */
+export function scanRoutes(file: string): ScannedRoute[] {
+  const src = readFileSync(file, "utf8");
+  const lines = src.split("\n");
+  const routes: ScannedRoute[] = [];
+  const narrowings: Narrowing[] = [];
+  let depth = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i] ?? "";
+    const line = stripCommentsAndStrings(raw);
+
+    // A narrowing only survives while its brace depth is still open.
+    while (narrowings.length > 0 && depth < narrowings[narrowings.length - 1]!.depth) {
+      narrowings.pop();
+    }
+
+      const pathMatch = /pathname\s*(===|!==)\s*"([^"]+)"/.exec(line);
+    if (pathMatch) {
+      const form = pathMatch[1] === "===" ? "equality" as const : "negated" as const;
+      const path = pathMatch[2]!;
+      // A guard can wrap across lines:
+      //   if (\n  url.pathname === "/x"\n  && (req.method === "PUT" || req.method === "PATCH")\n) {
+      // so the method clause is neither on the path line nor inside the opened block.
+      // Read forward to the `)` that closes the condition and treat that whole span as
+      // "the same line". Without this, `/api/codex-auth/pool-strategy` came back
+      // unresolved -- which is the scanner behaving correctly, and is how this case was
+      // found rather than assumed.
+      let conditionSpan = line;
+      if (!/\)\s*\{?\s*$/.test(line.trim()) || line.trim().startsWith("url.pathname")) {
+        for (let j = i + 1; j <= Math.min(i + 4, lines.length - 1); j++) {
+          const ahead = stripCommentsAndStrings(lines[j] ?? "");
+          conditionSpan += " " + ahead;
+          if (/^\s*\)\s*\{/.test(ahead) || /\)\s*\{\s*$/.test(ahead)) break;
+          if (/pathname\s*(===|!==)\s*"/.test(ahead)) break;
+        }
+      }
+      const sameLine = methodsOnLine(conditionSpan);
+      // A negated path guard pairs with a negated method guard on the same line:
+      // `if (pathname !== "/api/storage" || method !== "GET") return null` means the
+      // route IS GET /api/storage. Read the negated form directly.
+      const negatedSameLine: HttpMethod[] = [];
+      for (const m of METHODS) {
+        if (new RegExp(`method\\s*!==\\s*"${m}"`).test(conditionSpan)) negatedSameLine.push(m);
+      }
+      let method: HttpMethod | null = null;
+      if (sameLine.length > 0) {
+        // `PUT || PATCH` on one guard is TWO routes, not one. Emit every method in the
+        // disjunction; a plan that counted this line once undercounted the surface.
+        for (const m of sameLine) {
+          routes.push({ path, method: m, line: i + 1, form });
+        }
+        depth += depthDelta(line);
+        continue;
+      }
+      else if (negatedSameLine.length === 1) method = negatedSameLine[0]!;
+      else {
+        // Then the block this path guard opens (`{ if (method !== "GET") return null;`).
+        for (let j = i + 1; j <= Math.min(i + 3, lines.length - 1); j++) {
+          const ahead = stripCommentsAndStrings(lines[j] ?? "");
+          if (/pathname\s*(===|!==)\s*"/.test(ahead)) break;
+          const inner: HttpMethod[] = [];
+          for (const m of METHODS) {
+            if (new RegExp(`method\\s*!==\\s*"${m}"`).test(ahead)) inner.push(m);
+          }
+          if (inner.length === 1) { method = inner[0]!; break; }
+          const eq = methodsOnLine(ahead);
+          if (eq.length === 1) { method = eq[0]!; break; }
+        }
+        // Finally the narrowing context established by a preceding sibling guard.
+        if (method === null && narrowings.length > 0) {
+          method = narrowings[narrowings.length - 1]!.method;
+        }
+      }
+      routes.push({ path, method, line: i + 1, form });
+    } else {
+      // `if (req.method !== "GET") return null;` narrows everything after it.
+      const negated = /method\s*!==\s*"([A-Z]+)"/.exec(line);
+      if (negated && /return\s+null/.test(line)) {
+        const m = negated[1] as HttpMethod;
+        if (METHODS.includes(m)) narrowings.push({ depth, method: m });
+      } else {
+        // `if (req.method === "POST") {` narrows its own block.
+        const eq = methodsOnLine(line);
+        if (eq.length === 1 && line.includes("{") && !line.includes("pathname")) {
+          narrowings.push({ depth: depth + 1, method: eq[0]! });
+        }
+      }
+    }
+
+    depth += depthDelta(line);
+  }
+
+  return routes;
+}
+
+/** Distinct `(method, path)` pairs, with unresolved-method routes surfaced separately. */
+export function distinctRoutes(scanned: readonly ScannedRoute[]): {
+  pairs: string[];
+  unresolved: ScannedRoute[];
+} {
+  const pairs = new Set<string>();
+  const unresolved: ScannedRoute[] = [];
+  for (const r of scanned) {
+    if (r.method === null) { unresolved.push(r); continue; }
+    pairs.add(`${r.method} ${r.path}`);
+  }
+  return { pairs: [...pairs].sort(), unresolved };
+}

--- a/tests/local-management-direct-transport.test.ts
+++ b/tests/local-management-direct-transport.test.ts
@@ -354,7 +354,12 @@ describe("local management direct transport", () => {
       const line = stdout.trim().split(/\r?\n/).at(-1);
       expect(line ? JSON.parse(line) : null).toEqual({
         control: { via: "proxy" },
-        identity: { pid: PID },
+        // `version` rides back with the identity probe now that the CLI reports version
+        // skew against the running proxy (#2701). The healthz fixture above already serves
+        // `version: "test"`, so asserting it here pins that the field is threaded through
+        // the direct transport rather than dropped -- an exact-match assertion is the point
+        // of this test, so it is widened deliberately, not loosened to a subset match.
+        identity: { pid: PID, version: "test" },
         readiness: { ready: true, status: "ready", pid: PID, port: targetPort },
         readKind: "response",
         memory: { pid: PID },

--- a/tests/management-route-registry.test.ts
+++ b/tests/management-route-registry.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { MANAGEMENT_ROUTES } from "../src/server/management/route-registry";
+import { scanRoutes, distinctRoutes } from "./helpers/management-route-scan";
+
+/**
+ * Reconciles the declared route registry against source, in three directions.
+ *
+ * Why three, and why none of them is sufficient alone -- stated here because the
+ * original plan for this gate specified ONE mechanism that could not work, and a future
+ * reader is otherwise likely to "simplify" it back:
+ *
+ * 1. SOURCE -> REGISTRY. Every `(method, path)` pair resolvable from source must be
+ *    declared. Catches an added route. Cannot see the 18 routes registered by regex,
+ *    `endsWith`, `slice`, prefix decode, or a path constant.
+ * 2. REGISTRY -> SOURCE. Every declared literal route's path must appear in its declared
+ *    owner file. Catches a typo or a stale declaration. Cannot hold for the 18
+ *    non-literal routes, whose paths contain `{param}` placeholders that appear nowhere.
+ * 3. PER-MODULE RECONCILIATION. For each module, declared count must equal scanned pairs
+ *    plus declared non-literal routes. This is the one that catches an UNDER-declared
+ *    registry: a route omitted from the registry AND invisible to check 1 is invisible
+ *    to both other checks, and that is precisely where a gate passes vacuously.
+ *
+ * The reconciliation counts `(method, path)` PAIRS, never `rg` line hits. Line counting
+ * cannot balance: one guard registers two routes when it reads `PUT || PATCH`, nineteen
+ * path guards decide their method in a preceding sibling guard or a nested one, and two
+ * live routes are written `pathname !== "…"` so an equality scan never sees them. One
+ * module has one route and zero equality literals.
+ *
+ * The scanner fails loud: a path guard whose method it cannot resolve comes back with
+ * `method: null` and test 4 fails on it. It never assumes GET.
+ */
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** Files that carry management routes. Kept explicit: two live outside `management/`. */
+function routeCarryingFiles(): string[] {
+  const files = [
+    "src/server/management-api.ts",
+    // Mounted outside the `??` chain (management-api.ts:284, :289), which is why a scan
+    // scoped to `src/server/management/` misses 29 route literals entirely.
+    "src/codex/auth-api.ts",
+    "src/codex/native-profile-api.ts",
+  ];
+  for (const f of readdirSync(join(repoRoot, "src/server/management")).sort()) {
+    // Skip the registry itself: it is a data table whose doc comment quotes route paths,
+    // so scanning it would reconcile the declaration against its own prose.
+    if (f.endsWith(".ts") && f !== "route-registry.ts") files.push(`src/server/management/${f}`);
+  }
+  return files;
+}
+
+const moduleOf = (file: string): string => file.replace(/^src\//, "").replace(/\.ts$/, "");
+const key = (method: string, path: string): string => `${method} ${path}`;
+
+describe("management route registry reconciliation", () => {
+  test("every route resolvable from source is declared in the registry", () => {
+    const declared = new Set(MANAGEMENT_ROUTES.map(r => key(r.method, r.path)));
+    const undeclared: string[] = [];
+    for (const file of routeCarryingFiles()) {
+      const { pairs } = distinctRoutes(scanRoutes(join(repoRoot, file)));
+      for (const pair of pairs) {
+        if (!declared.has(pair)) undeclared.push(`${pair}  (${file})`);
+      }
+    }
+    expect(undeclared).toEqual([]);
+  });
+
+  test("every declared literal route's path appears in its owner module", () => {
+    const missing: string[] = [];
+    const cache = new Map<string, string>();
+    for (const route of MANAGEMENT_ROUTES) {
+      // Non-literal routes carry `{param}` placeholders or live behind a constant, so
+      // their path is not present as text. Check 3 covers them instead.
+      if (route.mechanism) continue;
+      const file = `src/${route.module}.ts`;
+      let src = cache.get(file);
+      if (src === undefined) {
+        src = readFileSync(join(repoRoot, file), "utf8");
+        cache.set(file, src);
+      }
+      if (!src.includes(`"${route.path}"`)) missing.push(`${key(route.method, route.path)} not in ${file}`);
+    }
+    expect(missing).toEqual([]);
+  });
+
+  test("per-module counts reconcile: declared == scanned pairs + declared non-literal", () => {
+    const mismatches: string[] = [];
+    for (const file of routeCarryingFiles()) {
+      const mod = moduleOf(file);
+      const { pairs } = distinctRoutes(scanRoutes(join(repoRoot, file)));
+      const declaredForModule = MANAGEMENT_ROUTES.filter(r => r.module === mod);
+      const nonLiteral = declaredForModule.filter(r => r.mechanism);
+      // A non-literal route can ALSO be scannable (a negated guard is both), so count
+      // the union rather than adding two overlapping sets.
+      const expected = new Set<string>(pairs);
+      for (const r of nonLiteral) expected.add(key(r.method, r.path));
+      const actual = new Set(declaredForModule.map(r => key(r.method, r.path)));
+      if (expected.size !== actual.size) {
+        const onlyExpected = [...expected].filter(k => !actual.has(k));
+        const onlyActual = [...actual].filter(k => !expected.has(k));
+        mismatches.push(`${mod}: expected ${expected.size} got ${actual.size}; missing=[${onlyExpected}] extra=[${onlyActual}]`);
+      }
+    }
+    expect(mismatches).toEqual([]);
+  });
+
+  test("the scanner resolves a method for every route guard it finds", () => {
+    // Fail loud, never guess. An unresolvable guard means the scanner needs a new
+    // narrowing rule, not a default.
+    const unresolved: string[] = [];
+    for (const file of routeCarryingFiles()) {
+      for (const r of distinctRoutes(scanRoutes(join(repoRoot, file))).unresolved) {
+        unresolved.push(`${file}:${r.line} ${r.path}`);
+      }
+    }
+    expect(unresolved).toEqual([]);
+  });
+
+  test("the scanner reports an unresolvable method instead of assuming GET", () => {
+    // Drives the fail-loud path red on purpose: without this, a scanner that silently
+    // defaulted to GET would satisfy every other test in this file while producing a
+    // route table nobody could trust.
+    const tmp = join(repoRoot, ".tmp-scanner-probe.ts");
+    const source = [
+      "export async function handleProbe(ctx: any): Promise<Response | null> {",
+      "  const { url, req } = ctx;",
+      "  const chosen = req.method;",
+      '  if (url.pathname === "/api/probe/unknowable") {',
+      "    return dispatch(chosen);",
+      "  }",
+      "  return null;",
+      "}",
+    ].join("\n");
+    try {
+      Bun.writeSync?.(0, "");
+    } catch {
+      // no-op: Bun.writeSync is not used, this is only to keep the try shape obvious
+    }
+    require("node:fs").writeFileSync(tmp, source);
+    try {
+      const { unresolved } = distinctRoutes(scanRoutes(tmp));
+      expect(unresolved.map(r => r.path)).toEqual(["/api/probe/unknowable"]);
+      expect(unresolved[0]?.method).toBeNull();
+    } finally {
+      require("node:fs").rmSync(tmp, { force: true });
+    }
+  });
+
+  test("a multi-method disjunction expands into one route per method", () => {
+    // `PUT || PATCH` on one guard is two routes. A count keyed on line hits saw one.
+    const poolStrategy = MANAGEMENT_ROUTES.filter(r => r.path === "/api/codex-auth/pool-strategy");
+    expect(poolStrategy.map(r => r.method).sort()).toEqual(["PATCH", "PUT"]);
+  });
+
+  test("the two negated-guard routes are declared", () => {
+    // An equality scan cannot see either, and for /api/storage it finds only the dead
+    // shadowed copy. Both must be present, and the live one must not be the dead one.
+    const storage = MANAGEMENT_ROUTES.filter(r => r.path === "/api/storage");
+    expect(storage).toHaveLength(2);
+    const live = storage.find(r => r.module.endsWith("storage-log-guard-routes"));
+    const dead = storage.find(r => r.module.endsWith("logs-usage-routes"));
+    expect(live?.exempt).toBeUndefined();
+    expect(dead?.exempt?.reason).toBe("dead");
+    expect(MANAGEMENT_ROUTES.some(r => r.path === "/api/routing-analytics")).toBe(true);
+  });
+});
+
+describe("route exemptions stay honest", () => {
+  test("every exemption carries a non-trivial reason", () => {
+    const thin = MANAGEMENT_ROUTES
+      .filter(r => r.exempt && r.exempt.why.trim().length < 40)
+      .map(r => key(r.method, r.path));
+    expect(thin).toEqual([]);
+  });
+
+  test("a deferred-verb exemption names an owner phase and a TRACKED doc that exists", () => {
+    // The owner doc is a repository file, deliberately NOT the goalplan: `.codexclaw/` is
+    // gitignored, so a test reading it would pass locally and find nothing in CI -- the
+    // same vacuous pass this suite exists to prevent.
+    const deferred = MANAGEMENT_ROUTES.filter(r => r.exempt?.reason === "deferred-verb");
+    expect(deferred.length).toBeGreaterThan(0);
+    const problems: string[] = [];
+    for (const route of deferred) {
+      const { owner, ownerDoc } = route.exempt!;
+      if (!owner) problems.push(`${key(route.method, route.path)}: no owner`);
+      if (!ownerDoc) { problems.push(`${key(route.method, route.path)}: no ownerDoc`); continue; }
+      if (!existsSync(join(repoRoot, ownerDoc))) problems.push(`${key(route.method, route.path)}: ownerDoc ${ownerDoc} missing`);
+    }
+    expect(problems).toEqual([]);
+  });
+
+  test("the user-consent star boundary is exempt and never gains a verb", () => {
+    const star = MANAGEMENT_ROUTES.find(r => r.path === "/api/github/star" && r.method === "POST");
+    expect(star?.exempt?.reason).toBe("session-only");
+  });
+
+  test("every mutating lab route is either verbed or bounded by a deferred-verb owner", () => {
+    // The original plan exempted "20 /api/lab/* reads" under local-transport. The family
+    // holds 7 mutating routes, and reading local SQLite cannot start an automation run,
+    // so local-transport never covered them.
+    const mutatingLab = MANAGEMENT_ROUTES.filter(r => r.path.startsWith("/api/lab") && r.mutates);
+    expect(mutatingLab).toHaveLength(7);
+    for (const route of mutatingLab) {
+      expect(route.exempt?.reason, key(route.method, route.path)).toBe("deferred-verb");
+    }
+  });
+
+  test("no lab route is exempted as local-transport while mutating", () => {
+    const wrong = MANAGEMENT_ROUTES
+      .filter(r => r.mutates && r.exempt?.reason === "local-transport")
+      .map(r => key(r.method, r.path));
+    expect(wrong).toEqual([]);
+  });
+});
+
+describe("the registry is inert data", () => {
+  test("route-registry.ts imports nothing at all", () => {
+    // It is imported by src/server/management-api.ts, which tests/core-lab-boundary
+    // protects. A path string creates no module edge; an import would.
+    const src = readFileSync(join(repoRoot, "src/server/management/route-registry.ts"), "utf8");
+    const imports = src.match(/^\s*(import|export)\s+[^;]*from\s+["'][^"']+["']/gm) ?? [];
+    expect(imports).toEqual([]);
+    // Check the import graph, not prose: this file's own header explains why it must not
+    // import Lab, so a naive substring search flags the explanation as the violation.
+    expect(/from\s+["'][^"']*lab[^"']*["']/.test(src)).toBe(false);
+    expect(/\bimport\s*\(/.test(src)).toBe(false);
+  });
+});

--- a/tests/management-route-registry.test.ts
+++ b/tests/management-route-registry.test.ts
@@ -133,11 +133,6 @@ describe("management route registry reconciliation", () => {
       "  return null;",
       "}",
     ].join("\n");
-    try {
-      Bun.writeSync?.(0, "");
-    } catch {
-      // no-op: Bun.writeSync is not used, this is only to keep the try shape obvious
-    }
     require("node:fs").writeFileSync(tmp, source);
     try {
       const { unresolved } = distinctRoutes(scanRoutes(tmp));

--- a/tests/proxy-liveness.test.ts
+++ b/tests/proxy-liveness.test.ts
@@ -53,7 +53,7 @@ describe("probeHostname", () => {
 describe("proxyIdentityAt", () => {
   test("returns the reported pid for our proxy", async () => {
     const identity = await proxyIdentityAt(10100, {}, { fetchFn: (async () => healthz(OURS)) as typeof fetch });
-    expect(identity).toEqual({ pid: 4242 });
+    expect(identity).toEqual({ pid: 4242, version: "2.6.17" });
   });
 
   test("rejects foreign 200s, non-OK responses, and pid mismatches", async () => {
@@ -76,7 +76,7 @@ describe("proxyIdentityAt", () => {
         return healthz(OURS);
       }) as typeof fetch,
     });
-    expect(identity).toEqual({ pid: 4242 });
+    expect(identity).toEqual({ pid: 4242, version: "2.6.17" });
     expect(calls).toBe(3);
     expect(sleeps).toEqual([100, 100]);
   });
@@ -103,7 +103,7 @@ describe("proxyIdentityAt", () => {
         return healthz(OURS);
       }) as typeof fetch,
     });
-    expect(identity).toEqual({ pid: 4242 });
+    expect(identity).toEqual({ pid: 4242, version: "2.6.17" });
     expect(calls).toBe(1);
   });
 
@@ -141,7 +141,7 @@ describe("findLiveProxy", () => {
       }) as typeof fetch,
     });
 
-    expect(live).toEqual({ pid: 4242, port: 58195, source: "runtime" });
+    expect(live).toEqual({ pid: 4242, port: 58195, source: "runtime", version: "2.6.17" });
     expect(urls).toEqual(["http://127.0.0.1:58195/healthz"]);
   });
 
@@ -154,7 +154,7 @@ describe("findLiveProxy", () => {
       fetchFn: (async () => healthz(OURS)) as typeof fetch,
     });
 
-    expect(live).toEqual({ pid: 4242, port: 10100, source: "config" });
+    expect(live).toEqual({ pid: 4242, port: 10100, source: "config", version: "2.6.17" });
   });
 
   test("a foreign listener on the configured port is not treated as our proxy", async () => {
@@ -181,7 +181,7 @@ describe("findLiveProxy", () => {
       }) as typeof fetch,
     });
 
-    expect(live).toEqual({ pid: 4242, port: 58195, hostname: "::1", source: "runtime" });
+    expect(live).toEqual({ pid: 4242, port: 58195, hostname: "::1", source: "runtime", version: "2.6.17" });
     expect(urls).toEqual(["http://[::1]:58195/healthz"]);
   });
 
@@ -197,7 +197,7 @@ describe("findLiveProxy", () => {
 
     // The record's pid 1111 may be dead/reused — synthesizing it would let `ocx stop`
     // kill an unrelated process via the taskkill/kill fallback.
-    expect(live).toEqual({ pid: null, port: 58195, hostname: undefined, source: "runtime" });
+    expect(live).toEqual({ pid: null, port: 58195, hostname: undefined, source: "runtime", version: "2.6.16" });
   });
 
   test("an orphaned record whose healthz pid mismatches is rejected (config fallback still runs)", async () => {
@@ -222,7 +222,7 @@ describe("findLiveProxy", () => {
     });
 
     // healthz-reported pids must pass identity verification before they become kill targets.
-    expect(live).toEqual({ pid: null, port: 58195, source: "config" });
+    expect(live).toEqual({ pid: null, port: 58195, source: "config", version: "2.6.17" });
   });
 
   test("a pidless legacy healthz never promotes an unverified cheap pid to a kill target", async () => {
@@ -235,7 +235,7 @@ describe("findLiveProxy", () => {
       fetchFn: (async () => healthz(legacyBody)) as typeof fetch,
     });
 
-    expect(live).toEqual({ pid: null, port: 58195, hostname: undefined, source: "runtime" });
+    expect(live).toEqual({ pid: null, port: 58195, hostname: undefined, source: "runtime", version: "2.6.16" });
   });
 
   test("a pidless legacy healthz returns the cheap pid once full identity verification echoes it", async () => {
@@ -253,7 +253,7 @@ describe("findLiveProxy", () => {
     });
 
     expect(verified).toEqual([1111]);
-    expect(live).toEqual({ pid: 1111, port: 58195, hostname: undefined, source: "runtime" });
+    expect(live).toEqual({ pid: 1111, port: 58195, hostname: undefined, source: "runtime", version: "2.6.16" });
   });
 
   test("a verifier answering with a DIFFERENT pid than the candidate is rejected (TOCTOU guard)", async () => {
@@ -266,7 +266,7 @@ describe("findLiveProxy", () => {
       fetchFn: (async () => healthz(legacyBody)) as typeof fetch,
     });
 
-    expect(live).toEqual({ pid: null, port: 58195, hostname: undefined, source: "runtime" });
+    expect(live).toEqual({ pid: null, port: 58195, hostname: undefined, source: "runtime", version: "2.6.16" });
   });
 });
 
@@ -399,7 +399,7 @@ describe("findLiveProxy single-deadline candidate gating", () => {
     });
     expect(urls).toEqual(["http://127.0.0.1:58195/healthz", "http://127.0.0.1:10100/healthz"]);
     expect(urls).toHaveLength(2);
-    expect(live).toEqual({ pid: 4242, port: 10100, hostname: undefined, source: "config" });
+    expect(live).toEqual({ pid: 4242, port: 10100, hostname: undefined, source: "config", version: "2.6.17" });
   });
 });
 


### PR DESCRIPTION
## Summary

Third PR in the ocx agentic-control stack. Targets **`codex/ocx-transport-honesty`** (PR #2775), not `dev` — retarget after the parent lands.

Closes #2701.

This is the keystone phase: it introduces the declared route registry and capability table that later phases register verbs into. Building verbs first would mean writing them twice.

Three things land:

1. **`src/server/management/route-registry.ts`** — 210 declared routes (192 resolved from source, 18 non-literal), with a mandatory-reason exemption vocabulary.
2. **`ocx capabilities`** — the machine-readable surface index, so an agent driving `ocx` does not have to parse help text.
3. **Version skew** (#2701) — `ocx status` and `ocx doctor` now report when the `ocx` on PATH is a different build from the running proxy.

### The registry is declared, not harvested

18 routes are unreachable by any text scan of their own file: four regexes over model paths, three over lab ids, an `endsWith`, a `pathname.slice`, a prefix decode, three path constants, and two negated `pathname !==` guards.

The negated pair is why this matters. `GET /api/routing-analytics` has no equality literal anywhere, so a scan built on `===` never sees it. And for `GET /api/storage` an equality scan finds **only the dead shadowed copy** in `logs-usage-routes.ts` — never the live guard in `storage-log-guard-routes.ts`. A gate built that way would have reconciled against the corpse and called the surface covered.

### The reconciliation counts routes, not grep hits

A count keyed on `rg` line hits cannot balance against this source:

- `/api/codex-auth/pool-strategy` registers **PUT and PATCH from one guard** spanning four lines.
- 19 path guards decide their method somewhere other than their own line.
- Both nesting orders occur and neither is inferable from the other: `lab-routes.ts:352` narrows to GET *before* eight path literals, while `storage-log-guard-routes.ts:112` opens with the path and puts the method guard *inside* at :113.

So the scanner walks statements in order maintaining a method-narrowing context, and when it cannot resolve a method it returns `null` and the test fails. It never assumes GET.

### The gate was driven red before being trusted

Injecting `POST /api/combos/red-first-probe` into a real handler failed two checks independently and named the route in both. A gate nobody has attacked is not evidence.

Three further defects were found **by the new tests** during implementation, not by inspection:

- the generator double-declared the negated-guard routes once the scanner learned to resolve them;
- the inertness assertion flagged the registry's own header prose;
- the capability table claimed `ocx status` drives `GET /api/status` — a route that does not exist. `collectStatus` probes `/healthz` and reads local config.

### Lab boundary

`route-registry.ts` is imported by `src/server/management-api.ts`, which `tests/core-lab-boundary.test.ts` protects. Route paths are strings, so declaring `/api/lab/status` creates no module edge. The module imports **nothing at all**, and a test asserts it.

The seven mutating `/api/lab` routes were going to be waved through as `local-transport` alongside the reads, but `ocx lab` reads local SQLite and cannot start an automation run or import a community bundle. They now carry `deferred-verb` with an owner phase and a **tracked** devlog doc the test verifies exists — deliberately a repository file and not the goalplan, which is gitignored, so the assertion means the same thing in CI as locally.

### Version skew (#2701)

No extra request: the identity probe already parsed the healthz body. Carrying the version took three hops, because `isOpencodexHealthz` is a boolean predicate and cannot return a value — `proxyIdentityAt`'s return type widened and all three `findLiveProxy` construction sites thread the field.

That broke 12 exhaustive `toEqual` assertions in `proxy-liveness.test.ts` (Bun's `toEqual` rejects an extra defined key). Each now asserts the version its own mock actually reports, rather than being loosened.

The warning gets its own `versionSkew` field rather than joining `warningParts`, which funnels into `codexRuntime.warning` and would print a stale-PATH fact under the Codex runtime heading. `schemaVersion` stays 1. Both placeholder versions (`0.0.0` server-side, `unknown` CLI-side) suppress the warning — a false stale-CLI warning sends an operator to reinstall a healthy install.

## Verification

- `bun test` over the 12 affected suites: **363 pass, 0 fail, 1216 expect() calls**.
- `tsc --noEmit`: clean.
- Reconciliation gate proven red-then-green by injecting a real route into `combo-routes.ts`.
- Fail-loud scanner path proven red by a synthetic unresolvable guard.
- Skew warning verified live, not only under test: this worktree's CLI at 2.35.0 against a running 2.32.1-preview proxy prints the warning.
- `tests/core-lab-boundary.test.ts` and `tests/repo-hygiene.test.ts` green.

Local full-suite and CI checks are deliberately deferred to the final stack-wide rebase and CI pass (wp9), per the stack plan.

## Checklist

- [x] Focused regression tests accompany the behavior change
- [x] `tsc --noEmit` clean
- [x] No request bodies, keys, or account identifiers logged
- [x] Targets the parent PR's head branch as an intentional stacked child
- [ ] Full `bun run test` / CI — deferred to the stack-wide final pass (wp9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ocx capabilities` with human-readable or JSON output, mutation filtering, and route lookup.
  * Added capability listings for status, providers, accounts, usage, and related commands.
  * `ocx status` and `ocx doctor` now detect and report CLI/proxy version mismatches.
  * Proxy discovery now preserves the running proxy’s reported version.

* **Documentation**
  * Updated CLI help to document the new capabilities command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->