### PR TITLE
fix(codex): fsync coordinator adoption files with a writable handle

### DIFF
--- a/src/codex/transition-state.ts
+++ b/src/codex/transition-state.ts
@@ -280,7 +280,16 @@ export interface CodexCoordinatorAdoptionOptions {
   readonly onCheckpoint?: (checkpoint: CodexCoordinatorAdoptionCheckpoint) => void;
 }
 
-function fsyncPath(path: string): void {
+function fsyncFile(path: string): void {
+  // Writable fd on purpose. Windows FlushFileBuffers needs GENERIC_WRITE;
+  // openSync(path, "r") is GENERIC_READ only and fails with EPERM (measured on
+  // Windows 11 25H2 / bun 1.3.14). prompt-journal.ts uses the same "r+" open.
+  const fd = openSync(path, "r+");
+  try { fsyncSync(fd); } finally { closeSync(fd); }
+}
+
+function fsyncDir(path: string): void {
+  // POSIX directory fsync is O_RDONLY. O_RDWR ("r+") is EISDIR.
   const fd = openSync(path, "r");
   try { fsyncSync(fd); } finally { closeSync(fd); }
 }
@@ -316,12 +325,12 @@ function publishAdoptionDatabase(
     } finally {
       temp.close();
     }
-    fsyncPath(tempPath);
+    fsyncFile(tempPath);
     options.onCheckpoint?.("temp-committed");
 
     linkSync(tempPath, finalDatabasePath);
     options.onCheckpoint?.("published");
-    if (process.platform !== "win32") fsyncPath(parent);
+    if (process.platform !== "win32") fsyncDir(parent);
   } catch (error) {
     if (errorCode(error) !== "EEXIST") throw error;
   } finally {

--- a/tests/codex-transition-state-adoption.test.ts
+++ b/tests/codex-transition-state-adoption.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { closeSync, existsSync, fsyncSync, mkdtempSync, openSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -69,3 +69,35 @@ for (const checkpoint of ["temp-created", "temp-committed", "published"] as cons
     }
   });
 }
+
+test("Windows fsync of a coordinator file needs a writable fd", () => {
+  const probe = join(root, "fsync-probe");
+  writeFileSync(probe, "x");
+  const readonlyFd = openSync(probe, "r");
+  try {
+    if (process.platform === "win32") {
+      expect(() => fsyncSync(readonlyFd)).toThrow(/EPERM|operation not permitted/);
+    } else {
+      fsyncSync(readonlyFd);
+    }
+  } finally {
+    closeSync(readonlyFd);
+  }
+  const writableFd = openSync(probe, "r+");
+  try {
+    fsyncSync(writableFd);
+  } finally {
+    closeSync(writableFd);
+  }
+});
+
+test("adoption publishes a coordinator database on this platform", () => {
+  const adopted = openCodexCoordinatorTransaction(coordinatorPath, { direction: "apply" });
+  try {
+    expect(existsSync(coordinatorPath)).toBe(true);
+    expect(adopted.version()).toEqual({ nativeGeneration: 0, currentTxId: null });
+    adopted.commit();
+  } finally {
+    adopted.close();
+  }
+});


### PR DESCRIPTION
## Summary

- Windows `FlushFileBuffers` needs a writable handle. Coordinator adoption (`ocx sync` on a pre-substrate routed home) fsynced the temp SQLite file after `openSync(path, "r")`, which fails with `EPERM: operation not permitted, fsync`.
- File fsync now uses `"r+"` (same contract as `src/codex/prompt-journal.ts`). POSIX directory fsync stays `"r"`; `"r+"` on a directory is `EISDIR`.
- Verified on DESKTOP-C795OH4 (Windows 11 25H2 / bun 1.3.14): `"r"` → EPERM, `"r+"` → OK. A live `ocx sync` on an already-coordinated home still completed. Isolated `{ readonly: true }` opens of `state_5.sqlite` did not hang in that session.

Closes #2814.

## Verification

- Isolated Windows probe: `openSync(..., "r")` + `fsyncSync` → `EPERM`; `"r+"` succeeds.
- `bun test tests/codex-transition-state-adoption.test.ts tests/codex-inject-write-lock.test.ts tests/codex-transition-state.test.ts` — 42 pass, including pre-substrate adoption and crash-resume checkpoints.
- Live `ocx sync` on the default coordinated Windows home (opencodex 2.32.1) exited 0 in ~8s (control; not the adoption path).

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database publication reliability across platforms by synchronizing temporary files with writable access before publishing.
  * Preserved directory synchronization behavior during adoption.

* **Tests**
  * Added coverage for platform-specific file synchronization behavior.
  * Added validation that opening a coordinator transaction publishes the database and reports the correct initial version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->