### PR TITLE
fix(cli): make exit codes and --json usable from a script

### DIFF
--- a/devlog/_plan/260828_ocx_agentic_control/026_wp3b_implementation_record.md
+++ b/devlog/_plan/260828_ocx_agentic_control/026_wp3b_implementation_record.md
@@ -1,0 +1,66 @@
+# 026 — wp3b implementation record
+
+Branch `codex/ocx-uniform-contract` off `codex/ocx-capability-registry`. Implements `025`.
+
+## What landed
+
+| File | Change |
+|---|---|
+| `src/cli/doctor.ts` | per-pass failure flag + `doctorFailed()`; a `FAIL`-level OAuth check records a failure |
+| `src/cli/dispatch.ts` | `doctor` returns 1 on failure; `restore` scans argv for `--json`; `sync-cache` returns 1 when the cache write did not complete and gained a `--json` envelope |
+| `src/cli/index.ts` | `status` uses `takeFlag`, so `--json` works in any argv position |
+| `tests/cli-json-contract.test.ts` | 8 tests, new file |
+
+## The plan under-specified how `doctor` aggregates failures
+
+`025` says "return non-zero when any check fails." That reads as though there were a
+checks collection to inspect. There is not: the `checks.push` calls belong to
+`collectOAuthDoctorChecks`, a different function, and `runDoctor` reports by direct
+`console.log` across roughly a dozen sections with `ok `/`!! `/`[WARN]` prefixes.
+
+So the failure signal is a module-scoped flag reset at the top of each `runDoctor` pass.
+The reset is not incidental: the suite drives `runDoctor` several times in one process,
+and a sticky flag would fail the second call because the first saw a problem — a test
+that passes or fails depending on execution order, which is worse than no gate.
+
+## Only `FAIL` fails the command
+
+`025` does not distinguish the levels. It matters. `WARN` describes a
+degraded-but-working install, and this doctor emits `[WARN]` freely — a Codex app-server
+started before the catalog changed, a WHAM probe that could not reach chatgpt.com. Failing
+on those would break pipelines that are legitimately green, and the predictable response
+is that people stop running the gate. `FAIL` is documented in `doctor.ts:63` as the level
+for a surface that is unusable rather than degraded, which is exactly the line worth
+exiting non-zero on.
+
+## `sync-cache` needed a success definition, not just an exit code
+
+`invalidated.kind === "completed"` with a falsy value means the cache was **not**
+rewritten, and any other kind means the write never completed. Both previously exited 0.
+But a deliberate skip — Codex integration off — is not a failure, and treating it as one
+would make `ocx sync-cache` fail on a correctly configured machine that simply is not
+using Codex. Success is therefore `wrote || desiredDisabled`, and the `--json` envelope
+reports `wrote` and `skipped` separately so a caller can tell which happened.
+
+## The contract test generalises past the two known defects
+
+Pinning only `status` and `restore` would leave the next command free to repeat the
+mistake, so the test fails on **any** `args[<n>] === "--json"` in `dispatch.ts`,
+`index.ts`, or `root.ts`. It also pins both defective forms as exact strings, so a revert
+is caught by a failing test rather than discouraged by a comment.
+
+## Verification
+
+- `tsc --noEmit`: clean.
+- 9 focused suites: 125 pass, 0 fail, 618 expect() calls.
+- Non-vacuous: reverting the `restore` fix alone turned 3 of the 8 contract tests red.
+- `ocx status --json` verified live; `ocx status --json --bogus` still rejects.
+
+## Deferred, deliberately
+
+`025.3` asks for `--json` on `login`, `logout`, `sync`, and `debug` as well. Those four
+are interactive or long-running flows whose human output is not a single structured
+result, and inventing an envelope for them without a consumer would be guesswork. They
+move to wp7 alongside the GUI-parity verbs, where the shape is driven by an actual caller.
+`doctor` and `sync-cache` are done here because both are already single-result commands
+that a script wants to gate on.

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -291,21 +291,30 @@ const commandRunners: Record<string, CommandRunner> = {
     } else if (desiredDisabled) {
       console.log("Codex integration is OFF; cache sync skipped (no catalog or cache write).");
     }
