### PR TITLE
fix(catalog): raise Muse Spark context window to 1M on OpenCode Go

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1442,6 +1442,10 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
       // The DeepSeek vision preview id is metadata-only here: the Go roster is
       // discovered live, so it applies the moment the gateway serves the id.
       [DEEPSEEK_VISION_PREVIEW_MODEL]: 1_048_576,
+      // Muse Spark 1.2 Contributor serves a 1,048,576-token (1M) context window over
+      // /responses on Zen Go, matching its 1.1 sibling (Meta developer docs, verified 2026-08-28).
+      // Without this declaration the catalog falls back to 128k, capping real usable context.
+      "muse-spark-1.2-contributor": 1_048_576,
     },
     modelInputModalities: {
       "kimi-k3": ["text", "image"],

--- a/tests/opencode-go-muse-context.test.ts
+++ b/tests/opencode-go-muse-context.test.ts
@@ -1,0 +1,54 @@
+/**
+ * OpenCode Go Muse Spark 1.2 Contributor context window regression.
+ *
+ * Muse Spark serves a 1,048,576-token (1M) context window over /responses on Zen Go,
+ * matching its 1.1 sibling. The registry declared no modelContextWindows entry, so the
+ * catalog fell back to the 128k unknown-window default and the Codex app capped real
+ * usable context well below what the model supports. These tests lock the declaration
+ * in and prove the catalog advertises the full 1M window for Muse.
+ */
+import { describe, expect, test } from "bun:test";
+import { applyProviderConfigHints } from "../src/codex/catalog";
+import { getProviderRegistryEntry, PROVIDER_REGISTRY } from "../src/providers/registry";
+import { providerConfigSeed } from "../src/providers/derive";
+import type { OcxProviderConfig } from "../src/types";
+
+const MUSE_MODEL = "muse-spark-1.2-contributor";
+const MUSE_CONTEXT = 1_048_576;
+
+/** Seeded OpenCode Go provider config for the Muse Spark context assertions. */
+function opencodeGo(): OcxProviderConfig {
+  const entry = getProviderRegistryEntry("opencode-go");
+  if (!entry) throw new Error("missing opencode-go registry fixture");
+  return { ...providerConfigSeed(entry), apiKey: "test-key" };
+}
+
+describe("OpenCode Go Muse Spark context window", () => {
+  test("registry declares the 1M context window for Muse", () => {
+    const entry = PROVIDER_REGISTRY.find(e => e.id === "opencode-go");
+    expect(entry?.modelContextWindows?.[MUSE_MODEL]).toBe(MUSE_CONTEXT);
+  });
+
+  test("the registry seed carries the 1M context window for Muse", () => {
+    const prov = opencodeGo();
+    expect(prov.modelContextWindows?.[MUSE_MODEL]).toBe(MUSE_CONTEXT);
+  });
+
+  test("applyProviderConfigHints exposes the 1M context window for Muse", () => {
+    const prov = opencodeGo();
+    const hinted = applyProviderConfigHints("opencode-go", prov, {
+      id: MUSE_MODEL,
+      provider: "opencode-go",
+    });
+    expect(hinted.contextWindow).toBe(MUSE_CONTEXT);
+  });
+
+  test("a discovered row with no window inherits the configured 1M window", () => {
+    const prov = opencodeGo();
+    const hinted = applyProviderConfigHints("opencode-go", prov, {
+      id: MUSE_MODEL,
+      provider: "opencode-go",
+    });
+    expect(hinted.contextWindow).toBe(MUSE_CONTEXT);
+  });
+});


### PR DESCRIPTION
## Summary

Muse Spark 1.2 Contributor on OpenCode Go (Zen) serves a **1,048,576-token (1M)** context window, matching its 1.1 sibling. The registry declared no `modelContextWindows` entry for it, so the catalog fell back to the 128k unknown-window default (`resolveUnknownRoutedContextWindow`). The Codex app then applied its 95% usable-context safeguard, showing only ~122k — far below what the model actually supports.

This adds `muse-spark-1.2-contributor` to `opencode-go`'s `modelContextWindows` as `1_048_576`, mirroring the existing 1M treatment of `kimi-k3` and the DeepSeek vision preview on the same provider.

Only the context window is changed. It does not touch wire routing, modalities, reasoning efforts, or credentials.

## Verification

```
bun x tsc --noEmit                                 exit 0
bun test tests/opencode-go-muse-context.test.ts    4 pass / 0 fail
bun test tests/opencode-go-muse-context.test.ts \
         tests/opencode-go-muse-vision.test.ts \
         tests/opencode-go-luna-wire.test.ts \
         tests/catalog-vision-sidecar-modalities.test.ts \
         tests/provider-registry-parity.test.ts      65 pass / 0 fail
```

## Checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the available context window for the `muse-spark-1.2-contributor` model to 1M tokens.
  - Ensured the correct context limit is consistently shown for configured and discovered model entries.

- **Tests**
  - Added coverage to verify the model’s 1M-token context window across provider configuration and model discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->