### PR TITLE
feat(cli): pool-steering verbs, and a log filter that stops lying

### DIFF
--- a/devlog/_plan/260828_ocx_agentic_control/041_wp5_implementation_record.md
+++ b/devlog/_plan/260828_ocx_agentic_control/041_wp5_implementation_record.md
@@ -129,6 +129,23 @@ overlap (`scripts/test-run-lock.ts:164`). It is sound for this file set: every t
 `fetchImpl` or calls `filterRequestLogs` directly, so none binds a port, and `tests/preload.ts`
 sandboxes `HOME`/`CODEX_HOME` on every invocation regardless of the wrapper.
 
+## Criterion 4: the new surface is in `ocx capabilities`
+
+```
+ocx capabilities --json → invocations:
+  ocx status, ocx capabilities, ocx provider list, ocx account list, ocx usage,
+  ocx account pause, ocx account resume, ocx account pause-exhausted,
+  ocx account strategy, ocx account sticky, ocx logs
+
+ocx capabilities --route /api/oauth/accounts/pool
+  → ocx account strategy, ocx account sticky   (both, with all four routes listed)
+```
+
+`ocx logs` had no capability entry at all before this phase, even though it was already a
+shipped command. It gets one here rather than in a later phase, because this phase changed its
+filter contract: an entry added later would have documented the fixed behavior without ever
+having declared the broken one.
+
 ## Deferred, with an owner
 
 `ocx logs --model` now filters correctly, but the `--model` **flag** was already declared in

--- a/devlog/_plan/260828_ocx_agentic_control/041_wp5_implementation_record.md
+++ b/devlog/_plan/260828_ocx_agentic_control/041_wp5_implementation_record.md
@@ -1,0 +1,144 @@
+# 041 — wp5 implementation record: new verbs and filters (#2702, #2704)
+
+Branch: `codex/ocx-new-verbs`, stacked on `codex/ocx-dto-fidelity`.
+Plan: `040_phase_new_verbs.md`. Both accept-criteria sets are met; the deviations from the
+plan are recorded below rather than silently absorbed.
+
+## What shipped
+
+| Verb / behavior | Route | File |
+|---|---|---|
+| `ocx account pause <provider> <id>` | `PUT /api/codex-auth/accounts/pause` | `src/cli/account-extended.ts` |
+| `ocx account resume <provider> <id>` | same route, `paused: false` | same |
+| `ocx account pause-exhausted <provider>` | `PUT /api/codex-auth/accounts/pause-exhausted` | same |
+| `ocx account strategy <provider> [<name>]` | codex or anthropic pool (see below) | same |
+| `ocx account sticky <provider> [<n>]` | same pair of pools | same |
+| `ocx logs --conversation\|--conversationId <id>` | `GET /api/logs` | `src/cli/observe.ts` |
+| server-side `model` filter | `filterRequestLogs` | `src/server/request-log.ts` |
+
+## The plan left one decision open, and this is the decision
+
+The plan named the sibling gap — `/api/oauth/accounts/pool` is the same capability for the
+Anthropic pool and had no verb either — and explicitly deferred the choice between
+`--provider` on the existing verbs and a second `provider-strategy`/`provider-sticky` pair.
+
+**Chosen: one verb pair over both pools**, dispatched on the provider positional that these
+verbs already required. A second pair would double the surface an operator has to learn to
+express one idea, and the provider argument was already there.
+
+That choice only works because the asymmetry is encoded rather than assumed. The two routes
+differ in four ways, and every one of them would have been a live defect under a naive
+"same settings, so same call" implementation:
+
+|  | Codex pool | Anthropic pool |
+|---|---|---|
+| read | `GET /api/codex-auth/active` | `GET /api/oauth/accounts/pool?provider=` |
+| write | `PUT /api/codex-auth/pool-strategy` | `PUT /api/oauth/accounts/pool` |
+| response keys | `accountPoolStrategy` / `accountPoolStickyLimit` | `strategy` / `stickyLimit` |
+| write body | bare field | field **plus a mandatory `provider`** |
+
+The mandatory `provider` is the sharpest one: omit it and the route answers 400
+(`oauth-account-routes.ts:344`), so a symmetric implementation would have failed at runtime
+on every Anthropic write while passing every Codex test.
+
+`--json` output uses pool-neutral keys (`strategy`, `stickyLimit`) for both pools. A consumer
+driving `ocx` programmatically should not have to branch on which pool answered in order to
+read the value it just set.
+
+`anthropic` is the only OAuth provider with this setting, and the route says so with a 400.
+The CLI refuses any other OAuth provider locally instead of spending a round-trip to learn it.
+
+## The server-side `--model` hole was real
+
+`filterRequestLogs` had clauses for `provider`, `conversationId`, `status`, `tail`, `offset`,
+and `limit` — and none for `model`. So `ocx logs --model x` was accepted and every row came
+back. That is worse than an error: the output looks filtered, so it yields a wrong conclusion
+from correct-looking data.
+
+The new clause matches `entry.model` **and** `entry.attempts[].model`, mirroring the `provider`
+clause directly above it, because a request that failed over should be findable by the model
+that actually served it.
+
+## Every new gate was driven red before being trusted
+
+Four probes, each reverting a specific decision:
+
+| Probe | Result |
+|---|---|
+| `model` clause matches top-level only, not attempts | 1 fail — the failover row stopped matching |
+| `model` clause deleted entirely (the shipped bug) | 1 fail — `model=absent-model` returned 2 rows where 0 were expected |
+| Anthropic `writeBody` drops `provider` | 1 fail — the exact-body assertion caught it |
+| Anthropic routed through `CODEX_POOL_TRANSPORT` (assume symmetry) | 3 fails — read path, write body, and `--json` keys all wrong |
+
+The second probe is the one worth keeping in mind: the positive assertion
+(`model=gpt-test` returns `["a"]`) passes with **no filter implemented at all**, since an
+unfiltered result contains the expected row. Only the non-matching assertion
+(`model=absent-model` → `[]`) can detect the shipped defect. A test suite for a filter that
+omits the negative case measures nothing.
+
+## Verification
+
+```
+bun test tests/cli-account-pool-verbs.test.ts tests/cli-usage-report.test.ts \
+  tests/request-log.test.ts tests/cli-capabilities.test.ts tests/cli-headless-parity.test.ts \
+  tests/management-route-registry.test.ts tests/request-log-conversation.test.ts \
+  tests/management-api-logs-metrics.test.ts
+→ 176 pass, 0 fail across 8 files
+
+./node_modules/.bin/tsc --noEmit → clean
+```
+
+Live, against the running proxy on :10100:
+
+```
+account strategy openai        → openai: pool strategy is quota                (exit 0)
+account sticky openai          → openai: sticky limit is 1                     (exit 0)
+account strategy anthropic     → anthropic: pool strategy is quota             (exit 0)
+account strategy gemini        → Error: unknown provider "gemini" + usage      (exit 1)
+account pause openai bogus_id  → Error: Account not found                     (exit 4)
+logs --limit 2                 → rows now carry `conv=24f7175…`
+```
+
+Two details worth pinning, because both contradict a plausible guess:
+
+**Exit 4, not 1.** A not-found management error exits 4 under the wp3b uniform exit-code
+contract; only the usage error exits 1. An earlier draft of this record said 1 for both.
+
+**`gemini` is refused before it reaches the new pool check.** `classifyAccount` rejects it as
+an unknown provider first, since it is not configured in this environment. The pool-specific
+refusal (`… not "gemini"`) is what a configured-but-poolless OAuth provider gets, and that
+path is covered by the unit test rather than by this live run.
+
+**The `--model` hole reproduced live.** The proxy on :10100 runs an older build from a
+different checkout, so it still has the unfixed `filterRequestLogs`:
+
+```
+logs --model no-such-model --limit 5  → 5 rows, all kiro/claude-opus-5   (exit 0)
+```
+
+A nonsense model returning a full page of rows, with exit 0, is exactly the defect #2704
+describes — output that looks filtered and is not. The fix is verified against
+`filterRequestLogs` directly in `tests/request-log.test.ts`; this live run is the
+before-picture, not a regression.
+
+### A note on how these tests were run
+
+Another worktree held the machine test lock (`opencodex-bun-test.lock`) for a full-suite run,
+so these ran under `OCX_TEST_NO_QUEUE=1`, which is the documented escape for intentional
+overlap (`scripts/test-run-lock.ts:164`). It is sound for this file set: every test injects
+`fetchImpl` or calls `filterRequestLogs` directly, so none binds a port, and `tests/preload.ts`
+sandboxes `HOME`/`CODEX_HOME` on every invocation regardless of the wrapper.
+
+## Deferred, with an owner
+
+`ocx logs --model` now filters correctly, but the `--model` **flag** was already declared in
+`observe.ts` usage, so no help change was needed. `#2699` per-account attribution and the
+remaining GUI-only Lab routes stay with wp6 and wp7 as declared in the route registry
+exemptions.
+
+## Subagent dispatch
+
+Sol-tier subagent spawns continued to fail with 429 rate limits, so the route-method
+verification, helper-signature audit, and both red-probe designs in this phase were done
+directly against source rather than delegated. Recording the substitution rather than
+implying a review that did not happen.

