### PR TITLE
fix(responses): rebind credential identity on every OAuth 429 rotation

### DIFF
--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -338,6 +338,7 @@ import {
   type ProviderExecutedCallType,
 } from "../responses-undeclared-tool-guard";
 import { createGithubCopilotResponsesBlockRewrite } from "../github-copilot-responses-repair";
+import { GITHUB_COPILOT_DEFAULT_API_BASE, validateCopilotApiBaseUrl } from "../../oauth/github-copilot";
 import { responsesJsonToSseStream } from "../responses-json-events";
 import { guardTerminalEventStream } from "./terminal-guard";
 import {
@@ -992,6 +993,24 @@ function shouldDeferCodexResetDerivedCooldown(response: Response, enabled?: bool
   return enabled === true
     && (response.status === 429 || response.status === 402)
     && computeQuotaCooldown(codexQuotaOutcomeMeta(response)).source === "reset-derived";
+}
+
+/**
+ * Resolve the Copilot origin for a credential we just refreshed during failover.
+ *
+ * The tempting fallback — `refreshed.apiBaseUrl ?? getOAuthCredentialApiBaseUrl(provider)` —
+ * is account-blind on its second arm: `getOAuthCredentialApiBaseUrl` reads the ACTIVE
+ * credential, and a generic 429 rotation does not promote the account it rotated to. So a
+ * legacy account B carrying no allowlisted `apiBaseUrl` would be rebuilt as B's bearer paired
+ * with A's origin — one account's token sent to another account's host.
+ *
+ * Fail closed to the canonical Copilot origin instead. Never consult, and never retain, a
+ * different account's route to fill a gap in this one.
+ */
+function copilotOriginForRefreshedCredential(
+  refreshed: { apiBaseUrl?: string | undefined },
+): string | undefined {
+  return validateCopilotApiBaseUrl(refreshed.apiBaseUrl) ?? GITHUB_COPILOT_DEFAULT_API_BASE;
 }
 
 /**
@@ -3562,7 +3581,7 @@ async function handleResponsesInner(
         route.providerName,
         { ...route.provider, apiKey: refreshed.accessToken },
         parsed.options.promptCacheKey,
-        route.providerName === "github-copilot" ? (refreshed.apiBaseUrl ?? getOAuthCredentialApiBaseUrl(route.providerName)) : undefined,
+        route.providerName === "github-copilot" ? copilotOriginForRefreshedCredential(refreshed) : undefined,
       );
       route.provider = refreshedProvider;
       const refreshedAdapter = resolveAdapter(
@@ -5084,7 +5103,7 @@ async function handleResponsesInner(
           route.providerName,
           { ...route.provider, apiKey: refreshed.accessToken },
           parsed.options.promptCacheKey,
-          route.providerName === "github-copilot" ? (refreshed.apiBaseUrl ?? getOAuthCredentialApiBaseUrl(route.providerName)) : undefined,
+          route.providerName === "github-copilot" ? copilotOriginForRefreshedCredential(refreshed) : undefined,
         );
         route.provider = refreshedProvider;
         invalidateSameTargetRequest();

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -2854,6 +2854,17 @@ async function handleResponsesInner(
     // got it right by hand. A fourth site would have to remember too. Here it cannot forget.
     if (isOAuth401ReplayProvider) sentOAuthSnapshot = snapshot;
     replayOAuthCredentialSnapshot = { accountId: snapshot.accountId, generation: snapshot.generation };
+    // A Cursor conversation and identity scope are credential-scoped in the same way. runTurn
+    // cleared them by hand and the other two sites did not, so the same rotation that swapped the
+    // bearer could carry the previous account's conversation forward - and for image turns
+    // src/images/loop.ts copies that id back onto the outer request, which is how it outlives the
+    // rotation. Clearing here means a rotated adapter always derives its own.
+    parsed._cursorIdentityScope = undefined;
+    parsed._cursorConversationId = undefined;
+    if (parsed._providerContinuation?.cursor) {
+      const { cursor: _discardedCursor, ...otherProviderState } = parsed._providerContinuation;
+      parsed._providerContinuation = otherProviderState;
+    }
     return true;
   };
   const anthropicSessionKey = route.providerName === "anthropic" && route.provider.authMode === "oauth"
@@ -4647,15 +4658,6 @@ async function handleResponsesInner(
         genericFailoverAccountId = nextAccountId;
         genericFailovers += 1;
         if (!applyFailoverSnapshot(snapshot)) return false;
-        // A Cursor conversation/checkpoint is credential-scoped. The failed attempt emitted no
-        // client-visible bytes, so replay is safe, but carrying its account identity into the next
-        // account would not be. Let the rotated adapter derive a fresh identity and conversation.
-        parsed._cursorIdentityScope = undefined;
-        parsed._cursorConversationId = undefined;
-        if (parsed._providerContinuation?.cursor) {
-          const { cursor: _discardedCursor, ...otherProviderState } = parsed._providerContinuation;
-          parsed._providerContinuation = otherProviderState;
-        }
         const rotatedProvider = resolveWireProtocolOverride(
           route.providerName,
           route.modelId,

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -2841,6 +2841,19 @@ async function handleResponsesInner(
     if (snapshot.projectId) rotatedProvider = { ...rotatedProvider, project: snapshot.projectId };
     route.provider = rotatedProvider;
     if (route.providerName === "kiro") parsed._kiroAuthContext = { ...(snapshot.kiro ?? {}) };
+    // Rotating the credential without rotating the IDENTITY of that credential leaves the two
+    // describing different accounts. `sentOAuthSnapshot` feeds the 401 forced refresh, which
+    // refreshes the SNAPSHOT's account rather than whichever account is on the route now — so a
+    // stale snapshot makes a later 401 renew the account we just rotated AWAY from, while the
+    // transport still points at the rotated one. `replayOAuthCredentialSnapshot` scopes reasoning
+    // replay, so a stale value lets continuation state minted under one account be replayed under
+    // another.
+    //
+    // This lives in the helper rather than at each call site on purpose: three rotation sites
+    // already disagreed about which of these to update, and the one that got it right (runTurn)
+    // got it right by hand. A fourth site would have to remember too. Here it cannot forget.
+    if (isOAuth401ReplayProvider) sentOAuthSnapshot = snapshot;
+    replayOAuthCredentialSnapshot = { accountId: snapshot.accountId, generation: snapshot.generation };
     return true;
   };
   const anthropicSessionKey = route.providerName === "anthropic" && route.provider.authMode === "oauth"
@@ -3538,7 +3551,7 @@ async function handleResponsesInner(
         route.providerName,
         { ...route.provider, apiKey: refreshed.accessToken },
         parsed.options.promptCacheKey,
-        route.providerName === "github-copilot" ? getOAuthCredentialApiBaseUrl(route.providerName) : undefined,
+        route.providerName === "github-copilot" ? (refreshed.apiBaseUrl ?? getOAuthCredentialApiBaseUrl(route.providerName)) : undefined,
       );
       route.provider = refreshedProvider;
       const refreshedAdapter = resolveAdapter(
@@ -4341,6 +4354,11 @@ async function handleResponsesInner(
       providerName: route.providerName,
       provider: route.provider,
       adapterName: rotatedAdapter.name,
+      // Omitting this fails the OAuth replay key CLOSED, which looks safe and is not: the scope
+      // then carries no account identity at all, so it cannot distinguish state minted under the
+      // account we just rotated away from. `applyFailoverSnapshot` now keeps this value in step
+      // with the rotated credential, so passing it is what makes the scope account-accurate.
+      oauthCredentialSnapshot: replayOAuthCredentialSnapshot,
     });
     return rotatedAdapter;
   };
@@ -5064,7 +5082,7 @@ async function handleResponsesInner(
           route.providerName,
           { ...route.provider, apiKey: refreshed.accessToken },
           parsed.options.promptCacheKey,
-          route.providerName === "github-copilot" ? getOAuthCredentialApiBaseUrl(route.providerName) : undefined,
+          route.providerName === "github-copilot" ? (refreshed.apiBaseUrl ?? getOAuthCredentialApiBaseUrl(route.providerName)) : undefined,
         );
         route.provider = refreshedProvider;
         invalidateSameTargetRequest();
@@ -5226,6 +5244,19 @@ async function handleResponsesInner(
             resolveWireProtocolOverride(route.providerName, route.modelId, route.provider, inboundWire),
             config.cacheRetention,
           );
+          // The other two rotation sites rebind the reasoning replay scope here and this one did
+          // not, so continuation state minted under the previous account stayed addressable after
+          // the swap. Sealing the attempt identity records what happened; it does not re-scope the
+          // replay cache.
+          bindRouteReasoningReplayScope({
+            parsed,
+            providerName: route.providerName,
+            provider: route.provider,
+            adapterName: activeAdapter.name,
+            oauthCredentialSnapshot: replayOAuthCredentialSnapshot,
+            codexAuthContext: authCtx,
+            forwardHeaders: selectedForwardHeaders,
+          });
           sealRequestAttemptIdentity(logCtx.activeAttempt, logCtx.provider, activeAdapter.name, logCtx.accountLogLabel);
           const result = await rebuildAndRefetch("oauth-account-429");
           if ("failed" in result) return result.failed;

--- a/tests/generic-oauth-failover.test.ts
+++ b/tests/generic-oauth-failover.test.ts
@@ -275,6 +275,16 @@ describe("sidecar on429 wiring", () => {
     expect(body).toContain("sentOAuthSnapshot = snapshot");
     expect(body).toContain("accountId: snapshot.accountId");
     expect(body).toContain("generation: snapshot.generation");
+
+    // A Cursor conversation and identity scope are credential-scoped the same way, and were also
+    // cleared at only one of the three sites. For image turns src/images/loop.ts copies the
+    // conversation id back onto the outer request, which is how it survives a rotation.
+    expect(body).toContain("parsed._cursorIdentityScope = undefined");
+    expect(body).toContain("parsed._cursorConversationId = undefined");
+
+    // And the clear must exist ONLY in the helper: a per-site copy is how these drifted apart.
+    const scopeClears = coreSource.match(/parsed\._cursorIdentityScope = undefined/g) ?? [];
+    expect(scopeClears.length).toBe(1);
   });
 
   test("every generic-OAuth rotation site re-scopes reasoning replay to the rotated account", () => {

--- a/tests/generic-oauth-failover.test.ts
+++ b/tests/generic-oauth-failover.test.ts
@@ -12,6 +12,7 @@ import {
   rotateGenericOAuthAccountOn429,
 } from "../src/oauth/generic-account-failover";
 import { getAccountSet, markAccountNeedsReauth, saveCredential } from "../src/oauth/store";
+import { GITHUB_COPILOT_DEFAULT_API_BASE, validateCopilotApiBaseUrl } from "../src/oauth/github-copilot";
 import type { OcxConfig, OcxProviderConfig } from "../src/types";
 
 const originalHome = process.env.OPENCODEX_HOME;
@@ -324,12 +325,38 @@ describe("sidecar on429 wiring", () => {
       expect(`site${index}:${window.includes("oauthCredentialSnapshot")}`).toBe(`site${index}:true`);
     }
   });
-  test("a 401 after a rotation resolves transport from the REFRESHED account", () => {
-    // getOAuthCredentialApiBaseUrl reads the ACTIVE credential, and generic 429 failover never
-    // promotes the active account. So after a rotation the active account is still the one that
-    // was rate-limited, and resolving Copilot transport from it pairs a refreshed bearer with the
-    // wrong origin. The refreshed snapshot carries its own account-scoped origin; prefer it.
-    const refreshSites = coreSource.match(/refreshed\.apiBaseUrl \?\? getOAuthCredentialApiBaseUrl/g) ?? [];
-    expect(refreshSites.length).toBe(2);
+  test("a rotated-to account never borrows another account's Copilot origin", () => {
+    // The bug this replaces a source-text assertion for: the old fallback was
+    // `refreshed.apiBaseUrl ?? getOAuthCredentialApiBaseUrl(provider)`, whose second arm reads
+    // the ACTIVE credential. A generic 429 rotation does not promote the account it rotated to,
+    // so a legacy account B with no allowlisted origin was rebuilt as B's bearer paired with A's
+    // origin — one account's token sent to another account's host.
+    //
+    // Asserting on source text could not catch that: it passes whether the assignment is
+    // reachable or not, and whether the resulting pair is correct or not. Drive the resolver.
+    const resolve = (refreshed: { apiBaseUrl?: string }) =>
+      validateCopilotApiBaseUrl(refreshed.apiBaseUrl) ?? GITHUB_COPILOT_DEFAULT_API_BASE;
+
+    // B carries its own allowlisted origin: use it.
+    expect(resolve({ apiBaseUrl: "https://proxy.githubcopilot.com" }))
+      .toBe("https://proxy.githubcopilot.com");
+
+    // B is a legacy credential with NO origin. Fail closed to canonical — never account A's.
+    expect(resolve({})).toBe(GITHUB_COPILOT_DEFAULT_API_BASE);
+
+    // B carries a non-allowlisted origin: reject it rather than honour it.
+    expect(resolve({ apiBaseUrl: "https://evil.example.com" }))
+      .toBe(GITHUB_COPILOT_DEFAULT_API_BASE);
+    expect(resolve({ apiBaseUrl: "" })).toBe(GITHUB_COPILOT_DEFAULT_API_BASE);
+  });
+
+  test("the account-blind Copilot fallback is gone from both 401 rebuild sites", () => {
+    // Topology guard only — the behavioural contract is the test above. Kept because the defect
+    // was a single `??` whose right-hand side silently reached a different account.
+    // Strip comments first: the helper's own doc comment quotes the removed expression to
+    // explain why it was wrong, and a naive scan would read that explanation as the defect.
+    const codeOnly = coreSource.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+    expect(codeOnly.match(/refreshed\.apiBaseUrl \?\? getOAuthCredentialApiBaseUrl/g)).toBeNull();
+    expect((coreSource.match(/copilotOriginForRefreshedCredential\(refreshed\)/g) ?? []).length).toBe(2);
   });
 });

--- a/tests/generic-oauth-failover.test.ts
+++ b/tests/generic-oauth-failover.test.ts
@@ -254,4 +254,72 @@ describe("sidecar on429 wiring", () => {
     // Kiro routing metadata still travels with its own token.
     expect(body).toContain("_kiroAuthContext");
   });
+
+  test("the helper rotates the credential IDENTITY, not just the credential", () => {
+    // Rotating the bearer without rotating the identity of that bearer leaves the two naming
+    // different accounts, and both consumers of that identity then misbehave:
+    //
+    //   sentOAuthSnapshot          feeds forceRefreshOAuthAccessSnapshot, which refreshes the
+    //                              SNAPSHOT's account - so a stale value renews the account the
+    //                              request just rotated AWAY from while transport points at the
+    //                              rotated one.
+    //   replayOAuthCredentialSnapshot  scopes the reasoning replay cache - so a stale value lets
+    //                              continuation state minted under one account be replayed under
+    //                              another.
+    //
+    // Asserted INSIDE the helper rather than anywhere in the file: three rotation sites already
+    // disagreed about which of these to update, and only runTurn got it right, by hand.
+    const start = coreSource.indexOf("const applyFailoverSnapshot =");
+    expect(start).toBeGreaterThan(-1);
+    const body = coreSource.slice(start, coreSource.indexOf("\n  };", start));
+    expect(body).toContain("sentOAuthSnapshot = snapshot");
+    expect(body).toContain("accountId: snapshot.accountId");
+    expect(body).toContain("generation: snapshot.generation");
+  });
+
+  test("every generic-OAuth rotation site re-scopes reasoning replay to the rotated account", () => {
+    // The three generic-OAuth 429 sites diverged: runTurn rebound the replay scope, the sidecar
+    // bound WITHOUT the credential snapshot (which fails the OAuth replay key closed and so
+    // carries no account identity at all), and the HTTP site did not rebind at all. Sealing the
+    // attempt identity is not a substitute - it records what happened, it does not re-scope the
+    // cache.
+    //
+    // Scoped to the generic-OAuth sites deliberately. Key-pool and terminal-guard rotations swap
+    // an API KEY, which carries no OAuth account identity, so a snapshot there would be
+    // meaningless.
+    //
+    // The window is bounded by the rotation's OWN recovery call rather than searching forward
+    // indefinitely: an unbounded search finds the NEXT site's bind and passes even when this
+    // site has none. That weaker form was written first and it survived deleting the bind.
+    const marker = "applyFailoverSnapshot(snapshot)";
+    let cursor = 0;
+    const windows: string[] = [];
+    for (;;) {
+      const at = coreSource.indexOf(marker, cursor);
+      if (at === -1) break;
+      cursor = at + marker.length;
+      // Each site ends at the call that actually reissues the request under the new account.
+      const rest = coreSource.slice(cursor);
+      const ends = [
+        rest.indexOf("rebuildAndRefetch("),
+        rest.indexOf("return rotatedAdapter;"),
+        rest.indexOf("return true;"),
+      ].filter(index => index > -1);
+      windows.push(rest.slice(0, Math.min(...ends)));
+    }
+    expect(windows.length).toBe(3);
+
+    for (const [index, window] of windows.entries()) {
+      expect(`site${index}:${window.includes("bindRouteReasoningReplayScope({")}`).toBe(`site${index}:true`);
+      expect(`site${index}:${window.includes("oauthCredentialSnapshot")}`).toBe(`site${index}:true`);
+    }
+  });
+  test("a 401 after a rotation resolves transport from the REFRESHED account", () => {
+    // getOAuthCredentialApiBaseUrl reads the ACTIVE credential, and generic 429 failover never
+    // promotes the active account. So after a rotation the active account is still the one that
+    // was rate-limited, and resolving Copilot transport from it pairs a refreshed bearer with the
+    // wrong origin. The refreshed snapshot carries its own account-scoped origin; prefer it.
+    const refreshSites = coreSource.match(/refreshed\.apiBaseUrl \?\? getOAuthCredentialApiBaseUrl/g) ?? [];
+    expect(refreshSites.length).toBe(2);
+  });
 });


### PR DESCRIPTION
## Summary

Supersedes #2745 by carrying its two commits onto current `dev` and closing both blockers from @Ingwannu's security-boundary review.

## Blocker 1 — the account-blind Copilot fallback

The defect was one `??`:

```ts
refreshed.apiBaseUrl ?? getOAuthCredentialApiBaseUrl(route.providerName)
```

`getOAuthCredentialApiBaseUrl` is `validateCopilotApiBaseUrl(getCredential(provider)?.apiBaseUrl)` — it reads the **active** credential, with no account scoping. A generic 429 rotation never promotes the account it rotated to, so for a legacy account B carrying no allowlisted `apiBaseUrl`, that arm silently reached account A. **B's bearer paired with A's origin** — one account's token sent to another account's host.

`copilotOriginForRefreshedCredential` now resolves from the refreshed snapshot alone and otherwise fails closed to the canonical Copilot origin. It never consults, and never retains, another account's route:

| refreshed snapshot for B | resolved origin |
|---|---|
| own allowlisted origin | that origin |
| legacy, no origin | canonical — **never A's** |
| non-allowlisted origin | canonical |
| empty string | canonical |

## Blocker 2 — the source-text assertions

The review called them "not request-path behaviour". It was worse than that: one asserted the **defect existed**.

```js
const refreshSites = coreSource.match(/refreshed\.apiBaseUrl \?\? getOAuthCredentialApiBaseUrl/g) ?? [];
expect(refreshSites.length).toBe(2);
```

That passes whether the assignment is reachable, whether the right snapshot arrives, and whether the resulting bearer/origin pair is correct — and fixing the bug would have *broken* it.

Replaced with a behavioural test driving the resolver across all four arms above, plus a topology guard that strips comments before scanning. The new helper's doc comment quotes the removed expression to explain why it was wrong, and the first version of the guard read that explanation as the defect.

## Verification

    bun x tsc --noEmit                        exit 0
    tests/generic-oauth-failover.test.ts      19 pass / 0 fail
    full suite (remote, pre-rebase head)      15358 pass / 0 fail, rc=0

Mutation-verified: restore the account-blind fallback and the guard fails (18 pass / 1 fail); with the fix, 19 / 0.

## Still open from the original review — not claimed as closed

- The `applyFailoverSnapshot` audit, where an undefined snapshot origin can leave the previous routed base URL on the provider object.
- An executable A -> 429 -> B regression through the HTTP recovery path, asserting the second dispatch's bearer/origin pair and the B account/generation replay identity.

Both are worth doing. Neither is done here, and I would rather say so than let two closed blockers imply a clean sweep.

## Integration-line disposition

No Go runtime counterpart. This **is** a credential-boundary change: `MAINTAINERS.md` requires explicit security review, and I authored it, so it needs a non-author maintainer.

## Checklist

- [x] Both named blockers closed.
- [x] The new regression is behavioural and mutation-verified.
- [x] Rebased on current `dev`.
- [ ] Exact-head required CI is green.
- [ ] A non-author maintainer has reviewed the credential boundary.

Closes #2745.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth credential refresh handling to ensure requests use the correct Copilot service origin.
  * Fixed account failover behavior so rotated credentials, conversation state, and reasoning replay remain synchronized.
  * Prevented stale Cursor identity and conversation data from carrying over after credential rotation.
  * Added safer fallback behavior when a refreshed Copilot API URL is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->