### PR TITLE
fix(doctor): diagnose broken Codex env_key launch path

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -24,7 +24,9 @@ import { probeNativeProfileRecoveryState, resolveNativeProfileContext } from "..
 import { NativeProfileError } from "../codex/native-profile-types";
 import { collectOrcaCodexHomeDiagnostic, resolveCodexHomeDir as resolveCodexHomeDirImpl, isWslRuntime, listWslWindowsCodexHomes, wslAutomountRoot, type CodexHomeDeps } from "../codex/home";
 import { scanCodexAgentRolesWithTomlModelFallback } from "../codex/subagent-model-fallback";
-import { findCodexOnPath, isWindowsInteropDir } from "../codex/shim";
+import { diagnoseCodexShim, findCodexOnPath, isWindowsInteropDir, type CodexShimDiagnostic } from "../codex/shim";
+import { providerTableString, rootTomlString } from "../codex/injected-marker";
+import { serviceApiTokenFilePath } from "../lib/service-secrets";
 import { countPendingOpencodexHistory } from "../codex/history-provider";
 import {
   inspectCodexCoordinator,
@@ -383,6 +385,32 @@ export function collectProviderApiKeyDiagnostics(
     });
   }
   return rows;
+}
+
+export type CodexEnvKeyReadinessDiagnostic = {
+  envName: string;
+  shimState: "missing" | "unhealthy";
+  detail: string;
+  action: string;
+};
+
+/** Warn when routed Codex cannot obtain its configured admission token at launch. */
+export function collectCodexEnvKeyReadiness(
+  configText: string | null,
+  env: EnvMap,
+  shim: CodexShimDiagnostic,
+  serviceTokenPresent: boolean,
+): CodexEnvKeyReadinessDiagnostic | null {
+  if (!configText || rootTomlString(configText, "model_provider") !== "opencodex") return null;
+  const envName = providerTableString(configText, "opencodex", "env_key")?.trim();
+  if (!envName || env[envName]?.trim() || shim.healthy || !serviceTokenPresent) return null;
+  const shimState = shim.installed ? "unhealthy" : "missing";
+  return {
+    envName,
+    shimState,
+    detail: `Codex uses env_key ${envName}, but that variable is unset and the OpenCodex shim is ${shimState}; the service token file exists but plain Codex does not load it`,
+    action: `Run 'ocx codex-shim install' to repair launch-time token injection, or export ${envName} in the process that starts Codex`,
+  };
 }
 
 export function collectConfiguredProxy(): ConfiguredProxyDiagnostic {
@@ -980,6 +1008,19 @@ export async function runDoctor(args: string[] = []): Promise<void> {
   }
 
   const doctorConfig = readConfigDiagnostics().config;
+  const codexConfigPath = join(resolveCodexHomeDirImpl(), "config.toml");
+  const codexConfigText = (() => {
+    try { return readFileSync(codexConfigPath, "utf8"); } catch { return null; }
+  })();
+  const serviceTokenPresent = (() => {
+    try { return readFileSync(serviceApiTokenFilePath(), "utf8").trim().length > 0; } catch { return false; }
+  })();
+  const codexEnvKeyReadiness = collectCodexEnvKeyReadiness(
+    codexConfigText,
+    process.env,
+    diagnoseCodexShim(),
+    serviceTokenPresent,
+  );
   const startup = collectStartupHealth(doctorConfig);
   console.log("\nCodex restart safety");
   console.log(`  ${startup.rebootSafe ? "ok " : "!! "} ${startupHealthSummary(startup)}`);
@@ -1042,6 +1083,14 @@ export async function runDoctor(args: string[] = []): Promise<void> {
     for (const row of providerApiKeys) {
       console.log(`  !!     ${row.detail}`);
     }
+  }
+
+  console.log("\nCodex env_key launch readiness");
+  if (codexEnvKeyReadiness) {
+    console.log(`  !!     ${codexEnvKeyReadiness.detail}`);
+    console.log(`         Action: ${codexEnvKeyReadiness.action}`);
+  } else {
+    console.log("  ok     no broken OpenCodex env_key launch path detected");
   }
 
   console.log("\nRunning proxy process proxy env (presence only)");
@@ -1175,6 +1224,7 @@ export async function runDoctor(args: string[] = []): Promise<void> {
   for (const row of providerApiKeys) {
     hints.push(`${row.detail}. Set ${row.envName} in the shell that starts the proxy, or store a literal key in config (value hidden here).`);
   }
+  if (codexEnvKeyReadiness) hints.push(`${codexEnvKeyReadiness.detail}. ${codexEnvKeyReadiness.action}.`);
   const anyDrvfs = paths.some(p => detectFsType(p.path, mounts).isDrvfs || detectFsType(p.path, mounts).isMntDrive);
   const noProxy = currentProxyEnv.every(p => !p.present) && !configuredProxy.present;
   if (!startup.rebootSafe) {

--- a/tests/doctor-codex-envkey-readiness.test.ts
+++ b/tests/doctor-codex-envkey-readiness.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { collectCodexEnvKeyReadiness } from "../src/cli/doctor";
+import type { CodexShimDiagnostic } from "../src/codex/shim";
+
+const config = `
+model_provider = "opencodex"
+
+[model_providers.opencodex]
+base_url = "http://127.0.0.1:10100/v1"
+env_key = "OPENCODEX_API_AUTH_TOKEN"
+`;
+
+const missingShim: CodexShimDiagnostic = {
+  installed: false,
+  healthy: false,
+  summary: "Codex autostart shim is not installed.",
+};
+
+const healthyShim: CodexShimDiagnostic = {
+  installed: true,
+  healthy: true,
+  summary: "healthy",
+};
+
+describe("doctor Codex env_key launch readiness", () => {
+  test("warns when env_key is unset, the shim is missing, and a service token exists", () => {
+    expect(collectCodexEnvKeyReadiness(config, {}, missingShim, true)).toEqual({
+      envName: "OPENCODEX_API_AUTH_TOKEN",
+      shimState: "missing",
+      detail: "Codex uses env_key OPENCODEX_API_AUTH_TOKEN, but that variable is unset and the OpenCodex shim is missing; the service token file exists but plain Codex does not load it",
+      action: "Run 'ocx codex-shim install' to repair launch-time token injection, or export OPENCODEX_API_AUTH_TOKEN in the process that starts Codex",
+    });
+  });
+
+  test("distinguishes an installed but unhealthy shim", () => {
+    const row = collectCodexEnvKeyReadiness(config, {}, { ...missingShim, installed: true }, true);
+    expect(row?.shimState).toBe("unhealthy");
+  });
+
+  test("does not warn when the configured environment variable is set", () => {
+    expect(collectCodexEnvKeyReadiness(config, { OPENCODEX_API_AUTH_TOKEN: "secret" }, missingShim, true)).toBeNull();
+  });
+
+  test("does not warn when the shim is healthy", () => {
+    expect(collectCodexEnvKeyReadiness(config, {}, healthyShim, true)).toBeNull();
+  });
+
+  test("does not warn when no usable service token exists", () => {
+    expect(collectCodexEnvKeyReadiness(config, {}, missingShim, false)).toBeNull();
+  });
+
+  test("ignores another active provider and env_key text outside the active table", () => {
+    const other = `${config.replace('model_provider = "opencodex"', 'model_provider = "openai"')}\n# env_key = "SHOULD_NOT_MATCH"`;
+    expect(collectCodexEnvKeyReadiness(other, {}, missingShim, true)).toBeNull();
+  });
+
+  test("never includes token material in output", () => {
+    const token = "super-secret-fixture-token";
+    const row = collectCodexEnvKeyReadiness(config, {}, missingShim, Boolean(token));
+    expect(JSON.stringify(row)).not.toContain(token);
+  });
+});


### PR DESCRIPTION
## Summary

- Diagnose the launch-path gap where Codex is configured with OpenCodex `env_key`, but the variable is absent and the shim is missing or unhealthy.
- Report a secret-free repair action only when a readable, non-empty service token exists.
- Avoid warnings when the environment is already usable, another provider is active, or `env_key` appears only in unrelated/commented TOML.

This is intentionally diagnostic-only: it does not change token lifecycle, shim behavior, or process environments.

Closes #2713

## Verification

- `./node_modules/.bin/bun test tests/doctor-codex-envkey-readiness.test.ts` — 7 pass, 0 fail
- `./node_modules/.bin/bun x tsc --noEmit` — pass
- `git diff --check origin/dev...HEAD` — pass

No GUI changes.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (Not needed: behavior is covered by the doctor output and focused tests.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new `ocx doctor` diagnostic for Codex launch-time token configuration.
  - Reports when the required environment key is unset and the OpenCodex shim is missing or unhealthy.
  - Provides guidance to install or export the required configuration.

- **Bug Fixes**
  - Improved diagnostic coverage for multiple Codex setup states.
  - Ensures token values are never exposed in diagnostic output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->