--- a/src/cli/account-extended.ts
+++ b/src/cli/account-extended.ts
@@ -40,6 +40,11 @@ const EXTENDED_USAGE = `Usage:
   ocx account auto-switch <provider> <on|off|status|threshold <0-100>> [--json]
   ocx account alias <provider> <id|main> <display-name|-> [--json]
   ocx account priority <provider> <id|main> [<-100..100|first|earlier|normal|later|last|reset>] [--json]
+  ocx account pause <provider> <id|main> [--json]
+  ocx account resume <provider> <id|main> [--json]
+  ocx account pause-exhausted <provider> [--json]
+  ocx account strategy <provider> [<quota|round-robin|fill-first>] [--json]
+  ocx account sticky <provider> [<1-100>] [--json]
   ocx account remove <provider> <id|main> --yes [--json]
   ocx account clear-cooldown <provider> <id|main> [--json]
   ocx account add-key <provider> [--label <label>] [--json]
@@ -698,6 +703,230 @@ export async function cmdPriority(args: string[], deps: AccountDeps): Promise<nu
   // this line that is a silent side effect of a command that looks purely declarative.
   console.error('Also releases any manual "use this account now" pin, on any account.');
   return 0;
+}
+
+/**
+ * `ocx account pause|resume <provider> <id>` (#2702).
+ *
+ * The server routes have always existed; only the CLI caller was missing, so pausing an
+ * account was dashboard-only. The issue reports these as POST; the code is PUT
+ * (`auth-api.ts:1494`), and the route is shared by both directions with a `paused` boolean
+ * rather than being two endpoints.
+ */
+export async function cmdPause(args: string[], deps: AccountDeps, paused: boolean): Promise<number> {
+  const wantsJson = flag(args, "--json");
+  const name = args.shift();
+  const requestedId = args.shift();
+  const verb = paused ? "pause" : "resume";
+  if (!name || !requestedId || args.length) return usage();
+  const classified = configAndType(deps, name);
+  if ("error" in classified) return usage(`Error: ${classified.error}`);
+  if (classified.type !== "codex") {
+    return usage(`Error: ${verb} applies to the openai Codex account pool`);
+  }
+  const id = requestedId === "main" ? MAIN_ID : requestedId;
+
+  const baseUrl = await resolveBaseUrl(deps);
+  if (!baseUrl) return proxyUnreachable();
+
+  const response = await apiJson(deps, baseUrl, "PUT", "/api/codex-auth/accounts/pause", { id, paused });
+  // Transport sentinel first: status 0 means the proxy never answered, and comparing it to
+  // 200 would report an unreachable proxy as a management error.
+  if (response.status === 0) return proxyUnreachable(response.transportError);
+  if (response.status !== 200) return apiError(response.json, `failed to ${verb} ${requestedId}`, response.status);
+
+  if (wantsJson) {
+    console.log(JSON.stringify({ ok: true, provider: name, id, paused }, null, 2));
+  } else {
+    console.log(`${name}: ${requestedId} ${paused ? "paused" : "resumed"}`);
+  }
+  if (paused) {
+    // Both are server-side effects of this route (auth-api.ts:1508-1510), not consequences
+    // the operator would infer from the word "pause".
+    console.error("Threads bound to this account are unbound, and a fallback account is selected if this one was active.");
+  }
+  return 0;
+}
+
+/**
+ * `ocx account pause-exhausted [--off]` (#2702).
+ *
+ * Pauses every account whose quota is spent. The route refreshes quota for each account, so
+ * it can partially fail; the response distinguishes "checked none and some failed" from
+ * "checked some", and that distinction is reported rather than flattened into ok/not-ok.
+ */
+export async function cmdPauseExhausted(args: string[], deps: AccountDeps): Promise<number> {
+  const wantsJson = flag(args, "--json");
+  const name = args.shift();
+  if (!name || args.length) return usage();
+  const classified = configAndType(deps, name);
+  if ("error" in classified) return usage(`Error: ${classified.error}`);
+  if (classified.type !== "codex") {
+    return usage("Error: pause-exhausted applies to the openai Codex account pool");
+  }
+
+  const baseUrl = await resolveBaseUrl(deps);
+  if (!baseUrl) return proxyUnreachable();
+
+  const response = await apiJson(deps, baseUrl, "PUT", "/api/codex-auth/accounts/pause-exhausted", {});
+  if (response.status === 0) return proxyUnreachable(response.transportError);
+  if (response.status !== 200) return apiError(response.json, "failed to pause exhausted accounts", response.status);
+
+  const pausedIds = Array.isArray(response.json.pausedAccountIds)
+    ? (response.json.pausedAccountIds as unknown[]).filter((value): value is string => typeof value === "string")
+    : [];
+  const checked = typeof response.json.checkedAccountCount === "number" ? response.json.checkedAccountCount : null;
+  const failed = typeof response.json.failedAccountCount === "number" ? response.json.failedAccountCount : null;
+
+  if (wantsJson) {
+    console.log(JSON.stringify({ ok: true, provider: name, pausedAccountIds: pausedIds, checkedAccountCount: checked, failedAccountCount: failed }, null, 2));
+    return 0;
+  }
+  console.log(pausedIds.length > 0
+    ? `${name}: paused ${pausedIds.length} exhausted account(s): ${pausedIds.join(", ")}`
+    : `${name}: no exhausted accounts to pause`);
+  // A quota refresh that failed for some accounts means those were not evaluated at all, so
+  // silence here would read as "none were exhausted" -- a different and wrong conclusion.
+  if (failed !== null && failed > 0) {
+    console.error(`Quota refresh failed for ${failed} account(s); those were not evaluated.`);
+  }
+  return 0;
+}
+
+/**
+ * Two pools expose strategy and sticky, and they are NOT reached the same way:
+ *
+ * |  | Codex pool | Anthropic pool |
+ * |---|---|---|
+ * | read | `GET /api/codex-auth/active` | `GET /api/oauth/accounts/pool?provider=` |
+ * | write | `PUT /api/codex-auth/pool-strategy` | `PUT /api/oauth/accounts/pool` |
+ * | keys | `accountPoolStrategy`/`accountPoolStickyLimit` | `strategy`/`stickyLimit` |
+ * | body | bare field | field **plus** a mandatory `provider` |
+ *
+ * Omitting `provider` from the Anthropic write body earns a 400
+ * (`oauth-account-routes.ts:344`), so the asymmetry has to be encoded somewhere. Encoding it
+ * here keeps ONE verb pair working on both pools. The alternative the plan left open -- a second
+ * `provider-strategy`/`provider-sticky` pair -- would double the surface an operator must learn
+ * to express one idea, and a CLI that can steer one pool and not the other is exactly the trap
+ * this unit exists to remove.
+ */
+interface PoolTransport {
+  readPath: string;
+  writePath: string;
+  /** Response key carrying the applied strategy. */
+  strategyKey: string;
+  /** Response key carrying the applied sticky limit. */
+  stickyKey: string;
+  writeBody: (field: "strategy" | "stickyLimit", value: unknown) => Record<string, unknown>;
+}
+
+const CODEX_POOL_TRANSPORT: PoolTransport = {
+  readPath: "/api/codex-auth/active",
+  writePath: "/api/codex-auth/pool-strategy",
+  strategyKey: "accountPoolStrategy",
+  stickyKey: "accountPoolStickyLimit",
+  writeBody: (field, value) => ({ [field]: value }),
+};
+
+function anthropicPoolTransport(provider: string): PoolTransport {
+  return {
+    readPath: `/api/oauth/accounts/pool?provider=${encodeURIComponent(provider)}`,
+    writePath: "/api/oauth/accounts/pool",
+    strategyKey: "strategy",
+    stickyKey: "stickyLimit",
+    writeBody: (field, value) => ({ provider, [field]: value }),
+  };
+}
+
+/**
+ * The pool-config route supports `anthropic` only and says so with a 400. Any other OAuth
+ * provider is refused here with the same wording rather than spending a round-trip to learn it.
+ */
+function poolTransportFor(
+  classified: { type: "codex" | "oauth" | "api-key" },
+  name: string,
+): PoolTransport | string {
+  if (classified.type === "codex") return CODEX_POOL_TRANSPORT;
+  if (classified.type === "oauth" && name === "anthropic") return anthropicPoolTransport(name);
+  return `pool settings apply to the openai Codex pool and the anthropic pool, not "${name}"`;
+}
+
+/**
+ * `ocx account strategy <provider> [<name>]` and `ocx account sticky <provider> [<n>]` (#2702).
+ *
+ * One implementation rather than two near-duplicates, because strategy and sticky are two
+ * fields of one setting on every pool that has them.
+ *
+* Values are NOT re-validated here. The server owns both contracts -- three strategy names,
+* a 1-100 sticky bound -- and a duplicated bound is a second thing to keep in sync. Its 400
+* is actionable now that the CLI prints `reason`.
+*/
+async function poolSetting(
+  args: string[],
+  deps: AccountDeps,
+  field: "strategy" | "stickyLimit",
+): Promise<number> {
+  const wantsJson = flag(args, "--json");
+  const name = args.shift();
+  const requested = args.shift();
+  const label = field === "strategy" ? "pool strategy" : "sticky limit";
+  if (!name || args.length) return usage();
+  const classified = configAndType(deps, name);
+  if ("error" in classified) return usage(`Error: ${classified.error}`);
+  const transport = poolTransportFor(classified, name);
+  if (typeof transport === "string") return usage(`Error: ${transport}`);
+
+  const baseUrl = await resolveBaseUrl(deps);
+  if (!baseUrl) return proxyUnreachable();
+
+  // No value means show. A read must not rewrite what it is reporting.
+  if (requested === undefined) {
+    const response = await apiJson(deps, baseUrl, "GET", transport.readPath);
+    if (response.status === 0) return proxyUnreachable(response.transportError);
+    if (response.status !== 200) return apiError(response.json, `failed to read ${label}`, response.status);
+    const strategy = response.json[transport.strategyKey];
+    const sticky = response.json[transport.stickyKey];
+    if (wantsJson) {
+      // Pool-neutral key names: the two routes spell the same two settings differently, and a
+      // `--json` consumer should not have to branch on which pool answered.
+      console.log(JSON.stringify({ ok: true, provider: name, strategy, stickyLimit: sticky }, null, 2));
+    } else {
+      console.log(`${name}: ${label} is ${String(field === "strategy" ? strategy : sticky)}`);
+    }
+    return 0;
+  }
+
+  // Sent as a number when it parses as one so the server sees the type it validates;
+  // a non-numeric string still goes through and earns the server's own 400.
+  const value = field === "strategy"
+    ? requested
+    : (Number.isNaN(Number(requested)) ? requested : Number(requested));
+  const response = await apiJson(deps, baseUrl, "PUT", transport.writePath, transport.writeBody(field, value));
+  if (response.status === 0) return proxyUnreachable(response.transportError);
+  if (response.status !== 200) return apiError(response.json, `failed to set ${label}`, response.status);
+
+  if (wantsJson) {
+    console.log(JSON.stringify({
+      ok: true,
+      provider: name,
+      strategy: response.json[transport.strategyKey],
+      stickyLimit: response.json[transport.stickyKey],
+    }, null, 2));
+  } else {
+    // Echo the APPLIED value from the response, not the requested one: the server normalizes,
+    // and printing the request would hide a normalization the operator should see.
+    const applied = field === "strategy" ? response.json[transport.strategyKey] : response.json[transport.stickyKey];
+    console.log(`${name}: ${label} is now ${String(applied)}`);
+  }
+  return 0;
+}
+
+export function cmdStrategy(args: string[], deps: AccountDeps): Promise<number> {
+  return poolSetting(args, deps, "strategy");
+}
+
+export function cmdSticky(args: string[], deps: AccountDeps): Promise<number> {
+  return poolSetting(args, deps, "stickyLimit");
 }
 
 export async function cmdAlias(args: string[], deps: AccountDeps): Promise<number> {

--- a/src/cli/account-extended.ts
+++ b/src/cli/account-extended.ts
@@ -778,19 +778,26 @@ export async function cmdPauseExhausted(args: string[], deps: AccountDeps): Prom
   const checked = typeof response.json.checkedAccountCount === "number" ? response.json.checkedAccountCount : null;
   const failed = typeof response.json.failedAccountCount === "number" ? response.json.failedAccountCount : null;
 
+  const complete = failed === null || failed === 0;
+  const ok = complete;
+  if (failed !== null && failed > 0) {
+    console.error(`Quota refresh failed for ${failed} account(s); those were not evaluated.`);
+  }
   if (wantsJson) {
-    console.log(JSON.stringify({ ok: true, provider: name, pausedAccountIds: pausedIds, checkedAccountCount: checked, failedAccountCount: failed }, null, 2));
-    return 0;
+    console.log(JSON.stringify({
+      ok,
+      complete,
+      provider: name,
+      pausedAccountIds: pausedIds,
+      checkedAccountCount: checked,
+      failedAccountCount: failed,
+    }, null, 2));
+    return ok ? 0 : 1;
   }
   console.log(pausedIds.length > 0
     ? `${name}: paused ${pausedIds.length} exhausted account(s): ${pausedIds.join(", ")}`
     : `${name}: no exhausted accounts to pause`);
-  // A quota refresh that failed for some accounts means those were not evaluated at all, so
-  // silence here would read as "none were exhausted" -- a different and wrong conclusion.
-  if (failed !== null && failed > 0) {
-    console.error(`Quota refresh failed for ${failed} account(s); those were not evaluated.`);
-  }
-  return 0;
+  return ok ? 0 : 1;
 }
 
 /**

--- a/src/cli/account.ts
+++ b/src/cli/account.ts
@@ -2,7 +2,20 @@
 import { loadConfig } from "../config";
 import { providerCodexAccountMode } from "../providers/registry";
 import type { OcxConfig } from "../types";
-import { cmdAddKey, cmdAlias, cmdAutoSwitch, cmdClearCooldown, cmdImport, cmdPriority, cmdRefresh, cmdRemove } from "./account-extended";
+import {
+  cmdAddKey,
+  cmdAlias,
+  cmdAutoSwitch,
+  cmdClearCooldown,
+  cmdImport,
+  cmdPause,
+  cmdPauseExhausted,
+  cmdPriority,
+  cmdRefresh,
+  cmdRemove,
+  cmdSticky,
+  cmdStrategy,
+} from "./account-extended";
 import { apiError, apiJson, classifyAccount, fetchRows, proxyUnreachable, resolveBaseUrl, type AccountDeps, type AccountRow, type AccountType, type ApiResult }
   from "./account-api";
 
@@ -23,6 +36,11 @@ const ACCOUNT_USAGE = `Usage:
   ocx account auto-switch <provider> <on|off|status|threshold <0-100>> [--json]
   ocx account alias <provider> <account-or-key-id> <display-name|-> [--json]
   ocx account priority <provider> <account-id|main> [<-100..100|first|earlier|normal|later|last|reset>] [--json]
