### PR TITLE
fix(security): classify NAT64-embedded IPv4 instead of refusing the wrapper

### DIFF
--- a/src/lib/destination-policy.ts
+++ b/src/lib/destination-policy.ts
@@ -68,6 +68,45 @@ function classifyIpv4(hostname: string): DestinationAssessment {
   return { kind: "public", detail: "public IP" };
 }
 
+/**
+ * Expand an IPv6 literal into its eight hextets, or null when it is not one this can parse.
+ * `firstIpv6Hextet` below only needs the leading group; prefix matching needs the whole address,
+ * and `::` compression plus the RFC 4291 trailing dotted-quad form both have to be handled.
+ */
+function ipv6Hextets(hostname: string): number[] | null {
+  let text = hostname;
+  const dotted = text.match(/(\d{1,3}(?:\.\d{1,3}){3})$/);
+  if (dotted?.index !== undefined) {
+    const octets = dotted[1].split(".").map(Number);
+    if (octets.some(octet => !Number.isInteger(octet) || octet < 0 || octet > 255)) return null;
+    text = text.slice(0, dotted.index)
+      + ((octets[0]! << 8) | octets[1]!).toString(16)
+      + ":"
+      + ((octets[2]! << 8) | octets[3]!).toString(16);
+  }
+  const halves = text.split("::");
+  if (halves.length > 2) return null;
+  const parseGroups = (part: string): number[] | null => {
+    if (!part) return [];
+    const out: number[] = [];
+    for (const piece of part.split(":")) {
+      if (!/^[0-9a-f]{1,4}$/i.test(piece)) return null;
+      out.push(Number.parseInt(piece, 16));
+    }
+    return out;
+  };
+  const head = parseGroups(halves[0] ?? "");
+  const tail = halves.length === 2 ? parseGroups(halves[1] ?? "") : [];
+  if (!head || !tail) return null;
+  if (halves.length === 1) return head.length === 8 ? head : null;
+  const fill = 8 - head.length - tail.length;
+  if (fill < 1) return null;
+  return [...head, ...Array<number>(fill).fill(0), ...tail];
+}
+
+/** RFC 6052 §2.1 well-known NAT64 prefix, 64:ff9b::/96, as its six leading hextets. */
+const NAT64_WELL_KNOWN_PREFIX = [0x64, 0xff9b, 0, 0, 0, 0] as const;
+
 function firstIpv6Hextet(hostname: string): number | null {
   const head = hostname.split(":")[0];
   if (!head) return 0;
@@ -88,6 +127,20 @@ function classifyIpv6(hostname: string): DestinationAssessment {
     const lo = Number.parseInt(hexMapped[2], 16);
     const ipv4 = `${(hi >> 8) & 255}.${hi & 255}.${(lo >> 8) & 255}.${lo & 255}`;
     return classifyIpv4(ipv4);
+  }
+  // NAT64 (RFC 6052): on an IPv6-only/DNS64 network every IPv4-only peer is synthesized into
+  // 64:ff9b::<ipv4>, whose leading hextet (0x64) is below the 2000::/3 global-unicast window and
+  // so fell through to "non-global address". That rejected ordinary public destinations for any
+  // user behind NAT64 — two tests already worked around it with `allowPrivateNetwork: true`.
+  // Classify the EMBEDDED IPv4 instead, exactly as the ::ffff: forms above do, so a wrapped
+  // 127.0.0.1 or 10/8 stays blocked rather than becoming an SSRF bypass. Only the well-known
+  // prefix is decoded; RFC 8215's 64:ff9b:1::/48 is reserved for local-use translation and keeps
+  // its non-global treatment.
+  const hextets = ipv6Hextets(hostname);
+  if (hextets && NAT64_WELL_KNOWN_PREFIX.every((group, index) => hextets[index] === group)) {
+    const hi = hextets[6]!;
+    const lo = hextets[7]!;
+    return classifyIpv4(`${(hi >> 8) & 255}.${hi & 255}.${(lo >> 8) & 255}.${lo & 255}`);
   }
   if (hostname === "::1") return { kind: "loopback", detail: "loopback address" };
   if (hostname === "::") return { kind: "unspecified", detail: "unspecified address" };

--- a/tests/destination-policy-resolved.test.ts
+++ b/tests/destination-policy-resolved.test.ts
@@ -253,3 +253,46 @@ describe("resolvePublicAddresses — caller-specific diagnostics", () => {
     )).rejects.toThrow("benchmark address (198.19.7.9)");
   });
 });
