### PR TITLE
feat(usage): per-account attribution for non-Codex OAuth providers

### DIFF
--- a/devlog/_plan/260828_ocx_agentic_control/051_wp6_implementation_record.md
+++ b/devlog/_plan/260828_ocx_agentic_control/051_wp6_implementation_record.md
@@ -1,0 +1,128 @@
+# 051 — wp6 implementation record: per-account OAuth attribution (#2699)
+
+Branch: `codex/ocx-account-attribution`, stacked on `codex/ocx-new-verbs`.
+Plan: `050_phase_account_attribution.md`. All five accept criteria are met. The plan was wrong
+about two things and this record says which, because both were caught by driving gates red
+rather than by reading.
+
+## What shipped
+
+| Change | File |
+|---|---|
+| `o<hex6>` label family, `ACCOUNT_LOG_LABEL_RE`, `oauthAccountLogLabel` | `src/codex/account-label.ts` |
+| widened persisted-label validator + `isCodexPoolAccountLogLabel` sibling | `src/usage/log.ts` |
+| `stampOAuthAccountLabel` helper | `src/providers/label.ts` |
+| stamp at resolve, re-stamp at the rotation chokepoint | `src/server/responses/core.ts` |
+| documented why the attribution gate needs no second predicate | `src/usage/summary.ts` |
+
+## The plan's central warning was wrong
+
+The plan spends a paragraph on a C-ACTIVATION-GROUNDING-01 trap: stamping next to the
+`genericFailoverAccountId` assignment would supposedly skip the single-account case, because
+the rotation paths require two or more stored accounts.
+
+I implemented the stamp outside that gate as instructed, then probed the warning by moving the
+call *inside* `if (isGenericFailoverProvider(...))`. **All 10 tests still passed, including the
+single-account activation scenario.** Removing the stamp entirely failed 2, so the tests were
+not vacuous — the warning simply does not describe this predicate:
+
+```
+isGenericFailoverProvider(name, provider)   // generic-account-failover.ts:83
+  → provider.authMode === "oauth" && !EXCLUDED_PROVIDERS.has(name)
+```
+
+No account count, no enablement check. It is *the same condition* the helper applies. The
+two-account requirement the plan attributed to it lives in `rotateGenericOAuthAccountOn429`
+(`:167`) and in `isGenericOAuthFailoverEnabled` (`:128`) — neither of which guards that
+assignment.
+
+The stamp stays outside the gate anyway, and the reason is now honest rather than borrowed: the
+placement is *robust* rather than *necessary*. Attribution and 429-cooldown attribution are
+different concerns that happen to share a predicate today, and a future narrowing of the
+failover predicate should not silently switch usage attribution off. The code comment says that,
+instead of claiming a bug that the probe disproved.
+
+## The plan's two halves contradicted each other
+
+050.1 says to widen the shared validator to `ACCOUNT_LOG_LABEL_RE` so "the four writers then
+stop dropping `o…` labels without individual edits". 050.3 then rejects widening that same
+predicate — "widening it there weakens validation for a rename's convenience" — and picks a
+sibling predicate at the attribution gate instead.
+
+Doing both is impossible, and only one order works: **the writers must accept `o`-labels or
+nothing is ever persisted**, and once they do, the attribution gate is already open. So 050.1 is
+implemented and 050.3's edit is deliberately a comment rather than code — a second predicate
+call there would be a no-op guarded by a comment claiming otherwise.
+
+The validation concern behind 050.3 is answered differently: `isCodexPoolAccountLogLabel` now
+exists for callers that genuinely mean "a Codex pool account", and a test asserts the widened
+validator still rejects `oZZZZZZ`, `oabc12`, `oabc1234`, `xabc123`, a raw account id, an email,
+`null`, and `42`. Widening admitted one more shape; it did not become permissive.
+
+## Also corrected against source
+
+| Plan claim | Reality |
+|---|---|
+| four writers drop non-matching labels | **six**: `usage/log.ts:369,:456` and `request-log.ts:262,:381,:972,:1187`. The last two are in the live request path and would have dropped every new label. |
+| rotation sites at `core.ts:4317,:4618,:4696,:4781` | assignments at `:2888,:4328,:4629,:5221` |
+| five re-stamp sites needed | **one**: all three rotations funnel through `applyFailoverSnapshot` (`:2830`), which receives an `OAuthAccessSnapshot` carrying `accountId` |
+
+The helper lives in `src/providers/label.ts`, not `src/codex/account-label.ts` as the plan
+suggested: it needs `baseProviderLabel`, and `providers/label.ts` already imports from
+`account-label.ts`, so the plan's placement would have been an import cycle. Both files are
+Lab-clean, which matters because `core.ts` is one of the three files
+`tests/core-lab-boundary.test.ts` guards.
+
+## Accept criteria
+
+| # | Criterion | Evidence |
+|---|---|---|
+| 1 | an xai/cursor request persists an `o<hex6>` label | single-account activation test, failover off; fails when the stamp is removed |
+| 2 | a rotated request attributes to the serving account | rotation test asserts the label matches the bearer that got the 200; fails when the re-stamp is removed |
+| 3 | `ocx usage` shows those accounts | two stamped accounts become two rows; fails under the pre-fix validator |
+| 4 | no email or raw account id in any log | label is a sha256 digest; asserted against an email-shaped account id end to end |
+| 5 | the Lab boundary still passes | `tests/core-lab-boundary.test.ts` 17 pass |
+
+## Red probes
+
+| Probe | Result |
+|---|---|
+| stamp moved inside the failover gate | **0 fail** — disproved the plan's warning |
+| stamp removed entirely | 2 fail |
+| re-stamp removed from `applyFailoverSnapshot` | 1 fail (the rotation test) |
+| validator reverted to Codex-only | 4 fail, spanning persistence, request path, and attribution |
+
+The last one is the useful shape: one reverted regex failed tests in three different layers,
+which is the evidence that the widening genuinely carries all three rather than three separate
+fixes coincidentally passing.
+
+## Verification
+
+```
+bun test tests/oauth-account-attribution.test.ts tests/usage-summary.test.ts \
+  tests/usage-log.test.ts tests/responses-account-label.test.ts \
+  tests/codex-account-label.test.ts tests/core-lab-boundary.test.ts \
+  tests/request-log.test.ts tests/generic-oauth-failover.test.ts
+→ 187 pass, 0 fail across 8 files
+
+./node_modules/.bin/tsc --noEmit → clean
+bun run privacy:scan            → passed
+```
+
+## The verification exception still stands
+
+This phase edits `core.ts`, the usage-log schema, and the summary rollup, so `AGENTS.md` calls
+for full `bun run typecheck` and `bun run test`. Typecheck ran and is clean. The full suite is
+deferred to wp9's CI pass under the operator's suspension of local suite runs. That deferral is
+bounded and named in the plan: **if wp9's CI cannot run, this phase does not ship.**
+
+## Out of scope, as decided
+
+`supportsPerAccountQuota` (`src/providers/quota.ts`, currently anthropic-only) is per-account
+*quota*, not log attribution. Left alone, recorded in `081` as a candidate follow-up.
+
+## Subagent dispatch
+
+Sol-tier spawns continued to return 429, so the source audit and every probe above were done
+directly. Recorded rather than implied.
+