+  ocx account pause <provider> <account-id|main> [--json]
+  ocx account resume <provider> <account-id|main> [--json]
+  ocx account pause-exhausted <provider> [--json]
+  ocx account strategy <provider> [<quota|round-robin|fill-first>] [--json]
+  ocx account sticky <provider> [<1-100>] [--json]
   ocx account remove <provider> <account-or-key-id|main> --yes [--json]
   ocx account clear-cooldown <provider> <account-id|main> [--json]
   ocx account add-key <provider> [--label <label>] [--json]
@@ -306,6 +324,13 @@ export async function cmdAccount(args: string[], deps: AccountDeps = {}): Promis
     if (sub === "auto-switch") return await cmdAutoSwitch(rest, deps);
     if (sub === "alias" || sub === "rename") return await cmdAlias(rest, deps);
     if (sub === "priority") return await cmdPriority(rest, deps);
+    // #2702: the server routes existed and only the CLI caller was missing, so these were
+    // dashboard-only capabilities.
+    if (sub === "pause") return await cmdPause(rest, deps, true);
+    if (sub === "resume") return await cmdPause(rest, deps, false);
+    if (sub === "pause-exhausted") return await cmdPauseExhausted(rest, deps);
+    if (sub === "strategy") return await cmdStrategy(rest, deps);
+    if (sub === "sticky") return await cmdSticky(rest, deps);
     if (sub === "remove") return await cmdRemove(rest, deps);
     if (sub === "clear-cooldown") return await cmdClearCooldown(rest, deps);
     if (sub === "add-key") return await cmdAddKey(rest, deps);