+
+describe("providerDestinationConfigError — NAT64 well-known prefix (RFC 6052)", () => {
+  // On an IPv6-only/DNS64 network every IPv4-only peer is synthesized into 64:ff9b::<ipv4>.
+  // 0x64 sits below the 2000::/3 global-unicast window, so the wrapper alone read as
+  // "non-global address" and rejected ordinary public destinations for anyone behind NAT64.
+  test("a wrapped public IPv4 is accepted", () => {
+    for (const host of ["64:ff9b::d25:c62c", "64:ff9b::0fe0:7748", "64:ff9b::13.37.198.44"]) {
+      expect(providerDestinationConfigError("p", provider(`https://[${host}]/v1`))).toBeNull();
+    }
+  });
+
+  // The embedded address is what gets classified, so the decode cannot become an SSRF bypass.
+  test("a wrapped private, loopback, or link-local IPv4 stays blocked", () => {
+    const cases: [string, string][] = [
+      ["64:ff9b::7f00:1", "loopback"],
+      ["64:ff9b::a00:1", "private-network"],
+      ["64:ff9b::c0a8:1", "private-network"],
+      ["64:ff9b::ac10:1", "private-network"],
+      // 169.254.169.254 is the cloud metadata IP, so the wrapped form lands on the stronger
+      // metadata blocklist rather than the generic link-local rule.
+      ["64:ff9b::a9fe:a9fe", "blocked metadata endpoint"],
+      ["64:ff9b::127.0.0.1", "loopback"],
+    ];
+    for (const [host, detail] of cases) {
+      expect(providerDestinationConfigError("p", provider(`https://[${host}]/v1`))).toContain(detail);
+    }
+  });
+
+  // RFC 8215 reserves 64:ff9b:1::/48 for local-use translation, which is not the well-known
+  // prefix and keeps its non-global treatment.
+  test("the RFC 8215 local-use prefix is not decoded", () => {
+    expect(providerDestinationConfigError("p", provider("https://[64:ff9b:1::d25:c62c]/v1")))
+      .toContain("non-global");
+  });
+
+  test("unrelated IPv6 classification is unchanged", () => {
+    expect(providerDestinationConfigError("p", provider("https://[2606:4700::6812:1250]/v1"))).toBeNull();
+    expect(providerDestinationConfigError("p", provider("https://[::1]/v1"))).toContain("loopback");
+    expect(providerDestinationConfigError("p", provider("https://[fd00::1]/v1"))).toContain("private-network");
+    expect(providerDestinationConfigError("p", provider("https://[fe80::1]/v1"))).toContain("link-local");
+    expect(providerDestinationConfigError("p", provider("https://[2001:db8::1]/v1"))).toContain("documentation");
+  });
+});


### PR DESCRIPTION
## Summary

`classifyIpv6` in `src/lib/destination-policy.ts` decodes both `::ffff:` IPv4-mapped forms and judges the **embedded** address, but had no case for NAT64. RFC 6052's well-known prefix `64:ff9b::/96` leads with hextet `0x64`, below the `2000::/3` global-unicast window, so it fell through to the closing `non-global address` branch.

## Why this is not an edge case

On any IPv6-only or DNS64 network the resolver synthesizes `64:ff9b::<ipv4>` for **every** IPv4-only peer, so ordinary public destinations were rejected outright.

The repository has been working around this rather than fixing it:

- `tests/codex-catalog.test.ts` — *"Keep it hermetic on NAT64 hosts whose resolver also returns `64:ff9b::/96` answers for api.openai.com"* → `allowPrivateNetwork: true`
- `tests/baseten-provider.test.ts` — *"Some test environments resolve public hosts through a NAT64 prefix"* → `allowPrivateNetwork: true`

And `tests/key-login-live-update.test.ts` has been **red on `dev`** for the same reason. Traced end to end:

```
commitKeyLoginProvider → notifyRunningProxy → requestBoundLocalProviderReload
  ← HTTP 409 {"error":"provider reload target rejected"}
    from providerDestinationResolvedError:
    "baseUrl hostname api.code.umans.ai resolves to a non-global address (64:ff9b::d25:c62c)"
```

The credential reached disk while the running proxy kept serving the stale in-memory row — which is exactly the regression that test was written to catch, reported as a test failure instead.

## The fix, and why it is not an SSRF bypass

The decode mirrors the existing `::ffff:` handling: extract the embedded IPv4 and run it through `classifyIpv4`. Verified per address:

| resolved address | embedded | result |
| --- | --- | --- |
| `64:ff9b::d25:c62c` | 13.37.198.44 | **allowed** |
| `64:ff9b::0fe0:7748` | 15.224.119.72 | **allowed** |
| `64:ff9b::7f00:1` | 127.0.0.1 | blocked — loopback |
| `64:ff9b::a00:1` | 10.0.0.1 | blocked — private-network |
| `64:ff9b::c0a8:1` | 192.168.0.1 | blocked — private-network |
| `64:ff9b::ac10:1` | 172.16.0.1 | blocked — private-network |
| `64:ff9b::a9fe:a9fe` | 169.254.169.254 | blocked — **metadata endpoint** (stronger than link-local) |
| `64:ff9b:1::d25:c62c` | — | blocked — RFC 8215 local-use prefix is not decoded |

Only the well-known prefix is decoded. RFC 8215 reserves `64:ff9b:1::/48` for local-use translation, so it keeps its non-global treatment.

Prefix matching needs all eight hextets rather than the leading group `firstIpv6Hextet` returns, so `ipv6Hextets` expands the literal, handling `::` compression and the RFC 4291 trailing dotted-quad form.

## Verification

- Reverting the classifier turns the four new cases **and** `key-login-live-update` red.
- `bun run test` — **15196 pass, 12 skip, 0 fail, exit 0**; all six serial lanes green. `key-login-live-update` passes, which it does not on unmodified `dev` @ `50e955604`.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.

The two `allowPrivateNetwork: true` test workarounds are left in place: they are unrelated to this classifier's contract and removing them would widen this PR beyond the fix.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IPv6 destination handling for NAT64 addresses.
  * Public destinations using the standard NAT64 prefix are now accepted correctly.
  * NAT64-wrapped private, loopback, link-local, and cloud-metadata addresses remain blocked.
  * Preserved existing handling for local-use NAT64 and other IPv6 address types.
  * Improved compatibility with IPv6 addresses using compressed notation and embedded IPv4 values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->