### PR TITLE
docs(devlog): close the cursor merge-train round log

### DIFF
--- a/devlog/_plan/260828_cursor_ndjson_backlog_train/050_merge_train.md
+++ b/devlog/_plan/260828_cursor_ndjson_backlog_train/050_merge_train.md
@@ -48,3 +48,14 @@ instruction is the maintainer approval for these session-authored PRs.
   (R1 lesson applied) — but the parent squash still made the old chain
   CONFLICTING; wire branch cherry-picked onto dev (874f59734, 116 tests +
   tsc green) and force-pushed; #2802 stayed OPEN base=dev.
+- R5 (#2802): fresh CI on the rebased head fully green (0F, macos SUCCESS).
+  MERGED squash fbb5b0216, branch deleted.
+
+## Train outcome: DONE
+
+All five cursor PRs landed on dev: #2774 5511a424c -> #2803 922d53424
+(successor of #2795) -> #2769 1e46430e3 -> #2801 7232a60a7 (with causal
+flake fix 22c073e03) -> #2802 fbb5b0216. No open cursor PRs remain; all
+train branches deleted. Squash-merge over a stacked child invalidates the
+child's chain even after retargeting — cherry-pick onto dev is the reliable
+restack (applied twice: R2, R4->R5).


### PR DESCRIPTION
## Summary

Closes out the cursor merge-train round log in `devlog/_plan/260828_cursor_ndjson_backlog_train/050_merge_train.md`: records R5 (#2802 merged as fbb5b0216) and the train outcome — all five cursor PRs landed (#2774, #2803, #2769, #2801, #2802), plus the operational lesson that squash-merging a stack parent invalidates the child chain even after retargeting (cherry-pick restack applied twice).

## Verification

Docs-only change in `devlog/`; nothing in the build/typecheck/test path reads it. `bun run privacy:scan` covers devlog and passes locally.

## Checklist

- [x] Targets dev
- [x] Docs-only; no code or test surface


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the cursor merge train plan with the completed R5 round, including successful CI validation and merge details.
  - Documented the full five-PR merge sequence onto `dev`.
  - Confirmed that no open cursor pull requests or train branches remain.
  - Added guidance on safely restacking stacked changes after squash merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->