--- a/src/cli/capabilities.ts
+++ b/src/cli/capabilities.ts
@@ -188,7 +188,7 @@ export const CAPABILITIES: readonly Capability[] = [
     mutates: true,
     json: "envelope",
     details: [
-      "The route refreshes quota per account and can partially fail; a non-zero failed count is reported, because silence would read as `none were exhausted`.",
+      "The route refreshes quota per account and can partially fail; a non-zero failed count exits 1 and sets ok:false, because silence would read as `none were exhausted`.",
     ],
   },
   {

--- a/src/cli/capabilities.ts
+++ b/src/cli/capabilities.ts
@@ -160,6 +160,73 @@ export const CAPABILITIES: readonly Capability[] = [
       "An `(ambiguous)` account row aggregates several accounts; do not read it as one identity.",
     ],
   },
+  {
+    command: ["account", "pause"],
+    summary: "Stop routing new requests to one account in the Codex pool.",
+    // One route, both directions: `resume` is the same PUT with `paused: false`.
+    routes: [{ method: "PUT", path: "/api/codex-auth/accounts/pause" }],
+    flags: [{ name: "--json", value: "boolean", summary: "Emit the pause result as JSON." }],
+    mutates: true,
+    json: "envelope",
+    details: [
+      "Pausing also unbinds threads pinned to the account and selects a fallback if it was active -- side effects of the route, not of the word `pause`.",
+      "The issue that requested this reported the route as POST; it is PUT.",
+    ],
+  },
+  {
+    command: ["account", "resume"],
+    summary: "Return a paused account to the Codex pool.",
+    routes: [{ method: "PUT", path: "/api/codex-auth/accounts/pause" }],
+    flags: [{ name: "--json", value: "boolean", summary: "Emit the resume result as JSON." }],
+    mutates: true,
+    json: "envelope",
+  },
+  {
+    command: ["account", "pause-exhausted"],
+    summary: "Pause every Codex account whose quota is spent.",
+    routes: [{ method: "PUT", path: "/api/codex-auth/accounts/pause-exhausted" }],
+    flags: [{ name: "--json", value: "boolean", summary: "Emit paused ids and the checked/failed counts as JSON." }],
+    mutates: true,
+    json: "envelope",
+    details: [
+      "The route refreshes quota per account and can partially fail; a non-zero failed count is reported, because silence would read as `none were exhausted`.",
+    ],
+  },
+  {
+    command: ["account", "strategy"],
+    summary: "Show or set how an account pool picks the next account.",
+    // Both pools, because both have the setting. The Codex pool reads its applied values
+    // from the active payload; the Anthropic pool has its own GET.
+    routes: [
+      { method: "GET", path: "/api/codex-auth/active" },
+      { method: "PUT", path: "/api/codex-auth/pool-strategy" },
+      { method: "GET", path: "/api/oauth/accounts/pool" },
+      { method: "PUT", path: "/api/oauth/accounts/pool" },
+    ],
+    flags: [{ name: "--json", value: "boolean", summary: "Emit the applied strategy and sticky limit as JSON." }],
+    mutates: true,
+    json: "envelope",
+    details: [
+      "A bare invocation reads and never writes.",
+      "The APPLIED value is echoed, not the requested one, so a server-side normalization stays visible.",
+      "Values are not re-validated in the CLI: the server owns the strategy names and the 1-100 sticky bound.",
+      "`anthropic` is the only OAuth pool with this setting; other OAuth providers are refused without a round-trip.",
+    ],
+  },
+  {
+    command: ["account", "sticky"],
+    summary: "Show or set how many consecutive requests stay on one account.",
+    routes: [
+      { method: "GET", path: "/api/codex-auth/active" },
+      { method: "PUT", path: "/api/codex-auth/pool-strategy" },
+      { method: "GET", path: "/api/oauth/accounts/pool" },
+      { method: "PUT", path: "/api/oauth/accounts/pool" },
+    ],
+    flags: [{ name: "--json", value: "boolean", summary: "Emit the applied strategy and sticky limit as JSON." }],
+    mutates: true,
+    json: "envelope",
+    details: ["Only meaningful under the sticky-capable strategies; the pool strategy is the other half of this setting."],
+  },
 ];
 
 /** Capabilities that drive `route`, for `ocx capabilities --route`. */