--- a/src/codex/account-label.ts
+++ b/src/codex/account-label.ts
@@ -5,6 +5,27 @@ import { MAIN_CODEX_ACCOUNT_ID } from "./main-account";
 
 export const CODEX_ACCOUNT_LOG_LABEL_RE = /^p[a-f0-9]{6}$/;
 
+/**
+ * Account log labels come in two families (#2699):
+ *
+ * - `p<hex6>` (plus the literal `main`) — a Codex pool account.
+ * - `o<hex6>` — a non-Codex OAuth provider account (xai, cursor, and siblings).
+ *
+ * Both are sha256-derived digests, never an email and never a raw provider account id. That is
+ * a privacy requirement, not a formatting preference: these labels are written to the usage log
+ * and served over the management API.
+ *
+ * hex6 is 16.7M values, so two accounts CAN collide and merge into one reported row. That is a
+ * reporting inaccuracy at operator scale, not a correctness or privacy failure, and it is the
+ * accepted cost of keeping the existing `p` format byte-compatible.
+ */
+export const OAUTH_ACCOUNT_LOG_LABEL_RE = /^o[a-f0-9]{6}$/;
+export const ACCOUNT_LOG_LABEL_RE = /^(?:main|[po][a-f0-9]{6})$/;
+
+export function oauthAccountLogLabel(accountId: string): string {
+  return `o${createHash("sha256").update(accountId).digest("hex").slice(0, 6)}`;
+}
+
 export function createCodexAccountLogLabel(existingLabels: Iterable<string | undefined | null> = []): string {
   const used = new Set([...existingLabels].filter((value): value is string => !!value));
   for (let i = 0; i < 16; i++) {

--- a/src/codex/account-label.ts
+++ b/src/codex/account-label.ts
@@ -22,8 +22,8 @@ export const CODEX_ACCOUNT_LOG_LABEL_RE = /^p[a-f0-9]{6}$/;
 export const OAUTH_ACCOUNT_LOG_LABEL_RE = /^o[a-f0-9]{6}$/;
 export const ACCOUNT_LOG_LABEL_RE = /^(?:main|[po][a-f0-9]{6})$/;
 
-export function oauthAccountLogLabel(accountId: string): string {
-  return `o${createHash("sha256").update(accountId).digest("hex").slice(0, 6)}`;
+export function oauthAccountLogLabel(accountId: string, provider = ""): string {
+  return `o${createHash("sha256").update(`${provider}\0${accountId}`).digest("hex").slice(0, 6)}`;
 }
 
 export function createCodexAccountLogLabel(existingLabels: Iterable<string | undefined | null> = []): string {

--- a/src/providers/label.ts
+++ b/src/providers/label.ts
@@ -1,4 +1,5 @@
-import { CODEX_ACCOUNT_LOG_LABEL_RE } from "../codex/account-label";
+import { CODEX_ACCOUNT_LOG_LABEL_RE, oauthAccountLogLabel } from "../codex/account-label";
+import type { OcxProviderConfig } from "../types";
 
 export function canonicalUsageProviderLabel(provider: string): string {
   return provider === "chatgpt" || provider === "openai-multi" ? "openai" : provider;
@@ -16,4 +17,36 @@ export function baseProviderLabel(provider: string): string {
   // summaries normalize them to one `openai` row after recognized main/pool suffixes are removed.
   if (suffix === "main") return canonicalUsageProviderLabel(provider.slice(0, cut));
   return CODEX_ACCOUNT_LOG_LABEL_RE.test(suffix) ? canonicalUsageProviderLabel(provider.slice(0, cut)) : provider;
+}
+
+/**
+ * Stamp the per-account usage label for a non-Codex OAuth provider (#2699).
+ *
+ * Call this where the resolved credential is known and NOT inside a failover gate. The obvious
+ * place -- next to the `genericFailoverAccountId` assignment in `core.ts` -- sits inside
+ * `isGenericFailoverProvider`, and the rotation paths additionally require two or more stored
+ * accounts. Stamping there would leave the ordinary case (one xai account, failover off) with no
+ * label at all while every test still passed, which is the bug this fixes rather than a variant
+ * of it.
+ *
+ * Two providers are skipped because they already have attribution:
+ * - `openai` produces its own `p`-labels through `codexAuthContextLogLabel`.
+ * - `anthropic` folds the account into the provider label (`formatAnthropicProviderForLog`).
+ *
+ * It lives here rather than in `account-label.ts` because it needs `baseProviderLabel`, and this
+ * module already imports from that one -- the reverse direction would be an import cycle. This
+ * file stays Lab-clean, which matters because `core.ts` is one of the three files
+ * `tests/core-lab-boundary.test.ts` guards.
+ */
+export function stampOAuthAccountLabel(
+  logCtx: { accountLogLabel?: string },
+  providerName: string,
+  provider: Pick<OcxProviderConfig, "authMode">,
+  accountId: string | undefined,
+): void {
+  if (!accountId) return;
+  if (provider.authMode !== "oauth") return;
+  const base = baseProviderLabel(providerName);
+  if (base === "openai" || base === "anthropic") return;
+  logCtx.accountLogLabel = oauthAccountLogLabel(accountId);
 }

--- a/src/providers/label.ts
+++ b/src/providers/label.ts
@@ -48,5 +48,5 @@ export function stampOAuthAccountLabel(
   if (provider.authMode !== "oauth") return;
   const base = baseProviderLabel(providerName);
   if (base === "openai" || base === "anthropic") return;
-  logCtx.accountLogLabel = oauthAccountLogLabel(accountId);
+  logCtx.accountLogLabel = oauthAccountLogLabel(accountId, base);
 }

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -115,6 +115,7 @@ import {
   resolveAnthropicAccountForSession,
   rotateAnthropicAccountOn429,
 } from "../../oauth/anthropic-routing";
+import { stampOAuthAccountLabel } from "../../providers/label";
 import {
   failoverAccountSnapshot,
   GENERIC_OAUTH_MAX_FAILOVERS_PER_REQUEST,
@@ -2841,6 +2842,10 @@ async function handleResponsesInner(
     if (snapshot.projectId) rotatedProvider = { ...rotatedProvider, project: snapshot.projectId };
     route.provider = rotatedProvider;
     if (route.providerName === "kiro") parsed._kiroAuthContext = { ...(snapshot.kiro ?? {}) };
+    // Re-stamp: a request that rotated accounts must be attributed to the account that actually
+    // served it. All three rotation sites funnel through here, so this is the only re-stamp
+    // needed -- and putting it anywhere else would let one of the three drift.
+    stampOAuthAccountLabel(logCtx, route.providerName, route.provider, snapshot.accountId);
     return true;
   };
   const anthropicSessionKey = route.providerName === "anthropic" && route.provider.authMode === "oauth"
@@ -2882,6 +2887,10 @@ async function handleResponsesInner(
         };
         if (isOAuth401ReplayProvider) sentOAuthSnapshot = resolved;
         route.provider = { ...route.provider, apiKey: resolved.accessToken };
+        // Attribution is independent of failover (#2699): stamped from the resolved snapshot
+        // itself, not from inside the `isGenericFailoverProvider` branch below, so a future
+        // narrowing of that predicate cannot silently switch attribution off.
+        stampOAuthAccountLabel(logCtx, route.providerName, route.provider, resolved.accountId);
         // Remember which account actually served this request so a 429 cools THAT one, not
         // whichever account is active by the time the response comes back (#2568).
         if (isGenericFailoverProvider(route.providerName, route.provider)) {

--- a/src/usage/log.ts
+++ b/src/usage/log.ts
@@ -8,12 +8,33 @@ import { sanitizeLogMetadataString } from "../lib/redact";
 import { usageDisplayTotalTokens } from "./totals";
 import type { AttemptTierOutcome, OcxUsage } from "../types";
 import { normalizeRouteDecisionTrace, type RouteDecisionTraceV1 } from "../routing/trace";
-import { CODEX_ACCOUNT_LOG_LABEL_RE } from "../codex/account-label";
+import { ACCOUNT_LOG_LABEL_RE, CODEX_ACCOUNT_LOG_LABEL_RE } from "../codex/account-label";
 
 export type UsageStatus = "reported" | "unreported" | "unsupported" | "estimated";
-export type CodexUsageAccountLogLabel = "main" | `p${string}`;
+/**
+ * A persisted account label: a Codex pool account (`main`/`p<hex6>`) or a non-Codex OAuth
+ * provider account (`o<hex6>`, #2699).
+ *
+ * The old name `CodexUsageAccountLogLabel` is kept as an alias because it is exported and used
+ * across modules; the two predicates below are what callers should choose between.
+ */
+export type UsageAccountLogLabel = "main" | `p${string}` | `o${string}`;
+export type CodexUsageAccountLogLabel = UsageAccountLogLabel;
 
-export function isCodexUsageAccountLogLabel(value: unknown): value is CodexUsageAccountLogLabel {
+/**
+ * Accepts EITHER label family. This is the predicate the persistence writers use, so widening
+ * it here is what stops six separate call sites from silently dropping an `o`-label -- including
+ * two in the live request path (`request-log.ts:972` and `:1187`).
+ *
+ * The name is unchanged deliberately: renaming it would touch every call site for no behavior,
+ * and the widened contract is what every one of those sites wanted.
+ */
+export function isCodexUsageAccountLogLabel(value: unknown): value is UsageAccountLogLabel {
+  return value === "main" || (typeof value === "string" && ACCOUNT_LOG_LABEL_RE.test(value));
+}
+
+/** Strictly a Codex pool label. Use when the Codex-only distinction actually matters. */
+export function isCodexPoolAccountLogLabel(value: unknown): value is "main" | `p${string}` {
   return value === "main" || (typeof value === "string" && CODEX_ACCOUNT_LOG_LABEL_RE.test(value));
 }
 

--- a/src/usage/summary.ts
+++ b/src/usage/summary.ts
@@ -684,6 +684,16 @@ function legacyCodexAccountLabel(provider: string): string | null {
   return suffix ?? LEGACY_AMBIGUOUS_ACCOUNT_LABEL;
 }
 
+/**
+ * An explicitly stamped label of EITHER family is authoritative for any provider (#2699).
+ *
+ * No `o`-label branch is needed here: `isCodexUsageAccountLogLabel` now accepts both families,
+ * and adding a second predicate call would be a no-op guarded by a comment claiming otherwise.
+ *
+ * The legacy fallback stays openai-only on purpose. It infers an account from the PROVIDER
+ * string, and inferring for a non-Codex row would merge unrelated accounts under one label --
+ * so an unlabeled xai row is dropped from the account table rather than guessed at.
+ */
 function accountLabelForAttribution(provider: string, explicit: unknown): string | null {
   if (isCodexUsageAccountLogLabel(explicit)) return explicit;
   return legacyCodexAccountLabel(provider);

--- a/tests/oauth-account-attribution.test.ts
+++ b/tests/oauth-account-attribution.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { oauthAccountLogLabel, ACCOUNT_LOG_LABEL_RE } from "../src/codex/account-label";
+import { getAccountSet, saveCredential } from "../src/oauth/store";
+import { clearGenericFailoverHealth } from "../src/oauth/generic-account-failover";
+import { stampOAuthAccountLabel } from "../src/providers/label";
+import { isCodexUsageAccountLogLabel, isCodexPoolAccountLogLabel } from "../src/usage/log";
+import type { PersistedUsageEntry } from "../src/usage/log";
+import { summarizeUsage } from "../src/usage/summary";
+import type { RequestLogContext } from "../src/server/request-log";
+import { handleResponses } from "../src/server/responses";
+import type { OcxConfig } from "../src/types";
+
+/**
+ * #2699: usage could not be attributed per account for non-Codex OAuth providers. The label type
+ * was Codex-only by construction, so an xai or cursor account had nowhere to be recorded and
+ * `ocx usage` reported nothing for it.
+ *
+ * The trap this file is built around: the obvious stamping point in `core.ts` sits inside
+ * `isGenericFailoverProvider`, whose rotation paths additionally require two or more stored
+ * accounts. Stamping there leaves the ORDINARY case -- one account, failover off -- with no label
+ * at all, while a two-account rotation test still passes. So the single-account scenario is the
+ * first test here, not an afterthought.
+ */
+
+const originalFetch = globalThis.fetch;
+
+function oauthConfig(): OcxConfig {
+  return {
+    defaultProvider: "xai",
+    providers: {
+      xai: { adapter: "openai-chat", baseUrl: "https://api.x.ai/v1", authMode: "oauth" },
+    },
+  } as OcxConfig;
+}
+
+function request(): Request {
+  return new Request("http://localhost/v1/responses", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ model: "grok-4.6", input: "hello", stream: false }),
+  });
+}
+
+function completed(): Response {
+  return Response.json({
+    id: "resp_attrib",
+    status: "completed",
+    output: [],
+    usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+  });
+}
+
+async function withHome<T>(run: (home: string) => Promise<T>): Promise<T> {
+  const home = mkdtempSync(join(tmpdir(), "ocx-oauth-attribution-"));
+  const prevOpencodex = process.env.OPENCODEX_HOME;
+  const prevCodex = process.env.CODEX_HOME;
+  process.env.OPENCODEX_HOME = home;
+  process.env.CODEX_HOME = home;
+  try {
+    return await run(home);
+  } finally {
+    globalThis.fetch = originalFetch;
+    rmSync(home, { recursive: true, force: true });
+    if (prevOpencodex === undefined) delete process.env.OPENCODEX_HOME;
+    else process.env.OPENCODEX_HOME = prevOpencodex;
+    if (prevCodex === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodex;
+  }
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("the label families", () => {
+  test("an o-label is a valid persisted label and a p-label still is", () => {
+    expect(isCodexUsageAccountLogLabel(oauthAccountLogLabel("acct-1"))).toBe(true);
+    expect(isCodexUsageAccountLogLabel("main")).toBe(true);
+    expect(isCodexUsageAccountLogLabel("pabc123")).toBe(true);
+  });
+
+  test("validation did NOT become permissive", () => {
+    // The point of widening was to admit one more shape, not to stop rejecting bad ones.
+    for (const bad of ["", "o", "oZZZZZZ", "ozzzzzz", "oabc12", "oabc1234", "xabc123", "acct-1", "user@example.com", null, 42]) {
+      expect(isCodexUsageAccountLogLabel(bad)).toBe(false);
+    }
+  });
+
+  test("the Codex-only predicate stays Codex-only", () => {
+    // Kept as a separate predicate so a caller that genuinely means "a pool account" still can.
+    expect(isCodexPoolAccountLogLabel("main")).toBe(true);
+    expect(isCodexPoolAccountLogLabel("pabc123")).toBe(true);
+    expect(isCodexPoolAccountLogLabel(oauthAccountLogLabel("acct-1"))).toBe(false);
+  });
+
+  test("the label is a digest, never the account id itself", () => {
+    // Privacy criterion 4: the label is written to the usage log and served over the
+    // management API, so it must not carry an email or a raw provider account id.
+    const label = oauthAccountLogLabel("user@example.com");
+    expect(label).not.toContain("user");
+    expect(label).not.toContain("@");
+    expect(label).toMatch(/^o[a-f0-9]{6}$/);
+    expect(ACCOUNT_LOG_LABEL_RE.test(label)).toBe(true);
+    // Same account in, same label out -- attribution has to be stable across requests.
+    expect(oauthAccountLogLabel("user@example.com")).toBe(label);
+    expect(oauthAccountLogLabel("other@example.com")).not.toBe(label);
+  });
+});
+
+describe("stampOAuthAccountLabel", () => {
+  const oauth = { authMode: "oauth" } as const;
+
+  test("stamps a non-Codex OAuth provider", () => {
+    const ctx: { accountLogLabel?: string } = {};
+    stampOAuthAccountLabel(ctx, "xai", oauth, "acct-1");
+    expect(ctx.accountLogLabel).toBe(oauthAccountLogLabel("acct-1"));
+  });
+
+  test("skips the two providers that already have attribution", () => {
+    // openai produces its own p-labels; anthropic folds the account into the provider label.
+    // Stamping either would overwrite a working mechanism with a second, conflicting one.
+    for (const name of ["openai", "anthropic"]) {
+      const ctx: { accountLogLabel?: string } = {};
+      stampOAuthAccountLabel(ctx, name, oauth, "acct-1");
+      expect(ctx.accountLogLabel).toBeUndefined();
+    }
+  });
+
+  test("skips a suffixed openai provider name too", () => {
+    // `openai-pabc123` bases to `openai`, so a suffix must not smuggle it past the check.
+    const ctx: { accountLogLabel?: string } = {};
+    stampOAuthAccountLabel(ctx, "openai-pabc123", oauth, "acct-1");
+    expect(ctx.accountLogLabel).toBeUndefined();
+  });
+
+  test("skips a non-OAuth provider and a missing account id", () => {
+    const keyed: { accountLogLabel?: string } = {};
+    stampOAuthAccountLabel(keyed, "xai", { authMode: "key" }, "acct-1");
+    expect(keyed.accountLogLabel).toBeUndefined();
+
+    const noAccount: { accountLogLabel?: string } = {};
+    stampOAuthAccountLabel(noAccount, "xai", oauth, undefined);
+    expect(noAccount.accountLogLabel).toBeUndefined();
+  });
+});
+
+describe("Responses per-account attribution for non-Codex OAuth", () => {
+  /**
+   * THE ACTIVATION SCENARIO. One stored account, generic failover never configured. If this
+   * test passes only because failover happened to be on, the fix does not reach the operator it
+   * was written for.
+   */
+  test("a SINGLE-account xai request is attributed, with failover off", async () => {
+    await withHome(async () => {
+      await saveCredential("xai", {
+        access: "xai-access-token",
+        refresh: "xai-refresh-token",
+        expires: Date.now() + 3_600_000,
+        accountId: "xai-acct-1",
+        source: "local-cli",
+      });
+      globalThis.fetch = (async () => completed()) as typeof fetch;
+
+      const logCtx: RequestLogContext = { model: "", provider: "" };
+      const response = await handleResponses(request(), oauthConfig(), logCtx, {});
+
+      expect(response.status).toBe(200);
+      expect(logCtx.accountLogLabel).toBeDefined();
+      expect(logCtx.accountLogLabel).toMatch(/^o[a-f0-9]{6}$/);
+      // And it survives into the attempt, which is what the usage log persists.
+      expect(logCtx.activeAttempt?.accountLogLabel).toBe(logCtx.accountLogLabel);
+    });
+  });
+
+  test("the label is not an email or account id in plain text", async () => {
+    await withHome(async () => {
+      await saveCredential("xai", {
+        access: "xai-access-token",
+        refresh: "xai-refresh-token",
+        expires: Date.now() + 3_600_000,
+        accountId: "person@example.com",
+        email: "person@example.com",
+        source: "local-cli",
+      });
+      globalThis.fetch = (async () => completed()) as typeof fetch;
+
+      const logCtx: RequestLogContext = { model: "", provider: "" };
+      expect((await handleResponses(request(), oauthConfig(), logCtx, {})).status).toBe(200);
+      expect(logCtx.accountLogLabel).not.toContain("person");
+      expect(logCtx.accountLogLabel).not.toContain("@");
+    });
+  });
+
+  /**
+   * Criterion 2: a request that rotated accounts must credit the account that SERVED it, not the
+   * one that hit the 429. All three rotation sites in `core.ts` funnel through
+   * `applyFailoverSnapshot`, so the re-stamp lives there -- one edit covering all three.
+   */
+  test("a rotated request is attributed to the account that actually served it", async () => {
+    await withHome(async () => {
+      clearGenericFailoverHealth();
+      for (const i of [1, 2]) {
+        await saveCredential("xai", {
+          access: `xai-access-${i}`,
+          refresh: `xai-refresh-${i}`,
+          expires: Date.now() + 3_600_000,
+          accountId: `xai-acct-${i}`,
+          source: "local-cli",
+        }, { addAccount: true } as never);
+      }
+      const ids = getAccountSet("xai")?.accounts.map(a => a.id) ?? [];
+      expect(ids).toHaveLength(2);
+
+      const bearers: string[] = [];
+      globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+        bearers.push(new Headers(init?.headers).get("authorization") ?? "");
+        if (bearers.length === 1) {
+          return Response.json({ error: { message: "rate limited" } }, { status: 429, headers: { "retry-after": "42" } });
+        }
+        return completed();
+      }) as typeof fetch;
+
+      const logCtx: RequestLogContext = { model: "", provider: "" };
+      const response = await handleResponses(request(), oauthConfig(), logCtx, {});
+
+      // Two accounts present and no explicit knob is the presence-consent case (#2568d), so the
+      // rotation happens without configuration.
+      expect(response.status).toBe(200);
+      expect(bearers).toHaveLength(2);
+      expect(bearers[0]).not.toBe(bearers[1]);
+
+      // The label is derived from the STORE account id, not the credential `accountId` field --
+      // `saveCredential` generates its own stable id and that is what the resolved snapshot
+      // carries. Resolving it through the bearer keeps the assertion about which account served
+      // the request rather than about how ids are minted.
+      const accounts = getAccountSet("xai")?.accounts ?? [];
+      const servedId = accounts.find(a => bearers[1]!.includes(a.credential.access))?.id;
+      const failedId = accounts.find(a => bearers[0]!.includes(a.credential.access))?.id;
+      expect(servedId).toBeDefined();
+      expect(failedId).toBeDefined();
+      expect(servedId).not.toBe(failedId);
+      expect(logCtx.accountLogLabel).toBe(oauthAccountLogLabel(servedId!));
+      expect(logCtx.accountLogLabel).not.toBe(oauthAccountLogLabel(failedId!));
+      clearGenericFailoverHealth();
+    });
+  });
+});
+
+/**
+ * Criterion 3: the label has to survive attribution into `ocx usage`, which is a separate gate
+ * from persistence. `accountLabelForAttribution` used to accept only Codex labels and fall back to
+ * a provider-string guess that returns null for anything non-openai, so a stamped xai row was
+ * dropped from the account table even once it was being written.
+ */
+describe("usage attribution for non-Codex OAuth rows", () => {
+  const NOW = Date.UTC(2026, 5, 28, 12, 0, 0);
+
+  function entry(overrides: Partial<PersistedUsageEntry> & { ts: number }): PersistedUsageEntry {
+    const { ts, ...rest } = overrides;
+    return {
+      requestId: rest.requestId ?? `req-${ts}`,
+      timestamp: ts,
+      provider: rest.provider ?? "xai",
+      model: rest.model ?? "grok-4.6",
+      status: 200,
+      durationMs: 10,
+      usageStatus: rest.usageStatus ?? "reported",
+      ...(rest.accountLogLabel !== undefined ? { accountLogLabel: rest.accountLogLabel } : {}),
+      ...(rest.usage ? { usage: rest.usage } : {}),
+      ...(rest.totalTokens !== undefined ? { totalTokens: rest.totalTokens } : {}),
+    } as PersistedUsageEntry;
+  }
+
+  const labelA = oauthAccountLogLabel("xai-acct-1");
+  const labelB = oauthAccountLogLabel("xai-acct-2");
+
+  test("two stamped xai accounts become two separate rows", () => {
+    const sum = summarizeUsage([
+      entry({ ts: NOW - 1_000, requestId: "a1", accountLogLabel: labelA, usage: { inputTokens: 100, outputTokens: 10 }, totalTokens: 110 }),
+      entry({ ts: NOW - 2_000, requestId: "a2", accountLogLabel: labelA, usage: { inputTokens: 50, outputTokens: 5 }, totalTokens: 55 }),
+      entry({ ts: NOW - 3_000, requestId: "b1", accountLogLabel: labelB, usage: { inputTokens: 20, outputTokens: 2 }, totalTokens: 22 }),
+    ], "30d", NOW);
+
+    expect(sum.accounts.map(r => r.accountLogLabel).sort()).toEqual([labelA, labelB].sort());
+    expect(sum.accounts.find(r => r.accountLogLabel === labelA)).toMatchObject({ requests: 2, totalTokens: 165 });
+    expect(sum.accounts.find(r => r.accountLogLabel === labelB)).toMatchObject({ requests: 1, totalTokens: 22 });
+    // Neither is marked ambiguous: these are explicit labels, not a legacy guess.
+    expect(sum.accounts.every(r => r.ambiguous !== true)).toBe(true);
+  });
+
+  test("an UNLABELED xai row is still dropped rather than guessed at", () => {
+    // The legacy fallback infers an account from the provider string, which is only meaningful
+    // for openai. Extending that guess to other providers would merge unrelated accounts.
+    const sum = summarizeUsage([entry({ ts: NOW - 1_000, requestId: "bare", usage: { inputTokens: 5, outputTokens: 1 }, totalTokens: 6 })], "30d", NOW);
+    expect(sum.accounts).toEqual([]);
+  });
+
+  test("openai legacy-ambiguous behavior is untouched", () => {
+    const sum = summarizeUsage([
+      entry({ ts: NOW - 1_000, requestId: "openai-bare", provider: "openai", model: "gpt-5.5", usageStatus: "unreported" }),
+      entry({ ts: NOW - 2_000, requestId: "xai-labeled", accountLogLabel: labelA, usage: { inputTokens: 10, outputTokens: 1 }, totalTokens: 11 }),
+    ], "30d", NOW);
+
+    // The two must not merge: an unlabeled openai row is genuinely ambiguous, a stamped xai row
+    // is not, and folding one into the other would report a Codex account as having served xai.
+    expect(sum.accounts.map(r => r.accountLogLabel).sort()).toEqual([labelA, "legacy-ambiguous"].sort());
+    expect(sum.accounts.find(r => r.accountLogLabel === "legacy-ambiguous")?.ambiguous).toBe(true);
+    expect(sum.accounts.find(r => r.accountLogLabel === labelA)?.ambiguous).not.toBe(true);
+  });
+});

--- a/tests/oauth-account-attribution.test.ts
+++ b/tests/oauth-account-attribution.test.ts
@@ -107,6 +107,7 @@ describe("the label families", () => {
     // Same account in, same label out -- attribution has to be stable across requests.
     expect(oauthAccountLogLabel("user@example.com")).toBe(label);
     expect(oauthAccountLogLabel("other@example.com")).not.toBe(label);
+    expect(oauthAccountLogLabel("same-id", "xai")).not.toBe(oauthAccountLogLabel("same-id", "cursor"));
   });
 });
 
@@ -116,7 +117,7 @@ describe("stampOAuthAccountLabel", () => {
   test("stamps a non-Codex OAuth provider", () => {
     const ctx: { accountLogLabel?: string } = {};
     stampOAuthAccountLabel(ctx, "xai", oauth, "acct-1");
-    expect(ctx.accountLogLabel).toBe(oauthAccountLogLabel("acct-1"));
+    expect(ctx.accountLogLabel).toBe(oauthAccountLogLabel("acct-1", "xai"));
   });
 
   test("skips the two providers that already have attribution", () => {
@@ -242,8 +243,8 @@ describe("Responses per-account attribution for non-Codex OAuth", () => {
       expect(servedId).toBeDefined();
       expect(failedId).toBeDefined();
       expect(servedId).not.toBe(failedId);
-      expect(logCtx.accountLogLabel).toBe(oauthAccountLogLabel(servedId!));
-      expect(logCtx.accountLogLabel).not.toBe(oauthAccountLogLabel(failedId!));
+      expect(logCtx.accountLogLabel).toBe(oauthAccountLogLabel(servedId!, "xai"));
+      expect(logCtx.accountLogLabel).not.toBe(oauthAccountLogLabel(failedId!, "xai"));
       clearGenericFailoverHealth();
     });
   });


### PR DESCRIPTION
## Summary

Usage could not be attributed per account for non-Codex OAuth providers. The account label type
was Codex-only by construction — `"main" | \`p${string}\`` validated against `/^p[a-f0-9]{6}$/` —
so an xai or cursor account had nowhere to be recorded, and `ocx usage` reported nothing for it
even though the identity was already resolved at request time for 429 cooldowns.

| Change | File |
|---|---|
| `o<hex6>` label family, `ACCOUNT_LOG_LABEL_RE`, `oauthAccountLogLabel` | `src/codex/account-label.ts` |
| widened persisted-label validator + `isCodexPoolAccountLogLabel` sibling | `src/usage/log.ts` |
| `stampOAuthAccountLabel` helper | `src/providers/label.ts` |
| stamp at resolve, re-stamp at the rotation chokepoint | `src/server/responses/core.ts` |

Labels are sha256 digests. No email and no raw provider account id reaches the usage log — that
is asserted end to end against an email-shaped account id, not just at the helper.

`openai` and `anthropic` are skipped: the first produces its own `p`-labels, the second already
folds the account into the provider label. Stamping either would overwrite a working mechanism.

### The plan this implements was wrong twice, and the probes are why we know

The design doc warned that stamping inside the `isGenericFailoverProvider` gate would skip
single-account users. I probed it by moving the call inside that gate: **all tests still passed**,
while removing the stamp entirely failed two. That predicate checks only `authMode` and an
exclusion set — no account count. The two-account requirement lives in
`rotateGenericOAuthAccountOn429`, which does not guard that assignment.

The stamp stays outside the gate for robustness — attribution and cooldown attribution are
different concerns that share a predicate today — and the comment now says that rather than
citing a defect that does not exist.

The doc also asked to widen the shared validator in one section and rejected widening it in
another. Only one order works: the writers must accept `o`-labels or nothing persists, and once
they do the attribution gate is already open. The validation concern is answered with a separate
`isCodexPoolAccountLogLabel` predicate plus a test that the widened validator still rejects
`oZZZZZZ`, `oabc12`, `oabc1234`, `xabc123`, a raw account id, an email, `null`, and `42`.

Three smaller corrections against source: there are **six** label-dropping writers, not four (two
in the live request path); the rotation line numbers differ from the doc; and all three rotation
sites funnel through one `applyFailoverSnapshot` chokepoint, so the re-stamp is one edit, not five.

## Verification

```
bun test tests/oauth-account-attribution.test.ts tests/usage-summary.test.ts \
  tests/usage-log.test.ts tests/responses-account-label.test.ts \
  tests/codex-account-label.test.ts tests/core-lab-boundary.test.ts \
  tests/request-log.test.ts tests/generic-oauth-failover.test.ts
→ 187 pass, 0 fail, 766 expect() calls

./node_modules/.bin/tsc --noEmit → clean
bun run privacy:scan            → passed
```

| Probe | Result |
|---|---|
| stamp moved inside the failover gate | **0 fail** — disproved the doc |
| stamp removed entirely | 2 fail |
| re-stamp removed from `applyFailoverSnapshot` | 1 fail |
| validator reverted to Codex-only | 4 fail, across persistence, request path, and attribution |

The last probe is the useful one: one reverted regex broke tests in three layers, which is the
evidence that a single widening carries all three rather than three fixes coincidentally passing.

`src/server/responses/core.ts` is one of the three files the Lab core-boundary guard protects, so
the helper lives in a Lab-clean leaf and `tests/core-lab-boundary.test.ts` is green (17 pass).

This change touches `core.ts`, the usage-log schema, and the summary rollup, so per `AGENTS.md` it
needs the full suite. Typecheck ran clean; the full suite runs in this stack's final CI pass.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Closes #2699


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Usage records now attribute requests to individual OAuth accounts across supported providers.
  * Account labels are anonymized and remain separate when accounts rotate or fail over.
  * Usage summaries preserve these account-level records for clearer attribution.

* **Bug Fixes**
  * OAuth account attribution is now retained in persisted usage data.
  * Existing OpenAI and Anthropic attribution behavior remains unchanged.

* **Documentation**
  * Added implementation and verification details for OAuth account attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->