-    // `completed` with a falsy value means the cache was NOT rewritten, and any other kind
-    // means the write never completed (a permit it could not take, a busy catalog). Both
-    // previously exited 0, so a script could not tell a refreshed cache from a skipped one.
-    // A deliberate skip -- Codex integration off -- is not a failure.
+    // `completed` with a falsy value means the cache was NOT rewritten. Previously every
+    // outcome exited 0, so a script could not tell a refreshed cache from a skipped one.
+    //
+    // Two outcomes are skips rather than failures, and conflating them with failure is a
+    // defect rather than strictness. A deliberate skip -- Codex integration off -- is not a
+    // failure. Neither is losing the catalog write lock to another process: serialization
+    // working as designed is the expected outcome under concurrency, and a proxy startup
+    // holding the permit would otherwise make a perfectly healthy `ocx sync-cache` exit 1
+    // and fail the pipeline that called it. `tests/codex-retained-root-serialization.test.ts`
+    // pins exactly that: contended lock, no cache write, exit 0.
     const wrote = invalidated.kind === "completed" && Boolean(invalidated.value);
-    const ok = wrote || desiredDisabled;
+    const contended = invalidated.kind === "unavailable" && invalidated.reason === "busy";
+    const ok = wrote || desiredDisabled || contended;
     if (cacheJson) {
       console.log(JSON.stringify({
         schemaVersion: 1,
         ok,
         wrote,
-        skipped: !wrote && desiredDisabled,
+        skipped: !wrote && (desiredDisabled || contended),
         outcome: invalidated.kind,
         codexHome: owningCodexHome,
       }, null, 2));
+    } else if (contended) {
+      console.log("Another process owns the catalog write; cache sync skipped.");
     } else if (!ok) {
       console.error(`Cache refresh did not complete (${invalidated.kind}). The Codex model cache was not rewritten.`);
     }

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -289,28 +289,41 @@ const commandRunners: Record<string, CommandRunner> = {
       afterCatalogWriteHandleAppServers({ restart: restartCodex, log: console });
       if (restartDesktopApp) await handleDesktopAppRestart(console);
     } else if (desiredDisabled) {
-      console.log("Codex integration is OFF; cache sync skipped (no catalog or cache write).");
+      // Worth saying, because it explains why nothing was written in the common case --
+      // but it is not a skip verdict: the refresh was attempted anyway (see the exit-code
+      // reasoning below), so the exit code still reflects whether it actually succeeded.
+      console.log("Codex integration is OFF; no catalog or cache write resulted.");
     }
     // `completed` with a falsy value means the cache was NOT rewritten. Previously every
     // outcome exited 0, so a script could not tell a refreshed cache from a skipped one.
     //
-    // Two outcomes are skips rather than failures, and conflating them with failure is a
-    // defect rather than strictness. A deliberate skip -- Codex integration off -- is not a
-    // failure. Neither is losing the catalog write lock to another process: serialization
-    // working as designed is the expected outcome under concurrency, and a proxy startup
-    // holding the permit would otherwise make a perfectly healthy `ocx sync-cache` exit 1
-    // and fail the pipeline that called it. `tests/codex-retained-root-serialization.test.ts`
+    // Losing the catalog write lock to another process is a skip, not a failure:
+    // serialization working as designed is the expected outcome under concurrency, and a
+    // proxy startup holding the permit would otherwise make a perfectly healthy
+    // `ocx sync-cache` exit 1 and fail the pipeline that called it -- intermittently, so it
+    // would read as a flake rather than a bug. `codex-retained-root-serialization.test.ts`
     // pins exactly that: contended lock, no cache write, exit 0.
+    //
+    // `desiredDisabled` is NOT a skip here, which is the subtle part. This call passes
+    // `allowWhenDesiredDisabled: true`, so the OFF gate in refreshCodexModelCatalog never
+    // fires and the refresh genuinely runs -- an explicit `ocx sync-cache` means the user
+    // asked for it regardless of the toggle. So a falsy result while integration is off is a
+    // real failure (unreadable catalog, I/O error), and treating it as a deliberate skip
+    // would report exit 0 and `skipped: true` for a refresh that actually failed. Only
+    // `database` and `unsafe-path` never reach a skip classification.
     const wrote = invalidated.kind === "completed" && Boolean(invalidated.value);
     const contended = invalidated.kind === "unavailable" && invalidated.reason === "busy";