--- a/src/cli/capabilities.ts
+++ b/src/cli/capabilities.ts
@@ -227,6 +227,28 @@ export const CAPABILITIES: readonly Capability[] = [
     json: "envelope",
     details: ["Only meaningful under the sticky-capable strategies; the pool strategy is the other half of this setting."],
   },
+  {
+    command: ["logs"],
+    summary: "Recent request log rows, filterable by provider, model, conversation, and status.",
+    routes: [{ method: "GET", path: "/api/logs" }],
+    flags: [
+      { name: "--provider", value: "string", summary: "Restrict to one provider, matching failover attempts too." },
+      { name: "--model", value: "string", summary: "Restrict to one model id, matching failover attempts too." },
+      { name: "--conversation", value: "string", summary: "Restrict to one conversation id (`--conversationId` is accepted too)." },
+      { name: "--status", value: "string", summary: "An exact code (429) or a class (5xx)." },
+      { name: "--limit", value: "number", summary: "Row cap; defaults to 200." },
+      { name: "--follow", value: "boolean", summary: "Stream new rows as JSONL; implies --jsonl." },
+      { name: "--json", value: "boolean", summary: "Emit the server payload as JSON." },
+      { name: "--jsonl", value: "boolean", summary: "Emit one row per line." },
+    ],
+    mutates: false,
+    json: "payload",
+    details: [
+      "`--provider` and `--model` both match a failover attempt, so a request is findable by what actually served it, not only by what was asked for.",
+      "Rows print `conv=<id>` when the entry carries one, so a conversation filter can be told apart from an empty result.",
+      "`--follow` deduplicates by row id and cannot be combined with `--json`.",
+    ],
+  },
 ];
 
 /** Capabilities that drive `route`, for `ocx capabilities --route`. */

--- a/src/cli/observe.ts
+++ b/src/cli/observe.ts
@@ -15,7 +15,7 @@ import { USAGE_RANGES, USAGE_SURFACES } from "../usage/summary";
 
 const USAGE = `Usage:
   ocx observe logs [--provider <name>] [--model <id>] [--status <code>]
-      [--limit <n>] [--follow] [--json|--jsonl]
+      [--conversation <id>] [--limit <n>] [--follow] [--json|--jsonl]
   ocx logs explain <request-id> [--json]
   ocx logs rebuild-index
   ocx logs index-status
@@ -50,7 +50,12 @@ function formatLog(row: LogEntry): string {
   const route = [row.provider, row.model].filter(Boolean).join("/");
   const status = row.status ?? row.statusCode ?? "?";
   const duration = row.durationMs !== undefined ? `${String(row.durationMs)}ms` : "";
-  return [time, String(status), route, duration].filter(Boolean).join("  ");
+  // The conversation id is shown because a conversation FILTER whose output never names the
+  // conversation is hard to trust: an empty result and a wrong-id result look identical (#2704).
+  const conversation = typeof row.conversationId === "string" && row.conversationId.length > 0
+    ? `conv=${row.conversationId}`
+    : "";
+  return [time, String(status), route, duration, conversation].filter(Boolean).join("  ");
 }
 
 async function logs(argv: string[], deps: RuntimeApiDeps): Promise<void> {
@@ -61,13 +66,16 @@ async function logs(argv: string[], deps: RuntimeApiDeps): Promise<void> {
   const provider = takeOption(args, "--provider");
   const model = takeOption(args, "--model");
   const status = takeOption(args, "--status");
+  // Both spellings, because the server accepts both (`request-log.ts:1032`) and an operator
+  // should not have to remember which one this surface wanted.
+  const conversationId = takeOption(args, "--conversation") ?? takeOption(args, "--conversationId");
   const limit = takeIntegerOption(args, "--limit", { min: 1 }) ?? 200;
   rejectArgs(args, USAGE);
   if (wantsJson && wantsJsonl) throw new CliUsageError("--json and --jsonl cannot be combined", USAGE);
   if (follow && wantsJson) throw new CliUsageError("--follow uses --jsonl, not --json", USAGE);
   let seen = new Set<string>();
   do {
-    const data = await runtimeRequest(`/api/logs${query({ provider, model, status, limit })}`, {}, deps);
+    const data = await runtimeRequest(`/api/logs${query({ provider, model, status, conversationId, limit })}`, {}, deps);
     const rows = logRows(data);
     if (!follow && wantsJson) printData(data, true);
     else {

--- a/src/server/request-log.ts
+++ b/src/server/request-log.ts
@@ -1033,6 +1033,15 @@ export function filterRequestLogs(logs: RequestLogEntry[], params: URLSearchPara
   if (conversationId) {
     filtered = filtered.filter(entry => matchesLogConversationId(entry.conversationId, conversationId));
   }
+  // #2704: there was no `model` clause at all, so `?model=x` was ACCEPTED and silently
+  // ignored -- worse than an error, because it yields wrong conclusions from output that
+  // looks correct. Attempts are matched for the same reason `provider` matches them: a
+  // request that failed over should be findable by the model that actually served it.
+  const model = params.get("model")?.trim();
+  if (model) {
+    filtered = filtered.filter(entry => entry.model === model
+      || entry.attempts?.some(attempt => attempt.model === model));
+  }
   const status = params.get("status")?.trim().toLowerCase();
   if (status) {
     filtered = /^[1-5]xx$/.test(status)

--- a/tests/cli-account-pool-verbs.test.ts
+++ b/tests/cli-account-pool-verbs.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, test } from "bun:test";
+import { cmdPause, cmdPauseExhausted, cmdStrategy, cmdSticky } from "../src/cli/account-extended";
+import type { AccountDeps } from "../src/cli/account-api";
+
+/**
+ * #2702: pause, resume, pause-exhausted, strategy, and sticky existed as server routes with
+ * no CLI caller, so steering the account pool was dashboard-only.
+ *
+ * The requests are asserted, not just the output. A verb that prints the right sentence while
+ * calling the wrong route or method is the failure these tests exist to catch -- and the
+ * method is a real trap here, since the issue reports POST and the server implements PUT.
+ */
+interface Captured {
+  method: string;
+  path: string;
+  body: unknown;
+}
+
+function deps(
+  respond: (captured: Captured) => { status?: number; json: unknown },
+  calls: Captured[],
+): AccountDeps {
+  return {
+    baseUrl: "http://127.0.0.1:10100",
+    loadConfigImpl: () => ({ providers: { openai: { adapter: "codex" } } }) as never,
+    fetchImpl: (async (url: string | URL | Request, init?: RequestInit) => {
+      const captured: Captured = {
+        method: init?.method ?? "GET",
+        path: new URL(String(url)).pathname,
+        body: init?.body === undefined ? undefined : JSON.parse(String(init.body)),
+      };
+      calls.push(captured);
+      const { status = 200, json } = respond(captured);
+      return new Response(JSON.stringify(json), { status });
+    }) as unknown as typeof fetch,
+  };
+}
+
+function capture(): { lines: string[]; errors: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const errors: string[] = [];
+  const log = console.log;
+  const err = console.error;
+  console.log = (...a: unknown[]) => { lines.push(a.map(String).join(" ")); };
+  console.error = (...a: unknown[]) => { errors.push(a.map(String).join(" ")); };
+  return { lines, errors, restore: () => { console.log = log; console.error = err; } };
+}
+
+describe("ocx account pause / resume", () => {
+  test("pause PUTs the shared route with paused true", async () => {
+    const calls: Captured[] = [];
+    const out = capture();
+    let code: number;
+    try {
+      code = await cmdPause(["openai", "acct_1"], deps(() => ({ json: { ok: true } }), calls), true);
+    } finally { out.restore(); }
+    expect(code).toBe(0);
+    // PUT, not POST: the issue text says POST and the server implements PUT.
+    expect(calls[0]?.method).toBe("PUT");
+    expect(calls[0]?.path).toBe("/api/codex-auth/accounts/pause");
+    expect(calls[0]?.body).toEqual({ id: "acct_1", paused: true });
+    expect(out.lines.join("\n")).toContain("paused");
+  });
+
+  test("resume uses the SAME route with paused false", async () => {
+    const calls: Captured[] = [];
+    const out = capture();
+    try {
+      await cmdPause(["openai", "acct_1"], deps(() => ({ json: { ok: true } }), calls), false);
+    } finally { out.restore(); }
+    expect(calls[0]?.path).toBe("/api/codex-auth/accounts/pause");
+    expect(calls[0]?.body).toEqual({ id: "acct_1", paused: false });
+    expect(out.lines.join("\n")).toContain("resumed");
+  });
+
+  test("main resolves to the main account id", async () => {
+    const calls: Captured[] = [];
+    const out = capture();
+    try {
+      await cmdPause(["openai", "main"], deps(() => ({ json: { ok: true } }), calls), true);
+    } finally { out.restore(); }
+    expect((calls[0]?.body as { id: string }).id).not.toBe("main");
+  });
+
+  test("pausing warns about unbinding and fallback selection", async () => {
+    // Both are server-side effects of this route, not consequences an operator would infer
+    // from the word "pause".
+    const out = capture();
+    try {
+      await cmdPause(["openai", "acct_1"], deps(() => ({ json: { ok: true } }), []), true);
+    } finally { out.restore(); }
+    expect(out.errors.join("\n")).toContain("unbound");
+  });
+
+  test("resuming does not print the pause side-effect warning", async () => {
+    const out = capture();
+    try {
+      await cmdPause(["openai", "acct_1"], deps(() => ({ json: { ok: true } }), []), false);
+    } finally { out.restore(); }
+    expect(out.errors.join("\n")).not.toContain("unbound");
+  });
+
+  test("a 404 surfaces the server's reason and a non-zero code", async () => {
+    const out = capture();
+    let code: number;
+    try {
+      code = await cmdPause(["openai", "nope"], deps(() => ({ status: 404, json: { error: "Account not found" } }), []), true);
+    } finally { out.restore(); }
+    expect(code).not.toBe(0);
+    expect(out.errors.join("\n")).toContain("Account not found");
+  });
+});
+
+describe("ocx account pause-exhausted", () => {
+  test("reports which accounts were paused", async () => {
+    const calls: Captured[] = [];
+    const out = capture();
+    try {
+      await cmdPauseExhausted(["openai"], deps(() => ({
+        json: { ok: true, pausedAccountIds: ["acct_1", "acct_2"], checkedAccountCount: 3, failedAccountCount: 0 },
+      }), calls));
+    } finally { out.restore(); }
+    expect(calls[0]?.method).toBe("PUT");
+    expect(out.lines.join("\n")).toContain("acct_1");
+  });
+
+  test("a partial quota-refresh failure is reported, not swallowed", async () => {
+    // Accounts whose quota refresh failed were never evaluated. Silence would read as
+    // "none were exhausted", which is a different and wrong conclusion.
+    const out = capture();
+    try {
+      await cmdPauseExhausted(["openai"], deps(() => ({
+        json: { ok: true, pausedAccountIds: [], checkedAccountCount: 1, failedAccountCount: 2 },
+      }), []));
+    } finally { out.restore(); }
+    expect(out.errors.join("\n")).toContain("2 account(s)");
+  });
+
+  test("no exhausted accounts says so instead of printing an empty list", async () => {
+    const out = capture();
+    try {
+      await cmdPauseExhausted(["openai"], deps(() => ({
+        json: { ok: true, pausedAccountIds: [], checkedAccountCount: 2, failedAccountCount: 0 },
+      }), []));
+    } finally { out.restore(); }
+    expect(out.lines.join("\n")).toContain("no exhausted accounts");
+  });
+});
+
+describe("ocx account strategy / sticky", () => {
+  test("a bare invocation READS and never writes", async () => {
+    const calls: Captured[] = [];
+    const out = capture();
+    try {
+      await cmdStrategy(["openai"], deps(() => ({
+        json: { accountPoolStrategy: "round-robin", accountPoolStickyLimit: 4 },
+      }), calls));
+    } finally { out.restore(); }
+    expect(calls.every(call => call.method === "GET")).toBe(true);
+    expect(out.lines.join("\n")).toContain("round-robin");
+  });
+
+  test("strategy and sticky share one write route", async () => {
+    const strategyCalls: Captured[] = [];
+    const stickyCalls: Captured[] = [];
+    const out = capture();
+    try {
+      await cmdStrategy(["openai", "fill-first"], deps(() => ({ json: { accountPoolStrategy: "fill-first", accountPoolStickyLimit: 1 } }), strategyCalls));
+      await cmdSticky(["openai", "7"], deps(() => ({ json: { accountPoolStrategy: "fill-first", accountPoolStickyLimit: 7 } }), stickyCalls));
+    } finally { out.restore(); }
+    expect(strategyCalls[0]?.path).toBe("/api/codex-auth/pool-strategy");
+    expect(stickyCalls[0]?.path).toBe("/api/codex-auth/pool-strategy");
+    expect(strategyCalls[0]?.body).toEqual({ strategy: "fill-first" });
+    // Sent as a number so the server sees the type it validates.
+    expect(stickyCalls[0]?.body).toEqual({ stickyLimit: 7 });
+  });
+
+  test("the APPLIED value is echoed, not the requested one", async () => {
+    // The server normalizes. Printing the request would hide a normalization the operator
+    // should see.
+    const out = capture();
+    try {
+      await cmdSticky(["openai", "9"], deps(() => ({ json: { accountPoolStrategy: "quota", accountPoolStickyLimit: 3 } }), []));
+    } finally { out.restore(); }
+    expect(out.lines.join("\n")).toContain("3");
+    expect(out.lines.join("\n")).not.toContain("9");
+  });
+
+  test("an invalid value is NOT rejected client-side; the server's 400 is surfaced", async () => {
+    // The server owns the 1-100 contract. A duplicated bound is a second thing to keep in
+    // sync, and its 400 is actionable now that the CLI prints `reason`.
+    const calls: Captured[] = [];
+    const out = capture();
+    let code: number;
+    try {
+      code = await cmdSticky(["openai", "9999"], deps(() => ({ status: 400, json: { error: "stickyLimit must be an integer 1-100" } }), calls));
+    } finally { out.restore(); }
+    expect(calls).toHaveLength(1);
+    expect(code).not.toBe(0);
+    expect(out.errors.join("\n")).toContain("1-100");
+  });
+});
+
+/**
+ * The sibling gap the plan named: `/api/oauth/accounts/pool` is the SAME capability for the
+ * Anthropic pool and had no verb either. A CLI that can steer one pool and not the other is a
+ * trap, so the decision recorded here is one verb pair over both pools rather than a second
+ * `provider-strategy`/`provider-sticky` pair.
+ *
+ * The route is genuinely different, and each difference gets an assertion: its own read path,
+ * unprefixed response keys, and a MANDATORY `provider` in the write body without which it
+ * answers 400 (`oauth-account-routes.ts:344`).
+ */
+describe("ocx account strategy / sticky on the anthropic pool", () => {
+  function anthropicDeps(
+    respond: (captured: Captured) => { status?: number; json: unknown },
+    calls: Captured[],
+  ): AccountDeps {
+    return {
+      baseUrl: "http://127.0.0.1:10100",
+      // No `adapter: "codex"`: anthropic classifies as a public OAuth provider, which is what
+      // routes it to the other pool.
+      loadConfigImpl: () => ({ providers: { anthropic: {} } }) as never,
+      fetchImpl: (async (url: string | URL | Request, init?: RequestInit) => {
+        const parsed = new URL(String(url));
+        const captured: Captured = {
+          method: init?.method ?? "GET",
+          path: parsed.pathname + parsed.search,
+          body: init?.body === undefined ? undefined : JSON.parse(String(init.body)),
+        };
+        calls.push(captured);
+        const { status = 200, json } = respond(captured);
+        return new Response(JSON.stringify(json), { status });
+      }) as unknown as typeof fetch,
+    };
+  }
+
+  test("a bare read uses the pool route with provider in the query, not the codex active route", async () => {
+    const calls: Captured[] = [];
+    const out = capture();
+    try {
+      await cmdStrategy(["anthropic"], anthropicDeps(() => ({ json: { strategy: "round-robin", stickyLimit: 5 } }), calls));
+    } finally { out.restore(); }
+    expect(calls[0]?.method).toBe("GET");
+    expect(calls[0]?.path).toBe("/api/oauth/accounts/pool?provider=anthropic");
+    // Unprefixed keys: this route spells the same settings without `accountPool`.
+    expect(out.lines.join("\n")).toContain("round-robin");
+  });
+
+  test("a write carries the MANDATORY provider key alongside the field", async () => {
+    const calls: Captured[] = [];
+    const out = capture();
+    try {
+      await cmdSticky(["anthropic", "6"], anthropicDeps(() => ({ json: { ok: true, strategy: "quota", stickyLimit: 6 } }), calls));
+    } finally { out.restore(); }
+    expect(calls[0]?.method).toBe("PUT");
+    expect(calls[0]?.path).toBe("/api/oauth/accounts/pool");
+    // Omitting `provider` here earns a 400 from the real route, so it is asserted exactly.
+    expect(calls[0]?.body).toEqual({ provider: "anthropic", stickyLimit: 6 });
+    expect(out.lines.join("\n")).toContain("6");
+  });
+
+  test("--json uses pool-neutral key names so a consumer need not branch on which pool answered", async () => {
+    const out = capture();
+    try {
+      await cmdStrategy(["anthropic", "--json"], anthropicDeps(() => ({ json: { strategy: "fill-first", stickyLimit: 2 } }), []));
+    } finally { out.restore(); }
+    expect(JSON.parse(out.lines.join("\n"))).toMatchObject({ provider: "anthropic", strategy: "fill-first", stickyLimit: 2 });
+  });
+
+  test("the codex pool keeps its own prefixed keys mapped onto the same neutral output", async () => {
+    const out = capture();
+    try {
+      await cmdStrategy(["openai", "--json"], deps(() => ({ json: { accountPoolStrategy: "quota", accountPoolStickyLimit: 1 } }), []));
+    } finally { out.restore(); }
+    expect(JSON.parse(out.lines.join("\n"))).toMatchObject({ provider: "openai", strategy: "quota", stickyLimit: 1 });
+  });
+
+  test("an OAuth provider without a pool config is refused WITHOUT a round-trip", async () => {
+    const calls: Captured[] = [];
+    const out = capture();
+    let code: number;
+    try {
+      code = await cmdStrategy(["gemini"], {
+        baseUrl: "http://127.0.0.1:10100",
+        loadConfigImpl: () => ({ providers: { gemini: {} } }) as never,
+        fetchImpl: (async (url: string | URL | Request, init?: RequestInit) => {
+          calls.push({ method: init?.method ?? "GET", path: new URL(String(url)).pathname, body: undefined });
+          return new Response("{}", { status: 200 });
+        }) as unknown as typeof fetch,
+      });
+    } finally { out.restore(); }
+    expect(code).not.toBe(0);
+    // The route would answer 400; spending the request to learn that is the thing avoided.
+    expect(calls).toHaveLength(0);
+    expect(out.errors.join("\n")).toContain("anthropic");
+  });
+});

--- a/tests/cli-account-pool-verbs.test.ts
+++ b/tests/cli-account-pool-verbs.test.ts
@@ -129,11 +129,26 @@ describe("ocx account pause-exhausted", () => {
     // "none were exhausted", which is a different and wrong conclusion.
     const out = capture();
     try {
-      await cmdPauseExhausted(["openai"], deps(() => ({
+      const code = await cmdPauseExhausted(["openai"], deps(() => ({
         json: { ok: true, pausedAccountIds: [], checkedAccountCount: 1, failedAccountCount: 2 },
       }), []));
+      expect(code).toBe(1);
     } finally { out.restore(); }
     expect(out.errors.join("\n")).toContain("2 account(s)");
+  });
+
+  test("a partial failure is not ok:true under --json", async () => {
+    const out = capture();
+    try {
+      const code = await cmdPauseExhausted(["openai", "--json"], deps(() => ({
+        json: { ok: true, pausedAccountIds: ["acct_1"], checkedAccountCount: 2, failedAccountCount: 1 },
+      }), []));
+      expect(code).toBe(1);
+    } finally { out.restore(); }
+    const payload = JSON.parse(out.lines.join("\n")) as { ok: boolean; complete: boolean; failedAccountCount: number };
+    expect(payload.ok).toBe(false);
+    expect(payload.complete).toBe(false);
+    expect(payload.failedAccountCount).toBe(1);
   });
 
   test("no exhausted accounts says so instead of printing an empty list", async () => {

--- a/tests/cli-usage-report.test.ts
+++ b/tests/cli-usage-report.test.ts
@@ -187,3 +187,38 @@ describe("ocx usage command", () => {
     expect(out).toContain("grok-4.6");
   });
 });
+
+/**
+ * #2704: `ocx logs` could not filter by conversation at all, even though the server route
+ * had accepted `conversationId` for a long time. The URL is asserted rather than the output,
+ * because a command that prints plausible rows while sending no filter is the failure mode.
+ */
+describe("ocx logs --conversation", () => {
+  const rows = [{ timestamp: "t0", status: 200, provider: "xai", model: "grok-4.6", durationMs: 12, conversationId: "conv-7" }];
+
+  test("both spellings build the same conversationId query", async () => {
+    const long = await run(["logs", "--conversationId", "conv-7"], rows);
+    expect(new URL(long.urls[0]!).searchParams.get("conversationId")).toBe("conv-7");
+
+    // The server accepts `conversation` too (`request-log.ts:1032`), so the CLI should not
+    // make an operator remember which spelling this surface wanted.
+    const short = await run(["logs", "--conversation", "conv-7"], rows);
+    expect(new URL(short.urls[0]!).searchParams.get("conversationId")).toBe("conv-7");
+  });
+
+  test("no filter sends no conversationId", async () => {
+    const { urls } = await run(["logs"], rows);
+    expect(new URL(urls[0]!).searchParams.get("conversationId")).toBeNull();
+  });
+
+  test("the human line names the conversation it claims to have filtered", async () => {
+    const { out } = await run(["logs", "--conversation", "conv-7"], rows);
+    // Without this, an empty result and a wrong-id result are indistinguishable.
+    expect(out).toContain("conv=conv-7");
+  });
+
+  test("a row with no conversation id does not print an empty conv= marker", async () => {
+    const { out } = await run(["logs"], [{ timestamp: "t0", status: 200, provider: "xai", model: "grok-4.6" }]);
+    expect(out).not.toContain("conv=");
+  });
+});

--- a/tests/request-log.test.ts
+++ b/tests/request-log.test.ts
@@ -723,6 +723,36 @@ describe("request log metadata", () => {
     expect(combined.map(entry => entry.requestId)).toEqual(["c"]);
   });
 
+  /**
+   * #2704: there was no `model` clause at all, so `?model=x` was accepted and silently
+   * ignored -- every row came back, and `ocx logs --model x` looked like it had filtered.
+   * The non-matching assertion is the one that matters: an unfiltered implementation passes
+   * the positive case for free.
+   */
+  test("filters logs by model, including the attempt that actually served a failover", () => {
+    const logs = [
+      log({ requestId: "a", model: "gpt-test", provider: "openai" }),
+      log({ requestId: "b", model: "grok-4.6", provider: "xai" }),
+      log({
+        requestId: "c",
+        model: "sonnet-4.6",
+        provider: "anthropic",
+        attempts: [
+          { ordinal: 1, provider: "anthropic", model: "sonnet-4.6", adapter: "anthropic", status: 429, durationMs: 5, sendCount: 1, recoveryKinds: [], usageStatus: "unreported" },
+          { ordinal: 2, provider: "xai", model: "grok-4.6", adapter: "openai", status: 200, durationMs: 7, sendCount: 1, recoveryKinds: [], usageStatus: "reported" },
+        ],
+      }),
+    ];
+
+    expect(filterRequestLogs(logs, new URLSearchParams("model=gpt-test")).map(entry => entry.requestId)).toEqual(["a"]);
+    // "c" matches on its second ATTEMPT, mirroring how `provider` already behaves: the request
+    // was ultimately served by grok-4.6, so a grok-4.6 search has to find it.
+    expect(filterRequestLogs(logs, new URLSearchParams("model=grok-4.6")).map(entry => entry.requestId)).toEqual(["b", "c"]);
+    // The assertion an unfiltered implementation cannot pass.
+    expect(filterRequestLogs(logs, new URLSearchParams("model=absent-model"))).toEqual([]);
+    expect(filterRequestLogs(logs, new URLSearchParams("model=grok-4.6&provider=xai")).map(entry => entry.requestId)).toEqual(["b", "c"]);
+  });
+
   test("filters logs by offset and limit", () => {
     const logs = Array.from({ length: 5 }, (_, i) => log({ requestId: `r${i}`, provider: "openai", status: 200 }));
     expect(filterRequestLogs(logs, new URLSearchParams("limit=2")).map(entry => entry.requestId)).toEqual(["r3", "r4"]);


### PR DESCRIPTION
## Summary

Five account verbs existed only as server routes, so pausing an account or changing pool
strategy was dashboard-only. `ocx logs` could not filter by conversation at all, and `--model`
was accepted and silently ignored — worse than an error, because the output looks filtered and
yields a wrong conclusion from correct-looking data.

| Verb / behavior | Route |
|---|---|
| `ocx account pause\|resume <provider> <id>` | `PUT /api/codex-auth/accounts/pause` |
| `ocx account pause-exhausted <provider>` | `PUT /api/codex-auth/accounts/pause-exhausted` |
| `ocx account strategy <provider> [<name>]` | codex **and** anthropic pools |
| `ocx account sticky <provider> [<n>]` | codex **and** anthropic pools |
| `ocx logs --conversation\|--conversationId <id>` | `GET /api/logs` |
| server-side `model` filter | `filterRequestLogs` |

### The two pools are not symmetric, and that is encoded rather than assumed

`/api/oauth/accounts/pool` is the same capability for the Anthropic pool and had no verb
either. One verb pair now covers both, dispatched on the provider positional these verbs
already required, rather than adding a second `provider-strategy`/`provider-sticky` pair that
would double the surface an operator must learn to express one idea.

That only works because the routes differ in four ways:

|  | Codex pool | Anthropic pool |
|---|---|---|
| read | `GET /api/codex-auth/active` | `GET /api/oauth/accounts/pool?provider=` |
| write | `PUT /api/codex-auth/pool-strategy` | `PUT /api/oauth/accounts/pool` |
| response keys | `accountPoolStrategy` / `accountPoolStickyLimit` | `strategy` / `stickyLimit` |
| write body | bare field | field **plus a mandatory `provider`** |

Omit that `provider` and the route answers 400 (`oauth-account-routes.ts:344`), so a symmetric
implementation would have failed at runtime on every Anthropic write while passing every Codex
test. `--json` output uses pool-neutral keys so a consumer need not branch on which pool
answered.

`ocx logs` also gains a capability entry. It was already a shipped command with none, and
declaring it in the phase that changed its filter contract keeps the record honest.

## Verification

```
bun test tests/cli-account-pool-verbs.test.ts tests/cli-usage-report.test.ts \
  tests/request-log.test.ts tests/cli-capabilities.test.ts tests/cli-headless-parity.test.ts \
  tests/management-route-registry.test.ts tests/request-log-conversation.test.ts \
  tests/management-api-logs-metrics.test.ts