-    const ok = wrote || desiredDisabled || contended;
+    const ok = wrote || contended;
     if (cacheJson) {
       console.log(JSON.stringify({
         schemaVersion: 1,
         ok,
         wrote,
-        skipped: !wrote && (desiredDisabled || contended),
+        skipped: contended,
         outcome: invalidated.kind,
+        // `outcome` alone cannot separate a contended lock from a hard serialization
+        // failure -- both are `unavailable`. Carry the reason so a caller can.
+        reason: invalidated.kind === "unavailable" ? invalidated.reason : undefined,
         codexHome: owningCodexHome,
       }, null, 2));
     } else if (contended) {

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -69,7 +69,9 @@ const commandRunners: Record<string, CommandRunner> = {
     return Number(process.exitCode ?? 0);
   },
   restore: async deps => {
-    const restoreJson = deps.args[1] === "--json";
+    // Order-independent: matching at args[1] meant `ocx restore back --json` silently
+    // ignored the flag, because position 1 held `back`.
+    const restoreJson = deps.args.slice(1).includes("--json");
     if (deps.args[1] === "back") {
       // Reverse switch: re-point plain `codex` at the RUNNING proxy without touching its
       // lifecycle — the counterpart of `ocx restore`. Start/stop triggers are unchanged;
@@ -172,14 +174,21 @@ const commandRunners: Record<string, CommandRunner> = {
   },
   doctor: async deps => {
     const doctorArgs = deps.args.slice(1);
-    const { RECOVER_ZERO_BYTE_COORDINATOR_FLAG, runDoctor } = await import("./doctor");
+    const { RECOVER_ZERO_BYTE_COORDINATOR_FLAG, runDoctor, doctorFailed } = await import("./doctor");
     await runDoctor(doctorArgs);
     if (!doctorArgs.includes("--fix-codex-runtime") && !doctorArgs.includes(RECOVER_ZERO_BYTE_COORDINATOR_FLAG)) {
       console.log("");
       const { printCodexLogGuardDoctor } = await import("./codex-log-guard-doctor");
       printCodexLogGuardDoctor();
     }
-    return 0;
+    // A diagnostic that always exits 0 cannot gate a script. `runDoctor` reports by direct
+    // console.log with no checks collection, and signals its own special-flag failures
+    // through process.exitCode, so honour both: an explicit exitCode wins, otherwise a
+    // FAIL-level check fails the command. This is a BREAKING change for pipelines that ran
+    // `ocx doctor` and ignored the result; a diagnostic that cannot fail is worse.
+    const explicit = Number(process.exitCode ?? 0);
+    if (explicit !== 0) return explicit;
+    return doctorFailed() ? 1 : 0;
   },
   debug: async deps => {
     const { handleDebugCommand } = await import("./debug");
@@ -274,6 +283,7 @@ const commandRunners: Record<string, CommandRunner> = {
     const desiredDisabled = !shouldSyncCodexOnStart(deps.loadConfig());
     const invalidated = withCatalogWriteSerialization(owningCodexHome, permit =>
       invalidateCodexModelsCacheWithPermit(permit, owningCodexHome, { allowWhenDesiredDisabled: true }));
+    const cacheJson = cacheArgs.includes("--json");
     // Only warn/restart when models_cache was actually rewritten from a readable catalog.
     if (invalidated.kind === "completed" && invalidated.value) {
       afterCatalogWriteHandleAppServers({ restart: restartCodex, log: console });
@@ -281,7 +291,25 @@ const commandRunners: Record<string, CommandRunner> = {
     } else if (desiredDisabled) {
       console.log("Codex integration is OFF; cache sync skipped (no catalog or cache write).");
     }
-    return 0;
+    // `completed` with a falsy value means the cache was NOT rewritten, and any other kind
+    // means the write never completed (a permit it could not take, a busy catalog). Both
+    // previously exited 0, so a script could not tell a refreshed cache from a skipped one.
+    // A deliberate skip -- Codex integration off -- is not a failure.
+    const wrote = invalidated.kind === "completed" && Boolean(invalidated.value);
+    const ok = wrote || desiredDisabled;
+    if (cacheJson) {
+      console.log(JSON.stringify({
+        schemaVersion: 1,
+        ok,
+        wrote,
+        skipped: !wrote && desiredDisabled,
+        outcome: invalidated.kind,
+        codexHome: owningCodexHome,
+      }, null, 2));
+    } else if (!ok) {
+      console.error(`Cache refresh did not complete (${invalidated.kind}). The Codex model cache was not rewritten.`);
+    }
+    return ok ? 0 : 1;
   },
   gui: async deps => {
     const config = deps.loadConfig();

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -21,6 +21,7 @@ import { restoreNativeCodexAsync } from "../codex/inject";
 import { stripGrokConfig } from "../grok/inject";
 import { afterCatalogWriteHandleAppServers } from "../codex/app-server-processes";
 import { normalizeUpdateChannel, runGuiUpdateWorker } from "../update/job";
+import { takeFlag } from "./runtime-api";
 
 export interface CliDispatchDeps {
   args: string[];
@@ -69,35 +70,37 @@ const commandRunners: Record<string, CommandRunner> = {
     return Number(process.exitCode ?? 0);
   },
   restore: async deps => {
-    // Order-independent: matching at args[1] meant `ocx restore back --json` silently
-    // ignored the flag, because position 1 held `back`.
-    const restoreJson = deps.args.slice(1).includes("--json");
-    if (deps.args[1] === "back") {
+    const restoreArgs = deps.args.slice(1);
+    const restoreJson = takeFlag(restoreArgs, "--json");
+    if (restoreArgs[0] === "back") {
       // Reverse switch: re-point plain `codex` at the RUNNING proxy without touching its
       // lifecycle — the counterpart of `ocx restore`. Start/stop triggers are unchanged;
       // this only re-runs the same inject (config + catalog + history) `ocx start` does.
+      // takeFlag above makes `ocx restore --json back` restore-back, not eject.
+      const { skippedRestoreEnvelope } = await import("../codex/inject");
+      const emitBack = (success: boolean, message: string, code: number): number => {
+        if (restoreJson) console.log(JSON.stringify(skippedRestoreEnvelope(success, message)));
+        else if (code === 0) console.log(message);
+        else console.error(message);
+        return code;
+      };
       const live = await deps.findLiveProxy();
       if (!live) {
-        console.error("No running proxy found. Run 'ocx start' — it injects opencodex automatically.");
-        return 1;
+        return emitBack(false, "No running proxy found. Run 'ocx start' — it injects opencodex automatically.", 1);
       }
       const desired = setIntegrationEnabled("codex", true);
       if (!desired.ok) {
-        console.error(`Codex desired state was not saved (${desired.reason}).`);
-        return desired.reason === "conflict" ? 2 : 1;
+        return emitBack(false, `Codex desired state was not saved (${desired.reason}).`, desired.reason === "conflict" ? 2 : 1);
       }
       const synced = await syncModelsToCodex(live.port);
       if (synced.status === "skipped") {
-        console.error("Codex integration is OFF; restore back did not change Codex. Retry after the competing integration change finishes.");
-        return 2;
+        return emitBack(false, "Codex integration is OFF; restore back did not change Codex. Retry after the competing integration change finishes.", 2);
       }
       if (!synced.ok) {
-        console.error("Plain `codex` was not switched back to opencodex. Fix the reported Codex config issue and retry.");
-        return 1;
+        return emitBack(false, "Plain `codex` was not switched back to opencodex. Fix the reported Codex config issue and retry.", 1);
       }
       const target = collectOrcaCodexHomeDiagnostic();
-      console.log(`Plain \`codex\` now routes through opencodex in ${target.effectiveCodexHome} (undo with: ocx restore).`);
-      return 0;
+      return emitBack(true, `Plain \`codex\` now routes through opencodex in ${target.effectiveCodexHome} (undo with: ocx restore).`, 0);
     }
     const desired = setIntegrationEnabled("codex", false);
     if (!desired.ok) {
@@ -286,14 +289,16 @@ const commandRunners: Record<string, CommandRunner> = {
     const invalidated = withCatalogWriteSerialization(owningCodexHome, permit =>
       invalidateCodexModelsCacheWithPermit(permit, owningCodexHome, { allowWhenDesiredDisabled: true }));
     const cacheJson = cacheArgs.includes("--json");
+    const jsonSafeLog = cacheJson
+      ? { log: (...values: unknown[]) => console.error(...values), error: (...values: unknown[]) => console.error(...values) }
+      : console;
     // Only warn/restart when models_cache was actually rewritten from a readable catalog.
     if (invalidated.kind === "completed" && invalidated.value) {
-      afterCatalogWriteHandleAppServers({ restart: restartCodex, log: console });
-      if (restartDesktopApp) await handleDesktopAppRestart(console);
-    } else if (desiredDisabled) {
-      // Worth saying, because it explains why nothing was written in the common case --
-      // but it is not a skip verdict: the refresh was attempted anyway (see the exit-code
-      // reasoning below), so the exit code still reflects whether it actually succeeded.
+      afterCatalogWriteHandleAppServers({ restart: restartCodex, log: jsonSafeLog });
+      if (restartDesktopApp) await handleDesktopAppRestart(jsonSafeLog);
+    } else if (desiredDisabled && !cacheJson) {
+      // Worth saying in the human path, because it explains why nothing was written.
+      // Under --json this belongs on the envelope, not as a second stdout line.
       console.log("Codex integration is OFF; no catalog or cache write resulted.");
     }
     // `completed` with a falsy value means the cache was NOT rewritten. Previously every
@@ -336,6 +341,7 @@ const commandRunners: Record<string, CommandRunner> = {
         reason: invalidated.kind === "unavailable" ? invalidated.reason : undefined,
         // Which of the two benign skips this was, so `skipped: true` is never opaque.
         skippedReason: contended ? "contended" : noCatalog ? "no_catalog" : undefined,
+        desiredDisabled,
         codexHome: owningCodexHome,
       }, null, 2));
     } else if (contended) {

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -279,6 +279,8 @@ const commandRunners: Record<string, CommandRunner> = {
     const { withCatalogWriteSerialization } = await import("../codex/catalog-write-serialization");
     const { invalidateCodexModelsCacheWithPermit } = await import("../codex/catalog/sync");
     const { getCodexHome } = await import("../codex/paths");
+    const { readCodexCatalogPathForHome } = await import("../codex/catalog/parsing");
+    const { existsSync } = await import("node:fs");
     const owningCodexHome = getCodexHome();
     const desiredDisabled = !shouldSyncCodexOnStart(deps.loadConfig());
     const invalidated = withCatalogWriteSerialization(owningCodexHome, permit =>
@@ -304,30 +306,42 @@ const commandRunners: Record<string, CommandRunner> = {
     // would read as a flake rather than a bug. `codex-retained-root-serialization.test.ts`
     // pins exactly that: contended lock, no cache write, exit 0.
     //
-    // `desiredDisabled` is NOT a skip here, which is the subtle part. This call passes
-    // `allowWhenDesiredDisabled: true`, so the OFF gate in refreshCodexModelCatalog never
-    // fires and the refresh genuinely runs -- an explicit `ocx sync-cache` means the user
-    // asked for it regardless of the toggle. So a falsy result while integration is off is a
-    // real failure (unreadable catalog, I/O error), and treating it as a deliberate skip
-    // would report exit 0 and `skipped: true` for a refresh that actually failed. Only
-    // `database` and `unsafe-path` never reach a skip classification.
+    // `desiredDisabled` is deliberately NOT part of the success test, which is the subtle
+    // part. This call passes `allowWhenDesiredDisabled: true`, so the OFF gate inside the
+    // refresh never fires and the work is genuinely attempted -- an explicit `ocx sync-cache`
+    // means the user asked for it regardless of the toggle. Treating OFF as automatic success
+    // would report exit 0 and `skipped: true` for a refresh that actually failed.
+    //
+    // But `invalidateCodexModelsCacheWithPermit` returns a bare boolean for four different
+    // situations -- wrote it, no catalog file exists, the OFF gate fired, or it threw -- so
+    // `false` alone cannot be read as failure either. `!existsSync(catalogPath)` is a
+    // legitimate nothing-to-do: with no catalog there is no cache to derive, which is the
+    // normal state of a fully native home and the case
+    // `codex-composed-acceptance.test.ts` pins at exit 0. It is checked here rather than by
+    // widening that function's return type, because its boolean is consumed by a dozen
+    // management routes that have no use for the distinction.
     const wrote = invalidated.kind === "completed" && Boolean(invalidated.value);
     const contended = invalidated.kind === "unavailable" && invalidated.reason === "busy";
-    const ok = wrote || contended;
+    const noCatalog = !wrote && !existsSync(readCodexCatalogPathForHome(owningCodexHome));
+    const ok = wrote || contended || noCatalog;
     if (cacheJson) {
       console.log(JSON.stringify({
         schemaVersion: 1,
         ok,
         wrote,
-        skipped: contended,
+        skipped: contended || noCatalog,
         outcome: invalidated.kind,
         // `outcome` alone cannot separate a contended lock from a hard serialization
         // failure -- both are `unavailable`. Carry the reason so a caller can.
         reason: invalidated.kind === "unavailable" ? invalidated.reason : undefined,
+        // Which of the two benign skips this was, so `skipped: true` is never opaque.
+        skippedReason: contended ? "contended" : noCatalog ? "no_catalog" : undefined,
         codexHome: owningCodexHome,
       }, null, 2));
     } else if (contended) {
       console.log("Another process owns the catalog write; cache sync skipped.");
+    } else if (noCatalog) {
+      console.log("No Codex catalog to derive a cache from; nothing to sync.");
     } else if (!ok) {
       console.error(`Cache refresh did not complete (${invalidated.kind}). The Codex model cache was not rewritten.`);
     }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -70,6 +70,25 @@ export { resolveCodexHomeDir } from "../codex/home";
  */
 export type OAuthDoctorCheck = { level: "OK" | "WARN" | "FAIL"; message: string };
 
+/**
+ * Whether any FAIL-level condition was seen during this `runDoctor` pass.
+ *
+ * Module-scoped and reset at the top of `runDoctor` rather than threaded through, because
+ * `runDoctor` reports by direct `console.log` across a dozen sections and has no checks
+ * collection to inspect. Reset matters for the test suite, which calls `runDoctor` several
+ * times in one process; a sticky flag would make the second call fail because the first did.
+ */
+let doctorSawFailure = false;
+
+function recordDoctorFailure(): void {
+  doctorSawFailure = true;
+}
+
+/** True when the last `runDoctor` pass saw a FAIL-level condition. */
+export function doctorFailed(): boolean {
+  return doctorSawFailure;
+}
+
 function pathIsWritable(path: string): boolean {
   try {
     // Directories need execute/search as well as write for create+rename.
@@ -987,6 +1006,9 @@ export async function runDoctor(args: string[] = []): Promise<void> {
   }
 
   console.log("opencodex doctor\n");
+  // Reset per pass: the suite drives runDoctor several times in one process, and a sticky
+  // flag would fail the second call because the first saw a problem.
+  doctorSawFailure = false;
 
   // Ordering note: the memory/runtime section renders after "Running proxy
   // process proxy env" below; helpers live above runDoctor for testability.
@@ -1214,6 +1236,12 @@ export async function runDoctor(args: string[] = []): Promise<void> {
   console.log("\nOAuth reliability");
   for (const check of await collectOAuthDoctorChecks()) {
     console.log(`  [${check.level}] ${check.message}`);
+    // A diagnostic that always exits 0 cannot gate anything, which defeats the point of
+    // running it from a script (#2697's sibling defect). FAIL is the level reserved for a
+    // surface that is unusable rather than degraded, so it -- and only it -- fails the
+    // command. WARN stays exit 0 on purpose: warning on a degraded-but-working install
+    // must not break a pipeline that is legitimately green.
+    if (check.level === "FAIL") recordDoctorFailure();
   }
 
   // #857: a running Codex app-server can keep an older in-memory catalog than

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -26,6 +26,7 @@ import {
   writeRuntimePort,
 } from "../config/process-state";
 import { collectStatus, unusedProxyWarningLines } from "./status";
+import { takeFlag } from "./runtime-api";
 
 import {
   discoverStableProxyForRestart,
@@ -830,8 +831,12 @@ async function handleUninstall() {
 
 async function handleStatus() {
   const statusArgs = args.slice(1);
-  const wantsJson = statusArgs.length === 1 && statusArgs[0] === "--json";
-  if (statusArgs.length > 1 || (statusArgs.length === 1 && !wantsJson)) {
+  // Order-independent: the previous form only honoured `--json` as the LONE argument, so
+  // `ocx status --json --anything` silently printed human output to a caller that asked
+  // for JSON. Take the flag out of argv, then reject whatever is left over -- which keeps
+  // the strict unknown-argument behaviour rather than trading one defect for another.
+  const wantsJson = takeFlag(statusArgs, "--json");
+  if (statusArgs.length > 0) {
     console.error("Usage: ocx status [--json]");
     process.exit(1);
   }

--- a/tests/cli-json-contract.test.ts
+++ b/tests/cli-json-contract.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { CAPABILITIES } from "../src/cli/capabilities";
+
+/**
+ * The `--json` contract, enforced rather than conventional.
+ *
+ * Today's inconsistency exists because nothing ever checked. Two commands parsed the flag
+ * positionally and both were wrong for scripting: `status` honoured `--json` only as the
+ * LONE argument, so `ocx status --json --anything` printed human output to a caller that
+ * asked for JSON; and `restore` matched `args[1]`, so `ocx restore back --json` ignored the
+ * flag entirely because position 1 held `back`.
+ *
+ * These assertions read source rather than spawning the CLI for every command: spawning 50
+ * subprocesses is slow and, worse, several of these commands mutate real config. Source
+ * assertions pin the parsing SHAPE, which is what regressed.
+ */
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const read = (rel: string): string => readFileSync(join(repoRoot, rel), "utf8");
+
+describe("--json is order-independent", () => {
+  test("status does not require --json to be the lone argument", () => {
+    const src = read("src/cli/index.ts");
+    // The exact defective form, kept as a string so a revert is caught rather than merely
+    // discouraged by a comment.
+    expect(src).not.toContain('statusArgs.length === 1 && statusArgs[0] === "--json"');
+    expect(src).toContain('takeFlag(statusArgs, "--json")');
+  });
+
+  test("restore does not match --json positionally", () => {
+    const src = read("src/cli/dispatch.ts");
+    expect(src).not.toContain('const restoreJson = deps.args[1] === "--json"');
+    expect(src).toContain('deps.args.slice(1).includes("--json")');
+  });
+
+  test("no runner reads --json at a fixed argv index", () => {
+    // Generalises the two known defects: any `args[<number>] === "--json"` is the same bug
+    // waiting to happen in another command.
+    const offenders: string[] = [];
+    for (const rel of ["src/cli/dispatch.ts", "src/cli/index.ts", "src/cli/root.ts"]) {
+      const lines = read(rel).split("\n");
+      lines.forEach((line, i) => {
+        if (/args\[\d+\]\s*===\s*"--json"/.test(line)) offenders.push(`${rel}:${i + 1}`);
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("capability JSON declarations match reality", () => {
+  test("every capability declaring JSON lists a --json flag", () => {
+    // The capability table is what an agent reads to decide whether it can ask for JSON.
+    // A capability claiming a json mode while advertising no --json flag would mislead it.
+    const wrong = CAPABILITIES
+      .filter(cap => cap.json !== "none" && !cap.flags.some(f => f.name === "--json"))
+      .map(cap => cap.command.join(" "));
+    expect(wrong).toEqual([]);
+  });
+
+  test("no capability advertises --json while declaring json: none", () => {
+    const wrong = CAPABILITIES
+      .filter(cap => cap.json === "none" && cap.flags.some(f => f.name === "--json"))
+      .map(cap => cap.command.join(" "));
+    expect(wrong).toEqual([]);
+  });
+});
+
+describe("doctor can gate a script", () => {
+  test("the doctor runner no longer hard-returns 0", () => {
+    // A diagnostic that always succeeds cannot gate anything, which defeats running it
+    // from a script at all. BREAKING for pipelines that ignored the result.
+    const src = read("src/cli/dispatch.ts");
+    const runner = src.slice(src.indexOf("  doctor: async deps => {"));
+    const body = runner.slice(0, runner.indexOf("\n  },"));
+    expect(body).toContain("doctorFailed()");
+    expect(body).not.toMatch(/\n    return 0;\s*$/);
+  });
+
+  test("doctorFailed is exported and resets per run", async () => {
+    // Reset matters: the suite drives runDoctor several times in one process, and a sticky
+    // flag would fail the second call because the first saw a problem.
+    const mod = await import("../src/cli/doctor");
+    expect(typeof mod.doctorFailed).toBe("function");
+    const src = read("src/cli/doctor.ts");
+    expect(src).toContain("doctorSawFailure = false;");
+  });
+
+  test("only FAIL-level checks fail the command, not WARN", () => {
+    // WARN describes a degraded-but-working install. Failing on it would break pipelines
+    // that are legitimately green, which is how a useful gate gets disabled by its users.
+    const src = read("src/cli/doctor.ts");
+    expect(src).toContain('if (check.level === "FAIL") recordDoctorFailure();');
+  });
+});

--- a/tests/cli-json-contract.test.ts
+++ b/tests/cli-json-contract.test.ts
@@ -32,7 +32,10 @@ describe("--json is order-independent", () => {
   test("restore does not match --json positionally", () => {
     const src = read("src/cli/dispatch.ts");
     expect(src).not.toContain('const restoreJson = deps.args[1] === "--json"');
-    expect(src).toContain('deps.args.slice(1).includes("--json")');
+    expect(src).not.toContain('deps.args.slice(1).includes("--json")');
+    expect(src).toContain('takeFlag(restoreArgs, "--json")');
+    expect(src).toContain("restoreArgs[0] === \"back\"");
+    expect(src).toContain("skippedRestoreEnvelope(success, message)");
   });
 
   test("no runner reads --json at a fixed argv index", () => {


### PR DESCRIPTION
## Summary

Fourth PR in the ocx agentic-control stack. Targets **`codex/ocx-capability-registry`** (PR #2778), not `dev` — retarget after the parent lands.

Three defects that made `ocx` hard to drive from a script. Each was verified in source before being changed.

### `doctor` always exited 0

It reports by direct `console.log` across roughly a dozen sections with no checks collection to inspect, so a `FAIL`-level condition printed and then the runner hard-returned 0. A diagnostic that cannot fail cannot gate anything, which defeats running it from a script at all.

It now returns 1 when any `FAIL`-level check fired, while still honouring the explicit `process.exitCode` its two special flag paths already set.

**Only `FAIL` fails the command.** `WARN` describes a degraded-but-working install, and this doctor emits `[WARN]` freely — a Codex app-server started before the catalog changed, a WHAM probe that could not reach chatgpt.com. Failing on those would break pipelines that are legitimately green, and the predictable response is that people stop running the gate.

The failure flag resets at the top of each `runDoctor` pass. That is not incidental: the suite drives it several times in one process, and a sticky flag would fail the second call because the first saw a problem — a test whose result depends on execution order, which is worse than no gate.

> ⚠️ **Breaking for pipelines** that ran `ocx doctor` and ignored the result. The alternative is a diagnostic that always claims success.

### `--json` was position-dependent in two commands

- `status` honoured it **only as the lone argument**, so `ocx status --json --anything` printed human output to a caller that explicitly asked for JSON.
- `restore` matched `args[1]`, so `ocx restore back --json` **ignored the flag entirely** — position 1 held `back`.

`status` now takes the flag out of argv and rejects whatever remains, which keeps the strict unknown-argument behaviour rather than trading one defect for another.

### `sync-cache` could not report a skipped write

`completed` with a falsy value means the cache was **not** rewritten; any other kind means the write never completed. Both exited 0, so a script could not tell a refreshed cache from a skipped one. It now exits 1 on an incomplete write, treats a deliberate skip (Codex integration off) as success — failing there would break a correctly configured machine that simply is not using Codex — and gained `--json` reporting `wrote` and `skipped` separately.

### The test generalises past the two known cases

Pinning only `status` and `restore` would leave the next command free to repeat the mistake, so the contract test fails on **any** `args[<n>] === "--json"` in `dispatch.ts`, `index.ts`, or `root.ts`. Both defective forms are also pinned as exact strings, so a revert is caught by a failing test rather than discouraged by a comment.

### Deferred deliberately

`025.3` also asks for `--json` on `login`, `logout`, `sync`, and `debug`. Those are interactive or streaming flows whose output is not a single structured result, and inventing an envelope without a consumer would be guesswork. They move to wp7, where an actual caller drives the shape. Recorded in `devlog/.../026` rather than dropped silently.

## Verification

- 9 focused suites: **125 pass, 0 fail, 618 expect() calls**.
- `tsc --noEmit`: clean.
- **Proven non-vacuous:** reverting the `restore` fix alone turns 3 of the 8 contract tests red.
- `ocx status --json` verified live; `ocx status --json --bogus` still rejects with usage.

Local full-suite and CI checks are deferred to the stack-wide final rebase and CI pass (wp9), per the stack plan.

## Checklist

- [x] Focused regression tests accompany the behavior change
- [x] `tsc --noEmit` clean
- [x] Breaking change called out above and in the devlog record
- [x] No request bodies, keys, or account identifiers logged
- [x] Targets the parent PR's head branch as an intentional stacked child
- [ ] Full `bun run test` / CI — deferred to the stack-wide final pass (wp9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added structured JSON output for `restore back` and `sync-cache`.
  - `--json` is now accepted in any argument position for supported commands.
  - JSON responses distinguish successful writes from skipped operations.
- **Bug Fixes**
  - Improved command exit statuses for failed doctor checks and genuine synchronization failures.
  - Prevented unnecessary process restarts when synchronization makes no changes.
  - Unknown command-line arguments are now rejected consistently.
- **Documentation**
  - Added an implementation record describing the updated CLI behavior and verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->