→ 176 pass, 0 fail, 653 expect() calls

./node_modules/.bin/tsc --noEmit → clean
bun run privacy:scan            → passed
```

Live against the running proxy, exit codes included:

```
account strategy openai        → openai: pool strategy is quota        (0)
account strategy anthropic     → anthropic: pool strategy is quota     (0)
account pause openai bogus_id  → Error: Account not found              (4)
logs --limit 2                 → rows now carry conv=24f7175…
capabilities --route /api/oauth/accounts/pool → both new verbs
```

### Every new gate was driven red first

| Probe | Result |
|---|---|
| `model` clause matches top-level only, not attempts | 1 fail |
| `model` clause deleted entirely (the shipped bug) | 1 fail |
| Anthropic `writeBody` drops `provider` | 1 fail |
| Anthropic routed through the codex transport | 3 fails |

The second probe is the instructive one: the positive assertion passes with **no filter at
all**, since an unfiltered result contains the expected row. Only the non-matching assertion
(`model=absent-model` → `[]`) can detect the shipped defect.

The `--model` hole also reproduced live — the proxy on :10100 runs an older build, and
`logs --model no-such-model` returned a full page of rows with exit 0. That is the
before-picture, not a regression.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Closes #2702
Closes #2704


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account controls to pause, resume, and pause quota-exhausted accounts.
  * Added commands to view and configure account strategy and sticky settings across supported providers.
  * Added conversation filtering to `ocx logs` using `--conversation` or `--conversationId`.
  * Added server-side log filtering by model, including models used during failover attempts.
  * Updated CLI help and capability listings for the new commands and filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->